### PR TITLE
sui-indexer-alt-framework: remove out of date comments

### DIFF
--- a/crates/sui-indexer-alt-framework/src/lib.rs
+++ b/crates/sui-indexer-alt-framework/src/lib.rs
@@ -1731,7 +1731,6 @@ mod tests {
     #[tokio::test]
     async fn test_init_watermark_concurrent_no_first_checkpoint() {
         let (committer_watermark, pruner_watermark) = test_init_watermark(None, true).await;
-        // Indexer will not init the watermark, pipeline tasks will write commit watermarks as normal.
         assert_eq!(committer_watermark, None);
         assert_eq!(pruner_watermark, None);
     }
@@ -1739,7 +1738,6 @@ mod tests {
     #[tokio::test]
     async fn test_init_watermark_concurrent_first_checkpoint_0() {
         let (committer_watermark, pruner_watermark) = test_init_watermark(Some(0), true).await;
-        // Indexer will not init the watermark, pipeline tasks will write commit watermarks as normal.
         assert_eq!(committer_watermark, None);
         assert_eq!(pruner_watermark, None);
     }


### PR DESCRIPTION
## Description 

These comments no longer apply as of #25774 because the watermark is always created.

## Test plan 

No functional changes.
---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
