### PR TITLE
indexer: further simplify back-pressure

### DIFF
--- a/crates/sui-indexer-alt-framework/src/ingestion/broadcaster.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/broadcaster.rs
@@ -45,7 +45,7 @@ use crate::types::full_checkpoint_content::Checkpoint;
 /// The task will shut down if the `checkpoints` range completes.
 pub(super) fn broadcaster<R, S>(
     checkpoints: R,
-    initial_commit_hi: Option<u64>,
+    regulated: bool,
     mut streaming_client: Option<S>,
     config: IngestionConfig,
     client: IngestionClient,
@@ -85,10 +85,9 @@ where
         // Track subscriber watermarks
         let mut subscribers_hi = HashMap::<&'static str, u64>::new();
 
-        // Initialize ingest_hi watch channel.
-        // Start with None (no backpressure) or Some if we have been provided an initial bound.
-        let initial_ingest_hi = initial_commit_hi.map(|min_hi| min_hi + buffer_size);
-        let (ingest_hi_watch_tx, ingest_hi_watch_rx) = watch::channel(initial_ingest_hi);
+        // Initialize ingest_hi watch channel from the start of the checkpoint range.
+        let (ingest_hi_tx, ingest_hi_rx) = watch::channel(start_cp.saturating_add(buffer_size));
+        let ingest_hi_rx = regulated.then_some(&ingest_hi_rx);
 
         // If the first attempt at streaming connection fails, we back off for an initial number
         // of checkpoints to process using ingestion. This value doubles on each subsequent failure.
@@ -112,7 +111,7 @@ where
                 &mut streaming_backoff_batch_size,
                 &config,
                 &subscribers,
-                &ingest_hi_watch_rx,
+                ingest_hi_rx.cloned(),
                 &metrics,
             )
             .await;
@@ -124,7 +123,7 @@ where
                 ingestion_end,
                 config.retry_interval(),
                 config.ingest_concurrency,
-                ingest_hi_watch_rx.clone(),
+                ingest_hi_rx.cloned(),
                 client.clone(),
                 subscribers.clone(),
             );
@@ -139,9 +138,9 @@ where
                         subscribers_hi.insert(name, hi);
 
                         if let Some(min_hi) = subscribers_hi.values().copied().min() {
-                            let new_ingest_hi = Some(min_hi + buffer_size);
+                            let new_ingest_hi = min_hi.saturating_add(buffer_size);
                             // Update the watch channel, which will notify all waiting tasks
-                            let _ = ingest_hi_watch_tx.send(new_ingest_hi);
+                            let _ = ingest_hi_tx.send(new_ingest_hi);
                         }
                     }
                     // docs::/#regulator
@@ -189,16 +188,23 @@ where
 fn backpressured_checkpoint_stream(
     start: u64,
     end: u64,
-    ingest_hi_rx: watch::Receiver<Option<u64>>,
+    ingest_hi_rx: Option<watch::Receiver<u64>>,
 ) -> impl Stream<Item = u64> {
-    futures::stream::unfold((start, ingest_hi_rx), move |(cp, mut rx)| async move {
+    futures::stream::unfold((start, ingest_hi_rx), move |(cp, rx)| async move {
         if cp >= end {
             return None;
         }
-        if rx.wait_for(|hi| hi.is_none_or(|hi| cp < hi)).await.is_err() {
+
+        let Some(mut rx) = rx else {
+            // No backpressure, just yield checkpoints as fast as possible.
+            return Some((cp, (cp + 1, None)));
+        };
+
+        if rx.wait_for(|hi| cp < *hi).await.is_err() {
             return None;
         }
-        Some((cp, (cp + 1, rx)))
+
+        Some((cp, (cp + 1, Some(rx))))
     })
 }
 
@@ -210,7 +216,7 @@ fn ingest_and_broadcast_range(
     end: u64,
     retry_interval: Duration,
     ingest_concurrency: usize,
-    ingest_hi_rx: watch::Receiver<Option<u64>>,
+    ingest_hi_rx: Option<watch::Receiver<u64>>,
     client: IngestionClient,
     subscribers: Arc<Vec<mpsc::Sender<Arc<Checkpoint>>>>,
 ) -> TaskGuard<Result<(), Break<Error>>> {
@@ -251,7 +257,7 @@ async fn setup_streaming_task<S>(
     streaming_backoff_batch_size: &mut u64,
     config: &IngestionConfig,
     subscribers: &Arc<Vec<mpsc::Sender<Arc<Checkpoint>>>>,
-    ingest_hi_watch_rx: &watch::Receiver<Option<u64>>,
+    ingest_hi_rx: Option<watch::Receiver<u64>>,
     metrics: &Arc<IngestionMetrics>,
 ) -> (TaskGuard<u64>, u64)
 where
@@ -326,7 +332,7 @@ where
         end_cp,
         stream,
         subscribers.clone(),
-        ingest_hi_watch_rx.clone(),
+        ingest_hi_rx,
         metrics.clone(),
     )));
 
@@ -343,7 +349,7 @@ async fn stream_and_broadcast_range(
     hi: u64,
     mut stream: impl Stream<Item = Result<Checkpoint, Error>> + Unpin,
     subscribers: Arc<Vec<mpsc::Sender<Arc<Checkpoint>>>>,
-    mut ingest_hi_rx: watch::Receiver<Option<u64>>,
+    mut ingest_hi_rx: Option<watch::Receiver<u64>>,
     metrics: Arc<IngestionMetrics>,
 ) -> u64 {
     while lo < hi {
@@ -377,10 +383,8 @@ async fn stream_and_broadcast_range(
         }
 
         assert_eq!(sequence_number, lo);
-        if ingest_hi_rx
-            .wait_for(|hi| hi.is_none_or(|hi| lo < hi))
-            .await
-            .is_err()
+        if let Some(ingest_hi_rx) = &mut ingest_hi_rx
+            && ingest_hi_rx.wait_for(|hi| lo < *hi).await.is_err()
         {
             // Channel closed, treat as cancellation to avoid letting a checkpoint slip through as
             // the indexer winds down.
@@ -520,7 +524,7 @@ mod tests {
         let metrics = test_ingestion_metrics();
         let mut svc = broadcaster::<_, MockStreamingClient>(
             cps,
-            None,
+            false,
             None,
             test_config(),
             mock_client(metrics.clone()),
@@ -545,7 +549,7 @@ mod tests {
         let metrics = test_ingestion_metrics();
         let mut svc = broadcaster::<_, MockStreamingClient>(
             0..,
-            None,
+            false,
             None,
             test_config(),
             mock_client(metrics.clone()),
@@ -571,7 +575,7 @@ mod tests {
         let metrics = test_ingestion_metrics();
         let svc = broadcaster::<_, MockStreamingClient>(
             0..,
-            None,
+            false,
             None,
             test_config(),
             mock_client(metrics.clone()),
@@ -590,8 +594,10 @@ mod tests {
 
     #[tokio::test]
     async fn halted() {
-        let (_, hi_rx) = mpsc::unbounded_channel();
+        let (hi_tx, hi_rx) = mpsc::unbounded_channel();
         let (subscriber_tx, mut subscriber_rx) = mpsc::channel(1);
+
+        hi_tx.send(("test", 4)).unwrap();
 
         let mut config = test_config();
         config.checkpoint_buffer_size = 0; // No buffer
@@ -599,7 +605,7 @@ mod tests {
         let metrics = test_ingestion_metrics();
         let _svc = broadcaster::<_, MockStreamingClient>(
             0..,
-            Some(4),
+            true,
             None,
             config,
             mock_client(metrics.clone()),
@@ -619,8 +625,10 @@ mod tests {
 
     #[tokio::test]
     async fn halted_buffered() {
-        let (_, hi_rx) = mpsc::unbounded_channel();
+        let (hi_tx, hi_rx) = mpsc::unbounded_channel();
         let (subscriber_tx, mut subscriber_rx) = mpsc::channel(1);
+
+        hi_tx.send(("test", 2)).unwrap();
 
         let mut config = test_config();
         config.checkpoint_buffer_size = 2; // Buffer of 2
@@ -628,7 +636,7 @@ mod tests {
         let metrics = test_ingestion_metrics();
         let _svc = broadcaster::<_, MockStreamingClient>(
             0..,
-            Some(2),
+            true,
             None,
             config,
             mock_client(metrics.clone()),
@@ -651,13 +659,15 @@ mod tests {
         let (hi_tx, hi_rx) = mpsc::unbounded_channel();
         let (subscriber_tx, mut subscriber_rx) = mpsc::channel(1);
 
+        hi_tx.send(("test", 2)).unwrap();
+
         let mut config = test_config();
         config.checkpoint_buffer_size = 0; // No buffer
 
         let metrics = test_ingestion_metrics();
         let _svc = broadcaster::<_, MockStreamingClient>(
             0..,
-            Some(2),
+            true,
             None,
             config,
             mock_client(metrics.clone()),
@@ -699,7 +709,7 @@ mod tests {
         let metrics = test_ingestion_metrics();
         let _svc = broadcaster::<_, MockStreamingClient>(
             cps,
-            Some(2),
+            true,
             None,
             config,
             mock_client(metrics.clone()),
@@ -747,7 +757,7 @@ mod tests {
         let metrics = test_ingestion_metrics();
         let mut svc = broadcaster::<_, MockStreamingClient>(
             0..,
-            None,
+            false,
             None,
             test_config(),
             mock_client(metrics.clone()),
@@ -787,7 +797,7 @@ mod tests {
         let metrics = test_ingestion_metrics();
         let mut svc = broadcaster::<_, MockStreamingClient>(
             1000..1010,
-            Some(1005),
+            true,
             None,
             config,
             mock_client(metrics.clone()),
@@ -831,7 +841,7 @@ mod tests {
         let metrics = test_ingestion_metrics();
         let mut svc = broadcaster(
             0..5, // Bounded range
-            None,
+            false,
             Some(streaming_client),
             test_config(),
             mock_client(metrics.clone()),
@@ -863,7 +873,7 @@ mod tests {
         let metrics = test_ingestion_metrics();
         let mut svc = broadcaster(
             0..60,
-            None,
+            false,
             Some(streaming_client),
             test_config(),
             mock_client(metrics.clone()),
@@ -899,7 +909,7 @@ mod tests {
         let metrics = test_ingestion_metrics();
         let mut svc = broadcaster(
             0..30,
-            None,
+            false,
             Some(streaming_client),
             test_config(),
             mock_client(metrics.clone()),
@@ -933,7 +943,7 @@ mod tests {
         let metrics = test_ingestion_metrics();
         let mut svc = broadcaster(
             30..100,
-            None,
+            false,
             Some(streaming_client),
             test_config(),
             mock_client(metrics.clone()),
@@ -972,7 +982,7 @@ mod tests {
         let metrics = test_ingestion_metrics();
         let mut svc = broadcaster(
             0..20,
-            None,
+            false,
             Some(streaming_client),
             test_config(),
             mock_client(metrics.clone()),
@@ -1008,7 +1018,7 @@ mod tests {
         let metrics = test_ingestion_metrics();
         let mut svc = broadcaster(
             0..10,
-            None,
+            false,
             Some(streaming_client),
             test_config(),
             mock_client(metrics.clone()),
@@ -1041,6 +1051,8 @@ mod tests {
         let (hi_tx, hi_rx) = mpsc::unbounded_channel();
         let (subscriber_tx, mut subscriber_rx) = mpsc::channel(30);
 
+        hi_tx.send(("test", 5)).unwrap();
+
         let streaming_client = MockStreamingClient::new(0..20, None);
 
         let config = IngestionConfig {
@@ -1051,7 +1063,7 @@ mod tests {
         let metrics = test_ingestion_metrics();
         let mut svc = broadcaster(
             0..20,
-            Some(5), // initial watermark to trigger backpressure
+            true,
             Some(streaming_client),
             config,
             mock_client(metrics.clone()),
@@ -1099,7 +1111,7 @@ mod tests {
         let metrics = test_ingestion_metrics();
         let mut svc = broadcaster(
             0..15,
-            None,
+            false,
             Some(streaming_client),
             test_config(),
             mock_client(metrics.clone()),
@@ -1142,7 +1154,7 @@ mod tests {
         let metrics = test_ingestion_metrics();
         let mut svc = broadcaster(
             0..20,
-            None,
+            false,
             Some(streaming_client),
             test_config(),
             mock_client(metrics.clone()),
@@ -1176,7 +1188,7 @@ mod tests {
         let metrics = test_ingestion_metrics();
         let mut svc = broadcaster(
             0..20,
-            None,
+            false,
             Some(streaming_service),
             IngestionConfig {
                 streaming_backoff_initial_batch_size: 5,
@@ -1219,7 +1231,7 @@ mod tests {
         let metrics = test_ingestion_metrics();
         let mut svc = broadcaster(
             0..20,
-            None,
+            false,
             Some(streaming_client),
             IngestionConfig {
                 streaming_backoff_initial_batch_size: 5,
@@ -1262,7 +1274,7 @@ mod tests {
         let metrics = test_ingestion_metrics();
         let mut svc = broadcaster(
             0..50,
-            None,
+            false,
             Some(streaming_client),
             test_config(),
             mock_client(metrics.clone()),
@@ -1302,7 +1314,7 @@ mod tests {
         let metrics = test_ingestion_metrics();
         let mut svc = broadcaster(
             0..50,
-            None,
+            false,
             Some(streaming_client),
             test_config(),
             mock_client(metrics.clone()),
@@ -1363,7 +1375,7 @@ mod tests {
         };
         let mut svc = broadcaster(
             0..20,
-            None,
+            false,
             Some(streaming_service),
             config,
             mock_client(metrics.clone()),
@@ -1409,7 +1421,7 @@ mod tests {
         };
         let mut svc = broadcaster(
             0..20,
-            None,
+            false,
             Some(streaming_client),
             config,
             mock_client(metrics.clone()),
@@ -1450,7 +1462,7 @@ mod tests {
         let metrics = test_ingestion_metrics();
         let mut svc = broadcaster(
             0..15,
-            None,
+            false,
             Some(streaming_client),
             test_config(),
             mock_client(metrics.clone()),

--- a/crates/sui-indexer-alt-framework/src/ingestion/mod.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/mod.rs
@@ -167,15 +167,19 @@ impl IngestionService {
     /// subscribers' channels (potentially out-of-order). Subscribers can communicate with the
     /// ingestion service via their channels in the following ways:
     ///
-    /// - If a subscriber is lagging (not receiving checkpoints fast enough), it will eventually
-    ///   provide back-pressure to the ingestion service, which will stop fetching new checkpoints.
-    /// - If a subscriber closes its channel, the ingestion service will interpret that as a signal
-    ///   to shutdown as well.
+    /// - If a subscriber is slow to accept checkpoints from the channel, it will provide
+    ///   back-pressure as this channel has a fixed buffer size (configured when the ingestion
+    ///   service is initialized).
+    /// - If the ingestion service is run with `regulated = true`, subscribers must also update the
+    ///   ingestion service with the latest checkpoint they have completely processed, and the
+    ///   ingestion service will use this to limit how far ahead it fetches checkpoints.
+    /// - If a subscriber closes either of these channels, the ingestion service will interpret
+    ///   that as a signal to shutdown as well.
     ///
     /// If ingestion reaches the leading edge of the network, it will encounter checkpoints that do
     /// not exist yet. These will be retried repeatedly on a fixed `retry_interval` until they
     /// become available.
-    pub async fn run<R>(self, checkpoints: R, initial_commit_hi: Option<u64>) -> Result<Service>
+    pub async fn run<R>(self, checkpoints: R, regulated: bool) -> Result<Service>
     where
         R: std::ops::RangeBounds<u64> + Send + 'static,
     {
@@ -195,7 +199,7 @@ impl IngestionService {
 
         Ok(broadcaster(
             checkpoints,
-            initial_commit_hi,
+            regulated,
             streaming_client,
             config,
             ingestion_client,
@@ -290,7 +294,7 @@ mod tests {
 
         let ingestion_service = test_ingestion(server.uri(), 1, 1).await;
 
-        let res = ingestion_service.run(0.., None).await;
+        let res = ingestion_service.run(0.., false).await;
         assert!(matches!(res, Err(Error::NoSubscribers)));
     }
 
@@ -309,7 +313,7 @@ mod tests {
 
         let (rx, _) = ingestion_service.subscribe();
         let subscriber = test_subscriber(usize::MAX, rx).await;
-        let svc = ingestion_service.run(0.., None).await.unwrap();
+        let svc = ingestion_service.run(0.., false).await.unwrap();
 
         svc.shutdown().await.unwrap();
         subscriber.await.unwrap();
@@ -330,7 +334,7 @@ mod tests {
 
         let (rx, _) = ingestion_service.subscribe();
         let subscriber = test_subscriber(1, rx).await;
-        let mut svc = ingestion_service.run(0.., None).await.unwrap();
+        let mut svc = ingestion_service.run(0.., false).await.unwrap();
 
         drop(subscriber);
         svc.join().await.unwrap();
@@ -357,7 +361,7 @@ mod tests {
 
         let (rx, _) = ingestion_service.subscribe();
         let subscriber = test_subscriber(5, rx).await;
-        let _svc = ingestion_service.run(0.., None).await.unwrap();
+        let _svc = ingestion_service.run(0.., false).await.unwrap();
 
         let seqs = subscriber.await.unwrap();
         assert_eq!(seqs, vec![1, 2, 3, 6, 7]);
@@ -383,7 +387,7 @@ mod tests {
 
         let (rx, _) = ingestion_service.subscribe();
         let subscriber = test_subscriber(5, rx).await;
-        let _svc = ingestion_service.run(0.., None).await.unwrap();
+        let _svc = ingestion_service.run(0.., false).await.unwrap();
 
         let seqs = subscriber.await.unwrap();
         assert_eq!(seqs, vec![1, 2, 3, 6, 7]);
@@ -414,7 +418,7 @@ mod tests {
 
         let (rx, _) = ingestion_service.subscribe();
         let subscriber = test_subscriber(5, rx).await;
-        let _svc = ingestion_service.run(0.., None).await.unwrap();
+        let _svc = ingestion_service.run(0.., false).await.unwrap();
 
         // At this point, the service will have been able to pass 3 checkpoints to the non-lagging
         // subscriber, while the laggard's buffer fills up. Now the laggard will pull two

--- a/crates/sui-indexer-alt-framework/src/pipeline/sequential/mod.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/sequential/mod.rs
@@ -117,7 +117,7 @@ pub(crate) fn pipeline<H: Handler + Send + Sync + 'static>(
     config: SequentialConfig,
     db: H::Store,
     checkpoint_rx: mpsc::Receiver<Arc<Checkpoint>>,
-    watermark_tx: mpsc::UnboundedSender<(&'static str, u64)>,
+    commit_hi_tx: mpsc::UnboundedSender<(&'static str, u64)>,
     metrics: Arc<IndexerMetrics>,
 ) -> Service {
     info!(
@@ -141,7 +141,7 @@ pub(crate) fn pipeline<H: Handler + Send + Sync + 'static>(
         config,
         next_checkpoint,
         committer_rx,
-        watermark_tx,
+        commit_hi_tx,
         db,
         metrics.clone(),
     );


### PR DESCRIPTION
## Description

This change proposes a further simplification following the recent change to unify concurrent- and sequential-pipeline back-pressure to use the regulator:

- The initial bound for checkpoints to fetch can be derived from the range of checkpoints to fetch, rather than the being passed as a separate parameter.
- The ingestion service can now be run in "regulated" mode (where it needs subscribers to tell it when they have completed the processing of a checkpoint), or not, where it relies on channel-based back-pressure (the old mechanism for concurrent pipelines).
- The watch channel used for communicating updates is now slightly simpler: Its internal state is just a `u64`, but the whole receiver is treated as optional (so that if the service is unregulated, `None` can be passed instead of a real receiver).

## Test plan

Existing tests:

```
$ cargo nextest run -p sui-indexer-alt-framework
$ cargo nextest run -p sui-indexer-alt-e2e-tests -j3
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
