### PR TITLE
fix: stop commit syncer after core shutdown

### DIFF
--- a/consensus/core/src/commit_syncer.rs
+++ b/consensus/core/src/commit_syncer.rs
@@ -171,7 +171,10 @@ impl<C: NetworkClient> CommitSyncer<C> {
                         return;
                     }
                     let (target_end, commits) = result.unwrap();
-                    self.handle_fetch_result(target_end, commits).await;
+                    if !self.handle_fetch_result(target_end, commits).await {
+                        self.inflight_fetches.shutdown().await;
+                        return;
+                    }
                 }
                 _ = &mut rx_shutdown => {
                     // Shutdown requested.
@@ -247,7 +250,7 @@ impl<C: NetworkClient> CommitSyncer<C> {
         &mut self,
         target_end: CommitIndex,
         certified_commits: CertifiedCommits,
-    ) {
+    ) -> bool {
         assert!(!certified_commits.commits().is_empty());
 
         let (total_blocks_fetched, total_blocks_size_bytes) = certified_commits
@@ -361,7 +364,7 @@ impl<C: NetworkClient> CommitSyncer<C> {
                 }
                 Err(e) => {
                     info!("Failed to add blocks, shutting down: {}", e);
-                    return;
+                    return false;
                 }
             };
 
@@ -378,6 +381,7 @@ impl<C: NetworkClient> CommitSyncer<C> {
         metrics
             .commit_sync_highest_synced_index
             .set(self.synced_commit_index as i64);
+        true
     }
 
     fn try_start_fetches(&mut self) {


### PR DESCRIPTION
Ensure CommitSyncer exits when CoreThreadDispatcher rejects certified commits. This aligns the shutdown log with actual behavior and avoids continued fetch work after core termination.