### PR TITLE
[move-ide] Temporary module extension crash remedy

### DIFF
--- a/external-crates/move/crates/move-analyzer/editors/code/package-lock.json
+++ b/external-crates/move/crates/move-analyzer/editors/code/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "move",
-  "version": "1.0.35",
+  "version": "1.0.37",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "move",
-      "version": "1.0.35",
+      "version": "1.0.37",
       "license": "Apache-2.0",
       "dependencies": {
         "command-exists": "^1.2.9",

--- a/external-crates/move/crates/move-analyzer/editors/code/package.json
+++ b/external-crates/move/crates/move-analyzer/editors/code/package.json
@@ -5,7 +5,7 @@
   "publisher": "mysten",
   "icon": "images/move.png",
   "license": "Apache-2.0",
-  "version": "1.0.36",
+  "version": "1.0.37",
   "preview": true,
   "repository": {
     "url": "https://github.com/MystenLabs/sui.git",

--- a/external-crates/move/crates/move-analyzer/src/analysis/parsing_analysis.rs
+++ b/external-crates/move/crates/move-analyzer/src/analysis/parsing_analysis.rs
@@ -32,10 +32,10 @@ pub struct ParsingAnalysisContext<'a> {
     pub mod_outer_defs: &'a mut BTreeMap<String, ModuleDefs>,
     /// Mapped file information for translating locations into positions
     pub files: &'a MappedFiles,
+    /// Additional information about definitions
+    pub def_info: &'a DefMap,
     /// Associates uses for a given definition to allow displaying all references
     pub references: &'a mut References,
-    /// Additional information about definitions
-    pub def_info: &'a mut DefMap,
     /// A UseDefMap for a given file
     pub use_defs: &'a mut BTreeMap<FileHash, UseDefMap>,
     /// Current module identifier string (needs to be appropriately set before the module


### PR DESCRIPTION
## Description 

We need a proper fix for this but as it is, if someone tries module extensions in their code base, `move-analyzer` will crash. With this temp fix, symbols defined in module extensions will not work but at least we will not crash

## Test plan 

Tested on a reported error to check that the crash is prevented
