### PR TITLE
fix: remove dead run-bytecode-verifier and print-diags-to-stderr flags

### DIFF
--- a/crates/sui-move/src/main.rs
+++ b/crates/sui-move/src/main.rs
@@ -27,12 +27,6 @@ struct Args {
     /// Path to a package which the command should be run with respect to.
     #[clap(long = "path", short = 'p', global = true)]
     pub package_path: Option<PathBuf>,
-    /// If true, run the Move bytecode verifier on the bytecode from a successful build
-    #[clap(long, global = true)]
-    pub run_bytecode_verifier: bool,
-    /// If true, print build diagnostics to stderr--no printing if false
-    #[clap(long, global = true)]
-    pub print_diags_to_stderr: bool,
     /// Package build options
     #[clap(flatten)]
     pub build_config: MoveBuildConfig,


### PR DESCRIPTION
The Sui Move CLI Args struct exposed run-bytecode-verifier and print-diags-to-stderr as global flags, but these values were never propagated into sui_move_build::BuildConfig. The actual build path always hard-codes both options to true in build.rs, and the public Sui Move CLI documentation does not mention these flags. This meant the flags were effectively no-ops and could mislead users into thinking they can control bytecode verification or diagnostics from the CLI. This change removes the unused flags from Args, aligning the CLI surface with the real behavior and the existing docs, without changing any functional behavior of the build and test commands.