### PR TITLE
[move] Remove old metadata in snapshot files

### DIFF
--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/ability_field_requirements/procedure_args.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/ability_field_requirements/procedure_args.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/ability_field_requirements/procedure_args.mvir
 ---
 processed 2 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/ability_field_requirements/resource_enum_has_resource_field.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/ability_field_requirements/resource_enum_has_resource_field.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/ability_field_requirements/resource_enum_has_resource_field.mvir
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/ability_field_requirements/resource_has_resource_field.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/ability_field_requirements/resource_has_resource_field.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/ability_field_requirements/resource_has_resource_field.mvir
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/ability_field_requirements/unrestricted_enum_has_resource_field.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/ability_field_requirements/unrestricted_enum_has_resource_field.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/ability_field_requirements/unrestricted_enum_has_resource_field.mvir
 ---
 processed 3 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/ability_field_requirements/unrestricted_has_resource_field.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/ability_field_requirements/unrestricted_has_resource_field.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/ability_field_requirements/unrestricted_has_resource_field.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_bounds/128_params_and_128_locals.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_bounds/128_params_and_128_locals.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/check_bounds/128_params_and_128_locals.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_bounds/1_param_and_255_locals.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_bounds/1_param_and_255_locals.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/check_bounds/1_param_and_255_locals.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_bounds/256_locals.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_bounds/256_locals.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/check_bounds/256_locals.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_bounds/256_params.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_bounds/256_params.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/check_bounds/256_params.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_bounds/too_few_type_actuals.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_bounds/too_few_type_actuals.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/check_bounds/too_few_type_actuals.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_bounds/too_few_type_actuals_enum.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_bounds/too_few_type_actuals_enum.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/check_bounds/too_few_type_actuals_enum.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_bounds/too_many_type_actuals.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_bounds/too_many_type_actuals.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/check_bounds/too_many_type_actuals.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_bounds/too_many_type_actuals_enum.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_bounds/too_many_type_actuals_enum.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/check_bounds/too_many_type_actuals_enum.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_duplication/duplicate_enum_and_struct_names.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_duplication/duplicate_enum_and_struct_names.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/check_duplication/duplicate_enum_and_struct_names.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_duplication/duplicate_enum_name.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_duplication/duplicate_enum_name.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/check_duplication/duplicate_enum_name.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_duplication/duplicate_field_name.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_duplication/duplicate_field_name.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/check_duplication/duplicate_field_name.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_duplication/duplicate_field_name_enum.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_duplication/duplicate_field_name_enum.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/check_duplication/duplicate_field_name_enum.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_duplication/duplicate_function_name.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_duplication/duplicate_function_name.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/check_duplication/duplicate_function_name.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_duplication/duplicate_struct_name.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_duplication/duplicate_struct_name.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/check_duplication/duplicate_struct_name.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_duplication/duplicate_variant_name.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_duplication/duplicate_variant_name.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/check_duplication/duplicate_variant_name.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_duplication/empty_enums.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_duplication/empty_enums.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/check_duplication/empty_enums.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_duplication/empty_structs.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_duplication/empty_structs.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/check_duplication/empty_structs.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_duplication/friend_decl_duplicated.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_duplication/friend_decl_duplicated.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/check_duplication/friend_decl_duplicated.mvir
 ---
 processed 2 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/control_flow/break_nested.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/control_flow/break_nested.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/control_flow/break_nested.mvir
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/control_flow/break_simple.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/control_flow/break_simple.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/control_flow/break_simple.mvir
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/control_flow/break_unreachable.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/control_flow/break_unreachable.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/control_flow/break_unreachable.mvir
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/control_flow/dead_return.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/control_flow/dead_return.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/control_flow/dead_return.mvir
 ---
 processed 2 tasks

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/control_flow/dead_return_local.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/control_flow/dead_return_local.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/control_flow/dead_return_local.mvir
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/control_flow/if_branch_diverges_5.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/control_flow/if_branch_diverges_5.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/control_flow/if_branch_diverges_5.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/control_flow/if_branch_diverges_6.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/control_flow/if_branch_diverges_6.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/control_flow/if_branch_diverges_6.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/control_flow/if_branch_diverges_8.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/control_flow/if_branch_diverges_8.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/control_flow/if_branch_diverges_8.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/control_flow/invalid_fallthrough1.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/control_flow/invalid_fallthrough1.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/control_flow/invalid_fallthrough1.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/control_flow/invalid_fallthrough2.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/control_flow/invalid_fallthrough2.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/control_flow/invalid_fallthrough2.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/control_flow/invalid_fallthrough3.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/control_flow/invalid_fallthrough3.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/control_flow/invalid_fallthrough3.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/control_flow/last_jump_unconditional_drop.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/control_flow/last_jump_unconditional_drop.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/control_flow/last_jump_unconditional_drop.mvir
 ---
 processed 2 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/control_flow/last_jump_unconditional_reference.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/control_flow/last_jump_unconditional_reference.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/control_flow/last_jump_unconditional_reference.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/control_flow/regression_test_496.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/control_flow/regression_test_496.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/control_flow/regression_test_496.move
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/control_flow/regression_test_678.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/control_flow/regression_test_678.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/control_flow/regression_test_678.move
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/control_flow/variant_switch.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/control_flow/variant_switch.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/control_flow/variant_switch.mvir
 ---
 processed 2 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/control_flow/variant_switch_successor.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/control_flow/variant_switch_successor.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/control_flow/variant_switch_successor.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/control_flow/variant_switch_unconditional_branch.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/control_flow/variant_switch_unconditional_branch.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/control_flow/variant_switch_unconditional_branch.mvir
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/dependencies/access_friend_function_invalid.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/dependencies/access_friend_function_invalid.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/dependencies/access_friend_function_invalid.mvir
 ---
 processed 2 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/dependencies/access_private_function.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/dependencies/access_private_function.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/dependencies/access_private_function.mvir
 ---
 processed 2 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/dependencies/access_public_function.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/dependencies/access_public_function.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/dependencies/access_public_function.mvir
 ---
 processed 2 tasks

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/dependencies/all_fields_accessible.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/dependencies/all_fields_accessible.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/dependencies/all_fields_accessible.mvir
 ---
 processed 2 tasks

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/dependencies/call_integers_valid.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/dependencies/call_integers_valid.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/dependencies/call_integers_valid.move
 ---
 processed 2 tasks

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/dependencies/internal_function_invalid_call.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/dependencies/internal_function_invalid_call.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/dependencies/internal_function_invalid_call.mvir
 ---
 processed 2 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/dependencies/non_internal_function_valid_call.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/dependencies/non_internal_function_valid_call.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/dependencies/non_internal_function_valid_call.mvir
 ---
 processed 2 tasks

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/dependencies/use_unpublished_module.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/dependencies/use_unpublished_module.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/dependencies/use_unpublished_module.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/enum_defs/enum_match.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/enum_defs/enum_match.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/enum_defs/enum_match.mvir
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/enum_defs/enum_match_out_of_bounds.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/enum_defs/enum_match_out_of_bounds.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/enum_defs/enum_match_out_of_bounds.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/enum_defs/module_enum_shared_name.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/enum_defs/module_enum_shared_name.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/enum_defs/module_enum_shared_name.mvir
 ---
 processed 2 tasks

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/enum_defs/module_enum_struct_shared_name.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/enum_defs/module_enum_struct_shared_name.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/enum_defs/module_enum_struct_shared_name.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/enum_defs/mutual_recursive_enum.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/enum_defs/mutual_recursive_enum.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/enum_defs/mutual_recursive_enum.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/enum_defs/recursive_enum.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/enum_defs/recursive_enum.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/enum_defs/recursive_enum.mvir
 ---
 processed 6 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/enum_defs/ref_in_enum.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/enum_defs/ref_in_enum.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/enum_defs/ref_in_enum.mvir
 ---
 processed 4 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/friends/friend_decl_different_address.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/friends/friend_decl_different_address.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/friends/friend_decl_different_address.mvir
 ---
 processed 2 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/friends/friend_decl_self.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/friends/friend_decl_self.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/friends/friend_decl_self.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/complex_1.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/complex_1.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/complex_1.mvir
 ---
 processed 3 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/complex_1_enum.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/complex_1_enum.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/complex_1_enum.mvir
 ---
 processed 3 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_just_type_params_ok.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_just_type_params_ok.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_just_type_params_ok.mvir
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_non_generic_type_ok.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_non_generic_type_ok.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_non_generic_type_ok.mvir
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_non_generic_type_ok_enum.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_non_generic_type_ok_enum.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_non_generic_type_ok_enum.mvir
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_three_args_just_type_params_shitfing_ok.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_three_args_just_type_params_shitfing_ok.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_three_args_just_type_params_shitfing_ok.mvir
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_three_args_type_con_non_generic_types_ok.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_three_args_type_con_non_generic_types_ok.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_three_args_type_con_non_generic_types_ok.mvir
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_three_args_type_con_non_generic_types_ok_enum.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_three_args_type_con_non_generic_types_ok_enum.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_three_args_type_con_non_generic_types_ok_enum.mvir
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_three_args_type_con_shifting.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_three_args_type_con_shifting.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_three_args_type_con_shifting.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_three_args_type_con_shifting_enum.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_three_args_type_con_shifting_enum.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_three_args_type_con_shifting_enum.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_two_args_non_generic_type_and_type_param_ok.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_two_args_non_generic_type_and_type_param_ok.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_two_args_non_generic_type_and_type_param_ok.mvir
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_two_args_swapping_just_type_params_ok.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_two_args_swapping_just_type_params_ok.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_two_args_swapping_just_type_params_ok.mvir
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_two_args_swapping_type_con.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_two_args_swapping_type_con.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_two_args_swapping_type_con.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_two_args_swapping_type_con_enum.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_two_args_swapping_type_con_enum.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_two_args_swapping_type_con_enum.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_type_con.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_type_con.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_type_con.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_type_con_enum.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_type_con_enum.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_type_con_enum.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/nested_types_1.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/nested_types_1.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/nested_types_1.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/nested_types_1_enum.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/nested_types_1_enum.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/nested_types_1_enum.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/nested_types_2.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/nested_types_2.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/nested_types_2.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/nested_types_2_enum.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/nested_types_2_enum.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/nested_types_2_enum.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/nested_types_2_enum_struct.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/nested_types_2_enum_struct.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/nested_types_2_enum_struct.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/recursive_infinite_type_terminates.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/recursive_infinite_type_terminates.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/recursive_infinite_type_terminates.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/recursive_one_arg_just_type_params_ok.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/recursive_one_arg_just_type_params_ok.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/recursive_one_arg_just_type_params_ok.mvir
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/recursive_one_arg_non_generic_type_ok.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/recursive_one_arg_non_generic_type_ok.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/recursive_one_arg_non_generic_type_ok.mvir
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/recursive_one_arg_type_con.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/recursive_one_arg_type_con.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/recursive_one_arg_type_con.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/recursive_one_arg_type_con_enum.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/recursive_one_arg_type_con_enum.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/recursive_one_arg_type_con_enum.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/recursive_two_args_swapping_type_con.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/recursive_two_args_swapping_type_con.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/recursive_two_args_swapping_type_con.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/recursive_two_args_swapping_type_con_enum.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/recursive_two_args_swapping_type_con_enum.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/recursive_two_args_swapping_type_con_enum.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/two_loops.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/two_loops.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/two_loops.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/two_loops_enum.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/two_loops_enum.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/two_loops_enum.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/abort_unreleased_reference.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/abort_unreleased_reference.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/locals_safety/abort_unreleased_reference.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/abort_unused_resource.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/abort_unused_resource.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/locals_safety/abort_unused_resource.mvir
 ---
 processed 2 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/assign_copy.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/assign_copy.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/locals_safety/assign_copy.mvir
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/assign_enum_resource.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/assign_enum_resource.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/locals_safety/assign_enum_resource.mvir
 ---
 processed 3 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/assign_in_one_if_branch.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/assign_in_one_if_branch.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/locals_safety/assign_in_one_if_branch.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/assign_move.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/assign_move.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/locals_safety/assign_move.mvir
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/assign_resource.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/assign_resource.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/locals_safety/assign_resource.mvir
 ---
 processed 2 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/assign_wrong_if_branch.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/assign_wrong_if_branch.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/locals_safety/assign_wrong_if_branch.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/assign_wrong_if_branch_no_else.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/assign_wrong_if_branch_no_else.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/locals_safety/assign_wrong_if_branch_no_else.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/branch_assigns_then_moves.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/branch_assigns_then_moves.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/locals_safety/branch_assigns_then_moves.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/branch_assigns_then_moves_then_assigns.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/branch_assigns_then_moves_then_assigns.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/locals_safety/branch_assigns_then_moves_then_assigns.mvir
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/deep_return_branch_doesnt_assign.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/deep_return_branch_doesnt_assign.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/locals_safety/deep_return_branch_doesnt_assign.mvir
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/else_assigns_if_doesnt.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/else_assigns_if_doesnt.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/locals_safety/else_assigns_if_doesnt.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/else_moves_if_doesnt.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/else_moves_if_doesnt.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/locals_safety/else_moves_if_doesnt.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/enum_non_drop_assignment.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/enum_non_drop_assignment.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/locals_safety/enum_non_drop_assignment.mvir
 ---
 processed 2 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/if_assigns_else_doesnt.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/if_assigns_else_doesnt.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/locals_safety/if_assigns_else_doesnt.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/if_assigns_no_else.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/if_assigns_no_else.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/locals_safety/if_assigns_no_else.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/if_moves_else_doesnt.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/if_moves_else_doesnt.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/locals_safety/if_moves_else_doesnt.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/if_moves_no_else.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/if_moves_no_else.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/locals_safety/if_moves_no_else.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/join_failure.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/join_failure.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/locals_safety/join_failure.mvir
 ---
 processed 5 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/move_before_assign.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/move_before_assign.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/locals_safety/move_before_assign.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/return_branch_doesnt_assign.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/return_branch_doesnt_assign.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/locals_safety/return_branch_doesnt_assign.mvir
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/return_branch_moves.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/return_branch_moves.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/locals_safety/return_branch_moves.mvir
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/signer_st_loc_partial.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/signer_st_loc_partial.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/locals_safety/signer_st_loc_partial.mvir
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/signer_unused.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/signer_unused.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/locals_safety/signer_unused.mvir
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/signer_unused_partial.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/signer_unused_partial.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/locals_safety/signer_unused_partial.mvir
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/use_before_assign.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/use_before_assign.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/locals_safety/use_before_assign.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/vector_ops_non_droppable_resource_not_destroyed.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/vector_ops_non_droppable_resource_not_destroyed.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/locals_safety/vector_ops_non_droppable_resource_not_destroyed.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/while_move_local.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/while_move_local.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/locals_safety/while_move_local.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/while_move_local_2.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/while_move_local_2.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/locals_safety/while_move_local_2.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/assign_field_after_local.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/assign_field_after_local.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/assign_field_after_local.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/assign_local_after_move.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/assign_local_after_move.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/assign_local_after_move.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/assign_local_struct.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/assign_local_struct.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/assign_local_struct.mvir
 ---
 processed 2 tasks

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/assign_local_struct_invalidated.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/assign_local_struct_invalidated.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/assign_local_struct_invalidated.mvir
 ---
 processed 2 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/assign_local_value.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/assign_local_value.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/assign_local_value.mvir
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/borrow_copy_ok.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/borrow_copy_ok.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/borrow_copy_ok.mvir
 ---
 processed 2 tasks

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/borrow_enum_field_mutable_invalid.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/borrow_enum_field_mutable_invalid.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/borrow_enum_field_mutable_invalid.mvir
 ---
 processed 3 tasks

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/borrow_field_ok.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/borrow_field_ok.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/borrow_field_ok.mvir
 ---
 processed 2 tasks

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/borrow_if.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/borrow_if.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/borrow_if.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/borrow_in_loop.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/borrow_in_loop.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/borrow_in_loop.mvir
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/borrow_return_mutable_borrow_bad.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/borrow_return_mutable_borrow_bad.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/borrow_return_mutable_borrow_bad.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/borrow_x_in_if_y_in_else.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/borrow_x_in_if_y_in_else.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/borrow_x_in_if_y_in_else.mvir
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/copy_loc_borrowed.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/copy_loc_borrowed.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/copy_loc_borrowed.mvir
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/copy_loc_borrowed_field.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/copy_loc_borrowed_field.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/copy_loc_borrowed_field.mvir
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/copy_loc_borrowed_field_invalid.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/copy_loc_borrowed_field_invalid.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/copy_loc_borrowed_field_invalid.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/copy_loc_borrowed_indirect.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/copy_loc_borrowed_indirect.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/copy_loc_borrowed_indirect.mvir
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/copy_loc_borrowed_indirect_invalid.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/copy_loc_borrowed_indirect_invalid.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/copy_loc_borrowed_indirect_invalid.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/copy_loc_borrowed_invalid.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/copy_loc_borrowed_invalid.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/copy_loc_borrowed_invalid.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/deref_borrow_field_ok.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/deref_borrow_field_ok.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/deref_borrow_field_ok.mvir
 ---
 processed 2 tasks

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/deref_copy_bad.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/deref_copy_bad.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/deref_copy_bad.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/deref_eq_bad.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/deref_eq_bad.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/deref_eq_bad.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/deref_eq_good.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/deref_eq_good.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/deref_eq_good.mvir
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/double_enum_unpack.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/double_enum_unpack.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/double_enum_unpack.mvir
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/eq_bad.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/eq_bad.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/eq_bad.mvir
 ---
 processed 4 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/eq_ok.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/eq_ok.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/eq_ok.mvir
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/factor_invalid_1.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/factor_invalid_1.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/factor_invalid_1.mvir
 ---
 processed 2 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/factor_invalid_2.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/factor_invalid_2.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/factor_invalid_2.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/factor_invalid_2_enum.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/factor_invalid_2_enum.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/factor_invalid_2_enum.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/factor_valid_1.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/factor_valid_1.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/factor_valid_1.mvir
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/factor_valid_2.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/factor_valid_2.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/factor_valid_2.mvir
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/imm_borrow_loc.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/imm_borrow_loc.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/imm_borrow_loc.mvir
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/imm_borrow_loc_trivial.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/imm_borrow_loc_trivial.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/imm_borrow_loc_trivial.mvir
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/imm_borrow_loc_trivial_valid.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/imm_borrow_loc_trivial_valid.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/imm_borrow_loc_trivial_valid.mvir
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/imm_borrow_loc_valid.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/imm_borrow_loc_valid.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/imm_borrow_loc_valid.mvir
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/imm_borrow_on_mut.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/imm_borrow_on_mut.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/imm_borrow_on_mut.mvir
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/imm_borrow_on_mut_trivial.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/imm_borrow_on_mut_trivial.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/imm_borrow_on_mut_trivial.mvir
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/imm_borrow_on_mut_trivial_invalid.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/imm_borrow_on_mut_trivial_invalid.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/imm_borrow_on_mut_trivial_invalid.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/imm_borrow_on_mut_trivial_invalid_enum.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/imm_borrow_on_mut_trivial_invalid_enum.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/imm_borrow_on_mut_trivial_invalid_enum.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/invalid_enum_ref_unpack.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/invalid_enum_ref_unpack.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/invalid_enum_ref_unpack.mvir
 ---
 processed 7 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/invalid_enum_ref_unpack_loop.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/invalid_enum_ref_unpack_loop.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/invalid_enum_ref_unpack_loop.mvir
 ---
 processed 5 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/join_borrow_unavailable_valid.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/join_borrow_unavailable_valid.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/join_borrow_unavailable_valid.mvir
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/move_one_branch.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/move_one_branch.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/move_one_branch.mvir
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/mutable_borrow_invalid.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/mutable_borrow_invalid.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/mutable_borrow_invalid.mvir
 ---
 processed 2 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/mutable_borrow_local_twice.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/mutable_borrow_local_twice.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/mutable_borrow_local_twice.mvir
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/mutable_borrow_local_twice_invalid.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/mutable_borrow_local_twice_invalid.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/mutable_borrow_local_twice_invalid.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/mutate_borrow_field_ok.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/mutate_borrow_field_ok.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/mutate_borrow_field_ok.mvir
 ---
 processed 2 tasks

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/mutate_resource_holder.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/mutate_resource_holder.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/mutate_resource_holder.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/mutate_resource_holder_2.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/mutate_resource_holder_2.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/mutate_resource_holder_2.mvir
 ---
 processed 2 tasks

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/mutate_with_borrowed_loc.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/mutate_with_borrowed_loc.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/mutate_with_borrowed_loc.mvir
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/mutate_with_borrowed_loc_invalid.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/mutate_with_borrowed_loc_invalid.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/mutate_with_borrowed_loc_invalid.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/mutate_with_borrowed_loc_struct_invalid.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/mutate_with_borrowed_loc_struct_invalid.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/mutate_with_borrowed_loc_struct_invalid.mvir
 ---
 processed 2 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/nested_mutate.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/nested_mutate.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/nested_mutate.mvir
 ---
 processed 3 tasks

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/no_borrow_ref.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/no_borrow_ref.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/no_borrow_ref.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/read_field_after_assign_local.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/read_field_after_assign_local.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/read_field_after_assign_local.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/read_local_ref_after_assign.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/read_local_ref_after_assign.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/read_local_ref_after_assign.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/read_local_ref_after_move.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/read_local_ref_after_move.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/read_local_ref_after_move.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/ref_moved_one_branch.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/ref_moved_one_branch.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/ref_moved_one_branch.mvir
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/release_cycle.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/release_cycle.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/release_cycle.mvir
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/return_local_ref.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/return_local_ref.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/return_local_ref.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/return_with_borrowed_loc.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/return_with_borrowed_loc.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/return_with_borrowed_loc.mvir
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/return_with_borrowed_loc_invalid.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/return_with_borrowed_loc_invalid.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/return_with_borrowed_loc_invalid.mvir
 ---
 processed 4 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/return_with_borrowed_loc_resource_invalid.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/return_with_borrowed_loc_resource_invalid.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/return_with_borrowed_loc_resource_invalid.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/simple_mutate.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/simple_mutate.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/simple_mutate.mvir
 ---
 processed 2 tasks

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/two_mutable_enum_unpacks.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/two_mutable_enum_unpacks.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/two_mutable_enum_unpacks.mvir
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/two_mutable_ref.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/two_mutable_ref.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/two_mutable_ref.mvir
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/use_after_move.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/use_after_move.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/use_after_move.mvir
 ---
 processed 2 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/use_prefix_after_move.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/use_prefix_after_move.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/use_prefix_after_move.mvir
 ---
 processed 3 tasks

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/use_suffix_after_move.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/use_suffix_after_move.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/use_suffix_after_move.mvir
 ---
 processed 2 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/valid_enum_ref_unpack.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/valid_enum_ref_unpack.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/valid_enum_ref_unpack.mvir
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/valid_enum_unpack_loop.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/valid_enum_unpack_loop.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/valid_enum_unpack_loop.mvir
 ---
 processed 3 tasks

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/vector_ops_double_borrow.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/vector_ops_double_borrow.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/vector_ops_double_borrow.mvir
 ---
 processed 3 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/vector_ops_move_after_borrow.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/vector_ops_move_after_borrow.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/vector_ops_move_after_borrow.mvir
 ---
 processed 2 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/vector_ops_pop_after_borrow.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/vector_ops_pop_after_borrow.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/vector_ops_pop_after_borrow.mvir
 ---
 processed 2 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/writeref_borrow_invalid.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/writeref_borrow_invalid.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/writeref_borrow_invalid.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/writeref_borrow_valid1.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/writeref_borrow_valid1.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/writeref_borrow_valid1.mvir
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/writeref_borrow_valid2.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/writeref_borrow_valid2.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/writeref_borrow_valid2.mvir
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/script_signature/script_type_parameters_in_args.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/script_signature/script_type_parameters_in_args.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/script_signature/script_type_parameters_in_args.mvir
 ---
 processed 5 tasks

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/script_signature/script_with_generic_type_arg.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/script_signature/script_with_generic_type_arg.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/script_signature/script_with_generic_type_arg.mvir
 ---
 processed 2 tasks

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/script_signature/script_with_type_parameters.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/script_signature/script_with_type_parameters.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/script_signature/script_with_type_parameters.mvir
 ---
 processed 2 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/script_signature/signer_double_signer.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/script_signature/signer_double_signer.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/script_signature/signer_double_signer.mvir
 ---
 processed 3 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/script_signature/signer_misplaced_signer_arg.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/script_signature/signer_misplaced_signer_arg.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/script_signature/signer_misplaced_signer_arg.mvir
 ---
 processed 2 tasks

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/script_signature/struct_arguments.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/script_signature/struct_arguments.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/script_signature/struct_arguments.mvir
 ---
 processed 3 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/all_as_all_ok.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/all_as_all_ok.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/signature/all_as_all_ok.mvir
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/all_as_resource.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/all_as_resource.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/signature/all_as_resource.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/all_as_unrestricted.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/all_as_unrestricted.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/signature/all_as_unrestricted.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/check_constraints_script.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/check_constraints_script.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/signature/check_constraints_script.mvir
 ---
 processed 9 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/check_constraints_script_invalid.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/check_constraints_script_invalid.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/signature/check_constraints_script_invalid.mvir
 ---
 processed 9 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/reference_as_type_actual_for_bytecode_instruction.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/reference_as_type_actual_for_bytecode_instruction.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/signature/reference_as_type_actual_for_bytecode_instruction.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/reference_as_type_actual_for_struct.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/reference_as_type_actual_for_struct.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/signature/reference_as_type_actual_for_struct.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/reference_as_type_actual_in_struct_inst_for_bytecode_instruction.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/reference_as_type_actual_in_struct_inst_for_bytecode_instruction.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/signature/reference_as_type_actual_in_struct_inst_for_bytecode_instruction.mvir
 ---
 processed 5 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/reference_in_fields.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/reference_in_fields.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/signature/reference_in_fields.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/reference_in_locals_ok.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/reference_in_locals_ok.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/signature/reference_in_locals_ok.mvir
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/resource_as_all_ok.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/resource_as_all_ok.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/signature/resource_as_all_ok.mvir
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/resource_as_unrestricted.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/resource_as_unrestricted.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/signature/resource_as_unrestricted.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/two_type_actuals_ok.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/two_type_actuals_ok.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/signature/two_type_actuals_ok.mvir
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/two_type_actuals_reverse_order.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/two_type_actuals_reverse_order.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/signature/two_type_actuals_reverse_order.mvir
 ---
 processed 2 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/unrestricted_as_all_ok.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/unrestricted_as_all_ok.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/signature/unrestricted_as_all_ok.mvir
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/unrestricted_as_resource.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/unrestricted_as_resource.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/signature/unrestricted_as_resource.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/vector_ops_invalid_type_args.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/vector_ops_invalid_type_args.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/signature/vector_ops_invalid_type_args.mvir
 ---
 processed 3 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/abort_negative_stack_size.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/abort_negative_stack_size.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/abort_negative_stack_size.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/abort_no_return.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/abort_no_return.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/abort_no_return.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/abort_positive_stack_size.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/abort_positive_stack_size.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/abort_positive_stack_size.mvir
 ---
 processed 2 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/cast_negative_stack.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/cast_negative_stack.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/cast_negative_stack.mvir
 ---
 processed 6 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/cast_positive_stack.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/cast_positive_stack.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/cast_positive_stack.mvir
 ---
 processed 6 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/consume_stack.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/consume_stack.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/consume_stack.mvir
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/exp_in_if_and_else_branch.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/exp_in_if_and_else_branch.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/exp_in_if_and_else_branch.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/function_call_negative_stack_err_1.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/function_call_negative_stack_err_1.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/function_call_negative_stack_err_1.mvir
 ---
 processed 2 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/function_call_negative_stack_err_2.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/function_call_negative_stack_err_2.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/function_call_negative_stack_err_2.mvir
 ---
 processed 2 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/function_composition_pos_and_neg_stack_err.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/function_composition_pos_and_neg_stack_err.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/function_composition_pos_and_neg_stack_err.mvir
 ---
 processed 2 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/function_composition_positive_stack_err_1.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/function_composition_positive_stack_err_1.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/function_composition_positive_stack_err_1.mvir
 ---
 processed 2 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/function_composition_positive_stack_err_2.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/function_composition_positive_stack_err_2.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/function_composition_positive_stack_err_2.mvir
 ---
 processed 2 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/integer_stack_balanced.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/integer_stack_balanced.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/integer_stack_balanced.mvir
 ---
 processed 6 tasks

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/integer_stack_negative.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/integer_stack_negative.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/integer_stack_negative.mvir
 ---
 processed 6 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/integer_stack_positive.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/integer_stack_positive.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/integer_stack_positive.mvir
 ---
 processed 6 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/load_positive_stack.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/load_positive_stack.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/load_positive_stack.mvir
 ---
 processed 6 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/multiple_bindings_negative_stack.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/multiple_bindings_negative_stack.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/multiple_bindings_negative_stack.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/multiple_bindings_positive_stack.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/multiple_bindings_positive_stack.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/multiple_bindings_positive_stack.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/multiple_return_values.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/multiple_return_values.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/multiple_return_values.mvir
 ---
 processed 2 tasks

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/multiple_return_values_extra_binding.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/multiple_return_values_extra_binding.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/multiple_return_values_extra_binding.mvir
 ---
 processed 2 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/multiple_return_values_extra_value.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/multiple_return_values_extra_value.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/multiple_return_values_extra_value.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/multiple_return_values_missing_binding.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/multiple_return_values_missing_binding.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/multiple_return_values_missing_binding.mvir
 ---
 processed 2 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/multiple_return_values_missing_value.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/multiple_return_values_missing_value.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/multiple_return_values_missing_value.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/pack_invalid_number_arguments_enum.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/pack_invalid_number_arguments_enum.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/pack_invalid_number_arguments_enum.mvir
 ---
 processed 4 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/pop_exact.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/pop_exact.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/pop_exact.mvir
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/pop_negative.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/pop_negative.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/pop_negative.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/pop_positive.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/pop_positive.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/pop_positive.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/unpack_extra_binding.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/unpack_extra_binding.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/unpack_extra_binding.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/unpack_extra_binding_enum.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/unpack_extra_binding_enum.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/unpack_extra_binding_enum.mvir
 ---
 processed 4 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/unpack_missing_binding.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/unpack_missing_binding.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/unpack_missing_binding.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/unpack_missing_binding_enum.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/unpack_missing_binding_enum.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/unpack_missing_binding_enum.mvir
 ---
 processed 4 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/vector_ops_pack_unpack.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/vector_ops_pack_unpack.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/vector_ops_pack_unpack.mvir
 ---
 processed 4 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/struct_defs/module_struct_shared_name.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/struct_defs/module_struct_shared_name.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/struct_defs/module_struct_shared_name.mvir
 ---
 processed 2 tasks

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/struct_defs/mutual_recursive_struct.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/struct_defs/mutual_recursive_struct.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/struct_defs/mutual_recursive_struct.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/struct_defs/recursive_struct.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/struct_defs/recursive_struct.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/struct_defs/recursive_struct.mvir
 ---
 processed 6 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/struct_defs/ref_in_struct.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/struct_defs/ref_in_struct.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/struct_defs/ref_in_struct.mvir
 ---
 processed 4 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/assign_local_resource.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/assign_local_resource.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/assign_local_resource.mvir
 ---
 processed 2 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/assign_local_resource_twice.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/assign_local_resource_twice.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/assign_local_resource_twice.mvir
 ---
 processed 2 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/assign_resource_type.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/assign_resource_type.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/assign_resource_type.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/assign_resource_type_enum.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/assign_resource_type_enum.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/assign_resource_type_enum.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/assign_wrong_type.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/assign_wrong_type.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/assign_wrong_type.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/boolean_not_non_boolean.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/boolean_not_non_boolean.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/boolean_not_non_boolean.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/cant_deref_resource.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/cant_deref_resource.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/cant_deref_resource.mvir
 ---
 processed 2 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/casting_operators_types_mismatch.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/casting_operators_types_mismatch.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/casting_operators_types_mismatch.mvir
 ---
 processed 18 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/deref_non_reference.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/deref_non_reference.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/deref_non_reference.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/deref_not_reference_bad.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/deref_not_reference_bad.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/deref_not_reference_bad.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/destroy_resource_holder.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/destroy_resource_holder.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/destroy_resource_holder.mvir
 ---
 processed 2 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/equality_one_ref.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/equality_one_ref.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/equality_one_ref.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/equality_resource_refs.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/equality_resource_refs.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/equality_resource_refs.mvir
 ---
 processed 4 tasks

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/equality_resource_values.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/equality_resource_values.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/equality_resource_values.mvir
 ---
 processed 2 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/freeze_makes_imm.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/freeze_makes_imm.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/freeze_makes_imm.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/freeze_on_imm.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/freeze_on_imm.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/freeze_on_imm.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/freeze_valid.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/freeze_valid.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/freeze_valid.mvir
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/freeze_wrong_type.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/freeze_wrong_type.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/freeze_wrong_type.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_abilities_borrow_field.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_abilities_borrow_field.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_abilities_borrow_field.mvir
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_abilities_call.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_abilities_call.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_abilities_call.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_abilities_imm_borrow_field.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_abilities_imm_borrow_field.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_abilities_imm_borrow_field.mvir
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_abilities_imm_unpack_enum.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_abilities_imm_unpack_enum.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_abilities_imm_unpack_enum.mvir
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_abilities_pack.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_abilities_pack.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_abilities_pack.mvir
 ---
 processed 2 tasks

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_abilities_struct_non_nominal_resource.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_abilities_struct_non_nominal_resource.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_abilities_struct_non_nominal_resource.mvir
 ---
 processed 2 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_abilities_type_param_all.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_abilities_type_param_all.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_abilities_type_param_all.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_abilities_type_param_resource.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_abilities_type_param_resource.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_abilities_type_param_resource.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_abilities_unpack.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_abilities_unpack.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_abilities_unpack.mvir
 ---
 processed 2 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_abilities_unpack_mut_enum.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_abilities_unpack_mut_enum.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_abilities_unpack_mut_enum.mvir
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_call.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_call.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_call.mvir
 ---
 processed 2 tasks

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_field_borrow.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_field_borrow.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_field_borrow.mvir
 ---
 processed 2 tasks

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_field_borrow_after_call.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_field_borrow_after_call.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_field_borrow_after_call.mvir
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_field_unpack_borrow_after_call_enum.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_field_unpack_borrow_after_call_enum.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_field_unpack_borrow_after_call_enum.mvir
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_function_def.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_function_def.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_function_def.mvir
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_id_function.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_id_function.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_id_function.mvir
 ---
 processed 2 tasks

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_import_function.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_import_function.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_import_function.mvir
 ---
 processed 3 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_import_struct.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_import_struct.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_import_struct.mvir
 ---
 processed 6 tasks

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_option.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_option.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_option.mvir
 ---
 processed 2 tasks

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_pack.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_pack.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_pack.mvir
 ---
 processed 4 tasks

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_pack_type_mismatch.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_pack_type_mismatch.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_pack_type_mismatch.mvir
 ---
 processed 8 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_struct_def.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_struct_def.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_struct_def.mvir
 ---
 processed 2 tasks

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_unpack.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_unpack.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_unpack.mvir
 ---
 processed 4 tasks

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_unpack_type_mismatch.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_unpack_type_mismatch.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_unpack_type_mismatch.mvir
 ---
 processed 2 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/integer_binary_operators_types_mismatch.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/integer_binary_operators_types_mismatch.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/integer_binary_operators_types_mismatch.mvir
 ---
 processed 191 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/integers_valid.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/integers_valid.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/integers_valid.mvir
 ---
 processed 6 tasks

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/invalid_field_write.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/invalid_field_write.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/invalid_field_write.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/invalid_field_write_mut_unpack_enum.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/invalid_field_write_mut_unpack_enum.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/invalid_field_write_mut_unpack_enum.mvir
 ---
 processed 2 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/invalid_resouce_write_unpack_mut_enum.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/invalid_resouce_write_unpack_mut_enum.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/invalid_resouce_write_unpack_mut_enum.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/invalid_resource_write.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/invalid_resource_write.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/invalid_resource_write.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/mut_borrow_from_imm_ref.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/mut_borrow_from_imm_ref.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/mut_borrow_from_imm_ref.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/mut_borrow_from_imm_ref_enum.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/mut_borrow_from_imm_ref_enum.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/mut_borrow_from_imm_ref_enum.mvir
 ---
 processed 2 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/mut_call_from_get_resource.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/mut_call_from_get_resource.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/mut_call_from_get_resource.mvir
 ---
 processed 2 tasks

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/mut_call_with_imm_ref.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/mut_call_with_imm_ref.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/mut_call_with_imm_ref.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/mut_call_with_imm_ref_enum.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/mut_call_with_imm_ref_enum.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/mut_call_with_imm_ref_enum.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/pack_enum_with_refs.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/pack_enum_with_refs.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/pack_enum_with_refs.mvir
 ---
 processed 9 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/pack_generic_enum_invalid_type_arguments.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/pack_generic_enum_invalid_type_arguments.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/pack_generic_enum_invalid_type_arguments.mvir
 ---
 processed 9 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/pack_generic_enum_non_generically.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/pack_generic_enum_non_generically.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/pack_generic_enum_non_generically.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/pack_non_generic_enum_generically.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/pack_non_generic_enum_generically.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/pack_non_generic_enum_generically.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/phantom_params/bytecode_ops_abilities_bad.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/phantom_params/bytecode_ops_abilities_bad.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/phantom_params/bytecode_ops_abilities_bad.mvir
 ---
 processed 12 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/phantom_params/bytecode_ops_abilities_ok.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/phantom_params/bytecode_ops_abilities_ok.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/phantom_params/bytecode_ops_abilities_ok.mvir
 ---
 processed 2 tasks

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/phantom_params/constraints_abilities_bad.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/phantom_params/constraints_abilities_bad.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/phantom_params/constraints_abilities_bad.mvir
 ---
 processed 12 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/phantom_params/constraints_abilities_ok.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/phantom_params/constraints_abilities_ok.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/phantom_params/constraints_abilities_ok.mvir
 ---
 processed 2 tasks

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/phantom_params/fields_abilities_bad.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/phantom_params/fields_abilities_bad.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/phantom_params/fields_abilities_bad.mvir
 ---
 processed 10 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/phantom_params/fields_abilities_ok.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/phantom_params/fields_abilities_ok.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/phantom_params/fields_abilities_ok.mvir
 ---
 processed 2 tasks

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/phantom_params/struct_definition_bad.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/phantom_params/struct_definition_bad.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/phantom_params/struct_definition_bad.mvir
 ---
 processed 12 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/phantom_params/struct_definition_ok.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/phantom_params/struct_definition_ok.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/phantom_params/struct_definition_ok.mvir
 ---
 processed 7 tasks

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/procedure_args_subtype.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/procedure_args_subtype.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/procedure_args_subtype.mvir
 ---
 processed 2 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/procedure_return_invalid_subtype.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/procedure_return_invalid_subtype.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/procedure_return_invalid_subtype.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/procedure_return_invalid_type.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/procedure_return_invalid_type.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/procedure_return_invalid_type.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/ref_type_param.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/ref_type_param.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/ref_type_param.mvir
 ---
 processed 8 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/ref_type_param_exploits.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/ref_type_param_exploits.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/ref_type_param_exploits.mvir
 ---
 processed 10 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/release.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/release.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/release.mvir
 ---
 processed 2 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/resource_instantiate_bad_type.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/resource_instantiate_bad_type.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/resource_instantiate_bad_type.mvir
 ---
 processed 2 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/return_type_mismatch_and_unused_resource.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/return_type_mismatch_and_unused_resource.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/return_type_mismatch_and_unused_resource.mvir
 ---
 processed 6 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/signer_copy_loc.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/signer_copy_loc.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/signer_copy_loc.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/signer_copy_loc_transitive.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/signer_copy_loc_transitive.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/signer_copy_loc_transitive.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/signer_does_not_have_store.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/signer_does_not_have_store.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/signer_does_not_have_store.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/signer_equality.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/signer_equality.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/signer_equality.mvir
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/signer_read_ref.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/signer_read_ref.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/signer_read_ref.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/signer_read_ref_transitive.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/signer_read_ref_transitive.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/signer_read_ref_transitive.mvir
 ---
 processed 2 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/signer_st_loc.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/signer_st_loc.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/signer_st_loc.mvir
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/signer_transitive.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/signer_transitive.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/signer_transitive.mvir
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/signer_write_ref.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/signer_write_ref.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/signer_write_ref.mvir
 ---
 processed 1 task

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/struct_kind_inference.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/struct_kind_inference.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/struct_kind_inference.mvir
 ---
 processed 10 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/type_error_after_branch.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/type_error_after_branch.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/type_error_after_branch.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/unpack_generic_enum_non_generically.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/unpack_generic_enum_non_generically.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/unpack_generic_enum_non_generically.mvir
 ---
 processed 9 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/unpack_generic_enum_wrong_type_arg.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/unpack_generic_enum_wrong_type_arg.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/unpack_generic_enum_wrong_type_arg.mvir
 ---
 processed 9 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/unpack_non_generic_enum_generically.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/unpack_non_generic_enum_generically.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/unpack_non_generic_enum_generically.mvir
 ---
 processed 9 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/unpack_resource.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/unpack_resource.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/unpack_resource.mvir
 ---
 processed 4 tasks

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/unpack_wrong_type.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/unpack_wrong_type.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/unpack_wrong_type.mvir
 ---
 processed 2 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/unrestricted_instantiate.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/unrestricted_instantiate.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/unrestricted_instantiate.mvir
 ---
 processed 4 tasks

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/unrestricted_instantiate_bad_type.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/unrestricted_instantiate_bad_type.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/unrestricted_instantiate_bad_type.mvir
 ---
 processed 2 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/unused_resource_holder.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/unused_resource_holder.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/unused_resource_holder.mvir
 ---
 processed 4 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/variant_switch_invalid_head_type.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/variant_switch_invalid_head_type.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/variant_switch_invalid_head_type.mvir
 ---
 processed 11 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/variant_switch_partial_enum_switch.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/variant_switch_partial_enum_switch.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/variant_switch_partial_enum_switch.mvir
 ---
 processed 3 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/variant_switch_valid_head_type.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/variant_switch_valid_head_type.snap
@@ -1,5 +1,4 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/variant_switch_valid_head_type.mvir
 ---
 processed 3 tasks

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/vector_ops_type_mismatch.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/vector_ops_type_mismatch.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/vector_ops_type_mismatch.mvir
 ---
 processed 8 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/vector_pack_mismatch.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/vector_pack_mismatch.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/vector_pack_mismatch.mvir
 ---
 processed 4 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/vector_type_param.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/vector_type_param.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/vector_type_param.mvir
 ---
 processed 6 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/vector_type_param_exploits.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/vector_type_param_exploits.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/vector_type_param_exploits.mvir
 ---
 processed 4 tasks
 

--- a/external-crates/move/crates/move-docgen-tests/tests/move/code_block/a__m.md@collapsed_sections.snap
+++ b/external-crates/move/crates/move-docgen-tests/tests/move/code_block/a__m.md@collapsed_sections.snap
@@ -8,7 +8,6 @@ info:
   no_collapsed_sections: true
   include_dep_diagrams: false
   include_call_diagrams: false
-input_file: crates/move-docgen-tests/tests/move/code_block/Move.toml
 ---
 <a name="a_m"></a>
 

--- a/external-crates/move/crates/move-docgen-tests/tests/move/code_block/a__m.md@default.snap
+++ b/external-crates/move/crates/move-docgen-tests/tests/move/code_block/a__m.md@default.snap
@@ -8,7 +8,6 @@ info:
   no_collapsed_sections: false
   include_dep_diagrams: false
   include_call_diagrams: false
-input_file: crates/move-docgen-tests/tests/move/code_block/Move.toml
 ---
 <a name="a_m"></a>
 

--- a/external-crates/move/crates/move-docgen-tests/tests/move/different_visibilities/a__m.md@collapsed_sections.snap
+++ b/external-crates/move/crates/move-docgen-tests/tests/move/different_visibilities/a__m.md@collapsed_sections.snap
@@ -8,7 +8,6 @@ info:
   no_collapsed_sections: true
   include_dep_diagrams: false
   include_call_diagrams: false
-input_file: crates/move-docgen-tests/tests/move/different_visibilities/Move.toml
 ---
 <a name="a_TestViz"></a>
 

--- a/external-crates/move/crates/move-docgen-tests/tests/move/different_visibilities/a__m.md@default.snap
+++ b/external-crates/move/crates/move-docgen-tests/tests/move/different_visibilities/a__m.md@default.snap
@@ -8,7 +8,6 @@ info:
   no_collapsed_sections: false
   include_dep_diagrams: false
   include_call_diagrams: false
-input_file: crates/move-docgen-tests/tests/move/different_visibilities/Move.toml
 ---
 <a name="a_TestViz"></a>
 

--- a/external-crates/move/crates/move-docgen-tests/tests/move/enums/a__m.md@collapsed_sections.snap
+++ b/external-crates/move/crates/move-docgen-tests/tests/move/enums/a__m.md@collapsed_sections.snap
@@ -8,7 +8,6 @@ info:
   no_collapsed_sections: true
   include_dep_diagrams: false
   include_call_diagrams: false
-input_file: crates/move-docgen-tests/tests/move/enums/Move.toml
 ---
 <a name="a_m"></a>
 

--- a/external-crates/move/crates/move-docgen-tests/tests/move/enums/a__m.md@default.snap
+++ b/external-crates/move/crates/move-docgen-tests/tests/move/enums/a__m.md@default.snap
@@ -8,7 +8,6 @@ info:
   no_collapsed_sections: false
   include_dep_diagrams: false
   include_call_diagrams: false
-input_file: crates/move-docgen-tests/tests/move/enums/Move.toml
 ---
 <a name="a_m"></a>
 

--- a/external-crates/move/crates/move-docgen-tests/tests/move/root_template/root.md@collapsed_sections.snap
+++ b/external-crates/move/crates/move-docgen-tests/tests/move/root_template/root.md@collapsed_sections.snap
@@ -8,7 +8,6 @@ info:
   no_collapsed_sections: true
   include_dep_diagrams: false
   include_call_diagrams: false
-input_file: crates/move-docgen-tests/tests/move/root_template/Move.toml
 ---
 <a name="@A_Root_Documentation_Template_0"></a>
 

--- a/external-crates/move/crates/move-docgen-tests/tests/move/root_template/root.md@default.snap
+++ b/external-crates/move/crates/move-docgen-tests/tests/move/root_template/root.md@default.snap
@@ -8,7 +8,6 @@ info:
   no_collapsed_sections: false
   include_dep_diagrams: false
   include_call_diagrams: false
-input_file: crates/move-docgen-tests/tests/move/root_template/Move.toml
 ---
 <a name="@A_Root_Documentation_Template_0"></a>
 


### PR DESCRIPTION
## Description 

Remove `input_file: .*` from the snapshots as we no longer generate them for new snapshots, and we don't update them during normal snapshot testing since it's part of the metadata and not used for diff/testing purposes.

This will minimize diffs for the landing of `bella-ciao` and in general clean things up a a bit.

## Test plan 

CI 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
