### PR TITLE
Track graphql error count by error code, and track number of graphql requests erroring out

### DIFF
--- a/crates/sui-indexer-alt-graphql/src/metrics.rs
+++ b/crates/sui-indexer-alt-graphql/src/metrics.rs
@@ -49,7 +49,8 @@ pub struct RpcMetrics {
     pub query_latency: Histogram,
     pub queries_received: IntCounter,
     pub queries_succeeded: IntCounter,
-    pub queries_failed: IntCounterVec,
+    pub queries_failed: IntCounter,
+    pub query_errors: IntCounterVec,
     pub queries_cancelled: IntCounter,
     pub queries_panicked: IntCounter,
     pub queries_in_flight: IntGauge,
@@ -152,9 +153,15 @@ impl RpcMetrics {
             )
             .unwrap(),
 
-            queries_failed: register_int_counter_vec_with_registry!(
+            queries_failed: register_int_counter_with_registry!(
                 "graphql_queries_failed",
-                "Number of read requests that have completed with at least one error",
+                "Number of read requests that have failed with an error",
+                registry,
+            ).unwrap(),
+
+            query_errors: register_int_counter_vec_with_registry!(
+                "graphql_query_errors",
+                "Count of graphql query failures by error code",
                 &["code"],
                 registry,
             )


### PR DESCRIPTION
## Description 

query_errors metric tracks count of error by code
queries_failed increments once per failed graphql request

## Test plan 

multiple_error_codes_single_request_failed consisting of `{ undefined1 undefined2 undefined3 }` creates 3 error codes for the single graphql request, but only increments queries_failed metric once.
---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
