### PR TITLE
[move][move-compiler] Fix #25349

### DIFF
--- a/external-crates/move/crates/move-compiler/src/typing/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/translate.rs
@@ -2558,6 +2558,12 @@ fn match_pattern_(
             let x_ty = context.get_local_type(&x);
             T::pat(x_ty, sp(loc, TP::Binder(mut_, x)))
         }
+        P::Literal(sp!(_, Value_::InferredString(_))) => {
+            let msg = "String literals are not currently supported in match patterns";
+            context.add_diag(diag!(TypeSafety::InvalidString, (loc, msg)));
+            let ty = context.error_type(loc);
+            T::pat(ty, sp(loc, TP::ErrorPat))
+        }
         P::Literal(v) => {
             let ty = match &v.value {
                 Value_::InferredNum(_) => core::make_num_tvar(context, loc),

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/string_literal_crash.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/string_literal_crash.move
@@ -1,0 +1,8 @@
+module 0x1::m {
+    fun f(x: vector<u8>) {
+        match (x) {
+            "a" => {},
+            _ => {},
+        };
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/string_literal_crash.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/string_literal_crash.snap
@@ -1,0 +1,12 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+error[E04038]: invalid string after type inference
+  ┌─ tests/move_2024/matching/string_literal_crash.move:4:13
+  │
+4 │             "a" => {},
+  │             ^^^ String literals are not currently supported in match patterns


### PR DESCRIPTION
## Description 

Carve out exception to refuse string literals in matching. This fixes #25349 where it was crashing, though long-term supporting something here might be preferred.

## Test plan 

New test added.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
