### PR TITLE
sui-indexer-alt-framework: rename fetch to checkpoint

### DIFF
--- a/crates/sui-indexer-alt-framework/src/ingestion/broadcaster.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/broadcaster.rs
@@ -439,30 +439,31 @@ mod tests {
     use std::fmt::Debug;
     use std::sync::Arc;
     use std::time::Duration;
+
+    use async_trait::async_trait;
     use tokio::time::error::Elapsed;
     use tokio::time::timeout;
 
-    use super::*;
     use crate::ingestion::IngestionConfig;
-    use crate::ingestion::ingestion_client::FetchData;
+    use crate::ingestion::ingestion_client::CheckpointData;
+    use crate::ingestion::ingestion_client::CheckpointResult;
+    use crate::ingestion::ingestion_client::IngestionClientTrait;
     use crate::ingestion::streaming_client::test_utils::MockStreamingClient;
     use crate::ingestion::test_utils::test_checkpoint_data;
     use crate::metrics::tests::test_ingestion_metrics;
 
+    use super::*;
+
     /// Create a mock IngestionClient for tests
     fn mock_client(metrics: Arc<IngestionMetrics>) -> IngestionClient {
-        use crate::ingestion::ingestion_client::FetchError;
-        use crate::ingestion::ingestion_client::IngestionClientTrait;
-        use async_trait::async_trait;
-
         struct MockClient;
 
         #[async_trait]
         impl IngestionClientTrait for MockClient {
-            async fn fetch(&self, checkpoint: u64) -> Result<FetchData, FetchError> {
+            async fn checkpoint(&self, checkpoint: u64) -> CheckpointResult {
                 // Return mock checkpoint data for any checkpoint number
                 let bytes = test_checkpoint_data(checkpoint);
-                Ok(FetchData::Raw(bytes.into()))
+                Ok(CheckpointData::Raw(bytes.into()))
             }
         }
 

--- a/crates/sui-indexer-alt-framework/src/ingestion/ingestion_client.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/ingestion_client.rs
@@ -47,7 +47,7 @@ const SLOW_OPERATION_WARNING_THRESHOLD: Duration = Duration::from_secs(60);
 
 #[async_trait]
 pub(crate) trait IngestionClientTrait: Send + Sync {
-    async fn fetch(&self, checkpoint: u64) -> FetchResult;
+    async fn checkpoint(&self, checkpoint: u64) -> CheckpointResult;
 }
 
 #[derive(clap::Args, Clone, Debug)]
@@ -136,7 +136,7 @@ impl IngestionClientArgs {
 }
 
 #[derive(thiserror::Error, Debug)]
-pub enum FetchError {
+pub enum CheckpointError {
     #[error("Checkpoint not found")]
     NotFound,
     #[error("Failed to fetch checkpoint due to {reason}: {error}")]
@@ -153,11 +153,11 @@ pub enum FetchError {
     },
 }
 
-pub type FetchResult = Result<FetchData, FetchError>;
+pub type CheckpointResult = Result<CheckpointData, CheckpointError>;
 
 #[derive(Clone)]
 #[allow(clippy::large_enum_variant)]
-pub enum FetchData {
+pub enum CheckpointData {
     Raw(Bytes),
     Checkpoint(Checkpoint),
 }
@@ -286,7 +286,7 @@ impl IngestionClient {
         let backoff = Constant::new(retry_interval);
         let fetch = || async move {
             use backoff::Error as BE;
-            self.fetch(checkpoint).await.map_err(|e| match e {
+            self.checkpoint(checkpoint).await.map_err(|e| match e {
                 IngestionError::NotFound(checkpoint) => {
                     debug!(checkpoint, "Checkpoint not found, retrying...");
                     self.metrics.total_ingested_not_found_retries.inc();
@@ -303,17 +303,17 @@ impl IngestionClient {
     ///
     /// Repeatedly retries transient errors with an exponential backoff (up to
     /// `MAX_TRANSIENT_RETRY_INTERVAL`). Transient errors are either defined by the client
-    /// implementation that returns a [FetchError::Transient] error variant, or within this
-    /// function if we fail to deserialize the result as [Checkpoint].
+    /// implementation that returns a [CheckpointError::Transient] error variant, or within
+    /// this function if we fail to deserialize the result as [Checkpoint].
     ///
     /// The function will immediately return if the checkpoint is not found.
-    pub async fn fetch(&self, checkpoint: u64) -> IngestionResult<Arc<Checkpoint>> {
+    pub async fn checkpoint(&self, checkpoint: u64) -> IngestionResult<Arc<Checkpoint>> {
         let client = self.client.clone();
         let request = move || {
             let client = client.clone();
             async move {
                 let fetch_data = with_slow_future_monitor(
-                    client.fetch(checkpoint),
+                    client.checkpoint(checkpoint),
                     SLOW_OPERATION_WARNING_THRESHOLD,
                     /* on_threshold_exceeded =*/
                     || {
@@ -326,13 +326,15 @@ impl IngestionClient {
                 )
                 .await
                 .map_err(|err| match err {
-                    FetchError::NotFound => BE::permanent(IngestionError::NotFound(checkpoint)),
-                    FetchError::Transient { reason, error } => self.metrics.inc_retry(
+                    CheckpointError::NotFound => {
+                        BE::permanent(IngestionError::NotFound(checkpoint))
+                    }
+                    CheckpointError::Transient { reason, error } => self.metrics.inc_retry(
                         checkpoint,
                         reason,
                         IngestionError::FetchError(checkpoint, error),
                     ),
-                    FetchError::Permanent { reason, error } => {
+                    CheckpointError::Permanent { reason, error } => {
                         error!(checkpoint, reason, "Permanent fetch error: {error}");
                         self.metrics
                             .total_ingested_permanent_errors
@@ -343,7 +345,7 @@ impl IngestionClient {
                 })?;
 
                 Ok::<Checkpoint, backoff::Error<IngestionError>>(match fetch_data {
-                    FetchData::Raw(bytes) => {
+                    CheckpointData::Raw(bytes) => {
                         self.metrics.total_ingested_bytes.inc_by(bytes.len() as u64);
 
                         decode::checkpoint(&bytes).map_err(|e| {
@@ -354,7 +356,7 @@ impl IngestionClient {
                             )
                         })?
                     }
-                    FetchData::Checkpoint(data) => {
+                    CheckpointData::Checkpoint(data) => {
                         // We are not recording size metric for Checkpoint data (from RPC client).
                         // TODO: Record the metric when we have a good way to get the size information
                         data
@@ -427,7 +429,7 @@ mod tests {
     /// Mock implementation of IngestionClientTrait for testing
     #[derive(Default)]
     struct MockIngestionClient {
-        checkpoints: DashMap<u64, FetchData>,
+        checkpoints: DashMap<u64, CheckpointData>,
         transient_failures: DashMap<u64, usize>,
         not_found_failures: DashMap<u64, usize>,
         permanent_failures: DashMap<u64, usize>,
@@ -435,13 +437,13 @@ mod tests {
 
     #[async_trait]
     impl IngestionClientTrait for MockIngestionClient {
-        async fn fetch(&self, checkpoint: u64) -> FetchResult {
+        async fn checkpoint(&self, checkpoint: u64) -> CheckpointResult {
             // Check for not found failures
             if let Some(mut remaining) = self.not_found_failures.get_mut(&checkpoint)
                 && *remaining > 0
             {
                 *remaining -= 1;
-                return Err(FetchError::NotFound);
+                return Err(CheckpointError::NotFound);
             }
 
             // Check for non-retryable failures
@@ -449,7 +451,7 @@ mod tests {
                 && *remaining > 0
             {
                 *remaining -= 1;
-                return Err(FetchError::Permanent {
+                return Err(CheckpointError::Permanent {
                     reason: "mock_permanent_error",
                     error: anyhow::anyhow!("Mock permanent error"),
                 });
@@ -460,7 +462,7 @@ mod tests {
                 && *remaining > 0
             {
                 *remaining -= 1;
-                return Err(FetchError::Transient {
+                return Err(CheckpointError::Transient {
                     reason: "mock_transient_error",
                     error: anyhow::anyhow!("Mock transient error"),
                 });
@@ -471,7 +473,7 @@ mod tests {
                 .get(&checkpoint)
                 .as_deref()
                 .cloned()
-                .ok_or(FetchError::NotFound)
+                .ok_or(CheckpointError::NotFound)
         }
     }
 
@@ -538,10 +540,11 @@ mod tests {
 
         // Create test data using test_checkpoint
         let bytes = Bytes::from(test_checkpoint_data(1));
-        mock.checkpoints.insert(1, FetchData::Raw(bytes.clone()));
+        mock.checkpoints
+            .insert(1, CheckpointData::Raw(bytes.clone()));
 
         // Fetch and verify
-        let result = client.fetch(1).await.unwrap();
+        let result = client.checkpoint(1).await.unwrap();
         assert_eq!(result.summary.sequence_number(), &1);
     }
 
@@ -551,10 +554,10 @@ mod tests {
 
         // Create test data - now returns zstd-compressed protobuf
         let bytes = Bytes::from(test_checkpoint_data(1));
-        mock.checkpoints.insert(1, FetchData::Raw(bytes));
+        mock.checkpoints.insert(1, CheckpointData::Raw(bytes));
 
         // Fetch and verify
-        let result = client.fetch(1).await.unwrap();
+        let result = client.checkpoint(1).await.unwrap();
         assert_eq!(result.summary.sequence_number(), &1);
     }
 
@@ -563,7 +566,7 @@ mod tests {
         let (client, _) = setup_test();
 
         // Try to fetch non-existent checkpoint
-        let result = client.fetch(1).await;
+        let result = client.checkpoint(1).await;
         assert!(matches!(result, Err(IngestionError::NotFound(1))));
     }
 
@@ -575,11 +578,11 @@ mod tests {
         let bytes = Bytes::from(test_checkpoint_data(1));
 
         // Add checkpoint to mock with 2 transient failures
-        mock.checkpoints.insert(1, FetchData::Raw(bytes));
+        mock.checkpoints.insert(1, CheckpointData::Raw(bytes));
         mock.transient_failures.insert(1, 2);
 
         // Fetch and verify it succeeds after retries
-        let result = client.fetch(1).await.unwrap();
+        let result = client.checkpoint(1).await.unwrap();
         assert_eq!(*result.summary.sequence_number(), 1);
 
         // Verify that exactly 2 retries were recorded
@@ -599,7 +602,7 @@ mod tests {
         let bytes = Bytes::from(test_checkpoint_data(1));
 
         // Add checkpoint to mock with 1 not_found failures
-        mock.checkpoints.insert(1, FetchData::Raw(bytes));
+        mock.checkpoints.insert(1, CheckpointData::Raw(bytes));
         mock.not_found_failures.insert(1, 1);
 
         // Wait for checkpoint with short retry interval
@@ -619,7 +622,7 @@ mod tests {
         let bytes = Bytes::from(test_checkpoint_data(1));
 
         // Add checkpoint to mock with no failures - data should be available immediately
-        mock.checkpoints.insert(1, FetchData::Raw(bytes));
+        mock.checkpoints.insert(1, CheckpointData::Raw(bytes));
 
         // Wait for checkpoint with short retry interval
         let result = client.wait_for(1, Duration::from_millis(50)).await.unwrap();
@@ -632,7 +635,7 @@ mod tests {
 
         // Add invalid data that will cause a deserialization error
         mock.checkpoints
-            .insert(1, FetchData::Raw(Bytes::from("invalid data")));
+            .insert(1, CheckpointData::Raw(Bytes::from("invalid data")));
 
         // wait_for should keep retrying on deserialization errors and timeout
         timeout(
@@ -649,7 +652,7 @@ mod tests {
 
         mock.permanent_failures.insert(1, 1);
 
-        let result = client.fetch(1).await;
+        let result = client.checkpoint(1).await;
         assert!(matches!(result, Err(IngestionError::FetchError(1, _))));
 
         // Verify that the non-retryable error metric was incremented

--- a/crates/sui-indexer-alt-framework/src/ingestion/rpc_client.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/rpc_client.rs
@@ -10,14 +10,14 @@ use sui_rpc::proto::sui::rpc::v2::GetCheckpointRequest;
 use sui_types::full_checkpoint_content::Checkpoint;
 use tonic::Code;
 
-use crate::ingestion::ingestion_client::FetchData;
-use crate::ingestion::ingestion_client::FetchError;
-use crate::ingestion::ingestion_client::FetchResult;
+use crate::ingestion::ingestion_client::CheckpointData;
+use crate::ingestion::ingestion_client::CheckpointError;
+use crate::ingestion::ingestion_client::CheckpointResult;
 use crate::ingestion::ingestion_client::IngestionClientTrait;
 
 #[async_trait]
 impl IngestionClientTrait for RpcClient {
-    async fn fetch(&self, checkpoint: u64) -> FetchResult {
+    async fn checkpoint(&self, checkpoint: u64) -> CheckpointResult {
         let request: GetCheckpointRequest = GetCheckpointRequest::by_sequence_number(checkpoint)
             .with_read_mask(FieldMask::from_paths([
                 "summary.bcs",
@@ -36,20 +36,21 @@ impl IngestionClientTrait for RpcClient {
             .get_checkpoint(request)
             .await
             .map_err(|status| match status.code() {
-                Code::NotFound => FetchError::NotFound,
-                _ => FetchError::Transient {
+                Code::NotFound => CheckpointError::NotFound,
+                _ => CheckpointError::Transient {
                     reason: "get_checkpoint",
                     error: anyhow!(status),
                 },
             })?
             .into_inner();
 
-        let checkpoint =
-            Checkpoint::try_from(response.checkpoint()).map_err(|e| FetchError::Permanent {
+        let checkpoint = Checkpoint::try_from(response.checkpoint()).map_err(|e| {
+            CheckpointError::Permanent {
                 reason: "proto_conversion",
                 error: e.into(),
-            })?;
+            }
+        })?;
 
-        Ok(FetchData::Checkpoint(checkpoint))
+        Ok(CheckpointData::Checkpoint(checkpoint))
     }
 }

--- a/crates/sui-indexer-alt-framework/src/ingestion/store_client.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/store_client.rs
@@ -14,9 +14,9 @@ use tracing::debug;
 use tracing::error;
 
 use crate::ingestion::decode;
-use crate::ingestion::ingestion_client::FetchData;
-use crate::ingestion::ingestion_client::FetchError;
-use crate::ingestion::ingestion_client::FetchResult;
+use crate::ingestion::ingestion_client::CheckpointData;
+use crate::ingestion::ingestion_client::CheckpointError;
+use crate::ingestion::ingestion_client::CheckpointResult;
 use crate::ingestion::ingestion_client::IngestionClientTrait;
 use crate::types::full_checkpoint_content::Checkpoint;
 
@@ -73,16 +73,16 @@ impl IngestionClientTrait for StoreIngestionClient {
     /// - rate limiting,
     /// - server errors (5xx),
     /// - issues getting a full response.
-    async fn fetch(&self, checkpoint: u64) -> FetchResult {
+    async fn checkpoint(&self, checkpoint: u64) -> CheckpointResult {
         match self.checkpoint_bytes(checkpoint).await {
-            Ok(bytes) => Ok(FetchData::Raw(bytes)),
+            Ok(bytes) => Ok(CheckpointData::Raw(bytes)),
             Err(ObjectStoreError::NotFound { .. }) => {
                 debug!(checkpoint, "Checkpoint not found");
-                Err(FetchError::NotFound)
+                Err(CheckpointError::NotFound)
             }
             Err(error) => {
                 error!(checkpoint, "Failed to fetch checkpoint: {error}");
-                Err(FetchError::Transient {
+                Err(CheckpointError::Transient {
                     reason: "object_store",
                     error: error.into(),
                 })
@@ -143,7 +143,7 @@ pub(crate) mod tests {
         respond_with(&server, status(StatusCode::NOT_FOUND)).await;
 
         let client = remote_test_client(server.uri());
-        let error = client.fetch(42).await.unwrap_err();
+        let error = client.checkpoint(42).await.unwrap_err();
 
         assert!(matches!(error, Error::NotFound(42)));
     }
@@ -177,7 +177,7 @@ pub(crate) mod tests {
         .await;
 
         let client = remote_test_client(server.uri());
-        let checkpoint = client.fetch(42).await.unwrap();
+        let checkpoint = client.checkpoint(42).await.unwrap();
 
         assert_eq!(42, checkpoint.summary.sequence_number)
     }
@@ -202,7 +202,7 @@ pub(crate) mod tests {
         .await;
 
         let client = remote_test_client(server.uri());
-        let checkpoint = client.fetch(42).await.unwrap();
+        let checkpoint = client.checkpoint(42).await.unwrap();
 
         assert_eq!(42, checkpoint.summary.sequence_number)
     }
@@ -225,7 +225,7 @@ pub(crate) mod tests {
         .await;
 
         let client = remote_test_client(server.uri());
-        let checkpoint = client.fetch(42).await.unwrap();
+        let checkpoint = client.checkpoint(42).await.unwrap();
 
         assert_eq!(42, checkpoint.summary.sequence_number)
     }
@@ -267,7 +267,7 @@ pub(crate) mod tests {
             IngestionClient::with_store(store, test_ingestion_metrics()).unwrap();
 
         // This should timeout once, then succeed on retry
-        let checkpoint = ingestion_client.fetch(42).await.unwrap();
+        let checkpoint = ingestion_client.checkpoint(42).await.unwrap();
         assert_eq!(42, checkpoint.summary.sequence_number);
 
         // Verify that the server received exactly 2 requests (1 timeout + 1 successful retry)


### PR DESCRIPTION
## Description 

This PR renames `fetch` to `checkpoint` in anticipation of future PRs that will add additional methods like `chain_id` and `latest_checkpoint_number`.

## Test plan 

No functional changes.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [x] Indexing Framework: Renamed `IngestionClientTrait::fetch` to `IngestionClientTrait::checkpoint`.
