### PR TITLE
pick(25783) display: avoid holding hash map lock while fetching objects

### DIFF
--- a/crates/sui-display/src/v2/interpreter.rs
+++ b/crates/sui-display/src/v2/interpreter.rs
@@ -6,7 +6,6 @@ use std::mem;
 use std::sync::Arc;
 
 use dashmap::DashMap;
-use dashmap::mapref::entry::Entry;
 use futures::future::OptionFuture;
 use futures::future::join_all;
 use futures::join;
@@ -394,18 +393,20 @@ impl<S: V::Store> Interpreter<S> {
     /// to remain valid for the lifetime 's because the cache (and the Arc it contains) lives for
     /// the entire lifetime of the Interpreter.
     async fn object<'s>(&'s self, id: AccountAddress) -> Result<Option<V::Slice<'s>>, FormatError> {
-        let entry = match self.cache.entry(id) {
-            Entry::Occupied(entry) => entry,
-            Entry::Vacant(entry) => entry.insert_entry(
-                self.store
-                    .object(id)
-                    .await
-                    .map_err(|e| FormatError::Store(Arc::new(e)))?
-                    .map(Arc::new),
-            ),
+        let owned = if let Some(cached) = self.cache.get(&id) {
+            cached.clone()
+        } else {
+            let loaded = self
+                .store
+                .object(id)
+                .await
+                .map_err(|e| FormatError::Store(Arc::new(e)))?
+                .map(Arc::new);
+
+            self.cache.entry(id).or_insert(loaded).clone()
         };
 
-        let Some(owned) = entry.get().as_ref() else {
+        let Some(owned) = owned.as_ref() else {
             return Ok(None);
         };
 

--- a/crates/sui-display/src/v2/mod.rs
+++ b/crates/sui-display/src/v2/mod.rs
@@ -268,8 +268,10 @@ impl<'s> Display<'s> {
 #[cfg(test)]
 mod tests {
     use std::str::FromStr;
+    use std::sync::Arc;
     use std::sync::atomic::AtomicUsize;
 
+    use async_trait::async_trait;
     use base64::Engine as _;
     use base64::engine::general_purpose::STANDARD;
     use insta::assert_debug_snapshot;
@@ -287,6 +289,8 @@ mod tests {
     use sui_types::dynamic_field::derive_dynamic_field_id;
     use sui_types::id::ID;
     use sui_types::id::UID;
+    use tokio::sync::Barrier;
+    use tokio::time::Duration;
 
     use crate::v2::value::tests::MockStore;
     use crate::v2::value::tests::enum_;
@@ -355,7 +359,7 @@ mod tests {
 
     /// Helper to parse display fields and render them against the provided object.
     async fn format<'s>(
-        store: MockStore,
+        store: impl Store,
         limits: Limits,
         bytes: Vec<u8>,
         layout: MoveTypeLayout,
@@ -1382,6 +1386,67 @@ mod tests {
             ),
             "missing": Ok(
                 Null,
+            ),
+        }
+        "###);
+    }
+
+    #[tokio::test]
+    async fn test_display_concurrent_dynamic_field_fetch() {
+        // Define a store that intentionally holds back requests to the store so they operate
+        // concurrently.
+        #[derive(Clone)]
+        struct BlockingStore {
+            barrier: Arc<Barrier>,
+            inner: MockStore,
+        }
+
+        #[async_trait]
+        impl Store for BlockingStore {
+            async fn object(&self, id: AccountAddress) -> anyhow::Result<Option<OwnedSlice>> {
+                self.barrier.wait().await;
+                self.inner.object(id).await
+            }
+        }
+
+        let parent = AccountAddress::from_str("0x1200").unwrap();
+        let bytes = bcs::to_bytes(&parent).unwrap();
+        let layout = struct_(
+            "0x1::m::Root",
+            vec![("id", L::Struct(Box::new(UID::layout())))],
+        );
+
+        let store = BlockingStore {
+            barrier: Arc::new(Barrier::new(2)),
+            inner: MockStore::default().with_dynamic_field(
+                parent,
+                "key",
+                L::Struct(Box::new(move_utf8_str_layout())),
+                42u64,
+                L::U64,
+            ),
+        };
+
+        let rendered = tokio::time::timeout(
+            Duration::from_secs(10),
+            format(
+                store,
+                Limits::default(),
+                bytes,
+                layout,
+                usize::MAX,
+                ONE_MB,
+                [("concurrent", "{id->['key']}{id->['key']}")],
+            ),
+        )
+        .await
+        .expect("back-to-back dynamic field expressions should not block")
+        .unwrap();
+
+        assert_debug_snapshot!(rendered, @r###"
+        {
+            "concurrent": Ok(
+                String("4242"),
             ),
         }
         "###);


### PR DESCRIPTION
## Description

The previous implementation of dynamic object loading created an entry in the object loading cache, and then tried to fetch the object. The cache is a concurrent hash-map, which means that we are implicitly taking a lock on that entry while waiting for the object to be fetched, which is not ideal.

This change splits the initial cache fetch, object load, and cache update into three updates without having to hold a lock between all three steps.

## Test plan

New test covers this case:

```
$ cargo nextest run -p sui-display -- concurrent_dynamic_field
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
