### PR TITLE
Fix release tag creation to use correct token and error handling

### DIFF
--- a/.github/workflows/create-release-announce.yml
+++ b/.github/workflows/create-release-announce.yml
@@ -93,14 +93,9 @@ jobs:
           echo "release_tag=${release_tag}" >> $GITHUB_ENV
           echo "new_tag=${release_tag}" >> "$GITHUB_OUTPUT"
 
-          curl -X POST \
-            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            -H "Accept: application/vnd.github+json" \
-            https://api.github.com/repos/MystenLabs/sui/git/refs \
-            -d "{
-              \"ref\": \"refs/tags/${release_tag}\",
-              \"sha\": \"${{ inputs.sui_commit }}\"
-            }"
+          echo "{\"ref\": \"refs/tags/${release_tag}\", \"sha\": \"${{ inputs.sui_commit }}\"}" | \
+            gh api -X POST /repos/MystenLabs/sui/git/refs \
+              --header "Accept: application/vnd.github+json" --input -
 
       - name: Get commits for branches
         shell: bash


### PR DESCRIPTION
## Summary

- Use `gh api` instead of `curl` for tag creation (consistent with branch update steps)
- This uses the `SUI_CREATE_RELEASE` token already authenticated via `gh auth login`
- `gh api` properly fails on non-2xx responses, preventing silent failures

## Root Cause

The tag creation step was using `GITHUB_TOKEN` which doesn't have permission to create tags. The `curl` command returned exit code 0 even when the API returned a 403 error, causing the workflow to show "success" despite the tag never being created.

```json
{
  "message": "Resource not accessible by integration",
  "status": "403"
}
```

This caused the `devnet-v1.65.0` release workflow to silently fail to create the tag.

## Test plan

- [x] Run `actionlint` on the workflow file
- [x] E2E: Tag creation with valid commit - creates tag successfully  
- [x] E2E: Error handling with invalid sha - fails with exit code 1
- [x] E2E: Error handling with permission denied - fails with exit code 1
- [x] E2E: Simulated workflow step - works as expected
- [ ] Manually trigger the release workflow for devnet to verify tag creation works

🤖 Generated with [Claude Code](https://claude.com/claude-code)