### PR TITLE
[Block Streaming] Extract proposing logic to separate component & refactor node type bootstrap

### DIFF
--- a/consensus/config/src/parameters.rs
+++ b/consensus/config/src/parameters.rs
@@ -113,6 +113,10 @@ pub struct Parameters {
     #[serde(default = "TonicParameters::default")]
     pub tonic: TonicParameters,
 
+    /// Observer node settings.
+    #[serde(default = "ObserverParameters::default")]
+    pub observer: ObserverParameters,
+
     /// Internal consensus parameters.
     #[serde(default = "InternalParameters::default")]
     pub internal: InternalParameters,
@@ -251,6 +255,7 @@ impl Default for Parameters {
             commit_sync_probe_timeout: Parameters::default_commit_sync_probe_timeout(),
             use_fifo_compaction: Parameters::default_use_fifo_compaction(),
             tonic: TonicParameters::default(),
+            observer: ObserverParameters::default(),
             internal: InternalParameters::default(),
             listen_address_override: None,
         }
@@ -318,33 +323,9 @@ pub struct TonicParameters {
     /// If unspecified, this will default to 1GiB.
     #[serde(default = "TonicParameters::default_message_size_limit")]
     pub message_size_limit: usize,
-
-    /// Port for the observer server. If configured, then the node will run the observer server on this port.
-    ///
-    /// If unspecified, this will default to `None`.
-    #[serde(default = "TonicParameters::default_observer_server_port")]
-    pub observer_server_port: Option<u16>,
-
-    /// Allowlist of observer public keys (hex encoded). If empty, all observers are allowed.
-    /// If non-empty, only observers with these public keys will be allowed to connect.
-    ///
-    /// If unspecified, this will default to an empty Vec (no allowlist, all observers allowed).
-    #[serde(default = "TonicParameters::default_observer_allowlist")]
-    pub observer_allowlist: Vec<String>,
-
-    /// List of observer peers to connect to when acting as an observer client.
-    /// Each record contains the network public key and multi-address of a peer observer server.
-    ///
-    /// If unspecified, this will default to an empty Vec.
-    #[serde(default = "TonicParameters::default_observer_peers")]
-    pub observer_peers: Vec<PeerRecord>,
 }
 
 impl TonicParameters {
-    pub fn is_observer_server_enabled(&self) -> bool {
-        self.observer_server_port.is_some()
-    }
-
     fn default_keepalive_interval() -> Duration {
         Duration::from_secs(10)
     }
@@ -360,18 +341,6 @@ impl TonicParameters {
     fn default_message_size_limit() -> usize {
         64 << 20
     }
-
-    fn default_observer_server_port() -> Option<u16> {
-        None
-    }
-
-    fn default_observer_allowlist() -> Vec<String> {
-        Vec::new()
-    }
-
-    fn default_observer_peers() -> Vec<PeerRecord> {
-        Vec::new()
-    }
 }
 
 impl Default for TonicParameters {
@@ -381,9 +350,58 @@ impl Default for TonicParameters {
             connection_buffer_size: TonicParameters::default_connection_buffer_size(),
             excessive_message_size: TonicParameters::default_excessive_message_size(),
             message_size_limit: TonicParameters::default_message_size_limit(),
-            observer_server_port: TonicParameters::default_observer_server_port(),
-            observer_allowlist: TonicParameters::default_observer_allowlist(),
-            observer_peers: TonicParameters::default_observer_peers(),
+        }
+    }
+}
+
+/// Observer node configuration parameters.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct ObserverParameters {
+    /// Port for the observer server. If configured, then the node will run the observer server on this port.
+    ///
+    /// If unspecified, this will default to `None`.
+    #[serde(default = "ObserverParameters::default_server_port")]
+    pub server_port: Option<u16>,
+
+    /// Allowlist of observer public keys (hex encoded). If empty, all observers are allowed.
+    /// If non-empty, only observers with these public keys will be allowed to connect.
+    ///
+    /// If unspecified, this will default to an empty Vec (no allowlist, all observers allowed).
+    #[serde(default = "ObserverParameters::default_allowlist")]
+    pub allowlist: Vec<String>,
+
+    /// List of observer peers to connect to when acting as an observer client.
+    /// Each record contains the network public key and multi-address of a peer observer server.
+    ///
+    /// If unspecified, this will default to an empty Vec.
+    #[serde(default = "ObserverParameters::default_peers")]
+    pub peers: Vec<PeerRecord>,
+}
+
+impl ObserverParameters {
+    pub fn is_server_enabled(&self) -> bool {
+        self.server_port.is_some()
+    }
+
+    fn default_server_port() -> Option<u16> {
+        None
+    }
+
+    fn default_allowlist() -> Vec<String> {
+        Vec::new()
+    }
+
+    fn default_peers() -> Vec<PeerRecord> {
+        Vec::new()
+    }
+}
+
+impl Default for ObserverParameters {
+    fn default() -> Self {
+        Self {
+            server_port: ObserverParameters::default_server_port(),
+            allowlist: ObserverParameters::default_allowlist(),
+            peers: ObserverParameters::default_peers(),
         }
     }
 }

--- a/consensus/config/tests/snapshots/parameters_test__parameters.snap
+++ b/consensus/config/tests/snapshots/parameters_test__parameters.snap
@@ -38,8 +38,9 @@ tonic:
   connection_buffer_size: 33554432
   excessive_message_size: 16777216
   message_size_limit: 67108864
-  observer_server_port: ~
-  observer_allowlist: []
-  observer_peers: []
+observer:
+  server_port: ~
+  allowlist: []
+  peers: []
 internal:
   skip_equivocation_validation: false

--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -30,7 +30,7 @@ use crate::{
     leader_timeout::{LeaderTimeoutTask, LeaderTimeoutTaskHandle},
     metrics::initialise_metrics,
     network::{
-        CommitSyncerClient, NetworkManager, SynchronizerClient, tonic_network::TonicManager,
+        CommitSyncerClient, NetworkManager, PeerId, SynchronizerClient, tonic_network::TonicManager,
     },
     observer_service::ObserverService,
     round_prober::{RoundProber, RoundProberHandle},
@@ -53,11 +53,11 @@ impl ConsensusAuthority {
     pub async fn start(
         network_type: NetworkType,
         epoch_start_timestamp_ms: u64,
-        own_index: AuthorityIndex,
         committee: Committee,
         parameters: Parameters,
         protocol_config: ConsensusProtocolConfig,
-        protocol_keypair: ProtocolKeyPair,
+        // Only required for validator nodes. Observer nodes don't have a protocol keypair.
+        protocol_keypair: Option<ProtocolKeyPair>,
         network_keypair: NetworkKeyPair,
         clock: Arc<Clock>,
         transaction_verifier: Arc<dyn TransactionVerifier>,
@@ -72,7 +72,6 @@ impl ConsensusAuthority {
             NetworkType::Tonic => {
                 let authority = AuthorityNode::start(
                     epoch_start_timestamp_ms,
-                    own_index,
                     committee,
                     parameters,
                     protocol_config,
@@ -125,6 +124,21 @@ pub enum NetworkType {
     Tonic,
 }
 
+/// Enum to handle different subscriber types based on whether the node is a validator or observer
+enum SubscriberType<N: NetworkManager> {
+    Validator(Subscriber<N::ValidatorClient, AuthorityService<ChannelCoreThreadDispatcher>>),
+    Observer(ObserverSubscriber<N::ObserverClient, ObserverService>),
+}
+
+impl<N: NetworkManager> SubscriberType<N> {
+    fn stop(&self) {
+        match self {
+            SubscriberType::Validator(subscriber) => subscriber.stop(),
+            SubscriberType::Observer(subscriber) => subscriber.stop(),
+        }
+    }
+}
+
 pub(crate) struct AuthorityNode<N>
 where
     N: NetworkManager,
@@ -135,10 +149,10 @@ where
     synchronizer: Arc<SynchronizerHandle>,
 
     commit_syncer_handle: CommitSyncerHandle,
-    round_prober_handle: RoundProberHandle,
+    round_prober_handle: Option<RoundProberHandle>,
     leader_timeout_handle: LeaderTimeoutTaskHandle,
     core_thread_handle: CoreThreadHandle,
-    subscriber: Subscriber<N::ValidatorClient, AuthorityService<ChannelCoreThreadDispatcher>>,
+    subscriber: SubscriberType<N>,
     network_manager: N,
 }
 
@@ -149,11 +163,10 @@ where
     // See comments above ConsensusAuthority::start() for details on the input.
     pub(crate) async fn start(
         epoch_start_timestamp_ms: u64,
-        own_index: AuthorityIndex,
         committee: Committee,
         parameters: Parameters,
         protocol_config: ConsensusProtocolConfig,
-        protocol_keypair: ProtocolKeyPair,
+        protocol_keypair: Option<ProtocolKeyPair>,
         network_keypair: NetworkKeyPair,
         clock: Arc<Clock>,
         transaction_verifier: Arc<dyn TransactionVerifier>,
@@ -161,22 +174,46 @@ where
         registry: Registry,
         boot_counter: u64,
     ) -> Self {
-        assert!(
-            committee.is_valid_index(own_index),
-            "Invalid own index {}",
-            own_index
-        );
-        let own_hostname = committee.authority(own_index).hostname.clone();
-        info!(
-            "Starting consensus authority {} {}, {:?}, epoch start timestamp {}, boot counter {}, replaying after commit index {}, consumer last processed commit index {}",
-            own_index,
-            own_hostname,
-            protocol_config.protocol_version(),
-            epoch_start_timestamp_ms,
-            boot_counter,
-            commit_consumer.replay_after_commit_index,
-            commit_consumer.consumer_last_processed_commit_index
-        );
+        let metrics = initialise_metrics(registry);
+
+        // If a protocol key pair is provided, then this is a validator node.
+        let own_index = if let Some(protocol_keypair) = &protocol_keypair {
+            let (own_index, _) = committee
+                .authorities()
+                .find(|(_, a)| a.protocol_key == protocol_keypair.public())
+                .expect("Own authority should be among the consensus authorities!");
+
+            let own_hostname = committee.authority(own_index).hostname.clone();
+            info!(
+                "Starting consensus validator authority {} {}, {:?}, epoch start timestamp {}, boot counter {}, replaying after commit index {}, consumer last processed commit index {}",
+                own_index,
+                own_hostname,
+                protocol_config.protocol_version(),
+                epoch_start_timestamp_ms,
+                boot_counter,
+                commit_consumer.replay_after_commit_index,
+                commit_consumer.consumer_last_processed_commit_index
+            );
+
+            metrics
+                .node_metrics
+                .authority_index
+                .with_label_values(&[&own_hostname])
+                .set(own_index.value() as i64);
+            Some(own_index)
+        } else {
+            // Otherwise this is an observer node and no index exists for it.
+            info!(
+                "Starting consensus observer authority, {:?}, epoch start timestamp {}, boot counter {}, replaying after commit index {}, consumer last processed commit index {}",
+                protocol_config.protocol_version(),
+                epoch_start_timestamp_ms,
+                boot_counter,
+                commit_consumer.replay_after_commit_index,
+                commit_consumer.consumer_last_processed_commit_index
+            );
+            None
+        };
+
         info!(
             "Consensus authorities: {}",
             committee
@@ -192,17 +229,11 @@ where
             committee,
             parameters,
             protocol_config,
-            initialise_metrics(registry),
+            metrics,
             clock,
         ));
         let start_time = Instant::now();
 
-        context
-            .metrics
-            .node_metrics
-            .authority_index
-            .with_label_values(&[&own_hostname])
-            .set(context.own_index.value() as i64);
         context
             .metrics
             .node_metrics
@@ -216,6 +247,7 @@ where
 
         let mut network_manager = N::new(context.clone(), network_keypair);
         let validator_client = network_manager.validator_client();
+        let observer_client = network_manager.observer_client();
 
         let synchronizer_client = Arc::new(SynchronizerClient::<
             N::ValidatorClient,
@@ -223,7 +255,7 @@ where
         >::new(
             context.clone(),
             Some(validator_client.clone()),
-            None, // TODO: set observer client if want to talk to a peer's observer server.
+            Some(observer_client.clone()),
         ));
         let commit_syncer_client = Arc::new(CommitSyncerClient::<
             N::ValidatorClient,
@@ -231,7 +263,7 @@ where
         >::new(
             context.clone(),
             Some(validator_client.clone()),
-            None, // TODO: set observer client if want to talk to a peer's observer server.
+            Some(observer_client.clone()),
         ));
 
         let store_path = context.parameters.db_path.as_path().to_str().unwrap();
@@ -249,11 +281,13 @@ where
         let transaction_vote_tracker =
             TransactionVoteTracker::new(context.clone(), block_verifier.clone(), dag_state.clone());
 
+        // Only sync last known own block if we are a validator and it's the first boot.
         let sync_last_known_own_block = boot_counter == 0
             && !context
                 .parameters
                 .sync_last_known_own_block_timeout
-                .is_zero();
+                .is_zero()
+            && context.is_validator();
         info!(
             "Sync last known own block: {}. Boot count: {}. Timeout: {:?}.",
             sync_last_known_own_block,
@@ -291,19 +325,30 @@ where
 
         // To avoid accidentally leaking the private key, the protocol key pair should only be
         // kept in Core.
-        let core = Core::new(
-            context.clone(),
-            leader_schedule,
-            tx_consumer,
-            transaction_vote_tracker.clone(),
-            block_manager,
-            commit_observer,
-            core_signals,
-            protocol_keypair,
-            dag_state.clone(),
-            sync_last_known_own_block,
-            round_tracker.clone(),
-        );
+        let core = if context.is_validator() {
+            Core::new_validator(
+                context.clone(),
+                leader_schedule,
+                tx_consumer,
+                transaction_vote_tracker.clone(),
+                block_manager,
+                commit_observer,
+                core_signals,
+                protocol_keypair.expect("protocol keypair is required when running as validator"),
+                dag_state.clone(),
+                sync_last_known_own_block,
+                round_tracker.clone(),
+            )
+        } else {
+            Core::new_observer(
+                context.clone(),
+                leader_schedule,
+                block_manager,
+                commit_observer,
+                core_signals,
+                dag_state.clone(),
+            )
+        };
 
         let (core_dispatcher, core_thread_handle) =
             ChannelCoreThreadDispatcher::start(context.clone(), &dag_state, core);
@@ -338,33 +383,30 @@ where
         )
         .start();
 
-        let round_prober_handle = RoundProber::new(
-            context.clone(),
-            core_dispatcher.clone(),
-            round_tracker.clone(),
-            dag_state.clone(),
-            validator_client.clone(),
-        )
-        .start();
+        let (subscriber, round_prober_handle) = if context.is_validator() {
+            let authority_service = Arc::new(AuthorityService::new(
+                context.clone(),
+                block_verifier,
+                commit_vote_monitor,
+                round_tracker.clone(),
+                synchronizer.clone(),
+                core_dispatcher.clone(),
+                signals_receivers.block_broadcast_receiver(),
+                transaction_vote_tracker,
+                dag_state.clone(),
+                store.clone(),
+            ));
 
-        let network_service = Arc::new(AuthorityService::new(
-            context.clone(),
-            block_verifier,
-            commit_vote_monitor,
-            round_tracker.clone(),
-            synchronizer.clone(),
-            core_dispatcher,
-            signals_receivers.block_broadcast_receiver(),
-            transaction_vote_tracker,
-            dag_state.clone(),
-            store.clone(),
-        ));
+            // Start the validator server if this is a validator node.
+            network_manager
+                .start_validator_server(authority_service.clone())
+                .await;
 
-        let subscriber = {
+            // Validator node: subscribe to all other validators
             let s = Subscriber::new(
                 context.clone(),
-                validator_client,
-                network_service.clone(),
+                validator_client.clone(),
+                authority_service.clone(),
                 dag_state.clone(),
             );
             for (peer, _) in context.committee.authorities() {
@@ -372,13 +414,59 @@ where
                     s.subscribe(peer);
                 }
             }
-            s
+
+            // Start the round prober
+            let round_prober_handle = Some(
+                RoundProber::new(
+                    context.clone(),
+                    core_dispatcher,
+                    round_tracker.clone(),
+                    dag_state.clone(),
+                    validator_client,
+                )
+                .start(),
+            );
+
+            (SubscriberType::Validator(s), round_prober_handle)
+        } else {
+            // Observer node: subscribe to specified peer(s) using ObserverSubscriber
+            let observer_client = network_manager.observer_client();
+            let observer_service = Arc::new(ObserverService::new(
+                context.clone(),
+                dag_state.clone(),
+                signals_receivers.accepted_block_broadcast_receiver(),
+            ));
+
+            let observer_subscriber = ObserverSubscriber::new(
+                context.clone(),
+                observer_client,
+                observer_service,
+                dag_state.clone(),
+            );
+
+            // Subscribe to peers specified in the configuration
+            // For now get the first peer from the list to connect to.
+            // TODO: support multiple peers - as in choose/detect which one to connect to.
+            for peer_record in context.parameters.tonic.observer_peers.iter().take(1) {
+                let peer_id = if let Some((index, _)) = context
+                    .committee
+                    .authorities()
+                    .find(|(_, authority)| authority.network_key == peer_record.public_key)
+                {
+                    PeerId::Validator(index)
+                } else {
+                    PeerId::Observer(peer_record.public_key.clone())
+                };
+
+                info!("Observer subscribing to peer: {:?}", peer_id);
+                observer_subscriber.subscribe(peer_id);
+            }
+
+            (SubscriberType::Observer(observer_subscriber), None)
         };
 
-        network_manager
-            .start_validator_server(network_service.clone())
-            .await;
-        if context.parameters.tonic.is_observer_server_enabled() {
+        // Start the observer server if this is an observer node, or the observer server is enabled in the parameters.
+        if context.is_observer() || context.parameters.tonic.is_observer_server_enabled() {
             let observer_service = Arc::new(ObserverService::new(
                 context.clone(),
                 dag_state.clone(),
@@ -425,7 +513,9 @@ where
             );
         };
         self.commit_syncer_handle.stop().await;
-        self.round_prober_handle.stop().await;
+        if let Some(round_prober_handle) = self.round_prober_handle {
+            round_prober_handle.stop().await;
+        }
         self.leader_timeout_handle.stop().await;
         // Shutdown Core to stop block productions and broadcast.
         self.core_thread_handle.stop().await;
@@ -470,7 +560,13 @@ where
         // Re-subscribe to the peer to force reconnection with new address
         if peer != self.context.own_index {
             info!("Re-subscribing to peer {} after address update", peer);
-            self.subscriber.subscribe(peer);
+            match &self.subscriber {
+                SubscriberType::Validator(s) => s.subscribe(peer),
+                SubscriberType::Observer(s) => {
+                    // For observer, create a PeerId for the validator
+                    s.subscribe(PeerId::Validator(peer));
+                }
+            }
         }
     }
 }
@@ -485,10 +581,13 @@ mod tests {
         time::Duration,
     };
 
-    use consensus_config::{Parameters, local_committee_and_keys};
+    use consensus_config::{
+        AuthorityIndex, Parameters, PeerRecord, TonicParameters, local_committee_and_keys,
+    };
     use mysten_metrics::RegistryService;
     use mysten_metrics::monitored_mpsc::UnboundedReceiver;
     use prometheus::Registry;
+    use rand::{SeedableRng, rngs::StdRng};
     use rstest::rstest;
     use tempfile::TempDir;
     use tokio::time::{sleep, timeout};
@@ -525,11 +624,10 @@ mod tests {
         let authority = ConsensusAuthority::start(
             network_type,
             0,
-            own_index,
             committee,
             parameters,
             ConsensusProtocolConfig::for_testing(),
-            protocol_keypair,
+            Some(protocol_keypair),
             network_keypair,
             Arc::new(Clock::default()),
             Arc::new(txn_verifier),
@@ -546,7 +644,55 @@ mod tests {
         authority.stop().await;
     }
 
+    #[rstest]
+    #[tokio::test]
+    async fn test_observer_start_and_stop(#[values(NetworkType::Tonic)] network_type: NetworkType) {
+        let (committee, keypairs) = local_committee_and_keys(0, vec![1]);
+        let registry = Registry::new();
+
+        let temp_dir = TempDir::new().unwrap();
+        let parameters = Parameters {
+            db_path: temp_dir.keep(),
+            ..Default::default()
+        };
+        let txn_verifier = NoopTransactionVerifier {};
+
+        // Use any network keypair for the observer, it doesn't need to match a committee member
+        let network_keypair = keypairs[0].0.clone();
+
+        let (commit_consumer, _) = CommitConsumerArgs::new(0, 0);
+
+        let observer = ConsensusAuthority::start(
+            network_type,
+            0,
+            committee.clone(),
+            parameters,
+            ConsensusProtocolConfig::for_testing(),
+            None, // No protocol keypair for observer node
+            network_keypair,
+            Arc::new(Clock::default()),
+            Arc::new(txn_verifier),
+            commit_consumer,
+            registry,
+            0,
+        )
+        .await;
+
+        sleep(Duration::from_secs(2)).await;
+
+        // Observer nodes have own_index set to MAX as a special value
+        assert_eq!(observer.context().own_index, AuthorityIndex::MAX);
+        assert_eq!(observer.context().committee.epoch(), 0);
+        assert_eq!(observer.context().committee.size(), 1);
+        assert!(!observer.context().is_validator());
+
+        observer.stop().await;
+    }
+
     // TODO: build AuthorityFixture.
+    // Spins up a committee of authorities and an observer node that connects to authority 0.
+    // Verifies that the network is progressing, advancing rounds and commits. It also verifies
+    // that the Observer node is receiving blocks from the network.
     #[rstest]
     #[tokio::test(flavor = "current_thread")]
     async fn test_authority_committee(
@@ -570,21 +716,85 @@ mod tests {
         let mut authorities = Vec::with_capacity(committee.size());
         let mut boot_counters = [0; NUM_OF_AUTHORITIES];
 
-        for (index, _authority_info) in committee.authorities() {
-            let (authority, commit_receiver) = make_authority(
-                index,
-                &temp_dirs[index.value()],
-                committee.clone(),
-                keypairs.clone(),
-                network_type,
-                boot_counters[index],
-                protocol_config.clone(),
-            )
-            .await;
+        // Use a unique port based on gc_depth to avoid conflicts between parallel tests
+        let observer_server_port = 8900 + gc_depth as u16;
+
+        // Create authorities with observer server enabled for authority 0
+        let mut authority_0_network_key = None;
+        for (index, authority_info) in committee.authorities() {
+            let (authority, commit_receiver) = if index.value() == 0 {
+                // Save authority 0's network key for Observer connection
+                authority_0_network_key = Some(authority_info.network_key.clone());
+                // Enable observer server for authority 0
+                make_authority_with_observer_server(
+                    index,
+                    &temp_dirs[index.value()],
+                    committee.clone(),
+                    keypairs.clone(),
+                    network_type,
+                    boot_counters[index],
+                    protocol_config.clone(),
+                    Some(observer_server_port),
+                )
+                .await
+            } else {
+                make_authority(
+                    index,
+                    &temp_dirs[index.value()],
+                    committee.clone(),
+                    keypairs.clone(),
+                    network_type,
+                    boot_counters[index],
+                    protocol_config.clone(),
+                )
+                .await
+            };
             boot_counters[index] += 1;
             commit_receivers.push(commit_receiver);
             authorities.push(authority);
         }
+
+        // Create an Observer node that connects to authority 0
+        let observer_temp_dir = TempDir::new().unwrap();
+        let mut rng = StdRng::from_seed([99; 32]);
+        let observer_network_keypair = consensus_config::NetworkKeyPair::generate(&mut rng);
+
+        let observer_parameters = Parameters {
+            db_path: observer_temp_dir.path().to_path_buf(),
+            tonic: TonicParameters {
+                // Configure Observer to connect to authority 0
+                observer_peers: vec![PeerRecord {
+                    public_key: authority_0_network_key
+                        .clone()
+                        .expect("Authority 0 network key should be set"),
+                    address: format!("/ip4/127.0.0.1/udp/{}", observer_server_port)
+                        .parse()
+                        .unwrap(),
+                }],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let (observer_commit_consumer, _observer_commit_receiver) = CommitConsumerArgs::new(0, 0);
+        let observer = ConsensusAuthority::start(
+            network_type,
+            0,
+            committee.clone(),
+            observer_parameters,
+            protocol_config.clone(),
+            None, // No protocol keypair for observer
+            observer_network_keypair,
+            Arc::new(Clock::default()),
+            Arc::new(NoopTransactionVerifier {}),
+            observer_commit_consumer,
+            Registry::new(),
+            0,
+        )
+        .await;
+
+        // Give Observer more time to connect and sync
+        sleep(Duration::from_secs(5)).await;
 
         const NUM_TRANSACTIONS: u8 = 15;
         let mut submitted_transactions = BTreeSet::<Vec<u8>>::new();
@@ -642,6 +852,59 @@ mod tests {
         commit_receivers[index] = commit_receiver;
         authorities.insert(index.value(), authority);
         sleep(Duration::from_secs(10)).await;
+
+        // Verify that the Observer node is running
+        // TODO: The actual block processing for observers is not fully implemented yet
+        // for now we just verify that blocks are received and the number of received blocks is not far from
+        // the number of blocks sent by authority 0.
+        let observer_context = observer.context();
+        assert!(
+            observer_context.is_observer(),
+            "It should be an observer node"
+        );
+
+        // Get the total verified_blocks from authority 0 (sum across all sending authorities)
+        let authority_0 = &authorities[0];
+        let authority_0_context = authority_0.context();
+        let mut authority_0_total_verified_blocks = 0;
+
+        // Sum verified_blocks from all authorities as seen by authority 0
+        for (_, authority_info) in committee.authorities() {
+            if let Ok(metric) = authority_0_context
+                .metrics
+                .node_metrics
+                .verified_blocks
+                .get_metric_with_label_values(&[&authority_info.hostname])
+            {
+                authority_0_total_verified_blocks += metric.get();
+            }
+        }
+
+        // Get the observer's received_blocks_observer metric
+        let observer_received_blocks_metric = observer_context
+            .metrics
+            .node_metrics
+            .verified_blocks
+            .get_metric_with_label_values(&["observer"])
+            .unwrap();
+        let observer_received_blocks = observer_received_blocks_metric.get();
+
+        // Compare the values - they should be related but might not be exactly equal
+        // due to timing and the observer connecting mid-stream
+        assert!(
+            observer_received_blocks > 0,
+            "Observer should have received at least some blocks, got: {}",
+            observer_received_blocks
+        );
+
+        const TOLERANCE: u64 = 20;
+        assert!(
+            authority_0_total_verified_blocks - observer_received_blocks <= TOLERANCE,
+            "The number of blocks received by the observer should be close to the number of blocks sent by authority 0"
+        );
+
+        // Stop observer first
+        observer.stop().await;
 
         // Stop all authorities and exit.
         for authority in authorities {
@@ -872,10 +1135,33 @@ mod tests {
         boot_counter: u64,
         protocol_config: ConsensusProtocolConfig,
     ) -> (ConsensusAuthority, UnboundedReceiver<CommittedSubDag>) {
+        make_authority_with_observer_server(
+            index,
+            db_dir,
+            committee,
+            keypairs,
+            network_type,
+            boot_counter,
+            protocol_config,
+            None, // No observer server port
+        )
+        .await
+    }
+
+    async fn make_authority_with_observer_server(
+        index: AuthorityIndex,
+        db_dir: &TempDir,
+        committee: Committee,
+        keypairs: Vec<(NetworkKeyPair, ProtocolKeyPair)>,
+        network_type: NetworkType,
+        boot_counter: u64,
+        protocol_config: ConsensusProtocolConfig,
+        observer_server_port: Option<u16>,
+    ) -> (ConsensusAuthority, UnboundedReceiver<CommittedSubDag>) {
         let registry = Registry::new();
 
         // Cache less blocks to exercise commit sync.
-        let parameters = Parameters {
+        let mut parameters = Parameters {
             db_path: db_dir.path().to_path_buf(),
             dag_state_cached_rounds: 5,
             commit_sync_parallel_fetches: 2,
@@ -883,6 +1169,12 @@ mod tests {
             sync_last_known_own_block_timeout: Duration::from_millis(2_000),
             ..Default::default()
         };
+
+        // Enable observer server if port is provided
+        if let Some(port) = observer_server_port {
+            parameters.tonic.observer_server_port = Some(port);
+        }
+
         let txn_verifier = NoopTransactionVerifier {};
 
         let protocol_keypair = keypairs[index].1.clone();
@@ -893,11 +1185,10 @@ mod tests {
         let authority = ConsensusAuthority::start(
             network_type,
             0,
-            index,
             committee,
             parameters,
             protocol_config,
-            protocol_keypair,
+            Some(protocol_keypair),
             network_keypair,
             Arc::new(Clock::default()),
             Arc::new(txn_verifier),

--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -428,6 +428,18 @@ where
                 .start(),
             );
 
+            // Start the observer server if the observer server is enabled in the parameters.
+            if context.parameters.tonic.is_observer_server_enabled() {
+                let observer_service = Arc::new(ObserverService::new(
+                    context.clone(),
+                    dag_state.clone(),
+                    signals_receivers.accepted_block_broadcast_receiver(),
+                ));
+                network_manager
+                    .start_observer_server(observer_service)
+                    .await;
+            }
+
             (SubscriberType::Validator(s), round_prober_handle)
         } else {
             // Observer node: subscribe to specified peer(s) using ObserverSubscriber
@@ -465,18 +477,6 @@ where
 
             (SubscriberType::Observer(observer_subscriber), None)
         };
-
-        // Start the observer server if this is an observer node, or the observer server is enabled in the parameters.
-        if context.is_observer() || context.parameters.tonic.is_observer_server_enabled() {
-            let observer_service = Arc::new(ObserverService::new(
-                context.clone(),
-                dag_state.clone(),
-                signals_receivers.accepted_block_broadcast_receiver(),
-            ));
-            network_manager
-                .start_observer_server(observer_service)
-                .await;
-        }
 
         info!(
             "Consensus authority started, took {:?}",

--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -429,7 +429,7 @@ where
             );
 
             // Start the observer server if the observer server is enabled in the parameters.
-            if context.parameters.tonic.is_observer_server_enabled() {
+            if context.parameters.observer.is_server_enabled() {
                 let observer_service = Arc::new(ObserverService::new(
                     context.clone(),
                     dag_state.clone(),
@@ -460,7 +460,7 @@ where
             // Subscribe to peers specified in the configuration
             // For now get the first peer from the list to connect to.
             // TODO: support multiple peers - as in choose/detect which one to connect to.
-            for peer_record in context.parameters.tonic.observer_peers.iter().take(1) {
+            for peer_record in context.parameters.observer.peers.iter().take(1) {
                 let peer_id = if let Some((index, _)) = context
                     .committee
                     .authorities()
@@ -583,7 +583,7 @@ mod tests {
     };
 
     use consensus_config::{
-        AuthorityIndex, Parameters, PeerRecord, TonicParameters, local_committee_and_keys,
+        AuthorityIndex, ObserverParameters, Parameters, PeerRecord, local_committee_and_keys,
     };
     use mysten_metrics::RegistryService;
     use mysten_metrics::monitored_mpsc::UnboundedReceiver;
@@ -762,9 +762,9 @@ mod tests {
 
         let observer_parameters = Parameters {
             db_path: observer_temp_dir.path().to_path_buf(),
-            tonic: TonicParameters {
+            observer: ObserverParameters {
                 // Configure Observer to connect to authority 0
-                observer_peers: vec![PeerRecord {
+                peers: vec![PeerRecord {
                     public_key: authority_0_network_key
                         .clone()
                         .expect("Authority 0 network key should be set"),
@@ -1198,7 +1198,7 @@ mod tests {
 
         // Enable observer server if port is provided
         if let Some(port) = observer_server_port {
-            parameters.tonic.observer_server_port = Some(port);
+            parameters.observer.server_port = Some(port);
         }
 
         let txn_verifier = NoopTransactionVerifier {};

--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -4,8 +4,8 @@
 use std::{sync::Arc, time::Instant};
 
 use consensus_config::{
-    AuthorityIndex, ChainType, Committee, ConsensusProtocolConfig, NetworkKeyPair,
-    NetworkPublicKey, Parameters, ProtocolKeyPair,
+    ChainType, Committee, ConsensusProtocolConfig, NetworkKeyPair, NetworkPublicKey, Parameters,
+    ProtocolKeyPair,
 };
 use consensus_types::block::Round;
 use itertools::Itertools;
@@ -33,6 +33,7 @@ use crate::{
         CommitSyncerClient, NetworkManager, PeerId, SynchronizerClient, tonic_network::TonicManager,
     },
     observer_service::ObserverService,
+    observer_subscriber::ObserverSubscriber,
     round_prober::{RoundProber, RoundProberHandle},
     round_tracker::RoundTracker,
     storage::rocksdb_store::RocksDBStore,

--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -878,8 +878,26 @@ mod tests {
                 .get_metric_with_label_values(&[&authority_info.hostname])
             {
                 authority_0_total_verified_blocks += metric.get();
+                println!(
+                    "authority_info.hostname: {}, metric: {:?}",
+                    authority_info.hostname, authority_0_total_verified_blocks
+                );
             }
         }
+
+        let mut authority_0_total_proposed_blocks = 0;
+        for force in [true, false] {
+            if let Ok(metric) = authority_0_context
+                .metrics
+                .node_metrics
+                .proposed_blocks
+                .get_metric_with_label_values(&[&force.to_string()])
+            {
+                authority_0_total_proposed_blocks += metric.get();
+            }
+        }
+
+        authority_0_total_verified_blocks += authority_0_total_proposed_blocks;
 
         // Get the observer's received_blocks_observer metric
         let observer_received_blocks_metric = observer_context
@@ -898,10 +916,17 @@ mod tests {
             observer_received_blocks
         );
 
+        println!(
+            "authority_0_total_verified_blocks: {}, observer_received_blocks: {}",
+            authority_0_total_verified_blocks, observer_received_blocks
+        );
+
         const TOLERANCE: u64 = 20;
         assert!(
             authority_0_total_verified_blocks - observer_received_blocks <= TOLERANCE,
-            "The number of blocks received by the observer should be close to the number of blocks sent by authority 0"
+            "The number of blocks received by the observer ({}) should be close to the number of blocks verified by authority 0 ({})",
+            observer_received_blocks,
+            authority_0_total_verified_blocks,
         );
 
         // Stop observer first

--- a/consensus/core/src/authority_service.rs
+++ b/consensus/core/src/authority_service.rs
@@ -363,7 +363,9 @@ impl<C: CoreThreadDispatcher> ValidatorNetworkService for AuthorityService<C> {
             let mut proposed_blocks =
                 dag_state.get_cached_blocks(self.context.own_index, last_received + 1);
             if proposed_blocks.is_empty() {
-                let last_proposed_block = dag_state.get_last_proposed_block();
+                let last_proposed_block = dag_state
+                    .get_last_proposed_block()
+                    .expect("A block should have been returned");
                 proposed_blocks = if last_proposed_block.round() > GENESIS_ROUND {
                     vec![last_proposed_block]
                 } else {

--- a/consensus/core/src/authority_service.rs
+++ b/consensus/core/src/authority_service.rs
@@ -365,7 +365,7 @@ impl<C: CoreThreadDispatcher> ValidatorNetworkService for AuthorityService<C> {
             if proposed_blocks.is_empty() {
                 let last_proposed_block = dag_state
                     .get_last_proposed_block()
-                    .expect("A block should have been returned");
+                    .expect("Last proposed block should be returned on validators");
                 proposed_blocks = if last_proposed_block.round() > GENESIS_ROUND {
                     vec![last_proposed_block]
                 } else {

--- a/consensus/core/src/context.rs
+++ b/consensus/core/src/context.rs
@@ -35,13 +35,20 @@ pub struct Context {
 impl Context {
     pub(crate) fn new(
         epoch_start_timestamp_ms: u64,
-        own_index: AuthorityIndex,
+        own_index: Option<AuthorityIndex>,
         committee: Committee,
         parameters: Parameters,
         protocol_config: ConsensusProtocolConfig,
         metrics: Arc<Metrics>,
         clock: Arc<Clock>,
     ) -> Self {
+        let own_index = if let Some(own_index) = own_index {
+            own_index
+        } else {
+            // If no index is provided, then this is an observer node. We assign a max index to it as a special value.
+            AuthorityIndex::MAX
+        };
+
         Self {
             epoch_start_timestamp_ms,
             own_index,
@@ -74,7 +81,7 @@ impl Context {
 
         let context = Context::new(
             0,
-            AuthorityIndex::new_for_test(0),
+            Some(AuthorityIndex::new_for_test(0)),
             committee,
             Parameters {
                 db_path: temp_dir.keep(),
@@ -115,6 +122,11 @@ impl Context {
     /// Returns true if this node is a validator (i.e., part of the committee).
     pub fn is_validator(&self) -> bool {
         self.committee.is_valid_index(self.own_index)
+    }
+
+    /// Returns true if this node is an observer (i.e., not part of the committee).
+    pub fn is_observer(&self) -> bool {
+        !self.is_validator()
     }
 }
 

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -3,26 +3,21 @@
 
 use std::{
     collections::{BTreeMap, BTreeSet},
-    iter,
     sync::Arc,
-    time::Duration,
     vec,
 };
 
-use consensus_config::{AuthorityIndex, ProtocolKeyPair};
+use consensus_config::ProtocolKeyPair;
 #[cfg(test)]
-use consensus_config::{Stake, local_committee_and_keys};
-use consensus_types::block::{BlockRef, BlockTimestampMs, Round};
+use consensus_config::{AuthorityIndex, Stake, local_committee_and_keys};
+use consensus_types::block::{BlockRef, Round};
 use itertools::Itertools as _;
 #[cfg(test)]
 use mysten_metrics::monitored_mpsc::UnboundedReceiver;
 use mysten_metrics::monitored_scope;
 use parking_lot::RwLock;
 use sui_macros::fail_point;
-use tokio::{
-    sync::{broadcast, watch},
-    time::Instant,
-};
+use tokio::sync::{broadcast, watch};
 use tracing::{debug, info, trace, warn};
 
 #[cfg(test)]
@@ -31,11 +26,8 @@ use crate::{
     storage::mem_store::MemStore,
 };
 use crate::{
-    ancestor::{AncestorState, AncestorStateManager},
-    block::{
-        Block, BlockAPI, BlockV1, BlockV2, ExtendedBlock, GENESIS_ROUND, SignedBlock, Slot,
-        VerifiedBlock,
-    },
+    ancestor::AncestorStateManager,
+    block::{BlockAPI, ExtendedBlock, GENESIS_ROUND, Slot, VerifiedBlock},
     block_manager::BlockManager,
     commit::{
         CertifiedCommit, CertifiedCommits, CommitAPI, CommitIndex, CommittedSubDag, DecidedLeader,
@@ -46,8 +38,8 @@ use crate::{
     dag_state::DagState,
     error::{ConsensusError, ConsensusResult},
     leader_schedule::LeaderSchedule,
+    proposer::{Proposer, ValidatorProposer},
     round_tracker::RoundTracker,
-    stake_aggregator::{QuorumThreshold, StakeAggregator},
     transaction::TransactionConsumer,
     transaction_vote_tracker::TransactionVoteTracker,
     universal_committer::{
@@ -55,34 +47,15 @@ use crate::{
     },
 };
 
-// Maximum number of commit votes to include in a block.
-// TODO: Move to protocol config, and verify in BlockVerifier.
-const MAX_COMMIT_VOTES_PER_BLOCK: usize = 100;
-
 pub(crate) struct Core {
     context: Arc<Context>,
-    /// The consumer to use in order to pull transactions to be included for the next proposals
-    transaction_consumer: TransactionConsumer,
-    /// This contains the reject votes on transactions which proposed blocks should include.
-    transaction_vote_tracker: TransactionVoteTracker,
     /// The block manager which is responsible for keeping track of the DAG dependencies when processing new blocks
     /// and accept them or suspend if we are missing their causal history
     block_manager: BlockManager,
-    /// Estimated delay by round for propagating blocks to a quorum.
-    /// Because of the nature of TCP and block streaming, propagation delay is expected to be
-    /// 0 in most cases, even when the actual latency of broadcasting blocks is high.
-    /// When this value is higher than the `propagation_delay_stop_proposal_threshold`,
-    /// most likely this validator cannot broadcast  blocks to the network at all.
-    /// Core stops proposing new blocks in this case.
-    propagation_delay: Round,
     /// Used to make commit decisions for leader blocks in the dag.
-    committer: UniversalCommitter,
+    committer: Arc<UniversalCommitter>,
     /// The last new round for which core has sent out a signal.
     last_signaled_round: Round,
-    /// The blocks of the last included ancestors per authority. This vector is basically used as a
-    /// watermark in order to include in the next block proposal only ancestors of higher rounds.
-    /// By default, is initialised with `None` values.
-    last_included_ancestors: Vec<Option<BlockRef>>,
     /// The last decided leader returned from the universal committer. Important to note
     /// that this does not signify that the leader has been persisted yet as it still has
     /// to go through CommitObserver and persist the commit in store. On recovery/restart
@@ -96,28 +69,16 @@ pub(crate) struct Core {
     commit_observer: CommitObserver,
     /// Sender of outgoing signals from Core.
     signals: CoreSignals,
-    /// The keypair to be used for block signing
-    block_signer: ProtocolKeyPair,
     /// Keeping track of state of the DAG, including blocks, commits and last committed rounds.
     dag_state: Arc<RwLock<DagState>>,
-    /// The last known round for which the node has proposed. Any proposal should be for a round > of this.
-    /// This is currently being used to avoid equivocations during a node recovering from amnesia. When value is None it means that
-    /// the last block sync mechanism is enabled, but it hasn't been initialised yet.
-    last_known_proposed_round: Option<Round>,
-    // The ancestor state manager will keep track of the quality of the authorities
-    // based on the distribution of their blocks to the network. It will use this
-    // information to decide whether to include that authority block in the next
-    // proposal or not.
-    ancestor_state_manager: AncestorStateManager,
-    // The round tracker will keep track of the highest received and accepted rounds
-    // from all authorities. It will use this information to then calculate the
-    // quorum rounds periodically which is used across other components to make
-    // decisions about block proposals.
-    round_tracker: Arc<RwLock<RoundTracker>>,
+    /// Block proposal engine for Validator nodes only.
+    /// Validators have a proposer to create blocks, Observers have None (they only receive blocks).
+    proposer: Option<Box<dyn Proposer>>,
 }
 
 impl Core {
-    pub(crate) fn new(
+    /// Creates a new Core instance for a validator node that participates in consensus.
+    pub(crate) fn new_validator(
         context: Arc<Context>,
         leader_schedule: Arc<LeaderSchedule>,
         transaction_consumer: TransactionConsumer,
@@ -132,33 +93,30 @@ impl Core {
     ) -> Self {
         let last_decided_leader = dag_state.read().last_commit_leader();
         let number_of_leaders = context.protocol_config.num_leaders_per_round().unwrap_or(1);
-        let committer = UniversalCommitterBuilder::new(
-            context.clone(),
-            leader_schedule.clone(),
-            dag_state.clone(),
-        )
-        .with_number_of_leaders(number_of_leaders)
-        .with_pipeline(true)
-        .build();
+        let committer = Arc::new(
+            UniversalCommitterBuilder::new(
+                context.clone(),
+                leader_schedule.clone(),
+                dag_state.clone(),
+            )
+            .with_number_of_leaders(number_of_leaders)
+            .with_pipeline(true)
+            .build(),
+        );
 
-        let last_proposed_block = dag_state.read().get_last_proposed_block();
-
+        let last_proposed_block = dag_state
+            .read()
+            .get_last_proposed_block()
+            .expect("A block should have been returned");
         let last_signaled_round = last_proposed_block.round();
 
-        // Recover the last included ancestor rounds based on the last proposed block. That will allow
-        // to perform the next block proposal by using ancestor blocks of higher rounds and avoid
-        // re-including blocks that have been already included in the last (or earlier) block proposal.
-        // This is only strongly guaranteed for a quorum of ancestors. It is still possible to re-include
-        // a block from an authority which hadn't been added as part of the last proposal hence its
-        // latest included ancestor is not accurately captured here. This is considered a small deficiency,
-        // and it mostly matters just for this next proposal without any actual penalties in performance
-        // or block proposal.
+        // Recover the last included ancestor rounds based on the last proposed block
         let mut last_included_ancestors = vec![None; context.committee.size()];
         for ancestor in last_proposed_block.ancestors() {
             last_included_ancestors[ancestor.author] = Some(*ancestor);
         }
 
-        let min_propose_round = if sync_last_known_own_block {
+        let last_known_proposed_round = if sync_last_known_own_block {
             None
         } else {
             // if the sync is disabled then we practically don't want to impose any restriction.
@@ -174,35 +132,96 @@ impl Core {
             AncestorStateManager::new(context.clone(), dag_state.clone());
         ancestor_state_manager.set_propagation_scores(propagation_scores);
 
+        // Create the ValidatorProposer
+        let proposer = Some(Box::new(ValidatorProposer::new(
+            dag_state.clone(),
+            context.clone(),
+            transaction_consumer,
+            transaction_vote_tracker.clone(),
+            block_signer,
+            last_known_proposed_round,
+            ancestor_state_manager,
+            round_tracker.clone(),
+            committer.clone(),
+        )) as Box<dyn Proposer>);
+
         Self {
             context,
             last_signaled_round,
-            last_included_ancestors,
             last_decided_leader,
             leader_schedule,
-            transaction_consumer,
-            transaction_vote_tracker,
             block_manager,
-            propagation_delay: 0,
             committer,
             commit_observer,
             signals,
-            block_signer,
             dag_state,
-            last_known_proposed_round: min_propose_round,
-            ancestor_state_manager,
-            round_tracker,
+            proposer,
         }
-        .recover()
+        .recover_validator()
     }
 
-    fn recover(mut self) -> Self {
+    /// Creates a new Core instance for an observer node that only processes blocks.
+    pub(crate) fn new_observer(
+        context: Arc<Context>,
+        leader_schedule: Arc<LeaderSchedule>,
+        block_manager: BlockManager,
+        commit_observer: CommitObserver,
+        signals: CoreSignals,
+        dag_state: Arc<RwLock<DagState>>,
+    ) -> Self {
+        let last_decided_leader = dag_state.read().last_commit_leader();
+        let number_of_leaders = context.protocol_config.num_leaders_per_round().unwrap_or(1);
+        let committer = Arc::new(
+            UniversalCommitterBuilder::new(
+                context.clone(),
+                leader_schedule.clone(),
+                dag_state.clone(),
+            )
+            .with_number_of_leaders(number_of_leaders)
+            .with_pipeline(true)
+            .build(),
+        );
+
+        // For the Observer nodes let's consider the last signaled round as the latest threshold clock round.
+        let last_signaled_round = dag_state.read().threshold_clock_round();
+
+        Self {
+            context,
+            last_signaled_round,
+            last_decided_leader,
+            leader_schedule,
+            block_manager,
+            committer,
+            commit_observer,
+            signals,
+            dag_state,
+            proposer: None,
+        }
+        .recover_observer()
+    }
+
+    fn recover_observer(mut self) -> Self {
         let _s = self
             .context
             .metrics
             .node_metrics
             .scope_processing_time
-            .with_label_values(&["Core::recover"])
+            .with_label_values(&["Core::recover_observer"])
+            .start_timer();
+
+        // Try to commit, since they may not have run after the last storage write.
+        self.try_commit(vec![]).unwrap();
+
+        self
+    }
+
+    fn recover_validator(mut self) -> Self {
+        let _s = self
+            .context
+            .metrics
+            .node_metrics
+            .scope_processing_time
+            .with_label_values(&["Core::recover_validator"])
             .start_timer();
 
         // Try to commit and propose, since they may not have run after the last storage write.
@@ -212,9 +231,13 @@ impl Core {
         {
             last_proposed_block
         } else {
-            let last_proposed_block = self.dag_state.read().get_last_proposed_block();
+            let proposer = self
+                .proposer
+                .as_ref()
+                .expect("Validator must have proposer");
+            let last_proposed_block = proposer.last_proposed_block();
 
-            if self.should_propose() {
+            if proposer.should_propose() {
                 assert!(
                     last_proposed_block.round() > GENESIS_ROUND,
                     "At minimum a block of round higher than genesis should have been produced during recovery"
@@ -237,7 +260,7 @@ impl Core {
         self.try_signal_new_round();
 
         info!(
-            "Core recovery completed with last proposed block {:?}",
+            "Core recovery for validator completed with last proposed block {:?}",
             last_proposed_block
         );
 
@@ -428,7 +451,9 @@ impl Core {
         force: bool,
     ) -> ConsensusResult<Option<VerifiedBlock>> {
         let _scope = monitored_scope("Core::new_block");
-        if self.last_proposed_round() < round {
+        if let Some(last_round) = self.last_proposed_round()
+            && last_round < round
+        {
             self.context
                 .metrics
                 .node_metrics
@@ -485,10 +510,9 @@ impl Core {
     // When force is true, ignore if leader from the last round exists among ancestors and if
     // the minimum round delay has passed.
     fn try_propose(&mut self, force: bool) -> ConsensusResult<Option<VerifiedBlock>> {
-        if !self.should_propose() {
-            return Ok(None);
-        }
-        if let Some(extended_block) = self.try_new_block(force) {
+        if let Some(proposer) = &mut self.proposer
+            && let Some(extended_block) = proposer.try_new_block(force)
+        {
             self.signals.new_block(extended_block.clone())?;
 
             fail_point!("consensus-after-propose");
@@ -498,272 +522,6 @@ impl Core {
             return Ok(Some(extended_block.block));
         }
         Ok(None)
-    }
-
-    /// Attempts to propose a new block for the next round. If a block has already proposed for latest
-    /// or earlier round, then no block is created and None is returned.
-    fn try_new_block(&mut self, force: bool) -> Option<ExtendedBlock> {
-        let _s = self
-            .context
-            .metrics
-            .node_metrics
-            .scope_processing_time
-            .with_label_values(&["Core::try_new_block"])
-            .start_timer();
-
-        // Ensure the new block has a higher round than the last proposed block.
-        let clock_round = {
-            let dag_state = self.dag_state.read();
-            let clock_round = dag_state.threshold_clock_round();
-            if clock_round <= dag_state.get_last_proposed_block().round() {
-                debug!(
-                    "Skipping block proposal for round {} as it is not higher than the last proposed block {}",
-                    clock_round,
-                    dag_state.get_last_proposed_block().round()
-                );
-                return None;
-            }
-            clock_round
-        };
-
-        // There must be a quorum of blocks from the previous round.
-        let quorum_round = clock_round.saturating_sub(1);
-
-        // Create a new block either because we want to "forcefully" propose a block due to a leader timeout,
-        // or because we are actually ready to produce the block (leader exists and min delay has passed).
-        if !force {
-            if !self.leaders_exist(quorum_round) {
-                return None;
-            }
-
-            if Duration::from_millis(
-                self.context
-                    .clock
-                    .timestamp_utc_ms()
-                    .saturating_sub(self.last_proposed_timestamp_ms()),
-            ) < self.context.parameters.min_round_delay
-            {
-                debug!(
-                    "Skipping block proposal for round {} as it is too soon after the last proposed block timestamp {}; min round delay is {}ms",
-                    clock_round,
-                    self.last_proposed_timestamp_ms(),
-                    self.context.parameters.min_round_delay.as_millis(),
-                );
-                return None;
-            }
-        }
-
-        // Determine the ancestors to be included in proposal.
-        let (ancestors, excluded_and_equivocating_ancestors) =
-            self.smart_ancestors_to_propose(clock_round, !force);
-
-        // If we did not find enough good ancestors to propose, continue to wait before proposing.
-        if ancestors.is_empty() {
-            assert!(
-                !force,
-                "Ancestors should have been returned if force is true!"
-            );
-            debug!(
-                "Skipping block proposal for round {} because no good ancestor is found",
-                clock_round,
-            );
-            return None;
-        }
-
-        let excluded_ancestors_limit = self.context.committee.size() * 2;
-        if excluded_and_equivocating_ancestors.len() > excluded_ancestors_limit {
-            debug!(
-                "Dropping {} excluded ancestor(s) during proposal due to size limit",
-                excluded_and_equivocating_ancestors.len() - excluded_ancestors_limit,
-            );
-        }
-        let excluded_ancestors = excluded_and_equivocating_ancestors
-            .into_iter()
-            .take(excluded_ancestors_limit)
-            .collect();
-
-        // Update the last included ancestor block refs
-        for ancestor in &ancestors {
-            self.last_included_ancestors[ancestor.author()] = Some(ancestor.reference());
-        }
-
-        let leader_authority = &self
-            .context
-            .committee
-            .authority(self.first_leader(quorum_round))
-            .hostname;
-        self.context
-            .metrics
-            .node_metrics
-            .block_proposal_leader_wait_ms
-            .with_label_values(&[leader_authority])
-            .inc_by(
-                Instant::now()
-                    .saturating_duration_since(self.dag_state.read().threshold_clock_quorum_ts())
-                    .as_millis() as u64,
-            );
-        self.context
-            .metrics
-            .node_metrics
-            .block_proposal_leader_wait_count
-            .with_label_values(&[leader_authority])
-            .inc();
-
-        self.context
-            .metrics
-            .node_metrics
-            .proposed_block_ancestors
-            .observe(ancestors.len() as f64);
-        for ancestor in &ancestors {
-            let authority = &self.context.committee.authority(ancestor.author()).hostname;
-            self.context
-                .metrics
-                .node_metrics
-                .proposed_block_ancestors_depth
-                .with_label_values(&[authority])
-                .observe(clock_round.saturating_sub(ancestor.round()).into());
-        }
-
-        let now = self.context.clock.timestamp_utc_ms();
-        ancestors.iter().for_each(|block| {
-            if block.timestamp_ms() > now {
-                trace!("Ancestor block {:?} has timestamp {}, greater than current timestamp {now}. Proposing for round {}.", block, block.timestamp_ms(), clock_round);
-                let authority = &self.context.committee.authority(block.author()).hostname;
-                self.context
-                    .metrics
-                    .node_metrics
-                    .proposed_block_ancestors_timestamp_drift_ms
-                    .with_label_values(&[authority])
-                    .inc_by(block.timestamp_ms().saturating_sub(now));
-            }
-        });
-
-        // Consume the next transactions to be included. Do not drop the guards yet as this would acknowledge
-        // the inclusion of transactions. Just let this be done in the end of the method.
-        let (transactions, ack_transactions, _limit_reached) = self.transaction_consumer.next();
-        self.context
-            .metrics
-            .node_metrics
-            .proposed_block_transactions
-            .observe(transactions.len() as f64);
-
-        // Consume the commit votes to be included.
-        let commit_votes = self
-            .dag_state
-            .write()
-            .take_commit_votes(MAX_COMMIT_VOTES_PER_BLOCK);
-
-        let transaction_votes = if self.context.protocol_config.transaction_voting_enabled() {
-            let new_causal_history = {
-                let mut dag_state = self.dag_state.write();
-                ancestors
-                    .iter()
-                    .flat_map(|ancestor| dag_state.link_causal_history(ancestor.reference()))
-                    .collect()
-            };
-            self.transaction_vote_tracker
-                .get_own_votes(new_causal_history)
-        } else {
-            vec![]
-        };
-
-        // Create the block and insert to storage.
-        let block = if self.context.protocol_config.transaction_voting_enabled() {
-            Block::V2(BlockV2::new(
-                self.context.committee.epoch(),
-                clock_round,
-                self.context.own_index,
-                now,
-                ancestors.iter().map(|b| b.reference()).collect(),
-                transactions,
-                commit_votes,
-                transaction_votes,
-                vec![],
-            ))
-        } else {
-            Block::V1(BlockV1::new(
-                self.context.committee.epoch(),
-                clock_round,
-                self.context.own_index,
-                now,
-                ancestors.iter().map(|b| b.reference()).collect(),
-                transactions,
-                commit_votes,
-                vec![],
-            ))
-        };
-        let signed_block =
-            SignedBlock::new(block, &self.block_signer).expect("Block signing failed.");
-        let serialized = signed_block
-            .serialize()
-            .expect("Block serialization failed.");
-        self.context
-            .metrics
-            .node_metrics
-            .proposed_block_size
-            .observe(serialized.len() as f64);
-        // Own blocks are assumed to be valid.
-        let verified_block = VerifiedBlock::new_verified(signed_block, serialized);
-
-        // Record the interval from last proposal, before accepting the proposed block.
-        let last_proposed_block = self.last_proposed_block();
-        if last_proposed_block.round() > 0 {
-            self.context
-                .metrics
-                .node_metrics
-                .block_proposal_interval
-                .observe(
-                    Duration::from_millis(
-                        verified_block
-                            .timestamp_ms()
-                            .saturating_sub(last_proposed_block.timestamp_ms()),
-                    )
-                    .as_secs_f64(),
-                );
-        }
-
-        // Accept the block into BlockManager and DagState.
-        let (accepted_blocks, missing) = self.accept_blocks(vec![verified_block.clone()]);
-        assert_eq!(accepted_blocks.len(), 1);
-        assert!(missing.is_empty());
-
-        // The block must be added to the transaction vote tracker before it is broadcasted or added to DagState.
-        // Update proposed state of blocks in local DAG.
-        // TODO(fastpath): move this logic and the logic afterwards to proposed block handler.
-        if self.context.protocol_config.transaction_voting_enabled() {
-            self.transaction_vote_tracker
-                .add_voted_blocks(vec![(verified_block.clone(), vec![])]);
-            self.dag_state
-                .write()
-                .link_causal_history(verified_block.reference());
-        }
-
-        // Ensure the new block and its ancestors are persisted, before broadcasting it.
-        self.dag_state.write().flush();
-
-        // Now acknowledge the transactions for their inclusion to block
-        ack_transactions(verified_block.reference());
-
-        info!("Created block {verified_block:?} for round {clock_round}");
-
-        self.context
-            .metrics
-            .node_metrics
-            .proposed_blocks
-            .with_label_values(&[&force.to_string()])
-            .inc();
-
-        let extended_block = ExtendedBlock {
-            block: verified_block,
-            excluded_ancestors,
-        };
-
-        // Update round tracker with our own highest accepted blocks
-        self.round_tracker
-            .write()
-            .update_from_verified_block(&extended_block);
-
-        Some(extended_block)
     }
 
     /// Runs commit rule to attempt to commit additional blocks from the DAG. If any `certified_commits` are provided, then
@@ -822,8 +580,9 @@ impl Core {
                     .read()
                     .reputation_scores
                     .clone();
-                self.ancestor_state_manager
-                    .set_propagation_scores(propagation_scores);
+                if let Some(proposer) = &mut self.proposer {
+                    proposer.set_propagation_scores(propagation_scores);
+                }
 
                 commits_until_update = self
                     .leader_schedule
@@ -932,8 +691,12 @@ impl Core {
                 (block.author() == self.context.own_index).then_some(block.reference())
             })
             .collect::<Vec<_>>();
-        self.transaction_consumer
-            .notify_own_blocks_status(committed_block_refs, self.dag_state.read().gc_round());
+        if let Some(proposer) = &self.proposer {
+            proposer.notify_own_blocks_committed(
+                committed_block_refs,
+                self.dag_state.read().gc_round(),
+            );
+        }
 
         Ok(committed_sub_dags)
     }
@@ -946,66 +709,38 @@ impl Core {
     /// Sets the delay by round for propagating blocks to a quorum.
     pub(crate) fn set_propagation_delay(&mut self, delay: Round) {
         info!("Propagation round delay set to: {delay}");
-        self.propagation_delay = delay;
+        if let Some(proposer) = &mut self.proposer {
+            proposer.set_propagation_delay(delay);
+        }
     }
 
     /// Sets the min propose round for the proposer allowing to propose blocks only for round numbers
     /// `> last_known_proposed_round`. At the moment is allowed to call the method only once leading to a panic
     /// if attempt to do multiple times.
     pub(crate) fn set_last_known_proposed_round(&mut self, round: Round) {
-        if self.last_known_proposed_round.is_some() {
-            panic!(
-                "Should not attempt to set the last known proposed round if that has been already set"
-            );
+        if let Some(proposer) = &mut self.proposer {
+            if proposer.get_last_known_proposed_round().is_some() {
+                panic!(
+                    "Should not attempt to set the last known proposed round if that has been already set"
+                );
+            }
+            proposer.set_last_known_proposed_round(round);
+            info!("Last known proposed round set to {round}");
         }
-        self.last_known_proposed_round = Some(round);
-        info!("Last known proposed round set to {round}");
     }
 
-    /// Whether the core should propose new blocks.
+    /// Returns true if the node should propose blocks.
+    /// Observers always return false since they don't have a proposer.
     pub(crate) fn should_propose(&self) -> bool {
-        let clock_round = self.dag_state.read().threshold_clock_round();
-        let core_skipped_proposals = &self.context.metrics.node_metrics.core_skipped_proposals;
+        self.proposer
+            .as_ref()
+            .map(|p| p.should_propose())
+            .unwrap_or(false)
+    }
 
-        if self.propagation_delay
-            > self
-                .context
-                .parameters
-                .propagation_delay_stop_proposal_threshold
-        {
-            debug!(
-                "Skip proposing for round {clock_round}, high propagation delay {} > {}.",
-                self.propagation_delay,
-                self.context
-                    .parameters
-                    .propagation_delay_stop_proposal_threshold
-            );
-            core_skipped_proposals
-                .with_label_values(&["high_propagation_delay"])
-                .inc();
-            return false;
-        }
-
-        let Some(last_known_proposed_round) = self.last_known_proposed_round else {
-            debug!(
-                "Skip proposing for round {clock_round}, last known proposed round has not been synced yet."
-            );
-            core_skipped_proposals
-                .with_label_values(&["no_last_known_proposed_round"])
-                .inc();
-            return false;
-        };
-        if clock_round <= last_known_proposed_round {
-            debug!(
-                "Skip proposing for round {clock_round} as last known proposed round is {last_known_proposed_round}"
-            );
-            core_skipped_proposals
-                .with_label_values(&["higher_last_known_proposed_round"])
-                .inc();
-            return false;
-        }
-
-        true
+    /// Returns the last proposed round, or None if this is an observer node.
+    pub(crate) fn last_proposed_round(&self) -> Option<Round> {
+        self.proposer.as_ref().map(|p| p.last_proposed_round())
     }
 
     // Tries to select a prefix of certified commits to be committed next respecting the `limit`.
@@ -1051,266 +786,23 @@ impl Core {
             .collect::<Vec<_>>()
     }
 
-    /// Retrieves the next ancestors to propose to form a block at `clock_round` round.
-    /// If smart selection is enabled then this will try to select the best ancestors
-    /// based on the propagation scores of the authorities.
-    fn smart_ancestors_to_propose(
-        &mut self,
-        clock_round: Round,
-        smart_select: bool,
-    ) -> (Vec<VerifiedBlock>, BTreeSet<BlockRef>) {
-        let node_metrics = &self.context.metrics.node_metrics;
-        let _s = node_metrics
-            .scope_processing_time
-            .with_label_values(&["Core::smart_ancestors_to_propose"])
-            .start_timer();
-
-        // Now take the ancestors before the clock_round (excluded) for each authority.
-        let all_ancestors = self
-            .dag_state
-            .read()
-            .get_last_cached_block_per_authority(clock_round);
-
-        assert_eq!(
-            all_ancestors.len(),
-            self.context.committee.size(),
-            "Fatal error, number of returned ancestors don't match committee size."
-        );
-
-        // Ensure ancestor state is up to date before selecting for proposal.
-        let accepted_quorum_rounds = self.round_tracker.read().compute_accepted_quorum_rounds();
-
-        self.ancestor_state_manager
-            .update_all_ancestors_state(&accepted_quorum_rounds);
-
-        let ancestor_state_map = self.ancestor_state_manager.get_ancestor_states();
-
-        let quorum_round = clock_round.saturating_sub(1);
-
-        let mut score_and_pending_excluded_ancestors = Vec::new();
-        let mut excluded_and_equivocating_ancestors = BTreeSet::new();
-
-        // Propose only ancestors of higher rounds than what has already been proposed.
-        // And always include own last proposed block first among ancestors.
-        // Start by only including the high scoring ancestors. Low scoring ancestors
-        // will be included in a second pass below.
-        let included_ancestors = iter::once(self.last_proposed_block().clone())
-            .chain(
-                all_ancestors
-                    .into_iter()
-                    .flat_map(|(ancestor, equivocating_ancestors)| {
-                        if ancestor.author() == self.context.own_index {
-                            return None;
-                        }
-                        if let Some(last_block_ref) =
-                            self.last_included_ancestors[ancestor.author()]
-                            && last_block_ref.round >= ancestor.round() {
-                                return None;
-                            }
-
-                        // We will never include equivocating ancestors so add them immediately
-                        excluded_and_equivocating_ancestors.extend(equivocating_ancestors);
-
-                        let ancestor_state = ancestor_state_map[ancestor.author()];
-                        match ancestor_state {
-                            AncestorState::Include => {
-                                trace!("Found ancestor {ancestor} with INCLUDE state for round {clock_round}");
-                            }
-                            AncestorState::Exclude(score) => {
-                                trace!("Added ancestor {ancestor} with EXCLUDE state with score {score} to temporary excluded ancestors for round {clock_round}");
-                                score_and_pending_excluded_ancestors.push((score, ancestor));
-                                return None;
-                            }
-                        }
-
-                        Some(ancestor)
-                    }),
-            )
-            .collect::<Vec<_>>();
-
-        let mut parent_round_quorum = StakeAggregator::<QuorumThreshold>::new();
-
-        // Check total stake of high scoring parent round ancestors
-        for ancestor in included_ancestors
-            .iter()
-            .filter(|a| a.round() == quorum_round)
-        {
-            parent_round_quorum.add(ancestor.author(), &self.context.committee);
-        }
-
-        if smart_select && !parent_round_quorum.reached_threshold(&self.context.committee) {
-            node_metrics.smart_selection_wait.inc();
-            debug!(
-                "Only found {} stake of good ancestors to include for round {clock_round}, will wait for more.",
-                parent_round_quorum.stake()
-            );
-            return (vec![], BTreeSet::new());
-        }
-
-        // Sort scores descending so we can include the best of the pending excluded
-        // ancestors first until we reach the threshold.
-        score_and_pending_excluded_ancestors.sort_by(|a, b| b.0.cmp(&a.0));
-
-        let mut ancestors_to_propose = included_ancestors;
-        let mut excluded_ancestors = Vec::new();
-        for (score, ancestor) in score_and_pending_excluded_ancestors.into_iter() {
-            let block_hostname = &self.context.committee.authority(ancestor.author()).hostname;
-            if !parent_round_quorum.reached_threshold(&self.context.committee)
-                && ancestor.round() == quorum_round
-            {
-                debug!(
-                    "Including temporarily excluded parent round ancestor {ancestor} with score {score} to propose for round {clock_round}"
-                );
-                parent_round_quorum.add(ancestor.author(), &self.context.committee);
-                ancestors_to_propose.push(ancestor);
-                node_metrics
-                    .included_excluded_proposal_ancestors_count_by_authority
-                    .with_label_values(&[block_hostname.as_str(), "timeout"])
-                    .inc();
-            } else {
-                excluded_ancestors.push((score, ancestor));
-            }
-        }
-
-        // Iterate through excluded ancestors and include the ancestor or the ancestor's ancestor
-        // that has been accepted by a quorum of the network. If the original ancestor itself
-        // is not included then it will be part of excluded ancestors that are not
-        // included in the block but will still be broadcasted to peers.
-        for (score, ancestor) in excluded_ancestors.iter() {
-            let excluded_author = ancestor.author();
-            let block_hostname = &self.context.committee.authority(excluded_author).hostname;
-            // A quorum of validators reported to have accepted blocks from the excluded_author up to the low quorum round.
-            let mut accepted_low_quorum_round = accepted_quorum_rounds[excluded_author].0;
-            // If the accepted quorum round of this ancestor is greater than or equal
-            // to the clock round then we want to make sure to set it to clock_round - 1
-            // as that is the max round the new block can include as an ancestor.
-            accepted_low_quorum_round = accepted_low_quorum_round.min(quorum_round);
-
-            let last_included_round = self.last_included_ancestors[excluded_author]
-                .map(|block_ref| block_ref.round)
-                .unwrap_or(GENESIS_ROUND);
-            if ancestor.round() <= last_included_round {
-                // This should have already been filtered out when filtering all_ancestors.
-                // Still, ensure previously included ancestors are filtered out.
-                continue;
-            }
-
-            if last_included_round >= accepted_low_quorum_round {
-                excluded_and_equivocating_ancestors.insert(ancestor.reference());
-                trace!(
-                    "Excluded low score ancestor {} with score {score} to propose for round {clock_round}: last included round {last_included_round} >= accepted low quorum round {accepted_low_quorum_round}",
-                    ancestor.reference()
-                );
-                node_metrics
-                    .excluded_proposal_ancestors_count_by_authority
-                    .with_label_values(&[block_hostname])
-                    .inc();
-                continue;
-            }
-
-            let ancestor = if ancestor.round() <= accepted_low_quorum_round {
-                // Include the ancestor block as it has been seen & accepted by a strong quorum.
-                ancestor.clone()
-            } else {
-                // Exclude this ancestor since it hasn't been accepted by a strong quorum
-                excluded_and_equivocating_ancestors.insert(ancestor.reference());
-                trace!(
-                    "Excluded low score ancestor {} with score {score} to propose for round {clock_round}: ancestor round {} > accepted low quorum round {accepted_low_quorum_round} ",
-                    ancestor.reference(),
-                    ancestor.round()
-                );
-                node_metrics
-                    .excluded_proposal_ancestors_count_by_authority
-                    .with_label_values(&[block_hostname])
-                    .inc();
-
-                // Look for an earlier block in the ancestor chain that we can include as there
-                // is a gap between the last included round and the accepted low quorum round.
-                //
-                // Note: Only cached blocks need to be propagated. Committed and GC'ed blocks
-                // do not need to be propagated.
-                match self.dag_state.read().get_last_cached_block_in_range(
-                    excluded_author,
-                    last_included_round + 1,
-                    accepted_low_quorum_round + 1,
-                ) {
-                    Some(earlier_ancestor) => {
-                        // Found an earlier block that has been propagated well - include it instead
-                        earlier_ancestor
-                    }
-                    None => {
-                        // No suitable earlier block found
-                        continue;
-                    }
-                }
-            };
-            self.last_included_ancestors[excluded_author] = Some(ancestor.reference());
-            ancestors_to_propose.push(ancestor.clone());
-            trace!(
-                "Included low scoring ancestor {} with score {score} seen at accepted low quorum round {accepted_low_quorum_round} to propose for round {clock_round}",
-                ancestor.reference()
-            );
-            node_metrics
-                .included_excluded_proposal_ancestors_count_by_authority
-                .with_label_values(&[block_hostname.as_str(), "quorum"])
-                .inc();
-        }
-
-        assert!(
-            parent_round_quorum.reached_threshold(&self.context.committee),
-            "Fatal error, quorum not reached for parent round when proposing for round {clock_round}. Possible mismatch between DagState and Core."
-        );
-
-        debug!(
-            "Included {} ancestors & excluded {} low performing or equivocating ancestors for proposal in round {clock_round}",
-            ancestors_to_propose.len(),
-            excluded_and_equivocating_ancestors.len()
-        );
-
-        (ancestors_to_propose, excluded_and_equivocating_ancestors)
+    /// Helper method for tests to get the last proposed block from the proposer.
+    #[cfg(test)]
+    pub(crate) fn last_proposed_block(&self) -> VerifiedBlock {
+        self.proposer
+            .as_ref()
+            .expect("Proposer should be present")
+            .last_proposed_block()
     }
 
-    /// Checks whether all the leaders of the round exist.
-    /// TODO: we can leverage some additional signal here in order to more cleverly manipulate later the leader timeout
-    /// Ex if we already have one leader - the first in order - we might don't want to wait as much.
-    fn leaders_exist(&self, round: Round) -> bool {
-        let dag_state = self.dag_state.read();
-        for leader in self.leaders(round) {
-            // Search for all the leaders. If at least one is not found, then return false.
-            // A linear search should be fine here as the set of elements is not expected to be small enough and more sophisticated
-            // data structures might not give us much here.
-            if !dag_state.contains_cached_block_at_slot(leader) {
-                return false;
-            }
-        }
-
-        true
-    }
-
-    /// Returns the leaders of the provided round.
-    fn leaders(&self, round: Round) -> Vec<Slot> {
-        self.committer
-            .get_leaders(round)
-            .into_iter()
-            .map(|authority_index| Slot::new(round, authority_index))
-            .collect()
-    }
-
-    /// Returns the 1st leader of the round.
-    fn first_leader(&self, round: Round) -> AuthorityIndex {
-        self.leaders(round).first().unwrap().authority
-    }
-
-    fn last_proposed_timestamp_ms(&self) -> BlockTimestampMs {
-        self.last_proposed_block().timestamp_ms()
-    }
-
-    fn last_proposed_round(&self) -> Round {
-        self.last_proposed_block().round()
-    }
-
-    fn last_proposed_block(&self) -> VerifiedBlock {
-        self.dag_state.read().get_last_proposed_block()
+    /// Helper method for tests to get the round tracker from the proposer.
+    /// Returns None if this is an observer node.
+    #[cfg(test)]
+    pub(crate) fn round_tracker_for_tests(&self) -> Arc<RwLock<RoundTracker>> {
+        self.proposer
+            .as_ref()
+            .expect("Proposer should be present")
+            .round_tracker_for_tests()
     }
 }
 
@@ -1495,8 +987,8 @@ impl CoreTextFixture {
         let block_signer = signers.remove(own_index.value()).1;
 
         let round_tracker = Arc::new(RwLock::new(RoundTracker::new(context.clone(), vec![])));
-        let core = Core::new(
-            context,
+        let core = Core::new_validator(
+            context.clone(),
             leader_schedule,
             transaction_consumer,
             transaction_vote_tracker.clone(),
@@ -1506,7 +998,7 @@ impl CoreTextFixture {
             block_signer,
             dag_state.clone(),
             sync_last_known_own_block,
-            round_tracker,
+            round_tracker.clone(),
         );
 
         Self {
@@ -1532,10 +1024,10 @@ impl CoreTextFixture {
 
 #[cfg(test)]
 mod test {
-    use std::{collections::BTreeSet, time::Duration};
+    use std::{collections::BTreeSet, iter, time::Duration};
 
     use consensus_config::{AuthorityIndex, Parameters};
-    use consensus_types::block::TransactionIndex;
+    use consensus_types::block::{BlockTimestampMs, TransactionIndex};
     use futures::{StreamExt, stream::FuturesUnordered};
     use tokio::time::sleep;
 
@@ -1631,7 +1123,7 @@ mod test {
         // Need at least one subscriber to the block broadcast channel.
         let mut block_receiver = signal_receivers.block_broadcast_receiver();
         let round_tracker = Arc::new(RwLock::new(RoundTracker::new(context.clone(), vec![])));
-        let _core = Core::new(
+        let _core = Core::new_validator(
             context.clone(),
             leader_schedule,
             transaction_consumer,
@@ -1765,7 +1257,7 @@ mod test {
         // Need at least one subscriber to the block broadcast channel.
         let mut block_receiver = signal_receivers.block_broadcast_receiver();
         let round_tracker = Arc::new(RwLock::new(RoundTracker::new(context.clone(), vec![])));
-        let mut core = Core::new(
+        let mut core = Core::new_validator(
             context.clone(),
             leader_schedule,
             transaction_consumer,
@@ -1861,7 +1353,7 @@ mod test {
         .await;
 
         let round_tracker = Arc::new(RwLock::new(RoundTracker::new(context.clone(), vec![])));
-        let mut core = Core::new(
+        let mut core = Core::new_validator(
             context.clone(),
             leader_schedule,
             transaction_consumer,
@@ -1963,7 +1455,7 @@ mod test {
         transaction_vote_tracker.add_voted_blocks(vec![(block_1.clone(), vec![])]);
         _ = core.add_blocks(vec![block_1]);
 
-        assert_eq!(core.last_proposed_round(), 1);
+        assert_eq!(core.last_proposed_round(), Some(1));
         expected_ancestors.insert(core.last_proposed_block().reference());
         // attempt to create a block - none will be produced.
         assert!(core.try_propose(false).unwrap().is_none());
@@ -1977,7 +1469,7 @@ mod test {
         transaction_vote_tracker.add_voted_blocks(vec![(block_2.clone(), vec![1, 4])]);
         _ = core.add_blocks(vec![block_2.clone()]);
 
-        assert_eq!(core.last_proposed_round(), 2);
+        assert_eq!(core.last_proposed_round(), Some(2));
 
         let proposed_block = core.last_proposed_block();
         assert_eq!(proposed_block.round(), 2);
@@ -2102,7 +1594,7 @@ mod test {
         // Need at least one subscriber to the block broadcast channel.
         let _block_receiver = signal_receivers.block_broadcast_receiver();
         let round_tracker = Arc::new(RwLock::new(RoundTracker::new(context.clone(), vec![])));
-        let _core = Core::new(
+        let _core = Core::new_validator(
             context.clone(),
             leader_schedule,
             transaction_consumer,
@@ -2260,7 +1752,7 @@ mod test {
         // Need at least one subscriber to the block broadcast channel.
         let _block_receiver = signal_receivers.block_broadcast_receiver();
         let round_tracker = Arc::new(RwLock::new(RoundTracker::new(context.clone(), vec![])));
-        let mut core = Core::new(
+        let mut core = Core::new_validator(
             context.clone(),
             leader_schedule,
             transaction_consumer,
@@ -2293,7 +1785,7 @@ mod test {
             .collect();
         core.add_blocks(blocks).expect("Should not fail");
 
-        assert_eq!(core.last_proposed_round(), 12);
+        assert_eq!(core.last_proposed_round(), Some(12));
     }
 
     #[tokio::test]
@@ -2336,7 +1828,7 @@ mod test {
         .await;
 
         let round_tracker = Arc::new(RwLock::new(RoundTracker::new(context.clone(), vec![])));
-        let mut core = Core::new(
+        let mut core = Core::new_validator(
             context.clone(),
             leader_schedule,
             transaction_consumer,
@@ -2353,7 +1845,7 @@ mod test {
         // No new block should have been produced
         assert_eq!(
             core.last_proposed_round(),
-            GENESIS_ROUND,
+            Some(GENESIS_ROUND),
             "No block should have been created other than genesis"
         );
 
@@ -2371,7 +1863,7 @@ mod test {
             .add_voted_blocks(blocks.iter().map(|b| (b.clone(), vec![])).collect());
         assert!(core.add_blocks(blocks).unwrap().is_empty());
 
-        core.round_tracker.write().update_from_probe(
+        core.round_tracker_for_tests().write().update_from_probe(
             vec![
                 vec![10, 10, 10, 10],
                 vec![10, 10, 10, 10],
@@ -2448,7 +1940,7 @@ mod test {
                 // Only when round > 1 and using non-genesis parents.
                 if let Some(r) = last_round_blocks.first().map(|b| b.round()) {
                     assert_eq!(round - 1, r);
-                    if core_fixture.core.last_proposed_round() == r {
+                    if core_fixture.core.last_proposed_round() == Some(r) {
                         // Force propose new block regardless of min round delay.
                         core_fixture
                             .core
@@ -2460,9 +1952,9 @@ mod test {
                     }
                 }
 
-                assert_eq!(core_fixture.core.last_proposed_round(), round);
+                assert_eq!(core_fixture.core.last_proposed_round(), Some(round));
 
-                this_round_blocks.push(core_fixture.core.last_proposed_block());
+                this_round_blocks.push(core_fixture.core.last_proposed_block().clone());
             }
 
             last_round_blocks = this_round_blocks;
@@ -2481,7 +1973,7 @@ mod test {
         // ignore any leader checks or min round delay.
         for core_fixture in cores.iter_mut() {
             assert!(core_fixture.core.new_block(4, true).unwrap().is_some());
-            assert_eq!(core_fixture.core.last_proposed_round(), 4);
+            assert_eq!(core_fixture.core.last_proposed_round(), Some(4));
 
             // Flush the DAG state to storage.
             core_fixture.dag_state.write().flush();
@@ -2545,27 +2037,31 @@ mod test {
 
                 core_fixture.add_blocks(last_round_blocks.clone()).unwrap();
 
-                core_fixture.core.round_tracker.write().update_from_probe(
-                    vec![
-                        vec![round, round, round, round, 0],
-                        vec![round, round, round, round, 0],
-                        vec![round, round, round, round, 0],
-                        vec![round, round, round, round, 0],
-                        vec![0, 0, 0, 0, 0],
-                    ],
-                    vec![
-                        vec![round, round, round, round, 0],
-                        vec![round, round, round, round, 0],
-                        vec![round, round, round, round, 0],
-                        vec![round, round, round, round, 0],
-                        vec![0, 0, 0, 0, 0],
-                    ],
-                );
+                core_fixture
+                    .core
+                    .round_tracker_for_tests()
+                    .write()
+                    .update_from_probe(
+                        vec![
+                            vec![round, round, round, round, 0],
+                            vec![round, round, round, round, 0],
+                            vec![round, round, round, round, 0],
+                            vec![round, round, round, round, 0],
+                            vec![0, 0, 0, 0, 0],
+                        ],
+                        vec![
+                            vec![round, round, round, round, 0],
+                            vec![round, round, round, round, 0],
+                            vec![round, round, round, round, 0],
+                            vec![round, round, round, round, 0],
+                            vec![0, 0, 0, 0, 0],
+                        ],
+                    );
 
                 // Only when round > 1 and using non-genesis parents.
                 if let Some(r) = last_round_blocks.first().map(|b| b.round()) {
                     assert_eq!(round - 1, r);
-                    if core_fixture.core.last_proposed_round() == r {
+                    if core_fixture.core.last_proposed_round() == Some(r) {
                         // Force propose new block regardless of min round delay.
                         core_fixture
                             .core
@@ -2577,7 +2073,7 @@ mod test {
                     }
                 }
 
-                assert_eq!(core_fixture.core.last_proposed_round(), round);
+                assert_eq!(core_fixture.core.last_proposed_round(), Some(round));
 
                 this_round_blocks.push(core_fixture.core.last_proposed_block().clone());
             }
@@ -2596,27 +2092,31 @@ mod test {
 
                 // Don't update probed rounds for authority 3 so it will remain
                 // excluded
-                core_fixture.core.round_tracker.write().update_from_probe(
-                    vec![
-                        vec![round, round, round, round, 0],
-                        vec![round, round, round, round, 0],
-                        vec![round, round, round, round, 0],
-                        vec![round, round, round, round, 0],
-                        vec![0, 0, 0, 0, 0],
-                    ],
-                    vec![
-                        vec![round, round, round, round, 0],
-                        vec![round, round, round, round, 0],
-                        vec![round, round, round, round, 0],
-                        vec![round, round, round, round, 0],
-                        vec![0, 0, 0, 0, 0],
-                    ],
-                );
+                core_fixture
+                    .core
+                    .round_tracker_for_tests()
+                    .write()
+                    .update_from_probe(
+                        vec![
+                            vec![round, round, round, round, 0],
+                            vec![round, round, round, round, 0],
+                            vec![round, round, round, round, 0],
+                            vec![round, round, round, round, 0],
+                            vec![0, 0, 0, 0, 0],
+                        ],
+                        vec![
+                            vec![round, round, round, round, 0],
+                            vec![round, round, round, round, 0],
+                            vec![round, round, round, round, 0],
+                            vec![round, round, round, round, 0],
+                            vec![0, 0, 0, 0, 0],
+                        ],
+                    );
 
                 // Only when round > 1 and using non-genesis parents.
                 if let Some(r) = last_round_blocks.first().map(|b| b.round()) {
                     assert_eq!(round - 1, r);
-                    if core_fixture.core.last_proposed_round() == r {
+                    if core_fixture.core.last_proposed_round() == Some(r) {
                         // Force propose new block regardless of min round delay.
                         core_fixture
                             .core
@@ -2690,7 +2190,7 @@ mod test {
         .await;
 
         let round_tracker = Arc::new(RwLock::new(RoundTracker::new(context.clone(), vec![])));
-        let mut core = Core::new(
+        let mut core = Core::new_validator(
             context.clone(),
             leader_schedule,
             transaction_consumer,
@@ -2707,7 +2207,7 @@ mod test {
         // No new block should have been produced
         assert_eq!(
             core.last_proposed_round(),
-            GENESIS_ROUND,
+            Some(GENESIS_ROUND),
             "No block should have been created other than genesis"
         );
 
@@ -2986,7 +2486,7 @@ mod test {
         .await;
 
         let round_tracker = Arc::new(RwLock::new(RoundTracker::new(context.clone(), vec![])));
-        let mut core = Core::new(
+        let mut core = Core::new_validator(
             context.clone(),
             leader_schedule,
             transaction_consumer,
@@ -3003,7 +2503,7 @@ mod test {
         // No new block should have been produced
         assert_eq!(
             core.last_proposed_round(),
-            GENESIS_ROUND,
+            Some(GENESIS_ROUND),
             "No block should have been created other than genesis"
         );
 
@@ -3079,7 +2579,7 @@ mod test {
         .await;
 
         let round_tracker = Arc::new(RwLock::new(RoundTracker::new(context.clone(), vec![])));
-        let mut core = Core::new(
+        let mut core = Core::new_validator(
             context.clone(),
             leader_schedule,
             transaction_consumer,
@@ -3173,20 +2673,24 @@ mod test {
                 // this will trigger a block creation for the round and a signal should be emitted
                 core_fixture.add_blocks(last_round_blocks.clone()).unwrap();
 
-                core_fixture.core.round_tracker.write().update_from_probe(
-                    vec![
-                        vec![round, round, round, round],
-                        vec![round, round, round, round],
-                        vec![round, round, round, round],
-                        vec![round, round, round, round],
-                    ],
-                    vec![
-                        vec![round, round, round, round],
-                        vec![round, round, round, round],
-                        vec![round, round, round, round],
-                        vec![round, round, round, round],
-                    ],
-                );
+                core_fixture
+                    .core
+                    .round_tracker_for_tests()
+                    .write()
+                    .update_from_probe(
+                        vec![
+                            vec![round, round, round, round],
+                            vec![round, round, round, round],
+                            vec![round, round, round, round],
+                            vec![round, round, round, round],
+                        ],
+                        vec![
+                            vec![round, round, round, round],
+                            vec![round, round, round, round],
+                            vec![round, round, round, round],
+                            vec![round, round, round, round],
+                        ],
+                    );
 
                 // A "new round" signal should be received given that all the blocks of previous round have been processed
                 let new_round = receive(
@@ -3306,7 +2810,7 @@ mod test {
         // No new block should have been produced
         assert_eq!(
             core.last_proposed_round(),
-            GENESIS_ROUND,
+            Some(GENESIS_ROUND),
             "No block should have been created other than genesis"
         );
 
@@ -3409,7 +2913,7 @@ mod test {
         // No new block should have been produced
         assert_eq!(
             core.last_proposed_round(),
-            GENESIS_ROUND,
+            Some(GENESIS_ROUND),
             "No block should have been created other than genesis"
         );
 
@@ -3524,7 +3028,7 @@ mod test {
         .await;
 
         let round_tracker = Arc::new(RwLock::new(RoundTracker::new(context.clone(), vec![])));
-        let mut core = Core::new(
+        let mut core = Core::new_validator(
             context.clone(),
             leader_schedule,
             transaction_consumer,
@@ -3541,7 +3045,7 @@ mod test {
         // No new block should have been produced
         assert_eq!(
             core.last_proposed_round(),
-            GENESIS_ROUND,
+            Some(GENESIS_ROUND),
             "No block should have been created other than genesis"
         );
 
@@ -3640,24 +3144,28 @@ mod test {
                 // this will trigger a block creation for the round and a signal should be emitted
                 core_fixture.add_blocks(last_round_blocks.clone()).unwrap();
 
-                core_fixture.core.round_tracker.write().update_from_probe(
-                    vec![
-                        vec![round, round, round, round, round, round],
-                        vec![round, round, round, round, round, round],
-                        vec![round, round, round, round, round, round],
-                        vec![round, round, round, round, round, round],
-                        vec![round, round, round, round, round, round],
-                        vec![round, round, round, round, round, round],
-                    ],
-                    vec![
-                        vec![round, round, round, round, round, round],
-                        vec![round, round, round, round, round, round],
-                        vec![round, round, round, round, round, round],
-                        vec![round, round, round, round, round, round],
-                        vec![round, round, round, round, round, round],
-                        vec![round, round, round, round, round, round],
-                    ],
-                );
+                core_fixture
+                    .core
+                    .round_tracker_for_tests()
+                    .write()
+                    .update_from_probe(
+                        vec![
+                            vec![round, round, round, round, round, round],
+                            vec![round, round, round, round, round, round],
+                            vec![round, round, round, round, round, round],
+                            vec![round, round, round, round, round, round],
+                            vec![round, round, round, round, round, round],
+                            vec![round, round, round, round, round, round],
+                        ],
+                        vec![
+                            vec![round, round, round, round, round, round],
+                            vec![round, round, round, round, round, round],
+                            vec![round, round, round, round, round, round],
+                            vec![round, round, round, round, round, round],
+                            vec![round, round, round, round, round, round],
+                            vec![round, round, round, round, round, round],
+                        ],
+                    );
 
                 // A "new round" signal should be received given that all the blocks of previous round have been processed
                 let new_round = receive(
@@ -3795,20 +3303,24 @@ mod test {
                 // this will trigger a block creation for the round and a signal should be emitted
                 core_fixture.add_blocks(last_round_blocks.clone()).unwrap();
 
-                core_fixture.core.round_tracker.write().update_from_probe(
-                    vec![
-                        vec![round, round, round, round],
-                        vec![round, round, round, round],
-                        vec![round, round, round, round],
-                        vec![round, round, round, round],
-                    ],
-                    vec![
-                        vec![round, round, round, round],
-                        vec![round, round, round, round],
-                        vec![round, round, round, round],
-                        vec![round, round, round, round],
-                    ],
-                );
+                core_fixture
+                    .core
+                    .round_tracker_for_tests()
+                    .write()
+                    .update_from_probe(
+                        vec![
+                            vec![round, round, round, round],
+                            vec![round, round, round, round],
+                            vec![round, round, round, round],
+                            vec![round, round, round, round],
+                        ],
+                        vec![
+                            vec![round, round, round, round],
+                            vec![round, round, round, round],
+                            vec![round, round, round, round],
+                            vec![round, round, round, round],
+                        ],
+                    );
 
                 // A "new round" signal should be received given that all the blocks of previous round have been processed
                 let new_round = receive(
@@ -3904,20 +3416,24 @@ mod test {
 
                 // try to propose to ensure that we are covering the case where we miss the leader authority 3
                 core_fixture.add_blocks(last_round_blocks.clone()).unwrap();
-                core_fixture.core.round_tracker.write().update_from_probe(
-                    vec![
-                        vec![round, round, round, round],
-                        vec![round, round, round, round],
-                        vec![round, round, round, round],
-                        vec![round, round, round, round],
-                    ],
-                    vec![
-                        vec![round, round, round, round],
-                        vec![round, round, round, round],
-                        vec![round, round, round, round],
-                        vec![round, round, round, round],
-                    ],
-                );
+                core_fixture
+                    .core
+                    .round_tracker_for_tests()
+                    .write()
+                    .update_from_probe(
+                        vec![
+                            vec![round, round, round, round],
+                            vec![round, round, round, round],
+                            vec![round, round, round, round],
+                            vec![round, round, round, round],
+                        ],
+                        vec![
+                            vec![round, round, round, round],
+                            vec![round, round, round, round],
+                            vec![round, round, round, round],
+                            vec![round, round, round, round],
+                        ],
+                    );
                 core_fixture.core.new_block(round, true).unwrap();
 
                 let block = core_fixture.core.last_proposed_block();

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -110,7 +110,14 @@ impl Core {
             .expect("A block should have been returned");
         let last_signaled_round = last_proposed_block.round();
 
-        // Recover the last included ancestor rounds based on the last proposed block
+        // Recover the last included ancestor rounds based on the last proposed block. That will allow
+        // to perform the next block proposal by using ancestor blocks of higher rounds and avoid
+        // re-including blocks that have been already included in the last (or earlier) block proposal.
+        // This is only strongly guaranteed for a quorum of ancestors. It is still possible to re-include
+        // a block from an authority which hadn't been added as part of the last proposal hence its
+        // latest included ancestor is not accurately captured here. This is considered a small deficiency,
+        // and it mostly matters just for this next proposal without any actual penalties in performance
+        // or block proposal.
         let mut last_included_ancestors = vec![None; context.committee.size()];
         for ancestor in last_proposed_block.ancestors() {
             last_included_ancestors[ancestor.author] = Some(*ancestor);

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -516,6 +516,10 @@ impl Core {
             && let Some(extended_block) = proposer.try_new_block(force)
         {
             self.signals.new_block(extended_block.clone())?;
+            self.signals.new_accepted_block(
+                extended_block.block.clone(),
+                self.dag_state.read().last_commit_index(),
+            );
 
             fail_point!("consensus-after-propose");
 

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -212,6 +212,8 @@ impl Core {
         // Try to commit, since they may not have run after the last storage write.
         self.try_commit(vec![]).unwrap();
 
+        self.try_signal_new_round();
+
         self
     }
 

--- a/consensus/core/src/core_thread.rs
+++ b/consensus/core/src/core_thread.rs
@@ -425,7 +425,7 @@ mod test {
             dag_state.clone(),
         ));
         let round_tracker = Arc::new(RwLock::new(RoundTracker::new(context.clone(), vec![])));
-        let core = Core::new(
+        let core = Core::new_validator(
             context.clone(),
             leader_schedule,
             transaction_consumer,

--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -350,13 +350,14 @@ impl DagState {
 
         if self.threshold_clock.add_block(block_ref) {
             // Do not measure quorum delay when no local block is proposed in the round.
-            let last_proposed_block = self.get_last_proposed_block();
-            if last_proposed_block.round() == block_ref.round {
+            if let Some(last_proposed_block) = self.get_last_proposed_block()
+                && last_proposed_block.round() == block_ref.round
+            {
                 let quorum_delay_ms = self
                     .context
                     .clock
                     .timestamp_utc_ms()
-                    .saturating_sub(self.get_last_proposed_block().timestamp_ms());
+                    .saturating_sub(last_proposed_block.timestamp_ms());
                 self.context
                     .metrics
                     .node_metrics
@@ -531,8 +532,13 @@ impl DagState {
 
     /// Gets the last proposed block from this authority.
     /// If no block is proposed yet, returns the genesis block.
-    pub(crate) fn get_last_proposed_block(&self) -> VerifiedBlock {
-        self.get_last_block_for_authority(self.context.own_index)
+    /// If the node is an observer, returns None.
+    pub(crate) fn get_last_proposed_block(&self) -> Option<VerifiedBlock> {
+        if self.context.is_validator() {
+            Some(self.get_last_block_for_authority(self.context.own_index))
+        } else {
+            None
+        }
     }
 
     /// Retrieves the last accepted block from the specified `authority`. If no block is found in cache
@@ -2550,7 +2556,7 @@ mod test {
                 .find(|block| block.author() == context.own_index)
                 .unwrap();
 
-            assert_eq!(dag_state.read().get_last_proposed_block(), my_genesis);
+            assert_eq!(dag_state.read().get_last_proposed_block(), Some(my_genesis));
         }
 
         // WHEN adding some blocks for authorities, only the last ones should be returned

--- a/consensus/core/src/lib.rs
+++ b/consensus/core/src/lib.rs
@@ -27,6 +27,7 @@ mod linearizer;
 mod metrics;
 mod network;
 mod observer_service;
+mod observer_subscriber;
 mod proposer;
 mod round_prober;
 mod round_tracker;

--- a/consensus/core/src/lib.rs
+++ b/consensus/core/src/lib.rs
@@ -27,6 +27,7 @@ mod linearizer;
 mod metrics;
 mod network;
 mod observer_service;
+mod proposer;
 mod round_prober;
 mod round_tracker;
 mod stake_aggregator;

--- a/consensus/core/src/network/observer.rs
+++ b/consensus/core/src/network/observer.rs
@@ -117,7 +117,7 @@ impl ChannelPool {
     fn new(context: Arc<Context>) -> Self {
         // Only allow to connect to peers that are within this pool.
         let mut observer_peers = BTreeMap::new();
-        for peer in &context.parameters.tonic.observer_peers {
+        for peer in &context.parameters.observer.peers {
             observer_peers.insert(peer.public_key.clone(), peer.address.clone());
         }
         Self {
@@ -536,8 +536,8 @@ mod tests {
 
         // Set up validator 0 with observer server
         let mut parameters = context.parameters.clone();
-        parameters.tonic.observer_server_port = Some(OBSERVER_PORT);
-        parameters.tonic.observer_peers = vec![PeerRecord {
+        parameters.observer.server_port = Some(OBSERVER_PORT);
+        parameters.observer.peers = vec![PeerRecord {
             public_key: keys[0].0.public(),
             address: Multiaddr::from_str(&format!("/ip4/127.0.0.1/udp/{}", OBSERVER_PORT)).unwrap(),
         }];

--- a/consensus/core/src/network/tonic_network.rs
+++ b/consensus/core/src/network/tonic_network.rs
@@ -764,6 +764,9 @@ impl TonicManager {
         // Calculate own address
         let own_address = if let Some(listen_addr) = &context.parameters.listen_address_override {
             listen_addr
+        } else if !context.is_validator() {
+            // Observer node - use a default local address since we're not in the committee. The port will be set separately during the server setup.
+            &Multiaddr::try_from("/ip4/0.0.0.0/tcp/0").unwrap()
         } else {
             let authority = context.committee.authority(context.own_index);
             // By default, bind to the unspecified address to allow the actual address to be assigned.
@@ -1426,9 +1429,10 @@ mod tests {
         let protocol_config = ConsensusProtocolConfig::for_testing();
         let metrics = initialise_metrics(Registry::new());
 
+        let authority_index = committee.to_authority_index(0).unwrap();
         let context = Arc::new(Context::new(
             0,
-            committee.to_authority_index(0).unwrap(),
+            Some(authority_index),
             committee,
             parameters,
             protocol_config,

--- a/consensus/core/src/network/tonic_network.rs
+++ b/consensus/core/src/network/tonic_network.rs
@@ -766,11 +766,7 @@ impl TonicManager {
             listen_addr
         } else if context.is_observer() {
             // Observer node - use the configured observer server port since we're not in the committee.
-            let port = context
-                .parameters
-                .tonic
-                .observer_server_port
-                .expect("Observer server port must be configured for observer nodes");
+            let port = context.parameters.tonic.observer_server_port.unwrap_or(0);
             &Multiaddr::try_from(format!("/ip4/0.0.0.0/tcp/{port}")).unwrap()
         } else {
             let authority = context.committee.authority(context.own_index);

--- a/consensus/core/src/network/tonic_network.rs
+++ b/consensus/core/src/network/tonic_network.rs
@@ -766,7 +766,7 @@ impl TonicManager {
             listen_addr
         } else if context.is_observer() {
             // Observer node - use the configured observer server port since we're not in the committee.
-            let port = context.parameters.tonic.observer_server_port.unwrap_or(0);
+            let port = context.parameters.observer.server_port.unwrap_or(0);
             &Multiaddr::try_from(format!("/ip4/0.0.0.0/tcp/{port}")).unwrap()
         } else {
             let authority = context.committee.authority(context.own_index);
@@ -969,14 +969,15 @@ impl TonicManager {
     }
 
     async fn start_observer_server_impl<O: ObserverNetworkService>(&mut self, service: Arc<O>) {
-        let config = &self.context.parameters.tonic;
-        let Some(observer_port) = config.observer_server_port else {
+        let observer_params = &self.context.parameters.observer;
+        let tonic_config = &self.context.parameters.tonic;
+        let Some(observer_port) = observer_params.server_port else {
             info!("Observer server not configured, skipping observer server start");
             return;
         };
 
         // Parse observer allowlist from configuration and create TLS verifier
-        let observer_allowlist = parse_observer_allowlist(&config.observer_allowlist);
+        let observer_allowlist = parse_observer_allowlist(&observer_params.allowlist);
         let observer_tls_config = if observer_allowlist.is_empty() {
             info!("Observer server allowlist disabled - all observers allowed");
             sui_tls::create_rustls_server_config_with_client_verifier(
@@ -1007,8 +1008,8 @@ impl TonicManager {
         let observer_service_proxy = ObserverServiceProxy::new(service);
 
         let observer_service_server = ObserverServiceServer::new(observer_service_proxy)
-            .max_encoding_message_size(config.message_size_limit)
-            .max_decoding_message_size(config.message_size_limit)
+            .max_encoding_message_size(tonic_config.message_size_limit)
+            .max_decoding_message_size(tonic_config.message_size_limit)
             .send_compressed(CompressionEncoding::Zstd)
             .accept_compressed(CompressionEncoding::Zstd);
 
@@ -1048,8 +1049,8 @@ impl TonicManager {
         let http_config = sui_http::Config::default()
             .initial_connection_window_size(HTTP2_INITIAL_CONNECTION_WINDOW_SIZE)
             .initial_stream_window_size(HTTP2_INITIAL_STREAM_WINDOW_SIZE)
-            .http2_keepalive_interval(Some(config.keepalive_interval))
-            .http2_keepalive_timeout(Some(config.keepalive_interval))
+            .http2_keepalive_interval(Some(tonic_config.keepalive_interval))
+            .http2_keepalive_timeout(Some(tonic_config.keepalive_interval))
             .accept_http1(false);
 
         let deadline = Instant::now() + Duration::from_secs(20);

--- a/consensus/core/src/network/tonic_network.rs
+++ b/consensus/core/src/network/tonic_network.rs
@@ -764,9 +764,14 @@ impl TonicManager {
         // Calculate own address
         let own_address = if let Some(listen_addr) = &context.parameters.listen_address_override {
             listen_addr
-        } else if !context.is_validator() {
-            // Observer node - use a default local address since we're not in the committee. The port will be set separately during the server setup.
-            &Multiaddr::try_from("/ip4/0.0.0.0/tcp/0").unwrap()
+        } else if context.is_observer() {
+            // Observer node - use the configured observer server port since we're not in the committee.
+            let port = context
+                .parameters
+                .tonic
+                .observer_server_port
+                .expect("Observer server port must be configured for observer nodes");
+            &Multiaddr::try_from(format!("/ip4/0.0.0.0/tcp/{port}")).unwrap()
         } else {
             let authority = context.committee.authority(context.own_index);
             // By default, bind to the unspecified address to allow the actual address to be assigned.

--- a/consensus/core/src/observer_service.rs
+++ b/consensus/core/src/observer_service.rs
@@ -12,7 +12,7 @@ use tokio::sync::broadcast;
 
 use crate::{
     authority_service::{BroadcastStream, SubscriptionCounter},
-    block::{BlockAPI as _, VerifiedBlock},
+    block::{BlockAPI as _, SignedBlock, VerifiedBlock},
     commit::{CommitIndex, CommitRange, TrustedCommit},
     context::Context,
     dag_state::DagState,
@@ -52,11 +52,28 @@ impl ObserverNetworkService for ObserverService {
     async fn handle_block(
         &self,
         _peer: PeerId,
-        _item: ObserverBlockStreamItem,
+        item: ObserverBlockStreamItem,
     ) -> ConsensusResult<()> {
         // TODO: implement block processing for observers.
         // This should validate and add blocks to DagState, similar to how validators
         // handle blocks in AuthorityService::handle_send_block.
+        let signed_block: SignedBlock =
+            bcs::from_bytes(&item.block).map_err(ConsensusError::MalformedBlock)?;
+
+        tracing::info!(
+            "Observer received round {}, author {} at timestamp: {}",
+            signed_block.round(),
+            signed_block.author(),
+            signed_block.timestamp_ms()
+        );
+
+        // TODO: we do a dummy increment here to allow us confirm that end to end flow in tests.
+        self.context
+            .metrics
+            .node_metrics
+            .verified_blocks
+            .with_label_values(&["observer"])
+            .inc();
         Ok(())
     }
 

--- a/consensus/core/src/observer_subscriber.rs
+++ b/consensus/core/src/observer_subscriber.rs
@@ -61,29 +61,18 @@ impl<C: ObserverNetworkClient, S: ObserverNetworkService> ObserverSubscriber<C, 
         let context = self.context.clone();
         let network_client = self.network_client.clone();
         let observer_service = self.observer_service.clone();
-
-        // Get the highest rounds we've seen per authority from DagState
-        let highest_round_per_authority = {
-            let dag_state = self.dag_state.read();
-            let mut rounds = vec![0u64; context.committee.size()];
-            for (authority, _) in context.committee.authorities() {
-                rounds[authority.value()] =
-                    dag_state.get_last_block_for_authority(authority).round() as u64;
-            }
-            rounds
-        };
-
-        if let Some(handle) = self.subscription.lock().take() {
-            handle.abort();
-        }
+        let dag_state = self.dag_state.clone();
 
         let mut subscription = self.subscription.lock();
+        if let Some(handle) = subscription.take() {
+            handle.abort();
+        }
         *subscription = Some(spawn_monitored_task!(Self::subscription_loop(
             context,
             network_client,
             observer_service,
+            dag_state,
             peer,
-            highest_round_per_authority,
         )));
     }
 
@@ -99,8 +88,8 @@ impl<C: ObserverNetworkClient, S: ObserverNetworkService> ObserverSubscriber<C, 
         context: Arc<Context>,
         network_client: Arc<C>,
         observer_service: Arc<S>,
+        dag_state: Arc<parking_lot::RwLock<DagState>>,
         peer: PeerId,
-        highest_round_per_authority: Vec<u64>,
     ) {
         const IMMEDIATE_RETRIES: i64 = 3;
         const MIN_TIMEOUT: Duration = Duration::from_millis(500);
@@ -126,14 +115,23 @@ impl<C: ObserverNetworkClient, S: ObserverNetworkService> ObserverSubscriber<C, 
             }
             retries += 1;
 
+            // Recompute highest rounds from DagState before each connection attempt
+            // so reconnections resume from where we left off rather than re-fetching
+            // already-seen blocks.
+            let highest_round_per_authority = {
+                let ds = dag_state.read();
+                let mut rounds = vec![0u64; context.committee.size()];
+                for (authority, _) in context.committee.authorities() {
+                    rounds[authority.value()] =
+                        ds.get_last_block_for_authority(authority).round() as u64;
+                }
+                rounds
+            };
+
             // Subscribe to stream blocks from the peer.
             let request_timeout = MIN_TIMEOUT.max(delay);
             let mut blocks = match network_client
-                .stream_blocks(
-                    peer.clone(),
-                    highest_round_per_authority.clone(),
-                    request_timeout,
-                )
+                .stream_blocks(peer.clone(), highest_round_per_authority, request_timeout)
                 .await
             {
                 Ok(blocks) => {
@@ -213,8 +211,9 @@ impl<C: ObserverNetworkClient, S: ObserverNetworkService> ObserverSubscriber<C, 
                             counter.fetch_sub(1, Ordering::AcqRel);
                         });
 
-                        // Reset retries when a block is received.
+                        // Reset retries when a block is received and also reset the backoff.
                         retries = 0;
+                        backoff.reset();
                     }
                     None => {
                         debug!("Subscription to blocks from peer {:?} ended", peer);

--- a/consensus/core/src/observer_subscriber.rs
+++ b/consensus/core/src/observer_subscriber.rs
@@ -28,7 +28,11 @@ use crate::{
 
 /// ObserverSubscriber manages block stream subscriptions to peers (validators or other observers),
 /// taking care of retrying when subscription streams break. Blocks returned from peers are sent
+<<<<<<< HEAD
 /// to the observer service for processing. The `ObserverSubscriber` can only subscribe to one peer at a time.
+=======
+/// to the observer service for processing.
+>>>>>>> ff75b17002 ([fix] lint)
 #[allow(unused)]
 pub(crate) struct ObserverSubscriber<C: ObserverNetworkClient, S: ObserverNetworkService> {
     context: Arc<Context>,

--- a/consensus/core/src/observer_subscriber.rs
+++ b/consensus/core/src/observer_subscriber.rs
@@ -28,11 +28,7 @@ use crate::{
 
 /// ObserverSubscriber manages block stream subscriptions to peers (validators or other observers),
 /// taking care of retrying when subscription streams break. Blocks returned from peers are sent
-<<<<<<< HEAD
 /// to the observer service for processing. The `ObserverSubscriber` can only subscribe to one peer at a time.
-=======
-/// to the observer service for processing.
->>>>>>> ff75b17002 ([fix] lint)
 #[allow(unused)]
 pub(crate) struct ObserverSubscriber<C: ObserverNetworkClient, S: ObserverNetworkService> {
     context: Arc<Context>,

--- a/consensus/core/src/proposer.rs
+++ b/consensus/core/src/proposer.rs
@@ -533,7 +533,8 @@ impl Proposer for ValidatorProposer {
                     .flat_map(|ancestor| dag_state.link_causal_history(ancestor.reference()))
                     .collect()
             };
-            self.transaction_vote_tracker.get_own_votes(new_causal_history)
+            self.transaction_vote_tracker
+                .get_own_votes(new_causal_history)
         } else {
             vec![]
         };

--- a/consensus/core/src/proposer.rs
+++ b/consensus/core/src/proposer.rs
@@ -134,6 +134,9 @@ impl ValidatorProposer {
     fn leaders_exist(&self, round: Round) -> bool {
         let dag_state = self.dag_state.read();
         for leader in self.leaders(round) {
+            // Search for all the leaders. If at least one is not found, then return false.
+            // A linear search should be fine here as the set of elements is not expected to be small enough and more sophisticated
+            // data structures might not give us much here.
             if !dag_state.contains_cached_block_at_slot(leader) {
                 return false;
             }
@@ -601,6 +604,7 @@ impl Proposer for ValidatorProposer {
         if self.context.protocol_config.transaction_voting_enabled() {
             self.transaction_vote_tracker
                 .add_voted_blocks(vec![(verified_block.clone(), vec![])]);
+            // Set the proposed block to be linked. Linked statuses of its ancestors have already been set.
             self.dag_state
                 .write()
                 .link_causal_history(verified_block.reference());

--- a/consensus/core/src/proposer.rs
+++ b/consensus/core/src/proposer.rs
@@ -1,0 +1,721 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{collections::BTreeSet, iter, sync::Arc, time::Duration};
+
+use consensus_config::ProtocolKeyPair;
+use consensus_types::block::{BlockRef, BlockTimestampMs, Round};
+use parking_lot::RwLock;
+use tokio::time::Instant;
+use tracing::{debug, info, trace};
+
+use crate::{
+    ancestor::{AncestorState, AncestorStateManager},
+    block::{
+        Block, BlockAPI, BlockV1, BlockV2, ExtendedBlock, GENESIS_ROUND, SignedBlock, Slot,
+        VerifiedBlock,
+    },
+    context::Context,
+    dag_state::DagState,
+    round_tracker::RoundTracker,
+    stake_aggregator::{QuorumThreshold, StakeAggregator},
+    transaction::TransactionConsumer,
+    transaction_vote_tracker::TransactionVoteTracker,
+};
+
+const MAX_COMMIT_VOTES_PER_BLOCK: usize = 100;
+
+/// Trait for handling block proposal logic.
+/// Only Validators have a proposer; Observers use None for the proposer field in Core.
+pub(crate) trait Proposer: Send + Sync {
+    /// Attempts to create and return a new block proposal.
+    /// Returns None if conditions for proposal are not met.
+    fn try_new_block(&mut self, force: bool) -> Option<ExtendedBlock>;
+
+    /// Returns whether this node should propose blocks
+    fn should_propose(&self) -> bool;
+
+    /// Sets the propagation delay (validators only)
+    fn set_propagation_delay(&mut self, delay: Round);
+
+    /// Sets the last known proposed round (validators only)
+    fn set_last_known_proposed_round(&mut self, round: Round);
+
+    /// Gets the last known proposed round if applicable
+    fn get_last_known_proposed_round(&self) -> Option<Round>;
+
+    /// Returns the round of the last proposed block (validators only)
+    fn last_proposed_round(&self) -> Round;
+
+    /// Returns the last proposed block (validators only)
+    fn last_proposed_block(&self) -> VerifiedBlock;
+
+    /// Sets propagation scores on the ancestor state manager (validators only)
+    fn set_propagation_scores(&mut self, scores: crate::leader_scoring::ReputationScores);
+
+    /// Notifies transaction consumer about committed own blocks (validators only)
+    fn notify_own_blocks_committed(&self, block_refs: Vec<BlockRef>, gc_round: Round);
+
+    /// Returns the round tracker for tests (validators only)
+    #[cfg(test)]
+    fn round_tracker_for_tests(&self) -> Arc<RwLock<RoundTracker>>;
+}
+
+/// Validator proposal engine - full block proposal implementation
+pub(crate) struct ValidatorProposer {
+    context: Arc<Context>,
+    transaction_consumer: TransactionConsumer,
+    transaction_vote_tracker: TransactionVoteTracker,
+    propagation_delay: Round,
+    last_included_ancestors: Vec<Option<BlockRef>>,
+    block_signer: ProtocolKeyPair,
+    last_known_proposed_round: Option<Round>,
+    ancestor_state_manager: AncestorStateManager,
+    round_tracker: Arc<RwLock<RoundTracker>>,
+    dag_state: Arc<RwLock<DagState>>,
+    committer: Arc<crate::universal_committer::UniversalCommitter>,
+}
+
+impl ValidatorProposer {
+    pub(crate) fn new(
+        dag_state: Arc<RwLock<DagState>>,
+        context: Arc<Context>,
+        transaction_consumer: TransactionConsumer,
+        transaction_vote_tracker: TransactionVoteTracker,
+        block_signer: ProtocolKeyPair,
+        last_known_proposed_round: Option<Round>,
+        ancestor_state_manager: AncestorStateManager,
+        round_tracker: Arc<RwLock<RoundTracker>>,
+        committer: Arc<crate::universal_committer::UniversalCommitter>,
+    ) -> Self {
+        let last_included_ancestors = vec![None; context.committee.size()];
+        Self {
+            context,
+            transaction_consumer,
+            transaction_vote_tracker,
+            propagation_delay: 0,
+            last_included_ancestors,
+            block_signer,
+            last_known_proposed_round,
+            ancestor_state_manager,
+            round_tracker,
+            dag_state,
+            committer,
+        }
+    }
+
+    fn last_proposed_block(&self) -> VerifiedBlock {
+        self.dag_state
+            .read()
+            .get_last_proposed_block()
+            .expect("A block should have been returned")
+    }
+
+    fn last_proposed_timestamp_ms(&self) -> BlockTimestampMs {
+        self.dag_state
+            .read()
+            .get_last_proposed_block()
+            .expect("A block should have been returned")
+            .timestamp_ms()
+    }
+
+    fn leaders(&self, round: Round) -> Vec<Slot> {
+        self.committer
+            .get_leaders(round)
+            .into_iter()
+            .map(|authority_index| Slot::new(round, authority_index))
+            .collect()
+    }
+
+    fn first_leader(&self, round: Round) -> consensus_config::AuthorityIndex {
+        self.leaders(round).first().unwrap().authority
+    }
+
+    fn leaders_exist(&self, round: Round) -> bool {
+        let dag_state = self.dag_state.read();
+        for leader in self.leaders(round) {
+            if !dag_state.contains_cached_block_at_slot(leader) {
+                return false;
+            }
+        }
+        true
+    }
+
+    /// Retrieves the next ancestors to propose to form a block at `clock_round` round.
+    /// If smart selection is enabled then this will try to select the best ancestors
+    /// based on the propagation scores of the authorities.
+    fn smart_ancestors_to_propose(
+        &mut self,
+        clock_round: Round,
+        smart_select: bool,
+    ) -> (Vec<VerifiedBlock>, BTreeSet<BlockRef>) {
+        let node_metrics = &self.context.metrics.node_metrics;
+        let _s = node_metrics
+            .scope_processing_time
+            .with_label_values(&["ValidatorProposer::smart_ancestors_to_propose"])
+            .start_timer();
+
+        // Now take the ancestors before the clock_round (excluded) for each authority.
+        let all_ancestors = self
+            .dag_state
+            .read()
+            .get_last_cached_block_per_authority(clock_round);
+
+        assert_eq!(
+            all_ancestors.len(),
+            self.context.committee.size(),
+            "Fatal error, number of returned ancestors don't match committee size."
+        );
+
+        // Ensure ancestor state is up to date before selecting for proposal.
+        let accepted_quorum_rounds = self.round_tracker.read().compute_accepted_quorum_rounds();
+
+        self.ancestor_state_manager
+            .update_all_ancestors_state(&accepted_quorum_rounds);
+
+        let ancestor_state_map = self.ancestor_state_manager.get_ancestor_states();
+
+        let quorum_round = clock_round.saturating_sub(1);
+
+        let mut score_and_pending_excluded_ancestors = Vec::new();
+        let mut excluded_and_equivocating_ancestors = BTreeSet::new();
+
+        // Propose only ancestors of higher rounds than what has already been proposed.
+        // And always include own last proposed block first among ancestors.
+        // Start by only including the high scoring ancestors. Low scoring ancestors
+        // will be included in a second pass below.
+        let included_ancestors = iter::once(self.last_proposed_block())
+            .chain(
+                all_ancestors
+                    .into_iter()
+                    .flat_map(|(ancestor, equivocating_ancestors)| {
+                        if ancestor.author() == self.context.own_index {
+                            return None;
+                        }
+                        if let Some(last_block_ref) =
+                            self.last_included_ancestors[ancestor.author()]
+                            && last_block_ref.round >= ancestor.round() {
+                                return None;
+                            }
+
+                        // We will never include equivocating ancestors so add them immediately
+                        excluded_and_equivocating_ancestors.extend(equivocating_ancestors);
+
+                        let ancestor_state = ancestor_state_map[ancestor.author()];
+                        match ancestor_state {
+                            AncestorState::Include => {
+                                trace!("Found ancestor {ancestor} with INCLUDE state for round {clock_round}");
+                            }
+                            AncestorState::Exclude(score) => {
+                                trace!("Added ancestor {ancestor} with EXCLUDE state with score {score} to temporary excluded ancestors for round {clock_round}");
+                                score_and_pending_excluded_ancestors.push((score, ancestor));
+                                return None;
+                            }
+                        }
+
+                        Some(ancestor)
+                    }),
+            )
+            .collect::<Vec<_>>();
+
+        let mut parent_round_quorum = StakeAggregator::<QuorumThreshold>::new();
+
+        // Check total stake of high scoring parent round ancestors
+        for ancestor in included_ancestors
+            .iter()
+            .filter(|a| a.round() == quorum_round)
+        {
+            parent_round_quorum.add(ancestor.author(), &self.context.committee);
+        }
+
+        if smart_select && !parent_round_quorum.reached_threshold(&self.context.committee) {
+            node_metrics.smart_selection_wait.inc();
+            debug!(
+                "Only found {} stake of good ancestors to include for round {clock_round}, will wait for more.",
+                parent_round_quorum.stake()
+            );
+            return (vec![], BTreeSet::new());
+        }
+
+        // Sort scores descending so we can include the best of the pending excluded
+        // ancestors first until we reach the threshold.
+        score_and_pending_excluded_ancestors.sort_by(|a, b| b.0.cmp(&a.0));
+
+        let mut ancestors_to_propose = included_ancestors;
+        let mut excluded_ancestors = Vec::new();
+        for (score, ancestor) in score_and_pending_excluded_ancestors.into_iter() {
+            let block_hostname = &self.context.committee.authority(ancestor.author()).hostname;
+            if !parent_round_quorum.reached_threshold(&self.context.committee)
+                && ancestor.round() == quorum_round
+            {
+                debug!(
+                    "Including temporarily excluded parent round ancestor {ancestor} with score {score} to propose for round {clock_round}"
+                );
+                parent_round_quorum.add(ancestor.author(), &self.context.committee);
+                ancestors_to_propose.push(ancestor);
+                node_metrics
+                    .included_excluded_proposal_ancestors_count_by_authority
+                    .with_label_values(&[block_hostname.as_str(), "timeout"])
+                    .inc();
+            } else {
+                excluded_ancestors.push((score, ancestor));
+            }
+        }
+
+        // Iterate through excluded ancestors and include the ancestor or the ancestor's ancestor
+        // that has been accepted by a quorum of the network. If the original ancestor itself
+        // is not included then it will be part of excluded ancestors that are not
+        // included in the block but will still be broadcasted to peers.
+        for (score, ancestor) in excluded_ancestors.iter() {
+            let excluded_author = ancestor.author();
+            let block_hostname = &self.context.committee.authority(excluded_author).hostname;
+            // A quorum of validators reported to have accepted blocks from the excluded_author up to the low quorum round.
+            let mut accepted_low_quorum_round = accepted_quorum_rounds[excluded_author].0;
+            // If the accepted quorum round of this ancestor is greater than or equal
+            // to the clock round then we want to make sure to set it to clock_round - 1
+            // as that is the max round the new block can include as an ancestor.
+            accepted_low_quorum_round = accepted_low_quorum_round.min(quorum_round);
+
+            let last_included_round = self.last_included_ancestors[excluded_author]
+                .map(|block_ref| block_ref.round)
+                .unwrap_or(GENESIS_ROUND);
+            if ancestor.round() <= last_included_round {
+                // This should have already been filtered out when filtering all_ancestors.
+                // Still, ensure previously included ancestors are filtered out.
+                continue;
+            }
+
+            if last_included_round >= accepted_low_quorum_round {
+                excluded_and_equivocating_ancestors.insert(ancestor.reference());
+                trace!(
+                    "Excluded low score ancestor {} with score {score} to propose for round {clock_round}: last included round {last_included_round} >= accepted low quorum round {accepted_low_quorum_round}",
+                    ancestor.reference()
+                );
+                node_metrics
+                    .excluded_proposal_ancestors_count_by_authority
+                    .with_label_values(&[block_hostname])
+                    .inc();
+                continue;
+            }
+
+            let ancestor = if ancestor.round() <= accepted_low_quorum_round {
+                // Include the ancestor block as it has been seen & accepted by a strong quorum.
+                ancestor.clone()
+            } else {
+                // Exclude this ancestor since it hasn't been accepted by a strong quorum
+                excluded_and_equivocating_ancestors.insert(ancestor.reference());
+                trace!(
+                    "Excluded low score ancestor {} with score {score} to propose for round {clock_round}: ancestor round {} > accepted low quorum round {accepted_low_quorum_round} ",
+                    ancestor.reference(),
+                    ancestor.round()
+                );
+                node_metrics
+                    .excluded_proposal_ancestors_count_by_authority
+                    .with_label_values(&[block_hostname])
+                    .inc();
+
+                // Look for an earlier block in the ancestor chain that we can include as there
+                // is a gap between the last included round and the accepted low quorum round.
+                //
+                // Note: Only cached blocks need to be propagated. Committed and GC'ed blocks
+                // do not need to be propagated.
+                match self.dag_state.read().get_last_cached_block_in_range(
+                    excluded_author,
+                    last_included_round + 1,
+                    accepted_low_quorum_round + 1,
+                ) {
+                    Some(earlier_ancestor) => {
+                        // Found an earlier block that has been propagated well - include it instead
+                        earlier_ancestor
+                    }
+                    None => {
+                        // No suitable earlier block found
+                        continue;
+                    }
+                }
+            };
+            self.last_included_ancestors[excluded_author] = Some(ancestor.reference());
+            ancestors_to_propose.push(ancestor.clone());
+            trace!(
+                "Included low scoring ancestor {} with score {score} seen at accepted low quorum round {accepted_low_quorum_round} to propose for round {clock_round}",
+                ancestor.reference()
+            );
+            node_metrics
+                .included_excluded_proposal_ancestors_count_by_authority
+                .with_label_values(&[block_hostname.as_str(), "quorum"])
+                .inc();
+        }
+
+        assert!(
+            parent_round_quorum.reached_threshold(&self.context.committee),
+            "Fatal error, quorum not reached for parent round when proposing for round {clock_round}. Possible mismatch between DagState and Core."
+        );
+
+        debug!(
+            "Included {} ancestors & excluded {} low performing or equivocating ancestors for proposal in round {clock_round}",
+            ancestors_to_propose.len(),
+            excluded_and_equivocating_ancestors.len()
+        );
+
+        (ancestors_to_propose, excluded_and_equivocating_ancestors)
+    }
+}
+
+impl Proposer for ValidatorProposer {
+    fn try_new_block(&mut self, force: bool) -> Option<ExtendedBlock> {
+        if !self.should_propose() {
+            return None;
+        }
+
+        let _s = self
+            .context
+            .metrics
+            .node_metrics
+            .scope_processing_time
+            .with_label_values(&["ValidatorProposer::try_new_block"])
+            .start_timer();
+
+        // Ensure the new block has a higher round than the last proposed block.
+        let clock_round = {
+            let dag_state = self.dag_state.read();
+            let clock_round = dag_state.threshold_clock_round();
+            if clock_round
+                <= dag_state
+                    .get_last_proposed_block()
+                    .expect("A block should have been returned")
+                    .round()
+            {
+                debug!(
+                    "Skipping block proposal for round {} as it is not higher than the last proposed block {}",
+                    clock_round,
+                    dag_state
+                        .get_last_proposed_block()
+                        .expect("A block should have been returned")
+                        .round()
+                );
+                return None;
+            }
+            clock_round
+        };
+
+        // There must be a quorum of blocks from the previous round.
+        let quorum_round = clock_round.saturating_sub(1);
+
+        // Create a new block either because we want to "forcefully" propose a block due to a leader timeout,
+        // or because we are actually ready to produce the block (leader exists and min delay has passed).
+        if !force {
+            if !self.leaders_exist(quorum_round) {
+                return None;
+            }
+
+            if Duration::from_millis(
+                self.context
+                    .clock
+                    .timestamp_utc_ms()
+                    .saturating_sub(self.last_proposed_timestamp_ms()),
+            ) < self.context.parameters.min_round_delay
+            {
+                debug!(
+                    "Skipping block proposal for round {} as it is too soon after the last proposed block timestamp {}; min round delay is {}ms",
+                    clock_round,
+                    self.last_proposed_timestamp_ms(),
+                    self.context.parameters.min_round_delay.as_millis(),
+                );
+                return None;
+            }
+        }
+
+        // Determine the ancestors to be included in proposal.
+        let (ancestors, excluded_and_equivocating_ancestors) =
+            self.smart_ancestors_to_propose(clock_round, !force);
+
+        // If we did not find enough good ancestors to propose, continue to wait before proposing.
+        if ancestors.is_empty() {
+            assert!(
+                !force,
+                "Ancestors should have been returned if force is true!"
+            );
+            debug!(
+                "Skipping block proposal for round {} because no good ancestor is found",
+                clock_round,
+            );
+            return None;
+        }
+
+        let excluded_ancestors_limit = self.context.committee.size() * 2;
+        if excluded_and_equivocating_ancestors.len() > excluded_ancestors_limit {
+            debug!(
+                "Dropping {} excluded ancestor(s) during proposal due to size limit",
+                excluded_and_equivocating_ancestors.len() - excluded_ancestors_limit,
+            );
+        }
+        let excluded_ancestors = excluded_and_equivocating_ancestors
+            .into_iter()
+            .take(excluded_ancestors_limit)
+            .collect();
+
+        // Update the last included ancestor block refs
+        for ancestor in &ancestors {
+            self.last_included_ancestors[ancestor.author()] = Some(ancestor.reference());
+        }
+
+        let leader_authority = &self
+            .context
+            .committee
+            .authority(self.first_leader(quorum_round))
+            .hostname;
+        self.context
+            .metrics
+            .node_metrics
+            .block_proposal_leader_wait_ms
+            .with_label_values(&[leader_authority])
+            .inc_by(
+                Instant::now()
+                    .saturating_duration_since(self.dag_state.read().threshold_clock_quorum_ts())
+                    .as_millis() as u64,
+            );
+        self.context
+            .metrics
+            .node_metrics
+            .block_proposal_leader_wait_count
+            .with_label_values(&[leader_authority])
+            .inc();
+
+        self.context
+            .metrics
+            .node_metrics
+            .proposed_block_ancestors
+            .observe(ancestors.len() as f64);
+        for ancestor in &ancestors {
+            let authority = &self.context.committee.authority(ancestor.author()).hostname;
+            self.context
+                .metrics
+                .node_metrics
+                .proposed_block_ancestors_depth
+                .with_label_values(&[authority])
+                .observe(clock_round.saturating_sub(ancestor.round()).into());
+        }
+
+        let now = self.context.clock.timestamp_utc_ms();
+        ancestors.iter().for_each(|block| {
+            if block.timestamp_ms() > now {
+                trace!("Ancestor block {:?} has timestamp {}, greater than current timestamp {now}. Proposing for round {}.", block, block.timestamp_ms(), clock_round);
+                let authority = &self.context.committee.authority(block.author()).hostname;
+                self.context
+                    .metrics
+                    .node_metrics
+                    .proposed_block_ancestors_timestamp_drift_ms
+                    .with_label_values(&[authority])
+                    .inc_by(block.timestamp_ms().saturating_sub(now));
+            }
+        });
+
+        // Consume the next transactions to be included. Do not drop the guards yet as this would acknowledge
+        // the inclusion of transactions. Just let this be done in the end of the method.
+        let (transactions, ack_transactions, _limit_reached) = self.transaction_consumer.next();
+        self.context
+            .metrics
+            .node_metrics
+            .proposed_block_transactions
+            .observe(transactions.len() as f64);
+
+        // Consume the commit votes to be included.
+        let commit_votes = self
+            .dag_state
+            .write()
+            .take_commit_votes(MAX_COMMIT_VOTES_PER_BLOCK);
+
+        let transaction_votes = if self.context.protocol_config.transaction_voting_enabled() {
+            let new_causal_history = {
+                let mut dag_state = self.dag_state.write();
+                ancestors
+                    .iter()
+                    .flat_map(|ancestor| dag_state.link_causal_history(ancestor.reference()))
+                    .collect()
+            };
+            self.transaction_vote_tracker.get_own_votes(new_causal_history)
+        } else {
+            vec![]
+        };
+
+        // Create the block.
+        let block = if self.context.protocol_config.transaction_voting_enabled() {
+            Block::V2(BlockV2::new(
+                self.context.committee.epoch(),
+                clock_round,
+                self.context.own_index,
+                now,
+                ancestors.iter().map(|b| b.reference()).collect(),
+                transactions,
+                commit_votes,
+                transaction_votes,
+                vec![],
+            ))
+        } else {
+            Block::V1(BlockV1::new(
+                self.context.committee.epoch(),
+                clock_round,
+                self.context.own_index,
+                now,
+                ancestors.iter().map(|b| b.reference()).collect(),
+                transactions,
+                commit_votes,
+                vec![],
+            ))
+        };
+        let signed_block =
+            SignedBlock::new(block, &self.block_signer).expect("Block signing failed.");
+        let serialized = signed_block
+            .serialize()
+            .expect("Block serialization failed.");
+        self.context
+            .metrics
+            .node_metrics
+            .proposed_block_size
+            .observe(serialized.len() as f64);
+        // Own blocks are assumed to be valid.
+        let verified_block = VerifiedBlock::new_verified(signed_block, serialized);
+
+        // Record the interval from last proposal.
+        let last_proposed_block = self.last_proposed_block();
+        if last_proposed_block.round() > 0 {
+            self.context
+                .metrics
+                .node_metrics
+                .block_proposal_interval
+                .observe(
+                    Duration::from_millis(
+                        verified_block
+                            .timestamp_ms()
+                            .saturating_sub(last_proposed_block.timestamp_ms()),
+                    )
+                    .as_secs_f64(),
+                );
+        }
+
+        // Add the block directly to DagState (skipping BlockManager since our own blocks cannot be suspended)
+        self.dag_state.write().accept_block(verified_block.clone());
+
+        // Update proposed state of blocks in local DAG.
+        if self.context.protocol_config.transaction_voting_enabled() {
+            self.transaction_vote_tracker
+                .add_voted_blocks(vec![(verified_block.clone(), vec![])]);
+            self.dag_state
+                .write()
+                .link_causal_history(verified_block.reference());
+        }
+
+        // Ensure the new block and its ancestors are persisted, before broadcasting it.
+        self.dag_state.write().flush();
+
+        // Now acknowledge the transactions for their inclusion to block
+        ack_transactions(verified_block.reference());
+
+        info!("Created block {verified_block:?} for round {clock_round}");
+
+        self.context
+            .metrics
+            .node_metrics
+            .proposed_blocks
+            .with_label_values(&[&force.to_string()])
+            .inc();
+
+        let extended_block = ExtendedBlock {
+            block: verified_block,
+            excluded_ancestors,
+        };
+
+        // Update round tracker with our own highest accepted blocks
+        self.round_tracker
+            .write()
+            .update_from_verified_block(&extended_block);
+
+        Some(extended_block)
+    }
+
+    fn should_propose(&self) -> bool {
+        let clock_round = self.dag_state.read().threshold_clock_round();
+        let core_skipped_proposals = &self.context.metrics.node_metrics.core_skipped_proposals;
+
+        if self.propagation_delay
+            > self
+                .context
+                .parameters
+                .propagation_delay_stop_proposal_threshold
+        {
+            debug!(
+                "Skip proposing for round {clock_round}, high propagation delay {} > {}.",
+                self.propagation_delay,
+                self.context
+                    .parameters
+                    .propagation_delay_stop_proposal_threshold
+            );
+            core_skipped_proposals
+                .with_label_values(&["high_propagation_delay"])
+                .inc();
+            return false;
+        }
+
+        let Some(last_known_proposed_round) = self.last_known_proposed_round else {
+            debug!(
+                "Skip proposing for round {clock_round}, last known proposed round has not been synced yet."
+            );
+            core_skipped_proposals
+                .with_label_values(&["no_last_known_proposed_round"])
+                .inc();
+            return false;
+        };
+        if clock_round <= last_known_proposed_round {
+            debug!(
+                "Skip proposing for round {clock_round} as last known proposed round is {last_known_proposed_round}"
+            );
+            core_skipped_proposals
+                .with_label_values(&["higher_last_known_proposed_round"])
+                .inc();
+            return false;
+        }
+
+        true
+    }
+
+    fn set_propagation_delay(&mut self, delay: Round) {
+        self.propagation_delay = delay;
+    }
+
+    fn set_last_known_proposed_round(&mut self, round: Round) {
+        self.last_known_proposed_round = Some(round);
+    }
+
+    fn get_last_known_proposed_round(&self) -> Option<Round> {
+        self.last_known_proposed_round
+    }
+
+    fn last_proposed_round(&self) -> Round {
+        self.dag_state
+            .read()
+            .get_last_proposed_block()
+            .expect("A block should have been returned")
+            .round()
+    }
+
+    fn last_proposed_block(&self) -> VerifiedBlock {
+        self.dag_state
+            .read()
+            .get_last_proposed_block()
+            .expect("A block should have been returned")
+    }
+
+    fn set_propagation_scores(&mut self, scores: crate::leader_scoring::ReputationScores) {
+        self.ancestor_state_manager.set_propagation_scores(scores);
+    }
+
+    fn notify_own_blocks_committed(&self, block_refs: Vec<BlockRef>, gc_round: Round) {
+        self.transaction_consumer
+            .notify_own_blocks_status(block_refs, gc_round);
+    }
+
+    #[cfg(test)]
+    fn round_tracker_for_tests(&self) -> Arc<RwLock<RoundTracker>> {
+        self.round_tracker.clone()
+    }
+}

--- a/consensus/core/src/synchronizer.rs
+++ b/consensus/core/src/synchronizer.rs
@@ -824,7 +824,7 @@ where
                 let mut retry_delay_step = Duration::from_millis(500);
                 'main:loop {
                     if context.committee.size() == 1 {
-                        highest_round = dag_state.read().get_last_proposed_block().expect("A block should have been returned").round();
+                        highest_round = dag_state.read().get_last_proposed_block().expect("Last proposed block should be returned on validators").round();
                         info!("Only one node in the network, will not try fetching own last block from peers.");
                         break 'main;
                     }

--- a/consensus/core/src/synchronizer.rs
+++ b/consensus/core/src/synchronizer.rs
@@ -824,7 +824,7 @@ where
                 let mut retry_delay_step = Duration::from_millis(500);
                 'main:loop {
                     if context.committee.size() == 1 {
-                        highest_round = dag_state.read().get_last_proposed_block().round();
+                        highest_round = dag_state.read().get_last_proposed_block().expect("A block should have been returned").round();
                         info!("Only one node in the network, will not try fetching own last block from peers.");
                         break 'main;
                     }

--- a/consensus/core/src/transaction_vote_tracker.rs
+++ b/consensus/core/src/transaction_vote_tracker.rs
@@ -320,7 +320,7 @@ struct VoteInfo {
 mod test {
     use std::sync::Arc;
 
-    use consensus_config::Parameters;
+    use consensus_config::{AuthorityIndex, Parameters};
 
     use crate::{
         TestBlock, Transaction, VerifiedBlock, block::BlockTransactionVotes, context::Context,
@@ -338,7 +338,7 @@ mod test {
         let temp_dir = tempfile::TempDir::new().unwrap();
         let context = Arc::new(Context::new(
             0,
-            consensus_config::AuthorityIndex::new_for_test(0),
+            Some(AuthorityIndex::new_for_test(0)),
             committee,
             Parameters {
                 db_path: temp_dir.path().to_path_buf(),

--- a/consensus/simtests/src/node.rs
+++ b/consensus/simtests/src/node.rs
@@ -294,11 +294,10 @@ pub(crate) async fn make_authority(
     let authority = ConsensusAuthority::start(
         NetworkType::Tonic,
         0,
-        authority_index,
         committee,
         parameters,
         protocol_config,
-        protocol_keypair,
+        Some(protocol_keypair),
         network_keypair,
         Arc::new(Clock::new_for_test(clock_drift)),
         transaction_verifier,

--- a/crates/mysten-common/src/backoff.rs
+++ b/crates/mysten-common/src/backoff.rs
@@ -33,6 +33,7 @@ use rand::Rng as _;
 /// ```
 #[derive(Debug, Clone)]
 pub struct ExponentialBackoff {
+    initial_delay: Duration,
     next: Duration,
     factor: f64,
     max_delay: Duration,
@@ -43,11 +44,17 @@ impl ExponentialBackoff {
     /// Constructs a new exponential backoff generator, specifying the maximum delay.
     pub fn new(initial_delay: Duration, max_delay: Duration) -> ExponentialBackoff {
         ExponentialBackoff {
+            initial_delay,
             next: initial_delay,
             factor: 1.2,
             max_delay,
             max_jitter: initial_delay,
         }
+    }
+
+    /// Resets the backoff to the initial delay.
+    pub fn reset(&mut self) {
+        self.next = self.initial_delay;
     }
 
     /// Sets the approximate ratio of consecutive backoff delays, before jitters are applied.
@@ -129,4 +136,20 @@ fn test_exponential_backoff_max_delay() {
     for _ in 0..10 {
         assert_eq!(backoff.next(), Some(Duration::from_secs(1)));
     }
+}
+
+#[test]
+fn test_exponential_backoff_reset() {
+    let mut backoff = ExponentialBackoff::new(Duration::from_millis(100), Duration::from_secs(10))
+        .factor(2.0)
+        .max_jitter(Duration::ZERO);
+
+    assert_eq!(backoff.next(), Some(Duration::from_millis(100)));
+    assert_eq!(backoff.next(), Some(Duration::from_millis(200)));
+    assert_eq!(backoff.next(), Some(Duration::from_millis(400)));
+
+    backoff.reset();
+
+    assert_eq!(backoff.next(), Some(Duration::from_millis(100)));
+    assert_eq!(backoff.next(), Some(Duration::from_millis(200)));
 }

--- a/crates/sui-core/src/consensus_manager/mod.rs
+++ b/crates/sui-core/src/consensus_manager/mod.rs
@@ -242,12 +242,6 @@ impl ConsensusManager {
             ..consensus_config.parameters.clone().unwrap_or_default()
         };
 
-        let own_protocol_key = self.protocol_keypair.public();
-        let (own_index, _) = committee
-            .authorities()
-            .find(|(_, a)| a.protocol_key == own_protocol_key)
-            .expect("Own authority should be among the consensus authorities!");
-
         let registry = Registry::new_custom(Some("consensus".to_string()), None).unwrap();
 
         let consensus_handler = consensus_handler_initializer.new_consensus_handler();
@@ -299,11 +293,10 @@ impl ConsensusManager {
         let authority = ConsensusAuthority::start(
             NetworkType::Tonic,
             epoch_store.epoch_start_config().epoch_start_timestamp_ms(),
-            own_index,
             committee.clone(),
             parameters.clone(),
             to_consensus_protocol_config(protocol_config, epoch_store.get_chain()),
-            self.protocol_keypair.clone(),
+            Some(self.protocol_keypair.clone()),
             self.network_keypair.clone(),
             Arc::new(Clock::default()),
             Arc::new(tx_validator.clone()),


### PR DESCRIPTION
## Description 

Observer nodes do not propose blocks. `Core` currently uses lots of components that will be either unused in this case or we'll need to set them as `Option`. Although that would be ok, separating the `Proposer` logic and initialising it only for `Validator` nodes deemed more appropriate.

Also the PR is doing some lightweight refactoring on the way the `AuthorityNode` is initialised to support the case where an `Observer` should initialised.

## Test plan 

CI

---

## Next

- https://github.com/MystenLabs/sui/pull/25975

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
