### PR TITLE
[package-alt] WIP (parked): lockfile loading via new graph2 module

### DIFF
--- a/external-crates/move/crates/move-package-alt/src/errors/mod.rs
+++ b/external-crates/move/crates/move-package-alt/src/errors/mod.rs
@@ -29,6 +29,11 @@ use crate::package::manifest::ManifestError;
 use crate::package::paths::FileError;
 use crate::package::paths::PackagePathError;
 
+/// Wrapper around a [PackageError] that indicates it has already been emitted.
+#[derive(Error, Debug)]
+#[error("Failed to load package")]
+pub struct PrintedPackageError(pub PackageError);
+
 /// Result type for package operations
 pub type PackageResult<T> = Result<T, PackageError>;
 
@@ -147,9 +152,10 @@ impl PackageError {
         }
     }
 
-    pub fn emit(&self) {
+    pub fn emit(self) -> PrintedPackageError {
         let diagnostic = self.to_diagnostic();
         let mut writer = StandardStream::stderr(ColorChoice::Auto);
         term::emit(&mut writer, &Config::default(), &Files, &diagnostic).unwrap();
+        PrintedPackageError(self)
     }
 }

--- a/external-crates/move/crates/move-package-alt/src/graph/mod.rs
+++ b/external-crates/move/crates/move-package-alt/src/graph/mod.rs
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod builder;
+mod builder2;
+mod graph2;
 mod linkage;
 mod package_info;
 mod rename_from;

--- a/external-crates/move/crates/move-package-alt/src/graph/package_info.rs
+++ b/external-crates/move/crates/move-package-alt/src/graph/package_info.rs
@@ -159,6 +159,7 @@ impl<'graph, F: MoveFlavor> PackageInfo<'graph, F> {
     /// The addresses for the names that are available to this package. For modern packages, this
     /// contains only the package and its dependencies, but legacy packages may define additional
     /// addresses as well
+    // TODO: can we validate this earlier to just return a `BTreeMap`?
     pub fn named_addresses(&self) -> PackageResult<BTreeMap<PackageName, NamedAddress>> {
         if self.package().is_legacy() {
             return self.legacy_named_addresses();
@@ -182,6 +183,7 @@ impl<'graph, F: MoveFlavor> PackageInfo<'graph, F> {
 
     /// For legacy packages, our named addresses need to include all transitive deps too.
     /// An example of that is depending on "sui", but also keeping it possible to use "std".
+    // TODO: can we validate this earlier to just return a `BTreeMap`?
     fn legacy_named_addresses(&self) -> PackageResult<BTreeMap<PackageName, NamedAddress>> {
         let mut result: BTreeMap<PackageName, NamedAddress> = BTreeMap::new();
 

--- a/external-crates/move/crates/move-package-alt/src/graph2/ephemeralize.rs
+++ b/external-crates/move/crates/move-package-alt/src/graph2/ephemeralize.rs
@@ -1,0 +1,16 @@
+use std::collections::BTreeMap;
+
+use crate::{
+    MoveFlavor,
+    graph2::PackageGraph,
+    schema::{EphemeralDependencyInfo, Publication},
+};
+
+impl<F: MoveFlavor> PackageGraph<'_, F> {
+    pub fn make_ephemeral(
+        self,
+        _overrides: BTreeMap<EphemeralDependencyInfo, Publication<F>>,
+    ) -> Self {
+        todo!()
+    }
+}

--- a/external-crates/move/crates/move-package-alt/src/graph2/linkage.rs
+++ b/external-crates/move/crates/move-package-alt/src/graph2/linkage.rs
@@ -1,0 +1,7 @@
+use crate::{MoveFlavor, graph2::PackageGraph};
+
+impl<F: MoveFlavor> PackageGraph<'_, F> {
+    pub fn apply_linkage(self) -> Self {
+        todo!()
+    }
+}

--- a/external-crates/move/crates/move-package-alt/src/graph2/loader.rs
+++ b/external-crates/move/crates/move-package-alt/src/graph2/loader.rs
@@ -1,0 +1,99 @@
+// Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use thiserror::Error;
+
+use crate::{
+    MoveFlavor,
+    dependency::Pinned,
+    errors::PackageResult,
+    graph2::PackageInfo,
+    package::{package_loader::PackageConfig, package_lock::PackageSystemLock},
+    schema::{Environment, EnvironmentName, PackageID, PackageName},
+};
+
+use super::PackageGraph;
+
+#[derive(Error, Debug)]
+pub enum LockfileError {
+    #[error("Invalid lockfile: there are multiple root nodes in environment {env}")]
+    MultipleRootNodes { env: EnvironmentName },
+
+    #[error("Invalid lockfile: there is no root node")]
+    NoRootNode,
+
+    #[error(
+        "Invalid lockfile: package `{source_id}` has a dependency named `{dep_name}` in its manifest, but that dependency is not pinned in the lockfile"
+    )]
+    MissingDep {
+        source_id: PackageID,
+        dep_name: PackageName,
+    },
+
+    #[error("Invalid lockfile: package depends on a package with undefined ID `{target_id}`")]
+    UndefinedDep { target_id: PackageID },
+}
+
+impl<'graph, F: MoveFlavor> PackageGraph<'graph, F> {
+    pub async fn load(config: &PackageConfig, env: &Environment, mtx: &PackageSystemLock) -> Self {
+        todo!()
+    }
+
+    /// Try to load the entire subgraph rooted at `package` from its lockfile into the graph.
+    /// If the lockfile is missing or out of date, return false and don't add any edges to
+    /// `package` (although disconnected nodes may be added to the graph)
+    async fn add_subgraph_from_lockfile(
+        &mut self,
+        package: &PackageInfo<'graph, F>,
+    ) -> PackageResult<bool> {
+        // for dep in package.transitive_deps_from_lockfile
+        //   load dep
+        //   if dep.digest doesn't match lockfile digest
+        //      return None
+        //
+        // for dep in package.direct_deps
+        //   add edge from package to dep
+        //
+        // return dep
+        todo!()
+    }
+
+    /// Load the entire subgraph rooted at `package` into `graph` and `visited` by first pinning
+    /// the dependencies of `package` and then recursively loading the dependencies (from their
+    /// lockfiles or manifests)
+    async fn add_subgraph_from_manifest(
+        &mut self,
+        package: &PackageInfo<'graph, F>,
+    ) -> PackageResult<()> {
+        // pin direct deps of package
+        // for dep in direct deps
+        //   load dep
+        //   direct_dep = add_subgraph(dep)
+        //   add edge from package to direct_dep
+        todo!()
+    }
+
+    /// Load the subgraph rooted at `package` into `graph` and `visited` by first trying to load
+    /// from the lockfile of `package` and then repinning if that fails
+    ///
+    /// precondition: package is loaded but its deps might not be
+    async fn add_subgraph(&mut self, package: &PackageInfo<'graph, F>) -> PackageResult<()> {
+        // if `package` is in `visited`, return early
+        // add package to graph
+        // add_subgraph_from_lockfile(package).or_else(add_subgraph_from_manifest(package))
+        // return `package`
+
+        todo!()
+    }
+
+    /// Fetch `dep` and add it (but not its dependencies) to the graph
+    async fn add_node(
+        &mut self,
+        dep: &Pinned,
+        env: &Environment,
+        mtx: &PackageSystemLock,
+    ) -> PackageResult<&PackageInfo<F>> {
+        todo!()
+    }
+}

--- a/external-crates/move/crates/move-package-alt/src/graph2/mod.rs
+++ b/external-crates/move/crates/move-package-alt/src/graph2/mod.rs
@@ -1,0 +1,36 @@
+/// defines [PackageGraph::make_ephemeral]
+mod ephemeralize;
+
+/// defines [PackageGraph::apply_linkage]
+mod linkage;
+
+/// defines [PackageGraph::load]
+mod loader;
+
+/// defines [PackageGraph::filter_for_mode]
+mod modes;
+
+/// defines [PackageGraph::to_lockfile]
+mod to_lockfile;
+
+mod package_info;
+pub use package_info::PackageInfo;
+
+use std::{collections::BTreeMap, path::PathBuf};
+
+use crate::MoveFlavor;
+
+pub struct PackageGraph<'graph, F: MoveFlavor> {
+    all_packages: BTreeMap<PathBuf, PackageInfo<'graph, F>>,
+    root: &'graph PackageInfo<'graph, F>,
+}
+
+impl<F: MoveFlavor> PackageGraph<'_, F> {
+    pub fn root(&self) -> &PackageInfo<F> {
+        self.root
+    }
+
+    pub fn packages(&self) -> impl Iterator<Item = &PackageInfo<F>> {
+        self.all_packages.values()
+    }
+}

--- a/external-crates/move/crates/move-package-alt/src/graph2/modes.rs
+++ b/external-crates/move/crates/move-package-alt/src/graph2/modes.rs
@@ -1,0 +1,7 @@
+use crate::{MoveFlavor, graph2::PackageGraph, schema::ModeName};
+
+impl<F: MoveFlavor> PackageGraph<'_, F> {
+    pub fn filter_for_mode(self, modes: &Vec<ModeName>) -> Self {
+        todo!()
+    }
+}

--- a/external-crates/move/crates/move-package-alt/src/graph2/package_info.rs
+++ b/external-crates/move/crates/move-package-alt/src/graph2/package_info.rs
@@ -1,0 +1,62 @@
+use std::collections::BTreeMap;
+
+use move_compiler::editions::Edition;
+
+use crate::{
+    MoveFlavor, NamedAddress,
+    dependency::PinnedDependencyInfo,
+    package::Package,
+    schema::{OriginalID, PackageID, PackageName, PublishAddresses},
+};
+
+pub struct PackageInfo<'graph, F: MoveFlavor> {
+    package: Package<F>,
+    children: Vec<(PinnedDependencyInfo, &'graph PackageInfo<'graph, F>)>,
+    parent: Option<&'graph PackageInfo<'graph, F>>,
+}
+
+impl<'graph, F: MoveFlavor> PackageInfo<'graph, F> {
+    pub fn name(&self) -> &PackageName {
+        todo!()
+    }
+
+    pub fn display_name(&self) -> &str {
+        todo!()
+    }
+
+    pub fn display_path(&self) -> String {
+        todo!()
+    }
+
+    pub fn id(&self) -> &PackageID {
+        todo!()
+    }
+
+    pub fn edition(&self) -> &Option<Edition> {
+        todo!()
+    }
+
+    pub fn published(&self) -> Option<PublishAddresses> {
+        todo!()
+    }
+
+    pub fn is_root(&self) -> bool {
+        todo!()
+    }
+
+    pub fn named_addresses(&self) -> BTreeMap<PackageName, NamedAddress> {
+        todo!()
+    }
+
+    pub fn named_address(&self) -> NamedAddress {
+        todo!()
+    }
+
+    pub(crate) fn original_id(&self) -> OriginalID {
+        todo!()
+    }
+
+    pub(crate) fn package(&self) -> &Package<F> {
+        todo!()
+    }
+}

--- a/external-crates/move/crates/move-package-alt/src/graph2/to_lockfile.rs
+++ b/external-crates/move/crates/move-package-alt/src/graph2/to_lockfile.rs
@@ -1,0 +1,14 @@
+use std::collections::BTreeMap;
+
+use crate::{
+    MoveFlavor,
+    errors::PackageResult,
+    graph2::PackageGraph,
+    schema::{PackageID, Pin},
+};
+
+impl<F: MoveFlavor> PackageGraph<'_, F> {
+    pub fn to_lockfile(&self) -> PackageResult<BTreeMap<PackageID, Pin>> {
+        todo!()
+    }
+}

--- a/external-crates/move/crates/move-package-alt/src/lib.rs
+++ b/external-crates/move/crates/move-package-alt/src/lib.rs
@@ -23,7 +23,7 @@ pub use package::paths::read_name_from_manifest;
 // TODO: maybe put Vanilla into test_utils
 // TODO: maybe put SourcePackageLayout, NamedAddress into schema
 
-pub use errors::{PackageError, PackageResult};
+pub use errors::{PackageError, PrintedPackageError};
 pub use flavor::{MoveFlavor, Vanilla};
 pub use graph::{NamedAddress, PackageInfo};
 pub use package::layout::SourcePackageLayout;

--- a/external-crates/move/crates/move-package-alt/src/lib.rs
+++ b/external-crates/move/crates/move-package-alt/src/lib.rs
@@ -11,6 +11,7 @@ mod dependency;
 mod errors;
 mod flavor;
 mod graph;
+mod graph2;
 mod logging;
 mod package;
 


### PR DESCRIPTION
⚠️ **Stale WIP — parked.** Created Jan 2026, last touched Mar 2026. No description was ever written; this note is a reminder to my future self.

## What's here
Introduces a new `graph2/` module in `move-package-alt` for **lockfile loading**: `ephemeralize.rs`, `linkage.rs`, `loader.rs`, `modes.rs`, `to_lockfile.rs`, `package_info.rs`, plus supporting changes in `errors/mod.rs` and `graph/`. Roughly **+313 lines across 12 files**.

## Before resuming
- Check for overlap with the later, polished **"read a package's publication without loading its graph"** work (sui#27241) — the graph/loading concepts may have moved on.
- The companion checkpoint PR (#24849, skeleton ephemeral pubfile generation) was **closed as an abandoned checkpoint**; this one was kept because it has real code worth salvaging.
