### PR TITLE
Reduce QUIC max_idle_timeout from 30s to 10s

### DIFF
--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -1189,7 +1189,7 @@ impl SuiNode {
                 quic_config.crypto_buffer_size = Some(1 << 20);
             }
             if quic_config.max_idle_timeout_ms.is_none() {
-                quic_config.max_idle_timeout_ms = Some(30_000);
+                quic_config.max_idle_timeout_ms = Some(10_000);
             }
             if quic_config.keep_alive_interval_ms.is_none() {
                 quic_config.keep_alive_interval_ms = Some(5_000);


### PR DESCRIPTION
## Summary
- Reduces the default QUIC `max_idle_timeout` from 30 seconds to 10 seconds for anemo peer connections
- This allows fullnodes to detect dead validator connections ~3x faster after a correlated crash, preventing checkpoint sync stalls

## Motivation
After a correlated validator crash (all validators restart simultaneously), the fullnode's QUIC connections become stale but remain in `ActivePeers`:

1. `open_bi()` and `write_request()` succeed locally on dead connections (no remote round-trip needed)
2. `read_response()` hangs until the 5-second request timeout fires
3. The QUIC idle timeout is the **only** mechanism that removes stale connections
4. At 30 seconds, the idle timeout races with the `CheckpointTimeout` (also ~30s), causing fullnodes to get stuck at a stale checkpoint and clients to see version mismatch errors on retry

Reducing the idle timeout to 10 seconds gives the fullnode time to detect dead connections, reconnect to restarted validators, and sync missed checkpoints before the `CheckpointTimeout` fires.

## Test plan
- [x] Original failing simtest seed (1770576154006) passes with the fix
- [x] `seed-search.py` on `test_simulated_load_with_reconfig_and_correlated_crashes`: 200/200 seeds pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)