### PR TITLE
Fix #18284: Add take_diagnostics() for intermediate passes

### DIFF
--- a/external-crates/move/crates/move-compiler/src/command_line/compiler.rs
+++ b/external-crates/move/crates/move-compiler/src/command_line/compiler.rs
@@ -1220,3 +1220,18 @@ fn run(
     }
     rec(compilation_env, pre_compiled_lib, cur, until)
 }
+
+//**************************************************************************************************
+// FIX for bug #18284: Diagnostic extraction after intermediate passes
+//**************************************************************************************************
+
+impl<const P: Pass> SteppedCompiler<P> {
+    /// Extract diagnostics after any compilation pass
+    /// 
+    /// This fixes GitHub issue #18284 where PASS_TYPING (and other intermediate
+    /// passes) would not expose diagnostic information.
+    pub fn take_diagnostics(mut self) -> (Self, Diagnostics) {
+        let diags = self.compilation_env.take_intermediate_diags();
+        (self, diags)
+    }
+}

--- a/external-crates/move/crates/move-compiler/src/shared/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/shared/mod.rs
@@ -418,6 +418,11 @@ impl CompilationEnv {
         final_diags
     }
 
+    /// FIX for bug #18284: Extract diagnostics at any point during compilation
+    pub fn take_intermediate_diags(&mut self) -> Diagnostics {
+        std::mem::take(&mut self.diags)
+    }
+
     pub fn known_filter_names(&self) -> impl IntoIterator<Item = FilterPrefix> + '_ {
         self.known_filters.keys().copied()
     }


### PR DESCRIPTION
## Description

This PR fixes issue #18284 by adding the ability to extract diagnostic information after intermediate compilation passes like `PASS_TYPING`.

### Problem
The Move compiler's `SteppedCompiler` did not provide a way to access diagnostic information after intermediate passes. Developers could not get type-checking errors without running full compilation to `PASS_COMPILATION`.

### Solution
Added `take_diagnostics()` method to `SteppedCompiler&lt;P&gt;` and `take_intermediate_diags()` to `CompilationEnv`.

### Changes
- `external-crates/move/crates/move-compiler/src/shared/mod.rs`: Added `take_intermediate_diags()`
- `external-crates/move/crates/move-compiler/src/command_line/compiler.rs`: Added `take_diagnostics()` impl

### Usage Example
```rust
let (files, stepped) = compiler.run::&lt;PASS_TYPING&gt;()?;
let (stepped, diags) = stepped.take_diagnostics(); // Now works!

Test plan
[x] Compiled successfully with cargo build -p move-compiler
[ ] Unit tests (if required by maintainers)
[ ] Integration test with real Move files
Tested locally with:
cd external-crates/move
cargo build -p move-compiler
# Build successful, no warnings introduced

Release notes
[ ] Protocol:
[ ] Nodes (Validators and Full nodes):
[ ] gRPC:
[ ] JSON-RPC:
[ ] GraphQL:
[ ] CLI:
[x] Rust SDK: Added take_diagnostics() method to SteppedCompiler for accessing diagnostics after intermediate compilation passes
[ ] Indexing Framework:
Checklist:
[x] Code compiles
[x] No breaking changes
[x] Follows existing code style
[x] Linked issue #18284
External reference: https://github.com/lau90eth/move-guard