### PR TITLE
refactor(display): RpcVisitor Writer -> Format + Meter

### DIFF
--- a/crates/sui-display/src/v2/error.rs
+++ b/crates/sui-display/src/v2/error.rs
@@ -299,8 +299,24 @@ impl fmt::Display for ExpectedSet {
 }
 
 impl From<RV::Error> for FormatError {
-    fn from(RV::Error: RV::Error) -> Self {
-        FormatError::Bcs(bcs::Error::Custom("unexpected type".to_string()))
+    fn from(error: RV::Error) -> Self {
+        match error {
+            RV::Error::Visitor(err) => err.into(),
+            RV::Error::Option(err) => err.into(),
+            RV::Error::Meter(err) => err.into(),
+            RV::Error::UnexpectedType => {
+                FormatError::Bcs(bcs::Error::Custom("unexpected type".to_string()))
+            }
+        }
+    }
+}
+
+impl From<RV::MeterError> for FormatError {
+    fn from(error: RV::MeterError) -> Self {
+        match error {
+            RV::MeterError::TooBig => FormatError::TooBig,
+            RV::MeterError::TooDeep => FormatError::TooDeep,
+        }
     }
 }
 

--- a/crates/sui-display/src/v2/mod.rs
+++ b/crates/sui-display/src/v2/mod.rs
@@ -2,19 +2,18 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::sync::Arc;
+use std::sync::atomic::AtomicUsize;
 
 use futures::future::try_join_all;
 use futures::join;
 use indexmap::IndexMap;
+use sui_types::object::rpc_visitor as RV;
 
 use crate::v2::meter::Meter;
 use crate::v2::parser::Chain;
 use crate::v2::parser::Literal;
 use crate::v2::parser::Parser;
 use crate::v2::parser::Strand;
-use crate::v2::writer::JsonValue;
-use crate::v2::writer::Writer;
-
 mod error;
 mod interpreter;
 mod lexer;
@@ -122,18 +121,19 @@ impl<'s> Format<'s> {
     }
 
     /// Evaluate the format string returning a formatted JSON value.
-    pub async fn format<V: JsonValue>(
+    pub async fn format<V: RV::Format>(
         &'s self,
         interpreter: &'s Interpreter<impl Store>,
         max_depth: usize,
         max_output_size: usize,
     ) -> Result<V, FormatError> {
-        let writer = Writer::new(max_depth, max_output_size);
+        let used_size = AtomicUsize::new(0);
+        let mut meter = writer::Meter::new(&used_size, max_output_size, max_depth);
         let Some(value) = interpreter.eval_strands(&self.0).await? else {
-            return Ok(V::null());
+            return Ok(V::null(&mut meter)?);
         };
 
-        writer.write(value)
+        writer::write(meter, value)
     }
 }
 
@@ -179,33 +179,37 @@ impl<'s> Display<'s> {
     /// This operation requires all field names to evaluate successfully to unique strings, and for
     /// the overall output to be bounded by `max_depth` and `max_output_size`, but otherwise
     /// supports partial failures (if one of the field values fails to parse or evaluate).
-    pub async fn display<V: JsonValue>(
+    pub async fn display<V: RV::Format>(
         &'s self,
         max_depth: usize,
         max_output_size: usize,
         interpreter: &'s Interpreter<impl Store>,
     ) -> Result<IndexMap<String, Result<V, FormatError>>, Error> {
-        let writer = Arc::new(Writer::new(max_depth, max_output_size));
+        let used_size = Arc::new(AtomicUsize::new(0));
         let mut output = IndexMap::new();
 
         // You think you want to factor a helper out to do the evaluation and error handling, but
         // trust me, you don't.
 
         let names = try_join_all(self.fields.iter().map(|kvp| {
-            let writer = writer.clone();
+            let used_size = used_size.clone();
             async move {
                 let strands = match kvp.key.val.as_ref() {
                     Ok(strands) => strands,
                     Err(e) => return Ok(Err(e.clone())),
                 };
 
+                let mut meter = writer::Meter::new(&used_size, max_output_size, max_depth);
                 let evaluated = match interpreter.eval_strands(strands).await {
                     Ok(Some(v)) => v,
-                    Ok(None) => return Ok(Ok(V::null())),
+                    Ok(None) => match V::null(&mut meter) {
+                        Ok(value) => return Ok(Ok(value)),
+                        Err(err) => return Ok(Err(err.into())),
+                    },
                     Err(e) => return Ok(Err(e)),
                 };
 
-                match writer.write(evaluated) {
+                match writer::write(meter, evaluated) {
                     Err(FormatError::TooMuchOutput) => Err(Error::TooMuchOutput),
                     other => Ok(other),
                 }
@@ -213,20 +217,24 @@ impl<'s> Display<'s> {
         }));
 
         let values = try_join_all(self.fields.iter().map(|kvp| {
-            let writer = writer.clone();
+            let used_size = used_size.clone();
             async move {
                 let strands = match kvp.val.val.as_ref() {
                     Ok(strands) => strands,
                     Err(e) => return Ok(Err(e.clone())),
                 };
 
+                let mut meter = writer::Meter::new(&used_size, max_output_size, max_depth);
                 let evaluated = match interpreter.eval_strands(strands).await {
                     Ok(Some(v)) => v,
-                    Ok(None) => return Ok(Ok(V::null())),
+                    Ok(None) => match V::null(&mut meter) {
+                        Ok(value) => return Ok(Ok(value)),
+                        Err(err) => return Ok(Err(err.into())),
+                    },
                     Err(e) => return Ok(Err(e)),
                 };
 
-                match writer.write(evaluated) {
+                match writer::write(meter, evaluated) {
                     Err(FormatError::TooMuchOutput) => Err(Error::TooMuchOutput),
                     other => Ok(other),
                 }
@@ -298,7 +306,6 @@ mod tests {
     use crate::v2::value::tests::struct_;
     use crate::v2::value::tests::vec_map;
     use crate::v2::value::tests::vector_;
-    use crate::v2::writer::JsonWriter;
 
     use super::*;
 
@@ -319,8 +326,8 @@ mod tests {
             return Ok(None);
         };
 
-        let writer: JsonWriter = JsonWriter::new(&used, usize::MAX, usize::MAX);
-        Ok(Some(value.format_json(writer)?))
+        let meter = writer::Meter::new(&used, usize::MAX, usize::MAX);
+        Ok(Some(value.format_json(meter)?))
     }
 
     async fn dynamic_field_id(

--- a/crates/sui-display/src/v2/value.rs
+++ b/crates/sui-display/src/v2/value.rs
@@ -29,14 +29,12 @@ use sui_types::dynamic_field::derive_dynamic_field_id;
 use sui_types::id::ID;
 use sui_types::id::UID;
 use sui_types::object::rpc_visitor as RV;
-use sui_types::object::rpc_visitor::Writer as _;
+use sui_types::object::rpc_visitor::Meter as _;
 
 use crate::v2::error::FormatError;
 use crate::v2::parser::Base64Modifier;
 use crate::v2::parser::Transform;
-use crate::v2::writer::JsonValue;
-use crate::v2::writer::JsonWriter;
-use crate::v2::writer::StringWriter;
+use crate::v2::writer;
 
 /// Dynamically load objects by their ID, returning the object's owned data.
 ///
@@ -179,7 +177,7 @@ impl Value<'_> {
     pub(crate) fn format(
         self,
         transform: Transform,
-        w: &mut StringWriter<'_>,
+        w: &mut writer::StringWriter<'_>,
     ) -> Result<(), FormatError> {
         match transform {
             Transform::Base64(xmod) => Atom::try_from(self)?.format_as_base64(xmod.engine(), w),
@@ -196,32 +194,39 @@ impl Value<'_> {
         }
     }
 
-    /// Write out a formatted representation of this value as JSON, using the provided writer.
+    /// Write out a formatted representation of this value as JSON, using the provided meter.
     ///
-    /// This operation can fail if the output is too large. If it succeeds, `w` will be modified to
-    /// account for the size of the written data, which will be returned.
-    pub(crate) fn format_json<V: JsonValue>(self, mut w: JsonWriter<V>) -> Result<V, FormatError> {
+    /// This operation can fail if the output is too large. If it succeeds, `meter` will be
+    /// modified to account for the size of the written data.
+    pub(crate) fn format_json<F: RV::Format>(
+        self,
+        mut meter: writer::Meter<'_>,
+    ) -> Result<F, FormatError> {
         match self {
-            Value::Address(a) => w.write_str(a.to_canonical_string(true)),
-            Value::Bool(b) => w.write_bool(b),
-            Value::U8(n) => w.write_number(n as u32),
-            Value::U16(n) => w.write_number(n as u32),
-            Value::U32(n) => w.write_number(n),
-            Value::U64(n) => w.write_str(n.to_string()),
-            Value::U128(n) => w.write_str(n.to_string()),
-            Value::U256(n) => w.write_str(n.to_string()),
+            Value::Address(a) => Ok(F::string(&mut meter, a.to_canonical_string(true))?),
+            Value::Bool(b) => Ok(F::bool(&mut meter, b)?),
+            Value::U8(n) => Ok(F::number(&mut meter, n as u32)?),
+            Value::U16(n) => Ok(F::number(&mut meter, n as u32)?),
+            Value::U32(n) => Ok(F::number(&mut meter, n)?),
+            Value::U64(n) => Ok(F::string(&mut meter, n.to_string())?),
+            Value::U128(n) => Ok(F::string(&mut meter, n.to_string())?),
+            Value::U256(n) => Ok(F::string(&mut meter, n.to_string())?),
 
-            Value::Bytes(bs) => w.write_str(Base64Modifier::EMPTY.engine().encode(&bs)),
-            Value::String(bs) => w.write_str(
-                str::from_utf8(&bs)
-                    .map_err(|_| FormatError::TransformInvalid("expected utf8 bytes"))?
-                    .to_owned(),
-            ),
+            Value::Bytes(bs) => {
+                let b64 = Base64Modifier::EMPTY.engine().encode(&bs);
+                Ok(F::string(&mut meter, b64)?)
+            }
 
-            Value::Struct(s) => s.format_json(w),
-            Value::Enum(e) => e.format_json(w),
-            Value::Vector(v) => v.format_json(w),
-            Value::Slice(s) => s.format_json(w),
+            Value::String(bs) => {
+                let s = str::from_utf8(&bs)
+                    .map_err(|_| FormatError::TransformInvalid("expected utf8 bytes"))?;
+                Ok(F::string(&mut meter, s.to_owned())?)
+            }
+
+            Value::Struct(s) => s.format_json(meter),
+            Value::Enum(e) => e.format_json(meter),
+            Value::Vector(v) => v.format_json(meter),
+            Value::Slice(s) => s.format_json(meter),
         }
     }
 
@@ -300,7 +305,7 @@ impl Value<'_> {
 
 impl Atom<'_> {
     /// Format the atom as a hexadecimal string.
-    fn format_as_hex(&self, w: &mut StringWriter<'_>) -> Result<(), FormatError> {
+    fn format_as_hex(&self, w: &mut writer::StringWriter<'_>) -> Result<(), FormatError> {
         match self {
             Atom::Bool(b) => write!(w, "{:02x}", *b as u8)?,
             Atom::U8(n) => write!(w, "{n:02x}")?,
@@ -327,7 +332,7 @@ impl Atom<'_> {
     }
 
     /// Format the atom as a string.
-    fn format_as_str(&self, w: &mut StringWriter<'_>) -> Result<(), FormatError> {
+    fn format_as_str(&self, w: &mut writer::StringWriter<'_>) -> Result<(), FormatError> {
         match self {
             Atom::Address(a) => write!(w, "{}", a.to_canonical_display(true))?,
             Atom::Bool(b) => write!(w, "{b}")?,
@@ -349,7 +354,7 @@ impl Atom<'_> {
 
     /// Coerce the atom into an `i64`, interpreted as an offset in milliseconds since the Unix
     /// epoch, and format it as an ISO8601 timestamp.
-    fn format_as_timestamp(&self, w: &mut StringWriter<'_>) -> Result<(), FormatError> {
+    fn format_as_timestamp(&self, w: &mut writer::StringWriter<'_>) -> Result<(), FormatError> {
         let ts = self
             .as_i64()
             .and_then(DateTime::from_timestamp_millis)
@@ -362,7 +367,7 @@ impl Atom<'_> {
     }
 
     /// Like string formatting, but percent-encoding reserved URL characters.
-    fn format_as_url(&self, w: &mut StringWriter<'_>) -> Result<(), FormatError> {
+    fn format_as_url(&self, w: &mut writer::StringWriter<'_>) -> Result<(), FormatError> {
         match self {
             Atom::Address(a) => write!(w, "{}", a.to_canonical_display(true))?,
             Atom::Bool(b) => write!(w, "{b}")?,
@@ -391,7 +396,7 @@ impl Atom<'_> {
     fn format_as_base64(
         &self,
         e: &impl Engine,
-        w: &mut StringWriter<'_>,
+        w: &mut writer::StringWriter<'_>,
     ) -> Result<(), FormatError> {
         let base64 = match self {
             Atom::Address(a) => e.encode(a.into_bytes()),
@@ -459,8 +464,12 @@ impl OwnedSlice {
 }
 
 impl Slice<'_> {
-    fn format_json<V: JsonValue>(self, w: JsonWriter<V>) -> Result<V, FormatError> {
-        A::MoveValue::visit_deserialize(self.bytes, self.layout, &mut RV::RpcVisitor::new(w))
+    fn format_json<F: RV::Format>(self, meter: writer::Meter<'_>) -> Result<F, FormatError> {
+        Ok(A::MoveValue::visit_deserialize(
+            self.bytes,
+            self.layout,
+            &mut RV::RpcVisitor::new(meter),
+        )?)
     }
 }
 
@@ -508,40 +517,42 @@ impl Vector<'_> {
         TypeTag::Vector(Box::new(self.type_.clone().into_owned()))
     }
 
-    fn format_json<V: JsonValue>(self, mut w: JsonWriter<V>) -> Result<V, FormatError> {
-        let mut elems = V::Vec::default();
-        let mut nested = w.nest()?;
+    fn format_json<F: RV::Format>(self, mut meter: writer::Meter<'_>) -> Result<F, FormatError> {
+        let mut elems = F::Vec::default();
+        let mut nested = meter.nest()?;
         for e in self.elements {
-            let json = e.format_json(nested)?;
-            nested.vec_push_element(&mut elems, json)?;
+            let json = e.format_json(nested.reborrow())?;
+            F::vec_push_element(&mut nested, &mut elems, json)?;
         }
 
-        w.write_vec(elems)
+        Ok(F::vec(&mut meter, elems)?)
     }
 }
 
 impl Struct<'_> {
-    fn format_json<V: JsonValue>(self, mut w: JsonWriter<V>) -> Result<V, FormatError> {
-        let mut map = V::Map::default();
-        let nested = w.nest()?;
-        self.fields.format_json(nested, &mut map)?;
-        w.write_map(map)
+    fn format_json<F: RV::Format>(self, mut meter: writer::Meter<'_>) -> Result<F, FormatError> {
+        let mut map = F::Map::default();
+        let nested = meter.nest()?;
+        self.fields.format_json::<F>(nested, &mut map)?;
+
+        Ok(F::map(&mut meter, map)?)
     }
 }
 
 impl Enum<'_> {
-    fn format_json<V: JsonValue>(self, mut w: JsonWriter<V>) -> Result<V, FormatError> {
-        let mut map = V::Map::default();
-        let mut nested = w.nest()?;
+    fn format_json<F: RV::Format>(self, mut meter: writer::Meter<'_>) -> Result<F, FormatError> {
+        let mut map = F::Map::default();
+        let mut nested = meter.nest()?;
 
         let name = match self.variant_name {
-            Some(name) => nested.write_str(name.to_owned())?,
-            None => nested.write_number(self.variant_index as u32)?,
+            Some(name) => F::string(&mut nested, name.to_owned())?,
+            None => F::number(&mut nested, self.variant_index as u32)?,
         };
 
-        nested.map_push_field(&mut map, "@variant".to_owned(), name)?;
-        self.fields.format_json(nested, &mut map)?;
-        w.write_map(map)
+        F::map_push_field(&mut nested, &mut map, "@variant".to_owned(), name)?;
+        self.fields.format_json::<F>(nested, &mut map)?;
+
+        Ok(F::map(&mut meter, map)?)
     }
 }
 
@@ -575,23 +586,23 @@ impl<'s> Fields<'s> {
         }
     }
 
-    fn format_json<V: JsonValue>(
+    fn format_json<F: RV::Format>(
         self,
-        mut w: JsonWriter<V>,
-        map: &mut V::Map,
+        mut meter: writer::Meter<'_>,
+        map: &mut F::Map,
     ) -> Result<(), FormatError> {
         match self {
             Fields::Positional(values) => {
                 for (i, value) in values.into_iter().enumerate() {
-                    let json = value.format_json(w)?;
-                    w.map_push_field(map, format!("pos{i}"), json)?;
+                    let json = value.format_json(meter.reborrow())?;
+                    F::map_push_field(&mut meter, map, format!("pos{i}"), json)?;
                 }
             }
 
             Fields::Named(items) => {
                 for (field, value) in items {
-                    let json = value.format_json(w)?;
-                    w.map_push_field(map, field.to_owned(), json)?;
+                    let json = value.format_json(meter.reborrow())?;
+                    F::map_push_field(&mut meter, map, field.to_owned(), json)?;
                 }
             }
         }
@@ -816,6 +827,7 @@ pub(crate) mod tests {
     use move_core_types::annotated_value::MoveStructLayout;
     use move_core_types::annotated_value::MoveTypeLayout as L;
     use move_core_types::identifier::Identifier;
+    use serde_json::Value as Json;
     use serde_json::json;
     use sui_types::MOVE_STDLIB_ADDRESS;
     use sui_types::base_types::STD_ASCII_MODULE_NAME;
@@ -825,8 +837,6 @@ pub(crate) mod tests {
     use sui_types::dynamic_field::derive_dynamic_field_id;
     use sui_types::id::ID;
     use sui_types::id::UID;
-
-    use crate::v2::writer::JsonWriter;
 
     use super::*;
 
@@ -1415,15 +1425,15 @@ pub(crate) mod tests {
         assert_eq!(values.len(), json.len());
         for (value, expect) in values.into_iter().zip(json.into_iter()) {
             let used = AtomicUsize::new(0);
-            let writer: JsonWriter = JsonWriter::new(&used, usize::MAX, usize::MAX);
-            let actual = value.format_json(writer).unwrap();
+            let meter = writer::Meter::new(&used, usize::MAX, usize::MAX);
+            let actual = value.format_json::<Json>(meter).unwrap();
             assert_eq!(actual, expect);
         }
     }
 
     #[test]
     fn test_struct_json_formatting() {
-        let literal = Value::Struct(Struct {
+        let lit = Value::Struct(Struct {
             type_: &"0x2::foo::Bar".parse().unwrap(),
             fields: Fields::Named(vec![
                 ("x", Value::U32(100)),
@@ -1448,15 +1458,14 @@ pub(crate) mod tests {
         });
 
         let used = AtomicUsize::new(0);
-        let writer: JsonWriter = JsonWriter::new(&used, usize::MAX, usize::MAX);
-
-        assert_eq!(expect, literal.format_json(writer).unwrap());
-        assert_eq!(expect, slice.format_json(writer).unwrap());
+        let mut meter = writer::Meter::new(&used, usize::MAX, usize::MAX);
+        assert_eq!(expect, lit.format_json::<Json>(meter.reborrow()).unwrap());
+        assert_eq!(expect, slice.format_json::<Json>(meter.reborrow()).unwrap());
     }
 
     #[test]
     fn test_enum_named_variant_json_formatting() {
-        let literal = Value::Enum(Enum {
+        let lit = Value::Enum(Enum {
             type_: &"0x1::m::E".parse().unwrap(),
             variant_name: Some("A"),
             variant_index: 0,
@@ -1478,10 +1487,9 @@ pub(crate) mod tests {
         });
 
         let used = AtomicUsize::new(0);
-        let writer: JsonWriter = JsonWriter::new(&used, usize::MAX, usize::MAX);
-
-        assert_eq!(expect, literal.format_json(writer).unwrap());
-        assert_eq!(expect, slice.format_json(writer).unwrap());
+        let mut meter = writer::Meter::new(&used, usize::MAX, usize::MAX);
+        assert_eq!(expect, lit.format_json::<Json>(meter.reborrow()).unwrap());
+        assert_eq!(expect, slice.format_json::<Json>(meter.reborrow()).unwrap());
     }
 
     #[test]
@@ -1500,7 +1508,7 @@ pub(crate) mod tests {
         });
 
         let used = AtomicUsize::new(0);
-        let writer: JsonWriter = JsonWriter::new(&used, usize::MAX, usize::MAX);
-        assert_eq!(expect, literal.format_json(writer).unwrap());
+        let meter = writer::Meter::new(&used, usize::MAX, usize::MAX);
+        assert_eq!(expect, literal.format_json::<Json>(meter).unwrap());
     }
 }

--- a/crates/sui-display/src/v2/writer.rs
+++ b/crates/sui-display/src/v2/writer.rs
@@ -7,468 +7,166 @@ use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 
 use sui_types::object::rpc_visitor as RV;
+use sui_types::object::rpc_visitor::Meter as _;
+use sui_types::object::rpc_visitor::Unmetered;
 
 use crate::v2::error::FormatError;
 use crate::v2::parser::Transform;
 use crate::v2::value as V;
 
-pub trait JsonValue {
-    type Vec: Default;
-    type Map: Default;
-
-    fn null() -> Self;
-    fn bool(value: bool) -> Self;
-    // For our purposes numbers are values that can fit in a `u32`
-    fn number(value: u32) -> Self;
-    fn string(value: String) -> Self;
-    fn array(value: Self::Vec) -> Self;
-    fn object(value: Self::Map) -> Self;
-
-    fn is_null(&self) -> bool;
-    fn is_bool(&self) -> bool;
-    fn is_number(&self) -> bool;
-    fn is_string(&self) -> bool;
-    fn is_array(&self) -> bool;
-    fn is_object(&self) -> bool;
-
-    fn as_bool(&self) -> Option<bool>;
-    fn as_string(&self) -> Option<&str>;
-    fn as_array(&self) -> Option<&Self::Vec>;
-    fn as_object(&self) -> Option<&Self::Map>;
-
-    fn vec_push_element(vec: &mut Self::Vec, value: Self);
-    fn map_push_field(map: &mut Self::Map, key: String, value: Self);
-}
-
-impl JsonValue for serde_json::Value {
-    type Vec = Vec<Self>;
-    type Map = serde_json::Map<String, Self>;
-
-    fn null() -> Self {
-        serde_json::Value::Null
-    }
-
-    fn bool(value: bool) -> Self {
-        serde_json::Value::Bool(value)
-    }
-
-    fn number(value: u32) -> Self {
-        serde_json::Value::Number(value.into())
-    }
-
-    fn string(value: String) -> Self {
-        serde_json::Value::String(value)
-    }
-
-    fn array(value: Self::Vec) -> Self {
-        serde_json::Value::Array(value)
-    }
-
-    fn object(value: Self::Map) -> Self {
-        serde_json::Value::Object(value)
-    }
-
-    fn is_null(&self) -> bool {
-        self.is_null()
-    }
-
-    fn is_bool(&self) -> bool {
-        self.is_boolean()
-    }
-
-    fn is_number(&self) -> bool {
-        self.is_number()
-    }
-
-    fn is_string(&self) -> bool {
-        self.is_string()
-    }
-
-    fn is_array(&self) -> bool {
-        self.is_array()
-    }
-
-    fn is_object(&self) -> bool {
-        self.is_object()
-    }
-
-    fn as_bool(&self) -> Option<bool> {
-        self.as_bool()
-    }
-
-    fn as_string(&self) -> Option<&str> {
-        self.as_str()
-    }
-
-    fn as_array(&self) -> Option<&Self::Vec> {
-        self.as_array()
-    }
-
-    fn as_object(&self) -> Option<&Self::Map> {
-        self.as_object()
-    }
-
-    fn vec_push_element(vec: &mut Self::Vec, value: Self) {
-        vec.push(value);
-    }
-
-    fn map_push_field(map: &mut Self::Map, key: String, value: Self) {
-        map.insert(key, value);
-    }
-}
-
-impl JsonValue for prost_types::Value {
-    type Vec = prost_types::ListValue;
-    type Map = prost_types::Struct;
-
-    fn null() -> Self {
-        prost_types::value::Kind::NullValue(0).into()
-    }
-
-    fn bool(value: bool) -> Self {
-        Self::from(value)
-    }
-
-    fn number(value: u32) -> Self {
-        Self::from(value)
-    }
-
-    fn string(value: String) -> Self {
-        Self::from(value)
-    }
-
-    fn array(value: Self::Vec) -> Self {
-        Self::from(value.values)
-    }
-
-    fn object(value: Self::Map) -> Self {
-        Self::from(value.fields)
-    }
-
-    fn is_null(&self) -> bool {
-        matches!(self.kind, Some(prost_types::value::Kind::NullValue(_)))
-    }
-
-    fn is_bool(&self) -> bool {
-        self.as_bool().is_some()
-    }
-
-    fn is_number(&self) -> bool {
-        matches!(self.kind, Some(prost_types::value::Kind::NumberValue(_)))
-    }
-
-    fn is_string(&self) -> bool {
-        self.as_string().is_some()
-    }
-
-    fn is_array(&self) -> bool {
-        self.as_array().is_some()
-    }
-
-    fn is_object(&self) -> bool {
-        self.as_object().is_some()
-    }
-
-    fn as_bool(&self) -> Option<bool> {
-        if let Some(prost_types::value::Kind::BoolValue(b)) = &self.kind {
-            Some(*b)
-        } else {
-            None
-        }
-    }
-
-    fn as_string(&self) -> Option<&str> {
-        if let Some(prost_types::value::Kind::StringValue(string)) = &self.kind {
-            Some(string.as_ref())
-        } else {
-            None
-        }
-    }
-
-    fn as_array(&self) -> Option<&Self::Vec> {
-        if let Some(prost_types::value::Kind::ListValue(array)) = &self.kind {
-            Some(array)
-        } else {
-            None
-        }
-    }
-
-    fn as_object(&self) -> Option<&Self::Map> {
-        if let Some(prost_types::value::Kind::StructValue(object)) = &self.kind {
-            Some(object)
-        } else {
-            None
-        }
-    }
-
-    fn vec_push_element(vec: &mut Self::Vec, value: Self) {
-        vec.values.push(value)
-    }
-
-    fn map_push_field(map: &mut Self::Map, key: String, value: Self) {
-        map.fields.insert(key, value);
-    }
-}
-
-/// A writer of evaluated values into JSON, tracking limits on output size and depth. A single
-/// writer can be used to write multiple values concurrently, with all writers sharing the same
-/// budgets.
-///
-/// Once a write is attempted, the budgets are decremented, even if the write fails, meaning that
-/// the errors are sticky and not recoverable.
-pub(crate) struct Writer {
-    max_depth: usize,
-    max_output_size: usize,
-    used_output: AtomicUsize,
-}
-
-/// A writer of strings that tracks an output budget (measured in bytes) shared across multiple
-/// writers. Writes will fail once the total number of bytes sent to be written, across all
-/// writers, exceeds the maximum, and will continue to fail from there on out.
-///
-/// Once a write is attempted, the budget is decremented, even if the write fails, meaning that the
-/// error is sticky and not recoverable.
-pub(crate) struct StringWriter<'u> {
-    output: String,
-    used: &'u AtomicUsize,
-    max: usize,
-}
-
-/// A writer of structured JSON values that tracks an output budget (measured in bytes) shared
-/// across multiple writers. Writes will fail once the total number of bytes sent to be written,
-/// across all writers, exceeds the maximum, and will continue to fail from there on out.
-///
-/// Once a write is attempted, the budget is decremented, even if the write fails, meaning that the
-/// error is sticky and not recoverable.
-pub(crate) struct JsonWriter<'u, V = serde_json::Value> {
-    used_size: &'u AtomicUsize,
+/// Shared output meter for Display rendering. Budget usage is sticky across all render operations
+/// that share the same `used_size` counter.
+pub(crate) struct Meter<'a> {
+    used_size: &'a AtomicUsize,
     max_size: usize,
     depth_budget: usize,
-    phantom: std::marker::PhantomData<V>,
 }
 
-impl<V> Clone for JsonWriter<'_, V> {
-    fn clone(&self) -> Self {
-        *self
-    }
+/// A writer of strings backed by a shared output meter.
+pub(crate) struct StringWriter<'a> {
+    output: String,
+    meter: Meter<'a>,
 }
 
-impl<V> Copy for JsonWriter<'_, V> {}
-
-impl Writer {
-    /// Create a new writer with the given limits.
-    ///
-    /// `max_depth` specifies the maximum depth of the output JSON, and `max_output_size` specifies
-    /// the size in bytes of the output JSON.
-    pub(crate) fn new(max_depth: usize, max_output_size: usize) -> Self {
-        Self {
-            max_depth,
-            max_output_size,
-            used_output: AtomicUsize::new(0),
-        }
-    }
-
-    /// Format a single strand as JSON.
-    pub(crate) fn write<JSON: JsonValue>(
-        &self,
-        mut strands: Vec<V::Strand<'_>>,
-    ) -> Result<JSON, FormatError> {
-        // Detect and handle JSON transforms (single strand containing an expression with an JSON
-        // transform) as a special case, because they do not always evaluate to strings.
-        if matches!(&strands[..], [V::Strand::Value { transform, .. }] if *transform == Transform::Json)
-        {
-            let V::Strand::Value { offset, value, .. } = strands.pop().unwrap() else {
-                unreachable!();
-            };
-
-            let writer = JsonWriter::new(&self.used_output, self.max_output_size, self.max_depth);
-            return value
-                .format_json(writer)
-                .map_err(|e| e.for_expr_at_offset(offset));
-        }
-
-        // Otherwise gather the results of formatting all strands into a single string.
-        let mut writer = StringWriter::new(&self.used_output, self.max_output_size);
-        for strand in strands {
-            match strand {
-                V::Strand::Text(s) => writer
-                    .write_str(s)
-                    .map_err(|_| FormatError::TooMuchOutput)?,
-
-                V::Strand::Value {
-                    offset,
-                    value,
-                    transform,
-                } => value
-                    .format(transform, &mut writer)
-                    .map_err(|e| e.for_expr_at_offset(offset))?,
-            }
-        }
-
-        Ok(JSON::string(writer.finish()))
-    }
-}
-
-impl<'u> StringWriter<'u> {
-    fn new(used: &'u AtomicUsize, max: usize) -> Self {
-        Self {
-            output: String::new(),
-            used,
-            max,
-        }
-    }
-
-    fn finish(self) -> String {
-        self.output
-    }
-}
-
-impl<'u, V> JsonWriter<'u, V> {
-    pub(crate) fn new(used_size: &'u AtomicUsize, max_size: usize, depth_budget: usize) -> Self {
+impl<'a> Meter<'a> {
+    pub(crate) fn new(used_size: &'a AtomicUsize, max_size: usize, depth_budget: usize) -> Self {
         Self {
             used_size,
             max_size,
             depth_budget,
-            phantom: std::marker::PhantomData,
         }
     }
 
-    fn debit(&self, size: usize) -> Result<(), FormatError> {
-        let prev = self.used_size.fetch_add(size, Ordering::Relaxed);
-        if prev + size > self.max_size {
-            return Err(FormatError::TooBig);
-        }
-        Ok(())
+    pub(crate) fn reborrow(&mut self) -> Meter<'_> {
+        Meter::new(self.used_size, self.max_size, self.depth_budget)
     }
 }
 
-impl<V: JsonValue> RV::Writer for JsonWriter<'_, V> {
-    type Value = V;
-    type Error = FormatError;
+impl<'a> StringWriter<'a> {
+    fn new(meter: Meter<'a>) -> Self {
+        Self {
+            output: String::new(),
+            meter,
+        }
+    }
 
-    type Vec = V::Vec;
-    type Map = V::Map;
+    fn finish<F: RV::Format>(self) -> F {
+        // The original meter has already been charged for the output, so do not apply metering
+        // again when formatting as a string.
+        F::string(&mut Unmetered, self.output).unwrap()
+    }
+}
 
+impl RV::Meter for Meter<'_> {
     type Nested<'a>
-        = JsonWriter<'a, V>
+        = Meter<'a>
     where
         Self: 'a;
 
-    fn nest(&mut self) -> Result<Self::Nested<'_>, Self::Error> {
+    fn nest(&mut self) -> Result<Self::Nested<'_>, RV::MeterError> {
         if self.depth_budget == 0 {
-            return Err(FormatError::TooDeep);
+            Err(RV::MeterError::TooDeep)
+        } else {
+            Ok(Meter::new(
+                self.used_size,
+                self.max_size,
+                self.depth_budget - 1,
+            ))
         }
-
-        Ok(JsonWriter {
-            used_size: self.used_size,
-            max_size: self.max_size,
-            depth_budget: self.depth_budget - 1,
-            phantom: std::marker::PhantomData,
-        })
     }
 
-    fn write_null(&mut self) -> Result<Self::Value, Self::Error> {
-        self.debit("null".len())?;
-        Ok(V::null())
-    }
-
-    fn write_bool(&mut self, value: bool) -> Result<Self::Value, Self::Error> {
-        self.debit(if value { "true".len() } else { "false".len() })?;
-        Ok(V::bool(value))
-    }
-
-    fn write_number(&mut self, value: u32) -> Result<Self::Value, Self::Error> {
-        self.debit(if value == 0 { 1 } else { value.ilog10() } as usize)?;
-        Ok(V::number(value))
-    }
-
-    fn write_str(&mut self, value: String) -> Result<Self::Value, Self::Error> {
-        // Account for the quotes around the string.
-        self.debit(2 + value.len())?;
-        Ok(V::string(value))
-    }
-
-    fn write_vec(&mut self, value: Self::Vec) -> Result<Self::Value, Self::Error> {
-        // Account for the opening bracket.
-        self.debit(1)?;
-        Ok(V::array(value))
-    }
-
-    fn write_map(&mut self, value: Self::Map) -> Result<Self::Value, Self::Error> {
-        // Account for the opening brace.
-        self.debit(1)?;
-        Ok(V::object(value))
-    }
-
-    fn vec_push_element(
-        &mut self,
-        vec: &mut Self::Vec,
-        val: Self::Value,
-    ) -> Result<(), Self::Error> {
-        // Account for comma (or closing bracket).
-        self.debit(1)?;
-        V::vec_push_element(vec, val);
-        Ok(())
-    }
-
-    fn map_push_field(
-        &mut self,
-        map: &mut Self::Map,
-        key: String,
-        val: Self::Value,
-    ) -> Result<(), Self::Error> {
-        // Account for quotes, colon, and comma (or closing brace).
-        self.debit(4 + key.len())?;
-        V::map_push_field(map, key, val);
-        Ok(())
+    fn charge(&mut self, amount: usize) -> Result<(), RV::MeterError> {
+        let prev = self.used_size.fetch_add(amount, Ordering::Relaxed);
+        if prev + amount > self.max_size {
+            Err(RV::MeterError::TooBig)
+        } else {
+            Ok(())
+        }
     }
 }
 
 impl fmt::Write for StringWriter<'_> {
     fn write_str(&mut self, s: &str) -> std::fmt::Result {
-        let prev = self.used.fetch_add(s.len(), Ordering::Relaxed);
-        if prev + s.len() > self.max {
-            return Err(std::fmt::Error);
-        }
-
+        self.meter.charge(s.len()).map_err(|_| std::fmt::Error)?;
         self.output.push_str(s);
         Ok(())
     }
 }
 
+pub(crate) fn write<F: RV::Format>(
+    meter: Meter<'_>,
+    mut strands: Vec<V::Strand<'_>>,
+) -> Result<F, FormatError> {
+    if matches!(&strands[..], [V::Strand::Value { transform, .. }] if *transform == Transform::Json)
+    {
+        let V::Strand::Value { offset, value, .. } = strands.pop().unwrap() else {
+            unreachable!();
+        };
+
+        return value
+            .format_json(meter)
+            .map_err(|e| e.for_expr_at_offset(offset));
+    }
+
+    let mut writer = StringWriter::new(meter);
+    for strand in strands {
+        match strand {
+            V::Strand::Text(s) => writer
+                .write_str(s)
+                .map_err(|_| FormatError::TooMuchOutput)?,
+
+            V::Strand::Value {
+                offset,
+                value,
+                transform,
+            } => value
+                .format(transform, &mut writer)
+                .map_err(|e| e.for_expr_at_offset(offset))?,
+        }
+    }
+
+    Ok(writer.finish())
+}
+
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::fmt::Write;
+
+    use serde_json::Value as Json;
+    use serde_json::json;
+
+    use super::*;
 
     #[test]
     fn test_bounded_writer_under_limit() {
         let used = AtomicUsize::new(0);
-        let mut w = StringWriter::new(&used, 100);
+        let mut w = StringWriter::new(Meter::new(&used, 100, usize::MAX));
 
         write!(w, "Hello").unwrap();
         write!(w, " ").unwrap();
         write!(w, "World").unwrap();
 
-        assert_eq!(w.finish(), "Hello World");
+        let output: Json = w.finish();
+        assert_eq!(output, json!("Hello World"));
         assert_eq!(used.load(Ordering::Relaxed), 11);
     }
 
     #[test]
     fn test_bounded_writer_at_limit() {
         let used = AtomicUsize::new(0);
-        let mut w = StringWriter::new(&used, 5);
+        let mut w = StringWriter::new(Meter::new(&used, 5, usize::MAX));
 
         write!(w, "Hello").unwrap();
 
-        assert_eq!(w.finish(), "Hello");
+        let output: Json = w.finish();
+        assert_eq!(output, json!("Hello"));
         assert_eq!(used.load(Ordering::Relaxed), 5);
     }
 
     #[test]
     fn test_bounded_writer_exceeds_limit() {
         let used = AtomicUsize::new(0);
-        let mut w = StringWriter::new(&used, 5);
+        let mut w = StringWriter::new(Meter::new(&used, 5, usize::MAX));
 
         write!(w, "Hello").unwrap();
         write!(w, " World").unwrap_err();
@@ -479,14 +177,16 @@ mod tests {
     fn test_bounded_writer_shared_counter() {
         let used = AtomicUsize::new(0);
 
-        let mut w = StringWriter::new(&used, 20);
+        let mut w = StringWriter::new(Meter::new(&used, 20, usize::MAX));
         write!(w, "First").unwrap();
-        assert_eq!(w.finish(), "First");
+        let output: Json = w.finish();
+        assert_eq!(output, json!("First"));
         assert_eq!(used.load(Ordering::Relaxed), 5);
 
-        let mut w = StringWriter::new(&used, 20);
+        let mut w = StringWriter::new(Meter::new(&used, 20, usize::MAX));
         write!(w, "Second").unwrap();
-        assert_eq!(w.finish(), "Second");
+        let output: Json = w.finish();
+        assert_eq!(output, json!("Second"));
         assert_eq!(used.load(Ordering::Relaxed), 11);
     }
 
@@ -494,10 +194,10 @@ mod tests {
     fn test_bounded_writer_shared_counter_exceeds_limit() {
         let used = AtomicUsize::new(0);
 
-        let mut w = StringWriter::new(&used, 10);
+        let mut w = StringWriter::new(Meter::new(&used, 10, usize::MAX));
         write!(w, "First").unwrap();
 
-        let mut w = StringWriter::new(&used, 10);
+        let mut w = StringWriter::new(Meter::new(&used, 10, usize::MAX));
         write!(w, "Second").unwrap_err();
 
         assert!(used.load(Ordering::Relaxed) > 10);
@@ -506,7 +206,7 @@ mod tests {
     #[test]
     fn test_bounded_writer_sticky_error() {
         let used = AtomicUsize::new(0);
-        let mut writer = StringWriter::new(&used, 6);
+        let mut writer = StringWriter::new(Meter::new(&used, 6, usize::MAX));
 
         write!(writer, "Hello").unwrap();
         write!(writer, " World").unwrap_err();
@@ -518,17 +218,17 @@ mod tests {
         let used = AtomicUsize::new(0);
         let limit = 20;
 
-        let mut w0 = StringWriter::new(&used, limit);
-        let mut w1 = StringWriter::new(&used, limit);
-        let mut w2 = StringWriter::new(&used, limit);
+        let mut w0 = StringWriter::new(Meter::new(&used, limit, usize::MAX));
+        let mut w1 = StringWriter::new(Meter::new(&used, limit, usize::MAX));
+        let mut w2 = StringWriter::new(Meter::new(&used, limit, usize::MAX));
 
         write!(w0, "AAA").unwrap();
         write!(w1, "BBBB").unwrap();
         write!(w2, "CCCCC").unwrap();
 
         assert_eq!(used.load(Ordering::Relaxed), 12);
-        assert_eq!(w0.finish(), "AAA");
-        assert_eq!(w1.finish(), "BBBB");
-        assert_eq!(w2.finish(), "CCCCC");
+        assert_eq!(w0.finish::<Json>(), json!("AAA"));
+        assert_eq!(w1.finish::<Json>(), json!("BBBB"));
+        assert_eq!(w2.finish::<Json>(), json!("CCCCC"));
     }
 }

--- a/crates/sui-indexer-alt-graphql/src/api/types/move_value.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/move_value.rs
@@ -20,7 +20,6 @@ use move_core_types::visitor_default;
 use sui_types::TypeTag;
 use sui_types::id::ID;
 use sui_types::id::UID;
-use sui_types::object::option_visitor as OV;
 use sui_types::object::rpc_visitor as RV;
 use tokio::join;
 
@@ -62,11 +61,6 @@ struct JsonVisitor {
     depth_budget: usize,
 }
 
-struct JsonWriter<'b> {
-    size_budget: &'b mut usize,
-    depth_budget: usize,
-}
-
 #[derive(thiserror::Error, Debug)]
 pub(crate) enum Error {
     #[error("Display error: {0}")]
@@ -80,21 +74,6 @@ pub(crate) enum Error {
 
     #[error("Extracted value is not a slice of existing on-chain data")]
     NotASlice,
-}
-
-#[derive(thiserror::Error, Debug)]
-enum VisitorError {
-    #[error(transparent)]
-    Visitor(#[from] AV::Error),
-
-    #[error("Unexpected type")]
-    UnexpectedType,
-
-    #[error("Value too big")]
-    TooBig,
-
-    #[error("Value too deep")]
-    TooDeep,
 }
 
 #[Object]
@@ -428,8 +407,10 @@ impl MoveValue {
             let value = JsonVisitor::new(limits)
                 .deserialize_value(&self.native, &layout)
                 .map_err(|e| match &e {
-                    VisitorError::Visitor(_) | VisitorError::UnexpectedType => anyhow!(e).into(),
-                    VisitorError::TooBig | VisitorError::TooDeep => resource_exhausted(e),
+                    RV::Error::Meter(_) => resource_exhausted(e),
+                    RV::Error::Visitor(_) | RV::Error::Option(_) | RV::Error::UnexpectedType => {
+                        anyhow!(e).into()
+                    }
                 })?;
 
             Ok(Some(Json::try_from(value)?))
@@ -468,26 +449,15 @@ impl JsonVisitor {
         &mut self,
         bytes: &[u8],
         layout: &A::MoveTypeLayout,
-    ) -> Result<serde_json::Value, VisitorError> {
+    ) -> Result<serde_json::Value, RV::Error> {
         A::MoveValue::visit_deserialize(
             bytes,
             layout,
-            &mut RV::RpcVisitor::new(JsonWriter {
-                size_budget: &mut self.size_budget,
-                depth_budget: self.depth_budget,
-            }),
+            &mut RV::RpcVisitor::new(RV::LocalMeter::new(
+                &mut self.size_budget,
+                self.depth_budget,
+            )),
         )
-    }
-}
-
-impl JsonWriter<'_> {
-    fn debit(&mut self, size: usize) -> Result<(), VisitorError> {
-        if *self.size_budget < size {
-            return Err(VisitorError::TooBig);
-        }
-
-        *self.size_budget -= size;
-        Ok(())
     }
 }
 
@@ -534,98 +504,6 @@ impl<'f, 'r> sui_display::v2::Store for DisplayStore<'f, 'r> {
 
         let bytes = move_object.contents().to_owned();
         Ok(Some(sui_display::v2::OwnedSlice { layout, bytes }))
-    }
-}
-
-impl RV::Writer for JsonWriter<'_> {
-    type Value = serde_json::Value;
-    type Error = VisitorError;
-
-    type Vec = Vec<serde_json::Value>;
-    type Map = serde_json::Map<String, serde_json::Value>;
-
-    type Nested<'b>
-        = JsonWriter<'b>
-    where
-        Self: 'b;
-
-    fn nest(&mut self) -> Result<Self::Nested<'_>, Self::Error> {
-        if self.depth_budget == 0 {
-            return Err(VisitorError::TooDeep);
-        }
-
-        Ok(JsonWriter {
-            size_budget: self.size_budget,
-            depth_budget: self.depth_budget - 1,
-        })
-    }
-
-    fn write_null(&mut self) -> Result<Self::Value, Self::Error> {
-        self.debit("null".len())?;
-        Ok(serde_json::Value::Null)
-    }
-
-    fn write_bool(&mut self, value: bool) -> Result<Self::Value, Self::Error> {
-        self.debit(if value { "true".len() } else { "false".len() })?;
-        Ok(serde_json::Value::Bool(value))
-    }
-
-    fn write_number(&mut self, value: u32) -> Result<Self::Value, Self::Error> {
-        self.debit(if value == 0 { 1 } else { value.ilog10() } as usize)?;
-        Ok(serde_json::Value::Number(value.into()))
-    }
-
-    fn write_str(&mut self, value: String) -> Result<Self::Value, Self::Error> {
-        // Account for the quotes around the string.
-        self.debit(2 + value.len())?;
-        Ok(serde_json::Value::String(value))
-    }
-
-    fn write_vec(&mut self, value: Self::Vec) -> Result<Self::Value, Self::Error> {
-        // Account for the opening bracket.
-        self.debit(1)?;
-        Ok(serde_json::Value::Array(value))
-    }
-
-    fn write_map(&mut self, value: Self::Map) -> Result<Self::Value, Self::Error> {
-        // Account for the opening brace.
-        self.debit(1)?;
-        Ok(serde_json::Value::Object(value))
-    }
-
-    fn vec_push_element(
-        &mut self,
-        vec: &mut Self::Vec,
-        val: Self::Value,
-    ) -> Result<(), Self::Error> {
-        // Account for comma (or closing bracket).
-        self.debit(1)?;
-        vec.push(val);
-        Ok(())
-    }
-
-    fn map_push_field(
-        &mut self,
-        map: &mut Self::Map,
-        key: String,
-        val: Self::Value,
-    ) -> Result<(), Self::Error> {
-        // Account for quotes, colon, and comma (or closing brace).
-        self.debit(4 + key.len())?;
-        map.insert(key, val);
-        Ok(())
-    }
-}
-
-impl From<OV::Error> for VisitorError {
-    fn from(OV::Error: OV::Error) -> Self {
-        VisitorError::UnexpectedType
-    }
-}
-
-impl From<RV::Error> for VisitorError {
-    fn from(RV::Error: RV::Error) -> Self {
-        VisitorError::UnexpectedType
     }
 }
 

--- a/crates/sui-rpc-api/src/grpc/v2/render.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/render.rs
@@ -53,7 +53,8 @@ impl RpcService {
             .ok()
             .flatten()?;
 
-        sui_types::proto_value::ProtoVisitor::new(self.config.max_json_move_value_size())
+        let bound = self.config.max_json_move_value_size();
+        sui_types::object::rpc_visitor::proto::ProtoVisitor::new(bound)
             .deserialize_value(contents, &layout)
             .map_err(|e| tracing::debug!("unable to convert move value to JSON: {e}"))
             .ok()

--- a/crates/sui-rpc-api/src/grpc/v2/transaction_execution_service/simulate/mod.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/transaction_execution_service/simulate/mod.rs
@@ -274,7 +274,8 @@ fn to_command_output(
         .ok()
         .flatten()
         .and_then(|layout| {
-            sui_types::proto_value::ProtoVisitor::new(service.config.max_json_move_value_size())
+            let bound = service.config.max_json_move_value_size();
+            sui_types::object::rpc_visitor::proto::ProtoVisitor::new(bound)
                 .deserialize_value(&bcs, &layout)
                 .map_err(|e| tracing::debug!("unable to convert to JSON: {e}"))
                 .ok()

--- a/crates/sui-rpc-resolver/src/json_visitor.rs
+++ b/crates/sui-rpc-resolver/src/json_visitor.rs
@@ -14,7 +14,6 @@ use move_core_types::annotated_value::MoveTypeLayout;
 use move_core_types::annotated_value::MoveValue;
 use move_core_types::annotated_visitor as AV;
 use move_core_types::language_storage::TypeTag;
-use serde_json::Map;
 use serde_json::Value;
 use sui_package_resolver::PackageStore;
 use sui_package_resolver::Resolver;
@@ -56,12 +55,10 @@ pub enum DeserializationError {
 /// - Byte vectors (`Vec<u8>`) are Base64-encoded strings
 pub struct JsonVisitor;
 
-struct JsonWriter;
-
 impl JsonVisitor {
     /// Deserialize BCS bytes as JSON using the provided type layout.
     pub fn deserialize_value(bytes: &[u8], layout: &MoveTypeLayout) -> anyhow::Result<Value> {
-        let mut visitor = RV::RpcVisitor::new(JsonWriter);
+        let mut visitor = RV::RpcVisitor::new(RV::Unmetered);
         Ok(MoveValue::visit_deserialize(bytes, layout, &mut visitor)?)
     }
 
@@ -70,7 +67,7 @@ impl JsonVisitor {
         bytes: &[u8],
         layout: &move_core_types::annotated_value::MoveStructLayout,
     ) -> anyhow::Result<Value> {
-        let mut visitor = RV::RpcVisitor::new(JsonWriter);
+        let mut visitor = RV::RpcVisitor::new(RV::Unmetered);
         Ok(MoveStruct::visit_deserialize(bytes, layout, &mut visitor)?)
     }
 
@@ -118,67 +115,13 @@ impl JsonVisitor {
     }
 }
 
-impl RV::Writer for JsonWriter {
-    type Value = Value;
-    type Error = Error;
-
-    type Vec = Vec<Value>;
-    type Map = Map<String, Value>;
-
-    type Nested<'a> = Self;
-
-    fn nest(&mut self) -> Result<Self, Error> {
-        Ok(Self)
-    }
-
-    fn write_null(&mut self) -> Result<Value, Error> {
-        Ok(Value::Null)
-    }
-
-    fn write_bool(&mut self, value: bool) -> Result<Value, Error> {
-        Ok(Value::Bool(value))
-    }
-
-    fn write_number(&mut self, value: u32) -> Result<Value, Error> {
-        Ok(Value::Number(value.into()))
-    }
-
-    fn write_str(&mut self, value: String) -> Result<Value, Error> {
-        Ok(Value::String(value))
-    }
-
-    fn write_vec(&mut self, value: Self::Vec) -> Result<Value, Error> {
-        Ok(Value::Array(value))
-    }
-
-    fn write_map(&mut self, value: Self::Map) -> Result<Value, Error> {
-        Ok(Value::Object(value))
-    }
-
-    fn vec_push_element(&mut self, vec: &mut Vec<Value>, val: Value) -> Result<(), Error> {
-        vec.push(val);
-        Ok(())
-    }
-
-    fn map_push_field(
-        &mut self,
-        map: &mut Map<String, Value>,
-        key: String,
-        val: Value,
-    ) -> Result<(), Error> {
-        map.insert(key, val);
-        Ok(())
-    }
-}
-
 impl From<RV::Error> for Error {
-    fn from(RV::Error: RV::Error) -> Self {
-        Error::UnexpectedType
-    }
-}
-
-impl From<OV::Error> for Error {
-    fn from(OV::Error: OV::Error) -> Self {
-        Error::UnexpectedType
+    fn from(error: RV::Error) -> Self {
+        match error {
+            RV::Error::Visitor(error) => Error::Visitor(error),
+            RV::Error::Option(OV::Error) => Error::UnexpectedType,
+            RV::Error::UnexpectedType => Error::UnexpectedType,
+            RV::Error::Meter(_) => unreachable!("JsonVisitor is unmetered"),
+        }
     }
 }

--- a/crates/sui-types/src/lib.rs
+++ b/crates/sui-types/src/lib.rs
@@ -80,7 +80,6 @@ pub mod nitro_attestation;
 pub mod object;
 pub mod passkey_authenticator;
 pub mod programmable_transaction_builder;
-pub mod proto_value;
 pub mod ptb_trace;
 pub mod randomness_state;
 pub mod rpc_proto_conversions;

--- a/crates/sui-types/src/object/rpc_visitor/format.rs
+++ b/crates/sui-types/src/object/rpc_visitor/format.rs
@@ -1,0 +1,59 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::object::rpc_visitor::Meter;
+use crate::object::rpc_visitor::MeterError;
+
+/// A trait for serializing Move values into some nested structured representation that supports
+/// `null`, `bool`, numbers, strings, vectors, and maps (e.g. JSON or Protobuf).
+///
+/// Formats decide both the output shape and how each output operation is charged against a meter.
+pub trait Format: Sized {
+    type Vec: Default;
+    type Map: Default;
+
+    fn is_null(&self) -> bool;
+    fn is_bool(&self) -> bool;
+    fn is_number(&self) -> bool;
+    fn is_string(&self) -> bool;
+    fn is_array(&self) -> bool;
+    fn is_object(&self) -> bool;
+
+    fn as_bool(&self) -> Option<bool>;
+    fn as_string(&self) -> Option<&str>;
+    fn as_array(&self) -> Option<&Self::Vec>;
+    fn as_object(&self) -> Option<&Self::Map>;
+
+    /// Write a `null` value.
+    fn null<M: Meter>(meter: &mut M) -> Result<Self, MeterError>;
+
+    /// Write a `true` or `false` value.
+    fn bool<M: Meter>(meter: &mut M, value: bool) -> Result<Self, MeterError>;
+
+    /// Write a numeric value that fits in a `u32`.
+    fn number<M: Meter>(meter: &mut M, value: u32) -> Result<Self, MeterError>;
+
+    /// Write a string value.
+    fn string<M: Meter>(meter: &mut M, value: String) -> Result<Self, MeterError>;
+
+    /// Write a completed vector.
+    fn vec<M: Meter>(meter: &mut M, value: Self::Vec) -> Result<Self, MeterError>;
+
+    /// Write a completed key-value map.
+    fn map<M: Meter>(meter: &mut M, value: Self::Map) -> Result<Self, MeterError>;
+
+    /// Add an element to a vector.
+    fn vec_push_element<M: Meter>(
+        meter: &mut M,
+        vec: &mut Self::Vec,
+        val: Self,
+    ) -> Result<(), MeterError>;
+
+    /// Add a key-value pair to a map.
+    fn map_push_field<M: Meter>(
+        meter: &mut M,
+        map: &mut Self::Map,
+        key: String,
+        val: Self,
+    ) -> Result<(), MeterError>;
+}

--- a/crates/sui-types/src/object/rpc_visitor/json.rs
+++ b/crates/sui-types/src/object/rpc_visitor/json.rs
@@ -1,0 +1,110 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use serde_json::Map;
+use serde_json::Value as Json;
+
+use crate::object::rpc_visitor::Format;
+use crate::object::rpc_visitor::Meter;
+use crate::object::rpc_visitor::MeterError;
+
+impl Format for Json {
+    type Vec = Vec<Self>;
+    type Map = Map<String, Self>;
+
+    fn is_null(&self) -> bool {
+        self.is_null()
+    }
+
+    fn is_bool(&self) -> bool {
+        self.is_boolean()
+    }
+
+    fn is_number(&self) -> bool {
+        self.is_number()
+    }
+
+    fn is_string(&self) -> bool {
+        self.is_string()
+    }
+
+    fn is_array(&self) -> bool {
+        self.is_array()
+    }
+
+    fn is_object(&self) -> bool {
+        self.is_object()
+    }
+
+    fn as_bool(&self) -> Option<bool> {
+        self.as_bool()
+    }
+
+    fn as_string(&self) -> Option<&str> {
+        self.as_str()
+    }
+
+    fn as_array(&self) -> Option<&Self::Vec> {
+        self.as_array()
+    }
+
+    fn as_object(&self) -> Option<&Self::Map> {
+        self.as_object()
+    }
+
+    fn null<M: Meter>(meter: &mut M) -> Result<Self, MeterError> {
+        meter.charge("null".len())?;
+        Ok(Json::Null)
+    }
+
+    fn bool<M: Meter>(meter: &mut M, value: bool) -> Result<Self, MeterError> {
+        meter.charge(if value { "true".len() } else { "false".len() })?;
+        Ok(Json::Bool(value))
+    }
+
+    fn number<M: Meter>(meter: &mut M, value: u32) -> Result<Self, MeterError> {
+        meter.charge(if value == 0 { 1 } else { value.ilog10() + 1 } as usize)?;
+        Ok(Json::Number(value.into()))
+    }
+
+    fn string<M: Meter>(meter: &mut M, value: String) -> Result<Self, MeterError> {
+        // Account for the quotes around the string
+        meter.charge(2 + value.len())?;
+        Ok(Json::String(value))
+    }
+
+    fn vec<M: Meter>(meter: &mut M, value: Self::Vec) -> Result<Self, MeterError> {
+        // Account for the opening bracket
+        meter.charge(1)?;
+        Ok(Json::Array(value))
+    }
+
+    fn map<M: Meter>(meter: &mut M, value: Self::Map) -> Result<Self, MeterError> {
+        // Account for the opening brace
+        meter.charge(1)?;
+        Ok(Json::Object(value))
+    }
+
+    fn vec_push_element<M: Meter>(
+        meter: &mut M,
+        vec: &mut Self::Vec,
+        value: Self,
+    ) -> Result<(), MeterError> {
+        // Account for the comma (or closing bracket)
+        meter.charge(1)?;
+        vec.push(value);
+        Ok(())
+    }
+
+    fn map_push_field<M: Meter>(
+        meter: &mut M,
+        map: &mut Self::Map,
+        key: String,
+        value: Self,
+    ) -> Result<(), MeterError> {
+        // Account for quotes, colon, and comma (or closing brace)
+        meter.charge(4 + key.len())?;
+        map.insert(key, value);
+        Ok(())
+    }
+}

--- a/crates/sui-types/src/object/rpc_visitor/meter.rs
+++ b/crates/sui-types/src/object/rpc_visitor/meter.rs
@@ -1,0 +1,84 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// A trait for tracking the resource limits consumed while serializing a value.
+pub trait Meter {
+    type Nested<'a>: Meter
+    where
+        Self: 'a;
+
+    /// Produce a new meter for nested contexts, consuming one unit of nesting budget.
+    fn nest(&mut self) -> Result<Self::Nested<'_>, MeterError>;
+
+    /// Charge `amount` units against the remaining size budget.
+    fn charge(&mut self, amount: usize) -> Result<(), MeterError>;
+}
+
+#[derive(Clone, Copy, Default)]
+pub struct Unmetered;
+
+/// A meter backed by mutable local budget state.
+///
+/// "Local" means nested visitors share a single remaining size budget reference while each meter
+/// handle keeps its own remaining depth budget.
+pub struct LocalMeter<'a> {
+    size_budget: &'a mut usize,
+    depth_budget: usize,
+}
+
+#[derive(thiserror::Error, Debug, Clone, Copy)]
+pub enum MeterError {
+    #[error("Deserialized value too large")]
+    TooBig,
+
+    #[error("Exceeded maximum depth")]
+    TooDeep,
+}
+
+impl<'a> LocalMeter<'a> {
+    pub fn new(size_budget: &'a mut usize, depth_budget: usize) -> Self {
+        Self {
+            size_budget,
+            depth_budget,
+        }
+    }
+}
+
+impl Meter for Unmetered {
+    type Nested<'a>
+        = Self
+    where
+        Self: 'a;
+
+    fn nest(&mut self) -> Result<Self::Nested<'_>, MeterError> {
+        Ok(*self)
+    }
+
+    fn charge(&mut self, _amount: usize) -> Result<(), MeterError> {
+        Ok(())
+    }
+}
+
+impl Meter for LocalMeter<'_> {
+    type Nested<'a>
+        = LocalMeter<'a>
+    where
+        Self: 'a;
+
+    fn nest(&mut self) -> Result<Self::Nested<'_>, MeterError> {
+        if self.depth_budget == 0 {
+            Err(MeterError::TooDeep)
+        } else {
+            Ok(LocalMeter::new(self.size_budget, self.depth_budget - 1))
+        }
+    }
+
+    fn charge(&mut self, amount: usize) -> Result<(), MeterError> {
+        if *self.size_budget < amount {
+            Err(MeterError::TooBig)
+        } else {
+            *self.size_budget -= amount;
+            Ok(())
+        }
+    }
+}

--- a/crates/sui-types/src/object/rpc_visitor/mod.rs
+++ b/crates/sui-types/src/object/rpc_visitor/mod.rs
@@ -1,6 +1,19 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+mod format;
+pub mod json;
+mod meter;
+pub mod proto;
+
+pub use format::Format;
+pub use meter::LocalMeter;
+pub use meter::Meter;
+pub use meter::MeterError;
+pub use meter::Unmetered;
+
+use std::marker::PhantomData;
+
 use move_core_types::account_address::AccountAddress;
 use move_core_types::annotated_visitor as AV;
 use move_core_types::language_storage::TypeTag;
@@ -15,94 +28,50 @@ use crate::id::ID;
 use crate::id::UID;
 use crate::object::option_visitor as OV;
 
-/// A trait for serializing Move values into some nested structured representation that supports
-/// `null`, `bool`, numbers, strings, vectors, and maps (e.g. JSON or Protobuf).
-///
-/// Writers are allowed to fail, e.g. to limit resource usage.
-pub trait Writer {
-    type Value;
-    type Error: std::error::Error
-        + From<Error>
-        + From<OV::Error>
-        + From<AV::Error>
-        + Send
-        + Sync
-        + 'static;
-
-    type Vec: Default;
-    type Map: Default;
-
-    type Nested<'a>: Writer<Value = Self::Value, Error = Self::Error, Vec = Self::Vec, Map = Self::Map>
-    where
-        Self: 'a;
-
-    /// Produce a new writer for writing into nested contexts (e.g. fields of structs or enum
-    /// variants, or elements of vectors).
-    fn nest(&mut self) -> Result<Self::Nested<'_>, Self::Error>;
-
-    /// Write a `null` value.
-    fn write_null(&mut self) -> Result<Self::Value, Self::Error>;
-
-    /// Write a `true` or `false` value.
-    fn write_bool(&mut self, value: bool) -> Result<Self::Value, Self::Error>;
-
-    /// Write a numeric value that fits in a `u32`.
-    fn write_number(&mut self, value: u32) -> Result<Self::Value, Self::Error>;
-
-    /// Write a string value.
-    fn write_str(&mut self, value: String) -> Result<Self::Value, Self::Error>;
-
-    /// Write a completed vector.
-    fn write_vec(&mut self, value: Self::Vec) -> Result<Self::Value, Self::Error>;
-
-    /// Write a completed key-value map.
-    fn write_map(&mut self, value: Self::Map) -> Result<Self::Value, Self::Error>;
-
-    /// Add an element to a vector.
-    fn vec_push_element(
-        &mut self,
-        vec: &mut Self::Vec,
-        val: Self::Value,
-    ) -> Result<(), Self::Error>;
-
-    /// Add a key-value pair to a map.
-    fn map_push_field(
-        &mut self,
-        map: &mut Self::Map,
-        key: String,
-        val: Self::Value,
-    ) -> Result<(), Self::Error>;
-}
-
 /// A visitor that serializes Move values into some representation appropriate for RPC outputs.
 ///
-/// The `W: Writer` type parameter determines the output format and how resource limits are
-/// enforced.
-pub struct RpcVisitor<W: Writer> {
-    writer: W,
+/// The `F: Format` type parameter determines the output format and charging semantics, while the
+/// `M: Meter` type parameter determines how budgets are tracked.
+pub struct RpcVisitor<F: Format, M: Meter> {
+    meter: M,
+    phantom: PhantomData<fn() -> F>,
 }
 
 #[derive(thiserror::Error, Debug)]
-#[error("Unexpected type")]
-pub struct Error;
+pub enum Error {
+    #[error(transparent)]
+    Visitor(#[from] AV::Error),
 
-impl<W: Writer> RpcVisitor<W> {
-    /// Create a new RPC visitor that writes into the given writer.
-    pub fn new(writer: W) -> Self {
-        Self { writer }
+    #[error(transparent)]
+    Option(#[from] OV::Error),
+
+    #[error(transparent)]
+    Meter(#[from] MeterError),
+
+    #[error("Unexpected type")]
+    UnexpectedType,
+}
+
+impl<F: Format, M: Meter> RpcVisitor<F, M> {
+    /// Create a new RPC visitor that writes into the chosen format with the given meter.
+    pub fn new(meter: M) -> Self {
+        Self {
+            meter,
+            phantom: PhantomData,
+        }
     }
 }
 
-impl<'b, 'l, W: Writer> AV::Visitor<'b, 'l> for RpcVisitor<W> {
-    type Value = <W as Writer>::Value;
-    type Error = <W as Writer>::Error;
+impl<'b, 'l, F: Format, M: Meter> AV::Visitor<'b, 'l> for RpcVisitor<F, M> {
+    type Value = F;
+    type Error = Error;
 
     fn visit_u8(
         &mut self,
         _: &AV::ValueDriver<'_, 'b, 'l>,
         value: u8,
     ) -> Result<Self::Value, Self::Error> {
-        self.writer.write_number(value as u32)
+        Ok(F::number(&mut self.meter, value as u32)?)
     }
 
     fn visit_u16(
@@ -110,7 +79,7 @@ impl<'b, 'l, W: Writer> AV::Visitor<'b, 'l> for RpcVisitor<W> {
         _: &AV::ValueDriver<'_, 'b, 'l>,
         value: u16,
     ) -> Result<Self::Value, Self::Error> {
-        self.writer.write_number(value as u32)
+        Ok(F::number(&mut self.meter, value as u32)?)
     }
 
     fn visit_u32(
@@ -118,7 +87,7 @@ impl<'b, 'l, W: Writer> AV::Visitor<'b, 'l> for RpcVisitor<W> {
         _: &AV::ValueDriver<'_, 'b, 'l>,
         value: u32,
     ) -> Result<Self::Value, Self::Error> {
-        self.writer.write_number(value)
+        Ok(F::number(&mut self.meter, value)?)
     }
 
     fn visit_u64(
@@ -126,7 +95,7 @@ impl<'b, 'l, W: Writer> AV::Visitor<'b, 'l> for RpcVisitor<W> {
         _: &AV::ValueDriver<'_, 'b, 'l>,
         value: u64,
     ) -> Result<Self::Value, Self::Error> {
-        self.writer.write_str(value.to_string())
+        Ok(F::string(&mut self.meter, value.to_string())?)
     }
 
     fn visit_u128(
@@ -134,7 +103,7 @@ impl<'b, 'l, W: Writer> AV::Visitor<'b, 'l> for RpcVisitor<W> {
         _: &AV::ValueDriver<'_, 'b, 'l>,
         value: u128,
     ) -> Result<Self::Value, Self::Error> {
-        self.writer.write_str(value.to_string())
+        Ok(F::string(&mut self.meter, value.to_string())?)
     }
 
     fn visit_u256(
@@ -142,7 +111,7 @@ impl<'b, 'l, W: Writer> AV::Visitor<'b, 'l> for RpcVisitor<W> {
         _: &AV::ValueDriver<'_, 'b, 'l>,
         value: U256,
     ) -> Result<Self::Value, Self::Error> {
-        self.writer.write_str(value.to_string())
+        Ok(F::string(&mut self.meter, value.to_string())?)
     }
 
     fn visit_bool(
@@ -150,7 +119,7 @@ impl<'b, 'l, W: Writer> AV::Visitor<'b, 'l> for RpcVisitor<W> {
         _: &AV::ValueDriver<'_, 'b, 'l>,
         value: bool,
     ) -> Result<Self::Value, Self::Error> {
-        self.writer.write_bool(value)
+        Ok(F::bool(&mut self.meter, value)?)
     }
 
     fn visit_address(
@@ -158,7 +127,7 @@ impl<'b, 'l, W: Writer> AV::Visitor<'b, 'l> for RpcVisitor<W> {
         _: &AV::ValueDriver<'_, 'b, 'l>,
         value: AccountAddress,
     ) -> Result<Self::Value, Self::Error> {
-        self.writer.write_str(value.to_canonical_string(true))
+        Ok(F::string(&mut self.meter, value.to_canonical_string(true))?)
     }
 
     fn visit_signer(
@@ -166,7 +135,7 @@ impl<'b, 'l, W: Writer> AV::Visitor<'b, 'l> for RpcVisitor<W> {
         _: &AV::ValueDriver<'_, 'b, 'l>,
         value: AccountAddress,
     ) -> Result<Self::Value, Self::Error> {
-        self.writer.write_str(value.to_canonical_string(true))
+        Ok(F::string(&mut self.meter, value.to_canonical_string(true))?)
     }
 
     fn visit_vector(
@@ -174,30 +143,31 @@ impl<'b, 'l, W: Writer> AV::Visitor<'b, 'l> for RpcVisitor<W> {
         driver: &mut AV::VecDriver<'_, 'b, 'l>,
     ) -> Result<Self::Value, Self::Error> {
         if driver.element_layout().is_type(&TypeTag::U8) {
-            // Base64 encode arbitrary bytes
-            use base64::{Engine, engine::general_purpose::STANDARD};
+            use base64::Engine;
+            use base64::engine::general_purpose::STANDARD;
 
+            // Base64 encode arbitrary bytes
             if let Some(bytes) = driver
                 .bytes()
                 .get(driver.position()..(driver.position() + driver.len() as usize))
             {
                 let b64 = STANDARD.encode(bytes);
-                self.writer.write_str(b64)
+                Ok(F::string(&mut self.meter, b64)?)
             } else {
                 Err(AV::Error::UnexpectedEof.into())
             }
         } else {
-            let mut elems = W::Vec::default();
-            {
-                let nested = self.writer.nest()?;
-                let mut visitor = RpcVisitor { writer: nested };
+            let mut elems = F::Vec::default();
 
+            {
+                let nested = self.meter.nest()?;
+                let mut visitor = RpcVisitor::new(nested);
                 while let Some(elem) = driver.next_element(&mut visitor)? {
-                    visitor.writer.vec_push_element(&mut elems, elem)?;
+                    F::vec_push_element(&mut visitor.meter, &mut elems, elem)?;
                 }
             }
 
-            self.writer.write_vec(elems)
+            Ok(F::vec(&mut self.meter, elems)?)
         }
     }
 
@@ -220,8 +190,8 @@ impl<'b, 'l, W: Writer> AV::Visitor<'b, 'l> for RpcVisitor<W> {
 
             // HACK: Bypassing the layout to deserialize its bytes as a Rust type.
             let bytes = &driver.bytes()[lo..hi];
-            let s: String = bcs::from_bytes(bytes).map_err(|_| Error)?;
-            self.writer.write_str(s)
+            let s: String = bcs::from_bytes(bytes).map_err(|_| Error::UnexpectedType)?;
+            Ok(F::string(&mut self.meter, s)?)
         } else if layout == &UID::layout() || layout == &ID::layout() {
             // 0x2::object::UID or 0x2::object::ID
 
@@ -232,16 +202,16 @@ impl<'b, 'l, W: Writer> AV::Visitor<'b, 'l> for RpcVisitor<W> {
             // HACK: Bypassing the layout to deserialize its bytes as a Rust type.
             let bytes = &driver.bytes()[lo..hi];
             let id = AccountAddress::from_bytes(bytes)
-                .map_err(|_| Error)?
+                .map_err(|_| Error::UnexpectedType)?
                 .to_canonical_string(true);
 
-            self.writer.write_str(id)
+            Ok(F::string(&mut self.meter, id)?)
         } else if (&ty.address, ty.module.as_ref(), ty.name.as_ref()) == RESOLVED_STD_OPTION {
             // 0x1::option::Option
 
             match OV::OptionVisitor(self).visit_struct(driver)? {
                 Some(value) => Ok(value),
-                None => self.writer.write_null(),
+                None => Ok(F::null(&mut self.meter)?),
             }
         } else if Balance::is_balance_layout(layout) {
             // 0x2::balance::Balance
@@ -253,25 +223,25 @@ impl<'b, 'l, W: Writer> AV::Visitor<'b, 'l> for RpcVisitor<W> {
             // HACK: Bypassing the layout to deserialize its bytes as a Rust type.
             let bytes = &driver.bytes()[lo..hi];
             let balance = bcs::from_bytes::<u64>(bytes)
-                .map_err(|_| Error)?
+                .map_err(|_| Error::UnexpectedType)?
                 .to_string();
 
-            self.writer.write_str(balance)
+            Ok(F::string(&mut self.meter, balance)?)
         } else {
             // Arbitrary structs
 
-            let mut map = W::Map::default();
-            {
-                let nested = self.writer.nest()?;
-                let mut visitor = RpcVisitor { writer: nested };
+            let mut map = F::Map::default();
 
+            {
+                let nested = self.meter.nest()?;
+                let mut visitor = RpcVisitor::<F, _>::new(nested);
                 while let Some((field, elem)) = driver.next_field(&mut visitor)? {
                     let name = field.name.to_string();
-                    visitor.writer.map_push_field(&mut map, name, elem)?;
+                    F::map_push_field(&mut visitor.meter, &mut map, name, elem)?;
                 }
             }
 
-            self.writer.write_map(map)
+            Ok(F::map(&mut self.meter, map)?)
         }
     }
 
@@ -279,21 +249,21 @@ impl<'b, 'l, W: Writer> AV::Visitor<'b, 'l> for RpcVisitor<W> {
         &mut self,
         driver: &mut AV::VariantDriver<'_, 'b, 'l>,
     ) -> Result<Self::Value, Self::Error> {
-        let mut map = W::Map::default();
+        let mut map = F::Map::default();
         {
-            let mut nested = self.writer.nest()?;
+            let mut nested_meter = self.meter.nest()?;
 
-            let variant = nested.write_str(driver.variant_name().to_string())?;
-            nested.map_push_field(&mut map, "@variant".to_owned(), variant)?;
+            let variant = F::string(&mut nested_meter, driver.variant_name().to_string())?;
+            F::map_push_field(&mut nested_meter, &mut map, "@variant".to_owned(), variant)?;
 
-            let mut visitor = RpcVisitor { writer: nested };
+            let mut visitor = RpcVisitor::<F, _>::new(nested_meter);
             while let Some((field, elem)) = driver.next_field(&mut visitor)? {
                 let name = field.name.to_string();
-                visitor.writer.map_push_field(&mut map, name, elem)?;
+                F::map_push_field(&mut visitor.meter, &mut map, name, elem)?;
             }
         }
 
-        self.writer.write_map(map)
+        Ok(F::map(&mut self.meter, map)?)
     }
 }
 
@@ -330,89 +300,9 @@ mod tests {
         };
     }
 
-    struct JsonWriter;
-
-    #[derive(thiserror::Error, Debug)]
-    enum Error {
-        #[error(transparent)]
-        Visitor(#[from] AV::Error),
-
-        #[error("Unexpected type")]
-        UnexpectedType,
-    }
-
-    impl Writer for JsonWriter {
-        type Value = Value;
-        type Error = Error;
-
-        type Vec = Vec<Value>;
-        type Map = serde_json::Map<String, Value>;
-
-        type Nested<'a> = Self;
-
-        fn nest(&mut self) -> Result<Self::Nested<'_>, Self::Error> {
-            Ok(JsonWriter)
-        }
-
-        fn write_null(&mut self) -> Result<Self::Value, Self::Error> {
-            Ok(Value::Null)
-        }
-
-        fn write_bool(&mut self, value: bool) -> Result<Self::Value, Self::Error> {
-            Ok(Value::Bool(value))
-        }
-
-        fn write_number(&mut self, value: u32) -> Result<Self::Value, Self::Error> {
-            Ok(Value::Number(value.into()))
-        }
-
-        fn write_str(&mut self, value: String) -> Result<Self::Value, Self::Error> {
-            Ok(Value::String(value))
-        }
-
-        fn write_vec(&mut self, value: Self::Vec) -> Result<Self::Value, Self::Error> {
-            Ok(Value::Array(value))
-        }
-
-        fn write_map(&mut self, value: Self::Map) -> Result<Self::Value, Self::Error> {
-            Ok(Value::Object(value))
-        }
-
-        fn vec_push_element(
-            &mut self,
-            vec: &mut Self::Vec,
-            value: Self::Value,
-        ) -> Result<(), Self::Error> {
-            vec.push(value);
-            Ok(())
-        }
-
-        fn map_push_field(
-            &mut self,
-            map: &mut Self::Map,
-            key: String,
-            val: Self::Value,
-        ) -> Result<(), Self::Error> {
-            map.insert(key, val);
-            Ok(())
-        }
-    }
-
-    impl From<OV::Error> for Error {
-        fn from(OV::Error: OV::Error) -> Self {
-            Error::UnexpectedType
-        }
-    }
-
-    impl From<super::Error> for Error {
-        fn from(super::Error: super::Error) -> Self {
-            Error::UnexpectedType
-        }
-    }
-
     fn json<T: Serialize>(layout: A::MoveTypeLayout, data: T) -> Value {
         let bcs = bcs::to_bytes(&data).unwrap();
-        let mut visitor = RpcVisitor::new(JsonWriter);
+        let mut visitor = RpcVisitor::new(Unmetered);
         A::MoveValue::visit_deserialize(&bcs, &layout, &mut visitor).unwrap()
     }
 

--- a/crates/sui-types/src/object/rpc_visitor/proto.rs
+++ b/crates/sui-types/src/object/rpc_visitor/proto.rs
@@ -2,17 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use move_core_types::annotated_value as A;
-use move_core_types::annotated_visitor as AV;
 use prost_types::Struct;
 use prost_types::Value;
 use prost_types::value::Kind;
 
-use crate::object::option_visitor as OV;
 use crate::object::rpc_visitor as RV;
 
-/// This is the maximum depth of a proto message
-/// The maximum depth of a proto message is 100. Given this value may be nested itself somewhere
-/// we'll conservitively cap this to ~80% of that.
+/// This is the maximum depth of a proto message.
+/// The maximum depth of a proto message is 100. Given this value may be nested itself somewhere,
+/// we'll conservatively cap this to ~80% of that.
 const MAX_DEPTH: usize = 80;
 
 pub struct ProtoVisitor {
@@ -20,163 +18,139 @@ pub struct ProtoVisitor {
     bound: usize,
 }
 
-pub struct ProtoWriter<'b> {
-    bound: &'b mut usize,
-    depth: usize,
-}
-
-#[derive(thiserror::Error, Debug)]
-pub enum Error {
-    #[error(transparent)]
-    Visitor(#[from] AV::Error),
-
-    #[error("Deserialized value too large")]
-    OutOfBudget,
-
-    #[error("Exceeded maximum depth")]
-    TooNested,
-
-    #[error("Unexpected type")]
-    UnexpectedType,
-}
-
 impl ProtoVisitor {
     pub fn new(bound: usize) -> Self {
         Self { bound }
     }
 
-    /// Deserialize `bytes` as a `MoveValue` with layout `layout`. Can fail if the bytes do not
-    /// represent a value with this layout, or if the deserialized value exceeds the field/type size
-    /// budget.
+    /// Deserialize `bytes` as a `MoveValue` with layout `layout`.
     pub fn deserialize_value(
         mut self,
         bytes: &[u8],
         layout: &A::MoveTypeLayout,
-    ) -> Result<Value, Error> {
+    ) -> Result<Value, RV::Error> {
         A::MoveValue::visit_deserialize(
             bytes,
             layout,
-            &mut RV::RpcVisitor::new(ProtoWriter {
-                bound: &mut self.bound,
-                depth: 0,
-            }),
+            &mut RV::RpcVisitor::<Value, _>::new(RV::LocalMeter::new(&mut self.bound, MAX_DEPTH)),
         )
     }
 }
 
-impl ProtoWriter<'_> {
-    fn debit(&mut self, size: usize) -> Result<(), Error> {
-        if *self.bound < size {
-            Err(Error::OutOfBudget)
-        } else {
-            *self.bound -= size;
-            Ok(())
-        }
-    }
-
-    fn debit_value(&mut self) -> Result<(), Error> {
-        self.debit(size_of::<Value>())
-    }
-
-    fn debit_str(&mut self, s: &str) -> Result<(), Error> {
-        self.debit(s.len())
-    }
-
-    fn debit_string_value(&mut self, s: &str) -> Result<(), Error> {
-        self.debit_str(s)?;
-        self.debit_value()
-    }
-}
-
-impl<'b> RV::Writer for ProtoWriter<'b> {
-    type Value = Value;
-    type Error = Error;
-
+impl RV::Format for Value {
     type Vec = Vec<Value>;
     type Map = Struct;
 
-    type Nested<'a>
-        = ProtoWriter<'a>
-    where
-        Self: 'a;
+    fn is_null(&self) -> bool {
+        matches!(self.kind, Some(Kind::NullValue(_)))
+    }
 
-    fn nest(&mut self) -> Result<Self::Nested<'_>, Self::Error> {
-        if self.depth >= MAX_DEPTH {
-            Err(Error::TooNested)
+    fn is_bool(&self) -> bool {
+        self.as_bool().is_some()
+    }
+
+    fn is_number(&self) -> bool {
+        matches!(self.kind, Some(Kind::NumberValue(_)))
+    }
+
+    fn is_string(&self) -> bool {
+        self.as_string().is_some()
+    }
+
+    fn is_array(&self) -> bool {
+        self.as_array().is_some()
+    }
+
+    fn is_object(&self) -> bool {
+        self.as_object().is_some()
+    }
+
+    fn as_bool(&self) -> Option<bool> {
+        if let Some(Kind::BoolValue(b)) = &self.kind {
+            Some(*b)
         } else {
-            Ok(ProtoWriter {
-                bound: self.bound,
-                depth: self.depth + 1,
-            })
+            None
         }
     }
 
-    fn write_null(&mut self) -> Result<Self::Value, Self::Error> {
-        self.debit_value()?;
+    fn as_string(&self) -> Option<&str> {
+        if let Some(Kind::StringValue(value)) = &self.kind {
+            Some(value)
+        } else {
+            None
+        }
+    }
+
+    fn as_array(&self) -> Option<&Self::Vec> {
+        if let Some(Kind::ListValue(value)) = &self.kind {
+            Some(&value.values)
+        } else {
+            None
+        }
+    }
+
+    fn as_object(&self) -> Option<&Self::Map> {
+        if let Some(Kind::StructValue(value)) = &self.kind {
+            Some(value)
+        } else {
+            None
+        }
+    }
+
+    fn null<M: RV::Meter>(meter: &mut M) -> Result<Self, RV::MeterError> {
+        meter.charge(std::mem::size_of::<Value>())?;
         Ok(Kind::NullValue(0).into())
     }
 
-    fn write_bool(&mut self, value: bool) -> Result<Self::Value, Self::Error> {
-        self.debit_value()?;
-        Ok(Kind::BoolValue(value).into())
+    fn bool<M: RV::Meter>(meter: &mut M, value: bool) -> Result<Self, RV::MeterError> {
+        meter.charge(std::mem::size_of::<Value>())?;
+        Ok(Self::from(value))
     }
 
-    fn write_number(&mut self, value: u32) -> Result<Self::Value, Self::Error> {
-        self.debit_value()?;
-        Ok(Value::from(value))
+    fn number<M: RV::Meter>(meter: &mut M, value: u32) -> Result<Self, RV::MeterError> {
+        meter.charge(std::mem::size_of::<Value>())?;
+        Ok(Self::from(value))
     }
 
-    fn write_str(&mut self, value: String) -> Result<Self::Value, Self::Error> {
-        self.debit_string_value(&value)?;
-        Ok(Kind::StringValue(value).into())
+    fn string<M: RV::Meter>(meter: &mut M, value: String) -> Result<Self, RV::MeterError> {
+        meter.charge(std::mem::size_of::<Value>() + value.len())?;
+        Ok(Self::from(value))
     }
 
-    fn write_vec(&mut self, value: Self::Vec) -> Result<Self::Value, Self::Error> {
-        self.debit_value()?;
-        Ok(Value::from(value))
+    fn vec<M: RV::Meter>(meter: &mut M, value: Self::Vec) -> Result<Self, RV::MeterError> {
+        meter.charge(std::mem::size_of::<Value>())?;
+        Ok(Self::from(value))
     }
 
-    fn write_map(&mut self, value: Self::Map) -> Result<Self::Value, Self::Error> {
-        self.debit_value()?;
-        Ok(Value::from(Kind::StructValue(value)))
+    fn map<M: RV::Meter>(meter: &mut M, value: Self::Map) -> Result<Self, RV::MeterError> {
+        meter.charge(std::mem::size_of::<Value>())?;
+        Ok(Self::from(Kind::StructValue(value)))
     }
 
-    fn vec_push_element(
-        &mut self,
+    fn vec_push_element<M: RV::Meter>(
+        _meter: &mut M,
         vec: &mut Self::Vec,
-        val: Self::Value,
-    ) -> Result<(), Self::Error> {
-        vec.push(val);
+        value: Self,
+    ) -> Result<(), RV::MeterError> {
+        vec.push(value);
         Ok(())
     }
 
-    fn map_push_field(
-        &mut self,
+    fn map_push_field<M: RV::Meter>(
+        meter: &mut M,
         map: &mut Self::Map,
         key: String,
-        val: Self::Value,
-    ) -> Result<(), Self::Error> {
-        self.debit_str(&key)?;
-        map.fields.insert(key, val);
+        value: Self,
+    ) -> Result<(), RV::MeterError> {
+        meter.charge(key.len())?;
+        map.fields.insert(key, value);
         Ok(())
-    }
-}
-
-impl From<RV::Error> for Error {
-    fn from(RV::Error: RV::Error) -> Self {
-        Error::UnexpectedType
-    }
-}
-
-impl From<OV::Error> for Error {
-    fn from(OV::Error: OV::Error) -> Self {
-        Error::UnexpectedType
     }
 }
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use super::*;
+    use crate::object::rpc_visitor::proto::*;
 
     use crate::object::bounded_visitor::tests::layout_;
     use crate::object::bounded_visitor::tests::serialize;
@@ -253,7 +227,6 @@ pub(crate) mod tests {
 
         assert_eq!(expected, proto_value_to_json_value(deser));
 
-        // One deeper
         layout = layout_("0x0::foo::Bar", vec![("f", layout)]);
         value = value_("0x0::foo::Bar", vec![("f", value)]);
 
@@ -270,7 +243,7 @@ pub(crate) mod tests {
     fn proto_value_to_json_value(proto: Value) -> serde_json::Value {
         match proto.kind {
             Some(Kind::NullValue(_)) | None => serde_json::Value::Null,
-            // Move doesn't support floats so for these tests can do a convert to u32
+            // Move doesn't support floats, so these tests can safely convert numbers back to u32.
             Some(Kind::NumberValue(n)) => serde_json::Value::from(n as u32),
             Some(Kind::StringValue(s)) => serde_json::Value::from(s),
             Some(Kind::BoolValue(b)) => serde_json::Value::from(b),


### PR DESCRIPTION
## Description

Factor `RpcVisitor`'s `Writer` trait into separate `Format` and `Meter` traits. This allows us to consolidate the logic for formatting Move Values in JSON and Protobuf into single `Format` impls, and combine them with different meters based on need (unmetered, single-threaded, and shared meters are implemented as before). The previously coupled `Writer` trait caused the JSON implementation in particular to be duplicated many times, and made it so that the gRPC Display v2 integration ended up using the JSON cost model which was not ideal.

## Test plan

```
$ cargo nextest run \
  -p sui-display \
  -p sui-indexer-alt-graphql \
  -p sui-rpc-api \
  -p sui-rpc-resolver \
  -p sui-types \
  -p sui-indexer-alt-e2e-tests \
  -j3
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
