### PR TITLE
[chore] Bump to rust 1.94.0

### DIFF
--- a/consensus/core/src/commit_observer.rs
+++ b/consensus/core/src/commit_observer.rs
@@ -319,9 +319,7 @@ impl CommitObserver {
                 .observe(commit.blocks.len() as f64);
 
             for block in &commit.blocks {
-                let latency_ms = utc_now
-                    .checked_sub(block.timestamp_ms())
-                    .unwrap_or_default();
+                let latency_ms = utc_now.saturating_sub(block.timestamp_ms());
                 metrics
                     .block_commit_latency
                     .observe(Duration::from_millis(latency_ms).as_secs_f64());

--- a/consensus/core/src/leader_scoring.rs
+++ b/consensus/core/src/leader_scoring.rs
@@ -112,13 +112,12 @@ impl ScoringSubdag {
         for subdag in committed_subdags {
             // If the commit range is not set, then set it to the range of the first
             // committed subdag index.
-            if self.commit_range.is_none() {
+            if let Some(commit_range) = &mut self.commit_range {
+                commit_range.extend_to(subdag.commit_ref.index);
+            } else {
                 self.commit_range = Some(CommitRange::new(
                     subdag.commit_ref.index..=subdag.commit_ref.index,
                 ));
-            } else {
-                let commit_range = self.commit_range.as_mut().unwrap();
-                commit_range.extend_to(subdag.commit_ref.index);
             }
 
             // Add the committed leader to the list of leaders we will be scoring.

--- a/consensus/core/src/test_dag_builder.rs
+++ b/consensus/core/src/test_dag_builder.rs
@@ -854,12 +854,11 @@ impl<'a> LayerBuilder<'a> {
         round: Round,
         num_block: u32,
     ) -> BlockTimestampMs {
-        if self.specified_authorities.is_some() && !self.timestamps.is_empty() {
-            let specified_authorities = self.specified_authorities.as_ref().unwrap();
-
-            if let Some(position) = specified_authorities.iter().position(|&x| x == authority) {
-                return self.timestamps[position] + (round + num_block) as u64;
-            }
+        if let Some(specified_authorities) = &self.specified_authorities
+            && !self.timestamps.is_empty()
+            && let Some(position) = specified_authorities.iter().position(|&x| x == authority)
+        {
+            return self.timestamps[position] + (round + num_block) as u64;
         }
         let author = authority.value() as u32;
         let base_ts = round as BlockTimestampMs * 1000;

--- a/crates/sui-bridge/src/sui_client.rs
+++ b/crates/sui-bridge/src/sui_client.rs
@@ -487,6 +487,7 @@ pub trait SuiClientInner: Send + Sync {
 }
 
 #[async_trait]
+#[allow(clippy::result_large_err)]
 impl SuiClientInner for sui_rpc_api::Client {
     async fn get_events_by_tx_digest(
         &self,

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -5107,6 +5107,7 @@ impl AuthorityState {
     }
 
     #[instrument(level = "trace", skip_all)]
+    #[allow(clippy::result_large_err)]
     pub async fn query_events(
         &self,
         kv_store: &Arc<TransactionKeyValueStore>,

--- a/crates/sui-core/src/authority/authority_store_pruner.rs
+++ b/crates/sui-core/src/authority/authority_store_pruner.rs
@@ -794,8 +794,7 @@ impl AuthorityStorePruner {
             .checked_div(Self::pruning_tick_duration_ms(epoch_duration_ms))
             .unwrap_or(1);
         let delta = max_eligible_checkpoint
-            .checked_sub(pruned_checkpoint)
-            .unwrap_or_default()
+            .saturating_sub(pruned_checkpoint)
             .checked_div(num_intervals)
             .unwrap_or(1);
         Ok(pruned_checkpoint + delta)

--- a/crates/sui-core/src/db_checkpoint_handler.rs
+++ b/crates/sui-core/src/db_checkpoint_handler.rs
@@ -134,13 +134,13 @@ impl DBCheckpointHandler {
     }
     pub fn start(self: Arc<Self>) -> tokio::sync::broadcast::Sender<()> {
         let (kill_sender, _kill_receiver) = tokio::sync::broadcast::channel::<()>(1);
-        if self.output_object_store.is_some() {
+        if let Some(output_object_store) = &self.output_object_store {
             tokio::task::spawn(Self::run_db_checkpoint_upload_loop(
                 self.clone(),
                 kill_sender.subscribe(),
             ));
             tokio::task::spawn(run_manifest_update_loop(
-                self.output_object_store.as_ref().unwrap().clone(),
+                output_object_store.clone(),
                 kill_sender.subscribe(),
             ));
         } else {

--- a/crates/sui-e2e-tests/tests/authenticated_events_api_tests.rs
+++ b/crates/sui-e2e-tests/tests/authenticated_events_api_tests.rs
@@ -186,7 +186,7 @@ where
     for attempt in 0..MAX_RETRIES {
         match tokio::time::timeout(CONNECT_TIMEOUT, connect_fn()).await {
             Ok(Ok(client)) => return client,
-            Ok(Err(e)) if attempt + 1 < MAX_RETRIES => {
+            Ok(Err(_)) if attempt + 1 < MAX_RETRIES => {
                 tokio::time::sleep(Duration::from_millis(100)).await;
             }
             Ok(Err(e)) => panic!("failed to connect after {MAX_RETRIES} attempts: {e}"),

--- a/crates/sui-e2e-tests/tests/authenticated_events_client_test.rs
+++ b/crates/sui-e2e-tests/tests/authenticated_events_client_test.rs
@@ -160,7 +160,7 @@ where
     for attempt in 0..MAX_RETRIES {
         match tokio::time::timeout(CONNECT_TIMEOUT, connect_fn()).await {
             Ok(Ok(client)) => return client,
-            Ok(Err(e)) if attempt + 1 < MAX_RETRIES => {
+            Ok(Err(_)) if attempt + 1 < MAX_RETRIES => {
                 tokio::time::sleep(Duration::from_millis(100)).await;
             }
             Ok(Err(e)) => panic!("failed to connect after {MAX_RETRIES} attempts: {e}"),

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -418,10 +418,10 @@ impl ReadApi {
 
         // fill cache with the timestamp
         for (_, cache_entry) in temp_response.iter_mut() {
-            if cache_entry.checkpoint_seq.is_some() {
+            if let Some(checkpoint_seq) = cache_entry.checkpoint_seq {
                 // safe to unwrap because is_some is checked
                 cache_entry.timestamp = *checkpoint_to_timestamp
-                    .get(cache_entry.checkpoint_seq.as_ref().unwrap())
+                    .get(&checkpoint_seq)
                     // Safe to unwrap because checkpoint_seq is guaranteed to exist in checkpoint_to_timestamp
                     .unwrap();
             }

--- a/crates/sui-replay/src/data_fetcher.rs
+++ b/crates/sui-replay/src/data_fetcher.rs
@@ -346,6 +346,7 @@ impl RemoteFetcher {
 }
 
 #[async_trait]
+#[allow(clippy::result_large_err)]
 impl DataFetcher for RemoteFetcher {
     #![allow(implied_bounds_entailment)]
     async fn multi_get_versioned(
@@ -712,6 +713,7 @@ impl NodeStateDumpFetcher {
 }
 
 #[async_trait]
+#[allow(clippy::result_large_err)]
 impl DataFetcher for NodeStateDumpFetcher {
     async fn multi_get_versioned(
         &self,

--- a/crates/sui-replay/src/replay.rs
+++ b/crates/sui-replay/src/replay.rs
@@ -676,6 +676,7 @@ impl LocalExec {
             .map_err(|e| ReplayEngineError::SuiRpcError { err: e.to_string() })
     }
 
+    #[allow(clippy::result_large_err)]
     pub async fn execute_all_in_checkpoints(
         &mut self,
         checkpoint_ids: &[u64],
@@ -1415,6 +1416,7 @@ impl LocalExec {
         Ok(mapping)
     }
 
+    #[allow(clippy::result_large_err)]
     pub async fn get_protocol_config(
         &self,
         epoch_id: EpochId,
@@ -1711,6 +1713,7 @@ impl LocalExec {
         })
     }
 
+    #[allow(clippy::result_large_err)]
     async fn resolve_download_input_objects(
         &mut self,
         tx_info: &OnChainTransactionInfo,

--- a/crates/sui-rpc-loadgen/src/payload/rpc_command_processor.rs
+++ b/crates/sui-rpc-loadgen/src/payload/rpc_command_processor.rs
@@ -309,11 +309,11 @@ impl Processor for RpcCommandProcessor {
                 .with_repeat_n_times(*repeat_n_times)
         });
 
-        let coins_and_keys = if config.signer_info.is_some() {
+        let coins_and_keys = if let Some(signer_info) = &config.signer_info {
             Some(
                 prepare_new_signer_and_coins(
                     clients.first().unwrap(),
-                    config.signer_info.as_ref().unwrap(),
+                    signer_info,
                     config.num_threads * config.num_chunks_per_thread,
                     config.max_repeat as u64 + 1,
                 )

--- a/crates/sui-sdk/src/wallet_context.rs
+++ b/crates/sui-sdk/src/wallet_context.rs
@@ -182,8 +182,7 @@ impl WalletContext {
         force_recache: bool,
     ) -> Result<String, anyhow::Error> {
         let env = self.get_active_env()?;
-        if !force_recache && env.chain_id.is_some() {
-            let chain_id = env.chain_id.as_ref().unwrap();
+        if !force_recache && let Some(chain_id) = &env.chain_id {
             info!("Found cached chain ID for env {}: {}", env.alias, chain_id);
             return Ok(chain_id.clone());
         }

--- a/crates/sui-types/src/gas_model/gas_v2.rs
+++ b/crates/sui-types/src/gas_model/gas_v2.rs
@@ -408,19 +408,15 @@ mod checked {
 
         fn bucketize_computation(&mut self, aborted: Option<bool>) -> Result<(), ExecutionError> {
             let gas_used = self.gas_status.gas_used_pre_gas_price();
-            let effective_gas_price = if self
+            let effective_gas_price = if let Some(max_gas_price_rgp_factor_for_aborted_txs) = self
                 .cost_table
                 .max_gas_price_rgp_factor_for_aborted_transactions
-                .is_some()
                 && aborted.unwrap_or(false)
             {
                 // For aborts, cap at max but don't exceed user's price
                 // This minimizes the risk of competing for priority execution in the case that the txn may be aborted.
-                let max_gas_price_for_aborted_txns = self
-                    .cost_table
-                    .max_gas_price_rgp_factor_for_aborted_transactions
-                    .unwrap()
-                    * self.reference_gas_price;
+                let max_gas_price_for_aborted_txns =
+                    max_gas_price_rgp_factor_for_aborted_txs * self.reference_gas_price;
                 self.gas_price.min(max_gas_price_for_aborted_txns)
             } else {
                 // For all other cases, use the user's gas price

--- a/crates/sui-types/src/rpc_proto_conversions.rs
+++ b/crates/sui-types/src/rpc_proto_conversions.rs
@@ -116,6 +116,7 @@ impl Merge<&crate::full_checkpoint_content::ExecutedTransaction> for ExecutedTra
 impl TryFrom<&Checkpoint> for crate::full_checkpoint_content::Checkpoint {
     type Error = TryFromProtoError;
 
+    #[allow(clippy::result_large_err)]
     fn try_from(checkpoint: &Checkpoint) -> Result<Self, Self::Error> {
         let summary = checkpoint
             .summary()
@@ -168,6 +169,7 @@ impl TryFrom<&Checkpoint> for crate::full_checkpoint_content::Checkpoint {
 impl TryFrom<&ExecutedTransaction> for crate::full_checkpoint_content::ExecutedTransaction {
     type Error = TryFromProtoError;
 
+    #[allow(clippy::result_large_err)]
     fn try_from(value: &ExecutedTransaction) -> Result<Self, Self::Error> {
         Ok(Self {
             transaction: value
@@ -967,6 +969,7 @@ impl TryFrom<&SystemState>
 {
     type Error = TryFromProtoError;
 
+    #[allow(clippy::result_large_err)]
     fn try_from(s: &SystemState) -> Result<Self, Self::Error> {
         Ok(Self {
             epoch: s.epoch(),
@@ -1576,6 +1579,7 @@ impl From<crate::committee::Committee> for ValidatorCommittee {
 impl TryFrom<&ValidatorCommittee> for crate::committee::Committee {
     type Error = TryFromProtoError;
 
+    #[allow(clippy::result_large_err)]
     fn try_from(s: &ValidatorCommittee) -> Result<Self, Self::Error> {
         let members = s
             .members()

--- a/docker/stress/Dockerfile
+++ b/docker/stress/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.92-bullseye AS builder
+FROM rust:1.93-bullseye AS builder
 ARG PROFILE=release
 ARG GIT_REVISION
 ENV GIT_REVISION=$GIT_REVISION
@@ -13,7 +13,7 @@ COPY external-crates external-crates
 
 RUN cargo build --profile ${PROFILE} --bin stress
 
-FROM rust:1.92-bullseye
+FROM rust:1.93-bullseye
 ARG PROFILE=release
 ARG GIT_REVISION
 COPY --from=builder /sui/target/${PROFILE}/stress /usr/local/bin

--- a/docker/stress/Dockerfile
+++ b/docker/stress/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.93-bullseye AS builder
+FROM rust:1.94-bullseye AS builder
 ARG PROFILE=release
 ARG GIT_REVISION
 ENV GIT_REVISION=$GIT_REVISION
@@ -13,7 +13,7 @@ COPY external-crates external-crates
 
 RUN cargo build --profile ${PROFILE} --bin stress
 
-FROM rust:1.93-bullseye
+FROM rust:1.94-bullseye
 ARG PROFILE=release
 ARG GIT_REVISION
 COPY --from=builder /sui/target/${PROFILE}/stress /usr/local/bin

--- a/docker/sui-analytics-indexer/Dockerfile
+++ b/docker/sui-analytics-indexer/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.92-bullseye as build
+FROM rust:1.93-bullseye as build
 
 ARG PROFILE=release
 WORKDIR /work

--- a/docker/sui-analytics-indexer/Dockerfile
+++ b/docker/sui-analytics-indexer/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.93-bullseye as build
+FROM rust:1.94-bullseye as build
 
 ARG PROFILE=release
 WORKDIR /work

--- a/docker/sui-bridge-indexer-alt/Dockerfile
+++ b/docker/sui-bridge-indexer-alt/Dockerfile
@@ -2,7 +2,7 @@
 #
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
-FROM rust:1.92-bullseye AS builder
+FROM rust:1.93-bullseye AS builder
 ARG PROFILE=release
 ARG GIT_REVISION
 ENV GIT_REVISION=$GIT_REVISION

--- a/docker/sui-bridge-indexer-alt/Dockerfile
+++ b/docker/sui-bridge-indexer-alt/Dockerfile
@@ -2,7 +2,7 @@
 #
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
-FROM rust:1.93-bullseye AS builder
+FROM rust:1.94-bullseye AS builder
 ARG PROFILE=release
 ARG GIT_REVISION
 ENV GIT_REVISION=$GIT_REVISION

--- a/docker/sui-bridge-indexer/Dockerfile
+++ b/docker/sui-bridge-indexer/Dockerfile
@@ -2,7 +2,7 @@
 #
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
-FROM rust:1.92-bullseye AS builder
+FROM rust:1.93-bullseye AS builder
 ARG PROFILE=release
 ARG GIT_REVISION
 ENV GIT_REVISION=$GIT_REVISION

--- a/docker/sui-bridge-indexer/Dockerfile
+++ b/docker/sui-bridge-indexer/Dockerfile
@@ -2,7 +2,7 @@
 #
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
-FROM rust:1.93-bullseye AS builder
+FROM rust:1.94-bullseye AS builder
 ARG PROFILE=release
 ARG GIT_REVISION
 ENV GIT_REVISION=$GIT_REVISION

--- a/docker/sui-checkpoint-blob-indexer/Dockerfile
+++ b/docker/sui-checkpoint-blob-indexer/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.92-bullseye as build
+FROM rust:1.93-bullseye as build
 
 ARG PROFILE=release
 WORKDIR /work

--- a/docker/sui-checkpoint-blob-indexer/Dockerfile
+++ b/docker/sui-checkpoint-blob-indexer/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.93-bullseye as build
+FROM rust:1.94-bullseye as build
 
 ARG PROFILE=release
 WORKDIR /work

--- a/docker/sui-indexer-alt-consistent-store/Dockerfile
+++ b/docker/sui-indexer-alt-consistent-store/Dockerfile
@@ -3,7 +3,7 @@
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
 ARG PROFILE=release-unwind
-FROM rust:1.92-bullseye AS builder
+FROM rust:1.93-bullseye AS builder
 ARG PROFILE
 ARG GIT_REVISION
 ENV GIT_REVISION=$GIT_REVISION

--- a/docker/sui-indexer-alt-consistent-store/Dockerfile
+++ b/docker/sui-indexer-alt-consistent-store/Dockerfile
@@ -3,7 +3,7 @@
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
 ARG PROFILE=release-unwind
-FROM rust:1.93-bullseye AS builder
+FROM rust:1.94-bullseye AS builder
 ARG PROFILE
 ARG GIT_REVISION
 ENV GIT_REVISION=$GIT_REVISION

--- a/docker/sui-indexer-alt-graphql/Dockerfile
+++ b/docker/sui-indexer-alt-graphql/Dockerfile
@@ -2,9 +2,9 @@
 #
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
-# rust:1.92-bullseye
+# rust:1.93-bullseye
 ARG PROFILE=release-unwind
-FROM rust:1.92-bullseye AS builder
+FROM rust:1.93-bullseye AS builder
 ARG PROFILE
 ARG GIT_REVISION
 ENV GIT_REVISION=$GIT_REVISION

--- a/docker/sui-indexer-alt-graphql/Dockerfile
+++ b/docker/sui-indexer-alt-graphql/Dockerfile
@@ -2,9 +2,9 @@
 #
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
-# rust:1.93-bullseye
+# rust:1.94-bullseye
 ARG PROFILE=release-unwind
-FROM rust:1.93-bullseye AS builder
+FROM rust:1.94-bullseye AS builder
 ARG PROFILE
 ARG GIT_REVISION
 ENV GIT_REVISION=$GIT_REVISION

--- a/docker/sui-indexer-alt-jsonrpc/Dockerfile
+++ b/docker/sui-indexer-alt-jsonrpc/Dockerfile
@@ -3,7 +3,7 @@
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
 ARG PROFILE=release-unwind
-FROM rust:1.92-bullseye AS builder
+FROM rust:1.93-bullseye AS builder
 ARG PROFILE
 ARG GIT_REVISION
 ENV GIT_REVISION=$GIT_REVISION

--- a/docker/sui-indexer-alt-jsonrpc/Dockerfile
+++ b/docker/sui-indexer-alt-jsonrpc/Dockerfile
@@ -3,7 +3,7 @@
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
 ARG PROFILE=release-unwind
-FROM rust:1.93-bullseye AS builder
+FROM rust:1.94-bullseye AS builder
 ARG PROFILE
 ARG GIT_REVISION
 ENV GIT_REVISION=$GIT_REVISION

--- a/docker/sui-indexer-alt/Dockerfile
+++ b/docker/sui-indexer-alt/Dockerfile
@@ -2,7 +2,7 @@
 #
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
-FROM rust:1.92-bullseye AS builder
+FROM rust:1.93-bullseye AS builder
 ARG PROFILE=release
 ARG GIT_REVISION
 ENV GIT_REVISION=$GIT_REVISION

--- a/docker/sui-indexer-alt/Dockerfile
+++ b/docker/sui-indexer-alt/Dockerfile
@@ -2,7 +2,7 @@
 #
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
-FROM rust:1.93-bullseye AS builder
+FROM rust:1.94-bullseye AS builder
 ARG PROFILE=release
 ARG GIT_REVISION
 ENV GIT_REVISION=$GIT_REVISION

--- a/docker/sui-kv-rpc/Dockerfile
+++ b/docker/sui-kv-rpc/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.92-bullseye as build
+FROM rust:1.93-bullseye as build
 
 ARG PROFILE=release
 WORKDIR /work

--- a/docker/sui-kv-rpc/Dockerfile
+++ b/docker/sui-kv-rpc/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.93-bullseye as build
+FROM rust:1.94-bullseye as build
 
 ARG PROFILE=release
 WORKDIR /work

--- a/docker/sui-kvstore/Dockerfile
+++ b/docker/sui-kvstore/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.92-bullseye as build
+FROM rust:1.93-bullseye as build
 
 ARG PROFILE=release
 WORKDIR /work

--- a/docker/sui-kvstore/Dockerfile
+++ b/docker/sui-kvstore/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.93-bullseye as build
+FROM rust:1.94-bullseye as build
 
 ARG PROFILE=release
 WORKDIR /work

--- a/docker/sui-node/Dockerfile
+++ b/docker/sui-node/Dockerfile
@@ -2,7 +2,7 @@
 #
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
-FROM rust:1.92-bullseye AS builder
+FROM rust:1.93-bullseye AS builder
 ARG PROFILE=release
 ARG GIT_REVISION
 ENV GIT_REVISION=$GIT_REVISION

--- a/docker/sui-node/Dockerfile
+++ b/docker/sui-node/Dockerfile
@@ -2,7 +2,7 @@
 #
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
-FROM rust:1.93-bullseye AS builder
+FROM rust:1.94-bullseye AS builder
 ARG PROFILE=release
 ARG GIT_REVISION
 ENV GIT_REVISION=$GIT_REVISION

--- a/docker/sui-proxy/Dockerfile
+++ b/docker/sui-proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.92-bullseye as build
+FROM rust:1.93-bullseye as build
 
 ARG PROFILE=release
 WORKDIR /work

--- a/docker/sui-proxy/Dockerfile
+++ b/docker/sui-proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.93-bullseye as build
+FROM rust:1.94-bullseye as build
 
 ARG PROFILE=release
 WORKDIR /work

--- a/docker/sui-rpc-benchmark/Dockerfile
+++ b/docker/sui-rpc-benchmark/Dockerfile
@@ -2,7 +2,7 @@
 #
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
-FROM rust:1.92-bullseye AS builder
+FROM rust:1.93-bullseye AS builder
 ARG PROFILE=release
 ARG GIT_REVISION
 ENV GIT_REVISION=$GIT_REVISION

--- a/docker/sui-rpc-benchmark/Dockerfile
+++ b/docker/sui-rpc-benchmark/Dockerfile
@@ -2,7 +2,7 @@
 #
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
-FROM rust:1.93-bullseye AS builder
+FROM rust:1.94-bullseye AS builder
 ARG PROFILE=release
 ARG GIT_REVISION
 ENV GIT_REVISION=$GIT_REVISION

--- a/docker/sui-services/Dockerfile
+++ b/docker/sui-services/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.92-bullseye AS chef
+FROM rust:1.93-bullseye AS chef
 WORKDIR sui
 ARG GIT_REVISION
 ENV GIT_REVISION=$GIT_REVISION

--- a/docker/sui-services/Dockerfile
+++ b/docker/sui-services/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.93-bullseye AS chef
+FROM rust:1.94-bullseye AS chef
 WORKDIR sui
 ARG GIT_REVISION
 ENV GIT_REVISION=$GIT_REVISION

--- a/docker/sui-tool/Dockerfile
+++ b/docker/sui-tool/Dockerfile
@@ -2,7 +2,7 @@
 #
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
-FROM rust:1.92-bullseye AS builder
+FROM rust:1.93-bullseye AS builder
 ARG PROFILE=release
 ARG GIT_REVISION
 ENV GIT_REVISION=$GIT_REVISION

--- a/docker/sui-tool/Dockerfile
+++ b/docker/sui-tool/Dockerfile
@@ -2,7 +2,7 @@
 #
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
-FROM rust:1.93-bullseye AS builder
+FROM rust:1.94-bullseye AS builder
 ARG PROFILE=release
 ARG GIT_REVISION
 ENV GIT_REVISION=$GIT_REVISION

--- a/docker/sui-tools/Dockerfile
+++ b/docker/sui-tools/Dockerfile
@@ -2,7 +2,7 @@
 #
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
-FROM rust:1.92-bullseye AS builder
+FROM rust:1.93-bullseye AS builder
 ARG PROFILE=release
 ARG GIT_REVISION
 ENV GIT_REVISION=$GIT_REVISION

--- a/docker/sui-tools/Dockerfile
+++ b/docker/sui-tools/Dockerfile
@@ -2,7 +2,7 @@
 #
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
 # and build the application.
-FROM rust:1.93-bullseye AS builder
+FROM rust:1.94-bullseye AS builder
 ARG PROFILE=release
 ARG GIT_REVISION
 ENV GIT_REVISION=$GIT_REVISION

--- a/external-crates/move/crates/move-binary-format/src/file_format.rs
+++ b/external-crates/move/crates/move-binary-format/src/file_format.rs
@@ -1330,8 +1330,6 @@ pub struct CodeUnit {
 /// Bytecodes operate on a stack machine and each bytecode has side effect on the stack and the
 /// instruction stream.
 #[derive(Clone, Hash, Eq, VariantCount, PartialEq)]
-#[cfg_attr(any(test, feature = "fuzzing"), derive(proptest_derive::Arbitrary))]
-#[cfg_attr(any(test, feature = "fuzzing"), proptest(no_params))]
 #[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "wasm", derive(Serialize, Deserialize))]
 pub enum Bytecode {
@@ -1830,6 +1828,254 @@ pub enum Bytecode {
     ImmBorrowGlobalDeprecated(StructDefinitionIndex),
     ImmBorrowGlobalGenericDeprecated(StructDefInstantiationIndex),
     // ******** END DEPRECATED BYTECODES ********
+}
+
+#[cfg(any(test, feature = "fuzzing"))]
+fn bytecode_weighted_strategies() -> Vec<(u32, BoxedStrategy<Bytecode>)> {
+    use Bytecode::*;
+
+    vec![
+        (1, Just(Pop).boxed()),
+        (1, Just(Ret).boxed()),
+        (1, any::<CodeOffset>().prop_map(BrTrue).boxed()),
+        (1, any::<CodeOffset>().prop_map(BrFalse).boxed()),
+        (1, any::<CodeOffset>().prop_map(Branch).boxed()),
+        (1, any::<u8>().prop_map(LdU8).boxed()),
+        (1, any::<u64>().prop_map(LdU64).boxed()),
+        (
+            1,
+            any::<u128>()
+                .prop_map(|value| LdU128(Box::new(value)))
+                .boxed(),
+        ),
+        (1, Just(CastU8).boxed()),
+        (1, Just(CastU64).boxed()),
+        (1, Just(CastU128).boxed()),
+        (1, any::<ConstantPoolIndex>().prop_map(LdConst).boxed()),
+        (1, Just(LdTrue).boxed()),
+        (1, Just(LdFalse).boxed()),
+        (1, any::<LocalIndex>().prop_map(CopyLoc).boxed()),
+        (1, any::<LocalIndex>().prop_map(MoveLoc).boxed()),
+        (1, any::<LocalIndex>().prop_map(StLoc).boxed()),
+        (1, any::<FunctionHandleIndex>().prop_map(Call).boxed()),
+        (
+            1,
+            any::<FunctionInstantiationIndex>()
+                .prop_map(CallGeneric)
+                .boxed(),
+        ),
+        (1, any::<StructDefinitionIndex>().prop_map(Pack).boxed()),
+        (
+            1,
+            any::<StructDefInstantiationIndex>()
+                .prop_map(PackGeneric)
+                .boxed(),
+        ),
+        (1, any::<StructDefinitionIndex>().prop_map(Unpack).boxed()),
+        (
+            1,
+            any::<StructDefInstantiationIndex>()
+                .prop_map(UnpackGeneric)
+                .boxed(),
+        ),
+        (1, Just(ReadRef).boxed()),
+        (1, Just(WriteRef).boxed()),
+        (1, Just(FreezeRef).boxed()),
+        (1, any::<LocalIndex>().prop_map(MutBorrowLoc).boxed()),
+        (1, any::<LocalIndex>().prop_map(ImmBorrowLoc).boxed()),
+        (
+            1,
+            any::<FieldHandleIndex>().prop_map(MutBorrowField).boxed(),
+        ),
+        (
+            1,
+            any::<FieldInstantiationIndex>()
+                .prop_map(MutBorrowFieldGeneric)
+                .boxed(),
+        ),
+        (
+            1,
+            any::<FieldHandleIndex>().prop_map(ImmBorrowField).boxed(),
+        ),
+        (
+            1,
+            any::<FieldInstantiationIndex>()
+                .prop_map(ImmBorrowFieldGeneric)
+                .boxed(),
+        ),
+        (1, Just(Add).boxed()),
+        (1, Just(Sub).boxed()),
+        (1, Just(Mul).boxed()),
+        (1, Just(Mod).boxed()),
+        (1, Just(Div).boxed()),
+        (1, Just(BitOr).boxed()),
+        (1, Just(BitAnd).boxed()),
+        (1, Just(Xor).boxed()),
+        (1, Just(Or).boxed()),
+        (1, Just(And).boxed()),
+        (1, Just(Not).boxed()),
+        (1, Just(Eq).boxed()),
+        (1, Just(Neq).boxed()),
+        (1, Just(Lt).boxed()),
+        (1, Just(Gt).boxed()),
+        (1, Just(Le).boxed()),
+        (1, Just(Ge).boxed()),
+        (1, Just(Abort).boxed()),
+        (1, Just(Nop).boxed()),
+        (1, Just(Shl).boxed()),
+        (1, Just(Shr).boxed()),
+        (
+            1,
+            (any::<SignatureIndex>(), any::<u64>())
+                .prop_map(|(sig_idx, count)| VecPack(sig_idx, count))
+                .boxed(),
+        ),
+        (1, any::<SignatureIndex>().prop_map(VecLen).boxed()),
+        (1, any::<SignatureIndex>().prop_map(VecImmBorrow).boxed()),
+        (1, any::<SignatureIndex>().prop_map(VecMutBorrow).boxed()),
+        (1, any::<SignatureIndex>().prop_map(VecPushBack).boxed()),
+        (1, any::<SignatureIndex>().prop_map(VecPopBack).boxed()),
+        (
+            1,
+            (any::<SignatureIndex>(), any::<u64>())
+                .prop_map(|(sig_idx, count)| VecUnpack(sig_idx, count))
+                .boxed(),
+        ),
+        (1, any::<SignatureIndex>().prop_map(VecSwap).boxed()),
+        (1, any::<u16>().prop_map(LdU16).boxed()),
+        (1, any::<u32>().prop_map(LdU32).boxed()),
+        (
+            1,
+            any::<move_core_types::u256::U256>()
+                .prop_map(|value| LdU256(Box::new(value)))
+                .boxed(),
+        ),
+        (1, Just(CastU16).boxed()),
+        (1, Just(CastU32).boxed()),
+        (1, Just(CastU256).boxed()),
+        (1, any::<VariantHandleIndex>().prop_map(PackVariant).boxed()),
+        (
+            1,
+            any::<VariantInstantiationHandleIndex>()
+                .prop_map(PackVariantGeneric)
+                .boxed(),
+        ),
+        (
+            1,
+            any::<VariantHandleIndex>().prop_map(UnpackVariant).boxed(),
+        ),
+        (
+            1,
+            any::<VariantHandleIndex>()
+                .prop_map(UnpackVariantImmRef)
+                .boxed(),
+        ),
+        (
+            1,
+            any::<VariantHandleIndex>()
+                .prop_map(UnpackVariantMutRef)
+                .boxed(),
+        ),
+        (
+            1,
+            any::<VariantInstantiationHandleIndex>()
+                .prop_map(UnpackVariantGeneric)
+                .boxed(),
+        ),
+        (
+            1,
+            any::<VariantInstantiationHandleIndex>()
+                .prop_map(UnpackVariantGenericImmRef)
+                .boxed(),
+        ),
+        (
+            1,
+            any::<VariantInstantiationHandleIndex>()
+                .prop_map(UnpackVariantGenericMutRef)
+                .boxed(),
+        ),
+        (
+            1,
+            any::<VariantJumpTableIndex>()
+                .prop_map(VariantSwitch)
+                .boxed(),
+        ),
+        (
+            1,
+            any::<StructDefinitionIndex>()
+                .prop_map(ExistsDeprecated)
+                .boxed(),
+        ),
+        (
+            1,
+            any::<StructDefInstantiationIndex>()
+                .prop_map(ExistsGenericDeprecated)
+                .boxed(),
+        ),
+        (
+            1,
+            any::<StructDefinitionIndex>()
+                .prop_map(MoveFromDeprecated)
+                .boxed(),
+        ),
+        (
+            1,
+            any::<StructDefInstantiationIndex>()
+                .prop_map(MoveFromGenericDeprecated)
+                .boxed(),
+        ),
+        (
+            1,
+            any::<StructDefinitionIndex>()
+                .prop_map(MoveToDeprecated)
+                .boxed(),
+        ),
+        (
+            1,
+            any::<StructDefInstantiationIndex>()
+                .prop_map(MoveToGenericDeprecated)
+                .boxed(),
+        ),
+        (
+            1,
+            any::<StructDefinitionIndex>()
+                .prop_map(MutBorrowGlobalDeprecated)
+                .boxed(),
+        ),
+        (
+            1,
+            any::<StructDefInstantiationIndex>()
+                .prop_map(MutBorrowGlobalGenericDeprecated)
+                .boxed(),
+        ),
+        (
+            1,
+            any::<StructDefinitionIndex>()
+                .prop_map(ImmBorrowGlobalDeprecated)
+                .boxed(),
+        ),
+        (
+            1,
+            any::<StructDefInstantiationIndex>()
+                .prop_map(ImmBorrowGlobalGenericDeprecated)
+                .boxed(),
+        ),
+    ]
+}
+
+#[cfg(test)]
+pub(crate) fn bytecode_strategy_variant_count() -> usize {
+    bytecode_weighted_strategies().len()
+}
+
+#[cfg(any(test, feature = "fuzzing"))]
+impl Arbitrary for Bytecode {
+    type Strategy = BoxedStrategy<Self>;
+    type Parameters = ();
+
+    fn arbitrary_with(_params: Self::Parameters) -> Self::Strategy {
+        proptest::strategy::Union::new_weighted(bytecode_weighted_strategies()).boxed()
+    }
 }
 
 impl ::std::fmt::Debug for Bytecode {

--- a/external-crates/move/crates/move-binary-format/src/unit_tests/bytecode_strategy_tests.rs
+++ b/external-crates/move/crates/move-binary-format/src/unit_tests/bytecode_strategy_tests.rs
@@ -1,0 +1,29 @@
+// Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::file_format::{Bytecode, bytecode_strategy_variant_count};
+use proptest::{
+    arbitrary::any,
+    collection::vec,
+    strategy::{Strategy, ValueTree},
+    test_runner::TestRunner,
+};
+
+#[test]
+fn bytecode_strategy_matches_variant_count() {
+    assert_eq!(bytecode_strategy_variant_count(), Bytecode::VARIANT_COUNT);
+}
+
+#[test]
+fn bytecode_vector_generation_smoke() {
+    let strategy = vec(any::<Bytecode>(), 0..=16);
+    let mut runner = TestRunner::default();
+
+    for _ in 0..1024 {
+        let tree = strategy
+            .new_tree(&mut runner)
+            .expect("bytecode vector generation should work");
+        let _ = tree.current();
+    }
+}

--- a/external-crates/move/crates/move-binary-format/src/unit_tests/mod.rs
+++ b/external-crates/move/crates/move-binary-format/src/unit_tests/mod.rs
@@ -4,6 +4,7 @@
 
 mod binary_limits_tests;
 mod binary_tests;
+mod bytecode_strategy_tests;
 mod compatibility_tests;
 mod deserializer_tests;
 mod equivalence_tests;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.92"
+channel = "1.93"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.93"
+channel = "1.93.1"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.93.1"
+channel = "1.94.0"


### PR DESCRIPTION
## Description 

Bump to 1.94.0 to take advantage of the new `cargo clean --workspace` command introduced in 1.93.0.

## Test plan 

Existing tests and CI.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
