### PR TITLE
[move-unit-test] Update default gas used for sui-move unit tests

### DIFF
--- a/crates/sui-move/src/unit_test.rs
+++ b/crates/sui-move/src/unit_test.rs
@@ -73,7 +73,13 @@ impl Test {
 
         // find manifest file directory from a given path or (if missing) from current dir
         let rerooted_path = base::reroot_path(path)?;
-        let unit_test_config = self.test.unit_test_config();
+
+        // If no gas limit is set, set it to the default max. This allows
+        // users to provide custom configs but not have to worry about setting a gas limit unless that
+        // is what they care about.
+        let unit_test_config = self
+            .test
+            .unit_test_config(Some(*MAX_UNIT_TEST_INSTRUCTIONS));
 
         // set the environment (this is a little janky: we get it from the manifest here, then pass
         // it as the optional argument in the build-config, which then looks it up again, but it

--- a/external-crates/move/crates/move-cli/src/base/test.rs
+++ b/external-crates/move/crates/move-cli/src/base/test.rs
@@ -95,7 +95,7 @@ impl Test {
         let result = run_move_unit_tests::<F, V, Stdout>(
             &rerooted_path,
             config,
-            self.unit_test_config(),
+            self.unit_test_config(None),
             vm_test_setup,
             compute_coverage,
             save_disassembly,
@@ -110,7 +110,7 @@ impl Test {
         Ok(())
     }
 
-    pub fn unit_test_config(self) -> UnitTestingConfig {
+    pub fn unit_test_config(self, default_execution_bound: Option<u64>) -> UnitTestingConfig {
         let Self {
             gas_limit,
             filter,
@@ -124,7 +124,7 @@ impl Test {
             trace,
         } = self;
         UnitTestingConfig {
-            gas_limit,
+            gas_limit: gas_limit.or(default_execution_bound),
             filter,
             list,
             num_threads,
@@ -133,7 +133,7 @@ impl Test {
             seed,
             rand_num_iters,
             trace,
-            ..UnitTestingConfig::default_with_bound(None)
+            ..UnitTestingConfig::default_with_bound(default_execution_bound)
         }
     }
 }


### PR DESCRIPTION
## Description 

With some of the recent refactors around the Move unit test runner, we were getting into a situation where the default gas being set was too low for sui-side gas usage (e.g., due to RGP factoring into it). This updates the creation of the unit testing config to take the sui default max gas that unit tests should run with.

## Test plan 

Ran local tests of various Move packages.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
