### PR TITLE
chore: expose helpers for system transactions

### DIFF
--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -2045,7 +2045,7 @@ impl TransactionData {
             TransactionData::V1(v1) => v1,
         }
     }
-    fn new_system_transaction(kind: TransactionKind) -> Self {
+    pub fn new_system_transaction(kind: TransactionKind) -> Self {
         // assert transaction kind if a system transaction
         assert!(kind.is_system_tx());
         let sender = SuiAddress::default();

--- a/sui-execution/src/lib.rs
+++ b/sui-execution/src/lib.rs
@@ -9,6 +9,7 @@ use sui_protocol_config::ProtocolConfig;
 use sui_types::{error::SuiResult, metrics::BytecodeVerifierMetrics};
 
 pub use executor::Executor;
+pub use sui_move_natives_latest::object_runtime;
 pub use verifier::Verifier;
 
 pub mod executor;


### PR DESCRIPTION
## Summary
- Make `TransactionData::new_system_transaction` public so external consumers can construct system transaction data directly, without the `VerifiedTransaction::new_system_transaction` → `.into_inner()` workaround.
- Re-export `object_runtime` module from `sui-execution`, so downstream crates can access `ObjectRuntime` via `sui_execution::object_runtime` instead of depending on `sui-move-natives-latest` directly.

## Test plan
- [x] `cargo check -p sui-types` passes
- [x] `cargo check -p sui-execution` passes
- No behavioral change — visibility-only modifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)