### PR TITLE
[1.65] [bridge] Handle storage layout mismatch during EVM contract upgrades

### DIFF
--- a/bridge/evm/contracts/utils/CommitteeUpgradeable.sol
+++ b/bridge/evm/contracts/utils/CommitteeUpgradeable.sol
@@ -20,7 +20,21 @@ abstract contract CommitteeUpgradeable is
     /* ========== STATE VARIABLES ========== */
 
     bool private _upgradeAuthorized;
-    // upgradeablity storage gap
+
+    // CRITICAL: Storage layout differs between mainnet and testnet!
+    //
+    // The __gap array was added AFTER testnet deployment but BEFORE mainnet deployment.
+    // This creates a permanent storage layout divergence:
+    //
+    //   - TESTNET (Sepolia 0xAE68...): vault @ slot 4, limiter @ slot 5 (NO __gap)
+    //   - MAINNET (0xda3b...):         vault @ slot 54, limiter @ slot 55 (HAS __gap)
+    //
+    // This file currently has __gap INCLUDED to support MAINNET upgrades.
+    //
+    // See bridge/SUI_NATIVE_BRIDGE_PRIMER.md for full documentation.
+    // For TESTNET upgrades, you must remove __gap.
+
+    // upgradeable storage gap
     uint256[50] private __gap;
 
     /* ========== INITIALIZER ========== */


### PR DESCRIPTION
## Summary
Cherry-pick of https://github.com/MystenLabs/sui/pull/25228 to the 1.65 release branch.

Original commit: 8c637bb8d6

This fix allows bridge nodes to start and sign governance actions when the EVM contract has a storage layout mismatch (vault/limiter returning 0x0), which occurred on testnet after the V2 upgrade.