### PR TITLE
sui-indexer-alt: Add metrics for connection pool acquisition attempts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16402,6 +16402,7 @@ dependencies = [
  "diesel-async",
  "diesel_migrations",
  "futures",
+ "prometheus",
  "rustls 0.23.31",
  "scoped-futures",
  "sui-field-count",

--- a/crates/sui-indexer-alt-reader/src/pg_reader.rs
+++ b/crates/sui-indexer-alt-reader/src/pg_reader.rs
@@ -52,7 +52,8 @@ impl PgReader {
         let db = if let Some(database_url) = database_url {
             let db = db::Db::for_read(database_url, db_args)
                 .await
-                .context("Failed to create database for reading")?;
+                .context("Failed to create database for reading")?
+                .register_metrics(prefix, registry)?;
 
             registry
                 .register(Box::new(DbConnectionStatsCollector::new(

--- a/crates/sui-pg-db/Cargo.toml
+++ b/crates/sui-pg-db/Cargo.toml
@@ -16,6 +16,7 @@ diesel = { workspace = true, features = ["chrono"] }
 diesel-async = { workspace = true, features = ["bb8", "postgres", "async-connection-wrapper"] }
 diesel_migrations.workspace = true
 futures.workspace = true
+prometheus.workspace = true
 rustls.workspace = true
 scoped-futures.workspace = true
 tempfile.workspace = true

--- a/crates/sui-pg-db/src/metrics/mod.rs
+++ b/crates/sui-pg-db/src/metrics/mod.rs
@@ -1,0 +1,44 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use prometheus::IntCounter;
+use prometheus::Registry;
+use prometheus::register_int_counter_with_registry;
+use std::sync::Arc;
+
+pub struct PoolMetrics {
+    pub requested: IntCounter,
+    pub acquired: IntCounter,
+    pub unacquired_error: IntCounter,
+    pub unacquired_canceled: IntCounter,
+}
+
+impl PoolMetrics {
+    pub fn new(prefix: Option<&str>, registry: &Registry) -> anyhow::Result<Arc<Self>> {
+        let prefix = prefix.unwrap_or("db");
+        let name = |n| format!("{prefix}_{n}");
+        let pool_metrics = PoolMetrics {
+            requested: register_int_counter_with_registry!(
+                name("connections_requested"),
+                "Total requested connections from the pool",
+                registry,
+            )?,
+            acquired: register_int_counter_with_registry!(
+                name("connections_acquired"),
+                "Total requested connections from the pool that were acquired",
+                registry,
+            )?,
+            unacquired_error: register_int_counter_with_registry!(
+                name("connections_unacquired_error"),
+                "Total requested connections from the pool that were not acquired due to an error",
+                registry,
+            )?,
+            unacquired_canceled: register_int_counter_with_registry!(
+                name("connections_unacquired_canceled"),
+                "Total requested connections from the pool that were not acquired due to task cancellation",
+                registry,
+            )?,
+        };
+        Ok(Arc::new(pool_metrics))
+    }
+}

--- a/crates/sui-pg-db/src/store.rs
+++ b/crates/sui-pg-db/src/store.rs
@@ -222,7 +222,7 @@ impl store::Store for Db {
     type Connection<'c> = Connection<'c>;
 
     async fn connect<'c>(&'c self) -> anyhow::Result<Self::Connection<'c>> {
-        Ok(Connection(self.0.get().await?))
+        self.connect().await
     }
 }
 


### PR DESCRIPTION
## Description 

This PR adds new connection pool metrics:
* `connections_requested` - Attempts to acquire a connection
* `connections_acquired` - Attempts that successfully acquired a connection.
* `connections_unacquired_error` - Attempts that failed to acquire a connection because of an error from the pool.
* `connections_unacquired_canceled` - Attempts that failed to acquire a connection because they were canceled before acquiring a connection.

These metrics are useful for knowing if the connection pool is able to handle the request throughput:
* If the connection pool is rightsized for the request throughput, `connections_requested` should be equal to or slightly above `connections_acquired + connections_unacquired_error + connections_unacquired_canceled` as there is a very small delay between requesting and acquiring a connection.
* If the connection pool is undersized for the request throughput, `connections_requested` will increase faster than `connections_acquired + connections_unacquired_error + connections_unacquired_canceled` until eventually `connections_unacquired_error` or `connections_unacquired_canceled` begin to increase as requests time out before connections become available.

## Test plan 

New unit tests.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
