### PR TITLE
Discovery: Add support for trusted `AccessType`

### DIFF
--- a/crates/sui-config/src/p2p.rs
+++ b/crates/sui-config/src/p2p.rs
@@ -418,15 +418,21 @@ impl StateSyncConfig {
 /// AccessType info is shared in the discovery process.
 /// * If the node marks itself as Public, other nodes may try to connect to it.
 /// * If the node marks itself as Private, only nodes that have it in
-///   their `allowlisted_peers` or `seed_peers` will try to connect to it.
+///   their `allowlisted_peers` or `seed_peers` will try to connect to it. The
+///   node's info will not be shared through discovery.
+/// * Trusted is the same as Private, except it allows sharing the node's info
+///   only to other preconfigured peers (i.e. those in `allowlisted_peers` and
+///   `seed_peers`).
 /// * If not set, defaults to Public.
 ///
 /// AccessType is useful when a network of nodes want to stay private. To achieve this,
-/// mark every node in this network as `Private` and allowlist/seed them to each other.
+/// mark every node in this network as `Private` or `Trusted`, and allowlist/seed them
+/// to each other.
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum AccessType {
     Public,
     Private,
+    Trusted,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]

--- a/crates/sui-network/src/discovery/mod.rs
+++ b/crates/sui-network/src/discovery/mod.rs
@@ -626,10 +626,12 @@ fn update_known_peers(
             continue;
         }
 
-        // If Peer is Private, and not in our configured peers, skip it.
-        if peer_info.access_type == AccessType::Private
-            && !configured_peers.contains_key(&peer_info.peer_id)
-        {
+        // If Peer is Private or Trusted, and not in our configured peers, skip it.
+        let is_restricted = match peer_info.access_type {
+            AccessType::Public => false,
+            AccessType::Private | AccessType::Trusted => true,
+        };
+        if is_restricted && !configured_peers.contains_key(&peer_info.peer_id) {
             continue;
         }
 


### PR DESCRIPTION
## Description 

Nodes configured as `Trusted` are shared in discovery only among other trusted (preconfigured) peers.

## Test plan 

Unit tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
