### PR TITLE
Fix flaky test_simulated_load_shared_object_congestion_control

### DIFF
--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -574,7 +574,7 @@ mod test {
             config
         });
 
-        let test_cluster = build_test_cluster(4, 5000, 2).await;
+        let test_cluster = build_test_cluster(4, 30000, 2).await;
         let mut simulated_load_config = SimulatedLoadConfig::default();
         {
             let mut rng = thread_rng();


### PR DESCRIPTION
## Summary
- Increase epoch duration from 5s to 30s in `test_simulated_load_shared_object_congestion_control`
- Test setup time (~18s) exceeded the epoch duration, causing transactions to always hit epoch boundaries

## Test plan
- [x] Verified with 1000 passing seeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)