### PR TITLE
sui-indexer-alt: add timeout error tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1770,6 +1770,8 @@ dependencies = [
  "static_assertions_next",
  "tempfile",
  "thiserror 1.0.69",
+ "tracing",
+ "tracing-futures",
 ]
 
 [[package]]
@@ -3133,7 +3135,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40723b8fb387abc38f4f4a37c09073622e41dd12327033091ef8950659e6dc0c"
 dependencies = [
  "memchr",
- "regex-automata 0.4.9",
+ "regex-automata",
  "serde",
 ]
 
@@ -4866,7 +4868,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e616e59155c92257e84970156f506287853355f58cd4a6eb167385722c32b790"
 dependencies = [
- "nu-ansi-term",
+ "nu-ansi-term 0.46.0",
 ]
 
 [[package]]
@@ -6180,7 +6182,7 @@ dependencies = [
  "aho-corasick",
  "bstr",
  "log",
- "regex-automata 0.4.9",
+ "regex-automata",
  "regex-syntax 0.8.5",
 ]
 
@@ -8119,11 +8121,11 @@ checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "matchers"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
- "regex-automata 0.1.10",
+ "regex-automata",
 ]
 
 [[package]]
@@ -9763,6 +9765,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "num"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10782,9 +10793,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "pin-utils"
@@ -11813,17 +11824,8 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.9",
+ "regex-automata",
  "regex-syntax 0.8.5",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax 0.6.28",
 ]
 
 [[package]]
@@ -15146,6 +15148,7 @@ dependencies = [
  "pin-project",
  "prometheus",
  "prost-types 0.14.1",
+ "regex",
  "reqwest",
  "rustls 0.23.31",
  "serde",
@@ -15168,11 +15171,14 @@ dependencies = [
  "sui-types",
  "telemetry-subscribers",
  "thiserror 1.0.69",
+ "timeout-tracing",
  "tokio",
  "toml 0.7.4",
  "tonic 0.14.3",
  "tower-http 0.5.2",
  "tracing",
+ "tracing-error",
+ "tracing-subscriber",
  "url",
  "uuid",
 ]
@@ -17494,6 +17500,7 @@ dependencies = [
  "tonic 0.12.3",
  "tracing",
  "tracing-appender",
+ "tracing-error",
  "tracing-opentelemetry",
  "tracing-subscriber",
 ]
@@ -17819,6 +17826,18 @@ checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "timeout-tracing"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4215a5d507354cba4bca5cd7c0dffdec3b7483758ddf4116cf21186bb73e913"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+ "tracing-error",
 ]
 
 [[package]]
@@ -18454,9 +18473,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.40"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "log",
  "pin-project-lite",
@@ -18477,9 +18496,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.27"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -18488,12 +18507,22 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.32"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",
+]
+
+[[package]]
+name = "tracing-error"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1581020d7a273442f5b45074a6a57d5757ad0a47dac0e9f0bd57b81936f3db"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -18502,19 +18531,10 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
+ "futures",
+ "futures-task",
  "pin-project",
  "tracing",
-]
-
-[[package]]
-name = "tracing-log"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
-dependencies = [
- "lazy_static",
- "log",
- "tracing-core",
 ]
 
 [[package]]
@@ -18541,16 +18561,16 @@ dependencies = [
  "smallvec",
  "tracing",
  "tracing-core",
- "tracing-log 0.2.0",
+ "tracing-log",
  "tracing-subscriber",
  "web-time",
 ]
 
 [[package]]
 name = "tracing-serde"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
 dependencies = [
  "serde",
  "tracing-core",
@@ -18558,14 +18578,14 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.17"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
+checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
 dependencies = [
  "matchers",
- "nu-ansi-term",
+ "nu-ansi-term 0.50.3",
  "once_cell",
- "regex",
+ "regex-automata",
  "serde",
  "serde_json",
  "sharded-slab",
@@ -18574,7 +18594,7 @@ dependencies = [
  "time",
  "tracing",
  "tracing-core",
- "tracing-log 0.1.3",
+ "tracing-log",
  "tracing-serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -532,6 +532,7 @@ tar = "0.4.40"
 tempfile = "3.20.0"
 test-fuzz = "3.0.4"
 thiserror = "1.0.40"
+timeout-tracing = "0.1.2"
 tiny-bip39 = "1.0.0"
 tokio = "=1.49.0"
 tokio-retry = "0.3"
@@ -573,7 +574,8 @@ tower-layer = "0.3.2"
 twox-hash = "1.6.3"
 tracing = "0.1.37"
 tracing-appender = "0.2.2"
-tracing-subscriber = { version = "0.3.15", default-features = false, features = [
+tracing-error = "0.2.1"
+tracing-subscriber = { version = "0.3.22", default-features = false, features = [
   "std",
   "smallvec",
   "fmt",

--- a/crates/sui-indexer-alt-graphql/Cargo.toml
+++ b/crates/sui-indexer-alt-graphql/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 
 [dependencies]
 anyhow.workspace = true
-async-graphql = { workspace = true, features = ["dataloader"] }
+async-graphql = { workspace = true, features = ["dataloader", "tracing"] }
 async-graphql-axum.workspace = true
 async-graphql-value.workspace = true
 async-trait.workspace = true
@@ -44,11 +44,14 @@ serde_json.workspace = true
 shared-crypto.workspace = true
 telemetry-subscribers.workspace = true
 thiserror.workspace = true
+timeout-tracing.workspace = true
 tokio.workspace = true
 toml.workspace = true
 tonic.workspace = true
 tower-http.workspace = true
 tracing.workspace = true
+tracing-error.workspace = true
+tracing-subscriber.workspace = true
 url.workspace = true
 uuid.workspace = true
 
@@ -77,6 +80,7 @@ sui-types.workspace = true
 [dev-dependencies]
 insta.workspace = true
 reqwest.workspace = true
+regex.workspace = true
 
 [features]
 staging = []

--- a/crates/sui-indexer-alt-graphql/src/extensions/logging.rs
+++ b/crates/sui-indexer-alt-graphql/src/extensions/logging.rs
@@ -213,9 +213,9 @@ where
 
         if resp.is_ok() {
             if log_enabled!(Level::Debug) {
-                debug!(%uuid, %addr, elapsed_ms, query = ext.query.get().unwrap(), response = %json!(resp), "Request succeeded");
+                debug!(request_id = %uuid, %addr, elapsed_ms, query = ext.query.get().unwrap(), response = %json!(resp), "Request succeeded");
             } else {
-                info!(%uuid, %addr, elapsed_ms, "Request succeeded");
+                info!(request_id = %uuid, %addr, elapsed_ms, "Request succeeded");
             }
             ext.metrics.queries_succeeded.inc();
         } else {
@@ -225,11 +225,11 @@ where
 
             // Log internal errors, timeouts, and unknown errors at a higher log level than other errors.
             if is_loud_query(&codes) {
-                warn!(%uuid, %addr, elapsed_ms, query = ext.query.get().unwrap(), response = %json!(resp), "Request failed");
+                warn!(request_id = %uuid, %addr, elapsed_ms, query = ext.query.get().unwrap(), response = %json!(resp), "Request failed");
             } else if log_enabled!(Level::Debug) {
-                debug!(%uuid, %addr, elapsed_ms, query = ext.query.get().unwrap(), response = %json!(resp), "Request failed");
+                debug!(request_id = %uuid, %addr, elapsed_ms, query = ext.query.get().unwrap(), response = %json!(resp), "Request failed");
             } else {
-                info!(%uuid, %addr, elapsed_ms, ?codes, "Request failed");
+                info!(request_id = %uuid, %addr, elapsed_ms, ?codes, "Request failed");
             }
 
             if codes.is_empty() {

--- a/crates/sui-indexer-alt-graphql/src/extensions/timeout.rs
+++ b/crates/sui-indexer-alt-graphql/src/extensions/timeout.rs
@@ -17,9 +17,12 @@ use async_graphql::extensions::NextExecute;
 use async_graphql::extensions::NextParseQuery;
 use async_graphql::parser::types::ExecutableDocument;
 use async_graphql::parser::types::OperationType;
-use tokio::time::timeout;
+use timeout_tracing::CaptureSpanTrace;
+use timeout_tracing::timeout;
+use tracing::warn;
 
 use crate::error::request_timeout;
+use crate::extensions::logging::Session;
 
 /// How long to wait for each kind of operation before timing out.
 pub(crate) struct TimeoutConfig {
@@ -87,10 +90,12 @@ impl Extension for TimeoutExt {
             self.config.query
         };
 
-        timeout(limit, next.run(ctx, operation_name))
+        timeout(limit, CaptureSpanTrace, next.run(ctx, operation_name))
             .await
-            .unwrap_or_else(|_| {
+            .unwrap_or_else(|e| {
                 let kind = if is_mutation { "Mutation" } else { "Query" };
+                let Session { uuid, .. } = ctx.data_unchecked();
+                warn!(request_id = %uuid, %kind, "Request timed out: {e}");
                 Response::from_errors(vec![ServerError::from(request_timeout(kind, limit))])
             })
     }
@@ -98,16 +103,26 @@ impl Extension for TimeoutExt {
 
 #[cfg(test)]
 mod tests {
+    use std::net::Ipv4Addr;
+    use std::net::SocketAddr;
+
     use async_graphql::EmptyMutation;
     use async_graphql::EmptySubscription;
     use async_graphql::Object;
     use async_graphql::Schema;
     use async_graphql::Value;
+    use async_graphql::extensions::Tracing;
+    use insta::assert_snapshot;
+    use itertools::Itertools;
+    use regex::Regex;
+    use telemetry_subscribers::TelemetryConfig;
+    use uuid::Uuid;
 
     use crate::error::code;
 
     use super::*;
 
+    #[derive(Clone)]
     struct Root(Duration);
 
     #[Object]
@@ -155,73 +170,122 @@ mod tests {
     /// The request takes longer than the timeout to handle, so it should fail.
     #[tokio::test]
     async fn test_query_timeout_fail() {
-        let zero = Duration::from_millis(0);
-        let delay = Duration::from_millis(200);
-        let response = Schema::build(Root(delay * 2), EmptyMutation, EmptySubscription)
-            .extension(Timeout::new(TimeoutConfig {
-                query: delay,
-                mutation: zero,
-            }))
-            .finish()
-            .execute("query { op }")
-            .await;
-
-        assert!(response.is_err());
-
-        let error = &response.errors[0];
-        assert!(error.message.contains("Query"));
-        assert_eq!(
-            error.extensions.as_ref().unwrap().get("code"),
-            Some(&Value::String(code::REQUEST_TIMEOUT.into()))
+        let timeout = Duration::from_millis(200);
+        let event = test_timeout_fail(
+            timeout,
+            Duration::ZERO,
+            timeout * 2,
+            "query { op }",
+            "Query",
         )
+        .await;
+        assert_snapshot!(event, @r"
+        [WARN] Request timed out: timeout elapsed at:
+        trace 0:
+           0: async_graphql::graphql::field
+                   with path: op, parent_type: Root, return_type: Boolean!
+           1: async_graphql::graphql::execute
+           2: async_graphql::graphql::request
+         request_id=ffffffff-ffff-ffff-ffff-ffffffffffff kind=Query
+        ")
     }
 
     /// Like [test_query_timeout_fail], but for a mutation.
     #[tokio::test]
     async fn test_mutation_timeout_fail() {
-        let zero = Duration::from_millis(0);
-        let delay = Duration::from_millis(200);
-        let response = Schema::build(Root(zero), Root(delay * 2), EmptySubscription)
-            .extension(Timeout::new(TimeoutConfig {
-                query: zero,
-                mutation: delay,
-            }))
-            .finish()
-            .execute("mutation { op }")
-            .await;
-
-        assert!(response.is_err());
-
-        let error = &response.errors[0];
-        assert!(error.message.contains("Mutation"));
-        assert_eq!(
-            error.extensions.as_ref().unwrap().get("code"),
-            Some(&Value::String(code::REQUEST_TIMEOUT.into()))
+        let timeout = Duration::from_millis(200);
+        let event = test_timeout_fail(
+            Duration::ZERO,
+            timeout,
+            timeout * 2,
+            "mutation { op }",
+            "Mutation",
         )
+        .await;
+        assert_snapshot!(event, @r"
+        [WARN] Request timed out: timeout elapsed at:
+        trace 0:
+           0: async_graphql::graphql::field
+                   with path: op, parent_type: Root, return_type: Boolean!
+           1: async_graphql::graphql::execute
+           2: async_graphql::graphql::request
+         request_id=ffffffff-ffff-ffff-ffff-ffffffffffff kind=Mutation
+        ")
     }
 
     /// Mutations are resolved sequentially, and the timeout should apply to the total time spent
     /// on the request.
     #[tokio::test]
     async fn test_mutation_additive_timeout() {
-        let zero = Duration::from_millis(0);
-        let delay = Duration::from_millis(200);
-        let response = Schema::build(Root(zero), Root(delay / 2), EmptySubscription)
+        let timeout = Duration::from_millis(200);
+        let event = test_timeout_fail(
+            Duration::ZERO,
+            timeout,
+            timeout / 2,
+            "mutation { a:op b:op c:op }",
+            "Mutation",
+        )
+        .await;
+        assert_snapshot!(event, @r"
+        [WARN] Request timed out: timeout elapsed at:
+        trace 0:
+           0: async_graphql::graphql::field
+                   with path: b, parent_type: Root, return_type: Boolean!
+           1: async_graphql::graphql::execute
+           2: async_graphql::graphql::request
+         request_id=ffffffff-ffff-ffff-ffff-ffffffffffff kind=Mutation
+        ")
+    }
+
+    async fn test_timeout_fail(
+        query_timeout: Duration,
+        mutation_timeout: Duration,
+        delay: Duration,
+        request: &str,
+        expected_error: &str,
+    ) -> String {
+        // Enable tracing, configured by environment variables.
+        let (_guard, handle) = TelemetryConfig::new()
+            .with_set_global_default(false)
+            // Enable to match default in main.rs
+            .with_enable_error_layer(true)
+            // Required for handle.get_test_layer_events()
+            .with_enable_test_layer(true)
+            .init();
+
+        let root = Root(delay);
+
+        let response = Schema::build(root.clone(), root, EmptySubscription)
+            // Timeout reads session data. This either needs to be set by the GraphQL framework or
+            // a test like this if bypassing the GraphQL framework.
+            .data(Session {
+                // ffffffff-ffff-ffff-ffff-ffffffffffff
+                uuid: Uuid::from_bytes([255; 16]),
+                addr: SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), 0),
+            })
             .extension(Timeout::new(TimeoutConfig {
-                query: zero,
-                mutation: delay,
+                query: query_timeout,
+                mutation: mutation_timeout,
             }))
+            .extension(Tracing)
             .finish()
-            .execute("mutation { a:op b:op c:op }")
+            .execute(request)
             .await;
 
         assert!(response.is_err());
 
         let error = &response.errors[0];
-        assert!(error.message.contains("Mutation"));
+        assert!(error.message.contains(expected_error));
         assert_eq!(
             error.extensions.as_ref().unwrap().get("code"),
             Some(&Value::String(code::REQUEST_TIMEOUT.into()))
-        )
+        );
+
+        let events = handle.get_test_layer_events();
+        assert_eq!(events.len(), 1);
+        // Remove line number strings to avoid test churn
+        // example: "             at /Users/evanwall/.cargo/git/checkouts/async-graphql-7336e61dcafca7ed/7be9351/src/extensions/tracing.rs:135"
+        let re = Regex::new(r"\s+at\s.+").unwrap();
+        events[0].split("\n").filter(|s| !re.is_match(s)).join("\n")
     }
 }

--- a/crates/sui-indexer-alt-graphql/src/lib.rs
+++ b/crates/sui-indexer-alt-graphql/src/lib.rs
@@ -16,6 +16,7 @@ use async_graphql::Schema;
 use async_graphql::SchemaBuilder;
 use async_graphql::SubscriptionType;
 use async_graphql::extensions::ExtensionFactory;
+use async_graphql::extensions::Tracing;
 use async_graphql::http::GraphiQLSource;
 use async_graphql_axum::GraphQLRequest;
 use async_graphql_axum::GraphQLResponse;
@@ -137,7 +138,9 @@ where
         let router = Router::new();
 
         // The logging extension should be outermost so that it can surround all other extensions.
-        let schema = schema.extension(Logging(metrics.clone()));
+        let schema = schema
+            .extension(Logging(metrics.clone()))
+            .extension(Tracing);
 
         Self {
             rpc_listen_address,

--- a/crates/sui-indexer-alt-graphql/src/main.rs
+++ b/crates/sui-indexer-alt-graphql/src/main.rs
@@ -12,6 +12,7 @@ use sui_indexer_alt_graphql::config::RpcLayer;
 use sui_indexer_alt_graphql::start_rpc;
 use sui_indexer_alt_metrics::MetricsService;
 use sui_indexer_alt_metrics::uptime;
+use telemetry_subscribers::TelemetryConfig;
 use tokio::fs;
 
 // Define the `GIT_REVISION` const
@@ -32,7 +33,10 @@ async fn main() -> anyhow::Result<()> {
     let args = Args::parse();
 
     // Enable tracing, configured by environment variables.
-    let _guard = telemetry_subscribers::TelemetryConfig::new()
+    let _guard = TelemetryConfig::new()
+        // ErrorLayer is disabled by default in TelemetryConfig, but enabled by default in GraphQL
+        // to give useful error output for debugging request timeouts.
+        .with_enable_error_layer(true)
         .with_env()
         .init();
 

--- a/crates/sui-pg-db/src/tls.rs
+++ b/crates/sui-pg-db/src/tls.rs
@@ -25,7 +25,6 @@ use rustls::pki_types::ServerName;
 use rustls::pki_types::UnixTime;
 use rustls::pki_types::pem::PemObject;
 use tokio_postgres_rustls::MakeRustlsConnect;
-use tracing::debug;
 use tracing::error;
 use tracing::info;
 use webpki_roots::TLS_SERVER_ROOTS;
@@ -149,10 +148,10 @@ pub(crate) async fn establish_tls_connection(
                 error!(pid, "Database connection terminated with error: {e}");
             }
             Ok(Ok(())) => {
-                debug!(pid, "Database connection terminated without error");
+                info!(pid, "Database connection terminated without error");
             }
             Err(e) => {
-                debug!(pid, "Database connection task failed: {e}");
+                info!(pid, "Database connection task failed: {e}");
             }
         }
     });

--- a/crates/telemetry-subscribers/Cargo.toml
+++ b/crates/telemetry-subscribers/Cargo.toml
@@ -16,6 +16,7 @@ once_cell.workspace = true
 prometheus.workspace = true
 tracing.workspace = true
 tracing-appender.workspace = true
+tracing-error.workspace = true
 tracing-subscriber.workspace = true
 opentelemetry = { version = "0.27.1" }
 opentelemetry_sdk = { version = "0.27.1", features = ["rt-tokio"] }

--- a/crates/telemetry-subscribers/src/lib.rs
+++ b/crates/telemetry-subscribers/src/lib.rs
@@ -23,15 +23,24 @@ use std::{
     str::FromStr,
     sync::{Arc, Mutex, atomic::Ordering},
 };
+use tracing::dispatcher::DefaultGuard;
 use tracing::metadata::LevelFilter;
 use tracing::{Level, error, info};
 use tracing_appender::non_blocking::{NonBlocking, WorkerGuard};
-use tracing_subscriber::{EnvFilter, Layer, Registry, filter, fmt, layer::SubscriberExt, reload};
+use tracing_error::ErrorLayer;
+use tracing_subscriber::{
+    EnvFilter, Layer, Registry, filter,
+    fmt::{self, format::Pretty},
+    layer::SubscriberExt,
+    reload,
+};
 
 use crate::file_exporter::{CachedOpenFile, FileExporter};
+use crate::test_layer::TestLayer;
 
 mod file_exporter;
 pub mod span_latency_prom;
+mod test_layer;
 
 /// Alias for a type-erased error type.
 pub type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
@@ -66,6 +75,12 @@ pub struct TelemetryConfig {
     pub trace_target: Option<Vec<String>>,
     /// Print unadorned logs from the target on standard error if this is a tty
     pub user_info_target: Vec<String>,
+    // Sets the subscriber created by this config to be the global default. Defaults to true if not set.
+    pub set_global_default: bool,
+    // Add error layer to capture trace spans. Defaults to false if not set.
+    pub enable_error_layer: bool,
+    // Capture output for tests. Defaults to false if not set.
+    pub enable_test_layer: bool,
 }
 
 #[must_use]
@@ -73,6 +88,7 @@ pub struct TelemetryConfig {
 pub struct TelemetryGuards {
     worker_guard: WorkerGuard,
     provider: Option<TracerProvider>,
+    subscriber: Option<DefaultGuard>,
 }
 
 impl TelemetryGuards {
@@ -80,11 +96,16 @@ impl TelemetryGuards {
         config: TelemetryConfig,
         worker_guard: WorkerGuard,
         provider: Option<TracerProvider>,
+        subscriber: Option<DefaultGuard>,
     ) -> Self {
-        set_global_telemetry_config(config);
+        // Do not set the global config if subscriber is present because a global subscriber was not set.
+        if subscriber.is_none() {
+            set_global_telemetry_config(config);
+        }
         Self {
             worker_guard,
             provider,
+            subscriber,
         }
     }
 }
@@ -116,6 +137,7 @@ pub struct TracingHandle {
     log: FilterHandle,
     trace: Option<FilterHandle>,
     file_output: CachedOpenFile,
+    test_layer: Option<TestLayer>,
     sampler: SamplingFilter,
 }
 
@@ -172,6 +194,13 @@ impl TracingHandle {
                 error!("failed to reset trace filter: {}", e);
             }
         }
+    }
+
+    pub fn get_test_layer_events(&self) -> Vec<String> {
+        self.test_layer
+            .as_ref()
+            .expect("test layer not enabled")
+            .get_events()
     }
 }
 
@@ -258,6 +287,9 @@ impl TelemetryConfig {
             sample_rate: 1.0,
             trace_target: None,
             user_info_target: Vec::new(),
+            set_global_default: true,
+            enable_error_layer: false,
+            enable_test_layer: false,
         }
     }
 
@@ -307,6 +339,21 @@ impl TelemetryConfig {
         self
     }
 
+    pub fn with_set_global_default(mut self, set_global_default: bool) -> Self {
+        self.set_global_default = set_global_default;
+        self
+    }
+
+    pub fn with_enable_error_layer(mut self, enable_error_layer: bool) -> Self {
+        self.enable_error_layer = enable_error_layer;
+        self
+    }
+
+    pub fn with_enable_test_layer(mut self, enable_test_layer: bool) -> Self {
+        self.enable_test_layer = enable_test_layer;
+        self
+    }
+
     pub fn with_env(mut self) -> Self {
         if env::var("CRASH_ON_PANIC").is_ok() {
             self.crash_on_panic = true
@@ -335,6 +382,12 @@ impl TelemetryConfig {
 
         if let Ok(sample_rate) = env::var("SAMPLE_RATE") {
             self.sample_rate = sample_rate.parse().expect("Cannot parse SAMPLE_RATE");
+        }
+
+        if let Ok(enable_error_layer) = env::var("ENABLE_ERROR_LAYER") {
+            self.enable_error_layer = enable_error_layer
+                .parse()
+                .expect("Cannot parse ENABLE_ERROR_LAYER");
         }
 
         self
@@ -499,9 +552,26 @@ impl TelemetryConfig {
             }
         }
 
+        if config.enable_error_layer {
+            layers.push(ErrorLayer::new(Pretty::default()).boxed())
+        }
+
+        let test_layer = if config.enable_test_layer {
+            let test_layer = TestLayer::new();
+            layers.push(test_layer.clone().boxed());
+            Some(test_layer)
+        } else {
+            None
+        };
+
         let subscriber = tracing_subscriber::registry().with(layers);
-        ::tracing::subscriber::set_global_default(subscriber)
-            .expect("unable to initialize tracing subscriber");
+        let subscriber_guard = if config.set_global_default {
+            tracing::subscriber::set_global_default(subscriber)
+                .expect("unable to initialize tracing subscriber");
+            None
+        } else {
+            Some(tracing::subscriber::set_default(subscriber))
+        };
 
         if config.panic_hook {
             set_panic_hook(config.crash_on_panic);
@@ -509,7 +579,7 @@ impl TelemetryConfig {
 
         // The guard must be returned and kept in the main fn of the app, as when it's dropped then the output
         // gets flushed and closed. If this is dropped too early then no output will appear!
-        let guards = TelemetryGuards::new(config_clone, worker_guard, provider);
+        let guards = TelemetryGuards::new(config_clone, worker_guard, provider, subscriber_guard);
 
         (
             guards,
@@ -517,6 +587,7 @@ impl TelemetryConfig {
                 log: log_filter_handle,
                 trace: trace_filter_handle,
                 file_output,
+                test_layer,
                 sampler,
             },
         )

--- a/crates/telemetry-subscribers/src/test_layer.rs
+++ b/crates/telemetry-subscribers/src/test_layer.rs
@@ -1,0 +1,92 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+use std::sync::Mutex;
+use tracing::field;
+use tracing_subscriber::Layer;
+use tracing_subscriber::layer;
+
+// Captures log events for tests.
+#[derive(Clone, Default)]
+pub struct TestLayer {
+    events: Arc<Mutex<Vec<String>>>,
+}
+
+impl TestLayer {
+    pub fn new() -> Self {
+        Self {
+            events: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    pub fn get_events(&self) -> Vec<String> {
+        self.events.lock().unwrap().clone()
+    }
+}
+
+impl<S> Layer<S> for TestLayer
+where
+    S: tracing::Subscriber,
+{
+    fn on_event(&self, event: &tracing::Event<'_>, _ctx: layer::Context<'_, S>) {
+        let mut visitor = TestVisitor::default();
+        event.record(&mut visitor);
+
+        let level = event.metadata().level();
+        let message = format!("[{}] {}", level, visitor.message);
+
+        self.events.lock().unwrap().push(message);
+    }
+}
+
+#[derive(Default)]
+struct TestVisitor {
+    message: String,
+}
+
+impl field::Visit for TestVisitor {
+    fn record_debug(&mut self, field: &field::Field, value: &dyn std::fmt::Debug) {
+        let space = if self.message.is_empty() { "" } else { " " };
+        if field.name() == "message" {
+            self.message += &format!("{space}{value:?}");
+        } else {
+            self.message += &format!("{space}{field}={value:?}");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tracing::error;
+    use tracing::info;
+    use tracing::warn;
+    use tracing_subscriber::layer::SubscriberExt;
+
+    use super::*;
+
+    #[test]
+    fn test_layer() {
+        let test_layer = TestLayer::new();
+
+        // Set up the subscriber with our test layer
+        let subscriber = tracing_subscriber::registry().with(test_layer.clone());
+
+        tracing::subscriber::with_default(subscriber, || {
+            info!("info-message");
+            info!(field1=%"value1", "info-message");
+            info!(field1=%"value1", field2=%"value2", "info-message");
+            warn!("warn-message");
+            error!("error-message");
+        });
+
+        let events = test_layer.get_events();
+
+        assert_eq!(events.len(), 5);
+        assert_eq!(events[0], "[INFO] info-message");
+        assert_eq!(events[1], "[INFO] info-message field1=value1");
+        assert_eq!(events[2], "[INFO] info-message field1=value1 field2=value2");
+        assert_eq!(events[3], "[WARN] warn-message");
+        assert_eq!(events[4], "[ERROR] error-message");
+    }
+}


### PR DESCRIPTION
## Description 

While running a benchmark, some requests were timing out (`query_timeout_ms`) with a response message containing `"message": "Query timed out after 40.00s"`, but no more details indicating the root cause. I eventually pinpointed it to the database being underprovisioned and not being able to handle the benchmark load.

This PR adds tracing to GraphQL and logs a warning containing the trace of where the thread(s) were when the request timed out.

## Test plan 

Added unit tests.

Example log output from the unit test:
```
[WARN] Request timed out: timeout elapsed at:
trace 0:
   0: async_graphql::graphql::field
           with path: op, parent_type: Root, return_type: Boolean!
             at /Users/evanwall/.cargo/git/checkouts/async-graphql-7336e61dcafca7ed/7be9351/src/extensions/tracing.rs:135
   1: async_graphql::graphql::execute
             at /Users/evanwall/.cargo/git/checkouts/async-graphql-7336e61dcafca7ed/7be9351/src/extensions/tracing.rs:120
   2: async_graphql::graphql::request
             at /Users/evanwall/.cargo/git/checkouts/async-graphql-7336e61dcafca7ed/7be9351/src/extensions/tracing.rs:55
 request_id=ffffffff-ffff-ffff-ffff-ffffffffffff kind=Query
```

This can be improved on by adding more span instrumentation: https://docs.rs/tracing/latest/tracing/attr.instrument.html.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
