### PR TITLE
fix: prevent panic when binding dollar-prefixed identifier

### DIFF
--- a/external-crates/move/crates/move-compiler/src/naming/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/naming/translate.rs
@@ -4039,15 +4039,18 @@ fn lvalue(
                     context.add_diag(diag!(Declarations::DuplicateItem, primary, secondary));
                 }
                 if v.is_syntax_identifier() {
-                    debug_assert!(
-                        matches!(case, C::Assign),
-                        "ICE this should fail during parsing"
-                    );
-                    let msg = format!(
-                        "Cannot assign to argument for parameter '{}'. \
-                        Arguments must be used in value positions",
-                        v.0
-                    );
+                    let msg = match case {
+                        C::Bind => format!(
+                            "Cannot bind argument for parameter '{}'. \
+                            Arguments must be used in value positions",
+                            v.0
+                        ),
+                        C::Assign => format!(
+                            "Cannot assign to argument for parameter '{}'. \
+                            Arguments must be used in value positions",
+                            v.0
+                        ),
+                    };
                     let mut diag = diag!(TypeSafety::CannotExpandMacro, (loc, msg));
                     diag.add_note(ASSIGN_SYNTAX_IDENTIFIER_NOTE);
                     context.add_diag(diag);

--- a/external-crates/move/crates/move-compiler/tests/move_2024/expansion/invalid_dollar_binding.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/expansion/invalid_dollar_binding.move
@@ -1,0 +1,5 @@
+module 0x0::M {
+    fun f() {
+        let mut $x = 0;
+    }
+}


### PR DESCRIPTION
## Summary
Fixes #25456

This PR prevents a debug assertion failure when dollar-prefixed identifiers are used in let bindings.

## The Problem
When code like `let mut $x = 0;` is written, the parser accepts it but the naming pass at `translate.rs:4042` has a `debug_assert!` that assumes this syntax was already rejected during parsing. This causes an ICE (Internal Compiler Error) in debug builds with the message "ICE this should fail during parsing".

## The Solution
Replace the `debug_assert!` with proper error handling for both `Bind` and `Assign` cases. Instead of panicking, the compiler now emits a diagnostic error explaining that syntax identifiers (dollar-prefixed) cannot be bound or assigned—they must be used in value positions.

## Test Case
Added `invalid_dollar_binding.move` test case demonstrating the previously panicking scenario with dollar-prefixed identifier in let binding.

## Changes
- `external-crates/move/crates/move-compiler/src/naming/translate.rs`: Replaced debug_assert with match expression that handles both Bind and Assign cases
- Added test case for dollar-prefixed identifier binding