### PR TITLE
indexer: track skipped and out-of-order checkpoints during streaming

### DIFF
--- a/crates/sui-indexer-alt-framework/src/ingestion/broadcaster.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/broadcaster.rs
@@ -380,11 +380,16 @@ async fn stream_and_broadcast_range(
                 checkpoint = sequence_number,
                 lo, "Skipping already processed checkpoint"
             );
+            metrics.total_skipped_streamed_checkpoints.inc();
+            metrics
+                .latest_skipped_streamed_checkpoint
+                .set(sequence_number as i64);
             continue;
         }
 
         if sequence_number > lo {
             warn!(checkpoint = sequence_number, lo, "Out-of-order checkpoint");
+            metrics.total_out_of_order_streamed_checkpoints.inc();
             // Return to main loop to fill up the gap.
             break;
         }
@@ -968,6 +973,8 @@ mod tests {
         assert_eq!(metrics.total_streamed_checkpoints.get(), 70);
         assert_eq!(metrics.total_ingested_checkpoints.get(), 0);
         assert_eq!(metrics.latest_streamed_checkpoint.get(), 99);
+        assert_eq!(metrics.total_skipped_streamed_checkpoints.get(), 30);
+        assert_eq!(metrics.latest_skipped_streamed_checkpoint.get(), 29);
 
         svc.join().await.unwrap();
     }
@@ -1007,6 +1014,8 @@ mod tests {
         assert_eq!(metrics.total_streamed_checkpoints.get(), 20);
         assert_eq!(metrics.total_ingested_checkpoints.get(), 0);
         assert_eq!(metrics.latest_streamed_checkpoint.get(), 19);
+        assert_eq!(metrics.total_skipped_streamed_checkpoints.get(), 2);
+        assert_eq!(metrics.latest_skipped_streamed_checkpoint.get(), 4);
 
         svc.join().await.unwrap();
     }
@@ -1047,6 +1056,7 @@ mod tests {
         assert_eq!(metrics.total_streamed_checkpoints.get(), 6);
         assert_eq!(metrics.total_ingested_checkpoints.get(), 4);
         assert_eq!(metrics.latest_streamed_checkpoint.get(), 9);
+        assert_eq!(metrics.total_out_of_order_streamed_checkpoints.get(), 1);
 
         svc.join().await.unwrap();
     }

--- a/crates/sui-indexer-alt-framework/src/metrics.rs
+++ b/crates/sui-indexer-alt-framework/src/metrics.rs
@@ -65,12 +65,15 @@ pub struct IngestionMetrics {
     pub total_ingested_not_found_retries: IntCounter,
     pub total_ingested_permanent_errors: IntCounterVec,
     pub total_streamed_checkpoints: IntCounter,
+    pub total_skipped_streamed_checkpoints: IntCounter,
+    pub total_out_of_order_streamed_checkpoints: IntCounter,
     pub total_stream_disconnections: IntCounter,
     pub total_streaming_connection_failures: IntCounter,
 
     // Checkpoint lag metrics for the ingestion pipeline.
     pub latest_ingested_checkpoint: IntGauge,
     pub latest_streamed_checkpoint: IntGauge,
+    pub latest_skipped_streamed_checkpoint: IntGauge,
     pub latest_ingested_checkpoint_timestamp_lag_ms: IntGauge,
     pub ingested_checkpoint_timestamp_lag: Histogram,
 
@@ -236,6 +239,18 @@ impl IngestionMetrics {
                 registry,
             )
             .unwrap(),
+            total_skipped_streamed_checkpoints: register_int_counter_with_registry!(
+                name("total_skipped_streamed_checkpoints"),
+                "Total number of streamed checkpoints skipped because they were already processed",
+                registry,
+            )
+            .unwrap(),
+            total_out_of_order_streamed_checkpoints: register_int_counter_with_registry!(
+                name("total_out_of_order_streamed_checkpoints"),
+                "Total number of streamed checkpoints received out of order",
+                registry,
+            )
+            .unwrap(),
             total_stream_disconnections: register_int_counter_with_registry!(
                 name("total_stream_disconnections"),
                 "Total number of times the gRPC stream was disconnected",
@@ -257,6 +272,12 @@ impl IngestionMetrics {
             latest_streamed_checkpoint: register_int_gauge_with_registry!(
                 name("latest_streamed_checkpoint"),
                 "Latest checkpoint sequence number received from gRPC streaming",
+                registry,
+            )
+            .unwrap(),
+            latest_skipped_streamed_checkpoint: register_int_gauge_with_registry!(
+                name("latest_skipped_streamed_checkpoint"),
+                "Latest streamed checkpoint sequence number skipped because it was already processed",
                 registry,
             )
             .unwrap(),


### PR DESCRIPTION
## Description

In a recent incident, we observed that the indexer seemed stuck at a certain checkpoint where actually it may have just been churning through checkpoints it needed to skip. Adding metrics to track skipped checkpoints so that we have more visibility on this behavior in the future.

## Test plan

Updated unit tests:

```
$ cargo nextest run -p sui-indexer-alt-framework -- broadcaster
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
