### PR TITLE
Fix FundsWithdrawScheduler DB reference leak

### DIFF
--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -2835,11 +2835,7 @@ async fn test_authority_persist() {
         authority_key: AuthorityKeyPair,
         store: Arc<AuthorityStore>,
     ) -> Arc<AuthorityState> {
-        let mut protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
-        // TODO(address-balances): This test fails with accumulators enabled, because something
-        // (likely the scheduler) retains a reference to the database, keeping it alive after the
-        // `drop(authority)`.
-        protocol_config.disable_accumulators_for_testing();
+        let protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
         TestAuthorityBuilder::new()
             .with_genesis_and_keypair(genesis, &authority_key)
             .with_protocol_config(protocol_config)


### PR DESCRIPTION
## Description 

The FundsWithdrawScheduler spawned background tasks that held clones of the entire scheduler, including channel senders. This created a self-referential pattern where the tasks held senders while waiting on receivers, preventing the channels from ever closing and keeping DB references alive.

Fix by passing only the inner schedulers (wrapped in Arc) to the spawned tasks instead of the whole scheduler. When the scheduler is dropped, the senders are dropped, channels close, and the tasks exit properly.


## Test plan 

This allows test_authority_persist to run with accumulators enabled.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
