### PR TITLE
[tidehunter] sanity check for database type

### DIFF
--- a/crates/typed-store/src/lib.rs
+++ b/crates/typed-store/src/lib.rs
@@ -25,6 +25,11 @@ pub use typed_store_error::TypedStoreError;
 pub use util::be_fix_int_ser;
 
 pub type StoreError = typed_store_error::TypedStoreError;
+#[derive(Debug, PartialEq)]
+pub(crate) enum StorageType {
+    Rocks,
+    TideHunter,
+}
 
 /// A helper macro to simplify common operations for opening and debugging TypedStore (currently internally structs of DBMaps)
 /// It operates on a struct where all the members are DBMap<K, V>

--- a/crates/typed-store/src/tidehunter_util.rs
+++ b/crates/typed-store/src/tidehunter_util.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::DBMetrics;
+use crate::{DBMetrics, StorageType, util::ensure_database_type};
 use bincode::Options;
 use prometheus::{HistogramTimer, Registry};
 use serde::de::DeserializeOwned;
@@ -35,6 +35,7 @@ pub fn open(path: &Path, key_shape: KeyShape, db_name: String) -> Arc<Db> {
     let registry = new_db_registry(db_name);
     registry_service.add(registry.clone());
     let metrics = Metrics::new_in(&registry);
+    ensure_database_type(path, StorageType::TideHunter).expect("failed to open tidehunter db");
     let db = Db::open(path, key_shape, Arc::new(thdb_config()), metrics)
         .expect("failed to open tidehunter db");
     db.start_periodic_snapshot();


### PR DESCRIPTION
## Description 

adds a sanity check during database opening to prevent accidentally opening a RocksDB folder with Tidehunter and vice versa

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
