### PR TITLE
[move][move-compiler] More VM hardening

### DIFF
--- a/external-crates/move/crates/move-vm-runtime/src/cache/arena.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/cache/arena.rs
@@ -55,8 +55,8 @@ impl ArenaBuilder {
         &self,
         items: impl ExactSizeIterator<Item = T>,
     ) -> PartialVMResult<ArenaVec<T>> {
-        let size = items.len();
         if let Ok(slice) = self.0.try_alloc_slice_fill_iter(items) {
+            let size = slice.len();
             Ok(ArenaVec(unsafe {
                 std::mem::ManuallyDrop::new(Vec::from_raw_parts(slice.as_mut_ptr(), size, size))
             }))

--- a/external-crates/move/crates/move-vm-runtime/src/jit/execution/translate.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/jit/execution/translate.rs
@@ -1224,16 +1224,7 @@ pub(crate) fn flatten_and_renumber_input_bytcode_and_jumptables(
             )
         })?;
 
-        current_offset = current_offset
-            .checked_add(bytecode_len_u16)
-            .ok_or_else(|| {
-                partial_vm_error!(
-                    UNKNOWN_INVARIANT_VIOLATION_ERROR,
-                    "Bytecode offset overflow: {} + {} exceeds u16::MAX",
-                    current_offset,
-                    bytecode_len_u16
-                )
-            })?;
+        current_offset = current_offset.safe_add(bytecode_len_u16)?;
 
         concatenated_bytecode.extend_from_slice(bytecodes);
     }

--- a/external-crates/move/crates/move-vm-runtime/src/natives/functions.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/natives/functions.rs
@@ -313,6 +313,9 @@ impl<'b> NativeContext<'_, 'b, '_> {
         self.gas_budget
     }
 
+    /// SAFETY: Uses `RefCell::borrow()` rather than `try_borrow()` because `gas_left` is only
+    /// mutably borrowed during `charge_gas`, which always drops its `RefMut` before returning.
+    /// This function is only called after charging completes, so no concurrent borrow is possible.
     pub fn gas_used(&self) -> InternalGas {
         self.gas_budget.saturating_sub(*self.gas_left.borrow())
     }


### PR DESCRIPTION
## Description 

Hardening fixes for the Move VM runtime identified during a security audit of the bella-ciao branch. These changes fix a gas metering issue for strings, remove potential panics from RefCell::borrow(), swap many `checked_add` calls for `safe_add`, and handle an unsafe length computation.

## Test plan 

Tests all still pass.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
