### PR TITLE
Fix checkpoint queue drain-boundary commit logic

### DIFF
--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -308,8 +308,28 @@ pub struct ExecutionIndicesWithStats {
     /// height, we've fully executed the commit.
     pub height: u64,
     pub stats: ConsensusStats,
-    #[serde(default)]
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq, Eq)]
+pub struct ExecutionIndicesWithStatsV2 {
+    pub index: ExecutionIndices,
+    pub height: u64,
+    pub stats: ConsensusStats,
     pub last_checkpoint_flush_timestamp: u64,
+    // Reserved for future use.
+    pub checkpoint_seq: u64,
+}
+
+impl From<ExecutionIndicesWithStats> for ExecutionIndicesWithStatsV2 {
+    fn from(v1: ExecutionIndicesWithStats) -> Self {
+        Self {
+            index: v1.index,
+            height: v1.height,
+            stats: v1.stats,
+            last_checkpoint_flush_timestamp: 0,
+            checkpoint_seq: 0,
+        }
+    }
 }
 
 type ExecutionModuleCache = SyncModuleCache<ResolverWrapper>;
@@ -508,6 +528,8 @@ pub struct AuthorityEpochTables {
     /// transactions, and accumulated stats of consensus output.
     /// This field is written by a single process (consensus handler).
     last_consensus_stats: DBMap<u64, ExecutionIndicesWithStats>,
+
+    last_consensus_stats_v2: DBMap<u64, ExecutionIndicesWithStatsV2>,
 
     /// This table contains current reconfiguration state for validator for current epoch
     reconfig_state: DBMap<u64, ReconfigState>,
@@ -728,6 +750,10 @@ impl AuthorityEpochTables {
                 ThConfig::new(8, 1, KeyType::uniform(1)),
             ),
             (
+                "last_consensus_stats_v2".to_string(),
+                ThConfig::new(8, 1, KeyType::uniform(1)),
+            ),
+            (
                 "reconfig_state".to_string(),
                 ThConfig::new(8, 1, KeyType::uniform(1)),
             ),
@@ -918,8 +944,17 @@ impl AuthorityEpochTables {
             .map(|s| s.index))
     }
 
-    pub fn get_last_consensus_stats(&self) -> SuiResult<Option<ExecutionIndicesWithStats>> {
-        Ok(self.last_consensus_stats.get(&LAST_CONSENSUS_STATS_ADDR)?)
+    pub fn get_last_consensus_stats(&self) -> SuiResult<Option<ExecutionIndicesWithStatsV2>> {
+        if let Some(v2) = self
+            .last_consensus_stats_v2
+            .get(&LAST_CONSENSUS_STATS_ADDR)?
+        {
+            return Ok(Some(v2));
+        }
+        Ok(self
+            .last_consensus_stats
+            .get(&LAST_CONSENSUS_STATS_ADDR)?
+            .map(Into::into))
     }
 
     pub fn get_locked_transaction(&self, obj_ref: &ObjectRef) -> SuiResult<Option<LockDetails>> {
@@ -2193,7 +2228,7 @@ impl AuthorityPerEpochStore {
             .collect()
     }
 
-    pub fn get_last_consensus_stats(&self) -> SuiResult<ExecutionIndicesWithStats> {
+    pub fn get_last_consensus_stats(&self) -> SuiResult<ExecutionIndicesWithStatsV2> {
         assert!(
             self.consensus_quarantine.read().is_empty(),
             "get_last_consensus_stats should only be called at startup"

--- a/crates/sui-core/src/authority/consensus_quarantine.rs
+++ b/crates/sui-core/src/authority/consensus_quarantine.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::authority::authority_per_epoch_store::{
-    AuthorityEpochTables, EncG, ExecutionIndicesWithStats, LockDetails, LockDetailsWrapper, PkG,
+    AuthorityEpochTables, EncG, ExecutionIndicesWithStatsV2, LockDetails, LockDetailsWrapper, PkG,
 };
 use crate::authority::transaction_deferral::DeferralKey;
 use crate::checkpoints::BuilderCheckpointSummary;
@@ -59,7 +59,7 @@ pub(crate) struct ConsensusCommitOutput {
     consensus_messages_processed: BTreeSet<SequencedConsensusTransactionKey>,
     end_of_publish: BTreeSet<AuthorityName>,
     reconfig_state: Option<ReconfigState>,
-    consensus_commit_stats: Option<ExecutionIndicesWithStats>,
+    consensus_commit_stats: Option<ExecutionIndicesWithStatsV2>,
 
     // transaction scheduling state
     next_shared_object_versions: Option<HashMap<ConsensusObjectSequenceKey, SequenceNumber>>,
@@ -182,7 +182,7 @@ impl ConsensusCommitOutput {
             .push((source, generation, estimates));
     }
 
-    pub(crate) fn record_consensus_commit_stats(&mut self, stats: ExecutionIndicesWithStats) {
+    pub(crate) fn record_consensus_commit_stats(&mut self, stats: ExecutionIndicesWithStatsV2) {
         self.consensus_commit_stats = Some(stats);
     }
 
@@ -319,7 +319,7 @@ impl ConsensusCommitOutput {
         let round = consensus_commit_stats.index.last_committed_round;
 
         batch.insert_batch(
-            &tables.last_consensus_stats,
+            &tables.last_consensus_stats_v2,
             [(LAST_CONSENSUS_STATS_ADDR, consensus_commit_stats)],
         )?;
 
@@ -1167,5 +1167,144 @@ where
 
     pub fn contains_key(&self, key: &K) -> bool {
         self.map.contains_key(key)
+    }
+}
+
+#[cfg(test)]
+impl ConsensusOutputQuarantine {
+    fn output_queue_len_for_testing(&self) -> usize {
+        self.output_queue.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::authority::test_authority_builder::TestAuthorityBuilder;
+    use sui_types::base_types::ExecutionDigests;
+    use sui_types::gas::GasCostSummary;
+
+    fn make_output(height: u64, round: u64, drained: bool) -> ConsensusCommitOutput {
+        let mut output = ConsensusCommitOutput::new(round);
+        output.record_consensus_commit_stats(ExecutionIndicesWithStatsV2 {
+            height,
+            ..Default::default()
+        });
+        output.set_checkpoint_queue_drained(drained);
+        output
+    }
+
+    fn make_builder_summary(
+        seq: CheckpointSequenceNumber,
+        height: CheckpointHeight,
+        protocol_config: &ProtocolConfig,
+    ) -> (BuilderCheckpointSummary, CheckpointContents) {
+        let contents =
+            CheckpointContents::new_with_digests_only_for_tests([ExecutionDigests::random()]);
+        let summary = CheckpointSummary::new(
+            protocol_config,
+            0,
+            seq,
+            0,
+            &contents,
+            None,
+            GasCostSummary::default(),
+            None,
+            0,
+            vec![],
+            vec![],
+        );
+        let builder_summary = BuilderCheckpointSummary {
+            summary,
+            checkpoint_height: Some(height),
+            position_in_commit: 0,
+        };
+        (builder_summary, contents)
+    }
+
+    #[tokio::test]
+    async fn test_drain_boundary_prevents_premature_commit() {
+        let mut protocol_config =
+            ProtocolConfig::get_for_version(ProtocolVersion::max(), Chain::Unknown);
+        protocol_config.set_split_checkpoints_in_consensus_handler_for_testing(true);
+        let state = TestAuthorityBuilder::new()
+            .with_protocol_config(protocol_config)
+            .build()
+            .await;
+        let epoch_store = state.epoch_store_for_testing();
+
+        let metrics = epoch_store.metrics.clone();
+        let mut quarantine = ConsensusOutputQuarantine::new(0, metrics);
+
+        // Output C: height=4, not drained
+        let c = make_output(4, 1, false);
+        quarantine.push_consensus_output(c, &epoch_store).unwrap();
+
+        // Output C2: height=5, drained
+        let c2 = make_output(5, 2, true);
+        quarantine.push_consensus_output(c2, &epoch_store).unwrap();
+
+        assert_eq!(quarantine.output_queue_len_for_testing(), 2);
+
+        // Insert builder summaries for checkpoints 1-4 with checkpoint_height = seq
+        let pc = epoch_store.protocol_config();
+        for seq in 1..=4 {
+            let (summary, contents) = make_builder_summary(seq, seq, pc);
+            quarantine.insert_builder_summary(seq, summary, contents);
+        }
+
+        // Certify up to checkpoint 4
+        let mut batch = epoch_store.db_batch_for_test();
+        quarantine
+            .update_highest_executed_checkpoint(4, &epoch_store, &mut batch)
+            .unwrap();
+        batch.write().unwrap();
+
+        // C has height=4 which is <= 4 but checkpoint_queue_drained=false.
+        // C2 has height=5 which is > 4, so it's skipped.
+        // No drain boundary found => nothing drained.
+        assert_eq!(quarantine.output_queue_len_for_testing(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_drain_boundary_commits_at_safe_point() {
+        let mut protocol_config =
+            ProtocolConfig::get_for_version(ProtocolVersion::max(), Chain::Unknown);
+        protocol_config.set_split_checkpoints_in_consensus_handler_for_testing(true);
+        let state = TestAuthorityBuilder::new()
+            .with_protocol_config(protocol_config)
+            .build()
+            .await;
+        let epoch_store = state.epoch_store_for_testing();
+
+        let metrics = epoch_store.metrics.clone();
+        let mut quarantine = ConsensusOutputQuarantine::new(0, metrics);
+
+        let c = make_output(4, 1, false);
+        quarantine.push_consensus_output(c, &epoch_store).unwrap();
+
+        let c2 = make_output(5, 2, true);
+        quarantine.push_consensus_output(c2, &epoch_store).unwrap();
+
+        assert_eq!(quarantine.output_queue_len_for_testing(), 2);
+
+        // Insert builder summaries for checkpoints 1-5 with checkpoint_height = seq
+        let pc = epoch_store.protocol_config();
+        for seq in 1..=5 {
+            let (summary, contents) = make_builder_summary(seq, seq, pc);
+            quarantine.insert_builder_summary(seq, summary, contents);
+        }
+
+        // Certify up to checkpoint 5
+        let mut batch = epoch_store.db_batch_for_test();
+        quarantine
+            .update_highest_executed_checkpoint(5, &epoch_store, &mut batch)
+            .unwrap();
+        batch.write().unwrap();
+
+        // C has height=4 <= 5, drained=false.
+        // C2 has height=5 <= 5, drained=true => drain boundary at index 1.
+        // Both outputs drained.
+        assert_eq!(quarantine.output_queue_len_for_testing(), 0);
     }
 }

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -63,7 +63,7 @@ use crate::{
         AuthorityMetrics, AuthorityState, ExecutionEnv,
         authority_per_epoch_store::{
             AuthorityPerEpochStore, CancelConsensusCertificateReason, ConsensusStats,
-            ConsensusStatsAPI, ExecutionIndices, ExecutionIndicesWithStats,
+            ConsensusStatsAPI, ExecutionIndices, ExecutionIndicesWithStatsV2,
             consensus_quarantine::ConsensusCommitOutput,
         },
         backpressure::{BackpressureManager, BackpressureSubscriber},
@@ -718,7 +718,7 @@ pub struct ConsensusHandler<C> {
     /// Holds the indices, hash and stats after the last consensus commit
     /// It is used for avoiding replaying already processed transactions,
     /// checking chain consistency, and accumulating per-epoch consensus output stats.
-    last_consensus_stats: ExecutionIndicesWithStats,
+    last_consensus_stats: ExecutionIndicesWithStatsV2,
     checkpoint_service: Arc<C>,
     /// cache reader is needed when determining the next version to assign for shared objects.
     cache_reader: Arc<dyn ObjectCacheRead>,
@@ -836,7 +836,7 @@ impl<C> ConsensusHandler<C> {
         throughput_calculator: Arc<ConsensusThroughputCalculator>,
         backpressure_subscriber: BackpressureSubscriber,
         traffic_controller: Option<Arc<TrafficController>>,
-        last_consensus_stats: ExecutionIndicesWithStats,
+        last_consensus_stats: ExecutionIndicesWithStatsV2,
     ) -> Self {
         let commit_rate_estimate_window_size = epoch_store
             .protocol_config()

--- a/crates/sui-core/src/epoch/randomness.rs
+++ b/crates/sui-core/src/epoch/randomness.rs
@@ -818,7 +818,7 @@ pub enum DkgStatus {
 mod tests {
     use crate::{
         authority::{
-            authority_per_epoch_store::{ExecutionIndices, ExecutionIndicesWithStats},
+            authority_per_epoch_store::{ExecutionIndices, ExecutionIndicesWithStatsV2},
             test_authority_builder::TestAuthorityBuilder,
         },
         checkpoints::CheckpointStore,
@@ -925,7 +925,7 @@ mod tests {
         }
         for i in 0..randomness_managers.len() {
             let mut output = ConsensusCommitOutput::new(0);
-            output.record_consensus_commit_stats(ExecutionIndicesWithStats {
+            output.record_consensus_commit_stats(ExecutionIndicesWithStatsV2 {
                 index: ExecutionIndices {
                     last_committed_round: 0,
                     ..Default::default()
@@ -962,7 +962,7 @@ mod tests {
         }
         for i in 0..randomness_managers.len() {
             let mut output = ConsensusCommitOutput::new(0);
-            output.record_consensus_commit_stats(ExecutionIndicesWithStats {
+            output.record_consensus_commit_stats(ExecutionIndicesWithStatsV2 {
                 index: ExecutionIndices {
                     last_committed_round: 1,
                     ..Default::default()
@@ -1077,7 +1077,7 @@ mod tests {
         }
         for i in 0..randomness_managers.len() {
             let mut output = ConsensusCommitOutput::new(0);
-            output.record_consensus_commit_stats(ExecutionIndicesWithStats {
+            output.record_consensus_commit_stats(ExecutionIndicesWithStatsV2 {
                 index: ExecutionIndices {
                     last_committed_round: 0,
                     ..Default::default()

--- a/crates/sui-core/src/unit_tests/consensus_test_utils.rs
+++ b/crates/sui-core/src/unit_tests/consensus_test_utils.rs
@@ -21,7 +21,7 @@ use sui_types::sui_system_state::epoch_start_sui_system_state::EpochStartSystemS
 use sui_types::transaction::{VerifiedCertificate, VerifiedTransaction};
 
 use crate::authority::authority_per_epoch_store::{
-    AuthorityPerEpochStore, ExecutionIndicesWithStats,
+    AuthorityPerEpochStore, ExecutionIndicesWithStatsV2,
 };
 use crate::authority::backpressure::BackpressureManager;
 use crate::authority::shared_object_version_manager::{AssignedTxAndVersions, Schedulable};
@@ -341,7 +341,7 @@ where
     let consensus_adapter =
         make_consensus_adapter_for_test(authority.clone(), HashSet::new(), false, vec![]);
 
-    let last_consensus_stats = ExecutionIndicesWithStats {
+    let last_consensus_stats = ExecutionIndicesWithStatsV2 {
         stats: crate::authority::authority_per_epoch_store::ConsensusStats::new(
             consensus_committee.size(),
         ),


### PR DESCRIPTION
## Description 

With split_checkpoints feature enabled, we must always ensure all commits queued together into PendingCheckpoints have been executed before updating consensus watermarks.

## Test plan 

simtest, 
[antithesis](https://mystenlabs.antithesis.com/report/WMwg19ZrRAjQVIzjq0GXbRQm/JfVADd4_19cr_8y39j666lS0FqtOWcSpl8bJ5EUKMWE.html?auth=v2.public.eyJzY29wZSI6eyJSZXBvcnRTY29wZVYxIjp7ImFzc2V0IjoiSmZWQURkNF8xOWNyXzh5MzlqNjY2bFMwRnF0T1djU3BsOGJKNUVVS01XRS5odG1sIiwicmVwb3J0X2lkIjoiV013ZzE5WnJSQWpRVkl6anEwR1hiUlFtIn19LCJuYmYiOiIyMDI2LTAyLTE3VDIzOjIxOjQ1LjY5MDAyMTk4M1oifbF-COKkouq-o0i26ZfBD8gxr5oC7BZ6sf6HHPILZZ6xsE0PU_vgnOX6vPLv_t-vtR-nFZpYq1Y5KSYKOiqCPwI)

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
