### PR TITLE
Remove FastpathCertified status and simplify authority server

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -16,4 +16,4 @@ TGE = "TGE"
 TTO = "TTO"
 
 [files]
-extend-exclude = ["**/*.excalidraw"]
+extend-exclude = ["**/*.excalidraw", "**/*.snap"]

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -1212,7 +1212,7 @@ impl AuthorityPerEpochStore {
         );
 
         let consensus_tx_status_cache = if protocol_config.mysticeti_fastpath() {
-            Some(ConsensusTxStatusCache::new(protocol_config.gc_depth()))
+            Some(ConsensusTxStatusCache::new())
         } else {
             None
         };
@@ -3518,10 +3518,6 @@ impl AuthorityPerEpochStore {
 
         // EOP can only be sent after finalizing remaining transactions.
         self.pending_consensus_certificates_empty()
-            && self
-                .consensus_tx_status_cache
-                .as_ref()
-                .is_none_or(|c| c.get_num_fastpath_certified() == 0)
     }
 
     pub(crate) fn write_pending_checkpoint(

--- a/crates/sui-core/src/authority/consensus_tx_status_cache.rs
+++ b/crates/sui-core/src/authority/consensus_tx_status_cache.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::{BTreeMap, BTreeSet, btree_map::Entry};
+use std::collections::{BTreeMap, btree_map::Entry};
 
 use consensus_types::block::Round;
 use mysten_common::sync::notify_read::NotifyRead;
@@ -20,8 +20,6 @@ pub(crate) const CONSENSUS_STATUS_RETENTION_ROUNDS: u32 = 400;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum ConsensusTxStatus {
-    // Transaction is voted to accept by a quorum of validators on fastpath.
-    FastpathCertified,
     // Transaction is rejected, either by a quorum of validators or indirectly post-commit.
     Rejected,
     // Transaction is finalized post commit.
@@ -44,9 +42,6 @@ pub(crate) enum NotifyReadConsensusTxStatusResult {
 }
 
 pub(crate) struct ConsensusTxStatusCache {
-    // GC depth in consensus.
-    consensus_gc_depth: u32,
-
     inner: RwLock<Inner>,
 
     status_notify_read: NotifyRead<ConsensusPosition, ConsensusTxStatus>,
@@ -59,23 +54,14 @@ pub(crate) struct ConsensusTxStatusCache {
 struct Inner {
     /// A map of transaction position to its status from consensus.
     transaction_status: BTreeMap<ConsensusPosition, ConsensusTxStatus>,
-    /// Consensus positions that are currently in the fastpath certified state.
-    fastpath_certified: BTreeSet<ConsensusPosition>,
     /// The last leader round updated in update_last_committed_leader_round().
     last_committed_leader_round: Option<Round>,
 }
 
 impl ConsensusTxStatusCache {
-    pub(crate) fn new(consensus_gc_depth: Round) -> Self {
-        assert!(
-            consensus_gc_depth < CONSENSUS_STATUS_RETENTION_ROUNDS,
-            "{} vs {}",
-            consensus_gc_depth,
-            CONSENSUS_STATUS_RETENTION_ROUNDS
-        );
+    pub(crate) fn new() -> Self {
         let (last_committed_leader_round_tx, last_committed_leader_round_rx) = watch::channel(None);
         Self {
-            consensus_gc_depth,
             inner: Default::default(),
             status_notify_read: Default::default(),
             last_committed_leader_round_tx,
@@ -101,52 +87,23 @@ impl ConsensusTxStatusCache {
         pos: ConsensusPosition,
         status: ConsensusTxStatus,
     ) {
-        // Calls to set_transaction_status are async and can be out of order.
-        // Makes sure this is tolerated by handling state transitions properly.
         let status_entry = inner.transaction_status.entry(pos);
         match status_entry {
             Entry::Vacant(entry) => {
-                // Set the status for the first time.
                 entry.insert(status);
-                if status == ConsensusTxStatus::FastpathCertified {
-                    // Only path where a status can be set to fastpath certified.
-                    assert!(inner.fastpath_certified.insert(pos));
-                }
             }
-            Entry::Occupied(mut entry) => {
+            Entry::Occupied(entry) => {
                 let old_status = *entry.get();
-                match (old_status, status) {
-                    // If the statuses are the same, no update is needed.
-                    (s1, s2) if s1 == s2 => return,
-                    // FastpathCertified is transient and can be updated to other statuses.
-                    (ConsensusTxStatus::FastpathCertified, _) => {
-                        entry.insert(status);
-                        if old_status == ConsensusTxStatus::FastpathCertified {
-                            // Only path where a status can transition out of fastpath certified.
-                            assert!(inner.fastpath_certified.remove(&pos));
-                        }
-                    }
-                    // This happens when statuses arrive out-of-order, and is a no-op.
-                    (
-                        ConsensusTxStatus::Rejected
-                        | ConsensusTxStatus::Dropped
-                        | ConsensusTxStatus::Finalized,
-                        ConsensusTxStatus::FastpathCertified,
-                    ) => {
-                        return;
-                    }
-                    // Transitions between terminal statuses are invalid.
-                    _ => {
-                        panic!(
-                            "Conflicting status updates for transaction {:?}: {:?} -> {:?}",
-                            pos, old_status, status
-                        );
-                    }
+                if old_status == status {
+                    return;
                 }
+                panic!(
+                    "Conflicting status updates for transaction {:?}: {:?} -> {:?}",
+                    pos, old_status, status
+                );
             }
         };
 
-        // All code paths leading to here should have set the status.
         debug!("Transaction status is set for {}: {:?}", pos, status);
         self.status_notify_read.notify(&pos, &status);
     }
@@ -158,8 +115,6 @@ impl ConsensusTxStatusCache {
         consensus_position: ConsensusPosition,
         old_status: Option<ConsensusTxStatus>,
     ) -> NotifyReadConsensusTxStatusResult {
-        // TODO(fastpath): We should track the typical distance between the last committed round
-        // and the requested round notified as metrics.
         let registration = self.status_notify_read.register_one(&consensus_position);
         let mut round_rx = self.last_committed_leader_round_rx.clone();
         {
@@ -167,14 +122,8 @@ impl ConsensusTxStatusCache {
             if let Some(status) = inner.transaction_status.get(&consensus_position)
                 && Some(status) != old_status.as_ref()
             {
-                if let Some(old_status) = old_status {
-                    // The only scenario where the status may change, is when the transaction
-                    // is initially fastpath certified, and then later finalized or rejected.
-                    assert_eq!(old_status, ConsensusTxStatus::FastpathCertified);
-                }
                 return NotifyReadConsensusTxStatusResult::Status(*status);
             }
-            // Inner read lock dropped here.
         }
 
         let expiration_check = async {
@@ -224,29 +173,7 @@ impl ConsensusTxStatusCache {
         // Remove transactions that are expired.
         while let Some((position, _)) = inner.transaction_status.first_key_value() {
             if position.block.round + CONSENSUS_STATUS_RETENTION_ROUNDS <= leader_round {
-                let (pos, status) = inner.transaction_status.pop_first().unwrap();
-                // Ensure the transaction is not in the fastpath certified set.
-                if status == ConsensusTxStatus::FastpathCertified {
-                    assert!(inner.fastpath_certified.remove(&pos));
-                }
-            } else {
-                break;
-            }
-        }
-
-        // GC fastpath certified transactions.
-        // In theory, notify_read_transaction_status_change() could return `Rejected` status directly
-        // to waiters on GC'ed transactions.
-        // But it is necessary to track the number of fastpath certified status anyway for end of epoch.
-        // So rejecting every fastpath certified transaction here.
-        while let Some(position) = inner.fastpath_certified.first().cloned() {
-            if position.block.round + self.consensus_gc_depth <= leader_round {
-                // Reject GC'ed transactions that were previously fastpath certified.
-                self.set_transaction_status_inner(
-                    &mut inner,
-                    position,
-                    ConsensusTxStatus::Rejected,
-                );
+                inner.transaction_status.pop_first();
             } else {
                 break;
             }
@@ -258,10 +185,6 @@ impl ConsensusTxStatusCache {
 
     pub(crate) fn get_last_committed_leader_round(&self) -> Option<u32> {
         *self.last_committed_leader_round_rx.borrow()
-    }
-
-    pub(crate) fn get_num_fastpath_certified(&self) -> usize {
-        self.inner.read().fastpath_certified.len()
     }
 
     /// Returns true if the position is too far ahead of the last committed round.
@@ -310,25 +233,23 @@ mod tests {
 
     #[tokio::test]
     async fn test_set_and_get_transaction_status() {
-        let cache = ConsensusTxStatusCache::new(60);
+        let cache = ConsensusTxStatusCache::new();
         let tx_pos = create_test_tx_position(1, 0);
 
-        // Set initial status
-        cache.set_transaction_status(tx_pos, ConsensusTxStatus::FastpathCertified);
+        cache.set_transaction_status(tx_pos, ConsensusTxStatus::Finalized);
 
-        // Read status immediately
         let result = cache
             .notify_read_transaction_status_change(tx_pos, None)
             .await;
         assert!(matches!(
             result,
-            NotifyReadConsensusTxStatusResult::Status(ConsensusTxStatus::FastpathCertified)
+            NotifyReadConsensusTxStatusResult::Status(ConsensusTxStatus::Finalized)
         ));
     }
 
     #[tokio::test]
     async fn test_status_notification() {
-        let cache = Arc::new(ConsensusTxStatusCache::new(60));
+        let cache = Arc::new(ConsensusTxStatusCache::new());
         let tx_pos = create_test_tx_position(1, 0);
 
         // Spawn a task that waits for status update
@@ -355,24 +276,20 @@ mod tests {
 
     #[tokio::test]
     async fn test_round_expiration() {
-        let cache = ConsensusTxStatusCache::new(60);
+        let cache = ConsensusTxStatusCache::new();
         let tx_pos = create_test_tx_position(1, 0);
 
-        // Set initial status
-        cache.set_transaction_status(tx_pos, ConsensusTxStatus::FastpathCertified);
+        cache.set_transaction_status(tx_pos, ConsensusTxStatus::Finalized);
 
-        // Set initial leader round which doesn't GC anything.
         cache
             .update_last_committed_leader_round(CONSENSUS_STATUS_RETENTION_ROUNDS + 1)
             .await;
 
-        // Update with round that will trigger GC using previous round (CONSENSUS_STATUS_RETENTION_ROUNDS + 1)
-        // This will expire transactions up to and including round 1
+        // Triggers GC using previous round
         cache
             .update_last_committed_leader_round(CONSENSUS_STATUS_RETENTION_ROUNDS + 2)
             .await;
 
-        // Try to read status - should be expired
         let result = cache
             .notify_read_transaction_status_change(tx_pos, None)
             .await;
@@ -383,22 +300,25 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_multiple_status_updates() {
-        let cache = ConsensusTxStatusCache::new(60);
+    #[should_panic(expected = "Conflicting status updates")]
+    async fn test_conflicting_status_updates() {
+        let cache = ConsensusTxStatusCache::new();
         let tx_pos = create_test_tx_position(1, 0);
 
-        // Set initial status
-        cache.set_transaction_status(tx_pos, ConsensusTxStatus::FastpathCertified);
+        cache.set_transaction_status(tx_pos, ConsensusTxStatus::Finalized);
+        cache.set_transaction_status(tx_pos, ConsensusTxStatus::Rejected);
+    }
 
-        // Update status
+    #[tokio::test]
+    async fn test_duplicate_status_is_noop() {
+        let cache = ConsensusTxStatusCache::new();
+        let tx_pos = create_test_tx_position(1, 0);
+
+        cache.set_transaction_status(tx_pos, ConsensusTxStatus::Finalized);
         cache.set_transaction_status(tx_pos, ConsensusTxStatus::Finalized);
 
-        // Read with old status
         let result = cache
-            .notify_read_transaction_status_change(
-                tx_pos,
-                Some(ConsensusTxStatus::FastpathCertified),
-            )
+            .notify_read_transaction_status_change(tx_pos, None)
             .await;
         assert!(matches!(
             result,
@@ -408,12 +328,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_cleanup_expired_rounds() {
-        let cache = ConsensusTxStatusCache::new(60);
+        let cache = ConsensusTxStatusCache::new();
 
         // Add transactions for multiple rounds
         for round in 1..=5 {
             let tx_pos = create_test_tx_position(round, 0);
-            cache.set_transaction_status(tx_pos, ConsensusTxStatus::FastpathCertified);
+            cache.set_transaction_status(tx_pos, ConsensusTxStatus::Finalized);
         }
 
         // Set initial leader round which doesn't GC anything.
@@ -469,7 +389,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_concurrent_operations() {
-        let cache = Arc::new(ConsensusTxStatusCache::new(60));
+        let cache = Arc::new(ConsensusTxStatusCache::new());
         let tx_pos = create_test_tx_position(1, 0);
 
         // Spawn multiple tasks that wait for status
@@ -497,149 +417,5 @@ mod tests {
                 NotifyReadConsensusTxStatusResult::Status(ConsensusTxStatus::Finalized)
             ));
         }
-    }
-
-    #[tokio::test]
-    async fn test_out_of_order_status_updates() {
-        let cache = Arc::new(ConsensusTxStatusCache::new(60));
-        let tx_pos = create_test_tx_position(1, 0);
-
-        // First update status to Finalized.
-        cache.set_transaction_status(tx_pos, ConsensusTxStatus::Finalized);
-        let result = cache
-            .notify_read_transaction_status_change(tx_pos, None)
-            .await;
-        assert!(matches!(
-            result,
-            NotifyReadConsensusTxStatusResult::Status(ConsensusTxStatus::Finalized)
-        ));
-
-        let cache_clone = cache.clone();
-        let notify_read_task = tokio::spawn(async move {
-            cache_clone
-                .notify_read_transaction_status_change(tx_pos, Some(ConsensusTxStatus::Finalized))
-                .await
-        });
-
-        // We should never receive a new status update since the new status is older than the old status.
-        cache.set_transaction_status(tx_pos, ConsensusTxStatus::FastpathCertified);
-        let result = tokio::time::timeout(Duration::from_secs(3), notify_read_task).await;
-        assert!(result.is_err());
-        assert_eq!(
-            cache.get_transaction_status(&tx_pos),
-            Some(ConsensusTxStatus::Finalized)
-        );
-    }
-
-    #[tokio::test]
-    async fn test_fastpath_certified_tracking() {
-        let cache = Arc::new(ConsensusTxStatusCache::new(60));
-
-        // Initially, no fastpath certified transactions
-        assert_eq!(cache.get_num_fastpath_certified(), 0);
-
-        // Add fastpath certified transactions
-        let tx_pos1 = create_test_tx_position(100, 0);
-        let tx_pos2 = create_test_tx_position(100, 1);
-        let tx_pos3 = create_test_tx_position(101, 2);
-        let tx_pos4 = create_test_tx_position(102, 3);
-
-        cache.set_transaction_status(tx_pos1, ConsensusTxStatus::FastpathCertified);
-        assert_eq!(cache.get_num_fastpath_certified(), 1);
-
-        cache.set_transaction_status(tx_pos2, ConsensusTxStatus::FastpathCertified);
-        assert_eq!(cache.get_num_fastpath_certified(), 2);
-
-        cache.set_transaction_status(tx_pos3, ConsensusTxStatus::FastpathCertified);
-        assert_eq!(cache.get_num_fastpath_certified(), 3);
-
-        cache.set_transaction_status(tx_pos4, ConsensusTxStatus::FastpathCertified);
-        assert_eq!(cache.get_num_fastpath_certified(), 4);
-
-        // Add a non-fastpath certified transaction
-        let tx_pos5 = create_test_tx_position(103, 4);
-        cache.set_transaction_status(tx_pos5, ConsensusTxStatus::Finalized);
-        assert_eq!(cache.get_num_fastpath_certified(), 4);
-
-        // Transition one fastpath certified to finalized
-        cache.set_transaction_status(tx_pos1, ConsensusTxStatus::Finalized);
-        assert_eq!(cache.get_num_fastpath_certified(), 3);
-        assert_eq!(
-            cache.get_transaction_status(&tx_pos1),
-            Some(ConsensusTxStatus::Finalized)
-        );
-
-        // Transition another fastpath certified to rejected
-        cache.set_transaction_status(tx_pos2, ConsensusTxStatus::Rejected);
-        assert_eq!(cache.get_num_fastpath_certified(), 2);
-        assert_eq!(
-            cache.get_transaction_status(&tx_pos2),
-            Some(ConsensusTxStatus::Rejected)
-        );
-
-        // Test GC of fastpath certified transactions
-        // tx_pos3 is at round 101, with gc_depth=60, it will be GC'd when prev leader round >= 161
-        // tx_pos4 is at round 102, with gc_depth=60, it will be GC'd when prev leader round >= 162
-
-        // Set initial leader round which doesn't GC anything.
-        cache.update_last_committed_leader_round(160).await;
-        assert_eq!(cache.get_num_fastpath_certified(), 2);
-        assert_eq!(
-            cache.get_transaction_status(&tx_pos3),
-            Some(ConsensusTxStatus::FastpathCertified)
-        );
-        assert_eq!(
-            cache.get_transaction_status(&tx_pos4),
-            Some(ConsensusTxStatus::FastpathCertified)
-        );
-
-        // Update to 161: uses 160 for GC
-        // tx_pos3: 101 + 60 = 161, 161 <= 160 is false, so NOT GC'd yet
-        cache.update_last_committed_leader_round(161).await;
-        assert_eq!(cache.get_num_fastpath_certified(), 2);
-        assert_eq!(
-            cache.get_transaction_status(&tx_pos3),
-            Some(ConsensusTxStatus::FastpathCertified)
-        );
-        assert_eq!(
-            cache.get_transaction_status(&tx_pos4),
-            Some(ConsensusTxStatus::FastpathCertified)
-        );
-
-        // Update to 162: uses 161 for GC
-        // tx_pos3: 101 + 60 = 161, 161 <= 161 is true, so GC'd
-        // tx_pos4: 102 + 60 = 162, 162 <= 161 is false, so NOT GC'd
-        cache.update_last_committed_leader_round(162).await;
-        assert_eq!(cache.get_num_fastpath_certified(), 1);
-        assert_eq!(
-            cache.get_transaction_status(&tx_pos3),
-            Some(ConsensusTxStatus::Rejected)
-        );
-        assert_eq!(
-            cache.get_transaction_status(&tx_pos4),
-            Some(ConsensusTxStatus::FastpathCertified)
-        );
-
-        // Update to 163: uses 162 for GC
-        // tx_pos4: 102 + 60 = 162, 162 <= 162 is true, so GC'd
-        cache.update_last_committed_leader_round(163).await;
-        assert_eq!(cache.get_num_fastpath_certified(), 0);
-        assert_eq!(
-            cache.get_transaction_status(&tx_pos4),
-            Some(ConsensusTxStatus::Rejected)
-        );
-
-        // Test that setting a transaction directly to non-fastpath doesn't affect count
-        let tx_pos6 = create_test_tx_position(200, 5);
-        cache.set_transaction_status(tx_pos6, ConsensusTxStatus::Finalized);
-        assert_eq!(cache.get_num_fastpath_certified(), 0);
-
-        // Can't transition from finalized back to fastpath certified
-        cache.set_transaction_status(tx_pos6, ConsensusTxStatus::FastpathCertified);
-        assert_eq!(cache.get_num_fastpath_certified(), 0);
-        assert_eq!(
-            cache.get_transaction_status(&tx_pos6),
-            Some(ConsensusTxStatus::Finalized)
-        );
     }
 }


### PR DESCRIPTION
Remove the FastpathCertified variant from ConsensusTxStatus and simplify the authority server's wait-for-effects flow:
- Remove FastpathCertified from ConsensusTxStatus enum and all handling
- Remove consensus_gc_depth from ConsensusTxStatusCache
- Remove fastpath EOP readiness check in authority_per_epoch_store
- Simplify wait_for_fastpath_effects into wait_for_consensus_status
- Simplify ping_response to single await
- Update wait_for_effects_tests to remove FastpathCertified test cases
- Exclude .snap files from typos checking

## Description 

Describe the changes or additions included in this PR.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
