### PR TITLE
Go back to 1 bigtable connection for readers

### DIFF
--- a/crates/sui-indexer-alt-reader/src/bigtable_reader.rs
+++ b/crates/sui-indexer-alt-reader/src/bigtable_reader.rs
@@ -82,7 +82,7 @@ impl BigtableReader {
                 client_name,
                 Some(registry),
                 bigtable_args.bigtable_app_profile_id,
-                None,
+                Some(1),
             )
             .await
             .context("Failed to create BigTable client")?,

--- a/crates/sui-kv-rpc/src/lib.rs
+++ b/crates/sui-kv-rpc/src/lib.rs
@@ -43,7 +43,7 @@ impl KvRpcServer {
             "sui-kv-rpc".to_string(),
             Some(registry),
             app_profile_id,
-            None,
+            Some(1),
             credentials_path,
         )
         .await?;


### PR DESCRIPTION
## Description

I introduced a connection pool with 10 connections for backfills, and also gave each reader instance 10 connections by default.

This is causing transient error spikes in testnet where the new reader code has been deployed due to stale connections (since now connection utilization is much lower).

I am doing some research into how Google's official Java/Go bigtable clients manage connection pool sizing, health checks, reconnects, keep-alive, etc, but in the immediate term reducing this count to 1 should increase connection utilization and at least get us back to where we were.
