### PR TITLE
Add a skill for simtest debugging

### DIFF
--- a/.claude/skills/simtest-debug/SKILL.md
+++ b/.claude/skills/simtest-debug/SKILL.md
@@ -1,0 +1,66 @@
+# Debug a simtest failure
+
+Debugs a simtest failure using logging and the scientific method.
+
+## Usage
+
+```
+/debug-simtest <repro command>
+```
+
+Example: `/debug-simtest "MSIM_TEST_SEED=1768248386016 RUST_LOG=sui=debug,info cargo simtest --test address_balance_tests test_deposit_and_withdraw"`
+
+## Arguments
+
+$ARGUMENTS should contain a single quoted string which is a command to run to reproduce the test failure.
+
+## Instructions
+
+This skill logs its progress to a file called NOTEBOOK.md in the repo root. The file should look like
+
+```
+# iteration 1
+- OBSERVATIONS
+  - <observation 1>
+  - <observation 2>
+  - ...
+- HYPOTHESIS: <description of hypothesis>
+- EXPERIMENT: <description of experiment>
+- RESULTS: <did the experiment confirm or refute the hypothesis?>
+
+# iteration 2
+<more observations, hypothesis, etc>
+```
+
+While executing the skill, never make functional changes to the code.  Only add logging statements as described below.  The goal is to find the root cause, not fix the issue.
+If at any point the reproduction command stops failing, or fails in a different way, this indicates that functional changes have been made. The test is deterministic and cannot
+be affected by emitting logs, doing expensive computations, etc.
+
+Execute the following steps:
+
+### 1. Ask the user for a description of the failure and any additional useful context.
+
+### 2. Run the test.
+Run the test as given in the commandline. If `RUST_LOG=...` is missing, add `RUST_LOG=sui=debug,info`. if `--no-capture` is missing, add it.
+Redirect the test output to a file. Do not run the test in the background or use a timeout. It may run for a long time, but it will finish.
+
+### 3. Examine the output and make observations.
+Use grep and other tools to examine the output log (which will be very large). Summarize your observations to NOTEBOOK.md.
+
+### 4. Form a hypothesis
+
+Based on the observations, form a hypothesis. Check if the hypothesis has not been ruled out by prior experiments. record it to NOTEBOOK.md.
+
+### 5. Plan an experiment
+
+An "experiment" consists of adding logging statments to the code which can confirm or refute the hypothesis. All logging statements should be of the form `info!("CLAUDE: ...")` so that you can grep for them easily.
+Summarize the experiment to NOTEBOOK.md
+
+### 6. Run and evaluate the experiment
+after adding logs to the code, run the reproduction command again. Determine whether the hypothesis was confirmed or refuted by the observations.
+Record the results of the experiment to NOTEBOOK.md.
+
+### 7. Decide whether we have found the root cause
+if a hypothesis has been confirmed, determine if it is the root cause.  If so, the debugging is complete. Summarize the results to the user.
+
+Otherwise, if the hypothesis is refuted, or if it is not a root cause, return to step 3, and form a new hypothesis consistent with previous hypotheses.  Repeat all steps until we find the root cause.


### PR DESCRIPTION
A claude skill that can debug simtest failures

An example NOTEBOOK.md from testing this:

```
# Simtest Debug: test_simulated_load_rolling_restarts_all_validators

Reproduction command: `RUST_LOG=sui=debug,info MSIM_TEST_SEED=1768586715031 cargo simtest --test simtest test_simulated_load_rolling_restarts_all_validators`

# iteration 1
- OBSERVATIONS
  - Test times out waiting for cluster to reach epoch 1
  - 4 validators: k#addeef94 (node 11), k#b3fd5efb (node 12), k#99f25ef6 (node 13), k#8dcff6d1 (node 14)
  - Node 11 (k#addeef94) keeps submitting EndOfPublish but it never gets committed
  - Log shows: "Still waiting 30 seconds for transactions [External(EndOfPublish(k#addeef94..))] to commit in consensus"
  - EndOfPublish from k#99f25ef6 and k#b3fd5efb were received at consensus rounds 277 and 278
  - EndOfPublish from k#addeef94 was NEVER received by consensus

- HYPOTHESIS: Initial hypothesis was wrong about the test cluster not calling close_epoch. The actual issue is that node 11's EndOfPublish submission is not being included in consensus blocks.

- EXPERIMENT: Added logging to trace close_epoch and should_send_end_of_publish calls.

- RESULTS: Confirmed that close_epoch IS called on 3 validators (11, 12, 13), and they all submit EndOfPublish. But only 2 (k#99f25ef6 and k#b3fd5efb) have their EndOfPublish committed by consensus.

# iteration 2

- OBSERVATIONS (more detailed analysis of node 11):
  - Node 11 (k#addeef94) restart timeline:
    - 07:40:23.066316: Node 11 starts (3rd restart in rolling restart sequence)
    - 07:40:23.066367: Consensus core recovery with last proposed block at round 91
    - 07:40:23.566369: "Last known proposed round set to 91"
  - When EndOfPublish was committed for other validators:
    - 07:41:27.407164: EndOfPublish from k#99f25ef6 received at consensus round 277
    - 07:41:27.621415: EndOfPublish from k#b3fd5efb received at consensus round 278
  - Node 11's consensus state at 07:41:23.713059:
    - Processing round 253 (still catching up from round 91)
  - Node 11 IS submitting transactions to consensus (including EndOfPublish)
  - But its EndOfPublish never appears in committed blocks

- HYPOTHESIS: Node 11's consensus instance recovered with last proposed block at round 91, but the network is at round 270+. Node 11's consensus is catching up via state sync (checkpoint syncing) rather than actively participating in block proposal. When it submits EndOfPublish to its local consensus, the transaction is queued but node 11 is not producing blocks that include it because:
  1. It may not be proposing blocks at the current round
  2. Its proposals may not be included because it's behind

This is a consensus liveness issue where a catching-up node's transactions are not being committed.

- EXPERIMENT: Add logging to understand:
  1. Whether node 11's consensus is actually proposing blocks
  2. What blocks are being committed around rounds 277-280
  3. Whether node 11's EndOfPublish transaction is being included in any block proposals

- RESULTS:
  - Node 11's ThresholdClock recovered at round 1 (not the expected round 170+)
  - Node 11's last_known_proposed_round is set to 91
  - Node 11's consensus NEVER produces any new blocks (no "ThresholdClock advanced" logs seen)
  - Without producing blocks, node 11's EndOfPublish transaction cannot be committed

# iteration 3

- OBSERVATIONS (root cause analysis of ThresholdClock issue):
  - Node 11's consensus DAG state:
    - ThresholdClock initialized at round 1 (dag_state.rs:119) regardless of recovery state
    - Core recovery completed with last proposed block B105 at round 105
    - last_known_proposed_round set to 91
  - Commit syncer is actively fetching and syncing commits:
    - synced_commit_index progresses: 169 → 179 → 189 → ... → 244
    - quorum_commit_index is 255-264
    - highest_scheduled_index reaches 264
  - Key finding: ThresholdClock never advances despite commit syncer adding blocks

- HYPOTHESIS: The root cause is a ThresholdClock initialization bug:
  1. When a node restarts, ThresholdClock is ALWAYS initialized to round 1 (dag_state.rs:119)
  2. When commit_syncer fetches commits and adds blocks via `try_accept_committed_blocks`:
     - It calls `dag_state.accept_blocks()` which should update the ThresholdClock
     - However, `accept_block()` (dag_state.rs:290-292) returns early if block already exists in storage
     - Blocks from before the crash ARE in storage, so they don't update the ThresholdClock
  3. For blocks that ARE new (produced while node 11 was down):
     - These should be accepted and advance the ThresholdClock
     - But the ThresholdClock stays at round 1
  4. Because ThresholdClock stays at round 1, and the node's should_propose() check (core.rs:938-981):
     - Requires `clock_round > last_known_proposed_round` (91)
     - clock_round = threshold_clock_round = 1
     - 1 <= 91, so the node NEVER proposes new blocks
  5. Without proposing blocks, node 11's EndOfPublish transaction is never included in any block
  6. The epoch change waits for EndOfPublish from quorum (3 validators), but can only get 2

  This is a consensus liveness bug where a catching-up node's ThresholdClock doesn't properly
  advance, preventing it from ever proposing blocks and including its pending transactions.

- EXPERIMENT: Add logging to confirm:
  1. Whether blocks from commit_syncer are hitting the "already exists" path in accept_block
  2. What the actual clock_round is when should_propose is called
  3. Whether the ThresholdClock.add_block method is being called for new blocks

- RESULTS: HYPOTHESIS WAS WRONG!
  - ThresholdClock IS advancing properly: 1 → 165 → 170 → ... → 538
  - Blocks ARE being accepted as NEW blocks
  - ThresholdClock.add_block IS being called and advancing the clock
  - So the ThresholdClock is NOT the issue

# iteration 4 - ROOT CAUSE FOUND

- OBSERVATIONS:
  - Added logging to should_propose() and found the actual cause
  - Node 11's should_propose() is being called with:
    - clock_round = 170-538 (properly advancing)
    - last_known_proposed_round = 91
  - BUT: should_propose() is SKIPPING due to HIGH PROPAGATION DELAY
  - Logs show: "should_propose SKIPPING due to high propagation delay 14 > 2"

- ROOT CAUSE:
  1. When node 11 restarts, it recovers with last_proposed_round around 105
  2. The round_prober calculates propagation_delay as:
     `propagation_delay = last_proposed_round - quorum_received_rounds[own_index]`
  3. Since node 11 was down, the quorum hasn't received its recent blocks
     The difference is 105 - 91 = 14 rounds of delay
  4. propagation_delay_stop_proposal_threshold = 2 (from consensus parameters)
  5. Since 14 > 2, should_propose() returns false
  6. Node 11 NEVER proposes any blocks, even though:
     - ThresholdClock is properly advancing
     - clock_round > last_known_proposed_round would normally allow proposing
  7. Without proposing blocks, node 11 cannot include its EndOfPublish transaction
  8. The epoch change requires quorum (3) validators' EndOfPublish, but can only get 2

- ANALYSIS: This is a consensus LIVENESS BUG in the propagation delay mechanism:
  - The propagation delay check is designed to prevent slow validators from proposing
  - But it creates a deadlock for catching-up nodes:
    - Node can't reduce propagation delay without proposing blocks
    - Node can't propose blocks due to high propagation delay
  - The node is stuck forever with propagation_delay = 14

- RELEVANT CODE:
  - consensus/core/src/core.rs:938-981 - should_propose() with propagation delay check
  - consensus/core/src/round_tracker.rs:98-172 - calculate_propagation_delay()
  - Threshold: propagation_delay_stop_proposal_threshold = 2 (consensus parameters)

- POTENTIAL FIXES (not implementing, just documenting):
  1. Reset propagation_delay to 0 after successful commit sync catch-up
  2. Add a "catch-up mode" that bypasses the propagation delay check
  3. Use a different metric for catching-up nodes (e.g., threshold clock vs last proposed)
  4. Gradually decrease propagation delay over time if node is synced
```