### PR TITLE
[core] enable defer unpaid amplification 

### DIFF
--- a/crates/sui-benchmark/src/lib.rs
+++ b/crates/sui-benchmark/src/lib.rs
@@ -489,8 +489,8 @@ impl LocalValidatorAggregatorProxy {
         let validators: Vec<_> = self
             .clients
             .values()
-            .cloned()
             .take(num_validators)
+            .cloned()
             .collect();
         let request = SubmitTxRequest::new_transaction(tx.clone());
 
@@ -1182,4 +1182,3 @@ pub fn convert_move_call_args(
         })
         .collect()
 }
-

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -310,7 +310,7 @@ const TESTNET_USDC: &str =
 // Version 117: Update Sui System metadata handling.
 // Version 118: Adds `transfer_migration_cap` to display registry
 // Version 119: Enable the new VM.
-//              Re-enable defer_unpaid_amplification (devnet + testnet).
+// Version 120: Re-enable defer_unpaid_amplification (devnet + testnet).
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
@@ -4768,12 +4768,13 @@ impl ProtocolConfig {
                     }
                     cfg.transfer_receive_object_cost_per_byte = Some(1);
                     cfg.transfer_receive_object_type_cost_per_byte = Some(2);
+                }
+                120 => {
                     // Re-enable unpaid amplification deferral protection (testnet + devnet)
                     if chain != Chain::Mainnet {
                         cfg.feature_flags.defer_unpaid_amplification = true;
                     }
                 }
-                120 => {}
                 // Use this template when making changes:
                 //
                 //     // modify an existing constant.

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_118.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_118.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/sui-protocol-config/src/lib.rs
-assertion_line: 5219
 expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
 ---
 version: 118
@@ -155,7 +154,6 @@ feature_flags:
   split_checkpoints_in_consensus_handler: true
   consensus_always_accept_system_transactions: true
   validator_metadata_verify_v2: true
-  defer_unpaid_amplification: true
   randomize_checkpoint_tx_limit_in_tests: true
   gasless_transaction_drop_safety: true
   use_coin_party_owner: true

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_120.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_120.snap
@@ -155,6 +155,7 @@ feature_flags:
   split_checkpoints_in_consensus_handler: true
   consensus_always_accept_system_transactions: true
   validator_metadata_verify_v2: true
+  defer_unpaid_amplification: true
   randomize_checkpoint_tx_limit_in_tests: true
   gasless_transaction_drop_safety: true
   merge_randomness_into_checkpoint: true

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_118.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_118.snap
@@ -157,7 +157,6 @@ feature_flags:
   split_checkpoints_in_consensus_handler: true
   consensus_always_accept_system_transactions: true
   validator_metadata_verify_v2: true
-  defer_unpaid_amplification: true
   randomize_checkpoint_tx_limit_in_tests: true
   gasless_transaction_drop_safety: true
   use_coin_party_owner: true

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_120.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_120.snap
@@ -158,6 +158,7 @@ feature_flags:
   split_checkpoints_in_consensus_handler: true
   consensus_always_accept_system_transactions: true
   validator_metadata_verify_v2: true
+  defer_unpaid_amplification: true
   randomize_checkpoint_tx_limit_in_tests: true
   gasless_transaction_drop_safety: true
   merge_randomness_into_checkpoint: true


### PR DESCRIPTION
## Description 

  - Fix bench_driver amplification to use fire-and-forget submissions
  - Enable `defer_unpaid_amplification` in protocol version 120 (for devnet and testnet only)
 
## Test plan 

  - [x] Validated on private-testnet with 5% amplification rate
  - [x] TPS stable at ~6000, p99 latency ~1s
  - [x] Deferrals metric (`consensus_handler_unpaid_amplification_deferrals`) confirmed active
---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
