### PR TITLE
Fix ephemeral port assignment in tests

### DIFF
--- a/crates/mysten-service/src/metrics.rs
+++ b/crates/mysten-service/src/metrics.rs
@@ -8,7 +8,7 @@ use std::net::{IpAddr, Ipv4Addr};
 pub const METRICS_HOST_PORT: u16 = 9184;
 
 /// This is an option if you need to use the underlying method
-pub use mysten_metrics::start_prometheus_server;
+pub use mysten_metrics::{MetricsServer, start_prometheus_server};
 
 /// Use the standard IP (0.0.0.0) and port (9184) to start a new
 /// prometheus server.
@@ -44,5 +44,8 @@ pub use mysten_metrics::start_prometheus_server;
 /// ```
 pub fn start_basic_prometheus_server() -> Registry {
     let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), METRICS_HOST_PORT);
-    mysten_metrics::start_prometheus_server(addr).default_registry()
+    let mysten_metrics::MetricsServer {
+        registry_service, ..
+    } = mysten_metrics::start_prometheus_server(addr);
+    registry_service.default_registry()
 }

--- a/crates/sui-analytics-indexer/src/main.rs
+++ b/crates/sui-analytics-indexer/src/main.rs
@@ -24,7 +24,9 @@ async fn main() -> Result<()> {
     let config: IndexerConfig = serde_yaml::from_str(&std::fs::read_to_string(&args[1])?)?;
     info!("Parsed config: {:#?}", config);
 
-    let registry_service = mysten_metrics::start_prometheus_server(
+    let mysten_metrics::MetricsServer {
+        registry_service, ..
+    } = mysten_metrics::start_prometheus_server(
         format!(
             "{}:{}",
             config.client_metric_host, config.client_metric_port

--- a/crates/sui-benchmark/src/bin/stress.rs
+++ b/crates/sui-benchmark/src/bin/stress.rs
@@ -79,7 +79,9 @@ async fn main() -> Result<()> {
     }
     let _guard = config.with_env().init();
 
-    let registry_service = mysten_metrics::start_prometheus_server(
+    let mysten_metrics::MetricsServer {
+        registry_service, ..
+    } = mysten_metrics::start_prometheus_server(
         format!("{}:{}", opts.client_metric_host, opts.client_metric_port)
             .parse()
             .unwrap(),

--- a/crates/sui-bridge-indexer/src/main.rs
+++ b/crates/sui-bridge-indexer/src/main.rs
@@ -21,7 +21,7 @@ use sui_config::Config;
 use tracing::info;
 
 use mysten_metrics::spawn_logged_monitored_task;
-use mysten_metrics::start_prometheus_server;
+use mysten_metrics::{MetricsServer, start_prometheus_server};
 
 use sui_bridge::metrics::BridgeMetrics;
 use sui_bridge::sui_bridge_watchdog::{
@@ -64,7 +64,9 @@ async fn main() -> Result<()> {
     // Init metrics server
     let metrics_address =
         SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), config.metric_port);
-    let registry_service = start_prometheus_server(metrics_address);
+    let MetricsServer {
+        registry_service, ..
+    } = start_prometheus_server(metrics_address);
     let registry = registry_service.default_registry();
     mysten_metrics::init_metrics(&registry);
     info!("Metrics server started at port {}", config.metric_port);

--- a/crates/sui-bridge/src/main.rs
+++ b/crates/sui-bridge/src/main.rs
@@ -3,7 +3,7 @@
 
 use clap::Parser;
 use fastcrypto::traits::KeyPair;
-use mysten_metrics::start_prometheus_server;
+use mysten_metrics::{MetricsServer, start_prometheus_server};
 use std::{
     net::{IpAddr, Ipv4Addr, SocketAddr},
     path::PathBuf,
@@ -35,7 +35,9 @@ async fn main() -> anyhow::Result<()> {
     // Init metrics server
     let metrics_address =
         SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), config.metrics_port);
-    let registry_service = start_prometheus_server(metrics_address);
+    let MetricsServer {
+        registry_service, ..
+    } = start_prometheus_server(metrics_address);
     let prometheus_registry = registry_service.default_registry();
     mysten_metrics::init_metrics(&prometheus_registry);
     info!("Metrics server started at port {}", config.metrics_port);

--- a/crates/sui-config/src/local_ip_utils.rs
+++ b/crates/sui-config/src/local_ip_utils.rs
@@ -1,7 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::net::SocketAddr;
 #[cfg(msim)]
 use std::sync::{Arc, atomic::AtomicI16};
 use sui_types::multiaddr::Multiaddr;
@@ -120,20 +119,6 @@ pub fn new_udp_address_for_testing(host: &str) -> Multiaddr {
     format!("/ip4/{}/udp/{}", host, get_available_port(host))
         .parse()
         .unwrap()
-}
-
-/// Returns a new unique TCP address in String format for localhost, by finding a new available port on localhost.
-pub fn new_local_tcp_socket_for_testing_string() -> String {
-    format!(
-        "{}:{}",
-        localhost_for_testing(),
-        get_available_port(&localhost_for_testing())
-    )
-}
-
-/// Returns a new unique TCP address (SocketAddr) for localhost, by finding a new available port on localhost.
-pub fn new_local_tcp_socket_for_testing() -> SocketAddr {
-    new_local_tcp_socket_for_testing_string().parse().unwrap()
 }
 
 /// Returns a new unique TCP address (Multiaddr) for localhost, by finding a new available port on localhost.

--- a/crates/sui-kv-rpc/src/main.rs
+++ b/crates/sui-kv-rpc/src/main.rs
@@ -47,7 +47,9 @@ async fn main() -> Result<()> {
         std::env::set_var("GOOGLE_APPLICATION_CREDENTIALS", app.credentials.clone());
     };
     let server_version = Some(ServerVersion::new("sui-kv-rpc", VERSION));
-    let registry_service = mysten_metrics::start_prometheus_server(
+    let mysten_metrics::MetricsServer {
+        registry_service, ..
+    } = mysten_metrics::start_prometheus_server(
         format!("{}:{}", app.metrics_host, app.metrics_port).parse()?,
     );
     let registry: Registry = registry_service.default_registry();

--- a/crates/sui-node/src/metrics.rs
+++ b/crates/sui-node/src/metrics.rs
@@ -147,7 +147,7 @@ impl MetricsCallbackProvider for GrpcMetrics {
 
 #[cfg(test)]
 mod tests {
-    use mysten_metrics::start_prometheus_server;
+    use mysten_metrics::{MetricsServer, start_prometheus_server};
     use prometheus::{IntCounter, Registry};
     use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
@@ -156,7 +156,9 @@ mod tests {
         let port: u16 = 8081;
         let socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), port);
 
-        let registry_service = start_prometheus_server(socket);
+        let MetricsServer {
+            registry_service, ..
+        } = start_prometheus_server(socket);
 
         tokio::task::yield_now().await;
 

--- a/crates/sui-oracle/src/main.rs
+++ b/crates/sui-oracle/src/main.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use clap::Parser;
-use mysten_metrics::start_prometheus_server;
+use mysten_metrics::{MetricsServer, start_prometheus_server};
 use std::path::PathBuf;
 use std::time::Duration;
 use sui_config::Config;
@@ -29,7 +29,9 @@ async fn main() -> anyhow::Result<()> {
         WalletContext::new(&args.client_config_path)?.with_request_timeout(Duration::from_secs(10)); // request times out after 10 secs
 
     // Init metrics server
-    let registry_service = start_prometheus_server(config.metrics_address);
+    let MetricsServer {
+        registry_service, ..
+    } = start_prometheus_server(config.metrics_address);
     let prometheus_registry = registry_service.default_registry();
 
     // Init logging

--- a/crates/sui-security-watchdog/src/main.rs
+++ b/crates/sui-security-watchdog/src/main.rs
@@ -19,7 +19,9 @@ async fn main() -> Result<()> {
     let pd_api_key = env::var("PD_API_KEY").expect("PD_API_KEY env var must be set");
     let sf_password = env::var("SF_PASSWORD").expect("SF_PASSWORD env var must be set");
 
-    let registry_service = mysten_metrics::start_prometheus_server(
+    let mysten_metrics::MetricsServer {
+        registry_service, ..
+    } = mysten_metrics::start_prometheus_server(
         format!(
             "{}:{}",
             config.client_metric_host, config.client_metric_port

--- a/crates/sui-swarm-config/src/genesis_config.rs
+++ b/crates/sui-swarm-config/src/genesis_config.rs
@@ -266,7 +266,7 @@ impl GenesisConfig {
 }
 
 fn default_socket_address() -> SocketAddr {
-    local_ip_utils::new_local_tcp_socket_for_testing()
+    SocketAddr::new(IpAddr::V4(std::net::Ipv4Addr::LOCALHOST), 0)
 }
 
 fn default_multiaddr_address() -> Multiaddr {

--- a/crates/sui-swarm-config/src/node_config_builder.rs
+++ b/crates/sui-swarm-config/src/node_config_builder.rs
@@ -548,7 +548,7 @@ impl FullnodeConfigBuilder {
                 .unwrap_or(validator_config.network_address),
             metrics_address: self
                 .metrics_address
-                .unwrap_or(local_ip_utils::new_local_tcp_socket_for_testing()),
+                .unwrap_or_else(|| SocketAddr::new(localhost.parse().unwrap(), 0)),
             admin_interface_port: self
                 .admin_interface_port
                 .unwrap_or(local_ip_utils::get_available_port(&localhost)),

--- a/crates/sui-swarm/src/memory/node.rs
+++ b/crates/sui-swarm/src/memory/node.rs
@@ -3,6 +3,7 @@
 
 use anyhow::Result;
 use anyhow::anyhow;
+use std::net::SocketAddr;
 use std::sync::Mutex;
 use std::sync::MutexGuard;
 use sui_config::NodeConfig;
@@ -91,6 +92,14 @@ impl Node {
             .unwrap()
             .as_ref()
             .and_then(|c| c.get_node_handle())
+    }
+
+    pub fn metrics_address(&self) -> Option<SocketAddr> {
+        self.container
+            .lock()
+            .unwrap()
+            .as_ref()
+            .and_then(|c| c.metrics_address())
     }
 
     /// Perform a health check on this Node by:

--- a/crates/sui-tool/src/lib.rs
+++ b/crates/sui-tool/src/lib.rs
@@ -835,8 +835,9 @@ pub async fn download_formal_snapshot(
     }
 
     // Start prometheus server so that we can serve metrics during snapshot download
-    let registry_service =
-        mysten_metrics::start_prometheus_server("127.0.0.1:9184".parse().unwrap());
+    let mysten_metrics::MetricsServer {
+        registry_service, ..
+    } = mysten_metrics::start_prometheus_server("127.0.0.1:9184".parse().unwrap());
     let prometheus_registry = registry_service.default_registry();
     DBMetrics::init(registry_service.clone());
     mysten_metrics::init_metrics(&prometheus_registry);


### PR DESCRIPTION
## Description

I have run into metric port conflicts causing panics in tests across multiple services and finally got annoyed enough to root cause and fix it. The old local_ip_utils code had a toctou race where it would find an open port, then bind to it. If multiple tests found the same open port, only the first could actually bind to it.

I changed the TestCluster to just be configured to use port 0 so an ephemeral port is assigned. I also plumbed the listen addr with the assigned port all the way up to the node object so we can actually inspect the metrics port from tests in the future.
