### PR TITLE
display(jsonrpc): prepare for Display v2

### DIFF
--- a/crates/sui-indexer-alt-jsonrpc/src/api/objects/response.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/objects/response.rs
@@ -9,6 +9,7 @@ use anyhow::bail;
 use futures::future::OptionFuture;
 use move_core_types::annotated_value::MoveTypeLayout;
 use move_core_types::language_storage::StructTag;
+use serde_json::Value as Json;
 use sui_display::v1::Format;
 use sui_indexer_alt_reader::displays::DisplayKey;
 use sui_json_rpc_types::DisplayFieldsResponse;
@@ -184,7 +185,7 @@ async fn display(ctx: &Context, object: &Object) -> DisplayFieldsResponse {
     for (name, value) in fields {
         match value {
             Ok(value) => {
-                field_values.insert(name, value);
+                field_values.insert(name, Json::String(value));
             }
             Err(e) => {
                 write!(field_errors, "{prefix}Error for field {name:?}: {e:#}").unwrap();

--- a/crates/sui-json-rpc-types/src/sui_object.rs
+++ b/crates/sui-json-rpc-types/src/sui_object.rs
@@ -166,7 +166,7 @@ impl TryFrom<SuiObjectResponse> for ObjectInfo {
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, Eq, PartialEq)]
 pub struct DisplayFieldsResponse {
-    pub data: Option<BTreeMap<String, String>>,
+    pub data: Option<BTreeMap<String, Value>>,
     pub error: Option<SuiObjectResponseError>,
 }
 

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -21,6 +21,7 @@ use move_bytecode_utils::module_cache::GetModule;
 use move_core_types::annotated_value::{MoveStructLayout, MoveTypeLayout};
 use move_core_types::language_storage::StructTag;
 use once_cell::sync::Lazy;
+use serde_json::Value as Json;
 use shared_crypto::intent::{IntentMessage, PersonalMessage};
 use sui_display::v1::Format;
 use sui_json_rpc_types::ZkLoginIntentScope;
@@ -1291,7 +1292,7 @@ async fn get_display_fields(
     for (key, value) in display {
         match value {
             Ok(v) => {
-                fields.insert(key, v);
+                fields.insert(key, Json::String(v));
             }
             Err(e) => {
                 errors.push(e.to_string());

--- a/crates/sui-open-rpc/tests/snapshots/generate_spec__openrpc.snap.json
+++ b/crates/sui-open-rpc/tests/snapshots/generate_spec__openrpc.snap.json
@@ -6253,9 +6253,7 @@
               "object",
               "null"
             ],
-            "additionalProperties": {
-              "type": "string"
-            }
+            "additionalProperties": true
           },
           "error": {
             "anyOf": [


### PR DESCRIPTION
## Description

Relax the type of `DisplayFieldsResponse` to allow values to be arbitrary JSON, instead of just strings, so it can support Display v2 fields.

## Test plan

CI

## Stack

- #23710 
- #25242

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
