### PR TITLE
sui-indexer-alt: init pipelines to checkpoint_hi_inclusive = reader_lo - 1

### DIFF
--- a/crates/sui-analytics-indexer/src/store/migration.rs
+++ b/crates/sui-analytics-indexer/src/store/migration.rs
@@ -24,6 +24,7 @@ use object_store::PutPayload;
 use object_store::UpdateVersion;
 use object_store::path::Path as ObjectPath;
 use sui_indexer_alt_framework_store_traits::CommitterWatermark;
+use sui_indexer_alt_framework_store_traits::InitWatermark;
 use sui_storage::object_store::util::find_all_dirs_with_epoch_prefix;
 use thiserror::Error;
 use tracing::debug;
@@ -260,12 +261,16 @@ impl MigrationStore {
     pub(crate) async fn init_watermark(
         &self,
         pipeline: &str,
-        _default_next_checkpoint: u64,
-    ) -> anyhow::Result<Option<u64>> {
-        Ok(self
+        init_watermark: InitWatermark,
+    ) -> anyhow::Result<InitWatermark> {
+        let checkpoint_hi_inclusive = self
             .committer_watermark(pipeline)
             .await?
-            .map(|w| w.checkpoint_hi_inclusive))
+            .map(|w| w.checkpoint_hi_inclusive);
+        Ok(InitWatermark {
+            checkpoint_hi_inclusive,
+            ..init_watermark
+        })
     }
 
     /// Update watermark for a single pipeline after successful file upload.

--- a/crates/sui-analytics-indexer/src/store/mod.rs
+++ b/crates/sui-analytics-indexer/src/store/mod.rs
@@ -34,6 +34,7 @@ use sui_indexer_alt_framework::store::Connection;
 use sui_indexer_alt_framework::store::Store;
 use sui_indexer_alt_framework::store::TransactionalStore;
 use sui_indexer_alt_framework_store_traits::CommitterWatermark;
+use sui_indexer_alt_framework_store_traits::InitWatermark;
 use sui_indexer_alt_framework_store_traits::PrunerWatermark;
 use sui_indexer_alt_framework_store_traits::ReaderWatermark;
 use sui_types::base_types::EpochId;
@@ -123,7 +124,6 @@ pub use migration::FileRangeEntry;
 pub use migration::FileRangeIndex;
 pub use migration::MigrationStore;
 pub use migration::WatermarkUpdateError;
-
 use uploader::PendingFileUpload;
 
 /// The operational mode of the analytics store.
@@ -628,27 +628,27 @@ impl Connection for AnalyticsConnection<'_> {
     /// Initialize watermark.
     ///
     /// In live mode: Watermarks are derived from file names, so just delegates to `committer_watermark`.
-    /// In migration mode: If no watermark exists and `default_next_checkpoint > 0`, initializes
-    /// the watermark to `default_next_checkpoint - 1` so migration starts from the configured
-    /// `first_checkpoint`.
+    /// In migration mode: Delegates to `MigrationStore::init_watermark`.
     async fn init_watermark(
         &mut self,
         pipeline_task: &str,
-        default_next_checkpoint: u64,
-    ) -> anyhow::Result<Option<u64>> {
+        init_watermark: InitWatermark,
+    ) -> anyhow::Result<InitWatermark> {
         match &self.store.mode {
             StoreMode::Live(_) => {
                 // Live mode: derive from file names
-                Ok(self
+                let checkpoint_hi_inclusive = self
                     .committer_watermark(pipeline_task)
                     .await?
-                    .map(|w| w.checkpoint_hi_inclusive))
+                    .map(|w| w.checkpoint_hi_inclusive);
+                Ok(InitWatermark {
+                    checkpoint_hi_inclusive,
+                    ..init_watermark
+                })
             }
             StoreMode::Migration(store) => {
                 let output_prefix = self.pipeline_config(pipeline_task).output_prefix();
-                store
-                    .init_watermark(output_prefix, default_next_checkpoint)
-                    .await
+                store.init_watermark(output_prefix, init_watermark).await
             }
         }
     }

--- a/crates/sui-indexer-alt-consistent-store/src/store/mod.rs
+++ b/crates/sui-indexer-alt-consistent-store/src/store/mod.rs
@@ -13,6 +13,7 @@ use prometheus::Registry;
 use scoped_futures::ScopedBoxFuture;
 use sui_indexer_alt_framework::service::Service;
 use sui_indexer_alt_framework::store::CommitterWatermark;
+use sui_indexer_alt_framework::store::InitWatermark;
 use sui_indexer_alt_framework::store::Store as _;
 use sui_indexer_alt_framework::store::{self};
 
@@ -165,11 +166,19 @@ impl<S: Send + Sync + 'static> store::TransactionalStore for Store<S> {
 
 #[async_trait::async_trait]
 impl<S: Send + Sync> store::Connection for Connection<'_, S> {
-    async fn init_watermark(&mut self, pipeline_task: &str, _: u64) -> anyhow::Result<Option<u64>> {
-        Ok(self
+    async fn init_watermark(
+        &mut self,
+        pipeline_task: &str,
+        init_watermark: InitWatermark,
+    ) -> anyhow::Result<InitWatermark> {
+        let checkpoint_hi_inclusive = self
             .committer_watermark(pipeline_task)
             .await?
-            .map(|w| w.checkpoint_hi_inclusive))
+            .map(|w| w.checkpoint_hi_inclusive);
+        Ok(InitWatermark {
+            checkpoint_hi_inclusive,
+            ..init_watermark
+        })
     }
 
     async fn committer_watermark(

--- a/crates/sui-indexer-alt-e2e-tests/src/lib.rs
+++ b/crates/sui-indexer-alt-e2e-tests/src/lib.rs
@@ -463,6 +463,7 @@ impl OffchainCluster {
         let latest: HashMap<String, i64> = w::watermarks
             .select((w::pipeline, w::checkpoint_hi_inclusive))
             .filter(w::pipeline.eq_any(&self.pipelines))
+            .filter(w::reader_lo.le(w::checkpoint_hi_inclusive))
             .load(&mut conn)
             .await?
             .into_iter()

--- a/crates/sui-indexer-alt-framework-store-traits/src/lib.rs
+++ b/crates/sui-indexer-alt-framework-store-traits/src/lib.rs
@@ -13,13 +13,14 @@ use scoped_futures::ScopedBoxFuture;
 /// operations, agnostic of the underlying store implementation.
 #[async_trait]
 pub trait Connection: Send {
-    /// If no existing watermark record exists, initializes it with `default_next_checkpoint`.
-    /// Returns the committer watermark `checkpoint_hi_inclusive`.
+    /// Returns the `InitWatermark` based on the existing watermark if it exists.
+    /// Otherwise, initializes a new watermark record with `InitWatermark` and returns
+    /// the value passed in.
     async fn init_watermark(
         &mut self,
         pipeline_task: &str,
-        default_next_checkpoint: u64,
-    ) -> anyhow::Result<Option<u64>>;
+        init_watermark: InitWatermark,
+    ) -> anyhow::Result<InitWatermark>;
 
     /// Given a `pipeline_task` representing either a pipeline name or a pipeline with an associated
     /// task (formatted as `{pipeline}{Store::DELIMITER}{task}`), return the committer watermark
@@ -114,6 +115,13 @@ pub trait TransactionalStore: Store {
         F: for<'r> FnOnce(
             &'r mut Self::Connection<'_>,
         ) -> ScopedBoxFuture<'a, 'r, anyhow::Result<R>>;
+}
+
+/// Used during watermark initialization to set and return state.
+#[derive(Default, Debug, Clone, Copy, PartialEq)]
+pub struct InitWatermark {
+    pub checkpoint_hi_inclusive: Option<u64>,
+    pub reader_lo: u64,
 }
 
 /// Represents the highest checkpoint for some pipeline that has been processed by the indexer

--- a/crates/sui-indexer-alt-framework/src/lib.rs
+++ b/crates/sui-indexer-alt-framework/src/lib.rs
@@ -15,6 +15,7 @@ use ingestion::ingestion_client::IngestionClient;
 use metrics::IndexerMetrics;
 use prometheus::Registry;
 use sui_indexer_alt_framework_store_traits::Connection;
+use sui_indexer_alt_framework_store_traits::InitWatermark;
 use sui_indexer_alt_framework_store_traits::Store;
 use sui_indexer_alt_framework_store_traits::TransactionalStore;
 use sui_indexer_alt_framework_store_traits::pipeline_task;
@@ -375,13 +376,21 @@ impl<S: Store> Indexer<S> {
         let pipeline_task =
             pipeline_task::<S>(P::NAME, self.task.as_ref().map(|t| t.task.as_str()))?;
 
-        let checkpoint_hi_inclusive = conn
-            .init_watermark(&pipeline_task, self.default_next_checkpoint)
+        let InitWatermark {
+            checkpoint_hi_inclusive,
+            reader_lo,
+        } = conn
+            .init_watermark(
+                &pipeline_task,
+                InitWatermark {
+                    checkpoint_hi_inclusive: self.default_next_checkpoint.checked_sub(1),
+                    reader_lo: self.default_next_checkpoint,
+                },
+            )
             .await
             .with_context(|| format!("Failed to init watermark for {pipeline_task}"))?;
 
-        let next_checkpoint =
-            checkpoint_hi_inclusive.map_or(self.default_next_checkpoint, |c| c + 1);
+        let next_checkpoint = checkpoint_hi_inclusive.map_or(reader_lo, |c| c + 1);
 
         self.first_ingestion_checkpoint = next_checkpoint.min(self.first_ingestion_checkpoint);
 
@@ -698,6 +707,10 @@ mod tests {
         test_pipeline!(D, "sequential_d");
 
         let mut conn = store.connect().await.unwrap();
+
+        conn.init_watermark(A::NAME, InitWatermark::default())
+            .await
+            .unwrap();
         conn.set_committer_watermark(
             A::NAME,
             CommitterWatermark {
@@ -707,6 +720,10 @@ mod tests {
         )
         .await
         .unwrap();
+
+        conn.init_watermark(B::NAME, InitWatermark::default())
+            .await
+            .unwrap();
         conn.set_committer_watermark(
             B::NAME,
             CommitterWatermark {
@@ -716,6 +733,10 @@ mod tests {
         )
         .await
         .unwrap();
+
+        conn.init_watermark(C::NAME, InitWatermark::default())
+            .await
+            .unwrap();
         conn.set_committer_watermark(
             C::NAME,
             CommitterWatermark {
@@ -725,6 +746,10 @@ mod tests {
         )
         .await
         .unwrap();
+
+        conn.init_watermark(D::NAME, InitWatermark::default())
+            .await
+            .unwrap();
         conn.set_committer_watermark(
             D::NAME,
             CommitterWatermark {
@@ -2053,10 +2078,10 @@ mod tests {
         }
         let main_pipeline_watermark = store.watermark("test").unwrap();
         // assert that the main pipeline's watermarks are not updated
-        assert_eq!(main_pipeline_watermark.checkpoint_hi_inclusive, 10);
+        assert_eq!(main_pipeline_watermark.checkpoint_hi_inclusive, Some(10));
         assert_eq!(main_pipeline_watermark.reader_lo, 5);
         let tasked_pipeline_watermark = store.watermark("test@task").unwrap();
-        assert_eq!(tasked_pipeline_watermark.checkpoint_hi_inclusive, 25);
+        assert_eq!(tasked_pipeline_watermark.checkpoint_hi_inclusive, Some(25));
         assert_eq!(tasked_pipeline_watermark.reader_lo, 9);
     }
 

--- a/crates/sui-indexer-alt-framework/src/mocks/store.rs
+++ b/crates/sui-indexer-alt-framework/src/mocks/store.rs
@@ -1,7 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::ops::Deref;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::atomic::AtomicUsize;
@@ -12,7 +11,9 @@ use std::time::UNIX_EPOCH;
 use anyhow::ensure;
 use async_trait::async_trait;
 use dashmap::DashMap;
+use dashmap::mapref::one::Ref;
 use scoped_futures::ScopedBoxFuture;
+use sui_indexer_alt_framework_store_traits::InitWatermark;
 use tokio::time::Duration;
 
 use crate::store::CommitterWatermark;
@@ -25,7 +26,9 @@ use crate::store::TransactionalStore;
 #[derive(Default, Clone)]
 pub struct MockWatermark {
     pub epoch_hi_inclusive: u64,
-    pub checkpoint_hi_inclusive: u64,
+    // Some -> highest indexed checkpoint
+    // None -> pipeline has been initialized, but no checkpoints have been indexed
+    pub checkpoint_hi_inclusive: Option<u64>,
     pub tx_hi: u64,
     pub timestamp_ms_hi_inclusive: u64,
     pub reader_lo: u64,
@@ -84,52 +87,60 @@ pub struct MockStore {
 #[derive(Clone)]
 pub struct MockConnection<'c>(pub &'c MockStore);
 
+impl MockConnection<'_> {
+    async fn get_watermark(
+        &self,
+        pipeline: &str,
+    ) -> anyhow::Result<Option<(Ref<String, MockWatermark>, u64)>> {
+        let Some(watermark) = self.0.watermarks.get(pipeline) else {
+            return Err(anyhow::anyhow!("Pipeline {} not found", pipeline));
+        };
+
+        Ok(watermark.checkpoint_hi_inclusive.map(|cp| (watermark, cp)))
+    }
+}
+
 #[async_trait]
 impl Connection for MockConnection<'_> {
     async fn init_watermark(
         &mut self,
         pipeline_task: &str,
-        default_next_checkpoint: u64,
-    ) -> anyhow::Result<Option<u64>> {
-        let Some(checkpoint_hi_inclusive) = default_next_checkpoint.checked_sub(1) else {
-            // Do not create a watermark record with checkpoint_hi_inclusive = -1.
-            return Ok(self
-                .committer_watermark(pipeline_task)
-                .await?
-                .map(|w| w.checkpoint_hi_inclusive));
-        };
-
-        let &MockWatermark {
-            checkpoint_hi_inclusive,
-            ..
-        } = self
+        init_watermark: InitWatermark,
+    ) -> anyhow::Result<InitWatermark> {
+        let watermark = self
             .0
             .watermarks
             .entry(pipeline_task.to_string())
             .or_insert(MockWatermark {
                 epoch_hi_inclusive: 0,
-                checkpoint_hi_inclusive,
+                checkpoint_hi_inclusive: init_watermark.checkpoint_hi_inclusive,
                 tx_hi: 0,
                 timestamp_ms_hi_inclusive: 0,
-                reader_lo: default_next_checkpoint,
+                reader_lo: init_watermark.reader_lo,
                 pruner_timestamp: 0,
-                pruner_hi: default_next_checkpoint,
-            })
-            .deref();
+                pruner_hi: init_watermark.reader_lo,
+            });
 
-        Ok(Some(checkpoint_hi_inclusive))
+        Ok(InitWatermark {
+            checkpoint_hi_inclusive: watermark.checkpoint_hi_inclusive,
+            reader_lo: watermark.reader_lo,
+        })
     }
 
     async fn committer_watermark(
         &mut self,
         pipeline_task: &str,
     ) -> Result<Option<CommitterWatermark>, anyhow::Error> {
-        let watermark = self.0.watermarks.get(pipeline_task);
-        Ok(watermark.map(|w| CommitterWatermark {
-            epoch_hi_inclusive: w.epoch_hi_inclusive,
-            checkpoint_hi_inclusive: w.checkpoint_hi_inclusive,
-            tx_hi: w.tx_hi,
-            timestamp_ms_hi_inclusive: w.timestamp_ms_hi_inclusive,
+        let Some((watermark, checkpoint_hi_inclusive)) = self.get_watermark(pipeline_task).await?
+        else {
+            return Ok(None);
+        };
+
+        Ok(Some(CommitterWatermark {
+            epoch_hi_inclusive: watermark.epoch_hi_inclusive,
+            checkpoint_hi_inclusive,
+            tx_hi: watermark.tx_hi,
+            timestamp_ms_hi_inclusive: watermark.timestamp_ms_hi_inclusive,
         }))
     }
 
@@ -137,10 +148,13 @@ impl Connection for MockConnection<'_> {
         &mut self,
         pipeline: &'static str,
     ) -> Result<Option<ReaderWatermark>, anyhow::Error> {
-        let watermark = self.0.watermarks.get(pipeline);
-        Ok(watermark.map(|w| ReaderWatermark {
-            checkpoint_hi_inclusive: w.checkpoint_hi_inclusive,
-            reader_lo: w.reader_lo,
+        let Some((watermark, checkpoint_hi_inclusive)) = self.get_watermark(pipeline).await? else {
+            return Ok(None);
+        };
+
+        Ok(Some(ReaderWatermark {
+            checkpoint_hi_inclusive,
+            reader_lo: watermark.reader_lo,
         }))
     }
 
@@ -149,19 +163,20 @@ impl Connection for MockConnection<'_> {
         pipeline: &'static str,
         delay: Duration,
     ) -> Result<Option<PrunerWatermark>, anyhow::Error> {
-        let watermark = self.0.watermarks.get(pipeline);
-        Ok(watermark.map(|w| {
-            let elapsed_ms = w.pruner_timestamp as i64
-                - SystemTime::now()
-                    .duration_since(UNIX_EPOCH)
-                    .unwrap()
-                    .as_millis() as i64;
-            let wait_for_ms = delay.as_millis() as i64 + elapsed_ms;
-            PrunerWatermark {
-                pruner_hi: w.pruner_hi,
-                reader_lo: w.reader_lo,
-                wait_for_ms,
-            }
+        let Some((watermark, _)) = self.get_watermark(pipeline).await? else {
+            return Ok(None);
+        };
+
+        let elapsed_ms = watermark.pruner_timestamp as i64
+            - SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_millis() as i64;
+        let wait_for_ms = delay.as_millis() as i64 + elapsed_ms;
+        Ok(Some(PrunerWatermark {
+            pruner_hi: watermark.pruner_hi,
+            reader_lo: watermark.reader_lo,
+            wait_for_ms,
         }))
     }
 
@@ -189,7 +204,7 @@ impl Connection for MockConnection<'_> {
             .or_default();
 
         wm.epoch_hi_inclusive = watermark.epoch_hi_inclusive;
-        wm.checkpoint_hi_inclusive = watermark.checkpoint_hi_inclusive;
+        wm.checkpoint_hi_inclusive = Some(watermark.checkpoint_hi_inclusive);
         wm.tx_hi = watermark.tx_hi;
         wm.timestamp_ms_hi_inclusive = watermark.timestamp_ms_hi_inclusive;
         Ok(true)
@@ -563,7 +578,9 @@ impl MockStore {
         let start = tokio::time::Instant::now();
         while start.elapsed() < timeout_duration {
             if let Some(watermark) = self.watermark(pipeline_task)
-                && watermark.checkpoint_hi_inclusive >= checkpoint
+                && watermark
+                    .checkpoint_hi_inclusive
+                    .is_some_and(|c| c >= checkpoint)
             {
                 return watermark;
             }

--- a/crates/sui-indexer-alt-framework/src/pipeline/concurrent/commit_watermark.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/concurrent/commit_watermark.rs
@@ -423,7 +423,7 @@ mod tests {
 
         // Verify watermark progression
         let watermark = setup.store.watermark(DataPipeline::NAME).unwrap();
-        assert_eq!(watermark.checkpoint_hi_inclusive, 3);
+        assert_eq!(watermark.checkpoint_hi_inclusive, Some(3));
     }
 
     #[tokio::test]
@@ -444,7 +444,7 @@ mod tests {
 
         // Verify watermark hasn't progressed past 2
         let watermark = setup.store.watermark(DataPipeline::NAME).unwrap();
-        assert_eq!(watermark.checkpoint_hi_inclusive, 2);
+        assert_eq!(watermark.checkpoint_hi_inclusive, Some(2));
 
         // Send checkpoint 3 to fill the gap
         setup
@@ -458,7 +458,7 @@ mod tests {
 
         // Verify watermark has progressed to 4
         let watermark = setup.store.watermark(DataPipeline::NAME).unwrap();
-        assert_eq!(watermark.checkpoint_hi_inclusive, 4);
+        assert_eq!(watermark.checkpoint_hi_inclusive, Some(4));
     }
 
     #[tokio::test]
@@ -486,7 +486,7 @@ mod tests {
 
         // Verify watermark has progressed
         let watermark = setup.store.watermark(DataPipeline::NAME).unwrap();
-        assert_eq!(watermark.checkpoint_hi_inclusive, 1);
+        assert_eq!(watermark.checkpoint_hi_inclusive, Some(1));
     }
 
     #[tokio::test]
@@ -519,7 +519,7 @@ mod tests {
 
         // Verify watermark has progressed after retry
         let watermark = setup.store.watermark(DataPipeline::NAME).unwrap();
-        assert_eq!(watermark.checkpoint_hi_inclusive, 10);
+        assert_eq!(watermark.checkpoint_hi_inclusive, Some(10));
     }
 
     #[tokio::test]
@@ -560,7 +560,7 @@ mod tests {
         tokio::time::sleep(Duration::from_millis(1_200)).await;
 
         let watermark = setup.store.watermark(DataPipeline::NAME).unwrap();
-        assert_eq!(watermark.checkpoint_hi_inclusive, 11);
+        assert_eq!(watermark.checkpoint_hi_inclusive, Some(11));
     }
 
     #[tokio::test]
@@ -601,7 +601,7 @@ mod tests {
 
         // Verify watermark has progressed
         let watermark = setup.store.watermark(DataPipeline::NAME).unwrap();
-        assert_eq!(watermark.checkpoint_hi_inclusive, 1);
+        assert_eq!(watermark.checkpoint_hi_inclusive, Some(1));
     }
 
     #[tokio::test]
@@ -635,6 +635,6 @@ mod tests {
 
         // Verify watermark has progressed
         let watermark = setup.store.watermark(DataPipeline::NAME).unwrap();
-        assert_eq!(watermark.checkpoint_hi_inclusive, 1);
+        assert_eq!(watermark.checkpoint_hi_inclusive, Some(1));
     }
 }

--- a/crates/sui-indexer-alt-framework/src/pipeline/concurrent/mod.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/concurrent/mod.rs
@@ -600,7 +600,7 @@ mod tests {
         }
 
         // Verify watermark progression
-        assert_eq!(watermark.checkpoint_hi_inclusive, 9);
+        assert_eq!(watermark.checkpoint_hi_inclusive, Some(9));
         assert_eq!(watermark.tx_hi, 18); // 9 * 2
         assert_eq!(watermark.timestamp_ms_hi_inclusive, 1000009000); // 1000000000 + 9 * 1000
 
@@ -662,7 +662,7 @@ mod tests {
 
         // Watermark should only progress to 1 (can't progress past the gap)
         let watermark = setup.store.watermark(DataPipeline::NAME).unwrap();
-        assert_eq!(watermark.checkpoint_hi_inclusive, 1);
+        assert_eq!(watermark.checkpoint_hi_inclusive, Some(1));
 
         // Now send the missing checkpoint 2
         setup
@@ -675,7 +675,7 @@ mod tests {
             .store
             .wait_for_watermark(DataPipeline::NAME, 4, TEST_TIMEOUT)
             .await;
-        assert_eq!(watermark.checkpoint_hi_inclusive, 4);
+        assert_eq!(watermark.checkpoint_hi_inclusive, Some(4));
     }
 
     // ==================== BACK-PRESSURE TESTING ====================

--- a/crates/sui-indexer-alt-framework/src/pipeline/concurrent/pruner.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/concurrent/pruner.rs
@@ -153,7 +153,7 @@ pub(super) fn pruner<H: Handler + Send + Sync + 'static>(
 
                     Ok(None) => {
                         guard.stop_and_record();
-                        warn!(pipeline = H::NAME, "No watermark for pipeline, skipping");
+                        info!(pipeline = H::NAME, "No watermark for pipeline, skipping");
                         continue;
                     }
 
@@ -535,7 +535,7 @@ mod tests {
 
         let watermark = MockWatermark {
             epoch_hi_inclusive: 0,
-            checkpoint_hi_inclusive: 3,
+            checkpoint_hi_inclusive: Some(3),
             tx_hi: 9,
             timestamp_ms_hi_inclusive: timestamp,
             reader_lo: 3,
@@ -614,7 +614,7 @@ mod tests {
 
         let watermark = MockWatermark {
             epoch_hi_inclusive: 0,
-            checkpoint_hi_inclusive: 3,
+            checkpoint_hi_inclusive: Some(3),
             tx_hi: 9,
             timestamp_ms_hi_inclusive: timestamp,
             reader_lo: 3,
@@ -680,7 +680,7 @@ mod tests {
 
         let watermark = MockWatermark {
             epoch_hi_inclusive: 0,
-            checkpoint_hi_inclusive: 4,
+            checkpoint_hi_inclusive: Some(4),
             tx_hi: 8,
             timestamp_ms_hi_inclusive: timestamp,
             reader_lo: 4,        // Allow pruning up to checkpoint 4 (exclusive)

--- a/crates/sui-indexer-alt-framework/src/pipeline/concurrent/reader_watermark.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/concurrent/reader_watermark.rs
@@ -53,7 +53,7 @@ pub(super) fn reader_watermark<H: Handler + 'static>(
                 Ok(Some(current)) => current,
 
                 Ok(None) => {
-                    warn!(pipeline = H::NAME, "No watermark for pipeline, skipping");
+                    info!(pipeline = H::NAME, "No watermark for pipeline, skipping");
                     continue;
                 }
 
@@ -65,9 +65,9 @@ pub(super) fn reader_watermark<H: Handler + 'static>(
 
             // Calculate the new reader watermark based on the current high watermark.
             let new_reader_lo =
-                (current.checkpoint_hi_inclusive as u64 + 1).saturating_sub(config.retention);
+                (current.checkpoint_hi_inclusive + 1).saturating_sub(config.retention);
 
-            if new_reader_lo <= current.reader_lo as u64 {
+            if new_reader_lo <= current.reader_lo {
                 debug!(
                     pipeline = H::NAME,
                     current = current.reader_lo,
@@ -195,7 +195,7 @@ mod tests {
     async fn test_reader_watermark_updates() {
         let watermark = MockWatermark {
             epoch_hi_inclusive: 0,
-            checkpoint_hi_inclusive: 10, // Current high watermark
+            checkpoint_hi_inclusive: Some(10), // Current high watermark
             tx_hi: 100,
             timestamp_ms_hi_inclusive: 1000,
             reader_lo: 0, // Initial reader_lo
@@ -227,7 +227,7 @@ mod tests {
     async fn test_reader_watermark_does_not_update_smaller_reader_lo() {
         let watermark = MockWatermark {
             epoch_hi_inclusive: 0,
-            checkpoint_hi_inclusive: 10, // Current high watermark
+            checkpoint_hi_inclusive: Some(10), // Current high watermark
             tx_hi: 100,
             timestamp_ms_hi_inclusive: 1000,
             reader_lo: 7, // Initial reader_lo
@@ -263,7 +263,7 @@ mod tests {
     async fn test_reader_watermark_retry_update_after_connection_failure() {
         let watermark = MockWatermark {
             epoch_hi_inclusive: 0,
-            checkpoint_hi_inclusive: 10, // Current high watermark
+            checkpoint_hi_inclusive: Some(10), // Current high watermark
             tx_hi: 100,
             timestamp_ms_hi_inclusive: 1000,
             reader_lo: 0, // Initial reader_lo
@@ -315,7 +315,7 @@ mod tests {
     async fn test_reader_watermark_retry_update_after_set_watermark_failure() {
         let watermark = MockWatermark {
             epoch_hi_inclusive: 0,
-            checkpoint_hi_inclusive: 10, // Current high watermark
+            checkpoint_hi_inclusive: Some(10), // Current high watermark
             tx_hi: 100,
             timestamp_ms_hi_inclusive: 1000,
             reader_lo: 0, // Initial reader_lo

--- a/crates/sui-indexer-alt-framework/src/pipeline/sequential/committer.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/sequential/committer.rs
@@ -535,7 +535,7 @@ mod tests {
         // Verify watermark was updated
         {
             let watermark = setup.store.watermark(TestHandler::NAME).unwrap();
-            assert_eq!(watermark.checkpoint_hi_inclusive, 2);
+            assert_eq!(watermark.checkpoint_hi_inclusive, Some(2));
             assert_eq!(watermark.tx_hi, 2);
         }
 
@@ -581,7 +581,7 @@ mod tests {
         // Verify watermark was updated
         {
             let watermark = setup.store.watermark(TestHandler::NAME).unwrap();
-            assert_eq!(watermark.checkpoint_hi_inclusive, 7);
+            assert_eq!(watermark.checkpoint_hi_inclusive, Some(7));
             assert_eq!(watermark.tx_hi, 7);
         }
     }
@@ -609,7 +609,7 @@ mod tests {
         // Verify watermark was updated
         {
             let watermark = setup.store.watermark(TestHandler::NAME).unwrap();
-            assert_eq!(watermark.checkpoint_hi_inclusive, 2);
+            assert_eq!(watermark.checkpoint_hi_inclusive, Some(2));
             assert_eq!(watermark.tx_hi, 2);
         }
 

--- a/crates/sui-indexer-alt-framework/src/postgres/mod.rs
+++ b/crates/sui-indexer-alt-framework/src/postgres/mod.rs
@@ -109,8 +109,8 @@ pub mod tests {
     use std::sync::Arc;
 
     use async_trait::async_trait;
-    use sui_indexer_alt_framework_store_traits::CommitterWatermark;
     use sui_indexer_alt_framework_store_traits::Connection as _;
+    use sui_indexer_alt_framework_store_traits::{CommitterWatermark, InitWatermark};
     use sui_types::full_checkpoint_content::Checkpoint;
 
     use crate::ConcurrentConfig;
@@ -169,6 +169,9 @@ pub mod tests {
         {
             let watermark = CommitterWatermark::new_for_testing(10);
             let mut conn = indexer.store().connect().await.unwrap();
+            conn.init_watermark(ConcurrentPipeline1::NAME, InitWatermark::default())
+                .await
+                .unwrap();
             assert!(
                 conn.set_committer_watermark(ConcurrentPipeline1::NAME, watermark)
                     .await
@@ -186,13 +189,21 @@ pub mod tests {
     async fn test_add_multiple_pipelines() {
         let (mut indexer, _temp_db) = Indexer::new_for_testing(&MIGRATIONS).await;
         {
-            let watermark1 = CommitterWatermark::new_for_testing(10);
             let mut conn = indexer.store().connect().await.unwrap();
+
+            conn.init_watermark(ConcurrentPipeline1::NAME, InitWatermark::default())
+                .await
+                .unwrap();
+            let watermark1 = CommitterWatermark::new_for_testing(10);
             assert!(
                 conn.set_committer_watermark(ConcurrentPipeline1::NAME, watermark1)
                     .await
                     .unwrap()
             );
+
+            conn.init_watermark(ConcurrentPipeline2::NAME, InitWatermark::default())
+                .await
+                .unwrap();
             let watermark2 = CommitterWatermark::new_for_testing(20);
             assert!(
                 conn.set_committer_watermark(ConcurrentPipeline2::NAME, watermark2)

--- a/crates/sui-indexer-alt-graphql/src/task/watermark.rs
+++ b/crates/sui-indexer-alt-graphql/src/task/watermark.rs
@@ -446,6 +446,8 @@ async fn watermarks_from_pg(
         .await
         .context("Failed to connect to database")?;
 
+    // Filter out pipelines that have been initialized, but do not yet have indexed checkpoints with
+    // `reader_lo <= checkpoint_hi_inclusive`.
     let rows: Vec<WatermarkRow> = conn
         .results(query!(
             r#"
@@ -464,7 +466,8 @@ async fn watermarks_from_pg(
                 cp_sequence_numbers c
             ON (w.reader_lo = c.cp_sequence_number)
             WHERE
-                pipeline = ANY({Array<Text>})
+                w.pipeline = ANY({Array<Text>})
+            AND w.reader_lo <= w.checkpoint_hi_inclusive
             "#,
             pg_pipelines,
         ))

--- a/crates/sui-indexer-alt-object-store/src/lib.rs
+++ b/crates/sui-indexer-alt-object-store/src/lib.rs
@@ -16,6 +16,7 @@ use object_store::path::Path as ObjectPath;
 use serde::Deserialize;
 use serde::Serialize;
 use sui_indexer_alt_framework_store_traits::Connection;
+use sui_indexer_alt_framework_store_traits::InitWatermark;
 use sui_indexer_alt_framework_store_traits::PrunerWatermark;
 use sui_indexer_alt_framework_store_traits::ReaderWatermark;
 use sui_indexer_alt_framework_store_traits::Store;
@@ -86,11 +87,19 @@ impl Store for ObjectStore {
 
 #[async_trait]
 impl Connection for ObjectStoreConnection {
-    async fn init_watermark(&mut self, pipeline_task: &str, _: u64) -> anyhow::Result<Option<u64>> {
-        Ok(self
+    async fn init_watermark(
+        &mut self,
+        pipeline_task: &str,
+        init_watermark: InitWatermark,
+    ) -> anyhow::Result<InitWatermark> {
+        let checkpoint_hi_inclusive = self
             .committer_watermark(pipeline_task)
             .await?
-            .map(|w| w.checkpoint_hi_inclusive))
+            .map(|w| w.checkpoint_hi_inclusive);
+        Ok(InitWatermark {
+            checkpoint_hi_inclusive,
+            ..init_watermark
+        })
     }
 
     async fn committer_watermark(

--- a/crates/sui-kvstore/src/bigtable/store.rs
+++ b/crates/sui-kvstore/src/bigtable/store.rs
@@ -17,6 +17,7 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use sui_indexer_alt_framework_store_traits::CommitterWatermark;
 use sui_indexer_alt_framework_store_traits::Connection;
+use sui_indexer_alt_framework_store_traits::InitWatermark;
 use sui_indexer_alt_framework_store_traits::PrunerWatermark;
 use sui_indexer_alt_framework_store_traits::ReaderWatermark;
 use sui_indexer_alt_framework_store_traits::Store;
@@ -83,13 +84,17 @@ impl Connection for BigTableConnection<'_> {
     async fn init_watermark(
         &mut self,
         pipeline_task: &str,
-        _default_next_checkpoint: u64,
-    ) -> Result<Option<u64>> {
-        Ok(self
+        init_watermark: InitWatermark,
+    ) -> Result<InitWatermark> {
+        let checkpoint_hi_inclusive = self
             .client
             .get_pipeline_watermark(pipeline_task)
             .await?
-            .map(|wm| wm.checkpoint_hi_inclusive))
+            .map(|wm| wm.checkpoint_hi_inclusive);
+        Ok(InitWatermark {
+            checkpoint_hi_inclusive,
+            ..init_watermark
+        })
     }
 
     async fn committer_watermark(

--- a/crates/sui-pg-db/src/store.rs
+++ b/crates/sui-pg-db/src/store.rs
@@ -4,10 +4,8 @@
 use std::time::Duration;
 
 use async_trait::async_trait;
-use chrono::DateTime;
 use chrono::Utc;
 use diesel::ExpressionMethods;
-use diesel::OptionalExtension;
 use diesel::prelude::*;
 use diesel::sql_types::BigInt;
 use diesel_async::AsyncConnection;
@@ -28,66 +26,73 @@ impl store::Connection for Connection<'_> {
     async fn init_watermark(
         &mut self,
         pipeline_task: &str,
-        default_next_checkpoint: u64,
-    ) -> anyhow::Result<Option<u64>> {
-        let Some(checkpoint_hi_inclusive) = default_next_checkpoint.checked_sub(1) else {
-            // Do not create a watermark record with checkpoint_hi_inclusive = -1.
-            return Ok(self
-                .committer_watermark(pipeline_task)
-                .await?
-                .map(|w| w.checkpoint_hi_inclusive));
-        };
-
+        store::InitWatermark {
+            checkpoint_hi_inclusive,
+            reader_lo,
+        }: store::InitWatermark,
+    ) -> anyhow::Result<store::InitWatermark> {
         let stored_watermark = StoredWatermark {
             pipeline: pipeline_task.to_string(),
             epoch_hi_inclusive: 0,
-            checkpoint_hi_inclusive: checkpoint_hi_inclusive as i64,
+            // Initially, `checkpoint_hi_inclusive` is less than `reader_lo` meaning that no
+            // checkpoints have been indexed yet.
+            checkpoint_hi_inclusive: checkpoint_hi_inclusive.map_or(-1, |c| c as i64),
             tx_hi: 0,
             timestamp_ms_hi_inclusive: 0,
-            reader_lo: default_next_checkpoint as i64,
+            reader_lo: reader_lo as i64,
             pruner_timestamp: Utc::now().naive_utc(),
-            pruner_hi: default_next_checkpoint as i64,
+            pruner_hi: reader_lo as i64,
         };
 
         use diesel::pg::upsert::excluded;
-        let checkpoint_hi_inclusive: i64 = diesel::insert_into(watermarks::table)
-            .values(&stored_watermark)
-            // There is an existing entry, so only write the new `hi` values
-            .on_conflict(watermarks::pipeline)
-            // Use `do_update` instead of `do_nothing` to return the existing row with `returning`.
-            .do_update()
-            // When using `do_update`, at least one change needs to be set, so set the pipeline to itself (nothing changes).
-            // `excluded` is a virtual table containing the existing row that there was a conflict with.
-            .set(watermarks::pipeline.eq(excluded(watermarks::pipeline)))
-            .returning(watermarks::checkpoint_hi_inclusive)
-            .get_result(self)
-            .await?;
+        let (checkpoint_hi_inclusive, reader_lo): (i64, i64) =
+            diesel::insert_into(watermarks::table)
+                .values(&stored_watermark)
+                // There is an existing entry, so only write the new `hi` values
+                .on_conflict(watermarks::pipeline)
+                // Use `do_update` instead of `do_nothing` to return the existing row with `returning`.
+                .do_update()
+                // When using `do_update`, at least one change needs to be set, so set the pipeline to itself (nothing changes).
+                // `excluded` is a virtual table containing the existing row that there was a conflict with.
+                .set(watermarks::pipeline.eq(excluded(watermarks::pipeline)))
+                .returning((watermarks::checkpoint_hi_inclusive, watermarks::reader_lo))
+                .get_result(self)
+                .await?;
 
-        Ok(Some(checkpoint_hi_inclusive as u64))
+        Ok(store::InitWatermark {
+            checkpoint_hi_inclusive: u64::try_from(checkpoint_hi_inclusive).ok(),
+            reader_lo: reader_lo as u64,
+        })
     }
 
     async fn committer_watermark(
         &mut self,
         pipeline_task: &str,
     ) -> anyhow::Result<Option<store::CommitterWatermark>> {
-        let watermark: Option<(i64, i64, i64, i64)> = watermarks::table
+        let (
+            epoch_hi_inclusive,
+            checkpoint_hi_inclusive,
+            tx_hi,
+            timestamp_ms_hi_inclusive,
+            reader_lo,
+        ): (i64, i64, i64, i64, i64) = watermarks::table
             .select((
                 watermarks::epoch_hi_inclusive,
                 watermarks::checkpoint_hi_inclusive,
                 watermarks::tx_hi,
                 watermarks::timestamp_ms_hi_inclusive,
+                watermarks::reader_lo,
             ))
             .filter(watermarks::pipeline.eq(pipeline_task))
             .first(self)
-            .await
-            .optional()?;
+            .await?;
 
-        if let Some(watermark) = watermark {
+        if reader_lo <= checkpoint_hi_inclusive {
             Ok(Some(store::CommitterWatermark {
-                epoch_hi_inclusive: watermark.0 as u64,
-                checkpoint_hi_inclusive: watermark.1 as u64,
-                tx_hi: watermark.2 as u64,
-                timestamp_ms_hi_inclusive: watermark.3 as u64,
+                epoch_hi_inclusive: epoch_hi_inclusive as u64,
+                checkpoint_hi_inclusive: checkpoint_hi_inclusive as u64,
+                tx_hi: tx_hi as u64,
+                timestamp_ms_hi_inclusive: timestamp_ms_hi_inclusive as u64,
             }))
         } else {
             Ok(None)
@@ -98,17 +103,16 @@ impl store::Connection for Connection<'_> {
         &mut self,
         pipeline: &'static str,
     ) -> anyhow::Result<Option<store::ReaderWatermark>> {
-        let watermark: Option<(i64, i64)> = watermarks::table
+        let (checkpoint_hi_inclusive, reader_lo): (i64, i64) = watermarks::table
             .select((watermarks::checkpoint_hi_inclusive, watermarks::reader_lo))
             .filter(watermarks::pipeline.eq(pipeline))
             .first(self)
-            .await
-            .optional()?;
+            .await?;
 
-        if let Some(watermark) = watermark {
+        if reader_lo <= checkpoint_hi_inclusive {
             Ok(Some(store::ReaderWatermark {
-                checkpoint_hi_inclusive: watermark.0 as u64,
-                reader_lo: watermark.1 as u64,
+                checkpoint_hi_inclusive: checkpoint_hi_inclusive as u64,
+                reader_lo: reader_lo as u64,
             }))
         } else {
             Ok(None)
@@ -130,18 +134,23 @@ impl store::Connection for Connection<'_> {
             delay.as_millis() as i64,
         );
 
-        let watermark: Option<(i64, i64, i64)> = watermarks::table
-            .select((wait_for, watermarks::pruner_hi, watermarks::reader_lo))
-            .filter(watermarks::pipeline.eq(pipeline))
-            .first(self)
-            .await
-            .optional()?;
+        let (wait_for_ms, pruner_hi, reader_lo, checkpoint_hi_inclusive): (i64, i64, i64, i64) =
+            watermarks::table
+                .select((
+                    wait_for,
+                    watermarks::pruner_hi,
+                    watermarks::reader_lo,
+                    watermarks::checkpoint_hi_inclusive,
+                ))
+                .filter(watermarks::pipeline.eq(pipeline))
+                .first(self)
+                .await?;
 
-        if let Some(watermark) = watermark {
+        if reader_lo <= checkpoint_hi_inclusive {
             Ok(Some(store::PrunerWatermark {
-                wait_for_ms: watermark.0,
-                pruner_hi: watermark.1 as u64,
-                reader_lo: watermark.2 as u64,
+                wait_for_ms,
+                pruner_hi: pruner_hi as u64,
+                reader_lo: reader_lo as u64,
             }))
         } else {
             Ok(None)
@@ -153,33 +162,17 @@ impl store::Connection for Connection<'_> {
         pipeline_task: &str,
         watermark: store::CommitterWatermark,
     ) -> anyhow::Result<bool> {
-        // Create a StoredWatermark directly from CommitterWatermark
-        let stored_watermark = StoredWatermark {
-            pipeline: pipeline_task.to_string(),
-            epoch_hi_inclusive: watermark.epoch_hi_inclusive as i64,
-            checkpoint_hi_inclusive: watermark.checkpoint_hi_inclusive as i64,
-            tx_hi: watermark.tx_hi as i64,
-            timestamp_ms_hi_inclusive: watermark.timestamp_ms_hi_inclusive as i64,
-            reader_lo: 0,
-            pruner_timestamp: DateTime::UNIX_EPOCH.naive_utc(),
-            pruner_hi: 0,
-        };
-
-        use diesel::query_dsl::methods::FilterDsl;
-        Ok(diesel::insert_into(watermarks::table)
-            .values(&stored_watermark)
-            // There is an existing entry, so only write the new `hi` values
-            .on_conflict(watermarks::pipeline)
-            .do_update()
+        Ok(diesel::update(watermarks::table)
             .set((
-                watermarks::epoch_hi_inclusive.eq(stored_watermark.epoch_hi_inclusive),
-                watermarks::checkpoint_hi_inclusive.eq(stored_watermark.checkpoint_hi_inclusive),
-                watermarks::tx_hi.eq(stored_watermark.tx_hi),
+                watermarks::epoch_hi_inclusive.eq(watermark.epoch_hi_inclusive as i64),
+                watermarks::checkpoint_hi_inclusive.eq(watermark.checkpoint_hi_inclusive as i64),
+                watermarks::tx_hi.eq(watermark.tx_hi as i64),
                 watermarks::timestamp_ms_hi_inclusive
-                    .eq(stored_watermark.timestamp_ms_hi_inclusive),
+                    .eq(watermark.timestamp_ms_hi_inclusive as i64),
             ))
+            .filter(watermarks::pipeline.eq(pipeline_task))
             .filter(
-                watermarks::checkpoint_hi_inclusive.lt(stored_watermark.checkpoint_hi_inclusive),
+                watermarks::checkpoint_hi_inclusive.lt(watermark.checkpoint_hi_inclusive as i64),
             )
             .execute(self)
             .await?


### PR DESCRIPTION
## Description 

This PR initializes pipelines in the `checkpoint_hi_inclusive = reader_lo - 1` state. This is a temporary state that indicates that no checkpoints have been indexed yet. After a checkpoint has been indexed and the committer watermark has been updated, `reader_lo <= checkpoint_hi_inclusive` will always be true. When in the `checkpoint_hi_inclusive = reader_lo - 1` state, the watermark record is ignored.

## Test plan 

Updated existing unit tests.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
