### PR TITLE
Make test_simulated_load_rolling_restarts_all_validators faster / more reliable

### DIFF
--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -231,7 +231,7 @@ mod test {
     #[sim_test(config = "test_config()")]
     async fn test_simulated_load_rolling_restarts_all_validators() {
         sui_protocol_config::ProtocolConfig::poison_get_for_min_version();
-        let test_cluster = build_test_cluster(4, 170_000, 1).await;
+        let test_cluster = build_test_cluster(4, 0, 1).await;
 
         let validators = test_cluster.get_validator_pubkeys();
         let test_cluster_clone = test_cluster.clone();
@@ -247,8 +247,13 @@ mod test {
             }
         });
         test_simulated_load(test_cluster.clone(), 170).await;
-        restarter_task.await.unwrap();
-        test_cluster.wait_for_epoch_all_nodes(1).await;
+
+        tokio::time::timeout(Duration::from_secs(20), restarter_task)
+            .await
+            .expect("Restarter task timed out")
+            .unwrap();
+
+        test_cluster.trigger_reconfiguration().await;
     }
 
     #[sim_test(config = "test_config()")]

--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -231,12 +231,12 @@ mod test {
     #[sim_test(config = "test_config()")]
     async fn test_simulated_load_rolling_restarts_all_validators() {
         sui_protocol_config::ProtocolConfig::poison_get_for_min_version();
-        let test_cluster = build_test_cluster(4, 330_000, 1).await;
+        let test_cluster = build_test_cluster(4, 170_000, 1).await;
 
         let validators = test_cluster.get_validator_pubkeys();
         let test_cluster_clone = test_cluster.clone();
         let restarter_task = tokio::task::spawn(async move {
-            for _ in 0..4 {
+            for _ in 0..2 {
                 for validator in validators.iter() {
                     info!("Killing validator {:?}", validator.concise());
                     test_cluster_clone.stop_node(validator);
@@ -246,7 +246,7 @@ mod test {
                 }
             }
         });
-        test_simulated_load(test_cluster.clone(), 330).await;
+        test_simulated_load(test_cluster.clone(), 170).await;
         restarter_task.await.unwrap();
         test_cluster.wait_for_epoch_all_nodes(1).await;
     }

--- a/crates/sui-network/src/lib.rs
+++ b/crates/sui-network/src/lib.rs
@@ -18,10 +18,21 @@ pub const DEFAULT_CONNECT_TIMEOUT_SEC: Duration = Duration::from_secs(10);
 pub const DEFAULT_REQUEST_TIMEOUT_SEC: Duration = Duration::from_secs(30);
 pub const DEFAULT_HTTP2_KEEPALIVE_SEC: Duration = Duration::from_secs(5);
 
+// Use shorter request timeout in test configurations to allow more retries during validator restarts
+pub const TEST_REQUEST_TIMEOUT_SEC: Duration = Duration::from_secs(10);
+
+static REQUEST_TIMEOUT: std::sync::LazyLock<Duration> = std::sync::LazyLock::new(|| {
+    if mysten_common::in_test_configuration() {
+        TEST_REQUEST_TIMEOUT_SEC
+    } else {
+        DEFAULT_REQUEST_TIMEOUT_SEC
+    }
+});
+
 pub fn default_mysten_network_config() -> Config {
     let mut net_config = mysten_network::config::Config::new();
     net_config.connect_timeout = Some(DEFAULT_CONNECT_TIMEOUT_SEC);
-    net_config.request_timeout = Some(DEFAULT_REQUEST_TIMEOUT_SEC);
+    net_config.request_timeout = Some(*REQUEST_TIMEOUT);
     net_config.http2_keepalive_interval = Some(DEFAULT_HTTP2_KEEPALIVE_SEC);
     net_config
 }


### PR DESCRIPTION
- Use shorter request timeout in test configurations: This lessens the chance of having a payload exhaust its retry budget before completing
- Speed up rolling restart test: the length of the test earlier wasn't doing much, since the real test is whether we can reconfigure, which only happens at the end
