### PR TITLE
Repro for consensus submission issue

### DIFF
--- a/scripts/simtest/seed-search.py
+++ b/scripts/simtest/seed-search.py
@@ -109,7 +109,7 @@ if __name__ == "__main__":
         next_seed = args.seed_start + i
         commands.append(("%s --test-threads 1 %s %s %s" % (binary, '--no-capture' if args.no_capture else '', '--exact' if args.exact else '', args.testname), {
           "MSIM_TEST_SEED": "%d" % next_seed,
-          "RUST_LOG": "error",
+          "RUST_LOG": "off",
         }))
 
     # register clean up code to kill all child processes when we exit


### PR DESCRIPTION
In the below test run, `k#99f25ef6..` is never able to submit EOP, and so the cluster can't reconfigure, and the test times out.

Repro:

      RUST_LOG=sui=debug,info MSIM_TEST_SEED=1768586715031 cargo simtest --test simtest test_simulated_load_rolling_restarts_all_validators

```
 grep -Ei 'Creating checkpoint executor for epoch|close_epoch|still waiting.*endofpublish|suinode' /tmp/a1 | grep '"k#99f2'
2022-12-12T07:38:23.000200Z  INFO node{id=2 name="k#99f25ef6.."}: sui_node: /Users/marklogan/.cargo/git/checkouts/sui-e0a047c8ed89192d/3fed97c/crates/sui-node/src/lib.rs:930: SuiNode started!
2022-12-12T07:38:23.000238Z  INFO node{id=2 name="k#99f25ef6.."}: sui_node: /Users/marklogan/.cargo/git/checkouts/sui-e0a047c8ed89192d/3fed97c/crates/sui-node/src/lib.rs:1756: Creating checkpoint executor for epoch 0
2022-12-12T07:39:03.057235Z  INFO node{id=7 name="k#99f25ef6.."}: sui_node: /Users/marklogan/.cargo/git/checkouts/sui-e0a047c8ed89192d/3fed97c/crates/sui-node/src/lib.rs:930: SuiNode started!
2022-12-12T07:39:03.057236Z  INFO node{id=7 name="k#99f25ef6.."}: sui_node: /Users/marklogan/.cargo/git/checkouts/sui-e0a047c8ed89192d/3fed97c/crates/sui-node/src/lib.rs:1756: Creating checkpoint executor for epoch 0
2022-12-12T07:40:23.057469Z  INFO node{id=11 name="k#99f25ef6.."}: sui_node: /Users/marklogan/.cargo/git/checkouts/sui-e0a047c8ed89192d/3fed97c/crates/sui-node/src/lib.rs:930: SuiNode started!
2022-12-12T07:40:23.057476Z  INFO node{id=11 name="k#99f25ef6.."}: sui_node: /Users/marklogan/.cargo/git/checkouts/sui-e0a047c8ed89192d/3fed97c/crates/sui-node/src/lib.rs:1756: Creating checkpoint executor for epoch 0
2022-12-12T07:41:23.057644Z  INFO node{id=11 name="k#99f25ef6.."}: sui_node: /Users/marklogan/.cargo/git/checkouts/sui-e0a047c8ed89192d/3fed97c/crates/sui-node/src/lib.rs:961: close_epoch (current epoch = 0)
2022-12-12T07:41:53.057645Z  WARN node{id=11 name="k#99f25ef6.."}: sui_core::consensus_adapter: /Users/marklogan/.cargo/git/checkouts/sui-e0a047c8ed89192d/3fed97c/crates/sui-core/src/consensus_adapter.rs:893: Still waiting 30 seconds for transactions [External(EndOfPublish(k#99f25ef6..))] to commit in consensus
2022-12-12T07:41:54.922019Z  WARN node{id=11 name="k#99f25ef6.."}: sui_core::consensus_adapter: /Users/marklogan/.cargo/git/checkouts/sui-e0a047c8ed89192d/3fed97c/crates/sui-core/src/consensus_adapter.rs:893: Still waiting 30 seconds for transactions [External(EndOfPublish(k#99f25ef6..))] to commit in consensus
2022-12-12T07:41:54.922019Z  WARN node{id=11 name="k#99f25ef6.."}: sui_core::consensus_adapter: /Users/marklogan/.cargo/git/checkouts/sui-e0a047c8ed89192d/3fed97c/crates/sui-core/src/consensus_adapter.rs:893: Still waiting 30 seconds for transactions [External(EndOfPublish(k#99f25ef6..))] to commit in consensus
2022-12-12T07:41:54.922019Z  WARN node{id=11 name="k#99f25ef6.."}: sui_core::consensus_adapter: /Users/marklogan/.cargo/git/checkouts/sui-e0a047c8ed89192d/3fed97c/crates/sui-core/src/consensus_adapter.rs:893: Still waiting 30 seconds for transactions [External(EndOfPublish(k#99f25ef6..))] to commit in consensus
2022-12-12T07:41:54.922020Z  WARN node{id=11 name="k#99f25ef6.."}: sui_core::consensus_adapter: /Users/marklogan/.cargo/git/checkouts/sui-e0a047c8ed89192d/3fed97c/crates/sui-core/src/consensus_adapter.rs:893: Still waiting 30 seconds for transactions [External(EndOfPublish(k#99f25ef6..))] to commit in consensus
2022-12-12T07:41:54.922021Z  WARN node{id=11 name="k#99f25ef6.."}: sui_core::consensus_adapter: /Users/marklogan/.cargo/git/checkouts/sui-e0a047c8ed89192d/3fed97c/crates/sui-core/src/consensus_adapter.rs:893: Still waiting 30 seconds for transactions [External(EndOfPublish(k#99f25ef6..))] to commit in consensus

... continues waiting until test times out
```