### PR TITLE
Fix object fund withdraw settle ahead of schedule issues

### DIFF
--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -1589,7 +1589,9 @@ impl CheckpointBuilder {
             funds_changes,
         };
 
-        self.state.execution_scheduler().settle_funds(settlements);
+        self.state
+            .execution_scheduler()
+            .settle_address_funds(settlements);
 
         (tx_key, settlement_effects)
     }

--- a/crates/sui-core/src/execution_scheduler/execution_scheduler_impl.rs
+++ b/crates/sui-core/src/execution_scheduler/execution_scheduler_impl.rs
@@ -28,7 +28,7 @@ use std::{
 use sui_config::node::AuthorityOverloadConfig;
 use sui_types::{
     SUI_ACCUMULATOR_ROOT_OBJECT_ID,
-    base_types::{FullObjectID, ObjectID},
+    base_types::{FullObjectID, ObjectID, SequenceNumber},
     digests::TransactionDigest,
     effects::{AccumulatorOperation, AccumulatorValue, TransactionEffects, TransactionEffectsAPI},
     error::SuiResult,
@@ -634,18 +634,20 @@ impl ExecutionScheduler {
             .inc_by(already_executed_certs_num);
     }
 
-    pub fn settle_funds(&self, settlement: FundsSettlement) {
-        if let Some(object_funds_withdraw_scheduler) =
-            self.object_funds_withdraw_scheduler.lock().as_ref()
-        {
-            object_funds_withdraw_scheduler
-                .settle_accumulator_version(settlement.next_accumulator_version);
-        }
+    pub fn settle_address_funds(&self, settlement: FundsSettlement) {
         self.address_funds_withdraw_scheduler
             .lock()
             .as_ref()
             .expect("Funds withdraw scheduler must be enabled if there are settlements")
             .settle_funds(settlement);
+    }
+
+    pub fn settle_object_funds(&self, next_accumulator_version: SequenceNumber) {
+        if let Some(object_funds_withdraw_scheduler) =
+            self.object_funds_withdraw_scheduler.lock().as_ref()
+        {
+            object_funds_withdraw_scheduler.settle_accumulator_version(next_accumulator_version);
+        }
     }
 
     /// Reconfigure internal state at epoch start. This resets the funds withdraw scheduler

--- a/crates/sui-core/src/execution_scheduler/funds_withdraw_scheduler/address_funds/e2e_tests.rs
+++ b/crates/sui-core/src/execution_scheduler/funds_withdraw_scheduler/address_funds/e2e_tests.rs
@@ -172,7 +172,7 @@ impl TestEnv {
             .collect();
         let mut accumulator_object = self.get_accumulator_object();
         let next_version = accumulator_object.version().next();
-        self.scheduler.settle_funds(FundsSettlement {
+        self.scheduler.settle_address_funds(FundsSettlement {
             next_accumulator_version: next_version,
             funds_changes: funds_changes.clone(),
         });

--- a/crates/sui-core/src/execution_scheduler/funds_withdraw_scheduler/object_funds/unit_tests.rs
+++ b/crates/sui-core/src/execution_scheduler/funds_withdraw_scheduler/object_funds/unit_tests.rs
@@ -210,3 +210,54 @@ async fn test_settle_accumulator_version() {
         SequenceNumber::from_u64(1)
     );
 }
+
+#[tokio::test]
+async fn test_account_version_ahead_of_schedule() {
+    let account = ObjectID::random();
+    let funds_read = Arc::new(MockFundsRead::new(
+        SequenceNumber::from_u64(0),
+        BTreeMap::from([(account, 100)]),
+    ));
+    funds_read.settle_funds_changes(
+        BTreeMap::from([(AccumulatorObjId::new_unchecked(account), 1)]),
+        SequenceNumber::from_u64(1),
+    );
+    let scheduler =
+        NaiveObjectFundsWithdrawScheduler::new(funds_read.clone(), SequenceNumber::from_u64(0));
+    let result = scheduler.schedule(
+        BTreeMap::from([(AccumulatorObjId::new_unchecked(account), 101)]),
+        SequenceNumber::from_u64(0),
+    );
+    let ObjectFundsWithdrawStatus::Pending(receiver) = result else {
+        panic!("Expected pending status");
+    };
+    let result = receiver.await.unwrap();
+    assert_eq!(result, FundsWithdrawStatus::Insufficient);
+
+    let result = scheduler.schedule(
+        BTreeMap::from([(AccumulatorObjId::new_unchecked(account), 100)]),
+        SequenceNumber::from_u64(0),
+    );
+    assert!(matches!(result, ObjectFundsWithdrawStatus::SufficientFunds));
+}
+
+#[tokio::test]
+async fn test_settle_ahead_of_schedule() {
+    let account = ObjectID::random();
+    let funds_read = Arc::new(MockFundsRead::new(
+        SequenceNumber::from_u64(0),
+        BTreeMap::from([(account, 100)]),
+    ));
+    let scheduler =
+        NaiveObjectFundsWithdrawScheduler::new(funds_read.clone(), SequenceNumber::from_u64(0));
+    scheduler.settle_accumulator_version(SequenceNumber::from_u64(1));
+    let result = scheduler.schedule(
+        BTreeMap::from([(AccumulatorObjId::new_unchecked(account), 101)]),
+        SequenceNumber::from_u64(0),
+    );
+    let ObjectFundsWithdrawStatus::Pending(receiver) = result else {
+        panic!("Expected pending status");
+    };
+    let result = receiver.await.unwrap();
+    assert_eq!(result, FundsWithdrawStatus::Insufficient);
+}

--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -35,9 +35,9 @@ use crate::signature_verification::{
 };
 use crate::type_input::TypeInput;
 use crate::{
-    SUI_AUTHENTICATOR_STATE_OBJECT_ID, SUI_CLOCK_OBJECT_ID, SUI_CLOCK_OBJECT_SHARED_VERSION,
-    SUI_FRAMEWORK_PACKAGE_ID, SUI_RANDOMNESS_STATE_OBJECT_ID, SUI_SYSTEM_STATE_OBJECT_ID,
-    SUI_SYSTEM_STATE_OBJECT_SHARED_VERSION,
+    SUI_ACCUMULATOR_ROOT_OBJECT_ID, SUI_AUTHENTICATOR_STATE_OBJECT_ID, SUI_CLOCK_OBJECT_ID,
+    SUI_CLOCK_OBJECT_SHARED_VERSION, SUI_FRAMEWORK_PACKAGE_ID, SUI_RANDOMNESS_STATE_OBJECT_ID,
+    SUI_SYSTEM_STATE_OBJECT_ID, SUI_SYSTEM_STATE_OBJECT_SHARED_VERSION,
 };
 use enum_dispatch::enum_dispatch;
 use fastcrypto::{encoding::Base64, hash::HashFunction};
@@ -1538,6 +1538,14 @@ impl TransactionKind {
             self,
             TransactionKind::EndOfEpochTransaction(_) | TransactionKind::ChangeEpoch(_)
         )
+    }
+
+    pub fn is_accumulator_barrier_settle_tx(&self) -> bool {
+        matches!(self, TransactionKind::ProgrammableSystemTransaction(_))
+            && self.shared_input_objects().any(|obj| {
+                obj.id == SUI_ACCUMULATOR_ROOT_OBJECT_ID
+                    && obj.mutability == SharedObjectMutability::Mutable
+            })
     }
 
     /// If this is advance epoch transaction, returns (total gas charged, total gas rebated).


### PR DESCRIPTION
## Description 

We settle object fund withdraw from checkpoint builder, which means that if we do not have a chance to run checkpoint builder (e.g. the network is already on the next epoch) the scheduler would lose liveness.
This PR fixes it by calling object fund withdraw settlement from post-execution, instead of checkpoint builder. This creates a new issue where the settled version in the scheduler can now run ahead of the scheduling version. So we removed the assertion on this. Furthermore, we can no longer rely on settled version to detect when the version changes in the scheduler, since it can run ahead. So we now use the scheduled accumulator version to identify when we move to a new consensus commit, and hence can clear all unsettled pending withdraws.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
