### PR TITLE
[antithesis] allow specifying a branch name for alt instead of commit SHA

### DIFF
--- a/scripts/run-antithesis-tests
+++ b/scripts/run-antithesis-tests
@@ -33,6 +33,18 @@ if [ -z "$TEST_DURATION" ]; then
   TEST_DURATION=0.25
 fi
 
+if [ -n "$ALT_COMMIT" ]; then
+  resolved_commit=$(git rev-parse --verify "$ALT_COMMIT^{commit}" 2>/dev/null)
+  if [ -z "$resolved_commit" ]; then
+    resolved_commit=$(git rev-parse --verify "origin/$ALT_COMMIT^{commit}" 2>/dev/null)
+  fi
+  if [ -z "$resolved_commit" ]; then
+    echo "Error: Could not resolve '$ALT_COMMIT' to a commit SHA" >&2
+    exit 1
+  fi
+  ALT_COMMIT=$resolved_commit
+fi
+
 branch=$(git rev-parse HEAD)
 
 remote_branches=$(git branch -r --contains "$branch" 2>/dev/null)


### PR DESCRIPTION
## Description 

minor antithesis improvement

## Test plan 

tested locally with existing and non-existing branches

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
