### PR TITLE
[bella-ciao] Panic on invariant violation in debug builds

### DIFF
--- a/external-crates/move/crates/move-binary-format/src/lib.rs
+++ b/external-crates/move/crates/move-binary-format/src/lib.rs
@@ -192,16 +192,37 @@ macro_rules! safe_assert {
 #[macro_export]
 macro_rules! partial_vm_error {
     ($error_name:ident $(,)?) => {{
-        $crate::errors::PartialVMError::new(
+
+        let _e = $crate::errors::PartialVMError::new(
             move_core_types::vm_status::StatusCode::$error_name,
-        )
+        );
+        #[cfg(all(debug_assertions, not(test)))]
+        {
+            if _e.major_status().status_type() == move_core_types::vm_status::StatusType::InvariantViolation {
+                panic!(
+                    "INVARIANT VIOLATION: {:?}",
+                    _e
+                );
+            }
+        }
+        _e
     }};
     ($error_name:ident, $($body:tt)*) => {{
-        $crate::errors::PartialVMError::new(
+        let _e = $crate::errors::PartialVMError::new(
             move_core_types::vm_status::StatusCode::$error_name,
         ).with_message(
             format!($($body)*),
-        )
+        );
+        #[cfg(all(debug_assertions, not(test)))]
+        {
+            if _e.major_status().status_type() == move_core_types::vm_status::StatusType::InvariantViolation {
+                panic!(
+                    "INVARIANT VIOLATION: {:?}",
+                    _e
+                );
+            }
+        }
+        _e
     }};
 }
 


### PR DESCRIPTION
## Description 

Set it up so that we panic in debug builds if an invariant violation is raised from the VM.

We also do not panic on raising invariant violations for unit tests for the Move VM, as we have a number of hand-rolled (Rust) unit tests that test this behiavior. 

## Test plan 

CI + verified it manually locally

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
