### PR TITLE
fix(sui-pg-db): missing CryptoProvider

### DIFF
--- a/crates/sui-pg-db/src/tls.rs
+++ b/crates/sui-pg-db/src/tls.rs
@@ -93,10 +93,13 @@ impl ServerCertVerifier for SkipServerCertCheck {
     }
 
     fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
-        rustls::client::WebPkiServerVerifier::builder(Arc::new(root_certs()))
-            .build()
-            .unwrap()
-            .supported_verify_schemes()
+        rustls::client::WebPkiServerVerifier::builder_with_provider(
+            Arc::new(root_certs()),
+            Arc::new(rustls::crypto::ring::default_provider()),
+        )
+        .build()
+        .unwrap()
+        .supported_verify_schemes()
     }
 }
 


### PR DESCRIPTION
## Description

CI surfaced an issue where another codepath required that an implicit `CryptoProvider` be set. Updated that to use an explicit provider instead.

## Test plan

Ran the build locally and it still works -- this also needs to go through a continuous deploy in CI to make sure it fixes the issue.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
