### PR TITLE
[bella-ciao] Cleanup resolution interface in the VM

### DIFF
--- a/external-crates/move/crates/move-transactional-test-runner/tests/vm_test_harness/publish_and_call_invalid.snap
+++ b/external-crates/move/crates/move-transactional-test-runner/tests/vm_test_harness/publish_and_call_invalid.snap
@@ -6,10 +6,10 @@ processed 1 task
 task 0, lines 1-10:
 //# publish-and-call --call 0x42::m::a --call 0x42::m::d
 Error: Function execution failed with VMError: {
-    major_status: VTABLE_KEY_LOOKUP_ERROR,
+    major_status: EXTERNAL_RESOLUTION_REQUEST_ERROR,
     sub_status: None,
-    location: undefined,
+    location: 0x42::m,
     indices: [],
     offsets: [],
-    message: "Could not find function 0000000000000000000000000000000000000000000000000000000000000042::m::d",
+    message: "Failed to find function 0000000000000000000000000000000000000000000000000000000000000042::m::d",
 }

--- a/external-crates/move/crates/move-vm-runtime/src/cache/identifier_interner.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/cache/identifier_interner.rs
@@ -62,6 +62,14 @@ impl IdentifierInterner {
         self.get_or_intern_str_internal(ident_str.borrow_str())
     }
 
+    /// Get the interned identifier key for the given string, if it exists. This does not intern
+    /// the string if it does not exist, and will return `None` instead.
+    ///
+    /// BE EXTREMELY CAREFUL WITH THIS FUNCTION: It deals with data that is shared across threads.
+    pub(crate) fn get_ident_str(&self, ident_str: &IdentStr) -> Option<IdentifierKey> {
+        self.0.get(ident_str.borrow_str()).map(IdentifierKey)
+    }
+
     #[allow(clippy::panic)]
     // [SAFETY] The unsafe code is inserting an identifier into the interner without ensuring it
     // will fit. If it fails to fit, it will panic, but that's likely a serious OOM issue, and it's

--- a/external-crates/move/crates/move-vm-runtime/src/dev_utils/in_memory_test_adapter.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/dev_utils/in_memory_test_adapter.rs
@@ -71,6 +71,10 @@ impl InMemoryTestAdapter {
         self.runtime.vm_config()
     }
 
+    pub fn runtime(&self) -> &MoveRuntime {
+        &self.runtime
+    }
+
     /// Compute all of the transitive dependencies for a `root_package`, including itself.
     pub fn transitive_dependencies(
         &self,

--- a/external-crates/move/crates/move-vm-runtime/src/unit_tests/bad_entry_point_tests.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/unit_tests/bad_entry_point_tests.rs
@@ -12,8 +12,10 @@ use crate::{
     shared::{gas::UnmeteredGasMeter, linkage_context::LinkageContext},
 };
 use move_core_types::{
-    account_address::AccountAddress, identifier::Identifier, language_storage::ModuleId,
-    vm_status::StatusType,
+    account_address::AccountAddress,
+    identifier::Identifier,
+    language_storage::{ModuleId, StructTag, TypeTag},
+    vm_status::{StatusCode, StatusType},
 };
 use std::collections::BTreeMap;
 
@@ -25,6 +27,7 @@ fn call_non_existent_module() {
     let linkage = LinkageContext::new(BTreeMap::new());
     let mut vm = adapter.make_vm(linkage).unwrap();
 
+    let before = adapter.runtime().cache().to_cache_telemetry().interner_size;
     let module_id = ModuleId::new(TEST_ADDR, Identifier::new("M").unwrap());
     let fun_name = Identifier::new("foo").unwrap();
 
@@ -38,8 +41,17 @@ fn call_non_existent_module() {
             None,
         )
         .unwrap_err();
+    let after = adapter.runtime().cache().to_cache_telemetry().interner_size;
 
-    assert_eq!(err.status_type(), StatusType::InvariantViolation);
+    assert_eq!(err.status_type(), StatusType::Execution);
+    assert_eq!(
+        err.major_status(),
+        StatusCode::EXTERNAL_RESOLUTION_REQUEST_ERROR
+    );
+    assert_eq!(
+        before, after,
+        "Unexpected interner growth when calling non-existent module"
+    );
 }
 
 #[test]
@@ -60,6 +72,7 @@ fn call_non_existent_function() {
     let linkage = adapter.get_linkage_context(TEST_ADDR).unwrap();
 
     let mut sess = adapter.make_vm(linkage).unwrap();
+    let before = adapter.runtime().cache().to_cache_telemetry().interner_size;
 
     let fun_name = Identifier::new("foo").unwrap();
 
@@ -73,6 +86,55 @@ fn call_non_existent_function() {
             None,
         )
         .unwrap_err();
+    let after = adapter.runtime().cache().to_cache_telemetry().interner_size;
 
-    assert_eq!(err.status_type(), StatusType::InvariantViolation);
+    assert_eq!(err.status_type(), StatusType::Execution);
+    assert_eq!(
+        err.major_status(),
+        StatusCode::EXTERNAL_RESOLUTION_REQUEST_ERROR
+    );
+    assert_eq!(
+        before, after,
+        "Unexpected interner growth when calling non-existent module"
+    );
+}
+
+#[test]
+fn resolve_non_existent_type() {
+    let code = r#"
+        module {{ADDR}}::M {}
+    "#;
+    let code = code.replace("{{ADDR}}", &format!("0x{}", TEST_ADDR));
+
+    let mut units = compile_units(&code).unwrap();
+    let m = as_module(units.pop().unwrap());
+
+    let mut adapter = InMemoryTestAdapter::new();
+    let pkg = StoredPackage::from_modules_for_testing(TEST_ADDR, vec![m]).unwrap();
+    adapter.insert_package_into_storage(pkg);
+
+    let linkage = adapter.get_linkage_context(TEST_ADDR).unwrap();
+
+    let sess = adapter.make_vm(linkage).unwrap();
+    let before = adapter.runtime().cache().to_cache_telemetry().interner_size;
+
+    let err = sess
+        .load_type(&TypeTag::Struct(Box::new(StructTag {
+            address: TEST_ADDR,
+            module: Identifier::new("M").unwrap(),
+            name: Identifier::new("S").unwrap(),
+            type_params: vec![],
+        })))
+        .unwrap_err();
+    let after = adapter.runtime().cache().to_cache_telemetry().interner_size;
+
+    assert_eq!(err.status_type(), StatusType::Execution);
+    assert_eq!(
+        err.major_status(),
+        StatusCode::EXTERNAL_RESOLUTION_REQUEST_ERROR
+    );
+    assert_eq!(
+        before, after,
+        "Unexpected interner growth when calling non-existent module"
+    );
 }

--- a/external-crates/move/crates/move-vm-runtime/src/unit_tests/loader_tests.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/unit_tests/loader_tests.rs
@@ -208,11 +208,10 @@ impl Adapter {
     ) -> DepthFormula {
         let vm = self.runtime_adapter.write();
         let mut session = vm.make_vm(self.store.linkage.clone()).unwrap();
-        let key = session.virtual_tables.to_virtual_table_key(
-            module_id.address(),
-            module_id.name(),
-            struct_name,
-        );
+        let key = session
+            .virtual_tables
+            .to_virtual_table_key_for_testing(module_id.address(), module_id.name(), struct_name)
+            .unwrap();
         session
             .virtual_tables
             .calculate_depth_of_type(&key)

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/env.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/env.rs
@@ -126,11 +126,13 @@ impl<'pc, 'vm, 'state, 'linkage, 'extensions> Env<'pc, 'vm, 'state, 'linkage, 'e
             StatusCode::NUMBER_OF_TYPE_ARGUMENTS_MISMATCH => {
                 ExecutionErrorKind::TypeArityMismatch.into()
             }
-            StatusCode::TYPE_RESOLUTION_FAILURE => ExecutionErrorKind::TypeArgumentError {
-                argument_idx,
-                kind: TypeArgumentError::TypeNotFound,
+            StatusCode::EXTERNAL_RESOLUTION_REQUEST_ERROR => {
+                ExecutionErrorKind::TypeArgumentError {
+                    argument_idx,
+                    kind: TypeArgumentError::TypeNotFound,
+                }
+                .into()
             }
-            .into(),
             StatusCode::CONSTRAINT_NOT_SATISFIED => ExecutionErrorKind::TypeArgumentError {
                 argument_idx,
                 kind: TypeArgumentError::ConstraintNotSatisfied,


### PR DESCRIPTION
## Description 

Cleans up the resolution interface for the VM so that external resolution requests get mapped to `EXTERNAL_RESOLUTION_REQUEST_ERROR`s.

It also ensures that external requests cannot cause undue interning of strings during the resolution process.

## Test plan 

CI + amended two tests and added another for internment checking. Updated some snapshots on this as well. 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
