### PR TITLE
Verify exact balance change amounts in JSON-RPC test

### DIFF
--- a/crates/sui-e2e-tests/tests/address_balance_tests.rs
+++ b/crates/sui-e2e-tests/tests/address_balance_tests.rs
@@ -3864,7 +3864,7 @@ async fn test_json_rpc_balance_changes_with_address_balance_withdrawal() {
     );
 
     // Verify sender's address balance was correctly decremented
-    let expected_remaining_balance = deposit_amount - withdraw_amount - (net_gas_cost as u64);
+    let expected_remaining_balance = deposit_amount - withdraw_amount - net_gas_cost;
     test_env.verify_accumulator_exists(sender, expected_remaining_balance);
 }
 


### PR DESCRIPTION
## Summary
- Enhance the `test_json_rpc_balance_changes_with_address_balance_withdrawal` test to verify exact balance change amounts
- Get gas cost from effects and assert sender spends exactly `withdraw_amount + net_gas_cost`
- Assert total balance change equals exactly `-net_gas_cost`

## Context
Follow-up to #25685 which fixed the bug where `execute_transaction_block` returned `None` for `balanceChanges` on address-balance-backed transactions. This PR strengthens the test by verifying exact amounts rather than just checking non-empty.

## Test plan
- [x] `cargo simtest -p sui-e2e-tests --test address_balance_tests -- test_json_rpc_balance_changes_with_address_balance_withdrawal`

🤖 Generated with [Claude Code](https://claude.com/claude-code)