### PR TITLE
Move TxContext into the execution layer 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13887,6 +13887,7 @@ dependencies = [
  "parking_lot 0.12.3",
  "serde",
  "serde_json",
+ "sui-execution-types",
  "sui-macros",
  "sui-move-natives-latest",
  "sui-protocol-config",
@@ -13922,6 +13923,7 @@ dependencies = [
  "once_cell",
  "parking_lot 0.12.3",
  "serde",
+ "sui-execution-types",
  "sui-macros",
  "sui-move-natives-v0",
  "sui-protocol-config",
@@ -13948,6 +13950,7 @@ dependencies = [
  "move-vm-types-v1",
  "parking_lot 0.12.3",
  "serde",
+ "sui-execution-types",
  "sui-macros",
  "sui-move-natives-v1",
  "sui-protocol-config",
@@ -13974,6 +13977,7 @@ dependencies = [
  "move-vm-types-v2",
  "parking_lot 0.12.3",
  "serde",
+ "sui-execution-types",
  "sui-macros",
  "sui-move-natives-v2",
  "sui-protocol-config",
@@ -14459,6 +14463,7 @@ dependencies = [
  "sui-authority-aggregation",
  "sui-config",
  "sui-execution",
+ "sui-execution-types",
  "sui-framework",
  "sui-genesis-builder",
  "sui-json-rpc-types",
@@ -14720,6 +14725,7 @@ dependencies = [
  "sui-adapter-v0",
  "sui-adapter-v1",
  "sui-adapter-v2",
+ "sui-execution-types",
  "sui-move-natives-latest",
  "sui-move-natives-v0",
  "sui-move-natives-v1",
@@ -14743,6 +14749,17 @@ dependencies = [
  "thiserror 1.0.69",
  "toml 0.7.4",
  "toml_edit 0.19.10",
+]
+
+[[package]]
+name = "sui-execution-types"
+version = "0.1.0"
+dependencies = [
+ "bcs",
+ "move-core-types",
+ "serde",
+ "sui-protocol-config",
+ "sui-types",
 ]
 
 [[package]]
@@ -15754,6 +15771,7 @@ dependencies = [
  "serde_yaml 0.8.26",
  "sui-adapter-latest",
  "sui-config",
+ "sui-execution-types",
  "sui-macros",
  "sui-move-build",
  "sui-move-natives-latest",
@@ -15831,6 +15849,7 @@ dependencies = [
  "move-vm-types",
  "rand 0.8.5",
  "smallvec",
+ "sui-execution-types",
  "sui-protocol-config",
  "sui-types",
  "tracing",
@@ -15851,6 +15870,7 @@ dependencies = [
  "move-vm-runtime-v0",
  "move-vm-types-v0",
  "smallvec",
+ "sui-execution-types",
  "sui-protocol-config",
  "sui-types",
  "tracing",
@@ -15871,6 +15891,7 @@ dependencies = [
  "move-vm-runtime-v1",
  "move-vm-types-v1",
  "smallvec",
+ "sui-execution-types",
  "sui-protocol-config",
  "sui-types",
  "tracing",
@@ -15891,6 +15912,7 @@ dependencies = [
  "move-vm-runtime-v2",
  "move-vm-types-v2",
  "smallvec",
+ "sui-execution-types",
  "sui-protocol-config",
  "sui-types",
  "tracing",
@@ -17238,6 +17260,7 @@ dependencies = [
  "move-bytecode-verifier-meter",
  "move-core-types",
  "move-vm-config",
+ "sui-execution-types",
  "sui-protocol-config",
  "sui-types",
 ]
@@ -17261,6 +17284,7 @@ dependencies = [
  "move-bytecode-verifier-v0",
  "move-core-types",
  "move-vm-config",
+ "sui-execution-types",
  "sui-protocol-config",
  "sui-types",
 ]
@@ -17276,6 +17300,7 @@ dependencies = [
  "move-bytecode-verifier-v1",
  "move-core-types",
  "move-vm-config",
+ "sui-execution-types",
  "sui-types",
 ]
 
@@ -17290,6 +17315,7 @@ dependencies = [
  "move-bytecode-verifier-v2",
  "move-core-types",
  "move-vm-config",
+ "sui-execution-types",
  "sui-protocol-config",
  "sui-types",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -208,6 +208,7 @@ members = [
   "crates/x",
   "sui-execution",
   "sui-execution/cut",
+  "sui-execution/sui-execution-types",
   "sui-execution/latest/sui-adapter",
   "sui-execution/latest/sui-move-natives",
   "sui-execution/latest/sui-verifier",
@@ -783,6 +784,7 @@ consensus-types = { path = "consensus/types" }
 consensus-simtests = { path = "consensus/simtests" }
 
 sui-execution = { path = "sui-execution" }
+sui-execution-types = { path = "sui-execution/sui-execution-types" }
 # sui-move-natives = { path = "sui-execution/latest/sui-move-natives", package = "sui-move-natives-latest" }
 # sui-adapter = { path = "sui-execution/latest/sui-adapter", package = "sui-adapter-latest" }
 # sui-verifier = { path = "sui-execution/latest/sui-verifier", package = "sui-verifier-latest" }

--- a/crates/sui-core/Cargo.toml
+++ b/crates/sui-core/Cargo.toml
@@ -83,6 +83,7 @@ sui-config.workspace = true
 sui-rpc.workspace = true
 sui-authority-aggregation.workspace = true
 sui-execution.workspace = true
+sui-execution-types.workspace = true
 sui-framework.workspace = true
 sui-swarm-config.workspace = true
 sui-genesis-builder.workspace = true

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -79,6 +79,8 @@ use crate::{
     consensus_test_utils::CapturedTransactions,
 };
 
+use sui_execution_types::TxContext;
+
 use super::*;
 
 pub use crate::authority::authority_test_utils::*;

--- a/crates/sui-json/src/lib.rs
+++ b/crates/sui-json/src/lib.rs
@@ -27,8 +27,8 @@ use sui_types::MOVE_STDLIB_ADDRESS;
 use sui_types::base_types::{
     ObjectID, RESOLVED_ASCII_STR, RESOLVED_STD_OPTION, RESOLVED_UTF8_STR, STD_ASCII_MODULE_NAME,
     STD_ASCII_STRUCT_NAME, STD_OPTION_MODULE_NAME, STD_OPTION_STRUCT_NAME, STD_UTF8_MODULE_NAME,
-    STD_UTF8_STRUCT_NAME, SuiAddress, TxContext, TxContextKind, is_primitive_type_tag,
-    move_ascii_str_layout, move_utf8_str_layout,
+    STD_UTF8_STRUCT_NAME, SuiAddress, TxContextKind, is_primitive_type_tag, move_ascii_str_layout,
+    move_utf8_str_layout,
 };
 use sui_types::id::{self, ID, RESOLVED_SUI_ID};
 use sui_types::move_package::MovePackage;
@@ -831,7 +831,7 @@ pub fn resolve_move_function_args(
 
     // Lengths have to match, less one, due to TxContext
     let expected_len = match parameters.last() {
-        Some(param) if TxContext::kind(&module, param) != TxContextKind::None => {
+        Some(param) if TxContextKind::derive(&module, param) != TxContextKind::None => {
             parameters.len() - 1
         }
         _ => parameters.len(),

--- a/crates/sui-move/Cargo.toml
+++ b/crates/sui-move/Cargo.toml
@@ -44,6 +44,7 @@ sui-config.workspace = true
 sui-move-build.workspace = true
 sui-protocol-config.workspace = true
 sui-sdk.workspace = true
+sui-execution-types.workspace = true
 sui-types.workspace = true
 sui-package-alt.workspace = true
 better_any = "0.1.1"

--- a/crates/sui-move/src/unit_test.rs
+++ b/crates/sui-move/src/unit_test.rs
@@ -19,6 +19,7 @@ use std::{
     sync::{Arc, LazyLock},
 };
 use sui_adapter::gas_meter::SuiGasMeter;
+use sui_execution_types::TxContext;
 use sui_move_build::decorate_warnings;
 use sui_move_natives::{
     NativesCostTable, object_runtime::ObjectRuntime, test_scenario::InMemoryTestStore,
@@ -28,7 +29,7 @@ use sui_package_alt::find_environment;
 use sui_protocol_config::ProtocolConfig;
 use sui_sdk::wallet_context::WalletContext;
 use sui_types::{
-    base_types::{SuiAddress, TxContext},
+    base_types::SuiAddress,
     digests::TransactionDigest,
     gas::{SuiGasStatus, SuiGasStatusAPI},
     gas_model::{tables::GasStatus, units_types::Gas},

--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -26,18 +26,15 @@ use crate::dynamic_field::DynamicFieldType;
 use crate::dynamic_field::{DYNAMIC_FIELD_FIELD_STRUCT_NAME, DYNAMIC_FIELD_MODULE_NAME};
 use crate::effects::TransactionEffects;
 use crate::effects::TransactionEffectsAPI;
-use crate::epoch_data::EpochData;
-use crate::error::ExecutionErrorKind;
 use crate::error::SuiError;
 use crate::error::SuiErrorKind;
-use crate::error::{ExecutionError, SuiResult};
+use crate::error::SuiResult;
 use crate::gas_coin::GAS;
 use crate::gas_coin::GasCoin;
 use crate::governance::STAKED_SUI_STRUCT_NAME;
 use crate::governance::STAKING_POOL_MODULE_NAME;
 use crate::governance::StakedSui;
 use crate::id::RESOLVED_SUI_ID;
-use crate::messages_checkpoint::CheckpointTimestamp;
 use crate::multisig::MultiSigPublicKey;
 use crate::object::{Object, Owner};
 use crate::parse_sui_struct_tag;
@@ -77,10 +74,9 @@ use serde_with::serde_as;
 use shared_crypto::intent::HashingIntentScope;
 use std::borrow::Cow;
 use std::cmp::max;
-use std::convert::{TryFrom, TryInto};
+use std::convert::TryFrom;
 use std::fmt;
 use std::str::FromStr;
-use sui_protocol_config::ProtocolConfig;
 
 #[cfg(test)]
 #[path = "unit_tests/base_types_tests.rs"]
@@ -1176,68 +1172,8 @@ pub fn url_layout() -> A::MoveStructLayout {
     }
 }
 
-// The Rust representation of the Move `TxContext`.
-// This struct must be kept in sync with the Move `TxContext` definition.
-// Moving forward we are going to zero all fields of the Move `TxContext`
-// and use native functions to retrieve info about the transaction.
-// However we cannot remove the Move type and so this struct is going to
-// be the Rust equivalent to the Move `TxContext` for legacy usages.
-//
-// `TxContext` in Rust (see below) is going to be purely used in Rust and can
-// evolve as needed without worrying any compatibility with Move.
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
-pub struct MoveLegacyTxContext {
-    // Signer/sender of the transaction
-    sender: AccountAddress,
-    // Digest of the current transaction
-    digest: Vec<u8>,
-    // The current epoch number
-    epoch: EpochId,
-    // Timestamp that the epoch started at
-    epoch_timestamp_ms: CheckpointTimestamp,
-    // Number of `ObjectID`'s generated during execution of the current transaction
-    ids_created: u64,
-}
-
-impl From<&TxContext> for MoveLegacyTxContext {
-    fn from(tx_context: &TxContext) -> Self {
-        Self {
-            sender: tx_context.sender,
-            digest: tx_context.digest.clone(),
-            epoch: tx_context.epoch,
-            epoch_timestamp_ms: tx_context.epoch_timestamp_ms,
-            ids_created: tx_context.ids_created,
-        }
-    }
-}
-
-// Information about the transaction context.
-// This struct is not related to Move and can evolve as needed/required.
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
-pub struct TxContext {
-    /// Sender of the transaction
-    sender: AccountAddress,
-    /// Digest of the current transaction
-    digest: Vec<u8>,
-    /// The current epoch number
-    epoch: EpochId,
-    /// Timestamp that the epoch started at
-    epoch_timestamp_ms: CheckpointTimestamp,
-    /// Number of `ObjectID`'s generated during execution of the current transaction
-    ids_created: u64,
-    // Reference gas price
-    rgp: u64,
-    // gas price passed to transaction as input
-    gas_price: u64,
-    // gas budget passed to transaction as input
-    gas_budget: u64,
-    // address of the sponsor if any
-    sponsor: Option<AccountAddress>,
-    // whether the `TxContext` is native or not
-    // (TODO: once we version execution we could drop this field)
-    is_native: bool,
-}
-
+// Whether a given argument (a `SignatureToken`) is a Move `TxContext` or
+// a reference (mutable or immutable) to it.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum TxContextKind {
     // No TxContext
@@ -1248,57 +1184,9 @@ pub enum TxContextKind {
     Immutable,
 }
 
-impl TxContext {
-    pub fn new(
-        sender: &SuiAddress,
-        digest: &TransactionDigest,
-        epoch_data: &EpochData,
-        rgp: u64,
-        gas_price: u64,
-        gas_budget: u64,
-        sponsor: Option<SuiAddress>,
-        protocol_config: &ProtocolConfig,
-    ) -> Self {
-        Self::new_from_components(
-            sender,
-            digest,
-            &epoch_data.epoch_id(),
-            epoch_data.epoch_start_timestamp(),
-            rgp,
-            gas_price,
-            gas_budget,
-            sponsor,
-            protocol_config,
-        )
-    }
-
-    pub fn new_from_components(
-        sender: &SuiAddress,
-        digest: &TransactionDigest,
-        epoch_id: &EpochId,
-        epoch_timestamp_ms: u64,
-        rgp: u64,
-        gas_price: u64,
-        gas_budget: u64,
-        sponsor: Option<SuiAddress>,
-        protocol_config: &ProtocolConfig,
-    ) -> Self {
-        Self {
-            sender: AccountAddress::new(sender.0),
-            digest: digest.into_inner().to_vec(),
-            epoch: *epoch_id,
-            epoch_timestamp_ms,
-            ids_created: 0,
-            rgp,
-            gas_price,
-            gas_budget,
-            sponsor: sponsor.map(|s| s.into()),
-            is_native: protocol_config.move_native_context(),
-        }
-    }
-
+impl TxContextKind {
     /// Returns whether the type signature is &mut TxContext, &TxContext, or none of the above.
-    pub fn kind(view: &CompiledModule, s: &SignatureToken) -> TxContextKind {
+    pub fn derive(view: &CompiledModule, s: &SignatureToken) -> Self {
         use SignatureToken as S;
         let (kind, s) = match s {
             S::MutableReference(s) => (TxContextKind::Mutable, s),
@@ -1315,131 +1203,6 @@ impl TxContext {
         } else {
             TxContextKind::None
         }
-    }
-
-    pub fn type_() -> StructTag {
-        StructTag {
-            address: SUI_FRAMEWORK_ADDRESS,
-            module: TX_CONTEXT_MODULE_NAME.to_owned(),
-            name: TX_CONTEXT_STRUCT_NAME.to_owned(),
-            type_params: vec![],
-        }
-    }
-
-    pub fn epoch(&self) -> EpochId {
-        self.epoch
-    }
-
-    pub fn sender(&self) -> SuiAddress {
-        self.sender.into()
-    }
-
-    pub fn epoch_timestamp_ms(&self) -> u64 {
-        self.epoch_timestamp_ms
-    }
-
-    /// Return the transaction digest, to include in new objects
-    pub fn digest(&self) -> TransactionDigest {
-        TransactionDigest::new(self.digest.clone().try_into().unwrap())
-    }
-
-    pub fn sponsor(&self) -> Option<SuiAddress> {
-        self.sponsor.map(SuiAddress::from)
-    }
-
-    pub fn rgp(&self) -> u64 {
-        self.rgp
-    }
-
-    pub fn gas_price(&self) -> u64 {
-        self.gas_price
-    }
-
-    pub fn gas_budget(&self) -> u64 {
-        self.gas_budget
-    }
-
-    pub fn ids_created(&self) -> u64 {
-        self.ids_created
-    }
-
-    /// Derive a globally unique object ID by hashing self.digest | self.ids_created
-    pub fn fresh_id(&mut self) -> ObjectID {
-        let id = ObjectID::derive_id(self.digest(), self.ids_created);
-
-        self.ids_created += 1;
-        id
-    }
-
-    pub fn to_bcs_legacy_context(&self) -> Vec<u8> {
-        let move_context: MoveLegacyTxContext = if self.is_native {
-            let tx_context = &TxContext {
-                sender: AccountAddress::ZERO,
-                digest: self.digest.clone(),
-                epoch: 0,
-                epoch_timestamp_ms: 0,
-                ids_created: 0,
-                rgp: 0,
-                gas_price: 0,
-                gas_budget: 0,
-                sponsor: None,
-                is_native: true,
-            };
-            tx_context.into()
-        } else {
-            self.into()
-        };
-        bcs::to_bytes(&move_context).unwrap()
-    }
-
-    pub fn to_vec(&self) -> Vec<u8> {
-        bcs::to_bytes(&self).unwrap()
-    }
-
-    /// Updates state of the context instance. It's intended to use
-    /// when mutable context is passed over some boundary via
-    /// serialize/deserialize and this is the reason why this method
-    /// consumes the other context..
-    pub fn update_state(&mut self, other: MoveLegacyTxContext) -> Result<(), ExecutionError> {
-        if !self.is_native {
-            if self.sender != other.sender
-                || self.digest != other.digest
-                || other.ids_created < self.ids_created
-            {
-                return Err(ExecutionError::new_with_source(
-                    ExecutionErrorKind::InvariantViolation,
-                    "Immutable fields for TxContext changed",
-                ));
-            }
-            self.ids_created = other.ids_created;
-        }
-        Ok(())
-    }
-
-    //
-    // Move test only API
-    //
-    pub fn replace(
-        &mut self,
-        sender: AccountAddress,
-        tx_hash: Vec<u8>,
-        epoch: u64,
-        epoch_timestamp_ms: u64,
-        ids_created: u64,
-        rgp: u64,
-        gas_price: u64,
-        gas_budget: u64,
-        sponsor: Option<AccountAddress>,
-    ) {
-        self.sender = sender;
-        self.digest = tx_hash;
-        self.epoch = epoch;
-        self.epoch_timestamp_ms = epoch_timestamp_ms;
-        self.ids_created = ids_created;
-        self.rgp = rgp;
-        self.gas_price = gas_price;
-        self.gas_budget = gas_budget;
-        self.sponsor = sponsor;
     }
 }
 

--- a/crates/sui/src/client_ptb/builder.rs
+++ b/crates/sui/src/client_ptb/builder.rs
@@ -34,7 +34,7 @@ use sui_rpc_api::Client;
 use sui_sdk::wallet_context::WalletContext;
 use sui_types::{
     Identifier, SUI_FRAMEWORK_PACKAGE_ID, TypeTag,
-    base_types::{ObjectID, TxContext, TxContextKind, is_primitive_type_tag},
+    base_types::{ObjectID, TxContextKind, is_primitive_type_tag},
     move_package::MovePackage,
     object::Owner,
     programmable_transaction_builder::ProgrammableTransactionBuilder,
@@ -562,7 +562,7 @@ impl<'a> PTBBuilder<'a> {
             .0
             .clone()
             .into_iter()
-            .filter(|tok| matches!(TxContext::kind(&module, tok), TxContextKind::None))
+            .filter(|tok| matches!(TxContextKind::derive(&module, tok), TxContextKind::None))
             .collect();
 
         if parameters.len() != args.len() {

--- a/sui-execution/Cargo.toml
+++ b/sui-execution/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 edition = "2024"
 
 [dependencies]
+sui-execution-types.workspace = true
 sui-protocol-config.workspace = true
 sui-types.workspace = true
 

--- a/sui-execution/latest/sui-adapter/Cargo.toml
+++ b/sui-execution/latest/sui-adapter/Cargo.toml
@@ -39,6 +39,7 @@ move-regex-borrow-graph = { path = "../../../external-crates/move/crates/move-re
 
 sui-macros.workspace = true
 sui-protocol-config.workspace = true
+sui-execution-types.workspace = true
 sui-types.workspace = true
 parking_lot.workspace = true
 either.workspace = true

--- a/sui-execution/latest/sui-adapter/src/adapter.rs
+++ b/sui-execution/latest/sui-adapter/src/adapter.rs
@@ -28,6 +28,7 @@ mod checked {
     use sui_verifier::check_for_verifier_timeout;
     use tracing::instrument;
 
+    use sui_execution_types::TxContext;
     use sui_move_natives::{NativesCostTable, object_runtime::ObjectRuntime};
     use sui_protocol_config::ProtocolConfig;
     use sui_types::{

--- a/sui-execution/latest/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/latest/sui-adapter/src/execution_engine.rs
@@ -39,6 +39,7 @@ mod checked {
     use crate::type_layout_resolver::TypeLayoutResolver;
     use crate::{gas_charger::GasCharger, temporary_store::TemporaryStore};
     use move_core_types::ident_str;
+    use sui_execution_types::TxContext;
     use sui_move_natives::all_natives;
     use sui_protocol_config::{
         LimitThresholdCrossed, PerObjectCongestionControlMode, ProtocolConfig, check_limit_by_meter,
@@ -81,7 +82,7 @@ mod checked {
     use sui_types::{
         SUI_AUTHENTICATOR_STATE_OBJECT_ID, SUI_FRAMEWORK_ADDRESS, SUI_FRAMEWORK_PACKAGE_ID,
         SUI_SYSTEM_PACKAGE_ID,
-        base_types::{SuiAddress, TransactionDigest, TxContext},
+        base_types::{SuiAddress, TransactionDigest},
         object::{Object, ObjectInner},
         sui_system_state::{ADVANCE_EPOCH_FUNCTION_NAME, SUI_SYSTEM_MODULE_NAME},
     };

--- a/sui-execution/latest/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/latest/sui-adapter/src/programmable_transactions/context.rs
@@ -53,6 +53,7 @@ mod checked {
         rc::Rc,
         sync::Arc,
     };
+    use sui_execution_types::TxContext;
     use sui_move_natives::object_runtime::{
         self, LoadedRuntimeObject, MoveAccumulatorEvent, MoveAccumulatorValue, ObjectRuntime,
         RuntimeResults, get_all_uids, max_event_error,
@@ -62,7 +63,7 @@ mod checked {
         accumulator_event::AccumulatorEvent,
         accumulator_root::AccumulatorObjId,
         balance::Balance,
-        base_types::{MoveObjectType, ObjectID, SuiAddress, TxContext},
+        base_types::{MoveObjectType, ObjectID, SuiAddress},
         coin::Coin,
         effects::{AccumulatorAddress, AccumulatorValue, AccumulatorWriteV1},
         error::{ExecutionError, ExecutionErrorKind, SuiError, command_argument_error},

--- a/sui-execution/latest/sui-adapter/src/programmable_transactions/execution.rs
+++ b/sui-execution/latest/sui-adapter/src/programmable_transactions/execution.rs
@@ -48,14 +48,14 @@ mod checked {
         sync::Arc,
         time::Instant,
     };
+    use sui_execution_types::{MoveLegacyTxContext, TxContext};
     use sui_move_natives::object_runtime::ObjectRuntime;
     use sui_protocol_config::ProtocolConfig;
     use sui_types::{
         SUI_FRAMEWORK_ADDRESS,
         base_types::{
-            MoveLegacyTxContext, MoveObjectType, ObjectID, RESOLVED_ASCII_STR, RESOLVED_STD_OPTION,
-            RESOLVED_UTF8_STR, SuiAddress, TX_CONTEXT_MODULE_NAME, TX_CONTEXT_STRUCT_NAME,
-            TxContext, TxContextKind,
+            MoveObjectType, ObjectID, RESOLVED_ASCII_STR, RESOLVED_STD_OPTION, RESOLVED_UTF8_STR,
+            SuiAddress, TX_CONTEXT_MODULE_NAME, TX_CONTEXT_STRUCT_NAME, TxContextKind,
         },
         coin::Coin,
         error::{ExecutionError, ExecutionErrorKind, command_argument_error},

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/env.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/env.rs
@@ -36,11 +36,12 @@ use move_core_types::{
 use move_vm_runtime::move_vm::MoveVM;
 use move_vm_types::{data_store::DataStore, loaded_data::runtime_types as vm_runtime_type};
 use std::{cell::OnceCell, rc::Rc, sync::Arc};
+use sui_execution_types::TxContext;
 use sui_protocol_config::ProtocolConfig;
 use sui_types::{
     Identifier, SUI_FRAMEWORK_PACKAGE_ID, TypeTag,
     balance::RESOLVED_BALANCE_STRUCT,
-    base_types::{ObjectID, TxContext},
+    base_types::ObjectID,
     coin::RESOLVED_COIN_STRUCT,
     error::{ExecutionError, ExecutionErrorKind},
     execution_status::TypeArgumentError,

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/execution/context.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/execution/context.rs
@@ -44,12 +44,13 @@ use std::{
     rc::Rc,
     sync::Arc,
 };
+use sui_execution_types::TxContext;
 use sui_move_natives::object_runtime::{
     self, LoadedRuntimeObject, ObjectRuntime, RuntimeResults, get_all_uids, max_event_error,
 };
 use sui_types::{
     TypeTag,
-    base_types::{MoveObjectType, ObjectID, SequenceNumber, TxContext},
+    base_types::{MoveObjectType, ObjectID, SequenceNumber},
     error::{ExecutionError, ExecutionErrorKind, SafeIndex},
     execution::ExecutionResults,
     metrics::LimitsMetrics,

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/execution/interpreter.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/execution/interpreter.rs
@@ -15,8 +15,8 @@ use crate::{
 use move_core_types::account_address::AccountAddress;
 use move_trace_format::format::MoveTraceBuilder;
 use std::{cell::RefCell, rc::Rc, sync::Arc, time::Instant};
+use sui_execution_types::TxContext;
 use sui_types::{
-    base_types::TxContext,
     error::{ExecutionError, ExecutionErrorKind},
     execution::{ExecutionTiming, ResultWithTimings},
     execution_status::PackageUpgradeError,

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/loading/translate.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/loading/translate.rs
@@ -11,8 +11,9 @@ use crate::{
     },
 };
 use move_core_types::{account_address::AccountAddress, language_storage::StructTag, u256::U256};
+use sui_execution_types::TxContext;
 use sui_types::{
-    base_types::{ObjectID, TxContext},
+    base_types::ObjectID,
     error::ExecutionError,
     object::Owner,
     transaction::{self as P, CallArg, FundsWithdrawalArg, ObjectArg, SharedObjectMutability},

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/mod.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/mod.rs
@@ -17,10 +17,11 @@ use crate::{
 use move_trace_format::format::MoveTraceBuilder;
 use move_vm_runtime::move_vm::MoveVM;
 use std::{cell::RefCell, rc::Rc, sync::Arc};
+use sui_execution_types::TxContext;
 use sui_protocol_config::ProtocolConfig;
 use sui_types::{
-    base_types::TxContext, error::ExecutionError, execution::ResultWithTimings,
-    metrics::LimitsMetrics, storage::BackingPackageStore, transaction::ProgrammableTransaction,
+    error::ExecutionError, execution::ResultWithTimings, metrics::LimitsMetrics,
+    storage::BackingPackageStore, transaction::ProgrammableTransaction,
 };
 
 // TODO we might replace this with a new one

--- a/sui-execution/latest/sui-move-natives/Cargo.toml
+++ b/sui-execution/latest/sui-move-natives/Cargo.toml
@@ -28,5 +28,6 @@ move-vm-runtime = { path = "../../../external-crates/move/crates/move-vm-runtime
 move-vm-types = { path = "../../../external-crates/move/crates/move-vm-types" }
 
 sui-protocol-config.workspace = true
+sui-execution-types.workspace = true
 sui-types.workspace = true
 tracing.workspace = true

--- a/sui-execution/latest/sui-move-natives/src/transaction_context.rs
+++ b/sui-execution/latest/sui-move-natives/src/transaction_context.rs
@@ -6,8 +6,9 @@ use move_binary_format::errors::{PartialVMError, PartialVMResult};
 use move_core_types::{account_address::AccountAddress, vm_status::StatusCode};
 use move_vm_runtime::native_extensions::NativeExtensionMarker;
 use std::{cell::RefCell, rc::Rc};
+use sui_execution_types::TxContext;
 use sui_types::{
-    base_types::{ObjectID, SuiAddress, TxContext},
+    base_types::{ObjectID, SuiAddress},
     committee::EpochId,
     digests::TransactionDigest,
 };

--- a/sui-execution/latest/sui-verifier/Cargo.toml
+++ b/sui-execution/latest/sui-verifier/Cargo.toml
@@ -17,5 +17,6 @@ move-abstract-stack.workspace = true
 
 move-bytecode-verifier = { path = "../../../external-crates/move/crates/move-bytecode-verifier" }
 
+sui-execution-types.workspace = true
 sui-types.workspace = true
 sui-protocol-config.workspace = true

--- a/sui-execution/latest/sui-verifier/src/entry_points_verifier.rs
+++ b/sui-execution/latest/sui-verifier/src/entry_points_verifier.rs
@@ -10,7 +10,7 @@ use move_vm_config::verifier::VerifierConfig;
 use sui_types::randomness_state::is_mutable_random;
 use sui_types::{
     SUI_FRAMEWORK_ADDRESS,
-    base_types::{TX_CONTEXT_MODULE_NAME, TX_CONTEXT_STRUCT_NAME, TxContext, TxContextKind},
+    base_types::{TX_CONTEXT_MODULE_NAME, TX_CONTEXT_STRUCT_NAME, TxContextKind},
     clock::Clock,
     error::ExecutionError,
     is_object, is_object_vector, is_primitive,
@@ -153,7 +153,7 @@ fn verify_init_function(module: &CompiledModule, fdef: &FunctionDefinition) -> R
     // then the first parameter must be of a one-time witness type and must be passed by value. This
     // is checked by the verifier for pass one-time witness value (one_time_witness_verifier) -
     // please see the description of this pass for additional details.
-    if TxContext::kind(module, &parameters[parameters.len() - 1]) != TxContextKind::None {
+    if TxContextKind::derive(module, &parameters[parameters.len() - 1]) != TxContextKind::None {
         Ok(())
     } else {
         Err(format!(
@@ -178,7 +178,7 @@ fn verify_entry_function_impl(
     let params = view.signature_at(handle.parameters);
 
     let all_non_ctx_params = match params.0.last() {
-        Some(last_param) if TxContext::kind(view, last_param) != TxContextKind::None => {
+        Some(last_param) if TxContextKind::derive(view, last_param) != TxContextKind::None => {
             &params.0[0..params.0.len() - 1]
         }
         _ => &params.0,

--- a/sui-execution/src/latest.rs
+++ b/sui-execution/src/latest.rs
@@ -5,12 +5,13 @@ use move_binary_format::CompiledModule;
 use move_trace_format::format::MoveTraceBuilder;
 use move_vm_config::verifier::{MeterConfig, VerifierConfig};
 use std::{cell::RefCell, rc::Rc, sync::Arc};
+use sui_execution_types::TxContext;
 use sui_protocol_config::ProtocolConfig;
 use sui_types::execution::ExecutionTiming;
 use sui_types::execution_params::ExecutionOrEarlyError;
 use sui_types::transaction::GasData;
 use sui_types::{
-    base_types::{SuiAddress, TxContext},
+    base_types::SuiAddress,
     committee::EpochId,
     digests::TransactionDigest,
     effects::TransactionEffects,

--- a/sui-execution/src/v0.rs
+++ b/sui-execution/src/v0.rs
@@ -6,12 +6,13 @@ use std::sync::Arc;
 use move_binary_format::CompiledModule;
 use move_trace_format::format::MoveTraceBuilder;
 use move_vm_config::verifier::{MeterConfig, VerifierConfig};
+use sui_execution_types::TxContext;
 use sui_protocol_config::ProtocolConfig;
 use sui_types::execution::ExecutionTiming;
 use sui_types::execution_params::ExecutionOrEarlyError;
 use sui_types::transaction::GasData;
 use sui_types::{
-    base_types::{SuiAddress, TxContext},
+    base_types::SuiAddress,
     committee::EpochId,
     digests::TransactionDigest,
     effects::TransactionEffects,

--- a/sui-execution/src/v1.rs
+++ b/sui-execution/src/v1.rs
@@ -6,12 +6,13 @@ use std::sync::Arc;
 use move_binary_format::CompiledModule;
 use move_trace_format::format::MoveTraceBuilder;
 use move_vm_config::verifier::{MeterConfig, VerifierConfig};
+use sui_execution_types::TxContext;
 use sui_protocol_config::ProtocolConfig;
 use sui_types::execution::ExecutionTiming;
 use sui_types::execution_params::ExecutionOrEarlyError;
 use sui_types::transaction::GasData;
 use sui_types::{
-    base_types::{SuiAddress, TxContext},
+    base_types::SuiAddress,
     committee::EpochId,
     digests::TransactionDigest,
     effects::TransactionEffects,

--- a/sui-execution/src/v2.rs
+++ b/sui-execution/src/v2.rs
@@ -6,12 +6,13 @@ use std::sync::Arc;
 use move_binary_format::CompiledModule;
 use move_trace_format::format::MoveTraceBuilder;
 use move_vm_config::verifier::{MeterConfig, VerifierConfig};
+use sui_execution_types::TxContext;
 use sui_protocol_config::ProtocolConfig;
 use sui_types::execution::ExecutionTiming;
 use sui_types::execution_params::ExecutionOrEarlyError;
 use sui_types::transaction::GasData;
 use sui_types::{
-    base_types::{SuiAddress, TxContext},
+    base_types::SuiAddress,
     committee::EpochId,
     digests::TransactionDigest,
     effects::TransactionEffects,

--- a/sui-execution/sui-execution-types/Cargo.toml
+++ b/sui-execution/sui-execution-types/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "sui-execution-types"
+version = "0.1.0"
+authors = ["Mysten Labs <eng@mystenlabs.com>"]
+description = "Types internal to the Sui execution layer."
+license = "Apache-2.0"
+publish = false
+edition = "2024"
+
+[lints]
+workspace = true
+
+[dependencies]
+bcs.workspace = true
+serde.workspace = true
+
+move-core-types.workspace = true
+
+sui-protocol-config.workspace = true
+sui-types.workspace = true

--- a/sui-execution/sui-execution-types/src/lib.rs
+++ b/sui-execution/sui-execution-types/src/lib.rs
@@ -1,0 +1,6 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+mod tx_context;
+
+pub use tx_context::{MoveLegacyTxContext, TxContext};

--- a/sui-execution/sui-execution-types/src/tx_context.rs
+++ b/sui-execution/sui-execution-types/src/tx_context.rs
@@ -1,0 +1,245 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use move_core_types::account_address::AccountAddress;
+use move_core_types::language_storage::StructTag;
+use serde::{Deserialize, Serialize};
+use sui_protocol_config::ProtocolConfig;
+use sui_types::SUI_FRAMEWORK_ADDRESS;
+use sui_types::base_types::{ObjectID, SuiAddress, TX_CONTEXT_MODULE_NAME, TX_CONTEXT_STRUCT_NAME};
+use sui_types::committee::EpochId;
+use sui_types::digests::TransactionDigest;
+use sui_types::epoch_data::EpochData;
+use sui_types::error::{ExecutionError, ExecutionErrorKind};
+use sui_types::messages_checkpoint::CheckpointTimestamp;
+
+//
+// `TxContext` in Rust (see below) is going to be purely used in Rust and can
+// evolve as needed without worrying any compatibility with Move.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub struct MoveLegacyTxContext {
+    // Signer/sender of the transaction
+    sender: AccountAddress,
+    // Digest of the current transaction
+    digest: Vec<u8>,
+    // The current epoch number
+    epoch: EpochId,
+    // Timestamp that the epoch started at
+    epoch_timestamp_ms: CheckpointTimestamp,
+    // Number of `ObjectID`'s generated during execution of the current transaction
+    ids_created: u64,
+}
+
+impl From<&TxContext> for MoveLegacyTxContext {
+    fn from(tx_context: &TxContext) -> Self {
+        Self {
+            sender: tx_context.sender,
+            digest: tx_context.digest.clone(),
+            epoch: tx_context.epoch,
+            epoch_timestamp_ms: tx_context.epoch_timestamp_ms,
+            ids_created: tx_context.ids_created,
+        }
+    }
+}
+
+// Information about the transaction context.
+// This struct is not related to Move and can evolve as needed/required.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub struct TxContext {
+    /// Sender of the transaction
+    sender: AccountAddress,
+    /// Digest of the current transaction
+    digest: Vec<u8>,
+    /// The current epoch number
+    epoch: EpochId,
+    /// Timestamp that the epoch started at
+    epoch_timestamp_ms: CheckpointTimestamp,
+    /// Number of `ObjectID`'s generated during execution of the current transaction
+    ids_created: u64,
+    // Reference gas price
+    rgp: u64,
+    // gas price passed to transaction as input
+    gas_price: u64,
+    // gas budget passed to transaction as input
+    gas_budget: u64,
+    // address of the sponsor if any
+    sponsor: Option<AccountAddress>,
+    // whether the `TxContext` is native or not
+    // (TODO: once we version execution we could drop this field)
+    is_native: bool,
+}
+
+impl TxContext {
+    pub fn new(
+        sender: &SuiAddress,
+        digest: &TransactionDigest,
+        epoch_data: &EpochData,
+        rgp: u64,
+        gas_price: u64,
+        gas_budget: u64,
+        sponsor: Option<SuiAddress>,
+        protocol_config: &ProtocolConfig,
+    ) -> Self {
+        Self::new_from_components(
+            sender,
+            digest,
+            &epoch_data.epoch_id(),
+            epoch_data.epoch_start_timestamp(),
+            rgp,
+            gas_price,
+            gas_budget,
+            sponsor,
+            protocol_config,
+        )
+    }
+
+    pub fn new_from_components(
+        sender: &SuiAddress,
+        digest: &TransactionDigest,
+        epoch_id: &EpochId,
+        epoch_timestamp_ms: u64,
+        rgp: u64,
+        gas_price: u64,
+        gas_budget: u64,
+        sponsor: Option<SuiAddress>,
+        protocol_config: &ProtocolConfig,
+    ) -> Self {
+        Self {
+            sender: (*sender).into(),
+            digest: digest.into_inner().to_vec(),
+            epoch: *epoch_id,
+            epoch_timestamp_ms,
+            ids_created: 0,
+            rgp,
+            gas_price,
+            gas_budget,
+            sponsor: sponsor.map(|s| s.into()),
+            is_native: protocol_config.move_native_context(),
+        }
+    }
+
+    pub fn type_() -> StructTag {
+        StructTag {
+            address: SUI_FRAMEWORK_ADDRESS,
+            module: TX_CONTEXT_MODULE_NAME.to_owned(),
+            name: TX_CONTEXT_STRUCT_NAME.to_owned(),
+            type_params: vec![],
+        }
+    }
+
+    pub fn epoch(&self) -> EpochId {
+        self.epoch
+    }
+
+    pub fn sender(&self) -> SuiAddress {
+        self.sender.into()
+    }
+
+    pub fn epoch_timestamp_ms(&self) -> u64 {
+        self.epoch_timestamp_ms
+    }
+
+    /// Return the transaction digest, to include in new objects
+    pub fn digest(&self) -> TransactionDigest {
+        TransactionDigest::new(self.digest.clone().try_into().unwrap())
+    }
+
+    pub fn sponsor(&self) -> Option<SuiAddress> {
+        self.sponsor.map(SuiAddress::from)
+    }
+
+    pub fn rgp(&self) -> u64 {
+        self.rgp
+    }
+
+    pub fn gas_price(&self) -> u64 {
+        self.gas_price
+    }
+
+    pub fn gas_budget(&self) -> u64 {
+        self.gas_budget
+    }
+
+    pub fn ids_created(&self) -> u64 {
+        self.ids_created
+    }
+
+    /// Derive a globally unique object ID by hashing self.digest | self.ids_created
+    pub fn fresh_id(&mut self) -> ObjectID {
+        let id = ObjectID::derive_id(self.digest(), self.ids_created);
+
+        self.ids_created += 1;
+        id
+    }
+
+    pub fn to_bcs_legacy_context(&self) -> Vec<u8> {
+        let move_context: MoveLegacyTxContext = if self.is_native {
+            let tx_context = &TxContext {
+                sender: AccountAddress::ZERO,
+                digest: self.digest.clone(),
+                epoch: 0,
+                epoch_timestamp_ms: 0,
+                ids_created: 0,
+                rgp: 0,
+                gas_price: 0,
+                gas_budget: 0,
+                sponsor: None,
+                is_native: true,
+            };
+            tx_context.into()
+        } else {
+            self.into()
+        };
+        bcs::to_bytes(&move_context).unwrap()
+    }
+
+    pub fn to_vec(&self) -> Vec<u8> {
+        bcs::to_bytes(&self).unwrap()
+    }
+
+    /// Updates state of the context instance. It's intended to use
+    /// when mutable context is passed over some boundary via
+    /// serialize/deserialize and this is the reason why this method
+    /// consumes the other context..
+    pub fn update_state(&mut self, other: MoveLegacyTxContext) -> Result<(), ExecutionError> {
+        if !self.is_native {
+            if self.sender != other.sender
+                || self.digest != other.digest
+                || other.ids_created < self.ids_created
+            {
+                return Err(ExecutionError::new_with_source(
+                    ExecutionErrorKind::InvariantViolation,
+                    "Immutable fields for TxContext changed",
+                ));
+            }
+            self.ids_created = other.ids_created;
+        }
+        Ok(())
+    }
+
+    //
+    // Move test only API
+    //
+    pub fn replace(
+        &mut self,
+        sender: AccountAddress,
+        tx_hash: Vec<u8>,
+        epoch: u64,
+        epoch_timestamp_ms: u64,
+        ids_created: u64,
+        rgp: u64,
+        gas_price: u64,
+        gas_budget: u64,
+        sponsor: Option<AccountAddress>,
+    ) {
+        self.sender = sender;
+        self.digest = tx_hash;
+        self.epoch = epoch;
+        self.epoch_timestamp_ms = epoch_timestamp_ms;
+        self.ids_created = ids_created;
+        self.rgp = rgp;
+        self.gas_price = gas_price;
+        self.gas_budget = gas_budget;
+        self.sponsor = sponsor;
+    }
+}

--- a/sui-execution/v0/sui-adapter/Cargo.toml
+++ b/sui-execution/v0/sui-adapter/Cargo.toml
@@ -33,6 +33,7 @@ move-vm-types = { path = "../../../external-crates/move/move-execution/v0/crates
 
 sui-macros.workspace = true
 sui-protocol-config.workspace = true
+sui-execution-types.workspace = true
 sui-types.workspace = true
 parking_lot.workspace = true
 

--- a/sui-execution/v0/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/v0/sui-adapter/src/execution_engine.rs
@@ -13,6 +13,7 @@ mod checked {
     use move_binary_format::CompiledModule;
     use move_vm_runtime::move_vm::MoveVM;
     use std::sync::Arc;
+    use sui_execution_types::TxContext;
     use sui_protocol_config::{check_limit_by_meter, LimitThresholdCrossed, ProtocolConfig};
     use sui_types::balance::{
         BALANCE_CREATE_REWARDS_FUNCTION_NAME, BALANCE_DESTROY_REBATES_FUNCTION_NAME,
@@ -43,7 +44,7 @@ mod checked {
         TransactionKind,
     };
     use sui_types::{
-        base_types::{ObjectRef, SuiAddress, TransactionDigest, TxContext},
+        base_types::{ObjectRef, SuiAddress, TransactionDigest},
         object::{Object, ObjectInner},
         sui_system_state::{ADVANCE_EPOCH_FUNCTION_NAME, SUI_SYSTEM_MODULE_NAME},
         SUI_FRAMEWORK_ADDRESS,

--- a/sui-execution/v0/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/v0/sui-adapter/src/programmable_transactions/context.rs
@@ -32,6 +32,7 @@ mod checked {
     };
     use move_vm_runtime::{move_vm::MoveVM, session::Session};
     use move_vm_types::loaded_data::runtime_types::Type;
+    use sui_execution_types::TxContext;
     use sui_move_natives::object_runtime::{
         self, get_all_uids, max_event_error, ObjectRuntime, RuntimeResults,
     };
@@ -40,7 +41,7 @@ mod checked {
     use sui_types::storage::PackageObject;
     use sui_types::{
         balance::Balance,
-        base_types::{MoveObjectType, ObjectID, SequenceNumber, SuiAddress, TxContext},
+        base_types::{MoveObjectType, ObjectID, SequenceNumber, SuiAddress},
         coin::Coin,
         error::{command_argument_error, ExecutionError, ExecutionErrorKind},
         event::Event,

--- a/sui-execution/v0/sui-adapter/src/programmable_transactions/execution.rs
+++ b/sui-execution/v0/sui-adapter/src/programmable_transactions/execution.rs
@@ -36,15 +36,15 @@ mod checked {
     };
     use move_vm_types::loaded_data::runtime_types::{CachedDatatype, Type};
     use serde::{de::DeserializeSeed, Deserialize};
+    use sui_execution_types::{MoveLegacyTxContext, TxContext};
     use sui_move_natives::object_runtime::ObjectRuntime;
     use sui_protocol_config::ProtocolConfig;
     use sui_types::execution_status::{CommandArgumentError, PackageUpgradeError};
     use sui_types::storage::{get_package_objects, PackageObject};
     use sui_types::{
         base_types::{
-            MoveLegacyTxContext, MoveObjectType, ObjectID, SuiAddress, TxContext, TxContextKind,
-            RESOLVED_ASCII_STR, RESOLVED_STD_OPTION, RESOLVED_UTF8_STR, TX_CONTEXT_MODULE_NAME,
-            TX_CONTEXT_STRUCT_NAME,
+            MoveObjectType, ObjectID, SuiAddress, TxContextKind, RESOLVED_ASCII_STR,
+            RESOLVED_STD_OPTION, RESOLVED_UTF8_STR, TX_CONTEXT_MODULE_NAME, TX_CONTEXT_STRUCT_NAME,
         },
         coin::Coin,
         error::{command_argument_error, ExecutionError, ExecutionErrorKind},

--- a/sui-execution/v0/sui-move-natives/Cargo.toml
+++ b/sui-execution/v0/sui-move-natives/Cargo.toml
@@ -23,5 +23,6 @@ move-vm-runtime = { path = "../../../external-crates/move/move-execution/v0/crat
 move-vm-types = { path = "../../../external-crates/move/move-execution/v0/crates/move-vm-types", package = "move-vm-types-v0" }
 
 sui-protocol-config.workspace = true
+sui-execution-types.workspace = true
 sui-types.workspace = true
 tracing.workspace = true

--- a/sui-execution/v0/sui-verifier/Cargo.toml
+++ b/sui-execution/v0/sui-verifier/Cargo.toml
@@ -20,5 +20,6 @@ move-abstract-stack.workspace = true
 
 move-bytecode-verifier = { path = "../../../external-crates/move/move-execution/v0/crates/move-bytecode-verifier", package = "move-bytecode-verifier-v0" }
 
+sui-execution-types.workspace = true
 sui-types.workspace = true
 sui-protocol-config.workspace = true

--- a/sui-execution/v0/sui-verifier/src/entry_points_verifier.rs
+++ b/sui-execution/v0/sui-verifier/src/entry_points_verifier.rs
@@ -8,7 +8,7 @@ use move_binary_format::{
 use move_bytecode_utils::format_signature_token;
 use sui_protocol_config::ProtocolConfig;
 use sui_types::{
-    base_types::{TxContext, TxContextKind, TX_CONTEXT_MODULE_NAME, TX_CONTEXT_STRUCT_NAME},
+    base_types::{TxContextKind, TX_CONTEXT_MODULE_NAME, TX_CONTEXT_STRUCT_NAME},
     clock::Clock,
     error::ExecutionError,
     is_object, is_object_vector, is_primitive,
@@ -154,7 +154,7 @@ fn verify_init_function(
     // then the first parameter must be of a one-time witness type and must be passed by value. This
     // is checked by the verifier for pass one-time witness value (one_time_witness_verifier) -
     // please see the description of this pass for additional details.
-    if TxContext::kind(module, &parameters[parameters.len() - 1]) != TxContextKind::None {
+    if TxContextKind::derive(module, &parameters[parameters.len() - 1]) != TxContextKind::None {
         Ok(())
     } else {
         Err(format!(
@@ -178,7 +178,7 @@ fn verify_entry_function_impl(
     let params = module.signature_at(handle.parameters);
 
     let all_non_ctx_params = match params.0.last() {
-        Some(last_param) if TxContext::kind(module, last_param) != TxContextKind::None => {
+        Some(last_param) if TxContextKind::derive(module, last_param) != TxContextKind::None => {
             &params.0[0..params.0.len() - 1]
         }
         _ => &params.0,

--- a/sui-execution/v1/sui-adapter/Cargo.toml
+++ b/sui-execution/v1/sui-adapter/Cargo.toml
@@ -32,6 +32,7 @@ move-vm-types = { path = "../../../external-crates/move/move-execution/v1/crates
 
 sui-macros.workspace = true
 sui-protocol-config.workspace = true
+sui-execution-types.workspace = true
 sui-types.workspace = true
 parking_lot.workspace = true
 

--- a/sui-execution/v1/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/v1/sui-adapter/src/execution_engine.rs
@@ -25,6 +25,7 @@ mod checked {
     use crate::programmable_transactions;
     use crate::type_layout_resolver::TypeLayoutResolver;
     use crate::{gas_charger::GasCharger, temporary_store::TemporaryStore};
+    use sui_execution_types::TxContext;
     use sui_protocol_config::{check_limit_by_meter, LimitThresholdCrossed, ProtocolConfig};
     use sui_types::authenticator_state::{
         AUTHENTICATOR_STATE_CREATE_FUNCTION_NAME, AUTHENTICATOR_STATE_EXPIRE_JWKS_FUNCTION_NAME,
@@ -49,7 +50,7 @@ mod checked {
         TransactionKind,
     };
     use sui_types::{
-        base_types::{ObjectRef, SuiAddress, TransactionDigest, TxContext},
+        base_types::{ObjectRef, SuiAddress, TransactionDigest},
         object::{Object, ObjectInner},
         sui_system_state::{ADVANCE_EPOCH_FUNCTION_NAME, SUI_SYSTEM_MODULE_NAME},
         SUI_AUTHENTICATOR_STATE_OBJECT_ID, SUI_FRAMEWORK_ADDRESS, SUI_FRAMEWORK_PACKAGE_ID,

--- a/sui-execution/v1/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/v1/sui-adapter/src/programmable_transactions/context.rs
@@ -41,6 +41,7 @@ mod checked {
     };
     use move_vm_types::data_store::DataStore;
     use move_vm_types::loaded_data::runtime_types::Type;
+    use sui_execution_types::TxContext;
     use sui_move_natives::object_runtime::{
         self, get_all_uids, max_event_error, LoadedRuntimeObject, ObjectRuntime, RuntimeResults,
     };
@@ -49,7 +50,7 @@ mod checked {
     use sui_types::storage::PackageObject;
     use sui_types::{
         balance::Balance,
-        base_types::{MoveObjectType, ObjectID, SuiAddress, TxContext},
+        base_types::{MoveObjectType, ObjectID, SuiAddress},
         coin::Coin,
         error::{ExecutionError, ExecutionErrorKind},
         event::Event,

--- a/sui-execution/v1/sui-adapter/src/programmable_transactions/execution.rs
+++ b/sui-execution/v1/sui-adapter/src/programmable_transactions/execution.rs
@@ -34,15 +34,15 @@ mod checked {
         fmt,
         sync::Arc,
     };
+    use sui_execution_types::{MoveLegacyTxContext, TxContext};
     use sui_move_natives::object_runtime::ObjectRuntime;
     use sui_protocol_config::ProtocolConfig;
     use sui_types::execution_status::{CommandArgumentError, PackageUpgradeError};
     use sui_types::storage::{get_package_objects, PackageObject};
     use sui_types::{
         base_types::{
-            MoveLegacyTxContext, MoveObjectType, ObjectID, SuiAddress, TxContext, TxContextKind,
-            RESOLVED_ASCII_STR, RESOLVED_STD_OPTION, RESOLVED_UTF8_STR, TX_CONTEXT_MODULE_NAME,
-            TX_CONTEXT_STRUCT_NAME,
+            MoveObjectType, ObjectID, SuiAddress, TxContextKind, RESOLVED_ASCII_STR,
+            RESOLVED_STD_OPTION, RESOLVED_UTF8_STR, TX_CONTEXT_MODULE_NAME, TX_CONTEXT_STRUCT_NAME,
         },
         coin::Coin,
         error::{command_argument_error, ExecutionError, ExecutionErrorKind},

--- a/sui-execution/v1/sui-move-natives/Cargo.toml
+++ b/sui-execution/v1/sui-move-natives/Cargo.toml
@@ -23,5 +23,6 @@ move-vm-runtime = { path = "../../../external-crates/move/move-execution/v1/crat
 move-vm-types = { path = "../../../external-crates/move/move-execution/v1/crates/move-vm-types", package = "move-vm-types-v1" }
 
 sui-protocol-config.workspace = true
+sui-execution-types.workspace = true
 sui-types.workspace = true
 tracing.workspace = true

--- a/sui-execution/v1/sui-verifier/Cargo.toml
+++ b/sui-execution/v1/sui-verifier/Cargo.toml
@@ -17,4 +17,5 @@ move-abstract-stack.workspace = true
 
 move-bytecode-verifier = { path = "../../../external-crates/move/move-execution/v1/crates/move-bytecode-verifier", package = "move-bytecode-verifier-v1" }
 
+sui-execution-types.workspace = true
 sui-types.workspace = true

--- a/sui-execution/v1/sui-verifier/src/entry_points_verifier.rs
+++ b/sui-execution/v1/sui-verifier/src/entry_points_verifier.rs
@@ -7,7 +7,7 @@ use move_binary_format::{
 };
 use move_bytecode_utils::format_signature_token;
 use sui_types::{
-    base_types::{TxContext, TxContextKind, TX_CONTEXT_MODULE_NAME, TX_CONTEXT_STRUCT_NAME},
+    base_types::{TxContextKind, TX_CONTEXT_MODULE_NAME, TX_CONTEXT_STRUCT_NAME},
     clock::Clock,
     error::ExecutionError,
     is_object, is_object_vector, is_primitive,
@@ -149,7 +149,7 @@ fn verify_init_function(module: &CompiledModule, fdef: &FunctionDefinition) -> R
     // then the first parameter must be of a one-time witness type and must be passed by value. This
     // is checked by the verifier for pass one-time witness value (one_time_witness_verifier) -
     // please see the description of this pass for additional details.
-    if TxContext::kind(module, &parameters[parameters.len() - 1]) != TxContextKind::None {
+    if TxContextKind::derive(module, &parameters[parameters.len() - 1]) != TxContextKind::None {
         Ok(())
     } else {
         Err(format!(
@@ -173,7 +173,7 @@ fn verify_entry_function_impl(
     let params = module.signature_at(handle.parameters);
 
     let all_non_ctx_params = match params.0.last() {
-        Some(last_param) if TxContext::kind(module, last_param) != TxContextKind::None => {
+        Some(last_param) if TxContextKind::derive(module, last_param) != TxContextKind::None => {
             &params.0[0..params.0.len() - 1]
         }
         _ => &params.0,

--- a/sui-execution/v2/sui-adapter/Cargo.toml
+++ b/sui-execution/v2/sui-adapter/Cargo.toml
@@ -32,6 +32,7 @@ move-vm-types = { path = "../../../external-crates/move/move-execution/v2/crates
 
 sui-macros.workspace = true
 sui-protocol-config.workspace = true
+sui-execution-types.workspace = true
 sui-types.workspace = true
 parking_lot.workspace = true
 

--- a/sui-execution/v2/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/v2/sui-adapter/src/execution_engine.rs
@@ -30,6 +30,7 @@ mod checked {
     use crate::programmable_transactions;
     use crate::type_layout_resolver::TypeLayoutResolver;
     use crate::{gas_charger::GasCharger, temporary_store::TemporaryStore};
+    use sui_execution_types::TxContext;
     use sui_protocol_config::{check_limit_by_meter, LimitThresholdCrossed, ProtocolConfig};
     use sui_types::authenticator_state::{
         AUTHENTICATOR_STATE_CREATE_FUNCTION_NAME, AUTHENTICATOR_STATE_EXPIRE_JWKS_FUNCTION_NAME,
@@ -55,7 +56,7 @@ mod checked {
     };
     use sui_types::transaction::{CheckedInputObjects, RandomnessStateUpdate};
     use sui_types::{
-        base_types::{ObjectRef, SuiAddress, TransactionDigest, TxContext},
+        base_types::{ObjectRef, SuiAddress, TransactionDigest},
         object::{Object, ObjectInner},
         sui_system_state::{ADVANCE_EPOCH_FUNCTION_NAME, SUI_SYSTEM_MODULE_NAME},
         SUI_AUTHENTICATOR_STATE_OBJECT_ID, SUI_FRAMEWORK_ADDRESS, SUI_FRAMEWORK_PACKAGE_ID,

--- a/sui-execution/v2/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/v2/sui-adapter/src/programmable_transactions/context.rs
@@ -43,6 +43,7 @@ mod checked {
     };
     use move_vm_types::data_store::DataStore;
     use move_vm_types::loaded_data::runtime_types::Type;
+    use sui_execution_types::TxContext;
     use sui_move_natives::object_runtime::{
         self, get_all_uids, max_event_error, LoadedRuntimeObject, ObjectRuntime, RuntimeResults,
     };
@@ -51,7 +52,7 @@ mod checked {
     use sui_types::storage::PackageObject;
     use sui_types::{
         balance::Balance,
-        base_types::{MoveObjectType, ObjectID, SuiAddress, TxContext},
+        base_types::{MoveObjectType, ObjectID, SuiAddress},
         coin::Coin,
         error::{ExecutionError, ExecutionErrorKind},
         event::Event,

--- a/sui-execution/v2/sui-adapter/src/programmable_transactions/execution.rs
+++ b/sui-execution/v2/sui-adapter/src/programmable_transactions/execution.rs
@@ -34,15 +34,15 @@ mod checked {
         fmt,
         sync::Arc,
     };
+    use sui_execution_types::{MoveLegacyTxContext, TxContext};
     use sui_move_natives::object_runtime::ObjectRuntime;
     use sui_protocol_config::ProtocolConfig;
     use sui_types::execution_status::{CommandArgumentError, PackageUpgradeError};
     use sui_types::storage::{get_package_objects, PackageObject};
     use sui_types::{
         base_types::{
-            MoveLegacyTxContext, MoveObjectType, ObjectID, SuiAddress, TxContext, TxContextKind,
-            RESOLVED_ASCII_STR, RESOLVED_STD_OPTION, RESOLVED_UTF8_STR, TX_CONTEXT_MODULE_NAME,
-            TX_CONTEXT_STRUCT_NAME,
+            MoveObjectType, ObjectID, SuiAddress, TxContextKind, RESOLVED_ASCII_STR,
+            RESOLVED_STD_OPTION, RESOLVED_UTF8_STR, TX_CONTEXT_MODULE_NAME, TX_CONTEXT_STRUCT_NAME,
         },
         coin::Coin,
         error::{command_argument_error, ExecutionError, ExecutionErrorKind},

--- a/sui-execution/v2/sui-move-natives/Cargo.toml
+++ b/sui-execution/v2/sui-move-natives/Cargo.toml
@@ -23,5 +23,6 @@ move-vm-runtime = { path = "../../../external-crates/move/move-execution/v2/crat
 move-vm-types = { path = "../../../external-crates/move/move-execution/v2/crates/move-vm-types", package = "move-vm-types-v2" }
 
 sui-protocol-config.workspace = true
+sui-execution-types.workspace = true
 sui-types.workspace = true
 tracing.workspace = true

--- a/sui-execution/v2/sui-verifier/Cargo.toml
+++ b/sui-execution/v2/sui-verifier/Cargo.toml
@@ -17,5 +17,6 @@ move-abstract-stack.workspace = true
 
 move-bytecode-verifier = { path = "../../../external-crates/move/move-execution/v2/crates/move-bytecode-verifier", package = "move-bytecode-verifier-v2" }
 
+sui-execution-types.workspace = true
 sui-types.workspace = true
 sui-protocol-config.workspace = true

--- a/sui-execution/v2/sui-verifier/src/entry_points_verifier.rs
+++ b/sui-execution/v2/sui-verifier/src/entry_points_verifier.rs
@@ -9,7 +9,7 @@ use move_bytecode_utils::format_signature_token;
 use move_vm_config::verifier::VerifierConfig;
 use sui_types::randomness_state::is_mutable_random;
 use sui_types::{
-    base_types::{TxContext, TxContextKind, TX_CONTEXT_MODULE_NAME, TX_CONTEXT_STRUCT_NAME},
+    base_types::{TxContextKind, TX_CONTEXT_MODULE_NAME, TX_CONTEXT_STRUCT_NAME},
     clock::Clock,
     error::ExecutionError,
     is_object, is_object_vector, is_primitive,
@@ -153,7 +153,7 @@ fn verify_init_function(module: &CompiledModule, fdef: &FunctionDefinition) -> R
     // then the first parameter must be of a one-time witness type and must be passed by value. This
     // is checked by the verifier for pass one-time witness value (one_time_witness_verifier) -
     // please see the description of this pass for additional details.
-    if TxContext::kind(module, &parameters[parameters.len() - 1]) != TxContextKind::None {
+    if TxContextKind::derive(module, &parameters[parameters.len() - 1]) != TxContextKind::None {
         Ok(())
     } else {
         Err(format!(
@@ -178,7 +178,7 @@ fn verify_entry_function_impl(
     let params = module.signature_at(handle.parameters);
 
     let all_non_ctx_params = match params.0.last() {
-        Some(last_param) if TxContext::kind(module, last_param) != TxContextKind::None => {
+        Some(last_param) if TxContextKind::derive(module, last_param) != TxContextKind::None => {
             &params.0[0..params.0.len() - 1]
         }
         _ => &params.0,


### PR DESCRIPTION
## Description 

We talked in past about moving the `TxContext` from `sui-types` in execution. That was after changing `TxContext` in Move to rely on native functions.
This PR attempts to do that at the best I can. And I truly dislike it.
There is a usage of `TxContext` in `authority_test.rs` that could likely be removed however I do not have a good home for `TxContext`.
This PR is the best I can do and I propose to leave everything as is and forget about it.
However open to suggestions if anybody cared.

This is what we end up with in terms of dependencies
```
sui-execution ──►  sui-adapter-*
     │                    │                         
     ▼                    │                     
sui-execution-types  ◄────┘
     │
     ▼
  sui-types
```
the issue is that we cannot put `TxContext` in `sui-execution` because we would create a circular dependency between adapter and execution.
So we need to create a new crate and at that point it feels just fine to leave `TxContext` where it is now

## Test plan 

Existing tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
