### PR TITLE
Protocol guard transition from `AddressAliases` to `AddressAliasesV2`

### DIFF
--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -9,6 +9,7 @@ use futures::{TryFutureExt, future};
 use itertools::Itertools as _;
 use mysten_common::{assert_reachable, debug_fatal};
 use mysten_metrics::spawn_monitored_task;
+use nonempty::NonEmpty;
 use prometheus::{
     Gauge, Histogram, HistogramVec, IntCounter, IntCounterVec, Registry,
     register_gauge_with_registry, register_histogram_vec_with_registry,
@@ -885,7 +886,26 @@ impl ValidatorService {
 
                 let (tx, aliases) = verified_transaction.into_inner();
                 if epoch_store.protocol_config().address_aliases() {
-                    claims.push(TransactionClaim::AddressAliasesV2(aliases));
+                    if epoch_store
+                        .protocol_config()
+                        .fix_checkpoint_signature_mapping()
+                    {
+                        claims.push(TransactionClaim::AddressAliasesV2(aliases));
+                    } else {
+                        let v1_aliases: Vec<_> = tx
+                            .data()
+                            .intent_message()
+                            .value
+                            .required_signers()
+                            .into_iter()
+                            .zip_eq(aliases.into_iter().map(|(_, seq)| seq))
+                            .collect();
+                        #[allow(deprecated)]
+                        claims.push(TransactionClaim::AddressAliases(
+                            NonEmpty::from_vec(v1_aliases)
+                                .expect("must have at least one required_signer"),
+                        ));
+                    }
                 }
 
                 let tx_with_claims = TransactionWithClaims::new(tx.into(), claims);

--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -3997,12 +3997,24 @@ impl<T> TransactionWithClaims<T> {
         self.tx
     }
 
-    /// Get the address aliases claim. Differentiate between empty and not present for validation.
+    /// Get the address aliases V2 claim. Differentiate between empty and not present for validation.
     pub fn aliases(&self) -> Option<NonEmpty<(u8, Option<SequenceNumber>)>> {
         self.claims
             .iter()
             .find_map(|c| match c {
                 TransactionClaim::AddressAliasesV2(aliases) => Some(aliases),
+                _ => None,
+            })
+            .cloned()
+    }
+
+    // TODO: Remove once `fix_checkpoint_signature_mapping` flag is enabled in testnet.
+    #[allow(deprecated)]
+    pub fn aliases_v1(&self) -> Option<NonEmpty<(SuiAddress, Option<SequenceNumber>)>> {
+        self.claims
+            .iter()
+            .find_map(|c| match c {
+                TransactionClaim::AddressAliases(aliases) => Some(aliases),
                 _ => None,
             })
             .cloned()


### PR DESCRIPTION
V1 vs V2 format is now controlled by the
`fix_checkpoint_signature_mapping` protocol config flag.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
