### PR TITLE
fix(bridge-cli): drop redundant committee RPC call

### DIFF
--- a/crates/sui-bridge-cli/src/lib.rs
+++ b/crates/sui-bridge-cli/src/lib.rs
@@ -455,7 +455,6 @@ impl LoadedBridgeCliConfig {
             eth_bridge_committee_proxy_address,
             eth_signer_provider.clone(),
         );
-        let eth_bridge_committee_proxy_address: EthAddress = sui_bridge.committee().call().await?;
         let eth_bridge_config_proxy_address: EthAddress = eth_committee.config().call().await?;
 
         let eth_address = eth_signer_provider.default_signer_address();


### PR DESCRIPTION
Reason:
Before this change, committee() was called twice during CLI config load, overwriting the same address and causing an unnecessary extra RPC call that adds latency without any functional gain.

Summary:
Remove the redundant committee() RPC call and reuse the initially fetched committee proxy address when building the CLI config.