### PR TITLE
Fix --sender flag ignored in publish/upgrade commands

### DIFF
--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -3503,7 +3503,9 @@ async fn publish_command(
         processing,
     } = args;
 
-    let sender = processing.sender.unwrap_or(context.infer_sender(&payment.gas).await?);
+    let sender = processing
+        .sender
+        .unwrap_or(context.infer_sender(&payment.gas).await?);
     let client = context.get_client().await?;
     let read_api = client.read_api();
     let chain_id = read_api.get_chain_identifier().await?;
@@ -3587,7 +3589,9 @@ async fn upgrade_command(
         processing,
     } = args;
 
-    let sender = processing.sender.unwrap_or(context.infer_sender(&payment.gas).await?);
+    let sender = processing
+        .sender
+        .unwrap_or(context.infer_sender(&payment.gas).await?);
     let client = context.get_client().await?;
     let read_api = client.read_api();
     let chain_id = read_api.get_chain_identifier().await?;

--- a/crates/sui/tests/cli_tests.rs
+++ b/crates/sui/tests/cli_tests.rs
@@ -5554,7 +5554,8 @@ async fn test_move_build_dump_bytecode_as_base64_with_unpublished_deps() -> Resu
 }
 
 #[sim_test]
-async fn test_publish_sender_flag_respected_in_serialized_transaction() -> Result<(), anyhow::Error> {
+async fn test_publish_sender_flag_respected_in_serialized_transaction() -> Result<(), anyhow::Error>
+{
     // This test verifies that when using --serialize-unsigned-transaction with --sender,
     // the sender address is correctly used as the UpgradeCap recipient in the PTB.
     // Previously, the sender was inferred from gas objects BEFORE checking the --sender flag,
@@ -5632,15 +5633,13 @@ async fn test_publish_sender_flag_respected_in_serialized_transaction() -> Resul
     };
 
     // Decode the address from BCS bytes
-    let recipient: SuiAddress = bcs::from_bytes(addr_bytes)
-        .expect("Failed to decode address from PTB input");
+    let recipient: SuiAddress =
+        bcs::from_bytes(addr_bytes).expect("Failed to decode address from PTB input");
 
     assert_eq!(
-        recipient,
-        specified_sender,
+        recipient, specified_sender,
         "UpgradeCap recipient in PTB should be the specified sender ({}), not active address ({})",
-        specified_sender,
-        active_address
+        specified_sender, active_address
     );
 
     Ok(())


### PR DESCRIPTION
## Description

Fixes a bug where the `--sender` flag was ignored when using `--serialize-unsigned-transaction` with `sui client publish` and `sui client upgrade` commands.

The `TxProcessingArgs::sender` field is documented as:

> Set the transaction sender to this address. **When not specified, the sender is inferred by finding the owner of the gas payment.**

However, `publish_command` and `upgrade_command` were always inferring the sender from gas objects, never checking `processing.sender`. This caused the UpgradeCap to be transferred to the inferred address instead of the specified sender.

This was problematic for workflows where:
- The transaction is serialized for later signing by a different party
- The signer address differs from the address owning the gas objects

The fix makes the implementation match the documented behavior: check `processing.sender` first and only fall back to gas inference if not specified.

## Test plan

Added `test_publish_sender_flag_respected_in_serialized_transaction` which:
1. Creates a test cluster with two addresses (address_0 as active, address_1 as specified sender)
2. Calls `TestPublish` with `--serialize-unsigned-transaction` and `--sender address_1`
3. Verifies the transaction sender is address_1
4. Verifies the UpgradeCap recipient in the PTB is address_1, not address_0

```bash
cargo test -p sui --test cli_tests test_publish_sender_flag_respected_in_serialized_transaction
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [x] CLI: The `--sender` flag is now correctly respected in `sui client publish` and `sui client upgrade` commands when used with `--serialize-unsigned-transaction`. Previously, the sender was incorrectly inferred from gas objects, ignoring the `--sender` flag.
- [ ] Rust SDK:
- [ ] Indexing Framework:
