### PR TITLE
Update ingest-concurrency docs

### DIFF
--- a/examples/prod-config/consistent_store.toml
+++ b/examples/prod-config/consistent_store.toml
@@ -1,5 +1,5 @@
 [ingestion]
-ingest-concurrency = 20
+ingest-concurrency = { kind = "fixed", value = 20 }
 
 [pipeline.address-balances]
 

--- a/examples/prod-config/indexer/obj_versions.toml
+++ b/examples/prod-config/indexer/obj_versions.toml
@@ -1,5 +1,5 @@
 [ingestion]
-ingest-concurrency = 20
+ingest-concurrency = { kind = "fixed", value = 20 }
 
 [committer]
 write-concurrency = 10

--- a/examples/prod-config/indexer/tx_affected_addresses.toml
+++ b/examples/prod-config/indexer/tx_affected_addresses.toml
@@ -1,5 +1,5 @@
 [ingestion]
-ingest-concurrency = 20
+ingest-concurrency = { kind = "fixed", value = 20 }
 
 [committer]
 write-concurrency = 10

--- a/examples/prod-config/indexer/unpruned.toml
+++ b/examples/prod-config/indexer/unpruned.toml
@@ -1,5 +1,5 @@
 [ingestion]
-ingest-concurrency = 20
+ingest-concurrency = { kind = "fixed", value = 20 }
 
 [pipeline.cp_sequence_numbers]
 


### PR DESCRIPTION
## Description

Missed these when I changed how ingest-concurrency gets de/serialized.
