### PR TITLE
Install default rustls CryptoProvider in sui-kv-rpc [1.65 backport]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15760,6 +15760,7 @@ dependencies = [
  "mysten-metrics",
  "mysten-network",
  "prometheus",
+ "rustls 0.23.31",
  "sui-data-ingestion-core",
  "sui-kvstore",
  "sui-protocol-config",

--- a/crates/sui-kv-rpc/Cargo.toml
+++ b/crates/sui-kv-rpc/Cargo.toml
@@ -12,6 +12,7 @@ axum.workspace = true
 bin-version.workspace = true
 clap.workspace = true
 prometheus.workspace = true
+rustls.workspace = true
 mysten-metrics.workspace = true
 mysten-network.workspace = true
 sui-data-ingestion-core.workspace = true

--- a/crates/sui-kv-rpc/src/main.rs
+++ b/crates/sui-kv-rpc/src/main.rs
@@ -42,6 +42,9 @@ async fn health_check() -> &'static str {
 #[tokio::main]
 async fn main() -> Result<()> {
     let _guard = TelemetryConfig::new().with_env().init();
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .expect("Failed to install CryptoProvider");
     let app = App::parse();
     unsafe {
         std::env::set_var("GOOGLE_APPLICATION_CREDENTIALS", app.credentials.clone());


### PR DESCRIPTION
## Summary
- Backport of #25303 to 1.65 release branch
- Install the default ring `CryptoProvider` at startup in `sui-kv-rpc`, same fix as #25300 (sui-indexer-alt-graphql / sui-indexer-alt-jsonrpc)
- Prevents panics when TLS is used without an explicitly installed provider

## Test plan
- [x] `cargo check -p sui-kv-rpc` passes
- [x] Cherry-pick applied cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)