### PR TITLE
Preserve serialized format for `deferred_transactions_with_aliases_v2`

### DIFF
--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -70,9 +70,9 @@ use sui_types::sui_system_state::epoch_start_sui_system_state::{
 };
 use sui_types::sui_system_state::{self, SuiSystemState};
 use sui_types::transaction::{
-    AuthenticatorStateUpdate, CertifiedTransaction, InputObjectKind, ProgrammableTransaction,
-    SenderSignedData, StoredExecutionTimeObservations, Transaction, TransactionData,
-    TransactionDataAPI, TransactionKey, TransactionKind, TxValidityCheckContext,
+    AuthenticatorStateUpdate, CertifiedTransaction, DeprecatedWithAliases, InputObjectKind,
+    ProgrammableTransaction, SenderSignedData, StoredExecutionTimeObservations, Transaction,
+    TransactionData, TransactionDataAPI, TransactionKey, TransactionKind, TxValidityCheckContext,
     VerifiedSignedTransaction, VerifiedTransaction, VerifiedTransactionWithAliases, WithAliases,
 };
 use tap::TapOptional;
@@ -595,6 +595,8 @@ pub struct AuthorityEpochTables {
     pub(crate) execution_time_observations:
         DBMap<(u64, AuthorityIndex), Vec<(ExecutionTimeObservationKey, Duration)>>,
     deferred_transactions_with_aliases_v2:
+        DBMap<DeferralKey, Vec<DeprecatedWithAliases<TrustedExecutableTransaction>>>,
+    deferred_transactions_with_aliases_v3:
         DBMap<DeferralKey, Vec<TrustedExecutableTransactionWithAliases>>,
 }
 
@@ -992,6 +994,39 @@ impl AuthorityEpochTables {
             })
             .chain(
                 self.deferred_transactions_with_aliases_v2
+                    .safe_iter()
+                    // The v2 table contains the deprecated format with SuiAddress instead of u8.
+                    // We convert by preserving the sequence numbers, but using 0 for the indexes.
+                    // This is safe because as long as the fix_checkpoint_signature_mapping flag is
+                    // false (which it must be for all builds that write to the v2 table),
+                    // the indexes will be thrown out when mapping signatures to alias config
+                    // versions.
+                    .map(
+                        |item: Result<
+                            (
+                                DeferralKey,
+                                Vec<DeprecatedWithAliases<TrustedExecutableTransaction>>,
+                            ),
+                            _,
+                        >| {
+                            item.map(|(key, txs)| {
+                                (
+                                    key,
+                                    txs.into_iter()
+                                        .map(|tx| {
+                                            let (inner, aliases) = tx.into_inner();
+                                            let new_aliases =
+                                                aliases.map(|(_addr, seq)| (0u8, seq));
+                                            WithAliases::new(inner, new_aliases).into()
+                                        })
+                                        .collect(),
+                                )
+                            })
+                        },
+                    ),
+            )
+            .chain(
+                self.deferred_transactions_with_aliases_v3
                     .safe_iter()
                     .map(|item| {
                         item.map(|(key, txs)| (key, txs.into_iter().map(Into::into).collect()))

--- a/crates/sui-core/src/authority/consensus_quarantine.rs
+++ b/crates/sui-core/src/authority/consensus_quarantine.rs
@@ -336,9 +336,13 @@ impl ConsensusCommitOutput {
             &tables.deferred_transactions_with_aliases_v2,
             &self.deleted_deferred_txns,
         )?;
+        batch.delete_batch(
+            &tables.deferred_transactions_with_aliases_v3,
+            &self.deleted_deferred_txns,
+        )?;
 
         batch.insert_batch(
-            &tables.deferred_transactions_with_aliases_v2,
+            &tables.deferred_transactions_with_aliases_v3,
             self.deferred_txns.into_iter().map(|(key, txs)| {
                 (
                     key,

--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -3868,6 +3868,21 @@ pub type TransactionWithAliases = WithAliases<Transaction>;
 pub type VerifiedTransactionWithAliases = WithAliases<VerifiedTransaction>;
 pub type TrustedTransactionWithAliases = WithAliases<TrustedTransaction>;
 
+/// Deprecated version of WithAliases that uses SuiAddress instead of u8.
+/// This is needed to read data from deferred_transactions_with_aliases_v2 table
+/// which was written with the old format before the type was changed.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct DeprecatedWithAliases<T>(
+    T,
+    #[serde(with = "nonempty_as_vec")] NonEmpty<(SuiAddress, Option<SequenceNumber>)>,
+);
+
+impl<T> DeprecatedWithAliases<T> {
+    pub fn into_inner(self) -> (T, NonEmpty<(SuiAddress, Option<SequenceNumber>)>) {
+        (self.0, self.1)
+    }
+}
+
 impl<T: Message, S> From<WithAliases<VerifiedEnvelope<T, S>>> for WithAliases<Envelope<T, S>> {
     fn from(value: WithAliases<VerifiedEnvelope<T, S>>) -> Self {
         Self(value.0.into(), value.1)


### PR DESCRIPTION
Adds a new table `deferred_transactions_with_aliases_v3` for the new format.


---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
