### PR TITLE
[decompiler] Add unstructured control flow fallback with goto statements

### DIFF
--- a/external-crates/move/crates/move-decompiler/src/refinement/mod.rs
+++ b/external-crates/move/crates/move-decompiler/src/refinement/mod.rs
@@ -87,6 +87,19 @@ trait Refine {
             E::VecUnpack(_, e) => self.refine(e),
             E::Unpack(_, _, e) => self.refine(e),
             E::UnpackVariant(_, _, _, e) => self.refine(e),
+            E::Unstructured(nodes) => {
+                use crate::ast::UnstructuredNode;
+                let mut changed = false;
+                for node in nodes.iter_mut() {
+                    match node {
+                        UnstructuredNode::Labeled(_, body) | UnstructuredNode::Statement(body) => {
+                            changed |= self.refine(body);
+                        }
+                        UnstructuredNode::Goto(_) => {}
+                    }
+                }
+                changed
+            }
         }
     }
 

--- a/external-crates/move/crates/move-decompiler/src/structuring/mod.rs
+++ b/external-crates/move/crates/move-decompiler/src/structuring/mod.rs
@@ -132,12 +132,11 @@ fn structure_loop(
             .all_children()
             .any(|child| child == succ_node)
     {
-        result = D::Structured::Seq(vec![
-            result,
-            structured_blocks.remove(&succ_node).unwrap_or_else(|| {
-                panic!("Expected successor node {succ_node:?} to be structured")
-            }),
-        ]);
+        if let Some(succ_structured) = structured_blocks.remove(&succ_node) {
+            result = D::Structured::Seq(vec![result, succ_structured]);
+        } else if config.debug_print.structuring {
+            println!("  failed to find successor node {succ_node:?} in structured blocks");
+        }
     }
     structured_blocks.insert(loop_head, result);
 }

--- a/external-crates/move/crates/move-decompiler/src/translate.rs
+++ b/external-crates/move/crates/move-decompiler/src/translate.rs
@@ -270,8 +270,30 @@ fn generate_output(mut terms: BTreeMap<D::Label, Out::Exp>, structured: D::Struc
             exps.push(Out::Exp::Switch(Box::new(cond), enum_, cases));
             Out::Exp::Seq(exps)
         }
-        D::Structured::Jump(_) | D::Structured::JumpIf { .. } => {
-            unreachable!("Jump nodes should not be present in the final output")
+        D::Structured::Jump(target) => {
+            let label = target.index() as u64;
+            Out::Exp::Unstructured(vec![Out::UnstructuredNode::Goto(label)])
+        }
+        D::Structured::JumpIf(code, then_target, else_target) => {
+            let term = terms.remove(&(code as u32).into()).unwrap();
+            let Exp::Seq(mut seq) = term else {
+                panic!("Expected Seq for JumpIf condition")
+            };
+            let cond = seq.pop().unwrap();
+
+            let then_label = then_target.index() as u64;
+            let else_label = else_target.index() as u64;
+
+            seq.push(Out::Exp::IfElse(
+                Box::new(cond),
+                Box::new(Out::Exp::Unstructured(vec![Out::UnstructuredNode::Goto(
+                    then_label,
+                )])),
+                Box::new(Some(Out::Exp::Unstructured(vec![
+                    Out::UnstructuredNode::Goto(else_label),
+                ]))),
+            ));
+            Out::Exp::Seq(seq)
         }
     }
 }


### PR DESCRIPTION
Add graceful fallback for control flow we cannot decompule yet introducing an Unstructured AST node that supports goto-based representation. This fixes the #1 failure mode (73.4% of all decompilation failures on mainnet_most_used) where the structuring algorithm panicked on Jump/JumpIf nodes that couldn't be eliminated. This is not ideal (obviously we'd prefer to decompile everything), but is a pragmatic compromise to continue decompiling without failures. This won't produce code that will compile, but it can (e.g.) be passed to a LLM which will probably do fine with the gotos.

The implementation adds a hybrid AST design where structured control flow is preferred, but unstructured (goto-based) control flow is used as a fallback when the structuring algorithm cannot eliminate all Jump nodes.

Key design principles:
- Goto/labeled blocks exist ONLY inside Unstructured containers
- Bidirectional nesting: structured nodes can appear inside unstructured regions and vice versa
- Single-node fallback strategy: each Jump converts to standalone Goto
- Move-like label syntax: 'label_N: for labels, goto 'label_N; for gotos

- Added Exp::Unstructured(Vec<UnstructuredNode>) variant
- Defined Label = u64 type for direct mapping from NodeIndex
- Created UnstructuredNode enum with three variants:
  - Labeled(Label, Box<Exp>) for labeled blocks
  - Statement(Box<Exp>) for unlabeled statements
  - Goto(Label) for goto statements
- Updated contains_break() and contains_continue() to recursively handle unstructured nodes
- Added Display implementation for debugging output

- Replaced panic at line 274 with graceful fallback logic
- Jump(target) → Unstructured([Goto(target.index())])
- JumpIf(code, t, e) → IfElse(cond, Unstructured([Goto(t)]), Unstructured([Goto(e)]))
- No longer panics on "Jump nodes should not be present"

- Extended Refine trait to recursively process Unstructured nodes
- Ensures all refinement passes (flatten_seq, introduce_while, loop_to_seq, remove_trailing_continue) work with unstructured regions
- Labeled and Statement nodes get refined, Goto nodes pass through

- Fixed panic when loop successor nodes aren't structured yet
- Changed from unwrap_or_else(|| panic!(...)) to if let Some(...)
- Allows structuring to complete even when successor nodes are unreachable due to irreducible control flow

Verified on mainnet_most_used corpus--no remaining failures from the original panic.

Example packages that failed: 0x00000000000000000000000000000000000000000000000000000000000001 or 0xc2f85e07181b90c140b15c5ce27d863f93c4d9159d2a4e7bdaeb40e286d6f5