### PR TITLE
graphql: better consistent watermark warnings

### DIFF
--- a/crates/sui-indexer-alt-consistent-api/src/proto/rpc/consistent/v1alpha/mod.rs
+++ b/crates/sui-indexer-alt-consistent-api/src/proto/rpc/consistent/v1alpha/mod.rs
@@ -8,9 +8,22 @@ include!("../../../generated/sui.rpc.consistent.v1alpha.rs");
 pub const FILE_DESCRIPTOR_SET: &[u8] =
     include_bytes!("../../../generated/sui.rpc.consistent.v1alpha.fds.bin");
 
-/// Metadata name used in requests to set the checkpoint to make the request at, and in responses
-/// to indicate the checkpoint at which the response was generated.
-pub const CHECKPOINT_METADATA: &str = "x-sui-checkpoint";
+/// Metadata name used in requests to set the checkpoint to make the request at.
+///
+/// Mirrors fullnode gRPC header naming in `sui-rpc`.
+pub const CHECKPOINT_HEIGHT_METADATA: &str = "x-sui-checkpoint-height";
+
+/// Metadata name used in responses to indicate the minimum checkpoint currently retained by
+/// consistent store.
+///
+/// Mirrors fullnode gRPC header naming in `sui-rpc`.
+pub const LOWEST_AVAILABLE_CHECKPOINT_METADATA: &str = "x-sui-lowest-available-checkpoint";
+
+/// Legacy metadata name for input checkpoints.
+///
+/// TODO(2026-03-09): Remove support for this legacy input header one release after introducing
+/// `x-sui-checkpoint-height`.
+pub const LEGACY_CHECKPOINT_METADATA: &str = "x-sui-checkpoint";
 
 #[cfg(test)]
 mod tests {

--- a/crates/sui-indexer-alt-consistent-store/src/rpc/consistent_service/mod.rs
+++ b/crates/sui-indexer-alt-consistent-store/src/rpc/consistent_service/mod.rs
@@ -12,7 +12,6 @@ use crate::rpc::consistent_service::list_objects_by_type::list_objects_by_type;
 use crate::rpc::consistent_service::list_owned_objects::list_owned_objects;
 use crate::rpc::consistent_service::service_config::service_config;
 use crate::rpc::state::State;
-use crate::rpc::state::checkpointed_response;
 
 mod available_range;
 mod balances;
@@ -26,62 +25,74 @@ impl ConsistentService for State {
         &self,
         request: tonic::Request<grpc::AvailableRangeRequest>,
     ) -> Result<tonic::Response<grpc::AvailableRangeResponse>, tonic::Status> {
-        let checkpoint = self.checkpoint(&request)?;
-        let response = available_range(self, checkpoint, request.into_inner())?;
-        Ok(checkpointed_response(checkpoint, response)?)
+        self.checkpointed_response(
+            self.checkpoint(&request)
+                .map_err(tonic::Status::from)
+                .and_then(|cp| Ok(available_range(self, cp, request.into_inner())?)),
+        )
     }
 
     async fn batch_get_balances(
         &self,
         request: tonic::Request<grpc::BatchGetBalancesRequest>,
     ) -> Result<tonic::Response<grpc::BatchGetBalancesResponse>, tonic::Status> {
-        let checkpoint = self.checkpoint(&request)?;
-        let response = batch_get_balances(self, checkpoint, request.into_inner())?;
-        Ok(checkpointed_response(checkpoint, response)?)
+        self.checkpointed_response(
+            self.checkpoint(&request)
+                .map_err(tonic::Status::from)
+                .and_then(|cp| Ok(batch_get_balances(self, cp, request.into_inner())?)),
+        )
     }
 
     async fn get_balance(
         &self,
         request: tonic::Request<grpc::GetBalanceRequest>,
     ) -> Result<tonic::Response<grpc::Balance>, tonic::Status> {
-        let checkpoint = self.checkpoint(&request)?;
-        let response = get_balance(self, checkpoint, request.into_inner())?;
-        Ok(checkpointed_response(checkpoint, response)?)
+        self.checkpointed_response(
+            self.checkpoint(&request)
+                .map_err(tonic::Status::from)
+                .and_then(|cp| Ok(get_balance(self, cp, request.into_inner())?)),
+        )
     }
 
     async fn list_balances(
         &self,
         request: tonic::Request<grpc::ListBalancesRequest>,
     ) -> Result<tonic::Response<grpc::ListBalancesResponse>, tonic::Status> {
-        let checkpoint = self.checkpoint(&request)?;
-        let response = list_balances(self, checkpoint, request.into_inner())?;
-        Ok(checkpointed_response(checkpoint, response)?)
+        self.checkpointed_response(
+            self.checkpoint(&request)
+                .map_err(tonic::Status::from)
+                .and_then(|cp| Ok(list_balances(self, cp, request.into_inner())?)),
+        )
     }
 
     async fn list_objects_by_type(
         &self,
         request: tonic::Request<grpc::ListObjectsByTypeRequest>,
     ) -> Result<tonic::Response<grpc::ListObjectsResponse>, tonic::Status> {
-        let checkpoint = self.checkpoint(&request)?;
-        let response = list_objects_by_type(self, checkpoint, request.into_inner())?;
-        Ok(checkpointed_response(checkpoint, response)?)
+        self.checkpointed_response(
+            self.checkpoint(&request)
+                .map_err(tonic::Status::from)
+                .and_then(|cp| Ok(list_objects_by_type(self, cp, request.into_inner())?)),
+        )
     }
 
     async fn list_owned_objects(
         &self,
         request: tonic::Request<grpc::ListOwnedObjectsRequest>,
     ) -> Result<tonic::Response<grpc::ListObjectsResponse>, tonic::Status> {
-        let checkpoint = self.checkpoint(&request)?;
-        let response = list_owned_objects(self, checkpoint, request.into_inner())?;
-        Ok(checkpointed_response(checkpoint, response)?)
+        self.checkpointed_response(
+            self.checkpoint(&request)
+                .map_err(tonic::Status::from)
+                .and_then(|cp| Ok(list_owned_objects(self, cp, request.into_inner())?)),
+        )
     }
 
     async fn service_config(
         &self,
         request: tonic::Request<grpc::ServiceConfigRequest>,
     ) -> Result<tonic::Response<grpc::ServiceConfigResponse>, tonic::Status> {
-        service_config(self, request.into_inner())
-            .map(tonic::Response::new)
-            .map_err(Into::into)
+        self.checkpointed_response(
+            service_config(self, request.into_inner()).map_err(tonic::Status::from),
+        )
     }
 }

--- a/crates/sui-indexer-alt-consistent-store/src/rpc/state.rs
+++ b/crates/sui-indexer-alt-consistent-store/src/rpc/state.rs
@@ -3,8 +3,9 @@
 
 use std::sync::Arc;
 
-use anyhow::Context;
-use sui_indexer_alt_consistent_api::proto::rpc::consistent::v1alpha::CHECKPOINT_METADATA;
+use sui_indexer_alt_consistent_api::proto::rpc::consistent::v1alpha::CHECKPOINT_HEIGHT_METADATA;
+use sui_indexer_alt_consistent_api::proto::rpc::consistent::v1alpha::LEGACY_CHECKPOINT_METADATA;
+use sui_indexer_alt_consistent_api::proto::rpc::consistent::v1alpha::LOWEST_AVAILABLE_CHECKPOINT_METADATA;
 use tonic::metadata::AsciiMetadataValue;
 
 use crate::config::ConsistencyConfig;
@@ -49,22 +50,62 @@ impl State {
         &self,
         request: &tonic::Request<T>,
     ) -> Result<u64, RpcError<Error>> {
-        let Some(checkpoint) = request.metadata().get(CHECKPOINT_METADATA) else {
+        let snapshot_range = self
+            .store
+            .db()
+            .snapshot_range(u64::MAX)
+            .ok_or(Error::NoSnapshots)?;
+
+        let metadata = request.metadata();
+        let Some(checkpoint) = metadata
+            .get(CHECKPOINT_HEIGHT_METADATA)
+            .or_else(|| metadata.get(LEGACY_CHECKPOINT_METADATA))
+        else {
             // If a checkpoint hasn't been supplied default to the latest snapshot.
-            return Ok(self
-                .store
-                .db()
-                .snapshot_range(u64::MAX)
-                .ok_or(Error::NoSnapshots)?
-                .end()
-                .checkpoint_hi_inclusive);
+            return Ok(snapshot_range.end().checkpoint_hi_inclusive);
         };
 
-        Ok(checkpoint
+        let checkpoint = checkpoint
             .to_str()
             .map_err(|_| Error::BadCheckpoint(checkpoint.clone()))?
             .parse()
-            .map_err(|_| Error::BadCheckpoint(checkpoint.clone()))?)
+            .map_err(|_| Error::BadCheckpoint(checkpoint.clone()))?;
+
+        if checkpoint < snapshot_range.start().checkpoint_hi_inclusive
+            || checkpoint > snapshot_range.end().checkpoint_hi_inclusive
+        {
+            return Err(RpcError::NotInRange(checkpoint));
+        }
+
+        Ok(checkpoint)
+    }
+
+    /// Convert a result into a `tonic::Response` and annotate it with checkpoint headers.
+    pub(super) fn checkpointed_response<T>(
+        &self,
+        result: Result<T, tonic::Status>,
+    ) -> Result<tonic::Response<T>, tonic::Status> {
+        let mut resp = result.map(tonic::Response::new);
+
+        let Some(range) = self.store.db().snapshot_range(u64::MAX) else {
+            return resp;
+        };
+
+        let meta = resp
+            .as_mut()
+            .map_or_else(|s| s.metadata_mut(), |r| r.metadata_mut());
+
+        if let Ok(min) = range.start().checkpoint_hi_inclusive.to_string().parse() {
+            meta.insert(LOWEST_AVAILABLE_CHECKPOINT_METADATA, min);
+        }
+
+        if let Ok(max) = range.end().checkpoint_hi_inclusive.to_string().parse() {
+            let max: AsciiMetadataValue = max;
+            meta.insert(CHECKPOINT_HEIGHT_METADATA, max.clone());
+            meta.insert(LEGACY_CHECKPOINT_METADATA, max);
+        }
+
+        resp
     }
 }
 
@@ -75,21 +116,4 @@ impl StatusCode for Error {
             Error::NoSnapshots => tonic::Code::Unavailable,
         }
     }
-}
-
-/// Convert `content` into a `tonic::Response` annotated with the checkpoint the data came from.
-pub(super) fn checkpointed_response<T>(
-    checkpoint: u64,
-    content: T,
-) -> Result<tonic::Response<T>, RpcError<Error>> {
-    let checkpoint = checkpoint
-        .to_string()
-        .parse()
-        .with_context(|| format!("Invalid checkpoint for metadata: {checkpoint}"))?;
-
-    let mut resp = tonic::Response::new(content);
-    let meta = resp.metadata_mut();
-    meta.insert(CHECKPOINT_METADATA, checkpoint);
-
-    Ok(resp)
 }

--- a/crates/sui-indexer-alt-e2e-tests/tests/consistent_store_address_balance_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/consistent_store_address_balance_tests.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 use std::str::FromStr;
 
 use sui_indexer_alt_consistent_api::proto::rpc::consistent::v1alpha::BatchGetBalancesRequest;
+use sui_indexer_alt_consistent_api::proto::rpc::consistent::v1alpha::CHECKPOINT_HEIGHT_METADATA;
 use sui_indexer_alt_consistent_api::proto::rpc::consistent::v1alpha::GetBalanceRequest;
 use sui_indexer_alt_consistent_api::proto::rpc::consistent::v1alpha::ListBalancesRequest;
 use sui_indexer_alt_consistent_api::proto::rpc::consistent::v1alpha::ListObjectsByTypeRequest;
@@ -714,7 +715,7 @@ async fn test_edge_cases() {
 
     request
         .metadata_mut()
-        .insert("x-sui-checkpoint", "10".parse().unwrap());
+        .insert(CHECKPOINT_HEIGHT_METADATA, "10".parse().unwrap());
 
     let err = client.list_balances(request).await.unwrap_err();
     assert_eq!(err.code(), tonic::Code::OutOfRange);
@@ -727,7 +728,7 @@ async fn test_edge_cases() {
 
     request
         .metadata_mut()
-        .insert("x-sui-checkpoint", "10".parse().unwrap());
+        .insert(CHECKPOINT_HEIGHT_METADATA, "10".parse().unwrap());
 
     let err = client.get_balance(request).await.unwrap_err();
     assert_eq!(err.code(), tonic::Code::OutOfRange);
@@ -1010,9 +1011,10 @@ impl BalanceCluster {
         });
 
         if let Some(checkpoint) = checkpoint {
-            request
-                .metadata_mut()
-                .insert("x-sui-checkpoint", checkpoint.to_string().parse().unwrap());
+            request.metadata_mut().insert(
+                CHECKPOINT_HEIGHT_METADATA,
+                checkpoint.to_string().parse().unwrap(),
+            );
         }
 
         let response = self.client.list_balances(request).await?.into_inner();
@@ -1048,9 +1050,10 @@ impl BalanceCluster {
         });
 
         if let Some(checkpoint) = checkpoint {
-            request
-                .metadata_mut()
-                .insert("x-sui-checkpoint", checkpoint.to_string().parse().unwrap());
+            request.metadata_mut().insert(
+                CHECKPOINT_HEIGHT_METADATA,
+                checkpoint.to_string().parse().unwrap(),
+            );
         }
 
         let response = self.client.get_balance(request).await?.into_inner();
@@ -1080,9 +1083,10 @@ impl BalanceCluster {
         });
 
         if let Some(checkpoint) = checkpoint {
-            request
-                .metadata_mut()
-                .insert("x-sui-checkpoint", checkpoint.to_string().parse().unwrap());
+            request.metadata_mut().insert(
+                CHECKPOINT_HEIGHT_METADATA,
+                checkpoint.to_string().parse().unwrap(),
+            );
         }
 
         Ok(self

--- a/crates/sui-indexer-alt-e2e-tests/tests/consistent_store_balance_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/consistent_store_balance_tests.rs
@@ -4,6 +4,7 @@
 use std::path::PathBuf;
 
 use sui_indexer_alt_consistent_api::proto::rpc::consistent::v1alpha::BatchGetBalancesRequest;
+use sui_indexer_alt_consistent_api::proto::rpc::consistent::v1alpha::CHECKPOINT_HEIGHT_METADATA;
 use sui_indexer_alt_consistent_api::proto::rpc::consistent::v1alpha::GetBalanceRequest;
 use sui_indexer_alt_consistent_api::proto::rpc::consistent::v1alpha::ListBalancesRequest;
 use sui_indexer_alt_consistent_api::proto::rpc::consistent::v1alpha::consistent_service_client::ConsistentServiceClient;
@@ -641,7 +642,7 @@ async fn test_edge_cases() {
 
     request
         .metadata_mut()
-        .insert("x-sui-checkpoint", "10".parse().unwrap());
+        .insert(CHECKPOINT_HEIGHT_METADATA, "10".parse().unwrap());
 
     let err = client.list_balances(request).await.unwrap_err();
     assert_eq!(err.code(), tonic::Code::OutOfRange);
@@ -654,7 +655,7 @@ async fn test_edge_cases() {
 
     request
         .metadata_mut()
-        .insert("x-sui-checkpoint", "10".parse().unwrap());
+        .insert(CHECKPOINT_HEIGHT_METADATA, "10".parse().unwrap());
 
     let err = client.get_balance(request).await.unwrap_err();
     assert_eq!(err.code(), tonic::Code::OutOfRange);
@@ -729,9 +730,10 @@ async fn list_balances(
     });
 
     if let Some(checkpoint) = checkpoint {
-        request
-            .metadata_mut()
-            .insert("x-sui-checkpoint", checkpoint.to_string().parse().unwrap());
+        request.metadata_mut().insert(
+            CHECKPOINT_HEIGHT_METADATA,
+            checkpoint.to_string().parse().unwrap(),
+        );
     }
 
     let response = client.list_balances(request).await?.into_inner();
@@ -771,9 +773,10 @@ async fn get_balance(
     });
 
     if let Some(checkpoint) = checkpoint {
-        request
-            .metadata_mut()
-            .insert("x-sui-checkpoint", checkpoint.to_string().parse().unwrap());
+        request.metadata_mut().insert(
+            CHECKPOINT_HEIGHT_METADATA,
+            checkpoint.to_string().parse().unwrap(),
+        );
     }
 
     let response = client.get_balance(request).await?.into_inner();
@@ -807,9 +810,10 @@ async fn batch_get_balances(
     });
 
     if let Some(checkpoint) = checkpoint {
-        request
-            .metadata_mut()
-            .insert("x-sui-checkpoint", checkpoint.to_string().parse().unwrap());
+        request.metadata_mut().insert(
+            CHECKPOINT_HEIGHT_METADATA,
+            checkpoint.to_string().parse().unwrap(),
+        );
     }
 
     Ok(client

--- a/crates/sui-indexer-alt-e2e-tests/tests/consistent_store_list_owned_objects_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/consistent_store_list_owned_objects_tests.rs
@@ -9,6 +9,7 @@ use move_core_types::u256::U256;
 use prometheus::Registry;
 use rand::rngs::OsRng;
 use simulacrum::Simulacrum;
+use sui_indexer_alt_consistent_api::proto::rpc::consistent::v1alpha::CHECKPOINT_HEIGHT_METADATA;
 use sui_indexer_alt_consistent_api::proto::rpc::consistent::v1alpha::ListOwnedObjectsRequest;
 use sui_indexer_alt_consistent_api::proto::rpc::consistent::v1alpha::Owner;
 use sui_indexer_alt_consistent_api::proto::rpc::consistent::v1alpha::consistent_service_client::ConsistentServiceClient;
@@ -67,9 +68,10 @@ async fn test_address_owner() {
         });
 
         if let Some(checkpoint) = checkpoint {
-            request
-                .metadata_mut()
-                .insert("x-sui-checkpoint", checkpoint.to_string().parse().unwrap());
+            request.metadata_mut().insert(
+                CHECKPOINT_HEIGHT_METADATA,
+                checkpoint.to_string().parse().unwrap(),
+            );
         }
 
         let response = client.list_owned_objects(request).await?.into_inner();

--- a/crates/sui-indexer-alt-e2e-tests/tests/consistent_store_range_metadata_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/consistent_store_range_metadata_tests.rs
@@ -1,0 +1,87 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use sui_indexer_alt_consistent_api::proto::rpc::consistent::v1alpha::AvailableRangeRequest;
+use sui_indexer_alt_consistent_api::proto::rpc::consistent::v1alpha::CHECKPOINT_HEIGHT_METADATA;
+use sui_indexer_alt_consistent_api::proto::rpc::consistent::v1alpha::LOWEST_AVAILABLE_CHECKPOINT_METADATA;
+use sui_indexer_alt_consistent_api::proto::rpc::consistent::v1alpha::consistent_service_client::ConsistentServiceClient;
+use sui_indexer_alt_e2e_tests::FullCluster;
+use tonic::metadata::AsciiMetadataValue;
+
+#[tokio::test]
+async fn test_checkpoint_bounds_metadata_on_success_response() {
+    let mut cluster = FullCluster::new().await.unwrap();
+    cluster.create_checkpoint().await;
+    cluster.create_checkpoint().await;
+    cluster.create_checkpoint().await;
+
+    let response = ConsistentServiceClient::connect(cluster.consistent_store_url().to_string())
+        .await
+        .unwrap()
+        .available_range(tonic::Request::new(AvailableRangeRequest {}))
+        .await
+        .unwrap();
+
+    assert_eq!(checkpoint_bounds(response.metadata()), (0, 3));
+}
+
+#[tokio::test]
+async fn test_checkpoint_bounds_metadata_on_non_out_of_range_status() {
+    let mut cluster = FullCluster::new().await.unwrap();
+    cluster.create_checkpoint().await;
+    cluster.create_checkpoint().await;
+
+    let mut request = tonic::Request::new(AvailableRangeRequest {});
+    request.metadata_mut().insert(
+        CHECKPOINT_HEIGHT_METADATA,
+        AsciiMetadataValue::from_static("not-a-number"),
+    );
+
+    let status = ConsistentServiceClient::connect(cluster.consistent_store_url().to_string())
+        .await
+        .unwrap()
+        .available_range(request)
+        .await
+        .unwrap_err();
+
+    assert_eq!(status.code(), tonic::Code::InvalidArgument);
+    assert_eq!(checkpoint_bounds(status.metadata()), (0, 2));
+}
+
+#[tokio::test]
+async fn test_checkpoint_bounds_metadata_on_out_of_range_status() {
+    let mut cluster = FullCluster::new().await.unwrap();
+    cluster.create_checkpoint().await;
+
+    let mut request = tonic::Request::new(AvailableRangeRequest {});
+    request.metadata_mut().insert(
+        CHECKPOINT_HEIGHT_METADATA,
+        AsciiMetadataValue::from_static("1000"),
+    );
+
+    let status = ConsistentServiceClient::connect(cluster.consistent_store_url().to_string())
+        .await
+        .unwrap()
+        .available_range(request)
+        .await
+        .unwrap_err();
+
+    assert_eq!(status.code(), tonic::Code::OutOfRange);
+    assert_eq!(checkpoint_bounds(status.metadata()), (0, 1));
+}
+
+fn checkpoint_bounds(metadata: &tonic::metadata::MetadataMap) -> (u64, u64) {
+    let min = metadata
+        .get(LOWEST_AVAILABLE_CHECKPOINT_METADATA)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap();
+
+    let max = metadata
+        .get(CHECKPOINT_HEIGHT_METADATA)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap();
+
+    (min, max)
+}

--- a/crates/sui-indexer-alt-graphql/src/task/watermark.rs
+++ b/crates/sui-indexer-alt-graphql/src/task/watermark.rs
@@ -21,11 +21,14 @@ use sui_indexer_alt_reader::bigtable_reader::BigtableReader;
 use sui_indexer_alt_reader::consistent_reader;
 use sui_indexer_alt_reader::consistent_reader::ConsistentReader;
 use sui_indexer_alt_reader::consistent_reader::proto::AvailableRangeResponse;
+use sui_indexer_alt_reader::consistent_reader::proto::CHECKPOINT_HEIGHT_METADATA;
+use sui_indexer_alt_reader::consistent_reader::proto::LOWEST_AVAILABLE_CHECKPOINT_METADATA;
 use sui_indexer_alt_reader::ledger_grpc_reader::LedgerGrpcReader;
 use sui_indexer_alt_reader::pg_reader::PgReader;
 use sui_sql_macro::query;
 use tokio::sync::RwLock;
 use tokio::time;
+use tonic::metadata::AsciiMetadataValue;
 use tracing::debug;
 use tracing::warn;
 
@@ -504,8 +507,30 @@ async fn watermark_from_consistent(
             tx_lo: 0,
         })),
 
-        Ok(_) => bail!("Missing data in consistent watermark"),
+        Ok(available_range) => {
+            bail!("Consistent watermark missing data: {available_range:?}");
+        }
+
+        Err(consistent_reader::Error::OutOfRange(status)) => {
+            let unknown = AsciiMetadataValue::from_static("<unknown>");
+
+            let min = status
+                .metadata()
+                .get(LOWEST_AVAILABLE_CHECKPOINT_METADATA)
+                .unwrap_or(&unknown);
+
+            let max = status
+                .metadata()
+                .get(CHECKPOINT_HEIGHT_METADATA)
+                .unwrap_or(&unknown);
+
+            bail!("{}: ({min:?}, {max:?})", status.message());
+        }
+
         Err(consistent_reader::Error::NotConfigured) => Ok(None),
-        Err(e) => Err(anyhow!(e).context("Failed to get consistent store watermarks")),
+
+        Err(e) => Err(anyhow!(e).context(format!(
+            "Failed to get consistent store watermarks at checkpoint {checkpoint}"
+        ))),
     }
 }

--- a/crates/sui-indexer-alt-reader/src/consistent_reader.rs
+++ b/crates/sui-indexer-alt-reader/src/consistent_reader.rs
@@ -357,7 +357,7 @@ impl ConsistentReader {
 
         if let Some(checkpoint) = checkpoint {
             request.metadata_mut().insert(
-                proto::CHECKPOINT_METADATA,
+                proto::CHECKPOINT_HEIGHT_METADATA,
                 checkpoint
                     .to_string()
                     .parse()


### PR DESCRIPTION
## Description

Improve the quality of the warning we produce when we fail to fetch an up-to-date watermark from the consistent store, because the other stores' watermarks fall outside the consistent range.

Previously, the error would just say that the consistent watermark was missing fields, but this was not really accurate. Now, the consistent store produces more data to help convey its range, and GraphQL's watermark task will use that information to produce an error:

- All ConsistentService methods will return an `OutOfRange` error if the requested checkpoint falls out of its consistent range.
- All responses include the consistent store's consistent range as metadata/response headers.

For convenience/consistency the header names have been aligned with the names used by Fullnode gRPC. `x-sui-checkpoint` (the previous header name) will be retained for backward compatibility, for one release.

## Test plan

New E2E tests for new headers and OutOfRange errors from consistent store:

```
$ cargo nextest run            \
  -p sui-indexer-alt-e2e-tests \
  --test consistent_store_range_metadata_tests
```

New error messages in GraphQL were manually tested:

```
... [snip] ...
2026-03-04T00:41:40.633197Z  WARN sui_indexer_alt_graphql::task::watermark: Failed to get consistent store watermark: Checkpoint 1000 not in the consistent range: ("1501", "2000")
... [snip] ...
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
