### PR TITLE
Update OpenRPC snapshot for v1.66.1 version bump

### DIFF
--- a/crates/sui-open-rpc/tests/snapshots/generate_spec__openrpc.snap.json
+++ b/crates/sui-open-rpc/tests/snapshots/generate_spec__openrpc.snap.json
@@ -12,7 +12,7 @@
       "name": "Apache-2.0",
       "url": "https://raw.githubusercontent.com/MystenLabs/sui/main/LICENSE"
     },
-    "version": "1.66.0"
+    "version": "1.66.1"
   },
   "methods": [
     {


### PR DESCRIPTION
## Summary
- The v1.66.1 version bump commit updated `Cargo.toml` but did not regenerate the OpenRPC spec snapshot
- This causes `sui-open-rpc::generate-spec::test_json_rpc_spec` to fail deterministically in CI (failed all 4 retries)
- The fix is a single-line change: `"version": "1.66.0"` → `"version": "1.66.1"` in the snapshot file

## Test plan
- [x] Ran `cargo insta test -p sui-open-rpc` locally — test passes with updated snapshot
- [ ] CI should pass on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)