### PR TITLE
[decompiler] Fix VecPopBack pretty printing index out of bounds error

### DIFF
--- a/external-crates/move/crates/move-decompiler/src/pretty_printer.rs
+++ b/external-crates/move/crates/move-decompiler/src/pretty_printer.rs
@@ -429,10 +429,7 @@ fn data_op_doc(context: &Context, op: &DataOp, args: &[Exp]) -> Doc {
             .concat(exp(context, &args[1]))
             .concat(D::text(")")),
 
-        DataOp::VecPopBack(_) => maybe_parens(context, &args[0])
-            .concat(D::text(".pop_back("))
-            .concat(exp(context, &args[1]))
-            .concat(D::text(")")),
+        DataOp::VecPopBack(_) => maybe_parens(context, &args[0]).concat(D::text(".pop_back()")),
 
         DataOp::VecSwap(_) => maybe_parens(context, &args[0])
             .concat(D::text(".swap("))


### PR DESCRIPTION
Fix bug where VecPopBack operation tried to access non-existent second argument, causing "index out of bounds: the len is 1 but the index is 1" errors during pretty printing

The pretty printer incorrectly assumed VecPopBack takes two arguments (vector and value), when in fact it only takes one argument (the vector).

In `pretty_printer.rs:452-455`, the code was:

```rust
DataOp::VecPopBack(_) => maybe_parens(context, &args[0])
    .concat(D::text(".pop_back("))
    .concat(exp(context, &args[1]))  // args[1] doesn't exist!
    .concat(D::text(")")),
```

Changed to:

```rust
DataOp::VecPopBack(_) => maybe_parens(context, &args[0])
    .concat(D::text(".pop_back()")),
```

Now correctly generates: `vec.pop_back()` instead of crashing.

- Fixes 5.7% of decompilation failures on mainnet_most_used (64 packages)
- Example packages that failed 0x031d94b39cf6cd78c2d12edcc6684d0c27330dc0871a2536fe8ba913e586a5a6

All tests pass with no regressions.

## Description 

Describe the changes or additions included in this PR.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
