### PR TITLE
[1.63] Apply consensus_skip_gced_blocks_in_direct_finalization

### DIFF
--- a/consensus/core/src/commit_finalizer.rs
+++ b/consensus/core/src/commit_finalizer.rs
@@ -288,14 +288,16 @@ impl CommitFinalizer {
         assert!(!commit_state.pending_blocks.is_empty());
         let pending_blocks = std::mem::take(&mut commit_state.pending_blocks);
 
-        for (block_ref, num_transactions) in pending_blocks {
-            if self
+        let curr_commit_index = commit_state.commit.commit_ref.index;
+        let skip_gced_blocks = (self.context.committee.epoch() == 1007
+            && curr_commit_index >= 968178)
+            || self.context.committee.epoch() > 1007
+            || self
                 .context
                 .protocol_config
-                .consensus_skip_gced_blocks_in_direct_finalization()
-                && block_ref.round <= vote_gc_round
-                && num_transactions > 0
-            {
+                .consensus_skip_gced_blocks_in_direct_finalization();
+        for (block_ref, num_transactions) in pending_blocks {
+            if skip_gced_blocks && block_ref.round <= vote_gc_round && num_transactions > 0 {
                 // The block is outside of GC bound.
                 let transactions =
                     (0..(num_transactions as TransactionIndex)).collect::<BTreeSet<_>>();

--- a/consensus/core/src/storage/mem_store.rs
+++ b/consensus/core/src/storage/mem_store.rs
@@ -233,4 +233,23 @@ impl Store for MemStore {
             .get(&(commit_ref.index, commit_ref.digest))
             .cloned())
     }
+
+    fn truncate_finalized_commits(&self, from_index: CommitIndex) -> ConsensusResult<()> {
+        let mut inner = self.inner.write();
+
+        let keys_to_remove: Vec<_> = inner
+            .finalized_commits
+            .range((
+                Included((from_index, CommitDigest::MIN)),
+                Included((CommitIndex::MAX, CommitDigest::MAX)),
+            ))
+            .map(|(k, _)| *k)
+            .collect();
+
+        for key in keys_to_remove {
+            inner.finalized_commits.remove(&key);
+        }
+
+        Ok(())
+    }
 }

--- a/consensus/core/src/storage/mod.rs
+++ b/consensus/core/src/storage/mod.rs
@@ -67,6 +67,10 @@ pub trait Store: Send + Sync {
         &self,
         commit_ref: CommitRef,
     ) -> ConsensusResult<Option<BTreeMap<BlockRef, Vec<TransactionIndex>>>>;
+
+    /// Truncates finalized commits from the given commit index (inclusive).
+    /// All finalized commits with index >= from_index will be deleted.
+    fn truncate_finalized_commits(&self, from_index: CommitIndex) -> ConsensusResult<()>;
 }
 
 /// Represents data to be written to the store together atomically.


### PR DESCRIPTION
## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [x] Protocol: Fix a consensus issue where validators do not agree on transactions that need to be rejected.
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework: