### PR TITLE
registry/display: JSONRPC integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15510,6 +15510,7 @@ dependencies = [
  "prometheus",
  "rand 0.8.5",
  "reqwest",
+ "serde_json",
  "shared-crypto",
  "sui-config",
  "sui-core",

--- a/crates/sui-json-rpc-tests/Cargo.toml
+++ b/crates/sui-json-rpc-tests/Cargo.toml
@@ -41,6 +41,7 @@ jsonrpsee.workspace = true
 prometheus.workspace = true
 rand.workspace = true
 reqwest.workspace = true
+serde_json.workspace = true
 tokio = { workspace = true, features = ["full"] }
 tracing.workspace = true
 shared-crypto.workspace = true

--- a/crates/sui-json-rpc-tests/tests/data/display_v2/Move.toml
+++ b/crates/sui-json-rpc-tests/tests/data/display_v2/Move.toml
@@ -1,0 +1,10 @@
+[package]
+name = "DisplayV2"
+version = "0.0.1"
+edition = "2024.beta"
+
+[dependencies]
+Sui = { local = "../../../../sui-framework/packages/sui-framework" }
+
+[addresses]
+display_v2 = "0x0"

--- a/crates/sui-json-rpc-tests/tests/data/display_v2/sources/display_v2.move
+++ b/crates/sui-json-rpc-tests/tests/data/display_v2/sources/display_v2.move
@@ -1,0 +1,91 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module display_v2::display_v2 {
+    use std::internal;
+    use std::string::String;
+    use sui::display_registry::{DisplayCap, DisplayRegistry};
+    use sui::dynamic_field as df;
+
+    public struct Foo has key, store {
+        id: UID,
+        bar: Bar,
+    }
+
+    public struct Bar has store {
+        baz: Baz,
+        val: u64,
+    }
+
+    public struct Baz has store {
+        qux: Qux,
+        val: bool,
+    }
+
+    public struct Qux has store {
+        quy: Quy,
+        val: String,
+    }
+
+    public struct Quy has store {
+        quz: Quz,
+        val: address,
+    }
+
+    public struct Quz has store {
+        val: u8,
+    }
+
+    public entry fun setup_display(registry: &mut DisplayRegistry, ctx: &mut TxContext) {
+        let (mut display, cap): (_, DisplayCap<Foo>) = registry.new(internal::permit<Foo>(), ctx);
+
+        display.set(&cap, "bar", "bar is {bar.val}!");
+        display.set(&cap, "baz", "baz is {bar.baz.val}?");
+        display.set(&cap, "qux", "{bar.baz.qux:json}");
+        display.set(&cap, "quy", "quy is {bar.baz.qux.quy.val}.");
+        display.set(&cap, "qu_", "x({bar.baz.qux.val}) y({bar.baz.qux.quy.val}), z({bar.baz.qux.quy.quz.val})?!");
+        display.set(&cap, "f42", "[42] is {id->[42u64] | 0x00420042u32 :hex}");
+
+        display.share();
+        transfer::public_transfer(cap, tx_context::sender(ctx));
+    }
+
+    public entry fun mint(
+        v_bar: u64,
+        v_qux: String,
+        v_quy: address,
+        recipient: address,
+        ctx: &mut TxContext,
+    ) {
+        let quy = Quy {
+            val: v_quy,
+            quz: Quz { val: 43 },
+        };
+
+        let qux = Qux {
+            val: v_qux,
+            quy,
+        };
+
+        let baz = Baz {
+            val: true,
+            qux,
+        };
+
+        let bar = Bar {
+            val: v_bar,
+            baz,
+        };
+
+        let foo = Foo {
+            id: object::new(ctx),
+            bar,
+        };
+
+        transfer::public_transfer(foo, recipient);
+    }
+
+    public entry fun add_df(foo: &mut Foo) {
+        df::add(&mut foo.id, 42u64, 0x42004200u32);
+    }
+}

--- a/crates/sui-json-rpc-tests/tests/rpc_server_tests.rs
+++ b/crates/sui-json-rpc-tests/tests/rpc_server_tests.rs
@@ -3,6 +3,7 @@
 
 #![allow(deprecated)]
 
+use serde_json::json;
 use shared_crypto::intent::{Intent, IntentMessage};
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
@@ -38,7 +39,7 @@ use sui_types::signature::GenericSignature;
 use sui_types::transaction_driver_types::ExecuteTransactionRequestType;
 use sui_types::utils::load_test_vectors;
 use sui_types::zk_login_authenticator::ZkLoginAuthenticator;
-use sui_types::{SUI_FRAMEWORK_ADDRESS, parse_sui_struct_tag};
+use sui_types::{SUI_DISPLAY_REGISTRY_OBJECT_ID, SUI_FRAMEWORK_ADDRESS, parse_sui_struct_tag};
 use test_cluster::TestClusterBuilder;
 use tokio::time::sleep;
 
@@ -94,6 +95,198 @@ async fn test_get_package_with_display_should_not_fail() -> Result<(), anyhow::E
             .data
             .is_none()
     );
+    Ok(())
+}
+
+#[sim_test]
+async fn test_get_object_with_display_v2_should_render() -> Result<(), anyhow::Error> {
+    let cluster = TestClusterBuilder::new().build().await;
+    let http_client = cluster.rpc_client();
+    let address = cluster.get_address_0();
+
+    let objects = http_client
+        .get_owned_objects(
+            address,
+            Some(SuiObjectResponseQuery::new_with_options(
+                SuiObjectDataOptions::new()
+                    .with_type()
+                    .with_owner()
+                    .with_previous_transaction(),
+            )),
+            None,
+            None,
+        )
+        .await?
+        .data;
+    let gas = objects.first().unwrap().object().unwrap();
+
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.extend(["tests", "data", "display_v2"]);
+    let compiled_package = BuildConfig::new_for_testing().build_async(&path).await?;
+    let compiled_modules_bytes =
+        compiled_package.get_package_base64(/* with_unpublished_deps */ false);
+    let dependencies = compiled_package.get_dependency_storage_package_ids();
+
+    let transaction_bytes: TransactionBlockBytes = http_client
+        .publish(
+            address,
+            compiled_modules_bytes,
+            dependencies,
+            Some(gas.object_id),
+            100_000_000.into(),
+        )
+        .await?;
+
+    let tx = cluster
+        .wallet
+        .sign_transaction(&transaction_bytes.to_data()?)
+        .await;
+    let (tx_bytes, signatures) = tx.to_tx_bytes_and_signatures();
+
+    let tx_response = http_client
+        .execute_transaction_block(
+            tx_bytes,
+            signatures,
+            Some(SuiTransactionBlockResponseOptions::new().with_object_changes()),
+            Some(ExecuteTransactionRequestType::WaitForLocalExecution),
+        )
+        .await?;
+
+    let object_changes = tx_response.object_changes.unwrap();
+    let package_id = object_changes
+        .iter()
+        .find_map(|e| {
+            if let ObjectChange::Published { package_id, .. } = e {
+                Some(*package_id)
+            } else {
+                None
+            }
+        })
+        .unwrap();
+
+    let setup_bytes: TransactionBlockBytes = http_client
+        .move_call(
+            address,
+            package_id,
+            "display_v2".to_string(),
+            "setup_display".to_string(),
+            type_args![]?,
+            call_args!(SUI_DISPLAY_REGISTRY_OBJECT_ID)?,
+            Some(gas.object_id),
+            50_000_000.into(),
+            None,
+        )
+        .await?;
+
+    let setup_tx = cluster
+        .wallet
+        .sign_transaction(&setup_bytes.to_data()?)
+        .await;
+    let (setup_tx_bytes, setup_signatures) = setup_tx.to_tx_bytes_and_signatures();
+
+    let setup_response = http_client
+        .execute_transaction_block(
+            setup_tx_bytes,
+            setup_signatures,
+            Some(SuiTransactionBlockResponseOptions::new().with_effects()),
+            Some(ExecuteTransactionRequestType::WaitForLocalExecution),
+        )
+        .await?;
+    assert_eq!(
+        SuiExecutionStatus::Success,
+        *setup_response.effects.unwrap().status()
+    );
+
+    let mint_bytes: TransactionBlockBytes = http_client
+        .move_call(
+            address,
+            package_id,
+            "display_v2".to_string(),
+            "mint".to_string(),
+            type_args![]?,
+            call_args!(42u64, "hello", address, address)?,
+            Some(gas.object_id),
+            10_000_000.into(),
+            None,
+        )
+        .await?;
+
+    let mint_tx = cluster
+        .wallet
+        .sign_transaction(&mint_bytes.to_data()?)
+        .await;
+    let (mint_tx_bytes, mint_signatures) = mint_tx.to_tx_bytes_and_signatures();
+
+    let mint_response = http_client
+        .execute_transaction_block(
+            mint_tx_bytes,
+            mint_signatures,
+            Some(SuiTransactionBlockResponseOptions::new().with_effects()),
+            Some(ExecuteTransactionRequestType::WaitForLocalExecution),
+        )
+        .await?;
+
+    let created = mint_response.effects.unwrap().created().to_vec();
+    let created_id = created.first().unwrap().reference.object_id;
+
+    let add_df_bytes: TransactionBlockBytes = http_client
+        .move_call(
+            address,
+            package_id,
+            "display_v2".to_string(),
+            "add_df".to_string(),
+            type_args![]?,
+            call_args!(created_id)?,
+            Some(gas.object_id),
+            10_000_000.into(),
+            None,
+        )
+        .await?;
+
+    let add_df_tx = cluster
+        .wallet
+        .sign_transaction(&add_df_bytes.to_data()?)
+        .await;
+    let (add_df_tx_bytes, add_df_signatures) = add_df_tx.to_tx_bytes_and_signatures();
+
+    http_client
+        .execute_transaction_block(
+            add_df_tx_bytes,
+            add_df_signatures,
+            Some(SuiTransactionBlockResponseOptions::new()),
+            Some(ExecuteTransactionRequestType::WaitForLocalExecution),
+        )
+        .await?;
+
+    let response = http_client
+        .get_object(
+            created_id,
+            Some(SuiObjectDataOptions::new().with_display().with_type()),
+        )
+        .await?;
+    let object = response.into_object()?;
+    let display = object.display.unwrap();
+    let display_data = display.data.unwrap();
+
+    assert!(display.error.is_none());
+    let expected_display = json!({
+        "bar": "bar is 42!",
+        "baz": "baz is true?",
+        "qux": {
+            "val": "hello",
+            "quy": {
+                "val": format!("{address}"),
+                "quz": {
+                    "val": 43
+                }
+            }
+        },
+        "quy": format!("quy is {address}."),
+        "qu_": format!("x(hello) y({address}), z(43)?!"),
+        "f42": "[42] is 42004200"
+    });
+    assert_eq!(serde_json::to_value(display_data)?, expected_display);
+
     Ok(())
 }
 

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -18,6 +18,7 @@ use itertools::Itertools;
 use jsonrpsee::RpcModule;
 use jsonrpsee::core::RpcResult;
 use move_bytecode_utils::module_cache::GetModule;
+use move_core_types::account_address::AccountAddress;
 use move_core_types::annotated_value::{MoveStructLayout, MoveTypeLayout};
 use move_core_types::language_storage::StructTag;
 use once_cell::sync::Lazy;
@@ -50,6 +51,7 @@ use sui_storage::key_value_store::TransactionKeyValueStore;
 use sui_types::base_types::{ObjectID, SequenceNumber, TransactionDigest};
 use sui_types::crypto::AggregateAuthoritySignature;
 use sui_types::display::DisplayVersionUpdatedEvent;
+use sui_types::display_registry;
 use sui_types::effects::{TransactionEffects, TransactionEffectsAPI, TransactionEvents};
 use sui_types::error::{SuiError, SuiObjectResponseError};
 use sui_types::messages_checkpoint::{
@@ -72,11 +74,67 @@ use shared_crypto::intent::Intent;
 use sui_json_rpc_types::ZkLoginVerifyResult;
 use sui_types::authenticator_state::{ActiveJwk, get_authenticator_state};
 
-/// A field access in a  Display string cannot exceed this level of nesting.
-const MAX_DISPLAY_NESTED_LEVEL: usize = 10;
+/// Default max depth used while converting rendered Display values to JSON.
+const DEFAULT_MAX_DISPLAY_MOVE_VALUE_DEPTH: usize = 32;
 
 /// Default budget for Display output size.
 const DEFAULT_MAX_DISPLAY_OUTPUT_SIZE: usize = 1024 * 1024;
+
+/// A field access in a Display string cannot exceed this level of nesting.
+static MAX_DISPLAY_FIELD_DEPTH: Lazy<usize> = Lazy::new(|| {
+    let max_opt = std::env::var("MAX_DISPLAY_FIELD_DEPTH")
+        .ok()
+        .and_then(|s| s.parse().ok());
+
+    if let Some(max) = max_opt {
+        info!("Using custom value for 'MAX_DISPLAY_FIELD_DEPTH': {max}");
+        max
+    } else {
+        sui_display::v2::Limits::default().max_depth
+    }
+});
+
+/// Parser node budget for Display v2.
+static MAX_DISPLAY_FORMAT_NODES: Lazy<usize> = Lazy::new(|| {
+    let max_opt = std::env::var("MAX_DISPLAY_FORMAT_NODES")
+        .ok()
+        .and_then(|s| s.parse().ok());
+
+    if let Some(max) = max_opt {
+        info!("Using custom value for 'MAX_DISPLAY_FORMAT_NODES': {max}");
+        max
+    } else {
+        sui_display::v2::Limits::default().max_nodes
+    }
+});
+
+/// Max object loads budget for Display v2.
+static MAX_DISPLAY_OBJECT_LOADS: Lazy<usize> = Lazy::new(|| {
+    let max_opt = std::env::var("MAX_DISPLAY_OBJECT_LOADS")
+        .ok()
+        .and_then(|s| s.parse().ok());
+
+    if let Some(max) = max_opt {
+        info!("Using custom value for 'MAX_DISPLAY_OBJECT_LOADS': {max}");
+        max
+    } else {
+        sui_display::v2::Limits::default().max_loads
+    }
+});
+
+/// Maximum depth used while converting rendered Display values to JSON.
+static MAX_DISPLAY_MOVE_VALUE_DEPTH: Lazy<usize> = Lazy::new(|| {
+    let max_opt = std::env::var("MAX_MOVE_VALUE_DEPTH")
+        .ok()
+        .and_then(|s| s.parse().ok());
+
+    if let Some(max) = max_opt {
+        info!("Using custom value for 'MAX_MOVE_VALUE_DEPTH': {max}");
+        max
+    } else {
+        DEFAULT_MAX_DISPLAY_MOVE_VALUE_DEPTH
+    }
+});
 
 /// Overall display output cannot exceed this size.
 static MAX_DISPLAY_OUTPUT_SIZE: Lazy<usize> = Lazy::new(|| {
@@ -91,6 +149,38 @@ static MAX_DISPLAY_OUTPUT_SIZE: Lazy<usize> = Lazy::new(|| {
         DEFAULT_MAX_DISPLAY_OUTPUT_SIZE
     }
 });
+
+struct DisplayStore<'s> {
+    state: &'s dyn StateRead,
+}
+
+impl<'s> DisplayStore<'s> {
+    fn new(state: &'s dyn StateRead) -> Self {
+        Self { state }
+    }
+}
+
+#[async_trait]
+impl sui_display::v2::Store for DisplayStore<'_> {
+    async fn object(
+        &self,
+        id: AccountAddress,
+    ) -> anyhow::Result<Option<sui_display::v2::OwnedSlice>> {
+        let read = self.state.get_object_read(&id.into())?;
+        let ObjectRead::Exists(_, object, Some(layout)) = read else {
+            return Ok(None);
+        };
+
+        let Some(move_object) = object.data.try_as_move() else {
+            return Ok(None);
+        };
+
+        Ok(Some(sui_display::v2::OwnedSlice {
+            bytes: move_object.contents().to_vec(),
+            layout: MoveTypeLayout::Struct(Box::new(layout)),
+        }))
+    }
+}
 
 // An implementation of the read portion of the JSON-RPC interface intended for use in
 // Fullnodes.
@@ -1232,6 +1322,9 @@ pub enum ObjectDisplayError {
 
     #[error(transparent)]
     StateReadError(#[from] StateReadError),
+
+    #[error(transparent)]
+    Internal(#[from] anyhow::Error),
 }
 
 #[instrument(skip(fullnode_api, kv_store))]
@@ -1241,7 +1334,11 @@ async fn get_display_fields(
     original_object: &Object,
     original_layout: &Option<MoveStructLayout>,
 ) -> Result<DisplayFieldsResponse, ObjectDisplayError> {
-    let Some(layout) = original_layout else {
+    let (layout, type_) = if let Some(layout) = original_layout {
+        let type_ = &layout.type_;
+        let layout = MoveTypeLayout::Struct(Box::new(layout.clone()));
+        (layout, type_)
+    } else {
         return Ok(DisplayFieldsResponse {
             data: None,
             error: None,
@@ -1252,39 +1349,88 @@ async fn get_display_fields(
         return Err(ObjectDisplayError::MoveObject);
     };
 
-    let Some(display_object) =
-        get_display_object_by_type(kv_store, fullnode_api, &layout.type_).await?
-    else {
-        return Ok(DisplayFieldsResponse {
-            data: None,
-            error: None,
-        });
-    };
+    let display: Vec<(String, Result<Json, anyhow::Error>)> =
+        if let Some(display_object) = get_display_object_v2_by_type(fullnode_api, type_)? {
+            let root = sui_display::v2::OwnedSlice {
+                bytes: move_object.contents().to_owned(),
+                layout,
+            };
 
-    let format = match Format::parse(MAX_DISPLAY_NESTED_LEVEL, &display_object.fields) {
-        Ok(format) => format,
-        Err(e) => {
+            let store = DisplayStore::new(fullnode_api.state.as_ref());
+            let interpreter = sui_display::v2::Interpreter::new(root, store);
+            let limits = sui_display::v2::Limits {
+                max_depth: *MAX_DISPLAY_FIELD_DEPTH,
+                max_nodes: *MAX_DISPLAY_FORMAT_NODES,
+                max_loads: *MAX_DISPLAY_OBJECT_LOADS,
+            };
+
+            match sui_display::v2::Display::parse(limits, display_object.fields()) {
+                Ok(display) => match display
+                    .display(
+                        *MAX_DISPLAY_MOVE_VALUE_DEPTH,
+                        *MAX_DISPLAY_OUTPUT_SIZE,
+                        &interpreter,
+                    )
+                    .await
+                {
+                    Ok(fields) => fields
+                        .into_iter()
+                        .map(|(field, value)| (field, value.map_err(anyhow::Error::from)))
+                        .collect(),
+                    Err(e) => {
+                        return Ok(DisplayFieldsResponse {
+                            data: None,
+                            error: Some(SuiObjectResponseError::DisplayError {
+                                error: e.to_string(),
+                            }),
+                        });
+                    }
+                },
+
+                Err(e) => {
+                    return Ok(DisplayFieldsResponse {
+                        data: None,
+                        error: Some(SuiObjectResponseError::DisplayError {
+                            error: e.to_string(),
+                        }),
+                    });
+                }
+            }
+        } else if let Some(display_object) =
+            get_display_object_v1_by_type(kv_store, fullnode_api, type_).await?
+        {
+            let format = match Format::parse(*MAX_DISPLAY_FIELD_DEPTH, &display_object.fields) {
+                Ok(format) => format,
+                Err(e) => {
+                    return Ok(DisplayFieldsResponse {
+                        data: None,
+                        error: Some(SuiObjectResponseError::DisplayError {
+                            error: e.to_string(),
+                        }),
+                    });
+                }
+            };
+
+            match format.display(*MAX_DISPLAY_OUTPUT_SIZE, move_object.contents(), &layout) {
+                Ok(fields) => fields
+                    .into_iter()
+                    .map(|(field, value)| (field, value.map(Json::String)))
+                    .collect(),
+                Err(e) => {
+                    return Ok(DisplayFieldsResponse {
+                        data: None,
+                        error: Some(SuiObjectResponseError::DisplayError {
+                            error: e.to_string(),
+                        }),
+                    });
+                }
+            }
+        } else {
             return Ok(DisplayFieldsResponse {
                 data: None,
-                error: Some(SuiObjectResponseError::DisplayError {
-                    error: e.to_string(),
-                }),
+                error: None,
             });
-        }
-    };
-
-    let layout = MoveTypeLayout::Struct(Box::new(layout.clone()));
-    let display = match format.display(*MAX_DISPLAY_OUTPUT_SIZE, move_object.contents(), &layout) {
-        Ok(fields) => fields,
-        Err(e) => {
-            return Ok(DisplayFieldsResponse {
-                data: None,
-                error: Some(SuiObjectResponseError::DisplayError {
-                    error: e.to_string(),
-                }),
-            });
-        }
-    };
+        };
 
     let mut fields = BTreeMap::new();
     let mut errors = vec![];
@@ -1292,7 +1438,7 @@ async fn get_display_fields(
     for (key, value) in display {
         match value {
             Ok(v) => {
-                fields.insert(key, Json::String(v));
+                fields.insert(key, v);
             }
             Err(e) => {
                 errors.push(e.to_string());
@@ -1309,11 +1455,10 @@ async fn get_display_fields(
 }
 
 #[instrument(skip(kv_store, fullnode_api))]
-async fn get_display_object_by_type(
+async fn get_display_object_v1_by_type(
     kv_store: &Arc<TransactionKeyValueStore>,
     fullnode_api: &ReadApi,
     object_type: &StructTag,
-    // TODO: add query version support
 ) -> Result<Option<DisplayVersionUpdatedEvent>, ObjectDisplayError> {
     let mut events = fullnode_api
         .state
@@ -1327,13 +1472,29 @@ async fn get_display_object_by_type(
         .await?;
 
     // If there's any recent version of Display, give it to the client.
-    // TODO: add support for version query.
     if let Some(event) = events.pop() {
         let display: DisplayVersionUpdatedEvent = bcs::from_bytes(&event.bcs.into_bytes())?;
         Ok(Some(display))
     } else {
         Ok(None)
     }
+}
+
+#[instrument(skip(fullnode_api))]
+fn get_display_object_v2_by_type(
+    fullnode_api: &ReadApi,
+    object_type: &StructTag,
+) -> Result<Option<display_registry::Display>, ObjectDisplayError> {
+    let object_id = display_registry::display_object_id(object_type.clone().into())?;
+    let ObjectRead::Exists(_, object, _) = fullnode_api.state.get_object_read(&object_id)? else {
+        return Ok(None);
+    };
+
+    let Some(move_object) = object.data.try_as_move() else {
+        return Ok(None);
+    };
+
+    Ok(Some(bcs::from_bytes(move_object.contents())?))
 }
 
 #[instrument(skip_all)]


### PR DESCRIPTION
## Description

Add support to legacy JSONRPC for Display v2.

## Test plan

New E2E tests:

```
$ cargo nextest run -p sui-json-rpc-tests --test rpc_server_tests
```

## Stack

- #23710 
- #25242
- #25358 
- #25359 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [x] JSON-RPC: Adds support for Display Registry to JSONRPC: When `showDisplay` is set, the RPC will look for a `Display<T>` stored in the Display Registry and will use that as the source of truth for its type's format. This takes precedence over any Display v1 formats that exist for this type.
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
