### PR TITLE
fix(cli): display decoded fields in sui client object instead of raw BCS bytes

### DIFF
--- a/crates/sui-rpc-api/src/client/mod.rs
+++ b/crates/sui-rpc-api/src/client/mod.rs
@@ -135,21 +135,51 @@ impl Client {
         object_id: ObjectID,
         version: Option<u64>,
     ) -> Result<Object> {
+        let (object, _) = self
+            .get_object_with_content(object_id, version, false)
+            .await?;
+        Ok(object)
+    }
+
+    pub async fn get_object_with_json(
+        &mut self,
+        object_id: ObjectID,
+    ) -> Result<(Object, Option<serde_json::Value>)> {
+        self.get_object_with_content(object_id, None, true).await
+    }
+
+    async fn get_object_with_content(
+        &mut self,
+        object_id: ObjectID,
+        version: Option<u64>,
+        include_json: bool,
+    ) -> Result<(Object, Option<serde_json::Value>)> {
+        let paths: Vec<&str> = if include_json {
+            vec!["bcs", "json"]
+        } else {
+            vec!["bcs"]
+        };
         let mut request = proto::GetObjectRequest::new(&object_id.into())
-            .with_read_mask(FieldMask::from_paths(["bcs"]));
+            .with_read_mask(FieldMask::from_paths(paths));
         request.version = version;
 
-        let (metadata, object, _extentions) = self
+        let (metadata, response, _extentions) = self
             .0
             .ledger_client()
             .get_object(request)
             .await?
             .into_parts();
 
-        let object = object
+        let proto_object = response
             .object
             .ok_or_else(|| tonic::Status::not_found("no object returned"))?;
-        object_try_from_proto(&object).map_err(|e| status_from_error_with_metadata(e, metadata))
+        let json_content = proto_object
+            .json
+            .as_ref()
+            .map(|v| proto_value_to_json_value(v));
+        let object = object_try_from_proto(&proto_object)
+            .map_err(|e| status_from_error_with_metadata(e, metadata))?;
+        Ok((object, json_content))
     }
 
     pub async fn batch_get_objects(&self, ids: &[ObjectID]) -> Result<Vec<Object>> {

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -1060,10 +1060,12 @@ impl SuiClientCommands {
             SuiClientCommands::Object { id, bcs } => {
                 // Fetch the object ref
                 let _ = context.cache_chain_id().await?;
-                let object = context.grpc_client()?.get_object(id).await?;
                 if !bcs {
-                    SuiClientCommandResult::Object(object)
+                    let (object, json_content) =
+                        context.grpc_client()?.get_object_with_json(id).await?;
+                    SuiClientCommandResult::Object(object, json_content)
                 } else {
+                    let object = context.grpc_client()?.get_object(id).await?;
                     SuiClientCommandResult::RawObject(object)
                 }
             }
@@ -2149,8 +2151,8 @@ impl Display for SuiClientCommandResult {
 
                 write!(f, "{}", table)?
             }
-            SuiClientCommandResult::Object(object) => {
-                let object = ObjectOutput::from(object);
+            SuiClientCommandResult::Object(object, json_content) => {
+                let object = ObjectOutput::from_object_with_json(object, json_content.clone());
                 let json_obj = json!(&object);
                 let mut table = json_to_table(&json_obj);
                 table.with(TableStyle::rounded().horizontals([]));
@@ -2576,7 +2578,10 @@ impl Debug for SuiClientCommandResult {
                     .collect::<Vec<_>>();
                 Ok(serde_json::to_string_pretty(&gas_coins)?)
             }
-            SuiClientCommandResult::Object(object) => Ok(serde_json::to_string_pretty(&object)?),
+            SuiClientCommandResult::Object(object, json_content) => {
+                let object = ObjectOutput::from_object_with_json(object, json_content.clone());
+                Ok(serde_json::to_string_pretty(&object)?)
+            }
             SuiClientCommandResult::RawObject(object) => Ok(serde_json::to_string_pretty(&object)?),
             SuiClientCommandResult::TransactionBlock(response) => Ok(serde_json::to_string_pretty(
                 &to_legacy_transaction_block_response(response),
@@ -2605,7 +2610,7 @@ impl SuiClientCommandResult {
     pub fn objects_response(&self) -> Option<Vec<Object>> {
         use SuiClientCommandResult::*;
         match self {
-            Object(o) | RawObject(o) => Some(vec![o.clone()]),
+            Object(o, _) | RawObject(o) => Some(vec![o.clone()]),
             Objects(o) => Some(o.clone()),
             _ => None,
         }
@@ -2666,16 +2671,17 @@ pub struct ObjectOutput {
     pub owner: Owner,
     pub prev_tx: TransactionDigest,
     pub storage_rebate: u64,
-    pub content: sui_types::object::Data,
+    pub content: serde_json::Value,
 }
 
-impl From<&Object> for ObjectOutput {
-    fn from(obj: &Object) -> Self {
+impl ObjectOutput {
+    pub fn from_object_with_json(obj: &Object, json_content: Option<serde_json::Value>) -> Self {
         let obj_type = if let Some(struct_tag) = obj.struct_tag() {
             struct_tag.to_canonical_string(true)
         } else {
             "package".to_string()
         };
+        let content = json_content.unwrap_or_else(|| json!(obj.data));
 
         Self {
             object_id: obj.id(),
@@ -2685,7 +2691,7 @@ impl From<&Object> for ObjectOutput {
             owner: obj.owner().clone(),
             prev_tx: obj.previous_transaction,
             storage_rebate: obj.storage_rebate,
-            content: obj.data.clone(),
+            content,
         }
     }
 }
@@ -2754,7 +2760,7 @@ pub enum SuiClientCommandResult {
     NewAddress(NewAddressOutput),
     NewEnv(SuiEnv),
     NoOutput,
-    Object(Object),
+    Object(Object, Option<serde_json::Value>),
     Objects(Vec<Object>),
     RawObject(Object),
     RemoveAddress(RemoveAddressOutput),

--- a/crates/sui/tests/cli_tests.rs
+++ b/crates/sui/tests/cli_tests.rs
@@ -2259,7 +2259,7 @@ async fn test_native_transfer() -> Result<(), anyhow::Error> {
     }
     .execute(context)
     .await?;
-    let mut_obj1 = if let SuiClientCommandResult::Object(object) = dbg!(resp) {
+    let mut_obj1 = if let SuiClientCommandResult::Object(object, _) = dbg!(resp) {
         object
     } else {
         panic!();
@@ -2271,7 +2271,7 @@ async fn test_native_transfer() -> Result<(), anyhow::Error> {
     }
     .execute(context)
     .await?;
-    let mut_obj2 = if let SuiClientCommandResult::Object(object) = resp2 {
+    let mut_obj2 = if let SuiClientCommandResult::Object(object, _) = resp2 {
         object
     } else {
         panic!();


### PR DESCRIPTION
## Description 

`sui client object <ID> `displays raw BCS-encoded byte arrays instead of decoded fields. This was reported by a hackathon participant following the Hello World tutorial — they expected `text: "Hello world!"` but got a wall of numbers.

The fix requests `["bcs", "json"]` from the node instead of just `["bcs"]`, so the fullnode returns already-decoded content for display. The `--bcs `flag is unchanged and still shows raw data.

## Test plan 

Built the CLI locally and tested against testnet objects:

`sui client object 0x86ef1280c6b34a15b06723ff668a3f25ee204d1b9a48b8a455cccf47ad981e7e` — MemeNFT with multiple field types (strings, addresses, u64) displays correctly
`sui client object 0x2834aa3d2ed1b5060f4e5d400092544fa9c95430fd894b139b7dfb0312501594` — Hello World Greeting object shows text: "Hello world!"
`sui client object <ID> --bcs` still returns raw BCS as before

---

## Release notes


- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [x] CLI: `sui client object` now displays decoded Move struct fields instead of raw BCS-encoded byte arrays.
- [ ] Rust SDK:
- [ ] Indexing Framework:
