### PR TITLE
feat: add makefile for common develop scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,11 @@
 
 .DEFAULT_GOAL := help
 
+# Cargo profile for builds. Default is debug for faster compilation.
+# Override with: make build PROFILE=release
+PROFILE ?= debug
+CARGO_PROFILE_FLAG := $(if $(filter release,$(PROFILE)),--release,)
+
 ##@ Help
 
 .PHONY: help
@@ -15,13 +20,13 @@ check: ## Check code without building (fast).
 	cargo check
 
 .PHONY: build
-build: ## Build the entire project.
-	cargo build
+build: ## Build the entire project (PROFILE=debug|release).
+	cargo build $(CARGO_PROFILE_FLAG)
 
 .PHONY: build-p
-build-p: ## Build a specific package (P=<package>).
+build-p: ## Build a specific package (P=<package>, PROFILE=debug|release).
 	@if [ -z "$(P)" ]; then echo "Usage: make build-p P=<package>"; exit 1; fi
-	cargo build -p $(P)
+	cargo build -p $(P) $(CARGO_PROFILE_FLAG)
 
 ##@ Test
 


### PR DESCRIPTION
## Description 

Describe the changes or additions included in this PR.


Currently, developers need to remember various cargo commands to run the build, test and lint routines, and Makefile is really useful and convenient tool to manage those things, so propose to add a Makefile with common development commands for building, testing, and linting. 


example usage:

```
make                          # show help
make check                    # fast code check
make build-p P=sui-core       # build specific package
make build PROFILE=release    # release build
make test-p P=sui-types       # test specific package
make lint                     # format and lint before commit
```

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
