### PR TITLE
[docs] [graphql-alt] mention unpruned indexer pipelines that must index from genesis

### DIFF
--- a/docs/content/guides/operator/indexer-stack-setup.mdx
+++ b/docs/content/guides/operator/indexer-stack-setup.mdx
@@ -54,36 +54,11 @@ A 30-day retention adds 1.8 TB on top, while a 90-day retention contributes up t
 | cp_sequence_numbers | 10 | 5 |
 | **TOTAL** | **755–842** | **2,440–3,181** |
 
-### Pipeline categories
-
-The indexer pipelines are divided into two categories based on their data retention requirements:
-
-#### Unpruned pipelines (must index from genesis)
-These pipelines contain foundational data that must be indexed from genesis (checkpoint 0):
-- `obj_versions.toml` - Object versions table containing complete object version to checkpoint sequence number mappings since genesis
-- `unpruned.toml` - Foundational reference data and smaller kv tables
-
-:::warning GraphQL Service Dependency
-The GraphQL RPC service will only operate normally once unpruned pipelines have caught up to the network tip. Plan accordingly as these pipelines can take 10-14 days to fully backfill from genesis.
-:::
-
-#### Pruned pipelines (can start from recent checkpoint)
-These pipelines can be configured with a `first-checkpoint` parameter based on your retention requirements:
-- `events.toml`
-- `tx_affected_addresses.toml`
-- `tx_affected_objects.toml`
-- `tx_calls.toml`
-- `tx_kinds.toml`
-
-For pruned pipelines, calculate the `first-checkpoint` based on your retention period:
-- **30-day retention**: Start from checkpoint `current_checkpoint - 10368000`
-- **90-day retention**: Start from checkpoint `current_checkpoint - 31104000`
-
 ### Run `sui-indexer-alt`
 
-Run an indexer instance using this command for each of the configuration files:
+Run an indexer instance using this command for each of the configuration files. The command varies based on whether the pipeline is prunable or unprunable:
 
-#### For unpruned pipelines (must start from genesis)
+#### For unprunable pipelines (must start from genesis)
 ```sh
 $ sui-indexer-alt indexer \
     --config <CONFIG_FILE> \
@@ -91,7 +66,7 @@ $ sui-indexer-alt indexer \
     --remote-store-url <REMOTE_STORE_URL>
 ```
 
-#### For pruned pipelines with retention period
+#### For prunable pipelines with retention period
 ```sh
 $ sui-indexer-alt indexer \
     --config <CONFIG_FILE> \
@@ -100,16 +75,20 @@ $ sui-indexer-alt indexer \
     --first-checkpoint <CHECKPOINT_NUMBER>
 ```
 
+For prunable pipelines, calculate the `first-checkpoint` based on your retention period:
+- **30-day retention**: Start from checkpoint `current_checkpoint - 10368000`
+- **90-day retention**: Start from checkpoint `current_checkpoint - 31104000`
+
 | **CLI param**            | **Description**                                                                                                                          |
 | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
 | `<CONFIG_FILE>`      | Path to indexer configuration file.                                                                                                  |
 | `<DATABASE_URL>`     | Postgres database connection string.                                                                                                 |
 | `<REMOTE_STORE_URL>` | URL of a checkpoint bucket to index from, one of multiple possible [data sources](/guides/developer/accessing-data/custom-indexing-framework#data-sources). |
-| `<CHECKPOINT_NUMBER>`| (Optional) For pruned pipelines only - the checkpoint to start indexing from based on retention requirements.                        |
+| `<CHECKPOINT_NUMBER>`| (Optional) For prunable pipelines only - the checkpoint to start indexing from based on retention requirements.                        |
 
 #### Examples
 
-**Unpruned pipeline (from genesis):**
+**Unprunable pipeline (from genesis):**
 ```sh
 $ sui-indexer-alt indexer \
     --config unpruned.toml \
@@ -117,13 +96,13 @@ $ sui-indexer-alt indexer \
     --remote-store-url https://checkpoints.mainnet.sui.io
 ```
 
-**Pruned pipeline with 30-day retention (assuming current checkpoint is 100,000,000):**
+**Prunable pipeline with 30-day retention (assuming current checkpoint is 100,000,000):**
 ```sh
 $ sui-indexer-alt indexer \
     --config events.toml \
     --database-url postgres://username:password@localhost:5432/database \
     --remote-store-url https://checkpoints.mainnet.sui.io \
-    --first-checkpoint 97408000
+    --first-checkpoint 89632000
 ```
 
 ### Run config recommendations {#indexer-run-config}
@@ -149,7 +128,7 @@ When backfilling, you should set the `ingest-concurrency` to a higher value, e.g
 	<tbody>
 		<tr>
 			<td>`events.toml`</td>
-			<td>**Pruned**</td>
+			<td>**Prunable**</td>
 			<td>Lightweight event tables.</td>
 			<td>
 				<ul className="pl-4">
@@ -158,8 +137,8 @@ When backfilling, you should set the `ingest-concurrency` to a higher value, e.g
 				</ul>
 			</td>
 			<td>1-2 days</td>
-			<td>90 days</td>
-			<td>Based on retention</td>
+			<td>Configurable (e.g., 30 or 90 days)</td>
+			<td>Based on retention period</td>
 		</tr>
 		<tr>
 			<td colspan={7}>
@@ -171,12 +150,12 @@ When backfilling, you should set the `ingest-concurrency` to a higher value, e.g
 		</tr>
 		<tr>
 			<td>`obj_versions.toml`</td>
-			<td>**Unpruned**</td>
-			<td>Heavyweight object versions table containing data since genesis.</td>
+			<td>**Unprunable**</td>
+			<td>Object versions table containing complete object version to checkpoint mappings.</td>
 			<td>`obj_versions`</td>
 			<td>10-14 days</td>
-			<td>Unpruned</td>
-			<td>Must start from genesis (0)</td>
+			<td>Must retain all data</td>
+			<td>Genesis (checkpoint 0)</td>
 		</tr>
 		<tr>
 			<td colspan={7}>
@@ -188,12 +167,12 @@ When backfilling, you should set the `ingest-concurrency` to a higher value, e.g
 		</tr>
 		<tr>
 			<td>`tx_affected_addresses.toml`</td>
-			<td>**Pruned**</td>
+			<td>**Prunable**</td>
 			<td>Midweight transaction table.</td>
 			<td>`tx_affected_addresses`</td>
 			<td>1-2 days</td>
-			<td>90 days</td>
-			<td>Based on retention</td>
+			<td>Configurable (e.g., 30 or 90 days)</td>
+			<td>Based on retention period</td>
 		</tr>
 		<tr>
 			<td colspan={7}>
@@ -205,12 +184,12 @@ When backfilling, you should set the `ingest-concurrency` to a higher value, e.g
 		</tr>
 		<tr>
 			<td>`tx_affected_objects.toml`</td>
-			<td>**Pruned**</td>
+			<td>**Prunable**</td>
 			<td>Midweight transaction table.</td>
 			<td>`tx_affected_objects`</td>
 			<td>1-2 days</td>
-			<td>90 days</td>
-			<td>Based on retention</td>
+			<td>Configurable (e.g., 30 or 90 days)</td>
+			<td>Based on retention period</td>
 		</tr>
 		<tr>
 			<td colspan={7}>
@@ -222,12 +201,12 @@ When backfilling, you should set the `ingest-concurrency` to a higher value, e.g
 		</tr>
 		<tr>
 			<td>`tx_calls.toml`</td>
-			<td>**Pruned**</td>
+			<td>**Prunable**</td>
 			<td>Midweight transaction table.</td>
 			<td>`tx_calls`</td>
 			<td>1-2 days</td>
-			<td>90 days</td>
-			<td>Based on retention</td>
+			<td>Configurable (e.g., 30 or 90 days)</td>
+			<td>Based on retention period</td>
 		</tr>
 		<tr>
 			<td colspan={7}>
@@ -239,12 +218,12 @@ When backfilling, you should set the `ingest-concurrency` to a higher value, e.g
 		</tr>
 		<tr>
 			<td>`tx_kinds.toml`</td>
-			<td>**Pruned**</td>
+			<td>**Prunable**</td>
 			<td>Midweight transaction table.</td>
 			<td>`tx_kinds`</td>
 			<td>1-2 days</td>
-			<td>90 days</td>
-			<td>Based on retention</td>
+			<td>Configurable (e.g., 30 or 90 days)</td>
+			<td>Based on retention period</td>
 		</tr>
 		<tr>
 			<td colspan={7}>
@@ -256,8 +235,8 @@ When backfilling, you should set the `ingest-concurrency` to a higher value, e.g
 		</tr>
 		<tr>
 			<td>`unpruned.toml`</td>
-			<td>**Unpruned**</td>
-			<td>Foundational and reference data that other queries and parts of the indexer depend on.</td>
+			<td>**Unprunable**</td>
+			<td>Foundational reference data that other queries depend on.</td>
 			<td>
 				<ul className="pl-4">
 					<li>`cp_sequence_numbers`</li>
@@ -272,8 +251,8 @@ When backfilling, you should set the `ingest-concurrency` to a higher value, e.g
 				</ul>
 			</td>
 			<td>2-4 days</td>
-			<td>Unpruned</td>
-			<td>Must start from genesis (0)</td>
+			<td>Must retain all data</td>
+			<td>Genesis (checkpoint 0)</td>
 		</tr>
 		<tr>
 			<td colspan={7}>
@@ -387,7 +366,7 @@ $ sui-indexer-alt-consistent-store run \
 				</ul>
 			</td>
 			<td>1-2 hours</td>
-			<td>Unpruned</td>
+			<td>Must retain all data</td>
 		</tr>
 	</tbody>
 </table>
@@ -401,9 +380,13 @@ $ sui-indexer-alt-consistent-store run \
 
 GraphQL RPC server reads data from the general-purpose indexer's database (Postgres), the consistent store, and the [archival service](/guides/developer/accessing-data/archival-store.mdx).
 
-:::warning Prerequisites
-Before starting the GraphQL RPC server, ensure that **all unpruned indexer pipelines** (`obj_versions.toml` and `unpruned.toml`) have fully caught up with the pruned pipelines.
-:::
+<Tabs className="tabsHeadingCentered--small">
+<TabItem value="prereq" label="Prerequisites">
+
+- [x] Ensure that **all unprunable indexer pipelines** (`obj_versions.toml` and `unpruned.toml`) have fully caught up to the network tip before starting the GraphQL RPC server. The GraphQL service will only operate normally once these pipelines are complete.
+
+</TabItem>
+</Tabs>
 
 #### Hardware requirements
 


### PR DESCRIPTION


## Description 

Update the documentation for indexer operator to emphasize indexer pipelines that must be unpruned and indexed from genesis.



---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
