### PR TITLE
futures: Avoid join_all allocation in Service shutdown

### DIFF
--- a/crates/sui-futures/src/service.rs
+++ b/crates/sui-futures/src/service.rs
@@ -216,7 +216,9 @@ impl Service {
     /// Returns with an error if any of the constituent tasks produced an error during shutdown,
     /// otherwise waits for all tasks (primary and secondy) to complete successfully.
     pub async fn shutdown(mut self) -> Result<(), Error> {
-        let _ = future::join_all(self.exits).await;
+        for exit in self.exits {
+            exit.await;
+        }
         if let Err(e) = future::try_join(run(&mut self.fsts), run(&mut self.snds)).await {
             error!("Task failure during shutdown: {e:#}");
             return Err(Error::Task(e));


### PR DESCRIPTION
Replaced join_all with a simple loop to await shutdown signals sequentially, removing an unnecessary Vec allocation while preserving behavior.