### PR TITLE
[decompiler] Fix infinite loop in find_loop_nodes causing package 0x7…

### DIFF
--- a/external-crates/move/crates/move-decompiler/src/structuring/graph.rs
+++ b/external-crates/move/crates/move-decompiler/src/structuring/graph.rs
@@ -118,6 +118,22 @@ impl Graph {
             .map(|(node_id, _)| *node_id);
 
         for latch_node in latch_nodes {
+            // Handle true self-loops: when there's an actual edge from node_start to itself
+            // in the CFG, all_simple_paths would hang indefinitely. We detect this by checking
+            // if latch_node == node_start AND there's an actual edge in the CFG.
+            if latch_node == node_start {
+                let has_self_loop_edge = self
+                    .cfg
+                    .neighbors_directed(node_start, petgraph::Direction::Outgoing)
+                    .any(|n| n == node_start);
+                if has_self_loop_edge {
+                    // True self-loop: skip all_simple_paths which would hang, but still
+                    // add the head node to loop_nodes so the loop body isn't empty
+                    loop_nodes.insert(node_start);
+                    continue;
+                }
+                // Fake self-loop from latch updates: let all_simple_paths run normally
+            }
             let paths = petgraph::algo::all_simple_paths::<Vec<_>, _, RandomState>(
                 &self.cfg, node_start, latch_node, 0, None,
             )
@@ -154,6 +170,7 @@ impl Graph {
             .get(loop_header)
             .all_children()
             .collect::<HashSet<_>>();
+
         while succ_nodes.len() > 1 && !new_nodes.is_empty() {
             new_nodes.clear();
             for node in succ_nodes.clone() {
@@ -170,8 +187,8 @@ impl Graph {
                         .filter(|node| !loop_nodes.contains(node) && dom_nodes.contains(node));
                     new_nodes.extend(nodes);
                 }
-                succ_nodes.extend(new_nodes.iter().cloned());
             }
+            succ_nodes.extend(new_nodes.iter().cloned());
         }
         (loop_nodes, succ_nodes)
     }

--- a/external-crates/move/crates/move-decompiler/tests/structuring/self_loop.snap
+++ b/external-crates/move/crates/move-decompiler/tests/structuring/self_loop.snap
@@ -1,0 +1,11 @@
+---
+source: crates/move-decompiler/tests/tests.rs
+---
+loop {
+    if (0) {
+        continue;
+    } else {
+        break;
+    }
+}
+{ 1 }

--- a/external-crates/move/crates/move-decompiler/tests/structuring/self_loop.stt
+++ b/external-crates/move/crates/move-decompiler/tests/structuring/self_loop.stt
@@ -1,0 +1,11 @@
+// Self-loop test: a node that loops back to itself
+// This tests the fix for infinite hang in all_simple_paths when called with start == end
+//
+//     ->0
+//    |  |\
+//    ----1
+//
+// Node 0 conditionally loops to itself (true branch) or exits to node 1 (false branch)
+
+cond,0,0,1
+code,1


### PR DESCRIPTION
…03835ce7a4e30225831d328affecc83b026d9fc4e3dd4b755e2b6e9ce5fe353 to timeout

Fixed critical bug where all_simple_paths was called with the same node as both start and end (self-loop case), causing it to hang indefinitely.

When a loop has a self-edge (back-edge from a node to itself), the algorithm tried to find all simple paths from node N to node N, which causes petgraph::algo::all_simple_paths to hang. The fix detects self-loops (latch_node == node_start) and handles them by adding the node to loop_nodes without calling all_simple_paths.

Package 0x70/3835ce7a4e30225831d328affecc83b026d9fc4e3dd4b755e2b6e9ce5fe353 now decompiles successfully
