### PR TITLE
chore: remove outdated TODO in metered_channel

### DIFF
--- a/crates/mysten-metrics/src/metered_channel.rs
+++ b/crates/mysten-metrics/src/metered_channel.rs
@@ -4,7 +4,6 @@
 
 use async_trait::async_trait;
 use std::future::Future;
-// TODO: complete tests - This kinda sorta facades the whole tokio::mpsc::{Sender, Receiver}: without tests, this will be fragile to maintain.
 use futures::{FutureExt, Stream, TryFutureExt};
 use prometheus::{IntCounter, IntGauge};
 use std::task::{Context, Poll};


### PR DESCRIPTION
Reason:
The TODO claimed that tests for the metered_channel facade were incomplete and fragile, but there is already a comprehensive test suite in tests/metered_channel_tests.rs, so the comment was misleading.

Summary:
Remove the outdated TODO comment at the top of metered_channel.rs without changing any functional code or tests.