### PR TITLE
fix(graphql): detect transaction payloads

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_execute_transaction_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_execute_transaction_tests.rs
@@ -112,6 +112,42 @@ struct GraphQlTestCluster {
 }
 
 impl GraphQlTestCluster {
+    async fn new(validator_cluster: &TestCluster) -> Self {
+        let graphql_port = get_available_port();
+        let graphql_listen_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), graphql_port);
+
+        let graphql_args = GraphQlArgs {
+            rpc_listen_address: graphql_listen_address,
+            no_ide: true,
+        };
+
+        let fullnode_args = FullnodeArgs {
+            fullnode_rpc_url: Some(validator_cluster.rpc_url().to_string()),
+        };
+
+        // Start GraphQL server that connects directly to TestCluster's RPC
+        let service = start_graphql(
+            None, // No database - GraphQL will use fullnode RPC for executeTransaction
+            fullnode_args,
+            DbArgs::default(),
+            GraphQlKvArgs::default(),
+            ConsistentReaderArgs::default(),
+            graphql_args,
+            SystemPackageTaskArgs::default(),
+            "0.0.0",
+            GraphQlConfig::default(),
+            vec![], // No pipelines since we're not using database
+            &Registry::new(),
+        )
+        .await
+        .expect("Failed to start GraphQL server");
+
+        let url = Url::parse(&format!("http://{graphql_listen_address}/graphql"))
+            .expect("Failed to parse GraphQL URL");
+
+        Self { url, service }
+    }
+
     /// Execute a GraphQL mutation or query
     async fn execute_graphql(&self, query: &str, variables: Value) -> anyhow::Result<Value> {
         let request_body = json!({
@@ -136,58 +172,6 @@ impl GraphQlTestCluster {
     }
 }
 
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct ObjectChangeNode {
-    id_created: bool,
-    id_deleted: bool,
-    input_state: Option<ObjectState>,
-    output_state: Option<ObjectState>,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct ObjectState {
-    version: u64,
-    as_move_object: Option<Value>,
-}
-
-async fn create_graphql_test_cluster(validator_cluster: &TestCluster) -> GraphQlTestCluster {
-    let graphql_port = get_available_port();
-    let graphql_listen_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), graphql_port);
-
-    let graphql_args = GraphQlArgs {
-        rpc_listen_address: graphql_listen_address,
-        no_ide: true,
-    };
-
-    let fullnode_args = FullnodeArgs {
-        fullnode_rpc_url: Some(validator_cluster.rpc_url().to_string()),
-    };
-
-    // Start GraphQL server that connects directly to TestCluster's RPC
-    let service = start_graphql(
-        None, // No database - GraphQL will use fullnode RPC for executeTransaction
-        fullnode_args,
-        DbArgs::default(),
-        GraphQlKvArgs::default(),
-        ConsistentReaderArgs::default(),
-        graphql_args,
-        SystemPackageTaskArgs::default(),
-        "0.0.0",
-        GraphQlConfig::default(),
-        vec![], // No pipelines since we're not using database
-        &Registry::new(),
-    )
-    .await
-    .expect("Failed to start GraphQL server");
-
-    let url = Url::parse(&format!("http://{}/graphql", graphql_listen_address))
-        .expect("Failed to parse GraphQL URL");
-
-    GraphQlTestCluster { url, service }
-}
-
 #[sim_test]
 async fn test_execute_transaction_mutation_schema() {
     let validator_cluster = TestClusterBuilder::new()
@@ -195,7 +179,7 @@ async fn test_execute_transaction_mutation_schema() {
         .build()
         .await;
 
-    let graphql_cluster = create_graphql_test_cluster(&validator_cluster).await;
+    let graphql_cluster = GraphQlTestCluster::new(&validator_cluster).await;
 
     // Create a simple transfer transaction for testing
     let recipient = SuiAddress::random_for_testing_only();
@@ -266,7 +250,7 @@ async fn test_execute_transaction_input_validation() {
         .with_num_validators(1)
         .build()
         .await;
-    let graphql_cluster = create_graphql_test_cluster(&validator_cluster).await;
+    let graphql_cluster = GraphQlTestCluster::new(&validator_cluster).await;
 
     // Test invalid Base64 transaction data
     let result = graphql_cluster
@@ -297,7 +281,7 @@ async fn test_execute_transaction_with_events() {
         .enable_fullnode_events()
         .build()
         .await;
-    let graphql_cluster = create_graphql_test_cluster(&validator_cluster).await;
+    let graphql_cluster = GraphQlTestCluster::new(&validator_cluster).await;
 
     // Publish our test package which emits events in its init function
     let path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("packages/emit_event");
@@ -374,7 +358,7 @@ async fn test_execute_transaction_grpc_errors() {
         .with_num_validators(1)
         .build()
         .await;
-    let graphql_cluster = create_graphql_test_cluster(&validator_cluster).await;
+    let graphql_cluster = GraphQlTestCluster::new(&validator_cluster).await;
 
     // Create signature mismatch scenario: use transaction data from one tx with signatures from another
     let recipient1 = SuiAddress::random_for_testing_only();
@@ -429,7 +413,7 @@ async fn test_execute_transaction_unchanged_consensus_objects() {
         .with_num_validators(1)
         .build()
         .await;
-    let graphql_cluster = create_graphql_test_cluster(&validator_cluster).await;
+    let graphql_cluster = GraphQlTestCluster::new(&validator_cluster).await;
 
     // Create a read-only transaction that accesses the Clock object
     let mut tx_builder = validator_cluster.test_transaction_builder().await;
@@ -522,7 +506,7 @@ async fn test_execute_transaction_unchanged_consensus_objects() {
 #[sim_test]
 async fn test_execute_transaction_object_changes_input_output() {
     let validator_cluster = TestClusterBuilder::new().build().await;
-    let graphql_cluster = create_graphql_test_cluster(&validator_cluster).await;
+    let graphql_cluster = GraphQlTestCluster::new(&validator_cluster).await;
 
     // Create a transfer transaction that will modify objects
     let recipient = SuiAddress::random_for_testing_only();
@@ -589,6 +573,22 @@ async fn test_execute_transaction_object_changes_input_output() {
     // Verify the transaction succeeded
     assert_eq!(effects.status, "SUCCESS");
 
+    #[derive(Debug, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct ObjectChangeNode {
+        id_created: bool,
+        id_deleted: bool,
+        input_state: Option<ObjectState>,
+        output_state: Option<ObjectState>,
+    }
+
+    #[derive(Debug, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct ObjectState {
+        version: u64,
+        as_move_object: Option<Value>,
+    }
+
     // Use pointer to navigate to object changes and deserialize directly
     let object_changes_value = result
         .pointer("/data/executeTransaction/effects/objectChanges/nodes")
@@ -653,7 +653,7 @@ async fn test_execute_transaction_effects_json() {
         .with_num_validators(1)
         .build()
         .await;
-    let graphql_cluster = create_graphql_test_cluster(&validator_cluster).await;
+    let graphql_cluster = GraphQlTestCluster::new(&validator_cluster).await;
 
     // Create a transfer transaction
     let recipient = SuiAddress::random_for_testing_only();
@@ -706,12 +706,66 @@ async fn test_execute_transaction_effects_json() {
 }
 
 #[sim_test]
+async fn test_execute_transaction_payload_bypasses_query_limit() {
+    let validator_cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
+    let graphql_cluster = GraphQlTestCluster::new(&validator_cluster).await;
+
+    let mut tx_builder = validator_cluster.test_transaction_builder().await;
+    let payload_size = GraphQlConfig::default().limits.max_query_payload_size;
+    tx_builder
+        .ptb_builder_mut()
+        .pure_bytes(vec![0u8; payload_size as usize], false);
+
+    let tx_data = tx_builder.build();
+    let signed_tx = validator_cluster.sign_transaction(&tx_data).await;
+    let (tx_bytes, signatures) = signed_tx.to_tx_bytes_and_signatures();
+
+    let result = graphql_cluster
+        .execute_graphql(
+            r#"
+            mutation($txData: Base64!, $sigs: [Base64!]!) {
+                executeTransaction(transactionDataBcs: $txData, signatures: $sigs) {
+                    effects { status }
+                    errors
+                }
+            }
+        "#,
+            json!({
+                "txData": tx_bytes.encoded(),
+                "sigs": signatures.iter().map(|s| s.encoded()).collect::<Vec<_>>()
+            }),
+        )
+        .await
+        .expect("GraphQL request failed");
+
+    let effects = result.pointer("/data/executeTransaction/effects");
+    assert!(
+        effects.is_some_and(|effects| !effects.is_null()),
+        "Expected executeTransaction effects in response"
+    );
+    assert!(
+        effects
+            .and_then(|effects| effects.pointer("/status"))
+            .and_then(|status| status.as_str())
+            .is_some(),
+        "Expected executeTransaction status to be populated"
+    );
+    assert_eq!(
+        result.pointer("/data/executeTransaction/errors"),
+        Some(&serde_json::Value::Null)
+    );
+}
+
+#[sim_test]
 async fn test_execute_transaction_transaction_json() {
     let validator_cluster = TestClusterBuilder::new()
         .with_num_validators(1)
         .build()
         .await;
-    let graphql_cluster = create_graphql_test_cluster(&validator_cluster).await;
+    let graphql_cluster = GraphQlTestCluster::new(&validator_cluster).await;
 
     // Create a transfer transaction
     let recipient = SuiAddress::random_for_testing_only();

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_simulate_transaction_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_simulate_transaction_tests.rs
@@ -1239,6 +1239,52 @@ async fn test_simulate_transaction_effects_json() {
 }
 
 #[tokio::test]
+async fn test_simulate_transaction_payload_bypasses_query_limit() {
+    let validator_cluster = TestClusterBuilder::new().build().await;
+    let graphql_cluster = GraphQlTestCluster::new(&validator_cluster).await;
+
+    let mut tx_builder = validator_cluster.test_transaction_builder().await;
+    let payload_size = GraphQlConfig::default().limits.max_query_payload_size;
+    tx_builder
+        .ptb_builder_mut()
+        .pure_bytes(vec![0u8; payload_size as usize], false);
+
+    let tx_data = tx_builder.build();
+    let signed_tx = validator_cluster.sign_transaction(&tx_data).await;
+    let (tx_bytes, _signatures) = signed_tx.to_tx_bytes_and_signatures();
+
+    let result = graphql_cluster
+        .execute_graphql(
+            r#"
+            query($txData: JSON!) {
+                simulateTransaction(transaction: $txData) {
+                    effects { status }
+                    error
+                }
+            }
+        "#,
+            json!({
+                "txData": {
+                    "bcs": {
+                        "value": tx_bytes.encoded()
+                    }
+                }
+            }),
+        )
+        .await
+        .expect("GraphQL request failed");
+
+    assert_eq!(
+        result.pointer("/data/simulateTransaction/effects/status"),
+        Some(&json!("SUCCESS"))
+    );
+    assert_eq!(
+        result.pointer("/data/simulateTransaction/error"),
+        Some(&serde_json::Value::Null)
+    );
+}
+
+#[tokio::test]
 async fn test_simulate_transaction_transaction_json() {
     let validator_cluster = TestClusterBuilder::new().build().await;
     let graphql_cluster = GraphQlTestCluster::new(&validator_cluster).await;

--- a/crates/sui-indexer-alt-graphql/src/config.rs
+++ b/crates/sui-indexer-alt-graphql/src/config.rs
@@ -279,11 +279,11 @@ impl Limits {
             max_query_payload_size: self.max_query_payload_size,
             max_tx_payload_size: self.max_tx_payload_size,
             tx_payload_args: BTreeSet::from([
-                ("Mutation", "executeTransaction", "txBytes"),
+                ("Mutation", "executeTransaction", "transactionDataBcs"),
                 ("Mutation", "executeTransaction", "signatures"),
                 ("Query", "simulateTransaction", "transaction"),
-                ("Query", "verifyZkloginSignature", "bytes"),
-                ("Query", "verifyZkloginSignature", "signature"),
+                ("Query", "verifyZkLoginSignature", "bytes"),
+                ("Query", "verifyZkLoginSignature", "signature"),
             ]),
         }
     }


### PR DESCRIPTION
## Description

Configuration for the type/field/parameters that can contain transaction payloads was stale (both for `Mutation.executeTransaction` and for `Query.verifyZkLoginSignature`), which meant that transactions that were larger than the smaller query payload size were being incorrectly rejected.

## Test plan

E2E tests have been updated to handle the case where the transaction is larger than the query payload size:

```
$ cargo nextest run -p sui-indexer-alt-e2e-tests \
  --test graphql_execute_transaction_tests \
  --test graphql_simulate_transaction_tests \
  --test graphql_zklogin_tests
```

This change also includes some clean-ups for those E2E tests:

- Standardize `GraphQlTestCluster` across tests.
- Remove telemetry calls, to reduce CI output

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
