### PR TITLE
feat(sui-tool): add --resume for downloading in resume

### DIFF
--- a/crates/sui-tool/src/commands.rs
+++ b/crates/sui-tool/src/commands.rs
@@ -340,6 +340,11 @@ pub enum ToolCommand {
         /// Defaults to 3 retries. Set to 0 to disable retries.
         #[clap(long = "max-retries", default_value = "3")]
         max_retries: usize,
+
+        /// Resume a previously interrupted download instead of starting from scratch.
+        /// When enabled, already downloaded files will be skipped.
+        #[clap(long = "resume")]
+        resume: bool,
     },
 
     #[clap(name = "replay")]
@@ -668,6 +673,7 @@ impl ToolCommand {
                 latest,
                 verbose,
                 max_retries,
+                resume,
             } => {
                 if !verbose {
                     tracing_handle
@@ -796,6 +802,7 @@ impl ToolCommand {
                     network,
                     verify,
                     max_retries,
+                    resume,
                 )
                 .await?;
             }


### PR DESCRIPTION
## Description 

Describe the changes or additions included in this PR.

When I'm using `sui-tool download-formal-snapshot --latest` to download the latest snapshot, it maybe failed of network jitting:

```
$ ./download-snapshot
Beginning formal snapshot restore to end of epoch 1009, network: Mainnet, verification mode: Normal
Beginning transaction digest backfill for epoch: 1009, backfilling from: 234946424..235280678
[00:11:38] ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ 1881/334255 transactions backfilled (2.7 chkpts/sec)
[01:05:37] ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ 1881/334255 transactions backfilled (0.5 chkpts/sec)
[01:05:37] ██████████████████████████████████████████████████████████████████████████████████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░ 779/1010 (checkpoints synced per sec: 0.19760258232175928)
[01:00:24] █████████████████████████████████████████████████████████████████████████████████████████████████ 1350 out of 1350 missing .ref files done (Missing ref files download complete)
[00:00:07] █████████████████████████████████████████████████████████████████████████████████████████████████████████████████ 1350 out of 1350 ref files checksummed (Checksumming complete)
[00:05:04] ███████████████████████████████████████████████████████████████████████████████████████████████████ 1350 out of 1350 ref files accumulated from snapshot (Accumulation complete)
thread 'main' panicked at /home/runner/work/sui/sui/crates/sui-tool/src/lib.rs:913:10:
Summaries task failed: Generic HTTP error: error decoding response body

Caused by:
    0: error decoding response body
    1: request or response body error
    2: operation timed out
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
./download-snapshot: line 7: 1294961 Aborted                 (core dumped) ./bin/sui-tool download-formal-snapshot --latest --genesis=etc/genesis.blob --network=mainnet --path=/md1/sui-sn
ap --num-parallel-downloads=200 --no-sign-request "$@"
```

And at the next time re-download it, sui-tool will try to rm them all and restart the downloading https://github.com/MystenLabs/sui/blob/67a56bbb6ab4608f99f78756075b1633e2a83bea/crates/sui-tool/src/lib.rs#L856-L857

So I'm proposing to add `--resume` flag to the `download-formal-snapshot` command that allows resuming a previously interrupted download. 

When enabled, already downloaded files and synced checkpoints are skipped instead of re-downloading from scratch, preserves existing staging and snapshot directories when resuming



## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
