### PR TITLE
rosetta: add ConvertToFungibleStakedSui operation support

### DIFF
--- a/crates/sui-rosetta/src/operations.rs
+++ b/crates/sui-rosetta/src/operations.rs
@@ -32,7 +32,9 @@ use sui_types::governance::{ADD_STAKE_FUN_NAME, WITHDRAW_STAKE_FUN_NAME};
 use sui_types::sui_system_state::SUI_SYSTEM_MODULE_NAME;
 use sui_types::{SUI_FRAMEWORK_PACKAGE_ID, SUI_SYSTEM_ADDRESS, SUI_SYSTEM_PACKAGE_ID};
 
-use crate::types::internal_operation::{PayCoin, PaySui, Stake, WithdrawStake};
+use crate::types::internal_operation::{
+    ConvertToFungibleStakedSui, PayCoin, PaySui, Stake, WithdrawStake,
+};
 use crate::types::{
     AccountIdentifier, Amount, CoinAction, CoinChange, CoinID, CoinIdentifier, Currency,
     InternalOperation, OperationIdentifier, OperationStatus, OperationType,
@@ -104,6 +106,9 @@ impl Operations {
             OperationType::PayCoin => self.pay_coin_ops_to_internal(),
             OperationType::Stake => self.stake_ops_to_internal(),
             OperationType::WithdrawStake => self.withdraw_stake_ops_to_internal(),
+            OperationType::ConvertToFungibleStakedSui => {
+                self.convert_to_fungible_staked_sui_ops_to_internal()
+            }
             op => Err(Error::UnsupportedOperation(op)),
         }
     }
@@ -247,6 +252,40 @@ impl Operations {
             sender,
             stake_ids,
         }))
+    }
+
+    fn convert_to_fungible_staked_sui_ops_to_internal(self) -> Result<InternalOperation, Error> {
+        let mut ops = self
+            .0
+            .into_iter()
+            .filter(|op| op.type_ == OperationType::ConvertToFungibleStakedSui)
+            .collect::<Vec<_>>();
+        if ops.len() != 1 {
+            return Err(Error::MalformedOperationError(
+                "ConvertToFungibleStakedSui should only have one operation.".into(),
+            ));
+        }
+        let op = ops.pop().unwrap();
+        let sender = op
+            .account
+            .ok_or_else(|| Error::MissingInput("Sender address".to_string()))?
+            .address;
+        let metadata = op.metadata.ok_or_else(|| {
+            Error::MissingInput("ConvertToFungibleStakedSui metadata".to_string())
+        })?;
+
+        let OperationMetadata::ConvertToFungibleStakedSui { staked_sui_id } = metadata else {
+            return Err(Error::InvalidInput(
+                "Cannot find convert to fungible staked sui info from metadata.".into(),
+            ));
+        };
+
+        Ok(InternalOperation::ConvertToFungibleStakedSui(
+            ConvertToFungibleStakedSui {
+                sender,
+                staked_sui_id,
+            },
+        ))
     }
 
     pub fn from_transaction(
@@ -519,6 +558,7 @@ impl Operations {
         let mut needs_generic = false;
         let mut operations = vec![];
         let mut stake_ids = vec![];
+        let mut convert_to_fungible: Option<ObjectID> = None;
         let mut currency: Option<Currency> = None;
 
         for command in commands {
@@ -585,6 +625,37 @@ impl Operations {
                 {
                     Some(vec![])
                 }
+                Some(Command::MoveCall(m))
+                    if Self::is_convert_to_fungible_staked_sui_call(m) =>
+                {
+                    let args = &m.arguments;
+                    // args: [system_state, staked_sui]
+                    if let Some(staked_sui_arg) = args.get(1) {
+                        let staked_sui_id = match staked_sui_arg.kind() {
+                            ArgumentKind::Input => inputs
+                                .get(staked_sui_arg.input() as usize)
+                                .and_then(|input| {
+                                    if input.kind() == InputKind::ImmutableOrOwned {
+                                        input
+                                            .object_id
+                                            .as_ref()
+                                            .and_then(|oid| ObjectID::from_str(oid).ok())
+                                    } else {
+                                        None
+                                    }
+                                }),
+                            _ => None,
+                        };
+                        if let Some(id) = staked_sui_id {
+                            convert_to_fungible = Some(id);
+                            break;
+                        } else {
+                            None
+                        }
+                    } else {
+                        None
+                    }
+                }
                 _ => None,
             };
             if let Some(result) = result {
@@ -646,6 +717,12 @@ impl Operations {
                 coin_change: None,
                 metadata,
             });
+        } else if let Some(staked_sui_id) = convert_to_fungible {
+            operations.push(Operation::convert_to_fungible_staked_sui(
+                status,
+                sender,
+                staked_sui_id,
+            ));
         } else if operations.is_empty() {
             let tx_kind = TransactionKind::default()
                 .with_kind(ProgrammableTransactionKind)
@@ -690,6 +767,16 @@ impl Operations {
             && tx.module() == SUI_SYSTEM_MODULE_NAME.as_str()
             && (tx.function() == WITHDRAW_STAKE_FUN_NAME.as_str()
                 || tx.function() == "request_withdraw_stake_non_entry")
+    }
+
+    fn is_convert_to_fungible_staked_sui_call(tx: &MoveCall) -> bool {
+        let package_id = match ObjectID::from_str(tx.package()) {
+            Ok(id) => id,
+            Err(_) => return false,
+        };
+        package_id == SUI_SYSTEM_PACKAGE_ID
+            && tx.module() == SUI_SYSTEM_MODULE_NAME.as_str()
+            && tx.function() == "convert_to_fungible_staked_sui"
     }
 
     /// Recognizes `coin::redeem_funds<T>` calls used for address-balance withdrawals.
@@ -1168,6 +1255,7 @@ pub enum OperationMetadata {
     GenericTransaction(TransactionKind),
     Stake { validator: SuiAddress },
     WithdrawStake { stake_ids: Vec<ObjectID> },
+    ConvertToFungibleStakedSui { staked_sui_id: ObjectID },
 }
 
 impl Operation {
@@ -1283,6 +1371,21 @@ impl Operation {
             amount: Some(Amount::new(amount, None)),
             coin_change: None,
             metadata: None,
+        }
+    }
+    fn convert_to_fungible_staked_sui(
+        status: Option<OperationStatus>,
+        sender: SuiAddress,
+        staked_sui_id: ObjectID,
+    ) -> Self {
+        Self {
+            operation_identifier: Default::default(),
+            type_: OperationType::ConvertToFungibleStakedSui,
+            status,
+            account: Some(sender.into()),
+            amount: None,
+            coin_change: None,
+            metadata: Some(OperationMetadata::ConvertToFungibleStakedSui { staked_sui_id }),
         }
     }
 }
@@ -1412,5 +1515,201 @@ mod tests {
         assert_eq!(data, parsed_data);
 
         Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_operation_data_parsing_convert_to_fungible_staked_sui(
+    ) -> Result<(), anyhow::Error> {
+        use crate::types::internal_operation::convert_to_fungible_staked_sui_pt;
+
+        let gas = (
+            ObjectID::random(),
+            SequenceNumber::new(),
+            ObjectDigest::random(),
+        );
+
+        let staked_sui = (
+            ObjectID::random(),
+            SequenceNumber::new(),
+            ObjectDigest::random(),
+        );
+
+        let sender = SuiAddress::random_for_testing_only();
+
+        let pt = convert_to_fungible_staked_sui_pt(sender, vec![staked_sui])?;
+        let gas_price = 10;
+        let data = TransactionData::new_programmable(
+            sender,
+            vec![gas],
+            pt,
+            TEST_ONLY_GAS_UNIT_FOR_TRANSFER * gas_price,
+            gas_price,
+        );
+
+        let proto_tx: Transaction = data.clone().into();
+        let ops = Operations::new(Operations::from_transaction(
+            proto_tx
+                .kind
+                .ok_or_else(|| Error::DataError("Transaction missing kind".to_string()))?,
+            sender,
+            None,
+        )?);
+        assert_eq!(1, ops.0.len());
+        assert_eq!(ops.0[0].type_, OperationType::ConvertToFungibleStakedSui);
+        assert_eq!(
+            ops.0[0].metadata,
+            Some(OperationMetadata::ConvertToFungibleStakedSui {
+                staked_sui_id: staked_sui.0,
+            })
+        );
+
+        let metadata = ConstructionMetadata {
+            sender,
+            gas_coins: vec![gas],
+            extra_gas_coins: vec![],
+            objects: vec![staked_sui],
+            party_objects: vec![],
+            total_coin_value: 0,
+            gas_price,
+            budget: TEST_ONLY_GAS_UNIT_FOR_TRANSFER * gas_price,
+            currency: None,
+            address_balance_withdrawal: 0,
+            epoch: None,
+            chain_id: None,
+        };
+        let parsed_data = ops.into_internal()?.try_into_data(metadata)?;
+        assert_eq!(data, parsed_data);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_convert_to_fungible_staked_sui_read_path_fields() -> Result<(), anyhow::Error> {
+        use crate::types::internal_operation::convert_to_fungible_staked_sui_pt;
+
+        let gas = (
+            ObjectID::random(),
+            SequenceNumber::new(),
+            ObjectDigest::random(),
+        );
+        let staked_sui = (
+            ObjectID::random(),
+            SequenceNumber::new(),
+            ObjectDigest::random(),
+        );
+        let sender = SuiAddress::random_for_testing_only();
+
+        let pt = convert_to_fungible_staked_sui_pt(sender, vec![staked_sui])?;
+        let data = TransactionData::new_programmable(
+            sender,
+            vec![gas],
+            pt,
+            TEST_ONLY_GAS_UNIT_FOR_TRANSFER * 10,
+            10,
+        );
+
+        let proto_tx: Transaction = data.into();
+        let ops = Operations::new(Operations::from_transaction(
+            proto_tx
+                .kind
+                .ok_or_else(|| Error::DataError("Transaction missing kind".to_string()))?,
+            sender,
+            Some(OperationStatus::Success),
+        )?);
+
+        assert_eq!(1, ops.0.len());
+        let op = &ops.0[0];
+        assert_eq!(op.type_, OperationType::ConvertToFungibleStakedSui);
+        assert_eq!(op.status, Some(OperationStatus::Success));
+        assert_eq!(op.account, Some(AccountIdentifier::from(sender)));
+        assert!(op.amount.is_none(), "Convert should have no amount");
+        assert!(
+            op.coin_change.is_none(),
+            "Convert should have no coin change"
+        );
+        assert_eq!(
+            op.metadata,
+            Some(OperationMetadata::ConvertToFungibleStakedSui {
+                staked_sui_id: staked_sui.0,
+            })
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_convert_to_fungible_staked_sui_ops_missing_metadata() {
+        let sender = SuiAddress::random_for_testing_only();
+        let ops: Operations = serde_json::from_value(serde_json::json!([{
+            "operation_identifier": {"index": 0},
+            "type": "ConvertToFungibleStakedSui",
+            "account": { "address": sender.to_string() },
+        }]))
+        .unwrap();
+        let result = ops.into_internal();
+        assert!(result.is_err(), "Expected error when metadata is missing");
+    }
+
+    #[tokio::test]
+    async fn test_convert_to_fungible_staked_sui_ops_wrong_metadata_type() {
+        let sender = SuiAddress::random_for_testing_only();
+        let validator = SuiAddress::random_for_testing_only();
+        let ops: Operations = serde_json::from_value(serde_json::json!([{
+            "operation_identifier": {"index": 0},
+            "type": "ConvertToFungibleStakedSui",
+            "account": { "address": sender.to_string() },
+            "metadata": { "Stake": { "validator": validator.to_string() } }
+        }]))
+        .unwrap();
+        let result = ops.into_internal();
+        assert!(
+            result.is_err(),
+            "Expected error when metadata type is wrong"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_convert_to_fungible_staked_sui_ops_missing_account() {
+        let staked_sui_id = ObjectID::random();
+        let ops: Operations = serde_json::from_value(serde_json::json!([{
+            "operation_identifier": {"index": 0},
+            "type": "ConvertToFungibleStakedSui",
+            "metadata": { "ConvertToFungibleStakedSui": {
+                "staked_sui_id": staked_sui_id.to_string(),
+            }}
+        }]))
+        .unwrap();
+        let result = ops.into_internal();
+        assert!(result.is_err(), "Expected error when account is missing");
+    }
+
+    #[tokio::test]
+    async fn test_convert_to_fungible_staked_sui_ops_duplicate_operations() {
+        let sender = SuiAddress::random_for_testing_only();
+        let staked_sui_id = ObjectID::random();
+        let ops: Operations = serde_json::from_value(serde_json::json!([
+            {
+                "operation_identifier": {"index": 0},
+                "type": "ConvertToFungibleStakedSui",
+                "account": { "address": sender.to_string() },
+                "metadata": { "ConvertToFungibleStakedSui": {
+                    "staked_sui_id": staked_sui_id.to_string(),
+                }}
+            },
+            {
+                "operation_identifier": {"index": 1},
+                "type": "ConvertToFungibleStakedSui",
+                "account": { "address": sender.to_string() },
+                "metadata": { "ConvertToFungibleStakedSui": {
+                    "staked_sui_id": staked_sui_id.to_string(),
+                }}
+            }
+        ]))
+        .unwrap();
+        let result = ops.into_internal();
+        assert!(
+            result.is_err(),
+            "Expected error when duplicate convert operations are provided"
+        );
     }
 }

--- a/crates/sui-rosetta/src/types.rs
+++ b/crates/sui-rosetta/src/types.rs
@@ -439,6 +439,7 @@ pub enum OperationType {
     PayCoin,
     Stake,
     WithdrawStake,
+    ConvertToFungibleStakedSui,
     // All other Sui transaction types, readonly
     EpochChange,
     Genesis,

--- a/crates/sui-rosetta/src/types/internal_operation.rs
+++ b/crates/sui-rosetta/src/types/internal_operation.rs
@@ -39,7 +39,10 @@ pub use stake::Stake;
 use stake::{stake_pt_ab_gas, stake_pt_coin_gas};
 pub use withdraw_stake::WithdrawStake;
 use withdraw_stake::withdraw_stake_pt;
+pub use convert_to_fungible_staked_sui::ConvertToFungibleStakedSui;
+pub(crate) use convert_to_fungible_staked_sui::convert_to_fungible_staked_sui_pt;
 
+mod convert_to_fungible_staked_sui;
 mod pay_coin;
 mod pay_sui;
 mod stake;
@@ -82,6 +85,7 @@ pub enum InternalOperation {
     PayCoin(PayCoin),
     Stake(Stake),
     WithdrawStake(WithdrawStake),
+    ConvertToFungibleStakedSui(ConvertToFungibleStakedSui),
 }
 
 impl InternalOperation {
@@ -90,7 +94,10 @@ impl InternalOperation {
             InternalOperation::PaySui(PaySui { sender, .. })
             | InternalOperation::PayCoin(PayCoin { sender, .. })
             | InternalOperation::Stake(Stake { sender, .. })
-            | InternalOperation::WithdrawStake(WithdrawStake { sender, .. }) => *sender,
+            | InternalOperation::WithdrawStake(WithdrawStake { sender, .. })
+            | InternalOperation::ConvertToFungibleStakedSui(ConvertToFungibleStakedSui {
+                sender, ..
+            }) => *sender,
         }
     }
 
@@ -194,6 +201,9 @@ impl InternalOperation {
                 let withdraw_all = stake_ids.is_empty();
                 withdraw_stake_pt(metadata.objects, withdraw_all)?
             }
+            InternalOperation::ConvertToFungibleStakedSui(ConvertToFungibleStakedSui {
+                sender, ..
+            }) => convert_to_fungible_staked_sui_pt(sender, metadata.objects)?,
         };
 
         if metadata.gas_coins.is_empty() {

--- a/crates/sui-rosetta/src/types/internal_operation/convert_to_fungible_staked_sui.rs
+++ b/crates/sui-rosetta/src/types/internal_operation/convert_to_fungible_staked_sui.rs
@@ -1,0 +1,122 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use async_trait::async_trait;
+use move_core_types::identifier::Identifier;
+use prost_types::FieldMask;
+use serde::{Deserialize, Serialize};
+use std::str::FromStr;
+use sui_rpc::client::Client;
+
+use sui_rpc::field::FieldMaskUtil;
+use sui_rpc::proto::sui::rpc::v2::GetObjectRequest;
+use sui_types::base_types::{ObjectID, ObjectRef, SuiAddress};
+use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
+use sui_types::rpc_proto_conversions::ObjectReferenceExt;
+use sui_types::sui_system_state::SUI_SYSTEM_MODULE_NAME;
+use sui_types::transaction::{CallArg, Command, ObjectArg, ProgrammableTransaction};
+use sui_types::SUI_SYSTEM_PACKAGE_ID;
+
+use crate::errors::Error;
+
+use super::{TransactionObjectData, TryConstructTransaction, simulate_transaction};
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct ConvertToFungibleStakedSui {
+    pub sender: SuiAddress,
+    pub staked_sui_id: ObjectID,
+}
+
+#[async_trait]
+impl TryConstructTransaction for ConvertToFungibleStakedSui {
+    async fn try_fetch_needed_objects(
+        self,
+        client: &mut Client,
+        gas_price: Option<u64>,
+        budget: Option<u64>,
+    ) -> Result<TransactionObjectData, Error> {
+        let Self {
+            sender,
+            staked_sui_id,
+        } = self;
+
+        let address: sui_sdk_types::Address = staked_sui_id.into();
+        let request = GetObjectRequest::new(&address)
+            .with_read_mask(FieldMask::from_paths(["object_id", "version", "digest"]));
+
+        let response = client
+            .ledger_client()
+            .get_object(request)
+            .await?
+            .into_inner();
+
+        let object_ref = if let Some(object) = response.object {
+            let oid = object.object_id.ok_or_else(|| {
+                Error::InvalidInput("Object ID missing in response".to_string())
+            })?;
+            let version = object.version.ok_or_else(|| {
+                Error::InvalidInput("Version missing in response".to_string())
+            })?;
+            let digest = object
+                .digest
+                .ok_or_else(|| Error::InvalidInput("Digest missing in response".to_string()))?;
+
+            (
+                ObjectID::from_str(&oid).map_err(|e| {
+                    Error::InvalidInput(format!("Failed to parse object ID: {}", e))
+                })?,
+                version.into(),
+                digest.parse().map_err(|e| {
+                    Error::InvalidInput(format!("Failed to parse digest: {}", e))
+                })?,
+            )
+        } else {
+            return Err(Error::InvalidInput(format!(
+                "StakedSui object {} not found",
+                staked_sui_id
+            )));
+        };
+
+        let pt = convert_to_fungible_staked_sui_pt(sender, vec![object_ref])?;
+        let (budget, gas_coin_objs) =
+            simulate_transaction(client, pt, sender, vec![], gas_price, budget).await?;
+
+        let total_sui_balance = gas_coin_objs.iter().map(|c| c.balance()).sum::<u64>() as i128;
+        let gas_coins = gas_coin_objs
+            .iter()
+            .map(|obj| obj.object_reference().try_to_object_ref())
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(TransactionObjectData {
+            gas_coins,
+            objects: vec![object_ref],
+            party_objects: vec![],
+            total_sui_balance,
+            budget,
+            address_balance_withdrawal: 0,
+        })
+    }
+}
+
+pub fn convert_to_fungible_staked_sui_pt(
+    sender: SuiAddress,
+    objects: Vec<ObjectRef>,
+) -> anyhow::Result<ProgrammableTransaction> {
+    let mut builder = ProgrammableTransactionBuilder::new();
+
+    let system_state = builder.input(CallArg::SUI_SYSTEM_MUT)?;
+    let staked_sui = builder.obj(ObjectArg::ImmOrOwnedObject(objects[0]))?;
+
+    let result = builder.command(Command::move_call(
+        SUI_SYSTEM_PACKAGE_ID,
+        SUI_SYSTEM_MODULE_NAME.to_owned(),
+        Identifier::new("convert_to_fungible_staked_sui")?,
+        vec![],
+        vec![system_state, staked_sui],
+    ));
+
+    let sender_arg = builder.pure(sender)?;
+    builder.command(Command::TransferObjects(vec![result], sender_arg));
+
+    Ok(builder.finish())
+}

--- a/crates/sui-rosetta/tests/end_to_end_tests.rs
+++ b/crates/sui-rosetta/tests/end_to_end_tests.rs
@@ -19,7 +19,9 @@ use sui_rosetta::types::{
 use sui_rosetta::types::{Currencies, OperationType, TransactionIdentifierResponse};
 use sui_rpc::client::Client as GrpcClient;
 use sui_rpc::field::FieldMaskUtil;
-use sui_rpc::proto::sui::rpc::v2::{GetCheckpointRequest, GetEpochRequest, GetTransactionRequest};
+use sui_rpc::proto::sui::rpc::v2::{
+    GetCheckpointRequest, GetEpochRequest, GetTransactionRequest, ListOwnedObjectsRequest,
+};
 
 mod test_utils;
 use sui_swarm_config::genesis_config::{DEFAULT_GAS_AMOUNT, DEFAULT_NUMBER_OF_OBJECT_PER_ACCOUNT};
@@ -1783,4 +1785,369 @@ async fn test_block_transaction() -> Result<()> {
     }
 
     Ok(())
+}
+
+#[tokio::test]
+async fn test_convert_to_fungible_staked_sui() {
+    telemetry_subscribers::init_for_testing();
+
+    let test_cluster = TestClusterBuilder::new()
+        .with_epoch_duration_ms(60000)
+        .build()
+        .await;
+    let sender = test_cluster.get_address_0();
+    let keystore = &test_cluster.wallet.config.keystore;
+
+    let mut client = GrpcClient::new(test_cluster.rpc_url()).unwrap();
+    let (rosetta_client, _handle) = start_rosetta_test_server(client.clone()).await;
+
+    let request = GetEpochRequest::latest().with_read_mask(FieldMask::from_paths(["system_state"]));
+    let response = client
+        .ledger_client()
+        .get_epoch(request)
+        .await
+        .unwrap()
+        .into_inner();
+
+    let system_state = response.epoch.and_then(|epoch| epoch.system_state).unwrap();
+    let validator = system_state.validators.unwrap().active_validators[0]
+        .address()
+        .parse::<SuiAddress>()
+        .unwrap();
+
+    let gas_price = client.get_reference_gas_price().await.unwrap();
+    let coins = get_all_coins(&mut client.clone(), sender).await.unwrap();
+
+    // Stake a coin to create a StakedSui object
+    let staking_coin_ref = get_object_ref(&mut client.clone(), coins[0].id())
+        .await
+        .unwrap();
+    let gas_object = get_random_sui(&mut client.clone(), sender, vec![coins[0].id()]).await;
+
+    let mut ptb = ProgrammableTransactionBuilder::new();
+    let arguments = vec![
+        ptb.input(CallArg::SUI_SYSTEM_MUT).unwrap(),
+        ptb.make_obj_vec(vec![ObjectArg::ImmOrOwnedObject(
+            staking_coin_ref.as_object_ref(),
+        )])
+        .unwrap(),
+        ptb.pure(Some(1_000_000_000u64)).unwrap(),
+        ptb.pure(validator).unwrap(),
+    ];
+    ptb.command(Command::move_call(
+        SUI_SYSTEM_PACKAGE_ID,
+        SUI_SYSTEM_MODULE_NAME.to_owned(),
+        ADD_STAKE_MUL_COIN_FUN_NAME.to_owned(),
+        vec![],
+        arguments,
+    ));
+    let tx_data = TransactionData::new_programmable(
+        sender,
+        vec![gas_object],
+        ptb.finish(),
+        1_000_000_000,
+        gas_price,
+    );
+    let tx = to_sender_signed_transaction(tx_data, keystore.export(&sender).unwrap());
+    execute_transaction(&mut client.clone(), &tx)
+        .await
+        .unwrap();
+
+    // Advance epoch so stake becomes active
+    test_cluster.trigger_reconfiguration().await;
+
+    // Find the StakedSui object
+    use futures::TryStreamExt;
+    let list_request = ListOwnedObjectsRequest::default()
+        .with_owner(sender.to_string())
+        .with_object_type("0x3::staking_pool::StakedSui".to_string())
+        .with_page_size(10u32)
+        .with_read_mask(FieldMask::from_paths(["object_id", "version", "digest"]));
+
+    let staked_sui_objects: Vec<_> = client
+        .clone()
+        .list_owned_objects(list_request)
+        .map_err(sui_rosetta::errors::Error::from)
+        .and_then(|object| async move {
+            let object_id = ObjectID::from_hex_literal(object.object_id()).map_err(|e| {
+                sui_rosetta::errors::Error::InvalidInput(format!("Invalid object_id: {}", e))
+            })?;
+            let version: u64 = object.version.ok_or_else(|| {
+                sui_rosetta::errors::Error::InvalidInput("Version missing".to_string())
+            })?;
+            let digest_str = object.digest.as_ref().ok_or_else(|| {
+                sui_rosetta::errors::Error::InvalidInput("Digest missing".to_string())
+            })?;
+            let digest: sui_types::base_types::ObjectDigest = digest_str.parse().map_err(|e| {
+                sui_rosetta::errors::Error::InvalidInput(format!("Invalid digest: {}", e))
+            })?;
+            Ok((
+                object_id,
+                sui_types::base_types::SequenceNumber::from_u64(version),
+                digest,
+            ))
+        })
+        .try_collect()
+        .await
+        .unwrap();
+
+    assert!(
+        !staked_sui_objects.is_empty(),
+        "Expected at least 1 StakedSui object, got 0",
+    );
+
+    let staked_sui_id = staked_sui_objects[0].0;
+
+    // Now use Rosetta to convert StakedSui to FungibleStakedSui
+    let ops: Operations = serde_json::from_value(json!([{
+        "operation_identifier": {"index": 0},
+        "type": "ConvertToFungibleStakedSui",
+        "account": { "address": sender.to_string() },
+        "metadata": { "ConvertToFungibleStakedSui": {
+            "staked_sui_id": staked_sui_id.to_string(),
+        }}
+    }]))
+    .unwrap();
+
+    let response = rosetta_client
+        .rosetta_flow(&ops, keystore, None)
+        .await
+        .submit
+        .unwrap()
+        .unwrap();
+
+    wait_for_transaction(
+        &mut client,
+        &response.transaction_identifier.hash.to_string(),
+    )
+    .await
+    .unwrap();
+
+    // Fetch and verify the transaction
+    let grpc_request = GetTransactionRequest::default()
+        .with_digest(response.transaction_identifier.hash.to_string())
+        .with_read_mask(FieldMask::from_paths([
+            "digest",
+            "transaction",
+            "effects",
+            "balance_changes",
+            "events",
+        ]));
+
+    let grpc_response = client
+        .clone()
+        .ledger_client()
+        .get_transaction(grpc_request)
+        .await
+        .unwrap()
+        .into_inner();
+
+    let tx = grpc_response
+        .transaction
+        .expect("Response transaction should not be empty");
+
+    assert!(
+        tx.effects().status().success(),
+        "ConvertToFungibleStakedSui transaction failed: {:?}",
+        tx.effects().status().error()
+    );
+
+    let coin_cache = CoinMetadataCache::new(client.clone(), NonZeroUsize::new(2).unwrap());
+    let ops2 = fetch_transaction_and_get_operations(
+        &test_cluster,
+        tx.digest().parse().unwrap(),
+        &coin_cache,
+    )
+    .await
+    .unwrap();
+    assert!(
+        ops2.contains(&ops),
+        "Operation mismatch. expecting:{}, got:{}",
+        serde_json::to_string(&ops).unwrap(),
+        serde_json::to_string(&ops2).unwrap()
+    );
+}
+
+#[tokio::test]
+async fn test_convert_to_fungible_staked_sui_read_path() {
+    telemetry_subscribers::init_for_testing();
+
+    let test_cluster = TestClusterBuilder::new()
+        .with_epoch_duration_ms(60000)
+        .build()
+        .await;
+    let sender = test_cluster.get_address_0();
+    let keystore = &test_cluster.wallet.config.keystore;
+
+    let mut client = GrpcClient::new(test_cluster.rpc_url()).unwrap();
+
+    let request = GetEpochRequest::latest().with_read_mask(FieldMask::from_paths(["system_state"]));
+    let response = client
+        .ledger_client()
+        .get_epoch(request)
+        .await
+        .unwrap()
+        .into_inner();
+
+    let system_state = response.epoch.and_then(|epoch| epoch.system_state).unwrap();
+    let validator = system_state.validators.unwrap().active_validators[0]
+        .address()
+        .parse::<SuiAddress>()
+        .unwrap();
+
+    let gas_price = client.get_reference_gas_price().await.unwrap();
+    let coins = get_all_coins(&mut client.clone(), sender).await.unwrap();
+
+    // Stake a coin
+    let staking_coin_ref = get_object_ref(&mut client.clone(), coins[0].id())
+        .await
+        .unwrap();
+    let gas_object = get_random_sui(&mut client.clone(), sender, vec![coins[0].id()]).await;
+
+    let mut ptb = ProgrammableTransactionBuilder::new();
+    let arguments = vec![
+        ptb.input(CallArg::SUI_SYSTEM_MUT).unwrap(),
+        ptb.make_obj_vec(vec![ObjectArg::ImmOrOwnedObject(
+            staking_coin_ref.as_object_ref(),
+        )])
+        .unwrap(),
+        ptb.pure(Some(1_000_000_000u64)).unwrap(),
+        ptb.pure(validator).unwrap(),
+    ];
+    ptb.command(Command::move_call(
+        SUI_SYSTEM_PACKAGE_ID,
+        SUI_SYSTEM_MODULE_NAME.to_owned(),
+        ADD_STAKE_MUL_COIN_FUN_NAME.to_owned(),
+        vec![],
+        arguments,
+    ));
+    let tx_data = TransactionData::new_programmable(
+        sender,
+        vec![gas_object],
+        ptb.finish(),
+        1_000_000_000,
+        gas_price,
+    );
+    let tx = to_sender_signed_transaction(tx_data, keystore.export(&sender).unwrap());
+    execute_transaction(&mut client.clone(), &tx)
+        .await
+        .unwrap();
+
+    test_cluster.trigger_reconfiguration().await;
+
+    // Find StakedSui object
+    use futures::TryStreamExt;
+    let list_request = ListOwnedObjectsRequest::default()
+        .with_owner(sender.to_string())
+        .with_object_type("0x3::staking_pool::StakedSui".to_string())
+        .with_page_size(10u32)
+        .with_read_mask(FieldMask::from_paths(["object_id", "version", "digest"]));
+
+    let staked_sui_objects: Vec<ObjectRef> = client
+        .clone()
+        .list_owned_objects(list_request)
+        .map_err(sui_rosetta::errors::Error::from)
+        .and_then(|object| async move {
+            let object_id = ObjectID::from_hex_literal(object.object_id()).map_err(|e| {
+                sui_rosetta::errors::Error::InvalidInput(format!("Invalid object_id: {}", e))
+            })?;
+            let version: u64 = object.version.ok_or_else(|| {
+                sui_rosetta::errors::Error::InvalidInput("Version missing".to_string())
+            })?;
+            let digest_str = object.digest.as_ref().ok_or_else(|| {
+                sui_rosetta::errors::Error::InvalidInput("Digest missing".to_string())
+            })?;
+            let digest: sui_types::base_types::ObjectDigest = digest_str.parse().map_err(|e| {
+                sui_rosetta::errors::Error::InvalidInput(format!("Invalid digest: {}", e))
+            })?;
+            Ok((
+                object_id,
+                sui_types::base_types::SequenceNumber::from_u64(version),
+                digest,
+            ))
+        })
+        .try_collect()
+        .await
+        .unwrap();
+
+    assert!(!staked_sui_objects.is_empty());
+
+    let staked_ref = staked_sui_objects[0];
+
+    // Convert StakedSui to FungibleStakedSui using direct PTB
+    let gas_object = get_random_sui(&mut client.clone(), sender, vec![staked_ref.0]).await;
+
+    let mut ptb = ProgrammableTransactionBuilder::new();
+    let system_state = ptb.input(CallArg::SUI_SYSTEM_MUT).unwrap();
+    let staked_sui = ptb.obj(ObjectArg::ImmOrOwnedObject(staked_ref)).unwrap();
+    let result = ptb.command(Command::move_call(
+        SUI_SYSTEM_PACKAGE_ID,
+        Identifier::new("sui_system").unwrap(),
+        Identifier::new("convert_to_fungible_staked_sui").unwrap(),
+        vec![],
+        vec![system_state, staked_sui],
+    ));
+    let sender_arg = ptb.pure(sender).unwrap();
+    ptb.command(Command::TransferObjects(vec![result], sender_arg));
+    let tx_data = TransactionData::new_programmable(
+        sender,
+        vec![gas_object],
+        ptb.finish(),
+        1_000_000_000,
+        gas_price,
+    );
+    let tx = to_sender_signed_transaction(tx_data, keystore.export(&sender).unwrap());
+    let response = execute_transaction(&mut client.clone(), &tx)
+        .await
+        .unwrap();
+
+    assert!(
+        response.effects().status().success(),
+        "Direct convert to fungible staked sui failed: {:?}",
+        response.effects().status().error()
+    );
+
+    // Now read back the transaction through Rosetta and verify the operation is recognized
+    let coin_cache = CoinMetadataCache::new(client.clone(), NonZeroUsize::new(2).unwrap());
+    let ops = fetch_transaction_and_get_operations(
+        &test_cluster,
+        response.digest().parse().unwrap(),
+        &coin_cache,
+    )
+    .await
+    .unwrap();
+
+    // Construct the expected operation and verify it is found in the parsed transaction
+    let expected_ops: Operations = serde_json::from_value(json!([{
+        "operation_identifier": {"index": 0},
+        "type": "ConvertToFungibleStakedSui",
+        "account": { "address": sender.to_string() },
+        "metadata": { "ConvertToFungibleStakedSui": {
+            "staked_sui_id": staked_ref.0.to_string(),
+        }}
+    }]))
+    .unwrap();
+    assert!(
+        ops.contains(&expected_ops),
+        "Operation mismatch. expecting:{}, got:{}",
+        serde_json::to_string(&expected_ops).unwrap(),
+        serde_json::to_string(&ops).unwrap()
+    );
+
+    // Also verify the operation type appears in serialized form
+    let ops_json = serde_json::to_string(&ops).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&ops_json).unwrap();
+    let ops_array = parsed.as_array().unwrap();
+    let convert_op = ops_array
+        .iter()
+        .find(|op| op["type"] == "ConvertToFungibleStakedSui")
+        .expect("Expected ConvertToFungibleStakedSui operation in parsed transaction");
+    assert_eq!(convert_op["account"]["address"], sender.to_string());
+    assert!(
+        convert_op.get("amount").is_none() || convert_op["amount"].is_null()
+    );
+    assert_eq!(
+        convert_op["metadata"]["ConvertToFungibleStakedSui"]["staked_sui_id"],
+        staked_ref.0.to_string()
+    );
 }


### PR DESCRIPTION
## Summary
- Add `ConvertToFungibleStakedSui` operation type to sui-rosetta, enabling conversion of a `StakedSui` object to a `FungibleStakedSui` via `0x3::sui_system::convert_to_fungible_staked_sui`
- **Write path**: Constructs a PTB calling `convert_to_fungible_staked_sui` with system state and staked SUI object ref, followed by `TransferObjects` to return the result to the sender
- **Read path**: Recognizes the `convert_to_fungible_staked_sui` MoveCall pattern in PTB parsing (breaks the command loop since TransferObjects follows), produces a typed `ConvertToFungibleStakedSui` operation with `staked_sui_id` metadata

## Changes
- `src/types.rs`: Add `ConvertToFungibleStakedSui` to `OperationType` enum
- `src/types/internal_operation/convert_to_fungible_staked_sui.rs`: New module with struct, `TryConstructTransaction` impl, PTB builder
- `src/types/internal_operation.rs`: Wire up `InternalOperation` enum, `sender()`, `try_into_data()`
- `src/operations.rs`: Write direction (`into_internal` dispatch), read direction (PTB parser + recognizer), `OperationMetadata` variant, `Operation` constructor
- `tests/end_to_end_tests.rs`: E2E and integration tests

## Test plan
- [x] **Unit tests** (6 tests in `operations.rs`):
  - Round-trip PTB build -> parse -> verify exact OperationType, metadata fields, and TransactionData equality
  - Read path field validation (status, account, amount=None, coin_change=None, metadata fields)
  - Error: missing metadata
  - Error: wrong metadata type (Stake metadata on ConvertToFungibleStakedSui op)
  - Error: missing account/sender
  - Error: duplicate convert operations
- [x] **E2E test** (`test_convert_to_fungible_staked_sui`): Stake SUI -> advance epoch -> convert via Rosetta Construction API -> read back and assert ops2.contains(&ops)
- [x] **Integration test** (`test_convert_to_fungible_staked_sui_read_path`): Same setup -> convert via direct PTB (not Rosetta) -> verify try_from_executed_transaction() produces correct ConvertToFungibleStakedSui operation with exact field assertions

Generated with [Claude Code](https://claude.com/claude-code)

Note: This is PR 3 of 4 for fungible staked SUI support. See also: MergeFungibleStakedSui (#25809). Remaining: SplitFungibleStakedSui, RedeemFungibleStakedSui.