### PR TITLE
fix: avoid double file read in FileProgressStore::save

### DIFF
--- a/crates/sui-data-ingestion-core/src/progress_store/file.rs
+++ b/crates/sui-data-ingestion-core/src/progress_store/file.rs
@@ -36,7 +36,7 @@ impl ProgressStore for FileProgressStore {
         let mut content: Value = if raw_content.is_empty() {
             Value::Object(serde_json::Map::new())
         } else {
-            serde_json::from_slice(&std::fs::read(self.path.clone())?)?
+            serde_json::from_slice(&raw_content)?
         };
         content[task_name] = Value::Number(Number::from(checkpoint_number));
         std::fs::write(self.path.clone(), serde_json::to_string_pretty(&content)?)?;


### PR DESCRIPTION
Reason:
Previously FileProgressStore::save() was reading the same progress file twice. The first read was only used to check emptiness, while JSON parsing performed a second read, causing redundant I/O and allocations without any functional benefit.

Overview:
Change save() to parse JSON from the already loaded raw_content buffer instead of calling std::fs::read() a second time, keeping behavior the same while reducing file reads and allocations.