### PR TITLE
fix(examples): resolve deprecated string::bytes usage in map_guess

### DIFF
--- a/docs/content/guides/developer/app-examples/coin-flip.mdx
+++ b/docs/content/guides/developer/app-examples/coin-flip.mdx
@@ -580,9 +580,9 @@ The rest of the functions are accessors and helper functions used to retrieve va
   fun map_guess(guess: String): u8 {
     let heads = HEADS;
     let tails = TAILS;
-    assert!(guess.bytes() == heads || guess.bytes() == tails, EInvalidGuess);
+    assert!(guess.as_bytes() == heads || guess.as_bytes() == tails, EInvalidGuess);
 
-    if (guess.bytes() == heads) {
+    if (guess.as_bytes() == heads) {
       0
     } else {
       1


### PR DESCRIPTION
## Description 

This PR fixes a compiler warning in the Sui Documentation / App examples / Coin Flip.
In the contract [single_player_satoshi.move](https://github.com/MystenLabs/sui/blob/main/single_player_satoshi.move), the function `map_guess()` used the method `std::string::bytes()`, which is deprecated. I have replaced it with `std::string::as_bytes()` in the `map_guess` function to resolve the warning and align with current Move standard library best practices.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
