### PR TITLE
consistency: remove legacy `x-sui-checkpoint` header

### DIFF
--- a/crates/sui-indexer-alt-consistent-api/src/proto/rpc/consistent/v1alpha/mod.rs
+++ b/crates/sui-indexer-alt-consistent-api/src/proto/rpc/consistent/v1alpha/mod.rs
@@ -19,12 +19,6 @@ pub const CHECKPOINT_HEIGHT_METADATA: &str = "x-sui-checkpoint-height";
 /// Mirrors fullnode gRPC header naming in `sui-rpc`.
 pub const LOWEST_AVAILABLE_CHECKPOINT_METADATA: &str = "x-sui-lowest-available-checkpoint";
 
-/// Legacy metadata name for input checkpoints.
-///
-/// TODO(2026-03-09): Remove support for this legacy input header one release after introducing
-/// `x-sui-checkpoint-height`.
-pub const LEGACY_CHECKPOINT_METADATA: &str = "x-sui-checkpoint";
-
 #[cfg(test)]
 mod tests {
     use super::FILE_DESCRIPTOR_SET;

--- a/crates/sui-indexer-alt-consistent-store/src/rpc/state.rs
+++ b/crates/sui-indexer-alt-consistent-store/src/rpc/state.rs
@@ -4,7 +4,6 @@
 use std::sync::Arc;
 
 use sui_indexer_alt_consistent_api::proto::rpc::consistent::v1alpha::CHECKPOINT_HEIGHT_METADATA;
-use sui_indexer_alt_consistent_api::proto::rpc::consistent::v1alpha::LEGACY_CHECKPOINT_METADATA;
 use sui_indexer_alt_consistent_api::proto::rpc::consistent::v1alpha::LOWEST_AVAILABLE_CHECKPOINT_METADATA;
 use tonic::metadata::AsciiMetadataValue;
 
@@ -57,10 +56,7 @@ impl State {
             .ok_or(Error::NoSnapshots)?;
 
         let metadata = request.metadata();
-        let Some(checkpoint) = metadata
-            .get(CHECKPOINT_HEIGHT_METADATA)
-            .or_else(|| metadata.get(LEGACY_CHECKPOINT_METADATA))
-        else {
+        let Some(checkpoint) = metadata.get(CHECKPOINT_HEIGHT_METADATA) else {
             // If a checkpoint hasn't been supplied default to the latest snapshot.
             return Ok(snapshot_range.end().checkpoint_hi_inclusive);
         };
@@ -100,9 +96,7 @@ impl State {
         }
 
         if let Ok(max) = range.end().checkpoint_hi_inclusive.to_string().parse() {
-            let max: AsciiMetadataValue = max;
-            meta.insert(CHECKPOINT_HEIGHT_METADATA, max.clone());
-            meta.insert(LEGACY_CHECKPOINT_METADATA, max);
+            meta.insert(CHECKPOINT_HEIGHT_METADATA, max);
         }
 
         resp

--- a/crates/sui-indexer-alt-e2e-tests/tests/consistent_store_address_balance_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/consistent_store_address_balance_tests.rs
@@ -749,7 +749,7 @@ async fn test_edge_cases() {
 
     request
         .metadata_mut()
-        .insert("x-sui-checkpoint", "10".parse().unwrap());
+        .insert(CHECKPOINT_HEIGHT_METADATA, "10".parse().unwrap());
 
     let err = client.batch_get_balances(request).await.unwrap_err();
     assert_eq!(err.code(), tonic::Code::OutOfRange);

--- a/crates/sui-indexer-alt-e2e-tests/tests/consistent_store_balance_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/consistent_store_balance_tests.rs
@@ -676,7 +676,7 @@ async fn test_edge_cases() {
 
     request
         .metadata_mut()
-        .insert("x-sui-checkpoint", "10".parse().unwrap());
+        .insert(CHECKPOINT_HEIGHT_METADATA, "10".parse().unwrap());
 
     let err = client.batch_get_balances(request).await.unwrap_err();
     assert_eq!(err.code(), tonic::Code::OutOfRange);


### PR DESCRIPTION
## Description

This header was retained for a single release so that an old instance of GraphQL does not get ignored by a new instance of the consistent store. The release has since been cut, so the header can be removed.

## Test plan

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
