### PR TITLE
Concurrent pipeline rate limiter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15088,6 +15088,7 @@ dependencies = [
  "diesel-async",
  "diesel_migrations",
  "futures",
+ "governor",
  "object_store 0.13.0",
  "pin-project-lite",
  "prometheus",

--- a/crates/sui-analytics-indexer/src/config.rs
+++ b/crates/sui-analytics-indexer/src/config.rs
@@ -100,6 +100,7 @@ impl CommitterLayer {
                 .watermark_interval_ms
                 .unwrap_or(base.watermark_interval_ms),
             watermark_interval_jitter_ms: 0,
+            max_rows_per_second: base.max_rows_per_second,
         }
     }
 }

--- a/crates/sui-checkpoint-blob-indexer/src/config.rs
+++ b/crates/sui-checkpoint-blob-indexer/src/config.rs
@@ -21,6 +21,7 @@ pub struct CommitterLayer {
     pub collect_interval_ms: Option<u64>,
     pub watermark_interval_ms: Option<u64>,
     pub watermark_interval_jitter_ms: Option<u64>,
+    pub max_rows_per_second: Option<u64>,
 }
 
 impl CommitterLayer {
@@ -34,6 +35,7 @@ impl CommitterLayer {
             watermark_interval_jitter_ms: self
                 .watermark_interval_jitter_ms
                 .unwrap_or(base.watermark_interval_jitter_ms),
+            max_rows_per_second: self.max_rows_per_second.or(base.max_rows_per_second),
         }
     }
 }

--- a/crates/sui-indexer-alt-framework/Cargo.toml
+++ b/crates/sui-indexer-alt-framework/Cargo.toml
@@ -19,6 +19,7 @@ diesel = { workspace = true, features = ["chrono"] }
 diesel-async = { workspace = true, features = ["bb8", "postgres", "async-connection-wrapper"] }
 diesel_migrations.workspace = true
 futures.workspace = true
+governor.workspace = true
 pin-project-lite.workspace = true
 prometheus.workspace = true
 object_store.workspace = true

--- a/crates/sui-indexer-alt-framework/src/pipeline/concurrent/committer.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/concurrent/committer.rs
@@ -1,10 +1,13 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::num::NonZeroU32;
 use std::sync::Arc;
 use std::time::Duration;
 
 use backoff::ExponentialBackoff;
+use governor::Quota;
+use governor::RateLimiter;
 use sui_futures::service::Service;
 use sui_futures::stream::Break;
 use sui_futures::stream::TrySpawnStreamExt;
@@ -22,6 +25,12 @@ use crate::pipeline::WatermarkPart;
 use crate::pipeline::concurrent::BatchedRows;
 use crate::pipeline::concurrent::Handler;
 use crate::store::Store;
+
+/// A shared rate limiter with its burst size pre-computed for chunked acquisition.
+struct SharedRateLimiter {
+    limiter: governor::DefaultDirectRateLimiter,
+    burst: NonZeroU32,
+}
 
 /// If the committer needs to retry a commit, it will wait this long initially.
 const INITIAL_RETRY_INTERVAL: Duration = Duration::from_millis(100);
@@ -54,6 +63,15 @@ pub(super) fn committer<H: Handler + 'static>(
             &metrics.latest_partially_committed_checkpoint,
         );
 
+        let rate_limiter: Option<Arc<SharedRateLimiter>> = config.max_rows_per_second.map(|rps| {
+            let burst = NonZeroU32::new(rps as u32).expect("max_rows_per_second must be > 0");
+            let quota = Quota::per_second(burst);
+            Arc::new(SharedRateLimiter {
+                limiter: RateLimiter::direct(quota),
+                burst,
+            })
+        });
+
         match ReceiverStream::new(rx)
             .try_for_each_spawned(
                 config.write_concurrency,
@@ -68,6 +86,7 @@ pub(super) fn committer<H: Handler + 'static>(
                     let db = db.clone();
                     let metrics = metrics.clone();
                     let checkpoint_lag_reporter = checkpoint_lag_reporter.clone();
+                    let rate_limiter = rate_limiter.clone();
 
                     // Repeatedly try to get a connection to the DB and write the batch. Use an
                     // exponential backoff in case the failure is due to contention over the DB
@@ -182,6 +201,24 @@ pub(super) fn committer<H: Handler + 'static>(
                     };
 
                     async move {
+                        // Acquire rate-limiter tokens before connecting to the store, so we
+                        // don't hold a connection while waiting. Large batches exceeding burst
+                        // are acquired in chunks.
+                        if batch_len > 0
+                            && let Some(ref rl) = rate_limiter
+                        {
+                            let burst = rl.burst.get();
+                            let mut remaining = batch_len as u32;
+                            while remaining > 0 {
+                                let take = remaining.min(burst);
+                                rl.limiter
+                                    .until_n_ready(NonZeroU32::new(take).unwrap())
+                                    .await
+                                    .expect("take <= burst, so this cannot fail");
+                                remaining -= take;
+                            }
+                        }
+
                         // Double check that the commit actually went through, (this backoff should
                         // not produce any permanent errors, but if it does, we need to shutdown
                         // the pipeline).

--- a/crates/sui-indexer-alt-framework/src/pipeline/mod.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/mod.rs
@@ -38,6 +38,9 @@ pub struct CommitterConfig {
 
     /// Maximum random jitter to add to the watermark interval, in milliseconds.
     pub watermark_interval_jitter_ms: u64,
+
+    /// Maximum rows per second the committer may write. `None` means unlimited.
+    pub max_rows_per_second: Option<u64>,
 }
 
 /// Processed values associated with a single checkpoint. This is an internal type used to
@@ -154,6 +157,7 @@ impl Default for CommitterConfig {
             collect_interval_ms: 500,
             watermark_interval_ms: 500,
             watermark_interval_jitter_ms: 0,
+            max_rows_per_second: None,
         }
     }
 }

--- a/crates/sui-indexer-alt/src/config.rs
+++ b/crates/sui-indexer-alt/src/config.rs
@@ -79,6 +79,7 @@ pub struct CommitterLayer {
     pub write_concurrency: Option<usize>,
     pub collect_interval_ms: Option<u64>,
     pub watermark_interval_ms: Option<u64>,
+    pub max_rows_per_second: Option<u64>,
 }
 
 #[DefaultConfig]
@@ -153,6 +154,7 @@ impl IndexerConfig {
                     collect_interval_ms: Some(50),
                     watermark_interval_ms: Some(50),
                     write_concurrency: Some(1),
+                    ..Default::default()
                 },
                 pruner: PrunerLayer {
                     interval_ms: Some(50),
@@ -229,6 +231,7 @@ impl CommitterLayer {
                 .watermark_interval_ms
                 .unwrap_or(base.watermark_interval_ms),
             watermark_interval_jitter_ms: 0,
+            max_rows_per_second: self.max_rows_per_second.or(base.max_rows_per_second),
         })
     }
 }
@@ -334,6 +337,7 @@ impl Merge for CommitterLayer {
             write_concurrency: other.write_concurrency.or(self.write_concurrency),
             collect_interval_ms: other.collect_interval_ms.or(self.collect_interval_ms),
             watermark_interval_ms: other.watermark_interval_ms.or(self.watermark_interval_ms),
+            max_rows_per_second: other.max_rows_per_second.or(self.max_rows_per_second),
         })
     }
 }
@@ -438,6 +442,7 @@ impl From<CommitterConfig> for CommitterLayer {
             write_concurrency: Some(config.write_concurrency),
             collect_interval_ms: Some(config.collect_interval_ms),
             watermark_interval_ms: Some(config.watermark_interval_ms),
+            max_rows_per_second: config.max_rows_per_second,
         }
     }
 }
@@ -477,6 +482,7 @@ mod tests {
                     write_concurrency: Some(10),
                     collect_interval_ms: Some(1000),
                     watermark_interval_ms: None,
+                    ..Default::default()
                 }),
                 checkpoint_lag: Some(100),
             }),
@@ -485,6 +491,7 @@ mod tests {
                     write_concurrency: Some(5),
                     collect_interval_ms: Some(500),
                     watermark_interval_ms: None,
+                    ..Default::default()
                 }),
                 ..Default::default()
             }),
@@ -497,6 +504,7 @@ mod tests {
                     write_concurrency: Some(5),
                     collect_interval_ms: None,
                     watermark_interval_ms: Some(500),
+                    ..Default::default()
                 }),
                 checkpoint_lag: Some(200),
             }),
@@ -515,6 +523,7 @@ mod tests {
                         write_concurrency: Some(5),
                         collect_interval_ms: Some(1000),
                         watermark_interval_ms: Some(500),
+                        ..
                     }),
                     checkpoint_lag: Some(200),
                 }),
@@ -523,6 +532,7 @@ mod tests {
                         write_concurrency: Some(5),
                         collect_interval_ms: Some(500),
                         watermark_interval_ms: None,
+                        ..
                     }),
                     pruner: None,
                 }),
@@ -538,6 +548,7 @@ mod tests {
                         write_concurrency: Some(10),
                         collect_interval_ms: Some(1000),
                         watermark_interval_ms: Some(500),
+                        ..
                     }),
                     checkpoint_lag: Some(100),
                 }),
@@ -546,6 +557,7 @@ mod tests {
                         write_concurrency: Some(5),
                         collect_interval_ms: Some(500),
                         watermark_interval_ms: None,
+                        ..
                     }),
                     pruner: None,
                 }),

--- a/crates/sui-kvstore/src/config.rs
+++ b/crates/sui-kvstore/src/config.rs
@@ -21,6 +21,7 @@ pub struct CommitterLayer {
     pub collect_interval_ms: Option<u64>,
     pub watermark_interval_ms: Option<u64>,
     pub watermark_interval_jitter_ms: Option<u64>,
+    pub max_rows_per_second: Option<u64>,
 }
 
 impl CommitterLayer {
@@ -34,6 +35,7 @@ impl CommitterLayer {
             watermark_interval_jitter_ms: self
                 .watermark_interval_jitter_ms
                 .unwrap_or(base.watermark_interval_jitter_ms),
+            max_rows_per_second: self.max_rows_per_second.or(base.max_rows_per_second),
         }
     }
 }

--- a/docs/content/concepts/data-access/indexer-runtime-perf.mdx
+++ b/docs/content/concepts/data-access/indexer-runtime-perf.mdx
@@ -106,6 +106,10 @@ For complex configuration scenarios requiring deep understanding of pipeline int
 - [Sequential pipeline architecture](/concepts/data-access/pipeline-architecture.mdx#sequential-pipeline-architecture)
 - [Concurrent pipeline architecture](/concepts/data-access/pipeline-architecture.mdx#concurrent-pipeline-architecture)
 
+#### Rate limiting writes
+
+During backfills the indexer can produce rows faster than the database can absorb them. Each concurrent pipeline supports an optional `max_rows_per_second` setting that caps write throughput across all parallel writers for that pipeline. The rate limiter uses a smooth (GCRA) algorithm so writes are spread evenly rather than bursting. See [`CommitterConfig` optimization](/concepts/data-access/pipeline-architecture.mdx#committerconfig-optimization) for details.
+
 ## Tokio runtime debugging
 
 For performance-sensitive pipelines or when troubleshooting async runtime issues, the `sui-indexer-alt-framework` integrates with `tokio-console`, a powerful debugger for async Rust applications. This tool provides real-time insights into task execution, helping identify performance bottlenecks, stuck tasks, and memory issues.

--- a/docs/content/concepts/data-access/pipeline-architecture.mdx
+++ b/docs/content/concepts/data-access/pipeline-architecture.mdx
@@ -552,12 +552,18 @@ let config = ConcurrentConfig {
     committer: CommitterConfig {
         // Number of parallel database writers (default: 5)
         write_concurrency: 10,
-        
+
         // How often collector checks for batches in ms (default: 500)
         collect_interval_ms: 250,
-        
+
         // How often watermarks are updated in ms (default: 500)
         watermark_interval_ms: 1000,
+
+        // Maximum random jitter added to watermark interval in ms (default: 0)
+        watermark_interval_jitter_ms: 100,
+
+        // Cap write throughput in rows/sec per pipeline (default: None = unlimited)
+        max_rows_per_second: Some(5000),
     },
     pruner: Some(pruner_config),
 };
@@ -568,6 +574,7 @@ Tuning guidelines:
 - **`write_concurrency`:** Higher values result in faster throughput but more database connections; `ensure total_pipelines × write_concurrency < db_connection_pool_size`.
 - **`collect_interval_ms`:** Lower values reduce latency but increase CPU overhead.
 - **`watermark_interval_ms`:** Controls how often watermarks are updated. Higher values reduce database contention from frequent watermark writes but make the indexer slower to respond to pipeline progress.
+- **`max_rows_per_second`:** Caps the combined write rate across all `write_concurrency` workers for this pipeline. Useful during backfills to prevent the indexer from overwhelming the database. The limit uses a smooth (GCRA) rate limiter so writes are spread evenly rather than bursting. Set to `None` (the default) for unlimited throughput.
 
 #### `PrunerConfig` settings
 


### PR DESCRIPTION
## Description

Introducing a rate limiter for concurrent pipelines. For bigtable we need to be able to create small batches really fast, but not _too_ fast. This let's us hit the sweet spot.

Wasn't sure if it really made sense for sequntial pipelines but we can hook it in there too if there is a use case.

## Test plan

I was finally able to hover at a 60% p100 cpu utilization on my test cluster.
