### PR TITLE
[cli][cherry-pick] Cherry pick cli fix ptb output

### DIFF
--- a/crates/sui/src/client_ptb/ptb.rs
+++ b/crates/sui/src/client_ptb/ptb.rs
@@ -268,19 +268,20 @@ impl PTB {
             }
         };
 
+        let command_result = SuiClientCommandResult::TransactionBlock(transaction_response);
+
         if program_metadata.json_set {
             let json_string = if program_metadata.summary_set {
                 serde_json::to_string_pretty(&serde_json::json!(summary))
                     .map_err(|_| anyhow!("Cannot serialize PTB result to json"))?
             } else {
-                serde_json::to_string_pretty(&serde_json::json!(transaction_response))
-                    .map_err(|_| anyhow!("Cannot serialize PTB result to json"))?
+                format!("{:?}", command_result)
             };
             println!("{}", json_string);
         } else if program_metadata.summary_set {
             println!("{}", Pretty(&summary));
         } else {
-            println!("{}", serde_json::to_string_pretty(&transaction_response)?);
+            println!("{}", command_result);
         }
 
         Ok(())


### PR DESCRIPTION
## Description 

This fixes the output for the `sui client ptb` to match what we used to have before the gRPC migration.

## Test plan 

Manually, locally via a few transactions with these flags.
```
--dry-run
--summary
--preview
--json
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [x] CLI: Fixed a bug to re-enable pretty printing of `sui client ptb` output.
- [ ] Rust SDK:
- [ ] Indexing Framework: