### PR TITLE
perf: avoid cloning type_params in upgrade compatibility formatting

### DIFF
--- a/crates/sui/src/upgrade_compatibility/formatting.rs
+++ b/crates/sui/src/upgrade_compatibility/formatting.rs
@@ -20,14 +20,14 @@ impl<S: fmt::Display> fmt::Display for FormattedType<'_, S> {
             write!(
                 f,
                 "{}",
-                format_param(self.type_, self.type_params.to_vec(), &mut Vec::new())
+                format_param(self.type_, self.type_params, &mut Vec::new())
                     .map_err(|_| fmt::Error)?,
             )
         } else {
             write!(
                 f,
                 "'{}'",
-                format_param(self.type_, self.type_params.to_vec(), &mut Vec::new())
+                format_param(self.type_, self.type_params, &mut Vec::new())
                     .map_err(|_| fmt::Error)?,
             )
         }
@@ -84,7 +84,7 @@ impl<S: fmt::Display> fmt::Display for FormattedField<'_, S> {
 /// Returns a string representation of a parameter and updates its secondary label to include its location.
 pub(super) fn format_param<S: fmt::Display>(
     param: &Type<S>,
-    type_params: Vec<SourceName>,
+    type_params: &[SourceName],
     secondary: &mut Vec<(Loc, String)>,
 ) -> Result<String, Error> {
     Ok(match param {
@@ -116,7 +116,7 @@ pub(super) fn format_param<S: fmt::Display>(
                 dt.name,
                 dt.type_arguments
                     .iter()
-                    .map(|t| format_param(t, type_params.clone(), secondary))
+                    .map(|t| format_param(t, type_params, secondary))
                     .collect::<Result<Vec<_>, _>>()?
                     .join(", ")
             )


### PR DESCRIPTION
Reason for the changes:
The upgrade compatibility diagnostics were allocating and cloning Vec<SourceName> repeatedly when formatting types and fields, especially for generic datatypes. This added unnecessary work and allocations without any semantic benefit, since the type parameter metadata is only read and never stored or mutated.
Summary of changes:
Switched format_param and field_mismatch_message to take &[SourceName] instead of Vec<SourceName>, updated FormattedType::fmt and all call sites in the upgrade compatibility module to pass slices rather than cloned vectors, and removed redundant Vec constructions where type parameter context is not needed.