### PR TITLE
Fix db reregistrations

### DIFF
--- a/crates/typed-store-derive/src/lib.rs
+++ b/crates/typed-store-derive/src/lib.rs
@@ -382,10 +382,11 @@ pub fn derive_dbmap_utils_general(input: TokenStream) -> TokenStream {
                         )*
                     );
                     let key_shape = builder.build();
-                    let inner_db = typed_store::tidehunter_util::open(path.as_path(), key_shape, metric_conf.db_name.clone());
-                    let db = std::sync::Arc::new(typed_store::rocks::Database::new(
+                    let (inner_db, registry_id) = typed_store::tidehunter_util::open(path.as_path(), key_shape, metric_conf.db_name.clone());
+                    let db = std::sync::Arc::new(typed_store::rocks::Database::new_with_registry_id(
                         typed_store::rocks::Storage::TideHunter(inner_db),
-                        metric_conf));
+                        metric_conf,
+                        registry_id));
                     let (
                         #(
                             #field_names


### PR DESCRIPTION
## Description 

Previously, every time a tidehunter database was opened, a new Prometheus registry was added to RegistryService but never removed. This caused:
  - 77-130× duplicate metric lines per scrape
  - ~100,000 mimir ingestion failures/second

Now, when a Database is dropped (e.g., during epoch changes), the associated registry is automatically removed from the RegistryService, preventing metric duplication.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
