### PR TITLE
Spawn admin server in Swarm for `force-close-epoch` support

### DIFF
--- a/crates/sui-node/src/main.rs
+++ b/crates/sui-node/src/main.rs
@@ -176,7 +176,7 @@ fn main() {
             ))
             .unwrap();
 
-        sui_node::admin::run_admin_server(node, admin_interface_port, filter_handle).await
+        sui_node::admin::run_admin_server(node, admin_interface_port, Some(filter_handle)).await
     });
 
     runtimes.metrics.spawn(async move {

--- a/crates/sui-swarm/src/memory/container.rs
+++ b/crates/sui-swarm/src/memory/container.rs
@@ -98,7 +98,12 @@ impl Container {
                     "Started Prometheus HTTP endpoint. To query metrics use\n\tcurl -s http://{}/metrics",
                     config.metrics_address
                 );
+                let admin_interface_port = config.admin_interface_port;
                 let server = SuiNode::start(config, registry_service).await.unwrap();
+                let admin_node = server.clone();
+                tokio::spawn(async move {
+                    sui_node::admin::run_admin_server(admin_node, admin_interface_port, None).await;
+                });
                 // Notify that we've successfully started the node
                 let _ = startup_sender.send(Arc::downgrade(&server));
                 // run until canceled


### PR DESCRIPTION
## Description 

`Container::spawn()` starts each validator via `SuiNode::start()` but does not start the admin HTTP server. The admin server (including `/force-close-epoch`) is only started in the `sui-node` binary's `main()`. This means tests using `sui start` or `TestCluster` cannot use the admin API to trigger deterministic epoch changes.                                                              
                                                                                              
This PR spawns the admin server alongside each Swarm node.

https://github.com/MystenLabs/hashi/issues/95

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
