### PR TITLE
[bella-ciao][hardening] Add flag at compilation time for when we should run paranoid ref checks

### DIFF
--- a/external-crates/move/crates/move-vm-runtime/src/jit/execution/ast.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/jit/execution/ast.rs
@@ -163,6 +163,9 @@ pub(crate) struct Function {
     pub name: VirtualTableKey,
     pub locals_len: usize,
     pub jump_tables: ArenaVec<VariantJumpTable>,
+    // If this function has more than two references, one of which is mutable, then we should run
+    // the paranoid reference checks on this function.
+    pub should_paranoid_ref_check: bool,
 }
 
 impl Drop for Function {


### PR DESCRIPTION
## Description 

Compute and add this flag to the `Function` during compilation so we can short circuit if we need to run the ref checks in https://github.com/MystenLabs/sui/pull/25427

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
