### PR TITLE
Additional schema changes per pull/25143

### DIFF
--- a/crates/sui-kvstore/src/tables/epochs.rs
+++ b/crates/sui-kvstore/src/tables/epochs.rs
@@ -27,6 +27,19 @@ pub mod col {
     // Epoch End columns
     pub const END_TIMESTAMP: &str = "et";
     pub const END_CHECKPOINT: &str = "ec";
+    pub const CP_HI: &str = "ch";
+    pub const TX_HI: &str = "th";
+    pub const SAFE_MODE: &str = "sm";
+    pub const TOTAL_STAKE: &str = "ts";
+    pub const STORAGE_FUND_BALANCE: &str = "sf";
+    pub const STORAGE_FUND_REINVESTMENT: &str = "sr";
+    pub const STORAGE_CHARGE: &str = "sg";
+    pub const STORAGE_REBATE: &str = "sb";
+    pub const STAKE_SUBSIDY_AMOUNT: &str = "sa";
+    pub const TOTAL_GAS_FEES: &str = "tg";
+    pub const TOTAL_STAKE_REWARDS_DISTRIBUTED: &str = "td";
+    pub const LEFTOVER_STORAGE_FUND_INFLOW: &str = "lf";
+    pub const EPOCH_COMMITMENTS: &str = "cm";
 }
 
 pub fn encode_key(epoch_id: EpochId) -> Vec<u8> {
@@ -75,8 +88,24 @@ pub fn encode_start(
 }
 
 /// Encode epoch end data to individual columns.
-pub fn encode_end(end_timestamp_ms: u64, end_checkpoint: u64) -> [(&'static str, Bytes); 2] {
-    [
+pub fn encode_end(
+    end_timestamp_ms: u64,
+    end_checkpoint: u64,
+    cp_hi: u64,
+    tx_hi: u64,
+    safe_mode: bool,
+    total_stake: Option<u64>,
+    storage_fund_balance: Option<u64>,
+    storage_fund_reinvestment: Option<u64>,
+    storage_charge: Option<u64>,
+    storage_rebate: Option<u64>,
+    stake_subsidy_amount: Option<u64>,
+    total_gas_fees: Option<u64>,
+    total_stake_rewards_distributed: Option<u64>,
+    leftover_storage_fund_inflow: Option<u64>,
+    epoch_commitments: &[u8],
+) -> Vec<(&'static str, Bytes)> {
+    let mut cols = vec![
         (
             col::END_TIMESTAMP,
             Bytes::from(end_timestamp_ms.to_be_bytes().to_vec()),
@@ -85,7 +114,40 @@ pub fn encode_end(end_timestamp_ms: u64, end_checkpoint: u64) -> [(&'static str,
             col::END_CHECKPOINT,
             Bytes::from(end_checkpoint.to_be_bytes().to_vec()),
         ),
-    ]
+        (col::CP_HI, Bytes::from(cp_hi.to_be_bytes().to_vec())),
+        (col::TX_HI, Bytes::from(tx_hi.to_be_bytes().to_vec())),
+        (col::SAFE_MODE, Bytes::from(vec![u8::from(safe_mode)])),
+        (
+            col::EPOCH_COMMITMENTS,
+            Bytes::from(epoch_commitments.to_vec()),
+        ),
+    ];
+
+    let optional_fields: [(&str, Option<u64>); 9] = [
+        (col::TOTAL_STAKE, total_stake),
+        (col::STORAGE_FUND_BALANCE, storage_fund_balance),
+        (col::STORAGE_FUND_REINVESTMENT, storage_fund_reinvestment),
+        (col::STORAGE_CHARGE, storage_charge),
+        (col::STORAGE_REBATE, storage_rebate),
+        (col::STAKE_SUBSIDY_AMOUNT, stake_subsidy_amount),
+        (col::TOTAL_GAS_FEES, total_gas_fees),
+        (
+            col::TOTAL_STAKE_REWARDS_DISTRIBUTED,
+            total_stake_rewards_distributed,
+        ),
+        (
+            col::LEFTOVER_STORAGE_FUND_INFLOW,
+            leftover_storage_fund_inflow,
+        ),
+    ];
+
+    for (name, value) in optional_fields {
+        if let Some(v) = value {
+            cols.push((name, Bytes::from(v.to_be_bytes().to_vec())));
+        }
+    }
+
+    cols
 }
 
 pub fn decode(row: &[(Bytes, Bytes)]) -> Result<EpochData> {
@@ -116,6 +178,32 @@ pub fn decode(row: &[(Bytes, Bytes)]) -> Result<EpochData> {
             b"ss" => data.system_state = Some(bcs::from_bytes(value)?),
             b"et" => data.end_timestamp_ms = Some(u64::from_be_bytes(value.as_ref().try_into()?)),
             b"ec" => data.end_checkpoint = Some(u64::from_be_bytes(value.as_ref().try_into()?)),
+            b"ch" => data.cp_hi = Some(u64::from_be_bytes(value.as_ref().try_into()?)),
+            b"th" => data.tx_hi = Some(u64::from_be_bytes(value.as_ref().try_into()?)),
+            b"sm" => data.safe_mode = Some(value.as_ref().first().copied().unwrap_or(0) != 0),
+            b"ts" => data.total_stake = Some(u64::from_be_bytes(value.as_ref().try_into()?)),
+            b"sf" => {
+                data.storage_fund_balance = Some(u64::from_be_bytes(value.as_ref().try_into()?))
+            }
+            b"sr" => {
+                data.storage_fund_reinvestment =
+                    Some(u64::from_be_bytes(value.as_ref().try_into()?))
+            }
+            b"sg" => data.storage_charge = Some(u64::from_be_bytes(value.as_ref().try_into()?)),
+            b"sb" => data.storage_rebate = Some(u64::from_be_bytes(value.as_ref().try_into()?)),
+            b"sa" => {
+                data.stake_subsidy_amount = Some(u64::from_be_bytes(value.as_ref().try_into()?))
+            }
+            b"tg" => data.total_gas_fees = Some(u64::from_be_bytes(value.as_ref().try_into()?)),
+            b"td" => {
+                data.total_stake_rewards_distributed =
+                    Some(u64::from_be_bytes(value.as_ref().try_into()?))
+            }
+            b"lf" => {
+                data.leftover_storage_fund_inflow =
+                    Some(u64::from_be_bytes(value.as_ref().try_into()?))
+            }
+            b"cm" => data.epoch_commitments = Some(value.to_vec()),
             _ => {}
         }
     }


### PR DESCRIPTION
## Description

Addressing post-merge feedback from pull/25143.

- Additional epoch end fields for graphql
- Optimizing object iteration
- Fixing mislocated pipeline name constants/comments

(Object types table has already been removed, we agreed to just load types from the object data table directly)

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework:
