### PR TITLE
chore: release notes script always looks up PRs.

### DIFF
--- a/.github/workflows/create-release-announce.yml
+++ b/.github/workflows/create-release-announce.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Update ${{ inputs.network }} branch
         shell: bash
-        run: |          
+        run: |
           export sui_release_version=$(cat Cargo.toml | grep '^version =' | tr -d '\"' | awk '{ print $3 }')
           echo "sui_release_version=${sui_release_version}" >> $GITHUB_ENV
 
@@ -81,7 +81,7 @@ jobs:
         run: |
           echo "${{ secrets.SUI_CREATE_RELEASE }}" | gh auth login --with-token
           echo "{\"sha\": \"${{ inputs.sui_commit }}\", \"force\": true}" | gh api -X PATCH /repos/MystenLabs/sui/git/refs/heads/framework/${{ inputs.network }} \
-            --header "Accept: application/vnd.github+json" --input -            
+            --header "Accept: application/vnd.github+json" --input -
 
       - name: Create ${{ inputs.network }}-v${{ env.sui_release_version }} release tag
         shell: bash
@@ -135,7 +135,7 @@ jobs:
           RELEASE_TAG: ${{ env.release_tag }}
         working-directory: ./
         run: |
-          SUI_REPO_TOKEN=${{ secrets.GITHUB_TOKEN }} \
+          GH_TOKEN=${{ secrets.GITHUB_TOKEN }} \
           python ./scripts/release_notes.py generate ${{ env.PREVIOUS_COMMIT }} ${{ env.CURRENT_COMMIT }} | tee -a ${{ env.RELEASE_NOTES_FILE }}
           echo "---" >> ${{ env.RELEASE_NOTES_FILE }}
           echo "#### Full Log: https://github.com/MystenLabs/sui/commits/${{ env.RELEASE_TAG }}" >> ${{ env.RELEASE_NOTES_FILE }}

--- a/.github/workflows/validate-release-notes-pre-land.yml
+++ b/.github/workflows/validate-release-notes-pre-land.yml
@@ -52,4 +52,4 @@ jobs:
       - name: Validate PR's release notes
         shell: bash
         run: |
-          GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} python ./scripts/release_notes.py check ${{ github.event.pull_request.number }}
+          GH_TOKEN=${{ secrets.GITHUB_TOKEN }} python ./scripts/release_notes.py check ${{ github.event.pull_request.number }}

--- a/scripts/release_notes.py
+++ b/scripts/release_notes.py
@@ -96,10 +96,10 @@ query($owner: String!, $name: String!, {params}) {{
 )
 
 # Set up a way to make requests to GitHub's GraphQL API
-TOKEN = os.getenv("GH_TOKEN")
+GH_TOKEN = os.getenv("GH_TOKEN")
 GH_CLI_PATH = shutil.which("gh")
-if TOKEN:
-    gql = lambda query, variables: gh_api_request(TOKEN, query, variables)
+if GH_TOKEN:
+    gql = lambda query, variables: gh_api_request(GH_TOKEN, query, variables)
 elif GH_CLI_PATH:
     gql = lambda query, variables: gh_cli_request(GH_CLI_PATH, query, variables)
 else:


### PR DESCRIPTION
## Description

Update the Release Notes PR so that it always work back from a landed commit to its associated PR, to find the release notes there. This allows it to pick up release notes for PRs that were landed using "Rebase & Merge" instead of "Squash & Merge" (or where the commit message was otherwise customized in the landed commit).

The script now requires `GH_TOKEN` to be set when it is run, to get authenticated access to GitHub's GraphQL API (or access to an authenticated `gh` CLI).

## Test plan

Locally:

```
$ ./scripts/release_notes.py generate \
  origin/releases/sui-v1.63.0-release \
  origin/releases/sui-v1.64.0-release
$ ./scripts/release_notes.py check 24770
```

The first command previously would miss release notes for many commits that didn't have them inline in the commit message, but now picks them up.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
