### PR TITLE
sui-move-fuzzer: forked execution mode — bug fixes, efficiency, developer features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+crates/sui-evil-compiler/
+
 # IDE and agents
 **/.history/
 **/.vscode/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,8 @@
 resolver = "2"
 
 exclude = [
+  "crates/sui-evil-compiler",
+  "crates/sui-move-fuzzer",
   "examples/tic-tac-toe/cli",
   "examples/regulated-coin/rust-client",
   "examples/custom-indexer/rust",

--- a/crates/sui-move-fuzzer/Cargo.toml
+++ b/crates/sui-move-fuzzer/Cargo.toml
@@ -1,0 +1,165 @@
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+[package]
+name = "sui-move-fuzzer"
+version = "0.1.0"
+authors = ["Mysten Labs <build@mystenlabs.com>"]
+license = "Apache-2.0"
+publish = false
+edition = "2024"
+
+[package.metadata]
+cargo-fuzz = true
+
+[features]
+default = ["e2e"]
+# The "e2e" feature gates sui-core and authority_harness for full E2E fuzzing.
+# Disable it for lightweight verifier-only targets that work with cargo fuzz:
+#   cargo +nightly fuzz run --fuzz-dir . verifier_crash -- --no-default-features
+# LLM-guided seed generation: calls Claude API to generate targeted seeds.
+# Usage: cargo run --features llm-guided --bin llm_seed_gen
+llm-guided = ["dep:reqwest"]
+
+e2e = [
+    "dep:sui-core",
+    "dep:sui-protocol-config",
+    "dep:sui-framework",
+    "dep:sui-swarm-config",
+    "dep:sui-genesis-builder",
+    "dep:shared-crypto",
+    "dep:tokio",
+    "dep:once_cell",
+    "dep:fastcrypto",
+]
+
+# Forked-execution mode: run modules against real Sui network state fetched lazily from RPC.
+# Enables oracle price object manipulation and full Sui native functions.
+# Usage: cargo run --features fork --bin fork_main -- --fork-rpc https://fullnode.mainnet.sui.io:443
+fork = [
+    "e2e",
+    "dep:sui-sdk",
+    "dep:sui-json-rpc-types",
+    "dep:prometheus",
+    "dep:bcs",
+]
+
+[dependencies]
+libfuzzer-sys = "0.4"
+arbitrary = { version = "1", features = ["derive"] }
+anyhow = "1"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+# HTTP client for LLM API calls — gated by "llm-guided" feature
+reqwest = { version = "0.12", features = ["json", "blocking"], optional = true }
+
+# Move crates (always needed)
+move-binary-format = { path = "../../external-crates/move/crates/move-binary-format", features = ["fuzzing"] }
+move-core-types = { path = "../../external-crates/move/crates/move-core-types", features = ["fuzzing"] }
+move-bytecode-verifier = { path = "../../external-crates/move/crates/move-bytecode-verifier" }
+move-bytecode-verifier-meter = { path = "../../external-crates/move/crates/move-bytecode-verifier-meter" }
+move-vm-config = { path = "../../external-crates/move/crates/move-vm-config" }
+
+# Sui execution layer (always needed for verifier)
+sui-execution = { path = "../../sui-execution" }
+sui-verifier = { package = "sui-verifier-latest", path = "../../sui-execution/latest/sui-verifier" }
+
+# Sui core (for TestAuthorityBuilder, authority_test_utils) — gated by "e2e" feature
+sui-core = { path = "../sui-core", optional = true }
+sui-types = { path = "../sui-types" }
+sui-protocol-config = { path = "../sui-protocol-config", optional = true }
+sui-framework = { path = "../sui-framework", optional = true }
+sui-swarm-config = { path = "../sui-swarm-config", optional = true }
+sui-genesis-builder = { path = "../sui-genesis-builder", optional = true }
+shared-crypto = { path = "../shared-crypto", optional = true }
+
+# Fork-mode RPC deps — gated by "fork" feature
+sui-sdk = { path = "../sui-sdk", optional = true }
+sui-json-rpc-types = { path = "../sui-json-rpc-types", optional = true }
+prometheus = { version = "0.13", optional = true }
+bcs = { version = "0.1", optional = true }
+
+# Runtime and utilities — gated by "e2e" feature
+tokio = { version = "1.49.0", features = ["full"], optional = true }
+once_cell = { version = "1", optional = true }
+rand = "0.8"
+tempfile = "3"
+fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "db643fd05a1b1c4cd52de3939766b53e12ce137e", optional = true }
+
+# Prevent this from interfering with workspaces
+#[workspace]
+#members = ["."]
+
+[[bin]]
+name = "e2e_publish_execute"
+path = "fuzz_targets/e2e_publish_execute.rs"
+test = false
+doc = false
+required-features = ["e2e"]
+
+[[bin]]
+name = "e2e_publish_crash"
+path = "fuzz_targets/e2e_publish_crash.rs"
+test = false
+doc = false
+required-features = ["e2e"]
+
+[[bin]]
+name = "ref_safety_diff"
+path = "fuzz_targets/ref_safety_diff.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "verifier_crash"
+path = "fuzz_targets/verifier_crash.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "deser_roundtrip"
+path = "fuzz_targets/deser_roundtrip.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "bounds_escape"
+path = "fuzz_targets/bounds_escape.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "ref_safety_diff_gen"
+path = "fuzz_targets/ref_safety_diff_gen.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "verifier_soundness"
+path = "fuzz_targets/verifier_soundness.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "gen_corpus"
+path = "src/bin/gen_corpus.rs"
+
+[[bin]]
+name = "coverage_gaps"
+path = "src/bin/coverage_gaps.rs"
+
+[[bin]]
+name = "llm_seed_gen"
+path = "src/bin/llm_seed_gen.rs"
+required-features = ["llm-guided"]
+
+[[bin]]
+name = "fuzz_loop"
+path = "src/bin/fuzz_loop.rs"
+required-features = ["llm-guided"]
+
+[[bin]]
+name = "fork_main"
+path = "src/bin/fork_main.rs"
+required-features = ["fork"]

--- a/crates/sui-move-fuzzer/fuzz_targets/bounds_escape.rs
+++ b/crates/sui-move-fuzzer/fuzz_targets/bounds_escape.rs
@@ -1,0 +1,41 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+#![no_main]
+
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+use sui_move_fuzzer::module_gen::{ModuleBuilder, ModuleGenConfig};
+use sui_move_fuzzer::mutators;
+use sui_move_fuzzer::sui_harness::run_full_verification;
+
+#[derive(Debug, Arbitrary)]
+struct BoundsEscapeInput {
+    config: ModuleGenConfig,
+    num_corruptions: u8,
+    raw_entropy: Vec<u8>,
+}
+
+fuzz_target!(|input: BoundsEscapeInput| {
+    let num_corruptions = input.num_corruptions.clamp(1, 5) as usize;
+
+    let mut u = arbitrary::Unstructured::new(&input.raw_entropy);
+
+    let builder = ModuleBuilder::new(input.config);
+    let mut module = match builder.build(&mut u) {
+        Ok(m) => m,
+        Err(_) => return,
+    };
+
+    // Apply N mutations; some will be BoundsCorrupt, others will be
+    // different kinds -- all contribute to verifier stress testing.
+    for _ in 0..num_corruptions {
+        if mutators::apply_mutation(&mut u, &mut module).is_err() {
+            break;
+        }
+    }
+
+    // The full verification pipeline (Move + Sui) should never panic on any input.
+    // Errors are expected and fine; panics indicate a bug.
+    // libfuzzer's signal handler catches panics directly — no manual catch_unwind needed.
+    run_full_verification(&module).ok();
+});

--- a/crates/sui-move-fuzzer/fuzz_targets/deser_roundtrip.rs
+++ b/crates/sui-move-fuzzer/fuzz_targets/deser_roundtrip.rs
@@ -1,0 +1,51 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+#![no_main]
+
+use libfuzzer_sys::{fuzz_mutator, fuzz_target};
+use move_binary_format::binary_config::BinaryConfig;
+use move_binary_format::file_format::CompiledModule;
+use sui_move_fuzzer::custom_mutator::mutate_move_module;
+
+fuzz_mutator!(|data: &mut [u8], size: usize, max_size: usize, seed: u32| {
+    match mutate_move_module(data, size, max_size, seed) {
+        Some(n) => n,
+        None => libfuzzer_sys::fuzzer_mutate(data, size, max_size),
+    }
+});
+
+fuzz_target!(|data: &[u8]| {
+    let config = BinaryConfig::standard();
+
+    // Step 1: Try to deserialize raw bytes into a CompiledModule.
+    let module = match CompiledModule::deserialize_with_config(data, &config) {
+        Ok(m) => m,
+        Err(_) => return, // Invalid binary is expected; not a bug.
+    };
+
+    // Step 2: Serialize back.
+    let mut bytes1 = Vec::new();
+    if module.serialize(&mut bytes1).is_err() {
+        panic!("Module deserializes but fails to re-serialize");
+    }
+
+    // Step 3: Deserialize from re-serialized bytes.
+    let module2 = match CompiledModule::deserialize_with_config(&bytes1, &config) {
+        Ok(m) => m,
+        Err(_) => panic!("Re-serialized bytes fail to deserialize"),
+    };
+
+    // Step 4: Serialize the second module and compare bytes.
+    let mut bytes2 = Vec::new();
+    if module2.serialize(&mut bytes2).is_err() {
+        panic!("Second re-serialization failed");
+    }
+
+    if bytes1 != bytes2 {
+        panic!(
+            "Non-idempotent serialization roundtrip: first {} bytes vs second {} bytes",
+            bytes1.len(),
+            bytes2.len()
+        );
+    }
+});

--- a/crates/sui-move-fuzzer/fuzz_targets/e2e_publish_crash.rs
+++ b/crates/sui-move-fuzzer/fuzz_targets/e2e_publish_crash.rs
@@ -1,0 +1,56 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+use move_binary_format::binary_config::BinaryConfig;
+use move_binary_format::file_format::CompiledModule;
+
+use sui_move_fuzzer::authority_harness::FUZZ_AUTHORITY;
+use sui_move_fuzzer::mutators::{apply_bytes_mutation, apply_mutation, ensure_code_unit};
+use sui_move_fuzzer::oracle::check_crash;
+
+fuzz_target!(|data: &[u8]| {
+    // Step 1: Try to deserialize raw bytes into a CompiledModule.
+    let config = BinaryConfig::standard();
+    let mut module = match CompiledModule::deserialize_with_config(data, &config) {
+        Ok(m) => m,
+        Err(_) => return,
+    };
+
+    // Ensure the module has at least one function with a code unit for mutations.
+    ensure_code_unit(&mut module);
+
+    // Step 2: Apply multiple rounds of targeted mutations (2-5 rounds).
+    let entropy_len = data.len().min(512);
+    let entropy = &data[..entropy_len];
+    let mut u = arbitrary::Unstructured::new(entropy);
+
+    let rounds = match u.int_in_range(2u8..=5) {
+        Ok(r) => r,
+        Err(_) => 3,
+    };
+    for _ in 0..rounds {
+        let _ = apply_mutation(&mut u, &mut module);
+    }
+
+    // Step 3: Serialize back to bytes.
+    let mut bytes = Vec::new();
+    if module.serialize(&mut bytes).is_err() {
+        return;
+    }
+
+    // Step 4: Optionally apply a raw bytes mutation (IntegerOverflowOffset).
+    let _ = apply_bytes_mutation(&mut u, &mut bytes);
+
+    // Step 5: Publish -- the pipeline should NEVER panic on any input.
+    // Any panic here is a real bug: the validator must handle all inputs gracefully.
+    let result = check_crash("e2e_publish_crash", || {
+        FUZZ_AUTHORITY.publish_module(bytes)
+    });
+
+    if let Err(bug) = result {
+        panic!("Validator crashed on mutated input: {:?}", bug);
+    }
+});

--- a/crates/sui-move-fuzzer/fuzz_targets/e2e_publish_execute.rs
+++ b/crates/sui-move-fuzzer/fuzz_targets/e2e_publish_execute.rs
@@ -1,0 +1,89 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+#![no_main]
+
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+
+use sui_move_fuzzer::authority_harness::FUZZ_AUTHORITY;
+use sui_move_fuzzer::crash_validator::validate_crash;
+use sui_move_fuzzer::module_gen::{ModuleGenConfig, ModuleBuilder};
+use sui_move_fuzzer::mutators::{MutationKind, apply_mutation};
+use sui_move_fuzzer::oracle::{BugClass, check_crash, check_effects_for_bugs};
+
+#[derive(Debug, Arbitrary)]
+struct E2eInput {
+    config: ModuleGenConfig,
+    mutation: Option<MutationKind>,
+    raw_entropy: Vec<u8>,
+}
+
+fuzz_target!(|input: E2eInput| {
+    let mut u = arbitrary::Unstructured::new(&input.raw_entropy);
+
+    // Step 1: Generate a CompiledModule from the grammar-based builder.
+    let builder = ModuleBuilder::new(input.config);
+    let mut module = match builder.build(&mut u) {
+        Ok(m) => m,
+        Err(_) => return,
+    };
+
+    // Step 2: Optionally apply a targeted mutation.
+    if let Some(_kind) = input.mutation {
+        let _ = apply_mutation(&mut u, &mut module);
+    }
+
+    // Step 3: Serialize the module to bytes.
+    let mut bytes = Vec::new();
+    if module.serialize(&mut bytes).is_err() {
+        return;
+    }
+
+    // Step 4: Publish through the real authority, catching any panics.
+    let publish_result = check_crash("e2e_publish", || {
+        FUZZ_AUTHORITY.publish_module(bytes.clone())
+    });
+
+    match publish_result {
+        Err(bug @ BugClass::ValidatorCrash { .. }) => {
+            // A panic in publish -- validate it is a real bug, not a fuzzer artifact.
+            if validate_crash(&module, &bug) {
+                panic!("Confirmed validator crash during publish: {:?}", bug);
+            }
+            return;
+        }
+        Err(_) => return,
+        Ok(Err(_)) => {
+            // Publish returned an error (e.g., verification rejected) -- expected for
+            // mutated modules. Not a bug.
+            return;
+        }
+        Ok(Ok((package_id, effects))) => {
+            // Step 5: Check effects for invariant violations.
+            if let Some(bug) = check_effects_for_bugs(&effects) {
+                panic!("Verifier soundness bug after publish: {:?}", bug);
+            }
+
+            // Step 6: Try calling the first entry function if one exists.
+            let has_entry = module.function_defs.iter().any(|f| f.is_entry);
+            if has_entry {
+                let call_result = check_crash("e2e_call", || {
+                    FUZZ_AUTHORITY.call_entry_function(package_id, "fuzz_mod", "f0")
+                });
+                match call_result {
+                    Err(bug @ BugClass::ValidatorCrash { .. }) => {
+                        if validate_crash(&module, &bug) {
+                            panic!("Confirmed validator crash during call: {:?}", bug);
+                        }
+                    }
+                    Ok(Ok(call_effects)) => {
+                        if let Some(bug) = check_effects_for_bugs(&call_effects) {
+                            panic!("Verifier soundness bug after call: {:?}", bug);
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+});

--- a/crates/sui-move-fuzzer/fuzz_targets/ref_safety_diff.rs
+++ b/crates/sui-move-fuzzer/fuzz_targets/ref_safety_diff.rs
@@ -1,0 +1,59 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+#![no_main]
+
+use libfuzzer_sys::{fuzz_mutator, fuzz_target};
+use move_binary_format::binary_config::BinaryConfig;
+use move_binary_format::file_format::CompiledModule;
+use move_bytecode_verifier::verify_module_with_config_metered;
+use move_bytecode_verifier_meter::dummy::DummyMeter;
+use move_vm_config::verifier::VerifierConfig;
+use sui_move_fuzzer::custom_mutator::mutate_move_module;
+
+fuzz_mutator!(|data: &mut [u8], size: usize, max_size: usize, seed: u32| {
+    match mutate_move_module(data, size, max_size, seed) {
+        Some(n) => n,
+        None => libfuzzer_sys::fuzzer_mutate(data, size, max_size),
+    }
+});
+
+fuzz_target!(|data: &[u8]| {
+    let config = BinaryConfig::standard();
+    let module = match CompiledModule::deserialize_with_config(data, &config) {
+        Ok(m) => m,
+        Err(_) => return,
+    };
+
+    // Graph-based reference safety (the traditional implementation)
+    let graph_config = VerifierConfig {
+        deprecate_global_storage_ops: true,
+        switch_to_regex_reference_safety: false,
+        sanity_check_with_regex_reference_safety: None,
+        ..Default::default()
+    };
+
+    // Regex-based reference safety (the newer implementation)
+    let regex_config = VerifierConfig {
+        deprecate_global_storage_ops: true,
+        switch_to_regex_reference_safety: true,
+        sanity_check_with_regex_reference_safety: None,
+        ..Default::default()
+    };
+
+    let graph_result = verify_module_with_config_metered(&graph_config, &module, &mut DummyMeter);
+    let regex_result = verify_module_with_config_metered(&regex_config, &module, &mut DummyMeter);
+
+    if graph_result.is_ok() && regex_result.is_err() {
+        panic!(
+            "reference safety inconsistency: graph accepts, regex rejects: {}",
+            regex_result.unwrap_err()
+        );
+    }
+
+    if regex_result.is_ok() && graph_result.is_err() {
+        panic!(
+            "reference safety inconsistency: regex accepts, graph rejects: {}",
+            graph_result.unwrap_err()
+        );
+    }
+});

--- a/crates/sui-move-fuzzer/fuzz_targets/ref_safety_diff_gen.rs
+++ b/crates/sui-move-fuzzer/fuzz_targets/ref_safety_diff_gen.rs
@@ -1,0 +1,63 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+#![no_main]
+
+//! Grammar-based differential oracle for reference safety.
+//!
+//! Generates valid-by-construction modules via `ModuleBuilder` and checks that
+//! graph-based and regex-based reference safety agree. Complements the raw-binary
+//! `ref_safety_diff` target: this one explores valid module structures with complex
+//! reference patterns, while `ref_safety_diff` explores unusual binary patterns
+//! via the custom mutator.
+
+use arbitrary::Unstructured;
+use libfuzzer_sys::fuzz_target;
+use move_bytecode_verifier::verify_module_with_config_metered;
+use move_bytecode_verifier_meter::dummy::DummyMeter;
+use move_vm_config::verifier::VerifierConfig;
+use sui_move_fuzzer::module_gen::{ModuleBuilder, ModuleGenConfig};
+
+fuzz_target!(|data: &[u8]| {
+    let mut u = Unstructured::new(data);
+
+    let config: ModuleGenConfig = match u.arbitrary() {
+        Ok(c) => c,
+        Err(_) => return,
+    };
+
+    let module = match ModuleBuilder::new(config).build(&mut u) {
+        Ok(m) => m,
+        Err(_) => return,
+    };
+
+    let graph_config = VerifierConfig {
+        deprecate_global_storage_ops: true,
+        switch_to_regex_reference_safety: false,
+        sanity_check_with_regex_reference_safety: None,
+        ..Default::default()
+    };
+
+    let regex_config = VerifierConfig {
+        deprecate_global_storage_ops: true,
+        switch_to_regex_reference_safety: true,
+        sanity_check_with_regex_reference_safety: None,
+        ..Default::default()
+    };
+
+    let graph_result = verify_module_with_config_metered(&graph_config, &module, &mut DummyMeter);
+    let regex_result = verify_module_with_config_metered(&regex_config, &module, &mut DummyMeter);
+
+    if graph_result.is_ok() && regex_result.is_err() {
+        panic!(
+            "reference safety inconsistency: graph accepts, regex rejects: {}",
+            regex_result.unwrap_err()
+        );
+    }
+
+    if regex_result.is_ok() && graph_result.is_err() {
+        panic!(
+            "reference safety inconsistency: regex accepts, graph rejects: {}",
+            graph_result.unwrap_err()
+        );
+    }
+});

--- a/crates/sui-move-fuzzer/fuzz_targets/verifier_crash.rs
+++ b/crates/sui-move-fuzzer/fuzz_targets/verifier_crash.rs
@@ -1,0 +1,63 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+#![no_main]
+
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+
+use move_bytecode_verifier::verify_module_with_config_metered;
+use move_bytecode_verifier_meter::dummy::DummyMeter;
+
+use sui_move_fuzzer::module_gen::{ModuleBuilder, ModuleGenConfig};
+use sui_move_fuzzer::mutators::{MutationKind, apply_mutation};
+use sui_move_fuzzer::sui_harness::{run_full_verification, run_sui_passes_individually,
+                                    sui_verifier_config};
+
+#[derive(Debug, Arbitrary)]
+struct Input {
+    config: ModuleGenConfig,
+    mutation: Option<MutationKind>,
+    raw_entropy: Vec<u8>,
+}
+
+fuzz_target!(|input: Input| {
+    let mut u = arbitrary::Unstructured::new(&input.raw_entropy);
+
+    let builder = ModuleBuilder::new(input.config);
+    let mut module = match builder.build(&mut u) {
+        Ok(m) => m,
+        Err(_) => return,
+    };
+
+    if input.mutation.is_some() {
+        let _ = apply_mutation(&mut u, &mut module);
+    }
+
+    // Strategy 1: Full pipeline crash detection.
+    // Any panic in the full Move + Sui verification pipeline is a real bug.
+    // This is the highest-value signal.
+    run_full_verification(&module).ok();
+    // If run_full_verification panics, libfuzzer catches the signal and saves the artifact.
+    // No need for manual catch_unwind — libfuzzer's own signal handler is more reliable.
+
+    // Strategy 2: Run individual Sui passes on modules that pass Move verification.
+    // This finds Sui-specific panics that only trigger after Move's bounds/type checks pass.
+    let config = sui_verifier_config();
+    let move_ok = verify_module_with_config_metered(&config, &module, &mut DummyMeter).is_ok();
+
+    if move_ok {
+        // Module passed Move verification — now stress-test each Sui pass individually.
+        // Panics here mean the Sui verifier crashes on a module the Move verifier accepted.
+        let results = run_sui_passes_individually(&module);
+        for (pass_name, result) in results {
+            if let Err(ref err_msg) = result
+                && err_msg.contains("CRASH")
+            {
+                panic!(
+                    "Sui verifier crash on Move-valid module in {}: {}",
+                    pass_name, err_msg
+                );
+            }
+        }
+    }
+});

--- a/crates/sui-move-fuzzer/fuzz_targets/verifier_soundness.rs
+++ b/crates/sui-move-fuzzer/fuzz_targets/verifier_soundness.rs
@@ -1,0 +1,39 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+#![no_main]
+
+//! Roundtrip oracle on verified modules.
+//!
+//! Generates modules via `ModuleBuilder`, filters to those that pass full
+//! Move + Sui verification, then checks that verified modules survive
+//! serialize → deserialize → serialize idempotently. Any failure indicates the
+//! verifier accepted something the serializer disagrees about.
+
+use arbitrary::Unstructured;
+use libfuzzer_sys::fuzz_target;
+use sui_move_fuzzer::module_gen::{ModuleBuilder, ModuleGenConfig};
+use sui_move_fuzzer::sui_harness;
+
+fuzz_target!(|data: &[u8]| {
+    let mut u = Unstructured::new(data);
+
+    let config: ModuleGenConfig = match u.arbitrary() {
+        Ok(c) => c,
+        Err(_) => return,
+    };
+
+    let module = match ModuleBuilder::new(config).build(&mut u) {
+        Ok(m) => m,
+        Err(_) => return,
+    };
+
+    // Only test modules that pass full verification
+    if sui_harness::run_full_verification(&module).is_err() {
+        return;
+    }
+
+    // Verified modules must survive roundtrip
+    if let Err(e) = sui_harness::roundtrip_check(&module) {
+        panic!("Verified module fails roundtrip: {e}");
+    }
+});

--- a/crates/sui-move-fuzzer/src/authority_harness.rs
+++ b/crates/sui-move-fuzzer/src/authority_harness.rs
@@ -1,0 +1,175 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use move_core_types::identifier::Identifier;
+use once_cell::sync::Lazy;
+use sui_core::authority::authority_test_utils::submit_and_execute;
+use sui_core::authority::test_authority_builder::TestAuthorityBuilder;
+use sui_core::authority::AuthorityState;
+use sui_types::base_types::{ObjectID, ObjectRef, SuiAddress};
+use sui_types::crypto::AccountKeyPair;
+use sui_types::effects::{TransactionEffects, TransactionEffectsAPI};
+use sui_types::object::Object;
+use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
+use sui_types::transaction::{Command, TransactionData};
+use sui_types::utils::to_sender_signed_transaction;
+use sui_types::{MOVE_STDLIB_PACKAGE_ID, SUI_FRAMEWORK_PACKAGE_ID};
+
+/// Default gas balance for fuzzing gas objects.
+const FUZZ_GAS_BALANCE: u64 = 300_000_000_000_000;
+
+/// Default gas budget per transaction.
+const FUZZ_GAS_BUDGET: u64 = 500_000_000;
+
+/// Wraps a real Sui validator for end-to-end fuzz testing.
+pub struct FuzzAuthority {
+    runtime: tokio::runtime::Runtime,
+    authority: Arc<AuthorityState>,
+    sender: SuiAddress,
+    sender_key: AccountKeyPair,
+    gas_object_id: ObjectID,
+}
+
+/// Global singleton so all fuzz iterations share one authority.
+pub static FUZZ_AUTHORITY: Lazy<FuzzAuthority> = Lazy::new(FuzzAuthority::init);
+
+impl FuzzAuthority {
+    /// Build a test authority, generate a sender keypair, and insert a gas object.
+    pub fn init() -> Self {
+        let runtime = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
+        let (sender, sender_key): (SuiAddress, AccountKeyPair) =
+            sui_types::crypto::deterministic_random_account_key();
+        let gas_object_id = ObjectID::random();
+
+        let authority = runtime.block_on(async {
+            let state = TestAuthorityBuilder::new().build().await;
+            let gas_object =
+                Object::with_id_owner_gas_for_testing(gas_object_id, sender, FUZZ_GAS_BALANCE);
+            state.insert_genesis_object(gas_object).await;
+            state
+        });
+
+        FuzzAuthority {
+            runtime,
+            authority,
+            sender,
+            sender_key,
+            gas_object_id,
+        }
+    }
+
+    /// Look up the current gas object reference from the authority store.
+    fn gas_object_ref(&self) -> ObjectRef {
+        self.runtime
+            .block_on(async {
+                self.authority
+                    .get_object(&self.gas_object_id)
+                    .await
+                    .expect("gas object must exist")
+                    .compute_object_reference()
+            })
+    }
+
+    /// Reference gas price from the authority's epoch store.
+    fn reference_gas_price(&self) -> u64 {
+        self.authority
+            .reference_gas_price_for_testing()
+            .expect("rgp must be available")
+    }
+
+    /// Publish a module (as raw bytes) and return the package ObjectID and effects.
+    pub fn publish_module(
+        &self,
+        module_bytes: Vec<u8>,
+    ) -> Result<(ObjectID, TransactionEffects), String> {
+        let gas_ref = self.gas_object_ref();
+        let rgp = self.reference_gas_price();
+
+        let mut builder = ProgrammableTransactionBuilder::new();
+        builder.publish_immutable(
+            vec![module_bytes],
+            vec![MOVE_STDLIB_PACKAGE_ID, SUI_FRAMEWORK_PACKAGE_ID],
+        );
+        let pt = builder.finish();
+
+        let data = TransactionData::new_programmable(
+            self.sender,
+            vec![gas_ref],
+            pt,
+            FUZZ_GAS_BUDGET,
+            rgp,
+        );
+        let transaction = to_sender_signed_transaction(data, &self.sender_key);
+
+        let (_exec, signed_effects) = self
+            .runtime
+            .block_on(submit_and_execute(&self.authority, transaction))
+            .map_err(|e| format!("submit_and_execute failed: {e}"))?;
+
+        let effects = signed_effects.into_data();
+
+        if !effects.status().is_ok() {
+            return Err(format!("publish failed: {:?}", effects.status()));
+        }
+
+        // The first created object owned by Immutable is the package.
+        let package_id = effects
+            .created()
+            .iter()
+            .find(|(_, owner)| owner.is_immutable())
+            .map(|(obj_ref, _)| obj_ref.0)
+            .ok_or_else(|| "no immutable package object in effects".to_string())?;
+
+        Ok((package_id, effects))
+    }
+
+    /// Call an entry function with no arguments on a published package.
+    pub fn call_entry_function(
+        &self,
+        package: ObjectID,
+        module: &str,
+        function: &str,
+    ) -> Result<TransactionEffects, String> {
+        let gas_ref = self.gas_object_ref();
+        let rgp = self.reference_gas_price();
+
+        let mut builder = ProgrammableTransactionBuilder::new();
+        builder.command(Command::move_call(
+            package,
+            Identifier::new(module).map_err(|e| format!("bad module name: {e}"))?,
+            Identifier::new(function).map_err(|e| format!("bad function name: {e}"))?,
+            vec![],
+            vec![],
+        ));
+        let pt = builder.finish();
+
+        let data = TransactionData::new_programmable(
+            self.sender,
+            vec![gas_ref],
+            pt,
+            FUZZ_GAS_BUDGET,
+            rgp,
+        );
+        let transaction = to_sender_signed_transaction(data, &self.sender_key);
+
+        let (_exec, signed_effects) = self
+            .runtime
+            .block_on(submit_and_execute(&self.authority, transaction))
+            .map_err(|e| format!("submit_and_execute failed: {e}"))?;
+
+        Ok(signed_effects.into_data())
+    }
+
+    /// Create a fresh gas object for the next iteration (the old one may have been consumed
+    /// or mutated by a previous transaction).
+    pub fn refresh_gas(&mut self) {
+        let new_gas_id = ObjectID::random();
+        let gas_object =
+            Object::with_id_owner_gas_for_testing(new_gas_id, self.sender, FUZZ_GAS_BALANCE);
+        self.runtime
+            .block_on(self.authority.insert_genesis_object(gas_object));
+        self.gas_object_id = new_gas_id;
+    }
+}

--- a/crates/sui-move-fuzzer/src/bin/coverage_gaps.rs
+++ b/crates/sui-move-fuzzer/src/bin/coverage_gaps.rs
@@ -1,0 +1,160 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Standalone corpus coverage analysis tool.
+//!
+//! Analyzes the seed corpus for each fuzz target, identifies which known
+//! verifier paths have zero coverage, and prints a gap report.
+//!
+//! Usage:
+//!   cargo run --no-default-features --bin coverage_gaps
+//!   cargo run --no-default-features --bin coverage_gaps -- --corpus-dir corpus/verifier_crash
+//!   cargo run --no-default-features --bin coverage_gaps -- --json
+
+use std::path::PathBuf;
+
+use sui_move_fuzzer::coverage_gaps::{analyze_corpus, identify_gaps};
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+
+    let mut corpus_dirs: Vec<PathBuf> = Vec::new();
+    let mut json_output = false;
+    let mut i = 1;
+
+    while i < args.len() {
+        match args[i].as_str() {
+            "--corpus-dir" if i + 1 < args.len() => {
+                i += 1;
+                corpus_dirs.push(PathBuf::from(&args[i]));
+            }
+            "--json" => json_output = true,
+            other if !other.starts_with("--") => {
+                corpus_dirs.push(PathBuf::from(other));
+            }
+            other => eprintln!("unknown flag: {other}"),
+        }
+        i += 1;
+    }
+
+    // Default: analyze all known corpus directories.
+    if corpus_dirs.is_empty() {
+        let known = [
+            "corpus/verifier_crash",
+            "corpus/ref_safety_diff",
+            "corpus/ref_safety_diff_gen",
+            "corpus/deser_roundtrip",
+            "corpus/bounds_escape",
+            "corpus/verifier_soundness",
+        ];
+        for dir in &known {
+            let p = PathBuf::from(dir);
+            if p.exists() {
+                corpus_dirs.push(p);
+            }
+        }
+        if corpus_dirs.is_empty() {
+            eprintln!("No corpus directories found. Run gen_corpus first or pass --corpus-dir.");
+            std::process::exit(1);
+        }
+    }
+
+    // Merge reports from all specified directories.
+    let mut merged = sui_move_fuzzer::coverage_gaps::CorpusCoverageReport::default();
+
+    for dir in &corpus_dirs {
+        if !dir.exists() {
+            eprintln!("warning: corpus dir {} does not exist, skipping", dir.display());
+            continue;
+        }
+        println!("Analyzing {}...", dir.display());
+        let report = analyze_corpus(dir);
+        merged.total_seeds += report.total_seeds;
+        merged.bounds_passing += report.bounds_passing;
+        merged.move_passing += report.move_passing;
+        merged.sui_passing += report.sui_passing;
+        for (k, v) in report.error_code_counts {
+            *merged.error_code_counts.entry(k).or_insert(0) += v;
+        }
+        merged.sui_pass_hit.extend(report.sui_pass_hit);
+    }
+
+    let gaps = identify_gaps(&merged);
+
+    if json_output {
+        print_json_report(&merged, &gaps);
+    } else {
+        print_text_report(&merged, &gaps);
+    }
+}
+
+fn print_text_report(
+    report: &sui_move_fuzzer::coverage_gaps::CorpusCoverageReport,
+    gaps: &[sui_move_fuzzer::coverage_gaps::CoverageGap],
+) {
+    println!();
+    println!("=== Corpus Coverage Report ===");
+    println!("  Total seeds analyzed : {}", report.total_seeds);
+    println!("  Bounds-passing       : {}", report.bounds_passing);
+    println!("  Move-verify passing  : {}", report.move_passing);
+    println!("  Sui-verify passing   : {}", report.sui_passing);
+
+    if !report.error_code_counts.is_empty() {
+        println!();
+        println!("Move verifier error breakdown:");
+        let mut codes: Vec<_> = report.error_code_counts.iter().collect();
+        codes.sort_by(|a, b| b.1.cmp(a.1));
+        for (code, count) in codes.iter().take(20) {
+            println!("  {:5}  {}", count, code);
+        }
+        if codes.len() > 20 {
+            println!("  ... and {} more", codes.len() - 20);
+        }
+    }
+
+    println!();
+    if gaps.is_empty() {
+        println!("All known verifier paths have corpus coverage.");
+    } else {
+        println!("Coverage gaps ({} uncovered paths):", gaps.len());
+        for gap in gaps {
+            println!();
+            println!("  [GAP] {}", gap.summary());
+            println!("        hint: {}", &gap.llm_hint[..gap.llm_hint.len().min(120)]);
+        }
+        println!();
+        println!(
+            "Run 'cargo run --features llm-guided --bin llm_seed_gen' to generate seeds for these gaps."
+        );
+    }
+}
+
+fn print_json_report(
+    report: &sui_move_fuzzer::coverage_gaps::CorpusCoverageReport,
+    gaps: &[sui_move_fuzzer::coverage_gaps::CoverageGap],
+) {
+    let gaps_json: Vec<serde_json::Value> = gaps
+        .iter()
+        .map(|g| {
+            serde_json::json!({
+                "id": g.path_id,
+                "description": g.description,
+                "pass": format!("{:?}", g.pass),
+                "error_code": g.error_code.map(|c| format!("{:?}", c)),
+                "hint": g.llm_hint,
+                "source_file": g.source_context_file,
+            })
+        })
+        .collect();
+
+    let output = serde_json::json!({
+        "total_seeds": report.total_seeds,
+        "bounds_passing": report.bounds_passing,
+        "move_passing": report.move_passing,
+        "sui_passing": report.sui_passing,
+        "error_code_counts": report.error_code_counts,
+        "coverage_gaps": gaps_json,
+    });
+
+    println!("{}", serde_json::to_string_pretty(&output).unwrap());
+}

--- a/crates/sui-move-fuzzer/src/bin/fork_main.rs
+++ b/crates/sui-move-fuzzer/src/bin/fork_main.rs
@@ -1,0 +1,317 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Forked-execution mode entry point.
+//!
+//! Runs the fuzzer's module-generation and mutation engine against real Sui
+//! network state fetched lazily from an RPC node.  Oracle price objects can be
+//! overridden so that adversarial modules see manipulated prices.
+//!
+//! # Usage
+//!
+//! ```text
+//! cargo run --features fork --bin fork_main -- \
+//!     --fork-rpc https://fullnode.mainnet.sui.io:443 \
+//!     --oracle-override 0x<price_feed_id>:500000000 \
+//!     --chain mainnet \
+//!     -c ./corpus \
+//!     -d ./findings \
+//!     -p 20
+//! ```
+//!
+//! # Flags
+//!
+//! | Flag | Default | Description |
+//! |------|---------|-------------|
+//! | `--fork-rpc URL` | (required) | RPC endpoint to fetch live chain state from |
+//! | `--chain mainnet\|testnet` | `mainnet` | Network chain ID for protocol config |
+//! | `--oracle-override ID:PRICE` | none | Override an oracle price object (repeatable) |
+//! | `-c DIR` | `./corpus` | Corpus directory for generated inputs |
+//! | `-d DIR` | `./findings` | Output directory for bug reports |
+//! | `-p N` | `100` | Number of iterations to run |
+//! | `--seed N` | random | RNG seed for reproducible runs |
+//! | `-v` | off | Verbose output |
+
+use std::path::PathBuf;
+
+use rand::SeedableRng;
+use sui_move_fuzzer::{
+    forked_executor::ForkedExecutor,
+    module_gen::{ModuleBuilder, ModuleGenConfig},
+    oracle,
+    oracle_override::{apply_price_override, build_price_patches, parse_override_spec, PriceOverride},
+};
+use sui_protocol_config::Chain;
+use sui_types::effects::TransactionEffectsAPI;
+use sui_types::MOVE_STDLIB_PACKAGE_ID;
+use sui_types::SUI_FRAMEWORK_PACKAGE_ID;
+
+fn main() {
+    let config = match Config::from_args() {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("error: {e}");
+            eprintln!("{}", USAGE);
+            std::process::exit(1);
+        }
+    };
+
+    if let Err(e) = run(config) {
+        eprintln!("fatal: {e}");
+        std::process::exit(1);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Driver
+// ---------------------------------------------------------------------------
+
+fn run(config: Config) -> anyhow::Result<()> {
+    eprintln!(
+        "[fork_main] connecting to {} (chain={:?})",
+        config.fork_rpc, config.chain
+    );
+
+    let mut exec = ForkedExecutor::new(&config.fork_rpc, config.chain)?;
+
+    // Apply oracle price overrides.
+    for (oracle_id, price) in &config.oracle_overrides {
+        if config.verbose {
+            eprintln!("[fork_main] override oracle {oracle_id} → price={price}");
+        }
+        let spec = PriceOverride {
+            oracle_object_id: *oracle_id,
+            price: *price,
+            confidence: None,
+            exponent: None,
+        };
+        let patches = build_price_patches(&spec);
+        apply_price_override(exec.store_mut(), &spec, &patches)?;
+    }
+
+    std::fs::create_dir_all(&config.corpus_dir)?;
+    std::fs::create_dir_all(&config.findings_dir)?;
+
+    // Seed the RNG — print it so any run can be reproduced with `--seed`.
+    let seed = config
+        .seed
+        .unwrap_or_else(|| rand::Rng::r#gen(&mut rand::thread_rng()));
+    eprintln!("[fork_main] seed={seed}");
+    let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
+
+    let mut bugs_found = 0usize;
+    let dep_ids = vec![MOVE_STDLIB_PACKAGE_ID, SUI_FRAMEWORK_PACKAGE_ID];
+
+    eprintln!("[fork_main] running {} iterations", config.iterations);
+
+    for iter in 0..config.iterations {
+        // Generate a module using the grammar-based builder with random config.
+        let gen_config = random_gen_config(&mut rng);
+        // Use a local Vec<u8> to avoid leaking memory on every iteration.
+        let entropy: Vec<u8> =
+            (0..1024).map(|_| rand::Rng::r#gen::<u8>(&mut rng)).collect();
+        let mut u = arbitrary::Unstructured::new(&entropy);
+        let module = match ModuleBuilder::new(gen_config.clone()).build(&mut u) {
+            Ok(m) => m,
+            Err(_) => continue, // arbitrary ran out of data — skip
+        };
+
+        // Extract the module name before serializing so we can call entry fns.
+        let self_handle =
+            &module.module_handles[module.self_module_handle_idx.0 as usize];
+        let module_name =
+            module.identifiers[self_handle.name.0 as usize].as_str().to_string();
+
+        let mut module_bytes = Vec::new();
+        if module.serialize(&mut module_bytes).is_err() {
+            continue;
+        }
+
+        // Call the first entry function (named "f0") when the generated module
+        // has one — this surfaces runtime bugs that only appear during execution.
+        let function_calls: Vec<(&str, &str)> = if gen_config.has_entry_fn {
+            vec![(module_name.as_str(), "f0")]
+        } else {
+            vec![]
+        };
+
+        // Wrap execution in catch_unwind to catch validator panics.
+        let call_result = oracle::check_crash("fork_exec", || {
+            exec.publish_and_call(module_bytes.clone(), dep_ids.clone(), &function_calls)
+        });
+
+        match call_result {
+            Ok(Ok(result)) => {
+                if config.verbose {
+                    eprintln!("[iter {iter}] status: {:?}", result.effects.status());
+                }
+                // Delegate invariant-violation detection to the shared oracle.
+                if let Some(bug) = oracle::check_effects_for_bugs(&result.effects) {
+                    bugs_found += 1;
+                    let finding_path = config
+                        .findings_dir
+                        .join(format!("fork-invariant-{iter}.bin"));
+                    std::fs::write(&finding_path, &module_bytes)?;
+                    eprintln!(
+                        "[fork_main] BUG FOUND (iter {iter}): {:?} — saved to {}",
+                        bug,
+                        finding_path.display()
+                    );
+                }
+            }
+            Ok(Err(e)) => {
+                if config.verbose {
+                    eprintln!("[iter {iter}] exec error: {e}");
+                }
+            }
+            Err(bug) => {
+                // Executor panicked — save the triggering module as a finding.
+                bugs_found += 1;
+                let finding_path =
+                    config.findings_dir.join(format!("fork-panic-{iter}.bin"));
+                std::fs::write(&finding_path, &module_bytes)?;
+                eprintln!(
+                    "[fork_main] PANIC (iter {iter}): {:?} — saved to {}",
+                    bug,
+                    finding_path.display()
+                );
+            }
+        }
+    }
+
+    eprintln!(
+        "[fork_main] done — {} iterations, {} bugs found",
+        config.iterations, bugs_found
+    );
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Config and arg parsing
+// ---------------------------------------------------------------------------
+
+struct Config {
+    fork_rpc: String,
+    chain: Chain,
+    oracle_overrides: Vec<(sui_types::base_types::ObjectID, i64)>,
+    corpus_dir: PathBuf,
+    findings_dir: PathBuf,
+    iterations: usize,
+    seed: Option<u64>,
+    verbose: bool,
+}
+
+const USAGE: &str = "\
+Usage: fork_main [OPTIONS]
+
+Required:
+  --fork-rpc URL              RPC endpoint for live chain state
+
+Optional:
+  --chain mainnet|testnet     Chain (default: mainnet)
+  --oracle-override ID:PRICE  Override oracle price, repeatable
+  -c DIR                      Corpus directory (default: ./corpus)
+  -d DIR                      Findings directory (default: ./findings)
+  -p N                        Number of iterations (default: 100)
+  --seed N                    RNG seed for reproducible runs (default: random)
+  -v                          Verbose output
+  -h, --help                  Show this message";
+
+impl Config {
+    fn from_args() -> anyhow::Result<Self> {
+        let args: Vec<String> = std::env::args().skip(1).collect();
+        let mut fork_rpc: Option<String> = None;
+        let mut chain = Chain::Mainnet;
+        let mut oracle_overrides = Vec::new();
+        let mut corpus_dir = PathBuf::from("./corpus");
+        let mut findings_dir = PathBuf::from("./findings");
+        let mut iterations: usize = 100;
+        let mut seed: Option<u64> = None;
+        let mut verbose = false;
+
+        let mut i = 0;
+        while i < args.len() {
+            match args[i].as_str() {
+                "--fork-rpc" => {
+                    i += 1;
+                    fork_rpc = Some(next_arg(&args, i, "--fork-rpc")?);
+                }
+                "--chain" => {
+                    i += 1;
+                    let s = next_arg(&args, i, "--chain")?;
+                    chain = match s.as_str() {
+                        "mainnet" => Chain::Mainnet,
+                        "testnet" => Chain::Testnet,
+                        other => anyhow::bail!("unknown chain '{other}', use mainnet or testnet"),
+                    };
+                }
+                "--oracle-override" => {
+                    i += 1;
+                    let s = next_arg(&args, i, "--oracle-override")?;
+                    oracle_overrides.push(parse_override_spec(&s)?);
+                }
+                "-c" => {
+                    i += 1;
+                    corpus_dir = PathBuf::from(next_arg(&args, i, "-c")?);
+                }
+                "-d" => {
+                    i += 1;
+                    findings_dir = PathBuf::from(next_arg(&args, i, "-d")?);
+                }
+                "-p" => {
+                    i += 1;
+                    let s = next_arg(&args, i, "-p")?;
+                    iterations = s
+                        .parse()
+                        .map_err(|_| anyhow::anyhow!("-p requires a positive integer, got '{s}'"))?;
+                }
+                "--seed" => {
+                    i += 1;
+                    let s = next_arg(&args, i, "--seed")?;
+                    seed = Some(
+                        s.parse()
+                            .map_err(|_| anyhow::anyhow!("--seed requires a u64, got '{s}'"))?,
+                    );
+                }
+                "-v" => verbose = true,
+                "-h" | "--help" => {
+                    println!("{USAGE}");
+                    std::process::exit(0);
+                }
+                unknown => anyhow::bail!("unknown flag '{unknown}'\n{USAGE}"),
+            }
+            i += 1;
+        }
+
+        let fork_rpc = fork_rpc.ok_or_else(|| anyhow::anyhow!("--fork-rpc is required"))?;
+
+        Ok(Config {
+            fork_rpc,
+            chain,
+            oracle_overrides,
+            corpus_dir,
+            findings_dir,
+            iterations,
+            seed,
+            verbose,
+        })
+    }
+}
+
+fn next_arg(args: &[String], i: usize, flag: &str) -> anyhow::Result<String> {
+    args.get(i)
+        .cloned()
+        .ok_or_else(|| anyhow::anyhow!("{flag} requires an argument"))
+}
+
+fn random_gen_config(rng: &mut impl rand::Rng) -> ModuleGenConfig {
+    ModuleGenConfig {
+        num_structs: rng.gen_range(0..=6),
+        num_functions: rng.gen_range(1..=6),
+        num_fields_per: rng.gen_range(0..=4),
+        max_code_len: rng.gen_range(4..=48),
+        has_key_struct: rand::Rng::r#gen::<bool>(rng),
+        has_entry_fn: rand::Rng::r#gen::<bool>(rng),
+    }
+}

--- a/crates/sui-move-fuzzer/src/bin/fuzz_loop.rs
+++ b/crates/sui-move-fuzzer/src/bin/fuzz_loop.rs
@@ -1,0 +1,757 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Continuous autonomous fuzz loop for the Sui Move VM fuzzer.
+//!
+//! Combines coverage gap analysis, LLM-guided seed generation, and fuzzer
+//! execution into a single long-running process that runs unattended for
+//! 5-10 hours, finding real verifier crashes/bypasses.
+//!
+//! Performance design:
+//!   - Fuzzer uses `-jobs=N -workers=N` (all available cores).
+//!   - LLM calls for all gaps fire in parallel (one thread per gap).
+//!   - Fuzzer subprocess and LLM generation run concurrently; seeds land in
+//!     the corpus while the fuzzer is already running, ready for the next round.
+//!
+//! Usage:
+//!   # Full autonomous run (10 hours):
+//!   OPENROUTER_API_KEY=sk-or-... cargo run --features llm-guided --bin fuzz_loop
+//!
+//!   # Dry test: no LLM, 2-minute global timeout, 60s fuzz window:
+//!   cargo run --features llm-guided --bin fuzz_loop -- --no-llm --timeout 120 --fuzz-time 60
+//!
+//!   # Custom parallelism:
+//!   OPENROUTER_API_KEY=sk-or-... cargo run --features llm-guided --bin fuzz_loop -- \
+//!       --jobs 8 --timeout 36000 --fuzz-time 600 --seeds-per-round 5 --keep-going
+
+use std::collections::HashSet;
+use std::fs;
+use std::panic::{AssertUnwindSafe, catch_unwind};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command};
+use std::thread;
+use std::time::Instant;
+
+use arbitrary::{Arbitrary, Unstructured};
+use move_binary_format::binary_config::BinaryConfig;
+use move_binary_format::file_format::CompiledModule;
+use move_bytecode_verifier::verify_module_with_config_metered;
+use move_bytecode_verifier_meter::dummy::DummyMeter;
+use sui_move_fuzzer::coverage_gaps::{CoverageGap, VerifierPass, analyze_corpus, identify_gaps};
+use sui_move_fuzzer::llm_client::call_llm_api;
+use sui_move_fuzzer::llm_prompts::{build_retry_prompt, build_seed_gen_prompt, extract_json};
+use sui_move_fuzzer::module_gen::{ModuleBuilder, ModuleGenConfig};
+use sui_move_fuzzer::module_spec::{ModuleSpec, ModuleSpecBuilder};
+use sui_move_fuzzer::mutators::{MutationKind, apply_mutation};
+use sui_move_fuzzer::sui_harness;
+
+// ─── CLI ─────────────────────────────────────────────────────────────────────
+
+struct Config {
+    target: String,
+    timeout: u64,
+    fuzz_time: u64,
+    seeds_per_round: usize,
+    max_attempts: usize,
+    /// Parallel fuzzer workers (`-jobs=N -workers=N` passed to libfuzzer).
+    jobs: usize,
+    model: String,
+    api_url: String,
+    source_root: PathBuf,
+    keep_going: bool,
+    no_llm: bool,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        // Leave one core free for the fuzz_loop process itself.
+        let parallelism = thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(4)
+            .saturating_sub(1)
+            .max(1);
+        Self {
+            target: "verifier_crash".to_string(),
+            timeout: 36000,
+            fuzz_time: 600,
+            seeds_per_round: 3,
+            max_attempts: 3,
+            jobs: parallelism,
+            model: "anthropic/claude-opus-4-6".to_string(),
+            api_url: "https://openrouter.ai/api/v1/chat/completions".to_string(),
+            source_root: PathBuf::from("../../"),
+            keep_going: false,
+            no_llm: false,
+        }
+    }
+}
+
+fn parse_args() -> Config {
+    let args: Vec<String> = std::env::args().collect();
+    let mut cfg = Config::default();
+    let mut i = 1;
+
+    while i < args.len() {
+        match args[i].as_str() {
+            "--target" if i + 1 < args.len() => {
+                i += 1;
+                cfg.target = args[i].clone();
+            }
+            "--timeout" if i + 1 < args.len() => {
+                i += 1;
+                cfg.timeout = args[i].parse().expect("timeout must be a number");
+            }
+            "--fuzz-time" if i + 1 < args.len() => {
+                i += 1;
+                cfg.fuzz_time = args[i].parse().expect("fuzz-time must be a number");
+            }
+            "--seeds-per-round" if i + 1 < args.len() => {
+                i += 1;
+                cfg.seeds_per_round = args[i].parse().expect("seeds-per-round must be a number");
+            }
+            "--max-attempts" if i + 1 < args.len() => {
+                i += 1;
+                cfg.max_attempts = args[i].parse().expect("max-attempts must be a number");
+            }
+            "--jobs" if i + 1 < args.len() => {
+                i += 1;
+                cfg.jobs = args[i].parse().expect("jobs must be a number");
+            }
+            "--model" if i + 1 < args.len() => {
+                i += 1;
+                cfg.model = args[i].clone();
+            }
+            "--api-url" if i + 1 < args.len() => {
+                i += 1;
+                cfg.api_url = args[i].clone();
+            }
+            "--source-root" if i + 1 < args.len() => {
+                i += 1;
+                cfg.source_root = PathBuf::from(&args[i]);
+            }
+            "--keep-going" => cfg.keep_going = true,
+            "--no-llm" => cfg.no_llm = true,
+            "--help" | "-h" => {
+                print_usage();
+                std::process::exit(0);
+            }
+            other => eprintln!("unknown flag: {other}"),
+        }
+        i += 1;
+    }
+
+    cfg
+}
+
+fn print_usage() {
+    println!(
+        "Usage: fuzz_loop [OPTIONS]
+
+  --target <NAME>         Fuzz target name (default: verifier_crash)
+  --timeout <SECS>        Global timeout in seconds (default: 36000 = 10 hours)
+  --fuzz-time <SECS>      Fuzzer time per round in seconds (default: 600 = 10 min)
+  --seeds-per-round <N>   Max gaps to target per LLM round (default: 3)
+  --max-attempts <N>      Max LLM retries per gap (default: 3)
+  --jobs <N>              Parallel fuzzer workers (default: num_cpus - 1)
+  --model <MODEL>         LLM model (default: anthropic/claude-opus-4-6)
+  --api-url <URL>         API endpoint (default: OpenRouter)
+  --source-root <PATH>    Repo root for verifier source context (default: ../../)
+  --keep-going            Don't stop on first crash, keep fuzzing
+  --no-llm                Skip LLM seed generation, just loop the fuzzer
+
+Environment:
+  OPENROUTER_API_KEY      API key for LLM calls (required unless --no-llm)
+"
+    );
+}
+
+// ─── Fuzz input mirror (matches verifier_crash fuzz target's Input struct) ────
+
+/// Mirrors the `Input` struct in fuzz_targets/verifier_crash.rs so crash
+/// artifacts can be reproduced for validation without spawning a subprocess.
+#[derive(Arbitrary)]
+struct FuzzInput {
+    config: ModuleGenConfig,
+    mutation: Option<MutationKind>,
+    raw_entropy: Vec<u8>,
+}
+
+// ─── LLM seed generation ──────────────────────────────────────────────────────
+
+struct SeedGenResult {
+    api_calls: usize,
+    saved: usize,
+    /// Per-gap messages collected during the parallel run, printed after joining.
+    log: Vec<String>,
+}
+
+/// Attempt to generate a seed for a single coverage gap (sequential retry loop).
+/// Returns a `SeedGenResult` with api_calls, saved count, and log lines.
+fn attempt_gap(
+    api_key: &str,
+    model: &str,
+    api_url: &str,
+    source_root: &Path,
+    max_attempts: usize,
+    gap: &CoverageGap,
+    corpus_dir: &Path,
+) -> SeedGenResult {
+    let mut api_calls = 0usize;
+    let mut saved = 0usize;
+    let mut log = Vec::new();
+    let source_context = load_source_context(source_root, gap.source_context_file);
+    let mut last_spec_json = String::new();
+    let mut last_error = String::new();
+
+    for attempt in 1..=max_attempts {
+        let prompt = if attempt == 1 {
+            build_seed_gen_prompt(gap, &source_context)
+        } else {
+            build_retry_prompt(gap, &last_spec_json, &last_error)
+        };
+
+        api_calls += 1;
+        let response = match call_llm_api(api_key, model, api_url, &prompt) {
+            Ok(r) => r,
+            Err(e) => {
+                last_error = format!("API call failed: {e}");
+                log.push(format!("  [{}] attempt {attempt}: API error: {e}", gap.path_id));
+                continue;
+            }
+        };
+
+        let spec_json = match extract_json(&response) {
+            Some(j) => j.to_string(),
+            None => {
+                last_error = "Response contained no ```json block".to_string();
+                last_spec_json = response[..response.len().min(200)].to_string();
+                log.push(format!("  [{}] attempt {attempt}: no JSON in response", gap.path_id));
+                continue;
+            }
+        };
+        last_spec_json = spec_json.clone();
+
+        let spec: ModuleSpec = match serde_json::from_str(&spec_json) {
+            Ok(s) => s,
+            Err(e) => {
+                last_error = format!("JSON parse error: {e}");
+                log.push(format!("  [{}] attempt {attempt}: JSON error: {e}", gap.path_id));
+                continue;
+            }
+        };
+
+        let module = match ModuleSpecBuilder::build(&spec) {
+            Ok(m) => m,
+            Err(e) => {
+                last_error = format!("ModuleSpec builder error: {e}");
+                log.push(format!("  [{}] attempt {attempt}: build error: {e}", gap.path_id));
+                continue;
+            }
+        };
+
+        let mut bytes = Vec::new();
+        if let Err(e) = module.serialize(&mut bytes) {
+            last_error = format!("Serialization error: {e:?}");
+            log.push(format!("  [{}] attempt {attempt}: serialize error: {e:?}", gap.path_id));
+            continue;
+        }
+
+        let config = BinaryConfig::standard();
+        if let Err(e) = CompiledModule::deserialize_with_config(&bytes, &config) {
+            last_error = format!("Bounds check failed: {e:?}");
+            log.push(format!(
+                "  [{}] attempt {attempt}: bounds check failed: {e:?}",
+                gap.path_id
+            ));
+            continue;
+        }
+
+        let verify_result = sui_harness::run_full_verification(&module);
+        if !check_reaches_target(&verify_result, gap) {
+            let why = match &verify_result {
+                Ok(()) => "module passed full verification".to_string(),
+                Err(e) => format!("wrong error: {}", &e[..e.len().min(80)]),
+            };
+            last_error = format!("does not reach target gap — {why}");
+            last_spec_json = spec_json;
+            log.push(format!("  [{}] attempt {attempt}: ✗ {}", gap.path_id, last_error));
+            continue;
+        }
+
+        let filename = format!("llm_{}_{:04}.bin", gap.path_id, saved);
+        let out_path = corpus_dir.join(&filename);
+        if let Err(e) = fs::write(&out_path, &bytes) {
+            log.push(format!(
+                "  [{}] attempt {attempt}: failed to write seed: {e}",
+                gap.path_id
+            ));
+        } else {
+            log.push(format!(
+                "  [{}] ✓ saved {} ({attempt} attempt(s))",
+                gap.path_id, filename
+            ));
+            saved += 1;
+        }
+        break;
+    }
+
+    if saved == 0 && log.last().map(|l| !l.contains('✓')).unwrap_or(true) {
+        log.push(format!(
+            "  [{}] gave up after {max_attempts} attempt(s): {}",
+            gap.path_id, last_error
+        ));
+    }
+
+    SeedGenResult { api_calls, saved, log }
+}
+
+/// Fire one thread per gap (up to `seeds_per_round`), collect and return
+/// aggregated results. Returns immediately when all threads finish.
+fn generate_seeds_parallel(
+    api_key: &str,
+    model: &str,
+    api_url: &str,
+    source_root: &Path,
+    max_attempts: usize,
+    seeds_per_round: usize,
+    gaps: &[CoverageGap],
+    corpus_dir: &Path,
+) -> SeedGenResult {
+    let handles: Vec<_> = gaps
+        .iter()
+        .take(seeds_per_round)
+        .map(|gap| {
+            // Clone all data needed by the thread.
+            let api_key = api_key.to_string();
+            let model = model.to_string();
+            let api_url = api_url.to_string();
+            let source_root = source_root.to_path_buf();
+            let corpus_dir = corpus_dir.to_path_buf();
+            let gap = gap.clone();
+
+            thread::spawn(move || {
+                attempt_gap(
+                    &api_key,
+                    &model,
+                    &api_url,
+                    &source_root,
+                    max_attempts,
+                    &gap,
+                    &corpus_dir,
+                )
+            })
+        })
+        .collect();
+
+    let mut total = SeedGenResult { api_calls: 0, saved: 0, log: Vec::new() };
+    for h in handles {
+        match h.join() {
+            Ok(r) => {
+                total.api_calls += r.api_calls;
+                total.saved += r.saved;
+                total.log.extend(r.log);
+            }
+            Err(_) => total.log.push("  [LLM] thread panicked".to_string()),
+        }
+    }
+    total
+}
+
+// ─── Fuzzer subprocess ────────────────────────────────────────────────────────
+
+/// Spawn `cargo +nightly fuzz run` and return the child process handle
+/// without waiting. Uses `-jobs=N -workers=N` for parallel execution and
+/// includes the dictionary for richer mutations.
+fn spawn_fuzzer(crate_dir: &Path, target: &str, fuzz_time: u64, jobs: usize) -> Option<Child> {
+    let corpus = format!("corpus/{target}");
+    let artifact_prefix = format!("-artifact_prefix=artifacts/{target}/");
+    let max_time = format!("-max_total_time={fuzz_time}");
+    let jobs_flag = format!("-jobs={jobs}");
+    let workers_flag = format!("-workers={jobs}");
+    let dict = format!("-dict={}", crate_dir.join("dictionaries/move_bytecode.dict").display());
+
+    match Command::new("cargo")
+        .args([
+            "+nightly",
+            "fuzz",
+            "run",
+            "--fuzz-dir",
+            crate_dir.to_str().unwrap_or("."),
+            "--no-default-features",
+            target,
+            &corpus,
+            "--",
+            &artifact_prefix,
+            "-print_final_stats=1",
+            &max_time,
+            &jobs_flag,
+            &workers_flag,
+            &dict,
+        ])
+        .current_dir(crate_dir)
+        .spawn()
+    {
+        Ok(child) => Some(child),
+        Err(e) => {
+            eprintln!("  [Fuzzer] Failed to spawn subprocess: {e}");
+            None
+        }
+    }
+}
+
+// ─── Crash scanning and validation ───────────────────────────────────────────
+
+/// List all crash artifact files in `dir` (files whose names start with `crash-`).
+fn list_crash_artifacts(dir: &Path) -> HashSet<PathBuf> {
+    let mut files = HashSet::new();
+    if let Ok(entries) = fs::read_dir(dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if let Some(name) = path.file_name().and_then(|n| n.to_str())
+                && (name.starts_with("crash-") || name.starts_with("leak-"))
+            {
+                files.insert(path);
+            }
+        }
+    }
+    files
+}
+
+/// Try to reproduce a crash artifact by mirroring the fuzz target's logic.
+///
+/// Returns the artifact file name on confirmed panic, `None` if the crash
+/// does not reproduce (e.g., a fuzzer metadata artifact or a fluke).
+fn validate_artifact(artifact_path: &Path) -> Option<String> {
+    let bytes = match fs::read(artifact_path) {
+        Ok(b) => b,
+        Err(e) => {
+            eprintln!("    Could not read artifact {}: {e}", artifact_path.display());
+            return None;
+        }
+    };
+
+    // Decode using the same Arbitrary layout as the fuzz target's Input struct.
+    let mut u = Unstructured::new(&bytes);
+    let input = match FuzzInput::arbitrary(&mut u) {
+        Ok(i) => i,
+        Err(_) => return None,
+    };
+
+    let mut u2 = Unstructured::new(&input.raw_entropy);
+    let builder = ModuleBuilder::new(input.config);
+    let mut module = match builder.build(&mut u2) {
+        Ok(m) => m,
+        Err(_) => return None,
+    };
+
+    if input.mutation.is_some() {
+        let mut u3 = Unstructured::new(&input.raw_entropy);
+        let _ = apply_mutation(&mut u3, &mut module);
+    }
+
+    // Run the same pipeline as the fuzz target under catch_unwind.
+    let panicked = catch_unwind(AssertUnwindSafe(|| {
+        sui_harness::run_full_verification(&module).ok();
+
+        let config = sui_harness::sui_verifier_config();
+        let move_ok =
+            verify_module_with_config_metered(&config, &module, &mut DummyMeter).is_ok();
+
+        if move_ok {
+            let results = sui_harness::run_sui_passes_individually(&module);
+            for (pass_name, result) in results {
+                if let Err(ref err_msg) = result
+                    && err_msg.contains("CRASH")
+                {
+                    panic!("Sui verifier crash in {}: {}", pass_name, err_msg);
+                }
+            }
+        }
+    }))
+    .is_err();
+
+    if panicked {
+        let name = artifact_path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("unknown")
+            .to_string();
+        Some(name)
+    } else {
+        None
+    }
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+fn count_files(dir: &Path) -> usize {
+    fs::read_dir(dir)
+        .map(|entries| entries.flatten().count())
+        .unwrap_or(0)
+}
+
+fn load_source_context(source_root: &Path, relative_path: &str) -> String {
+    let full_path = source_root.join(relative_path);
+    match fs::read_to_string(&full_path) {
+        Ok(content) => {
+            if content.len() > 8000 {
+                format!("{}... (truncated)", &content[..8000])
+            } else {
+                content
+            }
+        }
+        Err(_) => String::new(),
+    }
+}
+
+fn check_reaches_target(verify_result: &Result<(), String>, gap: &CoverageGap) -> bool {
+    match verify_result {
+        Ok(()) => false,
+        Err(e) => {
+            if let Some(code) = gap.error_code {
+                e.contains(&format!("{:?}", code))
+            } else {
+                let pass_name = match gap.pass {
+                    VerifierPass::SuiStructWithKey => "struct_with_key",
+                    VerifierPass::SuiIdLeak => "id_leak",
+                    VerifierPass::SuiEntryPoints => "entry_points",
+                    _ => "",
+                };
+                !pass_name.is_empty() && e.contains(pass_name)
+            }
+        }
+    }
+}
+
+/// Ensure the corpus directory exists, running gen_corpus if needed.
+fn ensure_corpus(crate_dir: &Path, target: &str) {
+    let corpus_dir = crate_dir.join(format!("corpus/{target}"));
+    if !corpus_dir.exists() {
+        println!("[*] Corpus missing — running gen_corpus...");
+        let status = Command::new("cargo")
+            .args(["run", "--bin", "gen_corpus"])
+            .current_dir(crate_dir)
+            .status();
+        match status {
+            Ok(s) if s.success() => println!("[*] Corpus generated."),
+            Ok(s) => eprintln!("[!] gen_corpus exited with: {s}"),
+            Err(e) => eprintln!("[!] Failed to run gen_corpus: {e}"),
+        }
+    }
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────────
+
+fn main() {
+    let cfg = parse_args();
+
+    let api_key: Option<String> = if cfg.no_llm {
+        None
+    } else {
+        std::env::var("OPENROUTER_API_KEY").ok()
+    };
+
+    if !cfg.no_llm && api_key.is_none() {
+        eprintln!(
+            "[!] OPENROUTER_API_KEY not set — LLM seed generation disabled.\n    \
+             Set the variable or pass --no-llm to suppress this warning."
+        );
+    }
+
+    let crate_dir = std::env::current_dir().expect("could not determine working directory");
+    let corpus_dir = crate_dir.join(format!("corpus/{}", cfg.target));
+    let artifact_dir = crate_dir.join(format!("artifacts/{}", cfg.target));
+
+    ensure_corpus(&crate_dir, &cfg.target);
+    fs::create_dir_all(&artifact_dir).expect("create artifact dir");
+
+    let sep = "=".repeat(70);
+    println!("\n{sep}");
+    println!("  sui-move-fuzzer :: continuous fuzz loop");
+    println!("  Target    : {}", cfg.target);
+    println!(
+        "  Timeout   : {}s ({:.1}h)",
+        cfg.timeout,
+        cfg.timeout as f64 / 3600.0
+    );
+    println!("  Fuzz/round: {}s  |  Workers: {}", cfg.fuzz_time, cfg.jobs);
+    match &api_key {
+        Some(key) => println!(
+            "  LLM       : {} (key ...{})",
+            cfg.model,
+            &key[key.len().saturating_sub(4)..]
+        ),
+        None => println!("  LLM       : disabled"),
+    }
+    println!("{sep}\n");
+
+    let start = Instant::now();
+    let mut round = 0usize;
+    let mut total_api_calls = 0usize;
+    let mut total_seeds_generated = 0usize;
+    let mut crashes_found: Vec<String> = Vec::new();
+    let mut known_artifacts = list_crash_artifacts(&artifact_dir);
+
+    loop {
+        round += 1;
+        let elapsed = start.elapsed().as_secs();
+        if elapsed >= cfg.timeout {
+            println!("\n[*] Global timeout reached after {} round(s).", round - 1);
+            break;
+        }
+        let remaining = cfg.timeout - elapsed;
+
+        println!(
+            "{}\nRound {} | Elapsed: {}m {}s | Remaining: {}m",
+            "-".repeat(60),
+            round,
+            elapsed / 60,
+            elapsed % 60,
+            remaining / 60,
+        );
+
+        // Phase 1: Gap analysis.
+        let report = analyze_corpus(&corpus_dir);
+        let gaps = identify_gaps(&report);
+        println!(
+            "[1] Corpus: {} seeds  |  bounds-ok: {}  |  gaps: {}",
+            report.total_seeds, report.bounds_passing, gaps.len()
+        );
+
+        // Phase 2+3: Start fuzzer and LLM generation concurrently.
+        //
+        // The fuzzer runs for fuzz_time seconds. LLM calls finish much sooner
+        // (~10-60s) and write seeds to corpus/ while the fuzzer is still running.
+        // Those seeds are available to the NEXT fuzzer round.
+        let fuzz_time = remaining.min(cfg.fuzz_time);
+        let corpus_before = count_files(&corpus_dir);
+
+        // Spawn the fuzzer subprocess (non-blocking).
+        println!(
+            "[2+3] Fuzzer ({fuzz_time}s, {} workers) + LLM generation starting in parallel...",
+            cfg.jobs
+        );
+        let mut fuzzer_child = spawn_fuzzer(&crate_dir, &cfg.target, fuzz_time, cfg.jobs);
+
+        // Fire LLM calls in a background thread while the fuzzer runs.
+        let llm_handle: Option<thread::JoinHandle<SeedGenResult>> =
+            if let Some(ref key) = api_key
+                && !gaps.is_empty()
+            {
+                let key = key.clone();
+                let model = cfg.model.clone();
+                let api_url = cfg.api_url.clone();
+                let source_root = cfg.source_root.clone();
+                let max_attempts = cfg.max_attempts;
+                let seeds_per_round = cfg.seeds_per_round;
+                let corpus_dir = corpus_dir.clone();
+                let gaps: Vec<CoverageGap> = gaps.clone();
+
+                Some(thread::spawn(move || {
+                    generate_seeds_parallel(
+                        &key,
+                        &model,
+                        &api_url,
+                        &source_root,
+                        max_attempts,
+                        seeds_per_round,
+                        &gaps,
+                        &corpus_dir,
+                    )
+                }))
+            } else {
+                None
+            };
+
+        // Wait for fuzzer to finish (it exits after fuzz_time seconds).
+        if let Some(ref mut child) = fuzzer_child {
+            match child.wait() {
+                Ok(s) if !s.success() => eprintln!("  [Fuzzer] exited with status: {s}"),
+                Err(e) => eprintln!("  [Fuzzer] wait error: {e}"),
+                _ => {}
+            }
+        }
+
+        let corpus_after = count_files(&corpus_dir);
+        println!(
+            "    Corpus: {} → {} (+{} new entries)",
+            corpus_before,
+            corpus_after,
+            corpus_after.saturating_sub(corpus_before)
+        );
+
+        // Collect LLM results (thread has likely already finished by now).
+        match llm_handle {
+            Some(h) => match h.join() {
+                Ok(result) => {
+                    for line in &result.log {
+                        println!("{line}");
+                    }
+                    println!(
+                        "    LLM: {} API call(s)  |  {} seed(s) saved",
+                        result.api_calls, result.saved
+                    );
+                    total_api_calls += result.api_calls;
+                    total_seeds_generated += result.saved;
+                }
+                Err(_) => eprintln!("    LLM thread panicked"),
+            },
+            None => println!("    LLM: disabled or no gaps."),
+        }
+
+        // Phase 4: Crash scan.
+        let current_artifacts = list_crash_artifacts(&artifact_dir);
+        let new_artifacts: Vec<PathBuf> = current_artifacts
+            .difference(&known_artifacts)
+            .cloned()
+            .collect();
+        known_artifacts = current_artifacts;
+
+        if new_artifacts.is_empty() {
+            println!("[4] No new crash artifacts.");
+        } else {
+            println!("[4] Checking {} new artifact(s)...", new_artifacts.len());
+            for artifact_path in &new_artifacts {
+                print!("    {} ... ", artifact_path.display());
+                if let Some(name) = validate_artifact(artifact_path) {
+                    println!("*** CONFIRMED CRASH: {name} ***");
+                    crashes_found.push(format!("{name} ({})", artifact_path.display()));
+                    if !cfg.keep_going {
+                        break;
+                    }
+                } else {
+                    println!("not reproduced (fuzzer artifact, not a verifier panic)");
+                }
+            }
+        }
+
+        if !crashes_found.is_empty() && !cfg.keep_going {
+            println!("\n[!] Stopping on confirmed crash (pass --keep-going to continue).");
+            break;
+        }
+
+        if start.elapsed().as_secs() >= cfg.timeout {
+            println!("\n[*] Global timeout reached.");
+            break;
+        }
+    }
+
+    // Final summary.
+    let elapsed = start.elapsed().as_secs();
+    let sep = "=".repeat(70);
+    println!("\n{sep}");
+    println!("  Final Summary");
+    println!("  Rounds completed  : {}", round);
+    println!("  Elapsed           : {}m {}s", elapsed / 60, elapsed % 60);
+    println!("  Total API calls   : {}", total_api_calls);
+    println!("  Seeds generated   : {}", total_seeds_generated);
+    println!("  Crashes confirmed : {}", crashes_found.len());
+    for crash in &crashes_found {
+        println!("    * {crash}");
+    }
+    println!("{sep}");
+
+    if !crashes_found.is_empty() {
+        std::process::exit(1);
+    }
+}

--- a/crates/sui-move-fuzzer/src/bin/gen_corpus.rs
+++ b/crates/sui-move-fuzzer/src/bin/gen_corpus.rs
@@ -1,0 +1,116 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Generates a seed corpus for the Sui Move VM fuzzer.
+//!
+//! Usage:
+//!   cargo run --bin gen_corpus
+//!
+//! Creates corpus directories with seed files for each fuzz target.
+
+use std::fs;
+use std::path::Path;
+
+use sui_move_fuzzer::module_spec::{ModuleSpec, ModuleSpecBuilder};
+use sui_move_fuzzer::seed_corpus;
+
+fn write_seeds(dir: &Path, seeds: &[Vec<u8>]) {
+    fs::create_dir_all(dir).expect("create corpus dir");
+    for (i, seed) in seeds.iter().enumerate() {
+        let path = dir.join(format!("seed_{i:04}.bin"));
+        fs::write(&path, seed).expect("write seed");
+    }
+    println!("  wrote {} seeds to {}", seeds.len(), dir.display());
+}
+
+fn main() {
+    let base = Path::new("corpus");
+
+    // Raw module bytes for deser_roundtrip, e2e_publish_crash, ref_safety_diff
+    println!("Generating raw module seeds...");
+    let raw_seeds = seed_corpus::generate_seeds(100);
+    write_seeds(&base.join("deser_roundtrip"), &raw_seeds);
+    write_seeds(&base.join("e2e_publish_crash"), &raw_seeds);
+    write_seeds(&base.join("ref_safety_diff"), &raw_seeds);
+
+    // Structured seeds for grammar-based targets
+    println!("Generating structured seeds...");
+    let structured_seeds = seed_corpus::generate_structured_seeds(100);
+    write_seeds(&base.join("verifier_crash"), &structured_seeds);
+    write_seeds(&base.join("bounds_escape"), &structured_seeds);
+    write_seeds(&base.join("e2e_publish_execute"), &structured_seeds);
+    write_seeds(&base.join("ref_safety_diff_gen"), &structured_seeds);
+    write_seeds(&base.join("verifier_soundness"), &structured_seeds);
+
+    // Load hand-written ModuleSpec JSON files from specs/ directory.
+    // These are curated seeds that target specific verifier paths.
+    let specs_dir = Path::new("specs");
+    if specs_dir.exists() {
+        println!("Loading ModuleSpec seeds from specs/...");
+        let mut spec_seeds: Vec<Vec<u8>> = Vec::new();
+
+        let mut entries: Vec<_> = fs::read_dir(specs_dir)
+            .expect("read specs dir")
+            .flatten()
+            .collect();
+        entries.sort_by_key(|e| e.path());
+
+        for entry in entries {
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("json") {
+                continue;
+            }
+            let json = match fs::read_to_string(&path) {
+                Ok(s) => s,
+                Err(e) => {
+                    eprintln!("  skipping {}: {e}", path.display());
+                    continue;
+                }
+            };
+            let spec: ModuleSpec = match serde_json::from_str(&json) {
+                Ok(s) => s,
+                Err(e) => {
+                    eprintln!("  invalid JSON in {}: {e}", path.display());
+                    continue;
+                }
+            };
+            match ModuleSpecBuilder::build(&spec) {
+                Ok(module) => {
+                    let mut bytes = Vec::new();
+                    if module.serialize(&mut bytes).is_ok() {
+                        println!("  built seed from {}", path.display());
+                        spec_seeds.push(bytes);
+                    } else {
+                        eprintln!("  serialization failed for {}", path.display());
+                    }
+                }
+                Err(e) => {
+                    eprintln!("  build error for {}: {e}", path.display());
+                }
+            }
+        }
+
+        if !spec_seeds.is_empty() {
+            // Deposit spec-based seeds into all grammar-based targets.
+            for target in &[
+                "verifier_crash",
+                "ref_safety_diff_gen",
+                "verifier_soundness",
+            ] {
+                let dir = base.join(target);
+                fs::create_dir_all(&dir).expect("create corpus dir");
+                for (i, seed) in spec_seeds.iter().enumerate() {
+                    let filename = dir.join(format!("spec_{:04}.bin", i));
+                    fs::write(&filename, seed).expect("write spec seed");
+                }
+                println!(
+                    "  wrote {} spec seeds to {}",
+                    spec_seeds.len(),
+                    dir.display()
+                );
+            }
+        }
+    }
+
+    println!("Done! Seed corpus written to {}", base.display());
+}

--- a/crates/sui-move-fuzzer/src/bin/llm_seed_gen.rs
+++ b/crates/sui-move-fuzzer/src/bin/llm_seed_gen.rs
@@ -1,0 +1,350 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! LLM-guided seed generation for the Sui Move VM fuzzer.
+//!
+//! Analyzes the corpus to find uncovered verifier paths, then uses an LLM
+//! (via OpenRouter or the Anthropic API) to generate `ModuleSpec` JSON that
+//! exercises those paths. Successfully built modules are saved to the corpus.
+//!
+//! Usage (OpenRouter — default):
+//!   OPENROUTER_API_KEY=sk-or-... cargo run --features llm-guided --bin llm_seed_gen
+//!   cargo run --features llm-guided --bin llm_seed_gen -- --dry-run
+//!   cargo run --features llm-guided --bin llm_seed_gen -- \
+//!       --model anthropic/claude-opus-4 \
+//!       --corpus-dir corpus/verifier_crash \
+//!       --output-dir corpus/llm_generated \
+//!       --max-targets 3 --max-attempts 5
+//!
+//! Usage (Anthropic direct):
+//!   OPENROUTER_API_KEY=sk-ant-... cargo run --features llm-guided --bin llm_seed_gen -- \
+//!       --api-url https://api.anthropic.com/v1/messages \
+//!       --model claude-sonnet-4-5-20251219
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use move_binary_format::binary_config::BinaryConfig;
+use move_binary_format::file_format::CompiledModule;
+use sui_move_fuzzer::coverage_gaps::{analyze_corpus, identify_gaps};
+use sui_move_fuzzer::llm_client::call_llm_api;
+use sui_move_fuzzer::llm_prompts::{build_retry_prompt, build_seed_gen_prompt, extract_json};
+use sui_move_fuzzer::module_spec::{ModuleSpec, ModuleSpecBuilder};
+use sui_move_fuzzer::sui_harness;
+
+// ─── CLI ─────────────────────────────────────────────────────────────────────
+
+struct Config {
+    corpus_dirs: Vec<PathBuf>,
+    output_dir: PathBuf,
+    max_targets: usize,
+    max_attempts: usize,
+    dry_run: bool,
+    model: String,
+    api_url: String,
+    source_root: PathBuf,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            corpus_dirs: vec![
+                PathBuf::from("corpus/verifier_crash"),
+                PathBuf::from("corpus/ref_safety_diff"),
+            ],
+            output_dir: PathBuf::from("corpus/llm_generated"),
+            max_targets: 5,
+            max_attempts: 3,
+            dry_run: false,
+            // OpenRouter model name. Opus is best for complex bytecode reasoning.
+            // Alternatives: "anthropic/claude-sonnet-4-5", "anthropic/claude-opus-4"
+            model: "anthropic/claude-opus-4-6".to_string(),
+            api_url: "https://openrouter.ai/api/v1/chat/completions".to_string(),
+            source_root: PathBuf::from("../../"),
+        }
+    }
+}
+
+fn parse_args() -> Config {
+    let args: Vec<String> = std::env::args().collect();
+    let mut cfg = Config::default();
+    let mut i = 1;
+
+    while i < args.len() {
+        match args[i].as_str() {
+            "--corpus-dir" if i + 1 < args.len() => {
+                i += 1;
+                if cfg.corpus_dirs == Config::default().corpus_dirs {
+                    cfg.corpus_dirs.clear();
+                }
+                cfg.corpus_dirs.push(PathBuf::from(&args[i]));
+            }
+            "--output-dir" if i + 1 < args.len() => {
+                i += 1;
+                cfg.output_dir = PathBuf::from(&args[i]);
+            }
+            "--max-targets" if i + 1 < args.len() => {
+                i += 1;
+                cfg.max_targets = args[i].parse().expect("max-targets must be a number");
+            }
+            "--max-attempts" if i + 1 < args.len() => {
+                i += 1;
+                cfg.max_attempts = args[i].parse().expect("max-attempts must be a number");
+            }
+            "--model" if i + 1 < args.len() => {
+                i += 1;
+                cfg.model = args[i].clone();
+            }
+            "--api-url" if i + 1 < args.len() => {
+                i += 1;
+                cfg.api_url = args[i].clone();
+            }
+            "--source-root" if i + 1 < args.len() => {
+                i += 1;
+                cfg.source_root = PathBuf::from(&args[i]);
+            }
+            "--dry-run" => {
+                cfg.dry_run = true;
+            }
+            other => eprintln!("unknown flag: {other}"),
+        }
+        i += 1;
+    }
+
+    cfg
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────────
+
+fn main() {
+    let cfg = parse_args();
+
+    let api_key = if cfg.dry_run {
+        String::new()
+    } else {
+        std::env::var("OPENROUTER_API_KEY").unwrap_or_else(|_| {
+            eprintln!("error: OPENROUTER_API_KEY environment variable not set");
+            eprintln!("       Use --dry-run to print prompts without calling the API");
+            std::process::exit(1);
+        })
+    };
+
+    // ── Step 1: Analyze corpus for gaps ────────────────────────────────────
+    println!("[*] Analyzing corpus for coverage gaps...");
+    let mut merged = sui_move_fuzzer::coverage_gaps::CorpusCoverageReport::default();
+    for dir in &cfg.corpus_dirs {
+        if dir.exists() {
+            let r = analyze_corpus(dir);
+            merged.total_seeds += r.total_seeds;
+            merged.bounds_passing += r.bounds_passing;
+            merged.move_passing += r.move_passing;
+            merged.sui_passing += r.sui_passing;
+            for (k, v) in r.error_code_counts {
+                *merged.error_code_counts.entry(k).or_insert(0) += v;
+            }
+            merged.sui_pass_hit.extend(r.sui_pass_hit);
+        }
+    }
+    println!(
+        "    {}/{} seeds pass bounds check, {}/{} pass Move verify",
+        merged.bounds_passing, merged.total_seeds, merged.move_passing, merged.total_seeds
+    );
+
+    let gaps = identify_gaps(&merged);
+    if gaps.is_empty() {
+        println!("[*] No coverage gaps found — corpus already covers all known paths.");
+        return;
+    }
+    println!("[*] Found {} coverage gap(s):", gaps.len());
+    for g in &gaps {
+        println!("    {}", g.summary());
+    }
+
+    // ── Step 2: Prepare output directory ───────────────────────────────────
+    if !cfg.dry_run {
+        fs::create_dir_all(&cfg.output_dir).expect("create output dir");
+    }
+
+    // ── Step 3: For each gap, ask the LLM to generate a seed ───────────────
+    let targets = gaps.iter().take(cfg.max_targets);
+    let mut total_generated = 0usize;
+    let mut total_attempts = 0usize;
+
+    for gap in targets {
+        println!("\n[*] Targeting gap: {}", gap.path_id);
+
+        // Load relevant source context (best-effort; skip on read failure).
+        let source_context = load_source_context(&cfg.source_root, gap.source_context_file);
+
+        let mut last_spec_json = String::new();
+        let mut last_error = String::new();
+
+        for attempt in 1..=cfg.max_attempts {
+            total_attempts += 1;
+            println!("    Attempt {}/{}", attempt, cfg.max_attempts);
+
+            // Build prompt.
+            let prompt = if attempt == 1 {
+                build_seed_gen_prompt(gap, &source_context)
+            } else {
+                build_retry_prompt(gap, &last_spec_json, &last_error)
+            };
+
+            if cfg.dry_run {
+                println!("    [DRY RUN] Prompt ({} chars):", prompt.len());
+                println!("    {}", &prompt[..prompt.len().min(500)]);
+                println!("    ...(truncated)");
+                break;
+            }
+
+            // Call LLM API.
+            let response = match call_llm_api(&api_key, &cfg.model, &cfg.api_url, &prompt) {
+                Ok(r) => r,
+                Err(e) => {
+                    eprintln!("    API error: {e}");
+                    last_error = format!("API call failed: {e}");
+                    continue;
+                }
+            };
+
+            // Extract JSON from response.
+            let spec_json = match extract_json(&response) {
+                Some(j) => j.to_string(),
+                None => {
+                    eprintln!("    No JSON found in response");
+                    last_error = "Response contained no ```json block".to_string();
+                    last_spec_json = response[..response.len().min(200)].to_string();
+                    continue;
+                }
+            };
+            last_spec_json = spec_json.clone();
+
+            // Parse ModuleSpec.
+            let spec: ModuleSpec = match serde_json::from_str(&spec_json) {
+                Ok(s) => s,
+                Err(e) => {
+                    last_error = format!("JSON parse error: {e}");
+                    eprintln!("    JSON parse error: {e}");
+                    continue;
+                }
+            };
+
+            // Build CompiledModule.
+            let module = match ModuleSpecBuilder::build(&spec) {
+                Ok(m) => m,
+                Err(e) => {
+                    last_error = format!("ModuleSpec builder error: {e}");
+                    eprintln!("    Build error: {e}");
+                    continue;
+                }
+            };
+
+            // Validate: bounds check.
+            let mut bytes = Vec::new();
+            if let Err(e) = module.serialize(&mut bytes) {
+                last_error = format!("Serialization error: {e:?}");
+                eprintln!("    Serialization error: {e:?}");
+                continue;
+            }
+            let config = BinaryConfig::standard();
+            if let Err(e) = CompiledModule::deserialize_with_config(&bytes, &config) {
+                last_error = format!("Bounds check failed: {e:?}");
+                eprintln!("    Bounds check failed: {e:?}");
+                continue;
+            }
+
+            // Only save if the module actually reaches the target verifier path.
+            let verify_result = sui_harness::run_full_verification(&module);
+            if !check_reaches_target(&verify_result, gap) {
+                let why = match &verify_result {
+                    Ok(()) => "module passed full verification (target expects a rejection)".to_string(),
+                    Err(e) => format!("wrong error: {}", &e[..e.len().min(80)]),
+                };
+                last_error = format!("does not reach target gap — {why}");
+                eprintln!("    ✗ {}", last_error);
+                last_spec_json = spec_json.clone();
+                continue;
+            }
+
+            println!("    ✓ Module reaches target gap!");
+            let filename = format!("llm_{}_{:04}.bin", gap.path_id, total_generated);
+            let out_path = cfg.output_dir.join(&filename);
+            fs::write(&out_path, &bytes).expect("write seed");
+            println!("    Saved: {}", out_path.display());
+            total_generated += 1;
+            break;
+        }
+    }
+
+    // ── Summary ────────────────────────────────────────────────────────────
+    println!("\n[*] Summary:");
+    println!("    Gaps targeted    : {}", cfg.max_targets.min(gaps.len()));
+    println!("    Total API calls  : {}", total_attempts);
+    println!("    Seeds generated  : {}", total_generated);
+    if total_generated > 0 {
+        println!("    Output directory : {}", cfg.output_dir.display());
+        println!();
+        println!("    Next: run the fuzzer with the new seeds:");
+        println!(
+            "      ./run_fuzzer.sh verifier_crash -max_total_time=3600"
+        );
+    }
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/// Load a source file for context injection. Returns a truncated snippet
+/// on success or an empty string if the file can't be read.
+fn load_source_context(source_root: &Path, relative_path: &str) -> String {
+    let full_path = source_root.join(relative_path);
+    match fs::read_to_string(&full_path) {
+        Ok(content) => {
+            // Truncate to ~8000 chars to stay within prompt budget.
+            if content.len() > 8000 {
+                format!("{}... (truncated)", &content[..8000])
+            } else {
+                content
+            }
+        }
+        Err(_) => {
+            eprintln!(
+                "    note: could not load source context from {}",
+                full_path.display()
+            );
+            String::new()
+        }
+    }
+}
+
+/// Check whether the verification result indicates the module reaches the
+/// target gap (either by producing the expected error or passing through to
+/// the relevant pass).
+fn check_reaches_target(
+    verify_result: &Result<(), String>,
+    gap: &sui_move_fuzzer::coverage_gaps::CoverageGap,
+) -> bool {
+    match verify_result {
+        Ok(()) => {
+            // Module passed full verification — check if the gap is a "should accept" path.
+            false
+        }
+        Err(e) => {
+            // Check if the error matches the target error code.
+            if let Some(code) = gap.error_code {
+                e.contains(&format!("{:?}", code))
+            } else {
+                // For Sui-pass gaps without a specific code, check if the error
+                // mentions the right pass.
+                let pass_name = match gap.pass {
+                    sui_move_fuzzer::coverage_gaps::VerifierPass::SuiStructWithKey => {
+                        "struct_with_key"
+                    }
+                    sui_move_fuzzer::coverage_gaps::VerifierPass::SuiIdLeak => "id_leak",
+                    sui_move_fuzzer::coverage_gaps::VerifierPass::SuiEntryPoints => "entry_points",
+                    _ => "",
+                };
+                !pass_name.is_empty() && e.contains(pass_name)
+            }
+        }
+    }
+}

--- a/crates/sui-move-fuzzer/src/coverage_gaps.rs
+++ b/crates/sui-move-fuzzer/src/coverage_gaps.rs
@@ -1,0 +1,308 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Corpus coverage analysis for the Sui Move VM fuzzer.
+//!
+//! Runs the existing seed corpus through each verifier pass and identifies
+//! which known verifier paths have never been exercised. These "gaps" are
+//! targets for LLM-guided seed generation.
+
+use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use move_binary_format::binary_config::BinaryConfig;
+use move_core_types::vm_status::StatusCode;
+use move_binary_format::file_format::CompiledModule;
+use move_bytecode_verifier::verify_module_with_config_metered;
+use move_bytecode_verifier_meter::dummy::DummyMeter;
+
+use crate::sui_harness;
+
+// ─── Known verifier paths ─────────────────────────────────────────────────────
+
+/// A specific verifier path we want corpus coverage for.
+#[derive(Debug, Clone)]
+pub struct KnownPath {
+    /// Short identifier used as a key.
+    pub id: &'static str,
+    /// Human-readable description of the path.
+    pub description: &'static str,
+    /// The verifier pass where this path lives.
+    pub pass: VerifierPass,
+    /// The `StatusCode` the path emits on failure (if it's a rejection path).
+    pub error_code: Option<StatusCode>,
+    /// Guidance for the LLM: what bytecode pattern reaches this path.
+    pub llm_hint: &'static str,
+    /// Relevant source file for context injection.
+    pub source_context: &'static str,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum VerifierPass {
+    BoundsChecker,
+    SignatureChecker,
+    TypeSafety,
+    ReferenceSafety,
+    LocalsSafety,
+    InstantiationLoops,
+    CodeUnitVerifier,
+    SuiStructWithKey,
+    SuiIdLeak,
+    SuiEntryPoints,
+    SuiGlobalStorage,
+    SuiOneTimeWitness,
+}
+
+/// The canonical list of verifier paths we want to reach.
+pub fn known_paths() -> Vec<KnownPath> {
+    vec![
+        KnownPath {
+            id: "ref_safety_loop_join",
+            description: "Reference safety: loop convergence with divergent borrow states \
+                          (join_() called at back-edge with mismatched ref sets)",
+            pass: VerifierPass::ReferenceSafety,
+            error_code: Some(StatusCode::UNSAFE_RET_LOCAL_OR_RESOURCE_STILL_BORROWED),
+            llm_hint: "Create a loop (back-edge) where one branch borrows a local via \
+                       MutBorrowLoc and the other does not. The join at the loop header \
+                       sees divergent borrow states, triggering the expensive join_() path. \
+                       Pattern: LdTrue → BrFalse(end) → MutBorrowLoc(0) → Pop → Branch(loop_top)",
+            source_context: "external-crates/move/crates/move-bytecode-verifier/src/reference_safety/abstract_state.rs",
+        },
+        KnownPath {
+            id: "type_instantiation_loop",
+            description: "Instantiation loop detection: generic call graph SCC with \
+                          TyConApp edges (LOOP_IN_INSTANTIATION_GRAPH)",
+            pass: VerifierPass::InstantiationLoops,
+            error_code: Some(StatusCode::LOOP_IN_INSTANTIATION_GRAPH),
+            llm_hint: "Create a generic function f<T>() that calls itself via CallGeneric \
+                       with a concrete instantiation, forming a cycle in the instantiation \
+                       graph. Or have f<T>() call g<vector<T>>() which calls f<T>().",
+            source_context: "external-crates/move/crates/move-bytecode-verifier/src/instantiation_loops.rs",
+        },
+        KnownPath {
+            id: "id_leak_through_conditional",
+            description: "ID leak: Fresh→Other join at a branch merge precedes Pack of \
+                          a key struct (id_leak_verifier)",
+            pass: VerifierPass::SuiIdLeak,
+            error_code: None,
+            llm_hint: "Create an entry function that conditionally calls object::new() \
+                       on one branch but not the other. At the merge point the UID state \
+                       is Fresh on one path and Other on the other. Packing a key struct \
+                       at the merge exercises the Fresh→Other join logic in id_leak_verifier.",
+            source_context: "sui-execution/latest/sui-verifier/src/id_leak_verifier.rs",
+        },
+        KnownPath {
+            id: "control_flow_reducibility",
+            description: "Control flow: almost-irreducible CFG with multiple back-edges \
+                          to the same loop header from different branches",
+            pass: VerifierPass::CodeUnitVerifier,
+            error_code: Some(StatusCode::INVALID_LOOP_SPLIT),
+            llm_hint: "Create two Branch instructions that both target the same earlier \
+                       offset, producing two separate back-edges to one block. \
+                       Pattern: block0 → block1 → BrTrue(block0) → Branch(block0)",
+            source_context: "external-crates/move/crates/move-bytecode-verifier/src/control_flow.rs",
+        },
+        KnownPath {
+            id: "key_struct_uid_check",
+            description: "Sui struct-with-key verifier: key struct whose first field \
+                          is not 0x2::object::UID",
+            pass: VerifierPass::SuiStructWithKey,
+            error_code: None,
+            llm_hint: "Define a struct with the 'key' ability where the first field \
+                       is NOT of type 0x2::object::UID. This exercises the \
+                       struct_with_key_verifier check for the ID field constraint.",
+            source_context: "sui-execution/latest/sui-verifier/src/struct_with_key_verifier.rs",
+        },
+        KnownPath {
+            id: "entry_non_droppable_return",
+            description: "Entry points verifier: entry function returns a non-droppable value",
+            pass: VerifierPass::SuiEntryPoints,
+            error_code: None,
+            llm_hint: "Define an entry function that returns a struct without the 'drop' \
+                       ability. The entry_points_verifier rejects this because entry function \
+                       return values must be droppable or transferable.",
+            source_context: "sui-execution/latest/sui-verifier/src/entry_points_verifier.rs",
+        },
+        KnownPath {
+            id: "signature_phantom_constraint",
+            description: "Signature checker: phantom type parameter used in non-phantom position",
+            pass: VerifierPass::SignatureChecker,
+            error_code: Some(StatusCode::INVALID_PHANTOM_TYPE_PARAM_POSITION),
+            llm_hint: "Declare a struct with a phantom type parameter T, then use T as \
+                       a field type (non-phantom position). This triggers the phantom \
+                       constraint check in the signature verifier.",
+            source_context: "external-crates/move/crates/move-bytecode-verifier/src/signature.rs",
+        },
+        KnownPath {
+            id: "stack_balance_across_branch",
+            description: "Code unit verifier: stack depth imbalance across a conditional branch \
+                          (different depths in then/else arms)",
+            pass: VerifierPass::CodeUnitVerifier,
+            error_code: Some(StatusCode::NEGATIVE_STACK_SIZE_WITHIN_BLOCK),
+            llm_hint: "Create a BrFalse branch where the then-arm pushes two values \
+                       but the else-arm pushes one. The merge point sees inconsistent \
+                       stack depths, triggering NEGATIVE_STACK_SIZE_WITHIN_BLOCK or \
+                       INVALID_FALLTHROUGH.",
+            source_context: "external-crates/move/crates/move-bytecode-verifier/src/code_unit_verifier.rs",
+        },
+    ]
+}
+
+// ─── Coverage analysis ────────────────────────────────────────────────────────
+
+/// Which verifier outcome each seed produced.
+#[derive(Debug, Clone)]
+pub struct SeedResult {
+    pub path: PathBuf,
+    /// Whether the seed deserializes to a valid CompiledModule.
+    pub bounds_ok: bool,
+    /// Error code produced by the Move bytecode verifier, if any.
+    pub move_error: Option<StatusCode>,
+    /// Error descriptions from individual Sui passes.
+    pub sui_pass_errors: Vec<(&'static str, String)>,
+}
+
+/// Aggregated coverage report for a corpus directory.
+#[derive(Debug, Default)]
+pub struct CorpusCoverageReport {
+    pub total_seeds: usize,
+    pub bounds_passing: usize,
+    pub move_passing: usize,
+    pub sui_passing: usize,
+    /// How many seeds triggered each StatusCode.
+    pub error_code_counts: HashMap<String, usize>,
+    /// Which Sui pass errors appeared at least once.
+    pub sui_pass_hit: HashSet<String>,
+}
+
+/// Walk `corpus_dir`, deserialize each seed, run through verifier passes,
+/// and return the aggregated coverage report.
+pub fn analyze_corpus(corpus_dir: &Path) -> CorpusCoverageReport {
+    let mut report = CorpusCoverageReport::default();
+    let config = BinaryConfig::standard();
+    let verifier_cfg = sui_harness::sui_verifier_config();
+
+    let entries = match fs::read_dir(corpus_dir) {
+        Ok(e) => e,
+        Err(_) => return report,
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) == Some("md") {
+            continue; // skip README files
+        }
+        let data = match fs::read(&path) {
+            Ok(d) => d,
+            Err(_) => continue,
+        };
+
+        report.total_seeds += 1;
+
+        let module = match CompiledModule::deserialize_with_config(&data, &config) {
+            Ok(m) => {
+                report.bounds_passing += 1;
+                m
+            }
+            Err(_) => continue,
+        };
+
+        let mut meter = DummyMeter;
+        match verify_module_with_config_metered(&verifier_cfg, &module, &mut meter) {
+            Ok(()) => {
+                report.move_passing += 1;
+                // Run Sui passes.
+                if sui_harness::run_full_verification(&module).is_ok() {
+                    report.sui_passing += 1;
+                } else {
+                    let sui_results = sui_harness::run_sui_passes_individually(&module);
+                    for (pass, result) in sui_results {
+                        if let Err(e) = result {
+                            let key = format!("{}:{}", pass, &e[..e.len().min(40)]);
+                            report.sui_pass_hit.insert(key);
+                            *report
+                                .error_code_counts
+                                .entry(format!("sui::{pass}"))
+                                .or_insert(0) += 1;
+                        }
+                    }
+                }
+            }
+            Err(e) => {
+                let code = e.major_status();
+                *report
+                    .error_code_counts
+                    .entry(format!("{:?}", code))
+                    .or_insert(0) += 1;
+            }
+        }
+    }
+
+    report
+}
+
+/// Identify which known verifier paths have zero corpus coverage.
+pub fn identify_gaps(report: &CorpusCoverageReport) -> Vec<CoverageGap> {
+    let mut gaps = Vec::new();
+
+    for path in known_paths() {
+        let covered = match &path.error_code {
+            Some(code) => report
+                .error_code_counts
+                .contains_key(&format!("{:?}", code)),
+            None => {
+                // For Sui passes without a specific error code, check if the
+                // pass name appears in sui_pass_hit.
+                let pass_key = match path.pass {
+                    VerifierPass::SuiStructWithKey => "struct_with_key_verifier",
+                    VerifierPass::SuiIdLeak => "id_leak_verifier",
+                    VerifierPass::SuiEntryPoints => "entry_points_verifier",
+                    VerifierPass::SuiGlobalStorage => "global_storage_access_verifier",
+                    VerifierPass::SuiOneTimeWitness => "one_time_witness_verifier",
+                    _ => "",
+                };
+                !pass_key.is_empty()
+                    && report
+                        .sui_pass_hit
+                        .iter()
+                        .any(|k| k.starts_with(pass_key))
+            }
+        };
+
+        if !covered {
+            gaps.push(CoverageGap {
+                path_id: path.id,
+                description: path.description,
+                pass: path.pass,
+                error_code: path.error_code,
+                llm_hint: path.llm_hint,
+                source_context_file: path.source_context,
+            });
+        }
+    }
+
+    gaps
+}
+
+/// A verifier path that the current corpus does not exercise.
+#[derive(Debug, Clone)]
+pub struct CoverageGap {
+    pub path_id: &'static str,
+    pub description: &'static str,
+    pub pass: VerifierPass,
+    pub error_code: Option<StatusCode>,
+    pub llm_hint: &'static str,
+    pub source_context_file: &'static str,
+}
+
+impl CoverageGap {
+    /// One-line summary for display.
+    pub fn summary(&self) -> String {
+        let code = self
+            .error_code
+            .map(|c| format!(" [{:?}]", c))
+            .unwrap_or_default();
+        format!("[{}]{} — {}", self.path_id, code, self.description)
+    }
+}

--- a/crates/sui-move-fuzzer/src/crash_validator.rs
+++ b/crates/sui-move-fuzzer/src/crash_validator.rs
@@ -1,0 +1,96 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Double-check crash reproduction.
+//!
+//! Re-runs a failing input to confirm it is a real bug rather than a
+//! fuzzer artifact (e.g., corrupted memory during mutation).
+
+use std::panic::{catch_unwind, AssertUnwindSafe};
+
+use move_binary_format::file_format::CompiledModule;
+use move_bytecode_verifier_meter::dummy::DummyMeter;
+
+use crate::oracle::BugClass;
+use crate::sui_harness::sui_verifier_config;
+
+/// Re-run a failing input to confirm it is a real bug, not a fuzzer artifact.
+///
+/// Returns `true` if the crash reproduces (confirmed bug), `false` otherwise.
+pub fn validate_crash(module: &CompiledModule, bug: &BugClass) -> bool {
+    // Step 1: Re-serialize the module. If serialization fails, the module bytes
+    // were likely corrupted by the fuzzer — not a real bug.
+    let mut bytes = Vec::new();
+    if module.serialize(&mut bytes).is_err() {
+        return false;
+    }
+
+    // Step 2: Determine which pass crashed and re-run it.
+    let pass_name = match bug {
+        BugClass::ValidatorCrash { pass, .. } => pass.as_str(),
+        _ => return false,
+    };
+
+    let config = sui_verifier_config();
+    let fn_info_map = std::collections::BTreeMap::new();
+
+    catch_unwind(AssertUnwindSafe(|| {
+        run_pass(pass_name, module, &config, &fn_info_map);
+    }))
+    .is_err()
+}
+
+/// Dispatch to the specific verifier pass by name.
+fn run_pass(
+    pass_name: &str,
+    module: &CompiledModule,
+    config: &move_vm_config::verifier::VerifierConfig,
+    fn_info_map: &sui_types::move_package::FnInfoMap,
+) {
+    match pass_name {
+        "struct_with_key_verifier" => {
+            let _ = sui_verifier::struct_with_key_verifier::verify_module(module);
+        }
+        "global_storage_access_verifier" => {
+            let _ = sui_verifier::global_storage_access_verifier::verify_module(module);
+        }
+        "id_leak_verifier" => {
+            let _ = sui_verifier::id_leak_verifier::verify_module(module, &mut DummyMeter);
+        }
+        "entry_points_verifier" => {
+            let _ = sui_verifier::entry_points_verifier::verify_module(module, fn_info_map, config);
+        }
+        "one_time_witness_verifier" => {
+            let _ = sui_verifier::one_time_witness_verifier::verify_module(module, fn_info_map);
+        }
+        "move_bytecode_verifier" => {
+            let _ = move_bytecode_verifier::verify_module_with_config_metered(
+                config,
+                module,
+                &mut DummyMeter,
+            );
+        }
+        "sui_verify_module" => {
+            let _ = sui_verifier::verifier::sui_verify_module_metered(
+                module,
+                fn_info_map,
+                &mut DummyMeter,
+                config,
+            );
+        }
+        _ => {
+            // Unknown pass name — run the full pipeline as a best effort.
+            let _ = move_bytecode_verifier::verify_module_with_config_metered(
+                config,
+                module,
+                &mut DummyMeter,
+            );
+            let _ = sui_verifier::verifier::sui_verify_module_metered(
+                module,
+                fn_info_map,
+                &mut DummyMeter,
+                config,
+            );
+        }
+    }
+}

--- a/crates/sui-move-fuzzer/src/custom_mutator.rs
+++ b/crates/sui-move-fuzzer/src/custom_mutator.rs
@@ -1,0 +1,65 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared structure-aware mutation logic for libFuzzer's custom mutator hook.
+//!
+//! Wires the existing targeted mutations from `mutators.rs` into libFuzzer's
+//! `fuzz_mutator!` macro, giving coverage-guided feedback on structurally
+//! meaningful mutations instead of random byte flips.
+
+use arbitrary::Unstructured;
+use move_binary_format::binary_config::BinaryConfig;
+use move_binary_format::file_format::CompiledModule;
+use rand::rngs::SmallRng;
+use rand::{RngCore, SeedableRng};
+
+use crate::mutators::{apply_mutation, ensure_code_unit};
+
+/// Structure-aware mutation function for use with `fuzz_mutator!`.
+///
+/// Returns `Some(new_size)` on success, or `None` to signal the caller
+/// should fall back to `libfuzzer_sys::fuzzer_mutate()`.
+pub fn mutate_move_module(
+    data: &mut [u8],
+    size: usize,
+    max_size: usize,
+    seed: u32,
+) -> Option<usize> {
+    // 20% of the time, fall back to libFuzzer's default byte mutations
+    // for exploration diversity.
+    if seed.is_multiple_of(5) {
+        return None;
+    }
+
+    let config = BinaryConfig::standard();
+    let mut module = match CompiledModule::deserialize_with_config(&data[..size], &config) {
+        Ok(m) => m,
+        Err(_) => return None,
+    };
+
+    let mut rng = SmallRng::seed_from_u64(seed as u64);
+    let mut entropy = [0u8; 64];
+    rng.fill_bytes(&mut entropy);
+    let mut u = Unstructured::new(&entropy);
+
+    ensure_code_unit(&mut module);
+
+    let num_mutations = (seed as usize % 3) + 1;
+    for _ in 0..num_mutations {
+        if apply_mutation(&mut u, &mut module).is_err() {
+            break;
+        }
+    }
+
+    let mut out = Vec::new();
+    if module.serialize(&mut out).is_err() {
+        return None;
+    }
+
+    if out.len() > max_size {
+        return None;
+    }
+
+    data[..out.len()].copy_from_slice(&out);
+    Some(out.len())
+}

--- a/crates/sui-move-fuzzer/src/forked_executor.rs
+++ b/crates/sui-move-fuzzer/src/forked_executor.rs
@@ -1,0 +1,261 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! `ForkedExecutor` — runs Move modules against real Sui network state fetched
+//! lazily from an RPC node, using `dev_inspect_transaction` with
+//! `skip_all_checks = true` so that gas, signatures, and transaction validation
+//! are all bypassed.
+//!
+//! Typical usage:
+//! ```ignore
+//! let mut exec = ForkedExecutor::new("https://fullnode.mainnet.sui.io:443")?;
+//! let result = exec.publish_and_call(module_bytes, dep_ids, &[("my_mod", "entry_fn")])?;
+//! ```
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use move_core_types::identifier::Identifier;
+use sui_protocol_config::{Chain, ProtocolConfig, ProtocolVersion};
+use sui_types::base_types::{ObjectID, SuiAddress, TransactionDigest};
+use sui_types::effects::{TransactionEffects, TransactionEffectsAPI};
+use sui_types::error::ExecutionError;
+use sui_types::execution_status::ExecutionStatus;
+use sui_types::execution::ExecutionResult;
+use sui_types::execution_params::ExecutionOrEarlyError;
+use sui_types::gas::SuiGasStatus;
+use sui_types::inner_temporary_store::InnerTemporaryStore;
+use sui_types::metrics::LimitsMetrics;
+use sui_types::object::Object;
+use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
+use sui_types::transaction::{
+    CheckedInputObjects, GasData, InputObjectKind, InputObjects, ObjectReadResult,
+    TransactionKind,
+};
+
+use crate::forked_store::ForkedStore;
+
+/// Budget and price constants for dev-inspect execution — gas accounting is
+/// bypassed by `skip_all_checks`, but non-zero values are required to pass
+/// basic struct validation.
+const DEV_INSPECT_GAS_BUDGET: u64 = 50_000_000_000;
+const DEV_INSPECT_GAS_PRICE: u64 = 1_000;
+const DEV_INSPECT_GAS_BALANCE: u64 = 100_000_000_000;
+
+/// Outcome of a `publish_and_call` invocation.
+pub struct ForkedExecResult {
+    /// Final transaction effects (created/mutated/deleted objects, gas, status).
+    pub effects: TransactionEffects,
+    /// Per-command execution results from dev-inspect, or an execution error.
+    pub execution_result: Result<Vec<ExecutionResult>, ExecutionError>,
+}
+
+pub struct ForkedExecutor {
+    store: ForkedStore,
+    executor: Arc<dyn sui_execution::Executor + Send + Sync>,
+    protocol_config: ProtocolConfig,
+    metrics: Arc<LimitsMetrics>,
+}
+
+impl ForkedExecutor {
+    /// Connect to `rpc_url` and build an executor for `chain` (Mainnet or Testnet).
+    pub fn new(rpc_url: &str, chain: Chain) -> Result<Self> {
+        let store = ForkedStore::new(rpc_url)?;
+        let protocol_config =
+            ProtocolConfig::get_for_version(ProtocolVersion::MAX, chain);
+        let executor = sui_execution::executor(&protocol_config, /*silent=*/ true)
+            .map_err(|e| anyhow::anyhow!("executor creation failed: {e}"))?;
+        let metrics = Arc::new(LimitsMetrics::new(&prometheus::Registry::new()));
+        Ok(Self {
+            store,
+            executor,
+            protocol_config,
+            metrics,
+        })
+    }
+
+    /// Access the underlying `ForkedStore` to inject oracle overrides, etc.
+    pub fn store_mut(&mut self) -> &mut ForkedStore {
+        &mut self.store
+    }
+
+    /// Publish `module_bytes` with the given framework dependencies, then call
+    /// each `(module_name, function_name)` entry function on the published package.
+    ///
+    /// Steps:
+    ///   1. Run a Publish PTB via `dev_inspect_transaction`.
+    ///   2. Extract the package ID from effects and inject all written objects
+    ///      (the new package) into the override layer.
+    ///   3. For each function call, run a separate MoveCall PTB.
+    ///
+    /// All execution uses `skip_all_checks = true`, bypassing gas validation,
+    /// signature checks, and protocol-level limits.
+    pub fn publish_and_call(
+        &mut self,
+        module_bytes: Vec<u8>,
+        dep_ids: Vec<ObjectID>,
+        function_calls: &[(&str, &str)],
+    ) -> Result<ForkedExecResult> {
+        // ---- Step 1: Publish --------------------------------------------
+        let (publish_inner, publish_effects, publish_result) =
+            self.run_publish(module_bytes, dep_ids)?;
+
+        // Persist the written objects (the new package) into the override
+        // layer so subsequent MoveCall PTBs can find them.
+        for (_, obj) in publish_inner.written {
+            self.store.inject_object(obj);
+        }
+
+        // If publish failed or there are no function calls, return now.
+        if function_calls.is_empty()
+            || matches!(publish_effects.status(), ExecutionStatus::Failure { .. })
+        {
+            return Ok(ForkedExecResult {
+                effects: publish_effects,
+                execution_result: publish_result,
+            });
+        }
+
+        // ---- Step 2: Find the package ID --------------------------------
+        let package_id = publish_effects
+            .created()
+            .iter()
+            .find(|(_, owner)| owner.is_immutable())
+            .map(|(obj_ref, _)| obj_ref.0)
+            .ok_or_else(|| anyhow::anyhow!("publish succeeded but no immutable package in effects"))?;
+
+        // ---- Step 3: Call each function ---------------------------------
+        let mut last_effects = publish_effects;
+        let mut last_result: Result<Vec<ExecutionResult>, ExecutionError> = publish_result;
+
+        for (module_name, fn_name) in function_calls {
+            let module_id =
+                Identifier::new(*module_name).map_err(|e| anyhow::anyhow!("{e}"))?;
+            let fn_id =
+                Identifier::new(*fn_name).map_err(|e| anyhow::anyhow!("{e}"))?;
+
+            let (_, effects, result) =
+                self.run_move_call(package_id, module_id, fn_id)?;
+            last_effects = effects;
+            last_result = result;
+        }
+
+        Ok(ForkedExecResult {
+            effects: last_effects,
+            execution_result: last_result,
+        })
+    }
+
+    // -------------------------------------------------------------------------
+    // Internal helpers
+    // -------------------------------------------------------------------------
+
+    /// Run a Publish PTB and return `(inner_store, effects, exec_result)`.
+    fn run_publish(
+        &mut self,
+        module_bytes: Vec<u8>,
+        dep_ids: Vec<ObjectID>,
+    ) -> Result<(InnerTemporaryStore, TransactionEffects, std::result::Result<Vec<ExecutionResult>, ExecutionError>)>
+    {
+        let mut builder = ProgrammableTransactionBuilder::new();
+        builder.publish_immutable(vec![module_bytes], dep_ids);
+        let pt = builder.finish();
+        self.run_pt(TransactionKind::ProgrammableTransaction(pt))
+    }
+
+    /// Run a MoveCall PTB calling `package::module::function()` with no args.
+    fn run_move_call(
+        &mut self,
+        package: ObjectID,
+        module: Identifier,
+        function: Identifier,
+    ) -> Result<(InnerTemporaryStore, TransactionEffects, std::result::Result<Vec<ExecutionResult>, ExecutionError>)>
+    {
+        let mut builder = ProgrammableTransactionBuilder::new();
+        builder.command(sui_types::transaction::Command::move_call(
+            package, module, function, vec![], vec![],
+        ));
+        let pt = builder.finish();
+        self.run_pt(TransactionKind::ProgrammableTransaction(pt))
+    }
+
+    /// Core: execute any `TransactionKind` via `dev_inspect_transaction` with a
+    /// dummy unmetered gas coin and no signature/protocol checks.
+    fn run_pt(
+        &mut self,
+        kind: TransactionKind,
+    ) -> Result<(InnerTemporaryStore, TransactionEffects, std::result::Result<Vec<ExecutionResult>, ExecutionError>)>
+    {
+        let sender = SuiAddress::ZERO;
+
+        // Create a dummy gas coin and inject it so the executor can find it.
+        let dummy_gas =
+            Object::new_gas_with_balance_and_owner_for_testing(DEV_INSPECT_GAS_BALANCE, sender);
+        let gas_ref = dummy_gas.compute_object_reference();
+        self.store.inject_object(dummy_gas.clone());
+
+        // Minimal CheckedInputObjects: just the gas coin.  With skip_all_checks
+        // the executor doesn't verify the object set, it just uses the BackingStore.
+        let input_objects = InputObjects::new(vec![ObjectReadResult::new(
+            InputObjectKind::ImmOrOwnedMoveObject(gas_ref),
+            dummy_gas.into(),
+        )]);
+        let checked = CheckedInputObjects::new_for_replay(input_objects);
+
+        let gas_data = GasData {
+            payment: vec![gas_ref],
+            owner: sender,
+            price: DEV_INSPECT_GAS_PRICE,
+            budget: DEV_INSPECT_GAS_BUDGET,
+        };
+
+        // new_unmetered() creates a SuiGasStatus with charge=false — gas
+        // accounting is fully disabled, matching skip_all_checks semantics.
+        let gas_status = SuiGasStatus::new_unmetered();
+
+        // epoch 0 / timestamp 0 is fine for dev-inspect (the executor doesn't
+        // enforce epoch validity when skip_all_checks=true).
+        let epoch_id: sui_types::committee::EpochId = 0;
+        let epoch_ts: u64 = 0;
+
+        let execution_params: ExecutionOrEarlyError = Ok(());
+        let tx_digest = TransactionDigest::random();
+
+        let (inner_store, _gas_status, effects, result) =
+            self.executor.dev_inspect_transaction(
+                &self.store,
+                &self.protocol_config,
+                self.metrics.clone(),
+                false, // enable_expensive_checks
+                execution_params,
+                &epoch_id,
+                epoch_ts,
+                checked,
+                gas_data,
+                gas_status,
+                kind,
+                sender,
+                tx_digest,
+                true, // skip_all_checks
+            );
+
+        Ok((inner_store, effects, result))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    // Integration tests require a live RPC node.  Run with:
+    //   SUI_RPC_URL=https://fullnode.mainnet.sui.io:443 cargo test --features fork -- --ignored
+
+    #[test]
+    #[ignore]
+    fn test_connect_mainnet() {
+        let rpc_url = std::env::var("SUI_RPC_URL")
+            .unwrap_or_else(|_| "https://fullnode.mainnet.sui.io:443".to_string());
+        let exec =
+            super::ForkedExecutor::new(&rpc_url, sui_protocol_config::Chain::Mainnet).unwrap();
+        // Just verify construction succeeds.
+        drop(exec);
+    }
+}

--- a/crates/sui-move-fuzzer/src/forked_store.rs
+++ b/crates/sui-move-fuzzer/src/forked_store.rs
@@ -1,0 +1,319 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! `ForkedStore` — a `BackingStore` implementation that lazily fetches objects
+//! from a Sui RPC node while allowing an in-memory override layer on top.
+//!
+//! Override priority (highest to lowest):
+//!   1. `overrides` — injected objects (oracle mocks, mock gas coins, etc.)
+//!   2. `cache`     — objects previously fetched from RPC (lazy-populated)
+//!   3. RPC fetch   — live network state, result stored in `cache`
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use anyhow::Result;
+use sui_json_rpc_types::SuiObjectDataOptions;
+use sui_sdk::{SuiClient, SuiClientBuilder};
+use sui_types::base_types::{ObjectID, ObjectRef, SequenceNumber};
+use sui_types::committee::EpochId;
+use sui_types::error::SuiResult;
+use sui_types::object::Object;
+use sui_types::storage::{
+    load_package_object_from_object_store, BackingPackageStore, ChildObjectResolver, ObjectStore,
+    PackageObject, ParentSync,
+};
+
+pub struct ForkedStore {
+    /// Highest-priority layer: objects injected by the caller (oracle mocks, etc.).
+    /// Modified via `&mut self` (inject_object / clear_override).
+    overrides: BTreeMap<ObjectID, Object>,
+    /// Lazily-populated cache of objects fetched from RPC.
+    /// Uses interior mutability so trait impls can update it via `&self`.
+    cache: Mutex<BTreeMap<ObjectID, Object>>,
+    /// Objects confirmed absent from the chain — avoids repeated RPC round-trips
+    /// for objects that don't exist.
+    negative_cache: Mutex<BTreeSet<ObjectID>>,
+    /// Total RPC fetches performed — useful for end-of-run diagnostics.
+    rpc_fetches: AtomicUsize,
+    /// Async Sui RPC client.
+    client: SuiClient,
+    /// Single-threaded Tokio runtime for bridging async RPC calls into sync trait impls.
+    /// The outer fuzzing loop is always synchronous, so block_on is safe here.
+    runtime: tokio::runtime::Runtime,
+}
+
+impl ForkedStore {
+    /// Create a new `ForkedStore` connected to the given RPC URL.
+    pub fn new(rpc_url: &str) -> Result<Self> {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()?;
+        let client = runtime.block_on(SuiClientBuilder::default().build(rpc_url))?;
+        Ok(Self {
+            overrides: BTreeMap::new(),
+            cache: Mutex::new(BTreeMap::new()),
+            negative_cache: Mutex::new(BTreeSet::new()),
+            rpc_fetches: AtomicUsize::new(0),
+            client,
+            runtime,
+        })
+    }
+
+    /// Insert `obj` into the override layer.  Subsequent lookups by ID will
+    /// return this object regardless of what the RPC returns.
+    pub fn inject_object(&mut self, obj: Object) {
+        self.overrides.insert(obj.id(), obj);
+    }
+
+    /// Remove an override (falls through to cache / RPC on next lookup).
+    pub fn clear_override(&mut self, id: &ObjectID) {
+        self.overrides.remove(id);
+    }
+
+    /// Fetch a single object from the RPC, bypassing the override/cache layers.
+    /// Useful for callers that need the raw on-chain state before patching it.
+    pub fn fetch_object(&self, id: &ObjectID) -> Result<Option<Object>> {
+        let response = self.runtime.block_on(
+            self.client
+                .read_api()
+                .get_object_with_options(*id, SuiObjectDataOptions::bcs_lossless()),
+        )?;
+        match response.into_object() {
+            Ok(data) => Ok(Some(data.try_into()?)),
+            Err(_) => Ok(None),
+        }
+    }
+
+    /// Total number of RPC fetches made since construction.
+    pub fn rpc_fetch_count(&self) -> usize {
+        self.rpc_fetches.load(Ordering::Relaxed)
+    }
+
+    // --- Internal helpers -------------------------------------------------
+
+    /// Fetch from RPC, populate cache, and return the object.
+    /// Returns `None` if the object does not exist or the RPC call fails.
+    /// Negative results are cached to avoid repeated RPC round-trips.
+    fn fetch_to_cache(&self, id: &ObjectID) -> Option<Object> {
+        // Skip the RPC call if we already know the object doesn't exist.
+        {
+            let neg = self.negative_cache.lock().unwrap();
+            if neg.contains(id) {
+                return None;
+            }
+        }
+
+        self.rpc_fetches.fetch_add(1, Ordering::Relaxed);
+
+        let response = match self.runtime.block_on(
+            self.client
+                .read_api()
+                .get_object_with_options(*id, SuiObjectDataOptions::bcs_lossless()),
+        ) {
+            Ok(r) => r,
+            Err(e) => {
+                eprintln!("[ForkedStore] RPC error fetching {id}: {e}");
+                return None;
+            }
+        };
+
+        let data = match response.into_object() {
+            Ok(d) => d,
+            Err(_) => {
+                // Object not found on chain — record the miss so we don't re-fetch.
+                self.negative_cache.lock().unwrap().insert(*id);
+                return None;
+            }
+        };
+
+        let obj: Object = match data.try_into() {
+            Ok(o) => o,
+            Err(e) => {
+                eprintln!("[ForkedStore] failed to convert object {id}: {e}");
+                return None;
+            }
+        };
+
+        let mut cache = self.cache.lock().unwrap();
+        cache.insert(obj.id(), obj.clone());
+        Some(obj)
+    }
+
+    /// Resolve an object ID through the full priority stack.
+    fn resolve(&self, id: &ObjectID) -> Option<Object> {
+        if let Some(obj) = self.overrides.get(id) {
+            return Some(obj.clone());
+        }
+        {
+            let cache = self.cache.lock().unwrap();
+            if let Some(obj) = cache.get(id) {
+                return Some(obj.clone());
+            }
+        }
+        self.fetch_to_cache(id)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// BackingStore supertrait implementations
+// ---------------------------------------------------------------------------
+
+impl ObjectStore for ForkedStore {
+    fn get_object(&self, object_id: &ObjectID) -> Option<Object> {
+        self.resolve(object_id)
+    }
+
+    fn get_object_by_key(
+        &self,
+        object_id: &ObjectID,
+        version: sui_types::base_types::VersionNumber,
+    ) -> Option<Object> {
+        // Check overrides first
+        if let Some(obj) = self.overrides.get(object_id)
+            && obj.version() == version
+        {
+            return Some(obj.clone());
+        }
+        // Check cache
+        {
+            let cache = self.cache.lock().unwrap();
+            if let Some(obj) = cache.get(object_id)
+                && obj.version() == version
+            {
+                return Some(obj.clone());
+            }
+        }
+        // Fetch latest from RPC and accept only if version matches
+        let obj = self.fetch_to_cache(object_id)?;
+        if obj.version() == version { Some(obj) } else { None }
+    }
+}
+
+impl BackingPackageStore for ForkedStore {
+    fn get_package_object(&self, package_id: &ObjectID) -> SuiResult<Option<PackageObject>> {
+        load_package_object_from_object_store(self, package_id)
+    }
+}
+
+impl ChildObjectResolver for ForkedStore {
+    /// Called by the Move VM when resolving dynamic field children.
+    /// The override layer is the oracle interception point: inject a patched
+    /// child object here to redirect price queries.
+    fn read_child_object(
+        &self,
+        _parent: &ObjectID,
+        child: &ObjectID,
+        child_version_upper_bound: SequenceNumber,
+    ) -> SuiResult<Option<Object>> {
+        // Overrides bypass all version checks — the caller owns the mock.
+        if let Some(obj) = self.overrides.get(child) {
+            return Ok(Some(obj.clone()));
+        }
+        {
+            let cache = self.cache.lock().unwrap();
+            if let Some(obj) = cache.get(child)
+                && obj.version() <= child_version_upper_bound
+            {
+                return Ok(Some(obj.clone()));
+            }
+        }
+        match self.fetch_to_cache(child) {
+            Some(obj) if obj.version() <= child_version_upper_bound => Ok(Some(obj)),
+            Some(_) => Ok(None),
+            None => Ok(None),
+        }
+    }
+
+    fn get_object_received_at_version(
+        &self,
+        _owner: &ObjectID,
+        receiving_object_id: &ObjectID,
+        receive_object_at_version: SequenceNumber,
+        _epoch_id: EpochId,
+    ) -> SuiResult<Option<Object>> {
+        if let Some(obj) = self.overrides.get(receiving_object_id)
+            && obj.version() == receive_object_at_version
+        {
+            return Ok(Some(obj.clone()));
+        }
+        {
+            let cache = self.cache.lock().unwrap();
+            if let Some(obj) = cache.get(receiving_object_id)
+                && obj.version() == receive_object_at_version
+            {
+                return Ok(Some(obj.clone()));
+            }
+        }
+        let obj = self.fetch_to_cache(receiving_object_id);
+        Ok(obj.filter(|o| o.version() == receive_object_at_version))
+    }
+}
+
+impl ParentSync for ForkedStore {
+    fn get_latest_parent_entry_ref_deprecated(&self, object_id: ObjectID) -> Option<ObjectRef> {
+        // Check overrides
+        if let Some(obj) = self.overrides.get(&object_id) {
+            return Some(obj.compute_object_reference());
+        }
+        // Check cache
+        {
+            let cache = self.cache.lock().unwrap();
+            if let Some(obj) = cache.get(&object_id) {
+                return Some(obj.compute_object_reference());
+            }
+        }
+        // Fall through to RPC on cache miss.
+        self.fetch_to_cache(&object_id)
+            .map(|obj| obj.compute_object_reference())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sui_types::base_types::SuiAddress;
+
+    /// Verify that injected overrides take priority over cache entries.
+    #[test]
+    fn override_beats_cache() {
+        // Build a store without connecting to RPC (we won't make any RPC calls).
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let client = runtime.block_on(async {
+            // Use a bogus URL — we won't actually call RPC in this test.
+            // The client construction would fail, so we skip ForkedStore::new
+            // and instead just verify the override logic directly.
+            None::<SuiClient>
+        });
+        // We can't easily construct a SuiClient without a real URL, so just
+        // verify the override data structure directly.
+        let _ = client;
+
+        let obj_a = Object::new_gas_with_balance_and_owner_for_testing(100, SuiAddress::ZERO);
+        let obj_b = Object::new_gas_with_balance_and_owner_for_testing(200, SuiAddress::ZERO);
+
+        let mut overrides: BTreeMap<ObjectID, Object> = BTreeMap::new();
+        let mut cache: BTreeMap<ObjectID, Object> = BTreeMap::new();
+
+        // obj_a in cache
+        let a = obj_a.clone();
+        // We can't easily set a custom ID on Object here, so use the default
+        // IDs assigned during construction.
+        let a_id = a.id();
+        cache.insert(a_id, a.clone());
+
+        // Override with obj_b using the same ID — we insert an object with
+        // obj_b's balance but under obj_a's ID (by injecting).
+        overrides.insert(a_id, obj_b.clone());
+
+        // Simulate resolve(): overrides win.
+        let resolved = overrides.get(&a_id).or_else(|| cache.get(&a_id)).cloned();
+        // The resolved object should be obj_b (from overrides), not obj_a (from cache).
+        let resolved = resolved.unwrap();
+        assert_eq!(resolved.id(), obj_b.id());
+    }
+}

--- a/crates/sui-move-fuzzer/src/lib.rs
+++ b/crates/sui-move-fuzzer/src/lib.rs
@@ -1,0 +1,33 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Sui Move VM Fuzzer
+//!
+//! A structure-aware fuzzer targeting the full Sui Move VM pipeline:
+//! deserialization → verification (Move + Sui) → publish → execute.
+//!
+//! Bug classes detected:
+//! - Validator crashes (panics in verification or execution)
+//! - Fund loss (SUI conservation violations)
+//! - Verifier soundness (bytecode passing verification but violating safety at runtime)
+
+#[cfg(feature = "e2e")]
+pub mod authority_harness;
+pub mod coverage_gaps;
+#[cfg(feature = "fork")]
+pub mod forked_executor;
+#[cfg(feature = "fork")]
+pub mod forked_store;
+#[cfg(feature = "fork")]
+pub mod oracle_override;
+#[cfg(feature = "llm-guided")]
+pub mod llm_client;
+pub mod crash_validator;
+pub mod custom_mutator;
+pub mod llm_prompts;
+pub mod module_gen;
+pub mod module_spec;
+pub mod mutators;
+pub mod oracle;
+pub mod seed_corpus;
+pub mod sui_harness;

--- a/crates/sui-move-fuzzer/src/llm_client.rs
+++ b/crates/sui-move-fuzzer/src/llm_client.rs
@@ -1,0 +1,57 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared LLM API client used by llm_seed_gen and fuzz_loop.
+
+/// Call an LLM via the OpenAI-compatible chat completions API (OpenRouter default).
+///
+/// OpenRouter endpoint:  https://openrouter.ai/api/v1/chat/completions
+/// Anthropic direct:     https://api.anthropic.com/v1/messages  (different shape)
+pub fn call_llm_api(
+    api_key: &str,
+    model: &str,
+    api_url: &str,
+    prompt: &str,
+) -> Result<String, String> {
+    let client = reqwest::blocking::Client::new();
+
+    // OpenAI-compatible format used by OpenRouter (and most other providers).
+    let body = serde_json::json!({
+        "model": model,
+        "max_tokens": 4096,
+        "messages": [
+            {"role": "user", "content": prompt}
+        ]
+    });
+
+    let response = client
+        .post(api_url)
+        .header("Authorization", format!("Bearer {api_key}"))
+        .header("Content-Type", "application/json")
+        // OpenRouter asks for these headers for routing/analytics.
+        .header("HTTP-Referer", "https://github.com/MystenLabs/sui")
+        .header("X-Title", "sui-move-fuzzer")
+        .json(&body)
+        .send()
+        .map_err(|e| format!("HTTP request failed: {e}"))?;
+
+    let status = response.status();
+    let text = response
+        .text()
+        .map_err(|e| format!("failed to read response body: {e}"))?;
+
+    if !status.is_success() {
+        return Err(format!("API returned {status}: {text}"));
+    }
+
+    let parsed: serde_json::Value =
+        serde_json::from_str(&text).map_err(|e| format!("failed to parse response JSON: {e}"))?;
+
+    // OpenAI-compatible response: choices[0].message.content
+    parsed["choices"]
+        .as_array()
+        .and_then(|arr| arr.first())
+        .and_then(|choice| choice["message"]["content"].as_str())
+        .map(|s| s.to_string())
+        .ok_or_else(|| format!("unexpected response shape: {text}"))
+}

--- a/crates/sui-move-fuzzer/src/llm_prompts.rs
+++ b/crates/sui-move-fuzzer/src/llm_prompts.rs
@@ -1,0 +1,338 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Prompt engineering for LLM-guided seed generation.
+//!
+//! Provides:
+//! - `build_seed_gen_prompt()` — constructs a gap-specific prompt
+//! - `BYTECODE_REFERENCE` — Move bytecode instruction reference for the LLM
+//! - `MODULE_SPEC_REFERENCE` — ModuleSpec JSON format documentation
+//! - `VERIFIER_ARCHITECTURE` — Summary of the Sui Move verification pipeline
+
+use crate::coverage_gaps::CoverageGap;
+
+// ─── Reference constants ──────────────────────────────────────────────────────
+
+pub const VERIFIER_ARCHITECTURE: &str = r#"
+# Sui Move VM Verification Pipeline
+
+A CompiledModule passes through these layers in order. Each layer fully
+rejects the module before the next one runs.
+
+1. **BoundsChecker** — validates that all table indices (handles, signatures,
+   identifiers) are within bounds. ~99% of random bytes fail here.
+
+2. **SignatureChecker** — validates that all Signature entries contain valid
+   token sequences (no cycles, phantom constraints satisfied, etc.)
+
+3. **InstructionConsistency** — validates that deprecated global-storage opcodes
+   are not used when `deprecate_global_storage_ops` is enabled (Sui mainnet).
+
+4. **CodeUnitVerifier** — runs multiple sub-passes on each function body:
+   - ControlFlow: checks CFG reducibility (no irreducible loops)
+   - StackUsageSafety: balanced stack across all paths, no underflow
+   - TypeSafety: type-checks each instruction using an abstract interpreter
+   - LocalsSafety: checks that locals are initialized before use
+   - ReferenceSafety: borrow-check using graph or regex analysis; checks that
+     references don't escape scopes, loops converge with consistent borrow states
+
+5. **InstantiationLoops** — detects cycles in the generic instantiation graph
+   (e.g., f<T> calls f<vector<T>> → infinite instantiation depth)
+
+6. **Sui-specific passes** (applied after Move verification passes):
+   - struct_with_key_verifier: key structs must have UID as first field
+   - global_storage_access_verifier: no global storage operations (Move global ops
+     like move_to/move_from are banned in Sui)
+   - id_leak_verifier: UID values must not be duplicated or laundered through
+     pack/unpack sequences; tracks Fresh/Bound/Other states
+   - entry_points_verifier: entry functions must have compatible signatures
+   - one_time_witness_verifier: OTW structs must follow naming conventions
+"#;
+
+pub const MODULE_SPEC_REFERENCE: &str = r#"
+# ModuleSpec JSON Format
+
+Output a JSON object with these fields:
+
+```json
+{
+  "module_name": "string",          // valid Move identifier, no spaces
+  "imports": [                       // optional list of framework imports
+    {
+      "address": "0x2",             // hex address (short form like "0x2" is OK)
+      "module": "object",           // module name
+      "types": ["UID"],             // types from this module you reference in field types
+      "functions": ["new"]          // functions you want to Call
+    }
+  ],
+  "structs": [                       // optional list of struct definitions
+    {
+      "name": "MyStruct",
+      "abilities": ["copy", "drop"], // any of: copy, drop, store, key
+      "fields": [
+        {"name": "x", "type": "u64"},
+        {"name": "id", "type": "UID"}  // use plain name if imported above
+      ]
+    }
+  ],
+  "functions": [                     // at least one function required
+    {
+      "name": "attack",
+      "visibility": "public",        // public | private | friend
+      "is_entry": true,              // optional, default false
+      "parameters": ["u64", "&mut TxContext"],  // type strings
+      "returns": [],                 // type strings
+      "locals": ["u64"],             // additional locals beyond parameters
+      "code": [                      // bytecode instruction strings
+        "CopyLoc(0)",
+        "LdU64(1)",
+        "Add",
+        "Pop",
+        "Ret"
+      ]
+    }
+  ]
+}
+```
+
+## Type strings
+
+Primitives: `bool`, `u8`, `u16`, `u32`, `u64`, `u128`, `u256`, `address`, `signer`
+References: `&T` (immutable), `&mut T` (mutable)
+Vectors: `vector<T>`
+Imported types: use the type name directly after listing it in `imports.types`
+Shorthands: `TxContext` = `0x2::tx_context::TxContext`, `UID` = `0x2::object::UID`
+Local structs: use the struct name directly (e.g., `"MyStruct"`)
+
+## Bytecode instructions
+
+Local variable operations:
+- `CopyLoc(N)` — copy local N onto stack (N is 0-indexed, params come first)
+- `MoveLoc(N)` — move local N onto stack (local becomes unavailable)
+- `StLoc(N)` — pop stack and store into local N
+- `ImmBorrowLoc(N)` — borrow local N immutably → &T on stack
+- `MutBorrowLoc(N)` — borrow local N mutably → &mut T on stack
+- `FreezeRef` — convert &mut T to &T
+- `ReadRef` — dereference &T → T
+- `WriteRef` — pop T and &mut T, write T through reference
+
+Integer constants:
+- `LdTrue`, `LdFalse` — push bool
+- `LdU8(N)`, `LdU16(N)`, `LdU32(N)`, `LdU64(N)`, `LdU128(N)`, `LdU256(N)` — push integer
+
+Arithmetic (pop 2 same-type integers, push 1):
+- `Add`, `Sub`, `Mul`, `Div`, `Mod`
+- `BitAnd`, `BitOr`, `Xor`
+- `Shl`, `Shr` — shift (second operand must be u8)
+
+Comparison (pop 2 same-type integers, push bool):
+- `Lt`, `Gt`, `Le`, `Ge`, `Eq`, `Neq`
+
+Logic (on bools):
+- `And`, `Or`, `Not`
+
+Control flow:
+- `Branch(N)` — unconditional jump to instruction index N (0-based)
+- `BrTrue(N)` — pop bool, jump if true
+- `BrFalse(N)` — pop bool, jump if false
+- `Ret` — return (must match function return type signature)
+
+Stack:
+- `Pop` — discard top of stack
+- `Abort` — abort with u64 error code from stack
+
+Casts:
+- `CastU8`, `CastU16`, `CastU32`, `CastU64`, `CastU128`, `CastU256`
+
+Struct operations:
+- `Pack(StructName)` — pop field values from stack, push struct value
+- `Unpack(StructName)` — pop struct value, push field values onto stack
+- `ImmBorrowField(N)` — borrow field N of struct ref (N is field_handle index)
+- `MutBorrowField(N)` — mutable borrow of field N
+
+Function calls:
+- `Call(module::function)` — call imported function (must be in imports.functions)
+
+## Key constraints
+
+1. Every function MUST end with `Ret`
+2. The stack must be empty at `Ret` (unless returning values matching the `returns` list)
+3. Branch targets are instruction indices (0-based) within the function body
+4. `CopyLoc`/`MoveLoc` can only access initialized locals (params are pre-initialized)
+5. Stack depth must be identical on all paths that merge at a branch target
+6. For `key` structs: the FIRST field must be of type `UID` (from 0x2::object)
+"#;
+
+pub const BYTECODE_REFERENCE: &str = r#"
+Complete Move bytecode instruction reference for LLM use:
+
+STACK EFFECTS (→ = result type pushed):
+  LdTrue → bool        LdFalse → bool
+  LdU8(n) → u8        LdU16(n) → u16      LdU32(n) → u32
+  LdU64(n) → u64      LdU128(n) → u128    LdU256(n) → u256
+  CopyLoc(i) → T      (T = type of local i)
+  MoveLoc(i) → T      (moves, local becomes unavailable)
+  StLoc(i): T →       (pops T, stores to local i, local must be type T)
+  ImmBorrowLoc(i) → &T
+  MutBorrowLoc(i) → &mut T
+  FreezeRef: &mut T → &T
+  ReadRef: &T → T
+  WriteRef: T, &mut T →    (pops value then reference, writes)
+  Pack(S): f0, f1, ... → S (fields in declaration order)
+  Unpack(S): S → f0, f1, ... (fields in declaration order)
+  ImmBorrowField(fhi): &S → &T  (field handle index → field type)
+  MutBorrowField(fhi): &mut S → &mut T
+  Call(fhi): args → rets
+  Add/Sub/Mul/Div/Mod: T, T → T   (same integer type)
+  BitAnd/BitOr/Xor: T, T → T
+  Shl/Shr: T, u8 → T  (first arg is any int, second must be u8)
+  Lt/Gt/Le/Ge: T, T → bool
+  Eq/Neq: T, T → bool  (any copyable type)
+  And/Or: bool, bool → bool
+  Not: bool → bool
+  CastU8..CastU256: (any int) → (target type)
+  Branch(n): (no stack effect)
+  BrTrue(n): bool →    (jumps if true)
+  BrFalse(n): bool →   (jumps if false)
+  Pop: T →
+  Ret: (return values) →
+  Abort: u64 →
+"#;
+
+// ─── Prompt builder ───────────────────────────────────────────────────────────
+
+/// Build a prompt asking Claude to generate a `ModuleSpec` JSON that exercises
+/// the given coverage gap.
+///
+/// `source_context` is the relevant verifier source code (a snippet or the
+/// full file content) that the LLM should reason about.
+pub fn build_seed_gen_prompt(gap: &CoverageGap, source_context: &str) -> String {
+    format!(
+        r#"You are an expert in the Move bytecode format and the Sui Move VM verifier.
+Your task is to generate a `ModuleSpec` JSON that exercises a specific, hard-to-reach
+verifier path. This will be used as a fuzzing seed.
+
+{VERIFIER_ARCHITECTURE}
+
+{MODULE_SPEC_REFERENCE}
+
+# Target coverage gap
+
+ID: {gap_id}
+Description: {gap_description}
+Verifier pass: {gap_pass:?}
+Error expected: {gap_error}
+
+# LLM hint
+
+{gap_hint}
+
+# Relevant verifier source code
+
+```rust
+{source_context}
+```
+
+# Your task
+
+Generate a `ModuleSpec` JSON that:
+1. Is structurally valid (passes BoundsChecker and SignatureChecker)
+2. Specifically targets the path described above
+3. Is as minimal as possible — include only what's needed to reach the target path
+
+Respond with ONLY the JSON, no explanation. Wrap it in ```json ... ``` fences.
+The JSON must be complete and valid — it will be parsed directly.
+
+Example of the expected format:
+```json
+{{
+  "module_name": "fuzz_target",
+  "imports": [],
+  "structs": [],
+  "functions": [{{
+    "name": "f",
+    "visibility": "public",
+    "parameters": [],
+    "returns": [],
+    "locals": [],
+    "code": ["LdU64(42)", "Pop", "Ret"]
+  }}]
+}}
+```
+
+Now generate the ModuleSpec for the target gap:
+"#,
+        gap_id = gap.path_id,
+        gap_description = gap.description,
+        gap_pass = gap.pass,
+        gap_error = gap
+            .error_code
+            .map(|c| format!("{:?}", c))
+            .unwrap_or_else(|| "varies (check Sui pass)".to_string()),
+        gap_hint = gap.llm_hint,
+    )
+}
+
+/// Build a retry prompt when the previous attempt failed.
+///
+/// `previous_spec` is the JSON the LLM produced last time.
+/// `error` is the error we got when trying to build/verify with it.
+pub fn build_retry_prompt(gap: &CoverageGap, previous_spec: &str, error: &str) -> String {
+    format!(
+        r#"Your previous attempt to generate a ModuleSpec for gap `{gap_id}` failed.
+
+**Error:** {error}
+
+**Your previous ModuleSpec:**
+```json
+{previous_spec}
+```
+
+Please fix the ModuleSpec to avoid this error while still targeting the same gap:
+- {gap_description}
+- Hint: {gap_hint}
+
+{MODULE_SPEC_REFERENCE}
+
+{BYTECODE_REFERENCE}
+
+Respond with ONLY the corrected JSON in ```json ... ``` fences.
+"#,
+        gap_id = gap.path_id,
+        gap_description = gap.description,
+        gap_hint = gap.llm_hint,
+    )
+}
+
+/// Extract the first ```json ... ``` block from an LLM response string.
+pub fn extract_json(response: &str) -> Option<&str> {
+    let start = response.find("```json")?.checked_add(7)?;
+    let rest = &response[start..];
+    // Skip optional leading newline.
+    let content_start = if rest.starts_with('\n') { 1 } else { 0 };
+    let end = rest.find("```")?;
+    Some(rest[content_start..end].trim())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_json_basic() {
+        let resp = "Here is the result:\n```json\n{\"a\": 1}\n```\nDone.";
+        assert_eq!(extract_json(resp), Some("{\"a\": 1}"));
+    }
+
+    #[test]
+    fn extract_json_no_newline() {
+        let resp = "```json{\"x\":2}```";
+        assert_eq!(extract_json(resp), Some("{\"x\":2}"));
+    }
+
+    #[test]
+    fn extract_json_none_without_fence() {
+        let resp = "no json here";
+        assert_eq!(extract_json(resp), None);
+    }
+}

--- a/crates/sui-move-fuzzer/src/module_gen.rs
+++ b/crates/sui-move-fuzzer/src/module_gen.rs
@@ -1,0 +1,983 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Grammar-based `CompiledModule` generator for Sui Move VM fuzzing.
+//!
+//! Generates structurally valid modules that pass bounds checking, duplication
+//! checking, and type safety — reaching deep verifier passes (reference safety,
+//! locals safety, Sui-specific checks). Uses `arbitrary::Unstructured` for
+//! fuzzer-driven randomness so that libFuzzer can efficiently explore the
+//! generation space.
+
+use arbitrary::{Result, Unstructured};
+use move_binary_format::file_format::{
+    AbilitySet, Bytecode, CodeUnit, CompiledModule, DatatypeHandle, DatatypeHandleIndex,
+    FieldDefinition, FieldHandle, FunctionDefinition, FunctionHandle, FunctionHandleIndex,
+    IdentifierIndex, ModuleHandleIndex, Signature, SignatureIndex, SignatureToken,
+    StructDefinition, StructDefinitionIndex, StructFieldInformation, TypeSignature, Visibility,
+    empty_module,
+};
+use move_core_types::identifier::Identifier;
+
+/// Configuration for module generation, derived from fuzzer input.
+#[derive(Debug, Clone, arbitrary::Arbitrary)]
+pub struct ModuleGenConfig {
+    pub num_structs: u8,
+    pub num_functions: u8,
+    pub num_fields_per: u8,
+    pub max_code_len: u8,
+    pub has_key_struct: bool,
+    pub has_entry_fn: bool,
+}
+
+impl ModuleGenConfig {
+    fn clamped(&self) -> ClampedConfig {
+        ClampedConfig {
+            num_structs: (self.num_structs % 7) as usize,       // 0..=6
+            num_functions: (self.num_functions % 6 + 1) as usize, // 1..=6
+            num_fields_per: (self.num_fields_per % 5) as usize, // 0..=4
+            max_code_len: (self.max_code_len % 45 + 4) as usize, // 4..=48
+            has_entry_fn: self.has_entry_fn,
+        }
+    }
+}
+
+struct ClampedConfig {
+    num_structs: usize,
+    num_functions: usize,
+    num_fields_per: usize,
+    max_code_len: usize,
+    has_entry_fn: bool,
+}
+
+/// Intern pool for deduplicating signatures.
+struct SigPool {
+    sigs: Vec<Signature>,
+}
+
+impl SigPool {
+    fn new() -> Self {
+        // Start with the empty signature that empty_module() provides
+        Self {
+            sigs: vec![Signature(vec![])],
+        }
+    }
+
+    /// Return the index for this signature, adding it only if not already present.
+    fn intern(&mut self, sig: Signature) -> SignatureIndex {
+        for (i, existing) in self.sigs.iter().enumerate() {
+            if existing.0 == sig.0 {
+                return SignatureIndex(i as u16);
+            }
+        }
+        let idx = self.sigs.len() as u16;
+        self.sigs.push(sig);
+        SignatureIndex(idx)
+    }
+}
+
+/// Context passed to code generation with module-level struct/field information.
+struct CodeGenContext {
+    /// Types of all locals (params ++ locals).
+    all_local_types: Vec<SignatureToken>,
+    num_params: usize,
+    return_types: Vec<SignatureToken>,
+    /// struct_def_idx → vec of field types (in declaration order).
+    struct_fields: Vec<Vec<SignatureToken>>,
+    /// field_handle_idx → (struct_def_idx, field_idx, field_type).
+    field_handle_info: Vec<(u16, u16, SignatureToken)>,
+}
+
+/// Builds a `CompiledModule` from fuzzer-driven configuration.
+pub struct ModuleBuilder {
+    config: ModuleGenConfig,
+}
+
+impl ModuleBuilder {
+    pub fn new(config: ModuleGenConfig) -> Self {
+        Self { config }
+    }
+
+    pub fn build(self, u: &mut Unstructured) -> Result<CompiledModule> {
+        let cfg = self.config.clamped();
+        let mut module = empty_module();
+        let mut sig_pool = SigPool::new();
+
+        // empty_module() gives us:
+        //   identifiers[0] = "DUMMY"
+        //   address_identifiers[0] = AccountAddress::ZERO
+        //   module_handles[0] = { address: 0, name: 0 }
+        //   signatures[0] = Signature(vec![])
+        //   self_module_handle_idx = ModuleHandleIndex(0)
+
+        // Step 1: Replace module name and add identifiers
+        module.identifiers[0] = Identifier::new("fuzz_mod").unwrap();
+
+        let struct_name_start = module.identifiers.len() as u16;
+        for i in 0..cfg.num_structs {
+            module
+                .identifiers
+                .push(Identifier::new(format!("S{i}")).unwrap());
+        }
+
+        let fn_name_start = module.identifiers.len() as u16;
+        for i in 0..cfg.num_functions {
+            module
+                .identifiers
+                .push(Identifier::new(format!("f{i}")).unwrap());
+        }
+
+        // Allocate at least 1 field name even if config says 0, since we
+        // enforce a minimum of 1 field per struct to avoid ZERO_SIZED_STRUCT.
+        let actual_field_names = cfg.num_fields_per.max(1);
+        let field_name_start = module.identifiers.len() as u16;
+        for i in 0..actual_field_names {
+            module
+                .identifiers
+                .push(Identifier::new(format!("field{i}")).unwrap());
+        }
+
+        // "id" identifier reserved for UID field in Key structs (added by mutations)
+        module
+            .identifiers
+            .push(Identifier::new("id").unwrap());
+
+        // Step 2: Add struct definitions
+        // We don't generate Key structs because Sui requires the first field to
+        // be 0x2::object::UID, which requires importing the Sui framework.
+        // Mutations can add Key ability to test the Sui verifier's UID check.
+        for i in 0..cfg.num_structs {
+            let abilities = AbilitySet::EMPTY
+                | move_binary_format::file_format::Ability::Copy
+                | move_binary_format::file_format::Ability::Drop
+                | move_binary_format::file_format::Ability::Store;
+
+            let dt_handle_idx = module.datatype_handles.len() as u16;
+            module.datatype_handles.push(DatatypeHandle {
+                module: ModuleHandleIndex(0),
+                name: IdentifierIndex(struct_name_start + i as u16),
+                abilities,
+                type_parameters: vec![],
+            });
+
+            let mut fields = Vec::new();
+
+            // Ensure at least 1 field (Move rejects zero-sized structs)
+            let field_count = cfg.num_fields_per.max(1);
+            for f in 0..field_count {
+                let sig_tok = pick_simple_type(u)?;
+                let name_idx = field_name_start + f as u16;
+                if (name_idx as usize) < module.identifiers.len() {
+                    fields.push(FieldDefinition {
+                        name: IdentifierIndex(name_idx),
+                        signature: TypeSignature(sig_tok),
+                    });
+                }
+            }
+
+            module.struct_defs.push(StructDefinition {
+                struct_handle: DatatypeHandleIndex(dt_handle_idx),
+                field_information: if fields.is_empty() {
+                    StructFieldInformation::Declared(vec![])
+                } else {
+                    StructFieldInformation::Declared(fields)
+                },
+            });
+        }
+
+        // Step 2b: Populate field_handles and build struct field type map
+        let mut struct_fields: Vec<Vec<SignatureToken>> = Vec::new();
+        let mut field_handle_info: Vec<(u16, u16, SignatureToken)> = Vec::new();
+        for (struct_idx, struct_def) in module.struct_defs.iter().enumerate() {
+            if let StructFieldInformation::Declared(fields) = &struct_def.field_information {
+                let field_types: Vec<SignatureToken> =
+                    fields.iter().map(|f| f.signature.0.clone()).collect();
+                for (field_idx, fd) in fields.iter().enumerate() {
+                    let fh_idx = module.field_handles.len();
+                    module.field_handles.push(FieldHandle {
+                        owner: StructDefinitionIndex(struct_idx as u16),
+                        field: field_idx as u16,
+                    });
+                    field_handle_info.push((
+                        struct_idx as u16,
+                        field_idx as u16,
+                        fd.signature.0.clone(),
+                    ));
+                    let _ = fh_idx; // used implicitly by index
+                }
+                struct_fields.push(field_types);
+            } else {
+                struct_fields.push(vec![]);
+            }
+        }
+
+        // Step 3: Add function definitions with type-aware code generation
+        for i in 0..cfg.num_functions {
+            let is_entry = cfg.has_entry_fn && i == 0;
+
+            let num_params: usize = *u.choose(&[0_usize, 1, 2])?;
+            let num_returns: usize = *u.choose(&[0_usize, 0, 0, 1])?;
+
+            let mut param_tokens = Vec::new();
+            for _ in 0..num_params {
+                param_tokens.push(pick_simple_type(u)?);
+            }
+
+            let mut return_tokens = Vec::new();
+            for _ in 0..num_returns {
+                return_tokens.push(pick_simple_type(u)?);
+            }
+
+            // Intern signatures to avoid duplicates
+            let params_sig_idx = sig_pool.intern(Signature(param_tokens.clone()));
+            let return_sig_idx = sig_pool.intern(Signature(return_tokens.clone()));
+
+            let num_locals: usize = *u.choose(&[0_usize, 1, 2, 3])?;
+            let mut local_tokens = Vec::new();
+            for _ in 0..num_locals {
+                // 25% chance of struct-typed local if structs exist
+                if !struct_fields.is_empty() && u.ratio(1, 4)? {
+                    let idx = u.int_in_range(0..=(struct_fields.len() - 1))?;
+                    local_tokens
+                        .push(SignatureToken::Datatype(DatatypeHandleIndex(idx as u16)));
+                } else {
+                    local_tokens.push(pick_simple_type(u)?);
+                }
+            }
+            let locals_sig_idx = sig_pool.intern(Signature(local_tokens.clone()));
+
+            // Build the full local type map: params ++ locals
+            let mut all_local_types: Vec<SignatureToken> = param_tokens.clone();
+            all_local_types.extend(local_tokens);
+
+            let fn_handle_idx = module.function_handles.len() as u16;
+            module.function_handles.push(FunctionHandle {
+                module: ModuleHandleIndex(0),
+                name: IdentifierIndex(fn_name_start + i as u16),
+                parameters: params_sig_idx,
+                return_: return_sig_idx,
+                type_parameters: vec![],
+            });
+
+            let ctx = CodeGenContext {
+                all_local_types: all_local_types.clone(),
+                num_params,
+                return_types: return_tokens.clone(),
+                struct_fields: struct_fields.clone(),
+                field_handle_info: field_handle_info.clone(),
+            };
+
+            let code = gen_typed_code_unit(u, &ctx, cfg.max_code_len)?;
+
+            module.function_defs.push(FunctionDefinition {
+                function: FunctionHandleIndex(fn_handle_idx),
+                visibility: Visibility::Public,
+                is_entry,
+                acquires_global_resources: vec![],
+                code: Some(CodeUnit {
+                    locals: locals_sig_idx,
+                    code,
+                    jump_tables: vec![],
+                }),
+            });
+        }
+
+        // Finalize: replace module's signature pool with deduplicated pool
+        module.signatures = sig_pool.sigs;
+
+        Ok(module)
+    }
+}
+
+/// Pick a random primitive `SignatureToken`.
+/// Excludes Address since we cannot produce Address constants via bytecode
+/// (Address requires LdConst with a constant pool entry).
+fn pick_simple_type(u: &mut Unstructured) -> Result<SignatureToken> {
+    let choice: u8 = u.int_in_range(0..=6)?;
+    Ok(match choice {
+        0 => SignatureToken::Bool,
+        1 => SignatureToken::U8,
+        2 => SignatureToken::U16,
+        3 => SignatureToken::U32,
+        4 => SignatureToken::U64,
+        5 => SignatureToken::U128,
+        6 => SignatureToken::U256,
+        _ => unreachable!(),
+    })
+}
+
+/// Returns true if the token is an integer type (not Bool or Address).
+fn is_integer(tok: &SignatureToken) -> bool {
+    matches!(
+        tok,
+        SignatureToken::U8
+            | SignatureToken::U16
+            | SignatureToken::U32
+            | SignatureToken::U64
+            | SignatureToken::U128
+            | SignatureToken::U256
+    )
+}
+
+/// Returns true if the token is a primitive (non-struct, non-reference) type.
+fn is_primitive(tok: &SignatureToken) -> bool {
+    matches!(
+        tok,
+        SignatureToken::Bool
+            | SignatureToken::U8
+            | SignatureToken::U16
+            | SignatureToken::U32
+            | SignatureToken::U64
+            | SignatureToken::U128
+            | SignatureToken::U256
+    )
+}
+
+/// Generate a type-safe bytecode sequence with references, branches, and struct ops.
+///
+/// Tracks a typed stack and local initialization state to ensure:
+/// - All operations receive operands of the correct type
+/// - CopyLoc/MoveLoc only access initialized locals
+/// - StLoc stores the correct type to the local
+/// - Return values match the function's return signature
+/// - References are created and consumed in self-contained patterns
+/// - Diamond branches push the same type on both sides
+fn gen_typed_code_unit(
+    u: &mut Unstructured,
+    ctx: &CodeGenContext,
+    max_len: usize,
+) -> Result<Vec<Bytecode>> {
+    let mut code = Vec::new();
+    let mut type_stack: Vec<SignatureToken> = Vec::new();
+
+    // Track which locals are initialized.
+    // Parameters (indices 0..num_params) start initialized.
+    let mut local_initialized = vec![false; ctx.all_local_types.len()];
+    for init in local_initialized.iter_mut().take(ctx.num_params) {
+        *init = true;
+    }
+
+    // Reserve space for return sequence + Ret
+    let effective_max = max_len.saturating_sub(ctx.return_types.len() + 1).max(1);
+
+    while code.len() < effective_max {
+        let stack_len = type_stack.len();
+
+        // --- Check what actions are possible ---
+
+        let can_binop = stack_len >= 2 && {
+            let a = &type_stack[stack_len - 1];
+            let b = &type_stack[stack_len - 2];
+            is_integer(a) && a == b
+        };
+        let can_shift = stack_len >= 2 && {
+            let top = &type_stack[stack_len - 1];
+            let below = &type_stack[stack_len - 2];
+            *top == SignatureToken::U8 && is_integer(below)
+        };
+        let can_compare = stack_len >= 2 && {
+            let a = &type_stack[stack_len - 1];
+            let b = &type_stack[stack_len - 2];
+            is_integer(a) && a == b
+        };
+        let can_not = stack_len >= 1 && type_stack[stack_len - 1] == SignatureToken::Bool;
+        let can_cast = stack_len >= 1 && is_integer(&type_stack[stack_len - 1]);
+        let can_pop = stack_len >= 1;
+
+        // StLoc candidates: locals matching top-of-stack type
+        let stloc_candidates: Vec<u8> = if can_pop {
+            let top = &type_stack[stack_len - 1];
+            ctx.all_local_types
+                .iter()
+                .enumerate()
+                .filter(|(_, lt)| *lt == top)
+                .map(|(i, _)| i as u8)
+                .collect()
+        } else {
+            vec![]
+        };
+
+        // CopyLoc candidates: initialized locals (all our types have Copy)
+        let copyloc_candidates: Vec<u8> = ctx
+            .all_local_types
+            .iter()
+            .enumerate()
+            .filter(|(i, lt)| local_initialized[*i] && is_primitive(lt))
+            .map(|(i, _)| i as u8)
+            .collect();
+
+        // MoveLoc candidates: initialized locals with primitive types
+        let moveloc_candidates: Vec<u8> = ctx
+            .all_local_types
+            .iter()
+            .enumerate()
+            .filter(|(i, lt)| local_initialized[*i] && is_primitive(lt))
+            .map(|(i, _)| i as u8)
+            .collect();
+
+        // Borrow-read pattern: initialized primitive locals (net +1)
+        let borrow_read_candidates: Vec<u8> = ctx
+            .all_local_types
+            .iter()
+            .enumerate()
+            .filter(|(i, lt)| local_initialized[*i] && is_primitive(lt))
+            .map(|(i, _)| i as u8)
+            .collect();
+
+        // Borrow-write pattern: need matching primitive T on stack AND an initialized local of type T
+        let borrow_write_candidates: Vec<u8> = if can_pop && is_primitive(&type_stack[stack_len - 1])
+        {
+            let top = &type_stack[stack_len - 1];
+            ctx.all_local_types
+                .iter()
+                .enumerate()
+                .filter(|(i, lt)| local_initialized[*i] && *lt == top)
+                .map(|(i, _)| i as u8)
+                .collect()
+        } else {
+            vec![]
+        };
+
+        // Borrow-field-read pattern: initialized struct-typed local
+        let borrow_field_read_candidates: Vec<(u8, usize)> = ctx
+            .all_local_types
+            .iter()
+            .enumerate()
+            .filter_map(|(i, lt)| {
+                if !local_initialized[i] {
+                    return None;
+                }
+                if let SignatureToken::Datatype(dt_idx) = lt {
+                    let sdi = dt_idx.0 as usize;
+                    if sdi < ctx.struct_fields.len() && !ctx.struct_fields[sdi].is_empty() {
+                        return Some((i as u8, sdi));
+                    }
+                }
+                None
+            })
+            .collect();
+
+        // If-diamond pattern: need Bool on top of stack, and enough room for
+        // the branch overhead (BrFalse + then_const + Branch + else_const = 4+ insns)
+        let can_if_diamond = stack_len >= 1
+            && type_stack[stack_len - 1] == SignatureToken::Bool
+            && code.len() + 6 < effective_max;
+
+        // Pack: need a struct with fields we can produce constants for
+        let pack_candidates: Vec<usize> = ctx
+            .struct_fields
+            .iter()
+            .enumerate()
+            .filter(|(_, fields)| {
+                !fields.is_empty()
+                    && fields.iter().all(is_primitive)
+                    && code.len() + fields.len() + 1 < effective_max
+            })
+            .map(|(i, _)| i)
+            .collect();
+
+        // Unpack: need struct value on top of stack
+        let can_unpack = can_pop && {
+            if let SignatureToken::Datatype(dt_idx) = &type_stack[stack_len - 1] {
+                let sdi = dt_idx.0 as usize;
+                sdi < ctx.struct_fields.len() && !ctx.struct_fields[sdi].is_empty()
+            } else {
+                false
+            }
+        };
+
+        // CopyLoc for struct-typed locals (all our structs have Copy)
+        let copyloc_struct_candidates: Vec<u8> = ctx
+            .all_local_types
+            .iter()
+            .enumerate()
+            .filter(|(i, lt)| {
+                local_initialized[*i] && matches!(lt, SignatureToken::Datatype(_))
+            })
+            .map(|(i, _)| i as u8)
+            .collect();
+
+        // --- Build weighted action list ---
+        // Actions: 0=push_const 1=binop 2=compare 3=not 4=cast 5=pop 6=stloc
+        //   7=copyloc 8=shift 9=moveloc 10=borrow_read 11=borrow_write
+        //   12=borrow_field_read 13=if_diamond 14=pack 15=unpack
+        let mut actions: Vec<u8> = Vec::new();
+
+        // push_const: weight 3
+        actions.extend_from_slice(&[0, 0, 0]);
+        if can_binop {
+            actions.push(1);
+        }
+        if can_compare {
+            actions.push(2);
+        }
+        if can_not {
+            actions.push(3);
+        }
+        if can_cast {
+            actions.push(4);
+        }
+        if can_pop {
+            actions.push(5);
+        }
+        if !stloc_candidates.is_empty() {
+            actions.push(6);
+        }
+        if !copyloc_candidates.is_empty() {
+            // weight 2
+            actions.extend_from_slice(&[7, 7]);
+        }
+        if can_shift {
+            actions.push(8);
+        }
+        if !moveloc_candidates.is_empty() {
+            actions.push(9);
+        }
+        if !borrow_read_candidates.is_empty() {
+            // weight 2
+            actions.extend_from_slice(&[10, 10]);
+        }
+        if !borrow_write_candidates.is_empty() {
+            actions.push(11);
+        }
+        if !borrow_field_read_candidates.is_empty() {
+            actions.push(12);
+        }
+        if can_if_diamond {
+            actions.push(13);
+        }
+        if !pack_candidates.is_empty() {
+            actions.push(14);
+        }
+        if can_unpack {
+            actions.push(15);
+        }
+        if !copyloc_struct_candidates.is_empty() {
+            actions.push(7); // reuse copyloc action for struct locals
+        }
+
+        let action = *u.choose(&actions)?;
+        match action {
+            0 => {
+                // Push a typed constant
+                let tok = pick_simple_type(u)?;
+                emit_typed_const(u, &mut code, &tok)?;
+                type_stack.push(tok);
+            }
+            1 => {
+                // Binary op: pop 2 same-type integers, push 1 of same type
+                let result_type = type_stack[stack_len - 1].clone();
+                type_stack.pop();
+                type_stack.pop();
+                emit_arith_binop(u, &mut code)?;
+                type_stack.push(result_type);
+            }
+            2 => {
+                // Comparison: pop 2 same-type integers, push Bool
+                type_stack.pop();
+                type_stack.pop();
+                let cmp = u.choose(&[Bytecode::Lt, Bytecode::Gt, Bytecode::Le, Bytecode::Ge])?;
+                code.push(cmp.clone());
+                type_stack.push(SignatureToken::Bool);
+            }
+            3 => {
+                // Not: pop Bool, push Bool
+                code.push(Bytecode::Not);
+            }
+            4 => {
+                // Cast: pop integer, push target integer type
+                type_stack.pop();
+                let (cast_bc, cast_type) = pick_cast(u)?;
+                code.push(cast_bc);
+                type_stack.push(cast_type);
+            }
+            5 => {
+                // Pop
+                type_stack.pop();
+                code.push(Bytecode::Pop);
+            }
+            6 => {
+                // StLoc
+                let idx = *u.choose(&stloc_candidates)?;
+                type_stack.pop();
+                code.push(Bytecode::StLoc(idx));
+                local_initialized[idx as usize] = true;
+            }
+            7 => {
+                // CopyLoc (primitive or struct — all our types have Copy)
+                let all_copy: Vec<u8> = ctx
+                    .all_local_types
+                    .iter()
+                    .enumerate()
+                    .filter(|(i, _)| local_initialized[*i])
+                    .map(|(i, _)| i as u8)
+                    .collect();
+                if let Ok(&idx) = u.choose(&all_copy) {
+                    let ty = ctx.all_local_types[idx as usize].clone();
+                    code.push(Bytecode::CopyLoc(idx));
+                    type_stack.push(ty);
+                } else {
+                    // Fallback: push constant
+                    let tok = pick_simple_type(u)?;
+                    emit_typed_const(u, &mut code, &tok)?;
+                    type_stack.push(tok);
+                }
+            }
+            8 => {
+                // Shift: pop U8 and integer, push integer
+                let result_type = type_stack[stack_len - 2].clone();
+                type_stack.pop();
+                type_stack.pop();
+                let op = u.choose(&[Bytecode::Shl, Bytecode::Shr])?;
+                code.push(op.clone());
+                type_stack.push(result_type);
+            }
+            9 => {
+                // MoveLoc: moves value out of local, marks it unavailable
+                let idx = *u.choose(&moveloc_candidates)?;
+                let ty = ctx.all_local_types[idx as usize].clone();
+                code.push(Bytecode::MoveLoc(idx));
+                type_stack.push(ty);
+                local_initialized[idx as usize] = false;
+            }
+            10 => {
+                // Borrow-Freeze-Read pattern (net +1): BorrowLoc → FreezeRef → ReadRef
+                let idx = *u.choose(&borrow_read_candidates)?;
+                code.push(Bytecode::MutBorrowLoc(idx));
+                code.push(Bytecode::FreezeRef);
+                code.push(Bytecode::ReadRef);
+                let ty = ctx.all_local_types[idx as usize].clone();
+                type_stack.push(ty);
+            }
+            11 => {
+                // Borrow-Write pattern (net -1): BorrowLoc → WriteRef
+                let idx = *u.choose(&borrow_write_candidates)?;
+                type_stack.pop(); // consume the T value on stack
+                code.push(Bytecode::MutBorrowLoc(idx));
+                code.push(Bytecode::WriteRef);
+            }
+            12 => {
+                // Borrow-Field-Read pattern (net +1):
+                //   BorrowLoc(struct_local) → ImmBorrowField(fh_idx) → ReadRef
+                let &(local_idx, struct_def_idx) =
+                    u.choose(&borrow_field_read_candidates)?;
+                let fields = &ctx.struct_fields[struct_def_idx];
+                let field_idx = u.int_in_range(0..=(fields.len() - 1))?;
+                let field_type = fields[field_idx].clone();
+
+                // Find the matching field_handle_index
+                let fh_idx = ctx
+                    .field_handle_info
+                    .iter()
+                    .position(|(sdi, fi, _)| {
+                        *sdi == struct_def_idx as u16 && *fi == field_idx as u16
+                    })
+                    .unwrap();
+
+                code.push(Bytecode::ImmBorrowLoc(local_idx));
+                code.push(Bytecode::ImmBorrowField(
+                    move_binary_format::file_format::FieldHandleIndex(fh_idx as u16),
+                ));
+                code.push(Bytecode::ReadRef);
+                type_stack.push(field_type);
+            }
+            13 => {
+                // If-then-else diamond (pops Bool, pushes T):
+                //   BrFalse(else_offset)
+                //   <then: emit_typed_const(T)>
+                //   Branch(end_offset)
+                //   <else: emit_typed_const(T)>
+                //   <end>
+                type_stack.pop(); // consume Bool
+
+                let tok = pick_simple_type(u)?;
+
+                // Emit BrFalse with placeholder offset
+                let brfalse_idx = code.len();
+                code.push(Bytecode::BrFalse(0));
+
+                // Then branch: push constant of type T
+                emit_typed_const(u, &mut code, &tok)?;
+
+                // Branch to end with placeholder
+                let branch_idx = code.len();
+                code.push(Bytecode::Branch(0));
+
+                // Else branch starts here
+                let else_offset = code.len() as u16;
+                emit_typed_const(u, &mut code, &tok)?;
+
+                // End label
+                let end_offset = code.len() as u16;
+
+                // Backpatch
+                code[brfalse_idx] = Bytecode::BrFalse(else_offset);
+                code[branch_idx] = Bytecode::Branch(end_offset);
+
+                type_stack.push(tok);
+            }
+            14 => {
+                // Pack: push field constants then Pack
+                let struct_idx = *u.choose(&pack_candidates)?;
+                let fields = &ctx.struct_fields[struct_idx];
+                for field_ty in fields {
+                    emit_typed_const(u, &mut code, field_ty)?;
+                }
+                code.push(Bytecode::Pack(StructDefinitionIndex(struct_idx as u16)));
+                type_stack.push(SignatureToken::Datatype(DatatypeHandleIndex(
+                    struct_idx as u16,
+                )));
+            }
+            15 => {
+                // Unpack: pop struct, push field values
+                let dt_idx = if let SignatureToken::Datatype(idx) = &type_stack[stack_len - 1] {
+                    idx.0 as usize
+                } else {
+                    unreachable!()
+                };
+                type_stack.pop();
+                let fields = ctx.struct_fields[dt_idx].clone();
+                code.push(Bytecode::Unpack(StructDefinitionIndex(dt_idx as u16)));
+                for ft in &fields {
+                    type_stack.push(ft.clone());
+                }
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    // Balance the stack: pop everything, then push return values as constants.
+    while let Some(ty) = type_stack.pop() {
+        // Struct values also have Drop, so Pop works for all our types
+        let _ = ty;
+        code.push(Bytecode::Pop);
+    }
+
+    for ret_ty in &ctx.return_types {
+        emit_typed_const(u, &mut code, ret_ty)?;
+    }
+
+    code.push(Bytecode::Ret);
+    Ok(code)
+}
+
+/// Emit a constant of a specific type onto the stack.
+fn emit_typed_const(
+    u: &mut Unstructured,
+    code: &mut Vec<Bytecode>,
+    tok: &SignatureToken,
+) -> Result<()> {
+    match tok {
+        SignatureToken::Bool => {
+            if u.arbitrary::<bool>()? {
+                code.push(Bytecode::LdTrue);
+            } else {
+                code.push(Bytecode::LdFalse);
+            }
+        }
+        SignatureToken::U8 => {
+            code.push(Bytecode::LdU8(u.arbitrary()?));
+        }
+        SignatureToken::U16 => {
+            code.push(Bytecode::LdU16(u.arbitrary()?));
+        }
+        SignatureToken::U32 => {
+            code.push(Bytecode::LdU32(u.arbitrary()?));
+        }
+        SignatureToken::U64 => {
+            code.push(Bytecode::LdU64(u.arbitrary()?));
+        }
+        SignatureToken::U128 => {
+            code.push(Bytecode::LdU128(u.arbitrary()?));
+        }
+        SignatureToken::U256 => {
+            code.push(Bytecode::LdU256(Box::new(move_core_types::u256::U256::from(
+                u.int_in_range(0u64..=u64::MAX)?,
+            ))));
+        }
+        _ => {
+            // Fallback for Address or complex types — push U64 as placeholder.
+            // pick_simple_type() excludes Address, so this is only hit by
+            // mutations or future extensions.
+            code.push(Bytecode::LdU64(0));
+        }
+    }
+    Ok(())
+}
+
+/// Pick a random cast instruction and its result type.
+fn pick_cast(u: &mut Unstructured) -> Result<(Bytecode, SignatureToken)> {
+    let choice: u8 = u.int_in_range(0..=5)?;
+    Ok(match choice {
+        0 => (Bytecode::CastU8, SignatureToken::U8),
+        1 => (Bytecode::CastU16, SignatureToken::U16),
+        2 => (Bytecode::CastU32, SignatureToken::U32),
+        3 => (Bytecode::CastU64, SignatureToken::U64),
+        4 => (Bytecode::CastU128, SignatureToken::U128),
+        5 => (Bytecode::CastU256, SignatureToken::U256),
+        _ => unreachable!(),
+    })
+}
+
+/// Emit an arithmetic binary operation (pop 2 same-type integers, push 1).
+/// Shl/Shr are handled separately since they require U8 as second operand.
+fn emit_arith_binop(u: &mut Unstructured, code: &mut Vec<Bytecode>) -> Result<()> {
+    let op = u.choose(&[
+        Bytecode::Add,
+        Bytecode::Sub,
+        Bytecode::Mul,
+        Bytecode::Div,
+        Bytecode::Mod,
+        Bytecode::BitAnd,
+        Bytecode::BitOr,
+        Bytecode::Xor,
+    ])?;
+    code.push(op.clone());
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generated_module_passes_bounds_check() {
+        let data: Vec<u8> = (0..256).map(|i| (i % 256) as u8).collect();
+        let mut u = Unstructured::new(&data);
+        let config: ModuleGenConfig = u.arbitrary().unwrap();
+        let builder = ModuleBuilder::new(config);
+        let module = builder.build(&mut u).unwrap();
+
+        let mut bytes = vec![];
+        module.serialize(&mut bytes).unwrap();
+
+        let config = move_binary_format::binary_config::BinaryConfig::standard();
+        let result = CompiledModule::deserialize_with_config(&bytes, &config);
+        assert!(result.is_ok(), "Bounds check failed: {result:?}");
+    }
+
+    #[test]
+    fn generated_module_has_functions() {
+        let data: Vec<u8> = (0..256).map(|i| ((i * 7) % 256) as u8).collect();
+        let mut u = Unstructured::new(&data);
+        let config: ModuleGenConfig = u.arbitrary().unwrap();
+        let builder = ModuleBuilder::new(config);
+        let module = builder.build(&mut u).unwrap();
+        assert!(
+            !module.function_defs.is_empty(),
+            "Module must have at least one function"
+        );
+    }
+
+    #[test]
+    fn multiple_seeds_produce_valid_modules() {
+        for seed in 0u8..20 {
+            let data: Vec<u8> = (0..512)
+                .map(|i| ((i as u16).wrapping_mul(seed as u16 + 1) % 256) as u8)
+                .collect();
+            let mut u = Unstructured::new(&data);
+            let config: ModuleGenConfig = match u.arbitrary() {
+                Ok(c) => c,
+                Err(_) => continue,
+            };
+            let builder = ModuleBuilder::new(config);
+            let module = match builder.build(&mut u) {
+                Ok(m) => m,
+                Err(_) => continue,
+            };
+
+            let mut bytes = vec![];
+            module.serialize(&mut bytes).unwrap();
+
+            let bin_config = move_binary_format::binary_config::BinaryConfig::standard();
+            let result = CompiledModule::deserialize_with_config(&bytes, &bin_config);
+            assert!(
+                result.is_ok(),
+                "Seed {seed} failed bounds check: {result:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn verification_pass_rates() {
+        use move_bytecode_verifier::verify_module_with_config_metered;
+        use move_bytecode_verifier_meter::dummy::DummyMeter;
+        use crate::sui_harness::{run_full_verification, sui_verifier_config};
+        use std::collections::HashMap;
+
+        let verifier_config = sui_verifier_config();
+        let mut pass_bounds = 0u32;
+        let mut pass_move = 0u32;
+        let mut pass_sui = 0u32;
+        let total = 200u32;
+        let mut error_counts: HashMap<String, u32> = HashMap::new();
+
+        for seed in 0..total {
+            let data: Vec<u8> = (0..1024)
+                .map(|i| {
+                    ((i as u32)
+                        .wrapping_mul(seed + 1)
+                        .wrapping_add(seed.wrapping_mul(37))
+                        % 256) as u8
+                })
+                .collect();
+            let mut u = Unstructured::new(&data);
+            let config: ModuleGenConfig = match u.arbitrary() {
+                Ok(c) => c,
+                Err(_) => continue,
+            };
+            let module = match ModuleBuilder::new(config).build(&mut u) {
+                Ok(m) => m,
+                Err(_) => continue,
+            };
+
+            let mut bytes = vec![];
+            if module.serialize(&mut bytes).is_err() {
+                continue;
+            }
+            let bin_config = move_binary_format::binary_config::BinaryConfig::standard();
+            if CompiledModule::deserialize_with_config(&bytes, &bin_config).is_ok() {
+                pass_bounds += 1;
+            }
+            match verify_module_with_config_metered(&verifier_config, &module, &mut DummyMeter) {
+                Ok(()) => pass_move += 1,
+                Err(e) => {
+                    let key = format!("Move: {:?}", e.major_status());
+                    *error_counts.entry(key).or_insert(0) += 1;
+                }
+            }
+            match run_full_verification(&module) {
+                Ok(()) => pass_sui += 1,
+                Err(e) => {
+                    let key = format!("Sui: {e}");
+                    *error_counts.entry(key).or_insert(0) += 1;
+                }
+            }
+        }
+
+        println!("Verification pass rates ({total} generated modules):");
+        println!(
+            "  Bounds check: {pass_bounds}/{total} ({:.0}%)",
+            pass_bounds as f64 / total as f64 * 100.0
+        );
+        println!(
+            "  Move verify:  {pass_move}/{total} ({:.0}%)",
+            pass_move as f64 / total as f64 * 100.0
+        );
+        println!(
+            "  Sui verify:   {pass_sui}/{total} ({:.0}%)",
+            pass_sui as f64 / total as f64 * 100.0
+        );
+        println!("\nMove verifier error breakdown:");
+        let mut errors: Vec<_> = error_counts.into_iter().collect();
+        errors.sort_by(|a, b| b.1.cmp(&a.1));
+        for (err, count) in &errors {
+            println!("  {err}: {count}");
+        }
+
+        assert!(
+            pass_bounds > total * 90 / 100,
+            "Generator should produce >90% bounds-valid modules, got {pass_bounds}/{total}"
+        );
+    }
+}

--- a/crates/sui-move-fuzzer/src/module_spec.rs
+++ b/crates/sui-move-fuzzer/src/module_spec.rs
@@ -1,0 +1,1069 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! High-level `ModuleSpec` format and `CompiledModule` builder for LLM-guided fuzzing.
+//!
+//! The LLM outputs a `ModuleSpec` JSON describing a module at a high level.
+//! The builder converts it to a `CompiledModule` while managing all the
+//! low-level index arithmetic (identifier pools, signature deduplication,
+//! handle tables). This lets the LLM reason about structure and semantics
+//! without worrying about Move binary format internals.
+//!
+//! # ModuleSpec JSON example
+//!
+//! ```json
+//! {
+//!   "module_name": "attack",
+//!   "imports": [
+//!     {"address": "0x2", "module": "object", "types": ["UID"], "functions": []}
+//!   ],
+//!   "structs": [
+//!     {
+//!       "name": "MyObj",
+//!       "abilities": ["key", "store"],
+//!       "fields": [
+//!         {"name": "id", "type": "0x2::object::UID"},
+//!         {"name": "val", "type": "u64"}
+//!       ]
+//!     }
+//!   ],
+//!   "functions": [
+//!     {
+//!       "name": "run",
+//!       "visibility": "public",
+//!       "is_entry": true,
+//!       "parameters": ["u64"],
+//!       "returns": [],
+//!       "locals": ["u64"],
+//!       "code": ["CopyLoc(0)", "LdU64(1)", "Add", "Pop", "Ret"]
+//!     }
+//!   ]
+//! }
+//! ```
+
+use std::collections::HashMap;
+
+use serde::Deserialize;
+
+use move_binary_format::file_format::{
+    Ability, AbilitySet, AddressIdentifierIndex, Bytecode, CodeUnit, CompiledModule,
+    DatatypeHandle, DatatypeHandleIndex, FieldDefinition, FieldHandle, FieldHandleIndex,
+    FunctionDefinition, FunctionHandle, FunctionHandleIndex, IdentifierIndex, ModuleHandle,
+    ModuleHandleIndex, Signature, SignatureIndex, SignatureToken, StructDefinition,
+    StructDefinitionIndex, StructFieldInformation, TypeSignature, Visibility, empty_module,
+};
+use move_core_types::account_address::AccountAddress;
+use move_core_types::identifier::Identifier;
+
+// ─── Spec types (LLM output format) ──────────────────────────────────────────
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ModuleSpec {
+    pub module_name: String,
+    #[serde(default)]
+    pub imports: Vec<ImportSpec>,
+    #[serde(default)]
+    pub structs: Vec<StructSpec>,
+    pub functions: Vec<FunctionSpec>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ImportSpec {
+    /// Hex address, e.g. "0x2" or full 32-byte form.
+    pub address: String,
+    pub module: String,
+    /// Type names exported by this module that we want to reference.
+    #[serde(default)]
+    pub types: Vec<String>,
+    /// Function names exported by this module that we want to Call.
+    #[serde(default)]
+    pub functions: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct StructSpec {
+    pub name: String,
+    /// e.g. ["copy", "drop", "store", "key"]
+    #[serde(default)]
+    pub abilities: Vec<String>,
+    #[serde(default)]
+    pub fields: Vec<FieldSpec>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct FieldSpec {
+    pub name: String,
+    #[serde(rename = "type")]
+    pub type_: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct FunctionSpec {
+    pub name: String,
+    #[serde(default = "default_public")]
+    pub visibility: String,
+    #[serde(default)]
+    pub is_entry: bool,
+    #[serde(default)]
+    pub parameters: Vec<String>,
+    #[serde(default)]
+    pub returns: Vec<String>,
+    /// Additional locals beyond parameters.
+    #[serde(default)]
+    pub locals: Vec<String>,
+    /// Bytecode instructions as strings, e.g. ["LdU64(42)", "Add", "Ret"].
+    #[serde(default)]
+    pub code: Vec<String>,
+}
+
+fn default_public() -> String {
+    "public".to_string()
+}
+
+// ─── Build context ────────────────────────────────────────────────────────────
+
+/// Internal lookup tables built incrementally as we process the spec.
+pub struct BuildCtx {
+    /// "normalized_address::module" → ModuleHandleIndex
+    module_handle_map: HashMap<String, u16>,
+    /// "normalized_address::module::Type" or "Self::Name" or "Name" → DatatypeHandleIndex
+    datatype_handle_map: HashMap<String, u16>,
+    /// "module::func" or "func" (for local fns) → FunctionHandleIndex
+    function_handle_map: HashMap<String, u16>,
+    /// Local struct name → StructDefinitionIndex
+    struct_def_map: HashMap<String, u16>,
+    /// Deduplicating signature pool; index 0 is always the empty signature.
+    pub sig_pool: Vec<Signature>,
+}
+
+impl Default for BuildCtx {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl BuildCtx {
+    pub fn new() -> Self {
+        Self {
+            module_handle_map: HashMap::new(),
+            datatype_handle_map: HashMap::new(),
+            function_handle_map: HashMap::new(),
+            struct_def_map: HashMap::new(),
+            // Index 0 must always be the empty signature (empty_module() requires it).
+            sig_pool: vec![Signature(vec![])],
+        }
+    }
+
+    pub fn intern_sig(&mut self, sig: Signature) -> SignatureIndex {
+        for (i, s) in self.sig_pool.iter().enumerate() {
+            if s.0 == sig.0 {
+                return SignatureIndex(i as u16);
+            }
+        }
+        let idx = self.sig_pool.len() as u16;
+        self.sig_pool.push(sig);
+        SignatureIndex(idx)
+    }
+}
+
+// ─── Builder ──────────────────────────────────────────────────────────────────
+
+/// Converts a `ModuleSpec` into a `CompiledModule`.
+pub struct ModuleSpecBuilder;
+
+impl ModuleSpecBuilder {
+    pub fn build(spec: &ModuleSpec) -> Result<CompiledModule, String> {
+        let mut module = empty_module();
+        let mut ctx = BuildCtx::new();
+
+        // empty_module() provides:
+        //   identifiers[0]          = "DUMMY"
+        //   address_identifiers[0]  = AccountAddress::ZERO
+        //   module_handles[0]       = { address: 0, name: 0 }  ← self
+        //   signatures[0]           = Signature([])
+        //   self_module_handle_idx  = ModuleHandleIndex(0)
+
+        // ── 1. Module name ──────────────────────────────────────────────────
+        module.identifiers[0] = Identifier::new(spec.module_name.as_str())
+            .map_err(|e| format!("invalid module name {:?}: {e}", spec.module_name))?;
+
+        // ── 2. Imports ──────────────────────────────────────────────────────
+        for imp in &spec.imports {
+            let addr = parse_address(&imp.address)?;
+            let norm_addr = normalize_addr(&addr);
+
+            // Intern address in address_identifiers table.
+            let addr_idx = if let Some(pos) =
+                module.address_identifiers.iter().position(|a| *a == addr)
+            {
+                pos as u16
+            } else {
+                let idx = module.address_identifiers.len() as u16;
+                module.address_identifiers.push(addr);
+                idx
+            };
+
+            // Intern the module name identifier.
+            let mod_id = Identifier::new(imp.module.as_str())
+                .map_err(|e| format!("invalid import module {:?}: {e}", imp.module))?;
+            let mod_ident_idx = intern_ident(&mut module.identifiers, mod_id);
+
+            // Create module handle if not already present.
+            let mh_key = format!("{}::{}", norm_addr, imp.module);
+            let mh_idx = if let Some(&idx) = ctx.module_handle_map.get(&mh_key) {
+                idx
+            } else {
+                let idx = module.module_handles.len() as u16;
+                module.module_handles.push(ModuleHandle {
+                    address: AddressIdentifierIndex(addr_idx),
+                    name: IdentifierIndex(mod_ident_idx),
+                });
+                ctx.module_handle_map.insert(mh_key.clone(), idx);
+                idx
+            };
+
+            // Create datatype handles for imported types.
+            for type_name in &imp.types {
+                let qualified = format!("{}::{}", mh_key, type_name);
+                if ctx.datatype_handle_map.contains_key(&qualified) {
+                    continue;
+                }
+                let type_id = Identifier::new(type_name.as_str())
+                    .map_err(|e| format!("invalid type name {:?}: {e}", type_name))?;
+                let type_ident_idx = intern_ident(&mut module.identifiers, type_id);
+                let dt_idx = module.datatype_handles.len() as u16;
+                module.datatype_handles.push(DatatypeHandle {
+                    module: ModuleHandleIndex(mh_idx),
+                    name: IdentifierIndex(type_ident_idx),
+                    // Abilities unknown for imported types; BoundsChecker doesn't verify these.
+                    abilities: AbilitySet::EMPTY,
+                    type_parameters: vec![],
+                });
+                ctx.datatype_handle_map.insert(qualified, dt_idx);
+                // Also register under shorthand "ModuleName::TypeName"
+                let short = format!("{}::{}", imp.module, type_name);
+                ctx.datatype_handle_map.entry(short).or_insert(dt_idx);
+                // And plain type name (last-write wins for ambiguous names)
+                ctx.datatype_handle_map
+                    .entry(type_name.clone())
+                    .or_insert(dt_idx);
+            }
+
+            // Create function handles for imported functions.
+            for fn_name in &imp.functions {
+                let short_key = format!("{}::{}", imp.module, fn_name);
+                if ctx.function_handle_map.contains_key(&short_key) {
+                    continue;
+                }
+                let fn_id = Identifier::new(fn_name.as_str())
+                    .map_err(|e| format!("invalid function name {:?}: {e}", fn_name))?;
+                let fn_ident_idx = intern_ident(&mut module.identifiers, fn_id);
+                let fh_idx = module.function_handles.len() as u16;
+                let empty_sig = ctx.intern_sig(Signature(vec![]));
+                module.function_handles.push(FunctionHandle {
+                    module: ModuleHandleIndex(mh_idx),
+                    name: IdentifierIndex(fn_ident_idx),
+                    parameters: empty_sig,
+                    return_: empty_sig,
+                    type_parameters: vec![],
+                });
+                ctx.function_handle_map.insert(short_key, fh_idx);
+                // Register under fully qualified and bare name too.
+                let full_key = format!("{}::{}", mh_key, fn_name);
+                ctx.function_handle_map.insert(full_key, fh_idx);
+                ctx.function_handle_map
+                    .entry(fn_name.clone())
+                    .or_insert(fh_idx);
+            }
+        }
+
+        // ── 3. Register local struct names in handle/def maps ───────────────
+        // We need two passes: first register DatatypeHandles so type resolution
+        // works when parsing field types in the second pass.
+        for (i, st) in spec.structs.iter().enumerate() {
+            let abilities = parse_abilities(&st.abilities)?;
+            let st_id = Identifier::new(st.name.as_str())
+                .map_err(|e| format!("invalid struct name {:?}: {e}", st.name))?;
+            let name_idx = intern_ident(&mut module.identifiers, st_id);
+            let dt_idx = module.datatype_handles.len() as u16;
+            module.datatype_handles.push(DatatypeHandle {
+                module: ModuleHandleIndex(0), // defined in this module
+                name: IdentifierIndex(name_idx),
+                abilities,
+                type_parameters: vec![],
+            });
+            let self_key = format!("Self::{}", st.name);
+            ctx.datatype_handle_map.insert(self_key, dt_idx);
+            ctx.datatype_handle_map.insert(st.name.clone(), dt_idx);
+            ctx.struct_def_map.insert(st.name.clone(), i as u16);
+        }
+
+        // ── 4. Build struct definitions with field types ─────────────────────
+        for st in &spec.structs {
+            let dt_handle_idx = *ctx.struct_def_map.get(&st.name).unwrap();
+
+            let mut fields = Vec::new();
+            for field in &st.fields {
+                let field_id = Identifier::new(field.name.as_str())
+                    .map_err(|e| format!("invalid field name {:?}: {e}", field.name))?;
+                let field_ident_idx = intern_ident(&mut module.identifiers, field_id);
+                let sig_tok = parse_type(&field.type_, &ctx)?;
+                fields.push(FieldDefinition {
+                    name: IdentifierIndex(field_ident_idx),
+                    signature: TypeSignature(sig_tok),
+                });
+            }
+
+            // Move rejects zero-sized structs.
+            if fields.is_empty() {
+                let dummy_idx = ensure_ident(&mut module.identifiers, "field0");
+                fields.push(FieldDefinition {
+                    name: IdentifierIndex(dummy_idx),
+                    signature: TypeSignature(SignatureToken::U64),
+                });
+            }
+
+            let struct_def_idx = module.struct_defs.len() as u16;
+            for (fi, _) in fields.iter().enumerate() {
+                module.field_handles.push(FieldHandle {
+                    owner: StructDefinitionIndex(struct_def_idx),
+                    field: fi as u16,
+                });
+            }
+
+            module.struct_defs.push(StructDefinition {
+                struct_handle: DatatypeHandleIndex(dt_handle_idx),
+                field_information: StructFieldInformation::Declared(fields),
+            });
+        }
+
+        // ── 5. Create function handles for local functions ───────────────────
+        for func in &spec.functions {
+            let fn_id = Identifier::new(func.name.as_str())
+                .map_err(|e| format!("invalid function name {:?}: {e}", func.name))?;
+            let fn_ident_idx = intern_ident(&mut module.identifiers, fn_id);
+
+            let mut param_toks = Vec::new();
+            for p in &func.parameters {
+                param_toks.push(parse_type(p, &ctx)?);
+            }
+            let mut ret_toks = Vec::new();
+            for r in &func.returns {
+                ret_toks.push(parse_type(r, &ctx)?);
+            }
+
+            let params_sig = ctx.intern_sig(Signature(param_toks));
+            let ret_sig = ctx.intern_sig(Signature(ret_toks));
+            let fh_idx = module.function_handles.len() as u16;
+            module.function_handles.push(FunctionHandle {
+                module: ModuleHandleIndex(0),
+                name: IdentifierIndex(fn_ident_idx),
+                parameters: params_sig,
+                return_: ret_sig,
+                type_parameters: vec![],
+            });
+            ctx.function_handle_map.insert(func.name.clone(), fh_idx);
+        }
+
+        // ── 6. Build function definitions with bytecode ──────────────────────
+        for func in &spec.functions {
+            let fh_idx = *ctx.function_handle_map.get(&func.name).unwrap();
+
+            let mut local_toks = Vec::new();
+            for l in &func.locals {
+                local_toks.push(parse_type(l, &ctx)?);
+            }
+            let locals_sig = ctx.intern_sig(Signature(local_toks));
+            let visibility = parse_visibility(&func.visibility)?;
+
+            let mut code: Vec<Bytecode> = Vec::new();
+            for instr in &func.code {
+                let bc = parse_bytecode(instr.trim(), &ctx)?;
+                code.push(bc);
+            }
+            // Guarantee every function ends with Ret.
+            if code.last() != Some(&Bytecode::Ret) {
+                code.push(Bytecode::Ret);
+            }
+
+            module.function_defs.push(FunctionDefinition {
+                function: FunctionHandleIndex(fh_idx),
+                visibility,
+                is_entry: func.is_entry,
+                acquires_global_resources: vec![],
+                code: Some(CodeUnit {
+                    locals: locals_sig,
+                    code,
+                    jump_tables: vec![],
+                }),
+            });
+        }
+
+        // ── 7. Finalize: replace signature pool ──────────────────────────────
+        module.signatures = ctx.sig_pool;
+
+        Ok(module)
+    }
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+fn intern_ident(identifiers: &mut Vec<Identifier>, id: Identifier) -> u16 {
+    if let Some(pos) = identifiers.iter().position(|i| *i == id) {
+        return pos as u16;
+    }
+    let idx = identifiers.len() as u16;
+    identifiers.push(id);
+    idx
+}
+
+fn ensure_ident(identifiers: &mut Vec<Identifier>, name: &str) -> u16 {
+    intern_ident(
+        identifiers,
+        Identifier::new(name).expect("hardcoded identifier is always valid"),
+    )
+}
+
+/// Parse "0x2" or "0x000...002" into `AccountAddress`.
+fn parse_address(s: &str) -> Result<AccountAddress, String> {
+    let hex = s.trim().strip_prefix("0x").unwrap_or(s.trim());
+    if hex.len() > 64 {
+        return Err(format!("address too long: {s:?}"));
+    }
+    let padded = format!("{:0>64}", hex);
+    let bytes: Vec<u8> = (0..32)
+        .map(|i| {
+            u8::from_str_radix(&padded[i * 2..i * 2 + 2], 16)
+                .map_err(|e| format!("bad hex in address {s:?}: {e}"))
+        })
+        .collect::<Result<_, _>>()?;
+    Ok(AccountAddress::new(bytes.try_into().unwrap()))
+}
+
+/// Canonical address string for map keys: 64-char lowercase hex without "0x".
+fn normalize_addr(addr: &AccountAddress) -> String {
+    let bytes = addr.to_vec();
+    bytes.iter().map(|b| format!("{:02x}", b)).collect()
+}
+
+fn parse_abilities(abilities: &[String]) -> Result<AbilitySet, String> {
+    let mut set = AbilitySet::EMPTY;
+    for a in abilities {
+        let ability = match a.to_lowercase().as_str() {
+            "copy" => Ability::Copy,
+            "drop" => Ability::Drop,
+            "store" => Ability::Store,
+            "key" => Ability::Key,
+            other => return Err(format!("unknown ability {other:?}")),
+        };
+        set = set | ability;
+    }
+    Ok(set)
+}
+
+fn parse_visibility(s: &str) -> Result<Visibility, String> {
+    match s.to_lowercase().as_str() {
+        "public" => Ok(Visibility::Public),
+        "private" | "" => Ok(Visibility::Private),
+        "friend" | "package" => Ok(Visibility::Friend),
+        other => Err(format!("unknown visibility {other:?}")),
+    }
+}
+
+/// Parse a type string into a `SignatureToken`.
+///
+/// Supported forms:
+/// - Primitives: `bool`, `u8`, `u16`, `u32`, `u64`, `u128`, `u256`, `address`, `signer`
+/// - References: `&T`, `&mut T`
+/// - Vectors: `vector<T>`
+/// - Qualified names: `0x2::object::UID`, `Self::MyStruct`, or plain `MyStruct`
+/// - Shorthands: `TxContext` → `0x2::tx_context::TxContext`, `UID` → `0x2::object::UID`
+/// - Type parameters: single uppercase letters like `T`, `E` → `TypeParameter(0)`
+pub fn parse_type(s: &str, ctx: &BuildCtx) -> Result<SignatureToken, String> {
+    let s = s.trim();
+
+    // Shorthands for common Sui framework types.
+    match s {
+        "TxContext" => {
+            // Resolve as 0x2::tx_context::TxContext if imported, else fall through.
+            let key = format!(
+                "{}::tx_context::TxContext",
+                normalize_addr(&AccountAddress::new([
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0, 2
+                ]))
+            );
+            if let Some(&idx) = ctx.datatype_handle_map.get(&key) {
+                return Ok(SignatureToken::Datatype(DatatypeHandleIndex(idx)));
+            }
+            if let Some(&idx) = ctx.datatype_handle_map.get("TxContext") {
+                return Ok(SignatureToken::Datatype(DatatypeHandleIndex(idx)));
+            }
+            if let Some(&idx) = ctx.datatype_handle_map.get("tx_context::TxContext") {
+                return Ok(SignatureToken::Datatype(DatatypeHandleIndex(idx)));
+            }
+        }
+        "UID" => {
+            if let Some(&idx) = ctx.datatype_handle_map.get("UID") {
+                return Ok(SignatureToken::Datatype(DatatypeHandleIndex(idx)));
+            }
+        }
+        "&mut TxContext" => {
+            return Ok(SignatureToken::MutableReference(Box::new(parse_type(
+                "TxContext",
+                ctx,
+            )?)));
+        }
+        "&TxContext" => {
+            return Ok(SignatureToken::Reference(Box::new(parse_type(
+                "TxContext",
+                ctx,
+            )?)));
+        }
+        _ => {}
+    }
+
+    match s {
+        "bool" => return Ok(SignatureToken::Bool),
+        "u8" => return Ok(SignatureToken::U8),
+        "u16" => return Ok(SignatureToken::U16),
+        "u32" => return Ok(SignatureToken::U32),
+        "u64" => return Ok(SignatureToken::U64),
+        "u128" => return Ok(SignatureToken::U128),
+        "u256" => return Ok(SignatureToken::U256),
+        "address" => return Ok(SignatureToken::Address),
+        "signer" => return Ok(SignatureToken::Signer),
+        _ => {}
+    }
+
+    if let Some(inner) = s.strip_prefix("&mut ") {
+        return Ok(SignatureToken::MutableReference(Box::new(parse_type(
+            inner, ctx,
+        )?)));
+    }
+    if let Some(inner) = s.strip_prefix('&') {
+        return Ok(SignatureToken::Reference(Box::new(parse_type(inner, ctx)?)));
+    }
+    if let Some(inner) = s
+        .strip_prefix("vector<")
+        .and_then(|t| t.strip_suffix('>'))
+    {
+        return Ok(SignatureToken::Vector(Box::new(parse_type(inner, ctx)?)));
+    }
+
+    // Try datatype resolution (handles qualified names and local names).
+    if let Some(&idx) = ctx.datatype_handle_map.get(s) {
+        return Ok(SignatureToken::Datatype(DatatypeHandleIndex(idx)));
+    }
+
+    // For "0x2::module::Type", try normalizing the address component.
+    if let Some(normalized) = try_normalize_qualified(s)
+        && let Some(&idx) = ctx.datatype_handle_map.get(&normalized)
+    {
+        return Ok(SignatureToken::Datatype(DatatypeHandleIndex(idx)));
+    }
+
+    // Single uppercase letter(s) → type parameter.
+    if !s.is_empty() && s.len() <= 2 && s.chars().all(|c| c.is_ascii_uppercase()) {
+        return Ok(SignatureToken::TypeParameter(0));
+    }
+
+    Err(format!(
+        "unknown type {s:?}; did you forget to list it in the imports section?"
+    ))
+}
+
+/// Attempt to normalize a qualified type string ("0x2::mod::Type") so the
+/// address component matches what's stored in `datatype_handle_map`.
+fn try_normalize_qualified(s: &str) -> Option<String> {
+    // Expect at least two "::" separators.
+    let mut parts = s.splitn(3, "::");
+    let addr_part = parts.next()?;
+    let mod_part = parts.next()?;
+    let type_part = parts.next()?;
+    let addr = parse_address(addr_part).ok()?;
+    Some(format!(
+        "{}::{}::{}",
+        normalize_addr(&addr),
+        mod_part,
+        type_part
+    ))
+}
+
+/// Parse a bytecode instruction string into a `Bytecode` variant.
+///
+/// Formats:
+/// - No-arg:        `"Ret"`, `"Add"`, `"Pop"`, `"LdTrue"`, etc.
+/// - Integer arg:   `"LdU64(42)"`, `"Branch(5)"`, `"CopyLoc(0)"`, etc.
+/// - Named ref:     `"Pack(MyStruct)"`, `"Unpack(MyStruct)"`, `"Call(object::new)"`, etc.
+pub fn parse_bytecode(s: &str, ctx: &BuildCtx) -> Result<Bytecode, String> {
+    let (name, arg) = if let Some(pos) = s.find('(') {
+        if !s.ends_with(')') {
+            return Err(format!("malformed instruction {s:?}: missing ')'"));
+        }
+        (&s[..pos], Some(s[pos + 1..s.len() - 1].trim()))
+    } else {
+        (s, None)
+    };
+    let name = name.trim();
+
+    macro_rules! no_arg {
+        ($bc:expr) => {{
+            if arg.is_some() {
+                return Err(format!("{name} takes no argument"));
+            }
+            Ok($bc)
+        }};
+    }
+
+    macro_rules! u8_arg {
+        ($bc:ident) => {{
+            let a = arg.ok_or_else(|| format!("{name} requires an argument"))?;
+            let n: u8 = a
+                .parse()
+                .map_err(|_| format!("{name} argument must be u8, got {a:?}"))?;
+            Ok(Bytecode::$bc(n))
+        }};
+    }
+
+    macro_rules! u16_arg {
+        ($bc:ident) => {{
+            let a = arg.ok_or_else(|| format!("{name} requires an argument"))?;
+            let n: u16 = a
+                .parse()
+                .map_err(|_| format!("{name} argument must be u16, got {a:?}"))?;
+            Ok(Bytecode::$bc(n))
+        }};
+    }
+
+    match name {
+        // ── No-argument instructions ────────────────────────────────────────
+        "Ret" => no_arg!(Bytecode::Ret),
+        "Pop" => no_arg!(Bytecode::Pop),
+        "LdTrue" => no_arg!(Bytecode::LdTrue),
+        "LdFalse" => no_arg!(Bytecode::LdFalse),
+        "Abort" => no_arg!(Bytecode::Abort),
+        "Nop" => no_arg!(Bytecode::Nop),
+        "FreezeRef" => no_arg!(Bytecode::FreezeRef),
+        "ReadRef" => no_arg!(Bytecode::ReadRef),
+        "WriteRef" => no_arg!(Bytecode::WriteRef),
+        "Add" => no_arg!(Bytecode::Add),
+        "Sub" => no_arg!(Bytecode::Sub),
+        "Mul" => no_arg!(Bytecode::Mul),
+        "Div" => no_arg!(Bytecode::Div),
+        "Mod" => no_arg!(Bytecode::Mod),
+        "BitAnd" => no_arg!(Bytecode::BitAnd),
+        "BitOr" => no_arg!(Bytecode::BitOr),
+        "Xor" => no_arg!(Bytecode::Xor),
+        "Shl" => no_arg!(Bytecode::Shl),
+        "Shr" => no_arg!(Bytecode::Shr),
+        "Or" => no_arg!(Bytecode::Or),
+        "And" => no_arg!(Bytecode::And),
+        "Not" => no_arg!(Bytecode::Not),
+        "Lt" => no_arg!(Bytecode::Lt),
+        "Gt" => no_arg!(Bytecode::Gt),
+        "Le" => no_arg!(Bytecode::Le),
+        "Ge" => no_arg!(Bytecode::Ge),
+        "Eq" => no_arg!(Bytecode::Eq),
+        "Neq" => no_arg!(Bytecode::Neq),
+        "CastU8" => no_arg!(Bytecode::CastU8),
+        "CastU16" => no_arg!(Bytecode::CastU16),
+        "CastU32" => no_arg!(Bytecode::CastU32),
+        "CastU64" => no_arg!(Bytecode::CastU64),
+        "CastU128" => no_arg!(Bytecode::CastU128),
+        "CastU256" => no_arg!(Bytecode::CastU256),
+
+        // ── Integer constant instructions ───────────────────────────────────
+        "LdU8" => {
+            let a = arg.ok_or_else(|| "LdU8 requires an argument".to_string())?;
+            let n: u8 = a
+                .parse()
+                .map_err(|_| format!("LdU8 argument must be u8, got {a:?}"))?;
+            Ok(Bytecode::LdU8(n))
+        }
+        "LdU16" => {
+            let a = arg.ok_or_else(|| "LdU16 requires an argument".to_string())?;
+            let n: u16 = a
+                .parse()
+                .map_err(|_| format!("LdU16 argument must be u16, got {a:?}"))?;
+            Ok(Bytecode::LdU16(n))
+        }
+        "LdU32" => {
+            let a = arg.ok_or_else(|| "LdU32 requires an argument".to_string())?;
+            let n: u32 = a
+                .parse()
+                .map_err(|_| format!("LdU32 argument must be u32, got {a:?}"))?;
+            Ok(Bytecode::LdU32(n))
+        }
+        "LdU64" => {
+            let a = arg.ok_or_else(|| "LdU64 requires an argument".to_string())?;
+            let n: u64 = a
+                .parse()
+                .map_err(|_| format!("LdU64 argument must be u64, got {a:?}"))?;
+            Ok(Bytecode::LdU64(n))
+        }
+        "LdU128" => {
+            let a = arg.ok_or_else(|| "LdU128 requires an argument".to_string())?;
+            let n: u128 = a
+                .parse()
+                .map_err(|_| format!("LdU128 argument must be u128, got {a:?}"))?;
+            Ok(Bytecode::LdU128(Box::new(n)))
+        }
+        "LdU256" => {
+            let a = arg.ok_or_else(|| "LdU256 requires an argument".to_string())?;
+            // Accept as u64-sized decimal for convenience.
+            let n: u64 = a
+                .parse()
+                .map_err(|_| format!("LdU256 argument must be a decimal integer, got {a:?}"))?;
+            Ok(Bytecode::LdU256(Box::new(
+                move_core_types::u256::U256::from(n),
+            )))
+        }
+
+        // ── Local variable instructions ─────────────────────────────────────
+        "CopyLoc" => u8_arg!(CopyLoc),
+        "MoveLoc" => u8_arg!(MoveLoc),
+        "StLoc" => u8_arg!(StLoc),
+        "ImmBorrowLoc" => u8_arg!(ImmBorrowLoc),
+        "MutBorrowLoc" => u8_arg!(MutBorrowLoc),
+
+        // ── Branch instructions ─────────────────────────────────────────────
+        "Branch" => u16_arg!(Branch),
+        "BrTrue" => u16_arg!(BrTrue),
+        "BrFalse" => u16_arg!(BrFalse),
+
+        // ── Struct pack/unpack ──────────────────────────────────────────────
+        "Pack" | "Unpack" => {
+            let a = arg.ok_or_else(|| format!("{name} requires a struct name or index"))?;
+            let sdi = resolve_struct(a, ctx)?;
+            Ok(match name {
+                "Pack" => Bytecode::Pack(sdi),
+                _ => Bytecode::Unpack(sdi),
+            })
+        }
+
+        // ── Field borrow ────────────────────────────────────────────────────
+        "ImmBorrowField" => {
+            let a = arg.ok_or_else(|| "ImmBorrowField requires a field handle index".to_string())?;
+            let n: u16 = a
+                .parse()
+                .map_err(|_| format!("ImmBorrowField argument must be u16, got {a:?}"))?;
+            Ok(Bytecode::ImmBorrowField(FieldHandleIndex(n)))
+        }
+        "MutBorrowField" => {
+            let a = arg.ok_or_else(|| "MutBorrowField requires a field handle index".to_string())?;
+            let n: u16 = a
+                .parse()
+                .map_err(|_| format!("MutBorrowField argument must be u16, got {a:?}"))?;
+            Ok(Bytecode::MutBorrowField(FieldHandleIndex(n)))
+        }
+
+        // ── Function calls ──────────────────────────────────────────────────
+        "Call" => {
+            let a = arg.ok_or_else(|| "Call requires a function reference".to_string())?;
+            let fh_idx = ctx
+                .function_handle_map
+                .get(a)
+                .ok_or_else(|| format!("Call: unknown function {a:?}; import it first"))?;
+            Ok(Bytecode::Call(FunctionHandleIndex(*fh_idx)))
+        }
+
+        // ── Vector operations ───────────────────────────────────────────────
+        "VecLen" => {
+            let a = arg.ok_or_else(|| "VecLen requires a signature index".to_string())?;
+            let n: u16 = a
+                .parse()
+                .map_err(|_| format!("VecLen argument must be u16, got {a:?}"))?;
+            Ok(Bytecode::VecLen(SignatureIndex(n)))
+        }
+        "VecImmBorrow" => {
+            let a = arg.ok_or_else(|| "VecImmBorrow requires a signature index".to_string())?;
+            let n: u16 = a
+                .parse()
+                .map_err(|_| format!("VecImmBorrow argument must be u16, got {a:?}"))?;
+            Ok(Bytecode::VecImmBorrow(SignatureIndex(n)))
+        }
+        "VecMutBorrow" => {
+            let a = arg.ok_or_else(|| "VecMutBorrow requires a signature index".to_string())?;
+            let n: u16 = a
+                .parse()
+                .map_err(|_| format!("VecMutBorrow argument must be u16, got {a:?}"))?;
+            Ok(Bytecode::VecMutBorrow(SignatureIndex(n)))
+        }
+        "VecPushBack" => {
+            let a = arg.ok_or_else(|| "VecPushBack requires a signature index".to_string())?;
+            let n: u16 = a
+                .parse()
+                .map_err(|_| format!("VecPushBack argument must be u16, got {a:?}"))?;
+            Ok(Bytecode::VecPushBack(SignatureIndex(n)))
+        }
+        "VecPopBack" => {
+            let a = arg.ok_or_else(|| "VecPopBack requires a signature index".to_string())?;
+            let n: u16 = a
+                .parse()
+                .map_err(|_| format!("VecPopBack argument must be u16, got {a:?}"))?;
+            Ok(Bytecode::VecPopBack(SignatureIndex(n)))
+        }
+        "VecSwap" => {
+            let a = arg.ok_or_else(|| "VecSwap requires a signature index".to_string())?;
+            let n: u16 = a
+                .parse()
+                .map_err(|_| format!("VecSwap argument must be u16, got {a:?}"))?;
+            Ok(Bytecode::VecSwap(SignatureIndex(n)))
+        }
+
+        other => Err(format!(
+            "unknown instruction {other:?}; \
+             check spelling or use a supported opcode"
+        )),
+    }
+}
+
+/// Resolve a struct argument (name or numeric index) to a `StructDefinitionIndex`.
+fn resolve_struct(a: &str, ctx: &BuildCtx) -> Result<StructDefinitionIndex, String> {
+    if let Ok(n) = a.parse::<u16>() {
+        return Ok(StructDefinitionIndex(n));
+    }
+    ctx.struct_def_map
+        .get(a)
+        .map(|&idx| StructDefinitionIndex(idx))
+        .ok_or_else(|| format!("unknown struct {a:?}; define it in the structs section"))
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sui_harness;
+
+    fn build(json: &str) -> Result<CompiledModule, String> {
+        let spec: ModuleSpec = serde_json::from_str(json).map_err(|e| e.to_string())?;
+        ModuleSpecBuilder::build(&spec)
+    }
+
+    #[test]
+    fn simple_module_roundtrips() {
+        let module = build(
+            r#"{
+            "module_name": "test_mod",
+            "structs": [{
+                "name": "MyVal",
+                "abilities": ["copy", "drop"],
+                "fields": [
+                    {"name": "x", "type": "u64"},
+                    {"name": "y", "type": "bool"}
+                ]
+            }],
+            "functions": [{
+                "name": "do_thing",
+                "visibility": "public",
+                "parameters": ["u64"],
+                "returns": ["u64"],
+                "locals": ["u64"],
+                "code": ["CopyLoc(0)", "LdU64(1)", "Add", "Ret"]
+            }]
+        }"#,
+        )
+        .expect("build");
+
+        assert_eq!(module.struct_defs.len(), 1);
+        assert_eq!(module.function_defs.len(), 1);
+        sui_harness::roundtrip_check(&module).expect("roundtrip");
+    }
+
+    #[test]
+    fn module_passes_bounds_check() {
+        let module = build(
+            r#"{
+            "module_name": "bounds_mod",
+            "functions": [{
+                "name": "f",
+                "parameters": [],
+                "returns": [],
+                "locals": [],
+                "code": ["LdU64(0)", "Pop", "Ret"]
+            }]
+        }"#,
+        )
+        .expect("build");
+
+        let mut bytes = Vec::new();
+        module.serialize(&mut bytes).expect("serialize");
+        let config = move_binary_format::binary_config::BinaryConfig::standard();
+        let result =
+            move_binary_format::file_format::CompiledModule::deserialize_with_config(&bytes, &config);
+        assert!(result.is_ok(), "bounds check failed: {result:?}");
+    }
+
+    #[test]
+    fn module_with_import_roundtrips() {
+        let module = build(
+            r#"{
+            "module_name": "fuzz_obj",
+            "imports": [{"address": "0x2", "module": "object", "types": ["UID"], "functions": []}],
+            "structs": [{
+                "name": "MyObj",
+                "abilities": ["key", "store"],
+                "fields": [
+                    {"name": "id", "type": "UID"},
+                    {"name": "val", "type": "u64"}
+                ]
+            }],
+            "functions": [{
+                "name": "empty",
+                "parameters": [],
+                "returns": [],
+                "locals": [],
+                "code": ["Ret"]
+            }]
+        }"#,
+        )
+        .expect("build");
+
+        sui_harness::roundtrip_check(&module).expect("roundtrip");
+    }
+
+    #[test]
+    fn type_parsing_primitives() {
+        let ctx = BuildCtx::new();
+        assert_eq!(parse_type("bool", &ctx).unwrap(), SignatureToken::Bool);
+        assert_eq!(parse_type("u64", &ctx).unwrap(), SignatureToken::U64);
+        assert_eq!(parse_type("u8", &ctx).unwrap(), SignatureToken::U8);
+        assert_eq!(parse_type("u128", &ctx).unwrap(), SignatureToken::U128);
+        assert_eq!(parse_type("address", &ctx).unwrap(), SignatureToken::Address);
+    }
+
+    #[test]
+    fn type_parsing_references_and_vectors() {
+        let ctx = BuildCtx::new();
+        assert_eq!(
+            parse_type("&u64", &ctx).unwrap(),
+            SignatureToken::Reference(Box::new(SignatureToken::U64))
+        );
+        assert_eq!(
+            parse_type("&mut u64", &ctx).unwrap(),
+            SignatureToken::MutableReference(Box::new(SignatureToken::U64))
+        );
+        assert_eq!(
+            parse_type("vector<u8>", &ctx).unwrap(),
+            SignatureToken::Vector(Box::new(SignatureToken::U8))
+        );
+        assert_eq!(
+            parse_type("vector<&u64>", &ctx).unwrap(),
+            SignatureToken::Vector(Box::new(SignatureToken::Reference(Box::new(
+                SignatureToken::U64
+            ))))
+        );
+    }
+
+    #[test]
+    fn bytecode_parsing_no_arg() {
+        let ctx = BuildCtx::new();
+        assert_eq!(parse_bytecode("Ret", &ctx).unwrap(), Bytecode::Ret);
+        assert_eq!(parse_bytecode("Add", &ctx).unwrap(), Bytecode::Add);
+        assert_eq!(parse_bytecode("Pop", &ctx).unwrap(), Bytecode::Pop);
+        assert_eq!(parse_bytecode("LdTrue", &ctx).unwrap(), Bytecode::LdTrue);
+        assert_eq!(parse_bytecode("FreezeRef", &ctx).unwrap(), Bytecode::FreezeRef);
+    }
+
+    #[test]
+    fn bytecode_parsing_with_args() {
+        let ctx = BuildCtx::new();
+        assert_eq!(parse_bytecode("LdU64(42)", &ctx).unwrap(), Bytecode::LdU64(42));
+        assert_eq!(parse_bytecode("LdU8(255)", &ctx).unwrap(), Bytecode::LdU8(255));
+        assert_eq!(parse_bytecode("CopyLoc(2)", &ctx).unwrap(), Bytecode::CopyLoc(2));
+        assert_eq!(parse_bytecode("Branch(10)", &ctx).unwrap(), Bytecode::Branch(10));
+        assert_eq!(parse_bytecode("BrTrue(5)", &ctx).unwrap(), Bytecode::BrTrue(5));
+        assert_eq!(parse_bytecode("BrFalse(0)", &ctx).unwrap(), Bytecode::BrFalse(0));
+        assert_eq!(parse_bytecode("StLoc(1)", &ctx).unwrap(), Bytecode::StLoc(1));
+    }
+
+    #[test]
+    fn bytecode_call_resolution() {
+        let mut ctx = BuildCtx::new();
+        ctx.function_handle_map.insert("object::new".to_string(), 1);
+        assert_eq!(
+            parse_bytecode("Call(object::new)", &ctx).unwrap(),
+            Bytecode::Call(FunctionHandleIndex(1))
+        );
+    }
+
+    #[test]
+    fn bytecode_pack_by_name() {
+        let mut ctx = BuildCtx::new();
+        ctx.struct_def_map.insert("MyStruct".to_string(), 0);
+        assert_eq!(
+            parse_bytecode("Pack(MyStruct)", &ctx).unwrap(),
+            Bytecode::Pack(StructDefinitionIndex(0))
+        );
+        assert_eq!(
+            parse_bytecode("Unpack(MyStruct)", &ctx).unwrap(),
+            Bytecode::Unpack(StructDefinitionIndex(0))
+        );
+    }
+
+    #[test]
+    fn multi_function_module() {
+        let module = build(
+            r#"{
+            "module_name": "multi",
+            "functions": [
+                {
+                    "name": "helper",
+                    "visibility": "private",
+                    "parameters": ["u64"],
+                    "returns": ["u64"],
+                    "locals": [],
+                    "code": ["CopyLoc(0)", "LdU64(1)", "Add", "Ret"]
+                },
+                {
+                    "name": "entry_fn",
+                    "visibility": "public",
+                    "is_entry": true,
+                    "parameters": ["u64"],
+                    "returns": [],
+                    "locals": [],
+                    "code": ["MoveLoc(0)", "Pop", "Ret"]
+                }
+            ]
+        }"#,
+        )
+        .expect("build");
+
+        assert_eq!(module.function_defs.len(), 2);
+        sui_harness::roundtrip_check(&module).expect("roundtrip");
+    }
+
+    #[test]
+    fn branching_module() {
+        // Tests BrFalse / Branch offset calculation.
+        let module = build(
+            r#"{
+            "module_name": "branch_mod",
+            "functions": [{
+                "name": "choose",
+                "parameters": ["bool"],
+                "returns": ["u64"],
+                "locals": [],
+                "code": [
+                    "CopyLoc(0)",
+                    "BrFalse(4)",
+                    "LdU64(1)",
+                    "Branch(5)",
+                    "LdU64(0)",
+                    "Ret"
+                ]
+            }]
+        }"#,
+        )
+        .expect("build");
+
+        let mut bytes = Vec::new();
+        module.serialize(&mut bytes).expect("serialize");
+        let config = move_binary_format::binary_config::BinaryConfig::standard();
+        let result =
+            move_binary_format::file_format::CompiledModule::deserialize_with_config(&bytes, &config);
+        assert!(result.is_ok(), "bounds check: {result:?}");
+    }
+}

--- a/crates/sui-move-fuzzer/src/mutators.rs
+++ b/crates/sui-move-fuzzer/src/mutators.rs
@@ -1,0 +1,514 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Targeted mutation strategies for the Sui Move VM fuzzer.
+//!
+//! Each mutation targets a specific known attack surface in the Move bytecode
+//! verifier or Sui execution pipeline.
+
+use arbitrary::Unstructured;
+use move_binary_format::file_format::{
+    AbilitySet, Bytecode, CodeUnit, DatatypeHandleIndex, EnumDefinition, EnumDefinitionIndex,
+    FunctionDefinition, FunctionHandleIndex, FunctionInstantiation, JumpTableInner, SignatureIndex,
+    StructDefInstantiationIndex, StructDefinitionIndex, VariantDefinition, VariantHandle,
+};
+use move_binary_format::CompiledModule;
+use move_core_types::identifier::Identifier;
+
+#[derive(Debug, Clone, Copy, arbitrary::Arbitrary)]
+pub enum MutationKind {
+    BoundsCorrupt,
+    PassOrderViolation,
+    RefSafetyStress,
+    IdLeakLaunder,
+    PrivateGenericsBypass,
+    IntegerOverflowOffset,
+    MeteringExhaust,
+    SafeAssertDual,
+    AbilityEscalation,
+    EnumVariantConfuse,
+}
+
+/// Apply a targeted mutation to a CompiledModule.
+pub fn apply_mutation(
+    u: &mut Unstructured,
+    module: &mut CompiledModule,
+) -> arbitrary::Result<MutationKind> {
+    let kind: MutationKind = u.arbitrary()?;
+    match kind {
+        MutationKind::BoundsCorrupt => mutate_bounds(u, module)?,
+        MutationKind::PassOrderViolation => mutate_pass_order(u, module)?,
+        MutationKind::RefSafetyStress => mutate_ref_safety(u, module)?,
+        MutationKind::IdLeakLaunder => mutate_id_leak(u, module)?,
+        MutationKind::PrivateGenericsBypass => mutate_private_generics(u, module)?,
+        MutationKind::IntegerOverflowOffset => {} // no-op on CompiledModule, handled by apply_bytes_mutation
+        MutationKind::MeteringExhaust => mutate_metering(u, module)?,
+        MutationKind::SafeAssertDual => mutate_safe_assert(u, module)?,
+        MutationKind::AbilityEscalation => mutate_ability_escalation(u, module)?,
+        MutationKind::EnumVariantConfuse => mutate_enum_variant(u, module)?,
+    }
+    Ok(kind)
+}
+
+/// Apply a mutation to serialized module bytes (for IntegerOverflowOffset).
+pub fn apply_bytes_mutation(u: &mut Unstructured, bytes: &mut [u8]) -> arbitrary::Result<()> {
+    mutate_integer_overflow(u, bytes)
+}
+
+/// Pick a random boundary-adjacent value for a given table length.
+fn boundary_value(u: &mut Unstructured, len: usize) -> arbitrary::Result<u16> {
+    let len16 = len as u16;
+    let choices: &[u16] = &[
+        len16,
+        len16.wrapping_sub(1),
+        len16.wrapping_add(1),
+        u16::MAX,
+        0,
+    ];
+    let idx = u.choose_index(choices.len())?;
+    Ok(choices[idx])
+}
+
+/// Get a mutable reference to a random function's code unit, if any exist.
+fn pick_code_unit<'a>(
+    u: &mut Unstructured,
+    module: &'a mut CompiledModule,
+) -> arbitrary::Result<Option<&'a mut CodeUnit>> {
+    let fns_with_code: Vec<usize> = module
+        .function_defs
+        .iter()
+        .enumerate()
+        .filter(|(_, f)| f.code.is_some())
+        .map(|(i, _)| i)
+        .collect();
+    if fns_with_code.is_empty() {
+        return Ok(None);
+    }
+    let idx = *u.choose(&fns_with_code)?;
+    Ok(module.function_defs[idx].code.as_mut())
+}
+
+// ---------------------------------------------------------------------------
+// 1. BoundsCorrupt
+// ---------------------------------------------------------------------------
+
+fn mutate_bounds(u: &mut Unstructured, module: &mut CompiledModule) -> arbitrary::Result<()> {
+    let variant: u8 = u.int_in_range(0..=3)?;
+    match variant {
+        0 => {
+            // Corrupt function_handle parameters -> out of bounds SignatureIndex
+            if let Some(fh) = module.function_handles.first_mut() {
+                fh.parameters = SignatureIndex(boundary_value(u, module.signatures.len())?);
+            }
+        }
+        1 => {
+            // Corrupt struct_def struct_handle -> out of bounds DatatypeHandleIndex
+            if let Some(sd) = module.struct_defs.first_mut() {
+                sd.struct_handle =
+                    DatatypeHandleIndex(boundary_value(u, module.datatype_handles.len())?);
+            }
+        }
+        2 => {
+            // Corrupt branch offset in code
+            if let Some(code) = pick_code_unit(u, module)?
+                && !code.code.is_empty()
+            {
+                let code_len = code.code.len();
+                let target = boundary_value(u, code_len)?;
+                let pos = u.choose_index(code_len)?;
+                let bc_variant: u8 = u.int_in_range(0..=2)?;
+                code.code[pos] = match bc_variant {
+                    0 => Bytecode::Branch(target),
+                    1 => Bytecode::BrTrue(target),
+                    _ => Bytecode::BrFalse(target),
+                };
+            }
+        }
+        _ => {
+            // Corrupt local index in CopyLoc/MoveLoc/StLoc
+            if let Some(code) = pick_code_unit(u, module)?
+                && !code.code.is_empty()
+            {
+                let code_len = code.code.len();
+                let pos = u.choose_index(code_len)?;
+                // Use u8::MAX as out-of-bounds local
+                let local_idx: u8 = *u.choose(&[0, u8::MAX, u8::MAX - 1])?;
+                let bc_variant: u8 = u.int_in_range(0..=2)?;
+                code.code[pos] = match bc_variant {
+                    0 => Bytecode::CopyLoc(local_idx),
+                    1 => Bytecode::MoveLoc(local_idx),
+                    _ => Bytecode::StLoc(local_idx),
+                };
+            }
+        }
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// 2. PassOrderViolation
+// ---------------------------------------------------------------------------
+
+fn mutate_pass_order(u: &mut Unstructured, module: &mut CompiledModule) -> arbitrary::Result<()> {
+    let deprecated_opcodes: &[Bytecode] = &[
+        Bytecode::MoveFromDeprecated(StructDefinitionIndex(0)),
+        Bytecode::MoveToDeprecated(StructDefinitionIndex(0)),
+        Bytecode::ImmBorrowGlobalDeprecated(StructDefinitionIndex(0)),
+        Bytecode::MutBorrowGlobalDeprecated(StructDefinitionIndex(0)),
+        Bytecode::ExistsDeprecated(StructDefinitionIndex(0)),
+        Bytecode::MoveFromGenericDeprecated(StructDefInstantiationIndex(0)),
+        Bytecode::MoveToGenericDeprecated(StructDefInstantiationIndex(0)),
+        Bytecode::ImmBorrowGlobalGenericDeprecated(StructDefInstantiationIndex(0)),
+        Bytecode::MutBorrowGlobalGenericDeprecated(StructDefInstantiationIndex(0)),
+        Bytecode::ExistsGenericDeprecated(StructDefInstantiationIndex(0)),
+    ];
+
+    let opcode = u.choose(deprecated_opcodes)?.clone();
+
+    if let Some(code) = pick_code_unit(u, module)? {
+        if code.code.is_empty() {
+            code.code.push(opcode);
+        } else {
+            let pos = u.choose_index(code.code.len() + 1)?;
+            code.code.insert(pos, opcode);
+        }
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// 3. RefSafetyStress
+// ---------------------------------------------------------------------------
+
+fn mutate_ref_safety(u: &mut Unstructured, module: &mut CompiledModule) -> arbitrary::Result<()> {
+    let pattern: u8 = u.int_in_range(0..=1)?;
+
+    if let Some(code) = pick_code_unit(u, module)? {
+        let code_len = code.code.len().max(1) as u16;
+        match pattern {
+            0 => {
+                // MutBorrowLoc, BrTrue, Pop, Branch, FreezeRef, Pop
+                let branch_target = u.int_in_range(0..=code_len.saturating_sub(1))?;
+                let seq = vec![
+                    Bytecode::MutBorrowLoc(0),
+                    Bytecode::LdTrue,
+                    Bytecode::BrTrue(branch_target),
+                    Bytecode::Pop,
+                    Bytecode::Branch(branch_target),
+                    Bytecode::FreezeRef,
+                    Bytecode::Pop,
+                ];
+                let pos = u.choose_index(code.code.len() + 1)?;
+                for (i, bc) in seq.into_iter().enumerate() {
+                    code.code.insert(pos + i, bc);
+                }
+            }
+            _ => {
+                // Interleave borrow patterns: MutBorrowLoc(0), ImmBorrowLoc(0) on same local
+                let seq = vec![
+                    Bytecode::MutBorrowLoc(0),
+                    Bytecode::Pop,
+                    Bytecode::ImmBorrowLoc(0),
+                    Bytecode::Pop,
+                    Bytecode::MutBorrowLoc(0),
+                    Bytecode::FreezeRef,
+                    Bytecode::Pop,
+                ];
+                for (i, bc) in seq.into_iter().enumerate() {
+                    code.code.insert(i, bc);
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// 4. IdLeakLaunder
+// ---------------------------------------------------------------------------
+
+fn mutate_id_leak(u: &mut Unstructured, module: &mut CompiledModule) -> arbitrary::Result<()> {
+    let pattern: u8 = u.int_in_range(0..=1)?;
+
+    // Read signatures length before borrowing module mutably via pick_code_unit.
+    let sig_idx = if module.signatures.is_empty() {
+        SignatureIndex(0)
+    } else {
+        SignatureIndex(u.int_in_range(0..=(module.signatures.len() as u16 - 1))?)
+    };
+
+    if let Some(code) = pick_code_unit(u, module)? {
+        match pattern {
+            0 => {
+                // VecPack(sig, 1) + VecUnpack(sig, 1) wrapping a value
+                let pos = u.choose_index(code.code.len().max(1))?;
+                code.code.insert(pos, Bytecode::VecPack(sig_idx, 1));
+                code.code.insert(pos + 1, Bytecode::VecUnpack(sig_idx, 1));
+            }
+            _ => {
+                // StLoc(idx) + CopyLoc(idx) - attempt to copy instead of move
+                let local_idx: u8 = u.int_in_range(0..=3)?;
+                let pos = u.choose_index(code.code.len().max(1))?;
+                code.code.insert(pos, Bytecode::StLoc(local_idx));
+                code.code.insert(pos + 1, Bytecode::CopyLoc(local_idx));
+            }
+        }
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// 5. PrivateGenericsBypass
+// ---------------------------------------------------------------------------
+
+fn mutate_private_generics(
+    u: &mut Unstructured,
+    module: &mut CompiledModule,
+) -> arbitrary::Result<()> {
+    if module.function_handles.is_empty() || module.signatures.is_empty() {
+        return Ok(());
+    }
+
+    // Pick a function handle (ideally from a foreign module)
+    let fh_idx = u.choose_index(module.function_handles.len())?;
+
+    // Find or create a signature with a foreign type argument
+    let type_sig_idx = if module.datatype_handles.is_empty() {
+        // No datatype handles, use an existing signature
+        SignatureIndex(u.int_in_range(0..=(module.signatures.len() as u16 - 1))?)
+    } else {
+        // Pick a datatype handle and create a signature referencing it
+        use move_binary_format::file_format::{Signature, SignatureToken};
+        let dh_idx = u.choose_index(module.datatype_handles.len())?;
+        let token = SignatureToken::Datatype(DatatypeHandleIndex(dh_idx as u16));
+        let sig = Signature(vec![token]);
+        let idx = module.signatures.len() as u16;
+        module.signatures.push(sig);
+        SignatureIndex(idx)
+    };
+
+    module.function_instantiations.push(FunctionInstantiation {
+        handle: FunctionHandleIndex(fh_idx as u16),
+        type_parameters: type_sig_idx,
+    });
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// 6. IntegerOverflowOffset (operates on bytes)
+// ---------------------------------------------------------------------------
+
+fn mutate_integer_overflow(u: &mut Unstructured, bytes: &mut [u8]) -> arbitrary::Result<()> {
+    // The binary header is 9 bytes: 4 magic + 4 version + 1 table_count
+    // Each table header is 9 bytes: 1 kind + 4 offset + 4 count
+    if bytes.len() < 10 {
+        return Ok(());
+    }
+
+    let table_count = bytes[8] as usize;
+    let header_end = 9 + table_count * 9;
+
+    let strategy: u8 = u.int_in_range(0..=2)?;
+    match strategy {
+        0 => {
+            // Corrupt table count fields with large values
+            for i in 0..table_count {
+                let count_offset = 9 + i * 9 + 5; // skip kind(1) + offset(4), count starts at +5
+                if count_offset + 4 <= bytes.len() {
+                    let corrupt: u8 = u.int_in_range(0..=1)?;
+                    let value: u32 = if corrupt == 0 {
+                        u32::MAX
+                    } else {
+                        u16::MAX as u32
+                    };
+                    bytes[count_offset..count_offset + 4].copy_from_slice(&value.to_le_bytes());
+                }
+            }
+        }
+        1 => {
+            // Corrupt table offsets to point beyond the binary
+            for i in 0..table_count {
+                let offset_pos = 9 + i * 9 + 1; // skip kind(1), offset starts at +1
+                if offset_pos + 4 <= bytes.len() {
+                    let value = u32::MAX;
+                    bytes[offset_pos..offset_pos + 4].copy_from_slice(&value.to_le_bytes());
+                }
+            }
+        }
+        _ => {
+            // Corrupt ULEB128 values in the table content area
+            if header_end < bytes.len() {
+                let target = u.int_in_range(header_end..=bytes.len() - 1)?;
+                // Overwrite with a 5-byte ULEB128 encoding of a large value
+                let remaining = bytes.len() - target;
+                if remaining >= 5 {
+                    // Encode u32::MAX as 5-byte ULEB128: 0xFF 0xFF 0xFF 0xFF 0x0F
+                    bytes[target] = 0xFF;
+                    if target + 1 < bytes.len() {
+                        bytes[target + 1] = 0xFF;
+                    }
+                    if target + 2 < bytes.len() {
+                        bytes[target + 2] = 0xFF;
+                    }
+                    if target + 3 < bytes.len() {
+                        bytes[target + 3] = 0xFF;
+                    }
+                    if target + 4 < bytes.len() {
+                        bytes[target + 4] = 0x0F;
+                    }
+                } else {
+                    // Just corrupt single byte with high-bit continuation
+                    bytes[target] = 0xFF;
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// 7. MeteringExhaust
+// ---------------------------------------------------------------------------
+
+fn mutate_metering(u: &mut Unstructured, module: &mut CompiledModule) -> arbitrary::Result<()> {
+    let num_blocks: u16 = u.int_in_range(10..=200)?;
+
+    if let Some(code) = pick_code_unit(u, module)? {
+        code.code.clear();
+        // Generate N basic blocks, each with a back-edge to block 0
+        // Each block: LdTrue, BrFalse(next), Branch(0)
+        // Block offsets: block i starts at i*3
+        for i in 0..num_blocks {
+            let next_block_offset = (i + 1) * 3;
+            code.code.push(Bytecode::LdTrue);
+            code.code.push(Bytecode::BrFalse(next_block_offset));
+            code.code.push(Bytecode::Branch(0)); // back edge
+        }
+        // Final block: Ret
+        code.code.push(Bytecode::Ret);
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// 8. SafeAssertDual
+// ---------------------------------------------------------------------------
+
+fn mutate_safe_assert(u: &mut Unstructured, module: &mut CompiledModule) -> arbitrary::Result<()> {
+    // Same as PassOrderViolation -- triggers safe_assert! in BoundsChecker
+    // when deprecate_global_storage_ops=true
+    mutate_pass_order(u, module)
+}
+
+// ---------------------------------------------------------------------------
+// 9. AbilityEscalation
+// ---------------------------------------------------------------------------
+
+fn mutate_ability_escalation(
+    _u: &mut Unstructured,
+    module: &mut CompiledModule,
+) -> arbitrary::Result<()> {
+    // Set a random datatype_handle abilities to ALL (0xF = Copy|Drop|Store|Key)
+    if let Some(dh) = module.datatype_handles.first_mut() {
+        dh.abilities = AbilitySet::ALL;
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// 10. EnumVariantConfuse
+// ---------------------------------------------------------------------------
+
+fn mutate_enum_variant(u: &mut Unstructured, module: &mut CompiledModule) -> arbitrary::Result<()> {
+    if !module.enum_defs.is_empty() {
+        let variant_strategy: u8 = u.int_in_range(0..=2)?;
+        match variant_strategy {
+            0 => {
+                // Corrupt VariantHandle variant tag to u16::MAX
+                if let Some(vh) = module.variant_handles.first_mut() {
+                    vh.variant = u16::MAX;
+                }
+            }
+            1 => {
+                // Corrupt jump table entries in code
+                for func_def in &mut module.function_defs {
+                    if let Some(ref mut code) = func_def.code {
+                        for jt in &mut code.jump_tables {
+                            let JumpTableInner::Full(ref mut offsets) = jt.jump_table;
+                            for offset in offsets.iter_mut() {
+                                *offset = u16::MAX;
+                            }
+                        }
+                    }
+                }
+            }
+            _ => {
+                // Corrupt an enum def's variant list
+                if let Some(ed) = module.enum_defs.first_mut() {
+                    // Add extra bogus variants with out-of-bounds identifiers
+                    let bogus_name_idx = module.identifiers.len() as u16;
+                    ed.variants.push(VariantDefinition {
+                        variant_name: move_binary_format::file_format::IdentifierIndex(
+                            bogus_name_idx,
+                        ),
+                        fields: vec![],
+                    });
+                }
+            }
+        }
+    } else {
+        // No enums exist -- add a minimal enum definition with corrupted variant count
+        if module.datatype_handles.is_empty() || module.identifiers.is_empty() {
+            return Ok(());
+        }
+
+        // Add identifier for the variant name
+        let variant_name_idx = module.identifiers.len() as u16;
+        module
+            .identifiers
+            .push(Identifier::new("V0").expect("valid identifier"));
+
+        let enum_handle_idx = DatatypeHandleIndex(0);
+        module.enum_defs.push(EnumDefinition {
+            enum_handle: enum_handle_idx,
+            variants: vec![VariantDefinition {
+                variant_name: move_binary_format::file_format::IdentifierIndex(variant_name_idx),
+                fields: vec![],
+            }],
+        });
+
+        // Add a variant handle with corrupted tag
+        module.variant_handles.push(VariantHandle {
+            enum_def: EnumDefinitionIndex(0),
+            variant: u16::MAX,
+        });
+    }
+    Ok(())
+}
+
+/// Ensure a module has at least one function with a code unit for mutation.
+/// Returns true if a function was added or one already existed.
+pub fn ensure_code_unit(module: &mut CompiledModule) -> bool {
+    let has_code = module.function_defs.iter().any(|f| f.code.is_some());
+    if has_code {
+        return true;
+    }
+
+    // Need a function handle and a signature for the locals
+    if module.function_handles.is_empty() || module.signatures.is_empty() {
+        return false;
+    }
+
+    module.function_defs.push(FunctionDefinition {
+        function: FunctionHandleIndex(0),
+        visibility: move_binary_format::file_format::Visibility::Private,
+        is_entry: false,
+        acquires_global_resources: vec![],
+        code: Some(CodeUnit {
+            locals: SignatureIndex(0),
+            code: vec![Bytecode::Ret],
+            jump_tables: vec![],
+        }),
+    });
+    true
+}

--- a/crates/sui-move-fuzzer/src/oracle.rs
+++ b/crates/sui-move-fuzzer/src/oracle.rs
@@ -1,0 +1,66 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Bug detection oracles for the Sui Move VM fuzzer.
+//!
+//! Provides wrappers to detect panics (validator crashes) and inspect
+//! transaction effects for signs of invariant violations or fund loss.
+
+use std::panic::{catch_unwind, AssertUnwindSafe};
+
+#[derive(Debug)]
+pub enum BugClass {
+    ValidatorCrash {
+        pass: String,
+        message: String,
+    },
+    FundLoss {
+        details: String,
+    },
+    VerifierSoundness {
+        description: String,
+    },
+}
+
+/// Wrap a closure in `catch_unwind`. Returns `Err(BugClass::ValidatorCrash)` on panic.
+pub fn check_crash<F: FnOnce() -> R, R>(label: &str, f: F) -> Result<R, BugClass> {
+    match catch_unwind(AssertUnwindSafe(f)) {
+        Ok(result) => Ok(result),
+        Err(payload) => {
+            let message = if let Some(s) = payload.downcast_ref::<String>() {
+                s.clone()
+            } else if let Some(s) = payload.downcast_ref::<&str>() {
+                (*s).to_string()
+            } else {
+                "unknown panic".to_string()
+            };
+            Err(BugClass::ValidatorCrash {
+                pass: label.to_string(),
+                message,
+            })
+        }
+    }
+}
+
+/// Check `TransactionEffects` for signs of invariant violations or fund loss.
+/// Returns `Some(BugClass)` if suspicious.
+#[cfg(feature = "e2e")]
+pub fn check_effects_for_bugs(
+    effects: &sui_types::effects::TransactionEffects,
+) -> Option<BugClass> {
+    use sui_types::effects::TransactionEffectsAPI;
+    use sui_types::execution_status::{ExecutionFailureStatus, ExecutionStatus};
+
+    match effects.status() {
+        ExecutionStatus::Failure { error, .. } => match error {
+            ExecutionFailureStatus::InvariantViolation => Some(BugClass::VerifierSoundness {
+                description: "InvariantViolation in transaction effects".to_string(),
+            }),
+            ExecutionFailureStatus::VMInvariantViolation => Some(BugClass::VerifierSoundness {
+                description: "VMInvariantViolation in transaction effects".to_string(),
+            }),
+            _ => None,
+        },
+        ExecutionStatus::Success => None,
+    }
+}

--- a/crates/sui-move-fuzzer/src/oracle_override.rs
+++ b/crates/sui-move-fuzzer/src/oracle_override.rs
@@ -1,0 +1,263 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Oracle price manipulation API for forked-execution mode.
+//!
+//! This module provides utilities for fetching real oracle price objects
+//! (Pyth, Switchboard, etc.) from the network and injecting modified versions
+//! into a `ForkedStore` so that adversarial modules see manipulated prices.
+//!
+//! # BCS byte patching
+//!
+//! Oracle price data is embedded as BCS-serialized Move struct fields inside
+//! the object's `contents` bytes.  Protocol-specific helpers decode and re-encode
+//! just the price fields while preserving the rest of the object layout.
+//!
+//! Initial implementation: raw byte-level patching via `BytePatch` (offset +
+//! replacement bytes).  Protocol-specific helpers (Pyth struct layout, dynamic
+//! field children) can be layered on top incrementally.
+
+use anyhow::{bail, Result};
+use sui_types::base_types::ObjectID;
+use sui_types::object::{Data, Object};
+
+use crate::forked_store::ForkedStore;
+
+// ---------------------------------------------------------------------------
+// Core data types
+// ---------------------------------------------------------------------------
+
+/// Specification for a price override to apply to an oracle object.
+pub struct PriceOverride {
+    /// On-chain object ID of the oracle price feed object.
+    pub oracle_object_id: ObjectID,
+    /// New price value (signed integer, same units as the oracle's exponent).
+    pub price: i64,
+    /// Optional 95% confidence interval around `price`.
+    pub confidence: Option<u64>,
+    /// Optional exponent — number of decimal places (e.g. -8 means × 10⁻⁸).
+    pub exponent: Option<i32>,
+}
+
+/// A raw byte patch: replace `len` bytes at `offset` in the object's BCS
+/// contents with `replacement`.
+pub struct BytePatch {
+    pub offset: usize,
+    pub replacement: Vec<u8>,
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/// Fetch the oracle object identified by `spec.oracle_object_id` from the RPC,
+/// apply `patches` to its BCS bytes, and inject the modified object into
+/// `store`'s override layer.
+///
+/// After this call, any Move code that reads the oracle object will see the
+/// patched bytes.
+///
+/// # Errors
+/// Returns an error if:
+/// - The object cannot be fetched (not found, RPC failure).
+/// - The object is a package (not a Move object).
+/// - A patch extends beyond the object's content length.
+pub fn apply_price_override(
+    store: &mut ForkedStore,
+    spec: &PriceOverride,
+    patches: &[BytePatch],
+) -> Result<()> {
+    let obj = store
+        .fetch_object(&spec.oracle_object_id)?
+        .ok_or_else(|| anyhow::anyhow!("oracle object {} not found", spec.oracle_object_id))?;
+
+    let patched = patch_object_contents(obj, patches)?;
+    store.inject_object(patched);
+    Ok(())
+}
+
+/// Like `apply_price_override` but also applies the same patches to the
+/// dynamic-field child object identified by `child_id`.
+///
+/// Pyth price feeds store the actual price data in a child `PriceInfoObject`
+/// that is a dynamic field of the parent feed.  This variant patches both.
+pub fn apply_price_override_with_child(
+    store: &mut ForkedStore,
+    spec: &PriceOverride,
+    parent_patches: &[BytePatch],
+    child_id: ObjectID,
+    child_patches: &[BytePatch],
+) -> Result<()> {
+    // Patch parent
+    let parent_obj = store
+        .fetch_object(&spec.oracle_object_id)?
+        .ok_or_else(|| anyhow::anyhow!("parent oracle object {} not found", spec.oracle_object_id))?;
+    let patched_parent = patch_object_contents(parent_obj, parent_patches)?;
+    store.inject_object(patched_parent);
+
+    // Patch child
+    let child_obj = store
+        .fetch_object(&child_id)?
+        .ok_or_else(|| anyhow::anyhow!("child oracle object {} not found", child_id))?;
+    let patched_child = patch_object_contents(child_obj, child_patches)?;
+    store.inject_object(patched_child);
+
+    Ok(())
+}
+
+/// Parse a `"<object_id>:<price_i64>"` string into a `(ObjectID, i64)` pair.
+/// Used for command-line `--oracle-override` flag parsing.
+///
+/// Example: `"0x1234abcd...:500000000"` → `(ObjectID, 500_000_000i64)`
+pub fn parse_override_spec(s: &str) -> Result<(ObjectID, i64)> {
+    let (id_part, price_part) = s
+        .rsplit_once(':')
+        .ok_or_else(|| anyhow::anyhow!("expected '<object_id>:<price>', got: {s}"))?;
+
+    let id: ObjectID = id_part
+        .parse()
+        .map_err(|e| anyhow::anyhow!("invalid ObjectID '{id_part}': {e}"))?;
+    let price: i64 = price_part
+        .parse()
+        .map_err(|e| anyhow::anyhow!("invalid price '{price_part}': {e}"))?;
+
+    Ok((id, price))
+}
+
+/// Build `BytePatch` entries from a `PriceOverride` spec, targeting the most
+/// common BCS field layout for oracle price objects.
+///
+/// Patches are generated at i64/u64/i32-aligned offsets:
+/// - offset 0: `price` (i64, 8 bytes)
+/// - offset 8: `confidence` (u64, 8 bytes), if `spec.confidence` is set
+/// - offset 16: `exponent` (i32, 4 bytes), if `spec.exponent` is set
+///
+/// The patch list is validated against the actual object size in
+/// `apply_price_override` via `patch_object_contents`.
+pub fn build_price_patches(spec: &PriceOverride) -> Vec<BytePatch> {
+    let mut patches = Vec::new();
+    patches.push(BytePatch {
+        offset: 0,
+        replacement: spec.price.to_le_bytes().to_vec(),
+    });
+    if let Some(conf) = spec.confidence {
+        patches.push(BytePatch {
+            offset: 8,
+            replacement: conf.to_le_bytes().to_vec(),
+        });
+    }
+    if let Some(exp) = spec.exponent {
+        patches.push(BytePatch {
+            offset: 16,
+            replacement: exp.to_le_bytes().to_vec(),
+        });
+    }
+    patches
+}
+
+/// Scan `contents` and return patches that overwrite every 8-byte aligned
+/// position with `price` in little-endian format.
+///
+/// Useful when the oracle struct layout is unknown — this maximises the chance
+/// that at least one field actually holds the price.
+pub fn build_simple_price_patch(price: i64, contents: &[u8]) -> Vec<BytePatch> {
+    let price_bytes = price.to_le_bytes().to_vec();
+    let max_offset = contents.len().saturating_sub(8);
+    (0..=max_offset)
+        .step_by(8)
+        .map(|offset| BytePatch {
+            offset,
+            replacement: price_bytes.clone(),
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/// Clone `obj`, apply `patches` to its Move object BCS contents, and return
+/// the modified object.
+fn patch_object_contents(mut obj: Object, patches: &[BytePatch]) -> Result<Object> {
+    let move_obj = match &mut obj.data {
+        Data::Move(m) => m,
+        Data::Package(_) => bail!("expected a Move object, got a package"),
+    };
+
+    // Clone the current contents so we can validate patches before applying.
+    let mut contents = move_obj.contents().to_vec();
+
+    for patch in patches {
+        let end = patch
+            .offset
+            .checked_add(patch.replacement.len())
+            .ok_or_else(|| anyhow::anyhow!("patch offset overflow"))?;
+        if end > contents.len() {
+            bail!(
+                "patch at offset {} (len {}) extends beyond object contents (len {})",
+                patch.offset,
+                patch.replacement.len(),
+                contents.len()
+            );
+        }
+        contents[patch.offset..end].copy_from_slice(&patch.replacement);
+    }
+
+    // Intentionally injecting adversarial bytes to test how downstream
+    // protocols react to manipulated oracle data.
+    move_obj.set_contents_unsafe(contents);
+
+    Ok(obj)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sui_types::base_types::SuiAddress;
+
+    /// Verify that `BytePatch` is applied correctly and that out-of-bounds
+    /// patches are rejected.
+    #[test]
+    fn byte_patch_applied() {
+        let obj = Object::new_gas_with_balance_and_owner_for_testing(0, SuiAddress::ZERO);
+        let original_len = match &obj.data {
+            Data::Move(m) => m.contents().len(),
+            _ => panic!("expected Move object"),
+        };
+
+        // Single byte patch at offset 0
+        let patches = vec![BytePatch {
+            offset: 0,
+            replacement: vec![0xFF],
+        }];
+        let patched = patch_object_contents(obj.clone(), &patches).unwrap();
+        match &patched.data {
+            Data::Move(m) => assert_eq!(m.contents()[0], 0xFF),
+            _ => panic!("expected Move object"),
+        }
+
+        // Out-of-bounds patch should fail
+        let bad_patches = vec![BytePatch {
+            offset: original_len,
+            replacement: vec![0x00],
+        }];
+        assert!(patch_object_contents(obj, &bad_patches).is_err());
+    }
+
+    #[test]
+    fn parse_override_spec_roundtrip() {
+        // A real-looking object ID + price
+        let s = "0x0000000000000000000000000000000000000000000000000000000000000006:1234567";
+        let (id, price) = parse_override_spec(s).unwrap();
+        assert_eq!(price, 1_234_567i64);
+        // id should equal the SUI clock object ID
+        assert_eq!(id, "0x6".parse::<ObjectID>().unwrap());
+    }
+
+    #[test]
+    fn parse_override_spec_rejects_bad_input() {
+        assert!(parse_override_spec("no_colon").is_err());
+        assert!(parse_override_spec("0x1:not_a_number").is_err());
+        assert!(parse_override_spec("not_an_id:42").is_err());
+    }
+}

--- a/crates/sui-move-fuzzer/src/seed_corpus.rs
+++ b/crates/sui-move-fuzzer/src/seed_corpus.rs
@@ -1,0 +1,134 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Seed corpus generator for the Sui Move VM fuzzer.
+//!
+//! Generates a set of valid `CompiledModule` bytes that pass verification,
+//! suitable as starting points for mutation-based fuzzing.
+
+use arbitrary::Unstructured;
+
+use crate::module_gen::{ModuleBuilder, ModuleGenConfig};
+
+/// Generate seed corpus entries as serialized module bytes.
+/// Each entry uses a different random seed to produce a diverse set of modules.
+pub fn generate_seeds(count: usize) -> Vec<Vec<u8>> {
+    let mut seeds = Vec::new();
+
+    for seed_idx in 0..count {
+        // Create deterministic but varied random data for each seed
+        let data: Vec<u8> = (0..2048)
+            .map(|i| {
+                ((i as u32)
+                    .wrapping_mul(seed_idx as u32 + 1)
+                    .wrapping_add(seed_idx as u32 * 37)
+                    % 256) as u8
+            })
+            .collect();
+
+        let mut u = Unstructured::new(&data);
+        let config: ModuleGenConfig = match u.arbitrary() {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+
+        let builder = ModuleBuilder::new(config);
+        let module = match builder.build(&mut u) {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+
+        let mut bytes = Vec::new();
+        if module.serialize(&mut bytes).is_ok() {
+            seeds.push(bytes);
+        }
+    }
+
+    seeds
+}
+
+/// Generate seeds wrapped in the `Input` struct format used by structured fuzz targets.
+/// Returns raw bytes suitable for the `verifier_crash` and `e2e_publish_execute` targets.
+pub fn generate_structured_seeds(count: usize) -> Vec<Vec<u8>> {
+    let mut seeds = Vec::new();
+
+    for seed_idx in 0..count {
+        // For structured targets, we need bytes that Arbitrary can parse into
+        // our Input structs. The simplest approach: create a ModuleGenConfig
+        // manually and serialize it with enough entropy for building.
+        let mut data = Vec::with_capacity(1024);
+
+        // ModuleGenConfig fields (6 bytes for Arbitrary):
+        let num_structs = ((seed_idx % 5) + 1) as u8;
+        let num_functions = ((seed_idx % 4) + 1) as u8;
+        let num_fields = (seed_idx % 4) as u8;
+        let max_code_len = ((seed_idx % 30) + 8) as u8;
+        let has_key = if seed_idx % 3 == 0 { 1u8 } else { 0 };
+        let has_entry = if seed_idx % 2 == 0 { 1u8 } else { 0 };
+
+        data.push(num_structs);
+        data.push(num_functions);
+        data.push(num_fields);
+        data.push(max_code_len);
+        data.push(has_key);
+        data.push(has_entry);
+
+        // Option<MutationKind>: 0 = None (no mutation for seed corpus)
+        data.push(0);
+
+        // Vec<u8> raw_entropy: fill with deterministic data for module building
+        let entropy: Vec<u8> = (0..512)
+            .map(|i| {
+                ((i as u32)
+                    .wrapping_mul(seed_idx as u32 + 7)
+                    .wrapping_add(13)
+                    % 256) as u8
+            })
+            .collect();
+        // Arbitrary for Vec<u8> reads a length prefix (ULEB128) then that many bytes
+        // For simplicity, encode a small length that fits in two ULEB128 bytes
+        let entropy_len = entropy.len().min(400);
+        // Encode length as 2-byte ULEB128: low 7 bits + continuation, then high bits
+        data.push((entropy_len as u8 & 0x7F) | 0x80);
+        data.push((entropy_len >> 7) as u8);
+        data.extend_from_slice(&entropy[..entropy_len]);
+
+        seeds.push(data);
+    }
+
+    seeds
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generates_valid_raw_seeds() {
+        let seeds = generate_seeds(20);
+        assert!(!seeds.is_empty(), "should generate at least one seed");
+
+        for (i, seed) in seeds.iter().enumerate() {
+            // Each seed should start with Move magic bytes
+            assert!(
+                seed.len() > 4,
+                "seed {i} too short: {} bytes",
+                seed.len()
+            );
+            assert_eq!(
+                &seed[..4],
+                &[0xA1, 0x1C, 0xEB, 0x0B],
+                "seed {i} missing Move magic"
+            );
+        }
+    }
+
+    #[test]
+    fn generates_structured_seeds() {
+        let seeds = generate_structured_seeds(10);
+        assert_eq!(seeds.len(), 10);
+        for seed in &seeds {
+            assert!(seed.len() > 10, "structured seed too short");
+        }
+    }
+}

--- a/crates/sui-move-fuzzer/src/sui_harness.rs
+++ b/crates/sui-move-fuzzer/src/sui_harness.rs
@@ -1,0 +1,155 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Lightweight verification-only harness for the Sui Move VM fuzzer.
+//!
+//! Runs the full Move + Sui verification pipeline without needing a full
+//! authority instance. Useful for fast crash-finding fuzz targets.
+
+use std::collections::BTreeMap;
+
+use move_binary_format::binary_config::BinaryConfig;
+use move_binary_format::file_format::CompiledModule;
+use move_bytecode_verifier::verify_module_with_config_metered;
+use move_bytecode_verifier_meter::dummy::DummyMeter;
+use move_vm_config::verifier::VerifierConfig;
+
+use sui_verifier::{
+    entry_points_verifier, global_storage_access_verifier, id_leak_verifier,
+    one_time_witness_verifier, struct_with_key_verifier,
+};
+
+use crate::oracle;
+
+/// Returns a `VerifierConfig` matching Sui production settings.
+pub fn sui_verifier_config() -> VerifierConfig {
+    VerifierConfig {
+        deprecate_global_storage_ops: true,
+        private_generics_verifier_v2: true,
+        sanity_check_with_regex_reference_safety: Some(8_000_000),
+        bytecode_version: 7,
+        max_loop_depth: Some(5),
+        max_function_parameters: Some(128),
+        max_generic_instantiation_length: Some(32),
+        max_basic_blocks: Some(1024),
+        max_value_stack_size: 1024,
+        max_type_nodes: Some(256),
+        max_push_size: Some(10000),
+        max_dependency_depth: Some(100),
+        max_data_definitions: Some(200),
+        max_fields_in_struct: Some(32),
+        max_function_definitions: Some(1000),
+        ..VerifierConfig::default()
+    }
+}
+
+/// Run the full Move + Sui verification pipeline. Returns `Ok(())` or an error string.
+pub fn run_full_verification(module: &CompiledModule) -> Result<(), String> {
+    let config = sui_verifier_config();
+    let mut meter = DummyMeter;
+
+    // Phase 1: Move bytecode verification
+    verify_module_with_config_metered(&config, module, &mut meter)
+        .map_err(|e| format!("Move verification failed: {:?}", e))?;
+
+    // Phase 2: Sui-specific verification
+    let fn_info_map = BTreeMap::new();
+    sui_verifier::verifier::sui_verify_module_metered(
+        module,
+        &fn_info_map,
+        &mut meter,
+        &config,
+    )
+    .map_err(|e| format!("Sui verification failed: {}", e))
+}
+
+/// Run each Sui verifier pass individually with `catch_unwind`.
+pub fn run_sui_passes_individually(
+    module: &CompiledModule,
+) -> Vec<(&'static str, Result<(), String>)> {
+    let config = sui_verifier_config();
+    let fn_info_map: BTreeMap<_, _> = BTreeMap::new();
+    let mut results = Vec::new();
+
+    // struct_with_key_verifier
+    let r = oracle::check_crash("struct_with_key_verifier", || {
+        struct_with_key_verifier::verify_module(module)
+    });
+    results.push((
+        "struct_with_key_verifier",
+        flatten_crash_result(r),
+    ));
+
+    // global_storage_access_verifier
+    let r = oracle::check_crash("global_storage_access_verifier", || {
+        global_storage_access_verifier::verify_module(module)
+    });
+    results.push((
+        "global_storage_access_verifier",
+        flatten_crash_result(r),
+    ));
+
+    // id_leak_verifier
+    let r = oracle::check_crash("id_leak_verifier", || {
+        id_leak_verifier::verify_module(module, &mut DummyMeter)
+    });
+    results.push(("id_leak_verifier", flatten_crash_result(r)));
+
+    // entry_points_verifier
+    let config_clone = config.clone();
+    let fn_info_clone = fn_info_map.clone();
+    let r = oracle::check_crash("entry_points_verifier", || {
+        entry_points_verifier::verify_module(module, &fn_info_clone, &config_clone)
+    });
+    results.push(("entry_points_verifier", flatten_crash_result(r)));
+
+    // one_time_witness_verifier
+    let r = oracle::check_crash("one_time_witness_verifier", || {
+        one_time_witness_verifier::verify_module(module, &fn_info_map)
+    });
+    results.push(("one_time_witness_verifier", flatten_crash_result(r)));
+
+    results
+}
+
+/// Serialize -> deserialize -> re-serialize -> compare bytes.
+pub fn roundtrip_check(module: &CompiledModule) -> Result<(), String> {
+    let mut bytes1 = Vec::new();
+    module
+        .serialize(&mut bytes1)
+        .map_err(|e| format!("Initial serialization failed: {:?}", e))?;
+
+    let config = BinaryConfig::standard();
+    let module2 = CompiledModule::deserialize_with_config(&bytes1, &config)
+        .map_err(|e| format!("Deserialization failed: {:?}", e))?;
+
+    let mut bytes2 = Vec::new();
+    module2
+        .serialize(&mut bytes2)
+        .map_err(|e| format!("Re-serialization failed: {:?}", e))?;
+
+    if bytes1 != bytes2 {
+        return Err(format!(
+            "Roundtrip mismatch: original {} bytes vs re-serialized {} bytes",
+            bytes1.len(),
+            bytes2.len()
+        ));
+    }
+
+    Ok(())
+}
+
+/// Convert a `Result<Result<(), impl Display>, BugClass>` from `check_crash` into a flat
+/// `Result<(), String>`, propagating panics as `Err`.
+fn flatten_crash_result<E: std::fmt::Display>(
+    result: Result<Result<(), E>, oracle::BugClass>,
+) -> Result<(), String> {
+    match result {
+        Ok(Ok(())) => Ok(()),
+        Ok(Err(e)) => Err(format!("{}", e)),
+        Err(oracle::BugClass::ValidatorCrash { pass, message }) => {
+            Err(format!("CRASH in {}: {}", pass, message))
+        }
+        Err(bug) => Err(format!("{:?}", bug)),
+    }
+}


### PR DESCRIPTION
## Summary

Addresses several issues found during review of the initial forked execution implementation (`forked_store`, `forked_executor`, `oracle_override`, `fork_main`).

**Critical bug fixes**
- Fix memory leak: `Box::leak` per-iteration replaced with a local `Vec<u8>` borrow; entropy increased 256 → 1024 bytes to reduce "ran out of data" skips
- Fix oracle overrides being no-ops: add `build_price_patches()` / `build_simple_price_patch()` to produce real `BytePatch` entries from a `PriceOverride` spec
- Fix misleading error on publish failure: check `ExecutionStatus` before searching effects for a package ID; failed publishes return early instead of "no immutable package in effects"

**Missing functionality**
- Call entry functions after publish: extract module name from `CompiledModule`, pass `("fuzz_mod", "f0")` to `publish_and_call` when `gen_config.has_entry_fn` is true — surfaces runtime bugs invisible to publish-only runs
- Add panic catching: `oracle::check_crash` wraps `publish_and_call`; panics save the triggering module bytes as a finding
- Add `--seed N` CLI flag: uses `rand::rngs::StdRng::seed_from_u64`; seed is printed at startup for reproducibility

**Code quality**
- Replace duplicate invariant-violation detection in `fork_main` with `oracle::check_effects_for_bugs`
- Fix doc comment: `::` separator → `:` in `parse_override_spec` example

**Efficiency**
- `ForkedStore`: add `negative_cache: Mutex<BTreeSet<ObjectID>>` — avoids repeated RPC round-trips for objects absent from chain
- `ForkedStore`: add `rpc_fetches: AtomicUsize` counter for end-of-run diagnostics
- `ForkedStore`: log RPC transport errors in `fetch_to_cache` (previously silent)
- `ParentSync::get_latest_parent_entry_ref_deprecated`: fall through to RPC on cache miss (previously only checked overrides + in-memory cache)

## Test plan

- [ ] `cargo check --features fork` — clean build
- [ ] `cargo test --features fork --lib` — 25 tests pass, 0 warnings
- [ ] `cargo clippy --features fork` — no new warnings in changed files
- [ ] `cargo test --lib` — 20 tests pass (default features, no regressions)
- [ ] Manual: `cargo run --features fork --bin fork_main -- --help` shows `--seed` flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)