### PR TITLE
[gasless] add gasless_send_funds method to balance

### DIFF
--- a/crates/sui-framework/packages/sui-framework/sources/balance.move
+++ b/crates/sui-framework/packages/sui-framework/sources/balance.move
@@ -103,6 +103,14 @@ public fun send_funds<T>(balance: Balance<T>, recipient: address) {
     sui::funds_accumulator::add_impl(balance, recipient);
 }
 
+/// Gasless (free tier) transfer: 
+/// Send a `Balance` to an address's funds accumulator.
+/// Basis points (BPs) may be charged on the transfer amount
+/// in the future.
+public fun gasless_send_funds<T>(balance: Balance<T>, recipient: address) {
+    sui::funds_accumulator::add_impl(balance, recipient);
+}
+
 /// Redeem a `Withdrawal<Balance<T>>` to get the underlying `Balance<T>` from an address's funds
 /// accumulator.
 public fun redeem_funds<T>(withdrawal: sui::funds_accumulator::Withdrawal<Balance<T>>): Balance<T> {


### PR DESCRIPTION
## Description 

Add gasless_send_funds() method to Balance.move.
This is not a ready-to-merge PR and is intended to start a discussion about the API design for this method

## Test plan 

None

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
