### PR TITLE
fix(jsonrpc-alt): fix type mismatch in display field response

### DIFF
--- a/crates/sui-indexer-alt-jsonrpc/src/api/objects/response.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/objects/response.rs
@@ -191,7 +191,7 @@ async fn display(ctx: &Context, object: &Object) -> DisplayFieldsResponse {
     for (name, value) in fields {
         match value {
             Ok(value) => {
-                field_values.insert(name, Json::String(value));
+                field_values.insert(name, value);
             }
             Err(e) => {
                 write!(field_errors, "{prefix}Error for field {name:?}: {e:#}").unwrap();


### PR DESCRIPTION
## Summary

- Fixes build failure introduced by #25359 (Display v2 JSONRPC-alt integration)
- `display_fields` return type changed from `BTreeMap<String, Result<String>>` to `BTreeMap<String, Result<Json>>`, but line 194 still wrapped the value in `Json::String(value)` causing a `mismatched types` compiler error
- Fix: use `value` directly instead of wrapping in `Json::String()`

## Test plan

- [x] `cargo check -p sui-indexer-alt-jsonrpc` passes
- Build failure: https://github.com/MystenLabs/sui-operations/actions/runs/22924670856/job/66531926292

🤖 Generated with [Claude Code](https://claude.com/claude-code)