### PR TITLE
[1.65] Fix tidehunter build errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8326,7 +8326,7 @@ dependencies = [
 [[package]]
 name = "minibytes"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/tidehunter.git?rev=220d41cd1134316337c0e2228d45805f7d0dea7e#220d41cd1134316337c0e2228d45805f7d0dea7e"
+source = "git+https://github.com/mystenlabs/tidehunter.git?rev=2d5358d68848fce7e6b564678795d87ab8ffc221#2d5358d68848fce7e6b564678795d87ab8ffc221"
 dependencies = [
  "bytes",
  "memmap2 0.7.1",
@@ -17941,7 +17941,7 @@ dependencies = [
 [[package]]
 name = "tidehunter"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/tidehunter.git?rev=220d41cd1134316337c0e2228d45805f7d0dea7e#220d41cd1134316337c0e2228d45805f7d0dea7e"
+source = "git+https://github.com/mystenlabs/tidehunter.git?rev=2d5358d68848fce7e6b564678795d87ab8ffc221#2d5358d68848fce7e6b564678795d87ab8ffc221"
 dependencies = [
  "arc-swap",
  "bincode 1.3.3",

--- a/crates/typed-store/Cargo.toml
+++ b/crates/typed-store/Cargo.toml
@@ -39,7 +39,7 @@ itertools.workspace = true
 mysten-common.workspace = true
 mysten-metrics.workspace = true
 [target.'cfg(not(windows))'.dependencies]
-tidehunter = {git = "https://github.com/mystenlabs/tidehunter.git", rev = "220d41cd1134316337c0e2228d45805f7d0dea7e", version = "0.1.0", optional = true}
+tidehunter = {git = "https://github.com/mystenlabs/tidehunter.git", rev = "2d5358d68848fce7e6b564678795d87ab8ffc221", version = "0.1.0", optional = true}
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 rocksdb = { version = "0.22.0", default-features = false, features = ["jemalloc"] }


### PR DESCRIPTION
## Summary
Cherry-pick of tidehunter dependency updates to the 1.65 release branch to fix build errors when compiling with tidehunter features enabled.

This PR includes:
- #25256 - Pin mystenlabs tidehunter commit for sui
- #25365 - Update to tidehunter to c3b7be698ea035f18e5bae36554768ddf71e472f

## Test Plan
✅ Built sui-node with tidehunter features: `cargo build -p sui-node --features typed-store/tidehunter`

Original commits:
- 86f052d678880a2d519d9643e17d73c059e8ec23
- 362c4758db295f3f4baa54aaf50824af6bef3eff