### PR TITLE
fix: SuiJSON number validation wording

### DIFF
--- a/crates/sui-json/src/lib.rs
+++ b/crates/sui-json/src/lib.rs
@@ -105,7 +105,7 @@ impl SuiJsonValue {
                 // Must be castable to u64
                 if !n.is_u64() {
                     return Err(anyhow!(
-                        "{n} not allowed. Number must be unsigned integer of at most u32"
+                        "{n} not allowed. Number must be an unsigned integer"
                     ));
                 }
             }
@@ -240,7 +240,7 @@ impl SuiJsonValue {
             // Bool to Bool is simple
             (JsonValue::Bool(b), MoveTypeLayout::Bool) => R::MoveValue::Bool(*b),
 
-            // In constructor, we have already checked that the JSON number is unsigned int of at most U32
+            // In constructor, we have already checked that the JSON number is a non-negative integer (u64)
             (JsonValue::Number(n), MoveTypeLayout::U8) => match n.as_u64() {
                 Some(x) => R::MoveValue::U8(u8::try_from(x)?),
                 None => return Err(anyhow!("{} is not a valid number. Only u8 allowed.", n)),


### PR DESCRIPTION
<!-- в чем причина правок? тоесть понятным образом обьясняешь что не так было до наших правок -->
Previously the SuiJsonValue number validation error message and the related comment claimed that JSON numbers must fit into u32, while the actual code only requires them to be non-negative integers representable as u64. This mismatch was confusing and contradicted the SuiJSON documentation.

<!-- Четкое и лаконичное общее описание изменений, вносимых этим PR -->
This change updates the SuiJsonValue error message and the to_move_value comment to state that JSON numbers must be unsigned integers (non-negative u64), without altering any runtime behavior.