### PR TITLE
Debottleneck indexing framework

### DIFF
--- a/crates/sui-futures/src/stream.rs
+++ b/crates/sui-futures/src/stream.rs
@@ -89,10 +89,6 @@ impl<S: Stream + Sized + 'static> TrySpawnStreamExt for S {
                 }
             }
 
-            if draining && permits == limit {
-                break;
-            }
-
             tokio::select! {
                 biased;
 


### PR DESCRIPTION
## Description

I have noticed that indexing framework seems to have artificial software bottlenecks for high-throughput, small-batch-size indexers like GCS and Big Table. I hit throughput limits well before bandwidth, compute, or the database or object stores were ever saturated and no amount of concurrency-tuning or channel-sizing ever seemed to help.

In my java past life, I have seen this technique where "greedily" draining queues before yielding the thread massively improves throughput by avoid scheduling overhead. I tried applying it to these channels in tokio and it seemed to work here too.

My bigtable throughput doubled and I'm now able to saturate a 6-node cluster if I set the concurrency limits high enough.

<img width="1121" height="328" alt="image" src="https://github.com/user-attachments/assets/dc9ac021-f089-4871-bf7d-615f77ecbc7f" />


## Test plan

It 2x'd throughput on my bigtable indexer. I'd like to a do a test where I do a bucket to bucket GCS copy using the object store indexer to see how fast it can go, but I haven't had a chance yet. This screenshot shows the ingestion throughput over the same watermark range. Commit throughput is similarly doubled. I suspect it would be more than doubled if I wasn't hitting database limits.
