### PR TITLE
Make sccache setup gracefully degrade on transient failures

### DIFF
--- a/.github/actions/setup-sccache/action.yml
+++ b/.github/actions/setup-sccache/action.yml
@@ -1,0 +1,41 @@
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Setup sccache
+description: Configure sccache with S3 backend for CI builds with graceful degradation
+
+inputs:
+  aws-access-key-id:
+    description: AWS access key ID for S3 cache backend
+    required: true
+  aws-secret-access-key:
+    description: AWS secret access key for S3 cache backend
+    required: true
+  key-prefix:
+    description: S3 key prefix for cache partitioning (e.g., ubuntu-ghcloud, windows-ghcloud)
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # pin@v5.1.1
+      with:
+        aws-access-key-id: ${{ inputs.aws-access-key-id }}
+        aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
+        aws-region: us-west-2
+
+    - name: Set sccache environment
+      shell: bash
+      run: |
+        echo "SCCACHE_BUCKET=mystenlabs-sccache" >> "$GITHUB_ENV"
+        echo "SCCACHE_REGION=us-west-2" >> "$GITHUB_ENV"
+        echo "SCCACHE_S3_KEY_PREFIX=${{ inputs.key-prefix }}" >> "$GITHUB_ENV"
+
+    - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # pin@v0.0.9
+      id: sccache
+      continue-on-error: true
+
+    - name: Enable sccache
+      if: steps.sccache.outcome == 'success'
+      shell: bash
+      run: echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -31,19 +31,13 @@ jobs:
   release:
     name: Build Release Binaries
     runs-on: [ubuntu-ghcloud]
-    env:
-      SCCACHE_BUCKET: mystenlabs-sccache
-      SCCACHE_REGION: us-west-2
-      SCCACHE_S3_KEY_PREFIX: ubuntu-ghcloud
-      RUSTC_WRAPPER: sccache
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
-      - uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # pin@v5.1.1
+      - uses: ./.github/actions/setup-sccache
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-west-2
-      - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # pin@v0.0.9
+          key-prefix: ubuntu-ghcloud
       - name: cargo build
         run: cargo build --all-targets --all-features --release
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,6 @@ jobs:
       SCCACHE_BUCKET: mystenlabs-sccache
       SCCACHE_REGION: us-west-2
       SCCACHE_S3_KEY_PREFIX: ${{ matrix.os }}
-      RUSTC_WRAPPER: sccache
     strategy:
       matrix:
         os:
@@ -165,7 +164,14 @@ jobs:
 
       - name: Setup sccache
         if: ${{ env.s3_existing_archive == '' }}
+        id: sccache
+        continue-on-error: true
         uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # pin@v0.0.9
+
+      - name: Enable sccache
+        if: steps.sccache.outcome == 'success'
+        shell: bash
+        run: echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
 
       - name: Cargo build for ${{ matrix.os }} platform
         if: ${{ env.s3_existing_archive == '' }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -84,10 +84,6 @@ jobs:
       # causes #[sim_test] to only run under the deterministic `simtest` job, and not the
       # non-deterministic `test` job.
       SUI_SKIP_SIMTESTS: 1
-      SCCACHE_BUCKET: mystenlabs-sccache
-      SCCACHE_REGION: us-west-2
-      SCCACHE_S3_KEY_PREFIX: ubuntu-ghcloud
-      RUSTC_WRAPPER: sccache
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -98,12 +94,11 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
         with:
           ref: ${{ github.event.inputs.sui_repo_ref || github.ref }}
-      - uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # pin@v5.1.1
+      - uses: ./.github/actions/setup-sccache
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-west-2
-      - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # pin@v0.0.9
+          key-prefix: ubuntu-ghcloud
       - uses: taiki-e/install-action@nextest
       - uses: taiki-e/install-action@protoc
       - name: Add postgres to PATH
@@ -134,10 +129,6 @@ jobs:
       # causes #[sim_test] to only run under the deterministic `simtest` job, and not the
       # non-deterministic `test` job.
       SUI_SKIP_SIMTESTS: 1
-      SCCACHE_BUCKET: mystenlabs-sccache
-      SCCACHE_REGION: us-west-2
-      SCCACHE_S3_KEY_PREFIX: ubuntu-ghcloud
-      RUSTC_WRAPPER: sccache
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -148,12 +139,11 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
         with:
           ref: ${{ github.event.inputs.sui_repo_ref || github.ref }}
-      - uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # pin@v5.1.1
+      - uses: ./.github/actions/setup-sccache
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-west-2
-      - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # pin@v0.0.9
+          key-prefix: ubuntu-ghcloud
       - uses: taiki-e/install-action@nextest
       - uses: taiki-e/install-action@protoc
       - name: Add postgres to PATH
@@ -178,10 +168,6 @@ jobs:
       # causes #[sim_test] to only run under the deterministic `simtest` job, and not the
       # non-deterministic `test` job.
       SUI_SKIP_SIMTESTS: 1
-      SCCACHE_BUCKET: mystenlabs-sccache
-      SCCACHE_REGION: us-west-2
-      SCCACHE_S3_KEY_PREFIX: ubuntu-ghcloud
-      RUSTC_WRAPPER: sccache
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -192,12 +178,11 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
         with:
           ref: ${{ github.event.inputs.sui_repo_ref || github.ref }}
-      - uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # pin@v5.1.1
+      - uses: ./.github/actions/setup-sccache
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-west-2
-      - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # pin@v0.0.9
+          key-prefix: ubuntu-ghcloud
       - uses: taiki-e/install-action@nextest
       - uses: taiki-e/install-action@protoc
       - name: Add postgres to PATH
@@ -253,21 +238,15 @@ jobs:
     if: needs.diff.outputs.isRust == 'true'
     timeout-minutes: 45
     runs-on: [ windows-ghcloud-128 ]
-    env:
-      SCCACHE_BUCKET: mystenlabs-sccache
-      SCCACHE_REGION: us-west-2
-      SCCACHE_S3_KEY_PREFIX: windows-ghcloud
-      RUSTC_WRAPPER: sccache
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
         with:
           ref: ${{ github.event.inputs.sui_repo_ref || github.ref }}
-      - uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # pin@v5.1.1
+      - uses: ./.github/actions/setup-sccache
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-west-2
-      - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # pin@v0.0.9
+          key-prefix: windows-ghcloud
 
       - uses: taiki-e/install-action@nextest
 
@@ -286,20 +265,15 @@ jobs:
       # causes #[sim_test] to only run under the deterministic `simtest` job, and not the
       # non-deterministic `test` job.
       SUI_SKIP_SIMTESTS: 1
-      SCCACHE_BUCKET: mystenlabs-sccache
-      SCCACHE_REGION: us-west-2
-      SCCACHE_S3_KEY_PREFIX: windows-ghcloud
-      RUSTC_WRAPPER: sccache
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
         with:
           ref: ${{ github.event.inputs.sui_repo_ref || github.ref }}
-      - uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # pin@v5.1.1
+      - uses: ./.github/actions/setup-sccache
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-west-2
-      - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # pin@v0.0.9
+          key-prefix: windows-ghcloud
 
       - uses: taiki-e/install-action@nextest
 
@@ -316,20 +290,15 @@ jobs:
     runs-on: [ ubuntu-ghcloud ]
     env:
       MSIM_WATCHDOG_TIMEOUT_MS: 300000
-      SCCACHE_BUCKET: mystenlabs-sccache
-      SCCACHE_REGION: us-west-2
-      SCCACHE_S3_KEY_PREFIX: ubuntu-ghcloud
-      RUSTC_WRAPPER: sccache
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
         with:
           ref: ${{ github.event.inputs.sui_repo_ref || github.ref }}
-      - uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # pin@v5.1.1
+      - uses: ./.github/actions/setup-sccache
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-west-2
-      - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # pin@v0.0.9
+          key-prefix: ubuntu-ghcloud
       - uses: taiki-e/install-action@nextest
       - uses: taiki-e/install-action@protoc
       - name: Add postgres to PATH
@@ -353,20 +322,15 @@ jobs:
     env:
       MSIM_WATCHDOG_TIMEOUT_MS: 300000
       SUI_PROTOCOL_CONFIG_CHAIN_OVERRIDE: mainnet
-      SCCACHE_BUCKET: mystenlabs-sccache
-      SCCACHE_REGION: us-west-2
-      SCCACHE_S3_KEY_PREFIX: ubuntu-ghcloud
-      RUSTC_WRAPPER: sccache
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
         with:
           ref: ${{ github.event.inputs.sui_repo_ref || github.ref }}
-      - uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # pin@v5.1.1
+      - uses: ./.github/actions/setup-sccache
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-west-2
-      - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # pin@v0.0.9
+          key-prefix: ubuntu-ghcloud
       - uses: taiki-e/install-action@nextest
       - uses: taiki-e/install-action@protoc
       - name: Add postgres to PATH
@@ -390,21 +354,15 @@ jobs:
     if: needs.diff.outputs.isRust == 'false' && needs.diff.outputs.isMove == 'true'
     timeout-minutes: 10
     runs-on: [ ubuntu-ghcloud ]
-    env:
-      SCCACHE_BUCKET: mystenlabs-sccache
-      SCCACHE_REGION: us-west-2
-      SCCACHE_S3_KEY_PREFIX: ubuntu-ghcloud
-      RUSTC_WRAPPER: sccache
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
         with:
           ref: ${{ github.event.inputs.sui_repo_ref || github.ref }}
-      - uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # pin@v5.1.1
+      - uses: ./.github/actions/setup-sccache
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-west-2
-      - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # pin@v0.0.9
+          key-prefix: ubuntu-ghcloud
       - uses: taiki-e/install-action@nextest
       - name: Run move tests
         run: |
@@ -492,21 +450,15 @@ jobs:
     needs: diff
     if: needs.diff.outputs.isRust == 'true'
     runs-on: [ ubuntu-ghcloud ]
-    env:
-      SCCACHE_BUCKET: mystenlabs-sccache
-      SCCACHE_REGION: us-west-2
-      SCCACHE_S3_KEY_PREFIX: ubuntu-ghcloud
-      RUSTC_WRAPPER: sccache
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
         with:
           ref: ${{ github.event.inputs.sui_repo_ref || github.ref }}
-      - uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # pin@v5.1.1
+      - uses: ./.github/actions/setup-sccache
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-west-2
-      - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # pin@v0.0.9
+          key-prefix: ubuntu-ghcloud
       - run: rustup component add clippy
       # TODO(bradh): debug and re-enable this; the caching is breaking the clippy build
       # Enable caching of the 'librocksdb-sys' crate by additionally caching the
@@ -559,21 +511,15 @@ jobs:
     needs: [diff, rustfmt, clippy]
     if: needs.diff.outputs.isRust == 'true'
     runs-on: [ ubuntu-ghcloud ]
-    env:
-      SCCACHE_BUCKET: mystenlabs-sccache
-      SCCACHE_REGION: us-west-2
-      SCCACHE_S3_KEY_PREFIX: ubuntu-ghcloud
-      RUSTC_WRAPPER: sccache
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
         with:
           ref: ${{ github.event.inputs.sui_repo_ref || github.ref }}
-      - uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # pin@v5.1.1
+      - uses: ./.github/actions/setup-sccache
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-west-2
-      - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # pin@v0.0.9
+          key-prefix: ubuntu-ghcloud
       - name: Install cargo-hakari, and cache the binary
         uses: baptiste0928/cargo-install@1cd874a5478fdca35d868ccc74640c5aabbb8f1b # pin@v3.0.0
         with:


### PR DESCRIPTION
## Summary
- Creates a reusable composite action (`.github/actions/setup-sccache`) that encapsulates AWS credentials + sccache installation + `RUSTC_WRAPPER` configuration
- Uses `continue-on-error: true` on the sccache-action step so builds proceed without caching if the sccache binary download fails (e.g., HTTP 502 from GitHub releases CDN)
- Only sets `RUSTC_WRAPPER=sccache` via `$GITHUB_ENV` when sccache is actually installed, preventing cargo from failing when the binary is missing
- Replaces duplicated sccache boilerplate across 10 jobs in `rust.yml`, 1 in `nightly.yml`, and 1 in `release.yml`
- `release.yml` uses inline fix instead of composite action since it checks out old release tags that may not contain the action
- `sccache-warmup.yml` is intentionally unchanged — its purpose is to warm the cache, so sccache failures there should be real failures

Fixes the `windows-cli-tests` failure from https://github.com/MystenLabs/sui/actions/runs/22476462296/job/65104380857 where sccache download returned HTTP 502.

## Test plan
- [ ] Verify `rust.yml` jobs pass with sccache available (normal path)
- [ ] Verify `release.yml` still works for release builds
- [ ] Verify `nightly.yml` still works for nightly builds
- [ ] Graceful degradation tested by design: `continue-on-error: true` + conditional `RUSTC_WRAPPER`

🤖 Generated with [Claude Code](https://claude.com/claude-code)