### PR TITLE
graphql-alt: scan apis

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/events/filter/module.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/events/filter/module.snap
@@ -625,24 +625,19 @@ Response: {
 task 9, lines 141-148:
 //# run-graphql
 Response: {
-  "data": {
-    "eventsByModuleAndTypeIsUnavailable": null
-  },
+  "data": null,
   "errors": [
     {
-      "message": "Filtering by both emitting module and event type is not supported not available",
+      "message": "Failed to parse \"EventFilter\": Filtering by both emitting module and event type is not supported",
       "locations": [
         {
           "line": 2,
-          "column": 3
+          "column": 65
         }
       ],
       "path": [
         "eventsByModuleAndTypeIsUnavailable"
-      ],
-      "extensions": {
-        "code": "FEATURE_UNAVAILABLE"
-      }
+      ]
     }
   ]
 }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/events/scan.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/events/scan.move
@@ -1,0 +1,169 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 70 --addresses P1=0x0 P2=0x0 --accounts A B C --simulator
+
+//# publish
+module P1::M1 {
+    use sui::event;
+    use std::ascii;
+
+    public struct EventA has copy, drop {
+        message: ascii::String,
+        value: u64,
+    }
+
+    public struct EventB has copy, drop {
+        message: ascii::String,
+        value: u64,
+    }
+
+    public entry fun emit_a(value: u64) {
+        event::emit(EventA {
+            message: ascii::string(b"Event A"),
+            value,
+        });
+    }
+
+    public entry fun emit_b(value: u64) {
+        event::emit(EventB {
+            message: ascii::string(b"Event B"),
+            value,
+        });
+    }
+
+    public entry fun emit_multiple(count: u64) {
+        let mut i = 0;
+        while (i < count) {
+            event::emit(EventA {
+                message: ascii::string(b"Event from loop"),
+                value: i + 1,
+            });
+            i = i + 1;
+        };
+    }
+}
+
+//# publish
+module P2::M2 {
+    use sui::event;
+    use std::ascii;
+
+    public struct EventC has copy, drop {
+        message: ascii::String,
+        value: u64,
+    }
+
+    public entry fun emit_c(value: u64) {
+        event::emit(EventC {
+            message: ascii::string(b"Event C from P2"),
+            value,
+        });
+    }
+}
+
+// Checkpoint 1: A emits EventA from P1::M1
+//# run P1::M1::emit_a --sender A --args 1
+
+//# create-checkpoint
+
+// Checkpoint 2: B emits EventB from P1::M1
+//# run P1::M1::emit_b --sender B --args 2
+
+//# create-checkpoint
+
+// Checkpoint 3: A emits EventC from P2::M2
+//# run P2::M2::emit_c --sender A --args 3
+
+//# create-checkpoint
+
+// Checkpoint 4: C emits EventA from P1::M1
+//# run P1::M1::emit_a --sender C --args 4
+
+//# create-checkpoint
+
+// Checkpoint 5: Multiple events in one checkpoint (A emits 3 EventA)
+//# run P1::M1::emit_multiple --sender A --args 3
+
+//# create-checkpoint
+
+//# advance-epoch
+
+// Generate 10,501 checkpoints to create 10 complete blocks + 500 extra for incomplete block
+//# create-checkpoint 10501
+
+// Checkpoint after blocks: B emits EventC from P2
+//# run P2::M2::emit_c --sender B --args 100
+
+//# create-checkpoint
+
+//# run-graphql
+# Scan vs indexed cross-check, multi-filter combinations, empty-result edge cases,
+# checkpoint-bounded scan, and scan across bloom blocks.
+{
+  scanEventsA: scanEvents(filter: { sender: "@{A}", beforeCheckpoint: 10510 }) { ...EV }
+  paginateEventsA: events(filter: { sender: "@{A}" }) { ...EV }
+
+  eventsAFromP1: scanEvents(filter: {
+    sender: "@{A}",
+    module: "@{P1}",
+    beforeCheckpoint: 10510
+  }) { ...EV }
+  scanTripleFilter: scanEvents(filter: {
+    sender: "@{A}",
+    module: "@{P1}",
+    type: "@{P1}::M1::EventA",
+    beforeCheckpoint: 10510
+  }) { ...EV }
+
+  emptyNonExistent: scanEvents(filter: {
+    sender: "0x0000000000000000000000000000000000000000000000000000000000000001",
+    beforeCheckpoint: 10510
+  }) { ...EV }
+
+  earlyEvents: scanEvents(filter: {
+    sender: "@{A}",
+    beforeCheckpoint: 4
+  }) { ...EV }
+  atCheckpoint5: scanEvents(filter: {
+    sender: "@{A}",
+    atCheckpoint: 5
+  }) { ...EV }
+
+  noFilter: scanEvents(first: 5, filter: {
+    afterCheckpoint: 0,
+    beforeCheckpoint: 6
+  }) { ...EV }
+
+  scanAcrossBlocks: scanEvents(filter: {
+    sender: "@{A}",
+    afterCheckpoint: 0,
+    beforeCheckpoint: 10510
+  }) { ...EV }
+}
+
+fragment EV on EventConnection {
+  pageInfo { startCursor endCursor hasPreviousPage hasNextPage }
+  edges { cursor node { sequenceNumber sender { address } contents { type { repr } } } }
+}
+
+//# run-graphql --cursors {"c":1,"t":3,"e":0} {"c":5,"t":7,"e":0} {"c":5,"t":7,"e":2} {"c":20,"t":20,"e":0}
+# Cursor pagination: cursor_0 is cp1 event (t=3,e=0),
+# cursor_1 is cp5 first event (t=7,e=0), cursor_2 is cp5 last event (t=7,e=2).
+{
+  first2: scanEvents(first: 2, filter: { sender: "@{A}", beforeCheckpoint: 10510 }) { ...EV }
+  last2: scanEvents(last: 2, filter: { sender: "@{A}", beforeCheckpoint: 10510 }) { ...EV }
+
+  firstAfter: scanEvents(first: 10, after: "@{cursor_0}", filter: { sender: "@{A}", beforeCheckpoint: 10510 }) { ...EV }
+  firstBefore: scanEvents(first: 10, before: "@{cursor_2}", filter: { sender: "@{A}", beforeCheckpoint: 10510 }) { ...EV }
+
+  windowFirst: scanEvents(first: 10, after: "@{cursor_0}", before: "@{cursor_2}", filter: { sender: "@{A}", beforeCheckpoint: 10510 }) { ...EV }
+
+  nonexistentCursor: scanEvents(last: 10, after: "@{cursor_3}", filter: { sender: "@{A}", beforeCheckpoint: 10510 }) { ...EV }
+  invalidOrder: scanEvents(first: 10, after: "@{cursor_2}", before: "@{cursor_0}", filter: { sender: "@{A}", beforeCheckpoint: 10510 }) { ...EV }
+}
+
+fragment EV on EventConnection {
+  pageInfo { startCursor endCursor hasPreviousPage hasNextPage }
+  edges { cursor node { sequenceNumber sender { address } contents { type { repr } } } }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/events/scan.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/events/scan.snap
@@ -1,0 +1,931 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+assertion_line: 833
+---
+processed 19 tasks
+
+init:
+A: object(0,0), B: object(0,1), C: object(0,2)
+
+task 1, lines 6-45:
+//# publish
+created: object(1,0)
+mutated: object(0,3)
+gas summary: computation_cost: 1000000, storage_cost: 6794400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 47-65:
+//# publish
+created: object(2,0)
+mutated: object(0,3)
+gas summary: computation_cost: 1000000, storage_cost: 5289600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 3, line 66:
+//# run P1::M1::emit_a --sender A --args 1
+events: Event { package_id: P1, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: P1, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [7, 69, 118, 101, 110, 116, 32, 65, 1, 0, 0, 0, 0, 0, 0, 0] }
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 4, lines 68-70:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 5, line 71:
+//# run P1::M1::emit_b --sender B --args 2
+events: Event { package_id: P1, transaction_module: Identifier("M1"), sender: B, type_: StructTag { address: P1, module: Identifier("M1"), name: Identifier("EventB"), type_params: [] }, contents: [7, 69, 118, 101, 110, 116, 32, 66, 2, 0, 0, 0, 0, 0, 0, 0] }
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 6, lines 73-75:
+//# create-checkpoint
+Checkpoint created: 2
+
+task 7, line 76:
+//# run P2::M2::emit_c --sender A --args 3
+events: Event { package_id: P2, transaction_module: Identifier("M2"), sender: A, type_: StructTag { address: P2, module: Identifier("M2"), name: Identifier("EventC"), type_params: [] }, contents: [15, 69, 118, 101, 110, 116, 32, 67, 32, 102, 114, 111, 109, 32, 80, 50, 3, 0, 0, 0, 0, 0, 0, 0] }
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 8, lines 78-80:
+//# create-checkpoint
+Checkpoint created: 3
+
+task 9, line 81:
+//# run P1::M1::emit_a --sender C --args 4
+events: Event { package_id: P1, transaction_module: Identifier("M1"), sender: C, type_: StructTag { address: P1, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [7, 69, 118, 101, 110, 116, 32, 65, 4, 0, 0, 0, 0, 0, 0, 0] }
+mutated: object(0,2)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 10, lines 83-85:
+//# create-checkpoint
+Checkpoint created: 4
+
+task 11, line 86:
+//# run P1::M1::emit_multiple --sender A --args 3
+events: Event { package_id: P1, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: P1, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [15, 69, 118, 101, 110, 116, 32, 102, 114, 111, 109, 32, 108, 111, 111, 112, 1, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: P1, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: P1, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [15, 69, 118, 101, 110, 116, 32, 102, 114, 111, 109, 32, 108, 111, 111, 112, 2, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: P1, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: P1, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [15, 69, 118, 101, 110, 116, 32, 102, 114, 111, 109, 32, 108, 111, 111, 112, 3, 0, 0, 0, 0, 0, 0, 0] }
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 12, line 88:
+//# create-checkpoint
+Checkpoint created: 5
+
+task 13, lines 90-92:
+//# advance-epoch
+Epoch advanced: 1
+
+task 14, lines 93-95:
+//# create-checkpoint 10501
+Checkpoint created: 10507
+
+task 15, line 96:
+//# run P2::M2::emit_c --sender B --args 100
+events: Event { package_id: P2, transaction_module: Identifier("M2"), sender: B, type_: StructTag { address: P2, module: Identifier("M2"), name: Identifier("EventC"), type_params: [] }, contents: [15, 69, 118, 101, 110, 116, 32, 67, 32, 102, 114, 111, 109, 32, 80, 50, 100, 0, 0, 0, 0, 0, 0, 0] }
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 16, line 98:
+//# create-checkpoint
+Checkpoint created: 10508
+
+task 17, lines 100-148:
+//# run-graphql
+Response: {
+  "data": {
+    "scanEventsA": {
+      "pageInfo": {
+        "startCursor": "eyJjIjoxLCJ0IjozLCJlIjowfQ==",
+        "endCursor": "eyJjIjo1LCJ0Ijo3LCJlIjoyfQ==",
+        "hasPreviousPage": false,
+        "hasNextPage": false
+      },
+      "edges": [
+        {
+          "cursor": "eyJjIjoxLCJ0IjozLCJlIjowfQ==",
+          "node": {
+            "sequenceNumber": 0,
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "contents": {
+              "type": {
+                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjozLCJ0Ijo1LCJlIjowfQ==",
+          "node": {
+            "sequenceNumber": 0,
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "contents": {
+              "type": {
+                "repr": "0x2a4de3bd8841a6d9f3987956258c1f43a7eb6b1927f33a9a9c920f0bf08113e8::M2::EventC"
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjo1LCJ0Ijo3LCJlIjowfQ==",
+          "node": {
+            "sequenceNumber": 0,
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "contents": {
+              "type": {
+                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjo1LCJ0Ijo3LCJlIjoxfQ==",
+          "node": {
+            "sequenceNumber": 1,
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "contents": {
+              "type": {
+                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjo1LCJ0Ijo3LCJlIjoyfQ==",
+          "node": {
+            "sequenceNumber": 2,
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "contents": {
+              "type": {
+                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "paginateEventsA": {
+      "pageInfo": {
+        "startCursor": "eyJ0IjozLCJlIjowfQ==",
+        "endCursor": "eyJ0Ijo3LCJlIjoyfQ==",
+        "hasPreviousPage": false,
+        "hasNextPage": false
+      },
+      "edges": [
+        {
+          "cursor": "eyJ0IjozLCJlIjowfQ==",
+          "node": {
+            "sequenceNumber": 0,
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "contents": {
+              "type": {
+                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJ0Ijo1LCJlIjowfQ==",
+          "node": {
+            "sequenceNumber": 0,
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "contents": {
+              "type": {
+                "repr": "0x2a4de3bd8841a6d9f3987956258c1f43a7eb6b1927f33a9a9c920f0bf08113e8::M2::EventC"
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJ0Ijo3LCJlIjowfQ==",
+          "node": {
+            "sequenceNumber": 0,
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "contents": {
+              "type": {
+                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJ0Ijo3LCJlIjoxfQ==",
+          "node": {
+            "sequenceNumber": 1,
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "contents": {
+              "type": {
+                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJ0Ijo3LCJlIjoyfQ==",
+          "node": {
+            "sequenceNumber": 2,
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "contents": {
+              "type": {
+                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "eventsAFromP1": {
+      "pageInfo": {
+        "startCursor": "eyJjIjoxLCJ0IjozLCJlIjowfQ==",
+        "endCursor": "eyJjIjo1LCJ0Ijo3LCJlIjoyfQ==",
+        "hasPreviousPage": false,
+        "hasNextPage": false
+      },
+      "edges": [
+        {
+          "cursor": "eyJjIjoxLCJ0IjozLCJlIjowfQ==",
+          "node": {
+            "sequenceNumber": 0,
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "contents": {
+              "type": {
+                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjo1LCJ0Ijo3LCJlIjowfQ==",
+          "node": {
+            "sequenceNumber": 0,
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "contents": {
+              "type": {
+                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjo1LCJ0Ijo3LCJlIjoxfQ==",
+          "node": {
+            "sequenceNumber": 1,
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "contents": {
+              "type": {
+                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjo1LCJ0Ijo3LCJlIjoyfQ==",
+          "node": {
+            "sequenceNumber": 2,
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "contents": {
+              "type": {
+                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "scanTripleFilter": {
+      "pageInfo": {
+        "startCursor": "eyJjIjoxLCJ0IjozLCJlIjowfQ==",
+        "endCursor": "eyJjIjo1LCJ0Ijo3LCJlIjoyfQ==",
+        "hasPreviousPage": false,
+        "hasNextPage": false
+      },
+      "edges": [
+        {
+          "cursor": "eyJjIjoxLCJ0IjozLCJlIjowfQ==",
+          "node": {
+            "sequenceNumber": 0,
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "contents": {
+              "type": {
+                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjo1LCJ0Ijo3LCJlIjowfQ==",
+          "node": {
+            "sequenceNumber": 0,
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "contents": {
+              "type": {
+                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjo1LCJ0Ijo3LCJlIjoxfQ==",
+          "node": {
+            "sequenceNumber": 1,
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "contents": {
+              "type": {
+                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjo1LCJ0Ijo3LCJlIjoyfQ==",
+          "node": {
+            "sequenceNumber": 2,
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "contents": {
+              "type": {
+                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "emptyNonExistent": {
+      "pageInfo": {
+        "startCursor": null,
+        "endCursor": null,
+        "hasPreviousPage": false,
+        "hasNextPage": false
+      },
+      "edges": []
+    },
+    "earlyEvents": {
+      "pageInfo": {
+        "startCursor": "eyJjIjoxLCJ0IjozLCJlIjowfQ==",
+        "endCursor": "eyJjIjozLCJ0Ijo1LCJlIjowfQ==",
+        "hasPreviousPage": false,
+        "hasNextPage": false
+      },
+      "edges": [
+        {
+          "cursor": "eyJjIjoxLCJ0IjozLCJlIjowfQ==",
+          "node": {
+            "sequenceNumber": 0,
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "contents": {
+              "type": {
+                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjozLCJ0Ijo1LCJlIjowfQ==",
+          "node": {
+            "sequenceNumber": 0,
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "contents": {
+              "type": {
+                "repr": "0x2a4de3bd8841a6d9f3987956258c1f43a7eb6b1927f33a9a9c920f0bf08113e8::M2::EventC"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "atCheckpoint5": {
+      "pageInfo": {
+        "startCursor": "eyJjIjo1LCJ0Ijo3LCJlIjowfQ==",
+        "endCursor": "eyJjIjo1LCJ0Ijo3LCJlIjoyfQ==",
+        "hasPreviousPage": false,
+        "hasNextPage": false
+      },
+      "edges": [
+        {
+          "cursor": "eyJjIjo1LCJ0Ijo3LCJlIjowfQ==",
+          "node": {
+            "sequenceNumber": 0,
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "contents": {
+              "type": {
+                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjo1LCJ0Ijo3LCJlIjoxfQ==",
+          "node": {
+            "sequenceNumber": 1,
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "contents": {
+              "type": {
+                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjo1LCJ0Ijo3LCJlIjoyfQ==",
+          "node": {
+            "sequenceNumber": 2,
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "contents": {
+              "type": {
+                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "noFilter": {
+      "pageInfo": {
+        "startCursor": "eyJjIjoxLCJ0IjozLCJlIjowfQ==",
+        "endCursor": "eyJjIjo1LCJ0Ijo3LCJlIjowfQ==",
+        "hasPreviousPage": false,
+        "hasNextPage": true
+      },
+      "edges": [
+        {
+          "cursor": "eyJjIjoxLCJ0IjozLCJlIjowfQ==",
+          "node": {
+            "sequenceNumber": 0,
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "contents": {
+              "type": {
+                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjoyLCJ0Ijo0LCJlIjowfQ==",
+          "node": {
+            "sequenceNumber": 0,
+            "sender": {
+              "address": "0xa7b032703878aa74c3126935789fd1d4d7e111d5911b09247d6963061c312b5a"
+            },
+            "contents": {
+              "type": {
+                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventB"
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjozLCJ0Ijo1LCJlIjowfQ==",
+          "node": {
+            "sequenceNumber": 0,
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "contents": {
+              "type": {
+                "repr": "0x2a4de3bd8841a6d9f3987956258c1f43a7eb6b1927f33a9a9c920f0bf08113e8::M2::EventC"
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjo0LCJ0Ijo2LCJlIjowfQ==",
+          "node": {
+            "sequenceNumber": 0,
+            "sender": {
+              "address": "0xda83166d01afd7ddcf8af5f844f45aaa53f48548e5117c23f5a2978cfd422244"
+            },
+            "contents": {
+              "type": {
+                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjo1LCJ0Ijo3LCJlIjowfQ==",
+          "node": {
+            "sequenceNumber": 0,
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "contents": {
+              "type": {
+                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "scanAcrossBlocks": {
+      "pageInfo": {
+        "startCursor": "eyJjIjoxLCJ0IjozLCJlIjowfQ==",
+        "endCursor": "eyJjIjo1LCJ0Ijo3LCJlIjoyfQ==",
+        "hasPreviousPage": false,
+        "hasNextPage": false
+      },
+      "edges": [
+        {
+          "cursor": "eyJjIjoxLCJ0IjozLCJlIjowfQ==",
+          "node": {
+            "sequenceNumber": 0,
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "contents": {
+              "type": {
+                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjozLCJ0Ijo1LCJlIjowfQ==",
+          "node": {
+            "sequenceNumber": 0,
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "contents": {
+              "type": {
+                "repr": "0x2a4de3bd8841a6d9f3987956258c1f43a7eb6b1927f33a9a9c920f0bf08113e8::M2::EventC"
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjo1LCJ0Ijo3LCJlIjowfQ==",
+          "node": {
+            "sequenceNumber": 0,
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "contents": {
+              "type": {
+                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjo1LCJ0Ijo3LCJlIjoxfQ==",
+          "node": {
+            "sequenceNumber": 1,
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "contents": {
+              "type": {
+                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjo1LCJ0Ijo3LCJlIjoyfQ==",
+          "node": {
+            "sequenceNumber": 2,
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "contents": {
+              "type": {
+                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+
+task 18, lines 150-169:
+//# run-graphql --cursors {"c":1,"t":3,"e":0} {"c":5,"t":7,"e":0} {"c":5,"t":7,"e":2} {"c":20,"t":20,"e":0}
+Response: {
+  "data": {
+    "first2": {
+      "pageInfo": {
+        "startCursor": "eyJjIjoxLCJ0IjozLCJlIjowfQ==",
+        "endCursor": "eyJjIjozLCJ0Ijo1LCJlIjowfQ==",
+        "hasPreviousPage": false,
+        "hasNextPage": true
+      },
+      "edges": [
+        {
+          "cursor": "eyJjIjoxLCJ0IjozLCJlIjowfQ==",
+          "node": {
+            "sequenceNumber": 0,
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "contents": {
+              "type": {
+                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjozLCJ0Ijo1LCJlIjowfQ==",
+          "node": {
+            "sequenceNumber": 0,
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "contents": {
+              "type": {
+                "repr": "0x2a4de3bd8841a6d9f3987956258c1f43a7eb6b1927f33a9a9c920f0bf08113e8::M2::EventC"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "last2": {
+      "pageInfo": {
+        "startCursor": "eyJjIjo1LCJ0Ijo3LCJlIjoxfQ==",
+        "endCursor": "eyJjIjo1LCJ0Ijo3LCJlIjoyfQ==",
+        "hasPreviousPage": true,
+        "hasNextPage": false
+      },
+      "edges": [
+        {
+          "cursor": "eyJjIjo1LCJ0Ijo3LCJlIjoxfQ==",
+          "node": {
+            "sequenceNumber": 1,
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "contents": {
+              "type": {
+                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjo1LCJ0Ijo3LCJlIjoyfQ==",
+          "node": {
+            "sequenceNumber": 2,
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "contents": {
+              "type": {
+                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "firstAfter": {
+      "pageInfo": {
+        "startCursor": "eyJjIjozLCJ0Ijo1LCJlIjowfQ==",
+        "endCursor": "eyJjIjo1LCJ0Ijo3LCJlIjoyfQ==",
+        "hasPreviousPage": true,
+        "hasNextPage": false
+      },
+      "edges": [
+        {
+          "cursor": "eyJjIjozLCJ0Ijo1LCJlIjowfQ==",
+          "node": {
+            "sequenceNumber": 0,
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "contents": {
+              "type": {
+                "repr": "0x2a4de3bd8841a6d9f3987956258c1f43a7eb6b1927f33a9a9c920f0bf08113e8::M2::EventC"
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjo1LCJ0Ijo3LCJlIjowfQ==",
+          "node": {
+            "sequenceNumber": 0,
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "contents": {
+              "type": {
+                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjo1LCJ0Ijo3LCJlIjoxfQ==",
+          "node": {
+            "sequenceNumber": 1,
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "contents": {
+              "type": {
+                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjo1LCJ0Ijo3LCJlIjoyfQ==",
+          "node": {
+            "sequenceNumber": 2,
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "contents": {
+              "type": {
+                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "firstBefore": {
+      "pageInfo": {
+        "startCursor": "eyJjIjoxLCJ0IjozLCJlIjowfQ==",
+        "endCursor": "eyJjIjo1LCJ0Ijo3LCJlIjoxfQ==",
+        "hasPreviousPage": false,
+        "hasNextPage": true
+      },
+      "edges": [
+        {
+          "cursor": "eyJjIjoxLCJ0IjozLCJlIjowfQ==",
+          "node": {
+            "sequenceNumber": 0,
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "contents": {
+              "type": {
+                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjozLCJ0Ijo1LCJlIjowfQ==",
+          "node": {
+            "sequenceNumber": 0,
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "contents": {
+              "type": {
+                "repr": "0x2a4de3bd8841a6d9f3987956258c1f43a7eb6b1927f33a9a9c920f0bf08113e8::M2::EventC"
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjo1LCJ0Ijo3LCJlIjowfQ==",
+          "node": {
+            "sequenceNumber": 0,
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "contents": {
+              "type": {
+                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjo1LCJ0Ijo3LCJlIjoxfQ==",
+          "node": {
+            "sequenceNumber": 1,
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "contents": {
+              "type": {
+                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "windowFirst": {
+      "pageInfo": {
+        "startCursor": "eyJjIjozLCJ0Ijo1LCJlIjowfQ==",
+        "endCursor": "eyJjIjo1LCJ0Ijo3LCJlIjoxfQ==",
+        "hasPreviousPage": true,
+        "hasNextPage": true
+      },
+      "edges": [
+        {
+          "cursor": "eyJjIjozLCJ0Ijo1LCJlIjowfQ==",
+          "node": {
+            "sequenceNumber": 0,
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "contents": {
+              "type": {
+                "repr": "0x2a4de3bd8841a6d9f3987956258c1f43a7eb6b1927f33a9a9c920f0bf08113e8::M2::EventC"
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjo1LCJ0Ijo3LCJlIjowfQ==",
+          "node": {
+            "sequenceNumber": 0,
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "contents": {
+              "type": {
+                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjo1LCJ0Ijo3LCJlIjoxfQ==",
+          "node": {
+            "sequenceNumber": 1,
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "contents": {
+              "type": {
+                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "nonexistentCursor": {
+      "pageInfo": {
+        "startCursor": null,
+        "endCursor": null,
+        "hasPreviousPage": false,
+        "hasNextPage": false
+      },
+      "edges": []
+    },
+    "invalidOrder": {
+      "pageInfo": {
+        "startCursor": null,
+        "endCursor": null,
+        "hasPreviousPage": false,
+        "hasNextPage": false
+      },
+      "edges": []
+    }
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/scan.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/scan.move
@@ -1,0 +1,167 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 70 --addresses Test=0x0 --accounts A B C --simulator
+
+//# publish
+module Test::M1 {
+    use sui::coin::Coin;
+
+    public struct Object has key, store {
+        id: UID,
+        value: u64,
+    }
+
+    fun foo<T: key, T2: drop>(_p1: u64, value1: T, _value2: &Coin<T2>, _p2: u64): T {
+        value1
+    }
+
+    public entry fun create(value: u64, recipient: address, ctx: &mut TxContext) {
+        transfer::public_transfer(
+            Object { id: object::new(ctx), value },
+            recipient
+        )
+    }
+}
+
+// Transaction 1: A creates object for A (checkpoint 1)
+//# run Test::M1::create --sender A --args 0 @A
+
+//# create-checkpoint
+
+// Transaction 2: A creates object for B (checkpoint 2) - matches A (sender) + B (recipient)
+//# run Test::M1::create --sender A --args 1 @B
+
+//# create-checkpoint
+
+// Transaction 3: B creates object for A (checkpoint 3) - matches B (sender) + A (recipient)
+//# run Test::M1::create --sender B --args 2 @A
+
+//# create-checkpoint
+
+// Transaction 4: C creates object for A (checkpoint 4) - matches C (sender) + A (recipient)
+//# run Test::M1::create --sender C --args 3 @A
+
+//# create-checkpoint
+
+// Transactions 5-7: Multiple transactions in checkpoint 5 to test cursor with t > 1
+//# run Test::M1::create --sender A --args 10 @A
+
+//# run Test::M1::create --sender A --args 11 @A
+
+//# run Test::M1::create --sender A --args 12 @A
+
+//# create-checkpoint
+
+// Generate 995 checkpoints together with the previous 5 checkpoints to create 1 complete block.
+//# create-checkpoint 995
+
+
+//# run Test::M1::create --sender A --args 100 @C
+
+// Generate one more checkpoint to put the previous txn in a separate, incomplete block.
+//# create-checkpoint
+
+//# run-graphql
+# Scan vs indexed cross-check, multi-filter combinations, empty-result edge cases,
+# no-filter scan, and checkpoint-bounded scan across bloom blocks.
+{
+  scanTransactionsA: scanTransactions(filter: { affectedAddress: "@{A}", beforeCheckpoint: 1002 }) { ...TX }
+  paginateTransactionsA: transactions(filter: { affectedAddress: "@{A}" }) { ...TX }
+
+  transactionsAWithObj: scanTransactions(filter: {
+    affectedAddress: "@{A}",
+    affectedObject: "@{obj_4_0}",
+    beforeCheckpoint: 1002
+  }) { ...TX }
+  transactionsBSentToA: scanTransactions(filter: {
+    affectedAddress: "@{A}",
+    sentAddress: "@{B}",
+    beforeCheckpoint: 1002
+  }) { ...TX }
+  scanFnAndObj: scanTransactions(filter: {
+    function: "@{Test}",
+    affectedObject: "@{obj_4_0}",
+    beforeCheckpoint: 1002
+  }) { ...TX }
+  scanFnAndAddr: scanTransactions(filter: {
+    function: "@{Test}",
+    affectedAddress: "@{C}",
+    beforeCheckpoint: 1002
+  }) { ...TX }
+  transactionsWithPackage: scanTransactions(filter: {
+    function: "@{Test}",
+    beforeCheckpoint: 1002
+  }) { ...TX }
+  atCheckpoint: scanTransactions(first: 5, filter: {
+    atCheckpoint: 5,
+  }) { ...TX }
+  scanAcrossBlocks: scanTransactions(filter: {
+    affectedAddress: "@{A}",
+    afterCheckpoint: 0, beforeCheckpoint: 1002
+  }) { ...TX }
+
+  emptyNonExistent: scanTransactions(filter: {
+    affectedAddress: "0x0000000000000000000000000000000000000000000000000000000000000001",
+    afterCheckpoint: 0, beforeCheckpoint: 1002
+  }) { ...TX }
+  emptyConflicting: scanTransactions(filter: {
+    sentAddress: "@{A}",
+    affectedAddress: "@{C}",
+    beforeCheckpoint: 5
+  }) { ...TX }
+  emptyBeyondData: scanTransactions(filter: {
+    affectedAddress: "@{A}",
+    afterCheckpoint: 50000, beforeCheckpoint: 60000
+  }) { ...TX }
+}
+
+fragment TX on TransactionConnection {
+  pageInfo { startCursor endCursor hasPreviousPage hasNextPage }
+  edges { cursor node { digest effects { checkpoint { sequenceNumber } } } }
+}
+
+//# run-graphql --cursors {"t":5,"c":4} {"t":7,"c":5} {"t":20,"c":1001}
+# Cursor pagination: cursor_0 is a checkpoint boundary (cp4,tx_seq=5),
+# cursor_1 is mid-checkpoint (cp5,tx_seq=7). Tests all first/last/after/before combos.
+{
+  first2: scanTransactions(first: 2, filter: { affectedAddress: "@{A}", beforeCheckpoint: 1002 }) { ...TX }
+  last2: scanTransactions(last: 2, filter: { affectedAddress: "@{A}", beforeCheckpoint: 1002 }) { ...TX }
+
+  firstAfter: scanTransactions(first: 10, after: "@{cursor_0}", filter: { affectedAddress: "@{A}", beforeCheckpoint: 1002 }) { ...TX }
+  lastBefore: scanTransactions(last: 10, before: "@{cursor_1}", filter: { affectedAddress: "@{A}", beforeCheckpoint: 1002 }) { ...TX }
+  firstBefore: scanTransactions(first: 10, before: "@{cursor_1}", filter: { affectedAddress: "@{A}", beforeCheckpoint: 1002 }) { ...TX }
+  lastAfter: scanTransactions(last: 10, after: "@{cursor_0}", filter: { affectedAddress: "@{A}", beforeCheckpoint: 1002 }) { ...TX }
+
+  windowFirst: scanTransactions(first: 10, after: "@{cursor_0}", before: "@{cursor_1}", filter: { affectedAddress: "@{A}", beforeCheckpoint: 1002 }) { ...TX }
+  windowLast: scanTransactions(last: 10, after: "@{cursor_0}", before: "@{cursor_1}", filter: { affectedAddress: "@{A}", beforeCheckpoint: 1002 }) { ...TX }
+
+  nonexistentCursor: scanTransactions(last: 10, after: "@{cursor_2}", filter: { affectedAddress: "@{A}", beforeCheckpoint: 1002 }) { ...TX }
+  invalidOrder: scanTransactions(first: 10, after: "@{cursor_1}", before: "@{cursor_0}", filter: { affectedAddress: "@{A}", beforeCheckpoint: 1002 }) { ...TX }
+}
+
+fragment TX on TransactionConnection {
+  pageInfo { startCursor endCursor hasPreviousPage hasNextPage }
+  edges { cursor node { digest effects { checkpoint { sequenceNumber } } } }
+}
+
+//# run-graphql
+{
+  noCheckpointBounds: scanTransactions(filter: {
+    affectedAddress: "@{A}"
+  }) { pageInfo { startCursor endCursor hasPreviousPage hasNextPage } }
+}
+
+//# run-graphql
+{
+  unboundedScan: scanTransactions(filter: {
+    afterCheckpoint: 0,
+  }) { pageInfo { startCursor endCursor hasPreviousPage hasNextPage } }
+}
+
+//# run-graphql
+{
+  scanLimit: scanTransactions(filter: {
+    beforeCheckpoint: 3000001,
+  }) { pageInfo { startCursor endCursor hasPreviousPage hasNextPage } }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/scan.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/scan.snap
@@ -1,0 +1,1126 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 22 tasks
+
+init:
+A: object(0,0), B: object(0,1), C: object(0,2)
+
+task 1, lines 6-27:
+//# publish
+created: object(1,0)
+mutated: object(0,3)
+gas summary: computation_cost: 1000000, storage_cost: 5570800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, line 28:
+//# run Test::M1::create --sender A --args 0 @A
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, lines 30-32:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 4, line 33:
+//# run Test::M1::create --sender A --args 1 @B
+created: object(4,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 5, lines 35-37:
+//# create-checkpoint
+Checkpoint created: 2
+
+task 6, line 38:
+//# run Test::M1::create --sender B --args 2 @A
+created: object(6,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 7, lines 40-42:
+//# create-checkpoint
+Checkpoint created: 3
+
+task 8, line 43:
+//# run Test::M1::create --sender C --args 3 @A
+created: object(8,0)
+mutated: object(0,2)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 9, lines 45-47:
+//# create-checkpoint
+Checkpoint created: 4
+
+task 10, line 48:
+//# run Test::M1::create --sender A --args 10 @A
+created: object(10,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 11, line 50:
+//# run Test::M1::create --sender A --args 11 @A
+created: object(11,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 12, line 52:
+//# run Test::M1::create --sender A --args 12 @A
+created: object(12,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 13, lines 54-56:
+//# create-checkpoint
+Checkpoint created: 5
+
+task 14, line 57:
+//# create-checkpoint 995
+Checkpoint created: 1000
+
+task 15, lines 60-62:
+//# run Test::M1::create --sender A --args 100 @C
+created: object(15,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 16, line 63:
+//# create-checkpoint
+Checkpoint created: 1001
+
+task 17, lines 65-122:
+//# run-graphql
+Response: {
+  "data": {
+    "scanTransactionsA": {
+      "pageInfo": {
+        "startCursor": "eyJjIjowLCJ0IjowfQ==",
+        "endCursor": "eyJjIjoxMDAxLCJ0Ijo5fQ==",
+        "hasPreviousPage": false,
+        "hasNextPage": false
+      },
+      "edges": [
+        {
+          "cursor": "eyJjIjowLCJ0IjowfQ==",
+          "node": {
+            "digest": "BTts7EAgPrFtKKMFM2WB2zz8zkiTumXwN7C8DjRpRDEb",
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 0
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjoxLCJ0IjoyfQ==",
+          "node": {
+            "digest": "CbqfqPqiJXnc3b5oXC1RmGdgQTHGdjwe3vay6AoMGdNc",
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 1
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjoyLCJ0IjozfQ==",
+          "node": {
+            "digest": "GxzHztdrcHGeWdCNt4DwE5WdeyZ4dDpjpmv8TuqE1K7B",
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 2
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjozLCJ0Ijo0fQ==",
+          "node": {
+            "digest": "7PQs2ZG4cXQ52kE4h2bGoq4mqRdANXhN5hXZNpebVqLq",
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 3
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjo0LCJ0Ijo1fQ==",
+          "node": {
+            "digest": "iNKPq8CmUWRDTYnEvAggeizPXCXqFUvi8BWhMnSz2ao",
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 4
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjo1LCJ0Ijo2fQ==",
+          "node": {
+            "digest": "qdSwcToNtAVT8TtNUoNG4ZFo1DnVbEn5iLmkHTKuMfi",
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 5
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjo1LCJ0Ijo3fQ==",
+          "node": {
+            "digest": "5WTk3hjbQaLmjgTJwb1JYj94fDTH4P2m7fxeA7m78Ca3",
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 5
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjo1LCJ0Ijo4fQ==",
+          "node": {
+            "digest": "BsKiwYgspBG3CVZnFFEDUftYQ42xBi6p2i4TgSU7a4Uq",
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 5
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjoxMDAxLCJ0Ijo5fQ==",
+          "node": {
+            "digest": "6BtSF6K4ePk4qXZJx8NFREr51iJr2jaBz8Ln2K3P3byC",
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 1001
+              }
+            }
+          }
+        }
+      ]
+    },
+    "paginateTransactionsA": {
+      "pageInfo": {
+        "startCursor": "MA==",
+        "endCursor": "OQ==",
+        "hasPreviousPage": false,
+        "hasNextPage": false
+      },
+      "edges": [
+        {
+          "cursor": "MA==",
+          "node": {
+            "digest": "BTts7EAgPrFtKKMFM2WB2zz8zkiTumXwN7C8DjRpRDEb",
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 0
+              }
+            }
+          }
+        },
+        {
+          "cursor": "Mg==",
+          "node": {
+            "digest": "CbqfqPqiJXnc3b5oXC1RmGdgQTHGdjwe3vay6AoMGdNc",
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 1
+              }
+            }
+          }
+        },
+        {
+          "cursor": "Mw==",
+          "node": {
+            "digest": "GxzHztdrcHGeWdCNt4DwE5WdeyZ4dDpjpmv8TuqE1K7B",
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 2
+              }
+            }
+          }
+        },
+        {
+          "cursor": "NA==",
+          "node": {
+            "digest": "7PQs2ZG4cXQ52kE4h2bGoq4mqRdANXhN5hXZNpebVqLq",
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 3
+              }
+            }
+          }
+        },
+        {
+          "cursor": "NQ==",
+          "node": {
+            "digest": "iNKPq8CmUWRDTYnEvAggeizPXCXqFUvi8BWhMnSz2ao",
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 4
+              }
+            }
+          }
+        },
+        {
+          "cursor": "Ng==",
+          "node": {
+            "digest": "qdSwcToNtAVT8TtNUoNG4ZFo1DnVbEn5iLmkHTKuMfi",
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 5
+              }
+            }
+          }
+        },
+        {
+          "cursor": "Nw==",
+          "node": {
+            "digest": "5WTk3hjbQaLmjgTJwb1JYj94fDTH4P2m7fxeA7m78Ca3",
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 5
+              }
+            }
+          }
+        },
+        {
+          "cursor": "OA==",
+          "node": {
+            "digest": "BsKiwYgspBG3CVZnFFEDUftYQ42xBi6p2i4TgSU7a4Uq",
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 5
+              }
+            }
+          }
+        },
+        {
+          "cursor": "OQ==",
+          "node": {
+            "digest": "6BtSF6K4ePk4qXZJx8NFREr51iJr2jaBz8Ln2K3P3byC",
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 1001
+              }
+            }
+          }
+        }
+      ]
+    },
+    "transactionsAWithObj": {
+      "pageInfo": {
+        "startCursor": "eyJjIjoyLCJ0IjozfQ==",
+        "endCursor": "eyJjIjoyLCJ0IjozfQ==",
+        "hasPreviousPage": false,
+        "hasNextPage": false
+      },
+      "edges": [
+        {
+          "cursor": "eyJjIjoyLCJ0IjozfQ==",
+          "node": {
+            "digest": "GxzHztdrcHGeWdCNt4DwE5WdeyZ4dDpjpmv8TuqE1K7B",
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 2
+              }
+            }
+          }
+        }
+      ]
+    },
+    "transactionsBSentToA": {
+      "pageInfo": {
+        "startCursor": "eyJjIjozLCJ0Ijo0fQ==",
+        "endCursor": "eyJjIjozLCJ0Ijo0fQ==",
+        "hasPreviousPage": false,
+        "hasNextPage": false
+      },
+      "edges": [
+        {
+          "cursor": "eyJjIjozLCJ0Ijo0fQ==",
+          "node": {
+            "digest": "7PQs2ZG4cXQ52kE4h2bGoq4mqRdANXhN5hXZNpebVqLq",
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 3
+              }
+            }
+          }
+        }
+      ]
+    },
+    "scanFnAndObj": {
+      "pageInfo": {
+        "startCursor": "eyJjIjoyLCJ0IjozfQ==",
+        "endCursor": "eyJjIjoyLCJ0IjozfQ==",
+        "hasPreviousPage": false,
+        "hasNextPage": false
+      },
+      "edges": [
+        {
+          "cursor": "eyJjIjoyLCJ0IjozfQ==",
+          "node": {
+            "digest": "GxzHztdrcHGeWdCNt4DwE5WdeyZ4dDpjpmv8TuqE1K7B",
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 2
+              }
+            }
+          }
+        }
+      ]
+    },
+    "scanFnAndAddr": {
+      "pageInfo": {
+        "startCursor": "eyJjIjo0LCJ0Ijo1fQ==",
+        "endCursor": "eyJjIjoxMDAxLCJ0Ijo5fQ==",
+        "hasPreviousPage": false,
+        "hasNextPage": false
+      },
+      "edges": [
+        {
+          "cursor": "eyJjIjo0LCJ0Ijo1fQ==",
+          "node": {
+            "digest": "iNKPq8CmUWRDTYnEvAggeizPXCXqFUvi8BWhMnSz2ao",
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 4
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjoxMDAxLCJ0Ijo5fQ==",
+          "node": {
+            "digest": "6BtSF6K4ePk4qXZJx8NFREr51iJr2jaBz8Ln2K3P3byC",
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 1001
+              }
+            }
+          }
+        }
+      ]
+    },
+    "transactionsWithPackage": {
+      "pageInfo": {
+        "startCursor": "eyJjIjoxLCJ0IjoyfQ==",
+        "endCursor": "eyJjIjoxMDAxLCJ0Ijo5fQ==",
+        "hasPreviousPage": false,
+        "hasNextPage": false
+      },
+      "edges": [
+        {
+          "cursor": "eyJjIjoxLCJ0IjoyfQ==",
+          "node": {
+            "digest": "CbqfqPqiJXnc3b5oXC1RmGdgQTHGdjwe3vay6AoMGdNc",
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 1
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjoyLCJ0IjozfQ==",
+          "node": {
+            "digest": "GxzHztdrcHGeWdCNt4DwE5WdeyZ4dDpjpmv8TuqE1K7B",
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 2
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjozLCJ0Ijo0fQ==",
+          "node": {
+            "digest": "7PQs2ZG4cXQ52kE4h2bGoq4mqRdANXhN5hXZNpebVqLq",
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 3
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjo0LCJ0Ijo1fQ==",
+          "node": {
+            "digest": "iNKPq8CmUWRDTYnEvAggeizPXCXqFUvi8BWhMnSz2ao",
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 4
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjo1LCJ0Ijo2fQ==",
+          "node": {
+            "digest": "qdSwcToNtAVT8TtNUoNG4ZFo1DnVbEn5iLmkHTKuMfi",
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 5
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjo1LCJ0Ijo3fQ==",
+          "node": {
+            "digest": "5WTk3hjbQaLmjgTJwb1JYj94fDTH4P2m7fxeA7m78Ca3",
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 5
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjo1LCJ0Ijo4fQ==",
+          "node": {
+            "digest": "BsKiwYgspBG3CVZnFFEDUftYQ42xBi6p2i4TgSU7a4Uq",
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 5
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjoxMDAxLCJ0Ijo5fQ==",
+          "node": {
+            "digest": "6BtSF6K4ePk4qXZJx8NFREr51iJr2jaBz8Ln2K3P3byC",
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 1001
+              }
+            }
+          }
+        }
+      ]
+    },
+    "atCheckpoint": {
+      "pageInfo": {
+        "startCursor": "eyJjIjo1LCJ0Ijo2fQ==",
+        "endCursor": "eyJjIjo1LCJ0Ijo4fQ==",
+        "hasPreviousPage": false,
+        "hasNextPage": false
+      },
+      "edges": [
+        {
+          "cursor": "eyJjIjo1LCJ0Ijo2fQ==",
+          "node": {
+            "digest": "qdSwcToNtAVT8TtNUoNG4ZFo1DnVbEn5iLmkHTKuMfi",
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 5
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjo1LCJ0Ijo3fQ==",
+          "node": {
+            "digest": "5WTk3hjbQaLmjgTJwb1JYj94fDTH4P2m7fxeA7m78Ca3",
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 5
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjo1LCJ0Ijo4fQ==",
+          "node": {
+            "digest": "BsKiwYgspBG3CVZnFFEDUftYQ42xBi6p2i4TgSU7a4Uq",
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 5
+              }
+            }
+          }
+        }
+      ]
+    },
+    "scanAcrossBlocks": {
+      "pageInfo": {
+        "startCursor": "eyJjIjoxLCJ0IjoyfQ==",
+        "endCursor": "eyJjIjoxMDAxLCJ0Ijo5fQ==",
+        "hasPreviousPage": false,
+        "hasNextPage": false
+      },
+      "edges": [
+        {
+          "cursor": "eyJjIjoxLCJ0IjoyfQ==",
+          "node": {
+            "digest": "CbqfqPqiJXnc3b5oXC1RmGdgQTHGdjwe3vay6AoMGdNc",
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 1
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjoyLCJ0IjozfQ==",
+          "node": {
+            "digest": "GxzHztdrcHGeWdCNt4DwE5WdeyZ4dDpjpmv8TuqE1K7B",
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 2
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjozLCJ0Ijo0fQ==",
+          "node": {
+            "digest": "7PQs2ZG4cXQ52kE4h2bGoq4mqRdANXhN5hXZNpebVqLq",
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 3
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjo0LCJ0Ijo1fQ==",
+          "node": {
+            "digest": "iNKPq8CmUWRDTYnEvAggeizPXCXqFUvi8BWhMnSz2ao",
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 4
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjo1LCJ0Ijo2fQ==",
+          "node": {
+            "digest": "qdSwcToNtAVT8TtNUoNG4ZFo1DnVbEn5iLmkHTKuMfi",
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 5
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjo1LCJ0Ijo3fQ==",
+          "node": {
+            "digest": "5WTk3hjbQaLmjgTJwb1JYj94fDTH4P2m7fxeA7m78Ca3",
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 5
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjo1LCJ0Ijo4fQ==",
+          "node": {
+            "digest": "BsKiwYgspBG3CVZnFFEDUftYQ42xBi6p2i4TgSU7a4Uq",
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 5
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjoxMDAxLCJ0Ijo5fQ==",
+          "node": {
+            "digest": "6BtSF6K4ePk4qXZJx8NFREr51iJr2jaBz8Ln2K3P3byC",
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 1001
+              }
+            }
+          }
+        }
+      ]
+    },
+    "emptyNonExistent": {
+      "pageInfo": {
+        "startCursor": null,
+        "endCursor": null,
+        "hasPreviousPage": false,
+        "hasNextPage": false
+      },
+      "edges": []
+    },
+    "emptyConflicting": {
+      "pageInfo": {
+        "startCursor": null,
+        "endCursor": null,
+        "hasPreviousPage": false,
+        "hasNextPage": false
+      },
+      "edges": []
+    },
+    "emptyBeyondData": {
+      "pageInfo": {
+        "startCursor": null,
+        "endCursor": null,
+        "hasPreviousPage": false,
+        "hasNextPage": false
+      },
+      "edges": []
+    }
+  }
+}
+
+task 18, lines 124-146:
+//# run-graphql --cursors {"t":5,"c":4} {"t":7,"c":5} {"t":20,"c":1001}
+Response: {
+  "data": {
+    "first2": {
+      "pageInfo": {
+        "startCursor": "eyJjIjowLCJ0IjowfQ==",
+        "endCursor": "eyJjIjoxLCJ0IjoyfQ==",
+        "hasPreviousPage": false,
+        "hasNextPage": true
+      },
+      "edges": [
+        {
+          "cursor": "eyJjIjowLCJ0IjowfQ==",
+          "node": {
+            "digest": "BTts7EAgPrFtKKMFM2WB2zz8zkiTumXwN7C8DjRpRDEb",
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 0
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjoxLCJ0IjoyfQ==",
+          "node": {
+            "digest": "CbqfqPqiJXnc3b5oXC1RmGdgQTHGdjwe3vay6AoMGdNc",
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 1
+              }
+            }
+          }
+        }
+      ]
+    },
+    "last2": {
+      "pageInfo": {
+        "startCursor": "eyJjIjo1LCJ0Ijo4fQ==",
+        "endCursor": "eyJjIjoxMDAxLCJ0Ijo5fQ==",
+        "hasPreviousPage": true,
+        "hasNextPage": false
+      },
+      "edges": [
+        {
+          "cursor": "eyJjIjo1LCJ0Ijo4fQ==",
+          "node": {
+            "digest": "BsKiwYgspBG3CVZnFFEDUftYQ42xBi6p2i4TgSU7a4Uq",
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 5
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjoxMDAxLCJ0Ijo5fQ==",
+          "node": {
+            "digest": "6BtSF6K4ePk4qXZJx8NFREr51iJr2jaBz8Ln2K3P3byC",
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 1001
+              }
+            }
+          }
+        }
+      ]
+    },
+    "firstAfter": {
+      "pageInfo": {
+        "startCursor": "eyJjIjo1LCJ0Ijo2fQ==",
+        "endCursor": "eyJjIjoxMDAxLCJ0Ijo5fQ==",
+        "hasPreviousPage": true,
+        "hasNextPage": false
+      },
+      "edges": [
+        {
+          "cursor": "eyJjIjo1LCJ0Ijo2fQ==",
+          "node": {
+            "digest": "qdSwcToNtAVT8TtNUoNG4ZFo1DnVbEn5iLmkHTKuMfi",
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 5
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjo1LCJ0Ijo3fQ==",
+          "node": {
+            "digest": "5WTk3hjbQaLmjgTJwb1JYj94fDTH4P2m7fxeA7m78Ca3",
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 5
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjo1LCJ0Ijo4fQ==",
+          "node": {
+            "digest": "BsKiwYgspBG3CVZnFFEDUftYQ42xBi6p2i4TgSU7a4Uq",
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 5
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjoxMDAxLCJ0Ijo5fQ==",
+          "node": {
+            "digest": "6BtSF6K4ePk4qXZJx8NFREr51iJr2jaBz8Ln2K3P3byC",
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 1001
+              }
+            }
+          }
+        }
+      ]
+    },
+    "lastBefore": {
+      "pageInfo": {
+        "startCursor": "eyJjIjowLCJ0IjowfQ==",
+        "endCursor": "eyJjIjo1LCJ0Ijo2fQ==",
+        "hasPreviousPage": false,
+        "hasNextPage": true
+      },
+      "edges": [
+        {
+          "cursor": "eyJjIjowLCJ0IjowfQ==",
+          "node": {
+            "digest": "BTts7EAgPrFtKKMFM2WB2zz8zkiTumXwN7C8DjRpRDEb",
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 0
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjoxLCJ0IjoyfQ==",
+          "node": {
+            "digest": "CbqfqPqiJXnc3b5oXC1RmGdgQTHGdjwe3vay6AoMGdNc",
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 1
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjoyLCJ0IjozfQ==",
+          "node": {
+            "digest": "GxzHztdrcHGeWdCNt4DwE5WdeyZ4dDpjpmv8TuqE1K7B",
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 2
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjozLCJ0Ijo0fQ==",
+          "node": {
+            "digest": "7PQs2ZG4cXQ52kE4h2bGoq4mqRdANXhN5hXZNpebVqLq",
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 3
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjo0LCJ0Ijo1fQ==",
+          "node": {
+            "digest": "iNKPq8CmUWRDTYnEvAggeizPXCXqFUvi8BWhMnSz2ao",
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 4
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjo1LCJ0Ijo2fQ==",
+          "node": {
+            "digest": "qdSwcToNtAVT8TtNUoNG4ZFo1DnVbEn5iLmkHTKuMfi",
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 5
+              }
+            }
+          }
+        }
+      ]
+    },
+    "firstBefore": {
+      "pageInfo": {
+        "startCursor": "eyJjIjowLCJ0IjowfQ==",
+        "endCursor": "eyJjIjo1LCJ0Ijo2fQ==",
+        "hasPreviousPage": false,
+        "hasNextPage": true
+      },
+      "edges": [
+        {
+          "cursor": "eyJjIjowLCJ0IjowfQ==",
+          "node": {
+            "digest": "BTts7EAgPrFtKKMFM2WB2zz8zkiTumXwN7C8DjRpRDEb",
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 0
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjoxLCJ0IjoyfQ==",
+          "node": {
+            "digest": "CbqfqPqiJXnc3b5oXC1RmGdgQTHGdjwe3vay6AoMGdNc",
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 1
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjoyLCJ0IjozfQ==",
+          "node": {
+            "digest": "GxzHztdrcHGeWdCNt4DwE5WdeyZ4dDpjpmv8TuqE1K7B",
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 2
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjozLCJ0Ijo0fQ==",
+          "node": {
+            "digest": "7PQs2ZG4cXQ52kE4h2bGoq4mqRdANXhN5hXZNpebVqLq",
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 3
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjo0LCJ0Ijo1fQ==",
+          "node": {
+            "digest": "iNKPq8CmUWRDTYnEvAggeizPXCXqFUvi8BWhMnSz2ao",
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 4
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjo1LCJ0Ijo2fQ==",
+          "node": {
+            "digest": "qdSwcToNtAVT8TtNUoNG4ZFo1DnVbEn5iLmkHTKuMfi",
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 5
+              }
+            }
+          }
+        }
+      ]
+    },
+    "lastAfter": {
+      "pageInfo": {
+        "startCursor": "eyJjIjo1LCJ0Ijo2fQ==",
+        "endCursor": "eyJjIjoxMDAxLCJ0Ijo5fQ==",
+        "hasPreviousPage": true,
+        "hasNextPage": false
+      },
+      "edges": [
+        {
+          "cursor": "eyJjIjo1LCJ0Ijo2fQ==",
+          "node": {
+            "digest": "qdSwcToNtAVT8TtNUoNG4ZFo1DnVbEn5iLmkHTKuMfi",
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 5
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjo1LCJ0Ijo3fQ==",
+          "node": {
+            "digest": "5WTk3hjbQaLmjgTJwb1JYj94fDTH4P2m7fxeA7m78Ca3",
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 5
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjo1LCJ0Ijo4fQ==",
+          "node": {
+            "digest": "BsKiwYgspBG3CVZnFFEDUftYQ42xBi6p2i4TgSU7a4Uq",
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 5
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjoxMDAxLCJ0Ijo5fQ==",
+          "node": {
+            "digest": "6BtSF6K4ePk4qXZJx8NFREr51iJr2jaBz8Ln2K3P3byC",
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 1001
+              }
+            }
+          }
+        }
+      ]
+    },
+    "windowFirst": {
+      "pageInfo": {
+        "startCursor": "eyJjIjo1LCJ0Ijo2fQ==",
+        "endCursor": "eyJjIjo1LCJ0Ijo2fQ==",
+        "hasPreviousPage": true,
+        "hasNextPage": true
+      },
+      "edges": [
+        {
+          "cursor": "eyJjIjo1LCJ0Ijo2fQ==",
+          "node": {
+            "digest": "qdSwcToNtAVT8TtNUoNG4ZFo1DnVbEn5iLmkHTKuMfi",
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 5
+              }
+            }
+          }
+        }
+      ]
+    },
+    "windowLast": {
+      "pageInfo": {
+        "startCursor": "eyJjIjo1LCJ0Ijo2fQ==",
+        "endCursor": "eyJjIjo1LCJ0Ijo2fQ==",
+        "hasPreviousPage": true,
+        "hasNextPage": true
+      },
+      "edges": [
+        {
+          "cursor": "eyJjIjo1LCJ0Ijo2fQ==",
+          "node": {
+            "digest": "qdSwcToNtAVT8TtNUoNG4ZFo1DnVbEn5iLmkHTKuMfi",
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 5
+              }
+            }
+          }
+        }
+      ]
+    },
+    "nonexistentCursor": {
+      "pageInfo": {
+        "startCursor": null,
+        "endCursor": null,
+        "hasPreviousPage": false,
+        "hasNextPage": false
+      },
+      "edges": []
+    },
+    "invalidOrder": {
+      "pageInfo": {
+        "startCursor": null,
+        "endCursor": null,
+        "hasPreviousPage": false,
+        "hasNextPage": false
+      },
+      "edges": []
+    }
+  }
+}
+
+task 19, lines 148-153:
+//# run-graphql
+Response: {
+  "data": null,
+  "errors": [
+    {
+      "message": "Failed to parse \"TransactionFilter\": Unbounded scan, add beforeCheckpoint or atCheckpoint filters (Scan limit: 3000000).",
+      "locations": [
+        {
+          "line": 2,
+          "column": 48
+        }
+      ],
+      "path": [
+        "noCheckpointBounds"
+      ]
+    }
+  ]
+}
+
+task 20, lines 155-160:
+//# run-graphql
+Response: {
+  "data": null,
+  "errors": [
+    {
+      "message": "Failed to parse \"TransactionFilter\": Unbounded scan, add beforeCheckpoint or atCheckpoint filters (Scan limit: 3000000).",
+      "locations": [
+        {
+          "line": 2,
+          "column": 43
+        }
+      ],
+      "path": [
+        "unboundedScan"
+      ]
+    }
+  ]
+}
+
+task 21, lines 162-167:
+//# run-graphql
+Response: {
+  "data": null,
+  "errors": [
+    {
+      "message": "Failed to parse \"TransactionFilter\": Scan of 3000001 checkpoints exceeds maximum of 3000000. Use afterCheckpoint and beforeCheckpoint or atCheckpoint filters to reduce the range.",
+      "locations": [
+        {
+          "line": 2,
+          "column": 39
+        }
+      ],
+      "path": [
+        "scanLimit"
+      ]
+    }
+  ]
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_scan_limit_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_scan_limit_tests.rs
@@ -1,0 +1,75 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::time::Duration;
+
+use insta::assert_json_snapshot;
+use prometheus::Registry;
+use reqwest::Client;
+use serde_json::json;
+use simulacrum::Simulacrum;
+use sui_indexer_alt_e2e_tests::FullCluster;
+use sui_indexer_alt_e2e_tests::OffchainClusterConfig;
+use sui_indexer_alt_graphql::config::Limits;
+use sui_indexer_alt_graphql::config::RpcConfig;
+
+#[tokio::test]
+async fn test_scan_limit_exceeded() {
+    let registry = Registry::new();
+
+    let graphql_config = RpcConfig {
+        limits: Limits {
+            max_scan_limit: 10,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let mut cluster = FullCluster::new_with_configs(
+        Simulacrum::new(),
+        OffchainClusterConfig {
+            graphql_config,
+            ..Default::default()
+        },
+        &registry,
+    )
+    .await
+    .expect("Failed to create cluster");
+
+    // Create 20 checkpoints to exceed the limit of 10
+    for _ in 0..20 {
+        cluster.create_checkpoint().await;
+    }
+
+    cluster
+        .wait_for_graphql(20, Duration::from_secs(30))
+        .await
+        .expect("Timed out waiting for checkpoint");
+
+    // Query that would scan all 20 checkpoints (exceeds limit of 10)
+    let query = r#"
+        query($addr: SuiAddress!) {
+            scanTransactions(filter: { affectedAddress: $addr, afterCheckpoint: 0, beforeCheckpoint: 21 }) {
+                edges { node { digest } }
+            }
+        }
+    "#;
+
+    let variables = json!({
+        "addr": "0x0000000000000000000000000000000000000000000000000000000000000000"
+    });
+
+    let client = Client::new();
+    let response = client
+        .post(cluster.graphql_url())
+        .json(&json!({
+            "query": query,
+            "variables": variables
+        }))
+        .send()
+        .await
+        .expect("Failed to send request");
+
+    let result: serde_json::Value = response.json().await.expect("Failed to parse response");
+    assert_json_snapshot!(result["errors"]);
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/snapshots/graphql_scan_limit_tests__scan_limit_exceeded.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/snapshots/graphql_scan_limit_tests__scan_limit_exceeded.snap
@@ -1,0 +1,18 @@
+---
+source: crates/sui-indexer-alt-e2e-tests/tests/graphql_scan_limit_tests.rs
+expression: "result[\"errors\"]"
+---
+[
+  {
+    "message": "Failed to parse \"TransactionFilter\": Scan of 20 checkpoints exceeds maximum of 10. Use afterCheckpoint and beforeCheckpoint or atCheckpoint filters to reduce the range.",
+    "locations": [
+      {
+        "line": 3,
+        "column": 38
+      }
+    ],
+    "path": [
+      "scanTransactions"
+    ]
+  }
+]

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -1448,7 +1448,7 @@ input EventFilter {
 	"""
 	Events emitted by a particular module. An event is emitted by a particular module if some function in the module is called by a PTB and emits an event.
 	
-	Modules can be filtered by their package, or package::module. We currently do not support filtering by emitting module and event type at the same time so if both are provided in one filter, the query will error.
+	Modules can be filtered by their package, or package::module.
 	"""
 	module: String
 	"""
@@ -3638,6 +3638,21 @@ type Query {
 	"""
 	protocolConfigs(version: UInt53): ProtocolConfigs
 	"""
+	The events that exist in the network, optionally filtered by multiple event filters.
+	Supports combining filters (e.g. `sender` AND `module` AND `type`). The checkpoint range being scanned can not exceed `ServiceConfig.maxScanLimit` — use `afterCheckpoint`, `beforeCheckpoint`, or `atCheckpoint` to narrow it. Supports a longer retention than `Query.events`.
+	
+	Note that this differs from `Query.events`, which supports a single filter with an optional sender filter, with no checkpoint range restriction and generally a shorter retention.
+	"""
+	scanEvents(first: Int, after: String, last: Int, before: String, filter: EventFilter!): EventConnection
+	"""
+	The transactions that exist in the network, optionally filtered by multiple transaction filters.
+	
+	Supports combining filters (e.g. `affectedAddress` AND `function`). The checkpoint range being scanned can not exceed `ServiceConfig.maxScanLimit` — use `checkpointBound` to narrow it. Supports a longer retention than `Query.transactions`.
+	
+	Note that this differs from `Query.transactions`, which supports a single filter with an optional sender filter, with no checkpoint range restriction and generally a shorter retention.
+	"""
+	scanTransactions(first: Int, after: String, last: Int, before: String, filter: TransactionFilter!): TransactionConnection
+	"""
 	Configuration for this RPC service.
 	"""
 	serviceConfig: ServiceConfig!
@@ -3913,6 +3928,10 @@ type ServiceConfig {
 	Maximum number of paginated fields that can return results in a single request. Queries on paginated fields that exceed this limit will return an error.
 	"""
 	maxRichQueries: Int
+	"""
+	Maximum number of checkpoints that can be scanned in a single scanning pagination query.
+	"""
+	maxScanLimit: Int
 	"""
 	Maximum size in bytes allowed for the `txBytes` and `signatures` parameters of an `executeTransaction` or `simulateTransaction` field, or the `bytes` and `signature` parameters of a `verifyZkLoginSignature` field.
 	

--- a/crates/sui-indexer-alt-graphql/src/api/query.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/query.rs
@@ -35,8 +35,11 @@ use crate::api::types::dynamic_field::DynamicField;
 use crate::api::types::epoch::CEpoch;
 use crate::api::types::epoch::Epoch;
 use crate::api::types::event::CEvent;
+use crate::api::types::event::CScanEvent;
 use crate::api::types::event::Event;
 use crate::api::types::event::filter::EventFilter;
+use crate::api::types::event::filter::EventFilterValidator as EFValidator;
+
 use crate::api::types::move_object::MoveObject;
 use crate::api::types::move_package;
 use crate::api::types::move_package::MovePackage;
@@ -55,8 +58,10 @@ use crate::api::types::object_filter::ObjectFilterValidator as OFValidator;
 use crate::api::types::protocol_configs::ProtocolConfigs;
 use crate::api::types::service_config::ServiceConfig;
 use crate::api::types::simulation_result::SimulationResult;
+use crate::api::types::transaction::CScanTransaction;
 use crate::api::types::transaction::CTransaction;
 use crate::api::types::transaction::Transaction;
+use crate::api::types::transaction::filter::ScanFilterValidator;
 use crate::api::types::transaction::filter::TransactionFilter;
 use crate::api::types::transaction::filter::TransactionFilterValidator as TFValidator;
 use crate::api::types::transaction_effects::TransactionEffects;
@@ -293,7 +298,7 @@ impl Query {
         after: Option<CEvent>,
         last: Option<u64>,
         before: Option<CEvent>,
-        filter: Option<EventFilter>,
+        #[graphql(validator(custom = "EFValidator"))] filter: Option<EventFilter>,
     ) -> Option<Result<Connection<String, Event>, RpcError>> {
         Some(
             async {
@@ -303,6 +308,32 @@ impl Query {
                 let page = Page::from_params(limits, first, after, last, before)?;
 
                 Event::paginate(ctx, scope, page, filter.unwrap_or_default()).await
+            }
+            .await,
+        )
+    }
+
+    /// The events that exist in the network, optionally filtered by multiple event filters.
+    /// Supports combining filters (e.g. `sender` AND `module` AND `type`). The checkpoint range being scanned can not exceed `ServiceConfig.maxScanLimit` — use `afterCheckpoint`, `beforeCheckpoint`, or `atCheckpoint` to narrow it. Supports a longer retention than `Query.events`.
+    ///
+    /// Note that this differs from `Query.events`, which supports a single filter with an optional sender filter, with no checkpoint range restriction and generally a shorter retention.
+    async fn scan_events(
+        &self,
+        ctx: &Context<'_>,
+        first: Option<u64>,
+        after: Option<CScanEvent>,
+        last: Option<u64>,
+        before: Option<CScanEvent>,
+        #[graphql(validator(custom = "ScanFilterValidator::new(ctx)"))] filter: EventFilter,
+    ) -> Option<Result<Connection<String, Event>, RpcError>> {
+        Some(
+            async {
+                let scope = self.scope(ctx)?;
+                let pagination: &PaginationConfig = ctx.data()?;
+                let limits = pagination.limits("Query", "events");
+                let page = Page::from_params(limits, first, after, last, before)?;
+
+                Event::scan(ctx, scope, page, filter).await
             }
             .await,
         )
@@ -710,9 +741,35 @@ impl Query {
                 let limits = pagination.limits("Query", "transactions");
                 let page = Page::from_params(limits, first, after, last, before)?;
 
-                // Use the filter if provided, otherwise use default (unfiltered)
                 let filter = filter.unwrap_or_default();
                 Transaction::paginate(ctx, scope, page, filter).await
+            }
+            .await,
+        )
+    }
+
+    /// The transactions that exist in the network, optionally filtered by multiple transaction filters.
+    ///
+    /// Supports combining filters (e.g. `affectedAddress` AND `function`). The checkpoint range being scanned can not exceed `ServiceConfig.maxScanLimit` — use `checkpointBound` to narrow it. Supports a longer retention than `Query.transactions`.
+    ///
+    /// Note that this differs from `Query.transactions`, which supports a single filter with an optional sender filter, with no checkpoint range restriction and generally a shorter retention.
+    async fn scan_transactions(
+        &self,
+        ctx: &Context<'_>,
+        first: Option<u64>,
+        after: Option<CScanTransaction>,
+        last: Option<u64>,
+        before: Option<CScanTransaction>,
+        #[graphql(validator(custom = "ScanFilterValidator::new(ctx)"))] filter: TransactionFilter,
+    ) -> Option<Result<Connection<String, Transaction>, RpcError>> {
+        Some(
+            async {
+                let scope = self.scope(ctx)?;
+                let pagination: &PaginationConfig = ctx.data()?;
+                let limits = pagination.limits("Query", "scanTransactions");
+                let page = Page::from_params(limits, first, after, last, before)?;
+
+                Transaction::scan(ctx, scope, page, filter).await
             }
             .await,
         )

--- a/crates/sui-indexer-alt-graphql/src/api/scalars/sui_address.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/scalars/sui_address.rs
@@ -53,6 +53,10 @@ impl ScalarType for SuiAddress {
 }
 
 impl SuiAddress {
+    pub fn into_bytes(self) -> [u8; SUI_ADDRESS_LENGTH] {
+        self.0
+    }
+
     pub fn into_vec(self) -> Vec<u8> {
         self.0.to_vec()
     }

--- a/crates/sui-indexer-alt-graphql/src/api/types/available_range.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/available_range.rs
@@ -140,6 +140,8 @@ impl AvailableRangeKey {
 pub(crate) fn pipeline_unavailable(pipeline: &str) -> RpcError {
     match pipeline {
         "consistent" => feature_unavailable("consistent queries across objects and balances"),
+        "cp_blooms" => feature_unavailable("scanning queries on transactions and events"),
+        "cp_bloom_blocks" => feature_unavailable("scanning queries on transactions and events"),
         "cp_sequence_numbers" => feature_unavailable("querying checkpoints"),
         "ev_emit_mod" => feature_unavailable("querying events by emitting module"),
         "ev_struct_inst" => feature_unavailable("querying events by type"),
@@ -388,6 +390,10 @@ collect_pipelines! {
         } else if filters.contains("kind") {
             pipelines.insert("tx_kinds".to_string());
         }
+    };
+    Query.[scanTransactions, scanEvents] |pipelines, _filters| {
+        pipelines.insert("cp_blooms".to_string());
+        pipelines.insert("cp_bloom_blocks".to_string());
     };
 
     TransactionEffects.[balanceChanges] |pipelines, _filters| {

--- a/crates/sui-indexer-alt-graphql/src/api/types/checkpoint/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/checkpoint/mod.rs
@@ -46,7 +46,7 @@ pub(crate) struct Checkpoint {
 }
 
 #[derive(Clone)]
-struct CheckpointContents {
+pub(crate) struct CheckpointContents {
     // TODO: Remove when the scope is used in a nested field.
     #[allow(unused)]
     scope: Scope,

--- a/crates/sui-indexer-alt-graphql/src/api/types/event/filter.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/event/filter.rs
@@ -4,7 +4,10 @@
 use std::ops::Range;
 
 use anyhow::Context as _;
+use async_graphql::CustomValidator;
 use async_graphql::InputObject;
+use async_graphql::InputValueError;
+use sui_indexer_alt_schema::blooms::should_skip_for_bloom;
 use sui_pg_db::query::Query;
 use sui_sql_macro::query;
 use sui_types::event::Event as NativeEvent;
@@ -16,7 +19,6 @@ use crate::api::scalars::uint53::UInt53;
 use crate::api::types::event::CEvent;
 use crate::api::types::lookups::CheckpointBounds;
 use crate::error::RpcError;
-use crate::error::feature_unavailable;
 use crate::pagination::Page;
 
 #[derive(InputObject, Debug, Default, Clone)]
@@ -35,7 +37,7 @@ pub(crate) struct EventFilter {
 
     /// Events emitted by a particular module. An event is emitted by a particular module if some function in the module is called by a PTB and emits an event.
     ///
-    /// Modules can be filtered by their package, or package::module. We currently do not support filtering by emitting module and event type at the same time so if both are provided in one filter, the query will error.
+    /// Modules can be filtered by their package, or package::module.
     pub module: Option<ModuleFilter>,
 
     /// This field is used to specify the type of event emitted.
@@ -51,12 +53,7 @@ impl EventFilter {
     /// Uses the provided transaction bounds subquery to limit results to a specific transaction range
     pub(crate) fn query<'q>(&self) -> Result<Query<'q>, RpcError> {
         let table = match (&self.module, &self.type_) {
-            (Some(_), Some(_)) => {
-                return Err(feature_unavailable(
-                    "Filtering by both emitting module and event type is not supported",
-                ));
-            }
-            (Some(_), None) => query!("ev_emit_mod"),
+            (Some(_), _) => query!("ev_emit_mod"),
             (None, _) => query!("ev_struct_inst"),
         };
 
@@ -168,6 +165,19 @@ impl EventFilter {
         }
         filters
     }
+
+    /// Values to probe in bloom filters.
+    pub(crate) fn bloom_probe_values(&self) -> Vec<[u8; 32]> {
+        [
+            self.sender.map(|s| s.into_bytes()),
+            self.module.as_ref().map(|m| m.package().into_bytes()),
+            self.type_.as_ref().map(|t| t.package().into_bytes()),
+        ]
+        .into_iter()
+        .flatten()
+        .filter(|v| !should_skip_for_bloom(v))
+        .collect()
+    }
 }
 
 impl CheckpointBounds for EventFilter {
@@ -181,6 +191,19 @@ impl CheckpointBounds for EventFilter {
 
     fn before_checkpoint(&self) -> Option<UInt53> {
         self.before_checkpoint
+    }
+}
+
+pub(crate) struct EventFilterValidator;
+
+impl CustomValidator<EventFilter> for EventFilterValidator {
+    fn check(&self, filter: &EventFilter) -> Result<(), InputValueError<EventFilter>> {
+        if filter.module.is_some() && filter.type_.is_some() {
+            return Err(InputValueError::custom(
+                "Filtering by both emitting module and event type is not supported",
+            ));
+        }
+        Ok(())
     }
 }
 

--- a/crates/sui-indexer-alt-graphql/src/api/types/event/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/event/mod.rs
@@ -24,6 +24,7 @@ use crate::api::scalars::date_time::DateTime;
 use crate::api::scalars::uint53::UInt53;
 use crate::api::types::address::Address;
 use crate::api::types::available_range::AvailableRangeKey;
+use crate::api::types::checkpoint::filter::checkpoint_bounds;
 use crate::api::types::event::filter::EventFilter;
 use crate::api::types::lookups::CheckpointBounds;
 use crate::api::types::lookups::TxBoundsCursor;
@@ -32,6 +33,7 @@ use crate::api::types::move_package::MovePackage;
 use crate::api::types::move_type::MoveType;
 use crate::api::types::move_value::MoveValue;
 use crate::api::types::transaction::Transaction;
+use crate::api::types::transaction::bloom;
 use crate::error::RpcError;
 use crate::extensions::query_limits;
 use crate::pagination::Page;
@@ -40,6 +42,8 @@ use crate::task::watermark::Watermarks;
 
 pub(crate) mod filter;
 mod lookups;
+
+pub(crate) type CScanEvent = JsonCursor<ScanEventCursor>;
 
 #[derive(Serialize, Deserialize, PartialEq, Eq, Clone, Debug, PartialOrd, Ord, Copy)]
 pub(crate) struct EventCursor {
@@ -50,6 +54,16 @@ pub(crate) struct EventCursor {
 }
 
 pub(crate) type CEvent = JsonCursor<EventCursor>;
+
+#[derive(Serialize, Deserialize, PartialEq, Eq, Clone, Debug, PartialOrd, Ord, Copy)]
+pub(crate) struct ScanEventCursor {
+    #[serde(rename = "c")]
+    pub cp_sequence_number: u64,
+    #[serde(rename = "t")]
+    pub tx_sequence_number: u64,
+    #[serde(rename = "e")]
+    pub ev_sequence_number: u64,
+}
 
 #[derive(Clone)]
 pub(crate) struct Event {
@@ -186,6 +200,46 @@ impl Event {
         .await?;
 
         page.paginate_results(events, |(c, _)| JsonCursor::new(*c), |(_, e)| Ok(e))
+    }
+
+    /// Scan a bounded checkpoint range for events matching the filter. Uses bloom filters to
+    /// find candidate checkpoints that may contain matching events, then fetches and returns
+    /// events that match the filter.
+    pub(crate) async fn scan(
+        ctx: &Context<'_>,
+        scope: Scope,
+        page: Page<CScanEvent>,
+        filter: EventFilter,
+    ) -> Result<Connection<String, Event>, RpcError> {
+        let watermarks: &Arc<Watermarks> = ctx.data()?;
+        let available_range_key = AvailableRangeKey {
+            type_: "Query".to_string(),
+            field: Some("scanEvents".to_string()),
+            filters: Some(filter.active_filters()),
+        };
+        let reader_lo = available_range_key.reader_lo(watermarks)?;
+
+        let Some(checkpoint_viewed_at) = scope.checkpoint_viewed_at() else {
+            return Ok(Connection::new(false, false));
+        };
+
+        let Some(cp_bounds) = checkpoint_bounds(
+            filter.after_checkpoint.map(u64::from),
+            filter.at_checkpoint.map(u64::from),
+            filter.before_checkpoint.map(u64::from),
+            reader_lo,
+            checkpoint_viewed_at,
+        ) else {
+            return Ok(Connection::new(false, false));
+        };
+
+        let events = bloom::events(ctx, &scope, &filter, &page, cp_bounds).await?;
+
+        page.paginate_filtered(
+            &events,
+            |event| filter.matches(&event.native),
+            |event| Ok::<_, RpcError>(event.clone()),
+        )
     }
 }
 

--- a/crates/sui-indexer-alt-graphql/src/api/types/service_config.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/service_config.rs
@@ -329,6 +329,12 @@ impl ServiceConfig {
         )
     }
 
+    /// Maximum number of checkpoints that can be scanned in a single scanning pagination query.
+    async fn max_scan_limit(&self, ctx: &Context<'_>) -> Result<Option<u64>, RpcError> {
+        let limits: &Limits = ctx.data()?;
+        Ok(Some(limits.max_scan_limit))
+    }
+
     /// Range of checkpoints for which data is available for a query type, field and optional filter. If filter is not provided, the strictest retention range for the query and type is returned.
     async fn available_range(
         &self,

--- a/crates/sui-indexer-alt-graphql/src/api/types/snapshots/sui_indexer_alt_graphql__api__types__available_range__field_piplines_tests__registry_collect_pipelines_snapshot.snap
+++ b/crates/sui-indexer-alt-graphql/src/api/types/snapshots/sui_indexer_alt_graphql__api__types__available_range__field_piplines_tests__registry_collect_pipelines_snapshot.snap
@@ -1406,6 +1406,9 @@ Query.events
 Query.events (filter: module)
   => {"ev_emit_mod", "tx_digests"}
 
+Query.scanEvents
+  => {"cp_bloom_blocks", "cp_blooms"}
+
 Query.multiGetAddresses
   => {}
 
@@ -1483,6 +1486,9 @@ Query.transactions (filter: affectedObject)
 
 Query.transactions (filter: sentAddress)
   => {"cp_sequence_numbers", "tx_affected_addresses", "tx_digests"}
+
+Query.scanTransactions
+  => {"cp_bloom_blocks", "cp_blooms"}
 
 Query.type
   => {}
@@ -1602,6 +1608,9 @@ ServiceConfig.maxDisassembledModuleSize
   => {}
 
 ServiceConfig.maxRichQueries
+  => {}
+
+ServiceConfig.maxScanLimit
   => {}
 
 ServiceConfig.availableRange

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction/bloom/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction/bloom/mod.rs
@@ -1,0 +1,413 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+use std::ops::RangeInclusive;
+
+use anyhow::Context as _;
+use async_graphql::Context;
+use diesel::QueryableByName;
+use diesel::sql_types::BigInt;
+use diesel::sql_types::Integer;
+use diesel::sql_types::SmallInt;
+use sui_indexer_alt_reader::kv_loader::KvLoader;
+use sui_indexer_alt_reader::kv_loader::TransactionContents;
+use sui_indexer_alt_reader::kv_loader::TransactionEventsContents;
+use sui_indexer_alt_reader::pg_reader::PgReader;
+use sui_indexer_alt_schema::blooms::blocked::BlockedBloomProbe;
+use sui_indexer_alt_schema::blooms::bloom::BloomProbe;
+use sui_indexer_alt_schema::cp_bloom_blocks::CP_BLOCK_SIZE;
+use sui_indexer_alt_schema::cp_bloom_blocks::CpBlockedBloomFilter;
+use sui_indexer_alt_schema::cp_bloom_blocks::cp_block_index;
+use sui_indexer_alt_schema::cp_blooms::CpBloomFilter;
+use sui_pg_db::query::Query;
+use sui_sql_macro::query;
+use sui_types::base_types::ExecutionDigests;
+use sui_types::digests::TransactionDigest;
+
+use crate::api::types::event::CScanEvent;
+use crate::api::types::event::Event;
+use crate::api::types::event::ScanEventCursor;
+use crate::api::types::event::filter::EventFilter;
+use crate::api::types::transaction::CScanTransaction;
+use crate::api::types::transaction::ScanTransactionCursor;
+use crate::api::types::transaction::filter::TransactionFilter;
+use crate::error::RpcError;
+use crate::pagination::Page;
+use crate::scope::Scope;
+
+/// Multiplier to page limit to adjust for bloom filter false positives.
+const OVERFETCH_MULTIPLIER: f64 = 3.0;
+
+pub(super) type EventsBySequenceNumbers = BTreeMap<ScanEventCursor, Event>;
+
+pub(crate) trait CpBoundsCursor {
+    fn cp_sequence_number(&self) -> u64;
+}
+
+impl CpBoundsCursor for CScanTransaction {
+    fn cp_sequence_number(&self) -> u64 {
+        self.cp_sequence_number
+    }
+}
+
+impl CpBoundsCursor for CScanEvent {
+    fn cp_sequence_number(&self) -> u64 {
+        self.cp_sequence_number
+    }
+}
+
+pub(super) type TransactionsBySequenceNumbers =
+    BTreeMap<ScanTransactionCursor, (TransactionDigest, TransactionContents)>;
+
+pub(crate) async fn transactions(
+    ctx: &Context<'_>,
+    page: &Page<CScanTransaction>,
+    filter: &TransactionFilter,
+    cp_bounds: RangeInclusive<u64>,
+) -> Result<TransactionsBySequenceNumbers, RpcError> {
+    let kv_loader: &KvLoader = ctx.data()?;
+
+    let (cp_lo, cp_hi_inclusive) = clamped_cp_bounds(page, &cp_bounds);
+    let filter_values = filter.bloom_probe_values();
+    let candidate_cps = candidate_cps(ctx, &filter_values, cp_lo, cp_hi_inclusive, page).await?;
+
+    if candidate_cps.is_empty() {
+        return Ok(BTreeMap::new());
+    }
+
+    let checkpoints = kv_loader
+        .load_many_checkpoints(candidate_cps.to_vec())
+        .await
+        .context("Failed to load checkpoint transactions")?;
+    let sequenced_tx_digests: Vec<_> = checkpoints
+        .into_values()
+        .flat_map(|(summary, content, _)| {
+            let cp_seq = summary.sequence_number;
+            content
+                .enumerate_transactions(&summary)
+                .map(move |(tx_seq, &ExecutionDigests { transaction, .. })| {
+                    (tx_seq, cp_seq, transaction)
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect();
+
+    let digests = sequenced_tx_digests
+        .iter()
+        .map(|(_, _, digest)| *digest)
+        .collect();
+    let mut transactions_by_digest = kv_loader
+        .load_many_transactions(digests)
+        .await
+        .context("Failed to load transactions")?;
+
+    sequenced_tx_digests
+        .into_iter()
+        .map(|(tx_seq, cp_seq, digest)| -> Result<_, RpcError> {
+            let contents = transactions_by_digest
+                .remove(&digest)
+                .with_context(|| format!("Failed to fetch Transaction with digest {digest}"))?;
+            let cursor = ScanTransactionCursor {
+                tx_sequence_number: tx_seq,
+                cp_sequence_number: cp_seq,
+            };
+            Ok((cursor, (digest, contents)))
+        })
+        .collect()
+}
+
+/// The map of events that might match the filter criteria in `cp_bounds` checkpoints keyed by EventCursor.
+pub(crate) async fn events(
+    ctx: &Context<'_>,
+    scope: &Scope,
+    filter: &EventFilter,
+    page: &Page<CScanEvent>,
+    cp_bounds: RangeInclusive<u64>,
+) -> Result<EventsBySequenceNumbers, RpcError> {
+    let kv_loader: &KvLoader = ctx.data()?;
+
+    let (cp_lo, cp_hi) = clamped_cp_bounds(page, &cp_bounds);
+    let filter_values = filter.bloom_probe_values();
+    let candidate_cps = candidate_cps(ctx, &filter_values, cp_lo, cp_hi, page).await?;
+
+    if candidate_cps.is_empty() {
+        return Ok(BTreeMap::new());
+    }
+
+    let checkpoints = kv_loader
+        .load_many_checkpoints(candidate_cps.to_vec())
+        .await
+        .context("Failed to load checkpoint transactions")?;
+    let sequenced_tx_digests: Vec<_> = checkpoints
+        .into_values()
+        .flat_map(|(summary, content, _)| {
+            let cp_seq = summary.sequence_number;
+            content
+                .enumerate_transactions(&summary)
+                .map(move |(tx_seq, &ExecutionDigests { transaction, .. })| {
+                    (tx_seq, cp_seq, transaction)
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect();
+
+    let digests: Vec<_> = sequenced_tx_digests
+        .iter()
+        .map(|(_, _, digest)| *digest)
+        .collect();
+    let events_by_digest: std::collections::HashMap<_, TransactionEventsContents> = kv_loader
+        .load_many_transaction_events(digests)
+        .await
+        .context("Failed to load transaction events")?;
+
+    let mut result = BTreeMap::new();
+    for (tx_sequence_number, cp_sequence_number, transaction_digest) in sequenced_tx_digests {
+        let contents = events_by_digest
+            .get(&transaction_digest)
+            .with_context(|| format!("Missing events for transaction {transaction_digest}"))?;
+        let timestamp_ms = contents.timestamp_ms();
+        for (idx, native) in contents.events()?.into_iter().enumerate() {
+            let sequence_number = idx as u64;
+            result.insert(
+                ScanEventCursor {
+                    cp_sequence_number,
+                    tx_sequence_number,
+                    ev_sequence_number: sequence_number,
+                },
+                Event {
+                    scope: scope.clone(),
+                    native,
+                    transaction_digest,
+                    sequence_number,
+                    timestamp_ms,
+                },
+            );
+        }
+    }
+    Ok(result)
+}
+
+/// The checkpoints that might contain the filter criteria.
+///
+/// Does a coarse filter over checkpoints ranges using cp_bloom_blocks,
+/// then a finer filter over those ranges for checkpoint matches using cp_blooms.
+async fn candidate_cps<C>(
+    ctx: &Context<'_>,
+    filter_values: &[[u8; 32]],
+    cp_lo: u64,
+    cp_hi_inclusive: u64,
+    page: &Page<C>,
+) -> Result<Vec<u64>, RpcError> {
+    if filter_values.is_empty() {
+        return Ok(if page.is_from_front() {
+            (cp_lo..=cp_hi_inclusive)
+                .take(page.limit_with_overhead())
+                .collect()
+        } else {
+            (cp_lo..=cp_hi_inclusive)
+                .rev()
+                .take(page.limit_with_overhead())
+                .collect()
+        });
+    }
+    let pg_reader: &PgReader = ctx.data()?;
+    let mut conn = pg_reader
+        .connect()
+        .await
+        .context("Failed to connect to database for bloom filter scan")?;
+
+    let cp_block_lo = cp_block_index(cp_lo);
+    let cp_block_hi_inclusive = cp_block_index(cp_hi_inclusive);
+
+    // Block index and probe for each block in the range. Seeds vary per block, so we must
+    // construct probes for each block.
+    let probes_by_block = (cp_block_lo..=cp_block_hi_inclusive).flat_map(|id| {
+        CpBlockedBloomFilter::probe(id as u128, filter_values)
+            .into_iter()
+            .map(move |probe| (id, probe))
+    });
+
+    let q_block_probes = cp_block_probes_sql(probes_by_block);
+    let q_bloom_check = cp_bloom_check_sql(&CpBloomFilter::probe(filter_values));
+
+    let block_size = CP_BLOCK_SIZE as i64;
+    let adjusted_limit = (page.limit_with_overhead() as f64 * OVERFETCH_MULTIPLIER) as i64;
+
+    // For each unique (cp_block_index, bloom_block_index) probe pair, fetch the bloom block
+    // row once via index lookup, then check all bit probes against it.
+    // The NOT EXISTS short-circuits on the first failing probe per pair.
+    // The GROUP BY / HAVING ensures ALL bloom_block_indices pass per cp_block_index.
+    let matched_blocks = query!(
+        r#"
+        SELECT
+            cp_bloom_blocks.cp_block_index,
+            cp_bloom_blocks.cp_block_index * {BigInt} AS cp_lo,
+            cp_bloom_blocks.cp_block_index * {BigInt} + {BigInt} - 1 AS cp_hi_inclusive
+        FROM
+            (SELECT DISTINCT cp_block_index, bloom_block_index, bloom_count
+             FROM block_byte_probes) unique_probes
+        JOIN cp_bloom_blocks USING (cp_block_index, bloom_block_index)
+        WHERE NOT EXISTS (
+            SELECT 1
+            FROM block_byte_probes
+            WHERE block_byte_probes.cp_block_index = cp_bloom_blocks.cp_block_index
+                AND block_byte_probes.bloom_block_index = cp_bloom_blocks.bloom_block_index
+                AND (get_byte(
+                    cp_bloom_blocks.bloom_filter,
+                    block_byte_probes.byte_pos % length(cp_bloom_blocks.bloom_filter)
+                ) & block_byte_probes.bit_mask) <> block_byte_probes.bit_mask
+        )
+        GROUP BY
+            cp_bloom_blocks.cp_block_index, unique_probes.bloom_count
+        HAVING
+            COUNT(*) = unique_probes.bloom_count
+        ORDER BY
+            cp_lo {}
+        LIMIT
+            {BigInt}
+        "#,
+        block_size,
+        block_size,
+        block_size,
+        page.order_by_direction(),
+        adjusted_limit,
+    );
+
+    // For each matched block, scan cp_blooms until we have adjusted_limit checkpoints that
+    // match the probe.
+    let query = query!(
+        r#"
+        WITH
+        block_byte_probes AS ({}),
+
+        matched_blocks AS ({})
+
+        SELECT
+            cp_sequence_number::BIGINT
+        FROM
+            matched_blocks
+        CROSS JOIN LATERAL (
+            SELECT
+                cp_sequence_number
+            FROM
+                cp_blooms
+            WHERE
+                cp_sequence_number BETWEEN GREATEST(matched_blocks.cp_lo, {BigInt})
+                    AND LEAST(matched_blocks.cp_hi_inclusive, {BigInt})
+                AND {}
+            ORDER BY
+                cp_sequence_number {}
+        ) cp_blooms
+        LIMIT
+            {BigInt}
+        "#,
+        q_block_probes,
+        matched_blocks,
+        cp_lo as i64,
+        cp_hi_inclusive as i64,
+        q_bloom_check,
+        page.order_by_direction(),
+        adjusted_limit,
+    );
+
+    #[derive(QueryableByName)]
+    struct CpResult {
+        #[diesel(sql_type = BigInt)]
+        cp_sequence_number: i64,
+    }
+
+    let results: Vec<CpResult> = conn
+        .results(query)
+        .await
+        .context("Failed to execute bloom filter scan query")?;
+    Ok(results
+        .into_iter()
+        .map(|r| r.cp_sequence_number as u64)
+        .collect())
+}
+
+/// SQL fragment that produces rows of probes (cp_block_index, bloom_block_index, byte_pos, bit_mask, bloom_count)
+/// using UNNEST. `bloom_count` is the number of distinct bloom_block_indices per cp_block_index,
+/// used in the HAVING clause to ensure all bloom blocks pass.
+fn cp_block_probes_sql(probes: impl Iterator<Item = (i64, BlockedBloomProbe)>) -> Query<'static> {
+    let mut cp_block_indices = vec![];
+    let mut bloom_indicies = vec![];
+    let mut byte_offsets = vec![];
+    let mut bit_masks = vec![];
+    let mut bloom_counts = vec![];
+
+    // Collect probes grouped by cp_block_index to compute bloom_count.
+    let mut probes_by_block: BTreeMap<i64, Vec<BlockedBloomProbe>> = BTreeMap::new();
+    for (cp_block_index, blocked_probe) in probes {
+        probes_by_block
+            .entry(cp_block_index)
+            .or_default()
+            .push(blocked_probe);
+    }
+
+    for (cp_block_index, block_probes) in &probes_by_block {
+        let bloom_count: i64 = block_probes
+            .iter()
+            .map(|p| p.block_idx)
+            .collect::<BTreeSet<_>>()
+            .len() as i64;
+        for blocked_probe in block_probes {
+            for &(offset, mask) in &blocked_probe.probe.bit_probes {
+                cp_block_indices.push(*cp_block_index);
+                bloom_indicies.push(blocked_probe.block_idx as i16);
+                byte_offsets.push(offset as i32);
+                bit_masks.push(mask as i32);
+                bloom_counts.push(bloom_count);
+            }
+        }
+    }
+
+    query!(
+        r#"
+        SELECT
+            UNNEST({Array<BigInt>}) cp_block_index,
+            UNNEST({Array<SmallInt>}) bloom_block_index,
+            UNNEST({Array<Integer>}) byte_pos,
+            UNNEST({Array<Integer>}) bit_mask,
+            UNNEST({Array<BigInt>}) bloom_count
+        "#,
+        cp_block_indices,
+        bloom_indicies,
+        byte_offsets,
+        bit_masks,
+        bloom_counts,
+    )
+}
+
+/// Check if all filter values are present in a checkpoint's bloom filter.
+fn cp_bloom_check_sql(probe: &BloomProbe) -> Query<'static> {
+    if probe.bit_probes.is_empty() {
+        return query!("TRUE");
+    }
+
+    let mut condition = query!("TRUE");
+    for &(offset, mask) in &probe.bit_probes {
+        condition += query!(
+            " AND (get_byte(cp_blooms.bloom_filter, {Integer} % length(cp_blooms.bloom_filter)) & {Integer}) = {Integer}",
+            offset as i32,
+            mask as i32,
+            mask as i32,
+        );
+    }
+    condition
+}
+
+fn clamped_cp_bounds<C: CpBoundsCursor>(
+    page: &Page<C>,
+    cp_bounds: &RangeInclusive<u64>,
+) -> (u64, u64) {
+    let cp_lo = page.after().map_or(*cp_bounds.start(), |c| {
+        c.cp_sequence_number().max(*cp_bounds.start())
+    });
+    let cp_hi_inclusive = page.before().map_or(*cp_bounds.end(), |c| {
+        c.cp_sequence_number().min(*cp_bounds.end())
+    });
+    (cp_lo, cp_hi_inclusive)
+}

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction/filter.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction/filter.rs
@@ -1,16 +1,39 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use async_graphql::Context;
 use async_graphql::CustomValidator;
 use async_graphql::Enum;
 use async_graphql::InputObject;
+use async_graphql::InputType;
 use async_graphql::InputValueError;
+use sui_indexer_alt_reader::kv_loader::TransactionContents;
+use sui_indexer_alt_schema::blooms::should_skip_for_bloom;
+use sui_types::transaction::TransactionDataAPI as _;
 
 use crate::api::scalars::fq_name_filter::FqNameFilter;
 use crate::api::scalars::sui_address::SuiAddress;
 use crate::api::scalars::uint53::UInt53;
+use crate::api::types::checkpoint::filter::checkpoint_bounds;
 use crate::api::types::lookups::CheckpointBounds;
+use crate::config::Limits;
 use crate::intersect;
+
+/// An input filter selecting for either system or programmable transactions.
+#[derive(Enum, Copy, Clone, Eq, PartialEq, Debug)]
+pub(crate) enum TransactionKindInput {
+    /// A system transaction can be one of several types of transactions.
+    /// See [unions/transaction-block-kind] for more details.
+    SystemTx = 0,
+    /// A user submitted transaction block.
+    ProgrammableTx = 1,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub(crate) enum Error {
+    #[error("Invalid filter, expected: {0}")]
+    InvalidFormat(&'static str),
+}
 
 #[derive(InputObject, Debug, Default, Clone)]
 pub(crate) struct TransactionFilter {
@@ -42,38 +65,10 @@ pub(crate) struct TransactionFilter {
     pub sent_address: Option<SuiAddress>,
 }
 
-/// An input filter selecting for either system or programmable transactions.
-#[derive(Enum, Copy, Clone, Eq, PartialEq, Debug)]
-pub(crate) enum TransactionKindInput {
-    /// A system transaction can be one of several types of transactions.
-    /// See [unions/transaction-block-kind] for more details.
-    SystemTx = 0,
-    /// A user submitted transaction block.
-    ProgrammableTx = 1,
-}
-
 pub(crate) struct TransactionFilterValidator;
 
-impl CustomValidator<TransactionFilter> for TransactionFilterValidator {
-    fn check(&self, filter: &TransactionFilter) -> Result<(), InputValueError<TransactionFilter>> {
-        let filters = filter.affected_address.is_some() as u8
-            + filter.affected_object.is_some() as u8
-            + filter.function.is_some() as u8
-            + filter.kind.is_some() as u8;
-        if filters > 1 {
-            return Err(InputValueError::custom(
-                "At most one of [affectedAddress, affectedObject, function, kind] can be specified",
-            ));
-        }
-
-        Ok(())
-    }
-}
-
-#[derive(thiserror::Error, Debug)]
-pub(crate) enum Error {
-    #[error("Invalid filter, expected: {0}")]
-    InvalidFormat(&'static str),
+pub(crate) struct ScanFilterValidator {
+    pub(crate) max_scan_limit: u64,
 }
 
 impl TransactionFilter {
@@ -131,6 +126,85 @@ impl TransactionFilter {
 
         filters
     }
+
+    /// Values to probe in bloom filters.
+    pub(crate) fn bloom_probe_values(&self) -> Vec<[u8; 32]> {
+        [
+            self.function.as_ref().map(|f| f.package().into_bytes()),
+            self.affected_address.map(|a| a.into_bytes()),
+            self.affected_object.map(|o| o.into_bytes()),
+            self.sent_address.map(|s| s.into_bytes()),
+        ]
+        .into_iter()
+        .flatten()
+        .filter(|v| !should_skip_for_bloom(v))
+        .collect()
+    }
+
+    /// Checks if a transaction's contents matches the filter conditions.
+    pub(crate) fn matches(&self, transaction: &TransactionContents) -> bool {
+        let Ok(data) = transaction.data() else {
+            return false;
+        };
+        let Ok(effects) = transaction.effects() else {
+            return false;
+        };
+
+        if let Some(function) = &self.function {
+            let has_match = data.move_calls().into_iter().any(|(_, p, m, f)| {
+                SuiAddress::from(*p) == function.package()
+                    && function.module().is_none_or(|module| m == module)
+                    && function.name().is_none_or(|name| f == name)
+            });
+            if !has_match {
+                return false;
+            }
+        }
+
+        if let Some(sent_address) = &self.sent_address
+            && SuiAddress::from(data.sender()) != *sent_address
+        {
+            return false;
+        }
+
+        if let Some(affected_address) = &self.affected_address {
+            let in_changed_objects = effects.all_changed_objects().iter().any(|(_, owner, _)| {
+                owner
+                    .get_address_owner_address()
+                    .is_ok_and(|addr| SuiAddress::from(addr) == *affected_address)
+            });
+            let is_sender = SuiAddress::from(data.sender()) == *affected_address;
+            if !in_changed_objects && !is_sender {
+                return false;
+            }
+        }
+
+        if let Some(affected_object) = &self.affected_object {
+            let has_match = effects
+                .all_changed_objects()
+                .iter()
+                .any(|((object_id, _, _), _, _)| SuiAddress::from(*object_id) == *affected_object);
+            if !has_match {
+                return false;
+            }
+        }
+
+        if let Some(kind) = &self.kind {
+            let is_programmable = matches!(
+                data.kind(),
+                sui_types::transaction::TransactionKind::ProgrammableTransaction(_)
+            );
+            let matches_kind = match kind {
+                TransactionKindInput::ProgrammableTx => is_programmable,
+                TransactionKindInput::SystemTx => !is_programmable,
+            };
+            if !matches_kind {
+                return false;
+            }
+        }
+
+        true
+    }
 }
 
 impl CheckpointBounds for TransactionFilter {
@@ -144,5 +218,107 @@ impl CheckpointBounds for TransactionFilter {
 
     fn before_checkpoint(&self) -> Option<UInt53> {
         self.before_checkpoint
+    }
+}
+
+impl ScanFilterValidator {
+    pub fn new(ctx: &Context<'_>) -> Self {
+        let &Limits { max_scan_limit, .. } = ctx.data_unchecked();
+        Self { max_scan_limit }
+    }
+}
+
+impl CustomValidator<TransactionFilter> for TransactionFilterValidator {
+    fn check(&self, filter: &TransactionFilter) -> Result<(), InputValueError<TransactionFilter>> {
+        let filters = filter.affected_address.is_some() as u8
+            + filter.affected_object.is_some() as u8
+            + filter.function.is_some() as u8
+            + filter.kind.is_some() as u8;
+        if filters > 1 {
+            return Err(InputValueError::custom(
+                "At most one of [affectedAddress, affectedObject, function, kind] can be specified",
+            ));
+        }
+
+        Ok(())
+    }
+}
+
+impl<T: CheckpointBounds + InputType> CustomValidator<T> for ScanFilterValidator {
+    fn check(&self, filter: &T) -> Result<(), InputValueError<T>> {
+        let Some(range) = checkpoint_bounds(
+            filter.after_checkpoint().map(u64::from),
+            filter.at_checkpoint().map(u64::from),
+            filter.before_checkpoint().map(u64::from),
+            0,
+            u64::MAX,
+        ) else {
+            return Ok(());
+        };
+
+        if range.end() == &u64::MAX {
+            return Err(InputValueError::custom(format!(
+                "Unbounded scan, add beforeCheckpoint or atCheckpoint filters \
+                (Scan limit: {}).",
+                self.max_scan_limit,
+            )));
+        }
+
+        let cps_scanned = range.end() - range.start() + 1;
+        if cps_scanned > self.max_scan_limit {
+            return Err(InputValueError::custom(format!(
+                "Scan of {cps_scanned} checkpoints exceeds maximum of {}. \
+                Use afterCheckpoint and beforeCheckpoint or atCheckpoint filters \
+                to reduce the range.",
+                self.max_scan_limit,
+            )));
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use super::*;
+
+    #[test]
+    fn test_bloom_probe_values_skips_zero_address() {
+        let zero = SuiAddress::from_str("0x0").unwrap();
+        let filter = TransactionFilter {
+            sent_address: Some(zero),
+            ..Default::default()
+        };
+        assert!(filter.bloom_probe_values().is_empty());
+    }
+
+    #[test]
+    fn test_bloom_probe_values_skips_clock_address() {
+        let clock = SuiAddress::from_str("0x6").unwrap();
+        let filter = TransactionFilter {
+            affected_object: Some(clock),
+            ..Default::default()
+        };
+        assert!(filter.bloom_probe_values().is_empty());
+    }
+
+    #[test]
+    fn test_bloom_probe_values_keeps_normal_address() {
+        let addr = SuiAddress::from_str("0x42").unwrap();
+        let filter = TransactionFilter {
+            sent_address: Some(addr),
+            ..Default::default()
+        };
+        let values = filter.bloom_probe_values();
+        assert_eq!(values.len(), 1);
+        assert_eq!(values[0], addr.into_bytes());
+    }
+
+    #[test]
+    fn test_bloom_probe_values_empty_filter() {
+        let filter = TransactionFilter::default();
+        assert!(filter.bloom_probe_values().is_empty());
     }
 }

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
@@ -34,6 +34,7 @@ use crate::api::scalars::json::Json;
 use crate::api::scalars::sui_address::SuiAddress;
 use crate::api::types::address::Address;
 use crate::api::types::available_range::AvailableRangeKey;
+use crate::api::types::checkpoint::filter::checkpoint_bounds;
 use crate::api::types::epoch::Epoch;
 use crate::api::types::gas_input::GasInput;
 use crate::api::types::lookups::CheckpointBounds;
@@ -50,7 +51,24 @@ use crate::pagination::Page;
 use crate::scope::Scope;
 use crate::task::watermark::Watermarks;
 
+pub(crate) mod bloom;
 pub(crate) mod filter;
+
+/// Cursor for transaction pagination
+pub(crate) type CTransaction = JsonCursor<u64>;
+
+/// Cursor for transaction scanning.
+#[derive(
+    serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Copy, Debug, PartialOrd, Ord,
+)]
+pub(crate) struct ScanTransactionCursor {
+    #[serde(rename = "c")]
+    pub(crate) cp_sequence_number: u64,
+    #[serde(rename = "t")]
+    pub(crate) tx_sequence_number: u64,
+}
+
+pub(crate) type CScanTransaction = JsonCursor<ScanTransactionCursor>;
 
 #[derive(Clone)]
 pub(crate) struct Transaction {
@@ -63,8 +81,6 @@ pub(crate) struct TransactionContents {
     pub(crate) scope: Scope,
     pub(crate) contents: Option<Arc<NativeTransactionContents>>,
 }
-
-pub(crate) type CTransaction = JsonCursor<u64>;
 
 /// Description of a transaction, the unit of activity on Sui.
 #[Object]
@@ -296,6 +312,54 @@ impl Transaction {
             tx_digests(ctx, &tx_sequence_numbers).await?,
             |(s, _)| JsonCursor::new(*s),
             |(_, d)| Ok(Self::with_digest(scope.clone(), d)),
+        )
+    }
+
+    /// Scan a bounded checkpoint range for transactions matching the filter. Uses bloom filters to
+    /// find candidate checkpoints that may contain matching transaction, then fetches and returns
+    /// transactions that match the filter.
+    pub(crate) async fn scan(
+        ctx: &Context<'_>,
+        scope: Scope,
+        page: Page<CScanTransaction>,
+        filter: TransactionFilter,
+    ) -> Result<Connection<String, Transaction>, RpcError> {
+        let watermarks: &Arc<Watermarks> = ctx.data()?;
+        let available_range_key = AvailableRangeKey {
+            type_: "Query".to_string(),
+            field: Some("scanTransactions".to_string()),
+            filters: Some(filter.active_filters()),
+        };
+        let reader_lo = available_range_key.reader_lo(watermarks)?;
+
+        let Some(checkpoint_viewed_at) = scope.checkpoint_viewed_at() else {
+            return Ok(Connection::new(false, false));
+        };
+
+        let Some(cp_bounds) = checkpoint_bounds(
+            filter.after_checkpoint().map(u64::from),
+            filter.at_checkpoint().map(u64::from),
+            filter.before_checkpoint().map(u64::from),
+            reader_lo,
+            checkpoint_viewed_at,
+        ) else {
+            return Ok(Connection::new(false, false));
+        };
+
+        let transactions = bloom::transactions(ctx, &page, &filter, cp_bounds).await?;
+
+        page.paginate_filtered(
+            &transactions,
+            |(_, contents)| filter.matches(contents),
+            |(digest, contents)| {
+                Ok::<_, RpcError>(Transaction {
+                    digest: *digest,
+                    contents: TransactionContents {
+                        scope: scope.clone(),
+                        contents: Some(Arc::new(contents.clone())),
+                    },
+                })
+            },
         )
     }
 }

--- a/crates/sui-indexer-alt-graphql/src/config.rs
+++ b/crates/sui-indexer-alt-graphql/src/config.rs
@@ -158,6 +158,8 @@ pub struct Limits {
     /// Maximum number of "rich" queries that can be performed in a single request. Rich queries are
     /// queries that require dedicated requests to the backing store.
     pub max_rich_queries: usize,
+    /// Maximum number of checkpoints that can be scanned in a single scanning pagination query.
+    pub max_scan_limit: u64,
 }
 
 #[DefaultConfig]
@@ -187,6 +189,7 @@ pub struct LimitsLayer {
     pub max_display_output_size: Option<usize>,
     pub max_disassembled_module_size: Option<usize>,
     pub max_rich_queries: Option<usize>,
+    pub max_scan_limit: Option<u64>,
 }
 
 #[DefaultConfig]
@@ -382,6 +385,7 @@ impl LimitsLayer {
                 .max_disassembled_module_size
                 .unwrap_or(base.max_disassembled_module_size),
             max_rich_queries: self.max_rich_queries.unwrap_or(base.max_rich_queries),
+            max_scan_limit: self.max_scan_limit.unwrap_or(base.max_scan_limit),
         }
     }
 }
@@ -452,6 +456,7 @@ impl From<Limits> for LimitsLayer {
             max_display_output_size: Some(value.max_display_output_size),
             max_disassembled_module_size: Some(value.max_disassembled_module_size),
             max_rich_queries: Some(value.max_rich_queries),
+            max_scan_limit: Some(value.max_scan_limit),
         }
     }
 }
@@ -544,6 +549,8 @@ impl Default for Limits {
             max_display_output_size: 1024 * 1024,
             max_disassembled_module_size: 1024 * 1024,
             max_rich_queries: 21,
+            // ~1 week worth of checkpoints
+            max_scan_limit: 3_000_000,
         }
     }
 }

--- a/crates/sui-indexer-alt-graphql/src/pagination.rs
+++ b/crates/sui-indexer-alt-graphql/src/pagination.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::BTreeMap;
+use std::ops::Bound;
 use std::ops::Range;
 
 use async_graphql::OutputType;
@@ -249,6 +250,19 @@ impl<C: CursorType + Eq + PartialEq + Clone> Page<C> {
         node: impl Fn(T) -> Result<N, E>,
     ) -> Result<Connection<String, N>, E> {
         let edges: Vec<_> = results.into_iter().map(|r| (cursor(&r), r)).collect();
+        self.connection(edges, node)
+    }
+
+    /// Validate cursors, detect has_previous_page/has_next_page, trim boundary elements,
+    /// and build a GraphQL `Connection` from pre-paired `(cursor, value)` entries.
+    ///
+    /// `edges` should contain elements in order, including up to one record either side of the
+    /// page (the `after` and `before` cursor elements) used for boundary detection.
+    fn connection<T, N: OutputType, E>(
+        &self,
+        edges: Vec<(C, T)>,
+        node: impl Fn(T) -> Result<N, E>,
+    ) -> Result<Connection<String, N>, E> {
         let first = edges.first().map(|(c, _)| c.clone());
         let last = edges.last().map(|(c, _)| c.clone());
 
@@ -327,6 +341,60 @@ impl<C: CursorType + Eq + PartialEq + Clone> Page<C> {
         }
 
         Ok(conn)
+    }
+}
+
+impl<C: Ord + Copy> Page<JsonCursor<C>> {
+    /// Paginate over entries in a map, filtered.
+    ///
+    /// Iterates over `map` entries between `self`'s cursor bounds, keeping only those where
+    /// `filter` returns true, up to the page limit (with overhead to detect previous/next pages).
+    ///
+    /// `node` converts a matched value into a GraphQL node. Returns a GraphQL `Connection`
+    /// populated with edges derived from the matching entries.
+    pub(crate) fn paginate_filtered<V, N: OutputType, E>(
+        &self,
+        map: &BTreeMap<C, V>,
+        filter: impl Fn(&V) -> bool,
+        node: impl Fn(&V) -> Result<N, E>,
+    ) -> Result<Connection<String, N>, E>
+    where
+        JsonCursor<C>: CursorType,
+    {
+        let lo = self
+            .after()
+            .map_or(Bound::Unbounded, |c| Bound::Included(**c));
+        let hi = self
+            .before()
+            .map_or(Bound::Unbounded, |c| Bound::Included(**c));
+
+        if let (Bound::Included(lo), Bound::Included(hi)) = (lo, hi)
+            && lo > hi
+        {
+            return Ok(Connection::new(false, false));
+        }
+
+        let limit = self.limit_with_overhead();
+        let bounded = map.range((lo, hi));
+
+        let edges: Vec<_> = if self.is_from_front() {
+            bounded
+                .filter(|(_, v)| filter(v))
+                .take(limit)
+                .map(|(&c, v)| (JsonCursor::new(c), v))
+                .collect()
+        } else {
+            let mut v: Vec<_> = bounded
+                .rev()
+                .filter(|(_, v)| filter(v))
+                .take(limit)
+                .map(|(&c, v)| (JsonCursor::new(c), v))
+                .collect();
+            v.reverse();
+            v
+        };
+
+        self.connection(edges, node)
     }
 }
 

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -1452,7 +1452,7 @@ input EventFilter {
 	"""
 	Events emitted by a particular module. An event is emitted by a particular module if some function in the module is called by a PTB and emits an event.
 	
-	Modules can be filtered by their package, or package::module. We currently do not support filtering by emitting module and event type at the same time so if both are provided in one filter, the query will error.
+	Modules can be filtered by their package, or package::module.
 	"""
 	module: String
 	"""
@@ -3642,6 +3642,21 @@ type Query {
 	"""
 	protocolConfigs(version: UInt53): ProtocolConfigs
 	"""
+	The events that exist in the network, optionally filtered by multiple event filters.
+	Supports combining filters (e.g. `sender` AND `module` AND `type`). The checkpoint range being scanned can not exceed `ServiceConfig.maxScanLimit` — use `afterCheckpoint`, `beforeCheckpoint`, or `atCheckpoint` to narrow it. Supports a longer retention than `Query.events`.
+	
+	Note that this differs from `Query.events`, which supports a single filter with an optional sender filter, with no checkpoint range restriction and generally a shorter retention.
+	"""
+	scanEvents(first: Int, after: String, last: Int, before: String, filter: EventFilter!): EventConnection
+	"""
+	The transactions that exist in the network, optionally filtered by multiple transaction filters.
+	
+	Supports combining filters (e.g. `affectedAddress` AND `function`). The checkpoint range being scanned can not exceed `ServiceConfig.maxScanLimit` — use `checkpointBound` to narrow it. Supports a longer retention than `Query.transactions`.
+	
+	Note that this differs from `Query.transactions`, which supports a single filter with an optional sender filter, with no checkpoint range restriction and generally a shorter retention.
+	"""
+	scanTransactions(first: Int, after: String, last: Int, before: String, filter: TransactionFilter!): TransactionConnection
+	"""
 	Configuration for this RPC service.
 	"""
 	serviceConfig: ServiceConfig!
@@ -3917,6 +3932,10 @@ type ServiceConfig {
 	Maximum number of paginated fields that can return results in a single request. Queries on paginated fields that exceed this limit will return an error.
 	"""
 	maxRichQueries: Int
+	"""
+	Maximum number of checkpoints that can be scanned in a single scanning pagination query.
+	"""
+	maxScanLimit: Int
 	"""
 	Maximum size in bytes allowed for the `txBytes` and `signatures` parameters of an `executeTransaction` or `simulateTransaction` field, or the `bytes` and `signature` parameters of a `verifyZkLoginSignature` field.
 	

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -1452,7 +1452,7 @@ input EventFilter {
 	"""
 	Events emitted by a particular module. An event is emitted by a particular module if some function in the module is called by a PTB and emits an event.
 	
-	Modules can be filtered by their package, or package::module. We currently do not support filtering by emitting module and event type at the same time so if both are provided in one filter, the query will error.
+	Modules can be filtered by their package, or package::module.
 	"""
 	module: String
 	"""
@@ -3642,6 +3642,21 @@ type Query {
 	"""
 	protocolConfigs(version: UInt53): ProtocolConfigs
 	"""
+	The events that exist in the network, optionally filtered by multiple event filters.
+	Supports combining filters (e.g. `sender` AND `module` AND `type`). The checkpoint range being scanned can not exceed `ServiceConfig.maxScanLimit` — use `afterCheckpoint`, `beforeCheckpoint`, or `atCheckpoint` to narrow it. Supports a longer retention than `Query.events`.
+	
+	Note that this differs from `Query.events`, which supports a single filter with an optional sender filter, with no checkpoint range restriction and generally a shorter retention.
+	"""
+	scanEvents(first: Int, after: String, last: Int, before: String, filter: EventFilter!): EventConnection
+	"""
+	The transactions that exist in the network, optionally filtered by multiple transaction filters.
+	
+	Supports combining filters (e.g. `affectedAddress` AND `function`). The checkpoint range being scanned can not exceed `ServiceConfig.maxScanLimit` — use `checkpointBound` to narrow it. Supports a longer retention than `Query.transactions`.
+	
+	Note that this differs from `Query.transactions`, which supports a single filter with an optional sender filter, with no checkpoint range restriction and generally a shorter retention.
+	"""
+	scanTransactions(first: Int, after: String, last: Int, before: String, filter: TransactionFilter!): TransactionConnection
+	"""
 	Configuration for this RPC service.
 	"""
 	serviceConfig: ServiceConfig!
@@ -3917,6 +3932,10 @@ type ServiceConfig {
 	Maximum number of paginated fields that can return results in a single request. Queries on paginated fields that exceed this limit will return an error.
 	"""
 	maxRichQueries: Int
+	"""
+	Maximum number of checkpoints that can be scanned in a single scanning pagination query.
+	"""
+	maxScanLimit: Int
 	"""
 	Maximum size in bytes allowed for the `txBytes` and `signatures` parameters of an `executeTransaction` or `simulateTransaction` field, or the `bytes` and `signature` parameters of a `verifyZkLoginSignature` field.
 	

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -1448,7 +1448,7 @@ input EventFilter {
 	"""
 	Events emitted by a particular module. An event is emitted by a particular module if some function in the module is called by a PTB and emits an event.
 	
-	Modules can be filtered by their package, or package::module. We currently do not support filtering by emitting module and event type at the same time so if both are provided in one filter, the query will error.
+	Modules can be filtered by their package, or package::module.
 	"""
 	module: String
 	"""
@@ -3638,6 +3638,21 @@ type Query {
 	"""
 	protocolConfigs(version: UInt53): ProtocolConfigs
 	"""
+	The events that exist in the network, optionally filtered by multiple event filters.
+	Supports combining filters (e.g. `sender` AND `module` AND `type`). The checkpoint range being scanned can not exceed `ServiceConfig.maxScanLimit` — use `afterCheckpoint`, `beforeCheckpoint`, or `atCheckpoint` to narrow it. Supports a longer retention than `Query.events`.
+	
+	Note that this differs from `Query.events`, which supports a single filter with an optional sender filter, with no checkpoint range restriction and generally a shorter retention.
+	"""
+	scanEvents(first: Int, after: String, last: Int, before: String, filter: EventFilter!): EventConnection
+	"""
+	The transactions that exist in the network, optionally filtered by multiple transaction filters.
+	
+	Supports combining filters (e.g. `affectedAddress` AND `function`). The checkpoint range being scanned can not exceed `ServiceConfig.maxScanLimit` — use `checkpointBound` to narrow it. Supports a longer retention than `Query.transactions`.
+	
+	Note that this differs from `Query.transactions`, which supports a single filter with an optional sender filter, with no checkpoint range restriction and generally a shorter retention.
+	"""
+	scanTransactions(first: Int, after: String, last: Int, before: String, filter: TransactionFilter!): TransactionConnection
+	"""
 	Configuration for this RPC service.
 	"""
 	serviceConfig: ServiceConfig!
@@ -3913,6 +3928,10 @@ type ServiceConfig {
 	Maximum number of paginated fields that can return results in a single request. Queries on paginated fields that exceed this limit will return an error.
 	"""
 	maxRichQueries: Int
+	"""
+	Maximum number of checkpoints that can be scanned in a single scanning pagination query.
+	"""
+	maxScanLimit: Int
 	"""
 	Maximum size in bytes allowed for the `txBytes` and `signatures` parameters of an `executeTransaction` or `simulateTransaction` field, or the `bytes` and `signature` parameters of a `verifyZkLoginSignature` field.
 	

--- a/crates/sui-indexer-alt-reader/src/kv_loader.rs
+++ b/crates/sui-indexer-alt-reader/src/kv_loader.rs
@@ -180,6 +180,45 @@ impl KvLoader {
         }
     }
 
+    pub async fn load_many_checkpoints(
+        &self,
+        sequence_numbers: Vec<u64>,
+    ) -> Result<
+        HashMap<
+            CheckpointKey,
+            (
+                CheckpointSummary,
+                CheckpointContents,
+                AuthorityQuorumSignInfo<true>,
+            ),
+        >,
+        Error,
+    > {
+        let keys: Vec<CheckpointKey> = sequence_numbers.iter().map(|s| CheckpointKey(*s)).collect();
+        match self {
+            Self::Bigtable(loader) => Ok(loader.load_many(keys).await?),
+            Self::Pg(loader) => loader
+                .load_many(keys)
+                .await?
+                .into_iter()
+                .map(|(key, stored)| {
+                    let summary: CheckpointSummary = bcs::from_bytes(&stored.checkpoint_summary)
+                        .context("Failed to deserialize checkpoint summary")?;
+
+                    let contents: CheckpointContents = bcs::from_bytes(&stored.checkpoint_contents)
+                        .context("Failed to deserialize checkpoint contents")?;
+
+                    let signature: AuthorityQuorumSignInfo<true> =
+                        bcs::from_bytes(&stored.validator_signatures)
+                            .context("Failed to deserialize validator signatures")?;
+
+                    Ok((key, (summary, contents, signature)))
+                })
+                .collect(),
+            Self::LedgerGrpc(loader) => Ok(loader.load_many(keys).await?),
+        }
+    }
+
     pub async fn load_one_transaction(
         &self,
         digest: TransactionDigest,

--- a/crates/sui-indexer-alt-schema/src/blooms/hash.rs
+++ b/crates/sui-indexer-alt-schema/src/blooms/hash.rs
@@ -52,7 +52,7 @@ impl DoubleHasher {
     }
 
     /// Generate a new hash value from the current h1 and h2 with:
-    /// - modulo addition of two independent hashes with well distributed bits to ensure inputs diverge into uncorrelated bits.
+    /// - modulo addition of two hashes with well distributed bits to ensure inputs diverge into uncorrelated bits.
     /// - circular left shift by 5 (coprime to 64) to avoid evenly spaced distributions by mixing high and low bits after the addition.
     pub fn next_hash(&mut self) -> u64 {
         self.h1 = self.h1.wrapping_add(self.h2).rotate_left(5);
@@ -68,12 +68,12 @@ impl Iterator for DoubleHasher {
     }
 }
 
-pub fn set_bit(bits: &mut [u8], pos: usize) {
-    bits[pos / 8] |= 1 << (pos % 8);
+pub fn set_bit(bytes: &mut [u8], bit_idx: usize) {
+    bytes[bit_idx / 8] |= 1 << (bit_idx % 8);
 }
 
-pub fn check_bit(bits: &[u8], pos: usize) -> bool {
-    bits[pos / 8] & (1 << (pos % 8)) != 0
+pub fn check_bit(bytes: &[u8], bit_idx: usize) -> bool {
+    bytes[bit_idx / 8] & (1 << (bit_idx % 8)) != 0
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Description 

Scanning queries that finds transactions and events matching filters over a range of checkpoints

  Changes

  GraphQL (sui-indexer-alt-graphql)
  - New scanTransactions query endpoint
  - New scenEvents query endpoint
  - maxScanLimit service config to limit checkpoints scanned per query
  - Transaction and Event filter and scan logic in `bloom/mod.rs`

  Reader (sui-indexer-alt-reader)
  - `cp_blooms` loader for batch-loading bloom filter data


## Test plan 

```
cargo nextest run -p sui-indexer-alt-graphql graphql_scan_limit_tests
cargo nextest run -p sui-indexer-alt-graphql
cargo nextest run -p sui-indexer-alt
cargo nextest run -p sui-indexer-alt-schema
```

Query Plan:
```
Limit  (cost=1911.69..1358704.33 rows=62 width=8) (actual time=14.454..14.836 rows=62 loops=1)
  Buffers: shared hit=7287
  CTE block_bit_probes
    ->  ProjectSet  (cost=0.00..8.20 rows=1635 width=18) (actual time=0.004..0.431 rows=1635 loops=1)
          ->  Result  (cost=0.00..0.01 rows=1 width=0) (actual time=0.001..0.001 rows=1 loops=1)
  ->  Nested Loop  (cost=1903.49..1358696.13 rows=62 width=8) (actual time=14.453..14.830 rows=62 loops=1)
        Buffers: shared hit=7287
        ->  Limit  (cost=1903.06..1903.22 rows=62 width=24) (actual time=14.411..14.414 rows=1 loops=1)
              Buffers: shared hit=6976
              CTE block_lookup
                ->  Nested Loop Left Join  (cost=41.30..1723.38 rows=200 width=131) (actual time=0.654..2.899 rows=327 loops=1)
                      Buffers: shared hit=1348
                      ->  HashAggregate  (cost=40.88..42.88 rows=200 width=10) (actual time=0.620..0.682 rows=327 loops=1)
                            Group Key: block_bit_probes_1.cp_block_index, block_bit_probes_1.bloom_idx
                            Batches: 1  Memory Usage: 61kB
                            ->  CTE Scan on block_bit_probes block_bit_probes_1  (cost=0.00..32.70 rows=1635 width=10) (actual time=0.000..0.159 rows=1635 loops=1)
                      ->  Index Scan using cp_bloom_blocks_pkey on cp_bloom_blocks bb  (cost=0.42..8.40 rows=1 width=131) (actual time=0.006..0.006 rows=1 loops=327)
                            Index Cond: ((cp_block_index = block_bit_probes_1.cp_block_index) AND (bloom_block_index = block_bit_probes_1.bloom_idx))
                            Buffers: shared hit=1343
              ->  Sort  (cost=179.69..180.17 rows=192 width=24) (actual time=14.410..14.412 rows=1 loops=1)
                    Sort Key: ((block_bit_probes.cp_block_index * '1000'::bigint))
                    Sort Method: quicksort  Memory: 25kB
                    Buffers: shared hit=6976
                    ->  Hash Right Anti Join  (cost=48.29..173.01 rows=192 width=24) (actual time=14.392..14.400 rows=5 loops=1)
                          Hash Cond: (p.cp_block_index = block_bit_probes.cp_block_index)
                          Buffers: shared hit=6976
                          ->  Hash Join  (cost=7.00..129.78 rows=8 width=8) (actual time=3.224..12.355 rows=1011 loops=1)
                                Hash Cond: ((p.cp_block_index = bl.cp_block_index) AND (p.bloom_idx = bl.bloom_idx))
                                Join Filter: ((bl.bloom_filter IS NULL) OR (p.bit_mask <> get_byte(bl.bloom_filter, (p.byte_pos % length(bl.bloom_filter)))))
                                Rows Removed by Join Filter: 624
                                Buffers: shared hit=6976
                                ->  CTE Scan on block_bit_probes p  (cost=0.00..32.70 rows=1635 width=18) (actual time=0.000..0.211 rows=1635 loops=1)
                                ->  Hash  (cost=4.00..4.00 rows=200 width=42) (actual time=3.142..3.142 rows=327 loops=1)
                                      Buckets: 1024  Batches: 1  Memory Usage: 93kB
                                      Buffers: shared hit=1348
                                      ->  CTE Scan on block_lookup bl  (cost=0.00..4.00 rows=200 width=42) (actual time=0.656..3.060 rows=327 loops=1)
                                            Buffers: shared hit=1348
                          ->  Hash  (cost=38.79..38.79 rows=200 width=8) (actual time=1.773..1.774 rows=327 loops=1)
                                Buckets: 1024  Batches: 1  Memory Usage: 21kB
                                ->  HashAggregate  (cost=36.79..38.79 rows=200 width=8) (actual time=1.668..1.717 rows=327 loops=1)
                                      Group Key: block_bit_probes.cp_block_index
                                      Batches: 1  Memory Usage: 61kB
                                      ->  CTE Scan on block_bit_probes  (cost=0.00..32.70 rows=1635 width=8) (actual time=0.007..1.162 rows=1635 loops=1)
        ->  Index Scan using cp_blooms_pkey on cp_blooms cb  (cost=0.43..21883.74 rows=1 width=8) (actual time=0.040..0.408 rows=62 loops=1)
              Index Cond: ((cp_sequence_number >= ((block_bit_probes.cp_block_index * '1000'::bigint))) AND (cp_sequence_number <= ((((block_bit_probes.cp_block_index * '1000'::bigint) + '1000'::bigint) - 1))))
              Filter: (((get_byte(bloom_filter, (208 % length(bloom_filter))) & 8) = 8) AND ((get_byte(bloom_filter, (5988 % length(bloom_filter))) & 32) = 32) AND ((get_byte(bloom_filter, (8084 % length(bloom_filter))) & 32) = 32) AND ((get_byte(bloom_filter, (15059 % length(bloom_filter))) & 32) = 32) AND ((get_byte(bloom_filter, (8330 % length(bloom_filter))) & 64) = 64) AND ((get_byte(bloom_filter, (10313 % length(bloom_filter))) & 4) = 4))
              Rows Removed by Filter: 318
              Buffers: shared hit=311
Planning:
  Buffers: shared hit=78
Planning Time: 2.181 ms
Execution Time: 15.060 ms
```

## Stack:
https://github.com/MystenLabs/sui/pull/24788 
https://github.com/MystenLabs/sui/pull/24900 👈 
https://github.com/MystenLabs/sui/pull/25097
---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:

## Description 

Describe the changes or additions included in this PR.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
