### PR TITLE
Fix `build_custom_clients` to accept genesis committee directly

### DIFF
--- a/crates/simulacrum/src/store/mod.rs
+++ b/crates/simulacrum/src/store/mod.rs
@@ -34,7 +34,7 @@ pub trait SimulatorStore:
     fn init_with_genesis(&mut self, genesis: &genesis::Genesis) {
         self.insert_checkpoint(genesis.checkpoint());
         self.insert_checkpoint_contents(genesis.checkpoint_contents().clone());
-        self.insert_committee(genesis.committee().unwrap());
+        self.insert_committee(genesis.committee().clone());
         self.insert_transaction(VerifiedTransaction::new_unchecked(
             genesis.transaction().clone(),
         ));

--- a/crates/sui-benchmark/src/lib.rs
+++ b/crates/sui-benchmark/src/lib.rs
@@ -346,7 +346,7 @@ impl LocalValidatorAggregatorProxy {
         let (aggregator, clients) = AuthorityAggregatorBuilder::from_genesis(genesis)
             .with_registry(registry)
             .build_network_clients();
-        let committee = genesis.committee().unwrap();
+        let committee = genesis.committee();
         let chain_identifier = ChainIdentifier::from(*genesis.checkpoint().digest());
         Self::new_impl(
             aggregator,

--- a/crates/sui-config/src/genesis.rs
+++ b/crates/sui-config/src/genesis.rs
@@ -26,7 +26,6 @@ use sui_types::transaction::Transaction;
 use sui_types::{SUI_BRIDGE_OBJECT_ID, SUI_RANDOMNESS_STATE_OBJECT_ID};
 use sui_types::{
     committee::{Committee, EpochId, ProtocolVersion},
-    error::SuiResult,
     object::Object,
 };
 use tracing::trace;
@@ -113,7 +112,7 @@ impl Genesis {
     pub fn checkpoint(&self) -> VerifiedCheckpoint {
         self.checkpoint
             .clone()
-            .try_into_verified(&self.committee().unwrap())
+            .try_into_verified(&self.committee())
             .unwrap()
     }
 
@@ -140,9 +139,8 @@ impl Genesis {
         self.sui_system_object().reference_gas_price()
     }
 
-    // TODO: No need to return SuiResult. Also consider return &.
-    pub fn committee(&self) -> SuiResult<Committee> {
-        Ok(self.committee_with_network().committee().clone())
+    pub fn committee(&self) -> Committee {
+        self.committee_with_network().committee().clone()
     }
 
     pub fn sui_system_wrapper_object(&self) -> SuiSystemStateWrapper {

--- a/crates/sui-core/src/authority/test_authority_builder.rs
+++ b/crates/sui-core/src/authority/test_authority_builder.rs
@@ -198,7 +198,7 @@ impl<'a> TestAuthorityBuilder<'a> {
         }
         let local_network_config = local_network_config_builder.build();
         let genesis = &self.genesis.unwrap_or(&local_network_config.genesis);
-        let genesis_committee = genesis.committee().unwrap();
+        let genesis_committee = genesis.committee();
         let path = self.store_base_path.unwrap_or_else(|| {
             let dir = std::env::temp_dir();
             let store_base_path =

--- a/crates/sui-core/src/transaction_driver/unit_tests/effects_certifier_tests.rs
+++ b/crates/sui-core/src/transaction_driver/unit_tests/effects_certifier_tests.rs
@@ -174,7 +174,8 @@ fn create_test_authority_aggregator() -> AuthorityAggregator<MockAuthority> {
         authority_clients.insert(*name, mock_authority);
     }
 
-    AuthorityAggregatorBuilder::from_committee(committee).build_custom_clients(authority_clients)
+    AuthorityAggregatorBuilder::from_committee(committee.clone())
+        .build_custom_clients(&committee, authority_clients)
 }
 
 fn create_test_effects_digest(value: u8) -> TransactionEffectsDigest {

--- a/crates/sui-core/src/transaction_driver/unit_tests/transaction_submitter_tests.rs
+++ b/crates/sui-core/src/transaction_driver/unit_tests/transaction_submitter_tests.rs
@@ -194,8 +194,8 @@ fn create_test_authority_aggregator_with_rgp(
         mock_authorities.push(mock_authority);
     }
 
-    let mut aggregator = AuthorityAggregatorBuilder::from_committee(committee)
-        .build_custom_clients(authority_clients);
+    let mut aggregator = AuthorityAggregatorBuilder::from_committee(committee.clone())
+        .build_custom_clients(&committee, authority_clients);
     aggregator.reference_gas_price = reference_gas_price;
     (aggregator, mock_authorities)
 }

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -2850,7 +2850,7 @@ async fn test_authority_persist() {
 
     let seed = [1u8; 32];
     let (genesis, authority_key) = init_state_parameters_from_rng(&mut StdRng::from_seed(seed));
-    let committee = genesis.committee().unwrap();
+    let committee = genesis.committee();
 
     // Create a random directory to store the DB
     let dir = env::temp_dir();
@@ -2883,7 +2883,7 @@ async fn test_authority_persist() {
     // Reopen the same authority with the same path
     let seed = [1u8; 32];
     let (genesis, authority_key) = init_state_parameters_from_rng(&mut StdRng::from_seed(seed));
-    let committee = genesis.committee().unwrap();
+    let committee = genesis.committee();
     let perpetual_tables = Arc::new(AuthorityPerpetualTables::open(&path, None, None));
     let store =
         AuthorityStore::open_with_committee_for_testing(perpetual_tables, &committee, &genesis)

--- a/crates/sui-core/src/unit_tests/unit_test_utils.rs
+++ b/crates/sui-core/src/unit_tests/unit_test_utils.rs
@@ -137,6 +137,7 @@ pub async fn init_local_authorities_with_genesis(
 ) -> AuthorityAggregator<LocalAuthorityClient> {
     telemetry_subscribers::init_for_testing();
     let mut clients = BTreeMap::new();
+    let genesis_committee = genesis.committee();
     for state in authorities {
         let name = state.name;
         let client = LocalAuthorityClient::new_from_authority(state);
@@ -148,5 +149,5 @@ pub async fn init_local_authorities_with_genesis(
     };
     AuthorityAggregatorBuilder::from_genesis(genesis)
         .with_timeouts_config(timeouts)
-        .build_custom_clients(clients)
+        .build_custom_clients(&genesis_committee, clients)
 }

--- a/crates/sui-light-client/src/checkpoint.rs
+++ b/crates/sui-light-client/src/checkpoint.rs
@@ -238,9 +238,7 @@ pub async fn check_and_sync_checkpoints(config: &Config) -> anyhow::Result<()> {
     // Load the genesis committee
     let mut genesis_path = config.checkpoint_summary_dir.clone();
     genesis_path.push(&config.genesis_filename);
-    let genesis_committee = Genesis::load(&genesis_path)?
-        .committee()
-        .map_err(|e| anyhow!(format!("Cannot load Genesis: {e}")))?;
+    let genesis_committee = Genesis::load(&genesis_path)?.committee();
 
     // Check the signatures of all checkpoints
     // And download any missing ones

--- a/crates/sui-light-client/src/verifier.rs
+++ b/crates/sui-light-client/src/verifier.rs
@@ -144,9 +144,7 @@ pub async fn get_verified_effects_and_events(
         // Since we did not find a small committee checkpoint we use the genesis
         let mut genesis_path = config.checkpoint_summary_dir.clone();
         genesis_path.push(&config.genesis_filename);
-        Genesis::load(&genesis_path)?
-            .committee()
-            .map_err(|e| anyhow!(format!("Cannot load Genesis: {e}")))?
+        Genesis::load(&genesis_path)?.committee()
     };
 
     info!("Extracting effects and events for TID: {}", tid);
@@ -234,9 +232,7 @@ pub async fn get_verified_checkpoint(
         // Since we did not find a small committee checkpoint we use the genesis
         let mut genesis_path = config.checkpoint_summary_dir.clone();
         genesis_path.push(&config.genesis_filename);
-        Genesis::load(&genesis_path)?
-            .committee()
-            .map_err(|e| anyhow!(format!("Cannot load Genesis: {e}")))?
+        Genesis::load(&genesis_path)?.committee()
     };
 
     // Verify that committee signed this checkpoint and checkpoint contents with digest

--- a/crates/sui-light-client/tests/ocs_proof.rs
+++ b/crates/sui-light-client/tests/ocs_proof.rs
@@ -40,8 +40,7 @@ fn load_test_data() -> Result<(CheckpointData, Committee), anyhow::Error> {
     d.push(GENESIS_FILE);
     let genesis_committee = Genesis::load(&d)
         .map_err(|e| anyhow!(format!("Cannot load Genesis: {e}")))?
-        .committee()
-        .map_err(|e| anyhow!(format!("Cannot load Genesis: {e}")))?;
+        .committee();
 
     // Sanity check
     checkpoint

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -482,7 +482,7 @@ impl SuiNode {
         let genesis = config.genesis()?.clone();
 
         let secret = Arc::pin(config.protocol_key_pair().copy());
-        let genesis_committee = genesis.committee()?;
+        let genesis_committee = genesis.committee();
         let committee_store = Arc::new(CommitteeStore::new(
             config.db_path().join("epochs"),
             &genesis_committee,

--- a/crates/sui-swarm-config/src/test_utils.rs
+++ b/crates/sui-swarm-config/src/test_utils.rs
@@ -58,7 +58,7 @@ impl CommitteeFixture {
     }
 
     pub fn from_network_config(network_config: &NetworkConfig) -> Self {
-        let committee = network_config.genesis.committee().unwrap();
+        let committee = network_config.genesis.committee();
         Self {
             epoch: committee.epoch,
             validators: committee

--- a/crates/sui-tool/src/lib.rs
+++ b/crates/sui-tool/src/lib.rs
@@ -847,7 +847,7 @@ pub async fn download_formal_snapshot(
         None,
     ));
     let genesis = Genesis::load(genesis).unwrap();
-    let genesis_committee = genesis.committee()?;
+    let genesis_committee = genesis.committee();
     let committee_store = Arc::new(CommitteeStore::new(
         path.join("epochs"),
         &genesis_committee,


### PR DESCRIPTION
Should fix crash during stress binary startup
