### PR TITLE
Update bytes crate to 1.11.1 to fix RUSTSEC-2026-0007

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3211,9 +3211,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 dependencies = [
  "serde",
 ]

--- a/external-crates/move/Cargo.lock
+++ b/external-crates/move/Cargo.lock
@@ -437,9 +437,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cassowary"


### PR DESCRIPTION
## Summary

Updates `bytes` crate from 1.10.1 to 1.11.1 to fix security advisory [RUSTSEC-2026-0007](https://rustsec.org/advisories/RUSTSEC-2026-0007).

## Vulnerability

Integer overflow in `BytesMut::reserve` - when `new_cap + offset` overflows `usize` in release builds, subsequent APIs may create out-of-bounds slices, leading to undefined behavior.

## Fix

```
cargo update -p bytes
```

## Test Plan

- [x] `cargo-deny check advisories` should pass after this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)