### PR TITLE
Enforce 10s minimum epoch duration for simtests

### DIFF
--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -101,7 +101,7 @@ mod test {
     #[sim_test(config = "test_config()")]
     async fn test_simulated_load_with_reconfig() {
         sui_protocol_config::ProtocolConfig::poison_get_for_min_version();
-        let test_cluster = build_test_cluster(2, 5_000, 1).await;
+        let test_cluster = build_test_cluster(2, 10_000, 1).await;
         test_simulated_load(test_cluster, 60).await;
     }
 
@@ -187,7 +187,7 @@ mod test {
     #[sim_test(config = "test_config()")]
     async fn test_simulated_load_conflicting_transfers() {
         sui_protocol_config::ProtocolConfig::poison_get_for_min_version();
-        let test_cluster = build_test_cluster(4, 5000, 1).await;
+        let test_cluster = build_test_cluster(4, 10_000, 1).await;
         let mut simulated_load_config = SimulatedLoadConfig::default();
         // Use LocalValidatorAggregatorProxy for soft bundle support
         simulated_load_config.remote_env = false;
@@ -254,7 +254,7 @@ mod test {
     #[sim_test(config = "test_config()")]
     async fn test_simulated_load_reconfig_restarts() {
         sui_protocol_config::ProtocolConfig::poison_get_for_min_version();
-        let test_cluster = build_test_cluster(4, 5_000, 1).await;
+        let test_cluster = build_test_cluster(4, 10_000, 1).await;
         let node_restarter = test_cluster
             .random_node_restarter()
             .with_kill_interval_secs(5, 15)
@@ -266,7 +266,7 @@ mod test {
     #[sim_test(config = "test_config()")]
     async fn test_simulated_load_small_committee_reconfig() {
         sui_protocol_config::ProtocolConfig::poison_get_for_min_version();
-        let test_cluster = build_test_cluster(1, 5_000, 0).await;
+        let test_cluster = build_test_cluster(1, 10_000, 0).await;
         test_simulated_load(test_cluster, 120).await;
     }
 
@@ -724,7 +724,7 @@ mod test {
     // simtest has low timeout tolerance and it is not designed to test performance.
     #[sim_test(config = "test_config_low_latency()")]
     async fn test_simulated_load_large_consensus_commit_prologue_size() {
-        let test_cluster = build_test_cluster(4, 5_000, 1).await;
+        let test_cluster = build_test_cluster(4, 10_000, 1).await;
 
         let mut additional_cancelled_txns = Vec::new();
         let num_txns = thread_rng().gen_range(500..2000);
@@ -757,7 +757,7 @@ mod test {
     #[cfg(not(tidehunter))]
     #[sim_test(config = "test_config()")]
     async fn test_simulated_load_pruning() {
-        let epoch_duration_ms = 5000;
+        let epoch_duration_ms = 10_000;
         let test_cluster = build_test_cluster(4, epoch_duration_ms, 0).await;
         test_simulated_load(test_cluster.clone(), 30).await;
 
@@ -1355,7 +1355,7 @@ mod test {
     async fn test_fork_recovery_transaction_effects_simulation() {
         sui_protocol_config::ProtocolConfig::poison_get_for_min_version();
 
-        let test_cluster = build_test_cluster(4, 5000, 4).await;
+        let test_cluster = build_test_cluster(4, 10_000, 4).await;
 
         let checkpoint_overrides: Arc<Mutex<BTreeMap<u64, String>>> =
             Arc::new(Mutex::new(BTreeMap::new()));

--- a/crates/sui-e2e-tests/tests/authenticated_events_api_tests.rs
+++ b/crates/sui-e2e-tests/tests/authenticated_events_api_tests.rs
@@ -749,7 +749,7 @@ async fn list_authenticated_events_end_to_end() {
     let test_cluster = TestClusterBuilder::new()
         .disable_fullnode_pruning()
         .with_rpc_config(rpc_config)
-        .with_epoch_duration_ms(5000)
+        .with_epoch_duration_ms(10000)
         .build()
         .await;
 

--- a/crates/sui-e2e-tests/tests/authenticated_events_client_test.rs
+++ b/crates/sui-e2e-tests/tests/authenticated_events_client_test.rs
@@ -234,7 +234,7 @@ async fn test_client_cross_epoch_stream() {
     let test_cluster = TestClusterBuilder::new()
         .disable_fullnode_pruning()
         .with_rpc_config(rpc_config)
-        .with_epoch_duration_ms(1000)
+        .with_epoch_duration_ms(10000)
         .build()
         .await;
 
@@ -487,7 +487,7 @@ async fn test_client_pruned_checkpoint_error() {
 
     let test_cluster = TestClusterBuilder::new()
         .with_rpc_config(rpc_config)
-        .with_epoch_duration_ms(5000)
+        .with_epoch_duration_ms(10000)
         .build()
         .await;
 

--- a/crates/sui-e2e-tests/tests/reconfiguration_tests.rs
+++ b/crates/sui-e2e-tests/tests/reconfiguration_tests.rs
@@ -112,7 +112,7 @@ async fn do_test_passive_reconfig(chain: Option<Chain>) {
     });
     ProtocolConfig::poison_get_for_min_version();
 
-    let mut builder = TestClusterBuilder::new().with_epoch_duration_ms(1000);
+    let mut builder = TestClusterBuilder::new().with_epoch_duration_ms(10000);
 
     if let Some(chain) = chain {
         builder = builder.with_chain_override(chain);
@@ -200,7 +200,7 @@ async fn test_create_advance_epoch_tx_race() {
     register_wait("reconfig_delay", target_node, reconfig_delay_tx.clone());
 
     let test_cluster = TestClusterBuilder::new()
-        .with_epoch_duration_ms(1000)
+        .with_epoch_duration_ms(10000)
         .build()
         .await;
 
@@ -227,7 +227,7 @@ async fn test_reconfig_with_failing_validator() {
 
     let test_cluster = Arc::new(
         TestClusterBuilder::new()
-            .with_epoch_duration_ms(5000)
+            .with_epoch_duration_ms(10000)
             .build()
             .await,
     );

--- a/crates/sui-json-rpc-tests/tests/transaction_tests.rs
+++ b/crates/sui-json-rpc-tests/tests/transaction_tests.rs
@@ -451,7 +451,7 @@ async fn test_query_transaction_blocks() -> Result<(), anyhow::Error> {
 #[sim_test]
 async fn test_display_transaction_block_with_empty_balance_changes() {
     let cluster = TestClusterBuilder::new()
-        .with_epoch_duration_ms(5_000)
+        .with_epoch_duration_ms(10_000)
         .build()
         .await;
     cluster.wait_for_epoch(Some(1)).await;

--- a/crates/sui-swarm/src/memory/swarm.rs
+++ b/crates/sui-swarm/src/memory/swarm.rs
@@ -230,6 +230,10 @@ impl<R> SwarmBuilder<R> {
     }
 
     pub fn with_epoch_duration_ms(mut self, epoch_duration_ms: u64) -> Self {
+        assert!(
+            epoch_duration_ms >= 10000,
+            "Epoch duration must be at least 10s (10000ms) to avoid flaky tests. Got {epoch_duration_ms}ms."
+        );
         self.get_or_init_genesis_config()
             .parameters
             .epoch_duration_ms = epoch_duration_ms;

--- a/crates/test-cluster/src/lib.rs
+++ b/crates/test-cluster/src/lib.rs
@@ -1217,6 +1217,10 @@ impl TestClusterBuilder {
     }
 
     pub fn with_epoch_duration_ms(mut self, epoch_duration_ms: u64) -> Self {
+        assert!(
+            epoch_duration_ms >= 10000,
+            "Epoch duration must be at least 10s (10000ms) to avoid flaky tests. Got {epoch_duration_ms}ms."
+        );
         self.get_or_init_genesis_config()
             .parameters
             .epoch_duration_ms = epoch_duration_ms;


### PR DESCRIPTION
## Description 

Lower durations cause flaky tests.

## Test plan 

Is test change

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
