### PR TITLE
fix url bug

### DIFF
--- a/crates/sui-indexer-alt-framework/src/ingestion/remote_client.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/remote_client.rs
@@ -56,7 +56,7 @@ impl RemoteIngestionClient {
         // SAFETY: The path being joined is statically known to be valid.
         let url = self
             .url
-            .join("/epochs.json")
+            .join("epochs.json")
             .expect("Unexpected invalid URL");
 
         self.client.get(url).send().await
@@ -68,7 +68,7 @@ impl RemoteIngestionClient {
         // SAFETY: The path being joined is statically known to be valid.
         let url = self
             .url
-            .join(&format!("/{checkpoint}.chk"))
+            .join(&format!("{checkpoint}.chk"))
             .expect("Unexpected invalid URL");
 
         self.client.get(url).send().await


### PR DESCRIPTION
## Description

When I tried to use this remote URL with the indexing framework, I got 404s for checkpoints that exist:
<https://storage.googleapis.com/mysten-mainnet-checkpoints/>

Then when I used this URL it worked:
<https://checkpoints.mainnet.sui.io/>

Claude figured out the problem -

When you use Url::join() in Rust (which follows RFC 3986), a path starting with / is treated as an absolute path that replaces everything after the host.

With leading /:
Base: <https://storage.googleapis.com/mysten-mainnet-checkpoints/>
Join: /0.binpb.zst
Result: <https://storage.googleapis.com/0.binpb.zst>
↑ bucket name is gone!

Without leading /:
Base: <https://storage.googleapis.com/mysten-mainnet-checkpoints/>
Join: 0.binpb.zst
Result: <https://storage.googleapis.com/mysten-mainnet-checkpoints/0.binpb.zst>
↑ bucket name preserved
