### PR TITLE
Add daily sccache cache-warming workflow for release builds

### DIFF
--- a/.github/workflows/sccache-warmup.yml
+++ b/.github/workflows/sccache-warmup.yml
@@ -8,6 +8,9 @@ on:
     - cron: '0 0 * * *' # every day at midnight UTC
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0


### PR DESCRIPTION
## Summary

- Adds a new daily workflow (`.github/workflows/sccache-warmup.yml`) that pre-warms the S3 sccache used by release builds
- Runs the same 3 cargo build commands as `release.yml` across all 5 platforms (ubuntu-ghcloud, ubuntu-arm64, windows-ghcloud, macos-latest-large, macos-latest-xlarge) at midnight UTC
- Checks out `main` branch to keep the cache aligned with upcoming release tags
- Includes failure notification via `sui-operations` dispatch (same pattern as `nightly.yml`)
- Supports manual trigger via `workflow_dispatch`

With ~12 merges/day and ~4 crate changes, daily warming keeps cache drift minimal. Release builds within a day of a warming run get near-full cache hits, significantly reducing build times especially for macOS and Windows.

## Test plan

- [ ] Verify `actionlint` passes (only pre-existing warnings from custom runner labels and scripts copied verbatim from `release.yml`)
- [ ] Trigger manually: `gh workflow run sccache-warmup.yml`
- [ ] Check S3 for all platforms: `aws s3 ls s3://sui-releases/sccache/ --summarize`
- [ ] Check "Post Setup sccache" step for cache hit/miss stats on each platform
- [ ] Trigger a second run to confirm warm cache speedup across all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)