### PR TITLE
[decompiler] Fix FixedBitSet panic on trivial functions with empty CFG

### DIFF
--- a/external-crates/move/crates/move-decompiler/src/structuring/mod.rs
+++ b/external-crates/move/crates/move-decompiler/src/structuring/mod.rs
@@ -28,6 +28,11 @@ pub(crate) fn structure(
     mut input: BTreeMap<D::Label, D::Input>,
     entry_node: D::Label,
 ) -> D::Structured {
+    // Native functions have empty basic blocks - return early to avoid panicking in Graph::new
+    if input.is_empty() {
+        return D::Structured::Seq(vec![]);
+    }
+
     let mut graph = Graph::new(config, &input, entry_node);
 
     let mut structured_blocks: BTreeMap<D::Label, D::Structured> = BTreeMap::new();


### PR DESCRIPTION
Framework packages contain many `native` functions with no basic blocks, resulting in empty input maps. Previously, `Graph::new` would create a 0-node CFG, causing petgraph's dominator algorithm to panic with "put at index 0 exceeds fixedbitset size 0".

Fixes:
1. Ensure start_node exists in CFG even when input is empty
2. Handle missing nodes in structure_acyclic by creating empty sequences

Example package to repro this: 0x0000000000000000000000000000000000000000000000000000000000000001

## Description 

Describe the changes or additions included in this PR.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
