### PR TITLE
impl Tracer for &mut Tracer

### DIFF
--- a/external-crates/move/crates/move-trace-format/src/interface.rs
+++ b/external-crates/move/crates/move-trace-format/src/interface.rs
@@ -29,7 +29,6 @@ impl<T: Tracer> Tracer for &mut T {
     }
 }
 
-
 /// A writer that allows you to push custom events to the trace but encapsulates the trace so that
 /// non-external events cannot be accidentally added.
 pub struct Writer<'a>(pub(crate) &'a mut MoveTrace);


### PR DESCRIPTION
## Description 

The allows `&mut T` to be used as a `Tracer` in case `T` is `Tracer`. Due to the orphan rule, it is not possible to achive this in downstream crates without extra wrapper code.

cc @tzakian 

## Test plan 

CI
---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
