### PR TITLE
sui-indexer-alt: change checkpoint_hi_inclusive to checkpoint_hi

### DIFF
--- a/crates/sui-analytics-indexer/src/store/live.rs
+++ b/crates/sui-analytics-indexer/src/store/live.rs
@@ -57,12 +57,9 @@ impl LiveStore {
             find_all_files_with_epoch_prefix(&self.object_store, Some(epoch_path)).await?;
 
         // Watermark = max(end) across all files
-        let checkpoint_hi = checkpoint_ranges.iter().map(|r| r.end).max().unwrap_or(0);
-
-        // Need checkpoint_hi - 1 since ranges are exclusive and watermark is inclusive
-        if checkpoint_hi == 0 {
+        let Some(checkpoint_hi) = checkpoint_ranges.iter().map(|r| r.end).max() else {
             return Ok(None);
-        }
+        };
 
         info!(
             pipeline,
@@ -73,9 +70,9 @@ impl LiveStore {
 
         Ok(Some(CommitterWatermark {
             epoch_hi_inclusive: epoch,
-            checkpoint_hi_inclusive: checkpoint_hi - 1, // Convert exclusive end to inclusive
-            tx_hi: 0,                                   // Not stored in filenames
-            timestamp_ms_hi_inclusive: 0,               // Not stored in filenames
+            checkpoint_hi,
+            tx_hi: 0,                     // Not stored in filenames
+            timestamp_ms_hi_inclusive: 0, // Not stored in filenames
         }))
     }
 
@@ -242,6 +239,6 @@ mod tests {
         let watermark = watermark.unwrap();
         // Should use latest epoch (1) and max checkpoint from that epoch
         assert_eq!(watermark.epoch_hi_inclusive, 1);
-        assert_eq!(watermark.checkpoint_hi_inclusive, 399); // max(300, 400) - 1
+        assert_eq!(watermark.checkpoint_hi, 400); // max(300, 400)
     }
 }

--- a/crates/sui-analytics-indexer/src/store/migration.rs
+++ b/crates/sui-analytics-indexer/src/store/migration.rs
@@ -241,7 +241,7 @@ impl MigrationStore {
                 );
                 Ok(Some(CommitterWatermark {
                     epoch_hi_inclusive: watermark.epoch_hi_inclusive,
-                    checkpoint_hi_inclusive: watermark.checkpoint_hi_inclusive,
+                    checkpoint_hi: watermark.checkpoint_hi_inclusive + 1,
                     tx_hi: 0,
                     timestamp_ms_hi_inclusive: 0,
                 }))
@@ -265,7 +265,7 @@ impl MigrationStore {
         Ok(self
             .committer_watermark(pipeline)
             .await?
-            .map(|w| w.checkpoint_hi_inclusive))
+            .map(|w| w.checkpoint_hi))
     }
 
     /// Update watermark for a single pipeline after successful file upload.
@@ -279,9 +279,12 @@ impl MigrationStore {
         &self,
         pipeline: &str,
         epoch_hi_inclusive: u64,
-        checkpoint_hi_inclusive: u64,
+        checkpoint_hi: u64,
     ) -> std::result::Result<(), WatermarkUpdateError> {
         let path = migration_watermark_path(pipeline, &self.migration_id);
+        let checkpoint_hi_inclusive = checkpoint_hi
+            .checked_sub(1)
+            .unwrap_or_else(|| panic!("MigrationWatermark checkpoint_hi underflow pipeline={pipeline} checkpoint_hi={checkpoint_hi} epoch_hi_inclusive={epoch_hi_inclusive}"));
         let json = serde_json::to_vec(&MigrationWatermark {
             checkpoint_hi_inclusive,
             epoch_hi_inclusive,
@@ -330,7 +333,7 @@ impl MigrationStore {
             .unwrap()
             .insert(pipeline.to_string(), (result.e_tag, result.version));
 
-        tracing::debug!(
+        debug!(
             pipeline,
             migration_id = self.migration_id,
             checkpoint = checkpoint_hi_inclusive,
@@ -413,11 +416,11 @@ impl MigrationStore {
         // the boundary detection above.
         if let Some(first) = pending_batch.first_checkpoint()
             && let Some(entry) = ranges.find_containing(first)
-            && watermark.checkpoint_hi_inclusive >= entry.end - 1
+            && watermark.checkpoint_hi >= entry.end
         {
             debug!(
                 pipeline,
-                watermark_cp = watermark.checkpoint_hi_inclusive,
+                watermark_cp = watermark.checkpoint_hi,
                 file_start = entry.start,
                 file_end = entry.end,
                 "File complete per watermark - completing batch"
@@ -737,7 +740,7 @@ mod tests {
         assert!(watermark.is_some());
         let watermark = watermark.unwrap();
         assert_eq!(watermark.epoch_hi_inclusive, 5);
-        assert_eq!(watermark.checkpoint_hi_inclusive, 500);
+        assert_eq!(watermark.checkpoint_hi, 500);
     }
 
     #[test]

--- a/crates/sui-analytics-indexer/src/store/mod.rs
+++ b/crates/sui-analytics-indexer/src/store/mod.rs
@@ -221,14 +221,12 @@ impl StoreMode {
         &self,
         pipeline: &str,
         epoch: u64,
-        checkpoint_hi_inclusive: u64,
+        checkpoint_hi: u64,
     ) -> Result<(), WatermarkUpdateError> {
         match self {
             StoreMode::Live(_) => Ok(()),
             StoreMode::Migration(store) => {
-                store
-                    .update_watermark(pipeline, epoch, checkpoint_hi_inclusive)
-                    .await
+                store.update_watermark(pipeline, epoch, checkpoint_hi).await
             }
         }
     }
@@ -642,7 +640,7 @@ impl Connection for AnalyticsConnection<'_> {
                 Ok(self
                     .committer_watermark(pipeline_task)
                     .await?
-                    .map(|w| w.checkpoint_hi_inclusive))
+                    .map(|w| w.checkpoint_hi))
             }
             StoreMode::Migration(store) => {
                 let output_prefix = self.pipeline_config(pipeline_task).output_prefix();

--- a/crates/sui-analytics-indexer/src/store/uploader.rs
+++ b/crates/sui-analytics-indexer/src/store/uploader.rs
@@ -274,7 +274,7 @@ struct SequentialUploader {
     last_watermark_update: Option<std::time::Instant>,
     /// Minimum interval between watermark writes
     watermark_update_interval: Duration,
-    /// Latest uploaded watermark (epoch, checkpoint_hi_inclusive).
+    /// Latest uploaded watermark (epoch, checkpoint_hi).
     latest_watermark: Option<(EpochId, u64)>,
 }
 
@@ -351,7 +351,7 @@ impl SequentialUploader {
                 .await
             {
                 Ok(()) => {
-                    let checkpoint_hi = file.checkpoint_range.end - 1;
+                    let checkpoint_hi = file.checkpoint_range.end;
 
                     record_file_metrics(&self.metrics, &self.pipeline_name, file.bytes.len());
                     self.metrics

--- a/crates/sui-analytics-indexer/tests/e2e_tests.rs
+++ b/crates/sui-analytics-indexer/tests/e2e_tests.rs
@@ -1217,8 +1217,9 @@ async fn test_migration_resume_after_crash() {
         .await
         .expect("Expected watermark after Phase 1");
     assert_eq!(
-        watermark_phase1.checkpoint_hi_inclusive, epoch_0_last,
-        "Phase 1 watermark should be at epoch_0_last"
+        watermark_phase1.checkpoint_hi,
+        epoch_0_last + 1,
+        "Phase 1 watermark should be at epoch_0_last + 1"
     );
     assert_eq!(
         watermark_phase1.epoch_hi_inclusive, 0,
@@ -1243,8 +1244,9 @@ async fn test_migration_resume_after_crash() {
         .await
         .expect("Expected watermark after Phase 2");
     assert_eq!(
-        watermark_phase2.checkpoint_hi_inclusive, last_seq,
-        "Phase 2 watermark should be at last_seq"
+        watermark_phase2.checkpoint_hi,
+        last_seq + 1,
+        "Phase 2 watermark should be at last_seq + 1"
     );
     assert_eq!(
         watermark_phase2.epoch_hi_inclusive, 1,
@@ -1546,7 +1548,8 @@ async fn test_migration_retry_after_partial_failure() {
     );
     let watermark = watermark_final.unwrap();
     assert_eq!(
-        watermark.checkpoint_hi_inclusive, last_seq,
+        watermark.checkpoint_hi,
+        last_seq + 1,
         "Watermark should be at last checkpoint"
     );
     assert_eq!(
@@ -2187,7 +2190,7 @@ async fn test_migration_snap_to_file_start() {
         .read_migration_watermark("snap-test", "checkpoints")
         .await
         .expect("Expected watermark");
-    assert_eq!(watermark.checkpoint_hi_inclusive, last_seq);
+    assert_eq!(watermark.checkpoint_hi, last_seq + 1);
 }
 
 /// Test that migration mode snaps first_checkpoint forward when in a gap between files.
@@ -2256,7 +2259,7 @@ async fn test_migration_snap_forward_in_gap() {
         .read_migration_watermark("gap-test", "checkpoints")
         .await
         .expect("Expected watermark");
-    assert_eq!(watermark.checkpoint_hi_inclusive, last_seq);
+    assert_eq!(watermark.checkpoint_hi, last_seq + 1);
     assert_eq!(
         watermark.epoch_hi_inclusive, 1,
         "Watermark should be at epoch 1"
@@ -2409,11 +2412,13 @@ async fn test_multi_pipeline_different_file_boundaries() {
         .expect("Expected transaction watermark");
 
     assert_eq!(
-        checkpoint_watermark.checkpoint_hi_inclusive, last_seq,
+        checkpoint_watermark.checkpoint_hi,
+        last_seq + 1,
         "Checkpoint pipeline watermark should be at last checkpoint"
     );
     assert_eq!(
-        transaction_watermark.checkpoint_hi_inclusive, last_seq,
+        transaction_watermark.checkpoint_hi,
+        last_seq + 1,
         "Transaction pipeline watermark should be at last checkpoint"
     );
 
@@ -2486,7 +2491,7 @@ async fn test_migration_first_checkpoint_zero() {
         .read_migration_watermark("zero-start-test", "checkpoints")
         .await
         .expect("Expected watermark");
-    assert_eq!(watermark.checkpoint_hi_inclusive, last_seq);
+    assert_eq!(watermark.checkpoint_hi, last_seq + 1);
     assert_eq!(watermark.epoch_hi_inclusive, 0);
 
     // Verify all rows present
@@ -2527,7 +2532,7 @@ async fn test_migration_no_first_checkpoint() {
         .read_migration_watermark("no-start-test", "checkpoints")
         .await
         .expect("Expected watermark");
-    assert_eq!(watermark.checkpoint_hi_inclusive, last_seq);
+    assert_eq!(watermark.checkpoint_hi, last_seq + 1);
 
     // Verify all rows present
     let files = harness.list_files("checkpoints/epoch_0").await;

--- a/crates/sui-indexer-alt-consistent-store/src/db/map.rs
+++ b/crates/sui-indexer-alt-consistent-store/src/db/map.rs
@@ -206,7 +206,7 @@ mod tests {
 
         let db = Arc::new(Db::open(d.path().join("db"), opts, 4, cfs).unwrap());
         let map: DbMap<u64, u64> = DbMap::new(db.clone(), "test");
-        db.take_snapshot(wm(0));
+        db.take_snapshot(wm(1));
 
         // Access succeeds at first, but will start to fail after the column family is dropped.
         assert!(map.get(0, 42).unwrap().is_none());
@@ -234,14 +234,14 @@ mod tests {
         let mut batch = rocksdb::WriteBatch::default();
         map.insert(42, 43, &mut batch).unwrap();
         map.insert(44, 45, &mut batch).unwrap();
-        db.write("batch", wm(0), batch).unwrap();
-        db.take_snapshot(wm(0));
+        db.write("batch", wm(1), batch).unwrap();
+        db.take_snapshot(wm(1));
 
         let mut batch = rocksdb::WriteBatch::default();
         map.remove(42, &mut batch).unwrap();
         map.insert(43, 42, &mut batch).unwrap();
-        db.write("batch", wm(1), batch).unwrap();
-        db.take_snapshot(wm(1));
+        db.write("batch", wm(2), batch).unwrap();
+        db.take_snapshot(wm(2));
 
         // Point look-ups
         assert_eq!(map.get(0, 42).unwrap(), Some(43));
@@ -333,21 +333,21 @@ mod tests {
         // Successfully perform a merge to counts.
         let mut batch = rocksdb::WriteBatch::default();
         counts.merge(42, 1, &mut batch).unwrap();
-        db.write("counts", wm(0), batch).unwrap();
-        db.take_snapshot(wm(0));
+        db.write("counts", wm(1), batch).unwrap();
+        db.take_snapshot(wm(1));
 
         // Merges allow for the accumulation of values.
         let mut batch = rocksdb::WriteBatch::default();
         counts.merge(42, 2, &mut batch).unwrap();
-        db.write("counts", wm(1), batch).unwrap();
-        db.take_snapshot(wm(1));
+        db.write("counts", wm(2), batch).unwrap();
+        db.take_snapshot(wm(2));
 
         // A single batch can include multiple merges for the same key.
         let mut batch = rocksdb::WriteBatch::default();
         counts.merge(42, 3, &mut batch).unwrap();
         counts.merge(42, 4, &mut batch).unwrap();
-        db.write("counts", wm(2), batch).unwrap();
-        db.take_snapshot(wm(2));
+        db.write("counts", wm(3), batch).unwrap();
+        db.take_snapshot(wm(3));
 
         assert_eq!(counts.get(0, 42).unwrap(), Some(1));
         assert_eq!(counts.get(1, 42).unwrap(), Some(3));
@@ -399,8 +399,8 @@ mod tests {
         map.insert(0x0000_0003, 30, &mut batch).unwrap();
         map.insert(0xffff_0004, 40, &mut batch).unwrap();
         map.insert(0x0000_0005, 50, &mut batch).unwrap();
-        db.write("batch", wm(0), batch).unwrap();
-        db.take_snapshot(wm(0));
+        db.write("batch", wm(1), batch).unwrap();
+        db.take_snapshot(wm(1));
 
         assert_eq!(
             map.prefix(0, &0x0000u16)

--- a/crates/sui-indexer-alt-consistent-store/src/db/mod.rs
+++ b/crates/sui-indexer-alt-consistent-store/src/db/mod.rs
@@ -80,7 +80,7 @@ pub(crate) struct Db(RwLock<Inner>);
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct Watermark {
     pub epoch_hi_inclusive: u64,
-    pub checkpoint_hi_inclusive: u64,
+    pub checkpoint_hi: u64,
     pub tx_hi: u64,
     pub timestamp_ms_hi_inclusive: u64,
 }
@@ -319,7 +319,10 @@ impl Db {
     pub(crate) fn take_snapshot(&self, watermark: Watermark) {
         self.0.write().expect("poisoned").with_mut(|f| {
             f.snapshots.insert(
-                watermark.checkpoint_hi_inclusive,
+                watermark
+                    .checkpoint_hi
+                    .checked_sub(1)
+                    .unwrap_or_else(|| panic!("Watermark checkpoint_hi underflow {watermark:?}")),
                 (Arc::new(f.db.snapshot()), watermark),
             );
 
@@ -753,8 +756,7 @@ unsafe impl marker::Send for Db {}
 /// Watermarks are identified by their checkpoint, so comparison can be limited to them.
 impl Ord for Watermark {
     fn cmp(&self, other: &Self) -> cmp::Ordering {
-        self.checkpoint_hi_inclusive
-            .cmp(&other.checkpoint_hi_inclusive)
+        self.checkpoint_hi.cmp(&other.checkpoint_hi)
     }
 }
 
@@ -768,7 +770,7 @@ impl From<Watermark> for CommitterWatermark {
     fn from(w: Watermark) -> Self {
         Self {
             epoch_hi_inclusive: w.epoch_hi_inclusive,
-            checkpoint_hi_inclusive: w.checkpoint_hi_inclusive,
+            checkpoint_hi: w.checkpoint_hi,
             tx_hi: w.tx_hi,
             timestamp_ms_hi_inclusive: w.timestamp_ms_hi_inclusive,
         }
@@ -779,7 +781,7 @@ impl From<CommitterWatermark> for Watermark {
     fn from(w: CommitterWatermark) -> Self {
         Self {
             epoch_hi_inclusive: w.epoch_hi_inclusive,
-            checkpoint_hi_inclusive: w.checkpoint_hi_inclusive,
+            checkpoint_hi: w.checkpoint_hi,
             tx_hi: w.tx_hi,
             timestamp_ms_hi_inclusive: w.timestamp_ms_hi_inclusive,
         }
@@ -841,10 +843,10 @@ pub(crate) mod tests {
         opts
     }
 
-    pub(crate) fn wm(cp: u64) -> Watermark {
+    pub(crate) fn wm(checkpoint_hi: u64) -> Watermark {
         Watermark {
             epoch_hi_inclusive: 0,
-            checkpoint_hi_inclusive: cp,
+            checkpoint_hi,
             tx_hi: 0,
             timestamp_ms_hi_inclusive: 0,
         }
@@ -883,7 +885,7 @@ pub(crate) mod tests {
         let db = Db::open(d.path().join("db"), opts(), 4, cfs()).unwrap();
         let cf = db.cf("test").unwrap();
 
-        db.take_snapshot(wm(0));
+        db.take_snapshot(wm(1));
         assert!(db.get::<u64, u64>(0, &cf, &42u64).unwrap().is_none());
     }
 
@@ -893,7 +895,7 @@ pub(crate) mod tests {
         let db = Db::open(d.path().join("db"), opts(), 4, cfs()).unwrap();
         let cf = db.cf("test").unwrap();
 
-        for i in 0..10 {
+        for i in 1..11 {
             db.take_snapshot(wm(i));
         }
 
@@ -919,7 +921,7 @@ pub(crate) mod tests {
         let cf = db.cf("test").unwrap();
 
         // Register an empty snapshot.
-        db.take_snapshot(wm(0));
+        db.take_snapshot(wm(1));
 
         let k = 42u64;
         let v0 = 43u64;
@@ -928,7 +930,7 @@ pub(crate) mod tests {
         // Write a value.
         let mut batch = rocksdb::WriteBatch::default();
         batch.put_cf(&cf, key::encode(&k), bcs::to_bytes(&v0).unwrap());
-        db.write("test", wm(1), batch).unwrap();
+        db.write("test", wm(2), batch).unwrap();
 
         {
             // The snapshot that the write would be in has not been taken yet -- attempting to read it
@@ -948,7 +950,7 @@ pub(crate) mod tests {
 
         {
             // Once the snapshot has been taken, the write is visible.
-            db.take_snapshot(wm(1));
+            db.take_snapshot(wm(2));
             assert_eq!(db.get(1, &cf, &k).unwrap(), Some(v0));
         }
 
@@ -959,8 +961,8 @@ pub(crate) mod tests {
 
         let mut batch = rocksdb::WriteBatch::default();
         batch.put_cf(&cf, key::encode(&k), bcs::to_bytes(&v1).unwrap());
-        db.write("test", wm(2), batch).unwrap();
-        db.take_snapshot(wm(2));
+        db.write("test", wm(3), batch).unwrap();
+        db.take_snapshot(wm(3));
 
         {
             // A new value has been written, and a snapshot taken, we can now read the value at
@@ -986,8 +988,8 @@ pub(crate) mod tests {
         batch.put_cf(&cf, key::encode(&k0), bcs::to_bytes(&v0).unwrap());
         batch.put_cf(&cf, key::encode(&k2), bcs::to_bytes(&v2).unwrap());
         batch.put_cf(&cf, key::encode(&k3), bcs::to_bytes(&v3).unwrap());
-        db.write("test", wm(0), batch).unwrap();
-        db.take_snapshot(wm(0));
+        db.write("test", wm(1), batch).unwrap();
+        db.take_snapshot(wm(1));
 
         let mut res = db
             .multi_get(0, &cf, [&k0, &k1, &k2, &k3])
@@ -1008,8 +1010,8 @@ pub(crate) mod tests {
         let mut batch = rocksdb::WriteBatch::default();
         batch.put_cf(&cf, key::encode(&k1), bcs::to_bytes(&v1).unwrap());
         batch.put_cf(&cf, key::encode(&k3), bcs::to_bytes(&v3).unwrap());
-        db.write("test", wm(1), batch).unwrap();
-        db.take_snapshot(wm(1));
+        db.write("test", wm(2), batch).unwrap();
+        db.take_snapshot(wm(2));
 
         let mut res = db
             .multi_get(1, &cf, [&k0, &k1, &k2, &k3])
@@ -1083,13 +1085,13 @@ pub(crate) mod tests {
 
             let mut batch = rocksdb::WriteBatch::default();
             batch.put_cf(&cf, key::encode(&42u64), bcs::to_bytes(&43u64).unwrap());
-            db.write("test", wm(1), batch).unwrap();
+            db.write("test", wm(2), batch).unwrap();
 
             // Check that the watermark was written.
-            assert_eq!(db.commit_watermark("test").unwrap(), Some(wm(1)));
+            assert_eq!(db.commit_watermark("test").unwrap(), Some(wm(2)));
 
             // ...and once there is a snapshot, the data can be read.
-            db.take_snapshot(wm(1));
+            db.take_snapshot(wm(2));
             assert_eq!(db.get(1, &cf, &42u64).unwrap(), Some(43u64));
         }
 
@@ -1099,7 +1101,7 @@ pub(crate) mod tests {
             let cf = db.cf("test").unwrap();
 
             // The `watermark` persists.
-            assert_eq!(db.commit_watermark("test").unwrap(), Some(wm(1)));
+            assert_eq!(db.commit_watermark("test").unwrap(), Some(wm(2)));
 
             // The snapshots do not, however, so reads will fail.
             let err = db.get::<u64, u64>(1, &cf, &42u64).unwrap_err();
@@ -1109,7 +1111,7 @@ pub(crate) mod tests {
             );
 
             // But once the snapshot has been taken, the data is still there.
-            db.take_snapshot(wm(1));
+            db.take_snapshot(wm(2));
             assert_eq!(db.get(1, &cf, &42u64).unwrap(), Some(43u64));
         }
     }
@@ -1128,8 +1130,8 @@ pub(crate) mod tests {
             batch.put_cf(&cf, key::encode(&i), bcs::to_bytes(&(i + 1)).unwrap());
         }
 
-        db.write("test", wm(0), batch).unwrap();
-        db.take_snapshot(wm(0));
+        db.write("test", wm(1), batch).unwrap();
+        db.take_snapshot(wm(1));
 
         let actual: Result<Vec<(u64, u64)>, Error> =
             db.iter(0, &cf, (U::<u64>, U)).unwrap().collect();
@@ -1261,8 +1263,8 @@ pub(crate) mod tests {
             batch.put_cf(&cf, key::encode(&i), bcs::to_bytes(&(i + 1)).unwrap());
         }
 
-        db.write("test", wm(0), batch).unwrap();
-        db.take_snapshot(wm(0));
+        db.write("test", wm(1), batch).unwrap();
+        db.take_snapshot(wm(1));
 
         let mut iter: iter::FwdIter<u64, u64> = db.iter(0, &cf, (U::<u64>, U)).unwrap();
         iter.seek(key::encode(&4u64));
@@ -1306,8 +1308,8 @@ pub(crate) mod tests {
             batch.put_cf(&cf, key::encode(&i), bcs::to_bytes(&(i + 1)).unwrap());
         }
 
-        db.write("test", wm(0), batch).unwrap();
-        db.take_snapshot(wm(0));
+        db.write("test", wm(1), batch).unwrap();
+        db.take_snapshot(wm(1));
 
         // Create an iterator from the first snapshot.
         let mut i0: iter::FwdIter<u64, u64> = db.iter(0, &cf, (U::<u64>, U)).unwrap();
@@ -1322,8 +1324,8 @@ pub(crate) mod tests {
             batch.put_cf(&cf, key::encode(&(i + 1)), bcs::to_bytes(&i).unwrap());
         }
 
-        db.write("test", wm(1), batch).unwrap();
-        db.take_snapshot(wm(1));
+        db.write("test", wm(2), batch).unwrap();
+        db.take_snapshot(wm(2));
 
         // Create an iterator from the next snapshot.
         let mut i1: iter::FwdIter<u64, u64> = db.iter(1, &cf, (U::<u64>, U)).unwrap();
@@ -1342,8 +1344,8 @@ pub(crate) mod tests {
             batch.delete_cf(&cf, key::encode(&i));
         }
 
-        db.write("test", wm(2), batch).unwrap();
-        db.take_snapshot(wm(2));
+        db.write("test", wm(3), batch).unwrap();
+        db.take_snapshot(wm(3));
 
         // Finish iterating through the second iterator.
         let kv1: Result<Vec<(u64, u64)>, Error> = (&mut i1).collect();
@@ -1386,14 +1388,14 @@ pub(crate) mod tests {
             batch.put_cf(&cf, key::encode(&i), bcs::to_bytes(&(i + 1)).unwrap());
         }
 
-        db.write("test", wm(0), batch).unwrap();
-        db.take_snapshot(wm(0));
+        db.write("test", wm(1), batch).unwrap();
+        db.take_snapshot(wm(1));
 
         // Create an iterator from the first snapshot.
         let iter: iter::FwdIter<u64, u64> = db.iter(0, &cf, (U::<u64>, U)).unwrap();
 
         // Create more snapshots...
-        for i in 1..5 {
+        for i in 2..6 {
             db.take_snapshot(wm(i));
         }
 
@@ -1425,8 +1427,8 @@ pub(crate) mod tests {
             batch.put_cf(&cf, key::encode(&(i + 1)), bcs::to_bytes(&i).unwrap());
         }
 
-        db.write("test", wm(0), batch).unwrap();
-        db.take_snapshot(wm(0));
+        db.write("test", wm(1), batch).unwrap();
+        db.take_snapshot(wm(1));
 
         let actual: Result<Vec<(u64, u64)>, Error> =
             db.iter_rev(0, &cf, (U::<u64>, U)).unwrap().collect();
@@ -1563,8 +1565,8 @@ pub(crate) mod tests {
             batch.put_cf(&cf, key::encode(&(i + 1)), bcs::to_bytes(&i).unwrap());
         }
 
-        db.write("test", wm(0), batch).unwrap();
-        db.take_snapshot(wm(0));
+        db.write("test", wm(1), batch).unwrap();
+        db.take_snapshot(wm(1));
 
         let mut iter: iter::RevIter<u64, u64> = db.iter_rev(0, &cf, (U::<u64>, U)).unwrap();
         iter.seek(key::encode(&5u64));
@@ -1735,8 +1737,8 @@ pub(crate) mod tests {
         for i in (0u64..10).step_by(2) {
             batch.put_cf(&cf, key::encode(&i), bcs::to_bytes(&(i + 1)).unwrap());
         }
-        db.write("test", wm(0), batch).unwrap();
-        db.take_snapshot(wm(0));
+        db.write("test", wm(1), batch).unwrap();
+        db.take_snapshot(wm(1));
 
         let mut iter: iter::FwdIter<u64, u64> = db.iter(0, &cf, (U::<u64>, U)).unwrap();
         // let mut iter = db.iter(0, &cf, (U::<u64>, U::<u64>)).unwrap();
@@ -1768,8 +1770,8 @@ pub(crate) mod tests {
         for i in (1u64..10).step_by(2) {
             batch.put_cf(&cf, key::encode(&i), bcs::to_bytes(&(i + 1)).unwrap());
         }
-        db.write("test", wm(0), batch).unwrap();
-        db.take_snapshot(wm(0));
+        db.write("test", wm(1), batch).unwrap();
+        db.take_snapshot(wm(1));
 
         // Create iterator, seek to start
         let mut iter: iter::RevIter<u64, u64> = db.iter_rev(0, &cf, (U::<u64>, U)).unwrap();

--- a/crates/sui-indexer-alt-consistent-store/src/restore/formal_snapshot.rs
+++ b/crates/sui-indexer-alt-consistent-store/src/restore/formal_snapshot.rs
@@ -178,7 +178,7 @@ impl FormalSnapshot {
 
         let watermark = Watermark {
             epoch_hi_inclusive: epoch,
-            checkpoint_hi_inclusive: summary.sequence_number,
+            checkpoint_hi: summary.sequence_number + 1,
             tx_hi: summary.network_total_transactions,
             timestamp_ms_hi_inclusive: summary.timestamp_ms,
         };

--- a/crates/sui-indexer-alt-consistent-store/src/rpc/consistent_service/available_range.rs
+++ b/crates/sui-indexer-alt-consistent-store/src/rpc/consistent_service/available_range.rs
@@ -12,9 +12,19 @@ pub(super) fn available_range(
     grpc::AvailableRangeRequest {}: grpc::AvailableRangeRequest,
 ) -> Result<grpc::AvailableRangeResponse, RpcError> {
     let range = state.store.db().snapshot_range(checkpoint);
+    let min_checkpoint = range.as_ref().map(|r| {
+        r.start().checkpoint_hi.checked_sub(1).unwrap_or_else(|| {
+            panic!("Snapshot range start checkpoint_hi underflow checkpoint={checkpoint}")
+        })
+    });
+    let max_checkpoint = range.as_ref().map(|r| {
+        r.end().checkpoint_hi.checked_sub(1).unwrap_or_else(|| {
+            panic!("Snapshot range end checkpoint_hi underflow checkpoint={checkpoint}")
+        })
+    });
     Ok(grpc::AvailableRangeResponse {
-        min_checkpoint: range.as_ref().map(|r| r.start().checkpoint_hi_inclusive),
-        max_checkpoint: range.as_ref().map(|r| r.end().checkpoint_hi_inclusive),
+        min_checkpoint,
+        max_checkpoint,
         max_epoch: range.as_ref().map(|r| r.end().epoch_hi_inclusive),
         total_transactions: range.as_ref().map(|r| r.end().tx_hi),
         max_timestamp_ms: range.as_ref().map(|r| r.end().timestamp_ms_hi_inclusive),

--- a/crates/sui-indexer-alt-consistent-store/src/rpc/pagination.rs
+++ b/crates/sui-indexer-alt-consistent-store/src/rpc/pagination.rs
@@ -361,8 +361,8 @@ mod tests {
         map.insert(0x0000_0005, 50, &mut batch).unwrap();
         map.insert(0x0000_0007, 70, &mut batch).unwrap();
         map.insert(0x0000_0009, 90, &mut batch).unwrap();
-        db.write("batch", wm(0), batch).unwrap();
-        db.take_snapshot(wm(0));
+        db.write("batch", wm(1), batch).unwrap();
+        db.take_snapshot(wm(1));
 
         let mut batch = rocksdb::WriteBatch::default();
         map.insert(0x0000_0000, 0, &mut batch).unwrap();
@@ -372,8 +372,8 @@ mod tests {
         map.insert(0x0000_0008, 80, &mut batch).unwrap();
         map.insert(0x0001_0000, 1, &mut batch).unwrap();
         map.insert(0x0001_0002, 21, &mut batch).unwrap();
-        db.write("batch", wm(1), batch).unwrap();
-        db.take_snapshot(wm(1));
+        db.write("batch", wm(2), batch).unwrap();
+        db.take_snapshot(wm(2));
 
         (d, map)
     }
@@ -786,8 +786,8 @@ mod tests {
         map.insert((0, 2, 0x0003), 30, &mut batch).unwrap();
         map.insert((0, 2, 0x0004), 40, &mut batch).unwrap();
         map.insert((0, 3, 0x0005), 50, &mut batch).unwrap();
-        db.write("batch", wm(0), batch).unwrap();
-        db.take_snapshot(wm(0));
+        db.write("batch", wm(1), batch).unwrap();
+        db.take_snapshot(wm(1));
         // First page: limit 2
         let resp = Page::from_request(&config(), &[], &[], 2, End::Front)
             .paginate_exclude::<_, _, _, _, Infallible>(&map, 0, &0u8, &2u8)
@@ -839,8 +839,8 @@ mod tests {
         map.insert((0, 2, 0x0003), 30, &mut batch).unwrap();
         map.insert((0, 2, 0x0004), 40, &mut batch).unwrap();
         map.insert((0, 3, 0x0005), 50, &mut batch).unwrap();
-        db.write("batch", wm(0), batch).unwrap();
-        db.take_snapshot(wm(0));
+        db.write("batch", wm(1), batch).unwrap();
+        db.take_snapshot(wm(1));
 
         // Page 1 from back: gets last 2 non-excluded results
         let resp = Page::from_request(&config(), &[], &[], 2, End::Back)
@@ -893,8 +893,8 @@ mod tests {
         map.insert((0, 1, 0x0002), 20, &mut batch).unwrap();
         map.insert((0, 2, 0x0003), 30, &mut batch).unwrap(); // excluded
         map.insert((0, 2, 0x0004), 40, &mut batch).unwrap(); // excluded
-        db.write("batch", wm(0), batch).unwrap();
-        db.take_snapshot(wm(0));
+        db.write("batch", wm(1), batch).unwrap();
+        db.take_snapshot(wm(1));
 
         // Request exactly 2 - should get both non-excluded, has_next should be FALSE
         let resp = Page::from_request(&config(), &[], &[], 2, End::Front)
@@ -932,8 +932,8 @@ mod tests {
         map.insert((0, 1, 0x0002), 20, &mut batch).unwrap(); // excluded
         map.insert((0, 2, 0x0003), 30, &mut batch).unwrap();
         map.insert((0, 2, 0x0004), 40, &mut batch).unwrap();
-        db.write("batch", wm(0), batch).unwrap();
-        db.take_snapshot(wm(0));
+        db.write("batch", wm(1), batch).unwrap();
+        db.take_snapshot(wm(1));
 
         // Request exactly 2 from back - should get both non-excluded, has_prev should be FALSE
         let resp = Page::from_request(&config(), &[], &[], 2, End::Back)

--- a/crates/sui-indexer-alt-consistent-store/src/rpc/state.rs
+++ b/crates/sui-indexer-alt-consistent-store/src/rpc/state.rs
@@ -62,7 +62,11 @@ impl State {
             .or_else(|| metadata.get(LEGACY_CHECKPOINT_METADATA))
         else {
             // If a checkpoint hasn't been supplied default to the latest snapshot.
-            return Ok(snapshot_range.end().checkpoint_hi_inclusive);
+            let watermark = snapshot_range.end();
+            return Ok(watermark
+                .checkpoint_hi
+                .checked_sub(1)
+                .unwrap_or_else(|| panic!("Range end checkpoint_hi underflow {watermark:?}")));
         };
 
         let checkpoint = checkpoint
@@ -71,8 +75,8 @@ impl State {
             .parse()
             .map_err(|_| Error::BadCheckpoint(checkpoint.clone()))?;
 
-        if checkpoint < snapshot_range.start().checkpoint_hi_inclusive
-            || checkpoint > snapshot_range.end().checkpoint_hi_inclusive
+        if checkpoint + 1 < snapshot_range.start().checkpoint_hi
+            || checkpoint >= snapshot_range.end().checkpoint_hi
         {
             return Err(RpcError::NotInRange(checkpoint));
         }
@@ -87,7 +91,8 @@ impl State {
     ) -> Result<tonic::Response<T>, tonic::Status> {
         let mut resp = result.map(tonic::Response::new);
 
-        let Some(range) = self.store.db().snapshot_range(u64::MAX) else {
+        let cp_hi_inclusive = u64::MAX;
+        let Some(range) = self.store.db().snapshot_range(cp_hi_inclusive) else {
             return resp;
         };
 
@@ -95,11 +100,21 @@ impl State {
             .as_mut()
             .map_or_else(|s| s.metadata_mut(), |r| r.metadata_mut());
 
-        if let Ok(min) = range.start().checkpoint_hi_inclusive.to_string().parse() {
+        let start = range
+            .start()
+            .checkpoint_hi
+            .checked_sub(1)
+            .unwrap_or_else(|| {
+                panic!("Range start checkpoint_hi underflow cp_hi_inclusive={cp_hi_inclusive}")
+            });
+        if let Ok(min) = start.to_string().parse() {
             meta.insert(LOWEST_AVAILABLE_CHECKPOINT_METADATA, min);
         }
 
-        if let Ok(max) = range.end().checkpoint_hi_inclusive.to_string().parse() {
+        let end = range.end().checkpoint_hi.checked_sub(1).unwrap_or_else(|| {
+            panic!("Range end checkpoint_hi underflow cp_hi_inclusive={cp_hi_inclusive}")
+        });
+        if let Ok(max) = end.to_string().parse() {
             let max: AsciiMetadataValue = max;
             meta.insert(CHECKPOINT_HEIGHT_METADATA, max.clone());
             meta.insert(LEGACY_CHECKPOINT_METADATA, max);

--- a/crates/sui-indexer-alt-consistent-store/src/store/mod.rs
+++ b/crates/sui-indexer-alt-consistent-store/src/store/mod.rs
@@ -169,7 +169,7 @@ impl<S: Send + Sync> store::Connection for Connection<'_, S> {
         Ok(self
             .committer_watermark(pipeline_task)
             .await?
-            .map(|w| w.checkpoint_hi_inclusive))
+            .map(|w| w.checkpoint_hi))
     }
 
     async fn committer_watermark(
@@ -282,8 +282,8 @@ mod tests {
 
     fn has_range(store: &Store<TestSchema>, lo: Option<u64>, hi: Option<u64>) -> bool {
         store.db().snapshot_range(u64::MAX).is_some_and(|s| {
-            lo.is_none_or(|lo| lo == s.start().checkpoint_hi_inclusive)
-                && hi.is_none_or(|hi| hi == s.end().checkpoint_hi_inclusive)
+            lo.is_none_or(|lo| lo == s.start().checkpoint_hi)
+                && hi.is_none_or(|hi| hi == s.end().checkpoint_hi)
         })
     }
 
@@ -300,8 +300,11 @@ mod tests {
             .transaction(move |c| {
                 async move {
                     mutator(c.store.schema(), &mut c.batch)?;
-                    c.set_committer_watermark(pipeline, CommitterWatermark::new_for_testing(cp))
-                        .await?;
+                    c.set_committer_watermark(
+                        pipeline,
+                        CommitterWatermark::new_for_testing(cp + 1),
+                    )
+                    .await?;
                     Ok(())
                 }
                 .scope_boxed()
@@ -357,7 +360,7 @@ mod tests {
         .await
         .unwrap();
 
-        wait_until(|| async { has_range(&store, None, Some(0)) })
+        wait_until(|| async { has_range(&store, None, Some(1)) })
             .await
             .unwrap();
 
@@ -401,7 +404,7 @@ mod tests {
         .await
         .unwrap();
 
-        wait_until(|| async { has_range(&store, None, Some(0)) })
+        wait_until(|| async { has_range(&store, None, Some(1)) })
             .await
             .unwrap();
 
@@ -432,7 +435,7 @@ mod tests {
 
             let mut batch = rocksdb::WriteBatch::default();
             schema.b.insert(42, "x".to_owned(), &mut batch).unwrap();
-            db.write("b", CommitterWatermark::new_for_testing(0).into(), batch)
+            db.write("b", CommitterWatermark::new_for_testing(1).into(), batch)
                 .unwrap();
         }
 
@@ -449,7 +452,7 @@ mod tests {
 
         // When there is existing data, the synchronizer will take a snapshot to make it available
         // before the store sees any writes.
-        wait_until(|| async { has_range(&store, None, Some(0)) })
+        wait_until(|| async { has_range(&store, None, Some(1)) })
             .await
             .unwrap();
     }
@@ -476,12 +479,12 @@ mod tests {
 
             let mut batch = rocksdb::WriteBatch::default();
             schema.a.insert("x".to_owned(), 42, &mut batch).unwrap();
-            db.write("a", CommitterWatermark::new_for_testing(0).into(), batch)
+            db.write("a", CommitterWatermark::new_for_testing(1).into(), batch)
                 .unwrap();
 
             let mut batch = rocksdb::WriteBatch::default();
             schema.b.insert(42, "x".to_owned(), &mut batch).unwrap();
-            db.write("b", CommitterWatermark::new_for_testing(0).into(), batch)
+            db.write("b", CommitterWatermark::new_for_testing(1).into(), batch)
                 .unwrap();
         }
 
@@ -499,7 +502,7 @@ mod tests {
 
         // When there is existing data, the synchronizer will take a snapshot to make it available
         // before the store sees any writes.
-        wait_until(|| async { has_range(&store, None, Some(0)) })
+        wait_until(|| async { has_range(&store, None, Some(1)) })
             .await
             .unwrap();
     }
@@ -526,7 +529,7 @@ mod tests {
 
             let mut batch = rocksdb::WriteBatch::default();
             schema.b.insert(42, "x".to_owned(), &mut batch).unwrap();
-            db.write("b", CommitterWatermark::new_for_testing(0).into(), batch)
+            db.write("b", CommitterWatermark::new_for_testing(1).into(), batch)
                 .unwrap();
         }
 
@@ -570,7 +573,7 @@ mod tests {
 
         // After the other pipeline was caught up, the synchronizer will take the snapshot, but it
         // will not yet make the subsequent write to the other pipeline available.
-        wait_until(|| async { has_range(&store, None, Some(0)) })
+        wait_until(|| async { has_range(&store, None, Some(1)) })
             .await
             .unwrap();
 
@@ -580,7 +583,7 @@ mod tests {
 
         // Catch up the first pipeline without writing any further data.
         write(&store, "a", 1, |_, _| Ok(())).await.unwrap();
-        wait_until(|| async { has_range(&store, None, Some(1)) })
+        wait_until(|| async { has_range(&store, None, Some(2)) })
             .await
             .unwrap();
 
@@ -660,7 +663,7 @@ mod tests {
 
         // With the fix, no snapshot is taken until after the first checkpoint is written.
         // The first snapshot will be at checkpoint 100, not 99.
-        wait_until(|| async { has_range(&store, Some(100), Some(100)) })
+        wait_until(|| async { has_range(&store, Some(101), Some(101)) })
             .await
             .unwrap();
 
@@ -696,7 +699,7 @@ mod tests {
         }
 
         // The synchronizer will take a snapshot before every `stride`-th checkpoint.
-        wait_until(|| async { has_range(&store, Some(2), Some(8)) })
+        wait_until(|| async { has_range(&store, Some(3), Some(9)) })
             .await
             .unwrap();
 
@@ -711,16 +714,10 @@ mod tests {
 
         // Querying the snapshot range at the latest checkpoint does the same thing as an unbounded
         // range request.
-        assert_eq!(
-            Some(8),
-            d.snapshot_range(8).map(|r| r.end().checkpoint_hi_inclusive)
-        );
+        assert_eq!(Some(9), d.snapshot_range(8).map(|r| r.end().checkpoint_hi));
 
         // Going one checkpoint back causes the range to drop back by the stride.
-        assert_eq!(
-            Some(5),
-            d.snapshot_range(7).map(|r| r.end().checkpoint_hi_inclusive)
-        );
+        assert_eq!(Some(6), d.snapshot_range(7).map(|r| r.end().checkpoint_hi));
 
         // Going back beyond the first checkpoint results in an empty range.
         assert_eq!(None, d.snapshot_range(1));
@@ -801,9 +798,8 @@ mod tests {
         let db = store.db();
         assert_eq!(db.snapshots(), 1);
         assert_eq!(
-            db.snapshot_range(u64::MAX)
-                .map(|s| s.end().checkpoint_hi_inclusive),
-            Some(0)
+            db.snapshot_range(u64::MAX).map(|s| s.end().checkpoint_hi),
+            Some(1)
         );
         assert_eq!(s.a.get(0, "x".to_owned()).unwrap(), Some(42));
         assert_eq!(s.a.get(0, "y".to_owned()).unwrap(), None);

--- a/crates/sui-indexer-alt-consistent-store/src/store/synchronizer.rs
+++ b/crates/sui-indexer-alt-consistent-store/src/store/synchronizer.rs
@@ -103,7 +103,13 @@ impl Synchronizer {
         let Some(init_checkpoint) = self
             .last_watermarks
             .values()
-            .map(|w| w.map_or(self.first_checkpoint, |w| w.checkpoint_hi_inclusive))
+            .map(|w| {
+                w.map_or(self.first_checkpoint, |w| {
+                    w.checkpoint_hi
+                        .checked_sub(1)
+                        .unwrap_or_else(|| panic!("Watermark checkpoint_hi underflow {w:?}"))
+                })
+            })
             .max()
         else {
             bail!("No pipelines registered with the synchronizer");
@@ -162,7 +168,7 @@ async fn synchronizer(
     loop {
         let next_checkpoint = current_watermark
             .as_ref()
-            .map(|w| w.checkpoint_hi_inclusive + 1)
+            .map(|w| w.checkpoint_hi)
             .unwrap_or(first_checkpoint);
 
         match next_snapshot_checkpoint.cmp(&next_checkpoint) {
@@ -216,7 +222,7 @@ async fn synchronizer(
 
         debug!(pipeline, ?watermark, "Received batch");
         ensure!(
-            watermark.checkpoint_hi_inclusive == next_checkpoint,
+            watermark.checkpoint_hi == next_checkpoint + 1,
             "Out-of-order batch for {pipeline}: expected {next_checkpoint}, got {watermark:?}",
         );
 

--- a/crates/sui-indexer-alt-e2e-tests/src/lib.rs
+++ b/crates/sui-indexer-alt-e2e-tests/src/lib.rs
@@ -222,7 +222,7 @@ impl FullCluster {
             .wait_for_graphql(checkpoint.sequence_number, Duration::from_secs(100));
 
         try_join!(indexer, consistent_store, graphql)
-            .expect("Timed out waiting for indexer and consistent store");
+            .expect("Timed out waiting for indexer, consistent store, graphql");
 
         checkpoint
     }
@@ -460,19 +460,29 @@ impl OffchainCluster {
             .await
             .context("Failed to connect to database")?;
 
-        let latest: HashMap<String, i64> = w::watermarks
-            .select((w::pipeline, w::checkpoint_hi_inclusive))
+        let checkpoint_his: HashMap<String, i64> = w::watermarks
+            .select((w::pipeline, w::checkpoint_hi))
             .filter(w::pipeline.eq_any(&self.pipelines))
+            // When reader_lo and checkpoint_hi are the same value, the
+            // [reader_lo, checkpoint_hi) range is empty.
+            .filter(w::checkpoint_hi.gt(w::reader_lo))
             .load(&mut conn)
             .await?
             .into_iter()
             .collect();
 
-        if latest.len() != self.pipelines.len() {
+        if checkpoint_his.len() != self.pipelines.len() {
             return Ok(None);
         }
 
-        Ok(latest.into_values().min().map(|l| l as u64))
+        // checkpoint_hi is exclusive, so subtract 1 to get the inclusive checkpoint.
+        Ok(checkpoint_his
+            .into_iter()
+            .map(|(pipeline, checkpoint_hi)| u64::try_from(checkpoint_hi)
+                .unwrap_or_else(|e| panic!("Entry checkpoint_hi is negative pipeline={pipeline} checkpoint_hi={checkpoint_hi}: {e}"))
+                .checked_sub(1)
+                .unwrap_or_else(|| panic!("Entry checkpoint_hi underflow pipeline={pipeline} checkpoint_hi={checkpoint_hi}")))
+            .min())
     }
 
     /// Returns the latest checkpoint that the pruner is willing to prune up to for the given

--- a/crates/sui-indexer-alt-framework-store-traits/src/lib.rs
+++ b/crates/sui-indexer-alt-framework-store-traits/src/lib.rs
@@ -14,7 +14,7 @@ use scoped_futures::ScopedBoxFuture;
 #[async_trait]
 pub trait Connection: Send {
     /// If no existing watermark record exists, initializes it with `default_next_checkpoint`.
-    /// Returns the committer watermark `checkpoint_hi_inclusive`.
+    /// Returns the committer watermark `checkpoint_hi`.
     async fn init_watermark(
         &mut self,
         pipeline_task: &str,
@@ -117,12 +117,12 @@ pub trait TransactionalStore: Store {
 }
 
 /// Represents the highest checkpoint for some pipeline that has been processed by the indexer
-/// framework. When read from the `Store`, this represents the inclusive upper bound checkpoint of
+/// framework. When read from the `Store`, this represents the exclusive upper bound checkpoint of
 /// data that has been written to the Store for a pipeline.
 #[derive(Default, Debug, Clone, Copy, PartialEq)]
 pub struct CommitterWatermark {
     pub epoch_hi_inclusive: u64,
-    pub checkpoint_hi_inclusive: u64,
+    pub checkpoint_hi: u64,
     pub tx_hi: u64,
     pub timestamp_ms_hi_inclusive: u64,
 }
@@ -131,7 +131,7 @@ pub struct CommitterWatermark {
 #[derive(Default, Debug, Clone, Copy)]
 pub struct ReaderWatermark {
     /// Within the framework, this value is used to determine the new `reader_lo`.
-    pub checkpoint_hi_inclusive: u64,
+    pub checkpoint_hi: u64,
     /// Within the framework, this value is used to check whether to actually make an update
     /// transaction to the database.
     pub reader_lo: u64,
@@ -165,11 +165,11 @@ impl CommitterWatermark {
     }
 
     /// Convenience function for testing, instantiates a CommitterWatermark with the given
-    /// `checkpoint_hi_inclusive` and sets all other values to 0.
-    pub fn new_for_testing(checkpoint_hi_inclusive: u64) -> Self {
+    /// `checkpoint_hi` and sets all other values to 0.
+    pub fn new_for_testing(checkpoint_hi: u64) -> Self {
         CommitterWatermark {
             epoch_hi_inclusive: 0,
-            checkpoint_hi_inclusive,
+            checkpoint_hi,
             tx_hi: 0,
             timestamp_ms_hi_inclusive: 0,
         }

--- a/crates/sui-indexer-alt-framework/src/cluster.rs
+++ b/crates/sui-indexer-alt-framework/src/cluster.rs
@@ -402,9 +402,8 @@ mod tests {
         assert_pipeline_metric!(total_collector_rows_received, 10);
         assert_pipeline_metric!(latest_collected_checkpoint, 9);
 
-        // The watermark checkpoint is inclusive, but the transaction is exclusive
-        assert_pipeline_metric!(watermark_checkpoint, 9);
-        assert_pipeline_metric!(watermark_checkpoint_in_db, 9);
+        assert_pipeline_metric!(watermark_checkpoint, 10);
+        assert_pipeline_metric!(watermark_checkpoint_in_db, 10);
         // 10 checkpoints, 2 user transactions + 1 settlement transaction per checkpoint
         assert_pipeline_metric!(watermark_transaction, 30);
         assert_pipeline_metric!(watermark_transaction_in_db, 30);

--- a/crates/sui-indexer-alt-framework/src/lib.rs
+++ b/crates/sui-indexer-alt-framework/src/lib.rs
@@ -375,13 +375,12 @@ impl<S: Store> Indexer<S> {
         let pipeline_task =
             pipeline_task::<S>(P::NAME, self.task.as_ref().map(|t| t.task.as_str()))?;
 
-        let checkpoint_hi_inclusive = conn
+        let checkpoint_hi = conn
             .init_watermark(&pipeline_task, self.default_next_checkpoint)
             .await
             .with_context(|| format!("Failed to init watermark for {pipeline_task}"))?;
 
-        let next_checkpoint =
-            checkpoint_hi_inclusive.map_or(self.default_next_checkpoint, |c| c + 1);
+        let next_checkpoint = checkpoint_hi.unwrap_or(self.default_next_checkpoint);
 
         self.first_ingestion_checkpoint = next_checkpoint.min(self.first_ingestion_checkpoint);
 
@@ -701,7 +700,7 @@ mod tests {
         conn.set_committer_watermark(
             A::NAME,
             CommitterWatermark {
-                checkpoint_hi_inclusive: 100,
+                checkpoint_hi: 101,
                 ..Default::default()
             },
         )
@@ -710,7 +709,7 @@ mod tests {
         conn.set_committer_watermark(
             B::NAME,
             CommitterWatermark {
-                checkpoint_hi_inclusive: 10,
+                checkpoint_hi: 11,
                 ..Default::default()
             },
         )
@@ -719,7 +718,7 @@ mod tests {
         conn.set_committer_watermark(
             C::NAME,
             CommitterWatermark {
-                checkpoint_hi_inclusive: 1,
+                checkpoint_hi: 2,
                 ..Default::default()
             },
         )
@@ -728,7 +727,7 @@ mod tests {
         conn.set_committer_watermark(
             D::NAME,
             CommitterWatermark {
-                checkpoint_hi_inclusive: 50,
+                checkpoint_hi: 51,
                 ..Default::default()
             },
         )
@@ -792,7 +791,7 @@ mod tests {
         conn.set_committer_watermark(
             B::NAME,
             CommitterWatermark {
-                checkpoint_hi_inclusive: 10,
+                checkpoint_hi: 11,
                 ..Default::default()
             },
         )
@@ -801,7 +800,7 @@ mod tests {
         conn.set_committer_watermark(
             C::NAME,
             CommitterWatermark {
-                checkpoint_hi_inclusive: 1,
+                checkpoint_hi: 2,
                 ..Default::default()
             },
         )
@@ -865,7 +864,7 @@ mod tests {
         conn.set_committer_watermark(
             A::NAME,
             CommitterWatermark {
-                checkpoint_hi_inclusive: 100,
+                checkpoint_hi: 101,
                 ..Default::default()
             },
         )
@@ -874,7 +873,7 @@ mod tests {
         conn.set_committer_watermark(
             B::NAME,
             CommitterWatermark {
-                checkpoint_hi_inclusive: 10,
+                checkpoint_hi: 11,
                 ..Default::default()
             },
         )
@@ -883,7 +882,7 @@ mod tests {
         conn.set_committer_watermark(
             C::NAME,
             CommitterWatermark {
-                checkpoint_hi_inclusive: 1,
+                checkpoint_hi: 2,
                 ..Default::default()
             },
         )
@@ -932,7 +931,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(indexer.first_ingestion_checkpoint, 1);
+        assert_eq!(indexer.first_ingestion_checkpoint, 0);
     }
 
     /// first_ingestion_checkpoint is first_checkpoint when at least one pipeline has no
@@ -951,7 +950,7 @@ mod tests {
         conn.set_committer_watermark(
             B::NAME,
             CommitterWatermark {
-                checkpoint_hi_inclusive: 50,
+                checkpoint_hi: 51,
                 ..Default::default()
             },
         )
@@ -960,7 +959,7 @@ mod tests {
         conn.set_committer_watermark(
             C::NAME,
             CommitterWatermark {
-                checkpoint_hi_inclusive: 10,
+                checkpoint_hi: 11,
                 ..Default::default()
             },
         )
@@ -1026,7 +1025,7 @@ mod tests {
         conn.set_committer_watermark(
             B::NAME,
             CommitterWatermark {
-                checkpoint_hi_inclusive: 50,
+                checkpoint_hi: 51,
                 ..Default::default()
             },
         )
@@ -1035,7 +1034,7 @@ mod tests {
         conn.set_committer_watermark(
             C::NAME,
             CommitterWatermark {
-                checkpoint_hi_inclusive: 10,
+                checkpoint_hi: 11,
                 ..Default::default()
             },
         )
@@ -1095,7 +1094,7 @@ mod tests {
         conn.set_committer_watermark(
             B::NAME,
             CommitterWatermark {
-                checkpoint_hi_inclusive: 50,
+                checkpoint_hi: 51,
                 ..Default::default()
             },
         )
@@ -1104,7 +1103,7 @@ mod tests {
         conn.set_committer_watermark(
             C::NAME,
             CommitterWatermark {
-                checkpoint_hi_inclusive: 10,
+                checkpoint_hi: 11,
                 ..Default::default()
             },
         )
@@ -1169,7 +1168,7 @@ mod tests {
         conn.set_committer_watermark(
             A::NAME,
             CommitterWatermark {
-                checkpoint_hi_inclusive: 5,
+                checkpoint_hi: 6,
                 ..Default::default()
             },
         )
@@ -1178,7 +1177,7 @@ mod tests {
         conn.set_committer_watermark(
             B::NAME,
             CommitterWatermark {
-                checkpoint_hi_inclusive: 10,
+                checkpoint_hi: 11,
                 ..Default::default()
             },
         )
@@ -1187,7 +1186,7 @@ mod tests {
         conn.set_committer_watermark(
             C::NAME,
             CommitterWatermark {
-                checkpoint_hi_inclusive: 15,
+                checkpoint_hi: 16,
                 ..Default::default()
             },
         )
@@ -1196,7 +1195,7 @@ mod tests {
         conn.set_committer_watermark(
             D::NAME,
             CommitterWatermark {
-                checkpoint_hi_inclusive: 20,
+                checkpoint_hi: 21,
                 ..Default::default()
             },
         )
@@ -1311,7 +1310,7 @@ mod tests {
         conn.set_committer_watermark(
             A::NAME,
             CommitterWatermark {
-                checkpoint_hi_inclusive: 5,
+                checkpoint_hi: 6,
                 ..Default::default()
             },
         )
@@ -1320,7 +1319,7 @@ mod tests {
         conn.set_committer_watermark(
             B::NAME,
             CommitterWatermark {
-                checkpoint_hi_inclusive: 10,
+                checkpoint_hi: 11,
                 ..Default::default()
             },
         )
@@ -1329,7 +1328,7 @@ mod tests {
         conn.set_committer_watermark(
             C::NAME,
             CommitterWatermark {
-                checkpoint_hi_inclusive: 15,
+                checkpoint_hi: 16,
                 ..Default::default()
             },
         )
@@ -1338,7 +1337,7 @@ mod tests {
         conn.set_committer_watermark(
             D::NAME,
             CommitterWatermark {
-                checkpoint_hi_inclusive: 20,
+                checkpoint_hi: 21,
                 ..Default::default()
             },
         )
@@ -1453,7 +1452,7 @@ mod tests {
         conn.set_committer_watermark(
             B::NAME,
             CommitterWatermark {
-                checkpoint_hi_inclusive: 10,
+                checkpoint_hi: 11,
                 ..Default::default()
             },
         )
@@ -1462,7 +1461,7 @@ mod tests {
         conn.set_committer_watermark(
             C::NAME,
             CommitterWatermark {
-                checkpoint_hi_inclusive: 15,
+                checkpoint_hi: 16,
                 ..Default::default()
             },
         )
@@ -1471,7 +1470,7 @@ mod tests {
         conn.set_committer_watermark(
             D::NAME,
             CommitterWatermark {
-                checkpoint_hi_inclusive: 20,
+                checkpoint_hi: 21,
                 ..Default::default()
             },
         )
@@ -1585,7 +1584,7 @@ mod tests {
         conn.set_committer_watermark(
             B::NAME,
             CommitterWatermark {
-                checkpoint_hi_inclusive: 10,
+                checkpoint_hi: 11,
                 ..Default::default()
             },
         )
@@ -1594,7 +1593,7 @@ mod tests {
         conn.set_committer_watermark(
             C::NAME,
             CommitterWatermark {
-                checkpoint_hi_inclusive: 15,
+                checkpoint_hi: 16,
                 ..Default::default()
             },
         )
@@ -1603,7 +1602,7 @@ mod tests {
         conn.set_committer_watermark(
             D::NAME,
             CommitterWatermark {
-                checkpoint_hi_inclusive: 20,
+                checkpoint_hi: 21,
                 ..Default::default()
             },
         )
@@ -1706,17 +1705,23 @@ mod tests {
     #[tokio::test]
     async fn test_init_watermark_concurrent_no_first_checkpoint() {
         let (committer_watermark, pruner_watermark) = test_init_watermark(None, true).await;
-        // Indexer will not init the watermark, pipeline tasks will write commit watermarks as normal.
-        assert_eq!(committer_watermark, None);
-        assert_eq!(pruner_watermark, None);
+
+        let committer_watermark = committer_watermark.unwrap();
+        assert_eq!(committer_watermark.checkpoint_hi, 0);
+
+        let pruner_watermark = pruner_watermark.unwrap();
+        assert_eq!(pruner_watermark.pruner_hi, 0);
     }
 
     #[tokio::test]
     async fn test_init_watermark_concurrent_first_checkpoint_0() {
         let (committer_watermark, pruner_watermark) = test_init_watermark(Some(0), true).await;
-        // Indexer will not init the watermark, pipeline tasks will write commit watermarks as normal.
-        assert_eq!(committer_watermark, None);
-        assert_eq!(pruner_watermark, None);
+
+        let committer_watermark = committer_watermark.unwrap();
+        assert_eq!(committer_watermark.checkpoint_hi, 0);
+
+        let pruner_watermark = pruner_watermark.unwrap();
+        assert_eq!(pruner_watermark.pruner_hi, 0);
     }
 
     #[tokio::test]
@@ -1724,7 +1729,7 @@ mod tests {
         let (committer_watermark, pruner_watermark) = test_init_watermark(Some(1), true).await;
 
         let committer_watermark = committer_watermark.unwrap();
-        assert_eq!(committer_watermark.checkpoint_hi_inclusive, 0);
+        assert_eq!(committer_watermark.checkpoint_hi, 1);
 
         let pruner_watermark = pruner_watermark.unwrap();
         assert_eq!(pruner_watermark.reader_lo, 1);
@@ -1736,7 +1741,7 @@ mod tests {
         let (committer_watermark, pruner_watermark) = test_init_watermark(Some(1), false).await;
 
         let committer_watermark = committer_watermark.unwrap();
-        assert_eq!(committer_watermark.checkpoint_hi_inclusive, 0);
+        assert_eq!(committer_watermark.checkpoint_hi, 1);
 
         let pruner_watermark = pruner_watermark.unwrap();
         assert_eq!(pruner_watermark.reader_lo, 1);
@@ -1756,7 +1761,7 @@ mod tests {
             MockHandler::NAME,
             CommitterWatermark {
                 epoch_hi_inclusive: 0,
-                checkpoint_hi_inclusive: 10,
+                checkpoint_hi: 11,
                 tx_hi: 20,
                 timestamp_ms_hi_inclusive: 10000,
             },
@@ -1769,7 +1774,7 @@ mod tests {
             SequentialHandler::NAME,
             CommitterWatermark {
                 epoch_hi_inclusive: 0,
-                checkpoint_hi_inclusive: 5,
+                checkpoint_hi: 6,
                 tx_hi: 10,
                 timestamp_ms_hi_inclusive: 5000,
             },
@@ -1857,8 +1862,8 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(watermark1.unwrap().checkpoint_hi_inclusive, 19);
-        assert_eq!(watermark2.unwrap().checkpoint_hi_inclusive, 19);
+        assert_eq!(watermark1.unwrap().checkpoint_hi, 20);
+        assert_eq!(watermark2.unwrap().checkpoint_hi, 20);
     }
 
     /// When a tasked indexer is initialized such that a tasked pipeline is run with a
@@ -1875,7 +1880,7 @@ mod tests {
         conn.set_committer_watermark(
             MockCheckpointSequenceNumberHandler::NAME,
             CommitterWatermark {
-                checkpoint_hi_inclusive: 10,
+                checkpoint_hi: 11,
                 ..Default::default()
             },
         )
@@ -1967,7 +1972,7 @@ mod tests {
         conn.set_committer_watermark(
             "test",
             CommitterWatermark {
-                checkpoint_hi_inclusive: 10,
+                checkpoint_hi: 11,
                 ..Default::default()
             },
         )
@@ -2053,10 +2058,10 @@ mod tests {
         }
         let main_pipeline_watermark = store.watermark("test").unwrap();
         // assert that the main pipeline's watermarks are not updated
-        assert_eq!(main_pipeline_watermark.checkpoint_hi_inclusive, 10);
+        assert_eq!(main_pipeline_watermark.checkpoint_hi, 11);
         assert_eq!(main_pipeline_watermark.reader_lo, 5);
         let tasked_pipeline_watermark = store.watermark("test@task").unwrap();
-        assert_eq!(tasked_pipeline_watermark.checkpoint_hi_inclusive, 25);
+        assert_eq!(tasked_pipeline_watermark.checkpoint_hi, 26);
         assert_eq!(tasked_pipeline_watermark.reader_lo, 9);
     }
 
@@ -2071,7 +2076,7 @@ mod tests {
         conn.set_committer_watermark(
             ControllableHandler::NAME,
             CommitterWatermark {
-                checkpoint_hi_inclusive: 11,
+                checkpoint_hi: 12,
                 ..Default::default()
             },
         )

--- a/crates/sui-indexer-alt-framework/src/mocks/store.rs
+++ b/crates/sui-indexer-alt-framework/src/mocks/store.rs
@@ -25,7 +25,7 @@ use crate::store::TransactionalStore;
 #[derive(Default, Clone)]
 pub struct MockWatermark {
     pub epoch_hi_inclusive: u64,
-    pub checkpoint_hi_inclusive: u64,
+    pub checkpoint_hi: u64,
     pub tx_hi: u64,
     pub timestamp_ms_hi_inclusive: u64,
     pub reader_lo: u64,
@@ -91,24 +91,13 @@ impl Connection for MockConnection<'_> {
         pipeline_task: &str,
         default_next_checkpoint: u64,
     ) -> anyhow::Result<Option<u64>> {
-        let Some(checkpoint_hi_inclusive) = default_next_checkpoint.checked_sub(1) else {
-            // Do not create a watermark record with checkpoint_hi_inclusive = -1.
-            return Ok(self
-                .committer_watermark(pipeline_task)
-                .await?
-                .map(|w| w.checkpoint_hi_inclusive));
-        };
-
-        let &MockWatermark {
-            checkpoint_hi_inclusive,
-            ..
-        } = self
+        let &MockWatermark { checkpoint_hi, .. } = self
             .0
             .watermarks
             .entry(pipeline_task.to_string())
             .or_insert(MockWatermark {
                 epoch_hi_inclusive: 0,
-                checkpoint_hi_inclusive,
+                checkpoint_hi: default_next_checkpoint,
                 tx_hi: 0,
                 timestamp_ms_hi_inclusive: 0,
                 reader_lo: default_next_checkpoint,
@@ -117,7 +106,7 @@ impl Connection for MockConnection<'_> {
             })
             .deref();
 
-        Ok(Some(checkpoint_hi_inclusive))
+        Ok(Some(checkpoint_hi))
     }
 
     async fn committer_watermark(
@@ -127,7 +116,7 @@ impl Connection for MockConnection<'_> {
         let watermark = self.0.watermarks.get(pipeline_task);
         Ok(watermark.map(|w| CommitterWatermark {
             epoch_hi_inclusive: w.epoch_hi_inclusive,
-            checkpoint_hi_inclusive: w.checkpoint_hi_inclusive,
+            checkpoint_hi: w.checkpoint_hi,
             tx_hi: w.tx_hi,
             timestamp_ms_hi_inclusive: w.timestamp_ms_hi_inclusive,
         }))
@@ -139,7 +128,7 @@ impl Connection for MockConnection<'_> {
     ) -> Result<Option<ReaderWatermark>, anyhow::Error> {
         let watermark = self.0.watermarks.get(pipeline);
         Ok(watermark.map(|w| ReaderWatermark {
-            checkpoint_hi_inclusive: w.checkpoint_hi_inclusive,
+            checkpoint_hi: w.checkpoint_hi,
             reader_lo: w.reader_lo,
         }))
     }
@@ -189,7 +178,7 @@ impl Connection for MockConnection<'_> {
             .or_default();
 
         wm.epoch_hi_inclusive = watermark.epoch_hi_inclusive;
-        wm.checkpoint_hi_inclusive = watermark.checkpoint_hi_inclusive;
+        wm.checkpoint_hi = watermark.checkpoint_hi;
         wm.tx_hi = watermark.tx_hi;
         wm.timestamp_ms_hi_inclusive = watermark.timestamp_ms_hi_inclusive;
         Ok(true)
@@ -563,7 +552,7 @@ impl MockStore {
         let start = tokio::time::Instant::now();
         while start.elapsed() < timeout_duration {
             if let Some(watermark) = self.watermark(pipeline_task)
-                && watermark.checkpoint_hi_inclusive >= checkpoint
+                && watermark.checkpoint_hi > checkpoint
             {
                 return watermark;
             }

--- a/crates/sui-indexer-alt-framework/src/pipeline/concurrent/collector.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/concurrent/collector.rs
@@ -795,7 +795,7 @@ mod tests {
 
         // The next batch should still be the remaining 10 rows from checkpoint 1.
         assert_eq!(batch.batch_len, 10);
-        assert_eq!(batch.watermark[0].watermark.checkpoint_hi_inclusive, 1);
+        assert_eq!(batch.watermark[0].watermark.checkpoint_hi, 2);
 
         recv_with_timeout(&mut collector_rx, Duration::from_secs(2)).await;
 

--- a/crates/sui-indexer-alt-framework/src/pipeline/concurrent/commit_watermark.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/concurrent/commit_watermark.rs
@@ -120,7 +120,7 @@ pub(super) fn commit_watermark<H: Handler + 'static>(
                     break;
                 }
 
-                match next_checkpoint.cmp(&part.watermark.checkpoint_hi_inclusive) {
+                match next_checkpoint.cmp(&part.checkpoint()) {
                     // Next pending checkpoint is from the future.
                     Ordering::Less => break,
 
@@ -157,7 +157,7 @@ pub(super) fn commit_watermark<H: Handler + 'static>(
                 metrics
                     .watermark_checkpoint
                     .with_label_values(&[H::NAME])
-                    .set(watermark.checkpoint_hi_inclusive as i64);
+                    .set(watermark.checkpoint_hi as i64);
 
                 metrics
                     .watermark_transaction
@@ -172,7 +172,7 @@ pub(super) fn commit_watermark<H: Handler + 'static>(
                 debug!(
                     pipeline = H::NAME,
                     elapsed_ms = elapsed * 1000.0,
-                    watermark = watermark.checkpoint_hi_inclusive,
+                    watermark = watermark.checkpoint_hi,
                     timestamp = %watermark.timestamp(),
                     pending = precommitted.len(),
                     "Gathered watermarks",
@@ -279,10 +279,8 @@ async fn write_watermark<H: Handler>(
 
             logger.log::<H>(watermark, elapsed);
 
-            checkpoint_lag_reporter.report_lag(
-                watermark.checkpoint_hi_inclusive,
-                watermark.timestamp_ms_hi_inclusive,
-            );
+            checkpoint_lag_reporter
+                .report_lag(watermark.checkpoint_hi, watermark.timestamp_ms_hi_inclusive);
 
             metrics
                 .watermark_epoch_in_db
@@ -399,7 +397,7 @@ mod tests {
     fn create_watermark_part_for_checkpoint(checkpoint: u64) -> WatermarkPart {
         WatermarkPart {
             watermark: CommitterWatermark {
-                checkpoint_hi_inclusive: checkpoint,
+                checkpoint_hi: checkpoint + 1,
                 ..Default::default()
             },
             batch_rows: 1,
@@ -423,7 +421,7 @@ mod tests {
 
         // Verify watermark progression
         let watermark = setup.store.watermark(DataPipeline::NAME).unwrap();
-        assert_eq!(watermark.checkpoint_hi_inclusive, 3);
+        assert_eq!(watermark.checkpoint_hi, 4);
     }
 
     #[tokio::test]
@@ -442,9 +440,9 @@ mod tests {
         // Wait for processing
         tokio::time::sleep(Duration::from_millis(100)).await;
 
-        // Verify watermark hasn't progressed past 2
+        // Verify watermark hasn't progressed past checkpoint 2
         let watermark = setup.store.watermark(DataPipeline::NAME).unwrap();
-        assert_eq!(watermark.checkpoint_hi_inclusive, 2);
+        assert_eq!(watermark.checkpoint_hi, 3);
 
         // Send checkpoint 3 to fill the gap
         setup
@@ -456,9 +454,9 @@ mod tests {
         // Wait for the next polling and processing
         tokio::time::sleep(Duration::from_secs(1)).await;
 
-        // Verify watermark has progressed to 4
+        // Verify watermark has progressed to checkpoint 4
         let watermark = setup.store.watermark(DataPipeline::NAME).unwrap();
-        assert_eq!(watermark.checkpoint_hi_inclusive, 4);
+        assert_eq!(watermark.checkpoint_hi, 5);
     }
 
     #[tokio::test]
@@ -486,7 +484,7 @@ mod tests {
 
         // Verify watermark has progressed
         let watermark = setup.store.watermark(DataPipeline::NAME).unwrap();
-        assert_eq!(watermark.checkpoint_hi_inclusive, 1);
+        assert_eq!(watermark.checkpoint_hi, 2);
     }
 
     #[tokio::test]
@@ -501,7 +499,7 @@ mod tests {
 
         let part = WatermarkPart {
             watermark: CommitterWatermark {
-                checkpoint_hi_inclusive: 10,
+                checkpoint_hi: 11,
                 ..Default::default()
             },
             batch_rows: 1,
@@ -519,7 +517,7 @@ mod tests {
 
         // Verify watermark has progressed after retry
         let watermark = setup.store.watermark(DataPipeline::NAME).unwrap();
-        assert_eq!(watermark.checkpoint_hi_inclusive, 10);
+        assert_eq!(watermark.checkpoint_hi, 11);
     }
 
     #[tokio::test]
@@ -533,7 +531,7 @@ mod tests {
 
         let part = WatermarkPart {
             watermark: CommitterWatermark {
-                checkpoint_hi_inclusive: 10,
+                checkpoint_hi: 11,
                 ..Default::default()
             },
             batch_rows: 1,
@@ -548,7 +546,7 @@ mod tests {
 
         let part = WatermarkPart {
             watermark: CommitterWatermark {
-                checkpoint_hi_inclusive: 11,
+                checkpoint_hi: 12,
                 ..Default::default()
             },
             batch_rows: 1,
@@ -560,7 +558,7 @@ mod tests {
         tokio::time::sleep(Duration::from_millis(1_200)).await;
 
         let watermark = setup.store.watermark(DataPipeline::NAME).unwrap();
-        assert_eq!(watermark.checkpoint_hi_inclusive, 11);
+        assert_eq!(watermark.checkpoint_hi, 12);
     }
 
     #[tokio::test]
@@ -574,7 +572,7 @@ mod tests {
         // Send the first incomplete watermark part
         let part = WatermarkPart {
             watermark: CommitterWatermark {
-                checkpoint_hi_inclusive: 1,
+                checkpoint_hi: 2,
                 ..Default::default()
             },
             batch_rows: 1,
@@ -601,7 +599,7 @@ mod tests {
 
         // Verify watermark has progressed
         let watermark = setup.store.watermark(DataPipeline::NAME).unwrap();
-        assert_eq!(watermark.checkpoint_hi_inclusive, 1);
+        assert_eq!(watermark.checkpoint_hi, 2);
     }
 
     #[tokio::test]
@@ -635,6 +633,6 @@ mod tests {
 
         // Verify watermark has progressed
         let watermark = setup.store.watermark(DataPipeline::NAME).unwrap();
-        assert_eq!(watermark.checkpoint_hi_inclusive, 1);
+        assert_eq!(watermark.checkpoint_hi, 2);
     }
 }

--- a/crates/sui-indexer-alt-framework/src/pipeline/concurrent/committer.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/concurrent/committer.rs
@@ -373,7 +373,7 @@ mod tests {
                 WatermarkPart {
                     watermark: CommitterWatermark {
                         epoch_hi_inclusive: 0,
-                        checkpoint_hi_inclusive: 1,
+                        checkpoint_hi: 2,
                         tx_hi: 3,
                         timestamp_ms_hi_inclusive: 1000,
                     },
@@ -383,7 +383,7 @@ mod tests {
                 WatermarkPart {
                     watermark: CommitterWatermark {
                         epoch_hi_inclusive: 0,
-                        checkpoint_hi_inclusive: 2,
+                        checkpoint_hi: 3,
                         tx_hi: 6,
                         timestamp_ms_hi_inclusive: 2000,
                     },
@@ -402,7 +402,7 @@ mod tests {
             vec![WatermarkPart {
                 watermark: CommitterWatermark {
                     epoch_hi_inclusive: 0,
-                    checkpoint_hi_inclusive: 3,
+                    checkpoint_hi: 4,
                     tx_hi: 9,
                     timestamp_ms_hi_inclusive: 3000,
                 },
@@ -445,7 +445,7 @@ mod tests {
             vec![WatermarkPart {
                 watermark: CommitterWatermark {
                     epoch_hi_inclusive: 0,
-                    checkpoint_hi_inclusive: 1,
+                    checkpoint_hi: 2,
                     tx_hi: 3,
                     timestamp_ms_hi_inclusive: 1000,
                 },
@@ -508,7 +508,7 @@ mod tests {
             vec![WatermarkPart {
                 watermark: CommitterWatermark {
                     epoch_hi_inclusive: 0,
-                    checkpoint_hi_inclusive: 1,
+                    checkpoint_hi: 2,
                     tx_hi: 3,
                     timestamp_ms_hi_inclusive: 1000,
                 },
@@ -557,7 +557,7 @@ mod tests {
             vec![WatermarkPart {
                 watermark: CommitterWatermark {
                     epoch_hi_inclusive: 0,
-                    checkpoint_hi_inclusive: 1,
+                    checkpoint_hi: 2,
                     tx_hi: 0,
                     timestamp_ms_hi_inclusive: 1000,
                 },
@@ -598,7 +598,7 @@ mod tests {
             vec![WatermarkPart {
                 watermark: CommitterWatermark {
                     epoch_hi_inclusive: 0,
-                    checkpoint_hi_inclusive: 1,
+                    checkpoint_hi: 2,
                     tx_hi: 3,
                     timestamp_ms_hi_inclusive: 1000,
                 },

--- a/crates/sui-indexer-alt-framework/src/pipeline/concurrent/mod.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/concurrent/mod.rs
@@ -600,7 +600,7 @@ mod tests {
         }
 
         // Verify watermark progression
-        assert_eq!(watermark.checkpoint_hi_inclusive, 9);
+        assert_eq!(watermark.checkpoint_hi, 10);
         assert_eq!(watermark.tx_hi, 18); // 9 * 2
         assert_eq!(watermark.timestamp_ms_hi_inclusive, 1000009000); // 1000000000 + 9 * 1000
 
@@ -662,7 +662,7 @@ mod tests {
 
         // Watermark should only progress to 1 (can't progress past the gap)
         let watermark = setup.store.watermark(DataPipeline::NAME).unwrap();
-        assert_eq!(watermark.checkpoint_hi_inclusive, 1);
+        assert_eq!(watermark.checkpoint_hi, 2);
 
         // Now send the missing checkpoint 2
         setup
@@ -675,7 +675,7 @@ mod tests {
             .store
             .wait_for_watermark(DataPipeline::NAME, 4, TEST_TIMEOUT)
             .await;
-        assert_eq!(watermark.checkpoint_hi_inclusive, 4);
+        assert_eq!(watermark.checkpoint_hi, 5);
     }
 
     // ==================== BACK-PRESSURE TESTING ====================

--- a/crates/sui-indexer-alt-framework/src/pipeline/concurrent/pruner.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/concurrent/pruner.rs
@@ -535,7 +535,7 @@ mod tests {
 
         let watermark = MockWatermark {
             epoch_hi_inclusive: 0,
-            checkpoint_hi_inclusive: 3,
+            checkpoint_hi: 4,
             tx_hi: 9,
             timestamp_ms_hi_inclusive: timestamp,
             reader_lo: 3,
@@ -614,7 +614,7 @@ mod tests {
 
         let watermark = MockWatermark {
             epoch_hi_inclusive: 0,
-            checkpoint_hi_inclusive: 3,
+            checkpoint_hi: 4,
             tx_hi: 9,
             timestamp_ms_hi_inclusive: timestamp,
             reader_lo: 3,
@@ -680,7 +680,7 @@ mod tests {
 
         let watermark = MockWatermark {
             epoch_hi_inclusive: 0,
-            checkpoint_hi_inclusive: 4,
+            checkpoint_hi: 5,
             tx_hi: 8,
             timestamp_ms_hi_inclusive: timestamp,
             reader_lo: 4,        // Allow pruning up to checkpoint 4 (exclusive)

--- a/crates/sui-indexer-alt-framework/src/pipeline/concurrent/reader_watermark.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/concurrent/reader_watermark.rs
@@ -64,8 +64,7 @@ pub(super) fn reader_watermark<H: Handler + 'static>(
             };
 
             // Calculate the new reader watermark based on the current high watermark.
-            let new_reader_lo =
-                (current.checkpoint_hi_inclusive as u64 + 1).saturating_sub(config.retention);
+            let new_reader_lo = current.checkpoint_hi.saturating_sub(config.retention);
 
             if new_reader_lo <= current.reader_lo as u64 {
                 debug!(
@@ -195,7 +194,7 @@ mod tests {
     async fn test_reader_watermark_updates() {
         let watermark = MockWatermark {
             epoch_hi_inclusive: 0,
-            checkpoint_hi_inclusive: 10, // Current high watermark
+            checkpoint_hi: 11, // Current high watermark
             tx_hi: 100,
             timestamp_ms_hi_inclusive: 1000,
             reader_lo: 0, // Initial reader_lo
@@ -216,7 +215,7 @@ mod tests {
         // Wait for a few intervals to allow the task to update the watermark
         tokio::time::sleep(Duration::from_millis(200)).await;
 
-        // new reader_lo = checkpoint_hi_inclusive (10) - retention (5) + 1 = 6
+        // new reader_lo = checkpoint_hi (11) - retention (5) = 6
         {
             let watermarks = setup.store.watermark(DataPipeline::NAME).unwrap();
             assert_eq!(watermarks.reader_lo, 6);
@@ -227,7 +226,7 @@ mod tests {
     async fn test_reader_watermark_does_not_update_smaller_reader_lo() {
         let watermark = MockWatermark {
             epoch_hi_inclusive: 0,
-            checkpoint_hi_inclusive: 10, // Current high watermark
+            checkpoint_hi: 11, // Current high watermark
             tx_hi: 100,
             timestamp_ms_hi_inclusive: 1000,
             reader_lo: 7, // Initial reader_lo
@@ -248,7 +247,7 @@ mod tests {
         // Wait for a few intervals to allow the task to update the watermark
         tokio::time::sleep(Duration::from_millis(200)).await;
 
-        // new reader_lo = checkpoint_hi_inclusive (10) - retention (5) + 1 = 6,
+        // new reader_lo = checkpoint_hi (11) - retention (5) = 6,
         // which is smaller than current reader_lo (7). Therefore, the reader_lo was not updated.
         {
             let watermarks = setup.store.watermark(DataPipeline::NAME).unwrap();
@@ -263,7 +262,7 @@ mod tests {
     async fn test_reader_watermark_retry_update_after_connection_failure() {
         let watermark = MockWatermark {
             epoch_hi_inclusive: 0,
-            checkpoint_hi_inclusive: 10, // Current high watermark
+            checkpoint_hi: 11, // Current high watermark
             tx_hi: 100,
             timestamp_ms_hi_inclusive: 1000,
             reader_lo: 0, // Initial reader_lo
@@ -315,7 +314,7 @@ mod tests {
     async fn test_reader_watermark_retry_update_after_set_watermark_failure() {
         let watermark = MockWatermark {
             epoch_hi_inclusive: 0,
-            checkpoint_hi_inclusive: 10, // Current high watermark
+            checkpoint_hi: 11, // Current high watermark
             tx_hi: 100,
             timestamp_ms_hi_inclusive: 1000,
             reader_lo: 0, // Initial reader_lo

--- a/crates/sui-indexer-alt-framework/src/pipeline/logging.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/logging.rs
@@ -95,7 +95,9 @@ impl WatermarkLogger {
 impl From<&CommitterWatermark> for LoggerWatermark {
     fn from(watermark: &CommitterWatermark) -> Self {
         Self {
-            checkpoint: watermark.checkpoint_hi_inclusive as i64,
+            checkpoint: watermark.checkpoint_hi.checked_sub(1).unwrap_or_else(|| {
+                panic!("CommitterWatermark checkpoint_hi underflow {watermark:?}")
+            }) as i64,
             transaction: Some(watermark.tx_hi as i64),
         }
     }

--- a/crates/sui-indexer-alt-framework/src/pipeline/mod.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/mod.rs
@@ -88,7 +88,7 @@ impl<P: Processor> IndexedCheckpoint<P> {
         Self {
             watermark: CommitterWatermark {
                 epoch_hi_inclusive: epoch,
-                checkpoint_hi_inclusive: cp_sequence_number,
+                checkpoint_hi: cp_sequence_number + 1,
                 tx_hi,
                 timestamp_ms_hi_inclusive: timestamp_ms,
             },
@@ -103,13 +103,20 @@ impl<P: Processor> IndexedCheckpoint<P> {
 
     /// The checkpoint sequence number that this data is from
     fn checkpoint(&self) -> u64 {
-        self.watermark.checkpoint_hi_inclusive
+        let watermark = self.watermark;
+        watermark
+            .checkpoint_hi
+            .checked_sub(1)
+            .unwrap_or_else(|| panic!("Watermark checkpoint_hi underflow {watermark:?}"))
     }
 }
 
 impl WatermarkPart {
     fn checkpoint(&self) -> u64 {
-        self.watermark.checkpoint_hi_inclusive
+        self.watermark
+            .checkpoint_hi
+            .checked_sub(1)
+            .unwrap_or_else(|| panic!("WatermarkPart checkpoint_hi underflow {self:?}"))
     }
 
     fn timestamp_ms(&self) -> u64 {
@@ -177,7 +184,7 @@ mod tests {
     fn test_watermark_part_getters() {
         let watermark = CommitterWatermark {
             epoch_hi_inclusive: 1,
-            checkpoint_hi_inclusive: 100,
+            checkpoint_hi: 101,
             tx_hi: 1000,
             timestamp_ms_hi_inclusive: 1234567890,
         };
@@ -195,7 +202,7 @@ mod tests {
     #[test]
     fn test_watermark_part_is_complete() {
         let part = WatermarkPart {
-            watermark: CommitterWatermark::default(),
+            watermark: CommitterWatermark::new_for_testing(1),
             batch_rows: 200,
             total_rows: 200,
         };
@@ -206,7 +213,7 @@ mod tests {
     #[test]
     fn test_watermark_part_is_not_complete() {
         let part = WatermarkPart {
-            watermark: CommitterWatermark::default(),
+            watermark: CommitterWatermark::new_for_testing(1),
             batch_rows: 199,
             total_rows: 200,
         };
@@ -217,14 +224,14 @@ mod tests {
     #[test]
     fn test_watermark_part_becomes_complete_after_adding_new_batch() {
         let mut part = WatermarkPart {
-            watermark: CommitterWatermark::default(),
+            watermark: CommitterWatermark::new_for_testing(1),
             batch_rows: 199,
             total_rows: 200,
         };
 
         // Add a batch that makes it complete
         part.add(WatermarkPart {
-            watermark: CommitterWatermark::default(),
+            watermark: CommitterWatermark::new_for_testing(1),
             batch_rows: 1,
             total_rows: 200,
         });
@@ -236,7 +243,7 @@ mod tests {
     #[test]
     fn test_watermark_part_becomes_incomplete_after_taking_away_batch() {
         let mut part = WatermarkPart {
-            watermark: CommitterWatermark::default(),
+            watermark: CommitterWatermark::new_for_testing(1),
             batch_rows: 200,
             total_rows: 200,
         };

--- a/crates/sui-indexer-alt-framework/src/pipeline/processor.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/processor.rs
@@ -260,7 +260,7 @@ mod tests {
             .recv()
             .await
             .expect("Should receive first IndexedCheckpoint");
-        assert_eq!(indexed1.watermark.checkpoint_hi_inclusive, 1);
+        assert_eq!(indexed1.watermark.checkpoint_hi, 2);
         assert_eq!(indexed1.watermark.epoch_hi_inclusive, 2);
         assert_eq!(indexed1.watermark.tx_hi, 5);
         assert_eq!(indexed1.watermark.timestamp_ms_hi_inclusive, 1000000001);
@@ -273,7 +273,7 @@ mod tests {
             .recv()
             .await
             .expect("Should receive second IndexedCheckpoint");
-        assert_eq!(indexed2.watermark.checkpoint_hi_inclusive, 2);
+        assert_eq!(indexed2.watermark.checkpoint_hi, 3);
         assert_eq!(indexed2.watermark.epoch_hi_inclusive, 2);
         assert_eq!(indexed2.watermark.tx_hi, 10);
         assert_eq!(indexed2.watermark.timestamp_ms_hi_inclusive, 1000000002);
@@ -319,7 +319,7 @@ mod tests {
             .recv()
             .await
             .expect("Should receive first IndexedCheckpoint");
-        assert_eq!(indexed1.watermark.checkpoint_hi_inclusive, 1);
+        assert_eq!(indexed1.watermark.checkpoint_hi, 2);
 
         // Shutdown the processor
         svc.shutdown().await.unwrap();
@@ -391,7 +391,7 @@ mod tests {
             .recv()
             .await
             .expect("Should receive first IndexedCheckpoint");
-        assert_eq!(indexed1.watermark.checkpoint_hi_inclusive, 1);
+        assert_eq!(indexed1.watermark.checkpoint_hi, 2);
 
         // Send second checkpoint (should fail twice, then succeed on 3rd attempt)
         data_tx.send(checkpoint2.clone()).await.unwrap();
@@ -400,7 +400,7 @@ mod tests {
             .recv()
             .await
             .expect("Should receive second IndexedCheckpoint after retries");
-        assert_eq!(indexed2.watermark.checkpoint_hi_inclusive, 2);
+        assert_eq!(indexed2.watermark.checkpoint_hi, 3);
 
         // Verify that exactly 3 attempts were made (2 failures + 1 success)
         assert_eq!(attempt_count.load(Ordering::Relaxed), 3);

--- a/crates/sui-indexer-alt-framework/src/pipeline/sequential/committer.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/sequential/committer.rs
@@ -212,7 +212,7 @@ where
                     metrics
                         .watermark_checkpoint
                         .with_label_values(&[H::NAME])
-                        .set(watermark.checkpoint_hi_inclusive as i64);
+                        .set(watermark.checkpoint_hi as i64);
 
                     metrics
                         .watermark_transaction
@@ -274,7 +274,7 @@ where
                     logger.log::<H>(&watermark, elapsed);
 
                     checkpoint_lag_reporter.report_lag(
-                        watermark.checkpoint_hi_inclusive,
+                        watermark.checkpoint_hi,
                         watermark.timestamp_ms_hi_inclusive
                     );
 
@@ -306,7 +306,7 @@ where
                     metrics
                         .watermark_checkpoint_in_db
                         .with_label_values(&[H::NAME])
-                        .set(watermark.checkpoint_hi_inclusive as i64);
+                        .set(watermark.checkpoint_hi as i64);
 
                     metrics
                         .watermark_transaction_in_db
@@ -322,7 +322,7 @@ where
                     // Ignore the result -- the ingestion service will close this channel
                     // once it is done, but there may still be checkpoints buffered that need
                     // processing.
-                    let _ = tx.send((H::NAME, watermark.checkpoint_hi_inclusive + 1));
+                    let _ = tx.send((H::NAME, watermark.checkpoint_hi));
                     // docs::/#send
 
                     let _ = std::mem::take(&mut batch);
@@ -535,14 +535,17 @@ mod tests {
         // Verify watermark was updated
         {
             let watermark = setup.store.watermark(TestHandler::NAME).unwrap();
-            assert_eq!(watermark.checkpoint_hi_inclusive, 2);
+            assert_eq!(watermark.checkpoint_hi, 3);
             assert_eq!(watermark.tx_hi, 2);
         }
 
         // Verify commit_hi was sent to ingestion
         let commit_hi = setup.commit_hi_rx.recv().await.unwrap();
         assert_eq!(commit_hi.0, "test", "Pipeline name should be 'test'");
-        assert_eq!(commit_hi.1, 3, "commit_hi should be 3 (checkpoint 2 + 1)");
+        assert_eq!(
+            commit_hi.1, 3,
+            "commit_hi should be 3 (checkpoint_hi of last processed)"
+        );
     }
 
     /// Configure the MockStore with no watermark, and emulate `first_checkpoint` by passing the
@@ -581,7 +584,7 @@ mod tests {
         // Verify watermark was updated
         {
             let watermark = setup.store.watermark(TestHandler::NAME).unwrap();
-            assert_eq!(watermark.checkpoint_hi_inclusive, 7);
+            assert_eq!(watermark.checkpoint_hi, 8);
             assert_eq!(watermark.tx_hi, 7);
         }
     }
@@ -609,14 +612,17 @@ mod tests {
         // Verify watermark was updated
         {
             let watermark = setup.store.watermark(TestHandler::NAME).unwrap();
-            assert_eq!(watermark.checkpoint_hi_inclusive, 2);
+            assert_eq!(watermark.checkpoint_hi, 3);
             assert_eq!(watermark.tx_hi, 2);
         }
 
         // Verify commit_hi was sent to ingestion
         let commit_hi = setup.commit_hi_rx.recv().await.unwrap();
         assert_eq!(commit_hi.0, "test", "Pipeline name should be 'test'");
-        assert_eq!(commit_hi.1, 3, "commit_hi should be 3 (checkpoint 2 + 1)");
+        assert_eq!(
+            commit_hi.1, 3,
+            "commit_hi should be 3 (checkpoint_hi of last processed)"
+        );
     }
 
     #[tokio::test]

--- a/crates/sui-indexer-alt-framework/src/postgres/mod.rs
+++ b/crates/sui-indexer-alt-framework/src/postgres/mod.rs
@@ -167,8 +167,11 @@ pub mod tests {
     async fn test_add_existing_pipeline() {
         let (mut indexer, _temp_db) = Indexer::new_for_testing(&MIGRATIONS).await;
         {
-            let watermark = CommitterWatermark::new_for_testing(10);
             let mut conn = indexer.store().connect().await.unwrap();
+            conn.init_watermark(ConcurrentPipeline1::NAME, 0)
+                .await
+                .unwrap();
+            let watermark = CommitterWatermark::new_for_testing(11);
             assert!(
                 conn.set_committer_watermark(ConcurrentPipeline1::NAME, watermark)
                     .await
@@ -186,14 +189,20 @@ pub mod tests {
     async fn test_add_multiple_pipelines() {
         let (mut indexer, _temp_db) = Indexer::new_for_testing(&MIGRATIONS).await;
         {
-            let watermark1 = CommitterWatermark::new_for_testing(10);
             let mut conn = indexer.store().connect().await.unwrap();
+            conn.init_watermark(ConcurrentPipeline1::NAME, 0)
+                .await
+                .unwrap();
+            conn.init_watermark(ConcurrentPipeline2::NAME, 0)
+                .await
+                .unwrap();
+            let watermark1 = CommitterWatermark::new_for_testing(11);
             assert!(
                 conn.set_committer_watermark(ConcurrentPipeline1::NAME, watermark1)
                     .await
                     .unwrap()
             );
-            let watermark2 = CommitterWatermark::new_for_testing(20);
+            let watermark2 = CommitterWatermark::new_for_testing(21);
             assert!(
                 conn.set_committer_watermark(ConcurrentPipeline2::NAME, watermark2)
                     .await

--- a/crates/sui-indexer-alt-graphql/src/task/watermark.rs
+++ b/crates/sui-indexer-alt-graphql/src/task/watermark.rs
@@ -96,7 +96,7 @@ pub(crate) struct Pipeline {
     timestamp_ms_hi_inclusive: i64,
 }
 
-#[derive(QueryableByName, Clone)]
+#[derive(QueryableByName, Clone, Debug)]
 struct WatermarkRow {
     #[diesel(sql_type = Text)]
     pipeline: String,
@@ -105,7 +105,7 @@ struct WatermarkRow {
     epoch_hi_inclusive: i64,
 
     #[diesel(sql_type = BigInt)]
-    checkpoint_hi_inclusive: i64,
+    checkpoint_hi: i64,
 
     #[diesel(sql_type = BigInt)]
     tx_hi: i64,
@@ -265,7 +265,10 @@ impl Watermarks {
         let pipeline = Pipeline {
             hi: Watermark {
                 epoch: row.epoch_hi_inclusive,
-                checkpoint: row.checkpoint_hi_inclusive,
+                checkpoint: row
+                    .checkpoint_hi
+                    .checked_sub(1)
+                    .unwrap_or_else(|| panic!("WatermarkRow checkpoint_hi underflow {row:?}")),
                 transaction: row.tx_hi,
             },
             lo: Watermark {
@@ -351,7 +354,7 @@ impl WatermarkRow {
         metrics
             .watermark_checkpoint
             .with_label_values(&[&self.pipeline])
-            .set(self.checkpoint_hi_inclusive);
+            .set(self.checkpoint_hi);
 
         metrics
             .watermark_transaction
@@ -404,7 +407,7 @@ async fn watermark_from_bigtable(bigtable_reader: &BigtableReader) -> anyhow::Re
     Ok(WatermarkRow {
         pipeline: "bigtable".to_owned(),
         epoch_hi_inclusive: wm.epoch_hi_inclusive as i64,
-        checkpoint_hi_inclusive: wm.checkpoint_hi_inclusive as i64,
+        checkpoint_hi: wm.checkpoint_hi_inclusive as i64 + 1,
         tx_hi: wm.tx_hi as i64,
         timestamp_ms_hi_inclusive: wm.timestamp_ms_hi_inclusive as i64,
         epoch_lo: 0,
@@ -424,7 +427,7 @@ async fn watermark_from_ledger_grpc(
     Ok(WatermarkRow {
         pipeline: "ledger_grpc".to_owned(),
         epoch_hi_inclusive: summary.epoch as i64,
-        checkpoint_hi_inclusive: summary.sequence_number as i64,
+        checkpoint_hi: summary.sequence_number as i64 + 1,
         tx_hi: summary.network_total_transactions as i64,
         timestamp_ms_hi_inclusive: summary.timestamp_ms as i64,
         epoch_lo: 0,
@@ -442,13 +445,15 @@ async fn watermarks_from_pg(
         .await
         .context("Failed to connect to database")?;
 
+    // Filtering on `reader_lo < checkpoint_hi` prevents returning an empty
+    // [reader_lo, checkpoint_hi) range.
     let rows: Vec<WatermarkRow> = conn
         .results(query!(
             r#"
             SELECT
                 w.pipeline,
                 w.epoch_hi_inclusive,
-                w.checkpoint_hi_inclusive,
+                w.checkpoint_hi,
                 w.tx_hi,
                 w.timestamp_ms_hi_inclusive,
                 c.epoch AS epoch_lo,
@@ -461,6 +466,7 @@ async fn watermarks_from_pg(
             ON (w.reader_lo = c.cp_sequence_number)
             WHERE
                 pipeline = ANY({Array<Text>})
+                AND w.reader_lo < w.checkpoint_hi
             "#,
             pg_pipelines,
         ))
@@ -499,7 +505,7 @@ async fn watermark_from_consistent(
         }) => Ok(Some(WatermarkRow {
             pipeline: "consistent".to_owned(),
             epoch_hi_inclusive: max_epoch as i64,
-            checkpoint_hi_inclusive: max_checkpoint as i64,
+            checkpoint_hi: max_checkpoint as i64 + 1,
             tx_hi: total_transactions as i64,
             timestamp_ms_hi_inclusive: max_timestamp_ms as i64,
             epoch_lo: 0,

--- a/crates/sui-indexer-alt-object-store/src/lib.rs
+++ b/crates/sui-indexer-alt-object-store/src/lib.rs
@@ -32,9 +32,9 @@ pub struct ObjectStoreConnection {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
-struct ComitterWatermark {
+struct CommitterWatermark {
     epoch_hi_inclusive: u64,
-    checkpoint_hi_inclusive: u64,
+    checkpoint_hi: u64,
     tx_hi: u64,
     timestamp_ms_hi_inclusive: u64,
 }
@@ -51,22 +51,22 @@ impl ObjectStoreConnection {
     }
 }
 
-impl From<framework_traits::CommitterWatermark> for ComitterWatermark {
+impl From<framework_traits::CommitterWatermark> for CommitterWatermark {
     fn from(w: framework_traits::CommitterWatermark) -> Self {
         Self {
             epoch_hi_inclusive: w.epoch_hi_inclusive,
-            checkpoint_hi_inclusive: w.checkpoint_hi_inclusive,
+            checkpoint_hi: w.checkpoint_hi,
             tx_hi: w.tx_hi,
             timestamp_ms_hi_inclusive: w.timestamp_ms_hi_inclusive,
         }
     }
 }
 
-impl From<ComitterWatermark> for framework_traits::CommitterWatermark {
-    fn from(w: ComitterWatermark) -> Self {
+impl From<CommitterWatermark> for framework_traits::CommitterWatermark {
+    fn from(w: CommitterWatermark) -> Self {
         Self {
             epoch_hi_inclusive: w.epoch_hi_inclusive,
-            checkpoint_hi_inclusive: w.checkpoint_hi_inclusive,
+            checkpoint_hi: w.checkpoint_hi,
             tx_hi: w.tx_hi,
             timestamp_ms_hi_inclusive: w.timestamp_ms_hi_inclusive,
         }
@@ -90,7 +90,7 @@ impl Connection for ObjectStoreConnection {
         Ok(self
             .committer_watermark(pipeline_task)
             .await?
-            .map(|w| w.checkpoint_hi_inclusive))
+            .map(|w| w.checkpoint_hi))
     }
 
     async fn committer_watermark(
@@ -101,12 +101,12 @@ impl Connection for ObjectStoreConnection {
         match self.object_store.get(&object_path).await {
             Ok(result) => {
                 let bytes = result.bytes().await?;
-                let watermark: ComitterWatermark = serde_json::from_slice(&bytes)
+                let watermark: CommitterWatermark = serde_json::from_slice(&bytes)
                     .context("Failed to parse watermark from object store")?;
 
                 info!(
                     pipeline_task,
-                    checkpoint = watermark.checkpoint_hi_inclusive,
+                    checkpoint_hi = watermark.checkpoint_hi,
                     "Downloaded watermark from object store"
                 );
 
@@ -137,7 +137,7 @@ impl Connection for ObjectStoreConnection {
         pipeline_task: &str,
         watermark: framework_traits::CommitterWatermark,
     ) -> anyhow::Result<bool> {
-        let new_watermark: ComitterWatermark = watermark.into();
+        let new_watermark: CommitterWatermark = watermark.into();
         let object_path = ObjectPath::from(format!("_metadata/watermarks/{}.json", pipeline_task));
 
         let (current_watermark, e_tag, version) = match self.object_store.get(&object_path).await {
@@ -145,7 +145,7 @@ impl Connection for ObjectStoreConnection {
                 let e_tag = result.meta.e_tag.clone();
                 let version = result.meta.version.clone();
                 let bytes = result.bytes().await?;
-                let watermark: ComitterWatermark = serde_json::from_slice(&bytes)
+                let watermark: CommitterWatermark = serde_json::from_slice(&bytes)
                     .context("Failed to parse watermark from object store")?;
                 (Some(watermark), e_tag, version)
             }
@@ -154,7 +154,7 @@ impl Connection for ObjectStoreConnection {
         };
 
         if let Some(ref current) = current_watermark
-            && current.checkpoint_hi_inclusive >= new_watermark.checkpoint_hi_inclusive
+            && current.checkpoint_hi >= new_watermark.checkpoint_hi
         {
             return Ok(false);
         }
@@ -216,7 +216,7 @@ mod tests {
         // Set initial watermark
         let initial_watermark = framework_traits::CommitterWatermark {
             epoch_hi_inclusive: 1,
-            checkpoint_hi_inclusive: 100,
+            checkpoint_hi: 100,
             tx_hi: 1000,
             timestamp_ms_hi_inclusive: 1000000,
         };
@@ -231,14 +231,14 @@ mod tests {
         assert!(watermark.is_some());
         let watermark = watermark.unwrap();
         assert_eq!(watermark.epoch_hi_inclusive, 1);
-        assert_eq!(watermark.checkpoint_hi_inclusive, 100);
+        assert_eq!(watermark.checkpoint_hi, 100);
         assert_eq!(watermark.tx_hi, 1000);
         assert_eq!(watermark.timestamp_ms_hi_inclusive, 1000000);
 
         // Update watermark with higher checkpoint
         let updated_watermark = framework_traits::CommitterWatermark {
             epoch_hi_inclusive: 2,
-            checkpoint_hi_inclusive: 200,
+            checkpoint_hi: 200,
             tx_hi: 2000,
             timestamp_ms_hi_inclusive: 2000000,
         };
@@ -253,12 +253,12 @@ mod tests {
 
         // Verify the updated watermark
         let watermark = conn.committer_watermark(pipeline).await.unwrap().unwrap();
-        assert_eq!(watermark.checkpoint_hi_inclusive, 200);
+        assert_eq!(watermark.checkpoint_hi, 200);
 
         // Try to set a watermark with a lower checkpoint (should be rejected)
         let regressed_watermark = framework_traits::CommitterWatermark {
             epoch_hi_inclusive: 1,
-            checkpoint_hi_inclusive: 150,
+            checkpoint_hi: 150,
             tx_hi: 1500,
             timestamp_ms_hi_inclusive: 1500000,
         };
@@ -270,6 +270,6 @@ mod tests {
 
         // Verify watermark hasn't changed
         let watermark = conn.committer_watermark(pipeline).await.unwrap().unwrap();
-        assert_eq!(watermark.checkpoint_hi_inclusive, 200);
+        assert_eq!(watermark.checkpoint_hi, 200);
     }
 }

--- a/crates/sui-indexer-alt-reader/src/system_package_task.rs
+++ b/crates/sui-indexer-alt-reader/src/system_package_task.rs
@@ -89,14 +89,14 @@ impl SystemPackageTask {
                     epoch_hi_inclusive: i64,
 
                     #[diesel(sql_type = BigInt)]
-                    checkpoint_hi_inclusive: i64,
+                    checkpoint_hi: i64,
                 }
 
                 let query = query!(
                     r#"
                     SELECT
                         epoch_hi_inclusive,
-                        checkpoint_hi_inclusive
+                        checkpoint_hi
                     FROM
                         watermarks
                     WHERE
@@ -106,7 +106,7 @@ impl SystemPackageTask {
 
                 let Watermark {
                     epoch_hi_inclusive: next_epoch,
-                    checkpoint_hi_inclusive,
+                    checkpoint_hi,
                 } = match conn.results(query).await.as_deref() {
                     Ok([watermark]) => *watermark,
 
@@ -147,9 +147,9 @@ impl SystemPackageTask {
                         kv_packages
                     WHERE
                         is_system_package
-                    AND cp_sequence_number <= {BigInt}
+                    AND cp_sequence_number < {BigInt}
                     "#,
-                    checkpoint_hi_inclusive
+                    checkpoint_hi
                 );
 
                 let system_packages: Vec<SystemPackage> = match conn.results(query).await {

--- a/crates/sui-indexer-alt-schema/src/schema.rs
+++ b/crates/sui-indexer-alt-schema/src/schema.rs
@@ -246,12 +246,12 @@ diesel::table! {
     watermarks (pipeline) {
         pipeline -> Text,
         epoch_hi_inclusive -> Int8,
-        checkpoint_hi_inclusive -> Int8,
         tx_hi -> Int8,
         timestamp_ms_hi_inclusive -> Int8,
         reader_lo -> Int8,
         pruner_timestamp -> Timestamp,
         pruner_hi -> Int8,
+        checkpoint_hi -> Int8,
     }
 }
 

--- a/crates/sui-indexer-alt/src/handlers/obj_info.rs
+++ b/crates/sui-indexer-alt/src/handlers/obj_info.rs
@@ -158,9 +158,9 @@ impl Handler for ObjInfo {
 
     /// To prune `obj_info`, entries between `[from, to_exclusive)` are read from the reference
     /// table, and the previous versions of the objects are deleted from the main table. Finally,
-    /// the reference entries themselves are deleted. The framework guarantees that `to_exclusive <=
-    /// checkpoint_hi_inclusive - retention`, so we only prune data that has been committed but is
-    /// beyond the retention window.
+    /// the reference entries themselves are deleted. The framework guarantees that
+    /// `to_exclusive < checkpoint_hi - retention`, so we only prune data that has been committed
+    /// but is beyond the retention window.
     async fn prune<'a>(
         &self,
         from: u64,

--- a/crates/sui-kvstore/src/bigtable/legacy_watermark.rs
+++ b/crates/sui-kvstore/src/bigtable/legacy_watermark.rs
@@ -23,7 +23,7 @@ impl LegacyWatermarkTracker {
         }
     }
 
-    /// Record a pipeline's latest checkpoint_hi_inclusive.
+    /// Record a pipeline's latest checkpoint_hi.
     /// Returns `Some((min, prev_last_written))` when all pipelines have reported
     /// AND the min has advanced past `last_written`. Eagerly sets `last_written`
     /// so concurrent callers don't redundantly attempt the same write. Pass

--- a/crates/sui-kvstore/src/bigtable/store.rs
+++ b/crates/sui-kvstore/src/bigtable/store.rs
@@ -89,7 +89,7 @@ impl Connection for BigTableConnection<'_> {
             .client
             .get_pipeline_watermark(pipeline_task)
             .await?
-            .map(|wm| wm.checkpoint_hi_inclusive))
+            .map(|wm| wm.checkpoint_hi_inclusive + 1))
     }
 
     async fn committer_watermark(

--- a/crates/sui-kvstore/src/lib.rs
+++ b/crates/sui-kvstore/src/lib.rs
@@ -235,7 +235,7 @@ pub trait KeyValueStoreReader {
         digest: CheckpointDigest,
     ) -> Result<Option<CheckpointData>>;
     /// Return the minimum watermark across the given pipelines, selecting the whole
-    /// watermark with the lowest `checkpoint_hi_inclusive`. Returns `None` if any
+    /// watermark with the lowest `checkpoint_hi`. Returns `None` if any
     /// pipeline is missing a watermark.
     async fn get_watermark_for_pipelines(
         &mut self,
@@ -480,7 +480,10 @@ impl From<sui_indexer_alt_framework_store_traits::CommitterWatermark> for Waterm
     fn from(w: sui_indexer_alt_framework_store_traits::CommitterWatermark) -> Self {
         Self {
             epoch_hi_inclusive: w.epoch_hi_inclusive,
-            checkpoint_hi_inclusive: w.checkpoint_hi_inclusive,
+            checkpoint_hi_inclusive: w
+                .checkpoint_hi
+                .checked_sub(1)
+                .unwrap_or_else(|| panic!("CommitterWatermark checkpoint_hi underflow {w:?}")),
             tx_hi: w.tx_hi,
             timestamp_ms_hi_inclusive: w.timestamp_ms_hi_inclusive,
         }
@@ -491,7 +494,7 @@ impl From<Watermark> for sui_indexer_alt_framework_store_traits::CommitterWaterm
     fn from(w: Watermark) -> Self {
         Self {
             epoch_hi_inclusive: w.epoch_hi_inclusive,
-            checkpoint_hi_inclusive: w.checkpoint_hi_inclusive,
+            checkpoint_hi: w.checkpoint_hi_inclusive + 1,
             tx_hi: w.tx_hi,
             timestamp_ms_hi_inclusive: w.timestamp_ms_hi_inclusive,
         }

--- a/crates/sui-kvstore/tests/e2e.rs
+++ b/crates/sui-kvstore/tests/e2e.rs
@@ -397,7 +397,7 @@ impl TestHarness {
                 interval.tick().await;
                 let ok = self.client.get_watermark().await.is_ok_and(|wm| {
                     wm.is_some_and(|wm| {
-                        wm.checkpoint_hi_inclusive >= checkpoint && wm.epoch_hi_inclusive >= epoch
+                        wm.checkpoint_hi_inclusive > checkpoint && wm.epoch_hi_inclusive >= epoch
                     })
                 });
                 if ok {

--- a/crates/sui-pg-db/migrations/2026-03-06-132800_watermarks_checkpoint_hi/down.sql
+++ b/crates/sui-pg-db/migrations/2026-03-06-132800_watermarks_checkpoint_hi/down.sql
@@ -1,0 +1,12 @@
+-- replace watermarks.checkpoint_hi with watermarks.checkpoint_hi_inclusive
+
+ALTER TABLE watermarks ADD COLUMN checkpoint_hi_inclusive BIGINT;
+
+UPDATE watermarks SET checkpoint_hi_inclusive = checkpoint_hi - 1;
+
+-- delete these records because they would not have been written by the old version
+DELETE FROM watermarks WHERE checkpoint_hi_inclusive = 0;
+
+ALTER TABLE watermarks ALTER COLUMN checkpoint_hi_inclusive SET NOT NULL;
+
+ALTER TABLE watermarks DROP COLUMN checkpoint_hi;

--- a/crates/sui-pg-db/migrations/2026-03-06-132800_watermarks_checkpoint_hi/up.sql
+++ b/crates/sui-pg-db/migrations/2026-03-06-132800_watermarks_checkpoint_hi/up.sql
@@ -1,0 +1,9 @@
+-- replace watermarks.checkpoint_hi_inclusive with watermarks.checkpoint_hi
+
+ALTER TABLE watermarks ADD COLUMN checkpoint_hi BIGINT;
+
+UPDATE watermarks SET checkpoint_hi = checkpoint_hi_inclusive + 1;
+
+ALTER TABLE watermarks ALTER COLUMN checkpoint_hi SET NOT NULL;
+
+ALTER TABLE watermarks DROP COLUMN checkpoint_hi_inclusive;

--- a/crates/sui-pg-db/src/model.rs
+++ b/crates/sui-pg-db/src/model.rs
@@ -12,7 +12,7 @@ use crate::schema::watermarks;
 pub struct StoredWatermark {
     pub pipeline: String,
     pub epoch_hi_inclusive: i64,
-    pub checkpoint_hi_inclusive: i64,
+    pub checkpoint_hi: i64,
     pub tx_hi: i64,
     pub timestamp_ms_hi_inclusive: i64,
     pub reader_lo: i64,

--- a/crates/sui-pg-db/src/schema.rs
+++ b/crates/sui-pg-db/src/schema.rs
@@ -6,11 +6,11 @@ diesel::table! {
     watermarks (pipeline) {
         pipeline -> Text,
         epoch_hi_inclusive -> Int8,
-        checkpoint_hi_inclusive -> Int8,
         tx_hi -> Int8,
         timestamp_ms_hi_inclusive -> Int8,
         reader_lo -> Int8,
         pruner_timestamp -> Timestamp,
         pruner_hi -> Int8,
+        checkpoint_hi -> Int8,
     }
 }

--- a/crates/sui-pg-db/src/store.rs
+++ b/crates/sui-pg-db/src/store.rs
@@ -4,7 +4,6 @@
 use std::time::Duration;
 
 use async_trait::async_trait;
-use chrono::DateTime;
 use chrono::Utc;
 use diesel::ExpressionMethods;
 use diesel::OptionalExtension;
@@ -30,18 +29,10 @@ impl store::Connection for Connection<'_> {
         pipeline_task: &str,
         default_next_checkpoint: u64,
     ) -> anyhow::Result<Option<u64>> {
-        let Some(checkpoint_hi_inclusive) = default_next_checkpoint.checked_sub(1) else {
-            // Do not create a watermark record with checkpoint_hi_inclusive = -1.
-            return Ok(self
-                .committer_watermark(pipeline_task)
-                .await?
-                .map(|w| w.checkpoint_hi_inclusive));
-        };
-
         let stored_watermark = StoredWatermark {
             pipeline: pipeline_task.to_string(),
             epoch_hi_inclusive: 0,
-            checkpoint_hi_inclusive: checkpoint_hi_inclusive as i64,
+            checkpoint_hi: default_next_checkpoint as i64,
             tx_hi: 0,
             timestamp_ms_hi_inclusive: 0,
             reader_lo: default_next_checkpoint as i64,
@@ -50,20 +41,16 @@ impl store::Connection for Connection<'_> {
         };
 
         use diesel::pg::upsert::excluded;
-        let checkpoint_hi_inclusive: i64 = diesel::insert_into(watermarks::table)
+        let checkpoint_hi: i64 = diesel::insert_into(watermarks::table)
             .values(&stored_watermark)
-            // There is an existing entry, so only write the new `hi` values
             .on_conflict(watermarks::pipeline)
-            // Use `do_update` instead of `do_nothing` to return the existing row with `returning`.
             .do_update()
-            // When using `do_update`, at least one change needs to be set, so set the pipeline to itself (nothing changes).
-            // `excluded` is a virtual table containing the existing row that there was a conflict with.
             .set(watermarks::pipeline.eq(excluded(watermarks::pipeline)))
-            .returning(watermarks::checkpoint_hi_inclusive)
+            .returning(watermarks::checkpoint_hi)
             .get_result(self)
             .await?;
 
-        Ok(Some(checkpoint_hi_inclusive as u64))
+        Ok(Some(u64::try_from(checkpoint_hi)?))
     }
 
     async fn committer_watermark(
@@ -73,7 +60,7 @@ impl store::Connection for Connection<'_> {
         let watermark: Option<(i64, i64, i64, i64)> = watermarks::table
             .select((
                 watermarks::epoch_hi_inclusive,
-                watermarks::checkpoint_hi_inclusive,
+                watermarks::checkpoint_hi,
                 watermarks::tx_hi,
                 watermarks::timestamp_ms_hi_inclusive,
             ))
@@ -84,10 +71,10 @@ impl store::Connection for Connection<'_> {
 
         if let Some(watermark) = watermark {
             Ok(Some(store::CommitterWatermark {
-                epoch_hi_inclusive: watermark.0 as u64,
-                checkpoint_hi_inclusive: watermark.1 as u64,
-                tx_hi: watermark.2 as u64,
-                timestamp_ms_hi_inclusive: watermark.3 as u64,
+                epoch_hi_inclusive: u64::try_from(watermark.0)?,
+                checkpoint_hi: u64::try_from(watermark.1)?,
+                tx_hi: u64::try_from(watermark.2)?,
+                timestamp_ms_hi_inclusive: u64::try_from(watermark.3)?,
             }))
         } else {
             Ok(None)
@@ -99,7 +86,7 @@ impl store::Connection for Connection<'_> {
         pipeline: &'static str,
     ) -> anyhow::Result<Option<store::ReaderWatermark>> {
         let watermark: Option<(i64, i64)> = watermarks::table
-            .select((watermarks::checkpoint_hi_inclusive, watermarks::reader_lo))
+            .select((watermarks::checkpoint_hi, watermarks::reader_lo))
             .filter(watermarks::pipeline.eq(pipeline))
             .first(self)
             .await
@@ -107,8 +94,8 @@ impl store::Connection for Connection<'_> {
 
         if let Some(watermark) = watermark {
             Ok(Some(store::ReaderWatermark {
-                checkpoint_hi_inclusive: watermark.0 as u64,
-                reader_lo: watermark.1 as u64,
+                checkpoint_hi: u64::try_from(watermark.0)?,
+                reader_lo: u64::try_from(watermark.1)?,
             }))
         } else {
             Ok(None)
@@ -140,8 +127,8 @@ impl store::Connection for Connection<'_> {
         if let Some(watermark) = watermark {
             Ok(Some(store::PrunerWatermark {
                 wait_for_ms: watermark.0,
-                pruner_hi: watermark.1 as u64,
-                reader_lo: watermark.2 as u64,
+                pruner_hi: u64::try_from(watermark.1)?,
+                reader_lo: u64::try_from(watermark.2)?,
             }))
         } else {
             Ok(None)
@@ -153,34 +140,16 @@ impl store::Connection for Connection<'_> {
         pipeline_task: &str,
         watermark: store::CommitterWatermark,
     ) -> anyhow::Result<bool> {
-        // Create a StoredWatermark directly from CommitterWatermark
-        let stored_watermark = StoredWatermark {
-            pipeline: pipeline_task.to_string(),
-            epoch_hi_inclusive: watermark.epoch_hi_inclusive as i64,
-            checkpoint_hi_inclusive: watermark.checkpoint_hi_inclusive as i64,
-            tx_hi: watermark.tx_hi as i64,
-            timestamp_ms_hi_inclusive: watermark.timestamp_ms_hi_inclusive as i64,
-            reader_lo: 0,
-            pruner_timestamp: DateTime::UNIX_EPOCH.naive_utc(),
-            pruner_hi: 0,
-        };
-
-        use diesel::query_dsl::methods::FilterDsl;
-        Ok(diesel::insert_into(watermarks::table)
-            .values(&stored_watermark)
-            // There is an existing entry, so only write the new `hi` values
-            .on_conflict(watermarks::pipeline)
-            .do_update()
+        Ok(diesel::update(watermarks::table)
             .set((
-                watermarks::epoch_hi_inclusive.eq(stored_watermark.epoch_hi_inclusive),
-                watermarks::checkpoint_hi_inclusive.eq(stored_watermark.checkpoint_hi_inclusive),
-                watermarks::tx_hi.eq(stored_watermark.tx_hi),
+                watermarks::epoch_hi_inclusive.eq(watermark.epoch_hi_inclusive as i64),
+                watermarks::checkpoint_hi.eq(watermark.checkpoint_hi as i64),
+                watermarks::tx_hi.eq(watermark.tx_hi as i64),
                 watermarks::timestamp_ms_hi_inclusive
-                    .eq(stored_watermark.timestamp_ms_hi_inclusive),
+                    .eq(watermark.timestamp_ms_hi_inclusive as i64),
             ))
-            .filter(
-                watermarks::checkpoint_hi_inclusive.lt(stored_watermark.checkpoint_hi_inclusive),
-            )
+            .filter(watermarks::pipeline.eq(pipeline_task))
+            .filter(watermarks::checkpoint_hi.lt(watermark.checkpoint_hi as i64))
             .execute(self)
             .await?
             > 0)

--- a/docs/content/concepts/data-access/pipeline-architecture.mdx
+++ b/docs/content/concepts/data-access/pipeline-architecture.mdx
@@ -67,17 +67,17 @@ The `Processor` component works identically in both sequential and concurrent pi
 
 Before diving into pipeline-specific architectures, understand the three types of watermarks used for coordination:
 
-| Watermark | Purpose | Used by |
-|-----------|---------|---------|
-| `checkpoint_hi_inclusive` | Highest checkpoint where all data is committed (no gaps) | Both pipelines for recovery and progress tracking |
-| `reader_lo` | Lowest checkpoint guaranteed to be available for queries | Concurrent pipelines with pruning enabled |
-| `pruner_hi` | Highest checkpoint that has been pruned (deleted) | Concurrent pipelines with pruning enabled |
+| Watermark       | Purpose                                                                          | Used by                                           |
+|-----------------|----------------------------------------------------------------------------------|---------------------------------------------------|
+| `checkpoint_hi` | Exclusive upper bound — all checkpoints below this value are committed (no gaps) | Both pipelines for recovery and progress tracking |
+| `reader_lo`     | Lowest checkpoint guaranteed to be available for queries                         | Concurrent pipelines with pruning enabled         |
+| `pruner_hi`     | Highest checkpoint that has been pruned (deleted)                                | Concurrent pipelines with pruning enabled         |
 
 These watermarks work together to enable safe out-of-order processing, automatic data cleanup, and recovery from failures.
 
 ## The watermark system {#watermark-system}
 
-For each pipeline, the indexer minimally tracks the highest checkpoint where all data up to that point is committed. Tracking is done through the `checkpoint_hi_inclusive` committer watermark. Both concurrent and sequential pipelines rely on `checkpoint_hi_inclusive` to understand where to resume processing on restarts.
+For each pipeline, the indexer minimally tracks the exclusive upper bound of committed checkpoints — all checkpoints below this value are committed. Tracking is done through the `checkpoint_hi` committer watermark. Both concurrent and sequential pipelines rely on `checkpoint_hi` to understand where to resume processing on restarts.
 
 Optionally, the pipeline tracks `reader_lo` and `pruner_hi`, which define safe lower bounds for reading and pruning operations, if pruning is enabled. These watermarks are particularly crucial for concurrent pipelines to enable out-of-order processing while maintaining data integrity.
 
@@ -97,56 +97,56 @@ This watermark system is what makes concurrent pipelines both high-performance a
 
 ### Scenario 1: Basic watermark (no pruning)
 
-With pruning disabled, the indexer reports each pipeline committer `checkpoint_hi_inclusive` only. Consider the following timeline, where a number of checkpoints are being processed and some are committed out of order.
+With pruning disabled, the indexer reports each pipeline committer `checkpoint_hi` only. Consider the following timeline, where a number of checkpoints are being processed and some are committed out of order.
 
 ```sh
 Checkpoint Processing Timeline:
 
 [1000] [1001] [1002] [1003] [1004] [1005]
   ✓      ✓      ✗      ✓      ✗      ✗
-         ^
-  checkpoint_hi_inclusive = 1001
+                ^
+  checkpoint_hi = 1002
 
 ✓ = Committed (all data written)
 ✗ = Not Committed (processing or failed)
 ```
 
-In this scenario, the `checkpoint_hi_inclusive` is at 1001, even though checkpoint 1003 is committed, because there is still a gap at 1002. The indexer must report the high watermark at 1001 to satisfy the guarantee that all data from start to `checkpoint_hi_inclusive` is available.
+In this scenario, `checkpoint_hi` is at 1002, even though checkpoint 1003 is committed, because there is still a gap at 1002. The indexer must report the high watermark at 1002 to satisfy the guarantee that all checkpoints below `checkpoint_hi` are available.
 
-After the checkpoint 1002 is committed, you can safely read data up to 1003.
+After checkpoint 1002 is committed, you can safely read data up to and including 1003.
 
 ```sh
 [1000] [1001] [1002] [1003] [1004] [1005]
   ✓      ✓      ✓      ✓      ✗       ✗
 [---- SAFE TO READ -------]
-(start   →   checkpoint_hi_inclusive at 1003)
+(start   →   checkpoint_hi = 1004)
 ```
 
 ### Scenario 2: Pruning enabled
 
-Pruning is enabled for pipelines configured with a retention policy. For example, if your table is growing too large and you want to keep only the last 4 checkpoints, then `retention = 4`. This means that the indexer periodically updates `reader_lo` as the difference between `checkpoint_hi_inclusive` and the configured retention. A separate pruning task is responsible for pruning data between `[pruner_hi, reader_lo]`.
+Pruning is enabled for pipelines configured with a retention policy. For example, if your table is growing too large and you want to keep only the last 4 checkpoints, then `retention = 4`. This means that the indexer periodically updates `reader_lo` as the difference between `checkpoint_hi` and the configured retention. A separate pruning task is responsible for pruning data between `[pruner_hi, reader_lo]`.
 
 ```sh
 [998] [999] [1000] [1001] [1002] [1003] [1004] [1005] [1006]
  🗑️    🗑️     ✓      ✓      ✓      ✓      ✗      ✗      ✗
-              ^                    ^
-       reader_lo = 1000       checkpoint_hi_inclusive = 1003
+              ^                           ^
+       reader_lo = 1000            checkpoint_hi = 1004
 
 🗑️ = Pruned (deleted)
-✓ = Committed  
+✓ = Committed
 ✗ = Not Committed
 ```
 
 Current watermarks:
 
-- `checkpoint_hi_inclusive` = 1003:
-       - All data from start to 1003 is complete (no gaps).
+- `checkpoint_hi` = 1004:
+       - All checkpoints below 1004 are committed (no gaps).
        - Cannot advance to 1005 because 1004 is not committed yet (gap).
 
 - `reader_lo` = 1000:
        - Lowest checkpoint guaranteed to be available.
-       - Calculated as: `reader_lo = checkpoint_hi_inclusive - retention + 1`.
-       - `reader_lo` = 1003 - 4 + 1 = 1000.
+       - Calculated as: `reader_lo = checkpoint_hi - retention`.
+       - `reader_lo` = 1004 - 4 = 1000.
 
 - `pruner_hi` = 1000:
        - Highest exclusive checkpoint that has been deleted.
@@ -168,34 +168,34 @@ Clear safe zones:
 ```sh
 [999] [1000] [1001] [1002] [1003] [1004] [1005] [1006] [1007]
  🗑️     ✓      ✓      ✓      ✓      ✓      ✗      ✓      ✗
-        ^                           ^
- reader_lo = 1000           checkpoint_hi_inclusive = 1004 (advanced by 1)
+        ^                                  ^
+ reader_lo = 1000                  checkpoint_hi = 1005 (advanced by 1)
  pruner_hi = 1000
 ```
 
-With checkpoint 1004 now committed, `checkpoint_hi_inclusive` can advance from 1003 to 1004 because there are no gaps up to 1004. Note that `reader_lo` and `pruner_hi` have not changed yet.
+With checkpoint 1004 now committed, `checkpoint_hi` can advance from 1004 to 1005 because all checkpoints below 1005 are committed. Note that `reader_lo` and `pruner_hi` have not changed yet.
 
 **Step 2:** Reader watermark updates periodically.
 
 ```sh
 [999] [1000] [1001] [1002] [1003] [1004] [1005] [1006] [1007]
  🗑️     ✓      ✓      ✓      ✓      ✓      ✗      ✓      ✗
-               ^                   ^
-        reader_lo = 1001    checkpoint_hi_inclusive = 1004
-        (1004 - 4 + 1 = 1001)
+               ^                           ^
+        reader_lo = 1001           checkpoint_hi = 1005
+        (1005 - 4 = 1001)
 
 pruner_hi = 1000 (unchanged as pruner hasn't run yet)
 ```
 
-A separate reader watermark update task (running periodically, configurable) advances `reader_lo` to 1001 (calculated as `1004 - 4 + 1 = 1001`) based on the retention policy. However, the pruner hasn't run yet, so `pruner_hi` remains at 1000.
+A separate reader watermark update task (running periodically, configurable) advances `reader_lo` to 1001 (calculated as `1005 - 4 = 1001`) based on the retention policy. However, the pruner hasn't run yet, so `pruner_hi` remains at 1000.
 
 **Step 3:** Pruner runs after safety delay.
 
 ```sh
 [999] [1000] [1001] [1002] [1003] [1004] [1005] [1006] [1007]
  🗑️     🗑️     ✓      ✓      ✓      ✓      ✗      ✓      ✗
-               ^                   ^
-        reader_lo = 1001    checkpoint_hi_inclusive = 1004
+               ^                           ^
+        reader_lo = 1001           checkpoint_hi = 1005
         pruner_hi = 1001
 ```
 
@@ -386,15 +386,15 @@ The `Committer` tasks don't actually perform database operations. Rather, it cal
 
 #### `CommitterWatermark` {#con-commit-watermark}
 
-The primary responsibility of the `CommitterWatermark` is to track which checkpoints are fully committed and update `checkpoint_hi_inclusive` in the `Watermark` table.
+The primary responsibility of the `CommitterWatermark` is to track which checkpoints are fully committed and update `checkpoint_hi` in the `Watermark` table.
 
 The `CommitterWatermark` receives `WatermarkParts` from successful `Committer` writes.
 
 <ImportContent mode="code" source="crates/sui-indexer-alt-framework/src/pipeline/mod.rs" struct="WatermarkPart"/>
     
-The `CommitterWatermark` maintains an in-memory map of checkpoint completion status, advancing `checkpoint_hi_inclusive` only when there are no gaps in the sequence. Periodically, it writes the new `checkpoint_hi_inclusive` to the `Watermark` database.
+The `CommitterWatermark` maintains an in-memory map of checkpoint completion status, advancing `checkpoint_hi` only when there are no gaps in the sequence. Periodically, it writes the new `checkpoint_hi` to the `Watermark` database.
 
-This component enforces the critical rule that `checkpoint_hi_inclusive` can advance only when all data up to that point is committed with no gaps. See the [watermark system](#watermark-system) for details on how this enables safe out-of-order processing.
+This component enforces the critical rule that `checkpoint_hi` can advance only when all checkpoints below it are committed with no gaps. See the [watermark system](#watermark-system) for details on how this enables safe out-of-order processing.
 
 By using polling, updates happen on a configurable interval (`watermark_interval_ms`) rather than immediately, balancing consistency with performance.
 
@@ -404,7 +404,7 @@ By using polling, updates happen on a configurable interval (`watermark_interval
 
 The primary responsibility of the `ReaderWatermark` is to calculate and update `reader_lo` to maintain the retention policy and provide safe pruning boundaries.
 
-The `ReaderWatermark` polls the `Watermark` database periodically (`interval_ms`) to check current `checkpoint_hi_inclusive`. It then calculates the new `reader_lo = checkpoint_hi_inclusive - retention + 1` value and updates the `reader_lo` and `pruner_timestamp` in the `Watermark` database. This behavior provides the safety buffer that prevents premature pruning.
+The `ReaderWatermark` polls the `Watermark` database periodically (`interval_ms`) to check current `checkpoint_hi`. It then calculates the new `reader_lo = checkpoint_hi - retention` value and updates the `reader_lo` and `pruner_timestamp` in the `Watermark` database. This behavior provides the safety buffer that prevents premature pruning.
 
 The `reader_lo` value represents the lowest checkpoint guaranteed to be available. This component ensures your retention policy is maintained. See the [watermark system](#watermark-system) section for details on how `reader_lo` creates safe reading zones.
 


### PR DESCRIPTION
## Description 

This PR changes the watermark `checkpoint_hi_inclusive` field to `checkpoint_hi` (exclusive) in order to support the initial `[reader_lo, checkpoint_hi)` empty state where no checkpoints have been indexed.

This replaces https://github.com/MystenLabs/sui/pull/25616.

## Test plan 

Unit tests passing.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
