### PR TITLE
Set watchdog timeout to 60s

### DIFF
--- a/scripts/simtest/cargo-simtest
+++ b/scripts/simtest/cargo-simtest
@@ -37,6 +37,8 @@ cleanup () (
 
 trap cleanup EXIT
 
+export MSIM_WATCHDOG_TIMEOUT_MS=60000
+
 if [[ -z "$MSIM_TEST_SEED" ]]; then
   export MSIM_TEST_SEED=1
 else


### PR DESCRIPTION
Extend the watchdog timeout. We haven't had a deadlock in ages, but the watchdog often trips prematurely due to blocking package publishing
