### PR TITLE
[Block Streaming] introduce the Synchronizer & CommitSyncer clients

### DIFF
--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -31,7 +31,9 @@ use crate::{
     leader_schedule::LeaderSchedule,
     leader_timeout::{LeaderTimeoutTask, LeaderTimeoutTaskHandle},
     metrics::initialise_metrics,
-    network::{NetworkManager, tonic_network::TonicManager},
+    network::{
+        CommitSyncerClient, NetworkManager, SynchronizerClient, tonic_network::TonicManager,
+    },
     proposed_block_handler::ProposedBlockHandler,
     round_prober::{RoundProber, RoundProberHandle},
     round_tracker::RoundTracker,
@@ -218,6 +220,23 @@ where
         let mut network_manager = N::new(context.clone(), network_keypair);
         let validator_client = network_manager.validator_client();
 
+        let synchronizer_client = Arc::new(SynchronizerClient::<
+            N::ValidatorClient,
+            N::ObserverClient,
+        >::new(
+            context.clone(),
+            Some(validator_client.clone()),
+            None, // TODO: set observer client if want to talk to a peer's observer server.
+        ));
+        let commit_syncer_client = Arc::new(CommitSyncerClient::<
+            N::ValidatorClient,
+            N::ObserverClient,
+        >::new(
+            context.clone(),
+            Some(validator_client.clone()),
+            None, // TODO: set observer client if want to talk to a peer's observer server.
+        ));
+
         let store_path = context.parameters.db_path.as_path().to_str().unwrap();
         let store = Arc::new(RocksDBStore::new(store_path));
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
@@ -308,7 +327,7 @@ where
         let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
 
         let synchronizer = Synchronizer::start(
-            validator_client.clone(),
+            synchronizer_client.clone(),
             context.clone(),
             core_dispatcher.clone(),
             commit_vote_monitor.clone(),
@@ -327,7 +346,7 @@ where
             block_verifier.clone(),
             transaction_certifier.clone(),
             round_tracker.clone(),
-            validator_client.clone(),
+            commit_syncer_client.clone(),
             dag_state.clone(),
         )
         .start();

--- a/consensus/core/src/authority_service.rs
+++ b/consensus/core/src/authority_service.rs
@@ -33,8 +33,8 @@ use crate::{
     dag_state::DagState,
     error::{ConsensusError, ConsensusResult},
     network::{
-        BlockStream, ExtendedSerializedBlock, NodeId, ObserverNetworkService,
-        ValidatorNetworkService,
+        BlockRequestStream, BlockStream, ExtendedSerializedBlock, NodeId, ObserverBlockStream,
+        ObserverNetworkService, ValidatorNetworkService,
     },
     round_tracker::RoundTracker,
     stake_aggregator::{QuorumThreshold, StakeAggregator},
@@ -648,6 +648,15 @@ impl<C: CoreThreadDispatcher> ValidatorNetworkService for AuthorityService<C> {
 
 #[async_trait]
 impl<C: CoreThreadDispatcher> ObserverNetworkService for AuthorityService<C> {
+    async fn handle_stream_blocks(
+        &self,
+        _peer: NodeId,
+        _request_stream: BlockRequestStream,
+    ) -> ConsensusResult<ObserverBlockStream> {
+        // TODO: Implement observer block streaming
+        todo!("Observer block streaming not yet implemented")
+    }
+
     async fn handle_fetch_blocks(
         &self,
         _peer: NodeId,
@@ -861,7 +870,8 @@ mod tests {
         dag_state::DagState,
         error::ConsensusResult,
         network::{
-            BlockStream, ExtendedSerializedBlock, ValidatorNetworkClient, ValidatorNetworkService,
+            BlockStream, ExtendedSerializedBlock, ObserverNetworkClient, SynchronizerClient,
+            ValidatorNetworkClient, ValidatorNetworkService,
         },
         round_tracker::RoundTracker,
         storage::mem_store::MemStore,
@@ -988,6 +998,36 @@ mod tests {
         }
     }
 
+    #[async_trait]
+    impl ObserverNetworkClient for FakeNetworkClient {
+        async fn stream_blocks(
+            &self,
+            _peer: crate::network::PeerId,
+            _request_stream: crate::network::BlockRequestStream,
+            _timeout: Duration,
+        ) -> ConsensusResult<crate::network::ObserverBlockStream> {
+            unimplemented!("Unimplemented")
+        }
+
+        async fn fetch_blocks(
+            &self,
+            _peer: crate::network::PeerId,
+            _block_refs: Vec<BlockRef>,
+            _timeout: Duration,
+        ) -> ConsensusResult<Vec<Bytes>> {
+            unimplemented!("Unimplemented")
+        }
+
+        async fn fetch_commits(
+            &self,
+            _peer: crate::network::PeerId,
+            _commit_range: CommitRange,
+            _timeout: Duration,
+        ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>)> {
+            unimplemented!("Unimplemented")
+        }
+    }
+
     #[tokio::test(flavor = "current_thread", start_paused = true)]
     async fn test_handle_send_block() {
         let (context, _keys) = Context::new_for_test(4);
@@ -996,7 +1036,12 @@ mod tests {
         let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
         let core_dispatcher = Arc::new(FakeCoreThreadDispatcher::new());
         let (_tx_block_broadcast, rx_block_broadcast) = broadcast::channel(100);
-        let network_client = Arc::new(FakeNetworkClient::default());
+        let fake_client = Arc::new(FakeNetworkClient::default());
+        let network_client = Arc::new(SynchronizerClient::new(
+            context.clone(),
+            Some(fake_client.clone()),
+            Some(fake_client.clone()),
+        ));
         let (blocks_sender, _blocks_receiver) =
             monitored_mpsc::unbounded_channel("consensus_block_output");
         let store = Arc::new(MemStore::new());
@@ -1115,7 +1160,12 @@ mod tests {
         let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
         let core_dispatcher = Arc::new(FakeCoreThreadDispatcher::new());
         let (_tx_block_broadcast, rx_block_broadcast) = broadcast::channel(100);
-        let network_client = Arc::new(FakeNetworkClient::default());
+        let fake_client = Arc::new(FakeNetworkClient::default());
+        let network_client = Arc::new(SynchronizerClient::new(
+            context.clone(),
+            Some(fake_client.clone()),
+            Some(fake_client.clone()),
+        ));
         let (blocks_sender, _blocks_receiver) =
             monitored_mpsc::unbounded_channel("consensus_block_output");
         let store = Arc::new(MemStore::new());
@@ -1283,7 +1333,12 @@ mod tests {
         let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
         let core_dispatcher = Arc::new(FakeCoreThreadDispatcher::new());
         let (_tx_block_broadcast, rx_block_broadcast) = broadcast::channel(100);
-        let network_client = Arc::new(FakeNetworkClient::default());
+        let fake_client = Arc::new(FakeNetworkClient::default());
+        let network_client = Arc::new(SynchronizerClient::new(
+            context.clone(),
+            Some(fake_client.clone()),
+            Some(fake_client.clone()),
+        ));
         let (blocks_sender, _blocks_receiver) =
             monitored_mpsc::unbounded_channel("consensus_block_output");
         let store = Arc::new(MemStore::new());
@@ -1356,7 +1411,12 @@ mod tests {
         let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
         let core_dispatcher = Arc::new(FakeCoreThreadDispatcher::new());
         let (_tx_block_broadcast, rx_block_broadcast) = broadcast::channel(100);
-        let network_client = Arc::new(FakeNetworkClient::default());
+        let fake_client = Arc::new(FakeNetworkClient::default());
+        let network_client = Arc::new(SynchronizerClient::new(
+            context.clone(),
+            Some(fake_client.clone()),
+            Some(fake_client.clone()),
+        ));
         let (blocks_sender, _blocks_receiver) =
             monitored_mpsc::unbounded_channel("consensus_block_output");
         let store = Arc::new(MemStore::new());
@@ -1446,7 +1506,12 @@ mod tests {
         let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
         let core_dispatcher = Arc::new(FakeCoreThreadDispatcher::new());
         let (_tx_block_broadcast, rx_block_broadcast) = broadcast::channel(100);
-        let network_client = Arc::new(FakeNetworkClient::default());
+        let fake_client = Arc::new(FakeNetworkClient::default());
+        let network_client = Arc::new(SynchronizerClient::new(
+            context.clone(),
+            Some(fake_client.clone()),
+            Some(fake_client.clone()),
+        ));
         let (blocks_sender, _blocks_receiver) =
             monitored_mpsc::unbounded_channel("consensus_block_output");
         let store = Arc::new(MemStore::new());

--- a/consensus/core/src/commit_syncer.rs
+++ b/consensus/core/src/commit_syncer.rs
@@ -59,7 +59,7 @@ use crate::{
     core_thread::CoreThreadDispatcher,
     dag_state::DagState,
     error::{ConsensusError, ConsensusResult},
-    network::ValidatorNetworkClient,
+    network::{CommitSyncerClient, ObserverNetworkClient, ValidatorNetworkClient},
     round_tracker::RoundTracker,
     stake_aggregator::{QuorumThreshold, StakeAggregator},
     transaction_certifier::TransactionCertifier,
@@ -83,11 +83,11 @@ impl CommitSyncerHandle {
     }
 }
 
-pub(crate) struct CommitSyncer<C: ValidatorNetworkClient> {
+pub(crate) struct CommitSyncer<VC: ValidatorNetworkClient, OC: ObserverNetworkClient> {
     // States shared by scheduler and fetch tasks.
 
     // Shared components wrapper.
-    inner: Arc<Inner<C>>,
+    inner: Arc<Inner<VC, OC>>,
 
     // States only used by the scheduler.
 
@@ -108,7 +108,11 @@ pub(crate) struct CommitSyncer<C: ValidatorNetworkClient> {
     synced_commit_index: CommitIndex,
 }
 
-impl<C: ValidatorNetworkClient> CommitSyncer<C> {
+impl<VC, OC> CommitSyncer<VC, OC>
+where
+    VC: ValidatorNetworkClient,
+    OC: ObserverNetworkClient,
+{
     pub(crate) fn new(
         context: Arc<Context>,
         core_thread_dispatcher: Arc<dyn CoreThreadDispatcher>,
@@ -117,7 +121,7 @@ impl<C: ValidatorNetworkClient> CommitSyncer<C> {
         block_verifier: Arc<dyn BlockVerifier>,
         transaction_certifier: TransactionCertifier,
         round_tracker: Arc<RwLock<RoundTracker>>,
-        network_client: Arc<C>,
+        network_client: Arc<CommitSyncerClient<VC, OC>>,
         dag_state: Arc<RwLock<DagState>>,
     ) -> Self {
         let inner = Arc::new(Inner {
@@ -429,7 +433,7 @@ impl<C: ValidatorNetworkClient> CommitSyncer<C> {
     // where at least a prefix of the commit range is fetched.
     // Returns the fetched commits and blocks referenced by the commits.
     async fn fetch_loop(
-        inner: Arc<Inner<C>>,
+        inner: Arc<Inner<VC, OC>>,
         commit_range: CommitRange,
     ) -> (CommitIndex, CertifiedCommits) {
         // Individual request base timeout.
@@ -533,7 +537,7 @@ impl<C: ValidatorNetworkClient> CommitSyncer<C> {
     // fetched and verified. After that, blocks referenced in the certified commits are fetched
     // and sent to Core for processing.
     async fn fetch_once(
-        inner: Arc<Inner<C>>,
+        inner: Arc<Inner<VC, OC>>,
         target_authority: AuthorityIndex,
         commit_range: CommitRange,
         timeout: Duration,
@@ -548,7 +552,11 @@ impl<C: ValidatorNetworkClient> CommitSyncer<C> {
         // 1. Fetch commits in the commit range from the target authority.
         let (serialized_commits, serialized_blocks) = inner
             .network_client
-            .fetch_commits(target_authority, commit_range.clone(), timeout)
+            .fetch_commits(
+                crate::network::PeerId::Validator(target_authority),
+                commit_range.clone(),
+                timeout,
+            )
             .await?;
 
         // 2. Verify the response contains blocks that can certify the last returned commit,
@@ -588,7 +596,7 @@ impl<C: ValidatorNetworkClient> CommitSyncer<C> {
                     let serialized_blocks = inner
                         .network_client
                         .fetch_blocks(
-                            target_authority,
+                            crate::network::PeerId::Validator(target_authority),
                             request_block_refs.to_vec(),
                             vec![],
                             false,
@@ -759,7 +767,7 @@ impl<C: ValidatorNetworkClient> CommitSyncer<C> {
     }
 }
 
-struct Inner<C: ValidatorNetworkClient> {
+struct Inner<VC: ValidatorNetworkClient, OC: ObserverNetworkClient> {
     context: Arc<Context>,
     core_thread_dispatcher: Arc<dyn CoreThreadDispatcher>,
     commit_vote_monitor: Arc<CommitVoteMonitor>,
@@ -767,11 +775,11 @@ struct Inner<C: ValidatorNetworkClient> {
     block_verifier: Arc<dyn BlockVerifier>,
     transaction_certifier: TransactionCertifier,
     round_tracker: Arc<RwLock<RoundTracker>>,
-    network_client: Arc<C>,
+    network_client: Arc<CommitSyncerClient<VC, OC>>,
     dag_state: Arc<RwLock<DagState>>,
 }
 
-impl<C: ValidatorNetworkClient> Inner<C> {
+impl<VC: ValidatorNetworkClient, OC: ObserverNetworkClient> Inner<VC, OC> {
     /// Verifies the commits and also certifies them using the provided vote blocks for the last commit. The
     /// method returns the trusted commits and the votes as verified blocks.
     fn verify_commits(
@@ -882,7 +890,7 @@ mod tests {
         core_thread::MockCoreThreadDispatcher,
         dag_state::DagState,
         error::ConsensusResult,
-        network::{BlockStream, ValidatorNetworkClient},
+        network::{BlockStream, CommitSyncerClient, ObserverNetworkClient, ValidatorNetworkClient},
         round_tracker::RoundTracker,
         storage::mem_store::MemStore,
         transaction_certifier::TransactionCertifier,
@@ -950,6 +958,36 @@ mod tests {
         }
     }
 
+    #[async_trait::async_trait]
+    impl ObserverNetworkClient for FakeNetworkClient {
+        async fn stream_blocks(
+            &self,
+            _peer: crate::network::PeerId,
+            _request_stream: crate::network::BlockRequestStream,
+            _timeout: Duration,
+        ) -> ConsensusResult<crate::network::ObserverBlockStream> {
+            unimplemented!("Unimplemented")
+        }
+
+        async fn fetch_blocks(
+            &self,
+            _peer: crate::network::PeerId,
+            _block_refs: Vec<BlockRef>,
+            _timeout: Duration,
+        ) -> ConsensusResult<Vec<Bytes>> {
+            unimplemented!("Unimplemented")
+        }
+
+        async fn fetch_commits(
+            &self,
+            _peer: crate::network::PeerId,
+            _commit_range: CommitRange,
+            _timeout: Duration,
+        ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>)> {
+            unimplemented!("Unimplemented")
+        }
+    }
+
     #[tokio::test(flavor = "current_thread", start_paused = true)]
     async fn commit_syncer_start_and_pause_scheduling() {
         // SETUP
@@ -969,7 +1007,12 @@ mod tests {
         let context = Arc::new(context);
         let block_verifier = Arc::new(NoopBlockVerifier {});
         let core_thread_dispatcher = Arc::new(MockCoreThreadDispatcher::default());
-        let network_client = Arc::new(FakeNetworkClient::default());
+        let mock_client = Arc::new(FakeNetworkClient::default());
+        let network_client = Arc::new(CommitSyncerClient::new(
+            context.clone(),
+            Some(mock_client.clone()),
+            Some(mock_client.clone()),
+        ));
         let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
         let (blocks_sender, _blocks_receiver) =

--- a/consensus/core/src/context.rs
+++ b/consensus/core/src/context.rs
@@ -112,6 +112,11 @@ impl Context {
         self.protocol_config = protocol_config;
         self
     }
+
+    /// Returns true if this node is a validator (i.e., part of the committee).
+    pub fn is_validator(&self) -> bool {
+        self.committee.is_valid_index(self.own_index)
+    }
 }
 
 /// A clock that allows to derive the current UNIX system timestamp while guaranteeing that timestamp

--- a/consensus/core/src/network/clients.rs
+++ b/consensus/core/src/network/clients.rs
@@ -1,0 +1,181 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{sync::Arc, time::Duration};
+
+use bytes::Bytes;
+use consensus_config::AuthorityIndex;
+use consensus_types::block::{BlockRef, Round};
+
+use super::{
+    ObserverNetworkClient, PeerId, ValidatorNetworkClient, observer::TonicObserverClient,
+    tonic_network::TonicValidatorClient,
+};
+use crate::{
+    commit::CommitRange,
+    context::Context,
+    error::{ConsensusError, ConsensusResult},
+};
+
+/// Concrete client implementation for synchronizer operations.
+/// Wraps validator and observer network clients and routes requests based on whether this node is
+/// a validator and the peer is an authority.
+pub(crate) struct SynchronizerClient<
+    V: ValidatorNetworkClient = TonicValidatorClient,
+    O: ObserverNetworkClient = TonicObserverClient,
+> {
+    context: Arc<Context>,
+    validator_client: Option<Arc<V>>,
+    observer_client: Option<Arc<O>>,
+}
+
+impl<V, O> SynchronizerClient<V, O>
+where
+    V: ValidatorNetworkClient,
+    O: ObserverNetworkClient,
+{
+    pub fn new(
+        context: Arc<Context>,
+        validator_client: Option<Arc<V>>,
+        observer_client: Option<Arc<O>>,
+    ) -> Self {
+        Self {
+            context,
+            validator_client,
+            observer_client,
+        }
+    }
+
+    pub async fn fetch_blocks(
+        &self,
+        peer: PeerId,
+        block_refs: Vec<BlockRef>,
+        highest_accepted_rounds: Vec<Round>,
+        breadth_first: bool,
+        timeout: Duration,
+    ) -> ConsensusResult<Vec<Bytes>> {
+        // A validator node will always talk via the validator interface to another authority.
+        // Otherwise, the only way to communicate with the other peer is via the observer interface.
+        if self.context.is_validator()
+            && let PeerId::Validator(authority) = peer
+        {
+            let client = self.validator_client.as_ref().ok_or_else(|| {
+                ConsensusError::NetworkConfig("Validator client not available".to_string())
+            })?;
+            client
+                .fetch_blocks(
+                    authority,
+                    block_refs,
+                    highest_accepted_rounds,
+                    breadth_first,
+                    timeout,
+                )
+                .await
+        } else {
+            let client = self.observer_client.as_ref().ok_or_else(|| {
+                ConsensusError::NetworkConfig("Observer client not available".to_string())
+            })?;
+            client.fetch_blocks(peer, block_refs, timeout).await
+        }
+    }
+
+    pub async fn fetch_latest_blocks(
+        &self,
+        peer: AuthorityIndex,
+        authorities: Vec<AuthorityIndex>,
+        timeout: Duration,
+    ) -> ConsensusResult<Vec<Bytes>> {
+        // fetch_latest_blocks is a validator-only operation: observers do not have a direct
+        // counterpart for this RPC, so it unconditionally requires the validator client.
+        let client = self.validator_client.as_ref().ok_or_else(|| {
+            ConsensusError::NetworkConfig("Validator client not available".to_string())
+        })?;
+        client.fetch_latest_blocks(peer, authorities, timeout).await
+    }
+}
+
+/// Concrete client implementation for commit syncer operations.
+/// Wraps validator and observer network clients and routes requests based on whether this node is
+/// a validator and the peer is an authority.
+pub(crate) struct CommitSyncerClient<
+    V: ValidatorNetworkClient = TonicValidatorClient,
+    O: ObserverNetworkClient = TonicObserverClient,
+> {
+    context: Arc<Context>,
+    validator_client: Option<Arc<V>>,
+    observer_client: Option<Arc<O>>,
+}
+
+impl<V, O> CommitSyncerClient<V, O>
+where
+    V: ValidatorNetworkClient,
+    O: ObserverNetworkClient,
+{
+    pub fn new(
+        context: Arc<Context>,
+        validator_client: Option<Arc<V>>,
+        observer_client: Option<Arc<O>>,
+    ) -> Self {
+        Self {
+            context,
+            validator_client,
+            observer_client,
+        }
+    }
+
+    pub async fn fetch_commits(
+        &self,
+        peer: PeerId,
+        commit_range: CommitRange,
+        timeout: Duration,
+    ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>)> {
+        // A validator node will always talk via the validator interface to another authority.
+        // Otherwise, the only way to communicate with the other peer is via the observer interface.
+        if self.context.is_validator()
+            && let PeerId::Validator(authority) = peer
+        {
+            let client = self.validator_client.as_ref().ok_or_else(|| {
+                ConsensusError::NetworkConfig("Validator client not available".to_string())
+            })?;
+            client.fetch_commits(authority, commit_range, timeout).await
+        } else {
+            let client = self.observer_client.as_ref().ok_or_else(|| {
+                ConsensusError::NetworkConfig("Observer client not available".to_string())
+            })?;
+            client.fetch_commits(peer, commit_range, timeout).await
+        }
+    }
+
+    pub async fn fetch_blocks(
+        &self,
+        peer: PeerId,
+        block_refs: Vec<BlockRef>,
+        highest_accepted_rounds: Vec<Round>,
+        breadth_first: bool,
+        timeout: Duration,
+    ) -> ConsensusResult<Vec<Bytes>> {
+        // A validator node will always talk via the validator interface to another authority.
+        // Otherwise, the only way to communicate with the other peer is via the observer interface.
+        if self.context.is_validator()
+            && let PeerId::Validator(authority) = peer
+        {
+            let client = self.validator_client.as_ref().ok_or_else(|| {
+                ConsensusError::NetworkConfig("Validator client not available".to_string())
+            })?;
+            client
+                .fetch_blocks(
+                    authority,
+                    block_refs,
+                    highest_accepted_rounds,
+                    breadth_first,
+                    timeout,
+                )
+                .await
+        } else {
+            let client = self.observer_client.as_ref().ok_or_else(|| {
+                ConsensusError::NetworkConfig("Observer client not available".to_string())
+            })?;
+            client.fetch_blocks(peer, block_refs, timeout).await
+        }
+    }
+}

--- a/consensus/core/src/network/mod.rs
+++ b/consensus/core/src/network/mod.rs
@@ -36,12 +36,23 @@ use crate::{
 #[allow(unused)]
 pub(crate) type NodeId = NetworkPublicKey;
 
+/// Identifies a peer in the network, which can be either a validator or an observer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum PeerId {
+    /// A validator node identified by its authority index.
+    Validator(AuthorityIndex),
+    /// An observer node identified by its network public key.
+    #[allow(dead_code)]
+    Observer(NodeId),
+}
+
 // Tonic generated RPC stubs.
 mod tonic_gen {
     include!(concat!(env!("OUT_DIR"), "/consensus.ConsensusService.rs"));
     include!(concat!(env!("OUT_DIR"), "/consensus.ObserverService.rs"));
 }
 
+mod clients;
 pub(crate) mod metrics;
 mod metrics_layer;
 #[cfg(all(test, not(msim)))]
@@ -181,11 +192,35 @@ pub(crate) trait ValidatorNetworkService: Send + Sync + 'static {
     ) -> ConsensusResult<(Vec<Round>, Vec<Round>)>;
 }
 
+/// A stream item for observer block streaming that includes both the block and highest commit index.
+#[allow(dead_code)]
+pub(crate) struct ObserverBlockStreamItem {
+    pub(crate) block: Bytes,
+    pub(crate) highest_commit_index: u64,
+}
+
+/// Observer block stream type.
+#[allow(dead_code)]
+pub(crate) type ObserverBlockStream = Pin<Box<dyn Stream<Item = ObserverBlockStreamItem> + Send>>;
+
+/// Observer block request stream type for bidirectional streaming.
+#[allow(dead_code)]
+pub(crate) type BlockRequestStream =
+    Pin<Box<dyn Stream<Item = crate::network::observer::BlockStreamRequest> + Send>>;
+
 /// Observer network service for handling requests from observer nodes.
 /// Unlike ValidatorNetworkService which uses AuthorityIndex, this uses NodeId (NetworkPublicKey)
 /// to identify peers since observers are not part of the committee.
 #[async_trait]
+#[allow(dead_code)]
 pub(crate) trait ObserverNetworkService: Send + Sync + 'static {
+    /// Handles the bidirectional block streaming request from an observer peer.
+    async fn handle_stream_blocks(
+        &self,
+        peer: NodeId,
+        request_stream: BlockRequestStream,
+    ) -> ConsensusResult<ObserverBlockStream>;
+
     /// Handles the request to fetch blocks by references from an observer peer.
     #[allow(unused)]
     async fn handle_fetch_blocks(
@@ -196,6 +231,7 @@ pub(crate) trait ObserverNetworkService: Send + Sync + 'static {
 
     /// Handles the request to fetch commits by index range from an observer peer.
     #[allow(unused)]
+    /// Returns serialized commits and certifier blocks.
     async fn handle_fetch_commits(
         &self,
         peer: NodeId,
@@ -203,16 +239,54 @@ pub(crate) trait ObserverNetworkService: Send + Sync + 'static {
     ) -> ConsensusResult<(Vec<TrustedCommit>, Vec<VerifiedBlock>)>;
 }
 
+/// Observer network client for communicating with validators' observer ports or other observers.
+/// Unlike ValidatorNetworkClient which uses AuthorityIndex, this uses PeerId to identify peers
+/// since the observer server can serve both validators and observer nodes.
+#[async_trait]
+#[allow(dead_code)]
+pub(crate) trait ObserverNetworkClient: Send + Sync + Sized + 'static {
+    /// Initiates bidirectional block streaming with a peer.
+    async fn stream_blocks(
+        &self,
+        peer: PeerId,
+        request_stream: BlockRequestStream,
+        timeout: Duration,
+    ) -> ConsensusResult<ObserverBlockStream>;
+
+    /// Fetches serialized blocks by references from a peer.
+    async fn fetch_blocks(
+        &self,
+        peer: PeerId,
+        block_refs: Vec<BlockRef>,
+        timeout: Duration,
+    ) -> ConsensusResult<Vec<Bytes>>;
+
+    /// Fetches serialized commits in the commit range from a peer.
+    /// Returns a tuple of both the serialized commits, and serialized blocks that contain
+    /// votes certifying the last commit.
+    async fn fetch_commits(
+        &self,
+        peer: PeerId,
+        commit_range: CommitRange,
+        timeout: Duration,
+    ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>)>;
+}
+
 /// An `AuthorityNode` holds a `NetworkManager` until shutdown.
 /// Dropping `NetworkManager` will shutdown the network service.
 pub(crate) trait NetworkManager: Send + Sync {
     type ValidatorClient: ValidatorNetworkClient;
+    type ObserverClient: ObserverNetworkClient;
 
     /// Creates a new network manager.
     fn new(context: Arc<Context>, network_keypair: NetworkKeyPair) -> Self;
 
     /// Returns the validator network client.
     fn validator_client(&self) -> Arc<Self::ValidatorClient>;
+
+    /// Returns the observer network client.
+    #[allow(dead_code)]
+    fn observer_client(&self) -> Arc<Self::ObserverClient>;
 
     /// Starts the validator network server with the provided service.
     async fn start_validator_server<V>(&mut self, service: Arc<V>)
@@ -231,6 +305,9 @@ pub(crate) trait NetworkManager: Send + Sync {
     /// If address is None, the override is cleared and the committee address will be used.
     fn update_peer_address(&self, peer: AuthorityIndex, address: Option<Multiaddr>);
 }
+
+// Re-export the concrete client implementations.
+pub(crate) use clients::{CommitSyncerClient, SynchronizerClient};
 
 /// Serialized block with extended information from the proposing authority.
 #[derive(Clone, PartialEq, Eq, Debug)]

--- a/consensus/core/src/network/observer.rs
+++ b/consensus/core/src/network/observer.rs
@@ -1,14 +1,21 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{pin::Pin, sync::Arc};
+use std::{pin::Pin, sync::Arc, time::Duration};
 
 use async_trait::async_trait;
 use bytes::Bytes;
-use consensus_config::NetworkPublicKey;
+use consensus_config::{NetworkKeyPair, NetworkPublicKey};
+use consensus_types::block::BlockRef;
 use futures::Stream;
 use tokio_stream::Iter;
 use tonic::{Request, Response, Streaming};
+
+use crate::{
+    CommitRange, Context,
+    error::{ConsensusError, ConsensusResult},
+    network::{BlockRequestStream, ObserverBlockStream, ObserverNetworkClient, PeerId},
+};
 
 use super::{ObserverNetworkService, tonic_gen::observer_service_server::ObserverService};
 
@@ -129,6 +136,57 @@ impl<S: ObserverNetworkService> ObserverService for ObserverServiceProxy<S> {
         // TODO: Implement fetch_commits for observer nodes
         Err(tonic::Status::unimplemented(
             "fetch_commits not yet implemented for observers",
+        ))
+    }
+}
+
+#[allow(dead_code)]
+pub(crate) struct TonicObserverClient {
+    context: Arc<Context>,
+    _network_keypair: NetworkKeyPair,
+}
+
+impl TonicObserverClient {
+    pub(crate) fn new(context: Arc<Context>, network_keypair: NetworkKeyPair) -> Self {
+        Self {
+            context,
+            _network_keypair: network_keypair,
+        }
+    }
+}
+
+#[async_trait]
+impl ObserverNetworkClient for TonicObserverClient {
+    async fn stream_blocks(
+        &self,
+        _peer: PeerId,
+        _request_stream: BlockRequestStream,
+        _timeout: Duration,
+    ) -> ConsensusResult<ObserverBlockStream> {
+        Err(ConsensusError::NetworkRequest(
+            "Not implemented".to_string(),
+        ))
+    }
+
+    async fn fetch_blocks(
+        &self,
+        _peer: PeerId,
+        _block_refs: Vec<BlockRef>,
+        _timeout: Duration,
+    ) -> ConsensusResult<Vec<Bytes>> {
+        Err(ConsensusError::NetworkRequest(
+            "Not implemented".to_string(),
+        ))
+    }
+
+    async fn fetch_commits(
+        &self,
+        _peer: PeerId,
+        _commit_range: CommitRange,
+        _timeout: Duration,
+    ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>)> {
+        Err(ConsensusError::NetworkRequest(
+            "Not implemented".to_string(),
         ))
     }
 }

--- a/consensus/core/src/network/test_network.rs
+++ b/consensus/core/src/network/test_network.rs
@@ -12,7 +12,10 @@ use crate::{
     block::VerifiedBlock,
     commit::{CommitRange, TrustedCommit},
     error::ConsensusResult,
-    network::{BlockStream, NodeId, ObserverNetworkService, ValidatorNetworkService},
+    network::{
+        BlockRequestStream, BlockStream, NodeId, ObserverBlockStream, ObserverNetworkService,
+        ValidatorNetworkService,
+    },
 };
 
 use super::ExtendedSerializedBlock;
@@ -109,6 +112,14 @@ impl ValidatorNetworkService for Mutex<TestService> {
 
 #[async_trait]
 impl ObserverNetworkService for Mutex<TestService> {
+    async fn handle_stream_blocks(
+        &self,
+        _peer: NodeId,
+        _request_stream: BlockRequestStream,
+    ) -> ConsensusResult<ObserverBlockStream> {
+        unimplemented!("ObserverNetworkService not implemented for TestService")
+    }
+
     async fn handle_fetch_blocks(
         &self,
         _peer: NodeId,

--- a/consensus/core/src/network/tonic_network.rs
+++ b/consensus/core/src/network/tonic_network.rs
@@ -32,7 +32,7 @@ use super::{
     BlockStream, ExtendedSerializedBlock, NetworkManager, ObserverNetworkService,
     ValidatorNetworkClient, ValidatorNetworkService,
     metrics_layer::{MetricsCallbackMaker, MetricsResponseCallback, SizedRequest, SizedResponse},
-    observer::{ObserverPeerInfo, ObserverServiceProxy},
+    observer::{ObserverPeerInfo, ObserverServiceProxy, TonicObserverClient},
     tonic_gen::{
         consensus_service_client::ConsensusServiceClient,
         consensus_service_server::ConsensusService,
@@ -734,7 +734,7 @@ impl<S: ValidatorNetworkService> ConsensusService for TonicServiceProxy<S> {
 
 /// Manages the lifecycle of Tonic network client and service. Typical usage during initialization:
 /// 1. Create a new `TonicManager`.
-/// 2. Take the validator client from `TonicManager::validator_client()`.
+/// 2. Take validator and observer clients from `TonicManager::validator_client()` and `TonicManager::observer_client()`.
 /// 3. Create consensus components.
 /// 4. Create `TonicService` for consensus service handler.
 /// 5. Install `TonicService` to `TonicManager` with `TonicManager::install_service()`.
@@ -743,6 +743,8 @@ pub(crate) struct TonicManager {
     network_keypair: NetworkKeyPair,
     own_address: SocketAddr,
     validator_client: Arc<TonicValidatorClient>,
+    #[allow(dead_code)]
+    observer_client: Arc<TonicObserverClient>,
     server: Option<ServerHandle>,
     observer_server: Option<ServerHandle>,
 }
@@ -750,6 +752,10 @@ pub(crate) struct TonicManager {
 impl TonicManager {
     pub(crate) fn new(context: Arc<Context>, network_keypair: NetworkKeyPair) -> Self {
         let validator_client = Arc::new(TonicValidatorClient::new(
+            context.clone(),
+            network_keypair.clone(),
+        ));
+        let observer_client = Arc::new(TonicObserverClient::new(
             context.clone(),
             network_keypair.clone(),
         ));
@@ -777,6 +783,7 @@ impl TonicManager {
             network_keypair,
             own_address,
             validator_client,
+            observer_client,
             server: None,
             observer_server: None,
         }
@@ -823,6 +830,7 @@ impl TonicManager {
 
 impl NetworkManager for TonicManager {
     type ValidatorClient = TonicValidatorClient;
+    type ObserverClient = TonicObserverClient;
 
     fn new(context: Arc<Context>, network_keypair: NetworkKeyPair) -> Self {
         TonicManager::new(context, network_keypair)
@@ -830,6 +838,10 @@ impl NetworkManager for TonicManager {
 
     fn validator_client(&self) -> Arc<Self::ValidatorClient> {
         self.validator_client.clone()
+    }
+
+    fn observer_client(&self) -> Arc<Self::ObserverClient> {
+        self.observer_client.clone()
     }
 
     fn update_peer_address(&self, peer: AuthorityIndex, address: Option<Multiaddr>) {


### PR DESCRIPTION
## Description 

After introducing the `ObserverService` we now have multiple combinations of nodes communicating with each other:
* validator <-> validator
* validator <-> observer
* observer <-> observer

introducing the `SynchronizerClient` and the `CommitSyncerClient` to abstract away the communication so the components themselves are not dealing with the networking details and making this more transparent to them. 

## Test plan 

CI

## Next
- [ ] https://github.com/MystenLabs/sui/pull/25477
- [ ] https://github.com/MystenLabs/sui/pull/25549

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
