### PR TITLE
chore: expose some helper functions

### DIFF
--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -2045,7 +2045,7 @@ impl TransactionData {
             TransactionData::V1(v1) => v1,
         }
     }
-    fn new_system_transaction(kind: TransactionKind) -> Self {
+    pub fn new_system_transaction(kind: TransactionKind) -> Self {
         // assert transaction kind if a system transaction
         assert!(kind.is_system_tx());
         let sender = SuiAddress::default();

--- a/sui-execution/src/lib.rs
+++ b/sui-execution/src/lib.rs
@@ -9,6 +9,7 @@ use sui_protocol_config::ProtocolConfig;
 use sui_types::{error::SuiResult, metrics::BytecodeVerifierMetrics};
 
 pub use executor::Executor;
+pub use sui_move_natives_latest::object_runtime;
 pub use verifier::Verifier;
 
 pub mod executor;


### PR DESCRIPTION
## Description 

Make `TransactionData::new_system_transaction` public so external consumers can construct system transaction data directly without the `VerifiedTransaction::new_system_transaction` → `.into_inner()` detour.

Re-export `object_runtime` from `sui-execution` so downstream crates can access `ObjectRuntime` without depending on
`sui-move-natives-latest` directly.


## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
