### PR TITLE
Track total withdraw amount per account for object funds withdraw

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2100,11 +2100,11 @@ impl AuthorityState {
             );
 
         let object_funds_checker = self.object_funds_checker.load();
-        // FIXME: effects contain merged funds changes. But we need the sum of all the withdraws per account.
         if let Some(object_funds_checker) = object_funds_checker.as_ref()
             && !object_funds_checker.should_commit_object_funds_withdraws(
                 certificate,
-                &effects,
+                effects.status(),
+                &inner_temp_store.accumulator_running_max_withdraws,
                 &execution_env,
                 self.get_account_funds_read(),
                 &self.execution_scheduler,

--- a/crates/sui-core/src/transaction_outputs.rs
+++ b/crates/sui-core/src/transaction_outputs.rs
@@ -48,6 +48,7 @@ impl TransactionOutputs {
             binary_config: _,
             runtime_packages_loaded_from_db: _,
             lamport_version,
+            accumulator_running_max_withdraws: _,
         } = inner_temporary_store;
 
         let tx_digest = *transaction.digest();

--- a/crates/sui-types/src/effects/object_change.rs
+++ b/crates/sui-types/src/effects/object_change.rs
@@ -195,6 +195,16 @@ impl AccumulatorWriteV1 {
             value: merged_value,
         }
     }
+
+    pub fn get_fund_withdraw_amount(&self) -> Option<u128> {
+        if let (&AccumulatorOperation::Split, &AccumulatorValue::Integer(amount)) =
+            (&self.operation, &self.value)
+        {
+            Some(amount as u128)
+        } else {
+            None
+        }
+    }
 }
 
 #[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize)]

--- a/crates/sui-types/src/inner_temporary_store.rs
+++ b/crates/sui-types/src/inner_temporary_store.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::accumulator_event::AccumulatorEvent;
+use crate::accumulator_root::AccumulatorObjId;
 use crate::base_types::{SequenceNumber, VersionDigest};
 use crate::effects::TransactionEvents;
 use crate::error::SuiResult;
@@ -36,6 +37,15 @@ pub struct InnerTemporaryStore {
     pub binary_config: BinaryConfig,
     pub runtime_packages_loaded_from_db: BTreeMap<ObjectID, PackageObject>,
     pub lamport_version: SequenceNumber,
+    /// For each accumulator account, tracks the max running net withdraws during this transaction.
+    /// For instance, if the funds accumulator events looke like this for an account:
+    /// - Split(100)
+    /// - Merge(100)
+    /// - Split(100)
+    ///
+    /// Then the accumulator_running_max_withdraws for this account will be 100,
+    /// because at any given moment, the net withdraws is at most 100.
+    pub accumulator_running_max_withdraws: BTreeMap<AccumulatorObjId, u128>,
 }
 
 pub struct TemporaryModuleResolver<'a, R> {

--- a/sui-execution/latest/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/latest/sui-adapter/src/execution_engine.rs
@@ -13,6 +13,7 @@ mod checked {
     use move_trace_format::format::MoveTraceBuilder;
     use move_vm_runtime::move_vm::MoveVM;
     use mysten_common::debug_fatal;
+    use std::collections::BTreeMap;
     use std::{cell::RefCell, collections::HashSet, rc::Rc, sync::Arc};
     use sui_types::accumulator_root::{ACCUMULATOR_ROOT_CREATE_FUNC, ACCUMULATOR_ROOT_MODULE};
     use sui_types::balance::{
@@ -313,7 +314,7 @@ mod checked {
         )
         .map_err(|(e, _)| e)?;
         temporary_store.update_object_version_and_prev_tx();
-        Ok(temporary_store.into_inner())
+        Ok(temporary_store.into_inner(BTreeMap::new()))
     }
 
     #[instrument(name = "tx_execute", level = "debug", skip_all)]

--- a/sui-execution/v0/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/v0/sui-adapter/src/temporary_store.rs
@@ -158,6 +158,7 @@ impl<'backing> TemporaryStore<'backing> {
             runtime_packages_loaded_from_db: self.runtime_packages_loaded_from_db.into_inner(),
             lamport_version: self.lamport_timestamp,
             binary_config: self.protocol_config.binary_config(None),
+            accumulator_running_max_withdraws: BTreeMap::new(),
         }
     }
 

--- a/sui-execution/v1/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/v1/sui-adapter/src/temporary_store.rs
@@ -122,6 +122,7 @@ impl<'backing> TemporaryStore<'backing> {
             runtime_packages_loaded_from_db: self.runtime_packages_loaded_from_db.into_inner(),
             lamport_version: self.lamport_timestamp,
             binary_config: self.protocol_config.binary_config(None),
+            accumulator_running_max_withdraws: BTreeMap::new(),
         }
     }
 

--- a/sui-execution/v2/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/v2/sui-adapter/src/temporary_store.rs
@@ -140,6 +140,7 @@ impl<'backing> TemporaryStore<'backing> {
             runtime_packages_loaded_from_db: self.runtime_packages_loaded_from_db.into_inner(),
             lamport_version: self.lamport_timestamp,
             binary_config: self.protocol_config.binary_config(None),
+            accumulator_running_max_withdraws: BTreeMap::new(),
         }
     }
 


### PR DESCRIPTION
## Description 

When we check whether object funds withdraw can be satisfied in an effects, it is important that we use the total withdraw amount instead of the merged results. For instance, if in the same transaction, we withdraw X from an object account and then deposit Y into it. We must ensure that there are X amount prior to this transaction, instead of just X - Y. This is important so that it cannot be exploited and do flash loans.

## Test plan 

Added unit tests.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
