### PR TITLE
[cleanup][move-transactional-tests] Make `VMConfig` part of the simple test harness

### DIFF
--- a/external-crates/move/crates/move-transactional-test-runner/src/vm_test_harness.rs
+++ b/external-crates/move/crates/move-transactional-test-runner/src/vm_test_harness.rs
@@ -289,7 +289,7 @@ impl SimpleVMTestAdapter {
     fn vm_config(&self) -> VMConfig {
         VMConfig {
             enable_invariant_violation_check_in_swap_loc: false,
-            deprecate_global_storage_ops_during_deserialization: false,
+            deprecate_global_storage_ops_during_deserialization: true,
             binary_config: move_binary_format::binary_config::BinaryConfig::legacy_with_flags(
                 /* check_no_extraneous_bytes */ true,
                 /* deprecate_global_storage_ops */ true,


### PR DESCRIPTION
## Description 

- In the next PR, I will need an `init` flag for transactional tests. This is just a cleanup to make room for that

## Test plan 

- Ran tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
