### PR TITLE
graphql-alt: ensure full walk of scanning pagination

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15265,6 +15265,7 @@ dependencies = [
  "futures",
  "hex",
  "itertools 0.13.0",
+ "move-core-types",
  "prometheus",
  "rand 0.8.5",
  "serde",

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/events/scan.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/events/scan.move
@@ -18,6 +18,10 @@ module P1::M1 {
         value: u64,
     }
 
+    public struct GenericEvent<phantom T> has copy, drop {
+        value: u64,
+    }
+
     public entry fun emit_a(value: u64) {
         event::emit(EventA {
             message: ascii::string(b"Event A"),
@@ -30,6 +34,14 @@ module P1::M1 {
             message: ascii::string(b"Event B"),
             value,
         });
+    }
+
+    public entry fun emit_generic_bool(value: u64) {
+        event::emit(GenericEvent<bool> { value });
+    }
+
+    public entry fun emit_generic_u64(value: u64) {
+        event::emit(GenericEvent<u64> { value });
     }
 
     public entry fun emit_multiple(count: u64) {
@@ -87,6 +99,16 @@ module P2::M2 {
 
 //# create-checkpoint
 
+// Checkpoint 6: A emits GenericEvent<bool>
+//# run P1::M1::emit_generic_bool --sender A --args 10
+
+//# create-checkpoint
+
+// Checkpoint 7: B emits GenericEvent<u64>
+//# run P1::M1::emit_generic_u64 --sender B --args 20
+
+//# create-checkpoint
+
 //# advance-epoch
 
 // Generate 10,501 checkpoints to create 10 complete blocks + 500 extra for incomplete block
@@ -101,24 +123,24 @@ module P2::M2 {
 # Scan vs indexed cross-check, multi-filter combinations, empty-result edge cases,
 # checkpoint-bounded scan, and scan across bloom blocks.
 {
-  scanEventsA: scanEvents(filter: { sender: "@{A}", beforeCheckpoint: 10510 }) { ...EV }
+  scanEventsA: scanEvents(filter: { sender: "@{A}", beforeCheckpoint: 10512 }) { ...EV }
   paginateEventsA: events(filter: { sender: "@{A}" }) { ...EV }
 
   eventsAFromP1: scanEvents(filter: {
     sender: "@{A}",
     module: "@{P1}",
-    beforeCheckpoint: 10510
+    beforeCheckpoint: 10512
   }) { ...EV }
   scanTripleFilter: scanEvents(filter: {
     sender: "@{A}",
     module: "@{P1}",
     type: "@{P1}::M1::EventA",
-    beforeCheckpoint: 10510
+    beforeCheckpoint: 10512
   }) { ...EV }
 
   emptyNonExistent: scanEvents(filter: {
     sender: "0x0000000000000000000000000000000000000000000000000000000000000001",
-    beforeCheckpoint: 10510
+    beforeCheckpoint: 10512
   }) { ...EV }
 
   earlyEvents: scanEvents(filter: {
@@ -135,10 +157,30 @@ module P2::M2 {
     beforeCheckpoint: 6
   }) { ...EV }
 
+  scanByTypeOnly: scanEvents(filter: {
+    type: "@{P2}::M2::EventC",
+    beforeCheckpoint: 6
+  }) { ...EV }
+
   scanAcrossBlocks: scanEvents(filter: {
     sender: "@{A}",
     afterCheckpoint: 0,
-    beforeCheckpoint: 10510
+    beforeCheckpoint: 10512
+  }) { ...EV }
+
+  # Primitive type param filtering: GenericEvent<bool> vs GenericEvent<u64>
+  scanGenericBool: scanEvents(filter: {
+    type: "@{P1}::M1::GenericEvent<bool>",
+    beforeCheckpoint: 10512
+  }) { ...EV }
+  scanGenericU64: scanEvents(filter: {
+    type: "@{P1}::M1::GenericEvent<u64>",
+    beforeCheckpoint: 10512
+  }) { ...EV }
+  # Without type params, should return both GenericEvent<bool> and GenericEvent<u64>
+  scanGenericAny: scanEvents(filter: {
+    type: "@{P1}::M1::GenericEvent",
+    beforeCheckpoint: 10512
   }) { ...EV }
 }
 
@@ -151,16 +193,16 @@ fragment EV on EventConnection {
 # Cursor pagination: cursor_0 is cp1 event (t=3,e=0),
 # cursor_1 is cp5 first event (t=7,e=0), cursor_2 is cp5 last event (t=7,e=2).
 {
-  first2: scanEvents(first: 2, filter: { sender: "@{A}", beforeCheckpoint: 10510 }) { ...EV }
-  last2: scanEvents(last: 2, filter: { sender: "@{A}", beforeCheckpoint: 10510 }) { ...EV }
+  first2: scanEvents(first: 2, filter: { sender: "@{A}", beforeCheckpoint: 10512 }) { ...EV }
+  last2: scanEvents(last: 2, filter: { sender: "@{A}", beforeCheckpoint: 10512 }) { ...EV }
 
-  firstAfter: scanEvents(first: 10, after: "@{cursor_0}", filter: { sender: "@{A}", beforeCheckpoint: 10510 }) { ...EV }
-  firstBefore: scanEvents(first: 10, before: "@{cursor_2}", filter: { sender: "@{A}", beforeCheckpoint: 10510 }) { ...EV }
+  firstAfter: scanEvents(first: 10, after: "@{cursor_0}", filter: { sender: "@{A}", beforeCheckpoint: 10512 }) { ...EV }
+  firstBefore: scanEvents(first: 10, before: "@{cursor_2}", filter: { sender: "@{A}", beforeCheckpoint: 10512 }) { ...EV }
 
-  windowFirst: scanEvents(first: 10, after: "@{cursor_0}", before: "@{cursor_2}", filter: { sender: "@{A}", beforeCheckpoint: 10510 }) { ...EV }
+  windowFirst: scanEvents(first: 10, after: "@{cursor_0}", before: "@{cursor_2}", filter: { sender: "@{A}", beforeCheckpoint: 10512 }) { ...EV }
 
-  nonexistentCursor: scanEvents(last: 10, after: "@{cursor_3}", filter: { sender: "@{A}", beforeCheckpoint: 10510 }) { ...EV }
-  invalidOrder: scanEvents(first: 10, after: "@{cursor_2}", before: "@{cursor_0}", filter: { sender: "@{A}", beforeCheckpoint: 10510 }) { ...EV }
+  nonexistentCursor: scanEvents(last: 10, after: "@{cursor_3}", filter: { sender: "@{A}", beforeCheckpoint: 10512 }) { ...EV }
+  invalidOrder: scanEvents(first: 10, after: "@{cursor_2}", before: "@{cursor_0}", filter: { sender: "@{A}", beforeCheckpoint: 10512 }) { ...EV }
 }
 
 fragment EV on EventConnection {

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/events/scan.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/events/scan.snap
@@ -1,100 +1,119 @@
 ---
 source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
-assertion_line: 833
 ---
-processed 19 tasks
+processed 23 tasks
 
 init:
 A: object(0,0), B: object(0,1), C: object(0,2)
 
-task 1, lines 6-45:
+task 1, lines 6-57:
 //# publish
 created: object(1,0)
 mutated: object(0,3)
-gas summary: computation_cost: 1000000, storage_cost: 6794400,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 8056000,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 2, lines 47-65:
+task 2, lines 59-77:
 //# publish
 created: object(2,0)
 mutated: object(0,3)
 gas summary: computation_cost: 1000000, storage_cost: 5289600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 3, line 66:
+task 3, line 78:
 //# run P1::M1::emit_a --sender A --args 1
 events: Event { package_id: P1, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: P1, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [7, 69, 118, 101, 110, 116, 32, 65, 1, 0, 0, 0, 0, 0, 0, 0] }
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 4, lines 68-70:
+task 4, lines 80-82:
 //# create-checkpoint
 Checkpoint created: 1
 
-task 5, line 71:
+task 5, line 83:
 //# run P1::M1::emit_b --sender B --args 2
 events: Event { package_id: P1, transaction_module: Identifier("M1"), sender: B, type_: StructTag { address: P1, module: Identifier("M1"), name: Identifier("EventB"), type_params: [] }, contents: [7, 69, 118, 101, 110, 116, 32, 66, 2, 0, 0, 0, 0, 0, 0, 0] }
 mutated: object(0,1)
 gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 6, lines 73-75:
+task 6, lines 85-87:
 //# create-checkpoint
 Checkpoint created: 2
 
-task 7, line 76:
+task 7, line 88:
 //# run P2::M2::emit_c --sender A --args 3
 events: Event { package_id: P2, transaction_module: Identifier("M2"), sender: A, type_: StructTag { address: P2, module: Identifier("M2"), name: Identifier("EventC"), type_params: [] }, contents: [15, 69, 118, 101, 110, 116, 32, 67, 32, 102, 114, 111, 109, 32, 80, 50, 3, 0, 0, 0, 0, 0, 0, 0] }
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 8, lines 78-80:
+task 8, lines 90-92:
 //# create-checkpoint
 Checkpoint created: 3
 
-task 9, line 81:
+task 9, line 93:
 //# run P1::M1::emit_a --sender C --args 4
 events: Event { package_id: P1, transaction_module: Identifier("M1"), sender: C, type_: StructTag { address: P1, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [7, 69, 118, 101, 110, 116, 32, 65, 4, 0, 0, 0, 0, 0, 0, 0] }
 mutated: object(0,2)
 gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 10, lines 83-85:
+task 10, lines 95-97:
 //# create-checkpoint
 Checkpoint created: 4
 
-task 11, line 86:
+task 11, line 98:
 //# run P1::M1::emit_multiple --sender A --args 3
 events: Event { package_id: P1, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: P1, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [15, 69, 118, 101, 110, 116, 32, 102, 114, 111, 109, 32, 108, 111, 111, 112, 1, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: P1, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: P1, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [15, 69, 118, 101, 110, 116, 32, 102, 114, 111, 109, 32, 108, 111, 111, 112, 2, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: P1, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: P1, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [15, 69, 118, 101, 110, 116, 32, 102, 114, 111, 109, 32, 108, 111, 111, 112, 3, 0, 0, 0, 0, 0, 0, 0] }
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 12, line 88:
+task 12, lines 100-102:
 //# create-checkpoint
 Checkpoint created: 5
 
-task 13, lines 90-92:
+task 13, line 103:
+//# run P1::M1::emit_generic_bool --sender A --args 10
+events: Event { package_id: P1, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: P1, module: Identifier("M1"), name: Identifier("GenericEvent"), type_params: [Bool] }, contents: [10, 0, 0, 0, 0, 0, 0, 0] }
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 14, lines 105-107:
+//# create-checkpoint
+Checkpoint created: 6
+
+task 15, line 108:
+//# run P1::M1::emit_generic_u64 --sender B --args 20
+events: Event { package_id: P1, transaction_module: Identifier("M1"), sender: B, type_: StructTag { address: P1, module: Identifier("M1"), name: Identifier("GenericEvent"), type_params: [U64] }, contents: [20, 0, 0, 0, 0, 0, 0, 0] }
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 16, line 110:
+//# create-checkpoint
+Checkpoint created: 7
+
+task 17, lines 112-114:
 //# advance-epoch
 Epoch advanced: 1
 
-task 14, lines 93-95:
+task 18, lines 115-117:
 //# create-checkpoint 10501
-Checkpoint created: 10507
+Checkpoint created: 10509
 
-task 15, line 96:
+task 19, line 118:
 //# run P2::M2::emit_c --sender B --args 100
 events: Event { package_id: P2, transaction_module: Identifier("M2"), sender: B, type_: StructTag { address: P2, module: Identifier("M2"), name: Identifier("EventC"), type_params: [] }, contents: [15, 69, 118, 101, 110, 116, 32, 67, 32, 102, 114, 111, 109, 32, 80, 50, 100, 0, 0, 0, 0, 0, 0, 0] }
 mutated: object(0,1)
 gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 16, line 98:
+task 20, line 120:
 //# create-checkpoint
-Checkpoint created: 10508
+Checkpoint created: 10510
 
-task 17, lines 100-148:
+task 21, lines 122-190:
 //# run-graphql
 Response: {
   "data": {
     "scanEventsA": {
       "pageInfo": {
         "startCursor": "eyJjIjoxLCJ0IjozLCJlIjowfQ==",
-        "endCursor": "eyJjIjo1LCJ0Ijo3LCJlIjoyfQ==",
+        "endCursor": "eyJjIjo2LCJ0Ijo4LCJlIjowfQ==",
         "hasPreviousPage": false,
         "hasNextPage": false
       },
@@ -108,7 +127,7 @@ Response: {
             },
             "contents": {
               "type": {
-                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
+                "repr": "0xc2f3bc23f30551acc78b78555d2ed472f66d42e0cac79a0539f91c1d5f1f46db::M1::EventA"
               }
             }
           }
@@ -122,7 +141,7 @@ Response: {
             },
             "contents": {
               "type": {
-                "repr": "0x2a4de3bd8841a6d9f3987956258c1f43a7eb6b1927f33a9a9c920f0bf08113e8::M2::EventC"
+                "repr": "0x83ef41027d189afd21ec61da0b7e38253e464c277ac662f5cc346280a8d4dcaf::M2::EventC"
               }
             }
           }
@@ -136,7 +155,7 @@ Response: {
             },
             "contents": {
               "type": {
-                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
+                "repr": "0xc2f3bc23f30551acc78b78555d2ed472f66d42e0cac79a0539f91c1d5f1f46db::M1::EventA"
               }
             }
           }
@@ -150,7 +169,7 @@ Response: {
             },
             "contents": {
               "type": {
-                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
+                "repr": "0xc2f3bc23f30551acc78b78555d2ed472f66d42e0cac79a0539f91c1d5f1f46db::M1::EventA"
               }
             }
           }
@@ -164,7 +183,21 @@ Response: {
             },
             "contents": {
               "type": {
-                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
+                "repr": "0xc2f3bc23f30551acc78b78555d2ed472f66d42e0cac79a0539f91c1d5f1f46db::M1::EventA"
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjo2LCJ0Ijo4LCJlIjowfQ==",
+          "node": {
+            "sequenceNumber": 0,
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "contents": {
+              "type": {
+                "repr": "0xc2f3bc23f30551acc78b78555d2ed472f66d42e0cac79a0539f91c1d5f1f46db::M1::GenericEvent<bool>"
               }
             }
           }
@@ -174,7 +207,7 @@ Response: {
     "paginateEventsA": {
       "pageInfo": {
         "startCursor": "eyJ0IjozLCJlIjowfQ==",
-        "endCursor": "eyJ0Ijo3LCJlIjoyfQ==",
+        "endCursor": "eyJ0Ijo4LCJlIjowfQ==",
         "hasPreviousPage": false,
         "hasNextPage": false
       },
@@ -188,7 +221,7 @@ Response: {
             },
             "contents": {
               "type": {
-                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
+                "repr": "0xc2f3bc23f30551acc78b78555d2ed472f66d42e0cac79a0539f91c1d5f1f46db::M1::EventA"
               }
             }
           }
@@ -202,7 +235,7 @@ Response: {
             },
             "contents": {
               "type": {
-                "repr": "0x2a4de3bd8841a6d9f3987956258c1f43a7eb6b1927f33a9a9c920f0bf08113e8::M2::EventC"
+                "repr": "0x83ef41027d189afd21ec61da0b7e38253e464c277ac662f5cc346280a8d4dcaf::M2::EventC"
               }
             }
           }
@@ -216,7 +249,7 @@ Response: {
             },
             "contents": {
               "type": {
-                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
+                "repr": "0xc2f3bc23f30551acc78b78555d2ed472f66d42e0cac79a0539f91c1d5f1f46db::M1::EventA"
               }
             }
           }
@@ -230,7 +263,7 @@ Response: {
             },
             "contents": {
               "type": {
-                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
+                "repr": "0xc2f3bc23f30551acc78b78555d2ed472f66d42e0cac79a0539f91c1d5f1f46db::M1::EventA"
               }
             }
           }
@@ -244,7 +277,21 @@ Response: {
             },
             "contents": {
               "type": {
-                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
+                "repr": "0xc2f3bc23f30551acc78b78555d2ed472f66d42e0cac79a0539f91c1d5f1f46db::M1::EventA"
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJ0Ijo4LCJlIjowfQ==",
+          "node": {
+            "sequenceNumber": 0,
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "contents": {
+              "type": {
+                "repr": "0xc2f3bc23f30551acc78b78555d2ed472f66d42e0cac79a0539f91c1d5f1f46db::M1::GenericEvent<bool>"
               }
             }
           }
@@ -254,7 +301,7 @@ Response: {
     "eventsAFromP1": {
       "pageInfo": {
         "startCursor": "eyJjIjoxLCJ0IjozLCJlIjowfQ==",
-        "endCursor": "eyJjIjo1LCJ0Ijo3LCJlIjoyfQ==",
+        "endCursor": "eyJjIjo2LCJ0Ijo4LCJlIjowfQ==",
         "hasPreviousPage": false,
         "hasNextPage": false
       },
@@ -268,7 +315,7 @@ Response: {
             },
             "contents": {
               "type": {
-                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
+                "repr": "0xc2f3bc23f30551acc78b78555d2ed472f66d42e0cac79a0539f91c1d5f1f46db::M1::EventA"
               }
             }
           }
@@ -282,7 +329,7 @@ Response: {
             },
             "contents": {
               "type": {
-                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
+                "repr": "0xc2f3bc23f30551acc78b78555d2ed472f66d42e0cac79a0539f91c1d5f1f46db::M1::EventA"
               }
             }
           }
@@ -296,7 +343,7 @@ Response: {
             },
             "contents": {
               "type": {
-                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
+                "repr": "0xc2f3bc23f30551acc78b78555d2ed472f66d42e0cac79a0539f91c1d5f1f46db::M1::EventA"
               }
             }
           }
@@ -310,7 +357,21 @@ Response: {
             },
             "contents": {
               "type": {
-                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
+                "repr": "0xc2f3bc23f30551acc78b78555d2ed472f66d42e0cac79a0539f91c1d5f1f46db::M1::EventA"
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjo2LCJ0Ijo4LCJlIjowfQ==",
+          "node": {
+            "sequenceNumber": 0,
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "contents": {
+              "type": {
+                "repr": "0xc2f3bc23f30551acc78b78555d2ed472f66d42e0cac79a0539f91c1d5f1f46db::M1::GenericEvent<bool>"
               }
             }
           }
@@ -334,7 +395,7 @@ Response: {
             },
             "contents": {
               "type": {
-                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
+                "repr": "0xc2f3bc23f30551acc78b78555d2ed472f66d42e0cac79a0539f91c1d5f1f46db::M1::EventA"
               }
             }
           }
@@ -348,7 +409,7 @@ Response: {
             },
             "contents": {
               "type": {
-                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
+                "repr": "0xc2f3bc23f30551acc78b78555d2ed472f66d42e0cac79a0539f91c1d5f1f46db::M1::EventA"
               }
             }
           }
@@ -362,7 +423,7 @@ Response: {
             },
             "contents": {
               "type": {
-                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
+                "repr": "0xc2f3bc23f30551acc78b78555d2ed472f66d42e0cac79a0539f91c1d5f1f46db::M1::EventA"
               }
             }
           }
@@ -376,7 +437,7 @@ Response: {
             },
             "contents": {
               "type": {
-                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
+                "repr": "0xc2f3bc23f30551acc78b78555d2ed472f66d42e0cac79a0539f91c1d5f1f46db::M1::EventA"
               }
             }
           }
@@ -409,7 +470,7 @@ Response: {
             },
             "contents": {
               "type": {
-                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
+                "repr": "0xc2f3bc23f30551acc78b78555d2ed472f66d42e0cac79a0539f91c1d5f1f46db::M1::EventA"
               }
             }
           }
@@ -423,7 +484,7 @@ Response: {
             },
             "contents": {
               "type": {
-                "repr": "0x2a4de3bd8841a6d9f3987956258c1f43a7eb6b1927f33a9a9c920f0bf08113e8::M2::EventC"
+                "repr": "0x83ef41027d189afd21ec61da0b7e38253e464c277ac662f5cc346280a8d4dcaf::M2::EventC"
               }
             }
           }
@@ -447,7 +508,7 @@ Response: {
             },
             "contents": {
               "type": {
-                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
+                "repr": "0xc2f3bc23f30551acc78b78555d2ed472f66d42e0cac79a0539f91c1d5f1f46db::M1::EventA"
               }
             }
           }
@@ -461,7 +522,7 @@ Response: {
             },
             "contents": {
               "type": {
-                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
+                "repr": "0xc2f3bc23f30551acc78b78555d2ed472f66d42e0cac79a0539f91c1d5f1f46db::M1::EventA"
               }
             }
           }
@@ -475,7 +536,7 @@ Response: {
             },
             "contents": {
               "type": {
-                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
+                "repr": "0xc2f3bc23f30551acc78b78555d2ed472f66d42e0cac79a0539f91c1d5f1f46db::M1::EventA"
               }
             }
           }
@@ -499,7 +560,7 @@ Response: {
             },
             "contents": {
               "type": {
-                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
+                "repr": "0xc2f3bc23f30551acc78b78555d2ed472f66d42e0cac79a0539f91c1d5f1f46db::M1::EventA"
               }
             }
           }
@@ -513,7 +574,7 @@ Response: {
             },
             "contents": {
               "type": {
-                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventB"
+                "repr": "0xc2f3bc23f30551acc78b78555d2ed472f66d42e0cac79a0539f91c1d5f1f46db::M1::EventB"
               }
             }
           }
@@ -527,7 +588,7 @@ Response: {
             },
             "contents": {
               "type": {
-                "repr": "0x2a4de3bd8841a6d9f3987956258c1f43a7eb6b1927f33a9a9c920f0bf08113e8::M2::EventC"
+                "repr": "0x83ef41027d189afd21ec61da0b7e38253e464c277ac662f5cc346280a8d4dcaf::M2::EventC"
               }
             }
           }
@@ -541,7 +602,7 @@ Response: {
             },
             "contents": {
               "type": {
-                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
+                "repr": "0xc2f3bc23f30551acc78b78555d2ed472f66d42e0cac79a0539f91c1d5f1f46db::M1::EventA"
               }
             }
           }
@@ -555,7 +616,31 @@ Response: {
             },
             "contents": {
               "type": {
-                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
+                "repr": "0xc2f3bc23f30551acc78b78555d2ed472f66d42e0cac79a0539f91c1d5f1f46db::M1::EventA"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "scanByTypeOnly": {
+      "pageInfo": {
+        "startCursor": "eyJjIjozLCJ0Ijo1LCJlIjowfQ==",
+        "endCursor": "eyJjIjozLCJ0Ijo1LCJlIjowfQ==",
+        "hasPreviousPage": false,
+        "hasNextPage": false
+      },
+      "edges": [
+        {
+          "cursor": "eyJjIjozLCJ0Ijo1LCJlIjowfQ==",
+          "node": {
+            "sequenceNumber": 0,
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "contents": {
+              "type": {
+                "repr": "0x83ef41027d189afd21ec61da0b7e38253e464c277ac662f5cc346280a8d4dcaf::M2::EventC"
               }
             }
           }
@@ -565,7 +650,7 @@ Response: {
     "scanAcrossBlocks": {
       "pageInfo": {
         "startCursor": "eyJjIjoxLCJ0IjozLCJlIjowfQ==",
-        "endCursor": "eyJjIjo1LCJ0Ijo3LCJlIjoyfQ==",
+        "endCursor": "eyJjIjo2LCJ0Ijo4LCJlIjowfQ==",
         "hasPreviousPage": false,
         "hasNextPage": false
       },
@@ -579,7 +664,7 @@ Response: {
             },
             "contents": {
               "type": {
-                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
+                "repr": "0xc2f3bc23f30551acc78b78555d2ed472f66d42e0cac79a0539f91c1d5f1f46db::M1::EventA"
               }
             }
           }
@@ -593,7 +678,7 @@ Response: {
             },
             "contents": {
               "type": {
-                "repr": "0x2a4de3bd8841a6d9f3987956258c1f43a7eb6b1927f33a9a9c920f0bf08113e8::M2::EventC"
+                "repr": "0x83ef41027d189afd21ec61da0b7e38253e464c277ac662f5cc346280a8d4dcaf::M2::EventC"
               }
             }
           }
@@ -607,7 +692,7 @@ Response: {
             },
             "contents": {
               "type": {
-                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
+                "repr": "0xc2f3bc23f30551acc78b78555d2ed472f66d42e0cac79a0539f91c1d5f1f46db::M1::EventA"
               }
             }
           }
@@ -621,7 +706,7 @@ Response: {
             },
             "contents": {
               "type": {
-                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
+                "repr": "0xc2f3bc23f30551acc78b78555d2ed472f66d42e0cac79a0539f91c1d5f1f46db::M1::EventA"
               }
             }
           }
@@ -635,7 +720,107 @@ Response: {
             },
             "contents": {
               "type": {
-                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
+                "repr": "0xc2f3bc23f30551acc78b78555d2ed472f66d42e0cac79a0539f91c1d5f1f46db::M1::EventA"
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjo2LCJ0Ijo4LCJlIjowfQ==",
+          "node": {
+            "sequenceNumber": 0,
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "contents": {
+              "type": {
+                "repr": "0xc2f3bc23f30551acc78b78555d2ed472f66d42e0cac79a0539f91c1d5f1f46db::M1::GenericEvent<bool>"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "scanGenericBool": {
+      "pageInfo": {
+        "startCursor": "eyJjIjo2LCJ0Ijo4LCJlIjowfQ==",
+        "endCursor": "eyJjIjo2LCJ0Ijo4LCJlIjowfQ==",
+        "hasPreviousPage": false,
+        "hasNextPage": false
+      },
+      "edges": [
+        {
+          "cursor": "eyJjIjo2LCJ0Ijo4LCJlIjowfQ==",
+          "node": {
+            "sequenceNumber": 0,
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "contents": {
+              "type": {
+                "repr": "0xc2f3bc23f30551acc78b78555d2ed472f66d42e0cac79a0539f91c1d5f1f46db::M1::GenericEvent<bool>"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "scanGenericU64": {
+      "pageInfo": {
+        "startCursor": "eyJjIjo3LCJ0Ijo5LCJlIjowfQ==",
+        "endCursor": "eyJjIjo3LCJ0Ijo5LCJlIjowfQ==",
+        "hasPreviousPage": false,
+        "hasNextPage": false
+      },
+      "edges": [
+        {
+          "cursor": "eyJjIjo3LCJ0Ijo5LCJlIjowfQ==",
+          "node": {
+            "sequenceNumber": 0,
+            "sender": {
+              "address": "0xa7b032703878aa74c3126935789fd1d4d7e111d5911b09247d6963061c312b5a"
+            },
+            "contents": {
+              "type": {
+                "repr": "0xc2f3bc23f30551acc78b78555d2ed472f66d42e0cac79a0539f91c1d5f1f46db::M1::GenericEvent<u64>"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "scanGenericAny": {
+      "pageInfo": {
+        "startCursor": "eyJjIjo2LCJ0Ijo4LCJlIjowfQ==",
+        "endCursor": "eyJjIjo3LCJ0Ijo5LCJlIjowfQ==",
+        "hasPreviousPage": false,
+        "hasNextPage": false
+      },
+      "edges": [
+        {
+          "cursor": "eyJjIjo2LCJ0Ijo4LCJlIjowfQ==",
+          "node": {
+            "sequenceNumber": 0,
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "contents": {
+              "type": {
+                "repr": "0xc2f3bc23f30551acc78b78555d2ed472f66d42e0cac79a0539f91c1d5f1f46db::M1::GenericEvent<bool>"
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjo3LCJ0Ijo5LCJlIjowfQ==",
+          "node": {
+            "sequenceNumber": 0,
+            "sender": {
+              "address": "0xa7b032703878aa74c3126935789fd1d4d7e111d5911b09247d6963061c312b5a"
+            },
+            "contents": {
+              "type": {
+                "repr": "0xc2f3bc23f30551acc78b78555d2ed472f66d42e0cac79a0539f91c1d5f1f46db::M1::GenericEvent<u64>"
               }
             }
           }
@@ -645,7 +830,7 @@ Response: {
   }
 }
 
-task 18, lines 150-169:
+task 22, lines 192-211:
 //# run-graphql --cursors {"c":1,"t":3,"e":0} {"c":5,"t":7,"e":0} {"c":5,"t":7,"e":2} {"c":20,"t":20,"e":0}
 Response: {
   "data": {
@@ -666,7 +851,7 @@ Response: {
             },
             "contents": {
               "type": {
-                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
+                "repr": "0xc2f3bc23f30551acc78b78555d2ed472f66d42e0cac79a0539f91c1d5f1f46db::M1::EventA"
               }
             }
           }
@@ -680,7 +865,7 @@ Response: {
             },
             "contents": {
               "type": {
-                "repr": "0x2a4de3bd8841a6d9f3987956258c1f43a7eb6b1927f33a9a9c920f0bf08113e8::M2::EventC"
+                "repr": "0x83ef41027d189afd21ec61da0b7e38253e464c277ac662f5cc346280a8d4dcaf::M2::EventC"
               }
             }
           }
@@ -689,26 +874,12 @@ Response: {
     },
     "last2": {
       "pageInfo": {
-        "startCursor": "eyJjIjo1LCJ0Ijo3LCJlIjoxfQ==",
-        "endCursor": "eyJjIjo1LCJ0Ijo3LCJlIjoyfQ==",
+        "startCursor": "eyJjIjo1LCJ0Ijo3LCJlIjoyfQ==",
+        "endCursor": "eyJjIjo2LCJ0Ijo4LCJlIjowfQ==",
         "hasPreviousPage": true,
         "hasNextPage": false
       },
       "edges": [
-        {
-          "cursor": "eyJjIjo1LCJ0Ijo3LCJlIjoxfQ==",
-          "node": {
-            "sequenceNumber": 1,
-            "sender": {
-              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
-            },
-            "contents": {
-              "type": {
-                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
-              }
-            }
-          }
-        },
         {
           "cursor": "eyJjIjo1LCJ0Ijo3LCJlIjoyfQ==",
           "node": {
@@ -718,7 +889,21 @@ Response: {
             },
             "contents": {
               "type": {
-                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
+                "repr": "0xc2f3bc23f30551acc78b78555d2ed472f66d42e0cac79a0539f91c1d5f1f46db::M1::EventA"
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjo2LCJ0Ijo4LCJlIjowfQ==",
+          "node": {
+            "sequenceNumber": 0,
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "contents": {
+              "type": {
+                "repr": "0xc2f3bc23f30551acc78b78555d2ed472f66d42e0cac79a0539f91c1d5f1f46db::M1::GenericEvent<bool>"
               }
             }
           }
@@ -728,7 +913,7 @@ Response: {
     "firstAfter": {
       "pageInfo": {
         "startCursor": "eyJjIjozLCJ0Ijo1LCJlIjowfQ==",
-        "endCursor": "eyJjIjo1LCJ0Ijo3LCJlIjoyfQ==",
+        "endCursor": "eyJjIjo2LCJ0Ijo4LCJlIjowfQ==",
         "hasPreviousPage": true,
         "hasNextPage": false
       },
@@ -742,7 +927,7 @@ Response: {
             },
             "contents": {
               "type": {
-                "repr": "0x2a4de3bd8841a6d9f3987956258c1f43a7eb6b1927f33a9a9c920f0bf08113e8::M2::EventC"
+                "repr": "0x83ef41027d189afd21ec61da0b7e38253e464c277ac662f5cc346280a8d4dcaf::M2::EventC"
               }
             }
           }
@@ -756,7 +941,7 @@ Response: {
             },
             "contents": {
               "type": {
-                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
+                "repr": "0xc2f3bc23f30551acc78b78555d2ed472f66d42e0cac79a0539f91c1d5f1f46db::M1::EventA"
               }
             }
           }
@@ -770,7 +955,7 @@ Response: {
             },
             "contents": {
               "type": {
-                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
+                "repr": "0xc2f3bc23f30551acc78b78555d2ed472f66d42e0cac79a0539f91c1d5f1f46db::M1::EventA"
               }
             }
           }
@@ -784,7 +969,21 @@ Response: {
             },
             "contents": {
               "type": {
-                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
+                "repr": "0xc2f3bc23f30551acc78b78555d2ed472f66d42e0cac79a0539f91c1d5f1f46db::M1::EventA"
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjo2LCJ0Ijo4LCJlIjowfQ==",
+          "node": {
+            "sequenceNumber": 0,
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "contents": {
+              "type": {
+                "repr": "0xc2f3bc23f30551acc78b78555d2ed472f66d42e0cac79a0539f91c1d5f1f46db::M1::GenericEvent<bool>"
               }
             }
           }
@@ -808,7 +1007,7 @@ Response: {
             },
             "contents": {
               "type": {
-                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
+                "repr": "0xc2f3bc23f30551acc78b78555d2ed472f66d42e0cac79a0539f91c1d5f1f46db::M1::EventA"
               }
             }
           }
@@ -822,7 +1021,7 @@ Response: {
             },
             "contents": {
               "type": {
-                "repr": "0x2a4de3bd8841a6d9f3987956258c1f43a7eb6b1927f33a9a9c920f0bf08113e8::M2::EventC"
+                "repr": "0x83ef41027d189afd21ec61da0b7e38253e464c277ac662f5cc346280a8d4dcaf::M2::EventC"
               }
             }
           }
@@ -836,7 +1035,7 @@ Response: {
             },
             "contents": {
               "type": {
-                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
+                "repr": "0xc2f3bc23f30551acc78b78555d2ed472f66d42e0cac79a0539f91c1d5f1f46db::M1::EventA"
               }
             }
           }
@@ -850,7 +1049,7 @@ Response: {
             },
             "contents": {
               "type": {
-                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
+                "repr": "0xc2f3bc23f30551acc78b78555d2ed472f66d42e0cac79a0539f91c1d5f1f46db::M1::EventA"
               }
             }
           }
@@ -874,7 +1073,7 @@ Response: {
             },
             "contents": {
               "type": {
-                "repr": "0x2a4de3bd8841a6d9f3987956258c1f43a7eb6b1927f33a9a9c920f0bf08113e8::M2::EventC"
+                "repr": "0x83ef41027d189afd21ec61da0b7e38253e464c277ac662f5cc346280a8d4dcaf::M2::EventC"
               }
             }
           }
@@ -888,7 +1087,7 @@ Response: {
             },
             "contents": {
               "type": {
-                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
+                "repr": "0xc2f3bc23f30551acc78b78555d2ed472f66d42e0cac79a0539f91c1d5f1f46db::M1::EventA"
               }
             }
           }
@@ -902,7 +1101,7 @@ Response: {
             },
             "contents": {
               "type": {
-                "repr": "0xab69efd2f54283fb2e9fb257b34d6ab572d3f06e958dcccf3760100c0e5a7a8e::M1::EventA"
+                "repr": "0xc2f3bc23f30551acc78b78555d2ed472f66d42e0cac79a0539f91c1d5f1f46db::M1::EventA"
               }
             }
           }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/events/scan_false_positives.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/events/scan_false_positives.move
@@ -1,0 +1,113 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Regression test for iterative bloom scanning with compound bloom keys.
+// Two modules in the same package: Common (high-activity) and Rare (low-activity).
+// Without compound bloom keys, querying for Rare::Signal matches every checkpoint with
+// ANY activity from package P. With compound keys the bloom also encodes the module name,
+// so the scanner can reject Common-only checkpoints at the bloom level.
+// The noise checkpoints also exercise adaptive batch sizing -- the scanner must continue
+// past false-positive batches across multiple empty bloom blocks to find real matches.
+
+//# init --protocol-version 70 --addresses P=0x0 --accounts A --simulator
+
+//# publish
+module P::Common {
+    use sui::event;
+
+    public struct Ping has copy, drop { value: u64 }
+
+    public entry fun ping(value: u64) {
+        event::emit(Ping { value });
+    }
+}
+
+module P::Rare {
+    use sui::event;
+
+    public struct Signal has copy, drop { value: u64 }
+
+    public entry fun signal(value: u64) {
+        event::emit(Signal { value });
+    }
+}
+
+// Block 0: Signal at cp 1, then Ping noise at cps 2-11
+//# run P::Rare::signal --sender A --args 1
+
+//# create-checkpoint
+
+//# run P::Common::ping --sender A --args 1
+
+//# create-checkpoint
+
+//# run P::Common::ping --sender A --args 2
+
+//# create-checkpoint
+
+//# run P::Common::ping --sender A --args 3
+
+//# create-checkpoint
+
+//# run P::Common::ping --sender A --args 4
+
+//# create-checkpoint
+
+//# run P::Common::ping --sender A --args 5
+
+//# create-checkpoint
+
+//# run P::Common::ping --sender A --args 6
+
+//# create-checkpoint
+
+//# run P::Common::ping --sender A --args 7
+
+//# create-checkpoint
+
+//# run P::Common::ping --sender A --args 8
+
+//# create-checkpoint
+
+//# run P::Common::ping --sender A --args 9
+
+//# create-checkpoint
+
+//# run P::Common::ping --sender A --args 10
+
+//# create-checkpoint
+
+// Skip to block 3
+//# create-checkpoint 2989
+
+// Block 3: second Signal at cp 3001
+//# run P::Rare::signal --sender A --args 2
+
+//# create-checkpoint
+
+//# run-graphql
+# Query by type: bloom matches package P in blocks 0 and 3, but compound keys let the
+# scanner reject the 10 Common::Ping checkpoints at the bloom level.
+# Query by module: tests module-level bloom selectivity directly.
+{
+  byType: scanEvents(filter: { type: "@{P}::Rare::Signal", beforeCheckpoint: 3002 }) { ...EV }
+  byModule: scanEvents(filter: { module: "@{P}::Rare", beforeCheckpoint: 3002 }) { ...EV }
+  backward: scanEvents(last: 10, filter: { type: "@{P}::Rare::Signal", beforeCheckpoint: 3002 }) { ...EV }
+}
+
+fragment EV on EventConnection {
+  pageInfo { startCursor endCursor hasPreviousPage hasNextPage }
+  edges { cursor node { sequenceNumber sender { address } contents { type { repr } } } }
+}
+
+//# run-graphql --cursors {"c":1,"t":2,"e":0}
+# Paginate forward after the first Signal — must cross 10 noise checkpoints in block 0,
+# then 2 empty blocks, to find the second Signal in block 3.
+{
+  afterFirst: scanEvents(first: 10, after: "@{cursor_0}", filter: { type: "@{P}::Rare::Signal", beforeCheckpoint: 3002 }) { ...EV }
+}
+
+fragment EV on EventConnection {
+  pageInfo { startCursor endCursor hasPreviousPage hasNextPage }
+  edges { cursor node { sequenceNumber sender { address } contents { type { repr } } } }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/events/scan_false_positives.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/events/scan_false_positives.snap
@@ -1,0 +1,290 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+assertion_line: 833
+---
+processed 29 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 14-35:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 6292800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, line 36:
+//# run P::Rare::signal --sender A --args 1
+events: Event { package_id: P, transaction_module: Identifier("Rare"), sender: A, type_: StructTag { address: P, module: Identifier("Rare"), name: Identifier("Signal"), type_params: [] }, contents: [1, 0, 0, 0, 0, 0, 0, 0] }
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, line 38:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 4, line 40:
+//# run P::Common::ping --sender A --args 1
+events: Event { package_id: P, transaction_module: Identifier("Common"), sender: A, type_: StructTag { address: P, module: Identifier("Common"), name: Identifier("Ping"), type_params: [] }, contents: [1, 0, 0, 0, 0, 0, 0, 0] }
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 5, line 42:
+//# create-checkpoint
+Checkpoint created: 2
+
+task 6, line 44:
+//# run P::Common::ping --sender A --args 2
+events: Event { package_id: P, transaction_module: Identifier("Common"), sender: A, type_: StructTag { address: P, module: Identifier("Common"), name: Identifier("Ping"), type_params: [] }, contents: [2, 0, 0, 0, 0, 0, 0, 0] }
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 7, line 46:
+//# create-checkpoint
+Checkpoint created: 3
+
+task 8, line 48:
+//# run P::Common::ping --sender A --args 3
+events: Event { package_id: P, transaction_module: Identifier("Common"), sender: A, type_: StructTag { address: P, module: Identifier("Common"), name: Identifier("Ping"), type_params: [] }, contents: [3, 0, 0, 0, 0, 0, 0, 0] }
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 9, line 50:
+//# create-checkpoint
+Checkpoint created: 4
+
+task 10, line 52:
+//# run P::Common::ping --sender A --args 4
+events: Event { package_id: P, transaction_module: Identifier("Common"), sender: A, type_: StructTag { address: P, module: Identifier("Common"), name: Identifier("Ping"), type_params: [] }, contents: [4, 0, 0, 0, 0, 0, 0, 0] }
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 11, line 54:
+//# create-checkpoint
+Checkpoint created: 5
+
+task 12, line 56:
+//# run P::Common::ping --sender A --args 5
+events: Event { package_id: P, transaction_module: Identifier("Common"), sender: A, type_: StructTag { address: P, module: Identifier("Common"), name: Identifier("Ping"), type_params: [] }, contents: [5, 0, 0, 0, 0, 0, 0, 0] }
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 13, line 58:
+//# create-checkpoint
+Checkpoint created: 6
+
+task 14, line 60:
+//# run P::Common::ping --sender A --args 6
+events: Event { package_id: P, transaction_module: Identifier("Common"), sender: A, type_: StructTag { address: P, module: Identifier("Common"), name: Identifier("Ping"), type_params: [] }, contents: [6, 0, 0, 0, 0, 0, 0, 0] }
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 15, line 62:
+//# create-checkpoint
+Checkpoint created: 7
+
+task 16, line 64:
+//# run P::Common::ping --sender A --args 7
+events: Event { package_id: P, transaction_module: Identifier("Common"), sender: A, type_: StructTag { address: P, module: Identifier("Common"), name: Identifier("Ping"), type_params: [] }, contents: [7, 0, 0, 0, 0, 0, 0, 0] }
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 17, line 66:
+//# create-checkpoint
+Checkpoint created: 8
+
+task 18, line 68:
+//# run P::Common::ping --sender A --args 8
+events: Event { package_id: P, transaction_module: Identifier("Common"), sender: A, type_: StructTag { address: P, module: Identifier("Common"), name: Identifier("Ping"), type_params: [] }, contents: [8, 0, 0, 0, 0, 0, 0, 0] }
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 19, line 70:
+//# create-checkpoint
+Checkpoint created: 9
+
+task 20, line 72:
+//# run P::Common::ping --sender A --args 9
+events: Event { package_id: P, transaction_module: Identifier("Common"), sender: A, type_: StructTag { address: P, module: Identifier("Common"), name: Identifier("Ping"), type_params: [] }, contents: [9, 0, 0, 0, 0, 0, 0, 0] }
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 21, line 74:
+//# create-checkpoint
+Checkpoint created: 10
+
+task 22, line 76:
+//# run P::Common::ping --sender A --args 10
+events: Event { package_id: P, transaction_module: Identifier("Common"), sender: A, type_: StructTag { address: P, module: Identifier("Common"), name: Identifier("Ping"), type_params: [] }, contents: [10, 0, 0, 0, 0, 0, 0, 0] }
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 23, lines 78-80:
+//# create-checkpoint
+Checkpoint created: 11
+
+task 24, lines 81-83:
+//# create-checkpoint 2989
+Checkpoint created: 3000
+
+task 25, line 84:
+//# run P::Rare::signal --sender A --args 2
+events: Event { package_id: P, transaction_module: Identifier("Rare"), sender: A, type_: StructTag { address: P, module: Identifier("Rare"), name: Identifier("Signal"), type_params: [] }, contents: [2, 0, 0, 0, 0, 0, 0, 0] }
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 26, line 86:
+//# create-checkpoint
+Checkpoint created: 3001
+
+task 27, lines 88-101:
+//# run-graphql
+Response: {
+  "data": {
+    "byType": {
+      "pageInfo": {
+        "startCursor": "eyJjIjoxLCJ0IjoyLCJlIjowfQ==",
+        "endCursor": "eyJjIjozMDAxLCJ0IjoxMywiZSI6MH0=",
+        "hasPreviousPage": false,
+        "hasNextPage": false
+      },
+      "edges": [
+        {
+          "cursor": "eyJjIjoxLCJ0IjoyLCJlIjowfQ==",
+          "node": {
+            "sequenceNumber": 0,
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "contents": {
+              "type": {
+                "repr": "0x91a14998b2ed70bbfa30fc4e0c38a84abdde338709e907eb5bbcc188f1d8f630::Rare::Signal"
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjozMDAxLCJ0IjoxMywiZSI6MH0=",
+          "node": {
+            "sequenceNumber": 0,
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "contents": {
+              "type": {
+                "repr": "0x91a14998b2ed70bbfa30fc4e0c38a84abdde338709e907eb5bbcc188f1d8f630::Rare::Signal"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "byModule": {
+      "pageInfo": {
+        "startCursor": "eyJjIjoxLCJ0IjoyLCJlIjowfQ==",
+        "endCursor": "eyJjIjozMDAxLCJ0IjoxMywiZSI6MH0=",
+        "hasPreviousPage": false,
+        "hasNextPage": false
+      },
+      "edges": [
+        {
+          "cursor": "eyJjIjoxLCJ0IjoyLCJlIjowfQ==",
+          "node": {
+            "sequenceNumber": 0,
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "contents": {
+              "type": {
+                "repr": "0x91a14998b2ed70bbfa30fc4e0c38a84abdde338709e907eb5bbcc188f1d8f630::Rare::Signal"
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjozMDAxLCJ0IjoxMywiZSI6MH0=",
+          "node": {
+            "sequenceNumber": 0,
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "contents": {
+              "type": {
+                "repr": "0x91a14998b2ed70bbfa30fc4e0c38a84abdde338709e907eb5bbcc188f1d8f630::Rare::Signal"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "backward": {
+      "pageInfo": {
+        "startCursor": "eyJjIjoxLCJ0IjoyLCJlIjowfQ==",
+        "endCursor": "eyJjIjozMDAxLCJ0IjoxMywiZSI6MH0=",
+        "hasPreviousPage": false,
+        "hasNextPage": false
+      },
+      "edges": [
+        {
+          "cursor": "eyJjIjoxLCJ0IjoyLCJlIjowfQ==",
+          "node": {
+            "sequenceNumber": 0,
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "contents": {
+              "type": {
+                "repr": "0x91a14998b2ed70bbfa30fc4e0c38a84abdde338709e907eb5bbcc188f1d8f630::Rare::Signal"
+              }
+            }
+          }
+        },
+        {
+          "cursor": "eyJjIjozMDAxLCJ0IjoxMywiZSI6MH0=",
+          "node": {
+            "sequenceNumber": 0,
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "contents": {
+              "type": {
+                "repr": "0x91a14998b2ed70bbfa30fc4e0c38a84abdde338709e907eb5bbcc188f1d8f630::Rare::Signal"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+
+task 28, lines 103-113:
+//# run-graphql --cursors {"c":1,"t":2,"e":0}
+Response: {
+  "data": {
+    "afterFirst": {
+      "pageInfo": {
+        "startCursor": "eyJjIjozMDAxLCJ0IjoxMywiZSI6MH0=",
+        "endCursor": "eyJjIjozMDAxLCJ0IjoxMywiZSI6MH0=",
+        "hasPreviousPage": true,
+        "hasNextPage": false
+      },
+      "edges": [
+        {
+          "cursor": "eyJjIjozMDAxLCJ0IjoxMywiZSI6MH0=",
+          "node": {
+            "sequenceNumber": 0,
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "contents": {
+              "type": {
+                "repr": "0x91a14998b2ed70bbfa30fc4e0c38a84abdde338709e907eb5bbcc188f1d8f630::Rare::Signal"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/crates/sui-indexer-alt-graphql/src/api/types/event/filter.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/event/filter.rs
@@ -177,17 +177,17 @@ impl EventFilter {
 
         if let Some(m) = &self.module {
             let pkg: AccountAddress = m.package().into_bytes().into();
-            values.push(BloomValue::EvAddress(pkg));
+            values.push(BloomValue::EventAddress(pkg));
             if let Some(mod_name) = m.module() {
-                values.push(BloomValue::EvEmitModule(mod_name.to_owned()));
+                values.push(BloomValue::EventEmitModule(mod_name.to_owned()));
             }
         }
 
         if let Some(t) = &self.type_ {
             let pkg: AccountAddress = t.package().into_bytes().into();
-            values.push(BloomValue::EvAddress(pkg));
+            values.push(BloomValue::EventAddress(pkg));
             if let Some(mod_name) = t.module() {
-                values.push(BloomValue::EvTypeModule(mod_name.to_owned()));
+                values.push(BloomValue::EventTypeModule(mod_name.to_owned()));
                 if let Some(name) = t.type_name() {
                     values.push(BloomValue::Name(name.to_owned()));
                 }
@@ -201,7 +201,7 @@ impl EventFilter {
 
         values
             .into_iter()
-            .filter(|v| !v.should_skip())
+            .filter(|v| !v.exclude())
             .map(|v| v.to_bytes())
             .collect()
     }

--- a/crates/sui-indexer-alt-graphql/src/api/types/event/filter.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/event/filter.rs
@@ -7,7 +7,8 @@ use anyhow::Context as _;
 use async_graphql::CustomValidator;
 use async_graphql::InputObject;
 use async_graphql::InputValueError;
-use sui_indexer_alt_schema::blooms::should_skip_for_bloom;
+use move_core_types::account_address::AccountAddress;
+use sui_indexer_alt_schema::blooms::BloomValue;
 use sui_pg_db::query::Query;
 use sui_sql_macro::query;
 use sui_types::event::Event as NativeEvent;
@@ -167,16 +168,42 @@ impl EventFilter {
     }
 
     /// Values to probe in bloom filters.
-    pub(crate) fn bloom_probe_values(&self) -> Vec<[u8; 32]> {
-        [
-            self.sender.map(|s| s.into_bytes()),
-            self.module.as_ref().map(|m| m.package().into_bytes()),
-            self.type_.as_ref().map(|t| t.package().into_bytes()),
-        ]
-        .into_iter()
-        .flatten()
-        .filter(|v| !should_skip_for_bloom(v))
-        .collect()
+    pub(crate) fn bloom_probe_values(&self) -> Vec<Vec<u8>> {
+        let mut values: Vec<BloomValue> = Vec::new();
+
+        if let Some(sender) = self.sender {
+            values.push(BloomValue::SenderOrRecipient(AccountAddress::from(sender)));
+        }
+
+        if let Some(m) = &self.module {
+            let pkg: AccountAddress = m.package().into_bytes().into();
+            values.push(BloomValue::EvAddress(pkg));
+            if let Some(mod_name) = m.module() {
+                values.push(BloomValue::EvEmitModule(mod_name.to_owned()));
+            }
+        }
+
+        if let Some(t) = &self.type_ {
+            let pkg: AccountAddress = t.package().into_bytes().into();
+            values.push(BloomValue::EvAddress(pkg));
+            if let Some(mod_name) = t.module() {
+                values.push(BloomValue::EvTypeModule(mod_name.to_owned()));
+                if let Some(name) = t.type_name() {
+                    values.push(BloomValue::Name(name.to_owned()));
+                }
+            }
+            if let Some(type_params) = t.type_params() {
+                for tp in type_params {
+                    values.push(BloomValue::TypeParam(tp.to_canonical_string(false)));
+                }
+            }
+        }
+
+        values
+            .into_iter()
+            .filter(|v| !v.should_skip())
+            .map(|v| v.to_bytes())
+            .collect()
     }
 }
 

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction/bloom/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction/bloom/mod.rs
@@ -39,7 +39,7 @@ use crate::scope::Scope;
 
 mod scan;
 
-struct CandidateTxn {
+struct SequencedTxnDigest {
     cp_sequence_number: u64,
     tx_sequence_number: u64,
     digest: TransactionDigest,
@@ -76,7 +76,7 @@ pub(crate) async fn transactions(
     let mut result = BTreeMap::new();
 
     while let Some(candidates) = scan.next(pg_reader, &filter_values).await? {
-        let txns = candidate_txns(kv_loader, candidates.candidates()).await?;
+        let txns = sequenced_txn_digests(kv_loader, candidates.candidates()).await?;
         let digests = txns.iter().map(|t| t.digest).collect();
         let mut transactions_by_digest = kv_loader
             .load_many_transactions(digests)
@@ -122,7 +122,7 @@ pub(crate) async fn events(
     let mut result = BTreeMap::new();
 
     while let Some(candidates) = scan.next(pg_reader, &filter_values).await? {
-        let txns = candidate_txns(kv_loader, candidates.candidates()).await?;
+        let txns = sequenced_txn_digests(kv_loader, candidates.candidates()).await?;
         let digests = txns.iter().map(|t| t.digest).collect();
         let events_by_digest = kv_loader
             .load_many_transaction_events(digests)
@@ -163,10 +163,10 @@ pub(crate) async fn events(
 }
 
 /// Load checkpoints for the given candidate CPs to get transaction digests with checkpoint and transaction sequence numbers.
-async fn candidate_txns(
+async fn sequenced_txn_digests(
     kv_loader: &KvLoader,
     candidate_cps: &[u64],
-) -> Result<Vec<CandidateTxn>, RpcError> {
+) -> Result<Vec<SequencedTxnDigest>, RpcError> {
     let checkpoints = kv_loader
         .load_many_checkpoints(candidate_cps.to_vec())
         .await
@@ -178,7 +178,7 @@ async fn candidate_txns(
             content
                 .enumerate_transactions(&summary)
                 .map(
-                    move |(tx_seq, &ExecutionDigests { transaction, .. })| CandidateTxn {
+                    move |(tx_seq, &ExecutionDigests { transaction, .. })| SequencedTxnDigest {
                         tx_sequence_number: tx_seq,
                         cp_sequence_number: cp_seq,
                         digest: transaction,
@@ -276,8 +276,7 @@ pub(super) async fn candidate_cps(
         limit as i64,
     );
 
-    // For each matched block, scan cp_blooms until we have adjusted_limit checkpoints that
-    // match the probe.
+    // Scan cp_blooms within matched blocks to find up to `limit` checkpoints matching the probe.
     let query = query!(
         r#"
         WITH

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction/bloom/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction/bloom/mod.rs
@@ -195,7 +195,7 @@ async fn candidate_txns(
 /// then a finer filter over those ranges for checkpoint matches using cp_blooms.
 pub(super) async fn candidate_cps(
     pg_reader: &PgReader,
-    filter_values: &[[u8; 32]],
+    filter_values: &[Vec<u8>],
     cp_lo: u64,
     cp_hi_inclusive: u64,
     is_from_front: bool,

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction/bloom/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction/bloom/mod.rs
@@ -13,7 +13,6 @@ use diesel::sql_types::Integer;
 use diesel::sql_types::SmallInt;
 use sui_indexer_alt_reader::kv_loader::KvLoader;
 use sui_indexer_alt_reader::kv_loader::TransactionContents;
-use sui_indexer_alt_reader::kv_loader::TransactionEventsContents;
 use sui_indexer_alt_reader::pg_reader::PgReader;
 use sui_indexer_alt_schema::blooms::blocked::BlockedBloomProbe;
 use sui_indexer_alt_schema::blooms::bloom::BloomProbe;
@@ -32,17 +31,21 @@ use crate::api::types::event::ScanEventCursor;
 use crate::api::types::event::filter::EventFilter;
 use crate::api::types::transaction::CScanTransaction;
 use crate::api::types::transaction::ScanTransactionCursor;
+use crate::api::types::transaction::bloom::scan::BloomScan;
 use crate::api::types::transaction::filter::TransactionFilter;
 use crate::error::RpcError;
 use crate::pagination::Page;
 use crate::scope::Scope;
 
-/// Multiplier to page limit to adjust for bloom filter false positives.
-const OVERFETCH_MULTIPLIER: f64 = 3.0;
+mod scan;
 
-pub(super) type EventsBySequenceNumbers = BTreeMap<ScanEventCursor, Event>;
+struct CandidateTxn {
+    cp_sequence_number: u64,
+    tx_sequence_number: u64,
+    digest: TransactionDigest,
+}
 
-pub(crate) trait CpBoundsCursor {
+pub(super) trait CpBoundsCursor {
     fn cp_sequence_number(&self) -> u64;
 }
 
@@ -58,161 +61,153 @@ impl CpBoundsCursor for CScanEvent {
     }
 }
 
-pub(super) type TransactionsBySequenceNumbers =
-    BTreeMap<ScanTransactionCursor, (TransactionDigest, TransactionContents)>;
-
+/// Scans a checkpoint range for transactions matching a filter using bloom-based
+/// candidate selection until it has filled a page of results that match the filter.
 pub(crate) async fn transactions(
     ctx: &Context<'_>,
     page: &Page<CScanTransaction>,
     filter: &TransactionFilter,
     cp_bounds: RangeInclusive<u64>,
-) -> Result<TransactionsBySequenceNumbers, RpcError> {
+) -> Result<BTreeMap<ScanTransactionCursor, (TransactionDigest, TransactionContents)>, RpcError> {
     let kv_loader: &KvLoader = ctx.data()?;
-
-    let (cp_lo, cp_hi_inclusive) = clamped_cp_bounds(page, &cp_bounds);
+    let pg_reader: &PgReader = ctx.data()?;
     let filter_values = filter.bloom_probe_values();
-    let candidate_cps = candidate_cps(ctx, &filter_values, cp_lo, cp_hi_inclusive, page).await?;
+    let mut scan = BloomScan::new(page, &cp_bounds);
+    let mut result = BTreeMap::new();
 
-    if candidate_cps.is_empty() {
-        return Ok(BTreeMap::new());
+    while let Some(candidates) = scan.next(pg_reader, &filter_values).await? {
+        let txns = candidate_txns(kv_loader, candidates.candidates()).await?;
+        let digests = txns.iter().map(|t| t.digest).collect();
+        let mut transactions_by_digest = kv_loader
+            .load_many_transactions(digests)
+            .await
+            .context("Failed to load transactions")?;
+
+        let mut batch_hits = 0;
+        for txn in txns {
+            let contents = transactions_by_digest
+                .remove(&txn.digest)
+                .with_context(|| {
+                    format!("Failed to fetch Transaction with digest {}", txn.digest)
+                })?;
+            if filter.matches(&contents) {
+                batch_hits += 1;
+                let cursor = ScanTransactionCursor {
+                    tx_sequence_number: txn.tx_sequence_number,
+                    cp_sequence_number: txn.cp_sequence_number,
+                };
+                result.insert(cursor, (txn.digest, contents));
+            }
+        }
+
+        candidates.record(batch_hits);
     }
 
-    let checkpoints = kv_loader
-        .load_many_checkpoints(candidate_cps.to_vec())
-        .await
-        .context("Failed to load checkpoint transactions")?;
-    let sequenced_tx_digests: Vec<_> = checkpoints
-        .into_values()
-        .flat_map(|(summary, content, _)| {
-            let cp_seq = summary.sequence_number;
-            content
-                .enumerate_transactions(&summary)
-                .map(move |(tx_seq, &ExecutionDigests { transaction, .. })| {
-                    (tx_seq, cp_seq, transaction)
-                })
-                .collect::<Vec<_>>()
-        })
-        .collect();
-
-    let digests = sequenced_tx_digests
-        .iter()
-        .map(|(_, _, digest)| *digest)
-        .collect();
-    let mut transactions_by_digest = kv_loader
-        .load_many_transactions(digests)
-        .await
-        .context("Failed to load transactions")?;
-
-    sequenced_tx_digests
-        .into_iter()
-        .map(|(tx_seq, cp_seq, digest)| -> Result<_, RpcError> {
-            let contents = transactions_by_digest
-                .remove(&digest)
-                .with_context(|| format!("Failed to fetch Transaction with digest {digest}"))?;
-            let cursor = ScanTransactionCursor {
-                tx_sequence_number: tx_seq,
-                cp_sequence_number: cp_seq,
-            };
-            Ok((cursor, (digest, contents)))
-        })
-        .collect()
+    Ok(result)
 }
 
-/// The map of events that might match the filter criteria in `cp_bounds` checkpoints keyed by EventCursor.
+/// Scans a checkpoint range for events matching a filter using bloom-based
+/// candidate selection until it has filled a page of results that match the filter.
 pub(crate) async fn events(
     ctx: &Context<'_>,
     scope: &Scope,
     filter: &EventFilter,
     page: &Page<CScanEvent>,
     cp_bounds: RangeInclusive<u64>,
-) -> Result<EventsBySequenceNumbers, RpcError> {
+) -> Result<BTreeMap<ScanEventCursor, Event>, RpcError> {
     let kv_loader: &KvLoader = ctx.data()?;
-
-    let (cp_lo, cp_hi) = clamped_cp_bounds(page, &cp_bounds);
+    let pg_reader: &PgReader = ctx.data()?;
     let filter_values = filter.bloom_probe_values();
-    let candidate_cps = candidate_cps(ctx, &filter_values, cp_lo, cp_hi, page).await?;
+    let mut scan = BloomScan::new(page, &cp_bounds);
+    let mut result = BTreeMap::new();
 
-    if candidate_cps.is_empty() {
-        return Ok(BTreeMap::new());
+    while let Some(candidates) = scan.next(pg_reader, &filter_values).await? {
+        let txns = candidate_txns(kv_loader, candidates.candidates()).await?;
+        let digests = txns.iter().map(|t| t.digest).collect();
+        let events_by_digest = kv_loader
+            .load_many_transaction_events(digests)
+            .await
+            .context("Failed to load transaction events")?;
+
+        let mut batch_hits = 0;
+        for txn in &txns {
+            let contents = events_by_digest
+                .get(&txn.digest)
+                .with_context(|| format!("Missing events for transaction {}", txn.digest))?;
+            for (idx, native) in contents.events()?.into_iter().enumerate() {
+                if filter.matches(&native) {
+                    batch_hits += 1;
+                    let sequence_number = idx as u64;
+                    result.insert(
+                        ScanEventCursor {
+                            cp_sequence_number: txn.cp_sequence_number,
+                            tx_sequence_number: txn.tx_sequence_number,
+                            ev_sequence_number: sequence_number,
+                        },
+                        Event {
+                            scope: scope.clone(),
+                            native,
+                            transaction_digest: txn.digest,
+                            sequence_number,
+                            timestamp_ms: contents.timestamp_ms(),
+                        },
+                    );
+                }
+            }
+        }
+
+        candidates.record(batch_hits);
     }
 
+    Ok(result)
+}
+
+/// Load checkpoints for the given candidate CPs to get transaction digests with checkpoint and transaction sequence numbers.
+async fn candidate_txns(
+    kv_loader: &KvLoader,
+    candidate_cps: &[u64],
+) -> Result<Vec<CandidateTxn>, RpcError> {
     let checkpoints = kv_loader
         .load_many_checkpoints(candidate_cps.to_vec())
         .await
         .context("Failed to load checkpoint transactions")?;
-    let sequenced_tx_digests: Vec<_> = checkpoints
+    Ok(checkpoints
         .into_values()
         .flat_map(|(summary, content, _)| {
             let cp_seq = summary.sequence_number;
             content
                 .enumerate_transactions(&summary)
-                .map(move |(tx_seq, &ExecutionDigests { transaction, .. })| {
-                    (tx_seq, cp_seq, transaction)
-                })
+                .map(
+                    move |(tx_seq, &ExecutionDigests { transaction, .. })| CandidateTxn {
+                        tx_sequence_number: tx_seq,
+                        cp_sequence_number: cp_seq,
+                        digest: transaction,
+                    },
+                )
                 .collect::<Vec<_>>()
         })
-        .collect();
-
-    let digests: Vec<_> = sequenced_tx_digests
-        .iter()
-        .map(|(_, _, digest)| *digest)
-        .collect();
-    let events_by_digest: std::collections::HashMap<_, TransactionEventsContents> = kv_loader
-        .load_many_transaction_events(digests)
-        .await
-        .context("Failed to load transaction events")?;
-
-    let mut result = BTreeMap::new();
-    for (tx_sequence_number, cp_sequence_number, transaction_digest) in sequenced_tx_digests {
-        let contents = events_by_digest
-            .get(&transaction_digest)
-            .with_context(|| format!("Missing events for transaction {transaction_digest}"))?;
-        let timestamp_ms = contents.timestamp_ms();
-        for (idx, native) in contents.events()?.into_iter().enumerate() {
-            let sequence_number = idx as u64;
-            result.insert(
-                ScanEventCursor {
-                    cp_sequence_number,
-                    tx_sequence_number,
-                    ev_sequence_number: sequence_number,
-                },
-                Event {
-                    scope: scope.clone(),
-                    native,
-                    transaction_digest,
-                    sequence_number,
-                    timestamp_ms,
-                },
-            );
-        }
-    }
-    Ok(result)
+        .collect())
 }
 
 /// The checkpoints that might contain the filter criteria.
 ///
 /// Does a coarse filter over checkpoints ranges using cp_bloom_blocks,
 /// then a finer filter over those ranges for checkpoint matches using cp_blooms.
-async fn candidate_cps<C>(
-    ctx: &Context<'_>,
+pub(super) async fn candidate_cps(
+    pg_reader: &PgReader,
     filter_values: &[[u8; 32]],
     cp_lo: u64,
     cp_hi_inclusive: u64,
-    page: &Page<C>,
+    is_from_front: bool,
+    limit: usize,
 ) -> Result<Vec<u64>, RpcError> {
     if filter_values.is_empty() {
-        return Ok(if page.is_from_front() {
-            (cp_lo..=cp_hi_inclusive)
-                .take(page.limit_with_overhead())
-                .collect()
+        return Ok(if is_from_front {
+            (cp_lo..=cp_hi_inclusive).take(limit).collect()
         } else {
-            (cp_lo..=cp_hi_inclusive)
-                .rev()
-                .take(page.limit_with_overhead())
-                .collect()
+            (cp_lo..=cp_hi_inclusive).rev().take(limit).collect()
         });
     }
-    let pg_reader: &PgReader = ctx.data()?;
     let mut conn = pg_reader
         .connect()
         .await
@@ -233,8 +228,6 @@ async fn candidate_cps<C>(
     let q_bloom_check = cp_bloom_check_sql(&CpBloomFilter::probe(filter_values));
 
     let block_size = CP_BLOCK_SIZE as i64;
-    let adjusted_limit = (page.limit_with_overhead() as f64 * OVERFETCH_MULTIPLIER) as i64;
-
     // For each unique (cp_block_index, bloom_block_index) probe pair, fetch the bloom block
     // row once via index lookup, then check all bit probes against it.
     // The NOT EXISTS short-circuits on the first failing probe per pair.
@@ -271,8 +264,12 @@ async fn candidate_cps<C>(
         block_size,
         block_size,
         block_size,
-        page.order_by_direction(),
-        adjusted_limit,
+        if is_from_front {
+            query!("ASC")
+        } else {
+            query!("DESC")
+        },
+        limit as i64,
     );
 
     // For each matched block, scan cp_blooms until we have adjusted_limit checkpoints that
@@ -308,8 +305,12 @@ async fn candidate_cps<C>(
         cp_lo as i64,
         cp_hi_inclusive as i64,
         q_bloom_check,
-        page.order_by_direction(),
-        adjusted_limit,
+        if is_from_front {
+            query!("ASC")
+        } else {
+            query!("DESC")
+        },
+        limit as i64,
     );
 
     #[derive(QueryableByName)]
@@ -397,17 +398,4 @@ fn cp_bloom_check_sql(probe: &BloomProbe) -> Query<'static> {
         );
     }
     condition
-}
-
-fn clamped_cp_bounds<C: CpBoundsCursor>(
-    page: &Page<C>,
-    cp_bounds: &RangeInclusive<u64>,
-) -> (u64, u64) {
-    let cp_lo = page.after().map_or(*cp_bounds.start(), |c| {
-        c.cp_sequence_number().max(*cp_bounds.start())
-    });
-    let cp_hi_inclusive = page.before().map_or(*cp_bounds.end(), |c| {
-        c.cp_sequence_number().min(*cp_bounds.end())
-    });
-    (cp_lo, cp_hi_inclusive)
 }

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction/bloom/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction/bloom/mod.rs
@@ -197,24 +197,29 @@ pub(super) async fn candidate_cps(
     pg_reader: &PgReader,
     filter_values: &[Vec<u8>],
     cp_lo: u64,
-    cp_hi_inclusive: u64,
+    cp_hi: u64,
     is_from_front: bool,
     limit: usize,
 ) -> Result<Vec<u64>, RpcError> {
+    if cp_lo >= cp_hi {
+        return Ok(vec![]);
+    }
+
     if filter_values.is_empty() {
         return Ok(if is_from_front {
-            (cp_lo..=cp_hi_inclusive).take(limit).collect()
+            (cp_lo..cp_hi).take(limit).collect()
         } else {
-            (cp_lo..=cp_hi_inclusive).rev().take(limit).collect()
+            (cp_lo..cp_hi).rev().take(limit).collect()
         });
     }
+
     let mut conn = pg_reader
         .connect()
         .await
         .context("Failed to connect to database for bloom filter scan")?;
 
     let cp_block_lo = cp_block_index(cp_lo);
-    let cp_block_hi_inclusive = cp_block_index(cp_hi_inclusive);
+    let cp_block_hi_inclusive = cp_block_index(cp_hi.saturating_sub(1));
 
     // Block index and probe for each block in the range. Seeds vary per block, so we must
     // construct probes for each block.
@@ -237,7 +242,7 @@ pub(super) async fn candidate_cps(
         SELECT
             cp_bloom_blocks.cp_block_index,
             cp_bloom_blocks.cp_block_index * {BigInt} AS cp_lo,
-            cp_bloom_blocks.cp_block_index * {BigInt} + {BigInt} - 1 AS cp_hi_inclusive
+            (cp_bloom_blocks.cp_block_index + 1) * {BigInt} AS cp_hi
         FROM
             (SELECT DISTINCT cp_block_index, bloom_block_index, bloom_count
              FROM block_byte_probes) unique_probes
@@ -261,7 +266,6 @@ pub(super) async fn candidate_cps(
         LIMIT
             {BigInt}
         "#,
-        block_size,
         block_size,
         block_size,
         if is_from_front {
@@ -291,8 +295,8 @@ pub(super) async fn candidate_cps(
             FROM
                 cp_blooms
             WHERE
-                cp_sequence_number BETWEEN GREATEST(matched_blocks.cp_lo, {BigInt})
-                    AND LEAST(matched_blocks.cp_hi_inclusive, {BigInt})
+                cp_sequence_number >= GREATEST(matched_blocks.cp_lo, {BigInt})
+                    AND cp_sequence_number < LEAST(matched_blocks.cp_hi, {BigInt})
                 AND {}
             ORDER BY
                 cp_sequence_number {}
@@ -303,7 +307,7 @@ pub(super) async fn candidate_cps(
         q_block_probes,
         matched_blocks,
         cp_lo as i64,
-        cp_hi_inclusive as i64,
+        cp_hi as i64,
         q_bloom_check,
         if is_from_front {
             query!("ASC")

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction/bloom/scan.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction/bloom/scan.rs
@@ -1,0 +1,169 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::ops::RangeInclusive;
+
+use sui_indexer_alt_reader::pg_reader::PgReader;
+
+use crate::error::RpcError;
+use crate::pagination::Page;
+
+use crate::api::types::transaction::bloom::CpBoundsCursor;
+use crate::api::types::transaction::bloom::candidate_cps;
+
+/// Approximate false positive rate of the bloom filter. Used to inflate the initial
+/// candidate fetch size before any real hit-rate data is available.
+const BLOOM_FPR: f64 = 0.1;
+
+/// Maximum number of bloom-matched candidate checkpoints to fetch in a single batch.
+const MAX_LIMIT: usize = 500;
+
+/// Scan state for paginating through bloom-filtered checkpoint candidates.
+///
+/// Tracks the current checkpoint window, hit rate, and iteration count to size
+/// each batch of candidates returned by [`next`](Self::next).
+///
+/// ```ignore
+/// while let Some(batch) = scan.next(&pg_reader, &filter_values).await? {
+///     let hits = process(batch.candidates());
+///     batch.record(hits);
+/// }
+/// ```
+pub(super) struct BloomScan {
+    cp_lo: u64,
+    cp_hi_inclusive: u64,
+    /// Target number of results to fill the page.
+    page_limit: usize,
+    /// Results that passed the real filter.
+    hits: usize,
+    iterations: usize,
+    is_from_front: bool,
+    /// The lowest non-zero per-batch hit rate observed so far, used as a pessimistic
+    /// estimate for sizing subsequent fetches.
+    min_batch_hit_rate: Option<f64>,
+}
+
+/// A set of bloom-matched candidate checkpoints returned by [`BloomScan::next`].
+/// Holds a mutable borrow on the scan — call [`record`](Self::record) to feed back the
+/// hit count and advance the scan window.
+pub(super) struct Candidates<'a> {
+    scan: &'a mut BloomScan,
+    candidates: Vec<u64>,
+}
+
+impl BloomScan {
+    pub(super) fn new<C: CpBoundsCursor>(page: &Page<C>, cp_bounds: &RangeInclusive<u64>) -> Self {
+        let cp_lo = page.after().map_or(*cp_bounds.start(), |c| {
+            c.cp_sequence_number().max(*cp_bounds.start())
+        });
+        let cp_hi_inclusive = page.before().map_or(*cp_bounds.end(), |c| {
+            c.cp_sequence_number().min(*cp_bounds.end())
+        });
+        Self {
+            cp_lo,
+            cp_hi_inclusive,
+            hits: 0,
+            iterations: 0,
+            page_limit: page.limit_with_overhead(),
+            is_from_front: page.is_from_front(),
+            min_batch_hit_rate: None,
+        }
+    }
+
+    /// Fetches the next batch of bloom-matched checkpoints, sized based on the hit rate
+    /// observed so far. Bloom filters operate on the values inserted and values inserted
+    /// from busy packages may cause a high false positive rate for other items,
+    /// so candidates include false positives — low hit rates cause larger fetches to compensate.
+    ///
+    /// Returns `None` when the page is filled or the checkpoint window is exhausted.
+    pub(super) async fn next<'a>(
+        &'a mut self,
+        pg_reader: &PgReader,
+        filter_values: &[[u8; 32]],
+    ) -> Result<Option<Candidates<'a>>, RpcError> {
+        if self.hits >= self.page_limit || self.cp_lo > self.cp_hi_inclusive {
+            return Ok(None);
+        }
+
+        let limit = self.limit();
+        let candidates = candidate_cps(
+            pg_reader,
+            filter_values,
+            self.cp_lo,
+            self.cp_hi_inclusive,
+            self.is_from_front,
+            limit,
+        )
+        .await?;
+
+        Ok(if candidates.is_empty() {
+            None
+        } else {
+            Some(Candidates {
+                scan: self,
+                candidates,
+            })
+        })
+    }
+
+    fn record(&mut self, candidates: &[u64], batch_hits: usize) {
+        let batch_size = candidates.len();
+        if batch_size == 0 {
+            return;
+        }
+
+        if batch_hits > 0 {
+            let batch_rate = batch_hits as f64 / batch_size as f64;
+            self.min_batch_hit_rate = Some(
+                self.min_batch_hit_rate
+                    .map_or(batch_rate, |r| r.min(batch_rate)),
+            );
+        }
+
+        self.iterations += 1;
+        self.hits += batch_hits;
+
+        let Some(&last_cp) = candidates.last() else {
+            return;
+        };
+
+        if self.is_from_front {
+            self.cp_lo = last_cp.saturating_add(1);
+        } else {
+            self.cp_hi_inclusive = last_cp.saturating_sub(1);
+        }
+    }
+
+    /// Estimates how many bloom-matched candidate checkpoints to request based on the current precision.
+    ///                                                                                                                                               
+    /// Before any hits are observed, assumes the STARTING_HIT_RATE and                                                                            
+    /// doubles the request size each round to handle unknown sparsity.               
+    ///  
+    /// Once hits are observed, switches to the empirical hit rate with
+    /// an overfetch multiplier to overfetch and reduce the chance of needing another round.
+    ///
+    /// The result is always clamped to `[remaining, MAX_LIMIT]` — at least
+    /// enough to fill the page at 100% hit rate, and at most MAX_LIMIT to
+    /// bound per-round work.
+    fn limit(&self) -> usize {
+        let remaining = self.page_limit.saturating_sub(self.hits);
+
+        let estimate = match self.min_batch_hit_rate {
+            None => self.page_limit as f64 / (1.0 - BLOOM_FPR) * f64::exp2(self.iterations as f64),
+            Some(rate) => remaining as f64 / rate,
+        };
+
+        estimate.clamp(remaining as f64, MAX_LIMIT as f64) as usize
+    }
+}
+
+impl<'a> Candidates<'a> {
+    pub(super) fn candidates(&self) -> &[u64] {
+        &self.candidates
+    }
+
+    /// Records how many candidates matched the real filter and advances the scan window.
+    pub(super) fn record(self, hits: usize) {
+        self.scan.record(&self.candidates, hits);
+    }
+}

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction/bloom/scan.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction/bloom/scan.rs
@@ -79,7 +79,7 @@ impl BloomScan {
     pub(super) async fn next<'a>(
         &'a mut self,
         pg_reader: &PgReader,
-        filter_values: &[[u8; 32]],
+        filter_values: &[Vec<u8>],
     ) -> Result<Option<Candidates<'a>>, RpcError> {
         if self.hits >= self.page_limit || self.cp_lo > self.cp_hi_inclusive {
             return Ok(None);

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction/bloom/scan.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction/bloom/scan.rs
@@ -31,7 +31,8 @@ const MAX_LIMIT: usize = 500;
 /// ```
 pub(super) struct BloomScan {
     cp_lo: u64,
-    cp_hi_inclusive: u64,
+    /// Exclusive upper bound on the checkpoint scan window.
+    cp_hi: u64,
     /// Target number of results to fill the page.
     page_limit: usize,
     /// Results that passed the real filter.
@@ -41,6 +42,10 @@ pub(super) struct BloomScan {
     /// The lowest non-zero per-batch hit rate observed so far, used as a pessimistic
     /// estimate for sizing subsequent fetches.
     min_batch_hit_rate: Option<f64>,
+    /// Number of candidates in the most recent batch, stashed by [`next`](Self::next).
+    last_batch_size: usize,
+    /// Last checkpoint in the most recent batch, stashed by [`next`](Self::next).
+    last_cp: Option<u64>,
 }
 
 /// A set of bloom-matched candidate checkpoints returned by [`BloomScan::next`].
@@ -56,17 +61,23 @@ impl BloomScan {
         let cp_lo = page.after().map_or(*cp_bounds.start(), |c| {
             c.cp_sequence_number().max(*cp_bounds.start())
         });
-        let cp_hi_inclusive = page.before().map_or(*cp_bounds.end(), |c| {
-            c.cp_sequence_number().min(*cp_bounds.end())
-        });
+        let cp_hi = page
+            .before()
+            .map_or(cp_bounds.end().saturating_add(1), |c| {
+                c.cp_sequence_number()
+                    .min(*cp_bounds.end())
+                    .saturating_add(1)
+            });
         Self {
             cp_lo,
-            cp_hi_inclusive,
+            cp_hi,
             hits: 0,
             iterations: 0,
             page_limit: page.limit_with_overhead(),
             is_from_front: page.is_from_front(),
             min_batch_hit_rate: None,
+            last_batch_size: 0,
+            last_cp: None,
         }
     }
 
@@ -81,7 +92,7 @@ impl BloomScan {
         pg_reader: &PgReader,
         filter_values: &[Vec<u8>],
     ) -> Result<Option<Candidates<'a>>, RpcError> {
-        if self.hits >= self.page_limit || self.cp_lo > self.cp_hi_inclusive {
+        if self.hits >= self.page_limit || self.cp_lo >= self.cp_hi {
             return Ok(None);
         }
 
@@ -90,7 +101,7 @@ impl BloomScan {
             pg_reader,
             filter_values,
             self.cp_lo,
-            self.cp_hi_inclusive,
+            self.cp_hi,
             self.is_from_front,
             limit,
         )
@@ -99,6 +110,8 @@ impl BloomScan {
         Ok(if candidates.is_empty() {
             None
         } else {
+            self.last_batch_size = candidates.len();
+            self.last_cp = candidates.last().copied();
             Some(Candidates {
                 scan: self,
                 candidates,
@@ -106,14 +119,13 @@ impl BloomScan {
         })
     }
 
-    fn record(&mut self, candidates: &[u64], batch_hits: usize) {
-        let batch_size = candidates.len();
-        if batch_size == 0 {
+    fn record(&mut self, batch_hits: usize) {
+        if self.last_batch_size == 0 {
             return;
         }
 
         if batch_hits > 0 {
-            let batch_rate = batch_hits as f64 / batch_size as f64;
+            let batch_rate = batch_hits as f64 / self.last_batch_size as f64;
             self.min_batch_hit_rate = Some(
                 self.min_batch_hit_rate
                     .map_or(batch_rate, |r| r.min(batch_rate)),
@@ -123,14 +135,14 @@ impl BloomScan {
         self.iterations += 1;
         self.hits += batch_hits;
 
-        let Some(&last_cp) = candidates.last() else {
+        let Some(last_cp) = self.last_cp else {
             return;
         };
 
         if self.is_from_front {
             self.cp_lo = last_cp.saturating_add(1);
         } else {
-            self.cp_hi_inclusive = last_cp.saturating_sub(1);
+            self.cp_hi = last_cp;
         }
     }
 
@@ -164,6 +176,28 @@ impl<'a> Candidates<'a> {
 
     /// Records how many candidates matched the real filter and advances the scan window.
     pub(super) fn record(self, hits: usize) {
-        self.scan.record(&self.candidates, hits);
+        self.scan.record(hits);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn backward_at_checkpoint_zero_terminates() {
+        let mut scan = BloomScan {
+            cp_lo: 0,
+            cp_hi: 1,
+            page_limit: 10,
+            hits: 0,
+            iterations: 0,
+            is_from_front: false,
+            min_batch_hit_rate: None,
+            last_batch_size: 1,
+            last_cp: Some(0),
+        };
+        scan.record(1);
+        assert!(scan.cp_lo >= scan.cp_hi);
     }
 }

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction/bloom/scan.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction/bloom/scan.rs
@@ -16,7 +16,7 @@ use crate::api::types::transaction::bloom::candidate_cps;
 const BLOOM_FPR: f64 = 0.1;
 
 /// Maximum number of bloom-matched candidate checkpoints to fetch in a single batch.
-const MAX_LIMIT: usize = 500;
+const MAX_CHECKPOINT_FETCH: usize = 500;
 
 /// Scan state for paginating through bloom-filtered checkpoint candidates.
 ///
@@ -81,10 +81,7 @@ impl BloomScan {
         }
     }
 
-    /// Fetches the next batch of bloom-matched checkpoints, sized based on the hit rate
-    /// observed so far. Bloom filters operate on the values inserted and values inserted
-    /// from busy packages may cause a high false positive rate for other items,
-    /// so candidates include false positives — low hit rates cause larger fetches to compensate.
+    /// Fetches the next batch of bloom-matched checkpoints. The current hit rate influences the number of checkpoints fetched in a batch.
     ///
     /// Returns `None` when the page is filled or the checkpoint window is exhausted.
     pub(super) async fn next<'a>(
@@ -154,8 +151,8 @@ impl BloomScan {
     /// Once hits are observed, switches to the empirical hit rate with
     /// an overfetch multiplier to overfetch and reduce the chance of needing another round.
     ///
-    /// The result is always clamped to `[remaining, MAX_LIMIT]` — at least
-    /// enough to fill the page at 100% hit rate, and at most MAX_LIMIT to
+    /// The result is always clamped to `[remaining, MAX_CHECKPOINT_FETCH]` — at least
+    /// enough to fill the page at 100% hit rate, and at most MAX_CHECKPOINT_FETCH to
     /// bound per-round work.
     fn limit(&self) -> usize {
         let remaining = self.page_limit.saturating_sub(self.hits);
@@ -165,7 +162,7 @@ impl BloomScan {
             Some(rate) => remaining as f64 / rate,
         };
 
-        estimate.clamp(remaining as f64, MAX_LIMIT as f64) as usize
+        estimate.clamp(remaining as f64, MAX_CHECKPOINT_FETCH as f64) as usize
     }
 }
 

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction/filter.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction/filter.rs
@@ -7,8 +7,9 @@ use async_graphql::Enum;
 use async_graphql::InputObject;
 use async_graphql::InputType;
 use async_graphql::InputValueError;
+use move_core_types::account_address::AccountAddress;
 use sui_indexer_alt_reader::kv_loader::TransactionContents;
-use sui_indexer_alt_schema::blooms::should_skip_for_bloom;
+use sui_indexer_alt_schema::blooms::BloomValue;
 use sui_types::transaction::TransactionDataAPI as _;
 
 use crate::api::scalars::fq_name_filter::FqNameFilter;
@@ -128,17 +129,35 @@ impl TransactionFilter {
     }
 
     /// Values to probe in bloom filters.
-    pub(crate) fn bloom_probe_values(&self) -> Vec<[u8; 32]> {
-        [
-            self.function.as_ref().map(|f| f.package().into_bytes()),
-            self.affected_address.map(|a| a.into_bytes()),
-            self.affected_object.map(|o| o.into_bytes()),
-            self.sent_address.map(|s| s.into_bytes()),
-        ]
-        .into_iter()
-        .flatten()
-        .filter(|v| !should_skip_for_bloom(v))
-        .collect()
+    pub(crate) fn bloom_probe_values(&self) -> Vec<Vec<u8>> {
+        let mut values: Vec<BloomValue> = Vec::new();
+
+        if let Some(f) = &self.function {
+            let pkg: AccountAddress = f.package().into_bytes().into();
+            values.push(BloomValue::MoveCallPackage(pkg));
+            if let Some(m) = f.module() {
+                values.push(BloomValue::MoveCallModule(m.to_owned()));
+                if let Some(n) = f.name() {
+                    values.push(BloomValue::Name(n.to_owned()));
+                }
+            }
+        }
+
+        if let Some(a) = self.affected_address {
+            values.push(BloomValue::SenderOrRecipient(AccountAddress::from(a)));
+        }
+        if let Some(o) = self.affected_object {
+            values.push(BloomValue::AffectedObject(AccountAddress::from(o)));
+        }
+        if let Some(s) = self.sent_address {
+            values.push(BloomValue::SenderOrRecipient(AccountAddress::from(s)));
+        }
+
+        values
+            .into_iter()
+            .filter(|v| !v.should_skip())
+            .map(|v| v.to_bytes())
+            .collect()
     }
 
     /// Checks if a transaction's contents matches the filter conditions.
@@ -275,50 +294,5 @@ impl<T: CheckpointBounds + InputType> CustomValidator<T> for ScanFilterValidator
         }
 
         Ok(())
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::str::FromStr;
-
-    use super::*;
-
-    #[test]
-    fn test_bloom_probe_values_skips_zero_address() {
-        let zero = SuiAddress::from_str("0x0").unwrap();
-        let filter = TransactionFilter {
-            sent_address: Some(zero),
-            ..Default::default()
-        };
-        assert!(filter.bloom_probe_values().is_empty());
-    }
-
-    #[test]
-    fn test_bloom_probe_values_skips_clock_address() {
-        let clock = SuiAddress::from_str("0x6").unwrap();
-        let filter = TransactionFilter {
-            affected_object: Some(clock),
-            ..Default::default()
-        };
-        assert!(filter.bloom_probe_values().is_empty());
-    }
-
-    #[test]
-    fn test_bloom_probe_values_keeps_normal_address() {
-        let addr = SuiAddress::from_str("0x42").unwrap();
-        let filter = TransactionFilter {
-            sent_address: Some(addr),
-            ..Default::default()
-        };
-        let values = filter.bloom_probe_values();
-        assert_eq!(values.len(), 1);
-        assert_eq!(values[0], addr.into_bytes());
-    }
-
-    #[test]
-    fn test_bloom_probe_values_empty_filter() {
-        let filter = TransactionFilter::default();
-        assert!(filter.bloom_probe_values().is_empty());
     }
 }

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction/filter.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction/filter.rs
@@ -155,7 +155,7 @@ impl TransactionFilter {
 
         values
             .into_iter()
-            .filter(|v| !v.should_skip())
+            .filter(|v| !v.exclude())
             .map(|v| v.to_bytes())
             .collect()
     }

--- a/crates/sui-indexer-alt-schema/src/blooms/mod.rs
+++ b/crates/sui-indexer-alt-schema/src/blooms/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use move_core_types::account_address::AccountAddress;
+use move_core_types::language_storage::StructTag;
 use sui_types::SUI_CLOCK_ADDRESS;
 
 pub mod blocked;
@@ -9,14 +10,108 @@ pub mod bloom;
 pub mod hash;
 
 /// High-frequency identifiers excluded from bloom filters. These appear in most
-/// checkpoints, so including them would:
-/// - Cause queries to match nearly all blocks and checkpoints
-/// - Require fetching and probing more bloom filter rows at both levels
+/// checkpoints, so including them would cause queries to match nearly all blocks.
 const BLOOM_SKIP_ADDRESSES: &[AccountAddress] = &[AccountAddress::ZERO, SUI_CLOCK_ADDRESS];
 
-/// Returns true if the bytes should be excluded from bloom filter operations.
-pub fn should_skip_for_bloom(bytes: &[u8]) -> bool {
-    BLOOM_SKIP_ADDRESSES.iter().any(|id| id.as_ref() == bytes)
+/// Single-byte prefix tags for bloom key dimensions that would otherwise collide.
+/// Not every `BloomValue` variant is tagged — untagged variants are unlikely to
+/// collide with other dimensions in practice (e.g. function names vs type params).
+#[repr(u8)]
+enum BloomTag {
+    MoveCallPackage = b'P',
+    MoveCallModule = b'M',
+    EvEmitModule = b'E',
+    EvAddress = b'A',
+    AffectedObject = b'O',
+    EvTypeModule = b'T',
+}
+
+impl BloomTag {
+    fn prefix(self, data: &[u8]) -> Vec<u8> {
+        [&[self as u8], data].concat()
+    }
+}
+
+/// Bloom filter values, each variant represents a distinct dimension
+/// that can be inserted into or probed against a checkpoint bloom filter.
+/// Some bloom filter values are prepended with tags to prevent collisions across
+/// dimensions, e.g. a Move call package address colliding with an event type module address.
+#[derive(Debug)]
+pub enum BloomValue {
+    /// Transaction sender or affected address (recipients, gas owner, etc.).
+    SenderOrRecipient(AccountAddress),
+    /// Object ID mutated, created, or deleted by a transaction.
+    AffectedObject(AccountAddress),
+    /// Move call package address.
+    MoveCallPackage(AccountAddress),
+    /// Move call module name.
+    MoveCallModule(String),
+    /// Event emitting or type package address.
+    EvAddress(AccountAddress),
+    /// Event emitting module name (the module whose function emitted the event).
+    EvEmitModule(String),
+    /// Event type module name (from the event's StructTag, not the emitting function).
+    EvTypeModule(String),
+    /// Function or type name (without package or module).
+    Name(String),
+    /// Event type parameter canonical string (e.g. "bool", "u64", "0x2::sui::SUI").
+    TypeParam(String),
+}
+
+impl BloomValue {
+    pub fn to_bytes(self) -> Vec<u8> {
+        match self {
+            Self::EvAddress(addr) => BloomTag::EvAddress.prefix(addr.as_ref()),
+            Self::SenderOrRecipient(addr) => addr.to_vec(),
+            Self::AffectedObject(addr) => BloomTag::AffectedObject.prefix(addr.as_ref()),
+            Self::MoveCallPackage(pkg) => BloomTag::MoveCallPackage.prefix(pkg.as_ref()),
+            Self::MoveCallModule(module) => BloomTag::MoveCallModule.prefix(module.as_bytes()),
+            Self::EvEmitModule(module) => BloomTag::EvEmitModule.prefix(module.as_bytes()),
+            Self::EvTypeModule(module) => BloomTag::EvTypeModule.prefix(module.as_bytes()),
+            Self::Name(name) => name.into_bytes(),
+            Self::TypeParam(s) => s.into_bytes(),
+        }
+    }
+
+    /// Returns true if this value should be excluded from bloom filter operations
+    /// because it matches a high-frequency address.
+    pub fn should_skip(&self) -> bool {
+        let addr = match self {
+            Self::EvAddress(addr)
+            | Self::SenderOrRecipient(addr)
+            | Self::AffectedObject(addr)
+            | Self::MoveCallPackage(addr) => addr,
+            Self::MoveCallModule(_)
+            | Self::EvEmitModule(_)
+            | Self::EvTypeModule(_)
+            | Self::Name(_)
+            | Self::TypeParam(_) => return false,
+        };
+        BLOOM_SKIP_ADDRESSES.contains(addr)
+    }
+
+    /// Extract bloom values from an event's StructTag for insertion into the
+    /// checkpoint bloom filter.
+    ///
+    /// The top-level struct gets three keys at increasing specificity:
+    ///   - `EvAddress(pkg)`        — matches queries filtering by package only
+    ///   - `EvTypeModule(mod)`       — matches queries filtering by module
+    ///   - `Name(name)`             — matches queries filtering by type name
+    ///
+    /// Each type parameter is inserted as its canonical string representation
+    /// (e.g. "bool", "u64", "0x2::sui::SUI"). This handles all TypeTag variants
+    /// including primitives and nested generics.
+    pub fn from_struct_tag(tag: &StructTag) -> Vec<BloomValue> {
+        let mut values = vec![
+            BloomValue::EvAddress(tag.address),
+            BloomValue::EvTypeModule(tag.module.to_string()),
+            BloomValue::Name(tag.name.to_string()),
+        ];
+        for tp in &tag.type_params {
+            values.push(BloomValue::TypeParam(tp.to_canonical_string(false)));
+        }
+        values
+    }
 }
 
 #[cfg(test)]
@@ -24,12 +119,48 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_should_skip_for_bloom() {
-        assert!(should_skip_for_bloom(AccountAddress::ZERO.as_ref()));
-        assert!(should_skip_for_bloom(SUI_CLOCK_ADDRESS.as_ref()));
+    fn test_should_skip() {
+        let zero = AccountAddress::ZERO;
+        let clock = SUI_CLOCK_ADDRESS;
+        let normal = AccountAddress::from_hex_literal("0x42").unwrap();
 
-        let mut bytes = [0u8; AccountAddress::LENGTH];
-        bytes[0] = 0x42;
-        assert!(!should_skip_for_bloom(&bytes));
+        assert!(BloomValue::EvAddress(zero).should_skip());
+        assert!(BloomValue::EvAddress(clock).should_skip());
+        assert!(!BloomValue::EvAddress(normal).should_skip());
+
+        assert!(BloomValue::SenderOrRecipient(zero).should_skip());
+        assert!(BloomValue::AffectedObject(zero).should_skip());
+        assert!(!BloomValue::SenderOrRecipient(normal).should_skip());
+        assert!(!BloomValue::AffectedObject(normal).should_skip());
+
+        assert!(BloomValue::MoveCallPackage(zero).should_skip());
+        assert!(!BloomValue::MoveCallModule("mod".into()).should_skip());
+        assert!(!BloomValue::EvEmitModule("mod".into()).should_skip());
+        assert!(!BloomValue::EvTypeModule("mod".into()).should_skip());
+        assert!(!BloomValue::Name("name".into()).should_skip());
+        assert!(!BloomValue::MoveCallPackage(normal).should_skip());
+        assert!(!BloomValue::TypeParam("bool".into()).should_skip());
+        assert!(!BloomValue::TypeParam("u64".into()).should_skip());
+    }
+
+    #[test]
+    fn test_all_tagged_variants_differ() {
+        let addr = AccountAddress::from_hex_literal("0x2").unwrap();
+        let variants = [
+            BloomValue::EvAddress(addr).to_bytes(),
+            BloomValue::SenderOrRecipient(addr).to_bytes(),
+            BloomValue::AffectedObject(addr).to_bytes(),
+            BloomValue::MoveCallPackage(addr).to_bytes(),
+            BloomValue::MoveCallModule("m".into()).to_bytes(),
+            BloomValue::EvEmitModule("m".into()).to_bytes(),
+            BloomValue::EvTypeModule("m".into()).to_bytes(),
+            BloomValue::Name("n".into()).to_bytes(),
+            BloomValue::TypeParam("bool".into()).to_bytes(),
+        ];
+        for i in 0..variants.len() {
+            for j in (i + 1)..variants.len() {
+                assert_ne!(variants[i], variants[j], "variants {i} and {j} collide");
+            }
+        }
     }
 }

--- a/crates/sui-indexer-alt-schema/src/blooms/mod.rs
+++ b/crates/sui-indexer-alt-schema/src/blooms/mod.rs
@@ -20,10 +20,10 @@ const BLOOM_SKIP_ADDRESSES: &[AccountAddress] = &[AccountAddress::ZERO, SUI_CLOC
 enum BloomTag {
     MoveCallPackage = b'P',
     MoveCallModule = b'M',
-    EvEmitModule = b'E',
-    EvAddress = b'A',
+    EventEmitModule = b'E',
+    EventAddress = b'A',
     AffectedObject = b'O',
-    EvTypeModule = b'T',
+    EventTypeModule = b'T',
 }
 
 impl BloomTag {
@@ -32,10 +32,12 @@ impl BloomTag {
     }
 }
 
-/// Bloom filter values, each variant represents a distinct dimension
-/// that can be inserted into or probed against a checkpoint bloom filter.
-/// Some bloom filter values are prepended with tags to prevent collisions across
-/// dimensions, e.g. a Move call package address colliding with an event type module address.
+/// Bloom filter values indexed as individual components (package, module, name) rather than
+/// compound keys (pkg::module::name). AND-probing N separate components requires N*k bloom
+/// bits to match, giving better selectivity than a single compound probe (k bits).
+///
+/// Tags prevent collisions across dimensions (e.g. a Move call package address vs an event
+/// type module address).
 #[derive(Debug)]
 pub enum BloomValue {
     /// Transaction sender or affected address (recipients, gas owner, etc.).
@@ -47,11 +49,11 @@ pub enum BloomValue {
     /// Move call module name.
     MoveCallModule(String),
     /// Event emitting or type package address.
-    EvAddress(AccountAddress),
+    EventAddress(AccountAddress),
     /// Event emitting module name (the module whose function emitted the event).
-    EvEmitModule(String),
+    EventEmitModule(String),
     /// Event type module name (from the event's StructTag, not the emitting function).
-    EvTypeModule(String),
+    EventTypeModule(String),
     /// Function or type name (without package or module).
     Name(String),
     /// Event type parameter canonical string (e.g. "bool", "u64", "0x2::sui::SUI").
@@ -61,13 +63,13 @@ pub enum BloomValue {
 impl BloomValue {
     pub fn to_bytes(self) -> Vec<u8> {
         match self {
-            Self::EvAddress(addr) => BloomTag::EvAddress.prefix(addr.as_ref()),
+            Self::EventAddress(addr) => BloomTag::EventAddress.prefix(addr.as_ref()),
             Self::SenderOrRecipient(addr) => addr.to_vec(),
             Self::AffectedObject(addr) => BloomTag::AffectedObject.prefix(addr.as_ref()),
             Self::MoveCallPackage(pkg) => BloomTag::MoveCallPackage.prefix(pkg.as_ref()),
             Self::MoveCallModule(module) => BloomTag::MoveCallModule.prefix(module.as_bytes()),
-            Self::EvEmitModule(module) => BloomTag::EvEmitModule.prefix(module.as_bytes()),
-            Self::EvTypeModule(module) => BloomTag::EvTypeModule.prefix(module.as_bytes()),
+            Self::EventEmitModule(module) => BloomTag::EventEmitModule.prefix(module.as_bytes()),
+            Self::EventTypeModule(module) => BloomTag::EventTypeModule.prefix(module.as_bytes()),
             Self::Name(name) => name.into_bytes(),
             Self::TypeParam(s) => s.into_bytes(),
         }
@@ -75,15 +77,15 @@ impl BloomValue {
 
     /// Returns true if this value should be excluded from bloom filter operations
     /// because it matches a high-frequency address.
-    pub fn should_skip(&self) -> bool {
+    pub fn exclude(&self) -> bool {
         let addr = match self {
-            Self::EvAddress(addr)
+            Self::EventAddress(addr)
             | Self::SenderOrRecipient(addr)
             | Self::AffectedObject(addr)
             | Self::MoveCallPackage(addr) => addr,
             Self::MoveCallModule(_)
-            | Self::EvEmitModule(_)
-            | Self::EvTypeModule(_)
+            | Self::EventEmitModule(_)
+            | Self::EventTypeModule(_)
             | Self::Name(_)
             | Self::TypeParam(_) => return false,
         };
@@ -94,17 +96,17 @@ impl BloomValue {
     /// checkpoint bloom filter.
     ///
     /// The top-level struct gets three keys at increasing specificity:
-    ///   - `EvAddress(pkg)`        — matches queries filtering by package only
-    ///   - `EvTypeModule(mod)`       — matches queries filtering by module
+    ///   - `EventAddress(pkg)`        — matches queries filtering by package only
+    ///   - `EventTypeModule(mod)`       — matches queries filtering by module
     ///   - `Name(name)`             — matches queries filtering by type name
     ///
     /// Each type parameter is inserted as its canonical string representation
     /// (e.g. "bool", "u64", "0x2::sui::SUI"). This handles all TypeTag variants
     /// including primitives and nested generics.
-    pub fn from_struct_tag(tag: &StructTag) -> Vec<BloomValue> {
+    pub fn from_event_struct_tag(tag: &StructTag) -> Vec<BloomValue> {
         let mut values = vec![
-            BloomValue::EvAddress(tag.address),
-            BloomValue::EvTypeModule(tag.module.to_string()),
+            BloomValue::EventAddress(tag.address),
+            BloomValue::EventTypeModule(tag.module.to_string()),
             BloomValue::Name(tag.name.to_string()),
         ];
         for tp in &tag.type_params {
@@ -119,41 +121,41 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_should_skip() {
+    fn test_should_exclude() {
         let zero = AccountAddress::ZERO;
         let clock = SUI_CLOCK_ADDRESS;
         let normal = AccountAddress::from_hex_literal("0x42").unwrap();
 
-        assert!(BloomValue::EvAddress(zero).should_skip());
-        assert!(BloomValue::EvAddress(clock).should_skip());
-        assert!(!BloomValue::EvAddress(normal).should_skip());
+        assert!(BloomValue::EventAddress(zero).exclude());
+        assert!(BloomValue::EventAddress(clock).exclude());
+        assert!(!BloomValue::EventAddress(normal).exclude());
 
-        assert!(BloomValue::SenderOrRecipient(zero).should_skip());
-        assert!(BloomValue::AffectedObject(zero).should_skip());
-        assert!(!BloomValue::SenderOrRecipient(normal).should_skip());
-        assert!(!BloomValue::AffectedObject(normal).should_skip());
+        assert!(BloomValue::SenderOrRecipient(zero).exclude());
+        assert!(BloomValue::AffectedObject(zero).exclude());
+        assert!(!BloomValue::SenderOrRecipient(normal).exclude());
+        assert!(!BloomValue::AffectedObject(normal).exclude());
 
-        assert!(BloomValue::MoveCallPackage(zero).should_skip());
-        assert!(!BloomValue::MoveCallModule("mod".into()).should_skip());
-        assert!(!BloomValue::EvEmitModule("mod".into()).should_skip());
-        assert!(!BloomValue::EvTypeModule("mod".into()).should_skip());
-        assert!(!BloomValue::Name("name".into()).should_skip());
-        assert!(!BloomValue::MoveCallPackage(normal).should_skip());
-        assert!(!BloomValue::TypeParam("bool".into()).should_skip());
-        assert!(!BloomValue::TypeParam("u64".into()).should_skip());
+        assert!(BloomValue::MoveCallPackage(zero).exclude());
+        assert!(!BloomValue::MoveCallModule("mod".into()).exclude());
+        assert!(!BloomValue::EventEmitModule("mod".into()).exclude());
+        assert!(!BloomValue::EventTypeModule("mod".into()).exclude());
+        assert!(!BloomValue::Name("name".into()).exclude());
+        assert!(!BloomValue::MoveCallPackage(normal).exclude());
+        assert!(!BloomValue::TypeParam("bool".into()).exclude());
+        assert!(!BloomValue::TypeParam("u64".into()).exclude());
     }
 
     #[test]
     fn test_all_tagged_variants_differ() {
         let addr = AccountAddress::from_hex_literal("0x2").unwrap();
         let variants = [
-            BloomValue::EvAddress(addr).to_bytes(),
+            BloomValue::EventAddress(addr).to_bytes(),
             BloomValue::SenderOrRecipient(addr).to_bytes(),
             BloomValue::AffectedObject(addr).to_bytes(),
             BloomValue::MoveCallPackage(addr).to_bytes(),
             BloomValue::MoveCallModule("m".into()).to_bytes(),
-            BloomValue::EvEmitModule("m".into()).to_bytes(),
-            BloomValue::EvTypeModule("m".into()).to_bytes(),
+            BloomValue::EventEmitModule("m".into()).to_bytes(),
+            BloomValue::EventTypeModule("m".into()).to_bytes(),
             BloomValue::Name("n".into()).to_bytes(),
             BloomValue::TypeParam("bool".into()).to_bytes(),
         ];

--- a/crates/sui-indexer-alt/Cargo.toml
+++ b/crates/sui-indexer-alt/Cargo.toml
@@ -29,6 +29,7 @@ diesel_migrations.workspace = true
 futures.workspace = true
 hex.workspace = true
 itertools.workspace = true
+move-core-types.workspace = true
 prometheus.workspace = true
 serde.workspace = true
 telemetry-subscribers.workspace = true

--- a/crates/sui-indexer-alt/src/handlers/cp_bloom_blocks.rs
+++ b/crates/sui-indexer-alt/src/handlers/cp_bloom_blocks.rs
@@ -22,7 +22,7 @@ use sui_indexer_alt_schema::cp_bloom_blocks::function_bytea_or;
 use sui_indexer_alt_schema::schema::cp_bloom_blocks;
 use sui_types::full_checkpoint_content::Checkpoint;
 
-use crate::handlers::cp_blooms::insert_tx_addresses;
+use crate::handlers::cp_blooms::insert_tx_bloom_values;
 
 /// Blocked bloom filters that span multiple checkpoints for efficient range queries.
 ///
@@ -62,7 +62,7 @@ impl Processor for CpBloomBlocks {
 
         let mut bloom = CpBlockedBloomFilter::new(seed);
         for tx in &checkpoint.transactions {
-            insert_tx_addresses(tx, &mut bloom);
+            insert_tx_bloom_values(tx, &mut bloom);
         }
 
         let blocks = bloom

--- a/crates/sui-indexer-alt/src/handlers/cp_blooms.rs
+++ b/crates/sui-indexer-alt/src/handlers/cp_blooms.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use anyhow::Result;
 use async_trait::async_trait;
 use diesel_async::RunQueryDsl;
+use move_core_types::account_address::AccountAddress;
 use sui_indexer_alt_framework::pipeline::Processor;
 use sui_indexer_alt_framework::postgres::Connection;
 use sui_indexer_alt_framework::postgres::handler::Handler;
@@ -13,7 +14,7 @@ use sui_indexer_alt_framework::types::effects::TransactionEffectsAPI;
 use sui_indexer_alt_framework::types::full_checkpoint_content::Checkpoint;
 use sui_indexer_alt_framework::types::full_checkpoint_content::ExecutedTransaction;
 use sui_indexer_alt_framework::types::transaction::TransactionDataAPI;
-use sui_indexer_alt_schema::blooms::should_skip_for_bloom;
+use sui_indexer_alt_schema::blooms::BloomValue;
 use sui_indexer_alt_schema::cp_blooms::CpBloomFilter;
 use sui_indexer_alt_schema::cp_blooms::MAX_FOLD_DENSITY;
 use sui_indexer_alt_schema::cp_blooms::MIN_FOLD_BYTES;
@@ -72,55 +73,41 @@ impl Handler for CpBlooms {
 
 /// Inserts values from a transaction into bloom filter.
 ///
-/// Values include:
-/// - Transaction sender
-/// - Recipient addresses of changed objects
-/// - Object IDs of all changed objects
-/// - Package IDs from Move calls
-/// - Addresses from emitted events (package, type address, type params)
-///
 /// Common addresses (e.g., 0x0, clock) are filtered out as they appear in most
 /// checkpoints and would defeat the bloom filter's purpose.
 pub(crate) fn insert_tx_addresses(tx: &ExecutedTransaction, bloom: &mut impl Extend<Vec<u8>>) {
-    let sender = std::iter::once(tx.transaction.sender().to_vec());
+    let mut values: Vec<BloomValue> = Vec::new();
 
-    let recipients = affected_addresses(&tx.effects).map(|a| a.to_vec());
+    let sender: AccountAddress = tx.transaction.sender().into();
+    values.push(BloomValue::SenderOrRecipient(sender));
 
-    let object_ids = tx
-        .effects
-        .object_changes()
-        .into_iter()
-        .map(|change| change.id.to_vec());
+    for addr in affected_addresses(&tx.effects) {
+        values.push(BloomValue::SenderOrRecipient(addr.into()));
+    }
 
-    let package_ids = tx
-        .transaction
-        .move_calls()
-        .into_iter()
-        .map(|(_, package_id, _, _)| package_id.to_vec());
+    for change in tx.effects.object_changes() {
+        values.push(BloomValue::AffectedObject(change.id.into()));
+    }
 
-    let event_addresses = tx
-        .events
-        .iter()
-        .flat_map(|evs| evs.data.iter())
-        .flat_map(|ev| {
-            std::iter::once(ev.type_.address.to_vec())
-                .chain(std::iter::once(ev.package_id.to_vec()))
-                .chain(
-                    ev.type_
-                        .type_params
-                        .iter()
-                        .flat_map(|tp| tp.all_addresses())
-                        .map(|addr| addr.to_vec()),
-                )
-        });
+    for (_, package_id, module, function) in tx.transaction.move_calls() {
+        let pkg: AccountAddress = (*package_id).into();
+        values.push(BloomValue::MoveCallPackage(pkg));
+        values.push(BloomValue::MoveCallModule(module.to_owned()));
+        values.push(BloomValue::Name(function.to_owned()));
+    }
+
+    for ev in tx.events.iter().flat_map(|evs| evs.data.iter()) {
+        let emit_pkg: AccountAddress = ev.package_id.into();
+        values.push(BloomValue::EvAddress(emit_pkg));
+        values.push(BloomValue::EvEmitModule(ev.transaction_module.to_string()));
+        values.extend(BloomValue::from_struct_tag(&ev.type_));
+    }
 
     bloom.extend(
-        sender
-            .chain(recipients)
-            .chain(object_ids)
-            .chain(package_ids)
-            .chain(event_addresses)
-            .filter(|bytes| !should_skip_for_bloom(bytes)),
+        values
+            .into_iter()
+            .filter(|v| !v.should_skip())
+            .map(|v| v.to_bytes()),
     );
 }
 
@@ -170,56 +157,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_cp_blooms_with_function_calls() {
-        let (indexer, _db) = Indexer::new_for_testing(&MIGRATIONS).await;
-        let mut conn = indexer.store().connect().await.unwrap();
-
-        let mut builder = TestCheckpointBuilder::new(0);
-        builder = builder
-            .start_transaction(1) // Use sender_idx=1 to avoid SuiAddress::ZERO which is filtered out
-            .add_move_call(ObjectID::ZERO, "module", "function")
-            .finish_transaction();
-        let checkpoint = Arc::new(builder.build_checkpoint());
-
-        let values = CpBlooms.process(&checkpoint).await.unwrap();
-
-        assert_eq!(values.len(), 1, "Should produce one bloom filter");
-        assert_eq!(values[0].cp_sequence_number, 0);
-        assert!(!values[0].bloom_filter.is_empty());
-
-        CpBlooms::commit(&values, &mut conn).await.unwrap();
-
-        let stored = get_all_bloom_filters(&mut conn).await;
-        assert_eq!(stored.len(), 1);
-        assert_eq!(stored[0].cp_sequence_number, 0);
-    }
-
-    #[tokio::test]
-    async fn test_cp_blooms_multiple_checkpoints() {
-        let (indexer, _db) = Indexer::new_for_testing(&MIGRATIONS).await;
-        let mut conn = indexer.store().connect().await.unwrap();
-
-        for cp_num in 0..3 {
-            let mut builder = TestCheckpointBuilder::new(cp_num);
-            builder = builder
-                .start_transaction(1) // Use sender_idx=1 to avoid SuiAddress::ZERO which is filtered out
-                .add_move_call(ObjectID::ZERO, "module", "function")
-                .finish_transaction();
-            let checkpoint = Arc::new(builder.build_checkpoint());
-
-            let values = CpBlooms.process(&checkpoint).await.unwrap();
-            CpBlooms::commit(&values, &mut conn).await.unwrap();
-        }
-
-        let stored = get_all_bloom_filters(&mut conn).await;
-        assert_eq!(stored.len(), 3);
-
-        for (i, bloom) in stored.iter().enumerate() {
-            assert_eq!(bloom.cp_sequence_number, i as i64);
-        }
-    }
-
-    #[tokio::test]
     async fn test_cp_blooms_filter_accuracy() {
         let package_id = ObjectID::from_single_byte(0x42);
         let mut builder = TestCheckpointBuilder::new(0);
@@ -238,8 +175,11 @@ mod tests {
         let bloom_bytes = &values[0].bloom_filter;
 
         assert!(
-            folded_bloom_contains(bloom_bytes, &package_id.to_vec()),
-            "Should contain package ID from move call"
+            folded_bloom_contains(
+                bloom_bytes,
+                &BloomValue::MoveCallPackage(package_id.into()).to_bytes()
+            ),
+            "Should contain move call package key"
         );
 
         // Common addresses should be filtered out
@@ -248,30 +188,42 @@ mod tests {
             "Should NOT contain common address ObjectID::ZERO"
         );
 
-        let sender_0 = checkpoint.transactions[0].transaction.sender();
-        let sender_1 = checkpoint.transactions[1].transaction.sender();
+        let sender_0: AccountAddress = checkpoint.transactions[0].transaction.sender().into();
+        let sender_1: AccountAddress = checkpoint.transactions[1].transaction.sender().into();
         assert!(
-            folded_bloom_contains(bloom_bytes, &sender_0.to_vec()),
+            folded_bloom_contains(
+                bloom_bytes,
+                &BloomValue::SenderOrRecipient(sender_0).to_bytes()
+            ),
             "Should contain sender address from tx 0"
         );
         assert!(
-            folded_bloom_contains(bloom_bytes, &sender_1.to_vec()),
+            folded_bloom_contains(
+                bloom_bytes,
+                &BloomValue::SenderOrRecipient(sender_1).to_bytes()
+            ),
             "Should contain sender address from tx 1"
         );
 
         for tx in &checkpoint.transactions {
             for ((obj_id, _, _), _, _) in tx.effects.all_changed_objects() {
                 assert!(
-                    folded_bloom_contains(bloom_bytes, &obj_id.to_vec()),
+                    folded_bloom_contains(
+                        bloom_bytes,
+                        &BloomValue::AffectedObject(*obj_id).to_bytes()
+                    ),
                     "Should contain object ID {}",
                     obj_id
                 );
             }
         }
 
-        let random_addr = SuiAddress::random_for_testing_only();
+        let random_addr: AccountAddress = SuiAddress::random_for_testing_only().into();
         assert!(
-            !folded_bloom_contains(bloom_bytes, &random_addr.to_vec()),
+            !folded_bloom_contains(
+                bloom_bytes,
+                &BloomValue::SenderOrRecipient(random_addr).to_bytes()
+            ),
             "Should not contain random address"
         );
     }
@@ -293,43 +245,21 @@ mod tests {
             .finish_transaction();
         let checkpoint1 = Arc::new(builder1.build_checkpoint());
         let values1 = CpBlooms.process(&checkpoint1).await.unwrap();
-        let sender1 = checkpoint1.transactions[0].transaction.sender();
 
         CpBlooms::commit(&values1, &mut conn).await.unwrap();
 
-        // Verify first key is present
         let stored1 = get_all_bloom_filters(&mut conn).await;
         assert_eq!(stored1.len(), 1);
-        assert!(
-            folded_bloom_contains(&stored1[0].bloom_filter, &package1.to_vec()),
-            "First commit should contain package1"
-        );
-        assert!(
-            folded_bloom_contains(&stored1[0].bloom_filter, &sender1.to_vec()),
-            "First commit should contain sender1"
-        );
 
-        // Second commit: same checkpoint 0 (simulating reprocessing)
-        // Since it's the same checkpoint, the bloom filter would be identical
-        // and do_nothing keeps the original row
+        // Second commit: same checkpoint 0 (simulating reprocessing).
+        // do_nothing keeps the original row unchanged.
         CpBlooms::commit(&values1, &mut conn).await.unwrap();
 
-        // Verify data is unchanged (do_nothing preserves original)
         let stored2 = get_all_bloom_filters(&mut conn).await;
+        assert_eq!(stored2.len(), 1);
         assert_eq!(
-            stored2.len(),
-            1,
-            "Should still have only one row for checkpoint 0"
-        );
-
-        // Keys from first commit should still be present
-        assert!(
-            folded_bloom_contains(&stored2[0].bloom_filter, &package1.to_vec()),
-            "package1 should still be present after do_nothing"
-        );
-        assert!(
-            folded_bloom_contains(&stored2[0].bloom_filter, &sender1.to_vec()),
-            "sender1 should still be present after do_nothing"
+            stored1[0].bloom_filter, stored2[0].bloom_filter,
+            "Bloom filter should be unchanged after do_nothing"
         );
     }
 }

--- a/crates/sui-indexer-alt/src/handlers/cp_blooms.rs
+++ b/crates/sui-indexer-alt/src/handlers/cp_blooms.rs
@@ -98,15 +98,17 @@ pub(crate) fn insert_tx_addresses(tx: &ExecutedTransaction, bloom: &mut impl Ext
 
     for ev in tx.events.iter().flat_map(|evs| evs.data.iter()) {
         let emit_pkg: AccountAddress = ev.package_id.into();
-        values.push(BloomValue::EvAddress(emit_pkg));
-        values.push(BloomValue::EvEmitModule(ev.transaction_module.to_string()));
-        values.extend(BloomValue::from_struct_tag(&ev.type_));
+        values.push(BloomValue::EventAddress(emit_pkg));
+        values.push(BloomValue::EventEmitModule(
+            ev.transaction_module.to_string(),
+        ));
+        values.extend(BloomValue::from_event_struct_tag(&ev.type_));
     }
 
     bloom.extend(
         values
             .into_iter()
-            .filter(|v| !v.should_skip())
+            .filter(|v| !v.exclude())
             .map(|v| v.to_bytes()),
     );
 }

--- a/crates/sui-indexer-alt/src/handlers/cp_blooms.rs
+++ b/crates/sui-indexer-alt/src/handlers/cp_blooms.rs
@@ -10,6 +10,8 @@ use move_core_types::account_address::AccountAddress;
 use sui_indexer_alt_framework::pipeline::Processor;
 use sui_indexer_alt_framework::postgres::Connection;
 use sui_indexer_alt_framework::postgres::handler::Handler;
+use sui_indexer_alt_framework::types::balance::Balance;
+use sui_indexer_alt_framework::types::effects::AccumulatorValue;
 use sui_indexer_alt_framework::types::effects::TransactionEffectsAPI;
 use sui_indexer_alt_framework::types::full_checkpoint_content::Checkpoint;
 use sui_indexer_alt_framework::types::full_checkpoint_content::ExecutedTransaction;
@@ -37,7 +39,7 @@ impl Processor for CpBlooms {
 
         let mut bloom = CpBloomFilter::new();
         for tx in &checkpoint.transactions {
-            insert_tx_addresses(tx, &mut bloom);
+            insert_tx_bloom_values(tx, &mut bloom);
         }
 
         if bloom.popcount() == 0 {
@@ -71,11 +73,10 @@ impl Handler for CpBlooms {
     }
 }
 
-/// Inserts values from a transaction into bloom filter.
-///
-/// Common addresses (e.g., 0x0, clock) are filtered out as they appear in most
-/// checkpoints and would defeat the bloom filter's purpose.
-pub(crate) fn insert_tx_addresses(tx: &ExecutedTransaction, bloom: &mut impl Extend<Vec<u8>>) {
+/// Inserts bloom filter values from a transaction: sender, recipients, balance change
+/// addresses, affected object IDs, Move call packages/modules/functions, and event
+/// type components. High-frequency addresses (e.g., 0x0, clock) are excluded.
+pub(crate) fn insert_tx_bloom_values(tx: &ExecutedTransaction, bloom: &mut impl Extend<Vec<u8>>) {
     let mut values: Vec<BloomValue> = Vec::new();
 
     let sender: AccountAddress = tx.transaction.sender().into();
@@ -83,6 +84,19 @@ pub(crate) fn insert_tx_addresses(tx: &ExecutedTransaction, bloom: &mut impl Ext
 
     for addr in affected_addresses(&tx.effects) {
         values.push(BloomValue::SenderOrRecipient(addr.into()));
+    }
+
+    // Balance change recipients from accumulator events (e.g. coin transfers where the
+    // recipient address only appears in the accumulator, not in object ownership changes).
+    for event in tx.effects.accumulator_events() {
+        let ty = &event.write.address.ty;
+        if Balance::is_balance_type(ty)
+            && matches!(&event.write.value, AccumulatorValue::Integer(_))
+        {
+            values.push(BloomValue::SenderOrRecipient(
+                event.write.address.address.into(),
+            ));
+        }
     }
 
     for change in tx.effects.object_changes() {


### PR DESCRIPTION
## Description 

## Problem
Bloom filters were built by tracking addresses only, not the full filter criteria (module, function, event type, etc.). A bloom filter match told you "this checkpoint contains a transaction or event from package X," but the actual query might filter on a specific module or function within that package. Combined with a one-shot candidate fetch, this caused pagination to terminate early for queries targeting rare events or functions on high-activity packages.

## Solution

### Iterative bloom scanning with adaptive limits

Replace the one-shot bloom candidate fetch with `BloomScan`, an iterative scanner that keeps fetching batches until the page is filled or the checkpoint range is exhausted. The old approach used a fixed 3x overfetch multiplier and returned after a single batch — when the real hit rate was low this caused premature pagination termination.

The scanner uses adaptive batch sizing:
- **Cold start**: assumes ~10% bloom FPR and doubles the request size each round to handle unknown sparsity
- **Warm**: switches to the minimum observed per-batch hit rate as a pessimistic estimate, clamped to `[remaining, 500]` candidates per round

### More selective bloom values

Add values so queries can reject checkpoints at the module and function level, not just the package level. Single-byte prefix tags prevent collisions across dimensions that would otherwise share the same space.

**Bloom values inserted per checkpoint:**

| Dimension | Values | Tag |
|---|---|---|
| Sender / affected address | raw address bytes | (none) |
| Affected object | address bytes | `O` |
| Move call package | address bytes | `P` |
| Move call module | `{module}` | `M` |
| Event type package | address bytes | `A` |
| Event emitting module | `{module}` | `E` |
| Event type module | `{module}` | `T` |
| Function / type name | `{name}` | (none) |
| Event type parameter | canonical string (e.g. `0x2::sui::SUI`) | (none) |

Previously a query like `function: "0x2::coin::TYPO"` would only probe the bloom for the `0x2` address, matching nearly every checkpoint. With compound keys, the bloom also probes for the module and function name, rejecting checkpoints that don't have matching move calls.

### Bloom filter saturation impact

CP range 10M–13M (~3M checkpoints). Most bloom filters still fold down to 1KB.

**1 KB filters (8192 total bits, 99.9%+ of all filters):**

| Percentile | Old (bits) | New (bits) | Δ bits |
|---|---|---|---|
| p25 | 689 | 779 | +90 |
| p50 | 924 | 1064 | +140 |
| p75 | 1227 | 1403 | +176 |
| p90 | 1644 | 1834 | +190 |
| p95 | 2400 | 2470 | +70 |
| p99 | 3521 | 3631 | +110 |
| max | 5288 | 5274 | -14 |
| avg | 1065 | 1182 | +117 |

Average density: 13.0% → 14.4% (+1.4%). Well below the 40% fold threshold. 2KB+ filters (<0.1%) unchanged.



## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
