### PR TITLE
[cherry-pick][cli] Fixes pretty printing for tx output (#25480)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13768,6 +13768,7 @@ dependencies = [
  "move-analyzer",
  "move-binary-format",
  "move-bytecode-source-map",
+ "move-bytecode-utils",
  "move-bytecode-verifier-meter",
  "move-cli",
  "move-command-line-common",

--- a/crates/sui/Cargo.toml
+++ b/crates/sui/Cargo.toml
@@ -82,6 +82,7 @@ sui-protocol-config.workspace = true
 shared-crypto.workspace = true
 sui-transaction-builder.workspace = true
 move-binary-format.workspace = true
+move-bytecode-utils.workspace = true
 move-trace-format.workspace = true
 move-bytecode-source-map.workspace = true
 mysten-common.workspace = true

--- a/crates/sui/src/displays/dry_run_tx_block.rs
+++ b/crates/sui/src/displays/dry_run_tx_block.rs
@@ -1,0 +1,128 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{client_commands::estimate_gas_budget_from_gas_cost, displays::Pretty};
+use std::fmt::{Display, Formatter};
+use sui_json_rpc_types::{
+    DryRunTransactionBlockResponse, ObjectChange, SuiTransactionBlockDataAPI,
+    SuiTransactionBlockEffectsAPI,
+};
+use tabled::{
+    builder::Builder as TableBuilder,
+    settings::{Panel as TablePanel, Style as TableStyle, style::HorizontalLine},
+};
+
+impl Display for Pretty<'_, DryRunTransactionBlockResponse> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let Pretty(response) = self;
+
+        writeln!(
+            f,
+            "Dry run completed, execution status: {}",
+            response.effects.status()
+        )?;
+
+        let mut builder = TableBuilder::default();
+        builder.push_record(vec![format!("{}", response.input)]);
+        let mut table = builder.build();
+        table.with(TablePanel::header("Dry Run Transaction Data"));
+        table.with(TableStyle::rounded().horizontals([HorizontalLine::new(
+            1,
+            TableStyle::modern().get_horizontal(),
+        )]));
+        writeln!(f, "{}", table)?;
+        writeln!(f, "{}", response.effects)?;
+        write!(f, "{}", response.events)?;
+
+        if response.object_changes.is_empty() {
+            writeln!(f, "╭─────────────────────────────╮")?;
+            writeln!(f, "│ No object changes           │")?;
+            writeln!(f, "╰─────────────────────────────╯")?;
+        } else {
+            let mut builder = TableBuilder::default();
+            let (
+                mut created,
+                mut deleted,
+                mut mutated,
+                mut published,
+                mut transferred,
+                mut wrapped,
+            ) = (vec![], vec![], vec![], vec![], vec![], vec![]);
+            for obj in &response.object_changes {
+                match obj {
+                    ObjectChange::Created { .. } => created.push(obj),
+                    ObjectChange::Deleted { .. } => deleted.push(obj),
+                    ObjectChange::Mutated { .. } => mutated.push(obj),
+                    ObjectChange::Published { .. } => published.push(obj),
+                    ObjectChange::Transferred { .. } => transferred.push(obj),
+                    ObjectChange::Wrapped { .. } => wrapped.push(obj),
+                };
+            }
+
+            write_obj_changes(created, "Created", &mut builder)?;
+            write_obj_changes(deleted, "Deleted", &mut builder)?;
+            write_obj_changes(mutated, "Mutated", &mut builder)?;
+            write_obj_changes(published, "Published", &mut builder)?;
+            write_obj_changes(transferred, "Transferred", &mut builder)?;
+            write_obj_changes(wrapped, "Wrapped", &mut builder)?;
+
+            let mut table = builder.build();
+            table.with(TablePanel::header("Object Changes"));
+            table.with(TableStyle::rounded().horizontals([HorizontalLine::new(
+                1,
+                TableStyle::modern().get_horizontal(),
+            )]));
+            writeln!(f, "{}", table)?;
+        }
+        if response.balance_changes.is_empty() {
+            writeln!(f, "╭─────────────────────────────╮")?;
+            writeln!(f, "│ No balance changes          │")?;
+            writeln!(f, "╰─────────────────────────────╯")?;
+        } else {
+            let mut builder = TableBuilder::default();
+            for balance in &response.balance_changes {
+                builder.push_record(vec![format!("{}", balance)]);
+            }
+            let mut table = builder.build();
+            table.with(TablePanel::header("Balance Changes"));
+            table.with(TableStyle::rounded().horizontals([HorizontalLine::new(
+                1,
+                TableStyle::modern().get_horizontal(),
+            )]));
+            writeln!(f, "{}", table)?;
+        }
+        writeln!(
+            f,
+            "Dry run completed, execution status: {}",
+            response.effects.status()
+        )?;
+        writeln!(
+            f,
+            "Estimated gas cost (includes a small buffer): {} MIST",
+            estimate_gas_budget_from_gas_cost(
+                response.effects.gas_cost_summary(),
+                response.input.gas_data().price
+            )
+        )?;
+
+        if let Some(err) = &response.execution_error_source {
+            writeln!(f, "Execution error: {}", err)?;
+        }
+
+        Ok(())
+    }
+}
+
+fn write_obj_changes<T: Display>(
+    values: Vec<T>,
+    output_string: &str,
+    builder: &mut TableBuilder,
+) -> std::fmt::Result {
+    if !values.is_empty() {
+        builder.push_record(vec![format!("{} Objects: ", output_string)]);
+        for obj in values {
+            builder.push_record(vec![format!("{}", obj)]);
+        }
+    }
+    Ok(())
+}

--- a/crates/sui/src/displays/mod.rs
+++ b/crates/sui/src/displays/mod.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+mod dry_run_tx_block;
 mod gas_cost_summary;
 mod ptb_preview;
 mod simulate;

--- a/crates/sui/tests/shell_tests/with_network/publish_with_flags/publish_dry_run.snap
+++ b/crates/sui/tests/shell_tests/with_network/publish_with_flags/publish_dry_run.snap
@@ -18,6 +18,7 @@ success: true
 exit_code: 0
 ----- stdout -----
 Dry run completed, execution status: success
+Dry run completed, execution status: success
 
 ----- stderr -----
 BUILDING test_pkg


### PR DESCRIPTION
## Description 

Fix pretty printing for transaction results, as well as json output format, to match what used to exist before 1.65.0.

The JSON format has one slight difference, so not sure what's the best approach here:
old:
```
 "confirmedLocalExecution": true
 ```
new:
```
  "timestampMs": "1771265071051",
  "checkpoint": "354"
 ```

## Test plan 

Existing tests.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework: