### PR TITLE
wip(registry/display): enable Display Registry

### DIFF
--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -291,6 +291,7 @@ const MAX_PROTOCOL_VERSION: u64 = 109;
 //              Enable address aliases on testnet.
 //              Enable poseidon_bn254 on mainnet.
 // Version 109: New framework.
+//              Enable Display Registry in devnet.
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
@@ -4461,7 +4462,11 @@ impl ProtocolConfig {
 
                     cfg.feature_flags.enable_poseidon = true;
                 }
-                109 => {}
+                109 => {
+                    if chain == Chain::Unknown {
+                        cfg.feature_flags.enable_display_registry = true;
+                    }
+                }
                 // Use this template when making changes:
                 //
                 //     // modify an existing constant.

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_109.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_109.snap
@@ -135,6 +135,7 @@ feature_flags:
   use_new_commit_handler: true
   better_loader_errors: true
   generate_df_type_layouts: true
+  enable_display_registry: true
   private_generics_verifier_v2: true
   deprecate_global_storage_ops: true
   consensus_skip_gced_accept_votes: true

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
@@ -240,13 +240,13 @@ validators:
         next_epoch_worker_address: ~
         extra_fields:
           id:
-            id: "0xf04ce0ea34dca699c85e28039bf98fd8a52b9cd547f667fb947e3a162d93d137"
+            id: "0xf6e132988cb507dc1865dbfc835f8b3551bdedae62f24a1cc85d4243f8d4b6b0"
           size: 0
       voting_power: 10000
-      operation_cap_id: "0xb5cadb0f7ced56e7099acf4b38cdc7fad34eaafc0dd1d0040775382462e4ad18"
+      operation_cap_id: "0x1fdbbb0be0f058d2a29d09f46825a95c532fcacee59cee2579829e433e62c0a7"
       gas_price: 1000
       staking_pool:
-        id: "0xf6e132988cb507dc1865dbfc835f8b3551bdedae62f24a1cc85d4243f8d4b6b0"
+        id: "0x6042d1f5357a4691a8f26142a217f49d9f14d67a3ce02c7a6dd274dfdff44414"
         activation_epoch: 0
         deactivation_epoch: ~
         sui_balance: 20000000000000000
@@ -254,14 +254,14 @@ validators:
           value: 0
         pool_token_balance: 20000000000000000
         exchange_rates:
-          id: "0x6042d1f5357a4691a8f26142a217f49d9f14d67a3ce02c7a6dd274dfdff44414"
+          id: "0x1f8f95a582f37344d5aa7e44e32aad5f642e30cd8b711e2a09990b028b8f95c1"
           size: 1
         pending_stake: 0
         pending_total_sui_withdraw: 0
         pending_pool_token_withdraw: 0
         extra_fields:
           id:
-            id: "0x1f8f95a582f37344d5aa7e44e32aad5f642e30cd8b711e2a09990b028b8f95c1"
+            id: "0xb5cadb0f7ced56e7099acf4b38cdc7fad34eaafc0dd1d0040775382462e4ad18"
           size: 0
       commission_rate: 200
       next_epoch_stake: 20000000000000000
@@ -269,27 +269,27 @@ validators:
       next_epoch_commission_rate: 200
       extra_fields:
         id:
-          id: "0x1fdbbb0be0f058d2a29d09f46825a95c532fcacee59cee2579829e433e62c0a7"
+          id: "0xcb5c74d089e56ce27c2fa08c5bb924c7c22adccb7d47b95a138d2497946d9ed2"
         size: 0
   pending_active_validators:
     contents:
-      id: "0xf9a8b664c7be17200dac111d45115e7baecf7f4c4ded9326752858a8ee79b2a9"
+      id: "0x1ff5f015bac7576af17b6132fc4285bfae4688ec1d8f6aa1b2fa342d4ed16d97"
       size: 0
   pending_removals: []
   staking_pool_mappings:
-    id: "0xc7b4661a716c7d0e045a3e8dfe4e428b44457edfd9ac4047863a25337ec52c11"
+    id: "0xf9a8b664c7be17200dac111d45115e7baecf7f4c4ded9326752858a8ee79b2a9"
     size: 1
   inactive_validators:
-    id: "0x1ff5f015bac7576af17b6132fc4285bfae4688ec1d8f6aa1b2fa342d4ed16d97"
+    id: "0x8c7708b425189508c92ce4a0fb7eaedb1daa996d012c885d0236eebec3babc05"
     size: 0
   validator_candidates:
-    id: "0x8c7708b425189508c92ce4a0fb7eaedb1daa996d012c885d0236eebec3babc05"
+    id: "0x68cc4d32aff0938e1d1a35cd4ca437e5fce1735f5df4ffd0fff9c44a610df0db"
     size: 0
   at_risk_validators:
     contents: []
   extra_fields:
     id:
-      id: "0x68cc4d32aff0938e1d1a35cd4ca437e5fce1735f5df4ffd0fff9c44a610df0db"
+      id: "0xc3febab6327ec9d05b37cd94996537dabdceb9d76ad1e309cbf271cec7c6b4f3"
     size: 0
 storage_fund:
   total_object_storage_rebates:
@@ -306,7 +306,7 @@ parameters:
   validator_low_stake_grace_period: 7
   extra_fields:
     id:
-      id: "0x64929a06fecd8aff4d1a2838b0374865d65e9fa0fe6400a98fa8e7d2b7199ab1"
+      id: "0xe261d578a4423490675c8829e9fa1951fb316bd27d076a3841ddd4660a1a8341"
     size: 0
 reference_gas_price: 1000
 validator_report_records:
@@ -320,7 +320,7 @@ stake_subsidy:
   stake_subsidy_decrease_rate: 1000
   extra_fields:
     id:
-      id: "0xe261d578a4423490675c8829e9fa1951fb316bd27d076a3841ddd4660a1a8341"
+      id: "0xc7b4661a716c7d0e045a3e8dfe4e428b44457edfd9ac4047863a25337ec52c11"
     size: 0
 safe_mode: false
 safe_mode_storage_rewards:
@@ -332,5 +332,5 @@ safe_mode_non_refundable_storage_fee: 0
 epoch_start_timestamp_ms: 10
 extra_fields:
   id:
-    id: "0xc3febab6327ec9d05b37cd94996537dabdceb9d76ad1e309cbf271cec7c6b4f3"
+    id: "0x8a6a8f0da8c66c06cccc8488681cd51703215790c1a14dac64919e8998614ced"
   size: 0


### PR DESCRIPTION
## Description
Enables Display Registry in Protocol Config 109, for non-production networks. This is to unblock E2E tests in integration PRs, but should not be landed until we are comfortable with Display Registry going out to Devnet.

## Test plan
E2E tests further up the stack.

## Stack

- #23710 
- #25240 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [x] Protocol: Enables Display v2 Registry on non-production networks.
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
