### PR TITLE
Move broadcaster backpressure from task-level to stream-level

### DIFF
--- a/crates/sui-indexer-alt-framework/src/ingestion/broadcaster.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/broadcaster.rs
@@ -217,9 +217,7 @@ fn ingest_and_broadcast_range(
     TaskGuard::new(tokio::spawn(async move {
         // Backpressure is enforced at the stream level: checkpoints are only yielded when
         // ingest_hi allows, preventing spawned tasks from piling up while blocked.
-        let checkpoints = backpressured_checkpoint_stream(start, end, ingest_hi_rx);
-
-        checkpoints
+        backpressured_checkpoint_stream(start, end, ingest_hi_rx)
             .try_for_each_spawned(ingest_concurrency, |cp| {
                 let client = client.clone();
                 let subscribers = subscribers.clone();


### PR DESCRIPTION
## Description

Previously, each spawned fetch task independently waited on ingest_hi inside itself, meaning tasks were already spawned and consuming resources while blocked on backpressure. Now checkpoints are gated at the stream level via backpressured_checkpoint_stream(), so tasks are only spawned when the backpressure window allows.

Without this change, it's impossible to let adaptive concurrency limiters find the upper bound for object store ingestion, because we will just keep spinning up futures (that are blocked on backpressure) until we OOM.

## Test plan

I have tested it during a testnet backfill as part of a larger effort to enable adaptive rate limiting.

## Release notes

- [x] Indexing Framework: Fix memory leak in ingestion stream.
