### PR TITLE
[bella-ciao] Fix warnings when building in release mode

### DIFF
--- a/external-crates/move/crates/move-vm-runtime/src/dev_utils/dbg_print.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/dev_utils/dbg_print.rs
@@ -2,8 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Debug print code for development. Remove when moving into production mode.
+#[cfg(debug_assertions)]
 pub const DEBUG_PRINT: bool = false;
 
+#[cfg(debug_assertions)]
 pub struct DebugFlags {
     pub function_list_sizes: bool,
     pub function_resolution: bool,
@@ -12,6 +14,7 @@ pub struct DebugFlags {
     pub optimizer: bool,
 }
 
+#[cfg(debug_assertions)]
 pub const DEBUG_FLAGS: DebugFlags = DebugFlags {
     function_list_sizes: false,
     function_resolution: false,

--- a/external-crates/move/crates/move-vm-runtime/src/jit/execution/translate.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/jit/execution/translate.rs
@@ -521,7 +521,7 @@ fn datatypes(
     // and pass a full and complete representation of it in with the package.
     fn defining_id(
         context: &PackageContext,
-        version_id: &VersionId,
+        _version_id: &VersionId,
         name: &VirtualTableKey,
     ) -> PartialVMResult<ModuleIdKey> {
         let defining_address = context
@@ -534,7 +534,7 @@ fn datatypes(
                     name.to_string(context.interner),
                 )
             })?;
-        dbg_println!("Package ID: {:?}", version_id);
+        dbg_println!("Package ID: {:?}", _version_id);
         dbg_println!("Defining Address: {:?}", defining_address);
         let module_id = name.intra_package_key().module_name;
         Ok(ModuleIdKey::from_parts(*defining_address, module_id))
@@ -603,8 +603,11 @@ fn structs(
 
             let abilities = struct_handle.abilities;
 
-            let struct_module_handle = module.module_handle_at(struct_handle.module);
-            dbg_println!("Indexing type {:?} at {:?}", name, struct_module_handle);
+            dbg_println!(
+                "Indexing type {:?} at {:?}",
+                name,
+                module.module_handle_at(struct_handle.module)
+            );
 
             let StructFieldInformation::Declared(fields) = &struct_def.field_information else {
                 return Err(partial_vm_error!(
@@ -669,8 +672,11 @@ fn enums(
             let def_vtable_key =
                 VirtualTableKey::from_parts(*original_id, *module_name, member_name);
 
-            let enum_module_handle = module.module_handle_at(enum_handle.module);
-            dbg_println!("Indexing type {:?} at {:?}", name, enum_module_handle);
+            dbg_println!(
+                "Indexing type {:?} at {:?}",
+                name,
+                module.module_handle_at(enum_handle.module)
+            );
 
             let abilities = enum_handle.abilities;
 

--- a/external-crates/move/crates/move-vm-runtime/src/runtime/mod.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/runtime/mod.rs
@@ -245,8 +245,7 @@ impl MoveRuntime {
             let total_timer = txn_telemetry.make_timer(crate::runtime::telemetry::TimerKind::Total);
 
             let result = try_block! {
-                let version_id = pkg.version_id;
-                dbg_println!("\n\nPublishing module at {version_id} (=> {original_id})\n\n");
+                dbg_println!("\n\nPublishing module at {} (=> {original_id})\n\n", pkg.version_id);
 
                 let link_context = LinkageContext::new(pkg.linkage_table.clone());
 


### PR DESCRIPTION
## Description 

We were getting unused variable warnings when building in release mode. Fix them.

## Test plan 

built in release mode and made sure the warnings were gone. There are still some from `main` but I will fix those over there and merge them into the bella ciao branch.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
