### PR TITLE
Revert "[consensus] use fifo compaction by default (#25314)"

### DIFF
--- a/consensus/config/src/parameters.rs
+++ b/consensus/config/src/parameters.rs
@@ -92,10 +92,6 @@ pub struct Parameters {
     #[serde(default = "Parameters::default_commit_sync_batches_ahead")]
     pub commit_sync_batches_ahead: usize,
 
-    /// Whether to use FIFO compaction for RocksDB.
-    #[serde(default = "Parameters::default_use_fifo_compaction")]
-    pub use_fifo_compaction: bool,
-
     /// Tonic network settings.
     #[serde(default = "TonicParameters::default")]
     pub tonic: TonicParameters,
@@ -196,10 +192,6 @@ impl Parameters {
         // while keeping the total number of inflight fetches and unprocessed fetched commits limited.
         32
     }
-
-    pub(crate) fn default_use_fifo_compaction() -> bool {
-        true
-    }
 }
 
 impl Default for Parameters {
@@ -221,7 +213,6 @@ impl Default for Parameters {
             commit_sync_parallel_fetches: Parameters::default_commit_sync_parallel_fetches(),
             commit_sync_batch_size: Parameters::default_commit_sync_batch_size(),
             commit_sync_batches_ahead: Parameters::default_commit_sync_batches_ahead(),
-            use_fifo_compaction: Parameters::default_use_fifo_compaction(),
             tonic: TonicParameters::default(),
             internal: InternalParameters::default(),
         }

--- a/consensus/config/tests/snapshots/parameters_test__parameters.snap
+++ b/consensus/config/tests/snapshots/parameters_test__parameters.snap
@@ -23,7 +23,6 @@ dag_state_cached_rounds: 500
 commit_sync_parallel_fetches: 8
 commit_sync_batch_size: 100
 commit_sync_batches_ahead: 32
-use_fifo_compaction: true
 tonic:
   keepalive_interval:
     secs: 10

--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -219,10 +219,7 @@ where
         let network_client = network_manager.client();
 
         let store_path = context.parameters.db_path.as_path().to_str().unwrap();
-        let store = Arc::new(RocksDBStore::new(
-            store_path,
-            context.parameters.use_fifo_compaction,
-        ));
+        let store = Arc::new(RocksDBStore::new(store_path));
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
 
         let block_verifier = Arc::new(SignedBlockVerifier::new(

--- a/consensus/core/src/storage/rocksdb_store.rs
+++ b/consensus/core/src/storage/rocksdb_store.rs
@@ -55,22 +55,18 @@ impl RocksDBStore {
 
     /// Creates a new instance of RocksDB storage.
     #[cfg(not(tidehunter))]
-    pub fn new(path: &str, use_fifo_compaction: bool) -> Self {
+    pub fn new(path: &str) -> Self {
         // Consensus data has high write throughput (all transactions) and is rarely read
         // (only during recovery and when helping peers catch up).
         let db_options = default_db_options().optimize_db_for_write_throughput(2);
         let mut metrics_conf = MetricConf::new("consensus");
         metrics_conf.read_sample_interval = SamplingInterval::new(Duration::from_secs(60), 0);
-        let cf_options = if use_fifo_compaction {
-            default_db_options().optimize_for_no_deletion()
-        } else {
-            default_db_options().optimize_for_write_throughput()
-        };
+        let cf_options = default_db_options().optimize_for_write_throughput();
         let column_family_options = DBMapTableConfigMap::new(BTreeMap::from([
             (
                 Self::BLOCKS_CF.to_string(),
-                cf_options
-                    .clone()
+                default_db_options()
+                    .optimize_for_write_throughput_no_deletion()
                     // Using larger block is ok since there is not much point reads on the cf.
                     .set_block_options(512, 128 << 10),
             ),
@@ -92,7 +88,7 @@ impl RocksDBStore {
     }
 
     #[cfg(tidehunter)]
-    pub fn new(path: &str, _use_fifo_compaction: bool) -> Self {
+    pub fn new(path: &str) -> Self {
         tracing::warn!("Consensus store using tidehunter");
         use typed_store::tidehunter_util::{
             KeyIndexing, KeySpaceConfig, KeyType, ThConfig, default_mutex_count,

--- a/consensus/core/src/storage/store_tests.rs
+++ b/consensus/core/src/storage/store_tests.rs
@@ -31,7 +31,7 @@ impl TestStore {
 fn new_rocksdb_teststore() -> TestStore {
     let temp_dir = TempDir::new().unwrap();
     TestStore::RocksDB((
-        RocksDBStore::new(temp_dir.path().to_str().unwrap(), true),
+        RocksDBStore::new(temp_dir.path().to_str().unwrap()),
         temp_dir,
     ))
 }

--- a/crates/sui-tool/src/commands.rs
+++ b/crates/sui-tool/src/commands.rs
@@ -436,7 +436,7 @@ impl ToolCommand {
                 start_commit,
                 end_commit,
             } => {
-                let rocks_db_store = RocksDBStore::new(&db_path, true);
+                let rocks_db_store = RocksDBStore::new(&db_path);
 
                 let start_commit = start_commit.unwrap_or(0);
                 let end_commit = end_commit.unwrap_or(u32::MAX);


### PR DESCRIPTION
## Summary
- Cherry-pick of the revert of PR #25314 onto the v1.66.0 release branch
- Due to file limit changes

## Test plan
- CI