### PR TITLE
[consensus] use fifo compaction by default

### DIFF
--- a/consensus/config/src/parameters.rs
+++ b/consensus/config/src/parameters.rs
@@ -92,6 +92,10 @@ pub struct Parameters {
     #[serde(default = "Parameters::default_commit_sync_batches_ahead")]
     pub commit_sync_batches_ahead: usize,
 
+    /// Whether to use FIFO compaction for RocksDB.
+    #[serde(default = "Parameters::default_use_fifo_compaction")]
+    pub use_fifo_compaction: bool,
+
     /// Tonic network settings.
     #[serde(default = "TonicParameters::default")]
     pub tonic: TonicParameters,
@@ -192,6 +196,10 @@ impl Parameters {
         // while keeping the total number of inflight fetches and unprocessed fetched commits limited.
         32
     }
+
+    pub(crate) fn default_use_fifo_compaction() -> bool {
+        true
+    }
 }
 
 impl Default for Parameters {
@@ -213,6 +221,7 @@ impl Default for Parameters {
             commit_sync_parallel_fetches: Parameters::default_commit_sync_parallel_fetches(),
             commit_sync_batch_size: Parameters::default_commit_sync_batch_size(),
             commit_sync_batches_ahead: Parameters::default_commit_sync_batches_ahead(),
+            use_fifo_compaction: Parameters::default_use_fifo_compaction(),
             tonic: TonicParameters::default(),
             internal: InternalParameters::default(),
         }

--- a/consensus/config/tests/snapshots/parameters_test__parameters.snap
+++ b/consensus/config/tests/snapshots/parameters_test__parameters.snap
@@ -23,6 +23,7 @@ dag_state_cached_rounds: 500
 commit_sync_parallel_fetches: 8
 commit_sync_batch_size: 100
 commit_sync_batches_ahead: 32
+use_fifo_compaction: true
 tonic:
   keepalive_interval:
     secs: 10

--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -219,7 +219,10 @@ where
         let network_client = network_manager.client();
 
         let store_path = context.parameters.db_path.as_path().to_str().unwrap();
-        let store = Arc::new(RocksDBStore::new(store_path));
+        let store = Arc::new(RocksDBStore::new(
+            store_path,
+            context.parameters.use_fifo_compaction,
+        ));
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
 
         let block_verifier = Arc::new(SignedBlockVerifier::new(

--- a/consensus/core/src/storage/rocksdb_store.rs
+++ b/consensus/core/src/storage/rocksdb_store.rs
@@ -55,18 +55,22 @@ impl RocksDBStore {
 
     /// Creates a new instance of RocksDB storage.
     #[cfg(not(tidehunter))]
-    pub fn new(path: &str) -> Self {
+    pub fn new(path: &str, use_fifo_compaction: bool) -> Self {
         // Consensus data has high write throughput (all transactions) and is rarely read
         // (only during recovery and when helping peers catch up).
         let db_options = default_db_options().optimize_db_for_write_throughput(2);
         let mut metrics_conf = MetricConf::new("consensus");
         metrics_conf.read_sample_interval = SamplingInterval::new(Duration::from_secs(60), 0);
-        let cf_options = default_db_options().optimize_for_write_throughput();
+        let cf_options = if use_fifo_compaction {
+            default_db_options().optimize_for_no_deletion()
+        } else {
+            default_db_options().optimize_for_write_throughput()
+        };
         let column_family_options = DBMapTableConfigMap::new(BTreeMap::from([
             (
                 Self::BLOCKS_CF.to_string(),
-                default_db_options()
-                    .optimize_for_write_throughput_no_deletion()
+                cf_options
+                    .clone()
                     // Using larger block is ok since there is not much point reads on the cf.
                     .set_block_options(512, 128 << 10),
             ),
@@ -88,7 +92,7 @@ impl RocksDBStore {
     }
 
     #[cfg(tidehunter)]
-    pub fn new(path: &str) -> Self {
+    pub fn new(path: &str, _use_fifo_compaction: bool) -> Self {
         tracing::warn!("Consensus store using tidehunter");
         use typed_store::tidehunter_util::{
             KeyIndexing, KeySpaceConfig, KeyType, ThConfig, default_mutex_count,

--- a/consensus/core/src/storage/store_tests.rs
+++ b/consensus/core/src/storage/store_tests.rs
@@ -31,7 +31,7 @@ impl TestStore {
 fn new_rocksdb_teststore() -> TestStore {
     let temp_dir = TempDir::new().unwrap();
     TestStore::RocksDB((
-        RocksDBStore::new(temp_dir.path().to_str().unwrap()),
+        RocksDBStore::new(temp_dir.path().to_str().unwrap(), true),
         temp_dir,
     ))
 }

--- a/crates/sui-tool/src/commands.rs
+++ b/crates/sui-tool/src/commands.rs
@@ -436,7 +436,7 @@ impl ToolCommand {
                 start_commit,
                 end_commit,
             } => {
-                let rocks_db_store = RocksDBStore::new(&db_path);
+                let rocks_db_store = RocksDBStore::new(&db_path, true);
 
                 let start_commit = start_commit.unwrap_or(0);
                 let end_commit = end_commit.unwrap_or(u32::MAX);

--- a/crates/typed-store/src/rocks/options.rs
+++ b/crates/typed-store/src/rocks/options.rs
@@ -1,9 +1,9 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::{collections::BTreeMap, env};
+
 use rocksdb::{BlockBasedOptions, Cache, MergeOperands, ReadOptions, compaction_filter::Decision};
-use std::collections::BTreeMap;
-use std::env;
 use tap::TapFallible;
 use tracing::{info, warn};
 
@@ -193,10 +193,9 @@ impl DBOptions {
         self
     }
 
-    // Optimize tables receiving significant insertions, without any deletions.
-    // TODO: merge this function with optimize_for_write_throughput(), and use a flag to
-    // indicate if deletion is received.
-    pub fn optimize_for_write_throughput_no_deletion(mut self) -> DBOptions {
+    // Optimize tables receiving significant insertions without any deletions.
+    // These tables are dropped with the DBs, for example the epoch and consensus DBs.
+    pub fn optimize_for_no_deletion(mut self) -> DBOptions {
         // Increase write buffer size to 256MiB.
         let write_buffer_size = read_size_from_env(ENV_VAR_MAX_WRITE_BUFFER_SIZE_MB)
             .unwrap_or(DEFAULT_MAX_WRITE_BUFFER_SIZE_MB)
@@ -214,12 +213,12 @@ impl DBOptions {
 
         // Switch to universal compactions.
         self.options
-            .set_compaction_style(rocksdb::DBCompactionStyle::Universal);
-        let mut compaction_options = rocksdb::UniversalCompactOptions::default();
-        compaction_options.set_max_size_amplification_percent(10000);
-        compaction_options.set_stop_style(rocksdb::UniversalCompactionStopStyle::Similar);
+            .set_compaction_style(rocksdb::DBCompactionStyle::Fifo);
+        let mut compaction_options = rocksdb::FifoCompactOptions::default();
+        // Allow each consensus DB column family to grow unlimited, and never drop data because of size limits.
+        compaction_options.set_max_table_files_size(u64::MAX);
         self.options
-            .set_universal_compaction_options(&compaction_options);
+            .set_fifo_compaction_options(&compaction_options);
 
         let max_level_zero_file_num = read_size_from_env(ENV_VAR_L0_NUM_FILES_COMPACTION_TRIGGER)
             .unwrap_or(DEFAULT_UNIVERSAL_COMPACTION_L0_NUM_FILES_COMPACTION_TRIGGER);
@@ -231,6 +230,8 @@ impl DBOptions {
         );
         self.options
             .set_level_zero_stop_writes_trigger((max_level_zero_file_num * 16).try_into().unwrap());
+        self.options
+            .set_max_bytes_for_level_base((write_buffer_size * max_level_zero_file_num) as u64);
 
         // Increase sst file size to 128MiB.
         self.options.set_target_file_size_base(
@@ -239,10 +240,6 @@ impl DBOptions {
                 * 1024
                 * 1024,
         );
-
-        // This should be a no-op for universal compaction but increasing it to be safe.
-        self.options
-            .set_max_bytes_for_level_base((write_buffer_size * max_level_zero_file_num) as u64);
 
         self
     }
@@ -297,10 +294,10 @@ pub fn default_db_options() -> DBOptions {
 
     // One common issue when running tests on Mac is that the default ulimit is too low,
     // leading to I/O errors such as "Too many open files". Raising fdlimit to bypass it.
-    if let Some(limit) = fdlimit::raise_fd_limit() {
-        // on windows raise_fd_limit return None
-        opt.set_max_open_files((limit / 8) as i32);
-    }
+    fdlimit::raise_fd_limit();
+
+    // Allow files opened by RocksDB to be kept open.
+    opt.set_max_open_files(-1);
 
     // The table cache is locked for updates and this determines the number
     // of shards, ie 2^10. Increase in case of lock contentions.


### PR DESCRIPTION
## Description 

Since most of the consensus data are never updated or deleted, and insertions are mostly append, FIFO compaction policy should work. 

## Test plan 

PT