### PR TITLE
display: Support `$self` meta variable

### DIFF
--- a/crates/sui-display/src/v2/interpreter.rs
+++ b/crates/sui-display/src/v2/interpreter.rs
@@ -294,6 +294,7 @@ impl<S: V::Store> Interpreter<S> {
         use V::Value as VV;
 
         Ok(match lit {
+            L::Self_ => Some(VV::Slice(self.root.as_slice())),
             L::Address(a) => Some(VV::Address(*a)),
             L::Bool(b) => Some(VV::Bool(*b)),
             L::U8(n) => Some(VV::U8(*n)),

--- a/crates/sui-display/src/v2/lexer.rs
+++ b/crates/sui-display/src/v2/lexer.rs
@@ -50,6 +50,8 @@ pub(crate) enum Token {
     Comma,
     /// '.'
     Dot,
+    /// '$'
+    Dollar,
     /// An identifier
     Ident,
     /// '<'
@@ -161,6 +163,8 @@ impl<'s> Lexer<'s> {
             b',' => self.take(ws, T::Comma, 1),
 
             b'.' => self.take(ws, T::Dot, 1),
+
+            b'$' => self.take(ws, T::Dollar, 1),
 
             b'0' if bytes.get(1) == Some(&b'x')
                 && bytes.get(2).is_some_and(|b| is_valid_hex_byte(*b)) =>
@@ -312,6 +316,7 @@ impl fmt::Display for OwnedLexeme {
             L(_, T::CColon, _, _) => write!(f, "'::'"),
             L(_, T::Comma, _, _) => write!(f, "','"),
             L(_, T::Dot, _, _) => write!(f, "'.'"),
+            L(_, T::Dollar, _, _) => write!(f, "'$'"),
             L(_, T::Ident, _, s) => write!(f, "identifier {s:?}"),
             L(_, T::LAngle, _, _) => write!(f, "'<'"),
             L(_, T::LBrace, _, _) => write!(f, "'{{'"),
@@ -361,6 +366,7 @@ impl fmt::Display for Token {
             T::CColon => write!(f, "'::'"),
             T::Comma => write!(f, "','"),
             T::Dot => write!(f, "'.'"),
+            T::Dollar => write!(f, "'$'"),
             T::Ident => write!(f, "an identifier"),
             T::LAngle => write!(f, "'<'"),
             T::LBrace => write!(f, "'{{'"),
@@ -884,23 +890,23 @@ mod tests {
         "###);
     }
 
-    /// Test handling of single-byte unexpected characters followed by valid tokens.
+    /// '$' is recognized as a standalone token.
     #[test]
-    fn test_unexpected_single_byte() {
+    fn test_dollar_token() {
         assert_snapshot!(text("{$hello}"), @r###"
         L(false, LBrace, 0, "{")
-        L(false, Unexpected, 1, "$")
+        L(false, Dollar, 1, "$")
         L(false, Ident, 2, "hello")
         L(false, RBrace, 7, "}")
         "###);
     }
 
-    /// Test unexpected character followed by multi-byte UTF-8 character.
+    /// '$' is followed by an unexpected multi-byte UTF-8 character.
     #[test]
     fn test_unexpected_before_multibyte() {
         assert_snapshot!(text("{$é}"), @r###"
         L(false, LBrace, 0, "{")
-        L(false, Unexpected, 1, "$")
+        L(false, Dollar, 1, "$")
         L(false, Unexpected, 2, "\xC3\xA9")
         L(false, RBrace, 4, "}")
         "###);
@@ -911,7 +917,7 @@ mod tests {
     fn test_unexpected_characters_utf8_safe() {
         assert_snapshot!(text("{$∑∞}"), @r###"
         L(false, LBrace, 0, "{")
-        L(false, Unexpected, 1, "$")
+        L(false, Dollar, 1, "$")
         L(false, Unexpected, 2, "\xE2\x88\x91")
         L(false, Unexpected, 5, "\xE2\x88\x9E")
         L(false, RBrace, 8, "}")

--- a/crates/sui-display/src/v2/snapshots/sui_display__v2__parser__tests__self_literal_expr.snap
+++ b/crates/sui-display/src/v2/snapshots/sui_display__v2__parser__tests__self_literal_expr.snap
@@ -1,0 +1,6 @@
+---
+source: crates/sui-display/src/v2/parser.rs
+expression: "strands(r#\"{$self}\"#)"
+---
+{ $self
+}@0

--- a/crates/sui-display/src/v2/snapshots/sui_display__v2__parser__tests__self_literal_invalid_identifier.snap
+++ b/crates/sui-display/src/v2/snapshots/sui_display__v2__parser__tests__self_literal_invalid_identifier.snap
@@ -1,0 +1,5 @@
+---
+source: crates/sui-display/src/v2/parser.rs
+expression: "strands(r#\"{$foo}\"#)"
+---
+Error: Unexpected identifier "foo" at byte offset 2, expected 'self'

--- a/crates/sui-display/src/v2/snapshots/sui_display__v2__parser__tests__self_literal_whitespace.snap
+++ b/crates/sui-display/src/v2/snapshots/sui_display__v2__parser__tests__self_literal_whitespace.snap
@@ -1,0 +1,5 @@
+---
+source: crates/sui-display/src/v2/parser.rs
+expression: "strands(r#\"{$ self}\"#)"
+---
+Error: Unexpected whitespace followed by identifier "self" at byte offset 3, expected 'self'

--- a/crates/sui-display/src/v2/snapshots/sui_display__v2__parser__tests__trailing_alternate.snap
+++ b/crates/sui-display/src/v2/snapshots/sui_display__v2__parser__tests__trailing_alternate.snap
@@ -2,4 +2,4 @@
 source: crates/sui-display/src/v2/parser.rs
 expression: "strands(r#\"{foo | bar | baz |}\"#)"
 ---
-Error: Unexpected '}' at byte offset 18, expected one of 'b', 'false', 'true', 'x', '@', an identifier, a decimal number, a hexadecimal number, or a string
+Error: Unexpected '}' at byte offset 18, expected one of 'b', 'false', 'true', 'x', '@', '$', an identifier, a decimal number, a hexadecimal number, or a string

--- a/crates/sui-display/src/v2/snapshots/sui_display__v2__parser__tests__trailing_string.snap
+++ b/crates/sui-display/src/v2/snapshots/sui_display__v2__parser__tests__trailing_string.snap
@@ -2,4 +2,4 @@
 source: crates/sui-display/src/v2/parser.rs
 expression: "strands(r#\"{'foo\"#)"
 ---
-Error: Unexpected "'foo" at byte offset 1, expected one of 'b', 'false', 'true', 'x', '@', an identifier, a decimal number, a hexadecimal number, or a string
+Error: Unexpected "'foo" at byte offset 1, expected one of 'b', 'false', 'true', 'x', '@', '$', an identifier, a decimal number, a hexadecimal number, or a string

--- a/crates/sui-display/src/v2/snapshots/sui_display__v2__parser__tests__unexpected_characters.snap
+++ b/crates/sui-display/src/v2/snapshots/sui_display__v2__parser__tests__unexpected_characters.snap
@@ -2,4 +2,4 @@
 source: crates/sui-display/src/v2/parser.rs
 expression: "strands(r#\"anything goes {? % ! 🔥}\"#)"
 ---
-Error: Unexpected "?" at byte offset 15, expected one of 'b', 'false', 'true', 'x', '@', an identifier, a decimal number, a hexadecimal number, or a string
+Error: Unexpected "?" at byte offset 15, expected one of 'b', 'false', 'true', 'x', '@', '$', an identifier, a decimal number, a hexadecimal number, or a string

--- a/crates/sui-display/src/v2/snapshots/sui_display__v2__parser__tests__unexpected_characters_malformed_utf8.snap
+++ b/crates/sui-display/src/v2/snapshots/sui_display__v2__parser__tests__unexpected_characters_malformed_utf8.snap
@@ -2,4 +2,4 @@
 source: crates/sui-display/src/v2/parser.rs
 expression: strands(input_str)
 ---
-Error: Unexpected "\xC3" at byte offset 1, expected one of 'b', 'false', 'true', 'x', '@', an identifier, a decimal number, a hexadecimal number, or a string
+Error: Unexpected "\xC3" at byte offset 1, expected one of 'b', 'false', 'true', 'x', '@', '$', an identifier, a decimal number, a hexadecimal number, or a string

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/objects/dynamic_field_literal_errors.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/objects/dynamic_field_literal_errors.snap
@@ -100,7 +100,7 @@ Response: {
   },
   "errors": [
     {
-      "message": "Literal error: Unexpected \"'hello\" at byte offset 0, expected one of 'b', 'false', 'true', 'x', '@', an identifier, a decimal number, a hexadecimal number, or a string",
+      "message": "Literal error: Unexpected \"'hello\" at byte offset 0, expected one of 'b', 'false', 'true', 'x', '@', '$', an identifier, a decimal number, a hexadecimal number, or a string",
       "locations": [
         {
           "line": 3,


### PR DESCRIPTION
## Description

Give users the ability to refer directly to the value being displayed, using `$self`. This makes it possiblet to write expressions where the `$self` is used as part of a dynamic field key, rather than part of the parent that that dynamic field is being fetched from. E.g. to use the value as a key to fetch from a registry, `@REGISTRY->[$self]`.

## Test plan

New unit tests:

```
$ cargo nextest run -p sui-display
```

## Stack

- #25479 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
