### PR TITLE
Add gas validation fuzz and edge-case tests for dry-run and dev-inspect

### DIFF
--- a/crates/transaction-fuzzer/tests/gas_data_tests.rs
+++ b/crates/transaction-fuzzer/tests/gas_data_tests.rs
@@ -3,17 +3,132 @@
 
 use proptest::arbitrary::*;
 use proptest::test_runner::TestCaseError;
-use sui_types::base_types::dbg_addr;
-use sui_types::crypto::KeypairTraits;
+use sui_types::base_types::{ObjectID, ObjectRef, SuiAddress, dbg_addr};
+use sui_types::crypto::{AccountKeyPair, KeypairTraits, get_key_pair};
+use sui_types::digests::TransactionDigest;
+use sui_types::error::SuiError;
+use sui_types::object::{MoveObject, OBJECT_START_VERSION, Object, Owner};
 use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
-use sui_types::transaction::TransactionData;
-use sui_types::transaction::TransactionKind;
+use sui_types::transaction::{GasData, TransactionData, TransactionKind};
 use sui_types::utils::to_sender_signed_transaction;
 use tracing::debug;
 use transaction_fuzzer::GasDataGenConfig;
 use transaction_fuzzer::GasDataWithObjects;
 use transaction_fuzzer::executor::Executor;
-use transaction_fuzzer::run_proptest;
+use transaction_fuzzer::{run_proptest, run_proptest_with_fullnode};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn make_transfer_sui_pt() -> TransactionKind {
+    let mut builder = ProgrammableTransactionBuilder::new();
+    builder.transfer_sui(dbg_addr(2), None);
+    TransactionKind::ProgrammableTransaction(builder.finish())
+}
+
+fn make_gas_coin(sender: SuiAddress, balance: u64) -> Object {
+    Object::new_move(
+        MoveObject::new_gas_coin(OBJECT_START_VERSION, ObjectID::random(), balance),
+        Owner::AddressOwner(sender),
+        TransactionDigest::genesis_marker(),
+    )
+}
+
+fn make_gas_data(sender: SuiAddress, objects: &[Object], price: u64, budget: u64) -> GasData {
+    GasData {
+        payment: objects
+            .iter()
+            .map(|o| o.compute_object_reference())
+            .collect(),
+        owner: sender,
+        price,
+        budget,
+    }
+}
+
+/// Results of running a gas scenario through all 4 execution modes.
+struct AllModeResults {
+    normal: Result<(), SuiError>,
+    dry_run: Result<(), SuiError>,
+    dev_inspect_skip: Result<(), SuiError>,
+    dev_inspect_no_skip: Result<(), SuiError>,
+}
+
+/// Run a gas scenario through normal execution, dry-run, dev-inspect(skip=true),
+/// and dev-inspect(skip=false). Returns results from each mode.
+fn run_all_modes(
+    executor: &mut Executor,
+    sender: SuiAddress,
+    sender_key: &AccountKeyPair,
+    gas_data: GasData,
+    objects: &[Object],
+) -> AllModeResults {
+    executor.add_objects(objects);
+
+    let kind = make_transfer_sui_pt();
+    let gas_refs: Vec<ObjectRef> = gas_data.payment.clone();
+    let price = gas_data.price;
+    let budget = gas_data.budget;
+
+    // Normal execution (uses validator)
+    let tx_data = TransactionData::new_with_gas_data(kind.clone(), sender, gas_data.clone());
+    let tx = to_sender_signed_transaction(tx_data, sender_key);
+    let normal = executor.execute_transaction(tx).map(|_| ());
+
+    // For dry-run and dev-inspect, we need a separate fullnode executor since the
+    // validator executor rejects these calls. Create one and insert the same objects.
+    let mut fullnode = Executor::new_fullnode();
+    fullnode.add_objects(objects);
+
+    // Dry-run
+    let tx_data = TransactionData::new_with_gas_data(kind.clone(), sender, gas_data);
+    let dry_run = fullnode.dry_run_transaction(tx_data);
+
+    // Dev-inspect with skip_checks=true (default)
+    let dev_inspect_skip = fullnode.dev_inspect_transaction(
+        sender,
+        kind.clone(),
+        Some(price),
+        Some(budget),
+        Some(sender),
+        Some(gas_refs.clone()),
+        Some(true),
+    );
+
+    // Dev-inspect with skip_checks=false
+    let dev_inspect_no_skip = fullnode.dev_inspect_transaction(
+        sender,
+        kind,
+        Some(price),
+        Some(budget),
+        Some(sender),
+        Some(gas_refs),
+        Some(false),
+    );
+
+    AllModeResults {
+        normal,
+        dry_run,
+        dev_inspect_skip,
+        dev_inspect_no_skip,
+    }
+}
+
+fn assert_err_contains(result: &Result<(), SuiError>, expected_substring: &str, mode: &str) {
+    let err = result
+        .as_ref()
+        .expect_err(&format!("{mode}: expected error, got Ok"));
+    let err_str = format!("{err:?}");
+    assert!(
+        err_str.contains(expected_substring),
+        "{mode}: expected error containing '{expected_substring}', got: {err_str}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Proptest fuzz tests (original + extended to dry-run & dev-inspect)
+// ---------------------------------------------------------------------------
 
 /// Send transfer sui txn with provided random gas data and gas objects to an authority.
 fn test_with_random_gas_data(
@@ -41,6 +156,49 @@ fn test_with_random_gas_data(
     Ok(())
 }
 
+fn test_with_random_gas_data_dry_run(
+    gas_data_test: GasDataWithObjects,
+    executor: &mut Executor,
+) -> Result<(), TestCaseError> {
+    let gas_data = gas_data_test.gas_data;
+    let objects = gas_data_test.objects;
+    let sender = gas_data_test.sender_key.public().into();
+
+    executor.add_objects(&objects);
+    let kind = make_transfer_sui_pt();
+    let tx_data = TransactionData::new_with_gas_data(kind, sender, gas_data);
+
+    let result = executor.dry_run_transaction(tx_data);
+    debug!("dry_run result: {:?}", result);
+    Ok(())
+}
+
+fn test_with_random_gas_data_dev_inspect(
+    gas_data_test: GasDataWithObjects,
+    executor: &mut Executor,
+    skip_checks: bool,
+) -> Result<(), TestCaseError> {
+    let gas_data = gas_data_test.gas_data;
+    let objects = gas_data_test.objects;
+    let sender: SuiAddress = gas_data_test.sender_key.public().into();
+
+    executor.add_objects(&objects);
+    let kind = make_transfer_sui_pt();
+    let gas_refs: Vec<ObjectRef> = gas_data.payment.clone();
+
+    let result = executor.dev_inspect_transaction(
+        sender,
+        kind,
+        Some(gas_data.price),
+        Some(gas_data.budget),
+        Some(gas_data.owner),
+        Some(gas_refs),
+        Some(skip_checks),
+    );
+    debug!("dev_inspect (skip={skip_checks}) result: {:?}", result);
+    Ok(())
+}
+
 #[test]
 #[cfg_attr(msim, ignore)]
 fn test_gas_data_owned_or_immut() {
@@ -57,4 +215,200 @@ fn test_gas_data_any_owner() {
     run_proptest(1000, strategy, |gas_data_test, mut executor| {
         test_with_random_gas_data(gas_data_test, &mut executor)
     });
+}
+
+#[test]
+#[cfg_attr(msim, ignore)]
+fn test_gas_data_dry_run_fuzz() {
+    let strategy = any_with::<GasDataWithObjects>(GasDataGenConfig::owned_by_sender_or_immut());
+    run_proptest_with_fullnode(1000, strategy, |gas_data_test, mut executor| {
+        test_with_random_gas_data_dry_run(gas_data_test, &mut executor)
+    });
+}
+
+#[test]
+#[cfg_attr(msim, ignore)]
+fn test_gas_data_dev_inspect_skip_checks_fuzz() {
+    // Must use sender_owned_only() because skip_checks=true bypasses ownership
+    // validation, and non-sender-owned gas objects (immutable, shared) would panic
+    // during execution when the system tries to modify them.
+    let strategy = any_with::<GasDataWithObjects>(GasDataGenConfig::sender_owned_only());
+    run_proptest_with_fullnode(1000, strategy, |gas_data_test, mut executor| {
+        test_with_random_gas_data_dev_inspect(gas_data_test, &mut executor, true)
+    });
+}
+
+#[test]
+#[cfg_attr(msim, ignore)]
+fn test_gas_data_dev_inspect_no_skip_fuzz() {
+    let strategy = any_with::<GasDataWithObjects>(GasDataGenConfig::owned_by_sender_or_immut());
+    run_proptest_with_fullnode(1000, strategy, |gas_data_test, mut executor| {
+        test_with_random_gas_data_dev_inspect(gas_data_test, &mut executor, false)
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Deterministic edge case tests
+// ---------------------------------------------------------------------------
+
+/// Valid gas data succeeds in all execution modes.
+#[test]
+#[cfg_attr(msim, ignore)]
+fn test_valid_gas_data_all_modes() {
+    let (sender, sender_key): (SuiAddress, AccountKeyPair) = get_key_pair();
+    let mut executor = Executor::new();
+    let rgp = executor.get_reference_gas_price();
+    let budget = rgp * 200_000; // well above min_transaction_cost
+    let gas_obj = make_gas_coin(sender, budget);
+    let gas_data = make_gas_data(sender, std::slice::from_ref(&gas_obj), rgp, budget);
+
+    let results = run_all_modes(&mut executor, sender, &sender_key, gas_data, &[gas_obj]);
+
+    assert!(results.normal.is_ok(), "normal: {:?}", results.normal);
+    assert!(results.dry_run.is_ok(), "dry_run: {:?}", results.dry_run);
+    assert!(
+        results.dev_inspect_skip.is_ok(),
+        "dev_inspect_skip: {:?}",
+        results.dev_inspect_skip
+    );
+    assert!(
+        results.dev_inspect_no_skip.is_ok(),
+        "dev_inspect_no_skip: {:?}",
+        results.dev_inspect_no_skip
+    );
+}
+
+/// Gas price = 0 (below RGP) fails in all modes.
+#[test]
+#[cfg_attr(msim, ignore)]
+fn test_gas_price_zero() {
+    let (sender, sender_key): (SuiAddress, AccountKeyPair) = get_key_pair();
+    let mut executor = Executor::new();
+    let budget = 100_000_000;
+    let gas_obj = make_gas_coin(sender, budget);
+    let gas_data = make_gas_data(sender, std::slice::from_ref(&gas_obj), 0, budget);
+
+    let results = run_all_modes(&mut executor, sender, &sender_key, gas_data, &[gas_obj]);
+
+    assert_err_contains(&results.normal, "GasPriceUnderRGP", "normal");
+    assert_err_contains(&results.dry_run, "GasPriceUnderRGP", "dry_run");
+    assert_err_contains(
+        &results.dev_inspect_skip,
+        "GasPriceUnderRGP",
+        "dev_inspect_skip",
+    );
+    assert_err_contains(
+        &results.dev_inspect_no_skip,
+        "GasPriceUnderRGP",
+        "dev_inspect_no_skip",
+    );
+}
+
+/// Gas price just below RGP fails in all modes.
+#[test]
+#[cfg_attr(msim, ignore)]
+fn test_gas_price_below_rgp() {
+    let (sender, sender_key): (SuiAddress, AccountKeyPair) = get_key_pair();
+    let mut executor = Executor::new();
+    let rgp = executor.get_reference_gas_price();
+    let budget = 100_000_000;
+    let gas_obj = make_gas_coin(sender, budget);
+    let gas_data = make_gas_data(sender, std::slice::from_ref(&gas_obj), rgp - 1, budget);
+
+    let results = run_all_modes(&mut executor, sender, &sender_key, gas_data, &[gas_obj]);
+
+    assert_err_contains(&results.normal, "GasPriceUnderRGP", "normal");
+    assert_err_contains(&results.dry_run, "GasPriceUnderRGP", "dry_run");
+    assert_err_contains(
+        &results.dev_inspect_skip,
+        "GasPriceUnderRGP",
+        "dev_inspect_skip",
+    );
+    assert_err_contains(
+        &results.dev_inspect_no_skip,
+        "GasPriceUnderRGP",
+        "dev_inspect_no_skip",
+    );
+}
+
+/// Gas budget of zero (below min_transaction_cost) fails in all modes.
+#[test]
+#[cfg_attr(msim, ignore)]
+fn test_gas_budget_zero() {
+    let (sender, sender_key): (SuiAddress, AccountKeyPair) = get_key_pair();
+    let mut executor = Executor::new();
+    let rgp = executor.get_reference_gas_price();
+    let gas_obj = make_gas_coin(sender, 1_000_000_000);
+    let gas_data = make_gas_data(sender, std::slice::from_ref(&gas_obj), rgp, 0);
+
+    let results = run_all_modes(&mut executor, sender, &sender_key, gas_data, &[gas_obj]);
+
+    assert_err_contains(&results.normal, "GasBudgetTooLow", "normal");
+    assert_err_contains(&results.dry_run, "GasBudgetTooLow", "dry_run");
+    assert_err_contains(
+        &results.dev_inspect_skip,
+        "GasBudgetTooLow",
+        "dev_inspect_skip",
+    );
+    assert_err_contains(
+        &results.dev_inspect_no_skip,
+        "GasBudgetTooLow",
+        "dev_inspect_no_skip",
+    );
+}
+
+/// Gas budget exceeding max_tx_gas fails in all modes.
+#[test]
+#[cfg_attr(msim, ignore)]
+fn test_gas_budget_exceeds_max() {
+    let (sender, sender_key): (SuiAddress, AccountKeyPair) = get_key_pair();
+    let mut executor = Executor::new();
+    let rgp = executor.get_reference_gas_price();
+    let max_budget = sui_protocol_config::ProtocolConfig::get_for_max_version_UNSAFE().max_tx_gas();
+    let over_budget = max_budget + 1;
+    let gas_obj = make_gas_coin(sender, over_budget);
+    let gas_data = make_gas_data(sender, std::slice::from_ref(&gas_obj), rgp, over_budget);
+
+    let results = run_all_modes(&mut executor, sender, &sender_key, gas_data, &[gas_obj]);
+
+    assert_err_contains(&results.normal, "GasBudgetTooHigh", "normal");
+    assert_err_contains(&results.dry_run, "GasBudgetTooHigh", "dry_run");
+    assert_err_contains(
+        &results.dev_inspect_skip,
+        "GasBudgetTooHigh",
+        "dev_inspect_skip",
+    );
+    assert_err_contains(
+        &results.dev_inspect_no_skip,
+        "GasBudgetTooHigh",
+        "dev_inspect_no_skip",
+    );
+}
+
+/// Gas coin balance < budget fails in all modes.
+#[test]
+#[cfg_attr(msim, ignore)]
+fn test_gas_balance_insufficient() {
+    let (sender, sender_key): (SuiAddress, AccountKeyPair) = get_key_pair();
+    let mut executor = Executor::new();
+    let rgp = executor.get_reference_gas_price();
+    let budget = rgp * 200_000;
+    // Gas coin has only 1 MIST -- far below budget
+    let gas_obj = make_gas_coin(sender, 1);
+    let gas_data = make_gas_data(sender, std::slice::from_ref(&gas_obj), rgp, budget);
+
+    let results = run_all_modes(&mut executor, sender, &sender_key, gas_data, &[gas_obj]);
+
+    assert_err_contains(&results.normal, "GasBalanceTooLow", "normal");
+    assert_err_contains(&results.dry_run, "GasBalanceTooLow", "dry_run");
+    assert_err_contains(
+        &results.dev_inspect_skip,
+        "GasBalanceTooLow",
+        "dev_inspect_skip",
+    );
+    assert_err_contains(
+        &results.dev_inspect_no_skip,
+        "GasBalanceTooLow",
+        "dev_inspect_no_skip",
+    );
 }


### PR DESCRIPTION
## Description 

Extend the transaction-fuzzer crate to test gas data handling across all
four execution modes: normal (validator), dry-run (fullnode), dev-inspect
with skip_checks=true, and dev-inspect with skip_checks=false. This
exercises the gas validation paths fixed in #25361 where (1) gas price
was accessed unchecked causing panics and (2) non-gas-coin objects as
gas in dev-inspect caused crashes.

Changes to executor.rs:
- Add `new_fullnode()` constructor that uses a keypair not in the
  committee, enabling dry-run and dev-inspect APIs
- Add `dry_run_transaction()` wrapping `AuthorityState::dry_exec_transaction`
- Add `dev_inspect_transaction()` wrapping
  `AuthorityState::dev_inspect_transaction_block`

Changes to lib.rs:
- Add `GasDataGenConfig::sender_owned_only()` which forces all gas coins
  to `AddressOwner(sender)`, needed for dev-inspect with skip_checks=true
  where ownership validation is bypassed and non-sender-owned gas objects
  would panic during execution
- Add `run_proptest_with_fullnode()` helper and refactor existing
  `run_proptest()` to share logic via `run_proptest_with_executor()`

Changes to gas_data_tests.rs:
- Add 3 new proptest fuzz tests: dry-run, dev-inspect with skip_checks,
  and dev-inspect without skip_checks
- Add 6 deterministic edge-case tests covering: valid gas data,
  gas_price=0, gas_price < RGP, gas_budget=0, gas_budget > max, and
  insufficient balance — each verified across all four execution modes
- Add helpers for constructing gas coins, gas data, and running all
  modes in a single test

## Test plan 

The gas tests cover 4 execution modes across 2 testing strategies:

### Proptest Fuzz Tests (5 total)

Randomly generate gas data (price, budget, balance, number of gas
objects, ownership) and verify no panics across execution modes:

- `test_gas_data_owned_or_immut`: sender-owned or immutable gas, normal execution
- `test_gas_data_any_owner`: any owner type, normal execution
- `test_gas_data_dry_run_fuzz`: sender-owned or immutable gas, dry-run
- `test_gas_data_dev_inspect_skip_checks_fuzz`: sender-owned only, dev-inspect (skip_checks=true)
- `test_gas_data_dev_inspect_no_skip_fuzz`: sender-owned or immutable gas, dev-inspect (skip_checks=false)

The skip_checks fuzz uses `sender_owned_only()` because when ownership
validation is bypassed, immutable/shared gas objects panic in
`temporary_store.rs` when the system tries to modify them.

### Deterministic Edge Case Tests (6 total)

Each test runs through all 4 modes (normal, dry-run, dev-inspect with
and without skip_checks) and asserts the expected error:

- `test_valid_gas_data_all_modes`: valid price/budget/balance, all modes succeed
- `test_gas_price_zero`: gas_price=0, expects "Gas price 0 under min"
- `test_gas_price_below_rgp`: gas_price=rgp-1, expects "Gas price ... under min"
- `test_gas_budget_zero`: gas_budget=0, expects "Gas budget 0 is below min"
- `test_gas_budget_exceeds_max`: gas_budget > max_tx_gas, expects "Gas budget ... is above max"
- `test_gas_balance_insufficient`: balance=1, expects "balance of ... is lower than the needed"

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
