### PR TITLE
[graphql-alt] Add MultisigSignature to SignatureScheme union [2/n]

### DIFF
--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -1141,6 +1141,16 @@ The value of a dynamic field (`MoveValue`) or dynamic object field (`MoveObject`
 union DynamicFieldValue = MoveObject | MoveValue
 
 """
+An Ed25519 public key.
+"""
+type Ed25519PublicKey {
+	"""
+	The raw public key bytes.
+	"""
+	bytes: Base64
+}
+
+"""
 An Ed25519 signature.
 """
 type Ed25519Signature {
@@ -2731,6 +2741,82 @@ enum MoveVisibility {
 }
 
 """
+The multisig committee definition.
+"""
+type MultisigCommittee {
+	"""
+	The committee members (public key + weight).
+	"""
+	members: [MultisigMember!]
+	"""
+	The threshold number of weight needed for a valid multisig.
+	"""
+	threshold: Int
+}
+
+"""
+A single member of a multisig committee.
+"""
+type MultisigMember {
+	"""
+	The member's public key.
+	"""
+	publicKey: MultisigMemberPublicKey
+	"""
+	The member's weight in the committee.
+	"""
+	weight: Int
+}
+
+"""
+A multisig member's public key, varying by scheme.
+"""
+union MultisigMemberPublicKey = Ed25519PublicKey | Secp256K1PublicKey | Secp256R1PublicKey | PasskeyPublicKey | ZkLoginPublicIdentifier
+
+"""
+A single member's signature within a multisig.
+"""
+type MultisigMemberSignature {
+	"""
+	The signature scheme used by this member.
+	"""
+	scheme: MultisigMemberSignatureScheme
+	"""
+	The raw signature bytes (without public key).
+	"""
+	signature: Base64
+}
+
+"""
+The signature scheme of a multisig member's signature.
+"""
+enum MultisigMemberSignatureScheme {
+	ED25519
+	SECP256K1
+	SECP256R1
+	ZKLOGIN
+	PASSKEY
+}
+
+"""
+An aggregated multisig signature.
+"""
+type MultisigSignature {
+	"""
+	A bitmap indicating which members of the committee signed.
+	"""
+	bitmap: Int
+	"""
+	The multisig committee (public keys + weights + threshold).
+	"""
+	committee: MultisigCommittee
+	"""
+	The individual member signatures, one per signer who participated.
+	"""
+	signatures: [MultisigMemberSignature!]
+}
+
+"""
 A transaction that wanted to mutate a consensus-managed object but couldn't because it became not-consensus-managed before the transaction executed (for example, it was deleted, turned into an owned object, or wrapped).
 """
 type MutateConsensusStreamEnded {
@@ -3223,6 +3309,16 @@ type PageInfo {
 	startCursor: String
 }
 
+"""
+A Passkey public key.
+"""
+type PasskeyPublicKey {
+	"""
+	The raw public key bytes.
+	"""
+	bytes: Base64
+}
+
 type PerEpochConfig {
 	"""
 	The per-epoch configuration object as of when the transaction was executed.
@@ -3617,6 +3713,16 @@ enum RegulatedState {
 }
 
 """
+A Secp256k1 public key.
+"""
+type Secp256K1PublicKey {
+	"""
+	The raw public key bytes.
+	"""
+	bytes: Base64
+}
+
+"""
 A Secp256k1 signature.
 """
 type Secp256K1Signature {
@@ -3628,6 +3734,16 @@ type Secp256K1Signature {
 	The raw signature bytes.
 	"""
 	signature: Base64
+}
+
+"""
+A Secp256r1 public key.
+"""
+type Secp256R1PublicKey {
+	"""
+	The raw public key bytes.
+	"""
+	bytes: Base64
 }
 
 """
@@ -3810,7 +3926,7 @@ type SharedInput {
 """
 The structured details of a signature, varying by scheme.
 """
-union SignatureScheme = Ed25519Signature | Secp256K1Signature | Secp256R1Signature
+union SignatureScheme = Ed25519Signature | Secp256K1Signature | Secp256R1Signature | MultisigSignature
 
 """
 The result of simulating a transaction, including the predicted effects.
@@ -4376,6 +4492,20 @@ enum ZkLoginIntentScope {
 	Indicates that the bytes are to be parsed as a personal message.
 	"""
 	PERSONAL_MESSAGE
+}
+
+"""
+A zkLogin public identifier, containing the OAuth issuer and address seed.
+"""
+type ZkLoginPublicIdentifier {
+	"""
+	The address seed as a decimal string.
+	"""
+	addressSeed: String
+	"""
+	The OAuth provider issuer string (e.g. "https://accounts.google.com").
+	"""
+	iss: String
 }
 
 """

--- a/crates/sui-indexer-alt-graphql/src/api/types/snapshots/sui_indexer_alt_graphql__api__types__available_range__field_piplines_tests__registry_collect_pipelines_snapshot.snap
+++ b/crates/sui-indexer-alt-graphql/src/api/types/snapshots/sui_indexer_alt_graphql__api__types__available_range__field_piplines_tests__registry_collect_pipelines_snapshot.snap
@@ -473,6 +473,9 @@ DynamicField.receivedTransactions
 DynamicField.value
   => {}
 
+Ed25519PublicKey.bytes
+  => {}
+
 Ed25519Signature.signature
   => {}
 
@@ -1121,6 +1124,33 @@ MoveValue.json
 MoveValue.type
   => {}
 
+MultisigCommittee.members
+  => {}
+
+MultisigCommittee.threshold
+  => {}
+
+MultisigMember.publicKey
+  => {}
+
+MultisigMember.weight
+  => {}
+
+MultisigMemberSignature.scheme
+  => {}
+
+MultisigMemberSignature.signature
+  => {}
+
+MultisigSignature.signatures
+  => {}
+
+MultisigSignature.bitmap
+  => {}
+
+MultisigSignature.committee
+  => {}
+
 MutateConsensusStreamEnded.address
   => {}
 
@@ -1260,6 +1290,9 @@ PageInfo.startCursor
   => {}
 
 PageInfo.endCursor
+  => {}
+
+PasskeyPublicKey.bytes
   => {}
 
 PerEpochConfig.object
@@ -1457,10 +1490,16 @@ ReadConsensusStreamEnded.sequenceNumber
 Receiving.object
   => {}
 
+Secp256K1PublicKey.bytes
+  => {}
+
 Secp256K1Signature.signature
   => {}
 
 Secp256K1Signature.publicKey
+  => {}
+
+Secp256R1PublicKey.bytes
   => {}
 
 Secp256R1Signature.signature
@@ -1713,6 +1752,12 @@ WithdrawMaxAmountU64.amount
   => {}
 
 WriteAccumulatorStorageCostTransaction._
+  => {}
+
+ZkLoginPublicIdentifier.iss
+  => {}
+
+ZkLoginPublicIdentifier.addressSeed
   => {}
 
 ZkLoginVerifyResult.success

--- a/crates/sui-indexer-alt-graphql/src/api/types/user_signature/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/user_signature/mod.rs
@@ -1,11 +1,15 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+pub(crate) mod multisig;
+
 use async_graphql::{Object, SimpleObject, Union};
 use sui_types::crypto::{SignatureScheme as NativeSignatureScheme, SuiSignature};
+use sui_types::multisig::MultiSig;
 use sui_types::signature::GenericSignature;
 
 use crate::api::scalars::base64::Base64;
+use crate::api::types::user_signature::multisig::MultisigSignature;
 
 /// The structured details of a signature, varying by scheme.
 #[derive(Union, Clone)]
@@ -13,6 +17,7 @@ pub(crate) enum SignatureScheme {
     Ed25519(Ed25519Signature),
     Secp256k1(Secp256k1Signature),
     Secp256r1(Secp256r1Signature),
+    Multisig(MultisigSignature),
 }
 
 /// A user signature for a transaction.
@@ -34,7 +39,11 @@ impl UserSignature {
     async fn scheme(&self) -> Option<SignatureScheme> {
         match &self.native {
             GenericSignature::Signature(s) => simple_signature_to_scheme(s),
-            // TODO: Add support for Multisig, ZkLogin, and Passkey signature schemes.
+            GenericSignature::MultiSig(m) => Some(SignatureScheme::Multisig(m.into())),
+            GenericSignature::MultiSigLegacy(m) => MultiSig::try_from(m.clone())
+                .ok()
+                .map(|ms| SignatureScheme::Multisig((&ms).into())),
+            // TODO: Add support for ZkLogin and Passkey signature schemes.
             _ => None,
         }
     }

--- a/crates/sui-indexer-alt-graphql/src/api/types/user_signature/multisig.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/user_signature/multisig.rs
@@ -1,0 +1,190 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use async_graphql::{Enum, SimpleObject, Union};
+use sui_types::crypto::{CompressedSignature, PublicKey};
+use sui_types::multisig::MultiSig;
+
+use crate::api::scalars::base64::Base64;
+
+/// An aggregated multisig signature.
+#[derive(SimpleObject, Clone)]
+pub(crate) struct MultisigSignature {
+    /// The individual member signatures, one per signer who participated.
+    signatures: Option<Vec<MultisigMemberSignature>>,
+    /// A bitmap indicating which members of the committee signed.
+    bitmap: Option<u16>,
+    /// The multisig committee (public keys + weights + threshold).
+    committee: Option<MultisigCommittee>,
+}
+
+/// A single member's signature within a multisig.
+#[derive(SimpleObject, Clone)]
+pub(crate) struct MultisigMemberSignature {
+    /// The signature scheme used by this member.
+    scheme: Option<MultisigMemberSignatureScheme>,
+    /// The raw signature bytes (without public key).
+    signature: Option<Base64>,
+}
+
+/// The signature scheme of a multisig member's signature.
+#[derive(Enum, Copy, Clone, Eq, PartialEq)]
+pub(crate) enum MultisigMemberSignatureScheme {
+    #[graphql(name = "ED25519")]
+    Ed25519,
+    #[graphql(name = "SECP256K1")]
+    Secp256k1,
+    #[graphql(name = "SECP256R1")]
+    Secp256r1,
+    #[graphql(name = "ZKLOGIN")]
+    ZkLogin,
+    #[graphql(name = "PASSKEY")]
+    Passkey,
+}
+
+/// The multisig committee definition.
+#[derive(SimpleObject, Clone)]
+pub(crate) struct MultisigCommittee {
+    /// The committee members (public key + weight).
+    members: Option<Vec<MultisigMember>>,
+    /// The threshold number of weight needed for a valid multisig.
+    threshold: Option<u16>,
+}
+
+/// A single member of a multisig committee.
+#[derive(SimpleObject, Clone)]
+pub(crate) struct MultisigMember {
+    /// The member's public key.
+    public_key: Option<MultisigMemberPublicKey>,
+    /// The member's weight in the committee.
+    weight: Option<u8>,
+}
+
+/// A multisig member's public key, varying by scheme.
+#[derive(Union, Clone)]
+pub(crate) enum MultisigMemberPublicKey {
+    Ed25519(Ed25519PublicKey),
+    Secp256k1(Secp256k1PublicKey),
+    Secp256r1(Secp256r1PublicKey),
+    Passkey(PasskeyPublicKey),
+    ZkLogin(ZkLoginPublicIdentifier),
+}
+
+/// An Ed25519 public key.
+#[derive(SimpleObject, Clone)]
+pub(crate) struct Ed25519PublicKey {
+    /// The raw public key bytes.
+    bytes: Option<Base64>,
+}
+
+/// A Secp256k1 public key.
+#[derive(SimpleObject, Clone)]
+pub(crate) struct Secp256k1PublicKey {
+    /// The raw public key bytes.
+    bytes: Option<Base64>,
+}
+
+/// A Secp256r1 public key.
+#[derive(SimpleObject, Clone)]
+pub(crate) struct Secp256r1PublicKey {
+    /// The raw public key bytes.
+    bytes: Option<Base64>,
+}
+
+/// A Passkey public key.
+#[derive(SimpleObject, Clone)]
+pub(crate) struct PasskeyPublicKey {
+    /// The raw public key bytes.
+    bytes: Option<Base64>,
+}
+
+/// A zkLogin public identifier, containing the OAuth issuer and address seed.
+#[derive(SimpleObject, Clone, Default)]
+pub(crate) struct ZkLoginPublicIdentifier {
+    /// The OAuth provider issuer string (e.g. "https://accounts.google.com").
+    iss: Option<String>,
+    /// The address seed as a decimal string.
+    address_seed: Option<String>,
+}
+
+impl From<&MultiSig> for MultisigSignature {
+    fn from(m: &MultiSig) -> Self {
+        Self {
+            signatures: Some(
+                m.get_sigs()
+                    .iter()
+                    .map(MultisigMemberSignature::from)
+                    .collect(),
+            ),
+            bitmap: Some(m.get_bitmap()),
+            committee: Some(MultisigCommittee::from(m.get_pk())),
+        }
+    }
+}
+
+impl From<&CompressedSignature> for MultisigMemberSignature {
+    fn from(sig: &CompressedSignature) -> Self {
+        let (scheme, bytes): (_, &[u8]) = match sig {
+            CompressedSignature::Ed25519(b) => (MultisigMemberSignatureScheme::Ed25519, &b.0),
+            CompressedSignature::Secp256k1(b) => (MultisigMemberSignatureScheme::Secp256k1, &b.0),
+            CompressedSignature::Secp256r1(b) => (MultisigMemberSignatureScheme::Secp256r1, &b.0),
+            CompressedSignature::ZkLogin(b) => {
+                (MultisigMemberSignatureScheme::ZkLogin, b.0.as_slice())
+            }
+            CompressedSignature::Passkey(b) => {
+                (MultisigMemberSignatureScheme::Passkey, b.0.as_slice())
+            }
+        };
+        Self {
+            scheme: Some(scheme),
+            signature: Some(Base64(bytes.to_vec())),
+        }
+    }
+}
+
+impl From<&sui_types::multisig::MultiSigPublicKey> for MultisigCommittee {
+    fn from(pk: &sui_types::multisig::MultiSigPublicKey) -> Self {
+        Self {
+            members: Some(
+                pk.pubkeys()
+                    .iter()
+                    .map(|(public_key, weight)| MultisigMember {
+                        public_key: Some(MultisigMemberPublicKey::from(public_key)),
+                        weight: Some(*weight),
+                    })
+                    .collect(),
+            ),
+            threshold: Some(*pk.threshold()),
+        }
+    }
+}
+
+impl From<&PublicKey> for MultisigMemberPublicKey {
+    fn from(pk: &PublicKey) -> Self {
+        match pk {
+            PublicKey::Ed25519(_) => MultisigMemberPublicKey::Ed25519(Ed25519PublicKey {
+                bytes: Some(Base64(pk.as_ref().to_vec())),
+            }),
+            PublicKey::Secp256k1(_) => MultisigMemberPublicKey::Secp256k1(Secp256k1PublicKey {
+                bytes: Some(Base64(pk.as_ref().to_vec())),
+            }),
+            PublicKey::Secp256r1(_) => MultisigMemberPublicKey::Secp256r1(Secp256r1PublicKey {
+                bytes: Some(Base64(pk.as_ref().to_vec())),
+            }),
+            PublicKey::Passkey(_) => MultisigMemberPublicKey::Passkey(PasskeyPublicKey {
+                bytes: Some(Base64(pk.as_ref().to_vec())),
+            }),
+            PublicKey::ZkLogin(z) => {
+                // Convert through sui_sdk_types for clean field extraction.
+                MultisigMemberPublicKey::ZkLogin(
+                    sui_sdk_types::ZkLoginPublicIdentifier::try_from(z.to_owned())
+                        .map(|id| ZkLoginPublicIdentifier {
+                            iss: Some(id.iss().to_owned()),
+                            address_seed: Some(id.address_seed().to_string()),
+                        })
+                        .unwrap_or_default(),
+                )
+            }
+        }
+    }
+}

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -1145,6 +1145,16 @@ The value of a dynamic field (`MoveValue`) or dynamic object field (`MoveObject`
 union DynamicFieldValue = MoveObject | MoveValue
 
 """
+An Ed25519 public key.
+"""
+type Ed25519PublicKey {
+	"""
+	The raw public key bytes.
+	"""
+	bytes: Base64
+}
+
+"""
 An Ed25519 signature.
 """
 type Ed25519Signature {
@@ -2735,6 +2745,82 @@ enum MoveVisibility {
 }
 
 """
+The multisig committee definition.
+"""
+type MultisigCommittee {
+	"""
+	The committee members (public key + weight).
+	"""
+	members: [MultisigMember!]
+	"""
+	The threshold number of weight needed for a valid multisig.
+	"""
+	threshold: Int
+}
+
+"""
+A single member of a multisig committee.
+"""
+type MultisigMember {
+	"""
+	The member's public key.
+	"""
+	publicKey: MultisigMemberPublicKey
+	"""
+	The member's weight in the committee.
+	"""
+	weight: Int
+}
+
+"""
+A multisig member's public key, varying by scheme.
+"""
+union MultisigMemberPublicKey = Ed25519PublicKey | Secp256K1PublicKey | Secp256R1PublicKey | PasskeyPublicKey | ZkLoginPublicIdentifier
+
+"""
+A single member's signature within a multisig.
+"""
+type MultisigMemberSignature {
+	"""
+	The signature scheme used by this member.
+	"""
+	scheme: MultisigMemberSignatureScheme
+	"""
+	The raw signature bytes (without public key).
+	"""
+	signature: Base64
+}
+
+"""
+The signature scheme of a multisig member's signature.
+"""
+enum MultisigMemberSignatureScheme {
+	ED25519
+	SECP256K1
+	SECP256R1
+	ZKLOGIN
+	PASSKEY
+}
+
+"""
+An aggregated multisig signature.
+"""
+type MultisigSignature {
+	"""
+	A bitmap indicating which members of the committee signed.
+	"""
+	bitmap: Int
+	"""
+	The multisig committee (public keys + weights + threshold).
+	"""
+	committee: MultisigCommittee
+	"""
+	The individual member signatures, one per signer who participated.
+	"""
+	signatures: [MultisigMemberSignature!]
+}
+
+"""
 A transaction that wanted to mutate a consensus-managed object but couldn't because it became not-consensus-managed before the transaction executed (for example, it was deleted, turned into an owned object, or wrapped).
 """
 type MutateConsensusStreamEnded {
@@ -3227,6 +3313,16 @@ type PageInfo {
 	startCursor: String
 }
 
+"""
+A Passkey public key.
+"""
+type PasskeyPublicKey {
+	"""
+	The raw public key bytes.
+	"""
+	bytes: Base64
+}
+
 type PerEpochConfig {
 	"""
 	The per-epoch configuration object as of when the transaction was executed.
@@ -3621,6 +3717,16 @@ enum RegulatedState {
 }
 
 """
+A Secp256k1 public key.
+"""
+type Secp256K1PublicKey {
+	"""
+	The raw public key bytes.
+	"""
+	bytes: Base64
+}
+
+"""
 A Secp256k1 signature.
 """
 type Secp256K1Signature {
@@ -3632,6 +3738,16 @@ type Secp256K1Signature {
 	The raw signature bytes.
 	"""
 	signature: Base64
+}
+
+"""
+A Secp256r1 public key.
+"""
+type Secp256R1PublicKey {
+	"""
+	The raw public key bytes.
+	"""
+	bytes: Base64
 }
 
 """
@@ -3814,7 +3930,7 @@ type SharedInput {
 """
 The structured details of a signature, varying by scheme.
 """
-union SignatureScheme = Ed25519Signature | Secp256K1Signature | Secp256R1Signature
+union SignatureScheme = Ed25519Signature | Secp256K1Signature | Secp256R1Signature | MultisigSignature
 
 """
 The result of simulating a transaction, including the predicted effects.
@@ -4380,6 +4496,20 @@ enum ZkLoginIntentScope {
 	Indicates that the bytes are to be parsed as a personal message.
 	"""
 	PERSONAL_MESSAGE
+}
+
+"""
+A zkLogin public identifier, containing the OAuth issuer and address seed.
+"""
+type ZkLoginPublicIdentifier {
+	"""
+	The address seed as a decimal string.
+	"""
+	addressSeed: String
+	"""
+	The OAuth provider issuer string (e.g. "https://accounts.google.com").
+	"""
+	iss: String
 }
 
 """

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -1145,6 +1145,16 @@ The value of a dynamic field (`MoveValue`) or dynamic object field (`MoveObject`
 union DynamicFieldValue = MoveObject | MoveValue
 
 """
+An Ed25519 public key.
+"""
+type Ed25519PublicKey {
+	"""
+	The raw public key bytes.
+	"""
+	bytes: Base64
+}
+
+"""
 An Ed25519 signature.
 """
 type Ed25519Signature {
@@ -2735,6 +2745,82 @@ enum MoveVisibility {
 }
 
 """
+The multisig committee definition.
+"""
+type MultisigCommittee {
+	"""
+	The committee members (public key + weight).
+	"""
+	members: [MultisigMember!]
+	"""
+	The threshold number of weight needed for a valid multisig.
+	"""
+	threshold: Int
+}
+
+"""
+A single member of a multisig committee.
+"""
+type MultisigMember {
+	"""
+	The member's public key.
+	"""
+	publicKey: MultisigMemberPublicKey
+	"""
+	The member's weight in the committee.
+	"""
+	weight: Int
+}
+
+"""
+A multisig member's public key, varying by scheme.
+"""
+union MultisigMemberPublicKey = Ed25519PublicKey | Secp256K1PublicKey | Secp256R1PublicKey | PasskeyPublicKey | ZkLoginPublicIdentifier
+
+"""
+A single member's signature within a multisig.
+"""
+type MultisigMemberSignature {
+	"""
+	The signature scheme used by this member.
+	"""
+	scheme: MultisigMemberSignatureScheme
+	"""
+	The raw signature bytes (without public key).
+	"""
+	signature: Base64
+}
+
+"""
+The signature scheme of a multisig member's signature.
+"""
+enum MultisigMemberSignatureScheme {
+	ED25519
+	SECP256K1
+	SECP256R1
+	ZKLOGIN
+	PASSKEY
+}
+
+"""
+An aggregated multisig signature.
+"""
+type MultisigSignature {
+	"""
+	A bitmap indicating which members of the committee signed.
+	"""
+	bitmap: Int
+	"""
+	The multisig committee (public keys + weights + threshold).
+	"""
+	committee: MultisigCommittee
+	"""
+	The individual member signatures, one per signer who participated.
+	"""
+	signatures: [MultisigMemberSignature!]
+}
+
+"""
 A transaction that wanted to mutate a consensus-managed object but couldn't because it became not-consensus-managed before the transaction executed (for example, it was deleted, turned into an owned object, or wrapped).
 """
 type MutateConsensusStreamEnded {
@@ -3227,6 +3313,16 @@ type PageInfo {
 	startCursor: String
 }
 
+"""
+A Passkey public key.
+"""
+type PasskeyPublicKey {
+	"""
+	The raw public key bytes.
+	"""
+	bytes: Base64
+}
+
 type PerEpochConfig {
 	"""
 	The per-epoch configuration object as of when the transaction was executed.
@@ -3621,6 +3717,16 @@ enum RegulatedState {
 }
 
 """
+A Secp256k1 public key.
+"""
+type Secp256K1PublicKey {
+	"""
+	The raw public key bytes.
+	"""
+	bytes: Base64
+}
+
+"""
 A Secp256k1 signature.
 """
 type Secp256K1Signature {
@@ -3632,6 +3738,16 @@ type Secp256K1Signature {
 	The raw signature bytes.
 	"""
 	signature: Base64
+}
+
+"""
+A Secp256r1 public key.
+"""
+type Secp256R1PublicKey {
+	"""
+	The raw public key bytes.
+	"""
+	bytes: Base64
 }
 
 """
@@ -3814,7 +3930,7 @@ type SharedInput {
 """
 The structured details of a signature, varying by scheme.
 """
-union SignatureScheme = Ed25519Signature | Secp256K1Signature | Secp256R1Signature
+union SignatureScheme = Ed25519Signature | Secp256K1Signature | Secp256R1Signature | MultisigSignature
 
 """
 The result of simulating a transaction, including the predicted effects.
@@ -4380,6 +4496,20 @@ enum ZkLoginIntentScope {
 	Indicates that the bytes are to be parsed as a personal message.
 	"""
 	PERSONAL_MESSAGE
+}
+
+"""
+A zkLogin public identifier, containing the OAuth issuer and address seed.
+"""
+type ZkLoginPublicIdentifier {
+	"""
+	The address seed as a decimal string.
+	"""
+	addressSeed: String
+	"""
+	The OAuth provider issuer string (e.g. "https://accounts.google.com").
+	"""
+	iss: String
 }
 
 """

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -1141,6 +1141,16 @@ The value of a dynamic field (`MoveValue`) or dynamic object field (`MoveObject`
 union DynamicFieldValue = MoveObject | MoveValue
 
 """
+An Ed25519 public key.
+"""
+type Ed25519PublicKey {
+	"""
+	The raw public key bytes.
+	"""
+	bytes: Base64
+}
+
+"""
 An Ed25519 signature.
 """
 type Ed25519Signature {
@@ -2731,6 +2741,82 @@ enum MoveVisibility {
 }
 
 """
+The multisig committee definition.
+"""
+type MultisigCommittee {
+	"""
+	The committee members (public key + weight).
+	"""
+	members: [MultisigMember!]
+	"""
+	The threshold number of weight needed for a valid multisig.
+	"""
+	threshold: Int
+}
+
+"""
+A single member of a multisig committee.
+"""
+type MultisigMember {
+	"""
+	The member's public key.
+	"""
+	publicKey: MultisigMemberPublicKey
+	"""
+	The member's weight in the committee.
+	"""
+	weight: Int
+}
+
+"""
+A multisig member's public key, varying by scheme.
+"""
+union MultisigMemberPublicKey = Ed25519PublicKey | Secp256K1PublicKey | Secp256R1PublicKey | PasskeyPublicKey | ZkLoginPublicIdentifier
+
+"""
+A single member's signature within a multisig.
+"""
+type MultisigMemberSignature {
+	"""
+	The signature scheme used by this member.
+	"""
+	scheme: MultisigMemberSignatureScheme
+	"""
+	The raw signature bytes (without public key).
+	"""
+	signature: Base64
+}
+
+"""
+The signature scheme of a multisig member's signature.
+"""
+enum MultisigMemberSignatureScheme {
+	ED25519
+	SECP256K1
+	SECP256R1
+	ZKLOGIN
+	PASSKEY
+}
+
+"""
+An aggregated multisig signature.
+"""
+type MultisigSignature {
+	"""
+	A bitmap indicating which members of the committee signed.
+	"""
+	bitmap: Int
+	"""
+	The multisig committee (public keys + weights + threshold).
+	"""
+	committee: MultisigCommittee
+	"""
+	The individual member signatures, one per signer who participated.
+	"""
+	signatures: [MultisigMemberSignature!]
+}
+
+"""
 A transaction that wanted to mutate a consensus-managed object but couldn't because it became not-consensus-managed before the transaction executed (for example, it was deleted, turned into an owned object, or wrapped).
 """
 type MutateConsensusStreamEnded {
@@ -3223,6 +3309,16 @@ type PageInfo {
 	startCursor: String
 }
 
+"""
+A Passkey public key.
+"""
+type PasskeyPublicKey {
+	"""
+	The raw public key bytes.
+	"""
+	bytes: Base64
+}
+
 type PerEpochConfig {
 	"""
 	The per-epoch configuration object as of when the transaction was executed.
@@ -3617,6 +3713,16 @@ enum RegulatedState {
 }
 
 """
+A Secp256k1 public key.
+"""
+type Secp256K1PublicKey {
+	"""
+	The raw public key bytes.
+	"""
+	bytes: Base64
+}
+
+"""
 A Secp256k1 signature.
 """
 type Secp256K1Signature {
@@ -3628,6 +3734,16 @@ type Secp256K1Signature {
 	The raw signature bytes.
 	"""
 	signature: Base64
+}
+
+"""
+A Secp256r1 public key.
+"""
+type Secp256R1PublicKey {
+	"""
+	The raw public key bytes.
+	"""
+	bytes: Base64
 }
 
 """
@@ -3810,7 +3926,7 @@ type SharedInput {
 """
 The structured details of a signature, varying by scheme.
 """
-union SignatureScheme = Ed25519Signature | Secp256K1Signature | Secp256R1Signature
+union SignatureScheme = Ed25519Signature | Secp256K1Signature | Secp256R1Signature | MultisigSignature
 
 """
 The result of simulating a transaction, including the predicted effects.
@@ -4376,6 +4492,20 @@ enum ZkLoginIntentScope {
 	Indicates that the bytes are to be parsed as a personal message.
 	"""
 	PERSONAL_MESSAGE
+}
+
+"""
+A zkLogin public identifier, containing the OAuth issuer and address seed.
+"""
+type ZkLoginPublicIdentifier {
+	"""
+	The address seed as a decimal string.
+	"""
+	addressSeed: String
+	"""
+	The OAuth provider issuer string (e.g. "https://accounts.google.com").
+	"""
+	iss: String
 }
 
 """


### PR DESCRIPTION
## Description 
- Add `MultisigSignature` variant to the `SignatureScheme` GraphQL union
- Introduce `MultisigMemberSignature` (flat struct with `MultisigMemberSignatureScheme` enum), `MultisigCommittee`, `MultisigMember`, and `MultisigMemberPublicKey` (union) types
- `MultisigMemberPublicKey` uses a union with `ZkLoginPublicIdentifier` (exposing `iss` + `addressSeed`) since it's structurally different from other key types
- `MultiSigLegacy` is converted to `MultiSig` via `TryFrom` to reuse a single code path
- ZkLogin public identifier conversion follows the same approach as gRPC (`rpc_proto_conversions.rs:1620`) — going through `sui_sdk_types`

## Test plan 

How did you test the new or updated feature?

- Unit test

---

## Stack
- #25657 
- #25658 <-
- #25659 

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
