### PR TITLE
[alloy][sui-bridge] Integrate Alloy multiprovider in sui bridge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,7 +424,7 @@ dependencies = [
 [[package]]
 name = "alloy-multiprovider-strategy"
 version = "0.1.0"
-source = "git+https://github.com/0xsiddharthks/alloy-multiprovider-strategy?rev=d94800292ffd393b7776817d01bca0c4f2533087#d94800292ffd393b7776817d01bca0c4f2533087"
+source = "git+https://github.com/0xsiddharthks/alloy-multiprovider-strategy?rev=0f8d034e679631a715f9eed104089430ae57283a#0f8d034e679631a715f9eed104089430ae57283a"
 dependencies = [
  "alloy-json-rpc",
  "alloy-network",

--- a/crates/sui-bridge/Cargo.toml
+++ b/crates/sui-bridge/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2024"
 
 [dependencies]
 alloy = { version = "1.1.3", features = ["rand", "sol-types", "json-rpc", "provider-ws"] }
-alloy-multiprovider-strategy = { git = "https://github.com/0xsiddharthks/alloy-multiprovider-strategy", rev = "d94800292ffd393b7776817d01bca0c4f2533087" }
+alloy-multiprovider-strategy = { git = "https://github.com/0xsiddharthks/alloy-multiprovider-strategy", rev = "0f8d034e679631a715f9eed104089430ae57283a" }
 tokio = { workspace = true, features = ["full"] }
 sui-types.workspace = true
 sui-authority-aggregation.workspace = true

--- a/crates/sui-bridge/src/e2e_tests/test_utils.rs
+++ b/crates/sui-bridge/src/e2e_tests/test_utils.rs
@@ -893,8 +893,8 @@ pub(crate) async fn start_bridge_cluster(
             run_client: i == 0,
             db_path: Some(db_path),
             eth: EthConfig {
-                eth_rpc_url: Some(eth_environment.rpc_url.clone()),
-                eth_rpc_urls: None,
+                eth_rpc_url: None, // to be deprecated
+                eth_rpc_urls: Some(vec![eth_environment.rpc_url.clone()]),
                 eth_rpc_quorum: 1,
                 eth_health_check_interval_secs: 300,
                 eth_bridge_proxy_address: eth_bridge_contract_address.clone(),

--- a/crates/sui-bridge/src/eth_client.rs
+++ b/crates/sui-bridge/src/eth_client.rs
@@ -37,9 +37,8 @@ impl EthClient {
         Ok(self_)
     }
 
-    /// Construct from a pre-built provider. Use this when the provider has
-    /// already been created (e.g. during config validation) to avoid
-    /// creating a second connection.
+    /// Construct from a pre-built provider.
+    /// Use this when the provider has already been created, to avoid creating a new connection.
     pub async fn from_provider(
         provider: EthProvider,
         contract_addresses: HashSet<EthAddress>,

--- a/crates/sui-bridge/src/node.rs
+++ b/crates/sui-bridge/src/node.rs
@@ -696,8 +696,8 @@ mod tests {
                 sui_bridge_next_sequence_number_override: None,
             },
             eth: EthConfig {
-                eth_rpc_url: Some(bridge_test_cluster.eth_rpc_url()),
-                eth_rpc_urls: None,
+                eth_rpc_url: None,
+                eth_rpc_urls: Some(vec![bridge_test_cluster.eth_rpc_url()]),
                 eth_rpc_quorum: 1,
                 eth_health_check_interval_secs: 300,
                 eth_bridge_proxy_address: bridge_test_cluster.sui_bridge_address(),
@@ -767,8 +767,8 @@ mod tests {
                 sui_bridge_next_sequence_number_override: None,
             },
             eth: EthConfig {
-                eth_rpc_url: Some(bridge_test_cluster.eth_rpc_url()),
-                eth_rpc_urls: None,
+                eth_rpc_url: None,
+                eth_rpc_urls: Some(vec![bridge_test_cluster.eth_rpc_url()]),
                 eth_rpc_quorum: 1,
                 eth_health_check_interval_secs: 300,
                 eth_bridge_proxy_address: bridge_test_cluster.sui_bridge_address(),
@@ -849,8 +849,8 @@ mod tests {
                 sui_bridge_next_sequence_number_override: None,
             },
             eth: EthConfig {
-                eth_rpc_url: Some(bridge_test_cluster.eth_rpc_url()),
-                eth_rpc_urls: None,
+                eth_rpc_url: None,
+                eth_rpc_urls: Some(vec![bridge_test_cluster.eth_rpc_url()]),
                 eth_rpc_quorum: 1,
                 eth_health_check_interval_secs: 300,
                 eth_bridge_proxy_address: bridge_test_cluster.sui_bridge_address(),

--- a/crates/sui-bridge/src/utils.rs
+++ b/crates/sui-bridge/src/utils.rs
@@ -314,8 +314,8 @@ pub fn generate_bridge_node_config_and_write_to_file(
             sui_bridge_next_sequence_number_override: None,
         },
         eth: EthConfig {
-            eth_rpc_url: Some("your_eth_rpc_url".to_string()),
-            eth_rpc_urls: None,
+            eth_rpc_url: None, // to be deprecated
+            eth_rpc_urls: Some(vec!["your_eth_rpc_url".to_string()]),
             eth_rpc_quorum: 1,
             eth_health_check_interval_secs: 300,
             eth_bridge_proxy_address: "0x0000000000000000000000000000000000000000".to_string(),


### PR DESCRIPTION
## Description 

This PR builds on top of #24575 and replaces the native Alloy provider with the [multiprovider implementation](https://github.com/0xsiddharthks/alloy-multiprovider-strategy).

I have added the following fields to the sui bridge config:
- eth_rpc_url (deprecated. kept for backward compatibility)
- eth_rpc_urls
- eth_rpc_quorum
- eth_health_check_interval_secs

This change is backwords compatible with the existing config, but we will deprecate the eth_rpc_url field in the future once all node operators have migrated to using the new config fields.

## Test plan 

I have thoroughly tested the `alloy-multiprovider-strategy` crate via various test scripts.

Also all the CI tests are passing on the sui repo.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [x] Nodes (Validators and Full nodes): Added multi-provider Ethereum RPC support to the bridge node. 

Operators can now configure multiple Ethereum RPC endpoints with quorum-based consensus for improved redundancy and fault tolerance. 

New optional YAML config fields (in sui bridge config): 
- `eth-rpc-urls` (list of RPC URLs), 
- `eth-rpc-quorum` (quorum size, defaults to 1)
- `eth-health-check-interval-secs` (health check interval, defaults to 300s).

The existing `eth-rpc-url` field continues to work for backward compatibility. When a single URL is configured, the multi-provider layer operates as a zero-overhead passthrough with no quorum, health-check, or locking machinery.
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
