### PR TITLE
fix: prevent panic in pattern matching with malformed patterns

### DIFF
--- a/external-crates/move/crates/move-compiler/src/shared/matching.rs
+++ b/external-crates/move/crates/move-compiler/src/shared/matching.rs
@@ -276,7 +276,7 @@ impl PatternArm {
         arg_types: &Vec<&Type>,
     ) -> Option<(Binders, PatternArm)> {
         let mut output = self.clone();
-        let first_pattern = output.pats.pop_front().unwrap();
+        let first_pattern = output.pats.pop_front()?;
         let loc = first_pattern.pat.loc;
         match first_pattern.pat.value {
             TP::Variant(mident, enum_, name, _, fields)

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/invalid_malformed_pattern_panic.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/invalid_malformed_pattern_panic.move
@@ -1,0 +1,17 @@
+module 0x42::M {
+    public enum Outer {
+        X { y: Inner }
+    }
+
+    public enum Inner {
+        Y(u64),
+        Z,
+    }
+
+    fun f(o: Outer): u64 {
+        match (o) {
+            // Malformed: duplicate Outer::X syntax, invalid nested pattern
+            Outer::X Outer::X(Inner::Q { v0x0::M }) => 0,
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Fixes #25460

This PR prevents a compiler panic when processing malformed match patterns that result in an empty pattern list during error recovery.

## The Problem
The `specialize_variant` function in `matching.rs:279` calls `pats.pop_front().unwrap()` without checking if the pattern list is empty. When error recovery from malformed patterns results in an empty list, this causes a panic with `"called Option::unwrap() on a None value"`.

## The Solution
Replace `.unwrap()` with the `?` operator. This returns `None` if the pattern list is empty, which is the correct behavior—when there are no patterns to specialize, the function should indicate that specialization is not applicable by returning `None`.

## Test Case
Added `invalid_malformed_pattern_panic.move` test case that demonstrates the previously panicking scenario with malformed match patterns.

## Changes
- `external-crates/move/crates/move-compiler/src/shared/matching.rs`: Changed line 279 from `.unwrap()` to `?`
- Added test case for malformed pattern error recovery