### PR TITLE
fix incorrect ordinal suffix for command numbers (11th/12th/13th)

### DIFF
--- a/crates/sui/src/clever_error_rendering.rs
+++ b/crates/sui/src/clever_error_rendering.rs
@@ -113,11 +113,14 @@ pub(crate) async fn render_clever_error_opt(error_string: &str, client: &Client)
 
     // Convert the command index into an ordinal.
     let command = command_index + 1;
-    let suffix = match command % 10 {
-        1 => "st",
-        2 => "nd",
-        3 => "rd",
-        _ => "th",
+    let suffix = match command % 100 {
+        11 | 12 | 13 => "th",
+        _ => match command % 10 {
+            1 => "st",
+            2 => "nd",
+            3 => "rd",
+            _ => "th",
+        },
     };
 
     Some(format!("{command}{suffix} command aborted within {error}"))


### PR DESCRIPTION
Fixes incorrect ordinal suffixes for command numbers in CLI output (11st/12nd/13rd - 11th/12th/13th), making error messages grammatically correct and clearer.