### PR TITLE
fix: correct build env flag hint

### DIFF
--- a/crates/sui-package-alt/src/find_env.rs
+++ b/crates/sui-package-alt/src/find_env.rs
@@ -155,7 +155,7 @@ impl EnvFinder<'_> {
         if candidates.len() > 1 {
             let mut s = String::new();
             for e in candidates.keys() {
-                s.push_str(&format!("\n\t--build-env {e}"))
+                s.push_str(&format!("\n\t-e {e}"))
             }
             bail!(
                 "Found multiple environments defined in Move.toml with chain-id `{chain_id}`. Please pass one of the following:{s}"


### PR DESCRIPTION
The error message for multiple environments suggested --build-env, but normal build flows use -e/--environment. This could mislead users and point them to a flag that doesn’t apply in this context.

Update the multi-environment error hint to recommend -e so the CLI guidance matches the actual build flag.