### PR TITLE
sui-indexer-alt-framework: verify indexer uses a single chain_id

### DIFF
--- a/crates/sui-analytics-indexer/src/store/mod.rs
+++ b/crates/sui-analytics-indexer/src/store/mod.rs
@@ -638,6 +638,15 @@ impl Connection for AnalyticsConnection<'_> {
         init_with_committer_watermark(self, pipeline_task, init_watermark).await
     }
 
+    async fn accepts_chain_id(
+        &mut self,
+        _pipeline_task: &str,
+        _chain_id: [u8; 32],
+    ) -> anyhow::Result<bool> {
+        // TODO: Implement storing chain_id
+        Ok(true)
+    }
+
     /// Determine the watermark.
     ///
     /// In live mode: scans file names in the object store.

--- a/crates/sui-indexer-alt-consistent-store/src/store/mod.rs
+++ b/crates/sui-indexer-alt-consistent-store/src/store/mod.rs
@@ -175,6 +175,15 @@ impl<S: Send + Sync> store::Connection for Connection<'_, S> {
         init_with_committer_watermark(self, pipeline_task, init_watermark).await
     }
 
+    async fn accepts_chain_id(
+        &mut self,
+        _pipeline_task: &str,
+        _chain_id: [u8; 32],
+    ) -> anyhow::Result<bool> {
+        // TODO: Implement storing chain_id
+        Ok(true)
+    }
+
     async fn committer_watermark(
         &mut self,
         pipeline_task: &str,

--- a/crates/sui-indexer-alt-framework-store-traits/src/lib.rs
+++ b/crates/sui-indexer-alt-framework-store-traits/src/lib.rs
@@ -21,6 +21,17 @@ pub trait Connection: Send {
         init_watermark: InitWatermark,
     ) -> anyhow::Result<InitWatermark>;
 
+    /// Checks if the store can accept a `chain_id`.
+    /// Returns `Ok(true)` if the store accepts this `chain_id` thereby allowing processing to continue.
+    /// Returns `Ok(false)` if the store does not accept the `chain_id` thereby halting processing with an error.
+    /// Returns `Err(_)` if the store encountered an error while trying to determine if it could accept
+    /// the `chain_id` which will cause `accepts_chain_id` to be retried.
+    async fn accepts_chain_id(
+        &mut self,
+        pipeline_task: &str,
+        chain_id: [u8; 32],
+    ) -> anyhow::Result<bool>;
+
     /// Given a `pipeline_task` representing either a pipeline name or a pipeline with an associated
     /// task (formatted as `{pipeline}{Store::DELIMITER}{task}`), return the committer watermark
     /// from the `Store`. The indexer fetches this value for each pipeline added to determine which

--- a/crates/sui-indexer-alt-framework/src/mocks/store.rs
+++ b/crates/sui-indexer-alt-framework/src/mocks/store.rs
@@ -35,6 +35,7 @@ pub struct MockWatermark {
     pub reader_lo: u64,
     pub pruner_timestamp: u64,
     pub pruner_hi: u64,
+    pub chain_id: Option<[u8; 32]>,
 }
 
 /// Configuration for simulating connection failures in tests
@@ -120,12 +121,32 @@ impl Connection for MockConnection<'_> {
                 reader_lo: init_watermark.reader_lo,
                 pruner_timestamp: 0,
                 pruner_hi: init_watermark.reader_lo,
+                chain_id: None,
             });
 
         Ok(InitWatermark {
             checkpoint_hi_inclusive: watermark.checkpoint_hi_inclusive,
             reader_lo: watermark.reader_lo,
         })
+    }
+
+    async fn accepts_chain_id(
+        &mut self,
+        pipeline_task: &str,
+        chain_id: [u8; 32],
+    ) -> anyhow::Result<bool> {
+        let mut wm = self
+            .0
+            .watermarks
+            .entry(pipeline_task.to_string())
+            .or_default();
+
+        if let Some(stored_chain_id) = wm.chain_id {
+            Ok(stored_chain_id == chain_id)
+        } else {
+            wm.chain_id = Some(chain_id);
+            Ok(true)
+        }
     }
 
     async fn committer_watermark(

--- a/crates/sui-indexer-alt-framework/src/pipeline/concurrent/mod.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/concurrent/mod.rs
@@ -287,6 +287,7 @@ pub(crate) fn pipeline<H: Handler + Send + Sync + 'static>(
         processor_tx,
         metrics.clone(),
         concurrency,
+        store.clone(),
     );
 
     let s_collector = collector::<H>(

--- a/crates/sui-indexer-alt-framework/src/pipeline/concurrent/pruner.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/concurrent/pruner.rs
@@ -541,6 +541,7 @@ mod tests {
             reader_lo: 3,
             pruner_timestamp: timestamp,
             pruner_hi: 0,
+            chain_id: None,
         };
         let store = MockStore::new()
             .with_watermark(DataPipeline::NAME, watermark)
@@ -620,6 +621,7 @@ mod tests {
             reader_lo: 3,
             pruner_timestamp: 0,
             pruner_hi: 0,
+            chain_id: None,
         };
         let store = MockStore::new()
             .with_watermark(DataPipeline::NAME, watermark)
@@ -686,6 +688,7 @@ mod tests {
             reader_lo: 4,        // Allow pruning up to checkpoint 4 (exclusive)
             pruner_timestamp: 0, // Past timestamp so delay doesn't block
             pruner_hi: 1,
+            chain_id: None,
         };
 
         // Configure failing behavior: range [1,2) should fail once before succeeding

--- a/crates/sui-indexer-alt-framework/src/pipeline/concurrent/reader_watermark.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/concurrent/reader_watermark.rs
@@ -201,6 +201,7 @@ mod tests {
             reader_lo: 0, // Initial reader_lo
             pruner_timestamp: 0,
             pruner_hi: 0,
+            chain_id: None,
         };
         let polling_interval_ms = 100;
         let connection_failure_attempts = 0;
@@ -233,6 +234,7 @@ mod tests {
             reader_lo: 7, // Initial reader_lo
             pruner_timestamp: 0,
             pruner_hi: 0,
+            chain_id: None,
         };
         let polling_interval_ms = 100;
         let connection_failure_attempts = 0;
@@ -269,6 +271,7 @@ mod tests {
             reader_lo: 0, // Initial reader_lo
             pruner_timestamp: 0,
             pruner_hi: 0,
+            chain_id: None,
         };
         let polling_interval_ms = 1_000; // Long interval for testing retry
         let connection_failure_attempts = 1;
@@ -321,6 +324,7 @@ mod tests {
             reader_lo: 0, // Initial reader_lo
             pruner_timestamp: 0,
             pruner_hi: 0,
+            chain_id: None,
         };
         let polling_interval_ms = 1_000; // Long interval for testing retry
         let connection_failure_attempts = 0;

--- a/crates/sui-indexer-alt-framework/src/pipeline/processor.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/processor.rs
@@ -4,18 +4,21 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use async_trait::async_trait;
 use backoff::ExponentialBackoff;
 use sui_futures::service::Service;
 use sui_futures::stream::Break;
 use sui_futures::stream::TrySpawnStreamExt;
+use sui_indexer_alt_framework_store_traits::Connection;
+use sui_indexer_alt_framework_store_traits::Store;
+use sui_types::digests::ChainIdentifier;
 use sui_types::full_checkpoint_content::Checkpoint;
+use tokio::sync::OnceCell;
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 use tracing::debug;
 use tracing::error;
 use tracing::info;
-
-use async_trait::async_trait;
 
 use crate::config::ConcurrencyConfig;
 use crate::ingestion::ingestion_client::CheckpointEnvelope;
@@ -60,12 +63,13 @@ pub trait Processor: Send + Sync + 'static {
 ///
 /// Each worker processes a checkpoint into rows and sends them on to the committer using the `tx`
 /// channel.
-pub(super) fn processor<P: Processor>(
+pub(super) fn processor<P: Processor, S: Store>(
     processor: Arc<P>,
     rx: mpsc::Receiver<Arc<CheckpointEnvelope>>,
     tx: mpsc::Sender<IndexedCheckpoint<P>>,
     metrics: Arc<IndexerMetrics>,
     concurrency: ConcurrencyConfig,
+    store: S,
 ) -> Service {
     Service::new().spawn_aborting(async move {
         info!(pipeline = P::NAME, "Starting processor");
@@ -76,6 +80,8 @@ pub(super) fn processor<P: Processor>(
         );
 
         let report_metrics = metrics.clone();
+        // Caches this pipeline's chain_id after the first time it has been read from the database.
+        let chain_id_accepted: Arc<OnceCell<(bool, ChainIdentifier)>> = Arc::default();
         match ReceiverStream::new(rx)
             .try_for_each_send_spawned(
                 concurrency.into(),
@@ -83,8 +89,11 @@ pub(super) fn processor<P: Processor>(
                     let metrics = metrics.clone();
                     let checkpoint_lag_reporter = checkpoint_lag_reporter.clone();
                     let processor = processor.clone();
+                    let store = store.clone();
+                    let chain_id_accepted = chain_id_accepted.clone();
 
                     async move {
+
                         metrics
                             .total_handler_checkpoints_received
                             .with_label_values(&[P::NAME])
@@ -104,14 +113,28 @@ pub(super) fn processor<P: Processor>(
                             ..Default::default()
                         };
 
-                        let checkpoint = checkpoint_envelope.checkpoint.clone();
+                        let chain_id = checkpoint_envelope.chain_id;
+                        let checkpoint = &checkpoint_envelope.checkpoint;
                         let checkpoint_sequence_number = checkpoint.summary.sequence_number;
                         let retry_metrics = metrics.clone();
                         let values = backoff::future::retry_notify(
                             backoff,
                             || async {
+                                let (accepted, accepted_chain_id) = chain_id_accepted.get_or_try_init(async || {
+                                    let mut conn = store.connect().await
+                                        .map_err(backoff::Error::transient)?;
+                                    let accepted = conn.accepts_chain_id(P::NAME, *chain_id.as_bytes()).await
+                                        .map_err(backoff::Error::transient)?;
+                                    Ok::<_, backoff::Error<anyhow::Error>>((accepted, chain_id))
+                                }).await?;
+                                if !accepted || *accepted_chain_id != chain_id {
+                                    return Err(backoff::Error::permanent(anyhow::anyhow!(
+                                        "checkpoint chain_id={chain_id:?} does not match stored chain_id",
+                                    )))
+                                }
+
                                 processor
-                                    .process(&checkpoint)
+                                    .process(checkpoint)
                                     .await
                                     .map_err(backoff::Error::transient)
                             },
@@ -200,12 +223,16 @@ mod tests {
     use std::time::Duration;
 
     use anyhow::ensure;
+    use sui_futures::service;
     use sui_types::digests::ChainIdentifier;
+    use sui_types::digests::CheckpointDigest;
     use sui_types::test_checkpoint_data_builder::TestCheckpointBuilder;
     use tokio::sync::mpsc;
     use tokio::time::timeout;
 
     use crate::metrics::IndexerMetrics;
+    use crate::mocks::store::MockStore;
+    use crate::mocks::store::MockWatermark;
 
     use super::*;
 
@@ -270,6 +297,7 @@ mod tests {
             indexed_tx,
             metrics,
             ConcurrencyConfig::Fixed { value: 10 },
+            MockStore::default(),
         );
 
         // Send both checkpoints
@@ -334,6 +362,7 @@ mod tests {
             indexed_tx,
             metrics,
             ConcurrencyConfig::Fixed { value: 10 },
+            MockStore::default(),
         );
 
         // Send first checkpoint.
@@ -412,6 +441,7 @@ mod tests {
             indexed_tx,
             metrics.clone(),
             ConcurrencyConfig::Fixed { value: 10 },
+            MockStore::default(),
         );
 
         // Send and verify first checkpoint (should succeed immediately)
@@ -442,10 +472,107 @@ mod tests {
         );
     }
 
-    // By default, Rust's async tests run on the single-threaded runtime.
-    // We need multi_thread here because our test uses std::thread::sleep which blocks the worker thread.
-    // The multi-threaded runtime allows other worker threads to continue processing while one is blocked.
-    #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+    async fn test_chain_id(
+        store: MockStore,
+        checkpoint_chain_id: ChainIdentifier,
+    ) -> (
+        Option<IndexedCheckpoint<DataPipeline>>,
+        Result<(), service::Error>,
+    ) {
+        let checkpoint_envelope = Arc::new(CheckpointEnvelope {
+            checkpoint: Arc::new(TestCheckpointBuilder::new(1).build_checkpoint()),
+            chain_id: checkpoint_chain_id,
+        });
+
+        let processor = Arc::new(DataPipeline);
+        let (data_tx, data_rx) = mpsc::channel(1);
+        let (indexed_tx, mut indexed_rx) = mpsc::channel(1);
+        let metrics = IndexerMetrics::new(None, &Default::default());
+
+        let service = super::processor(
+            processor,
+            data_rx,
+            indexed_tx,
+            metrics,
+            ConcurrencyConfig::Fixed { value: 1 },
+            store,
+        );
+
+        // Send the checkpoint then close the input channel.
+        data_tx.try_send(checkpoint_envelope).unwrap();
+        drop(data_tx);
+
+        let indexed_checkpoint = indexed_rx.recv().await;
+        let shutdown_result = service.shutdown().await;
+
+        (indexed_checkpoint, shutdown_result)
+    }
+
+    #[tokio::test]
+    async fn test_chain_id_stored_when_none_exists() {
+        let store = MockStore::default();
+        let chain_id = ChainIdentifier::default();
+
+        let (indexed_checkpoint, shutdown_result) = test_chain_id(store.clone(), chain_id).await;
+        assert!(shutdown_result.is_ok());
+
+        let indexed = indexed_checkpoint.expect("Should receive IndexedCheckpoint");
+        assert_eq!(indexed.watermark.checkpoint_hi_inclusive, 1);
+
+        let watermark = store.watermark(DataPipeline::NAME).unwrap();
+        assert_eq!(
+            watermark.chain_id,
+            Some(*chain_id.as_bytes()),
+            "chain_id should be stored after first checkpoint"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_chain_id_matches_existing() {
+        let chain_id = ChainIdentifier::default();
+        let store = MockStore::default().with_watermark(
+            DataPipeline::NAME,
+            MockWatermark {
+                chain_id: Some(*chain_id.as_bytes()),
+                ..Default::default()
+            },
+        );
+
+        let (indexed_checkpoint, shutdown_result) = test_chain_id(store, chain_id).await;
+        assert!(shutdown_result.is_ok());
+
+        let indexed =
+            indexed_checkpoint.expect("Should receive IndexedCheckpoint when chain_id matches");
+        assert_eq!(indexed.watermark.checkpoint_hi_inclusive, 1);
+    }
+
+    #[tokio::test]
+    async fn test_chain_id_mismatch_returns_error() {
+        let stored_chain_id = ChainIdentifier::default();
+        let different_chain_id: ChainIdentifier = CheckpointDigest::from([1u8; 32]).into();
+        let store = MockStore::default().with_watermark(
+            DataPipeline::NAME,
+            MockWatermark {
+                chain_id: Some(*stored_chain_id.as_bytes()),
+                ..Default::default()
+            },
+        );
+
+        let (indexed_checkpoint, shutdown_result) = test_chain_id(store, different_chain_id).await;
+        let shutdown_err = shutdown_result.unwrap_err();
+        assert!(
+            format!("{shutdown_err:#}").contains("does not match"),
+            "Error should indicate chain_id mismatch, got: {shutdown_err:#}"
+        );
+
+        // The processor should fail and drop indexed_tx, so recv returns None.
+        assert!(
+            indexed_checkpoint.is_none(),
+            "Channel should close without producing a result on chain_id mismatch"
+        );
+    }
+
+    #[tokio::test]
     async fn test_processor_concurrency() {
         // Create a processor that simulates work by sleeping
         struct SlowProcessor;
@@ -458,8 +585,11 @@ mod tests {
                 &self,
                 checkpoint: &Arc<Checkpoint>,
             ) -> anyhow::Result<Vec<Self::Value>> {
-                // Simulate work by sleeping
-                std::thread::sleep(std::time::Duration::from_millis(500));
+                // Use tokio::time::sleep rather than std::thread::sleep to avoid
+                // starving tasks woken by the chain_id RwLock. std::thread::sleep
+                // blocks the worker thread, preventing woken tasks queued on the
+                // same thread from making progress until the sleep finishes.
+                tokio::time::sleep(Duration::from_millis(500)).await;
                 Ok(vec![StoredData {
                     value: checkpoint.summary.sequence_number,
                 }])
@@ -489,6 +619,7 @@ mod tests {
             indexed_tx,
             metrics,
             ConcurrencyConfig::Fixed { value: 3 },
+            MockStore::default(),
         );
 
         // Send all checkpoints and measure time
@@ -508,7 +639,7 @@ mod tests {
         // With concurrency=3, 5 checkpoints should take ~1000ms (500ms * 2 (batches)) instead of 2500ms (500ms * 5).
         // Adding small 200ms for some processing overhead.
         let elapsed = start.elapsed();
-        assert!(elapsed < std::time::Duration::from_millis(1200));
+        assert!(elapsed < Duration::from_millis(1200));
 
         // Verify results
         assert_eq!(received.len(), 5);

--- a/crates/sui-indexer-alt-framework/src/pipeline/sequential/mod.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/sequential/mod.rs
@@ -127,7 +127,7 @@ pub(crate) fn pipeline<H: Handler + Send + Sync + 'static>(
     handler: H,
     next_checkpoint: u64,
     config: SequentialConfig,
-    db: H::Store,
+    store: H::Store,
     checkpoint_rx: mpsc::Receiver<Arc<CheckpointEnvelope>>,
     commit_hi_tx: mpsc::UnboundedSender<(&'static str, u64)>,
     metrics: Arc<IndexerMetrics>,
@@ -162,6 +162,7 @@ pub(crate) fn pipeline<H: Handler + Send + Sync + 'static>(
         processor_tx,
         metrics.clone(),
         concurrency,
+        store.clone(),
     );
 
     let s_committer = committer::<H>(
@@ -170,7 +171,7 @@ pub(crate) fn pipeline<H: Handler + Send + Sync + 'static>(
         next_checkpoint,
         committer_rx,
         commit_hi_tx,
-        db,
+        store,
         metrics.clone(),
         min_eager_rows,
         max_batch_checkpoints,

--- a/crates/sui-indexer-alt-object-store/src/lib.rs
+++ b/crates/sui-indexer-alt-object-store/src/lib.rs
@@ -96,6 +96,15 @@ impl Connection for ObjectStoreConnection {
         init_with_committer_watermark(self, pipeline_task, init_watermark).await
     }
 
+    async fn accepts_chain_id(
+        &mut self,
+        _pipeline_task: &str,
+        _chain_id: [u8; 32],
+    ) -> anyhow::Result<bool> {
+        // TODO: Implement storing chain_id
+        Ok(true)
+    }
+
     async fn committer_watermark(
         &mut self,
         pipeline_task: &str,

--- a/crates/sui-indexer-alt-schema/src/schema.rs
+++ b/crates/sui-indexer-alt-schema/src/schema.rs
@@ -214,6 +214,7 @@ diesel::table! {
         reader_lo -> Int8,
         pruner_timestamp -> Timestamp,
         pruner_hi -> Int8,
+        chain_id -> Nullable<Bytea>,
     }
 }
 

--- a/crates/sui-kvstore/src/bigtable/store.rs
+++ b/crates/sui-kvstore/src/bigtable/store.rs
@@ -69,6 +69,15 @@ impl Connection for BigTableConnection<'_> {
         init_with_committer_watermark(self, pipeline_task, init_watermark).await
     }
 
+    async fn accepts_chain_id(
+        &mut self,
+        _pipeline_task: &str,
+        _chain_id: [u8; 32],
+    ) -> Result<bool> {
+        // TODO: Implement storing chain_id
+        Ok(true)
+    }
+
     async fn committer_watermark(
         &mut self,
         pipeline_task: &str,

--- a/crates/sui-pg-db/migrations/2026-03-20-081396_watermarks_chain_id/down.sql
+++ b/crates/sui-pg-db/migrations/2026-03-20-081396_watermarks_chain_id/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE watermarks DROP COLUMN chain_id;

--- a/crates/sui-pg-db/migrations/2026-03-20-081396_watermarks_chain_id/up.sql
+++ b/crates/sui-pg-db/migrations/2026-03-20-081396_watermarks_chain_id/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE watermarks ADD COLUMN chain_id BYTEA;

--- a/crates/sui-pg-db/src/schema.rs
+++ b/crates/sui-pg-db/src/schema.rs
@@ -12,5 +12,6 @@ diesel::table! {
         reader_lo -> Int8,
         pruner_timestamp -> Timestamp,
         pruner_hi -> Int8,
+        chain_id -> Nullable<Bytea>,
     }
 }

--- a/crates/sui-pg-db/src/store.rs
+++ b/crates/sui-pg-db/src/store.rs
@@ -3,11 +3,15 @@
 
 use std::time::Duration;
 
+use anyhow::Context;
 use async_trait::async_trait;
 use chrono::Utc;
 use diesel::ExpressionMethods;
 use diesel::prelude::*;
 use diesel::sql_types::BigInt;
+use diesel::sql_types::Nullable;
+use diesel::sql_types::SingleValue;
+use diesel::sql_types::SqlType;
 use diesel_async::AsyncConnection;
 use diesel_async::RunQueryDsl;
 use scoped_futures::ScopedBoxFuture;
@@ -20,6 +24,10 @@ use crate::model::StoredWatermark;
 use crate::schema::watermarks;
 
 pub use sui_indexer_alt_framework_store_traits::Store;
+
+define_sql_function! {
+    fn coalesce<T: SqlType + SingleValue>(x: Nullable<T>, y: T) -> Nullable<T>;
+}
 
 #[async_trait]
 impl store::Connection for Connection<'_> {
@@ -63,6 +71,26 @@ impl store::Connection for Connection<'_> {
             checkpoint_hi_inclusive: u64::try_from(checkpoint_hi_inclusive).ok(),
             reader_lo: reader_lo as u64,
         })
+    }
+
+    async fn accepts_chain_id(
+        &mut self,
+        pipeline_task: &str,
+        chain_id: [u8; 32],
+    ) -> anyhow::Result<bool> {
+        let stored_chain_id: Option<Vec<u8>> = diesel::update(watermarks::table)
+            .filter(watermarks::pipeline.eq(pipeline_task))
+            // "coalesce" only updates the value if it is null in the existing row
+            .set(watermarks::chain_id.eq(coalesce(watermarks::chain_id, chain_id)))
+            .returning(watermarks::chain_id)
+            .get_result(self)
+            .await?;
+
+        let stored_chain_id = stored_chain_id.context("missing chain id after update")?;
+        let stored_chain_id: [u8; 32] = stored_chain_id
+            .try_into()
+            .map_err(|v: Vec<u8>| anyhow::anyhow!("chain id has wrong length: {}", v.len()))?;
+        Ok(stored_chain_id == chain_id)
     }
 
     async fn committer_watermark(


### PR DESCRIPTION
## Description 

This PR is a follow up to #25895 and #25905 that 
1. stores the `chain_id` per pipeline in the watermark
2. compares the stored `chain_id` to the `chain_id` returned by the streaming and ingestion clients
3. implements the `chain_id` storage for the Postgres and mock store implementations (other impls return the passed in `chain_id` and are no-ops)

## Test plan 

Adds new `test_chain_id` test cases.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [x] Indexing Framework: Add `Connection::init_chain_id` method to store and retrieve `chain_id`.