### PR TITLE
Fix important typo in docs - Anna to Alice.

### DIFF
--- a/docs/content/concepts/transactions.mdx
+++ b/docs/content/concepts/transactions.mdx
@@ -52,7 +52,7 @@ Tom decides to send 1 SUI coin to Alice. In this case, Object A is the input to 
 
 At the same time, John decides to send 2 SUI coins to Anna. The output of this transaction is:
 
-- Object B that contains 2 SUI coins and now belongs to Alice. 
+- Object B that contains 2 SUI coins and now belongs to Anna. 
 
 Because both transactions interact with different objects, the second transaction executes in parallel with the first transaction that sends coins from Tom to Alice. 
 


### PR DESCRIPTION
## Description 

The wrong name breaks the flow of someone trying to understand how transactions work.

## Test plan  
  
Re-read the example and diagram. The change make more sense.

---

## Release notes

N/A
