### PR TITLE
[move-compiler] Avoid IO when no artifacts are generated

### DIFF
--- a/external-crates/move/crates/move-package-alt-compilation/src/compilation.rs
+++ b/external-crates/move/crates/move-package-alt-compilation/src/compilation.rs
@@ -104,7 +104,6 @@ pub fn build_all<W: Write + Send, F: MoveFlavor>(
     // this has to match whatever we're doing in build_for_driver function
     let root_package_name = Symbol::from(package_name.to_string());
 
-    let no_units_compiled = all_compiled_units.is_empty();
     for mut annot_unit in all_compiled_units {
         let source_path = PathBuf::from(
             file_map
@@ -178,7 +177,8 @@ pub fn build_all<W: Write + Send, F: MoveFlavor>(
 
     let under_path = shared::get_build_output_path(&project_root, build_config);
 
-    if !no_units_compiled || compiled_docs.is_some() {
+    if !root_compiled_units.is_empty() || !deps_compiled_units.is_empty() || compiled_docs.is_some()
+    {
         // Save to disk only if there are any artfifacts. In particular,
         // driver compilation may not produce any compiled modules.
         save_to_disk(


### PR DESCRIPTION
## Description 

When working on an unrelated task, I realized that even if the compilation does not produce any artifacts, we still attempt writing them to disk. This has two rather unpleasant consequences:
- `move-analyzer` (whose compiler driver stops at creating CFGIR and does not produce bytecode) still does IO
- `move-analyzer`'s run on a package directory that contains build artifacts will wipe them from disk (not great if opening a package for trace-debugging...)
