### PR TITLE
Skip lock existence check during snapshot restore

### DIFF
--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -966,9 +966,8 @@ impl AuthorityStore {
     ) -> SuiResult {
         trace!(?objects, "initialize_locks");
 
-        let live_object_markers = live_object_marker_table.multi_get(objects)?;
-
         if !is_force_reset {
+            let live_object_markers = live_object_marker_table.multi_get(objects)?;
             // If any live_object_markers exist and are not None, return errors for them
             // Note we don't check if there is a pre-existing lock. this is because initializing the live
             // object marker will not overwrite the lock and cause the validator to equivocate.


### PR DESCRIPTION
  During formal snapshot restore, `bulk_insert_live_objects` calls `initialize_live_object_markers`                                                                        
  with `is_force_reset=false`, which issues a `multi_get` on `owned_object_transaction_locks` for                                                                          
  every non-child object before writing it. Since the database is empty during restore, these reads                                                                        
  are guaranteed misses and serve no purpose — there are no pre-existing locks to protect.                                                                                 
                                                                                                                                                                           
  This causes the `owned_object_transaction_locks` lookup count to grow continuously throughout                                                                            
  restore. The problem compounds as the table fills: TideHunter's bloom filter accumulates false                                                                           
  positives, driving up the actual index lookup cost per `multi_get`.                                                                                                      
                  
  Fix: pass `is_force_reset=true` in `bulk_insert_live_objects` so the read is skipped and markers                                                                         
  are written directly.
