### PR TITLE
fix(sui-http): use explicit rustls::CryptoProvider

### DIFF
--- a/crates/sui-http/src/lib.rs
+++ b/crates/sui-http/src/lib.rs
@@ -72,9 +72,12 @@ impl Builder {
 
         let certs = CertificateDer::pem_file_iter(cert_file)?.collect::<Result<_, _>>()?;
         let private_key = PrivateKeyDer::from_pem_file(private_key_file)?;
-        let tls_config = rustls::ServerConfig::builder()
-            .with_no_client_auth()
-            .with_single_cert(certs, private_key)?;
+        let tls_config = rustls::ServerConfig::builder_with_provider(Arc::new(
+            rustls::crypto::ring::default_provider(),
+        ))
+        .with_protocol_versions(rustls::DEFAULT_VERSIONS)?
+        .with_no_client_auth()
+        .with_single_cert(certs, private_key)?;
 
         Ok(self.tls_config(tls_config))
     }


### PR DESCRIPTION
## Description

If multiple crypto-provider related features are enabled on `rustls`, it will panic because it doesn't know how to pick a default one. We should not rely on the default, choosing instead fo pick an explicit provider.

## Test plan

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
