### PR TITLE
e

### DIFF
--- a/crates/sui-kv-rpc/src/lib.rs
+++ b/crates/sui-kv-rpc/src/lib.rs
@@ -29,6 +29,7 @@ impl KvRpcServer {
         project_id: Option<String>,
         app_profile_id: Option<String>,
         checkpoint_bucket: Option<String>,
+        channel_timeout: Option<Duration>,
         server_version: Option<ServerVersion>,
         registry: &Registry,
     ) -> anyhow::Result<Self> {
@@ -36,7 +37,7 @@ impl KvRpcServer {
             instance_id,
             project_id,
             false,
-            None,
+            channel_timeout,
             None,
             "sui-kv-rpc".to_string(),
             Some(registry),

--- a/crates/sui-kvstore/src/bin/sui-kvstore-alt.rs
+++ b/crates/sui-kvstore/src/bin/sui-kvstore-alt.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::path::PathBuf;
+use std::time::Duration;
 
 use anyhow::Result;
 use clap::Parser;
@@ -83,11 +84,15 @@ async fn main() -> Result<()> {
     info!(instance_id = %args.instance_id);
     info!("Config: {:#?}", config);
 
+    let channel_timeout = config
+        .bigtable_channel_timeout_ms
+        .map(Duration::from_millis);
+
     let client = BigTableClient::new_remote(
         args.instance_id,
         args.bigtable_project,
         false,
-        None,
+        channel_timeout,
         args.bigtable_max_decoding_message_size,
         "sui-kvstore-alt".to_string(),
         None,

--- a/crates/sui-kvstore/src/config.rs
+++ b/crates/sui-kvstore/src/config.rs
@@ -16,6 +16,8 @@ pub struct IndexerConfig {
     /// A good rule of thumb is to target ~25 concurrent RPCs per channel, so
     /// ceil(sum of write_concurrency across all pipelines / 25).
     pub bigtable_connection_pool_size: Option<usize>,
+    /// Channel-level timeout in milliseconds for BigTable gRPC calls (default: 60000).
+    pub bigtable_channel_timeout_ms: Option<u64>,
 }
 
 #[DefaultConfig]


### PR DESCRIPTION
## Description

A lack of timeout is causing watermark updates to hang indefinitely. Setting a reasonable/high default for now. Eventually we should probably have per-method timeouts that can be set tighter.
