### PR TITLE
docs: fix Validator Tools card link

### DIFF
--- a/docs/content/guides/operator/validator-index.mdx
+++ b/docs/content/guides/operator/validator-index.mdx
@@ -14,6 +14,6 @@ pagination_prev: null
 </Card>
 <Card title="Validator Management" href="/guides/operator/validator/validator-tasks">
 </Card>
-<Card title="Validator Tools" href="/guides/operator/validator/validator-config">
+<Card title="Validator Tools" href="/guides/operator/validator/node-tools">
 </Card>
 </Cards>


### PR DESCRIPTION
The Validator Tools card on the Sui Validators index page was linking to the validator configuration guide instead of the validator node tools guide. This change updates the href to /guides/operator/validator/node-tools so the tools card points to the correct documentation and the node tools guide is discoverable from the validator overview.