### PR TITLE
Fix flaky test_reconfig_with_committee_change_stress test

### DIFF
--- a/crates/sui-e2e-tests/tests/reconfiguration_tests.rs
+++ b/crates/sui-e2e-tests/tests/reconfiguration_tests.rs
@@ -1128,7 +1128,7 @@ async fn execute_add_validator_transactions(
 }
 
 async fn try_request_add_validator(
-    test_cluster: &mut TestCluster,
+    test_cluster: &TestCluster,
     new_validator: &ValidatorGenesisConfig,
 ) -> Result<(TransactionEffects, TransactionEvents), anyhow::Error> {
     let address = (&new_validator.account_key_pair.public()).into();
@@ -1144,7 +1144,33 @@ async fn try_request_add_validator(
         .call_request_add_validator()
         .build_and_sign(&new_validator.account_key_pair);
 
-    test_cluster
-        .execute_transaction_return_raw_effects(tx)
+    // Retry for up to 20 seconds with 5 second timeout per attempt. New validators
+    // may join consensus late and need time to catch up before their transactions
+    // can be sequenced.
+    let start = std::time::Instant::now();
+    let retry_timeout = std::time::Duration::from_secs(20);
+    let attempt_timeout = std::time::Duration::from_secs(5);
+    loop {
+        match tokio::time::timeout(
+            attempt_timeout,
+            test_cluster.execute_transaction_directly(&tx),
+        )
         .await
+        {
+            Ok(Ok((_digest, effects))) => {
+                return Ok((effects, TransactionEvents::default()));
+            }
+            Ok(Err(e)) => {
+                if start.elapsed() >= retry_timeout {
+                    return Err(e.into());
+                }
+            }
+            Err(_timeout) => {
+                if start.elapsed() >= retry_timeout {
+                    return Err(anyhow::anyhow!("Timeout waiting for transaction effects"));
+                }
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    }
 }

--- a/crates/test-cluster/src/lib.rs
+++ b/crates/test-cluster/src/lib.rs
@@ -623,6 +623,18 @@ impl TestCluster {
         Ok(res.pop().unwrap())
     }
 
+    /// Execute an already-signed transaction via direct validator submission, bypassing the fullnode.
+    pub async fn execute_transaction_directly(
+        &self,
+        tx: &Transaction,
+    ) -> SuiResult<(TransactionDigest, TransactionEffects)> {
+        let mut res = self
+            .execute_signed_txns_in_soft_bundle(std::slice::from_ref(tx))
+            .await?;
+        assert_eq!(res.len(), 1);
+        Ok(res.pop().unwrap())
+    }
+
     /// Sign and execute multiple transactions in a soft bundle.
     /// Soft bundles allow submitting multiple transactions together with best-effort
     /// ordering if they use the same gas price. Transactions in a soft bundle can be


### PR DESCRIPTION
## Summary
- Add retry logic to `try_request_add_validator` to handle cases where new validators join consensus late and need time to catch up before their transactions can be sequenced
- Add `execute_transaction_directly` method to `TestCluster` for executing already-signed transactions directly via validators

## Test plan
- Verified with the originally failing seed: `MSIM_TEST_SEED=1769814155031`
- Ran seed-search.py with 20 seeds, all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)