### PR TITLE
feat: SIP-70 PTB Structural Digest

### DIFF
--- a/crates/sui-framework/packages/sui-framework/sources/tx_context.move
+++ b/crates/sui-framework/packages/sui-framework/sources/tx_context.move
@@ -81,6 +81,16 @@ public fun gas_price(_self: &TxContext): u64 {
 }
 native fun native_gas_price(): u64;
 
+/// Return the normalized structural digest of the current PTB (SIP-70).
+/// Deterministic: same logical PTB structure -> same digest,
+/// even if coin object IDs differ due to splits/merges.
+/// Enables governance contracts to vote on a PTB template hash
+/// and verify at execution time that the executor's PTB matches.
+public fun structural_digest(_self: &TxContext): vector<u8> {
+    native_structural_digest()
+}
+native fun native_structural_digest(): vector<u8>;
+
 // ==== test-only functions ====
 #[test_only]
 /// Return the number of id's created by the current transaction.

--- a/crates/sui-framework/packages/sui-framework/sources/tx_context.move
+++ b/crates/sui-framework/packages/sui-framework/sources/tx_context.move
@@ -86,10 +86,24 @@ native fun native_gas_price(): u64;
 /// even if coin object IDs differ due to splits/merges.
 /// Enables governance contracts to vote on a PTB template hash
 /// and verify at execution time that the executor's PTB matches.
+/// Output: [version_byte | blake2b256_hash] (33 bytes, version 0x01).
 public fun structural_digest(_self: &TxContext): vector<u8> {
     native_structural_digest()
 }
 native fun native_structural_digest(): vector<u8>;
+
+/// Return the structural digest with specified Pure inputs treated as wildcards (SIP-70 v2).
+/// Wildcarded inputs are hashed as a marker (0xFF) instead of their actual value,
+/// allowing governance contracts to verify PTB structure while letting the executor
+/// vary certain parameters (e.g. slippage tolerance, deadline timestamp).
+/// `wildcard_pure_indices` contains the input indices to wildcard.
+public fun structural_digest_masked(
+    _self: &TxContext,
+    wildcard_pure_indices: vector<u64>,
+): vector<u8> {
+    native_structural_digest_masked(wildcard_pure_indices)
+}
+native fun native_structural_digest_masked(wildcard_pure_indices: vector<u64>): vector<u8>;
 
 // ==== test-only functions ====
 #[test_only]

--- a/crates/sui-framework/packages/sui-framework/sources/tx_context.move
+++ b/crates/sui-framework/packages/sui-framework/sources/tx_context.move
@@ -92,22 +92,6 @@ public fun structural_digest(_self: &TxContext): vector<u8> {
 }
 native fun native_structural_digest(): vector<u8>;
 
-/// Return the structural digest with coin normalization and optional wildcards (SIP-70 v2).
-/// Coins hash by TypeTag + balance instead of ObjectID (fungible across split/merge).
-/// Wildcarded inputs are hashed as a marker (0xFF) instead of their actual value,
-/// allowing governance contracts to verify PTB structure while letting the executor
-/// vary certain parameters (e.g. slippage tolerance, deadline timestamp).
-/// Pass empty vector for no wildcards (coin normalization only).
-/// `wildcard_pure_indices` contains the input indices to wildcard.
-/// Aborts if any index exceeds u16::MAX.
-public fun structural_digest_masked(
-    _self: &TxContext,
-    wildcard_pure_indices: vector<u64>,
-): vector<u8> {
-    native_structural_digest_masked(wildcard_pure_indices)
-}
-native fun native_structural_digest_masked(wildcard_pure_indices: vector<u64>): vector<u8>;
-
 // ==== test-only functions ====
 #[test_only]
 /// Return the number of id's created by the current transaction.

--- a/crates/sui-framework/packages/sui-framework/sources/tx_context.move
+++ b/crates/sui-framework/packages/sui-framework/sources/tx_context.move
@@ -81,9 +81,9 @@ public fun gas_price(_self: &TxContext): u64 {
 }
 native fun native_gas_price(): u64;
 
-/// Return the normalized structural digest of the current PTB (SIP-70).
-/// Deterministic: same logical PTB structure -> same digest,
-/// even if coin object IDs differ due to splits/merges.
+/// Return the structural digest of the current PTB (SIP-70).
+/// Identity-preserving: coins hash by ObjectID (not normalized).
+/// Deterministic: same logical PTB structure -> same digest.
 /// Enables governance contracts to vote on a PTB template hash
 /// and verify at execution time that the executor's PTB matches.
 /// Output: [version_byte | blake2b256_hash] (33 bytes, version 0x01).
@@ -92,11 +92,14 @@ public fun structural_digest(_self: &TxContext): vector<u8> {
 }
 native fun native_structural_digest(): vector<u8>;
 
-/// Return the structural digest with specified Pure inputs treated as wildcards (SIP-70 v2).
+/// Return the structural digest with coin normalization and optional wildcards (SIP-70 v2).
+/// Coins hash by TypeTag + balance instead of ObjectID (fungible across split/merge).
 /// Wildcarded inputs are hashed as a marker (0xFF) instead of their actual value,
 /// allowing governance contracts to verify PTB structure while letting the executor
 /// vary certain parameters (e.g. slippage tolerance, deadline timestamp).
+/// Pass empty vector for no wildcards (coin normalization only).
 /// `wildcard_pure_indices` contains the input indices to wildcard.
+/// Aborts if any index exceeds u16::MAX.
 public fun structural_digest_masked(
     _self: &TxContext,
     wildcard_pure_indices: vector<u64>,

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -24,7 +24,7 @@ use tracing::{info, warn};
 
 /// The minimum and maximum protocol versions supported by this build.
 const MIN_PROTOCOL_VERSION: u64 = 1;
-const MAX_PROTOCOL_VERSION: u64 = 112;
+const MAX_PROTOCOL_VERSION: u64 = 113;
 
 // Record history of protocol version allocations here:
 //
@@ -1518,6 +1518,8 @@ pub struct ProtocolConfig {
     tx_context_gas_budget_cost_base: Option<u64>,
     tx_context_ids_created_cost_base: Option<u64>,
     tx_context_replace_cost_base: Option<u64>,
+    // SIP-70: Cost for structural_digest native function
+    tx_context_structural_digest_cost_base: Option<u64>,
 
     // Types
     // Cost params for the Move native function `is_one_time_witness<T: drop>(_: &T): bool`
@@ -2913,6 +2915,7 @@ impl ProtocolConfig {
             tx_context_gas_budget_cost_base: None,
             tx_context_ids_created_cost_base: None,
             tx_context_replace_cost_base: None,
+            tx_context_structural_digest_cost_base: None,
 
             // `types` module
             // Cost params for the Move native function `is_one_time_witness<T: drop>(_: &T): bool`
@@ -4590,6 +4593,10 @@ impl ProtocolConfig {
                     }
 
                     cfg.feature_flags.address_aliases = true;
+                }
+                113 => {
+                    // SIP-70: PTB Structural Digest
+                    cfg.tx_context_structural_digest_cost_base = Some(30);
                 }
                 // Use this template when making changes:
                 //

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -1520,6 +1520,8 @@ pub struct ProtocolConfig {
     tx_context_replace_cost_base: Option<u64>,
     // SIP-70: Cost for structural_digest native function
     tx_context_structural_digest_cost_base: Option<u64>,
+    // SIP-70 v2: Cost for structural_digest_masked native function
+    tx_context_structural_digest_masked_cost_base: Option<u64>,
 
     // Types
     // Cost params for the Move native function `is_one_time_witness<T: drop>(_: &T): bool`
@@ -2916,6 +2918,7 @@ impl ProtocolConfig {
             tx_context_ids_created_cost_base: None,
             tx_context_replace_cost_base: None,
             tx_context_structural_digest_cost_base: None,
+            tx_context_structural_digest_masked_cost_base: None,
 
             // `types` module
             // Cost params for the Move native function `is_one_time_witness<T: drop>(_: &T): bool`
@@ -4597,6 +4600,8 @@ impl ProtocolConfig {
                 113 => {
                     // SIP-70: PTB Structural Digest
                     cfg.tx_context_structural_digest_cost_base = Some(30);
+                    // SIP-70 v2: structural_digest_masked (recomputation with wildcards)
+                    cfg.tx_context_structural_digest_masked_cost_base = Some(50);
                 }
                 // Use this template when making changes:
                 //

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -1521,9 +1521,6 @@ pub struct ProtocolConfig {
     // SIP-70: Cost for structural_digest native function
     tx_context_structural_digest_cost_base: Option<u64>,
     tx_context_structural_digest_cost_per_byte: Option<u64>,
-    // SIP-70 v2: Cost for structural_digest_masked native function
-    tx_context_structural_digest_masked_cost_base: Option<u64>,
-    tx_context_structural_digest_masked_cost_per_byte: Option<u64>,
 
     // Types
     // Cost params for the Move native function `is_one_time_witness<T: drop>(_: &T): bool`
@@ -2921,8 +2918,6 @@ impl ProtocolConfig {
             tx_context_replace_cost_base: None,
             tx_context_structural_digest_cost_base: None,
             tx_context_structural_digest_cost_per_byte: None,
-            tx_context_structural_digest_masked_cost_base: None,
-            tx_context_structural_digest_masked_cost_per_byte: None,
 
             // `types` module
             // Cost params for the Move native function `is_one_time_witness<T: drop>(_: &T): bool`
@@ -4605,9 +4600,6 @@ impl ProtocolConfig {
                     // SIP-70: PTB Structural Digest
                     cfg.tx_context_structural_digest_cost_base = Some(30);
                     cfg.tx_context_structural_digest_cost_per_byte = Some(1);
-                    // SIP-70 v2: structural_digest_masked (recomputation with wildcards)
-                    cfg.tx_context_structural_digest_masked_cost_base = Some(50);
-                    cfg.tx_context_structural_digest_masked_cost_per_byte = Some(2);
                 }
                 // Use this template when making changes:
                 //

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -1520,8 +1520,10 @@ pub struct ProtocolConfig {
     tx_context_replace_cost_base: Option<u64>,
     // SIP-70: Cost for structural_digest native function
     tx_context_structural_digest_cost_base: Option<u64>,
+    tx_context_structural_digest_cost_per_byte: Option<u64>,
     // SIP-70 v2: Cost for structural_digest_masked native function
     tx_context_structural_digest_masked_cost_base: Option<u64>,
+    tx_context_structural_digest_masked_cost_per_byte: Option<u64>,
 
     // Types
     // Cost params for the Move native function `is_one_time_witness<T: drop>(_: &T): bool`
@@ -2918,7 +2920,9 @@ impl ProtocolConfig {
             tx_context_ids_created_cost_base: None,
             tx_context_replace_cost_base: None,
             tx_context_structural_digest_cost_base: None,
+            tx_context_structural_digest_cost_per_byte: None,
             tx_context_structural_digest_masked_cost_base: None,
+            tx_context_structural_digest_masked_cost_per_byte: None,
 
             // `types` module
             // Cost params for the Move native function `is_one_time_witness<T: drop>(_: &T): bool`
@@ -4600,8 +4604,10 @@ impl ProtocolConfig {
                 113 => {
                     // SIP-70: PTB Structural Digest
                     cfg.tx_context_structural_digest_cost_base = Some(30);
+                    cfg.tx_context_structural_digest_cost_per_byte = Some(1);
                     // SIP-70 v2: structural_digest_masked (recomputation with wildcards)
                     cfg.tx_context_structural_digest_masked_cost_base = Some(50);
+                    cfg.tx_context_structural_digest_masked_cost_per_byte = Some(2);
                 }
                 // Use this template when making changes:
                 //

--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -1236,6 +1236,9 @@ pub struct TxContext {
     // whether the `TxContext` is native or not
     // (TODO: once we version execution we could drop this field)
     is_native: bool,
+    // Normalized structural digest of the PTB (SIP-70)
+    #[serde(default)]
+    structural_digest: Vec<u8>,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -1294,6 +1297,7 @@ impl TxContext {
             gas_budget,
             sponsor: sponsor.map(|s| s.into()),
             is_native: protocol_config.move_native_context(),
+            structural_digest: Vec::new(),
         }
     }
 
@@ -1347,6 +1351,16 @@ impl TxContext {
         self.sponsor.map(SuiAddress::from)
     }
 
+    /// Returns the normalized structural digest of the PTB (SIP-70).
+    pub fn structural_digest(&self) -> &[u8] {
+        &self.structural_digest
+    }
+
+    /// Sets the structural digest. Called by the execution engine before PTB execution.
+    pub fn set_structural_digest(&mut self, digest: Vec<u8>) {
+        self.structural_digest = digest;
+    }
+
     pub fn rgp(&self) -> u64 {
         self.rgp
     }
@@ -1384,6 +1398,7 @@ impl TxContext {
                 gas_budget: 0,
                 sponsor: None,
                 is_native: true,
+                structural_digest: Vec::new(),
             };
             tx_context.into()
         } else {

--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -1239,6 +1239,9 @@ pub struct TxContext {
     // Normalized structural digest of the PTB (SIP-70)
     #[serde(default)]
     structural_digest: Vec<u8>,
+    // Data for structural_digest_masked recomputation (SIP-70 v2, not serialized)
+    #[serde(skip)]
+    structural_digest_data: Option<crate::transaction::StructuralDigestData>,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -1298,6 +1301,7 @@ impl TxContext {
             sponsor: sponsor.map(|s| s.into()),
             is_native: protocol_config.move_native_context(),
             structural_digest: Vec::new(),
+            structural_digest_data: None,
         }
     }
 
@@ -1361,6 +1365,29 @@ impl TxContext {
         self.structural_digest = digest;
     }
 
+    /// Stores the PT + coin_info for masked digest recomputation (SIP-70 v2).
+    pub fn set_structural_digest_data(
+        &mut self,
+        data: crate::transaction::StructuralDigestData,
+    ) {
+        self.structural_digest_data = Some(data);
+    }
+
+    /// Recompute the structural digest with the given Pure input indices wildcarded.
+    pub fn structural_digest_masked(
+        &self,
+        wildcard_indices: &std::collections::BTreeSet<u16>,
+    ) -> Vec<u8> {
+        match &self.structural_digest_data {
+            Some(data) => data.pt.structural_digest_with_options(
+                Some(&data.coin_info),
+                wildcard_indices,
+            ),
+            // No PT data stored — fall back to the pre-computed full digest
+            None => self.structural_digest.clone(),
+        }
+    }
+
     pub fn rgp(&self) -> u64 {
         self.rgp
     }
@@ -1399,6 +1426,7 @@ impl TxContext {
                 sponsor: None,
                 is_native: true,
                 structural_digest: Vec::new(),
+                structural_digest_data: None,
             };
             tx_context.into()
         } else {

--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -1239,7 +1239,7 @@ pub struct TxContext {
     // Normalized structural digest of the PTB (SIP-70)
     #[serde(default)]
     structural_digest: Vec<u8>,
-    // Data for structural_digest_masked recomputation (SIP-70 v2, not serialized)
+    // Data for lazy structural_digest recomputation (SIP-70, not serialized)
     #[serde(skip)]
     structural_digest_data: Option<crate::transaction::StructuralDigestData>,
 }
@@ -1355,7 +1355,7 @@ impl TxContext {
         self.sponsor.map(SuiAddress::from)
     }
 
-    /// Returns the normalized structural digest of the PTB (SIP-70).
+    /// Returns the structural digest of the PTB (SIP-70).
     /// Lazily computes and caches the digest the first time it is requested.
     pub fn structural_digest(&mut self) -> Option<Vec<u8>> {
         if self.structural_digest.is_empty() {
@@ -1365,35 +1365,15 @@ impl TxContext {
         Some(self.structural_digest.clone())
     }
 
-    /// Stores the PT + coin_info for structural digest computation (SIP-70 v2).
+    /// Stores the PT for lazy structural digest computation (SIP-70).
     pub fn set_structural_digest_data(&mut self, data: crate::transaction::StructuralDigestData) {
         self.structural_digest_data = Some(data);
-    }
-
-    /// Recompute the structural digest with the given Pure input indices wildcarded.
-    pub fn structural_digest_masked(
-        &self,
-        wildcard_indices: &std::collections::BTreeSet<u16>,
-    ) -> Option<Vec<u8>> {
-        match &self.structural_digest_data {
-            Some(data) => Some(
-                data.pt
-                    .structural_digest_with_options(Some(&data.coin_info), wildcard_indices),
-            ),
-            None => None,
-        }
     }
 
     pub fn structural_digest_gas_bytes(&self) -> Option<u64> {
         self.structural_digest_data
             .as_ref()
             .map(|data| data.base_gas_bytes)
-    }
-
-    pub fn structural_digest_masked_gas_bytes(&self) -> Option<u64> {
-        self.structural_digest_data
-            .as_ref()
-            .map(|data| data.masked_gas_bytes)
     }
 
     pub fn rgp(&self) -> u64 {

--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -1356,20 +1356,17 @@ impl TxContext {
     }
 
     /// Returns the normalized structural digest of the PTB (SIP-70).
-    pub fn structural_digest(&self) -> &[u8] {
-        &self.structural_digest
+    /// Lazily computes and caches the digest the first time it is requested.
+    pub fn structural_digest(&mut self) -> Option<Vec<u8>> {
+        if self.structural_digest.is_empty() {
+            let data = self.structural_digest_data.as_ref()?;
+            self.structural_digest = data.pt.structural_digest();
+        }
+        Some(self.structural_digest.clone())
     }
 
-    /// Sets the structural digest. Called by the execution engine before PTB execution.
-    pub fn set_structural_digest(&mut self, digest: Vec<u8>) {
-        self.structural_digest = digest;
-    }
-
-    /// Stores the PT + coin_info for masked digest recomputation (SIP-70 v2).
-    pub fn set_structural_digest_data(
-        &mut self,
-        data: crate::transaction::StructuralDigestData,
-    ) {
+    /// Stores the PT + coin_info for structural digest computation (SIP-70 v2).
+    pub fn set_structural_digest_data(&mut self, data: crate::transaction::StructuralDigestData) {
         self.structural_digest_data = Some(data);
     }
 
@@ -1377,15 +1374,26 @@ impl TxContext {
     pub fn structural_digest_masked(
         &self,
         wildcard_indices: &std::collections::BTreeSet<u16>,
-    ) -> Vec<u8> {
+    ) -> Option<Vec<u8>> {
         match &self.structural_digest_data {
-            Some(data) => data.pt.structural_digest_with_options(
-                Some(&data.coin_info),
-                wildcard_indices,
+            Some(data) => Some(
+                data.pt
+                    .structural_digest_with_options(Some(&data.coin_info), wildcard_indices),
             ),
-            // No PT data stored — fall back to the pre-computed full digest
-            None => self.structural_digest.clone(),
+            None => None,
         }
+    }
+
+    pub fn structural_digest_gas_bytes(&self) -> Option<u64> {
+        self.structural_digest_data
+            .as_ref()
+            .map(|data| data.base_gas_bytes)
+    }
+
+    pub fn structural_digest_masked_gas_bytes(&self) -> Option<u64> {
+        self.structural_digest_data
+            .as_ref()
+            .map(|data| data.masked_gas_bytes)
     }
 
     pub fn rgp(&self) -> u64 {

--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -1013,6 +1013,13 @@ impl ProgrammableTransaction {
         result
     }
 
+    /// Hash a length as a u32 LE prefix. Prevents concatenation collisions
+    /// between adjacent variable-length fields (e.g. module "a" + function "bc"
+    /// vs module "ab" + function "c").
+    fn hash_len(hasher: &mut DefaultHash, len: usize) {
+        hasher.update(&(len as u32).to_le_bytes());
+    }
+
     fn hash_command_inner(
         &self,
         command: &Command,
@@ -1024,17 +1031,26 @@ impl ProgrammableTransaction {
             Command::MoveCall(call) => {
                 hasher.update(&[0x00]); // discriminator
                 hasher.update(call.package.as_ref());
+                // Length-prefix strings to prevent boundary collisions
+                Self::hash_len(&mut hasher, call.module.len());
                 hasher.update(call.module.as_bytes());
+                Self::hash_len(&mut hasher, call.function.len());
                 hasher.update(call.function.as_bytes());
+                // Count-prefix lists to prevent boundary ambiguity
+                Self::hash_len(&mut hasher, call.type_arguments.len());
                 for ty in &call.type_arguments {
-                    hasher.update(&bcs::to_bytes(ty).unwrap_or_default());
+                    let ty_bytes = bcs::to_bytes(ty).unwrap_or_default();
+                    Self::hash_len(&mut hasher, ty_bytes.len());
+                    hasher.update(&ty_bytes);
                 }
+                Self::hash_len(&mut hasher, call.arguments.len());
                 for arg in &call.arguments {
                     self.hash_argument_inner(&mut hasher, arg, coin_info, wildcard_indices);
                 }
             }
             Command::TransferObjects(objects, recipient) => {
                 hasher.update(&[0x01]);
+                Self::hash_len(&mut hasher, objects.len());
                 for obj in objects {
                     self.hash_argument_inner(&mut hasher, obj, coin_info, wildcard_indices);
                 }
@@ -1043,6 +1059,7 @@ impl ProgrammableTransaction {
             Command::SplitCoins(coin, amounts) => {
                 hasher.update(&[0x02]);
                 self.hash_argument_inner(&mut hasher, coin, coin_info, wildcard_indices);
+                Self::hash_len(&mut hasher, amounts.len());
                 for amt in amounts {
                     self.hash_argument_inner(&mut hasher, amt, coin_info, wildcard_indices);
                 }
@@ -1050,15 +1067,19 @@ impl ProgrammableTransaction {
             Command::MergeCoins(target, sources) => {
                 hasher.update(&[0x03]);
                 self.hash_argument_inner(&mut hasher, target, coin_info, wildcard_indices);
+                Self::hash_len(&mut hasher, sources.len());
                 for src in sources {
                     self.hash_argument_inner(&mut hasher, src, coin_info, wildcard_indices);
                 }
             }
             Command::Publish(modules, deps) => {
                 hasher.update(&[0x04]);
+                Self::hash_len(&mut hasher, modules.len());
                 for module in modules {
+                    Self::hash_len(&mut hasher, module.len());
                     hasher.update(module);
                 }
+                Self::hash_len(&mut hasher, deps.len());
                 for dep in deps {
                     hasher.update(dep.as_ref());
                 }
@@ -1066,17 +1087,26 @@ impl ProgrammableTransaction {
             Command::MakeMoveVec(type_tag, elements) => {
                 hasher.update(&[0x05]);
                 if let Some(tag) = type_tag {
-                    hasher.update(&bcs::to_bytes(tag).unwrap_or_default());
+                    hasher.update(&[0x01]); // tag-present marker
+                    let tag_bytes = bcs::to_bytes(tag).unwrap_or_default();
+                    Self::hash_len(&mut hasher, tag_bytes.len());
+                    hasher.update(&tag_bytes);
+                } else {
+                    hasher.update(&[0x00]); // tag-absent marker
                 }
+                Self::hash_len(&mut hasher, elements.len());
                 for elem in elements {
                     self.hash_argument_inner(&mut hasher, elem, coin_info, wildcard_indices);
                 }
             }
             Command::Upgrade(modules, deps, package_id, ticket) => {
                 hasher.update(&[0x06]);
+                Self::hash_len(&mut hasher, modules.len());
                 for module in modules {
+                    Self::hash_len(&mut hasher, module.len());
                     hasher.update(module);
                 }
+                Self::hash_len(&mut hasher, deps.len());
                 for dep in deps {
                     hasher.update(dep.as_ref());
                 }
@@ -1141,6 +1171,7 @@ impl ProgrammableTransaction {
                     hasher.update(&[0xFF]);
                 } else {
                     hasher.update(&[0x01]);
+                    Self::hash_len(hasher, bytes.len());
                     hasher.update(bytes);
                 }
             }
@@ -1187,7 +1218,7 @@ impl ProgrammableTransaction {
 /// Data needed for structural_digest_masked recomputation at runtime (SIP-70 v2).
 /// Stored on TxContext during execution so the masked native can recompute
 /// the digest with wildcard inputs.
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct StructuralDigestData {
     pub pt: ProgrammableTransaction,
     pub coin_info: BTreeMap<usize, (TypeTag, u64)>,

--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -969,44 +969,21 @@ impl ProgrammableTransaction {
             .any(|input| matches!(input, CallArg::Object(ObjectArg::SharedObject { .. })))
     }
 
-    /// Compute a deterministic structural digest of this PTB (SIP-70 v2).
+    /// Compute a deterministic structural digest of this PTB (SIP-70).
     ///
     /// The digest captures the logical structure of the transaction:
     /// - Which commands call which targets, in what order
     /// - How results flow between commands (provenance, not runtime identity)
     /// - What values are passed (Pure bytes, shared object IDs, owned object IDs)
     /// - Type arguments for each call
-    /// - Coins are normalized by TypeName + Balance (not ObjectID)
     ///
     /// Output format: [version_byte | blake2b256_hash]
     /// Version 0x01 = current scheme.
     pub fn structural_digest(&self) -> Vec<u8> {
-        self.structural_digest_with_options(None, &BTreeSet::new())
-    }
-
-    /// Returns a serialized-size proxy for gas metering structural digest work.
-    pub fn structural_digest_metered_bytes(&self) -> u64 {
-        u64::try_from(bcs::serialized_size(self).unwrap_or_default()).unwrap_or(u64::MAX)
-    }
-
-    /// Compute structural digest with coin normalization and/or wildcard support.
-    ///
-    /// - `coin_info`: maps input index to (TypeTag, balance) for coin-type inputs.
-    ///   When provided, coin inputs are hashed by TypeName + Balance instead of ObjectID,
-    ///   making the digest stable across coin split/merge.
-    /// - `wildcard_indices`: set of input indices whose Pure values are treated as wildcards.
-    ///   Wildcarded inputs hash as a 0xFF marker instead of their actual bytes, allowing
-    ///   the DAO to approve a PTB template while leaving certain parameters (e.g. slippage,
-    ///   deadline) to the executor's discretion.
-    pub fn structural_digest_with_options(
-        &self,
-        coin_info: Option<&BTreeMap<usize, (TypeTag, u64)>>,
-        wildcard_indices: &BTreeSet<u16>,
-    ) -> Vec<u8> {
         let mut outer_hasher = DefaultHash::default();
 
         for command in &self.commands {
-            let cmd_hash = self.hash_command_inner(command, coin_info, wildcard_indices);
+            let cmd_hash = self.hash_command_inner(command);
             outer_hasher.update(&cmd_hash);
         }
 
@@ -1018,6 +995,11 @@ impl ProgrammableTransaction {
         result
     }
 
+    /// Returns a serialized-size proxy for gas metering structural digest work.
+    pub fn structural_digest_metered_bytes(&self) -> u64 {
+        u64::try_from(bcs::serialized_size(self).unwrap_or_default()).unwrap_or(u64::MAX)
+    }
+
     /// Hash a length as a u32 LE prefix. Prevents concatenation collisions
     /// between adjacent variable-length fields (e.g. module "a" + function "bc"
     /// vs module "ab" + function "c").
@@ -1025,12 +1007,7 @@ impl ProgrammableTransaction {
         hasher.update(&(len as u32).to_le_bytes());
     }
 
-    fn hash_command_inner(
-        &self,
-        command: &Command,
-        coin_info: Option<&BTreeMap<usize, (TypeTag, u64)>>,
-        wildcard_indices: &BTreeSet<u16>,
-    ) -> [u8; 32] {
+    fn hash_command_inner(&self, command: &Command) -> [u8; 32] {
         let mut hasher = DefaultHash::default();
         match command {
             Command::MoveCall(call) => {
@@ -1050,31 +1027,31 @@ impl ProgrammableTransaction {
                 }
                 Self::hash_len(&mut hasher, call.arguments.len());
                 for arg in &call.arguments {
-                    self.hash_argument_inner(&mut hasher, arg, coin_info, wildcard_indices);
+                    self.hash_argument_inner(&mut hasher, arg);
                 }
             }
             Command::TransferObjects(objects, recipient) => {
                 hasher.update(&[0x01]);
                 Self::hash_len(&mut hasher, objects.len());
                 for obj in objects {
-                    self.hash_argument_inner(&mut hasher, obj, coin_info, wildcard_indices);
+                    self.hash_argument_inner(&mut hasher, obj);
                 }
-                self.hash_argument_inner(&mut hasher, recipient, coin_info, wildcard_indices);
+                self.hash_argument_inner(&mut hasher, recipient);
             }
             Command::SplitCoins(coin, amounts) => {
                 hasher.update(&[0x02]);
-                self.hash_argument_inner(&mut hasher, coin, coin_info, wildcard_indices);
+                self.hash_argument_inner(&mut hasher, coin);
                 Self::hash_len(&mut hasher, amounts.len());
                 for amt in amounts {
-                    self.hash_argument_inner(&mut hasher, amt, coin_info, wildcard_indices);
+                    self.hash_argument_inner(&mut hasher, amt);
                 }
             }
             Command::MergeCoins(target, sources) => {
                 hasher.update(&[0x03]);
-                self.hash_argument_inner(&mut hasher, target, coin_info, wildcard_indices);
+                self.hash_argument_inner(&mut hasher, target);
                 Self::hash_len(&mut hasher, sources.len());
                 for src in sources {
-                    self.hash_argument_inner(&mut hasher, src, coin_info, wildcard_indices);
+                    self.hash_argument_inner(&mut hasher, src);
                 }
             }
             Command::Publish(modules, deps) => {
@@ -1101,7 +1078,7 @@ impl ProgrammableTransaction {
                 }
                 Self::hash_len(&mut hasher, elements.len());
                 for elem in elements {
-                    self.hash_argument_inner(&mut hasher, elem, coin_info, wildcard_indices);
+                    self.hash_argument_inner(&mut hasher, elem);
                 }
             }
             Command::Upgrade(modules, deps, package_id, ticket) => {
@@ -1116,19 +1093,13 @@ impl ProgrammableTransaction {
                     hasher.update(dep.as_ref());
                 }
                 hasher.update(package_id.as_ref());
-                self.hash_argument_inner(&mut hasher, ticket, coin_info, wildcard_indices);
+                self.hash_argument_inner(&mut hasher, ticket);
             }
         }
         hasher.finalize().digest
     }
 
-    fn hash_argument_inner(
-        &self,
-        hasher: &mut DefaultHash,
-        arg: &Argument,
-        coin_info: Option<&BTreeMap<usize, (TypeTag, u64)>>,
-        wildcard_indices: &BTreeSet<u16>,
-    ) {
+    fn hash_argument_inner(&self, hasher: &mut DefaultHash, arg: &Argument) {
         match arg {
             Argument::GasCoin => {
                 hasher.update(&[0x00]);
@@ -1136,13 +1107,7 @@ impl ProgrammableTransaction {
             Argument::Input(idx) => {
                 let input_idx = *idx as usize;
                 if let Some(call_arg) = self.inputs.get(input_idx) {
-                    self.hash_call_arg_inner(
-                        hasher,
-                        call_arg,
-                        input_idx,
-                        coin_info,
-                        wildcard_indices,
-                    );
+                    self.hash_call_arg_inner(hasher, call_arg);
                 } else {
                     // Invalid input index — hash as-is for determinism
                     hasher.update(&[0x01]);
@@ -1161,24 +1126,12 @@ impl ProgrammableTransaction {
         }
     }
 
-    fn hash_call_arg_inner(
-        &self,
-        hasher: &mut DefaultHash,
-        call_arg: &CallArg,
-        input_idx: usize,
-        coin_info: Option<&BTreeMap<usize, (TypeTag, u64)>>,
-        wildcard_indices: &BTreeSet<u16>,
-    ) {
+    fn hash_call_arg_inner(&self, hasher: &mut DefaultHash, call_arg: &CallArg) {
         match call_arg {
             CallArg::Pure(bytes) => {
-                if wildcard_indices.contains(&(input_idx as u16)) {
-                    // Wildcard: hash marker instead of actual value
-                    hasher.update(&[0xFF]);
-                } else {
-                    hasher.update(&[0x01]);
-                    Self::hash_len(hasher, bytes.len());
-                    hasher.update(bytes);
-                }
+                hasher.update(&[0x01]);
+                Self::hash_len(hasher, bytes.len());
+                hasher.update(bytes);
             }
             CallArg::Object(ObjectArg::SharedObject { id, mutability, .. }) => {
                 // Shared objects: ObjectID plus mutability.
@@ -1193,27 +1146,14 @@ impl ProgrammableTransaction {
                 hasher.update(&[mutability_byte]);
             }
             CallArg::Object(ObjectArg::ImmOrOwnedObject((id, _, _))) => {
-                // Check coin normalization first
-                if let Some((type_tag, balance)) = coin_info.and_then(|m| m.get(&input_idx)) {
-                    hasher.update(&[0x08]); // coin-normalized
-                    hasher.update(&bcs::to_bytes(type_tag).unwrap_or_default());
-                    hasher.update(&balance.to_le_bytes());
-                } else {
-                    // Owned objects: ObjectID only (version drifts between vote and execution)
-                    hasher.update(&[0x03]);
-                    hasher.update(id.as_ref());
-                }
+                // Owned objects: ObjectID only (version drifts between vote and execution)
+                hasher.update(&[0x03]);
+                hasher.update(id.as_ref());
             }
             CallArg::Object(ObjectArg::Receiving((id, _, _))) => {
-                if let Some((type_tag, balance)) = coin_info.and_then(|m| m.get(&input_idx)) {
-                    hasher.update(&[0x09]); // coin-normalized receiving
-                    hasher.update(&bcs::to_bytes(type_tag).unwrap_or_default());
-                    hasher.update(&balance.to_le_bytes());
-                } else {
-                    // Receiving objects: ObjectID only
-                    hasher.update(&[0x04]);
-                    hasher.update(id.as_ref());
-                }
+                // Receiving objects: ObjectID only
+                hasher.update(&[0x04]);
+                hasher.update(id.as_ref());
             }
             CallArg::FundsWithdrawal(_) => {
                 hasher.update(&[0x07]);
@@ -1223,35 +1163,18 @@ impl ProgrammableTransaction {
     }
 }
 
-/// Data needed for structural_digest_masked recomputation at runtime (SIP-70 v2).
-/// Stored on TxContext during execution so the masked native can recompute
-/// the digest with wildcard inputs.
+/// Data needed for structural_digest recomputation at runtime (SIP-70).
+/// Stored on TxContext during execution so the native can compute the digest lazily.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct StructuralDigestData {
     pub pt: Arc<ProgrammableTransaction>,
-    pub coin_info: BTreeMap<usize, (TypeTag, u64)>,
     pub base_gas_bytes: u64,
-    pub masked_gas_bytes: u64,
 }
 
 impl StructuralDigestData {
-    pub fn new(
-        pt: Arc<ProgrammableTransaction>,
-        coin_info: BTreeMap<usize, (TypeTag, u64)>,
-    ) -> Self {
+    pub fn new(pt: Arc<ProgrammableTransaction>) -> Self {
         let base_gas_bytes = pt.structural_digest_metered_bytes();
-        let coin_info_bytes = coin_info.iter().fold(0u64, |acc, (_, (type_tag, _))| {
-            let type_tag_len = u64::try_from(bcs::to_bytes(type_tag).unwrap_or_default().len())
-                .unwrap_or(u64::MAX);
-            acc.saturating_add(type_tag_len).saturating_add(16)
-        });
-        let masked_gas_bytes = base_gas_bytes.saturating_add(coin_info_bytes);
-        Self {
-            pt,
-            coin_info,
-            base_gas_bytes,
-            masked_gas_bytes,
-        }
+        Self { pt, base_gas_bytes }
     }
 }
 

--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -969,28 +969,56 @@ impl ProgrammableTransaction {
             .any(|input| matches!(input, CallArg::Object(ObjectArg::SharedObject { .. })))
     }
 
-    /// Compute a deterministic structural digest of this PTB.
+    /// Compute a deterministic structural digest of this PTB (SIP-70 v2).
     ///
     /// The digest captures the logical structure of the transaction:
     /// - Which commands call which targets, in what order
     /// - How results flow between commands (provenance, not runtime identity)
-    /// - What values are passed (Pure bytes, shared object IDs, owned object refs)
+    /// - What values are passed (Pure bytes, shared object IDs, owned object IDs)
     /// - Type arguments for each call
+    /// - Coins are normalized by TypeName + Balance (not ObjectID)
     ///
-    /// This enables DAOs/governance contracts to vote on a PTB template hash
-    /// and verify at execution time that the executor's PTB matches.
+    /// Output format: [version_byte | blake2b256_hash]
+    /// Version 0x01 = current scheme.
     pub fn structural_digest(&self) -> Vec<u8> {
+        self.structural_digest_with_options(None, &BTreeSet::new())
+    }
+
+    /// Compute structural digest with coin normalization and/or wildcard support.
+    ///
+    /// - `coin_info`: maps input index to (TypeTag, balance) for coin-type inputs.
+    ///   When provided, coin inputs are hashed by TypeName + Balance instead of ObjectID,
+    ///   making the digest stable across coin split/merge.
+    /// - `wildcard_indices`: set of input indices whose Pure values are treated as wildcards.
+    ///   Wildcarded inputs hash as a 0xFF marker instead of their actual bytes, allowing
+    ///   the DAO to approve a PTB template while leaving certain parameters (e.g. slippage,
+    ///   deadline) to the executor's discretion.
+    pub fn structural_digest_with_options(
+        &self,
+        coin_info: Option<&BTreeMap<usize, (TypeTag, u64)>>,
+        wildcard_indices: &BTreeSet<u16>,
+    ) -> Vec<u8> {
         let mut outer_hasher = DefaultHash::default();
 
         for command in &self.commands {
-            let cmd_hash = self.hash_command(command);
+            let cmd_hash = self.hash_command_inner(command, coin_info, wildcard_indices);
             outer_hasher.update(&cmd_hash);
         }
 
-        outer_hasher.finalize().digest.to_vec()
+        let raw = outer_hasher.finalize().digest;
+        // Version prefix: 0x01 = current digest scheme
+        let mut result = Vec::with_capacity(1 + raw.len());
+        result.push(0x01);
+        result.extend_from_slice(&raw);
+        result
     }
 
-    fn hash_command(&self, command: &Command) -> [u8; 32] {
+    fn hash_command_inner(
+        &self,
+        command: &Command,
+        coin_info: Option<&BTreeMap<usize, (TypeTag, u64)>>,
+        wildcard_indices: &BTreeSet<u16>,
+    ) -> [u8; 32] {
         let mut hasher = DefaultHash::default();
         match command {
             Command::MoveCall(call) => {
@@ -1002,28 +1030,28 @@ impl ProgrammableTransaction {
                     hasher.update(&bcs::to_bytes(ty).unwrap_or_default());
                 }
                 for arg in &call.arguments {
-                    self.hash_argument(&mut hasher, arg);
+                    self.hash_argument_inner(&mut hasher, arg, coin_info, wildcard_indices);
                 }
             }
             Command::TransferObjects(objects, recipient) => {
                 hasher.update(&[0x01]);
                 for obj in objects {
-                    self.hash_argument(&mut hasher, obj);
+                    self.hash_argument_inner(&mut hasher, obj, coin_info, wildcard_indices);
                 }
-                self.hash_argument(&mut hasher, recipient);
+                self.hash_argument_inner(&mut hasher, recipient, coin_info, wildcard_indices);
             }
             Command::SplitCoins(coin, amounts) => {
                 hasher.update(&[0x02]);
-                self.hash_argument(&mut hasher, coin);
+                self.hash_argument_inner(&mut hasher, coin, coin_info, wildcard_indices);
                 for amt in amounts {
-                    self.hash_argument(&mut hasher, amt);
+                    self.hash_argument_inner(&mut hasher, amt, coin_info, wildcard_indices);
                 }
             }
             Command::MergeCoins(target, sources) => {
                 hasher.update(&[0x03]);
-                self.hash_argument(&mut hasher, target);
+                self.hash_argument_inner(&mut hasher, target, coin_info, wildcard_indices);
                 for src in sources {
-                    self.hash_argument(&mut hasher, src);
+                    self.hash_argument_inner(&mut hasher, src, coin_info, wildcard_indices);
                 }
             }
             Command::Publish(modules, deps) => {
@@ -1041,7 +1069,7 @@ impl ProgrammableTransaction {
                     hasher.update(&bcs::to_bytes(tag).unwrap_or_default());
                 }
                 for elem in elements {
-                    self.hash_argument(&mut hasher, elem);
+                    self.hash_argument_inner(&mut hasher, elem, coin_info, wildcard_indices);
                 }
             }
             Command::Upgrade(modules, deps, package_id, ticket) => {
@@ -1053,23 +1081,35 @@ impl ProgrammableTransaction {
                     hasher.update(dep.as_ref());
                 }
                 hasher.update(package_id.as_ref());
-                self.hash_argument(&mut hasher, ticket);
+                self.hash_argument_inner(&mut hasher, ticket, coin_info, wildcard_indices);
             }
         }
         hasher.finalize().digest
     }
 
-    fn hash_argument(&self, hasher: &mut DefaultHash, arg: &Argument) {
+    fn hash_argument_inner(
+        &self,
+        hasher: &mut DefaultHash,
+        arg: &Argument,
+        coin_info: Option<&BTreeMap<usize, (TypeTag, u64)>>,
+        wildcard_indices: &BTreeSet<u16>,
+    ) {
         match arg {
             Argument::GasCoin => {
                 hasher.update(&[0x00]);
             }
             Argument::Input(idx) => {
-                // Look up the actual input and hash its normalized form
-                if let Some(call_arg) = self.inputs.get(*idx as usize) {
-                    self.hash_call_arg(hasher, call_arg);
+                let input_idx = *idx as usize;
+                if let Some(call_arg) = self.inputs.get(input_idx) {
+                    self.hash_call_arg_inner(
+                        hasher,
+                        call_arg,
+                        input_idx,
+                        coin_info,
+                        wildcard_indices,
+                    );
                 } else {
-                    // Invalid input index — hash it as-is so the digest is still deterministic
+                    // Invalid input index — hash as-is for determinism
                     hasher.update(&[0x01]);
                     hasher.update(&idx.to_le_bytes());
                 }
@@ -1086,33 +1126,71 @@ impl ProgrammableTransaction {
         }
     }
 
-    fn hash_call_arg(&self, hasher: &mut DefaultHash, call_arg: &CallArg) {
+    fn hash_call_arg_inner(
+        &self,
+        hasher: &mut DefaultHash,
+        call_arg: &CallArg,
+        input_idx: usize,
+        coin_info: Option<&BTreeMap<usize, (TypeTag, u64)>>,
+        wildcard_indices: &BTreeSet<u16>,
+    ) {
         match call_arg {
             CallArg::Pure(bytes) => {
-                hasher.update(&[0x01]);
-                hasher.update(bytes);
+                if wildcard_indices.contains(&(input_idx as u16)) {
+                    // Wildcard: hash marker instead of actual value
+                    hasher.update(&[0xFF]);
+                } else {
+                    hasher.update(&[0x01]);
+                    hasher.update(bytes);
+                }
             }
             CallArg::Object(ObjectArg::SharedObject { id, .. }) => {
+                // Shared objects: ObjectID only (version-independent anchor)
                 hasher.update(&[0x02]);
                 hasher.update(id.as_ref());
             }
-            CallArg::Object(ObjectArg::ImmOrOwnedObject((id, version, _))) => {
-                hasher.update(&[0x03]);
-                hasher.update(id.as_ref());
-                hasher.update(&version.value().to_le_bytes());
+            CallArg::Object(ObjectArg::ImmOrOwnedObject((id, _, _))) => {
+                // Check coin normalization first
+                if let Some((type_tag, balance)) =
+                    coin_info.and_then(|m| m.get(&input_idx))
+                {
+                    hasher.update(&[0x08]); // coin-normalized
+                    hasher.update(&bcs::to_bytes(type_tag).unwrap_or_default());
+                    hasher.update(&balance.to_le_bytes());
+                } else {
+                    // Owned objects: ObjectID only (version drifts between vote and execution)
+                    hasher.update(&[0x03]);
+                    hasher.update(id.as_ref());
+                }
             }
-            CallArg::Object(ObjectArg::Receiving((id, version, _))) => {
-                hasher.update(&[0x04]);
-                hasher.update(id.as_ref());
-                hasher.update(&version.value().to_le_bytes());
+            CallArg::Object(ObjectArg::Receiving((id, _, _))) => {
+                if let Some((type_tag, balance)) =
+                    coin_info.and_then(|m| m.get(&input_idx))
+                {
+                    hasher.update(&[0x09]); // coin-normalized receiving
+                    hasher.update(&bcs::to_bytes(type_tag).unwrap_or_default());
+                    hasher.update(&balance.to_le_bytes());
+                } else {
+                    // Receiving objects: ObjectID only
+                    hasher.update(&[0x04]);
+                    hasher.update(id.as_ref());
+                }
             }
             CallArg::FundsWithdrawal(_) => {
                 hasher.update(&[0x07]);
-                // Hash the BCS representation for determinism
                 hasher.update(&bcs::to_bytes(call_arg).unwrap_or_default());
             }
         }
     }
+}
+
+/// Data needed for structural_digest_masked recomputation at runtime (SIP-70 v2).
+/// Stored on TxContext during execution so the masked native can recompute
+/// the digest with wildcard inputs.
+#[derive(Clone)]
+pub struct StructuralDigestData {
+    pub pt: ProgrammableTransaction,
+    pub coin_info: BTreeMap<usize, (TypeTag, u64)>,
 }
 
 /// A single command in a programmable transaction.

--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -984,6 +984,11 @@ impl ProgrammableTransaction {
         self.structural_digest_with_options(None, &BTreeSet::new())
     }
 
+    /// Returns a serialized-size proxy for gas metering structural digest work.
+    pub fn structural_digest_metered_bytes(&self) -> u64 {
+        u64::try_from(bcs::serialized_size(self).unwrap_or_default()).unwrap_or(u64::MAX)
+    }
+
     /// Compute structural digest with coin normalization and/or wildcard support.
     ///
     /// - `coin_info`: maps input index to (TypeTag, balance) for coin-type inputs.
@@ -1175,16 +1180,21 @@ impl ProgrammableTransaction {
                     hasher.update(bytes);
                 }
             }
-            CallArg::Object(ObjectArg::SharedObject { id, .. }) => {
-                // Shared objects: ObjectID only (version-independent anchor)
+            CallArg::Object(ObjectArg::SharedObject { id, mutability, .. }) => {
+                // Shared objects: ObjectID plus mutability.
+                // Mutability changes the lock shape and available call surface.
                 hasher.update(&[0x02]);
                 hasher.update(id.as_ref());
+                let mutability_byte = match mutability {
+                    SharedObjectMutability::Immutable => 0x00,
+                    SharedObjectMutability::Mutable => 0x01,
+                    SharedObjectMutability::NonExclusiveWrite => 0x02,
+                };
+                hasher.update(&[mutability_byte]);
             }
             CallArg::Object(ObjectArg::ImmOrOwnedObject((id, _, _))) => {
                 // Check coin normalization first
-                if let Some((type_tag, balance)) =
-                    coin_info.and_then(|m| m.get(&input_idx))
-                {
+                if let Some((type_tag, balance)) = coin_info.and_then(|m| m.get(&input_idx)) {
                     hasher.update(&[0x08]); // coin-normalized
                     hasher.update(&bcs::to_bytes(type_tag).unwrap_or_default());
                     hasher.update(&balance.to_le_bytes());
@@ -1195,9 +1205,7 @@ impl ProgrammableTransaction {
                 }
             }
             CallArg::Object(ObjectArg::Receiving((id, _, _))) => {
-                if let Some((type_tag, balance)) =
-                    coin_info.and_then(|m| m.get(&input_idx))
-                {
+                if let Some((type_tag, balance)) = coin_info.and_then(|m| m.get(&input_idx)) {
                     hasher.update(&[0x09]); // coin-normalized receiving
                     hasher.update(&bcs::to_bytes(type_tag).unwrap_or_default());
                     hasher.update(&balance.to_le_bytes());
@@ -1220,8 +1228,31 @@ impl ProgrammableTransaction {
 /// the digest with wildcard inputs.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct StructuralDigestData {
-    pub pt: ProgrammableTransaction,
+    pub pt: Arc<ProgrammableTransaction>,
     pub coin_info: BTreeMap<usize, (TypeTag, u64)>,
+    pub base_gas_bytes: u64,
+    pub masked_gas_bytes: u64,
+}
+
+impl StructuralDigestData {
+    pub fn new(
+        pt: Arc<ProgrammableTransaction>,
+        coin_info: BTreeMap<usize, (TypeTag, u64)>,
+    ) -> Self {
+        let base_gas_bytes = pt.structural_digest_metered_bytes();
+        let coin_info_bytes = coin_info.iter().fold(0u64, |acc, (_, (type_tag, _))| {
+            let type_tag_len = u64::try_from(bcs::to_bytes(type_tag).unwrap_or_default().len())
+                .unwrap_or(u64::MAX);
+            acc.saturating_add(type_tag_len).saturating_add(16)
+        });
+        let masked_gas_bytes = base_gas_bytes.saturating_add(coin_info_bytes);
+        Self {
+            pt,
+            coin_info,
+            base_gas_bytes,
+            masked_gas_bytes,
+        }
+    }
 }
 
 /// A single command in a programmable transaction.

--- a/crates/sui-types/src/unit_tests/structural_digest_tests.rs
+++ b/crates/sui-types/src/unit_tests/structural_digest_tests.rs
@@ -1,0 +1,516 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Tests for ProgrammableTransaction::structural_digest (SIP-70).
+//!
+//! Verifies that the structural digest is:
+//! - Deterministic (same PTB → same digest)
+//! - Sensitive to command addition/removal/reordering
+//! - Sensitive to argument changes (different Pure values, different objects)
+//! - Sensitive to Result redirection (changing which command output flows where)
+//! - Stable when only irrelevant metadata changes (e.g. object digest bytes)
+
+use crate::base_types::{ObjectID, SequenceNumber, ObjectDigest, random_object_ref};
+use crate::transaction::{
+    Argument, CallArg, Command, ObjectArg, ProgrammableMoveCall, ProgrammableTransaction,
+};
+use crate::type_input::TypeInput;
+
+/// Helper: build a simple MoveCall command
+fn make_move_call(
+    package: ObjectID,
+    module: &str,
+    function: &str,
+    arguments: Vec<Argument>,
+) -> Command {
+    Command::MoveCall(Box::new(ProgrammableMoveCall {
+        package,
+        module: module.to_string(),
+        function: function.to_string(),
+        type_arguments: vec![],
+        arguments,
+    }))
+}
+
+/// Helper: build a ProgrammableTransaction from inputs and commands
+fn make_pt(inputs: Vec<CallArg>, commands: Vec<Command>) -> ProgrammableTransaction {
+    ProgrammableTransaction { inputs, commands }
+}
+
+// ============================================================================
+// Determinism
+// ============================================================================
+
+#[test]
+fn test_structural_digest_is_deterministic() {
+    let obj_ref = random_object_ref();
+    let pkg = ObjectID::random();
+
+    let pt1 = make_pt(
+        vec![CallArg::Object(ObjectArg::ImmOrOwnedObject(obj_ref))],
+        vec![make_move_call(pkg, "module", "func", vec![Argument::Input(0)])],
+    );
+
+    let pt2 = make_pt(
+        vec![CallArg::Object(ObjectArg::ImmOrOwnedObject(obj_ref))],
+        vec![make_move_call(pkg, "module", "func", vec![Argument::Input(0)])],
+    );
+
+    assert_eq!(pt1.structural_digest(), pt2.structural_digest());
+}
+
+#[test]
+fn test_structural_digest_length() {
+    let pt = make_pt(vec![], vec![]);
+    let digest = pt.structural_digest();
+    // Blake2b256 produces 32 bytes
+    assert_eq!(digest.len(), 32);
+}
+
+// ============================================================================
+// Sensitivity to commands
+// ============================================================================
+
+#[test]
+fn test_digest_changes_with_extra_command() {
+    let pkg = ObjectID::random();
+
+    let pt1 = make_pt(
+        vec![CallArg::Pure(bcs::to_bytes(&100u64).unwrap())],
+        vec![make_move_call(pkg, "mod", "func", vec![Argument::Input(0)])],
+    );
+
+    let pt2 = make_pt(
+        vec![CallArg::Pure(bcs::to_bytes(&100u64).unwrap())],
+        vec![
+            make_move_call(pkg, "mod", "func", vec![Argument::Input(0)]),
+            make_move_call(pkg, "mod", "func2", vec![Argument::Result(0)]),
+        ],
+    );
+
+    assert_ne!(pt1.structural_digest(), pt2.structural_digest());
+}
+
+#[test]
+fn test_digest_changes_with_command_reorder() {
+    let pkg = ObjectID::random();
+
+    let cmd_a = make_move_call(pkg, "mod", "func_a", vec![]);
+    let cmd_b = make_move_call(pkg, "mod", "func_b", vec![]);
+
+    let pt1 = make_pt(vec![], vec![cmd_a.clone(), cmd_b.clone()]);
+    let pt2 = make_pt(vec![], vec![cmd_b, cmd_a]);
+
+    assert_ne!(pt1.structural_digest(), pt2.structural_digest());
+}
+
+#[test]
+fn test_digest_changes_with_command_removal() {
+    let pkg = ObjectID::random();
+
+    let cmd_a = make_move_call(pkg, "mod", "func_a", vec![]);
+    let cmd_b = make_move_call(pkg, "mod", "func_b", vec![]);
+
+    let pt1 = make_pt(vec![], vec![cmd_a.clone(), cmd_b]);
+    let pt2 = make_pt(vec![], vec![cmd_a]);
+
+    assert_ne!(pt1.structural_digest(), pt2.structural_digest());
+}
+
+// ============================================================================
+// Sensitivity to arguments
+// ============================================================================
+
+#[test]
+fn test_digest_changes_with_different_pure_value() {
+    let pkg = ObjectID::random();
+
+    let pt1 = make_pt(
+        vec![CallArg::Pure(bcs::to_bytes(&100u64).unwrap())],
+        vec![make_move_call(pkg, "mod", "func", vec![Argument::Input(0)])],
+    );
+
+    let pt2 = make_pt(
+        vec![CallArg::Pure(bcs::to_bytes(&200u64).unwrap())],
+        vec![make_move_call(pkg, "mod", "func", vec![Argument::Input(0)])],
+    );
+
+    assert_ne!(pt1.structural_digest(), pt2.structural_digest());
+}
+
+#[test]
+fn test_digest_changes_with_different_shared_object() {
+    let pkg = ObjectID::random();
+    let shared_id_1 = ObjectID::random();
+    let shared_id_2 = ObjectID::random();
+
+    let pt1 = make_pt(
+        vec![CallArg::Object(ObjectArg::SharedObject {
+            id: shared_id_1,
+            initial_shared_version: SequenceNumber::new(),
+            mutability: crate::transaction::SharedObjectMutability::Mutable,
+        })],
+        vec![make_move_call(pkg, "mod", "func", vec![Argument::Input(0)])],
+    );
+
+    let pt2 = make_pt(
+        vec![CallArg::Object(ObjectArg::SharedObject {
+            id: shared_id_2,
+            initial_shared_version: SequenceNumber::new(),
+            mutability: crate::transaction::SharedObjectMutability::Mutable,
+        })],
+        vec![make_move_call(pkg, "mod", "func", vec![Argument::Input(0)])],
+    );
+
+    assert_ne!(pt1.structural_digest(), pt2.structural_digest());
+}
+
+#[test]
+fn test_digest_stable_across_shared_object_version_change() {
+    // Shared objects are hashed by ObjectID only, not version.
+    // So changing initial_shared_version should NOT change the digest.
+    let pkg = ObjectID::random();
+    let shared_id = ObjectID::random();
+
+    let pt1 = make_pt(
+        vec![CallArg::Object(ObjectArg::SharedObject {
+            id: shared_id,
+            initial_shared_version: SequenceNumber::from_u64(1),
+            mutability: crate::transaction::SharedObjectMutability::Mutable,
+        })],
+        vec![make_move_call(pkg, "mod", "func", vec![Argument::Input(0)])],
+    );
+
+    let pt2 = make_pt(
+        vec![CallArg::Object(ObjectArg::SharedObject {
+            id: shared_id,
+            initial_shared_version: SequenceNumber::from_u64(999),
+            mutability: crate::transaction::SharedObjectMutability::Mutable,
+        })],
+        vec![make_move_call(pkg, "mod", "func", vec![Argument::Input(0)])],
+    );
+
+    assert_eq!(pt1.structural_digest(), pt2.structural_digest());
+}
+
+#[test]
+fn test_digest_stable_across_object_digest_change() {
+    // Owned objects are hashed by ObjectID + version. The ObjectDigest
+    // (content hash) is NOT included, so changing it should not affect the digest.
+    let pkg = ObjectID::random();
+    let obj_id = ObjectID::random();
+    let version = SequenceNumber::from_u64(5);
+
+    let pt1 = make_pt(
+        vec![CallArg::Object(ObjectArg::ImmOrOwnedObject((
+            obj_id,
+            version,
+            ObjectDigest::new([0xAA; 32]),
+        )))],
+        vec![make_move_call(pkg, "mod", "func", vec![Argument::Input(0)])],
+    );
+
+    let pt2 = make_pt(
+        vec![CallArg::Object(ObjectArg::ImmOrOwnedObject((
+            obj_id,
+            version,
+            ObjectDigest::new([0xBB; 32]),
+        )))],
+        vec![make_move_call(pkg, "mod", "func", vec![Argument::Input(0)])],
+    );
+
+    assert_eq!(pt1.structural_digest(), pt2.structural_digest());
+}
+
+#[test]
+fn test_digest_changes_with_different_owned_object() {
+    let pkg = ObjectID::random();
+
+    let pt1 = make_pt(
+        vec![CallArg::Object(ObjectArg::ImmOrOwnedObject(random_object_ref()))],
+        vec![make_move_call(pkg, "mod", "func", vec![Argument::Input(0)])],
+    );
+
+    let pt2 = make_pt(
+        vec![CallArg::Object(ObjectArg::ImmOrOwnedObject(random_object_ref()))],
+        vec![make_move_call(pkg, "mod", "func", vec![Argument::Input(0)])],
+    );
+
+    assert_ne!(pt1.structural_digest(), pt2.structural_digest());
+}
+
+// ============================================================================
+// Sensitivity to Result redirection (provenance)
+// ============================================================================
+
+#[test]
+fn test_digest_changes_with_result_redirection() {
+    let pkg = ObjectID::random();
+
+    // PTB1: cmd0 produces result, cmd1 uses Result(0)
+    let pt1 = make_pt(
+        vec![],
+        vec![
+            make_move_call(pkg, "mod", "produce", vec![]),
+            make_move_call(pkg, "mod", "consume", vec![Argument::Result(0)]),
+        ],
+    );
+
+    // PTB2: cmd0 and cmd1 produce results, cmd2 uses Result(1) instead of Result(0)
+    let pt2 = make_pt(
+        vec![],
+        vec![
+            make_move_call(pkg, "mod", "produce", vec![]),
+            make_move_call(pkg, "mod", "produce2", vec![]),
+            make_move_call(pkg, "mod", "consume", vec![Argument::Result(1)]),
+        ],
+    );
+
+    assert_ne!(pt1.structural_digest(), pt2.structural_digest());
+}
+
+#[test]
+fn test_digest_distinguishes_result_vs_nested_result() {
+    let pkg = ObjectID::random();
+
+    let pt1 = make_pt(
+        vec![],
+        vec![
+            make_move_call(pkg, "mod", "produce", vec![]),
+            make_move_call(pkg, "mod", "consume", vec![Argument::Result(0)]),
+        ],
+    );
+
+    let pt2 = make_pt(
+        vec![],
+        vec![
+            make_move_call(pkg, "mod", "produce", vec![]),
+            make_move_call(pkg, "mod", "consume", vec![Argument::NestedResult(0, 0)]),
+        ],
+    );
+
+    assert_ne!(pt1.structural_digest(), pt2.structural_digest());
+}
+
+// ============================================================================
+// GasCoin normalization
+// ============================================================================
+
+#[test]
+fn test_digest_gas_coin_is_stable() {
+    let pkg = ObjectID::random();
+
+    // Two identical PTBs using GasCoin — should produce same digest
+    let pt1 = make_pt(
+        vec![],
+        vec![make_move_call(pkg, "mod", "func", vec![Argument::GasCoin])],
+    );
+
+    let pt2 = make_pt(
+        vec![],
+        vec![make_move_call(pkg, "mod", "func", vec![Argument::GasCoin])],
+    );
+
+    assert_eq!(pt1.structural_digest(), pt2.structural_digest());
+}
+
+#[test]
+fn test_digest_gas_coin_differs_from_input() {
+    let pkg = ObjectID::random();
+
+    let pt1 = make_pt(
+        vec![],
+        vec![make_move_call(pkg, "mod", "func", vec![Argument::GasCoin])],
+    );
+
+    let pt2 = make_pt(
+        vec![CallArg::Pure(vec![0x00])],
+        vec![make_move_call(pkg, "mod", "func", vec![Argument::Input(0)])],
+    );
+
+    assert_ne!(pt1.structural_digest(), pt2.structural_digest());
+}
+
+// ============================================================================
+// Command type sensitivity
+// ============================================================================
+
+#[test]
+fn test_digest_distinguishes_command_types() {
+    let obj_ref = random_object_ref();
+
+    // SplitCoins vs MergeCoins with same arguments should differ
+    let pt1 = make_pt(
+        vec![
+            CallArg::Object(ObjectArg::ImmOrOwnedObject(obj_ref)),
+            CallArg::Pure(bcs::to_bytes(&100u64).unwrap()),
+        ],
+        vec![Command::SplitCoins(Argument::Input(0), vec![Argument::Input(1)])],
+    );
+
+    let pt2 = make_pt(
+        vec![
+            CallArg::Object(ObjectArg::ImmOrOwnedObject(obj_ref)),
+            CallArg::Pure(bcs::to_bytes(&100u64).unwrap()),
+        ],
+        vec![Command::MergeCoins(Argument::Input(0), vec![Argument::Input(1)])],
+    );
+
+    assert_ne!(pt1.structural_digest(), pt2.structural_digest());
+}
+
+// ============================================================================
+// Target sensitivity
+// ============================================================================
+
+#[test]
+fn test_digest_changes_with_different_package() {
+    let pkg1 = ObjectID::random();
+    let pkg2 = ObjectID::random();
+
+    let pt1 = make_pt(
+        vec![],
+        vec![make_move_call(pkg1, "mod", "func", vec![])],
+    );
+
+    let pt2 = make_pt(
+        vec![],
+        vec![make_move_call(pkg2, "mod", "func", vec![])],
+    );
+
+    assert_ne!(pt1.structural_digest(), pt2.structural_digest());
+}
+
+#[test]
+fn test_digest_changes_with_different_module() {
+    let pkg = ObjectID::random();
+
+    let pt1 = make_pt(vec![], vec![make_move_call(pkg, "mod_a", "func", vec![])]);
+    let pt2 = make_pt(vec![], vec![make_move_call(pkg, "mod_b", "func", vec![])]);
+
+    assert_ne!(pt1.structural_digest(), pt2.structural_digest());
+}
+
+#[test]
+fn test_digest_changes_with_different_function() {
+    let pkg = ObjectID::random();
+
+    let pt1 = make_pt(vec![], vec![make_move_call(pkg, "mod", "func_a", vec![])]);
+    let pt2 = make_pt(vec![], vec![make_move_call(pkg, "mod", "func_b", vec![])]);
+
+    assert_ne!(pt1.structural_digest(), pt2.structural_digest());
+}
+
+// ============================================================================
+// Type argument sensitivity
+// ============================================================================
+
+#[test]
+fn test_digest_changes_with_different_type_arguments() {
+    let pkg = ObjectID::random();
+
+    let pt1 = make_pt(
+        vec![],
+        vec![Command::MoveCall(Box::new(ProgrammableMoveCall {
+            package: pkg,
+            module: "mod".to_string(),
+            function: "func".to_string(),
+            type_arguments: vec![TypeInput::U64],
+            arguments: vec![],
+        }))],
+    );
+
+    let pt2 = make_pt(
+        vec![],
+        vec![Command::MoveCall(Box::new(ProgrammableMoveCall {
+            package: pkg,
+            module: "mod".to_string(),
+            function: "func".to_string(),
+            type_arguments: vec![TypeInput::Bool],
+            arguments: vec![],
+        }))],
+    );
+
+    assert_ne!(pt1.structural_digest(), pt2.structural_digest());
+}
+
+// ============================================================================
+// Empty PTB
+// ============================================================================
+
+#[test]
+fn test_empty_ptb_has_stable_digest() {
+    let pt1 = make_pt(vec![], vec![]);
+    let pt2 = make_pt(vec![], vec![]);
+
+    assert_eq!(pt1.structural_digest(), pt2.structural_digest());
+}
+
+// ============================================================================
+// Complex multi-command PTB (governance scenario)
+// ============================================================================
+
+#[test]
+fn test_governance_scenario_digest_stability() {
+    // Simulate: SplitCoin → Swap → Deposit
+    // The digest should be stable for the same logical flow
+    let pkg = ObjectID::random();
+    let coin_ref = random_object_ref();
+
+    let build_ptb = || {
+        make_pt(
+            vec![
+                CallArg::Object(ObjectArg::ImmOrOwnedObject(coin_ref)),
+                CallArg::Pure(bcs::to_bytes(&1000u64).unwrap()),
+            ],
+            vec![
+                // cmd 0: split coin
+                Command::SplitCoins(Argument::Input(0), vec![Argument::Input(1)]),
+                // cmd 1: swap (uses Result(0) = split output)
+                make_move_call(pkg, "dex", "swap", vec![Argument::Result(0)]),
+                // cmd 2: deposit (uses Result(1) = swap output)
+                make_move_call(pkg, "vault", "deposit", vec![Argument::Result(1)]),
+            ],
+        )
+    };
+
+    let pt1 = build_ptb();
+    let pt2 = build_ptb();
+
+    assert_eq!(pt1.structural_digest(), pt2.structural_digest());
+}
+
+#[test]
+fn test_governance_scenario_detects_swap_target_change() {
+    // Same flow but swapping on a different DEX should change the digest
+    let pkg1 = ObjectID::random();
+    let pkg2 = ObjectID::random();
+    let vault_pkg = ObjectID::random();
+    let coin_ref = random_object_ref();
+
+    let pt1 = make_pt(
+        vec![
+            CallArg::Object(ObjectArg::ImmOrOwnedObject(coin_ref)),
+            CallArg::Pure(bcs::to_bytes(&1000u64).unwrap()),
+        ],
+        vec![
+            Command::SplitCoins(Argument::Input(0), vec![Argument::Input(1)]),
+            make_move_call(pkg1, "dex", "swap", vec![Argument::Result(0)]),
+            make_move_call(vault_pkg, "vault", "deposit", vec![Argument::Result(1)]),
+        ],
+    );
+
+    let pt2 = make_pt(
+        vec![
+            CallArg::Object(ObjectArg::ImmOrOwnedObject(coin_ref)),
+            CallArg::Pure(bcs::to_bytes(&1000u64).unwrap()),
+        ],
+        vec![
+            Command::SplitCoins(Argument::Input(0), vec![Argument::Input(1)]),
+            make_move_call(pkg2, "dex", "swap", vec![Argument::Result(0)]),
+            make_move_call(vault_pkg, "vault", "deposit", vec![Argument::Result(1)]),
+        ],
+    );
+
+    assert_ne!(pt1.structural_digest(), pt2.structural_digest());
+}

--- a/crates/sui-types/src/unit_tests/structural_digest_tests.rs
+++ b/crates/sui-types/src/unit_tests/structural_digest_tests.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Tests for ProgrammableTransaction::structural_digest (SIP-70 v2).
+//! Tests for ProgrammableTransaction::structural_digest (SIP-70).
 //!
 //! Verifies that the structural digest is:
 //! - Deterministic (same PTB -> same digest)
@@ -10,16 +10,12 @@
 //! - Sensitive to argument changes (different Pure values, different objects)
 //! - Sensitive to Result redirection (changing which command output flows where)
 //! - Stable when only irrelevant metadata changes (e.g. object digest, object version)
-//! - Coin-normalizable (same TypeName + Balance -> same digest regardless of ObjectID)
-//! - Wildcard-capable (specified Pure inputs hash as marker, not value)
 
 use crate::base_types::{ObjectDigest, ObjectID, SequenceNumber, random_object_ref};
 use crate::transaction::{
     Argument, CallArg, Command, ObjectArg, ProgrammableMoveCall, ProgrammableTransaction,
 };
 use crate::type_input::TypeInput;
-use move_core_types::language_storage::{StructTag, TypeTag};
-use std::collections::{BTreeMap, BTreeSet};
 
 /// Helper: build a simple MoveCall command
 fn make_move_call(
@@ -40,26 +36,6 @@ fn make_move_call(
 /// Helper: build a ProgrammableTransaction from inputs and commands
 fn make_pt(inputs: Vec<CallArg>, commands: Vec<Command>) -> ProgrammableTransaction {
     ProgrammableTransaction { inputs, commands }
-}
-
-/// Helper: build a fake coin TypeTag (Coin<0x2::sui::SUI>)
-fn sui_coin_type() -> TypeTag {
-    TypeTag::Struct(Box::new(StructTag {
-        address: ObjectID::from_hex_literal("0x2").unwrap().into(),
-        module: move_core_types::identifier::Identifier::new("sui").unwrap(),
-        name: move_core_types::identifier::Identifier::new("SUI").unwrap(),
-        type_params: vec![],
-    }))
-}
-
-/// Helper: build a different coin TypeTag
-fn usdc_coin_type() -> TypeTag {
-    TypeTag::Struct(Box::new(StructTag {
-        address: ObjectID::from_hex_literal("0xdead").unwrap().into(),
-        module: move_core_types::identifier::Identifier::new("usdc").unwrap(),
-        name: move_core_types::identifier::Identifier::new("USDC").unwrap(),
-        type_params: vec![],
-    }))
 }
 
 // ============================================================================
@@ -566,257 +542,6 @@ fn test_empty_ptb_has_stable_digest() {
 }
 
 // ============================================================================
-// Coin normalization (Change 3)
-// ============================================================================
-
-#[test]
-fn test_coin_normalized_digest_stable_across_different_object_ids() {
-    // Two PTBs with different coin ObjectIDs but same TypeName + Balance
-    // should produce the same digest when coin_info is provided.
-    let pkg = ObjectID::random();
-    let coin_id_1 = ObjectID::random();
-    let coin_id_2 = ObjectID::random();
-
-    let pt1 = make_pt(
-        vec![CallArg::Object(ObjectArg::ImmOrOwnedObject((
-            coin_id_1,
-            SequenceNumber::from_u64(1),
-            ObjectDigest::new([0xAA; 32]),
-        )))],
-        vec![make_move_call(pkg, "mod", "func", vec![Argument::Input(0)])],
-    );
-
-    let pt2 = make_pt(
-        vec![CallArg::Object(ObjectArg::ImmOrOwnedObject((
-            coin_id_2,
-            SequenceNumber::from_u64(5),
-            ObjectDigest::new([0xBB; 32]),
-        )))],
-        vec![make_move_call(pkg, "mod", "func", vec![Argument::Input(0)])],
-    );
-
-    // Without coin_info: different ObjectIDs -> different digests
-    assert_ne!(pt1.structural_digest(), pt2.structural_digest());
-
-    // With coin_info (same type + balance): same digest
-    let coin_info_1: BTreeMap<usize, (TypeTag, u64)> =
-        [(0, (sui_coin_type(), 1000))].into_iter().collect();
-    let coin_info_2: BTreeMap<usize, (TypeTag, u64)> =
-        [(0, (sui_coin_type(), 1000))].into_iter().collect();
-
-    assert_eq!(
-        pt1.structural_digest_with_options(Some(&coin_info_1), &BTreeSet::new()),
-        pt2.structural_digest_with_options(Some(&coin_info_2), &BTreeSet::new()),
-    );
-}
-
-#[test]
-fn test_coin_normalized_digest_changes_with_different_balance() {
-    let pkg = ObjectID::random();
-
-    let pt = make_pt(
-        vec![CallArg::Object(ObjectArg::ImmOrOwnedObject(
-            random_object_ref(),
-        ))],
-        vec![make_move_call(pkg, "mod", "func", vec![Argument::Input(0)])],
-    );
-
-    let coin_info_1000: BTreeMap<usize, (TypeTag, u64)> =
-        [(0, (sui_coin_type(), 1000))].into_iter().collect();
-    let coin_info_2000: BTreeMap<usize, (TypeTag, u64)> =
-        [(0, (sui_coin_type(), 2000))].into_iter().collect();
-
-    assert_ne!(
-        pt.structural_digest_with_options(Some(&coin_info_1000), &BTreeSet::new()),
-        pt.structural_digest_with_options(Some(&coin_info_2000), &BTreeSet::new()),
-    );
-}
-
-#[test]
-fn test_coin_normalized_digest_changes_with_different_type() {
-    let pkg = ObjectID::random();
-
-    let pt = make_pt(
-        vec![CallArg::Object(ObjectArg::ImmOrOwnedObject(
-            random_object_ref(),
-        ))],
-        vec![make_move_call(pkg, "mod", "func", vec![Argument::Input(0)])],
-    );
-
-    let sui_info: BTreeMap<usize, (TypeTag, u64)> =
-        [(0, (sui_coin_type(), 1000))].into_iter().collect();
-    let usdc_info: BTreeMap<usize, (TypeTag, u64)> =
-        [(0, (usdc_coin_type(), 1000))].into_iter().collect();
-
-    assert_ne!(
-        pt.structural_digest_with_options(Some(&sui_info), &BTreeSet::new()),
-        pt.structural_digest_with_options(Some(&usdc_info), &BTreeSet::new()),
-    );
-}
-
-// ============================================================================
-// Wildcard slots (Change 4)
-// ============================================================================
-
-#[test]
-fn test_wildcard_digest_stable_across_different_pure_values() {
-    // Two PTBs that differ only in a wildcarded Pure input should produce the same digest.
-    let pkg = ObjectID::random();
-
-    let pt1 = make_pt(
-        vec![
-            CallArg::Pure(bcs::to_bytes(&100u64).unwrap()), // input 0: amount (pinned)
-            CallArg::Pure(bcs::to_bytes(&50u64).unwrap()),  // input 1: slippage (wildcard)
-        ],
-        vec![make_move_call(
-            pkg,
-            "dex",
-            "swap",
-            vec![Argument::Input(0), Argument::Input(1)],
-        )],
-    );
-
-    let pt2 = make_pt(
-        vec![
-            CallArg::Pure(bcs::to_bytes(&100u64).unwrap()), // input 0: same amount
-            CallArg::Pure(bcs::to_bytes(&999u64).unwrap()), // input 1: different slippage
-        ],
-        vec![make_move_call(
-            pkg,
-            "dex",
-            "swap",
-            vec![Argument::Input(0), Argument::Input(1)],
-        )],
-    );
-
-    // Without wildcards: different Pure values -> different digests
-    assert_ne!(pt1.structural_digest(), pt2.structural_digest());
-
-    // With wildcard on input 1: same digest
-    let wildcards: BTreeSet<u16> = [1].into_iter().collect();
-    assert_eq!(
-        pt1.structural_digest_with_options(None, &wildcards),
-        pt2.structural_digest_with_options(None, &wildcards),
-    );
-
-    // Non-wildcarded input (0) still differentiates
-    let pt3 = make_pt(
-        vec![
-            CallArg::Pure(bcs::to_bytes(&200u64).unwrap()), // input 0: different amount
-            CallArg::Pure(bcs::to_bytes(&50u64).unwrap()),  // input 1: same slippage
-        ],
-        vec![make_move_call(
-            pkg,
-            "dex",
-            "swap",
-            vec![Argument::Input(0), Argument::Input(1)],
-        )],
-    );
-
-    assert_ne!(
-        pt1.structural_digest_with_options(None, &wildcards),
-        pt3.structural_digest_with_options(None, &wildcards),
-    );
-}
-
-#[test]
-fn test_wildcard_only_applies_to_specified_indices() {
-    let pkg = ObjectID::random();
-
-    let pt1 = make_pt(
-        vec![
-            CallArg::Pure(bcs::to_bytes(&100u64).unwrap()),
-            CallArg::Pure(bcs::to_bytes(&200u64).unwrap()),
-        ],
-        vec![make_move_call(
-            pkg,
-            "mod",
-            "func",
-            vec![Argument::Input(0), Argument::Input(1)],
-        )],
-    );
-
-    let pt2 = make_pt(
-        vec![
-            CallArg::Pure(bcs::to_bytes(&100u64).unwrap()),
-            CallArg::Pure(bcs::to_bytes(&999u64).unwrap()),
-        ],
-        vec![make_move_call(
-            pkg,
-            "mod",
-            "func",
-            vec![Argument::Input(0), Argument::Input(1)],
-        )],
-    );
-
-    // Wildcard on input 0 only: input 1 still differentiates
-    let wildcards_0: BTreeSet<u16> = [0].into_iter().collect();
-    assert_ne!(
-        pt1.structural_digest_with_options(None, &wildcards_0),
-        pt2.structural_digest_with_options(None, &wildcards_0),
-    );
-
-    // Wildcard on input 1 only: input 0 is the same -> same digest
-    let wildcards_1: BTreeSet<u16> = [1].into_iter().collect();
-    assert_eq!(
-        pt1.structural_digest_with_options(None, &wildcards_1),
-        pt2.structural_digest_with_options(None, &wildcards_1),
-    );
-}
-
-#[test]
-fn test_wildcard_and_coin_normalization_combined() {
-    // Coin normalization and wildcards work together.
-    let pkg = ObjectID::random();
-
-    let pt1 = make_pt(
-        vec![
-            CallArg::Object(ObjectArg::ImmOrOwnedObject((
-                ObjectID::random(),
-                SequenceNumber::from_u64(1),
-                ObjectDigest::new([0xAA; 32]),
-            ))),
-            CallArg::Pure(bcs::to_bytes(&50u64).unwrap()), // slippage
-        ],
-        vec![make_move_call(
-            pkg,
-            "dex",
-            "swap",
-            vec![Argument::Input(0), Argument::Input(1)],
-        )],
-    );
-
-    let pt2 = make_pt(
-        vec![
-            CallArg::Object(ObjectArg::ImmOrOwnedObject((
-                ObjectID::random(), // different coin object
-                SequenceNumber::from_u64(99),
-                ObjectDigest::new([0xBB; 32]),
-            ))),
-            CallArg::Pure(bcs::to_bytes(&999u64).unwrap()), // different slippage
-        ],
-        vec![make_move_call(
-            pkg,
-            "dex",
-            "swap",
-            vec![Argument::Input(0), Argument::Input(1)],
-        )],
-    );
-
-    // Same coin type+balance, wildcard on slippage -> same digest
-    let coin_info_1: BTreeMap<usize, (TypeTag, u64)> =
-        [(0, (sui_coin_type(), 1000))].into_iter().collect();
-    let coin_info_2: BTreeMap<usize, (TypeTag, u64)> =
-        [(0, (sui_coin_type(), 1000))].into_iter().collect();
-    let wildcards: BTreeSet<u16> = [1].into_iter().collect();
-
-    assert_eq!(
-        pt1.structural_digest_with_options(Some(&coin_info_1), &wildcards),
-        pt2.structural_digest_with_options(Some(&coin_info_2), &wildcards),
-    );
-}
-
-// ============================================================================
 // Length framing (collision prevention)
 // ============================================================================
 
@@ -864,81 +589,6 @@ fn test_no_collision_different_arg_count() {
         )],
     );
 
-    assert_ne!(pt1.structural_digest(), pt2.structural_digest());
-}
-
-// ============================================================================
-// Two-mode coin normalization: base vs masked
-// ============================================================================
-
-#[test]
-fn test_base_digest_uses_object_id_for_coins() {
-    // structural_digest() should hash coins by ObjectID (identity-preserving).
-    // Different coin ObjectIDs with same type+balance -> different base digests.
-    let pkg = ObjectID::random();
-    let coin_id_1 = ObjectID::random();
-    let coin_id_2 = ObjectID::random();
-
-    let pt1 = make_pt(
-        vec![CallArg::Object(ObjectArg::ImmOrOwnedObject((
-            coin_id_1,
-            SequenceNumber::from_u64(1),
-            ObjectDigest::new([0xAA; 32]),
-        )))],
-        vec![make_move_call(pkg, "mod", "func", vec![Argument::Input(0)])],
-    );
-
-    let pt2 = make_pt(
-        vec![CallArg::Object(ObjectArg::ImmOrOwnedObject((
-            coin_id_2,
-            SequenceNumber::from_u64(1),
-            ObjectDigest::new([0xAA; 32]),
-        )))],
-        vec![make_move_call(pkg, "mod", "func", vec![Argument::Input(0)])],
-    );
-
-    // Base digest: different coin IDs -> different digests
-    assert_ne!(pt1.structural_digest(), pt2.structural_digest());
-}
-
-#[test]
-fn test_masked_digest_normalizes_coins_by_type_and_balance() {
-    // structural_digest_with_options(Some(coin_info), ...) normalizes coins.
-    // Different ObjectIDs with same type+balance -> same masked digest.
-    let pkg = ObjectID::random();
-    let coin_id_1 = ObjectID::random();
-    let coin_id_2 = ObjectID::random();
-
-    let pt1 = make_pt(
-        vec![CallArg::Object(ObjectArg::ImmOrOwnedObject((
-            coin_id_1,
-            SequenceNumber::from_u64(1),
-            ObjectDigest::new([0xAA; 32]),
-        )))],
-        vec![make_move_call(pkg, "mod", "func", vec![Argument::Input(0)])],
-    );
-
-    let pt2 = make_pt(
-        vec![CallArg::Object(ObjectArg::ImmOrOwnedObject((
-            coin_id_2,
-            SequenceNumber::from_u64(5),
-            ObjectDigest::new([0xBB; 32]),
-        )))],
-        vec![make_move_call(pkg, "mod", "func", vec![Argument::Input(0)])],
-    );
-
-    let coin_info_1: BTreeMap<usize, (TypeTag, u64)> =
-        [(0, (sui_coin_type(), 1000))].into_iter().collect();
-    let coin_info_2: BTreeMap<usize, (TypeTag, u64)> =
-        [(0, (sui_coin_type(), 1000))].into_iter().collect();
-
-    // Masked with coin normalization: same type+balance -> same digest
-    assert_eq!(
-        pt1.structural_digest_with_options(Some(&coin_info_1), &BTreeSet::new()),
-        pt2.structural_digest_with_options(Some(&coin_info_2), &BTreeSet::new()),
-    );
-
-    // But base digest differs (identity-preserving)
     assert_ne!(pt1.structural_digest(), pt2.structural_digest());
 }
 

--- a/crates/sui-types/src/unit_tests/structural_digest_tests.rs
+++ b/crates/sui-types/src/unit_tests/structural_digest_tests.rs
@@ -1,20 +1,25 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Tests for ProgrammableTransaction::structural_digest (SIP-70).
+//! Tests for ProgrammableTransaction::structural_digest (SIP-70 v2).
 //!
 //! Verifies that the structural digest is:
-//! - Deterministic (same PTB → same digest)
+//! - Deterministic (same PTB -> same digest)
+//! - Version-prefixed (first byte = 0x01, total length = 33)
 //! - Sensitive to command addition/removal/reordering
 //! - Sensitive to argument changes (different Pure values, different objects)
 //! - Sensitive to Result redirection (changing which command output flows where)
-//! - Stable when only irrelevant metadata changes (e.g. object digest bytes)
+//! - Stable when only irrelevant metadata changes (e.g. object digest, object version)
+//! - Coin-normalizable (same TypeName + Balance -> same digest regardless of ObjectID)
+//! - Wildcard-capable (specified Pure inputs hash as marker, not value)
 
-use crate::base_types::{ObjectID, SequenceNumber, ObjectDigest, random_object_ref};
+use crate::base_types::{ObjectDigest, ObjectID, SequenceNumber, random_object_ref};
 use crate::transaction::{
     Argument, CallArg, Command, ObjectArg, ProgrammableMoveCall, ProgrammableTransaction,
 };
 use crate::type_input::TypeInput;
+use move_core_types::language_storage::{StructTag, TypeTag};
+use std::collections::{BTreeMap, BTreeSet};
 
 /// Helper: build a simple MoveCall command
 fn make_move_call(
@@ -37,6 +42,39 @@ fn make_pt(inputs: Vec<CallArg>, commands: Vec<Command>) -> ProgrammableTransact
     ProgrammableTransaction { inputs, commands }
 }
 
+/// Helper: build a fake coin TypeTag (Coin<0x2::sui::SUI>)
+fn sui_coin_type() -> TypeTag {
+    TypeTag::Struct(Box::new(StructTag {
+        address: ObjectID::from_hex_literal("0x2").unwrap().into(),
+        module: move_core_types::identifier::Identifier::new("sui").unwrap(),
+        name: move_core_types::identifier::Identifier::new("SUI").unwrap(),
+        type_params: vec![],
+    }))
+}
+
+/// Helper: build a different coin TypeTag
+fn usdc_coin_type() -> TypeTag {
+    TypeTag::Struct(Box::new(StructTag {
+        address: ObjectID::from_hex_literal("0xdead").unwrap().into(),
+        module: move_core_types::identifier::Identifier::new("usdc").unwrap(),
+        name: move_core_types::identifier::Identifier::new("USDC").unwrap(),
+        type_params: vec![],
+    }))
+}
+
+// ============================================================================
+// Version prefix
+// ============================================================================
+
+#[test]
+fn test_structural_digest_has_version_prefix() {
+    let pt = make_pt(vec![], vec![]);
+    let digest = pt.structural_digest();
+    // Version prefix 0x01 + 32-byte Blake2b256 hash = 33 bytes
+    assert_eq!(digest.len(), 33);
+    assert_eq!(digest[0], 0x01);
+}
+
 // ============================================================================
 // Determinism
 // ============================================================================
@@ -57,14 +95,6 @@ fn test_structural_digest_is_deterministic() {
     );
 
     assert_eq!(pt1.structural_digest(), pt2.structural_digest());
-}
-
-#[test]
-fn test_structural_digest_length() {
-    let pt = make_pt(vec![], vec![]);
-    let digest = pt.structural_digest();
-    // Blake2b256 produces 32 bytes
-    assert_eq!(digest.len(), 32);
 }
 
 // ============================================================================
@@ -167,8 +197,6 @@ fn test_digest_changes_with_different_shared_object() {
 
 #[test]
 fn test_digest_stable_across_shared_object_version_change() {
-    // Shared objects are hashed by ObjectID only, not version.
-    // So changing initial_shared_version should NOT change the digest.
     let pkg = ObjectID::random();
     let shared_id = ObjectID::random();
 
@@ -195,8 +223,6 @@ fn test_digest_stable_across_shared_object_version_change() {
 
 #[test]
 fn test_digest_stable_across_object_digest_change() {
-    // Owned objects are hashed by ObjectID + version. The ObjectDigest
-    // (content hash) is NOT included, so changing it should not affect the digest.
     let pkg = ObjectID::random();
     let obj_id = ObjectID::random();
     let version = SequenceNumber::from_u64(5);
@@ -214,6 +240,64 @@ fn test_digest_stable_across_object_digest_change() {
         vec![CallArg::Object(ObjectArg::ImmOrOwnedObject((
             obj_id,
             version,
+            ObjectDigest::new([0xBB; 32]),
+        )))],
+        vec![make_move_call(pkg, "mod", "func", vec![Argument::Input(0)])],
+    );
+
+    assert_eq!(pt1.structural_digest(), pt2.structural_digest());
+}
+
+// ============================================================================
+// Owned object version stability (Change 2: version dropped)
+// ============================================================================
+
+#[test]
+fn test_digest_stable_across_owned_object_version_change() {
+    // Owned objects are now hashed by ObjectID only — version is dropped because
+    // it drifts between proposal vote time and execution time.
+    let pkg = ObjectID::random();
+    let obj_id = ObjectID::random();
+
+    let pt1 = make_pt(
+        vec![CallArg::Object(ObjectArg::ImmOrOwnedObject((
+            obj_id,
+            SequenceNumber::from_u64(1),
+            ObjectDigest::new([0xAA; 32]),
+        )))],
+        vec![make_move_call(pkg, "mod", "func", vec![Argument::Input(0)])],
+    );
+
+    let pt2 = make_pt(
+        vec![CallArg::Object(ObjectArg::ImmOrOwnedObject((
+            obj_id,
+            SequenceNumber::from_u64(999),
+            ObjectDigest::new([0xBB; 32]),
+        )))],
+        vec![make_move_call(pkg, "mod", "func", vec![Argument::Input(0)])],
+    );
+
+    assert_eq!(pt1.structural_digest(), pt2.structural_digest());
+}
+
+#[test]
+fn test_digest_stable_across_receiving_object_version_change() {
+    let pkg = ObjectID::random();
+    let obj_id = ObjectID::random();
+
+    let pt1 = make_pt(
+        vec![CallArg::Object(ObjectArg::Receiving((
+            obj_id,
+            SequenceNumber::from_u64(1),
+            ObjectDigest::new([0xAA; 32]),
+        )))],
+        vec![make_move_call(pkg, "mod", "func", vec![Argument::Input(0)])],
+    );
+
+    let pt2 = make_pt(
+        vec![CallArg::Object(ObjectArg::Receiving((
+            obj_id,
+            SequenceNumber::from_u64(999),
             ObjectDigest::new([0xBB; 32]),
         )))],
         vec![make_move_call(pkg, "mod", "func", vec![Argument::Input(0)])],
@@ -247,7 +331,6 @@ fn test_digest_changes_with_different_owned_object() {
 fn test_digest_changes_with_result_redirection() {
     let pkg = ObjectID::random();
 
-    // PTB1: cmd0 produces result, cmd1 uses Result(0)
     let pt1 = make_pt(
         vec![],
         vec![
@@ -256,7 +339,6 @@ fn test_digest_changes_with_result_redirection() {
         ],
     );
 
-    // PTB2: cmd0 and cmd1 produce results, cmd2 uses Result(1) instead of Result(0)
     let pt2 = make_pt(
         vec![],
         vec![
@@ -300,7 +382,6 @@ fn test_digest_distinguishes_result_vs_nested_result() {
 fn test_digest_gas_coin_is_stable() {
     let pkg = ObjectID::random();
 
-    // Two identical PTBs using GasCoin — should produce same digest
     let pt1 = make_pt(
         vec![],
         vec![make_move_call(pkg, "mod", "func", vec![Argument::GasCoin])],
@@ -339,7 +420,6 @@ fn test_digest_gas_coin_differs_from_input() {
 fn test_digest_distinguishes_command_types() {
     let obj_ref = random_object_ref();
 
-    // SplitCoins vs MergeCoins with same arguments should differ
     let pt1 = make_pt(
         vec![
             CallArg::Object(ObjectArg::ImmOrOwnedObject(obj_ref)),
@@ -368,15 +448,8 @@ fn test_digest_changes_with_different_package() {
     let pkg1 = ObjectID::random();
     let pkg2 = ObjectID::random();
 
-    let pt1 = make_pt(
-        vec![],
-        vec![make_move_call(pkg1, "mod", "func", vec![])],
-    );
-
-    let pt2 = make_pt(
-        vec![],
-        vec![make_move_call(pkg2, "mod", "func", vec![])],
-    );
+    let pt1 = make_pt(vec![], vec![make_move_call(pkg1, "mod", "func", vec![])]);
+    let pt2 = make_pt(vec![], vec![make_move_call(pkg2, "mod", "func", vec![])]);
 
     assert_ne!(pt1.structural_digest(), pt2.structural_digest());
 }
@@ -447,13 +520,223 @@ fn test_empty_ptb_has_stable_digest() {
 }
 
 // ============================================================================
+// Coin normalization (Change 3)
+// ============================================================================
+
+#[test]
+fn test_coin_normalized_digest_stable_across_different_object_ids() {
+    // Two PTBs with different coin ObjectIDs but same TypeName + Balance
+    // should produce the same digest when coin_info is provided.
+    let pkg = ObjectID::random();
+    let coin_id_1 = ObjectID::random();
+    let coin_id_2 = ObjectID::random();
+
+    let pt1 = make_pt(
+        vec![CallArg::Object(ObjectArg::ImmOrOwnedObject((
+            coin_id_1,
+            SequenceNumber::from_u64(1),
+            ObjectDigest::new([0xAA; 32]),
+        )))],
+        vec![make_move_call(pkg, "mod", "func", vec![Argument::Input(0)])],
+    );
+
+    let pt2 = make_pt(
+        vec![CallArg::Object(ObjectArg::ImmOrOwnedObject((
+            coin_id_2,
+            SequenceNumber::from_u64(5),
+            ObjectDigest::new([0xBB; 32]),
+        )))],
+        vec![make_move_call(pkg, "mod", "func", vec![Argument::Input(0)])],
+    );
+
+    // Without coin_info: different ObjectIDs -> different digests
+    assert_ne!(pt1.structural_digest(), pt2.structural_digest());
+
+    // With coin_info (same type + balance): same digest
+    let coin_info_1: BTreeMap<usize, (TypeTag, u64)> =
+        [(0, (sui_coin_type(), 1000))].into_iter().collect();
+    let coin_info_2: BTreeMap<usize, (TypeTag, u64)> =
+        [(0, (sui_coin_type(), 1000))].into_iter().collect();
+
+    assert_eq!(
+        pt1.structural_digest_with_options(Some(&coin_info_1), &BTreeSet::new()),
+        pt2.structural_digest_with_options(Some(&coin_info_2), &BTreeSet::new()),
+    );
+}
+
+#[test]
+fn test_coin_normalized_digest_changes_with_different_balance() {
+    let pkg = ObjectID::random();
+
+    let pt = make_pt(
+        vec![CallArg::Object(ObjectArg::ImmOrOwnedObject(random_object_ref()))],
+        vec![make_move_call(pkg, "mod", "func", vec![Argument::Input(0)])],
+    );
+
+    let coin_info_1000: BTreeMap<usize, (TypeTag, u64)> =
+        [(0, (sui_coin_type(), 1000))].into_iter().collect();
+    let coin_info_2000: BTreeMap<usize, (TypeTag, u64)> =
+        [(0, (sui_coin_type(), 2000))].into_iter().collect();
+
+    assert_ne!(
+        pt.structural_digest_with_options(Some(&coin_info_1000), &BTreeSet::new()),
+        pt.structural_digest_with_options(Some(&coin_info_2000), &BTreeSet::new()),
+    );
+}
+
+#[test]
+fn test_coin_normalized_digest_changes_with_different_type() {
+    let pkg = ObjectID::random();
+
+    let pt = make_pt(
+        vec![CallArg::Object(ObjectArg::ImmOrOwnedObject(random_object_ref()))],
+        vec![make_move_call(pkg, "mod", "func", vec![Argument::Input(0)])],
+    );
+
+    let sui_info: BTreeMap<usize, (TypeTag, u64)> =
+        [(0, (sui_coin_type(), 1000))].into_iter().collect();
+    let usdc_info: BTreeMap<usize, (TypeTag, u64)> =
+        [(0, (usdc_coin_type(), 1000))].into_iter().collect();
+
+    assert_ne!(
+        pt.structural_digest_with_options(Some(&sui_info), &BTreeSet::new()),
+        pt.structural_digest_with_options(Some(&usdc_info), &BTreeSet::new()),
+    );
+}
+
+// ============================================================================
+// Wildcard slots (Change 4)
+// ============================================================================
+
+#[test]
+fn test_wildcard_digest_stable_across_different_pure_values() {
+    // Two PTBs that differ only in a wildcarded Pure input should produce the same digest.
+    let pkg = ObjectID::random();
+
+    let pt1 = make_pt(
+        vec![
+            CallArg::Pure(bcs::to_bytes(&100u64).unwrap()), // input 0: amount (pinned)
+            CallArg::Pure(bcs::to_bytes(&50u64).unwrap()),  // input 1: slippage (wildcard)
+        ],
+        vec![make_move_call(pkg, "dex", "swap", vec![Argument::Input(0), Argument::Input(1)])],
+    );
+
+    let pt2 = make_pt(
+        vec![
+            CallArg::Pure(bcs::to_bytes(&100u64).unwrap()), // input 0: same amount
+            CallArg::Pure(bcs::to_bytes(&999u64).unwrap()), // input 1: different slippage
+        ],
+        vec![make_move_call(pkg, "dex", "swap", vec![Argument::Input(0), Argument::Input(1)])],
+    );
+
+    // Without wildcards: different Pure values -> different digests
+    assert_ne!(pt1.structural_digest(), pt2.structural_digest());
+
+    // With wildcard on input 1: same digest
+    let wildcards: BTreeSet<u16> = [1].into_iter().collect();
+    assert_eq!(
+        pt1.structural_digest_with_options(None, &wildcards),
+        pt2.structural_digest_with_options(None, &wildcards),
+    );
+
+    // Non-wildcarded input (0) still differentiates
+    let pt3 = make_pt(
+        vec![
+            CallArg::Pure(bcs::to_bytes(&200u64).unwrap()), // input 0: different amount
+            CallArg::Pure(bcs::to_bytes(&50u64).unwrap()),  // input 1: same slippage
+        ],
+        vec![make_move_call(pkg, "dex", "swap", vec![Argument::Input(0), Argument::Input(1)])],
+    );
+
+    assert_ne!(
+        pt1.structural_digest_with_options(None, &wildcards),
+        pt3.structural_digest_with_options(None, &wildcards),
+    );
+}
+
+#[test]
+fn test_wildcard_only_applies_to_specified_indices() {
+    let pkg = ObjectID::random();
+
+    let pt1 = make_pt(
+        vec![
+            CallArg::Pure(bcs::to_bytes(&100u64).unwrap()),
+            CallArg::Pure(bcs::to_bytes(&200u64).unwrap()),
+        ],
+        vec![make_move_call(pkg, "mod", "func", vec![Argument::Input(0), Argument::Input(1)])],
+    );
+
+    let pt2 = make_pt(
+        vec![
+            CallArg::Pure(bcs::to_bytes(&100u64).unwrap()),
+            CallArg::Pure(bcs::to_bytes(&999u64).unwrap()),
+        ],
+        vec![make_move_call(pkg, "mod", "func", vec![Argument::Input(0), Argument::Input(1)])],
+    );
+
+    // Wildcard on input 0 only: input 1 still differentiates
+    let wildcards_0: BTreeSet<u16> = [0].into_iter().collect();
+    assert_ne!(
+        pt1.structural_digest_with_options(None, &wildcards_0),
+        pt2.structural_digest_with_options(None, &wildcards_0),
+    );
+
+    // Wildcard on input 1 only: input 0 is the same -> same digest
+    let wildcards_1: BTreeSet<u16> = [1].into_iter().collect();
+    assert_eq!(
+        pt1.structural_digest_with_options(None, &wildcards_1),
+        pt2.structural_digest_with_options(None, &wildcards_1),
+    );
+}
+
+#[test]
+fn test_wildcard_and_coin_normalization_combined() {
+    // Coin normalization and wildcards work together.
+    let pkg = ObjectID::random();
+
+    let pt1 = make_pt(
+        vec![
+            CallArg::Object(ObjectArg::ImmOrOwnedObject((
+                ObjectID::random(),
+                SequenceNumber::from_u64(1),
+                ObjectDigest::new([0xAA; 32]),
+            ))),
+            CallArg::Pure(bcs::to_bytes(&50u64).unwrap()), // slippage
+        ],
+        vec![make_move_call(pkg, "dex", "swap", vec![Argument::Input(0), Argument::Input(1)])],
+    );
+
+    let pt2 = make_pt(
+        vec![
+            CallArg::Object(ObjectArg::ImmOrOwnedObject((
+                ObjectID::random(), // different coin object
+                SequenceNumber::from_u64(99),
+                ObjectDigest::new([0xBB; 32]),
+            ))),
+            CallArg::Pure(bcs::to_bytes(&999u64).unwrap()), // different slippage
+        ],
+        vec![make_move_call(pkg, "dex", "swap", vec![Argument::Input(0), Argument::Input(1)])],
+    );
+
+    // Same coin type+balance, wildcard on slippage -> same digest
+    let coin_info_1: BTreeMap<usize, (TypeTag, u64)> =
+        [(0, (sui_coin_type(), 1000))].into_iter().collect();
+    let coin_info_2: BTreeMap<usize, (TypeTag, u64)> =
+        [(0, (sui_coin_type(), 1000))].into_iter().collect();
+    let wildcards: BTreeSet<u16> = [1].into_iter().collect();
+
+    assert_eq!(
+        pt1.structural_digest_with_options(Some(&coin_info_1), &wildcards),
+        pt2.structural_digest_with_options(Some(&coin_info_2), &wildcards),
+    );
+}
+
+// ============================================================================
 // Complex multi-command PTB (governance scenario)
 // ============================================================================
 
 #[test]
 fn test_governance_scenario_digest_stability() {
-    // Simulate: SplitCoin → Swap → Deposit
-    // The digest should be stable for the same logical flow
     let pkg = ObjectID::random();
     let coin_ref = random_object_ref();
 
@@ -464,11 +747,8 @@ fn test_governance_scenario_digest_stability() {
                 CallArg::Pure(bcs::to_bytes(&1000u64).unwrap()),
             ],
             vec![
-                // cmd 0: split coin
                 Command::SplitCoins(Argument::Input(0), vec![Argument::Input(1)]),
-                // cmd 1: swap (uses Result(0) = split output)
                 make_move_call(pkg, "dex", "swap", vec![Argument::Result(0)]),
-                // cmd 2: deposit (uses Result(1) = swap output)
                 make_move_call(pkg, "vault", "deposit", vec![Argument::Result(1)]),
             ],
         )
@@ -482,7 +762,6 @@ fn test_governance_scenario_digest_stability() {
 
 #[test]
 fn test_governance_scenario_detects_swap_target_change() {
-    // Same flow but swapping on a different DEX should change the digest
     let pkg1 = ObjectID::random();
     let pkg2 = ObjectID::random();
     let vault_pkg = ObjectID::random();

--- a/crates/sui-types/src/unit_tests/structural_digest_tests.rs
+++ b/crates/sui-types/src/unit_tests/structural_digest_tests.rs
@@ -732,6 +732,132 @@ fn test_wildcard_and_coin_normalization_combined() {
 }
 
 // ============================================================================
+// Length framing (collision prevention)
+// ============================================================================
+
+#[test]
+fn test_no_collision_module_function_boundary() {
+    // Without length framing, "a" + "bc" hashes same as "ab" + "c".
+    // With length framing, they differ.
+    let pkg = ObjectID::random();
+
+    let pt1 = make_pt(vec![], vec![make_move_call(pkg, "a", "bc", vec![])]);
+    let pt2 = make_pt(vec![], vec![make_move_call(pkg, "ab", "c", vec![])]);
+
+    assert_ne!(pt1.structural_digest(), pt2.structural_digest());
+}
+
+#[test]
+fn test_no_collision_module_function_boundary_longer() {
+    // Another boundary case: "mod" + "func" vs "modf" + "unc"
+    let pkg = ObjectID::random();
+
+    let pt1 = make_pt(vec![], vec![make_move_call(pkg, "mod", "func", vec![])]);
+    let pt2 = make_pt(vec![], vec![make_move_call(pkg, "modf", "unc", vec![])]);
+
+    assert_ne!(pt1.structural_digest(), pt2.structural_digest());
+}
+
+#[test]
+fn test_no_collision_different_arg_count() {
+    // A single 2-byte Pure vs two 1-byte Pures should differ
+    // (list count framing prevents this collision)
+    let pkg = ObjectID::random();
+
+    let pt1 = make_pt(
+        vec![CallArg::Pure(vec![0x01, 0x02])],
+        vec![make_move_call(pkg, "mod", "func", vec![Argument::Input(0)])],
+    );
+
+    let pt2 = make_pt(
+        vec![CallArg::Pure(vec![0x01]), CallArg::Pure(vec![0x02])],
+        vec![make_move_call(
+            pkg,
+            "mod",
+            "func",
+            vec![Argument::Input(0), Argument::Input(1)],
+        )],
+    );
+
+    assert_ne!(pt1.structural_digest(), pt2.structural_digest());
+}
+
+// ============================================================================
+// Two-mode coin normalization: base vs masked
+// ============================================================================
+
+#[test]
+fn test_base_digest_uses_object_id_for_coins() {
+    // structural_digest() should hash coins by ObjectID (identity-preserving).
+    // Different coin ObjectIDs with same type+balance -> different base digests.
+    let pkg = ObjectID::random();
+    let coin_id_1 = ObjectID::random();
+    let coin_id_2 = ObjectID::random();
+
+    let pt1 = make_pt(
+        vec![CallArg::Object(ObjectArg::ImmOrOwnedObject((
+            coin_id_1,
+            SequenceNumber::from_u64(1),
+            ObjectDigest::new([0xAA; 32]),
+        )))],
+        vec![make_move_call(pkg, "mod", "func", vec![Argument::Input(0)])],
+    );
+
+    let pt2 = make_pt(
+        vec![CallArg::Object(ObjectArg::ImmOrOwnedObject((
+            coin_id_2,
+            SequenceNumber::from_u64(1),
+            ObjectDigest::new([0xAA; 32]),
+        )))],
+        vec![make_move_call(pkg, "mod", "func", vec![Argument::Input(0)])],
+    );
+
+    // Base digest: different coin IDs -> different digests
+    assert_ne!(pt1.structural_digest(), pt2.structural_digest());
+}
+
+#[test]
+fn test_masked_digest_normalizes_coins_by_type_and_balance() {
+    // structural_digest_with_options(Some(coin_info), ...) normalizes coins.
+    // Different ObjectIDs with same type+balance -> same masked digest.
+    let pkg = ObjectID::random();
+    let coin_id_1 = ObjectID::random();
+    let coin_id_2 = ObjectID::random();
+
+    let pt1 = make_pt(
+        vec![CallArg::Object(ObjectArg::ImmOrOwnedObject((
+            coin_id_1,
+            SequenceNumber::from_u64(1),
+            ObjectDigest::new([0xAA; 32]),
+        )))],
+        vec![make_move_call(pkg, "mod", "func", vec![Argument::Input(0)])],
+    );
+
+    let pt2 = make_pt(
+        vec![CallArg::Object(ObjectArg::ImmOrOwnedObject((
+            coin_id_2,
+            SequenceNumber::from_u64(5),
+            ObjectDigest::new([0xBB; 32]),
+        )))],
+        vec![make_move_call(pkg, "mod", "func", vec![Argument::Input(0)])],
+    );
+
+    let coin_info_1: BTreeMap<usize, (TypeTag, u64)> =
+        [(0, (sui_coin_type(), 1000))].into_iter().collect();
+    let coin_info_2: BTreeMap<usize, (TypeTag, u64)> =
+        [(0, (sui_coin_type(), 1000))].into_iter().collect();
+
+    // Masked with coin normalization: same type+balance -> same digest
+    assert_eq!(
+        pt1.structural_digest_with_options(Some(&coin_info_1), &BTreeSet::new()),
+        pt2.structural_digest_with_options(Some(&coin_info_2), &BTreeSet::new()),
+    );
+
+    // But base digest differs (identity-preserving)
+    assert_ne!(pt1.structural_digest(), pt2.structural_digest());
+}
+
+// ============================================================================
 // Complex multi-command PTB (governance scenario)
 // ============================================================================
 

--- a/crates/sui-types/src/unit_tests/structural_digest_tests.rs
+++ b/crates/sui-types/src/unit_tests/structural_digest_tests.rs
@@ -86,12 +86,22 @@ fn test_structural_digest_is_deterministic() {
 
     let pt1 = make_pt(
         vec![CallArg::Object(ObjectArg::ImmOrOwnedObject(obj_ref))],
-        vec![make_move_call(pkg, "module", "func", vec![Argument::Input(0)])],
+        vec![make_move_call(
+            pkg,
+            "module",
+            "func",
+            vec![Argument::Input(0)],
+        )],
     );
 
     let pt2 = make_pt(
         vec![CallArg::Object(ObjectArg::ImmOrOwnedObject(obj_ref))],
-        vec![make_move_call(pkg, "module", "func", vec![Argument::Input(0)])],
+        vec![make_move_call(
+            pkg,
+            "module",
+            "func",
+            vec![Argument::Input(0)],
+        )],
     );
 
     assert_eq!(pt1.structural_digest(), pt2.structural_digest());
@@ -248,6 +258,32 @@ fn test_digest_stable_across_object_digest_change() {
     assert_eq!(pt1.structural_digest(), pt2.structural_digest());
 }
 
+#[test]
+fn test_digest_changes_with_shared_object_mutability() {
+    let pkg = ObjectID::random();
+    let shared_id = ObjectID::random();
+
+    let pt1 = make_pt(
+        vec![CallArg::Object(ObjectArg::SharedObject {
+            id: shared_id,
+            initial_shared_version: SequenceNumber::from_u64(1),
+            mutability: crate::transaction::SharedObjectMutability::Mutable,
+        })],
+        vec![make_move_call(pkg, "mod", "func", vec![Argument::Input(0)])],
+    );
+
+    let pt2 = make_pt(
+        vec![CallArg::Object(ObjectArg::SharedObject {
+            id: shared_id,
+            initial_shared_version: SequenceNumber::from_u64(1),
+            mutability: crate::transaction::SharedObjectMutability::Immutable,
+        })],
+        vec![make_move_call(pkg, "mod", "func", vec![Argument::Input(0)])],
+    );
+
+    assert_ne!(pt1.structural_digest(), pt2.structural_digest());
+}
+
 // ============================================================================
 // Owned object version stability (Change 2: version dropped)
 // ============================================================================
@@ -311,12 +347,16 @@ fn test_digest_changes_with_different_owned_object() {
     let pkg = ObjectID::random();
 
     let pt1 = make_pt(
-        vec![CallArg::Object(ObjectArg::ImmOrOwnedObject(random_object_ref()))],
+        vec![CallArg::Object(ObjectArg::ImmOrOwnedObject(
+            random_object_ref(),
+        ))],
         vec![make_move_call(pkg, "mod", "func", vec![Argument::Input(0)])],
     );
 
     let pt2 = make_pt(
-        vec![CallArg::Object(ObjectArg::ImmOrOwnedObject(random_object_ref()))],
+        vec![CallArg::Object(ObjectArg::ImmOrOwnedObject(
+            random_object_ref(),
+        ))],
         vec![make_move_call(pkg, "mod", "func", vec![Argument::Input(0)])],
     );
 
@@ -425,7 +465,10 @@ fn test_digest_distinguishes_command_types() {
             CallArg::Object(ObjectArg::ImmOrOwnedObject(obj_ref)),
             CallArg::Pure(bcs::to_bytes(&100u64).unwrap()),
         ],
-        vec![Command::SplitCoins(Argument::Input(0), vec![Argument::Input(1)])],
+        vec![Command::SplitCoins(
+            Argument::Input(0),
+            vec![Argument::Input(1)],
+        )],
     );
 
     let pt2 = make_pt(
@@ -433,7 +476,10 @@ fn test_digest_distinguishes_command_types() {
             CallArg::Object(ObjectArg::ImmOrOwnedObject(obj_ref)),
             CallArg::Pure(bcs::to_bytes(&100u64).unwrap()),
         ],
-        vec![Command::MergeCoins(Argument::Input(0), vec![Argument::Input(1)])],
+        vec![Command::MergeCoins(
+            Argument::Input(0),
+            vec![Argument::Input(1)],
+        )],
     );
 
     assert_ne!(pt1.structural_digest(), pt2.structural_digest());
@@ -569,7 +615,9 @@ fn test_coin_normalized_digest_changes_with_different_balance() {
     let pkg = ObjectID::random();
 
     let pt = make_pt(
-        vec![CallArg::Object(ObjectArg::ImmOrOwnedObject(random_object_ref()))],
+        vec![CallArg::Object(ObjectArg::ImmOrOwnedObject(
+            random_object_ref(),
+        ))],
         vec![make_move_call(pkg, "mod", "func", vec![Argument::Input(0)])],
     );
 
@@ -589,7 +637,9 @@ fn test_coin_normalized_digest_changes_with_different_type() {
     let pkg = ObjectID::random();
 
     let pt = make_pt(
-        vec![CallArg::Object(ObjectArg::ImmOrOwnedObject(random_object_ref()))],
+        vec![CallArg::Object(ObjectArg::ImmOrOwnedObject(
+            random_object_ref(),
+        ))],
         vec![make_move_call(pkg, "mod", "func", vec![Argument::Input(0)])],
     );
 
@@ -618,7 +668,12 @@ fn test_wildcard_digest_stable_across_different_pure_values() {
             CallArg::Pure(bcs::to_bytes(&100u64).unwrap()), // input 0: amount (pinned)
             CallArg::Pure(bcs::to_bytes(&50u64).unwrap()),  // input 1: slippage (wildcard)
         ],
-        vec![make_move_call(pkg, "dex", "swap", vec![Argument::Input(0), Argument::Input(1)])],
+        vec![make_move_call(
+            pkg,
+            "dex",
+            "swap",
+            vec![Argument::Input(0), Argument::Input(1)],
+        )],
     );
 
     let pt2 = make_pt(
@@ -626,7 +681,12 @@ fn test_wildcard_digest_stable_across_different_pure_values() {
             CallArg::Pure(bcs::to_bytes(&100u64).unwrap()), // input 0: same amount
             CallArg::Pure(bcs::to_bytes(&999u64).unwrap()), // input 1: different slippage
         ],
-        vec![make_move_call(pkg, "dex", "swap", vec![Argument::Input(0), Argument::Input(1)])],
+        vec![make_move_call(
+            pkg,
+            "dex",
+            "swap",
+            vec![Argument::Input(0), Argument::Input(1)],
+        )],
     );
 
     // Without wildcards: different Pure values -> different digests
@@ -645,7 +705,12 @@ fn test_wildcard_digest_stable_across_different_pure_values() {
             CallArg::Pure(bcs::to_bytes(&200u64).unwrap()), // input 0: different amount
             CallArg::Pure(bcs::to_bytes(&50u64).unwrap()),  // input 1: same slippage
         ],
-        vec![make_move_call(pkg, "dex", "swap", vec![Argument::Input(0), Argument::Input(1)])],
+        vec![make_move_call(
+            pkg,
+            "dex",
+            "swap",
+            vec![Argument::Input(0), Argument::Input(1)],
+        )],
     );
 
     assert_ne!(
@@ -663,7 +728,12 @@ fn test_wildcard_only_applies_to_specified_indices() {
             CallArg::Pure(bcs::to_bytes(&100u64).unwrap()),
             CallArg::Pure(bcs::to_bytes(&200u64).unwrap()),
         ],
-        vec![make_move_call(pkg, "mod", "func", vec![Argument::Input(0), Argument::Input(1)])],
+        vec![make_move_call(
+            pkg,
+            "mod",
+            "func",
+            vec![Argument::Input(0), Argument::Input(1)],
+        )],
     );
 
     let pt2 = make_pt(
@@ -671,7 +741,12 @@ fn test_wildcard_only_applies_to_specified_indices() {
             CallArg::Pure(bcs::to_bytes(&100u64).unwrap()),
             CallArg::Pure(bcs::to_bytes(&999u64).unwrap()),
         ],
-        vec![make_move_call(pkg, "mod", "func", vec![Argument::Input(0), Argument::Input(1)])],
+        vec![make_move_call(
+            pkg,
+            "mod",
+            "func",
+            vec![Argument::Input(0), Argument::Input(1)],
+        )],
     );
 
     // Wildcard on input 0 only: input 1 still differentiates
@@ -703,7 +778,12 @@ fn test_wildcard_and_coin_normalization_combined() {
             ))),
             CallArg::Pure(bcs::to_bytes(&50u64).unwrap()), // slippage
         ],
-        vec![make_move_call(pkg, "dex", "swap", vec![Argument::Input(0), Argument::Input(1)])],
+        vec![make_move_call(
+            pkg,
+            "dex",
+            "swap",
+            vec![Argument::Input(0), Argument::Input(1)],
+        )],
     );
 
     let pt2 = make_pt(
@@ -715,7 +795,12 @@ fn test_wildcard_and_coin_normalization_combined() {
             ))),
             CallArg::Pure(bcs::to_bytes(&999u64).unwrap()), // different slippage
         ],
-        vec![make_move_call(pkg, "dex", "swap", vec![Argument::Input(0), Argument::Input(1)])],
+        vec![make_move_call(
+            pkg,
+            "dex",
+            "swap",
+            vec![Argument::Input(0), Argument::Input(1)],
+        )],
     );
 
     // Same coin type+balance, wildcard on slippage -> same digest

--- a/docs/sip-70-ptb-structural-digest.md
+++ b/docs/sip-70-ptb-structural-digest.md
@@ -1,0 +1,155 @@
+# SIP-70: PTB Structural Digest
+
+## Summary
+
+Add a single native function `sui::tx_context::structural_digest(&TxContext): vector<u8>` that returns a deterministic, normalized SHA2-256 hash of the current PTB's structure. This enables DAOs, smart accounts, and governance contracts to vote on "what will be executed" and verify at execution time that the PTB matches the approved template.
+
+## Motivation
+
+### The Problem
+
+DAOs and smart accounts need to vote on a transaction before it is executed. But committing to a PTB is surprisingly hard:
+
+- **Object IDs are brittle** — `SplitCoin` creates new IDs each time
+- **`tx_context::digest()` changes every execution** — it hashes the full transaction including signatures, gas payment, and exact object references
+- **Hot potato wrappers don't scale** — every protocol integration needs custom wrapper code
+
+### The Solution
+
+Hash the **structure and argument provenance**, not the runtime identity. A structural digest captures:
+- Which commands call which targets, in what order
+- How results flow between commands (`Result(n)` / `NestedResult(n, m)`)
+- What values are passed (Pure bytes, shared object IDs, owned object refs)
+- Type arguments for each call
+
+Two PTBs that differ only in which specific coin objects are used (but have the same type, balance, and flow) can produce the same digest.
+
+## Specification
+
+### Normalization Rules
+
+Each PTB argument type is normalized before hashing:
+
+| Argument Type | What Gets Hashed | Rationale |
+|---|---|---|
+| `GasCoin` | `0x00` marker byte | Gas coin ID is sender-dependent |
+| `Input(n)` → `CallArg::Pure(bytes)` | `0x01` + BCS bytes | Exact parameter values |
+| `Input(n)` → `ObjectArg::SharedObject` | `0x02` + ObjectID | Static anchors (pools, governance objects) |
+| `Input(n)` → `ObjectArg::ImmOrOwnedObject` | `0x03` + ObjectID + version | Identity-stable for non-fungible objects |
+| `Input(n)` → `ObjectArg::Receiving` | `0x04` + ObjectID + version | Receiving objects |
+| `Result(n)` | `0x05` + command_index(u16) | Provenance — which command produced this |
+| `NestedResult(n, m)` | `0x06` + command_index(u16) + result_index(u16) | Provenance with tuple element |
+
+### Hash Construction
+
+```
+structural_digest = SHA2-256(
+    for each command in order:
+        SHA2-256(command_discriminator || command_specific_data || normalized_arguments)
+)
+```
+
+For `Command::MoveCall`:
+```
+SHA2-256(0x00 || package_id || module_name || function_name || type_args_bcs || normalized_args)
+```
+
+For `Command::TransferObjects`:
+```
+SHA2-256(0x01 || normalized_objects || normalized_recipient)
+```
+
+For `Command::SplitCoins`:
+```
+SHA2-256(0x02 || normalized_coin || normalized_amounts)
+```
+
+For `Command::MergeCoins`:
+```
+SHA2-256(0x03 || normalized_target || normalized_sources)
+```
+
+For `Command::Publish`:
+```
+SHA2-256(0x04 || module_bytes || dependency_ids)
+```
+
+For `Command::MakeMoveVec`:
+```
+SHA2-256(0x05 || type_tag_bcs || normalized_elements)
+```
+
+For `Command::Upgrade`:
+```
+SHA2-256(0x06 || module_bytes || dependency_ids || package_id || normalized_ticket)
+```
+
+### Move API
+
+```move
+module sui::tx_context {
+    /// Returns the normalized structural digest of the current PTB.
+    /// Deterministic: same logical PTB structure -> same digest,
+    /// even if coin object IDs differ due to splits/merges.
+    public fun structural_digest(_self: &TxContext): vector<u8> {
+        native_structural_digest()
+    }
+    native fun native_structural_digest(): vector<u8>;
+}
+```
+
+### Governance Example
+
+```move
+module dao::executor {
+    use sui::tx_context;
+
+    public fun execute_approved(ctx: &TxContext, proposal: &Proposal) {
+        let digest = tx_context::structural_digest(ctx);
+        assert!(proposal.approved_digest() == digest, EDigestMismatch);
+    }
+}
+```
+
+### Client-Side Computation
+
+The SDK must implement the same normalization algorithm for off-chain digest preview:
+
+```typescript
+import { Transaction } from '@mysten/sui/transactions';
+
+const tx = new Transaction();
+// ... build PTB ...
+const digest = tx.computeStructuralDigest();
+// Submit digest to DAO for approval vote
+```
+
+## Implementation
+
+### Files Changed
+
+1. **`crates/sui-types/src/transaction.rs`** — `ProgrammableTransaction::structural_digest()` method
+2. **`crates/sui-types/src/base_types.rs`** — `structural_digest` field on `TxContext`
+3. **`sui-execution/latest/sui-adapter/src/execution_engine.rs`** — Compute digest before PTB execution
+4. **`sui-execution/latest/sui-move-natives/src/transaction_context.rs`** — Accessor
+5. **`sui-execution/latest/sui-move-natives/src/tx_context.rs`** — Native function impl
+6. **`sui-execution/latest/sui-move-natives/src/lib.rs`** — Registration + cost params
+7. **`crates/sui-framework/packages/sui-framework/sources/tx_context.move`** — Move declaration
+8. **`crates/sui-protocol-config/src/lib.rs`** — Feature gate + gas cost
+
+### Security Considerations
+
+- **Read-only, VM-computed, unforgeable** — contracts cannot influence the computation
+- **Order-sensitive** — adding/removing/reordering commands changes the digest
+- **Flow-sensitive** — redirecting a `Result` to a different command changes the digest
+- **No censorship vector** — contracts cannot inspect individual commands
+
+### Backwards Compatibility
+
+Purely additive. One new native function gated behind a protocol version bump.
+
+## Future Work
+
+- **Coin normalization** — Hash coins by `TypeName + Balance` instead of ObjectID, making the digest stable across coin split/merge. Requires input object resolution during digest computation.
+- **Client SDK** — `computeStructuralDigest()` in `@mysten/sui/transactions`
+- **Wildcard slots** — Allow certain argument positions to be "any value" in the digest template

--- a/docs/sip-70-ptb-structural-digest.md
+++ b/docs/sip-70-ptb-structural-digest.md
@@ -1,32 +1,26 @@
-# SIP-70: PTB Structural Digest (v2)
+# SIP-70: PTB Structural Digest
 
 ## Summary
 
-Two native functions on `sui::tx_context`:
+One native function on `sui::tx_context`:
 
-1. `structural_digest(&TxContext): vector<u8>` — returns a versioned, deterministic hash of the current PTB's structure. Identity-preserving: coins hash by ObjectID.
-2. `structural_digest_masked(&TxContext, wildcard_pure_indices: vector<u64>): vector<u8>` — same structure hash, but with coin normalization (TypeTag + balance instead of ObjectID) and specified Pure inputs treated as wildcards.
+1. `structural_digest(&TxContext): vector<u8>` — returns a versioned, deterministic hash of the current PTB's structure.
 
-This enables DAOs, smart accounts, and governance contracts to vote on "what will be executed" and verify at execution time that the PTB matches the approved template.
+This enables DAOs, smart accounts, and governance contracts to approve "what will be executed" and verify at execution time that the PTB matches that approval.
 
 ## Motivation
 
 ### The Problem
 
-DAOs and smart accounts need to vote on a transaction before it is executed. But committing to a PTB is surprisingly hard:
+Sui has strong atomic composition, but Move does not have a native way to verify that the currently executing PTB matches a prior approval.
 
-- **Object IDs are brittle** — `SplitCoin` creates new IDs each time
-- **`tx_context::digest()` changes every execution** — it hashes the full transaction including signatures, gas payment, and exact object references
-- **Hot potato wrappers don't scale** — every protocol integration needs custom wrapper code
+Today, applications that need separated authorization and execution end up building custom wrapper or interpreter logic around PTBs.
 
-### The Solution
+### The Goal
 
-Hash the **structure and argument provenance**, not the runtime identity. A structural digest captures:
-- Which commands call which targets, in what order
-- How results flow between commands (`Result(n)` / `NestedResult(n, m)`)
-- What values are passed (Pure bytes, shared object IDs, owned object IDs)
-- Type arguments for each call
-- Two modes: identity-preserving (coins by ObjectID) or normalized (coins by TypeTag + balance)
+Expose a minimal, VM-computed commitment to PTB structure that Move can compare on-chain.
+
+This proposal intentionally does **not** expose full PTB introspection and does **not** define a higher-level authorization model. It only exposes a read-only structural commitment.
 
 ## Specification
 
@@ -48,21 +42,12 @@ Each PTB argument type is normalized before hashing:
 | `GasCoin` | `0x00` | marker only | Gas coin ID is sender-dependent |
 | `Pure(bytes)` | `0x01` | BCS bytes | Exact parameter values |
 | `SharedObject` | `0x02` | ObjectID + mutability mode | Version-independent anchor plus lock semantics |
-| `ImmOrOwnedObject` | `0x03` | ObjectID | Version dropped — drifts between vote and execution |
+| `ImmOrOwnedObject` | `0x03` | ObjectID | Version dropped — drifts between approval and execution |
 | `Receiving` | `0x04` | ObjectID | Version dropped |
 | `Result(n)` | `0x05` | command_index | Provenance, not runtime identity |
 | `NestedResult(n,m)` | `0x06` | cmd_index + result_index | Provenance with tuple element |
-| `Coin (normalized)` | `0x08` | TypeTag BCS + balance LE | Fungible across split/merge |
-| `Coin Receiving (normalized)` | `0x09` | TypeTag BCS + balance LE | Fungible receiving coin |
-| `Wildcard Pure` | `0xFF` | marker only | Executor-discretion parameter |
 
-**Coin normalization (masked variant only):** `structural_digest_masked` resolves each object input from the loaded objects. If it's a `Coin<T>`, it hashes by TypeTag + balance (discriminator `0x08`/`0x09`) instead of ObjectID. This makes the digest stable across coin split/merge. The base `structural_digest` always hashes coins by ObjectID (`0x03`/`0x04`), preserving identity for use cases where specific coin objects matter.
-
-**Why two modes:** Coin identity is deliberately erased in the masked variant because governance approves economic intent ("transfer 100 SUI"), not specific UTXOs. However, some protocols key on coin ObjectID (deposit receipts, position tracking). The base variant preserves identity for these cases. Use `structural_digest` when coin identity matters, `structural_digest_masked(vector[])` for fungible coin handling.
-
-**Wildcard slots:** When `structural_digest_masked` is called with wildcard indices, Pure inputs at those positions are hashed as `0xFF` instead of their actual bytes. This lets a DAO approve "swap on this DEX at this amount" while leaving slippage tolerance to the executor. Wildcard indices are validated: values exceeding `u16::MAX` cause an abort.
-
-**Length framing:** All variable-length fields are length-prefixed (u32 LE) and all lists are count-prefixed to prevent concatenation collisions (e.g. module "a" + function "bc" vs module "ab" + function "c").
+All strings and byte blobs are length-prefixed with `u32 LE`. All lists are count-prefixed with `u32 LE`. This prevents concatenation collisions in the hash input.
 
 ### Hash Construction
 
@@ -77,25 +62,13 @@ digest = 0x01 || Blake2b256(
 )
 ```
 
-All strings and byte blobs are prefixed with their length as u32 LE. All lists are prefixed with their count as u32 LE. This prevents boundary ambiguity in the hash input.
-
 ### Move API
 
 ```move
 module sui::tx_context {
     /// Returns the structural digest of the current PTB.
-    /// Identity-preserving: coins hash by ObjectID.
     /// Output: [0x01 | blake2b256_hash] (33 bytes).
     public fun structural_digest(_self: &TxContext): vector<u8>;
-
-    /// Returns the structural digest with coin normalization and optional wildcards.
-    /// Coins hash by TypeTag + balance (fungible across split/merge).
-    /// Wildcarded Pure inputs hash as 0xFF marker instead of their value.
-    /// `wildcard_pure_indices` contains input indices to wildcard (pass empty for none).
-    public fun structural_digest_masked(
-        _self: &TxContext,
-        wildcard_pure_indices: vector<u64>,
-    ): vector<u8>;
 }
 ```
 
@@ -105,82 +78,45 @@ module sui::tx_context {
 module dao::executor {
     use sui::tx_context;
 
-    /// Verify exact PTB structure matches what was approved.
     public fun execute_approved(ctx: &TxContext, proposal: &Proposal) {
         let digest = tx_context::structural_digest(ctx);
         assert!(proposal.approved_digest() == digest, EDigestMismatch);
     }
-
-    /// Verify PTB structure with executor-discretion parameters.
-    /// Proposal stores: approved_digest + wildcard_indices.
-    public fun execute_with_wildcards(ctx: &TxContext, proposal: &Proposal) {
-        let digest = tx_context::structural_digest_masked(
-            ctx,
-            proposal.wildcard_indices(),
-        );
-        assert!(proposal.approved_digest() == digest, EDigestMismatch);
-    }
 }
-```
-
-### Client-Side Computation
-
-The SDK must implement the same normalization algorithm for off-chain digest preview:
-
-```typescript
-import { Transaction } from '@mysten/sui/transactions';
-
-const tx = new Transaction();
-// ... build PTB ...
-const digest = tx.computeStructuralDigest();
-// Submit digest to DAO for approval vote
 ```
 
 ## Implementation
 
 ### Files Changed
 
-1. **`crates/sui-types/src/transaction.rs`** — `structural_digest()` + `structural_digest_with_options()` algorithm, `StructuralDigestData` type
-2. **`crates/sui-types/src/base_types.rs`** — `structural_digest` + `structural_digest_data` fields on `TxContext`, `structural_digest_masked()` method
-3. **`sui-execution/latest/sui-adapter/src/execution_engine.rs`** — `build_coin_info_map()` resolves coins from input objects, stores `StructuralDigestData` on TxContext
-4. **`sui-execution/latest/sui-move-natives/src/transaction_context.rs`** — `structural_digest_masked()` accessor
-5. **`sui-execution/latest/sui-move-natives/src/tx_context.rs`** — Two native function impls
-6. **`sui-execution/latest/sui-move-natives/src/lib.rs`** — Registration + cost params for both natives
-7. **`crates/sui-framework/packages/sui-framework/sources/tx_context.move`** — Move declarations for both functions
-8. **`crates/sui-protocol-config/src/lib.rs`** — Feature gate + base/per-byte gas costs (protocol v113)
+1. **`crates/sui-types/src/transaction.rs`** — `structural_digest()` algorithm and `StructuralDigestData`
+2. **`crates/sui-types/src/base_types.rs`** — `TxContext` storage and lazy digest computation
+3. **`sui-execution/latest/sui-adapter/src/execution_engine.rs`** — stores `StructuralDigestData` on `TxContext`
+4. **`sui-execution/latest/sui-move-natives/src/transaction_context.rs`** — `structural_digest()` accessor
+5. **`sui-execution/latest/sui-move-natives/src/tx_context.rs`** — native implementation
+6. **`sui-execution/latest/sui-move-natives/src/lib.rs`** — registration and cost params
+7. **`crates/sui-framework/packages/sui-framework/sources/tx_context.move`** — Move declaration
+8. **`crates/sui-protocol-config/src/lib.rs`** — feature gate and base/per-byte gas costs (protocol v113)
 
 ### Design Decisions
 
 1. **Version prefix (0x01):** Future changes to the digest scheme bump this byte. Contracts storing digests can check `digest[0]` for compatibility.
-
-2. **Owned object version dropped:** Version increments between proposal vote and execution. Hashing by ObjectID only keeps the digest stable across this gap.
-
+2. **Owned object version dropped:** Version increments between approval and execution. Hashing by ObjectID only keeps the digest stable across this gap.
 3. **Shared object mutability preserved:** Shared object version is dropped for stability, but mutability mode is hashed alongside the ObjectID because immutable, mutable, and non-exclusive-write accesses imply different lock and execution semantics.
+4. **Lazy computation:** The PT is stored transiently on `TxContext`, and the digest itself is computed only if requested.
+5. **Size-sensitive gas:** The native charges a base cost plus a per-byte charge derived from PTB size so digest work scales with transaction size.
 
-4. **Two-mode coin handling:** `structural_digest` preserves coin identity (ObjectID). `structural_digest_masked` normalizes coins to TypeTag + balance. This is because coin normalization erases object identity, which is correct for governance ("transfer 100 SUI to Bob") but incorrect for protocols that key on coin ObjectID. The base variant is the safe default; the masked variant opts into fungibility.
-
-5. **Coin normalization at execution engine level:** The `ProgrammableTransaction` struct doesn't carry object types/balances. The execution engine resolves coins from the loaded input objects (and receiving objects from the backing store) and passes a `coin_info` map to the digest function.
-
-6. **Wildcard recomputation:** The full PT + coin_info is stored transiently on `TxContext` so `structural_digest_masked` can recompute with wildcard substitution at runtime, while the base digest itself is computed lazily on first use.
-
-7. **Length framing:** All variable-length fields are u32 LE length-prefixed before hashing to prevent concatenation collisions across field boundaries.
-
-8. **Wildcard validation:** Wildcard indices are validated at the native layer. Values exceeding u16::MAX cause an abort to prevent silent truncation (e.g. 65536 aliasing index 0).
-
-9. **Size-sensitive gas:** Both natives charge a base cost plus a per-byte charge derived from the normalized PTB size so recomputation work scales with transaction size.
-
-### Security Considerations
+## Security Considerations
 
 - **Read-only, VM-computed, unforgeable** — contracts cannot influence the computation
-- **Order-sensitive** — adding/removing/reordering commands changes the digest
+- **Order-sensitive** — adding, removing, or reordering commands changes the digest
 - **Flow-sensitive** — redirecting a `Result` to a different command changes the digest
-- **No censorship vector** — contracts cannot inspect individual commands
-- **Wildcards are caller-specified** — the contract decides which indices are wildcards, not the executor
+- **No PTB introspection** — contracts receive only an opaque commitment, not the full transaction structure
 
-### Backwards Compatibility
+## Backwards Compatibility
 
-Purely additive. Two new native functions gated behind a protocol version bump. The version prefix byte ensures old and new digests are distinguishable.
+Purely additive. One new native function gated behind a protocol version bump. The version prefix byte ensures future digest versions are distinguishable.
 
 ## Future Work
 
-- **Client SDK** — `computeStructuralDigest()` / `computeStructuralDigestMasked()` in `@mysten/sui/transactions`
+- Client SDK support for off-chain digest computation

--- a/docs/sip-70-ptb-structural-digest.md
+++ b/docs/sip-70-ptb-structural-digest.md
@@ -1,122 +1,258 @@
-# SIP-70: PTB Structural Digest
+# SIP-70: Current Command Range Hash
 
 ## Summary
 
-One native function on `sui::tx_context`:
+Add one native function on `sui::tx_context`:
 
-1. `structural_digest(&TxContext): vector<u8>` — returns a versioned, deterministic hash of the current PTB's structure.
+```move
+public fun current_command_range_hash(ctx: &TxContext, n: u64): vector<u8>
+```
 
-This enables DAOs, smart accounts, and governance contracts to approve "what will be executed" and verify at execution time that the PTB matches that approval.
+This returns a versioned hash of the current PTB command and the next `n - 1`
+commands.
+
+The point is simple: let a contract lock in the part of a PTB it cares about,
+while leaving the rest of the PTB open for wallets, solvers, sponsors, or other
+composition.
+
+This is more useful than a whole-PTB hash for smart accounts and governance,
+because the authorized intent can be fixed without forcing the whole transaction
+to be fixed.
 
 ## Motivation
 
-### The Problem
+Sui PTBs are already the right execution model for composition. The missing
+piece is that Move cannot currently ask:
 
-Sui has strong atomic composition, but Move does not have a native way to verify that the currently executing PTB matches a prior approval.
+> "Does the next part of this PTB match the thing I authorized?"
 
-Today, applications that need separated authorization and execution end up building custom wrapper or interpreter logic around PTBs.
+Without that primitive, apps that need separated authorization and execution
+build wrappers, interpreters, action specs, or custom typed execution systems.
+That works, but it moves PTB semantics into application code.
 
-### The Goal
+`current_command_range_hash(ctx, n)` keeps the primitive at the PTB layer:
 
-Expose a minimal, VM-computed commitment to PTB structure that Move can compare on-chain.
+- fixed intent commands can be committed to
+- solver/wallet commands before or after the range can stay open
+- Move receives only an opaque hash
+- no PTB introspection is exposed
+- no sub-PTB command is added
 
-This proposal intentionally does **not** expose full PTB introspection and does **not** define a higher-level authorization model. It only exposes a read-only structural commitment.
+This is idiomatic because it makes fixed intents and open solver execution
+composable without leaking PTB abstractions into Move.
 
 ## Specification
-
-### Output Format
-
-```
-[version_byte | blake2b256_hash]
-```
-
-- Version `0x01` = current scheme
-- Total output: 33 bytes (1 + 32)
-
-### Normalization Rules
-
-Each PTB argument type is normalized before hashing:
-
-| Argument Type | Discriminator | What Gets Hashed | Rationale |
-|---|---|---|---|
-| `GasCoin` | `0x00` | marker only | Gas coin ID is sender-dependent |
-| `Pure(bytes)` | `0x01` | BCS bytes | Exact parameter values |
-| `SharedObject` | `0x02` | ObjectID + mutability mode | Version-independent anchor plus lock semantics |
-| `ImmOrOwnedObject` | `0x03` | ObjectID | Version dropped — drifts between approval and execution |
-| `Receiving` | `0x04` | ObjectID | Version dropped |
-| `Result(n)` | `0x05` | command_index | Provenance, not runtime identity |
-| `NestedResult(n,m)` | `0x06` | cmd_index + result_index | Provenance with tuple element |
-
-All strings and byte blobs are length-prefixed with `u32 LE`. All lists are count-prefixed with `u32 LE`. This prevents concatenation collisions in the hash input.
-
-### Hash Construction
-
-```
-digest = 0x01 || Blake2b256(
-    for each command in order:
-        Blake2b256(
-            command_discriminator
-            || length_framed(command_specific_data)
-            || count(arguments) || normalized_arguments
-        )
-)
-```
 
 ### Move API
 
 ```move
 module sui::tx_context {
-    /// Returns the structural digest of the current PTB.
-    /// Output: [0x01 | blake2b256_hash] (33 bytes).
-    public fun structural_digest(_self: &TxContext): vector<u8>;
+    /// Returns a hash of the current command and the next `n - 1` commands.
+    /// Output: [version_byte | blake2b256_hash] (33 bytes).
+    public fun current_command_range_hash(_self: &TxContext, n: u64): vector<u8>;
 }
 ```
 
-### Governance Example
+`n` must be greater than zero.
+
+The current command is the PTB command that is currently executing this native.
+For example, if command 4 calls a smart account function that calls
+`current_command_range_hash(ctx, 3)`, the hash covers commands 4, 5, and 6.
+
+### Output Format
+
+```text
+[version_byte | blake2b256_hash]
+```
+
+- version `0x01` = current command range hash scheme
+- total output: 33 bytes
+
+If fewer than `n` commands remain in the PTB, the function returns a
+domain-separated unavailable hash, not an abort. The unavailable hash must not
+collide with any valid command range hash. Callers should treat it as a normal
+hash comparison failure.
+
+This lets contracts safely write:
 
 ```move
-module dao::executor {
-    use sui::tx_context;
-
-    public fun execute_approved(ctx: &TxContext, proposal: &Proposal) {
-        let digest = tx_context::structural_digest(ctx);
-        assert!(proposal.approved_digest() == digest, EDigestMismatch);
-    }
-}
+assert!(
+    tx_context::current_command_range_hash(ctx, n) == expected_hash,
+    EHashMismatch,
+);
 ```
 
-## Implementation
+without also needing to introspect PTB length.
 
-### Files Changed
+### What Is Hashed
 
-1. **`crates/sui-types/src/transaction.rs`** — `structural_digest()` algorithm and `StructuralDigestData`
-2. **`crates/sui-types/src/base_types.rs`** — `TxContext` storage and lazy digest computation
-3. **`sui-execution/latest/sui-adapter/src/execution_engine.rs`** — stores `StructuralDigestData` on `TxContext`
-4. **`sui-execution/latest/sui-move-natives/src/transaction_context.rs`** — `structural_digest()` accessor
-5. **`sui-execution/latest/sui-move-natives/src/tx_context.rs`** — native implementation
-6. **`sui-execution/latest/sui-move-natives/src/lib.rs`** — registration and cost params
-7. **`crates/sui-framework/packages/sui-framework/sources/tx_context.move`** — Move declaration
-8. **`crates/sui-protocol-config/src/lib.rs`** — feature gate and base/per-byte gas costs (protocol v113)
+The hash commits to the selected contiguous command range only.
 
-### Design Decisions
+For every command in the range, the encoder commits to:
 
-1. **Version prefix (0x01):** Future changes to the digest scheme bump this byte. Contracts storing digests can check `digest[0]` for compatibility.
-2. **Owned object version dropped:** Version increments between approval and execution. Hashing by ObjectID only keeps the digest stable across this gap.
-3. **Shared object mutability preserved:** Shared object version is dropped for stability, but mutability mode is hashed alongside the ObjectID because immutable, mutable, and non-exclusive-write accesses imply different lock and execution semantics.
-4. **Lazy computation:** The PT is stored transiently on `TxContext`, and the digest itself is computed only if requested.
-5. **Size-sensitive gas:** The native charges a base cost plus a per-byte charge derived from PTB size so digest work scales with transaction size.
+- command kind
+- package, module, function, and type arguments for Move calls
+- command-specific data for non-Move-call commands
+- argument count and argument structure
+- result flow between commands inside the range
+- imported values from outside the range, as imports
+
+All strings, byte blobs, and lists are length-framed.
+
+### What Is Not Hashed
+
+The hash does not commit to:
+
+- sender/caller address
+- sponsor address
+- signatures
+- transaction digest
+- gas budget
+- gas price
+- gas coin object ID
+- gas coin version
+- commands before the selected range
+- commands after the selected range
+- absolute command position
+
+The VM may use the current command index internally to compute the range, but
+the API exposes only the hash. It does not expose position, depth, frame kind, or
+whether the caller is inside any higher-level application abstraction.
+
+### Argument Normalization
+
+Each PTB argument is normalized before hashing:
+
+| Argument Type | What Gets Hashed | Rationale |
+| --- | --- | --- |
+| `GasCoin` | marker only | gas coin identity is sender-dependent and should not be part of intent |
+| `Pure(bytes)` | exact bytes | fixed parameter value |
+| `SharedObject` | ObjectID + mutability mode | stable object anchor plus lock semantics |
+| `ImmOrOwnedObject` | ObjectID | version can drift between authorization and execution |
+| `Receiving` | ObjectID | version can drift |
+| result inside range | relative command/result index | commits to flow inside the locked range |
+| result before range | import slot | allows solver/wallet setup before the locked range |
+
+Direct PTB inputs are fixed. If a command in the range uses a direct object or
+pure input, that value is part of the hash.
+
+If a command in the range uses a value produced by a command before the range,
+that value is encoded as an import. The hash commits that an imported value is
+used, and where it is used, but not to the full command sequence that produced
+it.
+
+Import slots are assigned by first use inside the range. Reusing the same
+external value reuses the same import slot. Different external values get
+different import slots.
+
+This is the key composability property: a solver can do any number of setup
+commands first, then route values into the fixed range, without changing the
+range hash.
+
+### Hash Construction
+
+Conceptually:
+
+```text
+range_hash = 0x01 || Blake2b256(
+    "SUI_CURRENT_COMMAND_RANGE_HASH"
+    || n
+    || for each selected command in order:
+        Blake2b256(
+            command_kind
+            || length_framed(command_specific_data)
+            || normalized_arguments
+        )
+)
+```
+
+The concrete encoder should be semantic and versioned, not raw BCS of the PTB
+Rust type. Future PTB shape changes can then be handled by the encoder instead
+of changing the Move API.
+
+### Example
+
+The wallet or solver can build:
+
+```text
+0. solver setup command
+1. solver setup command
+2. smart_account::authorize(expected_hash, 3, ctx)
+3. fixed intent command
+4. fixed intent command
+5. solver settlement command
+```
+
+Inside command 2, the smart account checks:
+
+```move
+let actual = tx_context::current_command_range_hash(ctx, 3);
+assert!(actual == expected_hash, EHashMismatch);
+```
+
+The hash covers commands 2, 3, and 4.
+
+Commands 0, 1, and 5 are not hashed. The solver can change them without
+changing the authorized intent, as long as the locked range still receives the
+right imported values and has the same command structure.
+
+## Why Not Full PTB Hash
+
+A full PTB hash is too rigid for the main use case.
+
+Smart accounts and governance usually want to authorize the important part of a
+transaction, not the exact gas setup, solver route, sponsorship details, or
+settlement tail.
+
+Whole-PTB commitment makes every solver/wallet implementation detail part of the
+authorization. That is hard to use and hard to support.
+
+Range hash keeps the protocol primitive smaller:
+
+- no new PTB command
+- no nested PTB execution
+- no full PTB introspection
+- no dependency on commands outside the authorized range
+- no sender/gas coupling
+
+## Implementation Notes
+
+This can be implemented with the same broad machinery as a structural digest,
+but scoped to the current command range:
+
+1. Store or expose the current `ProgrammableTransaction` to `TxContext` during
+   execution.
+2. Track the currently executing command index internally in the PTB executor.
+3. When the native is called, hash `[current_index, current_index + n)`.
+4. Encode in-range result references relatively.
+5. Encode references to earlier results as imports.
+6. Return the unavailable hash if the requested range runs past the end.
+7. Charge base gas plus a per-byte/per-command cost for the hashed range.
+
+The current command index is execution metadata. It is not returned to Move and
+is not part of the public API.
 
 ## Security Considerations
 
-- **Read-only, VM-computed, unforgeable** — contracts cannot influence the computation
-- **Order-sensitive** — adding, removing, or reordering commands changes the digest
-- **Flow-sensitive** — redirecting a `Result` to a different command changes the digest
-- **No PTB introspection** — contracts receive only an opaque commitment, not the full transaction structure
+- VM-computed and read-only
+- order-sensitive within the selected range
+- flow-sensitive within the selected range
+- no sender/caller address or gas coin identity in the hash
+- no PTB introspection
+- no way to ask for absolute PTB position
+- commands outside the range remain intentionally open
+
+Contracts should compare the returned hash against an expected hash that was
+computed off-chain using the same versioned encoder.
 
 ## Backwards Compatibility
 
-Purely additive. One new native function gated behind a protocol version bump. The version prefix byte ensures future digest versions are distinguishable.
+Purely additive. This adds one new native function behind a protocol version.
+
+The version byte lets future hash schemes coexist with existing stored hashes.
 
 ## Future Work
 
-- Client SDK support for off-chain digest computation
+- SDK support for off-chain range hash computation
+- test vectors for common smart-account and solver patterns
+- optional helper APIs in wallets for building PTBs around a locked range

--- a/docs/sip-70-ptb-structural-digest.md
+++ b/docs/sip-70-ptb-structural-digest.md
@@ -47,7 +47,7 @@ Each PTB argument type is normalized before hashing:
 |---|---|---|---|
 | `GasCoin` | `0x00` | marker only | Gas coin ID is sender-dependent |
 | `Pure(bytes)` | `0x01` | BCS bytes | Exact parameter values |
-| `SharedObject` | `0x02` | ObjectID | Version-independent anchor |
+| `SharedObject` | `0x02` | ObjectID + mutability mode | Version-independent anchor plus lock semantics |
 | `ImmOrOwnedObject` | `0x03` | ObjectID | Version dropped — drifts between vote and execution |
 | `Receiving` | `0x04` | ObjectID | Version dropped |
 | `Result(n)` | `0x05` | command_index | Provenance, not runtime identity |
@@ -147,23 +147,27 @@ const digest = tx.computeStructuralDigest();
 5. **`sui-execution/latest/sui-move-natives/src/tx_context.rs`** — Two native function impls
 6. **`sui-execution/latest/sui-move-natives/src/lib.rs`** — Registration + cost params for both natives
 7. **`crates/sui-framework/packages/sui-framework/sources/tx_context.move`** — Move declarations for both functions
-8. **`crates/sui-protocol-config/src/lib.rs`** — Feature gate + gas costs (protocol v113)
+8. **`crates/sui-protocol-config/src/lib.rs`** — Feature gate + base/per-byte gas costs (protocol v113)
 
 ### Design Decisions
 
 1. **Version prefix (0x01):** Future changes to the digest scheme bump this byte. Contracts storing digests can check `digest[0]` for compatibility.
 
-2. **Owned object version dropped:** Version increments between proposal vote and execution. Hashing by ObjectID only (same as shared objects) makes the digest stable across this gap.
+2. **Owned object version dropped:** Version increments between proposal vote and execution. Hashing by ObjectID only keeps the digest stable across this gap.
 
-3. **Two-mode coin handling:** `structural_digest` preserves coin identity (ObjectID). `structural_digest_masked` normalizes coins to TypeTag + balance. This is because coin normalization erases object identity, which is correct for governance ("transfer 100 SUI to Bob") but incorrect for protocols that key on coin ObjectID. The base variant is the safe default; the masked variant opts into fungibility.
+3. **Shared object mutability preserved:** Shared object version is dropped for stability, but mutability mode is hashed alongside the ObjectID because immutable, mutable, and non-exclusive-write accesses imply different lock and execution semantics.
 
-4. **Coin normalization at execution engine level:** The `ProgrammableTransaction` struct doesn't carry object types/balances. The execution engine resolves coins from the loaded input objects (and receiving objects from the backing store) and passes a `coin_info` map to the digest function.
+4. **Two-mode coin handling:** `structural_digest` preserves coin identity (ObjectID). `structural_digest_masked` normalizes coins to TypeTag + balance. This is because coin normalization erases object identity, which is correct for governance ("transfer 100 SUI to Bob") but incorrect for protocols that key on coin ObjectID. The base variant is the safe default; the masked variant opts into fungibility.
 
-5. **Wildcard recomputation:** The full PT + coin_info is stored (transient, `#[serde(skip)]`) on TxContext so `structural_digest_masked` can recompute with wildcard substitution at runtime.
+5. **Coin normalization at execution engine level:** The `ProgrammableTransaction` struct doesn't carry object types/balances. The execution engine resolves coins from the loaded input objects (and receiving objects from the backing store) and passes a `coin_info` map to the digest function.
 
-6. **Length framing:** All variable-length fields are u32 LE length-prefixed before hashing to prevent concatenation collisions across field boundaries.
+6. **Wildcard recomputation:** The full PT + coin_info is stored transiently on `TxContext` so `structural_digest_masked` can recompute with wildcard substitution at runtime, while the base digest itself is computed lazily on first use.
 
-7. **Wildcard validation:** Wildcard indices are validated at the native layer. Values exceeding u16::MAX cause an abort to prevent silent truncation (e.g. 65536 aliasing index 0).
+7. **Length framing:** All variable-length fields are u32 LE length-prefixed before hashing to prevent concatenation collisions across field boundaries.
+
+8. **Wildcard validation:** Wildcard indices are validated at the native layer. Values exceeding u16::MAX cause an abort to prevent silent truncation (e.g. 65536 aliasing index 0).
+
+9. **Size-sensitive gas:** Both natives charge a base cost plus a per-byte charge derived from the normalized PTB size so recomputation work scales with transaction size.
 
 ### Security Considerations
 

--- a/docs/sip-70-ptb-structural-digest.md
+++ b/docs/sip-70-ptb-structural-digest.md
@@ -4,8 +4,8 @@
 
 Two native functions on `sui::tx_context`:
 
-1. `structural_digest(&TxContext): vector<u8>` — returns a versioned, deterministic hash of the current PTB's normalized structure with coin normalization.
-2. `structural_digest_masked(&TxContext, wildcard_pure_indices: vector<u64>): vector<u8>` — same, but specified Pure inputs are treated as wildcards.
+1. `structural_digest(&TxContext): vector<u8>` — returns a versioned, deterministic hash of the current PTB's structure. Identity-preserving: coins hash by ObjectID.
+2. `structural_digest_masked(&TxContext, wildcard_pure_indices: vector<u64>): vector<u8>` — same structure hash, but with coin normalization (TypeTag + balance instead of ObjectID) and specified Pure inputs treated as wildcards.
 
 This enables DAOs, smart accounts, and governance contracts to vote on "what will be executed" and verify at execution time that the PTB matches the approved template.
 
@@ -26,9 +26,7 @@ Hash the **structure and argument provenance**, not the runtime identity. A stru
 - How results flow between commands (`Result(n)` / `NestedResult(n, m)`)
 - What values are passed (Pure bytes, shared object IDs, owned object IDs)
 - Type arguments for each call
-- Coin inputs normalized by TypeName + Balance (not ObjectID)
-
-Two PTBs that differ only in which specific coin objects are used (but have the same type and balance) produce the same digest.
+- Two modes: identity-preserving (coins by ObjectID) or normalized (coins by TypeTag + balance)
 
 ## Specification
 
@@ -58,29 +56,42 @@ Each PTB argument type is normalized before hashing:
 | `Coin Receiving (normalized)` | `0x09` | TypeTag BCS + balance LE | Fungible receiving coin |
 | `Wildcard Pure` | `0xFF` | marker only | Executor-discretion parameter |
 
-**Coin normalization:** The execution engine resolves each object input from the loaded objects. If it's a `Coin<T>`, it hashes by TypeTag + balance instead of ObjectID. This makes the digest stable across coin split/merge — any coin of the right type and amount satisfies the template.
+**Coin normalization (masked variant only):** `structural_digest_masked` resolves each object input from the loaded objects. If it's a `Coin<T>`, it hashes by TypeTag + balance (discriminator `0x08`/`0x09`) instead of ObjectID. This makes the digest stable across coin split/merge. The base `structural_digest` always hashes coins by ObjectID (`0x03`/`0x04`), preserving identity for use cases where specific coin objects matter.
 
-**Wildcard slots:** When `structural_digest_masked` is called with wildcard indices, Pure inputs at those positions are hashed as `0xFF` instead of their actual bytes. This lets a DAO approve "swap on this DEX at this amount" while leaving slippage tolerance to the executor.
+**Why two modes:** Coin identity is deliberately erased in the masked variant because governance approves economic intent ("transfer 100 SUI"), not specific UTXOs. However, some protocols key on coin ObjectID (deposit receipts, position tracking). The base variant preserves identity for these cases. Use `structural_digest` when coin identity matters, `structural_digest_masked(vector[])` for fungible coin handling.
+
+**Wildcard slots:** When `structural_digest_masked` is called with wildcard indices, Pure inputs at those positions are hashed as `0xFF` instead of their actual bytes. This lets a DAO approve "swap on this DEX at this amount" while leaving slippage tolerance to the executor. Wildcard indices are validated: values exceeding `u16::MAX` cause an abort.
+
+**Length framing:** All variable-length fields are length-prefixed (u32 LE) and all lists are count-prefixed to prevent concatenation collisions (e.g. module "a" + function "bc" vs module "ab" + function "c").
 
 ### Hash Construction
 
 ```
 digest = 0x01 || Blake2b256(
     for each command in order:
-        Blake2b256(command_discriminator || command_specific_data || normalized_arguments)
+        Blake2b256(
+            command_discriminator
+            || length_framed(command_specific_data)
+            || count(arguments) || normalized_arguments
+        )
 )
 ```
+
+All strings and byte blobs are prefixed with their length as u32 LE. All lists are prefixed with their count as u32 LE. This prevents boundary ambiguity in the hash input.
 
 ### Move API
 
 ```move
 module sui::tx_context {
-    /// Returns the normalized structural digest of the current PTB.
+    /// Returns the structural digest of the current PTB.
+    /// Identity-preserving: coins hash by ObjectID.
     /// Output: [0x01 | blake2b256_hash] (33 bytes).
     public fun structural_digest(_self: &TxContext): vector<u8>;
 
-    /// Returns the structural digest with specified Pure inputs wildcarded.
-    /// Wildcarded inputs hash as 0xFF marker instead of their value.
+    /// Returns the structural digest with coin normalization and optional wildcards.
+    /// Coins hash by TypeTag + balance (fungible across split/merge).
+    /// Wildcarded Pure inputs hash as 0xFF marker instead of their value.
+    /// `wildcard_pure_indices` contains input indices to wildcard (pass empty for none).
     public fun structural_digest_masked(
         _self: &TxContext,
         wildcard_pure_indices: vector<u64>,
@@ -144,9 +155,15 @@ const digest = tx.computeStructuralDigest();
 
 2. **Owned object version dropped:** Version increments between proposal vote and execution. Hashing by ObjectID only (same as shared objects) makes the digest stable across this gap.
 
-3. **Coin normalization at execution engine level:** The `ProgrammableTransaction` struct doesn't carry object types/balances. The execution engine resolves coins from the loaded input objects and passes a `coin_info` map to the digest function.
+3. **Two-mode coin handling:** `structural_digest` preserves coin identity (ObjectID). `structural_digest_masked` normalizes coins to TypeTag + balance. This is because coin normalization erases object identity, which is correct for governance ("transfer 100 SUI to Bob") but incorrect for protocols that key on coin ObjectID. The base variant is the safe default; the masked variant opts into fungibility.
 
-4. **Wildcard recomputation:** The full PT + coin_info is stored (transient, `#[serde(skip)]`) on TxContext so `structural_digest_masked` can recompute with wildcard substitution at runtime.
+4. **Coin normalization at execution engine level:** The `ProgrammableTransaction` struct doesn't carry object types/balances. The execution engine resolves coins from the loaded input objects (and receiving objects from the backing store) and passes a `coin_info` map to the digest function.
+
+5. **Wildcard recomputation:** The full PT + coin_info is stored (transient, `#[serde(skip)]`) on TxContext so `structural_digest_masked` can recompute with wildcard substitution at runtime.
+
+6. **Length framing:** All variable-length fields are u32 LE length-prefixed before hashing to prevent concatenation collisions across field boundaries.
+
+7. **Wildcard validation:** Wildcard indices are validated at the native layer. Values exceeding u16::MAX cause an abort to prevent silent truncation (e.g. 65536 aliasing index 0).
 
 ### Security Considerations
 

--- a/docs/sip-70-ptb-structural-digest.md
+++ b/docs/sip-70-ptb-structural-digest.md
@@ -1,8 +1,13 @@
-# SIP-70: PTB Structural Digest
+# SIP-70: PTB Structural Digest (v2)
 
 ## Summary
 
-Add a single native function `sui::tx_context::structural_digest(&TxContext): vector<u8>` that returns a deterministic, normalized SHA2-256 hash of the current PTB's structure. This enables DAOs, smart accounts, and governance contracts to vote on "what will be executed" and verify at execution time that the PTB matches the approved template.
+Two native functions on `sui::tx_context`:
+
+1. `structural_digest(&TxContext): vector<u8>` — returns a versioned, deterministic hash of the current PTB's normalized structure with coin normalization.
+2. `structural_digest_masked(&TxContext, wildcard_pure_indices: vector<u64>): vector<u8>` — same, but specified Pure inputs are treated as wildcards.
+
+This enables DAOs, smart accounts, and governance contracts to vote on "what will be executed" and verify at execution time that the PTB matches the approved template.
 
 ## Motivation
 
@@ -19,69 +24,51 @@ DAOs and smart accounts need to vote on a transaction before it is executed. But
 Hash the **structure and argument provenance**, not the runtime identity. A structural digest captures:
 - Which commands call which targets, in what order
 - How results flow between commands (`Result(n)` / `NestedResult(n, m)`)
-- What values are passed (Pure bytes, shared object IDs, owned object refs)
+- What values are passed (Pure bytes, shared object IDs, owned object IDs)
 - Type arguments for each call
+- Coin inputs normalized by TypeName + Balance (not ObjectID)
 
-Two PTBs that differ only in which specific coin objects are used (but have the same type, balance, and flow) can produce the same digest.
+Two PTBs that differ only in which specific coin objects are used (but have the same type and balance) produce the same digest.
 
 ## Specification
+
+### Output Format
+
+```
+[version_byte | blake2b256_hash]
+```
+
+- Version `0x01` = current scheme
+- Total output: 33 bytes (1 + 32)
 
 ### Normalization Rules
 
 Each PTB argument type is normalized before hashing:
 
-| Argument Type | What Gets Hashed | Rationale |
-|---|---|---|
-| `GasCoin` | `0x00` marker byte | Gas coin ID is sender-dependent |
-| `Input(n)` → `CallArg::Pure(bytes)` | `0x01` + BCS bytes | Exact parameter values |
-| `Input(n)` → `ObjectArg::SharedObject` | `0x02` + ObjectID | Static anchors (pools, governance objects) |
-| `Input(n)` → `ObjectArg::ImmOrOwnedObject` | `0x03` + ObjectID + version | Identity-stable for non-fungible objects |
-| `Input(n)` → `ObjectArg::Receiving` | `0x04` + ObjectID + version | Receiving objects |
-| `Result(n)` | `0x05` + command_index(u16) | Provenance — which command produced this |
-| `NestedResult(n, m)` | `0x06` + command_index(u16) + result_index(u16) | Provenance with tuple element |
+| Argument Type | Discriminator | What Gets Hashed | Rationale |
+|---|---|---|---|
+| `GasCoin` | `0x00` | marker only | Gas coin ID is sender-dependent |
+| `Pure(bytes)` | `0x01` | BCS bytes | Exact parameter values |
+| `SharedObject` | `0x02` | ObjectID | Version-independent anchor |
+| `ImmOrOwnedObject` | `0x03` | ObjectID | Version dropped — drifts between vote and execution |
+| `Receiving` | `0x04` | ObjectID | Version dropped |
+| `Result(n)` | `0x05` | command_index | Provenance, not runtime identity |
+| `NestedResult(n,m)` | `0x06` | cmd_index + result_index | Provenance with tuple element |
+| `Coin (normalized)` | `0x08` | TypeTag BCS + balance LE | Fungible across split/merge |
+| `Coin Receiving (normalized)` | `0x09` | TypeTag BCS + balance LE | Fungible receiving coin |
+| `Wildcard Pure` | `0xFF` | marker only | Executor-discretion parameter |
+
+**Coin normalization:** The execution engine resolves each object input from the loaded objects. If it's a `Coin<T>`, it hashes by TypeTag + balance instead of ObjectID. This makes the digest stable across coin split/merge — any coin of the right type and amount satisfies the template.
+
+**Wildcard slots:** When `structural_digest_masked` is called with wildcard indices, Pure inputs at those positions are hashed as `0xFF` instead of their actual bytes. This lets a DAO approve "swap on this DEX at this amount" while leaving slippage tolerance to the executor.
 
 ### Hash Construction
 
 ```
-structural_digest = SHA2-256(
+digest = 0x01 || Blake2b256(
     for each command in order:
-        SHA2-256(command_discriminator || command_specific_data || normalized_arguments)
+        Blake2b256(command_discriminator || command_specific_data || normalized_arguments)
 )
-```
-
-For `Command::MoveCall`:
-```
-SHA2-256(0x00 || package_id || module_name || function_name || type_args_bcs || normalized_args)
-```
-
-For `Command::TransferObjects`:
-```
-SHA2-256(0x01 || normalized_objects || normalized_recipient)
-```
-
-For `Command::SplitCoins`:
-```
-SHA2-256(0x02 || normalized_coin || normalized_amounts)
-```
-
-For `Command::MergeCoins`:
-```
-SHA2-256(0x03 || normalized_target || normalized_sources)
-```
-
-For `Command::Publish`:
-```
-SHA2-256(0x04 || module_bytes || dependency_ids)
-```
-
-For `Command::MakeMoveVec`:
-```
-SHA2-256(0x05 || type_tag_bcs || normalized_elements)
-```
-
-For `Command::Upgrade`:
-```
-SHA2-256(0x06 || module_bytes || dependency_ids || package_id || normalized_ticket)
 ```
 
 ### Move API
@@ -89,12 +76,15 @@ SHA2-256(0x06 || module_bytes || dependency_ids || package_id || normalized_tick
 ```move
 module sui::tx_context {
     /// Returns the normalized structural digest of the current PTB.
-    /// Deterministic: same logical PTB structure -> same digest,
-    /// even if coin object IDs differ due to splits/merges.
-    public fun structural_digest(_self: &TxContext): vector<u8> {
-        native_structural_digest()
-    }
-    native fun native_structural_digest(): vector<u8>;
+    /// Output: [0x01 | blake2b256_hash] (33 bytes).
+    public fun structural_digest(_self: &TxContext): vector<u8>;
+
+    /// Returns the structural digest with specified Pure inputs wildcarded.
+    /// Wildcarded inputs hash as 0xFF marker instead of their value.
+    public fun structural_digest_masked(
+        _self: &TxContext,
+        wildcard_pure_indices: vector<u64>,
+    ): vector<u8>;
 }
 ```
 
@@ -104,8 +94,19 @@ module sui::tx_context {
 module dao::executor {
     use sui::tx_context;
 
+    /// Verify exact PTB structure matches what was approved.
     public fun execute_approved(ctx: &TxContext, proposal: &Proposal) {
         let digest = tx_context::structural_digest(ctx);
+        assert!(proposal.approved_digest() == digest, EDigestMismatch);
+    }
+
+    /// Verify PTB structure with executor-discretion parameters.
+    /// Proposal stores: approved_digest + wildcard_indices.
+    public fun execute_with_wildcards(ctx: &TxContext, proposal: &Proposal) {
+        let digest = tx_context::structural_digest_masked(
+            ctx,
+            proposal.wildcard_indices(),
+        );
         assert!(proposal.approved_digest() == digest, EDigestMismatch);
     }
 }
@@ -128,14 +129,24 @@ const digest = tx.computeStructuralDigest();
 
 ### Files Changed
 
-1. **`crates/sui-types/src/transaction.rs`** — `ProgrammableTransaction::structural_digest()` method
-2. **`crates/sui-types/src/base_types.rs`** — `structural_digest` field on `TxContext`
-3. **`sui-execution/latest/sui-adapter/src/execution_engine.rs`** — Compute digest before PTB execution
-4. **`sui-execution/latest/sui-move-natives/src/transaction_context.rs`** — Accessor
-5. **`sui-execution/latest/sui-move-natives/src/tx_context.rs`** — Native function impl
-6. **`sui-execution/latest/sui-move-natives/src/lib.rs`** — Registration + cost params
-7. **`crates/sui-framework/packages/sui-framework/sources/tx_context.move`** — Move declaration
-8. **`crates/sui-protocol-config/src/lib.rs`** — Feature gate + gas cost
+1. **`crates/sui-types/src/transaction.rs`** — `structural_digest()` + `structural_digest_with_options()` algorithm, `StructuralDigestData` type
+2. **`crates/sui-types/src/base_types.rs`** — `structural_digest` + `structural_digest_data` fields on `TxContext`, `structural_digest_masked()` method
+3. **`sui-execution/latest/sui-adapter/src/execution_engine.rs`** — `build_coin_info_map()` resolves coins from input objects, stores `StructuralDigestData` on TxContext
+4. **`sui-execution/latest/sui-move-natives/src/transaction_context.rs`** — `structural_digest_masked()` accessor
+5. **`sui-execution/latest/sui-move-natives/src/tx_context.rs`** — Two native function impls
+6. **`sui-execution/latest/sui-move-natives/src/lib.rs`** — Registration + cost params for both natives
+7. **`crates/sui-framework/packages/sui-framework/sources/tx_context.move`** — Move declarations for both functions
+8. **`crates/sui-protocol-config/src/lib.rs`** — Feature gate + gas costs (protocol v113)
+
+### Design Decisions
+
+1. **Version prefix (0x01):** Future changes to the digest scheme bump this byte. Contracts storing digests can check `digest[0]` for compatibility.
+
+2. **Owned object version dropped:** Version increments between proposal vote and execution. Hashing by ObjectID only (same as shared objects) makes the digest stable across this gap.
+
+3. **Coin normalization at execution engine level:** The `ProgrammableTransaction` struct doesn't carry object types/balances. The execution engine resolves coins from the loaded input objects and passes a `coin_info` map to the digest function.
+
+4. **Wildcard recomputation:** The full PT + coin_info is stored (transient, `#[serde(skip)]`) on TxContext so `structural_digest_masked` can recompute with wildcard substitution at runtime.
 
 ### Security Considerations
 
@@ -143,13 +154,12 @@ const digest = tx.computeStructuralDigest();
 - **Order-sensitive** — adding/removing/reordering commands changes the digest
 - **Flow-sensitive** — redirecting a `Result` to a different command changes the digest
 - **No censorship vector** — contracts cannot inspect individual commands
+- **Wildcards are caller-specified** — the contract decides which indices are wildcards, not the executor
 
 ### Backwards Compatibility
 
-Purely additive. One new native function gated behind a protocol version bump.
+Purely additive. Two new native functions gated behind a protocol version bump. The version prefix byte ensures old and new digests are distinguishable.
 
 ## Future Work
 
-- **Coin normalization** — Hash coins by `TypeName + Balance` instead of ObjectID, making the digest stable across coin split/merge. Requires input object resolution during digest computation.
-- **Client SDK** — `computeStructuralDigest()` in `@mysten/sui/transactions`
-- **Wildcard slots** — Allow certain argument positions to be "any value" in the digest template
+- **Client SDK** — `computeStructuralDigest()` / `computeStructuralDigestMasked()` in `@mysten/sui/transactions`

--- a/sui-execution/latest/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/latest/sui-adapter/src/execution_engine.rs
@@ -699,6 +699,10 @@ mod checked {
                 Ok((Mode::empty_results(), vec![]))
             }
             TransactionKind::ProgrammableTransaction(pt) => {
+                // SIP-70: Compute and store the structural digest before execution
+                let structural_digest = pt.structural_digest();
+                tx_ctx.borrow_mut().set_structural_digest(structural_digest);
+
                 programmable_transactions::execution::execute::<Mode>(
                     protocol_config,
                     metrics,

--- a/sui-execution/latest/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/latest/sui-adapter/src/execution_engine.rs
@@ -588,38 +588,6 @@ mod checked {
         Ok(())
     }
 
-    /// SIP-70 v2: Build a map from PTB input index to (TypeTag, balance) for coin inputs.
-    /// This enables coin normalization — hashing coins by TypeName + Balance instead of ObjectID.
-    /// Looks up owned coins from input_objects and receiving coins from the backing store.
-    fn build_coin_info_map(
-        pt: &ProgrammableTransaction,
-        input_objects: &BTreeMap<sui_types::base_types::ObjectID, Object>,
-        store: &dyn sui_types::storage::BackingStore,
-    ) -> BTreeMap<usize, (move_core_types::language_storage::TypeTag, u64)> {
-        let mut coin_info = BTreeMap::new();
-        for (idx, input) in pt.inputs.iter().enumerate() {
-            let obj = match input {
-                CallArg::Object(ObjectArg::ImmOrOwnedObject((id, _, _))) => {
-                    input_objects.get(id).cloned()
-                }
-                CallArg::Object(ObjectArg::Receiving((id, version, _))) => {
-                    // Receiving objects aren't in input_objects — look up from store
-                    store.as_object_store().get_object_by_key(id, *version)
-                }
-                _ => None,
-            };
-            if let Some(obj) = obj {
-                if obj.is_coin() {
-                    if let Some(type_tag) = obj.coin_type_maybe() {
-                        let balance = obj.get_coin_value_unsafe();
-                        coin_info.insert(idx, (type_tag, balance));
-                    }
-                }
-            }
-        }
-        coin_info
-    }
-
     #[instrument(level = "debug", skip_all)]
     fn execution_loop<Mode: ExecutionMode>(
         store: &dyn BackingStore,
@@ -733,18 +701,11 @@ mod checked {
             TransactionKind::ProgrammableTransaction(pt) => {
                 let pt = Arc::new(pt);
 
-                // SIP-70 v2: Build coin_info for the masked variant.
-                // Coin normalization (TypeTag + balance) only applies to structural_digest_masked.
-                let coin_info = build_coin_info_map(pt.as_ref(), temporary_store.objects(), store);
-
                 {
                     let mut ctx = tx_ctx.borrow_mut();
-                    // Store PT + coin_info for lazy structural digest computation.
+                    // Store the PT for lazy structural digest computation.
                     ctx.set_structural_digest_data(
-                        sui_types::transaction::StructuralDigestData::new(
-                            Arc::clone(&pt),
-                            coin_info,
-                        ),
+                        sui_types::transaction::StructuralDigestData::new(Arc::clone(&pt)),
                     );
                 }
 

--- a/sui-execution/latest/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/latest/sui-adapter/src/execution_engine.rs
@@ -588,6 +588,33 @@ mod checked {
         Ok(())
     }
 
+    /// SIP-70 v2: Build a map from PTB input index to (TypeTag, balance) for coin inputs.
+    /// This enables coin normalization — hashing coins by TypeName + Balance instead of ObjectID.
+    fn build_coin_info_map(
+        pt: &ProgrammableTransaction,
+        objects: &BTreeMap<sui_types::base_types::ObjectID, Object>,
+    ) -> BTreeMap<usize, (move_core_types::language_storage::TypeTag, u64)> {
+        let mut coin_info = BTreeMap::new();
+        for (idx, input) in pt.inputs.iter().enumerate() {
+            let obj_id = match input {
+                CallArg::Object(ObjectArg::ImmOrOwnedObject((id, _, _))) => Some(id),
+                CallArg::Object(ObjectArg::Receiving((id, _, _))) => Some(id),
+                _ => None,
+            };
+            if let Some(id) = obj_id {
+                if let Some(obj) = objects.get(id) {
+                    if obj.is_coin() {
+                        if let Some(type_tag) = obj.coin_type_maybe() {
+                            let balance = obj.get_coin_value_unsafe();
+                            coin_info.insert(idx, (type_tag, balance));
+                        }
+                    }
+                }
+            }
+        }
+        coin_info
+    }
+
     #[instrument(level = "debug", skip_all)]
     fn execution_loop<Mode: ExecutionMode>(
         store: &dyn BackingStore,
@@ -699,9 +726,26 @@ mod checked {
                 Ok((Mode::empty_results(), vec![]))
             }
             TransactionKind::ProgrammableTransaction(pt) => {
-                // SIP-70: Compute and store the structural digest before execution
-                let structural_digest = pt.structural_digest();
-                tx_ctx.borrow_mut().set_structural_digest(structural_digest);
+                // SIP-70 v2: Build coin_info map from input objects for coin normalization
+                let coin_info = build_coin_info_map(&pt, temporary_store.objects());
+
+                // Compute structural digest with coin normalization
+                let structural_digest = pt.structural_digest_with_options(
+                    Some(&coin_info),
+                    &std::collections::BTreeSet::new(),
+                );
+
+                {
+                    let mut ctx = tx_ctx.borrow_mut();
+                    ctx.set_structural_digest(structural_digest);
+                    // Store PT + coin_info for masked digest recomputation
+                    ctx.set_structural_digest_data(
+                        sui_types::transaction::StructuralDigestData {
+                            pt: pt.clone(),
+                            coin_info,
+                        },
+                    );
+                }
 
                 programmable_transactions::execution::execute::<Mode>(
                     protocol_config,

--- a/sui-execution/latest/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/latest/sui-adapter/src/execution_engine.rs
@@ -309,7 +309,7 @@ mod checked {
             tx_context,
             &mut gas_charger,
             None,
-            pt,
+            Arc::new(pt),
             &mut None,
         )
         .map_err(|(e, _)| e)?;
@@ -731,23 +731,20 @@ mod checked {
                 Ok((Mode::empty_results(), vec![]))
             }
             TransactionKind::ProgrammableTransaction(pt) => {
-                // SIP-70: Compute base structural digest (no coin normalization).
-                // This is identity-preserving: coins hash by ObjectID.
-                let structural_digest = pt.structural_digest();
+                let pt = Arc::new(pt);
 
                 // SIP-70 v2: Build coin_info for the masked variant.
                 // Coin normalization (TypeTag + balance) only applies to structural_digest_masked.
-                let coin_info = build_coin_info_map(&pt, temporary_store.objects(), store);
+                let coin_info = build_coin_info_map(pt.as_ref(), temporary_store.objects(), store);
 
                 {
                     let mut ctx = tx_ctx.borrow_mut();
-                    ctx.set_structural_digest(structural_digest);
-                    // Store PT + coin_info for masked digest recomputation
+                    // Store PT + coin_info for lazy structural digest computation.
                     ctx.set_structural_digest_data(
-                        sui_types::transaction::StructuralDigestData {
-                            pt: pt.clone(),
+                        sui_types::transaction::StructuralDigestData::new(
+                            Arc::clone(&pt),
                             coin_info,
-                        },
+                        ),
                     );
                 }
 
@@ -774,7 +771,7 @@ mod checked {
                     tx_ctx,
                     gas_charger,
                     None,
-                    pt,
+                    Arc::new(pt),
                     trace_builder_opt,
                 )?;
                 Ok((Mode::empty_results(), vec![]))
@@ -1079,7 +1076,7 @@ mod checked {
             tx_ctx.clone(),
             gas_charger,
             None,
-            advance_epoch_pt,
+            Arc::new(advance_epoch_pt),
             trace_builder_opt,
         );
 
@@ -1111,7 +1108,7 @@ mod checked {
                     tx_ctx.clone(),
                     gas_charger,
                     None,
-                    advance_epoch_safe_mode_pt,
+                    Arc::new(advance_epoch_safe_mode_pt),
                     trace_builder_opt,
                 )
                 .map_err(|(e, _)| e)
@@ -1190,7 +1187,7 @@ mod checked {
                     tx_ctx.clone(),
                     gas_charger,
                     None,
-                    publish_pt,
+                    Arc::new(publish_pt),
                     trace_builder_opt,
                 )
                 .map_err(|(e, _)| e)
@@ -1264,7 +1261,7 @@ mod checked {
             tx_ctx,
             gas_charger,
             None,
-            pt,
+            Arc::new(pt),
             trace_builder_opt,
         )
         .map_err(|(e, _)| e)?;
@@ -1412,7 +1409,7 @@ mod checked {
             tx_ctx,
             gas_charger,
             None,
-            pt,
+            Arc::new(pt),
             trace_builder_opt,
         )
         .map_err(|(e, _)| e)?;
@@ -1485,7 +1482,7 @@ mod checked {
             tx_ctx,
             gas_charger,
             None,
-            pt,
+            Arc::new(pt),
             trace_builder_opt,
         )
         .map_err(|(e, _)| e)?;

--- a/sui-execution/latest/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/latest/sui-adapter/src/execution_engine.rs
@@ -590,24 +590,29 @@ mod checked {
 
     /// SIP-70 v2: Build a map from PTB input index to (TypeTag, balance) for coin inputs.
     /// This enables coin normalization — hashing coins by TypeName + Balance instead of ObjectID.
+    /// Looks up owned coins from input_objects and receiving coins from the backing store.
     fn build_coin_info_map(
         pt: &ProgrammableTransaction,
-        objects: &BTreeMap<sui_types::base_types::ObjectID, Object>,
+        input_objects: &BTreeMap<sui_types::base_types::ObjectID, Object>,
+        store: &dyn sui_types::storage::BackingStore,
     ) -> BTreeMap<usize, (move_core_types::language_storage::TypeTag, u64)> {
         let mut coin_info = BTreeMap::new();
         for (idx, input) in pt.inputs.iter().enumerate() {
-            let obj_id = match input {
-                CallArg::Object(ObjectArg::ImmOrOwnedObject((id, _, _))) => Some(id),
-                CallArg::Object(ObjectArg::Receiving((id, _, _))) => Some(id),
+            let obj = match input {
+                CallArg::Object(ObjectArg::ImmOrOwnedObject((id, _, _))) => {
+                    input_objects.get(id).cloned()
+                }
+                CallArg::Object(ObjectArg::Receiving((id, version, _))) => {
+                    // Receiving objects aren't in input_objects — look up from store
+                    store.as_object_store().get_object_by_key(id, *version)
+                }
                 _ => None,
             };
-            if let Some(id) = obj_id {
-                if let Some(obj) = objects.get(id) {
-                    if obj.is_coin() {
-                        if let Some(type_tag) = obj.coin_type_maybe() {
-                            let balance = obj.get_coin_value_unsafe();
-                            coin_info.insert(idx, (type_tag, balance));
-                        }
+            if let Some(obj) = obj {
+                if obj.is_coin() {
+                    if let Some(type_tag) = obj.coin_type_maybe() {
+                        let balance = obj.get_coin_value_unsafe();
+                        coin_info.insert(idx, (type_tag, balance));
                     }
                 }
             }
@@ -726,14 +731,13 @@ mod checked {
                 Ok((Mode::empty_results(), vec![]))
             }
             TransactionKind::ProgrammableTransaction(pt) => {
-                // SIP-70 v2: Build coin_info map from input objects for coin normalization
-                let coin_info = build_coin_info_map(&pt, temporary_store.objects());
+                // SIP-70: Compute base structural digest (no coin normalization).
+                // This is identity-preserving: coins hash by ObjectID.
+                let structural_digest = pt.structural_digest();
 
-                // Compute structural digest with coin normalization
-                let structural_digest = pt.structural_digest_with_options(
-                    Some(&coin_info),
-                    &std::collections::BTreeSet::new(),
-                );
+                // SIP-70 v2: Build coin_info for the masked variant.
+                // Coin normalization (TypeTag + balance) only applies to structural_digest_masked.
+                let coin_info = build_coin_info_map(&pt, temporary_store.objects(), store);
 
                 {
                     let mut ctx = tx_ctx.borrow_mut();

--- a/sui-execution/latest/sui-adapter/src/programmable_transactions/execution.rs
+++ b/sui-execution/latest/sui-adapter/src/programmable_transactions/execution.rs
@@ -88,7 +88,7 @@ mod checked {
         tx_context: Rc<RefCell<TxContext>>,
         gas_charger: &mut GasCharger,
         withdrawal_compatibility_inputs: Option<Vec<bool>>,
-        pt: ProgrammableTransaction,
+        pt: Arc<ProgrammableTransaction>,
         trace_builder_opt: &mut Option<MoveTraceBuilder>,
     ) -> ResultWithTimings<Mode::ExecutionResults, ExecutionError> {
         if protocol_config.enable_ptb_execution_v2() {
@@ -137,10 +137,9 @@ mod checked {
         state_view: &mut dyn ExecutionState,
         tx_context: Rc<RefCell<TxContext>>,
         gas_charger: &mut GasCharger,
-        pt: ProgrammableTransaction,
+        pt: Arc<ProgrammableTransaction>,
         trace_builder_opt: &mut Option<MoveTraceBuilder>,
     ) -> Result<Mode::ExecutionResults, ExecutionError> {
-        let ProgrammableTransaction { inputs, commands } = pt;
         let mut context = ExecutionContext::new(
             protocol_config,
             metrics,
@@ -148,14 +147,14 @@ mod checked {
             state_view,
             tx_context,
             gas_charger,
-            inputs,
+            pt.inputs.clone(),
         )?;
 
-        trace_utils::trace_ptb_summary::<Mode>(&mut context, trace_builder_opt, &commands)?;
+        trace_utils::trace_ptb_summary::<Mode>(&mut context, trace_builder_opt, &pt.commands)?;
 
         // execute commands
         let mut mode_results = Mode::empty_results();
-        for (idx, command) in commands.into_iter().enumerate() {
+        for (idx, command) in pt.commands.iter().cloned().enumerate() {
             let start = Instant::now();
             if let Err(err) =
                 execute_command::<Mode>(&mut context, &mut mode_results, command, trace_builder_opt)

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/loading/translate.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/loading/translate.rs
@@ -25,10 +25,9 @@ pub fn transaction<Mode: ExecutionMode>(
     // which inputs are withdrawals that need to be converted to coins, must
     // be the same length as the inputs
     withdrawal_compatibility_inputs: Option<Vec<bool>>,
-    pt: P::ProgrammableTransaction,
+    pt: &P::ProgrammableTransaction,
 ) -> Result<L::Transaction, ExecutionError> {
     metering::pre_translation::meter(meter, &pt)?;
-    let P::ProgrammableTransaction { inputs, commands } = pt;
     // withdrawal_compatibility_inputs specified ==> the protocol config flag is set
     assert_invariant!(
         withdrawal_compatibility_inputs.is_none()
@@ -38,20 +37,22 @@ pub fn transaction<Mode: ExecutionMode>(
         "if withdrawal compatibility must be specified, then the flag is set in the protocol config"
     );
     let withdrawal_compatibility_inputs =
-        withdrawal_compatibility_inputs.unwrap_or_else(|| vec![false; inputs.len()]);
+        withdrawal_compatibility_inputs.unwrap_or_else(|| vec![false; pt.inputs.len()]);
     assert_invariant!(
-        inputs.len() == withdrawal_compatibility_inputs.len(),
+        pt.inputs.len() == withdrawal_compatibility_inputs.len(),
         "withdrawal compatibility inputs must be the same length as the inputs"
     );
     let inputs = withdrawal_compatibility_inputs
         .into_iter()
-        .zip(inputs)
+        .zip(pt.inputs.iter().cloned())
         .map(|(is_withdrawal_compatibility_input, arg)| {
             input::<Mode>(env, tx_context, is_withdrawal_compatibility_input, arg)
         })
         .collect::<Result<Vec<_>, _>>()?;
-    let commands = commands
-        .into_iter()
+    let commands = pt
+        .commands
+        .iter()
+        .cloned()
         .enumerate()
         .map(|(idx, cmd)| command(env, cmd).map_err(|e| e.with_command_index(idx)))
         .collect::<Result<Vec<_>, _>>()?;

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/mod.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/mod.rs
@@ -44,7 +44,7 @@ pub fn execute<Mode: ExecutionMode>(
     gas_charger: &mut GasCharger,
     // which inputs are withdrawals that need to be converted to coins
     withdrawal_compatibility_inputs: Option<Vec<bool>>,
-    txn: ProgrammableTransaction,
+    txn: Arc<ProgrammableTransaction>,
     trace_builder_opt: &mut Option<MoveTraceBuilder>,
 ) -> ResultWithTimings<Mode::ExecutionResults, ExecutionError> {
     let package_store = CachedPackageStore::new(Box::new(package_store));
@@ -68,7 +68,7 @@ pub fn execute<Mode: ExecutionMode>(
             &env,
             &tx_context_ref,
             withdrawal_compatibility_inputs,
-            txn,
+            txn.as_ref(),
         )
         .map_err(|e| (e, vec![]))?
     };

--- a/sui-execution/latest/sui-move-natives/src/lib.rs
+++ b/sui-execution/latest/sui-move-natives/src/lib.rs
@@ -36,6 +36,7 @@ use self::{
         TxContextFreshIdCostParams, TxContextGasBudgetCostParams, TxContextGasPriceCostParams,
         TxContextIdsCreatedCostParams, TxContextRGPCostParams, TxContextReplaceCostParams,
         TxContextSenderCostParams, TxContextSponsorCostParams,
+        TxContextStructuralDigestCostParams,
     },
     types::TypesIsOneTimeWitnessCostParams,
     validator::ValidatorValidateMetadataBcsCostParams,
@@ -139,6 +140,7 @@ pub struct NativesCostTable {
     pub tx_context_gas_budget_cost_params: TxContextGasBudgetCostParams,
     pub tx_context_ids_created_cost_params: TxContextIdsCreatedCostParams,
     pub tx_context_replace_cost_params: TxContextReplaceCostParams,
+    pub tx_context_structural_digest_cost_params: TxContextStructuralDigestCostParams,
 
     // Type
     pub type_is_one_time_witness_cost_params: TypesIsOneTimeWitnessCostParams,
@@ -450,6 +452,12 @@ impl NativesCostTable {
                 } else {
                     DEFAULT_UNUSED_TX_CONTEXT_ENTRY_COST.into()
                 },
+            },
+            tx_context_structural_digest_cost_params: TxContextStructuralDigestCostParams {
+                tx_context_structural_digest_cost_base: protocol_config
+                    .tx_context_structural_digest_cost_base_as_option()
+                    .unwrap_or(DEFAULT_UNUSED_TX_CONTEXT_ENTRY_COST)
+                    .into(),
             },
             type_is_one_time_witness_cost_params: TypesIsOneTimeWitnessCostParams {
                 types_is_one_time_witness_cost_base: protocol_config
@@ -1246,6 +1254,11 @@ pub fn all_natives(silent: bool, protocol_config: &ProtocolConfig) -> NativeFunc
             make_native!(tx_context::ids_created),
         ),
         ("tx_context", "replace", make_native!(tx_context::replace)),
+        (
+            "tx_context",
+            "native_structural_digest",
+            make_native!(tx_context::structural_digest),
+        ),
         (
             "types",
             "is_one_time_witness",

--- a/sui-execution/latest/sui-move-natives/src/lib.rs
+++ b/sui-execution/latest/sui-move-natives/src/lib.rs
@@ -37,6 +37,7 @@ use self::{
         TxContextIdsCreatedCostParams, TxContextRGPCostParams, TxContextReplaceCostParams,
         TxContextSenderCostParams, TxContextSponsorCostParams,
         TxContextStructuralDigestCostParams,
+        TxContextStructuralDigestMaskedCostParams,
     },
     types::TypesIsOneTimeWitnessCostParams,
     validator::ValidatorValidateMetadataBcsCostParams,
@@ -141,6 +142,7 @@ pub struct NativesCostTable {
     pub tx_context_ids_created_cost_params: TxContextIdsCreatedCostParams,
     pub tx_context_replace_cost_params: TxContextReplaceCostParams,
     pub tx_context_structural_digest_cost_params: TxContextStructuralDigestCostParams,
+    pub tx_context_structural_digest_masked_cost_params: TxContextStructuralDigestMaskedCostParams,
 
     // Type
     pub type_is_one_time_witness_cost_params: TypesIsOneTimeWitnessCostParams,
@@ -456,6 +458,12 @@ impl NativesCostTable {
             tx_context_structural_digest_cost_params: TxContextStructuralDigestCostParams {
                 tx_context_structural_digest_cost_base: protocol_config
                     .tx_context_structural_digest_cost_base_as_option()
+                    .unwrap_or(DEFAULT_UNUSED_TX_CONTEXT_ENTRY_COST)
+                    .into(),
+            },
+            tx_context_structural_digest_masked_cost_params: TxContextStructuralDigestMaskedCostParams {
+                tx_context_structural_digest_masked_cost_base: protocol_config
+                    .tx_context_structural_digest_masked_cost_base_as_option()
                     .unwrap_or(DEFAULT_UNUSED_TX_CONTEXT_ENTRY_COST)
                     .into(),
             },
@@ -1258,6 +1266,11 @@ pub fn all_natives(silent: bool, protocol_config: &ProtocolConfig) -> NativeFunc
             "tx_context",
             "native_structural_digest",
             make_native!(tx_context::structural_digest),
+        ),
+        (
+            "tx_context",
+            "native_structural_digest_masked",
+            make_native!(tx_context::structural_digest_masked),
         ),
         (
             "types",

--- a/sui-execution/latest/sui-move-natives/src/lib.rs
+++ b/sui-execution/latest/sui-move-natives/src/lib.rs
@@ -36,7 +36,6 @@ use self::{
         TxContextFreshIdCostParams, TxContextGasBudgetCostParams, TxContextGasPriceCostParams,
         TxContextIdsCreatedCostParams, TxContextRGPCostParams, TxContextReplaceCostParams,
         TxContextSenderCostParams, TxContextSponsorCostParams, TxContextStructuralDigestCostParams,
-        TxContextStructuralDigestMaskedCostParams,
     },
     types::TypesIsOneTimeWitnessCostParams,
     validator::ValidatorValidateMetadataBcsCostParams,
@@ -141,7 +140,6 @@ pub struct NativesCostTable {
     pub tx_context_ids_created_cost_params: TxContextIdsCreatedCostParams,
     pub tx_context_replace_cost_params: TxContextReplaceCostParams,
     pub tx_context_structural_digest_cost_params: TxContextStructuralDigestCostParams,
-    pub tx_context_structural_digest_masked_cost_params: TxContextStructuralDigestMaskedCostParams,
 
     // Type
     pub type_is_one_time_witness_cost_params: TypesIsOneTimeWitnessCostParams,
@@ -464,17 +462,6 @@ impl NativesCostTable {
                     .unwrap_or(DEFAULT_UNUSED_TX_CONTEXT_ENTRY_COST)
                     .into(),
             },
-            tx_context_structural_digest_masked_cost_params:
-                TxContextStructuralDigestMaskedCostParams {
-                    tx_context_structural_digest_masked_cost_base: protocol_config
-                        .tx_context_structural_digest_masked_cost_base_as_option()
-                        .unwrap_or(DEFAULT_UNUSED_TX_CONTEXT_ENTRY_COST)
-                        .into(),
-                    tx_context_structural_digest_masked_cost_per_byte: protocol_config
-                        .tx_context_structural_digest_masked_cost_per_byte_as_option()
-                        .unwrap_or(DEFAULT_UNUSED_TX_CONTEXT_ENTRY_COST)
-                        .into(),
-                },
             type_is_one_time_witness_cost_params: TypesIsOneTimeWitnessCostParams {
                 types_is_one_time_witness_cost_base: protocol_config
                     .types_is_one_time_witness_cost_base()
@@ -1274,11 +1261,6 @@ pub fn all_natives(silent: bool, protocol_config: &ProtocolConfig) -> NativeFunc
             "tx_context",
             "native_structural_digest",
             make_native!(tx_context::structural_digest),
-        ),
-        (
-            "tx_context",
-            "native_structural_digest_masked",
-            make_native!(tx_context::structural_digest_masked),
         ),
         (
             "types",

--- a/sui-execution/latest/sui-move-natives/src/lib.rs
+++ b/sui-execution/latest/sui-move-natives/src/lib.rs
@@ -35,8 +35,7 @@ use self::{
         TxContextDeriveIdCostParams, TxContextEpochCostParams, TxContextEpochTimestampMsCostParams,
         TxContextFreshIdCostParams, TxContextGasBudgetCostParams, TxContextGasPriceCostParams,
         TxContextIdsCreatedCostParams, TxContextRGPCostParams, TxContextReplaceCostParams,
-        TxContextSenderCostParams, TxContextSponsorCostParams,
-        TxContextStructuralDigestCostParams,
+        TxContextSenderCostParams, TxContextSponsorCostParams, TxContextStructuralDigestCostParams,
         TxContextStructuralDigestMaskedCostParams,
     },
     types::TypesIsOneTimeWitnessCostParams,
@@ -460,13 +459,22 @@ impl NativesCostTable {
                     .tx_context_structural_digest_cost_base_as_option()
                     .unwrap_or(DEFAULT_UNUSED_TX_CONTEXT_ENTRY_COST)
                     .into(),
-            },
-            tx_context_structural_digest_masked_cost_params: TxContextStructuralDigestMaskedCostParams {
-                tx_context_structural_digest_masked_cost_base: protocol_config
-                    .tx_context_structural_digest_masked_cost_base_as_option()
+                tx_context_structural_digest_cost_per_byte: protocol_config
+                    .tx_context_structural_digest_cost_per_byte_as_option()
                     .unwrap_or(DEFAULT_UNUSED_TX_CONTEXT_ENTRY_COST)
                     .into(),
             },
+            tx_context_structural_digest_masked_cost_params:
+                TxContextStructuralDigestMaskedCostParams {
+                    tx_context_structural_digest_masked_cost_base: protocol_config
+                        .tx_context_structural_digest_masked_cost_base_as_option()
+                        .unwrap_or(DEFAULT_UNUSED_TX_CONTEXT_ENTRY_COST)
+                        .into(),
+                    tx_context_structural_digest_masked_cost_per_byte: protocol_config
+                        .tx_context_structural_digest_masked_cost_per_byte_as_option()
+                        .unwrap_or(DEFAULT_UNUSED_TX_CONTEXT_ENTRY_COST)
+                        .into(),
+                },
             type_is_one_time_witness_cost_params: TypesIsOneTimeWitnessCostParams {
                 types_is_one_time_witness_cost_base: protocol_config
                     .types_is_one_time_witness_cost_base()

--- a/sui-execution/latest/sui-move-natives/src/transaction_context.rs
+++ b/sui-execution/latest/sui-move-natives/src/transaction_context.rs
@@ -78,6 +78,11 @@ impl TransactionContext {
         self.tx_context.borrow_mut().fresh_id()
     }
 
+    /// Returns the normalized structural digest of the PTB (SIP-70).
+    pub fn structural_digest(&self) -> Vec<u8> {
+        self.tx_context.borrow().structural_digest().to_vec()
+    }
+
     //
     // Test only function
     //

--- a/sui-execution/latest/sui-move-natives/src/transaction_context.rs
+++ b/sui-execution/latest/sui-move-natives/src/transaction_context.rs
@@ -78,29 +78,13 @@ impl TransactionContext {
         self.tx_context.borrow_mut().fresh_id()
     }
 
-    /// Returns the normalized structural digest of the PTB (SIP-70).
+    /// Returns the structural digest of the PTB (SIP-70).
     pub fn structural_digest(&self) -> Option<Vec<u8>> {
         self.tx_context.borrow_mut().structural_digest()
     }
 
-    /// Returns the structural digest with specified Pure inputs wildcarded (SIP-70 v2).
-    pub fn structural_digest_masked(
-        &self,
-        wildcard_indices: &std::collections::BTreeSet<u16>,
-    ) -> Option<Vec<u8>> {
-        self.tx_context
-            .borrow()
-            .structural_digest_masked(wildcard_indices)
-    }
-
     pub fn structural_digest_gas_bytes(&self) -> Option<u64> {
         self.tx_context.borrow().structural_digest_gas_bytes()
-    }
-
-    pub fn structural_digest_masked_gas_bytes(&self) -> Option<u64> {
-        self.tx_context
-            .borrow()
-            .structural_digest_masked_gas_bytes()
     }
 
     //

--- a/sui-execution/latest/sui-move-natives/src/transaction_context.rs
+++ b/sui-execution/latest/sui-move-natives/src/transaction_context.rs
@@ -79,13 +79,28 @@ impl TransactionContext {
     }
 
     /// Returns the normalized structural digest of the PTB (SIP-70).
-    pub fn structural_digest(&self) -> Vec<u8> {
-        self.tx_context.borrow().structural_digest().to_vec()
+    pub fn structural_digest(&self) -> Option<Vec<u8>> {
+        self.tx_context.borrow_mut().structural_digest()
     }
 
     /// Returns the structural digest with specified Pure inputs wildcarded (SIP-70 v2).
-    pub fn structural_digest_masked(&self, wildcard_indices: &std::collections::BTreeSet<u16>) -> Vec<u8> {
-        self.tx_context.borrow().structural_digest_masked(wildcard_indices)
+    pub fn structural_digest_masked(
+        &self,
+        wildcard_indices: &std::collections::BTreeSet<u16>,
+    ) -> Option<Vec<u8>> {
+        self.tx_context
+            .borrow()
+            .structural_digest_masked(wildcard_indices)
+    }
+
+    pub fn structural_digest_gas_bytes(&self) -> Option<u64> {
+        self.tx_context.borrow().structural_digest_gas_bytes()
+    }
+
+    pub fn structural_digest_masked_gas_bytes(&self) -> Option<u64> {
+        self.tx_context
+            .borrow()
+            .structural_digest_masked_gas_bytes()
     }
 
     //

--- a/sui-execution/latest/sui-move-natives/src/transaction_context.rs
+++ b/sui-execution/latest/sui-move-natives/src/transaction_context.rs
@@ -83,6 +83,11 @@ impl TransactionContext {
         self.tx_context.borrow().structural_digest().to_vec()
     }
 
+    /// Returns the structural digest with specified Pure inputs wildcarded (SIP-70 v2).
+    pub fn structural_digest_masked(&self, wildcard_indices: &std::collections::BTreeSet<u16>) -> Vec<u8> {
+        self.tx_context.borrow().structural_digest_masked(wildcard_indices)
+    }
+
     //
     // Test only function
     //

--- a/sui-execution/latest/sui-move-natives/src/tx_context.rs
+++ b/sui-execution/latest/sui-move-natives/src/tx_context.rs
@@ -464,3 +464,38 @@ pub fn last_created_id(
         smallvec![Value::address(address)],
     ))
 }
+
+#[derive(Clone)]
+pub struct TxContextStructuralDigestCostParams {
+    pub tx_context_structural_digest_cost_base: InternalGas,
+}
+/***************************************************************************************************
+ * native fun native_structural_digest
+ * Implementation of the Move native function `fun native_structural_digest(): vector<u8>`
+ * Returns the normalized structural digest of the current PTB (SIP-70).
+ *   gas cost: tx_context_structural_digest_cost_base    | fixed size output
+ **************************************************************************************************/
+pub fn structural_digest(
+    context: &mut NativeContext,
+    ty_args: Vec<Type>,
+    args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    debug_assert!(ty_args.is_empty());
+    debug_assert!(args.is_empty());
+
+    let tx_context_structural_digest_cost_params = get_extension!(context, NativesCostTable)?
+        .tx_context_structural_digest_cost_params
+        .clone();
+    native_charge_gas_early_exit!(
+        context,
+        tx_context_structural_digest_cost_params.tx_context_structural_digest_cost_base
+    );
+
+    let transaction_context: &mut TransactionContext = get_extension_mut!(context)?;
+    let digest = transaction_context.structural_digest();
+
+    Ok(NativeResult::ok(
+        context.gas_used(),
+        smallvec![Value::vector_u8(digest)],
+    ))
+}

--- a/sui-execution/latest/sui-move-natives/src/tx_context.rs
+++ b/sui-execution/latest/sui-move-natives/src/tx_context.rs
@@ -8,7 +8,10 @@ use move_vm_types::{
     loaded_data::runtime_types::Type, natives::function::NativeResult, pop_arg, values::Value,
 };
 use smallvec::smallvec;
-use std::collections::VecDeque;
+use std::{
+    collections::{BTreeSet, VecDeque},
+    ops::Mul,
+};
 use sui_types::{base_types::ObjectID, digests::TransactionDigest};
 
 use crate::{
@@ -426,6 +429,8 @@ pub fn replace(
 // Attempt to get the most recent created object ID when none has been created.
 // Lifted out of Move into this native function.
 const E_NO_IDS_CREATED: u64 = 1;
+const E_STRUCTURAL_DIGEST_UNAVAILABLE: u64 = 2;
+const E_WILDCARD_INDEX_TOO_LARGE: u64 = 3;
 
 // use same protocol config and cost value as derive_id
 /***************************************************************************************************
@@ -468,12 +473,14 @@ pub fn last_created_id(
 #[derive(Clone)]
 pub struct TxContextStructuralDigestCostParams {
     pub tx_context_structural_digest_cost_base: InternalGas,
+    pub tx_context_structural_digest_cost_per_byte: InternalGas,
 }
 /***************************************************************************************************
  * native fun native_structural_digest
  * Implementation of the Move native function `fun native_structural_digest(): vector<u8>`
  * Returns the normalized structural digest of the current PTB (SIP-70).
- *   gas cost: tx_context_structural_digest_cost_base    | fixed size output
+ *   gas cost: tx_context_structural_digest_cost_base
+ *              + tx_context_structural_digest_cost_per_byte * pt_size
  **************************************************************************************************/
 pub fn structural_digest(
     context: &mut NativeContext,
@@ -491,8 +498,30 @@ pub fn structural_digest(
         tx_context_structural_digest_cost_params.tx_context_structural_digest_cost_base
     );
 
-    let transaction_context: &mut TransactionContext = get_extension_mut!(context)?;
-    let digest = transaction_context.structural_digest();
+    let Some(gas_bytes) = ({
+        let transaction_context: &mut TransactionContext = get_extension_mut!(context)?;
+        transaction_context.structural_digest_gas_bytes()
+    }) else {
+        return Ok(NativeResult::err(
+            context.gas_used(),
+            E_STRUCTURAL_DIGEST_UNAVAILABLE,
+        ));
+    };
+    native_charge_gas_early_exit!(
+        context,
+        tx_context_structural_digest_cost_params
+            .tx_context_structural_digest_cost_per_byte
+            .mul(gas_bytes.into())
+    );
+    let Some(digest) = ({
+        let transaction_context: &mut TransactionContext = get_extension_mut!(context)?;
+        transaction_context.structural_digest()
+    }) else {
+        return Ok(NativeResult::err(
+            context.gas_used(),
+            E_STRUCTURAL_DIGEST_UNAVAILABLE,
+        ));
+    };
 
     Ok(NativeResult::ok(
         context.gas_used(),
@@ -503,12 +532,14 @@ pub fn structural_digest(
 #[derive(Clone)]
 pub struct TxContextStructuralDigestMaskedCostParams {
     pub tx_context_structural_digest_masked_cost_base: InternalGas,
+    pub tx_context_structural_digest_masked_cost_per_byte: InternalGas,
 }
 /***************************************************************************************************
  * native fun native_structural_digest_masked
  * Implementation of `fun native_structural_digest_masked(wildcard_pure_indices: vector<u64>): vector<u8>`
  * Returns the structural digest with specified Pure inputs treated as wildcards (SIP-70 v2).
- *   gas cost: tx_context_structural_digest_masked_cost_base    | recomputation cost
+ *   gas cost: tx_context_structural_digest_masked_cost_base
+ *              + tx_context_structural_digest_masked_cost_per_byte * pt_size
  **************************************************************************************************/
 pub fn structural_digest_masked(
     context: &mut NativeContext,
@@ -531,14 +562,38 @@ pub fn structural_digest_masked(
     // Validate: abort if any index exceeds u16::MAX (prevents silent truncation)
     for &v in &wildcard_vec {
         if v > u16::MAX as u64 {
-            return Ok(NativeResult::err(context.gas_used(), 0));
+            return Ok(NativeResult::err(
+                context.gas_used(),
+                E_WILDCARD_INDEX_TOO_LARGE,
+            ));
         }
     }
-    let wildcard_indices: std::collections::BTreeSet<u16> =
-        wildcard_vec.into_iter().map(|v| v as u16).collect();
+    let wildcard_indices: BTreeSet<u16> = wildcard_vec.into_iter().map(|v| v as u16).collect();
 
-    let transaction_context: &mut TransactionContext = get_extension_mut!(context)?;
-    let digest = transaction_context.structural_digest_masked(&wildcard_indices);
+    let Some(gas_bytes) = ({
+        let transaction_context: &mut TransactionContext = get_extension_mut!(context)?;
+        transaction_context.structural_digest_masked_gas_bytes()
+    }) else {
+        return Ok(NativeResult::err(
+            context.gas_used(),
+            E_STRUCTURAL_DIGEST_UNAVAILABLE,
+        ));
+    };
+    native_charge_gas_early_exit!(
+        context,
+        cost_params
+            .tx_context_structural_digest_masked_cost_per_byte
+            .mul(gas_bytes.into())
+    );
+    let Some(digest) = ({
+        let transaction_context: &mut TransactionContext = get_extension_mut!(context)?;
+        transaction_context.structural_digest_masked(&wildcard_indices)
+    }) else {
+        return Ok(NativeResult::err(
+            context.gas_used(),
+            E_STRUCTURAL_DIGEST_UNAVAILABLE,
+        ));
+    };
 
     Ok(NativeResult::ok(
         context.gas_used(),

--- a/sui-execution/latest/sui-move-natives/src/tx_context.rs
+++ b/sui-execution/latest/sui-move-natives/src/tx_context.rs
@@ -8,10 +8,7 @@ use move_vm_types::{
     loaded_data::runtime_types::Type, natives::function::NativeResult, pop_arg, values::Value,
 };
 use smallvec::smallvec;
-use std::{
-    collections::{BTreeSet, VecDeque},
-    ops::Mul,
-};
+use std::{collections::VecDeque, ops::Mul};
 use sui_types::{base_types::ObjectID, digests::TransactionDigest};
 
 use crate::{
@@ -430,7 +427,6 @@ pub fn replace(
 // Lifted out of Move into this native function.
 const E_NO_IDS_CREATED: u64 = 1;
 const E_STRUCTURAL_DIGEST_UNAVAILABLE: u64 = 2;
-const E_WILDCARD_INDEX_TOO_LARGE: u64 = 3;
 
 // use same protocol config and cost value as derive_id
 /***************************************************************************************************
@@ -478,7 +474,7 @@ pub struct TxContextStructuralDigestCostParams {
 /***************************************************************************************************
  * native fun native_structural_digest
  * Implementation of the Move native function `fun native_structural_digest(): vector<u8>`
- * Returns the normalized structural digest of the current PTB (SIP-70).
+ * Returns the structural digest of the current PTB (SIP-70).
  *   gas cost: tx_context_structural_digest_cost_base
  *              + tx_context_structural_digest_cost_per_byte * pt_size
  **************************************************************************************************/
@@ -516,78 +512,6 @@ pub fn structural_digest(
     let Some(digest) = ({
         let transaction_context: &mut TransactionContext = get_extension_mut!(context)?;
         transaction_context.structural_digest()
-    }) else {
-        return Ok(NativeResult::err(
-            context.gas_used(),
-            E_STRUCTURAL_DIGEST_UNAVAILABLE,
-        ));
-    };
-
-    Ok(NativeResult::ok(
-        context.gas_used(),
-        smallvec![Value::vector_u8(digest)],
-    ))
-}
-
-#[derive(Clone)]
-pub struct TxContextStructuralDigestMaskedCostParams {
-    pub tx_context_structural_digest_masked_cost_base: InternalGas,
-    pub tx_context_structural_digest_masked_cost_per_byte: InternalGas,
-}
-/***************************************************************************************************
- * native fun native_structural_digest_masked
- * Implementation of `fun native_structural_digest_masked(wildcard_pure_indices: vector<u64>): vector<u8>`
- * Returns the structural digest with specified Pure inputs treated as wildcards (SIP-70 v2).
- *   gas cost: tx_context_structural_digest_masked_cost_base
- *              + tx_context_structural_digest_masked_cost_per_byte * pt_size
- **************************************************************************************************/
-pub fn structural_digest_masked(
-    context: &mut NativeContext,
-    ty_args: Vec<Type>,
-    mut args: VecDeque<Value>,
-) -> PartialVMResult<NativeResult> {
-    debug_assert!(ty_args.is_empty());
-    debug_assert!(args.len() == 1);
-
-    let cost_params = get_extension!(context, NativesCostTable)?
-        .tx_context_structural_digest_masked_cost_params
-        .clone();
-    native_charge_gas_early_exit!(
-        context,
-        cost_params.tx_context_structural_digest_masked_cost_base
-    );
-
-    // Pop wildcard_pure_indices: vector<u64>, validate, convert to BTreeSet<u16>
-    let wildcard_vec = pop_arg!(args, Vec<u64>);
-    // Validate: abort if any index exceeds u16::MAX (prevents silent truncation)
-    for &v in &wildcard_vec {
-        if v > u16::MAX as u64 {
-            return Ok(NativeResult::err(
-                context.gas_used(),
-                E_WILDCARD_INDEX_TOO_LARGE,
-            ));
-        }
-    }
-    let wildcard_indices: BTreeSet<u16> = wildcard_vec.into_iter().map(|v| v as u16).collect();
-
-    let Some(gas_bytes) = ({
-        let transaction_context: &mut TransactionContext = get_extension_mut!(context)?;
-        transaction_context.structural_digest_masked_gas_bytes()
-    }) else {
-        return Ok(NativeResult::err(
-            context.gas_used(),
-            E_STRUCTURAL_DIGEST_UNAVAILABLE,
-        ));
-    };
-    native_charge_gas_early_exit!(
-        context,
-        cost_params
-            .tx_context_structural_digest_masked_cost_per_byte
-            .mul(gas_bytes.into())
-    );
-    let Some(digest) = ({
-        let transaction_context: &mut TransactionContext = get_extension_mut!(context)?;
-        transaction_context.structural_digest_masked(&wildcard_indices)
     }) else {
         return Ok(NativeResult::err(
             context.gas_used(),

--- a/sui-execution/latest/sui-move-natives/src/tx_context.rs
+++ b/sui-execution/latest/sui-move-natives/src/tx_context.rs
@@ -499,3 +499,43 @@ pub fn structural_digest(
         smallvec![Value::vector_u8(digest)],
     ))
 }
+
+#[derive(Clone)]
+pub struct TxContextStructuralDigestMaskedCostParams {
+    pub tx_context_structural_digest_masked_cost_base: InternalGas,
+}
+/***************************************************************************************************
+ * native fun native_structural_digest_masked
+ * Implementation of `fun native_structural_digest_masked(wildcard_pure_indices: vector<u64>): vector<u8>`
+ * Returns the structural digest with specified Pure inputs treated as wildcards (SIP-70 v2).
+ *   gas cost: tx_context_structural_digest_masked_cost_base    | recomputation cost
+ **************************************************************************************************/
+pub fn structural_digest_masked(
+    context: &mut NativeContext,
+    ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    debug_assert!(ty_args.is_empty());
+    debug_assert!(args.len() == 1);
+
+    let cost_params = get_extension!(context, NativesCostTable)?
+        .tx_context_structural_digest_masked_cost_params
+        .clone();
+    native_charge_gas_early_exit!(
+        context,
+        cost_params.tx_context_structural_digest_masked_cost_base
+    );
+
+    // Pop wildcard_pure_indices: vector<u64>, convert to BTreeSet<u16>
+    let wildcard_vec = pop_arg!(args, Vec<u64>);
+    let wildcard_indices: std::collections::BTreeSet<u16> =
+        wildcard_vec.into_iter().map(|v| v as u16).collect();
+
+    let transaction_context: &mut TransactionContext = get_extension_mut!(context)?;
+    let digest = transaction_context.structural_digest_masked(&wildcard_indices);
+
+    Ok(NativeResult::ok(
+        context.gas_used(),
+        smallvec![Value::vector_u8(digest)],
+    ))
+}

--- a/sui-execution/latest/sui-move-natives/src/tx_context.rs
+++ b/sui-execution/latest/sui-move-natives/src/tx_context.rs
@@ -526,8 +526,14 @@ pub fn structural_digest_masked(
         cost_params.tx_context_structural_digest_masked_cost_base
     );
 
-    // Pop wildcard_pure_indices: vector<u64>, convert to BTreeSet<u16>
+    // Pop wildcard_pure_indices: vector<u64>, validate, convert to BTreeSet<u16>
     let wildcard_vec = pop_arg!(args, Vec<u64>);
+    // Validate: abort if any index exceeds u16::MAX (prevents silent truncation)
+    for &v in &wildcard_vec {
+        if v > u16::MAX as u64 {
+            return Ok(NativeResult::err(context.gas_used(), 0));
+        }
+    }
     let wildcard_indices: std::collections::BTreeSet<u16> =
         wildcard_vec.into_iter().map(|v| v as u16).collect();
 


### PR DESCRIPTION
## Summary

Adds one `sui::tx_context` native that lets governance and smart-account contracts verify PTB structure at execution time:

1. `structural_digest(&TxContext): vector<u8>` — a versioned, deterministic structural digest of the current PTB

This lets proposals approve an exact PTB shape and verify at execution time that the submitted PTB matches that approval.

## Main Changes

- SIP-70 structural digest over PTB commands, arguments, type arguments, and result flow
- Exact structural commitment only: no wildcarding, no second masked/normalized mode, no PTB introspection
- Length framing for variable-length fields and list counts
- Shared-object mutability included in the digest
- Owned and receiving object versions dropped from the digest for approval/execution stability
- Protocol-config gating in v113 and updated SIP documentation

## Follow-up Fixes

- Per-byte gas charging so digest work scales with PTB size
- Lazy digest computation plus transient `StructuralDigestData` so programmable transactions are not eagerly rehashed or fully cloned
- Explicit abort when structural digest data is unavailable
- Regression coverage for shared-object mutability and digest stability

## Validation

- [x] `cargo check -p sui-adapter-latest -p sui-move-natives-latest -p sui-protocol-config -p sui-types`
- [x] `cargo test -p sui-types structural_digest_tests --lib`
