### PR TITLE
Add USDSUI token and pools to DeepBook docs

### DIFF
--- a/docs/content/standards/deepbookv3/contract-information.mdx
+++ b/docs/content/standards/deepbookv3/contract-information.mdx
@@ -211,6 +211,16 @@ DeepBookV3 uses upgradeable contracts. When a contract is upgraded, only `DEEPBO
 
 </details>
 
+<details>
+<summary>USDSUI Token</summary>
+
+| Parameter | Value |
+|-----------|-------|
+| Type | `0x44f838219cf67b058f3b37907b655f226153c18e33dfcd0da559a844fea9b1c1::usdsui::USDSUI` |
+| Decimals | 6 |
+
+</details>
+
 ## Pools
 
 :::info
@@ -505,6 +515,34 @@ Taker and maker fees are subject to change based on governance proposals. See [S
 | Parameter | Value |
 |-----------|-------|
 | Pool ID | `0x034f3a42e7348de2084406db7a725f9d9d132a56c68324713e6e623601fb4fd7` |
+| Tick Size | 0.0001 |
+| Lot Size | 0.1 SUI |
+| Min Size | 0.1 SUI |
+| Taker Fee | 10 bps |
+| Maker Fee | 5 bps |
+
+</details>
+
+<details>
+<summary>USDSUI/USDC</summary>
+
+| Parameter | Value |
+|-----------|-------|
+| Pool ID | `0xa374264d43e6baa5aa8b35ff18ff24fdba7443b4bcb884cb4c2f568d32cdac36` |
+| Tick Size | 0.000001 |
+| Lot Size | 0.1 USDSUI |
+| Min Size | 0.1 USDSUI |
+| Taker Fee | 1 bps |
+| Maker Fee | 0.5 bps |
+
+</details>
+
+<details>
+<summary>SUI/USDSUI</summary>
+
+| Parameter | Value |
+|-----------|-------|
+| Pool ID | `0x826eeacb2799726334aa580396338891205a41cf9344655e526aae6ddd5dc03f` |
 | Tick Size | 0.0001 |
 | Lot Size | 0.1 SUI |
 | Min Size | 0.1 SUI |


### PR DESCRIPTION
## Summary
- Add USDSUI token (6 decimals) to DeepBook supported coins
- Add USDSUI/USDC pool (tick 0.000001, 1/0.5 bps fees)
- Add SUI/USDSUI pool (tick 0.0001, 10/5 bps fees)

## Test plan
- [x] Verify docs build successfully
- [x] Confirm pool IDs and token type are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)