### PR TITLE
get_balance: fix parsing of shortened addresses

### DIFF
--- a/crates/sui-rpc-api/src/grpc/v2/state_service/get_balance.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/state_service/get_balance.rs
@@ -4,6 +4,7 @@
 use crate::{ErrorReason, Result, RpcError, RpcService};
 use sui_rpc::proto::google::rpc::bad_request::FieldViolation;
 use sui_rpc::proto::sui::rpc::v2::{Balance, GetBalanceRequest, GetBalanceResponse};
+use sui_sdk_types::Address;
 use sui_sdk_types::StructTag;
 use sui_types::base_types::SuiAddress;
 use sui_types::storage::BalanceInfo;
@@ -25,12 +26,13 @@ pub fn get_balance(service: &RpcService, request: GetBalanceRequest) -> Result<G
                 .with_description("missing owner")
                 .with_reason(ErrorReason::FieldMissing)
         })?
-        .parse::<SuiAddress>()
+        .parse::<Address>()
         .map_err(|e| {
             FieldViolation::new("owner")
                 .with_description(format!("invalid owner: {e}"))
                 .with_reason(ErrorReason::FieldInvalid)
         })?;
+    let owner = SuiAddress::from(owner);
 
     let coin_type = request
         .coin_type


### PR DESCRIPTION
Fix parsing of the owner address in get_balance implementation to support shortened hex strings (e.g. 0x2).

## Description 

Describe the changes or additions included in this PR.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
