### PR TITLE
sccache-warmup: add missing commit_sha to failure notification

### DIFF
--- a/.github/workflows/sccache-warmup.yml
+++ b/.github/workflows/sccache-warmup.yml
@@ -242,6 +242,7 @@ jobs:
           event-type: nightly-build-failure
           client-payload: |-
             {
+              "commit_sha": "${{ github.sha }}",
               "run_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
               "run_id": "${{ github.run_id }}",
               "workflow_name": "${{ github.workflow }}",


### PR DESCRIPTION
## Summary
- The `nightly-build-failure-notify` workflow in sui-operations requires `commit_sha` in the dispatch payload, but `sccache-warmup.yml` was not sending it
- This caused every sccache warmup failure notification to fail validation (`Missing required field: commit_sha`), silently dropping the Slack alert
- Example failure: https://github.com/MystenLabs/sui-operations/actions/runs/22673386881
- The `nightly.yml` workflow already sends `commit_sha` correctly — this aligns `sccache-warmup.yml` with the same pattern

## Test plan
- [x] Verified `nightly.yml` sends `commit_sha` (existing working reference)
- [x] Verified the receiver (`nightly-build-failure-notify.yml`) validates `commit_sha` is non-empty
- [x] One-line addition of `"commit_sha": "${{ github.sha }}"` to the dispatch payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)