### PR TITLE
fix: pg_isready error message

### DIFF
--- a/crates/sui-pg-db/src/temp.rs
+++ b/crates/sui-pg-db/src/temp.rs
@@ -278,7 +278,7 @@ fn pg_isready(port: u16) -> Result<(), HealthCheckError> {
         .arg(port.to_string())
         .arg("--username=postgres")
         .output()
-        .map_err(|e| HealthCheckError::Unknown(format!("command not found: pg_ctl: {e}")))?;
+        .map_err(|e| HealthCheckError::Unknown(format!("command not found: pg_isready: {e}")))?;
 
     trace!("pg_isready code: {:?}", output.status.code());
     trace!("pg_isready output: {}", output.stderr.escape_ascii());


### PR DESCRIPTION
Cause:
The error message in pg_isready referenced pg_ctl, which is a different command and misleads diagnostics when pg_isready is missing.

Change:
Updated the error text to correctly reference pg_isready, improving clarity for troubleshooting.