### PR TITLE
docs: fix .mdx to .md conversion in markdown export links

### DIFF
--- a/docs/site/scripts/copy-markdown-files.js
+++ b/docs/site/scripts/copy-markdown-files.js
@@ -38,6 +38,9 @@ function cleanMdxComponents(content) {
   // Remove self-closing JSX tags
   cleaned = cleaned.replace(/<\w+[^>]*\/>/g, '');
 
+  // Replace .mdx with .md in markdown links to ensure internal links work
+  cleaned = cleaned.replace(/\[([^\]]+)\]\(([^)]+)\.mdx((?:#[^)]*)?)\)/g, '[$1]($2.md$3)');
+
   // Clean up excessive newlines
   cleaned = cleaned.replace(/\n{3,}/g, '\n\n');
 


### PR DESCRIPTION
Converts .mdx file extensions to .md in all markdown links during export to ensure internal documentation links work correctly when viewing .md URLs.

Example transformation:
- Before: [Checkpoint Data](/guides/file.mdx#section)
- After: [Checkpoint Data](/guides/file.md#section)

The regex pattern only targets markdown link syntax [text](url.mdx), so:
- Inline code mentions of .mdx are preserved (e.g., `file.mdx`)
- Documentation text explaining .mdx format is preserved
- Anchor links (#section) are maintained

This fixes broken internal links when viewing docs via the .md URL feature (e.g., https://docs.sui.io/guides/getting-started.md)

## Description 

Describe the changes or additions included in this PR.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
