### PR TITLE
indexer-alt: track ConsensusAddressOwner for tx_affected_addresses and blooms pipelines

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/transactions_consensus_owner.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/transactions_consensus_owner.move
@@ -1,0 +1,36 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 108 --accounts A B C --simulator
+
+// Create a consensus-owned (party) object owned by B, sent by A
+//# programmable --sender A --inputs 1000 @B
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::party::single_owner(Input(1));
+//> 2: sui::transfer::public_party_transfer<sui::coin::Coin<sui::sui::SUI>>(Result(0), Result(1));
+
+// Create a regular address-owned object sent to C by A
+//# programmable --sender A --inputs 2000 @C
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+
+//# create-checkpoint
+
+//# run-graphql
+{
+  # A sent both transactions
+  sentByA: transactions(filter: { sentAddress: "@{A}", atCheckpoint: 1 }) { ...TX }
+  # B should only be affected by the party transfer
+  affectedB: transactions(filter: { affectedAddress: "@{B}", atCheckpoint: 1 }) { ...TX }
+  # C should only be affected by the regular transfer
+  affectedC: transactions(filter: { affectedAddress: "@{C}", atCheckpoint: 1 }) { ...TX }
+}
+
+fragment TX on TransactionConnection {
+  edges {
+    cursor
+    node {
+      digest
+    }
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/transactions_consensus_owner.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/transactions_consensus_owner.snap
@@ -1,0 +1,72 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 5 tasks
+
+init:
+A: object(0,0), B: object(0,1), C: object(0,2)
+
+task 1, lines 7-12:
+//# programmable --sender A --inputs 1000 @B
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::party::single_owner(Input(1));
+//> 2: sui::transfer::public_party_transfer<sui::coin::Coin<sui::sui::SUI>>(Result(0), Result(1));
+// Create a regular address-owned object sent to C by A
+created: object(1,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 13-15:
+//# programmable --sender A --inputs 2000 @C
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 3, line 17:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 4, lines 19-36:
+//# run-graphql
+Response: {
+  "data": {
+    "sentByA": {
+      "edges": [
+        {
+          "cursor": "MQ==",
+          "node": {
+            "digest": "FT42es4ZJobrXXLf5oVGtFtk69AaydrtHKR34hzUsQLk"
+          }
+        },
+        {
+          "cursor": "Mg==",
+          "node": {
+            "digest": "61uSLPFvHtzYKpe9P51cYYv2n6dGuJvoj1RUFC1Evxr6"
+          }
+        }
+      ]
+    },
+    "affectedB": {
+      "edges": [
+        {
+          "cursor": "MQ==",
+          "node": {
+            "digest": "FT42es4ZJobrXXLf5oVGtFtk69AaydrtHKR34hzUsQLk"
+          }
+        }
+      ]
+    },
+    "affectedC": {
+      "edges": [
+        {
+          "cursor": "Mg==",
+          "node": {
+            "digest": "61uSLPFvHtzYKpe9P51cYYv2n6dGuJvoj1RUFC1Evxr6"
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Description 

Previously, the indexer only tracked `AddressOwner` as affected addresses, so queries like "show me all transactions affecting address X" would miss transactions that only touched consensus-owned objects affecting X. This change ensures those addresses are indexed the same way.

Changes:
 - extracted recipient match logic into a shared helper and added `ConsensusAddressOwner` to match arm
 - use recipient shared helped in `tx_affected_address` and bloom pipelines


## Test plan 
```
cargo nextest run -p sui-indexer-alt
cargo nextest run -p sui-indexer-alt-e2e-tests -- graphql/
```


---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
