### PR TITLE
Get auth token from gke metadata server if we are running in gke

### DIFF
--- a/crates/sui-indexer-alt-consistent-store/src/restore/formal_snapshot.rs
+++ b/crates/sui-indexer-alt-consistent-store/src/restore/formal_snapshot.rs
@@ -147,6 +147,7 @@ impl FormalSnapshot {
         // Use the remote store to associate the epoch with a watermark pointing to its last
         // transaction.
         let client = RemoteIngestionClient::new(snapshot_args.remote_store_url)
+            .await
             .context("Failed to connect to remote checkpoint store")?;
 
         let end_of_epoch_checkpoints: Vec<_> = client

--- a/crates/sui-indexer-alt-framework/src/ingestion/ingestion_client.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/ingestion_client.rs
@@ -107,10 +107,13 @@ pub struct IngestionClient {
 
 impl IngestionClient {
     /// Construct a new ingestion client. Its source is determined by `args`.
-    pub fn new(args: IngestionClientArgs, metrics: Arc<IngestionMetrics>) -> IngestionResult<Self> {
+    pub async fn new(
+        args: IngestionClientArgs,
+        metrics: Arc<IngestionMetrics>,
+    ) -> IngestionResult<Self> {
         // TODO: Support stacking multiple ingestion clients for redundancy/failover.
         let client = if let Some(url) = args.remote_store_url.as_ref() {
-            IngestionClient::new_remote(url.clone(), metrics.clone())?
+            IngestionClient::new_remote(url.clone(), metrics.clone()).await?
         } else if let Some(path) = args.local_ingestion_path.as_ref() {
             IngestionClient::new_local(path.clone(), metrics.clone())
         } else if let Some(rpc_api_url) = args.rpc_api_url.as_ref() {
@@ -129,19 +132,19 @@ impl IngestionClient {
 
     /// An ingestion client that fetches checkpoints from a remote store (an object store, over
     /// HTTP).
-    pub fn new_remote(url: Url, metrics: Arc<IngestionMetrics>) -> IngestionResult<Self> {
-        let client = Arc::new(RemoteIngestionClient::new(url)?);
+    pub async fn new_remote(url: Url, metrics: Arc<IngestionMetrics>) -> IngestionResult<Self> {
+        let client = Arc::new(RemoteIngestionClient::new(url).await?);
         Ok(Self::new_impl(client, metrics))
     }
 
     /// An ingestion client that fetches checkpoints from a remote store (an object store, over
     /// HTTP), with a configured request timeout.
-    pub fn new_remote_with_timeout(
+    pub async fn new_remote_with_timeout(
         url: Url,
         timeout: std::time::Duration,
         metrics: Arc<IngestionMetrics>,
     ) -> IngestionResult<Self> {
-        let client = Arc::new(RemoteIngestionClient::new_with_timeout(url, timeout)?);
+        let client = Arc::new(RemoteIngestionClient::new_with_timeout(url, timeout).await?);
         Ok(Self::new_impl(client, metrics))
     }
 

--- a/crates/sui-indexer-alt-framework/src/ingestion/mod.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/mod.rs
@@ -106,14 +106,14 @@ impl IngestionService {
     ///
     /// After initialization, subscribers can be added using [Self::subscribe], and the service is
     /// started with [Self::run], given a range of checkpoints to fetch (potentially unbounded).
-    pub fn new(
+    pub async fn new(
         args: ClientArgs,
         config: IngestionConfig,
         metrics_prefix: Option<&str>,
         registry: &Registry,
     ) -> Result<Self> {
         let metrics = IngestionMetrics::new(metrics_prefix, registry);
-        let ingestion_client = IngestionClient::new(args.ingestion, metrics.clone())?;
+        let ingestion_client = IngestionClient::new(args.ingestion, metrics.clone()).await?;
         let streaming_client = args
             .streaming
             .streaming_url
@@ -259,6 +259,7 @@ mod tests {
             None,
             &registry,
         )
+        .await
         .unwrap()
     }
 

--- a/crates/sui-indexer-alt-framework/src/lib.rs
+++ b/crates/sui-indexer-alt-framework/src/lib.rs
@@ -213,7 +213,7 @@ impl<S: Store> Indexer<S> {
         let metrics = IndexerMetrics::new(metrics_prefix, registry);
 
         let ingestion_service =
-            IngestionService::new(client_args, ingestion_config, metrics_prefix, registry)?;
+            IngestionService::new(client_args, ingestion_config, metrics_prefix, registry).await?;
 
         Ok(Self {
             store,


### PR DESCRIPTION
## Description

If we are running in GKE we can set the auth header from the GKE metadata server. This can help avoid rate limits during backfills.

## Test plan

Currently running this in my GCS -> S3 proto backfill for the checkpoint bucket
