### PR TITLE
sui-indexer-alt: remove init_watermark

### DIFF
--- a/crates/sui-analytics-indexer/src/store/migration.rs
+++ b/crates/sui-analytics-indexer/src/store/migration.rs
@@ -251,23 +251,6 @@ impl MigrationStore {
         }
     }
 
-    /// Initialize migration mode for a pipeline.
-    ///
-    /// Reads existing watermark file if present.
-    ///
-    /// Returns the last processed checkpoint if a watermark exists, or None if starting fresh.
-    /// The watermark file is created/updated by `update_watermark` after file uploads.
-    pub(crate) async fn init_watermark(
-        &self,
-        pipeline: &str,
-        _default_next_checkpoint: u64,
-    ) -> anyhow::Result<Option<u64>> {
-        Ok(self
-            .committer_watermark(pipeline)
-            .await?
-            .map(|w| w.checkpoint_hi_inclusive))
-    }
-
     /// Update watermark for a single pipeline after successful file upload.
     ///
     /// Called by the upload worker after each file is successfully uploaded.

--- a/crates/sui-analytics-indexer/src/store/mod.rs
+++ b/crates/sui-analytics-indexer/src/store/mod.rs
@@ -625,34 +625,6 @@ impl TransactionalStore for AnalyticsStore {
 
 #[async_trait]
 impl Connection for AnalyticsConnection<'_> {
-    /// Initialize watermark.
-    ///
-    /// In live mode: Watermarks are derived from file names, so just delegates to `committer_watermark`.
-    /// In migration mode: If no watermark exists and `default_next_checkpoint > 0`, initializes
-    /// the watermark to `default_next_checkpoint - 1` so migration starts from the configured
-    /// `first_checkpoint`.
-    async fn init_watermark(
-        &mut self,
-        pipeline_task: &str,
-        default_next_checkpoint: u64,
-    ) -> anyhow::Result<Option<u64>> {
-        match &self.store.mode {
-            StoreMode::Live(_) => {
-                // Live mode: derive from file names
-                Ok(self
-                    .committer_watermark(pipeline_task)
-                    .await?
-                    .map(|w| w.checkpoint_hi_inclusive))
-            }
-            StoreMode::Migration(store) => {
-                let output_prefix = self.pipeline_config(pipeline_task).output_prefix();
-                store
-                    .init_watermark(output_prefix, default_next_checkpoint)
-                    .await
-            }
-        }
-    }
-
     /// Determine the watermark.
     ///
     /// In live mode: scans file names in the object store.

--- a/crates/sui-indexer-alt-consistent-store/src/indexer.rs
+++ b/crates/sui-indexer-alt-consistent-store/src/indexer.rs
@@ -118,7 +118,6 @@ impl<S: Schema + Send + Sync + 'static> Indexer<S> {
             H::NAME
         );
 
-        // TODO: Refactor consistent store indexer to use `init_watermark` instead of wrapping `sequential_pipeline`.
         self.sync
             .register_pipeline(H::NAME)
             .with_context(|| format!("Failed to add pipeline {:?} to synchronizer", H::NAME))?;

--- a/crates/sui-indexer-alt-consistent-store/src/store/mod.rs
+++ b/crates/sui-indexer-alt-consistent-store/src/store/mod.rs
@@ -165,13 +165,6 @@ impl<S: Send + Sync + 'static> store::TransactionalStore for Store<S> {
 
 #[async_trait::async_trait]
 impl<S: Send + Sync> store::Connection for Connection<'_, S> {
-    async fn init_watermark(&mut self, pipeline_task: &str, _: u64) -> anyhow::Result<Option<u64>> {
-        Ok(self
-            .committer_watermark(pipeline_task)
-            .await?
-            .map(|w| w.checkpoint_hi_inclusive))
-    }
-
     async fn committer_watermark(
         &mut self,
         pipeline_task: &str,

--- a/crates/sui-indexer-alt-framework-store-traits/src/lib.rs
+++ b/crates/sui-indexer-alt-framework-store-traits/src/lib.rs
@@ -13,14 +13,6 @@ use scoped_futures::ScopedBoxFuture;
 /// operations, agnostic of the underlying store implementation.
 #[async_trait]
 pub trait Connection: Send {
-    /// If no existing watermark record exists, initializes it with `default_next_checkpoint`.
-    /// Returns the committer watermark `checkpoint_hi_inclusive`.
-    async fn init_watermark(
-        &mut self,
-        pipeline_task: &str,
-        default_next_checkpoint: u64,
-    ) -> anyhow::Result<Option<u64>>;
-
     /// Given a `pipeline_task` representing either a pipeline name or a pipeline with an associated
     /// task (formatted as `{pipeline}{Store::DELIMITER}{task}`), return the committer watermark
     /// from the `Store`. The indexer fetches this value for each pipeline added to determine which

--- a/crates/sui-indexer-alt-framework/src/lib.rs
+++ b/crates/sui-indexer-alt-framework/src/lib.rs
@@ -375,13 +375,14 @@ impl<S: Store> Indexer<S> {
         let pipeline_task =
             pipeline_task::<S>(P::NAME, self.task.as_ref().map(|t| t.task.as_str()))?;
 
-        let checkpoint_hi_inclusive = conn
-            .init_watermark(&pipeline_task, self.default_next_checkpoint)
+        let committer_watermark = conn
+            .committer_watermark(&pipeline_task)
             .await
             .with_context(|| format!("Failed to init watermark for {pipeline_task}"))?;
 
-        let next_checkpoint =
-            checkpoint_hi_inclusive.map_or(self.default_next_checkpoint, |c| c + 1);
+        let next_checkpoint = committer_watermark.map_or(self.default_next_checkpoint, |c| {
+            c.checkpoint_hi_inclusive + 1
+        });
 
         self.first_ingestion_checkpoint = next_checkpoint.min(self.first_ingestion_checkpoint);
 
@@ -448,7 +449,6 @@ mod tests {
 
     use async_trait::async_trait;
     use clap::Parser;
-    use sui_indexer_alt_framework_store_traits::PrunerWatermark;
     use sui_synthetic_ingestion::synthetic_ingestion;
     use tokio::sync::watch;
 
@@ -597,62 +597,6 @@ mod tests {
     test_pipeline!(MockHandler, "test_processor");
     test_pipeline!(SequentialHandler, "sequential_handler");
     test_pipeline!(MockCheckpointSequenceNumberHandler, "test");
-
-    async fn test_init_watermark(
-        first_checkpoint: Option<u64>,
-        is_concurrent: bool,
-    ) -> (Option<CommitterWatermark>, Option<PrunerWatermark>) {
-        let registry = Registry::new();
-        let store = MockStore::default();
-
-        test_pipeline!(A, "pipeline_name");
-
-        let mut conn = store.connect().await.unwrap();
-
-        let indexer_args = IndexerArgs {
-            first_checkpoint,
-            ..IndexerArgs::default()
-        };
-        let temp_dir = tempfile::tempdir().unwrap();
-        let client_args = ClientArgs {
-            ingestion: IngestionClientArgs {
-                local_ingestion_path: Some(temp_dir.path().to_owned()),
-                ..Default::default()
-            },
-            ..Default::default()
-        };
-        let ingestion_config = IngestionConfig::default();
-
-        let mut indexer = Indexer::new(
-            store.clone(),
-            indexer_args,
-            client_args,
-            ingestion_config,
-            None,
-            &registry,
-        )
-        .await
-        .unwrap();
-
-        if is_concurrent {
-            indexer
-                .concurrent_pipeline::<A>(A, ConcurrentConfig::default())
-                .await
-                .unwrap();
-        } else {
-            indexer
-                .sequential_pipeline::<A>(A, SequentialConfig::default())
-                .await
-                .unwrap();
-        }
-
-        (
-            conn.committer_watermark(A::NAME).await.unwrap(),
-            conn.pruner_watermark(A::NAME, Duration::ZERO)
-                .await
-                .unwrap(),
-        )
-    }
 
     #[test]
     fn test_arg_parsing() {
@@ -1704,46 +1648,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_init_watermark_concurrent_no_first_checkpoint() {
-        let (committer_watermark, pruner_watermark) = test_init_watermark(None, true).await;
-        // Indexer will not init the watermark, pipeline tasks will write commit watermarks as normal.
-        assert_eq!(committer_watermark, None);
-        assert_eq!(pruner_watermark, None);
-    }
-
-    #[tokio::test]
-    async fn test_init_watermark_concurrent_first_checkpoint_0() {
-        let (committer_watermark, pruner_watermark) = test_init_watermark(Some(0), true).await;
-        // Indexer will not init the watermark, pipeline tasks will write commit watermarks as normal.
-        assert_eq!(committer_watermark, None);
-        assert_eq!(pruner_watermark, None);
-    }
-
-    #[tokio::test]
-    async fn test_init_watermark_concurrent_first_checkpoint_1() {
-        let (committer_watermark, pruner_watermark) = test_init_watermark(Some(1), true).await;
-
-        let committer_watermark = committer_watermark.unwrap();
-        assert_eq!(committer_watermark.checkpoint_hi_inclusive, 0);
-
-        let pruner_watermark = pruner_watermark.unwrap();
-        assert_eq!(pruner_watermark.reader_lo, 1);
-        assert_eq!(pruner_watermark.pruner_hi, 1);
-    }
-
-    #[tokio::test]
-    async fn test_init_watermark_sequential() {
-        let (committer_watermark, pruner_watermark) = test_init_watermark(Some(1), false).await;
-
-        let committer_watermark = committer_watermark.unwrap();
-        assert_eq!(committer_watermark.checkpoint_hi_inclusive, 0);
-
-        let pruner_watermark = pruner_watermark.unwrap();
-        assert_eq!(pruner_watermark.reader_lo, 1);
-        assert_eq!(pruner_watermark.pruner_hi, 1);
-    }
-
-    #[tokio::test]
     async fn test_multiple_sequential_pipelines_next_checkpoint() {
         let registry = Registry::new();
         let store = MockStore::default();
@@ -2057,7 +1961,7 @@ mod tests {
         assert_eq!(main_pipeline_watermark.reader_lo, 5);
         let tasked_pipeline_watermark = store.watermark("test@task").unwrap();
         assert_eq!(tasked_pipeline_watermark.checkpoint_hi_inclusive, 25);
-        assert_eq!(tasked_pipeline_watermark.reader_lo, 9);
+        assert_eq!(tasked_pipeline_watermark.reader_lo, 0);
     }
 
     /// Test that when the collector observes `reader_lo = X`, that all checkpoints >= X will be

--- a/crates/sui-indexer-alt-framework/src/mocks/store.rs
+++ b/crates/sui-indexer-alt-framework/src/mocks/store.rs
@@ -1,7 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::ops::Deref;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::atomic::AtomicUsize;
@@ -86,40 +85,6 @@ pub struct MockConnection<'c>(pub &'c MockStore);
 
 #[async_trait]
 impl Connection for MockConnection<'_> {
-    async fn init_watermark(
-        &mut self,
-        pipeline_task: &str,
-        default_next_checkpoint: u64,
-    ) -> anyhow::Result<Option<u64>> {
-        let Some(checkpoint_hi_inclusive) = default_next_checkpoint.checked_sub(1) else {
-            // Do not create a watermark record with checkpoint_hi_inclusive = -1.
-            return Ok(self
-                .committer_watermark(pipeline_task)
-                .await?
-                .map(|w| w.checkpoint_hi_inclusive));
-        };
-
-        let &MockWatermark {
-            checkpoint_hi_inclusive,
-            ..
-        } = self
-            .0
-            .watermarks
-            .entry(pipeline_task.to_string())
-            .or_insert(MockWatermark {
-                epoch_hi_inclusive: 0,
-                checkpoint_hi_inclusive,
-                tx_hi: 0,
-                timestamp_ms_hi_inclusive: 0,
-                reader_lo: default_next_checkpoint,
-                pruner_timestamp: 0,
-                pruner_hi: default_next_checkpoint,
-            })
-            .deref();
-
-        Ok(Some(checkpoint_hi_inclusive))
-    }
-
     async fn committer_watermark(
         &mut self,
         pipeline_task: &str,
@@ -182,11 +147,17 @@ impl Connection for MockConnection<'_> {
             self.0.commit_watermark_failures.failures - prev
         );
 
+        let checkpoint_hi = watermark.checkpoint_hi_inclusive;
         let mut wm = self
             .0
             .watermarks
             .entry(pipeline_task.to_string())
-            .or_default();
+            .or_insert_with(|| MockWatermark {
+                // Match PG behavior: initialize pruner_hi to checkpoint_hi_inclusive so the
+                // pruner does not attempt to prune checkpoints before the first committed data.
+                pruner_hi: checkpoint_hi,
+                ..Default::default()
+            });
 
         wm.epoch_hi_inclusive = watermark.epoch_hi_inclusive;
         wm.checkpoint_hi_inclusive = watermark.checkpoint_hi_inclusive;

--- a/crates/sui-indexer-alt-framework/src/pipeline/concurrent/commit_watermark.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/concurrent/commit_watermark.rs
@@ -424,6 +424,15 @@ mod tests {
         // Verify watermark progression
         let watermark = setup.store.watermark(DataPipeline::NAME).unwrap();
         assert_eq!(watermark.checkpoint_hi_inclusive, 3);
+
+        // pruner_hi must be initialized to checkpoint_hi_inclusive of the first write
+        // instead of 0. Otherwise, starting an indexer with --first-checkpoint > 0 causes the
+        // pruner to attempt to prune the checkpoints less than checkpoint_hi_inclusive that were
+        // never indexed.
+        assert_eq!(watermark.pruner_hi, 3);
+
+        // reader_lo cannot be below pruner_hi so it must be initialized to at least the same value.
+        assert_eq!(watermark.reader_lo, 3);
     }
 
     #[tokio::test]

--- a/crates/sui-indexer-alt-framework/src/pipeline/concurrent/mod.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/concurrent/mod.rs
@@ -352,6 +352,7 @@ mod tests {
     use crate::metrics::IndexerMetrics;
     use crate::mocks::store::MockConnection;
     use crate::mocks::store::MockStore;
+    use crate::mocks::store::MockWatermark;
     use crate::pipeline::Processor;
     use crate::types::full_checkpoint_content::Checkpoint;
     use crate::types::test_checkpoint_data_builder::TestCheckpointBuilder;
@@ -510,7 +511,16 @@ mod tests {
             }),
             ..Default::default()
         };
-        let store = MockStore::default();
+        // Pre-configure the watermark with pruner_hi = 0 to get deterministic pruning behavior.
+        // Without this, pruner_hi is initialized to the first committed checkpoint_hi_inclusive,
+        // which depends on timing and could skip pruning early checkpoints.
+        let store = MockStore::default().with_watermark(
+            DataPipeline::NAME,
+            MockWatermark {
+                pruner_hi: 0,
+                ..Default::default()
+            },
+        );
         let setup = TestSetup::new(config, store, 0).await;
 
         // Send initial checkpoints
@@ -873,8 +883,17 @@ mod tests {
             ..Default::default()
         };
 
-        // Configure prune failures for range [0, 2) - fail twice then succeed
-        let store = MockStore::default().with_prune_failures(0, 2, 1);
+        // Pre-configure the watermark with pruner_hi = 0 for deterministic pruning behavior.
+        // Configure prune failures for range [0, 2) - fail once then succeed
+        let store = MockStore::default()
+            .with_watermark(
+                DataPipeline::NAME,
+                MockWatermark {
+                    pruner_hi: 0,
+                    ..Default::default()
+                },
+            )
+            .with_prune_failures(0, 2, 1);
         let setup = TestSetup::new(config, store, 0).await;
 
         // Send enough checkpoints to trigger pruning

--- a/crates/sui-indexer-alt-framework/src/pipeline/concurrent/pruner.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/concurrent/pruner.rs
@@ -153,7 +153,7 @@ pub(super) fn pruner<H: Handler + Send + Sync + 'static>(
 
                     Ok(None) => {
                         guard.stop_and_record();
-                        warn!(pipeline = H::NAME, "No watermark for pipeline, skipping");
+                        info!(pipeline = H::NAME, "No watermark for pipeline, skipping");
                         continue;
                     }
 

--- a/crates/sui-indexer-alt-framework/src/pipeline/concurrent/reader_watermark.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/concurrent/reader_watermark.rs
@@ -53,7 +53,7 @@ pub(super) fn reader_watermark<H: Handler + 'static>(
                 Ok(Some(current)) => current,
 
                 Ok(None) => {
-                    warn!(pipeline = H::NAME, "No watermark for pipeline, skipping");
+                    info!(pipeline = H::NAME, "No watermark for pipeline, skipping");
                     continue;
                 }
 

--- a/crates/sui-indexer-alt-object-store/src/lib.rs
+++ b/crates/sui-indexer-alt-object-store/src/lib.rs
@@ -86,13 +86,6 @@ impl Store for ObjectStore {
 
 #[async_trait]
 impl Connection for ObjectStoreConnection {
-    async fn init_watermark(&mut self, pipeline_task: &str, _: u64) -> anyhow::Result<Option<u64>> {
-        Ok(self
-            .committer_watermark(pipeline_task)
-            .await?
-            .map(|w| w.checkpoint_hi_inclusive))
-    }
-
     async fn committer_watermark(
         &mut self,
         pipeline_task: &str,

--- a/crates/sui-kvstore/src/bigtable/store.rs
+++ b/crates/sui-kvstore/src/bigtable/store.rs
@@ -80,18 +80,6 @@ impl Store for BigTableStore {
 
 #[async_trait]
 impl Connection for BigTableConnection<'_> {
-    async fn init_watermark(
-        &mut self,
-        pipeline_task: &str,
-        _default_next_checkpoint: u64,
-    ) -> Result<Option<u64>> {
-        Ok(self
-            .client
-            .get_pipeline_watermark(pipeline_task)
-            .await?
-            .map(|wm| wm.checkpoint_hi_inclusive))
-    }
-
     async fn committer_watermark(
         &mut self,
         pipeline_task: &str,

--- a/crates/sui-pg-db/src/store.rs
+++ b/crates/sui-pg-db/src/store.rs
@@ -5,7 +5,6 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use chrono::DateTime;
-use chrono::Utc;
 use diesel::ExpressionMethods;
 use diesel::OptionalExtension;
 use diesel::prelude::*;
@@ -25,47 +24,6 @@ pub use sui_indexer_alt_framework_store_traits::Store;
 
 #[async_trait]
 impl store::Connection for Connection<'_> {
-    async fn init_watermark(
-        &mut self,
-        pipeline_task: &str,
-        default_next_checkpoint: u64,
-    ) -> anyhow::Result<Option<u64>> {
-        let Some(checkpoint_hi_inclusive) = default_next_checkpoint.checked_sub(1) else {
-            // Do not create a watermark record with checkpoint_hi_inclusive = -1.
-            return Ok(self
-                .committer_watermark(pipeline_task)
-                .await?
-                .map(|w| w.checkpoint_hi_inclusive));
-        };
-
-        let stored_watermark = StoredWatermark {
-            pipeline: pipeline_task.to_string(),
-            epoch_hi_inclusive: 0,
-            checkpoint_hi_inclusive: checkpoint_hi_inclusive as i64,
-            tx_hi: 0,
-            timestamp_ms_hi_inclusive: 0,
-            reader_lo: default_next_checkpoint as i64,
-            pruner_timestamp: Utc::now().naive_utc(),
-            pruner_hi: default_next_checkpoint as i64,
-        };
-
-        use diesel::pg::upsert::excluded;
-        let checkpoint_hi_inclusive: i64 = diesel::insert_into(watermarks::table)
-            .values(&stored_watermark)
-            // There is an existing entry, so only write the new `hi` values
-            .on_conflict(watermarks::pipeline)
-            // Use `do_update` instead of `do_nothing` to return the existing row with `returning`.
-            .do_update()
-            // When using `do_update`, at least one change needs to be set, so set the pipeline to itself (nothing changes).
-            // `excluded` is a virtual table containing the existing row that there was a conflict with.
-            .set(watermarks::pipeline.eq(excluded(watermarks::pipeline)))
-            .returning(watermarks::checkpoint_hi_inclusive)
-            .get_result(self)
-            .await?;
-
-        Ok(Some(checkpoint_hi_inclusive as u64))
-    }
-
     async fn committer_watermark(
         &mut self,
         pipeline_task: &str,
@@ -154,15 +112,25 @@ impl store::Connection for Connection<'_> {
         watermark: store::CommitterWatermark,
     ) -> anyhow::Result<bool> {
         // Create a StoredWatermark directly from CommitterWatermark
+        //
+        // Initialize pruner_hi to checkpoint_hi_inclusive so the pruner does not attempt to
+        // prune checkpoints before the first committed data. Required when the indexer
+        // is started with --first-checkpoint > 0, as checkpoints before that point were never
+        // indexed and have no cp_sequence_numbers mappings. This only affects the INSERT
+        // (not the ON CONFLICT UPDATE) behavior below.
+        //
+        // Initialize reader_lo to checkpoint_hi_inclusive for these reasons:
+        //   1. The reader does not attempt to read checkpoints before the first indexed checkpoint.
+        //   2. It maintains the pruner_hi <= reader_lo invariant.
         let stored_watermark = StoredWatermark {
             pipeline: pipeline_task.to_string(),
             epoch_hi_inclusive: watermark.epoch_hi_inclusive as i64,
             checkpoint_hi_inclusive: watermark.checkpoint_hi_inclusive as i64,
             tx_hi: watermark.tx_hi as i64,
             timestamp_ms_hi_inclusive: watermark.timestamp_ms_hi_inclusive as i64,
-            reader_lo: 0,
+            reader_lo: watermark.checkpoint_hi_inclusive as i64,
             pruner_timestamp: DateTime::UNIX_EPOCH.naive_utc(),
-            pruner_hi: 0,
+            pruner_hi: watermark.checkpoint_hi_inclusive as i64,
         };
 
         use diesel::query_dsl::methods::FilterDsl;


### PR DESCRIPTION
## Description 

1. Removes the `init_watermark` function added in #24523.

   This is a prereq to be able to index backwards because a checkpoint_hi_inclusive value cannot be written until that checkpoint has been indexed. 

   For example: Using `--first-checkpoint 10` would have previously resulted in a watermark record with `checkpoint_hi_inclusive = 9` even though checkpoint 9 was not actually indexed. If the indexer tried to index backwards from 10, it would have incorrectly skipped over checkpoint 9.

2. Delay the delay `pruner`, `reader_watermark` tasks until after a watermark exists to prevent WARN logs during initialization when those tasks attempt to read a watermark before it exists.

## Test plan 

1. Added assertion to unit tests.
2. Verified no warning/error logs in `sui-indexer-alt-benchmark`.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
