### PR TITLE
Disable release-notes-monitor workflow on forks

### DIFF
--- a/.github/workflows/release-notes-monitor.yml
+++ b/.github/workflows/release-notes-monitor.yml
@@ -13,6 +13,7 @@ permissions:
 jobs:
   get-list-of-prs:
     name: Get Release Notes for new PRs
+    if: github.repository == 'MystenLabs/sui'
     outputs:
       matrix: ${{ steps.get-pr-list.outputs.matrix }}
       new_commit_hash: ${{ steps.get-pr-list.outputs.new_commit_hash }}


### PR DESCRIPTION
## Summary

Adds a repository check to prevent the `release-notes-monitor` workflow from running on forked repositories.

## Problem

When forks sync with upstream, the scheduled workflow runs but fails because:
- `SLACK_BOT_TOKEN` secret is not available on forks
- `SUI_CREATE_RELEASE` secret is not available on forks

Example failure: https://github.com/awnion/sui/actions/runs/21643397025

## Solution

Add `if: github.repository == 'MystenLabs/sui'` condition to the first job. Since subsequent jobs depend on this one, they will also be skipped on forks.

## Test Plan

- [x] Workflow will skip on forks (condition prevents execution)
- [x] Workflow continues to work on MystenLabs/sui (condition passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)