### PR TITLE
registry/display: GraphQL integration

### DIFF
--- a/crates/sui-display/src/v2/error.rs
+++ b/crates/sui-display/src/v2/error.rs
@@ -149,7 +149,36 @@ pub(crate) enum Match<T> {
     Tried(Option<usize>, ExpectedSet),
 }
 
+impl Error {
+    /// Whether this error is because of something outside the user's control.
+    pub fn is_internal_error(&self) -> bool {
+        matches!(self, Self::NameEvaluation(_, e) if e.is_internal_error())
+    }
+
+    /// Whether this error is because a resource limit was exceeded.
+    pub fn is_resource_limit_error(&self) -> bool {
+        matches!(self, Self::NameEvaluation(_, e) if e.is_resource_limit_error())
+            || matches!(
+                self,
+                Self::TooBig | Self::TooManyLoads | Self::TooMuchOutput
+            )
+    }
+}
+
 impl FormatError {
+    /// Whether this error is because of something outside the user's control.
+    pub fn is_internal_error(&self) -> bool {
+        matches!(self, Self::Bcs(_) | Self::Store(_) | Self::Visitor(_))
+    }
+
+    /// Whether this error is because a resource limit was exceeded.
+    pub fn is_resource_limit_error(&self) -> bool {
+        matches!(
+            self,
+            Self::TooBig | Self::TooDeep | Self::TooManyLoads | Self::TooMuchOutput
+        )
+    }
+
     /// Indicate that the error occurred while processing an expression at `offset`.
     pub(crate) fn for_expr_at_offset(self, offset: usize) -> Self {
         match self {

--- a/crates/sui-display/src/v2/mod.rs
+++ b/crates/sui-display/src/v2/mod.rs
@@ -7,7 +7,6 @@ use futures::future::try_join_all;
 use futures::join;
 use indexmap::IndexMap;
 
-use crate::v2::error::Error;
 use crate::v2::meter::Meter;
 use crate::v2::parser::Chain;
 use crate::v2::parser::Literal;
@@ -25,6 +24,7 @@ mod value;
 mod visitor;
 mod writer;
 
+pub use crate::v2::error::Error;
 pub use crate::v2::error::FormatError;
 pub use crate::v2::interpreter::Interpreter;
 pub use crate::v2::meter::Limits;
@@ -180,9 +180,9 @@ impl<'s> Display<'s> {
     /// supports partial failures (if one of the field values fails to parse or evaluate).
     pub async fn display<S: Store>(
         &'s self,
-        interpreter: &'s Interpreter<S>,
         max_depth: usize,
         max_output_size: usize,
+        interpreter: &'s Interpreter<S>,
     ) -> Result<IndexMap<String, Result<serde_json::Value, FormatError>>, Error> {
         let writer = Arc::new(Writer::new(max_depth, max_output_size));
         let mut output = IndexMap::new();
@@ -365,7 +365,7 @@ mod tests {
     ) -> Result<IndexMap<String, Result<serde_json::Value, FormatError>>, Error> {
         let interpreter = Interpreter::new(OwnedSlice { bytes, layout }, store);
         Display::parse(limits, fields)?
-            .display(&interpreter, max_depth, max_output_size)
+            .display(max_depth, max_output_size, &interpreter)
             .await
     }
 

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/objects/display/display_v2.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/objects/display/display_v2.move
@@ -1,0 +1,95 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// TODO: set protocol version once it's no longer the max
+//# init --accounts A --addresses test=0x0 --simulator
+
+//# publish --sender A
+module test::mod {
+  use std::string::String;
+  use sui::display_registry::DisplayRegistry;
+  use sui::display_registry::DisplayCap;
+  use sui::dynamic_field as df;
+
+  public struct Foo has key, store {
+    id: UID,
+    bar: Bar,
+  }
+
+  public struct Bar has store { baz: Baz, val: u64 }
+  public struct Baz has store { qux: Qux, val: bool }
+  public struct Qux has store { quy: Quy, val: String }
+  public struct Quy has store { quz: Quz, val: Option<ID> }
+  public struct Quz has store { val: u8 }
+
+  /// Register a Display v2 grammar for `Foo`.
+  public fun display(registry: &mut DisplayRegistry, ctx: &mut TxContext): DisplayCap<Foo> {
+    let (mut display, cap) = registry.new(internal::permit(), ctx);
+
+    display.set(&cap, "bar", "bar is {bar.val}!");
+    display.set(&cap, "baz", "baz is {bar.baz.val}?");
+    display.set(&cap, "qux", "{bar.baz.qux:json}");
+    display.set(&cap, "quy", "quy is {bar.baz.qux.quy.val}.");
+    display.set(&cap, "qu_", "x({bar.baz.qux.val}) y({bar.baz.qux.quy.val}), z({bar.baz.qux.quy.quz.val})?!");
+    display.set(&cap, "f42", "[42] is {id->[42u64] | 0x00420042u32 :hex}");
+    display.share();
+
+    cap
+  }
+
+  public fun new(
+    v_bar: u64,
+    v_baz: bool,
+    v_qux: String,
+    v_quy: Option<ID>,
+    v_quz: u8,
+    ctx: &mut TxContext,
+  ): Foo {
+    let quz = Quz { val: v_quz };
+    let quy = Quy { val: v_quy, quz };
+    let qux = Qux { val: v_qux, quy };
+    let baz = Baz { val: v_baz, qux };
+    let bar = Bar { val: v_bar, baz };
+    Foo { id: object::new(ctx), bar }
+  }
+
+  public fun add_df(foo: &mut Foo) {
+    df::add(&mut foo.id, 42u64, 0x42004200u32);
+  }
+}
+
+//# programmable --sender A --inputs object(0xd) @A
+//> 0: test::mod::display(Input(0));
+//> 1: TransferObjects([Result(0)], Input(1))
+
+//# programmable --sender A --inputs @A 42 true "hello" 43u8
+//> 0: std::option::some<sui::object::ID>(Input(0));
+//> 1: test::mod::new(Input(1), Input(2), Input(3), Result(0), Input(4));
+//> 2: TransferObjects([Result(1)], Input(0))
+
+//# programmable --sender A --inputs @A 42 true "hello" 43u8
+//> 0: std::option::none<sui::object::ID>();
+//> 1: test::mod::new(Input(1), Input(2), Input(3), Result(0), Input(4));
+//> 2: TransferObjects([Result(1)], Input(0))
+
+//# programmable --sender A --inputs object(4,0)
+//> 0: test::mod::add_df(Input(0))
+
+//# create-checkpoint
+
+//# run-graphql
+{
+  multiGetObjects(keys: [
+    { address: "@{obj_3_0}" },
+    { address: "@{obj_4_0}" }
+  ]) {
+    asMoveObject {
+      contents {
+        display {
+          output
+          errors
+        }
+      }
+    }
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/objects/display/display_v2.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/objects/display/display_v2.snap
@@ -1,0 +1,109 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 8 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 7-59:
+//# publish --sender A
+created: object(1,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 13748400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 61-63:
+//# programmable --sender A --inputs object(0xd) @A
+//> 0: test::mod::display(Input(0));
+//> 1: TransferObjects([Result(0)], Input(1))
+created: object(2,0), object(2,1), object(2,2)
+mutated: 0x000000000000000000000000000000000000000000000000000000000000000d, object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 10343600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 3, lines 65-68:
+//# programmable --sender A --inputs @A 42 true "hello" 43u8
+//> 0: std::option::some<sui::object::ID>(Input(0));
+//> 1: test::mod::new(Input(1), Input(2), Input(3), Result(0), Input(4));
+//> 2: TransferObjects([Result(1)], Input(0))
+created: object(3,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2599200,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 4, lines 70-73:
+//# programmable --sender A --inputs @A 42 true "hello" 43u8
+//> 0: std::option::none<sui::object::ID>();
+//> 1: test::mod::new(Input(1), Input(2), Input(3), Result(0), Input(4));
+//> 2: TransferObjects([Result(1)], Input(0))
+created: object(4,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2356000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 5, lines 75-76:
+//# programmable --sender A --inputs object(4,0)
+//> 0: test::mod::add_df(Input(0))
+created: object(5,0)
+mutated: object(0,0), object(4,0)
+gas summary: computation_cost: 1000000, storage_cost: 3792400,  storage_rebate: 2332440, non_refundable_storage_fee: 23560
+
+task 6, line 78:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 7, lines 80-95:
+//# run-graphql
+Response: {
+  "data": {
+    "multiGetObjects": [
+      {
+        "asMoveObject": {
+          "contents": {
+            "display": {
+              "output": {
+                "bar": "bar is 42!",
+                "baz": "baz is true?",
+                "qux": {
+                  "quy": {
+                    "quz": {
+                      "val": 43
+                    },
+                    "val": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+                  },
+                  "val": "hello"
+                },
+                "quy": "quy is 0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e.",
+                "qu_": "x(hello) y(0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e), z(43)?!",
+                "f42": "[42] is 00420042"
+              },
+              "errors": null
+            }
+          }
+        }
+      },
+      {
+        "asMoveObject": {
+          "contents": {
+            "display": {
+              "output": {
+                "bar": "bar is 42!",
+                "baz": "baz is true?",
+                "qux": {
+                  "quy": {
+                    "quz": {
+                      "val": 43
+                    },
+                    "val": null
+                  },
+                  "val": "hello"
+                },
+                "quy": null,
+                "qu_": null,
+                "f42": "[42] is 42004200"
+              },
+              "errors": null
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/crates/sui-indexer-alt-graphql/src/api/types/display.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/display.rs
@@ -1,9 +1,22 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::sync::Arc;
+
+use anyhow::Context as _;
+use async_graphql::Context;
 use async_graphql::SimpleObject;
+use async_graphql::dataloader::DataLoader;
+use move_core_types::language_storage::StructTag;
+use sui_indexer_alt_reader::displays::DisplayKey;
+use sui_indexer_alt_reader::pg_reader::PgReader;
+use sui_types::display::DisplayVersionUpdatedEvent;
+use sui_types::display_registry;
 
 use crate::api::scalars::json::Json;
+use crate::api::types::object::Object;
+use crate::error::RpcError;
+use crate::scope::Scope;
 
 /// A rendered JSON blob based on an on-chain template.
 #[derive(SimpleObject)]
@@ -13,4 +26,53 @@ pub(crate) struct Display {
 
     /// If any fields failed to render, this will contain a mapping from failed field names to error messages. If all fields succeed, this will be `null`.
     pub(crate) errors: Option<Json>,
+}
+
+/// Try to load the V1 Display format for this type.
+pub(crate) async fn display_v1(
+    ctx: &Context<'_>,
+    type_: StructTag,
+) -> Result<Option<DisplayVersionUpdatedEvent>, RpcError> {
+    let pg_loader: &Arc<DataLoader<PgReader>> = ctx.data()?;
+
+    let Some(stored) = pg_loader
+        .load_one(DisplayKey(type_))
+        .await
+        .context("Failed to fetch Display v1")?
+    else {
+        return Ok(None);
+    };
+
+    let event: DisplayVersionUpdatedEvent = bcs::from_bytes(&stored.display)
+        .context("Failed to deserialize DisplayVersionUpdatedEvent")?;
+
+    Ok(Some(event))
+}
+
+/// Try to load the V2 Display format for this type.
+pub(crate) async fn display_v2(
+    ctx: &Context<'_>,
+    scope: Scope,
+    type_: StructTag,
+) -> Result<Option<display_registry::Display>, RpcError> {
+    let object_id = display_registry::display_object_id(type_.into())
+        .context("Failed to derive Display V2 object ID")?;
+
+    let Some(object) = Object::latest(ctx, scope, object_id.into()).await? else {
+        return Ok(None);
+    };
+
+    let Some(native) = object.contents(ctx).await? else {
+        return Ok(None);
+    };
+
+    let move_object = native
+        .data
+        .try_as_move()
+        .context("Display V2 object is not a Move object")?;
+
+    let display: display_registry::Display = bcs::from_bytes(move_object.contents())
+        .context("Failed to deserialize Display V2 object")?;
+
+    Ok(Some(display))
 }

--- a/crates/sui-indexer-alt-graphql/src/api/types/move_value.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/move_value.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
-
 use anyhow::Context as _;
 use anyhow::anyhow;
 use async_graphql::Context;
@@ -12,7 +10,6 @@ use async_graphql::Value;
 use async_graphql::connection::Connection;
 use async_graphql::connection::CursorType;
 use async_graphql::connection::Edge;
-use async_graphql::dataloader::DataLoader;
 use async_graphql::indexmap::IndexMap;
 use async_trait::async_trait;
 use move_core_types::account_address::AccountAddress;
@@ -20,10 +17,7 @@ use move_core_types::annotated_value as A;
 use move_core_types::annotated_visitor as AV;
 use move_core_types::u256::U256;
 use move_core_types::visitor_default;
-use sui_indexer_alt_reader::displays::DisplayKey;
-use sui_indexer_alt_reader::pg_reader::PgReader;
 use sui_types::TypeTag;
-use sui_types::display::DisplayVersionUpdatedEvent;
 use sui_types::id::ID;
 use sui_types::id::UID;
 use sui_types::object::option_visitor as OV;
@@ -35,6 +29,8 @@ use crate::api::scalars::cursor::JsonCursor;
 use crate::api::scalars::json::Json;
 use crate::api::types::address::Address;
 use crate::api::types::display::Display;
+use crate::api::types::display::display_v1;
+use crate::api::types::display::display_v2;
 use crate::api::types::move_type::MoveType;
 use crate::api::types::object::Object;
 use crate::config::Limits;
@@ -73,6 +69,9 @@ struct JsonWriter<'b> {
 
 #[derive(thiserror::Error, Debug)]
 pub(crate) enum Error {
+    #[error("Display error: {0}")]
+    Display(sui_display::v2::Error),
+
     #[error("Format error: {0}")]
     Format(sui_display::v2::FormatError),
 
@@ -228,48 +227,84 @@ impl MoveValue {
     /// A rendered JSON blob based on an on-chain template, substituted with data from this value.
     ///
     /// Returns `null` if the value's type does not have an associated `Display` template.
-    async fn display(&self, ctx: &Context<'_>) -> Option<Result<Display, RpcError>> {
+    async fn display(&self, ctx: &Context<'_>) -> Option<Result<Display, RpcError<Error>>> {
         async {
             let limits: &Limits = ctx.data()?;
-            let pg_loader: &Arc<DataLoader<PgReader>> = ctx.data()?;
 
             let Some(TypeTag::Struct(type_)) = self.type_.to_type_tag() else {
                 return Ok(None);
             };
 
-            let (layout, display) = join!(
+            let (layout, display_v1, display_v2) = join!(
                 self.type_.layout_impl(),
-                pg_loader.load_one(DisplayKey(*type_)),
+                display_v1(ctx, *type_.clone()),
+                display_v2(ctx, self.type_.scope.clone(), *type_)
             );
 
-            let (Some(layout), Some(display)) =
-                (layout?, display.context("Failed to fetch Display")?)
-            else {
+            let Some(layout) = layout.map_err(upcast)? else {
                 return Ok(None);
             };
-
-            let event: DisplayVersionUpdatedEvent = bcs::from_bytes(&display.display)
-                .context("Failed to deserialize DisplayVersionUpdatedEvent")?;
 
             let mut output = IndexMap::new();
             let mut errors = IndexMap::new();
 
-            for (field, value) in
-                sui_display::v1::Format::parse(limits.max_display_field_depth, &event.fields)
-                    .map_err(resource_exhausted)?
-                    .display(limits.max_display_output_size, &self.native, &layout)
-                    .map_err(resource_exhausted)?
-            {
-                match value {
-                    Ok(v) => {
-                        output.insert(Name::new(&field), Value::String(v));
-                    }
+            if let Some(display_v2) = display_v2.map_err(upcast)? {
+                let store = DisplayStore::new(ctx, &self.type_.scope);
 
-                    Err(e) => {
-                        output.insert(Name::new(&field), Value::Null);
-                        errors.insert(Name::new(&field), Value::String(e.to_string()));
-                    }
+                let root = sui_display::v2::OwnedSlice {
+                    bytes: self.native.clone(),
+                    layout,
                 };
+
+                let interpreter = sui_display::v2::Interpreter::new(root, store);
+
+                for (field, value) in
+                    sui_display::v2::Display::parse(limits.display(), display_v2.fields())
+                        .map_err(display_error)?
+                        .display(
+                            limits.max_move_value_depth,
+                            limits.max_display_output_size,
+                            &interpreter,
+                        )
+                        .await
+                        .map_err(display_error)?
+                {
+                    match value {
+                        Ok(v) => {
+                            output.insert(
+                                Name::new(&field),
+                                v.try_into().context("Failed to serialize JSON")?,
+                            );
+                        }
+
+                        Err(e) => {
+                            output.insert(Name::new(&field), Value::Null);
+                            errors.insert(Name::new(&field), Value::String(e.to_string()));
+                        }
+                    }
+                }
+            } else if let Some(display_v1) = display_v1.map_err(upcast)? {
+                for (field, value) in sui_display::v1::Format::parse(
+                    limits.max_display_field_depth,
+                    &display_v1.fields,
+                )
+                .map_err(resource_exhausted)?
+                .display(limits.max_display_output_size, &self.native, &layout)
+                .map_err(resource_exhausted)?
+                {
+                    match value {
+                        Ok(v) => {
+                            output.insert(Name::new(&field), Value::String(v));
+                        }
+
+                        Err(e) => {
+                            output.insert(Name::new(&field), Value::Null);
+                            errors.insert(Name::new(&field), Value::String(e.to_string()));
+                        }
+                    };
+                }
+            } else {
+                return Ok(None);
             }
 
             Ok(Some(Display {
@@ -594,26 +629,25 @@ impl From<RV::Error> for VisitorError {
     }
 }
 
+fn display_error(e: sui_display::v2::Error) -> RpcError<Error> {
+    if e.is_internal_error() {
+        anyhow!(e).into()
+    } else if e.is_resource_limit_error() {
+        resource_exhausted(e)
+    } else {
+        bad_user_input(Error::Display(e))
+    }
+}
+
 fn format_error(
     wrap: impl FnOnce(sui_display::v2::FormatError) -> Error,
     e: sui_display::v2::FormatError,
 ) -> RpcError<Error> {
-    use sui_display::v2::FormatError as FE;
-    match &e {
-        FE::InvalidHexCharacter(_)
-        | FE::InvalidIdentifier(_)
-        | FE::InvalidNumber { .. }
-        | FE::OddHexLiteral(_)
-        | FE::TransformInvalid(_)
-        | FE::TransformInvalid_ { .. }
-        | FE::UnexpectedEos { .. }
-        | FE::UnexpectedRemaining(_)
-        | FE::UnexpectedToken { .. }
-        | FE::VectorArity { .. }
-        | FE::VectorNoType
-        | FE::VectorTypeMismatch { .. } => bad_user_input(wrap(e)),
-
-        FE::TooBig | FE::TooDeep | FE::TooManyLoads | FE::TooMuchOutput => resource_exhausted(e),
-        FE::Bcs(_) | FE::Visitor(_) | FE::Store(_) => anyhow!(e).into(),
+    if e.is_internal_error() {
+        anyhow!(e).into()
+    } else if e.is_resource_limit_error() {
+        resource_exhausted(e)
+    } else {
+        bad_user_input(wrap(e))
     }
 }

--- a/crates/sui-transaction-checks/src/lib.rs
+++ b/crates/sui-transaction-checks/src/lib.rs
@@ -23,7 +23,7 @@ mod checked {
     use sui_types::{
         SUI_ACCUMULATOR_ROOT_OBJECT_ID, SUI_ADDRESS_ALIAS_STATE_OBJECT_ID, SUI_BRIDGE_OBJECT_ID,
         SUI_CLOCK_OBJECT_ID, SUI_COIN_REGISTRY_OBJECT_ID, SUI_DENY_LIST_OBJECT_ID,
-        SUI_RANDOMNESS_STATE_OBJECT_ID, SUI_SYSTEM_STATE_OBJECT_ID,
+        SUI_DISPLAY_REGISTRY_OBJECT_ID, SUI_RANDOMNESS_STATE_OBJECT_ID, SUI_SYSTEM_STATE_OBJECT_ID,
     };
     use sui_types::{
         base_types::{SequenceNumber, SuiAddress},
@@ -573,6 +573,7 @@ mod checked {
                         (SUI_SYSTEM_STATE_OBJECT_ID, _)
                         | (SUI_ADDRESS_ALIAS_STATE_OBJECT_ID, _)
                         | (SUI_COIN_REGISTRY_OBJECT_ID, _)
+                        | (SUI_DISPLAY_REGISTRY_OBJECT_ID, _)
                         | (SUI_DENY_LIST_OBJECT_ID, _)
                         | (SUI_BRIDGE_OBJECT_ID, _)
 

--- a/crates/sui-types/src/display_registry.rs
+++ b/crates/sui-types/src/display_registry.rs
@@ -1,10 +1,50 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    SUI_DISPLAY_REGISTRY_OBJECT_ID, base_types::SequenceNumber, error::SuiResult, object::Owner,
-    storage::ObjectStore,
-};
+use move_core_types::ident_str;
+use move_core_types::identifier::IdentStr;
+use move_core_types::language_storage::StructTag;
+use move_core_types::language_storage::TypeTag;
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::SUI_DISPLAY_REGISTRY_OBJECT_ID;
+use crate::SUI_FRAMEWORK_ADDRESS;
+use crate::base_types::ObjectID;
+use crate::base_types::SequenceNumber;
+use crate::collection_types::VecMap;
+use crate::derived_object::derive_object_id;
+use crate::error::SuiResult;
+use crate::object::Owner;
+use crate::storage::ObjectStore;
+
+pub const DISPLAY_REGISTRY_MODULE_NAME: &IdentStr = ident_str!("display_registry");
+pub const DISPLAY_KEY_STRUCT_NAME: &IdentStr = ident_str!("DisplayKey");
+
+#[derive(Serialize, Deserialize)]
+pub struct Display {
+    pub id: ObjectID,
+    pub fields: VecMap<String, String>,
+    pub cap_id: Option<ObjectID>,
+}
+
+impl Display {
+    pub fn fields(&self) -> impl Iterator<Item = (&str, &str)> {
+        self.fields
+            .contents
+            .iter()
+            .map(|e| (e.key.as_str(), e.value.as_str()))
+    }
+}
+
+/// Derive the ObjectID at which to find the Display object for the given type.
+pub fn display_object_id(type_: TypeTag) -> Result<ObjectID, bcs::Error> {
+    derive_object_id(
+        SUI_DISPLAY_REGISTRY_OBJECT_ID,
+        &display_key(type_).into(),
+        &[0x00],
+    )
+}
 
 pub fn get_display_registry_obj_initial_shared_version(
     object_store: &dyn ObjectStore,
@@ -17,4 +57,13 @@ pub fn get_display_registry_obj_initial_shared_version(
             } => initial_shared_version,
             _ => unreachable!("DisplayRegistry object must be shared"),
         }))
+}
+
+fn display_key(type_: TypeTag) -> StructTag {
+    StructTag {
+        address: SUI_FRAMEWORK_ADDRESS,
+        module: DISPLAY_REGISTRY_MODULE_NAME.to_owned(),
+        name: DISPLAY_KEY_STRUCT_NAME.to_owned(),
+        type_params: vec![type_],
+    }
 }


### PR DESCRIPTION
## Description
GraphQL will look for and preference `sui::display_registry::Display<T>` over `sui::display::Display<T>` (+ its events) when computing the Display output for a given Move Value.

## Test plan

New E2E tests:

```
$ cargo nextest run            \
  -p sui-indexer-alt-e2e-tests \
  --test transactional_tests   \
  -- display_v2
```

## Stack

- #23710 
- #25240 
- #25241

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [x] GraphQL: Adds support for Display Registry to GraphQL: `MoveValue.display` will look for a `Display<T>` stored in the Display Registry and will use that as the source of truth for its type's format. This takes precedence over any Display v1 formats that exist for this type.
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
