### PR TITLE
docs: Update DeepBook docs to match latest SDK and indexer APIs

### DIFF
--- a/docs/content/standards/deepbook-margin-sdk/margin-manager.mdx
+++ b/docs/content/standards/deepbook-margin-sdk/margin-manager.mdx
@@ -54,6 +54,20 @@ Use `shareMarginManager` to share a margin manager created with `newMarginManage
 
 <ImportContent source="packages/deepbook-v3/src/transactions/marginManager.ts" mode="code" org="MystenLabs" repo="ts-sdks" fun="shareMarginManager" signatureOnly />
 
+### `depositDuringInitialization`
+
+Use `depositDuringInitialization` to deposit funds into a margin manager during its creation, before it is shared. This must be called in the same transaction as `newMarginManagerWithInitializer` and before `shareMarginManager`. The call returns a function that takes a `Transaction` object.
+
+**Parameters**
+
+- `manager`: `TransactionArgument` representing the margin manager returned by `newMarginManagerWithInitializer`.
+- `poolKey`: String that identifies the DeepBook pool.
+- `coinType`: String identifying the coin type to deposit (for example, `'SUI'`, `'DBUSDC'`, `'DEEP'`).
+- `amount`: Number representing the amount to deposit (provide either `amount` or `coin`, not both).
+- `coin`: `TransactionArgument` representing a coin object to deposit (provide either `amount` or `coin`, not both).
+
+<ImportContent source="packages/deepbook-v3/src/transactions/marginManager.ts" mode="code" org="MystenLabs" repo="ts-sdks" fun="depositDuringInitialization" signatureOnly />
+
 ### `depositBase`, `depositQuote`, `depositDeep`
 
 Use these functions to deposit assets into a margin manager. The call returns a function that takes a `Transaction` object.
@@ -137,17 +151,23 @@ Use `unsetMarginManagerReferral` to remove the referral association from a margi
 
 The following functions query margin manager state without modifying it.
 
-### `riskRatio`
+### `managerState`
 
-Query the risk ratio of the margin manager, which represents the ratio of assets to debt. Higher ratios indicate healthier positions.
+Query comprehensive state information for a margin manager, including risk ratio, assets, debts, and Pyth price data.
 
-<ImportContent source="packages/deepbook-v3/src/transactions/marginManager.ts" mode="code" org="MystenLabs" repo="ts-sdks" fun="riskRatio" signatureOnly />
+<ImportContent source="packages/deepbook-v3/src/transactions/marginManager.ts" mode="code" org="MystenLabs" repo="ts-sdks" fun="managerState" signatureOnly />
 
 ### `owner`, `deepbookPool`, `marginPoolId`
 
 Query basic margin manager information.
 
 <ImportContent source="packages/deepbook-v3/src/transactions/marginManager.ts" mode="code" org="MystenLabs" repo="ts-sdks" fun="ownerByPoolKey,deepbookPool,marginPoolId" signatureOnly />
+
+### `baseBalance`, `quoteBalance`, `deepBalance`
+
+Query individual asset balances held in the margin manager.
+
+<ImportContent source="packages/deepbook-v3/src/transactions/marginManager.ts" mode="code" org="MystenLabs" repo="ts-sdks" fun="baseBalance,quoteBalance,deepBalance" signatureOnly />
 
 ### `borrowedShares`, `borrowedBaseShares`, `borrowedQuoteShares`, `hasBaseDebt`
 

--- a/docs/content/standards/deepbook-margin-sdk/margin-pool.mdx
+++ b/docs/content/standards/deepbook-margin-sdk/margin-pool.mdx
@@ -82,7 +82,7 @@ The following functions query margin pool state without modifying it.
 
 Query basic pool information and configuration.
 
-<ImportContent source="packages/deepbook-v3/src/transactions/marginPool.ts" mode="code" org="MystenLabs" repo="ts-sdks" fun="getId,deepbookPoolAllowed,supplyCap,maxUtilizationRate,protocolSpread,protocolFees,minBorrow" signatureOnly />
+<ImportContent source="packages/deepbook-v3/src/transactions/marginPool.ts" mode="code" org="MystenLabs" repo="ts-sdks" fun="getId,deepbookPoolAllowed,supplyCap,maxUtilizationRate,protocolSpread,minBorrow" signatureOnly />
 
 ### Supply and borrow metrics
 

--- a/docs/content/standards/deepbook-margin-sdk/orders.mdx
+++ b/docs/content/standards/deepbook-margin-sdk/orders.mdx
@@ -143,6 +143,27 @@ Use `claimRebate` to claim trading rebates earned through the margin manager. Th
 
 <ImportContent source="packages/deepbook-v3/src/transactions/poolProxy.ts" mode="code" org="MystenLabs" repo="ts-sdks" fun="claimRebate" signatureOnly />
 
+### `withdrawMarginSettledAmounts`
+
+Use `withdrawMarginSettledAmounts` to permissionlessly withdraw settled amounts for any margin manager by its object ID. Unlike `withdrawSettledAmounts` which requires ownership, this can be called by anyone. The call returns a function that takes a `Transaction` object.
+
+**Parameters**
+
+- `poolKey`: String that identifies the DeepBook pool.
+- `marginManagerId`: String representing the object ID of the margin manager.
+
+<ImportContent source="packages/deepbook-v3/src/transactions/poolProxy.ts" mode="code" org="MystenLabs" repo="ts-sdks" fun="withdrawMarginSettledAmounts" signatureOnly />
+
+### `updateCurrentPrice`
+
+Use `updateCurrentPrice` to update the current price for a pool using the Pyth oracle. The call returns a function that takes a `Transaction` object.
+
+**Parameters**
+
+- `poolKey`: String that identifies the DeepBook pool.
+
+<ImportContent source="packages/deepbook-v3/src/transactions/poolProxy.ts" mode="code" org="MystenLabs" repo="ts-sdks" fun="updateCurrentPrice" signatureOnly />
+
 ## Examples
 
 The following examples demonstrate common margin order operations.

--- a/docs/content/standards/deepbook-margin-sdk/tpsl.mdx
+++ b/docs/content/standards/deepbook-margin-sdk/tpsl.mdx
@@ -62,7 +62,8 @@ Use `executeConditionalOrders` to execute conditional orders that have been trig
 
 **Parameters**
 
-- `marginManagerKey`: String that identifies the margin manager.
+- `managerAddress`: String representing the address of the margin manager whose orders to execute.
+- `poolKey`: String that identifies the DeepBook pool.
 - `maxOrdersToExecute`: Number representing the maximum number of orders to execute in this call.
 
 <ImportContent source="packages/deepbook-v3/src/transactions/marginTPSL.ts" mode="code" org="MystenLabs" repo="ts-sdks" fun="executeConditionalOrders" signatureOnly />
@@ -132,21 +133,9 @@ Query a specific conditional order by ID.
 
 <ImportContent source="packages/deepbook-v3/src/transactions/marginTPSL.ts" mode="code" org="MystenLabs" repo="ts-sdks" fun="conditionalOrder" signatureOnly />
 
-### `triggerBelowOrders`, `triggerAboveOrders`
-
-Query the lists of conditional orders sorted by trigger price.
-
-<ImportContent source="packages/deepbook-v3/src/transactions/marginTPSL.ts" mode="code" org="MystenLabs" repo="ts-sdks" fun="triggerBelowOrders,triggerAboveOrders" signatureOnly />
-
-### `numConditionalOrders`
-
-Query the total number of conditional orders for a margin manager.
-
-<ImportContent source="packages/deepbook-v3/src/transactions/marginTPSL.ts" mode="code" org="MystenLabs" repo="ts-sdks" fun="numConditionalOrders" signatureOnly />
-
 ### `lowestTriggerAbovePrice`, `highestTriggerBelowPrice`
 
-Query trigger prices for conditional orders.
+Query trigger prices for conditional orders. `lowestTriggerAbovePrice` returns the lowest trigger price among trigger-above orders (or `max_u64` if none exist). `highestTriggerBelowPrice` returns the highest trigger price among trigger-below orders (or `0` if none exist).
 
 <ImportContent source="packages/deepbook-v3/src/transactions/marginTPSL.ts" mode="code" org="MystenLabs" repo="ts-sdks" fun="lowestTriggerAbovePrice,highestTriggerBelowPrice" signatureOnly />
 
@@ -200,8 +189,8 @@ const setTakeProfit = (tx: Transaction) => {
 ```tsx
 // Example: Execute conditional orders as a keeper
 const executeOrders = (tx: Transaction) => {
-	const managerKey = 'MARGIN_MANAGER_1';
+	const managerAddress = '0x...'; // Address of margin manager
 	// Execute up to 10 triggered orders
-	traderClient.marginTPSL.executeConditionalOrders(managerKey, 10)(tx);
+	traderClient.marginTPSL.executeConditionalOrders(managerAddress, 'SUI_USDC', 10)(tx);
 };
 ```

--- a/docs/content/standards/deepbookv3-indexer.mdx
+++ b/docs/content/standards/deepbookv3-indexer.mdx
@@ -1013,6 +1013,149 @@ produces a response similar to
 </details>
 
 <details>
+<summary>Get margin supply</summary>
+
+```http
+/margin_supply
+```
+
+Returns the total supply balance for each margin pool, queried on-chain via the margin pool contract.
+
+#### Response
+
+```json
+{
+    "0x2::sui::SUI": 1000000000000,
+    "0xdba3...::usdc::USDC": 5000000000000
+}
+```
+
+A map of asset type to total supply amount (in smallest units).
+
+</details>
+
+<details>
+<summary>Get pool creation events</summary>
+
+```http
+/pool_created
+```
+
+Returns events for when DeepBook pools are created.
+
+#### Response
+
+```json
+[
+    {
+        "event_digest": "0xabc123...",
+        "digest": "0xdef456...",
+        "sender": "0x1111...",
+        "checkpoint": 12345678,
+        "checkpoint_timestamp_ms": 1738000000000,
+        "package": "0x2222...",
+        "pool_id": "0x1234...",
+        "taker_fee": 1000000,
+        "maker_fee": 500000,
+        "tick_size": 10000,
+        "lot_size": 10000000,
+        "min_size": 100000000,
+        "whitelisted_pool": false,
+        "treasury_address": "0x5678..."
+    }
+]
+```
+
+</details>
+
+<details>
+<summary>Get book parameters updated events</summary>
+
+```http
+/book_params_updated?pool_id=<ID>
+```
+
+Returns the most recent book parameter update event for a pool. The `pool_id` parameter is required.
+
+#### Response
+
+```json
+{
+    "event_digest": "0xabc123...",
+    "digest": "0xdef456...",
+    "sender": "0x1111...",
+    "checkpoint": 12345678,
+    "checkpoint_timestamp_ms": 1738000000000,
+    "package": "0x2222...",
+    "pool_id": "0x1234...",
+    "tick_size": 10000,
+    "lot_size": 10000000,
+    "min_size": 100000000,
+    "onchain_timestamp": 1738000000000
+}
+```
+
+</details>
+
+<details>
+<summary>Get user portfolio</summary>
+
+```http
+/portfolio/:wallet_address
+```
+
+Returns a comprehensive portfolio view for a wallet address, including margin positions, collateral balances, LP positions, and a summary of total equity.
+
+#### Response
+
+```json
+{
+    "margin_positions": [
+        {
+            "margin_manager_id": "0x1234...",
+            "pool": "SUI_USDC",
+            "base_asset_symbol": "SUI",
+            "quote_asset_symbol": "USDC",
+            "base_asset": 100.0,
+            "quote_asset": 500.0,
+            "base_debt": 50.0,
+            "quote_debt": 200.0,
+            "base_asset_usd": 350.0,
+            "quote_asset_usd": 500.0,
+            "base_debt_usd": 175.0,
+            "quote_debt_usd": 200.0,
+            "total_debt_usd": 375.0,
+            "net_value_usd": 475.0,
+            "risk_ratio": 2.27
+        }
+    ],
+    "collateral_balances": [
+        {
+            "asset": "SUI",
+            "balance": 100.0,
+            "balance_usd": 350.0
+        }
+    ],
+    "lp_positions": [
+        {
+            "margin_pool_id": "0x5678...",
+            "asset": "USDC",
+            "supplied": 1000.0,
+            "shares": 1000000000,
+            "supplied_usd": 1000.0
+        }
+    ],
+    "summary": {
+        "total_equity_usd": 1850.0,
+        "total_debt_usd": 375.0,
+        "net_value_usd": 1475.0
+    }
+}
+```
+
+</details>
+
+<details>
 <summary>Get referral fee events</summary>
 
 ```http


### PR DESCRIPTION
## Summary

- **Fix `executeConditionalOrders` API mismatch** (`tpsl.mdx`): Added missing `poolKey` parameter, renamed `marginManagerKey` to `managerAddress` to match SDK signature `(managerAddress, poolKey, maxOrdersToExecute)`, updated example
- **Add `depositDuringInitialization`** (`margin-manager.mdx`): Document previously undocumented function for depositing during margin manager creation
- **Replace non-existent `riskRatio` with `managerState`** (`margin-manager.mdx`): `riskRatio` was referenced but doesn't exist in SDK; replaced with actual `managerState` comprehensive state getter
- **Add `baseBalance`, `quoteBalance`, `deepBalance`** (`margin-manager.mdx`): Document undocumented balance query functions
- **Remove false `protocolFees` reference** (`margin-pool.mdx`): Function doesn't exist in SDK, would cause broken ImportContent
- **Remove false `triggerBelowOrders`, `triggerAboveOrders`, `numConditionalOrders` references** (`tpsl.mdx`): Functions don't exist in SDK, would cause broken ImportContent tags
- **Add `withdrawMarginSettledAmounts` and `updateCurrentPrice`** (`orders.mdx`): Document undocumented permissionless settlement and Pyth price update functions
- **Add 4 undocumented indexer endpoints** (`deepbookv3-indexer.mdx`): `/margin_supply`, `/pool_created`, `/book_params_updated`, `/portfolio/:wallet_address`

## Test plan

- [ ] Verify all ImportContent tags resolve correctly against `ts-sdks` repo function names
- [ ] Confirm no broken links or rendering issues in docs build
- [ ] Cross-reference parameter descriptions against SDK source in `ts-sdks/packages/deepbook-v3/src/transactions/`
- [ ] Verify new indexer endpoint docs match handler signatures in `deepbookv3/crates/server/src/server.rs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)