### PR TITLE
display: support fetching derived objects

### DIFF
--- a/crates/sui-display/src/v2/interpreter.rs
+++ b/crates/sui-display/src/v2/interpreter.rs
@@ -187,6 +187,16 @@ impl<S: V::Store> Interpreter<S> {
                     root = VV::Slice(value_slice);
                 }
 
+                (VV::Address(a), A::Derived(i)) => {
+                    let id = i.derive_object_id(a)?.into();
+                    let Some(slice) = self.object(id).await? else {
+                        return Ok(None);
+                    };
+
+                    accessors.pop();
+                    root = VV::Slice(slice);
+                }
+
                 // Fetch a single byte from a byte array, as long as the accessor evaluates to a
                 // numeric index.
                 (VV::Bytes(bs), accessor) => {
@@ -278,6 +288,7 @@ impl<S: V::Store> Interpreter<S> {
             PA::Index(chain) => Box::pin(self.eval_chain(chain)).await?.map(VA::Index),
             PA::DFIndex(chain) => Box::pin(self.eval_chain(chain)).await?.map(VA::DFIndex),
             PA::DOFIndex(chain) => Box::pin(self.eval_chain(chain)).await?.map(VA::DOFIndex),
+            PA::Derived(chain) => Box::pin(self.eval_chain(chain)).await?.map(VA::Derived),
         })
     }
 

--- a/crates/sui-display/src/v2/lexer.rs
+++ b/crates/sui-display/src/v2/lexer.rs
@@ -40,6 +40,8 @@ pub(crate) enum Token {
     Arrow,
     /// '=>'
     AArrow,
+    /// '~>'
+    TArrow,
     /// '@'
     At,
     /// ':'
@@ -153,6 +155,8 @@ impl<'s> Lexer<'s> {
             b'-' if bytes.get(1) == Some(&b'>') => self.take(ws, T::Arrow, 2),
 
             b'=' if bytes.get(1) == Some(&b'>') => self.take(ws, T::AArrow, 2),
+
+            b'~' if bytes.get(1) == Some(&b'>') => self.take(ws, T::TArrow, 2),
 
             b'@' => self.take(ws, T::At, 1),
 
@@ -311,6 +315,7 @@ impl fmt::Display for OwnedLexeme {
         match self {
             L(_, T::Arrow, _, _) => write!(f, "'->'"),
             L(_, T::AArrow, _, _) => write!(f, "'=>'"),
+            L(_, T::TArrow, _, _) => write!(f, "'~>'"),
             L(_, T::At, _, _) => write!(f, "'@'"),
             L(_, T::Colon, _, _) => write!(f, "':'"),
             L(_, T::CColon, _, _) => write!(f, "'::'"),
@@ -361,6 +366,7 @@ impl fmt::Display for Token {
         match self {
             T::Arrow => write!(f, "'->'"),
             T::AArrow => write!(f, "'=>'"),
+            T::TArrow => write!(f, "'~>'"),
             T::At => write!(f, "'@'"),
             T::Colon => write!(f, "':'"),
             T::CColon => write!(f, "'::'"),
@@ -623,11 +629,12 @@ mod tests {
         "###);
     }
 
-    // Display supports three kinds of index -- `foo[i]`, `bar->[j]`, and `baz=>[k]`, representing
-    // vector/VecMap, dynamic field, and dynamic object field access respectively.
+    // Display supports four kinds of index -- `foo[i]`, `bar->[j]`, `baz=>[k]`, and
+    // `qux~>[m]`, representing vector/VecMap, dynamic field, dynamic object field, and derived
+    // object access respectively.
     #[test]
     fn test_indices() {
-        assert_snapshot!(text(r#"foo {bar[baz].qux=>[quy]->[quz]}"#), @r###"
+        assert_snapshot!(text(r#"foo {bar[baz].qux=>[quy]->[quz]~>[quux]}"#), @r###"
         L(false, Text, 0, "foo ")
         L(false, LBrace, 4, "{")
         L(false, Ident, 5, "bar")
@@ -644,7 +651,11 @@ mod tests {
         L(false, LBracket, 26, "[")
         L(false, Ident, 27, "quz")
         L(false, RBracket, 30, "]")
-        L(false, RBrace, 31, "}")
+        L(false, TArrow, 31, "~>")
+        L(false, LBracket, 33, "[")
+        L(false, Ident, 34, "quux")
+        L(false, RBracket, 38, "]")
+        L(false, RBrace, 39, "}")
         "###);
     }
 

--- a/crates/sui-display/src/v2/mod.rs
+++ b/crates/sui-display/src/v2/mod.rs
@@ -357,6 +357,23 @@ mod tests {
         Ok(Some(value.derive_dynamic_object_field_id(parent)?.into()))
     }
 
+    async fn derived_object_id(
+        store: MockStore,
+        bytes: Vec<u8>,
+        layout: MoveTypeLayout,
+        parent: AccountAddress,
+        literal: &str,
+    ) -> Result<Option<AccountAddress>, FormatError> {
+        let interpreter = Interpreter::new(OwnedSlice { bytes, layout }, store);
+
+        let name = Name::parse(Limits::default(), literal)?;
+        let Some(value) = name.eval(&interpreter).await? else {
+            return Ok(None);
+        };
+
+        Ok(Some(value.derive_object_id(parent)?.into()))
+    }
+
     /// Helper to parse display fields and render them against the provided object.
     async fn format<'s>(
         store: impl Store,
@@ -509,6 +526,64 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_extract_with_derived_object_loads() {
+        let parent = AccountAddress::from_str("0x5100").unwrap();
+        let child = AccountAddress::from_str("0x5101").unwrap();
+        let bytes = bcs::to_bytes(&parent).unwrap();
+
+        let layout = struct_(
+            "0x1::m::Root",
+            vec![(
+                "parent",
+                struct_(
+                    "0x1::m::Parent",
+                    vec![("id", L::Struct(Box::new(UID::layout())))],
+                ),
+            )],
+        );
+
+        let store = MockStore::default().with_derived_object(
+            parent,
+            "derived_key",
+            L::Struct(Box::new(move_utf8_str_layout())),
+            (child, 111u64, 222u64),
+            struct_(
+                "0x1::m::Child",
+                vec![
+                    ("id", L::Struct(Box::new(UID::layout()))),
+                    ("x", L::U64),
+                    ("y", L::U64),
+                ],
+            ),
+        );
+
+        let fields = [
+            "parent~>['derived_key'].x",
+            "parent~>['derived_key'].y",
+            "parent.id~>['derived_key'].id",
+            "parent~>['missing']",
+        ];
+
+        let mut outputs = Vec::with_capacity(fields.len());
+        for field in fields {
+            outputs.push(
+                extract(store.clone(), bytes.clone(), layout.clone(), field)
+                    .await
+                    .unwrap(),
+            );
+        }
+
+        assert_json_snapshot!(outputs, @r###"
+        [
+          "111",
+          "222",
+          "0x0000000000000000000000000000000000000000000000000000000000005101",
+          null
+        ]
+        "###);
+    }
+
+    #[tokio::test]
     async fn test_dynamic_field_names() {
         let parent = AccountAddress::from_str("0x4242").unwrap();
 
@@ -619,6 +694,46 @@ mod tests {
             let type_: TypeTag = type_.parse().unwrap();
             let wrapper_type = DynamicFieldInfo::dynamic_object_field_wrapper(type_);
             let expected = derive_dynamic_field_id(parent, &wrapper_type.into(), &bytes).unwrap();
+            assert_eq!(id, expected.into(), "mismatch for literal: {literal}");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_derived_object_names() {
+        let parent = AccountAddress::from_str("0x4242").unwrap();
+
+        let obj_bytes = bcs::to_bytes(&0u8).unwrap();
+        let obj_layout = L::U8;
+
+        let cases: Vec<(&str, &str, Vec<u8>)> = vec![
+            (
+                "'hello'",
+                "0x1::string::String",
+                bcs::to_bytes(&"hello").unwrap(),
+            ),
+            ("42u64", "u64", bcs::to_bytes(&42u64).unwrap()),
+            (
+                "0x1::m::Key(99u32, 'test')",
+                "0x1::m::Key",
+                bcs::to_bytes(&(99u32, "test")).unwrap(),
+            ),
+        ];
+
+        for (literal, type_, bytes) in cases {
+            let id = derived_object_id(
+                MockStore::default(),
+                obj_bytes.clone(),
+                obj_layout.clone(),
+                parent,
+                literal,
+            )
+            .await
+            .unwrap()
+            .unwrap();
+
+            let type_: TypeTag = type_.parse().unwrap();
+            let expected =
+                sui_types::derived_object::derive_object_id(parent, &type_, &bytes).unwrap();
             assert_eq!(id, expected.into(), "mismatch for literal: {literal}");
         }
     }

--- a/crates/sui-display/src/v2/parser.rs
+++ b/crates/sui-display/src/v2/parser.rs
@@ -78,6 +78,9 @@ pub enum Accessor<'s> {
 
     /// Index into a dynamic object field.
     DOFIndex(Chain<'s>),
+
+    /// Index into a derived object lookup.
+    Derived(Chain<'s>),
 }
 
 /// Literal forms are elements whose syntax determines their (outer) type.
@@ -245,6 +248,7 @@ macro_rules! match_token_opt {
 ///              | '[' chain ']'
 ///              | '->' '[' chain ']'
 ///              | '=>' '[' chain ']'
+///              | '~>' '[' chain ']'
 ///
 ///   literal  ::= self | address | bool | number | string | vector | struct | enum
 ///
@@ -595,6 +599,18 @@ impl<'s> Parser<'s> {
                 meter.load()?;
                 meter.alloc()?;
                 Accessor::DOFIndex(chain)
+            },
+
+            Tok(_, T::TArrow, _, _) => {
+                self.lexer.next();
+
+                match_token! { self.lexer; Tok(_, T::LBracket, _, _) => self.lexer.next() };
+                let chain = self.parse_chain(meter)?;
+                match_token! { self.lexer; Tok(_, T::RBracket, _, _) => self.lexer.next() };
+
+                meter.load()?;
+                meter.alloc()?;
+                Accessor::Derived(chain)
             },
 
             Tok(_, T::LBracket, _, _) => {
@@ -1165,6 +1181,7 @@ impl fmt::Debug for Chain<'_> {
                 A::Index(chain) => write!(f, "[{chain:?}]")?,
                 A::DFIndex(chain) => write!(f, "->[{chain:?}]")?,
                 A::DOFIndex(chain) => write!(f, "=>[{chain:?}]")?,
+                A::Derived(chain) => write!(f, "~>[{chain:?}]")?,
             }
         }
 

--- a/crates/sui-display/src/v2/value.rs
+++ b/crates/sui-display/src/v2/value.rs
@@ -24,6 +24,7 @@ use sui_types::base_types::SuiAddress;
 use sui_types::base_types::move_ascii_str_layout;
 use sui_types::base_types::move_utf8_str_layout;
 use sui_types::base_types::url_layout;
+use sui_types::derived_object::derive_object_id;
 use sui_types::dynamic_field::DynamicFieldInfo;
 use sui_types::dynamic_field::derive_dynamic_field_id;
 use sui_types::id::ID;
@@ -100,6 +101,7 @@ pub enum Accessor<'s> {
     Index(Value<'s>),
     DFIndex(Value<'s>),
     DOFIndex(Value<'s>),
+    Derived(Value<'s>),
 }
 
 /// Bytes extracted from the serialized representation of a Move value, along with its layout.
@@ -169,6 +171,15 @@ impl Value<'_> {
         let type_ = DynamicFieldInfo::dynamic_object_field_wrapper(self.type_()).into();
 
         Ok(derive_dynamic_field_id(parent, &type_, &bytes)?)
+    }
+
+    /// Treat this value as a derived object key and derive the corresponding object ID under the
+    /// given parent address.
+    pub fn derive_object_id(&self, parent: impl Into<SuiAddress>) -> Result<ObjectID, FormatError> {
+        let bytes = bcs::to_bytes(self)?;
+        let type_ = self.type_();
+
+        Ok(derive_object_id(parent, &type_, &bytes)?)
     }
 
     /// Write out a formatted representation of this value, transformed by `transform`, to the
@@ -434,7 +445,7 @@ impl<'s> Accessor<'s> {
         match self {
             A::Index(value) => value.as_u64(),
             // All other index types don't represent a numeric index.
-            A::DFIndex(_) | A::DOFIndex(_) | A::Field(_) | A::Positional(_) => None,
+            A::DFIndex(_) | A::DOFIndex(_) | A::Derived(_) | A::Field(_) | A::Positional(_) => None,
         }
     }
 
@@ -444,7 +455,7 @@ impl<'s> Accessor<'s> {
         match self {
             A::Field(f) => Some(Cow::Borrowed(*f)),
             A::Positional(i) => Some(Cow::Owned(format!("pos{i}"))),
-            A::Index(_) | A::DFIndex(_) | A::DOFIndex(_) => None,
+            A::Index(_) | A::DFIndex(_) | A::DOFIndex(_) | A::Derived(_) => None,
         }
     }
 }
@@ -820,6 +831,7 @@ pub(crate) mod tests {
     use sui_types::MOVE_STDLIB_ADDRESS;
     use sui_types::base_types::STD_ASCII_MODULE_NAME;
     use sui_types::base_types::STD_ASCII_STRUCT_NAME;
+    use sui_types::derived_object::derive_object_id;
     use sui_types::dynamic_field::DynamicFieldInfo;
     use sui_types::dynamic_field::Field;
     use sui_types::dynamic_field::derive_dynamic_field_id;
@@ -937,6 +949,29 @@ pub(crate) mod tests {
 
             self.data.insert(dof_id.into(), field);
             self.data.insert(val_id, value);
+            self
+        }
+
+        /// Add a derived object to the store.
+        pub(crate) fn with_derived_object<N: Serialize, V: Serialize>(
+            mut self,
+            parent: AccountAddress,
+            name: N,
+            name_layout: MoveTypeLayout,
+            value: V,
+            value_layout: MoveTypeLayout,
+        ) -> Self {
+            let name_bytes = bcs::to_bytes(&name).unwrap();
+            let name_type = TypeTag::from(&name_layout);
+            let id = derive_object_id(parent, &name_type, &name_bytes).unwrap();
+
+            self.data.insert(
+                id.into(),
+                OwnedSlice {
+                    layout: value_layout,
+                    bytes: bcs::to_bytes(&value).unwrap(),
+                },
+            );
             self
         }
     }

--- a/crates/sui-display/src/v2/visitor/extractor.rs
+++ b/crates/sui-display/src/v2/visitor/extractor.rs
@@ -157,10 +157,13 @@ impl<'v> AV::Visitor<'v, 'v> for Extractor<'v, '_> {
             })));
         };
 
-        // If the next accessor is for a dynamic field, try and find the parent ID within this
-        // struct, but don't consume the accessor (the dynamic field access will be handled by the
+        // If the next accessor is for a dynamic field or derived object, try and find the parent
+        // ID within this struct, but don't consume the accessor (the lookup will be handled by the
         // interpreter).
-        if matches!(accessor, Accessor::DFIndex(_) | Accessor::DOFIndex(_)) {
+        if matches!(
+            accessor,
+            Accessor::DFIndex(_) | Accessor::DOFIndex(_) | Accessor::Derived(_)
+        ) {
             return AddressExtractor
                 .visit_struct(driver)
                 .map(|a| a.map(Value::Address));

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/objects/display/derived_object.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/objects/display/derived_object.move
@@ -1,0 +1,59 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 108 --accounts A --addresses test=0x0 --simulator
+
+//# publish --sender A
+module test::mod {
+  use sui::derived_object;
+
+  public struct Parent has key, store {
+    id: UID,
+  }
+
+  public struct Child has key, store {
+    id: UID,
+    x: u64,
+    y: u64,
+  }
+
+  public fun new(ctx: &mut TxContext): Parent {
+    Parent { id: object::new(ctx) }
+  }
+
+  public fun add_child(parent: &mut Parent, key: u64, x: u64, y: u64, ctx: &mut TxContext) {
+    let child = Child {
+      id: derived_object::claim(&mut parent.id, key),
+      x,
+      y,
+    };
+    transfer::public_transfer(child, ctx.sender());
+  }
+}
+
+//# programmable --sender A --inputs @A
+//> 0: test::mod::new();
+//> 1: TransferObjects([Result(0)], Input(0))
+
+//# programmable --sender A --inputs object(2,0) 7u64 111u64 222u64
+//> 0: test::mod::add_child(Input(0), Input(1), Input(2), Input(3))
+
+//# create-checkpoint
+
+//# run-graphql
+{
+  object(address: "@{obj_2_0}") {
+    asMoveObject {
+      contents {
+        formatted: format(format: "{id~>[7u64].x}")
+        missingFormatted: format(format: "{id~>[8u64].x}")
+        extracted: extract(path: "id~>[7u64]") {
+          json
+        }
+        missingExtracted: extract(path: "id~>[8u64]") {
+          json
+        }
+      }
+    }
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/objects/display/derived_object.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/objects/display/derived_object.snap
@@ -1,0 +1,55 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 6 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-32:
+//# publish --sender A
+created: object(1,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 6384000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 34-36:
+//# programmable --sender A --inputs @A
+//> 0: test::mod::new();
+//> 1: TransferObjects([Result(0)], Input(0))
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2249600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 3, lines 38-39:
+//# programmable --sender A --inputs object(2,0) 7u64 111u64 222u64
+//> 0: test::mod::add_child(Input(0), Input(1), Input(2), Input(3))
+created: object(3,0), object(3,1)
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 6118000,  storage_rebate: 2227104, non_refundable_storage_fee: 22496
+
+task 4, line 41:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 5, lines 43-59:
+//# run-graphql
+Response: {
+  "data": {
+    "object": {
+      "asMoveObject": {
+        "contents": {
+          "formatted": "111",
+          "missingFormatted": null,
+          "extracted": {
+            "json": {
+              "id": "0xc216dfd7f50e774f029dc99c3031df39c04451dbb51e40dde501db48400b4f69",
+              "x": "111",
+              "y": "222"
+            }
+          },
+          "missingExtracted": null
+        }
+      }
+    }
+  }
+}

--- a/docs/content/references/object-display-syntax.mdx
+++ b/docs/content/references/object-display-syntax.mdx
@@ -96,9 +96,23 @@ Load a dynamic object field (the value is a full Sui object):
 
 Each `=>` access costs 2 object loads (1 for the wrapper `Field`, 1 for the object).
 
+### Derived object access (`~>`)
+
+Load a derived object from on-chain storage using the parent object and a derived key:
+
+```
+{parent~>['key']}       — derived object with string key 'key'
+{parent~>['key'].x}     — access field 'x' on the loaded object
+{parent.id~>['key'].id} — load the object and read its UID
+{registry~>[$self]}     — use the current object as the derived key
+```
+
+Each `~>` access costs 1 object load from the budget.
+
 ## Literal values
 
-Literals can appear as expression roots or as dynamic field name keys.
+Literals can appear as expression roots or as keys for dynamic field, dynamic object field, and
+derived object lookups.
 
 ### Scalars
 
@@ -372,6 +386,7 @@ accessor ::= '.' IDENT
            | '[' chain ']'
            | '->' '[' chain ']'
            | '=>' '[' chain ']'
+           | '~>' '[' chain ']'
 
 literal  ::= address | bool | number | string | vector | struct | enum
 


### PR DESCRIPTION
## Description
Add an ability to load a derived object against a parent ID/object, using `parent~>[name]` syntax.

## Test plan

Unit tests:

```
$ cargo nextest run -p sui-display
```

E2E tests (GraphQL):

```
$ cargo nextest run -p sui-indexer-alt-e2e-tests -- tests/graphql/objects/display/derived_object.move
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
