### PR TITLE
Optimize CrashRecoverySchedule instance selection

### DIFF
--- a/crates/sui-aws-orchestrator/src/faults.rs
+++ b/crates/sui-aws-orchestrator/src/faults.rs
@@ -124,7 +124,7 @@ impl CrashRecoverySchedule {
             FaultsType::Permanent { faults } => {
                 if self.dead == 0 {
                     self.dead = *faults;
-                    CrashRecoveryAction::kill(self.instances.clone().drain(0..*faults).collect())
+                    CrashRecoveryAction::kill(self.instances[0..*faults].to_vec())
                 } else {
                     CrashRecoveryAction::no_op()
                 }
@@ -136,7 +136,7 @@ impl CrashRecoverySchedule {
 
                 // Recover all nodes if we already crashed them all.
                 if self.dead == *max_faults {
-                    let instances: Vec<_> = self.instances.clone().drain(0..*max_faults).collect();
+                    let instances: Vec<_> = self.instances[0..*max_faults].to_vec();
                     self.dead = 0;
                     CrashRecoveryAction::boot(instances)
                 }
@@ -150,7 +150,7 @@ impl CrashRecoverySchedule {
                         (2 * min_faults, *max_faults)
                     };
 
-                    let instances: Vec<_> = self.instances.clone().drain(l..h).collect();
+                    let instances: Vec<_> = self.instances[l..h].to_vec();
                     self.dead += h - l;
                     CrashRecoveryAction::kill(instances)
                 }


### PR DESCRIPTION
Previously CrashRecoverySchedule::update cloned the entire instances vector and then drained a subrange, causing unnecessary O(n) allocations and copies of all Instance values on every update tick.

This change replaces self.instances.clone().drain(..).collect() with self.instances[range].to_vec() for the relevant ranges, preserving behavior and panic semantics while only cloning the actually needed subset of instances.