### PR TITLE
reader: increase bigtable/kv client max decoding size

### DIFF
--- a/crates/sui-indexer-alt-graphql/src/args.rs
+++ b/crates/sui-indexer-alt-graphql/src/args.rs
@@ -33,6 +33,12 @@ pub struct KvArgs {
     #[arg(long)]
     pub bigtable_app_profile_id: Option<String>,
 
+    /// Maximum gRPC decoding message size for KV responses, in bytes.
+    ///
+    /// Applies to both Bigtable and Ledger gRPC readers.
+    #[arg(long)]
+    pub kv_max_decoding_message_size: Option<usize>,
+
     /// gRPC endpoint URL for the ledger service (e.g., archive.mainnet.sui.io)
     #[arg(long, group = "kv_source")]
     pub ledger_grpc_url: Option<Uri>,
@@ -49,6 +55,7 @@ impl KvArgs {
             bigtable_statement_timeout_ms: self.kv_statement_timeout_ms,
             bigtable_project: self.bigtable_project.clone(),
             bigtable_app_profile_id: self.bigtable_app_profile_id.clone(),
+            bigtable_max_decoding_message_size: self.kv_max_decoding_message_size,
         }
     }
 
@@ -56,6 +63,7 @@ impl KvArgs {
     pub fn ledger_grpc_args(&self) -> LedgerGrpcArgs {
         LedgerGrpcArgs {
             ledger_grpc_statement_timeout_ms: self.kv_statement_timeout_ms,
+            ledger_grpc_max_decoding_message_size: self.kv_max_decoding_message_size,
         }
     }
 }

--- a/crates/sui-indexer-alt-reader/src/bigtable_reader.rs
+++ b/crates/sui-indexer-alt-reader/src/bigtable_reader.rs
@@ -34,6 +34,10 @@ pub struct BigtableArgs {
     /// App profile ID to use for Bigtable client. If not provided, the default profile will be used.
     #[arg(long)]
     pub bigtable_app_profile_id: Option<String>,
+
+    /// Maximum gRPC decoding message size for Bigtable responses, in bytes.
+    #[arg(long)]
+    pub bigtable_max_decoding_message_size: Option<usize>,
 }
 
 /// A reader backed by BigTable KV store.
@@ -74,6 +78,7 @@ impl BigtableReader {
                 bigtable_args.bigtable_project,
                 true,
                 timeout,
+                bigtable_args.bigtable_max_decoding_message_size,
                 client_name,
                 Some(registry),
                 bigtable_args.bigtable_app_profile_id,

--- a/crates/sui-kv-rpc/src/lib.rs
+++ b/crates/sui-kv-rpc/src/lib.rs
@@ -37,6 +37,7 @@ impl KvRpcServer {
             project_id,
             false,
             None,
+            None,
             "sui-kv-rpc".to_string(),
             Some(registry),
             app_profile_id,

--- a/crates/sui-kvstore/src/bin/sui-kvstore-alt.rs
+++ b/crates/sui-kvstore/src/bin/sui-kvstore-alt.rs
@@ -49,6 +49,10 @@ struct Args {
     #[arg(long)]
     app_profile_id: Option<String>,
 
+    /// Maximum gRPC decoding message size for Bigtable responses, in bytes.
+    #[arg(long)]
+    bigtable_max_decoding_message_size: Option<usize>,
+
     /// Maximum mutations per BigTable batch (must be < 100k)
     #[arg(long, value_parser = parse_max_mutations)]
     max_mutations: Option<usize>,
@@ -98,6 +102,7 @@ async fn main() -> Result<()> {
         args.bigtable_project,
         false,
         None,
+        args.bigtable_max_decoding_message_size,
         "sui-kvstore-alt".to_string(),
         None,
         args.app_profile_id,


### PR DESCRIPTION
## Description

Increase the default acceptable size of a single response from BigTableClient (for GraphQL and Archival) and also the LedgerService for GraphQL.

Also make this value configurable in both cases, in case we need to tweak it further in future.

## Test plan
CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
