### PR TITLE
[docs] ix Sui CLI replay command and command count

### DIFF
--- a/docs/content/references/cli.mdx
+++ b/docs/content/references/cli.mdx
@@ -21,11 +21,11 @@ The `tracing` feature is important as it adds Move test coverage and debugger su
 
 ## Sui CLI commands
 
-There are a number of top-level commands available, but the five most useful to users are the following. Use the `help` flag for the commands that are not documented yet. For example, `sui validator --help`.
+There are a number of top-level commands available, but the six most useful to users are the following. Use the `help` flag for the commands that are not documented yet. For example, `sui validator --help`.
 
 - **[Sui Client CLI](./cli/client.mdx):** Use the `sui client` commands to interact with the Sui network.
 - **[Sui Client PTB CLI](./cli/ptb.mdx):** Use the `sui client ptb` command to build and execute PTBs.
 - **[Sui Keytool CLI](./cli/keytool.mdx):** Use the `sui keytool` commands to access cryptography utilities.
 - **[Sui Move CLI](./cli/move.mdx):** Use the `sui move` commands to work with the Move programming language.
-- **[Sui Replay CLI](./cli/replay.mdx):** Use the `sui client replay` command to replay a transaction and generate transaction traces for the Move Debugger and trace analysis tools.
+- **[Sui Replay CLI](./cli/replay.mdx):** Use the `sui replay` command to replay a transaction and generate transaction traces for the Move Debugger and trace analysis tools.
 - **[Sui Validator CLI](./cli/validator.mdx):** Use the `sui validator` commands to access tools useful for Sui validators.


### PR DESCRIPTION
Updated the Sui CLI reference to match the current CLI behavior. The replay section previously documented the command as sui client replay, but the actual top-level command implemented in SuiCommand is sui replay. I also fixed the “five most useful” wording to reflect that there are six CLI groups listed.