### PR TITLE
[core] tests/logs - clean up reachability assertions from v1 path, clarify log messages

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1152,7 +1152,6 @@ impl AuthorityState {
             .get_transaction_cache_reader()
             .transaction_executed_in_last_epoch(transaction.digest(), epoch_store.epoch())
         {
-            assert_reachable!("transaction executed in last epoch");
             return Err(SuiErrorKind::TransactionAlreadyExecuted {
                 digest: (*transaction.digest()),
             }

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1574,9 +1574,6 @@ impl AuthorityState {
             }
         }
 
-        // TODO: We should also settle address funds during execution,
-        // instead of from checkpoint builder. It will improve performance
-        // since we will be settling as soon as we can.
         if certificate
             .transaction_data()
             .kind()

--- a/crates/sui-core/src/authority/consensus_quarantine.rs
+++ b/crates/sui-core/src/authority/consensus_quarantine.rs
@@ -718,7 +718,6 @@ impl ConsensusOutputQuarantine {
             if let Some(idx) = last_drain_idx {
                 for _ in 0..=idx {
                     let output = self.output_queue.pop_front().unwrap();
-                    info!("committing drain-boundary output");
                     self.remove_shared_object_next_versions(&output);
                     self.remove_processed_consensus_messages(&output);
                     self.remove_congestion_control_debts(&output);

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -2008,12 +2008,12 @@ impl CheckpointBuilder {
         debug!(
             ?settlement_digests,
             ?settlement_key,
-            "fallback: reading settlement effects from cache"
+            "reading settlement effects from cache"
         );
 
         let settlement_effects = wait_for_effects_with_retry(
             self.effects_store.as_ref(),
-            "CheckpointBuilder::fallback_settlement_effects",
+            "CheckpointBuilder::settlement_effects",
             &settlement_digests,
             settlement_key,
         )
@@ -2031,7 +2031,7 @@ impl CheckpointBuilder {
 
         let barrier_effects = wait_for_effects_with_retry(
             self.effects_store.as_ref(),
-            "CheckpointBuilder::fallback_barrier_effects",
+            "CheckpointBuilder::barrier_effects",
             &[barrier_digest],
             settlement_key,
         )


### PR DESCRIPTION
## Description 

the asserts in settlement_scheduler.rs are unreachable in antithesis with `split_checkpoints_in_consensus_handler` and cannot be usefully replicated on that path.
`transaction executed in last epoch` is explicitly validated by simtest and impractical to hit with antithesis

## Test plan 

tests/logs only

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
