### PR TITLE
Do not emit invariant violation when randomness update execution lags

### DIFF
--- a/crates/mysten-common/src/logging.rs
+++ b/crates/mysten-common/src/logging.rs
@@ -116,6 +116,37 @@ macro_rules! debug_fatal {
 }
 
 #[macro_export]
+macro_rules! debug_fatal_no_invariant {
+    ($msg:literal $(, $arg:expr)*) => {{
+        loop {
+            #[cfg(msim)]
+            {
+                if let Some(cb) = $crate::logging::intercept_debug_fatal::get_callback() {
+                    tracing::error!($msg $(, $arg)*);
+                    let msg = format!($msg $(, $arg)*);
+                    if msg.contains(&cb.pattern) {
+                        (cb.callback)();
+                    }
+                    break;
+                }
+            }
+
+            if !$crate::in_antithesis() && $crate::logging::crash_on_debug() {
+                $crate::fatal!($msg $(, $arg)*);
+            } else {
+                tracing::error!($msg $(, $arg)*);
+                if $crate::in_antithesis() {
+                    let full_msg = format!($msg $(, $arg)*);
+                    let json = $crate::logging::json!({ "message": full_msg });
+                    $crate::logging::assert_unreachable_antithesis!($msg, &json);
+                }
+            }
+            break;
+        }
+    }};
+}
+
+#[macro_export]
 macro_rules! assert_reachable {
     () => {
         $crate::logging::assert_reachable!("");

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -109,7 +109,7 @@ use crate::jsonrpc_index::IndexStore;
 use crate::jsonrpc_index::{
     CoinInfo, IndexStoreCacheUpdates, IndexStoreCacheUpdatesWithLocks, ObjectIndexChanges,
 };
-use mysten_common::debug_fatal;
+use mysten_common::{debug_fatal, debug_fatal_no_invariant};
 use shared_crypto::intent::{AppId, Intent, IntentMessage, IntentScope, IntentVersion};
 use sui_config::genesis::Genesis;
 use sui_config::node::{DBCheckpointConfig, ExpensiveSafetyCheckConfig};
@@ -6500,7 +6500,7 @@ impl RandomnessRoundReceiver {
                 Ok(result) => result,
                 Err(_) => {
                     // Crash on randomness update execution timeout in debug builds.
-                    debug_fatal!(
+                    debug_fatal_no_invariant!(
                         "randomness state update transaction execution timed out at epoch {epoch}, round {round}"
                     );
                     // Continue waiting as long as necessary in non-debug builds.


### PR DESCRIPTION
## Description 

IIUC lagging randomness update execution can happen naturally during node catchup, and there is no plan to mitigate the issue yet.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
