### PR TITLE
[move-ide] Fixed crash when module extension extends user module

### DIFF
--- a/external-crates/move/crates/move-analyzer/src/symbols/compilation.rs
+++ b/external-crates/move/crates/move-analyzer/src/symbols/compilation.rs
@@ -1055,7 +1055,55 @@ fn is_typed_mod_modified(
         debug_assert!(false);
         return false;
     };
-    modified_files.contains(mod_file_path)
+    if modified_files.contains(mod_file_path) {
+        return true;
+    }
+
+    // TODO: Module extensions are not fully supported yet. This check prevents a crash but
+    // doesn't provide full IDE support for extension members.
+    //
+    // When both the extended module and extension are in user space, extension members get
+    // inlined into the extended module during expansion. If only the extension file is modified,
+    // the extended module's definition location (checked above) appears unchanged. Without
+    // checking member locations, we'd use stale cached data with incorrect file hashes.
+    //
+    // This is NOT a problem when the extended module is a dependency (pre-compiled lib) because
+    // extensions cannot be applied to pre-compiled modules - they lack the expansion-level AST
+    // needed for inlining.
+    let is_member_modified = |loc: &Loc| -> bool {
+        let Some(member_file_path) = file_paths.get(&loc.file_hash()) else {
+            eprintln!(
+                "no file path for member in typed module {}",
+                mident.value.module
+            );
+            debug_assert!(false);
+            return false;
+        };
+        modified_files.contains(member_file_path)
+    };
+
+    for (name_loc, _, _) in &mdef.functions {
+        if is_member_modified(&name_loc) {
+            return true;
+        }
+    }
+    for (name_loc, _, _) in &mdef.structs {
+        if is_member_modified(&name_loc) {
+            return true;
+        }
+    }
+    for (name_loc, _, _) in &mdef.enums {
+        if is_member_modified(&name_loc) {
+            return true;
+        }
+    }
+    for (name_loc, _, _) in &mdef.constants {
+        if is_member_modified(&name_loc) {
+            return true;
+        }
+    }
+
+    false
 }
 
 /// Checks if any of the package modules's were modified.

--- a/external-crates/move/crates/move-analyzer/tests/module-ext/Move.toml
+++ b/external-crates/move/crates/move-analyzer/tests/module-ext/Move.toml
@@ -1,0 +1,11 @@
+[package]
+name = "ModuleExt"
+edition = "2024.alpha"
+
+[dependencies]
+MoveStdlib = { local = "../../../move-stdlib/", addr_subst = { "std" = "0x1" } }
+ModIdentUniform = { local = "../mod-ident-uniform/" }
+
+[addresses]
+ParseError = "0xCAFE"
+ModuleExt = "0x0"

--- a/external-crates/move/crates/move-analyzer/tests/module-ext/sources/M1.move
+++ b/external-crates/move/crates/move-analyzer/tests/module-ext/sources/M1.move
@@ -1,0 +1,18 @@
+module ModuleExt::M1 {
+
+    #[test]
+    fun test() {
+        ModuleExt::M2::bar();
+        Symbols::M1::baz();
+    }
+}
+
+#[test_only]
+extend module ModuleExt::M2 {
+    public fun bar(): u64 { 7 }
+}
+
+#[test_only]
+extend module ModIdentUniform::M1 {
+    public fun baz(): u64 { 7 }
+}

--- a/external-crates/move/crates/move-analyzer/tests/module-ext/sources/M2.move
+++ b/external-crates/move/crates/move-analyzer/tests/module-ext/sources/M2.move
@@ -1,0 +1,6 @@
+module ModuleExt::M2 {
+    public fun foo(): u64 { 42 }
+}
+
+
+

--- a/external-crates/move/crates/move-analyzer/tests/module_ext.ide
+++ b/external-crates/move/crates/move-analyzer/tests/module_ext.ide
@@ -1,0 +1,26 @@
+// Tests if definition in extended module is recognized
+{
+  "UseDef": {
+    "project": "tests/module-ext",
+    "file_tests": {
+      "M1.move": [
+        {
+          "use_line": 5,
+          "use_ndx": 1
+        },
+        {
+          "use_line": 6,
+          "use_ndx": 1
+        },
+        {
+          "use_line": 12,
+          "use_ndx": 0
+        },
+        {
+          "use_line": 17,
+          "use_ndx": 0
+        }        
+      ]
+    }
+  }
+}

--- a/external-crates/move/crates/move-analyzer/tests/module_ext.snap
+++ b/external-crates/move/crates/move-analyzer/tests/module_ext.snap
@@ -1,0 +1,149 @@
+---
+source: crates/move-analyzer/tests/ide_testsuite.rs
+---
+== M1.move ========================================================
+-- test 0 -------------------
+use line: 5, use_ndx: 1
+Use: 'bar', start: 23, end: 26
+Def: 'bar', line: 11, def char: 15
+TypeDef: no info
+On Hover:
+public fun ModuleExt::M2::bar(): u64
+
+-- test 1 -------------------
+use line: 6, use_ndx: 1
+ERROR: No use_line 6 in mod_symbols UseDefMap(
+    {
+        0: {
+            UseDef {
+                col_start: 18,
+                col_end: 20,
+                def_loc: Loc {
+                    file_hash: "08aa457b92acf8f968cfb3acea2e3c75a2d69c5e32dba19a2a2015dacddfc5f1",
+                    start: 7,
+                    end: 20,
+                },
+                type_def_loc: None,
+            },
+        },
+        3: {
+            UseDef {
+                col_start: 8,
+                col_end: 12,
+                def_loc: Loc {
+                    file_hash: "08aa457b92acf8f968cfb3acea2e3c75a2d69c5e32dba19a2a2015dacddfc5f1",
+                    start: 44,
+                    end: 48,
+                },
+                type_def_loc: None,
+            },
+        },
+        4: {
+            UseDef {
+                col_start: 19,
+                col_end: 21,
+                def_loc: Loc {
+                    file_hash: "ba589af83dd8a9f0fe078b09dd620741847edc5913b1089e1bb5587bbc746e49",
+                    start: 7,
+                    end: 20,
+                },
+                type_def_loc: None,
+            },
+            UseDef {
+                col_start: 23,
+                col_end: 26,
+                def_loc: Loc {
+                    file_hash: "08aa457b92acf8f968cfb3acea2e3c75a2d69c5e32dba19a2a2015dacddfc5f1",
+                    start: 178,
+                    end: 181,
+                },
+                type_def_loc: None,
+            },
+        },
+        11: {
+            UseDef {
+                col_start: 15,
+                col_end: 18,
+                def_loc: Loc {
+                    file_hash: "08aa457b92acf8f968cfb3acea2e3c75a2d69c5e32dba19a2a2015dacddfc5f1",
+                    start: 178,
+                    end: 181,
+                },
+                type_def_loc: None,
+            },
+        },
+    },
+) for file M1.move
+
+-- test 2 -------------------
+use line: 12, use_ndx: 0
+Use: 'bar', start: 15, end: 18
+Def: 'bar', line: 11, def char: 15
+TypeDef: no info
+On Hover:
+public fun ModuleExt::M2::bar(): u64
+
+-- test 3 -------------------
+use line: 17, use_ndx: 0
+ERROR: No use_line 17 in mod_symbols UseDefMap(
+    {
+        0: {
+            UseDef {
+                col_start: 18,
+                col_end: 20,
+                def_loc: Loc {
+                    file_hash: "08aa457b92acf8f968cfb3acea2e3c75a2d69c5e32dba19a2a2015dacddfc5f1",
+                    start: 7,
+                    end: 20,
+                },
+                type_def_loc: None,
+            },
+        },
+        3: {
+            UseDef {
+                col_start: 8,
+                col_end: 12,
+                def_loc: Loc {
+                    file_hash: "08aa457b92acf8f968cfb3acea2e3c75a2d69c5e32dba19a2a2015dacddfc5f1",
+                    start: 44,
+                    end: 48,
+                },
+                type_def_loc: None,
+            },
+        },
+        4: {
+            UseDef {
+                col_start: 19,
+                col_end: 21,
+                def_loc: Loc {
+                    file_hash: "ba589af83dd8a9f0fe078b09dd620741847edc5913b1089e1bb5587bbc746e49",
+                    start: 7,
+                    end: 20,
+                },
+                type_def_loc: None,
+            },
+            UseDef {
+                col_start: 23,
+                col_end: 26,
+                def_loc: Loc {
+                    file_hash: "08aa457b92acf8f968cfb3acea2e3c75a2d69c5e32dba19a2a2015dacddfc5f1",
+                    start: 178,
+                    end: 181,
+                },
+                type_def_loc: None,
+            },
+        },
+        11: {
+            UseDef {
+                col_start: 15,
+                col_end: 18,
+                def_loc: Loc {
+                    file_hash: "08aa457b92acf8f968cfb3acea2e3c75a2d69c5e32dba19a2a2015dacddfc5f1",
+                    start: 178,
+                    end: 181,
+                },
+                type_def_loc: None,
+            },
+        },
+    },
+) for file M1.move


### PR DESCRIPTION
## Description 

While working on a full module extension fix we at least want to prevent `move-analyzer` from crashing when someone tries to work on a module extension in the IDE.

One such problem was addressed in https://github.com/MystenLabs/sui/pull/25078 and another one (and hopefully the last one) in this PR. The following is also included as a (TODO) comment in the code.

When both the extended module and extension are in user space, extension members get inlined into the extended module during expansion. If only the extension file is modified, the extended module's definition location (checked above) appears unchanged. Without checking member locations, we'd use stale cached data with incorrect file hashes.

This is NOT a problem when the extended module is a dependency (pre-compiled lib) because extensions cannot be applied to pre-compiled modules - they lack the expansion-level AST needed for inlining.

## Test plan 

Added an extra test that was crashing before this PR and now runs to completion. The result is still incorrect of course as we do not have full support for module extensions.
