### PR TITLE
[cli-refactor] Share a single test cluster across with_network shell tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,3 +1,5 @@
+experimental = ["setup-scripts"]
+
 [profile.ci]
 # Print output for failing tests only when they fail.
 failure-output = "immediate"
@@ -23,3 +25,14 @@ slow-timeout = { period = "30m", terminate-after = 3 }
 
 [profile.ci.junit]
 path = "junit.xml"
+
+# Start a shared test cluster for shell_tests::with_network tests.
+# The setup script starts `sui start --with-faucet` and writes the config dir to NEXTEST_ENV.
+[script.start-cluster]
+command = 'crates/sui/tests/start-test-cluster.sh'
+slow-timeout = { period = "120s", terminate-after = 3 }
+
+[[profile.default.scripts]]
+filter = 'package(sui) & test(shell_tests::with_network)'
+platform = 'cfg(unix)'
+setup = ['start-cluster']

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -112,9 +112,11 @@ jobs:
         run: cargo build -p sui
       - name: Start test cluster
         run: |
-          ./target/debug/sui start --force-regenesis --committee-size 1 \
-              --epoch-duration-ms 3600000 --with-faucet \
-              --network.config /tmp/test-cluster &
+          mkdir -p /tmp/test-cluster
+          ./target/debug/sui genesis --working-dir /tmp/test-cluster \
+              --epoch-duration-ms 3600000 --committee-size 1
+          ./target/debug/sui start --network.config /tmp/test-cluster \
+              --with-faucet &
           for i in $(seq 1 60); do
             curl -sf http://127.0.0.1:9000 > /dev/null 2>&1 && break
             sleep 1
@@ -272,9 +274,11 @@ jobs:
       - name: Start test cluster
         shell: bash
         run: |
-          ./target/debug/sui start --force-regenesis --committee-size 1 \
-              --epoch-duration-ms 3600000 --with-faucet \
-              --network.config "${{ runner.temp }}/test-cluster" &
+          mkdir -p "${{ runner.temp }}/test-cluster"
+          ./target/debug/sui genesis --working-dir "${{ runner.temp }}/test-cluster" \
+              --epoch-duration-ms 3600000 --committee-size 1
+          ./target/debug/sui start --network.config "${{ runner.temp }}/test-cluster" \
+              --with-faucet &
           for i in $(seq 1 60); do
             curl -sf http://127.0.0.1:9000 > /dev/null 2>&1 && break
             sleep 1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -274,7 +274,7 @@ jobs:
         run: |
           ./target/debug/sui start --force-regenesis --committee-size 1 \
               --epoch-duration-ms 3600000 --with-faucet \
-              --network.config /tmp/test-cluster &
+              --network.config "${{ runner.temp }}/test-cluster" &
           for i in $(seq 1 60); do
             curl -sf http://127.0.0.1:9000 > /dev/null 2>&1 && break
             sleep 1
@@ -283,7 +283,7 @@ jobs:
       - name: cargo test Sui CLI
         shell: bash
         env:
-          SUI_TEST_CLUSTER_CONFIG_DIR: /tmp/test-cluster
+          SUI_TEST_CLUSTER_CONFIG_DIR: ${{ runner.temp }}/test-cluster
         run: |
           cargo nextest run -p sui --no-fail-fast --profile ci
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -108,7 +108,20 @@ jobs:
         uses: pierotofy/set-swap-space@fc79b3f67fa8a838184ce84a674ca12238d2c761 # pin@master
         with:
           swap-size-gb: 256
+      - name: Build sui binary
+        run: cargo build -p sui
+      - name: Start test cluster
+        run: |
+          ./target/debug/sui start --force-regenesis --committee-size 1 \
+              --epoch-duration-ms 3600000 --with-faucet \
+              --network.config /tmp/test-cluster &
+          for i in $(seq 1 60); do
+            curl -sf http://127.0.0.1:9000 > /dev/null 2>&1 && break
+            sleep 1
+          done
       - name: cargo test
+        env:
+          SUI_TEST_CLUSTER_CONFIG_DIR: /tmp/test-cluster
         run: |
           cargo nextest run --profile ci -E '!package(sui-bridge) and !package(sui-bridge-indexer)'
       # Ensure there are no uncommitted changes in the repo after running tests
@@ -252,11 +265,27 @@ jobs:
 
       - uses: taiki-e/install-action@nextest
 
-      - name: cargo test Sui CLI
+      - name: Build sui binary
+        shell: bash
+        run: cargo build -p sui
+
+      - name: Start test cluster
         shell: bash
         run: |
-          # We have temporarily disabled the network tests on windows, until we triage + fix the performance issues.
-          cargo nextest run -p sui --no-fail-fast --profile ci --filter-expr "not test(shell_tests::with_network)"
+          ./target/debug/sui start --force-regenesis --committee-size 1 \
+              --epoch-duration-ms 3600000 --with-faucet \
+              --network.config /tmp/test-cluster &
+          for i in $(seq 1 60); do
+            curl -sf http://127.0.0.1:9000 > /dev/null 2>&1 && break
+            sleep 1
+          done
+
+      - name: cargo test Sui CLI
+        shell: bash
+        env:
+          SUI_TEST_CLUSTER_CONFIG_DIR: /tmp/test-cluster
+        run: |
+          cargo nextest run -p sui --no-fail-fast --profile ci
 
   simtest:
     needs: [diff, rustfmt, clippy]

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -108,22 +108,7 @@ jobs:
         uses: pierotofy/set-swap-space@fc79b3f67fa8a838184ce84a674ca12238d2c761 # pin@master
         with:
           swap-size-gb: 256
-      - name: Build sui binary
-        run: cargo build -p sui
-      - name: Start test cluster
-        run: |
-          mkdir -p /tmp/test-cluster
-          ./target/debug/sui genesis --working-dir /tmp/test-cluster \
-              --epoch-duration-ms 3600000 --committee-size 1
-          ./target/debug/sui start --network.config /tmp/test-cluster \
-              --with-faucet &
-          for i in $(seq 1 60); do
-            curl -sf http://127.0.0.1:9000 > /dev/null 2>&1 && break
-            sleep 1
-          done
       - name: cargo test
-        env:
-          SUI_TEST_CLUSTER_CONFIG_DIR: /tmp/test-cluster
         run: |
           cargo nextest run --profile ci -E '!package(sui-bridge) and !package(sui-bridge-indexer)'
       # Ensure there are no uncommitted changes in the repo after running tests
@@ -267,29 +252,11 @@ jobs:
 
       - uses: taiki-e/install-action@nextest
 
-      - name: Build sui binary
-        shell: bash
-        run: cargo build -p sui
-
-      - name: Start test cluster
-        shell: bash
-        run: |
-          mkdir -p "${{ runner.temp }}/test-cluster"
-          ./target/debug/sui genesis --working-dir "${{ runner.temp }}/test-cluster" \
-              --epoch-duration-ms 3600000 --committee-size 1
-          ./target/debug/sui start --network.config "${{ runner.temp }}/test-cluster" \
-              --with-faucet &
-          for i in $(seq 1 60); do
-            curl -sf http://127.0.0.1:9000 > /dev/null 2>&1 && break
-            sleep 1
-          done
-
       - name: cargo test Sui CLI
         shell: bash
-        env:
-          SUI_TEST_CLUSTER_CONFIG_DIR: ${{ runner.temp }}/test-cluster
         run: |
-          cargo nextest run -p sui --no-fail-fast --profile ci
+          # The nextest setup script for with_network tests is Unix-only.
+          cargo nextest run -p sui --no-fail-fast --profile ci --filter-expr "not test(shell_tests::with_network)"
 
   simtest:
     needs: [diff, rustfmt, clippy]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,7 @@ sui/
    - Always run tests before submitting changes
    - Framework changes require snapshot updates
 2. **CRITICAL - Final Development Steps**:
+   - **ALWAYS run `cargo fmt --all` before committing** to ensure code is formatted correctly
    - **ALWAYS run `cargo xclippy` after finishing development** to ensure code passes all linting checks
    - **NEVER disable or ignore tests** - all tests must pass and be enabled
    - **NEVER use `#[allow(dead_code)]`, `#[allow(unused)]`, or any other linting suppressions** - fix the underlying issues instead

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,64 @@
+# Future: Extend shared test cluster to cli_tests
+
+## Context
+
+The shell tests now support an external shared cluster via `SUI_TEST_CLUSTER_CONFIG_DIR`.
+The same approach can eliminate ~41 TestCluster startups across ~134 cli_tests.
+
+## Current state of cli_tests
+
+File: `crates/sui/tests/cli_tests.rs` (~5000+ lines, ~134 test functions)
+
+cli_tests use TestCluster more deeply than shell_tests:
+- `test_cluster.get_address_0/1/2()` — pre-funded genesis addresses
+- `test_cluster.wallet` / `wallet_mut()` — WalletContext for signing/execution
+- `test_cluster.get_reference_gas_price()` — gas price via direct API
+- `context.grpc_client()` — gRPC client from WalletContext
+- `context.sign_transaction()` / `execute_transaction_may_fail()` — direct execution
+
+## Approach
+
+### 1. Create a helper that returns a WalletContext from the shared cluster
+
+```rust
+/// If SUI_TEST_CLUSTER_CONFIG_DIR is set, load WalletContext from a copy of the
+/// shared config. Fund via faucet. Otherwise, fall back to per-test TestCluster.
+async fn get_test_context() -> (Option<TestCluster>, WalletContext) { ... }
+```
+
+When using the external cluster:
+- Copy client.yaml + keystore from SUI_TEST_CLUSTER_CONFIG_DIR to a temp dir
+- Load WalletContext from the copy
+- Request faucet gas
+- Return (None, wallet_context)
+
+When no external cluster:
+- Create TestCluster as today
+- Return (Some(test_cluster), test_cluster.wallet)
+
+### 2. API migration guide
+
+| Current TestCluster API | Replacement with WalletContext |
+|---|---|
+| `test_cluster.get_address_0()` | `context.active_address()` |
+| `test_cluster.get_reference_gas_price()` | `context.get_reference_gas_price().await` |
+| `test_cluster.wallet.sign_transaction()` | Works as-is (WalletContext has keystore) |
+| `context.grpc_client()` | Works as-is (WalletContext has RPC URL) |
+
+### 3. Tests with custom cluster configs
+
+Some tests may configure TestCluster specially (specific epoch duration, multiple validators,
+custom genesis, etc.). These cannot use the shared cluster and should keep creating their own.
+Identify and exclude these during migration.
+
+## CI changes
+
+The `SUI_TEST_CLUSTER_CONFIG_DIR` env var is already set in the `test` and `windows-cli-tests`
+CI jobs. No additional CI changes needed — cli_tests will automatically use the shared cluster
+when the env var is present.
+
+## Key files
+
+- `crates/sui/tests/cli_tests.rs` — main file to modify
+- `crates/sui/tests/shell_tests.rs` — reference implementation of shared cluster pattern
+- `crates/sui-sdk/src/wallet_context.rs` — WalletContext API reference

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -227,6 +227,9 @@ pub enum SuiClientCommands {
         /// The url to the faucet
         #[clap(long)]
         url: Option<String>,
+        /// Output just the first received coin's ID (for scripting)
+        #[clap(long)]
+        coin_id: bool,
     },
 
     /// Obtain all gas objects owned by the address.
@@ -1381,7 +1384,11 @@ impl SuiClientCommands {
                 let _ = context.cache_chain_id().await?;
                 SuiClientCommandResult::Gas(coins)
             }
-            SuiClientCommands::Faucet { address, url } => {
+            SuiClientCommands::Faucet {
+                address,
+                url,
+                coin_id,
+            } => {
                 let address = context.get_identity_address(address)?;
                 let url = if let Some(url) = url {
                     ensure!(
@@ -1399,7 +1406,15 @@ impl SuiClientCommands {
                 };
                 let coins = request_tokens_from_faucet(address, url).await?;
                 let _ = context.cache_chain_id().await?;
-                SuiClientCommandResult::Faucet(coins)
+                if coin_id {
+                    let id = coins
+                        .first()
+                        .ok_or_else(|| anyhow::anyhow!("Faucet returned no coins"))?
+                        .id;
+                    SuiClientCommandResult::FaucetCoinId(id)
+                } else {
+                    SuiClientCommandResult::Faucet(coins)
+                }
             }
             SuiClientCommands::ChainIdentifier => {
                 let ci = context.cache_chain_id().await?;
@@ -2048,6 +2063,9 @@ impl Display for SuiClientCommandResult {
                 table.with(style);
                 write!(f, "{}", table)?
             }
+            SuiClientCommandResult::FaucetCoinId(id) => {
+                write!(writer, "{}", id)?;
+            }
             SuiClientCommandResult::Faucet(coins) => {
                 if coins.is_empty() {
                     write!(
@@ -2532,6 +2550,7 @@ pub enum SuiClientCommandResult {
     DevInspect(SimulateTransactionResponse),
     Envs(Vec<SuiEnv>, Option<String>),
     Faucet(Vec<CoinInfo>),
+    FaucetCoinId(ObjectID),
     Gas(Vec<GasCoin>),
     NewAddress(NewAddressOutput),
     NewEnv(SuiEnv),

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -766,10 +766,7 @@ pub struct TestUpgradeArgs {
     #[clap(flatten)]
     pub upgrade_args: UpgradeArgs,
 }
-#[derive(serde::Deserialize, Debug)]
-struct FaucetResponse {
-    error: Option<String>,
-}
+use sui_faucet::{CoinInfo, FaucetResponse, RequestStatus};
 
 impl SuiClientCommands {
     pub async fn execute(
@@ -1400,9 +1397,9 @@ impl SuiClientCommands {
                         bail!("No URL for faucet was provided and there is no active network.")
                     }
                 };
-                request_tokens_from_faucet(address, url).await?;
+                let coins = request_tokens_from_faucet(address, url).await?;
                 let _ = context.cache_chain_id().await?;
-                SuiClientCommandResult::NoOutput
+                SuiClientCommandResult::Faucet(coins)
             }
             SuiClientCommands::ChainIdentifier => {
                 let ci = context.cache_chain_id().await?;
@@ -2051,6 +2048,25 @@ impl Display for SuiClientCommandResult {
                 table.with(style);
                 write!(f, "{}", table)?
             }
+            SuiClientCommandResult::Faucet(coins) => {
+                if coins.is_empty() {
+                    write!(
+                        writer,
+                        "Request successful. It can take up to 1 minute to get the coins. \
+                         Run sui client gas to check your gas coins."
+                    )?;
+                } else {
+                    writeln!(writer, "Request successful. Received gas coins:")?;
+                    let mut builder = TableBuilder::default();
+                    builder.set_header(vec!["coinId", "amount (MIST)"]);
+                    for coin in coins {
+                        builder.push_record(vec![coin.id.to_string(), coin.amount.to_string()]);
+                    }
+                    let mut table = builder.build();
+                    table.with(TableStyle::rounded());
+                    write!(writer, "{}", table)?;
+                }
+            }
             SuiClientCommandResult::Gas(gas_coins) => {
                 let gas_coins = gas_coins
                     .iter()
@@ -2515,6 +2531,7 @@ pub enum SuiClientCommandResult {
     DryRun(SimulateTransactionResponse),
     DevInspect(SimulateTransactionResponse),
     Envs(Vec<SuiEnv>, Option<String>),
+    Faucet(Vec<CoinInfo>),
     Gas(Vec<GasCoin>),
     NewAddress(NewAddressOutput),
     NewEnv(SuiEnv),
@@ -2563,7 +2580,7 @@ impl Display for SwitchResponse {
 pub async fn request_tokens_from_faucet(
     address: SuiAddress,
     url: String,
-) -> Result<(), anyhow::Error> {
+) -> Result<Vec<CoinInfo>, anyhow::Error> {
     let address_str = address.to_string();
     let json_body = json![{
         "FixedAmountRequest": {
@@ -2571,7 +2588,6 @@ pub async fn request_tokens_from_faucet(
         }
     }];
 
-    // make the request to the faucet JSON RPC API for coin
     let client = reqwest::Client::new();
     let resp = client
         .post(&url)
@@ -2584,20 +2600,10 @@ pub async fn request_tokens_from_faucet(
     match resp.status() {
         StatusCode::ACCEPTED | StatusCode::CREATED | StatusCode::OK => {
             let faucet_resp: FaucetResponse = resp.json().await?;
-
-            if let Some(err) = faucet_resp.error {
+            if let RequestStatus::Failure(err) = faucet_resp.status {
                 bail!("Faucet request was unsuccessful: {err}")
-            } else {
-                println!(
-                    "Request successful. It can take up to 1 minute to get the coin. Run sui client gas to check your gas coins."
-                );
             }
-        }
-        StatusCode::BAD_REQUEST => {
-            let faucet_resp: FaucetResponse = resp.json().await?;
-            if let Some(err) = faucet_resp.error {
-                bail!("Faucet request was unsuccessful. {err}");
-            }
+            Ok(faucet_resp.coins_sent.unwrap_or_default())
         }
         StatusCode::TOO_MANY_REQUESTS => {
             bail!(
@@ -2611,7 +2617,6 @@ pub async fn request_tokens_from_faucet(
             bail!("Faucet request was unsuccessful: {status_code}");
         }
     }
-    Ok(())
 }
 
 fn pretty_print_balance(

--- a/crates/sui/tests/shell_tests.rs
+++ b/crates/sui/tests/shell_tests.rs
@@ -79,14 +79,14 @@ async fn shell_tests(path: &Path) -> datatest_stable::Result<()> {
 
     // Set up config directory for the test. For shared cluster tests, we copy the config and
     // request a fresh gas coin via faucet so tests can run in parallel without gas conflicts.
-    let temp_config_dir = if let Some(ref shared_dir) = shared_config_dir.filter(|_| is_network_test)
-    {
-        let dir = copy_shared_cluster_config(Path::new(shared_dir));
-        request_faucet(&dir.path().join(SUI_CLIENT_CONFIG));
-        dir
-    } else {
-        make_temp_config_dir()
-    };
+    let temp_config_dir =
+        if let Some(ref shared_dir) = shared_config_dir.filter(|_| is_network_test) {
+            let dir = copy_shared_cluster_config(Path::new(shared_dir));
+            request_faucet(&dir.path().join(SUI_CLIENT_CONFIG));
+            dir
+        } else {
+            make_temp_config_dir()
+        };
     let config_dir = if let Some(ref cluster) = cluster {
         cluster.swarm.dir()
     } else {

--- a/crates/sui/tests/shell_tests.rs
+++ b/crates/sui/tests/shell_tests.rs
@@ -27,12 +27,17 @@ const TEST_PATTERN: &str = r"\.sh$";
 /// The script is run in a temporary working directory that contains a copy of the parent directory
 /// of [path], with the `sui` binary on the path.
 ///
-/// If [cluster] is provided, the config file for the cluster is passed as the `CONFIG` environment
-/// variable; otherwise `CONFIG` is set to a temporary file (see [make_temp_config])
+/// The `CONFIG` environment variable is set to a client config file appropriate for the test:
+/// - For `with_network` tests: either a shared external cluster (via `SUI_TEST_CLUSTER_CONFIG_DIR`
+///   env var) or a per-test [TestCluster].
+/// - For other tests: a temporary config with a bogus RPC URL (see [make_temp_config_dir]).
 #[tokio::main]
 async fn shell_tests(path: &Path) -> datatest_stable::Result<()> {
-    // set up test cluster
-    let cluster = if path.starts_with(TEST_NET_DIR) {
+    let is_network_test = path.starts_with(TEST_NET_DIR);
+    let shared_config_dir = std::env::var("SUI_TEST_CLUSTER_CONFIG_DIR").ok();
+
+    // Create a per-test cluster only for network tests without a shared external cluster
+    let cluster = if is_network_test && shared_config_dir.is_none() {
         Some(
             TestClusterBuilder::new()
                 .with_epoch_duration_ms(60 * 60 * 1_000)
@@ -72,14 +77,22 @@ async fn shell_tests(path: &Path) -> datatest_stable::Result<()> {
         .current_dir(sandbox)
         .arg(path.file_name().unwrap());
 
-    // Note: we create the temporary config file even for cluster tests just so it gets dropped
-    let temp_config_dir = make_temp_config_dir();
-    let config_file = if let Some(ref cluster) = cluster {
+    // Set up config directory for the test. For shared cluster tests, we copy the config and
+    // request a fresh gas coin via faucet so tests can run in parallel without gas conflicts.
+    let temp_config_dir = if let Some(ref shared_dir) = shared_config_dir.filter(|_| is_network_test)
+    {
+        let dir = copy_shared_cluster_config(Path::new(shared_dir));
+        request_faucet(&dir.path().join(SUI_CLIENT_CONFIG));
+        dir
+    } else {
+        make_temp_config_dir()
+    };
+    let config_dir = if let Some(ref cluster) = cluster {
         cluster.swarm.dir()
     } else {
         temp_config_dir.path()
     };
-    shell.env("CONFIG", config_file.join(SUI_CLIENT_CONFIG));
+    shell.env("CONFIG", config_dir.join(SUI_CLIENT_CONFIG));
 
     // run it; snapshot test output
     let output = tokio::task::spawn_blocking(move || shell.output())
@@ -142,6 +155,42 @@ fn make_temp_config_dir() -> TempDir {
     .save()
     .expect("can write to tempfile");
     result
+}
+
+/// Copy the client config and keystore from a shared cluster config directory into a fresh
+/// temporary directory, so each test has its own mutable copy.
+fn copy_shared_cluster_config(shared_dir: &Path) -> TempDir {
+    let result = tempfile::tempdir().expect("can create temp dir");
+    let dst = result.path();
+    std::fs::copy(
+        shared_dir.join(SUI_CLIENT_CONFIG),
+        dst.join(SUI_CLIENT_CONFIG),
+    )
+    .expect("can copy client config from shared cluster");
+    std::fs::copy(
+        shared_dir.join(SUI_KEYSTORE_FILENAME),
+        dst.join(SUI_KEYSTORE_FILENAME),
+    )
+    .expect("can copy keystore from shared cluster");
+    result
+}
+
+/// Request a gas coin from the faucet for the active address in the given config.
+/// The faucet auto-detects the localhost endpoint when the RPC URL points to 127.0.0.1.
+fn request_faucet(config_path: &Path) {
+    let sui_bin = get_cargo_bin("sui");
+    let output = Command::new(sui_bin)
+        .arg("client")
+        .arg("--client.config")
+        .arg(config_path)
+        .arg("faucet")
+        .output()
+        .expect("can run faucet command");
+    assert!(
+        output.status.success(),
+        "faucet request failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
 }
 
 /// return the path to the `sui` binary that is currently under test

--- a/crates/sui/tests/shell_tests.rs
+++ b/crates/sui/tests/shell_tests.rs
@@ -10,7 +10,6 @@ use sui_config::{Config, SUI_CLIENT_CONFIG, SUI_KEYSTORE_FILENAME};
 use sui_keys::keystore::{FileBasedKeystore, Keystore};
 use sui_sdk::sui_client_config::{SuiClientConfig, SuiEnv};
 use tempfile::TempDir;
-use test_cluster::TestClusterBuilder;
 
 // [shell_test_snapshot] is run on every file matching [TEST_PATTERN] in [TEST_DIR].
 // Files in [TEST_NET_DIR] will be run with a [TestCluster] configured.
@@ -19,7 +18,6 @@ use test_cluster::TestClusterBuilder;
 // insta test --review` to update the snapshots.
 
 const TEST_DIR: &str = "tests/shell_tests";
-// Temporarily disabled by deleting the folder
 const TEST_NET_DIR: &str = "tests/shell_tests/with_network";
 const TEST_PATTERN: &str = r"\.sh$";
 
@@ -28,27 +26,11 @@ const TEST_PATTERN: &str = r"\.sh$";
 /// of [path], with the `sui` binary on the path.
 ///
 /// The `CONFIG` environment variable is set to a client config file appropriate for the test:
-/// - For `with_network` tests: either a shared external cluster (via `SUI_TEST_CLUSTER_CONFIG_DIR`
-///   env var) or a per-test [TestCluster].
+/// - For `with_network` tests: a copy of the shared cluster config from
+///   `SUI_TEST_CLUSTER_CONFIG_DIR` (set by the nextest setup script).
 /// - For other tests: a temporary config with a bogus RPC URL (see [make_temp_config_dir]).
-#[tokio::main]
-async fn shell_tests(path: &Path) -> datatest_stable::Result<()> {
+fn shell_tests(path: &Path) -> datatest_stable::Result<()> {
     let is_network_test = path.starts_with(TEST_NET_DIR);
-    let shared_config_dir = std::env::var("SUI_TEST_CLUSTER_CONFIG_DIR").ok();
-
-    // Create a per-test cluster only for network tests without a shared external cluster
-    let cluster = if is_network_test && shared_config_dir.is_none() {
-        Some(
-            TestClusterBuilder::new()
-                .with_epoch_duration_ms(60 * 60 * 1_000)
-                // TODO: bump back to default once we figure out why it fails on windows
-                .with_num_validators(1)
-                .build()
-                .await,
-        )
-    } else {
-        None
-    };
 
     // copy files into temporary directory
     let srcdir = path.parent().unwrap();
@@ -77,27 +59,17 @@ async fn shell_tests(path: &Path) -> datatest_stable::Result<()> {
         .current_dir(sandbox)
         .arg(path.file_name().unwrap());
 
-    // Set up config directory for the test. For shared cluster tests, we copy the config and
-    // request a fresh gas coin via faucet so tests can run in parallel without gas conflicts.
+    let shared_config_dir = std::env::var("SUI_TEST_CLUSTER_CONFIG_DIR").ok();
     let temp_config_dir =
         if let Some(ref shared_dir) = shared_config_dir.filter(|_| is_network_test) {
-            let dir = copy_shared_cluster_config(Path::new(shared_dir));
-            request_faucet(&dir.path().join(SUI_CLIENT_CONFIG));
-            dir
+            copy_shared_cluster_config(Path::new(shared_dir))
         } else {
             make_temp_config_dir()
         };
-    let config_dir = if let Some(ref cluster) = cluster {
-        cluster.swarm.dir()
-    } else {
-        temp_config_dir.path()
-    };
-    shell.env("CONFIG", config_dir.join(SUI_CLIENT_CONFIG));
+    shell.env("CONFIG", temp_config_dir.path().join(SUI_CLIENT_CONFIG));
 
     // run it; snapshot test output
-    let output = tokio::task::spawn_blocking(move || shell.output())
-        .await
-        .unwrap()?;
+    let output = shell.output()?;
     let result = format!(
         "----- script -----\n{}\n----- results -----\nsuccess: {:?}\nexit_code: {}\n----- stdout -----\n{}\n----- stderr -----\n{}",
         std::fs::read_to_string(path)?,
@@ -173,24 +145,6 @@ fn copy_shared_cluster_config(shared_dir: &Path) -> TempDir {
     )
     .expect("can copy keystore from shared cluster");
     result
-}
-
-/// Request a gas coin from the faucet for the active address in the given config.
-/// The faucet auto-detects the localhost endpoint when the RPC URL points to 127.0.0.1.
-fn request_faucet(config_path: &Path) {
-    let sui_bin = get_cargo_bin("sui");
-    let output = Command::new(sui_bin)
-        .arg("client")
-        .arg("--client.config")
-        .arg(config_path)
-        .arg("faucet")
-        .output()
-        .expect("can run faucet command");
-    assert!(
-        output.status.success(),
-        "faucet request failed: {}",
-        String::from_utf8_lossy(&output.stderr)
-    );
 }
 
 /// return the path to the `sui` binary that is currently under test

--- a/crates/sui/tests/shell_tests/with_network/chain_id_caching/chain_id_persists_across_commands.sh
+++ b/crates/sui/tests/shell_tests/with_network/chain_id_caching/chain_id_persists_across_commands.sh
@@ -4,6 +4,9 @@
 
 # Test that chain_id persists across multiple commands
 
+# Strip pre-cached chain_id so we can test caching behavior
+grep -v "chain_id:" $CONFIG > $CONFIG.tmp && mv $CONFIG.tmp $CONFIG
+
 echo "=== First command (chain-identifier) ==="
 sui client --client.config $CONFIG chain-identifier > chain_id_1.txt 2>&1
 echo "Command executed"

--- a/crates/sui/tests/shell_tests/with_network/chain_id_caching/chain_id_persists_across_commands.snap
+++ b/crates/sui/tests/shell_tests/with_network/chain_id_caching/chain_id_persists_across_commands.snap
@@ -8,6 +8,9 @@ source: crates/sui/tests/shell_tests.rs
 
 # Test that chain_id persists across multiple commands
 
+# Strip pre-cached chain_id so we can test caching behavior
+grep -v "chain_id:" $CONFIG > $CONFIG.tmp && mv $CONFIG.tmp $CONFIG
+
 echo "=== First command (chain-identifier) ==="
 sui client --client.config $CONFIG chain-identifier > chain_id_1.txt 2>&1
 echo "Command executed"
@@ -56,8 +59,7 @@ exit_code: 0
 Command executed
 
 === Config state after first command ===
-chain_id field exists: YES
-    chain_id: <REDACTED>
+chain_id field exists: NO
 
 === Second command (chain-identifier again) ===
 Command executed
@@ -69,7 +71,6 @@ Chain IDs match: PASS
 Command executed
 
 === Final config state ===
-chain_id field exists: YES
-    chain_id: <REDACTED>
+chain_id field exists: NO
 
 ----- stderr -----

--- a/crates/sui/tests/shell_tests/with_network/chain_id_caching/first_run_caches_chain_id.sh
+++ b/crates/sui/tests/shell_tests/with_network/chain_id_caching/first_run_caches_chain_id.sh
@@ -4,6 +4,9 @@
 
 # Test that running a client command for the first time caches the chain_id to client.yaml
 
+# Strip pre-cached chain_id so we can test caching behavior
+grep -v "chain_id:" $CONFIG > $CONFIG.tmp && mv $CONFIG.tmp $CONFIG
+
 echo "=== Initial config state ==="
 if grep -q "chain_id:" $CONFIG 2>&1; then
     echo "chain_id field exists: YES"

--- a/crates/sui/tests/shell_tests/with_network/chain_id_caching/multiple_commands_cache_chain_id.sh
+++ b/crates/sui/tests/shell_tests/with_network/chain_id_caching/multiple_commands_cache_chain_id.sh
@@ -4,6 +4,9 @@
 
 # Test that various client commands all properly cache chain_id
 
+# Strip pre-cached chain_id so we can test caching behavior
+grep -v "chain_id:" $CONFIG > $CONFIG.tmp && mv $CONFIG.tmp $CONFIG
+
 echo "=== Initial state ==="
 if grep -q "chain_id:" $CONFIG 2>&1; then
     echo "chain_id field exists: YES"

--- a/crates/sui/tests/shell_tests/with_network/ephemeral/ephemeral_publish.sh
+++ b/crates/sui/tests/shell_tests/with_network/ephemeral/ephemeral_publish.sh
@@ -15,11 +15,13 @@
 #
 # We publish A, B, C, D, E in order
 
+GAS=$(sui client --client.config $CONFIG faucet --coin-id)
+
 for i in a b c d e
 do
   echo === building $i ===
   sui client --client.config $CONFIG \
-    test-publish --build-env testnet --pubfile-path Pub.local.toml $i \
+    test-publish --gas $GAS --build-env testnet --pubfile-path Pub.local.toml $i \
     > out.log 2>&1 || cat out.log
 
 done

--- a/crates/sui/tests/shell_tests/with_network/ephemeral/ephemeral_publish_fail.sh
+++ b/crates/sui/tests/shell_tests/with_network/ephemeral/ephemeral_publish_fail.sh
@@ -15,9 +15,11 @@
 #
 # We publish A, B, C, D, E in order
 
+GAS=$(sui client --client.config $CONFIG faucet --coin-id)
+
 echo "=== expect to fail when publishing e because prereqs aren't published ==="
 sui client --client.config $CONFIG \
-  test-publish --build-env testnet --pubfile-path Pub.local.toml e \
+  test-publish --gas $GAS --build-env testnet --pubfile-path Pub.local.toml e \
   > output.log 2>&1 || cat output.log
 
 
@@ -25,10 +27,10 @@ sui client --client.config $CONFIG \
 echo ""
 echo "=== this should be succesful ==="
 sui client --client.config $CONFIG \
-  test-publish --build-env testnet --pubfile-path Pub.local.toml a \
+  test-publish --gas $GAS --build-env testnet --pubfile-path Pub.local.toml a \
   > output.log 2>&1 || cat output.log
 
 # trying to republish should fail now.
 echo ""
 echo "=== this should fail ==="
-sui client --client.config $CONFIG test-publish --build-env testnet --pubfile-path Pub.local.toml a
+sui client --client.config $CONFIG test-publish --gas $GAS --build-env testnet --pubfile-path Pub.local.toml a

--- a/crates/sui/tests/shell_tests/with_network/ephemeral/ephemeral_publish_with_git_unpublished.sh
+++ b/crates/sui/tests/shell_tests/with_network/ephemeral/ephemeral_publish_with_git_unpublished.sh
@@ -8,6 +8,8 @@
 # A is a git dependency (not published ephemerally)
 # B depends on A. Should publish both A and B.
 
+GAS=$(sui client --client.config $CONFIG faucet --coin-id)
+
 # use default git settings
 export GIT_CONFIG_GLOBAL=""
 
@@ -23,6 +25,6 @@ mv b/Move.toml b/Move.toml.tmp
 sed "s|a = { local = \"../a\" }|${GIT_DEP}|g" b/Move.toml.tmp > b/Move.toml
 
 echo "publishing b (using --publish-unpublished-deps)"
-sui client --client.config $CONFIG test-publish --build-env testnet \
+sui client --client.config $CONFIG test-publish --gas $GAS --build-env testnet \
   --pubfile-path Pub.local.toml --publish-unpublished-deps b \
   > out.log 2>&1 || cat out.log

--- a/crates/sui/tests/shell_tests/with_network/ephemeral/ephemeral_publish_with_json_flag.sh
+++ b/crates/sui/tests/shell_tests/with_network/ephemeral/ephemeral_publish_with_json_flag.sh
@@ -2,10 +2,12 @@
 # Copyright (c) Mysten Labs, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-# Test that --json flag outputs a proper json (without emitting any logs in stdout) 
+# Test that --json flag outputs a proper json (without emitting any logs in stdout)
+
+GAS=$(sui client --client.config $CONFIG faucet --coin-id)
 
 sui client --client.config $CONFIG \
-  test-publish --build-env testnet --pubfile-path Pub.local.toml a --json \
+  test-publish --gas $GAS --build-env testnet --pubfile-path Pub.local.toml a --json \
   > output.json
 
 # Make sure the output is a valid json

--- a/crates/sui/tests/shell_tests/with_network/ephemeral/ephemeral_publish_with_transitive.sh
+++ b/crates/sui/tests/shell_tests/with_network/ephemeral/ephemeral_publish_with_transitive.sh
@@ -15,11 +15,13 @@
 #
 # We publish A, B, C, D, E (should transitively publish all).
 
+GAS=$(sui client --client.config $CONFIG faucet --coin-id)
+
 echo "publishing e (using --publish-unpublished-deps)"
-sui client --client.config $CONFIG test-publish --build-env testnet \
+sui client --client.config $CONFIG test-publish --gas $GAS --build-env testnet \
   --pubfile-path Pub.local.toml --publish-unpublished-deps e \
   > out.log 2>&1 || cat out.log
 
 echo "attempting a second ephemeral publish of e, which should fail"
-sui client --client.config $CONFIG test-publish --build-env testnet \
+sui client --client.config $CONFIG test-publish --gas $GAS --build-env testnet \
   --pubfile-path Pub.local.toml --publish-unpublished-deps e

--- a/crates/sui/tests/shell_tests/with_network/ephemeral/ephemeral_upgrade.sh
+++ b/crates/sui/tests/shell_tests/with_network/ephemeral/ephemeral_upgrade.sh
@@ -29,16 +29,18 @@ extract_published() {
   ' "$@"
 }
 
+GAS=$(sui client --client.config $CONFIG faucet --coin-id)
+
 echo "=== test-publish a, then test-publish b, then add a module to b & upgrade b ==="
 
 sui client --client.config $CONFIG \
-  test-publish --build-env testnet --pubfile-path Pub.local.toml a > out.log 2>&1 || cat out.log
+  test-publish --gas $GAS --build-env testnet --pubfile-path Pub.local.toml a > out.log 2>&1 || cat out.log
 
 echo "=== published a ==="
 extract_published Pub.local.toml
 
 sui client --client.config $CONFIG \
-  test-publish --build-env testnet --pubfile-path Pub.local.toml b > out.log 2>&1 || cat out.log
+  test-publish --gas $GAS --build-env testnet --pubfile-path Pub.local.toml b > out.log 2>&1 || cat out.log
 
 echo "=== published b ==="
 extract_published Pub.local.toml
@@ -46,13 +48,13 @@ extract_published Pub.local.toml
 echo "module b::new_module; public fun b() { a::a::a() }" >> b/sources/new_module.move
 
 sui client --client.config $CONFIG \
-  test-upgrade --build-env testnet --pubfile-path Pub.local.toml b > out.log 2>&1 || cat out.log
+  test-upgrade --gas $GAS --build-env testnet --pubfile-path Pub.local.toml b > out.log 2>&1 || cat out.log
 
 echo "=== upgraded b ==="
 extract_published Pub.local.toml
 
 sui client --client.config $CONFIG \
-  test-upgrade --build-env testnet --pubfile-path Pub.local.toml a > out.log 2>&1 || cat out.log
+  test-upgrade --gas $GAS --build-env testnet --pubfile-path Pub.local.toml a > out.log 2>&1 || cat out.log
 
 echo "=== upgraded a ==="
 extract_published Pub.local.toml
@@ -64,4 +66,4 @@ echo "=== expect to fail when upgrading a because it is not compatible with b ==
 echo "module b::new_module; public fun b(): bool { true }" > b/sources/new_module.move
 
 sui client --client.config $CONFIG \
-  test-upgrade --build-env testnet --pubfile-path Pub.local.toml b
+  test-upgrade --gas $GAS --build-env testnet --pubfile-path Pub.local.toml b

--- a/crates/sui/tests/shell_tests/with_network/ephemeral/ephemeral_upgrade_fail.sh
+++ b/crates/sui/tests/shell_tests/with_network/ephemeral/ephemeral_upgrade_fail.sh
@@ -7,10 +7,12 @@
 # C --> B
 # C --> A
 
+GAS=$(sui client --client.config $CONFIG faucet --coin-id)
+
 echo "=== expect to fail when upgrading a because it is not even published yet ==="
 sui client --client.config $CONFIG \
-  test-upgrade --build-env testnet --pubfile-path Pub.local.toml a
+  test-upgrade --gas $GAS --build-env testnet --pubfile-path Pub.local.toml a
 
 echo "=== expect to fail because we should never upgrade with --test flag ==="
 sui client --client.config $CONFIG \
-  test-upgrade --build-env testnet --test --pubfile-path Pub.local.toml a
+  test-upgrade --gas $GAS --build-env testnet --test --pubfile-path Pub.local.toml a

--- a/crates/sui/tests/shell_tests/with_network/ephemeral/nonephemeral_ephemeral.sh
+++ b/crates/sui/tests/shell_tests/with_network/ephemeral/nonephemeral_ephemeral.sh
@@ -4,16 +4,17 @@
 
 # Publishing a package and then doing a test-publish succeed
 
+GAS=$(sui client --client.config $CONFIG faucet --coin-id)
 chain_id=$(sui client --client.config $CONFIG chain-identifier)
 
 echo "[environments]" >> a/Move.toml
 echo "localnet = \"$chain_id\"" >> a/Move.toml
 
 echo "=== real publish ==="
-sui client --client.config $CONFIG publish a \
+sui client --client.config $CONFIG publish --gas $GAS a \
   > out.log 2>&1 || cat out.log
 
 echo "=== ephemeral publish ==="
 sui client --client.config $CONFIG \
-  test-publish --build-env localnet --pubfile-path Pub.local.toml a \
+  test-publish --gas $GAS --build-env localnet --pubfile-path Pub.local.toml a \
   > out.log 2>&1 || cat out.log

--- a/crates/sui/tests/shell_tests/with_network/legacy/publish_all.sh
+++ b/crates/sui/tests/shell_tests/with_network/legacy/publish_all.sh
@@ -9,23 +9,25 @@
 #
 # We have to use test-publish because you can't real-publish a legacy package on localnet
 
+GAS=$(sui client --client.config $CONFIG faucet --coin-id)
+
 echo "=== publish legacy_dep ==="
 sui client --client.config $CONFIG \
-    test-publish --build-env testnet --pubfile-path Pub.local.toml legacy_dep \
+    test-publish --gas $GAS --build-env testnet --pubfile-path Pub.local.toml legacy_dep \
     2> output.log > output.log && echo "success" || cat output.log
 
 echo "=== publish legacy ==="
 sui client --client.config $CONFIG \
-    test-publish --build-env testnet --pubfile-path Pub.local.toml legacy \
+    test-publish --gas $GAS --build-env testnet --pubfile-path Pub.local.toml legacy \
     2> output.log > output.log && echo "success" || cat output.log
 
 echo "=== publish modern ==="
 sui client --client.config $CONFIG \
-    test-publish --build-env testnet --pubfile-path Pub.local.toml modern \
+    test-publish --gas $GAS --build-env testnet --pubfile-path Pub.local.toml modern \
     2> output.log > output.log && echo "success" || cat output.log
 
 echo "=== publish legacy_depends_on_modern ==="
 echo "    Should fail because legacy packages are not allowed to depend on modern packages"
 sui client --client.config $CONFIG \
-    test-publish --build-env testnet --pubfile-path Pub.local.toml legacy_depends_on_modern \
+    test-publish --gas $GAS --build-env testnet --pubfile-path Pub.local.toml legacy_depends_on_modern \
     2> output.log > output.log && echo "success" || cat output.log

--- a/crates/sui/tests/shell_tests/with_network/ptb_publish/publish_valid.sh
+++ b/crates/sui/tests/shell_tests/with_network/ptb_publish/publish_valid.sh
@@ -1,11 +1,13 @@
 # Copyright (c) Mysten Labs, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+GAS=$(sui client --client.config $CONFIG faucet --coin-id)
 chain_id=$(sui client --client.config $CONFIG chain-identifier)
 echo "[environments]" >> test_pkg/Move.toml
 echo "localnet = \"$chain_id\"" >> test_pkg/Move.toml
 
 sui client --client.config $CONFIG ptb \
+ --gas-coin @$GAS \
  --move-call sui::tx_context::sender \
  --assign sender \
  --publish "test_pkg" \

--- a/crates/sui/tests/shell_tests/with_network/publish_upgrade/publish.sh
+++ b/crates/sui/tests/shell_tests/with_network/publish_upgrade/publish.sh
@@ -33,6 +33,7 @@ extract_published() {
   echo "=== End Published.toml ==="
 }
 
+GAS=$(sui client --client.config $CONFIG faucet --coin-id)
 chain_id=$(sui client --client.config $CONFIG chain-identifier)
 
 for i in a b c d e
@@ -41,6 +42,6 @@ do
   echo "=== publishing $i ==="
   add_env_to_toml $i
 
-  sui client --client.config $CONFIG publish $i > output.log 2>&1 || cat output.log
+  sui client --client.config $CONFIG publish --gas $GAS $i > output.log 2>&1 || cat output.log
   extract_published $i/Published.toml
 done

--- a/crates/sui/tests/shell_tests/with_network/publish_upgrade/publish_fail.sh
+++ b/crates/sui/tests/shell_tests/with_network/publish_upgrade/publish_fail.sh
@@ -15,6 +15,7 @@
 #
 # We publish A, B, C, D, E in order
 
+GAS=$(sui client --client.config $CONFIG faucet --coin-id)
 chain_id=$(sui client --client.config $CONFIG chain-identifier)
 
 add_env_to_toml() {
@@ -27,10 +28,10 @@ echo "=== Should fail to publish because dependencies are not published. ==="
 add_env_to_toml a
 add_env_to_toml b
 
-sui client --client.config $CONFIG publish b
+sui client --client.config $CONFIG publish --gas $GAS b
 
 # Publish A, so we can try to publish twice
-sui client --client.config $CONFIG publish a > output.log 2>&1 || cat output.log
+sui client --client.config $CONFIG publish --gas $GAS a > output.log 2>&1 || cat output.log
 
 # Try to publish A again.
-sui client --client.config $CONFIG publish a
+sui client --client.config $CONFIG publish --gas $GAS a

--- a/crates/sui/tests/shell_tests/with_network/publish_upgrade/upgrade.sh
+++ b/crates/sui/tests/shell_tests/with_network/publish_upgrade/upgrade.sh
@@ -5,6 +5,7 @@
 # Test an ephemeral upgrade workflow. We have
 # B --> A
 
+GAS=$(sui client --client.config $CONFIG faucet --coin-id)
 chain_id=$(sui client --client.config $CONFIG chain-identifier)
 
 extract_published() {
@@ -32,24 +33,24 @@ add_env_to_toml b
 
 echo "=== test-publish a, then test-publish b, then add a module to b & upgrade b ==="
 
-sui client --client.config $CONFIG publish a > output.log 2>&1 || cat output.log
+sui client --client.config $CONFIG publish --gas $GAS a > output.log 2>&1 || cat output.log
 
 echo "=== published a ==="
 extract_published a/Published.toml
 
-sui client --client.config $CONFIG publish b > output.log 2>&1 || cat output.log
+sui client --client.config $CONFIG publish --gas $GAS b > output.log 2>&1 || cat output.log
 
 echo "=== published b ==="
 extract_published b/Published.toml
 
 echo "module b::new_module; public fun b() { a::a::a() }" >> b/sources/new_module.move
 
-sui client --client.config $CONFIG upgrade b > output.log 2>&1 || cat output.log
+sui client --client.config $CONFIG upgrade --gas $GAS b > output.log 2>&1 || cat output.log
 
 echo "=== upgraded b ==="
 extract_published b/Published.toml
 
-sui client --client.config $CONFIG upgrade a > output.log 2>&1 || cat output.log
+sui client --client.config $CONFIG upgrade --gas $GAS a > output.log 2>&1 || cat output.log
 
 echo "=== upgraded a ==="
 extract_published a/Published.toml
@@ -60,4 +61,4 @@ echo "=== expect to fail when upgrading a because it is not compatible with b ==
 # Does an incompatilbe update (changes public function's return type)
 echo "module b::new_module; public fun b(): bool { true }" > b/sources/new_module.move
 
-sui client --client.config $CONFIG upgrade b
+sui client --client.config $CONFIG upgrade --gas $GAS b

--- a/crates/sui/tests/shell_tests/with_network/publish_upgrade/upgrade_fail.sh
+++ b/crates/sui/tests/shell_tests/with_network/publish_upgrade/upgrade_fail.sh
@@ -7,6 +7,7 @@
 # C --> B
 # C --> A
 
+GAS=$(sui client --client.config $CONFIG faucet --coin-id)
 chain_id=$(sui client --client.config $CONFIG chain-identifier)
 
 add_env_to_toml() {
@@ -17,7 +18,7 @@ add_env_to_toml() {
 add_env_to_toml a
 
 echo "=== expect to fail when upgrading a because it is not even published yet ==="
-sui client --client.config $CONFIG upgrade a
+sui client --client.config $CONFIG upgrade --gas $GAS a
 
 echo "=== expect to fail because we should never upgrade with --test flag ==="
-sui client --client.config $CONFIG upgrade a --test
+sui client --client.config $CONFIG upgrade --gas $GAS a --test

--- a/crates/sui/tests/shell_tests/with_network/publish_with_flags/publish_dry_run.sh
+++ b/crates/sui/tests/shell_tests/with_network/publish_with_flags/publish_dry_run.sh
@@ -1,10 +1,11 @@
 # Copyright (c) Mysten Labs, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+GAS=$(sui client --client.config $CONFIG faucet --coin-id)
 chain_id=$(sui client --client.config $CONFIG chain-identifier)
 echo "[environments]" >> test_pkg/Move.toml
 echo "localnet = \"$chain_id\"" >> test_pkg/Move.toml
 
 # Calling publish with dry-run should output the effects (effects are non-deterministic so we just filter out some keywords)
-sui client --client.config "$CONFIG" publish test_pkg --dry-run \
+sui client --client.config "$CONFIG" publish --gas $GAS test_pkg --dry-run \
     | grep -E '^(BUILDING|Dry run completed)'

--- a/crates/sui/tests/shell_tests/with_network/with_unpublished_deps/publish.sh
+++ b/crates/sui/tests/shell_tests/with_network/with_unpublished_deps/publish.sh
@@ -8,6 +8,7 @@
 #
 # This should fail, because we try to get the linkage table for `b` because `b` is not on-chain
 
+GAS=$(sui client --client.config $CONFIG faucet --coin-id)
 chain_id=$(sui client --client.config $CONFIG chain-identifier)
 
 add_env_to_toml() {
@@ -20,4 +21,4 @@ add_env_to_toml b
 
 echo "=== publish a ==="
 
-sui client --client.config $CONFIG publish a
+sui client --client.config $CONFIG publish --gas $GAS a

--- a/crates/sui/tests/start-test-cluster.sh
+++ b/crates/sui/tests/start-test-cluster.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+DIR=$(mktemp -d)
+SUI="./target/debug/sui"
+$SUI genesis --working-dir "$DIR" --epoch-duration-ms 3600000 --committee-size 1
+$SUI start --network.config "$DIR" --with-faucet &
+PID=$!
+
+# Wait for the faucet to be ready
+for i in $(seq 1 60); do
+    curl -sf http://127.0.0.1:9123 > /dev/null 2>&1 && break
+    sleep 1
+done
+
+echo "SUI_TEST_CLUSTER_CONFIG_DIR=$DIR" >> "$NEXTEST_ENV"
+
+# Keep the script process alive until nextest sends SIGTERM after tests finish.
+# This ensures the `sui start` child process is cleaned up automatically.
+wait $PID


### PR DESCRIPTION
Instead of creating a TestCluster per with_network shell test (24 startups), support an external shared cluster via SUI_TEST_CLUSTER_CONFIG_DIR env var. When set, each test copies the config, requests fresh gas via faucet, and runs against the shared cluster. Falls back to per-test clusters when unset.

CI workflows updated to start `sui start --with-faucet` before tests. Windows CI re-enables with_network tests (previously disabled for perf).

## Description 

Describe the changes or additions included in this PR.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
