### PR TITLE
Fix sui client object to display decoded fields instead of raw BCS bytes

### DIFF
--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -2767,7 +2767,7 @@ pub struct ObjectOutput {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub storage_rebate: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub content: Option<SuiParsedData>,
+    pub content: Option<Value>,
 }
 
 impl From<&SuiObjectData> for ObjectOutput {
@@ -2776,6 +2776,10 @@ impl From<&SuiObjectData> for ObjectOutput {
             Some(x) => x.to_string(),
             None => "unknown".to_string(),
         };
+        let content = obj.content.as_ref().map(|c| match c {
+            SuiParsedData::MoveObject(o) => o.fields.clone().to_json_value(),
+            SuiParsedData::Package(p) => json!(p),
+        });
         Self {
             object_id: obj.object_id,
             version: obj.version,
@@ -2784,7 +2788,7 @@ impl From<&SuiObjectData> for ObjectOutput {
             owner: obj.owner.clone(),
             prev_tx: obj.previous_transaction,
             storage_rebate: obj.storage_rebate,
-            content: obj.content.clone(),
+            content,
         }
     }
 }


### PR DESCRIPTION
## Description 

`sui client object` displays raw BCS-encoded byte arrays for object contents instead of decoded fields. This makes the Hello World tutorial confusing — users expect to see `text: "Hello world!"` but get a wall of numbers.

This PR changes `ObjectOutput` to extract decoded Move fields via `to_json_value()` (the same path used by `sui_getObject` with `showContent: true`) instead of passing through the raw `SuiParsedData`.

## Test plan 

Built the CLI locally and verified` sui client object <ID>` against testnet objects — fields now display as decoded key-value pairs instead of raw bytes.

---

## Release notes

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ✓] CLI: `sui client object` now displays decoded Move struct fields (e.g. `text: "Hello world!"`)
- [ ] Rust SDK:
- [ ] Indexing Framework:
