### PR TITLE
Add staking cluster test

### DIFF
--- a/crates/sui-cluster-test/src/lib.rs
+++ b/crates/sui-cluster-test/src/lib.rs
@@ -32,7 +32,7 @@ use test_case::{
     fullnode_build_publish_transaction_test::FullNodeBuildPublishTransactionTest,
     fullnode_execute_transaction_test::FullNodeExecuteTransactionTest,
     native_transfer_test::NativeTransferTest, random_beacon_test::RandomBeaconTest,
-    shared_object_test::SharedCounterTest,
+    shared_object_test::SharedCounterTest, staking_test::StakingTest,
 };
 use tokio::time::{self, Duration};
 use tracing::{error, info};
@@ -317,6 +317,7 @@ impl ClusterTest {
             TestCase::new(FullNodeBuildPublishTransactionTest {}),
             TestCase::new(CoinIndexTest {}),
             TestCase::new(RandomBeaconTest {}),
+            TestCase::new(StakingTest {}),
         ];
 
         // TODO: improve the runner parallelism for efficiency

--- a/crates/sui-cluster-test/src/test_case.rs
+++ b/crates/sui-cluster-test/src/test_case.rs
@@ -8,3 +8,4 @@ pub mod fullnode_execute_transaction_test;
 pub mod native_transfer_test;
 pub mod random_beacon_test;
 pub mod shared_object_test;
+pub mod staking_test;

--- a/crates/sui-cluster-test/src/test_case/staking_test.rs
+++ b/crates/sui-cluster-test/src/test_case/staking_test.rs
@@ -1,0 +1,72 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{TestCaseImpl, TestContext};
+use async_trait::async_trait;
+use sui_test_transaction_builder::make_staking_transaction;
+use sui_types::transaction_driver_types::ExecuteTransactionRequestType;
+use tracing::info;
+
+pub struct StakingTest;
+
+#[async_trait]
+impl TestCaseImpl for StakingTest {
+    fn name(&self) -> &'static str {
+        "Staking"
+    }
+
+    fn description(&self) -> &'static str {
+        "Stake SUI with a validator and verify the delegation appears"
+    }
+
+    async fn run(&self, ctx: &mut TestContext) -> Result<(), anyhow::Error> {
+        info!("Testing staking workflow");
+
+        ctx.get_sui_from_faucet(Some(1)).await;
+        let sender = ctx.get_wallet_address();
+
+        // Get a validator address from system state
+        let system_state = ctx.get_latest_sui_system_state().await;
+        let validator_addr = system_state
+            .active_validators
+            .first()
+            .expect("Should have at least one active validator")
+            .sui_address;
+        info!("Staking to validator: {validator_addr}");
+
+        // Build and execute the staking transaction
+        let txn = make_staking_transaction(ctx.get_wallet(), validator_addr).await;
+        let digest = *txn.digest();
+
+        let client = ctx.clone_fullnode_client();
+        client
+            .quorum_driver_api()
+            .execute_transaction_block(
+                txn,
+                Default::default(),
+                Some(ExecuteTransactionRequestType::WaitForLocalExecution),
+            )
+            .await?;
+        info!("Staking transaction executed: {digest}");
+
+        // Verify the stake appeared
+        let stakes = client.governance_api().get_stakes(sender).await?;
+        assert!(
+            !stakes.is_empty(),
+            "Should have at least one stake after staking"
+        );
+        let matching = stakes
+            .iter()
+            .find(|s| s.validator_address == validator_addr);
+        assert!(
+            matching.is_some(),
+            "Should find a stake delegated to {validator_addr}"
+        );
+        info!(
+            "Staking verified: {} delegation(s), staked to {validator_addr}",
+            stakes.len()
+        );
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary

Add a `StakingTest` to the `sui-cluster-test` suite to cover the staking workflow — a critical user path not currently exercised by cluster tests.

The test:
1. Fetches SUI from the faucet
2. Queries system state to get a validator address (`governance_api().get_latest_sui_system_state()`)
3. Builds and executes a staking transaction (`make_staking_transaction`)
4. Verifies the delegation appeared via `governance_api().get_stakes()`

This brings the cluster test count from 7 to 8 and adds coverage for the governance/staking APIs that were previously untested in deployment health checks.

## Test plan

- [x] `cargo check -p sui-cluster-test` — compiles cleanly
- [x] `cargo fmt -p sui-cluster-test` — no formatting issues
- [x] `SUI_SKIP_SIMTESTS=1 cargo nextest run -p sui-cluster-test` — all 8 tests pass on local cluster (~58s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)