### PR TITLE
sui-indexer-alt-framework: add chain_id to CheckpointStreamingClient

### DIFF
--- a/crates/sui-indexer-alt-framework/src/ingestion/broadcaster.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/broadcaster.rs
@@ -24,10 +24,11 @@ use tracing::warn;
 use crate::config::ConcurrencyConfig;
 use crate::ingestion::IngestionConfig;
 use crate::ingestion::error::Error;
+use crate::ingestion::ingestion_client::CheckpointEnvelope;
 use crate::ingestion::ingestion_client::IngestionClient;
+use crate::ingestion::streaming_client::CheckpointStream;
 use crate::ingestion::streaming_client::CheckpointStreamingClient;
 use crate::metrics::IngestionMetrics;
-use crate::types::full_checkpoint_content::Checkpoint;
 
 /// Broadcaster task that manages checkpoint flow and spawns broadcast tasks for ranges
 /// via either streaming or ingesting, or both.
@@ -51,7 +52,7 @@ pub(super) fn broadcaster<R, S>(
     config: IngestionConfig,
     client: IngestionClient,
     mut commit_hi_rx: mpsc::UnboundedReceiver<(&'static str, u64)>,
-    subscribers: Vec<mpsc::Sender<Arc<Checkpoint>>>,
+    subscribers: Vec<mpsc::Sender<Arc<CheckpointEnvelope>>>,
     metrics: Arc<IngestionMetrics>,
 ) -> Service
 where
@@ -221,7 +222,7 @@ fn ingest_and_broadcast_range(
     ingest_concurrency: ConcurrencyConfig,
     ingest_hi_rx: Option<watch::Receiver<u64>>,
     client: IngestionClient,
-    subscribers: Arc<Vec<mpsc::Sender<Arc<Checkpoint>>>>,
+    subscribers: Arc<Vec<mpsc::Sender<Arc<CheckpointEnvelope>>>>,
     metrics: Arc<IngestionMetrics>,
 ) -> TaskGuard<Result<(), Break<Error>>> {
     TaskGuard::new(tokio::spawn(async move {
@@ -237,7 +238,7 @@ fn ingest_and_broadcast_range(
                         // Fetch the checkpoint or stop if cancelled.
                         let checkpoint_envelope = client.wait_for(cp, retry_interval).await?;
                         debug!(checkpoint = cp, "Fetched checkpoint");
-                        Ok(checkpoint_envelope.checkpoint)
+                        Ok(Arc::new(checkpoint_envelope))
                     }
                 },
                 Arc::unwrap_or_clone(subscribers),
@@ -263,7 +264,7 @@ async fn setup_streaming_task<S>(
     end_cp: u64,
     streaming_backoff_batch_size: &mut u64,
     config: &IngestionConfig,
-    subscribers: &Arc<Vec<mpsc::Sender<Arc<Checkpoint>>>>,
+    subscribers: &Arc<Vec<mpsc::Sender<Arc<CheckpointEnvelope>>>>,
     ingest_hi_rx: Option<watch::Receiver<u64>>,
     metrics: &Arc<IngestionMetrics>,
 ) -> (TaskGuard<u64>, u64)
@@ -292,22 +293,30 @@ where
 
     // Wrap the stream with a statement timeout to prevent hanging indefinitely, and then make it
     // peekable.
-    let mut stream = Box::pin(match streaming_client.connect().await {
-        Ok(stream) => stream
-            .timeout(config.streaming_statement_timeout())
-            .map(|res| {
-                res.map_err(|_| Error::StreamingError(anyhow!("Connection timeout")))
-                    .flatten()
-            }),
-
+    let CheckpointStream { stream, chain_id } = match streaming_client.connect().await {
+        Ok(checkpoint_stream) => checkpoint_stream,
         Err(e) => {
             return fallback(&format!("Streaming connection failed: {e}"));
         }
-    })
+    };
+
+    let mut checkpoint_envelope_stream = Box::pin(
+        stream
+            .timeout(config.streaming_statement_timeout())
+            .map(move |result| {
+                result
+                    .map_err(|_| Error::StreamingError(anyhow!("Connection timeout")))
+                    .flatten()
+                    .map(|checkpoint| CheckpointEnvelope {
+                        checkpoint: Arc::new(checkpoint),
+                        chain_id,
+                    })
+            }),
+    )
     .peekable();
 
-    let checkpoint = match stream.peek().await {
-        Some(Ok(checkpoint)) => checkpoint,
+    let checkpoint_envelope = match checkpoint_envelope_stream.peek().await {
+        Some(Ok(checkpoint_envelope)) => checkpoint_envelope,
         Some(Err(e)) => {
             return fallback(&format!("Failed to peek latest checkpoint: {e}"));
         }
@@ -319,7 +328,7 @@ where
     // We have successfully connected and peeked, reset backoff batch size.
     *streaming_backoff_batch_size = config.streaming_backoff_initial_batch_size as u64;
 
-    let network_latest_cp = *checkpoint.summary.sequence_number();
+    let network_latest_cp = *checkpoint_envelope.checkpoint.summary.sequence_number();
     let ingestion_end = network_latest_cp.min(end_cp);
     if network_latest_cp > checkpoint_hi + config.checkpoint_buffer_size as u64 {
         info!(
@@ -337,7 +346,7 @@ where
     let stream_guard = TaskGuard::new(tokio::spawn(stream_and_broadcast_range(
         network_latest_cp.max(checkpoint_hi),
         end_cp,
-        stream,
+        checkpoint_envelope_stream,
         subscribers.clone(),
         ingest_hi_rx,
         metrics.clone(),
@@ -354,8 +363,8 @@ where
 async fn stream_and_broadcast_range(
     mut lo: u64,
     hi: u64,
-    mut stream: impl Stream<Item = Result<Checkpoint, Error>> + Unpin,
-    subscribers: Arc<Vec<mpsc::Sender<Arc<Checkpoint>>>>,
+    mut stream: impl Stream<Item = Result<CheckpointEnvelope, Error>> + Unpin,
+    subscribers: Arc<Vec<mpsc::Sender<Arc<CheckpointEnvelope>>>>,
     mut ingest_hi_rx: Option<watch::Receiver<u64>>,
     metrics: Arc<IngestionMetrics>,
 ) -> u64 {
@@ -365,15 +374,15 @@ async fn stream_and_broadcast_range(
             break;
         };
 
-        let checkpoint = match item {
-            Ok(checkpoint) => checkpoint,
+        let checkpoint_envelope = match item {
+            Ok(checkpoint_envelope) => checkpoint_envelope,
             Err(e) => {
                 warn!(lo, "Streaming error: {e}");
                 break;
             }
         };
 
-        let sequence_number = *checkpoint.summary.sequence_number();
+        let sequence_number = *checkpoint_envelope.checkpoint.summary.sequence_number();
 
         if sequence_number < lo {
             debug!(
@@ -398,7 +407,7 @@ async fn stream_and_broadcast_range(
             break;
         }
 
-        if send_checkpoint(Arc::new(checkpoint), &subscribers)
+        if send_checkpoint(Arc::new(checkpoint_envelope), &subscribers)
             .await
             .is_err()
         {
@@ -420,10 +429,12 @@ async fn stream_and_broadcast_range(
 /// Send a checkpoint to all subscribers.
 /// Returns an error if any subscriber's channel is closed.
 async fn send_checkpoint(
-    checkpoint: Arc<Checkpoint>,
-    subscribers: &[mpsc::Sender<Arc<Checkpoint>>],
-) -> Result<Vec<()>, mpsc::error::SendError<Arc<Checkpoint>>> {
-    let futures = subscribers.iter().map(|s| s.send(checkpoint.clone()));
+    checkpoint_envelope: Arc<CheckpointEnvelope>,
+    subscribers: &[mpsc::Sender<Arc<CheckpointEnvelope>>],
+) -> Result<Vec<()>, mpsc::error::SendError<Arc<CheckpointEnvelope>>> {
+    let futures = subscribers
+        .iter()
+        .map(|s| s.send(checkpoint_envelope.clone()));
     try_join_all(futures).await
 }
 
@@ -504,26 +515,38 @@ mod tests {
 
     /// Receive `count` checkpoints from the channel and return their sequence numbers as a Vec.
     /// Maintains order, useful for verifying sequential delivery (e.g., from streaming).
-    async fn recv_vec(rx: &mut mpsc::Receiver<Arc<Checkpoint>>, count: usize) -> Vec<u64> {
+    async fn recv_vec(rx: &mut mpsc::Receiver<Arc<CheckpointEnvelope>>, count: usize) -> Vec<u64> {
         let mut result = Vec::with_capacity(count);
         for _ in 0..count {
-            let checkpoint = expect_recv(rx).await.unwrap();
-            result.push(*checkpoint.summary.sequence_number());
+            let checkpoint_envelope = expect_recv(rx).await.unwrap();
+            assert_eq!(
+                checkpoint_envelope.chain_id,
+                MockStreamingClient::mock_chain_id()
+            );
+            result.push(*checkpoint_envelope.checkpoint.summary.sequence_number());
         }
         result
     }
 
     /// Receive `count` checkpoints from the channel and return their sequence numbers as a BTreeSet.
     /// Useful for verifying unordered delivery (e.g., from concurrent ingestion).
-    async fn recv_set(rx: &mut mpsc::Receiver<Arc<Checkpoint>>, count: usize) -> BTreeSet<u64> {
+    async fn recv_set(
+        rx: &mut mpsc::Receiver<Arc<CheckpointEnvelope>>,
+        count: usize,
+    ) -> BTreeSet<u64> {
         let mut result = BTreeSet::new();
         for _ in 0..count {
-            let checkpoint = expect_recv(rx).await.unwrap();
-            let inserted = result.insert(*checkpoint.summary.sequence_number());
+            let checkpoint_envelope = expect_recv(rx).await.unwrap();
+            assert_eq!(
+                checkpoint_envelope.chain_id,
+                MockStreamingClient::mock_chain_id()
+            );
+            let sequence_number = *checkpoint_envelope.checkpoint.summary.sequence_number();
+            let inserted = result.insert(sequence_number);
             assert!(
                 inserted,
                 "Received duplicate checkpoint {}",
-                checkpoint.summary.sequence_number()
+                sequence_number
             );
         }
         result
@@ -746,16 +769,24 @@ mod tests {
 
         // But updating a's watermark does.
         hi_tx.send(("a", 3)).unwrap();
-        let checkpoint = expect_recv(&mut subscriber_rx).await.unwrap();
-        assert_eq!(*checkpoint.summary.sequence_number(), 2);
+        let checkpoint_envelope = expect_recv(&mut subscriber_rx).await.unwrap();
+        assert_eq!(*checkpoint_envelope.checkpoint.summary.sequence_number(), 2);
+        assert_eq!(
+            checkpoint_envelope.chain_id,
+            MockStreamingClient::mock_chain_id()
+        );
 
         // ...by one checkpoint.
         expect_timeout(&mut subscriber_rx).await;
 
         // And we can make more progress by updating it again.
         hi_tx.send(("a", 4)).unwrap();
-        let checkpoint = expect_recv(&mut subscriber_rx).await.unwrap();
-        assert_eq!(*checkpoint.summary.sequence_number(), 3);
+        let checkpoint_envelope = expect_recv(&mut subscriber_rx).await.unwrap();
+        assert_eq!(*checkpoint_envelope.checkpoint.summary.sequence_number(), 3);
+        assert_eq!(
+            checkpoint_envelope.chain_id,
+            MockStreamingClient::mock_chain_id()
+        );
 
         // But another update to "a" will now not make a difference, because "b" is still behind.
         hi_tx.send(("a", 5)).unwrap();

--- a/crates/sui-indexer-alt-framework/src/ingestion/mod.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/mod.rs
@@ -19,12 +19,12 @@ pub use crate::config::ConcurrencyConfig as IngestConcurrencyConfig;
 use crate::ingestion::broadcaster::broadcaster;
 use crate::ingestion::error::Error;
 use crate::ingestion::error::Result;
+use crate::ingestion::ingestion_client::CheckpointEnvelope;
 use crate::ingestion::ingestion_client::IngestionClient;
 use crate::ingestion::ingestion_client::IngestionClientArgs;
 use crate::ingestion::streaming_client::GrpcStreamingClient;
 use crate::ingestion::streaming_client::StreamingClientArgs;
 use crate::metrics::IngestionMetrics;
-use crate::types::full_checkpoint_content::Checkpoint;
 
 mod broadcaster;
 pub(crate) mod decode;
@@ -81,7 +81,7 @@ pub struct IngestionService {
     streaming_client: Option<GrpcStreamingClient>,
     commit_hi_tx: mpsc::UnboundedSender<(&'static str, u64)>,
     commit_hi_rx: mpsc::UnboundedReceiver<(&'static str, u64)>,
-    subscribers: Vec<mpsc::Sender<Arc<Checkpoint>>>,
+    subscribers: Vec<mpsc::Sender<Arc<CheckpointEnvelope>>>,
     metrics: Arc<IngestionMetrics>,
 }
 
@@ -157,7 +157,7 @@ impl IngestionService {
     pub fn subscribe(
         &mut self,
     ) -> (
-        mpsc::Receiver<Arc<Checkpoint>>,
+        mpsc::Receiver<Arc<CheckpointEnvelope>>,
         mpsc::UnboundedSender<(&'static str, u64)>,
     ) {
         let (sender, receiver) = mpsc::channel(self.config.checkpoint_buffer_size);
@@ -284,16 +284,16 @@ mod tests {
 
     async fn test_subscriber(
         stop_after: usize,
-        mut rx: mpsc::Receiver<Arc<Checkpoint>>,
+        mut rx: mpsc::Receiver<Arc<CheckpointEnvelope>>,
     ) -> TaskGuard<Vec<u64>> {
         TaskGuard::new(tokio::spawn(async move {
             let mut seqs = vec![];
             for _ in 0..stop_after {
-                let Some(checkpoint) = rx.recv().await else {
+                let Some(checkpoint_envelope) = rx.recv().await else {
                     break;
                 };
 
-                seqs.push(checkpoint.summary.sequence_number);
+                seqs.push(checkpoint_envelope.checkpoint.summary.sequence_number);
             }
 
             seqs
@@ -433,9 +433,9 @@ mod tests {
 
         // This subscriber will take its sweet time processing checkpoints.
         let (mut laggard, _) = ingestion_service.subscribe();
-        async fn unblock(laggard: &mut mpsc::Receiver<Arc<Checkpoint>>) -> u64 {
-            let checkpoint = laggard.recv().await.unwrap();
-            checkpoint.summary.sequence_number
+        async fn unblock(laggard: &mut mpsc::Receiver<Arc<CheckpointEnvelope>>) -> u64 {
+            let checkpoint_envelope = laggard.recv().await.unwrap();
+            checkpoint_envelope.checkpoint.summary.sequence_number
         }
 
         let (rx, _) = ingestion_service.subscribe();

--- a/crates/sui-indexer-alt-framework/src/ingestion/streaming_client.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/streaming_client.rs
@@ -5,11 +5,15 @@ use std::pin::Pin;
 use std::time::Duration;
 
 use anyhow::Context;
+use anyhow::anyhow;
 use async_trait::async_trait;
 use futures::Stream;
 use futures::StreamExt;
+use sui_rpc::headers::X_SUI_CHAIN_ID;
 use sui_rpc::proto::sui::rpc::v2::SubscribeCheckpointsRequest;
 use sui_rpc::proto::sui::rpc::v2::subscription_service_client::SubscriptionServiceClient;
+use sui_types::digests::ChainIdentifier;
+use sui_types::messages_checkpoint::CheckpointDigest;
 use tonic::Status;
 use tonic::transport::Endpoint;
 use tonic::transport::Uri;
@@ -19,12 +23,15 @@ use crate::ingestion::error::Error;
 use crate::ingestion::error::Result;
 use crate::types::full_checkpoint_content::Checkpoint;
 
-/// Type alias for a stream of checkpoint data.
-pub type CheckpointStream = Pin<Box<dyn Stream<Item = Result<Checkpoint>> + Send>>;
+pub struct CheckpointStream {
+    pub stream: Pin<Box<dyn Stream<Item = Result<Checkpoint>> + Send>>,
+    pub chain_id: ChainIdentifier,
+}
 
 /// Trait representing a client for streaming checkpoint data.
 #[async_trait]
 pub trait CheckpointStreamingClient {
+    /// Returns the CheckpointStream and chain id.
     async fn connect(&mut self) -> Result<CheckpointStream>;
 }
 
@@ -63,13 +70,22 @@ impl CheckpointStreamingClient for GrpcStreamingClient {
         let mut request = SubscribeCheckpointsRequest::default();
         request.read_mask = Some(Checkpoint::proto_field_mask());
 
-        let stream = client
+        let response = client
             .subscribe_checkpoints(request)
             .await
-            .map_err(Error::RpcClientError)?
-            .into_inner();
+            .map_err(Error::RpcClientError)?;
 
-        let converted_stream = stream.map(|result| match result {
+        let chain_id_value = response.metadata().get(X_SUI_CHAIN_ID).ok_or_else(|| {
+            Error::StreamingError(anyhow!("Chain ID not found in response metadata"))
+        })?;
+        let chain_id: ChainIdentifier = chain_id_value
+            .to_str()
+            .map_err(|e| Error::StreamingError(anyhow!("Chain ID is not valid ASCII: {e}")))?
+            .parse::<CheckpointDigest>()
+            .map_err(|e| Error::StreamingError(anyhow!("Chain ID parse error: {e}")))?
+            .into();
+
+        let converted_stream = response.into_inner().map(|result| match result {
             Ok(response) => response
                 .checkpoint
                 .context("Checkpoint data missing in response")
@@ -80,7 +96,10 @@ impl CheckpointStreamingClient for GrpcStreamingClient {
             Err(e) => Err(Error::RpcClientError(e)),
         });
 
-        Ok(Box::pin(converted_stream))
+        Ok(CheckpointStream {
+            stream: Box::pin(converted_stream),
+            chain_id,
+        })
     }
 }
 
@@ -165,6 +184,10 @@ pub mod test_utils {
     }
 
     impl MockStreamingClient {
+        pub fn mock_chain_id() -> ChainIdentifier {
+            CheckpointDigest::new([1; 32]).into()
+        }
+
         pub fn new<I>(checkpoint_range: I, timeout_duration: Option<Duration>) -> Self
         where
             I: IntoIterator<Item = u64>,
@@ -245,11 +268,14 @@ pub mod test_utils {
                     "Mock connection failure"
                 )));
             }
-            let stream = MockStreamState {
+            let stream = Box::pin(MockStreamState {
                 actions: Arc::clone(&self.actions),
-            };
+            });
 
-            Ok(Box::pin(stream))
+            Ok(CheckpointStream {
+                stream,
+                chain_id: Self::mock_chain_id(),
+            })
         }
     }
 }

--- a/crates/sui-indexer-alt-framework/src/pipeline/concurrent/mod.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/concurrent/mod.rs
@@ -14,6 +14,7 @@ use tracing::info;
 
 use crate::Task;
 use crate::config::ConcurrencyConfig;
+use crate::ingestion::ingestion_client::CheckpointEnvelope;
 use crate::metrics::IndexerMetrics;
 use crate::pipeline::CommitterConfig;
 use crate::pipeline::Processor;
@@ -26,7 +27,6 @@ use crate::pipeline::concurrent::pruner::pruner;
 use crate::pipeline::concurrent::reader_watermark::reader_watermark;
 use crate::pipeline::processor::processor;
 use crate::store::Store;
-use crate::types::full_checkpoint_content::Checkpoint;
 
 mod collector;
 mod commit_watermark;
@@ -238,7 +238,7 @@ pub(crate) fn pipeline<H: Handler + Send + Sync + 'static>(
     config: ConcurrentConfig,
     store: H::Store,
     task: Option<Task>,
-    checkpoint_rx: mpsc::Receiver<Arc<Checkpoint>>,
+    checkpoint_rx: mpsc::Receiver<Arc<CheckpointEnvelope>>,
     metrics: Arc<IndexerMetrics>,
 ) -> Service {
     info!(
@@ -345,6 +345,7 @@ mod tests {
     use std::time::Duration;
 
     use prometheus::Registry;
+    use sui_types::digests::CheckpointDigest;
     use tokio::sync::mpsc;
     use tokio::time::timeout;
 
@@ -441,7 +442,7 @@ mod tests {
 
     struct TestSetup {
         store: MockStore,
-        checkpoint_tx: mpsc::Sender<Arc<Checkpoint>>,
+        checkpoint_tx: mpsc::Sender<Arc<CheckpointEnvelope>>,
         #[allow(unused)]
         pipeline: Service,
     }
@@ -469,14 +470,17 @@ mod tests {
         }
 
         async fn send_checkpoint(&self, checkpoint: u64) -> anyhow::Result<()> {
-            let checkpoint = Arc::new(
-                TestCheckpointBuilder::new(checkpoint)
-                    .with_epoch(1)
-                    .with_network_total_transactions(checkpoint * 2)
-                    .with_timestamp_ms(1000000000 + checkpoint * 1000)
-                    .build_checkpoint(),
-            );
-            self.checkpoint_tx.send(checkpoint).await?;
+            let checkpoint_envelope = Arc::new(CheckpointEnvelope {
+                checkpoint: Arc::new(
+                    TestCheckpointBuilder::new(checkpoint)
+                        .with_epoch(1)
+                        .with_network_total_transactions(checkpoint * 2)
+                        .with_timestamp_ms(1000000000 + checkpoint * 1000)
+                        .build_checkpoint(),
+                ),
+                chain_id: CheckpointDigest::new([1; 32]).into(),
+            });
+            self.checkpoint_tx.send(checkpoint_envelope).await?;
             Ok(())
         }
 

--- a/crates/sui-indexer-alt-framework/src/pipeline/processor.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/processor.rs
@@ -18,6 +18,7 @@ use tracing::info;
 use async_trait::async_trait;
 
 use crate::config::ConcurrencyConfig;
+use crate::ingestion::ingestion_client::CheckpointEnvelope;
 use crate::metrics::CheckpointLagMetricReporter;
 use crate::metrics::IndexerMetrics;
 use crate::pipeline::IndexedCheckpoint;
@@ -61,7 +62,7 @@ pub trait Processor: Send + Sync + 'static {
 /// channel.
 pub(super) fn processor<P: Processor>(
     processor: Arc<P>,
-    rx: mpsc::Receiver<Arc<Checkpoint>>,
+    rx: mpsc::Receiver<Arc<CheckpointEnvelope>>,
     tx: mpsc::Sender<IndexedCheckpoint<P>>,
     metrics: Arc<IndexerMetrics>,
     concurrency: ConcurrencyConfig,
@@ -78,7 +79,7 @@ pub(super) fn processor<P: Processor>(
         match ReceiverStream::new(rx)
             .try_for_each_send_spawned(
                 concurrency.into(),
-                |checkpoint| {
+                |checkpoint_envelope| {
                     let metrics = metrics.clone();
                     let checkpoint_lag_reporter = checkpoint_lag_reporter.clone();
                     let processor = processor.clone();
@@ -103,6 +104,7 @@ pub(super) fn processor<P: Processor>(
                             ..Default::default()
                         };
 
+                        let checkpoint = checkpoint_envelope.checkpoint.clone();
                         let checkpoint_sequence_number = checkpoint.summary.sequence_number;
                         let retry_metrics = metrics.clone();
                         let values = backoff::future::retry_notify(
@@ -198,6 +200,7 @@ mod tests {
     use std::time::Duration;
 
     use anyhow::ensure;
+    use sui_types::digests::ChainIdentifier;
     use sui_types::test_checkpoint_data_builder::TestCheckpointBuilder;
     use tokio::sync::mpsc;
     use tokio::time::timeout;
@@ -233,20 +236,26 @@ mod tests {
     #[tokio::test]
     async fn test_processor_process_checkpoints() {
         // Build two checkpoints using the test builder
-        let checkpoint1: Arc<Checkpoint> = Arc::new(
-            TestCheckpointBuilder::new(1)
-                .with_epoch(2)
-                .with_network_total_transactions(5)
-                .with_timestamp_ms(1000000001)
-                .build_checkpoint(),
-        );
-        let checkpoint2: Arc<Checkpoint> = Arc::new(
-            TestCheckpointBuilder::new(2)
-                .with_epoch(2)
-                .with_network_total_transactions(10)
-                .with_timestamp_ms(1000000002)
-                .build_checkpoint(),
-        );
+        let checkpoint_envelope_1 = Arc::new(CheckpointEnvelope {
+            checkpoint: Arc::new(
+                TestCheckpointBuilder::new(1)
+                    .with_epoch(2)
+                    .with_network_total_transactions(5)
+                    .with_timestamp_ms(1000000001)
+                    .build_checkpoint(),
+            ),
+            chain_id: ChainIdentifier::default(),
+        });
+        let checkpoint_envelope_2 = Arc::new(CheckpointEnvelope {
+            checkpoint: Arc::new(
+                TestCheckpointBuilder::new(2)
+                    .with_epoch(2)
+                    .with_network_total_transactions(10)
+                    .with_timestamp_ms(1000000002)
+                    .build_checkpoint(),
+            ),
+            chain_id: ChainIdentifier::default(),
+        });
 
         // Set up the processor, channels, and metrics
         let processor = Arc::new(DataPipeline);
@@ -264,8 +273,8 @@ mod tests {
         );
 
         // Send both checkpoints
-        data_tx.send(checkpoint1.clone()).await.unwrap();
-        data_tx.send(checkpoint2.clone()).await.unwrap();
+        data_tx.send(checkpoint_envelope_1).await.unwrap();
+        data_tx.send(checkpoint_envelope_2).await.unwrap();
 
         // Receive and verify first checkpoint
         let indexed1 = indexed_rx
@@ -303,10 +312,14 @@ mod tests {
     #[tokio::test]
     async fn test_processor_does_not_process_checkpoint_after_cancellation() {
         // Build two checkpoints using the test builder
-        let checkpoint1: Arc<Checkpoint> =
-            Arc::new(TestCheckpointBuilder::new(1).build_checkpoint());
-        let checkpoint2: Arc<Checkpoint> =
-            Arc::new(TestCheckpointBuilder::new(2).build_checkpoint());
+        let checkpoint_envelope_1 = Arc::new(CheckpointEnvelope {
+            checkpoint: Arc::new(TestCheckpointBuilder::new(1).build_checkpoint()),
+            chain_id: ChainIdentifier::default(),
+        });
+        let checkpoint_envelope_2 = Arc::new(CheckpointEnvelope {
+            checkpoint: Arc::new(TestCheckpointBuilder::new(2).build_checkpoint()),
+            chain_id: ChainIdentifier::default(),
+        });
 
         // Set up the processor, channels, and metrics
         let processor = Arc::new(DataPipeline);
@@ -324,7 +337,7 @@ mod tests {
         );
 
         // Send first checkpoint.
-        data_tx.send(checkpoint1.clone()).await.unwrap();
+        data_tx.send(checkpoint_envelope_1).await.unwrap();
 
         // Receive and verify first checkpoint
         let indexed1 = indexed_rx
@@ -338,7 +351,7 @@ mod tests {
 
         // Sending second checkpoint after shutdown should fail, because the data_rx channel is
         // closed.
-        data_tx.send(checkpoint2.clone()).await.unwrap_err();
+        data_tx.send(checkpoint_envelope_2).await.unwrap_err();
 
         // Indexed channel is closed, and indexed_rx receives the last None result.
         let next_result = indexed_rx.recv().await;
@@ -373,10 +386,14 @@ mod tests {
         }
 
         // Set up test data
-        let checkpoint1: Arc<Checkpoint> =
-            Arc::new(TestCheckpointBuilder::new(1).build_checkpoint());
-        let checkpoint2: Arc<Checkpoint> =
-            Arc::new(TestCheckpointBuilder::new(2).build_checkpoint());
+        let checkpoint1 = Arc::new(CheckpointEnvelope {
+            checkpoint: Arc::new(TestCheckpointBuilder::new(1).build_checkpoint()),
+            chain_id: ChainIdentifier::default(),
+        });
+        let checkpoint2 = Arc::new(CheckpointEnvelope {
+            checkpoint: Arc::new(TestCheckpointBuilder::new(2).build_checkpoint()),
+            chain_id: ChainIdentifier::default(),
+        });
 
         let attempt_count = Arc::new(AtomicU32::new(0));
         let processor = Arc::new(RetryTestPipeline {
@@ -450,8 +467,13 @@ mod tests {
         }
 
         // Set up test data
-        let checkpoints: Vec<Arc<Checkpoint>> = (0..5)
-            .map(|i| Arc::new(TestCheckpointBuilder::new(i).build_checkpoint()))
+        let checkpoints: Vec<Arc<CheckpointEnvelope>> = (0..5)
+            .map(|i| {
+                Arc::new(CheckpointEnvelope {
+                    checkpoint: Arc::new(TestCheckpointBuilder::new(i).build_checkpoint()),
+                    chain_id: ChainIdentifier::default(),
+                })
+            })
             .collect();
 
         // Set up channels and metrics

--- a/crates/sui-indexer-alt-framework/src/pipeline/sequential/mod.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/sequential/mod.rs
@@ -11,6 +11,7 @@ use tokio::sync::mpsc;
 use tracing::info;
 
 use crate::config::ConcurrencyConfig;
+use crate::ingestion::ingestion_client::CheckpointEnvelope;
 use crate::metrics::IndexerMetrics;
 use crate::pipeline::CommitterConfig;
 use crate::pipeline::Processor;
@@ -18,7 +19,6 @@ use crate::pipeline::processor::processor;
 use crate::pipeline::sequential::committer::committer;
 use crate::store::Store;
 use crate::store::TransactionalStore;
-use crate::types::full_checkpoint_content::Checkpoint;
 
 mod committer;
 
@@ -128,7 +128,7 @@ pub(crate) fn pipeline<H: Handler + Send + Sync + 'static>(
     next_checkpoint: u64,
     config: SequentialConfig,
     db: H::Store,
-    checkpoint_rx: mpsc::Receiver<Arc<Checkpoint>>,
+    checkpoint_rx: mpsc::Receiver<Arc<CheckpointEnvelope>>,
     commit_hi_tx: mpsc::UnboundedSender<(&'static str, u64)>,
     metrics: Arc<IndexerMetrics>,
 ) -> Service {


### PR DESCRIPTION
## Description 

This continues the work started in #25895 by adding a `chain_id` response header that the `CheckpointStreamingClient` reads. The `chain_id` is plumbed through to the `Processor` alongside `checkpoint`.

The `processor`'s `Service` currently ignores the `chain_id`.

This change depends on https://github.com/MystenLabs/sui/pull/25908.

## Test plan 

Updated existing unit tests to assert the `chain_id` is passed along with the `checkpoint`.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [x] Indexing Framework: Changed `Processor`'s receiver to accept new `CheckpointEnvelope` type containing the `chain_id`.
