### PR TITLE
Decouple cross-pipeline lag and ingestion channel size

### DIFF
--- a/crates/sui-checkpoint-blob-indexer/src/config.rs
+++ b/crates/sui-checkpoint-blob-indexer/src/config.rs
@@ -78,7 +78,6 @@ pub struct IngestionConfig {
     pub streaming_backoff_max_batch_size: usize,
     pub streaming_connection_timeout_ms: u64,
     pub streaming_statement_timeout_ms: u64,
-    pub checkpoint_channel_size: usize,
 }
 
 impl Default for IngestionConfig {
@@ -97,7 +96,6 @@ impl From<framework::ingestion::IngestionConfig> for IngestionConfig {
             streaming_backoff_max_batch_size: config.streaming_backoff_max_batch_size,
             streaming_connection_timeout_ms: config.streaming_connection_timeout_ms,
             streaming_statement_timeout_ms: config.streaming_statement_timeout_ms,
-            checkpoint_channel_size: config.checkpoint_channel_size,
         }
     }
 }
@@ -112,7 +110,6 @@ impl From<IngestionConfig> for framework::ingestion::IngestionConfig {
             streaming_backoff_max_batch_size: config.streaming_backoff_max_batch_size,
             streaming_connection_timeout_ms: config.streaming_connection_timeout_ms,
             streaming_statement_timeout_ms: config.streaming_statement_timeout_ms,
-            checkpoint_channel_size: config.checkpoint_channel_size,
         }
     }
 }

--- a/crates/sui-indexer-alt-consistent-store/src/config.rs
+++ b/crates/sui-indexer-alt-consistent-store/src/config.rs
@@ -44,7 +44,6 @@ pub struct IngestionConfig {
     pub streaming_backoff_max_batch_size: usize,
     pub streaming_connection_timeout_ms: u64,
     pub streaming_statement_timeout_ms: u64,
-    pub checkpoint_channel_size: usize,
 }
 
 #[DefaultConfig]
@@ -152,7 +151,6 @@ impl From<framework::ingestion::IngestionConfig> for IngestionConfig {
             streaming_backoff_max_batch_size: config.streaming_backoff_max_batch_size,
             streaming_connection_timeout_ms: config.streaming_connection_timeout_ms,
             streaming_statement_timeout_ms: config.streaming_statement_timeout_ms,
-            checkpoint_channel_size: config.checkpoint_channel_size,
         }
     }
 }
@@ -167,7 +165,6 @@ impl From<IngestionConfig> for framework::ingestion::IngestionConfig {
             streaming_backoff_max_batch_size: config.streaming_backoff_max_batch_size,
             streaming_connection_timeout_ms: config.streaming_connection_timeout_ms,
             streaming_statement_timeout_ms: config.streaming_statement_timeout_ms,
-            checkpoint_channel_size: config.checkpoint_channel_size,
         }
     }
 }

--- a/crates/sui-indexer-alt-framework/src/ingestion/mod.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/mod.rs
@@ -70,10 +70,6 @@ pub struct IngestionConfig {
 
     /// Timeout for streaming statement (peek/next) operations in milliseconds.
     pub streaming_statement_timeout_ms: u64,
-
-    /// Size of the per-pipeline checkpoint channel. Controls how many checkpoints can be buffered
-    /// between the broadcaster and each pipeline's processor.
-    pub checkpoint_channel_size: usize,
 }
 
 pub struct IngestionService {
@@ -161,7 +157,7 @@ impl IngestionService {
         mpsc::Receiver<Arc<Checkpoint>>,
         mpsc::UnboundedSender<(&'static str, u64)>,
     ) {
-        let (sender, receiver) = mpsc::channel(self.config.checkpoint_channel_size);
+        let (sender, receiver) = mpsc::channel(self.config.checkpoint_buffer_size);
         self.subscribers.push(sender);
         (receiver, self.commit_hi_tx.clone())
     }
@@ -175,16 +171,21 @@ impl IngestionService {
     /// - If a subscriber is slow to accept checkpoints from the channel, it will provide
     ///   back-pressure as this channel has a fixed buffer size (configured when the ingestion
     ///   service is initialized).
-    /// - If the ingestion service is run with `regulated = true`, subscribers must also update the
-    ///   ingestion service with the latest checkpoint they have completely processed, and the
-    ///   ingestion service will use this to limit how far ahead it fetches checkpoints.
+    /// - If the ingestion service is run with `next_sequential_checkpoint` set, subscribers must
+    ///   also update the ingestion service with the latest checkpoint they have completely
+    ///   processed, and the ingestion service will use this to limit how far ahead it fetches
+    ///   checkpoints.
     /// - If a subscriber closes either of these channels, the ingestion service will interpret
     ///   that as a signal to shutdown as well.
     ///
     /// If ingestion reaches the leading edge of the network, it will encounter checkpoints that do
     /// not exist yet. These will be retried repeatedly on a fixed `retry_interval` until they
     /// become available.
-    pub async fn run<R>(self, checkpoints: R, regulated: bool) -> Result<Service>
+    pub async fn run<R>(
+        self,
+        checkpoints: R,
+        next_sequential_checkpoint: Option<u64>,
+    ) -> Result<Service>
     where
         R: std::ops::RangeBounds<u64> + Send + 'static,
     {
@@ -204,7 +205,7 @@ impl IngestionService {
 
         Ok(broadcaster(
             checkpoints,
-            regulated,
+            next_sequential_checkpoint,
             streaming_client,
             config,
             ingestion_client,
@@ -225,7 +226,6 @@ impl Default for IngestionConfig {
             streaming_backoff_max_batch_size: 10000,  // 10000 checkpoints, ~ 40 minutes
             streaming_connection_timeout_ms: 5000,    // 5 seconds
             streaming_statement_timeout_ms: 5000,     // 5 seconds
-            checkpoint_channel_size: 1000,
         }
     }
 }
@@ -300,7 +300,7 @@ mod tests {
 
         let ingestion_service = test_ingestion(server.uri(), 1, 1).await;
 
-        let res = ingestion_service.run(0.., false).await;
+        let res = ingestion_service.run(0.., None).await;
         assert!(matches!(res, Err(Error::NoSubscribers)));
     }
 
@@ -319,7 +319,7 @@ mod tests {
 
         let (rx, _) = ingestion_service.subscribe();
         let subscriber = test_subscriber(usize::MAX, rx).await;
-        let svc = ingestion_service.run(0.., false).await.unwrap();
+        let svc = ingestion_service.run(0.., None).await.unwrap();
 
         svc.shutdown().await.unwrap();
         subscriber.await.unwrap();
@@ -340,7 +340,7 @@ mod tests {
 
         let (rx, _) = ingestion_service.subscribe();
         let subscriber = test_subscriber(1, rx).await;
-        let mut svc = ingestion_service.run(0.., false).await.unwrap();
+        let mut svc = ingestion_service.run(0.., None).await.unwrap();
 
         drop(subscriber);
         svc.join().await.unwrap();
@@ -367,7 +367,7 @@ mod tests {
 
         let (rx, _) = ingestion_service.subscribe();
         let subscriber = test_subscriber(5, rx).await;
-        let _svc = ingestion_service.run(0.., false).await.unwrap();
+        let _svc = ingestion_service.run(0.., None).await.unwrap();
 
         let seqs = subscriber.await.unwrap();
         assert_eq!(seqs, vec![1, 2, 3, 6, 7]);
@@ -393,7 +393,7 @@ mod tests {
 
         let (rx, _) = ingestion_service.subscribe();
         let subscriber = test_subscriber(5, rx).await;
-        let _svc = ingestion_service.run(0.., false).await.unwrap();
+        let _svc = ingestion_service.run(0.., None).await.unwrap();
 
         let seqs = subscriber.await.unwrap();
         assert_eq!(seqs, vec![1, 2, 3, 6, 7]);
@@ -424,7 +424,7 @@ mod tests {
 
         let (rx, _) = ingestion_service.subscribe();
         let subscriber = test_subscriber(5, rx).await;
-        let _svc = ingestion_service.run(0.., false).await.unwrap();
+        let _svc = ingestion_service.run(0.., None).await.unwrap();
 
         // At this point, the service will have been able to pass 3 checkpoints to the non-lagging
         // subscriber, while the laggard's buffer fills up. Now the laggard will pull two

--- a/crates/sui-indexer-alt/src/config.rs
+++ b/crates/sui-indexer-alt/src/config.rs
@@ -54,7 +54,6 @@ pub struct IngestionLayer {
     pub streaming_backoff_max_batch_size: Option<usize>,
     pub streaming_connection_timeout_ms: Option<u64>,
     pub streaming_statement_timeout_ms: Option<u64>,
-    pub checkpoint_channel_size: Option<usize>,
 }
 
 #[DefaultConfig]
@@ -186,9 +185,6 @@ impl IngestionLayer {
             streaming_statement_timeout_ms: self
                 .streaming_statement_timeout_ms
                 .unwrap_or(base.streaming_statement_timeout_ms),
-            checkpoint_channel_size: self
-                .checkpoint_channel_size
-                .unwrap_or(base.checkpoint_channel_size),
         })
     }
 }
@@ -310,9 +306,6 @@ impl Merge for IngestionLayer {
             streaming_statement_timeout_ms: other
                 .streaming_statement_timeout_ms
                 .or(self.streaming_statement_timeout_ms),
-            checkpoint_channel_size: other
-                .checkpoint_channel_size
-                .or(self.checkpoint_channel_size),
         })
     }
 }
@@ -417,7 +410,6 @@ impl From<IngestionConfig> for IngestionLayer {
             streaming_backoff_max_batch_size: Some(config.streaming_backoff_max_batch_size),
             streaming_connection_timeout_ms: Some(config.streaming_connection_timeout_ms),
             streaming_statement_timeout_ms: Some(config.streaming_statement_timeout_ms),
-            checkpoint_channel_size: Some(config.checkpoint_channel_size),
         }
     }
 }

--- a/crates/sui-kvstore/src/config.rs
+++ b/crates/sui-kvstore/src/config.rs
@@ -89,7 +89,6 @@ pub struct IngestionConfig {
     pub streaming_backoff_max_batch_size: usize,
     pub streaming_connection_timeout_ms: u64,
     pub streaming_statement_timeout_ms: u64,
-    pub checkpoint_channel_size: usize,
 }
 
 impl Default for IngestionConfig {
@@ -108,7 +107,6 @@ impl From<framework::ingestion::IngestionConfig> for IngestionConfig {
             streaming_backoff_max_batch_size: config.streaming_backoff_max_batch_size,
             streaming_connection_timeout_ms: config.streaming_connection_timeout_ms,
             streaming_statement_timeout_ms: config.streaming_statement_timeout_ms,
-            checkpoint_channel_size: config.checkpoint_channel_size,
         }
     }
 }
@@ -123,7 +121,6 @@ impl From<IngestionConfig> for framework::ingestion::IngestionConfig {
             streaming_backoff_max_batch_size: config.streaming_backoff_max_batch_size,
             streaming_connection_timeout_ms: config.streaming_connection_timeout_ms,
             streaming_statement_timeout_ms: config.streaming_statement_timeout_ms,
-            checkpoint_channel_size: config.checkpoint_channel_size,
         }
     }
 }

--- a/docs/content/concepts/data-access/pipeline-architecture.mdx
+++ b/docs/content/concepts/data-access/pipeline-architecture.mdx
@@ -256,7 +256,7 @@ Sequential pipelines use two layers of backpressure to prevent memory overflow a
 
 Sequential pipelines use channel-based flow control with a simpler topology due to fewer components:
 
-- **Broadcaster → Processor:** `checkpoint_channel_size` slots (default: 1000).
+- **Broadcaster → Processor:** `checkpoint_buffer_size` slots.
 - **Processor → Committer:** `FANOUT + PIPELINE_BUFFER` slots.
 
 When any channel fills, senders automatically block, creating upstream pressure that cascades back through the pipeline. This mechanism works identically to concurrent pipelines but with fewer channel hops. See [concurrent pipeline backpressure](#concurrent-backpressure) for detailed mechanics of how channel-based blocking propagates.
@@ -418,7 +418,7 @@ The `Handler` is where you implement your indexing business logic. The framework
 ```rust
 trait Processor {
     // Called by Processor workers
-    fn process(&self, checkpoint: &CheckpointData) -> Vec<Self::Value>;
+    async fn process(&self, checkpoint: &Arc<Checkpoint>) -> anyhow::Result<Vec<Self::Value>>;
 }
 
 trait Handler { 
@@ -456,12 +456,10 @@ With the component architecture detailed, let's examine how the pipeline prevent
 
 Each channel has a fixed buffer size that automatically blocks when full:
 
-**`Broadcaster` to `Processor`**: `checkpoint_channel_size` slots (default: 1000) → `Broadcaster` blocks, upstream pressure.
+**`Broadcaster` to `Processor`**: `checkpoint_buffer_size` slots → `Broadcaster` blocks, upstream pressure.
 
-<ImportContent mode="code" source="crates/sui-indexer-alt-framework/src/ingestion/mod.rs" struct="IngestionConfig" highlight="checkpoint_channel_size" />
-
-The per-pipeline channel defaults to 1000 checkpoints. This is independent from `checkpoint_buffer_size`, which controls the lag regulation window. You can tune `checkpoint_channel_size` to control per-pipeline memory usage without affecting how far ahead the ingestion service fetches.
-
+<ImportContent mode="code" source="crates/sui-indexer-alt-framework/src/ingestion/mod.rs" struct="IngestionConfig" highlight="checkpoint_buffer_size" />   
+    
 **`Processor` to `Collector`**: `FANOUT + PIPELINE_BUFFER` slots → All workers block on `send()`.
 
 <ImportContent mode="code" source="crates/sui-indexer-alt-framework/src/pipeline/concurrent/mod.rs" variable="processor_tx" />
@@ -487,12 +485,6 @@ Database connection limits are also in place. The `Committer` blocks when all co
 <ImportContent mode="code" source="crates/sui-indexer-alt-framework/src/ingestion/broadcaster.rs" fun="spawn_aborting" /> 
     
 Finally, memory protection ensures the entire system operates within predictable memory bounds.
-
-:::tip
-
-If your indexer uses only concurrent pipelines, watermark-based regulation is not strictly necessary — concurrent pipelines already have channel-based and row-count backpressure to bound memory. You can set `checkpoint_buffer_size` to a high value to effectively disable regulation, allowing the ingestion service to fetch further ahead and improve throughput during backfills.
-
-:::
 
 #### Backpressure in practice
 
@@ -524,27 +516,52 @@ The following sections detail the configuration settings you can implement for o
 
 #### Concurrent pipeline `Handler` constants
 
-`Handler` constants are the most direct way to tune pipeline behavior. These are implemented as associated constants in your `Handler` trait implementation.
+`Handler` constants are the most direct way to tune pipeline behavior. These are implemented as associated constants in your `Handler` trait implementation and serve as per-handler defaults.
 
 ```rust
 impl concurrent::Handler for MyHandler {
     type Store = Db;
-    
+
     // Number of concurrent processor workers (default: 10)
     const FANOUT: usize = 20;
-    
+
     // Minimum rows to trigger eager commit for committer (default: 50)
     const MIN_EAGER_ROWS: usize = 100;
-    
-    // Backpressure threshold on committer (default: 5000)
+
+    // Backpressure threshold on collector (default: 5000)
     const MAX_PENDING_ROWS: usize = 10000;
-    
+
     // Maximum watermarks per batch (default: 10,000)
     const MAX_WATERMARK_UPDATES: usize = 5000;
 }
 ```
 
-Tuning guidelines: 
+These constants can also be overridden at runtime through `ConcurrentConfig` and `SequentialConfig`, without recompiling. Config values take precedence over trait constants when present. For concurrent pipelines:
+
+```rust
+let config = ConcurrentConfig {
+    committer: committer_config,
+    pruner: Some(pruner_config),
+    fanout: Some(20),
+    min_eager_rows: Some(100),
+    max_pending_rows: Some(10000),
+    max_watermark_updates: Some(5000),
+};
+```
+
+For sequential pipelines:
+
+```rust
+let config = SequentialConfig {
+    committer: committer_config,
+    checkpoint_lag: 0,
+    fanout: Some(20),
+    min_eager_rows: Some(100),
+    max_batch_checkpoints: Some(500),
+};
+```
+
+Tuning guidelines:
 
 - **`FANOUT`:** Increase for CPU-intensive processing, decrease for memory-constrained environments.
 - **`MIN_EAGER_ROWS`:** Lower values reduce data commit latency (individual data appears in database sooner), higher values improve overall throughput (more efficient larger batches).
@@ -560,12 +577,18 @@ let config = ConcurrentConfig {
     committer: CommitterConfig {
         // Number of parallel database writers (default: 5)
         write_concurrency: 10,
-        
+
         // How often collector checks for batches in ms (default: 500)
         collect_interval_ms: 250,
-        
+
         // How often watermarks are updated in ms (default: 500)
         watermark_interval_ms: 1000,
+
+        // Maximum random jitter added to watermark interval in ms (default: 0)
+        watermark_interval_jitter_ms: 100,
+
+        // Cap write throughput in rows/sec per pipeline (default: None = unlimited)
+        max_rows_per_second: Some(5000),
     },
     pruner: Some(pruner_config),
 };
@@ -576,6 +599,7 @@ Tuning guidelines:
 - **`write_concurrency`:** Higher values result in faster throughput but more database connections; `ensure total_pipelines × write_concurrency < db_connection_pool_size`.
 - **`collect_interval_ms`:** Lower values reduce latency but increase CPU overhead.
 - **`watermark_interval_ms`:** Controls how often watermarks are updated. Higher values reduce database contention from frequent watermark writes but make the indexer slower to respond to pipeline progress.
+- **`max_rows_per_second`:** Caps the combined write rate across all `write_concurrency` workers for this pipeline. Useful during backfills to prevent the indexer from overwhelming the database. The limit uses a smooth (GCRA) rate limiter so writes are spread evenly rather than bursting. Set to `None` (the default) for unlimited throughput.
 
 #### `PrunerConfig` settings
 


### PR DESCRIPTION
## Description

I find it kind of hard to reason about the memory consumption and throughput consequences of checkpoint-buffer-size since it controls both the lag between the slowest and fastest pipeline _and_ the size of the ingestion channel. I find it much easier to set it to infinity, then a set a reasonably small ingestion channel size, and cap memory usage via the new row counter.
