### PR TITLE
docs: properly enable indexer pruning in config

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,2 +1,4 @@
 **/subtree/**/*.mdx
+content/references/release-notes.mdx
+MARKDOWN_EXPORT.mdx
 README.mdx

--- a/docs/content/guides/operator/indexer-stack-setup.mdx
+++ b/docs/content/guides/operator/indexer-stack-setup.mdx
@@ -75,14 +75,18 @@ Example:
 
 ```sh
 $ sui-indexer-alt indexer \
-    --config misc.toml \
+    --config unpruned.toml \
     --database-url postgres://username:password@localhost:5432/database \
     --remote-store-url https://checkpoints.mainnet.sui.io
 ```
 
 ### Run config recommendations {#indexer-run-config}
 
-We recommend using the TOML files below which are grouped by pipeline speed. All pipelines in an instance are limited by the slowest pipeline in that instance so these files each contain pipelines that run at approximately the same speed.
+Use the TOML files below; they are grouped by pipeline speed. All pipelines in an instance are limited by the slowest pipeline in that instance so these files each contain pipelines that run at approximately the same speed.
+
+:::info
+When backfilling, you should set the `ingest-concurrency` to a higher value, e.g. 200, then reduce it to 20 for normal operation at network tip.
+:::
 
 <table>
 	<thead>
@@ -111,34 +115,7 @@ We recommend using the TOML files below which are grouped by pipeline speed. All
 			<td colspan={5}>
 				<details>
 					<summary>`events.toml`</summary>
-					<ImportContent source="examples/prod-config/events.toml" mode="code" />
-				</details>
-			</td>
-		</tr>
-		<tr>
-			<td>`misc.toml`</td>
-			<td>Lightweight miscellaneous tables.</td>
-			<td>
-				<ul className="pl-4">
-					<li>`cp_sequence_numbers`</li>
-					<li>`tx_balance_changes`</li>
-					<li>`tx_digests`</li>
-					<li>`kv_epoch_ends`</li>
-					<li>`kv_epoch_starts`</li>
-					<li>`kv_feature_flags`</li>
-					<li>`kv_packages`</li>
-					<li>`kv_protocol_configs`</li>
-					<li>`sum_displays`</li>
-				</ul>
-			</td>
-			<td>2-4 days</td>
-			<td>90 days</td>
-		</tr>
-		<tr>
-			<td colspan={5}>
-				<details>
-					<summary>`misc.toml`</summary>
-					<ImportContent source="examples/prod-config/misc.toml" mode="code" />
+					<ImportContent source="examples/prod-config/indexer/events.toml" mode="code" />
 				</details>
 			</td>
 		</tr>
@@ -147,13 +124,13 @@ We recommend using the TOML files below which are grouped by pipeline speed. All
 			<td>Heavyweight object versions table containing data since genesis.</td>
 			<td>`obj_versions`</td>
 			<td>10-14 days</td>
-			<td>unpruned</td>
+			<td>Unpruned</td>
 		</tr>
 		<tr>
 			<td colspan={5}>
 				<details>
 					<summary>`obj_versions.toml`</summary>
-					<ImportContent source="examples/prod-config/obj_versions.toml" mode="code" />
+					<ImportContent source="examples/prod-config/indexer/obj_versions.toml" mode="code" />
 				</details>
 			</td>
 		</tr>
@@ -168,7 +145,7 @@ We recommend using the TOML files below which are grouped by pipeline speed. All
 			<td colspan={5}>
 				<details>
 					<summary>`tx_affected_addresses.toml`</summary>
-					<ImportContent source="examples/prod-config/tx_affected_addresses.toml" mode="code" />
+					<ImportContent source="examples/prod-config/indexer/tx_affected_addresses.toml" mode="code" />
 				</details>
 			</td>
 		</tr>
@@ -183,7 +160,7 @@ We recommend using the TOML files below which are grouped by pipeline speed. All
 			<td colspan={5}>
 				<details>
 					<summary>`tx_affected_objects.toml`</summary>
-					<ImportContent source="examples/prod-config/tx_affected_objects.toml" mode="code" />
+					<ImportContent source="examples/prod-config/indexer/tx_affected_objects.toml" mode="code" />
 				</details>
 			</td>
 		</tr>
@@ -198,7 +175,7 @@ We recommend using the TOML files below which are grouped by pipeline speed. All
 			<td colspan={5}>
 				<details>
 					<summary>`tx_calls.toml`</summary>
-					<ImportContent source="examples/prod-config/tx_calls.toml" mode="code" />
+					<ImportContent source="examples/prod-config/indexer/tx_calls.toml" mode="code" />
 				</details>
 			</td>
 		</tr>
@@ -213,7 +190,34 @@ We recommend using the TOML files below which are grouped by pipeline speed. All
 			<td colspan={5}>
 				<details>
 					<summary>`tx_kinds.toml`</summary>
-					<ImportContent source="examples/prod-config/tx_kinds.toml" mode="code" />
+					<ImportContent source="examples/prod-config/indexer/tx_kinds.toml" mode="code" />
+				</details>
+			</td>
+		</tr>
+		<tr>
+			<td>`unpruned.toml`</td>
+			<td>Foundational and reference data that other queries and parts of the indexer depend on.</td>
+			<td>
+				<ul className="pl-4">
+					<li>`cp_sequence_numbers`</li>
+					<li>`kv_epoch_ends`</li>
+					<li>`kv_epoch_starts`</li>
+					<li>`kv_feature_flags`</li>
+					<li>`kv_packages`</li>
+					<li>`kv_protocol_configs`</li>
+					<li>`sum_displays`</li>
+					<li>`tx_balance_changes`</li>
+					<li>`tx_digests`</li>
+				</ul>
+			</td>
+			<td>2-4 days</td>
+			<td>Unpruned</td>
+		</tr>
+		<tr>
+			<td colspan={5}>
+				<details>
+					<summary>`unpruned.toml`</summary>
+					<ImportContent source="examples/prod-config/indexer/unpruned.toml" mode="code" />
 				</details>
 			</td>
 		</tr>
@@ -390,12 +394,12 @@ Example:
 sui-indexer-alt-graphql rpc \
     --config graphql.toml \
     --indexer-config events.toml \
-    --indexer-config misc.toml \
     --indexer-config obj_versions.toml \
     --indexer-config tx_affected_addresses.toml \
     --indexer-config tx_affected_objects.toml \
     --indexer-config tx_calls.toml \
     --indexer-config tx_kinds.toml \
+    --indexer-config unpruned.toml \
     --ledger-grpc-url https://archive.mainnet.sui.io:443 \
     --consistent-store-url https://localhost:7001 \
     --database-url postgres://username:password@localhost:5432/database \

--- a/examples/prod-config/consistent_store.toml
+++ b/examples/prod-config/consistent_store.toml
@@ -1,6 +1,8 @@
 [ingestion]
 ingest-concurrency = 20
 
+[pipeline.address-balances]
+
 [pipeline.balances]
 
 [pipeline.object-by-owner]

--- a/examples/prod-config/events.toml
+++ b/examples/prod-config/events.toml
@@ -1,6 +1,0 @@
-[pruner]
-retention = 31104000
-
-[pipeline.ev_emit_mod]
-
-[pipeline.ev_struct_inst]

--- a/examples/prod-config/indexer/events.toml
+++ b/examples/prod-config/indexer/events.toml
@@ -1,0 +1,6 @@
+[pruner]
+retention = 31104000
+
+[pipeline.ev_emit_mod.pruner]
+
+[pipeline.ev_struct_inst.pruner]

--- a/examples/prod-config/indexer/obj_versions.toml
+++ b/examples/prod-config/indexer/obj_versions.toml
@@ -4,4 +4,6 @@ ingest-concurrency = 20
 [committer]
 write-concurrency = 10
 
+# obj_versions pipeline pruning not yet supported
+
 [pipeline.obj_versions]

--- a/examples/prod-config/indexer/tx_affected_addresses.toml
+++ b/examples/prod-config/indexer/tx_affected_addresses.toml
@@ -7,4 +7,4 @@ write-concurrency = 10
 [pruner]
 retention = 31104000
 
-[pipeline.tx_affected_addresses]
+[pipeline.tx_affected_addresses.pruner]

--- a/examples/prod-config/indexer/tx_affected_objects.toml
+++ b/examples/prod-config/indexer/tx_affected_objects.toml
@@ -4,4 +4,4 @@ write-concurrency = 20
 [pruner]
 retention = 31104000
 
-[pipeline.tx_affected_objects]
+[pipeline.tx_affected_objects.pruner]

--- a/examples/prod-config/indexer/tx_calls.toml
+++ b/examples/prod-config/indexer/tx_calls.toml
@@ -4,4 +4,4 @@ write-concurrency = 10
 [pruner]
 retention = 31104000
 
-[pipeline.tx_calls]
+[pipeline.tx_calls.pruner]

--- a/examples/prod-config/indexer/tx_kinds.toml
+++ b/examples/prod-config/indexer/tx_kinds.toml
@@ -1,4 +1,4 @@
 [pruner]
 retention = 31104000
 
-[pipeline.tx_kinds]
+[pipeline.tx_kinds.pruner]

--- a/examples/prod-config/indexer/unpruned.toml
+++ b/examples/prod-config/indexer/unpruned.toml
@@ -1,14 +1,7 @@
 [ingestion]
 ingest-concurrency = 20
 
-[pruner]
-retention = 31104000
-
 [pipeline.cp_sequence_numbers]
-
-[pipeline.tx_balance_changes]
-
-[pipeline.tx_digests]
 
 [pipeline.kv_epoch_ends]
 
@@ -21,3 +14,7 @@ retention = 31104000
 [pipeline.kv_protocol_configs]
 
 [pipeline.sum_displays]
+
+[pipeline.tx_balance_changes]
+
+[pipeline.tx_digests]


### PR DESCRIPTION
## Description 

Fixes the indexer config toml files to properly enable pruning on supported pipelines.

Also groups indexer config in an `indexer` dir to more easily figure out which configs apply to the indexer.

Incorporates changes from https://github.com/MystenLabs/sui/pull/25265

## Test plan 

Tested locally with `pnpm start`.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
