### PR TITLE
graphql: uninitialized watermark is considered unhealthy

### DIFF
--- a/crates/sui-indexer-alt-graphql/src/health.rs
+++ b/crates/sui-indexer-alt-graphql/src/health.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::anyhow;
+use anyhow::ensure;
 use async_graphql::indexmap::IndexMap;
 use axum::Extension;
 use axum::Json;
@@ -31,7 +32,7 @@ pub(crate) struct Params {
 }
 
 /// Response body for the health check endpoint. This is output as JSON.
-#[derive(Serialize)]
+#[derive(Serialize, Default)]
 pub(crate) struct Response {
     #[serde(skip_serializing_if = "Option::is_none")]
     checkpoint_lag_ms: Option<u64>,
@@ -52,45 +53,57 @@ pub(crate) async fn check(
     Extension(DbProbe(db_url)): Extension<DbProbe>,
     Query(params): Query<Params>,
 ) -> Response {
-    let mut errors = vec![];
-
-    let (lag, pipelines) = check_watermarks(&watermarks).await;
+    let mut resp = Response::default();
 
     if let Err(e) = check_connection(&db_url).await {
-        errors.push(format!("DB probe failed: {e}"));
+        resp.errors.push(format!("DB probe failed: {e}"));
     }
+
+    let (checkpoint_lag_ms, pipelines) = match check_watermarks(&watermarks).await {
+        Ok(watermark) => watermark,
+        Err(e) => {
+            resp.errors.push(e.to_string());
+            return resp;
+        }
+    };
 
     let max_lag = params
         .max_checkpoint_lag_ms
         .unwrap_or(config.max_checkpoint_lag.as_millis() as u64);
 
-    if lag > max_lag {
-        errors.push("Watermark lag is too high".to_owned());
+    if checkpoint_lag_ms > max_lag {
+        resp.errors.push("Watermark lag is too high".to_owned());
     }
 
-    Response {
-        checkpoint_lag_ms: Some(lag),
-        pipelines,
-        errors,
-    }
+    resp.checkpoint_lag_ms = Some(checkpoint_lag_ms);
+    resp.pipelines = pipelines;
+    resp
 }
 
 /// Returns the lag between the latest checkpoint the indexer is aware of and the current time.
-async fn check_watermarks(watermarks: &WatermarksLock) -> (u64, IndexMap<String, u64>) {
+async fn check_watermarks(
+    watermarks: &WatermarksLock,
+) -> anyhow::Result<(u64, IndexMap<String, u64>)> {
     let now = Utc::now();
     let watermarks = watermarks.read().await;
+
+    ensure!(
+        watermarks.initialized(),
+        "Watermark has not been initialized"
+    );
 
     let mut pipeline_lags: Vec<(String, u64)> = watermarks
         .per_pipeline()
         .iter()
         .map(|(pipeline, watermark)| (pipeline.clone(), watermark.lag_ms(now)))
         .collect();
+
     pipeline_lags.sort_by(|(name_a, lag_a), (name_b, lag_b)| {
         lag_b.cmp(lag_a).then_with(|| name_a.cmp(name_b))
     });
 
     let pipelines = pipeline_lags.into_iter().collect();
-    (watermarks.lag_ms(now), pipelines)
+    Ok((watermarks.lag_ms(now), pipelines))
 }
 
 /// Checks that the service can talk to the database.
@@ -120,5 +133,39 @@ impl IntoResponse for Response {
         };
 
         (status, Json(self)).into_response()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use axum::Extension;
+    use axum::extract::Query;
+    use tokio::sync::RwLock;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_uninitialized_watermark_is_unhealthy() {
+        let response = check(
+            Extension(Arc::new(RwLock::new(Arc::new(
+                crate::task::watermark::Watermarks::default(),
+            )))),
+            Extension(HealthConfig::default()),
+            Extension(DbProbe(None)),
+            Query(Params {
+                max_checkpoint_lag_ms: None,
+            }),
+        )
+        .await;
+
+        assert_eq!(response.checkpoint_lag_ms, None);
+        assert!(response.pipelines.is_empty());
+        assert!(
+            response
+                .errors
+                .contains(&"Watermark has not been initialized".to_owned())
+        );
     }
 }

--- a/crates/sui-indexer-alt-graphql/src/task/watermark.rs
+++ b/crates/sui-indexer-alt-graphql/src/task/watermark.rs
@@ -261,6 +261,10 @@ impl Watermarks {
             .as_millis() as u64
     }
 
+    pub(crate) fn initialized(&self) -> bool {
+        self.global_hi.checkpoint != i64::MAX
+    }
+
     fn merge(&mut self, row: WatermarkRow) {
         let pipeline = Pipeline {
             hi: Watermark {


### PR DESCRIPTION
## Description

GraphQL's health check looks for the sigil that indicates that a watermark is uninitialized and treats that as an error, which pushes the service into an unhealthy state.

## Test plan

New unit test:

```
$ cargo nextest run -p sui-indexer-alt-graphql -- uninitialized_watermark_is_unhealthy
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
