### PR TITLE
docs(indexer): update checkpoint type in framework examples

### DIFF
--- a/docs/content/concepts/data-access/pipeline-architecture.mdx
+++ b/docs/content/concepts/data-access/pipeline-architecture.mdx
@@ -418,7 +418,7 @@ The `Handler` is where you implement your indexing business logic. The framework
 ```rust
 trait Processor {
     // Called by Processor workers
-    fn process(&self, checkpoint: &CheckpointData) -> Vec<Self::Value>;
+    async fn process(&self, checkpoint: &Arc<Checkpoint>) -> anyhow::Result<Vec<Self::Value>>;
 }
 
 trait Handler { 

--- a/docs/content/guides/developer/accessing-data/custom-indexer/bring-your-own-store.mdx
+++ b/docs/content/guides/developer/accessing-data/custom-indexer/bring-your-own-store.mdx
@@ -246,7 +246,7 @@ In checkpoint data, these events arrive as **raw BCS bytes** that need to be con
 
     ```rust
     impl Processor for YourHandler {
-        fn process(&self, checkpoint: &Arc<CheckpointData>) -> anyhow::Result<Vec<Self::Value>> {
+        async fn process(&self, checkpoint: &Arc<Checkpoint>) -> anyhow::Result<Vec<Self::Value>> {
             let mut results = Vec::new();
 
             for transaction in &checkpoint.transactions {

--- a/docs/content/guides/developer/accessing-data/custom-indexing-framework.mdx
+++ b/docs/content/guides/developer/accessing-data/custom-indexing-framework.mdx
@@ -19,11 +19,11 @@ Sequential and concurrent pipeline types and their trade-offs are detailed in [P
 
 <summary>
 
-`CheckpointData` struct
+`Checkpoint` struct
 
 </summary>
 
-<ImportContent source="crates/sui-types/src/full_checkpoint_content.rs" mode="code" struct="CheckpointData" />
+<ImportContent source="crates/sui-types/src/full_checkpoint_content.rs" mode="code" struct="Checkpoint" />
 
 </details>
 


### PR DESCRIPTION
## Description

Updating some of our docs examples related to the indexing framework, in response to some recent interface changes:

- `CheckpointData` -> `Checkpoint`.
- `process` function is now `async`.

## Test plan

:eyes:

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
