### PR TITLE
Fix simtest failure notification missing commit_sha

### DIFF
--- a/.github/workflows/simulator-nightly.yml
+++ b/.github/workflows/simulator-nightly.yml
@@ -136,9 +136,6 @@ jobs:
     steps:
     - uses: technote-space/workflow-conclusion-action@45ce8e0eb155657ab8ccf346ade734257fd196a5 # Pin v4.1.1
 
-    - name: Get sui commit
-      run: echo "sui_sha=$(git rev-parse HEAD)" >> $GITHUB_ENV
-
     - name: Dispatch to sui-operations for notification
       uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # pin@v4.0.1
       with:
@@ -147,7 +144,7 @@ jobs:
         event-type: simtest-failure
         client-payload: |-
           {
-            "commit_sha": "${{ env.sui_sha }}",
+            "commit_sha": "${{ github.sha }}",
             "run_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
             "run_id": "${{ github.run_id }}",
             "workflow_name": "${{ github.workflow }}",


### PR DESCRIPTION
## Summary
- Remove broken `git rev-parse HEAD` step that ran on a fresh runner without checkout
- Use `github.sha` directly which GitHub provides for scheduled runs

## Root Cause
The `notify` job runs on a fresh `ubuntu-latest` runner that never checks out the repo. The `git rev-parse HEAD` command returned empty, causing the dispatch to fail with "Missing required field: commit_sha".

Failed run: https://github.com/MystenLabs/sui-operations/actions/runs/21673729924

## Test Plan
- [x] Run `actionlint` on workflow - passes (pre-existing warnings unrelated to change)
- [x] Verify `github.sha` provides correct value for scheduled runs:
  - Failed run had `head_sha: 3fd85b70368fefc17d840f96c8436c8bed679d5f`
  - This matches what `github.sha` would have provided
- [x] Backwards compatible - sui-operations workflow unchanged, just receives correct data now
- [x] No changes to sui-operations needed - it already validates `commit_sha` is present

🤖 Generated with [Claude Code](https://claude.ai/code)