### PR TITLE
[move-stackless-bytecode-2] Fix VecPack type inference bug causing Vector<T> vs T m…

### DIFF
--- a/external-crates/move/crates/move-stackless-bytecode-2/src/translate.rs
+++ b/external-crates/move/crates/move-stackless-bytecode-2/src/translate.rs
@@ -586,8 +586,9 @@ pub(crate) fn bytecode<K: SourceKind>(
 
         IB::VecPack(bx) => {
             let args = pop_n!(bx.1);
+            let vec_type = Type::Vector(Box::new(bx.0.as_ref().clone()));
             assign_reg!(
-                [push!(bx.0.clone())] = RValue::Data {
+                [push!(vec_type.into())] = RValue::Data {
                     op: DataOp::VecPack(bx.0.clone()),
                     args,
                 }

--- a/external-crates/move/crates/move-stackless-bytecode-2/tests/move/vector/vec_tests@no_opt.sbir.snap
+++ b/external-crates/move/crates/move-stackless-bytecode-2/tests/move/vector/vec_tests@no_opt.sbir.snap
@@ -6,8 +6,8 @@ source: crates/move-stackless-bytecode-2/tests/from_source.rs
       Label LBL_0:
         reg_0 : u8 = Move(lcl_0)
         reg_1 : u8 = Move(lcl_1)
-        reg_2 : u8 = VecPack<u8>(reg_0 : u8, reg_1 : u8)
-        Return(reg_2 : u8)
+        reg_2 : vector<u8> = VecPack<u8>(reg_0 : u8, reg_1 : u8)
+        Return(reg_2 : vector<u8>)
 
 
     Function: create_empty (entry: LBL_0)

--- a/external-crates/move/crates/move-stackless-bytecode-2/tests/move/vector/vec_tests@opt.sbir.snap
+++ b/external-crates/move/crates/move-stackless-bytecode-2/tests/move/vector/vec_tests@opt.sbir.snap
@@ -6,8 +6,8 @@ source: crates/move-stackless-bytecode-2/tests/from_source.rs
       Label LBL_0:
         reg_0 : u8 = Move(lcl_0)
         reg_1 : u8 = Move(lcl_1)
-        reg_2 : u8 = VecPack<u8>(reg_0 : u8, reg_1 : u8)
-        Return(reg_2 : u8)
+        reg_2 : vector<u8> = VecPack<u8>(reg_0 : u8, reg_1 : u8)
+        Return(reg_2 : vector<u8>)
 
 
     Function: create_empty (entry: LBL_0)


### PR DESCRIPTION
…ismatches

Fix bug in stackless bytecode translation where VecPack was pushing the element type instead of the vector type onto the stack, causing widespread type mismatch errors

In the bytecode translation layer (`move-stackless-bytecode-2`), the VecPack instruction was incorrectly pushing the element type `T` instead of `Vector<T>`:

```rust
// BEFORE (WRONG):
IB::VecPack(bx) => {
    let args = pop_n!(bx.1);
    assign_reg!(
        [push!(bx.0.clone())] = RValue::Data {  // Pushes T instead of Vector<T>
            op: DataOp::VecPack(bx.0.clone()),
            args,
        }
    )
}
```

Where `bx.0` is the element type `T`, not the vector type.

This caused cascading type errors. For example:

```move
// Bytecode sequence:
PC=8:  VecPack<ID>(0)          // Creates empty vector<ID>
PC=9:  CopyLoc(registry)        // Copies registry reference
PC=10: MutBorrowField("burned_tool_ids")  // Borrows &mut vector<ID> field
PC=11: WriteRef                 // Writes the vector to the field
```

The translator would:
1. **VecPack** pushes type `ID` (WRONG - should push `Vector<ID>`)
2. **CopyLoc** pushes `&mut QuestSystem`
3. **MutBorrowField** pops registry, pushes `&mut Vector<ID>` ✓
4. **WriteRef** pops value (expected `Vector<ID>`, got `ID`) TYPE MISMATCH

This triggered the assertion:
```
Type mismatch: Vector<ID> vs ID
```

Correctly wrap the element type in a Vector type constructor:

```rust
// AFTER (CORRECT):
IB::VecPack(bx) => {
    let args = pop_n!(bx.1);
    let vec_type = Type::Vector(Box::new(bx.0.as_ref().clone()));
    assign_reg!(
        [push!(vec_type.into())] = RValue::Data {  // ✓ Pushes Vector<T>
            op: DataOp::VecPack(bx.0.clone()),
            args,
        }
    )
}
```

Now VecPack correctly pushes `Vector<T>` type, matching the actual runtime value.

- Fixes 4.3% of decompilation failures (~48 packages) in mainnet_most_used
- Eliminates all "Type mismatch: Vector(T) vs T" errors

The VecPack bytecode instruction creates a vector from N stack values. The instruction parameter is `(element_type, count)`. The stack effect is:
- Pop: N values of type `element_type`
- Push: 1 value of type `Vector<element_type>`

The bug was treating the push type as `element_type` instead of `Vector<element_type>`.

Example package to repro this: 0x0000000000000000000000000000000000000000000000000000000000000001

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
