### PR TITLE
ci: pre-build tidehunter binaries on release branch push

### DIFF
--- a/.github/workflows/trigger-builds.yml
+++ b/.github/workflows/trigger-builds.yml
@@ -27,7 +27,7 @@ jobs:
           repository: MystenLabs/sui-operations
           token: ${{ secrets.DOCKER_BINARY_BUILDS_DISPATCH }}
           event-type: build-release-binaries
-          client-payload: '{"sui_commit": "${{ github.sha }}"}'
+          client-payload: '{"sui_commit": "${{ github.sha }}", "build_with_tidehunter": true}'
 
   # Tag all sui images with branch name, so that they can be easily found
   tag-docker-hub-images:


### PR DESCRIPTION
## Summary

- Pass `build_with_tidehunter: true` in the `repository_dispatch` payload to sui-operations

**Problem:** Devnet wipe deploys rebuild all Sui binaries from scratch (~20 min) even though standard binaries already exist in S3. This happens because `trigger-builds.yml` only dispatches standard binary builds — it never passes the tidehunter flag. When `pulumi-sui-deploy.yaml` runs with `build_with_tidehunter: true` for devnet, it finds `sui-node-th` missing in S3 and rebuilds everything.

**Fix:** Always pass `build_with_tidehunter: true` so tidehunter binaries are pre-built on every push to release branches (and main/devnet/testnet/mainnet). The extra build adds ~10 min to the one-time binary build but saves ~20 min on every devnet deploy.

**Companion:** MystenLabs/sui-operations#7255 (receiver-side fix to read the flag from `client_payload`)

## Test plan

- [ ] Push to a release branch triggers binary build with tidehunter
- [ ] `sui-node-th` appears in S3 after the build
- [ ] Subsequent devnet deploy skips binary rebuild (S3 check finds `sui-node-th`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)