### PR TITLE
Remove assertion_line metadata from v114 protocol config snapshots

### DIFF
--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_114.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_114.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/sui-protocol-config/src/lib.rs
-assertion_line: 5162
 expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
 ---
 version: 114

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_114.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_114.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/sui-protocol-config/src/lib.rs
-assertion_line: 5162
 expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
 ---
 version: 114


### PR DESCRIPTION
## Summary
- Removes `assertion_line: 5162` metadata from v114 Testnet and Mainnet protocol config snapshots
- This metadata was inadvertently added in #25564 when snapshot tests were re-run
- The released testnet binary (`4e8aa9ee8b30`) does not have this metadata, causing `check-protocol-compatibility.sh testnet check` to fail with a false diff

## Test plan
- [x] `cargo test --package sui-protocol-config snapshot_tests` passes
- [x] Verified the two snapshot files now match the released testnet version

🤖 Generated with [Claude Code](https://claude.ai/code)