### PR TITLE
[1.66] Gate checkpointed transactions index check on enable_secondary_index_checks

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -4279,9 +4279,9 @@ impl AuthorityState {
         // Verify all checkpointed transactions are present in transactions_seq.
         // This catches any post-processing gaps that could occur if async
         // post-processing failed to complete before persistence.
-        // This runs whenever indexes are enabled (not gated on enable_secondary_index_checks)
-        // because it is cheap and critical for async post-processing correctness.
-        if let Some(indexes) = self.indexes.clone() {
+        if expensive_safety_check_config.enable_secondary_index_checks()
+            && let Some(indexes) = self.indexes.clone()
+        {
             let epoch = cur_epoch_store.epoch();
             // Only verify the current epoch's checkpoints. Previous epoch contents
             // may have been pruned, and we only need to verify that this epoch's


### PR DESCRIPTION
## Summary
Cherry-pick of #25726 to the 1.66 release branch.

- The verification that all checkpointed transactions are in `transactions_seq` now only runs when `enable_secondary_index_checks` is true
- This makes it consistent with the other secondary index verification in `check_system_consistency`

## Test plan
- Code compiles successfully
- Logic is straightforward conditional gating

🤖 Generated with [Claude Code](https://claude.com/claude-code)