### PR TITLE
docs(tutorial): include missing start_game function in coin_flip tutorial

### DIFF
--- a/docs/content/guides/developer/app-examples/coin-flip.mdx
+++ b/docs/content/guides/developer/app-examples/coin-flip.mdx
@@ -483,6 +483,20 @@ Now add a function that handles game disputes:
 
 This function, `dispute_and_win`, ensures that no bet can live in “purgatory”. After a certain amount of time passes, the player can call this function and get all of their funds back.
 
+We also need a function that creates and initializes a new game:
+
+```move title='single_player_satoshi.move'
+  public fun start_game(guess: String, counter: &mut Counter, coin: Coin<SUI>, house_data: &mut HouseData, ctx: &mut TxContext): ID {
+    let fee_bp = house_data.base_fee_in_bp();
+    let (game_id, new_game) = internal_start_game(guess, counter, coin, house_data, fee_bp, ctx);
+
+    dof::add(house_data.borrow_mut(), game_id, new_game);
+    game_id
+  }
+```
+
+The `start_game` function creates a new game by calling the internal `internal_start_game` helper function, then adds the newly created game as a dynamic object field to the `HouseData` object and returns the game ID for later reference.
+
 The rest of the functions are accessors and helper functions used to retrieve values, check if values exist, initialize the game, and so on:
 
 ```move title='single_player_satoshi.move'


### PR DESCRIPTION
## Description 

The tutorial text on [Sui Documentation/App Examples/Coin Flip/single_player_satoshi.move](https://docs.sui.io/guides/developer/app-examples/coin-flip#single_player_satoshi-module) is missing the code snippet for the public `start_game` function, leaving only the internal function `internal_start_game`:

```
 fun internal_start_game(guess: String, counter: &mut Counter, coin: Coin<SUI>, house_data: &mut HouseData, fee_bp: u16, ctx: &mut TxContext): (ID, Game) {
```

The actual source code in the [repo](https://github.com/MystenLabs/satoshi-coin-flip/blob/main/docs/single_player_satoshi.md#0x0_single_player_satoshi_start_game) has this function, but the mdx documentation skipped it.
This leads to errors for users who reach the frontend integration part. I added same the `start_game` code block in the repo to the tutorial markdown file to ensure its integrity.

```
public fun start_game(guess: String, counter: &mut Counter, coin: Coin<SUI>, house_data: &mut HouseData, ctx: &mut TxContext): ID {
    let fee_bp = house_data.base_fee_in_bp();
    let (game_id, new_game) = internal_start_game(guess, counter, coin, house_data, fee_bp, ctx);

    dof::add(house_data.borrow_mut(), game_id, new_game);
    game_id
}
```

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
