### PR TITLE
easy(display): clarify Store trait contract

### DIFF
--- a/crates/sui-display/src/v2/value.rs
+++ b/crates/sui-display/src/v2/value.rs
@@ -40,7 +40,9 @@ use crate::v2::writer::StringWriter;
 /// Dynamically load objects by their ID, returning the object's owned data.
 ///
 /// The `Store` trait is responsible only for fetching object data -- lifetime management
-/// and caching are handled by the `Interpreter`.
+/// and caching are handled by the `Interpreter`. The interpreter can potentially issue racing
+/// requests for the same object, and it is the store's responsibility to handle this correctly
+/// (e.g. by deduplicating in-flight requests).
 #[async_trait]
 pub trait Store {
     async fn object(&self, id: AccountAddress) -> anyhow::Result<Option<OwnedSlice>>;


### PR DESCRIPTION
## Description

Make it clear what Display's `Store` trait is responsible for when it comes to concurrent requests from the interpreter.

## Test plan

:eyes:

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
