### PR TITLE
Do no panic on missing effects during notify_read_executed_effects

### DIFF
--- a/crates/sui-core/src/accumulators/object_funds_checker/integration_tests.rs
+++ b/crates/sui-core/src/accumulators/object_funds_checker/integration_tests.rs
@@ -270,9 +270,8 @@ async fn test_object_withdraw_multiple_withdraws() {
             assert!(matches!(output, ExecutionOutput::RetryLater));
             let effects = env
                 .authority
-                .notify_read_effects("test", digest)
-                .await
-                .unwrap();
+                .notify_read_effects_for_testing("test", digest)
+                .await;
             assert!(matches!(
                 effects.status(),
                 ExecutionStatus::Failure {
@@ -327,9 +326,8 @@ async fn test_object_withdraw_and_deposit_same_transaction() {
     assert!(matches!(output, ExecutionOutput::RetryLater));
     let effects = env
         .authority
-        .notify_read_effects("test", digest)
-        .await
-        .unwrap();
+        .notify_read_effects_for_testing("test", digest)
+        .await;
     assert!(matches!(
         effects.status(),
         ExecutionStatus::Failure {
@@ -389,9 +387,8 @@ async fn test_object_withdraw_and_deposit_same_transaction() {
     assert!(matches!(output, ExecutionOutput::RetryLater));
     let effects = env
         .authority
-        .notify_read_effects("test", digest)
-        .await
-        .unwrap();
+        .notify_read_effects_for_testing("test", digest)
+        .await;
     assert!(matches!(
         effects.status(),
         ExecutionStatus::Failure {

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -34,7 +34,6 @@ use move_binary_format::binary_config::BinaryConfig;
 use move_core_types::annotated_value::MoveStructLayout;
 use move_core_types::language_storage::ModuleId;
 use mysten_common::{assert_reachable, fatal};
-use mysten_metrics::{TX_TYPE_SHARED_OBJ_TX, TX_TYPE_SINGLE_WRITER_TX};
 use parking_lot::Mutex;
 use prometheus::{
     Histogram, HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec, Registry,
@@ -97,7 +96,6 @@ use tokio::sync::watch::error::RecvError;
 use tokio::sync::{mpsc, oneshot};
 use tokio::task::JoinHandle;
 use tokio::time::timeout;
-use tracing::trace;
 use tracing::{debug, error, info, instrument, warn};
 
 use self::authority_store::ExecutionLockWriteGuard;
@@ -264,7 +262,6 @@ pub mod backpressure;
 pub struct AuthorityMetrics {
     tx_orders: IntCounter,
     total_certs: IntCounter,
-    total_cert_attempts: IntCounter,
     total_effects: IntCounter,
     // TODO: this tracks consensus object tx, not just shared. Consider renaming.
     pub shared_obj_tx: IntCounter,
@@ -276,10 +273,6 @@ pub struct AuthorityMetrics {
     batch_size: Histogram,
 
     authority_state_handle_vote_transaction_latency: Histogram,
-
-    execute_certificate_latency_single_writer: Histogram,
-    execute_certificate_latency_shared_object: Histogram,
-    await_transaction_latency: Histogram,
 
     internal_execution_latency: Histogram,
     execution_load_input_objects_latency: Histogram,
@@ -401,20 +394,6 @@ pub const WAIT_FOR_FASTPATH_INPUT_TIMEOUT: Duration = Duration::from_secs(2);
 
 impl AuthorityMetrics {
     pub fn new(registry: &prometheus::Registry) -> AuthorityMetrics {
-        let execute_certificate_latency = register_histogram_vec_with_registry!(
-            "authority_state_execute_certificate_latency",
-            "Latency of executing certificates, including waiting for inputs",
-            &["tx_type"],
-            LATENCY_SEC_BUCKETS.to_vec(),
-            registry,
-        )
-        .unwrap();
-
-        let execute_certificate_latency_single_writer =
-            execute_certificate_latency.with_label_values(&[TX_TYPE_SINGLE_WRITER_TX]);
-        let execute_certificate_latency_shared_object =
-            execute_certificate_latency.with_label_values(&[TX_TYPE_SHARED_OBJ_TX]);
-
         Self {
             tx_orders: register_int_counter_with_registry!(
                 "total_transaction_orders",
@@ -425,12 +404,6 @@ impl AuthorityMetrics {
             total_certs: register_int_counter_with_registry!(
                 "total_transaction_certificates",
                 "Total number of transaction certificates handled",
-                registry,
-            )
-            .unwrap(),
-            total_cert_attempts: register_int_counter_with_registry!(
-                "total_handle_certificate_attempts",
-                "Number of calls to handle_certificate",
                 registry,
             )
             .unwrap(),
@@ -486,15 +459,6 @@ impl AuthorityMetrics {
             authority_state_handle_vote_transaction_latency: register_histogram_with_registry!(
                 "authority_state_handle_vote_transaction_latency",
                 "Latency of voting on transactions without signing",
-                LATENCY_SEC_BUCKETS.to_vec(),
-                registry,
-            )
-            .unwrap(),
-            execute_certificate_latency_single_writer,
-            execute_certificate_latency_shared_object,
-            await_transaction_latency: register_histogram_with_registry!(
-                "await_transaction_latency",
-                "Latency of awaiting user transaction execution, including waiting for inputs",
                 LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
             )
@@ -1398,75 +1362,41 @@ impl AuthorityState {
         })
     }
 
-    /// Wait for a certificate to be executed.
-    /// For consensus transactions, it needs to be sequenced by the consensus.
-    /// For owned object transactions, this function will enqueue the transaction for execution.
-    // TODO: The next 3 functions are very similar. We should refactor them.
-    #[instrument(level = "trace", skip_all)]
-    pub async fn wait_for_certificate_execution(
-        &self,
-        certificate: &VerifiedCertificate,
-        epoch_store: &Arc<AuthorityPerEpochStore>,
-    ) -> SuiResult<TransactionEffects> {
-        self.wait_for_transaction_execution(
-            &VerifiedExecutableTransaction::new_from_certificate(certificate.clone()),
-            epoch_store,
-        )
-        .await
-    }
-
     /// Wait for a transaction to be executed.
     /// For consensus transactions, it needs to be sequenced by the consensus.
     /// For owned object transactions, this function will enqueue the transaction for execution.
+    ///
+    /// Only use this in tests.
     #[instrument(level = "trace", skip_all)]
-    pub async fn wait_for_transaction_execution(
+    pub async fn wait_for_transaction_execution_for_testing(
         &self,
         transaction: &VerifiedExecutableTransaction,
         epoch_store: &Arc<AuthorityPerEpochStore>,
-    ) -> SuiResult<TransactionEffects> {
-        let _metrics_guard = if transaction.is_consensus_tx() {
-            self.metrics
-                .execute_certificate_latency_shared_object
-                .start_timer()
-        } else {
-            self.metrics
-                .execute_certificate_latency_single_writer
-                .start_timer()
-        };
-        trace!("execute_transaction");
+    ) -> TransactionEffects {
+        if !transaction.is_consensus_tx()
+            && !epoch_store.protocol_config().disable_preconsensus_locking()
+        {
+            // Shared object transactions need to be sequenced by the consensus before enqueueing
+            // for execution, done in AuthorityPerEpochStore::handle_consensus_transaction().
+            //
+            // For owned object transactions, they can be enqueued for execution immediately
+            // ONLY when disable_preconsensus_locking is false (QD/original fastpath mode).
+            // When disable_preconsensus_locking is true (MFP mode), all transactions including
+            // owned object transactions must go through consensus before enqueuing for execution.
+            self.execution_scheduler.enqueue(
+                vec![(
+                    Schedulable::Transaction(transaction.clone()),
+                    ExecutionEnv::new().with_scheduling_source(SchedulingSource::NonFastPath),
+                )],
+                epoch_store,
+            );
+        }
 
-        self.metrics.total_cert_attempts.inc();
-
-        // tx could be reverted when epoch ends, so we must be careful not to return a result
-        // here after the epoch ends.
-        epoch_store
-            .within_alive_epoch(self.notify_read_effects(
-                "AuthorityState::wait_for_transaction_execution",
-                *transaction.digest(),
-            ))
-            .await
-            .map_err(|_| SuiErrorKind::EpochEnded(epoch_store.epoch()).into())
-            .and_then(|r| r)
-    }
-
-    /// Awaits the effects of executing a user transaction.
-    ///
-    /// Relies on consensus to enqueue the transaction for execution.
-    pub async fn await_transaction_effects(
-        &self,
-        digest: TransactionDigest,
-        epoch_store: &Arc<AuthorityPerEpochStore>,
-    ) -> SuiResult<TransactionEffects> {
-        let _metrics_guard = self.metrics.await_transaction_latency.start_timer();
-        debug!("await_transaction");
-
-        epoch_store
-            .within_alive_epoch(
-                self.notify_read_effects("AuthorityState::await_transaction_effects", digest),
-            )
-            .await
-            .map_err(|_| SuiErrorKind::EpochEnded(epoch_store.epoch()).into())
-            .and_then(|r| r)
+        self.notify_read_effects_for_testing(
+            "AuthorityState::wait_for_transaction_execution_for_testing",
+            *transaction.digest(),
+        )
+        .await
     }
 
     /// Internal logic to execute a certificate.
@@ -1733,17 +1663,20 @@ impl AuthorityState {
         (signed_effects, execution_error_opt)
     }
 
-    pub async fn notify_read_effects(
+    /// Wait until the effects of the given transaction are available and return them.
+    /// Panics if the effects are not found.
+    ///
+    /// Only use this in tests where effects are expected to exist.
+    pub async fn notify_read_effects_for_testing(
         &self,
         task_name: &'static str,
         digest: TransactionDigest,
-    ) -> SuiResult<TransactionEffects> {
-        Ok(self
-            .get_transaction_cache_reader()
+    ) -> TransactionEffects {
+        self.get_transaction_cache_reader()
             .notify_read_executed_effects(task_name, &[digest])
             .await
             .pop()
-            .expect("must return correct number of effects"))
+            .expect("must return correct number of effects")
     }
 
     fn check_owned_locks(&self, owned_object_refs: &[ObjectRef]) -> SuiResult {

--- a/crates/sui-core/src/authority/authority_test_utils.rs
+++ b/crates/sui-core/src/authority/authority_test_utils.rs
@@ -231,7 +231,9 @@ pub async fn enqueue_and_execute_all(
     );
     let mut output = Vec::new();
     for (exec, _) in executables {
-        let effects = authority.notify_read_effects("", *exec.digest()).await?;
+        let effects = authority
+            .notify_read_effects_for_testing("", *exec.digest())
+            .await;
         output.push(effects);
     }
     Ok(output)

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -1190,19 +1190,20 @@ impl ValidatorService {
             // Ensure that finalized effects are always prioritized.
             biased;
             // We always wait for effects regardless of consensus position via
-            // notify_read_executed_effects. This is safe because we have separated
+            // notify_read_executed_effects_may_fail. This is safe because we have separated
             // mysticeti fastpath outputs to a separate dirty cache
             // UncommittedData::fastpath_transaction_outputs that will only get flushed
-            // once finalized. So the output of notify_read_executed_effects is
+            // once finalized. So the output of notify_read_executed_effects_may_fail is
             // guaranteed to be finalized effects or effects from QD execution.
-            mut effects = self.state
+            // We use _may_fail variant because effects may have been pruned for old transactions.
+            effects_result = self.state
                 .get_transaction_cache_reader()
-                .notify_read_executed_effects(
+                .notify_read_executed_effects_may_fail(
                     "AuthorityServer::wait_for_effects::notify_read_executed_effects_finalized",
                     &tx_digests,
                 ) => {
                 tracing::Span::current().record("fast_path_effects", false);
-                let effects = effects.pop().unwrap();
+                let effects = effects_result?.pop().unwrap();
                 let details = if request.include_details {
                     Some(self.complete_executed_data(effects.clone(), None).await?)
                 } else {

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -4126,17 +4126,15 @@ mod tests {
     }
 
     impl TransactionCacheRead for HashMap<TransactionDigest, TransactionEffects> {
-        fn notify_read_executed_effects(
+        fn notify_read_executed_effects_may_fail(
             &self,
             _: &str,
             digests: &[TransactionDigest],
-        ) -> BoxFuture<'_, Vec<TransactionEffects>> {
-            std::future::ready(
-                digests
-                    .iter()
-                    .map(|d| self.get(d).expect("effects not found").clone())
-                    .collect(),
-            )
+        ) -> BoxFuture<'_, SuiResult<Vec<TransactionEffects>>> {
+            std::future::ready(Ok(digests
+                .iter()
+                .map(|d| self.get(d).expect("effects not found").clone())
+                .collect()))
             .boxed()
         }
 

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -3675,11 +3675,12 @@ mod tests {
         // THEN check for execution status of user transactions.
         for (i, t) in user_transactions.iter().enumerate() {
             let digest = t.tx().digest();
-            if let Ok(Ok(_)) = tokio::time::timeout(
+            if tokio::time::timeout(
                 std::time::Duration::from_secs(10),
-                state.notify_read_effects("", *digest),
+                state.notify_read_effects_for_testing("", *digest),
             )
             .await
+            .is_ok()
             {
                 // Effects exist as expected.
             } else {

--- a/crates/sui-core/src/test_utils.rs
+++ b/crates/sui-core/src/test_utils.rs
@@ -59,7 +59,9 @@ pub async fn wait_for_tx(digest: TransactionDigest, state: Arc<AuthorityState>, 
     )
     .await
     {
-        Ok(_) => info!(?digest, "digest found"),
+        Ok(_) => {
+            info!(?digest, "digest found");
+        }
         Err(e) => {
             warn!(?digest, "digest not found!");
             panic!("timed out waiting for effects of digest! {e}");

--- a/crates/sui-core/src/transaction_orchestrator.rs
+++ b/crates/sui-core/src/transaction_orchestrator.rs
@@ -553,7 +553,7 @@ where
         let mut local_effects_future = self
             .validator_state
             .get_transaction_cache_reader()
-            .notify_read_executed_effects(
+            .notify_read_executed_effects_may_fail(
                 "TransactionOrchestrator::notify_read_execute_transaction_with_effects_waiting",
                 &digests,
             )
@@ -567,10 +567,12 @@ where
                 biased;
 
                 // Local effects might be available
-                all_effects = &mut local_effects_future => {
+                all_effects_result = &mut local_effects_future => {
                     debug!(
                         "Effects became available while execution was running"
                     );
+                    let all_effects = all_effects_result
+                        .map_err(TransactionSubmissionError::TransactionDriverInternalError)?;
                     if all_effects.len() != 1 {
                         break Err(TransactionSubmissionError::TransactionDriverInternalError(SuiErrorKind::Unknown(format!("Unexpected number of effects found: {}", all_effects.len())).into()));
                     }

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -2303,9 +2303,8 @@ async fn test_handle_confirmation_transaction_idempotent() {
 
     // Query the effects again - should return the same result
     let effects2 = authority_state
-        .notify_read_effects("", tx_digest)
-        .await
-        .unwrap();
+        .notify_read_effects_for_testing("", tx_digest)
+        .await;
     assert_eq!(effects2.status(), &ExecutionStatus::Success);
 
     // this is valid because we're checking the authority state does not change the effects
@@ -4772,9 +4771,8 @@ async fn test_shared_object_transaction_ok() {
 
     // Ensure transaction effects are available.
     authority
-        .notify_read_effects("", *executable.digest())
-        .await
-        .unwrap();
+        .notify_read_effects_for_testing("", *executable.digest())
+        .await;
 
     // Ensure shared object sequence number increased.
     let shared_object_version = authority

--- a/crates/sui-core/src/unit_tests/transfer_to_object_tests.rs
+++ b/crates/sui-core/src/unit_tests/transfer_to_object_tests.rs
@@ -231,9 +231,8 @@ impl TestRunner {
         assign_versions_and_schedule(&self.authority_state, &executable).await;
         let effects = self
             .authority_state
-            .wait_for_transaction_execution(&executable, &epoch_store)
-            .await
-            .unwrap();
+            .wait_for_transaction_execution_for_testing(&executable, &epoch_store)
+            .await;
 
         if self.aggressive_pruning_enabled {
             self.authority_state

--- a/crates/sui-single-node-benchmark/src/single_node.rs
+++ b/crates/sui-single-node-benchmark/src/single_node.rs
@@ -179,9 +179,8 @@ impl SingleValidator {
                     &self.epoch_store,
                 );
                 self.get_validator()
-                    .wait_for_transaction_execution(&executable, &self.epoch_store)
+                    .wait_for_transaction_execution_for_testing(&executable, &self.epoch_store)
                     .await
-                    .unwrap()
             }
             Component::ValidatorWithoutConsensus | Component::ValidatorWithFakeConsensus => {
                 // Execute the transaction directly using try_execute_executable_for_test


### PR DESCRIPTION
## Description 

This panic is too strict. We keep hitting it in tests in the presence of pruning.
We should make it return Result and panic when needed in the caller (mostly just in the checkpoint logic).
Other places should be able to tolerate this.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
