### PR TITLE
Improve error handling in deny_list_v1.rs to match other system object getters

### DIFF
--- a/crates/sui-config/src/genesis.rs
+++ b/crates/sui-config/src/genesis.rs
@@ -335,7 +335,7 @@ impl UnsignedGenesis {
     }
 
     pub fn coin_deny_list_state(&self) -> Option<PerTypeDenyList> {
-        get_coin_deny_list(&self.objects())
+        get_coin_deny_list(&self.objects()).expect("read from genesis cannot fail")
     }
 }
 

--- a/crates/sui-core/src/authority/epoch_start_configuration.rs
+++ b/crates/sui-core/src/authority/epoch_start_configuration.rs
@@ -173,7 +173,7 @@ impl EpochStartConfiguration {
         let randomness_obj_initial_shared_version =
             get_randomness_state_obj_initial_shared_version(object_store)?;
         let coin_deny_list_obj_initial_shared_version =
-            get_deny_list_obj_initial_shared_version(object_store);
+            get_deny_list_obj_initial_shared_version(object_store)?;
         let bridge_obj_initial_shared_version =
             get_bridge_obj_initial_shared_version(object_store)?;
         let accumulator_root_obj_initial_shared_version =


### PR DESCRIPTION


## Description 

Describe the changes or additions included in this PR.
- Change return types of get_deny_list_root_object, get_coin_deny_list, and get_deny_list_obj_initial_shared_version from Option to SuiResult<Option> for consistency with authenticator/bridge/randomness patterns
- Replace manual cfg!(debug_assertions) + panic! with debug_fatal! macro to properly report invariant violation metrics
- Replace .expect() in get_coin_deny_list with proper error propagation via SuiErrorKind::SuiSystemStateReadError
- Use .expect() in genesis coin_deny_list_state() to match authenticator_state_object() pattern instead of silently swallowing errors
- Update call site in epoch_start_configuration.rs to propagate errors with ?

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
