### PR TITLE
cli(ptb): pure type inference looks through references

### DIFF
--- a/crates/sui-json/src/lib.rs
+++ b/crates/sui-json/src/lib.rs
@@ -575,9 +575,11 @@ pub fn primitive_type(
         SignatureToken::U128 => MoveTypeLayout::U128,
         SignatureToken::U256 => MoveTypeLayout::U256,
         SignatureToken::Address => MoveTypeLayout::Address,
+
         SignatureToken::Vector(inner) => {
             MoveTypeLayout::Vector(Box::new(primitive_type(view, type_args, inner)?))
         }
+
         SignatureToken::Datatype(struct_handle_idx) => {
             let resolved_struct = resolve_struct(view, *struct_handle_idx);
             if resolved_struct == RESOLVED_ASCII_STR {
@@ -591,6 +593,7 @@ pub fn primitive_type(
                 return None;
             }
         }
+
         SignatureToken::DatatypeInstantiation(struct_inst) => {
             let (idx, targs) = &**struct_inst;
             let resolved_struct = resolve_struct(view, *idx);
@@ -602,12 +605,16 @@ pub fn primitive_type(
                 return None;
             }
         }
+
         SignatureToken::TypeParameter(idx) => {
             layout_of_primitive_typetag(type_args.get(*idx as usize)?)?
         }
-        SignatureToken::Signer
-        | SignatureToken::Reference(_)
-        | SignatureToken::MutableReference(_) => return None,
+
+        SignatureToken::Reference(sig) | SignatureToken::MutableReference(sig) => {
+            primitive_type(view, type_args, sig)?
+        }
+
+        SignatureToken::Signer => return None,
     })
 }
 


### PR DESCRIPTION
## Description

Add support to the CLI to look "through" reference types when checking whether an argument is a pure type.

## Test plan

The following invocation would have failed before, and now it succeeds:

```
$ cargo run --bin sui -- client ptb \
    --move-call 0x3::sui_system::validator_address_by_pool_id @0x5 @0x0cf0a8d13f56cb4c675a74f9f8e646dc7c3e00c5e50da0d6c076b291f57f617f \
    --dev-inspect
```

It failed previously because the argument was an `&ID`, but now the CLI can understand that and still serialize it as an `address`.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [x] CLI: Fix an issue where the CLI would fail to infer the type of a primitive argument to a Move call if that argument was accessed by reference or by mutable reference.
- [ ] Rust SDK:
- [ ] Indexing Framework:
