### PR TITLE
[workflows] Migrate notifications to sui-operations via dispatch

### DIFF
--- a/.github/workflows/cargo-llvm-cov.yml
+++ b/.github/workflows/cargo-llvm-cov.yml
@@ -98,97 +98,30 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
       with:
         ref: ${{ github.event.inputs.sui_repo_ref || github.ref }}
-    
-    - name: Get sui commit
+
+    - name: Get sui commit and branch
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        export sui_sha=$(git rev-parse HEAD)
+        sui_sha=$(git rev-parse HEAD)
         echo "sui_sha=${sui_sha}" >> $GITHUB_ENV
 
-    - name: Get a branch name for a sui commit
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        export sui_branch_name=$(gh api -H 'Accept: application/vnd.github+json' /repos/MystenLabs/sui/commits/${{ env.sui_sha }}/branches-where-head --jq '.[].name' | head -n 1)
-        # if the commit is not the head of the branch, get it's base branch 
-        [[ -z $sui_branch_name ]] && export sui_branch_name=$(gh api -H 'Accept: application/vnd.github+json' /repos/MystenLabs/sui/commits/${{ env.sui_sha }}/pulls --jq '.[].base.ref' | head -n 1)
+        sui_branch_name=$(gh api -H 'Accept: application/vnd.github+json' /repos/MystenLabs/sui/commits/${sui_sha}/branches-where-head --jq '.[].name' | head -n 1)
+        [[ -z $sui_branch_name ]] && sui_branch_name=$(gh api -H 'Accept: application/vnd.github+json' /repos/MystenLabs/sui/commits/${sui_sha}/pulls --jq '.[].base.ref' | head -n 1)
         echo "sui_branch_name=${sui_branch_name}" >> $GITHUB_ENV
-        echo "sui_branch_name_url=$(echo ${sui_branch_name} | sed 's\/\%2F\g')" >> $GITHUB_ENV
 
-    - name: Get link to logs
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        gh_job_link=$(gh api -X GET 'repos/MystenLabs/sui/actions/runs/${{ github.run_id }}/jobs' --jq '.jobs.[0].html_url')
-        echo "gh_job_link=${gh_job_link}" >> $GITHUB_ENV
-
-    - name: Get current oncall from PagerDuty
-      run: |
-        # Fetch oncall info including user details (for email)
-        response=$(curl -s --max-time 30 --request GET \
-          --url 'https://api.pagerduty.com/oncalls?schedule_ids[]=PGCQ3YS&include[]=users' \
-          --header 'Accept: application/json' \
-          --header 'Authorization: Token token=${{ secrets.PAGERDUTY_ACCESS_KEY }}' \
-          --header 'Content-Type: application/json')
-
-        oncall_email=$(echo "$response" | jq -r '.oncalls[0].user.email // empty')
-        oncall_user_name=$(echo "$response" | jq -r '.oncalls[0].user.summary // empty')
-        oncall_policy=$(echo "$response" | jq -r '.oncalls[0].escalation_policy.summary // empty')
-
-        echo "oncall_email=${oncall_email}" >> "$GITHUB_ENV"
-        echo "oncall_user_name=${oncall_user_name}" >> "$GITHUB_ENV"
-        echo "oncall_policy=${oncall_policy}" >> "$GITHUB_ENV"
-
-        if [ -z "$oncall_email" ]; then
-          echo "::warning::Could not get oncall email from PagerDuty"
-        fi
-
-    - name: Get Slack ID for oncall
-      run: |
-        if [ -z "${{ env.oncall_email }}" ]; then
-          echo "::warning::No oncall email available, skipping Slack lookup"
-          echo "slack_id=" >> "$GITHUB_ENV"
-          exit 0
-        fi
-
-        # URL-encode the email for the API call
-        encoded_email=$(printf '%s' "${{ env.oncall_email }}" | jq -sRr @uri)
-
-        # Lookup Slack ID from email
-        slack_response=$(curl -s --max-time 30 "https://slack.com/api/users.lookupByEmail?email=${encoded_email}" \
-          -H "Authorization: Bearer ${{ secrets.SLACK_BOT_TOKEN }}")
-
-        slack_ok=$(echo "$slack_response" | jq -r '.ok')
-        slack_id=$(echo "$slack_response" | jq -r '.user.id // empty')
-
-        if [ "$slack_ok" != "true" ]; then
-          error=$(echo "$slack_response" | jq -r '.error')
-          echo "::warning::Slack lookup failed for ${{ env.oncall_email }}: ${error}"
-          echo "slack_id=" >> "$GITHUB_ENV"
-          exit 0
-        fi
-
-        echo "slack_id=${slack_id}" >> "$GITHUB_ENV"
-
-    - name: Post to slack
-      uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # pin@v2.1.1
-      env:
-        SUI_SHA: ${{ env.sui_sha }}
-        SUI_BRANCH_NAME: ${{ env.sui_branch_name }}
-        SUI_BRANCH_NAME_URL: ${{ env.sui_branch_name_url }}
-        GH_JOB_LINK: ${{ env.gh_job_link }}
-        SLACK_ID: ${{ env.slack_id }}
-        ONCALL_USER_NAME: ${{ env.oncall_user_name }}
-        ONCALL_POLICY: ${{ env.oncall_policy }}
+    - name: Dispatch to sui-operations for notification
+      uses: peter-evans/repository-dispatch@8e2aaa08bcf5d9a5ef61e3b5ecc11e8e41cbcc48 # pin@v3.0.0
       with:
-        method: chat.postMessage
-        token: ${{ secrets.SLACK_BOT_TOKEN }}
-        payload: |
-          channel: "code-coverage"
-          text: |
-            *${{ github.workflow }}* workflow status: `${{ env.WORKFLOW_CONCLUSION }}`
-            Sui commit: <https://github.com/MystenLabs/sui/commit/${{ env.SUI_SHA }}|${{ env.SUI_SHA }}>
-            Sui branch: `${{ env.SUI_BRANCH_NAME }}`
-            Run: <${{ env.GH_JOB_LINK }}|${{ github.run_id }}>
-            ${{ env.SLACK_ID && format('<@{0}>', env.SLACK_ID) || env.ONCALL_USER_NAME }}, current `${{ env.ONCALL_POLICY }}` oncall, please look over the code coverage <https://app.codecov.io/github/MystenLabs/sui/tree/${{ env.SUI_BRANCH_NAME_URL }}|report> for the `${{ env.SUI_BRANCH_NAME }}` branch in Sui repo, to manually check if there are coverage regressions.
+        token: ${{ secrets.OPERATIONS_DISPATCH_TOKEN }}
+        repository: MystenLabs/sui-operations
+        event-type: code-coverage-notify
+        client-payload: |-
+          {
+            "commit_sha": "${{ env.sui_sha }}",
+            "branch_name": "${{ env.sui_branch_name }}",
+            "run_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+            "run_id": "${{ github.run_id }}",
+            "workflow_name": "${{ github.workflow }}",
+            "workflow_conclusion": "${{ env.WORKFLOW_CONCLUSION }}"
+          }

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,16 +27,17 @@ jobs:
     runs-on: [ubuntu-latest]
     
     steps:
-      - name: Notify Slack of Examples Changes
-        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # pin@v2.1.1
+      - name: Dispatch to sui-operations for notification
+        uses: peter-evans/repository-dispatch@8e2aaa08bcf5d9a5ef61e3b5ecc11e8e41cbcc48 # pin@v3.0.0
         with:
-          method: chat.postMessage
-          token: ${{ secrets.SLACK_BOT_TOKEN }}
-          payload: |
-            channel: "docs-automations"
-            text: |
-              An open PR modifies files in the `examples/` directory.
-              Please review it: <https://github.com/${{ github.repository }}/pull/${{ github.event.number }}|PR${{ github.event.number }}>
+          token: ${{ secrets.OPERATIONS_DISPATCH_TOKEN }}
+          repository: MystenLabs/sui-operations
+          event-type: docs-change-notify
+          client-payload: |-
+            {
+              "pr_number": "${{ github.event.number }}",
+              "repository": "${{ github.repository }}"
+            }
   
   spelling:
     name: Lint documentation

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -44,78 +44,20 @@ jobs:
     steps:
       - uses: technote-space/workflow-conclusion-action@45ce8e0eb155657ab8ccf346ade734257fd196a5 # Pin v4.1.1
 
-      - name: Checkout sui repo main branch
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
-    
       - name: Get sui commit
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          export sui_sha=$(git rev-parse HEAD)
-          echo "sui_sha=${sui_sha}" >> $GITHUB_ENV
+        run: echo "sui_sha=$(git rev-parse HEAD)" >> $GITHUB_ENV
 
-      - name: Get current oncall from PagerDuty
-        run: |
-          # Fetch oncall info including user details (for email)
-          response=$(curl -s --max-time 30 --request GET \
-            --url 'https://api.pagerduty.com/oncalls?schedule_ids[]=PGCQ3YS&include[]=users' \
-            --header 'Accept: application/json' \
-            --header 'Authorization: Token token=${{ secrets.PAGERDUTY_ACCESS_KEY }}' \
-            --header 'Content-Type: application/json')
-
-          oncall_email=$(echo "$response" | jq -r '.oncalls[0].user.email // empty')
-          oncall_user_name=$(echo "$response" | jq -r '.oncalls[0].user.summary // empty')
-          oncall_policy=$(echo "$response" | jq -r '.oncalls[0].escalation_policy.summary // empty')
-
-          echo "oncall_email=${oncall_email}" >> "$GITHUB_ENV"
-          echo "oncall_user_name=${oncall_user_name}" >> "$GITHUB_ENV"
-          echo "oncall_policy=${oncall_policy}" >> "$GITHUB_ENV"
-
-          if [ -z "$oncall_email" ]; then
-            echo "::warning::Could not get oncall email from PagerDuty"
-          fi
-
-      - name: Get Slack ID for oncall
-        run: |
-          if [ -z "${{ env.oncall_email }}" ]; then
-            echo "::warning::No oncall email available, skipping Slack lookup"
-            echo "slack_id=" >> "$GITHUB_ENV"
-            exit 0
-          fi
-
-          # URL-encode the email for the API call
-          encoded_email=$(printf '%s' "${{ env.oncall_email }}" | jq -sRr @uri)
-
-          # Lookup Slack ID from email
-          slack_response=$(curl -s --max-time 30 "https://slack.com/api/users.lookupByEmail?email=${encoded_email}" \
-            -H "Authorization: Bearer ${{ secrets.SLACK_BOT_TOKEN }}")
-
-          slack_ok=$(echo "$slack_response" | jq -r '.ok')
-          slack_id=$(echo "$slack_response" | jq -r '.user.id // empty')
-
-          if [ "$slack_ok" != "true" ]; then
-            error=$(echo "$slack_response" | jq -r '.error')
-            echo "::warning::Slack lookup failed for ${{ env.oncall_email }}: ${error}"
-            echo "slack_id=" >> "$GITHUB_ENV"
-            exit 0
-          fi
-
-          echo "slack_id=${slack_id}" >> "$GITHUB_ENV" 
-
-      - name: Post to slack
-        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # pin@v2.1.1
-        env:
-          SUI_SHA: ${{ env.sui_sha }}
-          SLACK_ID: ${{ env.slack_id }}
-          ONCALL_USER_NAME: ${{ env.oncall_user_name }}
-          ONCALL_POLICY: ${{ env.oncall_policy }}
+      - name: Dispatch to sui-operations for notification
+        uses: peter-evans/repository-dispatch@8e2aaa08bcf5d9a5ef61e3b5ecc11e8e41cbcc48 # pin@v3.0.0
         with:
-          method: chat.postMessage
-          token: ${{ secrets.SLACK_BOT_TOKEN }}
-          payload: |
-            channel: "build-failures-sui"
-            text: |
-              :sui::error-cross: Workflow *${{ github.workflow }}* has `${{ env.WORKFLOW_CONCLUSION }}`.
-              Sui commit: <https://github.com/MystenLabs/sui/commit/${{ env.SUI_SHA }}|${{ env.SUI_SHA }}>
-              ${{ env.SLACK_ID && format('<@{0}>', env.SLACK_ID) || env.ONCALL_USER_NAME }}, current `${{ env.ONCALL_POLICY }}` oncall, please debug failures.
-              Logs are here: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.run_id }}>
+          token: ${{ secrets.OPERATIONS_DISPATCH_TOKEN }}
+          repository: MystenLabs/sui-operations
+          event-type: nightly-build-failure
+          client-payload: |-
+            {
+              "commit_sha": "${{ env.sui_sha }}",
+              "run_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+              "run_id": "${{ github.run_id }}",
+              "workflow_name": "${{ github.workflow }}",
+              "workflow_conclusion": "${{ env.WORKFLOW_CONCLUSION }}"
+            }

--- a/.github/workflows/release-notes-monitor.yml
+++ b/.github/workflows/release-notes-monitor.yml
@@ -115,18 +115,20 @@ jobs:
         echo "author=${author}" >> $GITHUB_ENV
         echo "pr_title=${pr_title}" >> $GITHUB_ENV
 
-    - name: Post to a Slack channel
-      uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # pin@v2.1.1
+    - name: Dispatch to sui-operations for notification
+      uses: peter-evans/repository-dispatch@8e2aaa08bcf5d9a5ef61e3b5ecc11e8e41cbcc48 # pin@v3.0.0
       with:
-        method: chat.postMessage
-        token: ${{ secrets.SLACK_BOT_TOKEN }}
-        payload: |
-          channel: "#ext-mysten-release-notes"
-          text: |
-            ${{ vars.RELEASE_NOTES_REVIEWERS_SLACK_MENTIONS || '' }}${{ vars.RELEASE_NOTES_REVIEWERS_SLACK_MENTIONS && ', please' || 'Please' }} review release notes for upcoming `v${{ needs.get-list-of-prs.outputs.sui_version }}` release.
-            *PR* <https://github.com/MystenLabs/sui/pull/${{ matrix.pr }}|#${{ matrix.pr }}: ${{ env.pr_title }}> by <https://github.com/${{ env.author }}|@${{ env.author }}>
-            *Release Notes:*
-            ${{ steps.read-notes.outputs.release_notes }}
+        token: ${{ secrets.OPERATIONS_DISPATCH_TOKEN }}
+        repository: MystenLabs/sui-operations
+        event-type: release-notes-review
+        client-payload: |-
+          {
+            "pr_number": "${{ matrix.pr }}",
+            "pr_title": "${{ env.pr_title }}",
+            "author": "${{ env.author }}",
+            "release_notes": ${{ toJSON(steps.read-notes.outputs.release_notes) }},
+            "sui_version": "${{ needs.get-list-of-prs.outputs.sui_version }}"
+          }
 
   update-last-processed-commit:
     name: Update last processed commit

--- a/.github/workflows/simulator-nightly.yml
+++ b/.github/workflows/simulator-nightly.yml
@@ -84,6 +84,7 @@ jobs:
           tsh -i ${{ steps.auth.outputs.identity-file }} ssh ubuntu@simtest-01 "source ~/.bashrc && source ~/.cargo/env && cd ~/sui && ./scripts/simtest/install.sh"
 
       - name: Set protocol config override based on trigger
+        id: protocol
         # This step determines which protocol config override to use.
         # It checks if the trigger was a manual dispatch or a specific schedule.
         run: |
@@ -124,6 +125,7 @@ jobs:
     outputs:
       failed_tests: ${{ steps.failures.outputs.failed_tests }}
       log_dir: ${{ steps.failures.outputs.log_dir }}
+      protocol_message: ${{ steps.protocol.outputs.protocol_message }}
 
   notify:
     name: Notify
@@ -134,92 +136,23 @@ jobs:
     steps:
     - uses: technote-space/workflow-conclusion-action@45ce8e0eb155657ab8ccf346ade734257fd196a5 # Pin v4.1.1
 
-    - name: Checkout sui repo main branch
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
-    
     - name: Get sui commit
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        export sui_sha=$(git rev-parse HEAD)
-        echo "sui_sha=${sui_sha}" >> $GITHUB_ENV
+      run: echo "sui_sha=$(git rev-parse HEAD)" >> $GITHUB_ENV
 
-    - name: Get link to logs
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        gh_job_link=$(gh api -X GET 'repos/MystenLabs/sui/actions/runs/${{ github.run_id }}/jobs' --jq '.jobs.[0].html_url')
-        echo "gh_job_link=${gh_job_link}" >> $GITHUB_ENV
-
-    - name: Get current oncall from PagerDuty
-      run: |
-        # Fetch oncall info including user details (for email)
-        response=$(curl -s --max-time 30 --request GET \
-          --url 'https://api.pagerduty.com/oncalls?schedule_ids[]=PGCQ3YS&include[]=users' \
-          --header 'Accept: application/json' \
-          --header 'Authorization: Token token=${{ secrets.PAGERDUTY_ACCESS_KEY }}' \
-          --header 'Content-Type: application/json')
-
-        oncall_email=$(echo "$response" | jq -r '.oncalls[0].user.email // empty')
-        oncall_user_name=$(echo "$response" | jq -r '.oncalls[0].user.summary // empty')
-        oncall_policy=$(echo "$response" | jq -r '.oncalls[0].escalation_policy.summary // empty')
-
-        echo "oncall_email=${oncall_email}" >> "$GITHUB_ENV"
-        echo "oncall_user_name=${oncall_user_name}" >> "$GITHUB_ENV"
-        echo "oncall_policy=${oncall_policy}" >> "$GITHUB_ENV"
-
-        if [ -z "$oncall_email" ]; then
-          echo "::warning::Could not get oncall email from PagerDuty"
-        fi
-
-    - name: Get Slack ID for oncall
-      run: |
-        if [ -z "${{ env.oncall_email }}" ]; then
-          echo "::warning::No oncall email available, skipping Slack lookup"
-          echo "slack_id=" >> "$GITHUB_ENV"
-          exit 0
-        fi
-
-        # URL-encode the email for the API call
-        encoded_email=$(printf '%s' "${{ env.oncall_email }}" | jq -sRr @uri)
-
-        # Lookup Slack ID from email
-        slack_response=$(curl -s --max-time 30 "https://slack.com/api/users.lookupByEmail?email=${encoded_email}" \
-          -H "Authorization: Bearer ${{ secrets.SLACK_BOT_TOKEN }}")
-
-        slack_ok=$(echo "$slack_response" | jq -r '.ok')
-        slack_id=$(echo "$slack_response" | jq -r '.user.id // empty')
-
-        if [ "$slack_ok" != "true" ]; then
-          error=$(echo "$slack_response" | jq -r '.error')
-          echo "::warning::Slack lookup failed for ${{ env.oncall_email }}: ${error}"
-          echo "slack_id=" >> "$GITHUB_ENV"
-          exit 0
-        fi
-
-        echo "slack_id=${slack_id}" >> "$GITHUB_ENV"        
-
-    - name: Post to slack
-      uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # pin@v2.1.1
-      env:
-        SUI_SHA: ${{ env.sui_sha }}
-        GH_JOB_LINK: ${{ env.gh_job_link }}
-        SLACK_ID: ${{ env.slack_id }}
-        ONCALL_USER_NAME: ${{ env.oncall_user_name }}
-        ONCALL_POLICY: ${{ env.oncall_policy }}
+    - name: Dispatch to sui-operations for notification
+      uses: peter-evans/repository-dispatch@8e2aaa08bcf5d9a5ef61e3b5ecc11e8e41cbcc48 # pin@v3.0.0
       with:
-        method: chat.postMessage
-        token: ${{ secrets.SLACK_BOT_TOKEN }}
-        payload: |
-          channel: "simtest-nightly"
-          text: |
-            :sui::error-cross: *${{ github.workflow }}* ${{ needs.simtest.outputs.protocol_message }}workflow status: `${{ env.WORKFLOW_CONCLUSION }}`
-            Sui commit: <https://github.com/MystenLabs/sui/commit/${{ env.SUI_SHA }}|${{ env.SUI_SHA }}>
-            Run: <${{ env.GH_JOB_LINK }}|${{ github.run_id }}>
-
-            *Failed tests:*
-            ```
-            ${{ needs.simtest.outputs.failed_tests }}
-            ```
-
-            ${{ env.SLACK_ID && format('<@{0}>', env.SLACK_ID) || env.ONCALL_USER_NAME }}, current `${{ env.ONCALL_POLICY }}` oncall, please debug: `tsh ssh ubuntu@simtest-01` and look in `${{ needs.simtest.outputs.log_dir }}`
+        token: ${{ secrets.OPERATIONS_DISPATCH_TOKEN }}
+        repository: MystenLabs/sui-operations
+        event-type: simtest-failure
+        client-payload: |-
+          {
+            "commit_sha": "${{ env.sui_sha }}",
+            "run_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+            "run_id": "${{ github.run_id }}",
+            "workflow_name": "${{ github.workflow }}",
+            "workflow_conclusion": "${{ env.WORKFLOW_CONCLUSION }}",
+            "protocol_message": "${{ needs.simtest.outputs.protocol_message }}",
+            "failed_tests": ${{ toJSON(needs.simtest.outputs.failed_tests) }},
+            "log_dir": "${{ needs.simtest.outputs.log_dir }}"
+          }


### PR DESCRIPTION
## Summary
- Migrate all PagerDuty oncall lookups and Slack notifications from sui repo to sui-operations
- Replace direct Slack/PagerDuty API calls with `repository_dispatch` events
- This allows removing `PAGERDUTY_ACCESS_KEY` and `SLACK_BOT_TOKEN` secrets from sui repo

## Changes
| Workflow | Event Type | Channel |
|----------|------------|---------|
| nightly.yml | `nightly-build-failure` | #build-failures-sui |
| cargo-llvm-cov.yml | `code-coverage-notify` | #code-coverage |
| simulator-nightly.yml | `simtest-failure` | #simtest-nightly |
| release-notes-monitor.yml | `release-notes-review` | #ext-mysten-release-notes |
| docs.yml | `docs-change-notify` | #docs-automations |

## Dependencies
Requires sui-operations PR #7019 to be merged first (adds the dispatch handlers). ✅ Merged

## Test plan

### Code Quality
- [x] actionlint passes on all modified workflows
- [x] Fixed missing `protocol_message` output in simulator-nightly.yml (added step id and job output)

### E2E Testing
Tested all 5 dispatch handlers by sending test payloads directly to sui-operations:

| Handler | Run | Status |
|---------|-----|--------|
| `nightly-build-failure` | [#21645848741](https://github.com/MystenLabs/sui-operations/actions/runs/21645848741) | ✅ |
| `simtest-failure` | [#21645869002](https://github.com/MystenLabs/sui-operations/actions/runs/21645869002) | ✅ |
| `docs-change-notify` | [#21645898307](https://github.com/MystenLabs/sui-operations/actions/runs/21645898307) | ✅ |
| `code-coverage-notify` | [#21645912938](https://github.com/MystenLabs/sui-operations/actions/runs/21645912938) | ✅ |
| `release-notes-review` | [#21645928246](https://github.com/MystenLabs/sui-operations/actions/runs/21645928246) | ✅ |

All handlers:
- Triggered correctly via repository_dispatch
- PagerDuty oncall lookup works (for handlers that use it)
- Slack notifications sent successfully
- Payload validation passes

### Post-merge verification
- [ ] Verify natural workflow triggers dispatch correctly (nightly runs, PR events, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)