### PR TITLE
Use single validator in RPC tests

### DIFF
--- a/crates/sui-e2e-tests/tests/rpc/client.rs
+++ b/crates/sui-e2e-tests/tests/rpc/client.rs
@@ -15,7 +15,10 @@ use test_cluster::TestClusterBuilder;
 
 #[sim_test]
 async fn get_object() {
-    let test_cluster = TestClusterBuilder::new().build().await;
+    let test_cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
 
     let id: Address = "0x5".parse().unwrap();
 
@@ -31,7 +34,10 @@ async fn get_object() {
 
 #[sim_test]
 async fn execute_transaction_transfer() {
-    let test_cluster = TestClusterBuilder::new().build().await;
+    let test_cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
 
     let mut client = Client::new(test_cluster.rpc_url()).unwrap();
     let address = SuiAddress::random_for_testing_only();
@@ -71,7 +77,10 @@ async fn execute_transaction_transfer() {
 
 #[sim_test]
 async fn get_full_checkpoint() {
-    let test_cluster = TestClusterBuilder::new().build().await;
+    let test_cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
 
     let _transaction_digest = transfer_coin(&test_cluster.wallet).await;
 
@@ -91,7 +100,10 @@ async fn get_checkpoint_artifacts() {
         return;
     }
 
-    let test_cluster = TestClusterBuilder::new().build().await;
+    let test_cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
 
     // Send a tx just to make sure a few checkpoints are created
     let _transaction_digest = transfer_coin(&test_cluster.wallet).await;

--- a/crates/sui-e2e-tests/tests/rpc/v2/ledger_service/get_checkpoint.rs
+++ b/crates/sui-e2e-tests/tests/rpc/v2/ledger_service/get_checkpoint.rs
@@ -15,6 +15,7 @@ use crate::{stake_with_validator, transfer_coin};
 #[sim_test]
 async fn get_checkpoint() {
     let test_cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
         .disable_fullnode_pruning()
         .build()
         .await;

--- a/crates/sui-e2e-tests/tests/rpc/v2/ledger_service/get_epoch.rs
+++ b/crates/sui-e2e-tests/tests/rpc/v2/ledger_service/get_epoch.rs
@@ -10,7 +10,10 @@ use test_cluster::TestClusterBuilder;
 
 #[sim_test]
 async fn get_epoch() {
-    let test_cluster = TestClusterBuilder::new().build().await;
+    let test_cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
 
     let mut client = LedgerServiceClient::connect(test_cluster.rpc_url().to_owned())
         .await

--- a/crates/sui-e2e-tests/tests/rpc/v2/ledger_service/get_object.rs
+++ b/crates/sui-e2e-tests/tests/rpc/v2/ledger_service/get_object.rs
@@ -14,7 +14,10 @@ use test_cluster::TestClusterBuilder;
 
 #[sim_test]
 async fn get_object() {
-    let test_cluster = TestClusterBuilder::new().build().await;
+    let test_cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
 
     let id: Address = "0x5".parse().unwrap();
 
@@ -152,7 +155,10 @@ async fn get_object() {
 
 #[sim_test]
 async fn batch_get_objects() {
-    let test_cluster = TestClusterBuilder::new().build().await;
+    let test_cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
 
     let mut client = LedgerServiceClient::connect(test_cluster.rpc_url().to_owned())
         .await

--- a/crates/sui-e2e-tests/tests/rpc/v2/ledger_service/get_service_info.rs
+++ b/crates/sui-e2e-tests/tests/rpc/v2/ledger_service/get_service_info.rs
@@ -9,7 +9,10 @@ use test_cluster::TestClusterBuilder;
 
 #[sim_test]
 async fn get_service_info() {
-    let test_cluster = TestClusterBuilder::new().build().await;
+    let test_cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
 
     let mut grpc_client = LedgerServiceClient::connect(test_cluster.rpc_url().to_owned())
         .await

--- a/crates/sui-e2e-tests/tests/rpc/v2/ledger_service/get_transaction.rs
+++ b/crates/sui-e2e-tests/tests/rpc/v2/ledger_service/get_transaction.rs
@@ -11,7 +11,10 @@ use test_cluster::TestClusterBuilder;
 
 #[sim_test]
 async fn get_transaction() {
-    let test_cluster = TestClusterBuilder::new().build().await;
+    let test_cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
 
     let transaction_digest = stake_with_validator(&test_cluster).await;
 

--- a/crates/sui-e2e-tests/tests/rpc/v2/move_package_service/get_datatype.rs
+++ b/crates/sui-e2e-tests/tests/rpc/v2/move_package_service/get_datatype.rs
@@ -11,7 +11,10 @@ use sui_macros::sim_test;
 
 #[sim_test]
 async fn test_get_struct_datatype() {
-    let cluster = TestClusterBuilder::new().build().await;
+    let cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
 
     let mut service = MovePackageServiceClient::connect(cluster.rpc_url().to_owned())
         .await
@@ -30,7 +33,10 @@ async fn test_get_struct_datatype() {
 
 #[sim_test]
 async fn test_get_datatype_not_found() {
-    let cluster = TestClusterBuilder::new().build().await;
+    let cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
 
     let mut service = MovePackageServiceClient::connect(cluster.rpc_url().to_owned())
         .await
@@ -53,7 +59,10 @@ async fn test_get_datatype_not_found() {
 
 #[sim_test]
 async fn test_get_datatype_invalid_package() {
-    let cluster = TestClusterBuilder::new().build().await;
+    let cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
 
     let mut service = MovePackageServiceClient::connect(cluster.rpc_url().to_owned())
         .await
@@ -72,7 +81,10 @@ async fn test_get_datatype_invalid_package() {
 
 #[sim_test]
 async fn test_get_datatype_module_not_found() {
-    let cluster = TestClusterBuilder::new().build().await;
+    let cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
 
     let mut service = MovePackageServiceClient::connect(cluster.rpc_url().to_owned())
         .await
@@ -91,7 +103,10 @@ async fn test_get_datatype_module_not_found() {
 
 #[sim_test]
 async fn test_get_datatype_missing_package_id() {
-    let cluster = TestClusterBuilder::new().build().await;
+    let cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
 
     let mut service = MovePackageServiceClient::connect(cluster.rpc_url().to_owned())
         .await
@@ -109,7 +124,10 @@ async fn test_get_datatype_missing_package_id() {
 
 #[sim_test]
 async fn test_get_datatype_missing_module_name() {
-    let cluster = TestClusterBuilder::new().build().await;
+    let cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
 
     let mut service = MovePackageServiceClient::connect(cluster.rpc_url().to_owned())
         .await
@@ -127,7 +145,10 @@ async fn test_get_datatype_missing_module_name() {
 
 #[sim_test]
 async fn test_get_datatype_missing_name() {
-    let cluster = TestClusterBuilder::new().build().await;
+    let cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
 
     let mut service = MovePackageServiceClient::connect(cluster.rpc_url().to_owned())
         .await

--- a/crates/sui-e2e-tests/tests/rpc/v2/move_package_service/get_function.rs
+++ b/crates/sui-e2e-tests/tests/rpc/v2/move_package_service/get_function.rs
@@ -10,7 +10,10 @@ use crate::v2::move_package_service::system_package_expectations::validate_new_u
 
 #[sim_test]
 async fn test_get_function_validator_cap() {
-    let cluster = TestClusterBuilder::new().build().await;
+    let cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
     let mut service = MovePackageServiceClient::connect(cluster.rpc_url().to_owned())
         .await
         .unwrap();
@@ -28,7 +31,10 @@ async fn test_get_function_validator_cap() {
 
 #[sim_test]
 async fn test_get_function_not_found() {
-    let cluster = TestClusterBuilder::new().build().await;
+    let cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
     let mut service = MovePackageServiceClient::connect(cluster.rpc_url().to_owned())
         .await
         .unwrap();
@@ -45,7 +51,10 @@ async fn test_get_function_not_found() {
 
 #[sim_test]
 async fn test_get_function_invalid_hex() {
-    let cluster = TestClusterBuilder::new().build().await;
+    let cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
     let mut service = MovePackageServiceClient::connect(cluster.rpc_url().to_owned())
         .await
         .unwrap();
@@ -62,7 +71,10 @@ async fn test_get_function_invalid_hex() {
 
 #[sim_test]
 async fn test_get_function_missing_package_id() {
-    let cluster = TestClusterBuilder::new().build().await;
+    let cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
     let mut service = MovePackageServiceClient::connect(cluster.rpc_url().to_owned())
         .await
         .unwrap();
@@ -79,7 +91,10 @@ async fn test_get_function_missing_package_id() {
 
 #[sim_test]
 async fn test_get_function_missing_module_name() {
-    let cluster = TestClusterBuilder::new().build().await;
+    let cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
     let mut service = MovePackageServiceClient::connect(cluster.rpc_url().to_owned())
         .await
         .unwrap();
@@ -96,7 +111,10 @@ async fn test_get_function_missing_module_name() {
 
 #[sim_test]
 async fn test_get_function_missing_name() {
-    let cluster = TestClusterBuilder::new().build().await;
+    let cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
     let mut service = MovePackageServiceClient::connect(cluster.rpc_url().to_owned())
         .await
         .unwrap();

--- a/crates/sui-e2e-tests/tests/rpc/v2/move_package_service/get_package.rs
+++ b/crates/sui-e2e-tests/tests/rpc/v2/move_package_service/get_package.rs
@@ -11,7 +11,10 @@ use crate::v2::move_package_service::system_package_expectations::validate_syste
 
 #[sim_test]
 async fn test_get_package_system() {
-    let cluster = TestClusterBuilder::new().build().await;
+    let cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
     let mut service = MovePackageServiceClient::connect(cluster.rpc_url().to_owned())
         .await
         .unwrap();
@@ -27,7 +30,10 @@ async fn test_get_package_system() {
 
 #[sim_test]
 async fn test_get_package_not_found() {
-    let cluster = TestClusterBuilder::new().build().await;
+    let cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
     let mut service = MovePackageServiceClient::connect(cluster.rpc_url().to_owned())
         .await
         .unwrap();
@@ -42,7 +48,10 @@ async fn test_get_package_not_found() {
 
 #[sim_test]
 async fn test_get_package_invalid_hex() {
-    let cluster = TestClusterBuilder::new().build().await;
+    let cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
     let mut service = MovePackageServiceClient::connect(cluster.rpc_url().to_owned())
         .await
         .unwrap();
@@ -57,7 +66,10 @@ async fn test_get_package_invalid_hex() {
 
 #[sim_test]
 async fn test_get_package_missing_id() {
-    let cluster = TestClusterBuilder::new().build().await;
+    let cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
     let mut service = MovePackageServiceClient::connect(cluster.rpc_url().to_owned())
         .await
         .unwrap();

--- a/crates/sui-e2e-tests/tests/rpc/v2/move_package_service/list_package_versions.rs
+++ b/crates/sui-e2e-tests/tests/rpc/v2/move_package_service/list_package_versions.rs
@@ -17,7 +17,10 @@ use test_cluster::TestClusterBuilder;
 
 #[sim_test]
 async fn test_list_package_versions_system_package() {
-    let cluster = TestClusterBuilder::new().build().await;
+    let cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
     let mut service = MovePackageServiceClient::connect(cluster.rpc_url().to_owned())
         .await
         .unwrap();
@@ -40,7 +43,10 @@ async fn test_list_package_versions_system_package() {
 
 #[sim_test]
 async fn test_list_package_versions_with_upgrades() {
-    let cluster = TestClusterBuilder::new().build().await;
+    let cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
     let mut service = MovePackageServiceClient::connect(cluster.rpc_url().to_owned())
         .await
         .unwrap();
@@ -306,7 +312,10 @@ async fn test_list_package_versions_with_upgrades() {
 
 #[sim_test]
 async fn test_list_package_versions_not_found() {
-    let cluster = TestClusterBuilder::new().build().await;
+    let cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
     let mut service = MovePackageServiceClient::connect(cluster.rpc_url().to_owned())
         .await
         .unwrap();
@@ -321,7 +330,10 @@ async fn test_list_package_versions_not_found() {
 
 #[sim_test]
 async fn test_list_package_versions_invalid_package_id() {
-    let cluster = TestClusterBuilder::new().build().await;
+    let cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
     let mut service = MovePackageServiceClient::connect(cluster.rpc_url().to_owned())
         .await
         .unwrap();
@@ -340,7 +352,10 @@ async fn test_list_package_versions_invalid_package_id() {
 
 #[sim_test]
 async fn test_list_package_versions_missing_package_id() {
-    let cluster = TestClusterBuilder::new().build().await;
+    let cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
     let mut service = MovePackageServiceClient::connect(cluster.rpc_url().to_owned())
         .await
         .unwrap();
@@ -358,7 +373,10 @@ async fn test_list_package_versions_missing_package_id() {
 
 #[sim_test]
 async fn test_list_package_versions_invalid_pagination() {
-    let cluster = TestClusterBuilder::new().build().await;
+    let cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
     let mut service = MovePackageServiceClient::connect(cluster.rpc_url().to_owned())
         .await
         .unwrap();

--- a/crates/sui-e2e-tests/tests/rpc/v2/signature_verification_service.rs
+++ b/crates/sui-e2e-tests/tests/rpc/v2/signature_verification_service.rs
@@ -21,6 +21,7 @@ async fn test_verify_signature_zklogin() -> Result<(), anyhow::Error> {
     }
 
     let test_cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
         .with_epoch_duration_ms(10000)
         .with_default_jwks()
         .build()

--- a/crates/sui-e2e-tests/tests/rpc/v2/state_service/balance.rs
+++ b/crates/sui-e2e-tests/tests/rpc/v2/state_service/balance.rs
@@ -22,7 +22,10 @@ const INITIAL_SUI_BALANCE: u64 = 150000000000000000;
 
 #[sim_test]
 async fn test_balance_apis() {
-    let test_cluster = TestClusterBuilder::new().build().await;
+    let test_cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
     let mut grpc_client = get_grpc_client(&test_cluster).await;
 
     let address = test_cluster.get_address_0();
@@ -40,7 +43,10 @@ async fn test_balance_apis() {
 
 #[sim_test]
 async fn test_balance_changes_on_transfer() {
-    let test_cluster = TestClusterBuilder::new().build().await;
+    let test_cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
     let mut grpc_client = get_grpc_client(&test_cluster).await;
 
     let sender = test_cluster.get_address_0();
@@ -86,7 +92,10 @@ async fn test_address_balance() {
         cfg
     });
 
-    let test_cluster = TestClusterBuilder::new().build().await;
+    let test_cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
     let mut grpc_client = get_grpc_client(&test_cluster).await;
 
     let sender = test_cluster.get_address_0();
@@ -133,7 +142,10 @@ async fn test_address_balance_account_with_only_address_balance() {
         cfg
     });
 
-    let test_cluster = TestClusterBuilder::new().build().await;
+    let test_cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
     let mut grpc_client = get_grpc_client(&test_cluster).await;
 
     let sender = test_cluster.get_address_0();
@@ -173,7 +185,10 @@ async fn test_address_balance_account_with_only_address_balance() {
 
 #[sim_test]
 async fn test_custom_coin_balance() {
-    let test_cluster = TestClusterBuilder::new().build().await;
+    let test_cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
     let mut grpc_client = get_grpc_client(&test_cluster).await;
 
     let address = test_cluster.get_address_0();
@@ -370,7 +385,10 @@ async fn test_custom_coin_balance() {
 
 #[sim_test]
 async fn test_multiple_concurrent_balance_changes() {
-    let test_cluster = TestClusterBuilder::new().build().await;
+    let test_cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
     let mut grpc_client = get_grpc_client(&test_cluster).await;
 
     let address_0 = test_cluster.get_address_0();
@@ -487,7 +505,10 @@ async fn test_multiple_concurrent_balance_changes() {
 
 #[sim_test]
 async fn test_fresh_address_with_no_coins() {
-    let test_cluster = TestClusterBuilder::new().build().await;
+    let test_cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
     let mut grpc_client = get_grpc_client(&test_cluster).await;
 
     // Generate a new address that has never received any coins
@@ -528,7 +549,10 @@ async fn test_fresh_address_with_no_coins() {
 
 #[sim_test]
 async fn test_invalid_requests() {
-    let test_cluster = TestClusterBuilder::new().build().await;
+    let test_cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
     let mut grpc_client = get_grpc_client(&test_cluster).await;
 
     // Test with missing owner

--- a/crates/sui-e2e-tests/tests/rpc/v2/state_service/get_coin_info.rs
+++ b/crates/sui-e2e-tests/tests/rpc/v2/state_service/get_coin_info.rs
@@ -25,7 +25,10 @@ use test_cluster::TestClusterBuilder;
 // not been migrated.
 #[sim_test]
 async fn get_coin_info_sui() {
-    let test_cluster = TestClusterBuilder::new().build().await;
+    let test_cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
 
     let mut grpc_client = get_grpc_client(&test_cluster).await;
 
@@ -80,7 +83,10 @@ async fn get_coin_info_sui() {
 
 #[sim_test]
 async fn test_get_coin_info_registry_coin() {
-    let test_cluster = TestClusterBuilder::new().build().await;
+    let test_cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
 
     let mut grpc_client = get_grpc_client(&test_cluster).await;
 
@@ -285,7 +291,10 @@ async fn test_get_coin_info_registry_coin() {
 
 #[sim_test]
 async fn test_get_coin_info_burnonly_coin() {
-    let test_cluster = TestClusterBuilder::new().build().await;
+    let test_cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
 
     let mut grpc_client = get_grpc_client(&test_cluster).await;
 
@@ -424,7 +433,10 @@ async fn test_get_coin_info_burnonly_coin() {
 
 #[sim_test]
 async fn test_get_coin_info_regulated_coin() {
-    let test_cluster = TestClusterBuilder::new().build().await;
+    let test_cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
 
     let mut grpc_client = get_grpc_client(&test_cluster).await;
 
@@ -474,7 +486,10 @@ async fn test_get_coin_info_regulated_coin() {
 
 #[sim_test]
 async fn test_get_coin_info_non_otw_coin() {
-    let test_cluster = TestClusterBuilder::new().build().await;
+    let test_cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
 
     let mut grpc_client = get_grpc_client(&test_cluster).await;
 
@@ -556,7 +571,10 @@ async fn test_get_coin_info_non_otw_coin() {
 
 #[sim_test]
 async fn test_get_coin_info_legacy_coin() {
-    let test_cluster = TestClusterBuilder::new().build().await;
+    let test_cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
 
     let mut grpc_client = get_grpc_client(&test_cluster).await;
 
@@ -1124,7 +1142,10 @@ async fn finalize_registration(
 
 #[sim_test]
 async fn test_invalid_coin_type() {
-    let test_cluster = TestClusterBuilder::new().build().await;
+    let test_cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
     let mut grpc_client = get_grpc_client(&test_cluster).await;
 
     // Test with malformed coin type

--- a/crates/sui-e2e-tests/tests/rpc/v2/state_service/list_owned_objects.rs
+++ b/crates/sui-e2e-tests/tests/rpc/v2/state_service/list_owned_objects.rs
@@ -19,7 +19,10 @@ use test_cluster::TestClusterBuilder;
 
 #[sim_test]
 async fn test_indexing_with_tto() {
-    let cluster = TestClusterBuilder::new().build().await;
+    let cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
 
     let mut client = Client::new(cluster.rpc_url().to_owned()).unwrap();
     let address = cluster.get_address_0();
@@ -277,7 +280,10 @@ async fn test_indexing_with_tto() {
 
 #[sim_test]
 async fn test_filter_by_type() {
-    let cluster = TestClusterBuilder::new().build().await;
+    let cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
 
     let sui = "0x2::coin::Coin<0x2::sui::SUI>"
         .parse::<TypeTag>()
@@ -529,7 +535,10 @@ async fn test_filter_by_type() {
 
 #[sim_test]
 async fn test_reverse_sorted_coins_by_balance() {
-    let cluster = TestClusterBuilder::new().build().await;
+    let cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
 
     let mut client = Client::new(cluster.rpc_url().to_owned()).unwrap();
 

--- a/crates/sui-e2e-tests/tests/rpc/v2/subscription_service.rs
+++ b/crates/sui-e2e-tests/tests/rpc/v2/subscription_service.rs
@@ -12,7 +12,10 @@ use tokio_stream::StreamExt;
 
 #[sim_test]
 async fn subscribe_checkpoint() {
-    let test_cluster = TestClusterBuilder::new().build().await;
+    let test_cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
 
     let _transaction_digest = transfer_coin(&test_cluster.wallet).await;
 

--- a/crates/sui-e2e-tests/tests/rpc/v2/transaction_execution_service/mod.rs
+++ b/crates/sui-e2e-tests/tests/rpc/v2/transaction_execution_service/mod.rs
@@ -20,7 +20,10 @@ mod resolve;
 
 #[sim_test]
 async fn execute_transaction_transfer() {
-    let test_cluster = TestClusterBuilder::new().build().await;
+    let test_cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
 
     let mut client = TransactionExecutionServiceClient::connect(test_cluster.rpc_url().to_owned())
         .await

--- a/crates/sui-e2e-tests/tests/rpc/v2/transaction_execution_service/resolve.rs
+++ b/crates/sui-e2e-tests/tests/rpc/v2/transaction_execution_service/resolve.rs
@@ -60,7 +60,10 @@ fn proto_to_response(
 
 #[sim_test]
 async fn resolve_transaction_simple_transfer() {
-    let test_cluster = TestClusterBuilder::new().build().await;
+    let test_cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
 
     let mut client = Client::new(test_cluster.rpc_url()).unwrap();
     let mut alpha_client =
@@ -120,7 +123,10 @@ async fn resolve_transaction_simple_transfer() {
 
 #[sim_test]
 async fn resolve_transaction_transfer_with_sponsor() {
-    let test_cluster = TestClusterBuilder::new().build().await;
+    let test_cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
 
     let mut client = Client::new(test_cluster.rpc_url()).unwrap();
     let mut alpha_client =
@@ -201,7 +207,10 @@ async fn resolve_transaction_transfer_with_sponsor() {
 
 #[sim_test]
 async fn resolve_transaction_borrowed_shared_object() {
-    let test_cluster = TestClusterBuilder::new().build().await;
+    let test_cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
 
     let mut client = Client::new(test_cluster.rpc_url()).unwrap();
     let mut alpha_client =
@@ -252,7 +261,10 @@ async fn resolve_transaction_borrowed_shared_object() {
 
 #[sim_test]
 async fn resolve_transaction_mutable_shared_object() {
-    let test_cluster = TestClusterBuilder::new().build().await;
+    let test_cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
 
     let mut client = Client::new(test_cluster.rpc_url()).unwrap();
     let mut alpha_client =
@@ -324,7 +336,10 @@ async fn resolve_transaction_mutable_shared_object() {
 
 #[sim_test]
 async fn resolve_transaction_insufficient_gas() {
-    let test_cluster = TestClusterBuilder::new().build().await;
+    let test_cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
     let mut alpha_client =
         TransactionExecutionServiceClient::connect(test_cluster.rpc_url().to_owned())
             .await
@@ -370,7 +385,10 @@ fn assert_contains(haystack: &str, needle: &str) {
 
 #[sim_test]
 async fn resolve_transaction_gas_budget_clamping() {
-    let test_cluster = TestClusterBuilder::new().build().await;
+    let test_cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
 
     let mut client = Client::new(test_cluster.rpc_url()).unwrap();
     let mut alpha_client =
@@ -443,7 +461,10 @@ async fn resolve_transaction_gas_budget_clamping() {
 
 #[sim_test]
 async fn resolve_transaction_insufficient_gas_with_payment_objects() {
-    let test_cluster = TestClusterBuilder::new().build().await;
+    let test_cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
     let mut alpha_client =
         TransactionExecutionServiceClient::connect(test_cluster.rpc_url().to_owned())
             .await
@@ -585,7 +606,10 @@ async fn resolve_transaction_insufficient_gas_with_payment_objects() {
 async fn resolve_transaction_shared_object_with_generic_type_parameter() {
     use sui_test_transaction_builder::publish_basics_package_and_make_party_object;
 
-    let test_cluster = TestClusterBuilder::new().build().await;
+    let test_cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
 
     let mut client = Client::new(test_cluster.rpc_url()).unwrap();
     let mut alpha_client =
@@ -683,7 +707,10 @@ async fn test_gas_selection_with_address_balance() {
         cfg
     });
 
-    let test_cluster = TestClusterBuilder::new().build().await;
+    let test_cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
 
     let mut client = sui_rpc::Client::new(test_cluster.rpc_url()).unwrap();
 

--- a/crates/sui-e2e-tests/tests/rpc/v2/unchanged_loaded_runtime_objects.rs
+++ b/crates/sui-e2e-tests/tests/rpc/v2/unchanged_loaded_runtime_objects.rs
@@ -29,7 +29,10 @@ use crate::{stake_with_validator, transfer_coin};
 async fn test_unchanged_loaded_runtime_objects() {
     use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
 
-    let test_cluster = TestClusterBuilder::new().build().await;
+    let test_cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
 
     let _transaction_digest = transfer_coin(&test_cluster.wallet).await;
     let transaction_digest = stake_with_validator(&test_cluster).await;
@@ -146,7 +149,10 @@ async fn test_unchanged_loaded_runtime_objects() {
 
 #[sim_test]
 async fn test_tto_receive_twice() {
-    let cluster = TestClusterBuilder::new().build().await;
+    let cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
 
     let mut client = Client::new(cluster.rpc_url().to_owned()).unwrap();
     let address = cluster.get_address_0();
@@ -421,7 +427,10 @@ async fn test_tto_receive_twice() {
 
 #[sim_test]
 async fn test_tto_success() {
-    let cluster = TestClusterBuilder::new().build().await;
+    let cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
 
     let mut client = Client::new(cluster.rpc_url().to_owned()).unwrap();
     let address = cluster.get_address_0();
@@ -782,7 +791,10 @@ async fn test_tto_success() {
 
 #[sim_test]
 async fn test_receive_input() {
-    let cluster = TestClusterBuilder::new().build().await;
+    let cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
 
     let mut client = Client::new(cluster.rpc_url().to_owned()).unwrap();
     let address = cluster.get_address_0();


### PR DESCRIPTION
This should speed tests up a little bit

## Summary
- Configure all TestClusterBuilder usages in RPC tests to use `.with_num_validators(1)`
- This reduces test execution time by using a single validator instead of the default 4
- 18 test files updated across the `crates/sui-e2e-tests/tests/rpc/` directory

## Test plan
- [ ] Verify RPC tests still pass with `cargo simtest -p sui-e2e-tests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)