### PR TITLE
graphql: partial errors for Display-related fields

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/addressable/dynamic_fields.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/addressable/dynamic_fields.snap
@@ -223,7 +223,9 @@ task 12, lines 127-137:
 //# run-graphql
 Response: {
   "data": {
-    "address": null
+    "address": {
+      "dynamicFields": null
+    }
   },
   "errors": [
     {

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/move_value/extract.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/move_value/extract.snap
@@ -267,7 +267,9 @@ Response: {
   "data": {
     "object": {
       "asMoveObject": {
-        "contents": null
+        "contents": {
+          "parseError": null
+        }
       }
     }
   },
@@ -299,7 +301,9 @@ Response: {
   "data": {
     "object": {
       "asMoveObject": {
-        "contents": null
+        "contents": {
+          "tooDeep": null
+        }
       }
     }
   },
@@ -331,7 +335,9 @@ Response: {
   "data": {
     "object": {
       "asMoveObject": {
-        "contents": null
+        "contents": {
+          "tooManyLoads": null
+        }
       }
     }
   },
@@ -363,7 +369,9 @@ Response: {
   "data": {
     "object": {
       "asMoveObject": {
-        "contents": null
+        "contents": {
+          "notASlice": null
+        }
       }
     }
   },

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/objects/dynamic_field_literal_errors.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/objects/dynamic_field_literal_errors.snap
@@ -10,7 +10,9 @@ task 1, lines 8-15:
 //# run-graphql --cursors bcs(42u64)
 Response: {
   "data": {
-    "address": null
+    "address": {
+      "dynamicField": null
+    }
   },
   "errors": [
     {
@@ -36,7 +38,9 @@ task 2, lines 17-24:
 //# run-graphql --cursors bcs(42u64)
 Response: {
   "data": {
-    "address": null
+    "address": {
+      "dynamicField": null
+    }
   },
   "errors": [
     {
@@ -62,7 +66,9 @@ task 3, lines 26-33:
 //# run-graphql --cursors bcs(42u64)
 Response: {
   "data": {
-    "address": null
+    "address": {
+      "dynamicField": null
+    }
   },
   "errors": [
     {
@@ -88,7 +94,9 @@ task 4, lines 35-42:
 //# run-graphql
 Response: {
   "data": {
-    "address": null
+    "address": {
+      "dynamicField": null
+    }
   },
   "errors": [
     {
@@ -114,7 +122,9 @@ task 5, lines 44-51:
 //# run-graphql
 Response: {
   "data": {
-    "address": null
+    "address": {
+      "dynamicField": null
+    }
   },
   "errors": [
     {

--- a/crates/sui-indexer-alt-graphql/src/api/types/coin_metadata.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/coin_metadata.rs
@@ -128,8 +128,11 @@ impl CoinMetadata {
         ctx: &Context<'_>,
         root_version: Option<UInt53>,
         checkpoint: Option<UInt53>,
-    ) -> Result<Option<Address>, RpcError<address::Error>> {
-        self.super_.address_at(ctx, root_version, checkpoint).await
+    ) -> Option<Result<Address, RpcError<address::Error>>> {
+        self.super_
+            .address_at(ctx, root_version, checkpoint)
+            .await
+            .ok()?
     }
 
     /// The version of this object that this content comes from.

--- a/crates/sui-indexer-alt-graphql/src/api/types/dynamic_field.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/dynamic_field.rs
@@ -156,8 +156,11 @@ impl DynamicField {
         ctx: &Context<'_>,
         root_version: Option<UInt53>,
         checkpoint: Option<UInt53>,
-    ) -> Result<Option<Address>, RpcError<address::Error>> {
-        self.super_.address_at(ctx, root_version, checkpoint).await
+    ) -> Option<Result<Address, RpcError<address::Error>>> {
+        self.super_
+            .address_at(ctx, root_version, checkpoint)
+            .await
+            .ok()?
     }
 
     /// The version of this object that this content comes from.

--- a/crates/sui-indexer-alt-graphql/src/api/types/epoch.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/epoch.rs
@@ -304,8 +304,8 @@ impl Epoch {
     }
 
     /// The contents of the system state inner object at the start of this epoch.
-    async fn system_state(&self, ctx: &Context<'_>) -> Result<Option<MoveValue>, RpcError> {
-        self.system_state_impl(ctx).await
+    async fn system_state(&self, ctx: &Context<'_>) -> Option<Result<MoveValue, RpcError>> {
+        self.system_state_impl(ctx).await.transpose()
     }
 
     /// The total number of checkpoints in this epoch.

--- a/crates/sui-indexer-alt-graphql/src/api/types/move_object.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/move_object.rs
@@ -140,8 +140,11 @@ impl MoveObject {
         ctx: &Context<'_>,
         root_version: Option<UInt53>,
         checkpoint: Option<UInt53>,
-    ) -> Result<Option<Address>, RpcError<address::Error>> {
-        self.super_.address_at(ctx, root_version, checkpoint).await
+    ) -> Option<Result<Address, RpcError<address::Error>>> {
+        self.super_
+            .address_at(ctx, root_version, checkpoint)
+            .await
+            .ok()?
     }
 
     /// The version of this object that this content comes from.

--- a/crates/sui-indexer-alt-graphql/src/api/types/move_package.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/move_package.rs
@@ -157,8 +157,11 @@ impl MovePackage {
         ctx: &Context<'_>,
         root_version: Option<UInt53>,
         checkpoint: Option<UInt53>,
-    ) -> Result<Option<Address>, RpcError<address::Error>> {
-        self.super_.address_at(ctx, root_version, checkpoint).await
+    ) -> Option<Result<Address, RpcError<address::Error>>> {
+        self.super_
+            .address_at(ctx, root_version, checkpoint)
+            .await
+            .ok()?
     }
 
     /// The version of this package that this content comes from.

--- a/crates/sui-indexer-alt-graphql/src/api/types/object.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/object.rs
@@ -260,8 +260,11 @@ impl Object {
         ctx: &Context<'_>,
         root_version: Option<UInt53>,
         checkpoint: Option<UInt53>,
-    ) -> Result<Option<Address>, RpcError<address::Error>> {
-        self.super_.address_at(ctx, root_version, checkpoint).await
+    ) -> Option<Result<Address, RpcError<address::Error>>> {
+        self.super_
+            .address_at(ctx, root_version, checkpoint)
+            .await
+            .ok()?
     }
 
     /// The version of this object that this content comes from.

--- a/crates/sui-indexer-alt-graphql/src/error.rs
+++ b/crates/sui-indexer-alt-graphql/src/error.rs
@@ -31,7 +31,7 @@ pub(crate) mod code {
     pub const RESOURCE_EXHAUSTED: &str = "RESOURCE_EXHAUSTED";
 }
 
-#[derive(thiserror::Error, Debug, Clone)]
+#[derive(thiserror::Error, Debug)]
 pub(crate) enum RpcError<E: std::error::Error = Infallible> {
     /// An error that is the user's fault.
     BadUserInput(Arc<E>),
@@ -124,6 +124,20 @@ impl<E: std::error::Error> From<RpcError<E>> for async_graphql::Error {
                     }
                 })
             }
+        }
+    }
+}
+
+impl<E: std::error::Error> Clone for RpcError<E> {
+    fn clone(&self) -> Self {
+        match self {
+            Self::BadUserInput(e) => Self::BadUserInput(e.clone()),
+            &Self::FeatureUnavailable { what } => Self::FeatureUnavailable { what },
+            Self::GraphQlError(e) => Self::GraphQlError(e.clone()),
+            Self::InternalError(e) => Self::InternalError(e.clone()),
+            Self::Pagination(e) => Self::Pagination(e.clone()),
+            &Self::RequestTimeout { kind, limit } => Self::RequestTimeout { kind, limit },
+            Self::ResourceExhausted(e) => Self::ResourceExhausted(e.clone()),
         }
     }
 }


### PR DESCRIPTION
## Description

Update the fields that are newly added as of the Display stack to support partial errors.

## Test plan

E2E tests:

```
$ cargo nextest run -p sui-indexer-alt-e2e-tests -j3
```

## Stack

- #24621 
- #24652 
- #24768 
- #24769 
- #24770 
- #24771 
- #24772 
- #24773 
- #24774 
- #24775 
- #24776 
- #24777 
- #24778
- #24779 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
