### PR TITLE
fix: prevent panic when destructuring native struct in match

### DIFF
--- a/external-crates/move/crates/move-compiler/src/typing/match_analysis.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/match_analysis.rs
@@ -373,8 +373,7 @@ fn find_counterexample_impl(
                 let ctor_arity = arg_types.len() as u32;
                 let decl_fields = context
                     .info()
-                    .struct_fields(&mident, &datatype_name)
-                    .unwrap();
+                    .struct_fields(&mident, &datatype_name)?;
                 let fringe_binders =
                     context.make_imm_ref_match_binders(decl_fields, ploc, arg_types);
                 let is_positional = context.info().struct_is_positional(&mident, &datatype_name);

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/invalid_native_struct_destructure.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/invalid_native_struct_destructure.move
@@ -1,0 +1,9 @@
+module 0x0::M {
+    native struct S;
+    
+    fun f(s: S): u64 {
+        match (s) {
+            S {} => 0,
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Fixes #25458

This PR prevents a compiler panic when attempting to destructure a native struct in a match expression.

## The Problem
The `find_counterexample_impl` function in `match_analysis.rs:377` calls `struct_fields().unwrap()` without checking if the struct is native. Native structs have no field definitions, so `struct_fields()` returns `None`, causing the unwrap to panic with `"called Option::unwrap() on a None value"`.

## The Solution
Replace `.unwrap()` with the `?` operator. When encountering a native struct (which returns `None` from `struct_fields()`), the function now returns `None` from the counterexample analysis, which is the correct behavior—the compiler should gracefully handle this case rather than crashing.

## Test Case
Added `invalid_native_struct_destructure.move` test case demonstrating the previously panicking scenario with native struct destructuring in match.

## Changes
- `external-crates/move/crates/move-compiler/src/typing/match_analysis.rs`: Changed line 377 from `.unwrap()` to `?`
- Added test case for native struct destructuring