### PR TITLE
fix: prevent panic when matching on abort expression

### DIFF
--- a/external-crates/move/crates/move-compiler/src/hlir/match_compilation.rs
+++ b/external-crates/move/crates/move-compiler/src/hlir/match_compilation.rs
@@ -170,7 +170,11 @@ fn build_match_tree(
     if subject.ty.value.unfold_to_builtin_type_name().is_some() {
         compile_match_literal(context, subject, fringe, matrix)
     } else {
-        let tyargs = subject.ty.value.type_arguments().unwrap().clone();
+        let Some(tyargs) = subject.ty.value.type_arguments().cloned() else {
+            // Type has no type arguments (e.g., abort expression). This represents
+            // unreachable code, so treat as match failure.
+            return MatchTree::Failure;
+        };
 
         let (mident, datatype_name) = subject
             .ty

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/match_abort_expression.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/match_abort_expression.move
@@ -1,0 +1,8 @@
+module 0x2a::M {
+    fun f(): u64 {
+        match (abort 0u64) {
+            0u64 => 0u64,
+            _ => 0u64,
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Fixes #25457

This PR prevents a compiler panic when attempting to match on an abort expression.

## The Problem
The `build_match_tree` function in `match_compilation.rs:173` calls `type_arguments().unwrap()` without checking if the type has type arguments. When the match scrutinee is an `abort` expression (which has type "Nothing"), `type_arguments()` returns `None`, causing the unwrap to panic.

## The Solution
Replace the unwrap with a guard that checks if `type_arguments()` returns `None`. When it does, return `MatchTree::Failure` since matching on abort represents unreachable dead code. This allows the compiler to handle this case gracefully rather than panicking.

## Test Case
Added `match_abort_expression.move` test case demonstrating the previously panicking scenario with abort in match scrutinee.

## Changes
- `external-crates/move/crates/move-compiler/src/hlir/match_compilation.rs`: Replaced unwrap with guard at line 173
- Added test case for abort expression in match