### PR TITLE
fix(sui-http): use explicit rustls::CryptoProvider (#25106)

### DIFF
--- a/crates/sui-http/src/lib.rs
+++ b/crates/sui-http/src/lib.rs
@@ -72,9 +72,12 @@ impl Builder {
 
         let certs = CertificateDer::pem_file_iter(cert_file)?.collect::<Result<_, _>>()?;
         let private_key = PrivateKeyDer::from_pem_file(private_key_file)?;
-        let tls_config = rustls::ServerConfig::builder()
-            .with_no_client_auth()
-            .with_single_cert(certs, private_key)?;
+        let tls_config = rustls::ServerConfig::builder_with_provider(Arc::new(
+            rustls::crypto::ring::default_provider(),
+        ))
+        .with_protocol_versions(rustls::DEFAULT_VERSIONS)?
+        .with_no_client_auth()
+        .with_single_cert(certs, private_key)?;
 
         Ok(self.tls_config(tls_config))
     }

--- a/crates/sui-types/src/multisig_legacy.rs
+++ b/crates/sui-types/src/multisig_legacy.rs
@@ -150,9 +150,8 @@ impl TryFrom<MultiSigPublicKeyLegacy> for MultiSigPublicKey {
 
 /// Convert a roaring bitmap to plain bitmap.
 pub fn bitmap_to_u16(roaring: RoaringBitmap) -> Result<u16, FastCryptoError> {
-    let indices: Vec<u32> = roaring.into_iter().collect();
     let mut val = 0;
-    for i in indices {
+    for i in roaring {
         if i >= 10 {
             return Err(FastCryptoError::InvalidInput);
         }


### PR DESCRIPTION
If multiple crypto-provider related features are enabled on `rustls`, it will panic because it doesn't know how to pick a default one. We should not rely on the default, choosing instead fo pick an explicit provider.

CI

---

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework:

## Description 

Describe the changes or additions included in this PR.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
