### PR TITLE
[move][move-vm][bella-ciao] Swap out caching table representations for better perf.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6378,6 +6378,12 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashers"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "foldhash 0.2.0",
  "serde",
@@ -9129,6 +9135,7 @@ dependencies = [
  "bcs",
  "better_any",
  "bumpalo",
+ "dashmap 6.1.0",
  "fail",
  "hex",
  "indexmap 2.8.0",
@@ -9143,6 +9150,7 @@ dependencies = [
  "move-vm-profiler",
  "parking_lot 0.11.2",
  "petgraph 0.8.1",
+ "quick_cache",
  "serde",
  "sha2 0.9.9",
  "sha3 0.9.1",
@@ -11412,6 +11420,18 @@ checksum = "165859e9e55f79d67b96c5d96f4e88b6f2695a1972849c15a6a3f5c59fc2c003"
 dependencies = [
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "quick_cache"
+version = "0.6.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ada44a88ef953a3294f6eb55d2007ba44646015e18613d2f213016379203ef3"
+dependencies = [
+ "ahash 0.8.11",
+ "equivalent",
+ "hashbrown 0.16.1",
+ "parking_lot 0.12.3",
 ]
 
 [[package]]

--- a/external-crates/move/Cargo.lock
+++ b/external-crates/move/Cargo.lock
@@ -24,6 +24,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
+ "getrandom 0.3.1",
  "once_cell",
  "version_check",
  "zerocopy 0.8.27",
@@ -1373,6 +1374,12 @@ dependencies = [
  "equivalent",
  "foldhash",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "heck"
@@ -2978,6 +2985,7 @@ dependencies = [
  "bcs",
  "better_any",
  "bumpalo",
+ "dashmap",
  "fail",
  "hex",
  "indexmap 2.8.0",
@@ -3000,6 +3008,7 @@ dependencies = [
  "parking_lot 0.11.2",
  "petgraph",
  "proptest",
+ "quick_cache",
  "serde",
  "sha2",
  "sha3",
@@ -3686,6 +3695,18 @@ name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quick_cache"
+version = "0.6.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ada44a88ef953a3294f6eb55d2007ba44646015e18613d2f213016379203ef3"
+dependencies = [
+ "ahash",
+ "equivalent",
+ "hashbrown 0.16.1",
+ "parking_lot 0.12.3",
+]
 
 [[package]]
 name = "quote"

--- a/external-crates/move/Cargo.toml
+++ b/external-crates/move/Cargo.toml
@@ -52,6 +52,7 @@ crossbeam = "0.8"
 crossbeam-channel = "0.5.0"
 crossterm = "0.25.0"
 curve25519-dalek = { version = "0.1.0", package = "curve25519-dalek-fiat", default-features = false, features = ["std", "u64_backend"] }
+dashmap = "6.1.0"
 datatest-stable = "0.1.1"
 derivative = "2.2.0"
 difference = "2.0.0"
@@ -105,6 +106,7 @@ primitive-types = { version = "0.10.1", features = ["impl-serde"]}
 proc-macro2 = "1.0.24"
 proptest = "1.6.0"
 proptest-derive = "0.5"
+quick_cache = { version = "0.6.18", features = ["stats"] }
 quote = "1.0.9"
 rand = "0.8.0"
 ratatui = "0.29.0"

--- a/external-crates/move/crates/move-vm-runtime/Cargo.toml
+++ b/external-crates/move/crates/move-vm-runtime/Cargo.toml
@@ -16,27 +16,29 @@ anyhow.workspace = true
 bcs.workspace = true
 better_any.workspace = true
 bumpalo.workspace = true
+dashmap.workspace = true
 fail.workspace = true
 hex.workspace = true
 indexmap.workspace = true
 lasso.workspace = true
 lru.workspace = true
 parking_lot.workspace = true
+petgraph.workspace = true
+quick_cache.workspace = true
 serde.workspace = true
 sha2.workspace = true
 sha3.workspace = true
 smallvec.workspace = true
 tracing.workspace = true
-move-abstract-interpreter.workspace = true
 
 # referred to via path for execution versioning
+move-abstract-interpreter.workspace = true
+move-binary-format.workspace = true
 move-bytecode-verifier = { path = "../move-bytecode-verifier" }
 move-core-types.workspace = true
-move-vm-config.workspace = true
-move-binary-format.workspace = true
-move-vm-profiler.workspace = true
-petgraph.workspace = true
 move-trace-format.workspace = true
+move-vm-config.workspace = true
+move-vm-profiler.workspace = true
 
 [dev-dependencies]
 anyhow.workspace = true

--- a/external-crates/move/crates/move-vm-runtime/src/cache/identifier_interner.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/cache/identifier_interner.rs
@@ -59,21 +59,18 @@ impl IdentifierInterner {
         }
     }
 
-    #[allow(dead_code)]
     /// Get the interned identifier value. This may raise an invariant error if `try_get_or_intern`
     /// fails, but that's likely a serious OOM issue.
     pub(crate) fn intern_identifier(&self, ident: &Identifier) -> PartialVMResult<IdentifierKey> {
         self.get_or_intern_str_internal(ident.borrow_str())
     }
 
-    #[allow(dead_code)]
     /// Get the interned identifier string value. This may raise an invariant error if
     /// `get_or_intern` fails, but that's likely a serious OOM issue.
     pub(crate) fn intern_ident_str(&self, ident_str: &IdentStr) -> PartialVMResult<IdentifierKey> {
         self.get_or_intern_str_internal(ident_str.borrow_str())
     }
 
-    #[allow(dead_code)]
     /// Get the interned identifier value, using `key_type` in the error case. This may raise an
     /// invariant error if `try_get_or_intern` fails, but that's likely a serious OOM issue.
     pub(crate) fn intern_identifier_with_msg(

--- a/external-crates/move/crates/move-vm-runtime/src/cache/move_cache.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/cache/move_cache.rs
@@ -6,13 +6,22 @@
 // and publishing packages to the VM.
 
 use crate::{
-    jit, runtime::telemetry::MoveCacheTelemetry, shared::types::VersionId, validation::verification,
+    cache::identifier_interner::IdentifierInterner,
+    execution::dispatch_tables::VMDispatchTables,
+    jit,
+    runtime::telemetry::MoveCacheTelemetry,
+    shared::{
+        constants::VIRTUAL_DISPATCH_TABLE_CACHE_SIZE, linkage_context::LinkageHash,
+        types::VersionId,
+    },
+    validation::verification,
 };
-use move_vm_config::runtime::VMConfig;
-use parking_lot::RwLock;
-use std::{collections::HashMap, sync::Arc};
 
-use super::identifier_interner::IdentifierInterner;
+use dashmap::DashMap;
+use move_vm_config::runtime::VMConfig;
+use quick_cache::sync::Cache as QCache;
+
+use std::sync::Arc;
 
 // -------------------------------------------------------------------------------------------------
 // Types
@@ -24,14 +33,15 @@ pub struct Package {
     pub runtime: Arc<jit::execution::ast::Package>,
 }
 
-type PackageCache = HashMap<VersionId, Arc<Package>>;
+type PackageCache = DashMap<VersionId, Arc<Package>>;
 
 /// The loader for the VM. This is the data structure is used to resolve packages and cache them
 /// and their types. This is then used to create the VTables for the VM.
 #[derive(Debug)]
 pub struct MoveCache {
     pub(crate) vm_config: Arc<VMConfig>,
-    pub(crate) package_cache: Arc<RwLock<PackageCache>>,
+    pub(crate) package_cache: Arc<PackageCache>,
+    pub(crate) linkage_vtables: Arc<QCache<LinkageHash, VMDispatchTables>>,
     pub(crate) interner: Arc<IdentifierInterner>,
 }
 
@@ -51,13 +61,14 @@ impl MoveCache {
     pub fn new(vm_config: Arc<VMConfig>) -> Self {
         Self {
             vm_config,
-            package_cache: Arc::new(RwLock::new(HashMap::new())),
+            package_cache: Arc::new(DashMap::new()),
             interner: Arc::new(IdentifierInterner::new()),
+            linkage_vtables: Arc::new(QCache::new(VIRTUAL_DISPATCH_TABLE_CACHE_SIZE)),
         }
     }
 
     // -------------------------------------------
-    // Caching Operations
+    // Package Caching Operations
     // -------------------------------------------
 
     /// Add a package to the cache. If the package is already present, this is a no-op.
@@ -72,36 +83,79 @@ impl MoveCache {
     /// Returns `true` if the package was newly inserted, `false` if it was already present.
     /// NB: in a parallel scenario the result of this function is not guaranteed to be
     /// deterministic.
-    pub fn add_to_cache(
+    pub(crate) fn add_package_to_cache(
         &self,
         package_key: VersionId,
         verified: verification::ast::Package,
         runtime: jit::execution::ast::Package,
     ) -> bool {
-        // NB: We grab a write lock here to ensure that we don't double-insert a package.
-        let mut package_cache = self.package_cache.write();
-
-        if package_cache.contains_key(&package_key) {
-            return false;
+        use dashmap::mapref::entry::Entry;
+        // Grab the entry at the top, so we can figure out which flag to return while holding the
+        // lock on the shard of dashmap we are modifying (so this does not change out from under us
+        // mid-write).
+        let entry = self.package_cache.entry(package_key);
+        match entry {
+            Entry::Occupied(_) => {
+                // Package is already present.
+                false
+            }
+            Entry::Vacant(vacant_entry) => {
+                let verified = Arc::new(verified);
+                let runtime = Arc::new(runtime);
+                let package = Package { verified, runtime };
+                vacant_entry.insert(Arc::new(package));
+                true
+            }
         }
-        let verified = Arc::new(verified);
-        let runtime = Arc::new(runtime);
-        let package = Package { verified, runtime };
-        package_cache.insert(package_key, Arc::new(package));
-        true
     }
 
     /// Get a package from the cache, if it is present.
     /// If not present, returns `None`.
-    pub fn cached_package_at(&self, package_key: VersionId) -> Option<Arc<Package>> {
-        self.package_cache.read().get(&package_key).map(Arc::clone)
+    pub(crate) fn cached_package_at(&self, package_key: VersionId) -> Option<Arc<Package>> {
+        self.package_cache
+            .get(&package_key)
+            .as_deref()
+            .map(Arc::clone)
+    }
+
+    // -------------------------------------------
+    // Linkage VTable Caching Operations
+    // -------------------------------------------
+
+    /// Add linkage tables to the cache for a given linkage context.
+    ///
+    /// Returns `true` if the tables were newly inserted, `false` if they were already present.
+    pub(crate) fn add_linkage_tables_to_cache(
+        &self,
+        linkage_key: LinkageHash,
+        vtables: VMDispatchTables,
+    ) -> bool {
+        let mut inserted = false;
+        let _insert_result: Result<VMDispatchTables, ()> = self
+            .linkage_vtables
+            .get_or_insert_with::<_, ()>(&linkage_key, || {
+                inserted = true;
+                Ok(vtables)
+            });
+        inserted
+    }
+
+    /// Get cached linkage tables for a given linkage context, if present, and updates the LRU
+    /// stats. If not present, returns `None`.
+    pub(crate) fn cached_linkage_tables_at(
+        &self,
+        linkage_key: &LinkageHash,
+    ) -> Option<VMDispatchTables> {
+        // NB: QuickCache returns a cloned value. This means we perform a deep clone of the
+        // VMDispatchTables, which is mostly Arc pointers, so this is not too expensive.
+        self.linkage_vtables.get(linkage_key)
     }
 
     // -------------------------------------------
     // Getters
     // -------------------------------------------
 
-    pub fn package_cache(&self) -> &RwLock<PackageCache> {
+    pub fn package_cache(&self) -> &PackageCache {
         &self.package_cache
     }
 
@@ -112,17 +166,17 @@ impl MoveCache {
     /// For use with unit testing: remove a package, returning `true` if it was present.
     #[cfg(test)]
     pub(crate) fn remove_package(&self, version_id: &VersionId) -> bool {
-        self.package_cache.write().remove(version_id).is_some()
+        self.package_cache.remove(version_id).is_some()
     }
 
     // -------------------------------------------
     // Telemetry Reporting
     // -------------------------------------------
 
+    /// Grab telemetry information about the current state of the Move Cache.
+    /// Note this may change as it is being computed, due to concurrent access. We do not care, as
+    /// telemetry is best-effort.
     pub(crate) fn to_cache_telemetry(&self) -> MoveCacheTelemetry {
-        // Lock the package_cache for reading.
-        let package_cache = self.package_cache.read();
-
         let mut package_cache_count: u64 = 0;
         let mut total_arena_size: u64 = 0;
         let mut module_count: u64 = 0;
@@ -130,7 +184,8 @@ impl MoveCache {
         let mut type_count: u64 = 0;
 
         // Iterate over each package.
-        for (_version_id, package_arc) in package_cache.iter() {
+        for entry in self.package_cache.iter() {
+            let package_arc = entry.value();
             package_cache_count += 1;
 
             // Dereference the runtime package.
@@ -149,6 +204,10 @@ impl MoveCache {
 
         let interner_size: u64 = self.interner.size() as u64;
 
+        let vtable_cache_count = self.linkage_vtables.len() as u64;
+        let vtable_cache_hits = self.linkage_vtables.hits();
+        let vtable_cache_misses = self.linkage_vtables.misses();
+
         MoveCacheTelemetry {
             package_cache_count,
             total_arena_size,
@@ -156,6 +215,9 @@ impl MoveCache {
             function_count,
             type_count,
             interner_size,
+            vtable_cache_count,
+            vtable_cache_hits,
+            vtable_cache_misses,
         }
     }
 }
@@ -186,11 +248,13 @@ impl Clone for MoveCache {
             vm_config,
             package_cache,
             interner,
+            linkage_vtables,
         } = self;
         Self {
             vm_config: Arc::clone(vm_config),
             package_cache: Arc::clone(package_cache),
             interner: Arc::clone(interner),
+            linkage_vtables: Arc::clone(linkage_vtables),
         }
     }
 }

--- a/external-crates/move/crates/move-vm-runtime/src/runtime/package_resolution.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/runtime/package_resolution.rs
@@ -258,7 +258,7 @@ pub(crate) fn jit_and_cache_package(
     .map_err(|err| err.finish(Location::Package(version_id)));
     telemetry.report_time(timer);
 
-    let fresh_insert_to_cache = cache.add_to_cache(version_id, verified_pkg, runtime_pkg?);
+    let fresh_insert_to_cache = cache.add_package_to_cache(version_id, verified_pkg, runtime_pkg?);
 
     // If we compiled the package, but another thread already inserted it during compilation,
     // record that this was a redundant compilation for telemetry and move on.

--- a/external-crates/move/crates/move-vm-runtime/src/runtime/telemetry.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/runtime/telemetry.rs
@@ -33,6 +33,12 @@ pub struct MoveRuntimeTelemetry {
     pub type_count: u64,
     /// Total size of all string interner
     pub interner_size: u64,
+    /// Total number of VTables in the LRU
+    pub vtable_cache_count: u64,
+    ///  Total number of VTable cache hits
+    pub vtable_cache_hits: u64,
+    ///  Total number of VTable cache misses
+    pub vtable_cache_misses: u64,
 
     // -------------------------------------------
     // Telemetry Tracked over Execution
@@ -141,6 +147,12 @@ pub(crate) struct MoveCacheTelemetry {
     pub type_count: u64,
     /// Total identifiers interned
     pub interner_size: u64,
+    /// Total number of VTables in the VTable cache
+    pub vtable_cache_count: u64,
+    ///  Total number of VTable cache hits
+    pub vtable_cache_hits: u64,
+    ///  Total number of VTable cache misses
+    pub vtable_cache_misses: u64,
 }
 
 /// Timer Kinds
@@ -277,6 +289,9 @@ impl TelemetryContext {
             function_count,
             type_count,
             interner_size,
+            vtable_cache_count,
+            vtable_cache_hits,
+            vtable_cache_misses,
         } = package_cache.to_cache_telemetry();
 
         MoveRuntimeTelemetry {
@@ -287,6 +302,9 @@ impl TelemetryContext {
             function_count,
             type_count,
             interner_size,
+            vtable_cache_count,
+            vtable_cache_hits,
+            vtable_cache_misses,
 
             // Telemetry metrics.
             total_load_time,

--- a/external-crates/move/crates/move-vm-runtime/src/shared/constants.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/shared/constants.rs
@@ -27,3 +27,13 @@ pub const HISTORICAL_MAX_TYPE_TO_LAYOUT_NODES: u64 = 256;
 /// Maximal nodes which are all allowed when instantiating a generic type. This does not include
 /// field types of datatypes.
 pub const MAX_TYPE_INSTANTIATION_NODES: u64 = 128;
+
+/// Size of the type depth LRU
+/// TODO(vm-rewrite): find a good bound for this
+pub const TYPE_DEPTH_LRU_SIZE: usize = 16_384;
+
+/// Size of the linkage-cahge virtual dispatch LRU
+/// TODO(vm-rewrite): find a good bound for this
+/// This number is currently 1 GB / 128 bytes (size of VMDispatchTables), giving approximately
+/// a gigabytes of storage to VTables (though this disregards key and LRU overhead).
+pub const VIRTUAL_DISPATCH_TABLE_CACHE_SIZE: usize = 1_000_000;

--- a/external-crates/move/crates/move-vm-runtime/src/shared/linkage_context.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/shared/linkage_context.rs
@@ -10,7 +10,7 @@ use crate::shared::types::{OriginalId, VersionId};
 
 /// An execution context that remaps the modules referred to at runtime according to a linkage
 /// table, allowing the same module in storage to be run against different dependencies.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LinkageContext {
     // Linkage Table. This is a table indicating, for a given Address, how it should be linked.
     // This is purely for versioning. Assume some Package P is published at V1 and V2 as:
@@ -21,6 +21,12 @@ pub struct LinkageContext {
     // 0xDEAD for this purpose.
     pub linkage_table: BTreeMap<OriginalId, VersionId>,
 }
+
+/// A hashable representation of a linkage context, for caching purposes.
+// This actually just holds the linkage for now, but in the future other implementations may
+// replace it.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct LinkageHash(BTreeMap<OriginalId, VersionId>);
 
 impl LinkageContext {
     pub fn new(linkage_table: BTreeMap<OriginalId, VersionId>) -> Self {
@@ -106,5 +112,9 @@ impl LinkageContext {
             .filter(|id| *id != &except)
             .cloned()
             .collect::<BTreeSet<_>>())
+    }
+
+    pub(crate) fn to_linkage_hash(&self) -> LinkageHash {
+        LinkageHash(self.linkage_table.clone())
     }
 }

--- a/external-crates/move/crates/move-vm-runtime/src/unit_tests/package_cache_tests.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/unit_tests/package_cache_tests.rs
@@ -340,7 +340,7 @@ fn cache_and_evict_packages() {
     let result = load_linkage_packages_into_runtime(&mut adapter, &link_context);
     assert!(result.is_ok());
 
-    assert!(adapter.runtime().cache().package_cache().read().len() == 3);
+    assert!(adapter.runtime().cache().package_cache().len() == 3);
     assert!(
         adapter
             .runtime()
@@ -367,13 +367,13 @@ fn cache_and_evict_packages() {
         adapter.runtime().cache().remove_package(&package2_address),
         "Package 2 not found"
     );
-    assert!(adapter.runtime().cache().package_cache().read().len() == 2);
+    assert!(adapter.runtime().cache().package_cache().len() == 2);
 
     assert!(
         !adapter.runtime().cache().remove_package(&package2_address),
         "Package 2 double-evicted"
     );
-    assert!(adapter.runtime().cache().package_cache().read().len() == 2);
+    assert!(adapter.runtime().cache().package_cache().len() == 2);
     assert!(
         adapter
             .runtime()
@@ -399,7 +399,7 @@ fn cache_and_evict_packages() {
     // This should re-load package 2, but not packages 1 or 3.
     let result = load_linkage_packages_into_runtime(&mut adapter, &link_context);
     assert!(result.is_ok());
-    assert!(adapter.runtime().cache().package_cache().read().len() == 3);
+    assert!(adapter.runtime().cache().package_cache().len() == 3);
     assert!(
         adapter
             .runtime()
@@ -427,7 +427,7 @@ fn cache_and_evict_packages() {
         adapter.runtime().cache().remove_package(&package2_address),
         "Package 2 not found"
     );
-    assert!(adapter.runtime().cache().package_cache().read().len() == 2);
+    assert!(adapter.runtime().cache().package_cache().len() == 2);
     assert!(
         adapter
             .runtime()
@@ -658,7 +658,7 @@ fn relink() {
         )
         .unwrap();
 
-    assert_eq!(adapter.runtime()cache().package_cache().read().len(), 0);
+    assert_eq!(adapter.runtime()cache().package_cache().len(), 0);
 
     // publish c v1
     let packages = compile_modules_in_file("rt_c_v1.move", &[]);
@@ -682,7 +682,7 @@ fn relink() {
         )
         .unwrap();
 
-    assert_eq!(adapter.cache.package_cache().read().len(), 1);
+    assert_eq!(adapter.cache.package_cache().len(), 1);
 
     // publish b_v0 <- c_v0
     let packages = compile_modules_in_file("rt_b_v0.move", &["rt_c_v0.move"]);
@@ -698,7 +698,7 @@ fn relink() {
         )
         .unwrap();
 
-    assert_eq!(adapter.cache.package_cache().read().len(), 2);
+    assert_eq!(adapter.cache.package_cache().len(), 2);
 
     // publish b_v0 <- c_v1
     let packages = compile_modules_in_file("rt_b_v0.move", &["rt_c_v1.move"]);
@@ -731,7 +731,7 @@ fn relink() {
         )
         .unwrap();
 
-    assert_eq!(adapter.cache.package_cache().read().len(), 4);
+    assert_eq!(adapter.cache.package_cache().len(), 4);
 
     // publish a_v0 <- c_v1 && b_v0
     let packages = compile_modules_in_file("rt_a_v0.move", &["rt_c_v1.move", "rt_b_v0.move"]);
@@ -764,7 +764,7 @@ fn relink() {
         )
         .unwrap();
 
-    assert_eq!(adapter.cache.package_cache().read().len(), 5);
+    assert_eq!(adapter.cache.package_cache().len(), 5);
 
     // publish a_v0 <- c_v0 && b_v0 -- ERROR since a_v0 requires c_v1+
     let packages = compile_modules_in_file("rt_a_v0.move", &["rt_c_v1.move", "rt_b_v0.move"]);
@@ -789,6 +789,6 @@ fn relink() {
         .unwrap_err();
 
     // cache stays the same since the publish failed
-    assert_eq!(adapter.cache.package_cache().read().len(), 5);
+    assert_eq!(adapter.cache.package_cache().len(), 5);
     */
 }

--- a/external-crates/move/crates/move-vm-runtime/src/validation/mod.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/validation/mod.rs
@@ -25,7 +25,7 @@ use self::verification::linkage::verify_linkage_and_cyclic_checks;
 
 /// Verify a package for publication, including ensuring it is valid against its dependencies for
 /// linkage.
-pub fn validate_for_publish(
+pub(crate) fn validate_for_publish(
     natives: &NativeFunctions,
     vm_config: &VMConfig,
     original_id: OriginalId,
@@ -58,7 +58,7 @@ pub fn validate_for_publish(
 }
 
 /// Verify a set of packages for VM execution, ensuring linkage is correct and there are no cycles.
-pub fn validate_for_vm_execution(
+pub(crate) fn validate_for_vm_execution(
     packages: BTreeMap<VersionId, &verification::ast::Package>,
 ) -> VMResult<()> {
     verify_linkage_and_cyclic_checks(&packages)


### PR DESCRIPTION
## Description 

This brings `dashmap` and `quickcache` into the VM's cache, in hopes of reducing lock contention.

## Test plan 

Tim will test perf; everything else is as green as before.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
