### PR TITLE
Add support for multiple address types to discovery protocol

### DIFF
--- a/crates/sui-config/src/p2p.rs
+++ b/crates/sui-config/src/p2p.rs
@@ -484,6 +484,12 @@ pub struct DiscoveryConfig {
     /// If unspecified, this will default to `1,024`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mailbox_capacity: Option<usize>,
+
+    /// Use get_known_peers_v3 RPC to fetch peer info.
+    ///
+    /// If unspecified, this will default to `false`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub use_get_known_peers_v3: Option<bool>,
 }
 
 impl DiscoveryConfig {
@@ -515,6 +521,10 @@ impl DiscoveryConfig {
         const MAILBOX_CAPACITY: usize = 1_024;
 
         self.mailbox_capacity.unwrap_or(MAILBOX_CAPACITY)
+    }
+
+    pub fn use_get_known_peers_v3(&self) -> bool {
+        self.use_get_known_peers_v3.unwrap_or(false)
     }
 }
 

--- a/crates/sui-network/build.rs
+++ b/crates/sui-network/build.rs
@@ -125,6 +125,15 @@ fn build_anemo_services(out_dir: &Path) {
                 .codec_path(codec_path)
                 .build(),
         )
+        .method(
+            anemo_build::manual::Method::builder()
+                .name("get_known_peers_v3")
+                .route_name("GetKnownPeersV3")
+                .request_type("crate::discovery::GetKnownPeersRequestV3")
+                .response_type("crate::discovery::GetKnownPeersResponseV3")
+                .codec_path(codec_path)
+                .build(),
+        )
         .build();
 
     let state_sync = anemo_build::manual::Service::builder()

--- a/crates/sui-network/src/discovery/server.rs
+++ b/crates/sui-network/src/discovery/server.rs
@@ -1,7 +1,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use super::{Discovery, MAX_PEERS_TO_SEND, SignedNodeInfo, State};
+use super::{
+    Discovery, DiscoveryMessage, MAX_PEERS_TO_SEND, SignedNodeInfo, SignedVersionedNodeInfo, State,
+    VerifiedSignedVersionedNodeInfo,
+};
 use anemo::{PeerId, Request, Response, types::PeerInfo};
 use rand::seq::IteratorRandom;
 use serde::{Deserialize, Serialize};
@@ -10,6 +13,7 @@ use std::{
     sync::{Arc, OnceLock, RwLock},
 };
 use sui_config::p2p::AccessType;
+use tokio::sync::mpsc;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct GetKnownPeersResponseV2 {
@@ -17,9 +21,21 @@ pub struct GetKnownPeersResponseV2 {
     pub known_peers: Vec<SignedNodeInfo>,
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct GetKnownPeersRequestV3 {
+    pub own_info: SignedVersionedNodeInfo,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct GetKnownPeersResponseV3 {
+    pub own_info: SignedVersionedNodeInfo,
+    pub known_peers: Vec<SignedVersionedNodeInfo>,
+}
+
 pub(super) struct Server {
     pub(super) state: Arc<RwLock<State>>,
     pub(super) configured_peers: Arc<OnceLock<HashMap<PeerId, PeerInfo>>>,
+    pub(super) mailbox_sender: mpsc::Sender<DiscoveryMessage>,
 }
 
 #[anemo::async_trait]
@@ -98,6 +114,95 @@ impl Discovery for Server {
         };
 
         Ok(Response::new(GetKnownPeersResponseV2 {
+            own_info,
+            known_peers,
+        }))
+    }
+
+    async fn get_known_peers_v3(
+        &self,
+        request: Request<GetKnownPeersRequestV3>,
+    ) -> Result<Response<GetKnownPeersResponseV3>, anemo::rpc::Status> {
+        let requester_peer_id = request.peer_id().copied();
+
+        // Send pushed peer info to the event loop for processing
+        let pushed_info = request.into_body().own_info;
+        let _ = self
+            .mailbox_sender
+            .try_send(DiscoveryMessage::ReceivedNodeInfo {
+                peer_info: Box::new(pushed_info),
+            });
+
+        let state = self.state.read().unwrap();
+        let own_info = state.our_info_v2.clone().ok_or_else(|| {
+            anemo::rpc::Status::internal("own_info_v2 has not been initialized yet")
+        })?;
+
+        let should_share = |info: &VerifiedSignedVersionedNodeInfo| match info.access_type() {
+            AccessType::Public => true,
+            AccessType::Private => false,
+            AccessType::Trusted => self
+                .configured_peers
+                .get()
+                .and_then(|configured_peers| {
+                    requester_peer_id.map(|id| configured_peers.contains_key(&id))
+                })
+                .unwrap_or(false),
+        };
+
+        let known_peers = if state.known_peers_v2.len() < MAX_PEERS_TO_SEND {
+            state
+                .known_peers_v2
+                .values()
+                .filter(|e| should_share(e))
+                .map(|e| e.inner())
+                .cloned()
+                .collect()
+        } else {
+            let mut rng = rand::thread_rng();
+            // prefer returning peers that we are connected to as they are known-good
+            let mut known_peers: HashMap<PeerId, &VerifiedSignedVersionedNodeInfo> = state
+                .connected_peers
+                .keys()
+                .filter_map(|peer_id| {
+                    state
+                        .known_peers_v2
+                        .get(peer_id)
+                        .map(|info| (*peer_id, info))
+                })
+                .filter(|(_, info)| should_share(info))
+                .choose_multiple(&mut rng, MAX_PEERS_TO_SEND)
+                .into_iter()
+                .collect();
+
+            if known_peers.len() < MAX_PEERS_TO_SEND {
+                // Fill the remaining space with other peers, randomly sampling at most MAX_PEERS_TO_SEND
+                for (peer_id, info) in state
+                    .known_peers_v2
+                    .iter()
+                    .filter(|(_, info)| should_share(info))
+                    // Filter to only peers with a P2P peer_id before sampling
+                    .filter_map(|(_, info)| info.peer_id().map(|pid| (pid, info)))
+                    // This randomly samples the iterator stream but the order of elements after
+                    // sampling may not be random, this is ok though since we're just trying to do
+                    // best-effort on sharing info of peers we haven't connected with ourselves.
+                    .choose_multiple(&mut rng, MAX_PEERS_TO_SEND)
+                {
+                    if known_peers.len() >= MAX_PEERS_TO_SEND {
+                        break;
+                    }
+                    known_peers.insert(peer_id, info);
+                }
+            }
+
+            known_peers
+                .into_values()
+                .map(|e| e.inner())
+                .cloned()
+                .collect()
+        };
+
+        Ok(Response::new(GetKnownPeersResponseV3 {
             own_info,
             known_peers,
         }))

--- a/crates/sui-network/src/endpoint_manager.rs
+++ b/crates/sui-network/src/endpoint_manager.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 
 use arc_swap::ArcSwapOption;
 use mysten_network::Multiaddr;
+use serde::{Deserialize, Serialize};
 use sui_types::crypto::NetworkPublicKey;
 use sui_types::error::{SuiErrorKind, SuiResult};
 use tap::TapFallible;
@@ -103,6 +104,7 @@ impl EndpointManager {
     }
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub enum EndpointId {
     P2p(anemo::PeerId),
     Consensus(NetworkPublicKey),


### PR DESCRIPTION
## Description 

- Creates new versioned node info which tracks addresses for multiple different endpoint types.
- New discovery RPC method uses versioned enum for easier changes in the future.
- New RPC method pushes own address when querying for known peers, making discovery protocol push/pull.

When enabling v3, both v2 and v3 versions are run concurrently. Once all production nodes have v3 enabled, v2 can be removed.

## Test plan 

Unit tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
