### PR TITLE
indexer: log and track processor retries

### DIFF
--- a/crates/sui-indexer-alt-framework/src/metrics.rs
+++ b/crates/sui-indexer-alt-framework/src/metrics.rs
@@ -3,6 +3,7 @@
 
 use std::sync::Arc;
 use std::sync::atomic::AtomicU64;
+use std::time::Duration;
 
 use prometheus::Histogram;
 use prometheus::HistogramVec;
@@ -83,6 +84,7 @@ pub struct IngestionMetrics {
 pub struct IndexerMetrics {
     // Statistics related to individual ingestion pipelines' handlers.
     pub total_handler_checkpoints_received: IntCounterVec,
+    pub total_handler_processor_retries: IntCounterVec,
     pub total_handler_checkpoints_processed: IntCounterVec,
     pub total_handler_rows_created: IntCounterVec,
 
@@ -321,6 +323,13 @@ impl IndexerMetrics {
             total_handler_checkpoints_received: register_int_counter_vec_with_registry!(
                 name("total_handler_checkpoints_received"),
                 "Total number of checkpoints received by this handler",
+                &["pipeline"],
+                registry,
+            )
+            .unwrap(),
+            total_handler_processor_retries: register_int_counter_vec_with_registry!(
+                name("total_handler_processor_retries"),
+                "Total number of handler retries after transient processing failures",
                 &["pipeline"],
                 registry,
             )
@@ -704,6 +713,24 @@ impl IndexerMetrics {
             )
             .unwrap(),
         })
+    }
+
+    pub(crate) fn inc_processor_retry<P: Processor>(
+        &self,
+        checkpoint: u64,
+        error: &anyhow::Error,
+        delay: Duration,
+    ) {
+        warn!(
+            pipeline = P::NAME,
+            checkpoint,
+            retry_delay_ms = delay.as_millis(),
+            "Retrying processor after error: {error:?}",
+        );
+
+        self.total_handler_processor_retries
+            .with_label_values(&[P::NAME])
+            .inc();
     }
 }
 

--- a/crates/sui-indexer-alt-framework/src/pipeline/processor.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/processor.rs
@@ -103,12 +103,24 @@ pub(super) fn processor<P: Processor>(
                             ..Default::default()
                         };
 
-                        let values = backoff::future::retry(backoff, || async {
-                            processor
-                                .process(&checkpoint)
-                                .await
-                                .map_err(backoff::Error::transient)
-                        })
+                        let checkpoint_sequence_number = checkpoint.summary.sequence_number;
+                        let retry_metrics = metrics.clone();
+                        let values = backoff::future::retry_notify(
+                            backoff,
+                            || async {
+                                processor
+                                    .process(&checkpoint)
+                                    .await
+                                    .map_err(backoff::Error::transient)
+                            },
+                            move |error: anyhow::Error, delay| {
+                                retry_metrics.inc_processor_retry::<P>(
+                                    checkpoint_sequence_number,
+                                    &error,
+                                    delay,
+                                );
+                            },
+                        )
                         .await?;
 
                         let elapsed = guard.stop_and_record();
@@ -381,7 +393,7 @@ mod tests {
             processor,
             data_rx,
             indexed_tx,
-            metrics,
+            metrics.clone(),
             ConcurrencyConfig::Fixed { value: 10 },
         );
 
@@ -404,6 +416,13 @@ mod tests {
 
         // Verify that exactly 3 attempts were made (2 failures + 1 success)
         assert_eq!(attempt_count.load(Ordering::Relaxed), 3);
+        assert_eq!(
+            metrics
+                .total_handler_processor_retries
+                .with_label_values(&[RetryTestPipeline::NAME])
+                .get(),
+            2
+        );
     }
 
     // By default, Rust's async tests run on the single-threaded runtime.


### PR DESCRIPTION
## Description

Track the number of processor retries for each pipeline in the indexer, and log a warning when the processor fails. We recently faced an issue where the `kv_feature_flags` and `kv_protocol_configs` tables stalled because of a processor failure and this logging would have helped us figure out what was happening much faster.

## Test plan

New unit tests for the framework:

```
$ cargo nextest run -p sui-indexer-alt-framework
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
