### PR TITLE
Adapt Chain Identifier to return full 32 byte digest

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/chain_identifier.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/chain_identifier.snap
@@ -7,6 +7,6 @@ task 1, lines 8-11:
 //# run-graphql
 Response: {
   "data": {
-    "chainIdentifier": "a6a639f2"
+    "chainIdentifier": "CDXgyfL9effgQDWAiNSAnk34hMVbnyvzpTohmNRNQgKc"
   }
 }

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -3329,7 +3329,7 @@ type Query {
 	"""
 	address(address: SuiAddress, name: String, rootVersion: UInt53, atCheckpoint: UInt53): Address
 	"""
-	First four bytes of the network's genesis checkpoint digest (uniquely identifies the network), hex-encoded.
+	The network's genesis checkpoint digest (uniquely identifies the network), Base58-encoded.
 	"""
 	chainIdentifier: String!
 	"""

--- a/crates/sui-indexer-alt-graphql/src/api/query.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/query.rs
@@ -67,6 +67,8 @@ use crate::pagination::Page;
 use crate::pagination::PaginationConfig;
 use crate::scope::Scope;
 use crate::task::chain_identifier::ChainIdentifier;
+use fastcrypto::encoding::Base58;
+use fastcrypto::encoding::Encoding;
 
 #[derive(Default)]
 pub struct Query {
@@ -173,10 +175,10 @@ impl Query {
         .await
     }
 
-    /// First four bytes of the network's genesis checkpoint digest (uniquely identifies the network), hex-encoded.
+    /// The network's genesis checkpoint digest (uniquely identifies the network), Base58-encoded.
     async fn chain_identifier(&self, ctx: &Context<'_>) -> Result<String, RpcError> {
         let chain_id: &ChainIdentifier = ctx.data()?;
-        Ok(chain_id.wait().await.to_string())
+        Ok(Base58::encode(chain_id.wait().await.as_bytes()))
     }
 
     /// Fetch a checkpoint by its sequence number, or the latest checkpoint if no sequence number is provided.

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -3333,7 +3333,7 @@ type Query {
 	"""
 	address(address: SuiAddress, name: String, rootVersion: UInt53, atCheckpoint: UInt53): Address
 	"""
-	First four bytes of the network's genesis checkpoint digest (uniquely identifies the network), hex-encoded.
+	The network's genesis checkpoint digest (uniquely identifies the network), Base58-encoded.
 	"""
 	chainIdentifier: String!
 	"""

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -3333,7 +3333,7 @@ type Query {
 	"""
 	address(address: SuiAddress, name: String, rootVersion: UInt53, atCheckpoint: UInt53): Address
 	"""
-	First four bytes of the network's genesis checkpoint digest (uniquely identifies the network), hex-encoded.
+	The network's genesis checkpoint digest (uniquely identifies the network), Base58-encoded.
 	"""
 	chainIdentifier: String!
 	"""

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -3329,7 +3329,7 @@ type Query {
 	"""
 	address(address: SuiAddress, name: String, rootVersion: UInt53, atCheckpoint: UInt53): Address
 	"""
-	First four bytes of the network's genesis checkpoint digest (uniquely identifies the network), hex-encoded.
+	The network's genesis checkpoint digest (uniquely identifies the network), Base58-encoded.
 	"""
 	chainIdentifier: String!
 	"""


### PR DESCRIPTION
## Description 

The 4-byte hex representation is a holdover from JSON-RPC. We should return the full Base58 encoded genesis digest instead, as it is used in other places (e.g. `TransactionExpiration`) with that format.

## Test plan 

How did you test the new or updated feature?

```
cargo nextest run -p sui-indexer-alt-graphql
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [x] GraphQL: `chainIdentifier` query now returns full Base58-encoded 32 byte digest
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
