### PR TITLE
ci: fix sccache setup failing on fork PRs

### DIFF
--- a/.github/actions/setup-sccache/action.yml
+++ b/.github/actions/setup-sccache/action.yml
@@ -6,11 +6,11 @@ description: Configure sccache with S3 backend for CI builds with graceful degra
 
 inputs:
   aws-access-key-id:
-    description: AWS access key ID for S3 cache backend
-    required: true
+    description: AWS access key ID for S3 cache backend (empty for fork PRs)
+    required: false
   aws-secret-access-key:
-    description: AWS secret access key for S3 cache backend
-    required: true
+    description: AWS secret access key for S3 cache backend (empty for fork PRs)
+    required: false
   key-prefix:
     description: S3 key prefix for cache partitioning (e.g., ubuntu-ghcloud, windows-ghcloud)
     required: true
@@ -18,13 +18,16 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # pin@v5.1.1
+    - name: Configure AWS credentials
+      if: inputs.aws-access-key-id != ''
+      uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # pin@v5.1.1
       with:
         aws-access-key-id: ${{ inputs.aws-access-key-id }}
         aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
         aws-region: us-west-2
 
     - name: Set sccache environment
+      if: inputs.aws-access-key-id != ''
       shell: bash
       run: |
         echo "SCCACHE_BUCKET=mystenlabs-sccache" >> "$GITHUB_ENV"
@@ -32,6 +35,7 @@ runs:
         echo "SCCACHE_S3_KEY_PREFIX=${{ inputs.key-prefix }}" >> "$GITHUB_ENV"
 
     - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # pin@v0.0.9
+      if: inputs.aws-access-key-id != ''
       id: sccache
       continue-on-error: true
 

--- a/.github/workflows/external.yml
+++ b/.github/workflows/external.yml
@@ -55,10 +55,6 @@ jobs:
       # causes #[sim_test] to only run under the deterministic `simtest` job, and not the
       # non-deterministic `test` job.
       SUI_SKIP_SIMTESTS: 1
-      SCCACHE_BUCKET: mystenlabs-sccache
-      SCCACHE_REGION: us-west-2
-      SCCACHE_S3_KEY_PREFIX: ubuntu-ghcloud
-      RUSTC_WRAPPER: sccache
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -67,12 +63,11 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
-      - uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # pin@v5.1.1
+      - uses: ./.github/actions/setup-sccache
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-west-2
-      - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # pin@v0.0.9
+          key-prefix: ubuntu-ghcloud
       - uses: taiki-e/install-action@nextest
       - name: Set Swap Space
         uses: pierotofy/set-swap-space@fc79b3f67fa8a838184ce84a674ca12238d2c761 # pin@master
@@ -107,19 +102,13 @@ jobs:
     needs: diff
     if: needs.diff.outputs.isRust == 'true'
     runs-on: [ubuntu-ghcloud]
-    env:
-      SCCACHE_BUCKET: mystenlabs-sccache
-      SCCACHE_REGION: us-west-2
-      SCCACHE_S3_KEY_PREFIX: ubuntu-ghcloud
-      RUSTC_WRAPPER: sccache
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
-      - uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # pin@v5.1.1
+      - uses: ./.github/actions/setup-sccache
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-west-2
-      - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # pin@v0.0.9
+          key-prefix: ubuntu-ghcloud
       - run: rustup component add clippy
 
       # See '.cargo/config' for list of enabled/disappled clippy lints


### PR DESCRIPTION
## Summary

Fork PRs don't have access to repo secrets, causing the `setup-sccache` composite action to fail at the AWS credentials step. This broke CI for ~31% of open PRs (all fork PRs), including jobs like `clippy` and `windows-cli-tests`.

**Changes:**
- Make AWS credential inputs optional in `setup-sccache` composite action
- Gate all sccache steps on credentials being present — when empty, sccache is skipped entirely and builds proceed without caching
- Migrate `external.yml` from inline sccache setup to the shared composite action for consistency with `rust.yml`

**Behavior:**
- Internal PRs (branches on `MystenLabs/sui`): sccache works as before
- Fork PRs: sccache is skipped, builds run without caching (same as before sccache was introduced)

## Test plan

- [ ] Internal PR CI passes with sccache enabled (cache hits in logs)
- [ ] Fork PR CI passes without sccache (no credential errors)
- [ ] `external.yml` clippy and test jobs work correctly
- [ ] `rust.yml` clippy and windows-cli-tests jobs work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)