### PR TITLE
sui-indexer-alt-framework: add chain_id to IngestionClient

### DIFF
--- a/crates/sui-indexer-alt-framework/src/ingestion/broadcaster.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/broadcaster.rs
@@ -235,9 +235,9 @@ fn ingest_and_broadcast_range(
                     let client = client.clone();
                     async move {
                         // Fetch the checkpoint or stop if cancelled.
-                        let checkpoint = client.wait_for(cp, retry_interval).await?;
+                        let checkpoint_envelope = client.wait_for(cp, retry_interval).await?;
                         debug!(checkpoint = cp, "Fetched checkpoint");
-                        Ok(checkpoint)
+                        Ok(checkpoint_envelope.checkpoint)
                     }
                 },
                 Arc::unwrap_or_clone(subscribers),
@@ -441,6 +441,8 @@ mod tests {
     use std::time::Duration;
 
     use async_trait::async_trait;
+    use sui_types::digests::ChainIdentifier;
+    use sui_types::messages_checkpoint::CheckpointDigest;
     use tokio::time::error::Elapsed;
     use tokio::time::timeout;
 
@@ -460,6 +462,10 @@ mod tests {
 
         #[async_trait]
         impl IngestionClientTrait for MockClient {
+            async fn chain_id(&self) -> anyhow::Result<ChainIdentifier> {
+                Ok(CheckpointDigest::new([1; 32]).into())
+            }
+
             async fn checkpoint(&self, checkpoint: u64) -> CheckpointResult {
                 // Return mock checkpoint data for any checkpoint number
                 let bytes = test_checkpoint_data(checkpoint);

--- a/crates/sui-indexer-alt-framework/src/ingestion/ingestion_client.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/ingestion_client.rs
@@ -21,6 +21,8 @@ use object_store::local::LocalFileSystem;
 use sui_futures::future::with_slow_future_monitor;
 use sui_rpc::Client;
 use sui_rpc::client::HeadersInterceptor;
+use sui_types::digests::ChainIdentifier;
+use tokio::sync::OnceCell;
 use tracing::debug;
 use tracing::error;
 use tracing::warn;
@@ -30,6 +32,7 @@ use crate::ingestion::Error as IngestionError;
 use crate::ingestion::MAX_GRPC_MESSAGE_SIZE_BYTES;
 use crate::ingestion::Result as IngestionResult;
 use crate::ingestion::decode;
+use crate::ingestion::error::Error::FetchError;
 use crate::ingestion::store_client::StoreIngestionClient;
 use crate::metrics::CheckpointLagMetricReporter;
 use crate::metrics::IngestionMetrics;
@@ -47,6 +50,8 @@ const SLOW_OPERATION_WARNING_THRESHOLD: Duration = Duration::from_secs(60);
 
 #[async_trait]
 pub(crate) trait IngestionClientTrait: Send + Sync {
+    async fn chain_id(&self) -> anyhow::Result<ChainIdentifier>;
+
     async fn checkpoint(&self, checkpoint: u64) -> CheckpointResult;
 }
 
@@ -168,6 +173,13 @@ pub struct IngestionClient {
     /// Wrap the metrics in an `Arc` to keep copies of the client cheap.
     metrics: Arc<IngestionMetrics>,
     checkpoint_lag_reporter: Arc<CheckpointLagMetricReporter>,
+    chain_id: OnceCell<ChainIdentifier>,
+}
+
+#[derive(Clone, Debug)]
+pub struct CheckpointEnvelope {
+    pub checkpoint: Arc<Checkpoint>,
+    pub chain_id: ChainIdentifier,
 }
 
 impl IngestionClient {
@@ -270,6 +282,7 @@ impl IngestionClient {
             client,
             metrics,
             checkpoint_lag_reporter,
+            chain_id: OnceCell::new(),
         }
     }
 
@@ -282,7 +295,7 @@ impl IngestionClient {
         &self,
         checkpoint: u64,
         retry_interval: Duration,
-    ) -> IngestionResult<Arc<Checkpoint>> {
+    ) -> IngestionResult<CheckpointEnvelope> {
         let backoff = Constant::new(retry_interval);
         let fetch = || async move {
             use backoff::Error as BE;
@@ -307,12 +320,12 @@ impl IngestionClient {
     /// this function if we fail to deserialize the result as [Checkpoint].
     ///
     /// The function will immediately return if the checkpoint is not found.
-    pub async fn checkpoint(&self, checkpoint: u64) -> IngestionResult<Arc<Checkpoint>> {
-        let client = self.client.clone();
+    pub async fn checkpoint(&self, checkpoint: u64) -> IngestionResult<CheckpointEnvelope> {
+        let checkpoint_client = self.client.clone();
         let request = move || {
-            let client = client.clone();
+            let client = checkpoint_client.clone();
             async move {
-                let fetch_data = with_slow_future_monitor(
+                let checkpoint_data = with_slow_future_monitor(
                     client.checkpoint(checkpoint),
                     SLOW_OPERATION_WARNING_THRESHOLD,
                     /* on_threshold_exceeded =*/
@@ -320,7 +333,7 @@ impl IngestionClient {
                         warn!(
                             checkpoint,
                             threshold_ms = SLOW_OPERATION_WARNING_THRESHOLD.as_millis(),
-                            "Slow checkpoint fetch operation detected"
+                            "Slow checkpoint operation detected"
                         );
                     },
                 )
@@ -335,7 +348,7 @@ impl IngestionClient {
                         IngestionError::FetchError(checkpoint, error),
                     ),
                     CheckpointError::Permanent { reason, error } => {
-                        error!(checkpoint, reason, "Permanent fetch error: {error}");
+                        error!(checkpoint, reason, "Permanent checkpoint error: {error}");
                         self.metrics
                             .total_ingested_permanent_errors
                             .with_label_values(&[reason])
@@ -344,7 +357,7 @@ impl IngestionClient {
                     }
                 })?;
 
-                Ok::<Checkpoint, backoff::Error<IngestionError>>(match fetch_data {
+                Ok::<Checkpoint, backoff::Error<IngestionError>>(match checkpoint_data {
                     CheckpointData::Raw(bytes) => {
                         self.metrics.total_ingested_bytes.inc_by(bytes.len() as u64);
 
@@ -402,7 +415,56 @@ impl IngestionClient {
             .total_ingested_objects
             .inc_by(data.object_set.len() as u64);
 
-        Ok(Arc::new(data))
+        let chain_id = *self.get_or_init_chain_id(checkpoint).await?;
+
+        Ok(CheckpointEnvelope {
+            checkpoint: Arc::new(data),
+            chain_id,
+        })
+    }
+
+    async fn get_or_init_chain_id(&self, checkpoint: u64) -> IngestionResult<&ChainIdentifier> {
+        let chain_id_client = self.client.clone();
+        let chain_id = self
+            .chain_id
+            .get_or_try_init(|| {
+                let request = move || {
+                    let client = chain_id_client.clone();
+                    async move {
+                        let chain_id = with_slow_future_monitor(
+                            client.chain_id(),
+                            SLOW_OPERATION_WARNING_THRESHOLD,
+                            /* on_threshold_exceeded =*/
+                            || {
+                                warn!(
+                                    checkpoint,
+                                    threshold_ms = SLOW_OPERATION_WARNING_THRESHOLD.as_millis(),
+                                    "Slow chain_id operation detected"
+                                );
+                            },
+                        )
+                        .await
+                        .map_err(|err| {
+                            let reason = "chain_id";
+                            warn!(reason, "Retrying due to error: {err}");
+                            backoff::Error::transient(FetchError(checkpoint, err))
+                        })?;
+
+                        Ok::<ChainIdentifier, backoff::Error<IngestionError>>(chain_id)
+                    }
+                };
+
+                // Keep backing off until we are waiting for the max interval, but don't give up.
+                let backoff = ExponentialBackoff {
+                    max_interval: MAX_TRANSIENT_RETRY_INTERVAL,
+                    max_elapsed_time: None,
+                    ..Default::default()
+                };
+
+                backoff::future::retry(backoff, request)
+            })
+            .await?;
+        Ok(chain_id)
     }
 }
 
@@ -414,6 +476,7 @@ mod tests {
     use prometheus::Registry;
     use std::sync::Arc;
     use std::time::Duration;
+    use sui_types::digests::CheckpointDigest;
     use tokio::time::timeout;
 
     use crate::ingestion::test_utils::test_checkpoint_data;
@@ -435,8 +498,18 @@ mod tests {
         permanent_failures: DashMap<u64, usize>,
     }
 
+    impl MockIngestionClient {
+        fn mock_chain_id() -> ChainIdentifier {
+            CheckpointDigest::new([1; 32]).into()
+        }
+    }
+
     #[async_trait]
     impl IngestionClientTrait for MockIngestionClient {
+        async fn chain_id(&self) -> anyhow::Result<ChainIdentifier> {
+            Ok(Self::mock_chain_id())
+        }
+
         async fn checkpoint(&self, checkpoint: u64) -> CheckpointResult {
             // Check for not found failures
             if let Some(mut remaining) = self.not_found_failures.get_mut(&checkpoint)
@@ -545,7 +618,8 @@ mod tests {
 
         // Fetch and verify
         let result = client.checkpoint(1).await.unwrap();
-        assert_eq!(result.summary.sequence_number(), &1);
+        assert_eq!(result.checkpoint.summary.sequence_number(), &1);
+        assert_eq!(result.chain_id, MockIngestionClient::mock_chain_id());
     }
 
     #[tokio::test]
@@ -558,7 +632,8 @@ mod tests {
 
         // Fetch and verify
         let result = client.checkpoint(1).await.unwrap();
-        assert_eq!(result.summary.sequence_number(), &1);
+        assert_eq!(result.checkpoint.summary.sequence_number(), &1);
+        assert_eq!(result.chain_id, MockIngestionClient::mock_chain_id());
     }
 
     #[tokio::test]
@@ -583,7 +658,8 @@ mod tests {
 
         // Fetch and verify it succeeds after retries
         let result = client.checkpoint(1).await.unwrap();
-        assert_eq!(*result.summary.sequence_number(), 1);
+        assert_eq!(*result.checkpoint.summary.sequence_number(), 1);
+        assert_eq!(result.chain_id, MockIngestionClient::mock_chain_id());
 
         // Verify that exactly 2 retries were recorded
         let retries = client
@@ -607,7 +683,8 @@ mod tests {
 
         // Wait for checkpoint with short retry interval
         let result = client.wait_for(1, Duration::from_millis(50)).await.unwrap();
-        assert_eq!(result.summary.sequence_number(), &1);
+        assert_eq!(result.checkpoint.summary.sequence_number(), &1);
+        assert_eq!(result.chain_id, MockIngestionClient::mock_chain_id());
 
         // Verify that exactly 1 retry was recorded
         let retries = client.metrics.total_ingested_not_found_retries.get();
@@ -626,7 +703,8 @@ mod tests {
 
         // Wait for checkpoint with short retry interval
         let result = client.wait_for(1, Duration::from_millis(50)).await.unwrap();
-        assert_eq!(result.summary.sequence_number(), &1);
+        assert_eq!(result.checkpoint.summary.sequence_number(), &1);
+        assert_eq!(result.chain_id, MockIngestionClient::mock_chain_id());
     }
 
     #[tokio::test]

--- a/crates/sui-indexer-alt-framework/src/ingestion/mod.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/mod.rs
@@ -249,6 +249,7 @@ mod tests {
     use wiremock::Request;
 
     use crate::ingestion::store_client::tests::respond_with;
+    use crate::ingestion::store_client::tests::respond_with_chain_id;
     use crate::ingestion::store_client::tests::status;
     use crate::ingestion::test_utils::test_checkpoint_data;
 
@@ -324,6 +325,7 @@ mod tests {
             status(StatusCode::OK).set_body_bytes(test_checkpoint_data(42)),
         )
         .await;
+        respond_with_chain_id(&server).await;
 
         let mut ingestion_service = test_ingestion(server.uri(), 1, 1).await;
 
@@ -345,6 +347,7 @@ mod tests {
             status(StatusCode::OK).set_body_bytes(test_checkpoint_data(42)),
         )
         .await;
+        respond_with_chain_id(&server).await;
 
         let mut ingestion_service = test_ingestion(server.uri(), 1, 1).await;
 
@@ -372,15 +375,16 @@ mod tests {
             }
         })
         .await;
+        respond_with_chain_id(&server).await;
 
         let mut ingestion_service = test_ingestion(server.uri(), 1, 1).await;
 
         let (rx, _) = ingestion_service.subscribe();
-        let subscriber = test_subscriber(5, rx).await;
+        let subscriber = test_subscriber(6, rx).await;
         let _svc = ingestion_service.run(0.., None).await.unwrap();
 
         let seqs = subscriber.await.unwrap();
-        assert_eq!(seqs, vec![1, 2, 3, 6, 7]);
+        assert_eq!(seqs, vec![0, 1, 2, 3, 6, 7]);
     }
 
     /// Similar to the previous test, but now it's a transient error that causes the retry.
@@ -398,15 +402,16 @@ mod tests {
             }
         })
         .await;
+        respond_with_chain_id(&server).await;
 
         let mut ingestion_service = test_ingestion(server.uri(), 1, 1).await;
 
         let (rx, _) = ingestion_service.subscribe();
-        let subscriber = test_subscriber(5, rx).await;
+        let subscriber = test_subscriber(6, rx).await;
         let _svc = ingestion_service.run(0.., None).await.unwrap();
 
         let seqs = subscriber.await.unwrap();
-        assert_eq!(seqs, vec![1, 2, 3, 6, 7]);
+        assert_eq!(seqs, vec![0, 1, 2, 3, 6, 7]);
     }
 
     /// One subscriber is going to stop processing checkpoints, so even though the service can keep
@@ -422,6 +427,7 @@ mod tests {
             status(StatusCode::OK).set_body_bytes(test_checkpoint_data(*times))
         })
         .await;
+        respond_with_chain_id(&server).await;
 
         let mut ingestion_service = test_ingestion(server.uri(), 3, 1).await;
 
@@ -433,17 +439,18 @@ mod tests {
         }
 
         let (rx, _) = ingestion_service.subscribe();
-        let subscriber = test_subscriber(5, rx).await;
+        let subscriber = test_subscriber(6, rx).await;
         let _svc = ingestion_service.run(0.., None).await.unwrap();
 
         // At this point, the service will have been able to pass 3 checkpoints to the non-lagging
         // subscriber, while the laggard's buffer fills up. Now the laggard will pull two
         // checkpoints, which will allow the rest of the pipeline to progress enough for the live
-        // subscriber to receive its quota.
+        // subscriber to receive its quota. Checkpoint 0 is served by the chain_id mock.
+        assert_eq!(unblock(&mut laggard).await, 0);
         assert_eq!(unblock(&mut laggard).await, 1);
         assert_eq!(unblock(&mut laggard).await, 2);
 
         let seqs = subscriber.await.unwrap();
-        assert_eq!(seqs, vec![1, 2, 3, 4, 5]);
+        assert_eq!(seqs, vec![0, 1, 2, 3, 4, 5]);
     }
 }

--- a/crates/sui-indexer-alt-framework/src/ingestion/rpc_client.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/rpc_client.rs
@@ -4,9 +4,13 @@
 use anyhow::anyhow;
 use async_trait::async_trait;
 use prost_types::FieldMask;
+use std::str::FromStr;
 use sui_rpc::Client as RpcClient;
 use sui_rpc::field::FieldMaskUtil;
 use sui_rpc::proto::sui::rpc::v2::GetCheckpointRequest;
+use sui_rpc::proto::sui::rpc::v2::GetServiceInfoRequest;
+use sui_types::digests::ChainIdentifier;
+use sui_types::digests::CheckpointDigest;
 use sui_types::full_checkpoint_content::Checkpoint;
 use tonic::Code;
 
@@ -17,6 +21,17 @@ use crate::ingestion::ingestion_client::IngestionClientTrait;
 
 #[async_trait]
 impl IngestionClientTrait for RpcClient {
+    async fn chain_id(&self) -> anyhow::Result<ChainIdentifier> {
+        let request = GetServiceInfoRequest::const_default();
+        let response = self
+            .clone()
+            .ledger_client()
+            .get_service_info(request)
+            .await?
+            .into_inner();
+        Ok(CheckpointDigest::from_str(response.chain_id())?.into())
+    }
+
     async fn checkpoint(&self, checkpoint: u64) -> CheckpointResult {
         let request: GetCheckpointRequest = GetCheckpointRequest::by_sequence_number(checkpoint)
             .with_read_mask(FieldMask::from_paths([

--- a/crates/sui-indexer-alt-framework/src/ingestion/store_client.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/store_client.rs
@@ -10,6 +10,7 @@ use object_store::ObjectStoreExt;
 use object_store::RetryConfig;
 use object_store::path::Path as ObjectPath;
 use serde::de::DeserializeOwned;
+use sui_types::digests::ChainIdentifier;
 use tracing::debug;
 use tracing::error;
 
@@ -64,6 +65,11 @@ impl StoreIngestionClient {
 
 #[async_trait::async_trait]
 impl IngestionClientTrait for StoreIngestionClient {
+    async fn chain_id(&self) -> anyhow::Result<ChainIdentifier> {
+        let checkpoint = self.checkpoint(0).await?;
+        Ok((*checkpoint.summary.digest()).into())
+    }
+
     /// Fetch a checkpoint from the remote store.
     ///
     /// Transient errors include:
@@ -106,6 +112,7 @@ pub(crate) mod tests {
     use wiremock::Respond;
     use wiremock::ResponseTemplate;
     use wiremock::matchers::method;
+    use wiremock::matchers::path;
     use wiremock::matchers::path_regex;
 
     use crate::ingestion::error::Error;
@@ -121,6 +128,24 @@ pub(crate) mod tests {
             .respond_with(response)
             .mount(server)
             .await;
+    }
+
+    /// Mount a high-priority mock for checkpoint 0 used by `StoreIngestionClient::chain_id()`.
+    pub(crate) async fn respond_with_chain_id(server: &MockServer) {
+        Mock::given(method("GET"))
+            .and(path("/0.binpb.zst"))
+            .respond_with(status(StatusCode::OK).set_body_bytes(test_checkpoint_data(0)))
+            .with_priority(1)
+            .mount(server)
+            .await;
+    }
+
+    /// Returns the expected chain_id produced by `StoreIngestionClient::chain_id()` when
+    /// `respond_with_chain_id` is mounted.
+    pub(crate) fn expected_chain_id() -> ChainIdentifier {
+        let bytes = test_checkpoint_data(0);
+        let checkpoint = crate::ingestion::decode::checkpoint(&bytes).unwrap();
+        (*checkpoint.summary.digest()).into()
     }
 
     pub(crate) fn status(code: StatusCode) -> ResponseTemplate {
@@ -159,14 +184,13 @@ pub(crate) mod tests {
             let mut times = times.lock().unwrap();
             *times += 1;
             match (*times, r.url.path()) {
-                // The first request will trigger a redirect to 0.binpb.zst no matter what the
-                // original request was for -- triggering a request error.
-                (1, _) => {
-                    status(StatusCode::MOVED_PERMANENTLY).append_header("Location", "/0.binpb.zst")
-                }
+                // The first request will trigger a redirect to 999999.binpb.zst no matter what
+                // the original request was for -- triggering a request error.
+                (1, _) => status(StatusCode::MOVED_PERMANENTLY)
+                    .append_header("Location", "/999999.binpb.zst"),
 
-                // Set-up checkpoint 0 as an infinite redirect loop.
-                (_, "/0.binpb.zst") => {
+                // Set-up checkpoint 999999 as an infinite redirect loop.
+                (_, "/999999.binpb.zst") => {
                     status(StatusCode::MOVED_PERMANENTLY).append_header("Location", r.url.as_str())
                 }
 
@@ -175,11 +199,13 @@ pub(crate) mod tests {
             }
         })
         .await;
+        respond_with_chain_id(&server).await;
 
         let client = remote_test_client(server.uri());
-        let checkpoint = client.checkpoint(42).await.unwrap();
+        let envelope = client.checkpoint(42).await.unwrap();
 
-        assert_eq!(42, checkpoint.summary.sequence_number)
+        assert_eq!(42, envelope.checkpoint.summary.sequence_number);
+        assert_eq!(envelope.chain_id, expected_chain_id());
     }
 
     /// Assume that certain errors will recover by themselves, and keep retrying with an
@@ -200,11 +226,13 @@ pub(crate) mod tests {
             }
         })
         .await;
+        respond_with_chain_id(&server).await;
 
         let client = remote_test_client(server.uri());
-        let checkpoint = client.checkpoint(42).await.unwrap();
+        let envelope = client.checkpoint(42).await.unwrap();
 
-        assert_eq!(42, checkpoint.summary.sequence_number)
+        assert_eq!(42, envelope.checkpoint.summary.sequence_number);
+        assert_eq!(envelope.chain_id, expected_chain_id());
     }
 
     /// Treat deserialization failure as another kind of transient error -- all checkpoint data
@@ -223,11 +251,13 @@ pub(crate) mod tests {
             }
         })
         .await;
+        respond_with_chain_id(&server).await;
 
         let client = remote_test_client(server.uri());
-        let checkpoint = client.checkpoint(42).await.unwrap();
+        let envelope = client.checkpoint(42).await.unwrap();
 
-        assert_eq!(42, checkpoint.summary.sequence_number)
+        assert_eq!(42, envelope.checkpoint.summary.sequence_number);
+        assert_eq!(envelope.chain_id, expected_chain_id());
     }
 
     /// Test that timeout errors are retried as transient errors.
@@ -253,6 +283,7 @@ pub(crate) mod tests {
             }
         })
         .await;
+        respond_with_chain_id(&server).await;
 
         let options = ClientOptions::default()
             .with_allow_http(true)
@@ -267,10 +298,12 @@ pub(crate) mod tests {
             IngestionClient::with_store(store, test_ingestion_metrics()).unwrap();
 
         // This should timeout once, then succeed on retry
-        let checkpoint = ingestion_client.checkpoint(42).await.unwrap();
-        assert_eq!(42, checkpoint.summary.sequence_number);
+        let envelope = ingestion_client.checkpoint(42).await.unwrap();
+        assert_eq!(42, envelope.checkpoint.summary.sequence_number);
+        assert_eq!(envelope.chain_id, expected_chain_id());
 
         // Verify that the server received exactly 2 requests (1 timeout + 1 successful retry)
+        // The chain_id request for checkpoint 0 is handled by a separate mock.
         let final_count = times.load(Ordering::Relaxed);
         assert_eq!(final_count, 2);
     }

--- a/crates/sui-indexer-alt-framework/src/lib.rs
+++ b/crates/sui-indexer-alt-framework/src/lib.rs
@@ -1232,8 +1232,8 @@ mod tests {
         let temp_dir = tempfile::tempdir().unwrap();
         synthetic_ingestion::generate_ingestion(synthetic_ingestion::Config {
             ingestion_dir: temp_dir.path().to_owned(),
-            starting_checkpoint: 5,
-            num_checkpoints: 25,
+            starting_checkpoint: 0,
+            num_checkpoints: 30,
             checkpoint_size: 1,
         })
         .await;
@@ -1374,8 +1374,8 @@ mod tests {
         let temp_dir = tempfile::tempdir().unwrap();
         synthetic_ingestion::generate_ingestion(synthetic_ingestion::Config {
             ingestion_dir: temp_dir.path().to_owned(),
-            starting_checkpoint: 5,
-            num_checkpoints: 25,
+            starting_checkpoint: 0,
+            num_checkpoints: 30,
             checkpoint_size: 1,
         })
         .await;
@@ -1639,8 +1639,8 @@ mod tests {
         let temp_dir = tempfile::tempdir().unwrap();
         synthetic_ingestion::generate_ingestion(synthetic_ingestion::Config {
             ingestion_dir: temp_dir.path().to_owned(),
-            starting_checkpoint: 5,
-            num_checkpoints: 25,
+            starting_checkpoint: 0,
+            num_checkpoints: 30,
             checkpoint_size: 1,
         })
         .await;
@@ -2009,8 +2009,8 @@ mod tests {
         let temp_dir = tempfile::tempdir().unwrap();
         synthetic_ingestion::generate_ingestion(synthetic_ingestion::Config {
             ingestion_dir: temp_dir.path().to_owned(),
-            starting_checkpoint: 9,
-            num_checkpoints: 17,
+            starting_checkpoint: 0,
+            num_checkpoints: 26,
             checkpoint_size: 2,
         })
         .await;

--- a/crates/sui-indexer-alt/src/bootstrap.rs
+++ b/crates/sui-indexer-alt/src/bootstrap.rs
@@ -71,17 +71,17 @@ pub async fn bootstrap(
         // - Get the Genesis system transaction from the genesis checkpoint.
         // - Get the system state object that was written out by the system transaction.
         None => {
-            let genesis_checkpoint = indexer
+            let genesis_checkpoint_envelope = indexer
                 .ingestion_client()
                 .wait_for(0, retry_interval)
                 .await
                 .context("Failed to fetch genesis checkpoint")?;
 
             let Checkpoint {
-                summary: checkpoint_summary,
                 transactions,
+                object_set,
                 ..
-            } = genesis_checkpoint.as_ref();
+            } = genesis_checkpoint_envelope.checkpoint.as_ref();
 
             let Some(genesis_transaction) = transactions
                 .iter()
@@ -91,7 +91,7 @@ pub async fn bootstrap(
             };
 
             let output_objects: Vec<_> = genesis_transaction
-                .output_objects(&genesis_checkpoint.object_set)
+                .output_objects(object_set)
                 .cloned()
                 .collect();
 
@@ -99,7 +99,7 @@ pub async fn bootstrap(
                 .context("Failed to get Genesis SystemState")?;
 
             let stored_genesis = StoredGenesis {
-                genesis_digest: checkpoint_summary.digest().inner().to_vec(),
+                genesis_digest: genesis_checkpoint_envelope.chain_id.as_bytes().to_vec(),
                 initial_protocol_version: sui_system_state.protocol_version() as i64,
             };
             let stored_epoch_start = StoredEpochStart {


### PR DESCRIPTION
## Description 

This PR adds a new `chain_id()` method to `IngestionClientTrait`. The `IngestionClient` calls this method the first time it is used and caches it to return in the `CheckpiontEnvelope`. 

`IngestionClient` callers currently ignore the `chain_id`.

## Test plan 

Updated existing tests with chain_id assertions and mock the chain_id reponse.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [x] Indexing Framework: Adds new `IngestionClientTrait::chain_id` to retrieve the `chain_id` from that ingestion source.
