### PR TITLE
sui-forking: basic skeleton and startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14926,6 +14926,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "sui-forking"
+version = "1.69.0"
+dependencies = [
+ "anyhow",
+ "axum 0.8.3",
+ "axum-server",
+ "base64 0.21.7",
+ "bcs",
+ "bin-version",
+ "bytes",
+ "clap",
+ "const-str",
+ "cynic",
+ "cynic-codegen",
+ "datatest-stable",
+ "fastcrypto",
+ "futures",
+ "http 1.3.1",
+ "move-binary-format",
+ "move-bytecode-utils",
+ "move-command-line-common",
+ "move-core-types",
+ "mysten-common",
+ "mysten-network",
+ "pin-project",
+ "prometheus",
+ "prost 0.14.1",
+ "prost-types 0.14.1",
+ "rand 0.8.5",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "simulacrum",
+ "sui-data-store",
+ "sui-futures",
+ "sui-rpc",
+ "sui-rpc-api",
+ "sui-sdk-types",
+ "sui-swarm-config",
+ "sui-types",
+ "tap",
+ "tempfile",
+ "test-cluster",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-stream",
+ "tonic 0.14.3",
+ "tonic-health",
+ "tonic-reflection",
+ "tower 0.5.2",
+ "tower-http 0.5.2",
+ "tracing",
+ "tracing-subscriber",
+ "url",
+]
+
+[[package]]
 name = "sui-framework"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,6 +120,7 @@ members = [
     "crates/sui-faucet",
     "crates/sui-field-count",
     "crates/sui-field-count-derive",
+    "crates/sui-forking",
     "crates/sui-framework",
     "crates/sui-framework-snapshot",
     "crates/sui-framework-tests",

--- a/crates/simulacrum/src/lib.rs
+++ b/crates/simulacrum/src/lib.rs
@@ -264,9 +264,10 @@ impl<R, S: store::SimulatorStore> Simulacrum<R, S> {
         // Create sender signed data with dummy signatures
         let sender_signed_data = SenderSignedData::new(transaction_data, vec![sig.into()]);
 
-        // Create transaction and verify signatures
-        let verified_transaction = Transaction::new(sender_signed_data)
-            .try_into_verified_for_testing(self.epoch_state.epoch(), &VerifyParams::default())?;
+        // Create transaction and skip verifying signatures because it wouldn't match with the
+        // sender address' public key
+        let transaction = Transaction::new(sender_signed_data);
+        let verified_transaction = VerifiedTransaction::new_unchecked(transaction);
 
         self.execute_transaction_impl(verified_transaction)
     }

--- a/crates/sui-data-store/src/stores/composite.rs
+++ b/crates/sui-data-store/src/stores/composite.rs
@@ -1,15 +1,12 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Composite store skeleton.
-
 use crate::{
     CheckpointStore, CheckpointStoreWriter, EpochData, EpochStore, EpochStoreWriter,
     FullCheckpointData, ObjectKey, ObjectStore, ObjectStoreWriter, StoreSummary, TransactionInfo,
     TransactionStore, TransactionStoreWriter,
 };
 use anyhow::{Error, Result};
-use std::io::Write;
 use sui_types::{
     digests::{CheckpointContentsDigest, CheckpointDigest},
     messages_checkpoint::CheckpointSequenceNumber,
@@ -17,8 +14,7 @@ use sui_types::{
     supported_protocol_versions::ProtocolConfig,
 };
 
-/// A router that delegates each capability to a dedicated backing chain.
-#[derive(Debug)]
+/// A store that routes each capability to a different backing chain.
 pub struct CompositeStore<Tx, Epoch, Obj, Ckpt> {
     transactions: Tx,
     epochs: Epoch,
@@ -36,26 +32,6 @@ impl<Tx, Epoch, Obj, Ckpt> CompositeStore<Tx, Epoch, Obj, Ckpt> {
             checkpoints,
         }
     }
-
-    /// Return the transaction chain.
-    pub fn transactions(&self) -> &Tx {
-        &self.transactions
-    }
-
-    /// Return the epoch chain.
-    pub fn epochs(&self) -> &Epoch {
-        &self.epochs
-    }
-
-    /// Return the object chain.
-    pub fn objects(&self) -> &Obj {
-        &self.objects
-    }
-
-    /// Return the checkpoint chain.
-    pub fn checkpoints(&self) -> &Ckpt {
-        &self.checkpoints
-    }
 }
 
 impl<Tx, Epoch, Obj, Ckpt> TransactionStore for CompositeStore<Tx, Epoch, Obj, Ckpt>
@@ -64,9 +40,9 @@ where
 {
     fn transaction_data_and_effects(
         &self,
-        _tx_digest: &str,
+        tx_digest: &str,
     ) -> Result<Option<TransactionInfo>, Error> {
-        todo!("composite transaction routing is not implemented in the skeleton")
+        self.transactions.transaction_data_and_effects(tx_digest)
     }
 }
 
@@ -76,10 +52,11 @@ where
 {
     fn write_transaction(
         &self,
-        _tx_digest: &str,
-        _transaction_info: TransactionInfo,
+        tx_digest: &str,
+        transaction_info: TransactionInfo,
     ) -> Result<(), Error> {
-        todo!("composite transaction writes are not implemented in the skeleton")
+        self.transactions
+            .write_transaction(tx_digest, transaction_info)
     }
 }
 
@@ -87,12 +64,12 @@ impl<Tx, Epoch, Obj, Ckpt> EpochStore for CompositeStore<Tx, Epoch, Obj, Ckpt>
 where
     Epoch: EpochStore,
 {
-    fn epoch_info(&self, _epoch: u64) -> Result<Option<EpochData>, Error> {
-        todo!("composite epoch routing is not implemented in the skeleton")
+    fn epoch_info(&self, epoch: u64) -> Result<Option<EpochData>, Error> {
+        self.epochs.epoch_info(epoch)
     }
 
-    fn protocol_config(&self, _epoch: u64) -> Result<Option<ProtocolConfig>, Error> {
-        todo!("composite protocol-config routing is not implemented in the skeleton")
+    fn protocol_config(&self, epoch: u64) -> Result<Option<ProtocolConfig>, Error> {
+        self.epochs.protocol_config(epoch)
     }
 }
 
@@ -100,8 +77,8 @@ impl<Tx, Epoch, Obj, Ckpt> EpochStoreWriter for CompositeStore<Tx, Epoch, Obj, C
 where
     Epoch: EpochStoreWriter,
 {
-    fn write_epoch_info(&self, _epoch: u64, _epoch_data: EpochData) -> Result<(), Error> {
-        todo!("composite epoch writes are not implemented in the skeleton")
+    fn write_epoch_info(&self, epoch: u64, epoch_data: EpochData) -> Result<(), Error> {
+        self.epochs.write_epoch_info(epoch, epoch_data)
     }
 }
 
@@ -109,8 +86,8 @@ impl<Tx, Epoch, Obj, Ckpt> ObjectStore for CompositeStore<Tx, Epoch, Obj, Ckpt>
 where
     Obj: ObjectStore,
 {
-    fn get_objects(&self, _keys: &[ObjectKey]) -> Result<Vec<Option<(Object, u64)>>, Error> {
-        todo!("composite object routing is not implemented in the skeleton")
+    fn get_objects(&self, keys: &[ObjectKey]) -> Result<Vec<Option<(Object, u64)>>, Error> {
+        self.objects.get_objects(keys)
     }
 }
 
@@ -120,11 +97,11 @@ where
 {
     fn write_object(
         &self,
-        _key: &ObjectKey,
-        _object: Object,
-        _actual_version: u64,
+        key: &ObjectKey,
+        object: Object,
+        actual_version: u64,
     ) -> Result<(), Error> {
-        todo!("composite object writes are not implemented in the skeleton")
+        self.objects.write_object(key, object, actual_version)
     }
 }
 
@@ -134,27 +111,27 @@ where
 {
     fn get_checkpoint_by_sequence_number(
         &self,
-        _sequence: CheckpointSequenceNumber,
+        sequence: CheckpointSequenceNumber,
     ) -> Result<Option<FullCheckpointData>, Error> {
-        todo!("composite checkpoint routing is not implemented in the skeleton")
+        self.checkpoints.get_checkpoint_by_sequence_number(sequence)
     }
 
     fn get_latest_checkpoint(&self) -> Result<Option<FullCheckpointData>, Error> {
-        todo!("composite latest-checkpoint routing is not implemented in the skeleton")
+        self.checkpoints.get_latest_checkpoint()
     }
 
     fn get_sequence_by_checkpoint_digest(
         &self,
-        _digest: &CheckpointDigest,
+        digest: &CheckpointDigest,
     ) -> Result<Option<CheckpointSequenceNumber>, Error> {
-        todo!("composite checkpoint-digest routing is not implemented in the skeleton")
+        self.checkpoints.get_sequence_by_checkpoint_digest(digest)
     }
 
     fn get_sequence_by_contents_digest(
         &self,
-        _digest: &CheckpointContentsDigest,
+        digest: &CheckpointContentsDigest,
     ) -> Result<Option<CheckpointSequenceNumber>, Error> {
-        todo!("composite contents-digest routing is not implemented in the skeleton")
+        self.checkpoints.get_sequence_by_contents_digest(digest)
     }
 }
 
@@ -162,8 +139,8 @@ impl<Tx, Epoch, Obj, Ckpt> CheckpointStoreWriter for CompositeStore<Tx, Epoch, O
 where
     Ckpt: CheckpointStoreWriter,
 {
-    fn write_checkpoint(&self, _checkpoint: &FullCheckpointData) -> Result<(), Error> {
-        todo!("composite checkpoint writes are not implemented in the skeleton")
+    fn write_checkpoint(&self, checkpoint: &FullCheckpointData) -> Result<(), Error> {
+        self.checkpoints.write_checkpoint(checkpoint)
     }
 }
 
@@ -174,11 +151,15 @@ where
     Obj: StoreSummary,
     Ckpt: StoreSummary,
 {
-    fn summary<W: Write>(&self, writer: &mut W) -> Result<()> {
-        writeln!(writer, "CompositeStore")?;
+    fn summary<W: std::io::Write>(&self, writer: &mut W) -> Result<()> {
+        writeln!(writer, "CompositeStore summary")?;
+        writeln!(writer, "Transactions:")?;
         self.transactions.summary(writer)?;
+        writeln!(writer, "Epochs:")?;
         self.epochs.summary(writer)?;
+        writeln!(writer, "Objects:")?;
         self.objects.summary(writer)?;
+        writeln!(writer, "Checkpoints:")?;
         self.checkpoints.summary(writer)
     }
 }

--- a/crates/sui-data-store/src/stores/filesystem.rs
+++ b/crates/sui-data-store/src/stores/filesystem.rs
@@ -1,26 +1,98 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//! File-system backed store skeleton.
+//! File system implementation of the data store interfaces: `TransactionStore`, `EpochStore`,
+//! and `ObjectStore`.
+//! Data is persisted on disk under a simple, human-inspectable directory layout.
 //!
-//! This module intentionally keeps the public shape of the intended store while
-//! deferring the actual persistence logic to a later commit.
+//! # Directory Structure
+//!
+//! ```text
+//! ~/.sui_data_store/
+//!   node_mapping.csv              (CSV: "node,chain_id" mappings)
+//!   <chain_id>/
+//!     transaction/
+//!       <tx_digest>              (BCS: TransactionFileData)
+//!     epoch/
+//!       <epoch_id>               (BCS: EpochFileData)
+//!     checkpoint/
+//!       <sequence>.binpb.zst     (zstd(proto::Checkpoint), full ingestion payload)
+//!       checkpoint_digest_index.csv
+//!       contents_digest_index.csv
+//!       latest                   (optional latest sequence marker)
+//!     objects/
+//!       <object_id>/
+//!         <version>              (BCS: sui_types::object::Object)
+//!         root_versions          (CSV lines: "<max_version>,<actual_version>")
+//!         checkpoint_versions    (CSV lines: "<checkpoint>,<actual_version>")
+//! ```
+//!
+//! - The top-level directory is fixed to `~/.sui_data_store`.
+//! - The `node_mapping.csv` file maps node types to chain identifiers.
+//! - The next level directory is the chain identifier (e.g., "sui_mainnet", "sui_testnet").
+//! - Node types: `mainnet`, `testnet`, `devnet` (not yet available), and custom URLs.
+//!
+//! # File Formats
+//!
+//! - Transaction files in `transaction/<tx_digest>` store `TransactionFileData` as BCS, which
+//!   includes the original `TransactionData`, its `TransactionEffects`, and the execution
+//!   `checkpoint`.
+//! - Epoch files in `epoch/<epoch_id>` store `EpochFileData` as BCS, capturing epoch metadata.
+//! - Checkpoint files in `checkpoint/<sequence>.binpb.zst` store a zstd-compressed
+//!   `sui_rpc::proto::sui::rpc::v2::Checkpoint` in full-ingestion payload form.
+//! - Object files in `objects/<object_id>/<version>` store the `Object` at the corresponding
+//!   version as BCS.
+//!
+//! # Version Mapping Files
+//!
+//! The `root_versions` and `checkpoint_versions` files provide stable lookups for queries
+//! that are not targeted to a specific version. Each line is a comma-separated pair and the
+//! files can be edited manually or updated by this store:
+//!
+//! - `root_versions`: maps a root version bound to the actual stored version.
+//!   - line format: `<max_version>,<actual_version>`
+//!   - example: `4,3` means the highest version not exceeding 4 is 3
+//!
+//! - `checkpoint_versions`: maps a checkpoint to the actual stored version for the object
+//!   at that point.
+//!   - line format: `<checkpoint>,<actual_version>`
+//!   - example: `100,1` means at checkpoint 100 the object version is 1
+//!
+//! These mapping files allow answering `VersionQuery::RootVersion(_)` and
+//! `VersionQuery::AtCheckpoint(_)` without requiring a full index; the store writes them as
+//! it learns the concrete versions.
 
 use crate::{
     CheckpointStore, CheckpointStoreWriter, EpochData, EpochStore, EpochStoreWriter,
     FullCheckpointData, ObjectKey, ObjectStore, ObjectStoreWriter, SetupStore, StoreSummary,
-    TransactionInfo, TransactionStore, TransactionStoreWriter, node::Node,
+    TransactionInfo, TransactionStore, TransactionStoreWriter, VersionQuery, node::Node,
 };
-use anyhow::{Error, Result, anyhow};
-use std::{io::Write, path::PathBuf};
+use anyhow::{Context, Error, Result, anyhow};
+use prost::Message;
+use std::{
+    collections::BTreeMap,
+    fs,
+    io::Write,
+    path::{Path, PathBuf},
+    sync::{
+        RwLock,
+        atomic::{AtomicU64, Ordering},
+    },
+};
+use sui_rpc::merge::Merge;
+use sui_rpc::proto::sui::rpc::v2::Checkpoint as ProtoCheckpoint;
 use sui_types::{
     base_types::{ObjectID, SuiAddress},
+    committee::ProtocolVersion,
     digests::{CheckpointContentsDigest, CheckpointDigest},
+    effects::TransactionEffects,
     messages_checkpoint::CheckpointSequenceNumber,
-    object::Object,
-    supported_protocol_versions::ProtocolConfig,
+    object::{Object, Owner},
+    supported_protocol_versions::{Chain, ProtocolConfig},
+    transaction::TransactionData,
 };
 
+// Public constants for file system paths
 pub const DATA_STORE_DIR: &str = ".sui_data_store";
 pub const NODE_MAPPING_FILE: &str = "node_mapping.csv";
 pub const OBJECTS_DIR: &str = "objects";
@@ -34,29 +106,107 @@ pub const CHECKPOINT_LATEST_FILE: &str = "latest";
 pub const ROOT_VERSIONS_FILE: &str = "root_versions";
 pub const CHECKPOINT_VERSIONS_FILE: &str = "checkpoint_versions";
 
-/// Persistent file-system store.
-#[derive(Debug)]
+/// Serializable wrapper for transaction data stored in files
+#[derive(serde::Serialize, serde::Deserialize)]
+struct TransactionFileData {
+    pub data: TransactionData,
+    pub effects: TransactionEffects,
+    pub checkpoint: u64,
+}
+
+/// Serializable wrapper for epoch data stored in files
+#[derive(serde::Serialize, serde::Deserialize)]
+struct EpochFileData {
+    pub epoch_id: u64,
+    pub protocol_version: u64,
+    pub rgp: u64,
+    pub start_timestamp: u64,
+}
+
+#[derive(Default)]
+struct FsStoreMetrics {
+    // transactions
+    txn_hit: AtomicU64,
+    txn_miss: AtomicU64,
+    txn_error: AtomicU64,
+    // epochs
+    epoch_hit: AtomicU64,
+    epoch_miss: AtomicU64,
+    epoch_error: AtomicU64,
+    // protocol config
+    proto_hit: AtomicU64,
+    proto_miss: AtomicU64,
+    proto_error: AtomicU64,
+    // checkpoints
+    checkpoint_hit: AtomicU64,
+    checkpoint_miss: AtomicU64,
+    checkpoint_error: AtomicU64,
+    // objects by query kind
+    obj_version_hit: AtomicU64,
+    obj_version_miss: AtomicU64,
+    obj_version_error: AtomicU64,
+    obj_root_hit: AtomicU64,
+    obj_root_miss: AtomicU64,
+    obj_root_error: AtomicU64,
+    obj_checkpoint_hit: AtomicU64,
+    obj_checkpoint_miss: AtomicU64,
+    obj_checkpoint_error: AtomicU64,
+}
+
+impl From<EpochFileData> for EpochData {
+    fn from(file_data: EpochFileData) -> Self {
+        EpochData {
+            epoch_id: file_data.epoch_id,
+            protocol_version: file_data.protocol_version,
+            rgp: file_data.rgp,
+            start_timestamp: file_data.start_timestamp,
+        }
+    }
+}
+
+impl From<EpochData> for EpochFileData {
+    fn from(epoch_data: EpochData) -> Self {
+        EpochFileData {
+            epoch_id: epoch_data.epoch_id,
+            protocol_version: epoch_data.protocol_version,
+            rgp: epoch_data.rgp,
+            start_timestamp: epoch_data.start_timestamp,
+        }
+    }
+}
+
+/// File system implementation of the data store interfaces.
 pub struct FileSystemStore {
     node: Node,
     base_path: PathBuf,
+    metrics: FsStoreMetrics,
+    // In-memory caches of version mappings per object id
+    root_versions_map: RwLock<BTreeMap<ObjectID, BTreeMap<u64, u64>>>,
+    checkpoint_versions_map: RwLock<BTreeMap<ObjectID, BTreeMap<u64, u64>>>,
 }
 
 impl FileSystemStore {
-    /// Create a store rooted at the default data-store path.
     pub fn new(node: Node) -> Result<Self, Error> {
         let base_path = Self::base_path()?;
-        Ok(Self { node, base_path })
+        Ok(Self {
+            node,
+            base_path,
+            metrics: FsStoreMetrics::default(),
+            root_versions_map: RwLock::new(BTreeMap::new()),
+            checkpoint_versions_map: RwLock::new(BTreeMap::new()),
+        })
     }
 
-    /// Create a store rooted at an explicit path.
     pub fn new_with_path(node: Node, full_path: PathBuf) -> Result<Self, Error> {
         Ok(Self {
             node,
             base_path: full_path,
+            metrics: FsStoreMetrics::default(),
+            root_versions_map: RwLock::new(BTreeMap::new()),
+            checkpoint_versions_map: RwLock::new(BTreeMap::new()),
         })
     }
 
-    /// Resolve the default base path for on-disk storage.
     pub fn base_path() -> Result<PathBuf, Error> {
         let home_dir = std::env::var("SUI_DATA_STORE")
             .or_else(|_| std::env::var("SUI_CONFIG_DIR"))
@@ -70,153 +220,1014 @@ impl FileSystemStore {
         Ok(PathBuf::from(home_dir).join(DATA_STORE_DIR))
     }
 
-    /// Return the configured node.
-    pub fn node(&self) -> &Node {
-        &self.node
+    fn node_dir(&self) -> Result<PathBuf, Error> {
+        // Read the chain identifier mapping to determine the directory name
+        let chain_id = self.get_chain_id_for_node()?;
+        Ok(self.base_path.join(chain_id))
     }
 
-    /// Return the configured base path.
-    pub fn store_path(&self) -> &PathBuf {
-        &self.base_path
+    fn get_chain_id_for_node(&self) -> Result<String, Error> {
+        let mapping_file = self.base_path.join(NODE_MAPPING_FILE);
+
+        if !mapping_file.exists() {
+            return Err(anyhow!(
+                "Node mapping file not found at {}. File must exist with format: node,chain_id",
+                mapping_file.display()
+            ));
+        }
+
+        let file = fs::File::open(&mapping_file).with_context(|| {
+            format!(
+                "Failed to open node mapping file: {}",
+                mapping_file.display()
+            )
+        })?;
+
+        let mut rdr = csv::ReaderBuilder::new()
+            .has_headers(false)
+            .trim(csv::Trim::All)
+            .from_reader(file);
+
+        let node_key = match &self.node {
+            Node::Mainnet => "mainnet",
+            Node::Testnet => "testnet",
+            Node::Devnet => "devnet",
+            Node::Custom(url) => url,
+        };
+
+        for result in rdr.records() {
+            let record = result.with_context(|| {
+                format!("Failed to read CSV record from: {}", mapping_file.display())
+            })?;
+
+            if record.len() != 2 {
+                return Err(anyhow!(
+                    "Invalid format in node mapping file {}: expected 2 columns, got {}",
+                    mapping_file.display(),
+                    record.len()
+                ));
+            }
+
+            let node = record[0].trim();
+            let chain_id = record[1].trim();
+
+            if node == node_key {
+                return Ok(chain_id.to_string());
+            }
+        }
+
+        Err(anyhow!(
+            "No mapping found for node '{}' in mapping file {}",
+            node_key,
+            mapping_file.display()
+        ))
     }
 
-    /// Filesystem-specific latest-object helper.
-    pub fn get_object_latest(&self, _object_id: &ObjectID) -> Result<Option<(Object, u64)>, Error> {
-        todo!("filesystem latest-object lookup is not implemented in the skeleton")
+    fn transaction_dir(&self) -> Result<PathBuf, Error> {
+        Ok(self.node_dir()?.join(TRANSACTION_DIR))
     }
 
-    /// Filesystem-specific owner scan helper.
-    pub fn get_objects_by_owner(&self, _owner: SuiAddress) -> Result<Vec<Object>, Error> {
-        todo!("filesystem owner scan is not implemented in the skeleton")
+    fn epoch_dir(&self) -> Result<PathBuf, Error> {
+        Ok(self.node_dir()?.join(EPOCH_DIR))
     }
 
-    /// Filesystem-specific exact-version helper.
+    fn objects_dir(&self) -> Result<PathBuf, Error> {
+        Ok(self.node_dir()?.join(OBJECTS_DIR))
+    }
+
+    fn checkpoint_dir(&self) -> Result<PathBuf, Error> {
+        Ok(self.node_dir()?.join(CHECKPOINT_DIR))
+    }
+
+    fn checkpoint_file_path(&self, sequence: CheckpointSequenceNumber) -> Result<PathBuf, Error> {
+        Ok(self
+            .checkpoint_dir()?
+            .join(format!("{sequence}.{CHECKPOINT_FILE_EXTENSION}")))
+    }
+
+    fn checkpoint_latest_path(&self) -> Result<PathBuf, Error> {
+        Ok(self.checkpoint_dir()?.join(CHECKPOINT_LATEST_FILE))
+    }
+
+    fn checkpoint_digest_index_path(&self) -> Result<PathBuf, Error> {
+        Ok(self.checkpoint_dir()?.join(CHECKPOINT_DIGEST_INDEX_FILE))
+    }
+
+    fn checkpoint_contents_digest_index_path(&self) -> Result<PathBuf, Error> {
+        Ok(self
+            .checkpoint_dir()?
+            .join(CHECKPOINT_CONTENTS_DIGEST_INDEX_FILE))
+    }
+
+    fn root_versions_path(&self, object_id: &ObjectID) -> Result<PathBuf, Error> {
+        Ok(self
+            .objects_dir()?
+            .join(object_id.to_string())
+            .join(ROOT_VERSIONS_FILE))
+    }
+
+    fn checkpoint_versions_path(&self, object_id: &ObjectID) -> Result<PathBuf, Error> {
+        Ok(self
+            .objects_dir()?
+            .join(object_id.to_string())
+            .join(CHECKPOINT_VERSIONS_FILE))
+    }
+
+    fn read_bcs_file<T: serde::de::DeserializeOwned>(&self, path: &Path) -> Result<T, Error> {
+        let bytes =
+            fs::read(path).with_context(|| format!("Failed to read file: {}", path.display()))?;
+        bcs::from_bytes(&bytes)
+            .with_context(|| format!("Failed to deserialize BCS data from: {}", path.display()))
+    }
+
+    fn write_bcs_file<T: serde::Serialize>(&self, path: &Path, data: &T) -> Result<(), Error> {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("Failed to create directory: {}", parent.display()))?;
+        }
+        let bytes = bcs::to_bytes(data)
+            .with_context(|| format!("Failed to serialize BCS data for: {}", path.display()))?;
+        fs::write(path, bytes)
+            .with_context(|| format!("Failed to write file: {}", path.display()))?;
+        Ok(())
+    }
+
+    fn read_checkpoint_file(&self, path: &Path) -> Result<FullCheckpointData, Error> {
+        let bytes =
+            fs::read(path).with_context(|| format!("Failed to read file: {}", path.display()))?;
+        let decompressed = zstd::decode_all(&bytes[..])
+            .with_context(|| format!("Failed to decompress checkpoint file: {}", path.display()))?;
+        let proto_checkpoint = ProtoCheckpoint::decode(&decompressed[..]).with_context(|| {
+            format!(
+                "Failed to decode checkpoint protobuf file: {}",
+                path.display()
+            )
+        })?;
+        FullCheckpointData::try_from(&proto_checkpoint).with_context(|| {
+            format!(
+                "Failed to convert protobuf checkpoint to full checkpoint content: {}",
+                path.display()
+            )
+        })
+    }
+
+    fn write_checkpoint_file(
+        &self,
+        sequence: CheckpointSequenceNumber,
+        checkpoint: &FullCheckpointData,
+    ) -> Result<(), Error> {
+        let path = self.checkpoint_file_path(sequence)?;
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("Failed to create directory: {}", parent.display()))?;
+        }
+
+        let mask = FullCheckpointData::proto_field_mask();
+        let proto_checkpoint = ProtoCheckpoint::merge_from(checkpoint, &mask.into());
+        let encoded = proto_checkpoint.encode_to_vec();
+        let compressed = zstd::encode_all(&encoded[..], 3).with_context(|| {
+            format!(
+                "Failed to compress checkpoint protobuf file: {}",
+                path.display()
+            )
+        })?;
+        fs::write(&path, compressed)
+            .with_context(|| format!("Failed to write checkpoint file: {}", path.display()))?;
+        Ok(())
+    }
+
+    fn write_latest_checkpoint_marker(
+        &self,
+        sequence: CheckpointSequenceNumber,
+    ) -> Result<(), Error> {
+        let path = self.checkpoint_latest_path()?;
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("Failed to create directory: {}", parent.display()))?;
+        }
+        fs::write(&path, sequence.to_string()).with_context(|| {
+            format!(
+                "Failed to write latest checkpoint marker: {}",
+                path.display()
+            )
+        })
+    }
+
+    fn read_latest_checkpoint_marker(&self) -> Result<Option<CheckpointSequenceNumber>, Error> {
+        let path = self.checkpoint_latest_path()?;
+        if !path.exists() {
+            return Ok(None);
+        }
+        let raw = fs::read_to_string(&path).with_context(|| {
+            format!(
+                "Failed to read latest checkpoint marker: {}",
+                path.display()
+            )
+        })?;
+        let sequence = raw
+            .trim()
+            .parse::<CheckpointSequenceNumber>()
+            .with_context(|| {
+                format!(
+                    "Failed to parse latest checkpoint marker sequence from {}",
+                    path.display()
+                )
+            })?;
+        Ok(Some(sequence))
+    }
+
+    fn scan_latest_checkpoint_sequence(&self) -> Result<Option<CheckpointSequenceNumber>, Error> {
+        let dir = self.checkpoint_dir()?;
+        if !dir.exists() {
+            return Ok(None);
+        }
+
+        let suffix = format!(".{CHECKPOINT_FILE_EXTENSION}");
+        let mut latest: Option<CheckpointSequenceNumber> = None;
+        for entry in fs::read_dir(&dir)
+            .with_context(|| format!("Failed to read checkpoint dir: {}", dir.display()))?
+        {
+            let entry = entry.with_context(|| {
+                format!(
+                    "Failed to read entry from checkpoint dir: {}",
+                    dir.display()
+                )
+            })?;
+            let file_name = entry.file_name();
+            let Some(file_name) = file_name.to_str() else {
+                continue;
+            };
+            if !file_name.ends_with(&suffix) {
+                continue;
+            }
+            let Some(sequence_str) = file_name.strip_suffix(&suffix) else {
+                continue;
+            };
+            if let Ok(sequence) = sequence_str.parse::<CheckpointSequenceNumber>() {
+                latest = Some(latest.map_or(sequence, |curr| curr.max(sequence)));
+            }
+        }
+        Ok(latest)
+    }
+
+    fn append_digest_index(
+        &self,
+        index_path: &Path,
+        digest: &str,
+        sequence: CheckpointSequenceNumber,
+    ) -> Result<(), Error> {
+        if let Some(parent) = index_path.parent() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("Failed to create directory: {}", parent.display()))?;
+        }
+        let mut file = fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(index_path)
+            .with_context(|| format!("Failed to open index file: {}", index_path.display()))?;
+        writeln!(file, "{digest},{sequence}")
+            .with_context(|| format!("Failed to write index file: {}", index_path.display()))?;
+        Ok(())
+    }
+
+    fn read_sequence_from_digest_index(
+        &self,
+        index_path: &Path,
+        target_digest: &str,
+    ) -> Result<Option<CheckpointSequenceNumber>, Error> {
+        if !index_path.exists() {
+            return Ok(None);
+        }
+
+        let file = fs::File::open(index_path)
+            .with_context(|| format!("Failed to open index file: {}", index_path.display()))?;
+        let mut rdr = csv::ReaderBuilder::new()
+            .has_headers(false)
+            .trim(csv::Trim::All)
+            .from_reader(file);
+
+        let mut result = None;
+        for record in rdr.records() {
+            let record = record.with_context(|| {
+                format!("Failed to read CSV record from: {}", index_path.display())
+            })?;
+            if record.len() != 2 {
+                return Err(anyhow!(
+                    "Invalid format in index file {}: expected 2 columns, got {}",
+                    index_path.display(),
+                    record.len()
+                ));
+            }
+            if record[0].trim() == target_digest {
+                let sequence = record[1]
+                    .trim()
+                    .parse::<CheckpointSequenceNumber>()
+                    .with_context(|| {
+                        format!(
+                            "Failed to parse checkpoint sequence '{}' in {}",
+                            &record[1],
+                            index_path.display()
+                        )
+                    })?;
+                result = Some(sequence);
+            }
+        }
+        Ok(result)
+    }
+
+    fn write_checkpoint_indexes(
+        &self,
+        sequence: CheckpointSequenceNumber,
+        checkpoint_digest: CheckpointDigest,
+        contents_digest: CheckpointContentsDigest,
+    ) -> Result<(), Error> {
+        let checkpoint_index = self.checkpoint_digest_index_path()?;
+        self.append_digest_index(&checkpoint_index, &checkpoint_digest.to_string(), sequence)?;
+
+        let contents_index = self.checkpoint_contents_digest_index_path()?;
+        self.append_digest_index(&contents_index, &contents_digest.to_string(), sequence)?;
+        Ok(())
+    }
+
+    fn read_version_mapping(&self, path: &Path) -> Result<BTreeMap<u64, u64>, Error> {
+        if !path.exists() {
+            return Ok(BTreeMap::new());
+        }
+
+        let file = fs::File::open(path)
+            .with_context(|| format!("Failed to open version mapping file: {}", path.display()))?;
+
+        let mut rdr = csv::ReaderBuilder::new()
+            .has_headers(false)
+            .trim(csv::Trim::All)
+            .from_reader(file);
+
+        let mut mapping = BTreeMap::new();
+        for result in rdr.records() {
+            let record = result
+                .with_context(|| format!("Failed to read CSV record from: {}", path.display()))?;
+
+            if record.len() != 2 {
+                return Err(anyhow!(
+                    "Invalid format in version mapping file {}: expected 2 columns, got {}",
+                    path.display(),
+                    record.len()
+                ));
+            }
+
+            let key: u64 = record[0].parse().with_context(|| {
+                format!("Failed to parse key '{}' in {}", &record[0], path.display())
+            })?;
+            let version: u64 = record[1].parse().with_context(|| {
+                format!(
+                    "Failed to parse version '{}' in {}",
+                    &record[1],
+                    path.display()
+                )
+            })?;
+
+            mapping.insert(key, version);
+        }
+
+        Ok(mapping)
+    }
+
+    fn write_full_version_mapping(
+        &self,
+        path: &Path,
+        mapping: &BTreeMap<u64, u64>,
+    ) -> Result<(), Error> {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("Failed to create directory: {}", parent.display()))?;
+        }
+        let mut content = String::new();
+        for (k, v) in mapping {
+            content.push_str(&format!("{},{}\n", k, v));
+        }
+        fs::write(path, content)
+            .with_context(|| format!("Failed to write version mapping file: {}", path.display()))?;
+        Ok(())
+    }
+
+    fn load_root_mapping(&self, object_id: &ObjectID) -> Result<(), Error> {
+        if self
+            .root_versions_map
+            .read()
+            .unwrap()
+            .contains_key(object_id)
+        {
+            return Ok(());
+        }
+        let path = self.root_versions_path(object_id)?;
+        let mapping = self.read_version_mapping(&path)?;
+        self.root_versions_map
+            .write()
+            .unwrap()
+            .insert(*object_id, mapping);
+        Ok(())
+    }
+
+    fn load_checkpoint_mapping(&self, object_id: &ObjectID) -> Result<(), Error> {
+        if self
+            .checkpoint_versions_map
+            .read()
+            .unwrap()
+            .contains_key(object_id)
+        {
+            return Ok(());
+        }
+        let path = self.checkpoint_versions_path(object_id)?;
+        let mapping = self.read_version_mapping(&path)?;
+        self.checkpoint_versions_map
+            .write()
+            .unwrap()
+            .insert(*object_id, mapping);
+        Ok(())
+    }
+
+    fn update_root_mapping(
+        &self,
+        object_id: &ObjectID,
+        key: u64,
+        version: u64,
+    ) -> Result<(), Error> {
+        self.load_root_mapping(object_id)?;
+        {
+            let mut maps = self.root_versions_map.write().unwrap();
+            let entry = maps.get_mut(object_id).unwrap();
+            entry.insert(key, version);
+            let path = self.root_versions_path(object_id)?;
+            self.write_full_version_mapping(&path, entry)?;
+        }
+        Ok(())
+    }
+
+    fn update_checkpoint_mapping(
+        &self,
+        object_id: &ObjectID,
+        key: u64,
+        version: u64,
+    ) -> Result<(), Error> {
+        self.load_checkpoint_mapping(object_id)?;
+        {
+            let mut maps = self.checkpoint_versions_map.write().unwrap();
+            let entry = maps.get_mut(object_id).unwrap();
+            entry.insert(key, version);
+            let path = self.checkpoint_versions_path(object_id)?;
+            self.write_full_version_mapping(&path, entry)?;
+        }
+        Ok(())
+    }
+
+    // TODO: this should not be pub, probably this should come from an indexer
+    pub fn get_objects_by_owner(&self, owner: SuiAddress) -> Result<Vec<Object>> {
+        let object_dir = self.objects_dir()?;
+        if !object_dir.exists() {
+            return Ok(vec![]);
+        }
+
+        let mut results = Vec::new();
+        for entry in fs::read_dir(&object_dir)? {
+            let entry = entry?;
+            if entry.file_type()?.is_dir() {
+                let object_id_str = entry.file_name().to_string_lossy().to_string();
+                if let Ok(object_id) = ObjectID::from_hex_literal(&object_id_str)
+                    && let Some((object, _version)) = self.get_object_latest(&object_id)?
+                    && (matches!(object.owner(), Owner::AddressOwner(address) if *address == owner)
+                        || matches!(
+                            object.owner(),
+                            Owner::ConsensusAddressOwner {
+                                owner: address,
+                                ..
+                            } if *address == owner
+                        ))
+                {
+                    results.push(object);
+                }
+            }
+        }
+
+        Ok(results)
+    }
+
+    // TODO: this should not be pub
+    pub fn get_object_latest(&self, object_id: &ObjectID) -> Result<Option<(Object, u64)>, Error> {
+        let object_dir = self.objects_dir()?.join(object_id.to_string());
+        if !object_dir.exists() {
+            return Ok(None);
+        }
+
+        let latest_version = fs::read_dir(&object_dir)?
+            .filter_map(|entry| entry.ok())
+            .filter_map(|entry| entry.file_name().to_str()?.parse::<u64>().ok())
+            .max();
+
+        match latest_version {
+            Some(version) => self.get_object_by_version(object_id, version),
+            None => Ok(None),
+        }
+    }
+
     pub fn get_object_at_version(
         &self,
-        _object_id: &ObjectID,
-        _version: u64,
+        object_id: &ObjectID,
+        version: u64,
     ) -> Result<Option<(Object, u64)>, Error> {
-        todo!("filesystem exact-version lookup is not implemented in the skeleton")
+        self.get_object_by_version(object_id, version)
     }
 
-    /// Filesystem-specific root-version helper.
     pub fn get_object_at_root_version(
         &self,
-        _object_id: &ObjectID,
-        _root_version: u64,
+        object_id: &ObjectID,
+        max_version: u64,
     ) -> Result<Option<(Object, u64)>, Error> {
-        todo!("filesystem root-version lookup is not implemented in the skeleton")
+        self.get_object_by_root_version(object_id, max_version)
     }
 
-    /// Filesystem-specific checkpoint helper.
     pub fn get_object_at_checkpoint(
         &self,
-        _object_id: &ObjectID,
-        _checkpoint: u64,
+        object_id: &ObjectID,
+        checkpoint: u64,
     ) -> Result<Option<(Object, u64)>, Error> {
-        todo!("filesystem checkpoint lookup is not implemented in the skeleton")
+        self.get_object_by_checkpoint(object_id, checkpoint)
+    }
+
+    fn get_object_by_version(
+        &self,
+        object_id: &ObjectID,
+        version: u64,
+    ) -> Result<Option<(Object, u64)>, Error> {
+        let object_dir = self.objects_dir()?.join(object_id.to_string());
+        let version_file = object_dir.join(version.to_string());
+        if !version_file.exists() {
+            return Ok(None);
+        }
+        self.read_bcs_file(&version_file)
+            .map(|obj| Some((obj, version)))
+    }
+
+    fn get_object_by_root_version(
+        &self,
+        object_id: &ObjectID,
+        max_version: u64,
+    ) -> Result<Option<(Object, u64)>, Error> {
+        self.load_root_mapping(object_id)?;
+        let maps = self.root_versions_map.read().unwrap();
+        if let Some(map) = maps.get(object_id)
+            && let Some(&actual_version) = map.get(&max_version)
+        {
+            return self.get_object_by_version(object_id, actual_version);
+        }
+        Ok(None)
+    }
+
+    fn get_object_by_checkpoint(
+        &self,
+        object_id: &ObjectID,
+        checkpoint: u64,
+    ) -> Result<Option<(Object, u64)>, Error> {
+        self.load_checkpoint_mapping(object_id)?;
+        let maps = self.checkpoint_versions_map.read().unwrap();
+        if let Some(map) = maps.get(object_id)
+            && let Some(&actual_version) = map.get(&checkpoint)
+        {
+            return self.get_object_by_version(object_id, actual_version);
+        }
+        Ok(None)
+    }
+
+    pub fn chain(&self) -> Chain {
+        self.node.chain()
+    }
+    pub fn node(&self) -> &Node {
+        &self.node
     }
 }
 
 impl TransactionStore for FileSystemStore {
     fn transaction_data_and_effects(
         &self,
-        _tx_digest: &str,
+        tx_digest: &str,
     ) -> Result<Option<TransactionInfo>, Error> {
-        todo!("filesystem transaction reads are not implemented in the skeleton")
-    }
-}
-
-impl TransactionStoreWriter for FileSystemStore {
-    fn write_transaction(
-        &self,
-        _tx_digest: &str,
-        _transaction_info: TransactionInfo,
-    ) -> Result<(), Error> {
-        todo!("filesystem transaction writes are not implemented in the skeleton")
+        let file_path = self.transaction_dir()?.join(tx_digest);
+        if !file_path.exists() {
+            self.metrics.txn_miss.fetch_add(1, Ordering::Relaxed);
+            return Ok(None);
+        }
+        let txn_data: TransactionFileData = match self
+            .read_bcs_file(&file_path)
+            .with_context(|| format!("Failed to load transaction data for digest: {}", tx_digest))
+        {
+            Ok(v) => v,
+            Err(e) => {
+                self.metrics.txn_error.fetch_add(1, Ordering::Relaxed);
+                return Err(e);
+            }
+        };
+        self.metrics.txn_hit.fetch_add(1, Ordering::Relaxed);
+        Ok(Some(TransactionInfo {
+            data: txn_data.data,
+            effects: txn_data.effects,
+            checkpoint: txn_data.checkpoint,
+        }))
     }
 }
 
 impl EpochStore for FileSystemStore {
-    fn epoch_info(&self, _epoch: u64) -> Result<Option<EpochData>, Error> {
-        todo!("filesystem epoch reads are not implemented in the skeleton")
+    fn epoch_info(&self, epoch: u64) -> Result<Option<EpochData>, Error> {
+        let file_path = self.epoch_dir()?.join(epoch.to_string());
+        if !file_path.exists() {
+            self.metrics.epoch_miss.fetch_add(1, Ordering::Relaxed);
+            return Ok(None);
+        }
+        let epoch_file_data: EpochFileData = match self
+            .read_bcs_file(&file_path)
+            .with_context(|| format!("Failed to load epoch data for epoch: {}", epoch))
+        {
+            Ok(v) => v,
+            Err(e) => {
+                self.metrics.epoch_error.fetch_add(1, Ordering::Relaxed);
+                return Err(e);
+            }
+        };
+        self.metrics.epoch_hit.fetch_add(1, Ordering::Relaxed);
+        Ok(Some(epoch_file_data.into()))
     }
 
-    fn protocol_config(&self, _epoch: u64) -> Result<Option<ProtocolConfig>, Error> {
-        todo!("filesystem protocol-config reads are not implemented in the skeleton")
-    }
-}
-
-impl EpochStoreWriter for FileSystemStore {
-    fn write_epoch_info(&self, _epoch: u64, _epoch_data: EpochData) -> Result<(), Error> {
-        todo!("filesystem epoch writes are not implemented in the skeleton")
-    }
-}
-
-impl ObjectStore for FileSystemStore {
-    fn get_objects(&self, _keys: &[ObjectKey]) -> Result<Vec<Option<(Object, u64)>>, Error> {
-        todo!("filesystem object reads are not implemented in the skeleton")
-    }
-}
-
-impl ObjectStoreWriter for FileSystemStore {
-    fn write_object(
-        &self,
-        _key: &ObjectKey,
-        _object: Object,
-        _actual_version: u64,
-    ) -> Result<(), Error> {
-        todo!("filesystem object writes are not implemented in the skeleton")
+    fn protocol_config(&self, epoch: u64) -> Result<Option<ProtocolConfig>, Error> {
+        match self.epoch_info(epoch) {
+            Ok(Some(epoch_data)) => {
+                self.metrics.proto_hit.fetch_add(1, Ordering::Relaxed);
+                Ok(Some(ProtocolConfig::get_for_version(
+                    ProtocolVersion::new(epoch_data.protocol_version),
+                    self.chain(),
+                )))
+            }
+            Ok(None) => {
+                self.metrics.proto_miss.fetch_add(1, Ordering::Relaxed);
+                Ok(None)
+            }
+            Err(e) => {
+                self.metrics.proto_error.fetch_add(1, Ordering::Relaxed);
+                Err(e)
+            }
+        }
     }
 }
 
 impl CheckpointStore for FileSystemStore {
     fn get_checkpoint_by_sequence_number(
         &self,
-        _sequence: CheckpointSequenceNumber,
+        sequence: CheckpointSequenceNumber,
     ) -> Result<Option<FullCheckpointData>, Error> {
-        todo!("filesystem checkpoint reads are not implemented in the skeleton")
+        let file_path = self.checkpoint_file_path(sequence)?;
+        if !file_path.exists() {
+            self.metrics.checkpoint_miss.fetch_add(1, Ordering::Relaxed);
+            return Ok(None);
+        }
+
+        match self.read_checkpoint_file(&file_path) {
+            Ok(checkpoint) => {
+                self.metrics.checkpoint_hit.fetch_add(1, Ordering::Relaxed);
+                Ok(Some(checkpoint))
+            }
+            Err(e) => {
+                self.metrics
+                    .checkpoint_error
+                    .fetch_add(1, Ordering::Relaxed);
+                Err(e)
+            }
+        }
     }
 
     fn get_latest_checkpoint(&self) -> Result<Option<FullCheckpointData>, Error> {
-        todo!("filesystem latest-checkpoint lookup is not implemented in the skeleton")
+        if let Some(sequence) = self.read_latest_checkpoint_marker()?
+            && let Some(checkpoint) = self.get_checkpoint_by_sequence_number(sequence)?
+        {
+            return Ok(Some(checkpoint));
+        }
+
+        let Some(latest_sequence) = self.scan_latest_checkpoint_sequence()? else {
+            self.metrics.checkpoint_miss.fetch_add(1, Ordering::Relaxed);
+            return Ok(None);
+        };
+        let checkpoint = self.get_checkpoint_by_sequence_number(latest_sequence)?;
+        if checkpoint.is_some() {
+            self.write_latest_checkpoint_marker(latest_sequence)?;
+        }
+        Ok(checkpoint)
     }
 
     fn get_sequence_by_checkpoint_digest(
         &self,
-        _digest: &CheckpointDigest,
+        digest: &CheckpointDigest,
     ) -> Result<Option<CheckpointSequenceNumber>, Error> {
-        todo!("filesystem checkpoint-digest lookups are not implemented in the skeleton")
+        let path = self.checkpoint_digest_index_path()?;
+        self.read_sequence_from_digest_index(&path, &digest.to_string())
     }
 
     fn get_sequence_by_contents_digest(
         &self,
-        _digest: &CheckpointContentsDigest,
+        digest: &CheckpointContentsDigest,
     ) -> Result<Option<CheckpointSequenceNumber>, Error> {
-        todo!("filesystem contents-digest lookups are not implemented in the skeleton")
+        let path = self.checkpoint_contents_digest_index_path()?;
+        self.read_sequence_from_digest_index(&path, &digest.to_string())
     }
 }
 
 impl CheckpointStoreWriter for FileSystemStore {
-    fn write_checkpoint(&self, _checkpoint: &FullCheckpointData) -> Result<(), Error> {
-        todo!("filesystem checkpoint writes are not implemented in the skeleton")
+    fn write_checkpoint(&self, checkpoint: &FullCheckpointData) -> Result<(), Error> {
+        let sequence = checkpoint.summary.sequence_number;
+        self.write_checkpoint_file(sequence, checkpoint)?;
+        self.write_checkpoint_indexes(
+            sequence,
+            *checkpoint.summary.digest(),
+            *checkpoint.contents.digest(),
+        )?;
+        self.write_latest_checkpoint_marker(sequence)?;
+        Ok(())
     }
 }
 
-impl SetupStore for FileSystemStore {
-    fn setup(&self, _chain_id: Option<String>) -> Result<Option<String>, Error> {
-        todo!("filesystem setup is not implemented in the skeleton")
+impl ObjectStore for FileSystemStore {
+    fn get_objects(&self, keys: &[ObjectKey]) -> Result<Vec<Option<(Object, u64)>>, Error> {
+        let mut results = Vec::with_capacity(keys.len());
+        for key in keys {
+            let (object_and_version_res, hit_ctr, miss_ctr, err_ctr) = match &key.version_query {
+                VersionQuery::Version(version) => (
+                    self.get_object_by_version(&key.object_id, *version),
+                    &self.metrics.obj_version_hit,
+                    &self.metrics.obj_version_miss,
+                    &self.metrics.obj_version_error,
+                ),
+                VersionQuery::RootVersion(max_version) => (
+                    self.get_object_by_root_version(&key.object_id, *max_version),
+                    &self.metrics.obj_root_hit,
+                    &self.metrics.obj_root_miss,
+                    &self.metrics.obj_root_error,
+                ),
+                VersionQuery::AtCheckpoint(checkpoint) => (
+                    self.get_object_by_checkpoint(&key.object_id, *checkpoint),
+                    &self.metrics.obj_checkpoint_hit,
+                    &self.metrics.obj_checkpoint_miss,
+                    &self.metrics.obj_checkpoint_error,
+                ),
+            };
+
+            match object_and_version_res {
+                Ok(object_and_version) => {
+                    if object_and_version.is_some() {
+                        hit_ctr.fetch_add(1, Ordering::Relaxed);
+                    } else {
+                        miss_ctr.fetch_add(1, Ordering::Relaxed);
+                    }
+                    results.push(object_and_version);
+                }
+                Err(e) => {
+                    err_ctr.fetch_add(1, Ordering::Relaxed);
+                    return Err(e);
+                }
+            }
+        }
+        Ok(results)
+    }
+}
+
+impl TransactionStoreWriter for FileSystemStore {
+    fn write_transaction(
+        &self,
+        tx_digest: &str,
+        transaction_info: TransactionInfo,
+    ) -> Result<(), Error> {
+        let file_path = self.transaction_dir()?.join(tx_digest);
+        let txn_file_data = TransactionFileData {
+            data: transaction_info.data,
+            effects: transaction_info.effects,
+            checkpoint: transaction_info.checkpoint,
+        };
+        self.write_bcs_file(&file_path, &txn_file_data)
+    }
+}
+
+impl EpochStoreWriter for FileSystemStore {
+    fn write_epoch_info(&self, epoch: u64, epoch_data: EpochData) -> Result<(), Error> {
+        let file_path = self.epoch_dir()?.join(epoch.to_string());
+        let epoch_file_data = EpochFileData::from(epoch_data);
+        self.write_bcs_file(&file_path, &epoch_file_data)
+    }
+}
+
+impl ObjectStoreWriter for FileSystemStore {
+    fn write_object(
+        &self,
+        key: &ObjectKey,
+        object: Object,
+        actual_version: u64,
+    ) -> Result<(), Error> {
+        let object_dir = self.objects_dir()?.join(key.object_id.to_string());
+        let object_file = object_dir.join(actual_version.to_string());
+        self.write_bcs_file(&object_file, &object)?;
+        match &key.version_query {
+            VersionQuery::Version(_) => {}
+            VersionQuery::RootVersion(max_version) => {
+                self.update_root_mapping(&key.object_id, *max_version, actual_version)?;
+            }
+            VersionQuery::AtCheckpoint(checkpoint) => {
+                self.update_checkpoint_mapping(&key.object_id, *checkpoint, actual_version)?;
+            }
+        }
+        Ok(())
     }
 }
 
 impl StoreSummary for FileSystemStore {
-    fn summary<W: Write>(&self, writer: &mut W) -> Result<()> {
+    fn summary<W: std::io::Write>(&self, w: &mut W) -> Result<()> {
+        let m = &self.metrics;
+        let txn_hit = m.txn_hit.load(Ordering::Relaxed);
+        let txn_miss = m.txn_miss.load(Ordering::Relaxed);
+        let txn_err = m.txn_error.load(Ordering::Relaxed);
+        let epoch_hit = m.epoch_hit.load(Ordering::Relaxed);
+        let epoch_miss = m.epoch_miss.load(Ordering::Relaxed);
+        let epoch_err = m.epoch_error.load(Ordering::Relaxed);
+        let proto_hit = m.proto_hit.load(Ordering::Relaxed);
+        let proto_miss = m.proto_miss.load(Ordering::Relaxed);
+        let proto_err = m.proto_error.load(Ordering::Relaxed);
+        let checkpoint_hit = m.checkpoint_hit.load(Ordering::Relaxed);
+        let checkpoint_miss = m.checkpoint_miss.load(Ordering::Relaxed);
+        let checkpoint_err = m.checkpoint_error.load(Ordering::Relaxed);
+        let obj_v_hit = m.obj_version_hit.load(Ordering::Relaxed);
+        let obj_v_miss = m.obj_version_miss.load(Ordering::Relaxed);
+        let obj_v_err = m.obj_version_error.load(Ordering::Relaxed);
+        let obj_r_hit = m.obj_root_hit.load(Ordering::Relaxed);
+        let obj_r_miss = m.obj_root_miss.load(Ordering::Relaxed);
+        let obj_r_err = m.obj_root_error.load(Ordering::Relaxed);
+        let obj_c_hit = m.obj_checkpoint_hit.load(Ordering::Relaxed);
+        let obj_c_miss = m.obj_checkpoint_miss.load(Ordering::Relaxed);
+        let obj_c_err = m.obj_checkpoint_error.load(Ordering::Relaxed);
+
+        let total_hit =
+            txn_hit + epoch_hit + proto_hit + checkpoint_hit + obj_v_hit + obj_r_hit + obj_c_hit;
+        let total_miss = txn_miss
+            + epoch_miss
+            + proto_miss
+            + checkpoint_miss
+            + obj_v_miss
+            + obj_r_miss
+            + obj_c_miss;
+        let total_err =
+            txn_err + epoch_err + proto_err + checkpoint_err + obj_v_err + obj_r_err + obj_c_err;
+        let obj_total_hit = obj_v_hit + obj_r_hit + obj_c_hit;
+        let obj_total_miss = obj_v_miss + obj_r_miss + obj_c_miss;
+        let obj_total_err = obj_v_err + obj_r_err + obj_c_err;
+
+        writeln!(w, "FileSystemStore summary")?;
         writeln!(
-            writer,
-            "FileSystemStore(node={}, base_path={})",
-            self.node.network_name(),
-            self.base_path.display()
+            w,
+            "  Overall: hit={} miss={} error={}",
+            total_hit, total_miss, total_err
         )?;
+        writeln!(
+            w,
+            "  Transaction: hit={} miss={} error={}",
+            txn_hit, txn_miss, txn_err
+        )?;
+        writeln!(
+            w,
+            "  Epoch:       hit={} miss={} error={}",
+            epoch_hit, epoch_miss, epoch_err
+        )?;
+        writeln!(
+            w,
+            "  Protocol:    hit={} miss={} error={}",
+            proto_hit, proto_miss, proto_err
+        )?;
+        writeln!(
+            w,
+            "  Checkpoint:  hit={} miss={} error={}",
+            checkpoint_hit, checkpoint_miss, checkpoint_err
+        )?;
+        writeln!(
+            w,
+            "  Objects (all): hit={} miss={} error={}",
+            obj_total_hit, obj_total_miss, obj_total_err
+        )?;
+        writeln!(w, "  Objects:")?;
+        writeln!(
+            w,
+            "    Version:     hit={} miss={} error={}",
+            obj_v_hit, obj_v_miss, obj_v_err
+        )?;
+        writeln!(
+            w,
+            "    RootVersion: hit={} miss={} error={}",
+            obj_r_hit, obj_r_miss, obj_r_err
+        )?;
+        writeln!(
+            w,
+            "    Checkpoint:  hit={} miss={} error={}",
+            obj_c_hit, obj_c_miss, obj_c_err
+        )?;
+        Ok(())
+    }
+}
+
+impl SetupStore for FileSystemStore {
+    fn setup(&self, chain_id: Option<String>) -> Result<Option<String>, Error> {
+        if let Some(chain_id) = chain_id {
+            // Override the mapping of network -> chain_id in node_mapping.csv
+            self.write_chain_identifier(chain_id)?;
+        }
+        // If chain_id is None, do nothing
+        // Return the chain identifier from the mapping file if available
+        Ok(self.get_chain_id_for_node().ok())
+    }
+}
+
+impl FileSystemStore {
+    fn write_chain_identifier(&self, chain_id: String) -> Result<(), Error> {
+        let mapping_file = self.base_path.join(NODE_MAPPING_FILE);
+
+        // Create the base directory if it doesn't exist
+        if let Some(parent) = mapping_file.parent() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("Failed to create directory: {}", parent.display()))?;
+        }
+
+        // Read existing mappings to preserve them
+        let mut mappings = Vec::new();
+        if mapping_file.exists() {
+            let file = fs::File::open(&mapping_file).with_context(|| {
+                format!(
+                    "Failed to open existing mapping file: {}",
+                    mapping_file.display()
+                )
+            })?;
+
+            let mut rdr = csv::ReaderBuilder::new()
+                .has_headers(false)
+                .trim(csv::Trim::All)
+                .from_reader(file);
+
+            for result in rdr.records() {
+                let record = result.with_context(|| {
+                    format!("Failed to read CSV record from: {}", mapping_file.display())
+                })?;
+
+                if record.len() == 2 {
+                    mappings.push((record[0].trim().to_string(), record[1].trim().to_string()));
+                }
+            }
+        }
+
+        // Determine the node key for this store
+        let node_key = match &self.node {
+            Node::Mainnet => "mainnet",
+            Node::Testnet => "testnet",
+            Node::Devnet => "devnet",
+            Node::Custom(url) => url,
+        };
+
+        // Update or add the mapping for this node
+        let mut found = false;
+        for (node, _) in &mut mappings {
+            if node == node_key {
+                *node = node_key.to_string();
+                found = true;
+                break;
+            }
+        }
+
+        if !found {
+            mappings.push((node_key.to_string(), chain_id.clone()));
+        } else {
+            // Update the existing mapping
+            for (node, existing_chain_id) in &mut mappings {
+                if node == node_key {
+                    *existing_chain_id = chain_id.clone();
+                    break;
+                }
+            }
+        }
+
+        // Write the updated mappings back to the file
+        let file = fs::File::create(&mapping_file).with_context(|| {
+            format!("Failed to create mapping file: {}", mapping_file.display())
+        })?;
+
+        let mut wtr = csv::WriterBuilder::new()
+            .has_headers(false)
+            .from_writer(file);
+
+        for (node, chain_id) in mappings {
+            wtr.write_record([&node, &chain_id]).with_context(|| {
+                format!("Failed to write mapping record: {} -> {}", node, chain_id)
+            })?;
+        }
+
+        wtr.flush()
+            .with_context(|| "Failed to flush mapping file")?;
+
         Ok(())
     }
 }

--- a/crates/sui-data-store/src/stores/graphql.rs
+++ b/crates/sui-data-store/src/stores/graphql.rs
@@ -1,147 +1,435 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//! GraphQL-backed store skeleton.
+//! An implementation of the data store interfaces: `TransactionStore`, `EpochStore` and `ObjectStore`
+//! backed by the RPC GQL endpoint. Schema in `crates/sui-indexer-alt-graphql/schema.graphql`.
+//! The RPC calls are implemented in `gql_queries.rs`.
 
 use crate::{
-    CheckpointStore, EpochData, EpochStore, FullCheckpointData, ObjectKey, ObjectStore,
-    SetupStore, StoreSummary, TransactionInfo, TransactionStore, node::Node,
+    EpochData, EpochStore, ObjectKey, ObjectStore, SetupStore, StoreSummary, TransactionInfo,
+    TransactionStore, VersionQuery, gql_queries, node::Node,
 };
 use anyhow::{Context, Error, Result};
 use cynic::{GraphQlResponse, Operation};
-use std::io::Write;
+use reqwest::header::USER_AGENT;
+use std::time::Instant;
+use std::{
+    collections::BTreeMap,
+    sync::{
+        RwLock,
+        atomic::{AtomicU64, Ordering},
+    },
+};
 use sui_types::{
-    digests::{CheckpointContentsDigest, CheckpointDigest},
-    messages_checkpoint::CheckpointSequenceNumber,
+    committee::ProtocolVersion,
+    effects::TransactionEffects,
     object::Object,
     supported_protocol_versions::{Chain, ProtocolConfig},
+    transaction::TransactionData,
 };
+use tracing::{debug, debug_span};
 
-/// Remote GraphQL-backed store.
-#[derive(Debug, Clone)]
+type EpochId = u64;
+
+/// GraphQL-backed implementation of the data store traits.
 pub struct DataStore {
     client: reqwest::Client,
     rpc: reqwest::Url,
     node: Node,
+    // Keep the epoch data considering its small size and footprint
+    epoch_map: RwLock<BTreeMap<EpochId, EpochData>>,
+    /// The binary's version passed to the User-Agent header in GQL query requests
     version: String,
+    /// Metrics for hit/miss accounting
+    metrics: DataStoreMetrics,
 }
 
-impl DataStore {
-    /// Create a new GraphQL-backed store.
-    pub fn new(node: Node, version: &str) -> Result<Self, Error> {
-        let rpc = reqwest::Url::parse(node.gql_url())
-            .with_context(|| format!("invalid GraphQL URL '{}'", node.gql_url()))?;
-        Ok(Self {
-            client: reqwest::Client::new(),
-            rpc,
-            node,
-            version: version.to_string(),
-        })
-    }
+#[derive(Default)]
+struct DataStoreMetrics {
+    // transactions
+    txn_hit: AtomicU64,
+    txn_miss: AtomicU64,
+    txn_error: AtomicU64,
+    // epochs
+    epoch_hit: AtomicU64,
+    epoch_miss: AtomicU64,
+    epoch_error: AtomicU64,
+    // protocol config
+    proto_hit: AtomicU64,
+    proto_miss: AtomicU64,
+    proto_error: AtomicU64,
+    // objects by query kind
+    obj_version_hit: AtomicU64,
+    obj_version_miss: AtomicU64,
+    obj_version_error: AtomicU64,
+    obj_root_hit: AtomicU64,
+    obj_root_miss: AtomicU64,
+    obj_root_error: AtomicU64,
+    obj_checkpoint_hit: AtomicU64,
+    obj_checkpoint_miss: AtomicU64,
+    obj_checkpoint_error: AtomicU64,
+}
 
-    /// Return the configured node.
-    pub fn node(&self) -> &Node {
-        &self.node
-    }
-
-    /// Return the configured GraphQL endpoint.
-    pub fn rpc(&self) -> &reqwest::Url {
-        &self.rpc
-    }
-
-    /// Return the binary version used for identification.
-    pub fn version(&self) -> &str {
-        &self.version
-    }
-
-    /// Return the chain associated with the configured node.
-    pub fn chain(&self) -> Chain {
-        self.node.chain()
-    }
-
-    /// Return the HTTP client used by the store.
-    pub fn client(&self) -> &reqwest::Client {
-        &self.client
-    }
-
-    pub(crate) async fn run_query<T, V>(
-        &self,
-        _operation: &Operation<T, V>,
-    ) -> Result<GraphQlResponse<T>, Error>
-    where
-        T: serde::de::DeserializeOwned,
-        V: serde::Serialize,
-    {
-        todo!("GraphQL query execution is not implemented in the skeleton")
-    }
+macro_rules! block_on {
+    ($expr:expr) => {{
+        #[allow(clippy::disallowed_methods, clippy::result_large_err)]
+        {
+            if tokio::runtime::Handle::try_current().is_ok() {
+                // When already inside a Tokio runtime, spawn a scoped thread to
+                // run a separate current-thread runtime without requiring
+                // tokio::task::block_in_place (which may be unavailable).
+                std::thread::scope(|scope| {
+                    scope
+                        .spawn(|| {
+                            let rt = tokio::runtime::Builder::new_current_thread()
+                                .enable_all()
+                                .build()
+                                .expect("failed to build Tokio runtime");
+                            rt.block_on($expr)
+                        })
+                        .join()
+                        .expect("failed to join scoped thread running nested runtime")
+                })
+            } else {
+                let rt = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .expect("failed to build Tokio runtime");
+                rt.block_on($expr)
+            }
+        }
+    }};
 }
 
 impl TransactionStore for DataStore {
-    fn transaction_data_and_effects(
-        &self,
-        _tx_digest: &str,
-    ) -> Result<Option<TransactionInfo>, Error> {
-        todo!("GraphQL transaction reads are not implemented in the skeleton")
+    fn transaction_data_and_effects(&self, digest: &str) -> Result<Option<TransactionInfo>, Error> {
+        match block_on!(self.transaction(digest)) {
+            Ok(Some((data, effects, checkpoint))) => {
+                self.metrics.txn_hit.fetch_add(1, Ordering::Relaxed);
+                Ok(Some(TransactionInfo {
+                    data,
+                    effects,
+                    checkpoint,
+                }))
+            }
+            Ok(None) => {
+                self.metrics.txn_miss.fetch_add(1, Ordering::Relaxed);
+                Ok(None)
+            }
+            Err(e) => {
+                self.metrics.txn_error.fetch_add(1, Ordering::Relaxed);
+                Err(e)
+            }
+        }
     }
 }
 
 impl EpochStore for DataStore {
-    fn epoch_info(&self, _epoch: u64) -> Result<Option<EpochData>, Error> {
-        todo!("GraphQL epoch reads are not implemented in the skeleton")
+    fn epoch_info(&self, epoch: u64) -> Result<Option<EpochData>, Error> {
+        if let Some(epoch_data) = self.epoch_map.read().unwrap().get(&epoch) {
+            self.metrics.epoch_hit.fetch_add(1, Ordering::Relaxed);
+            return Ok(Some(epoch_data.clone()));
+        }
+        match block_on!(self.epoch(epoch)) {
+            Ok(Some(epoch_data)) => {
+                self.epoch_map
+                    .write()
+                    .unwrap()
+                    .insert(epoch, epoch_data.clone());
+                self.metrics.epoch_hit.fetch_add(1, Ordering::Relaxed);
+                Ok(Some(epoch_data))
+            }
+            Ok(None) => {
+                self.metrics.epoch_miss.fetch_add(1, Ordering::Relaxed);
+                Ok(None)
+            }
+            Err(e) => {
+                self.metrics.epoch_error.fetch_add(1, Ordering::Relaxed);
+                Err(e)
+            }
+        }
     }
 
-    fn protocol_config(&self, _epoch: u64) -> Result<Option<ProtocolConfig>, Error> {
-        todo!("GraphQL protocol-config reads are not implemented in the skeleton")
+    // Get the protocol config for an epoch directly from the binary
+    fn protocol_config(&self, epoch: u64) -> Result<Option<ProtocolConfig>, Error> {
+        match self.epoch_info(epoch) {
+            Ok(Some(epoch)) => {
+                self.metrics.proto_hit.fetch_add(1, Ordering::Relaxed);
+                Ok(Some(ProtocolConfig::get_for_version(
+                    ProtocolVersion::new(epoch.protocol_version),
+                    self.chain(),
+                )))
+            }
+            Ok(None) => {
+                self.metrics.proto_miss.fetch_add(1, Ordering::Relaxed);
+                Ok(None)
+            }
+            Err(e) => {
+                self.metrics.proto_error.fetch_add(1, Ordering::Relaxed);
+                Err(e)
+            }
+        }
     }
 }
 
 impl ObjectStore for DataStore {
-    fn get_objects(&self, _keys: &[ObjectKey]) -> Result<Vec<Option<(Object, u64)>>, Error> {
-        todo!("GraphQL object reads are not implemented in the skeleton")
-    }
-}
-
-impl CheckpointStore for DataStore {
-    fn get_checkpoint_by_sequence_number(
-        &self,
-        _sequence: CheckpointSequenceNumber,
-    ) -> Result<Option<FullCheckpointData>, Error> {
-        todo!("GraphQL checkpoint reads are not implemented in the skeleton")
-    }
-
-    fn get_latest_checkpoint(&self) -> Result<Option<FullCheckpointData>, Error> {
-        todo!("GraphQL latest-checkpoint lookup is not implemented in the skeleton")
-    }
-
-    fn get_sequence_by_checkpoint_digest(
-        &self,
-        _digest: &CheckpointDigest,
-    ) -> Result<Option<CheckpointSequenceNumber>, Error> {
-        todo!("GraphQL checkpoint-digest lookups are not implemented in the skeleton")
-    }
-
-    fn get_sequence_by_contents_digest(
-        &self,
-        _digest: &CheckpointContentsDigest,
-    ) -> Result<Option<CheckpointSequenceNumber>, Error> {
-        todo!("GraphQL contents-digest lookups are not implemented in the skeleton")
+    fn get_objects(&self, keys: &[ObjectKey]) -> Result<Vec<Option<(Object, u64)>>, Error> {
+        match block_on!(self.objects(keys)) {
+            Ok(results) => {
+                assert_eq!(results.len(), keys.len());
+                for (key, res) in keys.iter().zip(results.iter()) {
+                    match key.version_query {
+                        VersionQuery::Version(_) => {
+                            if res.is_some() {
+                                self.metrics.obj_version_hit.fetch_add(1, Ordering::Relaxed);
+                            } else {
+                                self.metrics
+                                    .obj_version_miss
+                                    .fetch_add(1, Ordering::Relaxed);
+                            }
+                        }
+                        VersionQuery::RootVersion(_) => {
+                            if res.is_some() {
+                                self.metrics.obj_root_hit.fetch_add(1, Ordering::Relaxed);
+                            } else {
+                                self.metrics.obj_root_miss.fetch_add(1, Ordering::Relaxed);
+                            }
+                        }
+                        VersionQuery::AtCheckpoint(_) => {
+                            if res.is_some() {
+                                self.metrics
+                                    .obj_checkpoint_hit
+                                    .fetch_add(1, Ordering::Relaxed);
+                            } else {
+                                self.metrics
+                                    .obj_checkpoint_miss
+                                    .fetch_add(1, Ordering::Relaxed);
+                            }
+                        }
+                    }
+                }
+                Ok(results)
+            }
+            Err(e) => {
+                // Attribute the error to each requested key type
+                for key in keys.iter() {
+                    match key.version_query {
+                        VersionQuery::Version(_) => {
+                            self.metrics
+                                .obj_version_error
+                                .fetch_add(1, Ordering::Relaxed);
+                        }
+                        VersionQuery::RootVersion(_) => {
+                            self.metrics.obj_root_error.fetch_add(1, Ordering::Relaxed);
+                        }
+                        VersionQuery::AtCheckpoint(_) => {
+                            self.metrics
+                                .obj_checkpoint_error
+                                .fetch_add(1, Ordering::Relaxed);
+                        }
+                    }
+                }
+                Err(e)
+            }
+        }
     }
 }
 
 impl SetupStore for DataStore {
     fn setup(&self, _chain_id: Option<String>) -> Result<Option<String>, Error> {
-        todo!("GraphQL setup is not implemented in the skeleton")
+        // Return the chain identifier
+        Ok(Some(block_on!(gql_queries::chain_id_query::query(self))?))
+    }
+}
+
+impl DataStore {
+    pub fn new(node: Node, version: &str) -> Result<Self, Error> {
+        debug!("Start stores creation");
+        let client = reqwest::Client::builder()
+            .connect_timeout(std::time::Duration::from_secs(3))
+            .timeout(std::time::Duration::from_secs(5))
+            .build()?;
+        let url = node.gql_url();
+        let rpc =
+            reqwest::Url::parse(url).context(format!("Failed to parse GQL RPC URL {}", url))?;
+        let epoch_map = RwLock::new(BTreeMap::new());
+        debug!("End stores creation");
+
+        Ok(Self {
+            client,
+            node,
+            epoch_map,
+            rpc,
+            version: version.to_string(),
+            metrics: DataStoreMetrics::default(),
+        })
+    }
+
+    pub fn node(&self) -> &Node {
+        &self.node
+    }
+    pub fn chain(&self) -> Chain {
+        self.node.chain()
+    }
+
+    pub(crate) async fn run_query<T, V>(
+        &self,
+        operation: &Operation<T, V>,
+    ) -> Result<GraphQlResponse<T>, Error>
+    where
+        T: serde::de::DeserializeOwned,
+        V: serde::Serialize,
+    {
+        Self::run_query_internal(&self.client, &self.rpc, &self.version, operation).await
+    }
+
+    async fn run_query_internal<T, V>(
+        client: &reqwest::Client,
+        rpc: &reqwest::Url,
+        version: &str,
+        operation: &Operation<T, V>,
+    ) -> Result<GraphQlResponse<T>, Error>
+    where
+        T: serde::de::DeserializeOwned,
+        V: serde::Serialize,
+    {
+        client
+            .post(rpc.clone())
+            .header(USER_AGENT, format!("sui-data-store-v{}", version))
+            .json(&operation)
+            .send()
+            .await
+            .context("Failed to send GQL query")?
+            .json::<GraphQlResponse<T>>()
+            .await
+            .context("Failed to read response in GQL query")
+    }
+
+    async fn transaction(
+        &self,
+        digest: &str,
+    ) -> Result<Option<(TransactionData, TransactionEffects, u64)>, Error> {
+        let _span = debug_span!("gql_txn_query", digest = %digest).entered();
+        debug!(op = "txn_query", phase = "start", "transaction query");
+        let t0 = Instant::now();
+        let data = gql_queries::txn_query::query(digest.to_string(), self).await;
+        let elapsed = t0.elapsed().as_millis();
+        debug!(
+            op = "txn_query",
+            phase = "end",
+            elapsed_ms = elapsed,
+            "transaction query"
+        );
+        data
+    }
+
+    async fn epoch(&self, epoch_id: u64) -> Result<Option<EpochData>, Error> {
+        let _span = debug_span!("gql_epoch_query", epoch = epoch_id).entered();
+        debug!(op = "epoch_query", phase = "start", "epoch query");
+        let t0 = Instant::now();
+        let data = gql_queries::epoch_query::query(epoch_id, self).await;
+        let elapsed = t0.elapsed().as_millis();
+        debug!(
+            op = "epoch_query",
+            phase = "end",
+            elapsed_ms = elapsed,
+            "epoch query"
+        );
+        data
+    }
+
+    async fn objects(&self, keys: &[ObjectKey]) -> Result<Vec<Option<(Object, u64)>>, Error> {
+        let _span = debug_span!("gql_objects_query", num_keys = keys.len()).entered();
+        debug!(op = "objects_query", phase = "start", "objects query");
+        let t0 = Instant::now();
+        let data = gql_queries::object_query::query(keys, self).await?;
+        let elapsed = t0.elapsed().as_millis();
+        debug!(
+            op = "objects_query",
+            phase = "end",
+            elapsed_ms = elapsed,
+            "objects query"
+        );
+        Ok(data)
     }
 }
 
 impl StoreSummary for DataStore {
-    fn summary<W: Write>(&self, writer: &mut W) -> Result<()> {
+    fn summary<W: std::io::Write>(&self, w: &mut W) -> Result<()> {
+        let m = &self.metrics;
+        let txn_hit = m.txn_hit.load(Ordering::Relaxed);
+        let txn_miss = m.txn_miss.load(Ordering::Relaxed);
+        let txn_err = m.txn_error.load(Ordering::Relaxed);
+        let epoch_hit = m.epoch_hit.load(Ordering::Relaxed);
+        let epoch_miss = m.epoch_miss.load(Ordering::Relaxed);
+        let epoch_err = m.epoch_error.load(Ordering::Relaxed);
+        let proto_hit = m.proto_hit.load(Ordering::Relaxed);
+        let proto_miss = m.proto_miss.load(Ordering::Relaxed);
+        let proto_err = m.proto_error.load(Ordering::Relaxed);
+        let obj_v_hit = m.obj_version_hit.load(Ordering::Relaxed);
+        let obj_v_miss = m.obj_version_miss.load(Ordering::Relaxed);
+        let obj_v_err = m.obj_version_error.load(Ordering::Relaxed);
+        let obj_r_hit = m.obj_root_hit.load(Ordering::Relaxed);
+        let obj_r_miss = m.obj_root_miss.load(Ordering::Relaxed);
+        let obj_r_err = m.obj_root_error.load(Ordering::Relaxed);
+        let obj_c_hit = m.obj_checkpoint_hit.load(Ordering::Relaxed);
+        let obj_c_miss = m.obj_checkpoint_miss.load(Ordering::Relaxed);
+        let obj_c_err = m.obj_checkpoint_error.load(Ordering::Relaxed);
+        let obj_total_hit = obj_v_hit + obj_r_hit + obj_c_hit;
+        let obj_total_miss = obj_v_miss + obj_r_miss + obj_c_miss;
+        let obj_total_err = obj_v_err + obj_r_err + obj_c_err;
+        let total_hit = txn_hit + epoch_hit + proto_hit + obj_total_hit;
+        let total_miss = txn_miss + epoch_miss + proto_miss + obj_total_miss;
+        let total_err = txn_err + epoch_err + proto_err + obj_total_err;
+
+        writeln!(w, "DataStore (remote GQL) summary")?;
+        writeln!(w, "  Node: {:?}", self.node())?;
+        writeln!(w, "  Cache sizes:")?;
         writeln!(
-            writer,
-            "DataStore(node={}, rpc={}, version={})",
-            self.node.network_name(),
-            self.rpc,
-            self.version
+            w,
+            "    Epochs: {} entries",
+            self.epoch_map.read().unwrap().len()
+        )?;
+        writeln!(
+            w,
+            "  Overall:    hit={} miss={} error={}",
+            total_hit, total_miss, total_err
+        )?;
+        writeln!(w, "  Hits/Misses:")?;
+        writeln!(
+            w,
+            "    Transaction: hit={} miss={} error={}",
+            txn_hit, txn_miss, txn_err
+        )?;
+        writeln!(
+            w,
+            "    Epoch:       hit={} miss={} error={}",
+            epoch_hit, epoch_miss, epoch_err
+        )?;
+        writeln!(
+            w,
+            "    Protocol:    hit={} miss={} error={}",
+            proto_hit, proto_miss, proto_err
+        )?;
+        writeln!(
+            w,
+            "    Objects(all): hit={} miss={} error={}",
+            obj_total_hit, obj_total_miss, obj_total_err
+        )?;
+        writeln!(
+            w,
+            "      Version:     hit={} miss={}",
+            obj_v_hit, obj_v_miss
+        )?;
+        writeln!(
+            w,
+            "      RootVersion: hit={} miss={}",
+            obj_r_hit, obj_r_miss
+        )?;
+        writeln!(
+            w,
+            "      Checkpoint:  hit={} miss={}",
+            obj_c_hit, obj_c_miss
         )?;
         Ok(())
     }

--- a/crates/sui-data-store/src/stores/in_memory.rs
+++ b/crates/sui-data-store/src/stores/in_memory.rs
@@ -1,25 +1,227 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//! In-memory store skeleton.
+//! In-memory implementation of the data store interfaces: `TransactionStore`, `EpochStore`, and `ObjectStore`.
+//! The `InMemoryStore` provides fast in-memory lookups.
+//!
+//! This store is purely cache-based - it only returns data that has been explicitly stored in memory.
+//! For `TransactionStore`, `EpochStore`, and `ObjectStore`, missing data results in `Ok(None)`.
+//!
+//! # Usage Examples
+//!
+//! ```ignore
+//! use crate::data_stores::InMemoryStore;
+//! use crate::Node;
+//!
+//! // Create an in-memory store
+//! let store = InMemoryStore::new(Node::Mainnet);
+//!
+//! // Attempting to fetch data not in cache will return None
+//! let result = store.epoch_info(123); // Returns Ok(None) since cache is empty
+//!
+//! // Data must be explicitly added to cache before it can be retrieved
+//! // (This would typically be done by other parts of the system)
+//! ```
 
 use crate::{
     CheckpointStore, CheckpointStoreWriter, EpochData, EpochStore, EpochStoreWriter,
     FullCheckpointData, ObjectKey, ObjectStore, ObjectStoreWriter, SetupStore, StoreSummary,
-    TransactionInfo, TransactionStore, TransactionStoreWriter, node::Node,
+    TransactionInfo, TransactionStore, TransactionStoreWriter, VersionQuery, node::Node,
 };
 use anyhow::{Error, Result};
-use std::io::Write;
+use std::{
+    collections::BTreeMap,
+    sync::{
+        RwLock,
+        atomic::{AtomicU64, Ordering},
+    },
+};
 use sui_types::{
     base_types::ObjectID,
+    committee::ProtocolVersion,
     digests::{CheckpointContentsDigest, CheckpointDigest},
     messages_checkpoint::CheckpointSequenceNumber,
     object::Object,
     supported_protocol_versions::{Chain, ProtocolConfig},
 };
 
-/// Cheap summary of the in-memory caches.
-#[derive(Clone, Debug, Default)]
+/// In-memory store implementing the data store interfaces.
+struct InMemoryStoreInner {
+    node: Node,
+    transaction_cache: BTreeMap<String, TransactionInfo>,
+    epoch_data_cache: BTreeMap<u64, EpochData>,
+    checkpoint_data_cache: BTreeMap<CheckpointSequenceNumber, FullCheckpointData>,
+    checkpoint_digest_cache: BTreeMap<CheckpointDigest, CheckpointSequenceNumber>,
+    checkpoint_contents_digest_cache: BTreeMap<CheckpointContentsDigest, CheckpointSequenceNumber>,
+    latest_checkpoint_sequence: Option<CheckpointSequenceNumber>,
+    object_cache: BTreeMap<ObjectID, BTreeMap<u64, Object>>,
+    // The next 2 maps can be organized as flat maps or nested maps
+    // and the best solution depends on usage patterns.
+    // For now, we use flat maps but we may want to review in the future
+    /// Cache mapping (ObjectID, root_version) -> actual_version
+    /// Used for VersionQuery::RootVersion lookups
+    root_version_cache: BTreeMap<(ObjectID, u64), u64>,
+    /// Cache mapping (ObjectID, checkpoint) -> actual_version  
+    /// Used for VersionQuery::AtCheckpoint lookups
+    checkpoint_cache: BTreeMap<(ObjectID, u64), u64>,
+    /// Metrics: hit/miss counters for API calls
+    metrics: MemStoreMetrics,
+}
+
+// The RwLock is needed for 2 reasons:
+// 1. to make tokio happy
+// 2. to allow interior mutability for the cache
+pub struct InMemoryStore(RwLock<InMemoryStoreInner>);
+
+#[derive(Default)]
+struct MemStoreMetrics {
+    // transactions
+    txn_hit: AtomicU64,
+    txn_miss: AtomicU64,
+    txn_error: AtomicU64,
+    // epochs
+    epoch_hit: AtomicU64,
+    epoch_miss: AtomicU64,
+    epoch_error: AtomicU64,
+    // protocol config
+    proto_hit: AtomicU64,
+    proto_miss: AtomicU64,
+    proto_error: AtomicU64,
+    // checkpoints
+    checkpoint_hit: AtomicU64,
+    checkpoint_miss: AtomicU64,
+    checkpoint_error: AtomicU64,
+    // objects by query kind
+    obj_version_hit: AtomicU64,
+    obj_version_miss: AtomicU64,
+    obj_version_error: AtomicU64,
+    obj_root_hit: AtomicU64,
+    obj_root_miss: AtomicU64,
+    obj_root_error: AtomicU64,
+    obj_checkpoint_hit: AtomicU64,
+    obj_checkpoint_miss: AtomicU64,
+    obj_checkpoint_error: AtomicU64,
+}
+
+impl InMemoryStore {
+    /// Create a new InMemoryStore with the given node
+    pub fn new(node: Node) -> Self {
+        Self(RwLock::new(InMemoryStoreInner {
+            node,
+            transaction_cache: BTreeMap::new(),
+            epoch_data_cache: BTreeMap::new(),
+            checkpoint_data_cache: BTreeMap::new(),
+            checkpoint_digest_cache: BTreeMap::new(),
+            checkpoint_contents_digest_cache: BTreeMap::new(),
+            latest_checkpoint_sequence: None,
+            object_cache: BTreeMap::new(),
+            root_version_cache: BTreeMap::new(),
+            checkpoint_cache: BTreeMap::new(),
+            metrics: MemStoreMetrics::default(),
+        }))
+    }
+
+    /// Get the chain for this store
+    pub fn chain(&self) -> Chain {
+        self.0.read().unwrap().node.chain()
+    }
+
+    /// Get the node for this store
+    pub fn node(&self) -> Node {
+        self.0.read().unwrap().node.clone()
+    }
+
+    /// Clear all caches
+    pub fn clear_all_caches(&self) {
+        let mut inner = self.0.write().unwrap();
+        inner.transaction_cache.clear();
+        inner.epoch_data_cache.clear();
+        inner.checkpoint_data_cache.clear();
+        inner.checkpoint_digest_cache.clear();
+        inner.checkpoint_contents_digest_cache.clear();
+        inner.latest_checkpoint_sequence = None;
+        inner.object_cache.clear();
+        inner.root_version_cache.clear();
+        inner.checkpoint_cache.clear();
+    }
+
+    /// Get cache statistics
+    pub fn cache_stats(&self) -> CacheStats {
+        let inner = self.0.read().unwrap();
+        let object_cache_size = inner
+            .object_cache
+            .values()
+            .map(|versions| versions.len())
+            .sum();
+
+        let root_version_cache_size = inner.root_version_cache.len();
+
+        let object_checkpoint_map_cache_size = inner.checkpoint_cache.len();
+
+        CacheStats {
+            transaction_cache_size: inner.transaction_cache.len(),
+            epoch_data_cache_size: inner.epoch_data_cache.len(),
+            checkpoint_data_cache_size: inner.checkpoint_data_cache.len(),
+            checkpoint_digest_cache_size: inner.checkpoint_digest_cache.len(),
+            checkpoint_contents_digest_cache_size: inner.checkpoint_contents_digest_cache.len(),
+            object_cache_size,
+            root_version_cache_size,
+            object_checkpoint_map_cache_size,
+        }
+    }
+
+    /// Add transaction data to the cache
+    pub fn add_transaction_data(&self, tx_digest: String, transaction_info: TransactionInfo) {
+        self.0
+            .write()
+            .unwrap()
+            .transaction_cache
+            .insert(tx_digest, transaction_info);
+    }
+
+    /// Add epoch data to the cache
+    pub fn add_epoch_data(&self, epoch: u64, epoch_data: EpochData) {
+        self.0
+            .write()
+            .unwrap()
+            .epoch_data_cache
+            .insert(epoch, epoch_data);
+    }
+
+    /// Add checkpoint data to the cache.
+    pub fn add_checkpoint_data(&self, checkpoint: FullCheckpointData) {
+        let sequence = checkpoint.summary.sequence_number;
+        let checkpoint_digest = *checkpoint.summary.digest();
+        let contents_digest = *checkpoint.contents.digest();
+        let mut inner = self.0.write().unwrap();
+        inner.checkpoint_data_cache.insert(sequence, checkpoint);
+        inner
+            .checkpoint_digest_cache
+            .insert(checkpoint_digest, sequence);
+        inner
+            .checkpoint_contents_digest_cache
+            .insert(contents_digest, sequence);
+        inner.latest_checkpoint_sequence = Some(
+            inner
+                .latest_checkpoint_sequence
+                .map_or(sequence, |current| current.max(sequence)),
+        );
+    }
+
+    /// Add object data to the cache
+    pub fn add_object_data(&self, object_id: ObjectID, version: u64, object: Object) {
+        self.0
+            .write()
+            .unwrap()
+            .object_cache
+            .entry(object_id)
+            .or_default()
+            .insert(version, object);
+    }
+}
+
+/// Statistics about cache usage
+#[derive(Debug, Clone)]
 pub struct CacheStats {
     pub transaction_cache_size: usize,
     pub epoch_data_cache_size: usize,
@@ -31,153 +233,405 @@ pub struct CacheStats {
     pub object_checkpoint_map_cache_size: usize,
 }
 
-/// Unbounded in-memory store.
-#[derive(Debug)]
-pub struct InMemoryStore {
-    node: Node,
-}
-
-impl InMemoryStore {
-    /// Create a new in-memory store.
-    pub fn new(node: Node) -> Self {
-        Self { node }
-    }
-
-    /// Return the chain associated with the configured node.
-    pub fn chain(&self) -> Chain {
-        self.node.chain()
-    }
-
-    /// Return the configured node.
-    pub fn node(&self) -> &Node {
-        &self.node
-    }
-
-    /// Clear all caches.
-    pub fn clear_all_caches(&self) {
-        todo!("in-memory cache clearing is not implemented in the skeleton")
-    }
-
-    /// Return current cache sizes.
-    pub fn cache_stats(&self) -> CacheStats {
-        CacheStats::default()
-    }
-
-    /// Add transaction data to the cache.
-    pub fn add_transaction_data(&self, _tx_digest: String, _transaction_info: TransactionInfo) {
-        todo!("in-memory transaction insertion is not implemented in the skeleton")
-    }
-
-    /// Add epoch data to the cache.
-    pub fn add_epoch_data(&self, _epoch: u64, _epoch_data: EpochData) {
-        todo!("in-memory epoch insertion is not implemented in the skeleton")
-    }
-
-    /// Add checkpoint data to the cache.
-    pub fn add_checkpoint_data(&self, _checkpoint: FullCheckpointData) {
-        todo!("in-memory checkpoint insertion is not implemented in the skeleton")
-    }
-
-    /// Add object data to the cache.
-    pub fn add_object_data(&self, _object_id: ObjectID, _version: u64, _object: Object) {
-        todo!("in-memory object insertion is not implemented in the skeleton")
-    }
-}
-
 impl TransactionStore for InMemoryStore {
     fn transaction_data_and_effects(
         &self,
-        _tx_digest: &str,
+        tx_digest: &str,
     ) -> Result<Option<TransactionInfo>, Error> {
-        todo!("in-memory transaction reads are not implemented in the skeleton")
-    }
-}
-
-impl TransactionStoreWriter for InMemoryStore {
-    fn write_transaction(
-        &self,
-        _tx_digest: &str,
-        _transaction_info: TransactionInfo,
-    ) -> Result<(), Error> {
-        todo!("in-memory transaction writes are not implemented in the skeleton")
+        let inner = self.0.read().unwrap();
+        if let Some(cached) = inner.transaction_cache.get(tx_digest) {
+            inner.metrics.txn_hit.fetch_add(1, Ordering::Relaxed);
+            return Ok(Some(cached.clone()));
+        }
+        inner.metrics.txn_miss.fetch_add(1, Ordering::Relaxed);
+        Ok(None)
     }
 }
 
 impl EpochStore for InMemoryStore {
-    fn epoch_info(&self, _epoch: u64) -> Result<Option<EpochData>, Error> {
-        todo!("in-memory epoch reads are not implemented in the skeleton")
+    fn epoch_info(&self, epoch: u64) -> Result<Option<EpochData>, Error> {
+        let inner = self.0.read().unwrap();
+        if let Some(cached) = inner.epoch_data_cache.get(&epoch) {
+            inner.metrics.epoch_hit.fetch_add(1, Ordering::Relaxed);
+            return Ok(Some(cached.clone()));
+        }
+        inner.metrics.epoch_miss.fetch_add(1, Ordering::Relaxed);
+        Ok(None)
     }
 
-    fn protocol_config(&self, _epoch: u64) -> Result<Option<ProtocolConfig>, Error> {
-        todo!("in-memory protocol-config reads are not implemented in the skeleton")
-    }
-}
-
-impl EpochStoreWriter for InMemoryStore {
-    fn write_epoch_info(&self, _epoch: u64, _epoch_data: EpochData) -> Result<(), Error> {
-        todo!("in-memory epoch writes are not implemented in the skeleton")
-    }
-}
-
-impl ObjectStore for InMemoryStore {
-    fn get_objects(&self, _keys: &[ObjectKey]) -> Result<Vec<Option<(Object, u64)>>, Error> {
-        todo!("in-memory object reads are not implemented in the skeleton")
-    }
-}
-
-impl ObjectStoreWriter for InMemoryStore {
-    fn write_object(
-        &self,
-        _key: &ObjectKey,
-        _object: Object,
-        _actual_version: u64,
-    ) -> Result<(), Error> {
-        todo!("in-memory object writes are not implemented in the skeleton")
+    fn protocol_config(&self, epoch: u64) -> Result<Option<ProtocolConfig>, Error> {
+        match self.epoch_info(epoch) {
+            Ok(Some(epoch_data)) => {
+                let inner = self.0.read().unwrap();
+                inner.metrics.proto_hit.fetch_add(1, Ordering::Relaxed);
+                Ok(Some(ProtocolConfig::get_for_version(
+                    ProtocolVersion::new(epoch_data.protocol_version),
+                    self.chain(),
+                )))
+            }
+            Ok(None) => {
+                let inner = self.0.read().unwrap();
+                inner.metrics.proto_miss.fetch_add(1, Ordering::Relaxed);
+                Ok(None)
+            }
+            Err(e) => {
+                let inner = self.0.read().unwrap();
+                inner.metrics.proto_error.fetch_add(1, Ordering::Relaxed);
+                Err(e)
+            }
+        }
     }
 }
 
 impl CheckpointStore for InMemoryStore {
     fn get_checkpoint_by_sequence_number(
         &self,
-        _sequence: CheckpointSequenceNumber,
+        sequence: CheckpointSequenceNumber,
     ) -> Result<Option<FullCheckpointData>, Error> {
-        todo!("in-memory checkpoint reads are not implemented in the skeleton")
+        let inner = self.0.read().unwrap();
+        if let Some(checkpoint) = inner.checkpoint_data_cache.get(&sequence) {
+            inner.metrics.checkpoint_hit.fetch_add(1, Ordering::Relaxed);
+            return Ok(Some(checkpoint.clone()));
+        }
+        inner
+            .metrics
+            .checkpoint_miss
+            .fetch_add(1, Ordering::Relaxed);
+        Ok(None)
     }
 
     fn get_latest_checkpoint(&self) -> Result<Option<FullCheckpointData>, Error> {
-        todo!("in-memory latest-checkpoint lookup is not implemented in the skeleton")
+        let inner = self.0.read().unwrap();
+        let Some(sequence) = inner.latest_checkpoint_sequence else {
+            inner
+                .metrics
+                .checkpoint_miss
+                .fetch_add(1, Ordering::Relaxed);
+            return Ok(None);
+        };
+        if let Some(checkpoint) = inner.checkpoint_data_cache.get(&sequence) {
+            inner.metrics.checkpoint_hit.fetch_add(1, Ordering::Relaxed);
+            return Ok(Some(checkpoint.clone()));
+        }
+        inner
+            .metrics
+            .checkpoint_error
+            .fetch_add(1, Ordering::Relaxed);
+        Err(anyhow::anyhow!(
+            "latest checkpoint sequence {sequence} was cached without checkpoint data"
+        ))
     }
 
     fn get_sequence_by_checkpoint_digest(
         &self,
-        _digest: &CheckpointDigest,
+        digest: &CheckpointDigest,
     ) -> Result<Option<CheckpointSequenceNumber>, Error> {
-        todo!("in-memory checkpoint-digest lookups are not implemented in the skeleton")
+        let inner = self.0.read().unwrap();
+        if let Some(sequence) = inner.checkpoint_digest_cache.get(digest) {
+            inner.metrics.checkpoint_hit.fetch_add(1, Ordering::Relaxed);
+            return Ok(Some(*sequence));
+        }
+        inner
+            .metrics
+            .checkpoint_miss
+            .fetch_add(1, Ordering::Relaxed);
+        Ok(None)
     }
 
     fn get_sequence_by_contents_digest(
         &self,
-        _digest: &CheckpointContentsDigest,
+        digest: &CheckpointContentsDigest,
     ) -> Result<Option<CheckpointSequenceNumber>, Error> {
-        todo!("in-memory contents-digest lookups are not implemented in the skeleton")
+        let inner = self.0.read().unwrap();
+        if let Some(sequence) = inner.checkpoint_contents_digest_cache.get(digest) {
+            inner.metrics.checkpoint_hit.fetch_add(1, Ordering::Relaxed);
+            return Ok(Some(*sequence));
+        }
+        inner
+            .metrics
+            .checkpoint_miss
+            .fetch_add(1, Ordering::Relaxed);
+        Ok(None)
+    }
+}
+
+impl ObjectStore for InMemoryStore {
+    fn get_objects(&self, keys: &[ObjectKey]) -> Result<Vec<Option<(Object, u64)>>, Error> {
+        let mut results = Vec::with_capacity(keys.len());
+        let inner = self.0.read().unwrap();
+
+        // Check caches for each key
+        for key in keys.iter() {
+            let (object_and_version, hit_ctr, miss_ctr) = match &key.version_query {
+                VersionQuery::Version(version) => {
+                    let res = if let Some(versions_map) = inner.object_cache.get(&key.object_id) {
+                        versions_map
+                            .get(version)
+                            .cloned()
+                            .map(|obj| (obj, *version))
+                    } else {
+                        None
+                    };
+                    (
+                        res,
+                        &inner.metrics.obj_version_hit,
+                        &inner.metrics.obj_version_miss,
+                    )
+                }
+                VersionQuery::RootVersion(max_version) => {
+                    let actual_version = inner
+                        .root_version_cache
+                        .get(&(key.object_id, *max_version))
+                        .copied();
+                    let res = actual_version.and_then(|actual_version| {
+                        inner
+                            .object_cache
+                            .get(&key.object_id)
+                            .and_then(|versions_map| versions_map.get(&actual_version))
+                            .cloned()
+                            .map(|obj| (obj, actual_version))
+                    });
+                    (
+                        res,
+                        &inner.metrics.obj_root_hit,
+                        &inner.metrics.obj_root_miss,
+                    )
+                }
+                VersionQuery::AtCheckpoint(checkpoint) => {
+                    let actual_version = inner
+                        .checkpoint_cache
+                        .get(&(key.object_id, *checkpoint))
+                        .copied();
+                    let res = actual_version.and_then(|actual_version| {
+                        inner
+                            .object_cache
+                            .get(&key.object_id)
+                            .and_then(|versions_map| versions_map.get(&actual_version))
+                            .cloned()
+                            .map(|obj| (obj, actual_version))
+                    });
+                    (
+                        res,
+                        &inner.metrics.obj_checkpoint_hit,
+                        &inner.metrics.obj_checkpoint_miss,
+                    )
+                }
+            };
+            if object_and_version.is_some() {
+                hit_ctr.fetch_add(1, Ordering::Relaxed);
+            } else {
+                miss_ctr.fetch_add(1, Ordering::Relaxed);
+            }
+            results.push(object_and_version);
+        }
+
+        Ok(results)
+    }
+}
+
+impl TransactionStoreWriter for InMemoryStore {
+    fn write_transaction(
+        &self,
+        tx_digest: &str,
+        transaction_info: TransactionInfo,
+    ) -> Result<(), Error> {
+        self.0
+            .write()
+            .unwrap()
+            .transaction_cache
+            .insert(tx_digest.to_string(), transaction_info);
+        Ok(())
+    }
+}
+
+impl EpochStoreWriter for InMemoryStore {
+    fn write_epoch_info(&self, epoch: u64, epoch_data: EpochData) -> Result<(), Error> {
+        self.0
+            .write()
+            .unwrap()
+            .epoch_data_cache
+            .insert(epoch, epoch_data);
+        Ok(())
     }
 }
 
 impl CheckpointStoreWriter for InMemoryStore {
-    fn write_checkpoint(&self, _checkpoint: &FullCheckpointData) -> Result<(), Error> {
-        todo!("in-memory checkpoint writes are not implemented in the skeleton")
+    fn write_checkpoint(&self, checkpoint: &FullCheckpointData) -> Result<(), Error> {
+        let sequence = checkpoint.summary.sequence_number;
+        let checkpoint_digest = *checkpoint.summary.digest();
+        let contents_digest = *checkpoint.contents.digest();
+        let mut inner = self.0.write().unwrap();
+        inner
+            .checkpoint_data_cache
+            .insert(sequence, checkpoint.clone());
+        inner
+            .checkpoint_digest_cache
+            .insert(checkpoint_digest, sequence);
+        inner
+            .checkpoint_contents_digest_cache
+            .insert(contents_digest, sequence);
+        inner.latest_checkpoint_sequence = Some(
+            inner
+                .latest_checkpoint_sequence
+                .map_or(sequence, |current| current.max(sequence)),
+        );
+        Ok(())
+    }
+}
+
+impl ObjectStoreWriter for InMemoryStore {
+    fn write_object(
+        &self,
+        key: &ObjectKey,
+        object: Object,
+        actual_version: u64,
+    ) -> Result<(), Error> {
+        let mut inner = self.0.write().unwrap();
+
+        // Always store the object at its actual version
+        inner
+            .object_cache
+            .entry(key.object_id)
+            .or_default()
+            .insert(actual_version, object);
+
+        // Handle version mappings based on query type
+        match &key.version_query {
+            VersionQuery::Version(_) => {
+                // No additional mapping needed for direct version queries
+            }
+            VersionQuery::RootVersion(max_version) => {
+                inner
+                    .root_version_cache
+                    .insert((key.object_id, *max_version), actual_version);
+            }
+            VersionQuery::AtCheckpoint(checkpoint) => {
+                inner
+                    .checkpoint_cache
+                    .insert((key.object_id, *checkpoint), actual_version);
+            }
+        }
+
+        Ok(())
     }
 }
 
 impl SetupStore for InMemoryStore {
     fn setup(&self, _chain_id: Option<String>) -> Result<Option<String>, Error> {
-        todo!("in-memory setup is not implemented in the skeleton")
+        Ok(None)
     }
 }
 
 impl StoreSummary for InMemoryStore {
-    fn summary<W: Write>(&self, writer: &mut W) -> Result<()> {
-        writeln!(writer, "InMemoryStore(node={})", self.node.network_name())?;
+    fn summary<W: std::io::Write>(&self, w: &mut W) -> Result<()> {
+        let stats = self.cache_stats();
+        let inner = self.0.read().unwrap();
+        let m = &inner.metrics;
+        let txn_hit = m.txn_hit.load(Ordering::Relaxed);
+        let txn_miss = m.txn_miss.load(Ordering::Relaxed);
+        let txn_err = m.txn_error.load(Ordering::Relaxed);
+        let epoch_hit = m.epoch_hit.load(Ordering::Relaxed);
+        let epoch_miss = m.epoch_miss.load(Ordering::Relaxed);
+        let epoch_err = m.epoch_error.load(Ordering::Relaxed);
+        let proto_hit = m.proto_hit.load(Ordering::Relaxed);
+        let proto_miss = m.proto_miss.load(Ordering::Relaxed);
+        let proto_err = m.proto_error.load(Ordering::Relaxed);
+        let checkpoint_hit = m.checkpoint_hit.load(Ordering::Relaxed);
+        let checkpoint_miss = m.checkpoint_miss.load(Ordering::Relaxed);
+        let checkpoint_err = m.checkpoint_error.load(Ordering::Relaxed);
+        let obj_v_hit = m.obj_version_hit.load(Ordering::Relaxed);
+        let obj_v_miss = m.obj_version_miss.load(Ordering::Relaxed);
+        let obj_v_err = m.obj_version_error.load(Ordering::Relaxed);
+        let obj_r_hit = m.obj_root_hit.load(Ordering::Relaxed);
+        let obj_r_miss = m.obj_root_miss.load(Ordering::Relaxed);
+        let obj_r_err = m.obj_root_error.load(Ordering::Relaxed);
+        let obj_c_hit = m.obj_checkpoint_hit.load(Ordering::Relaxed);
+        let obj_c_miss = m.obj_checkpoint_miss.load(Ordering::Relaxed);
+        let obj_c_err = m.obj_checkpoint_error.load(Ordering::Relaxed);
+        let obj_total_hit = obj_v_hit + obj_r_hit + obj_c_hit;
+        let obj_total_miss = obj_v_miss + obj_r_miss + obj_c_miss;
+        let obj_total_err = obj_v_err + obj_r_err + obj_c_err;
+        let total_hit = txn_hit + epoch_hit + proto_hit + checkpoint_hit + obj_total_hit;
+        let total_miss = txn_miss + epoch_miss + proto_miss + checkpoint_miss + obj_total_miss;
+        let total_err = txn_err + epoch_err + proto_err + checkpoint_err + obj_total_err;
+
+        writeln!(w, "InMemoryStore summary")?;
+        writeln!(w, "  Node: {:?}", self.node())?;
+        writeln!(w, "  Cache sizes:")?;
+        writeln!(
+            w,
+            "    Transactions: {} entries",
+            stats.transaction_cache_size
+        )?;
+        writeln!(w, "    Epochs: {} entries", stats.epoch_data_cache_size)?;
+        writeln!(w, "    Objects: {} versions", stats.object_cache_size)?;
+        writeln!(w, "    Root map: {} entries", stats.root_version_cache_size)?;
+        writeln!(
+            w,
+            "    Checkpoints: {} entries",
+            stats.checkpoint_data_cache_size
+        )?;
+        writeln!(
+            w,
+            "    Checkpoint digest index: {} entries",
+            stats.checkpoint_digest_cache_size
+        )?;
+        writeln!(
+            w,
+            "    Checkpoint contents index: {} entries",
+            stats.checkpoint_contents_digest_cache_size
+        )?;
+        writeln!(
+            w,
+            "    Object checkpoint map: {} entries",
+            stats.object_checkpoint_map_cache_size
+        )?;
+        writeln!(
+            w,
+            "  Overall:    hit={} miss={} error={}",
+            total_hit, total_miss, total_err
+        )?;
+        writeln!(w, "  Hits/Misses:")?;
+        writeln!(
+            w,
+            "    Transaction: hit={} miss={} error={}",
+            txn_hit, txn_miss, txn_err
+        )?;
+        writeln!(
+            w,
+            "    Epoch:       hit={} miss={} error={}",
+            epoch_hit, epoch_miss, epoch_err
+        )?;
+        writeln!(
+            w,
+            "    Protocol:    hit={} miss={} error={}",
+            proto_hit, proto_miss, proto_err
+        )?;
+        writeln!(
+            w,
+            "    Checkpoint:  hit={} miss={} error={}",
+            checkpoint_hit, checkpoint_miss, checkpoint_err
+        )?;
+        writeln!(
+            w,
+            "    Objects(all): hit={} miss={} error={}",
+            obj_total_hit, obj_total_miss, obj_total_err
+        )?;
+        writeln!(
+            w,
+            "      Version:     hit={} miss={} error={}",
+            obj_v_hit, obj_v_miss, obj_v_err
+        )?;
+        writeln!(
+            w,
+            "      RootVersion: hit={} miss={} error={}",
+            obj_r_hit, obj_r_miss, obj_r_err
+        )?;
+        writeln!(
+            w,
+            "      Checkpoint:  hit={} miss={} error={}",
+            obj_c_hit, obj_c_miss, obj_c_err
+        )?;
         Ok(())
     }
 }

--- a/crates/sui-data-store/src/stores/read_through.rs
+++ b/crates/sui-data-store/src/stores/read_through.rs
@@ -1,15 +1,12 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Read-through store skeleton.
-
 use crate::{
     CheckpointStore, CheckpointStoreWriter, EpochData, EpochStore, EpochStoreWriter,
     FullCheckpointData, ObjectKey, ObjectStore, ObjectStoreWriter, SetupStore, StoreSummary,
     TransactionInfo, TransactionStore, TransactionStoreWriter,
 };
-use anyhow::{Error, Result};
-use std::io::Write;
+use anyhow::{Error, Result, anyhow};
 use sui_types::{
     digests::{CheckpointContentsDigest, CheckpointDigest},
     messages_checkpoint::CheckpointSequenceNumber,
@@ -17,8 +14,11 @@ use sui_types::{
     supported_protocol_versions::ProtocolConfig,
 };
 
-/// Read-through cache over a primary and secondary store.
-#[derive(Debug)]
+/// A read-through store that composes a primary cache and a secondary source.
+///
+/// Reads consult the primary first, fall back to the secondary on miss, and cache
+/// successful secondary results back into the primary.
+/// Direct writes only update the primary.
 pub struct ReadThroughStore<P, S> {
     primary: P,
     secondary: S,
@@ -30,14 +30,57 @@ impl<P, S> ReadThroughStore<P, S> {
         Self { primary, secondary }
     }
 
-    /// Return the primary layer.
-    pub fn primary(&self) -> &P {
-        &self.primary
+    fn cache_checkpoint_by_sequence(
+        &self,
+        sequence: CheckpointSequenceNumber,
+    ) -> Result<Option<FullCheckpointData>, Error>
+    where
+        P: CheckpointStoreWriter,
+        S: CheckpointStore,
+    {
+        let Some(checkpoint) = self.secondary.get_checkpoint_by_sequence_number(sequence)? else {
+            return Ok(None);
+        };
+        self.primary.write_checkpoint(&checkpoint)?;
+        Ok(Some(checkpoint))
     }
 
-    /// Return the secondary layer.
-    pub fn secondary(&self) -> &S {
-        &self.secondary
+    fn cache_checkpoint_for_checkpoint_digest(
+        &self,
+        digest: &CheckpointDigest,
+    ) -> Result<Option<CheckpointSequenceNumber>, Error>
+    where
+        P: CheckpointStoreWriter,
+        S: CheckpointStore,
+    {
+        let Some(sequence) = self.secondary.get_sequence_by_checkpoint_digest(digest)? else {
+            return Ok(None);
+        };
+        self.cache_checkpoint_by_sequence(sequence)?.ok_or_else(|| {
+            anyhow!(
+                "secondary store resolved checkpoint digest {digest} to sequence {sequence}, but the checkpoint payload was missing"
+            )
+        })?;
+        Ok(Some(sequence))
+    }
+
+    fn cache_checkpoint_for_contents_digest(
+        &self,
+        digest: &CheckpointContentsDigest,
+    ) -> Result<Option<CheckpointSequenceNumber>, Error>
+    where
+        P: CheckpointStoreWriter,
+        S: CheckpointStore,
+    {
+        let Some(sequence) = self.secondary.get_sequence_by_contents_digest(digest)? else {
+            return Ok(None);
+        };
+        self.cache_checkpoint_by_sequence(sequence)?.ok_or_else(|| {
+            anyhow!(
+                "secondary store resolved checkpoint contents digest {digest} to sequence {sequence}, but the checkpoint payload was missing"
+            )
+        })?;
+        Ok(Some(sequence))
     }
 }
 
@@ -48,9 +91,18 @@ where
 {
     fn transaction_data_and_effects(
         &self,
-        _tx_digest: &str,
+        tx_digest: &str,
     ) -> Result<Option<TransactionInfo>, Error> {
-        todo!("read-through transaction reads are not implemented in the skeleton")
+        match self.primary.transaction_data_and_effects(tx_digest)? {
+            Some(transaction_info) => Ok(Some(transaction_info)),
+            None => self
+                .secondary
+                .transaction_data_and_effects(tx_digest)?
+                .map_or(Ok(None), |info| {
+                    self.primary.write_transaction(tx_digest, info.clone())?;
+                    Ok(Some(info))
+                }),
+        }
     }
 }
 
@@ -61,10 +113,10 @@ where
 {
     fn write_transaction(
         &self,
-        _tx_digest: &str,
-        _transaction_info: TransactionInfo,
+        tx_digest: &str,
+        transaction_info: TransactionInfo,
     ) -> Result<(), Error> {
-        todo!("read-through transaction writes are not implemented in the skeleton")
+        self.primary.write_transaction(tx_digest, transaction_info)
     }
 }
 
@@ -73,12 +125,24 @@ where
     P: EpochStoreWriter,
     S: EpochStore,
 {
-    fn epoch_info(&self, _epoch: u64) -> Result<Option<EpochData>, Error> {
-        todo!("read-through epoch reads are not implemented in the skeleton")
+    fn epoch_info(&self, epoch: u64) -> Result<Option<EpochData>, Error> {
+        match self.primary.epoch_info(epoch)? {
+            Some(epoch_data) => Ok(Some(epoch_data)),
+            None => match self.secondary.epoch_info(epoch)? {
+                Some(epoch_data) => {
+                    self.primary.write_epoch_info(epoch, epoch_data.clone())?;
+                    Ok(Some(epoch_data))
+                }
+                None => Ok(None),
+            },
+        }
     }
 
-    fn protocol_config(&self, _epoch: u64) -> Result<Option<ProtocolConfig>, Error> {
-        todo!("read-through protocol-config reads are not implemented in the skeleton")
+    fn protocol_config(&self, epoch: u64) -> Result<Option<ProtocolConfig>, Error> {
+        match self.primary.protocol_config(epoch)? {
+            Some(config) => Ok(Some(config)),
+            None => self.secondary.protocol_config(epoch),
+        }
     }
 }
 
@@ -87,8 +151,8 @@ where
     P: EpochStoreWriter,
     S: EpochStore,
 {
-    fn write_epoch_info(&self, _epoch: u64, _epoch_data: EpochData) -> Result<(), Error> {
-        todo!("read-through epoch writes are not implemented in the skeleton")
+    fn write_epoch_info(&self, epoch: u64, epoch_data: EpochData) -> Result<(), Error> {
+        self.primary.write_epoch_info(epoch, epoch_data)
     }
 }
 
@@ -97,8 +161,38 @@ where
     P: ObjectStoreWriter,
     S: ObjectStore,
 {
-    fn get_objects(&self, _keys: &[ObjectKey]) -> Result<Vec<Option<(Object, u64)>>, Error> {
-        todo!("read-through object reads are not implemented in the skeleton")
+    fn get_objects(&self, keys: &[ObjectKey]) -> Result<Vec<Option<(Object, u64)>>, Error> {
+        let cached_objects = self.primary.get_objects(keys)?;
+
+        let mut keys_to_fetch = Vec::new();
+        let mut none_object_idx = Vec::new();
+        for (i, object) in cached_objects.iter().enumerate() {
+            if object.is_none() {
+                keys_to_fetch.push(keys[i].clone());
+                none_object_idx.push(i);
+            }
+        }
+
+        let mut objects = cached_objects;
+        if !keys_to_fetch.is_empty() {
+            let fetched_objects = self.secondary.get_objects(&keys_to_fetch)?;
+
+            assert_eq!(none_object_idx.len(), keys_to_fetch.len());
+            assert_eq!(fetched_objects.len(), keys_to_fetch.len());
+
+            for ((idx, key), fetched) in none_object_idx
+                .iter()
+                .zip(keys_to_fetch.iter())
+                .zip(fetched_objects.iter())
+            {
+                if let Some((object, actual_version)) = fetched {
+                    self.primary
+                        .write_object(key, object.clone(), *actual_version)?;
+                    objects[*idx] = Some((object.clone(), *actual_version));
+                }
+            }
+        }
+        Ok(objects)
     }
 }
 
@@ -109,11 +203,11 @@ where
 {
     fn write_object(
         &self,
-        _key: &ObjectKey,
-        _object: Object,
-        _actual_version: u64,
+        key: &ObjectKey,
+        object: Object,
+        actual_version: u64,
     ) -> Result<(), Error> {
-        todo!("read-through object writes are not implemented in the skeleton")
+        self.primary.write_object(key, object, actual_version)
     }
 }
 
@@ -124,27 +218,45 @@ where
 {
     fn get_checkpoint_by_sequence_number(
         &self,
-        _sequence: CheckpointSequenceNumber,
+        sequence: CheckpointSequenceNumber,
     ) -> Result<Option<FullCheckpointData>, Error> {
-        todo!("read-through checkpoint reads are not implemented in the skeleton")
+        match self.primary.get_checkpoint_by_sequence_number(sequence)? {
+            Some(checkpoint) => Ok(Some(checkpoint)),
+            None => self.cache_checkpoint_by_sequence(sequence),
+        }
     }
 
     fn get_latest_checkpoint(&self) -> Result<Option<FullCheckpointData>, Error> {
-        todo!("read-through latest-checkpoint lookup is not implemented in the skeleton")
+        match self.primary.get_latest_checkpoint()? {
+            Some(checkpoint) => Ok(Some(checkpoint)),
+            None => match self.secondary.get_latest_checkpoint()? {
+                Some(checkpoint) => {
+                    self.primary.write_checkpoint(&checkpoint)?;
+                    Ok(Some(checkpoint))
+                }
+                None => Ok(None),
+            },
+        }
     }
 
     fn get_sequence_by_checkpoint_digest(
         &self,
-        _digest: &CheckpointDigest,
+        digest: &CheckpointDigest,
     ) -> Result<Option<CheckpointSequenceNumber>, Error> {
-        todo!("read-through checkpoint-digest lookups are not implemented in the skeleton")
+        match self.primary.get_sequence_by_checkpoint_digest(digest)? {
+            Some(sequence) => Ok(Some(sequence)),
+            None => self.cache_checkpoint_for_checkpoint_digest(digest),
+        }
     }
 
     fn get_sequence_by_contents_digest(
         &self,
-        _digest: &CheckpointContentsDigest,
+        digest: &CheckpointContentsDigest,
     ) -> Result<Option<CheckpointSequenceNumber>, Error> {
-        todo!("read-through contents-digest lookups are not implemented in the skeleton")
+        match self.primary.get_sequence_by_contents_digest(digest)? {
+            Some(sequence) => Ok(Some(sequence)),
+            None => self.cache_checkpoint_for_contents_digest(digest),
+        }
     }
 }
 
@@ -153,17 +265,8 @@ where
     P: CheckpointStoreWriter,
     S: CheckpointStore,
 {
-    fn write_checkpoint(&self, _checkpoint: &FullCheckpointData) -> Result<(), Error> {
-        todo!("read-through checkpoint writes are not implemented in the skeleton")
-    }
-}
-
-impl<P, S> SetupStore for ReadThroughStore<P, S>
-where
-    P: SetupStore,
-{
-    fn setup(&self, _chain_id: Option<String>) -> Result<Option<String>, Error> {
-        todo!("read-through setup is not implemented in the skeleton")
+    fn write_checkpoint(&self, checkpoint: &FullCheckpointData) -> Result<(), Error> {
+        self.primary.write_checkpoint(checkpoint)
     }
 }
 
@@ -172,9 +275,20 @@ where
     P: StoreSummary,
     S: StoreSummary,
 {
-    fn summary<W: Write>(&self, writer: &mut W) -> Result<()> {
-        writeln!(writer, "ReadThroughStore")?;
+    fn summary<W: std::io::Write>(&self, writer: &mut W) -> Result<()> {
         self.primary.summary(writer)?;
         self.secondary.summary(writer)
+    }
+}
+
+impl<P, S> SetupStore for ReadThroughStore<P, S>
+where
+    P: SetupStore,
+    S: SetupStore,
+{
+    fn setup(&self, chain_id: Option<String>) -> Result<Option<String>, Error> {
+        let resolved_chain_id = self.secondary.setup(chain_id.clone())?.or(chain_id);
+        self.primary.setup(resolved_chain_id.clone())?;
+        Ok(resolved_chain_id)
     }
 }

--- a/crates/sui-data-store/src/stores/write_through.rs
+++ b/crates/sui-data-store/src/stores/write_through.rs
@@ -1,15 +1,12 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Write-through store skeleton.
-
 use crate::{
     CheckpointStore, CheckpointStoreWriter, EpochData, EpochStore, EpochStoreWriter,
     FullCheckpointData, ObjectKey, ObjectStore, ObjectStoreWriter, SetupStore, StoreSummary,
     TransactionInfo, TransactionStore, TransactionStoreWriter,
 };
-use anyhow::{Error, Result};
-use std::io::Write;
+use anyhow::{Error, Result, anyhow};
 use sui_types::{
     digests::{CheckpointContentsDigest, CheckpointDigest},
     messages_checkpoint::CheckpointSequenceNumber,
@@ -17,8 +14,10 @@ use sui_types::{
     supported_protocol_versions::ProtocolConfig,
 };
 
-/// Write-through cache over a primary and secondary store.
-#[derive(Debug)]
+/// A write-through store that composes a primary hot cache with a writable secondary store.
+///
+/// Reads behave like a read-through cache. Direct writes update the secondary first and
+/// then the primary.
 pub struct WriteThroughStore<P, S> {
     primary: P,
     secondary: S,
@@ -29,16 +28,6 @@ impl<P, S> WriteThroughStore<P, S> {
     pub fn new(primary: P, secondary: S) -> Self {
         Self { primary, secondary }
     }
-
-    /// Return the primary layer.
-    pub fn primary(&self) -> &P {
-        &self.primary
-    }
-
-    /// Return the secondary layer.
-    pub fn secondary(&self) -> &S {
-        &self.secondary
-    }
 }
 
 impl<P, S> TransactionStore for WriteThroughStore<P, S>
@@ -48,9 +37,18 @@ where
 {
     fn transaction_data_and_effects(
         &self,
-        _tx_digest: &str,
+        tx_digest: &str,
     ) -> Result<Option<TransactionInfo>, Error> {
-        todo!("write-through transaction reads are not implemented in the skeleton")
+        match self.primary.transaction_data_and_effects(tx_digest)? {
+            Some(transaction_info) => Ok(Some(transaction_info)),
+            None => self
+                .secondary
+                .transaction_data_and_effects(tx_digest)?
+                .map_or(Ok(None), |info| {
+                    self.primary.write_transaction(tx_digest, info.clone())?;
+                    Ok(Some(info))
+                }),
+        }
     }
 }
 
@@ -61,10 +59,12 @@ where
 {
     fn write_transaction(
         &self,
-        _tx_digest: &str,
-        _transaction_info: TransactionInfo,
+        tx_digest: &str,
+        transaction_info: TransactionInfo,
     ) -> Result<(), Error> {
-        todo!("write-through transaction writes are not implemented in the skeleton")
+        self.secondary
+            .write_transaction(tx_digest, transaction_info.clone())?;
+        self.primary.write_transaction(tx_digest, transaction_info)
     }
 }
 
@@ -73,12 +73,24 @@ where
     P: EpochStoreWriter,
     S: EpochStore,
 {
-    fn epoch_info(&self, _epoch: u64) -> Result<Option<EpochData>, Error> {
-        todo!("write-through epoch reads are not implemented in the skeleton")
+    fn epoch_info(&self, epoch: u64) -> Result<Option<EpochData>, Error> {
+        match self.primary.epoch_info(epoch)? {
+            Some(epoch_data) => Ok(Some(epoch_data)),
+            None => match self.secondary.epoch_info(epoch)? {
+                Some(epoch_data) => {
+                    self.primary.write_epoch_info(epoch, epoch_data.clone())?;
+                    Ok(Some(epoch_data))
+                }
+                None => Ok(None),
+            },
+        }
     }
 
-    fn protocol_config(&self, _epoch: u64) -> Result<Option<ProtocolConfig>, Error> {
-        todo!("write-through protocol-config reads are not implemented in the skeleton")
+    fn protocol_config(&self, epoch: u64) -> Result<Option<ProtocolConfig>, Error> {
+        match self.primary.protocol_config(epoch)? {
+            Some(config) => Ok(Some(config)),
+            None => self.secondary.protocol_config(epoch),
+        }
     }
 }
 
@@ -87,8 +99,9 @@ where
     P: EpochStoreWriter,
     S: EpochStoreWriter,
 {
-    fn write_epoch_info(&self, _epoch: u64, _epoch_data: EpochData) -> Result<(), Error> {
-        todo!("write-through epoch writes are not implemented in the skeleton")
+    fn write_epoch_info(&self, epoch: u64, epoch_data: EpochData) -> Result<(), Error> {
+        self.secondary.write_epoch_info(epoch, epoch_data.clone())?;
+        self.primary.write_epoch_info(epoch, epoch_data)
     }
 }
 
@@ -97,8 +110,38 @@ where
     P: ObjectStoreWriter,
     S: ObjectStore,
 {
-    fn get_objects(&self, _keys: &[ObjectKey]) -> Result<Vec<Option<(Object, u64)>>, Error> {
-        todo!("write-through object reads are not implemented in the skeleton")
+    fn get_objects(&self, keys: &[ObjectKey]) -> Result<Vec<Option<(Object, u64)>>, Error> {
+        let cached_objects = self.primary.get_objects(keys)?;
+
+        let mut keys_to_fetch = Vec::new();
+        let mut none_object_idx = Vec::new();
+        for (i, object) in cached_objects.iter().enumerate() {
+            if object.is_none() {
+                keys_to_fetch.push(keys[i].clone());
+                none_object_idx.push(i);
+            }
+        }
+
+        let mut objects = cached_objects;
+        if !keys_to_fetch.is_empty() {
+            let fetched_objects = self.secondary.get_objects(&keys_to_fetch)?;
+
+            assert_eq!(none_object_idx.len(), keys_to_fetch.len());
+            assert_eq!(fetched_objects.len(), keys_to_fetch.len());
+
+            for ((idx, key), fetched) in none_object_idx
+                .iter()
+                .zip(keys_to_fetch.iter())
+                .zip(fetched_objects.iter())
+            {
+                if let Some((object, actual_version)) = fetched {
+                    self.primary
+                        .write_object(key, object.clone(), *actual_version)?;
+                    objects[*idx] = Some((object.clone(), *actual_version));
+                }
+            }
+        }
+        Ok(objects)
     }
 }
 
@@ -109,11 +152,13 @@ where
 {
     fn write_object(
         &self,
-        _key: &ObjectKey,
-        _object: Object,
-        _actual_version: u64,
+        key: &ObjectKey,
+        object: Object,
+        actual_version: u64,
     ) -> Result<(), Error> {
-        todo!("write-through object writes are not implemented in the skeleton")
+        self.secondary
+            .write_object(key, object.clone(), actual_version)?;
+        self.primary.write_object(key, object, actual_version)
     }
 }
 
@@ -124,27 +169,79 @@ where
 {
     fn get_checkpoint_by_sequence_number(
         &self,
-        _sequence: CheckpointSequenceNumber,
+        sequence: CheckpointSequenceNumber,
     ) -> Result<Option<FullCheckpointData>, Error> {
-        todo!("write-through checkpoint reads are not implemented in the skeleton")
+        match self.primary.get_checkpoint_by_sequence_number(sequence)? {
+            Some(checkpoint) => Ok(Some(checkpoint)),
+            None => match self.secondary.get_checkpoint_by_sequence_number(sequence)? {
+                Some(checkpoint) => {
+                    self.primary.write_checkpoint(&checkpoint)?;
+                    Ok(Some(checkpoint))
+                }
+                None => Ok(None),
+            },
+        }
     }
 
     fn get_latest_checkpoint(&self) -> Result<Option<FullCheckpointData>, Error> {
-        todo!("write-through latest-checkpoint lookup is not implemented in the skeleton")
+        match self.primary.get_latest_checkpoint()? {
+            Some(checkpoint) => Ok(Some(checkpoint)),
+            None => match self.secondary.get_latest_checkpoint()? {
+                Some(checkpoint) => {
+                    self.primary.write_checkpoint(&checkpoint)?;
+                    Ok(Some(checkpoint))
+                }
+                None => Ok(None),
+            },
+        }
     }
 
     fn get_sequence_by_checkpoint_digest(
         &self,
-        _digest: &CheckpointDigest,
+        digest: &CheckpointDigest,
     ) -> Result<Option<CheckpointSequenceNumber>, Error> {
-        todo!("write-through checkpoint-digest lookups are not implemented in the skeleton")
+        match self.primary.get_sequence_by_checkpoint_digest(digest)? {
+            Some(sequence) => Ok(Some(sequence)),
+            None => match self.secondary.get_sequence_by_checkpoint_digest(digest)? {
+                Some(sequence) => {
+                    let checkpoint = self
+                        .secondary
+                        .get_checkpoint_by_sequence_number(sequence)?
+                        .ok_or_else(|| {
+                            anyhow!(
+                                "secondary store resolved checkpoint digest {digest} to sequence {sequence}, but the checkpoint payload was missing"
+                            )
+                        })?;
+                    self.primary.write_checkpoint(&checkpoint)?;
+                    Ok(Some(sequence))
+                }
+                None => Ok(None),
+            },
+        }
     }
 
     fn get_sequence_by_contents_digest(
         &self,
-        _digest: &CheckpointContentsDigest,
+        digest: &CheckpointContentsDigest,
     ) -> Result<Option<CheckpointSequenceNumber>, Error> {
-        todo!("write-through contents-digest lookups are not implemented in the skeleton")
+        match self.primary.get_sequence_by_contents_digest(digest)? {
+            Some(sequence) => Ok(Some(sequence)),
+            None => match self.secondary.get_sequence_by_contents_digest(digest)? {
+                Some(sequence) => {
+                    let checkpoint = self
+                        .secondary
+                        .get_checkpoint_by_sequence_number(sequence)?
+                        .ok_or_else(|| {
+                            anyhow!(
+                                "secondary store resolved checkpoint contents digest {digest} to sequence {sequence}, but the checkpoint payload was missing"
+                            )
+                        })?;
+                    self.primary.write_checkpoint(&checkpoint)?;
+                    Ok(Some(sequence))
+                }
+                None => Ok(None),
+            },
+        }
     }
 }
 
@@ -153,17 +250,9 @@ where
     P: CheckpointStoreWriter,
     S: CheckpointStoreWriter,
 {
-    fn write_checkpoint(&self, _checkpoint: &FullCheckpointData) -> Result<(), Error> {
-        todo!("write-through checkpoint writes are not implemented in the skeleton")
-    }
-}
-
-impl<P, S> SetupStore for WriteThroughStore<P, S>
-where
-    P: SetupStore,
-{
-    fn setup(&self, _chain_id: Option<String>) -> Result<Option<String>, Error> {
-        todo!("write-through setup is not implemented in the skeleton")
+    fn write_checkpoint(&self, checkpoint: &FullCheckpointData) -> Result<(), Error> {
+        self.secondary.write_checkpoint(checkpoint)?;
+        self.primary.write_checkpoint(checkpoint)
     }
 }
 
@@ -172,9 +261,20 @@ where
     P: StoreSummary,
     S: StoreSummary,
 {
-    fn summary<W: Write>(&self, writer: &mut W) -> Result<()> {
-        writeln!(writer, "WriteThroughStore")?;
+    fn summary<W: std::io::Write>(&self, writer: &mut W) -> Result<()> {
         self.primary.summary(writer)?;
         self.secondary.summary(writer)
+    }
+}
+
+impl<P, S> SetupStore for WriteThroughStore<P, S>
+where
+    P: SetupStore,
+    S: SetupStore,
+{
+    fn setup(&self, chain_id: Option<String>) -> Result<Option<String>, Error> {
+        let resolved_chain_id = self.secondary.setup(chain_id.clone())?.or(chain_id);
+        self.primary.setup(resolved_chain_id.clone())?;
+        Ok(resolved_chain_id)
     }
 }

--- a/crates/sui-data-store/tests/composition.rs
+++ b/crates/sui-data-store/tests/composition.rs
@@ -1,87 +1,373 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::path::PathBuf;
-
-use anyhow::Result;
-use sui_data_store::{
-    CheckpointStore, CheckpointStoreWriter, EpochStore, EpochStoreWriter, ObjectStore,
-    ObjectStoreWriter, SetupStore, StoreSummary, TransactionStore, TransactionStoreWriter,
-    node::Node,
-    stores::{
-        CompositeStore, DataStore, FileSystemStore, InMemoryStore, LruMemoryStore,
-        ReadThroughStore, WriteThroughStore,
+use std::{
+    collections::BTreeMap,
+    fs,
+    sync::{
+        Arc, RwLock,
+        atomic::{AtomicUsize, Ordering},
     },
 };
 
-fn temp_store_path() -> Result<PathBuf> {
-    Ok(tempfile::tempdir()?.into_path())
+use anyhow::{Result, anyhow};
+use sui_data_store::{
+    CheckpointStore, CheckpointStoreWriter, EpochData, Node, ObjectKey, ObjectStore,
+    ObjectStoreWriter, ReadDataStore, SetupStore, TransactionInfo, TransactionStore,
+    TransactionStoreWriter, VersionQuery,
+    stores::{
+        CHECKPOINT_DIR, CHECKPOINT_LATEST_FILE, CompositeStore, DataStore, FileSystemStore,
+        InMemoryStore, ReadThroughStore, WriteThroughStore,
+    },
+};
+use sui_types::{
+    base_types::{ObjectID, SequenceNumber, SuiAddress},
+    object::{Object, Owner},
+    test_checkpoint_data_builder::TestCheckpointBuilder,
+};
+
+const CHAIN_ID: &str = "test_chain";
+
+fn make_store() -> Result<(tempfile::TempDir, FileSystemStore)> {
+    let tempdir = tempfile::tempdir()?;
+    let store = FileSystemStore::new_with_path(Node::Testnet, tempdir.path().to_path_buf())?;
+    store.setup(Some(CHAIN_ID.to_string()))?;
+    Ok((tempdir, store))
 }
 
-fn assert_read_write_store<T>()
-where
-    T: TransactionStore
-        + TransactionStoreWriter
-        + EpochStore
-        + EpochStoreWriter
-        + ObjectStore
-        + ObjectStoreWriter
-        + CheckpointStore
-        + CheckpointStoreWriter
-        + SetupStore
-        + StoreSummary,
-{
+fn sample_checkpoint(sequence: u64) -> sui_data_store::FullCheckpointData {
+    TestCheckpointBuilder::new(sequence)
+        .start_transaction(1)
+        .create_owned_object(42)
+        .finish_transaction()
+        .build_checkpoint()
 }
 
-fn assert_read_only_store<T>()
-where
-    T: TransactionStore + EpochStore + ObjectStore + CheckpointStore + SetupStore + StoreSummary,
-{
+fn transaction_info(checkpoint: &sui_data_store::FullCheckpointData) -> TransactionInfo {
+    let executed = &checkpoint.transactions[0];
+    TransactionInfo {
+        data: executed.transaction.clone(),
+        effects: executed.effects.clone(),
+        checkpoint: checkpoint.summary.sequence_number,
+    }
+}
+
+fn sample_object(object_id: ObjectID, owner: SuiAddress, version: u64) -> Object {
+    Object::with_id_owner_version_for_testing(
+        object_id,
+        SequenceNumber::from_u64(version),
+        Owner::AddressOwner(owner),
+    )
+}
+
+#[derive(Default)]
+struct TxStoreStub {
+    transactions: RwLock<BTreeMap<String, TransactionInfo>>,
+    read_calls: AtomicUsize,
+    write_calls: AtomicUsize,
+    fail_writes: bool,
+}
+
+impl TxStoreStub {
+    fn with_failure() -> Self {
+        Self {
+            fail_writes: true,
+            ..Self::default()
+        }
+    }
+}
+
+impl TransactionStore for TxStoreStub {
+    fn transaction_data_and_effects(
+        &self,
+        tx_digest: &str,
+    ) -> Result<Option<TransactionInfo>, anyhow::Error> {
+        self.read_calls.fetch_add(1, Ordering::Relaxed);
+        Ok(self.transactions.read().unwrap().get(tx_digest).cloned())
+    }
+}
+
+impl TransactionStoreWriter for TxStoreStub {
+    fn write_transaction(
+        &self,
+        tx_digest: &str,
+        transaction_info: TransactionInfo,
+    ) -> Result<(), anyhow::Error> {
+        self.write_calls.fetch_add(1, Ordering::Relaxed);
+        if self.fail_writes {
+            return Err(anyhow!("stub write failure"));
+        }
+        self.transactions
+            .write()
+            .unwrap()
+            .insert(tx_digest.to_string(), transaction_info);
+        Ok(())
+    }
+}
+
+#[derive(Default)]
+struct ObjectSourceStub {
+    objects: RwLock<BTreeMap<ObjectKey, (Object, u64)>>,
+    read_calls: AtomicUsize,
+}
+
+impl ObjectStore for ObjectSourceStub {
+    fn get_objects(&self, keys: &[ObjectKey]) -> Result<Vec<Option<(Object, u64)>>, anyhow::Error> {
+        self.read_calls.fetch_add(1, Ordering::Relaxed);
+        let objects = self.objects.read().unwrap();
+        Ok(keys.iter().map(|key| objects.get(key).cloned()).collect())
+    }
 }
 
 #[test]
-fn backends_instantiate() -> Result<()> {
-    let _graphql = DataStore::new(Node::Mainnet, "test-version")?;
-    let _filesystem = FileSystemStore::new_with_path(Node::Mainnet, temp_store_path()?)?;
-    let _memory = InMemoryStore::new(Node::Mainnet);
-    let _lru = LruMemoryStore::new(Node::Mainnet);
-    Ok(())
-}
+fn filesystem_store_round_trips_generic_traits_and_helpers() -> Result<()> {
+    let (tempdir, store) = make_store()?;
+    let checkpoint = sample_checkpoint(7);
+    let tx_info = transaction_info(&checkpoint);
 
-#[test]
-fn backend_trait_surfaces_compile() {
-    assert_read_only_store::<DataStore>();
-    assert_read_write_store::<FileSystemStore>();
-    assert_read_write_store::<InMemoryStore>();
-    assert_read_write_store::<LruMemoryStore>();
-}
-
-#[test]
-fn combinators_instantiate() -> Result<()> {
-    let filesystem = FileSystemStore::new_with_path(Node::Mainnet, temp_store_path()?)?;
-    let graphql = DataStore::new(Node::Mainnet, "test-version")?;
-    let read_through = ReadThroughStore::new(filesystem, graphql);
-
-    let filesystem = FileSystemStore::new_with_path(Node::Mainnet, temp_store_path()?)?;
-    let memory = InMemoryStore::new(Node::Mainnet);
-    let write_through = WriteThroughStore::new(memory, filesystem);
-
-    let composite = CompositeStore::new(
-        InMemoryStore::new(Node::Mainnet),
-        InMemoryStore::new(Node::Mainnet),
-        InMemoryStore::new(Node::Mainnet),
-        InMemoryStore::new(Node::Mainnet),
+    TransactionStoreWriter::write_transaction(&store, "tx-1", tx_info.clone())?;
+    let stored_tx = TransactionStore::transaction_data_and_effects(&store, "tx-1")?
+        .expect("transaction should be present");
+    assert_eq!(stored_tx.checkpoint, tx_info.checkpoint);
+    assert_eq!(
+        bcs::to_bytes(&stored_tx.data)?,
+        bcs::to_bytes(&tx_info.data)?
+    );
+    assert_eq!(
+        bcs::to_bytes(&stored_tx.effects)?,
+        bcs::to_bytes(&tx_info.effects)?
     );
 
-    let _ = read_through.primary();
-    let _ = write_through.secondary();
-    let _ = composite.objects();
+    let epoch = EpochData {
+        epoch_id: 7,
+        protocol_version: 1,
+        rgp: 1_000,
+        start_timestamp: 123_456,
+    };
+    sui_data_store::EpochStoreWriter::write_epoch_info(&store, epoch.epoch_id, epoch.clone())?;
+    let stored_epoch =
+        sui_data_store::EpochStore::epoch_info(&store, epoch.epoch_id)?.expect("epoch present");
+    assert_eq!(stored_epoch.epoch_id, epoch.epoch_id);
+    assert!(
+        sui_data_store::EpochStore::protocol_config(&store, epoch.epoch_id)?.is_some(),
+        "protocol config should derive from stored epoch data"
+    );
+
+    let owner = SuiAddress::random_for_testing_only();
+    let object_id = ObjectID::random();
+    let object = sample_object(object_id, owner, 2);
+    let exact_key = ObjectKey {
+        object_id,
+        version_query: VersionQuery::Version(2),
+    };
+    let root_key = ObjectKey {
+        object_id,
+        version_query: VersionQuery::RootVersion(10),
+    };
+    let checkpoint_key = ObjectKey {
+        object_id,
+        version_query: VersionQuery::AtCheckpoint(100),
+    };
+
+    ObjectStoreWriter::write_object(&store, &exact_key, object.clone(), 2)?;
+    ObjectStoreWriter::write_object(&store, &root_key, object.clone(), 2)?;
+    ObjectStoreWriter::write_object(&store, &checkpoint_key, object.clone(), 2)?;
+
+    let objects = ObjectStore::get_objects(&store, &[exact_key.clone(), root_key, checkpoint_key])?;
+    assert!(objects.iter().all(|entry| entry.is_some()));
+    assert!(store.get_object_latest(&object_id)?.is_some());
+    assert!(store.get_object_at_version(&object_id, 2)?.is_some());
+    assert!(store.get_object_at_root_version(&object_id, 10)?.is_some());
+    assert!(store.get_object_at_checkpoint(&object_id, 100)?.is_some());
+    assert_eq!(store.get_objects_by_owner(owner)?.len(), 1);
+
+    CheckpointStoreWriter::write_checkpoint(&store, &checkpoint)?;
+    let by_sequence = CheckpointStore::get_checkpoint_by_sequence_number(
+        &store,
+        checkpoint.summary.sequence_number,
+    )?
+    .expect("checkpoint should be present");
+    assert_eq!(
+        by_sequence.summary.sequence_number,
+        checkpoint.summary.sequence_number
+    );
+    assert_eq!(
+        CheckpointStore::get_sequence_by_checkpoint_digest(&store, checkpoint.summary.digest())?,
+        Some(checkpoint.summary.sequence_number)
+    );
+    assert_eq!(
+        CheckpointStore::get_sequence_by_contents_digest(&store, checkpoint.contents.digest())?,
+        Some(checkpoint.summary.sequence_number)
+    );
+
+    let latest_marker = tempdir
+        .path()
+        .join(CHAIN_ID)
+        .join(CHECKPOINT_DIR)
+        .join(CHECKPOINT_LATEST_FILE);
+    fs::remove_file(latest_marker)?;
+    let latest = CheckpointStore::get_latest_checkpoint(&store)?.expect("latest should exist");
+    assert_eq!(
+        latest.summary.sequence_number,
+        checkpoint.summary.sequence_number
+    );
+
     Ok(())
 }
 
 #[test]
-fn combinator_trait_surfaces_compile() {
-    assert_read_only_store::<ReadThroughStore<FileSystemStore, DataStore>>();
-    assert_read_write_store::<WriteThroughStore<InMemoryStore, FileSystemStore>>();
-    assert_read_write_store::<CompositeStore<InMemoryStore, InMemoryStore, InMemoryStore, InMemoryStore>>();
+fn read_through_backfills_checkpoints_and_writes_only_primary() -> Result<()> {
+    let primary = InMemoryStore::new(Node::Testnet);
+    let secondary = InMemoryStore::new(Node::Testnet);
+    let checkpoint = sample_checkpoint(7);
+    let second_checkpoint = sample_checkpoint(8);
+
+    CheckpointStoreWriter::write_checkpoint(&secondary, &checkpoint)?;
+
+    let store = ReadThroughStore::new(&primary, &secondary);
+    let loaded = CheckpointStore::get_checkpoint_by_sequence_number(
+        &store,
+        checkpoint.summary.sequence_number,
+    )?
+    .expect("checkpoint should load from secondary");
+    assert_eq!(
+        loaded.summary.sequence_number,
+        checkpoint.summary.sequence_number
+    );
+    assert!(
+        CheckpointStore::get_checkpoint_by_sequence_number(
+            &primary,
+            checkpoint.summary.sequence_number
+        )?
+        .is_some()
+    );
+
+    CheckpointStoreWriter::write_checkpoint(&store, &second_checkpoint)?;
+    assert!(
+        CheckpointStore::get_checkpoint_by_sequence_number(
+            &primary,
+            second_checkpoint.summary.sequence_number
+        )?
+        .is_some()
+    );
+    assert!(
+        CheckpointStore::get_checkpoint_by_sequence_number(
+            &secondary,
+            second_checkpoint.summary.sequence_number
+        )?
+        .is_none()
+    );
+
+    Ok(())
+}
+
+#[test]
+fn write_through_reads_and_writes_across_both_layers() -> Result<()> {
+    let primary = TxStoreStub::default();
+    let secondary = TxStoreStub::default();
+    let checkpoint = sample_checkpoint(7);
+    let tx_info = transaction_info(&checkpoint);
+
+    TransactionStoreWriter::write_transaction(&secondary, "tx-1", tx_info.clone())?;
+
+    let store = WriteThroughStore::new(&primary, &secondary);
+    let loaded = TransactionStore::transaction_data_and_effects(&store, "tx-1")?
+        .expect("transaction should load from secondary");
+    assert_eq!(loaded.checkpoint, tx_info.checkpoint);
+    assert!(TransactionStore::transaction_data_and_effects(&primary, "tx-1")?.is_some());
+
+    let second_checkpoint = sample_checkpoint(8);
+    let second_tx = transaction_info(&second_checkpoint);
+    TransactionStoreWriter::write_transaction(&store, "tx-2", second_tx.clone())?;
+    assert!(TransactionStore::transaction_data_and_effects(&primary, "tx-2")?.is_some());
+    assert!(TransactionStore::transaction_data_and_effects(&secondary, "tx-2")?.is_some());
+
+    Ok(())
+}
+
+#[test]
+fn write_through_secondary_failure_prevents_primary_write() {
+    let primary = TxStoreStub::default();
+    let secondary = TxStoreStub::with_failure();
+    let checkpoint = sample_checkpoint(7);
+    let tx_info = transaction_info(&checkpoint);
+
+    let store = WriteThroughStore::new(&primary, &secondary);
+    let err = TransactionStoreWriter::write_transaction(&store, "tx-1", tx_info);
+    assert!(err.is_err());
+    assert_eq!(primary.write_calls.load(Ordering::Relaxed), 0);
+    assert!(
+        TransactionStore::transaction_data_and_effects(&primary, "tx-1")
+            .expect("lookup should succeed")
+            .is_none()
+    );
+}
+
+#[test]
+fn composite_store_routes_the_forking_topology() -> Result<()> {
+    let (_tempdir, filesystem) = make_store()?;
+    let memory = InMemoryStore::new(Node::Testnet);
+    let object_source = ObjectSourceStub::default();
+
+    let checkpoint = sample_checkpoint(7);
+    let tx_info = transaction_info(&checkpoint);
+    TransactionStoreWriter::write_transaction(&filesystem, "tx-1", tx_info)?;
+    CheckpointStoreWriter::write_checkpoint(&filesystem, &checkpoint)?;
+
+    let owner = SuiAddress::random_for_testing_only();
+    let object_id = ObjectID::random();
+    let object = sample_object(object_id, owner, 2);
+    let object_key = ObjectKey {
+        object_id,
+        version_query: VersionQuery::Version(2),
+    };
+    object_source
+        .objects
+        .write()
+        .unwrap()
+        .insert(object_key.clone(), (object.clone(), 2));
+
+    let hot_mem_fs = WriteThroughStore::new(&memory, &filesystem);
+    let disk_then_source_objects = ReadThroughStore::new(&filesystem, &object_source);
+    let hot_objects = WriteThroughStore::new(&memory, &disk_then_source_objects);
+    let store = CompositeStore::new(&hot_mem_fs, &hot_mem_fs, &hot_objects, &hot_mem_fs);
+
+    assert!(TransactionStore::transaction_data_and_effects(&store, "tx-1")?.is_some());
+    assert!(
+        CheckpointStore::get_checkpoint_by_sequence_number(
+            &store,
+            checkpoint.summary.sequence_number
+        )?
+        .is_some()
+    );
+    assert_eq!(object_source.read_calls.load(Ordering::Relaxed), 0);
+
+    let loaded_objects = ObjectStore::get_objects(&store, std::slice::from_ref(&object_key))?;
+    assert_eq!(object_source.read_calls.load(Ordering::Relaxed), 1);
+    let (loaded_object, actual_version) = loaded_objects[0].clone().expect("object should load");
+    assert_eq!(actual_version, 2);
+    assert_eq!(bcs::to_bytes(&loaded_object)?, bcs::to_bytes(&object)?);
+
+    assert!(filesystem.get_object_at_version(&object_id, 2)?.is_some());
+    assert!(ObjectStore::get_objects(&memory, &[object_key])?[0].is_some());
+
+    Ok(())
+}
+
+#[test]
+fn arc_forwarding_impls_compile_for_common_store_shapes() {
+    fn assert_tx_store<T: TransactionStore>() {}
+    fn assert_obj_store<T: ObjectStore>() {}
+    fn assert_checkpoint_store<T: CheckpointStore>() {}
+    fn assert_read_data_store<T: ReadDataStore>() {}
+
+    assert_tx_store::<Arc<FileSystemStore>>();
+    assert_obj_store::<Arc<FileSystemStore>>();
+    assert_checkpoint_store::<Arc<FileSystemStore>>();
+    assert_read_data_store::<Arc<ReadThroughStore<InMemoryStore, FileSystemStore>>>();
+    assert_checkpoint_store::<Arc<ReadThroughStore<InMemoryStore, FileSystemStore>>>();
+    assert_checkpoint_store::<Arc<WriteThroughStore<InMemoryStore, FileSystemStore>>>();
+    assert_obj_store::<
+        Arc<WriteThroughStore<InMemoryStore, ReadThroughStore<FileSystemStore, DataStore>>>,
+    >();
 }

--- a/crates/sui-forking/Cargo.toml
+++ b/crates/sui-forking/Cargo.toml
@@ -1,0 +1,70 @@
+[package]
+name = "sui-forking"
+version.workspace = true
+authors = ["Mysten Labs <build@mystenlabs.com>"]
+license = "Apache-2.0"
+publish = false
+edition = "2024"
+
+[dependencies]
+anyhow.workspace = true
+axum.workspace = true
+axum-server.workspace = true
+base64.workspace = true
+bcs.workspace = true
+bytes.workspace = true
+clap.workspace = true
+const-str.workspace = true
+cynic.workspace = true
+fastcrypto.workspace = true
+futures.workspace = true
+http.workspace = true
+pin-project.workspace = true
+prometheus.workspace = true
+rand.workspace = true
+reqwest.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tap.workspace = true
+thiserror.workspace = true
+tokio.workspace = true
+tokio-stream.workspace = true
+tower-http.workspace = true
+tower.workspace = true
+tonic.workspace = true
+tonic-reflection.workspace = true
+tonic-health.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
+url.workspace = true
+
+bin-version.workspace = true
+mysten-common.workspace = true
+mysten-network.workspace = true
+simulacrum.workspace = true
+
+move-binary-format.workspace = true
+move-core-types.workspace = true
+move-bytecode-utils.workspace = true
+
+sui-data-store.workspace = true
+sui-futures.workspace = true
+sui-swarm-config.workspace = true
+sui-types.workspace = true
+sui-rpc.workspace = true
+sui-rpc-api.workspace = true
+sui-sdk-types.workspace = true
+prost.workspace = true
+prost-types.workspace = true
+
+[build-dependencies]
+cynic-codegen.workspace = true
+
+[dev-dependencies]
+datatest-stable.workspace = true
+move-command-line-common.workspace = true
+tempfile.workspace = true
+test-cluster.workspace = true
+
+[lints]
+workspace = true

--- a/crates/sui-forking/README.md
+++ b/crates/sui-forking/README.md
@@ -1,0 +1,210 @@
+# Disclaimer
+
+This is highly experimental tooling intended for development and testing purposes only. It is not recommended for production use and is provided as-is without guarantees.
+
+Expect breaking changes until this is officially released and stable.
+
+# Sui Forking Tool
+
+A development tool that enables testing and developing against a local Sui network initialized with state from mainnet, testnet, or devnet at a specific checkpoint.
+
+## Overview
+
+`sui-forking` allows developers to start a local network in lock-step mode and execute transactions against some initial state derived from the live Sui network. This enables you to:
+
+- Depend on existing on-chain packages and data
+- Test contracts that interact with real deployed packages
+- Develop locally while maintaining consistency with production state
+- Run integration tests against forked network state and using packages deployed on the real live network
+
+**Important Note**
+Unlike a standard local Sui network with validators, the forking tool runs in lock-step mode where each transaction is executed sequentially and creates a checkpoint.
+That means that you have full control over the advancement of checkpoints, time, and epochs to simulate different scenarios.
+
+## Forked Network vs Sui CLI Local Network
+
+The table below summarizes when to use each option:
+
+| Topic | Local forked network (`sui-forking`) | Sui CLI local network |
+| --- | --- | --- |
+| Initial state | Starts from real chain state (mainnet/testnet/devnet) at a chosen checkpoint | Starts from a fresh genesis state (or from an existing one on disk) |
+| Existing on-chain packages and objects | Available from the fork point (fetched/cached on demand) | Not available unless you deploy/create them locally |
+| External dependency at runtime | Needs network access to source chain for first-time object fetches | Fully local once started |
+| Execution model | Single validator, lock-step, sequential execution | Multi-validator local network flow |
+| Checkpoint/time/epoch control | Explicit control through `advance-checkpoint`, `advance-clock`, `advance-epoch` | Driven by normal local network progression |
+| Best for | Testing against real deployed packages and realistic chain state | Fast local development from clean state |
+| Startup cost | Higher (state bootstrap + potential object downloads) | Lower (local genesis and startup) |
+| Determinism/reproducibility | Deterministic from selected checkpoint + seeded objects | Deterministic from local genesis/configuration |
+
+## Limitations
+- Staking and related operations are not supported.
+- Single validator, single authority network.
+- Object fetching overhead: First access to objects requires network download.
+- Forking from a checkpoint older than 1 hour requires explicit object seeding (you need to know which owned objects you want to have pulled at startup)
+- If it forks at checkpoint X, you cannot depend on objects created after checkpoint X from the actual real network. You'll need to restart the network at that checkpoint or a later one.
+- Sequential execution: Transactions are executed one at a time, no parallelism.
+
+## Usage
+
+### Build from source
+To build the `sui-forking` tool from source, ensure you have Rust and Cargo installed, then run:
+
+```bash
+git clone https://github.com/MystenLabs/sui.git
+cd sui/crates/sui-forking
+cargo build
+```
+
+Now use the `sui-forking` binary located in `sui/target/debug/sui-forking`.
+
+### Programmatic Usage (Rust)
+
+`sui-forking` also exposes a library API for starting and controlling a local fork in-process.
+
+```rust
+use sui_forking::{ForkingNetwork, ForkingNode, ForkingNodeConfig, StartupSeeding};
+
+# async fn run() -> anyhow::Result<()> {
+let config = ForkingNodeConfig::builder()
+    .network(ForkingNetwork::Testnet)
+    .server_port(9001)
+    .rpc_port(9000)
+    .startup_seeding(StartupSeeding::None)
+    .build()?;
+
+let node = ForkingNode::start(config).await?;
+let client = node.client();
+let status = client.status().await?;
+println!("checkpoint={} epoch={}", status.checkpoint, status.epoch);
+
+node.shutdown().await?;
+# Ok(())
+# }
+```
+
+### Starting a Local Forked Network
+
+Start a local forked network at the latest checkpoint:
+
+```bash
+sui-forking start --network testnet
+```
+
+This command:
+- Starts a local "forking server" on port 9001 (default) - this is used to interact with the forked network, e.g., advance-checkpoints, request gas, advance-clock, advance-epoch, etc. You can do so via the CLI commands with the `sui-forking` binary or via the REST API (see below).
+- Starts the RPC server on port 9000 (default) - this is the gRPC endpoint you can connect the Sui client to interact with the network. 
+- Allows you to execute transactions against this local state and fetches objects on-demand from the real network
+
+#### Options
+
+- `--checkpoint <number>`: The checkpoint to fork from (required)  - note that this is WIP
+- `--network <network>`: Network to fork from: `mainnet`, `testnet`, `devnet`, or a custom one (`--network <CUSTOM-GRAPHQL-ENDPOINT> --fullnode-url <URL>`
+
+### Old checkpoint seeding (`--accounts` vs `--objects`)
+
+When you provide `--checkpoint`, startup seeding supports two exclusive modes:
+
+- `--accounts`: discover owned objects through GraphQL at startup time for checkpoints not older than 1h.
+- `--objects`: provide explicit object IDs to prefetch at startup time, required for checkpoints older than 1h.
+
+`--accounts` and `--objects` are mutually exclusive.
+
+Examples:
+
+```bash
+# Recent checkpoint (<=1h), account-based startup seeding
+sui-forking start --network testnet --checkpoint 123456 --accounts 0x123...,0xabc...
+```
+
+```bash
+# Old checkpoint (>1h), explicit object seeding
+sui-forking start --network testnet --checkpoint 123456 --objects 0xabc...,0xdef...
+```
+
+## Available Commands
+
+Once the forked network is running, you can use these commands:
+
+### Faucet - request SUI tokens
+
+```bash
+sui-forking faucet --address <address> --amount <amount> # Max is 10M SUI
+```
+
+### Advance Checkpoint
+
+```bash
+sui-forking advance-checkpoint
+```
+
+Advances the checkpoint of the local network by 1.
+
+### Advance Clock
+
+```bash
+sui-forking advance-clock
+```
+
+Advances the clock of the local network by 1 millisecond.
+
+### Advance Epoch
+
+```bash
+sui-forking advance-epoch
+```
+
+Advances the epoch of the local network by 1.
+
+### Check Status
+
+```bash
+sui-forking status
+```
+
+Shows the current checkpoint, epoch, and number of transactions.
+
+## Basic Use Case
+
+1. Start the forked network:
+
+```bash
+sui-forking start --network testnet
+```
+
+2. In another terminal, switch your Sui client to point to the local forked network (starts by default at `http://localhost:9000`):
+
+```
+sui client switch --env local (or add a new env)
+
+```
+
+3. Request tokens:
+
+```bash
+sui-forking faucet --address <your-address> --amount 5000000000 (5 SUI)
+```
+
+4. Check balance
+```bash
+sui client gas
+```
+
+5. Call a package from testnet (e.g., the `@potatoes/ascii` package):
+```bash
+sui client ptb --move-call 0x65d106ccd0feddc4183dcaa92decafd3376ee9b34315aae938dc838f6d654f18::ascii::is_ascii '"hello"' --gas-budget 5000000
+```
+
+## Server REST API
+The local forked network server exposes a REST API for interaction. The server listens on port 9001 by default.
+### Endpoints
+- `POST /advance-checkpoint`: Advance the checkpoint by 1
+- `POST /advance-clock [milliseconds]`: Advance the clock by milliseconds (default: 1ms if omitted).
+- `POST /advance-epoch`: Advance the epoch by 1
+- `POST /faucet`: Request SUI tokens
+  - Body: `{ "address": "<address>", "amount": <amount> }`
+- `GET /status`: Get current checkpoint, epoch, clock.
+
+## Related Tools
+
+- `sui-replay-2`: A generic data store implementation for downloading and caching objects from the RPC.
+- `simulacrum`: Local network execution in lock-step mode

--- a/crates/sui-forking/build.rs
+++ b/crates/sui-forking/build.rs
@@ -1,0 +1,10 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+fn main() {
+    cynic_codegen::register_schema("rpc")
+        .from_sdl_file("../sui-indexer-alt-graphql/schema.graphql")
+        .expect("Failed to find GraphQL Schema")
+        .as_default()
+        .unwrap();
+}

--- a/crates/sui-forking/src/api/client.rs
+++ b/crates/sui-forking/src/api/client.rs
@@ -1,0 +1,150 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Minimal client API for interacting with a running `sui-forking` server.
+
+use serde::de::DeserializeOwned;
+use url::Url;
+
+use crate::api::endpoints::{self, Endpoint, EndpointMethod};
+use crate::api::error::ClientError;
+use crate::api::types::{ApiResponse, ForkingStatus};
+
+#[derive(Clone, Debug)]
+pub struct ForkingClient {
+    base_url: Url,
+    http: reqwest::Client,
+}
+
+impl ForkingClient {
+    pub fn new(mut base_url: Url) -> Self {
+        if base_url.path().is_empty() {
+            base_url.set_path("/");
+        }
+        base_url.set_query(None);
+        base_url.set_fragment(None);
+
+        Self {
+            base_url,
+            http: reqwest::Client::new(),
+        }
+    }
+
+    pub fn base_url(&self) -> &Url {
+        &self.base_url
+    }
+
+    pub async fn status(&self) -> Result<ForkingStatus, ClientError> {
+        self.send_without_body(endpoints::STATUS).await
+    }
+
+    async fn send_without_body<T>(&self, endpoint: Endpoint) -> Result<T, ClientError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = self.endpoint_url(endpoint)?;
+        let response = self
+            .http
+            .request(reqwest_method(endpoint.method), url.clone())
+            .send()
+            .await
+            .map_err(|source| ClientError::Transport {
+                url: url.clone(),
+                source,
+            })?;
+        self.decode_response(endpoint.path, url, response).await
+    }
+
+    async fn decode_response<T>(
+        &self,
+        endpoint: &'static str,
+        url: Url,
+        response: reqwest::Response,
+    ) -> Result<T, ClientError>
+    where
+        T: DeserializeOwned,
+    {
+        let status = response.status();
+        if !status.is_success() {
+            let body = match response.text().await {
+                Ok(text) => text,
+                Err(err) => format!("<failed to read response body: {err}>"),
+            };
+            return Err(ClientError::HttpStatus { url, status, body });
+        }
+
+        let envelope: ApiResponse<T> =
+            response
+                .json()
+                .await
+                .map_err(|source| ClientError::Decode {
+                    url: url.clone(),
+                    source,
+                })?;
+
+        if !envelope.success {
+            return Err(ClientError::Api {
+                message: envelope
+                    .error
+                    .unwrap_or_else(|| format!("endpoint '{endpoint}' reported failure")),
+            });
+        }
+
+        envelope.data.ok_or(ClientError::MissingData { endpoint })
+    }
+
+    fn endpoint_url(&self, endpoint: Endpoint) -> Result<Url, ClientError> {
+        self.base_url
+            .join(endpoint.client_path())
+            .map_err(|source| ClientError::UrlJoin {
+                path: endpoint.path.to_string(),
+                source,
+            })
+    }
+}
+
+fn reqwest_method(method: EndpointMethod) -> reqwest::Method {
+    match method {
+        EndpointMethod::Get => reqwest::Method::GET,
+        EndpointMethod::Post => reqwest::Method::POST,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{Json, Router, routing::get};
+    use tokio::net::TcpListener;
+
+    use super::*;
+
+    async fn status_handler() -> Json<ApiResponse<ForkingStatus>> {
+        Json(ApiResponse {
+            success: true,
+            data: Some(ForkingStatus {
+                checkpoint: 7,
+                epoch: 3,
+                clock_timestamp_ms: 1234,
+            }),
+            error: None,
+        })
+    }
+
+    #[tokio::test]
+    async fn status_calls_minimal_status_endpoint() {
+        let app = Router::new().route("/status", get(status_handler));
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let addr = listener.local_addr().expect("local addr");
+
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app).await.expect("server should run");
+        });
+
+        let client = ForkingClient::new(Url::parse(&format!("http://{addr}")).expect("url"));
+        let status = client.status().await.expect("status");
+        assert_eq!(status.checkpoint, 7);
+        assert_eq!(status.epoch, 3);
+        assert_eq!(status.clock_timestamp_ms, 1234);
+
+        server.abort();
+    }
+}

--- a/crates/sui-forking/src/api/config.rs
+++ b/crates/sui-forking/src/api/config.rs
@@ -1,0 +1,470 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Configuration types for starting `sui-forking` programmatically.
+
+use std::net::{IpAddr, Ipv4Addr};
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+
+use sui_types::base_types::ObjectID;
+use url::Url;
+
+use crate::api::error::ConfigError;
+
+const DEFAULT_RPC_PORT: u16 = 9000;
+const DEFAULT_SERVER_PORT: u16 = 9001;
+
+/// Supported source network selection for forking.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ForkingNetwork {
+    /// Sui mainnet.
+    Mainnet,
+    /// Sui testnet.
+    Testnet,
+    /// Sui devnet.
+    Devnet,
+    /// Custom GraphQL endpoint URL.
+    Custom(Url),
+}
+
+impl ForkingNetwork {
+    /// Parse a network selector from CLI-style input.
+    ///
+    /// Accepted values:
+    /// - `mainnet`
+    /// - `testnet`
+    /// - `devnet`
+    /// - any full `http(s)` URL that points to the GraphQL server
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ConfigError`] when the input is empty, malformed, or uses a non-HTTP scheme.
+    pub fn parse(value: &str) -> Result<Self, ConfigError> {
+        let trimmed = value.trim();
+        let parsed = crate::network::ForkNetwork::parse(trimmed).map_err(|err| {
+            let message = err.to_string();
+            if let Some(scheme) = parse_scheme_from_error(&message) {
+                return ConfigError::InvalidUrlScheme {
+                    field: "network",
+                    scheme,
+                };
+            }
+            ConfigError::InvalidNetwork {
+                value: value.to_string(),
+                reason: message,
+            }
+        })?;
+
+        match parsed {
+            crate::network::ForkNetwork::Mainnet => Ok(Self::Mainnet),
+            crate::network::ForkNetwork::Testnet => Ok(Self::Testnet),
+            crate::network::ForkNetwork::Devnet => Ok(Self::Devnet),
+            crate::network::ForkNetwork::Custom(url) => {
+                let parsed_url = Url::parse(&url).map_err(|err| ConfigError::InvalidNetwork {
+                    value: url,
+                    reason: err.to_string(),
+                })?;
+                Ok(Self::Custom(parsed_url))
+            }
+        }
+    }
+
+    pub(crate) fn to_internal(&self) -> crate::network::ForkNetwork {
+        match self {
+            Self::Mainnet => crate::network::ForkNetwork::Mainnet,
+            Self::Testnet => crate::network::ForkNetwork::Testnet,
+            Self::Devnet => crate::network::ForkNetwork::Devnet,
+            Self::Custom(url) => crate::network::ForkNetwork::Custom(url.to_string()),
+        }
+    }
+}
+
+impl FromStr for ForkingNetwork {
+    type Err = ConfigError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::parse(s)
+    }
+}
+
+impl std::fmt::Display for ForkingNetwork {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Mainnet => write!(f, "mainnet"),
+            Self::Testnet => write!(f, "testnet"),
+            Self::Devnet => write!(f, "devnet"),
+            Self::Custom(url) => write!(f, "{url}"),
+        }
+    }
+}
+
+/// Startup seeding mode for prefetching objects at boot.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum StartupSeeding {
+    /// Do not prefetch startup objects.
+    None,
+    /// Prefetch these explicit object IDs.
+    Objects(Vec<ObjectID>),
+}
+
+impl StartupSeeding {
+    pub(crate) fn into_internal(self) -> crate::seeds::StartupSeeds {
+        match self {
+            Self::None => crate::seeds::StartupSeeds::default(),
+            Self::Objects(objects) => crate::seeds::StartupSeeds { objects },
+        }
+    }
+}
+
+/// Immutable node configuration used to start a programmatic forking runtime.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ForkingNodeConfig {
+    pub(crate) network: ForkingNetwork,
+    pub(crate) checkpoint: Option<u64>,
+    pub(crate) fullnode_url: Option<Url>,
+    pub(crate) host: IpAddr,
+    pub(crate) server_port: u16,
+    pub(crate) rpc_port: u16,
+    pub(crate) data_dir: Option<PathBuf>,
+    pub(crate) startup_seeding: StartupSeeding,
+}
+
+impl ForkingNodeConfig {
+    /// Create a new builder with defaults matching CLI behavior.
+    pub fn builder() -> ForkingNodeConfigBuilder {
+        ForkingNodeConfigBuilder::default()
+    }
+
+    /// Returns the selected network.
+    pub fn network(&self) -> &ForkingNetwork {
+        &self.network
+    }
+
+    /// Returns the optional checkpoint override.
+    pub fn checkpoint(&self) -> Option<u64> {
+        self.checkpoint
+    }
+
+    /// Returns the optional fullnode URL override.
+    pub fn fullnode_url(&self) -> Option<&Url> {
+        self.fullnode_url.as_ref()
+    }
+
+    /// Returns the bind host for the control HTTP server.
+    pub fn host(&self) -> IpAddr {
+        self.host
+    }
+
+    /// Returns the control HTTP server port.
+    pub fn server_port(&self) -> u16 {
+        self.server_port
+    }
+
+    /// Returns the gRPC RPC port.
+    pub fn rpc_port(&self) -> u16 {
+        self.rpc_port
+    }
+
+    /// Returns the optional data directory root.
+    pub fn data_dir(&self) -> Option<&Path> {
+        self.data_dir.as_deref()
+    }
+
+    /// Returns configured startup seeding.
+    pub fn startup_seeding(&self) -> &StartupSeeding {
+        &self.startup_seeding
+    }
+}
+
+/// Builder for [`ForkingNodeConfig`].
+#[derive(Clone, Debug)]
+#[must_use]
+pub struct ForkingNodeConfigBuilder {
+    network: ForkingNetwork,
+    checkpoint: Option<u64>,
+    fullnode_url: Option<Url>,
+    host: IpAddr,
+    server_port: u16,
+    rpc_port: u16,
+    data_dir: Option<PathBuf>,
+    startup_seeding: StartupSeeding,
+}
+
+impl Default for ForkingNodeConfigBuilder {
+    fn default() -> Self {
+        Self {
+            network: ForkingNetwork::Mainnet,
+            checkpoint: None,
+            fullnode_url: None,
+            host: IpAddr::V4(Ipv4Addr::LOCALHOST),
+            server_port: DEFAULT_SERVER_PORT,
+            rpc_port: DEFAULT_RPC_PORT,
+            data_dir: None,
+            startup_seeding: StartupSeeding::None,
+        }
+    }
+}
+
+impl ForkingNodeConfigBuilder {
+    /// Set the source network.
+    pub fn network(mut self, network: ForkingNetwork) -> Self {
+        self.network = network;
+        self
+    }
+
+    /// Set the optional starting checkpoint.
+    pub fn checkpoint(mut self, checkpoint: u64) -> Self {
+        self.checkpoint = Some(checkpoint);
+        self
+    }
+
+    /// Set the fullnode URL override.
+    pub fn fullnode_url(mut self, url: Url) -> Self {
+        self.fullnode_url = Some(url);
+        self
+    }
+
+    /// Set the bind host for the HTTP control server.
+    pub fn host(mut self, host: IpAddr) -> Self {
+        self.host = host;
+        self
+    }
+
+    /// Set the gRPC RPC server port.
+    pub fn rpc_port(mut self, port: u16) -> Self {
+        self.rpc_port = port;
+        self
+    }
+
+    /// Set the HTTP control server port.
+    pub fn server_port(mut self, port: u16) -> Self {
+        self.server_port = port;
+        self
+    }
+
+    /// Set the optional local data directory root.
+    pub fn data_dir(mut self, path: impl Into<PathBuf>) -> Self {
+        self.data_dir = Some(path.into());
+        self
+    }
+
+    /// Set startup object seeding behavior.
+    pub fn startup_seeding(mut self, seeding: StartupSeeding) -> Self {
+        self.startup_seeding = seeding;
+        self
+    }
+
+    /// Build a validated [`ForkingNodeConfig`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ConfigError`] when any field combination is invalid.
+    pub fn build(self) -> Result<ForkingNodeConfig, ConfigError> {
+        if self.rpc_port == 0 {
+            return Err(ConfigError::InvalidPort { field: "rpc_port" });
+        }
+        if self.server_port == 0 {
+            return Err(ConfigError::InvalidPort {
+                field: "server_port",
+            });
+        }
+
+        if let Some(path) = &self.data_dir
+            && path.as_os_str().is_empty()
+        {
+            return Err(ConfigError::EmptyDataDir);
+        }
+
+        if let Some(fullnode_url) = &self.fullnode_url {
+            validate_http_or_https("fullnode_url", fullnode_url)?;
+        }
+
+        if let ForkingNetwork::Custom(url) = &self.network {
+            validate_http_or_https("network", url)?;
+            if self.fullnode_url.is_none() {
+                return Err(ConfigError::MissingFullnodeUrlForCustomNetwork);
+            }
+        }
+
+        Ok(ForkingNodeConfig {
+            network: self.network,
+            checkpoint: self.checkpoint,
+            fullnode_url: self.fullnode_url,
+            host: self.host,
+            server_port: self.server_port,
+            rpc_port: self.rpc_port,
+            data_dir: self.data_dir,
+            startup_seeding: self.startup_seeding,
+        })
+    }
+}
+
+fn validate_http_or_https(field: &'static str, url: &Url) -> Result<(), ConfigError> {
+    match url.scheme() {
+        "http" | "https" => Ok(()),
+        scheme => Err(ConfigError::InvalidUrlScheme {
+            field,
+            scheme: scheme.to_string(),
+        }),
+    }
+}
+
+fn parse_scheme_from_error(message: &str) -> Option<String> {
+    let prefix = "unsupported URL scheme '";
+    let start = message.find(prefix)?;
+    let after_prefix = &message[(start + prefix.len())..];
+    let end = after_prefix.find('\'')?;
+    Some(after_prefix[..end].to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builder_defaults_match_cli_defaults() {
+        let config = ForkingNodeConfig::builder()
+            .build()
+            .expect("valid defaults");
+        assert_eq!(config.network(), &ForkingNetwork::Mainnet);
+        assert_eq!(config.host(), IpAddr::V4(Ipv4Addr::LOCALHOST));
+        assert_eq!(config.rpc_port(), 9000);
+        assert_eq!(config.server_port(), 9001);
+        assert!(config.checkpoint().is_none());
+        assert!(matches!(config.startup_seeding(), StartupSeeding::None));
+    }
+
+    #[test]
+    fn rejects_zero_ports() {
+        let rpc_err = ForkingNodeConfig::builder()
+            .rpc_port(0)
+            .build()
+            .expect_err("rpc_port=0 must fail");
+        assert!(matches!(
+            rpc_err,
+            ConfigError::InvalidPort { field: "rpc_port" }
+        ));
+
+        let http_err = ForkingNodeConfig::builder()
+            .server_port(0)
+            .build()
+            .expect_err("server_port=0 must fail");
+        assert!(matches!(
+            http_err,
+            ConfigError::InvalidPort {
+                field: "server_port"
+            }
+        ));
+    }
+
+    #[test]
+    fn rejects_custom_network_without_fullnode() {
+        let custom_network = ForkingNetwork::Custom(
+            Url::parse("https://example.com/graphql").expect("custom network URL"),
+        );
+        let err = ForkingNodeConfig::builder()
+            .network(custom_network)
+            .build()
+            .expect_err("missing fullnode_url must fail");
+        assert!(matches!(
+            err,
+            ConfigError::MissingFullnodeUrlForCustomNetwork
+        ));
+    }
+
+    #[test]
+    fn accepts_custom_network_with_fullnode() {
+        let custom_network = ForkingNetwork::Custom(
+            Url::parse("https://example.com/graphql").expect("custom network URL"),
+        );
+        let fullnode_url = Url::parse("https://example.com/fullnode").expect("fullnode URL");
+        let config = ForkingNodeConfig::builder()
+            .network(custom_network)
+            .fullnode_url(fullnode_url)
+            .build()
+            .expect("valid custom network config");
+        assert!(matches!(config.network(), ForkingNetwork::Custom(_)));
+    }
+
+    #[test]
+    fn parses_keyword_networks() {
+        assert_eq!(
+            ForkingNetwork::parse("mainnet").expect("mainnet parse"),
+            ForkingNetwork::Mainnet
+        );
+        assert_eq!(
+            ForkingNetwork::parse("testnet").expect("testnet parse"),
+            ForkingNetwork::Testnet
+        );
+        assert_eq!(
+            ForkingNetwork::parse("devnet").expect("devnet parse"),
+            ForkingNetwork::Devnet
+        );
+    }
+
+    #[test]
+    fn parses_custom_url_network() {
+        let parsed = ForkingNetwork::parse("https://my-network.example.com/graphql")
+            .expect("custom URL parse");
+        assert!(matches!(parsed, ForkingNetwork::Custom(_)));
+    }
+
+    #[test]
+    fn rejects_invalid_network_string() {
+        let err = ForkingNetwork::parse("not-a-network").expect_err("invalid network must fail");
+        assert!(matches!(err, ConfigError::InvalidNetwork { .. }));
+    }
+
+    #[test]
+    fn rejects_non_http_network_scheme() {
+        let err = ForkingNetwork::parse("ws://example.com/graphql")
+            .expect_err("non-http network scheme must fail");
+        assert!(matches!(
+            err,
+            ConfigError::InvalidUrlScheme {
+                field: "network",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn rejects_non_http_fullnode_scheme() {
+        let fullnode_url = Url::parse("ws://example.com:9000").expect("url parse");
+        let err = ForkingNodeConfig::builder()
+            .fullnode_url(fullnode_url)
+            .build()
+            .expect_err("non-http fullnode URL must fail");
+        assert!(matches!(err, ConfigError::InvalidUrlScheme { .. }));
+    }
+
+    #[test]
+    fn keyword_network_parse_is_deterministic() {
+        for keyword in ["mainnet", "testnet", "devnet"] {
+            let first = ForkingNetwork::parse(keyword).expect("valid keyword");
+            let second = ForkingNetwork::parse(keyword).expect("valid keyword");
+            assert_eq!(&first, &second);
+            assert_eq!(first.to_string(), keyword);
+        }
+    }
+
+    #[test]
+    fn builder_port_invariants_hold_for_boundary_combinations() {
+        let boundary_ports = [0_u16, 1_u16, 2_u16, u16::MAX];
+        for rpc_port in boundary_ports {
+            for server_port in boundary_ports {
+                let result = ForkingNodeConfig::builder()
+                    .rpc_port(rpc_port)
+                    .server_port(server_port)
+                    .build();
+
+                if rpc_port == 0 || server_port == 0 {
+                    assert!(result.is_err());
+                } else {
+                    assert!(result.is_ok());
+                }
+            }
+        }
+    }
+}

--- a/crates/sui-forking/src/api/endpoints.rs
+++ b/crates/sui-forking/src/api/endpoints.rs
@@ -1,0 +1,29 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Canonical control API endpoint definitions shared by server and client.
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum EndpointMethod {
+    Get,
+    Post,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct Endpoint {
+    pub path: &'static str,
+    pub method: EndpointMethod,
+}
+
+impl Endpoint {
+    const fn new(path: &'static str, method: EndpointMethod) -> Self {
+        Self { path, method }
+    }
+
+    pub fn client_path(self) -> &'static str {
+        self.path.strip_prefix('/').unwrap_or(self.path)
+    }
+}
+
+pub(crate) const HEALTH: Endpoint = Endpoint::new("/health", EndpointMethod::Get);
+pub(crate) const STATUS: Endpoint = Endpoint::new("/status", EndpointMethod::Get);

--- a/crates/sui-forking/src/api/error.rs
+++ b/crates/sui-forking/src/api/error.rs
@@ -1,0 +1,163 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Public error types for `sui-forking` programmatic APIs.
+
+use std::net::SocketAddr;
+use std::path::PathBuf;
+
+/// Configuration errors returned while building [`crate::ForkingNodeConfig`].
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum ConfigError {
+    /// Returned when a network string cannot be parsed as a known network or valid URL.
+    #[error("invalid network '{value}': {reason}")]
+    InvalidNetwork {
+        /// User-provided raw value.
+        value: String,
+        /// Human-readable parse error.
+        reason: String,
+    },
+
+    /// Returned when `--network` is custom and fullnode URL is missing.
+    #[error("fullnode_url is required when network is custom")]
+    MissingFullnodeUrlForCustomNetwork,
+
+    /// Returned when a URL uses a non-http(s) scheme.
+    #[error("unsupported URL scheme '{scheme}' for {field}; expected http or https")]
+    InvalidUrlScheme {
+        /// Field name being validated.
+        field: &'static str,
+        /// The invalid scheme.
+        scheme: String,
+    },
+
+    /// Returned when a configured port is zero.
+    #[error("{field} must be non-zero")]
+    InvalidPort {
+        /// Field name being validated.
+        field: &'static str,
+    },
+
+    /// Returned when a configured data directory is empty.
+    #[error("data_dir cannot be empty")]
+    EmptyDataDir,
+}
+
+/// Runtime startup and lifecycle errors for [`crate::ForkingNode`].
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum StartError {
+    /// Error while validating configuration.
+    #[error(transparent)]
+    Config(#[from] ConfigError),
+
+    /// Failed to create the configured data directory.
+    #[error("failed to create data directory at {path}")]
+    CreateDataDir {
+        /// Directory path.
+        path: PathBuf,
+        /// Source OS error.
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// Failed to resolve the default data directory when none was configured.
+    #[error("failed to resolve default data directory (~/.sui_data_store): {message}")]
+    ResolveDefaultDataDir {
+        /// Detailed error message.
+        message: String,
+    },
+
+    /// Startup task exited before it reported readiness.
+    #[error("forking server exited before readiness: {message}")]
+    ExitedBeforeReady {
+        /// Detailed error message.
+        message: String,
+    },
+
+    /// Local HTTP server URL could not be built from runtime settings.
+    #[error("failed to construct control base URL for {address}: {source}")]
+    InvalidControlUrl {
+        /// Resolved control address.
+        address: SocketAddr,
+        /// URL parse error.
+        #[source]
+        source: url::ParseError,
+    },
+
+    /// Background runtime task panicked or was cancelled unexpectedly.
+    #[error("forking runtime task failed to join")]
+    Join {
+        /// Tokio join error.
+        #[source]
+        source: tokio::task::JoinError,
+    },
+
+    /// Runtime server returned an execution error.
+    #[error("forking runtime failed: {message}")]
+    Runtime {
+        /// Detailed error message.
+        message: String,
+    },
+}
+
+/// Typed control client errors for [`crate::ForkingClient`].
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum ClientError {
+    /// Failed to join a relative endpoint path with the configured base URL.
+    #[error("failed to resolve endpoint '{path}' against base URL: {source}")]
+    UrlJoin {
+        /// Relative endpoint path.
+        path: String,
+        /// URL parse error.
+        #[source]
+        source: url::ParseError,
+    },
+
+    /// Network transport or protocol error from the HTTP client.
+    #[error("request to {url} failed")]
+    Transport {
+        /// Target URL.
+        url: url::Url,
+        /// Underlying reqwest error.
+        #[source]
+        source: reqwest::Error,
+    },
+
+    /// Endpoint returned a non-success HTTP status.
+    #[error("request to {url} failed with status {status}")]
+    HttpStatus {
+        /// Target URL.
+        url: url::Url,
+        /// HTTP status code.
+        status: reqwest::StatusCode,
+        /// Raw response body.
+        body: String,
+    },
+
+    /// Failed to decode JSON response payload.
+    #[error("failed to decode response from {url}")]
+    Decode {
+        /// Target URL.
+        url: url::Url,
+        /// Underlying reqwest decode error.
+        #[source]
+        source: reqwest::Error,
+    },
+
+    /// Server returned a successful HTTP response with `success: false`.
+    #[error("control endpoint returned failure: {message}")]
+    Api {
+        /// Server-provided error message.
+        message: String,
+    },
+
+    /// Server responded with `success: true` but omitted `data`.
+    #[error("control endpoint '{endpoint}' returned success without data")]
+    MissingData {
+        /// Endpoint path.
+        endpoint: &'static str,
+    },
+}

--- a/crates/sui-forking/src/api/mod.rs
+++ b/crates/sui-forking/src/api/mod.rs
@@ -1,0 +1,12 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Public programmatic API for running and controlling `sui-forking`.
+
+pub mod client;
+pub mod config;
+pub mod error;
+pub mod node;
+pub mod types;
+
+pub(crate) mod endpoints;

--- a/crates/sui-forking/src/api/node.rs
+++ b/crates/sui-forking/src/api/node.rs
@@ -1,0 +1,285 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! API for running `sui-forking` in-process.
+
+use std::net::SocketAddr;
+use std::path::{Path, PathBuf};
+
+use tokio::sync::oneshot;
+use tokio::task::JoinHandle;
+use url::Url;
+
+use crate::api::client::ForkingClient;
+use crate::api::config::ForkingNodeConfig;
+use crate::api::error::StartError;
+
+/// Handle for a running in-process `sui-forking` node.
+#[derive(Debug)]
+pub struct ForkingNode {
+    client: ForkingClient,
+    http_base_url: Url,
+    rpc_address: SocketAddr,
+    data_dir: PathBuf,
+    shutdown_sender: Option<oneshot::Sender<()>>,
+    task: Option<JoinHandle<anyhow::Result<()>>>,
+}
+
+impl ForkingNode {
+    /// Start a new local forking node.
+    ///
+    /// This returns only after startup has completed and listeners are ready.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StartError`] when startup fails, readiness cannot be reached, or runtime task
+    /// initialization crashes.
+    pub async fn start(config: ForkingNodeConfig) -> Result<Self, StartError> {
+        let data_dir = prepare_data_dir(config.data_dir)?;
+
+        let host = config.host.to_string();
+        let server_port = config.server_port;
+        let rpc_port = config.rpc_port;
+        let fullnode_url = config.fullnode_url.map(|url| url.to_string());
+        let startup_seeds = config.startup_seeding.into_internal();
+        let fork_network = config.network.to_internal();
+        let checkpoint = config.checkpoint;
+
+        let (shutdown_sender, shutdown_receiver) = oneshot::channel();
+        let (ready_sender, ready_receiver) = oneshot::channel();
+
+        let data_dir_for_task = data_dir.clone();
+        let mut task = tokio::spawn(async move {
+            crate::server::start_server(
+                startup_seeds,
+                fork_network,
+                checkpoint,
+                fullnode_url,
+                host,
+                server_port,
+                rpc_port,
+                data_dir_for_task,
+                crate::VERSION,
+                Some(shutdown_receiver),
+                Some(ready_sender),
+            )
+            .await
+        });
+
+        wait_for_ready(&mut task, ready_receiver).await?;
+
+        let http_address = SocketAddr::new(config.host, server_port);
+        let http_base_url = control_url(http_address)?;
+        let rpc_address = SocketAddr::from(([127, 0, 0, 1], rpc_port));
+
+        Ok(Self {
+            client: ForkingClient::new(http_base_url.clone()),
+            http_base_url,
+            rpc_address,
+            data_dir,
+            shutdown_sender: Some(shutdown_sender),
+            task: Some(task),
+        })
+    }
+
+    /// Return a typed control client for this node.
+    pub fn client(&self) -> ForkingClient {
+        self.client.clone()
+    }
+
+    /// Return the control API base URL.
+    pub fn http_base_url(&self) -> &Url {
+        &self.http_base_url
+    }
+
+    /// Return the gRPC address.
+    pub fn rpc_address(&self) -> SocketAddr {
+        self.rpc_address
+    }
+
+    /// Return the data directory root used by this node.
+    pub fn data_dir(&self) -> &Path {
+        &self.data_dir
+    }
+
+    /// Trigger graceful shutdown and wait for completion.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StartError`] if shutdown fails or runtime task crashes.
+    pub async fn shutdown(mut self) -> Result<(), StartError> {
+        if let Some(sender) = self.shutdown_sender.take() {
+            let _ = sender.send(());
+        }
+        wait_for_task(self.task.take()).await
+    }
+
+    /// Wait until the node exits.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StartError`] if runtime task exits with failure.
+    pub async fn wait(mut self) -> Result<(), StartError> {
+        wait_for_task(self.task.take()).await
+    }
+}
+
+impl Drop for ForkingNode {
+    fn drop(&mut self) {
+        if let Some(sender) = self.shutdown_sender.take() {
+            let _ = sender.send(());
+        }
+        if let Some(task) = self.task.take() {
+            task.abort();
+        }
+    }
+}
+
+fn prepare_data_dir(configured: Option<PathBuf>) -> Result<PathBuf, StartError> {
+    let path = match configured {
+        Some(path) => path,
+        None => sui_data_store::stores::FileSystemStore::base_path().map_err(|err| {
+            StartError::ResolveDefaultDataDir {
+                message: err.to_string(),
+            }
+        })?,
+    };
+
+    std::fs::create_dir_all(&path).map_err(|source| StartError::CreateDataDir {
+        path: path.clone(),
+        source,
+    })?;
+    Ok(path)
+}
+
+fn control_url(address: SocketAddr) -> Result<Url, StartError> {
+    Url::parse(&format!("http://{address}"))
+        .map_err(|source| StartError::InvalidControlUrl { address, source })
+}
+
+async fn wait_for_ready(
+    task: &mut JoinHandle<anyhow::Result<()>>,
+    ready_receiver: oneshot::Receiver<()>,
+) -> Result<(), StartError> {
+    tokio::select! {
+        ready = ready_receiver => {
+            match ready {
+                Ok(()) => Ok(()),
+                Err(_) => exited_before_ready_from_runtime(task).await,
+            }
+        }
+        runtime_result = &mut *task => {
+            exited_before_ready_from_result(runtime_result)
+        }
+    }
+}
+
+async fn exited_before_ready_from_runtime(
+    task: &mut JoinHandle<anyhow::Result<()>>,
+) -> Result<(), StartError> {
+    let runtime_result = task.await;
+    exited_before_ready_from_result(runtime_result)
+}
+
+fn exited_before_ready_from_result(
+    runtime_result: Result<anyhow::Result<()>, tokio::task::JoinError>,
+) -> Result<(), StartError> {
+    let runtime_result = runtime_result.map_err(|source| StartError::Join { source })?;
+    match runtime_result {
+        Ok(()) => Err(StartError::ExitedBeforeReady {
+            message: "runtime exited before readiness".to_string(),
+        }),
+        Err(err) => Err(StartError::ExitedBeforeReady {
+            message: format!("{err:#}"),
+        }),
+    }
+}
+
+async fn wait_for_task(task: Option<JoinHandle<anyhow::Result<()>>>) -> Result<(), StartError> {
+    let Some(task) = task else {
+        return Ok(());
+    };
+    let runtime_result = task.await.map_err(|source| StartError::Join { source })?;
+    runtime_result.map_err(|err| StartError::Runtime {
+        message: err.to_string(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use tokio::sync::Notify;
+    use tokio::time::{Duration, sleep};
+
+    use super::*;
+
+    fn fake_node(
+        task: JoinHandle<anyhow::Result<()>>,
+        shutdown_sender: oneshot::Sender<()>,
+    ) -> ForkingNode {
+        let base_url = Url::parse("http://127.0.0.1:9001").expect("url");
+        ForkingNode {
+            client: ForkingClient::new(base_url.clone()),
+            http_base_url: base_url,
+            rpc_address: SocketAddr::from(([127, 0, 0, 1], 9000)),
+            data_dir: PathBuf::from("/tmp/forking"),
+            shutdown_sender: Some(shutdown_sender),
+            task: Some(task),
+        }
+    }
+
+    #[tokio::test]
+    async fn readiness_succeeds_when_signal_arrives() {
+        let mut task = tokio::spawn(async move {
+            std::future::pending::<()>().await;
+            Ok(())
+        });
+        let (ready_sender, ready_receiver) = oneshot::channel();
+        ready_sender.send(()).expect("ready signal");
+
+        wait_for_ready(&mut task, ready_receiver)
+            .await
+            .expect("readiness succeeds");
+        task.abort();
+    }
+
+    #[tokio::test]
+    async fn readiness_fails_when_runtime_exits_first() {
+        let mut task = tokio::spawn(async move { anyhow::bail!("startup failed") });
+        let (_ready_sender, ready_receiver) = oneshot::channel::<()>();
+
+        let err = wait_for_ready(&mut task, ready_receiver)
+            .await
+            .expect_err("runtime exits before readiness");
+        assert!(matches!(err, StartError::ExitedBeforeReady { .. }));
+    }
+
+    #[tokio::test]
+    async fn shutdown_sends_signal_and_waits() {
+        let notified = Arc::new(Notify::new());
+        let notified_clone = notified.clone();
+        let (shutdown_sender, shutdown_receiver) = oneshot::channel();
+        let task = tokio::spawn(async move {
+            let _ = shutdown_receiver.await;
+            notified_clone.notify_one();
+            Ok(())
+        });
+        let node = fake_node(task, shutdown_sender);
+
+        node.shutdown().await.expect("shutdown succeeds");
+        notified.notified().await;
+    }
+
+    #[tokio::test]
+    async fn drop_aborts_runtime_task() {
+        let (shutdown_sender, _shutdown_receiver) = oneshot::channel::<()>();
+        let task = tokio::spawn(async move { std::future::pending::<anyhow::Result<()>>().await });
+        let abort_handle = task.abort_handle();
+        let node = fake_node(task, shutdown_sender);
+
+        drop(node);
+        sleep(Duration::from_millis(10)).await;
+        assert!(abort_handle.is_finished());
+    }
+}

--- a/crates/sui-forking/src/api/types.rs
+++ b/crates/sui-forking/src/api/types.rs
@@ -1,0 +1,25 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Public wire-compatible types used by the minimal control HTTP API.
+
+use serde::{Deserialize, Serialize};
+
+/// Status response for the local forking runtime.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ForkingStatus {
+    /// Latest locally produced checkpoint sequence number.
+    pub checkpoint: u64,
+    /// Current local epoch.
+    pub epoch: u64,
+    /// Current simulated on-chain time (seconds since Unix epoch).
+    pub clock_timestamp_ms: u64,
+}
+
+/// Generic envelope returned by control API endpoints.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub(crate) struct ApiResponse<T> {
+    pub success: bool,
+    pub data: Option<T>,
+    pub error: Option<String>,
+}

--- a/crates/sui-forking/src/cli.rs
+++ b/crates/sui-forking/src/cli.rs
@@ -1,0 +1,73 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use clap::{Parser, Subcommand};
+
+use sui_types::base_types::ObjectID;
+
+const RPC_PORT: &str = "9000";
+const SERVER_PORT: &str = "9001";
+const IP: &str = "127.0.0.1";
+const DEFAULT_ADDRESS: &str = "http://127.0.0.1:9001";
+
+#[derive(Parser, Debug)]
+#[clap(name = "sui-forking")]
+#[clap(about = "Minimal CLI for Sui forking with simulacrum", long_about = None)]
+pub struct Args {
+    #[clap(subcommand)]
+    pub command: Commands,
+}
+
+#[derive(clap::Args, Clone, Debug, Default)]
+pub struct StartupSeedArgs {
+    /// Explicit object IDs to prefetch at startup.
+    #[clap(long, value_delimiter = ',')]
+    pub objects: Vec<ObjectID>,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum Commands {
+    /// Start the forking server
+    Start {
+        /// Port to bind the gRPC RPC service. Default is 9000.
+        #[clap(long, default_value = RPC_PORT)]
+        rpc_port: u16,
+
+        /// Port to bind the HTTP forking server. Default is 9001.
+        #[clap(long, default_value = SERVER_PORT)]
+        server_port: u16,
+
+        /// Host IP address to bind the server. Default is localhost.
+        #[clap(long, default_value = IP)]
+        host: String,
+
+        /// Checkpoint to fork from.
+        /// If a local fork cache exists for this checkpoint, startup resumes from the latest
+        /// locally cached checkpoint in that fork directory.
+        /// If not provided, forks from the remote latest checkpoint.
+        #[clap(long)]
+        checkpoint: Option<u64>,
+
+        /// Network to fork from: `mainnet`, `testnet`, `devnet`, or a full GraphQL URL.
+        /// Any non-keyword value must be a valid `http(s)` GraphQL endpoint URL.
+        #[clap(long, default_value = "mainnet")]
+        network: String,
+
+        /// Optional fullnode RPC URL.
+        /// Required when `--network` is a custom GraphQL URL.
+        #[clap(long)]
+        fullnode_url: Option<String>,
+
+        /// Optional data directory for storing forked data
+        #[clap(long)]
+        data_dir: Option<String>,
+        /// Startup seed inputs.
+        #[clap(flatten)]
+        seeds: StartupSeedArgs,
+    },
+    /// Get current status
+    Status {
+        #[clap(long, default_value = DEFAULT_ADDRESS)]
+        server_url: String,
+    },
+}

--- a/crates/sui-forking/src/context.rs
+++ b/crates/sui-forking/src/context.rs
@@ -1,0 +1,56 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use anyhow::Context as _;
+use rand::rngs::OsRng;
+use sui_rpc_api::subscription::SubscriptionServiceHandle;
+use sui_types::full_checkpoint_content::Checkpoint;
+use sui_types::storage::ReadStore;
+use tokio::sync::RwLock;
+use tokio::sync::mpsc;
+
+use crate::store::ForkingStore;
+use simulacrum::Simulacrum;
+use sui_types::digests::ChainIdentifier;
+
+#[derive(Clone)]
+pub(crate) struct Context {
+    pub simulacrum: Arc<RwLock<Simulacrum<OsRng, ForkingStore>>>,
+    pub subscription_service_handle: SubscriptionServiceHandle,
+    pub checkpoint_sender: mpsc::Sender<Checkpoint>,
+    pub chain_id: ChainIdentifier,
+}
+
+impl Context {
+    /// Publish a checkpoint to the subscription service by its sequence number. This is used for
+    /// the subscription service for checkpoints.
+    pub async fn publish_checkpoint_by_sequence_number(
+        &self,
+        checkpoint_sequence_number: u64,
+    ) -> anyhow::Result<()> {
+        let checkpoint = {
+            let sim = self.simulacrum.read().await;
+            let store = sim.store();
+
+            let verified_checkpoint = store
+                .get_checkpoint_by_sequence_number(checkpoint_sequence_number)
+                .with_context(|| {
+                    format!("missing checkpoint summary at sequence {checkpoint_sequence_number}")
+                })?;
+            let checkpoint_contents = store
+                .get_checkpoint_contents_by_digest(&verified_checkpoint.content_digest)
+                .with_context(|| {
+                    format!("missing checkpoint contents for sequence {checkpoint_sequence_number}")
+                })?;
+
+            sim.get_checkpoint_data(verified_checkpoint.clone(), checkpoint_contents)?
+        };
+
+        self.checkpoint_sender
+            .send(checkpoint)
+            .await
+            .context("failed to enqueue checkpoint to subscription service")
+    }
+}

--- a/crates/sui-forking/src/graphql.rs
+++ b/crates/sui-forking/src/graphql.rs
@@ -1,0 +1,322 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use tracing::info;
+
+/// GraphQL client for fetching data from Sui network
+pub struct GraphQLClient {
+    endpoint: String,
+    client: reqwest::Client,
+}
+
+#[derive(Debug, Serialize)]
+struct GraphQLRequest {
+    query: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    variables: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GraphQLResponse<T> {
+    data: Option<T>,
+    errors: Option<Vec<GraphQLError>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GraphQLError {
+    message: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct LatestCheckpointResponse {
+    checkpoint: CheckpointNumberProtocolVersion,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ChainIdentifierResponse {
+    chain_identifier: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CheckpointNumberProtocolVersion {
+    sequence_number: u64,
+    query: QueryData,
+}
+
+#[derive(Debug, Deserialize)]
+struct ProtocolVersionResponse {
+    checkpoint: CheckpointWithQuery,
+}
+
+#[derive(Debug, Deserialize)]
+struct CheckpointWithQuery {
+    query: QueryData,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct QueryData {
+    protocol_configs: ProtocolConfigs,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProtocolConfigs {
+    pub protocol_version: u64,
+}
+
+impl GraphQLClient {
+    pub fn new(endpoint: String) -> Self {
+        Self {
+            endpoint,
+            client: reqwest::Client::new(),
+        }
+    }
+
+    pub fn endpoint(&self) -> &str {
+        &self.endpoint
+    }
+
+    /// Fetch protocol version at a specific checkpoint
+    pub async fn fetch_protocol_version(&self, sequence_number: Option<u64>) -> Result<u64> {
+        let query = if let Some(seq) = sequence_number {
+            format!(
+                r#"query {{
+  checkpoint(sequenceNumber: {}) {{
+    query {{
+      protocolConfigs {{
+        protocolVersion
+      }}
+    }}
+  }}
+}}"#,
+                seq
+            )
+        } else {
+            info!("No checkpoint provided, fetching last checkpoint's protocol version");
+            "{
+               checkpoint {
+                 query {
+                  protocolConfigs {
+                    protocolVersion
+                  }
+                }
+              }
+             }"
+            .to_string()
+        };
+        info!("GraphQL query: {}", query);
+
+        let request = GraphQLRequest {
+            query,
+            variables: None,
+        };
+
+        let response = self
+            .client
+            .post(&self.endpoint)
+            .json(&request)
+            .send()
+            .await
+            .context("Failed to send GraphQL request")?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unable to read error response".to_string());
+            anyhow::bail!(
+                "GraphQL request failed with status {}: {}",
+                status,
+                error_text
+            );
+        }
+
+        let graphql_response: GraphQLResponse<ProtocolVersionResponse> = response
+            .json()
+            .await
+            .context("Failed to parse GraphQL response")?;
+        extract_protocol_version(graphql_response)
+    }
+
+    pub async fn fetch_latest_checkpoint_and_protocol_version(&self) -> Result<(u64, u64)> {
+        let query = "query {
+              checkpoint {
+                sequenceNumber
+                query {
+                  protocolConfigs {
+                    protocolVersion
+                  }
+                }
+              }
+            }"
+        .to_string();
+
+        let request = GraphQLRequest {
+            query,
+            variables: None,
+        };
+
+        let response = self
+            .client
+            .post(&self.endpoint)
+            .json(&request)
+            .send()
+            .await
+            .context("Failed to send GraphQL request")?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unable to read error response".to_string());
+            anyhow::bail!(
+                "GraphQL request failed with status {}: {}",
+                status,
+                error_text
+            );
+        }
+
+        let graphql_response: GraphQLResponse<LatestCheckpointResponse> = response
+            .json()
+            .await
+            .context("Failed to parse GraphQL response")?;
+        extract_latest_checkpoint_and_protocol_version(graphql_response)
+    }
+
+    /// Fetch the network chain identifier from GraphQL.
+    pub async fn fetch_chain_identifier(&self) -> Result<String> {
+        let request = GraphQLRequest {
+            query: "query { chainIdentifier }".to_string(),
+            variables: None,
+        };
+
+        let response = self
+            .client
+            .post(&self.endpoint)
+            .json(&request)
+            .send()
+            .await
+            .context("Failed to send GraphQL request")?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unable to read error response".to_string());
+            anyhow::bail!(
+                "GraphQL request failed with status {}: {}",
+                status,
+                error_text
+            );
+        }
+
+        let graphql_response: GraphQLResponse<ChainIdentifierResponse> = response
+            .json()
+            .await
+            .context("Failed to parse GraphQL response")?;
+        extract_chain_identifier(graphql_response)
+    }
+}
+
+fn extract_graphql_data<T>(graphql_response: GraphQLResponse<T>) -> Result<T> {
+    if let Some(errors) = graphql_response.errors {
+        let error_messages: Vec<String> = errors.into_iter().map(|e| e.message).collect();
+        anyhow::bail!("GraphQL errors: {}", error_messages.join(", "));
+    }
+
+    graphql_response.data.context("No data in GraphQL response")
+}
+
+fn extract_protocol_version(
+    graphql_response: GraphQLResponse<ProtocolVersionResponse>,
+) -> Result<u64> {
+    let data = extract_graphql_data(graphql_response)?;
+    Ok(data.checkpoint.query.protocol_configs.protocol_version)
+}
+
+fn extract_latest_checkpoint_and_protocol_version(
+    graphql_response: GraphQLResponse<LatestCheckpointResponse>,
+) -> Result<(u64, u64)> {
+    let data = extract_graphql_data(graphql_response)?;
+    Ok((
+        data.checkpoint.sequence_number,
+        data.checkpoint.query.protocol_configs.protocol_version,
+    ))
+}
+
+fn extract_chain_identifier(
+    graphql_response: GraphQLResponse<ChainIdentifierResponse>,
+) -> Result<String> {
+    let data = extract_graphql_data(graphql_response)?;
+    data.chain_identifier
+        .context("No chainIdentifier in GraphQL response")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fetch_protocol_version_uses_local_response() {
+        let graphql_response: GraphQLResponse<ProtocolVersionResponse> =
+            serde_json::from_value(serde_json::json!({
+                "data": {
+                    "checkpoint": {
+                        "query": {
+                            "protocolConfigs": {
+                                "protocolVersion": 77
+                            }
+                        }
+                    }
+                }
+            }))
+            .expect("response parse");
+        let protocol_version =
+            extract_protocol_version(graphql_response).expect("protocol version");
+        assert_eq!(protocol_version, 77);
+    }
+
+    #[test]
+    fn fetch_latest_checkpoint_and_chain_identifier_use_local_responses() {
+        let latest_response: GraphQLResponse<LatestCheckpointResponse> =
+            serde_json::from_value(serde_json::json!({
+                "data": {
+                    "checkpoint": {
+                        "sequenceNumber": 111,
+                        "query": {
+                            "protocolConfigs": {
+                                "protocolVersion": 88
+                            }
+                        }
+                    }
+                }
+            }))
+            .expect("latest response parse");
+        let (checkpoint, protocol_version) =
+            extract_latest_checkpoint_and_protocol_version(latest_response)
+                .expect("latest checkpoint");
+        assert_eq!(checkpoint, 111);
+        assert_eq!(protocol_version, 88);
+
+        let chain_response: GraphQLResponse<ChainIdentifierResponse> =
+            serde_json::from_value(serde_json::json!({
+                "data": {
+                    "chainIdentifier": "7f7ad12684f6f7325e5f279ce8f7f46dbf51b97f34f3412f178ff6424fdaceda"
+                }
+            }))
+            .expect("chain response parse");
+        let chain_identifier = extract_chain_identifier(chain_response).expect("chain identifier");
+        assert_eq!(
+            chain_identifier,
+            "7f7ad12684f6f7325e5f279ce8f7f46dbf51b97f34f3412f178ff6424fdaceda"
+        );
+    }
+}

--- a/crates/sui-forking/src/grpc/error.rs
+++ b/crates/sui-forking/src/grpc/error.rs
@@ -1,0 +1,87 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{convert::Infallible, str::FromStr, sync::Arc};
+
+use tonic::{
+    Status,
+    metadata::{MetadataMap, MetadataValue},
+};
+
+pub(super) trait StatusCode {
+    fn code(&self) -> tonic::Code;
+}
+
+#[derive(thiserror::Error, Debug, Clone)]
+pub(super) enum RpcError<E = Infallible> {
+    /// A custom error type to cover the service or method-specific error cases.
+    Custom(Arc<E>),
+
+    /// Error to wrap existing framework errors.
+    Status(Arc<tonic::Status>),
+
+    /// An error produced by the internal works of the service (our fault).
+    InternalError(Arc<anyhow::Error>),
+}
+
+impl StatusCode for Infallible {
+    fn code(&self) -> tonic::Code {
+        match *self {}
+    }
+}
+
+impl<E: std::error::Error + StatusCode> From<E> for RpcError<E> {
+    fn from(err: E) -> Self {
+        RpcError::Custom(Arc::new(err))
+    }
+}
+
+/// Cannot use `#[from]` for this conversion because we want to avoid cloning the `tonic::Status`,
+/// when cloning the eror.
+impl<E> From<tonic::Status> for RpcError<E> {
+    fn from(err: tonic::Status) -> Self {
+        RpcError::Status(Arc::new(err))
+    }
+}
+
+/// Cannot use `#[from]` for this conversion because [`anyhow::Error`] does not implement `Clone`,
+/// so it needs to be wrapped in an [`Arc`].
+impl<E> From<anyhow::Error> for RpcError<E> {
+    fn from(err: anyhow::Error) -> Self {
+        RpcError::InternalError(Arc::new(err))
+    }
+}
+
+impl<E> From<RpcError<E>> for Status
+where
+    E: std::error::Error + StatusCode,
+    E: Send + Sync + 'static,
+{
+    fn from(err: RpcError<E>) -> Self {
+        match err {
+            RpcError::Custom(err) => {
+                let mut status = Status::new(err.code(), err.to_string());
+                status.set_source(err);
+                status
+            }
+
+            RpcError::Status(status) => status.as_ref().clone(),
+
+            RpcError::InternalError(err) => {
+                let mut chain = err.chain().enumerate();
+                let Some((_, top)) = chain.next() else {
+                    return Status::internal("Unknown error");
+                };
+
+                let mut meta = MetadataMap::new();
+                for (ix, err) in chain {
+                    let data = MetadataValue::from_str(&format!("{ix}: {err}"))
+                        .unwrap_or_else(|_| MetadataValue::from_static("[invalid]"));
+                    meta.append("x-sui-rpc-chain", data);
+                }
+
+                Status::with_metadata(tonic::Code::Internal, top.to_string(), meta)
+            }
+        }
+    }
+}

--- a/crates/sui-forking/src/grpc/ledger_service.rs
+++ b/crates/sui-forking/src/grpc/ledger_service.rs
@@ -1,0 +1,116 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use sui_rpc::merge::Merge;
+use sui_rpc::proto::sui::rpc::v2::{
+    BatchGetObjectsRequest, BatchGetObjectsResponse, BatchGetTransactionsRequest,
+    BatchGetTransactionsResponse, GetCheckpointRequest, GetCheckpointResponse, GetEpochRequest,
+    GetEpochResponse, GetObjectRequest, GetObjectResponse, GetServiceInfoRequest,
+    GetServiceInfoResponse, GetTransactionRequest, GetTransactionResponse, Object,
+    ledger_service_server::LedgerService,
+};
+use sui_rpc_api::grpc::v2::ledger_service::validate_get_object_requests;
+use sui_rpc_api::{ObjectNotFoundError, RpcError};
+use sui_types::base_types::{ObjectID, SequenceNumber};
+
+use crate::context::Context;
+
+/// Minimal ledger service for the runnable forking skeleton.
+pub struct ForkingLedgerService {
+    context: Context,
+}
+
+impl ForkingLedgerService {
+    pub fn new(context: Context) -> Self {
+        Self { context }
+    }
+}
+
+#[tonic::async_trait]
+impl LedgerService for ForkingLedgerService {
+    async fn get_service_info(
+        &self,
+        _request: tonic::Request<GetServiceInfoRequest>,
+    ) -> Result<tonic::Response<GetServiceInfoResponse>, tonic::Status> {
+        todo!("get_service_info is not implemented in the runnable skeleton")
+    }
+
+    async fn get_object(
+        &self,
+        request: tonic::Request<GetObjectRequest>,
+    ) -> Result<tonic::Response<GetObjectResponse>, tonic::Status> {
+        let GetObjectRequest {
+            object_id,
+            version,
+            read_mask,
+            ..
+        } = request.into_inner();
+
+        let (requests, read_mask) =
+            validate_get_object_requests(vec![(object_id, version)], read_mask)
+                .map_err(tonic::Status::from)?;
+        let (object_id, version) = requests[0];
+        let object = self
+            .get_object_impl(object_id.into(), version)
+            .await
+            .map_err(tonic::Status::from)?;
+
+        let mut proto_object = Object::default();
+        proto_object.merge(&object, &read_mask);
+
+        Ok(tonic::Response::new(GetObjectResponse::new(proto_object)))
+    }
+
+    async fn batch_get_objects(
+        &self,
+        _request: tonic::Request<BatchGetObjectsRequest>,
+    ) -> Result<tonic::Response<BatchGetObjectsResponse>, tonic::Status> {
+        todo!("batch_get_objects is not implemented in the runnable skeleton")
+    }
+
+    async fn get_transaction(
+        &self,
+        _request: tonic::Request<GetTransactionRequest>,
+    ) -> Result<tonic::Response<GetTransactionResponse>, tonic::Status> {
+        todo!("get_transaction is not implemented in the runnable skeleton")
+    }
+
+    async fn batch_get_transactions(
+        &self,
+        _request: tonic::Request<BatchGetTransactionsRequest>,
+    ) -> Result<tonic::Response<BatchGetTransactionsResponse>, tonic::Status> {
+        todo!("batch_get_transactions is not implemented in the runnable skeleton")
+    }
+
+    async fn get_checkpoint(
+        &self,
+        _request: tonic::Request<GetCheckpointRequest>,
+    ) -> Result<tonic::Response<GetCheckpointResponse>, tonic::Status> {
+        todo!("get_checkpoint is not implemented in the runnable skeleton")
+    }
+
+    async fn get_epoch(
+        &self,
+        _request: tonic::Request<GetEpochRequest>,
+    ) -> Result<tonic::Response<GetEpochResponse>, tonic::Status> {
+        todo!("get_epoch is not implemented in the runnable skeleton")
+    }
+}
+
+impl ForkingLedgerService {
+    async fn get_object_impl(
+        &self,
+        object_id: ObjectID,
+        version: Option<u64>,
+    ) -> Result<sui_types::object::Object, RpcError> {
+        let sim = self.context.simulacrum.read().await;
+        let store = sim.store();
+        let object = if let Some(version) = version {
+            store.get_object_at_version(&object_id, SequenceNumber::from_u64(version))
+        } else {
+            sui_types::storage::ObjectStore::get_object(store, &object_id)
+        };
+
+        object.ok_or_else(|| ObjectNotFoundError::new(object_id.into()).into())
+    }
+}

--- a/crates/sui-forking/src/grpc/metrics.rs
+++ b/crates/sui-forking/src/grpc/metrics.rs
@@ -1,0 +1,77 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use prometheus::{
+    HistogramVec, IntCounter, IntCounterVec, Registry, register_histogram_vec_with_registry,
+    register_int_counter_vec_with_registry, register_int_counter_with_registry,
+};
+
+/// Histogram buckets for the distribution of latency (time between receiving a request and sending
+/// a response).
+const LATENCY_SEC_BUCKETS: &[f64] = &[
+    0.001, 0.002, 0.005, 0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1.0, 2.0, 5.0, 10.0, 20.0, 50.0, 100.0,
+    200.0, 500.0, 1000.0,
+];
+
+pub struct RpcMetrics {
+    pub request_latency: HistogramVec,
+    pub requests_received: IntCounterVec,
+    pub requests_succeeded: IntCounterVec,
+    pub requests_failed: IntCounterVec,
+    pub requests_cancelled: IntCounterVec,
+    pub requests_panicked: IntCounter,
+}
+
+impl RpcMetrics {
+    pub(crate) fn new(registry: &Registry) -> Self {
+        Self {
+            request_latency: register_histogram_vec_with_registry!(
+                "consistent_rpc_request_latency",
+                "Time taken to response to gRPC requests, by path",
+                &["path"],
+                LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            )
+            .unwrap(),
+
+            requests_received: register_int_counter_vec_with_registry!(
+                "consistent_rpc_requests_received",
+                "Number of requests initiated for each gRPC method",
+                &["path"],
+                registry,
+            )
+            .unwrap(),
+
+            requests_succeeded: register_int_counter_vec_with_registry!(
+                "consistent_rpc_requests_succeeded",
+                "Number of requests that completed successfully, by path",
+                &["path", "code"],
+                registry,
+            )
+            .unwrap(),
+
+            requests_failed: register_int_counter_vec_with_registry!(
+                "consistent_rpc_requests_failed",
+                "Number of requests that completed with an error, by path",
+                &["path", "code"],
+                registry,
+            )
+            .unwrap(),
+
+            requests_cancelled: register_int_counter_vec_with_registry!(
+                "consistent_rpc_requests_cancelled",
+                "Number of requests that were cancelled before completion, by path",
+                &["path"],
+                registry,
+            )
+            .unwrap(),
+
+            requests_panicked: register_int_counter_with_registry!(
+                "consistent_rpc_requests_panicked",
+                "Number of requests that panicked during processing",
+                registry,
+            )
+            .unwrap(),
+        }
+    }
+}

--- a/crates/sui-forking/src/grpc/middleware/metrics.rs
+++ b/crates/sui-forking/src/grpc/middleware/metrics.rs
@@ -1,0 +1,148 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{borrow::Cow, sync::Arc};
+
+use axum::extract::MatchedPath;
+use http::{StatusCode, header::CONTENT_TYPE};
+use mysten_network::callback::{MakeCallbackHandler, ResponseHandler};
+use prometheus::HistogramTimer;
+use tonic::{Code, metadata::GRPC_CONTENT_TYPE};
+
+use crate::grpc::metrics::RpcMetrics;
+
+#[derive(Clone)]
+pub struct MakeMetricsHandler {
+    metrics: Arc<RpcMetrics>,
+}
+
+pub struct Handler {
+    metrics: Arc<RpcMetrics>,
+    path: Cow<'static, str>,
+    timer: Option<HistogramTimer>,
+}
+
+impl MakeMetricsHandler {
+    pub fn new(metrics: Arc<RpcMetrics>) -> Self {
+        Self { metrics }
+    }
+}
+
+impl MakeCallbackHandler for MakeMetricsHandler {
+    type Handler = Handler;
+
+    fn make_handler(&self, request: &http::request::Parts) -> Self::Handler {
+        let metrics = self.metrics.clone();
+
+        let path = if let Some(matched_path) = request.extensions.get::<MatchedPath>() {
+            if request
+                .headers
+                .get(&CONTENT_TYPE)
+                .is_some_and(|header| header == GRPC_CONTENT_TYPE)
+            {
+                Cow::Owned(request.uri.path().to_owned())
+            } else {
+                Cow::Owned(matched_path.as_str().to_owned())
+            }
+        } else {
+            Cow::Borrowed("unknown")
+        };
+
+        let timer = metrics
+            .request_latency
+            .with_label_values(&[path.as_ref()])
+            .start_timer();
+
+        metrics
+            .requests_received
+            .with_label_values(&[path.as_ref()])
+            .inc();
+
+        Handler {
+            metrics,
+            path,
+            timer: Some(timer),
+        }
+    }
+}
+
+impl ResponseHandler for Handler {
+    fn on_response(&mut self, response: &http::response::Parts) {
+        const GRPC_STATUS: http::HeaderName = http::HeaderName::from_static("grpc-status");
+
+        let (success, status) = if response
+            .headers
+            .get(&CONTENT_TYPE)
+            .is_some_and(|content_type| {
+                content_type
+                    .as_bytes()
+                    // check if the content-type starts_with 'application/grpc' in order to
+                    // consider this as a gRPC request. A prefix comparison is done instead of a
+                    // full equality check in order to account for the various types of
+                    // content-types that are considered as gRPC traffic.
+                    .starts_with(GRPC_CONTENT_TYPE.as_bytes())
+            }) {
+            let code = response
+                .headers
+                .get(&GRPC_STATUS)
+                .map(http::HeaderValue::as_bytes)
+                .map(Code::from_bytes)
+                .unwrap_or(Code::Ok);
+
+            (code == Code::Ok, code_as_str(code))
+        } else {
+            (response.status == StatusCode::OK, response.status.as_str())
+        };
+
+        self.timer.take().map(HistogramTimer::stop_and_record);
+
+        if success {
+            self.metrics
+                .requests_succeeded
+                .with_label_values(&[self.path.as_ref(), status])
+                .inc();
+        } else {
+            self.metrics
+                .requests_failed
+                .with_label_values(&[self.path.as_ref(), status])
+                .inc();
+        }
+    }
+
+    fn on_error<E>(&mut self, _error: &E) {
+        unreachable!("all axum services are required to have an error type of Infallible");
+    }
+}
+
+impl Drop for Handler {
+    fn drop(&mut self) {
+        if self.timer.is_some() {
+            self.metrics
+                .requests_cancelled
+                .with_label_values(&[self.path.as_ref()])
+                .inc();
+        }
+    }
+}
+
+fn code_as_str(code: Code) -> &'static str {
+    match code {
+        Code::Ok => "ok",
+        Code::Cancelled => "cancelled",
+        Code::Unknown => "unknown",
+        Code::InvalidArgument => "invalid-argument",
+        Code::DeadlineExceeded => "deadline-exceeded",
+        Code::NotFound => "not-found",
+        Code::AlreadyExists => "already-exists",
+        Code::PermissionDenied => "permission-denied",
+        Code::ResourceExhausted => "resource-exhausted",
+        Code::FailedPrecondition => "failed-precondition",
+        Code::Aborted => "aborted",
+        Code::OutOfRange => "out-of-range",
+        Code::Unimplemented => "unimplemented",
+        Code::Internal => "internal",
+        Code::Unavailable => "unavailable",
+        Code::DataLoss => "data-loss",
+        Code::Unauthenticated => "unauthenticated",
+    }
+}

--- a/crates/sui-forking/src/grpc/middleware/mod.rs
+++ b/crates/sui-forking/src/grpc/middleware/mod.rs
@@ -1,0 +1,6 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+pub(super) mod metrics;
+pub(super) mod panic;
+pub(super) mod version;

--- a/crates/sui-forking/src/grpc/middleware/panic.rs
+++ b/crates/sui-forking/src/grpc/middleware/panic.rs
@@ -1,0 +1,159 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{
+    future::Future,
+    panic::AssertUnwindSafe,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+use axum::body::Body;
+use futures::FutureExt;
+use http::{Request, Response};
+use pin_project::pin_project;
+use tonic::Status;
+use tower::{Layer, Service};
+
+use crate::grpc::metrics::RpcMetrics;
+
+/// Tower layer that catches panics during request processing and converts them to gRPC
+/// `Status::internal()` errors.
+#[derive(Clone)]
+pub struct CatchPanicLayer {
+    metrics: Arc<RpcMetrics>,
+}
+
+/// Tower service that catches panics and returns gRPC internal errors.
+#[derive(Clone)]
+pub struct CatchPanicService<S> {
+    inner: S,
+    metrics: Arc<RpcMetrics>,
+}
+
+/// Future that catches panics and converts them to gRPC errors.
+#[pin_project]
+pub struct CatchPanicFuture<F> {
+    #[pin]
+    inner: futures::future::CatchUnwind<AssertUnwindSafe<F>>,
+    metrics: Arc<RpcMetrics>,
+}
+
+impl CatchPanicLayer {
+    pub fn new(metrics: Arc<RpcMetrics>) -> Self {
+        Self { metrics }
+    }
+}
+
+impl<S> Layer<S> for CatchPanicLayer {
+    type Service = CatchPanicService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        CatchPanicService {
+            inner,
+            metrics: self.metrics.clone(),
+        }
+    }
+}
+
+impl<S, ReqBody> Service<Request<ReqBody>> for CatchPanicService<S>
+where
+    S: Service<Request<ReqBody>, Response = Response<Body>>,
+    S::Future: Send + 'static,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = CatchPanicFuture<S::Future>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
+        CatchPanicFuture {
+            inner: AssertUnwindSafe(self.inner.call(req)).catch_unwind(),
+            metrics: self.metrics.clone(),
+        }
+    }
+}
+
+impl<F, E> Future for CatchPanicFuture<F>
+where
+    F: Future<Output = Result<Response<Body>, E>>,
+{
+    type Output = Result<Response<Body>, E>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+
+        match this.inner.poll(cx) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(Ok(result)) => Poll::Ready(result),
+            Poll::Ready(Err(err)) => {
+                this.metrics.requests_panicked.inc();
+
+                let status = Status::internal(if let Some(s) = err.downcast_ref::<String>() {
+                    format!("Request panicked: {s}")
+                } else if let Some(s) = err.downcast_ref::<&str>() {
+                    format!("Request panicked: {s}")
+                } else {
+                    "Request panicked".to_string()
+                });
+
+                Poll::Ready(Ok(status.into_http()))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::convert::Infallible;
+
+    use prometheus::Registry;
+    use tower::ServiceExt;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_catch_panic() {
+        let registry = Registry::new();
+        let metrics = Arc::new(RpcMetrics::new(&registry));
+
+        #[allow(unreachable_code)]
+        let panic_service = tower::service_fn(|_: Request<Body>| async {
+            panic!("Boom!");
+            Ok::<_, Infallible>(Response::new(Body::empty()))
+        });
+
+        let service = CatchPanicLayer::new(metrics.clone()).layer(panic_service);
+        let request = Request::builder().uri("/test").body(Body::empty()).unwrap();
+        let response = service.oneshot(request).await.unwrap();
+
+        let status = response
+            .headers()
+            .get("grpc-status")
+            .expect("Should have grpc-status header");
+
+        assert_eq!(status, &(tonic::Code::Internal as usize).to_string());
+        assert_eq!(metrics.requests_panicked.get(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_catch_panic_passthrough() {
+        let registry = Registry::new();
+        let metrics = Arc::new(RpcMetrics::new(&registry));
+
+        let ok_service = tower::service_fn(|_req: Request<Body>| async {
+            Ok::<_, Infallible>(Response::new(Body::empty()))
+        });
+
+        let service = CatchPanicLayer::new(metrics.clone()).layer(ok_service);
+        let request = Request::builder().uri("/test").body(Body::empty()).unwrap();
+        let response = service.oneshot(request).await.unwrap();
+
+        assert_eq!(response.status(), http::StatusCode::OK);
+        assert_eq!(metrics.requests_panicked.get(), 0);
+    }
+}

--- a/crates/sui-forking/src/grpc/middleware/version.rs
+++ b/crates/sui-forking/src/grpc/middleware/version.rs
@@ -1,0 +1,29 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use axum::{
+    body::Body,
+    extract::State,
+    http::{HeaderName, HeaderValue, Request},
+    middleware::Next,
+    response::Response,
+};
+
+pub(crate) static VERSION_HEADER: HeaderName = HeaderName::from_static("x-sui-rpc-version");
+
+/// Extension wrapping to make the version available to the middleware.
+#[derive(Copy, Clone, Debug)]
+pub(crate) struct Version(pub &'static str);
+
+/// Mark every outgoing response with a header indicating the precise version of the RPC that was
+/// used (including that patch version and SHA).
+pub(crate) async fn set_version(
+    State(Version(version)): State<Version>,
+    request: Request<Body>,
+    next: Next,
+) -> Response {
+    let mut response = next.run(request).await;
+    let headers = response.headers_mut();
+    headers.insert(VERSION_HEADER.clone(), HeaderValue::from_static(version));
+    response
+}

--- a/crates/sui-forking/src/grpc/mod.rs
+++ b/crates/sui-forking/src/grpc/mod.rs
@@ -1,0 +1,277 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::{convert::Infallible, sync::Arc};
+
+use anyhow::Context;
+use axum::Router;
+use axum::extract::Request;
+use axum::response::IntoResponse;
+use axum_server::Handle;
+use axum_server::tls_rustls::RustlsConfig;
+use metrics::RpcMetrics;
+use middleware::metrics::MakeMetricsHandler;
+use middleware::panic::CatchPanicLayer;
+use middleware::version::Version;
+use mysten_network::callback::CallbackLayer;
+use prometheus::Registry;
+use sui_futures::service::Service;
+use tokio::net::TcpListener;
+use tokio::sync::oneshot;
+use tonic::server::NamedService;
+use tonic_health::ServingStatus;
+use tracing::info;
+
+mod error;
+pub mod ledger_service;
+mod metrics;
+mod middleware;
+pub mod state_service;
+pub mod subscription_service;
+pub mod transaction_execution_service;
+
+#[derive(clap::Args, Clone, Debug)]
+pub struct RpcArgs {
+    /// Address to accept incoming RPC connections on.
+    #[clap(long, default_value_t = Self::default().rpc_listen_address)]
+    pub rpc_listen_address: SocketAddr,
+
+    /// TLS configuration
+    #[clap(flatten)]
+    pub tls: TlsArgs,
+}
+
+#[derive(clap::Args, Clone, Debug, Default)]
+pub struct TlsArgs {
+    /// Address to accept incoming TLS/HTTPS connections on
+    #[clap(long, requires_all = &["tls_cert", "tls_key"])]
+    pub rpc_tls_listen_address: Option<SocketAddr>,
+
+    /// Path to TLS certificate file (PEM format)
+    #[clap(long, requires_all = &["rpc_tls_listen_address", "tls_key"])]
+    pub tls_cert: Option<PathBuf>,
+
+    /// Path to TLS private key file (PEM format)
+    #[clap(long, requires_all = &["rpc_tls_listen_address", "tls_cert"])]
+    pub tls_key: Option<PathBuf>,
+}
+
+/// Responsible for the set-up of a gRPC service -- adding services, configuring reflection,
+/// health-checks, logging and metrics middleware, etc.
+pub(crate) struct RpcService<'d> {
+    /// Address to accept incoming RPC connections on.
+    rpc_listen_address: SocketAddr,
+
+    /// Optional address to accept incoming TLS RPC connections on.
+    rpc_tls_listen_address: Option<SocketAddr>,
+
+    /// TLS configuration
+    tls_config: Option<RustlsConfig>,
+
+    /// The version string to report with each response, as an HTTP header.
+    version: &'static str,
+
+    /// File descriptors are added to these builders to eventually be exposed via the reflection
+    /// service.
+    reflection_v1: tonic_reflection::server::Builder<'d>,
+    reflection_v1alpha: tonic_reflection::server::Builder<'d>,
+
+    /// The names of gRPC services registered with this instance.
+    service_names: Vec<&'static str>,
+
+    /// The axum router that wil handle incoming requests.
+    router: Router,
+
+    /// Metrics for the RPC service.
+    metrics: Arc<RpcMetrics>,
+}
+
+pub type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
+
+impl<'d> RpcService<'d> {
+    pub(crate) async fn new(
+        args: RpcArgs,
+        version: &'static str,
+        registry: &Registry,
+    ) -> anyhow::Result<Self> {
+        let RpcArgs {
+            rpc_listen_address,
+            tls,
+        } = args;
+
+        let TlsArgs {
+            rpc_tls_listen_address,
+            tls_cert,
+            tls_key,
+        } = tls;
+
+        let tls_config = if let (Some(cert), Some(key)) = (tls_cert, tls_key) {
+            Some(
+                RustlsConfig::from_pem_file(cert, key)
+                    .await
+                    .context("Failed to load TLS configuration")?,
+            )
+        } else {
+            None
+        };
+
+        Ok(Self {
+            rpc_listen_address,
+            rpc_tls_listen_address,
+            tls_config,
+            version,
+            reflection_v1: tonic_reflection::server::Builder::configure(),
+            reflection_v1alpha: tonic_reflection::server::Builder::configure(),
+            service_names: vec![],
+            router: Router::new(),
+            metrics: Arc::new(RpcMetrics::new(registry)),
+        })
+    }
+
+    /// Register a file descriptor set to be exposed via the reflection service.
+    pub(crate) fn register_encoded_file_descriptor_set(mut self, fds: &'d [u8]) -> Self {
+        self.reflection_v1 = self.reflection_v1.register_encoded_file_descriptor_set(fds);
+        self.reflection_v1alpha = self
+            .reflection_v1alpha
+            .register_encoded_file_descriptor_set(fds);
+        self
+    }
+
+    /// Register a new gRPC service.
+    pub(crate) fn add_service<S>(mut self, s: S) -> Self
+    where
+        S: Clone + Send + Sync + 'static,
+        S: NamedService,
+        S: tower::Service<Request, Response: IntoResponse, Error = Infallible>,
+        S::Future: Send + 'static,
+        S::Error: Send + Into<BoxError>,
+    {
+        self.service_names.push(S::NAME);
+        self.router = add_service(self.router, s);
+        self
+    }
+
+    /// Run the RPC service. This binds the listener and exposes handlers for the RPC service.
+    pub(crate) async fn run(self) -> anyhow::Result<Service> {
+        let Self {
+            rpc_listen_address,
+            rpc_tls_listen_address,
+            tls_config,
+            version,
+            reflection_v1,
+            reflection_v1alpha,
+            mut service_names,
+            mut router,
+            metrics,
+        } = self;
+
+        let reflection_v1 = reflection_v1
+            .register_encoded_file_descriptor_set(tonic_health::pb::FILE_DESCRIPTOR_SET)
+            .build_v1()
+            .context("Failed to build v1 gRPC reflection service")?;
+
+        let reflection_v1alpha = reflection_v1alpha
+            .register_encoded_file_descriptor_set(tonic_health::pb::FILE_DESCRIPTOR_SET)
+            .build_v1alpha()
+            .context("Failed to build v1alpha gRPC reflection service")?;
+
+        let (health_reporter, health_service) = tonic_health::server::health_reporter();
+
+        service_names.extend([
+            service_name(&reflection_v1),
+            service_name(&reflection_v1alpha),
+            service_name(&health_service),
+        ]);
+
+        router = add_service(router, reflection_v1);
+        router = add_service(router, reflection_v1alpha);
+        router = add_service(router, health_service);
+        router = router
+            .layer(CallbackLayer::new(MakeMetricsHandler::new(metrics.clone())))
+            .layer(tower_http::trace::TraceLayer::new_for_grpc())
+            .layer(axum::middleware::from_fn_with_state(
+                Version(version),
+                middleware::version::set_version,
+            ))
+            .layer(CatchPanicLayer::new(metrics));
+
+        for service_name in service_names {
+            health_reporter
+                .set_service_status(service_name, ServingStatus::Serving)
+                .await;
+        }
+
+        let mut service = Service::new();
+
+        // Start HTTPS server if TLS is configured
+        if let (Some(listen_address), Some(config)) = (rpc_tls_listen_address, tls_config) {
+            info!("Starting Consistent RPC TLS service on {listen_address}");
+            let handle = Handle::new();
+            let tls_router = router.clone();
+
+            service = service
+                .with_shutdown_signal({
+                    let handle = handle.clone();
+                    async move {
+                        handle.graceful_shutdown(None);
+                    }
+                })
+                .spawn(async move {
+                    axum_server::bind_rustls(listen_address, config)
+                        .handle(handle)
+                        .serve(tls_router.into_make_service())
+                        .await
+                        .context("Consistent RPC TLS service failed")?;
+                    Ok(())
+                });
+        }
+
+        // Start HTTP server
+        info!("Starting Consistent RPC service on {rpc_listen_address}");
+        let listener = TcpListener::bind(rpc_listen_address)
+            .await
+            .context("Failed to bind Consistent RPC to listen address")?;
+
+        let (stx, srx) = oneshot::channel::<()>();
+        service = service
+            .with_shutdown_signal(async move {
+                let _ = stx.send(());
+            })
+            .spawn(async move {
+                axum::serve(listener, router)
+                    .with_graceful_shutdown(async move {
+                        let _ = srx.await;
+                    })
+                    .await
+                    .context("Consistent RPC HTTP service failed")
+            });
+
+        Ok(service)
+    }
+}
+
+impl Default for RpcArgs {
+    fn default() -> Self {
+        Self {
+            rpc_listen_address: SocketAddr::from(([0, 0, 0, 0], 7001)),
+            tls: TlsArgs::default(),
+        }
+    }
+}
+
+fn service_name<S: NamedService>(_: &S) -> &'static str {
+    S::NAME
+}
+
+fn add_service<S>(router: Router, s: S) -> Router
+where
+    S: Clone + Send + Sync + 'static,
+    S: NamedService,
+    S: tower::Service<Request, Response: IntoResponse, Error = Infallible>,
+    S::Future: Send + 'static,
+    S::Error: Send + Into<BoxError>,
+{
+    router.route_service(&format!("/{}/{{*rest}}", S::NAME), s)
+}

--- a/crates/sui-forking/src/grpc/state_service/mod.rs
+++ b/crates/sui-forking/src/grpc/state_service/mod.rs
@@ -1,0 +1,59 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::context::Context;
+use sui_rpc::proto::sui::rpc::v2::state_service_server::StateService;
+use sui_rpc_api::proto::sui::rpc::v2 as grpc;
+
+pub(crate) struct ForkingStateService {
+    context: Context,
+}
+
+impl ForkingStateService {
+    pub fn new(context: Context) -> Self {
+        Self { context }
+    }
+}
+
+#[tonic::async_trait]
+impl StateService for ForkingStateService {
+    async fn get_coin_info(
+        &self,
+        _request: tonic::Request<grpc::GetCoinInfoRequest>,
+    ) -> Result<tonic::Response<grpc::GetCoinInfoResponse>, tonic::Status> {
+        let _ = &self.context;
+        todo!("get_coin_info is not implemented in the runnable skeleton")
+    }
+
+    async fn list_dynamic_fields(
+        &self,
+        _request: tonic::Request<grpc::ListDynamicFieldsRequest>,
+    ) -> Result<tonic::Response<grpc::ListDynamicFieldsResponse>, tonic::Status> {
+        let _ = &self.context;
+        todo!("list_dynamic_fields is not implemented in the runnable skeleton")
+    }
+
+    async fn get_balance(
+        &self,
+        _request: tonic::Request<grpc::GetBalanceRequest>,
+    ) -> Result<tonic::Response<grpc::GetBalanceResponse>, tonic::Status> {
+        let _ = &self.context;
+        todo!("get_balance is not implemented in the runnable skeleton")
+    }
+
+    async fn list_balances(
+        &self,
+        _request: tonic::Request<grpc::ListBalancesRequest>,
+    ) -> Result<tonic::Response<grpc::ListBalancesResponse>, tonic::Status> {
+        let _ = &self.context;
+        todo!("list_balances is not implemented in the runnable skeleton")
+    }
+
+    async fn list_owned_objects(
+        &self,
+        _request: tonic::Request<grpc::ListOwnedObjectsRequest>,
+    ) -> Result<tonic::Response<grpc::ListOwnedObjectsResponse>, tonic::Status> {
+        let _ = &self.context;
+        todo!("list_owned_objects is not implemented in the runnable skeleton")
+    }
+}

--- a/crates/sui-forking/src/grpc/subscription_service.rs
+++ b/crates/sui-forking/src/grpc/subscription_service.rs
@@ -1,0 +1,36 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::pin::Pin;
+
+use sui_rpc::proto::sui::rpc::v2::subscription_service_server::SubscriptionService;
+use sui_rpc::proto::sui::rpc::v2::{SubscribeCheckpointsRequest, SubscribeCheckpointsResponse};
+
+/// Minimal subscription service placeholder for the runnable forking skeleton.
+pub struct ForkingSubscriptionService {
+    context: crate::context::Context,
+}
+
+impl ForkingSubscriptionService {
+    pub fn new(context: crate::context::Context) -> Self {
+        Self { context }
+    }
+}
+
+#[tonic::async_trait]
+impl SubscriptionService for ForkingSubscriptionService {
+    type SubscribeCheckpointsStream = Pin<
+        Box<
+            dyn tokio_stream::Stream<Item = Result<SubscribeCheckpointsResponse, tonic::Status>>
+                + Send,
+        >,
+    >;
+
+    async fn subscribe_checkpoints(
+        &self,
+        _request: tonic::Request<SubscribeCheckpointsRequest>,
+    ) -> Result<tonic::Response<Self::SubscribeCheckpointsStream>, tonic::Status> {
+        let _ = &self.context;
+        todo!("subscribe_checkpoints is not implemented in the runnable skeleton")
+    }
+}

--- a/crates/sui-forking/src/grpc/transaction_execution_service.rs
+++ b/crates/sui-forking/src/grpc/transaction_execution_service.rs
@@ -1,0 +1,39 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use sui_rpc::proto::sui::rpc::v2::{
+    ExecuteTransactionRequest, ExecuteTransactionResponse, SimulateTransactionRequest,
+    SimulateTransactionResponse, transaction_execution_service_server::TransactionExecutionService,
+};
+
+use crate::context::Context;
+
+/// Minimal transaction execution service placeholder for the runnable forking skeleton.
+pub struct ForkingTransactionExecutionService {
+    context: Context,
+}
+
+impl ForkingTransactionExecutionService {
+    pub fn new(context: Context) -> Self {
+        Self { context }
+    }
+}
+
+#[tonic::async_trait]
+impl TransactionExecutionService for ForkingTransactionExecutionService {
+    async fn execute_transaction(
+        &self,
+        _request: tonic::Request<ExecuteTransactionRequest>,
+    ) -> Result<tonic::Response<ExecuteTransactionResponse>, tonic::Status> {
+        let _ = &self.context;
+        todo!("execute_transaction is not implemented in the runnable skeleton")
+    }
+
+    async fn simulate_transaction(
+        &self,
+        _request: tonic::Request<SimulateTransactionRequest>,
+    ) -> Result<tonic::Response<SimulateTransactionResponse>, tonic::Status> {
+        let _ = &self.context;
+        todo!("simulate_transaction is not implemented in the runnable skeleton")
+    }
+}

--- a/crates/sui-forking/src/lib.rs
+++ b/crates/sui-forking/src/lib.rs
@@ -1,0 +1,22 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Programmatic API and binary support for the `sui-forking` tool.
+
+pub mod api;
+
+mod context;
+mod graphql;
+mod grpc;
+mod network;
+mod seeds;
+mod server;
+mod store;
+
+pub use api::client::ForkingClient;
+pub use api::config::{ForkingNetwork, ForkingNodeConfig, StartupSeeding};
+pub use api::error::{ClientError, ConfigError, StartError};
+pub use api::node::ForkingNode;
+pub use api::types::ForkingStatus;
+
+pub(crate) static VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/crates/sui-forking/src/main.rs
+++ b/crates/sui-forking/src/main.rs
@@ -1,0 +1,87 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+mod cli;
+
+use std::net::IpAddr;
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use sui_forking::{ForkingClient, ForkingNetwork, ForkingNode, ForkingNodeConfig, StartupSeeding};
+use tracing::info;
+use url::Url;
+
+use crate::cli::{Args, Commands};
+
+fn client_from_server_url(server_url: &str) -> Result<ForkingClient> {
+    let base_url =
+        Url::parse(server_url).with_context(|| format!("invalid server URL '{}'", server_url))?;
+    Ok(ForkingClient::new(base_url))
+}
+
+fn startup_seeding(args: cli::StartupSeedArgs) -> StartupSeeding {
+    if !args.objects.is_empty() {
+        return StartupSeeding::Objects(args.objects);
+    }
+    StartupSeeding::None
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt::init();
+
+    let args = Args::parse();
+
+    match args.command {
+        Commands::Start {
+            host,
+            checkpoint,
+            rpc_port,
+            server_port,
+            network,
+            fullnode_url,
+            data_dir,
+            seeds,
+        } => {
+            let fork_network = ForkingNetwork::parse(&network)?;
+            let host: IpAddr = host
+                .parse()
+                .with_context(|| format!("invalid host IP '{}'", host))?;
+
+            info!(
+                "Starting forking server with {} as the starting point...",
+                fork_network
+            );
+
+            let mut builder = ForkingNodeConfig::builder()
+                .network(fork_network)
+                .host(host)
+                .server_port(server_port)
+                .rpc_port(rpc_port)
+                .startup_seeding(startup_seeding(seeds));
+
+            if let Some(checkpoint) = checkpoint {
+                builder = builder.checkpoint(checkpoint);
+            }
+            if let Some(fullnode_url) = fullnode_url {
+                let url = Url::parse(&fullnode_url)
+                    .with_context(|| format!("invalid fullnode URL '{}'", fullnode_url))?;
+                builder = builder.fullnode_url(url);
+            }
+            if let Some(data_dir) = data_dir {
+                builder = builder.data_dir(data_dir);
+            }
+
+            let node = ForkingNode::start(builder.build()?).await?;
+            node.wait().await?;
+        }
+        Commands::Status { server_url } => {
+            let status = client_from_server_url(&server_url)?.status().await?;
+            println!("Checkpoint: {}", status.checkpoint);
+            println!("Epoch: {}", status.epoch);
+            println!("Clock timestamp (ms): {}", status.clock_timestamp_ms);
+        }
+    }
+
+    Ok(())
+}

--- a/crates/sui-forking/src/network.rs
+++ b/crates/sui-forking/src/network.rs
@@ -1,0 +1,289 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{Result, anyhow};
+use sui_data_store::{
+    Node,
+    node::{
+        DEVNET_GQL_URL, DEVNET_RPC_URL, MAINNET_GQL_URL, MAINNET_RPC_URL, TESTNET_GQL_URL,
+        TESTNET_RPC_URL,
+    },
+};
+use sui_types::supported_protocol_versions::Chain;
+use url::Url;
+
+/// Parsed network selection for `sui-forking`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum ForkNetwork {
+    Mainnet,
+    Testnet,
+    Devnet,
+    Custom(String),
+}
+
+impl ForkNetwork {
+    /// Parse the CLI `--network` argument.
+    ///
+    /// Accepted values:
+    /// - `mainnet`, `testnet`, `devnet`
+    /// - any full `http` or `https` URL (treated as custom GraphQL endpoint)
+    pub(crate) fn parse(value: &str) -> Result<Self> {
+        let value = value.trim();
+        if value.is_empty() {
+            return Err(anyhow!("network cannot be empty"));
+        }
+
+        match value.to_ascii_lowercase().as_str() {
+            "mainnet" => Ok(Self::Mainnet),
+            "testnet" => Ok(Self::Testnet),
+            "devnet" => Ok(Self::Devnet),
+            _ => validate_http_url("network", value)
+                .map(|()| Self::Custom(value.to_string()))
+                .map_err(|e| anyhow!("invalid network value '{value}': {e}")),
+        }
+    }
+
+    /// Return the protocol config chain override.
+    pub(crate) fn protocol_chain(&self) -> Chain {
+        match self {
+            Self::Mainnet => Chain::Mainnet,
+            Self::Testnet => Chain::Testnet,
+            Self::Devnet | Self::Custom(_) => Chain::Unknown,
+        }
+    }
+
+    /// Return the GraphQL endpoint URL used for network reads.
+    pub(crate) fn gql_endpoint(&self) -> &str {
+        match self {
+            Self::Mainnet => MAINNET_GQL_URL,
+            Self::Testnet => TESTNET_GQL_URL,
+            Self::Devnet => DEVNET_GQL_URL,
+            Self::Custom(url) => url.as_str(),
+        }
+    }
+
+    /// Return the fullnode RPC endpoint for checkpoint/object gRPC reads.
+    ///
+    /// - `mainnet` / `testnet` / `devnet`: uses defaults unless an override is provided.
+    /// - custom GraphQL network: requires `fullnode_url`.
+    pub(crate) fn resolve_fullnode_endpoint(&self, fullnode_url: Option<&str>) -> Result<String> {
+        let override_url = fullnode_url.and_then(|url| {
+            let trimmed = url.trim();
+            (!trimmed.is_empty()).then_some(trimmed)
+        });
+
+        if let Some(url) = override_url {
+            validate_http_url("fullnode URL", url)?;
+            return Ok(url.to_string());
+        }
+
+        match self {
+            Self::Mainnet => Ok(MAINNET_RPC_URL.to_string()),
+            Self::Testnet => Ok(TESTNET_RPC_URL.to_string()),
+            Self::Devnet => Ok(DEVNET_RPC_URL.to_string()),
+            Self::Custom(_) => Err(anyhow!(
+                "--fullnode-url is required when --network is a custom GraphQL URL"
+            )),
+        }
+    }
+
+    /// Return the backing data-store node for this network.
+    pub(crate) fn node(&self) -> Node {
+        match self {
+            Self::Mainnet => Node::Mainnet,
+            Self::Testnet => Node::Testnet,
+            Self::Devnet => Node::Devnet,
+            Self::Custom(url) => Node::Custom(url.clone()),
+        }
+    }
+
+    /// Human-readable label for logging.
+    pub(crate) fn display_name(&self) -> &str {
+        match self {
+            Self::Mainnet => "mainnet",
+            Self::Testnet => "testnet",
+            Self::Devnet => "devnet",
+            Self::Custom(url) => url.as_str(),
+        }
+    }
+
+    /// Cache path component under `forking/<component>/...`.
+    pub(crate) fn cache_path_component(&self) -> String {
+        match self {
+            Self::Mainnet => "mainnet".to_string(),
+            Self::Testnet => "testnet".to_string(),
+            Self::Devnet => "devnet".to_string(),
+            Self::Custom(url) => {
+                let sanitized = sanitize_cache_path_component(url);
+                if sanitized.is_empty() {
+                    "custom_url".to_string()
+                } else {
+                    format!("custom_{sanitized}")
+                }
+            }
+        }
+    }
+}
+
+fn sanitize_cache_path_component(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    let mut prev_is_underscore = false;
+    for ch in value.to_ascii_lowercase().chars() {
+        if ch.is_ascii_lowercase() || ch.is_ascii_digit() {
+            out.push(ch);
+            prev_is_underscore = false;
+        } else if !prev_is_underscore {
+            out.push('_');
+            prev_is_underscore = true;
+        }
+    }
+    out.trim_matches('_').to_string()
+}
+
+fn validate_http_url(field_name: &str, value: &str) -> Result<()> {
+    let parsed = Url::parse(value)
+        .map_err(|e| anyhow!("expected mainnet/testnet/devnet or a full http(s) URL ({e})"))?;
+    match parsed.scheme() {
+        "http" | "https" => Ok(()),
+        scheme => Err(anyhow!(
+            "unsupported URL scheme '{scheme}' for {field_name}; expected http or https"
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ForkNetwork, sanitize_cache_path_component};
+
+    #[test]
+    fn parses_known_network_keywords() {
+        assert_eq!(ForkNetwork::parse("mainnet").unwrap(), ForkNetwork::Mainnet);
+        assert_eq!(ForkNetwork::parse("testnet").unwrap(), ForkNetwork::Testnet);
+        assert_eq!(ForkNetwork::parse("devnet").unwrap(), ForkNetwork::Devnet);
+    }
+
+    #[test]
+    fn parses_custom_graphql_url_without_rewriting() {
+        let url = "https://example.com/custom/graphql";
+        let network = ForkNetwork::parse(url).unwrap();
+        assert_eq!(network.gql_endpoint(), url);
+    }
+
+    #[test]
+    fn rejects_invalid_non_url_custom_values() {
+        let err = ForkNetwork::parse("not-a-network").unwrap_err().to_string();
+        assert!(err.contains("expected mainnet/testnet/devnet"));
+    }
+
+    #[test]
+    fn rejects_non_http_scheme_custom_values() {
+        let err = ForkNetwork::parse("ws://example.com/graphql")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("unsupported URL scheme"));
+    }
+
+    #[test]
+    fn resolves_default_fullnode_url_for_known_networks() {
+        assert_eq!(
+            ForkNetwork::Mainnet
+                .resolve_fullnode_endpoint(None)
+                .unwrap(),
+            "https://fullnode.mainnet.sui.io:443"
+        );
+        assert_eq!(
+            ForkNetwork::Testnet
+                .resolve_fullnode_endpoint(None)
+                .unwrap(),
+            "https://fullnode.testnet.sui.io:443"
+        );
+        assert_eq!(
+            ForkNetwork::Devnet.resolve_fullnode_endpoint(None).unwrap(),
+            "https://fullnode.devnet.sui.io:443"
+        );
+    }
+
+    #[test]
+    fn requires_fullnode_url_for_custom_network() {
+        let network = ForkNetwork::parse("https://example.com/graphql").unwrap();
+        let err = network
+            .resolve_fullnode_endpoint(None)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("--fullnode-url is required"));
+    }
+
+    #[test]
+    fn accepts_override_fullnode_url() {
+        let network = ForkNetwork::Mainnet;
+        assert_eq!(
+            network
+                .resolve_fullnode_endpoint(Some("https://my-rpc.example.com:443"))
+                .unwrap(),
+            "https://my-rpc.example.com:443"
+        );
+    }
+
+    #[test]
+    fn cache_path_component_for_known_networks_is_stable() {
+        assert_eq!(ForkNetwork::Mainnet.cache_path_component(), "mainnet");
+        assert_eq!(ForkNetwork::Testnet.cache_path_component(), "testnet");
+        assert_eq!(ForkNetwork::Devnet.cache_path_component(), "devnet");
+    }
+
+    #[test]
+    fn custom_cache_path_component_is_sanitized_and_deterministic() {
+        let network =
+            ForkNetwork::parse("HTTPS://GraphQL.DevNet.Sui.IO/graphql?foo=bar&&baz=1").unwrap();
+        assert_eq!(
+            network.cache_path_component(),
+            "custom_https_graphql_devnet_sui_io_graphql_foo_bar_baz_1"
+        );
+    }
+
+    #[test]
+    fn sanitization_output_is_valid_for_edge_cases() {
+        let inputs = [
+            "",
+            "mainnet",
+            "__already__underscored__",
+            "  leading and trailing spaces  ",
+            "HTTPS://GraphQL.DevNet.Sui.IO/graphql?foo=bar&&baz=1",
+            "!!!###",
+            "a---b___c...d",
+            "MiXeD-Case_123",
+            "éxámplê🙂url",
+        ];
+
+        for input in inputs {
+            let output = sanitize_cache_path_component(input);
+            assert!(
+                output
+                    .chars()
+                    .all(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '_')
+            );
+            assert!(!output.starts_with('_'));
+            assert!(!output.ends_with('_'));
+            assert!(!output.contains("__"));
+        }
+    }
+
+    #[test]
+    fn sanitization_is_idempotent_for_edge_cases() {
+        let inputs = [
+            "",
+            "a",
+            "A_B-C",
+            "__x__",
+            "https://example.com/graphql?x=1&&y=2",
+            "Σui🙂",
+            "abc_123_def",
+        ];
+
+        for input in inputs {
+            let once = sanitize_cache_path_component(input);
+            let twice = sanitize_cache_path_component(&once);
+            assert_eq!(once, twice);
+        }
+    }
+}

--- a/crates/sui-forking/src/seeds.rs
+++ b/crates/sui-forking/src/seeds.rs
@@ -1,0 +1,135 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{Context, Result};
+use clap::Args;
+use tracing::info;
+
+use sui_data_store::{ObjectKey, VersionQuery};
+use sui_types::base_types::ObjectID;
+
+use crate::store::ForkingStore;
+
+#[derive(Args, Clone, Debug, Default)]
+pub struct StartupSeeds {
+    /// Explicit object IDs to prefetch at startup.
+    #[clap(long, value_delimiter = ',')]
+    pub objects: Vec<ObjectID>,
+}
+
+impl StartupSeeds {
+    fn collect_missing_object_ids<T>(
+        requested_object_ids: &[ObjectID],
+        fetched_objects: &[Option<T>],
+    ) -> Vec<ObjectID> {
+        requested_object_ids
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, object_id)| {
+                if matches!(fetched_objects.get(idx), Some(Some(_))) {
+                    None
+                } else {
+                    Some(*object_id)
+                }
+            })
+            .collect()
+    }
+
+    /// Prefetch explicit startup objects and fail startup if any requested object is missing.
+    pub async fn prefetch_startup_objects(
+        &self,
+        store: &ForkingStore,
+        startup_checkpoint: u64,
+    ) -> Result<()> {
+        if self.objects.is_empty() {
+            return Ok(());
+        }
+
+        info!(
+            startup_checkpoint,
+            object_count = self.objects.len(),
+            "Prefetching explicit startup objects"
+        );
+
+        let object_keys: Vec<_> = self
+            .objects
+            .iter()
+            .copied()
+            .map(|object_id| ObjectKey {
+                object_id,
+                version_query: VersionQuery::AtCheckpoint(startup_checkpoint),
+            })
+            .collect();
+
+        let fetched_objects = store
+            .get_objects(&object_keys)
+            .context("Failed to prefetch startup objects from object store")?;
+
+        let requested_ids = object_keys
+            .iter()
+            .map(|key| key.object_id)
+            .collect::<Vec<_>>();
+        let missing_objects = Self::collect_missing_object_ids(&requested_ids, &fetched_objects);
+        if !missing_objects.is_empty() {
+            let missing = missing_objects
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join(", ");
+            anyhow::bail!(
+                "Failed to prefetch explicit startup objects at checkpoint {}. Missing object IDs: {}",
+                startup_checkpoint,
+                missing
+            );
+        }
+
+        let fetched = fetched_objects.iter().flatten().count();
+        info!(
+            startup_checkpoint,
+            requested = object_keys.len(),
+            fetched,
+            "Startup object prefetch completed"
+        );
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+    use sui_types::base_types::ObjectID;
+
+    use super::StartupSeeds;
+
+    #[derive(Parser, Debug)]
+    struct SeedCli {
+        #[clap(flatten)]
+        seeds: StartupSeeds,
+    }
+
+    fn parse_object_id(value: &str) -> ObjectID {
+        ObjectID::from_hex_literal(value).expect("valid object id")
+    }
+
+    #[test]
+    fn collects_missing_object_ids() {
+        let id1 = parse_object_id("0x11");
+        let id2 = parse_object_id("0x22");
+        let id3 = parse_object_id("0x33");
+        let requested = vec![id1, id2, id3];
+        let fetched = vec![Some(()), None, Some(())];
+        let missing = StartupSeeds::collect_missing_object_ids(&requested, &fetched);
+        assert_eq!(missing, vec![id2]);
+    }
+
+    #[test]
+    fn clap_parses_explicit_object_ids() {
+        let parsed = SeedCli::try_parse_from(["seed-cli", "--objects", "0x5,0x6"])
+            .expect("objects should parse");
+        assert_eq!(
+            parsed.seeds.objects,
+            vec![parse_object_id("0x5"), parse_object_id("0x6")]
+        );
+    }
+}

--- a/crates/sui-forking/src/server/data_store_setup.rs
+++ b/crates/sui-forking/src/server/data_store_setup.rs
@@ -1,0 +1,376 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{path::Path, sync::Arc};
+
+use anyhow::Context as _;
+use tracing::info;
+
+use sui_data_store::{
+    CheckpointStore as _, CheckpointStoreWriter as _, FullCheckpointData, SetupStore as _,
+    stores::{DataStore, FileSystemStore, InMemoryStore, ReadThroughStore, WriteThroughStore},
+};
+use sui_rpc_api::client::Client as RpcClient;
+use sui_types::supported_protocol_versions::Chain;
+
+use crate::{
+    network::ForkNetwork,
+    store::{DiskThenGraphqlObjects, ForkDataStore, HotMemFs, HotObjects},
+};
+
+pub(super) struct DataStoreSetup {
+    filesystem: Arc<FileSystemStore>,
+    store: ForkDataStore,
+    fullnode_endpoint: String,
+}
+
+impl DataStoreSetup {
+    pub(super) fn filesystem(&self) -> &Arc<FileSystemStore> {
+        &self.filesystem
+    }
+
+    pub(super) fn store(&self) -> &ForkDataStore {
+        &self.store
+    }
+
+    pub(super) fn into_parts(self) -> (Arc<FileSystemStore>, ForkDataStore) {
+        (self.filesystem, self.store)
+    }
+
+    pub(super) fn determine_startup_checkpoint(
+        &self,
+        checkpoint: Option<u64>,
+        forked_at_checkpoint: u64,
+    ) -> Result<u64, anyhow::Error> {
+        let Some(requested_checkpoint) = checkpoint else {
+            return Ok(forked_at_checkpoint);
+        };
+
+        let local_latest = self
+            .store
+            .get_latest_checkpoint()
+            .context("failed to inspect local checkpoint cache")?;
+
+        match local_latest {
+            None => Ok(requested_checkpoint),
+            Some(checkpoint_data) => {
+                let local_latest_sequence = checkpoint_data.summary.sequence_number;
+                if local_latest_sequence < requested_checkpoint {
+                    anyhow::bail!(
+                        "local fork cache for checkpoint {} is stale: latest local checkpoint is {}",
+                        requested_checkpoint,
+                        local_latest_sequence
+                    );
+                }
+                Ok(local_latest_sequence)
+            }
+        }
+    }
+
+    pub(super) async fn load_startup_checkpoint_data(
+        &self,
+        startup_checkpoint: u64,
+    ) -> Result<FullCheckpointData, anyhow::Error> {
+        match self
+            .store
+            .get_checkpoint_by_sequence_number(startup_checkpoint)
+            .context("failed to read startup checkpoint from local checkpoint store")?
+        {
+            Some(checkpoint) => Ok(checkpoint),
+            None => {
+                let checkpoint = self.fetch_checkpoint_from_grpc(startup_checkpoint).await?;
+                self.store.write_checkpoint(&checkpoint).with_context(|| {
+                    format!(
+                        "failed to persist startup checkpoint {} into local stores",
+                        startup_checkpoint
+                    )
+                })?;
+                Ok(checkpoint)
+            }
+        }
+    }
+
+    #[cfg(test)]
+    async fn load_startup_checkpoint_data_with<F, Fut>(
+        &self,
+        startup_checkpoint: u64,
+        fetcher: F,
+    ) -> Result<FullCheckpointData, anyhow::Error>
+    where
+        F: FnOnce(u64) -> Fut,
+        Fut: Future<Output = Result<FullCheckpointData, anyhow::Error>>,
+    {
+        match self
+            .store
+            .get_checkpoint_by_sequence_number(startup_checkpoint)
+            .context("failed to read startup checkpoint from local checkpoint store")?
+        {
+            Some(checkpoint) => Ok(checkpoint),
+            None => {
+                let checkpoint = fetcher(startup_checkpoint).await?;
+                self.store.write_checkpoint(&checkpoint).with_context(|| {
+                    format!(
+                        "failed to persist startup checkpoint {} into local stores",
+                        startup_checkpoint
+                    )
+                })?;
+                Ok(checkpoint)
+            }
+        }
+    }
+
+    pub(super) async fn fetch_checkpoint_from_grpc(
+        &self,
+        sequence: u64,
+    ) -> Result<FullCheckpointData, anyhow::Error> {
+        let mut client = RpcClient::new(self.fullnode_endpoint.clone()).with_context(|| {
+            format!(
+                "failed to construct fullnode gRPC client for {}",
+                self.fullnode_endpoint
+            )
+        })?;
+        client.get_full_checkpoint(sequence).await.with_context(|| {
+            format!(
+                "failed to fetch checkpoint {} from fullnode gRPC endpoint {}",
+                sequence, self.fullnode_endpoint
+            )
+        })
+    }
+}
+
+pub(super) fn build_data_store_setup(
+    fork_network: &ForkNetwork,
+    fullnode_endpoint: &str,
+    at_checkpoint: u64,
+    data_ingestion_path: &Path,
+    version: &'static str,
+) -> Result<DataStoreSetup, anyhow::Error> {
+    let forking_path = format!(
+        "forking/{}/forked_at_checkpoint_{}",
+        fork_network.cache_path_component(),
+        at_checkpoint
+    );
+
+    let node = fork_network.node();
+    let fs_base_path = data_ingestion_path.join(forking_path);
+    let filesystem = Arc::new(
+        FileSystemStore::new_with_path(node.clone(), fs_base_path.clone())
+            .context("failed to initialize file-system cache store")?,
+    );
+    let memory = Arc::new(InMemoryStore::new(node.clone()));
+    let graphql =
+        Arc::new(DataStore::new(node, version).context("failed to initialize GraphQL data store")?);
+
+    let hot_mem_fs: Arc<HotMemFs> =
+        Arc::new(WriteThroughStore::new(memory.clone(), filesystem.clone()));
+    let disk_then_graphql_objects: Arc<DiskThenGraphqlObjects> =
+        Arc::new(ReadThroughStore::new(filesystem.clone(), graphql));
+    let hot_objects: Arc<HotObjects> =
+        Arc::new(WriteThroughStore::new(memory, disk_then_graphql_objects));
+
+    info!("Fs base path {:?}", fs_base_path.display());
+    match fork_network {
+        ForkNetwork::Mainnet => {
+            hot_mem_fs
+                .setup(Some(Chain::Mainnet.as_str().to_string()))
+                .context("failed to initialize local mainnet node mapping")?;
+        }
+        ForkNetwork::Testnet => {
+            hot_mem_fs
+                .setup(Some(Chain::Testnet.as_str().to_string()))
+                .context("failed to initialize local testnet node mapping")?;
+        }
+        ForkNetwork::Devnet | ForkNetwork::Custom(_) => {
+            let chain_id = hot_objects
+                .setup(None)
+                .context("failed to initialize dynamic chain identifier mapping")?
+                .with_context(|| {
+                    format!(
+                        "missing chain identifier while setting up {} data store",
+                        fork_network.display_name()
+                    )
+                })?;
+            info!(
+                "Resolved dynamic chain identifier for {}: {}",
+                fork_network.display_name(),
+                chain_id
+            );
+        }
+    }
+
+    let store = ForkDataStore::new(
+        hot_mem_fs.clone(),
+        hot_mem_fs.clone(),
+        hot_objects,
+        hot_mem_fs,
+    );
+
+    Ok(DataStoreSetup {
+        filesystem,
+        store,
+        fullnode_endpoint: fullnode_endpoint.to_string(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    use sui_data_store::{CheckpointStore as _, CheckpointStoreWriter as _};
+    use sui_types::test_checkpoint_data_builder::TestCheckpointBuilder;
+    use tempfile::TempDir;
+
+    use super::*;
+
+    fn sample_checkpoint(sequence: u64) -> FullCheckpointData {
+        TestCheckpointBuilder::new(sequence)
+            .start_transaction(1)
+            .create_owned_object(42)
+            .finish_transaction()
+            .build_checkpoint()
+    }
+
+    fn build_test_setup(tempdir: &TempDir) -> Result<DataStoreSetup, anyhow::Error> {
+        build_data_store_setup(
+            &ForkNetwork::Testnet,
+            "http://127.0.0.1:9000",
+            11,
+            tempdir.path(),
+            "test-version",
+        )
+    }
+
+    #[test]
+    fn determine_startup_checkpoint_uses_requested_when_local_cache_is_empty() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let setup = build_test_setup(&tempdir).expect("setup");
+
+        assert_eq!(
+            setup
+                .determine_startup_checkpoint(Some(17), 11)
+                .expect("startup checkpoint"),
+            17
+        );
+        assert_eq!(
+            setup
+                .determine_startup_checkpoint(None, 11)
+                .expect("default checkpoint"),
+            11
+        );
+    }
+
+    #[test]
+    fn determine_startup_checkpoint_resumes_from_local_latest() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let setup = build_test_setup(&tempdir).expect("setup");
+        let checkpoint = sample_checkpoint(19);
+
+        setup
+            .store()
+            .write_checkpoint(&checkpoint)
+            .expect("write checkpoint");
+
+        assert_eq!(
+            setup
+                .determine_startup_checkpoint(Some(11), 11)
+                .expect("resumed checkpoint"),
+            19
+        );
+    }
+
+    #[test]
+    fn determine_startup_checkpoint_rejects_stale_local_cache() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let setup = build_test_setup(&tempdir).expect("setup");
+        let checkpoint = sample_checkpoint(13);
+
+        setup
+            .store()
+            .write_checkpoint(&checkpoint)
+            .expect("write checkpoint");
+
+        let err = setup
+            .determine_startup_checkpoint(Some(17), 11)
+            .expect_err("stale cache should fail");
+        assert!(
+            err.to_string()
+                .contains("local fork cache for checkpoint 17 is stale")
+        );
+    }
+
+    #[tokio::test]
+    async fn load_startup_checkpoint_uses_local_cache_without_fetching() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let setup = build_test_setup(&tempdir).expect("setup");
+        let checkpoint = sample_checkpoint(21);
+        let fetch_calls = Arc::new(AtomicUsize::new(0));
+
+        setup
+            .store()
+            .write_checkpoint(&checkpoint)
+            .expect("write checkpoint");
+
+        let loaded = setup
+            .load_startup_checkpoint_data_with(21, {
+                let fetch_calls = fetch_calls.clone();
+                move |_| {
+                    let fetch_calls = fetch_calls.clone();
+                    async move {
+                        fetch_calls.fetch_add(1, Ordering::Relaxed);
+                        panic!("fetcher should not be called for local checkpoint hits");
+                    }
+                }
+            })
+            .await
+            .expect("load checkpoint");
+
+        assert_eq!(loaded.summary.sequence_number, 21);
+        assert_eq!(fetch_calls.load(Ordering::Relaxed), 0);
+    }
+
+    #[tokio::test]
+    async fn load_startup_checkpoint_fetches_and_persists_missing_checkpoint() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let setup = build_test_setup(&tempdir).expect("setup");
+        let checkpoint = sample_checkpoint(23);
+        let fetch_calls = Arc::new(AtomicUsize::new(0));
+
+        let loaded = setup
+            .load_startup_checkpoint_data_with(23, {
+                let checkpoint = checkpoint.clone();
+                let fetch_calls = fetch_calls.clone();
+                move |sequence| {
+                    let checkpoint = checkpoint.clone();
+                    let fetch_calls = fetch_calls.clone();
+                    async move {
+                        fetch_calls.fetch_add(1, Ordering::Relaxed);
+                        assert_eq!(sequence, 23);
+                        Ok(checkpoint)
+                    }
+                }
+            })
+            .await
+            .expect("load checkpoint");
+
+        assert_eq!(loaded.summary.sequence_number, 23);
+        assert_eq!(fetch_calls.load(Ordering::Relaxed), 1);
+
+        let cached = setup
+            .store()
+            .get_checkpoint_by_sequence_number(23)
+            .expect("checkpoint read")
+            .expect("checkpoint persisted");
+        assert_eq!(cached.summary.sequence_number, 23);
+
+        let loaded_again = setup
+            .load_startup_checkpoint_data_with(23, |_| async {
+                panic!("persisted checkpoint should not be fetched twice");
+            })
+            .await
+            .expect("load checkpoint again");
+        assert_eq!(loaded_again.summary.sequence_number, 23);
+    }
+}

--- a/crates/sui-forking/src/server/handlers.rs
+++ b/crates/sui-forking/src/server/handlers.rs
@@ -1,0 +1,45 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use axum::{Json, extract::State, response::IntoResponse};
+
+use crate::api::types::{ApiResponse, ForkingStatus};
+
+/// The shared state for the forking server.
+pub(super) struct AppState {
+    pub context: crate::context::Context,
+}
+
+impl AppState {
+    pub async fn new(context: crate::context::Context) -> Self {
+        Self { context }
+    }
+}
+
+pub(super) async fn health() -> &'static str {
+    "OK"
+}
+
+pub(super) async fn get_status(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    let sim = state.context.simulacrum.read().await;
+    let store = sim.store();
+
+    let checkpoint = store
+        .get_highest_checkpint()
+        .map(|c| c.sequence_number)
+        .unwrap_or(0);
+    let epoch = store.get_highest_checkpint().map(|c| c.epoch()).unwrap_or(0);
+    let clock_timestamp_ms = store.get_clock().timestamp_ms();
+
+    Json(ApiResponse {
+        success: true,
+        data: Some(ForkingStatus {
+            checkpoint,
+            epoch,
+            clock_timestamp_ms,
+        }),
+        error: None,
+    })
+}

--- a/crates/sui-forking/src/server/mod.rs
+++ b/crates/sui-forking/src/server/mod.rs
@@ -1,0 +1,245 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+mod data_store_setup;
+mod handlers;
+mod setup;
+
+use std::{net::SocketAddr, path::PathBuf, str::FromStr, sync::Arc};
+
+use anyhow::{Context as _, Result};
+use axum::{
+    Router,
+    routing::get,
+};
+use prometheus::Registry;
+use tokio::sync::{RwLock, oneshot};
+use tower_http::cors::CorsLayer;
+use tracing::{info, warn};
+
+use sui_futures::service::Service;
+use sui_rpc::proto::sui::rpc::v2::{
+    ledger_service_server::LedgerServiceServer,
+    subscription_service_server::SubscriptionServiceServer,
+};
+use sui_rpc::proto::sui::rpc::v2::{
+    state_service_server::StateServiceServer,
+    transaction_execution_service_server::TransactionExecutionServiceServer,
+};
+use sui_rpc_api::subscription::SubscriptionService as RpcSubscriptionService;
+use sui_types::{
+    digests::{
+        ChainIdentifier, CheckpointDigest, get_mainnet_chain_identifier,
+        get_testnet_chain_identifier,
+    },
+    supported_protocol_versions::Chain,
+};
+
+use crate::api::endpoints;
+use crate::grpc::{
+    RpcArgs as GrpcArgs, RpcService as GrpcRpcService, TlsArgs as GrpcTlsArgs,
+    ledger_service::ForkingLedgerService, state_service::ForkingStateService,
+    subscription_service::ForkingSubscriptionService,
+    transaction_execution_service::ForkingTransactionExecutionService,
+};
+use crate::{graphql::GraphQLClient, network::ForkNetwork, seeds::StartupSeeds};
+
+use self::data_store_setup::build_data_store_setup;
+use self::handlers::{
+    AppState, get_status, health,
+};
+use self::setup::{SimulacrumSetup, setup_simulacrum};
+
+/// Start the forking server
+pub(crate) async fn start_server(
+    startup_seeds: StartupSeeds,
+    fork_network: ForkNetwork,
+    checkpoint: Option<u64>,
+    fullnode_url: Option<String>,
+    host: String,
+    server_port: u16,
+    rpc_port: u16,
+    data_ingestion_path: PathBuf,
+    version: &'static str,
+    shutdown_receiver: Option<oneshot::Receiver<()>>,
+    ready_sender: Option<oneshot::Sender<()>>,
+) -> Result<()> {
+    let fullnode_endpoint = fork_network
+        .resolve_fullnode_endpoint(fullnode_url.as_deref())
+        .context("failed to resolve fullnode RPC endpoint")?;
+    let client = GraphQLClient::new(fork_network.gql_endpoint().to_string());
+    let (forked_at_checkpoint, protocol_version) = if let Some(cp) = checkpoint {
+        (cp, client.fetch_protocol_version(Some(cp)).await?)
+    } else {
+        client
+            .fetch_latest_checkpoint_and_protocol_version()
+            .await?
+    };
+    let data_store_setup = build_data_store_setup(
+        &fork_network,
+        &fullnode_endpoint,
+        forked_at_checkpoint,
+        &data_ingestion_path,
+        version,
+    )?;
+    let startup_checkpoint =
+        data_store_setup.determine_startup_checkpoint(checkpoint, forked_at_checkpoint)?;
+
+    let is_resuming_existing_fork =
+        checkpoint.is_some() && startup_checkpoint != forked_at_checkpoint;
+    if is_resuming_existing_fork {
+        println!(
+            "Resuming {} forked network, current checkpoint: {}, forked at checkpoint: {}, protocol version {}",
+            fork_network.display_name(),
+            startup_checkpoint,
+            forked_at_checkpoint,
+            protocol_version
+        );
+    } else {
+        println!(
+            "Starting from {} at checkpoint {} with protocol version {}",
+            fork_network.display_name(),
+            forked_at_checkpoint,
+            protocol_version
+        );
+    }
+
+    let SimulacrumSetup { simulacrum } = setup_simulacrum(
+        forked_at_checkpoint,
+        startup_checkpoint,
+        &startup_seeds,
+        protocol_version,
+        fork_network.protocol_chain(),
+        data_store_setup,
+    )
+    .await?;
+    let simulacrum = Arc::new(RwLock::new(simulacrum));
+
+    let registry = Registry::new_custom(Some("sui_forking".into()), None)
+        .context("Failed to create Prometheus registry.")?;
+    let (checkpoint_sender, subscription_service_handle) = RpcSubscriptionService::build(&registry);
+
+    let chain_id = resolve_chain_identifier(&fork_network, &client).await?;
+    let context = crate::context::Context {
+        simulacrum: simulacrum.clone(),
+        subscription_service_handle,
+        checkpoint_sender,
+        chain_id,
+    };
+
+    let grpc = start_grpc_services(context.clone(), version, &registry, rpc_port).await?;
+    let grpc_handle = tokio::spawn(grpc.main());
+
+    let state = Arc::new(AppState::new(context.clone()).await);
+
+    let app = Router::new()
+        .route(endpoints::HEALTH.path, get(health))
+        .route(endpoints::STATUS.path, get(get_status))
+        .layer(CorsLayer::permissive())
+        .with_state(state);
+
+    let addr: SocketAddr = format!("{}:{}", host, server_port).parse()?;
+    println!("Forking server listening on {}", addr);
+    println!("Ready to accept requests");
+
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+    if let Some(ready_sender) = ready_sender {
+        let _ = ready_sender.send(());
+    }
+
+    let shutdown_signal = async move {
+        match shutdown_receiver {
+            Some(receiver) => {
+                let ctrl_c = async {
+                    match tokio::signal::ctrl_c().await {
+                        Ok(()) => {
+                            info!("\nReceived CTRL+C, shutting down gracefully...");
+                        }
+                        Err(err) => {
+                            warn!("Failed to install CTRL+C signal handler: {err}");
+                            std::future::pending::<()>().await;
+                        }
+                    }
+                };
+
+                tokio::select! {
+                    _ = receiver => {
+                        info!("received programmatic shutdown signal");
+                    }
+                    _ = ctrl_c => {
+                    }
+                }
+            }
+            None => {
+                if let Err(err) = tokio::signal::ctrl_c().await {
+                    warn!("Failed to install CTRL+C signal handler: {err}");
+                    return;
+                }
+                info!("\nReceived CTRL+C, shutting down gracefully...");
+            }
+        }
+    };
+
+    // Serve with graceful shutdown
+    axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown_signal)
+        .await?;
+
+    // Abort the spawned tasks when the server shuts down
+    grpc_handle.abort();
+
+    info!("Server shutdown complete");
+
+    Ok(())
+}
+
+async fn resolve_chain_identifier(
+    fork_network: &ForkNetwork,
+    client: &GraphQLClient,
+) -> Result<ChainIdentifier> {
+    match fork_network.protocol_chain() {
+        Chain::Mainnet => Ok(get_mainnet_chain_identifier()),
+        Chain::Testnet => Ok(get_testnet_chain_identifier()),
+        Chain::Unknown => {
+            let chain_identifier = client.fetch_chain_identifier().await?;
+            let digest = CheckpointDigest::from_str(&chain_identifier).with_context(|| {
+                format!(
+                    "invalid chainIdentifier '{}' returned by {}",
+                    chain_identifier,
+                    client.endpoint()
+                )
+            })?;
+            Ok(ChainIdentifier::from(digest))
+        }
+    }
+}
+
+/// Start the gRPC services for the forking server
+async fn start_grpc_services(
+    context: crate::context::Context,
+    version: &'static str,
+    registry: &Registry,
+    rpc_port: u16,
+) -> Result<Service, anyhow::Error> {
+    let grpc_listen_address = SocketAddr::from(([127, 0, 0, 1], rpc_port));
+    println!("RPC listening on {}", grpc_listen_address);
+
+    let grpc_args = GrpcArgs {
+        rpc_listen_address: grpc_listen_address,
+        tls: GrpcTlsArgs::default(),
+    };
+
+    let subscription_service = ForkingSubscriptionService::new(context.clone());
+    let ledger_service = ForkingLedgerService::new(context.clone());
+    let state_service = ForkingStateService::new(context.clone());
+    let tx_execution_service = ForkingTransactionExecutionService::new(context.clone());
+    let grpc = GrpcRpcService::new(grpc_args, version, registry)
+        .await?
+        .register_encoded_file_descriptor_set(sui_rpc::proto::sui::rpc::v2::FILE_DESCRIPTOR_SET)
+        .add_service(LedgerServiceServer::new(ledger_service))
+        .add_service(SubscriptionServiceServer::new(subscription_service))
+        .add_service(StateServiceServer::new(state_service))
+        .add_service(TransactionExecutionServiceServer::new(tx_execution_service));
+    let handle = grpc.run().await?;
+    Ok(handle)
+}

--- a/crates/sui-forking/src/server/setup.rs
+++ b/crates/sui-forking/src/server/setup.rs
@@ -1,0 +1,434 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::num::NonZeroUsize;
+
+use anyhow::{Context as _, anyhow};
+use rand::rngs::OsRng;
+use tracing::{info, warn};
+
+use simulacrum::{Simulacrum, store::in_mem_store::KeyStore};
+use sui_data_store::{FullCheckpointData, ObjectKey, ObjectStoreWriter as _, VersionQuery};
+use sui_swarm_config::network_config::NetworkConfig;
+use sui_swarm_config::network_config_builder::ConfigBuilder;
+use sui_types::{
+    accumulator_root::get_accumulator_root_obj_initial_shared_version,
+    message_envelope::Envelope,
+    messages_checkpoint::VerifiedCheckpoint,
+    object::Object,
+    sui_system_state::{SuiSystemState, SuiSystemStateTrait},
+    supported_protocol_versions::Chain,
+    transaction::{TransactionDataAPI, TransactionKind},
+};
+
+use crate::seeds::StartupSeeds;
+use crate::store::ForkingStore;
+
+use super::data_store_setup::DataStoreSetup;
+
+/// Runtime artifacts prepared by the server setup path.
+pub(super) struct SimulacrumSetup {
+    /// Local simulacrum initialized from the selected checkpoint.
+    pub(super) simulacrum: Simulacrum<OsRng, ForkingStore>,
+}
+
+/// Builds a deterministic single-validator config for local execution.
+fn build_network_config(protocol_version: u64, chain: Chain, rng: &mut OsRng) -> NetworkConfig {
+    ConfigBuilder::new_with_temp_dir()
+        .rng(rng)
+        .with_chain_start_timestamp_ms(0)
+        .deterministic_committee_size(NonZeroUsize::MIN)
+        .with_protocol_version(protocol_version.into())
+        .with_chain_override(chain)
+        .build()
+}
+
+/// Converts full checkpoint data into a verified checkpoint envelope.
+fn build_verified_startup_checkpoint(
+    startup_checkpoint_data: &FullCheckpointData,
+) -> VerifiedCheckpoint {
+    let certified_summary = startup_checkpoint_data.summary.clone();
+    let env_checkpoint = Envelope::new_from_data_and_sig(
+        certified_summary.data().clone(),
+        certified_summary.auth_sig().clone(),
+    );
+    VerifiedCheckpoint::new_unchecked(env_checkpoint)
+}
+
+/// Stores the object in local cache only when it is not already present.
+fn cache_object_if_missing(
+    data_store_setup: &DataStoreSetup,
+    object: Object,
+) -> Result<bool, anyhow::Error> {
+    let object_id = object.id();
+    if data_store_setup
+        .filesystem()
+        .get_object_latest(&object_id)
+        .with_context(|| format!("failed to inspect local object cache for {object_id}"))?
+        .is_some()
+    {
+        return Ok(false);
+    }
+
+    let version: u64 = object.version().into();
+    let object_key = ObjectKey {
+        object_id,
+        version_query: VersionQuery::Version(version),
+    };
+    data_store_setup
+        .store()
+        .write_object(&object_key, object, version)
+        .with_context(|| format!("failed to seed local object {object_id}"))?;
+    Ok(true)
+}
+
+/// Seeds a local gas object from genesis for the first configured validator account.
+fn seed_genesis_faucet_coin(
+    data_store_setup: &DataStoreSetup,
+    genesis_objects: &[Object],
+    local_owner: sui_types::base_types::SuiAddress,
+) -> Result<(), anyhow::Error> {
+    let Some(faucet_coin) = genesis_objects
+        .iter()
+        .filter(|object| object.is_gas_coin())
+        .filter(|object| object.owner.get_address_owner_address().ok() == Some(local_owner))
+        .max_by_key(|object| object.get_coin_value_unsafe())
+        .cloned()
+    else {
+        warn!(
+            local_owner = %local_owner,
+            "No genesis gas coin found for the local validator account"
+        );
+        return Ok(());
+    };
+
+    let faucet_coin_id = faucet_coin.id();
+    let faucet_coin_version = faucet_coin.version().value();
+    let faucet_coin_balance = faucet_coin.get_coin_value_unsafe();
+    if cache_object_if_missing(data_store_setup, faucet_coin)? {
+        info!(
+            local_owner = %local_owner,
+            faucet_coin_id = %faucet_coin_id,
+            faucet_coin_version,
+            faucet_coin_balance,
+            "Seeded local genesis gas coin into fork store"
+        );
+    } else {
+        info!(
+            local_owner = %local_owner,
+            faucet_coin_id = %faucet_coin_id,
+            "Local genesis gas coin already present in fork store"
+        );
+    }
+
+    Ok(())
+}
+
+/// Returns the post-checkpoint system state when the checkpoint itself materializes one.
+fn post_checkpoint_system_state(
+    startup_checkpoint_data: &FullCheckpointData,
+) -> Result<Option<SuiSystemState>, anyhow::Error> {
+    startup_checkpoint_data
+        .epoch_info()
+        .map_err(|err| {
+            anyhow!(
+                "failed to derive post-checkpoint system state from checkpoint {}: {err}",
+                startup_checkpoint_data.summary.sequence_number
+            )
+        })
+        .map(|epoch_info| epoch_info.and_then(|info| info.system_state))
+}
+
+/// Persists the epoch-transition outputs so subsequent object-store reads see the post-checkpoint
+/// system state, not the pre-transition one.
+fn cache_epoch_transition_outputs(
+    data_store_setup: &DataStoreSetup,
+    startup_checkpoint_data: &FullCheckpointData,
+) -> Result<(), anyhow::Error> {
+    if startup_checkpoint_data.summary.end_of_epoch_data.is_none() {
+        return Ok(());
+    }
+
+    let Some(epoch_change_transaction) = startup_checkpoint_data.transactions.iter().find(|tx| {
+        matches!(
+            tx.transaction.kind(),
+            TransactionKind::ChangeEpoch(_) | TransactionKind::EndOfEpochTransaction(_)
+        )
+    }) else {
+        anyhow::bail!(
+            "checkpoint {} is marked end-of-epoch but is missing the epoch-change transaction",
+            startup_checkpoint_data.summary.sequence_number
+        );
+    };
+
+    for object in epoch_change_transaction
+        .output_objects(&startup_checkpoint_data.object_set)
+        .cloned()
+    {
+        let object_id = object.id();
+        let version = object.version().value();
+        let object_key = ObjectKey {
+            object_id,
+            version_query: VersionQuery::AtCheckpoint(
+                startup_checkpoint_data.summary.sequence_number,
+            ),
+        };
+        data_store_setup
+            .store()
+            .write_object(&object_key, object, version)
+            .with_context(|| {
+                format!(
+                    "failed to persist epoch-transition object {object_id} for startup checkpoint {}",
+                    startup_checkpoint_data.summary.sequence_number
+                )
+            })?;
+    }
+
+    Ok(())
+}
+
+/// Builds initial system state from the post-checkpoint state while reusing genesis validators.
+fn build_initial_system_state(
+    startup_checkpoint_data: &FullCheckpointData,
+    store: &ForkingStore,
+    config: &NetworkConfig,
+) -> Result<SuiSystemState, anyhow::Error> {
+    let system_state = match post_checkpoint_system_state(startup_checkpoint_data)? {
+        Some(system_state) => system_state,
+        None => sui_types::sui_system_state::get_sui_system_state(store).map_err(|err| {
+            anyhow!(
+                "failed to read Sui system state after startup checkpoint {}: {err}",
+                startup_checkpoint_data.summary.sequence_number
+            )
+        })?,
+    };
+
+    let validators = match config.genesis.sui_system_object() {
+        SuiSystemState::V1(genesis_inner) => genesis_inner.validators,
+        SuiSystemState::V2(genesis_inner) => genesis_inner.validators,
+        #[cfg(msim)]
+        _ => anyhow::bail!("unsupported genesis system state variant"),
+    };
+
+    match system_state {
+        SuiSystemState::V1(mut inner) => {
+            inner.validators = validators.clone();
+            Ok(SuiSystemState::V1(inner))
+        }
+        SuiSystemState::V2(mut inner) => {
+            inner.validators = validators;
+            Ok(SuiSystemState::V2(inner))
+        }
+        #[cfg(msim)]
+        _ => anyhow::bail!("unsupported system state variant"),
+    }
+}
+
+/// Installs validator override and committee required by local execution.
+fn override_system_validators(store: &mut ForkingStore, initial_sui_system_state: &SuiSystemState) {
+    let validator_set_override = match initial_sui_system_state {
+        SuiSystemState::V1(inner) => inner.validators.clone(),
+        SuiSystemState::V2(inner) => inner.validators.clone(),
+    };
+    store.set_system_state_validator_set_override(validator_set_override);
+
+    let initial_committee = initial_sui_system_state
+        .get_current_epoch_committee()
+        .committee()
+        .clone();
+    store.insert_committee(initial_committee);
+}
+
+/// Constructs a simulacrum from preloaded checkpoint, state, and store.
+fn build_simulacrum(
+    keystore: KeyStore,
+    verified_checkpoint: VerifiedCheckpoint,
+    initial_sui_system_state: SuiSystemState,
+    config: &NetworkConfig,
+    store: ForkingStore,
+    rng: OsRng,
+) -> Result<Simulacrum<OsRng, ForkingStore>, anyhow::Error> {
+    // The mock checkpoint builder relies on the accumulator root object to be present in the store
+    // with the correct initial shared version, so we need to fetch it here and pass it to the
+    // simulacrum. This is needed if protocol config has enabled accumulators
+    // TODO: do we need this if protocol config does not have enabled accumulators?
+    let _acc_initial_shared_version = get_accumulator_root_obj_initial_shared_version(&store)?
+        .ok_or_else(|| anyhow!("Failed to get accumulator root object from store"))?;
+
+    Ok(Simulacrum::new_from_custom_state(
+        keystore,
+        verified_checkpoint,
+        initial_sui_system_state,
+        config,
+        store,
+        rng,
+        // Some(acc_initial_shared_version),
+    ))
+}
+
+/// Prepares simulacrum state and faucet owner for server startup.
+pub(super) async fn setup_simulacrum(
+    forked_at_checkpoint: u64,
+    startup_checkpoint: u64,
+    startup_seeds: &StartupSeeds,
+    protocol_version: u64,
+    chain: Chain,
+    data_store_setup: DataStoreSetup,
+) -> Result<SimulacrumSetup, anyhow::Error> {
+    let mut rng = OsRng;
+    let config = build_network_config(protocol_version, chain, &mut rng);
+    let keystore = KeyStore::from_network_config(&config);
+    let startup_checkpoint_data = data_store_setup
+        .load_startup_checkpoint_data(startup_checkpoint)
+        .await?;
+    cache_epoch_transition_outputs(&data_store_setup, &startup_checkpoint_data)?;
+    let verified_checkpoint = build_verified_startup_checkpoint(&startup_checkpoint_data);
+
+    if let Some((local_owner, _)) = keystore.accounts().next() {
+        if let Err(err) =
+            seed_genesis_faucet_coin(&data_store_setup, config.genesis.objects(), *local_owner)
+        {
+            warn!(
+                local_owner = %local_owner,
+                "Failed to seed local genesis gas coin into fork store: {err}"
+            );
+        }
+    } else {
+        warn!("No local validator account keys available");
+    }
+
+    let (filesystem, store_handles) = data_store_setup.into_parts();
+    let mut store = ForkingStore::new(forked_at_checkpoint, filesystem, store_handles);
+    store.insert_checkpoint(verified_checkpoint.clone());
+    store.insert_checkpoint_contents(startup_checkpoint_data.contents.clone());
+    startup_seeds
+        .prefetch_startup_objects(&store, startup_checkpoint)
+        .await
+        .context("Failed to prefetch startup objects")?;
+
+    let initial_sui_system_state =
+        build_initial_system_state(&startup_checkpoint_data, &store, &config)?;
+    override_system_validators(&mut store, &initial_sui_system_state);
+
+    let simulacrum = build_simulacrum(
+        keystore,
+        verified_checkpoint,
+        initial_sui_system_state,
+        &config,
+        store,
+        rng,
+    )?;
+
+    Ok(SimulacrumSetup { simulacrum })
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::Result;
+    use rand::rngs::OsRng;
+    use simulacrum::{AdvanceEpochConfig, Simulacrum};
+    use sui_types::storage::ReadStore;
+    use tempfile::TempDir;
+
+    use crate::network::ForkNetwork;
+    use crate::store::ForkingStore;
+
+    use super::*;
+
+    fn sample_end_of_epoch_checkpoint() -> FullCheckpointData {
+        let mut simulacrum = Simulacrum::new();
+        simulacrum.advance_epoch(AdvanceEpochConfig::default());
+
+        let checkpoint = simulacrum
+            .store_dyn()
+            .get_highest_checkpint()
+            .expect("highest checkpoint");
+        let contents = simulacrum
+            .store_dyn()
+            .get_checkpoint_contents(&checkpoint.content_digest)
+            .expect("checkpoint contents");
+
+        simulacrum
+            .get_checkpoint_data(checkpoint, contents)
+            .expect("full checkpoint data")
+    }
+
+    fn build_test_setup(
+        tempdir: &TempDir,
+        at_checkpoint: u64,
+    ) -> Result<DataStoreSetup, anyhow::Error> {
+        super::super::data_store_setup::build_data_store_setup(
+            &ForkNetwork::Testnet,
+            "http://127.0.0.1:9000",
+            at_checkpoint,
+            tempdir.path(),
+            "test-version",
+        )
+    }
+
+    #[test]
+    fn build_initial_system_state_uses_post_checkpoint_epoch_state() -> Result<()> {
+        let startup_checkpoint_data = sample_end_of_epoch_checkpoint();
+        let expected_system_state = post_checkpoint_system_state(&startup_checkpoint_data)?
+            .expect("post-checkpoint system state");
+        let tempdir = tempfile::tempdir()?;
+        let data_store_setup =
+            build_test_setup(&tempdir, startup_checkpoint_data.summary.sequence_number)?;
+
+        cache_epoch_transition_outputs(&data_store_setup, &startup_checkpoint_data)?;
+        let (filesystem, store_handles) = data_store_setup.into_parts();
+        let store = ForkingStore::new(
+            startup_checkpoint_data.summary.sequence_number,
+            filesystem,
+            store_handles,
+        );
+        let mut rng = OsRng;
+        let config = build_network_config(
+            expected_system_state.protocol_version(),
+            Chain::Testnet,
+            &mut rng,
+        );
+
+        let initial_system_state =
+            build_initial_system_state(&startup_checkpoint_data, &store, &config)?;
+
+        assert_eq!(startup_checkpoint_data.summary.epoch, 0);
+        assert_eq!(expected_system_state.epoch(), 1);
+        assert_eq!(initial_system_state.epoch(), expected_system_state.epoch());
+        assert_eq!(
+            initial_system_state.protocol_version(),
+            expected_system_state.protocol_version()
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn cache_epoch_transition_outputs_seeds_fork_store_system_state() -> Result<()> {
+        let startup_checkpoint_data = sample_end_of_epoch_checkpoint();
+        let expected_system_state = post_checkpoint_system_state(&startup_checkpoint_data)?
+            .expect("post-checkpoint system state");
+        let tempdir = tempfile::tempdir()?;
+        let data_store_setup =
+            build_test_setup(&tempdir, startup_checkpoint_data.summary.sequence_number)?;
+
+        cache_epoch_transition_outputs(&data_store_setup, &startup_checkpoint_data)?;
+        let (filesystem, store_handles) = data_store_setup.into_parts();
+        let store = ForkingStore::new(
+            startup_checkpoint_data.summary.sequence_number,
+            filesystem,
+            store_handles,
+        );
+
+        assert_eq!(
+            store.get_system_state().epoch(),
+            expected_system_state.epoch()
+        );
+        assert_eq!(
+            store.get_system_state().protocol_version(),
+            expected_system_state.protocol_version()
+        );
+
+        Ok(())
+    }
+}

--- a/crates/sui-forking/src/store/mod.rs
+++ b/crates/sui-forking/src/store/mod.rs
@@ -1,0 +1,1115 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::{BTreeMap, HashMap};
+use std::sync::Arc;
+
+use anyhow::{Context as _, anyhow};
+use tracing::{error, warn};
+
+use move_binary_format::CompiledModule;
+use move_bytecode_utils::module_cache::GetModule;
+use move_core_types::{language_storage::ModuleId, resolver::ModuleResolver};
+
+use simulacrum::SimulatorStore;
+use sui_data_store::stores::{
+    CompositeStore, DataStore, FileSystemStore, InMemoryStore, ReadThroughStore, WriteThroughStore,
+};
+use sui_data_store::{
+    CheckpointStore as _, CheckpointStoreWriter as _, FullCheckpointData, ObjectKey,
+    ObjectStore as _, ObjectStoreWriter as _, TransactionInfo, TransactionStore,
+    TransactionStoreWriter, VersionQuery,
+};
+use sui_types::SUI_CLOCK_OBJECT_ID;
+use sui_types::clock::Clock;
+use sui_types::error::SuiErrorKind;
+use sui_types::message_envelope::Envelope;
+use sui_types::storage::ReadStore;
+use sui_types::sui_system_state::sui_system_state_inner_v1::ValidatorSetV1;
+use sui_types::sui_system_state::{SuiSystemState, get_sui_system_state};
+use sui_types::transaction::{SenderSignedData, Transaction};
+use sui_types::{
+    base_types::{ObjectID, SequenceNumber, SuiAddress},
+    committee::{Committee, EpochId},
+    digests::{ObjectDigest, TransactionDigest},
+    effects::{TransactionEffects, TransactionEffectsAPI, TransactionEvents},
+    messages_checkpoint::{
+        CheckpointContents, CheckpointContentsDigest, CheckpointDigest, CheckpointSequenceNumber,
+        VerifiedCheckpoint,
+    },
+    object::{Object, Owner},
+    storage::{
+        BackingPackageStore, ChildObjectResolver, ObjectStore, PackageObject, ParentSync,
+        get_module, load_package_object_from_object_store,
+    },
+    transaction::VerifiedTransaction,
+};
+
+pub(crate) type HotMemFs = WriteThroughStore<Arc<InMemoryStore>, Arc<FileSystemStore>>;
+pub(crate) type DiskThenGraphqlObjects = ReadThroughStore<Arc<FileSystemStore>, Arc<DataStore>>;
+pub(crate) type HotObjects = WriteThroughStore<Arc<InMemoryStore>, Arc<DiskThenGraphqlObjects>>;
+pub(crate) type ForkDataStore =
+    CompositeStore<Arc<HotMemFs>, Arc<HotMemFs>, Arc<HotObjects>, Arc<HotMemFs>>;
+
+pub struct ForkingStore {
+    // Transaction events not available through fs transaction file blobs.
+    // TODO: add events to FS transaction blobs and remove this in-memory cache.
+    events: HashMap<TransactionDigest, TransactionEvents>,
+
+    // Committee data
+    epoch_to_committee: BTreeMap<EpochId, Committee>,
+
+    /// Bare file system handle used for filesystem-specific helpers such as latest-object lookups
+    /// and owner scans that are not part of the generic `sui-data-store` traits.
+    filesystem: Arc<FileSystemStore>,
+
+    /// Capability-routed composite store:
+    /// - transactions/epochs/checkpoints: memory -> filesystem
+    /// - objects: memory -> filesystem -> GraphQL
+    store: ForkDataStore,
+
+    // The checkpoint at which this forked network was forked
+    forked_at_checkpoint: u64,
+
+    /// Optional validator-set override used when building epoch state for checkpoint production.
+    /// This keeps the committee aligned with locally available validator keys in forking mode.
+    validator_set_override: Option<ValidatorSetV1>,
+
+    // Simulacrum inserts checkpoint summary and contents in two separate calls.
+    // Keep the summary only until contents arrives so we can persist one full checkpoint payload.
+    pending_checkpoint: Option<VerifiedCheckpoint>,
+}
+
+impl ForkingStore {
+    /// Creates a forking store with local cache/store chains already composed.
+    pub fn new(
+        forked_at_checkpoint: u64,
+        filesystem: Arc<FileSystemStore>,
+        store: ForkDataStore,
+    ) -> Self {
+        Self {
+            events: HashMap::new(),
+            epoch_to_committee: BTreeMap::new(),
+            filesystem,
+            store,
+            forked_at_checkpoint,
+            validator_set_override: None,
+            pending_checkpoint: None,
+        }
+    }
+
+    /// Converts full checkpoint payload data into a verified checkpoint summary envelope.
+    fn verified_checkpoint_from_full_checkpoint_data(
+        checkpoint: &FullCheckpointData,
+    ) -> VerifiedCheckpoint {
+        let certified_summary = checkpoint.summary.clone();
+        let envelope = Envelope::new_from_data_and_sig(
+            certified_summary.data().clone(),
+            certified_summary.auth_sig().clone(),
+        );
+        VerifiedCheckpoint::new_unchecked(envelope)
+    }
+
+    /// Loads full checkpoint payload by sequence from the local memory/filesystem path.
+    pub fn get_full_checkpoint_by_sequence_number(
+        &self,
+        sequence_number: CheckpointSequenceNumber,
+    ) -> Option<FullCheckpointData> {
+        self.store
+            .get_checkpoint_by_sequence_number(sequence_number)
+            .ok()
+            .flatten()
+    }
+
+    /// Returns checkpoint summary by sequence from the local memory/filesystem path.
+    pub fn get_checkpoint_by_sequence_number(
+        &self,
+        sequence_number: CheckpointSequenceNumber,
+    ) -> Option<VerifiedCheckpoint> {
+        self.get_full_checkpoint_by_sequence_number(sequence_number)
+            .map(|checkpoint| Self::verified_checkpoint_from_full_checkpoint_data(&checkpoint))
+    }
+
+    /// Returns checkpoint summary by digest via local digest index and sequence read.
+    pub fn get_checkpoint_by_digest(
+        &self,
+        digest: &CheckpointDigest,
+    ) -> Option<VerifiedCheckpoint> {
+        let sequence_number = self
+            .store
+            .get_sequence_by_checkpoint_digest(digest)
+            .ok()
+            .flatten()?;
+        self.get_checkpoint_by_sequence_number(sequence_number)
+    }
+
+    /// Returns checkpoint contents by sequence from the local memory/filesystem path.
+    pub fn get_checkpoint_contents_by_sequence_number(
+        &self,
+        sequence_number: CheckpointSequenceNumber,
+    ) -> Option<CheckpointContents> {
+        self.get_full_checkpoint_by_sequence_number(sequence_number)
+            .map(|checkpoint| checkpoint.contents)
+    }
+
+    /// Returns checkpoint contents by digest via local digest index and sequence read.
+    pub fn get_checkpoint_contents_by_digest(
+        &self,
+        digest: &CheckpointContentsDigest,
+    ) -> Option<CheckpointContents> {
+        let sequence_number = self
+            .store
+            .get_sequence_by_contents_digest(digest)
+            .ok()
+            .flatten()?;
+        self.get_checkpoint_contents_by_sequence_number(sequence_number)
+    }
+
+    /// Returns the latest locally available checkpoint summary from the local checkpoint path.
+    pub fn get_highest_checkpint(&self) -> Option<VerifiedCheckpoint> {
+        let full_checkpoint = self.store.get_latest_checkpoint().ok().flatten()?;
+        Some(Self::verified_checkpoint_from_full_checkpoint_data(
+            &full_checkpoint,
+        ))
+    }
+
+    /// Returns committee metadata for an epoch, if known in-memory.
+    pub fn get_committee_by_epoch(&self, epoch: EpochId) -> Option<&Committee> {
+        self.epoch_to_committee.get(&epoch)
+    }
+
+    /// Returns the transaction by digest from the local transaction path.
+    pub fn get_transaction(&self, digest: &TransactionDigest) -> Option<VerifiedTransaction> {
+        let tx = match self.store.transaction_data_and_effects(&digest.to_string()) {
+            Ok(tx) => tx,
+            Err(err) => {
+                error!(
+                    transaction_digest = %digest,
+                    "failed to read transaction data/effects from local store: {err}"
+                );
+                return None;
+            }
+        };
+
+        let tx = match tx {
+            None => return None,
+            Some(tx_info) => {
+                let sender_signed_data = SenderSignedData::new(tx_info.data, vec![]).clone();
+                let tx = Transaction::new(sender_signed_data);
+                VerifiedTransaction::new_unchecked(tx)
+            }
+        };
+
+        Some(tx)
+    }
+
+    /// Returns transaction effects by digest from the local transaction path.
+    pub fn get_transaction_effects(
+        &self,
+        digest: &TransactionDigest,
+    ) -> Option<TransactionEffects> {
+        let tx = match self.store.transaction_data_and_effects(&digest.to_string()) {
+            Ok(tx) => tx,
+            Err(err) => {
+                error!(
+                    transaction_digest = %digest,
+                    "failed to read transaction effects from local store: {err}"
+                );
+                return None;
+            }
+        };
+
+        tx.map(|tx_info| tx_info.effects)
+    }
+
+    /// Returns in-memory transaction events by transaction digest.
+    pub fn get_transaction_events(&self, digest: &TransactionDigest) -> Option<&TransactionEvents> {
+        self.events.get(digest)
+    }
+
+    /// Tries to fetch the object at the latest version, and if not found, it will fetch it from
+    /// RPC at the forked checkpoint.
+    pub fn get_object(&self, id: &ObjectID) -> Option<Object> {
+        // fetch object at latest version from the primary cache (FileSystem).
+        let object = match self.filesystem.get_object_latest(id) {
+            Ok(object) => object,
+            Err(err) => {
+                error!(
+                    object_id = %id,
+                    "failed to read latest object from local filesystem store: {err}"
+                );
+                None
+            }
+        };
+
+        if let Some((obj, _)) = object {
+            return Some(obj);
+        }
+
+        // if object does not exist, then fetch it at forked checkpoint. The object store will
+        // first try in the memory/filesystem cache chain and then fallback to GraphQL if not
+        // found, persisting the result into the local stores for future reads.
+        let objects = match self.store.get_objects(&[ObjectKey {
+            object_id: *id,
+            version_query: sui_data_store::VersionQuery::AtCheckpoint(self.forked_at_checkpoint),
+        }]) {
+            Ok(objects) => objects,
+            Err(err) => {
+                error!(
+                    object_id = %id,
+                    checkpoint = self.forked_at_checkpoint,
+                    "failed to fetch object at fork checkpoint via read-through store: {err}"
+                );
+                return None;
+            }
+        };
+
+        let first = objects.first().and_then(|opt| opt.as_ref());
+        first.map(|(obj, _)| obj.clone())
+    }
+
+    /// Returns an object at an exact version using read-through object fetch.
+    pub fn get_object_at_version(&self, id: &ObjectID, version: SequenceNumber) -> Option<Object> {
+        let objects = match self.store.get_objects(&[ObjectKey {
+            object_id: *id,
+            version_query: sui_data_store::VersionQuery::Version(version.into()),
+        }]) {
+            Ok(objects) => objects,
+            Err(err) => {
+                error!(
+                    object_id = %id,
+                    object_version = version.value(),
+                    "failed to fetch object version via read-through store: {err}"
+                );
+                return None;
+            }
+        };
+        let first = objects.first().and_then(|opt| opt.as_ref());
+
+        first.map(|(obj, _)| obj.clone())
+    }
+
+    /// Gets the latest version of each object for the given keys, returning None for any missing
+    /// objects.
+    ///
+    /// This uses the memory/filesystem/object-fallback path.
+    pub fn get_objects(
+        &self,
+        keys: &[ObjectKey],
+    ) -> Result<Vec<Option<(Object, u64)>>, anyhow::Error> {
+        self.store.get_objects(keys)
+    }
+
+    /// Returns the current system state view derived from this store.
+    /// Importantly, if `validator_set_override` is set, it will be used in place of the on-chain
+    /// validator set for epoch state construction. This allows the forking store to keep the
+    /// system state up-to-date with the locally available validator set.
+    pub fn get_system_state(&self) -> SuiSystemState {
+        let system_state = get_sui_system_state(self).expect("system state should exist");
+        let Some(validators) = &self.validator_set_override else {
+            return system_state;
+        };
+
+        match system_state {
+            SuiSystemState::V1(mut inner) => {
+                inner.validators = validators.clone();
+                SuiSystemState::V1(inner)
+            }
+            SuiSystemState::V2(mut inner) => {
+                inner.validators = validators.clone();
+                SuiSystemState::V2(inner)
+            }
+            #[cfg(msim)]
+            state @ (SuiSystemState::SimTestV1(_)
+            | SuiSystemState::SimTestShallowV2(_)
+            | SuiSystemState::SimTestDeepV2(_)) => state,
+        }
+    }
+
+    /// Gets the clock object, which should always be present in the store since it's a system
+    /// object. Panics if not found or fails to deserialize.
+    pub fn get_clock(&self) -> Clock {
+        self.get_object(&SUI_CLOCK_OBJECT_ID)
+            .expect("clock should exist")
+            .to_rust()
+            .expect("clock object should deserialize")
+    }
+
+    /// Returns all locally cached objects currently owned by an address.
+    pub fn owned_objects(&self, owner: SuiAddress) -> Vec<Object> {
+        self.filesystem
+            .get_objects_by_owner(owner)
+            .unwrap_or_default()
+    }
+
+    /// Installs a validator-set override used by `get_system_state` for epoch-state derivation.
+    pub fn set_system_state_validator_set_override(&mut self, validators: ValidatorSetV1) {
+        self.validator_set_override = Some(validators);
+    }
+}
+
+impl ForkingStore {
+    /// Records checkpoint summary state and updates committee map on epoch transitions.
+    /// The matching contents are expected in a later `insert_checkpoint_contents` call.
+    pub fn insert_checkpoint(&mut self, checkpoint: VerifiedCheckpoint) {
+        if let Some(end_of_epoch_data) = &checkpoint.data().end_of_epoch_data {
+            let next_committee = end_of_epoch_data
+                .next_epoch_committee
+                .iter()
+                .cloned()
+                .collect();
+            if let Some(next_epoch) = checkpoint.epoch().checked_add(1) {
+                let committee = Committee::new(next_epoch, next_committee);
+                self.insert_committee(committee);
+            } else {
+                warn!(
+                    sequence_number = *checkpoint.sequence_number(),
+                    current_epoch = checkpoint.epoch(),
+                    "skipping committee insertion due to epoch overflow"
+                );
+            }
+        }
+
+        if let Some(previous_pending) = &self.pending_checkpoint {
+            warn!(
+                previous_sequence = *previous_pending.sequence_number(),
+                next_sequence = *checkpoint.sequence_number(),
+                "overwriting pending checkpoint before matching contents were inserted"
+            );
+        }
+        self.pending_checkpoint = Some(checkpoint);
+    }
+
+    /// Completes a pending checkpoint and persists full checkpoint payload for post-fork sequences.
+    pub fn insert_checkpoint_contents(&mut self, contents: CheckpointContents) {
+        let Some(checkpoint) = self.pending_checkpoint.take() else {
+            warn!("checkpoint contents inserted without a pending checkpoint summary");
+            return;
+        };
+
+        if checkpoint.content_digest != *contents.digest() {
+            warn!(
+                sequence_number = *checkpoint.sequence_number(),
+                "checkpoint content digest mismatch between summary and inserted contents"
+            );
+            return;
+        }
+
+        let sequence_number = *checkpoint.sequence_number();
+
+        // The startup checkpoint is fetched directly through the checkpoint store read path.
+        // Only persist checkpoints produced after the fork point.
+        if sequence_number <= self.forked_at_checkpoint {
+            return;
+        }
+
+        // Startup resume can begin from an already persisted post-fork checkpoint.
+        // Avoid rewriting existing entries and duplicating digest index rows.
+        match self
+            .store
+            .get_checkpoint_by_sequence_number(sequence_number)
+        {
+            Ok(Some(_)) => return,
+            Ok(None) => {}
+            Err(err) => {
+                error!(
+                    sequence_number,
+                    "failed to check for existing checkpoint before persistence: {err}"
+                );
+            }
+        }
+
+        match self.get_checkpoint_data(checkpoint, contents) {
+            Ok(full_checkpoint) => {
+                if let Err(err) = self.store.write_checkpoint(&full_checkpoint) {
+                    error!(
+                        sequence_number,
+                        "failed to persist checkpoint to checkpoint store: {err}"
+                    );
+                }
+            }
+            Err(err) => {
+                error!(
+                    sequence_number,
+                    "failed to build full checkpoint data for persistence: {err}"
+                );
+            }
+        }
+    }
+
+    /// Inserts committee info for an epoch if not already present.
+    pub fn insert_committee(&mut self, committee: Committee) {
+        self.epoch_to_committee
+            .entry(committee.epoch)
+            .or_insert(committee);
+    }
+
+    /// Inserts the transaction, its effects, events, and the written objects into the store. The
+    /// transaction and its effects are stored in the fs transaction file blobs, while the events
+    /// and written objects are stored in memory in the ForkingStore since they are not available
+    /// through the fs transaction file blobs and are needed for the execution of subsequent
+    /// transactions in the forked network.
+    pub fn insert_executed_transaction(
+        &mut self,
+        transaction: VerifiedTransaction,
+        effects: TransactionEffects,
+        events: TransactionEvents,
+        written_objects: BTreeMap<ObjectID, Object>,
+    ) {
+        let transaction_digest = *effects.transaction_digest();
+        let tx_digest = transaction_digest.to_string();
+        let checkpoint_sequence = match self.get_latest_checkpoint_sequence_number() {
+            Ok(sequence) => sequence,
+            Err(err) => {
+                error!(
+                    transaction_digest = %transaction_digest,
+                    "skipping transaction persistence because latest checkpoint is unavailable: {err}"
+                );
+                return;
+            }
+        };
+        let tx_info = TransactionInfo {
+            data: transaction.data().inner().intent_message().value.clone(),
+            effects,
+            checkpoint: checkpoint_sequence,
+        };
+        if let Err(err) = self.store.write_transaction(&tx_digest, tx_info) {
+            error!(
+                transaction_digest = %transaction_digest,
+                "failed to persist transaction data/effects to local store: {err}"
+            );
+        }
+        self.events.insert(transaction_digest, events);
+
+        let objects = written_objects.into_iter().map(|(id, object)| {
+            let version = object.version().into();
+            let key = ObjectKey {
+                object_id: id,
+                version_query: sui_data_store::VersionQuery::Version(version),
+            };
+            (key, object, version)
+        });
+
+        if let Err(err) = self.persist_objects(objects) {
+            error!(
+                transaction_digest = %transaction_digest,
+                "failed to persist written objects for executed transaction: {err}"
+            );
+        }
+    }
+
+    /// Placeholder for direct transaction insertion; currently unused in forking mode.
+    pub fn insert_transaction(&mut self, transaction: VerifiedTransaction) {
+        warn!(
+            transaction_digest = %transaction.digest(),
+            "insert_transaction is not implemented for ForkingStore; use insert_executed_transaction"
+        );
+    }
+
+    /// Placeholder for direct effects insertion; currently unused in forking mode.
+    pub fn insert_transaction_effects(&mut self, effects: TransactionEffects) {
+        warn!(
+            transaction_digest = %effects.transaction_digest(),
+            "insert_transaction_effects is not implemented for ForkingStore; use insert_executed_transaction"
+        );
+    }
+
+    /// Stores transaction events in-memory.
+    pub fn insert_events(&mut self, tx_digest: &TransactionDigest, events: TransactionEvents) {
+        self.events.insert(*tx_digest, events);
+    }
+
+    /// Placeholder for object update path; currently unused.
+    pub fn update_objects(
+        &mut self,
+        written_objects: BTreeMap<ObjectID, Object>,
+        _deleted_objects: Vec<(ObjectID, SequenceNumber, ObjectDigest)>,
+    ) {
+        let objects = written_objects.into_iter().map(|(id, object)| {
+            let version = object.version().into();
+            let key = ObjectKey {
+                object_id: id,
+                version_query: sui_data_store::VersionQuery::Version(version),
+            };
+            (key, object, version)
+        });
+
+        if let Err(err) = self.persist_objects(objects) {
+            error!("failed to persist updated objects to local store: {err}");
+        }
+    }
+
+    fn persist_objects<I>(&self, objects: I) -> Result<(), anyhow::Error>
+    where
+        I: IntoIterator<Item = (ObjectKey, Object, u64)>,
+    {
+        for (key, object, version) in objects {
+            self.store
+                .write_object(&key, object, version)
+                .with_context(|| {
+                    format!(
+                        "failed to persist object {} at version {}",
+                        key.object_id, version
+                    )
+                })?;
+        }
+        Ok(())
+    }
+}
+
+impl BackingPackageStore for ForkingStore {
+    fn get_package_object(
+        &self,
+        package_id: &ObjectID,
+    ) -> sui_types::error::SuiResult<Option<PackageObject>> {
+        load_package_object_from_object_store(self, package_id)
+    }
+}
+
+impl ChildObjectResolver for ForkingStore {
+    fn read_child_object(
+        &self,
+        parent: &ObjectID,
+        child: &ObjectID,
+        child_version_upper_bound: SequenceNumber,
+    ) -> sui_types::error::SuiResult<Option<Object>> {
+        let validate = |child_object: Object| -> sui_types::error::SuiResult<Option<Object>> {
+            let parent = *parent;
+            if child_object.owner != Owner::ObjectOwner(parent.into()) {
+                return Err(SuiErrorKind::InvalidChildObjectAccess {
+                    object: *child,
+                    given_parent: parent,
+                    actual_owner: child_object.owner.clone(),
+                }
+                .into());
+            }
+
+            if child_object.version() > child_version_upper_bound {
+                return Err(SuiErrorKind::UnsupportedFeatureError {
+                    error:
+                        "TODO ForkingStore::read_child_object does not yet support bounded reads"
+                            .to_owned(),
+                }
+                .into());
+            }
+
+            Ok(Some(child_object))
+        };
+
+        let local_latest = self
+            .filesystem
+            .get_object_latest(child)
+            .map_err(|e| SuiErrorKind::Storage(e.to_string()))?;
+        if let Some((child_object, _)) = &local_latest
+            && child_object.version() <= child_version_upper_bound
+        {
+            return validate(child_object.clone());
+        }
+
+        let object_key = ObjectKey {
+            object_id: *child,
+            version_query: VersionQuery::RootVersion(child_version_upper_bound.value()),
+        };
+        let mut object = self
+            .get_objects(&[object_key])
+            .map_err(|e| SuiErrorKind::Storage(e.to_string()))?;
+        debug_assert!(object.len() == 1, "Expected one object for {}", child);
+        let object = object.pop().unwrap().map(|(obj, _version)| obj);
+
+        match object {
+            Some(obj) => validate(obj),
+            None => {
+                if local_latest.is_some() {
+                    Err(SuiErrorKind::UnsupportedFeatureError {
+                        error:
+                            "TODO ForkingStore::read_child_object does not yet support bounded reads"
+                                .to_owned(),
+                    }
+                    .into())
+                } else {
+                    Ok(None)
+                }
+            }
+        }
+    }
+
+    fn get_object_received_at_version(
+        &self,
+        owner: &ObjectID,
+        receiving_object_id: &ObjectID,
+        receive_object_at_version: SequenceNumber,
+        _epoch_id: EpochId,
+    ) -> sui_types::error::SuiResult<Option<Object>> {
+        let recv_object = match self.get_object(receiving_object_id) {
+            None => return Ok(None),
+            Some(obj) => obj,
+        };
+        if recv_object.owner != Owner::AddressOwner((*owner).into()) {
+            return Ok(None);
+        }
+
+        if recv_object.version() != receive_object_at_version {
+            return Ok(None);
+        }
+        Ok(Some(recv_object))
+    }
+}
+
+impl GetModule for ForkingStore {
+    type Error = anyhow::Error;
+    type Item = Arc<CompiledModule>;
+
+    fn get_module_by_id(&self, id: &ModuleId) -> Result<Option<Self::Item>, Self::Error> {
+        let module = self
+            .get_module(id)?
+            .map(|bytes| {
+                CompiledModule::deserialize_with_defaults(&bytes)
+                    .map_err(|err| anyhow!("failed to deserialize compiled module {id:?}: {err}"))
+            })
+            .transpose()?;
+
+        Ok(module.map(Arc::new))
+    }
+}
+
+impl ModuleResolver for ForkingStore {
+    type Error = anyhow::Error;
+
+    fn get_module(&self, module_id: &ModuleId) -> Result<Option<Vec<u8>>, Self::Error> {
+        get_module(self, module_id).map_err(|e| anyhow!(e.to_string()))
+    }
+
+    fn get_packages_static<const N: usize>(
+        &self,
+        _ids: [move_core_types::account_address::AccountAddress; N],
+    ) -> Result<[Option<move_core_types::resolver::SerializedPackage>; N], Self::Error> {
+        todo!()
+    }
+
+    fn get_packages<'a>(
+        &self,
+        _ids: impl ExactSizeIterator<Item = &'a move_core_types::account_address::AccountAddress>,
+    ) -> Result<Vec<Option<move_core_types::resolver::SerializedPackage>>, Self::Error> {
+        todo!()
+    }
+}
+
+impl ObjectStore for ForkingStore {
+    fn get_object(&self, object_id: &ObjectID) -> Option<Object> {
+        self.get_object(object_id)
+    }
+
+    fn get_object_by_key(
+        &self,
+        object_id: &ObjectID,
+        version: sui_types::base_types::VersionNumber,
+    ) -> Option<Object> {
+        self.get_object_at_version(object_id, version)
+    }
+}
+
+impl ParentSync for ForkingStore {
+    fn get_latest_parent_entry_ref_deprecated(
+        &self,
+        _object_id: ObjectID,
+    ) -> Option<sui_types::base_types::ObjectRef> {
+        panic!("Never called in newer protocol versions")
+    }
+}
+
+impl SimulatorStore for ForkingStore {
+    fn get_checkpoint_by_sequence_number(
+        &self,
+        sequence_number: CheckpointSequenceNumber,
+    ) -> Option<VerifiedCheckpoint> {
+        ForkingStore::get_checkpoint_by_sequence_number(self, sequence_number)
+    }
+
+    fn get_checkpoint_by_digest(&self, digest: &CheckpointDigest) -> Option<VerifiedCheckpoint> {
+        ForkingStore::get_checkpoint_by_digest(self, digest)
+    }
+
+    fn get_highest_checkpint(&self) -> Option<VerifiedCheckpoint> {
+        ForkingStore::get_highest_checkpint(self)
+    }
+
+    fn get_checkpoint_contents(
+        &self,
+        digest: &CheckpointContentsDigest,
+    ) -> Option<CheckpointContents> {
+        ForkingStore::get_checkpoint_contents_by_digest(self, digest)
+    }
+
+    fn get_committee_by_epoch(&self, epoch: EpochId) -> Option<Committee> {
+        self.get_committee_by_epoch(epoch).cloned()
+    }
+
+    fn get_transaction(&self, digest: &TransactionDigest) -> Option<VerifiedTransaction> {
+        self.get_transaction(digest)
+    }
+
+    fn get_transaction_effects(&self, digest: &TransactionDigest) -> Option<TransactionEffects> {
+        self.get_transaction_effects(digest)
+    }
+
+    fn get_transaction_events(&self, digest: &TransactionDigest) -> Option<TransactionEvents> {
+        self.get_transaction_events(digest).cloned()
+    }
+
+    fn get_object(&self, id: &ObjectID) -> Option<Object> {
+        self.get_object(id)
+    }
+
+    fn get_object_at_version(&self, id: &ObjectID, version: SequenceNumber) -> Option<Object> {
+        self.get_object_at_version(id, version)
+    }
+
+    fn get_system_state(&self) -> SuiSystemState {
+        self.get_system_state()
+    }
+
+    fn get_clock(&self) -> Clock {
+        self.get_clock()
+    }
+
+    fn owned_objects(&self, owner: SuiAddress) -> Box<dyn Iterator<Item = Object> + '_> {
+        Box::new(self.owned_objects(owner).into_iter())
+    }
+
+    fn insert_checkpoint(&mut self, checkpoint: VerifiedCheckpoint) {
+        self.insert_checkpoint(checkpoint)
+    }
+
+    fn insert_checkpoint_contents(&mut self, contents: CheckpointContents) {
+        self.insert_checkpoint_contents(contents)
+    }
+
+    fn insert_committee(&mut self, committee: Committee) {
+        self.insert_committee(committee)
+    }
+
+    fn insert_executed_transaction(
+        &mut self,
+        transaction: VerifiedTransaction,
+        effects: TransactionEffects,
+        events: TransactionEvents,
+        written_objects: BTreeMap<ObjectID, Object>,
+    ) {
+        self.insert_executed_transaction(transaction, effects, events, written_objects)
+    }
+
+    fn insert_transaction(&mut self, transaction: VerifiedTransaction) {
+        self.insert_transaction(transaction)
+    }
+
+    fn insert_transaction_effects(&mut self, effects: TransactionEffects) {
+        self.insert_transaction_effects(effects)
+    }
+
+    fn insert_events(&mut self, tx_digest: &TransactionDigest, events: TransactionEvents) {
+        self.insert_events(tx_digest, events)
+    }
+
+    fn update_objects(
+        &mut self,
+        written_objects: BTreeMap<ObjectID, Object>,
+        deleted_objects: Vec<(ObjectID, SequenceNumber, ObjectDigest)>,
+    ) {
+        self.update_objects(written_objects, deleted_objects)
+    }
+
+    fn backing_store(&self) -> &dyn sui_types::storage::BackingStore {
+        self
+    }
+}
+
+impl ReadStore for ForkingStore {
+    fn get_committee(&self, epoch: EpochId) -> Option<Arc<Committee>> {
+        self.get_committee_by_epoch(epoch).cloned().map(Arc::new)
+    }
+
+    fn get_latest_checkpoint(&self) -> sui_types::storage::error::Result<VerifiedCheckpoint> {
+        self.get_highest_checkpint()
+            .ok_or_else(|| sui_types::storage::error::Error::custom("No checkpoint available"))
+    }
+
+    fn get_highest_verified_checkpoint(
+        &self,
+    ) -> sui_types::storage::error::Result<VerifiedCheckpoint> {
+        self.get_latest_checkpoint()
+    }
+
+    fn get_highest_synced_checkpoint(
+        &self,
+    ) -> sui_types::storage::error::Result<VerifiedCheckpoint> {
+        self.get_latest_checkpoint()
+    }
+
+    fn get_lowest_available_checkpoint(
+        &self,
+    ) -> sui_types::storage::error::Result<CheckpointSequenceNumber> {
+        Ok(0)
+    }
+
+    fn get_checkpoint_by_digest(&self, digest: &CheckpointDigest) -> Option<VerifiedCheckpoint> {
+        ForkingStore::get_checkpoint_by_digest(self, digest)
+    }
+
+    fn get_checkpoint_by_sequence_number(
+        &self,
+        sequence_number: CheckpointSequenceNumber,
+    ) -> Option<VerifiedCheckpoint> {
+        ForkingStore::get_checkpoint_by_sequence_number(self, sequence_number)
+    }
+
+    fn get_checkpoint_contents_by_digest(
+        &self,
+        digest: &CheckpointContentsDigest,
+    ) -> Option<CheckpointContents> {
+        ForkingStore::get_checkpoint_contents_by_digest(self, digest)
+    }
+
+    fn get_checkpoint_contents_by_sequence_number(
+        &self,
+        sequence_number: CheckpointSequenceNumber,
+    ) -> Option<CheckpointContents> {
+        ForkingStore::get_checkpoint_contents_by_sequence_number(self, sequence_number)
+    }
+
+    fn get_transaction(&self, tx_digest: &TransactionDigest) -> Option<Arc<VerifiedTransaction>> {
+        self.get_transaction(tx_digest).map(Arc::new)
+    }
+
+    fn get_transaction_effects(&self, tx_digest: &TransactionDigest) -> Option<TransactionEffects> {
+        self.get_transaction_effects(tx_digest)
+    }
+
+    fn get_events(&self, tx_digest: &TransactionDigest) -> Option<TransactionEvents> {
+        self.get_transaction_events(tx_digest).cloned()
+    }
+
+    fn get_unchanged_loaded_runtime_objects(
+        &self,
+        _digest: &TransactionDigest,
+    ) -> Option<Vec<sui_types::storage::ObjectKey>> {
+        // Not tracked in forking store
+        None
+    }
+
+    fn get_transaction_checkpoint(
+        &self,
+        _digest: &TransactionDigest,
+    ) -> Option<CheckpointSequenceNumber> {
+        // Transaction-to-checkpoint mapping not tracked in forking store
+        None
+    }
+
+    fn get_full_checkpoint_contents(
+        &self,
+        _sequence_number: Option<CheckpointSequenceNumber>,
+        _digest: &CheckpointContentsDigest,
+    ) -> Option<sui_types::messages_checkpoint::VersionedFullCheckpointContents> {
+        // Full checkpoint contents not tracked in forking store
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use sui_data_store::{
+        CheckpointStoreWriter as _, Node, ObjectKey, ObjectStoreWriter as _, SetupStore as _,
+        TransactionInfo, TransactionStoreWriter as _, VersionQuery,
+    };
+    use sui_types::{
+        base_types::{ObjectID, SequenceNumber, SuiAddress},
+        object::{Object, Owner},
+        test_checkpoint_data_builder::TestCheckpointBuilder,
+    };
+    use tempfile::TempDir;
+
+    use super::*;
+
+    const CHAIN_ID: &str = "test_chain";
+
+    fn sample_checkpoint(sequence: u64) -> FullCheckpointData {
+        TestCheckpointBuilder::new(sequence)
+            .start_transaction(1)
+            .create_owned_object(42)
+            .finish_transaction()
+            .build_checkpoint()
+    }
+
+    fn transaction_info(checkpoint: &FullCheckpointData) -> TransactionInfo {
+        let executed = &checkpoint.transactions[0];
+        TransactionInfo {
+            data: executed.transaction.clone(),
+            effects: executed.effects.clone(),
+            checkpoint: checkpoint.summary.sequence_number,
+        }
+    }
+
+    fn sample_object(object_id: ObjectID, owner: SuiAddress, version: u64) -> Object {
+        Object::with_id_owner_version_for_testing(
+            object_id,
+            SequenceNumber::from_u64(version),
+            Owner::AddressOwner(owner),
+        )
+    }
+
+    fn make_forking_store(
+        forked_at_checkpoint: u64,
+    ) -> Result<(TempDir, ForkingStore), anyhow::Error> {
+        let tempdir = tempfile::tempdir()?;
+        let filesystem = Arc::new(FileSystemStore::new_with_path(
+            Node::Testnet,
+            tempdir.path().to_path_buf(),
+        )?);
+        filesystem.setup(Some(CHAIN_ID.to_string()))?;
+
+        let memory = Arc::new(InMemoryStore::new(Node::Testnet));
+        let graphql = Arc::new(DataStore::new(Node::Testnet, "test-version")?);
+        let hot_mem_fs: Arc<HotMemFs> =
+            Arc::new(WriteThroughStore::new(memory.clone(), filesystem.clone()));
+        let disk_then_graphql_objects: Arc<DiskThenGraphqlObjects> =
+            Arc::new(ReadThroughStore::new(filesystem.clone(), graphql));
+        let hot_objects: Arc<HotObjects> =
+            Arc::new(WriteThroughStore::new(memory, disk_then_graphql_objects));
+        let store = ForkDataStore::new(
+            hot_mem_fs.clone(),
+            hot_mem_fs.clone(),
+            hot_objects,
+            hot_mem_fs,
+        );
+
+        Ok((
+            tempdir,
+            ForkingStore::new(forked_at_checkpoint, filesystem, store),
+        ))
+    }
+
+    #[test]
+    fn transaction_reads_use_local_composite_store() -> Result<(), anyhow::Error> {
+        let (_tempdir, store) = make_forking_store(11)?;
+        let checkpoint = sample_checkpoint(11);
+        let tx_info = transaction_info(&checkpoint);
+        let tx_digest = checkpoint.transactions[0]
+            .effects
+            .transaction_digest()
+            .to_string();
+
+        store
+            .store
+            .write_transaction(&tx_digest, tx_info.clone())
+            .expect("write transaction");
+
+        let tx = store.get_transaction(checkpoint.transactions[0].effects.transaction_digest());
+        assert!(
+            tx.is_some(),
+            "transaction should be readable from forking store"
+        );
+
+        let effects = store
+            .get_transaction_effects(checkpoint.transactions[0].effects.transaction_digest())
+            .expect("transaction effects");
+        assert_eq!(effects, tx_info.effects);
+
+        Ok(())
+    }
+
+    #[test]
+    fn checkpoint_reads_use_local_composite_store() -> Result<(), anyhow::Error> {
+        let (_tempdir, store) = make_forking_store(11)?;
+        let checkpoint = sample_checkpoint(13);
+
+        store
+            .store
+            .write_checkpoint(&checkpoint)
+            .expect("write checkpoint");
+
+        let summary = store
+            .get_checkpoint_by_sequence_number(13)
+            .expect("checkpoint summary");
+        assert_eq!(summary.sequence_number, 13);
+        assert_eq!(
+            store
+                .get_checkpoint_by_digest(checkpoint.summary.digest())
+                .expect("checkpoint by digest")
+                .sequence_number,
+            13
+        );
+        assert_eq!(
+            store
+                .get_checkpoint_contents_by_digest(checkpoint.contents.digest())
+                .expect("checkpoint contents")
+                .digest(),
+            checkpoint.contents.digest()
+        );
+        assert!(store.get_full_checkpoint_by_sequence_number(13).is_some());
+
+        Ok(())
+    }
+
+    #[test]
+    fn get_object_prefers_local_latest_and_owned_objects_stay_filesystem_backed()
+    -> Result<(), anyhow::Error> {
+        let (_tempdir, store) = make_forking_store(50)?;
+        let owner = SuiAddress::random_for_testing_only();
+        let object_id = ObjectID::random();
+        let checkpoint_object = sample_object(object_id, owner, 1);
+        let latest_object = sample_object(object_id, owner, 3);
+
+        store
+            .store
+            .write_object(
+                &ObjectKey {
+                    object_id,
+                    version_query: VersionQuery::AtCheckpoint(50),
+                },
+                checkpoint_object,
+                1,
+            )
+            .expect("write checkpoint object");
+        store
+            .store
+            .write_object(
+                &ObjectKey {
+                    object_id,
+                    version_query: VersionQuery::Version(3),
+                },
+                latest_object.clone(),
+                3,
+            )
+            .expect("write latest object");
+
+        let returned = store.get_object(&object_id).expect("latest object");
+        assert_eq!(returned.version().value(), 3);
+
+        let owned = store.owned_objects(owner);
+        assert_eq!(owned.len(), 1);
+        assert_eq!(owned[0].id(), object_id);
+
+        Ok(())
+    }
+
+    #[test]
+    fn update_objects_persists_to_local_filesystem_path() -> Result<(), anyhow::Error> {
+        let (_tempdir, mut store) = make_forking_store(9)?;
+        let owner = SuiAddress::random_for_testing_only();
+        let object_id = ObjectID::random();
+        let object = sample_object(object_id, owner, 7);
+
+        store.update_objects(BTreeMap::from([(object_id, object.clone())]), Vec::new());
+
+        let local_latest = store
+            .filesystem
+            .get_object_latest(&object_id)?
+            .expect("object should be in filesystem");
+        assert_eq!(local_latest.0.version().value(), 7);
+        assert_eq!(
+            store.get_object(&object_id).expect("object lookup").id(),
+            object_id
+        );
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Description 

This PR builds on top of `codex/forking-pr1` which has the `sui-data-store` changes around checkpoints, transactions, objects, etc.

In this PR, we have the basic skeleton of `sui-forking`
- grpc -- most of it is disabled. `get_object` in `ledger_service` is implemented to be able to download objects
- store -- implements the `SimulatorStore` needed for `simulacrum`.
- server -- has the REST API to work with the CLI tool, the grpc setup, and the setup of the data-store.

## Test plan 

```
cargo nextest run -p sui-forking
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
