### PR TITLE
[bella-ciao][sui] Super minor cleanups and making sure things match `main` that should

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16656,7 +16656,6 @@ dependencies = [
  "mysten-network",
  "rand 0.8.5",
  "serde",
- "sui-execution",
  "sui-framework",
  "sui-move-build",
  "sui-types",

--- a/crates/sui-adapter-transactional-tests/tests/deny_list_v2/double_add_v74.snap
+++ b/crates/sui-adapter-transactional-tests/tests/deny_list_v2/double_add_v74.snap
@@ -29,8 +29,8 @@ gas summary: computation_cost: 1000000, storage_cost: 12190400,  storage_rebate:
 
 task 4, lines 54-56:
 //# run sui::coin::deny_list_v2_add --args object(0x403) object(1,3) @B --type-args test::regulated_coin::REGULATED_COIN --sender A
-mutated: 0x0000000000000000000000000000000000000000000000000000000000000403, object(0,0), object(1,3)
-gas summary: computation_cost: 1000000, storage_cost: 4400400,  storage_rebate: 4356396, non_refundable_storage_fee: 44004
+mutated: 0x0000000000000000000000000000000000000000000000000000000000000403, object(0,0), object(1,3), object(3,1)
+gas summary: computation_cost: 1000000, storage_cost: 6862800,  storage_rebate: 6794172, non_refundable_storage_fee: 68628
 
 task 5, lines 57-59:
 //# run test::regulated_coin::assert_address_deny_status --args immshared(0x403) @B true --sender A

--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/mut_unchanged_chain_dof_v74.snap
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/mut_unchanged_chain_dof_v74.snap
@@ -64,10 +64,10 @@ gas summary: computation_cost: 1000000, storage_cost: 13657200,  storage_rebate:
 
 task 9, line 94:
 //# run test::m1::write_back --sender A --args object(2,8)
-mutated: object(0,0), object(2,8)
-gas summary: computation_cost: 1000000, storage_cost: 2318000,  storage_rebate: 2294820, non_refundable_storage_fee: 23180
+mutated: object(0,0), object(2,8), object(2,10)
+gas summary: computation_cost: 1000000, storage_cost: 3838000,  storage_rebate: 3799620, non_refundable_storage_fee: 38380
 
 task 10, line 96:
 //# run test::m1::write_back --sender A --args object(2,9)
-mutated: object(0,0), object(2,9)
-gas summary: computation_cost: 1000000, storage_cost: 2318000,  storage_rebate: 2294820, non_refundable_storage_fee: 23180
+mutated: object(0,0), object(2,9), object(2,11)
+gas summary: computation_cost: 1000000, storage_cost: 3838000,  storage_rebate: 3799620, non_refundable_storage_fee: 38380

--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/mut_unchanged_chain_v74.snap
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/mut_unchanged_chain_v74.snap
@@ -64,10 +64,10 @@ gas summary: computation_cost: 1000000, storage_cost: 10427200,  storage_rebate:
 
 task 9, line 106:
 //# run test::m1::write_back --sender A --args object(2,8)
-mutated: object(0,0), object(2,8)
-gas summary: computation_cost: 1000000, storage_cost: 2318000,  storage_rebate: 2294820, non_refundable_storage_fee: 23180
+mutated: object(0,0), object(2,2), object(2,6), object(2,8)
+gas summary: computation_cost: 1000000, storage_cost: 6505600,  storage_rebate: 6440544, non_refundable_storage_fee: 65056
 
 task 10, line 108:
 //# run test::m1::write_back --sender A --args object(2,9)
-mutated: object(0,0), object(2,9)
-gas summary: computation_cost: 1000000, storage_cost: 2318000,  storage_rebate: 2294820, non_refundable_storage_fee: 23180
+mutated: object(0,0), object(2,3), object(2,7), object(2,9)
+gas summary: computation_cost: 1000000, storage_cost: 6505600,  storage_rebate: 6440544, non_refundable_storage_fee: 65056

--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/mut_unchanged_dof_v74.snap
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/mut_unchanged_dof_v74.snap
@@ -64,10 +64,10 @@ gas summary: computation_cost: 1000000, storage_cost: 6194000,  storage_rebate: 
 
 task 9, line 70:
 //# run test::m1::write_back --sender A --args object(2,4)
-mutated: object(0,0), object(2,4)
-gas summary: computation_cost: 1000000, storage_cost: 2242000,  storage_rebate: 2219580, non_refundable_storage_fee: 22420
+mutated: object(0,0), object(2,2), object(2,4)
+gas summary: computation_cost: 1000000, storage_cost: 3762000,  storage_rebate: 3724380, non_refundable_storage_fee: 37620
 
 task 10, line 72:
 //# run test::m1::write_back --sender A --args object(2,5)
-mutated: object(0,0), object(2,5)
-gas summary: computation_cost: 1000000, storage_cost: 2242000,  storage_rebate: 2219580, non_refundable_storage_fee: 22420
+mutated: object(0,0), object(2,3), object(2,5)
+gas summary: computation_cost: 1000000, storage_cost: 3762000,  storage_rebate: 3724380, non_refundable_storage_fee: 37620

--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/mut_unchanged_v74.snap
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/mut_unchanged_v74.snap
@@ -64,10 +64,10 @@ gas summary: computation_cost: 1000000, storage_cost: 6429600,  storage_rebate: 
 
 task 9, line 83:
 //# run test::m1::write_back --sender A --args object(2,4)
-mutated: object(0,0), object(2,4)
-gas summary: computation_cost: 1000000, storage_cost: 2242000,  storage_rebate: 2219580, non_refundable_storage_fee: 22420
+mutated: object(0,0), object(2,1), object(2,3), object(2,4)
+gas summary: computation_cost: 1000000, storage_cost: 6429600,  storage_rebate: 6365304, non_refundable_storage_fee: 64296
 
 task 10, line 85:
 //# run test::m1::write_back --sender A --args object(2,5)
-mutated: object(0,0), object(2,5)
-gas summary: computation_cost: 1000000, storage_cost: 2242000,  storage_rebate: 2219580, non_refundable_storage_fee: 22420
+mutated: object(0,0), object(2,0), object(2,2), object(2,5)
+gas summary: computation_cost: 1000000, storage_cost: 6429600,  storage_rebate: 6365304, non_refundable_storage_fee: 64296

--- a/crates/sui-adapter-transactional-tests/tests/programmable/make_vec_non_existent_type_v71.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/make_vec_non_existent_type_v71.move
@@ -1,13 +1,12 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-// TODO/XXX(vm-rewrite): This test is currently disabled because this behavior is not protocol gated in the VM.
-// Once we make the execution version cut for the new and old VM, this test should be re-enabled and re-generated.
 
 //# init --addresses test=0x0 --accounts A --protocol-version 71
 
-// //# programmable --sender A 
-// //> 0: MakeMoveVec<std::string::utf8>([]);
-// 
-// //# programmable --sender A --inputs 1
-// //> 0: MakeMoveVec<std::string::utf8>([Input(0)]);
+//# programmable --sender A 
+//> 0: MakeMoveVec<std::string::utf8>([]);
+
+//# programmable --sender A --inputs 1
+//> 0: MakeMoveVec<std::string::utf8>([Input(0)]);
+

--- a/crates/sui-adapter-transactional-tests/tests/programmable/make_vec_non_existent_type_v71.snap
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/make_vec_non_existent_type_v71.snap
@@ -1,7 +1,19 @@
 ---
 source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
 ---
-processed 1 task
+processed 3 tasks
 
 init:
 A: object(0,0)
+
+task 1, lines 7-8:
+//# programmable --sender A 
+//> 0: MakeMoveVec<std::string::utf8>([]);
+Error: Transaction Effects Status: MOVE VM INVARIANT VIOLATION.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: VMInvariantViolation, source: Some(VMError { major_status: TYPE_RESOLUTION_FAILURE, sub_status: None, message: Some("Cannot find std::string::utf8 in cache"), exec_state: None, location: Undefined, indices: [], offsets: [] }), command: Some(0) } }
+
+task 2, lines 10-11:
+//# programmable --sender A --inputs 1
+//> 0: MakeMoveVec<std::string::utf8>([Input(0)]);
+Error: Transaction Effects Status: MOVE VM INVARIANT VIOLATION.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: VMInvariantViolation, source: Some(VMError { major_status: TYPE_RESOLUTION_FAILURE, sub_status: None, message: Some("Cannot find std::string::utf8 in cache"), exec_state: None, location: Undefined, indices: [], offsets: [] }), command: Some(0) } }

--- a/crates/sui-core/src/congestion_tracker.rs
+++ b/crates/sui-core/src/congestion_tracker.rs
@@ -40,8 +40,7 @@ impl CongestionInfo {
         }
     }
 
-    fn update_for_cancellation(&mut self, now: CheckpointTimestamp, gas_price: u64) {
-        self.last_cancellation_time = now;
+    fn update_cancellation_gas_price(&mut self, gas_price: u64) {
         self.highest_cancelled_gas_price =
             std::cmp::max(self.highest_cancelled_gas_price, gas_price);
     }
@@ -185,7 +184,7 @@ impl CongestionTracker {
             for object in objects {
                 match congestion_info_map.entry(*object) {
                     Entry::Occupied(entry) => {
-                        entry.into_mut().update_for_cancellation(now, *gas_price);
+                        entry.into_mut().update_cancellation_gas_price(*gas_price);
                     }
                     Entry::Vacant(entry) => {
                         let info = CongestionInfo {

--- a/crates/sui-core/src/unit_tests/congestion_control_tests.rs
+++ b/crates/sui-core/src/unit_tests/congestion_control_tests.rs
@@ -202,9 +202,6 @@ impl TestSetup {
 //   1. Cancelled transaction should return correct error status.
 //   2. Executing cancelled transaction with effects should result in the same transaction cancellation.
 #[sim_test]
-#[ignore] // TODO(vm-rewrite): Fix this test it is failing since the `failpoint` is not triggering,
-// but AFAICT nothing related to it has changed so it should be working. Ignoring for now
-// and will circle back to it once we rebase again.
 async fn test_congestion_control_execution_cancellation() {
     telemetry_subscribers::init_for_testing();
 

--- a/crates/sui-core/src/unit_tests/move_package_publish_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_package_publish_tests.rs
@@ -163,13 +163,13 @@ async fn test_publish_duplicate_modules() {
     );
     let transaction = to_sender_signed_transaction(data, &sender_key);
     let result = submit_and_execute(&authority, transaction).await.unwrap().1;
-    assert!(matches!(
+    assert_eq!(
         result.status(),
         &ExecutionStatus::Failure {
-            error: ExecutionFailureStatus::DuplicateModuleName { .. },
+            error: ExecutionFailureStatus::VMVerificationOrDeserializationError,
             command: Some(0)
         }
-    ));
+    )
 }
 
 #[tokio::test]

--- a/crates/sui-core/src/unit_tests/move_package_upgrade_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_package_upgrade_tests.rs
@@ -64,7 +64,7 @@ enum FileOverlay<'a> {
 fn build_upgrade_test_modules_with_overlay(
     base_pkg: &str,
     overlay: FileOverlay<'_>,
-) -> (Vec<u8>, Vec<Vec<u8>>) {
+) -> (Vec<u8>, Vec<Vec<u8>>, Vec<ObjectID>) {
     // Root temp dirs under `move_upgrade` directory so that dependency paths remain correct.
     let mut tmp_dir_root_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     tmp_dir_root_path.extend(["src", "unit_tests", "data", "move_upgrade"]);
@@ -97,7 +97,8 @@ fn build_upgrade_test_modules_with_overlay(
 
 fn build_upgrade_test_modules(test_dir: &str) -> (Vec<u8>, Vec<Vec<u8>>) {
     let path = pkg_path_of(test_dir);
-    build_pkg_at_path(&path)
+    let (digest, modules, _dep_ids) = build_pkg_at_path(&path);
+    (digest, modules)
 }
 
 fn pkg_path_of(pkg_name: &str) -> PathBuf {
@@ -106,12 +107,13 @@ fn pkg_path_of(pkg_name: &str) -> PathBuf {
     path
 }
 
-fn build_pkg_at_path(path: &Path) -> (Vec<u8>, Vec<Vec<u8>>) {
+fn build_pkg_at_path(path: &Path) -> (Vec<u8>, Vec<Vec<u8>>, Vec<ObjectID>) {
     let with_unpublished_deps = false;
     let package = BuildConfig::new_for_testing().build(path).unwrap();
     (
         package.get_package_digest(with_unpublished_deps).to_vec(),
         package.get_package_bytes(with_unpublished_deps),
+        package.get_published_dependencies_ids(),
     )
 }
 
@@ -533,7 +535,7 @@ async fn test_upgrade_package_add_new_module_in_dep_only_mode_pre_v68() {
     let mut runner = UpgradeStateRunner::new("move_upgrade/base").await;
     let base_pkg = "dep_only_upgrade";
     assert_valid_dep_only_upgrade(&mut runner, base_pkg).await;
-    let (digest, modules) = build_upgrade_test_modules_with_overlay(
+    let (digest, modules, dep_ids) = build_upgrade_test_modules_with_overlay(
         base_pkg,
         FileOverlay::Add {
             file_name: "new_module.move",
@@ -541,12 +543,7 @@ async fn test_upgrade_package_add_new_module_in_dep_only_mode_pre_v68() {
         },
     );
     let effects = runner
-        .upgrade(
-            UpgradePolicy::DEP_ONLY,
-            digest,
-            modules,
-            vec![SUI_FRAMEWORK_PACKAGE_ID, MOVE_STDLIB_PACKAGE_ID],
-        )
+        .upgrade(UpgradePolicy::DEP_ONLY, digest, modules, dep_ids)
         .await;
 
     assert!(effects.status().is_ok(), "{:#?}", effects.status());
@@ -573,14 +570,9 @@ public fun friend_call(): u64 { base_addr::base::friend_fun(1) }
         FileOverlay::Remove("friend_module.move"),
     ];
     for overlay in overlays {
-        let (digest, modules) = build_upgrade_test_modules_with_overlay(base_pkg, overlay);
+        let (digest, modules, dep_ids) = build_upgrade_test_modules_with_overlay(base_pkg, overlay);
         let effects = runner
-            .upgrade(
-                UpgradePolicy::DEP_ONLY,
-                digest,
-                modules,
-                vec![SUI_FRAMEWORK_PACKAGE_ID, MOVE_STDLIB_PACKAGE_ID],
-            )
+            .upgrade(UpgradePolicy::DEP_ONLY, digest, modules, dep_ids)
             .await;
 
         assert_eq!(
@@ -613,14 +605,9 @@ public fun friend_call(): u64 { base_addr::base::friend_fun(1) }
     ];
 
     for overlay in overlays {
-        let (digest, modules) = build_upgrade_test_modules_with_overlay(base_pkg, overlay);
+        let (digest, modules, dep_ids) = build_upgrade_test_modules_with_overlay(base_pkg, overlay);
         let effects = runner
-            .upgrade(
-                UpgradePolicy::DEP_ONLY,
-                digest,
-                modules,
-                vec![SUI_FRAMEWORK_PACKAGE_ID, MOVE_STDLIB_PACKAGE_ID],
-            )
+            .upgrade(UpgradePolicy::DEP_ONLY, digest, modules, dep_ids)
             .await;
 
         assert_eq!(

--- a/crates/sui-json-rpc/src/lib.rs
+++ b/crates/sui-json-rpc/src/lib.rs
@@ -1,16 +1,12 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::env;
 use std::net::SocketAddr;
 use std::sync::Arc;
 
 use axum::body::Body;
 use axum::http;
-use hyper::Method;
 use hyper::Request;
-use hyper::header::HeaderName;
-use hyper::header::HeaderValue;
 use jsonrpsee::RpcModule;
 use metrics::Metrics;
 use metrics::MetricsLayer;
@@ -21,17 +17,12 @@ use sui_types::traffic_control::PolicyConfig;
 use tokio::runtime::Handle;
 use tokio_util::sync::CancellationToken;
 use tower::ServiceBuilder;
-use tower_http::cors::{AllowOrigin, CorsLayer};
 use tower_http::trace::TraceLayer;
 use tracing::info;
 
 pub use balance_changes::*;
 pub use object_changes::*;
 pub use sui_config::node::ServerType;
-use sui_json_rpc_api::{
-    CLIENT_REQUEST_METHOD_HEADER, CLIENT_SDK_TYPE_HEADER, CLIENT_SDK_VERSION_HEADER,
-    CLIENT_TARGET_API_VERSION_HEADER,
-};
 use sui_open_rpc::{Module, Project};
 use traffic_control::TrafficControllerService;
 
@@ -99,35 +90,6 @@ impl JsonRpcServerBuilder {
         Ok(self.module.merge(module.rpc())?)
     }
 
-    fn cors() -> Result<CorsLayer, Error> {
-        let acl = match env::var("ACCESS_CONTROL_ALLOW_ORIGIN") {
-            Ok(value) => {
-                let allow_hosts = value
-                    .split(',')
-                    .map(HeaderValue::from_str)
-                    .collect::<Result<Vec<_>, _>>()?;
-                AllowOrigin::list(allow_hosts)
-            }
-            _ => AllowOrigin::any(),
-        };
-        info!(?acl);
-
-        let cors = CorsLayer::new()
-            // Allow `POST` when accessing the resource
-            .allow_methods([Method::POST])
-            // Allow requests from any origin
-            .allow_origin(acl)
-            .allow_headers([
-                hyper::header::CONTENT_TYPE,
-                HeaderName::from_static(CLIENT_SDK_TYPE_HEADER),
-                HeaderName::from_static(CLIENT_SDK_VERSION_HEADER),
-                HeaderName::from_static(CLIENT_TARGET_API_VERSION_HEADER),
-                HeaderName::from_static(APP_NAME_HEADER),
-                HeaderName::from_static(CLIENT_REQUEST_METHOD_HEADER),
-            ]);
-        Ok(cors)
-    }
-
     fn trace_layer() -> TraceLayer<
         tower_http::classify::SharedClassifier<tower_http::classify::ServerErrorsAsFailures>,
         impl tower_http::trace::MakeSpan<Body> + Clone,
@@ -181,7 +143,6 @@ impl JsonRpcServerBuilder {
         let metrics_clone = metrics.clone();
         let middleware = ServiceBuilder::new()
             .layer(Self::trace_layer())
-            .layer(Self::cors()?)
             .map_request(move |mut request: http::Request<_>| {
                 metrics_clone.on_http_request(request.headers());
                 if let Some(client_id_source) = client_id_source.clone() {

--- a/crates/sui-package-resolver/src/lib.rs
+++ b/crates/sui-package-resolver/src/lib.rs
@@ -1947,7 +1947,6 @@ mod tests {
     /// A type that refers to types a different package.
     #[tokio::test]
     async fn test_cross_package_layout() {
-        // Use this to benchmark cross-package resolution performance, and calls.
         let (_, cache) = package_cache([
             (1, build_package("a0"), a0_types()),
             (1, build_package("b0"), b0_types()),

--- a/crates/sui-simulator/Cargo.toml
+++ b/crates/sui-simulator/Cargo.toml
@@ -30,4 +30,3 @@ bcs.workspace = true
 
 [target.'cfg(msim)'.dependencies]
 msim.workspace = true
-sui-execution.workspace = true

--- a/crates/sui-simulator/src/lib.rs
+++ b/crates/sui-simulator/src/lib.rs
@@ -18,8 +18,6 @@ pub use lru;
 pub use move_package_alt;
 pub use move_package_alt_compilation;
 pub use mysten_network;
-#[cfg(msim)]
-pub use sui_execution;
 pub use sui_framework;
 pub use sui_move_build;
 pub use sui_types;

--- a/crates/sui-types/src/execution_status.rs
+++ b/crates/sui-types/src/execution_status.rs
@@ -247,9 +247,6 @@ pub enum ExecutionFailureStatus {
 
     #[error("Non-exclusive write input object {id} has been modified")]
     NonExclusiveWriteInputObjectModified { id: ObjectID },
-
-    #[error("Duplicate module name {duplicate_module_name} in package")]
-    DuplicateModuleName { duplicate_module_name: String },
     // NOTE: if you want to add a new enum,
     // please add it at the end for Rust SDK backward compatibility.
 }

--- a/crates/sui-types/src/move_package.rs
+++ b/crates/sui-types/src/move_package.rs
@@ -350,7 +350,11 @@ impl MovePackage {
                 .serialize_with_version(module.version, &mut bytes)
                 .unwrap();
             if module_map.insert(name, bytes).is_some() {
-                panic!("Duplicate module {} in system package", module.self_id());
+                panic!(
+                    "Duplicate module {} in system package {}",
+                    module.self_id(),
+                    storage_id
+                );
             }
         }
 
@@ -395,10 +399,13 @@ impl MovePackage {
             };
             module.serialize_with_version(version, &mut bytes).unwrap();
             if module_map.insert(name, bytes).is_some() {
-                return Err(ExecutionError::from_kind(
-                    ExecutionErrorKind::DuplicateModuleName {
-                        duplicate_module_name: module.self_id().to_string(),
-                    },
+                return Err(ExecutionError::new_with_source(
+                    ExecutionErrorKind::VMVerificationOrDeserializationError,
+                    format!(
+                        "Duplicate module {} in package {}",
+                        module.self_id(),
+                        storage_id
+                    ),
                 ));
             }
         }

--- a/crates/sui-types/src/rpc_proto_conversions.rs
+++ b/crates/sui-types/src/rpc_proto_conversions.rs
@@ -1369,7 +1369,6 @@ impl From<crate::execution_status::ExecutionFailureStatus> for ExecutionError {
                 message.set_object_id(id.to_canonical_string(true));
                 ExecutionErrorKind::NonExclusiveWriteInputObjectModified
             }
-            E::DuplicateModuleName { .. } => todo!("Add DuplicateModuleName to rpc sdk"),
         };
 
         message.set_kind(kind);

--- a/crates/sui-types/src/sui_sdk_types_conversions.rs
+++ b/crates/sui-types/src/sui_sdk_types_conversions.rs
@@ -935,9 +935,6 @@ impl From<crate::execution_status::ExecutionFailureStatus> for ExecutionError {
             crate::execution_status::ExecutionFailureStatus::NonExclusiveWriteInputObjectModified { id } => {
                 Self::NonExclusiveWriteInputObjectModified { object: id.into() }
             }
-            crate::execution_status::ExecutionFailureStatus::DuplicateModuleName { .. } => {
-                todo!("Add DuplicateModuleName to sdk")
-            }
         }
     }
 }

--- a/crates/sui-types/tests/snapshots/format__sui.yaml.snap
+++ b/crates/sui-types/tests/snapshots/format__sui.yaml.snap
@@ -666,10 +666,6 @@ ExecutionFailureStatus:
         STRUCT:
           - id:
               TYPENAME: ObjectID
-    42:
-      DuplicateModuleName:
-        STRUCT:
-          - duplicate_module_name: STR
 ExecutionStatus:
   ENUM:
     0:

--- a/crates/sui-types/tests/staged/exec_failure_status.yaml
+++ b/crates/sui-types/tests/staged/exec_failure_status.yaml
@@ -41,4 +41,3 @@
 39: InvalidLinkage
 40: InsufficientFundsForWithdraw
 41: NonExclusiveWriteInputObjectModified
-42: DuplicateModuleName

--- a/external-crates/move/crates/move-vm-runtime/src/unit_tests/package_cache_tests.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/unit_tests/package_cache_tests.rs
@@ -732,7 +732,10 @@ fn cache_reuses_packages_across_linkage_contexts() {
     );
 
     // But the contents should be equivalent
-    assert_eq!(pkg1_before.loaded_types_len(), pkg1_reloaded.loaded_types_len());
+    assert_eq!(
+        pkg1_before.loaded_types_len(),
+        pkg1_reloaded.loaded_types_len()
+    );
 }
 
 /// Compile a relinker test module with the given original/version IDs and dependencies.
@@ -749,17 +752,17 @@ fn relinker_pkg(
         .to_string();
     let dep_paths: Vec<String> = deps
         .iter()
-        .map(|d| base.join(format!("rt_{d}.move")).to_string_lossy().to_string())
+        .map(|d| {
+            base.join(format!("rt_{d}.move"))
+                .to_string_lossy()
+                .to_string()
+        })
         .collect();
 
-    let (_, units) = Compiler::from_files(
-        None,
-        vec![source],
-        dep_paths,
-        BTreeMap::<String, _>::new(),
-    )
-    .build_and_report()
-    .expect("compilation failed");
+    let (_, units) =
+        Compiler::from_files(None, vec![source], dep_paths, BTreeMap::<String, _>::new())
+            .build_and_report()
+            .expect("compilation failed");
 
     let modules: Vec<CompiledModule> = expect_modules(units)
         .filter(|m| *m.self_id().address() == original_id)
@@ -826,8 +829,7 @@ fn relink() {
 
     // A v0 (original=0x4, stored at 0x4) linked against C v1 and B v0
     let mut a0 = relinker_pkg(a_orig, a_orig, "a_v0", &["b_v0", "c_v1"]);
-    a0.0.linkage_table =
-        BTreeMap::from([(c_orig, c_v1_addr), (b_orig, b_orig), (a_orig, a_orig)]);
+    a0.0.linkage_table = BTreeMap::from([(c_orig, c_v1_addr), (b_orig, b_orig), (a_orig, a_orig)]);
     adapter.insert_package_into_storage(a0);
 
     // -- Load packages into cache with different linkage contexts --
@@ -870,7 +872,13 @@ fn relink() {
     );
 
     // Both C versions are cached as separate entries
-    assert!(adapter.runtime().cache().cached_package_at(c_orig).is_some());
+    assert!(
+        adapter
+            .runtime()
+            .cache()
+            .cached_package_at(c_orig)
+            .is_some()
+    );
     assert!(
         adapter
             .runtime()
@@ -884,8 +892,7 @@ fn relink() {
     // Try publishing A v0 linked against C v0 instead of C v1.
     // A calls d() which only exists in C v1, so verification should fail.
     let mut a0_bad = relinker_pkg(a_orig, a_orig, "a_v0", &["b_v0", "c_v1"]);
-    a0_bad.0.linkage_table =
-        BTreeMap::from([(c_orig, c_orig), (b_orig, b_orig), (a_orig, a_orig)]);
+    a0_bad.0.linkage_table = BTreeMap::from([(c_orig, c_orig), (b_orig, b_orig), (a_orig, a_orig)]);
     let result = adapter.publish_package(a_orig, a0_bad.into_serialized_package());
     assert!(
         result.is_err(),


### PR DESCRIPTION
## Description 

Diff the `sui` side directly against `main` and revert any drift. 

This also removes a new error for duplicate module names that was added in development, and reverts it to the existing error that you would get today.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
