### PR TITLE
Fix safe_iter to return Err on deserialization failure

### DIFF
--- a/crates/typed-store/src/rocks/tests.rs
+++ b/crates/typed-store/src/rocks/tests.rs
@@ -801,11 +801,7 @@ async fn test_safe_iter_returns_error_on_deserialization_failure() {
 
     // Verify each result is an error
     for (i, result) in results.iter().enumerate() {
-        assert!(
-            result.is_err(),
-            "Entry {} should be an Err, got Ok",
-            i
-        );
+        assert!(result.is_err(), "Entry {} should be an Err, got Ok", i);
     }
 
     // Verify the data is still there by reading with the correct type


### PR DESCRIPTION
## Summary
- Fixed a bug in `SafeIter::next()` where values that fail to deserialize were silently ignored
- Previously, `.ok()` converted deserialization errors to `None`, causing failed entries to be skipped with no indication
- Now returns `Err(TypedStoreError::SerializationError)` for each entry that fails to deserialize

## Test plan
- Added `test_safe_iter_returns_error_on_deserialization_failure` which:
  - Writes values with one type (`OriginalValue`)
  - Attempts to iterate with an incompatible type (`IncompatibleValue`)
  - Verifies that 3 `Err` results are returned (one per entry)

🤖 Generated with [Claude Code](https://claude.ai/code)