### PR TITLE
[antithesis] use branch name as description when unspecified

### DIFF
--- a/scripts/run-antithesis-tests
+++ b/scripts/run-antithesis-tests
@@ -35,6 +35,28 @@ fi
 
 branch=$(git rev-parse HEAD)
 
+remote_branches=$(git branch -r --contains "$branch" 2>/dev/null)
+if [ -z "$remote_branches" ]; then
+  echo "Error: Current commit $branch has not been pushed to remote. Please push your changes first." >&2
+  exit 1
+fi
+
+if [ -z "$DESCRIPTION" ]; then
+  tracking_branch=$(git rev-parse --abbrev-ref --symbolic-full-name @{upstream} 2>/dev/null)
+  if [ -n "$tracking_branch" ]; then
+    DESCRIPTION=${tracking_branch#origin/}
+  else
+    local_branch=$(git rev-parse --abbrev-ref HEAD)
+    if [ "$local_branch" != "HEAD" ]; then
+      DESCRIPTION=$local_branch
+    fi
+  fi
+fi
+
+if [ -n "$DESCRIPTION" ]; then
+  echo "Description: $DESCRIPTION"
+fi
+
 if [ "$SPLIT_VERSION" = true ]; then
   if [ -n "$ALT_COMMIT" ]; then
     COMMIT=$ALT_COMMIT


### PR DESCRIPTION
## Description 

minor quality of life improvements to antithesis command

## Test plan 

tested with unpushed branch and pushed branch - description set correctly

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
