### PR TITLE
fix: update OpenRPC insta snapshot in version bump workflow

### DIFF
--- a/scripts/gen_branch_cut_prs.sh
+++ b/scripts/gen_branch_cut_prs.sh
@@ -108,6 +108,10 @@ elif [[ "$PR_TYPE" == *version-bump* ]]; then
   # Update the version in Cargo.toml and openrpc.json
   sed -i -E "s/^(version = \")[0-9]+\.[0-9]+\.[0-9]+(\"$)/\1${NEW_SUI_VERSION}\2/" Cargo.toml
   sed -i -E "s/(\"version\": \")([0-9]+\.[0-9]+\.[0-9]+)(\")/\1${NEW_SUI_VERSION}\3/" crates/sui-open-rpc/spec/openrpc.json
+  SNAP_FILE="crates/sui-open-rpc/tests/snapshots/generate_spec__openrpc.snap.json"
+  if [[ -f "$SNAP_FILE" ]]; then
+    sed -i -E "s/(\"version\": \")([0-9]+\.[0-9]+\.[0-9]+)(\")/\1${NEW_SUI_VERSION}\3/" "$SNAP_FILE"
+  fi
 
   # Cargo check to generate Cargo.lock changes
   cargo check || true


### PR DESCRIPTION
## Summary
- The `generate-branch-cut-prs.yml` workflow's version bump mode updates `crates/sui-open-rpc/spec/openrpc.json` with the new version, but does not update the insta test snapshot at `crates/sui-open-rpc/tests/snapshots/generate_spec__openrpc.snap.json`
- This causes `test_json_rpc_spec` to fail on every version bump PR, requiring manual intervention (admin merge or manual snapshot fix) every branch cut cycle
- Adds a matching `sed` to update the snapshot file alongside the spec — instant, deterministic, same pattern already used in the script

## Test plan
- [x] Verified the sed pattern matches exactly 1 line in the snapshot file (`"version": "1.67.0"` at line 15)
- [x] Confirmed no other lines match (integer version fields like `"version": 2` are not affected)
- [x] `shellcheck` passes clean on the modified script
- [ ] Next branch cut will validate end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)