### PR TITLE
Normalize formula to be a more consistent shape and match the new VM 

### DIFF
--- a/crates/sui-core/src/authority/snapshots/sui_core__authority__execution_time_estimator__tests__execution_time_observer_v115.snap
+++ b/crates/sui-core/src/authority/snapshots/sui_core__authority__execution_time_estimator__tests__execution_time_observer_v115.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/sui-core/src/authority/execution_time_estimator.rs
-assertion_line: 2218
 expression: snapshot_data
 ---
 protocol_version: 115

--- a/crates/sui-open-rpc/tests/snapshots/generate_spec__openrpc.snap.json
+++ b/crates/sui-open-rpc/tests/snapshots/generate_spec__openrpc.snap.json
@@ -1401,6 +1401,7 @@
                 "narwhal_versioned_metadata": false,
                 "native_charging_v2": false,
                 "no_extraneous_module_bytes": false,
+                "normalize_depth_formula": false,
                 "normalize_ptb_arguments": false,
                 "object_runtime_charge_cache_load_gas": false,
                 "package_digest_hash_module": false,

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -951,6 +951,10 @@ struct FeatureFlags {
     #[serde(skip_serializing_if = "is_false")]
     deprecate_global_storage_ops: bool,
 
+    // If true, normalize depth formula to not be empty for zero depth.
+    #[serde(skip_serializing_if = "is_false")]
+    normalize_depth_formula: bool,
+
     // If true, skip GC'ed accept votes in CommitFinalizer.
     #[serde(skip_serializing_if = "is_false")]
     consensus_skip_gced_accept_votes: bool,
@@ -2572,6 +2576,10 @@ impl ProtocolConfig {
 
     pub fn deprecate_global_storage_ops(&self) -> bool {
         self.feature_flags.deprecate_global_storage_ops
+    }
+
+    pub fn normalize_depth_formula(&self) -> bool {
+        self.feature_flags.normalize_depth_formula
     }
 
     pub fn consensus_skip_gced_accept_votes(&self) -> bool {
@@ -4655,13 +4663,14 @@ impl ProtocolConfig {
                     }
                 }
                 115 => {
+                    cfg.feature_flags.normalize_depth_formula = true;
+                }
+                116 => {
                     cfg.feature_flags.gasless_transaction_drop_safety = true;
                     cfg.feature_flags.address_aliases = true;
                     cfg.feature_flags.relax_valid_during_for_owned_inputs = true;
                     // Disabled while debugging
                     cfg.feature_flags.defer_unpaid_amplification = false;
-                }
-                116 => {
                     cfg.feature_flags.enable_display_registry = true;
                 }
                 // Use this template when making changes:

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_115.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_115.snap
@@ -114,7 +114,6 @@ feature_flags:
   address_balance_gas_check_rgp_at_signing: true
   address_balance_gas_reject_gas_coin_arg: true
   enable_multi_epoch_transaction_expiration: true
-  relax_valid_during_for_owned_inputs: true
   enable_ptb_execution_v2: true
   better_adapter_type_resolution_errors: true
   record_time_estimate_processed: true
@@ -135,9 +134,9 @@ feature_flags:
   generate_df_type_layouts: true
   private_generics_verifier_v2: true
   deprecate_global_storage_ops: true
+  normalize_depth_formula: true
   consensus_skip_gced_accept_votes: true
   include_cancelled_randomness_txns_in_prologue: true
-  address_aliases: true
   fix_checkpoint_signature_mapping: true
   consensus_skip_gced_blocks_in_direct_finalization: true
   gas_rounding_halve_digits: true
@@ -147,7 +146,6 @@ feature_flags:
   consensus_always_accept_system_transactions: true
   validator_metadata_verify_v2: true
   randomize_checkpoint_tx_limit_in_tests: true
-  gasless_transaction_drop_safety: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_116.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_116.snap
@@ -136,6 +136,7 @@ feature_flags:
   enable_display_registry: true
   private_generics_verifier_v2: true
   deprecate_global_storage_ops: true
+  normalize_depth_formula: true
   consensus_skip_gced_accept_votes: true
   include_cancelled_randomness_txns_in_prologue: true
   address_aliases: true

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_115.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_115.snap
@@ -117,7 +117,6 @@ feature_flags:
   address_balance_gas_check_rgp_at_signing: true
   address_balance_gas_reject_gas_coin_arg: true
   enable_multi_epoch_transaction_expiration: true
-  relax_valid_during_for_owned_inputs: true
   enable_ptb_execution_v2: true
   better_adapter_type_resolution_errors: true
   record_time_estimate_processed: true
@@ -139,6 +138,7 @@ feature_flags:
   generate_df_type_layouts: true
   private_generics_verifier_v2: true
   deprecate_global_storage_ops: true
+  normalize_depth_formula: true
   consensus_skip_gced_accept_votes: true
   include_cancelled_randomness_txns_in_prologue: true
   address_aliases: true
@@ -153,7 +153,6 @@ feature_flags:
   consensus_always_accept_system_transactions: true
   validator_metadata_verify_v2: true
   randomize_checkpoint_tx_limit_in_tests: true
-  gasless_transaction_drop_safety: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_116.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_116.snap
@@ -140,6 +140,7 @@ feature_flags:
   enable_display_registry: true
   private_generics_verifier_v2: true
   deprecate_global_storage_ops: true
+  normalize_depth_formula: true
   consensus_skip_gced_accept_votes: true
   include_cancelled_randomness_txns_in_prologue: true
   address_aliases: true

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_115.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_115.snap
@@ -120,7 +120,6 @@ feature_flags:
   address_balance_gas_check_rgp_at_signing: true
   address_balance_gas_reject_gas_coin_arg: true
   enable_multi_epoch_transaction_expiration: true
-  relax_valid_during_for_owned_inputs: true
   enable_ptb_execution_v2: true
   better_adapter_type_resolution_errors: true
   record_time_estimate_processed: true
@@ -142,6 +141,7 @@ feature_flags:
   generate_df_type_layouts: true
   private_generics_verifier_v2: true
   deprecate_global_storage_ops: true
+  normalize_depth_formula: true
   consensus_skip_gced_accept_votes: true
   include_cancelled_randomness_txns_in_prologue: true
   address_aliases: true
@@ -155,8 +155,8 @@ feature_flags:
   split_checkpoints_in_consensus_handler: true
   consensus_always_accept_system_transactions: true
   validator_metadata_verify_v2: true
+  defer_unpaid_amplification: true
   randomize_checkpoint_tx_limit_in_tests: true
-  gasless_transaction_drop_safety: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_116.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_116.snap
@@ -143,6 +143,7 @@ feature_flags:
   enable_display_registry: true
   private_generics_verifier_v2: true
   deprecate_global_storage_ops: true
+  normalize_depth_formula: true
   consensus_skip_gced_accept_votes: true
   include_cancelled_randomness_txns_in_prologue: true
   address_aliases: true

--- a/external-crates/move/crates/move-vm-config/src/runtime.rs
+++ b/external-crates/move/crates/move-vm-config/src/runtime.rs
@@ -33,6 +33,8 @@ pub struct VMConfig {
     pub variant_nodes: bool,
     /// Check for deprecated global storage operations during deserialization.
     pub deprecate_global_storage_ops_during_deserialization: bool,
+    /// Normalize all formula to have a consistent structure.
+    pub normalize_depth_formula: bool,
 }
 
 impl Default for VMConfig {
@@ -52,6 +54,7 @@ impl Default for VMConfig {
             max_type_to_layout_nodes: Some(512),
             variant_nodes: true,
             deprecate_global_storage_ops_during_deserialization: false,
+            normalize_depth_formula: true,
         }
     }
 }

--- a/external-crates/move/crates/move-vm-integration-tests/src/tests/loader_tests.rs
+++ b/external-crates/move/crates/move-vm-integration-tests/src/tests/loader_tests.rs
@@ -420,7 +420,7 @@ fn test_depth() {
             "Box",
             Some(DepthFormula {
                 terms: vec![(0, 1)],
-                constant: None,
+                constant: Some(1),
             }),
         ),
         (
@@ -428,7 +428,7 @@ fn test_depth() {
             "Box3",
             Some(DepthFormula {
                 terms: vec![(0, 3)],
-                constant: None,
+                constant: Some(3),
             }),
         ),
         (
@@ -436,7 +436,7 @@ fn test_depth() {
             "Box7",
             Some(DepthFormula {
                 terms: vec![(0, 7)],
-                constant: None,
+                constant: Some(7),
             }),
         ),
         (
@@ -444,7 +444,7 @@ fn test_depth() {
             "Box15",
             Some(DepthFormula {
                 terms: vec![(0, 15)],
-                constant: None,
+                constant: Some(15),
             }),
         ),
         (
@@ -452,7 +452,7 @@ fn test_depth() {
             "Box31",
             Some(DepthFormula {
                 terms: vec![(0, 31)],
-                constant: None,
+                constant: Some(31),
             }),
         ),
         (
@@ -460,7 +460,7 @@ fn test_depth() {
             "Box63",
             Some(DepthFormula {
                 terms: vec![(0, 63)],
-                constant: None,
+                constant: Some(63),
             }),
         ),
         (
@@ -468,7 +468,7 @@ fn test_depth() {
             "Box127",
             Some(DepthFormula {
                 terms: vec![(0, 127)],
-                constant: None,
+                constant: Some(127),
             }),
         ),
         (

--- a/external-crates/move/crates/move-vm-runtime/src/loader.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/loader.rs
@@ -123,6 +123,8 @@ pub struct ModuleCache {
     defining_linkages: BTreeMap<AccountAddress, AccountAddress>,
     /// Global list of loaded functions, shared among all modules.
     functions: Vec<Arc<Function>>,
+    /// VM config, used for configuring the loading process
+    vm_config: VMConfig,
 }
 
 /// Tracks the current end point of the `ModuleCache`'s `types`s and `function`s, so that we can
@@ -133,7 +135,7 @@ struct CacheCursor {
 }
 
 impl ModuleCache {
-    fn new() -> Self {
+    fn new(vm_config: VMConfig) -> Self {
         Self {
             compiled_modules: BinaryCache::new(),
             verified_dependencies: BTreeSet::new(),
@@ -141,6 +143,7 @@ impl ModuleCache {
             datatypes: BinaryCache::new(),
             functions: vec![],
             defining_linkages: BTreeMap::new(),
+            vm_config,
         }
     }
 
@@ -529,7 +532,7 @@ impl ModuleCache {
                 .map(|field_type| self.calculate_depth_of_type(field_type, depth_cache))
                 .collect::<PartialVMResult<Vec<_>>>()?,
         };
-        let mut formula = DepthFormula::normalize(formulas);
+        let mut formula = DepthFormula::normalize(formulas, self.vm_config.normalize_depth_formula);
         // add 1 for the struct/variant itself
         formula.add(1);
         let prev = depth_cache.insert(def_idx, formula.clone());
@@ -564,7 +567,9 @@ impl ModuleCache {
                 inner.add(1);
                 inner
             }
-            Type::TyParam(ty_idx) => DepthFormula::type_parameter(*ty_idx),
+            Type::TyParam(ty_idx) => {
+                DepthFormula::type_parameter(*ty_idx, self.vm_config.normalize_depth_formula)
+            }
             Type::Datatype(cache_idx) => {
                 let datatype = self.type_at(*cache_idx);
                 let datatype_formula = self.calculate_depth_of_datatype(&datatype, depth_cache)?;
@@ -584,7 +589,7 @@ impl ModuleCache {
                     .collect::<PartialVMResult<BTreeMap<_, _>>>()?;
                 let datatype_formula = self.calculate_depth_of_datatype(&datatype, depth_cache)?;
 
-                datatype_formula.subst(ty_arg_map)?
+                datatype_formula.subst(ty_arg_map, self.vm_config.normalize_depth_formula)?
             }
         })
     }
@@ -844,7 +849,7 @@ pub(crate) struct Loader {
 impl Loader {
     pub(crate) fn new(natives: NativeFunctions, vm_config: VMConfig) -> Self {
         Self {
-            module_cache: RwLock::new(ModuleCache::new()),
+            module_cache: RwLock::new(ModuleCache::new(vm_config.clone())),
             type_cache: RwLock::new(TypeCache::new()),
             natives,
             vm_config,

--- a/external-crates/move/crates/move-vm-types/src/loaded_data/runtime_types.rs
+++ b/external-crates/move/crates/move-vm-types/src/loaded_data/runtime_types.rs
@@ -40,17 +40,18 @@ impl DepthFormula {
     }
 
     /// A stand alone type parameter value
-    pub fn type_parameter(tparam: TypeParameterIndex) -> Self {
+    pub fn type_parameter(tparam: TypeParameterIndex, normalize_formula: bool) -> Self {
+        let constant = if normalize_formula { Some(0) } else { None };
         Self {
             terms: vec![(tparam, 0)],
-            constant: None,
+            constant,
         }
     }
 
     /// We `max` over a list of formulas, and we normalize it to deal with duplicate terms, e.g.
     /// `max(max(t1 + 1, t2 + 2, 2), max(t1 + 3, t2 + 1, 4))` becomes
     /// `max(t1 + 3, t2 + 2, 4)`
-    pub fn normalize(formulas: Vec<Self>) -> Self {
+    pub fn normalize(formulas: Vec<Self>, normalize_formula: bool) -> Self {
         let mut var_map = BTreeMap::new();
         let mut constant_acc = None;
         for formula in formulas {
@@ -67,9 +68,14 @@ impl DepthFormula {
                 (Some(c1), Some(c2)) => constant_acc = Some(max(c1, c2)),
             }
         }
+        let constant = if normalize_formula {
+            constant_acc.or(Some(0))
+        } else {
+            constant_acc
+        };
         Self {
             terms: var_map.into_iter().collect(),
-            constant: constant_acc,
+            constant,
         }
     }
 
@@ -77,6 +83,7 @@ impl DepthFormula {
     pub fn subst(
         &self,
         mut map: BTreeMap<TypeParameterIndex, DepthFormula>,
+        normalize_formula: bool,
     ) -> PartialVMResult<DepthFormula> {
         let Self { terms, constant } = self;
         let mut formulas = vec![];
@@ -93,7 +100,7 @@ impl DepthFormula {
             u_form.add(*c_i);
             formulas.push(u_form)
         }
-        Ok(DepthFormula::normalize(formulas))
+        Ok(DepthFormula::normalize(formulas, normalize_formula))
     }
 
     /// Given depths for each type parameter, solve the formula giving the max depth for the type

--- a/sui-execution/latest/sui-adapter/src/adapter.rs
+++ b/sui-execution/latest/sui-adapter/src/adapter.rs
@@ -69,6 +69,7 @@ mod checked {
             variant_nodes: protocol_config.variant_nodes(),
             deprecate_global_storage_ops_during_deserialization: protocol_config
                 .deprecate_global_storage_ops_during_deserialization(),
+            normalize_depth_formula: protocol_config.normalize_depth_formula(),
         }
     }
 

--- a/sui-execution/v0/sui-adapter/src/adapter.rs
+++ b/sui-execution/v0/sui-adapter/src/adapter.rs
@@ -64,6 +64,7 @@ mod checked {
                 variant_nodes: protocol_config.variant_nodes(),
                 deprecate_global_storage_ops_during_deserialization: protocol_config
                     .deprecate_global_storage_ops_during_deserialization(),
+                normalize_depth_formula: protocol_config.normalize_depth_formula(),
             },
         )
         .map_err(|_| SuiErrorKind::ExecutionInvariantViolation.into())

--- a/sui-execution/v1/sui-adapter/src/adapter.rs
+++ b/sui-execution/v1/sui-adapter/src/adapter.rs
@@ -64,6 +64,7 @@ mod checked {
                 variant_nodes: protocol_config.variant_nodes(),
                 deprecate_global_storage_ops_during_deserialization: protocol_config
                     .deprecate_global_storage_ops_during_deserialization(),
+                normalize_depth_formula: protocol_config.normalize_depth_formula(),
             },
         )
         .map_err(|_| SuiErrorKind::ExecutionInvariantViolation.into())

--- a/sui-execution/v2/sui-adapter/src/adapter.rs
+++ b/sui-execution/v2/sui-adapter/src/adapter.rs
@@ -62,6 +62,7 @@ mod checked {
                 variant_nodes: protocol_config.variant_nodes(),
                 deprecate_global_storage_ops_during_deserialization: protocol_config
                     .deprecate_global_storage_ops_during_deserialization(),
+                normalize_depth_formula: protocol_config.normalize_depth_formula(),
             },
         )
         .map_err(|_| SuiErrorKind::ExecutionInvariantViolation.into())


### PR DESCRIPTION
Normalize representation to match the new VM and smooth the upcoming rollout of it. If we don't do it now we'd need to protocol gate it in the new VM and all the messiness that that brings in the new VM. This way it can be nice and clean.

CI/existing tests

---

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [X] Protocol: Adds a new protocol version 115 to normalize representation of some structures within the VM.
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework:
