### PR TITLE
jsonrpc: compute gas from accumulator events for failed ab transactions

### DIFF
--- a/crates/sui-json-rpc/src/balance_changes.rs
+++ b/crates/sui-json-rpc/src/balance_changes.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::{BTreeMap, HashMap, HashSet};
-use std::ops::Neg;
 
 use async_trait::async_trait;
 use sui_types::balance_change::derive_balance_changes;
@@ -12,9 +11,7 @@ use sui_json_rpc_types::BalanceChange;
 use sui_types::base_types::{ObjectID, ObjectRef, SequenceNumber};
 use sui_types::digests::ObjectDigest;
 use sui_types::effects::{TransactionEffects, TransactionEffectsAPI};
-use sui_types::execution_status::ExecutionStatus;
-use sui_types::gas_coin::GAS;
-use sui_types::object::Object;
+use sui_types::object::{Object, Owner};
 use sui_types::storage::WriteKind;
 use sui_types::transaction::InputObjectKind;
 use tracing::instrument;
@@ -26,17 +23,6 @@ pub async fn get_balance_changes_from_effect<P: ObjectProvider<Error = E>, E>(
     input_objs: Vec<InputObjectKind>,
     mocked_coin: Option<ObjectID>,
 ) -> Result<Vec<BalanceChange>, E> {
-    let (_, gas_owner) = effects.gas_object();
-
-    // Only charge gas when tx fails, skip all object parsing
-    if effects.status() != &ExecutionStatus::Success {
-        return Ok(vec![BalanceChange {
-            owner: gas_owner,
-            coin_type: GAS::type_tag(),
-            amount: effects.gas_cost_summary().net_gas_usage().neg() as i128,
-        }]);
-    }
-
     let all_mutated = effects
         .all_changed_objects()
         .into_iter()
@@ -81,7 +67,7 @@ pub async fn get_balance_changes_from_effect<P: ObjectProvider<Error = E>, E>(
         derive_balance_changes(effects, &input_coins, &mutated_coins)
             .into_iter()
             .map(|change| BalanceChange {
-                owner: sui_types::object::Owner::AddressOwner(change.address),
+                owner: Owner::AddressOwner(change.address),
                 coin_type: change.coin_type,
                 amount: change.amount,
             })
@@ -249,5 +235,351 @@ where
         } else {
             Ok(None)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+    use sui_types::accumulator_root::AccumulatorValue as AccumulatorValueRoot;
+    use sui_types::balance::Balance;
+    use sui_types::base_types::{ObjectID, SequenceNumber, SuiAddress};
+    use sui_types::digests::TransactionDigest;
+    use sui_types::effects::{
+        AccumulatorAddress, AccumulatorOperation, AccumulatorValue, AccumulatorWriteV1,
+        EffectsObjectChange,
+    };
+    use sui_types::execution_status::{ExecutionFailureStatus, ExecutionStatus};
+    use sui_types::gas::GasCostSummary;
+    use sui_types::gas_coin::GAS;
+    use sui_types::object::MoveObject;
+
+    struct MockObjectProvider {
+        objects: HashMap<(ObjectID, SequenceNumber), Object>,
+    }
+
+    impl MockObjectProvider {
+        fn new() -> Self {
+            Self {
+                objects: HashMap::new(),
+            }
+        }
+
+        fn insert(&mut self, obj: Object) {
+            self.objects.insert((obj.id(), obj.version()), obj);
+        }
+    }
+
+    #[async_trait]
+    impl ObjectProvider for MockObjectProvider {
+        type Error = anyhow::Error;
+        async fn get_object(
+            &self,
+            id: &ObjectID,
+            version: &SequenceNumber,
+        ) -> Result<Object, Self::Error> {
+            self.objects
+                .get(&(*id, *version))
+                .cloned()
+                .ok_or_else(|| anyhow::anyhow!("Object not found: {} v{}", id, version))
+        }
+        async fn find_object_lt_or_eq_version(
+            &self,
+            id: &ObjectID,
+            version: &SequenceNumber,
+        ) -> Result<Option<Object>, Self::Error> {
+            let result = self
+                .objects
+                .iter()
+                .filter(|((oid, v), _)| oid == id && v <= version)
+                .max_by_key(|((_, v), _)| *v)
+                .map(|(_, obj)| obj.clone());
+            Ok(result)
+        }
+    }
+
+    fn create_failed_effects_with_gas_coin(
+        gas_owner: SuiAddress,
+        gas_deduction: u64,
+    ) -> (TransactionEffects, MockObjectProvider) {
+        let gas_id = ObjectID::random();
+        let old_version = SequenceNumber::from_u64(1);
+        let lamport_version = SequenceNumber::from_u64(2);
+        let initial_value = 1_000_000 + gas_deduction;
+        let final_value = 1_000_000u64;
+
+        let input_obj = Object::new_move(
+            MoveObject::new_gas_coin(old_version, gas_id, initial_value),
+            Owner::AddressOwner(gas_owner),
+            TransactionDigest::random(),
+        );
+        let output_obj = Object::new_move(
+            MoveObject::new_gas_coin(lamport_version, gas_id, final_value),
+            Owner::AddressOwner(gas_owner),
+            TransactionDigest::random(),
+        );
+
+        let mut changed_objects = BTreeMap::new();
+        changed_objects.insert(
+            gas_id,
+            EffectsObjectChange::new(
+                Some((
+                    (old_version, input_obj.digest()),
+                    Owner::AddressOwner(gas_owner),
+                )),
+                Some(&output_obj),
+                false,
+                false,
+            ),
+        );
+
+        let effects = TransactionEffects::new_from_execution_v2(
+            ExecutionStatus::new_failure(ExecutionFailureStatus::InsufficientGas, None),
+            0,
+            GasCostSummary::new(gas_deduction, 0, 0, 0),
+            vec![],
+            std::collections::BTreeSet::new(),
+            TransactionDigest::random(),
+            lamport_version,
+            changed_objects,
+            Some(gas_id),
+            None,
+            vec![],
+        );
+
+        let mut provider = MockObjectProvider::new();
+        provider.insert(input_obj);
+        provider.insert(output_obj);
+
+        (effects, provider)
+    }
+
+    fn sui_balance_type() -> move_core_types::language_storage::TypeTag {
+        Balance::type_tag("0x2::sui::SUI".parse().unwrap())
+    }
+
+    fn create_accumulator_write(
+        address: SuiAddress,
+        amount: u64,
+    ) -> (ObjectID, EffectsObjectChange) {
+        let balance_type = sui_balance_type();
+        let obj_id = *AccumulatorValueRoot::get_field_id(address, &balance_type)
+            .unwrap()
+            .inner();
+        let write = AccumulatorWriteV1 {
+            address: AccumulatorAddress::new(address, balance_type),
+            operation: AccumulatorOperation::Split,
+            value: AccumulatorValue::Integer(amount),
+        };
+        (
+            obj_id,
+            EffectsObjectChange::new_from_accumulator_write(write),
+        )
+    }
+
+    fn create_failed_effects_with_accumulator(
+        address: SuiAddress,
+        amount: u64,
+    ) -> TransactionEffects {
+        let (obj_id, change) = create_accumulator_write(address, amount);
+        let mut changed_objects = BTreeMap::new();
+        changed_objects.insert(obj_id, change);
+
+        TransactionEffects::new_from_execution_v2(
+            ExecutionStatus::new_failure(ExecutionFailureStatus::InsufficientGas, None),
+            0,
+            GasCostSummary::new(amount, 0, 0, 0),
+            vec![],
+            std::collections::BTreeSet::new(),
+            TransactionDigest::random(),
+            SequenceNumber::new(),
+            changed_objects,
+            None,
+            None,
+            vec![],
+        )
+    }
+
+    fn create_failed_effects_with_gas_coin_and_accumulator(
+        gas_owner: SuiAddress,
+        gas_deduction: u64,
+        acc_address: SuiAddress,
+        acc_amount: u64,
+    ) -> (TransactionEffects, MockObjectProvider) {
+        let gas_id = ObjectID::random();
+        let old_version = SequenceNumber::from_u64(1);
+        let lamport_version = SequenceNumber::from_u64(2);
+        let initial_value = 1_000_000 + gas_deduction;
+        let final_value = 1_000_000u64;
+
+        let input_obj = Object::new_move(
+            MoveObject::new_gas_coin(old_version, gas_id, initial_value),
+            Owner::AddressOwner(gas_owner),
+            TransactionDigest::random(),
+        );
+        let output_obj = Object::new_move(
+            MoveObject::new_gas_coin(lamport_version, gas_id, final_value),
+            Owner::AddressOwner(gas_owner),
+            TransactionDigest::random(),
+        );
+
+        let mut changed_objects = BTreeMap::new();
+        changed_objects.insert(
+            gas_id,
+            EffectsObjectChange::new(
+                Some((
+                    (old_version, input_obj.digest()),
+                    Owner::AddressOwner(gas_owner),
+                )),
+                Some(&output_obj),
+                false,
+                false,
+            ),
+        );
+
+        let (acc_obj_id, acc_change) = create_accumulator_write(acc_address, acc_amount);
+        changed_objects.insert(acc_obj_id, acc_change);
+
+        let effects = TransactionEffects::new_from_execution_v2(
+            ExecutionStatus::new_failure(ExecutionFailureStatus::InsufficientGas, None),
+            0,
+            GasCostSummary::new(gas_deduction, 0, 0, 0),
+            vec![],
+            std::collections::BTreeSet::new(),
+            TransactionDigest::random(),
+            lamport_version,
+            changed_objects,
+            Some(gas_id),
+            None,
+            vec![],
+        );
+
+        let mut provider = MockObjectProvider::new();
+        provider.insert(input_obj);
+        provider.insert(output_obj);
+
+        (effects, provider)
+    }
+
+    #[tokio::test]
+    async fn test_failed_txn_coin_gas_balance_change() {
+        let gas_owner = SuiAddress::random_for_testing_only();
+        let (effects, provider) = create_failed_effects_with_gas_coin(gas_owner, 1000);
+
+        let result = get_balance_changes_from_effect(&provider, &effects, vec![], None)
+            .await
+            .unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].owner, Owner::AddressOwner(gas_owner));
+        assert_eq!(result[0].coin_type, GAS::type_tag());
+        assert_eq!(result[0].amount, -1000);
+    }
+
+    #[tokio::test]
+    async fn test_failed_txn_address_balance_gas_balance_change() {
+        let address = SuiAddress::random_for_testing_only();
+        let effects = create_failed_effects_with_accumulator(address, 500);
+        let provider = MockObjectProvider::new();
+
+        let result = get_balance_changes_from_effect(&provider, &effects, vec![], None)
+            .await
+            .unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].owner, Owner::AddressOwner(address));
+        assert_eq!(result[0].amount, -500);
+    }
+
+    #[tokio::test]
+    async fn test_failed_txn_zero_coin_gas_returns_empty() {
+        let gas_owner = SuiAddress::random_for_testing_only();
+        let (effects, provider) = create_failed_effects_with_gas_coin(gas_owner, 0);
+
+        let result = get_balance_changes_from_effect(&provider, &effects, vec![], None)
+            .await
+            .unwrap();
+
+        assert!(result.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_failed_txn_zero_gas_no_objects_returns_empty() {
+        let effects = TransactionEffects::new_from_execution_v2(
+            ExecutionStatus::new_failure(ExecutionFailureStatus::InsufficientGas, None),
+            0,
+            GasCostSummary::new(0, 0, 0, 0),
+            vec![],
+            std::collections::BTreeSet::new(),
+            TransactionDigest::random(),
+            SequenceNumber::new(),
+            BTreeMap::new(),
+            None,
+            None,
+            vec![],
+        );
+        let provider = MockObjectProvider::new();
+
+        let result = get_balance_changes_from_effect(&provider, &effects, vec![], None)
+            .await
+            .unwrap();
+
+        assert!(result.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_failed_txn_sponsored_address_balance_gas() {
+        let sponsor = SuiAddress::random_for_testing_only();
+        let effects = create_failed_effects_with_accumulator(sponsor, 750);
+        let provider = MockObjectProvider::new();
+
+        let result = get_balance_changes_from_effect(&provider, &effects, vec![], None)
+            .await
+            .unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].owner, Owner::AddressOwner(sponsor));
+        assert_eq!(result[0].amount, -750);
+    }
+
+    #[tokio::test]
+    async fn test_failed_txn_coin_gas_and_accumulator_different_addresses() {
+        let gas_owner = SuiAddress::random_for_testing_only();
+        let acc_address = SuiAddress::random_for_testing_only();
+        let (effects, provider) =
+            create_failed_effects_with_gas_coin_and_accumulator(gas_owner, 1000, acc_address, 200);
+
+        let result = get_balance_changes_from_effect(&provider, &effects, vec![], None)
+            .await
+            .unwrap();
+
+        assert_eq!(result.len(), 2);
+        let gas_change = result
+            .iter()
+            .find(|c| c.owner == Owner::AddressOwner(gas_owner))
+            .unwrap();
+        let acc_change = result
+            .iter()
+            .find(|c| c.owner == Owner::AddressOwner(acc_address))
+            .unwrap();
+        assert_eq!(gas_change.amount, -1000);
+        assert_eq!(acc_change.amount, -200);
+    }
+
+    #[tokio::test]
+    async fn test_failed_txn_coin_gas_and_accumulator_same_address() {
+        let address = SuiAddress::random_for_testing_only();
+        let (effects, provider) =
+            create_failed_effects_with_gas_coin_and_accumulator(address, 1000, address, 200);
+
+        let result = get_balance_changes_from_effect(&provider, &effects, vec![], None)
+            .await
+            .unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].owner, Owner::AddressOwner(address));
+        assert_eq!(result[0].coin_type, GAS::type_tag());
+        assert_eq!(result[0].amount, -1200);
     }
 }


### PR DESCRIPTION
## Description 

If we have a failed ab tx, gas costs are now attributed to the correct gas_owner 

## Test plan 

unit tested

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
