### PR TITLE
chore: remove stale TODO for settle_early (already implemented)

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1576,9 +1576,6 @@ impl AuthorityState {
             }
         }
 
-        // TODO: We should also settle address funds during execution,
-        // instead of from checkpoint builder. It will improve performance
-        // since we will be settling as soon as we can.
         if certificate
             .transaction_data()
             .kind()


### PR DESCRIPTION
The TODO comment in `authority.rs` noted that address funds should be settled during execution rather than from the checkpoint builder. This has since been implemented via the `settle_early` workstream and is live on testnet. Removing the stale comment.