### PR TITLE
runtime configurable pipeline knobs

### DIFF
--- a/crates/sui-analytics-indexer/src/config.rs
+++ b/crates/sui-analytics-indexer/src/config.rs
@@ -108,6 +108,9 @@ impl CommitterLayer {
 pub struct SequentialLayer {
     pub committer: Option<CommitterLayer>,
     pub checkpoint_lag: Option<u64>,
+    pub fanout: Option<usize>,
+    pub min_eager_rows: Option<usize>,
+    pub max_batch_checkpoints: Option<usize>,
 }
 
 impl SequentialLayer {
@@ -119,6 +122,9 @@ impl SequentialLayer {
                 base.committer
             },
             checkpoint_lag: self.checkpoint_lag.unwrap_or(base.checkpoint_lag),
+            fanout: self.fanout.or(base.fanout),
+            min_eager_rows: self.min_eager_rows.or(base.min_eager_rows),
+            max_batch_checkpoints: self.max_batch_checkpoints.or(base.max_batch_checkpoints),
         }
     }
 }

--- a/crates/sui-checkpoint-blob-indexer/src/config.rs
+++ b/crates/sui-checkpoint-blob-indexer/src/config.rs
@@ -42,6 +42,10 @@ impl CommitterLayer {
 #[derive(Clone, Default, Debug)]
 pub struct ConcurrentLayer {
     pub committer: Option<CommitterLayer>,
+    pub fanout: Option<usize>,
+    pub min_eager_rows: Option<usize>,
+    pub max_pending_rows: Option<usize>,
+    pub max_watermark_updates: Option<usize>,
 }
 
 impl ConcurrentLayer {
@@ -53,6 +57,10 @@ impl ConcurrentLayer {
                 base.committer
             },
             pruner: None,
+            fanout: self.fanout.or(base.fanout),
+            min_eager_rows: self.min_eager_rows.or(base.min_eager_rows),
+            max_pending_rows: self.max_pending_rows.or(base.max_pending_rows),
+            max_watermark_updates: self.max_watermark_updates.or(base.max_watermark_updates),
         }
     }
 }

--- a/crates/sui-checkpoint-blob-indexer/src/main.rs
+++ b/crates/sui-checkpoint-blob-indexer/src/main.rs
@@ -162,6 +162,7 @@ async fn main() -> anyhow::Result<()> {
     let base = ConcurrentConfig {
         committer,
         pruner: None,
+        ..Default::default()
     };
 
     indexer

--- a/crates/sui-indexer-alt-consistent-store/src/lib.rs
+++ b/crates/sui-indexer-alt-consistent-store/src/lib.rs
@@ -139,6 +139,7 @@ pub async fn start_service(
                         SequentialConfig {
                             committer: layer.finish(committer.clone()),
                             checkpoint_lag: 0,
+                            ..Default::default()
                         },
                     )
                     .await?

--- a/crates/sui-indexer-alt/src/lib.rs
+++ b/crates/sui-indexer-alt/src/lib.rs
@@ -149,6 +149,7 @@ pub async fn setup_indexer(
                         layer.finish(ConcurrentConfig {
                             committer: committer.clone(),
                             pruner: Some(pruner.clone()),
+                            ..Default::default()
                         })?,
                     )
                     .await?

--- a/crates/sui-kvstore/src/config.rs
+++ b/crates/sui-kvstore/src/config.rs
@@ -44,6 +44,10 @@ pub struct ConcurrentLayer {
     pub committer: Option<CommitterLayer>,
     /// Maximum rows per BigTable batch for this pipeline.
     pub max_rows: Option<usize>,
+    pub fanout: Option<usize>,
+    pub min_eager_rows: Option<usize>,
+    pub max_pending_rows: Option<usize>,
+    pub max_watermark_updates: Option<usize>,
 }
 
 impl ConcurrentLayer {
@@ -55,6 +59,10 @@ impl ConcurrentLayer {
                 base.committer
             },
             pruner: None,
+            fanout: self.fanout.or(base.fanout),
+            min_eager_rows: self.min_eager_rows.or(base.min_eager_rows),
+            max_pending_rows: self.max_pending_rows.or(base.max_pending_rows),
+            max_watermark_updates: self.max_watermark_updates.or(base.max_watermark_updates),
         }
     }
 }

--- a/crates/sui-kvstore/src/lib.rs
+++ b/crates/sui-kvstore/src/lib.rs
@@ -324,6 +324,7 @@ impl BigTableIndexer {
         let base = ConcurrentConfig {
             committer,
             pruner: None,
+            ..Default::default()
         };
 
         indexer

--- a/docs/content/concepts/data-access/pipeline-architecture.mdx
+++ b/docs/content/concepts/data-access/pipeline-architecture.mdx
@@ -516,27 +516,52 @@ The following sections detail the configuration settings you can implement for o
 
 #### Concurrent pipeline `Handler` constants
 
-`Handler` constants are the most direct way to tune pipeline behavior. These are implemented as associated constants in your `Handler` trait implementation.
+`Handler` constants are the most direct way to tune pipeline behavior. These are implemented as associated constants in your `Handler` trait implementation and serve as per-handler defaults.
 
 ```rust
 impl concurrent::Handler for MyHandler {
     type Store = Db;
-    
+
     // Number of concurrent processor workers (default: 10)
     const FANOUT: usize = 20;
-    
+
     // Minimum rows to trigger eager commit for committer (default: 50)
     const MIN_EAGER_ROWS: usize = 100;
-    
-    // Backpressure threshold on committer (default: 5000)
+
+    // Backpressure threshold on collector (default: 5000)
     const MAX_PENDING_ROWS: usize = 10000;
-    
+
     // Maximum watermarks per batch (default: 10,000)
     const MAX_WATERMARK_UPDATES: usize = 5000;
 }
 ```
 
-Tuning guidelines: 
+These constants can also be overridden at runtime through `ConcurrentConfig` and `SequentialConfig`, without recompiling. Config values take precedence over trait constants when present. For concurrent pipelines:
+
+```rust
+let config = ConcurrentConfig {
+    committer: committer_config,
+    pruner: Some(pruner_config),
+    fanout: Some(20),
+    min_eager_rows: Some(100),
+    max_pending_rows: Some(10000),
+    max_watermark_updates: Some(5000),
+};
+```
+
+For sequential pipelines:
+
+```rust
+let config = SequentialConfig {
+    committer: committer_config,
+    checkpoint_lag: 0,
+    fanout: Some(20),
+    min_eager_rows: Some(100),
+    max_batch_checkpoints: Some(500),
+};
+```
+
+Tuning guidelines:
 
 - **`FANOUT`:** Increase for CPU-intensive processing, decrease for memory-constrained environments.
 - **`MIN_EAGER_ROWS`:** Lower values reduce data commit latency (individual data appears in database sooner), higher values improve overall throughput (more efficient larger batches).


### PR DESCRIPTION
## Description

Making the handler/processor trait consts overridable with runtime-config to make it possible to tune without recompiling.
