### PR TITLE
[graphql-alt] Update Query return types for partial error support [8/n]

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/checkpoints/query.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/checkpoints/query.snap
@@ -112,7 +112,9 @@ task 9, lines 64-74:
 Response: {
   "data": {
     "checkpoint": {
-      "query": null
+      "query": {
+        "atCheckpoint": null
+      }
     }
   },
   "errors": [

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/events/filter/module.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/events/filter/module.snap
@@ -625,7 +625,9 @@ Response: {
 task 9, lines 141-148:
 //# run-graphql
 Response: {
-  "data": null,
+  "data": {
+    "eventsByModuleAndTypeIsUnavailable": null
+  },
   "errors": [
     {
       "message": "Filtering by both emitting module and event type is not supported not available",

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/objects/at_checkpoint.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/objects/at_checkpoint.snap
@@ -192,7 +192,9 @@ Response: {
 task 25, lines 135-138:
 //# run-graphql
 Response: {
-  "data": null,
+  "data": {
+    "object": null
+  },
   "errors": [
     {
       "message": "Checkpoint 9 in the future",

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/objects/root_version.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/objects/root_version.snap
@@ -217,7 +217,9 @@ Response: {
 task 22, lines 186-189:
 //# run-graphql
 Response: {
-  "data": null,
+  "data": {
+    "object": null
+  },
   "errors": [
     {
       "message": "At most one of a version, a root version, or a checkpoint bound can be specified when fetching an object",

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/packages/at_checkpoint.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/packages/at_checkpoint.snap
@@ -125,7 +125,9 @@ Response: {
 task 11, lines 123-126:
 //# run-graphql
 Response: {
-  "data": null,
+  "data": {
+    "future": null
+  },
   "errors": [
     {
       "message": "Checkpoint 3 in the future",

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/type.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/type.snap
@@ -453,7 +453,9 @@ Response: {
 task 6, lines 61-76:
 //# run-graphql
 Response: {
-  "data": null,
+  "data": {
+    "type": null
+  },
   "errors": [
     {
       "message": "Type parameter nesting exceeded limit of 16",
@@ -476,7 +478,9 @@ Response: {
 task 7, lines 78-83:
 //# run-graphql
 Response: {
-  "data": null,
+  "data": {
+    "type": null
+  },
   "errors": [
     {
       "message": "Error resolving type: Expected 1 type parameters, but got 2",

--- a/crates/sui-indexer-alt-graphql/src/api/query.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/query.rs
@@ -78,63 +78,69 @@ pub struct Query {
 #[Object]
 impl Query {
     /// Fetch a `Node` by its globally unique `ID`. Returns `null` if the node cannot be found (e.g., the underlying data was pruned or never existed).
-    async fn node(&self, ctx: &Context<'_>, id: Id) -> Result<Option<Node>, RpcError> {
-        let scope = self.scope(ctx)?;
-        Ok(match id {
-            Id::Address(a) => Some(Node::Address(Box::new(Address::with_address(scope, a)))),
+    async fn node(&self, ctx: &Context<'_>, id: Id) -> Option<Result<Node, RpcError>> {
+        async {
+            let scope = self.scope(ctx)?;
+            Ok(match id {
+                Id::Address(a) => Some(Node::Address(Box::new(Address::with_address(scope, a)))),
 
-            Id::Checkpoint(s) => Checkpoint::with_sequence_number(scope, Some(s))
-                .map(Box::new)
-                .map(Node::Checkpoint),
-
-            Id::DynamicFieldByAddress(a) => {
-                let object = Object::with_address(scope, a);
-                DynamicField::from_object(&object, ctx)
-                    .await?
+                Id::Checkpoint(s) => Checkpoint::with_sequence_number(scope, Some(s))
                     .map(Box::new)
-                    .map(Node::DynamicField)
-            }
+                    .map(Node::Checkpoint),
 
-            Id::DynamicFieldByRef(a, v, d) => {
-                let object = Object::with_ref(&scope, a, v, d);
-                DynamicField::from_object(&object, ctx)
-                    .await?
-                    .map(Box::new)
-                    .map(Node::DynamicField)
-            }
+                Id::DynamicFieldByAddress(a) => {
+                    let object = Object::with_address(scope, a);
+                    DynamicField::from_object(&object, ctx)
+                        .await?
+                        .map(Box::new)
+                        .map(Node::DynamicField)
+                }
 
-            Id::Epoch(e) => Some(Node::Epoch(Box::new(Epoch::with_id(scope, e)))),
+                Id::DynamicFieldByRef(a, v, d) => {
+                    let object = Object::with_ref(&scope, a, v, d);
+                    DynamicField::from_object(&object, ctx)
+                        .await?
+                        .map(Box::new)
+                        .map(Node::DynamicField)
+                }
 
-            Id::MoveObjectByAddress(a) => {
-                let object = Object::with_address(scope, a);
-                MoveObject::from_object(&object, ctx)
-                    .await?
-                    .map(Box::new)
-                    .map(Node::MoveObject)
-            }
+                Id::Epoch(e) => Some(Node::Epoch(Box::new(Epoch::with_id(scope, e)))),
 
-            Id::MoveObjectByRef(a, v, d) => {
-                let object = Object::with_ref(&scope, a, v, d);
-                MoveObject::from_object(&object, ctx)
-                    .await?
-                    .map(Box::new)
-                    .map(Node::MoveObject)
-            }
+                Id::MoveObjectByAddress(a) => {
+                    let object = Object::with_address(scope, a);
+                    MoveObject::from_object(&object, ctx)
+                        .await?
+                        .map(Box::new)
+                        .map(Node::MoveObject)
+                }
 
-            Id::MovePackage(a) => Some(Node::MovePackage(Box::new(MovePackage::with_address(
-                scope, a,
-            )))),
+                Id::MoveObjectByRef(a, v, d) => {
+                    let object = Object::with_ref(&scope, a, v, d);
+                    MoveObject::from_object(&object, ctx)
+                        .await?
+                        .map(Box::new)
+                        .map(Node::MoveObject)
+                }
 
-            Id::ObjectByAddress(a) => Some(Node::Object(Box::new(Object::with_address(scope, a)))),
+                Id::MovePackage(a) => Some(Node::MovePackage(Box::new(MovePackage::with_address(
+                    scope, a,
+                )))),
 
-            Id::ObjectByRef(a, v, d) => {
-                Some(Node::Object(Box::new(Object::with_ref(&scope, a, v, d))))
-            }
+                Id::ObjectByAddress(a) => {
+                    Some(Node::Object(Box::new(Object::with_address(scope, a))))
+                }
 
-            Id::Transaction(d) => Some(Node::Transaction(Box::new(Transaction::with_digest(
-                scope, d,
-            )))),
-        })
+                Id::ObjectByRef(a, v, d) => {
+                    Some(Node::Object(Box::new(Object::with_ref(&scope, a, v, d))))
+                }
+
+                Id::Transaction(d) => Some(Node::Transaction(Box::new(Transaction::with_digest(
+                    scope, d,
+                )))),
+            })
+        }
+        .await
+        .transpose()
     }
 
     /// Look-up an account by its SuiAddress.
@@ -159,18 +165,22 @@ impl Query {
         name: Option<Domain>,
         root_version: Option<UInt53>,
         at_checkpoint: Option<UInt53>,
-    ) -> Result<Option<Address>, RpcError<address::Error>> {
-        Address::by_key(
-            ctx,
-            self.scope(ctx)?,
-            AddressKey {
-                address,
-                name,
-                root_version,
-                at_checkpoint,
-            },
-        )
+    ) -> Option<Result<Address, RpcError<address::Error>>> {
+        async {
+            Address::by_key(
+                ctx,
+                self.scope(ctx)?,
+                AddressKey {
+                    address,
+                    name,
+                    root_version,
+                    at_checkpoint,
+                },
+            )
+            .await
+        }
         .await
+        .transpose()
     }
 
     /// First four bytes of the network's genesis checkpoint digest (uniquely identifies the network), hex-encoded.
@@ -186,12 +196,16 @@ impl Query {
         &self,
         ctx: &Context<'_>,
         sequence_number: Option<UInt53>,
-    ) -> Result<Option<Checkpoint>, RpcError> {
-        let scope = self.scope(ctx)?;
-        Ok(Checkpoint::with_sequence_number(
-            scope,
-            sequence_number.map(|s| s.into()),
-        ))
+    ) -> Option<Result<Checkpoint, RpcError>> {
+        async {
+            let scope = self.scope(ctx)?;
+            Ok(Checkpoint::with_sequence_number(
+                scope,
+                sequence_number.map(|s| s.into()),
+            ))
+        }
+        .await
+        .transpose()
     }
 
     /// Paginate checkpoints in the network, optionally bounded to checkpoints in the given epoch.
@@ -203,16 +217,19 @@ impl Query {
         last: Option<u64>,
         before: Option<CCheckpoint>,
         filter: Option<CheckpointFilter>,
-    ) -> Result<Option<Connection<String, Checkpoint>>, RpcError> {
-        let scope = self.scope(ctx)?;
-        let pagination: &PaginationConfig = ctx.data()?;
-        let limits = pagination.limits("Query", "checkpoints");
-        let page = Page::from_params(limits, first, after, last, before)?;
+    ) -> Option<Result<Connection<String, Checkpoint>, RpcError>> {
+        Some(
+            async {
+                let scope = self.scope(ctx)?;
+                let pagination: &PaginationConfig = ctx.data()?;
+                let limits = pagination.limits("Query", "checkpoints");
+                let page = Page::from_params(limits, first, after, last, before)?;
 
-        let filter = filter.unwrap_or_default();
-        Checkpoint::paginate(ctx, scope, page, filter)
-            .await
-            .map(Some)
+                let filter = filter.unwrap_or_default();
+                Checkpoint::paginate(ctx, scope, page, filter).await
+            }
+            .await,
+        )
     }
 
     /// Fetch the CoinMetadata for a given coin type.
@@ -222,8 +239,10 @@ impl Query {
         &self,
         ctx: &Context<'_>,
         coin_type: TypeInput,
-    ) -> Result<Option<CoinMetadata>, RpcError<object::Error>> {
-        CoinMetadata::by_coin_type(ctx, self.scope(ctx)?, coin_type.into()).await
+    ) -> Option<Result<CoinMetadata, RpcError<object::Error>>> {
+        async { CoinMetadata::by_coin_type(ctx, self.scope(ctx)?, coin_type.into()).await }
+            .await
+            .transpose()
     }
 
     /// Fetch an epoch by its ID, or fetch the latest epoch if no ID is provided.
@@ -233,9 +252,13 @@ impl Query {
         &self,
         ctx: &Context<'_>,
         epoch_id: Option<UInt53>,
-    ) -> Result<Option<Epoch>, RpcError> {
-        let scope = self.scope(ctx)?;
-        Epoch::fetch(ctx, scope, epoch_id).await
+    ) -> Option<Result<Epoch, RpcError>> {
+        async {
+            let scope = self.scope(ctx)?;
+            Epoch::fetch(ctx, scope, epoch_id).await
+        }
+        .await
+        .transpose()
     }
 
     /// Paginate epochs that are in the network.
@@ -246,13 +269,17 @@ impl Query {
         after: Option<CEpoch>,
         last: Option<u64>,
         before: Option<CEpoch>,
-    ) -> Result<Option<Connection<String, Epoch>>, RpcError> {
-        let scope = self.scope(ctx)?;
-        let pagination: &PaginationConfig = ctx.data()?;
-        let limits = pagination.limits("Query", "epochs");
-        let page = Page::from_params(limits, first, after, last, before)?;
+    ) -> Option<Result<Connection<String, Epoch>, RpcError>> {
+        async {
+            let scope = self.scope(ctx)?;
+            let pagination: &PaginationConfig = ctx.data()?;
+            let limits = pagination.limits("Query", "epochs");
+            let page = Page::from_params(limits, first, after, last, before)?;
 
-        Epoch::paginate(ctx, &scope, page).await
+            Epoch::paginate(ctx, &scope, page).await
+        }
+        .await
+        .transpose()
     }
 
     /// Paginate events that are emitted in the network, optionally filtered by event filters.
@@ -264,15 +291,18 @@ impl Query {
         last: Option<u64>,
         before: Option<CEvent>,
         filter: Option<EventFilter>,
-    ) -> Result<Option<Connection<String, Event>>, RpcError> {
-        let scope = self.scope(ctx)?;
-        let pagination: &PaginationConfig = ctx.data()?;
-        let limits = pagination.limits("Query", "events");
-        let page = Page::from_params(limits, first, after, last, before)?;
+    ) -> Option<Result<Connection<String, Event>, RpcError>> {
+        Some(
+            async {
+                let scope = self.scope(ctx)?;
+                let pagination: &PaginationConfig = ctx.data()?;
+                let limits = pagination.limits("Query", "events");
+                let page = Page::from_params(limits, first, after, last, before)?;
 
-        Event::paginate(ctx, scope, page, filter.unwrap_or_default())
-            .await
-            .map(Some)
+                Event::paginate(ctx, scope, page, filter.unwrap_or_default()).await
+            }
+            .await,
+        )
     }
 
     /// Fetch addresses by their keys.
@@ -410,8 +440,10 @@ impl Query {
         &self,
         ctx: &Context<'_>,
         name: Domain,
-    ) -> Result<Option<NameRecord>, RpcError<object::Error>> {
-        NameRecord::by_domain(ctx, self.scope(ctx)?, name.into()).await
+    ) -> Option<Result<NameRecord, RpcError<object::Error>>> {
+        async { NameRecord::by_domain(ctx, self.scope(ctx)?, name.into()).await }
+            .await
+            .transpose()
     }
 
     /// Fetch an object by its address.
@@ -440,18 +472,22 @@ impl Query {
         version: Option<UInt53>,
         root_version: Option<UInt53>,
         at_checkpoint: Option<UInt53>,
-    ) -> Result<Option<Object>, RpcError<object::Error>> {
-        Object::by_key(
-            ctx,
-            self.scope(ctx)?,
-            ObjectKey {
-                address,
-                version,
-                root_version,
-                at_checkpoint,
-            },
-        )
+    ) -> Option<Result<Object, RpcError<object::Error>>> {
+        async {
+            Object::by_key(
+                ctx,
+                self.scope(ctx)?,
+                ObjectKey {
+                    address,
+                    version,
+                    root_version,
+                    at_checkpoint,
+                },
+            )
+            .await
+        }
         .await
+        .transpose()
     }
 
     /// Paginate objects in the live object set, optionally filtered by owner and/or type. `filter` can be one of:
@@ -467,14 +503,17 @@ impl Query {
         last: Option<u64>,
         before: Option<object::CLive>,
         #[graphql(validator(custom = "OFValidator::default()"))] filter: ObjectFilter,
-    ) -> Result<Option<Connection<String, Object>>, RpcError<object::Error>> {
-        let pagination: &PaginationConfig = ctx.data()?;
-        let limits = pagination.limits("Query", "objects");
-        let page = Page::from_params(limits, first, after, last, before)?;
+    ) -> Option<Result<Connection<String, Object>, RpcError<object::Error>>> {
+        Some(
+            async {
+                let pagination: &PaginationConfig = ctx.data()?;
+                let limits = pagination.limits("Query", "objects");
+                let page = Page::from_params(limits, first, after, last, before)?;
 
-        Ok(Some(
-            Object::paginate_live(ctx, self.scope(ctx)?, page, filter).await?,
-        ))
+                Object::paginate_live(ctx, self.scope(ctx)?, page, filter).await
+            }
+            .await,
+        )
     }
 
     /// Paginate all versions of an object at `address`, optionally bounding the versions exclusively from below with `filter.afterVersion` or from above with `filter.beforeVersion`.
@@ -487,21 +526,24 @@ impl Query {
         before: Option<object::CVersion>,
         address: SuiAddress,
         filter: Option<VersionFilter>,
-    ) -> Result<Option<Connection<String, Object>>, RpcError> {
-        let pagination: &PaginationConfig = ctx.data()?;
-        let limits = pagination.limits("Query", "objectVersions");
-        let page = Page::from_params(limits, first, after, last, before)?;
+    ) -> Option<Result<Connection<String, Object>, RpcError>> {
+        Some(
+            async {
+                let pagination: &PaginationConfig = ctx.data()?;
+                let limits = pagination.limits("Query", "objectVersions");
+                let page = Page::from_params(limits, first, after, last, before)?;
 
-        Ok(Some(
-            Object::paginate_by_version(
-                ctx,
-                self.scope(ctx)?,
-                page,
-                address.into(),
-                filter.unwrap_or_default(),
-            )
-            .await?,
-        ))
+                Object::paginate_by_version(
+                    ctx,
+                    self.scope(ctx)?,
+                    page,
+                    address.into(),
+                    filter.unwrap_or_default(),
+                )
+                .await
+            }
+            .await,
+        )
     }
 
     /// Fetch a package by its address.
@@ -521,17 +563,21 @@ impl Query {
         address: SuiAddress,
         version: Option<UInt53>,
         at_checkpoint: Option<UInt53>,
-    ) -> Result<Option<MovePackage>, RpcError<move_package::Error>> {
-        MovePackage::by_key(
-            ctx,
-            self.scope(ctx)?,
-            PackageKey {
-                address,
-                version,
-                at_checkpoint,
-            },
-        )
+    ) -> Option<Result<MovePackage, RpcError<move_package::Error>>> {
+        async {
+            MovePackage::by_key(
+                ctx,
+                self.scope(ctx)?,
+                PackageKey {
+                    address,
+                    version,
+                    at_checkpoint,
+                },
+            )
+            .await
+        }
         .await
+        .transpose()
     }
 
     /// Paginate all packages published on-chain, optionally bounded to packages published strictly after `filter.afterCheckpoint` and/or strictly before `filter.beforeCheckpoint`.
@@ -543,20 +589,23 @@ impl Query {
         last: Option<u64>,
         before: Option<move_package::CPackage>,
         filter: Option<PackageCheckpointFilter>,
-    ) -> Result<Option<Connection<String, MovePackage>>, RpcError> {
-        let pagination: &PaginationConfig = ctx.data()?;
-        let limits = pagination.limits("Query", "packages");
-        let page = Page::from_params(limits, first, after, last, before)?;
+    ) -> Option<Result<Connection<String, MovePackage>, RpcError>> {
+        Some(
+            async {
+                let pagination: &PaginationConfig = ctx.data()?;
+                let limits = pagination.limits("Query", "packages");
+                let page = Page::from_params(limits, first, after, last, before)?;
 
-        Ok(Some(
-            MovePackage::paginate_by_checkpoint(
-                ctx,
-                self.scope(ctx)?,
-                page,
-                filter.unwrap_or_default(),
-            )
-            .await?,
-        ))
+                MovePackage::paginate_by_checkpoint(
+                    ctx,
+                    self.scope(ctx)?,
+                    page,
+                    filter.unwrap_or_default(),
+                )
+                .await
+            }
+            .await,
+        )
     }
 
     /// Paginate all versions of a package at `address`, optionally bounding the versions exclusively from below with `filter.afterVersion` or from above with `filter.beforeVersion`.
@@ -571,21 +620,24 @@ impl Query {
         before: Option<object::CVersion>,
         address: SuiAddress,
         filter: Option<VersionFilter>,
-    ) -> Result<Option<Connection<String, MovePackage>>, RpcError> {
-        let pagination: &PaginationConfig = ctx.data()?;
-        let limits = pagination.limits("Query", "packageVersions");
-        let page = Page::from_params(limits, first, after, last, before)?;
+    ) -> Option<Result<Connection<String, MovePackage>, RpcError>> {
+        Some(
+            async {
+                let pagination: &PaginationConfig = ctx.data()?;
+                let limits = pagination.limits("Query", "packageVersions");
+                let page = Page::from_params(limits, first, after, last, before)?;
 
-        Ok(Some(
-            MovePackage::paginate_by_version(
-                ctx,
-                self.scope(ctx)?,
-                page,
-                address.into(),
-                filter.unwrap_or_default(),
-            )
-            .await?,
-        ))
+                MovePackage::paginate_by_version(
+                    ctx,
+                    self.scope(ctx)?,
+                    page,
+                    address.into(),
+                    filter.unwrap_or_default(),
+                )
+                .await
+            }
+            .await,
+        )
     }
 
     /// Fetch the protocol config by protocol version, or the latest protocol config used on chain if no version is provided.
@@ -593,13 +645,17 @@ impl Query {
         &self,
         ctx: &Context<'_>,
         version: Option<UInt53>,
-    ) -> Result<Option<ProtocolConfigs>, RpcError> {
-        if let Some(version) = version {
-            Ok(Some(ProtocolConfigs::with_protocol_version(version.into())))
-        } else {
-            let scope = self.scope(ctx)?;
-            ProtocolConfigs::latest(ctx, &scope).await
+    ) -> Option<Result<ProtocolConfigs, RpcError>> {
+        async {
+            if let Some(version) = version {
+                Ok(Some(ProtocolConfigs::with_protocol_version(version.into())))
+            } else {
+                let scope = self.scope(ctx)?;
+                ProtocolConfigs::latest(ctx, &scope).await
+            }
         }
+        .await
+        .transpose()
     }
 
     /// Configuration for this RPC service.
@@ -615,8 +671,10 @@ impl Query {
         &self,
         ctx: &Context<'_>,
         digest: Digest,
-    ) -> Result<Option<Transaction>, RpcError> {
-        Transaction::fetch(ctx, self.scope(ctx)?, digest).await
+    ) -> Option<Result<Transaction, RpcError>> {
+        async { Transaction::fetch(ctx, self.scope(ctx)?, digest).await }
+            .await
+            .transpose()
     }
 
     /// Fetch transaction effects by its transaction's digest.
@@ -626,8 +684,10 @@ impl Query {
         &self,
         ctx: &Context<'_>,
         digest: Digest,
-    ) -> Result<Option<TransactionEffects>, RpcError> {
-        TransactionEffects::fetch(ctx, self.scope(ctx)?, digest).await
+    ) -> Option<Result<TransactionEffects, RpcError>> {
+        async { TransactionEffects::fetch(ctx, self.scope(ctx)?, digest).await }
+            .await
+            .transpose()
     }
 
     /// The transactions that exist in the network, optionally filtered by transaction filters.
@@ -639,17 +699,20 @@ impl Query {
         last: Option<u64>,
         before: Option<CTransaction>,
         #[graphql(validator(custom = "TFValidator"))] filter: Option<TransactionFilter>,
-    ) -> Result<Option<Connection<String, Transaction>>, RpcError> {
-        let scope = self.scope(ctx)?;
-        let pagination: &PaginationConfig = ctx.data()?;
-        let limits = pagination.limits("Query", "transactions");
-        let page = Page::from_params(limits, first, after, last, before)?;
+    ) -> Option<Result<Connection<String, Transaction>, RpcError>> {
+        Some(
+            async {
+                let scope = self.scope(ctx)?;
+                let pagination: &PaginationConfig = ctx.data()?;
+                let limits = pagination.limits("Query", "transactions");
+                let page = Page::from_params(limits, first, after, last, before)?;
 
-        // Use the filter if provided, otherwise use default (unfiltered)
-        let filter = filter.unwrap_or_default();
-        Transaction::paginate(ctx, scope, page, filter)
-            .await
-            .map(Some)
+                // Use the filter if provided, otherwise use default (unfiltered)
+                let filter = filter.unwrap_or_default();
+                Transaction::paginate(ctx, scope, page, filter).await
+            }
+            .await,
+        )
     }
 
     /// Fetch a structured representation of a concrete type, including its layout information.
@@ -661,8 +724,10 @@ impl Query {
         &self,
         ctx: &Context<'_>,
         type_: TypeInput,
-    ) -> Result<Option<MoveType>, RpcError<move_type::Error>> {
-        MoveType::canonicalize(type_.into(), self.scope(ctx)?).await
+    ) -> Option<Result<MoveType, RpcError<move_type::Error>>> {
+        async { MoveType::canonicalize(type_.into(), self.scope(ctx)?).await }
+            .await
+            .transpose()
     }
 
     /// Simulate a transaction to preview its effects without executing it on chain.


### PR DESCRIPTION
## Description 

Updates `Query` return types from `Result<Option<T>, E>` to `Option<Result<T, E>>` for partial error support.

Files changed:
  - crates/sui-indexer-alt-graphql/src/api/query.rs

## Test plan 

How did you test the new or updated feature?

```
cargo nextest run -p sui-indexer-alt-e2e-tests
```

---

- #24595
- #24681 
- #24682 
- #24683 
- #24684 
- #25108 
- #25109
- #25110 ⬅️

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [x] GraphQL: Partial error will be properly supported in GraphQL. Invalid fields will have error messages and valid fields will still be displayed normally
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
