### PR TITLE
[v1.65.0] tidehunter: add `deferred_transactions_with_aliases_v3` table

### DIFF
--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -837,6 +837,10 @@ impl AuthorityEpochTables {
                 ThConfig::new_with_indexing(KeyIndexing::Hash, mutexes, uniform_key),
             ),
             (
+                "deferred_transactions_with_aliases_v3".to_string(),
+                ThConfig::new_with_indexing(KeyIndexing::Hash, mutexes, uniform_key),
+            ),
+            (
                 "dkg_processed_messages_v2".to_string(),
                 ThConfig::new(2, 1, KeyType::uniform(1)),
             ),


### PR DESCRIPTION
## Summary

Cherry-pick of #25291 to `releases/sui-v1.65.0-release`.

- Adds tidehunter configuration for the new `deferred_transactions_with_aliases_v3` table

This fixes a panic on tidehunter nodes when starting up after #25274 was applied:

```
Missing tidehunter configuration for table deferred_transactions_with_aliases_v3 from database AuthorityEpochTables
```

## Test plan

- Verify tidehunter nodes can start without panic

🤖 Generated with [Claude Code](https://claude.com/claude-code)