### PR TITLE
[tidehunter] unregister metrics on Drop

### DIFF
--- a/crates/typed-store-derive/src/lib.rs
+++ b/crates/typed-store-derive/src/lib.rs
@@ -382,10 +382,11 @@ pub fn derive_dbmap_utils_general(input: TokenStream) -> TokenStream {
                         )*
                     );
                     let key_shape = builder.build();
-                    let inner_db = typed_store::tidehunter_util::open(path.as_path(), key_shape, metric_conf.db_name.clone());
+                    let (inner_db, registry_id) = typed_store::tidehunter_util::open(path.as_path(), key_shape, metric_conf.db_name.clone());
                     let db = std::sync::Arc::new(typed_store::rocks::Database::new(
                         typed_store::rocks::Storage::TideHunter(inner_db),
-                        metric_conf));
+                        metric_conf,
+                        Some(registry_id)));
                     let (
                         #(
                             #field_names

--- a/crates/typed-store/src/rocks/mod.rs
+++ b/crates/typed-store/src/rocks/mod.rs
@@ -25,6 +25,7 @@ use crate::{
 use backoff::backoff::Backoff;
 use fastcrypto::hash::{Digest, HashFunction};
 use mysten_common::debug_fatal;
+use mysten_metrics::RegistryID;
 use prometheus::{Histogram, HistogramTimer};
 use rocksdb::properties::num_files_at_level;
 use rocksdb::{
@@ -136,11 +137,16 @@ impl std::fmt::Debug for Storage {
 pub struct Database {
     storage: Storage,
     metric_conf: MetricConf,
+    registry_id: Option<RegistryID>,
 }
 
 impl Drop for Database {
     fn drop(&mut self) {
-        DBMetrics::get().decrement_num_active_dbs(&self.metric_conf.db_name);
+        let metrics = DBMetrics::get();
+        metrics.decrement_num_active_dbs(&self.metric_conf.db_name);
+        if let Some(registry_id) = self.registry_id {
+            metrics.registry_serivce.remove(registry_id);
+        }
     }
 }
 
@@ -164,11 +170,12 @@ impl Deref for GetResult<'_> {
 }
 
 impl Database {
-    pub fn new(storage: Storage, metric_conf: MetricConf) -> Self {
+    pub fn new(storage: Storage, metric_conf: MetricConf, registry_id: Option<RegistryID>) -> Self {
         DBMetrics::get().increment_num_active_dbs(&metric_conf.db_name);
         Self {
             storage,
             metric_conf,
+            registry_id,
         }
     }
 
@@ -1802,6 +1809,7 @@ pub fn open_cf_opts<P: AsRef<Path>>(
                 underlying: rocksdb,
             }),
             metric_conf,
+            None,
         )))
     })
 }
@@ -1867,6 +1875,7 @@ pub fn open_cf_opts_secondary<P: AsRef<Path>>(
                 underlying: rocksdb,
             }),
             metric_conf,
+            None,
         )))
     })
 }

--- a/crates/typed-store/src/tidehunter_util.rs
+++ b/crates/typed-store/src/tidehunter_util.rs
@@ -3,6 +3,7 @@
 
 use crate::DBMetrics;
 use bincode::Options;
+use mysten_metrics::RegistryID;
 use prometheus::{HistogramTimer, Registry};
 use serde::de::DeserializeOwned;
 use std::env;
@@ -29,16 +30,16 @@ pub struct ThConfig {
     pub prefix: Option<Vec<u8>>,
 }
 
-pub fn open(path: &Path, key_shape: KeyShape, db_name: String) -> Arc<Db> {
+pub fn open(path: &Path, key_shape: KeyShape, db_name: String) -> (Arc<Db>, RegistryID) {
     std::fs::create_dir_all(path).expect("failed to open tidehunter db");
     let registry_service = &DBMetrics::get().registry_serivce;
     let registry = new_db_registry(db_name);
-    registry_service.add(registry.clone());
+    let registry_id = registry_service.add(registry.clone());
     let metrics = Metrics::new_in(&registry);
     let db = Db::open(path, key_shape, Arc::new(thdb_config()), metrics)
         .expect("failed to open tidehunter db");
     db.start_periodic_snapshot();
-    db
+    (db, registry_id)
 }
 
 fn new_db_registry(name: String) -> Registry {


### PR DESCRIPTION
## Description 

unregister metrics on Drop for tidehunter storage type

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
