### PR TITLE
Move defer_unpaid_amplification=false from protocol v114 to v115

### DIFF
--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -302,6 +302,7 @@ const MAX_PROTOCOL_VERSION: u64 = 115;
 // Version 115: Gasless transaction drop safety.
 //              Enable address aliases on mainnet.
 //              Relax ValidDuring requirement for transactions with owned inputs.
+//              Disable defer_unpaid_amplification (debugging).
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
@@ -4651,13 +4652,13 @@ impl ProtocolConfig {
                         cfg.feature_flags
                             .include_checkpoint_artifacts_digest_in_summary = true;
                     }
-                    // Disabled while debugging
-                    cfg.feature_flags.defer_unpaid_amplification = false;
                 }
                 115 => {
                     cfg.feature_flags.gasless_transaction_drop_safety = true;
                     cfg.feature_flags.address_aliases = true;
                     cfg.feature_flags.relax_valid_during_for_owned_inputs = true;
+                    // Disabled while debugging
+                    cfg.feature_flags.defer_unpaid_amplification = false;
                 }
                 // Use this template when making changes:
                 //

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_114.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_114.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/sui-protocol-config/src/lib.rs
-assertion_line: 5162
 expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
 ---
 version: 114
@@ -155,6 +154,7 @@ feature_flags:
   split_checkpoints_in_consensus_handler: true
   consensus_always_accept_system_transactions: true
   validator_metadata_verify_v2: true
+  defer_unpaid_amplification: true
   randomize_checkpoint_tx_limit_in_tests: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048


### PR DESCRIPTION
## Summary
- Fix protocol config issue from PR #25663 where `defer_unpaid_amplification=false` was incorrectly added to version 114
- Version 114 is already in release branch 1.67.0 and cannot be modified
- Moves the setting to version 115 where it belongs
- Also fixes duplicate "Version 115:" comment in protocol config version history

## Test plan
- [x] `cargo insta test -p sui-protocol-config --accept` passes with snapshot updates
- [x] Protocol config snapshot for version 114 reverted to correct state

🤖 Generated with [Claude Code](https://claude.com/claude-code)