### PR TITLE
Remove very slow test that is not doing much more us

### DIFF
--- a/crates/sui-e2e-tests/tests/reconfiguration_tests.rs
+++ b/crates/sui-e2e-tests/tests/reconfiguration_tests.rs
@@ -697,11 +697,6 @@ async fn test_reconfig_with_committee_change_stress() {
     do_test_reconfig_with_committee_change_stress().await;
 }
 
-#[sim_test(check_determinism)]
-async fn test_reconfig_with_committee_change_stress_determinism() {
-    do_test_reconfig_with_committee_change_stress().await;
-}
-
 async fn do_test_reconfig_with_committee_change_stress() {
     let mut candidates = (0..6)
         .map(|_| ValidatorGenesisConfigBuilder::new().build(&mut OsRng))


### PR DESCRIPTION
There are other tests the check determinism, and this is the longest simtest we run. It is starting to hit timeouts, and slows down CI even when it finishes in time.
