### PR TITLE
allow custom natives in dependents of sui-move and sui-execution

### DIFF
--- a/crates/sui-framework-tests/tests/move_tests.rs
+++ b/crates/sui-framework-tests/tests/move_tests.rs
@@ -7,7 +7,7 @@ use move_cli::base::test::UnitTestResult;
 use move_package_alt_compilation::lint_flag::LintFlag;
 use move_unit_test::UnitTestingConfig;
 use sui_framework_tests::setup_examples;
-use sui_move::unit_test::{MAX_UNIT_TEST_INSTRUCTIONS, run_move_unit_tests};
+use sui_move::unit_test::{MAX_UNIT_TEST_INSTRUCTIONS, SuiVMTestSetup, run_move_unit_tests};
 use sui_move_build::BuildConfig;
 use sui_package_alt::SuiFlavor;
 
@@ -88,7 +88,8 @@ pub(crate) async fn tests(path: &Path) -> datatest_stable::Result<()> {
             Some(testing_config),
             false,
             false,
-            SuiFlavor::new()
+            SuiFlavor::new(),
+            SuiVMTestSetup::new(),
         )
         .await
         .unwrap(),

--- a/crates/sui-move/src/lib.rs
+++ b/crates/sui-move/src/lib.rs
@@ -1,12 +1,15 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::path::Path;
+
 use clap::Parser;
 use move_cli::base::test::UnitTestResult;
 use move_package_alt_compilation::build_config::BuildConfig;
-use std::path::Path;
 use sui_package_alt::SuiFlavor;
 use sui_sdk::wallet_context::WalletContext;
+
+use crate::unit_test::SuiVMTestSetup;
 
 pub mod build;
 pub mod cache_package;
@@ -71,7 +74,13 @@ pub async fn execute_move_command(
         }
         Command::Test(c) => {
             let result = c
-                .execute(package_path, build_config, wallet, flavor)
+                .execute(
+                    package_path,
+                    build_config,
+                    wallet,
+                    flavor,
+                    SuiVMTestSetup::new(),
+                )
                 .await?;
 
             // Return a non-zero exit code if any test failed

--- a/crates/sui-move/src/unit_test.rs
+++ b/crates/sui-move/src/unit_test.rs
@@ -1,6 +1,15 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::{
+    cell::RefCell,
+    collections::BTreeMap,
+    ops::{Deref, DerefMut},
+    path::Path,
+    rc::Rc,
+    sync::{Arc, LazyLock},
+};
+
 use clap::Parser;
 use move_cli::base::{
     self,
@@ -9,14 +18,8 @@ use move_cli::base::{
 use move_package_alt_compilation::build_config::BuildConfig;
 use move_unit_test::{UnitTestingConfig, vm_test_setup::VMTestSetup};
 use move_vm_config::runtime::VMConfig;
-use move_vm_runtime::natives::extensions::NativeContextExtensions;
-use std::{
-    cell::RefCell,
-    collections::BTreeMap,
-    ops::{Deref, DerefMut},
-    path::Path,
-    rc::Rc,
-    sync::{Arc, LazyLock},
+use move_vm_runtime::natives::{
+    extensions::NativeContextExtensions, functions::NativeFunctionTable,
 };
 use sui_adapter::gas_meter::SuiGasMeter;
 use sui_move_build::decorate_warnings;
@@ -57,6 +60,7 @@ impl Test {
         mut build_config: BuildConfig,
         wallet: &WalletContext,
         flavor: SuiFlavor,
+        vm_test_setup: SuiVMTestSetup,
     ) -> anyhow::Result<UnitTestResult> {
         let compute_coverage = self.test.compute_coverage;
         if !cfg!(feature = "tracing") && compute_coverage {
@@ -96,6 +100,7 @@ impl Test {
             compute_coverage,
             save_disassembly,
             flavor,
+            vm_test_setup,
         )
         .await
     }
@@ -110,6 +115,7 @@ pub async fn run_move_unit_tests(
     compute_coverage: bool,
     save_disassembly: bool,
     flavor: SuiFlavor,
+    vm_test_setup: SuiVMTestSetup,
 ) -> anyhow::Result<UnitTestResult> {
     let config = config.unwrap_or_else(|| {
         UnitTestingConfig::default_with_bound(Some(*MAX_UNIT_TEST_INSTRUCTIONS))
@@ -123,7 +129,7 @@ pub async fn run_move_unit_tests(
             ..config
         },
         flavor,
-        SuiVMTestSetup::new(),
+        vm_test_setup,
         compute_coverage,
         save_disassembly,
         &mut std::io::stdout(),
@@ -158,6 +164,16 @@ impl SuiVMTestSetup {
         let protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
         let native_function_table =
             sui_move_natives::all_natives(/* silent */ false, &protocol_config);
+        Self {
+            gas_price: TEST_GAS_PRICE,
+            reference_gas_price: TEST_GAS_PRICE,
+            protocol_config,
+            native_function_table,
+        }
+    }
+
+    pub fn new_with_custom_natives(native_function_table: NativeFunctionTable) -> Self {
+        let protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
         Self {
             gas_price: TEST_GAS_PRICE,
             reference_gas_price: TEST_GAS_PRICE,

--- a/external-crates/move/crates/move-vm-runtime/src/execution/tracing/tracer.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/execution/tracing/tracer.rs
@@ -51,16 +51,66 @@ pub(crate) struct VMTracer<'a> {
 }
 
 #[derive(Debug, Clone)]
-pub(crate) enum GlobalValue {
-    // Currently loaded into a local
-    InLocal(TraceIndex, usize),
-    // Value loaded from a native function, or a value that was passed in externally (and may be
-    // passed back out).
-    Value(TraceValue),
-    // (ephemeral) Currently on the stack, but we don't have a snapshot of the value but the value is at offset
-    // `usize`. This is used when moving from a local to a stack value. We should always reify back
-    // to a value or or in local state.
-    AtStackOffset(usize),
+pub(crate) struct GlobalValue {
+    snapshot: TraceValue,
+    locations: Vec<GlobalLocation>,
+}
+
+/// A live place where a loaded global value can currently be read by the tracer.
+///
+/// `GlobalValue` keeps one stable fallback snapshot plus a stack of live locations. The newest
+/// location is active; if the stack is empty, the snapshot is used. Locals are pushed as references
+/// to globals flow through frames and are popped/removed before those locals become unreadable. When
+/// a local is moved to the operand stack, it is temporarily represented by `StackOffset` only long
+/// enough to snapshot the stack value, then the fallback snapshot is updated and the temporary
+/// location is removed.
+#[derive(Debug, Clone)]
+pub(crate) enum GlobalLocation {
+    // Currently loaded into a local.
+    Local(TraceIndex, usize),
+    // Ephemeral location used while reifying a moved local into the fallback snapshot.
+    StackOffset(usize),
+}
+
+impl GlobalValue {
+    // Start with a stable snapshot of the loaded global value.
+    fn new(snapshot: TraceValue) -> Self {
+        Self {
+            snapshot,
+            locations: vec![],
+        }
+    }
+
+    // Record that the current active copy of this global is held by a local.
+    // Track each same-frame local separately; moving one local must not hide another live alias.
+    fn push_local(&mut self, frame_identifier: TraceIndex, local_index: usize) {
+        if matches!(self.locations.last(), Some(GlobalLocation::Local(fidx, lidx)) if *fidx == frame_identifier && *lidx == local_index)
+        {
+            return;
+        }
+        self.locations
+            .push(GlobalLocation::Local(frame_identifier, local_index));
+    }
+
+    // Drop locations owned by an exiting frame so older caller locations or the snapshot become active.
+    fn remove_frame_locations(&mut self, frame_identifier: TraceIndex) {
+        while matches!(self.locations.last(), Some(GlobalLocation::Local(fidx, _)) if *fidx == frame_identifier)
+        {
+            self.locations.pop();
+        }
+    }
+
+    // Drop locations for a local that is being moved from or overwritten.
+    fn remove_local_locations(&mut self, frame_identifier: TraceIndex, local_index: usize) {
+        self.locations.retain(|location| {
+            !matches!(location, GlobalLocation::Local(fidx, lidx) if *fidx == frame_identifier && *lidx == local_index)
+        });
+    }
+
+    // The newest live location is active; otherwise the fallback snapshot is used.
+    fn last_location(&self) -> Option<GlobalLocation> {
+        self.locations.last().cloned()
+    }
 }
 
 /// Information about a frame that we keep during trace building
@@ -246,6 +296,22 @@ impl VMTracer<'_> {
         Some(self.current_frame()?.frame_identifier)
     }
 
+    fn remove_global_locations_for_frame(&mut self, frame_identifier: TraceIndex) {
+        for global in self.loaded_data.values_mut() {
+            global.remove_frame_locations(frame_identifier);
+        }
+    }
+
+    fn remove_global_locations_for_local(
+        &mut self,
+        frame_identifier: TraceIndex,
+        local_index: usize,
+    ) {
+        for global in self.loaded_data.values_mut() {
+            global.remove_local_locations(frame_identifier, local_index);
+        }
+    }
+
     /// Given the trace index for a frame, return the index of the frame in the call stack.
     fn trace_index_to_frame_index(&self, idx: TraceIndex) -> Option<usize> {
         self.active_frames
@@ -292,7 +358,7 @@ impl VMTracer<'_> {
                 local.ref_type = ReferenceKind::Empty {
                     ref_type: ref_type.clone(),
                 };
-                self.record_global_push(vtables, machine, &location)?;
+                self.record_global_push(vtables, machine, &location, local_index)?;
             }
             ReferenceKind::Empty { .. } => (),
             ReferenceKind::Value => (),
@@ -306,32 +372,34 @@ impl VMTracer<'_> {
         vtables: &VMDispatchTables,
         machine: &MachineState,
         location: &RuntimeLocation,
+        local_index: usize,
     ) -> Option<()> {
         let RuntimeLocation::Global(idx) = location else {
             return Some(());
         };
         let current_frame_identifier = self.current_frame_identifier()?;
-        let global = self.loaded_data.get_mut(idx)?;
-
-        // This was an alias to a local reference further up the call stack -- do nothing.
-        if let GlobalValue::InLocal(fidx, _) = global
-            && current_frame_identifier != *fidx
-        {
+        let location_index = self
+            .loaded_data
+            .get(idx)?
+            .locations
+            .iter()
+            .rposition(|location| {
+                matches!(location, GlobalLocation::Local(fidx, lidx) if *fidx == current_frame_identifier && *lidx == local_index)
+            });
+        let Some(location_index) = location_index else {
             return Some(());
-        }
-
-        let new_state = GlobalValue::AtStackOffset(machine.operand_stack.value.len() - 1);
-        let GlobalValue::InLocal(..) = std::mem::replace(global, new_state) else {
-            // We are pushing a global that was not in a local, this is not fine.
-            return None;
         };
+
+        self.loaded_data.get_mut(idx)?.locations[location_index] =
+            GlobalLocation::StackOffset(machine.operand_stack.value.len() - 1);
         let v = self.resolve_stack_value(vtables, machine, 0)?;
-        let new_state = GlobalValue::Value(v);
         let global = self.loaded_data.get_mut(idx)?;
-        let GlobalValue::AtStackOffset(..) = std::mem::replace(global, new_state) else {
+        let Some(GlobalLocation::StackOffset(_)) = global.locations.get(location_index) else {
             // Better be what we just set it to earlier...
             return None;
         };
+        global.snapshot = v;
+        global.locations.remove(location_index);
 
         Some(())
     }
@@ -400,18 +468,8 @@ impl VMTracer<'_> {
         local_index: usize,
         global_index: TraceIndex,
     ) -> Option<()> {
-        let location = GlobalValue::InLocal(frame_identifier, local_index);
         let global = self.loaded_data.get_mut(&global_index)?;
-        match global {
-            // Keep aliasing all the way back to the root.
-            // Basically this is the case where we've already rooted the global reference into a
-            // local higher up, so we don't update the root -- it's rooted in a local, and we should keep it
-            // there and that's where we should look for state updates.
-            GlobalValue::InLocal(_, _) => (),
-            // If it's not a root then set the location to be a local root
-            GlobalValue::Value(_) | GlobalValue::AtStackOffset(_) => *global = location,
-        }
-
+        global.push_local(frame_identifier, local_index);
         Some(())
     }
 
@@ -432,6 +490,42 @@ impl VMTracer<'_> {
                 ref_type: Some((_, RuntimeLocation::Global(idx))),
             } => self.record_global_store(frame_identifier, local_index, *idx),
             _ => Some(()),
+        }
+    }
+
+    fn resolve_global_location(
+        &self,
+        vtables: &VMDispatchTables,
+        machine: &MachineState,
+        id: TraceIndex,
+    ) -> Option<TraceValue> {
+        let global = self.loaded_data.get(&id)?;
+        match global.last_location() {
+            Some(GlobalLocation::Local(fidx, lidx)) => {
+                self.resolve_location(vtables, machine, &RuntimeLocation::Local(fidx, lidx))
+            }
+            Some(GlobalLocation::StackOffset(idx)) => {
+                self.resolve_location(vtables, machine, &RuntimeLocation::Stack(idx))
+            }
+            None => Some(global.snapshot.clone()),
+        }
+    }
+
+    fn global_root_location_snapshot(
+        &self,
+        vtables: &VMDispatchTables,
+        machine: &MachineState,
+        id: TraceIndex,
+    ) -> Option<SerializableMoveValue> {
+        let global = self.loaded_data.get(&id)?;
+        match global.last_location() {
+            Some(GlobalLocation::Local(fidx, lidx)) => {
+                self.root_location_snapshot(vtables, machine, &RuntimeLocation::Local(fidx, lidx))
+            }
+            Some(GlobalLocation::StackOffset(idx)) => {
+                self.root_location_snapshot(vtables, machine, &RuntimeLocation::Stack(idx))
+            }
+            None => Some(global.snapshot.snapshot().clone()),
         }
     }
 
@@ -474,15 +568,7 @@ impl VMTracer<'_> {
             RuntimeLocation::Indexed(location, _) => {
                 self.resolve_location(vtables, machine, location)
             }
-            RuntimeLocation::Global(id) => match &self.loaded_data.get(id)? {
-                GlobalValue::InLocal(fidx, lidx) => {
-                    self.resolve_location(vtables, machine, &RuntimeLocation::Local(*fidx, *lidx))
-                }
-                GlobalValue::Value(trace_value) => Some(trace_value.clone()),
-                GlobalValue::AtStackOffset(idx) => {
-                    self.resolve_location(vtables, machine, &RuntimeLocation::Stack(*idx))
-                }
-            },
+            RuntimeLocation::Global(id) => self.resolve_global_location(vtables, machine, *id),
         }
     }
 
@@ -543,17 +629,9 @@ impl VMTracer<'_> {
             RuntimeLocation::Indexed(loc, _) => {
                 self.root_location_snapshot(vtables, machine, loc)?
             }
-            RuntimeLocation::Global(id) => match &self.loaded_data.get(id)? {
-                GlobalValue::InLocal(fidx, lidx) => self.root_location_snapshot(
-                    vtables,
-                    machine,
-                    &RuntimeLocation::Local(*fidx, *lidx),
-                )?,
-                GlobalValue::Value(trace_value) => Some(trace_value.snapshot().clone())?,
-                GlobalValue::AtStackOffset(idx) => {
-                    self.root_location_snapshot(vtables, machine, &RuntimeLocation::Stack(*idx))?
-                }
-            },
+            RuntimeLocation::Global(id) => {
+                self.global_root_location_snapshot(vtables, machine, *id)?
+            }
         })
     }
 
@@ -605,7 +683,7 @@ impl VMTracer<'_> {
         let (trace_index, trace_value) = self.emit_data_load(value, ref_type)?;
 
         self.loaded_data
-            .insert(trace_index, GlobalValue::Value(trace_value));
+            .insert(trace_index, GlobalValue::new(trace_value));
         Some((ref_type.clone(), RuntimeLocation::Global(trace_index)))
     }
 
@@ -657,7 +735,7 @@ impl VMTracer<'_> {
                     Some(ref_type) => {
                         let (id, trace_value) = self.emit_data_load(move_value, &ref_type)?;
                         self.loaded_data
-                            .insert(id, GlobalValue::Value(trace_value.clone()));
+                            .insert(id, GlobalValue::new(trace_value.clone()));
                         Some((trace_value, Some(id)))
                     }
                     None => Some((TraceValue::RuntimeValue { value: move_value }, None)),
@@ -748,18 +826,17 @@ impl VMTracer<'_> {
                     Some(ref_type) => {
                         let (id, trace_value) = self.emit_data_load(move_value, &ref_type)?;
                         self.loaded_data
-                            .insert(id, GlobalValue::Value(trace_value.clone()));
+                            .insert(id, GlobalValue::new(trace_value.clone()));
                         Some(trace_value)
                     }
                     None => Some(TraceValue::RuntimeValue { value: move_value }),
                 }
             })
             .collect::<Option<_>>()?;
-        self.trace.close_frame(
-            self.current_frame_identifier()?,
-            return_values,
-            *remaining_gas,
-        );
+        let frame_identifier = self.current_frame_identifier()?;
+        self.trace
+            .close_frame(frame_identifier, return_values, *remaining_gas);
+        self.remove_global_locations_for_frame(frame_identifier);
         let last_frame_opt = self.active_frames.pop_last();
         self.trace_assert(last_frame_opt.is_some(), "Unbalanced frame close");
         Some(())
@@ -775,7 +852,10 @@ impl VMTracer<'_> {
     ) -> Option<()> {
         let new_frame_idx = self.trace.current_trace_offset();
 
-        let call_args = (0..function.arg_count())
+        let type_stack_len = self.type_stack.len();
+        let arg_count = function.arg_count();
+        let arg_start = type_stack_len.checked_sub(arg_count)?;
+        let call_args = (0..arg_count)
             .rev()
             .enumerate()
             .map(|(local_idx, stack_idx)| {
@@ -785,11 +865,10 @@ impl VMTracer<'_> {
                 self.store_global(machine, new_frame_idx, stack_idx, local_idx)?;
                 Some(val)
             })
-            .collect::<Option<Vec<_>>>()?;
+            .collect::<Option<Vec<_>>>();
 
-        let call_args_types = self
-            .type_stack
-            .split_off(self.type_stack.len() - function.arg_count());
+        let call_args_types = self.type_stack.split_off(arg_start);
+        let call_args = call_args?;
         let function_type_info = FunctionTypeInfo::new(vtables, function, ty_args)?;
 
         let locals_types = function_type_info
@@ -887,11 +966,10 @@ impl VMTracer<'_> {
             }
         }
 
-        self.trace.close_frame(
-            self.current_frame_identifier()?,
-            return_values,
-            *remaining_gas,
-        );
+        let frame_identifier = self.current_frame_identifier()?;
+        self.trace
+            .close_frame(frame_identifier, return_values, *remaining_gas);
+        self.remove_global_locations_for_frame(frame_identifier);
         let last_frame_opt = self.active_frames.pop_last();
         self.trace_assert(last_frame_opt.is_some(), "Unbalanced frame close");
         Some(())
@@ -929,12 +1007,9 @@ impl VMTracer<'_> {
                 // StLoc: still need store_global and insert_local side effects.
                 B::StLoc(lidx) => {
                     let ty = self.type_stack.last()?.clone();
-                    self.store_global(
-                        machine,
-                        self.current_frame_identifier()?,
-                        0,
-                        *lidx as usize,
-                    )?;
+                    let frame_identifier = self.current_frame_identifier()?;
+                    self.remove_global_locations_for_local(frame_identifier, *lidx as usize);
+                    self.store_global(machine, frame_identifier, 0, *lidx as usize)?;
                     self.insert_local(*lidx as usize, ty)?;
                 }
                 // VecImmBorrow/VecMutBorrow: capture just the u64 index (trivially cheap) since
@@ -1052,10 +1127,12 @@ impl VMTracer<'_> {
                 }
             }
             B::StLoc(lidx) => {
-                let ty = self.type_stack.last()?.clone();
-                self.store_global(machine, self.current_frame_identifier()?, 0, *lidx as usize)?;
-                self.insert_local(*lidx as usize, ty)?;
                 emit_pre_effect!(EF::Pop(self.resolve_stack_value(vtables, machine, 0)?));
+                let ty = self.type_stack.last()?.clone();
+                let frame_identifier = self.current_frame_identifier()?;
+                self.remove_global_locations_for_local(frame_identifier, *lidx as usize);
+                self.store_global(machine, frame_identifier, 0, *lidx as usize)?;
+                self.insert_local(*lidx as usize, ty)?;
             }
             B::ImmBorrowLoc(l_idx) | B::MutBorrowLoc(l_idx) => {
                 emit_pre_effect! {

--- a/sui-execution/Cargo.toml
+++ b/sui-execution/Cargo.toml
@@ -83,3 +83,4 @@ tracing = [
 #   "move-vm-runtime-$CUT/tracing",
     "move-vm-config/tracing",
 ]
+custom-natives = []

--- a/sui-execution/src/custom_natives.rs
+++ b/sui-execution/src/custom_natives.rs
@@ -1,0 +1,41 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Custom native functions support for the latest execution version.
+//!
+//! This module is only available when the `custom-natives` feature is enabled.
+
+use std::sync::Arc;
+
+use sui_protocol_config::ProtocolConfig;
+use sui_types::error::SuiResult;
+
+use crate::Executor;
+use crate::latest;
+
+pub use move_vm_runtime_latest::natives::functions::{NativeFunction, NativeFunctionTable};
+pub use sui_move_natives_latest::{all_natives, make_native};
+
+/// Create an executor with custom native functions for the latest execution version (4).
+///
+/// This is useful for e.g. research projects that use the `sui-execution` crate but require
+/// additional or different native functions. Only protocol configs with execution version 4
+/// are supported; for earlier versions this function panics.
+pub fn latest_executor_with_custom_natives(
+    protocol_config: &ProtocolConfig,
+    silent: bool,
+    native_functions: NativeFunctionTable,
+) -> SuiResult<Arc<dyn Executor + Send + Sync>> {
+    let version = protocol_config.execution_version_as_option().unwrap_or(0);
+    Ok(match version {
+        0..=3 => {
+            panic!("Custom native functions are not supported for execution versions before 4")
+        }
+        4 => Arc::new(latest::Executor::new_with_custom_natives(
+            protocol_config,
+            silent,
+            native_functions,
+        )?),
+        v => panic!("Unsupported execution version {v}"),
+    })
+}

--- a/sui-execution/src/latest.rs
+++ b/sui-execution/src/latest.rs
@@ -1,45 +1,44 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use move_binary_format::CompiledModule;
-use move_trace_format::format::MoveTraceBuilder;
-use move_vm_config::verifier::{MeterConfig, VerifierConfig};
 use std::collections::BTreeMap;
 use std::{cell::RefCell, rc::Rc, sync::Arc};
+
+use move_binary_format::CompiledModule;
+use move_bytecode_verifier_meter::Meter;
+use move_trace_format::format::MoveTraceBuilder;
+use move_vm_config::verifier::{MeterConfig, VerifierConfig};
+#[cfg(feature = "custom-natives")]
+use move_vm_runtime_latest::natives::functions::NativeFunctionTable;
+use move_vm_runtime_latest::runtime::MoveRuntime;
+use mysten_common::debug_fatal;
+use sui_adapter_latest::{
+    adapter::{new_move_runtime, run_metered_move_bytecode_verifier},
+    execution_engine::{execute_genesis_state_update, execute_transaction_to_effects},
+    execution_mode,
+    type_layout_resolver::TypeLayoutResolver,
+};
+use sui_move_natives_latest::all_natives;
 use sui_protocol_config::ProtocolConfig;
-use sui_types::execution::ExecutionTiming;
-use sui_types::execution_params::ExecutionOrEarlyError;
-use sui_types::transaction::GasData;
 use sui_types::{
     base_types::{ObjectID, SequenceNumber, SuiAddress, TxContext},
     committee::EpochId,
     digests::TransactionDigest,
     effects::TransactionEffects,
     error::{ExecutionError, ExecutionErrorTrait, SuiError, SuiResult},
-    execution::{ExecutionResult, TypeLayoutStore},
+    execution::{ExecutionResult, ExecutionTiming, TypeLayoutStore},
+    execution_params::ExecutionOrEarlyError,
     execution_status::ExecutionFailure,
     gas::SuiGasStatus,
     inner_temporary_store::InnerTemporaryStore,
     layout_resolver::LayoutResolver,
     metrics::{BytecodeVerifierMetrics, ExecutionMetrics},
-    transaction::{CheckedInputObjects, ProgrammableTransaction, TransactionKind},
+    storage::BackingStore,
+    transaction::{CheckedInputObjects, GasData, ProgrammableTransaction, TransactionKind},
 };
-
-use move_bytecode_verifier_meter::Meter;
-use move_vm_runtime_latest::runtime::MoveRuntime;
-use mysten_common::debug_fatal;
-use sui_adapter_latest::adapter::{new_move_runtime, run_metered_move_bytecode_verifier};
-use sui_adapter_latest::execution_engine::{
-    execute_genesis_state_update, execute_transaction_to_effects,
-};
-use sui_adapter_latest::type_layout_resolver::TypeLayoutResolver;
-use sui_move_natives_latest::all_natives;
-use sui_types::storage::BackingStore;
 use sui_verifier_latest::meter::SuiVerifierMeter;
 
-use crate::executor;
-use crate::verifier;
-use sui_adapter_latest::execution_mode;
+use crate::{executor, verifier};
 
 pub(crate) struct Executor(Arc<MoveRuntime>);
 
@@ -52,6 +51,18 @@ impl Executor {
     pub(crate) fn new(protocol_config: &ProtocolConfig, silent: bool) -> Result<Self, SuiError> {
         Ok(Executor(Arc::new(new_move_runtime(
             all_natives(silent, protocol_config),
+            protocol_config,
+        )?)))
+    }
+
+    #[cfg(feature = "custom-natives")]
+    pub(crate) fn new_with_custom_natives(
+        protocol_config: &ProtocolConfig,
+        _silent: bool,
+        native_functions: NativeFunctionTable,
+    ) -> Result<Self, SuiError> {
+        Ok(Executor(Arc::new(new_move_runtime(
+            native_functions,
             protocol_config,
         )?)))
     }

--- a/sui-execution/src/lib.rs
+++ b/sui-execution/src/lib.rs
@@ -14,6 +14,9 @@ pub use verifier::Verifier;
 pub mod executor;
 pub mod verifier;
 
+#[cfg(feature = "custom-natives")]
+pub mod custom_natives;
+
 mod latest;
 mod v0;
 mod v1;

--- a/sui-execution/src/lib.template.rs
+++ b/sui-execution/src/lib.template.rs
@@ -14,6 +14,9 @@ pub use verifier::Verifier;
 pub mod executor;
 pub mod verifier;
 
+#[cfg(feature = "custom-natives")]
+pub mod custom_natives;
+
 // $MOD_CUTS
 
 #[cfg(test)]


### PR DESCRIPTION
## Description 

This PR exposes APIs to create an executor with custom native functions and allows to easily construct a tool to run move tests with custom native functions. We want to make use of this for research projects, where we need to use the `sui-execution` crate (but don't want to fork the full codebase) and require additional or different native functions.

I've put the new interface behind a feature flag in `sui-execution` to make it obvious that it is not a standard interface that should be used, but happy to change that.

## Test plan 

Existing tests. The PR does not change any functionality, just exposes additional interfaces.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
