### PR TITLE
docs: Add SUIUSDE and USDSUI asset scalars to indexer docs

### DIFF
--- a/docs/content/standards/deepbookv3-indexer.mdx
+++ b/docs/content/standards/deepbookv3-indexer.mdx
@@ -70,6 +70,8 @@ Following are the decimal places (scalars) used to determine the base unit for e
 | SEND | 6 |
 | SUI | 9 |
 | TYPUS | 9 |
+| SUIUSDE | 6 |
+| USDSUI | 6 |
 | WAL | 9 |
 | Wormhole USDC (WUSDC) | 6 |
 | Wormhole USDT (WUSDT) | 6 |


### PR DESCRIPTION
## Summary

- Add SUIUSDE (6) and USDSUI (6) to the asset scalar conversion table in the DeepBook indexer docs

Other changes from the original PR (indexer endpoints, margin indexer docs) were already merged via #25864.

## Test plan

- [ ] Verify docs build renders the table correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)