### PR TITLE
[bella-ciao] all the tests for VM values

### DIFF
--- a/external-crates/move/crates/move-vm-runtime/Cargo.toml
+++ b/external-crates/move/crates/move-vm-runtime/Cargo.toml
@@ -58,7 +58,7 @@ indexing_slicing = "warn"
 
 [features]
 default = []
-fuzzing = []
+fuzzing = ["move-core-types/fuzzing"]
 failpoints = ["fail/failpoints"]
 testing = []
 lazy_natives = []

--- a/external-crates/move/crates/move-vm-runtime/src/execution/values/values_impl.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/execution/values/values_impl.rs
@@ -3520,12 +3520,14 @@ impl GlobalValue {
 // -------------------------------------------------------------------------------------------------
 // Random generation of values that fit into a given layout.
 
-#[cfg(feature = "fuzzing")]
+#[cfg(all(test, feature = "fuzzing"))]
 pub mod prop {
     use super::*;
     use proptest::{collection::vec, prelude::*};
 
-    pub fn value_strategy_with_layout(layout: &MoveTypeLayout) -> impl Strategy<Value = Value> {
+    pub fn value_strategy_with_layout(
+        layout: &MoveTypeLayout,
+    ) -> impl Strategy<Value = Value> + use<> {
         use MoveTypeLayout as L;
 
         match layout {
@@ -3540,68 +3542,24 @@ pub mod prop {
             L::Signer => any::<AccountAddress>().prop_map(Value::signer).boxed(),
 
             L::Vector(layout) => match &**layout {
-                L::U8 => vec(any::<u8>(), 0..10)
-                    .prop_map(|vals| {
-                        Value(Value::Container(Container::VecU8(Rc::new(RefCell::new(
-                            vals,
-                        )))))
-                    })
-                    .boxed(),
-                L::U16 => vec(any::<u16>(), 0..10)
-                    .prop_map(|vals| {
-                        Value(Value::Container(Container::VecU16(Rc::new(RefCell::new(
-                            vals,
-                        )))))
-                    })
-                    .boxed(),
-                L::U32 => vec(any::<u32>(), 0..10)
-                    .prop_map(|vals| {
-                        Value(Value::Container(Container::VecU32(Rc::new(RefCell::new(
-                            vals,
-                        )))))
-                    })
-                    .boxed(),
-                L::U64 => vec(any::<u64>(), 0..10)
-                    .prop_map(|vals| {
-                        Value(Value::Container(Container::VecU64(Rc::new(RefCell::new(
-                            vals,
-                        )))))
-                    })
-                    .boxed(),
+                L::U8 => vec(any::<u8>(), 0..10).prop_map(Value::vector_u8).boxed(),
+                L::U16 => vec(any::<u16>(), 0..10).prop_map(Value::vector_u16).boxed(),
+                L::U32 => vec(any::<u32>(), 0..10).prop_map(Value::vector_u32).boxed(),
+                L::U64 => vec(any::<u64>(), 0..10).prop_map(Value::vector_u64).boxed(),
                 L::U128 => vec(any::<u128>(), 0..10)
-                    .prop_map(|vals| {
-                        Value(Value::Container(Container::VecU128(Rc::new(RefCell::new(
-                            vals,
-                        )))))
-                    })
+                    .prop_map(Value::vector_u128)
                     .boxed(),
                 L::U256 => vec(any::<u256::U256>(), 0..10)
-                    .prop_map(|vals| {
-                        Value(Value::Container(Container::VecU256(Rc::new(RefCell::new(
-                            vals,
-                        )))))
-                    })
+                    .prop_map(Value::vector_u256)
                     .boxed(),
                 L::Bool => vec(any::<bool>(), 0..10)
-                    .prop_map(|vals| {
-                        Value(Value::Container(Container::VecBool(Rc::new(RefCell::new(
-                            vals,
-                        )))))
-                    })
+                    .prop_map(Value::vector_bool)
                     .boxed(),
                 L::Address => vec(any::<AccountAddress>(), 0..10)
-                    .prop_map(|vals| {
-                        Value(Value::Container(Container::VecAddress(Rc::new(
-                            RefCell::new(vals),
-                        ))))
-                    })
+                    .prop_map(Value::vector_address)
                     .boxed(),
                 layout => vec(value_strategy_with_layout(layout), 0..10)
-                    .prop_map(|vals| {
-                        Value(Value::Container(Container::Vec(Rc::new(RefCell::new(
-                            vals.into_iter().map(|val| val.0).collect(),
-                        )))))
-                    })
+                    .prop_map(|vals| Value::Vec(vals.into_iter().map(MemBox::new).collect()))
                     .boxed(),
             },
 
@@ -3612,6 +3570,24 @@ pub mod prop {
                 .collect::<Vec<_>>()
                 .prop_map(move |vals| Value::struct_(Struct::pack(vals)))
                 .boxed(),
+
+            L::Enum(enum_layout) => {
+                let MoveEnumLayout(variants) = &**enum_layout;
+                let variant_strategies: Vec<_> = variants
+                    .iter()
+                    .enumerate()
+                    .map(|(tag, field_layouts)| {
+                        let tag = tag as u16;
+                        field_layouts
+                            .iter()
+                            .map(value_strategy_with_layout)
+                            .collect::<Vec<_>>()
+                            .prop_map(move |vals| Value::make_variant(tag, vals))
+                            .boxed()
+                    })
+                    .collect();
+                proptest::strategy::Union::new(variant_strategies).boxed()
+            }
         }
     }
 
@@ -3633,8 +3609,10 @@ pub mod prop {
         leaf.prop_recursive(8, 32, 2, |inner| {
             prop_oneof![
                 1 => inner.clone().prop_map(|layout| L::Vector(Box::new(layout))),
-                1 => vec(inner, 0..1).prop_map(|f_layouts| {
-                     L::Struct(MoveStructLayout::new(f_layouts))}),
+                1 => vec(inner.clone(), 0..1).prop_map(|f_layouts| {
+                     L::Struct(Box::new(MoveStructLayout::new(f_layouts)))}),
+                1 => vec(vec(inner, 0..3), 1..4).prop_map(|variant_layouts| {
+                     L::Enum(Box::new(MoveEnumLayout(Box::new(variant_layouts))))}),
             ]
         })
     }

--- a/external-crates/move/crates/move-vm-runtime/src/unit_tests/value_prop_tests.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/unit_tests/value_prop_tests.rs
@@ -2,11 +2,263 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::values::{Value, prop::layout_and_value_strategy};
-use move_core_types::runtime_value::MoveValue;
+use crate::execution::values::{prop::layout_and_value_strategy, *};
+use move_core_types::{runtime_value::MoveValue, u256::U256};
 use proptest::prelude::*;
 
+/// Generates a matched pair of raw u64 values tagged with a byte-width discriminant.
+/// Width is one of 1, 2, 4, 8, 16, 32 (the actual byte-width of the integer type).
+fn tagged_u64_pair() -> impl Strategy<Value = (u8, u64, u64)> {
+    prop_oneof![
+        Just(1u8),
+        Just(2u8),
+        Just(4u8),
+        Just(8u8),
+        Just(16u8),
+        Just(32u8),
+    ]
+    .prop_flat_map(|w| (Just(w), any::<u64>(), any::<u64>()))
+}
+
+/// Constructs an IntegerValue from a byte-width tag and raw u64 (truncated).
+fn make_int(width: u8, raw: u64) -> IntegerValue {
+    match width {
+        1 => IntegerValue::U8(raw as u8),
+        2 => IntegerValue::U16(raw as u16),
+        4 => IntegerValue::U32(raw as u32),
+        8 => IntegerValue::U64(raw),
+        16 => IntegerValue::U128(raw as u128),
+        32 => IntegerValue::U256(move_core_types::u256::U256::from(raw)),
+        _ => unreachable!("invalid byte-width: {width}"),
+    }
+}
+
+/// Constructs the zero IntegerValue for a given byte-width tag.
+fn make_zero(width: u8) -> IntegerValue {
+    make_int(width, 0)
+}
+
+/// Extracts the numeric value from an IntegerValue as u128.
+/// Safe for all widths since inputs are generated from u64 (results fit in u128).
+fn int_to_u128(v: IntegerValue) -> u128 {
+    match v {
+        IntegerValue::U8(x) => x as u128,
+        IntegerValue::U16(x) => x as u128,
+        IntegerValue::U32(x) => x as u128,
+        IntegerValue::U64(x) => x as u128,
+        IntegerValue::U128(x) => x,
+        IntegerValue::U256(x) => x.try_into().unwrap(),
+    }
+}
+
+/// Performs a native Rust checked arithmetic op on truncated values, returning
+/// the result as a u128 (None if overflow/div-by-zero). This serves as the
+/// reference implementation to compare VM results against.
+fn native_checked_op(width: u8, ra: u64, rb: u64, op: &str) -> Option<u128> {
+    match width {
+        1 => {
+            let (a, b) = (ra as u8, rb as u8);
+            match op {
+                "add" => a.checked_add(b).map(|v| v as u128),
+                "sub" => a.checked_sub(b).map(|v| v as u128),
+                "mul" => a.checked_mul(b).map(|v| v as u128),
+                "div" => a.checked_div(b).map(|v| v as u128),
+                "rem" => a.checked_rem(b).map(|v| v as u128),
+                _ => unreachable!(),
+            }
+        }
+        2 => {
+            let (a, b) = (ra as u16, rb as u16);
+            match op {
+                "add" => a.checked_add(b).map(|v| v as u128),
+                "sub" => a.checked_sub(b).map(|v| v as u128),
+                "mul" => a.checked_mul(b).map(|v| v as u128),
+                "div" => a.checked_div(b).map(|v| v as u128),
+                "rem" => a.checked_rem(b).map(|v| v as u128),
+                _ => unreachable!(),
+            }
+        }
+        4 => {
+            let (a, b) = (ra as u32, rb as u32);
+            match op {
+                "add" => a.checked_add(b).map(|v| v as u128),
+                "sub" => a.checked_sub(b).map(|v| v as u128),
+                "mul" => a.checked_mul(b).map(|v| v as u128),
+                "div" => a.checked_div(b).map(|v| v as u128),
+                "rem" => a.checked_rem(b).map(|v| v as u128),
+                _ => unreachable!(),
+            }
+        }
+        8 => {
+            let (a, b) = (ra, rb);
+            match op {
+                "add" => a.checked_add(b).map(|v| v as u128),
+                "sub" => a.checked_sub(b).map(|v| v as u128),
+                "mul" => a.checked_mul(b).map(|v| v as u128),
+                "div" => a.checked_div(b).map(|v| v as u128),
+                "rem" => a.checked_rem(b).map(|v| v as u128),
+                _ => unreachable!(),
+            }
+        }
+        16 => {
+            let (a, b) = (ra as u128, rb as u128);
+            match op {
+                "add" => a.checked_add(b),
+                "sub" => a.checked_sub(b),
+                "mul" => a.checked_mul(b),
+                "div" => a.checked_div(b),
+                "rem" => a.checked_rem(b),
+                _ => unreachable!(),
+            }
+        }
+        32 => {
+            let a = U256::from(ra);
+            let b = U256::from(rb);
+            match op {
+                "add" => a.checked_add(b).map(|r| r.try_into().unwrap()),
+                "sub" => a.checked_sub(b).map(|r| r.try_into().unwrap()),
+                "mul" => a.checked_mul(b).map(|r| r.try_into().unwrap()),
+                "div" => a.checked_div(b).map(|r| r.try_into().unwrap()),
+                "rem" => a.checked_rem(b).map(|r| r.try_into().unwrap()),
+                _ => unreachable!(),
+            }
+        }
+        _ => unreachable!(),
+    }
+}
+
+/// Performs a native Rust comparison on truncated values.
+fn native_cmp(width: u8, ra: u64, rb: u64, op: &str) -> bool {
+    match width {
+        1 => {
+            let (a, b) = (ra as u8, rb as u8);
+            match op {
+                "lt" => a < b,
+                "le" => a <= b,
+                "gt" => a > b,
+                "ge" => a >= b,
+                _ => unreachable!(),
+            }
+        }
+        2 => {
+            let (a, b) = (ra as u16, rb as u16);
+            match op {
+                "lt" => a < b,
+                "le" => a <= b,
+                "gt" => a > b,
+                "ge" => a >= b,
+                _ => unreachable!(),
+            }
+        }
+        4 => {
+            let (a, b) = (ra as u32, rb as u32);
+            match op {
+                "lt" => a < b,
+                "le" => a <= b,
+                "gt" => a > b,
+                "ge" => a >= b,
+                _ => unreachable!(),
+            }
+        }
+        8 => {
+            let (a, b) = (ra, rb);
+            match op {
+                "lt" => a < b,
+                "le" => a <= b,
+                "gt" => a > b,
+                "ge" => a >= b,
+                _ => unreachable!(),
+            }
+        }
+        16 => {
+            let (a, b) = (ra as u128, rb as u128);
+            match op {
+                "lt" => a < b,
+                "le" => a <= b,
+                "gt" => a > b,
+                "ge" => a >= b,
+                _ => unreachable!(),
+            }
+        }
+        32 => {
+            let (a, b) = (U256::from(ra), U256::from(rb));
+            match op {
+                "lt" => a < b,
+                "le" => a <= b,
+                "gt" => a > b,
+                "ge" => a >= b,
+                _ => unreachable!(),
+            }
+        }
+        _ => unreachable!(),
+    }
+}
+
+/// Performs a native Rust bitwise op on truncated values, returns as u128.
+fn native_bitwise(width: u8, ra: u64, rb: u64, op: &str) -> u128 {
+    match width {
+        1 => {
+            let (a, b) = (ra as u8, rb as u8);
+            (match op {
+                "or" => a | b,
+                "and" => a & b,
+                "xor" => a ^ b,
+                _ => unreachable!(),
+            }) as u128
+        }
+        2 => {
+            let (a, b) = (ra as u16, rb as u16);
+            (match op {
+                "or" => a | b,
+                "and" => a & b,
+                "xor" => a ^ b,
+                _ => unreachable!(),
+            }) as u128
+        }
+        4 => {
+            let (a, b) = (ra as u32, rb as u32);
+            (match op {
+                "or" => a | b,
+                "and" => a & b,
+                "xor" => a ^ b,
+                _ => unreachable!(),
+            }) as u128
+        }
+        8 => {
+            let (a, b) = (ra, rb);
+            (match op {
+                "or" => a | b,
+                "and" => a & b,
+                "xor" => a ^ b,
+                _ => unreachable!(),
+            }) as u128
+        }
+        16 => {
+            let (a, b) = (ra as u128, rb as u128);
+            match op {
+                "or" => a | b,
+                "and" => a & b,
+                "xor" => a ^ b,
+                _ => unreachable!(),
+            }
+        }
+        32 => {
+            let (a, b) = (U256::from(ra), U256::from(rb));
+            (match op {
+                "or" => a | b,
+                "and" => a & b,
+                "xor" => a ^ b,
+                _ => unreachable!(),
+            })
+            .try_into()
+            .unwrap()
+        }
+        _ => unreachable!(),
+    }
+}
+
 proptest! {
+    /// serialize -> deserialize round-trip for both VM values and MoveValues.
     #[test]
     fn serializer_round_trip((layout, value) in layout_and_value_strategy()) {
         let blob = value.typed_serialize(&layout).expect("must serialize");
@@ -14,12 +266,414 @@ proptest! {
         let value_deserialized = Value::simple_deserialize(&blob, &layout).expect("must deserialize");
         assert!(value.equals(&value_deserialized).unwrap());
 
-        let move_value = value.as_move_value(&layout);
+        let move_value = value.as_move_value(&layout).expect("must convert to MoveValue");
 
         let blob2 = move_value.simple_serialize().expect("must serialize");
         assert_eq!(blob, blob2);
 
         let move_value_deserialized = MoveValue::simple_deserialize(&blob2, &layout).expect("must deserialize.");
         assert_eq!(move_value, move_value_deserialized);
+    }
+
+    /// copy_value always produces an equal value.
+    #[test]
+    fn copy_value_preserves_equality((_layout, value) in layout_and_value_strategy()) {
+        let copy = value.copy_value();
+        assert!(value.equals(&copy).unwrap());
+    }
+
+    /// Every value equals itself.
+    #[test]
+    fn equals_is_reflexive((_, value) in layout_and_value_strategy()) {
+        assert!(value.equals(&value).unwrap());
+    }
+
+    /// a.equals(b) == b.equals(a) for any pair of equal values.
+    #[test]
+    fn equals_is_symmetric((_layout, a) in layout_and_value_strategy()) {
+        let b = a.copy_value();
+        let ab = a.equals(&b).unwrap();
+        let ba = b.equals(&a).unwrap();
+        assert_eq!(ab, ba);
+    }
+
+    /// Vector::pack -> unpack round-trip preserves all elements.
+    #[test]
+    fn vector_pack_unpack_round_trip(values in
+        proptest::collection::vec(any::<u64>(), 0..10)
+    ) {
+        let original_values: Vec<Value> = values.iter().map(|&v| Value::u64(v)).collect();
+        let packed = Vector::pack(
+            VectorSpecialization::U64,
+            original_values.iter().map(Value::copy_value),
+        ).unwrap();
+        let vec: Vector = VMValueCast::cast(packed).unwrap();
+        let unpacked = vec.unpack(
+            &crate::jit::execution::ast::Type::U64,
+            values.len() as u64,
+        ).unwrap();
+        assert_eq!(unpacked.len(), original_values.len());
+        for (a, b) in original_values.iter().zip(unpacked.iter()) {
+            assert!(a.equals(b).unwrap());
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Integer Arithmetic — VM matches native Rust
+    // -----------------------------------------------------------------------
+
+    /// Arithmetic between mismatched widths always errors (all width pairs).
+    #[test]
+    fn integer_type_mismatch_always_errors((w1, ra, _) in tagged_u64_pair(), w2 in prop_oneof![Just(1u8), Just(2u8), Just(4u8), Just(8u8), Just(16u8), Just(32u8)]) {
+        if w1 == w2 { return Ok(()); }
+        assert!(make_int(w1, ra).add_checked(make_int(w2, ra)).is_err());
+    }
+
+    // -----------------------------------------------------------------------
+    // Arithmetic Correctness — VM results match native Rust
+    // -----------------------------------------------------------------------
+
+    /// VM add matches native Rust checked_add (all widths).
+    #[test]
+    fn integer_add_matches_native((w, ra, rb) in tagged_u64_pair()) {
+        let vm_result = make_int(w, ra).add_checked(make_int(w, rb));
+        match native_checked_op(w, ra, rb, "add") {
+            Some(expected) => assert_eq!(int_to_u128(vm_result.unwrap()), expected),
+            None => assert!(vm_result.is_err()),
+        }
+    }
+
+    /// VM sub matches native Rust checked_sub (all widths).
+    #[test]
+    fn integer_sub_matches_native((w, ra, rb) in tagged_u64_pair()) {
+        let vm_result = make_int(w, ra).sub_checked(make_int(w, rb));
+        match native_checked_op(w, ra, rb, "sub") {
+            Some(expected) => assert_eq!(int_to_u128(vm_result.unwrap()), expected),
+            None => assert!(vm_result.is_err()),
+        }
+    }
+
+    /// VM mul matches native Rust checked_mul (all widths).
+    #[test]
+    fn integer_mul_matches_native((w, ra, rb) in tagged_u64_pair()) {
+        let vm_result = make_int(w, ra).mul_checked(make_int(w, rb));
+        match native_checked_op(w, ra, rb, "mul") {
+            Some(expected) => assert_eq!(int_to_u128(vm_result.unwrap()), expected),
+            None => assert!(vm_result.is_err()),
+        }
+    }
+
+    /// VM div matches native Rust checked_div (all widths).
+    #[test]
+    fn integer_div_matches_native((w, ra, rb) in tagged_u64_pair()) {
+        let vm_result = make_int(w, ra).div_checked(make_int(w, rb));
+        match native_checked_op(w, ra, rb, "div") {
+            Some(expected) => assert_eq!(int_to_u128(vm_result.unwrap()), expected),
+            None => assert!(vm_result.is_err()),
+        }
+    }
+
+    /// VM rem matches native Rust checked_rem (all widths).
+    #[test]
+    fn integer_rem_matches_native((w, ra, rb) in tagged_u64_pair()) {
+        let vm_result = make_int(w, ra).rem_checked(make_int(w, rb));
+        match native_checked_op(w, ra, rb, "rem") {
+            Some(expected) => assert_eq!(int_to_u128(vm_result.unwrap()), expected),
+            None => assert!(vm_result.is_err()),
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Bitwise Correctness — VM results match native Rust
+    // -----------------------------------------------------------------------
+
+    /// VM bit_or matches native Rust | (all widths).
+    #[test]
+    fn integer_bit_or_matches_native((w, ra, rb) in tagged_u64_pair()) {
+        let result = make_int(w, ra).bit_or(make_int(w, rb)).unwrap();
+        assert_eq!(int_to_u128(result), native_bitwise(w, ra, rb, "or"));
+    }
+
+    /// VM bit_and matches native Rust & (all widths).
+    #[test]
+    fn integer_bit_and_matches_native((w, ra, rb) in tagged_u64_pair()) {
+        let result = make_int(w, ra).bit_and(make_int(w, rb)).unwrap();
+        assert_eq!(int_to_u128(result), native_bitwise(w, ra, rb, "and"));
+    }
+
+    /// VM bit_xor matches native Rust ^ (all widths).
+    #[test]
+    fn integer_bit_xor_matches_native((w, ra, rb) in tagged_u64_pair()) {
+        let result = make_int(w, ra).bit_xor(make_int(w, rb)).unwrap();
+        assert_eq!(int_to_u128(result), native_bitwise(w, ra, rb, "xor"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Shift Correctness — VM results match native Rust
+    // -----------------------------------------------------------------------
+
+    /// VM shl matches native Rust << for valid shift amounts (all widths).
+    #[test]
+    fn integer_shl_matches_native((w, ra, _) in tagged_u64_pair(), n in 0..8u8) {
+        // n < 8 is always a valid shift for all widths (smallest is u8 = 8 bits).
+        let vm_result = make_int(w, ra).shl_checked(n).unwrap();
+        let expected: u128 = match w {
+            1 => ((ra as u8) << n) as u128,
+            2 => ((ra as u16) << n) as u128,
+            4 => ((ra as u32) << n) as u128,
+            8 => ((ra) << n) as u128,
+            16 => (ra as u128) << n,
+            32 => (U256::from(ra) << (n as u32)).try_into().unwrap(),
+            _ => unreachable!(),
+        };
+        assert_eq!(int_to_u128(vm_result), expected);
+    }
+
+    /// VM shr matches native Rust >> for valid shift amounts (all widths).
+    #[test]
+    fn integer_shr_matches_native((w, ra, _) in tagged_u64_pair(), n in 0..8u8) {
+        let vm_result = make_int(w, ra).shr_checked(n).unwrap();
+        let expected: u128 = match w {
+            1 => ((ra as u8) >> n) as u128,
+            2 => ((ra as u16) >> n) as u128,
+            4 => ((ra as u32) >> n) as u128,
+            8 => (ra >> n) as u128,
+            16 => (ra as u128) >> n,
+            32 => (U256::from(ra) >> n).try_into().unwrap(),
+            _ => unreachable!(),
+        };
+        assert_eq!(int_to_u128(vm_result), expected);
+    }
+
+    // -----------------------------------------------------------------------
+    // Comparison Correctness — VM results match native Rust
+    // -----------------------------------------------------------------------
+
+    /// VM lt matches native Rust < (all widths).
+    #[test]
+    fn integer_lt_matches_native((w, ra, rb) in tagged_u64_pair()) {
+        assert_eq!(make_int(w, ra).lt(make_int(w, rb)).unwrap(), native_cmp(w, ra, rb, "lt"));
+    }
+
+    /// VM le matches native Rust <= (all widths).
+    #[test]
+    fn integer_le_matches_native((w, ra, rb) in tagged_u64_pair()) {
+        assert_eq!(make_int(w, ra).le(make_int(w, rb)).unwrap(), native_cmp(w, ra, rb, "le"));
+    }
+
+    /// VM gt matches native Rust > (all widths).
+    #[test]
+    fn integer_gt_matches_native((w, ra, rb) in tagged_u64_pair()) {
+        assert_eq!(make_int(w, ra).gt(make_int(w, rb)).unwrap(), native_cmp(w, ra, rb, "gt"));
+    }
+
+    /// VM ge matches native Rust >= (all widths).
+    #[test]
+    fn integer_ge_matches_native((w, ra, rb) in tagged_u64_pair()) {
+        assert_eq!(make_int(w, ra).ge(make_int(w, rb)).unwrap(), native_cmp(w, ra, rb, "ge"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Casting Properties — Widening (every source type to every wider target)
+    // -----------------------------------------------------------------------
+
+    /// u8 widens to all larger types, preserving value.
+    #[test]
+    fn widening_u8_to_all(x in any::<u8>()) {
+        assert_eq!(IntegerValue::U8(x).cast_u16().unwrap(), x as u16);
+        assert_eq!(IntegerValue::U8(x).cast_u32().unwrap(), x as u32);
+        assert_eq!(IntegerValue::U8(x).cast_u64().unwrap(), x as u64);
+        assert_eq!(IntegerValue::U8(x).cast_u128().unwrap(), x as u128);
+        assert_eq!(IntegerValue::U8(x).cast_u256().unwrap(), U256::from(x as u64));
+    }
+
+    /// u16 widens to u32/u64/u128/u256.
+    #[test]
+    fn widening_u16_to_all(x in any::<u16>()) {
+        assert_eq!(IntegerValue::U16(x).cast_u32().unwrap(), x as u32);
+        assert_eq!(IntegerValue::U16(x).cast_u64().unwrap(), x as u64);
+        assert_eq!(IntegerValue::U16(x).cast_u128().unwrap(), x as u128);
+        assert_eq!(IntegerValue::U16(x).cast_u256().unwrap(), U256::from(x as u64));
+    }
+
+    /// u32 widens to u64/u128/u256.
+    #[test]
+    fn widening_u32_to_all(x in any::<u32>()) {
+        assert_eq!(IntegerValue::U32(x).cast_u64().unwrap(), x as u64);
+        assert_eq!(IntegerValue::U32(x).cast_u128().unwrap(), x as u128);
+        assert_eq!(IntegerValue::U32(x).cast_u256().unwrap(), U256::from(x as u64));
+    }
+
+    /// u64 widens to u128/u256.
+    #[test]
+    fn widening_u64_to_all(x in any::<u64>()) {
+        assert_eq!(IntegerValue::U64(x).cast_u128().unwrap(), x as u128);
+        assert_eq!(IntegerValue::U64(x).cast_u256().unwrap(), U256::from(x));
+    }
+
+    /// u128 widens to u256.
+    #[test]
+    fn widening_u128_to_u256(x in any::<u128>()) {
+        assert_eq!(IntegerValue::U128(x).cast_u256().unwrap(), U256::from(x));
+    }
+
+    // -----------------------------------------------------------------------
+    // Casting Properties — Narrowing (fails iff value exceeds target range)
+    // -----------------------------------------------------------------------
+
+    /// u16 -> u8: succeeds iff x <= u8::MAX.
+    #[test]
+    fn narrowing_u16_to_u8(x in any::<u16>()) {
+        let result = IntegerValue::U16(x).cast_u8();
+        if x <= u8::MAX as u16 { assert_eq!(result.unwrap(), x as u8); }
+        else { assert!(result.is_err()); }
+    }
+
+    /// u32 -> u8: succeeds iff x <= u8::MAX.
+    #[test]
+    fn narrowing_u32_to_u8(x in any::<u32>()) {
+        let result = IntegerValue::U32(x).cast_u8();
+        if x <= u8::MAX as u32 { assert_eq!(result.unwrap(), x as u8); }
+        else { assert!(result.is_err()); }
+    }
+
+    /// u32 -> u16: succeeds iff x <= u16::MAX.
+    #[test]
+    fn narrowing_u32_to_u16(x in any::<u32>()) {
+        let result = IntegerValue::U32(x).cast_u16();
+        if x <= u16::MAX as u32 { assert_eq!(result.unwrap(), x as u16); }
+        else { assert!(result.is_err()); }
+    }
+
+    /// u64 -> u8: succeeds iff x <= u8::MAX.
+    #[test]
+    fn narrowing_u64_to_u8(x in any::<u64>()) {
+        let result = IntegerValue::U64(x).cast_u8();
+        if x <= u8::MAX as u64 { assert_eq!(result.unwrap(), x as u8); }
+        else { assert!(result.is_err()); }
+    }
+
+    /// u64 -> u16: succeeds iff x <= u16::MAX.
+    #[test]
+    fn narrowing_u64_to_u16(x in any::<u64>()) {
+        let result = IntegerValue::U64(x).cast_u16();
+        if x <= u16::MAX as u64 { assert_eq!(result.unwrap(), x as u16); }
+        else { assert!(result.is_err()); }
+    }
+
+    /// u64 -> u32: succeeds iff x <= u32::MAX.
+    #[test]
+    fn narrowing_u64_to_u32(x in any::<u64>()) {
+        let result = IntegerValue::U64(x).cast_u32();
+        if x <= u32::MAX as u64 { assert_eq!(result.unwrap(), x as u32); }
+        else { assert!(result.is_err()); }
+    }
+
+    /// u128 -> u8: succeeds iff x <= u8::MAX.
+    #[test]
+    fn narrowing_u128_to_u8(x in any::<u128>()) {
+        let result = IntegerValue::U128(x).cast_u8();
+        if x <= u8::MAX as u128 { assert_eq!(result.unwrap(), x as u8); }
+        else { assert!(result.is_err()); }
+    }
+
+    /// u128 -> u16: succeeds iff x <= u16::MAX.
+    #[test]
+    fn narrowing_u128_to_u16(x in any::<u128>()) {
+        let result = IntegerValue::U128(x).cast_u16();
+        if x <= u16::MAX as u128 { assert_eq!(result.unwrap(), x as u16); }
+        else { assert!(result.is_err()); }
+    }
+
+    /// u128 -> u32: succeeds iff x <= u32::MAX.
+    #[test]
+    fn narrowing_u128_to_u32(x in any::<u128>()) {
+        let result = IntegerValue::U128(x).cast_u32();
+        if x <= u32::MAX as u128 { assert_eq!(result.unwrap(), x as u32); }
+        else { assert!(result.is_err()); }
+    }
+
+    /// u128 -> u64: succeeds iff x <= u64::MAX.
+    #[test]
+    fn narrowing_u128_to_u64(x in any::<u128>()) {
+        let result = IntegerValue::U128(x).cast_u64();
+        if x <= u64::MAX as u128 { assert_eq!(result.unwrap(), x as u64); }
+        else { assert!(result.is_err()); }
+    }
+
+    /// u256 -> u8: succeeds iff x <= u8::MAX.
+    #[test]
+    fn narrowing_u256_to_u8(raw in any::<u128>()) {
+        let x = U256::from(raw);
+        let result = IntegerValue::U256(x).cast_u8();
+        if raw <= u8::MAX as u128 { assert_eq!(result.unwrap(), raw as u8); }
+        else { assert!(result.is_err()); }
+    }
+
+    /// u256 -> u16: succeeds iff x <= u16::MAX.
+    #[test]
+    fn narrowing_u256_to_u16(raw in any::<u128>()) {
+        let x = U256::from(raw);
+        let result = IntegerValue::U256(x).cast_u16();
+        if raw <= u16::MAX as u128 { assert_eq!(result.unwrap(), raw as u16); }
+        else { assert!(result.is_err()); }
+    }
+
+    /// u256 -> u32: succeeds iff x <= u32::MAX.
+    #[test]
+    fn narrowing_u256_to_u32(raw in any::<u128>()) {
+        let x = U256::from(raw);
+        let result = IntegerValue::U256(x).cast_u32();
+        if raw <= u32::MAX as u128 { assert_eq!(result.unwrap(), raw as u32); }
+        else { assert!(result.is_err()); }
+    }
+
+    /// u256 -> u64: succeeds iff x <= u64::MAX.
+    #[test]
+    fn narrowing_u256_to_u64(raw in any::<u128>()) {
+        let x = U256::from(raw);
+        let result = IntegerValue::U256(x).cast_u64();
+        if raw <= u64::MAX as u128 { assert_eq!(result.unwrap(), raw as u64); }
+        else { assert!(result.is_err()); }
+    }
+
+    /// u256 -> u128: succeeds iff x <= u128::MAX.
+    #[test]
+    fn narrowing_u256_to_u128(raw in any::<u128>()) {
+        // Values constructed from u128 always fit, so also test above u128::MAX.
+        let x = U256::from(raw);
+        assert_eq!(IntegerValue::U256(x).cast_u128().unwrap(), raw);
+    }
+
+    /// u256 values above u128::MAX fail to narrow to u128.
+    #[test]
+    fn narrowing_u256_above_u128_max_fails(lo in any::<u128>(), hi in 1..=u128::MAX) {
+        // Construct a value > u128::MAX by setting high bits.
+        let x = U256::from(lo) + (U256::from(hi) << 128u32);
+        assert!(IntegerValue::U256(x).cast_u128().is_err());
+    }
+
+    // -----------------------------------------------------------------------
+    // Casting identity — casting to own width is always the identity.
+    // -----------------------------------------------------------------------
+
+    /// Casting to the same width always succeeds and is the identity.
+    #[test]
+    fn cast_same_width_is_identity((w, ra, _) in tagged_u64_pair()) {
+        let v = make_int(w, ra);
+        match w {
+            1 => { let x: u8 = VMValueCast::cast(v.into_value()).unwrap();
+                   assert_eq!(x, ra as u8); }
+            2 => { let x: u16 = VMValueCast::cast(v.into_value()).unwrap();
+                   assert_eq!(x, ra as u16); }
+            4 => { let x: u32 = VMValueCast::cast(v.into_value()).unwrap();
+                   assert_eq!(x, ra as u32); }
+            8 => { let x: u64 = VMValueCast::cast(v.into_value()).unwrap();
+                   assert_eq!(x, ra); }
+            16 => { let x: u128 = VMValueCast::cast(v.into_value()).unwrap();
+                    assert_eq!(x, ra as u128); }
+            32 => { assert!(v.cast_u256().is_ok()); }
+            _ => unreachable!(),
+        }
     }
 }

--- a/external-crates/move/crates/move-vm-runtime/src/unit_tests/value_tests.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/unit_tests/value_tests.rs
@@ -12,7 +12,7 @@ use crate::{
     jit::execution::ast::Type,
     shared::views::*,
 };
-use move_binary_format::errors::*;
+use move_binary_format::{errors::*, file_format::VariantTag};
 use move_core_types::{account_address::AccountAddress, runtime_value, u256::U256};
 
 #[cfg(test)]
@@ -352,4 +352,927 @@ fn signer_equivalence() -> PartialVMResult<()> {
     );
 
     Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Vector Operations — VectorRef push_back/pop/swap/len/borrow_elem on
+// PrimVec and Container (generic Vec) specializations.
+// ---------------------------------------------------------------------------
+
+/// push_back grows a PrimVec and the new element is readable via borrow_elem.
+#[test]
+fn vector_push_back_and_len_prim_vec() -> PartialVMResult<()> {
+    let v = MemBox::new(Value::vector_u8([1, 2, 3]));
+    let vr: VectorRef = VMValueCast::cast(v.as_ref_value())?;
+
+    assert!(vr.len(&Type::U8)?.equals(&Value::u64(3))?);
+
+    vr.push_back(Value::u8(4), &Type::U8, 100)?;
+    assert!(vr.len(&Type::U8)?.equals(&Value::u64(4))?);
+
+    let elem = vr.borrow_elem(3, &Type::U8)?;
+    let r: Reference = VMValueCast::cast(elem)?;
+    assert!(r.read_ref()?.equals(&Value::u8(4))?);
+
+    Ok(())
+}
+
+/// pop returns the last element and shrinks the vector by one.
+#[test]
+fn vector_pop_prim_vec() -> PartialVMResult<()> {
+    let v = MemBox::new(Value::vector_u64([10, 20, 30]));
+    let vr: VectorRef = VMValueCast::cast(v.as_ref_value())?;
+
+    let popped = vr.pop(&Type::U64)?;
+    assert!(popped.equals(&Value::u64(30))?);
+    assert!(vr.len(&Type::U64)?.equals(&Value::u64(2))?);
+
+    Ok(())
+}
+
+/// Popping an empty vector produces an error.
+#[test]
+fn vector_pop_empty_errors() -> PartialVMResult<()> {
+    let v = MemBox::new(Value::vector_u8([]));
+    let vr: VectorRef = VMValueCast::cast(v.as_ref_value())?;
+
+    assert!(vr.pop(&Type::U8).is_err());
+    Ok(())
+}
+
+/// swap exchanges two elements in a PrimVec.
+#[test]
+fn vector_swap_prim_vec() -> PartialVMResult<()> {
+    let v = MemBox::new(Value::vector_u64([10, 20, 30]));
+    let vr: VectorRef = VMValueCast::cast(v.as_ref_value())?;
+
+    vr.swap(0, 2, &Type::U64)?;
+
+    let r0: Reference = VMValueCast::cast(vr.borrow_elem(0, &Type::U64)?)?;
+    assert!(r0.read_ref()?.equals(&Value::u64(30))?);
+    let r2: Reference = VMValueCast::cast(vr.borrow_elem(2, &Type::U64)?)?;
+    assert!(r2.read_ref()?.equals(&Value::u64(10))?);
+
+    Ok(())
+}
+
+/// swap with an out-of-bounds index errors.
+#[test]
+fn vector_swap_out_of_bounds() -> PartialVMResult<()> {
+    let v = MemBox::new(Value::vector_u8([1, 2]));
+    let vr: VectorRef = VMValueCast::cast(v.as_ref_value())?;
+
+    assert!(vr.swap(0, 5, &Type::U8).is_err());
+    Ok(())
+}
+
+/// borrow_elem with an out-of-bounds index errors.
+#[test]
+fn vector_borrow_elem_out_of_bounds() -> PartialVMResult<()> {
+    let v = MemBox::new(Value::vector_u8([1]));
+    let vr: VectorRef = VMValueCast::cast(v.as_ref_value())?;
+
+    assert!(vr.borrow_elem(10, &Type::U8).is_err());
+    Ok(())
+}
+
+/// push_back/pop on the Container (non-primitive) specialization.
+#[test]
+fn vector_push_back_and_pop_container_vec() -> PartialVMResult<()> {
+    let inner1 = Value::vector_u8([1, 2, 3]);
+    let inner2 = Value::vector_u8([4, 5]);
+    let vec_val = Vector::pack(VectorSpecialization::Container, [inner1.copy_value()])?;
+    let v = MemBox::new(vec_val);
+    let vr: VectorRef = VMValueCast::cast(v.as_ref_value())?;
+
+    // Vector-of-vectors maps to Container specialization.
+    let ty = Type::Vector(Box::new(Type::U8));
+    vr.push_back(inner2.copy_value(), &ty, 100)?;
+    assert!(vr.len(&ty)?.equals(&Value::u64(2))?);
+
+    let popped = vr.pop(&ty)?;
+    assert!(popped.equals(&inner2)?);
+
+    Ok(())
+}
+
+/// Vector::pack followed by unpack preserves values for PrimVec (U64).
+#[test]
+fn vector_pack_unpack_prim() -> PartialVMResult<()> {
+    let packed = Vector::pack(VectorSpecialization::U64, [Value::u64(5), Value::u64(10)])?;
+    let vec: Vector = VMValueCast::cast(packed)?;
+    let unpacked = vec.unpack(&Type::U64, 2)?;
+
+    assert_eq!(unpacked.len(), 2);
+    assert!(unpacked[0].equals(&Value::u64(5))?);
+    assert!(unpacked[1].equals(&Value::u64(10))?);
+    Ok(())
+}
+
+/// unpack with a mismatched expected_num errors.
+#[test]
+fn vector_unpack_wrong_count_errors() -> PartialVMResult<()> {
+    let packed = Vector::pack(VectorSpecialization::U8, [Value::u8(1), Value::u8(2)])?;
+    let vec: Vector = VMValueCast::cast(packed)?;
+    assert!(vec.unpack(&Type::U8, 5).is_err());
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Variant Operations — Variant pack/unpack/check_tag and VariantRef
+// get_tag/check_tag/unpack_variant on borrowed variants.
+// ---------------------------------------------------------------------------
+
+/// Variant::pack -> unpack round-trip preserves tag and field values.
+#[test]
+fn variant_pack_unpack_round_trip() -> PartialVMResult<()> {
+    let tag: VariantTag = 1;
+    let fields = [Value::u64(42), Value::bool(true)];
+    let variant = Variant::pack(tag, fields.iter().map(Value::copy_value));
+
+    assert_eq!(variant.len(), 2);
+    variant.check_tag(1)?;
+
+    let unpacked: Vec<_> = variant.unpack().collect();
+    assert_eq!(unpacked.len(), 2);
+    assert!(unpacked[0].equals(&Value::u64(42))?);
+    assert!(unpacked[1].equals(&Value::bool(true))?);
+    Ok(())
+}
+
+/// check_tag succeeds on match, errors on mismatch.
+#[test]
+fn variant_check_tag_success_and_failure() -> PartialVMResult<()> {
+    let variant = Variant::pack(2, vec![Value::u8(10)]);
+    assert!(variant.check_tag(2).is_ok());
+    assert!(variant.check_tag(0).is_err());
+    Ok(())
+}
+
+/// VariantRef::get_tag reads the tag and unpack_variant yields field references.
+#[test]
+fn variant_ref_get_tag_and_unpack() -> PartialVMResult<()> {
+    let mut heap = MachineHeap::new();
+    let mut locals = heap.allocate_stack_frame(vec![], 1)?;
+
+    locals.store_loc(0, Value::make_variant(1, vec![Value::u64(99)]))?;
+    let vr: VariantRef = VMValueCast::cast(locals.borrow_loc(0)?)?;
+
+    assert_eq!(vr.get_tag()?, 1);
+
+    let field_refs = vr.unpack_variant()?;
+    assert_eq!(field_refs.len(), 1);
+    let r: Reference = VMValueCast::cast(field_refs.into_iter().next().unwrap())?;
+    assert!(r.read_ref()?.equals(&Value::u64(99))?);
+
+    Ok(())
+}
+
+/// VariantRef::check_tag errors when the tag doesn't match.
+#[test]
+fn variant_ref_check_tag_mismatch() -> PartialVMResult<()> {
+    let mut heap = MachineHeap::new();
+    let mut locals = heap.allocate_stack_frame(vec![], 1)?;
+
+    locals.store_loc(0, Value::make_variant(0, vec![Value::bool(false)]))?;
+    let vr: VariantRef = VMValueCast::cast(locals.borrow_loc(0)?)?;
+
+    assert!(vr.check_tag(5).is_err());
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// GlobalValue Lifecycle — empty/move_to/borrow_global/move_from/into_value.
+// (global_value_non_struct above covers the create-rejects-non-struct path.)
+// ---------------------------------------------------------------------------
+
+/// Full lifecycle: empty -> move_to -> borrow_global -> move_from -> empty.
+#[test]
+fn global_value_full_lifecycle() -> PartialVMResult<()> {
+    let mut gv = GlobalValue::empty();
+    assert!(!gv.exists()?);
+    assert!(gv.borrow_global().is_err());
+
+    let s = Value::make_struct(vec![Value::u64(100)]);
+    gv.move_to(s).unwrap();
+    assert!(gv.exists()?);
+    assert!(gv.borrow_global().is_ok());
+
+    // borrow_global returns a reference to the struct
+    let sr: StructRef = VMValueCast::cast(gv.borrow_global()?)?;
+    let f: Reference = VMValueCast::cast(sr.borrow_field(0)?)?;
+    assert!(f.read_ref()?.equals(&Value::u64(100))?);
+
+    // move_from extracts the value and empties the slot
+    let moved = gv.move_from()?;
+    assert!(!gv.exists()?);
+    assert!(moved.equals(&Value::make_struct(vec![Value::u64(100)]))?);
+    assert!(gv.borrow_global().is_err());
+
+    Ok(())
+}
+
+/// move_to on an already-occupied slot errors
+#[test]
+fn global_value_move_to_occupied_errors() -> PartialVMResult<()> {
+    let mut gv = GlobalValue::empty();
+    gv.move_to(Value::make_struct(vec![Value::u8(1)])).unwrap();
+
+    let result = gv.move_to(Value::make_struct(vec![Value::u8(2)]));
+    assert!(result.is_err());
+    Ok(())
+}
+
+/// into_value returns None for empty, Some(value) for filled.
+#[test]
+fn global_value_into_value() -> PartialVMResult<()> {
+    let gv_empty = GlobalValue::empty();
+    assert!(gv_empty.into_value()?.is_none());
+
+    let gv_filled = GlobalValue::create(Value::make_struct(vec![Value::u64(42)]))?;
+    let val = gv_filled.into_value()?;
+    assert!(
+        val.unwrap()
+            .equals(&Value::make_struct(vec![Value::u64(42)]))?
+    );
+    Ok(())
+}
+
+/// Writes through a borrow_global ref are visible when the value is moved out.
+#[test]
+fn global_value_borrow_global_write_through() -> PartialVMResult<()> {
+    let mut gv = GlobalValue::empty();
+    gv.move_to(Value::make_struct(vec![Value::u64(1)])).unwrap();
+
+    let borrow_ref: StructRef = VMValueCast::cast(gv.borrow_global()?)?;
+    let field_ref: Reference = VMValueCast::cast(borrow_ref.borrow_field(0)?)?;
+    field_ref.write_ref(Value::u64(999))?;
+
+    let moved = gv.move_from()?;
+    assert!(moved.equals(&Value::make_struct(vec![Value::u64(999)]))?);
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Indexed References — write_ref through Reference::Indexed (the variant
+// produced by VectorRef::borrow_elem on PrimVec elements).
+// ---------------------------------------------------------------------------
+
+/// Writing through an indexed ref updates the underlying PrimVec element.
+#[test]
+fn indexed_ref_write_ref_prim_vec() -> PartialVMResult<()> {
+    let v = MemBox::new(Value::vector_u8([10, 20, 30]));
+    let vr: VectorRef = VMValueCast::cast(v.as_ref_value())?;
+
+    let elem_ref: Reference = VMValueCast::cast(vr.borrow_elem(1, &Type::U8)?)?;
+    elem_ref.write_ref(Value::u8(99))?;
+
+    let elem_ref2: Reference = VMValueCast::cast(vr.borrow_elem(1, &Type::U8)?)?;
+    assert!(elem_ref2.read_ref()?.equals(&Value::u8(99))?);
+    Ok(())
+}
+
+/// Writing the wrong type through an indexed ref errors (u64 into u8 vec).
+#[test]
+fn indexed_ref_write_ref_type_mismatch() -> PartialVMResult<()> {
+    let v = MemBox::new(Value::vector_u8([10]));
+    let vr: VectorRef = VMValueCast::cast(v.as_ref_value())?;
+    let elem_ref: Reference = VMValueCast::cast(vr.borrow_elem(0, &Type::U8)?)?;
+
+    assert!(elem_ref.write_ref(Value::u64(999)).is_err());
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Deep Copy — copy_value produces an independent clone.
+// ---------------------------------------------------------------------------
+
+/// Mutating one copy of a struct doesn't affect the other.
+#[test]
+fn copy_value_deep_copy_semantics() -> PartialVMResult<()> {
+    let original = Value::make_struct(vec![Value::u64(10), Value::bool(true)]);
+    let copy = original.copy_value();
+
+    assert!(original.equals(&copy)?);
+
+    let mut heap = MachineHeap::new();
+    let mut locals = heap.allocate_stack_frame(vec![], 2)?;
+    locals.store_loc(0, original)?;
+    locals.store_loc(1, copy)?;
+
+    let sr: StructRef = VMValueCast::cast(locals.borrow_loc(0)?)?;
+    let f: Reference = VMValueCast::cast(sr.borrow_field(0)?)?;
+    f.write_ref(Value::u64(999))?;
+
+    let v0 = locals.move_loc(0)?;
+    let v1 = locals.move_loc(1)?;
+    assert!(!v0.equals(&v1)?);
+    assert!(v1.equals(&Value::make_struct(vec![Value::u64(10), Value::bool(true)]))?);
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Integer Arithmetic Boundary Conditions — overflow/underflow at every width.
+// ---------------------------------------------------------------------------
+
+/// u8 arithmetic boundaries: MAX+1 overflows, 0-1 underflows, MAX*2 overflows.
+#[test]
+fn integer_arithmetic_boundary_u8() -> PartialVMResult<()> {
+    // Addition overflow
+    assert!(
+        IntegerValue::U8(u8::MAX)
+            .add_checked(IntegerValue::U8(1))
+            .is_err()
+    );
+    // MAX + 0 succeeds
+    assert_eq!(
+        VMValueCast::<u8>::cast(
+            IntegerValue::U8(u8::MAX)
+                .add_checked(IntegerValue::U8(0))?
+                .into_value()
+        )?,
+        u8::MAX
+    );
+    // Subtraction underflow
+    assert!(
+        IntegerValue::U8(0)
+            .sub_checked(IntegerValue::U8(1))
+            .is_err()
+    );
+    // MAX - MAX = 0
+    assert_eq!(
+        VMValueCast::<u8>::cast(
+            IntegerValue::U8(u8::MAX)
+                .sub_checked(IntegerValue::U8(u8::MAX))?
+                .into_value()
+        )?,
+        0u8
+    );
+    // Multiplication overflow
+    assert!(
+        IntegerValue::U8(u8::MAX)
+            .mul_checked(IntegerValue::U8(2))
+            .is_err()
+    );
+    // MAX * 1 = MAX
+    assert_eq!(
+        VMValueCast::<u8>::cast(
+            IntegerValue::U8(u8::MAX)
+                .mul_checked(IntegerValue::U8(1))?
+                .into_value()
+        )?,
+        u8::MAX
+    );
+    // Division: MAX / 1 = MAX, div by zero errors
+    assert_eq!(
+        VMValueCast::<u8>::cast(
+            IntegerValue::U8(u8::MAX)
+                .div_checked(IntegerValue::U8(1))?
+                .into_value()
+        )?,
+        u8::MAX
+    );
+    assert!(
+        IntegerValue::U8(1)
+            .div_checked(IntegerValue::U8(0))
+            .is_err()
+    );
+    // Remainder: MAX % MAX = 0, rem by zero errors
+    assert_eq!(
+        VMValueCast::<u8>::cast(
+            IntegerValue::U8(u8::MAX)
+                .rem_checked(IntegerValue::U8(u8::MAX))?
+                .into_value()
+        )?,
+        0u8
+    );
+    assert!(
+        IntegerValue::U8(1)
+            .rem_checked(IntegerValue::U8(0))
+            .is_err()
+    );
+    Ok(())
+}
+
+/// u16 arithmetic boundaries.
+#[test]
+fn integer_arithmetic_boundary_u16() -> PartialVMResult<()> {
+    assert!(
+        IntegerValue::U16(u16::MAX)
+            .add_checked(IntegerValue::U16(1))
+            .is_err()
+    );
+    assert_eq!(
+        VMValueCast::<u16>::cast(
+            IntegerValue::U16(u16::MAX)
+                .add_checked(IntegerValue::U16(0))?
+                .into_value()
+        )?,
+        u16::MAX
+    );
+    assert!(
+        IntegerValue::U16(0)
+            .sub_checked(IntegerValue::U16(1))
+            .is_err()
+    );
+    assert_eq!(
+        VMValueCast::<u16>::cast(
+            IntegerValue::U16(u16::MAX)
+                .sub_checked(IntegerValue::U16(u16::MAX))?
+                .into_value()
+        )?,
+        0u16
+    );
+    assert!(
+        IntegerValue::U16(u16::MAX)
+            .mul_checked(IntegerValue::U16(2))
+            .is_err()
+    );
+    assert_eq!(
+        VMValueCast::<u16>::cast(
+            IntegerValue::U16(u16::MAX)
+                .mul_checked(IntegerValue::U16(1))?
+                .into_value()
+        )?,
+        u16::MAX
+    );
+    assert!(
+        IntegerValue::U16(1)
+            .div_checked(IntegerValue::U16(0))
+            .is_err()
+    );
+    assert!(
+        IntegerValue::U16(1)
+            .rem_checked(IntegerValue::U16(0))
+            .is_err()
+    );
+    Ok(())
+}
+
+/// u32 arithmetic boundaries.
+#[test]
+fn integer_arithmetic_boundary_u32() -> PartialVMResult<()> {
+    assert!(
+        IntegerValue::U32(u32::MAX)
+            .add_checked(IntegerValue::U32(1))
+            .is_err()
+    );
+    assert_eq!(
+        VMValueCast::<u32>::cast(
+            IntegerValue::U32(u32::MAX)
+                .add_checked(IntegerValue::U32(0))?
+                .into_value()
+        )?,
+        u32::MAX
+    );
+    assert!(
+        IntegerValue::U32(0)
+            .sub_checked(IntegerValue::U32(1))
+            .is_err()
+    );
+    assert_eq!(
+        VMValueCast::<u32>::cast(
+            IntegerValue::U32(u32::MAX)
+                .sub_checked(IntegerValue::U32(u32::MAX))?
+                .into_value()
+        )?,
+        0u32
+    );
+    assert!(
+        IntegerValue::U32(u32::MAX)
+            .mul_checked(IntegerValue::U32(2))
+            .is_err()
+    );
+    assert_eq!(
+        VMValueCast::<u32>::cast(
+            IntegerValue::U32(u32::MAX)
+                .mul_checked(IntegerValue::U32(1))?
+                .into_value()
+        )?,
+        u32::MAX
+    );
+    assert!(
+        IntegerValue::U32(1)
+            .div_checked(IntegerValue::U32(0))
+            .is_err()
+    );
+    assert!(
+        IntegerValue::U32(1)
+            .rem_checked(IntegerValue::U32(0))
+            .is_err()
+    );
+    Ok(())
+}
+
+/// u64 arithmetic boundaries.
+#[test]
+fn integer_arithmetic_boundary_u64() -> PartialVMResult<()> {
+    assert!(
+        IntegerValue::U64(u64::MAX)
+            .add_checked(IntegerValue::U64(1))
+            .is_err()
+    );
+    assert_eq!(
+        VMValueCast::<u64>::cast(
+            IntegerValue::U64(u64::MAX)
+                .add_checked(IntegerValue::U64(0))?
+                .into_value()
+        )?,
+        u64::MAX
+    );
+    assert!(
+        IntegerValue::U64(0)
+            .sub_checked(IntegerValue::U64(1))
+            .is_err()
+    );
+    assert_eq!(
+        VMValueCast::<u64>::cast(
+            IntegerValue::U64(u64::MAX)
+                .sub_checked(IntegerValue::U64(u64::MAX))?
+                .into_value()
+        )?,
+        0u64
+    );
+    assert!(
+        IntegerValue::U64(u64::MAX)
+            .mul_checked(IntegerValue::U64(2))
+            .is_err()
+    );
+    assert_eq!(
+        VMValueCast::<u64>::cast(
+            IntegerValue::U64(u64::MAX)
+                .mul_checked(IntegerValue::U64(1))?
+                .into_value()
+        )?,
+        u64::MAX
+    );
+    assert!(
+        IntegerValue::U64(1)
+            .div_checked(IntegerValue::U64(0))
+            .is_err()
+    );
+    assert!(
+        IntegerValue::U64(1)
+            .rem_checked(IntegerValue::U64(0))
+            .is_err()
+    );
+    Ok(())
+}
+
+/// u128 arithmetic boundaries.
+#[test]
+fn integer_arithmetic_boundary_u128() -> PartialVMResult<()> {
+    assert!(
+        IntegerValue::U128(u128::MAX)
+            .add_checked(IntegerValue::U128(1))
+            .is_err()
+    );
+    assert_eq!(
+        VMValueCast::<u128>::cast(
+            IntegerValue::U128(u128::MAX)
+                .add_checked(IntegerValue::U128(0))?
+                .into_value()
+        )?,
+        u128::MAX
+    );
+    assert!(
+        IntegerValue::U128(0)
+            .sub_checked(IntegerValue::U128(1))
+            .is_err()
+    );
+    assert_eq!(
+        VMValueCast::<u128>::cast(
+            IntegerValue::U128(u128::MAX)
+                .sub_checked(IntegerValue::U128(u128::MAX))?
+                .into_value()
+        )?,
+        0u128
+    );
+    assert!(
+        IntegerValue::U128(u128::MAX)
+            .mul_checked(IntegerValue::U128(2))
+            .is_err()
+    );
+    assert_eq!(
+        VMValueCast::<u128>::cast(
+            IntegerValue::U128(u128::MAX)
+                .mul_checked(IntegerValue::U128(1))?
+                .into_value()
+        )?,
+        u128::MAX
+    );
+    assert!(
+        IntegerValue::U128(1)
+            .div_checked(IntegerValue::U128(0))
+            .is_err()
+    );
+    assert!(
+        IntegerValue::U128(1)
+            .rem_checked(IntegerValue::U128(0))
+            .is_err()
+    );
+    Ok(())
+}
+
+/// u256 arithmetic boundaries.
+#[test]
+fn integer_arithmetic_boundary_u256() -> PartialVMResult<()> {
+    assert!(
+        IntegerValue::U256(U256::max_value())
+            .add_checked(IntegerValue::U256(U256::from(1u64)))
+            .is_err()
+    );
+    assert_eq!(
+        IntegerValue::U256(U256::max_value())
+            .add_checked(IntegerValue::U256(U256::zero()))?
+            .cast_u256()?,
+        U256::max_value()
+    );
+    assert!(
+        IntegerValue::U256(U256::zero())
+            .sub_checked(IntegerValue::U256(U256::from(1u64)))
+            .is_err()
+    );
+    assert_eq!(
+        IntegerValue::U256(U256::max_value())
+            .sub_checked(IntegerValue::U256(U256::max_value()))?
+            .cast_u256()?,
+        U256::zero()
+    );
+    assert!(
+        IntegerValue::U256(U256::max_value())
+            .mul_checked(IntegerValue::U256(U256::from(2u64)))
+            .is_err()
+    );
+    assert_eq!(
+        IntegerValue::U256(U256::max_value())
+            .mul_checked(IntegerValue::U256(U256::from(1u64)))?
+            .cast_u256()?,
+        U256::max_value()
+    );
+    assert!(
+        IntegerValue::U256(U256::from(1u64))
+            .div_checked(IntegerValue::U256(U256::zero()))
+            .is_err()
+    );
+    assert!(
+        IntegerValue::U256(U256::from(1u64))
+            .rem_checked(IntegerValue::U256(U256::zero()))
+            .is_err()
+    );
+    Ok(())
+}
+
+/// Shift overflow at exact bit-width boundary for every integer type.
+#[test]
+fn integer_shift_boundary_all_widths() -> PartialVMResult<()> {
+    // Shifting by exactly the bit-width errors; shifting by bit-width - 1 succeeds.
+    assert!(IntegerValue::U8(1).shl_checked(8).is_err());
+    assert!(IntegerValue::U8(1).shl_checked(7).is_ok());
+    assert!(IntegerValue::U16(1).shl_checked(16).is_err());
+    assert!(IntegerValue::U16(1).shl_checked(15).is_ok());
+    assert!(IntegerValue::U32(1).shl_checked(32).is_err());
+    assert!(IntegerValue::U32(1).shl_checked(31).is_ok());
+    assert!(IntegerValue::U64(1).shl_checked(64).is_err());
+    assert!(IntegerValue::U64(1).shl_checked(63).is_ok());
+    assert!(IntegerValue::U128(1).shl_checked(128).is_err());
+    assert!(IntegerValue::U128(1).shl_checked(127).is_ok());
+    // U256 has 256 bits but shift amount is u8 (max 255), so max valid shift is 255.
+    assert!(
+        IntegerValue::U256(U256::from(1u64))
+            .shl_checked(255)
+            .is_ok()
+    );
+    // Same for shr
+    assert!(IntegerValue::U8(1).shr_checked(8).is_err());
+    assert!(IntegerValue::U8(1).shr_checked(7).is_ok());
+    assert!(IntegerValue::U16(1).shr_checked(16).is_err());
+    assert!(IntegerValue::U64(1).shr_checked(64).is_err());
+    assert!(IntegerValue::U128(1).shr_checked(128).is_err());
+    assert!(
+        IntegerValue::U256(U256::from(1u64))
+            .shr_checked(255)
+            .is_ok()
+    );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Integer Cast Boundary Conditions — exact MAX/MAX+1 at every type boundary.
+// ---------------------------------------------------------------------------
+
+/// Casting exactly T::MAX to a wider type succeeds; T::MAX+1 in a narrower cast fails.
+#[test]
+fn integer_cast_boundary_u8() -> PartialVMResult<()> {
+    // u8::MAX fits in all wider types
+    assert_eq!(IntegerValue::U8(u8::MAX).cast_u16()?, u8::MAX as u16);
+    assert_eq!(IntegerValue::U8(u8::MAX).cast_u32()?, u8::MAX as u32);
+    assert_eq!(IntegerValue::U8(u8::MAX).cast_u64()?, u8::MAX as u64);
+    assert_eq!(IntegerValue::U8(u8::MAX).cast_u128()?, u8::MAX as u128);
+    assert_eq!(
+        IntegerValue::U8(u8::MAX).cast_u256()?,
+        U256::from(u8::MAX as u64)
+    );
+    // u8::MAX cast back to u8 succeeds (identity)
+    assert_eq!(IntegerValue::U8(u8::MAX).cast_u8()?, u8::MAX);
+    // 0 always succeeds
+    assert_eq!(IntegerValue::U8(0).cast_u8()?, 0u8);
+    Ok(())
+}
+
+/// u16 boundary: MAX fits in wider types, MAX narrows to u8 fails.
+#[test]
+fn integer_cast_boundary_u16() -> PartialVMResult<()> {
+    assert_eq!(IntegerValue::U16(u16::MAX).cast_u32()?, u16::MAX as u32);
+    assert_eq!(IntegerValue::U16(u16::MAX).cast_u64()?, u16::MAX as u64);
+    assert_eq!(IntegerValue::U16(u16::MAX).cast_u128()?, u16::MAX as u128);
+    assert_eq!(
+        IntegerValue::U16(u16::MAX).cast_u256()?,
+        U256::from(u16::MAX as u64)
+    );
+    assert_eq!(IntegerValue::U16(u16::MAX).cast_u16()?, u16::MAX);
+    // u16::MAX > u8::MAX → narrowing fails
+    assert!(IntegerValue::U16(u16::MAX).cast_u8().is_err());
+    // u8::MAX as u16 → narrowing succeeds
+    assert_eq!(IntegerValue::U16(u8::MAX as u16).cast_u8()?, u8::MAX);
+    // u8::MAX + 1 as u16 → narrowing fails
+    assert!(IntegerValue::U16(u8::MAX as u16 + 1).cast_u8().is_err());
+    Ok(())
+}
+
+/// u32 boundary: MAX fits in wider types, narrowing to u8/u16 fails at boundary.
+#[test]
+fn integer_cast_boundary_u32() -> PartialVMResult<()> {
+    assert_eq!(IntegerValue::U32(u32::MAX).cast_u64()?, u32::MAX as u64);
+    assert_eq!(IntegerValue::U32(u32::MAX).cast_u128()?, u32::MAX as u128);
+    assert_eq!(
+        IntegerValue::U32(u32::MAX).cast_u256()?,
+        U256::from(u32::MAX as u64)
+    );
+    assert_eq!(IntegerValue::U32(u32::MAX).cast_u32()?, u32::MAX);
+    // Narrowing failures
+    assert!(IntegerValue::U32(u32::MAX).cast_u8().is_err());
+    assert!(IntegerValue::U32(u32::MAX).cast_u16().is_err());
+    // Exact boundary: u16::MAX fits, u16::MAX+1 doesn't
+    assert_eq!(IntegerValue::U32(u16::MAX as u32).cast_u16()?, u16::MAX);
+    assert!(IntegerValue::U32(u16::MAX as u32 + 1).cast_u16().is_err());
+    assert_eq!(IntegerValue::U32(u8::MAX as u32).cast_u8()?, u8::MAX);
+    assert!(IntegerValue::U32(u8::MAX as u32 + 1).cast_u8().is_err());
+    Ok(())
+}
+
+/// u64 boundary: MAX fits in u128/u256, narrowing to u8/u16/u32 fails at boundary.
+#[test]
+fn integer_cast_boundary_u64() -> PartialVMResult<()> {
+    assert_eq!(IntegerValue::U64(u64::MAX).cast_u128()?, u64::MAX as u128);
+    assert_eq!(
+        IntegerValue::U64(u64::MAX).cast_u256()?,
+        U256::from(u64::MAX)
+    );
+    assert_eq!(IntegerValue::U64(u64::MAX).cast_u64()?, u64::MAX);
+    // Narrowing failures at MAX
+    assert!(IntegerValue::U64(u64::MAX).cast_u8().is_err());
+    assert!(IntegerValue::U64(u64::MAX).cast_u16().is_err());
+    assert!(IntegerValue::U64(u64::MAX).cast_u32().is_err());
+    // Exact boundaries
+    assert_eq!(IntegerValue::U64(u32::MAX as u64).cast_u32()?, u32::MAX);
+    assert!(IntegerValue::U64(u32::MAX as u64 + 1).cast_u32().is_err());
+    assert_eq!(IntegerValue::U64(u16::MAX as u64).cast_u16()?, u16::MAX);
+    assert!(IntegerValue::U64(u16::MAX as u64 + 1).cast_u16().is_err());
+    assert_eq!(IntegerValue::U64(u8::MAX as u64).cast_u8()?, u8::MAX);
+    assert!(IntegerValue::U64(u8::MAX as u64 + 1).cast_u8().is_err());
+    Ok(())
+}
+
+/// u128 boundary: MAX fits in u256, narrowing to all smaller types fails at boundary.
+#[test]
+fn integer_cast_boundary_u128() -> PartialVMResult<()> {
+    assert_eq!(
+        IntegerValue::U128(u128::MAX).cast_u256()?,
+        U256::from(u128::MAX)
+    );
+    assert_eq!(IntegerValue::U128(u128::MAX).cast_u128()?, u128::MAX);
+    // Narrowing failures at MAX
+    assert!(IntegerValue::U128(u128::MAX).cast_u8().is_err());
+    assert!(IntegerValue::U128(u128::MAX).cast_u16().is_err());
+    assert!(IntegerValue::U128(u128::MAX).cast_u32().is_err());
+    assert!(IntegerValue::U128(u128::MAX).cast_u64().is_err());
+    // Exact boundaries
+    assert_eq!(IntegerValue::U128(u64::MAX as u128).cast_u64()?, u64::MAX);
+    assert!(IntegerValue::U128(u64::MAX as u128 + 1).cast_u64().is_err());
+    assert_eq!(IntegerValue::U128(u32::MAX as u128).cast_u32()?, u32::MAX);
+    assert!(IntegerValue::U128(u32::MAX as u128 + 1).cast_u32().is_err());
+    assert_eq!(IntegerValue::U128(u16::MAX as u128).cast_u16()?, u16::MAX);
+    assert!(IntegerValue::U128(u16::MAX as u128 + 1).cast_u16().is_err());
+    assert_eq!(IntegerValue::U128(u8::MAX as u128).cast_u8()?, u8::MAX);
+    assert!(IntegerValue::U128(u8::MAX as u128 + 1).cast_u8().is_err());
+    Ok(())
+}
+
+/// u256 boundary: narrowing to all smaller types fails for values above their MAX.
+#[test]
+fn integer_cast_boundary_u256() -> PartialVMResult<()> {
+    // Identity
+    assert!(IntegerValue::U256(U256::max_value()).cast_u256().is_ok());
+    assert_eq!(IntegerValue::U256(U256::zero()).cast_u256()?, U256::zero());
+    // Narrowing failures at MAX+1
+    assert!(
+        IntegerValue::U256(U256::from(u128::MAX) + U256::from(1u64))
+            .cast_u128()
+            .is_err()
+    );
+    assert!(
+        IntegerValue::U256(U256::from(u64::MAX) + U256::from(1u64))
+            .cast_u64()
+            .is_err()
+    );
+    assert!(
+        IntegerValue::U256(U256::from(u32::MAX as u64) + U256::from(1u64))
+            .cast_u32()
+            .is_err()
+    );
+    assert!(
+        IntegerValue::U256(U256::from(u16::MAX as u64) + U256::from(1u64))
+            .cast_u16()
+            .is_err()
+    );
+    assert!(
+        IntegerValue::U256(U256::from(u8::MAX as u64) + U256::from(1u64))
+            .cast_u8()
+            .is_err()
+    );
+    // Exact MAX fits
+    assert_eq!(
+        IntegerValue::U256(U256::from(u128::MAX)).cast_u128()?,
+        u128::MAX
+    );
+    assert_eq!(
+        IntegerValue::U256(U256::from(u64::MAX)).cast_u64()?,
+        u64::MAX
+    );
+    assert_eq!(
+        IntegerValue::U256(U256::from(u32::MAX as u64)).cast_u32()?,
+        u32::MAX
+    );
+    assert_eq!(
+        IntegerValue::U256(U256::from(u16::MAX as u64)).cast_u16()?,
+        u16::MAX
+    );
+    assert_eq!(
+        IntegerValue::U256(U256::from(u8::MAX as u64)).cast_u8()?,
+        u8::MAX
+    );
+    // Zero always works
+    assert_eq!(IntegerValue::U256(U256::zero()).cast_u8()?, 0u8);
+    assert_eq!(IntegerValue::U256(U256::zero()).cast_u128()?, 0u128);
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// VMValueCast Error Paths — casting to incompatible types.
+// ---------------------------------------------------------------------------
+
+/// Primitives cannot be cast to unrelated types (u64 -> Struct, etc.).
+#[test]
+fn cast_wrong_type_errors() {
+    assert!(VMValueCast::<Struct>::cast(Value::u64(0)).is_err());
+    assert!(VMValueCast::<u8>::cast(Value::bool(true)).is_err());
+    assert!(VMValueCast::<u64>::cast(Value::address(AccountAddress::ZERO)).is_err());
+}
+
+/// An indexed ref (into a PrimVec) cannot be cast to StructRef.
+#[test]
+fn cast_indexed_ref_to_struct_ref_errors() -> PartialVMResult<()> {
+    let v = MemBox::new(Value::vector_u8([1, 2, 3]));
+    let vr: VectorRef = VMValueCast::cast(v.as_ref_value())?;
+    let elem = vr.borrow_elem(0, &Type::U8)?;
+
+    assert!(VMValueCast::<StructRef>::cast(elem).is_err());
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// VectorSpecialization — TryFrom<&Type> mapping.
+// ---------------------------------------------------------------------------
+
+/// Each Type maps to the expected specialization; ref/typaram types error.
+#[test]
+fn vector_specialization_from_type() {
+    use VectorSpecialization as VS;
+
+    assert!(matches!(VS::try_from(&Type::U8), Ok(VS::U8)));
+    assert!(matches!(VS::try_from(&Type::U16), Ok(VS::U16)));
+    assert!(matches!(VS::try_from(&Type::U32), Ok(VS::U32)));
+    assert!(matches!(VS::try_from(&Type::U64), Ok(VS::U64)));
+    assert!(matches!(VS::try_from(&Type::U128), Ok(VS::U128)));
+    assert!(matches!(VS::try_from(&Type::U256), Ok(VS::U256)));
+    assert!(matches!(VS::try_from(&Type::Bool), Ok(VS::Bool)));
+    assert!(matches!(VS::try_from(&Type::Address), Ok(VS::Address)));
+    assert!(matches!(VS::try_from(&Type::Signer), Ok(VS::Container)));
+    assert!(matches!(
+        VS::try_from(&Type::Vector(Box::new(Type::U8))),
+        Ok(VS::Container)
+    ));
+    assert!(VS::try_from(&Type::Reference(Box::new(Type::U8))).is_err());
+    assert!(VS::try_from(&Type::TyParam(0)).is_err());
 }


### PR DESCRIPTION
Wrote a ton of basic correctness tests for VM values, and fixed
proptests (+ wrote a ton more) for them as well.

- Fixed the broken `prop` module in `values_impl.rs` — it referenced the old value API (`Container::VecU8`, `Rc`, `RefCell`). Rewrote to use current constructors (`Value::vector_u8`, `Value::Vec`, `Value::make_variant`) and added enum/variant support to both `value_strategy_with_layout()` and `layout_strategy()`. Additionally, changed the gating on this to be `#[cfg(all(test, feature = "fuzzing"))]` so `proptest` stays a dev-dependency. There's a followup here possibly to look at removing the `fuzzing` feature flag in favor of just testing possibly, but that's a larger discussion.
- Added 45 unit tests and 43 proptests covering various value operations (for which we didn't have already-existing tests).

**Vector Operations (9):** `push_back`/`pop`/`swap`/`len`/`borrow_elem` on PrimVec and Container specializations, `pack`/`unpack` round-trip, empty-pop error, OOB errors, wrong-count unpack error.

**Variant Operations (4):** `pack`/`unpack` round-trip, `check_tag` success/failure, `VariantRef::get_tag`+`unpack_variant`, `VariantRef::check_tag` mismatch.

**GlobalValue Lifecycle (4):** Full lifecycle (empty -> move_to -> borrow_global -> move_from), move_to on occupied slot errors, `into_value` for empty/filled, write-through via `borrow_global` ref.

**Indexed References (2):** Write through indexed ref updates underlying PrimVec, type-mismatch write errors.

**Deep Copy (1):** Mutating a copy doesn't affect the original.

**Arithmetic Boundary Conditions (7):** Per-type (u8/u16/u32/u64/u128/u256) overflow/underflow at MAX/0 boundaries for add/sub/mul/div/rem. Shift boundary test at exact bit-width for all types.

**Cast Boundary Conditions (6):** Per-type (u8 through u256) exact MAX/MAX+1 boundary for every widening and narrowing cast combination.

**VMValueCast Error Paths (2):** Primitive-to-wrong-type cast errors, indexed-ref-to-StructRef cast error.

**VectorSpecialization (1):** `TryFrom<&Type>` mapping for all primitive, container, and error types.

**Value Equality (3):** `copy_value` preserves equality, reflexivity, symmetry.

**Vector (1):** `pack`/`unpack` round-trip with random u64 vectors.

**Integer Arithmetic Correctness (6):** VM `add`/`sub`/`mul`/`div`/`rem` match native Rust `checked_*` across all 6 widths (u8-u256). Type-mismatch between different widths always errors.

**Bitwise Correctness (3):** VM `bit_or`/`bit_and`/`bit_xor` match native `|`/`&`/`^` across all widths.

**Shift Correctness (2):** VM `shl`/`shr` match native `<<`/`>>` for valid shift amounts across all widths.

**Comparison Correctness (4):** VM `lt`/`le`/`gt`/`ge` match native comparisons across all widths.

**Casting — Widening (5):** Every source type widens to all larger types preserving value (u8->all, u16->u32+, u32->u64+, u64->u128+, u128->u256).

**Casting — Narrowing (16):** Every narrowing pair (u16->u8, u32->u8/u16, u64->u8/u16/u32, u128->u8/u16/u32/u64, u256->u8/u16/u32/u64/u128) succeeds iff value fits, plus u256 values above u128::MAX always fail.

**Casting — Identity (1):** Cast to own width always succeeds and returns the same value.

It's all tests! 🎉

```bash
cargo nextest run -p move-vm-runtime --lib -- value_tests

cargo nextest run -p move-vm-runtime --lib --features fuzzing -- value_prop_tests
```