### PR TITLE
TS-sdks path fix

### DIFF
--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -1,1 +1,1 @@
-`@mysten/sui` has moved to https://github.com/MystenLabs/ts-sdks/tree/main/packages/typescript
+`@mysten/sui` has moved to https://github.com/MystenLabs/ts-sdks/tree/main


### PR DESCRIPTION
## Description 

Alter the path to ts-sdks. Current one leads to 404

## Test plan 

Added the new path  to browser and it does link to a 404 (but it links to the ts-sdk repo)

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
