### PR TITLE
[sui-e2e-tests] Change some assert!(..is_ok()` and `assert!(..is_err(……))` to equivalent unwraps

### DIFF
--- a/crates/sui-e2e-tests/tests/transfer_to_object_tests.rs
+++ b/crates/sui-e2e-tests/tests/transfer_to_object_tests.rs
@@ -77,7 +77,7 @@ async fn receive_of_object_with_reconfiguration_receive_after_reconfig() {
     let (parent, child) = env.start().await;
     let (new_parent, new_child) = env.receive(parent, child).await.unwrap();
     env.test_cluster.trigger_reconfiguration().await;
-    assert!(env.receive(new_parent, new_child).await.is_ok());
+    env.receive(new_parent, new_child).await.unwrap();
 }
 
 #[sim_test]
@@ -86,7 +86,7 @@ async fn receive_of_object_with_reconfiguration_receive_of_old_child_after_recon
     let (parent, child) = env.start().await;
     let (new_parent, _) = env.receive(parent, child).await.unwrap();
     env.test_cluster.trigger_reconfiguration().await;
-    assert!(env.receive(new_parent, child).await.is_err());
+    env.receive(new_parent, child).await.unwrap_err();
 }
 
 #[sim_test]
@@ -95,7 +95,7 @@ async fn receive_of_object_with_reconfiguration_receive_of_old_parent_after_reco
     let (parent, child) = env.start().await;
     let (_, new_child) = env.receive(parent, child).await.unwrap();
     env.test_cluster.trigger_reconfiguration().await;
-    assert!(env.receive(parent, new_child).await.is_err());
+    env.receive(parent, new_child).await.unwrap_err();
 }
 
 #[sim_test]
@@ -104,7 +104,7 @@ async fn receive_of_object_with_reconfiguration_receive_of_old_parent_and_child_
     let (parent, child) = env.start().await;
     env.receive(parent, child).await.unwrap();
     env.test_cluster.trigger_reconfiguration().await;
-    assert!(env.receive(parent, child).await.is_err());
+    env.receive(parent, child).await.unwrap_err();
 }
 
 #[sim_test]
@@ -113,7 +113,7 @@ async fn receive_of_object_with_reconfiguration_receive_after_reconfig_with_inva
     let (parent, child) = env.start().await;
     let (new_parent, new_child) = env.receive(parent, child).await.unwrap();
     env.test_cluster.trigger_reconfiguration().await;
-    assert!(env.receive(new_child, new_parent).await.is_err());
+    env.receive(new_child, new_parent).await.unwrap_err();
 }
 
 #[sim_test]
@@ -122,7 +122,7 @@ async fn delete_of_object_with_reconfiguration_receive_of_old_parent_and_child_a
     let (parent, child) = env.start().await;
     env.delete(parent, child).await;
     env.test_cluster.trigger_reconfiguration().await;
-    assert!(env.receive(parent, child).await.is_err());
+    env.receive(parent, child).await.unwrap_err();
 }
 
 #[sim_test]
@@ -132,7 +132,7 @@ async fn delete_of_object_with_reconfiguration_receive_of_new_parent_and_old_chi
     let (parent, child) = env.start().await;
     let new_parent = env.delete(parent, child).await;
     env.test_cluster.trigger_reconfiguration().await;
-    assert!(env.receive(new_parent, child).await.is_err());
+    env.receive(new_parent, child).await.unwrap_err();
 }
 
 fn get_parent_and_child(created: Vec<(ObjectRef, Owner)>) -> (ObjectRef, ObjectRef) {


### PR DESCRIPTION
## Description 

Convert some assertions to their equivalent unwraps

## Test plan 

It's in tests. Ran them locally.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
