### PR TITLE
[move] Update docgen generated structure to be flat

### DIFF
--- a/crates/sui-framework/docs/std/internal.md
+++ b/crates/sui-framework/docs/std/internal.md
@@ -12,8 +12,8 @@ module example::use_permit;
 public struct MyType { /* ... */ }
 
 public fun test_permit() {
-let permit = internal::permit<MyType>();
-/* external_module::call_with_permit(permit); */
+   let permit = internal::permit<MyType>();
+   /* external_module::call_with_permit(permit); */
 }
 ```
 
@@ -25,7 +25,7 @@ To write a function that is guarded by a <code><a href="../std/internal.md#std_i
 module example::type_registry;
 
 public fun register_type<T>(_: internal::Permit<T> /* ... */) {
-/* ... */
+  /* ... */
 }
 ```
 

--- a/crates/sui-framework/docs/sui/accumulator.md
+++ b/crates/sui-framework/docs/sui/accumulator.md
@@ -161,8 +161,8 @@ to cause an overflow.
 
 <pre><code><b>fun</b> <a href="../sui/accumulator.md#sui_accumulator_create">create</a>(ctx: &TxContext) {
     <b>assert</b>!(ctx.sender() == @0x0, <a href="../sui/accumulator.md#sui_accumulator_ENotSystemAddress">ENotSystemAddress</a>);
-    <a href="../sui/transfer.md#sui_transfer_share_object">transfer::share_object</a>(<a href="../sui/accumulator.md#sui_accumulator_AccumulatorRoot">AccumulatorRoot</a> {
-        id: <a href="../sui/object.md#sui_object_sui_accumulator_root_object_id">object::sui_accumulator_root_object_id</a>(),
+    transfer::share_object(<a href="../sui/accumulator.md#sui_accumulator_AccumulatorRoot">AccumulatorRoot</a> {
+        id: object::sui_accumulator_root_object_id(),
     })
 }
 </code></pre>
@@ -177,7 +177,7 @@ to cause an overflow.
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/accumulator.md#sui_accumulator_root_id">root_id</a>(accumulator_root: &<a href="../sui/accumulator.md#sui_accumulator_AccumulatorRoot">sui::accumulator::AccumulatorRoot</a>): &<a href="../sui/object.md#sui_object_UID">sui::object::UID</a>
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/accumulator.md#sui_accumulator_root_id">root_id</a>(accumulator_root: &<a href="../sui/accumulator.md#sui_accumulator_AccumulatorRoot">sui::accumulator::AccumulatorRoot</a>): &<a href="../sui/object.md#sui_object_UID">sui::object::UID</a>
 </code></pre>
 
 
@@ -186,7 +186,7 @@ to cause an overflow.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/accumulator.md#sui_accumulator_root_id">root_id</a>(accumulator_root: &<a href="../sui/accumulator.md#sui_accumulator_AccumulatorRoot">AccumulatorRoot</a>): &UID {
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/accumulator.md#sui_accumulator_root_id">root_id</a>(accumulator_root: &<a href="../sui/accumulator.md#sui_accumulator_AccumulatorRoot">AccumulatorRoot</a>): &UID {
     &accumulator_root.id
 }
 </code></pre>
@@ -201,7 +201,7 @@ to cause an overflow.
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/accumulator.md#sui_accumulator_root_id_mut">root_id_mut</a>(accumulator_root: &<b>mut</b> <a href="../sui/accumulator.md#sui_accumulator_AccumulatorRoot">sui::accumulator::AccumulatorRoot</a>): &<b>mut</b> <a href="../sui/object.md#sui_object_UID">sui::object::UID</a>
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/accumulator.md#sui_accumulator_root_id_mut">root_id_mut</a>(accumulator_root: &<b>mut</b> <a href="../sui/accumulator.md#sui_accumulator_AccumulatorRoot">sui::accumulator::AccumulatorRoot</a>): &<b>mut</b> <a href="../sui/object.md#sui_object_UID">sui::object::UID</a>
 </code></pre>
 
 
@@ -210,7 +210,7 @@ to cause an overflow.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/accumulator.md#sui_accumulator_root_id_mut">root_id_mut</a>(accumulator_root: &<b>mut</b> <a href="../sui/accumulator.md#sui_accumulator_AccumulatorRoot">AccumulatorRoot</a>): &<b>mut</b> UID {
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/accumulator.md#sui_accumulator_root_id_mut">root_id_mut</a>(accumulator_root: &<b>mut</b> <a href="../sui/accumulator.md#sui_accumulator_AccumulatorRoot">AccumulatorRoot</a>): &<b>mut</b> UID {
     &<b>mut</b> accumulator_root.id
 }
 </code></pre>
@@ -225,7 +225,7 @@ to cause an overflow.
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/accumulator.md#sui_accumulator_accumulator_u128_exists">accumulator_u128_exists</a>&lt;T&gt;(root: &<a href="../sui/accumulator.md#sui_accumulator_AccumulatorRoot">sui::accumulator::AccumulatorRoot</a>, <b>address</b>: <b>address</b>): bool
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/accumulator.md#sui_accumulator_accumulator_u128_exists">accumulator_u128_exists</a>&lt;T&gt;(root: &<a href="../sui/accumulator.md#sui_accumulator_AccumulatorRoot">sui::accumulator::AccumulatorRoot</a>, <b>address</b>: <b>address</b>): bool
 </code></pre>
 
 
@@ -234,7 +234,7 @@ to cause an overflow.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/accumulator.md#sui_accumulator_accumulator_u128_exists">accumulator_u128_exists</a>&lt;T&gt;(root: &<a href="../sui/accumulator.md#sui_accumulator_AccumulatorRoot">AccumulatorRoot</a>, <b>address</b>: <b>address</b>): bool {
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/accumulator.md#sui_accumulator_accumulator_u128_exists">accumulator_u128_exists</a>&lt;T&gt;(root: &<a href="../sui/accumulator.md#sui_accumulator_AccumulatorRoot">AccumulatorRoot</a>, <b>address</b>: <b>address</b>): bool {
     root.has_accumulator&lt;T, <a href="../sui/accumulator.md#sui_accumulator_U128">U128</a>&gt;(<a href="../sui/accumulator.md#sui_accumulator_Key">Key</a>&lt;T&gt; { <b>address</b> })
 }
 </code></pre>
@@ -249,7 +249,7 @@ to cause an overflow.
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/accumulator.md#sui_accumulator_accumulator_u128_read">accumulator_u128_read</a>&lt;T&gt;(root: &<a href="../sui/accumulator.md#sui_accumulator_AccumulatorRoot">sui::accumulator::AccumulatorRoot</a>, <b>address</b>: <b>address</b>): u128
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/accumulator.md#sui_accumulator_accumulator_u128_read">accumulator_u128_read</a>&lt;T&gt;(root: &<a href="../sui/accumulator.md#sui_accumulator_AccumulatorRoot">sui::accumulator::AccumulatorRoot</a>, <b>address</b>: <b>address</b>): u128
 </code></pre>
 
 
@@ -258,9 +258,9 @@ to cause an overflow.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/accumulator.md#sui_accumulator_accumulator_u128_read">accumulator_u128_read</a>&lt;T&gt;(root: &<a href="../sui/accumulator.md#sui_accumulator_AccumulatorRoot">AccumulatorRoot</a>, <b>address</b>: <b>address</b>): u128 {
-    <b>let</b> <a href="../sui/accumulator.md#sui_accumulator">accumulator</a> = root.borrow_accumulator&lt;T, <a href="../sui/accumulator.md#sui_accumulator_U128">U128</a>&gt;(<a href="../sui/accumulator.md#sui_accumulator_Key">Key</a>&lt;T&gt; { <b>address</b> });
-    <a href="../sui/accumulator.md#sui_accumulator">accumulator</a>.value
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/accumulator.md#sui_accumulator_accumulator_u128_read">accumulator_u128_read</a>&lt;T&gt;(root: &<a href="../sui/accumulator.md#sui_accumulator_AccumulatorRoot">AccumulatorRoot</a>, <b>address</b>: <b>address</b>): u128 {
+    <b>let</b> accumulator = root.borrow_accumulator&lt;T, <a href="../sui/accumulator.md#sui_accumulator_U128">U128</a>&gt;(<a href="../sui/accumulator.md#sui_accumulator_Key">Key</a>&lt;T&gt; { <b>address</b> });
+    accumulator.value
 }
 </code></pre>
 
@@ -274,7 +274,7 @@ to cause an overflow.
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/accumulator.md#sui_accumulator_create_u128">create_u128</a>(value: u128): <a href="../sui/accumulator.md#sui_accumulator_U128">sui::accumulator::U128</a>
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/accumulator.md#sui_accumulator_create_u128">create_u128</a>(value: u128): <a href="../sui/accumulator.md#sui_accumulator_U128">sui::accumulator::U128</a>
 </code></pre>
 
 
@@ -283,7 +283,7 @@ to cause an overflow.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/accumulator.md#sui_accumulator_create_u128">create_u128</a>(value: u128): <a href="../sui/accumulator.md#sui_accumulator_U128">U128</a> {
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/accumulator.md#sui_accumulator_create_u128">create_u128</a>(value: u128): <a href="../sui/accumulator.md#sui_accumulator_U128">U128</a> {
     <a href="../sui/accumulator.md#sui_accumulator_U128">U128</a> { value }
 }
 </code></pre>
@@ -298,7 +298,7 @@ to cause an overflow.
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/accumulator.md#sui_accumulator_destroy_u128">destroy_u128</a>(u128: <a href="../sui/accumulator.md#sui_accumulator_U128">sui::accumulator::U128</a>)
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/accumulator.md#sui_accumulator_destroy_u128">destroy_u128</a>(u128: <a href="../sui/accumulator.md#sui_accumulator_U128">sui::accumulator::U128</a>)
 </code></pre>
 
 
@@ -307,7 +307,7 @@ to cause an overflow.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/accumulator.md#sui_accumulator_destroy_u128">destroy_u128</a>(u128: <a href="../sui/accumulator.md#sui_accumulator_U128">U128</a>) {
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/accumulator.md#sui_accumulator_destroy_u128">destroy_u128</a>(u128: <a href="../sui/accumulator.md#sui_accumulator_U128">U128</a>) {
     <b>let</b> <a href="../sui/accumulator.md#sui_accumulator_U128">U128</a> { value: _ } = u128;
 }
 </code></pre>
@@ -322,7 +322,7 @@ to cause an overflow.
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/accumulator.md#sui_accumulator_update_u128">update_u128</a>(u128: &<b>mut</b> <a href="../sui/accumulator.md#sui_accumulator_U128">sui::accumulator::U128</a>, merge: u128, split: u128)
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/accumulator.md#sui_accumulator_update_u128">update_u128</a>(u128: &<b>mut</b> <a href="../sui/accumulator.md#sui_accumulator_U128">sui::accumulator::U128</a>, merge: u128, split: u128)
 </code></pre>
 
 
@@ -331,7 +331,7 @@ to cause an overflow.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/accumulator.md#sui_accumulator_update_u128">update_u128</a>(u128: &<b>mut</b> <a href="../sui/accumulator.md#sui_accumulator_U128">U128</a>, merge: u128, split: u128) {
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/accumulator.md#sui_accumulator_update_u128">update_u128</a>(u128: &<b>mut</b> <a href="../sui/accumulator.md#sui_accumulator_U128">U128</a>, merge: u128, split: u128) {
     u128.value = u128.value + merge - split;
 }
 </code></pre>
@@ -346,7 +346,7 @@ to cause an overflow.
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/accumulator.md#sui_accumulator_is_zero_u128">is_zero_u128</a>(u128: &<a href="../sui/accumulator.md#sui_accumulator_U128">sui::accumulator::U128</a>): bool
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/accumulator.md#sui_accumulator_is_zero_u128">is_zero_u128</a>(u128: &<a href="../sui/accumulator.md#sui_accumulator_U128">sui::accumulator::U128</a>): bool
 </code></pre>
 
 
@@ -355,7 +355,7 @@ to cause an overflow.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/accumulator.md#sui_accumulator_is_zero_u128">is_zero_u128</a>(u128: &<a href="../sui/accumulator.md#sui_accumulator_U128">U128</a>): bool {
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/accumulator.md#sui_accumulator_is_zero_u128">is_zero_u128</a>(u128: &<a href="../sui/accumulator.md#sui_accumulator_U128">U128</a>): bool {
     u128.value == 0
 }
 </code></pre>
@@ -370,7 +370,7 @@ to cause an overflow.
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/accumulator.md#sui_accumulator_accumulator_key">accumulator_key</a>&lt;T&gt;(<b>address</b>: <b>address</b>): <a href="../sui/accumulator.md#sui_accumulator_Key">sui::accumulator::Key</a>&lt;T&gt;
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/accumulator.md#sui_accumulator_accumulator_key">accumulator_key</a>&lt;T&gt;(<b>address</b>: <b>address</b>): <a href="../sui/accumulator.md#sui_accumulator_Key">sui::accumulator::Key</a>&lt;T&gt;
 </code></pre>
 
 
@@ -379,7 +379,7 @@ to cause an overflow.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/accumulator.md#sui_accumulator_accumulator_key">accumulator_key</a>&lt;T&gt;(<b>address</b>: <b>address</b>): <a href="../sui/accumulator.md#sui_accumulator_Key">Key</a>&lt;T&gt; {
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/accumulator.md#sui_accumulator_accumulator_key">accumulator_key</a>&lt;T&gt;(<b>address</b>: <b>address</b>): <a href="../sui/accumulator.md#sui_accumulator_Key">Key</a>&lt;T&gt; {
     <a href="../sui/accumulator.md#sui_accumulator_Key">Key</a> { <b>address</b> }
 }
 </code></pre>
@@ -394,7 +394,7 @@ to cause an overflow.
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/accumulator.md#sui_accumulator_accumulator_address">accumulator_address</a>&lt;T&gt;(<b>address</b>: <b>address</b>): <b>address</b>
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/accumulator.md#sui_accumulator_accumulator_address">accumulator_address</a>&lt;T&gt;(<b>address</b>: <b>address</b>): <b>address</b>
 </code></pre>
 
 
@@ -403,9 +403,9 @@ to cause an overflow.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/accumulator.md#sui_accumulator_accumulator_address">accumulator_address</a>&lt;T&gt;(<b>address</b>: <b>address</b>): <b>address</b> {
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/accumulator.md#sui_accumulator_accumulator_address">accumulator_address</a>&lt;T&gt;(<b>address</b>: <b>address</b>): <b>address</b> {
     <b>let</b> key = <a href="../sui/accumulator.md#sui_accumulator_Key">Key</a>&lt;T&gt; { <b>address</b> };
-    <a href="../sui/dynamic_field.md#sui_dynamic_field_hash_type_and_key">dynamic_field::hash_type_and_key</a>(sui_accumulator_root_address(), key)
+    dynamic_field::hash_type_and_key(sui_accumulator_root_address(), key)
 }
 </code></pre>
 
@@ -420,7 +420,7 @@ to cause an overflow.
 Balance object methods
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/accumulator.md#sui_accumulator_root_has_accumulator">root_has_accumulator</a>&lt;K, V: store&gt;(accumulator_root: &<a href="../sui/accumulator.md#sui_accumulator_AccumulatorRoot">sui::accumulator::AccumulatorRoot</a>, name: <a href="../sui/accumulator.md#sui_accumulator_Key">sui::accumulator::Key</a>&lt;K&gt;): bool
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/accumulator.md#sui_accumulator_root_has_accumulator">root_has_accumulator</a>&lt;K, V: store&gt;(accumulator_root: &<a href="../sui/accumulator.md#sui_accumulator_AccumulatorRoot">sui::accumulator::AccumulatorRoot</a>, name: <a href="../sui/accumulator.md#sui_accumulator_Key">sui::accumulator::Key</a>&lt;K&gt;): bool
 </code></pre>
 
 
@@ -429,11 +429,11 @@ Balance object methods
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/accumulator.md#sui_accumulator_root_has_accumulator">root_has_accumulator</a>&lt;K, V: store&gt;(
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/accumulator.md#sui_accumulator_root_has_accumulator">root_has_accumulator</a>&lt;K, V: store&gt;(
     accumulator_root: &<a href="../sui/accumulator.md#sui_accumulator_AccumulatorRoot">AccumulatorRoot</a>,
     name: <a href="../sui/accumulator.md#sui_accumulator_Key">Key</a>&lt;K&gt;,
 ): bool {
-    <a href="../sui/dynamic_field.md#sui_dynamic_field_exists_with_type">dynamic_field::exists_with_type</a>&lt;<a href="../sui/accumulator.md#sui_accumulator_Key">Key</a>&lt;K&gt;, V&gt;(&accumulator_root.id, name)
+    dynamic_field::exists_with_type&lt;<a href="../sui/accumulator.md#sui_accumulator_Key">Key</a>&lt;K&gt;, V&gt;(&accumulator_root.id, name)
 }
 </code></pre>
 
@@ -447,7 +447,7 @@ Balance object methods
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/accumulator.md#sui_accumulator_root_add_accumulator">root_add_accumulator</a>&lt;K, V: store&gt;(accumulator_root: &<b>mut</b> <a href="../sui/accumulator.md#sui_accumulator_AccumulatorRoot">sui::accumulator::AccumulatorRoot</a>, name: <a href="../sui/accumulator.md#sui_accumulator_Key">sui::accumulator::Key</a>&lt;K&gt;, value: V)
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/accumulator.md#sui_accumulator_root_add_accumulator">root_add_accumulator</a>&lt;K, V: store&gt;(accumulator_root: &<b>mut</b> <a href="../sui/accumulator.md#sui_accumulator_AccumulatorRoot">sui::accumulator::AccumulatorRoot</a>, name: <a href="../sui/accumulator.md#sui_accumulator_Key">sui::accumulator::Key</a>&lt;K&gt;, value: V)
 </code></pre>
 
 
@@ -456,12 +456,12 @@ Balance object methods
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/accumulator.md#sui_accumulator_root_add_accumulator">root_add_accumulator</a>&lt;K, V: store&gt;(
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/accumulator.md#sui_accumulator_root_add_accumulator">root_add_accumulator</a>&lt;K, V: store&gt;(
     accumulator_root: &<b>mut</b> <a href="../sui/accumulator.md#sui_accumulator_AccumulatorRoot">AccumulatorRoot</a>,
     name: <a href="../sui/accumulator.md#sui_accumulator_Key">Key</a>&lt;K&gt;,
     value: V,
 ) {
-    <a href="../sui/dynamic_field.md#sui_dynamic_field_add">dynamic_field::add</a>(&<b>mut</b> accumulator_root.id, name, value);
+    dynamic_field::add(&<b>mut</b> accumulator_root.id, name, value);
 }
 </code></pre>
 
@@ -475,7 +475,7 @@ Balance object methods
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/accumulator.md#sui_accumulator_root_borrow_accumulator_mut">root_borrow_accumulator_mut</a>&lt;K, V: store&gt;(accumulator_root: &<b>mut</b> <a href="../sui/accumulator.md#sui_accumulator_AccumulatorRoot">sui::accumulator::AccumulatorRoot</a>, name: <a href="../sui/accumulator.md#sui_accumulator_Key">sui::accumulator::Key</a>&lt;K&gt;): &<b>mut</b> V
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/accumulator.md#sui_accumulator_root_borrow_accumulator_mut">root_borrow_accumulator_mut</a>&lt;K, V: store&gt;(accumulator_root: &<b>mut</b> <a href="../sui/accumulator.md#sui_accumulator_AccumulatorRoot">sui::accumulator::AccumulatorRoot</a>, name: <a href="../sui/accumulator.md#sui_accumulator_Key">sui::accumulator::Key</a>&lt;K&gt;): &<b>mut</b> V
 </code></pre>
 
 
@@ -484,11 +484,11 @@ Balance object methods
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/accumulator.md#sui_accumulator_root_borrow_accumulator_mut">root_borrow_accumulator_mut</a>&lt;K, V: store&gt;(
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/accumulator.md#sui_accumulator_root_borrow_accumulator_mut">root_borrow_accumulator_mut</a>&lt;K, V: store&gt;(
     accumulator_root: &<b>mut</b> <a href="../sui/accumulator.md#sui_accumulator_AccumulatorRoot">AccumulatorRoot</a>,
     name: <a href="../sui/accumulator.md#sui_accumulator_Key">Key</a>&lt;K&gt;,
 ): &<b>mut</b> V {
-    <a href="../sui/dynamic_field.md#sui_dynamic_field_borrow_mut">dynamic_field::borrow_mut</a>&lt;<a href="../sui/accumulator.md#sui_accumulator_Key">Key</a>&lt;K&gt;, V&gt;(&<b>mut</b> accumulator_root.id, name)
+    dynamic_field::borrow_mut&lt;<a href="../sui/accumulator.md#sui_accumulator_Key">Key</a>&lt;K&gt;, V&gt;(&<b>mut</b> accumulator_root.id, name)
 }
 </code></pre>
 
@@ -502,7 +502,7 @@ Balance object methods
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/accumulator.md#sui_accumulator_root_borrow_accumulator">root_borrow_accumulator</a>&lt;K, V: store&gt;(accumulator_root: &<a href="../sui/accumulator.md#sui_accumulator_AccumulatorRoot">sui::accumulator::AccumulatorRoot</a>, name: <a href="../sui/accumulator.md#sui_accumulator_Key">sui::accumulator::Key</a>&lt;K&gt;): &V
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/accumulator.md#sui_accumulator_root_borrow_accumulator">root_borrow_accumulator</a>&lt;K, V: store&gt;(accumulator_root: &<a href="../sui/accumulator.md#sui_accumulator_AccumulatorRoot">sui::accumulator::AccumulatorRoot</a>, name: <a href="../sui/accumulator.md#sui_accumulator_Key">sui::accumulator::Key</a>&lt;K&gt;): &V
 </code></pre>
 
 
@@ -511,11 +511,11 @@ Balance object methods
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/accumulator.md#sui_accumulator_root_borrow_accumulator">root_borrow_accumulator</a>&lt;K, V: store&gt;(
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/accumulator.md#sui_accumulator_root_borrow_accumulator">root_borrow_accumulator</a>&lt;K, V: store&gt;(
     accumulator_root: &<a href="../sui/accumulator.md#sui_accumulator_AccumulatorRoot">AccumulatorRoot</a>,
     name: <a href="../sui/accumulator.md#sui_accumulator_Key">Key</a>&lt;K&gt;,
 ): &V {
-    <a href="../sui/dynamic_field.md#sui_dynamic_field_borrow">dynamic_field::borrow</a>&lt;<a href="../sui/accumulator.md#sui_accumulator_Key">Key</a>&lt;K&gt;, V&gt;(&accumulator_root.id, name)
+    dynamic_field::borrow&lt;<a href="../sui/accumulator.md#sui_accumulator_Key">Key</a>&lt;K&gt;, V&gt;(&accumulator_root.id, name)
 }
 </code></pre>
 
@@ -529,7 +529,7 @@ Balance object methods
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/accumulator.md#sui_accumulator_root_remove_accumulator">root_remove_accumulator</a>&lt;K, V: store&gt;(accumulator_root: &<b>mut</b> <a href="../sui/accumulator.md#sui_accumulator_AccumulatorRoot">sui::accumulator::AccumulatorRoot</a>, name: <a href="../sui/accumulator.md#sui_accumulator_Key">sui::accumulator::Key</a>&lt;K&gt;): V
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/accumulator.md#sui_accumulator_root_remove_accumulator">root_remove_accumulator</a>&lt;K, V: store&gt;(accumulator_root: &<b>mut</b> <a href="../sui/accumulator.md#sui_accumulator_AccumulatorRoot">sui::accumulator::AccumulatorRoot</a>, name: <a href="../sui/accumulator.md#sui_accumulator_Key">sui::accumulator::Key</a>&lt;K&gt;): V
 </code></pre>
 
 
@@ -538,11 +538,11 @@ Balance object methods
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/accumulator.md#sui_accumulator_root_remove_accumulator">root_remove_accumulator</a>&lt;K, V: store&gt;(
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/accumulator.md#sui_accumulator_root_remove_accumulator">root_remove_accumulator</a>&lt;K, V: store&gt;(
     accumulator_root: &<b>mut</b> <a href="../sui/accumulator.md#sui_accumulator_AccumulatorRoot">AccumulatorRoot</a>,
     name: <a href="../sui/accumulator.md#sui_accumulator_Key">Key</a>&lt;K&gt;,
 ): V {
-    <a href="../sui/dynamic_field.md#sui_dynamic_field_remove">dynamic_field::remove</a>&lt;<a href="../sui/accumulator.md#sui_accumulator_Key">Key</a>&lt;K&gt;, V&gt;(&<b>mut</b> accumulator_root.id, name)
+    dynamic_field::remove&lt;<a href="../sui/accumulator.md#sui_accumulator_Key">Key</a>&lt;K&gt;, V&gt;(&<b>mut</b> accumulator_root.id, name)
 }
 </code></pre>
 
@@ -556,7 +556,7 @@ Balance object methods
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/accumulator.md#sui_accumulator_emit_deposit_event">emit_deposit_event</a>&lt;T&gt;(<a href="../sui/accumulator.md#sui_accumulator">accumulator</a>: <b>address</b>, recipient: <b>address</b>, amount: u64)
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/accumulator.md#sui_accumulator_emit_deposit_event">emit_deposit_event</a>&lt;T&gt;(accumulator: <b>address</b>, recipient: <b>address</b>, amount: u64)
 </code></pre>
 
 
@@ -565,8 +565,8 @@ Balance object methods
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>native</b> <b>fun</b> <a href="../sui/accumulator.md#sui_accumulator_emit_deposit_event">emit_deposit_event</a>&lt;T&gt;(
-    <a href="../sui/accumulator.md#sui_accumulator">accumulator</a>: <b>address</b>,
+<pre><code><b>public</b>(package) <b>native</b> <b>fun</b> <a href="../sui/accumulator.md#sui_accumulator_emit_deposit_event">emit_deposit_event</a>&lt;T&gt;(
+    accumulator: <b>address</b>,
     recipient: <b>address</b>,
     amount: u64,
 );
@@ -582,7 +582,7 @@ Balance object methods
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/accumulator.md#sui_accumulator_emit_withdraw_event">emit_withdraw_event</a>&lt;T&gt;(<a href="../sui/accumulator.md#sui_accumulator">accumulator</a>: <b>address</b>, owner: <b>address</b>, amount: u64)
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/accumulator.md#sui_accumulator_emit_withdraw_event">emit_withdraw_event</a>&lt;T&gt;(accumulator: <b>address</b>, owner: <b>address</b>, amount: u64)
 </code></pre>
 
 
@@ -591,8 +591,8 @@ Balance object methods
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>native</b> <b>fun</b> <a href="../sui/accumulator.md#sui_accumulator_emit_withdraw_event">emit_withdraw_event</a>&lt;T&gt;(
-    <a href="../sui/accumulator.md#sui_accumulator">accumulator</a>: <b>address</b>,
+<pre><code><b>public</b>(package) <b>native</b> <b>fun</b> <a href="../sui/accumulator.md#sui_accumulator_emit_withdraw_event">emit_withdraw_event</a>&lt;T&gt;(
+    accumulator: <b>address</b>,
     owner: <b>address</b>,
     amount: u64,
 );

--- a/crates/sui-framework/docs/sui/accumulator_metadata.md
+++ b/crates/sui-framework/docs/sui/accumulator_metadata.md
@@ -210,13 +210,13 @@ barrier transaction.
     objects_destroyed: u64,
 ) {
     <b>let</b> key = <a href="../sui/accumulator_metadata.md#sui_accumulator_metadata_AccumulatorObjectCountKey">AccumulatorObjectCountKey</a>();
-    <b>if</b> (<a href="../sui/dynamic_field.md#sui_dynamic_field_exists_">dynamic_field::exists_</a>(accumulator_root.id_mut(), key)) {
-        <b>let</b> current_count: &<b>mut</b> u64 = <a href="../sui/dynamic_field.md#sui_dynamic_field_borrow_mut">dynamic_field::borrow_mut</a>(accumulator_root.id_mut(), key);
+    <b>if</b> (dynamic_field::exists_(accumulator_root.id_mut(), key)) {
+        <b>let</b> current_count: &<b>mut</b> u64 = dynamic_field::borrow_mut(accumulator_root.id_mut(), key);
         <b>assert</b>!(*current_count + objects_created &gt;= objects_destroyed, <a href="../sui/accumulator_metadata.md#sui_accumulator_metadata_EInvariantViolation">EInvariantViolation</a>);
         *current_count = *current_count + objects_created - objects_destroyed;
     } <b>else</b> {
         <b>assert</b>!(objects_created &gt;= objects_destroyed, <a href="../sui/accumulator_metadata.md#sui_accumulator_metadata_EInvariantViolation">EInvariantViolation</a>);
-        <a href="../sui/dynamic_field.md#sui_dynamic_field_add">dynamic_field::add</a>(accumulator_root.id_mut(), key, objects_created - objects_destroyed);
+        dynamic_field::add(accumulator_root.id_mut(), key, objects_created - objects_destroyed);
     };
 }
 </code></pre>
@@ -243,8 +243,8 @@ Returns the current count of accumulator objects stored as a dynamic field.
 
 <pre><code><b>fun</b> <a href="../sui/accumulator_metadata.md#sui_accumulator_metadata_get_accumulator_object_count">get_accumulator_object_count</a>(accumulator_root: &AccumulatorRoot): u64 {
     <b>let</b> key = <a href="../sui/accumulator_metadata.md#sui_accumulator_metadata_AccumulatorObjectCountKey">AccumulatorObjectCountKey</a>();
-    <b>if</b> (<a href="../sui/dynamic_field.md#sui_dynamic_field_exists_">dynamic_field::exists_</a>(accumulator_root.id(), key)) {
-        *<a href="../sui/dynamic_field.md#sui_dynamic_field_borrow">dynamic_field::borrow</a>(accumulator_root.id(), key)
+    <b>if</b> (dynamic_field::exists_(accumulator_root.id(), key)) {
+        *dynamic_field::borrow(accumulator_root.id(), key)
     } <b>else</b> {
         0
     }

--- a/crates/sui-framework/docs/sui/accumulator_settlement.md
+++ b/crates/sui-framework/docs/sui/accumulator_settlement.md
@@ -120,9 +120,9 @@ digest.
     _epoch: u64,
     _checkpoint_height: u64,
     _idx: u64,
-    // Total input <a href="../sui/sui.md#sui_sui">sui</a> received from user transactions
+    // Total input sui received from user transactions
     input_sui: u64,
-    // Total output <a href="../sui/sui.md#sui_sui">sui</a> withdrawn by user transactions
+    // Total output sui withdrawn by user transactions
     output_sui: u64,
     ctx: &TxContext,
 ) {
@@ -261,7 +261,7 @@ Called by the settlement transaction to track conservation of SUI.
 
 
 <pre><code><b>fun</b> <a href="../sui/accumulator_settlement.md#sui_accumulator_settlement_u256_from_bytes">u256_from_bytes</a>(bytes: vector&lt;u8&gt;): u256 {
-    <a href="../sui/bcs.md#sui_bcs_new">bcs::new</a>(bytes).peel_u256()
+    bcs::new(bytes).peel_u256()
 }
 </code></pre>
 
@@ -285,11 +285,11 @@ Called by the settlement transaction to track conservation of SUI.
 
 
 <pre><code><b>fun</b> <a href="../sui/accumulator_settlement.md#sui_accumulator_settlement_hash_two_to_one_u256">hash_two_to_one_u256</a>(left: u256, right: u256): u256 {
-    <b>let</b> left_bytes = <a href="../sui/bcs.md#sui_bcs_to_bytes">bcs::to_bytes</a>(&left);
-    <b>let</b> right_bytes = <a href="../sui/bcs.md#sui_bcs_to_bytes">bcs::to_bytes</a>(&right);
+    <b>let</b> left_bytes = bcs::to_bytes(&left);
+    <b>let</b> right_bytes = bcs::to_bytes(&right);
     <b>let</b> <b>mut</b> concatenated = left_bytes;
     vector::append(&<b>mut</b> concatenated, right_bytes);
-    <a href="../sui/accumulator_settlement.md#sui_accumulator_settlement_u256_from_bytes">u256_from_bytes</a>(<a href="../sui/hash.md#sui_hash_blake2b256">hash::blake2b256</a>(&concatenated))
+    <a href="../sui/accumulator_settlement.md#sui_accumulator_settlement_u256_from_bytes">u256_from_bytes</a>(hash::blake2b256(&concatenated))
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/sui/address.md
+++ b/crates/sui-framework/docs/sui/address.md
@@ -150,7 +150,7 @@ Convert <code>a</code> into BCS-encoded bytes.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/address.md#sui_address_to_bytes">to_bytes</a>(a: <b>address</b>): vector&lt;u8&gt; {
-    <a href="../sui/bcs.md#sui_bcs_to_bytes">bcs::to_bytes</a>(&a)
+    bcs::to_bytes(&a)
 }
 </code></pre>
 
@@ -175,7 +175,7 @@ Convert <code>a</code> to a hex-encoded ASCII string
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/address.md#sui_address_to_ascii_string">to_ascii_string</a>(a: <b>address</b>): ascii::String {
-    <a href="../sui/hex.md#sui_hex_encode">hex::encode</a>(<a href="../sui/address.md#sui_address_to_bytes">to_bytes</a>(a)).<a href="../sui/address.md#sui_address_to_ascii_string">to_ascii_string</a>()
+    hex::encode(<a href="../sui/address.md#sui_address_to_bytes">to_bytes</a>(a)).<a href="../sui/address.md#sui_address_to_ascii_string">to_ascii_string</a>()
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/sui/address_alias.md
+++ b/crates/sui-framework/docs/sui/address_alias.md
@@ -141,7 +141,7 @@ Internal key used for derivation of AddressAliases object addresses.
 
 
 <pre><code>#[error]
-<b>const</b> <a href="../sui/address_alias.md#sui_address_alias_ENotSystemAddress">ENotSystemAddress</a>: vector&lt;u8&gt; = b"Only the system can <a href="../sui/address_alias.md#sui_address_alias_create">create</a> the alias state <a href="../sui/object.md#sui_object">object</a>.";
+<b>const</b> <a href="../sui/address_alias.md#sui_address_alias_ENotSystemAddress">ENotSystemAddress</a>: vector&lt;u8&gt; = b"Only the system can <a href="../sui/address_alias.md#sui_address_alias_create">create</a> the alias state object.";
 </code></pre>
 
 
@@ -225,10 +225,10 @@ Can only be called by genesis or change_epoch transactions.
 <pre><code><b>fun</b> <a href="../sui/address_alias.md#sui_address_alias_create">create</a>(ctx: &TxContext) {
     <b>assert</b>!(ctx.sender() == @0x0, <a href="../sui/address_alias.md#sui_address_alias_ENotSystemAddress">ENotSystemAddress</a>);
     <b>let</b> self = <a href="../sui/address_alias.md#sui_address_alias_AddressAliasState">AddressAliasState</a> {
-        id: <a href="../sui/object.md#sui_object_address_alias_state">object::address_alias_state</a>(),
+        id: object::address_alias_state(),
         version: <a href="../sui/address_alias.md#sui_address_alias_CURRENT_VERSION">CURRENT_VERSION</a>,
     };
-    <a href="../sui/transfer.md#sui_transfer_share_object">transfer::share_object</a>(self);
+    transfer::share_object(self);
 }
 </code></pre>
 
@@ -257,15 +257,15 @@ object can be used to change the set of allowed aliases after enabling.
 
 <pre><code><b>entry</b> <b>fun</b> <a href="../sui/address_alias.md#sui_address_alias_enable">enable</a>(address_alias_state: &<b>mut</b> <a href="../sui/address_alias.md#sui_address_alias_AddressAliasState">AddressAliasState</a>, ctx: &TxContext) {
     <b>assert</b>!(
-        !<a href="../sui/derived_object.md#sui_derived_object_exists">derived_object::exists</a>(&address_alias_state.id, <a href="../sui/address_alias.md#sui_address_alias_AliasKey">AliasKey</a>(ctx.sender())),
+        !derived_object::exists(&address_alias_state.id, <a href="../sui/address_alias.md#sui_address_alias_AliasKey">AliasKey</a>(ctx.sender())),
         <a href="../sui/address_alias.md#sui_address_alias_EAliasAlreadyExists">EAliasAlreadyExists</a>,
     );
-    <a href="../sui/transfer.md#sui_transfer_party_transfer">transfer::party_transfer</a>(
+    transfer::party_transfer(
         <a href="../sui/address_alias.md#sui_address_alias_AddressAliases">AddressAliases</a> {
-            id: <a href="../sui/derived_object.md#sui_derived_object_claim">derived_object::claim</a>(&<b>mut</b> address_alias_state.id, <a href="../sui/address_alias.md#sui_address_alias_AliasKey">AliasKey</a>(ctx.sender())),
-            aliases: <a href="../sui/vec_set.md#sui_vec_set_singleton">vec_set::singleton</a>(ctx.sender()),
+            id: derived_object::claim(&<b>mut</b> address_alias_state.id, <a href="../sui/address_alias.md#sui_address_alias_AliasKey">AliasKey</a>(ctx.sender())),
+            aliases: vec_set::singleton(ctx.sender()),
         },
-        <a href="../sui/party.md#sui_party_single_owner">party::single_owner</a>(ctx.sender()),
+        party::single_owner(ctx.sender()),
     );
 }
 </code></pre>
@@ -318,7 +318,7 @@ Overwrites the aliases for the sender's address with the given set.
 
 
 <pre><code><b>entry</b> <b>fun</b> <a href="../sui/address_alias.md#sui_address_alias_replace_all">replace_all</a>(aliases: &<b>mut</b> <a href="../sui/address_alias.md#sui_address_alias_AddressAliases">AddressAliases</a>, new_aliases: vector&lt;<b>address</b>&gt;) {
-    <b>let</b> new_aliases = <a href="../sui/vec_set.md#sui_vec_set_from_keys">vec_set::from_keys</a>(new_aliases);
+    <b>let</b> new_aliases = vec_set::from_keys(new_aliases);
     <b>assert</b>!(new_aliases.length() &gt; 0, <a href="../sui/address_alias.md#sui_address_alias_ECannotRemoveLastAlias">ECannotRemoveLastAlias</a>);
     <b>assert</b>!(new_aliases.length() &lt;= <a href="../sui/address_alias.md#sui_address_alias_MAX_ALIASES">MAX_ALIASES</a>, <a href="../sui/address_alias.md#sui_address_alias_ETooManyAliases">ETooManyAliases</a>);
     aliases.aliases = new_aliases;

--- a/crates/sui-framework/docs/sui/authenticator_state.md
+++ b/crates/sui-framework/docs/sui/authenticator_state.md
@@ -447,11 +447,11 @@ Can only be called by genesis or change_epoch transactions.
         active_jwks: vector[],
     };
     <b>let</b> <b>mut</b> self = <a href="../sui/authenticator_state.md#sui_authenticator_state_AuthenticatorState">AuthenticatorState</a> {
-        id: <a href="../sui/object.md#sui_object_authenticator_state">object::authenticator_state</a>(),
+        id: object::authenticator_state(),
         version,
     };
-    <a href="../sui/dynamic_field.md#sui_dynamic_field_add">dynamic_field::add</a>(&<b>mut</b> self.id, version, inner);
-    <a href="../sui/transfer.md#sui_transfer_share_object">transfer::share_object</a>(self);
+    dynamic_field::add(&<b>mut</b> self.id, version, inner);
+    transfer::share_object(self);
 }
 </code></pre>
 
@@ -476,9 +476,9 @@ Can only be called by genesis or change_epoch transactions.
 
 <pre><code><b>fun</b> <a href="../sui/authenticator_state.md#sui_authenticator_state_load_inner_mut">load_inner_mut</a>(self: &<b>mut</b> <a href="../sui/authenticator_state.md#sui_authenticator_state_AuthenticatorState">AuthenticatorState</a>): &<b>mut</b> <a href="../sui/authenticator_state.md#sui_authenticator_state_AuthenticatorStateInner">AuthenticatorStateInner</a> {
     <b>let</b> version = self.version;
-    // replace this with a lazy update function when we add a new version of the inner <a href="../sui/object.md#sui_object">object</a>.
+    // replace this with a lazy update function when we add a new version of the inner object.
     <b>assert</b>!(version == <a href="../sui/authenticator_state.md#sui_authenticator_state_CurrentVersion">CurrentVersion</a>, <a href="../sui/authenticator_state.md#sui_authenticator_state_EWrongInnerVersion">EWrongInnerVersion</a>);
-    <b>let</b> inner: &<b>mut</b> <a href="../sui/authenticator_state.md#sui_authenticator_state_AuthenticatorStateInner">AuthenticatorStateInner</a> = <a href="../sui/dynamic_field.md#sui_dynamic_field_borrow_mut">dynamic_field::borrow_mut</a>(&<b>mut</b> self.id, self.version);
+    <b>let</b> inner: &<b>mut</b> <a href="../sui/authenticator_state.md#sui_authenticator_state_AuthenticatorStateInner">AuthenticatorStateInner</a> = dynamic_field::borrow_mut(&<b>mut</b> self.id, self.version);
     <b>assert</b>!(inner.version == version, <a href="../sui/authenticator_state.md#sui_authenticator_state_EWrongInnerVersion">EWrongInnerVersion</a>);
     inner
 }
@@ -505,9 +505,9 @@ Can only be called by genesis or change_epoch transactions.
 
 <pre><code><b>fun</b> <a href="../sui/authenticator_state.md#sui_authenticator_state_load_inner">load_inner</a>(self: &<a href="../sui/authenticator_state.md#sui_authenticator_state_AuthenticatorState">AuthenticatorState</a>): &<a href="../sui/authenticator_state.md#sui_authenticator_state_AuthenticatorStateInner">AuthenticatorStateInner</a> {
     <b>let</b> version = self.version;
-    // replace this with a lazy update function when we add a new version of the inner <a href="../sui/object.md#sui_object">object</a>.
+    // replace this with a lazy update function when we add a new version of the inner object.
     <b>assert</b>!(version == <a href="../sui/authenticator_state.md#sui_authenticator_state_CurrentVersion">CurrentVersion</a>, <a href="../sui/authenticator_state.md#sui_authenticator_state_EWrongInnerVersion">EWrongInnerVersion</a>);
-    <b>let</b> inner: &<a href="../sui/authenticator_state.md#sui_authenticator_state_AuthenticatorStateInner">AuthenticatorStateInner</a> = <a href="../sui/dynamic_field.md#sui_dynamic_field_borrow">dynamic_field::borrow</a>(&self.id, self.version);
+    <b>let</b> inner: &<a href="../sui/authenticator_state.md#sui_authenticator_state_AuthenticatorStateInner">AuthenticatorStateInner</a> = dynamic_field::borrow(&self.id, self.version);
     <b>assert</b>!(inner.version == version, <a href="../sui/authenticator_state.md#sui_authenticator_state_EWrongInnerVersion">EWrongInnerVersion</a>);
     inner
 }
@@ -645,7 +645,7 @@ indicate that the JWK has been validated in the current epoch and should not be 
         <b>let</b> jwk = &jwks[i];
         <b>if</b> (prev.is_none()) {
             prev.fill(jwk.jwk_id);
-        } <b>else</b> <b>if</b> (<a href="../sui/authenticator_state.md#sui_authenticator_state_jwk_id_equal">jwk_id_equal</a>(prev.<a href="../sui/borrow.md#sui_borrow">borrow</a>(), &jwk.jwk_id)) {
+        } <b>else</b> <b>if</b> (<a href="../sui/authenticator_state.md#sui_authenticator_state_jwk_id_equal">jwk_id_equal</a>(prev.borrow(), &jwk.jwk_id)) {
             // skip duplicate jwks in input
             i = i + 1;
             <b>continue</b>
@@ -700,7 +700,7 @@ indicate that the JWK has been validated in the current epoch and should not be 
             prev_issuer.fill(*cur_iss);
             issuer_max_epochs.push_back(cur.epoch);
         } <b>else</b> {
-            <b>if</b> (cur_iss == prev_issuer.<a href="../sui/borrow.md#sui_borrow">borrow</a>()) {
+            <b>if</b> (cur_iss == prev_issuer.borrow()) {
                 <b>let</b> back = issuer_max_epochs.length() - 1;
                 <b>let</b> prev_max_epoch = &<b>mut</b> issuer_max_epochs[back];
                 *prev_max_epoch = (*prev_max_epoch).max(cur.epoch);
@@ -722,7 +722,7 @@ indicate that the JWK has been validated in the current epoch and should not be 
         <b>let</b> cur_iss = &jwk.jwk_id.iss;
         <b>if</b> (prev_issuer.is_none()) {
             prev_issuer.fill(*cur_iss);
-        } <b>else</b> <b>if</b> (cur_iss != prev_issuer.<a href="../sui/borrow.md#sui_borrow">borrow</a>()) {
+        } <b>else</b> <b>if</b> (cur_iss != prev_issuer.borrow()) {
             *prev_issuer.borrow_mut() = *cur_iss;
             j = j + 1;
         };

--- a/crates/sui-framework/docs/sui/bag.md
+++ b/crates/sui-framework/docs/sui/bag.md
@@ -117,7 +117,7 @@ Creates a new, empty bag
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/bag.md#sui_bag_new">new</a>(ctx: &<b>mut</b> TxContext): <a href="../sui/bag.md#sui_bag_Bag">Bag</a> {
     <a href="../sui/bag.md#sui_bag_Bag">Bag</a> {
-        id: <a href="../sui/object.md#sui_object_new">object::new</a>(ctx),
+        id: object::new(ctx),
         size: 0,
     }
 }
@@ -131,12 +131,12 @@ Creates a new, empty bag
 
 ## Function `add`
 
-Adds a key-value pair to the bag <code><a href="../sui/bag.md#sui_bag">bag</a>: &<b>mut</b> <a href="../sui/bag.md#sui_bag_Bag">Bag</a></code>
+Adds a key-value pair to the bag <code>bag: &<b>mut</b> <a href="../sui/bag.md#sui_bag_Bag">Bag</a></code>
 Aborts with <code><a href="../sui/dynamic_field.md#sui_dynamic_field_EFieldAlreadyExists">sui::dynamic_field::EFieldAlreadyExists</a></code> if the bag already has an entry with
 that key <code>k: K</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/bag.md#sui_bag_add">add</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(<a href="../sui/bag.md#sui_bag">bag</a>: &<b>mut</b> <a href="../sui/bag.md#sui_bag_Bag">sui::bag::Bag</a>, k: K, v: V)
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/bag.md#sui_bag_add">add</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(bag: &<b>mut</b> <a href="../sui/bag.md#sui_bag_Bag">sui::bag::Bag</a>, k: K, v: V)
 </code></pre>
 
 
@@ -145,9 +145,9 @@ that key <code>k: K</code>.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/bag.md#sui_bag_add">add</a>&lt;K: <b>copy</b> + drop + store, V: store&gt;(<a href="../sui/bag.md#sui_bag">bag</a>: &<b>mut</b> <a href="../sui/bag.md#sui_bag_Bag">Bag</a>, k: K, v: V) {
-    field::add(&<b>mut</b> <a href="../sui/bag.md#sui_bag">bag</a>.id, k, v);
-    <a href="../sui/bag.md#sui_bag">bag</a>.size = <a href="../sui/bag.md#sui_bag">bag</a>.size + 1;
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/bag.md#sui_bag_add">add</a>&lt;K: <b>copy</b> + drop + store, V: store&gt;(bag: &<b>mut</b> <a href="../sui/bag.md#sui_bag_Bag">Bag</a>, k: K, v: V) {
+    field::add(&<b>mut</b> bag.id, k, v);
+    bag.size = bag.size + 1;
 }
 </code></pre>
 
@@ -159,14 +159,14 @@ that key <code>k: K</code>.
 
 ## Function `borrow`
 
-Immutable borrows the value associated with the key in the bag <code><a href="../sui/bag.md#sui_bag">bag</a>: &<a href="../sui/bag.md#sui_bag_Bag">Bag</a></code>.
+Immutable borrows the value associated with the key in the bag <code>bag: &<a href="../sui/bag.md#sui_bag_Bag">Bag</a></code>.
 Aborts with <code><a href="../sui/dynamic_field.md#sui_dynamic_field_EFieldDoesNotExist">sui::dynamic_field::EFieldDoesNotExist</a></code> if the bag does not have an entry with
 that key <code>k: K</code>.
 Aborts with <code><a href="../sui/dynamic_field.md#sui_dynamic_field_EFieldTypeMismatch">sui::dynamic_field::EFieldTypeMismatch</a></code> if the bag has an entry for the key, but
 the value does not have the specified type.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/borrow.md#sui_borrow">borrow</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(<a href="../sui/bag.md#sui_bag">bag</a>: &<a href="../sui/bag.md#sui_bag_Bag">sui::bag::Bag</a>, k: K): &V
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/bag.md#sui_bag_borrow">borrow</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(bag: &<a href="../sui/bag.md#sui_bag_Bag">sui::bag::Bag</a>, k: K): &V
 </code></pre>
 
 
@@ -175,8 +175,8 @@ the value does not have the specified type.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/borrow.md#sui_borrow">borrow</a>&lt;K: <b>copy</b> + drop + store, V: store&gt;(<a href="../sui/bag.md#sui_bag">bag</a>: &<a href="../sui/bag.md#sui_bag_Bag">Bag</a>, k: K): &V {
-    field::borrow(&<a href="../sui/bag.md#sui_bag">bag</a>.id, k)
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/bag.md#sui_bag_borrow">borrow</a>&lt;K: <b>copy</b> + drop + store, V: store&gt;(bag: &<a href="../sui/bag.md#sui_bag_Bag">Bag</a>, k: K): &V {
+    field::borrow(&bag.id, k)
 }
 </code></pre>
 
@@ -188,14 +188,14 @@ the value does not have the specified type.
 
 ## Function `borrow_mut`
 
-Mutably borrows the value associated with the key in the bag <code><a href="../sui/bag.md#sui_bag">bag</a>: &<b>mut</b> <a href="../sui/bag.md#sui_bag_Bag">Bag</a></code>.
+Mutably borrows the value associated with the key in the bag <code>bag: &<b>mut</b> <a href="../sui/bag.md#sui_bag_Bag">Bag</a></code>.
 Aborts with <code><a href="../sui/dynamic_field.md#sui_dynamic_field_EFieldDoesNotExist">sui::dynamic_field::EFieldDoesNotExist</a></code> if the bag does not have an entry with
 that key <code>k: K</code>.
 Aborts with <code><a href="../sui/dynamic_field.md#sui_dynamic_field_EFieldTypeMismatch">sui::dynamic_field::EFieldTypeMismatch</a></code> if the bag has an entry for the key, but
 the value does not have the specified type.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/bag.md#sui_bag_borrow_mut">borrow_mut</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(<a href="../sui/bag.md#sui_bag">bag</a>: &<b>mut</b> <a href="../sui/bag.md#sui_bag_Bag">sui::bag::Bag</a>, k: K): &<b>mut</b> V
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/bag.md#sui_bag_borrow_mut">borrow_mut</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(bag: &<b>mut</b> <a href="../sui/bag.md#sui_bag_Bag">sui::bag::Bag</a>, k: K): &<b>mut</b> V
 </code></pre>
 
 
@@ -204,8 +204,8 @@ the value does not have the specified type.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/bag.md#sui_bag_borrow_mut">borrow_mut</a>&lt;K: <b>copy</b> + drop + store, V: store&gt;(<a href="../sui/bag.md#sui_bag">bag</a>: &<b>mut</b> <a href="../sui/bag.md#sui_bag_Bag">Bag</a>, k: K): &<b>mut</b> V {
-    field::borrow_mut(&<b>mut</b> <a href="../sui/bag.md#sui_bag">bag</a>.id, k)
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/bag.md#sui_bag_borrow_mut">borrow_mut</a>&lt;K: <b>copy</b> + drop + store, V: store&gt;(bag: &<b>mut</b> <a href="../sui/bag.md#sui_bag_Bag">Bag</a>, k: K): &<b>mut</b> V {
+    field::borrow_mut(&<b>mut</b> bag.id, k)
 }
 </code></pre>
 
@@ -217,14 +217,14 @@ the value does not have the specified type.
 
 ## Function `remove`
 
-Mutably borrows the key-value pair in the bag <code><a href="../sui/bag.md#sui_bag">bag</a>: &<b>mut</b> <a href="../sui/bag.md#sui_bag_Bag">Bag</a></code> and returns the value.
+Mutably borrows the key-value pair in the bag <code>bag: &<b>mut</b> <a href="../sui/bag.md#sui_bag_Bag">Bag</a></code> and returns the value.
 Aborts with <code><a href="../sui/dynamic_field.md#sui_dynamic_field_EFieldDoesNotExist">sui::dynamic_field::EFieldDoesNotExist</a></code> if the bag does not have an entry with
 that key <code>k: K</code>.
 Aborts with <code><a href="../sui/dynamic_field.md#sui_dynamic_field_EFieldTypeMismatch">sui::dynamic_field::EFieldTypeMismatch</a></code> if the bag has an entry for the key, but
 the value does not have the specified type.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/bag.md#sui_bag_remove">remove</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(<a href="../sui/bag.md#sui_bag">bag</a>: &<b>mut</b> <a href="../sui/bag.md#sui_bag_Bag">sui::bag::Bag</a>, k: K): V
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/bag.md#sui_bag_remove">remove</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(bag: &<b>mut</b> <a href="../sui/bag.md#sui_bag_Bag">sui::bag::Bag</a>, k: K): V
 </code></pre>
 
 
@@ -233,9 +233,9 @@ the value does not have the specified type.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/bag.md#sui_bag_remove">remove</a>&lt;K: <b>copy</b> + drop + store, V: store&gt;(<a href="../sui/bag.md#sui_bag">bag</a>: &<b>mut</b> <a href="../sui/bag.md#sui_bag_Bag">Bag</a>, k: K): V {
-    <b>let</b> v = field::remove(&<b>mut</b> <a href="../sui/bag.md#sui_bag">bag</a>.id, k);
-    <a href="../sui/bag.md#sui_bag">bag</a>.size = <a href="../sui/bag.md#sui_bag">bag</a>.size - 1;
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/bag.md#sui_bag_remove">remove</a>&lt;K: <b>copy</b> + drop + store, V: store&gt;(bag: &<b>mut</b> <a href="../sui/bag.md#sui_bag_Bag">Bag</a>, k: K): V {
+    <b>let</b> v = field::remove(&<b>mut</b> bag.id, k);
+    bag.size = bag.size - 1;
     v
 }
 </code></pre>
@@ -248,10 +248,10 @@ the value does not have the specified type.
 
 ## Function `contains`
 
-Returns true iff there is an value associated with the key <code>k: K</code> in the bag <code><a href="../sui/bag.md#sui_bag">bag</a>: &<a href="../sui/bag.md#sui_bag_Bag">Bag</a></code>
+Returns true iff there is an value associated with the key <code>k: K</code> in the bag <code>bag: &<a href="../sui/bag.md#sui_bag_Bag">Bag</a></code>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/bag.md#sui_bag_contains">contains</a>&lt;K: <b>copy</b>, drop, store&gt;(<a href="../sui/bag.md#sui_bag">bag</a>: &<a href="../sui/bag.md#sui_bag_Bag">sui::bag::Bag</a>, k: K): bool
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/bag.md#sui_bag_contains">contains</a>&lt;K: <b>copy</b>, drop, store&gt;(bag: &<a href="../sui/bag.md#sui_bag_Bag">sui::bag::Bag</a>, k: K): bool
 </code></pre>
 
 
@@ -260,8 +260,8 @@ Returns true iff there is an value associated with the key <code>k: K</code> in 
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/bag.md#sui_bag_contains">contains</a>&lt;K: <b>copy</b> + drop + store&gt;(<a href="../sui/bag.md#sui_bag">bag</a>: &<a href="../sui/bag.md#sui_bag_Bag">Bag</a>, k: K): bool {
-    field::exists_&lt;K&gt;(&<a href="../sui/bag.md#sui_bag">bag</a>.id, k)
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/bag.md#sui_bag_contains">contains</a>&lt;K: <b>copy</b> + drop + store&gt;(bag: &<a href="../sui/bag.md#sui_bag_Bag">Bag</a>, k: K): bool {
+    field::exists_&lt;K&gt;(&bag.id, k)
 }
 </code></pre>
 
@@ -273,11 +273,11 @@ Returns true iff there is an value associated with the key <code>k: K</code> in 
 
 ## Function `contains_with_type`
 
-Returns true iff there is an value associated with the key <code>k: K</code> in the bag <code><a href="../sui/bag.md#sui_bag">bag</a>: &<a href="../sui/bag.md#sui_bag_Bag">Bag</a></code>
+Returns true iff there is an value associated with the key <code>k: K</code> in the bag <code>bag: &<a href="../sui/bag.md#sui_bag_Bag">Bag</a></code>
 with an assigned value of type <code>V</code>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/bag.md#sui_bag_contains_with_type">contains_with_type</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(<a href="../sui/bag.md#sui_bag">bag</a>: &<a href="../sui/bag.md#sui_bag_Bag">sui::bag::Bag</a>, k: K): bool
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/bag.md#sui_bag_contains_with_type">contains_with_type</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(bag: &<a href="../sui/bag.md#sui_bag_Bag">sui::bag::Bag</a>, k: K): bool
 </code></pre>
 
 
@@ -286,8 +286,8 @@ with an assigned value of type <code>V</code>
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/bag.md#sui_bag_contains_with_type">contains_with_type</a>&lt;K: <b>copy</b> + drop + store, V: store&gt;(<a href="../sui/bag.md#sui_bag">bag</a>: &<a href="../sui/bag.md#sui_bag_Bag">Bag</a>, k: K): bool {
-    field::exists_with_type&lt;K, V&gt;(&<a href="../sui/bag.md#sui_bag">bag</a>.id, k)
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/bag.md#sui_bag_contains_with_type">contains_with_type</a>&lt;K: <b>copy</b> + drop + store, V: store&gt;(bag: &<a href="../sui/bag.md#sui_bag_Bag">Bag</a>, k: K): bool {
+    field::exists_with_type&lt;K, V&gt;(&bag.id, k)
 }
 </code></pre>
 
@@ -302,7 +302,7 @@ with an assigned value of type <code>V</code>
 Returns the size of the bag, the number of key-value pairs
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/bag.md#sui_bag_length">length</a>(<a href="../sui/bag.md#sui_bag">bag</a>: &<a href="../sui/bag.md#sui_bag_Bag">sui::bag::Bag</a>): u64
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/bag.md#sui_bag_length">length</a>(bag: &<a href="../sui/bag.md#sui_bag_Bag">sui::bag::Bag</a>): u64
 </code></pre>
 
 
@@ -311,8 +311,8 @@ Returns the size of the bag, the number of key-value pairs
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/bag.md#sui_bag_length">length</a>(<a href="../sui/bag.md#sui_bag">bag</a>: &<a href="../sui/bag.md#sui_bag_Bag">Bag</a>): u64 {
-    <a href="../sui/bag.md#sui_bag">bag</a>.size
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/bag.md#sui_bag_length">length</a>(bag: &<a href="../sui/bag.md#sui_bag_Bag">Bag</a>): u64 {
+    bag.size
 }
 </code></pre>
 
@@ -327,7 +327,7 @@ Returns the size of the bag, the number of key-value pairs
 Returns true iff the bag is empty (if <code><a href="../sui/bag.md#sui_bag_length">length</a></code> returns <code>0</code>)
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/bag.md#sui_bag_is_empty">is_empty</a>(<a href="../sui/bag.md#sui_bag">bag</a>: &<a href="../sui/bag.md#sui_bag_Bag">sui::bag::Bag</a>): bool
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/bag.md#sui_bag_is_empty">is_empty</a>(bag: &<a href="../sui/bag.md#sui_bag_Bag">sui::bag::Bag</a>): bool
 </code></pre>
 
 
@@ -336,8 +336,8 @@ Returns true iff the bag is empty (if <code><a href="../sui/bag.md#sui_bag_lengt
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/bag.md#sui_bag_is_empty">is_empty</a>(<a href="../sui/bag.md#sui_bag">bag</a>: &<a href="../sui/bag.md#sui_bag_Bag">Bag</a>): bool {
-    <a href="../sui/bag.md#sui_bag">bag</a>.size == 0
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/bag.md#sui_bag_is_empty">is_empty</a>(bag: &<a href="../sui/bag.md#sui_bag_Bag">Bag</a>): bool {
+    bag.size == 0
 }
 </code></pre>
 
@@ -353,7 +353,7 @@ Destroys an empty bag
 Aborts with <code><a href="../sui/bag.md#sui_bag_EBagNotEmpty">EBagNotEmpty</a></code> if the bag still contains values
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/bag.md#sui_bag_destroy_empty">destroy_empty</a>(<a href="../sui/bag.md#sui_bag">bag</a>: <a href="../sui/bag.md#sui_bag_Bag">sui::bag::Bag</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/bag.md#sui_bag_destroy_empty">destroy_empty</a>(bag: <a href="../sui/bag.md#sui_bag_Bag">sui::bag::Bag</a>)
 </code></pre>
 
 
@@ -362,8 +362,8 @@ Aborts with <code><a href="../sui/bag.md#sui_bag_EBagNotEmpty">EBagNotEmpty</a><
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/bag.md#sui_bag_destroy_empty">destroy_empty</a>(<a href="../sui/bag.md#sui_bag">bag</a>: <a href="../sui/bag.md#sui_bag_Bag">Bag</a>) {
-    <b>let</b> <a href="../sui/bag.md#sui_bag_Bag">Bag</a> { id, size } = <a href="../sui/bag.md#sui_bag">bag</a>;
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/bag.md#sui_bag_destroy_empty">destroy_empty</a>(bag: <a href="../sui/bag.md#sui_bag_Bag">Bag</a>) {
+    <b>let</b> <a href="../sui/bag.md#sui_bag_Bag">Bag</a> { id, size } = bag;
     <b>assert</b>!(size == 0, <a href="../sui/bag.md#sui_bag_EBagNotEmpty">EBagNotEmpty</a>);
     id.delete()
 }

--- a/crates/sui-framework/docs/sui/balance.md
+++ b/crates/sui-framework/docs/sui/balance.md
@@ -283,7 +283,7 @@ Increase supply by <code><a href="../sui/balance.md#sui_balance_value">value</a>
 Burn a Balance<T> and decrease Supply<T>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/balance.md#sui_balance_decrease_supply">decrease_supply</a>&lt;T&gt;(self: &<b>mut</b> <a href="../sui/balance.md#sui_balance_Supply">sui::balance::Supply</a>&lt;T&gt;, <a href="../sui/balance.md#sui_balance">balance</a>: <a href="../sui/balance.md#sui_balance_Balance">sui::balance::Balance</a>&lt;T&gt;): u64
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/balance.md#sui_balance_decrease_supply">decrease_supply</a>&lt;T&gt;(self: &<b>mut</b> <a href="../sui/balance.md#sui_balance_Supply">sui::balance::Supply</a>&lt;T&gt;, balance: <a href="../sui/balance.md#sui_balance_Balance">sui::balance::Balance</a>&lt;T&gt;): u64
 </code></pre>
 
 
@@ -292,8 +292,8 @@ Burn a Balance<T> and decrease Supply<T>.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/balance.md#sui_balance_decrease_supply">decrease_supply</a>&lt;T&gt;(self: &<b>mut</b> <a href="../sui/balance.md#sui_balance_Supply">Supply</a>&lt;T&gt;, <a href="../sui/balance.md#sui_balance">balance</a>: <a href="../sui/balance.md#sui_balance_Balance">Balance</a>&lt;T&gt;): u64 {
-    <b>let</b> <a href="../sui/balance.md#sui_balance_Balance">Balance</a> { <a href="../sui/balance.md#sui_balance_value">value</a> } = <a href="../sui/balance.md#sui_balance">balance</a>;
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/balance.md#sui_balance_decrease_supply">decrease_supply</a>&lt;T&gt;(self: &<b>mut</b> <a href="../sui/balance.md#sui_balance_Supply">Supply</a>&lt;T&gt;, balance: <a href="../sui/balance.md#sui_balance_Balance">Balance</a>&lt;T&gt;): u64 {
+    <b>let</b> <a href="../sui/balance.md#sui_balance_Balance">Balance</a> { <a href="../sui/balance.md#sui_balance_value">value</a> } = balance;
     <b>assert</b>!(self.<a href="../sui/balance.md#sui_balance_value">value</a> &gt;= <a href="../sui/balance.md#sui_balance_value">value</a>, <a href="../sui/balance.md#sui_balance_EOverflow">EOverflow</a>);
     self.<a href="../sui/balance.md#sui_balance_value">value</a> = self.<a href="../sui/balance.md#sui_balance_value">value</a> - <a href="../sui/balance.md#sui_balance_value">value</a>;
     <a href="../sui/balance.md#sui_balance_value">value</a>
@@ -336,7 +336,7 @@ Create a zero <code><a href="../sui/balance.md#sui_balance_Balance">Balance</a><
 Join two balances together.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/balance.md#sui_balance_join">join</a>&lt;T&gt;(self: &<b>mut</b> <a href="../sui/balance.md#sui_balance_Balance">sui::balance::Balance</a>&lt;T&gt;, <a href="../sui/balance.md#sui_balance">balance</a>: <a href="../sui/balance.md#sui_balance_Balance">sui::balance::Balance</a>&lt;T&gt;): u64
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/balance.md#sui_balance_join">join</a>&lt;T&gt;(self: &<b>mut</b> <a href="../sui/balance.md#sui_balance_Balance">sui::balance::Balance</a>&lt;T&gt;, balance: <a href="../sui/balance.md#sui_balance_Balance">sui::balance::Balance</a>&lt;T&gt;): u64
 </code></pre>
 
 
@@ -345,8 +345,8 @@ Join two balances together.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/balance.md#sui_balance_join">join</a>&lt;T&gt;(self: &<b>mut</b> <a href="../sui/balance.md#sui_balance_Balance">Balance</a>&lt;T&gt;, <a href="../sui/balance.md#sui_balance">balance</a>: <a href="../sui/balance.md#sui_balance_Balance">Balance</a>&lt;T&gt;): u64 {
-    <b>let</b> <a href="../sui/balance.md#sui_balance_Balance">Balance</a> { <a href="../sui/balance.md#sui_balance_value">value</a> } = <a href="../sui/balance.md#sui_balance">balance</a>;
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/balance.md#sui_balance_join">join</a>&lt;T&gt;(self: &<b>mut</b> <a href="../sui/balance.md#sui_balance_Balance">Balance</a>&lt;T&gt;, balance: <a href="../sui/balance.md#sui_balance_Balance">Balance</a>&lt;T&gt;): u64 {
+    <b>let</b> <a href="../sui/balance.md#sui_balance_Balance">Balance</a> { <a href="../sui/balance.md#sui_balance_value">value</a> } = balance;
     self.<a href="../sui/balance.md#sui_balance_value">value</a> = self.<a href="../sui/balance.md#sui_balance_value">value</a> + <a href="../sui/balance.md#sui_balance_value">value</a>;
     self.<a href="../sui/balance.md#sui_balance_value">value</a>
 }
@@ -416,7 +416,7 @@ Withdraw all balance. After this the remaining balance must be 0.
 Destroy a zero <code><a href="../sui/balance.md#sui_balance_Balance">Balance</a></code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/balance.md#sui_balance_destroy_zero">destroy_zero</a>&lt;T&gt;(<a href="../sui/balance.md#sui_balance">balance</a>: <a href="../sui/balance.md#sui_balance_Balance">sui::balance::Balance</a>&lt;T&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/balance.md#sui_balance_destroy_zero">destroy_zero</a>&lt;T&gt;(balance: <a href="../sui/balance.md#sui_balance_Balance">sui::balance::Balance</a>&lt;T&gt;)
 </code></pre>
 
 
@@ -425,9 +425,9 @@ Destroy a zero <code><a href="../sui/balance.md#sui_balance_Balance">Balance</a>
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/balance.md#sui_balance_destroy_zero">destroy_zero</a>&lt;T&gt;(<a href="../sui/balance.md#sui_balance">balance</a>: <a href="../sui/balance.md#sui_balance_Balance">Balance</a>&lt;T&gt;) {
-    <b>assert</b>!(<a href="../sui/balance.md#sui_balance">balance</a>.<a href="../sui/balance.md#sui_balance_value">value</a> == 0, <a href="../sui/balance.md#sui_balance_ENonZero">ENonZero</a>);
-    <b>let</b> <a href="../sui/balance.md#sui_balance_Balance">Balance</a> { <a href="../sui/balance.md#sui_balance_value">value</a>: _ } = <a href="../sui/balance.md#sui_balance">balance</a>;
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/balance.md#sui_balance_destroy_zero">destroy_zero</a>&lt;T&gt;(balance: <a href="../sui/balance.md#sui_balance_Balance">Balance</a>&lt;T&gt;) {
+    <b>assert</b>!(balance.<a href="../sui/balance.md#sui_balance_value">value</a> == 0, <a href="../sui/balance.md#sui_balance_ENonZero">ENonZero</a>);
+    <b>let</b> <a href="../sui/balance.md#sui_balance_Balance">Balance</a> { <a href="../sui/balance.md#sui_balance_value">value</a>: _ } = balance;
 }
 </code></pre>
 
@@ -442,7 +442,7 @@ Destroy a zero <code><a href="../sui/balance.md#sui_balance_Balance">Balance</a>
 Send a <code><a href="../sui/balance.md#sui_balance_Balance">Balance</a></code> to an address's funds accumulator.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/balance.md#sui_balance_send_funds">send_funds</a>&lt;T&gt;(<a href="../sui/balance.md#sui_balance">balance</a>: <a href="../sui/balance.md#sui_balance_Balance">sui::balance::Balance</a>&lt;T&gt;, recipient: <b>address</b>)
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/balance.md#sui_balance_send_funds">send_funds</a>&lt;T&gt;(balance: <a href="../sui/balance.md#sui_balance_Balance">sui::balance::Balance</a>&lt;T&gt;, recipient: <b>address</b>)
 </code></pre>
 
 
@@ -451,8 +451,8 @@ Send a <code><a href="../sui/balance.md#sui_balance_Balance">Balance</a></code> 
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/balance.md#sui_balance_send_funds">send_funds</a>&lt;T&gt;(<a href="../sui/balance.md#sui_balance">balance</a>: <a href="../sui/balance.md#sui_balance_Balance">Balance</a>&lt;T&gt;, recipient: <b>address</b>) {
-    <a href="../sui/funds_accumulator.md#sui_funds_accumulator_add_impl">sui::funds_accumulator::add_impl</a>(<a href="../sui/balance.md#sui_balance">balance</a>, recipient);
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/balance.md#sui_balance_send_funds">send_funds</a>&lt;T&gt;(balance: <a href="../sui/balance.md#sui_balance_Balance">Balance</a>&lt;T&gt;, recipient: <b>address</b>) {
+    <a href="../sui/funds_accumulator.md#sui_funds_accumulator_add_impl">sui::funds_accumulator::add_impl</a>(balance, recipient);
 }
 </code></pre>
 
@@ -548,7 +548,7 @@ the current consensus commit. Can read either address-owned or object-owned bala
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/balance.md#sui_balance_create_supply_internal">create_supply_internal</a>&lt;T&gt;(): <a href="../sui/balance.md#sui_balance_Supply">sui::balance::Supply</a>&lt;T&gt;
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/balance.md#sui_balance_create_supply_internal">create_supply_internal</a>&lt;T&gt;(): <a href="../sui/balance.md#sui_balance_Supply">sui::balance::Supply</a>&lt;T&gt;
 </code></pre>
 
 
@@ -557,7 +557,7 @@ the current consensus commit. Can read either address-owned or object-owned bala
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/balance.md#sui_balance_create_supply_internal">create_supply_internal</a>&lt;T&gt;(): <a href="../sui/balance.md#sui_balance_Supply">Supply</a>&lt;T&gt; {
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/balance.md#sui_balance_create_supply_internal">create_supply_internal</a>&lt;T&gt;(): <a href="../sui/balance.md#sui_balance_Supply">Supply</a>&lt;T&gt; {
     <a href="../sui/balance.md#sui_balance_Supply">Supply</a> { <a href="../sui/balance.md#sui_balance_value">value</a>: 0 }
 }
 </code></pre>
@@ -637,7 +637,7 @@ and nowhere else.
 Destroy a <code><a href="../sui/balance.md#sui_balance_Supply">Supply</a></code> preventing any further minting and burning.
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/balance.md#sui_balance_destroy_supply">destroy_supply</a>&lt;T&gt;(self: <a href="../sui/balance.md#sui_balance_Supply">sui::balance::Supply</a>&lt;T&gt;): u64
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/balance.md#sui_balance_destroy_supply">destroy_supply</a>&lt;T&gt;(self: <a href="../sui/balance.md#sui_balance_Supply">sui::balance::Supply</a>&lt;T&gt;): u64
 </code></pre>
 
 
@@ -646,7 +646,7 @@ Destroy a <code><a href="../sui/balance.md#sui_balance_Supply">Supply</a></code>
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/balance.md#sui_balance_destroy_supply">destroy_supply</a>&lt;T&gt;(self: <a href="../sui/balance.md#sui_balance_Supply">Supply</a>&lt;T&gt;): u64 {
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/balance.md#sui_balance_destroy_supply">destroy_supply</a>&lt;T&gt;(self: <a href="../sui/balance.md#sui_balance_Supply">Supply</a>&lt;T&gt;): u64 {
     <b>let</b> <a href="../sui/balance.md#sui_balance_Supply">Supply</a> { <a href="../sui/balance.md#sui_balance_value">value</a> } = self;
     <a href="../sui/balance.md#sui_balance_value">value</a>
 }

--- a/crates/sui-framework/docs/sui/bcs.md
+++ b/crates/sui-framework/docs/sui/bcs.md
@@ -19,18 +19,18 @@ Usage example:
 /// This function reads u8 and u64 value from the input
 /// and returns the rest of the bytes.
 fun deserialize(bytes: vector<u8>): (u8, u64, vector<u8>) {
-use sui::bcs::{Self, BCS};
+    use sui::bcs::{Self, BCS};
 
-let prepared: BCS = bcs::new(bytes);
-let (u8_value, u64_value) = (
-prepared.peel_u8(),
-prepared.peel_u64()
-);
+    let prepared: BCS = bcs::new(bytes);
+    let (u8_value, u64_value) = (
+        prepared.peel_u8(),
+        prepared.peel_u64()
+    );
 
-// unpack bcs struct
-let leftovers = prepared.into_remainder_bytes();
+    // unpack bcs struct
+    let leftovers = prepared.into_remainder_bytes();
 
-(u8_value, u64_value, leftovers)
+    (u8_value, u64_value, leftovers)
 }
 ```
 
@@ -768,11 +768,11 @@ however the tag can be any <code>u32</code> value.
 Example:
 ```rust
 let my_enum = match (bcs.peel_enum_tag()) {
-0 => Enum::Empty,
-1 => Enum::U8(bcs.peel_u8()),
-2 => Enum::U16(bcs.peel_u16()),
-3 => Enum::Struct { a: bcs.peel_address(), b: bcs.peel_u8() },
-_ => abort,
+   0 => Enum::Empty,
+   1 => Enum::U8(bcs.peel_u8()),
+   2 => Enum::U16(bcs.peel_u16()),
+   3 => Enum::Struct { a: bcs.peel_address(), b: bcs.peel_u8() },
+   _ => abort,
 };
 ```
 

--- a/crates/sui-framework/docs/sui/bcs.md
+++ b/crates/sui-framework/docs/sui/bcs.md
@@ -152,7 +152,7 @@ For when ULEB byte is out of range (or not found).
 ## Function `to_bytes`
 
 Get BCS serialized bytes for any value.
-Re-exports stdlib <code><a href="../sui/bcs.md#sui_bcs_to_bytes">bcs::to_bytes</a></code>.
+Re-exports stdlib <code>bcs::to_bytes</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_to_bytes">to_bytes</a>&lt;T&gt;(value: &T): vector&lt;u8&gt;
@@ -165,7 +165,7 @@ Re-exports stdlib <code><a href="../sui/bcs.md#sui_bcs_to_bytes">bcs::to_bytes</
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_to_bytes">to_bytes</a>&lt;T&gt;(value: &T): vector&lt;u8&gt; {
-    <a href="../sui/bcs.md#sui_bcs_to_bytes">bcs::to_bytes</a>(value)
+    bcs::to_bytes(value)
 }
 </code></pre>
 
@@ -208,7 +208,7 @@ Unpack the <code><a href="../sui/bcs.md#sui_bcs_BCS">BCS</a></code> struct retur
 Useful for passing the data further after partial deserialization.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_into_remainder_bytes">into_remainder_bytes</a>(<a href="../sui/bcs.md#sui_bcs">bcs</a>: <a href="../sui/bcs.md#sui_bcs_BCS">sui::bcs::BCS</a>): vector&lt;u8&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_into_remainder_bytes">into_remainder_bytes</a>(bcs: <a href="../sui/bcs.md#sui_bcs_BCS">sui::bcs::BCS</a>): vector&lt;u8&gt;
 </code></pre>
 
 
@@ -217,8 +217,8 @@ Useful for passing the data further after partial deserialization.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_into_remainder_bytes">into_remainder_bytes</a>(<a href="../sui/bcs.md#sui_bcs">bcs</a>: <a href="../sui/bcs.md#sui_bcs_BCS">BCS</a>): vector&lt;u8&gt; {
-    <b>let</b> <a href="../sui/bcs.md#sui_bcs_BCS">BCS</a> { <b>mut</b> bytes } = <a href="../sui/bcs.md#sui_bcs">bcs</a>;
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_into_remainder_bytes">into_remainder_bytes</a>(bcs: <a href="../sui/bcs.md#sui_bcs_BCS">BCS</a>): vector&lt;u8&gt; {
+    <b>let</b> <a href="../sui/bcs.md#sui_bcs_BCS">BCS</a> { <b>mut</b> bytes } = bcs;
     bytes.reverse();
     bytes
 }
@@ -235,7 +235,7 @@ Useful for passing the data further after partial deserialization.
 Read address from the bcs-serialized bytes.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_address">peel_address</a>(<a href="../sui/bcs.md#sui_bcs">bcs</a>: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">sui::bcs::BCS</a>): <b>address</b>
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_address">peel_address</a>(bcs: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">sui::bcs::BCS</a>): <b>address</b>
 </code></pre>
 
 
@@ -244,9 +244,9 @@ Read address from the bcs-serialized bytes.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_address">peel_address</a>(<a href="../sui/bcs.md#sui_bcs">bcs</a>: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">BCS</a>): <b>address</b> {
-    <b>assert</b>!(<a href="../sui/bcs.md#sui_bcs">bcs</a>.bytes.length() &gt;= <a href="../sui/address.md#sui_address_length">address::length</a>(), <a href="../sui/bcs.md#sui_bcs_EOutOfRange">EOutOfRange</a>);
-    <a href="../sui/address.md#sui_address_from_bytes">address::from_bytes</a>(vector::tabulate!(<a href="../sui/address.md#sui_address_length">address::length</a>(), |_| <a href="../sui/bcs.md#sui_bcs">bcs</a>.bytes.pop_back()))
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_address">peel_address</a>(bcs: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">BCS</a>): <b>address</b> {
+    <b>assert</b>!(bcs.bytes.length() &gt;= address::length(), <a href="../sui/bcs.md#sui_bcs_EOutOfRange">EOutOfRange</a>);
+    address::from_bytes(vector::tabulate!(address::length(), |_| bcs.bytes.pop_back()))
 }
 </code></pre>
 
@@ -261,7 +261,7 @@ Read address from the bcs-serialized bytes.
 Read a <code>bool</code> value from bcs-serialized bytes.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_bool">peel_bool</a>(<a href="../sui/bcs.md#sui_bcs">bcs</a>: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">sui::bcs::BCS</a>): bool
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_bool">peel_bool</a>(bcs: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">sui::bcs::BCS</a>): bool
 </code></pre>
 
 
@@ -270,8 +270,8 @@ Read a <code>bool</code> value from bcs-serialized bytes.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_bool">peel_bool</a>(<a href="../sui/bcs.md#sui_bcs">bcs</a>: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">BCS</a>): bool {
-    <b>let</b> value = <a href="../sui/bcs.md#sui_bcs">bcs</a>.<a href="../sui/bcs.md#sui_bcs_peel_u8">peel_u8</a>();
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_bool">peel_bool</a>(bcs: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">BCS</a>): bool {
+    <b>let</b> value = bcs.<a href="../sui/bcs.md#sui_bcs_peel_u8">peel_u8</a>();
     <b>if</b> (value == 0) <b>false</b>
     <b>else</b> <b>if</b> (value == 1) <b>true</b>
     <b>else</b> <b>abort</b> <a href="../sui/bcs.md#sui_bcs_ENotBool">ENotBool</a>
@@ -289,7 +289,7 @@ Read a <code>bool</code> value from bcs-serialized bytes.
 Read <code>u8</code> value from bcs-serialized bytes.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_u8">peel_u8</a>(<a href="../sui/bcs.md#sui_bcs">bcs</a>: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">sui::bcs::BCS</a>): u8
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_u8">peel_u8</a>(bcs: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">sui::bcs::BCS</a>): u8
 </code></pre>
 
 
@@ -298,9 +298,9 @@ Read <code>u8</code> value from bcs-serialized bytes.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_u8">peel_u8</a>(<a href="../sui/bcs.md#sui_bcs">bcs</a>: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">BCS</a>): u8 {
-    <b>assert</b>!(<a href="../sui/bcs.md#sui_bcs">bcs</a>.bytes.length() &gt;= 1, <a href="../sui/bcs.md#sui_bcs_EOutOfRange">EOutOfRange</a>);
-    <a href="../sui/bcs.md#sui_bcs">bcs</a>.bytes.pop_back()
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_u8">peel_u8</a>(bcs: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">BCS</a>): u8 {
+    <b>assert</b>!(bcs.bytes.length() &gt;= 1, <a href="../sui/bcs.md#sui_bcs_EOutOfRange">EOutOfRange</a>);
+    bcs.bytes.pop_back()
 }
 </code></pre>
 
@@ -314,7 +314,7 @@ Read <code>u8</code> value from bcs-serialized bytes.
 
 
 
-<pre><code><b>macro</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_num">peel_num</a>&lt;$I, $T&gt;($<a href="../sui/bcs.md#sui_bcs">bcs</a>: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">sui::bcs::BCS</a>, $len: u64, $bits: $I): $T
+<pre><code><b>macro</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_num">peel_num</a>&lt;$I, $T&gt;($bcs: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">sui::bcs::BCS</a>, $len: u64, $bits: $I): $T
 </code></pre>
 
 
@@ -323,14 +323,14 @@ Read <code>u8</code> value from bcs-serialized bytes.
 <summary>Implementation</summary>
 
 
-<pre><code><b>macro</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_num">peel_num</a>&lt;$I, $T&gt;($<a href="../sui/bcs.md#sui_bcs">bcs</a>: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">BCS</a>, $len: u64, $bits: $I): $T {
-    <b>let</b> <a href="../sui/bcs.md#sui_bcs">bcs</a> = $<a href="../sui/bcs.md#sui_bcs">bcs</a>;
-    <b>assert</b>!(<a href="../sui/bcs.md#sui_bcs">bcs</a>.bytes.length() &gt;= $len, <a href="../sui/bcs.md#sui_bcs_EOutOfRange">EOutOfRange</a>);
+<pre><code><b>macro</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_num">peel_num</a>&lt;$I, $T&gt;($bcs: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">BCS</a>, $len: u64, $bits: $I): $T {
+    <b>let</b> bcs = $bcs;
+    <b>assert</b>!(bcs.bytes.length() &gt;= $len, <a href="../sui/bcs.md#sui_bcs_EOutOfRange">EOutOfRange</a>);
     <b>let</b> <b>mut</b> value: $T = 0;
     <b>let</b> <b>mut</b> i: $I = 0;
     <b>let</b> bits = $bits;
     <b>while</b> (i &lt; bits) {
-        <b>let</b> byte = <a href="../sui/bcs.md#sui_bcs">bcs</a>.bytes.pop_back() <b>as</b> $T;
+        <b>let</b> byte = bcs.bytes.pop_back() <b>as</b> $T;
         value = value + (byte &lt;&lt; (i <b>as</b> u8));
         i = i + 8;
     };
@@ -349,7 +349,7 @@ Read <code>u8</code> value from bcs-serialized bytes.
 Read <code>u16</code> value from bcs-serialized bytes.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_u16">peel_u16</a>(<a href="../sui/bcs.md#sui_bcs">bcs</a>: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">sui::bcs::BCS</a>): u16
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_u16">peel_u16</a>(bcs: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">sui::bcs::BCS</a>): u16
 </code></pre>
 
 
@@ -358,8 +358,8 @@ Read <code>u16</code> value from bcs-serialized bytes.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_u16">peel_u16</a>(<a href="../sui/bcs.md#sui_bcs">bcs</a>: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">BCS</a>): u16 {
-    <a href="../sui/bcs.md#sui_bcs">bcs</a>.<a href="../sui/bcs.md#sui_bcs_peel_num">peel_num</a>!(2, 16u8)
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_u16">peel_u16</a>(bcs: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">BCS</a>): u16 {
+    bcs.<a href="../sui/bcs.md#sui_bcs_peel_num">peel_num</a>!(2, 16u8)
 }
 </code></pre>
 
@@ -374,7 +374,7 @@ Read <code>u16</code> value from bcs-serialized bytes.
 Read <code>u32</code> value from bcs-serialized bytes.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_u32">peel_u32</a>(<a href="../sui/bcs.md#sui_bcs">bcs</a>: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">sui::bcs::BCS</a>): u32
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_u32">peel_u32</a>(bcs: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">sui::bcs::BCS</a>): u32
 </code></pre>
 
 
@@ -383,8 +383,8 @@ Read <code>u32</code> value from bcs-serialized bytes.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_u32">peel_u32</a>(<a href="../sui/bcs.md#sui_bcs">bcs</a>: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">BCS</a>): u32 {
-    <a href="../sui/bcs.md#sui_bcs">bcs</a>.<a href="../sui/bcs.md#sui_bcs_peel_num">peel_num</a>!(4, 32u8)
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_u32">peel_u32</a>(bcs: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">BCS</a>): u32 {
+    bcs.<a href="../sui/bcs.md#sui_bcs_peel_num">peel_num</a>!(4, 32u8)
 }
 </code></pre>
 
@@ -399,7 +399,7 @@ Read <code>u32</code> value from bcs-serialized bytes.
 Read <code>u64</code> value from bcs-serialized bytes.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_u64">peel_u64</a>(<a href="../sui/bcs.md#sui_bcs">bcs</a>: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">sui::bcs::BCS</a>): u64
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_u64">peel_u64</a>(bcs: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">sui::bcs::BCS</a>): u64
 </code></pre>
 
 
@@ -408,8 +408,8 @@ Read <code>u64</code> value from bcs-serialized bytes.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_u64">peel_u64</a>(<a href="../sui/bcs.md#sui_bcs">bcs</a>: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">BCS</a>): u64 {
-    <a href="../sui/bcs.md#sui_bcs">bcs</a>.<a href="../sui/bcs.md#sui_bcs_peel_num">peel_num</a>!(8, 64u8)
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_u64">peel_u64</a>(bcs: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">BCS</a>): u64 {
+    bcs.<a href="../sui/bcs.md#sui_bcs_peel_num">peel_num</a>!(8, 64u8)
 }
 </code></pre>
 
@@ -424,7 +424,7 @@ Read <code>u64</code> value from bcs-serialized bytes.
 Read <code>u128</code> value from bcs-serialized bytes.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_u128">peel_u128</a>(<a href="../sui/bcs.md#sui_bcs">bcs</a>: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">sui::bcs::BCS</a>): u128
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_u128">peel_u128</a>(bcs: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">sui::bcs::BCS</a>): u128
 </code></pre>
 
 
@@ -433,8 +433,8 @@ Read <code>u128</code> value from bcs-serialized bytes.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_u128">peel_u128</a>(<a href="../sui/bcs.md#sui_bcs">bcs</a>: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">BCS</a>): u128 {
-    <a href="../sui/bcs.md#sui_bcs">bcs</a>.<a href="../sui/bcs.md#sui_bcs_peel_num">peel_num</a>!(16, 128u8)
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_u128">peel_u128</a>(bcs: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">BCS</a>): u128 {
+    bcs.<a href="../sui/bcs.md#sui_bcs_peel_num">peel_num</a>!(16, 128u8)
 }
 </code></pre>
 
@@ -449,7 +449,7 @@ Read <code>u128</code> value from bcs-serialized bytes.
 Read <code>u256</code> value from bcs-serialized bytes.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_u256">peel_u256</a>(<a href="../sui/bcs.md#sui_bcs">bcs</a>: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">sui::bcs::BCS</a>): u256
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_u256">peel_u256</a>(bcs: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">sui::bcs::BCS</a>): u256
 </code></pre>
 
 
@@ -458,8 +458,8 @@ Read <code>u256</code> value from bcs-serialized bytes.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_u256">peel_u256</a>(<a href="../sui/bcs.md#sui_bcs">bcs</a>: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">BCS</a>): u256 {
-    <a href="../sui/bcs.md#sui_bcs">bcs</a>.<a href="../sui/bcs.md#sui_bcs_peel_num">peel_num</a>!(32, 256u16)
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_u256">peel_u256</a>(bcs: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">BCS</a>): u256 {
+    bcs.<a href="../sui/bcs.md#sui_bcs_peel_num">peel_num</a>!(32, 256u16)
 }
 </code></pre>
 
@@ -478,7 +478,7 @@ In BCS <code>vector</code> length is implemented with ULEB128;
 See more here: https://en.wikipedia.org/wiki/LEB128
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_vec_length">peel_vec_length</a>(<a href="../sui/bcs.md#sui_bcs">bcs</a>: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">sui::bcs::BCS</a>): u64
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_vec_length">peel_vec_length</a>(bcs: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">sui::bcs::BCS</a>): u64
 </code></pre>
 
 
@@ -487,11 +487,11 @@ See more here: https://en.wikipedia.org/wiki/LEB128
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_vec_length">peel_vec_length</a>(<a href="../sui/bcs.md#sui_bcs">bcs</a>: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">BCS</a>): u64 {
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_vec_length">peel_vec_length</a>(bcs: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">BCS</a>): u64 {
     <b>let</b> (<b>mut</b> total, <b>mut</b> shift, <b>mut</b> len) = (0u64, 0u8, 0u64);
     <b>loop</b> {
         <b>assert</b>!(len &lt;= 4, <a href="../sui/bcs.md#sui_bcs_ELenOutOfRange">ELenOutOfRange</a>);
-        <b>let</b> byte = <a href="../sui/bcs.md#sui_bcs">bcs</a>.bytes.pop_back() <b>as</b> u64;
+        <b>let</b> byte = bcs.bytes.pop_back() <b>as</b> u64;
         len = len + 1;
         total = total | ((byte & 0x7f) &lt;&lt; shift);
         <b>if</b> ((byte & 0x80) == 0) <b>break</b>;
@@ -513,7 +513,7 @@ Peel <code>vector&lt;$T&gt;</code> from serialized bytes, where <code>$peel: |&<
 functionality of peeling each value.
 
 
-<pre><code><b>public</b> <b>macro</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_vec">peel_vec</a>&lt;$T&gt;($<a href="../sui/bcs.md#sui_bcs">bcs</a>: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">sui::bcs::BCS</a>, $peel: |&<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">sui::bcs::BCS</a>| -&gt; $T): vector&lt;$T&gt;
+<pre><code><b>public</b> <b>macro</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_vec">peel_vec</a>&lt;$T&gt;($bcs: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">sui::bcs::BCS</a>, $peel: |&<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">sui::bcs::BCS</a>| -&gt; $T): vector&lt;$T&gt;
 </code></pre>
 
 
@@ -522,9 +522,9 @@ functionality of peeling each value.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>macro</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_vec">peel_vec</a>&lt;$T&gt;($<a href="../sui/bcs.md#sui_bcs">bcs</a>: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">BCS</a>, $peel: |&<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">BCS</a>| -&gt; $T): vector&lt;$T&gt; {
-    <b>let</b> <a href="../sui/bcs.md#sui_bcs">bcs</a> = $<a href="../sui/bcs.md#sui_bcs">bcs</a>;
-    vector::tabulate!(<a href="../sui/bcs.md#sui_bcs">bcs</a>.<a href="../sui/bcs.md#sui_bcs_peel_vec_length">peel_vec_length</a>(), |_| $peel(<a href="../sui/bcs.md#sui_bcs">bcs</a>))
+<pre><code><b>public</b> <b>macro</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_vec">peel_vec</a>&lt;$T&gt;($bcs: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">BCS</a>, $peel: |&<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">BCS</a>| -&gt; $T): vector&lt;$T&gt; {
+    <b>let</b> bcs = $bcs;
+    vector::tabulate!(bcs.<a href="../sui/bcs.md#sui_bcs_peel_vec_length">peel_vec_length</a>(), |_| $peel(bcs))
 }
 </code></pre>
 
@@ -539,7 +539,7 @@ functionality of peeling each value.
 Peel a vector of <code><b>address</b></code> from serialized bytes.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_vec_address">peel_vec_address</a>(<a href="../sui/bcs.md#sui_bcs">bcs</a>: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">sui::bcs::BCS</a>): vector&lt;<b>address</b>&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_vec_address">peel_vec_address</a>(bcs: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">sui::bcs::BCS</a>): vector&lt;<b>address</b>&gt;
 </code></pre>
 
 
@@ -548,8 +548,8 @@ Peel a vector of <code><b>address</b></code> from serialized bytes.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_vec_address">peel_vec_address</a>(<a href="../sui/bcs.md#sui_bcs">bcs</a>: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">BCS</a>): vector&lt;<b>address</b>&gt; {
-    <a href="../sui/bcs.md#sui_bcs">bcs</a>.<a href="../sui/bcs.md#sui_bcs_peel_vec">peel_vec</a>!(|<a href="../sui/bcs.md#sui_bcs">bcs</a>| <a href="../sui/bcs.md#sui_bcs">bcs</a>.<a href="../sui/bcs.md#sui_bcs_peel_address">peel_address</a>())
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_vec_address">peel_vec_address</a>(bcs: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">BCS</a>): vector&lt;<b>address</b>&gt; {
+    bcs.<a href="../sui/bcs.md#sui_bcs_peel_vec">peel_vec</a>!(|bcs| bcs.<a href="../sui/bcs.md#sui_bcs_peel_address">peel_address</a>())
 }
 </code></pre>
 
@@ -564,7 +564,7 @@ Peel a vector of <code><b>address</b></code> from serialized bytes.
 Peel a vector of <code><b>address</b></code> from serialized bytes.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_vec_bool">peel_vec_bool</a>(<a href="../sui/bcs.md#sui_bcs">bcs</a>: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">sui::bcs::BCS</a>): vector&lt;bool&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_vec_bool">peel_vec_bool</a>(bcs: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">sui::bcs::BCS</a>): vector&lt;bool&gt;
 </code></pre>
 
 
@@ -573,8 +573,8 @@ Peel a vector of <code><b>address</b></code> from serialized bytes.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_vec_bool">peel_vec_bool</a>(<a href="../sui/bcs.md#sui_bcs">bcs</a>: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">BCS</a>): vector&lt;bool&gt; {
-    <a href="../sui/bcs.md#sui_bcs">bcs</a>.<a href="../sui/bcs.md#sui_bcs_peel_vec">peel_vec</a>!(|<a href="../sui/bcs.md#sui_bcs">bcs</a>| <a href="../sui/bcs.md#sui_bcs">bcs</a>.<a href="../sui/bcs.md#sui_bcs_peel_bool">peel_bool</a>())
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_vec_bool">peel_vec_bool</a>(bcs: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">BCS</a>): vector&lt;bool&gt; {
+    bcs.<a href="../sui/bcs.md#sui_bcs_peel_vec">peel_vec</a>!(|bcs| bcs.<a href="../sui/bcs.md#sui_bcs_peel_bool">peel_bool</a>())
 }
 </code></pre>
 
@@ -589,7 +589,7 @@ Peel a vector of <code><b>address</b></code> from serialized bytes.
 Peel a vector of <code>u8</code> (eg string) from serialized bytes.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_vec_u8">peel_vec_u8</a>(<a href="../sui/bcs.md#sui_bcs">bcs</a>: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">sui::bcs::BCS</a>): vector&lt;u8&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_vec_u8">peel_vec_u8</a>(bcs: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">sui::bcs::BCS</a>): vector&lt;u8&gt;
 </code></pre>
 
 
@@ -598,8 +598,8 @@ Peel a vector of <code>u8</code> (eg string) from serialized bytes.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_vec_u8">peel_vec_u8</a>(<a href="../sui/bcs.md#sui_bcs">bcs</a>: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">BCS</a>): vector&lt;u8&gt; {
-    <a href="../sui/bcs.md#sui_bcs">bcs</a>.<a href="../sui/bcs.md#sui_bcs_peel_vec">peel_vec</a>!(|<a href="../sui/bcs.md#sui_bcs">bcs</a>| <a href="../sui/bcs.md#sui_bcs">bcs</a>.<a href="../sui/bcs.md#sui_bcs_peel_u8">peel_u8</a>())
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_vec_u8">peel_vec_u8</a>(bcs: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">BCS</a>): vector&lt;u8&gt; {
+    bcs.<a href="../sui/bcs.md#sui_bcs_peel_vec">peel_vec</a>!(|bcs| bcs.<a href="../sui/bcs.md#sui_bcs_peel_u8">peel_u8</a>())
 }
 </code></pre>
 
@@ -614,7 +614,7 @@ Peel a vector of <code>u8</code> (eg string) from serialized bytes.
 Peel a <code>vector&lt;vector&lt;u8&gt;&gt;</code> (eg vec of string) from serialized bytes.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_vec_vec_u8">peel_vec_vec_u8</a>(<a href="../sui/bcs.md#sui_bcs">bcs</a>: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">sui::bcs::BCS</a>): vector&lt;vector&lt;u8&gt;&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_vec_vec_u8">peel_vec_vec_u8</a>(bcs: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">sui::bcs::BCS</a>): vector&lt;vector&lt;u8&gt;&gt;
 </code></pre>
 
 
@@ -623,8 +623,8 @@ Peel a <code>vector&lt;vector&lt;u8&gt;&gt;</code> (eg vec of string) from seria
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_vec_vec_u8">peel_vec_vec_u8</a>(<a href="../sui/bcs.md#sui_bcs">bcs</a>: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">BCS</a>): vector&lt;vector&lt;u8&gt;&gt; {
-    <a href="../sui/bcs.md#sui_bcs">bcs</a>.<a href="../sui/bcs.md#sui_bcs_peel_vec">peel_vec</a>!(|<a href="../sui/bcs.md#sui_bcs">bcs</a>| <a href="../sui/bcs.md#sui_bcs">bcs</a>.<a href="../sui/bcs.md#sui_bcs_peel_vec_u8">peel_vec_u8</a>())
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_vec_vec_u8">peel_vec_vec_u8</a>(bcs: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">BCS</a>): vector&lt;vector&lt;u8&gt;&gt; {
+    bcs.<a href="../sui/bcs.md#sui_bcs_peel_vec">peel_vec</a>!(|bcs| bcs.<a href="../sui/bcs.md#sui_bcs_peel_vec_u8">peel_vec_u8</a>())
 }
 </code></pre>
 
@@ -639,7 +639,7 @@ Peel a <code>vector&lt;vector&lt;u8&gt;&gt;</code> (eg vec of string) from seria
 Peel a vector of <code>u16</code> from serialized bytes.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_vec_u16">peel_vec_u16</a>(<a href="../sui/bcs.md#sui_bcs">bcs</a>: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">sui::bcs::BCS</a>): vector&lt;u16&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_vec_u16">peel_vec_u16</a>(bcs: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">sui::bcs::BCS</a>): vector&lt;u16&gt;
 </code></pre>
 
 
@@ -648,8 +648,8 @@ Peel a vector of <code>u16</code> from serialized bytes.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_vec_u16">peel_vec_u16</a>(<a href="../sui/bcs.md#sui_bcs">bcs</a>: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">BCS</a>): vector&lt;u16&gt; {
-    <a href="../sui/bcs.md#sui_bcs">bcs</a>.<a href="../sui/bcs.md#sui_bcs_peel_vec">peel_vec</a>!(|<a href="../sui/bcs.md#sui_bcs">bcs</a>| <a href="../sui/bcs.md#sui_bcs">bcs</a>.<a href="../sui/bcs.md#sui_bcs_peel_u16">peel_u16</a>())
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_vec_u16">peel_vec_u16</a>(bcs: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">BCS</a>): vector&lt;u16&gt; {
+    bcs.<a href="../sui/bcs.md#sui_bcs_peel_vec">peel_vec</a>!(|bcs| bcs.<a href="../sui/bcs.md#sui_bcs_peel_u16">peel_u16</a>())
 }
 </code></pre>
 
@@ -664,7 +664,7 @@ Peel a vector of <code>u16</code> from serialized bytes.
 Peel a vector of <code>u32</code> from serialized bytes.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_vec_u32">peel_vec_u32</a>(<a href="../sui/bcs.md#sui_bcs">bcs</a>: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">sui::bcs::BCS</a>): vector&lt;u32&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_vec_u32">peel_vec_u32</a>(bcs: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">sui::bcs::BCS</a>): vector&lt;u32&gt;
 </code></pre>
 
 
@@ -673,8 +673,8 @@ Peel a vector of <code>u32</code> from serialized bytes.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_vec_u32">peel_vec_u32</a>(<a href="../sui/bcs.md#sui_bcs">bcs</a>: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">BCS</a>): vector&lt;u32&gt; {
-    <a href="../sui/bcs.md#sui_bcs">bcs</a>.<a href="../sui/bcs.md#sui_bcs_peel_vec">peel_vec</a>!(|<a href="../sui/bcs.md#sui_bcs">bcs</a>| <a href="../sui/bcs.md#sui_bcs">bcs</a>.<a href="../sui/bcs.md#sui_bcs_peel_u32">peel_u32</a>())
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_vec_u32">peel_vec_u32</a>(bcs: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">BCS</a>): vector&lt;u32&gt; {
+    bcs.<a href="../sui/bcs.md#sui_bcs_peel_vec">peel_vec</a>!(|bcs| bcs.<a href="../sui/bcs.md#sui_bcs_peel_u32">peel_u32</a>())
 }
 </code></pre>
 
@@ -689,7 +689,7 @@ Peel a vector of <code>u32</code> from serialized bytes.
 Peel a vector of <code>u64</code> from serialized bytes.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_vec_u64">peel_vec_u64</a>(<a href="../sui/bcs.md#sui_bcs">bcs</a>: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">sui::bcs::BCS</a>): vector&lt;u64&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_vec_u64">peel_vec_u64</a>(bcs: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">sui::bcs::BCS</a>): vector&lt;u64&gt;
 </code></pre>
 
 
@@ -698,8 +698,8 @@ Peel a vector of <code>u64</code> from serialized bytes.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_vec_u64">peel_vec_u64</a>(<a href="../sui/bcs.md#sui_bcs">bcs</a>: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">BCS</a>): vector&lt;u64&gt; {
-    <a href="../sui/bcs.md#sui_bcs">bcs</a>.<a href="../sui/bcs.md#sui_bcs_peel_vec">peel_vec</a>!(|<a href="../sui/bcs.md#sui_bcs">bcs</a>| <a href="../sui/bcs.md#sui_bcs">bcs</a>.<a href="../sui/bcs.md#sui_bcs_peel_u64">peel_u64</a>())
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_vec_u64">peel_vec_u64</a>(bcs: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">BCS</a>): vector&lt;u64&gt; {
+    bcs.<a href="../sui/bcs.md#sui_bcs_peel_vec">peel_vec</a>!(|bcs| bcs.<a href="../sui/bcs.md#sui_bcs_peel_u64">peel_u64</a>())
 }
 </code></pre>
 
@@ -714,7 +714,7 @@ Peel a vector of <code>u64</code> from serialized bytes.
 Peel a vector of <code>u128</code> from serialized bytes.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_vec_u128">peel_vec_u128</a>(<a href="../sui/bcs.md#sui_bcs">bcs</a>: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">sui::bcs::BCS</a>): vector&lt;u128&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_vec_u128">peel_vec_u128</a>(bcs: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">sui::bcs::BCS</a>): vector&lt;u128&gt;
 </code></pre>
 
 
@@ -723,8 +723,8 @@ Peel a vector of <code>u128</code> from serialized bytes.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_vec_u128">peel_vec_u128</a>(<a href="../sui/bcs.md#sui_bcs">bcs</a>: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">BCS</a>): vector&lt;u128&gt; {
-    <a href="../sui/bcs.md#sui_bcs">bcs</a>.<a href="../sui/bcs.md#sui_bcs_peel_vec">peel_vec</a>!(|<a href="../sui/bcs.md#sui_bcs">bcs</a>| <a href="../sui/bcs.md#sui_bcs">bcs</a>.<a href="../sui/bcs.md#sui_bcs_peel_u128">peel_u128</a>())
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_vec_u128">peel_vec_u128</a>(bcs: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">BCS</a>): vector&lt;u128&gt; {
+    bcs.<a href="../sui/bcs.md#sui_bcs_peel_vec">peel_vec</a>!(|bcs| bcs.<a href="../sui/bcs.md#sui_bcs_peel_u128">peel_u128</a>())
 }
 </code></pre>
 
@@ -739,7 +739,7 @@ Peel a vector of <code>u128</code> from serialized bytes.
 Peel a vector of <code>u256</code> from serialized bytes.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_vec_u256">peel_vec_u256</a>(<a href="../sui/bcs.md#sui_bcs">bcs</a>: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">sui::bcs::BCS</a>): vector&lt;u256&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_vec_u256">peel_vec_u256</a>(bcs: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">sui::bcs::BCS</a>): vector&lt;u256&gt;
 </code></pre>
 
 
@@ -748,8 +748,8 @@ Peel a vector of <code>u256</code> from serialized bytes.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_vec_u256">peel_vec_u256</a>(<a href="../sui/bcs.md#sui_bcs">bcs</a>: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">BCS</a>): vector&lt;u256&gt; {
-    <a href="../sui/bcs.md#sui_bcs">bcs</a>.<a href="../sui/bcs.md#sui_bcs_peel_vec">peel_vec</a>!(|<a href="../sui/bcs.md#sui_bcs">bcs</a>| <a href="../sui/bcs.md#sui_bcs">bcs</a>.<a href="../sui/bcs.md#sui_bcs_peel_u256">peel_u256</a>())
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_vec_u256">peel_vec_u256</a>(bcs: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">BCS</a>): vector&lt;u256&gt; {
+    bcs.<a href="../sui/bcs.md#sui_bcs_peel_vec">peel_vec</a>!(|bcs| bcs.<a href="../sui/bcs.md#sui_bcs_peel_u256">peel_u256</a>())
 }
 </code></pre>
 
@@ -777,7 +777,7 @@ let my_enum = match (bcs.peel_enum_tag()) {
 ```
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_enum_tag">peel_enum_tag</a>(<a href="../sui/bcs.md#sui_bcs">bcs</a>: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">sui::bcs::BCS</a>): u32
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_enum_tag">peel_enum_tag</a>(bcs: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">sui::bcs::BCS</a>): u32
 </code></pre>
 
 
@@ -786,8 +786,8 @@ let my_enum = match (bcs.peel_enum_tag()) {
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_enum_tag">peel_enum_tag</a>(<a href="../sui/bcs.md#sui_bcs">bcs</a>: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">BCS</a>): u32 {
-    <b>let</b> tag = <a href="../sui/bcs.md#sui_bcs">bcs</a>.<a href="../sui/bcs.md#sui_bcs_peel_vec_length">peel_vec_length</a>();
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_enum_tag">peel_enum_tag</a>(bcs: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">BCS</a>): u32 {
+    <b>let</b> tag = bcs.<a href="../sui/bcs.md#sui_bcs_peel_vec_length">peel_vec_length</a>();
     <b>assert</b>!(tag &lt;= <a href="../std/u32.md#std_u32_max_value">std::u32::max_value</a>!() <b>as</b> u64, <a href="../sui/bcs.md#sui_bcs_EOutOfRange">EOutOfRange</a>);
     tag <b>as</b> u32
 }
@@ -805,7 +805,7 @@ Peel <code>Option&lt;$T&gt;</code> from serialized bytes, where <code>$peel: |&<
 functionality of peeling the inner value.
 
 
-<pre><code><b>public</b> <b>macro</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_option">peel_option</a>&lt;$T&gt;($<a href="../sui/bcs.md#sui_bcs">bcs</a>: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">sui::bcs::BCS</a>, $peel: |&<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">sui::bcs::BCS</a>| -&gt; $T): <a href="../std/option.md#std_option_Option">std::option::Option</a>&lt;$T&gt;
+<pre><code><b>public</b> <b>macro</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_option">peel_option</a>&lt;$T&gt;($bcs: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">sui::bcs::BCS</a>, $peel: |&<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">sui::bcs::BCS</a>| -&gt; $T): <a href="../std/option.md#std_option_Option">std::option::Option</a>&lt;$T&gt;
 </code></pre>
 
 
@@ -814,9 +814,9 @@ functionality of peeling the inner value.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>macro</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_option">peel_option</a>&lt;$T&gt;($<a href="../sui/bcs.md#sui_bcs">bcs</a>: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">BCS</a>, $peel: |&<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">BCS</a>| -&gt; $T): Option&lt;$T&gt; {
-    <b>let</b> <a href="../sui/bcs.md#sui_bcs">bcs</a> = $<a href="../sui/bcs.md#sui_bcs">bcs</a>;
-    <b>if</b> (<a href="../sui/bcs.md#sui_bcs">bcs</a>.<a href="../sui/bcs.md#sui_bcs_peel_bool">peel_bool</a>()) option::some($peel(<a href="../sui/bcs.md#sui_bcs">bcs</a>)) <b>else</b> option::none()
+<pre><code><b>public</b> <b>macro</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_option">peel_option</a>&lt;$T&gt;($bcs: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">BCS</a>, $peel: |&<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">BCS</a>| -&gt; $T): Option&lt;$T&gt; {
+    <b>let</b> bcs = $bcs;
+    <b>if</b> (bcs.<a href="../sui/bcs.md#sui_bcs_peel_bool">peel_bool</a>()) option::some($peel(bcs)) <b>else</b> option::none()
 }
 </code></pre>
 
@@ -831,7 +831,7 @@ functionality of peeling the inner value.
 Peel <code>Option&lt;<b>address</b>&gt;</code> from serialized bytes.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_option_address">peel_option_address</a>(<a href="../sui/bcs.md#sui_bcs">bcs</a>: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">sui::bcs::BCS</a>): <a href="../std/option.md#std_option_Option">std::option::Option</a>&lt;<b>address</b>&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_option_address">peel_option_address</a>(bcs: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">sui::bcs::BCS</a>): <a href="../std/option.md#std_option_Option">std::option::Option</a>&lt;<b>address</b>&gt;
 </code></pre>
 
 
@@ -840,8 +840,8 @@ Peel <code>Option&lt;<b>address</b>&gt;</code> from serialized bytes.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_option_address">peel_option_address</a>(<a href="../sui/bcs.md#sui_bcs">bcs</a>: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">BCS</a>): Option&lt;<b>address</b>&gt; {
-    <a href="../sui/bcs.md#sui_bcs">bcs</a>.<a href="../sui/bcs.md#sui_bcs_peel_option">peel_option</a>!(|<a href="../sui/bcs.md#sui_bcs">bcs</a>| <a href="../sui/bcs.md#sui_bcs">bcs</a>.<a href="../sui/bcs.md#sui_bcs_peel_address">peel_address</a>())
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_option_address">peel_option_address</a>(bcs: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">BCS</a>): Option&lt;<b>address</b>&gt; {
+    bcs.<a href="../sui/bcs.md#sui_bcs_peel_option">peel_option</a>!(|bcs| bcs.<a href="../sui/bcs.md#sui_bcs_peel_address">peel_address</a>())
 }
 </code></pre>
 
@@ -856,7 +856,7 @@ Peel <code>Option&lt;<b>address</b>&gt;</code> from serialized bytes.
 Peel <code>Option&lt;bool&gt;</code> from serialized bytes.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_option_bool">peel_option_bool</a>(<a href="../sui/bcs.md#sui_bcs">bcs</a>: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">sui::bcs::BCS</a>): <a href="../std/option.md#std_option_Option">std::option::Option</a>&lt;bool&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_option_bool">peel_option_bool</a>(bcs: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">sui::bcs::BCS</a>): <a href="../std/option.md#std_option_Option">std::option::Option</a>&lt;bool&gt;
 </code></pre>
 
 
@@ -865,8 +865,8 @@ Peel <code>Option&lt;bool&gt;</code> from serialized bytes.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_option_bool">peel_option_bool</a>(<a href="../sui/bcs.md#sui_bcs">bcs</a>: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">BCS</a>): Option&lt;bool&gt; {
-    <a href="../sui/bcs.md#sui_bcs">bcs</a>.<a href="../sui/bcs.md#sui_bcs_peel_option">peel_option</a>!(|<a href="../sui/bcs.md#sui_bcs">bcs</a>| <a href="../sui/bcs.md#sui_bcs">bcs</a>.<a href="../sui/bcs.md#sui_bcs_peel_bool">peel_bool</a>())
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_option_bool">peel_option_bool</a>(bcs: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">BCS</a>): Option&lt;bool&gt; {
+    bcs.<a href="../sui/bcs.md#sui_bcs_peel_option">peel_option</a>!(|bcs| bcs.<a href="../sui/bcs.md#sui_bcs_peel_bool">peel_bool</a>())
 }
 </code></pre>
 
@@ -881,7 +881,7 @@ Peel <code>Option&lt;bool&gt;</code> from serialized bytes.
 Peel <code>Option&lt;u8&gt;</code> from serialized bytes.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_option_u8">peel_option_u8</a>(<a href="../sui/bcs.md#sui_bcs">bcs</a>: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">sui::bcs::BCS</a>): <a href="../std/option.md#std_option_Option">std::option::Option</a>&lt;u8&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_option_u8">peel_option_u8</a>(bcs: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">sui::bcs::BCS</a>): <a href="../std/option.md#std_option_Option">std::option::Option</a>&lt;u8&gt;
 </code></pre>
 
 
@@ -890,8 +890,8 @@ Peel <code>Option&lt;u8&gt;</code> from serialized bytes.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_option_u8">peel_option_u8</a>(<a href="../sui/bcs.md#sui_bcs">bcs</a>: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">BCS</a>): Option&lt;u8&gt; {
-    <a href="../sui/bcs.md#sui_bcs">bcs</a>.<a href="../sui/bcs.md#sui_bcs_peel_option">peel_option</a>!(|<a href="../sui/bcs.md#sui_bcs">bcs</a>| <a href="../sui/bcs.md#sui_bcs">bcs</a>.<a href="../sui/bcs.md#sui_bcs_peel_u8">peel_u8</a>())
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_option_u8">peel_option_u8</a>(bcs: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">BCS</a>): Option&lt;u8&gt; {
+    bcs.<a href="../sui/bcs.md#sui_bcs_peel_option">peel_option</a>!(|bcs| bcs.<a href="../sui/bcs.md#sui_bcs_peel_u8">peel_u8</a>())
 }
 </code></pre>
 
@@ -906,7 +906,7 @@ Peel <code>Option&lt;u8&gt;</code> from serialized bytes.
 Peel <code>Option&lt;u16&gt;</code> from serialized bytes.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_option_u16">peel_option_u16</a>(<a href="../sui/bcs.md#sui_bcs">bcs</a>: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">sui::bcs::BCS</a>): <a href="../std/option.md#std_option_Option">std::option::Option</a>&lt;u16&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_option_u16">peel_option_u16</a>(bcs: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">sui::bcs::BCS</a>): <a href="../std/option.md#std_option_Option">std::option::Option</a>&lt;u16&gt;
 </code></pre>
 
 
@@ -915,8 +915,8 @@ Peel <code>Option&lt;u16&gt;</code> from serialized bytes.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_option_u16">peel_option_u16</a>(<a href="../sui/bcs.md#sui_bcs">bcs</a>: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">BCS</a>): Option&lt;u16&gt; {
-    <a href="../sui/bcs.md#sui_bcs">bcs</a>.<a href="../sui/bcs.md#sui_bcs_peel_option">peel_option</a>!(|<a href="../sui/bcs.md#sui_bcs">bcs</a>| <a href="../sui/bcs.md#sui_bcs">bcs</a>.<a href="../sui/bcs.md#sui_bcs_peel_u16">peel_u16</a>())
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_option_u16">peel_option_u16</a>(bcs: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">BCS</a>): Option&lt;u16&gt; {
+    bcs.<a href="../sui/bcs.md#sui_bcs_peel_option">peel_option</a>!(|bcs| bcs.<a href="../sui/bcs.md#sui_bcs_peel_u16">peel_u16</a>())
 }
 </code></pre>
 
@@ -931,7 +931,7 @@ Peel <code>Option&lt;u16&gt;</code> from serialized bytes.
 Peel <code>Option&lt;u32&gt;</code> from serialized bytes.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_option_u32">peel_option_u32</a>(<a href="../sui/bcs.md#sui_bcs">bcs</a>: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">sui::bcs::BCS</a>): <a href="../std/option.md#std_option_Option">std::option::Option</a>&lt;u32&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_option_u32">peel_option_u32</a>(bcs: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">sui::bcs::BCS</a>): <a href="../std/option.md#std_option_Option">std::option::Option</a>&lt;u32&gt;
 </code></pre>
 
 
@@ -940,8 +940,8 @@ Peel <code>Option&lt;u32&gt;</code> from serialized bytes.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_option_u32">peel_option_u32</a>(<a href="../sui/bcs.md#sui_bcs">bcs</a>: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">BCS</a>): Option&lt;u32&gt; {
-    <a href="../sui/bcs.md#sui_bcs">bcs</a>.<a href="../sui/bcs.md#sui_bcs_peel_option">peel_option</a>!(|<a href="../sui/bcs.md#sui_bcs">bcs</a>| <a href="../sui/bcs.md#sui_bcs">bcs</a>.<a href="../sui/bcs.md#sui_bcs_peel_u32">peel_u32</a>())
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_option_u32">peel_option_u32</a>(bcs: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">BCS</a>): Option&lt;u32&gt; {
+    bcs.<a href="../sui/bcs.md#sui_bcs_peel_option">peel_option</a>!(|bcs| bcs.<a href="../sui/bcs.md#sui_bcs_peel_u32">peel_u32</a>())
 }
 </code></pre>
 
@@ -956,7 +956,7 @@ Peel <code>Option&lt;u32&gt;</code> from serialized bytes.
 Peel <code>Option&lt;u64&gt;</code> from serialized bytes.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_option_u64">peel_option_u64</a>(<a href="../sui/bcs.md#sui_bcs">bcs</a>: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">sui::bcs::BCS</a>): <a href="../std/option.md#std_option_Option">std::option::Option</a>&lt;u64&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_option_u64">peel_option_u64</a>(bcs: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">sui::bcs::BCS</a>): <a href="../std/option.md#std_option_Option">std::option::Option</a>&lt;u64&gt;
 </code></pre>
 
 
@@ -965,8 +965,8 @@ Peel <code>Option&lt;u64&gt;</code> from serialized bytes.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_option_u64">peel_option_u64</a>(<a href="../sui/bcs.md#sui_bcs">bcs</a>: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">BCS</a>): Option&lt;u64&gt; {
-    <a href="../sui/bcs.md#sui_bcs">bcs</a>.<a href="../sui/bcs.md#sui_bcs_peel_option">peel_option</a>!(|<a href="../sui/bcs.md#sui_bcs">bcs</a>| <a href="../sui/bcs.md#sui_bcs">bcs</a>.<a href="../sui/bcs.md#sui_bcs_peel_u64">peel_u64</a>())
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_option_u64">peel_option_u64</a>(bcs: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">BCS</a>): Option&lt;u64&gt; {
+    bcs.<a href="../sui/bcs.md#sui_bcs_peel_option">peel_option</a>!(|bcs| bcs.<a href="../sui/bcs.md#sui_bcs_peel_u64">peel_u64</a>())
 }
 </code></pre>
 
@@ -981,7 +981,7 @@ Peel <code>Option&lt;u64&gt;</code> from serialized bytes.
 Peel <code>Option&lt;u128&gt;</code> from serialized bytes.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_option_u128">peel_option_u128</a>(<a href="../sui/bcs.md#sui_bcs">bcs</a>: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">sui::bcs::BCS</a>): <a href="../std/option.md#std_option_Option">std::option::Option</a>&lt;u128&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_option_u128">peel_option_u128</a>(bcs: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">sui::bcs::BCS</a>): <a href="../std/option.md#std_option_Option">std::option::Option</a>&lt;u128&gt;
 </code></pre>
 
 
@@ -990,8 +990,8 @@ Peel <code>Option&lt;u128&gt;</code> from serialized bytes.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_option_u128">peel_option_u128</a>(<a href="../sui/bcs.md#sui_bcs">bcs</a>: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">BCS</a>): Option&lt;u128&gt; {
-    <a href="../sui/bcs.md#sui_bcs">bcs</a>.<a href="../sui/bcs.md#sui_bcs_peel_option">peel_option</a>!(|<a href="../sui/bcs.md#sui_bcs">bcs</a>| <a href="../sui/bcs.md#sui_bcs">bcs</a>.<a href="../sui/bcs.md#sui_bcs_peel_u128">peel_u128</a>())
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_option_u128">peel_option_u128</a>(bcs: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">BCS</a>): Option&lt;u128&gt; {
+    bcs.<a href="../sui/bcs.md#sui_bcs_peel_option">peel_option</a>!(|bcs| bcs.<a href="../sui/bcs.md#sui_bcs_peel_u128">peel_u128</a>())
 }
 </code></pre>
 
@@ -1006,7 +1006,7 @@ Peel <code>Option&lt;u128&gt;</code> from serialized bytes.
 Peel <code>Option&lt;u256&gt;</code> from serialized bytes.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_option_u256">peel_option_u256</a>(<a href="../sui/bcs.md#sui_bcs">bcs</a>: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">sui::bcs::BCS</a>): <a href="../std/option.md#std_option_Option">std::option::Option</a>&lt;u256&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_option_u256">peel_option_u256</a>(bcs: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">sui::bcs::BCS</a>): <a href="../std/option.md#std_option_Option">std::option::Option</a>&lt;u256&gt;
 </code></pre>
 
 
@@ -1015,8 +1015,8 @@ Peel <code>Option&lt;u256&gt;</code> from serialized bytes.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_option_u256">peel_option_u256</a>(<a href="../sui/bcs.md#sui_bcs">bcs</a>: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">BCS</a>): Option&lt;u256&gt; {
-    <a href="../sui/bcs.md#sui_bcs">bcs</a>.<a href="../sui/bcs.md#sui_bcs_peel_option">peel_option</a>!(|<a href="../sui/bcs.md#sui_bcs">bcs</a>| <a href="../sui/bcs.md#sui_bcs">bcs</a>.<a href="../sui/bcs.md#sui_bcs_peel_u256">peel_u256</a>())
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/bcs.md#sui_bcs_peel_option_u256">peel_option_u256</a>(bcs: &<b>mut</b> <a href="../sui/bcs.md#sui_bcs_BCS">BCS</a>): Option&lt;u256&gt; {
+    bcs.<a href="../sui/bcs.md#sui_bcs_peel_option">peel_option</a>!(|bcs| bcs.<a href="../sui/bcs.md#sui_bcs_peel_u256">peel_u256</a>())
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/sui/bls12381.md
+++ b/crates/sui-framework/docs/sui/bls12381.md
@@ -376,7 +376,7 @@ BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_NUL_, return true. Otherwise, return fals
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/bls12381.md#sui_bls12381_scalar_from_bytes">scalar_from_bytes</a>(bytes: &vector&lt;u8&gt;): Element&lt;<a href="../sui/bls12381.md#sui_bls12381_Scalar">Scalar</a>&gt; {
-    <a href="../sui/group_ops.md#sui_group_ops_from_bytes">group_ops::from_bytes</a>(<a href="../sui/bls12381.md#sui_bls12381_SCALAR_TYPE">SCALAR_TYPE</a>, *bytes, <b>false</b>)
+    group_ops::from_bytes(<a href="../sui/bls12381.md#sui_bls12381_SCALAR_TYPE">SCALAR_TYPE</a>, *bytes, <b>false</b>)
 }
 </code></pre>
 
@@ -401,8 +401,8 @@ BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_NUL_, return true. Otherwise, return fals
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/bls12381.md#sui_bls12381_scalar_from_u64">scalar_from_u64</a>(x: u64): Element&lt;<a href="../sui/bls12381.md#sui_bls12381_Scalar">Scalar</a>&gt; {
     <b>let</b> <b>mut</b> bytes = <a href="../sui/bls12381.md#sui_bls12381_SCALAR_ZERO_BYTES">SCALAR_ZERO_BYTES</a>;
-    <a href="../sui/group_ops.md#sui_group_ops_set_as_prefix">group_ops::set_as_prefix</a>(x, <b>true</b>, &<b>mut</b> bytes);
-    <a href="../sui/group_ops.md#sui_group_ops_from_bytes">group_ops::from_bytes</a>(<a href="../sui/bls12381.md#sui_bls12381_SCALAR_TYPE">SCALAR_TYPE</a>, bytes, <b>true</b>)
+    group_ops::set_as_prefix(x, <b>true</b>, &<b>mut</b> bytes);
+    group_ops::from_bytes(<a href="../sui/bls12381.md#sui_bls12381_SCALAR_TYPE">SCALAR_TYPE</a>, bytes, <b>true</b>)
 }
 </code></pre>
 
@@ -426,7 +426,7 @@ BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_NUL_, return true. Otherwise, return fals
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/bls12381.md#sui_bls12381_scalar_zero">scalar_zero</a>(): Element&lt;<a href="../sui/bls12381.md#sui_bls12381_Scalar">Scalar</a>&gt; {
-    <a href="../sui/group_ops.md#sui_group_ops_from_bytes">group_ops::from_bytes</a>(<a href="../sui/bls12381.md#sui_bls12381_SCALAR_TYPE">SCALAR_TYPE</a>, <a href="../sui/bls12381.md#sui_bls12381_SCALAR_ZERO_BYTES">SCALAR_ZERO_BYTES</a>, <b>true</b>)
+    group_ops::from_bytes(<a href="../sui/bls12381.md#sui_bls12381_SCALAR_TYPE">SCALAR_TYPE</a>, <a href="../sui/bls12381.md#sui_bls12381_SCALAR_ZERO_BYTES">SCALAR_ZERO_BYTES</a>, <b>true</b>)
 }
 </code></pre>
 
@@ -450,7 +450,7 @@ BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_NUL_, return true. Otherwise, return fals
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/bls12381.md#sui_bls12381_scalar_one">scalar_one</a>(): Element&lt;<a href="../sui/bls12381.md#sui_bls12381_Scalar">Scalar</a>&gt; {
-    <a href="../sui/group_ops.md#sui_group_ops_from_bytes">group_ops::from_bytes</a>(<a href="../sui/bls12381.md#sui_bls12381_SCALAR_TYPE">SCALAR_TYPE</a>, <a href="../sui/bls12381.md#sui_bls12381_SCALAR_ONE_BYTES">SCALAR_ONE_BYTES</a>, <b>true</b>)
+    group_ops::from_bytes(<a href="../sui/bls12381.md#sui_bls12381_SCALAR_TYPE">SCALAR_TYPE</a>, <a href="../sui/bls12381.md#sui_bls12381_SCALAR_ONE_BYTES">SCALAR_ONE_BYTES</a>, <b>true</b>)
 }
 </code></pre>
 
@@ -474,7 +474,7 @@ BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_NUL_, return true. Otherwise, return fals
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/bls12381.md#sui_bls12381_scalar_add">scalar_add</a>(e1: &Element&lt;<a href="../sui/bls12381.md#sui_bls12381_Scalar">Scalar</a>&gt;, e2: &Element&lt;<a href="../sui/bls12381.md#sui_bls12381_Scalar">Scalar</a>&gt;): Element&lt;<a href="../sui/bls12381.md#sui_bls12381_Scalar">Scalar</a>&gt; {
-    <a href="../sui/group_ops.md#sui_group_ops_add">group_ops::add</a>(<a href="../sui/bls12381.md#sui_bls12381_SCALAR_TYPE">SCALAR_TYPE</a>, e1, e2)
+    group_ops::add(<a href="../sui/bls12381.md#sui_bls12381_SCALAR_TYPE">SCALAR_TYPE</a>, e1, e2)
 }
 </code></pre>
 
@@ -498,7 +498,7 @@ BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_NUL_, return true. Otherwise, return fals
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/bls12381.md#sui_bls12381_scalar_sub">scalar_sub</a>(e1: &Element&lt;<a href="../sui/bls12381.md#sui_bls12381_Scalar">Scalar</a>&gt;, e2: &Element&lt;<a href="../sui/bls12381.md#sui_bls12381_Scalar">Scalar</a>&gt;): Element&lt;<a href="../sui/bls12381.md#sui_bls12381_Scalar">Scalar</a>&gt; {
-    <a href="../sui/group_ops.md#sui_group_ops_sub">group_ops::sub</a>(<a href="../sui/bls12381.md#sui_bls12381_SCALAR_TYPE">SCALAR_TYPE</a>, e1, e2)
+    group_ops::sub(<a href="../sui/bls12381.md#sui_bls12381_SCALAR_TYPE">SCALAR_TYPE</a>, e1, e2)
 }
 </code></pre>
 
@@ -522,7 +522,7 @@ BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_NUL_, return true. Otherwise, return fals
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/bls12381.md#sui_bls12381_scalar_mul">scalar_mul</a>(e1: &Element&lt;<a href="../sui/bls12381.md#sui_bls12381_Scalar">Scalar</a>&gt;, e2: &Element&lt;<a href="../sui/bls12381.md#sui_bls12381_Scalar">Scalar</a>&gt;): Element&lt;<a href="../sui/bls12381.md#sui_bls12381_Scalar">Scalar</a>&gt; {
-    <a href="../sui/group_ops.md#sui_group_ops_mul">group_ops::mul</a>(<a href="../sui/bls12381.md#sui_bls12381_SCALAR_TYPE">SCALAR_TYPE</a>, e1, e2)
+    group_ops::mul(<a href="../sui/bls12381.md#sui_bls12381_SCALAR_TYPE">SCALAR_TYPE</a>, e1, e2)
 }
 </code></pre>
 
@@ -547,7 +547,7 @@ Returns e2/e1, fails if a is zero.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/bls12381.md#sui_bls12381_scalar_div">scalar_div</a>(e1: &Element&lt;<a href="../sui/bls12381.md#sui_bls12381_Scalar">Scalar</a>&gt;, e2: &Element&lt;<a href="../sui/bls12381.md#sui_bls12381_Scalar">Scalar</a>&gt;): Element&lt;<a href="../sui/bls12381.md#sui_bls12381_Scalar">Scalar</a>&gt; {
-    <a href="../sui/group_ops.md#sui_group_ops_div">group_ops::div</a>(<a href="../sui/bls12381.md#sui_bls12381_SCALAR_TYPE">SCALAR_TYPE</a>, e1, e2)
+    group_ops::div(<a href="../sui/bls12381.md#sui_bls12381_SCALAR_TYPE">SCALAR_TYPE</a>, e1, e2)
 }
 </code></pre>
 
@@ -619,7 +619,7 @@ Returns e2/e1, fails if a is zero.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/bls12381.md#sui_bls12381_g1_from_bytes">g1_from_bytes</a>(bytes: &vector&lt;u8&gt;): Element&lt;<a href="../sui/bls12381.md#sui_bls12381_G1">G1</a>&gt; {
-    <a href="../sui/group_ops.md#sui_group_ops_from_bytes">group_ops::from_bytes</a>(<a href="../sui/bls12381.md#sui_bls12381_G1_TYPE">G1_TYPE</a>, *bytes, <b>false</b>)
+    group_ops::from_bytes(<a href="../sui/bls12381.md#sui_bls12381_G1_TYPE">G1_TYPE</a>, *bytes, <b>false</b>)
 }
 </code></pre>
 
@@ -643,7 +643,7 @@ Returns e2/e1, fails if a is zero.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/bls12381.md#sui_bls12381_g1_identity">g1_identity</a>(): Element&lt;<a href="../sui/bls12381.md#sui_bls12381_G1">G1</a>&gt; {
-    <a href="../sui/group_ops.md#sui_group_ops_from_bytes">group_ops::from_bytes</a>(<a href="../sui/bls12381.md#sui_bls12381_G1_TYPE">G1_TYPE</a>, <a href="../sui/bls12381.md#sui_bls12381_G1_IDENTITY_BYTES">G1_IDENTITY_BYTES</a>, <b>true</b>)
+    group_ops::from_bytes(<a href="../sui/bls12381.md#sui_bls12381_G1_TYPE">G1_TYPE</a>, <a href="../sui/bls12381.md#sui_bls12381_G1_IDENTITY_BYTES">G1_IDENTITY_BYTES</a>, <b>true</b>)
 }
 </code></pre>
 
@@ -667,7 +667,7 @@ Returns e2/e1, fails if a is zero.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/bls12381.md#sui_bls12381_g1_generator">g1_generator</a>(): Element&lt;<a href="../sui/bls12381.md#sui_bls12381_G1">G1</a>&gt; {
-    <a href="../sui/group_ops.md#sui_group_ops_from_bytes">group_ops::from_bytes</a>(<a href="../sui/bls12381.md#sui_bls12381_G1_TYPE">G1_TYPE</a>, <a href="../sui/bls12381.md#sui_bls12381_G1_GENERATOR_BYTES">G1_GENERATOR_BYTES</a>, <b>true</b>)
+    group_ops::from_bytes(<a href="../sui/bls12381.md#sui_bls12381_G1_TYPE">G1_TYPE</a>, <a href="../sui/bls12381.md#sui_bls12381_G1_GENERATOR_BYTES">G1_GENERATOR_BYTES</a>, <b>true</b>)
 }
 </code></pre>
 
@@ -691,7 +691,7 @@ Returns e2/e1, fails if a is zero.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/bls12381.md#sui_bls12381_g1_add">g1_add</a>(e1: &Element&lt;<a href="../sui/bls12381.md#sui_bls12381_G1">G1</a>&gt;, e2: &Element&lt;<a href="../sui/bls12381.md#sui_bls12381_G1">G1</a>&gt;): Element&lt;<a href="../sui/bls12381.md#sui_bls12381_G1">G1</a>&gt; {
-    <a href="../sui/group_ops.md#sui_group_ops_add">group_ops::add</a>(<a href="../sui/bls12381.md#sui_bls12381_G1_TYPE">G1_TYPE</a>, e1, e2)
+    group_ops::add(<a href="../sui/bls12381.md#sui_bls12381_G1_TYPE">G1_TYPE</a>, e1, e2)
 }
 </code></pre>
 
@@ -715,7 +715,7 @@ Returns e2/e1, fails if a is zero.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/bls12381.md#sui_bls12381_g1_sub">g1_sub</a>(e1: &Element&lt;<a href="../sui/bls12381.md#sui_bls12381_G1">G1</a>&gt;, e2: &Element&lt;<a href="../sui/bls12381.md#sui_bls12381_G1">G1</a>&gt;): Element&lt;<a href="../sui/bls12381.md#sui_bls12381_G1">G1</a>&gt; {
-    <a href="../sui/group_ops.md#sui_group_ops_sub">group_ops::sub</a>(<a href="../sui/bls12381.md#sui_bls12381_G1_TYPE">G1_TYPE</a>, e1, e2)
+    group_ops::sub(<a href="../sui/bls12381.md#sui_bls12381_G1_TYPE">G1_TYPE</a>, e1, e2)
 }
 </code></pre>
 
@@ -739,7 +739,7 @@ Returns e2/e1, fails if a is zero.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/bls12381.md#sui_bls12381_g1_mul">g1_mul</a>(e1: &Element&lt;<a href="../sui/bls12381.md#sui_bls12381_Scalar">Scalar</a>&gt;, e2: &Element&lt;<a href="../sui/bls12381.md#sui_bls12381_G1">G1</a>&gt;): Element&lt;<a href="../sui/bls12381.md#sui_bls12381_G1">G1</a>&gt; {
-    <a href="../sui/group_ops.md#sui_group_ops_mul">group_ops::mul</a>(<a href="../sui/bls12381.md#sui_bls12381_G1_TYPE">G1_TYPE</a>, e1, e2)
+    group_ops::mul(<a href="../sui/bls12381.md#sui_bls12381_G1_TYPE">G1_TYPE</a>, e1, e2)
 }
 </code></pre>
 
@@ -764,7 +764,7 @@ Returns e2 / e1, fails if scalar is zero.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/bls12381.md#sui_bls12381_g1_div">g1_div</a>(e1: &Element&lt;<a href="../sui/bls12381.md#sui_bls12381_Scalar">Scalar</a>&gt;, e2: &Element&lt;<a href="../sui/bls12381.md#sui_bls12381_G1">G1</a>&gt;): Element&lt;<a href="../sui/bls12381.md#sui_bls12381_G1">G1</a>&gt; {
-    <a href="../sui/group_ops.md#sui_group_ops_div">group_ops::div</a>(<a href="../sui/bls12381.md#sui_bls12381_G1_TYPE">G1_TYPE</a>, e1, e2)
+    group_ops::div(<a href="../sui/bls12381.md#sui_bls12381_G1_TYPE">G1_TYPE</a>, e1, e2)
 }
 </code></pre>
 
@@ -813,7 +813,7 @@ Hash using DST = BLS_SIG_BLS12381G1_XMD:SHA-256_SSWU_RO_NUL_
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/bls12381.md#sui_bls12381_hash_to_g1">hash_to_g1</a>(m: &vector&lt;u8&gt;): Element&lt;<a href="../sui/bls12381.md#sui_bls12381_G1">G1</a>&gt; {
-    <a href="../sui/group_ops.md#sui_group_ops_hash_to">group_ops::hash_to</a>(<a href="../sui/bls12381.md#sui_bls12381_G1_TYPE">G1_TYPE</a>, m)
+    group_ops::hash_to(<a href="../sui/bls12381.md#sui_bls12381_G1_TYPE">G1_TYPE</a>, m)
 }
 </code></pre>
 
@@ -843,7 +843,7 @@ Aborts with <code>EInputTooLong</code> if the vectors are larger than 32 (may in
     scalars: &vector&lt;Element&lt;<a href="../sui/bls12381.md#sui_bls12381_Scalar">Scalar</a>&gt;&gt;,
     elements: &vector&lt;Element&lt;<a href="../sui/bls12381.md#sui_bls12381_G1">G1</a>&gt;&gt;,
 ): Element&lt;<a href="../sui/bls12381.md#sui_bls12381_G1">G1</a>&gt; {
-    <a href="../sui/group_ops.md#sui_group_ops_multi_scalar_multiplication">group_ops::multi_scalar_multiplication</a>(<a href="../sui/bls12381.md#sui_bls12381_G1_TYPE">G1_TYPE</a>, scalars, elements)
+    group_ops::multi_scalar_multiplication(<a href="../sui/bls12381.md#sui_bls12381_G1_TYPE">G1_TYPE</a>, scalars, elements)
 }
 </code></pre>
 
@@ -868,7 +868,7 @@ Convert an <code>Element&lt;<a href="../sui/bls12381.md#sui_bls12381_G1">G1</a>&
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/bls12381.md#sui_bls12381_g1_to_uncompressed_g1">g1_to_uncompressed_g1</a>(e: &Element&lt;<a href="../sui/bls12381.md#sui_bls12381_G1">G1</a>&gt;): Element&lt;<a href="../sui/bls12381.md#sui_bls12381_UncompressedG1">UncompressedG1</a>&gt; {
-    <a href="../sui/group_ops.md#sui_group_ops_convert">group_ops::convert</a>(<a href="../sui/bls12381.md#sui_bls12381_G1_TYPE">G1_TYPE</a>, <a href="../sui/bls12381.md#sui_bls12381_UNCOMPRESSED_G1_TYPE">UNCOMPRESSED_G1_TYPE</a>, e)
+    group_ops::convert(<a href="../sui/bls12381.md#sui_bls12381_G1_TYPE">G1_TYPE</a>, <a href="../sui/bls12381.md#sui_bls12381_UNCOMPRESSED_G1_TYPE">UNCOMPRESSED_G1_TYPE</a>, e)
 }
 </code></pre>
 
@@ -892,7 +892,7 @@ Convert an <code>Element&lt;<a href="../sui/bls12381.md#sui_bls12381_G1">G1</a>&
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/bls12381.md#sui_bls12381_g2_from_bytes">g2_from_bytes</a>(bytes: &vector&lt;u8&gt;): Element&lt;<a href="../sui/bls12381.md#sui_bls12381_G2">G2</a>&gt; {
-    <a href="../sui/group_ops.md#sui_group_ops_from_bytes">group_ops::from_bytes</a>(<a href="../sui/bls12381.md#sui_bls12381_G2_TYPE">G2_TYPE</a>, *bytes, <b>false</b>)
+    group_ops::from_bytes(<a href="../sui/bls12381.md#sui_bls12381_G2_TYPE">G2_TYPE</a>, *bytes, <b>false</b>)
 }
 </code></pre>
 
@@ -916,7 +916,7 @@ Convert an <code>Element&lt;<a href="../sui/bls12381.md#sui_bls12381_G1">G1</a>&
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/bls12381.md#sui_bls12381_g2_identity">g2_identity</a>(): Element&lt;<a href="../sui/bls12381.md#sui_bls12381_G2">G2</a>&gt; {
-    <a href="../sui/group_ops.md#sui_group_ops_from_bytes">group_ops::from_bytes</a>(<a href="../sui/bls12381.md#sui_bls12381_G2_TYPE">G2_TYPE</a>, <a href="../sui/bls12381.md#sui_bls12381_G2_IDENTITY_BYTES">G2_IDENTITY_BYTES</a>, <b>true</b>)
+    group_ops::from_bytes(<a href="../sui/bls12381.md#sui_bls12381_G2_TYPE">G2_TYPE</a>, <a href="../sui/bls12381.md#sui_bls12381_G2_IDENTITY_BYTES">G2_IDENTITY_BYTES</a>, <b>true</b>)
 }
 </code></pre>
 
@@ -940,7 +940,7 @@ Convert an <code>Element&lt;<a href="../sui/bls12381.md#sui_bls12381_G1">G1</a>&
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/bls12381.md#sui_bls12381_g2_generator">g2_generator</a>(): Element&lt;<a href="../sui/bls12381.md#sui_bls12381_G2">G2</a>&gt; {
-    <a href="../sui/group_ops.md#sui_group_ops_from_bytes">group_ops::from_bytes</a>(<a href="../sui/bls12381.md#sui_bls12381_G2_TYPE">G2_TYPE</a>, <a href="../sui/bls12381.md#sui_bls12381_G2_GENERATOR_BYTES">G2_GENERATOR_BYTES</a>, <b>true</b>)
+    group_ops::from_bytes(<a href="../sui/bls12381.md#sui_bls12381_G2_TYPE">G2_TYPE</a>, <a href="../sui/bls12381.md#sui_bls12381_G2_GENERATOR_BYTES">G2_GENERATOR_BYTES</a>, <b>true</b>)
 }
 </code></pre>
 
@@ -964,7 +964,7 @@ Convert an <code>Element&lt;<a href="../sui/bls12381.md#sui_bls12381_G1">G1</a>&
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/bls12381.md#sui_bls12381_g2_add">g2_add</a>(e1: &Element&lt;<a href="../sui/bls12381.md#sui_bls12381_G2">G2</a>&gt;, e2: &Element&lt;<a href="../sui/bls12381.md#sui_bls12381_G2">G2</a>&gt;): Element&lt;<a href="../sui/bls12381.md#sui_bls12381_G2">G2</a>&gt; {
-    <a href="../sui/group_ops.md#sui_group_ops_add">group_ops::add</a>(<a href="../sui/bls12381.md#sui_bls12381_G2_TYPE">G2_TYPE</a>, e1, e2)
+    group_ops::add(<a href="../sui/bls12381.md#sui_bls12381_G2_TYPE">G2_TYPE</a>, e1, e2)
 }
 </code></pre>
 
@@ -988,7 +988,7 @@ Convert an <code>Element&lt;<a href="../sui/bls12381.md#sui_bls12381_G1">G1</a>&
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/bls12381.md#sui_bls12381_g2_sub">g2_sub</a>(e1: &Element&lt;<a href="../sui/bls12381.md#sui_bls12381_G2">G2</a>&gt;, e2: &Element&lt;<a href="../sui/bls12381.md#sui_bls12381_G2">G2</a>&gt;): Element&lt;<a href="../sui/bls12381.md#sui_bls12381_G2">G2</a>&gt; {
-    <a href="../sui/group_ops.md#sui_group_ops_sub">group_ops::sub</a>(<a href="../sui/bls12381.md#sui_bls12381_G2_TYPE">G2_TYPE</a>, e1, e2)
+    group_ops::sub(<a href="../sui/bls12381.md#sui_bls12381_G2_TYPE">G2_TYPE</a>, e1, e2)
 }
 </code></pre>
 
@@ -1012,7 +1012,7 @@ Convert an <code>Element&lt;<a href="../sui/bls12381.md#sui_bls12381_G1">G1</a>&
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/bls12381.md#sui_bls12381_g2_mul">g2_mul</a>(e1: &Element&lt;<a href="../sui/bls12381.md#sui_bls12381_Scalar">Scalar</a>&gt;, e2: &Element&lt;<a href="../sui/bls12381.md#sui_bls12381_G2">G2</a>&gt;): Element&lt;<a href="../sui/bls12381.md#sui_bls12381_G2">G2</a>&gt; {
-    <a href="../sui/group_ops.md#sui_group_ops_mul">group_ops::mul</a>(<a href="../sui/bls12381.md#sui_bls12381_G2_TYPE">G2_TYPE</a>, e1, e2)
+    group_ops::mul(<a href="../sui/bls12381.md#sui_bls12381_G2_TYPE">G2_TYPE</a>, e1, e2)
 }
 </code></pre>
 
@@ -1037,7 +1037,7 @@ Returns e2 / e1, fails if scalar is zero.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/bls12381.md#sui_bls12381_g2_div">g2_div</a>(e1: &Element&lt;<a href="../sui/bls12381.md#sui_bls12381_Scalar">Scalar</a>&gt;, e2: &Element&lt;<a href="../sui/bls12381.md#sui_bls12381_G2">G2</a>&gt;): Element&lt;<a href="../sui/bls12381.md#sui_bls12381_G2">G2</a>&gt; {
-    <a href="../sui/group_ops.md#sui_group_ops_div">group_ops::div</a>(<a href="../sui/bls12381.md#sui_bls12381_G2_TYPE">G2_TYPE</a>, e1, e2)
+    group_ops::div(<a href="../sui/bls12381.md#sui_bls12381_G2_TYPE">G2_TYPE</a>, e1, e2)
 }
 </code></pre>
 
@@ -1086,7 +1086,7 @@ Hash using DST = BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_NUL_
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/bls12381.md#sui_bls12381_hash_to_g2">hash_to_g2</a>(m: &vector&lt;u8&gt;): Element&lt;<a href="../sui/bls12381.md#sui_bls12381_G2">G2</a>&gt; {
-    <a href="../sui/group_ops.md#sui_group_ops_hash_to">group_ops::hash_to</a>(<a href="../sui/bls12381.md#sui_bls12381_G2_TYPE">G2_TYPE</a>, m)
+    group_ops::hash_to(<a href="../sui/bls12381.md#sui_bls12381_G2_TYPE">G2_TYPE</a>, m)
 }
 </code></pre>
 
@@ -1116,7 +1116,7 @@ Aborts with <code>EInputTooLong</code> if the vectors are larger than 32 (may in
     scalars: &vector&lt;Element&lt;<a href="../sui/bls12381.md#sui_bls12381_Scalar">Scalar</a>&gt;&gt;,
     elements: &vector&lt;Element&lt;<a href="../sui/bls12381.md#sui_bls12381_G2">G2</a>&gt;&gt;,
 ): Element&lt;<a href="../sui/bls12381.md#sui_bls12381_G2">G2</a>&gt; {
-    <a href="../sui/group_ops.md#sui_group_ops_multi_scalar_multiplication">group_ops::multi_scalar_multiplication</a>(<a href="../sui/bls12381.md#sui_bls12381_G2_TYPE">G2_TYPE</a>, scalars, elements)
+    group_ops::multi_scalar_multiplication(<a href="../sui/bls12381.md#sui_bls12381_G2_TYPE">G2_TYPE</a>, scalars, elements)
 }
 </code></pre>
 
@@ -1140,7 +1140,7 @@ Aborts with <code>EInputTooLong</code> if the vectors are larger than 32 (may in
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/bls12381.md#sui_bls12381_gt_identity">gt_identity</a>(): Element&lt;<a href="../sui/bls12381.md#sui_bls12381_GT">GT</a>&gt; {
-    <a href="../sui/group_ops.md#sui_group_ops_from_bytes">group_ops::from_bytes</a>(<a href="../sui/bls12381.md#sui_bls12381_GT_TYPE">GT_TYPE</a>, <a href="../sui/bls12381.md#sui_bls12381_GT_IDENTITY_BYTES">GT_IDENTITY_BYTES</a>, <b>true</b>)
+    group_ops::from_bytes(<a href="../sui/bls12381.md#sui_bls12381_GT_TYPE">GT_TYPE</a>, <a href="../sui/bls12381.md#sui_bls12381_GT_IDENTITY_BYTES">GT_IDENTITY_BYTES</a>, <b>true</b>)
 }
 </code></pre>
 
@@ -1164,7 +1164,7 @@ Aborts with <code>EInputTooLong</code> if the vectors are larger than 32 (may in
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/bls12381.md#sui_bls12381_gt_generator">gt_generator</a>(): Element&lt;<a href="../sui/bls12381.md#sui_bls12381_GT">GT</a>&gt; {
-    <a href="../sui/group_ops.md#sui_group_ops_from_bytes">group_ops::from_bytes</a>(<a href="../sui/bls12381.md#sui_bls12381_GT_TYPE">GT_TYPE</a>, <a href="../sui/bls12381.md#sui_bls12381_GT_GENERATOR_BYTES">GT_GENERATOR_BYTES</a>, <b>true</b>)
+    group_ops::from_bytes(<a href="../sui/bls12381.md#sui_bls12381_GT_TYPE">GT_TYPE</a>, <a href="../sui/bls12381.md#sui_bls12381_GT_GENERATOR_BYTES">GT_GENERATOR_BYTES</a>, <b>true</b>)
 }
 </code></pre>
 
@@ -1188,7 +1188,7 @@ Aborts with <code>EInputTooLong</code> if the vectors are larger than 32 (may in
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/bls12381.md#sui_bls12381_gt_add">gt_add</a>(e1: &Element&lt;<a href="../sui/bls12381.md#sui_bls12381_GT">GT</a>&gt;, e2: &Element&lt;<a href="../sui/bls12381.md#sui_bls12381_GT">GT</a>&gt;): Element&lt;<a href="../sui/bls12381.md#sui_bls12381_GT">GT</a>&gt; {
-    <a href="../sui/group_ops.md#sui_group_ops_add">group_ops::add</a>(<a href="../sui/bls12381.md#sui_bls12381_GT_TYPE">GT_TYPE</a>, e1, e2)
+    group_ops::add(<a href="../sui/bls12381.md#sui_bls12381_GT_TYPE">GT_TYPE</a>, e1, e2)
 }
 </code></pre>
 
@@ -1212,7 +1212,7 @@ Aborts with <code>EInputTooLong</code> if the vectors are larger than 32 (may in
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/bls12381.md#sui_bls12381_gt_sub">gt_sub</a>(e1: &Element&lt;<a href="../sui/bls12381.md#sui_bls12381_GT">GT</a>&gt;, e2: &Element&lt;<a href="../sui/bls12381.md#sui_bls12381_GT">GT</a>&gt;): Element&lt;<a href="../sui/bls12381.md#sui_bls12381_GT">GT</a>&gt; {
-    <a href="../sui/group_ops.md#sui_group_ops_sub">group_ops::sub</a>(<a href="../sui/bls12381.md#sui_bls12381_GT_TYPE">GT_TYPE</a>, e1, e2)
+    group_ops::sub(<a href="../sui/bls12381.md#sui_bls12381_GT_TYPE">GT_TYPE</a>, e1, e2)
 }
 </code></pre>
 
@@ -1236,7 +1236,7 @@ Aborts with <code>EInputTooLong</code> if the vectors are larger than 32 (may in
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/bls12381.md#sui_bls12381_gt_mul">gt_mul</a>(e1: &Element&lt;<a href="../sui/bls12381.md#sui_bls12381_Scalar">Scalar</a>&gt;, e2: &Element&lt;<a href="../sui/bls12381.md#sui_bls12381_GT">GT</a>&gt;): Element&lt;<a href="../sui/bls12381.md#sui_bls12381_GT">GT</a>&gt; {
-    <a href="../sui/group_ops.md#sui_group_ops_mul">group_ops::mul</a>(<a href="../sui/bls12381.md#sui_bls12381_GT_TYPE">GT_TYPE</a>, e1, e2)
+    group_ops::mul(<a href="../sui/bls12381.md#sui_bls12381_GT_TYPE">GT_TYPE</a>, e1, e2)
 }
 </code></pre>
 
@@ -1261,7 +1261,7 @@ Returns e2 / e1, fails if scalar is zero.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/bls12381.md#sui_bls12381_gt_div">gt_div</a>(e1: &Element&lt;<a href="../sui/bls12381.md#sui_bls12381_Scalar">Scalar</a>&gt;, e2: &Element&lt;<a href="../sui/bls12381.md#sui_bls12381_GT">GT</a>&gt;): Element&lt;<a href="../sui/bls12381.md#sui_bls12381_GT">GT</a>&gt; {
-    <a href="../sui/group_ops.md#sui_group_ops_div">group_ops::div</a>(<a href="../sui/bls12381.md#sui_bls12381_GT_TYPE">GT_TYPE</a>, e1, e2)
+    group_ops::div(<a href="../sui/bls12381.md#sui_bls12381_GT_TYPE">GT_TYPE</a>, e1, e2)
 }
 </code></pre>
 
@@ -1309,7 +1309,7 @@ Returns e2 / e1, fails if scalar is zero.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/bls12381.md#sui_bls12381_pairing">pairing</a>(e1: &Element&lt;<a href="../sui/bls12381.md#sui_bls12381_G1">G1</a>&gt;, e2: &Element&lt;<a href="../sui/bls12381.md#sui_bls12381_G2">G2</a>&gt;): Element&lt;<a href="../sui/bls12381.md#sui_bls12381_GT">GT</a>&gt; {
-    <a href="../sui/group_ops.md#sui_group_ops_pairing">group_ops::pairing</a>(<a href="../sui/bls12381.md#sui_bls12381_G1_TYPE">G1_TYPE</a>, e1, e2)
+    group_ops::pairing(<a href="../sui/bls12381.md#sui_bls12381_G1_TYPE">G1_TYPE</a>, e1, e2)
 }
 </code></pre>
 
@@ -1335,7 +1335,7 @@ Create a <code>Element&lt;<a href="../sui/bls12381.md#sui_bls12381_G1">G1</a>&gt
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/bls12381.md#sui_bls12381_uncompressed_g1_to_g1">uncompressed_g1_to_g1</a>(e: &Element&lt;<a href="../sui/bls12381.md#sui_bls12381_UncompressedG1">UncompressedG1</a>&gt;): Element&lt;<a href="../sui/bls12381.md#sui_bls12381_G1">G1</a>&gt; {
-    <a href="../sui/group_ops.md#sui_group_ops_convert">group_ops::convert</a>(<a href="../sui/bls12381.md#sui_bls12381_UNCOMPRESSED_G1_TYPE">UNCOMPRESSED_G1_TYPE</a>, <a href="../sui/bls12381.md#sui_bls12381_G1_TYPE">G1_TYPE</a>, e)
+    group_ops::convert(<a href="../sui/bls12381.md#sui_bls12381_UNCOMPRESSED_G1_TYPE">UNCOMPRESSED_G1_TYPE</a>, <a href="../sui/bls12381.md#sui_bls12381_G1_TYPE">G1_TYPE</a>, e)
 }
 </code></pre>
 
@@ -1361,7 +1361,7 @@ This is significantly faster and cheaper than summing the elements.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/bls12381.md#sui_bls12381_uncompressed_g1_sum">uncompressed_g1_sum</a>(terms: &vector&lt;Element&lt;<a href="../sui/bls12381.md#sui_bls12381_UncompressedG1">UncompressedG1</a>&gt;&gt;): Element&lt;<a href="../sui/bls12381.md#sui_bls12381_UncompressedG1">UncompressedG1</a>&gt; {
-    <a href="../sui/group_ops.md#sui_group_ops_sum">group_ops::sum</a>(<a href="../sui/bls12381.md#sui_bls12381_UNCOMPRESSED_G1_TYPE">UNCOMPRESSED_G1_TYPE</a>, terms)
+    group_ops::sum(<a href="../sui/bls12381.md#sui_bls12381_UNCOMPRESSED_G1_TYPE">UNCOMPRESSED_G1_TYPE</a>, terms)
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/sui/borrow.md
+++ b/crates/sui-framework/docs/sui/borrow.md
@@ -156,7 +156,7 @@ Borrow the <code>T</code> from the <code><a href="../sui/borrow.md#sui_borrow_Re
 hot potato.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/borrow.md#sui_borrow">borrow</a>&lt;T: key, store&gt;(self: &<b>mut</b> <a href="../sui/borrow.md#sui_borrow_Referent">sui::borrow::Referent</a>&lt;T&gt;): (T, <a href="../sui/borrow.md#sui_borrow_Borrow">sui::borrow::Borrow</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/borrow.md#sui_borrow_borrow">borrow</a>&lt;T: key, store&gt;(self: &<b>mut</b> <a href="../sui/borrow.md#sui_borrow_Referent">sui::borrow::Referent</a>&lt;T&gt;): (T, <a href="../sui/borrow.md#sui_borrow_Borrow">sui::borrow::Borrow</a>)
 </code></pre>
 
 
@@ -165,9 +165,9 @@ hot potato.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/borrow.md#sui_borrow">borrow</a>&lt;T: key + store&gt;(self: &<b>mut</b> <a href="../sui/borrow.md#sui_borrow_Referent">Referent</a>&lt;T&gt;): (T, <a href="../sui/borrow.md#sui_borrow_Borrow">Borrow</a>) {
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/borrow.md#sui_borrow_borrow">borrow</a>&lt;T: key + store&gt;(self: &<b>mut</b> <a href="../sui/borrow.md#sui_borrow_Referent">Referent</a>&lt;T&gt;): (T, <a href="../sui/borrow.md#sui_borrow_Borrow">Borrow</a>) {
     <b>let</b> value = self.value.extract();
-    <b>let</b> id = <a href="../sui/object.md#sui_object_id">object::id</a>(&value);
+    <b>let</b> id = object::id(&value);
     (
         value,
         <a href="../sui/borrow.md#sui_borrow_Borrow">Borrow</a> {
@@ -189,7 +189,7 @@ hot potato.
 Put an object and the <code><a href="../sui/borrow.md#sui_borrow_Borrow">Borrow</a></code> hot potato back.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/borrow.md#sui_borrow_put_back">put_back</a>&lt;T: key, store&gt;(self: &<b>mut</b> <a href="../sui/borrow.md#sui_borrow_Referent">sui::borrow::Referent</a>&lt;T&gt;, value: T, <a href="../sui/borrow.md#sui_borrow">borrow</a>: <a href="../sui/borrow.md#sui_borrow_Borrow">sui::borrow::Borrow</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/borrow.md#sui_borrow_put_back">put_back</a>&lt;T: key, store&gt;(self: &<b>mut</b> <a href="../sui/borrow.md#sui_borrow_Referent">sui::borrow::Referent</a>&lt;T&gt;, value: T, <a href="../sui/borrow.md#sui_borrow_borrow">borrow</a>: <a href="../sui/borrow.md#sui_borrow_Borrow">sui::borrow::Borrow</a>)
 </code></pre>
 
 
@@ -198,9 +198,9 @@ Put an object and the <code><a href="../sui/borrow.md#sui_borrow_Borrow">Borrow<
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/borrow.md#sui_borrow_put_back">put_back</a>&lt;T: key + store&gt;(self: &<b>mut</b> <a href="../sui/borrow.md#sui_borrow_Referent">Referent</a>&lt;T&gt;, value: T, <a href="../sui/borrow.md#sui_borrow">borrow</a>: <a href="../sui/borrow.md#sui_borrow_Borrow">Borrow</a>) {
-    <b>let</b> <a href="../sui/borrow.md#sui_borrow_Borrow">Borrow</a> { ref, obj } = <a href="../sui/borrow.md#sui_borrow">borrow</a>;
-    <b>assert</b>!(<a href="../sui/object.md#sui_object_id">object::id</a>(&value) == obj, <a href="../sui/borrow.md#sui_borrow_EWrongValue">EWrongValue</a>);
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/borrow.md#sui_borrow_put_back">put_back</a>&lt;T: key + store&gt;(self: &<b>mut</b> <a href="../sui/borrow.md#sui_borrow_Referent">Referent</a>&lt;T&gt;, value: T, <a href="../sui/borrow.md#sui_borrow_borrow">borrow</a>: <a href="../sui/borrow.md#sui_borrow_Borrow">Borrow</a>) {
+    <b>let</b> <a href="../sui/borrow.md#sui_borrow_Borrow">Borrow</a> { ref, obj } = <a href="../sui/borrow.md#sui_borrow_borrow">borrow</a>;
+    <b>assert</b>!(object::id(&value) == obj, <a href="../sui/borrow.md#sui_borrow_EWrongValue">EWrongValue</a>);
     <b>assert</b>!(self.id == ref, <a href="../sui/borrow.md#sui_borrow_EWrongBorrow">EWrongBorrow</a>);
     self.value.fill(value);
 }

--- a/crates/sui-framework/docs/sui/clock.md
+++ b/crates/sui-framework/docs/sui/clock.md
@@ -91,11 +91,11 @@ Sender is not @0x0 the system address.
 
 ## Function `timestamp_ms`
 
-The <code><a href="../sui/clock.md#sui_clock">clock</a></code>'s current timestamp as a running total of
+The <code>clock</code>'s current timestamp as a running total of
 milliseconds since an arbitrary point in the past.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/clock.md#sui_clock_timestamp_ms">timestamp_ms</a>(<a href="../sui/clock.md#sui_clock">clock</a>: &<a href="../sui/clock.md#sui_clock_Clock">sui::clock::Clock</a>): u64
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/clock.md#sui_clock_timestamp_ms">timestamp_ms</a>(clock: &<a href="../sui/clock.md#sui_clock_Clock">sui::clock::Clock</a>): u64
 </code></pre>
 
 
@@ -104,8 +104,8 @@ milliseconds since an arbitrary point in the past.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/clock.md#sui_clock_timestamp_ms">timestamp_ms</a>(<a href="../sui/clock.md#sui_clock">clock</a>: &<a href="../sui/clock.md#sui_clock_Clock">Clock</a>): u64 {
-    <a href="../sui/clock.md#sui_clock">clock</a>.<a href="../sui/clock.md#sui_clock_timestamp_ms">timestamp_ms</a>
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/clock.md#sui_clock_timestamp_ms">timestamp_ms</a>(clock: &<a href="../sui/clock.md#sui_clock_Clock">Clock</a>): u64 {
+    clock.<a href="../sui/clock.md#sui_clock_timestamp_ms">timestamp_ms</a>
 }
 </code></pre>
 
@@ -132,8 +132,8 @@ called exactly once, during genesis.
 
 <pre><code><b>fun</b> <a href="../sui/clock.md#sui_clock_create">create</a>(ctx: &TxContext) {
     <b>assert</b>!(ctx.sender() == @0x0, <a href="../sui/clock.md#sui_clock_ENotSystemAddress">ENotSystemAddress</a>);
-    <a href="../sui/transfer.md#sui_transfer_share_object">transfer::share_object</a>(<a href="../sui/clock.md#sui_clock_Clock">Clock</a> {
-        id: <a href="../sui/object.md#sui_object_clock">object::clock</a>(),
+    transfer::share_object(<a href="../sui/clock.md#sui_clock_Clock">Clock</a> {
+        id: object::clock(),
         // Initialised to zero, but set to a real timestamp by a
         // system transaction before it can be witnessed by a <b>move</b>
         // call.
@@ -152,7 +152,7 @@ called exactly once, during genesis.
 
 
 
-<pre><code><b>fun</b> <a href="../sui/clock.md#sui_clock_consensus_commit_prologue">consensus_commit_prologue</a>(<a href="../sui/clock.md#sui_clock">clock</a>: &<b>mut</b> <a href="../sui/clock.md#sui_clock_Clock">sui::clock::Clock</a>, <a href="../sui/clock.md#sui_clock_timestamp_ms">timestamp_ms</a>: u64, ctx: &<a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>)
+<pre><code><b>fun</b> <a href="../sui/clock.md#sui_clock_consensus_commit_prologue">consensus_commit_prologue</a>(clock: &<b>mut</b> <a href="../sui/clock.md#sui_clock_Clock">sui::clock::Clock</a>, <a href="../sui/clock.md#sui_clock_timestamp_ms">timestamp_ms</a>: u64, ctx: &<a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -161,10 +161,10 @@ called exactly once, during genesis.
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="../sui/clock.md#sui_clock_consensus_commit_prologue">consensus_commit_prologue</a>(<a href="../sui/clock.md#sui_clock">clock</a>: &<b>mut</b> <a href="../sui/clock.md#sui_clock_Clock">Clock</a>, <a href="../sui/clock.md#sui_clock_timestamp_ms">timestamp_ms</a>: u64, ctx: &TxContext) {
+<pre><code><b>fun</b> <a href="../sui/clock.md#sui_clock_consensus_commit_prologue">consensus_commit_prologue</a>(clock: &<b>mut</b> <a href="../sui/clock.md#sui_clock_Clock">Clock</a>, <a href="../sui/clock.md#sui_clock_timestamp_ms">timestamp_ms</a>: u64, ctx: &TxContext) {
     // Validator will make a special system call with sender set <b>as</b> 0x0.
     <b>assert</b>!(ctx.sender() == @0x0, <a href="../sui/clock.md#sui_clock_ENotSystemAddress">ENotSystemAddress</a>);
-    <a href="../sui/clock.md#sui_clock">clock</a>.<a href="../sui/clock.md#sui_clock_timestamp_ms">timestamp_ms</a> = <a href="../sui/clock.md#sui_clock_timestamp_ms">timestamp_ms</a>
+    clock.<a href="../sui/clock.md#sui_clock_timestamp_ms">timestamp_ms</a> = <a href="../sui/clock.md#sui_clock_timestamp_ms">timestamp_ms</a>
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/sui/coin.md
+++ b/crates/sui-framework/docs/sui/coin.md
@@ -131,7 +131,7 @@ A coin of type <code>T</code> worth <code><a href="../sui/coin.md#sui_coin_value
 <dd>
 </dd>
 <dt>
-<code><a href="../sui/balance.md#sui_balance">balance</a>: <a href="../sui/balance.md#sui_balance_Balance">sui::balance::Balance</a>&lt;T&gt;</code>
+<code><a href="../sui/coin.md#sui_coin_balance">balance</a>: <a href="../sui/balance.md#sui_balance_Balance">sui::balance::Balance</a>&lt;T&gt;</code>
 </dt>
 <dd>
 </dd>
@@ -435,7 +435,7 @@ Return the total number of <code>T</code>'s in circulation.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_total_supply">total_supply</a>&lt;T&gt;(cap: &<a href="../sui/coin.md#sui_coin_TreasuryCap">TreasuryCap</a>&lt;T&gt;): u64 {
-    <a href="../sui/balance.md#sui_balance_supply_value">balance::supply_value</a>(&cap.<a href="../sui/coin.md#sui_coin_total_supply">total_supply</a>)
+    balance::supply_value(&cap.<a href="../sui/coin.md#sui_coin_total_supply">total_supply</a>)
 }
 </code></pre>
 
@@ -540,7 +540,7 @@ Public getter for the coin's value
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_value">value</a>&lt;T&gt;(self: &<a href="../sui/coin.md#sui_coin_Coin">Coin</a>&lt;T&gt;): u64 {
-    self.<a href="../sui/balance.md#sui_balance">balance</a>.<a href="../sui/coin.md#sui_coin_value">value</a>()
+    self.<a href="../sui/coin.md#sui_coin_balance">balance</a>.<a href="../sui/coin.md#sui_coin_value">value</a>()
 }
 </code></pre>
 
@@ -555,7 +555,7 @@ Public getter for the coin's value
 Get immutable reference to the balance of a coin.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/balance.md#sui_balance">balance</a>&lt;T&gt;(<a href="../sui/coin.md#sui_coin">coin</a>: &<a href="../sui/coin.md#sui_coin_Coin">sui::coin::Coin</a>&lt;T&gt;): &<a href="../sui/balance.md#sui_balance_Balance">sui::balance::Balance</a>&lt;T&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_balance">balance</a>&lt;T&gt;(coin: &<a href="../sui/coin.md#sui_coin_Coin">sui::coin::Coin</a>&lt;T&gt;): &<a href="../sui/balance.md#sui_balance_Balance">sui::balance::Balance</a>&lt;T&gt;
 </code></pre>
 
 
@@ -564,8 +564,8 @@ Get immutable reference to the balance of a coin.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/balance.md#sui_balance">balance</a>&lt;T&gt;(<a href="../sui/coin.md#sui_coin">coin</a>: &<a href="../sui/coin.md#sui_coin_Coin">Coin</a>&lt;T&gt;): &Balance&lt;T&gt; {
-    &<a href="../sui/coin.md#sui_coin">coin</a>.<a href="../sui/balance.md#sui_balance">balance</a>
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_balance">balance</a>&lt;T&gt;(coin: &<a href="../sui/coin.md#sui_coin_Coin">Coin</a>&lt;T&gt;): &Balance&lt;T&gt; {
+    &coin.<a href="../sui/coin.md#sui_coin_balance">balance</a>
 }
 </code></pre>
 
@@ -580,7 +580,7 @@ Get immutable reference to the balance of a coin.
 Get a mutable reference to the balance of a coin.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_balance_mut">balance_mut</a>&lt;T&gt;(<a href="../sui/coin.md#sui_coin">coin</a>: &<b>mut</b> <a href="../sui/coin.md#sui_coin_Coin">sui::coin::Coin</a>&lt;T&gt;): &<b>mut</b> <a href="../sui/balance.md#sui_balance_Balance">sui::balance::Balance</a>&lt;T&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_balance_mut">balance_mut</a>&lt;T&gt;(coin: &<b>mut</b> <a href="../sui/coin.md#sui_coin_Coin">sui::coin::Coin</a>&lt;T&gt;): &<b>mut</b> <a href="../sui/balance.md#sui_balance_Balance">sui::balance::Balance</a>&lt;T&gt;
 </code></pre>
 
 
@@ -589,8 +589,8 @@ Get a mutable reference to the balance of a coin.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_balance_mut">balance_mut</a>&lt;T&gt;(<a href="../sui/coin.md#sui_coin">coin</a>: &<b>mut</b> <a href="../sui/coin.md#sui_coin_Coin">Coin</a>&lt;T&gt;): &<b>mut</b> Balance&lt;T&gt; {
-    &<b>mut</b> <a href="../sui/coin.md#sui_coin">coin</a>.<a href="../sui/balance.md#sui_balance">balance</a>
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_balance_mut">balance_mut</a>&lt;T&gt;(coin: &<b>mut</b> <a href="../sui/coin.md#sui_coin_Coin">Coin</a>&lt;T&gt;): &<b>mut</b> Balance&lt;T&gt; {
+    &<b>mut</b> coin.<a href="../sui/coin.md#sui_coin_balance">balance</a>
 }
 </code></pre>
 
@@ -605,7 +605,7 @@ Get a mutable reference to the balance of a coin.
 Wrap a balance into a Coin to make it transferable.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_from_balance">from_balance</a>&lt;T&gt;(<a href="../sui/balance.md#sui_balance">balance</a>: <a href="../sui/balance.md#sui_balance_Balance">sui::balance::Balance</a>&lt;T&gt;, ctx: &<b>mut</b> <a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>): <a href="../sui/coin.md#sui_coin_Coin">sui::coin::Coin</a>&lt;T&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_from_balance">from_balance</a>&lt;T&gt;(<a href="../sui/coin.md#sui_coin_balance">balance</a>: <a href="../sui/balance.md#sui_balance_Balance">sui::balance::Balance</a>&lt;T&gt;, ctx: &<b>mut</b> <a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>): <a href="../sui/coin.md#sui_coin_Coin">sui::coin::Coin</a>&lt;T&gt;
 </code></pre>
 
 
@@ -614,8 +614,8 @@ Wrap a balance into a Coin to make it transferable.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_from_balance">from_balance</a>&lt;T&gt;(<a href="../sui/balance.md#sui_balance">balance</a>: Balance&lt;T&gt;, ctx: &<b>mut</b> TxContext): <a href="../sui/coin.md#sui_coin_Coin">Coin</a>&lt;T&gt; {
-    <a href="../sui/coin.md#sui_coin_Coin">Coin</a> { id: <a href="../sui/object.md#sui_object_new">object::new</a>(ctx), <a href="../sui/balance.md#sui_balance">balance</a> }
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_from_balance">from_balance</a>&lt;T&gt;(<a href="../sui/coin.md#sui_coin_balance">balance</a>: Balance&lt;T&gt;, ctx: &<b>mut</b> TxContext): <a href="../sui/coin.md#sui_coin_Coin">Coin</a>&lt;T&gt; {
+    <a href="../sui/coin.md#sui_coin_Coin">Coin</a> { id: object::new(ctx), <a href="../sui/coin.md#sui_coin_balance">balance</a> }
 }
 </code></pre>
 
@@ -630,7 +630,7 @@ Wrap a balance into a Coin to make it transferable.
 Destruct a Coin wrapper and keep the balance.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_into_balance">into_balance</a>&lt;T&gt;(<a href="../sui/coin.md#sui_coin">coin</a>: <a href="../sui/coin.md#sui_coin_Coin">sui::coin::Coin</a>&lt;T&gt;): <a href="../sui/balance.md#sui_balance_Balance">sui::balance::Balance</a>&lt;T&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_into_balance">into_balance</a>&lt;T&gt;(coin: <a href="../sui/coin.md#sui_coin_Coin">sui::coin::Coin</a>&lt;T&gt;): <a href="../sui/balance.md#sui_balance_Balance">sui::balance::Balance</a>&lt;T&gt;
 </code></pre>
 
 
@@ -639,10 +639,10 @@ Destruct a Coin wrapper and keep the balance.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_into_balance">into_balance</a>&lt;T&gt;(<a href="../sui/coin.md#sui_coin">coin</a>: <a href="../sui/coin.md#sui_coin_Coin">Coin</a>&lt;T&gt;): Balance&lt;T&gt; {
-    <b>let</b> <a href="../sui/coin.md#sui_coin_Coin">Coin</a> { id, <a href="../sui/balance.md#sui_balance">balance</a> } = <a href="../sui/coin.md#sui_coin">coin</a>;
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_into_balance">into_balance</a>&lt;T&gt;(coin: <a href="../sui/coin.md#sui_coin_Coin">Coin</a>&lt;T&gt;): Balance&lt;T&gt; {
+    <b>let</b> <a href="../sui/coin.md#sui_coin_Coin">Coin</a> { id, <a href="../sui/coin.md#sui_coin_balance">balance</a> } = coin;
     id.delete();
-    <a href="../sui/balance.md#sui_balance">balance</a>
+    <a href="../sui/coin.md#sui_coin_balance">balance</a>
 }
 </code></pre>
 
@@ -655,10 +655,10 @@ Destruct a Coin wrapper and keep the balance.
 ## Function `take`
 
 Take a <code><a href="../sui/coin.md#sui_coin_Coin">Coin</a></code> worth of <code><a href="../sui/coin.md#sui_coin_value">value</a></code> from <code>Balance</code>.
-Aborts if <code><a href="../sui/coin.md#sui_coin_value">value</a> &gt; <a href="../sui/balance.md#sui_balance">balance</a>.<a href="../sui/coin.md#sui_coin_value">value</a></code>
+Aborts if <code><a href="../sui/coin.md#sui_coin_value">value</a> &gt; <a href="../sui/coin.md#sui_coin_balance">balance</a>.<a href="../sui/coin.md#sui_coin_value">value</a></code>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_take">take</a>&lt;T&gt;(<a href="../sui/balance.md#sui_balance">balance</a>: &<b>mut</b> <a href="../sui/balance.md#sui_balance_Balance">sui::balance::Balance</a>&lt;T&gt;, <a href="../sui/coin.md#sui_coin_value">value</a>: u64, ctx: &<b>mut</b> <a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>): <a href="../sui/coin.md#sui_coin_Coin">sui::coin::Coin</a>&lt;T&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_take">take</a>&lt;T&gt;(<a href="../sui/coin.md#sui_coin_balance">balance</a>: &<b>mut</b> <a href="../sui/balance.md#sui_balance_Balance">sui::balance::Balance</a>&lt;T&gt;, <a href="../sui/coin.md#sui_coin_value">value</a>: u64, ctx: &<b>mut</b> <a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>): <a href="../sui/coin.md#sui_coin_Coin">sui::coin::Coin</a>&lt;T&gt;
 </code></pre>
 
 
@@ -667,10 +667,10 @@ Aborts if <code><a href="../sui/coin.md#sui_coin_value">value</a> &gt; <a href="
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_take">take</a>&lt;T&gt;(<a href="../sui/balance.md#sui_balance">balance</a>: &<b>mut</b> Balance&lt;T&gt;, <a href="../sui/coin.md#sui_coin_value">value</a>: u64, ctx: &<b>mut</b> TxContext): <a href="../sui/coin.md#sui_coin_Coin">Coin</a>&lt;T&gt; {
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_take">take</a>&lt;T&gt;(<a href="../sui/coin.md#sui_coin_balance">balance</a>: &<b>mut</b> Balance&lt;T&gt;, <a href="../sui/coin.md#sui_coin_value">value</a>: u64, ctx: &<b>mut</b> TxContext): <a href="../sui/coin.md#sui_coin_Coin">Coin</a>&lt;T&gt; {
     <a href="../sui/coin.md#sui_coin_Coin">Coin</a> {
-        id: <a href="../sui/object.md#sui_object_new">object::new</a>(ctx),
-        <a href="../sui/balance.md#sui_balance">balance</a>: <a href="../sui/balance.md#sui_balance">balance</a>.<a href="../sui/coin.md#sui_coin_split">split</a>(<a href="../sui/coin.md#sui_coin_value">value</a>),
+        id: object::new(ctx),
+        <a href="../sui/coin.md#sui_coin_balance">balance</a>: <a href="../sui/coin.md#sui_coin_balance">balance</a>.<a href="../sui/coin.md#sui_coin_split">split</a>(<a href="../sui/coin.md#sui_coin_value">value</a>),
     }
 }
 </code></pre>
@@ -686,7 +686,7 @@ Aborts if <code><a href="../sui/coin.md#sui_coin_value">value</a> &gt; <a href="
 Put a <code><a href="../sui/coin.md#sui_coin_Coin">Coin</a>&lt;T&gt;</code> to the <code>Balance&lt;T&gt;</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_put">put</a>&lt;T&gt;(<a href="../sui/balance.md#sui_balance">balance</a>: &<b>mut</b> <a href="../sui/balance.md#sui_balance_Balance">sui::balance::Balance</a>&lt;T&gt;, <a href="../sui/coin.md#sui_coin">coin</a>: <a href="../sui/coin.md#sui_coin_Coin">sui::coin::Coin</a>&lt;T&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_put">put</a>&lt;T&gt;(<a href="../sui/coin.md#sui_coin_balance">balance</a>: &<b>mut</b> <a href="../sui/balance.md#sui_balance_Balance">sui::balance::Balance</a>&lt;T&gt;, coin: <a href="../sui/coin.md#sui_coin_Coin">sui::coin::Coin</a>&lt;T&gt;)
 </code></pre>
 
 
@@ -695,8 +695,8 @@ Put a <code><a href="../sui/coin.md#sui_coin_Coin">Coin</a>&lt;T&gt;</code> to t
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_put">put</a>&lt;T&gt;(<a href="../sui/balance.md#sui_balance">balance</a>: &<b>mut</b> Balance&lt;T&gt;, <a href="../sui/coin.md#sui_coin">coin</a>: <a href="../sui/coin.md#sui_coin_Coin">Coin</a>&lt;T&gt;) {
-    <a href="../sui/balance.md#sui_balance">balance</a>.<a href="../sui/coin.md#sui_coin_join">join</a>(<a href="../sui/coin.md#sui_coin_into_balance">into_balance</a>(<a href="../sui/coin.md#sui_coin">coin</a>));
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_put">put</a>&lt;T&gt;(<a href="../sui/coin.md#sui_coin_balance">balance</a>: &<b>mut</b> Balance&lt;T&gt;, coin: <a href="../sui/coin.md#sui_coin_Coin">Coin</a>&lt;T&gt;) {
+    <a href="../sui/coin.md#sui_coin_balance">balance</a>.<a href="../sui/coin.md#sui_coin_join">join</a>(<a href="../sui/coin.md#sui_coin_into_balance">into_balance</a>(coin));
 }
 </code></pre>
 
@@ -724,7 +724,7 @@ Redeem a <code>Withdrawal&lt;Balance&lt;T&gt;&gt;</code> and create a <code><a h
     withdrawal: <a href="../sui/funds_accumulator.md#sui_funds_accumulator_Withdrawal">sui::funds_accumulator::Withdrawal</a>&lt;Balance&lt;T&gt;&gt;,
     ctx: &<b>mut</b> TxContext,
 ): <a href="../sui/coin.md#sui_coin_Coin">Coin</a>&lt;T&gt; {
-    <a href="../sui/balance.md#sui_balance_redeem_funds">balance::redeem_funds</a>(withdrawal).into_coin(ctx)
+    balance::redeem_funds(withdrawal).into_coin(ctx)
 }
 </code></pre>
 
@@ -739,7 +739,7 @@ Redeem a <code>Withdrawal&lt;Balance&lt;T&gt;&gt;</code> and create a <code><a h
 Send a coin to an address balance
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_send_funds">send_funds</a>&lt;T&gt;(<a href="../sui/coin.md#sui_coin">coin</a>: <a href="../sui/coin.md#sui_coin_Coin">sui::coin::Coin</a>&lt;T&gt;, recipient: <b>address</b>)
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_send_funds">send_funds</a>&lt;T&gt;(coin: <a href="../sui/coin.md#sui_coin_Coin">sui::coin::Coin</a>&lt;T&gt;, recipient: <b>address</b>)
 </code></pre>
 
 
@@ -748,8 +748,8 @@ Send a coin to an address balance
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_send_funds">send_funds</a>&lt;T&gt;(<a href="../sui/coin.md#sui_coin">coin</a>: <a href="../sui/coin.md#sui_coin_Coin">Coin</a>&lt;T&gt;, recipient: <b>address</b>) {
-    <a href="../sui/balance.md#sui_balance_send_funds">balance::send_funds</a>(<a href="../sui/coin.md#sui_coin">coin</a>.<a href="../sui/coin.md#sui_coin_into_balance">into_balance</a>(), recipient);
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_send_funds">send_funds</a>&lt;T&gt;(coin: <a href="../sui/coin.md#sui_coin_Coin">Coin</a>&lt;T&gt;, recipient: <b>address</b>) {
+    balance::send_funds(coin.<a href="../sui/coin.md#sui_coin_into_balance">into_balance</a>(), recipient);
 }
 </code></pre>
 
@@ -775,9 +775,9 @@ Aborts if <code>c.<a href="../sui/coin.md#sui_coin_value">value</a> + self.<a hr
 
 
 <pre><code><b>public</b> <b>entry</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_join">join</a>&lt;T&gt;(self: &<b>mut</b> <a href="../sui/coin.md#sui_coin_Coin">Coin</a>&lt;T&gt;, c: <a href="../sui/coin.md#sui_coin_Coin">Coin</a>&lt;T&gt;) {
-    <b>let</b> <a href="../sui/coin.md#sui_coin_Coin">Coin</a> { id, <a href="../sui/balance.md#sui_balance">balance</a> } = c;
+    <b>let</b> <a href="../sui/coin.md#sui_coin_Coin">Coin</a> { id, <a href="../sui/coin.md#sui_coin_balance">balance</a> } = c;
     id.delete();
-    self.<a href="../sui/balance.md#sui_balance">balance</a>.<a href="../sui/coin.md#sui_coin_join">join</a>(<a href="../sui/balance.md#sui_balance">balance</a>);
+    self.<a href="../sui/coin.md#sui_coin_balance">balance</a>.<a href="../sui/coin.md#sui_coin_join">join</a>(<a href="../sui/coin.md#sui_coin_balance">balance</a>);
 }
 </code></pre>
 
@@ -803,7 +803,7 @@ and the remaining balance is left is <code>self</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_split">split</a>&lt;T&gt;(self: &<b>mut</b> <a href="../sui/coin.md#sui_coin_Coin">Coin</a>&lt;T&gt;, split_amount: u64, ctx: &<b>mut</b> TxContext): <a href="../sui/coin.md#sui_coin_Coin">Coin</a>&lt;T&gt; {
-    <a href="../sui/coin.md#sui_coin_take">take</a>(&<b>mut</b> self.<a href="../sui/balance.md#sui_balance">balance</a>, split_amount, ctx)
+    <a href="../sui/coin.md#sui_coin_take">take</a>(&<b>mut</b> self.<a href="../sui/coin.md#sui_coin_balance">balance</a>, split_amount, ctx)
 }
 </code></pre>
 
@@ -858,7 +858,7 @@ bids/payments or preemptively making empty balances.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_zero">zero</a>&lt;T&gt;(ctx: &<b>mut</b> TxContext): <a href="../sui/coin.md#sui_coin_Coin">Coin</a>&lt;T&gt; {
-    <a href="../sui/coin.md#sui_coin_Coin">Coin</a> { id: <a href="../sui/object.md#sui_object_new">object::new</a>(ctx), <a href="../sui/balance.md#sui_balance">balance</a>: <a href="../sui/balance.md#sui_balance_zero">balance::zero</a>() }
+    <a href="../sui/coin.md#sui_coin_Coin">Coin</a> { id: object::new(ctx), <a href="../sui/coin.md#sui_coin_balance">balance</a>: balance::zero() }
 }
 </code></pre>
 
@@ -883,9 +883,9 @@ Destroy a coin with value zero
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_destroy_zero">destroy_zero</a>&lt;T&gt;(c: <a href="../sui/coin.md#sui_coin_Coin">Coin</a>&lt;T&gt;) {
-    <b>let</b> <a href="../sui/coin.md#sui_coin_Coin">Coin</a> { id, <a href="../sui/balance.md#sui_balance">balance</a> } = c;
+    <b>let</b> <a href="../sui/coin.md#sui_coin_Coin">Coin</a> { id, <a href="../sui/coin.md#sui_coin_balance">balance</a> } = c;
     id.delete();
-    <a href="../sui/balance.md#sui_balance">balance</a>.<a href="../sui/coin.md#sui_coin_destroy_zero">destroy_zero</a>()
+    <a href="../sui/coin.md#sui_coin_balance">balance</a>.<a href="../sui/coin.md#sui_coin_destroy_zero">destroy_zero</a>()
 }
 </code></pre>
 
@@ -924,11 +924,11 @@ type, ensuring that there's only one <code><a href="../sui/coin.md#sui_coin_Trea
     <b>assert</b>!(<a href="../sui/types.md#sui_types_is_one_time_witness">sui::types::is_one_time_witness</a>(&witness), <a href="../sui/coin.md#sui_coin_EBadWitness">EBadWitness</a>);
     (
         <a href="../sui/coin.md#sui_coin_TreasuryCap">TreasuryCap</a> {
-            id: <a href="../sui/object.md#sui_object_new">object::new</a>(ctx),
-            <a href="../sui/coin.md#sui_coin_total_supply">total_supply</a>: <a href="../sui/balance.md#sui_balance_create_supply">balance::create_supply</a>(witness),
+            id: object::new(ctx),
+            <a href="../sui/coin.md#sui_coin_total_supply">total_supply</a>: balance::create_supply(witness),
         },
         <a href="../sui/coin.md#sui_coin_CoinMetadata">CoinMetadata</a> {
-            id: <a href="../sui/object.md#sui_object_new">object::new</a>(ctx),
+            id: object::new(ctx),
             decimals,
             name: name.to_string(),
             symbol: symbol.to_ascii_string(),
@@ -986,13 +986,13 @@ will not change the result of the "contains" APIs.
         ctx,
     );
     <b>let</b> deny_cap = <a href="../sui/coin.md#sui_coin_DenyCapV2">DenyCapV2</a> {
-        id: <a href="../sui/object.md#sui_object_new">object::new</a>(ctx),
+        id: object::new(ctx),
         <a href="../sui/coin.md#sui_coin_allow_global_pause">allow_global_pause</a>,
     };
-    <a href="../sui/transfer.md#sui_transfer_freeze_object">transfer::freeze_object</a>(<a href="../sui/coin.md#sui_coin_RegulatedCoinMetadata">RegulatedCoinMetadata</a>&lt;T&gt; {
-        id: <a href="../sui/object.md#sui_object_new">object::new</a>(ctx),
-        coin_metadata_object: <a href="../sui/object.md#sui_object_id">object::id</a>(&metadata),
-        deny_cap_object: <a href="../sui/object.md#sui_object_id">object::id</a>(&deny_cap),
+    transfer::freeze_object(<a href="../sui/coin.md#sui_coin_RegulatedCoinMetadata">RegulatedCoinMetadata</a>&lt;T&gt; {
+        id: object::new(ctx),
+        coin_metadata_object: object::id(&metadata),
+        deny_cap_object: object::id(&deny_cap),
     });
     (treasury_cap, deny_cap, metadata)
 }
@@ -1011,7 +1011,7 @@ All entries in the deny list will be migrated to the new format.
 See <code><a href="../sui/coin.md#sui_coin_create_regulated_currency_v2">create_regulated_currency_v2</a></code> for details on the new v2 of the deny list.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_migrate_regulated_currency_to_v2">migrate_regulated_currency_to_v2</a>&lt;T&gt;(<a href="../sui/deny_list.md#sui_deny_list">deny_list</a>: &<b>mut</b> <a href="../sui/deny_list.md#sui_deny_list_DenyList">sui::deny_list::DenyList</a>, cap: <a href="../sui/coin.md#sui_coin_DenyCap">sui::coin::DenyCap</a>&lt;T&gt;, <a href="../sui/coin.md#sui_coin_allow_global_pause">allow_global_pause</a>: bool, ctx: &<b>mut</b> <a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>): <a href="../sui/coin.md#sui_coin_DenyCapV2">sui::coin::DenyCapV2</a>&lt;T&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_migrate_regulated_currency_to_v2">migrate_regulated_currency_to_v2</a>&lt;T&gt;(deny_list: &<b>mut</b> <a href="../sui/deny_list.md#sui_deny_list_DenyList">sui::deny_list::DenyList</a>, cap: <a href="../sui/coin.md#sui_coin_DenyCap">sui::coin::DenyCap</a>&lt;T&gt;, <a href="../sui/coin.md#sui_coin_allow_global_pause">allow_global_pause</a>: bool, ctx: &<b>mut</b> <a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>): <a href="../sui/coin.md#sui_coin_DenyCapV2">sui::coin::DenyCapV2</a>&lt;T&gt;
 </code></pre>
 
 
@@ -1021,7 +1021,7 @@ See <code><a href="../sui/coin.md#sui_coin_create_regulated_currency_v2">create_
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_migrate_regulated_currency_to_v2">migrate_regulated_currency_to_v2</a>&lt;T&gt;(
-    <a href="../sui/deny_list.md#sui_deny_list">deny_list</a>: &<b>mut</b> DenyList,
+    deny_list: &<b>mut</b> DenyList,
     cap: <a href="../sui/coin.md#sui_coin_DenyCap">DenyCap</a>&lt;T&gt;,
     <a href="../sui/coin.md#sui_coin_allow_global_pause">allow_global_pause</a>: bool,
     ctx: &<b>mut</b> TxContext,
@@ -1029,9 +1029,9 @@ See <code><a href="../sui/coin.md#sui_coin_create_regulated_currency_v2">create_
     <b>let</b> <a href="../sui/coin.md#sui_coin_DenyCap">DenyCap</a> { id } = cap;
     id.delete();
     <b>let</b> ty = type_name::with_original_ids&lt;T&gt;().into_string().into_bytes();
-    <a href="../sui/deny_list.md#sui_deny_list">deny_list</a>.migrate_v1_to_v2(<a href="../sui/coin.md#sui_coin_DENY_LIST_COIN_INDEX">DENY_LIST_COIN_INDEX</a>, ty, ctx);
+    deny_list.migrate_v1_to_v2(<a href="../sui/coin.md#sui_coin_DENY_LIST_COIN_INDEX">DENY_LIST_COIN_INDEX</a>, ty, ctx);
     <a href="../sui/coin.md#sui_coin_DenyCapV2">DenyCapV2</a> {
-        id: <a href="../sui/object.md#sui_object_new">object::new</a>(ctx),
+        id: object::new(ctx),
         <a href="../sui/coin.md#sui_coin_allow_global_pause">allow_global_pause</a>,
     }
 }
@@ -1060,8 +1060,8 @@ in <code>cap</code> accordingly.
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_mint">mint</a>&lt;T&gt;(cap: &<b>mut</b> <a href="../sui/coin.md#sui_coin_TreasuryCap">TreasuryCap</a>&lt;T&gt;, <a href="../sui/coin.md#sui_coin_value">value</a>: u64, ctx: &<b>mut</b> TxContext): <a href="../sui/coin.md#sui_coin_Coin">Coin</a>&lt;T&gt; {
     <a href="../sui/coin.md#sui_coin_Coin">Coin</a> {
-        id: <a href="../sui/object.md#sui_object_new">object::new</a>(ctx),
-        <a href="../sui/balance.md#sui_balance">balance</a>: cap.<a href="../sui/coin.md#sui_coin_total_supply">total_supply</a>.increase_supply(<a href="../sui/coin.md#sui_coin_value">value</a>),
+        id: object::new(ctx),
+        <a href="../sui/coin.md#sui_coin_balance">balance</a>: cap.<a href="../sui/coin.md#sui_coin_total_supply">total_supply</a>.increase_supply(<a href="../sui/coin.md#sui_coin_value">value</a>),
     }
 }
 </code></pre>
@@ -1115,9 +1115,9 @@ accordingly.
 
 
 <pre><code><b>public</b> <b>entry</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_burn">burn</a>&lt;T&gt;(cap: &<b>mut</b> <a href="../sui/coin.md#sui_coin_TreasuryCap">TreasuryCap</a>&lt;T&gt;, c: <a href="../sui/coin.md#sui_coin_Coin">Coin</a>&lt;T&gt;): u64 {
-    <b>let</b> <a href="../sui/coin.md#sui_coin_Coin">Coin</a> { id, <a href="../sui/balance.md#sui_balance">balance</a> } = c;
+    <b>let</b> <a href="../sui/coin.md#sui_coin_Coin">Coin</a> { id, <a href="../sui/coin.md#sui_coin_balance">balance</a> } = c;
     id.delete();
-    cap.<a href="../sui/coin.md#sui_coin_total_supply">total_supply</a>.decrease_supply(<a href="../sui/balance.md#sui_balance">balance</a>)
+    cap.<a href="../sui/coin.md#sui_coin_total_supply">total_supply</a>.decrease_supply(<a href="../sui/coin.md#sui_coin_balance">balance</a>)
 }
 </code></pre>
 
@@ -1134,7 +1134,7 @@ coin type as an input to a transaction. Additionally at the start of the next ep
 address will be unable to receive objects of this coin type.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_deny_list_v2_add">deny_list_v2_add</a>&lt;T&gt;(<a href="../sui/deny_list.md#sui_deny_list">deny_list</a>: &<b>mut</b> <a href="../sui/deny_list.md#sui_deny_list_DenyList">sui::deny_list::DenyList</a>, _deny_cap: &<b>mut</b> <a href="../sui/coin.md#sui_coin_DenyCapV2">sui::coin::DenyCapV2</a>&lt;T&gt;, addr: <b>address</b>, ctx: &<b>mut</b> <a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_deny_list_v2_add">deny_list_v2_add</a>&lt;T&gt;(deny_list: &<b>mut</b> <a href="../sui/deny_list.md#sui_deny_list_DenyList">sui::deny_list::DenyList</a>, _deny_cap: &<b>mut</b> <a href="../sui/coin.md#sui_coin_DenyCapV2">sui::coin::DenyCapV2</a>&lt;T&gt;, addr: <b>address</b>, ctx: &<b>mut</b> <a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -1144,13 +1144,13 @@ address will be unable to receive objects of this coin type.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_deny_list_v2_add">deny_list_v2_add</a>&lt;T&gt;(
-    <a href="../sui/deny_list.md#sui_deny_list">deny_list</a>: &<b>mut</b> DenyList,
+    deny_list: &<b>mut</b> DenyList,
     _deny_cap: &<b>mut</b> <a href="../sui/coin.md#sui_coin_DenyCapV2">DenyCapV2</a>&lt;T&gt;,
     addr: <b>address</b>,
     ctx: &<b>mut</b> TxContext,
 ) {
     <b>let</b> ty = type_name::with_original_ids&lt;T&gt;().into_string().into_bytes();
-    <a href="../sui/deny_list.md#sui_deny_list">deny_list</a>.v2_add(<a href="../sui/coin.md#sui_coin_DENY_LIST_COIN_INDEX">DENY_LIST_COIN_INDEX</a>, ty, addr, ctx)
+    deny_list.v2_add(<a href="../sui/coin.md#sui_coin_DENY_LIST_COIN_INDEX">DENY_LIST_COIN_INDEX</a>, ty, addr, ctx)
 }
 </code></pre>
 
@@ -1167,7 +1167,7 @@ objects will be immediate, but the effect for receiving objects will be delayed 
 next epoch.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_deny_list_v2_remove">deny_list_v2_remove</a>&lt;T&gt;(<a href="../sui/deny_list.md#sui_deny_list">deny_list</a>: &<b>mut</b> <a href="../sui/deny_list.md#sui_deny_list_DenyList">sui::deny_list::DenyList</a>, _deny_cap: &<b>mut</b> <a href="../sui/coin.md#sui_coin_DenyCapV2">sui::coin::DenyCapV2</a>&lt;T&gt;, addr: <b>address</b>, ctx: &<b>mut</b> <a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_deny_list_v2_remove">deny_list_v2_remove</a>&lt;T&gt;(deny_list: &<b>mut</b> <a href="../sui/deny_list.md#sui_deny_list_DenyList">sui::deny_list::DenyList</a>, _deny_cap: &<b>mut</b> <a href="../sui/coin.md#sui_coin_DenyCapV2">sui::coin::DenyCapV2</a>&lt;T&gt;, addr: <b>address</b>, ctx: &<b>mut</b> <a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -1177,13 +1177,13 @@ next epoch.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_deny_list_v2_remove">deny_list_v2_remove</a>&lt;T&gt;(
-    <a href="../sui/deny_list.md#sui_deny_list">deny_list</a>: &<b>mut</b> DenyList,
+    deny_list: &<b>mut</b> DenyList,
     _deny_cap: &<b>mut</b> <a href="../sui/coin.md#sui_coin_DenyCapV2">DenyCapV2</a>&lt;T&gt;,
     addr: <b>address</b>,
     ctx: &<b>mut</b> TxContext,
 ) {
     <b>let</b> ty = type_name::with_original_ids&lt;T&gt;().into_string().into_bytes();
-    <a href="../sui/deny_list.md#sui_deny_list">deny_list</a>.v2_remove(<a href="../sui/coin.md#sui_coin_DENY_LIST_COIN_INDEX">DENY_LIST_COIN_INDEX</a>, ty, addr, ctx)
+    deny_list.v2_remove(<a href="../sui/coin.md#sui_coin_DENY_LIST_COIN_INDEX">DENY_LIST_COIN_INDEX</a>, ty, addr, ctx)
 }
 </code></pre>
 
@@ -1199,7 +1199,7 @@ Check if the deny list contains the given address for the current epoch. Denied 
 in the current epoch will be unable to receive objects of this coin type.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_deny_list_v2_contains_current_epoch">deny_list_v2_contains_current_epoch</a>&lt;T&gt;(<a href="../sui/deny_list.md#sui_deny_list">deny_list</a>: &<a href="../sui/deny_list.md#sui_deny_list_DenyList">sui::deny_list::DenyList</a>, addr: <b>address</b>, ctx: &<a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>): bool
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_deny_list_v2_contains_current_epoch">deny_list_v2_contains_current_epoch</a>&lt;T&gt;(deny_list: &<a href="../sui/deny_list.md#sui_deny_list_DenyList">sui::deny_list::DenyList</a>, addr: <b>address</b>, ctx: &<a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>): bool
 </code></pre>
 
 
@@ -1209,12 +1209,12 @@ in the current epoch will be unable to receive objects of this coin type.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_deny_list_v2_contains_current_epoch">deny_list_v2_contains_current_epoch</a>&lt;T&gt;(
-    <a href="../sui/deny_list.md#sui_deny_list">deny_list</a>: &DenyList,
+    deny_list: &DenyList,
     addr: <b>address</b>,
     ctx: &TxContext,
 ): bool {
     <b>let</b> ty = type_name::with_original_ids&lt;T&gt;().into_string().into_bytes();
-    <a href="../sui/deny_list.md#sui_deny_list">deny_list</a>.v2_contains_current_epoch(<a href="../sui/coin.md#sui_coin_DENY_LIST_COIN_INDEX">DENY_LIST_COIN_INDEX</a>, ty, addr, ctx)
+    deny_list.v2_contains_current_epoch(<a href="../sui/coin.md#sui_coin_DENY_LIST_COIN_INDEX">DENY_LIST_COIN_INDEX</a>, ty, addr, ctx)
 }
 </code></pre>
 
@@ -1231,7 +1231,7 @@ the next epoch will immediately be unable to use objects of this coin type as in
 start of the next epoch, the address will be unable to receive objects of this coin type.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_deny_list_v2_contains_next_epoch">deny_list_v2_contains_next_epoch</a>&lt;T&gt;(<a href="../sui/deny_list.md#sui_deny_list">deny_list</a>: &<a href="../sui/deny_list.md#sui_deny_list_DenyList">sui::deny_list::DenyList</a>, addr: <b>address</b>): bool
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_deny_list_v2_contains_next_epoch">deny_list_v2_contains_next_epoch</a>&lt;T&gt;(deny_list: &<a href="../sui/deny_list.md#sui_deny_list_DenyList">sui::deny_list::DenyList</a>, addr: <b>address</b>): bool
 </code></pre>
 
 
@@ -1240,9 +1240,9 @@ start of the next epoch, the address will be unable to receive objects of this c
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_deny_list_v2_contains_next_epoch">deny_list_v2_contains_next_epoch</a>&lt;T&gt;(<a href="../sui/deny_list.md#sui_deny_list">deny_list</a>: &DenyList, addr: <b>address</b>): bool {
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_deny_list_v2_contains_next_epoch">deny_list_v2_contains_next_epoch</a>&lt;T&gt;(deny_list: &DenyList, addr: <b>address</b>): bool {
     <b>let</b> ty = type_name::with_original_ids&lt;T&gt;().into_string().into_bytes();
-    <a href="../sui/deny_list.md#sui_deny_list">deny_list</a>.v2_contains_next_epoch(<a href="../sui/coin.md#sui_coin_DENY_LIST_COIN_INDEX">DENY_LIST_COIN_INDEX</a>, ty, addr)
+    deny_list.v2_contains_next_epoch(<a href="../sui/coin.md#sui_coin_DENY_LIST_COIN_INDEX">DENY_LIST_COIN_INDEX</a>, ty, addr)
 }
 </code></pre>
 
@@ -1259,7 +1259,7 @@ from using objects of this coin type as inputs. At the start of the next epoch, 
 addresses will be unable to receive objects of this coin type.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_deny_list_v2_enable_global_pause">deny_list_v2_enable_global_pause</a>&lt;T&gt;(<a href="../sui/deny_list.md#sui_deny_list">deny_list</a>: &<b>mut</b> <a href="../sui/deny_list.md#sui_deny_list_DenyList">sui::deny_list::DenyList</a>, deny_cap: &<b>mut</b> <a href="../sui/coin.md#sui_coin_DenyCapV2">sui::coin::DenyCapV2</a>&lt;T&gt;, ctx: &<b>mut</b> <a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_deny_list_v2_enable_global_pause">deny_list_v2_enable_global_pause</a>&lt;T&gt;(deny_list: &<b>mut</b> <a href="../sui/deny_list.md#sui_deny_list_DenyList">sui::deny_list::DenyList</a>, deny_cap: &<b>mut</b> <a href="../sui/coin.md#sui_coin_DenyCapV2">sui::coin::DenyCapV2</a>&lt;T&gt;, ctx: &<b>mut</b> <a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -1269,13 +1269,13 @@ addresses will be unable to receive objects of this coin type.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_deny_list_v2_enable_global_pause">deny_list_v2_enable_global_pause</a>&lt;T&gt;(
-    <a href="../sui/deny_list.md#sui_deny_list">deny_list</a>: &<b>mut</b> DenyList,
+    deny_list: &<b>mut</b> DenyList,
     deny_cap: &<b>mut</b> <a href="../sui/coin.md#sui_coin_DenyCapV2">DenyCapV2</a>&lt;T&gt;,
     ctx: &<b>mut</b> TxContext,
 ) {
     <b>assert</b>!(deny_cap.<a href="../sui/coin.md#sui_coin_allow_global_pause">allow_global_pause</a>, <a href="../sui/coin.md#sui_coin_EGlobalPauseNotAllowed">EGlobalPauseNotAllowed</a>);
     <b>let</b> ty = type_name::with_original_ids&lt;T&gt;().into_string().into_bytes();
-    <a href="../sui/deny_list.md#sui_deny_list">deny_list</a>.v2_enable_global_pause(<a href="../sui/coin.md#sui_coin_DENY_LIST_COIN_INDEX">DENY_LIST_COIN_INDEX</a>, ty, ctx)
+    deny_list.v2_enable_global_pause(<a href="../sui/coin.md#sui_coin_DENY_LIST_COIN_INDEX">DENY_LIST_COIN_INDEX</a>, ty, ctx)
 }
 </code></pre>
 
@@ -1292,7 +1292,7 @@ to resume using objects of this coin type as inputs. However, receiving objects 
 type will still be paused until the start of the next epoch.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_deny_list_v2_disable_global_pause">deny_list_v2_disable_global_pause</a>&lt;T&gt;(<a href="../sui/deny_list.md#sui_deny_list">deny_list</a>: &<b>mut</b> <a href="../sui/deny_list.md#sui_deny_list_DenyList">sui::deny_list::DenyList</a>, deny_cap: &<b>mut</b> <a href="../sui/coin.md#sui_coin_DenyCapV2">sui::coin::DenyCapV2</a>&lt;T&gt;, ctx: &<b>mut</b> <a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_deny_list_v2_disable_global_pause">deny_list_v2_disable_global_pause</a>&lt;T&gt;(deny_list: &<b>mut</b> <a href="../sui/deny_list.md#sui_deny_list_DenyList">sui::deny_list::DenyList</a>, deny_cap: &<b>mut</b> <a href="../sui/coin.md#sui_coin_DenyCapV2">sui::coin::DenyCapV2</a>&lt;T&gt;, ctx: &<b>mut</b> <a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -1302,13 +1302,13 @@ type will still be paused until the start of the next epoch.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_deny_list_v2_disable_global_pause">deny_list_v2_disable_global_pause</a>&lt;T&gt;(
-    <a href="../sui/deny_list.md#sui_deny_list">deny_list</a>: &<b>mut</b> DenyList,
+    deny_list: &<b>mut</b> DenyList,
     deny_cap: &<b>mut</b> <a href="../sui/coin.md#sui_coin_DenyCapV2">DenyCapV2</a>&lt;T&gt;,
     ctx: &<b>mut</b> TxContext,
 ) {
     <b>assert</b>!(deny_cap.<a href="../sui/coin.md#sui_coin_allow_global_pause">allow_global_pause</a>, <a href="../sui/coin.md#sui_coin_EGlobalPauseNotAllowed">EGlobalPauseNotAllowed</a>);
     <b>let</b> ty = type_name::with_original_ids&lt;T&gt;().into_string().into_bytes();
-    <a href="../sui/deny_list.md#sui_deny_list">deny_list</a>.v2_disable_global_pause(<a href="../sui/coin.md#sui_coin_DENY_LIST_COIN_INDEX">DENY_LIST_COIN_INDEX</a>, ty, ctx)
+    deny_list.v2_disable_global_pause(<a href="../sui/coin.md#sui_coin_DENY_LIST_COIN_INDEX">DENY_LIST_COIN_INDEX</a>, ty, ctx)
 }
 </code></pre>
 
@@ -1323,7 +1323,7 @@ type will still be paused until the start of the next epoch.
 Check if the global pause is enabled for the given coin type in the current epoch.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_deny_list_v2_is_global_pause_enabled_current_epoch">deny_list_v2_is_global_pause_enabled_current_epoch</a>&lt;T&gt;(<a href="../sui/deny_list.md#sui_deny_list">deny_list</a>: &<a href="../sui/deny_list.md#sui_deny_list_DenyList">sui::deny_list::DenyList</a>, ctx: &<a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>): bool
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_deny_list_v2_is_global_pause_enabled_current_epoch">deny_list_v2_is_global_pause_enabled_current_epoch</a>&lt;T&gt;(deny_list: &<a href="../sui/deny_list.md#sui_deny_list_DenyList">sui::deny_list::DenyList</a>, ctx: &<a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>): bool
 </code></pre>
 
 
@@ -1333,11 +1333,11 @@ Check if the global pause is enabled for the given coin type in the current epoc
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_deny_list_v2_is_global_pause_enabled_current_epoch">deny_list_v2_is_global_pause_enabled_current_epoch</a>&lt;T&gt;(
-    <a href="../sui/deny_list.md#sui_deny_list">deny_list</a>: &DenyList,
+    deny_list: &DenyList,
     ctx: &TxContext,
 ): bool {
     <b>let</b> ty = type_name::with_original_ids&lt;T&gt;().into_string().into_bytes();
-    <a href="../sui/deny_list.md#sui_deny_list">deny_list</a>.v2_is_global_pause_enabled_current_epoch(<a href="../sui/coin.md#sui_coin_DENY_LIST_COIN_INDEX">DENY_LIST_COIN_INDEX</a>, ty, ctx)
+    deny_list.v2_is_global_pause_enabled_current_epoch(<a href="../sui/coin.md#sui_coin_DENY_LIST_COIN_INDEX">DENY_LIST_COIN_INDEX</a>, ty, ctx)
 }
 </code></pre>
 
@@ -1352,7 +1352,7 @@ Check if the global pause is enabled for the given coin type in the current epoc
 Check if the global pause is enabled for the given coin type in the next epoch.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_deny_list_v2_is_global_pause_enabled_next_epoch">deny_list_v2_is_global_pause_enabled_next_epoch</a>&lt;T&gt;(<a href="../sui/deny_list.md#sui_deny_list">deny_list</a>: &<a href="../sui/deny_list.md#sui_deny_list_DenyList">sui::deny_list::DenyList</a>): bool
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_deny_list_v2_is_global_pause_enabled_next_epoch">deny_list_v2_is_global_pause_enabled_next_epoch</a>&lt;T&gt;(deny_list: &<a href="../sui/deny_list.md#sui_deny_list_DenyList">sui::deny_list::DenyList</a>): bool
 </code></pre>
 
 
@@ -1361,9 +1361,9 @@ Check if the global pause is enabled for the given coin type in the next epoch.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_deny_list_v2_is_global_pause_enabled_next_epoch">deny_list_v2_is_global_pause_enabled_next_epoch</a>&lt;T&gt;(<a href="../sui/deny_list.md#sui_deny_list">deny_list</a>: &DenyList): bool {
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_deny_list_v2_is_global_pause_enabled_next_epoch">deny_list_v2_is_global_pause_enabled_next_epoch</a>&lt;T&gt;(deny_list: &DenyList): bool {
     <b>let</b> ty = type_name::with_original_ids&lt;T&gt;().into_string().into_bytes();
-    <a href="../sui/deny_list.md#sui_deny_list">deny_list</a>.v2_is_global_pause_enabled_next_epoch(<a href="../sui/coin.md#sui_coin_DENY_LIST_COIN_INDEX">DENY_LIST_COIN_INDEX</a>, ty)
+    deny_list.v2_is_global_pause_enabled_next_epoch(<a href="../sui/coin.md#sui_coin_DENY_LIST_COIN_INDEX">DENY_LIST_COIN_INDEX</a>, ty)
 }
 </code></pre>
 
@@ -1393,7 +1393,7 @@ Mint <code>amount</code> of <code><a href="../sui/coin.md#sui_coin_Coin">Coin</a
     recipient: <b>address</b>,
     ctx: &<b>mut</b> TxContext,
 ) {
-    <a href="../sui/transfer.md#sui_transfer_public_transfer">transfer::public_transfer</a>(c.<a href="../sui/coin.md#sui_coin_mint">mint</a>(amount, ctx), recipient)
+    transfer::public_transfer(c.<a href="../sui/coin.md#sui_coin_mint">mint</a>(amount, ctx), recipient)
 }
 </code></pre>
 
@@ -1495,7 +1495,7 @@ Update the description of the coin in <code><a href="../sui/coin.md#sui_coin_Coi
 Update the url of the coin in <code><a href="../sui/coin.md#sui_coin_CoinMetadata">CoinMetadata</a></code>
 
 
-<pre><code><b>public</b> <b>entry</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_update_icon_url">update_icon_url</a>&lt;T&gt;(_treasury: &<a href="../sui/coin.md#sui_coin_TreasuryCap">sui::coin::TreasuryCap</a>&lt;T&gt;, metadata: &<b>mut</b> <a href="../sui/coin.md#sui_coin_CoinMetadata">sui::coin::CoinMetadata</a>&lt;T&gt;, <a href="../sui/url.md#sui_url">url</a>: <a href="../std/ascii.md#std_ascii_String">std::ascii::String</a>)
+<pre><code><b>public</b> <b>entry</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_update_icon_url">update_icon_url</a>&lt;T&gt;(_treasury: &<a href="../sui/coin.md#sui_coin_TreasuryCap">sui::coin::TreasuryCap</a>&lt;T&gt;, metadata: &<b>mut</b> <a href="../sui/coin.md#sui_coin_CoinMetadata">sui::coin::CoinMetadata</a>&lt;T&gt;, url: <a href="../std/ascii.md#std_ascii_String">std::ascii::String</a>)
 </code></pre>
 
 
@@ -1507,9 +1507,9 @@ Update the url of the coin in <code><a href="../sui/coin.md#sui_coin_CoinMetadat
 <pre><code><b>public</b> <b>entry</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_update_icon_url">update_icon_url</a>&lt;T&gt;(
     _treasury: &<a href="../sui/coin.md#sui_coin_TreasuryCap">TreasuryCap</a>&lt;T&gt;,
     metadata: &<b>mut</b> <a href="../sui/coin.md#sui_coin_CoinMetadata">CoinMetadata</a>&lt;T&gt;,
-    <a href="../sui/url.md#sui_url">url</a>: ascii::String,
+    url: ascii::String,
 ) {
-    metadata.icon_url = option::some(<a href="../sui/url.md#sui_url_new_unsafe">url::new_unsafe</a>(<a href="../sui/url.md#sui_url">url</a>));
+    metadata.icon_url = option::some(url::new_unsafe(url));
 }
 </code></pre>
 
@@ -1644,7 +1644,7 @@ Update the url of the coin in <code><a href="../sui/coin.md#sui_coin_CoinMetadat
 Destroy legacy <code><a href="../sui/coin.md#sui_coin_CoinMetadata">CoinMetadata</a></code> object
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/coin.md#sui_coin_destroy_metadata">destroy_metadata</a>&lt;T&gt;(metadata: <a href="../sui/coin.md#sui_coin_CoinMetadata">sui::coin::CoinMetadata</a>&lt;T&gt;)
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/coin.md#sui_coin_destroy_metadata">destroy_metadata</a>&lt;T&gt;(metadata: <a href="../sui/coin.md#sui_coin_CoinMetadata">sui::coin::CoinMetadata</a>&lt;T&gt;)
 </code></pre>
 
 
@@ -1653,7 +1653,7 @@ Destroy legacy <code><a href="../sui/coin.md#sui_coin_CoinMetadata">CoinMetadata
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/coin.md#sui_coin_destroy_metadata">destroy_metadata</a>&lt;T&gt;(metadata: <a href="../sui/coin.md#sui_coin_CoinMetadata">CoinMetadata</a>&lt;T&gt;) {
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/coin.md#sui_coin_destroy_metadata">destroy_metadata</a>&lt;T&gt;(metadata: <a href="../sui/coin.md#sui_coin_CoinMetadata">CoinMetadata</a>&lt;T&gt;) {
     <b>let</b> <a href="../sui/coin.md#sui_coin_CoinMetadata">CoinMetadata</a> { id, .. } = metadata;
     id.delete()
 }
@@ -1669,7 +1669,7 @@ Destroy legacy <code><a href="../sui/coin.md#sui_coin_CoinMetadata">CoinMetadata
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/coin.md#sui_coin_deny_cap_id">deny_cap_id</a>&lt;T&gt;(metadata: &<a href="../sui/coin.md#sui_coin_RegulatedCoinMetadata">sui::coin::RegulatedCoinMetadata</a>&lt;T&gt;): <a href="../sui/object.md#sui_object_ID">sui::object::ID</a>
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/coin.md#sui_coin_deny_cap_id">deny_cap_id</a>&lt;T&gt;(metadata: &<a href="../sui/coin.md#sui_coin_RegulatedCoinMetadata">sui::coin::RegulatedCoinMetadata</a>&lt;T&gt;): <a href="../sui/object.md#sui_object_ID">sui::object::ID</a>
 </code></pre>
 
 
@@ -1678,7 +1678,7 @@ Destroy legacy <code><a href="../sui/coin.md#sui_coin_CoinMetadata">CoinMetadata
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/coin.md#sui_coin_deny_cap_id">deny_cap_id</a>&lt;T&gt;(metadata: &<a href="../sui/coin.md#sui_coin_RegulatedCoinMetadata">RegulatedCoinMetadata</a>&lt;T&gt;): ID {
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/coin.md#sui_coin_deny_cap_id">deny_cap_id</a>&lt;T&gt;(metadata: &<a href="../sui/coin.md#sui_coin_RegulatedCoinMetadata">RegulatedCoinMetadata</a>&lt;T&gt;): ID {
     metadata.deny_cap_object
 }
 </code></pre>
@@ -1693,7 +1693,7 @@ Destroy legacy <code><a href="../sui/coin.md#sui_coin_CoinMetadata">CoinMetadata
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/coin.md#sui_coin_new_deny_cap_v2">new_deny_cap_v2</a>&lt;T&gt;(<a href="../sui/coin.md#sui_coin_allow_global_pause">allow_global_pause</a>: bool, ctx: &<b>mut</b> <a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>): <a href="../sui/coin.md#sui_coin_DenyCapV2">sui::coin::DenyCapV2</a>&lt;T&gt;
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/coin.md#sui_coin_new_deny_cap_v2">new_deny_cap_v2</a>&lt;T&gt;(<a href="../sui/coin.md#sui_coin_allow_global_pause">allow_global_pause</a>: bool, ctx: &<b>mut</b> <a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>): <a href="../sui/coin.md#sui_coin_DenyCapV2">sui::coin::DenyCapV2</a>&lt;T&gt;
 </code></pre>
 
 
@@ -1702,12 +1702,12 @@ Destroy legacy <code><a href="../sui/coin.md#sui_coin_CoinMetadata">CoinMetadata
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/coin.md#sui_coin_new_deny_cap_v2">new_deny_cap_v2</a>&lt;T&gt;(
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/coin.md#sui_coin_new_deny_cap_v2">new_deny_cap_v2</a>&lt;T&gt;(
     <a href="../sui/coin.md#sui_coin_allow_global_pause">allow_global_pause</a>: bool,
     ctx: &<b>mut</b> TxContext,
 ): <a href="../sui/coin.md#sui_coin_DenyCapV2">DenyCapV2</a>&lt;T&gt; {
     <a href="../sui/coin.md#sui_coin_DenyCapV2">DenyCapV2</a> {
-        id: <a href="../sui/object.md#sui_object_new">object::new</a>(ctx),
+        id: object::new(ctx),
         <a href="../sui/coin.md#sui_coin_allow_global_pause">allow_global_pause</a>,
     }
 }
@@ -1723,7 +1723,7 @@ Destroy legacy <code><a href="../sui/coin.md#sui_coin_CoinMetadata">CoinMetadata
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/coin.md#sui_coin_new_treasury_cap">new_treasury_cap</a>&lt;T&gt;(ctx: &<b>mut</b> <a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>): <a href="../sui/coin.md#sui_coin_TreasuryCap">sui::coin::TreasuryCap</a>&lt;T&gt;
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/coin.md#sui_coin_new_treasury_cap">new_treasury_cap</a>&lt;T&gt;(ctx: &<b>mut</b> <a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>): <a href="../sui/coin.md#sui_coin_TreasuryCap">sui::coin::TreasuryCap</a>&lt;T&gt;
 </code></pre>
 
 
@@ -1732,10 +1732,10 @@ Destroy legacy <code><a href="../sui/coin.md#sui_coin_CoinMetadata">CoinMetadata
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/coin.md#sui_coin_new_treasury_cap">new_treasury_cap</a>&lt;T&gt;(ctx: &<b>mut</b> TxContext): <a href="../sui/coin.md#sui_coin_TreasuryCap">TreasuryCap</a>&lt;T&gt; {
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/coin.md#sui_coin_new_treasury_cap">new_treasury_cap</a>&lt;T&gt;(ctx: &<b>mut</b> TxContext): <a href="../sui/coin.md#sui_coin_TreasuryCap">TreasuryCap</a>&lt;T&gt; {
     <a href="../sui/coin.md#sui_coin_TreasuryCap">TreasuryCap</a> {
-        id: <a href="../sui/object.md#sui_object_new">object::new</a>(ctx),
-        <a href="../sui/coin.md#sui_coin_total_supply">total_supply</a>: <a href="../sui/balance.md#sui_balance_create_supply_internal">balance::create_supply_internal</a>(),
+        id: object::new(ctx),
+        <a href="../sui/coin.md#sui_coin_total_supply">total_supply</a>: balance::create_supply_internal(),
     }
 }
 </code></pre>
@@ -1750,7 +1750,7 @@ Destroy legacy <code><a href="../sui/coin.md#sui_coin_CoinMetadata">CoinMetadata
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/coin.md#sui_coin_allow_global_pause">allow_global_pause</a>&lt;T&gt;(cap: &<a href="../sui/coin.md#sui_coin_DenyCapV2">sui::coin::DenyCapV2</a>&lt;T&gt;): bool
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/coin.md#sui_coin_allow_global_pause">allow_global_pause</a>&lt;T&gt;(cap: &<a href="../sui/coin.md#sui_coin_DenyCapV2">sui::coin::DenyCapV2</a>&lt;T&gt;): bool
 </code></pre>
 
 
@@ -1759,7 +1759,7 @@ Destroy legacy <code><a href="../sui/coin.md#sui_coin_CoinMetadata">CoinMetadata
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/coin.md#sui_coin_allow_global_pause">allow_global_pause</a>&lt;T&gt;(cap: &<a href="../sui/coin.md#sui_coin_DenyCapV2">DenyCapV2</a>&lt;T&gt;): bool {
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/coin.md#sui_coin_allow_global_pause">allow_global_pause</a>&lt;T&gt;(cap: &<a href="../sui/coin.md#sui_coin_DenyCapV2">DenyCapV2</a>&lt;T&gt;): bool {
     cap.<a href="../sui/coin.md#sui_coin_allow_global_pause">allow_global_pause</a>
 }
 </code></pre>
@@ -1774,7 +1774,7 @@ Destroy legacy <code><a href="../sui/coin.md#sui_coin_CoinMetadata">CoinMetadata
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/coin.md#sui_coin_new_coin_metadata">new_coin_metadata</a>&lt;T&gt;(decimals: u8, name: <a href="../std/string.md#std_string_String">std::string::String</a>, symbol: <a href="../std/ascii.md#std_ascii_String">std::ascii::String</a>, description: <a href="../std/string.md#std_string_String">std::string::String</a>, icon_url: <a href="../std/ascii.md#std_ascii_String">std::ascii::String</a>, ctx: &<b>mut</b> <a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>): <a href="../sui/coin.md#sui_coin_CoinMetadata">sui::coin::CoinMetadata</a>&lt;T&gt;
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/coin.md#sui_coin_new_coin_metadata">new_coin_metadata</a>&lt;T&gt;(decimals: u8, name: <a href="../std/string.md#std_string_String">std::string::String</a>, symbol: <a href="../std/ascii.md#std_ascii_String">std::ascii::String</a>, description: <a href="../std/string.md#std_string_String">std::string::String</a>, icon_url: <a href="../std/ascii.md#std_ascii_String">std::ascii::String</a>, ctx: &<b>mut</b> <a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>): <a href="../sui/coin.md#sui_coin_CoinMetadata">sui::coin::CoinMetadata</a>&lt;T&gt;
 </code></pre>
 
 
@@ -1783,7 +1783,7 @@ Destroy legacy <code><a href="../sui/coin.md#sui_coin_CoinMetadata">CoinMetadata
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/coin.md#sui_coin_new_coin_metadata">new_coin_metadata</a>&lt;T&gt;(
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/coin.md#sui_coin_new_coin_metadata">new_coin_metadata</a>&lt;T&gt;(
     decimals: u8,
     name: string::String,
     symbol: ascii::String,
@@ -1792,12 +1792,12 @@ Destroy legacy <code><a href="../sui/coin.md#sui_coin_CoinMetadata">CoinMetadata
     ctx: &<b>mut</b> TxContext,
 ): <a href="../sui/coin.md#sui_coin_CoinMetadata">CoinMetadata</a>&lt;T&gt; {
     <a href="../sui/coin.md#sui_coin_CoinMetadata">CoinMetadata</a> {
-        id: <a href="../sui/object.md#sui_object_new">object::new</a>(ctx),
+        id: object::new(ctx),
         decimals,
         name,
         symbol,
         description,
-        icon_url: option::some(<a href="../sui/url.md#sui_url_new_unsafe">url::new_unsafe</a>(icon_url)),
+        icon_url: option::some(url::new_unsafe(icon_url)),
     }
 }
 </code></pre>
@@ -1814,7 +1814,7 @@ Internal function to refresh the <code><a href="../sui/coin.md#sui_coin_CoinMeta
 <code>CoinRegistry</code> borrowing.
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/coin.md#sui_coin_update_coin_metadata">update_coin_metadata</a>&lt;T&gt;(metadata: &<b>mut</b> <a href="../sui/coin.md#sui_coin_CoinMetadata">sui::coin::CoinMetadata</a>&lt;T&gt;, name: <a href="../std/string.md#std_string_String">std::string::String</a>, symbol: <a href="../std/ascii.md#std_ascii_String">std::ascii::String</a>, description: <a href="../std/string.md#std_string_String">std::string::String</a>, icon_url: <a href="../std/ascii.md#std_ascii_String">std::ascii::String</a>)
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/coin.md#sui_coin_update_coin_metadata">update_coin_metadata</a>&lt;T&gt;(metadata: &<b>mut</b> <a href="../sui/coin.md#sui_coin_CoinMetadata">sui::coin::CoinMetadata</a>&lt;T&gt;, name: <a href="../std/string.md#std_string_String">std::string::String</a>, symbol: <a href="../std/ascii.md#std_ascii_String">std::ascii::String</a>, description: <a href="../std/string.md#std_string_String">std::string::String</a>, icon_url: <a href="../std/ascii.md#std_ascii_String">std::ascii::String</a>)
 </code></pre>
 
 
@@ -1823,7 +1823,7 @@ Internal function to refresh the <code><a href="../sui/coin.md#sui_coin_CoinMeta
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/coin.md#sui_coin_update_coin_metadata">update_coin_metadata</a>&lt;T&gt;(
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/coin.md#sui_coin_update_coin_metadata">update_coin_metadata</a>&lt;T&gt;(
     metadata: &<b>mut</b> <a href="../sui/coin.md#sui_coin_CoinMetadata">CoinMetadata</a>&lt;T&gt;,
     name: string::String,
     symbol: ascii::String,
@@ -1833,7 +1833,7 @@ Internal function to refresh the <code><a href="../sui/coin.md#sui_coin_CoinMeta
     metadata.name = name;
     metadata.symbol = symbol;
     metadata.description = description;
-    metadata.icon_url = option::some(<a href="../sui/url.md#sui_url_new_unsafe">url::new_unsafe</a>(icon_url));
+    metadata.icon_url = option::some(url::new_unsafe(icon_url));
 }
 </code></pre>
 
@@ -1902,12 +1902,12 @@ with the coin as input objects.
         ctx,
     );
     <b>let</b> deny_cap = <a href="../sui/coin.md#sui_coin_DenyCap">DenyCap</a> {
-        id: <a href="../sui/object.md#sui_object_new">object::new</a>(ctx),
+        id: object::new(ctx),
     };
-    <a href="../sui/transfer.md#sui_transfer_freeze_object">transfer::freeze_object</a>(<a href="../sui/coin.md#sui_coin_RegulatedCoinMetadata">RegulatedCoinMetadata</a>&lt;T&gt; {
-        id: <a href="../sui/object.md#sui_object_new">object::new</a>(ctx),
-        coin_metadata_object: <a href="../sui/object.md#sui_object_id">object::id</a>(&metadata),
-        deny_cap_object: <a href="../sui/object.md#sui_object_id">object::id</a>(&deny_cap),
+    transfer::freeze_object(<a href="../sui/coin.md#sui_coin_RegulatedCoinMetadata">RegulatedCoinMetadata</a>&lt;T&gt; {
+        id: object::new(ctx),
+        coin_metadata_object: object::id(&metadata),
+        deny_cap_object: object::id(&deny_cap),
     });
     (treasury_cap, deny_cap, metadata)
 }
@@ -1925,7 +1925,7 @@ Adds the given address to the deny list, preventing it
 from interacting with the specified coin type as an input to a transaction.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_deny_list_add">deny_list_add</a>&lt;T&gt;(<a href="../sui/deny_list.md#sui_deny_list">deny_list</a>: &<b>mut</b> <a href="../sui/deny_list.md#sui_deny_list_DenyList">sui::deny_list::DenyList</a>, _deny_cap: &<b>mut</b> <a href="../sui/coin.md#sui_coin_DenyCap">sui::coin::DenyCap</a>&lt;T&gt;, addr: <b>address</b>, _ctx: &<b>mut</b> <a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_deny_list_add">deny_list_add</a>&lt;T&gt;(deny_list: &<b>mut</b> <a href="../sui/deny_list.md#sui_deny_list_DenyList">sui::deny_list::DenyList</a>, _deny_cap: &<b>mut</b> <a href="../sui/coin.md#sui_coin_DenyCap">sui::coin::DenyCap</a>&lt;T&gt;, addr: <b>address</b>, _ctx: &<b>mut</b> <a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -1935,13 +1935,13 @@ from interacting with the specified coin type as an input to a transaction.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_deny_list_add">deny_list_add</a>&lt;T&gt;(
-    <a href="../sui/deny_list.md#sui_deny_list">deny_list</a>: &<b>mut</b> DenyList,
+    deny_list: &<b>mut</b> DenyList,
     _deny_cap: &<b>mut</b> <a href="../sui/coin.md#sui_coin_DenyCap">DenyCap</a>&lt;T&gt;,
     addr: <b>address</b>,
     _ctx: &<b>mut</b> TxContext,
 ) {
     <b>let</b> `type` = type_name::into_string(type_name::get_with_original_ids&lt;T&gt;()).into_bytes();
-    <a href="../sui/deny_list.md#sui_deny_list">deny_list</a>.v1_add(<a href="../sui/coin.md#sui_coin_DENY_LIST_COIN_INDEX">DENY_LIST_COIN_INDEX</a>, `type`, addr)
+    deny_list.v1_add(<a href="../sui/coin.md#sui_coin_DENY_LIST_COIN_INDEX">DENY_LIST_COIN_INDEX</a>, `type`, addr)
 }
 </code></pre>
 
@@ -1957,7 +1957,7 @@ Removes an address from the deny list.
 Aborts with <code>ENotFrozen</code> if the address is not already in the list.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_deny_list_remove">deny_list_remove</a>&lt;T&gt;(<a href="../sui/deny_list.md#sui_deny_list">deny_list</a>: &<b>mut</b> <a href="../sui/deny_list.md#sui_deny_list_DenyList">sui::deny_list::DenyList</a>, _deny_cap: &<b>mut</b> <a href="../sui/coin.md#sui_coin_DenyCap">sui::coin::DenyCap</a>&lt;T&gt;, addr: <b>address</b>, _ctx: &<b>mut</b> <a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_deny_list_remove">deny_list_remove</a>&lt;T&gt;(deny_list: &<b>mut</b> <a href="../sui/deny_list.md#sui_deny_list_DenyList">sui::deny_list::DenyList</a>, _deny_cap: &<b>mut</b> <a href="../sui/coin.md#sui_coin_DenyCap">sui::coin::DenyCap</a>&lt;T&gt;, addr: <b>address</b>, _ctx: &<b>mut</b> <a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -1967,13 +1967,13 @@ Aborts with <code>ENotFrozen</code> if the address is not already in the list.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_deny_list_remove">deny_list_remove</a>&lt;T&gt;(
-    <a href="../sui/deny_list.md#sui_deny_list">deny_list</a>: &<b>mut</b> DenyList,
+    deny_list: &<b>mut</b> DenyList,
     _deny_cap: &<b>mut</b> <a href="../sui/coin.md#sui_coin_DenyCap">DenyCap</a>&lt;T&gt;,
     addr: <b>address</b>,
     _ctx: &<b>mut</b> TxContext,
 ) {
     <b>let</b> `type` = type_name::into_string(type_name::get_with_original_ids&lt;T&gt;()).into_bytes();
-    <a href="../sui/deny_list.md#sui_deny_list">deny_list</a>.v1_remove(<a href="../sui/coin.md#sui_coin_DENY_LIST_COIN_INDEX">DENY_LIST_COIN_INDEX</a>, `type`, addr)
+    deny_list.v1_remove(<a href="../sui/coin.md#sui_coin_DENY_LIST_COIN_INDEX">DENY_LIST_COIN_INDEX</a>, `type`, addr)
 }
 </code></pre>
 
@@ -1989,7 +1989,7 @@ Returns true iff the given address is denied for the given coin type. It will
 return false if given a non-coin type.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_deny_list_contains">deny_list_contains</a>&lt;T&gt;(<a href="../sui/deny_list.md#sui_deny_list">deny_list</a>: &<a href="../sui/deny_list.md#sui_deny_list_DenyList">sui::deny_list::DenyList</a>, addr: <b>address</b>): bool
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_deny_list_contains">deny_list_contains</a>&lt;T&gt;(deny_list: &<a href="../sui/deny_list.md#sui_deny_list_DenyList">sui::deny_list::DenyList</a>, addr: <b>address</b>): bool
 </code></pre>
 
 
@@ -1998,11 +1998,11 @@ return false if given a non-coin type.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_deny_list_contains">deny_list_contains</a>&lt;T&gt;(<a href="../sui/deny_list.md#sui_deny_list">deny_list</a>: &DenyList, addr: <b>address</b>): bool {
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/coin.md#sui_coin_deny_list_contains">deny_list_contains</a>&lt;T&gt;(deny_list: &DenyList, addr: <b>address</b>): bool {
     <b>let</b> name = type_name::get_with_original_ids&lt;T&gt;();
     <b>if</b> (type_name::is_primitive(&name)) <b>return</b> <b>false</b>;
     <b>let</b> `type` = type_name::into_string(name).into_bytes();
-    <a href="../sui/deny_list.md#sui_deny_list">deny_list</a>.v1_contains(<a href="../sui/coin.md#sui_coin_DENY_LIST_COIN_INDEX">DENY_LIST_COIN_INDEX</a>, `type`, addr)
+    deny_list.v1_contains(<a href="../sui/coin.md#sui_coin_DENY_LIST_COIN_INDEX">DENY_LIST_COIN_INDEX</a>, `type`, addr)
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/sui/coin_registry.md
+++ b/crates/sui-framework/docs/sui/coin_registry.md
@@ -521,7 +521,7 @@ Variant <code>Unknown</code>
 </dt>
 <dd>
  Regulatory status is unknown.
- Result of a legacy migration for that coin (from <code><a href="../sui/coin.md#sui_coin">coin</a>.<b>move</b></code> constructors)
+ Result of a legacy migration for that coin (from <code>coin.<b>move</b></code> constructors)
 </dd>
 </dl>
 
@@ -610,7 +610,7 @@ Currency for this coin type already exists
 
 
 <pre><code>#[error]
-<b>const</b> <a href="../sui/coin_registry.md#sui_coin_registry_ECurrencyAlreadyExists">ECurrencyAlreadyExists</a>: vector&lt;u8&gt; = b"<a href="../sui/coin_registry.md#sui_coin_registry_Currency">Currency</a> <b>for</b> this <a href="../sui/coin.md#sui_coin">coin</a> type already <a href="../sui/coin_registry.md#sui_coin_registry_exists">exists</a>.";
+<b>const</b> <a href="../sui/coin_registry.md#sui_coin_registry_ECurrencyAlreadyExists">ECurrencyAlreadyExists</a>: vector&lt;u8&gt; = b"<a href="../sui/coin_registry.md#sui_coin_registry_Currency">Currency</a> <b>for</b> this coin type already <a href="../sui/coin_registry.md#sui_coin_registry_exists">exists</a>.";
 </code></pre>
 
 
@@ -726,7 +726,7 @@ Attempt to migrate legacy metadata for a <code><a href="../sui/coin_registry.md#
 
 
 <pre><code>#[error]
-<b>const</b> <a href="../sui/coin_registry.md#sui_coin_registry_EBorrowLegacyMetadata">EBorrowLegacyMetadata</a>: vector&lt;u8&gt; = b"Cannot <a href="../sui/borrow.md#sui_borrow">borrow</a> legacy metadata <b>for</b> migrated currency";
+<b>const</b> <a href="../sui/coin_registry.md#sui_coin_registry_EBorrowLegacyMetadata">EBorrowLegacyMetadata</a>: vector&lt;u8&gt; = b"Cannot borrow legacy metadata <b>for</b> migrated currency";
 </code></pre>
 
 
@@ -792,9 +792,9 @@ This can be called from the module that defines <code>T</code> any time after it
 ): (<a href="../sui/coin_registry.md#sui_coin_registry_CurrencyInitializer">CurrencyInitializer</a>&lt;T&gt;, TreasuryCap&lt;T&gt;) {
     <b>assert</b>!(!registry.<a href="../sui/coin_registry.md#sui_coin_registry_exists">exists</a>&lt;T&gt;(), <a href="../sui/coin_registry.md#sui_coin_registry_ECurrencyAlreadyExists">ECurrencyAlreadyExists</a>);
     <b>assert</b>!(<a href="../sui/coin_registry.md#sui_coin_registry_is_ascii_printable">is_ascii_printable</a>!(&<a href="../sui/coin_registry.md#sui_coin_registry_symbol">symbol</a>), <a href="../sui/coin_registry.md#sui_coin_registry_EInvalidSymbol">EInvalidSymbol</a>);
-    <b>let</b> treasury_cap = <a href="../sui/coin.md#sui_coin_new_treasury_cap">coin::new_treasury_cap</a>(ctx);
+    <b>let</b> treasury_cap = coin::new_treasury_cap(ctx);
     <b>let</b> currency = <a href="../sui/coin_registry.md#sui_coin_registry_Currency">Currency</a>&lt;T&gt; {
-        id: <a href="../sui/derived_object.md#sui_derived_object_claim">derived_object::claim</a>(&<b>mut</b> registry.id, <a href="../sui/coin_registry.md#sui_coin_registry_CurrencyKey">CurrencyKey</a>&lt;T&gt;()),
+        id: derived_object::claim(&<b>mut</b> registry.id, <a href="../sui/coin_registry.md#sui_coin_registry_CurrencyKey">CurrencyKey</a>&lt;T&gt;()),
         <a href="../sui/coin_registry.md#sui_coin_registry_decimals">decimals</a>,
         <a href="../sui/coin_registry.md#sui_coin_registry_name">name</a>,
         <a href="../sui/coin_registry.md#sui_coin_registry_symbol">symbol</a>,
@@ -802,11 +802,11 @@ This can be called from the module that defines <code>T</code> any time after it
         <a href="../sui/coin_registry.md#sui_coin_registry_icon_url">icon_url</a>,
         supply: option::some(SupplyState::Unknown),
         regulated: RegulatedState::Unregulated,
-        <a href="../sui/coin_registry.md#sui_coin_registry_treasury_cap_id">treasury_cap_id</a>: option::some(<a href="../sui/object.md#sui_object_id">object::id</a>(&treasury_cap)),
+        <a href="../sui/coin_registry.md#sui_coin_registry_treasury_cap_id">treasury_cap_id</a>: option::some(object::id(&treasury_cap)),
         <a href="../sui/coin_registry.md#sui_coin_registry_metadata_cap_id">metadata_cap_id</a>: MetadataCapState::Unclaimed,
-        extra_fields: <a href="../sui/vec_map.md#sui_vec_map_empty">vec_map::empty</a>(),
+        extra_fields: vec_map::empty(),
     };
-    (<a href="../sui/coin_registry.md#sui_coin_registry_CurrencyInitializer">CurrencyInitializer</a> { currency, is_otw: <b>false</b>, extra_fields: <a href="../sui/bag.md#sui_bag_new">bag::new</a>(ctx) }, treasury_cap)
+    (<a href="../sui/coin_registry.md#sui_coin_registry_CurrencyInitializer">CurrencyInitializer</a> { currency, is_otw: <b>false</b>, extra_fields: bag::new(ctx) }, treasury_cap)
 }
 </code></pre>
 
@@ -845,9 +845,9 @@ This is a two-step operation:
 ): (<a href="../sui/coin_registry.md#sui_coin_registry_CurrencyInitializer">CurrencyInitializer</a>&lt;T&gt;, TreasuryCap&lt;T&gt;) {
     <b>assert</b>!(<a href="../sui/types.md#sui_types_is_one_time_witness">sui::types::is_one_time_witness</a>(&otw), <a href="../sui/coin_registry.md#sui_coin_registry_ENotOneTimeWitness">ENotOneTimeWitness</a>);
     <b>assert</b>!(<a href="../sui/coin_registry.md#sui_coin_registry_is_ascii_printable">is_ascii_printable</a>!(&<a href="../sui/coin_registry.md#sui_coin_registry_symbol">symbol</a>), <a href="../sui/coin_registry.md#sui_coin_registry_EInvalidSymbol">EInvalidSymbol</a>);
-    <b>let</b> treasury_cap = <a href="../sui/coin.md#sui_coin_new_treasury_cap">coin::new_treasury_cap</a>(ctx);
+    <b>let</b> treasury_cap = coin::new_treasury_cap(ctx);
     <b>let</b> currency = <a href="../sui/coin_registry.md#sui_coin_registry_Currency">Currency</a>&lt;T&gt; {
-        id: <a href="../sui/object.md#sui_object_new">object::new</a>(ctx),
+        id: object::new(ctx),
         <a href="../sui/coin_registry.md#sui_coin_registry_decimals">decimals</a>,
         <a href="../sui/coin_registry.md#sui_coin_registry_name">name</a>,
         <a href="../sui/coin_registry.md#sui_coin_registry_symbol">symbol</a>,
@@ -855,11 +855,11 @@ This is a two-step operation:
         <a href="../sui/coin_registry.md#sui_coin_registry_icon_url">icon_url</a>,
         supply: option::some(SupplyState::Unknown),
         regulated: RegulatedState::Unregulated,
-        <a href="../sui/coin_registry.md#sui_coin_registry_treasury_cap_id">treasury_cap_id</a>: option::some(<a href="../sui/object.md#sui_object_id">object::id</a>(&treasury_cap)),
+        <a href="../sui/coin_registry.md#sui_coin_registry_treasury_cap_id">treasury_cap_id</a>: option::some(object::id(&treasury_cap)),
         <a href="../sui/coin_registry.md#sui_coin_registry_metadata_cap_id">metadata_cap_id</a>: MetadataCapState::Unclaimed,
-        extra_fields: <a href="../sui/vec_map.md#sui_vec_map_empty">vec_map::empty</a>(),
+        extra_fields: vec_map::empty(),
     };
-    (<a href="../sui/coin_registry.md#sui_coin_registry_CurrencyInitializer">CurrencyInitializer</a> { currency, is_otw: <b>true</b>, extra_fields: <a href="../sui/bag.md#sui_bag_new">bag::new</a>(ctx) }, treasury_cap)
+    (<a href="../sui/coin_registry.md#sui_coin_registry_CurrencyInitializer">CurrencyInitializer</a> { currency, is_otw: <b>true</b>, extra_fields: bag::new(ctx) }, treasury_cap)
 }
 </code></pre>
 
@@ -893,7 +893,7 @@ Deleted <code><a href="../sui/coin_registry.md#sui_coin_registry_MetadataCap">Me
     ctx: &<b>mut</b> TxContext,
 ): <a href="../sui/coin_registry.md#sui_coin_registry_MetadataCap">MetadataCap</a>&lt;T&gt; {
     <b>assert</b>!(!currency.<a href="../sui/coin_registry.md#sui_coin_registry_is_metadata_cap_claimed">is_metadata_cap_claimed</a>(), <a href="../sui/coin_registry.md#sui_coin_registry_EMetadataCapAlreadyClaimed">EMetadataCapAlreadyClaimed</a>);
-    <b>let</b> id = <a href="../sui/object.md#sui_object_new">object::new</a>(ctx);
+    <b>let</b> id = object::new(ctx);
     currency.<a href="../sui/coin_registry.md#sui_coin_registry_metadata_cap_id">metadata_cap_id</a> = MetadataCapState::Claimed(id.to_inner());
     <a href="../sui/coin_registry.md#sui_coin_registry_MetadataCap">MetadataCap</a> { id }
 }
@@ -929,10 +929,10 @@ This action is irreversible.
     ctx: &<b>mut</b> TxContext,
 ): DenyCapV2&lt;T&gt; {
     <b>assert</b>!(init.currency.regulated == RegulatedState::Unregulated, <a href="../sui/coin_registry.md#sui_coin_registry_EDenyCapAlreadyCreated">EDenyCapAlreadyCreated</a>);
-    <b>let</b> deny_cap = <a href="../sui/coin.md#sui_coin_new_deny_cap_v2">coin::new_deny_cap_v2</a>&lt;T&gt;(allow_global_pause, ctx);
+    <b>let</b> deny_cap = coin::new_deny_cap_v2&lt;T&gt;(allow_global_pause, ctx);
     init.currency.regulated =
         RegulatedState::Regulated {
-            cap: <a href="../sui/object.md#sui_object_id">object::id</a>(&deny_cap),
+            cap: object::id(&deny_cap),
             allow_global_pause: option::some(allow_global_pause),
             variant: <a href="../sui/coin_registry.md#sui_coin_registry_REGULATED_COIN_VERSION">REGULATED_COIN_VERSION</a>,
         };
@@ -1078,9 +1078,9 @@ Finalize the coin initialization, returning <code><a href="../sui/coin_registry.
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/coin_registry.md#sui_coin_registry_finalize">finalize</a>&lt;T&gt;(builder: <a href="../sui/coin_registry.md#sui_coin_registry_CurrencyInitializer">CurrencyInitializer</a>&lt;T&gt;, ctx: &<b>mut</b> TxContext): <a href="../sui/coin_registry.md#sui_coin_registry_MetadataCap">MetadataCap</a>&lt;T&gt; {
     <b>let</b> is_otw = builder.is_otw;
     <b>let</b> (currency, metadata_cap) = <a href="../sui/coin_registry.md#sui_coin_registry_finalize_impl">finalize_impl</a>!(builder, ctx);
-    // Either share directly (`<a href="../sui/coin_registry.md#sui_coin_registry_new_currency">new_currency</a>` scenario), or <a href="../sui/transfer.md#sui_transfer">transfer</a> <b>as</b> TTO to `<a href="../sui/coin_registry.md#sui_coin_registry_CoinRegistry">CoinRegistry</a>`.
-    <b>if</b> (is_otw) <a href="../sui/transfer.md#sui_transfer_transfer">transfer::transfer</a>(currency, <a href="../sui/object.md#sui_object_sui_coin_registry_address">object::sui_coin_registry_address</a>())
-    <b>else</b> <a href="../sui/transfer.md#sui_transfer_share_object">transfer::share_object</a>(currency);
+    // Either share directly (`<a href="../sui/coin_registry.md#sui_coin_registry_new_currency">new_currency</a>` scenario), or transfer <b>as</b> TTO to `<a href="../sui/coin_registry.md#sui_coin_registry_CoinRegistry">CoinRegistry</a>`.
+    <b>if</b> (is_otw) transfer::transfer(currency, object::sui_coin_registry_address())
+    <b>else</b> transfer::share_object(currency);
     metadata_cap
 }
 </code></pre>
@@ -1112,9 +1112,9 @@ Does the same as <code><a href="../sui/coin_registry.md#sui_coin_registry_finali
     <b>let</b> is_otw = builder.is_otw;
     <b>let</b> (<b>mut</b> currency, metadata_cap) = <a href="../sui/coin_registry.md#sui_coin_registry_finalize_impl">finalize_impl</a>!(builder, ctx);
     currency.<a href="../sui/coin_registry.md#sui_coin_registry_delete_metadata_cap">delete_metadata_cap</a>(metadata_cap);
-    // Either share directly (`<a href="../sui/coin_registry.md#sui_coin_registry_new_currency">new_currency</a>` scenario), or <a href="../sui/transfer.md#sui_transfer">transfer</a> <b>as</b> TTO to `<a href="../sui/coin_registry.md#sui_coin_registry_CoinRegistry">CoinRegistry</a>`.
-    <b>if</b> (is_otw) <a href="../sui/transfer.md#sui_transfer_transfer">transfer::transfer</a>(currency, <a href="../sui/object.md#sui_object_sui_coin_registry_address">object::sui_coin_registry_address</a>())
-    <b>else</b> <a href="../sui/transfer.md#sui_transfer_share_object">transfer::share_object</a>(currency);
+    // Either share directly (`<a href="../sui/coin_registry.md#sui_coin_registry_new_currency">new_currency</a>` scenario), or transfer <b>as</b> TTO to `<a href="../sui/coin_registry.md#sui_coin_registry_CoinRegistry">CoinRegistry</a>`.
+    <b>if</b> (is_otw) transfer::transfer(currency, object::sui_coin_registry_address())
+    <b>else</b> transfer::share_object(currency);
 }
 </code></pre>
 
@@ -1161,11 +1161,11 @@ Can be performed by anyone.
         <a href="../sui/coin_registry.md#sui_coin_registry_treasury_cap_id">treasury_cap_id</a>,
         <a href="../sui/coin_registry.md#sui_coin_registry_metadata_cap_id">metadata_cap_id</a>,
         extra_fields,
-    } = <a href="../sui/transfer.md#sui_transfer_receive">transfer::receive</a>(&<b>mut</b> registry.id, currency);
+    } = transfer::receive(&<b>mut</b> registry.id, currency);
     id.delete();
-    // Now, <a href="../sui/coin_registry.md#sui_coin_registry_create">create</a> the derived version of the <a href="../sui/coin.md#sui_coin">coin</a> currency.
-    <a href="../sui/transfer.md#sui_transfer_share_object">transfer::share_object</a>(<a href="../sui/coin_registry.md#sui_coin_registry_Currency">Currency</a> {
-        id: <a href="../sui/derived_object.md#sui_derived_object_claim">derived_object::claim</a>(&<b>mut</b> registry.id, <a href="../sui/coin_registry.md#sui_coin_registry_CurrencyKey">CurrencyKey</a>&lt;T&gt;()),
+    // Now, <a href="../sui/coin_registry.md#sui_coin_registry_create">create</a> the derived version of the coin currency.
+    transfer::share_object(<a href="../sui/coin_registry.md#sui_coin_registry_Currency">Currency</a> {
+        id: derived_object::claim(&<b>mut</b> registry.id, <a href="../sui/coin_registry.md#sui_coin_registry_CurrencyKey">CurrencyKey</a>&lt;T&gt;()),
         <a href="../sui/coin_registry.md#sui_coin_registry_decimals">decimals</a>,
         <a href="../sui/coin_registry.md#sui_coin_registry_name">name</a>,
         <a href="../sui/coin_registry.md#sui_coin_registry_symbol">symbol</a>,
@@ -1219,7 +1219,7 @@ This action is IRREVERSIBLE, and the <code><a href="../sui/coin_registry.md#sui_
 Burn the <code>Coin</code> if the <code><a href="../sui/coin_registry.md#sui_coin_registry_Currency">Currency</a></code> has a <code>BurnOnly</code> supply state.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/coin_registry.md#sui_coin_registry_burn">burn</a>&lt;T&gt;(currency: &<b>mut</b> <a href="../sui/coin_registry.md#sui_coin_registry_Currency">sui::coin_registry::Currency</a>&lt;T&gt;, <a href="../sui/coin.md#sui_coin">coin</a>: <a href="../sui/coin.md#sui_coin_Coin">sui::coin::Coin</a>&lt;T&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/coin_registry.md#sui_coin_registry_burn">burn</a>&lt;T&gt;(currency: &<b>mut</b> <a href="../sui/coin_registry.md#sui_coin_registry_Currency">sui::coin_registry::Currency</a>&lt;T&gt;, coin: <a href="../sui/coin.md#sui_coin_Coin">sui::coin::Coin</a>&lt;T&gt;)
 </code></pre>
 
 
@@ -1228,8 +1228,8 @@ Burn the <code>Coin</code> if the <code><a href="../sui/coin_registry.md#sui_coi
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/coin_registry.md#sui_coin_registry_burn">burn</a>&lt;T&gt;(currency: &<b>mut</b> <a href="../sui/coin_registry.md#sui_coin_registry_Currency">Currency</a>&lt;T&gt;, <a href="../sui/coin.md#sui_coin">coin</a>: Coin&lt;T&gt;) {
-    currency.<a href="../sui/coin_registry.md#sui_coin_registry_burn_balance">burn_balance</a>(<a href="../sui/coin.md#sui_coin">coin</a>.into_balance());
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/coin_registry.md#sui_coin_registry_burn">burn</a>&lt;T&gt;(currency: &<b>mut</b> <a href="../sui/coin_registry.md#sui_coin_registry_Currency">Currency</a>&lt;T&gt;, coin: Coin&lt;T&gt;) {
+    currency.<a href="../sui/coin_registry.md#sui_coin_registry_burn_balance">burn_balance</a>(coin.into_balance());
 }
 </code></pre>
 
@@ -1244,7 +1244,7 @@ Burn the <code>Coin</code> if the <code><a href="../sui/coin_registry.md#sui_coi
 Burn the <code>Balance</code> if the <code><a href="../sui/coin_registry.md#sui_coin_registry_Currency">Currency</a></code> has a <code>BurnOnly</code> supply state.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/coin_registry.md#sui_coin_registry_burn_balance">burn_balance</a>&lt;T&gt;(currency: &<b>mut</b> <a href="../sui/coin_registry.md#sui_coin_registry_Currency">sui::coin_registry::Currency</a>&lt;T&gt;, <a href="../sui/balance.md#sui_balance">balance</a>: <a href="../sui/balance.md#sui_balance_Balance">sui::balance::Balance</a>&lt;T&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/coin_registry.md#sui_coin_registry_burn_balance">burn_balance</a>&lt;T&gt;(currency: &<b>mut</b> <a href="../sui/coin_registry.md#sui_coin_registry_Currency">sui::coin_registry::Currency</a>&lt;T&gt;, balance: <a href="../sui/balance.md#sui_balance_Balance">sui::balance::Balance</a>&lt;T&gt;)
 </code></pre>
 
 
@@ -1253,10 +1253,10 @@ Burn the <code>Balance</code> if the <code><a href="../sui/coin_registry.md#sui_
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/coin_registry.md#sui_coin_registry_burn_balance">burn_balance</a>&lt;T&gt;(currency: &<b>mut</b> <a href="../sui/coin_registry.md#sui_coin_registry_Currency">Currency</a>&lt;T&gt;, <a href="../sui/balance.md#sui_balance">balance</a>: Balance&lt;T&gt;) {
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/coin_registry.md#sui_coin_registry_burn_balance">burn_balance</a>&lt;T&gt;(currency: &<b>mut</b> <a href="../sui/coin_registry.md#sui_coin_registry_Currency">Currency</a>&lt;T&gt;, balance: Balance&lt;T&gt;) {
     <b>assert</b>!(currency.<a href="../sui/coin_registry.md#sui_coin_registry_is_supply_burn_only">is_supply_burn_only</a>(), <a href="../sui/coin_registry.md#sui_coin_registry_ESupplyNotBurnOnly">ESupplyNotBurnOnly</a>);
     match (currency.supply.borrow_mut()) {
-        SupplyState::BurnOnly(supply) =&gt; { supply.decrease_supply(<a href="../sui/balance.md#sui_balance">balance</a>); },
+        SupplyState::BurnOnly(supply) =&gt; { supply.decrease_supply(balance); },
         _ =&gt; <b>abort</b> <a href="../sui/coin_registry.md#sui_coin_registry_EInvariantViolation">EInvariantViolation</a>, // unreachable
     }
 }
@@ -1360,7 +1360,7 @@ initialization.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/coin_registry.md#sui_coin_registry_set_treasury_cap_id">set_treasury_cap_id</a>&lt;T&gt;(currency: &<b>mut</b> <a href="../sui/coin_registry.md#sui_coin_registry_Currency">Currency</a>&lt;T&gt;, cap: &TreasuryCap&lt;T&gt;) {
-    currency.<a href="../sui/coin_registry.md#sui_coin_registry_treasury_cap_id">treasury_cap_id</a>.fill(<a href="../sui/object.md#sui_object_id">object::id</a>(cap));
+    currency.<a href="../sui/coin_registry.md#sui_coin_registry_treasury_cap_id">treasury_cap_id</a>.fill(object::id(cap));
 }
 </code></pre>
 
@@ -1392,7 +1392,7 @@ Register <code>CoinMetadata</code> in the <code><a href="../sui/coin_registry.md
     _ctx: &<b>mut</b> TxContext,
 ) {
     <b>let</b> currency = <a href="../sui/coin_registry.md#sui_coin_registry_migrate_legacy_metadata_impl">migrate_legacy_metadata_impl</a>!(registry, legacy);
-    <a href="../sui/transfer.md#sui_transfer_share_object">transfer::share_object</a>(currency);
+    transfer::share_object(currency);
 }
 </code></pre>
 
@@ -1424,7 +1424,7 @@ the <code><a href="../sui/coin_registry.md#sui_coin_registry_MetadataCap">Metada
     currency.<a href="../sui/coin_registry.md#sui_coin_registry_description">description</a> = legacy.get_description();
     currency.<a href="../sui/coin_registry.md#sui_coin_registry_decimals">decimals</a> = legacy.get_decimals();
     currency.<a href="../sui/coin_registry.md#sui_coin_registry_icon_url">icon_url</a> =
-        legacy.get_icon_url().map!(|<a href="../sui/url.md#sui_url">url</a>| <a href="../sui/url.md#sui_url">url</a>.inner_url().to_string()).destroy_or!(b"".to_string());
+        legacy.get_icon_url().map!(|url| url.inner_url().to_string()).destroy_or!(b"".to_string());
 }
 </code></pre>
 
@@ -1511,7 +1511,7 @@ Mark regulated state by showing the <code>DenyCapV2</code> object for the <code>
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/coin_registry.md#sui_coin_registry_migrate_regulated_state_by_cap">migrate_regulated_state_by_cap</a>&lt;T&gt;(currency: &<b>mut</b> <a href="../sui/coin_registry.md#sui_coin_registry_Currency">Currency</a>&lt;T&gt;, cap: &DenyCapV2&lt;T&gt;) {
     currency.regulated =
         RegulatedState::Regulated {
-            cap: <a href="../sui/object.md#sui_object_id">object::id</a>(cap),
+            cap: object::id(cap),
             allow_global_pause: option::some(cap.allow_global_pause()),
             variant: <a href="../sui/coin_registry.md#sui_coin_registry_REGULATED_COIN_VERSION">REGULATED_COIN_VERSION</a>,
         };
@@ -1575,7 +1575,7 @@ Return the borrowed <code>CoinMetadata</code> and the <code><a href="../sui/coin
 Note to self: Borrow requirement prevents deletion through this method.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/coin_registry.md#sui_coin_registry_return_borrowed_legacy_metadata">return_borrowed_legacy_metadata</a>&lt;T&gt;(currency: &<b>mut</b> <a href="../sui/coin_registry.md#sui_coin_registry_Currency">sui::coin_registry::Currency</a>&lt;T&gt;, legacy: <a href="../sui/coin.md#sui_coin_CoinMetadata">sui::coin::CoinMetadata</a>&lt;T&gt;, <a href="../sui/borrow.md#sui_borrow">borrow</a>: <a href="../sui/coin_registry.md#sui_coin_registry_Borrow">sui::coin_registry::Borrow</a>&lt;T&gt;, _ctx: &<b>mut</b> <a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/coin_registry.md#sui_coin_registry_return_borrowed_legacy_metadata">return_borrowed_legacy_metadata</a>&lt;T&gt;(currency: &<b>mut</b> <a href="../sui/coin_registry.md#sui_coin_registry_Currency">sui::coin_registry::Currency</a>&lt;T&gt;, legacy: <a href="../sui/coin.md#sui_coin_CoinMetadata">sui::coin::CoinMetadata</a>&lt;T&gt;, borrow: <a href="../sui/coin_registry.md#sui_coin_registry_Borrow">sui::coin_registry::Borrow</a>&lt;T&gt;, _ctx: &<b>mut</b> <a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -1587,11 +1587,11 @@ Note to self: Borrow requirement prevents deletion through this method.
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/coin_registry.md#sui_coin_registry_return_borrowed_legacy_metadata">return_borrowed_legacy_metadata</a>&lt;T&gt;(
     currency: &<b>mut</b> <a href="../sui/coin_registry.md#sui_coin_registry_Currency">Currency</a>&lt;T&gt;,
     <b>mut</b> legacy: CoinMetadata&lt;T&gt;,
-    <a href="../sui/borrow.md#sui_borrow">borrow</a>: <a href="../sui/coin_registry.md#sui_coin_registry_Borrow">Borrow</a>&lt;T&gt;,
+    borrow: <a href="../sui/coin_registry.md#sui_coin_registry_Borrow">Borrow</a>&lt;T&gt;,
     _ctx: &<b>mut</b> TxContext,
 ) {
     <b>assert</b>!(!df::exists_(&currency.id, <a href="../sui/coin_registry.md#sui_coin_registry_LegacyMetadataKey">LegacyMetadataKey</a>()), <a href="../sui/coin_registry.md#sui_coin_registry_EDuplicateBorrow">EDuplicateBorrow</a>);
-    <b>let</b> <a href="../sui/coin_registry.md#sui_coin_registry_Borrow">Borrow</a> {} = <a href="../sui/borrow.md#sui_borrow">borrow</a>;
+    <b>let</b> <a href="../sui/coin_registry.md#sui_coin_registry_Borrow">Borrow</a> {} = borrow;
     // Always store up to date value.
     legacy.update_coin_metadata(
         currency.<a href="../sui/coin_registry.md#sui_coin_registry_name">name</a>,
@@ -1879,7 +1879,7 @@ Check if the supply is fixed.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/coin_registry.md#sui_coin_registry_is_supply_fixed">is_supply_fixed</a>&lt;T&gt;(currency: &<a href="../sui/coin_registry.md#sui_coin_registry_Currency">Currency</a>&lt;T&gt;): bool {
-    match (currency.supply.<a href="../sui/borrow.md#sui_borrow">borrow</a>()) {
+    match (currency.supply.borrow()) {
         SupplyState::Fixed(_) =&gt; <b>true</b>,
         _ =&gt; <b>false</b>,
     }
@@ -1907,7 +1907,7 @@ Check if the supply is burn-only.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/coin_registry.md#sui_coin_registry_is_supply_burn_only">is_supply_burn_only</a>&lt;T&gt;(currency: &<a href="../sui/coin_registry.md#sui_coin_registry_Currency">Currency</a>&lt;T&gt;): bool {
-    match (currency.supply.<a href="../sui/borrow.md#sui_borrow">borrow</a>()) {
+    match (currency.supply.borrow()) {
         SupplyState::BurnOnly(_) =&gt; <b>true</b>,
         _ =&gt; <b>false</b>,
     }
@@ -1964,7 +1964,7 @@ burn-only state. Returns <code>None</code> if the SupplyState is Unknown.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/coin_registry.md#sui_coin_registry_total_supply">total_supply</a>&lt;T&gt;(currency: &<a href="../sui/coin_registry.md#sui_coin_registry_Currency">Currency</a>&lt;T&gt;): Option&lt;u64&gt; {
-    match (currency.supply.<a href="../sui/borrow.md#sui_borrow">borrow</a>()) {
+    match (currency.supply.borrow()) {
         SupplyState::Fixed(supply) =&gt; option::some(supply.value()),
         SupplyState::BurnOnly(supply) =&gt; option::some(supply.value()),
         SupplyState::Unknown =&gt; option::none(),
@@ -1993,7 +1993,7 @@ Check if coin data exists for the given type T in the registry.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/coin_registry.md#sui_coin_registry_exists">exists</a>&lt;T&gt;(registry: &<a href="../sui/coin_registry.md#sui_coin_registry_CoinRegistry">CoinRegistry</a>): bool {
-    <a href="../sui/derived_object.md#sui_derived_object_exists">derived_object::exists</a>(&registry.id, <a href="../sui/coin_registry.md#sui_coin_registry_CurrencyKey">CurrencyKey</a>&lt;T&gt;())
+    derived_object::exists(&registry.id, <a href="../sui/coin_registry.md#sui_coin_registry_CurrencyKey">CurrencyKey</a>&lt;T&gt;())
 }
 </code></pre>
 
@@ -2043,7 +2043,7 @@ Create a new legacy <code>CoinMetadata</code> from a <code><a href="../sui/coin_
 
 
 <pre><code><b>fun</b> <a href="../sui/coin_registry.md#sui_coin_registry_to_legacy_metadata">to_legacy_metadata</a>&lt;T&gt;(currency: &<a href="../sui/coin_registry.md#sui_coin_registry_Currency">Currency</a>&lt;T&gt;, ctx: &<b>mut</b> TxContext): CoinMetadata&lt;T&gt; {
-    <a href="../sui/coin.md#sui_coin_new_coin_metadata">coin::new_coin_metadata</a>(
+    coin::new_coin_metadata(
         currency.<a href="../sui/coin_registry.md#sui_coin_registry_decimals">decimals</a>,
         currency.<a href="../sui/coin_registry.md#sui_coin_registry_name">name</a>,
         currency.<a href="../sui/coin_registry.md#sui_coin_registry_symbol">symbol</a>.to_ascii(),
@@ -2078,8 +2078,8 @@ Only the system address (0x0) can create the registry.
 
 <pre><code><b>fun</b> <a href="../sui/coin_registry.md#sui_coin_registry_create">create</a>(ctx: &TxContext) {
     <b>assert</b>!(ctx.sender() == @0x0, <a href="../sui/coin_registry.md#sui_coin_registry_ENotSystemAddress">ENotSystemAddress</a>);
-    <a href="../sui/transfer.md#sui_transfer_share_object">transfer::share_object</a>(<a href="../sui/coin_registry.md#sui_coin_registry_CoinRegistry">CoinRegistry</a> {
-        id: <a href="../sui/object.md#sui_object_sui_coin_registry_object_id">object::sui_coin_registry_object_id</a>(),
+    transfer::share_object(<a href="../sui/coin_registry.md#sui_coin_registry_CoinRegistry">CoinRegistry</a> {
+        id: object::sui_coin_registry_object_id(),
     });
 }
 </code></pre>
@@ -2110,7 +2110,7 @@ Internal macro to keep implementation between build and test modes.
 ): (<a href="../sui/coin_registry.md#sui_coin_registry_Currency">Currency</a>&lt;$T&gt;, <a href="../sui/coin_registry.md#sui_coin_registry_MetadataCap">MetadataCap</a>&lt;$T&gt;) {
     <b>let</b> <a href="../sui/coin_registry.md#sui_coin_registry_CurrencyInitializer">CurrencyInitializer</a> { <b>mut</b> currency, extra_fields, is_otw: _ } = $builder;
     extra_fields.destroy_empty();
-    <b>let</b> id = <a href="../sui/object.md#sui_object_new">object::new</a>($ctx);
+    <b>let</b> id = object::new($ctx);
     currency.<a href="../sui/coin_registry.md#sui_coin_registry_metadata_cap_id">metadata_cap_id</a> = MetadataCapState::Claimed(id.to_inner());
     // Mark the currency <b>as</b> new, so in the future we can support borrowing of the
     // legacy metadata.
@@ -2153,20 +2153,20 @@ Internal macro to keep implementation between build and test modes.
     <b>assert</b>!(!registry.<a href="../sui/coin_registry.md#sui_coin_registry_exists">exists</a>&lt;$T&gt;(), <a href="../sui/coin_registry.md#sui_coin_registry_ECurrencyAlreadyRegistered">ECurrencyAlreadyRegistered</a>);
     <b>assert</b>!(<a href="../sui/coin_registry.md#sui_coin_registry_is_ascii_printable">is_ascii_printable</a>!(&legacy.get_symbol().to_string()), <a href="../sui/coin_registry.md#sui_coin_registry_EInvalidSymbol">EInvalidSymbol</a>);
     <a href="../sui/coin_registry.md#sui_coin_registry_Currency">Currency</a>&lt;$T&gt; {
-        id: <a href="../sui/derived_object.md#sui_derived_object_claim">derived_object::claim</a>(&<b>mut</b> registry.id, <a href="../sui/coin_registry.md#sui_coin_registry_CurrencyKey">CurrencyKey</a>&lt;$T&gt;()),
+        id: derived_object::claim(&<b>mut</b> registry.id, <a href="../sui/coin_registry.md#sui_coin_registry_CurrencyKey">CurrencyKey</a>&lt;$T&gt;()),
         <a href="../sui/coin_registry.md#sui_coin_registry_decimals">decimals</a>: legacy.get_decimals(),
         <a href="../sui/coin_registry.md#sui_coin_registry_name">name</a>: legacy.get_name(),
         <a href="../sui/coin_registry.md#sui_coin_registry_symbol">symbol</a>: legacy.get_symbol().to_string(),
         <a href="../sui/coin_registry.md#sui_coin_registry_description">description</a>: legacy.get_description(),
         <a href="../sui/coin_registry.md#sui_coin_registry_icon_url">icon_url</a>: legacy
             .get_icon_url()
-            .map!(|<a href="../sui/url.md#sui_url">url</a>| <a href="../sui/url.md#sui_url">url</a>.inner_url().to_string())
+            .map!(|url| url.inner_url().to_string())
             .destroy_or!(b"".to_string()),
         supply: option::some(SupplyState::Unknown),
         regulated: RegulatedState::Unknown,
         <a href="../sui/coin_registry.md#sui_coin_registry_treasury_cap_id">treasury_cap_id</a>: option::none(),
         <a href="../sui/coin_registry.md#sui_coin_registry_metadata_cap_id">metadata_cap_id</a>: MetadataCapState::Unclaimed,
-        extra_fields: <a href="../sui/vec_map.md#sui_vec_map_empty">vec_map::empty</a>(),
+        extra_fields: vec_map::empty(),
     }
 }
 </code></pre>

--- a/crates/sui-framework/docs/sui/config.md
+++ b/crates/sui-framework/docs/sui/config.md
@@ -166,7 +166,7 @@ title: Module `sui::config`
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/config.md#sui_config_new">new</a>&lt;WriteCap&gt;(_cap: &<b>mut</b> WriteCap, ctx: &<b>mut</b> <a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>): <a href="../sui/config.md#sui_config_Config">sui::config::Config</a>&lt;WriteCap&gt;
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/config.md#sui_config_new">new</a>&lt;WriteCap&gt;(_cap: &<b>mut</b> WriteCap, ctx: &<b>mut</b> <a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>): <a href="../sui/config.md#sui_config_Config">sui::config::Config</a>&lt;WriteCap&gt;
 </code></pre>
 
 
@@ -175,8 +175,8 @@ title: Module `sui::config`
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/config.md#sui_config_new">new</a>&lt;WriteCap&gt;(_cap: &<b>mut</b> WriteCap, ctx: &<b>mut</b> TxContext): <a href="../sui/config.md#sui_config_Config">Config</a>&lt;WriteCap&gt; {
-    <a href="../sui/config.md#sui_config_Config">Config</a>&lt;WriteCap&gt; { id: <a href="../sui/object.md#sui_object_new">object::new</a>(ctx) }
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/config.md#sui_config_new">new</a>&lt;WriteCap&gt;(_cap: &<b>mut</b> WriteCap, ctx: &<b>mut</b> TxContext): <a href="../sui/config.md#sui_config_Config">Config</a>&lt;WriteCap&gt; {
+    <a href="../sui/config.md#sui_config_Config">Config</a>&lt;WriteCap&gt; { id: object::new(ctx) }
 }
 </code></pre>
 
@@ -190,7 +190,7 @@ title: Module `sui::config`
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/config.md#sui_config_share">share</a>&lt;WriteCap&gt;(<a href="../sui/config.md#sui_config">config</a>: <a href="../sui/config.md#sui_config_Config">sui::config::Config</a>&lt;WriteCap&gt;)
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/config.md#sui_config_share">share</a>&lt;WriteCap&gt;(config: <a href="../sui/config.md#sui_config_Config">sui::config::Config</a>&lt;WriteCap&gt;)
 </code></pre>
 
 
@@ -199,8 +199,8 @@ title: Module `sui::config`
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/config.md#sui_config_share">share</a>&lt;WriteCap&gt;(<a href="../sui/config.md#sui_config">config</a>: <a href="../sui/config.md#sui_config_Config">Config</a>&lt;WriteCap&gt;) {
-    <a href="../sui/transfer.md#sui_transfer_share_object">transfer::share_object</a>(<a href="../sui/config.md#sui_config">config</a>)
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/config.md#sui_config_share">share</a>&lt;WriteCap&gt;(config: <a href="../sui/config.md#sui_config_Config">Config</a>&lt;WriteCap&gt;) {
+    transfer::share_object(config)
 }
 </code></pre>
 
@@ -214,7 +214,7 @@ title: Module `sui::config`
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/transfer.md#sui_transfer">transfer</a>&lt;WriteCap&gt;(<a href="../sui/config.md#sui_config">config</a>: <a href="../sui/config.md#sui_config_Config">sui::config::Config</a>&lt;WriteCap&gt;, owner: <b>address</b>)
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/config.md#sui_config_transfer">transfer</a>&lt;WriteCap&gt;(config: <a href="../sui/config.md#sui_config_Config">sui::config::Config</a>&lt;WriteCap&gt;, owner: <b>address</b>)
 </code></pre>
 
 
@@ -223,8 +223,8 @@ title: Module `sui::config`
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/transfer.md#sui_transfer">transfer</a>&lt;WriteCap&gt;(<a href="../sui/config.md#sui_config">config</a>: <a href="../sui/config.md#sui_config_Config">Config</a>&lt;WriteCap&gt;, owner: <b>address</b>) {
-    <a href="../sui/transfer.md#sui_transfer_transfer">transfer::transfer</a>(<a href="../sui/config.md#sui_config">config</a>, owner)
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/config.md#sui_config_transfer">transfer</a>&lt;WriteCap&gt;(config: <a href="../sui/config.md#sui_config_Config">Config</a>&lt;WriteCap&gt;, owner: <b>address</b>) {
+    transfer::transfer(config, owner)
 }
 </code></pre>
 
@@ -238,7 +238,7 @@ title: Module `sui::config`
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/config.md#sui_config_add_for_next_epoch">add_for_next_epoch</a>&lt;WriteCap, Name: <b>copy</b>, drop, store, Value: <b>copy</b>, drop, store&gt;(<a href="../sui/config.md#sui_config">config</a>: &<b>mut</b> <a href="../sui/config.md#sui_config_Config">sui::config::Config</a>&lt;WriteCap&gt;, _cap: &<b>mut</b> WriteCap, name: Name, value: Value, ctx: &<b>mut</b> <a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>): <a href="../std/option.md#std_option_Option">std::option::Option</a>&lt;Value&gt;
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/config.md#sui_config_add_for_next_epoch">add_for_next_epoch</a>&lt;WriteCap, Name: <b>copy</b>, drop, store, Value: <b>copy</b>, drop, store&gt;(config: &<b>mut</b> <a href="../sui/config.md#sui_config_Config">sui::config::Config</a>&lt;WriteCap&gt;, _cap: &<b>mut</b> WriteCap, name: Name, value: Value, ctx: &<b>mut</b> <a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>): <a href="../std/option.md#std_option_Option">std::option::Option</a>&lt;Value&gt;
 </code></pre>
 
 
@@ -247,19 +247,19 @@ title: Module `sui::config`
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/config.md#sui_config_add_for_next_epoch">add_for_next_epoch</a>&lt;
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/config.md#sui_config_add_for_next_epoch">add_for_next_epoch</a>&lt;
     WriteCap,
     Name: <b>copy</b> + drop + store,
     Value: <b>copy</b> + drop + store,
 &gt;(
-    <a href="../sui/config.md#sui_config">config</a>: &<b>mut</b> <a href="../sui/config.md#sui_config_Config">Config</a>&lt;WriteCap&gt;,
+    config: &<b>mut</b> <a href="../sui/config.md#sui_config_Config">Config</a>&lt;WriteCap&gt;,
     _cap: &<b>mut</b> WriteCap,
     name: Name,
     value: Value,
     ctx: &<b>mut</b> TxContext,
 ): Option&lt;Value&gt; {
     <b>let</b> epoch = ctx.epoch();
-    <b>if</b> (!field::exists_(&<a href="../sui/config.md#sui_config">config</a>.id, name)) {
+    <b>if</b> (!field::exists_(&config.id, name)) {
         <b>let</b> sobj = <a href="../sui/config.md#sui_config_Setting">Setting</a> {
             data: option::some(<a href="../sui/config.md#sui_config_SettingData">SettingData</a> {
                 newer_value_epoch: epoch,
@@ -267,10 +267,10 @@ title: Module `sui::config`
                 older_value_opt: option::none(),
             }),
         };
-        field::add(&<b>mut</b> <a href="../sui/config.md#sui_config">config</a>.id, name, sobj);
+        field::add(&<b>mut</b> config.id, name, sobj);
         option::none()
     } <b>else</b> {
-        <b>let</b> sobj: &<b>mut</b> <a href="../sui/config.md#sui_config_Setting">Setting</a>&lt;Value&gt; = field::borrow_mut(&<b>mut</b> <a href="../sui/config.md#sui_config">config</a>.id, name);
+        <b>let</b> sobj: &<b>mut</b> <a href="../sui/config.md#sui_config_Setting">Setting</a>&lt;Value&gt; = field::borrow_mut(&<b>mut</b> config.id, name);
         <b>let</b> <a href="../sui/config.md#sui_config_SettingData">SettingData</a> {
             newer_value_epoch,
             newer_value,
@@ -308,7 +308,7 @@ title: Module `sui::config`
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/config.md#sui_config_remove_for_next_epoch">remove_for_next_epoch</a>&lt;WriteCap, Name: <b>copy</b>, drop, store, Value: <b>copy</b>, drop, store&gt;(<a href="../sui/config.md#sui_config">config</a>: &<b>mut</b> <a href="../sui/config.md#sui_config_Config">sui::config::Config</a>&lt;WriteCap&gt;, _cap: &<b>mut</b> WriteCap, name: Name, ctx: &<b>mut</b> <a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>): <a href="../std/option.md#std_option_Option">std::option::Option</a>&lt;Value&gt;
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/config.md#sui_config_remove_for_next_epoch">remove_for_next_epoch</a>&lt;WriteCap, Name: <b>copy</b>, drop, store, Value: <b>copy</b>, drop, store&gt;(config: &<b>mut</b> <a href="../sui/config.md#sui_config_Config">sui::config::Config</a>&lt;WriteCap&gt;, _cap: &<b>mut</b> WriteCap, name: Name, ctx: &<b>mut</b> <a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>): <a href="../std/option.md#std_option_Option">std::option::Option</a>&lt;Value&gt;
 </code></pre>
 
 
@@ -317,19 +317,19 @@ title: Module `sui::config`
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/config.md#sui_config_remove_for_next_epoch">remove_for_next_epoch</a>&lt;
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/config.md#sui_config_remove_for_next_epoch">remove_for_next_epoch</a>&lt;
     WriteCap,
     Name: <b>copy</b> + drop + store,
     Value: <b>copy</b> + drop + store,
 &gt;(
-    <a href="../sui/config.md#sui_config">config</a>: &<b>mut</b> <a href="../sui/config.md#sui_config_Config">Config</a>&lt;WriteCap&gt;,
+    config: &<b>mut</b> <a href="../sui/config.md#sui_config_Config">Config</a>&lt;WriteCap&gt;,
     _cap: &<b>mut</b> WriteCap,
     name: Name,
     ctx: &<b>mut</b> TxContext,
 ): Option&lt;Value&gt; {
     <b>let</b> epoch = ctx.epoch();
-    <b>if</b> (!field::exists_(&<a href="../sui/config.md#sui_config">config</a>.id, name)) <b>return</b> option::none();
-    <b>let</b> sobj: &<b>mut</b> <a href="../sui/config.md#sui_config_Setting">Setting</a>&lt;Value&gt; = field::borrow_mut(&<b>mut</b> <a href="../sui/config.md#sui_config">config</a>.id, name);
+    <b>if</b> (!field::exists_(&config.id, name)) <b>return</b> option::none();
+    <b>let</b> sobj: &<b>mut</b> <a href="../sui/config.md#sui_config_Setting">Setting</a>&lt;Value&gt; = field::borrow_mut(&<b>mut</b> config.id, name);
     <b>let</b> <a href="../sui/config.md#sui_config_SettingData">SettingData</a> {
         newer_value_epoch,
         newer_value,
@@ -352,7 +352,7 @@ title: Module `sui::config`
             older_value_opt,
         });
     <b>if</b> (older_value_opt_is_none) {
-        field::remove&lt;_, <a href="../sui/config.md#sui_config_Setting">Setting</a>&lt;Value&gt;&gt;(&<b>mut</b> <a href="../sui/config.md#sui_config">config</a>.id, name);
+        field::remove&lt;_, <a href="../sui/config.md#sui_config_Setting">Setting</a>&lt;Value&gt;&gt;(&<b>mut</b> config.id, name);
     };
     removed_value
 }
@@ -368,7 +368,7 @@ title: Module `sui::config`
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/config.md#sui_config_exists_with_type">exists_with_type</a>&lt;WriteCap, Name: <b>copy</b>, drop, store, Value: <b>copy</b>, drop, store&gt;(<a href="../sui/config.md#sui_config">config</a>: &<a href="../sui/config.md#sui_config_Config">sui::config::Config</a>&lt;WriteCap&gt;, name: Name): bool
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/config.md#sui_config_exists_with_type">exists_with_type</a>&lt;WriteCap, Name: <b>copy</b>, drop, store, Value: <b>copy</b>, drop, store&gt;(config: &<a href="../sui/config.md#sui_config_Config">sui::config::Config</a>&lt;WriteCap&gt;, name: Name): bool
 </code></pre>
 
 
@@ -377,15 +377,15 @@ title: Module `sui::config`
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/config.md#sui_config_exists_with_type">exists_with_type</a>&lt;
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/config.md#sui_config_exists_with_type">exists_with_type</a>&lt;
     WriteCap,
     Name: <b>copy</b> + drop + store,
     Value: <b>copy</b> + drop + store,
 &gt;(
-    <a href="../sui/config.md#sui_config">config</a>: &<a href="../sui/config.md#sui_config_Config">Config</a>&lt;WriteCap&gt;,
+    config: &<a href="../sui/config.md#sui_config_Config">Config</a>&lt;WriteCap&gt;,
     name: Name,
 ): bool {
-    field::exists_with_type&lt;_, <a href="../sui/config.md#sui_config_Setting">Setting</a>&lt;Value&gt;&gt;(&<a href="../sui/config.md#sui_config">config</a>.id, name)
+    field::exists_with_type&lt;_, <a href="../sui/config.md#sui_config_Setting">Setting</a>&lt;Value&gt;&gt;(&config.id, name)
 }
 </code></pre>
 
@@ -399,7 +399,7 @@ title: Module `sui::config`
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/config.md#sui_config_exists_with_type_for_next_epoch">exists_with_type_for_next_epoch</a>&lt;WriteCap, Name: <b>copy</b>, drop, store, Value: <b>copy</b>, drop, store&gt;(<a href="../sui/config.md#sui_config">config</a>: &<a href="../sui/config.md#sui_config_Config">sui::config::Config</a>&lt;WriteCap&gt;, name: Name, ctx: &<a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>): bool
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/config.md#sui_config_exists_with_type_for_next_epoch">exists_with_type_for_next_epoch</a>&lt;WriteCap, Name: <b>copy</b>, drop, store, Value: <b>copy</b>, drop, store&gt;(config: &<a href="../sui/config.md#sui_config_Config">sui::config::Config</a>&lt;WriteCap&gt;, name: Name, ctx: &<a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>): bool
 </code></pre>
 
 
@@ -408,20 +408,20 @@ title: Module `sui::config`
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/config.md#sui_config_exists_with_type_for_next_epoch">exists_with_type_for_next_epoch</a>&lt;
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/config.md#sui_config_exists_with_type_for_next_epoch">exists_with_type_for_next_epoch</a>&lt;
     WriteCap,
     Name: <b>copy</b> + drop + store,
     Value: <b>copy</b> + drop + store,
 &gt;(
-    <a href="../sui/config.md#sui_config">config</a>: &<a href="../sui/config.md#sui_config_Config">Config</a>&lt;WriteCap&gt;,
+    config: &<a href="../sui/config.md#sui_config_Config">Config</a>&lt;WriteCap&gt;,
     name: Name,
     ctx: &TxContext,
 ): bool {
-    field::exists_with_type&lt;_, <a href="../sui/config.md#sui_config_Setting">Setting</a>&lt;Value&gt;&gt;(&<a href="../sui/config.md#sui_config">config</a>.id, name) && {
+    field::exists_with_type&lt;_, <a href="../sui/config.md#sui_config_Setting">Setting</a>&lt;Value&gt;&gt;(&config.id, name) && {
         <b>let</b> epoch = ctx.epoch();
-        <b>let</b> sobj: &<a href="../sui/config.md#sui_config_Setting">Setting</a>&lt;Value&gt; = field::borrow(&<a href="../sui/config.md#sui_config">config</a>.id, name);
-        epoch == sobj.data.<a href="../sui/borrow.md#sui_borrow">borrow</a>().newer_value_epoch &&
-        sobj.data.<a href="../sui/borrow.md#sui_borrow">borrow</a>().newer_value.is_some()
+        <b>let</b> sobj: &<a href="../sui/config.md#sui_config_Setting">Setting</a>&lt;Value&gt; = field::borrow(&config.id, name);
+        epoch == sobj.data.borrow().newer_value_epoch &&
+        sobj.data.borrow().newer_value.is_some()
     }
 }
 </code></pre>
@@ -436,7 +436,7 @@ title: Module `sui::config`
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/config.md#sui_config_borrow_for_next_epoch_mut">borrow_for_next_epoch_mut</a>&lt;WriteCap, Name: <b>copy</b>, drop, store, Value: <b>copy</b>, drop, store&gt;(<a href="../sui/config.md#sui_config">config</a>: &<b>mut</b> <a href="../sui/config.md#sui_config_Config">sui::config::Config</a>&lt;WriteCap&gt;, _cap: &<b>mut</b> WriteCap, name: Name, ctx: &<b>mut</b> <a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>): &<b>mut</b> Value
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/config.md#sui_config_borrow_for_next_epoch_mut">borrow_for_next_epoch_mut</a>&lt;WriteCap, Name: <b>copy</b>, drop, store, Value: <b>copy</b>, drop, store&gt;(config: &<b>mut</b> <a href="../sui/config.md#sui_config_Config">sui::config::Config</a>&lt;WriteCap&gt;, _cap: &<b>mut</b> WriteCap, name: Name, ctx: &<b>mut</b> <a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>): &<b>mut</b> Value
 </code></pre>
 
 
@@ -445,18 +445,18 @@ title: Module `sui::config`
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/config.md#sui_config_borrow_for_next_epoch_mut">borrow_for_next_epoch_mut</a>&lt;
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/config.md#sui_config_borrow_for_next_epoch_mut">borrow_for_next_epoch_mut</a>&lt;
     WriteCap,
     Name: <b>copy</b> + drop + store,
     Value: <b>copy</b> + drop + store,
 &gt;(
-    <a href="../sui/config.md#sui_config">config</a>: &<b>mut</b> <a href="../sui/config.md#sui_config_Config">Config</a>&lt;WriteCap&gt;,
+    config: &<b>mut</b> <a href="../sui/config.md#sui_config_Config">Config</a>&lt;WriteCap&gt;,
     _cap: &<b>mut</b> WriteCap,
     name: Name,
     ctx: &<b>mut</b> TxContext,
 ): &<b>mut</b> Value {
     <b>let</b> epoch = ctx.epoch();
-    <b>let</b> sobj: &<b>mut</b> <a href="../sui/config.md#sui_config_Setting">Setting</a>&lt;Value&gt; = field::borrow_mut(&<b>mut</b> <a href="../sui/config.md#sui_config">config</a>.id, name);
+    <b>let</b> sobj: &<b>mut</b> <a href="../sui/config.md#sui_config_Setting">Setting</a>&lt;Value&gt; = field::borrow_mut(&<b>mut</b> config.id, name);
     <b>let</b> data = sobj.data.borrow_mut();
     <b>assert</b>!(data.newer_value_epoch == epoch, <a href="../sui/config.md#sui_config_ENotSetForEpoch">ENotSetForEpoch</a>);
     <b>assert</b>!(data.newer_value.is_some(), <a href="../sui/config.md#sui_config_ENotSetForEpoch">ENotSetForEpoch</a>);
@@ -474,7 +474,7 @@ title: Module `sui::config`
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/config.md#sui_config_read_setting_for_next_epoch">read_setting_for_next_epoch</a>&lt;WriteCap, Name: <b>copy</b>, drop, store, Value: <b>copy</b>, drop, store&gt;(<a href="../sui/config.md#sui_config">config</a>: &<a href="../sui/config.md#sui_config_Config">sui::config::Config</a>&lt;WriteCap&gt;, name: Name): <a href="../std/option.md#std_option_Option">std::option::Option</a>&lt;Value&gt;
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/config.md#sui_config_read_setting_for_next_epoch">read_setting_for_next_epoch</a>&lt;WriteCap, Name: <b>copy</b>, drop, store, Value: <b>copy</b>, drop, store&gt;(config: &<a href="../sui/config.md#sui_config_Config">sui::config::Config</a>&lt;WriteCap&gt;, name: Name): <a href="../std/option.md#std_option_Option">std::option::Option</a>&lt;Value&gt;
 </code></pre>
 
 
@@ -483,17 +483,17 @@ title: Module `sui::config`
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/config.md#sui_config_read_setting_for_next_epoch">read_setting_for_next_epoch</a>&lt;
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/config.md#sui_config_read_setting_for_next_epoch">read_setting_for_next_epoch</a>&lt;
     WriteCap,
     Name: <b>copy</b> + drop + store,
     Value: <b>copy</b> + drop + store,
 &gt;(
-    <a href="../sui/config.md#sui_config">config</a>: &<a href="../sui/config.md#sui_config_Config">Config</a>&lt;WriteCap&gt;,
+    config: &<a href="../sui/config.md#sui_config_Config">Config</a>&lt;WriteCap&gt;,
     name: Name,
 ): Option&lt;Value&gt; {
-    <b>if</b> (!field::exists_with_type&lt;_, <a href="../sui/config.md#sui_config_Setting">Setting</a>&lt;Value&gt;&gt;(&<a href="../sui/config.md#sui_config">config</a>.id, name)) <b>return</b> option::none();
-    <b>let</b> sobj: &<a href="../sui/config.md#sui_config_Setting">Setting</a>&lt;Value&gt; = field::borrow(&<a href="../sui/config.md#sui_config">config</a>.id, name);
-    <b>let</b> data = sobj.data.<a href="../sui/borrow.md#sui_borrow">borrow</a>();
+    <b>if</b> (!field::exists_with_type&lt;_, <a href="../sui/config.md#sui_config_Setting">Setting</a>&lt;Value&gt;&gt;(&config.id, name)) <b>return</b> option::none();
+    <b>let</b> sobj: &<a href="../sui/config.md#sui_config_Setting">Setting</a>&lt;Value&gt; = field::borrow(&config.id, name);
+    <b>let</b> data = sobj.data.borrow();
     data.newer_value
 }
 </code></pre>
@@ -508,7 +508,7 @@ title: Module `sui::config`
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>macro</b> <b>fun</b> <b>entry</b>&lt;$WriteCap, $Name: <b>copy</b>, drop, store, $Value: <b>copy</b>, drop, store&gt;($<a href="../sui/config.md#sui_config">config</a>: &<b>mut</b> <a href="../sui/config.md#sui_config_Config">sui::config::Config</a>&lt;$WriteCap&gt;, $cap: &<b>mut</b> $WriteCap, $name: $Name, $initial_for_next_epoch: |&<b>mut</b> <a href="../sui/config.md#sui_config_Config">sui::config::Config</a>&lt;$WriteCap&gt;, &<b>mut</b> $WriteCap, &<b>mut</b> <a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>| -&gt; $Value, $ctx: &<b>mut</b> <a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>): &<b>mut</b> $Value
+<pre><code><b>public</b>(package) <b>macro</b> <b>fun</b> <b>entry</b>&lt;$WriteCap, $Name: <b>copy</b>, drop, store, $Value: <b>copy</b>, drop, store&gt;($config: &<b>mut</b> <a href="../sui/config.md#sui_config_Config">sui::config::Config</a>&lt;$WriteCap&gt;, $cap: &<b>mut</b> $WriteCap, $name: $Name, $initial_for_next_epoch: |&<b>mut</b> <a href="../sui/config.md#sui_config_Config">sui::config::Config</a>&lt;$WriteCap&gt;, &<b>mut</b> $WriteCap, &<b>mut</b> <a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>| -&gt; $Value, $ctx: &<b>mut</b> <a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>): &<b>mut</b> $Value
 </code></pre>
 
 
@@ -517,22 +517,22 @@ title: Module `sui::config`
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>macro</b> <b>fun</b> <b>entry</b>&lt;$WriteCap, $Name: <b>copy</b> + drop + store, $Value: <b>copy</b> + drop + store&gt;(
-    $<a href="../sui/config.md#sui_config">config</a>: &<b>mut</b> <a href="../sui/config.md#sui_config_Config">Config</a>&lt;$WriteCap&gt;,
+<pre><code><b>public</b>(package) <b>macro</b> <b>fun</b> <b>entry</b>&lt;$WriteCap, $Name: <b>copy</b> + drop + store, $Value: <b>copy</b> + drop + store&gt;(
+    $config: &<b>mut</b> <a href="../sui/config.md#sui_config_Config">Config</a>&lt;$WriteCap&gt;,
     $cap: &<b>mut</b> $WriteCap,
     $name: $Name,
     $initial_for_next_epoch: |&<b>mut</b> <a href="../sui/config.md#sui_config_Config">Config</a>&lt;$WriteCap&gt;, &<b>mut</b> $WriteCap, &<b>mut</b> TxContext| -&gt; $Value,
     $ctx: &<b>mut</b> TxContext,
 ): &<b>mut</b> $Value {
-    <b>let</b> <a href="../sui/config.md#sui_config">config</a> = $<a href="../sui/config.md#sui_config">config</a>;
+    <b>let</b> config = $config;
     <b>let</b> cap = $cap;
     <b>let</b> name = $name;
     <b>let</b> ctx = $ctx;
-    <b>if</b> (!<a href="../sui/config.md#sui_config">config</a>.<a href="../sui/config.md#sui_config_exists_with_type_for_next_epoch">exists_with_type_for_next_epoch</a>&lt;_, _, $Value&gt;(name, ctx)) {
-        <b>let</b> initial = $initial_for_next_epoch(<a href="../sui/config.md#sui_config">config</a>, cap, ctx);
-        <a href="../sui/config.md#sui_config">config</a>.<a href="../sui/config.md#sui_config_add_for_next_epoch">add_for_next_epoch</a>(cap, name, initial, ctx);
+    <b>if</b> (!config.<a href="../sui/config.md#sui_config_exists_with_type_for_next_epoch">exists_with_type_for_next_epoch</a>&lt;_, _, $Value&gt;(name, ctx)) {
+        <b>let</b> initial = $initial_for_next_epoch(config, cap, ctx);
+        config.<a href="../sui/config.md#sui_config_add_for_next_epoch">add_for_next_epoch</a>(cap, name, initial, ctx);
     };
-    <a href="../sui/config.md#sui_config">config</a>.<a href="../sui/config.md#sui_config_borrow_for_next_epoch_mut">borrow_for_next_epoch_mut</a>(cap, name, ctx)
+    config.<a href="../sui/config.md#sui_config_borrow_for_next_epoch_mut">borrow_for_next_epoch_mut</a>(cap, name, ctx)
 }
 </code></pre>
 
@@ -546,7 +546,7 @@ title: Module `sui::config`
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>macro</b> <b>fun</b> <a href="../sui/config.md#sui_config_update">update</a>&lt;$WriteCap, $Name: <b>copy</b>, drop, store, $Value: <b>copy</b>, drop, store&gt;($<a href="../sui/config.md#sui_config">config</a>: &<b>mut</b> <a href="../sui/config.md#sui_config_Config">sui::config::Config</a>&lt;$WriteCap&gt;, $cap: &<b>mut</b> $WriteCap, $name: $Name, $initial_for_next_epoch: |&<b>mut</b> <a href="../sui/config.md#sui_config_Config">sui::config::Config</a>&lt;$WriteCap&gt;, &<b>mut</b> $WriteCap, &<b>mut</b> <a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>| -&gt; $Value, $update_for_next_epoch: |<a href="../std/option.md#std_option_Option">std::option::Option</a>&lt;$Value&gt;, &<b>mut</b> $Value| -&gt; (), $ctx: &<b>mut</b> <a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>)
+<pre><code><b>public</b>(package) <b>macro</b> <b>fun</b> <a href="../sui/config.md#sui_config_update">update</a>&lt;$WriteCap, $Name: <b>copy</b>, drop, store, $Value: <b>copy</b>, drop, store&gt;($config: &<b>mut</b> <a href="../sui/config.md#sui_config_Config">sui::config::Config</a>&lt;$WriteCap&gt;, $cap: &<b>mut</b> $WriteCap, $name: $Name, $initial_for_next_epoch: |&<b>mut</b> <a href="../sui/config.md#sui_config_Config">sui::config::Config</a>&lt;$WriteCap&gt;, &<b>mut</b> $WriteCap, &<b>mut</b> <a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>| -&gt; $Value, $update_for_next_epoch: |<a href="../std/option.md#std_option_Option">std::option::Option</a>&lt;$Value&gt;, &<b>mut</b> $Value| -&gt; (), $ctx: &<b>mut</b> <a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -555,29 +555,29 @@ title: Module `sui::config`
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>macro</b> <b>fun</b> <a href="../sui/config.md#sui_config_update">update</a>&lt;
+<pre><code><b>public</b>(package) <b>macro</b> <b>fun</b> <a href="../sui/config.md#sui_config_update">update</a>&lt;
     $WriteCap,
     $Name: <b>copy</b> + drop + store,
     $Value: <b>copy</b> + drop + store,
 &gt;(
-    $<a href="../sui/config.md#sui_config">config</a>: &<b>mut</b> <a href="../sui/config.md#sui_config_Config">Config</a>&lt;$WriteCap&gt;,
+    $config: &<b>mut</b> <a href="../sui/config.md#sui_config_Config">Config</a>&lt;$WriteCap&gt;,
     $cap: &<b>mut</b> $WriteCap,
     $name: $Name,
     $initial_for_next_epoch: |&<b>mut</b> <a href="../sui/config.md#sui_config_Config">Config</a>&lt;$WriteCap&gt;, &<b>mut</b> $WriteCap, &<b>mut</b> TxContext| -&gt; $Value,
     $update_for_next_epoch: |Option&lt;$Value&gt;, &<b>mut</b> $Value|,
     $ctx: &<b>mut</b> TxContext,
 ) {
-    <b>let</b> <a href="../sui/config.md#sui_config">config</a> = $<a href="../sui/config.md#sui_config">config</a>;
+    <b>let</b> config = $config;
     <b>let</b> cap = $cap;
     <b>let</b> name = $name;
     <b>let</b> ctx = $ctx;
-    <b>let</b> old_value_opt = <b>if</b> (!<a href="../sui/config.md#sui_config">config</a>.<a href="../sui/config.md#sui_config_exists_with_type_for_next_epoch">exists_with_type_for_next_epoch</a>&lt;_, _, $Value&gt;(name, ctx)) {
-        <b>let</b> initial = $initial_for_next_epoch(<a href="../sui/config.md#sui_config">config</a>, cap, ctx);
-        <a href="../sui/config.md#sui_config">config</a>.<a href="../sui/config.md#sui_config_add_for_next_epoch">add_for_next_epoch</a>(cap, name, initial, ctx)
+    <b>let</b> old_value_opt = <b>if</b> (!config.<a href="../sui/config.md#sui_config_exists_with_type_for_next_epoch">exists_with_type_for_next_epoch</a>&lt;_, _, $Value&gt;(name, ctx)) {
+        <b>let</b> initial = $initial_for_next_epoch(config, cap, ctx);
+        config.<a href="../sui/config.md#sui_config_add_for_next_epoch">add_for_next_epoch</a>(cap, name, initial, ctx)
     } <b>else</b> {
         option::none()
     };
-    $update_for_next_epoch(old_value_opt, <a href="../sui/config.md#sui_config">config</a>.<a href="../sui/config.md#sui_config_borrow_for_next_epoch_mut">borrow_for_next_epoch_mut</a>(cap, name, ctx));
+    $update_for_next_epoch(old_value_opt, config.<a href="../sui/config.md#sui_config_borrow_for_next_epoch_mut">borrow_for_next_epoch_mut</a>(cap, name, ctx));
 }
 </code></pre>
 
@@ -591,7 +591,7 @@ title: Module `sui::config`
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/config.md#sui_config_read_setting">read_setting</a>&lt;Name: <b>copy</b>, drop, store, Value: <b>copy</b>, drop, store&gt;(<a href="../sui/config.md#sui_config">config</a>: <a href="../sui/object.md#sui_object_ID">sui::object::ID</a>, name: Name, ctx: &<a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>): <a href="../std/option.md#std_option_Option">std::option::Option</a>&lt;Value&gt;
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/config.md#sui_config_read_setting">read_setting</a>&lt;Name: <b>copy</b>, drop, store, Value: <b>copy</b>, drop, store&gt;(config: <a href="../sui/object.md#sui_object_ID">sui::object::ID</a>, name: Name, ctx: &<a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>): <a href="../std/option.md#std_option_Option">std::option::Option</a>&lt;Value&gt;
 </code></pre>
 
 
@@ -600,13 +600,13 @@ title: Module `sui::config`
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/config.md#sui_config_read_setting">read_setting</a>&lt;Name: <b>copy</b> + drop + store, Value: <b>copy</b> + drop + store&gt;(
-    <a href="../sui/config.md#sui_config">config</a>: ID,
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/config.md#sui_config_read_setting">read_setting</a>&lt;Name: <b>copy</b> + drop + store, Value: <b>copy</b> + drop + store&gt;(
+    config: ID,
     name: Name,
     ctx: &TxContext,
 ): Option&lt;Value&gt; {
     <b>use</b> <a href="../sui/dynamic_field.md#sui_dynamic_field_Field">sui::dynamic_field::Field</a>;
-    <b>let</b> config_id = <a href="../sui/config.md#sui_config">config</a>.to_address();
+    <b>let</b> config_id = config.to_address();
     <b>let</b> setting_df = field::hash_type_and_key(config_id, name);
     <a href="../sui/config.md#sui_config_read_setting_impl">read_setting_impl</a>&lt;Field&lt;Name, <a href="../sui/config.md#sui_config_Setting">Setting</a>&lt;Value&gt;&gt;, <a href="../sui/config.md#sui_config_Setting">Setting</a>&lt;Value&gt;, <a href="../sui/config.md#sui_config_SettingData">SettingData</a>&lt;Value&gt;, Value&gt;(
         config_id,
@@ -626,7 +626,7 @@ title: Module `sui::config`
 
 
 
-<pre><code><b>fun</b> <a href="../sui/config.md#sui_config_read_setting_impl">read_setting_impl</a>&lt;FieldSettingValue: key, SettingValue: store, SettingDataValue: store, Value: <b>copy</b>, drop, store&gt;(<a href="../sui/config.md#sui_config">config</a>: <b>address</b>, name: <b>address</b>, current_epoch: u64): <a href="../std/option.md#std_option_Option">std::option::Option</a>&lt;Value&gt;
+<pre><code><b>fun</b> <a href="../sui/config.md#sui_config_read_setting_impl">read_setting_impl</a>&lt;FieldSettingValue: key, SettingValue: store, SettingDataValue: store, Value: <b>copy</b>, drop, store&gt;(config: <b>address</b>, name: <b>address</b>, current_epoch: u64): <a href="../std/option.md#std_option_Option">std::option::Option</a>&lt;Value&gt;
 </code></pre>
 
 
@@ -641,7 +641,7 @@ title: Module `sui::config`
     SettingDataValue: store,
     Value: <b>copy</b> + drop + store,
 &gt;(
-    <a href="../sui/config.md#sui_config">config</a>: <b>address</b>,
+    config: <b>address</b>,
     name: <b>address</b>,
     current_epoch: u64,
 ): Option&lt;Value&gt;;

--- a/crates/sui-framework/docs/sui/deny_list.md
+++ b/crates/sui-framework/docs/sui/deny_list.md
@@ -344,7 +344,7 @@ meaningless to add them to the deny list.
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/deny_list.md#sui_deny_list_v2_add">v2_add</a>(<a href="../sui/deny_list.md#sui_deny_list">deny_list</a>: &<b>mut</b> <a href="../sui/deny_list.md#sui_deny_list_DenyList">sui::deny_list::DenyList</a>, per_type_index: u64, per_type_key: vector&lt;u8&gt;, addr: <b>address</b>, ctx: &<b>mut</b> <a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>)
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/deny_list.md#sui_deny_list_v2_add">v2_add</a>(deny_list: &<b>mut</b> <a href="../sui/deny_list.md#sui_deny_list_DenyList">sui::deny_list::DenyList</a>, per_type_index: u64, per_type_key: vector&lt;u8&gt;, addr: <b>address</b>, ctx: &<b>mut</b> <a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -353,14 +353,14 @@ meaningless to add them to the deny list.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/deny_list.md#sui_deny_list_v2_add">v2_add</a>(
-    <a href="../sui/deny_list.md#sui_deny_list">deny_list</a>: &<b>mut</b> <a href="../sui/deny_list.md#sui_deny_list_DenyList">DenyList</a>,
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/deny_list.md#sui_deny_list_v2_add">v2_add</a>(
+    deny_list: &<b>mut</b> <a href="../sui/deny_list.md#sui_deny_list_DenyList">DenyList</a>,
     per_type_index: u64,
     per_type_key: vector&lt;u8&gt;,
     addr: <b>address</b>,
     ctx: &<b>mut</b> TxContext,
 ) {
-    <b>let</b> per_type_config = <a href="../sui/deny_list.md#sui_deny_list">deny_list</a>.<a href="../sui/deny_list.md#sui_deny_list_per_type_config_entry">per_type_config_entry</a>!(per_type_index, per_type_key, ctx);
+    <b>let</b> per_type_config = deny_list.<a href="../sui/deny_list.md#sui_deny_list_per_type_config_entry">per_type_config_entry</a>!(per_type_index, per_type_key, ctx);
     <b>let</b> setting_name = <a href="../sui/deny_list.md#sui_deny_list_AddressKey">AddressKey</a>(addr);
     <b>let</b> next_epoch_entry = per_type_config.<b>entry</b>!&lt;_, <a href="../sui/deny_list.md#sui_deny_list_AddressKey">AddressKey</a>, bool&gt;(
         &<b>mut</b> <a href="../sui/deny_list.md#sui_deny_list_ConfigWriteCap">ConfigWriteCap</a>(),
@@ -382,7 +382,7 @@ meaningless to add them to the deny list.
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/deny_list.md#sui_deny_list_v2_remove">v2_remove</a>(<a href="../sui/deny_list.md#sui_deny_list">deny_list</a>: &<b>mut</b> <a href="../sui/deny_list.md#sui_deny_list_DenyList">sui::deny_list::DenyList</a>, per_type_index: u64, per_type_key: vector&lt;u8&gt;, addr: <b>address</b>, ctx: &<b>mut</b> <a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>)
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/deny_list.md#sui_deny_list_v2_remove">v2_remove</a>(deny_list: &<b>mut</b> <a href="../sui/deny_list.md#sui_deny_list_DenyList">sui::deny_list::DenyList</a>, per_type_index: u64, per_type_key: vector&lt;u8&gt;, addr: <b>address</b>, ctx: &<b>mut</b> <a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -391,14 +391,14 @@ meaningless to add them to the deny list.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/deny_list.md#sui_deny_list_v2_remove">v2_remove</a>(
-    <a href="../sui/deny_list.md#sui_deny_list">deny_list</a>: &<b>mut</b> <a href="../sui/deny_list.md#sui_deny_list_DenyList">DenyList</a>,
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/deny_list.md#sui_deny_list_v2_remove">v2_remove</a>(
+    deny_list: &<b>mut</b> <a href="../sui/deny_list.md#sui_deny_list_DenyList">DenyList</a>,
     per_type_index: u64,
     per_type_key: vector&lt;u8&gt;,
     addr: <b>address</b>,
     ctx: &<b>mut</b> TxContext,
 ) {
-    <b>let</b> per_type_config = <a href="../sui/deny_list.md#sui_deny_list">deny_list</a>.<a href="../sui/deny_list.md#sui_deny_list_per_type_config_entry">per_type_config_entry</a>!(per_type_index, per_type_key, ctx);
+    <b>let</b> per_type_config = deny_list.<a href="../sui/deny_list.md#sui_deny_list_per_type_config_entry">per_type_config_entry</a>!(per_type_index, per_type_key, ctx);
     <b>let</b> setting_name = <a href="../sui/deny_list.md#sui_deny_list_AddressKey">AddressKey</a>(addr);
     per_type_config.remove_for_next_epoch&lt;_, <a href="../sui/deny_list.md#sui_deny_list_AddressKey">AddressKey</a>, bool&gt;(
         &<b>mut</b> <a href="../sui/deny_list.md#sui_deny_list_ConfigWriteCap">ConfigWriteCap</a>(),
@@ -418,7 +418,7 @@ meaningless to add them to the deny list.
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/deny_list.md#sui_deny_list_v2_contains_current_epoch">v2_contains_current_epoch</a>(<a href="../sui/deny_list.md#sui_deny_list">deny_list</a>: &<a href="../sui/deny_list.md#sui_deny_list_DenyList">sui::deny_list::DenyList</a>, per_type_index: u64, per_type_key: vector&lt;u8&gt;, addr: <b>address</b>, ctx: &<a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>): bool
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/deny_list.md#sui_deny_list_v2_contains_current_epoch">v2_contains_current_epoch</a>(deny_list: &<a href="../sui/deny_list.md#sui_deny_list_DenyList">sui::deny_list::DenyList</a>, per_type_index: u64, per_type_key: vector&lt;u8&gt;, addr: <b>address</b>, ctx: &<a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>): bool
 </code></pre>
 
 
@@ -427,17 +427,17 @@ meaningless to add them to the deny list.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/deny_list.md#sui_deny_list_v2_contains_current_epoch">v2_contains_current_epoch</a>(
-    <a href="../sui/deny_list.md#sui_deny_list">deny_list</a>: &<a href="../sui/deny_list.md#sui_deny_list_DenyList">DenyList</a>,
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/deny_list.md#sui_deny_list_v2_contains_current_epoch">v2_contains_current_epoch</a>(
+    deny_list: &<a href="../sui/deny_list.md#sui_deny_list_DenyList">DenyList</a>,
     per_type_index: u64,
     per_type_key: vector&lt;u8&gt;,
     addr: <b>address</b>,
     ctx: &TxContext,
 ): bool {
-    <b>if</b> (!<a href="../sui/deny_list.md#sui_deny_list">deny_list</a>.<a href="../sui/deny_list.md#sui_deny_list_per_type_exists">per_type_exists</a>(per_type_index, per_type_key)) <b>return</b> <b>false</b>;
-    <b>let</b> per_type_config = <a href="../sui/deny_list.md#sui_deny_list">deny_list</a>.<a href="../sui/deny_list.md#sui_deny_list_borrow_per_type_config">borrow_per_type_config</a>(per_type_index, per_type_key);
+    <b>if</b> (!deny_list.<a href="../sui/deny_list.md#sui_deny_list_per_type_exists">per_type_exists</a>(per_type_index, per_type_key)) <b>return</b> <b>false</b>;
+    <b>let</b> per_type_config = deny_list.<a href="../sui/deny_list.md#sui_deny_list_borrow_per_type_config">borrow_per_type_config</a>(per_type_index, per_type_key);
     <b>let</b> setting_name = <a href="../sui/deny_list.md#sui_deny_list_AddressKey">AddressKey</a>(addr);
-    <a href="../sui/config.md#sui_config_read_setting">config::read_setting</a>(<a href="../sui/object.md#sui_object_id">object::id</a>(per_type_config), setting_name, ctx).destroy_or!(<b>false</b>)
+    config::read_setting(object::id(per_type_config), setting_name, ctx).destroy_or!(<b>false</b>)
 }
 </code></pre>
 
@@ -451,7 +451,7 @@ meaningless to add them to the deny list.
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/deny_list.md#sui_deny_list_v2_contains_next_epoch">v2_contains_next_epoch</a>(<a href="../sui/deny_list.md#sui_deny_list">deny_list</a>: &<a href="../sui/deny_list.md#sui_deny_list_DenyList">sui::deny_list::DenyList</a>, per_type_index: u64, per_type_key: vector&lt;u8&gt;, addr: <b>address</b>): bool
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/deny_list.md#sui_deny_list_v2_contains_next_epoch">v2_contains_next_epoch</a>(deny_list: &<a href="../sui/deny_list.md#sui_deny_list_DenyList">sui::deny_list::DenyList</a>, per_type_index: u64, per_type_key: vector&lt;u8&gt;, addr: <b>address</b>): bool
 </code></pre>
 
 
@@ -460,14 +460,14 @@ meaningless to add them to the deny list.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/deny_list.md#sui_deny_list_v2_contains_next_epoch">v2_contains_next_epoch</a>(
-    <a href="../sui/deny_list.md#sui_deny_list">deny_list</a>: &<a href="../sui/deny_list.md#sui_deny_list_DenyList">DenyList</a>,
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/deny_list.md#sui_deny_list_v2_contains_next_epoch">v2_contains_next_epoch</a>(
+    deny_list: &<a href="../sui/deny_list.md#sui_deny_list_DenyList">DenyList</a>,
     per_type_index: u64,
     per_type_key: vector&lt;u8&gt;,
     addr: <b>address</b>,
 ): bool {
-    <b>if</b> (!<a href="../sui/deny_list.md#sui_deny_list">deny_list</a>.<a href="../sui/deny_list.md#sui_deny_list_per_type_exists">per_type_exists</a>(per_type_index, per_type_key)) <b>return</b> <b>false</b>;
-    <b>let</b> per_type_config = <a href="../sui/deny_list.md#sui_deny_list">deny_list</a>.<a href="../sui/deny_list.md#sui_deny_list_borrow_per_type_config">borrow_per_type_config</a>(per_type_index, per_type_key);
+    <b>if</b> (!deny_list.<a href="../sui/deny_list.md#sui_deny_list_per_type_exists">per_type_exists</a>(per_type_index, per_type_key)) <b>return</b> <b>false</b>;
+    <b>let</b> per_type_config = deny_list.<a href="../sui/deny_list.md#sui_deny_list_borrow_per_type_config">borrow_per_type_config</a>(per_type_index, per_type_key);
     <b>let</b> setting_name = <a href="../sui/deny_list.md#sui_deny_list_AddressKey">AddressKey</a>(addr);
     per_type_config.read_setting_for_next_epoch(setting_name).destroy_or!(<b>false</b>)
 }
@@ -483,7 +483,7 @@ meaningless to add them to the deny list.
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/deny_list.md#sui_deny_list_v2_enable_global_pause">v2_enable_global_pause</a>(<a href="../sui/deny_list.md#sui_deny_list">deny_list</a>: &<b>mut</b> <a href="../sui/deny_list.md#sui_deny_list_DenyList">sui::deny_list::DenyList</a>, per_type_index: u64, per_type_key: vector&lt;u8&gt;, ctx: &<b>mut</b> <a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>)
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/deny_list.md#sui_deny_list_v2_enable_global_pause">v2_enable_global_pause</a>(deny_list: &<b>mut</b> <a href="../sui/deny_list.md#sui_deny_list_DenyList">sui::deny_list::DenyList</a>, per_type_index: u64, per_type_key: vector&lt;u8&gt;, ctx: &<b>mut</b> <a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -492,13 +492,13 @@ meaningless to add them to the deny list.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/deny_list.md#sui_deny_list_v2_enable_global_pause">v2_enable_global_pause</a>(
-    <a href="../sui/deny_list.md#sui_deny_list">deny_list</a>: &<b>mut</b> <a href="../sui/deny_list.md#sui_deny_list_DenyList">DenyList</a>,
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/deny_list.md#sui_deny_list_v2_enable_global_pause">v2_enable_global_pause</a>(
+    deny_list: &<b>mut</b> <a href="../sui/deny_list.md#sui_deny_list_DenyList">DenyList</a>,
     per_type_index: u64,
     per_type_key: vector&lt;u8&gt;,
     ctx: &<b>mut</b> TxContext,
 ) {
-    <b>let</b> per_type_config = <a href="../sui/deny_list.md#sui_deny_list">deny_list</a>.<a href="../sui/deny_list.md#sui_deny_list_per_type_config_entry">per_type_config_entry</a>!(per_type_index, per_type_key, ctx);
+    <b>let</b> per_type_config = deny_list.<a href="../sui/deny_list.md#sui_deny_list_per_type_config_entry">per_type_config_entry</a>!(per_type_index, per_type_key, ctx);
     <b>let</b> setting_name = <a href="../sui/deny_list.md#sui_deny_list_GlobalPauseKey">GlobalPauseKey</a>();
     <b>let</b> next_epoch_entry = per_type_config.<b>entry</b>!&lt;_, <a href="../sui/deny_list.md#sui_deny_list_GlobalPauseKey">GlobalPauseKey</a>, bool&gt;(
         &<b>mut</b> <a href="../sui/deny_list.md#sui_deny_list_ConfigWriteCap">ConfigWriteCap</a>(),
@@ -520,7 +520,7 @@ meaningless to add them to the deny list.
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/deny_list.md#sui_deny_list_v2_disable_global_pause">v2_disable_global_pause</a>(<a href="../sui/deny_list.md#sui_deny_list">deny_list</a>: &<b>mut</b> <a href="../sui/deny_list.md#sui_deny_list_DenyList">sui::deny_list::DenyList</a>, per_type_index: u64, per_type_key: vector&lt;u8&gt;, ctx: &<b>mut</b> <a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>)
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/deny_list.md#sui_deny_list_v2_disable_global_pause">v2_disable_global_pause</a>(deny_list: &<b>mut</b> <a href="../sui/deny_list.md#sui_deny_list_DenyList">sui::deny_list::DenyList</a>, per_type_index: u64, per_type_key: vector&lt;u8&gt;, ctx: &<b>mut</b> <a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -529,13 +529,13 @@ meaningless to add them to the deny list.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/deny_list.md#sui_deny_list_v2_disable_global_pause">v2_disable_global_pause</a>(
-    <a href="../sui/deny_list.md#sui_deny_list">deny_list</a>: &<b>mut</b> <a href="../sui/deny_list.md#sui_deny_list_DenyList">DenyList</a>,
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/deny_list.md#sui_deny_list_v2_disable_global_pause">v2_disable_global_pause</a>(
+    deny_list: &<b>mut</b> <a href="../sui/deny_list.md#sui_deny_list_DenyList">DenyList</a>,
     per_type_index: u64,
     per_type_key: vector&lt;u8&gt;,
     ctx: &<b>mut</b> TxContext,
 ) {
-    <b>let</b> per_type_config = <a href="../sui/deny_list.md#sui_deny_list">deny_list</a>.<a href="../sui/deny_list.md#sui_deny_list_per_type_config_entry">per_type_config_entry</a>!(per_type_index, per_type_key, ctx);
+    <b>let</b> per_type_config = deny_list.<a href="../sui/deny_list.md#sui_deny_list_per_type_config_entry">per_type_config_entry</a>!(per_type_index, per_type_key, ctx);
     <b>let</b> setting_name = <a href="../sui/deny_list.md#sui_deny_list_GlobalPauseKey">GlobalPauseKey</a>();
     per_type_config.remove_for_next_epoch&lt;_, <a href="../sui/deny_list.md#sui_deny_list_GlobalPauseKey">GlobalPauseKey</a>, bool&gt;(
         &<b>mut</b> <a href="../sui/deny_list.md#sui_deny_list_ConfigWriteCap">ConfigWriteCap</a>(),
@@ -555,7 +555,7 @@ meaningless to add them to the deny list.
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/deny_list.md#sui_deny_list_v2_is_global_pause_enabled_current_epoch">v2_is_global_pause_enabled_current_epoch</a>(<a href="../sui/deny_list.md#sui_deny_list">deny_list</a>: &<a href="../sui/deny_list.md#sui_deny_list_DenyList">sui::deny_list::DenyList</a>, per_type_index: u64, per_type_key: vector&lt;u8&gt;, ctx: &<a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>): bool
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/deny_list.md#sui_deny_list_v2_is_global_pause_enabled_current_epoch">v2_is_global_pause_enabled_current_epoch</a>(deny_list: &<a href="../sui/deny_list.md#sui_deny_list_DenyList">sui::deny_list::DenyList</a>, per_type_index: u64, per_type_key: vector&lt;u8&gt;, ctx: &<a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>): bool
 </code></pre>
 
 
@@ -564,16 +564,16 @@ meaningless to add them to the deny list.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/deny_list.md#sui_deny_list_v2_is_global_pause_enabled_current_epoch">v2_is_global_pause_enabled_current_epoch</a>(
-    <a href="../sui/deny_list.md#sui_deny_list">deny_list</a>: &<a href="../sui/deny_list.md#sui_deny_list_DenyList">DenyList</a>,
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/deny_list.md#sui_deny_list_v2_is_global_pause_enabled_current_epoch">v2_is_global_pause_enabled_current_epoch</a>(
+    deny_list: &<a href="../sui/deny_list.md#sui_deny_list_DenyList">DenyList</a>,
     per_type_index: u64,
     per_type_key: vector&lt;u8&gt;,
     ctx: &TxContext,
 ): bool {
-    <b>if</b> (!<a href="../sui/deny_list.md#sui_deny_list">deny_list</a>.<a href="../sui/deny_list.md#sui_deny_list_per_type_exists">per_type_exists</a>(per_type_index, per_type_key)) <b>return</b> <b>false</b>;
-    <b>let</b> per_type_config = <a href="../sui/deny_list.md#sui_deny_list">deny_list</a>.<a href="../sui/deny_list.md#sui_deny_list_borrow_per_type_config">borrow_per_type_config</a>(per_type_index, per_type_key);
+    <b>if</b> (!deny_list.<a href="../sui/deny_list.md#sui_deny_list_per_type_exists">per_type_exists</a>(per_type_index, per_type_key)) <b>return</b> <b>false</b>;
+    <b>let</b> per_type_config = deny_list.<a href="../sui/deny_list.md#sui_deny_list_borrow_per_type_config">borrow_per_type_config</a>(per_type_index, per_type_key);
     <b>let</b> setting_name = <a href="../sui/deny_list.md#sui_deny_list_GlobalPauseKey">GlobalPauseKey</a>();
-    <a href="../sui/config.md#sui_config_read_setting">config::read_setting</a>(<a href="../sui/object.md#sui_object_id">object::id</a>(per_type_config), setting_name, ctx).destroy_or!(<b>false</b>)
+    config::read_setting(object::id(per_type_config), setting_name, ctx).destroy_or!(<b>false</b>)
 }
 </code></pre>
 
@@ -587,7 +587,7 @@ meaningless to add them to the deny list.
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/deny_list.md#sui_deny_list_v2_is_global_pause_enabled_next_epoch">v2_is_global_pause_enabled_next_epoch</a>(<a href="../sui/deny_list.md#sui_deny_list">deny_list</a>: &<a href="../sui/deny_list.md#sui_deny_list_DenyList">sui::deny_list::DenyList</a>, per_type_index: u64, per_type_key: vector&lt;u8&gt;): bool
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/deny_list.md#sui_deny_list_v2_is_global_pause_enabled_next_epoch">v2_is_global_pause_enabled_next_epoch</a>(deny_list: &<a href="../sui/deny_list.md#sui_deny_list_DenyList">sui::deny_list::DenyList</a>, per_type_index: u64, per_type_key: vector&lt;u8&gt;): bool
 </code></pre>
 
 
@@ -596,13 +596,13 @@ meaningless to add them to the deny list.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/deny_list.md#sui_deny_list_v2_is_global_pause_enabled_next_epoch">v2_is_global_pause_enabled_next_epoch</a>(
-    <a href="../sui/deny_list.md#sui_deny_list">deny_list</a>: &<a href="../sui/deny_list.md#sui_deny_list_DenyList">DenyList</a>,
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/deny_list.md#sui_deny_list_v2_is_global_pause_enabled_next_epoch">v2_is_global_pause_enabled_next_epoch</a>(
+    deny_list: &<a href="../sui/deny_list.md#sui_deny_list_DenyList">DenyList</a>,
     per_type_index: u64,
     per_type_key: vector&lt;u8&gt;,
 ): bool {
-    <b>if</b> (!<a href="../sui/deny_list.md#sui_deny_list">deny_list</a>.<a href="../sui/deny_list.md#sui_deny_list_per_type_exists">per_type_exists</a>(per_type_index, per_type_key)) <b>return</b> <b>false</b>;
-    <b>let</b> per_type_config = <a href="../sui/deny_list.md#sui_deny_list">deny_list</a>.<a href="../sui/deny_list.md#sui_deny_list_borrow_per_type_config">borrow_per_type_config</a>(per_type_index, per_type_key);
+    <b>if</b> (!deny_list.<a href="../sui/deny_list.md#sui_deny_list_per_type_exists">per_type_exists</a>(per_type_index, per_type_key)) <b>return</b> <b>false</b>;
+    <b>let</b> per_type_config = deny_list.<a href="../sui/deny_list.md#sui_deny_list_borrow_per_type_config">borrow_per_type_config</a>(per_type_index, per_type_key);
     <b>let</b> setting_name = <a href="../sui/deny_list.md#sui_deny_list_GlobalPauseKey">GlobalPauseKey</a>();
     per_type_config.read_setting_for_next_epoch(setting_name).destroy_or!(<b>false</b>)
 }
@@ -618,7 +618,7 @@ meaningless to add them to the deny list.
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/deny_list.md#sui_deny_list_migrate_v1_to_v2">migrate_v1_to_v2</a>(<a href="../sui/deny_list.md#sui_deny_list">deny_list</a>: &<b>mut</b> <a href="../sui/deny_list.md#sui_deny_list_DenyList">sui::deny_list::DenyList</a>, per_type_index: u64, per_type_key: vector&lt;u8&gt;, ctx: &<b>mut</b> <a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>)
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/deny_list.md#sui_deny_list_migrate_v1_to_v2">migrate_v1_to_v2</a>(deny_list: &<b>mut</b> <a href="../sui/deny_list.md#sui_deny_list_DenyList">sui::deny_list::DenyList</a>, per_type_index: u64, per_type_key: vector&lt;u8&gt;, ctx: &<b>mut</b> <a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -627,13 +627,13 @@ meaningless to add them to the deny list.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/deny_list.md#sui_deny_list_migrate_v1_to_v2">migrate_v1_to_v2</a>(
-    <a href="../sui/deny_list.md#sui_deny_list">deny_list</a>: &<b>mut</b> <a href="../sui/deny_list.md#sui_deny_list_DenyList">DenyList</a>,
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/deny_list.md#sui_deny_list_migrate_v1_to_v2">migrate_v1_to_v2</a>(
+    deny_list: &<b>mut</b> <a href="../sui/deny_list.md#sui_deny_list_DenyList">DenyList</a>,
     per_type_index: u64,
     per_type_key: vector&lt;u8&gt;,
     ctx: &<b>mut</b> TxContext,
 ) {
-    <b>let</b> bag_entry: &<b>mut</b> <a href="../sui/deny_list.md#sui_deny_list_PerTypeList">PerTypeList</a> = &<b>mut</b> <a href="../sui/deny_list.md#sui_deny_list">deny_list</a>.lists[per_type_index];
+    <b>let</b> bag_entry: &<b>mut</b> <a href="../sui/deny_list.md#sui_deny_list_PerTypeList">PerTypeList</a> = &<b>mut</b> deny_list.lists[per_type_index];
     <b>let</b> elements = <b>if</b> (!bag_entry.denied_addresses.contains(per_type_key)) vector[] <b>else</b> bag_entry
         .denied_addresses
         .remove(per_type_key)
@@ -646,7 +646,7 @@ meaningless to add them to the deny list.
             bag_entry.denied_count.remove(addr);
         }
     });
-    <b>let</b> per_type_config = <a href="../sui/deny_list.md#sui_deny_list">deny_list</a>.<a href="../sui/deny_list.md#sui_deny_list_per_type_config_entry">per_type_config_entry</a>!(per_type_index, per_type_key, ctx);
+    <b>let</b> per_type_config = deny_list.<a href="../sui/deny_list.md#sui_deny_list_per_type_config_entry">per_type_config_entry</a>!(per_type_index, per_type_key, ctx);
     elements.do!(|addr| {
         <b>let</b> setting_name = <a href="../sui/deny_list.md#sui_deny_list_AddressKey">AddressKey</a>(addr);
         <b>let</b> next_epoch_entry = per_type_config.<b>entry</b>!&lt;_, <a href="../sui/deny_list.md#sui_deny_list_AddressKey">AddressKey</a>, bool&gt;(
@@ -670,7 +670,7 @@ meaningless to add them to the deny list.
 
 
 
-<pre><code><b>fun</b> <a href="../sui/deny_list.md#sui_deny_list_add_per_type_config">add_per_type_config</a>(<a href="../sui/deny_list.md#sui_deny_list">deny_list</a>: &<b>mut</b> <a href="../sui/deny_list.md#sui_deny_list_DenyList">sui::deny_list::DenyList</a>, per_type_index: u64, per_type_key: vector&lt;u8&gt;, ctx: &<b>mut</b> <a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>)
+<pre><code><b>fun</b> <a href="../sui/deny_list.md#sui_deny_list_add_per_type_config">add_per_type_config</a>(deny_list: &<b>mut</b> <a href="../sui/deny_list.md#sui_deny_list_DenyList">sui::deny_list::DenyList</a>, per_type_index: u64, per_type_key: vector&lt;u8&gt;, ctx: &<b>mut</b> <a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -680,15 +680,15 @@ meaningless to add them to the deny list.
 
 
 <pre><code><b>fun</b> <a href="../sui/deny_list.md#sui_deny_list_add_per_type_config">add_per_type_config</a>(
-    <a href="../sui/deny_list.md#sui_deny_list">deny_list</a>: &<b>mut</b> <a href="../sui/deny_list.md#sui_deny_list_DenyList">DenyList</a>,
+    deny_list: &<b>mut</b> <a href="../sui/deny_list.md#sui_deny_list_DenyList">DenyList</a>,
     per_type_index: u64,
     per_type_key: vector&lt;u8&gt;,
     ctx: &<b>mut</b> TxContext,
 ) {
     <b>let</b> key = <a href="../sui/deny_list.md#sui_deny_list_ConfigKey">ConfigKey</a> { per_type_index, per_type_key };
-    <b>let</b> <a href="../sui/config.md#sui_config">config</a> = <a href="../sui/config.md#sui_config_new">config::new</a>(&<b>mut</b> <a href="../sui/deny_list.md#sui_deny_list_ConfigWriteCap">ConfigWriteCap</a>(), ctx);
-    <b>let</b> config_id = <a href="../sui/object.md#sui_object_id">object::id</a>(&<a href="../sui/config.md#sui_config">config</a>);
-    ofield::internal_add(&<b>mut</b> <a href="../sui/deny_list.md#sui_deny_list">deny_list</a>.id, key, <a href="../sui/config.md#sui_config">config</a>);
+    <b>let</b> config = config::new(&<b>mut</b> <a href="../sui/deny_list.md#sui_deny_list_ConfigWriteCap">ConfigWriteCap</a>(), ctx);
+    <b>let</b> config_id = object::id(&config);
+    ofield::internal_add(&<b>mut</b> deny_list.id, key, config);
     <a href="../sui/event.md#sui_event_emit">sui::event::emit</a>(<a href="../sui/deny_list.md#sui_deny_list_PerTypeConfigCreated">PerTypeConfigCreated</a> { key, config_id });
 }
 </code></pre>
@@ -703,7 +703,7 @@ meaningless to add them to the deny list.
 
 
 
-<pre><code><b>fun</b> <a href="../sui/deny_list.md#sui_deny_list_borrow_per_type_config_mut">borrow_per_type_config_mut</a>(<a href="../sui/deny_list.md#sui_deny_list">deny_list</a>: &<b>mut</b> <a href="../sui/deny_list.md#sui_deny_list_DenyList">sui::deny_list::DenyList</a>, per_type_index: u64, per_type_key: vector&lt;u8&gt;): &<b>mut</b> <a href="../sui/config.md#sui_config_Config">sui::config::Config</a>&lt;<a href="../sui/deny_list.md#sui_deny_list_ConfigWriteCap">sui::deny_list::ConfigWriteCap</a>&gt;
+<pre><code><b>fun</b> <a href="../sui/deny_list.md#sui_deny_list_borrow_per_type_config_mut">borrow_per_type_config_mut</a>(deny_list: &<b>mut</b> <a href="../sui/deny_list.md#sui_deny_list_DenyList">sui::deny_list::DenyList</a>, per_type_index: u64, per_type_key: vector&lt;u8&gt;): &<b>mut</b> <a href="../sui/config.md#sui_config_Config">sui::config::Config</a>&lt;<a href="../sui/deny_list.md#sui_deny_list_ConfigWriteCap">sui::deny_list::ConfigWriteCap</a>&gt;
 </code></pre>
 
 
@@ -713,12 +713,12 @@ meaningless to add them to the deny list.
 
 
 <pre><code><b>fun</b> <a href="../sui/deny_list.md#sui_deny_list_borrow_per_type_config_mut">borrow_per_type_config_mut</a>(
-    <a href="../sui/deny_list.md#sui_deny_list">deny_list</a>: &<b>mut</b> <a href="../sui/deny_list.md#sui_deny_list_DenyList">DenyList</a>,
+    deny_list: &<b>mut</b> <a href="../sui/deny_list.md#sui_deny_list_DenyList">DenyList</a>,
     per_type_index: u64,
     per_type_key: vector&lt;u8&gt;,
 ): &<b>mut</b> Config&lt;<a href="../sui/deny_list.md#sui_deny_list_ConfigWriteCap">ConfigWriteCap</a>&gt; {
     <b>let</b> key = <a href="../sui/deny_list.md#sui_deny_list_ConfigKey">ConfigKey</a> { per_type_index, per_type_key };
-    ofield::internal_borrow_mut(&<b>mut</b> <a href="../sui/deny_list.md#sui_deny_list">deny_list</a>.id, key)
+    ofield::internal_borrow_mut(&<b>mut</b> deny_list.id, key)
 }
 </code></pre>
 
@@ -732,7 +732,7 @@ meaningless to add them to the deny list.
 
 
 
-<pre><code><b>fun</b> <a href="../sui/deny_list.md#sui_deny_list_borrow_per_type_config">borrow_per_type_config</a>(<a href="../sui/deny_list.md#sui_deny_list">deny_list</a>: &<a href="../sui/deny_list.md#sui_deny_list_DenyList">sui::deny_list::DenyList</a>, per_type_index: u64, per_type_key: vector&lt;u8&gt;): &<a href="../sui/config.md#sui_config_Config">sui::config::Config</a>&lt;<a href="../sui/deny_list.md#sui_deny_list_ConfigWriteCap">sui::deny_list::ConfigWriteCap</a>&gt;
+<pre><code><b>fun</b> <a href="../sui/deny_list.md#sui_deny_list_borrow_per_type_config">borrow_per_type_config</a>(deny_list: &<a href="../sui/deny_list.md#sui_deny_list_DenyList">sui::deny_list::DenyList</a>, per_type_index: u64, per_type_key: vector&lt;u8&gt;): &<a href="../sui/config.md#sui_config_Config">sui::config::Config</a>&lt;<a href="../sui/deny_list.md#sui_deny_list_ConfigWriteCap">sui::deny_list::ConfigWriteCap</a>&gt;
 </code></pre>
 
 
@@ -742,12 +742,12 @@ meaningless to add them to the deny list.
 
 
 <pre><code><b>fun</b> <a href="../sui/deny_list.md#sui_deny_list_borrow_per_type_config">borrow_per_type_config</a>(
-    <a href="../sui/deny_list.md#sui_deny_list">deny_list</a>: &<a href="../sui/deny_list.md#sui_deny_list_DenyList">DenyList</a>,
+    deny_list: &<a href="../sui/deny_list.md#sui_deny_list_DenyList">DenyList</a>,
     per_type_index: u64,
     per_type_key: vector&lt;u8&gt;,
 ): &Config&lt;<a href="../sui/deny_list.md#sui_deny_list_ConfigWriteCap">ConfigWriteCap</a>&gt; {
     <b>let</b> key = <a href="../sui/deny_list.md#sui_deny_list_ConfigKey">ConfigKey</a> { per_type_index, per_type_key };
-    ofield::internal_borrow(&<a href="../sui/deny_list.md#sui_deny_list">deny_list</a>.id, key)
+    ofield::internal_borrow(&deny_list.id, key)
 }
 </code></pre>
 
@@ -761,7 +761,7 @@ meaningless to add them to the deny list.
 
 
 
-<pre><code><b>fun</b> <a href="../sui/deny_list.md#sui_deny_list_per_type_exists">per_type_exists</a>(<a href="../sui/deny_list.md#sui_deny_list">deny_list</a>: &<a href="../sui/deny_list.md#sui_deny_list_DenyList">sui::deny_list::DenyList</a>, per_type_index: u64, per_type_key: vector&lt;u8&gt;): bool
+<pre><code><b>fun</b> <a href="../sui/deny_list.md#sui_deny_list_per_type_exists">per_type_exists</a>(deny_list: &<a href="../sui/deny_list.md#sui_deny_list_DenyList">sui::deny_list::DenyList</a>, per_type_index: u64, per_type_key: vector&lt;u8&gt;): bool
 </code></pre>
 
 
@@ -770,9 +770,9 @@ meaningless to add them to the deny list.
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="../sui/deny_list.md#sui_deny_list_per_type_exists">per_type_exists</a>(<a href="../sui/deny_list.md#sui_deny_list">deny_list</a>: &<a href="../sui/deny_list.md#sui_deny_list_DenyList">DenyList</a>, per_type_index: u64, per_type_key: vector&lt;u8&gt;): bool {
+<pre><code><b>fun</b> <a href="../sui/deny_list.md#sui_deny_list_per_type_exists">per_type_exists</a>(deny_list: &<a href="../sui/deny_list.md#sui_deny_list_DenyList">DenyList</a>, per_type_index: u64, per_type_key: vector&lt;u8&gt;): bool {
     <b>let</b> key = <a href="../sui/deny_list.md#sui_deny_list_ConfigKey">ConfigKey</a> { per_type_index, per_type_key };
-    ofield::exists_(&<a href="../sui/deny_list.md#sui_deny_list">deny_list</a>.id, key)
+    ofield::exists_(&deny_list.id, key)
 }
 </code></pre>
 
@@ -786,7 +786,7 @@ meaningless to add them to the deny list.
 
 
 
-<pre><code><b>macro</b> <b>fun</b> <a href="../sui/deny_list.md#sui_deny_list_per_type_config_entry">per_type_config_entry</a>($<a href="../sui/deny_list.md#sui_deny_list">deny_list</a>: &<b>mut</b> <a href="../sui/deny_list.md#sui_deny_list_DenyList">sui::deny_list::DenyList</a>, $per_type_index: u64, $per_type_key: vector&lt;u8&gt;, $ctx: &<b>mut</b> <a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>): &<b>mut</b> <a href="../sui/config.md#sui_config_Config">sui::config::Config</a>&lt;<a href="../sui/deny_list.md#sui_deny_list_ConfigWriteCap">sui::deny_list::ConfigWriteCap</a>&gt;
+<pre><code><b>macro</b> <b>fun</b> <a href="../sui/deny_list.md#sui_deny_list_per_type_config_entry">per_type_config_entry</a>($deny_list: &<b>mut</b> <a href="../sui/deny_list.md#sui_deny_list_DenyList">sui::deny_list::DenyList</a>, $per_type_index: u64, $per_type_key: vector&lt;u8&gt;, $ctx: &<b>mut</b> <a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>): &<b>mut</b> <a href="../sui/config.md#sui_config_Config">sui::config::Config</a>&lt;<a href="../sui/deny_list.md#sui_deny_list_ConfigWriteCap">sui::deny_list::ConfigWriteCap</a>&gt;
 </code></pre>
 
 
@@ -796,19 +796,19 @@ meaningless to add them to the deny list.
 
 
 <pre><code><b>macro</b> <b>fun</b> <a href="../sui/deny_list.md#sui_deny_list_per_type_config_entry">per_type_config_entry</a>(
-    $<a href="../sui/deny_list.md#sui_deny_list">deny_list</a>: &<b>mut</b> <a href="../sui/deny_list.md#sui_deny_list_DenyList">DenyList</a>,
+    $deny_list: &<b>mut</b> <a href="../sui/deny_list.md#sui_deny_list_DenyList">DenyList</a>,
     $per_type_index: u64,
     $per_type_key: vector&lt;u8&gt;,
     $ctx: &<b>mut</b> TxContext,
 ): &<b>mut</b> Config&lt;<a href="../sui/deny_list.md#sui_deny_list_ConfigWriteCap">ConfigWriteCap</a>&gt; {
-    <b>let</b> <a href="../sui/deny_list.md#sui_deny_list">deny_list</a> = $<a href="../sui/deny_list.md#sui_deny_list">deny_list</a>;
+    <b>let</b> deny_list = $deny_list;
     <b>let</b> per_type_index = $per_type_index;
     <b>let</b> per_type_key = $per_type_key;
     <b>let</b> ctx = $ctx;
-    <b>if</b> (!<a href="../sui/deny_list.md#sui_deny_list">deny_list</a>.<a href="../sui/deny_list.md#sui_deny_list_per_type_exists">per_type_exists</a>(per_type_index, per_type_key)) {
-        <a href="../sui/deny_list.md#sui_deny_list">deny_list</a>.<a href="../sui/deny_list.md#sui_deny_list_add_per_type_config">add_per_type_config</a>(per_type_index, per_type_key, ctx);
+    <b>if</b> (!deny_list.<a href="../sui/deny_list.md#sui_deny_list_per_type_exists">per_type_exists</a>(per_type_index, per_type_key)) {
+        deny_list.<a href="../sui/deny_list.md#sui_deny_list_add_per_type_config">add_per_type_config</a>(per_type_index, per_type_key, ctx);
     };
-    <a href="../sui/deny_list.md#sui_deny_list">deny_list</a>.<a href="../sui/deny_list.md#sui_deny_list_borrow_per_type_config_mut">borrow_per_type_config_mut</a>(per_type_index, per_type_key)
+    deny_list.<a href="../sui/deny_list.md#sui_deny_list_borrow_per_type_config_mut">borrow_per_type_config_mut</a>(per_type_index, per_type_key)
 }
 </code></pre>
 
@@ -826,7 +826,7 @@ the type specified is the type of the coin, not the coin type itself. For exampl
 "00...0123::my_coin::MY_COIN" would be the type, not "00...02::coin::Coin".
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/deny_list.md#sui_deny_list_v1_add">v1_add</a>(<a href="../sui/deny_list.md#sui_deny_list">deny_list</a>: &<b>mut</b> <a href="../sui/deny_list.md#sui_deny_list_DenyList">sui::deny_list::DenyList</a>, per_type_index: u64, type: vector&lt;u8&gt;, addr: <b>address</b>)
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/deny_list.md#sui_deny_list_v1_add">v1_add</a>(deny_list: &<b>mut</b> <a href="../sui/deny_list.md#sui_deny_list_DenyList">sui::deny_list::DenyList</a>, per_type_index: u64, type: vector&lt;u8&gt;, addr: <b>address</b>)
 </code></pre>
 
 
@@ -835,15 +835,15 @@ the type specified is the type of the coin, not the coin type itself. For exampl
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/deny_list.md#sui_deny_list_v1_add">v1_add</a>(
-    <a href="../sui/deny_list.md#sui_deny_list">deny_list</a>: &<b>mut</b> <a href="../sui/deny_list.md#sui_deny_list_DenyList">DenyList</a>,
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/deny_list.md#sui_deny_list_v1_add">v1_add</a>(
+    deny_list: &<b>mut</b> <a href="../sui/deny_list.md#sui_deny_list_DenyList">DenyList</a>,
     per_type_index: u64,
     `type`: vector&lt;u8&gt;,
     addr: <b>address</b>,
 ) {
     <b>let</b> reserved = <a href="../sui/deny_list.md#sui_deny_list_RESERVED">RESERVED</a>;
     <b>assert</b>!(!reserved.contains(&addr), <a href="../sui/deny_list.md#sui_deny_list_EInvalidAddress">EInvalidAddress</a>);
-    <b>let</b> bag_entry: &<b>mut</b> <a href="../sui/deny_list.md#sui_deny_list_PerTypeList">PerTypeList</a> = &<b>mut</b> <a href="../sui/deny_list.md#sui_deny_list">deny_list</a>.lists[per_type_index];
+    <b>let</b> bag_entry: &<b>mut</b> <a href="../sui/deny_list.md#sui_deny_list_PerTypeList">PerTypeList</a> = &<b>mut</b> deny_list.lists[per_type_index];
     bag_entry.<a href="../sui/deny_list.md#sui_deny_list_v1_per_type_list_add">v1_per_type_list_add</a>(`type`, addr)
 }
 </code></pre>
@@ -869,7 +869,7 @@ the type specified is the type of the coin, not the coin type itself. For exampl
 
 <pre><code><b>fun</b> <a href="../sui/deny_list.md#sui_deny_list_v1_per_type_list_add">v1_per_type_list_add</a>(list: &<b>mut</b> <a href="../sui/deny_list.md#sui_deny_list_PerTypeList">PerTypeList</a>, `type`: vector&lt;u8&gt;, addr: <b>address</b>) {
     <b>if</b> (!list.denied_addresses.contains(`type`)) {
-        list.denied_addresses.add(`type`, <a href="../sui/vec_set.md#sui_vec_set_empty">vec_set::empty</a>());
+        list.denied_addresses.add(`type`, vec_set::empty());
     };
     <b>let</b> denied_addresses = &<b>mut</b> list.denied_addresses[`type`];
     <b>let</b> already_denied = denied_addresses.contains(&addr);
@@ -895,7 +895,7 @@ Removes a previously denied address from the list.
 Aborts with <code><a href="../sui/deny_list.md#sui_deny_list_ENotDenied">ENotDenied</a></code> if the address is not on the list.
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/deny_list.md#sui_deny_list_v1_remove">v1_remove</a>(<a href="../sui/deny_list.md#sui_deny_list">deny_list</a>: &<b>mut</b> <a href="../sui/deny_list.md#sui_deny_list_DenyList">sui::deny_list::DenyList</a>, per_type_index: u64, type: vector&lt;u8&gt;, addr: <b>address</b>)
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/deny_list.md#sui_deny_list_v1_remove">v1_remove</a>(deny_list: &<b>mut</b> <a href="../sui/deny_list.md#sui_deny_list_DenyList">sui::deny_list::DenyList</a>, per_type_index: u64, type: vector&lt;u8&gt;, addr: <b>address</b>)
 </code></pre>
 
 
@@ -904,15 +904,15 @@ Aborts with <code><a href="../sui/deny_list.md#sui_deny_list_ENotDenied">ENotDen
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/deny_list.md#sui_deny_list_v1_remove">v1_remove</a>(
-    <a href="../sui/deny_list.md#sui_deny_list">deny_list</a>: &<b>mut</b> <a href="../sui/deny_list.md#sui_deny_list_DenyList">DenyList</a>,
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/deny_list.md#sui_deny_list_v1_remove">v1_remove</a>(
+    deny_list: &<b>mut</b> <a href="../sui/deny_list.md#sui_deny_list_DenyList">DenyList</a>,
     per_type_index: u64,
     `type`: vector&lt;u8&gt;,
     addr: <b>address</b>,
 ) {
     <b>let</b> reserved = <a href="../sui/deny_list.md#sui_deny_list_RESERVED">RESERVED</a>;
     <b>assert</b>!(!reserved.contains(&addr), <a href="../sui/deny_list.md#sui_deny_list_EInvalidAddress">EInvalidAddress</a>);
-    <b>let</b> bag_entry: &<b>mut</b> <a href="../sui/deny_list.md#sui_deny_list_PerTypeList">PerTypeList</a> = &<b>mut</b> <a href="../sui/deny_list.md#sui_deny_list">deny_list</a>.lists[per_type_index];
+    <b>let</b> bag_entry: &<b>mut</b> <a href="../sui/deny_list.md#sui_deny_list_PerTypeList">PerTypeList</a> = &<b>mut</b> deny_list.lists[per_type_index];
     bag_entry.<a href="../sui/deny_list.md#sui_deny_list_v1_per_type_list_remove">v1_per_type_list_remove</a>(`type`, addr)
 }
 </code></pre>
@@ -959,7 +959,7 @@ Aborts with <code><a href="../sui/deny_list.md#sui_deny_list_ENotDenied">ENotDen
 Returns true iff the given address is denied for the given type.
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/deny_list.md#sui_deny_list_v1_contains">v1_contains</a>(<a href="../sui/deny_list.md#sui_deny_list">deny_list</a>: &<a href="../sui/deny_list.md#sui_deny_list_DenyList">sui::deny_list::DenyList</a>, per_type_index: u64, type: vector&lt;u8&gt;, addr: <b>address</b>): bool
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/deny_list.md#sui_deny_list_v1_contains">v1_contains</a>(deny_list: &<a href="../sui/deny_list.md#sui_deny_list_DenyList">sui::deny_list::DenyList</a>, per_type_index: u64, type: vector&lt;u8&gt;, addr: <b>address</b>): bool
 </code></pre>
 
 
@@ -968,15 +968,15 @@ Returns true iff the given address is denied for the given type.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/deny_list.md#sui_deny_list_v1_contains">v1_contains</a>(
-    <a href="../sui/deny_list.md#sui_deny_list">deny_list</a>: &<a href="../sui/deny_list.md#sui_deny_list_DenyList">DenyList</a>,
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/deny_list.md#sui_deny_list_v1_contains">v1_contains</a>(
+    deny_list: &<a href="../sui/deny_list.md#sui_deny_list_DenyList">DenyList</a>,
     per_type_index: u64,
     `type`: vector&lt;u8&gt;,
     addr: <b>address</b>,
 ): bool {
     <b>let</b> reserved = <a href="../sui/deny_list.md#sui_deny_list_RESERVED">RESERVED</a>;
     <b>if</b> (reserved.contains(&addr)) <b>return</b> <b>false</b>;
-    <b>let</b> bag_entry: &<a href="../sui/deny_list.md#sui_deny_list_PerTypeList">PerTypeList</a> = &<a href="../sui/deny_list.md#sui_deny_list">deny_list</a>.lists[per_type_index];
+    <b>let</b> bag_entry: &<a href="../sui/deny_list.md#sui_deny_list_PerTypeList">PerTypeList</a> = &deny_list.lists[per_type_index];
     bag_entry.<a href="../sui/deny_list.md#sui_deny_list_v1_per_type_list_contains">v1_per_type_list_contains</a>(`type`, addr)
 }
 </code></pre>
@@ -1033,13 +1033,13 @@ via a system transaction.
 
 <pre><code><b>fun</b> <a href="../sui/deny_list.md#sui_deny_list_create">create</a>(ctx: &<b>mut</b> TxContext) {
     <b>assert</b>!(ctx.sender() == @0x0, <a href="../sui/deny_list.md#sui_deny_list_ENotSystemAddress">ENotSystemAddress</a>);
-    <b>let</b> <b>mut</b> lists = <a href="../sui/bag.md#sui_bag_new">bag::new</a>(ctx);
+    <b>let</b> <b>mut</b> lists = bag::new(ctx);
     lists.add(<a href="../sui/deny_list.md#sui_deny_list_COIN_INDEX">COIN_INDEX</a>, <a href="../sui/deny_list.md#sui_deny_list_per_type_list">per_type_list</a>(ctx));
     <b>let</b> deny_list_object = <a href="../sui/deny_list.md#sui_deny_list_DenyList">DenyList</a> {
-        id: <a href="../sui/object.md#sui_object_sui_deny_list_object_id">object::sui_deny_list_object_id</a>(),
+        id: object::sui_deny_list_object_id(),
         lists,
     };
-    <a href="../sui/transfer.md#sui_transfer_share_object">transfer::share_object</a>(deny_list_object);
+    transfer::share_object(deny_list_object);
 }
 </code></pre>
 
@@ -1064,9 +1064,9 @@ via a system transaction.
 
 <pre><code><b>fun</b> <a href="../sui/deny_list.md#sui_deny_list_per_type_list">per_type_list</a>(ctx: &<b>mut</b> TxContext): <a href="../sui/deny_list.md#sui_deny_list_PerTypeList">PerTypeList</a> {
     <a href="../sui/deny_list.md#sui_deny_list_PerTypeList">PerTypeList</a> {
-        id: <a href="../sui/object.md#sui_object_new">object::new</a>(ctx),
-        denied_count: <a href="../sui/table.md#sui_table_new">table::new</a>(ctx),
-        denied_addresses: <a href="../sui/table.md#sui_table_new">table::new</a>(ctx),
+        id: object::new(ctx),
+        denied_count: table::new(ctx),
+        denied_addresses: table::new(ctx),
     }
 }
 </code></pre>

--- a/crates/sui-framework/docs/sui/derived_object.md
+++ b/crates/sui-framework/docs/sui/derived_object.md
@@ -133,7 +133,7 @@ Tries to create an object twice with the same parent-key combination.
 
 
 <pre><code>#[error]
-<b>const</b> <a href="../sui/derived_object.md#sui_derived_object_EObjectAlreadyExists">EObjectAlreadyExists</a>: vector&lt;u8&gt; = b"Derived <a href="../sui/object.md#sui_object">object</a> is already claimed.";
+<b>const</b> <a href="../sui/derived_object.md#sui_derived_object_EObjectAlreadyExists">EObjectAlreadyExists</a>: vector&lt;u8&gt; = b"Derived object is already claimed.";
 </code></pre>
 
 
@@ -159,7 +159,7 @@ Claim a deterministic UID, using the parent's UID & any key.
     <b>let</b> id = addr.to_id();
     <b>assert</b>!(!df::exists_(parent, <a href="../sui/derived_object.md#sui_derived_object_Claimed">Claimed</a>(id)), <a href="../sui/derived_object.md#sui_derived_object_EObjectAlreadyExists">EObjectAlreadyExists</a>);
     df::add(parent, <a href="../sui/derived_object.md#sui_derived_object_Claimed">Claimed</a>(id), ClaimedStatus::Reserved);
-    <a href="../sui/object.md#sui_object_new_uid_from_hash">object::new_uid_from_hash</a>(addr)
+    object::new_uid_from_hash(addr)
 }
 </code></pre>
 
@@ -172,7 +172,7 @@ Claim a deterministic UID, using the parent's UID & any key.
 ## Function `exists`
 
 Checks if a provided <code>key</code> has been claimed for the given parent.
-Note: If the UID has been deleted through <code><a href="../sui/object.md#sui_object_delete">object::delete</a></code>, this will always return true.
+Note: If the UID has been deleted through <code>object::delete</code>, this will always return true.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/derived_object.md#sui_derived_object_exists">exists</a>&lt;K: <b>copy</b>, drop, store&gt;(parent: &<a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, key: K): bool

--- a/crates/sui-framework/docs/sui/display.md
+++ b/crates/sui-framework/docs/sui/display.md
@@ -74,11 +74,11 @@ on the property values of an Object.
 ```
 // Example of a display object
 Display<0x...::capy::Capy> {
-fields:
-<name, "Capy { genes }">
-<link, "https://capy.art/capy/{ id }">
-<image, "https://api.capy.art/capy/{ id }/svg">
-<description, "Lovely Capy, one of many">
+ fields:
+   <name, "Capy { genes }">
+   <link, "https://capy.art/capy/{ id }">
+   <image, "https://api.capy.art/capy/{ id }/svg">
+   <description, "Lovely Capy, one of many">
 }
 ```
 

--- a/crates/sui-framework/docs/sui/display.md
+++ b/crates/sui-framework/docs/sui/display.md
@@ -265,9 +265,9 @@ Create a new Display<T> object with a set of fields.
 ): <a href="../sui/display.md#sui_display_Display">Display</a>&lt;T&gt; {
     <b>let</b> len = <a href="../sui/display.md#sui_display_fields">fields</a>.length();
     <b>assert</b>!(len == values.length(), <a href="../sui/display.md#sui_display_EVecLengthMismatch">EVecLengthMismatch</a>);
-    <b>let</b> <b>mut</b> <a href="../sui/display.md#sui_display">display</a> = <a href="../sui/display.md#sui_display_new">new</a>&lt;T&gt;(pub, ctx);
-    <a href="../sui/display.md#sui_display_fields">fields</a>.zip_do!(values, |field, value| <a href="../sui/display.md#sui_display">display</a>.<a href="../sui/display.md#sui_display_add_internal">add_internal</a>(field, value));
-    <a href="../sui/display.md#sui_display">display</a>
+    <b>let</b> <b>mut</b> display = <a href="../sui/display.md#sui_display_new">new</a>&lt;T&gt;(pub, ctx);
+    <a href="../sui/display.md#sui_display_fields">fields</a>.zip_do!(values, |field, value| display.<a href="../sui/display.md#sui_display_add_internal">add_internal</a>(field, value));
+    display
 }
 </code></pre>
 
@@ -292,7 +292,7 @@ Create a new empty Display<T> object and keep it.
 
 
 <pre><code><b>public</b> <b>entry</b> <b>fun</b> <a href="../sui/display.md#sui_display_create_and_keep">create_and_keep</a>&lt;T: key&gt;(pub: &Publisher, ctx: &<b>mut</b> TxContext) {
-    <a href="../sui/transfer.md#sui_transfer_public_transfer">transfer::public_transfer</a>(<a href="../sui/display.md#sui_display_new">new</a>&lt;T&gt;(pub, ctx), ctx.sender())
+    transfer::public_transfer(<a href="../sui/display.md#sui_display_new">new</a>&lt;T&gt;(pub, ctx), ctx.sender())
 }
 </code></pre>
 
@@ -307,7 +307,7 @@ Create a new empty Display<T> object and keep it.
 Manually bump the version and emit an event with the updated version's contents.
 
 
-<pre><code><b>public</b> <b>entry</b> <b>fun</b> <a href="../sui/display.md#sui_display_update_version">update_version</a>&lt;T: key&gt;(<a href="../sui/display.md#sui_display">display</a>: &<b>mut</b> <a href="../sui/display.md#sui_display_Display">sui::display::Display</a>&lt;T&gt;)
+<pre><code><b>public</b> <b>entry</b> <b>fun</b> <a href="../sui/display.md#sui_display_update_version">update_version</a>&lt;T: key&gt;(display: &<b>mut</b> <a href="../sui/display.md#sui_display_Display">sui::display::Display</a>&lt;T&gt;)
 </code></pre>
 
 
@@ -316,12 +316,12 @@ Manually bump the version and emit an event with the updated version's contents.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>entry</b> <b>fun</b> <a href="../sui/display.md#sui_display_update_version">update_version</a>&lt;T: key&gt;(<a href="../sui/display.md#sui_display">display</a>: &<b>mut</b> <a href="../sui/display.md#sui_display_Display">Display</a>&lt;T&gt;) {
-    <a href="../sui/display.md#sui_display">display</a>.<a href="../sui/display.md#sui_display_version">version</a> = <a href="../sui/display.md#sui_display">display</a>.<a href="../sui/display.md#sui_display_version">version</a> + 1;
-    <a href="../sui/event.md#sui_event_emit">event::emit</a>(<a href="../sui/display.md#sui_display_VersionUpdated">VersionUpdated</a>&lt;T&gt; {
-        <a href="../sui/display.md#sui_display_version">version</a>: <a href="../sui/display.md#sui_display">display</a>.<a href="../sui/display.md#sui_display_version">version</a>,
-        <a href="../sui/display.md#sui_display_fields">fields</a>: *&<a href="../sui/display.md#sui_display">display</a>.<a href="../sui/display.md#sui_display_fields">fields</a>,
-        id: <a href="../sui/display.md#sui_display">display</a>.id.to_inner(),
+<pre><code><b>public</b> <b>entry</b> <b>fun</b> <a href="../sui/display.md#sui_display_update_version">update_version</a>&lt;T: key&gt;(display: &<b>mut</b> <a href="../sui/display.md#sui_display_Display">Display</a>&lt;T&gt;) {
+    display.<a href="../sui/display.md#sui_display_version">version</a> = display.<a href="../sui/display.md#sui_display_version">version</a> + 1;
+    event::emit(<a href="../sui/display.md#sui_display_VersionUpdated">VersionUpdated</a>&lt;T&gt; {
+        <a href="../sui/display.md#sui_display_version">version</a>: display.<a href="../sui/display.md#sui_display_version">version</a>,
+        <a href="../sui/display.md#sui_display_fields">fields</a>: *&display.<a href="../sui/display.md#sui_display_fields">fields</a>,
+        id: display.id.to_inner(),
     })
 }
 </code></pre>
@@ -520,7 +520,7 @@ Read the <code><a href="../sui/display.md#sui_display_fields">fields</a></code> 
 Allow destroying legacy display objects.
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/display.md#sui_display_destroy">destroy</a>&lt;T: key&gt;(<a href="../sui/display.md#sui_display">display</a>: <a href="../sui/display.md#sui_display_Display">sui::display::Display</a>&lt;T&gt;)
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/display.md#sui_display_destroy">destroy</a>&lt;T: key&gt;(display: <a href="../sui/display.md#sui_display_Display">sui::display::Display</a>&lt;T&gt;)
 </code></pre>
 
 
@@ -529,8 +529,8 @@ Allow destroying legacy display objects.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/display.md#sui_display_destroy">destroy</a>&lt;T: key&gt;(<a href="../sui/display.md#sui_display">display</a>: <a href="../sui/display.md#sui_display_Display">Display</a>&lt;T&gt;) {
-    <b>let</b> <a href="../sui/display.md#sui_display_Display">Display</a> { id, .. } = <a href="../sui/display.md#sui_display">display</a>;
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/display.md#sui_display_destroy">destroy</a>&lt;T: key&gt;(display: <a href="../sui/display.md#sui_display_Display">Display</a>&lt;T&gt;) {
+    <b>let</b> <a href="../sui/display.md#sui_display_Display">Display</a> { id, .. } = display;
     id.delete();
 }
 </code></pre>
@@ -556,13 +556,13 @@ Internal function to create a new <code><a href="../sui/display.md#sui_display_D
 
 
 <pre><code><b>fun</b> <a href="../sui/display.md#sui_display_create_internal">create_internal</a>&lt;T: key&gt;(ctx: &<b>mut</b> TxContext): <a href="../sui/display.md#sui_display_Display">Display</a>&lt;T&gt; {
-    <b>let</b> uid = <a href="../sui/object.md#sui_object_new">object::new</a>(ctx);
-    <a href="../sui/event.md#sui_event_emit">event::emit</a>(<a href="../sui/display.md#sui_display_DisplayCreated">DisplayCreated</a>&lt;T&gt; {
+    <b>let</b> uid = object::new(ctx);
+    event::emit(<a href="../sui/display.md#sui_display_DisplayCreated">DisplayCreated</a>&lt;T&gt; {
         id: uid.to_inner(),
     });
     <a href="../sui/display.md#sui_display_Display">Display</a> {
         id: uid,
-        <a href="../sui/display.md#sui_display_fields">fields</a>: <a href="../sui/vec_map.md#sui_vec_map_empty">vec_map::empty</a>(),
+        <a href="../sui/display.md#sui_display_fields">fields</a>: vec_map::empty(),
         <a href="../sui/display.md#sui_display_version">version</a>: 0,
     }
 }
@@ -579,7 +579,7 @@ Internal function to create a new <code><a href="../sui/display.md#sui_display_D
 Private method for inserting fields without security checks.
 
 
-<pre><code><b>fun</b> <a href="../sui/display.md#sui_display_add_internal">add_internal</a>&lt;T: key&gt;(<a href="../sui/display.md#sui_display">display</a>: &<b>mut</b> <a href="../sui/display.md#sui_display_Display">sui::display::Display</a>&lt;T&gt;, name: <a href="../std/string.md#std_string_String">std::string::String</a>, value: <a href="../std/string.md#std_string_String">std::string::String</a>)
+<pre><code><b>fun</b> <a href="../sui/display.md#sui_display_add_internal">add_internal</a>&lt;T: key&gt;(display: &<b>mut</b> <a href="../sui/display.md#sui_display_Display">sui::display::Display</a>&lt;T&gt;, name: <a href="../std/string.md#std_string_String">std::string::String</a>, value: <a href="../std/string.md#std_string_String">std::string::String</a>)
 </code></pre>
 
 
@@ -588,8 +588,8 @@ Private method for inserting fields without security checks.
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="../sui/display.md#sui_display_add_internal">add_internal</a>&lt;T: key&gt;(<a href="../sui/display.md#sui_display">display</a>: &<b>mut</b> <a href="../sui/display.md#sui_display_Display">Display</a>&lt;T&gt;, name: String, value: String) {
-    <a href="../sui/display.md#sui_display">display</a>.<a href="../sui/display.md#sui_display_fields">fields</a>.insert(name, value)
+<pre><code><b>fun</b> <a href="../sui/display.md#sui_display_add_internal">add_internal</a>&lt;T: key&gt;(display: &<b>mut</b> <a href="../sui/display.md#sui_display_Display">Display</a>&lt;T&gt;, name: String, value: String) {
+    display.<a href="../sui/display.md#sui_display_fields">fields</a>.insert(name, value)
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/sui/display_registry.md
+++ b/crates/sui-framework/docs/sui/display_registry.md
@@ -242,7 +242,7 @@ This is a multi-sig address responsible for the migration of V1 displays into V2
 
 
 <pre><code>#[error]
-<b>const</b> <a href="../sui/display_registry.md#sui_display_registry_ECapAlreadyClaimed">ECapAlreadyClaimed</a>: vector&lt;u8&gt; = b"Cap <b>for</b> this <a href="../sui/display.md#sui_display">display</a> <a href="../sui/object.md#sui_object">object</a> <b>has</b> already been claimed.";
+<b>const</b> <a href="../sui/display_registry.md#sui_display_registry_ECapAlreadyClaimed">ECapAlreadyClaimed</a>: vector&lt;u8&gt; = b"Cap <b>for</b> this display object <b>has</b> already been claimed.";
 </code></pre>
 
 
@@ -262,7 +262,7 @@ This is a multi-sig address responsible for the migration of V1 displays into V2
 
 
 <pre><code>#[error]
-<b>const</b> <a href="../sui/display_registry.md#sui_display_registry_EFieldDoesNotExist">EFieldDoesNotExist</a>: vector&lt;u8&gt; = b"Field does not exist in the <a href="../sui/display.md#sui_display">display</a>.";
+<b>const</b> <a href="../sui/display_registry.md#sui_display_registry_EFieldDoesNotExist">EFieldDoesNotExist</a>: vector&lt;u8&gt; = b"Field does not exist in the display.";
 </code></pre>
 
 
@@ -272,7 +272,7 @@ This is a multi-sig address responsible for the migration of V1 displays into V2
 
 
 <pre><code>#[error]
-<b>const</b> <a href="../sui/display_registry.md#sui_display_registry_ECapNotClaimed">ECapNotClaimed</a>: vector&lt;u8&gt; = b"Cap <b>for</b> this <a href="../sui/display.md#sui_display">display</a> <a href="../sui/object.md#sui_object">object</a> <b>has</b> not been claimed so you cannot delete the legacy <a href="../sui/display.md#sui_display">display</a> yet.";
+<b>const</b> <a href="../sui/display_registry.md#sui_display_registry_ECapNotClaimed">ECapNotClaimed</a>: vector&lt;u8&gt; = b"Cap <b>for</b> this display object <b>has</b> not been claimed so you cannot delete the legacy display yet.";
 </code></pre>
 
 
@@ -299,8 +299,8 @@ prove type ownership.
     _: internal::Permit&lt;T&gt;,
     ctx: &<b>mut</b> TxContext,
 ): (<a href="../sui/display_registry.md#sui_display_registry_Display">Display</a>&lt;T&gt;, <a href="../sui/display_registry.md#sui_display_registry_DisplayCap">DisplayCap</a>&lt;T&gt;) {
-    <b>let</b> (<a href="../sui/display.md#sui_display">display</a>, cap) = <a href="../sui/display_registry.md#sui_display_registry_new_display">new_display</a>&lt;T&gt;(registry, ctx);
-    (<a href="../sui/display.md#sui_display">display</a>, cap)
+    <b>let</b> (display, cap) = <a href="../sui/display_registry.md#sui_display_registry_new_display">new_display</a>&lt;T&gt;(registry, ctx);
+    (display, cap)
 }
 </code></pre>
 
@@ -330,8 +330,8 @@ Create a new display object using the <code>Publisher</code> object.
     ctx: &<b>mut</b> TxContext,
 ): (<a href="../sui/display_registry.md#sui_display_registry_Display">Display</a>&lt;T&gt;, <a href="../sui/display_registry.md#sui_display_registry_DisplayCap">DisplayCap</a>&lt;T&gt;) {
     <b>assert</b>!(publisher.from_package&lt;T&gt;(), <a href="../sui/display_registry.md#sui_display_registry_ENotValidPublisher">ENotValidPublisher</a>);
-    <b>let</b> (<a href="../sui/display.md#sui_display">display</a>, cap) = <a href="../sui/display_registry.md#sui_display_registry_new_display">new_display</a>&lt;T&gt;(registry, ctx);
-    (<a href="../sui/display.md#sui_display">display</a>, cap)
+    <b>let</b> (display, cap) = <a href="../sui/display_registry.md#sui_display_registry_new_display">new_display</a>&lt;T&gt;(registry, ctx);
+    (display, cap)
 }
 </code></pre>
 
@@ -346,7 +346,7 @@ Create a new display object using the <code>Publisher</code> object.
 Unset a key from display.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/display_registry.md#sui_display_registry_unset">unset</a>&lt;T&gt;(<a href="../sui/display.md#sui_display">display</a>: &<b>mut</b> <a href="../sui/display_registry.md#sui_display_registry_Display">sui::display_registry::Display</a>&lt;T&gt;, _: &<a href="../sui/display_registry.md#sui_display_registry_DisplayCap">sui::display_registry::DisplayCap</a>&lt;T&gt;, name: <a href="../std/string.md#std_string_String">std::string::String</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/display_registry.md#sui_display_registry_unset">unset</a>&lt;T&gt;(display: &<b>mut</b> <a href="../sui/display_registry.md#sui_display_registry_Display">sui::display_registry::Display</a>&lt;T&gt;, _: &<a href="../sui/display_registry.md#sui_display_registry_DisplayCap">sui::display_registry::DisplayCap</a>&lt;T&gt;, name: <a href="../std/string.md#std_string_String">std::string::String</a>)
 </code></pre>
 
 
@@ -355,9 +355,9 @@ Unset a key from display.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/display_registry.md#sui_display_registry_unset">unset</a>&lt;T&gt;(<a href="../sui/display.md#sui_display">display</a>: &<b>mut</b> <a href="../sui/display_registry.md#sui_display_registry_Display">Display</a>&lt;T&gt;, _: &<a href="../sui/display_registry.md#sui_display_registry_DisplayCap">DisplayCap</a>&lt;T&gt;, name: String) {
-    <b>assert</b>!(<a href="../sui/display.md#sui_display">display</a>.<a href="../sui/display_registry.md#sui_display_registry_fields">fields</a>.contains(&name), <a href="../sui/display_registry.md#sui_display_registry_EFieldDoesNotExist">EFieldDoesNotExist</a>);
-    <a href="../sui/display.md#sui_display">display</a>.<a href="../sui/display_registry.md#sui_display_registry_fields">fields</a>.remove(&name);
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/display_registry.md#sui_display_registry_unset">unset</a>&lt;T&gt;(display: &<b>mut</b> <a href="../sui/display_registry.md#sui_display_registry_Display">Display</a>&lt;T&gt;, _: &<a href="../sui/display_registry.md#sui_display_registry_DisplayCap">DisplayCap</a>&lt;T&gt;, name: String) {
+    <b>assert</b>!(display.<a href="../sui/display_registry.md#sui_display_registry_fields">fields</a>.contains(&name), <a href="../sui/display_registry.md#sui_display_registry_EFieldDoesNotExist">EFieldDoesNotExist</a>);
+    display.<a href="../sui/display_registry.md#sui_display_registry_fields">fields</a>.remove(&name);
 }
 </code></pre>
 
@@ -372,7 +372,7 @@ Unset a key from display.
 Set a value for the specified key, replaces existing value if it exists.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/display_registry.md#sui_display_registry_set">set</a>&lt;T&gt;(<a href="../sui/display.md#sui_display">display</a>: &<b>mut</b> <a href="../sui/display_registry.md#sui_display_registry_Display">sui::display_registry::Display</a>&lt;T&gt;, _: &<a href="../sui/display_registry.md#sui_display_registry_DisplayCap">sui::display_registry::DisplayCap</a>&lt;T&gt;, name: <a href="../std/string.md#std_string_String">std::string::String</a>, value: <a href="../std/string.md#std_string_String">std::string::String</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/display_registry.md#sui_display_registry_set">set</a>&lt;T&gt;(display: &<b>mut</b> <a href="../sui/display_registry.md#sui_display_registry_Display">sui::display_registry::Display</a>&lt;T&gt;, _: &<a href="../sui/display_registry.md#sui_display_registry_DisplayCap">sui::display_registry::DisplayCap</a>&lt;T&gt;, name: <a href="../std/string.md#std_string_String">std::string::String</a>, value: <a href="../std/string.md#std_string_String">std::string::String</a>)
 </code></pre>
 
 
@@ -381,11 +381,11 @@ Set a value for the specified key, replaces existing value if it exists.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/display_registry.md#sui_display_registry_set">set</a>&lt;T&gt;(<a href="../sui/display.md#sui_display">display</a>: &<b>mut</b> <a href="../sui/display_registry.md#sui_display_registry_Display">Display</a>&lt;T&gt;, _: &<a href="../sui/display_registry.md#sui_display_registry_DisplayCap">DisplayCap</a>&lt;T&gt;, name: String, value: String) {
-    <b>if</b> (<a href="../sui/display.md#sui_display">display</a>.<a href="../sui/display_registry.md#sui_display_registry_fields">fields</a>.contains(&name)) {
-        <a href="../sui/display.md#sui_display">display</a>.<a href="../sui/display_registry.md#sui_display_registry_fields">fields</a>.remove(&name);
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/display_registry.md#sui_display_registry_set">set</a>&lt;T&gt;(display: &<b>mut</b> <a href="../sui/display_registry.md#sui_display_registry_Display">Display</a>&lt;T&gt;, _: &<a href="../sui/display_registry.md#sui_display_registry_DisplayCap">DisplayCap</a>&lt;T&gt;, name: String, value: String) {
+    <b>if</b> (display.<a href="../sui/display_registry.md#sui_display_registry_fields">fields</a>.contains(&name)) {
+        display.<a href="../sui/display_registry.md#sui_display_registry_fields">fields</a>.remove(&name);
     };
-    <a href="../sui/display.md#sui_display">display</a>.<a href="../sui/display_registry.md#sui_display_registry_fields">fields</a>.insert(name, value);
+    display.<a href="../sui/display_registry.md#sui_display_registry_fields">fields</a>.insert(name, value);
 }
 </code></pre>
 
@@ -400,7 +400,7 @@ Set a value for the specified key, replaces existing value if it exists.
 Clear the display vec_map, allowing a fresh re-creation of fields
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/display_registry.md#sui_display_registry_clear">clear</a>&lt;T&gt;(<a href="../sui/display.md#sui_display">display</a>: &<b>mut</b> <a href="../sui/display_registry.md#sui_display_registry_Display">sui::display_registry::Display</a>&lt;T&gt;, _: &<a href="../sui/display_registry.md#sui_display_registry_DisplayCap">sui::display_registry::DisplayCap</a>&lt;T&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/display_registry.md#sui_display_registry_clear">clear</a>&lt;T&gt;(display: &<b>mut</b> <a href="../sui/display_registry.md#sui_display_registry_Display">sui::display_registry::Display</a>&lt;T&gt;, _: &<a href="../sui/display_registry.md#sui_display_registry_DisplayCap">sui::display_registry::DisplayCap</a>&lt;T&gt;)
 </code></pre>
 
 
@@ -409,8 +409,8 @@ Clear the display vec_map, allowing a fresh re-creation of fields
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/display_registry.md#sui_display_registry_clear">clear</a>&lt;T&gt;(<a href="../sui/display.md#sui_display">display</a>: &<b>mut</b> <a href="../sui/display_registry.md#sui_display_registry_Display">Display</a>&lt;T&gt;, _: &<a href="../sui/display_registry.md#sui_display_registry_DisplayCap">DisplayCap</a>&lt;T&gt;) {
-    <a href="../sui/display.md#sui_display">display</a>.<a href="../sui/display_registry.md#sui_display_registry_fields">fields</a> = <a href="../sui/vec_map.md#sui_vec_map_empty">vec_map::empty</a>();
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/display_registry.md#sui_display_registry_clear">clear</a>&lt;T&gt;(display: &<b>mut</b> <a href="../sui/display_registry.md#sui_display_registry_Display">Display</a>&lt;T&gt;, _: &<a href="../sui/display_registry.md#sui_display_registry_DisplayCap">DisplayCap</a>&lt;T&gt;) {
+    display.<a href="../sui/display_registry.md#sui_display_registry_fields">fields</a> = vec_map::empty();
 }
 </code></pre>
 
@@ -425,7 +425,7 @@ Clear the display vec_map, allowing a fresh re-creation of fields
 Share the <code><a href="../sui/display_registry.md#sui_display_registry_Display">Display</a></code> object to finalize the creation.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/display_registry.md#sui_display_registry_share">share</a>&lt;T&gt;(<a href="../sui/display.md#sui_display">display</a>: <a href="../sui/display_registry.md#sui_display_registry_Display">sui::display_registry::Display</a>&lt;T&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/display_registry.md#sui_display_registry_share">share</a>&lt;T&gt;(display: <a href="../sui/display_registry.md#sui_display_registry_Display">sui::display_registry::Display</a>&lt;T&gt;)
 </code></pre>
 
 
@@ -434,8 +434,8 @@ Share the <code><a href="../sui/display_registry.md#sui_display_registry_Display
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/display_registry.md#sui_display_registry_share">share</a>&lt;T&gt;(<a href="../sui/display.md#sui_display">display</a>: <a href="../sui/display_registry.md#sui_display_registry_Display">Display</a>&lt;T&gt;) {
-    <a href="../sui/transfer.md#sui_transfer_share_object">transfer::share_object</a>(<a href="../sui/display.md#sui_display">display</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/display_registry.md#sui_display_registry_share">share</a>&lt;T&gt;(display: <a href="../sui/display_registry.md#sui_display_registry_Display">Display</a>&lt;T&gt;) {
+    transfer::share_object(display)
 }
 </code></pre>
 
@@ -450,7 +450,7 @@ Share the <code><a href="../sui/display_registry.md#sui_display_registry_Display
 Allow a legacy Display holder to claim the capability object.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/display_registry.md#sui_display_registry_claim">claim</a>&lt;T: key&gt;(<a href="../sui/display.md#sui_display">display</a>: &<b>mut</b> <a href="../sui/display_registry.md#sui_display_registry_Display">sui::display_registry::Display</a>&lt;T&gt;, legacy: <a href="../sui/display.md#sui_display_Display">sui::display::Display</a>&lt;T&gt;, ctx: &<b>mut</b> <a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>): <a href="../sui/display_registry.md#sui_display_registry_DisplayCap">sui::display_registry::DisplayCap</a>&lt;T&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/display_registry.md#sui_display_registry_claim">claim</a>&lt;T: key&gt;(display: &<b>mut</b> <a href="../sui/display_registry.md#sui_display_registry_Display">sui::display_registry::Display</a>&lt;T&gt;, legacy: <a href="../sui/display.md#sui_display_Display">sui::display::Display</a>&lt;T&gt;, ctx: &<b>mut</b> <a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>): <a href="../sui/display_registry.md#sui_display_registry_DisplayCap">sui::display_registry::DisplayCap</a>&lt;T&gt;
 </code></pre>
 
 
@@ -460,13 +460,13 @@ Allow a legacy Display holder to claim the capability object.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/display_registry.md#sui_display_registry_claim">claim</a>&lt;T: key&gt;(
-    <a href="../sui/display.md#sui_display">display</a>: &<b>mut</b> <a href="../sui/display_registry.md#sui_display_registry_Display">Display</a>&lt;T&gt;,
+    display: &<b>mut</b> <a href="../sui/display_registry.md#sui_display_registry_Display">Display</a>&lt;T&gt;,
     legacy: LegacyDisplay&lt;T&gt;,
     ctx: &<b>mut</b> TxContext,
 ): <a href="../sui/display_registry.md#sui_display_registry_DisplayCap">DisplayCap</a>&lt;T&gt; {
-    <b>assert</b>!(<a href="../sui/display.md#sui_display">display</a>.<a href="../sui/display_registry.md#sui_display_registry_cap_id">cap_id</a>.is_none(), <a href="../sui/display_registry.md#sui_display_registry_ECapAlreadyClaimed">ECapAlreadyClaimed</a>);
-    <b>let</b> cap = <a href="../sui/display_registry.md#sui_display_registry_DisplayCap">DisplayCap</a>&lt;T&gt; { id: <a href="../sui/object.md#sui_object_new">object::new</a>(ctx) };
-    <a href="../sui/display.md#sui_display">display</a>.<a href="../sui/display_registry.md#sui_display_registry_cap_id">cap_id</a>.fill(cap.id.to_inner());
+    <b>assert</b>!(display.<a href="../sui/display_registry.md#sui_display_registry_cap_id">cap_id</a>.is_none(), <a href="../sui/display_registry.md#sui_display_registry_ECapAlreadyClaimed">ECapAlreadyClaimed</a>);
+    <b>let</b> cap = <a href="../sui/display_registry.md#sui_display_registry_DisplayCap">DisplayCap</a>&lt;T&gt; { id: object::new(ctx) };
+    display.<a href="../sui/display_registry.md#sui_display_registry_cap_id">cap_id</a>.fill(cap.id.to_inner());
     legacy.destroy();
     cap
 }
@@ -483,7 +483,7 @@ Allow a legacy Display holder to claim the capability object.
 Allow claiming a new display using <code>Publisher</code> as proof of ownership.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/display_registry.md#sui_display_registry_claim_with_publisher">claim_with_publisher</a>&lt;T: key&gt;(<a href="../sui/display.md#sui_display">display</a>: &<b>mut</b> <a href="../sui/display_registry.md#sui_display_registry_Display">sui::display_registry::Display</a>&lt;T&gt;, publisher: &<b>mut</b> <a href="../sui/package.md#sui_package_Publisher">sui::package::Publisher</a>, ctx: &<b>mut</b> <a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>): <a href="../sui/display_registry.md#sui_display_registry_DisplayCap">sui::display_registry::DisplayCap</a>&lt;T&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/display_registry.md#sui_display_registry_claim_with_publisher">claim_with_publisher</a>&lt;T: key&gt;(display: &<b>mut</b> <a href="../sui/display_registry.md#sui_display_registry_Display">sui::display_registry::Display</a>&lt;T&gt;, publisher: &<b>mut</b> <a href="../sui/package.md#sui_package_Publisher">sui::package::Publisher</a>, ctx: &<b>mut</b> <a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>): <a href="../sui/display_registry.md#sui_display_registry_DisplayCap">sui::display_registry::DisplayCap</a>&lt;T&gt;
 </code></pre>
 
 
@@ -493,14 +493,14 @@ Allow claiming a new display using <code>Publisher</code> as proof of ownership.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/display_registry.md#sui_display_registry_claim_with_publisher">claim_with_publisher</a>&lt;T: key&gt;(
-    <a href="../sui/display.md#sui_display">display</a>: &<b>mut</b> <a href="../sui/display_registry.md#sui_display_registry_Display">Display</a>&lt;T&gt;,
+    display: &<b>mut</b> <a href="../sui/display_registry.md#sui_display_registry_Display">Display</a>&lt;T&gt;,
     publisher: &<b>mut</b> Publisher,
     ctx: &<b>mut</b> TxContext,
 ): <a href="../sui/display_registry.md#sui_display_registry_DisplayCap">DisplayCap</a>&lt;T&gt; {
-    <b>assert</b>!(<a href="../sui/display.md#sui_display">display</a>.<a href="../sui/display_registry.md#sui_display_registry_cap_id">cap_id</a>.is_none(), <a href="../sui/display_registry.md#sui_display_registry_ECapAlreadyClaimed">ECapAlreadyClaimed</a>);
+    <b>assert</b>!(display.<a href="../sui/display_registry.md#sui_display_registry_cap_id">cap_id</a>.is_none(), <a href="../sui/display_registry.md#sui_display_registry_ECapAlreadyClaimed">ECapAlreadyClaimed</a>);
     <b>assert</b>!(publisher.from_package&lt;T&gt;(), <a href="../sui/display_registry.md#sui_display_registry_ENotValidPublisher">ENotValidPublisher</a>);
-    <b>let</b> cap = <a href="../sui/display_registry.md#sui_display_registry_DisplayCap">DisplayCap</a>&lt;T&gt; { id: <a href="../sui/object.md#sui_object_new">object::new</a>(ctx) };
-    <a href="../sui/display.md#sui_display">display</a>.<a href="../sui/display_registry.md#sui_display_registry_cap_id">cap_id</a>.fill(cap.id.to_inner());
+    <b>let</b> cap = <a href="../sui/display_registry.md#sui_display_registry_DisplayCap">DisplayCap</a>&lt;T&gt; { id: object::new(ctx) };
+    display.<a href="../sui/display_registry.md#sui_display_registry_cap_id">cap_id</a>.fill(cap.id.to_inner());
     cap
 }
 </code></pre>
@@ -516,7 +516,7 @@ Allow claiming a new display using <code>Publisher</code> as proof of ownership.
 Allow the <code><a href="../sui/display_registry.md#sui_display_registry_SystemMigrationCap">SystemMigrationCap</a></code> holder to create display objects with supplied
 values. The migration is performed once on launch of the DisplayRegistry,
 further migrations will have to be performed for each object, and will only
-be possible until legacy <code><a href="../sui/display.md#sui_display">display</a></code> methods are finally deprecated.
+be possible until legacy <code>display</code> methods are finally deprecated.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/display_registry.md#sui_display_registry_system_migration">system_migration</a>&lt;T: key&gt;(registry: &<b>mut</b> <a href="../sui/display_registry.md#sui_display_registry_DisplayRegistry">sui::display_registry::DisplayRegistry</a>, _: &<a href="../sui/display_registry.md#sui_display_registry_SystemMigrationCap">sui::display_registry::SystemMigrationCap</a>, keys: vector&lt;<a href="../std/string.md#std_string_String">std::string::String</a>&gt;, values: vector&lt;<a href="../std/string.md#std_string_String">std::string::String</a>&gt;, _ctx: &<b>mut</b> <a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>)
@@ -537,10 +537,10 @@ be possible until legacy <code><a href="../sui/display.md#sui_display">display</
 ) {
     <b>let</b> key = <a href="../sui/display_registry.md#sui_display_registry_DisplayKey">DisplayKey</a>&lt;T&gt;();
     // Gracefully <b>return</b> to avoid batching issues <b>if</b> someone migrates before our script.
-    <b>if</b> (<a href="../sui/derived_object.md#sui_derived_object_exists">derived_object::exists</a>(&registry.id, key)) <b>return</b>;
-    <a href="../sui/transfer.md#sui_transfer_share_object">transfer::share_object</a>(<a href="../sui/display_registry.md#sui_display_registry_Display">Display</a>&lt;T&gt; {
-        id: <a href="../sui/derived_object.md#sui_derived_object_claim">derived_object::claim</a>(&<b>mut</b> registry.id, key),
-        <a href="../sui/display_registry.md#sui_display_registry_fields">fields</a>: <a href="../sui/vec_map.md#sui_vec_map_from_keys_values">vec_map::from_keys_values</a>(keys, values),
+    <b>if</b> (derived_object::exists(&registry.id, key)) <b>return</b>;
+    transfer::share_object(<a href="../sui/display_registry.md#sui_display_registry_Display">Display</a>&lt;T&gt; {
+        id: derived_object::claim(&<b>mut</b> registry.id, key),
+        <a href="../sui/display_registry.md#sui_display_registry_fields">fields</a>: vec_map::from_keys_values(keys, values),
         <a href="../sui/display_registry.md#sui_display_registry_cap_id">cap_id</a>: option::none(),
     });
 }
@@ -572,10 +572,10 @@ if a new one has not yet been created.
     legacy: LegacyDisplay&lt;T&gt;,
     ctx: &<b>mut</b> TxContext,
 ): (<a href="../sui/display_registry.md#sui_display_registry_Display">Display</a>&lt;T&gt;, <a href="../sui/display_registry.md#sui_display_registry_DisplayCap">DisplayCap</a>&lt;T&gt;) {
-    <b>let</b> (<b>mut</b> <a href="../sui/display.md#sui_display">display</a>, cap) = <a href="../sui/display_registry.md#sui_display_registry_new_display">new_display</a>&lt;T&gt;(registry, ctx);
-    <a href="../sui/display.md#sui_display">display</a>.<a href="../sui/display_registry.md#sui_display_registry_fields">fields</a> = *legacy.<a href="../sui/display_registry.md#sui_display_registry_fields">fields</a>();
+    <b>let</b> (<b>mut</b> display, cap) = <a href="../sui/display_registry.md#sui_display_registry_new_display">new_display</a>&lt;T&gt;(registry, ctx);
+    display.<a href="../sui/display_registry.md#sui_display_registry_fields">fields</a> = *legacy.<a href="../sui/display_registry.md#sui_display_registry_fields">fields</a>();
     legacy.destroy();
-    (<a href="../sui/display.md#sui_display">display</a>, cap)
+    (display, cap)
 }
 </code></pre>
 
@@ -625,7 +625,7 @@ Destroy the <code><a href="../sui/display_registry.md#sui_display_registry_Syste
 
 
 <pre><code><b>entry</b> <b>fun</b> <a href="../sui/display_registry.md#sui_display_registry_transfer_migration_cap">transfer_migration_cap</a>(cap: <a href="../sui/display_registry.md#sui_display_registry_SystemMigrationCap">SystemMigrationCap</a>, recipient: <b>address</b>) {
-    <a href="../sui/transfer.md#sui_transfer_transfer">transfer::transfer</a>(cap, recipient);
+    transfer::transfer(cap, recipient);
 }
 </code></pre>
 
@@ -640,7 +640,7 @@ Destroy the <code><a href="../sui/display_registry.md#sui_display_registry_Syste
 Allow deleting legacy display objects, as long as the cap has been claimed first.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/display_registry.md#sui_display_registry_delete_legacy">delete_legacy</a>&lt;T: key&gt;(<a href="../sui/display.md#sui_display">display</a>: &<a href="../sui/display_registry.md#sui_display_registry_Display">sui::display_registry::Display</a>&lt;T&gt;, legacy: <a href="../sui/display.md#sui_display_Display">sui::display::Display</a>&lt;T&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/display_registry.md#sui_display_registry_delete_legacy">delete_legacy</a>&lt;T: key&gt;(display: &<a href="../sui/display_registry.md#sui_display_registry_Display">sui::display_registry::Display</a>&lt;T&gt;, legacy: <a href="../sui/display.md#sui_display_Display">sui::display::Display</a>&lt;T&gt;)
 </code></pre>
 
 
@@ -649,8 +649,8 @@ Allow deleting legacy display objects, as long as the cap has been claimed first
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/display_registry.md#sui_display_registry_delete_legacy">delete_legacy</a>&lt;T: key&gt;(<a href="../sui/display.md#sui_display">display</a>: &<a href="../sui/display_registry.md#sui_display_registry_Display">Display</a>&lt;T&gt;, legacy: LegacyDisplay&lt;T&gt;) {
-    <b>assert</b>!(<a href="../sui/display.md#sui_display">display</a>.<a href="../sui/display_registry.md#sui_display_registry_cap_id">cap_id</a>.is_some(), <a href="../sui/display_registry.md#sui_display_registry_ECapNotClaimed">ECapNotClaimed</a>);
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/display_registry.md#sui_display_registry_delete_legacy">delete_legacy</a>&lt;T: key&gt;(display: &<a href="../sui/display_registry.md#sui_display_registry_Display">Display</a>&lt;T&gt;, legacy: LegacyDisplay&lt;T&gt;) {
+    <b>assert</b>!(display.<a href="../sui/display_registry.md#sui_display_registry_cap_id">cap_id</a>.is_some(), <a href="../sui/display_registry.md#sui_display_registry_ECapNotClaimed">ECapNotClaimed</a>);
     legacy.destroy();
 }
 </code></pre>
@@ -666,7 +666,7 @@ Allow deleting legacy display objects, as long as the cap has been claimed first
 Get a reference to the fields of display.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/display_registry.md#sui_display_registry_fields">fields</a>&lt;T&gt;(<a href="../sui/display.md#sui_display">display</a>: &<a href="../sui/display_registry.md#sui_display_registry_Display">sui::display_registry::Display</a>&lt;T&gt;): &<a href="../sui/vec_map.md#sui_vec_map_VecMap">sui::vec_map::VecMap</a>&lt;<a href="../std/string.md#std_string_String">std::string::String</a>, <a href="../std/string.md#std_string_String">std::string::String</a>&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/display_registry.md#sui_display_registry_fields">fields</a>&lt;T&gt;(display: &<a href="../sui/display_registry.md#sui_display_registry_Display">sui::display_registry::Display</a>&lt;T&gt;): &<a href="../sui/vec_map.md#sui_vec_map_VecMap">sui::vec_map::VecMap</a>&lt;<a href="../std/string.md#std_string_String">std::string::String</a>, <a href="../std/string.md#std_string_String">std::string::String</a>&gt;
 </code></pre>
 
 
@@ -675,8 +675,8 @@ Get a reference to the fields of display.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/display_registry.md#sui_display_registry_fields">fields</a>&lt;T&gt;(<a href="../sui/display.md#sui_display">display</a>: &<a href="../sui/display_registry.md#sui_display_registry_Display">Display</a>&lt;T&gt;): &VecMap&lt;String, String&gt; {
-    &<a href="../sui/display.md#sui_display">display</a>.<a href="../sui/display_registry.md#sui_display_registry_fields">fields</a>
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/display_registry.md#sui_display_registry_fields">fields</a>&lt;T&gt;(display: &<a href="../sui/display_registry.md#sui_display_registry_Display">Display</a>&lt;T&gt;): &VecMap&lt;String, String&gt; {
+    &display.<a href="../sui/display_registry.md#sui_display_registry_fields">fields</a>
 }
 </code></pre>
 
@@ -691,7 +691,7 @@ Get a reference to the fields of display.
 Get the cap ID for the display.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/display_registry.md#sui_display_registry_cap_id">cap_id</a>&lt;T&gt;(<a href="../sui/display.md#sui_display">display</a>: &<a href="../sui/display_registry.md#sui_display_registry_Display">sui::display_registry::Display</a>&lt;T&gt;): <a href="../std/option.md#std_option_Option">std::option::Option</a>&lt;<a href="../sui/object.md#sui_object_ID">sui::object::ID</a>&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/display_registry.md#sui_display_registry_cap_id">cap_id</a>&lt;T&gt;(display: &<a href="../sui/display_registry.md#sui_display_registry_Display">sui::display_registry::Display</a>&lt;T&gt;): <a href="../std/option.md#std_option_Option">std::option::Option</a>&lt;<a href="../sui/object.md#sui_object_ID">sui::object::ID</a>&gt;
 </code></pre>
 
 
@@ -700,8 +700,8 @@ Get the cap ID for the display.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/display_registry.md#sui_display_registry_cap_id">cap_id</a>&lt;T&gt;(<a href="../sui/display.md#sui_display">display</a>: &<a href="../sui/display_registry.md#sui_display_registry_Display">Display</a>&lt;T&gt;): Option&lt;ID&gt; {
-    <a href="../sui/display.md#sui_display">display</a>.<a href="../sui/display_registry.md#sui_display_registry_cap_id">cap_id</a>
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/display_registry.md#sui_display_registry_cap_id">cap_id</a>&lt;T&gt;(display: &<a href="../sui/display_registry.md#sui_display_registry_Display">Display</a>&lt;T&gt;): Option&lt;ID&gt; {
+    display.<a href="../sui/display_registry.md#sui_display_registry_cap_id">cap_id</a>
 }
 </code></pre>
 
@@ -715,7 +715,7 @@ Get the cap ID for the display.
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/display_registry.md#sui_display_registry_migration_cap_receiver">migration_cap_receiver</a>(): <b>address</b>
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/display_registry.md#sui_display_registry_migration_cap_receiver">migration_cap_receiver</a>(): <b>address</b>
 </code></pre>
 
 
@@ -724,7 +724,7 @@ Get the cap ID for the display.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/display_registry.md#sui_display_registry_migration_cap_receiver">migration_cap_receiver</a>(): <b>address</b> {
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/display_registry.md#sui_display_registry_migration_cap_receiver">migration_cap_receiver</a>(): <b>address</b> {
     <a href="../sui/display_registry.md#sui_display_registry_SYSTEM_MIGRATION_ADDRESS">SYSTEM_MIGRATION_ADDRESS</a>
 }
 </code></pre>
@@ -753,14 +753,14 @@ Get the cap ID for the display.
     ctx: &<b>mut</b> TxContext,
 ): (<a href="../sui/display_registry.md#sui_display_registry_Display">Display</a>&lt;T&gt;, <a href="../sui/display_registry.md#sui_display_registry_DisplayCap">DisplayCap</a>&lt;T&gt;) {
     <b>let</b> key = <a href="../sui/display_registry.md#sui_display_registry_DisplayKey">DisplayKey</a>&lt;T&gt;();
-    <b>assert</b>!(!<a href="../sui/derived_object.md#sui_derived_object_exists">derived_object::exists</a>(&registry.id, key), <a href="../sui/display_registry.md#sui_display_registry_EDisplayAlreadyExists">EDisplayAlreadyExists</a>);
-    <b>let</b> cap = <a href="../sui/display_registry.md#sui_display_registry_DisplayCap">DisplayCap</a>&lt;T&gt; { id: <a href="../sui/object.md#sui_object_new">object::new</a>(ctx) };
-    <b>let</b> <a href="../sui/display.md#sui_display">display</a> = <a href="../sui/display_registry.md#sui_display_registry_Display">Display</a>&lt;T&gt; {
-        id: <a href="../sui/derived_object.md#sui_derived_object_claim">derived_object::claim</a>(&<b>mut</b> registry.id, key),
-        <a href="../sui/display_registry.md#sui_display_registry_fields">fields</a>: <a href="../sui/vec_map.md#sui_vec_map_empty">vec_map::empty</a>(),
+    <b>assert</b>!(!derived_object::exists(&registry.id, key), <a href="../sui/display_registry.md#sui_display_registry_EDisplayAlreadyExists">EDisplayAlreadyExists</a>);
+    <b>let</b> cap = <a href="../sui/display_registry.md#sui_display_registry_DisplayCap">DisplayCap</a>&lt;T&gt; { id: object::new(ctx) };
+    <b>let</b> display = <a href="../sui/display_registry.md#sui_display_registry_Display">Display</a>&lt;T&gt; {
+        id: derived_object::claim(&<b>mut</b> registry.id, key),
+        <a href="../sui/display_registry.md#sui_display_registry_fields">fields</a>: vec_map::empty(),
         <a href="../sui/display_registry.md#sui_display_registry_cap_id">cap_id</a>: option::some(cap.id.to_inner()),
     };
-    (<a href="../sui/display.md#sui_display">display</a>, cap)
+    (display, cap)
 }
 </code></pre>
 
@@ -786,11 +786,11 @@ Create a new display registry object callable only from 0x0 (end of epoch)
 
 <pre><code><b>fun</b> <a href="../sui/display_registry.md#sui_display_registry_create">create</a>(ctx: &<b>mut</b> TxContext) {
     <b>assert</b>!(ctx.sender() == @0x0, <a href="../sui/display_registry.md#sui_display_registry_ENotSystemAddress">ENotSystemAddress</a>);
-    <a href="../sui/transfer.md#sui_transfer_share_object">transfer::share_object</a>(<a href="../sui/display_registry.md#sui_display_registry_DisplayRegistry">DisplayRegistry</a> {
-        id: <a href="../sui/object.md#sui_object_sui_display_registry_object_id">object::sui_display_registry_object_id</a>(),
+    transfer::share_object(<a href="../sui/display_registry.md#sui_display_registry_DisplayRegistry">DisplayRegistry</a> {
+        id: object::sui_display_registry_object_id(),
     });
-    <a href="../sui/transfer.md#sui_transfer_transfer">transfer::transfer</a>(
-        <a href="../sui/display_registry.md#sui_display_registry_SystemMigrationCap">SystemMigrationCap</a> { id: <a href="../sui/object.md#sui_object_new">object::new</a>(ctx) },
+    transfer::transfer(
+        <a href="../sui/display_registry.md#sui_display_registry_SystemMigrationCap">SystemMigrationCap</a> { id: object::new(ctx) },
         <a href="../sui/display_registry.md#sui_display_registry_SYSTEM_MIGRATION_ADDRESS">SYSTEM_MIGRATION_ADDRESS</a>,
     );
 }

--- a/crates/sui-framework/docs/sui/dynamic_field.md
+++ b/crates/sui-framework/docs/sui/dynamic_field.md
@@ -144,11 +144,11 @@ The object added as a dynamic field was previously a shared object
 
 ## Function `add`
 
-Adds a dynamic field to the object <code><a href="../sui/object.md#sui_object">object</a>: &<b>mut</b> UID</code> at field specified by <code>name: Name</code>.
+Adds a dynamic field to the object <code>object: &<b>mut</b> UID</code> at field specified by <code>name: Name</code>.
 Aborts with <code><a href="../sui/dynamic_field.md#sui_dynamic_field_EFieldAlreadyExists">EFieldAlreadyExists</a></code> if the object already has that field with that name.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/dynamic_field.md#sui_dynamic_field_add">add</a>&lt;Name: <b>copy</b>, drop, store, Value: store&gt;(<a href="../sui/object.md#sui_object">object</a>: &<b>mut</b> <a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, name: Name, value: Value)
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/dynamic_field.md#sui_dynamic_field_add">add</a>&lt;Name: <b>copy</b>, drop, store, Value: store&gt;(object: &<b>mut</b> <a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, name: Name, value: Value)
 </code></pre>
 
 
@@ -159,15 +159,15 @@ Aborts with <code><a href="../sui/dynamic_field.md#sui_dynamic_field_EFieldAlrea
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/dynamic_field.md#sui_dynamic_field_add">add</a>&lt;Name: <b>copy</b> + drop + store, Value: store&gt;(
     // we <b>use</b> &<b>mut</b> UID in several spots <b>for</b> access control
-    <a href="../sui/object.md#sui_object">object</a>: &<b>mut</b> UID,
+    object: &<b>mut</b> UID,
     name: Name,
     value: Value,
 ) {
-    <b>let</b> object_addr = <a href="../sui/object.md#sui_object">object</a>.to_address();
-    <b>let</b> <a href="../sui/hash.md#sui_hash">hash</a> = <a href="../sui/dynamic_field.md#sui_dynamic_field_hash_type_and_key">hash_type_and_key</a>(object_addr, name);
-    <b>assert</b>!(!<a href="../sui/dynamic_field.md#sui_dynamic_field_has_child_object">has_child_object</a>(object_addr, <a href="../sui/hash.md#sui_hash">hash</a>), <a href="../sui/dynamic_field.md#sui_dynamic_field_EFieldAlreadyExists">EFieldAlreadyExists</a>);
+    <b>let</b> object_addr = object.to_address();
+    <b>let</b> hash = <a href="../sui/dynamic_field.md#sui_dynamic_field_hash_type_and_key">hash_type_and_key</a>(object_addr, name);
+    <b>assert</b>!(!<a href="../sui/dynamic_field.md#sui_dynamic_field_has_child_object">has_child_object</a>(object_addr, hash), <a href="../sui/dynamic_field.md#sui_dynamic_field_EFieldAlreadyExists">EFieldAlreadyExists</a>);
     <b>let</b> field = <a href="../sui/dynamic_field.md#sui_dynamic_field_Field">Field</a> {
-        id: <a href="../sui/object.md#sui_object_new_uid_from_hash">object::new_uid_from_hash</a>(<a href="../sui/hash.md#sui_hash">hash</a>),
+        id: object::new_uid_from_hash(hash),
         name,
         value,
     };
@@ -183,13 +183,13 @@ Aborts with <code><a href="../sui/dynamic_field.md#sui_dynamic_field_EFieldAlrea
 
 ## Function `borrow`
 
-Immutably borrows the <code><a href="../sui/object.md#sui_object">object</a></code>s dynamic field with the name specified by <code>name: Name</code>.
+Immutably borrows the <code>object</code>s dynamic field with the name specified by <code>name: Name</code>.
 Aborts with <code><a href="../sui/dynamic_field.md#sui_dynamic_field_EFieldDoesNotExist">EFieldDoesNotExist</a></code> if the object does not have a field with that name.
 Aborts with <code><a href="../sui/dynamic_field.md#sui_dynamic_field_EFieldTypeMismatch">EFieldTypeMismatch</a></code> if the field exists, but the value does not have the specified
 type.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/borrow.md#sui_borrow">borrow</a>&lt;Name: <b>copy</b>, drop, store, Value: store&gt;(<a href="../sui/object.md#sui_object">object</a>: &<a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, name: Name): &Value
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/dynamic_field.md#sui_dynamic_field_borrow">borrow</a>&lt;Name: <b>copy</b>, drop, store, Value: store&gt;(object: &<a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, name: Name): &Value
 </code></pre>
 
 
@@ -198,10 +198,10 @@ type.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/borrow.md#sui_borrow">borrow</a>&lt;Name: <b>copy</b> + drop + store, Value: store&gt;(<a href="../sui/object.md#sui_object">object</a>: &UID, name: Name): &Value {
-    <b>let</b> object_addr = <a href="../sui/object.md#sui_object">object</a>.to_address();
-    <b>let</b> <a href="../sui/hash.md#sui_hash">hash</a> = <a href="../sui/dynamic_field.md#sui_dynamic_field_hash_type_and_key">hash_type_and_key</a>(object_addr, name);
-    <b>let</b> field = <a href="../sui/dynamic_field.md#sui_dynamic_field_borrow_child_object">borrow_child_object</a>&lt;<a href="../sui/dynamic_field.md#sui_dynamic_field_Field">Field</a>&lt;Name, Value&gt;&gt;(<a href="../sui/object.md#sui_object">object</a>, <a href="../sui/hash.md#sui_hash">hash</a>);
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/dynamic_field.md#sui_dynamic_field_borrow">borrow</a>&lt;Name: <b>copy</b> + drop + store, Value: store&gt;(object: &UID, name: Name): &Value {
+    <b>let</b> object_addr = object.to_address();
+    <b>let</b> hash = <a href="../sui/dynamic_field.md#sui_dynamic_field_hash_type_and_key">hash_type_and_key</a>(object_addr, name);
+    <b>let</b> field = <a href="../sui/dynamic_field.md#sui_dynamic_field_borrow_child_object">borrow_child_object</a>&lt;<a href="../sui/dynamic_field.md#sui_dynamic_field_Field">Field</a>&lt;Name, Value&gt;&gt;(object, hash);
     &field.value
 }
 </code></pre>
@@ -214,13 +214,13 @@ type.
 
 ## Function `borrow_mut`
 
-Mutably borrows the <code><a href="../sui/object.md#sui_object">object</a></code>s dynamic field with the name specified by <code>name: Name</code>.
+Mutably borrows the <code>object</code>s dynamic field with the name specified by <code>name: Name</code>.
 Aborts with <code><a href="../sui/dynamic_field.md#sui_dynamic_field_EFieldDoesNotExist">EFieldDoesNotExist</a></code> if the object does not have a field with that name.
 Aborts with <code><a href="../sui/dynamic_field.md#sui_dynamic_field_EFieldTypeMismatch">EFieldTypeMismatch</a></code> if the field exists, but the value does not have the specified
 type.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/dynamic_field.md#sui_dynamic_field_borrow_mut">borrow_mut</a>&lt;Name: <b>copy</b>, drop, store, Value: store&gt;(<a href="../sui/object.md#sui_object">object</a>: &<b>mut</b> <a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, name: Name): &<b>mut</b> Value
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/dynamic_field.md#sui_dynamic_field_borrow_mut">borrow_mut</a>&lt;Name: <b>copy</b>, drop, store, Value: store&gt;(object: &<b>mut</b> <a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, name: Name): &<b>mut</b> Value
 </code></pre>
 
 
@@ -230,12 +230,12 @@ type.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/dynamic_field.md#sui_dynamic_field_borrow_mut">borrow_mut</a>&lt;Name: <b>copy</b> + drop + store, Value: store&gt;(
-    <a href="../sui/object.md#sui_object">object</a>: &<b>mut</b> UID,
+    object: &<b>mut</b> UID,
     name: Name,
 ): &<b>mut</b> Value {
-    <b>let</b> object_addr = <a href="../sui/object.md#sui_object">object</a>.to_address();
-    <b>let</b> <a href="../sui/hash.md#sui_hash">hash</a> = <a href="../sui/dynamic_field.md#sui_dynamic_field_hash_type_and_key">hash_type_and_key</a>(object_addr, name);
-    <b>let</b> field = <a href="../sui/dynamic_field.md#sui_dynamic_field_borrow_child_object_mut">borrow_child_object_mut</a>&lt;<a href="../sui/dynamic_field.md#sui_dynamic_field_Field">Field</a>&lt;Name, Value&gt;&gt;(<a href="../sui/object.md#sui_object">object</a>, <a href="../sui/hash.md#sui_hash">hash</a>);
+    <b>let</b> object_addr = object.to_address();
+    <b>let</b> hash = <a href="../sui/dynamic_field.md#sui_dynamic_field_hash_type_and_key">hash_type_and_key</a>(object_addr, name);
+    <b>let</b> field = <a href="../sui/dynamic_field.md#sui_dynamic_field_borrow_child_object_mut">borrow_child_object_mut</a>&lt;<a href="../sui/dynamic_field.md#sui_dynamic_field_Field">Field</a>&lt;Name, Value&gt;&gt;(object, hash);
     &<b>mut</b> field.value
 }
 </code></pre>
@@ -248,14 +248,14 @@ type.
 
 ## Function `remove`
 
-Removes the <code><a href="../sui/object.md#sui_object">object</a></code>s dynamic field with the name specified by <code>name: Name</code> and returns the
+Removes the <code>object</code>s dynamic field with the name specified by <code>name: Name</code> and returns the
 bound value.
 Aborts with <code><a href="../sui/dynamic_field.md#sui_dynamic_field_EFieldDoesNotExist">EFieldDoesNotExist</a></code> if the object does not have a field with that name.
 Aborts with <code><a href="../sui/dynamic_field.md#sui_dynamic_field_EFieldTypeMismatch">EFieldTypeMismatch</a></code> if the field exists, but the value does not have the specified
 type.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/dynamic_field.md#sui_dynamic_field_remove">remove</a>&lt;Name: <b>copy</b>, drop, store, Value: store&gt;(<a href="../sui/object.md#sui_object">object</a>: &<b>mut</b> <a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, name: Name): Value
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/dynamic_field.md#sui_dynamic_field_remove">remove</a>&lt;Name: <b>copy</b>, drop, store, Value: store&gt;(object: &<b>mut</b> <a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, name: Name): Value
 </code></pre>
 
 
@@ -264,10 +264,10 @@ type.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/dynamic_field.md#sui_dynamic_field_remove">remove</a>&lt;Name: <b>copy</b> + drop + store, Value: store&gt;(<a href="../sui/object.md#sui_object">object</a>: &<b>mut</b> UID, name: Name): Value {
-    <b>let</b> object_addr = <a href="../sui/object.md#sui_object">object</a>.to_address();
-    <b>let</b> <a href="../sui/hash.md#sui_hash">hash</a> = <a href="../sui/dynamic_field.md#sui_dynamic_field_hash_type_and_key">hash_type_and_key</a>(object_addr, name);
-    <b>let</b> <a href="../sui/dynamic_field.md#sui_dynamic_field_Field">Field</a> { id, name: _, value } = <a href="../sui/dynamic_field.md#sui_dynamic_field_remove_child_object">remove_child_object</a>&lt;<a href="../sui/dynamic_field.md#sui_dynamic_field_Field">Field</a>&lt;Name, Value&gt;&gt;(object_addr, <a href="../sui/hash.md#sui_hash">hash</a>);
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/dynamic_field.md#sui_dynamic_field_remove">remove</a>&lt;Name: <b>copy</b> + drop + store, Value: store&gt;(object: &<b>mut</b> UID, name: Name): Value {
+    <b>let</b> object_addr = object.to_address();
+    <b>let</b> hash = <a href="../sui/dynamic_field.md#sui_dynamic_field_hash_type_and_key">hash_type_and_key</a>(object_addr, name);
+    <b>let</b> <a href="../sui/dynamic_field.md#sui_dynamic_field_Field">Field</a> { id, name: _, value } = <a href="../sui/dynamic_field.md#sui_dynamic_field_remove_child_object">remove_child_object</a>&lt;<a href="../sui/dynamic_field.md#sui_dynamic_field_Field">Field</a>&lt;Name, Value&gt;&gt;(object_addr, hash);
     id.delete();
     value
 }
@@ -281,11 +281,11 @@ type.
 
 ## Function `exists_`
 
-Returns true if and only if the <code><a href="../sui/object.md#sui_object">object</a></code> has a dynamic field with the name specified by
+Returns true if and only if the <code>object</code> has a dynamic field with the name specified by
 <code>name: Name</code> but without specifying the <code>Value</code> type
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/dynamic_field.md#sui_dynamic_field_exists_">exists_</a>&lt;Name: <b>copy</b>, drop, store&gt;(<a href="../sui/object.md#sui_object">object</a>: &<a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, name: Name): bool
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/dynamic_field.md#sui_dynamic_field_exists_">exists_</a>&lt;Name: <b>copy</b>, drop, store&gt;(object: &<a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, name: Name): bool
 </code></pre>
 
 
@@ -294,10 +294,10 @@ Returns true if and only if the <code><a href="../sui/object.md#sui_object">obje
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/dynamic_field.md#sui_dynamic_field_exists_">exists_</a>&lt;Name: <b>copy</b> + drop + store&gt;(<a href="../sui/object.md#sui_object">object</a>: &UID, name: Name): bool {
-    <b>let</b> object_addr = <a href="../sui/object.md#sui_object">object</a>.to_address();
-    <b>let</b> <a href="../sui/hash.md#sui_hash">hash</a> = <a href="../sui/dynamic_field.md#sui_dynamic_field_hash_type_and_key">hash_type_and_key</a>(object_addr, name);
-    <a href="../sui/dynamic_field.md#sui_dynamic_field_has_child_object">has_child_object</a>(object_addr, <a href="../sui/hash.md#sui_hash">hash</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/dynamic_field.md#sui_dynamic_field_exists_">exists_</a>&lt;Name: <b>copy</b> + drop + store&gt;(object: &UID, name: Name): bool {
+    <b>let</b> object_addr = object.to_address();
+    <b>let</b> hash = <a href="../sui/dynamic_field.md#sui_dynamic_field_hash_type_and_key">hash_type_and_key</a>(object_addr, name);
+    <a href="../sui/dynamic_field.md#sui_dynamic_field_has_child_object">has_child_object</a>(object_addr, hash)
 }
 </code></pre>
 
@@ -312,7 +312,7 @@ Returns true if and only if the <code><a href="../sui/object.md#sui_object">obje
 Removes the dynamic field if it exists. Returns the <code>some(Value)</code> if it exists or none otherwise.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/dynamic_field.md#sui_dynamic_field_remove_if_exists">remove_if_exists</a>&lt;Name: <b>copy</b>, drop, store, Value: store&gt;(<a href="../sui/object.md#sui_object">object</a>: &<b>mut</b> <a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, name: Name): <a href="../std/option.md#std_option_Option">std::option::Option</a>&lt;Value&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/dynamic_field.md#sui_dynamic_field_remove_if_exists">remove_if_exists</a>&lt;Name: <b>copy</b>, drop, store, Value: store&gt;(object: &<b>mut</b> <a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, name: Name): <a href="../std/option.md#std_option_Option">std::option::Option</a>&lt;Value&gt;
 </code></pre>
 
 
@@ -322,11 +322,11 @@ Removes the dynamic field if it exists. Returns the <code>some(Value)</code> if 
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/dynamic_field.md#sui_dynamic_field_remove_if_exists">remove_if_exists</a>&lt;Name: <b>copy</b> + drop + store, Value: store&gt;(
-    <a href="../sui/object.md#sui_object">object</a>: &<b>mut</b> UID,
+    object: &<b>mut</b> UID,
     name: Name,
 ): Option&lt;Value&gt; {
-    <b>if</b> (<a href="../sui/dynamic_field.md#sui_dynamic_field_exists_">exists_</a>&lt;Name&gt;(<a href="../sui/object.md#sui_object">object</a>, name)) {
-        option::some(<a href="../sui/dynamic_field.md#sui_dynamic_field_remove">remove</a>(<a href="../sui/object.md#sui_object">object</a>, name))
+    <b>if</b> (<a href="../sui/dynamic_field.md#sui_dynamic_field_exists_">exists_</a>&lt;Name&gt;(object, name)) {
+        option::some(<a href="../sui/dynamic_field.md#sui_dynamic_field_remove">remove</a>(object, name))
     } <b>else</b> {
         option::none()
     }
@@ -341,11 +341,11 @@ Removes the dynamic field if it exists. Returns the <code>some(Value)</code> if 
 
 ## Function `exists_with_type`
 
-Returns true if and only if the <code><a href="../sui/object.md#sui_object">object</a></code> has a dynamic field with the name specified by
+Returns true if and only if the <code>object</code> has a dynamic field with the name specified by
 <code>name: Name</code> with an assigned value of type <code>Value</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/dynamic_field.md#sui_dynamic_field_exists_with_type">exists_with_type</a>&lt;Name: <b>copy</b>, drop, store, Value: store&gt;(<a href="../sui/object.md#sui_object">object</a>: &<a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, name: Name): bool
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/dynamic_field.md#sui_dynamic_field_exists_with_type">exists_with_type</a>&lt;Name: <b>copy</b>, drop, store, Value: store&gt;(object: &<a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, name: Name): bool
 </code></pre>
 
 
@@ -355,12 +355,12 @@ Returns true if and only if the <code><a href="../sui/object.md#sui_object">obje
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/dynamic_field.md#sui_dynamic_field_exists_with_type">exists_with_type</a>&lt;Name: <b>copy</b> + drop + store, Value: store&gt;(
-    <a href="../sui/object.md#sui_object">object</a>: &UID,
+    object: &UID,
     name: Name,
 ): bool {
-    <b>let</b> object_addr = <a href="../sui/object.md#sui_object">object</a>.to_address();
-    <b>let</b> <a href="../sui/hash.md#sui_hash">hash</a> = <a href="../sui/dynamic_field.md#sui_dynamic_field_hash_type_and_key">hash_type_and_key</a>(object_addr, name);
-    <a href="../sui/dynamic_field.md#sui_dynamic_field_has_child_object_with_ty">has_child_object_with_ty</a>&lt;<a href="../sui/dynamic_field.md#sui_dynamic_field_Field">Field</a>&lt;Name, Value&gt;&gt;(object_addr, <a href="../sui/hash.md#sui_hash">hash</a>)
+    <b>let</b> object_addr = object.to_address();
+    <b>let</b> hash = <a href="../sui/dynamic_field.md#sui_dynamic_field_hash_type_and_key">hash_type_and_key</a>(object_addr, name);
+    <a href="../sui/dynamic_field.md#sui_dynamic_field_has_child_object_with_ty">has_child_object_with_ty</a>&lt;<a href="../sui/dynamic_field.md#sui_dynamic_field_Field">Field</a>&lt;Name, Value&gt;&gt;(object_addr, hash)
 }
 </code></pre>
 
@@ -374,7 +374,7 @@ Returns true if and only if the <code><a href="../sui/object.md#sui_object">obje
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/dynamic_field.md#sui_dynamic_field_field_info">field_info</a>&lt;Name: <b>copy</b>, drop, store&gt;(<a href="../sui/object.md#sui_object">object</a>: &<a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, name: Name): (&<a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, <b>address</b>)
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/dynamic_field.md#sui_dynamic_field_field_info">field_info</a>&lt;Name: <b>copy</b>, drop, store&gt;(object: &<a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, name: Name): (&<a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, <b>address</b>)
 </code></pre>
 
 
@@ -383,13 +383,13 @@ Returns true if and only if the <code><a href="../sui/object.md#sui_object">obje
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/dynamic_field.md#sui_dynamic_field_field_info">field_info</a>&lt;Name: <b>copy</b> + drop + store&gt;(
-    <a href="../sui/object.md#sui_object">object</a>: &UID,
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/dynamic_field.md#sui_dynamic_field_field_info">field_info</a>&lt;Name: <b>copy</b> + drop + store&gt;(
+    object: &UID,
     name: Name,
 ): (&UID, <b>address</b>) {
-    <b>let</b> object_addr = <a href="../sui/object.md#sui_object">object</a>.to_address();
-    <b>let</b> <a href="../sui/hash.md#sui_hash">hash</a> = <a href="../sui/dynamic_field.md#sui_dynamic_field_hash_type_and_key">hash_type_and_key</a>(object_addr, name);
-    <b>let</b> <a href="../sui/dynamic_field.md#sui_dynamic_field_Field">Field</a> { id, name: _, value } = <a href="../sui/dynamic_field.md#sui_dynamic_field_borrow_child_object">borrow_child_object</a>&lt;<a href="../sui/dynamic_field.md#sui_dynamic_field_Field">Field</a>&lt;Name, ID&gt;&gt;(<a href="../sui/object.md#sui_object">object</a>, <a href="../sui/hash.md#sui_hash">hash</a>);
+    <b>let</b> object_addr = object.to_address();
+    <b>let</b> hash = <a href="../sui/dynamic_field.md#sui_dynamic_field_hash_type_and_key">hash_type_and_key</a>(object_addr, name);
+    <b>let</b> <a href="../sui/dynamic_field.md#sui_dynamic_field_Field">Field</a> { id, name: _, value } = <a href="../sui/dynamic_field.md#sui_dynamic_field_borrow_child_object">borrow_child_object</a>&lt;<a href="../sui/dynamic_field.md#sui_dynamic_field_Field">Field</a>&lt;Name, ID&gt;&gt;(object, hash);
     (id, value.to_address())
 }
 </code></pre>
@@ -404,7 +404,7 @@ Returns true if and only if the <code><a href="../sui/object.md#sui_object">obje
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/dynamic_field.md#sui_dynamic_field_field_info_mut">field_info_mut</a>&lt;Name: <b>copy</b>, drop, store&gt;(<a href="../sui/object.md#sui_object">object</a>: &<b>mut</b> <a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, name: Name): (&<b>mut</b> <a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, <b>address</b>)
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/dynamic_field.md#sui_dynamic_field_field_info_mut">field_info_mut</a>&lt;Name: <b>copy</b>, drop, store&gt;(object: &<b>mut</b> <a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, name: Name): (&<b>mut</b> <a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, <b>address</b>)
 </code></pre>
 
 
@@ -413,13 +413,13 @@ Returns true if and only if the <code><a href="../sui/object.md#sui_object">obje
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/dynamic_field.md#sui_dynamic_field_field_info_mut">field_info_mut</a>&lt;Name: <b>copy</b> + drop + store&gt;(
-    <a href="../sui/object.md#sui_object">object</a>: &<b>mut</b> UID,
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/dynamic_field.md#sui_dynamic_field_field_info_mut">field_info_mut</a>&lt;Name: <b>copy</b> + drop + store&gt;(
+    object: &<b>mut</b> UID,
     name: Name,
 ): (&<b>mut</b> UID, <b>address</b>) {
-    <b>let</b> object_addr = <a href="../sui/object.md#sui_object">object</a>.to_address();
-    <b>let</b> <a href="../sui/hash.md#sui_hash">hash</a> = <a href="../sui/dynamic_field.md#sui_dynamic_field_hash_type_and_key">hash_type_and_key</a>(object_addr, name);
-    <b>let</b> <a href="../sui/dynamic_field.md#sui_dynamic_field_Field">Field</a> { id, name: _, value } = <a href="../sui/dynamic_field.md#sui_dynamic_field_borrow_child_object_mut">borrow_child_object_mut</a>&lt;<a href="../sui/dynamic_field.md#sui_dynamic_field_Field">Field</a>&lt;Name, ID&gt;&gt;(<a href="../sui/object.md#sui_object">object</a>, <a href="../sui/hash.md#sui_hash">hash</a>);
+    <b>let</b> object_addr = object.to_address();
+    <b>let</b> hash = <a href="../sui/dynamic_field.md#sui_dynamic_field_hash_type_and_key">hash_type_and_key</a>(object_addr, name);
+    <b>let</b> <a href="../sui/dynamic_field.md#sui_dynamic_field_Field">Field</a> { id, name: _, value } = <a href="../sui/dynamic_field.md#sui_dynamic_field_borrow_child_object_mut">borrow_child_object_mut</a>&lt;<a href="../sui/dynamic_field.md#sui_dynamic_field_Field">Field</a>&lt;Name, ID&gt;&gt;(object, hash);
     (id, value.to_address())
 }
 </code></pre>
@@ -435,7 +435,7 @@ Returns true if and only if the <code><a href="../sui/object.md#sui_object">obje
 May abort with <code><a href="../sui/dynamic_field.md#sui_dynamic_field_EBCSSerializationFailure">EBCSSerializationFailure</a></code>.
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/dynamic_field.md#sui_dynamic_field_hash_type_and_key">hash_type_and_key</a>&lt;K: <b>copy</b>, drop, store&gt;(parent: <b>address</b>, k: K): <b>address</b>
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/dynamic_field.md#sui_dynamic_field_hash_type_and_key">hash_type_and_key</a>&lt;K: <b>copy</b>, drop, store&gt;(parent: <b>address</b>, k: K): <b>address</b>
 </code></pre>
 
 
@@ -444,7 +444,7 @@ May abort with <code><a href="../sui/dynamic_field.md#sui_dynamic_field_EBCSSeri
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>native</b> <b>fun</b> <a href="../sui/dynamic_field.md#sui_dynamic_field_hash_type_and_key">hash_type_and_key</a>&lt;K: <b>copy</b> + drop + store&gt;(
+<pre><code><b>public</b>(package) <b>native</b> <b>fun</b> <a href="../sui/dynamic_field.md#sui_dynamic_field_hash_type_and_key">hash_type_and_key</a>&lt;K: <b>copy</b> + drop + store&gt;(
     parent: <b>address</b>,
     k: K,
 ): <b>address</b>;
@@ -460,7 +460,7 @@ May abort with <code><a href="../sui/dynamic_field.md#sui_dynamic_field_EBCSSeri
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/dynamic_field.md#sui_dynamic_field_add_child_object">add_child_object</a>&lt;Child: key&gt;(parent: <b>address</b>, child: Child)
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/dynamic_field.md#sui_dynamic_field_add_child_object">add_child_object</a>&lt;Child: key&gt;(parent: <b>address</b>, child: Child)
 </code></pre>
 
 
@@ -469,7 +469,7 @@ May abort with <code><a href="../sui/dynamic_field.md#sui_dynamic_field_EBCSSeri
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>native</b> <b>fun</b> <a href="../sui/dynamic_field.md#sui_dynamic_field_add_child_object">add_child_object</a>&lt;Child: key&gt;(parent: <b>address</b>, child: Child);
+<pre><code><b>public</b>(package) <b>native</b> <b>fun</b> <a href="../sui/dynamic_field.md#sui_dynamic_field_add_child_object">add_child_object</a>&lt;Child: key&gt;(parent: <b>address</b>, child: Child);
 </code></pre>
 
 
@@ -486,7 +486,7 @@ and may also abort with <code><a href="../sui/dynamic_field.md#sui_dynamic_field
 we need two versions to return a reference or a mutable reference
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/dynamic_field.md#sui_dynamic_field_borrow_child_object">borrow_child_object</a>&lt;Child: key&gt;(<a href="../sui/object.md#sui_object">object</a>: &<a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, id: <b>address</b>): &Child
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/dynamic_field.md#sui_dynamic_field_borrow_child_object">borrow_child_object</a>&lt;Child: key&gt;(object: &<a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, id: <b>address</b>): &Child
 </code></pre>
 
 
@@ -495,7 +495,7 @@ we need two versions to return a reference or a mutable reference
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>native</b> <b>fun</b> <a href="../sui/dynamic_field.md#sui_dynamic_field_borrow_child_object">borrow_child_object</a>&lt;Child: key&gt;(<a href="../sui/object.md#sui_object">object</a>: &UID, id: <b>address</b>): &Child;
+<pre><code><b>public</b>(package) <b>native</b> <b>fun</b> <a href="../sui/dynamic_field.md#sui_dynamic_field_borrow_child_object">borrow_child_object</a>&lt;Child: key&gt;(object: &UID, id: <b>address</b>): &Child;
 </code></pre>
 
 
@@ -508,7 +508,7 @@ we need two versions to return a reference or a mutable reference
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/dynamic_field.md#sui_dynamic_field_borrow_child_object_mut">borrow_child_object_mut</a>&lt;Child: key&gt;(<a href="../sui/object.md#sui_object">object</a>: &<b>mut</b> <a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, id: <b>address</b>): &<b>mut</b> Child
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/dynamic_field.md#sui_dynamic_field_borrow_child_object_mut">borrow_child_object_mut</a>&lt;Child: key&gt;(object: &<b>mut</b> <a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, id: <b>address</b>): &<b>mut</b> Child
 </code></pre>
 
 
@@ -517,8 +517,8 @@ we need two versions to return a reference or a mutable reference
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>native</b> <b>fun</b> <a href="../sui/dynamic_field.md#sui_dynamic_field_borrow_child_object_mut">borrow_child_object_mut</a>&lt;Child: key&gt;(
-    <a href="../sui/object.md#sui_object">object</a>: &<b>mut</b> UID,
+<pre><code><b>public</b>(package) <b>native</b> <b>fun</b> <a href="../sui/dynamic_field.md#sui_dynamic_field_borrow_child_object_mut">borrow_child_object_mut</a>&lt;Child: key&gt;(
+    object: &<b>mut</b> UID,
     id: <b>address</b>,
 ): &<b>mut</b> Child;
 </code></pre>
@@ -536,7 +536,7 @@ or throws <code><a href="../sui/dynamic_field.md#sui_dynamic_field_EFieldTypeMis
 and may also abort with <code><a href="../sui/dynamic_field.md#sui_dynamic_field_EBCSSerializationFailure">EBCSSerializationFailure</a></code>.
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/dynamic_field.md#sui_dynamic_field_remove_child_object">remove_child_object</a>&lt;Child: key&gt;(parent: <b>address</b>, id: <b>address</b>): Child
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/dynamic_field.md#sui_dynamic_field_remove_child_object">remove_child_object</a>&lt;Child: key&gt;(parent: <b>address</b>, id: <b>address</b>): Child
 </code></pre>
 
 
@@ -545,7 +545,7 @@ and may also abort with <code><a href="../sui/dynamic_field.md#sui_dynamic_field
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>native</b> <b>fun</b> <a href="../sui/dynamic_field.md#sui_dynamic_field_remove_child_object">remove_child_object</a>&lt;Child: key&gt;(parent: <b>address</b>, id: <b>address</b>): Child;
+<pre><code><b>public</b>(package) <b>native</b> <b>fun</b> <a href="../sui/dynamic_field.md#sui_dynamic_field_remove_child_object">remove_child_object</a>&lt;Child: key&gt;(parent: <b>address</b>, id: <b>address</b>): Child;
 </code></pre>
 
 
@@ -558,7 +558,7 @@ and may also abort with <code><a href="../sui/dynamic_field.md#sui_dynamic_field
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/dynamic_field.md#sui_dynamic_field_has_child_object">has_child_object</a>(parent: <b>address</b>, id: <b>address</b>): bool
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/dynamic_field.md#sui_dynamic_field_has_child_object">has_child_object</a>(parent: <b>address</b>, id: <b>address</b>): bool
 </code></pre>
 
 
@@ -567,7 +567,7 @@ and may also abort with <code><a href="../sui/dynamic_field.md#sui_dynamic_field
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>native</b> <b>fun</b> <a href="../sui/dynamic_field.md#sui_dynamic_field_has_child_object">has_child_object</a>(parent: <b>address</b>, id: <b>address</b>): bool;
+<pre><code><b>public</b>(package) <b>native</b> <b>fun</b> <a href="../sui/dynamic_field.md#sui_dynamic_field_has_child_object">has_child_object</a>(parent: <b>address</b>, id: <b>address</b>): bool;
 </code></pre>
 
 
@@ -580,7 +580,7 @@ and may also abort with <code><a href="../sui/dynamic_field.md#sui_dynamic_field
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/dynamic_field.md#sui_dynamic_field_has_child_object_with_ty">has_child_object_with_ty</a>&lt;Child: key&gt;(parent: <b>address</b>, id: <b>address</b>): bool
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/dynamic_field.md#sui_dynamic_field_has_child_object_with_ty">has_child_object_with_ty</a>&lt;Child: key&gt;(parent: <b>address</b>, id: <b>address</b>): bool
 </code></pre>
 
 
@@ -589,7 +589,7 @@ and may also abort with <code><a href="../sui/dynamic_field.md#sui_dynamic_field
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>native</b> <b>fun</b> <a href="../sui/dynamic_field.md#sui_dynamic_field_has_child_object_with_ty">has_child_object_with_ty</a>&lt;Child: key&gt;(parent: <b>address</b>, id: <b>address</b>): bool;
+<pre><code><b>public</b>(package) <b>native</b> <b>fun</b> <a href="../sui/dynamic_field.md#sui_dynamic_field_has_child_object_with_ty">has_child_object_with_ty</a>&lt;Child: key&gt;(parent: <b>address</b>, id: <b>address</b>): bool;
 </code></pre>
 
 

--- a/crates/sui-framework/docs/sui/dynamic_object_field.md
+++ b/crates/sui-framework/docs/sui/dynamic_object_field.md
@@ -72,11 +72,11 @@ for external tools. The difference is otherwise not observable from within Move.
 
 ## Function `add`
 
-Adds a dynamic object field to the object <code><a href="../sui/object.md#sui_object">object</a>: &<b>mut</b> UID</code> at field specified by <code>name: Name</code>.
+Adds a dynamic object field to the object <code>object: &<b>mut</b> UID</code> at field specified by <code>name: Name</code>.
 Aborts with <code>EFieldAlreadyExists</code> if the object already has that field with that name.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_add">add</a>&lt;Name: <b>copy</b>, drop, store, Value: key, store&gt;(<a href="../sui/object.md#sui_object">object</a>: &<b>mut</b> <a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, name: Name, value: Value)
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_add">add</a>&lt;Name: <b>copy</b>, drop, store, Value: key, store&gt;(object: &<b>mut</b> <a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, name: Name, value: Value)
 </code></pre>
 
 
@@ -87,11 +87,11 @@ Aborts with <code>EFieldAlreadyExists</code> if the object already has that fiel
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_add">add</a>&lt;Name: <b>copy</b> + drop + store, Value: key + store&gt;(
     // we <b>use</b> &<b>mut</b> UID in several spots <b>for</b> access control
-    <a href="../sui/object.md#sui_object">object</a>: &<b>mut</b> UID,
+    object: &<b>mut</b> UID,
     name: Name,
     value: Value,
 ) {
-    <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_add_impl">add_impl</a>!(<a href="../sui/object.md#sui_object">object</a>, name, value)
+    <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_add_impl">add_impl</a>!(object, name, value)
 }
 </code></pre>
 
@@ -103,13 +103,13 @@ Aborts with <code>EFieldAlreadyExists</code> if the object already has that fiel
 
 ## Function `borrow`
 
-Immutably borrows the <code><a href="../sui/object.md#sui_object">object</a></code>s dynamic object field with the name specified by <code>name: Name</code>.
+Immutably borrows the <code>object</code>s dynamic object field with the name specified by <code>name: Name</code>.
 Aborts with <code>EFieldDoesNotExist</code> if the object does not have a field with that name.
 Aborts with <code>EFieldTypeMismatch</code> if the field exists, but the value object does not have the
 specified type.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/borrow.md#sui_borrow">borrow</a>&lt;Name: <b>copy</b>, drop, store, Value: key, store&gt;(<a href="../sui/object.md#sui_object">object</a>: &<a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, name: Name): &Value
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_borrow">borrow</a>&lt;Name: <b>copy</b>, drop, store, Value: key, store&gt;(object: &<a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, name: Name): &Value
 </code></pre>
 
 
@@ -118,8 +118,8 @@ specified type.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/borrow.md#sui_borrow">borrow</a>&lt;Name: <b>copy</b> + drop + store, Value: key + store&gt;(<a href="../sui/object.md#sui_object">object</a>: &UID, name: Name): &Value {
-    <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_borrow_impl">borrow_impl</a>!(<a href="../sui/object.md#sui_object">object</a>, name)
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_borrow">borrow</a>&lt;Name: <b>copy</b> + drop + store, Value: key + store&gt;(object: &UID, name: Name): &Value {
+    <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_borrow_impl">borrow_impl</a>!(object, name)
 }
 </code></pre>
 
@@ -131,13 +131,13 @@ specified type.
 
 ## Function `borrow_mut`
 
-Mutably borrows the <code><a href="../sui/object.md#sui_object">object</a></code>s dynamic object field with the name specified by <code>name: Name</code>.
+Mutably borrows the <code>object</code>s dynamic object field with the name specified by <code>name: Name</code>.
 Aborts with <code>EFieldDoesNotExist</code> if the object does not have a field with that name.
 Aborts with <code>EFieldTypeMismatch</code> if the field exists, but the value object does not have the
 specified type.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_borrow_mut">borrow_mut</a>&lt;Name: <b>copy</b>, drop, store, Value: key, store&gt;(<a href="../sui/object.md#sui_object">object</a>: &<b>mut</b> <a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, name: Name): &<b>mut</b> Value
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_borrow_mut">borrow_mut</a>&lt;Name: <b>copy</b>, drop, store, Value: key, store&gt;(object: &<b>mut</b> <a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, name: Name): &<b>mut</b> Value
 </code></pre>
 
 
@@ -147,10 +147,10 @@ specified type.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_borrow_mut">borrow_mut</a>&lt;Name: <b>copy</b> + drop + store, Value: key + store&gt;(
-    <a href="../sui/object.md#sui_object">object</a>: &<b>mut</b> UID,
+    object: &<b>mut</b> UID,
     name: Name,
 ): &<b>mut</b> Value {
-    <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_borrow_mut_impl">borrow_mut_impl</a>!(<a href="../sui/object.md#sui_object">object</a>, name)
+    <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_borrow_mut_impl">borrow_mut_impl</a>!(object, name)
 }
 </code></pre>
 
@@ -162,14 +162,14 @@ specified type.
 
 ## Function `remove`
 
-Removes the <code><a href="../sui/object.md#sui_object">object</a></code>s dynamic object field with the name specified by <code>name: Name</code> and returns
+Removes the <code>object</code>s dynamic object field with the name specified by <code>name: Name</code> and returns
 the bound object.
 Aborts with <code>EFieldDoesNotExist</code> if the object does not have a field with that name.
 Aborts with <code>EFieldTypeMismatch</code> if the field exists, but the value object does not have the
 specified type.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_remove">remove</a>&lt;Name: <b>copy</b>, drop, store, Value: key, store&gt;(<a href="../sui/object.md#sui_object">object</a>: &<b>mut</b> <a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, name: Name): Value
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_remove">remove</a>&lt;Name: <b>copy</b>, drop, store, Value: key, store&gt;(object: &<b>mut</b> <a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, name: Name): Value
 </code></pre>
 
 
@@ -179,10 +179,10 @@ specified type.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_remove">remove</a>&lt;Name: <b>copy</b> + drop + store, Value: key + store&gt;(
-    <a href="../sui/object.md#sui_object">object</a>: &<b>mut</b> UID,
+    object: &<b>mut</b> UID,
     name: Name,
 ): Value {
-    <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_remove_impl">remove_impl</a>!(<a href="../sui/object.md#sui_object">object</a>, name)
+    <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_remove_impl">remove_impl</a>!(object, name)
 }
 </code></pre>
 
@@ -194,11 +194,11 @@ specified type.
 
 ## Function `exists_`
 
-Returns true if and only if the <code><a href="../sui/object.md#sui_object">object</a></code> has a dynamic object field with the name specified by
+Returns true if and only if the <code>object</code> has a dynamic object field with the name specified by
 <code>name: Name</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_exists_">exists_</a>&lt;Name: <b>copy</b>, drop, store&gt;(<a href="../sui/object.md#sui_object">object</a>: &<a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, name: Name): bool
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_exists_">exists_</a>&lt;Name: <b>copy</b>, drop, store&gt;(object: &<a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, name: Name): bool
 </code></pre>
 
 
@@ -207,9 +207,9 @@ Returns true if and only if the <code><a href="../sui/object.md#sui_object">obje
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_exists_">exists_</a>&lt;Name: <b>copy</b> + drop + store&gt;(<a href="../sui/object.md#sui_object">object</a>: &UID, name: Name): bool {
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_exists_">exists_</a>&lt;Name: <b>copy</b> + drop + store&gt;(object: &UID, name: Name): bool {
     <b>let</b> key = <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_Wrapper">Wrapper</a> { name };
-    field::exists_with_type&lt;<a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_Wrapper">Wrapper</a>&lt;Name&gt;, ID&gt;(<a href="../sui/object.md#sui_object">object</a>, key)
+    field::exists_with_type&lt;<a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_Wrapper">Wrapper</a>&lt;Name&gt;, ID&gt;(object, key)
 }
 </code></pre>
 
@@ -221,11 +221,11 @@ Returns true if and only if the <code><a href="../sui/object.md#sui_object">obje
 
 ## Function `exists_with_type`
 
-Returns true if and only if the <code><a href="../sui/object.md#sui_object">object</a></code> has a dynamic field with the name specified by
+Returns true if and only if the <code>object</code> has a dynamic field with the name specified by
 <code>name: Name</code> with an assigned value of type <code>Value</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_exists_with_type">exists_with_type</a>&lt;Name: <b>copy</b>, drop, store, Value: key, store&gt;(<a href="../sui/object.md#sui_object">object</a>: &<a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, name: Name): bool
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_exists_with_type">exists_with_type</a>&lt;Name: <b>copy</b>, drop, store, Value: key, store&gt;(object: &<a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, name: Name): bool
 </code></pre>
 
 
@@ -235,10 +235,10 @@ Returns true if and only if the <code><a href="../sui/object.md#sui_object">obje
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_exists_with_type">exists_with_type</a>&lt;Name: <b>copy</b> + drop + store, Value: key + store&gt;(
-    <a href="../sui/object.md#sui_object">object</a>: &UID,
+    object: &UID,
     name: Name,
 ): bool {
-    <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_exists_with_type_impl">exists_with_type_impl</a>!&lt;_, Value&gt;(<a href="../sui/object.md#sui_object">object</a>, name)
+    <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_exists_with_type_impl">exists_with_type_impl</a>!&lt;_, Value&gt;(object, name)
 }
 </code></pre>
 
@@ -254,7 +254,7 @@ Returns the ID of the object associated with the dynamic object field
 Returns none otherwise
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_id">id</a>&lt;Name: <b>copy</b>, drop, store&gt;(<a href="../sui/object.md#sui_object">object</a>: &<a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, name: Name): <a href="../std/option.md#std_option_Option">std::option::Option</a>&lt;<a href="../sui/object.md#sui_object_ID">sui::object::ID</a>&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_id">id</a>&lt;Name: <b>copy</b>, drop, store&gt;(object: &<a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, name: Name): <a href="../std/option.md#std_option_Option">std::option::Option</a>&lt;<a href="../sui/object.md#sui_object_ID">sui::object::ID</a>&gt;
 </code></pre>
 
 
@@ -263,10 +263,10 @@ Returns none otherwise
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_id">id</a>&lt;Name: <b>copy</b> + drop + store&gt;(<a href="../sui/object.md#sui_object">object</a>: &UID, name: Name): Option&lt;ID&gt; {
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_id">id</a>&lt;Name: <b>copy</b> + drop + store&gt;(object: &UID, name: Name): Option&lt;ID&gt; {
     <b>let</b> key = <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_Wrapper">Wrapper</a> { name };
-    <b>if</b> (!field::exists_with_type&lt;<a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_Wrapper">Wrapper</a>&lt;Name&gt;, ID&gt;(<a href="../sui/object.md#sui_object">object</a>, key)) <b>return</b> option::none();
-    <b>let</b> (_field, value_addr) = field::field_info&lt;<a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_Wrapper">Wrapper</a>&lt;Name&gt;&gt;(<a href="../sui/object.md#sui_object">object</a>, key);
+    <b>if</b> (!field::exists_with_type&lt;<a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_Wrapper">Wrapper</a>&lt;Name&gt;, ID&gt;(object, key)) <b>return</b> option::none();
+    <b>let</b> (_field, value_addr) = field::field_info&lt;<a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_Wrapper">Wrapper</a>&lt;Name&gt;&gt;(object, key);
     option::some(value_addr.to_id())
 }
 </code></pre>
@@ -281,7 +281,7 @@ Returns none otherwise
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_internal_add">internal_add</a>&lt;Name: <b>copy</b>, drop, store, Value: key&gt;(<a href="../sui/object.md#sui_object">object</a>: &<b>mut</b> <a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, name: Name, value: Value)
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_internal_add">internal_add</a>&lt;Name: <b>copy</b>, drop, store, Value: key&gt;(object: &<b>mut</b> <a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, name: Name, value: Value)
 </code></pre>
 
 
@@ -290,13 +290,13 @@ Returns none otherwise
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_internal_add">internal_add</a>&lt;Name: <b>copy</b> + drop + store, Value: key&gt;(
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_internal_add">internal_add</a>&lt;Name: <b>copy</b> + drop + store, Value: key&gt;(
     // we <b>use</b> &<b>mut</b> UID in several spots <b>for</b> access control
-    <a href="../sui/object.md#sui_object">object</a>: &<b>mut</b> UID,
+    object: &<b>mut</b> UID,
     name: Name,
     value: Value,
 ) {
-    <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_add_impl">add_impl</a>!(<a href="../sui/object.md#sui_object">object</a>, name, value)
+    <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_add_impl">add_impl</a>!(object, name, value)
 }
 </code></pre>
 
@@ -310,7 +310,7 @@ Returns none otherwise
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_internal_borrow">internal_borrow</a>&lt;Name: <b>copy</b>, drop, store, Value: key&gt;(<a href="../sui/object.md#sui_object">object</a>: &<a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, name: Name): &Value
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_internal_borrow">internal_borrow</a>&lt;Name: <b>copy</b>, drop, store, Value: key&gt;(object: &<a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, name: Name): &Value
 </code></pre>
 
 
@@ -319,11 +319,11 @@ Returns none otherwise
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_internal_borrow">internal_borrow</a>&lt;Name: <b>copy</b> + drop + store, Value: key&gt;(
-    <a href="../sui/object.md#sui_object">object</a>: &UID,
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_internal_borrow">internal_borrow</a>&lt;Name: <b>copy</b> + drop + store, Value: key&gt;(
+    object: &UID,
     name: Name,
 ): &Value {
-    <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_borrow_impl">borrow_impl</a>!(<a href="../sui/object.md#sui_object">object</a>, name)
+    <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_borrow_impl">borrow_impl</a>!(object, name)
 }
 </code></pre>
 
@@ -337,7 +337,7 @@ Returns none otherwise
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_internal_borrow_mut">internal_borrow_mut</a>&lt;Name: <b>copy</b>, drop, store, Value: key&gt;(<a href="../sui/object.md#sui_object">object</a>: &<b>mut</b> <a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, name: Name): &<b>mut</b> Value
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_internal_borrow_mut">internal_borrow_mut</a>&lt;Name: <b>copy</b>, drop, store, Value: key&gt;(object: &<b>mut</b> <a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, name: Name): &<b>mut</b> Value
 </code></pre>
 
 
@@ -346,11 +346,11 @@ Returns none otherwise
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_internal_borrow_mut">internal_borrow_mut</a>&lt;Name: <b>copy</b> + drop + store, Value: key&gt;(
-    <a href="../sui/object.md#sui_object">object</a>: &<b>mut</b> UID,
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_internal_borrow_mut">internal_borrow_mut</a>&lt;Name: <b>copy</b> + drop + store, Value: key&gt;(
+    object: &<b>mut</b> UID,
     name: Name,
 ): &<b>mut</b> Value {
-    <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_borrow_mut_impl">borrow_mut_impl</a>!(<a href="../sui/object.md#sui_object">object</a>, name)
+    <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_borrow_mut_impl">borrow_mut_impl</a>!(object, name)
 }
 </code></pre>
 
@@ -364,7 +364,7 @@ Returns none otherwise
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_internal_remove">internal_remove</a>&lt;Name: <b>copy</b>, drop, store, Value: key&gt;(<a href="../sui/object.md#sui_object">object</a>: &<b>mut</b> <a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, name: Name): Value
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_internal_remove">internal_remove</a>&lt;Name: <b>copy</b>, drop, store, Value: key&gt;(object: &<b>mut</b> <a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, name: Name): Value
 </code></pre>
 
 
@@ -373,11 +373,11 @@ Returns none otherwise
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_internal_remove">internal_remove</a>&lt;Name: <b>copy</b> + drop + store, Value: key&gt;(
-    <a href="../sui/object.md#sui_object">object</a>: &<b>mut</b> UID,
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_internal_remove">internal_remove</a>&lt;Name: <b>copy</b> + drop + store, Value: key&gt;(
+    object: &<b>mut</b> UID,
     name: Name,
 ): Value {
-    <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_remove_impl">remove_impl</a>!(<a href="../sui/object.md#sui_object">object</a>, name)
+    <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_remove_impl">remove_impl</a>!(object, name)
 }
 </code></pre>
 
@@ -391,7 +391,7 @@ Returns none otherwise
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_internal_exists_with_type">internal_exists_with_type</a>&lt;Name: <b>copy</b>, drop, store, Value: key&gt;(<a href="../sui/object.md#sui_object">object</a>: &<a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, name: Name): bool
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_internal_exists_with_type">internal_exists_with_type</a>&lt;Name: <b>copy</b>, drop, store, Value: key&gt;(object: &<a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, name: Name): bool
 </code></pre>
 
 
@@ -400,11 +400,11 @@ Returns none otherwise
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_internal_exists_with_type">internal_exists_with_type</a>&lt;Name: <b>copy</b> + drop + store, Value: key&gt;(
-    <a href="../sui/object.md#sui_object">object</a>: &UID,
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_internal_exists_with_type">internal_exists_with_type</a>&lt;Name: <b>copy</b> + drop + store, Value: key&gt;(
+    object: &UID,
     name: Name,
 ): bool {
-    <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_exists_with_type_impl">exists_with_type_impl</a>!&lt;_, Value&gt;(<a href="../sui/object.md#sui_object">object</a>, name)
+    <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_exists_with_type_impl">exists_with_type_impl</a>!&lt;_, Value&gt;(object, name)
 }
 </code></pre>
 
@@ -418,7 +418,7 @@ Returns none otherwise
 
 
 
-<pre><code><b>macro</b> <b>fun</b> <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_add_impl">add_impl</a>&lt;$Name: <b>copy</b>, drop, store, $Value: key&gt;($<a href="../sui/object.md#sui_object">object</a>: &<b>mut</b> <a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, $name: $Name, $value: $Value)
+<pre><code><b>macro</b> <b>fun</b> <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_add_impl">add_impl</a>&lt;$Name: <b>copy</b>, drop, store, $Value: key&gt;($object: &<b>mut</b> <a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, $name: $Name, $value: $Value)
 </code></pre>
 
 
@@ -429,17 +429,17 @@ Returns none otherwise
 
 <pre><code><b>macro</b> <b>fun</b> <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_add_impl">add_impl</a>&lt;$Name: <b>copy</b> + drop + store, $Value: key&gt;(
     // we <b>use</b> &<b>mut</b> UID in several spots <b>for</b> access control
-    $<a href="../sui/object.md#sui_object">object</a>: &<b>mut</b> UID,
+    $object: &<b>mut</b> UID,
     $name: $Name,
     $value: $Value,
 ) {
-    <b>let</b> <a href="../sui/object.md#sui_object">object</a> = $<a href="../sui/object.md#sui_object">object</a>;
+    <b>let</b> object = $object;
     <b>let</b> name = $name;
     <b>let</b> value = $value;
     <b>let</b> key = <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_Wrapper">Wrapper</a> { name };
-    <b>let</b> <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_id">id</a> = <a href="../sui/object.md#sui_object_id">object::id</a>(&value);
-    field::add(<a href="../sui/object.md#sui_object">object</a>, key, <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_id">id</a>);
-    <b>let</b> (field, _) = field::field_info&lt;<a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_Wrapper">Wrapper</a>&lt;$Name&gt;&gt;(<a href="../sui/object.md#sui_object">object</a>, key);
+    <b>let</b> <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_id">id</a> = object::id(&value);
+    field::add(object, key, <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_id">id</a>);
+    <b>let</b> (field, _) = field::field_info&lt;<a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_Wrapper">Wrapper</a>&lt;$Name&gt;&gt;(object, key);
     add_child_object(field.to_address(), value);
 }
 </code></pre>
@@ -454,7 +454,7 @@ Returns none otherwise
 
 
 
-<pre><code><b>macro</b> <b>fun</b> <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_borrow_impl">borrow_impl</a>&lt;$Name: <b>copy</b>, drop, store, $Value: key&gt;($<a href="../sui/object.md#sui_object">object</a>: &<a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, $name: $Name): &$Value
+<pre><code><b>macro</b> <b>fun</b> <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_borrow_impl">borrow_impl</a>&lt;$Name: <b>copy</b>, drop, store, $Value: key&gt;($object: &<a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, $name: $Name): &$Value
 </code></pre>
 
 
@@ -464,13 +464,13 @@ Returns none otherwise
 
 
 <pre><code><b>macro</b> <b>fun</b> <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_borrow_impl">borrow_impl</a>&lt;$Name: <b>copy</b> + drop + store, $Value: key&gt;(
-    $<a href="../sui/object.md#sui_object">object</a>: &UID,
+    $object: &UID,
     $name: $Name,
 ): &$Value {
-    <b>let</b> <a href="../sui/object.md#sui_object">object</a> = $<a href="../sui/object.md#sui_object">object</a>;
+    <b>let</b> object = $object;
     <b>let</b> name = $name;
     <b>let</b> key = <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_Wrapper">Wrapper</a> { name };
-    <b>let</b> (field, value_id) = field::field_info&lt;<a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_Wrapper">Wrapper</a>&lt;$Name&gt;&gt;(<a href="../sui/object.md#sui_object">object</a>, key);
+    <b>let</b> (field, value_id) = field::field_info&lt;<a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_Wrapper">Wrapper</a>&lt;$Name&gt;&gt;(object, key);
     borrow_child_object&lt;$Value&gt;(field, value_id)
 }
 </code></pre>
@@ -485,7 +485,7 @@ Returns none otherwise
 
 
 
-<pre><code><b>macro</b> <b>fun</b> <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_borrow_mut_impl">borrow_mut_impl</a>&lt;$Name: <b>copy</b>, drop, store, $Value: key&gt;($<a href="../sui/object.md#sui_object">object</a>: &<b>mut</b> <a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, $name: $Name): &<b>mut</b> $Value
+<pre><code><b>macro</b> <b>fun</b> <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_borrow_mut_impl">borrow_mut_impl</a>&lt;$Name: <b>copy</b>, drop, store, $Value: key&gt;($object: &<b>mut</b> <a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, $name: $Name): &<b>mut</b> $Value
 </code></pre>
 
 
@@ -495,13 +495,13 @@ Returns none otherwise
 
 
 <pre><code><b>macro</b> <b>fun</b> <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_borrow_mut_impl">borrow_mut_impl</a>&lt;$Name: <b>copy</b> + drop + store, $Value: key&gt;(
-    $<a href="../sui/object.md#sui_object">object</a>: &<b>mut</b> UID,
+    $object: &<b>mut</b> UID,
     $name: $Name,
 ): &<b>mut</b> $Value {
-    <b>let</b> <a href="../sui/object.md#sui_object">object</a> = $<a href="../sui/object.md#sui_object">object</a>;
+    <b>let</b> object = $object;
     <b>let</b> name = $name;
     <b>let</b> key = <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_Wrapper">Wrapper</a> { name };
-    <b>let</b> (field, value_id) = field::field_info_mut&lt;<a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_Wrapper">Wrapper</a>&lt;$Name&gt;&gt;(<a href="../sui/object.md#sui_object">object</a>, key);
+    <b>let</b> (field, value_id) = field::field_info_mut&lt;<a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_Wrapper">Wrapper</a>&lt;$Name&gt;&gt;(object, key);
     borrow_child_object_mut&lt;$Value&gt;(field, value_id)
 }
 </code></pre>
@@ -516,7 +516,7 @@ Returns none otherwise
 
 
 
-<pre><code><b>macro</b> <b>fun</b> <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_remove_impl">remove_impl</a>&lt;$Name: <b>copy</b>, drop, store, $Value: key&gt;($<a href="../sui/object.md#sui_object">object</a>: &<b>mut</b> <a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, $name: $Name): $Value
+<pre><code><b>macro</b> <b>fun</b> <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_remove_impl">remove_impl</a>&lt;$Name: <b>copy</b>, drop, store, $Value: key&gt;($object: &<b>mut</b> <a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, $name: $Name): $Value
 </code></pre>
 
 
@@ -526,15 +526,15 @@ Returns none otherwise
 
 
 <pre><code><b>macro</b> <b>fun</b> <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_remove_impl">remove_impl</a>&lt;$Name: <b>copy</b> + drop + store, $Value: key&gt;(
-    $<a href="../sui/object.md#sui_object">object</a>: &<b>mut</b> UID,
+    $object: &<b>mut</b> UID,
     $name: $Name,
 ): $Value {
-    <b>let</b> <a href="../sui/object.md#sui_object">object</a> = $<a href="../sui/object.md#sui_object">object</a>;
+    <b>let</b> object = $object;
     <b>let</b> name = $name;
     <b>let</b> key = <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_Wrapper">Wrapper</a> { name };
-    <b>let</b> (field, value_id) = field::field_info&lt;<a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_Wrapper">Wrapper</a>&lt;$Name&gt;&gt;(<a href="../sui/object.md#sui_object">object</a>, key);
+    <b>let</b> (field, value_id) = field::field_info&lt;<a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_Wrapper">Wrapper</a>&lt;$Name&gt;&gt;(object, key);
     <b>let</b> value = remove_child_object&lt;$Value&gt;(field.to_address(), value_id);
-    field::remove&lt;<a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_Wrapper">Wrapper</a>&lt;$Name&gt;, ID&gt;(<a href="../sui/object.md#sui_object">object</a>, key);
+    field::remove&lt;<a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_Wrapper">Wrapper</a>&lt;$Name&gt;, ID&gt;(object, key);
     value
 }
 </code></pre>
@@ -549,7 +549,7 @@ Returns none otherwise
 
 
 
-<pre><code><b>macro</b> <b>fun</b> <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_exists_with_type_impl">exists_with_type_impl</a>&lt;$Name: <b>copy</b>, drop, store, $Value: key&gt;($<a href="../sui/object.md#sui_object">object</a>: &<a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, $name: $Name): bool
+<pre><code><b>macro</b> <b>fun</b> <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_exists_with_type_impl">exists_with_type_impl</a>&lt;$Name: <b>copy</b>, drop, store, $Value: key&gt;($object: &<a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, $name: $Name): bool
 </code></pre>
 
 
@@ -559,14 +559,14 @@ Returns none otherwise
 
 
 <pre><code><b>macro</b> <b>fun</b> <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_exists_with_type_impl">exists_with_type_impl</a>&lt;$Name: <b>copy</b> + drop + store, $Value: key&gt;(
-    $<a href="../sui/object.md#sui_object">object</a>: &UID,
+    $object: &UID,
     $name: $Name,
 ): bool {
-    <b>let</b> <a href="../sui/object.md#sui_object">object</a> = $<a href="../sui/object.md#sui_object">object</a>;
+    <b>let</b> object = $object;
     <b>let</b> name = $name;
     <b>let</b> key = <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_Wrapper">Wrapper</a> { name };
-    <b>if</b> (!field::exists_with_type&lt;<a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_Wrapper">Wrapper</a>&lt;$Name&gt;, ID&gt;(<a href="../sui/object.md#sui_object">object</a>, key)) <b>return</b> <b>false</b>;
-    <b>let</b> (field, value_id) = field::field_info&lt;<a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_Wrapper">Wrapper</a>&lt;$Name&gt;&gt;(<a href="../sui/object.md#sui_object">object</a>, key);
+    <b>if</b> (!field::exists_with_type&lt;<a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_Wrapper">Wrapper</a>&lt;$Name&gt;, ID&gt;(object, key)) <b>return</b> <b>false</b>;
+    <b>let</b> (field, value_id) = field::field_info&lt;<a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_Wrapper">Wrapper</a>&lt;$Name&gt;&gt;(object, key);
     field::has_child_object_with_ty&lt;$Value&gt;(field.to_address(), value_id)
 }
 </code></pre>

--- a/crates/sui-framework/docs/sui/ecdsa_k1.md
+++ b/crates/sui-framework/docs/sui/ecdsa_k1.md
@@ -84,7 +84,7 @@ key, otherwise throw error. This is similar to ecrecover in Ethereum, can only b
 applied to Secp256k1 signatures. May abort with <code><a href="../sui/ecdsa_k1.md#sui_ecdsa_k1_EFailToRecoverPubKey">EFailToRecoverPubKey</a></code> or <code><a href="../sui/ecdsa_k1.md#sui_ecdsa_k1_EInvalidSignature">EInvalidSignature</a></code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/ecdsa_k1.md#sui_ecdsa_k1_secp256k1_ecrecover">secp256k1_ecrecover</a>(signature: &vector&lt;u8&gt;, msg: &vector&lt;u8&gt;, <a href="../sui/hash.md#sui_hash">hash</a>: u8): vector&lt;u8&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/ecdsa_k1.md#sui_ecdsa_k1_secp256k1_ecrecover">secp256k1_ecrecover</a>(signature: &vector&lt;u8&gt;, msg: &vector&lt;u8&gt;, hash: u8): vector&lt;u8&gt;
 </code></pre>
 
 
@@ -96,7 +96,7 @@ applied to Secp256k1 signatures. May abort with <code><a href="../sui/ecdsa_k1.m
 <pre><code><b>public</b> <b>native</b> <b>fun</b> <a href="../sui/ecdsa_k1.md#sui_ecdsa_k1_secp256k1_ecrecover">secp256k1_ecrecover</a>(
     signature: &vector&lt;u8&gt;,
     msg: &vector&lt;u8&gt;,
-    <a href="../sui/hash.md#sui_hash">hash</a>: u8,
+    hash: u8,
 ): vector&lt;u8&gt;;
 </code></pre>
 
@@ -145,7 +145,7 @@ https://github.com/MystenLabs/fastcrypto/blob/74aec4886e62122a5b769464c2bea5f803
 If the signature is valid to the pubkey and hashed message, return true. Else false.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/ecdsa_k1.md#sui_ecdsa_k1_secp256k1_verify">secp256k1_verify</a>(signature: &vector&lt;u8&gt;, public_key: &vector&lt;u8&gt;, msg: &vector&lt;u8&gt;, <a href="../sui/hash.md#sui_hash">hash</a>: u8): bool
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/ecdsa_k1.md#sui_ecdsa_k1_secp256k1_verify">secp256k1_verify</a>(signature: &vector&lt;u8&gt;, public_key: &vector&lt;u8&gt;, msg: &vector&lt;u8&gt;, hash: u8): bool
 </code></pre>
 
 
@@ -158,7 +158,7 @@ If the signature is valid to the pubkey and hashed message, return true. Else fa
     signature: &vector&lt;u8&gt;,
     public_key: &vector&lt;u8&gt;,
     msg: &vector&lt;u8&gt;,
-    <a href="../sui/hash.md#sui_hash">hash</a>: u8,
+    hash: u8,
 ): bool;
 </code></pre>
 

--- a/crates/sui-framework/docs/sui/ecdsa_r1.md
+++ b/crates/sui-framework/docs/sui/ecdsa_r1.md
@@ -73,7 +73,7 @@ key, otherwise throw error. This is similar to ecrecover in Ethereum, can only b
 applied to Secp256r1 signatures. May fail with <code><a href="../sui/ecdsa_r1.md#sui_ecdsa_r1_EFailToRecoverPubKey">EFailToRecoverPubKey</a></code> or <code><a href="../sui/ecdsa_r1.md#sui_ecdsa_r1_EInvalidSignature">EInvalidSignature</a></code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/ecdsa_r1.md#sui_ecdsa_r1_secp256r1_ecrecover">secp256r1_ecrecover</a>(signature: &vector&lt;u8&gt;, msg: &vector&lt;u8&gt;, <a href="../sui/hash.md#sui_hash">hash</a>: u8): vector&lt;u8&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/ecdsa_r1.md#sui_ecdsa_r1_secp256r1_ecrecover">secp256r1_ecrecover</a>(signature: &vector&lt;u8&gt;, msg: &vector&lt;u8&gt;, hash: u8): vector&lt;u8&gt;
 </code></pre>
 
 
@@ -85,7 +85,7 @@ applied to Secp256r1 signatures. May fail with <code><a href="../sui/ecdsa_r1.md
 <pre><code><b>public</b> <b>native</b> <b>fun</b> <a href="../sui/ecdsa_r1.md#sui_ecdsa_r1_secp256r1_ecrecover">secp256r1_ecrecover</a>(
     signature: &vector&lt;u8&gt;,
     msg: &vector&lt;u8&gt;,
-    <a href="../sui/hash.md#sui_hash">hash</a>: u8,
+    hash: u8,
 ): vector&lt;u8&gt;;
 </code></pre>
 
@@ -108,7 +108,7 @@ https://github.com/MystenLabs/fastcrypto/blob/74aec4886e62122a5b769464c2bea5f803
 If the signature is valid to the pubkey and hashed message, return true. Else false.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/ecdsa_r1.md#sui_ecdsa_r1_secp256r1_verify">secp256r1_verify</a>(signature: &vector&lt;u8&gt;, public_key: &vector&lt;u8&gt;, msg: &vector&lt;u8&gt;, <a href="../sui/hash.md#sui_hash">hash</a>: u8): bool
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/ecdsa_r1.md#sui_ecdsa_r1_secp256r1_verify">secp256r1_verify</a>(signature: &vector&lt;u8&gt;, public_key: &vector&lt;u8&gt;, msg: &vector&lt;u8&gt;, hash: u8): bool
 </code></pre>
 
 
@@ -121,7 +121,7 @@ If the signature is valid to the pubkey and hashed message, return true. Else fa
     signature: &vector&lt;u8&gt;,
     public_key: &vector&lt;u8&gt;,
     msg: &vector&lt;u8&gt;,
-    <a href="../sui/hash.md#sui_hash">hash</a>: u8,
+    hash: u8,
 ): bool;
 </code></pre>
 

--- a/crates/sui-framework/docs/sui/ecvrf.md
+++ b/crates/sui-framework/docs/sui/ecvrf.md
@@ -55,7 +55,7 @@ title: Module `sui::ecvrf`
 Verify a proof for a Ristretto ECVRF. Returns true if the proof is valid and corresponds to the given output. May abort with <code><a href="../sui/ecvrf.md#sui_ecvrf_EInvalidHashLength">EInvalidHashLength</a></code>, <code><a href="../sui/ecvrf.md#sui_ecvrf_EInvalidPublicKeyEncoding">EInvalidPublicKeyEncoding</a></code> or <code><a href="../sui/ecvrf.md#sui_ecvrf_EInvalidProofEncoding">EInvalidProofEncoding</a></code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/ecvrf.md#sui_ecvrf_ecvrf_verify">ecvrf_verify</a>(<a href="../sui/hash.md#sui_hash">hash</a>: &vector&lt;u8&gt;, alpha_string: &vector&lt;u8&gt;, public_key: &vector&lt;u8&gt;, proof: &vector&lt;u8&gt;): bool
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/ecvrf.md#sui_ecvrf_ecvrf_verify">ecvrf_verify</a>(hash: &vector&lt;u8&gt;, alpha_string: &vector&lt;u8&gt;, public_key: &vector&lt;u8&gt;, proof: &vector&lt;u8&gt;): bool
 </code></pre>
 
 
@@ -65,7 +65,7 @@ Verify a proof for a Ristretto ECVRF. Returns true if the proof is valid and cor
 
 
 <pre><code><b>public</b> <b>native</b> <b>fun</b> <a href="../sui/ecvrf.md#sui_ecvrf_ecvrf_verify">ecvrf_verify</a>(
-    <a href="../sui/hash.md#sui_hash">hash</a>: &vector&lt;u8&gt;,
+    hash: &vector&lt;u8&gt;,
     alpha_string: &vector&lt;u8&gt;,
     public_key: &vector&lt;u8&gt;,
     proof: &vector&lt;u8&gt;,

--- a/crates/sui-framework/docs/sui/event.md
+++ b/crates/sui-framework/docs/sui/event.md
@@ -7,24 +7,24 @@ creates and sends a custom MoveEvent as a part of the effects
 certificate of the transaction.
 
 Every MoveEvent has the following properties:
-- sender
-- type signature (<code>T</code>)
-- event data (the value of <code>T</code>)
-- timestamp (local to a node)
-- transaction digest
+ - sender
+ - type signature (<code>T</code>)
+ - event data (the value of <code>T</code>)
+ - timestamp (local to a node)
+ - transaction digest
 
 Example:
 ```
 module my::marketplace {
-use sui::event;
-/* ... */
-struct ItemPurchased has copy, drop {
-item_id: ID, buyer: address
-}
-entry fun buy(/* .... */) {
-/* ... */
-event::emit(ItemPurchased { item_id: ..., buyer: .... })
-}
+   use sui::event;
+   /* ... */
+   struct ItemPurchased has copy, drop {
+     item_id: ID, buyer: address
+   }
+   entry fun buy(/* .... */) {
+      /* ... */
+      event::emit(ItemPurchased { item_id: ..., buyer: .... })
+   }
 }
 ```
 

--- a/crates/sui-framework/docs/sui/event.md
+++ b/crates/sui-framework/docs/sui/event.md
@@ -70,7 +70,7 @@ The type <code>T</code> is the main way to index the event, and can contain
 phantom parameters, eg <code><a href="../sui/event.md#sui_event_emit">emit</a>(MyEvent&lt;<b>phantom</b> T&gt;)</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/event.md#sui_event_emit">emit</a>&lt;T: <b>copy</b>, drop&gt;(<a href="../sui/event.md#sui_event">event</a>: T)
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/event.md#sui_event_emit">emit</a>&lt;T: <b>copy</b>, drop&gt;(event: T)
 </code></pre>
 
 
@@ -79,7 +79,7 @@ phantom parameters, eg <code><a href="../sui/event.md#sui_event_emit">emit</a>(M
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>native</b> <b>fun</b> <a href="../sui/event.md#sui_event_emit">emit</a>&lt;T: <b>copy</b> + drop&gt;(<a href="../sui/event.md#sui_event">event</a>: T);
+<pre><code><b>public</b> <b>native</b> <b>fun</b> <a href="../sui/event.md#sui_event_emit">emit</a>&lt;T: <b>copy</b> + drop&gt;(event: T);
 </code></pre>
 
 
@@ -97,7 +97,7 @@ defines the event type <code>T</code>.
 Only the package that defines the type <code>T</code> can emit authenticated events to this stream.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/event.md#sui_event_emit_authenticated">emit_authenticated</a>&lt;T: <b>copy</b>, drop&gt;(<a href="../sui/event.md#sui_event">event</a>: T)
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/event.md#sui_event_emit_authenticated">emit_authenticated</a>&lt;T: <b>copy</b>, drop&gt;(event: T)
 </code></pre>
 
 
@@ -106,10 +106,10 @@ Only the package that defines the type <code>T</code> can emit authenticated eve
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/event.md#sui_event_emit_authenticated">emit_authenticated</a>&lt;T: <b>copy</b> + drop&gt;(<a href="../sui/event.md#sui_event">event</a>: T) {
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/event.md#sui_event_emit_authenticated">emit_authenticated</a>&lt;T: <b>copy</b> + drop&gt;(event: T) {
     <b>let</b> stream_id = type_name::original_id&lt;T&gt;();
-    <b>let</b> accumulator_addr = <a href="../sui/accumulator.md#sui_accumulator_accumulator_address">accumulator::accumulator_address</a>&lt;EventStreamHead&gt;(stream_id);
-    <a href="../sui/event.md#sui_event_emit_authenticated_impl">emit_authenticated_impl</a>&lt;EventStreamHead, T&gt;(accumulator_addr, stream_id, <a href="../sui/event.md#sui_event">event</a>);
+    <b>let</b> accumulator_addr = accumulator::accumulator_address&lt;EventStreamHead&gt;(stream_id);
+    <a href="../sui/event.md#sui_event_emit_authenticated_impl">emit_authenticated_impl</a>&lt;EventStreamHead, T&gt;(accumulator_addr, stream_id, event);
 }
 </code></pre>
 
@@ -123,7 +123,7 @@ Only the package that defines the type <code>T</code> can emit authenticated eve
 
 
 
-<pre><code><b>fun</b> <a href="../sui/event.md#sui_event_emit_authenticated_impl">emit_authenticated_impl</a>&lt;StreamHeadT, T: <b>copy</b>, drop&gt;(accumulator_id: <b>address</b>, stream: <b>address</b>, <a href="../sui/event.md#sui_event">event</a>: T)
+<pre><code><b>fun</b> <a href="../sui/event.md#sui_event_emit_authenticated_impl">emit_authenticated_impl</a>&lt;StreamHeadT, T: <b>copy</b>, drop&gt;(accumulator_id: <b>address</b>, stream: <b>address</b>, event: T)
 </code></pre>
 
 
@@ -135,7 +135,7 @@ Only the package that defines the type <code>T</code> can emit authenticated eve
 <pre><code><b>native</b> <b>fun</b> <a href="../sui/event.md#sui_event_emit_authenticated_impl">emit_authenticated_impl</a>&lt;StreamHeadT, T: <b>copy</b> + drop&gt;(
     accumulator_id: <b>address</b>,
     stream: <b>address</b>,
-    <a href="../sui/event.md#sui_event">event</a>: T,
+    event: T,
 );
 </code></pre>
 

--- a/crates/sui-framework/docs/sui/funds_accumulator.md
+++ b/crates/sui-framework/docs/sui/funds_accumulator.md
@@ -240,7 +240,7 @@ Aborts with <code><a href="../sui/funds_accumulator.md#sui_funds_accumulator_EOv
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/funds_accumulator.md#sui_funds_accumulator_redeem">redeem</a>&lt;T: store&gt;(withdrawal: <a href="../sui/funds_accumulator.md#sui_funds_accumulator_Withdrawal">sui::funds_accumulator::Withdrawal</a>&lt;T&gt;, _: <a href="../std/internal.md#std_internal_Permit">std::internal::Permit</a>&lt;T&gt;): T
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/funds_accumulator.md#sui_funds_accumulator_redeem">redeem</a>&lt;T: store&gt;(withdrawal: <a href="../sui/funds_accumulator.md#sui_funds_accumulator_Withdrawal">sui::funds_accumulator::Withdrawal</a>&lt;T&gt;, _: <a href="../std/internal.md#std_internal_Permit">std::internal::Permit</a>&lt;T&gt;): T
 </code></pre>
 
 
@@ -249,7 +249,7 @@ Aborts with <code><a href="../sui/funds_accumulator.md#sui_funds_accumulator_EOv
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/funds_accumulator.md#sui_funds_accumulator_redeem">redeem</a>&lt;T: store&gt;(withdrawal: <a href="../sui/funds_accumulator.md#sui_funds_accumulator_Withdrawal">Withdrawal</a>&lt;T&gt;, _: internal::Permit&lt;T&gt;): T {
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/funds_accumulator.md#sui_funds_accumulator_redeem">redeem</a>&lt;T: store&gt;(withdrawal: <a href="../sui/funds_accumulator.md#sui_funds_accumulator_Withdrawal">Withdrawal</a>&lt;T&gt;, _: internal::Permit&lt;T&gt;): T {
     <b>let</b> <a href="../sui/funds_accumulator.md#sui_funds_accumulator_Withdrawal">Withdrawal</a> { owner, limit: value } = withdrawal;
     <a href="../sui/funds_accumulator.md#sui_funds_accumulator_withdraw_impl">withdraw_impl</a>(owner, value)
 }
@@ -265,7 +265,7 @@ Aborts with <code><a href="../sui/funds_accumulator.md#sui_funds_accumulator_EOv
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/funds_accumulator.md#sui_funds_accumulator_withdraw_from_object">withdraw_from_object</a>&lt;T: store&gt;(obj: &<b>mut</b> <a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, limit: u256): <a href="../sui/funds_accumulator.md#sui_funds_accumulator_Withdrawal">sui::funds_accumulator::Withdrawal</a>&lt;T&gt;
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/funds_accumulator.md#sui_funds_accumulator_withdraw_from_object">withdraw_from_object</a>&lt;T: store&gt;(obj: &<b>mut</b> <a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, limit: u256): <a href="../sui/funds_accumulator.md#sui_funds_accumulator_Withdrawal">sui::funds_accumulator::Withdrawal</a>&lt;T&gt;
 </code></pre>
 
 
@@ -274,7 +274,7 @@ Aborts with <code><a href="../sui/funds_accumulator.md#sui_funds_accumulator_EOv
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/funds_accumulator.md#sui_funds_accumulator_withdraw_from_object">withdraw_from_object</a>&lt;T: store&gt;(obj: &<b>mut</b> UID, limit: u256): <a href="../sui/funds_accumulator.md#sui_funds_accumulator_Withdrawal">Withdrawal</a>&lt;T&gt; {
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/funds_accumulator.md#sui_funds_accumulator_withdraw_from_object">withdraw_from_object</a>&lt;T: store&gt;(obj: &<b>mut</b> UID, limit: u256): <a href="../sui/funds_accumulator.md#sui_funds_accumulator_Withdrawal">Withdrawal</a>&lt;T&gt; {
     <b>assert</b>!(
         <a href="../sui/protocol_config.md#sui_protocol_config_is_feature_enabled">sui::protocol_config::is_feature_enabled</a>(b"enable_object_funds_withdraw"),
         <a href="../sui/funds_accumulator.md#sui_funds_accumulator_EObjectFundsWithdrawNotEnabled">EObjectFundsWithdrawNotEnabled</a>,
@@ -294,7 +294,7 @@ Aborts with <code><a href="../sui/funds_accumulator.md#sui_funds_accumulator_EOv
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/funds_accumulator.md#sui_funds_accumulator_add_impl">add_impl</a>&lt;T: store&gt;(value: T, recipient: <b>address</b>)
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/funds_accumulator.md#sui_funds_accumulator_add_impl">add_impl</a>&lt;T: store&gt;(value: T, recipient: <b>address</b>)
 </code></pre>
 
 
@@ -303,9 +303,9 @@ Aborts with <code><a href="../sui/funds_accumulator.md#sui_funds_accumulator_EOv
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/funds_accumulator.md#sui_funds_accumulator_add_impl">add_impl</a>&lt;T: store&gt;(value: T, recipient: <b>address</b>) {
-    <b>let</b> <a href="../sui/accumulator.md#sui_accumulator">accumulator</a> = <a href="../sui/accumulator.md#sui_accumulator_accumulator_address">sui::accumulator::accumulator_address</a>&lt;T&gt;(recipient);
-    <a href="../sui/funds_accumulator.md#sui_funds_accumulator_add_to_accumulator_address">add_to_accumulator_address</a>&lt;T&gt;(<a href="../sui/accumulator.md#sui_accumulator">accumulator</a>, recipient, value)
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/funds_accumulator.md#sui_funds_accumulator_add_impl">add_impl</a>&lt;T: store&gt;(value: T, recipient: <b>address</b>) {
+    <b>let</b> accumulator = <a href="../sui/accumulator.md#sui_accumulator_accumulator_address">sui::accumulator::accumulator_address</a>&lt;T&gt;(recipient);
+    <a href="../sui/funds_accumulator.md#sui_funds_accumulator_add_to_accumulator_address">add_to_accumulator_address</a>&lt;T&gt;(accumulator, recipient, value)
 }
 </code></pre>
 
@@ -329,8 +329,8 @@ Aborts with <code><a href="../sui/funds_accumulator.md#sui_funds_accumulator_EOv
 
 
 <pre><code><b>fun</b> <a href="../sui/funds_accumulator.md#sui_funds_accumulator_withdraw_impl">withdraw_impl</a>&lt;T: store&gt;(owner: <b>address</b>, value: u256): T {
-    <b>let</b> <a href="../sui/accumulator.md#sui_accumulator">accumulator</a> = <a href="../sui/accumulator.md#sui_accumulator_accumulator_address">sui::accumulator::accumulator_address</a>&lt;T&gt;(owner);
-    <a href="../sui/funds_accumulator.md#sui_funds_accumulator_withdraw_from_accumulator_address">withdraw_from_accumulator_address</a>&lt;T&gt;(<a href="../sui/accumulator.md#sui_accumulator">accumulator</a>, owner, value)
+    <b>let</b> accumulator = <a href="../sui/accumulator.md#sui_accumulator_accumulator_address">sui::accumulator::accumulator_address</a>&lt;T&gt;(owner);
+    <a href="../sui/funds_accumulator.md#sui_funds_accumulator_withdraw_from_accumulator_address">withdraw_from_accumulator_address</a>&lt;T&gt;(accumulator, owner, value)
 }
 </code></pre>
 
@@ -344,7 +344,7 @@ Aborts with <code><a href="../sui/funds_accumulator.md#sui_funds_accumulator_EOv
 
 
 
-<pre><code><b>fun</b> <a href="../sui/funds_accumulator.md#sui_funds_accumulator_add_to_accumulator_address">add_to_accumulator_address</a>&lt;T: store&gt;(<a href="../sui/accumulator.md#sui_accumulator">accumulator</a>: <b>address</b>, recipient: <b>address</b>, value: T)
+<pre><code><b>fun</b> <a href="../sui/funds_accumulator.md#sui_funds_accumulator_add_to_accumulator_address">add_to_accumulator_address</a>&lt;T: store&gt;(accumulator: <b>address</b>, recipient: <b>address</b>, value: T)
 </code></pre>
 
 
@@ -353,7 +353,7 @@ Aborts with <code><a href="../sui/funds_accumulator.md#sui_funds_accumulator_EOv
 <summary>Implementation</summary>
 
 
-<pre><code><b>native</b> <b>fun</b> <a href="../sui/funds_accumulator.md#sui_funds_accumulator_add_to_accumulator_address">add_to_accumulator_address</a>&lt;T: store&gt;(<a href="../sui/accumulator.md#sui_accumulator">accumulator</a>: <b>address</b>, recipient: <b>address</b>, value: T);
+<pre><code><b>native</b> <b>fun</b> <a href="../sui/funds_accumulator.md#sui_funds_accumulator_add_to_accumulator_address">add_to_accumulator_address</a>&lt;T: store&gt;(accumulator: <b>address</b>, recipient: <b>address</b>, value: T);
 </code></pre>
 
 
@@ -366,7 +366,7 @@ Aborts with <code><a href="../sui/funds_accumulator.md#sui_funds_accumulator_EOv
 
 
 
-<pre><code><b>fun</b> <a href="../sui/funds_accumulator.md#sui_funds_accumulator_withdraw_from_accumulator_address">withdraw_from_accumulator_address</a>&lt;T: store&gt;(<a href="../sui/accumulator.md#sui_accumulator">accumulator</a>: <b>address</b>, owner: <b>address</b>, value: u256): T
+<pre><code><b>fun</b> <a href="../sui/funds_accumulator.md#sui_funds_accumulator_withdraw_from_accumulator_address">withdraw_from_accumulator_address</a>&lt;T: store&gt;(accumulator: <b>address</b>, owner: <b>address</b>, value: u256): T
 </code></pre>
 
 
@@ -376,7 +376,7 @@ Aborts with <code><a href="../sui/funds_accumulator.md#sui_funds_accumulator_EOv
 
 
 <pre><code><b>native</b> <b>fun</b> <a href="../sui/funds_accumulator.md#sui_funds_accumulator_withdraw_from_accumulator_address">withdraw_from_accumulator_address</a>&lt;T: store&gt;(
-    <a href="../sui/accumulator.md#sui_accumulator">accumulator</a>: <b>address</b>,
+    accumulator: <b>address</b>,
     owner: <b>address</b>,
     value: u256,
 ): T;
@@ -392,7 +392,7 @@ Aborts with <code><a href="../sui/funds_accumulator.md#sui_funds_accumulator_EOv
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/funds_accumulator.md#sui_funds_accumulator_create_withdrawal">create_withdrawal</a>&lt;T: store&gt;(owner: <b>address</b>, limit: u256): <a href="../sui/funds_accumulator.md#sui_funds_accumulator_Withdrawal">sui::funds_accumulator::Withdrawal</a>&lt;T&gt;
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/funds_accumulator.md#sui_funds_accumulator_create_withdrawal">create_withdrawal</a>&lt;T: store&gt;(owner: <b>address</b>, limit: u256): <a href="../sui/funds_accumulator.md#sui_funds_accumulator_Withdrawal">sui::funds_accumulator::Withdrawal</a>&lt;T&gt;
 </code></pre>
 
 
@@ -401,7 +401,7 @@ Aborts with <code><a href="../sui/funds_accumulator.md#sui_funds_accumulator_EOv
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/funds_accumulator.md#sui_funds_accumulator_create_withdrawal">create_withdrawal</a>&lt;T: store&gt;(owner: <b>address</b>, limit: u256): <a href="../sui/funds_accumulator.md#sui_funds_accumulator_Withdrawal">Withdrawal</a>&lt;T&gt; {
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/funds_accumulator.md#sui_funds_accumulator_create_withdrawal">create_withdrawal</a>&lt;T: store&gt;(owner: <b>address</b>, limit: u256): <a href="../sui/funds_accumulator.md#sui_funds_accumulator_Withdrawal">Withdrawal</a>&lt;T&gt; {
     <a href="../sui/funds_accumulator.md#sui_funds_accumulator_Withdrawal">Withdrawal</a> { owner, limit }
 }
 </code></pre>

--- a/crates/sui-framework/docs/sui/groth16.md
+++ b/crates/sui-framework/docs/sui/groth16.md
@@ -206,7 +206,7 @@ A <code><a href="../sui/groth16.md#sui_groth16_ProofPoints">ProofPoints</a></cod
 Return the <code><a href="../sui/groth16.md#sui_groth16_Curve">Curve</a></code> value indicating that the BLS12-381 construction should be used in a given function.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/bls12381.md#sui_bls12381">bls12381</a>(): <a href="../sui/groth16.md#sui_groth16_Curve">sui::groth16::Curve</a>
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/groth16.md#sui_groth16_bls12381">bls12381</a>(): <a href="../sui/groth16.md#sui_groth16_Curve">sui::groth16::Curve</a>
 </code></pre>
 
 
@@ -215,7 +215,7 @@ Return the <code><a href="../sui/groth16.md#sui_groth16_Curve">Curve</a></code> 
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/bls12381.md#sui_bls12381">bls12381</a>(): <a href="../sui/groth16.md#sui_groth16_Curve">Curve</a> { <a href="../sui/groth16.md#sui_groth16_Curve">Curve</a> { id: 0 } }
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/groth16.md#sui_groth16_bls12381">bls12381</a>(): <a href="../sui/groth16.md#sui_groth16_Curve">Curve</a> { <a href="../sui/groth16.md#sui_groth16_Curve">Curve</a> { id: 0 } }
 </code></pre>
 
 
@@ -367,7 +367,7 @@ Creates a Groth16 <code><a href="../sui/groth16.md#sui_groth16_ProofPoints">Proo
 
 ## Function `prepare_verifying_key`
 
-@param curve: What elliptic curve construction to use. See <code><a href="../sui/bls12381.md#sui_bls12381">bls12381</a></code> and <code><a href="../sui/groth16.md#sui_groth16_bn254">bn254</a></code>.
+@param curve: What elliptic curve construction to use. See <code><a href="../sui/groth16.md#sui_groth16_bls12381">bls12381</a></code> and <code><a href="../sui/groth16.md#sui_groth16_bn254">bn254</a></code>.
 @param verifying_key: An Arkworks canonical compressed serialization of a verifying key.
 
 Returns four vectors of bytes representing the four components of a prepared verifying key.
@@ -423,7 +423,7 @@ Native functions that flattens the inputs into an array and passes to the Rust n
 
 ## Function `verify_groth16_proof`
 
-@param curve: What elliptic curve construction to use. See the <code><a href="../sui/bls12381.md#sui_bls12381">bls12381</a></code> and <code><a href="../sui/groth16.md#sui_groth16_bn254">bn254</a></code> functions.
+@param curve: What elliptic curve construction to use. See the <code><a href="../sui/groth16.md#sui_groth16_bls12381">bls12381</a></code> and <code><a href="../sui/groth16.md#sui_groth16_bn254">bn254</a></code> functions.
 @param prepared_verifying_key: Consists of four vectors of bytes representing the four components of a prepared verifying key.
 @param public_proof_inputs: Represent inputs that are public.
 @param proof_points: Represent three proof points.

--- a/crates/sui-framework/docs/sui/group_ops.md
+++ b/crates/sui-framework/docs/sui/group_ops.md
@@ -165,7 +165,7 @@ Generic Move and native functions for group operations.
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/group_ops.md#sui_group_ops_from_bytes">from_bytes</a>&lt;G&gt;(type_: u8, <a href="../sui/group_ops.md#sui_group_ops_bytes">bytes</a>: vector&lt;u8&gt;, is_trusted: bool): <a href="../sui/group_ops.md#sui_group_ops_Element">sui::group_ops::Element</a>&lt;G&gt;
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/group_ops.md#sui_group_ops_from_bytes">from_bytes</a>&lt;G&gt;(type_: u8, <a href="../sui/group_ops.md#sui_group_ops_bytes">bytes</a>: vector&lt;u8&gt;, is_trusted: bool): <a href="../sui/group_ops.md#sui_group_ops_Element">sui::group_ops::Element</a>&lt;G&gt;
 </code></pre>
 
 
@@ -174,7 +174,7 @@ Generic Move and native functions for group operations.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/group_ops.md#sui_group_ops_from_bytes">from_bytes</a>&lt;G&gt;(type_: u8, <a href="../sui/group_ops.md#sui_group_ops_bytes">bytes</a>: vector&lt;u8&gt;, is_trusted: bool): <a href="../sui/group_ops.md#sui_group_ops_Element">Element</a>&lt;G&gt; {
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/group_ops.md#sui_group_ops_from_bytes">from_bytes</a>&lt;G&gt;(type_: u8, <a href="../sui/group_ops.md#sui_group_ops_bytes">bytes</a>: vector&lt;u8&gt;, is_trusted: bool): <a href="../sui/group_ops.md#sui_group_ops_Element">Element</a>&lt;G&gt; {
     <b>assert</b>!(is_trusted || <a href="../sui/group_ops.md#sui_group_ops_internal_validate">internal_validate</a>(type_, &<a href="../sui/group_ops.md#sui_group_ops_bytes">bytes</a>), <a href="../sui/group_ops.md#sui_group_ops_EInvalidInput">EInvalidInput</a>);
     <a href="../sui/group_ops.md#sui_group_ops_Element">Element</a>&lt;G&gt; { <a href="../sui/group_ops.md#sui_group_ops_bytes">bytes</a> }
 }
@@ -190,7 +190,7 @@ Generic Move and native functions for group operations.
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/group_ops.md#sui_group_ops_add">add</a>&lt;G&gt;(type_: u8, e1: &<a href="../sui/group_ops.md#sui_group_ops_Element">sui::group_ops::Element</a>&lt;G&gt;, e2: &<a href="../sui/group_ops.md#sui_group_ops_Element">sui::group_ops::Element</a>&lt;G&gt;): <a href="../sui/group_ops.md#sui_group_ops_Element">sui::group_ops::Element</a>&lt;G&gt;
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/group_ops.md#sui_group_ops_add">add</a>&lt;G&gt;(type_: u8, e1: &<a href="../sui/group_ops.md#sui_group_ops_Element">sui::group_ops::Element</a>&lt;G&gt;, e2: &<a href="../sui/group_ops.md#sui_group_ops_Element">sui::group_ops::Element</a>&lt;G&gt;): <a href="../sui/group_ops.md#sui_group_ops_Element">sui::group_ops::Element</a>&lt;G&gt;
 </code></pre>
 
 
@@ -199,7 +199,7 @@ Generic Move and native functions for group operations.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/group_ops.md#sui_group_ops_add">add</a>&lt;G&gt;(type_: u8, e1: &<a href="../sui/group_ops.md#sui_group_ops_Element">Element</a>&lt;G&gt;, e2: &<a href="../sui/group_ops.md#sui_group_ops_Element">Element</a>&lt;G&gt;): <a href="../sui/group_ops.md#sui_group_ops_Element">Element</a>&lt;G&gt; {
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/group_ops.md#sui_group_ops_add">add</a>&lt;G&gt;(type_: u8, e1: &<a href="../sui/group_ops.md#sui_group_ops_Element">Element</a>&lt;G&gt;, e2: &<a href="../sui/group_ops.md#sui_group_ops_Element">Element</a>&lt;G&gt;): <a href="../sui/group_ops.md#sui_group_ops_Element">Element</a>&lt;G&gt; {
     <a href="../sui/group_ops.md#sui_group_ops_Element">Element</a>&lt;G&gt; { <a href="../sui/group_ops.md#sui_group_ops_bytes">bytes</a>: <a href="../sui/group_ops.md#sui_group_ops_internal_add">internal_add</a>(type_, &e1.<a href="../sui/group_ops.md#sui_group_ops_bytes">bytes</a>, &e2.<a href="../sui/group_ops.md#sui_group_ops_bytes">bytes</a>) }
 }
 </code></pre>
@@ -214,7 +214,7 @@ Generic Move and native functions for group operations.
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/group_ops.md#sui_group_ops_sub">sub</a>&lt;G&gt;(type_: u8, e1: &<a href="../sui/group_ops.md#sui_group_ops_Element">sui::group_ops::Element</a>&lt;G&gt;, e2: &<a href="../sui/group_ops.md#sui_group_ops_Element">sui::group_ops::Element</a>&lt;G&gt;): <a href="../sui/group_ops.md#sui_group_ops_Element">sui::group_ops::Element</a>&lt;G&gt;
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/group_ops.md#sui_group_ops_sub">sub</a>&lt;G&gt;(type_: u8, e1: &<a href="../sui/group_ops.md#sui_group_ops_Element">sui::group_ops::Element</a>&lt;G&gt;, e2: &<a href="../sui/group_ops.md#sui_group_ops_Element">sui::group_ops::Element</a>&lt;G&gt;): <a href="../sui/group_ops.md#sui_group_ops_Element">sui::group_ops::Element</a>&lt;G&gt;
 </code></pre>
 
 
@@ -223,7 +223,7 @@ Generic Move and native functions for group operations.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/group_ops.md#sui_group_ops_sub">sub</a>&lt;G&gt;(type_: u8, e1: &<a href="../sui/group_ops.md#sui_group_ops_Element">Element</a>&lt;G&gt;, e2: &<a href="../sui/group_ops.md#sui_group_ops_Element">Element</a>&lt;G&gt;): <a href="../sui/group_ops.md#sui_group_ops_Element">Element</a>&lt;G&gt; {
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/group_ops.md#sui_group_ops_sub">sub</a>&lt;G&gt;(type_: u8, e1: &<a href="../sui/group_ops.md#sui_group_ops_Element">Element</a>&lt;G&gt;, e2: &<a href="../sui/group_ops.md#sui_group_ops_Element">Element</a>&lt;G&gt;): <a href="../sui/group_ops.md#sui_group_ops_Element">Element</a>&lt;G&gt; {
     <a href="../sui/group_ops.md#sui_group_ops_Element">Element</a>&lt;G&gt; { <a href="../sui/group_ops.md#sui_group_ops_bytes">bytes</a>: <a href="../sui/group_ops.md#sui_group_ops_internal_sub">internal_sub</a>(type_, &e1.<a href="../sui/group_ops.md#sui_group_ops_bytes">bytes</a>, &e2.<a href="../sui/group_ops.md#sui_group_ops_bytes">bytes</a>) }
 }
 </code></pre>
@@ -238,7 +238,7 @@ Generic Move and native functions for group operations.
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/group_ops.md#sui_group_ops_mul">mul</a>&lt;S, G&gt;(type_: u8, scalar: &<a href="../sui/group_ops.md#sui_group_ops_Element">sui::group_ops::Element</a>&lt;S&gt;, e: &<a href="../sui/group_ops.md#sui_group_ops_Element">sui::group_ops::Element</a>&lt;G&gt;): <a href="../sui/group_ops.md#sui_group_ops_Element">sui::group_ops::Element</a>&lt;G&gt;
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/group_ops.md#sui_group_ops_mul">mul</a>&lt;S, G&gt;(type_: u8, scalar: &<a href="../sui/group_ops.md#sui_group_ops_Element">sui::group_ops::Element</a>&lt;S&gt;, e: &<a href="../sui/group_ops.md#sui_group_ops_Element">sui::group_ops::Element</a>&lt;G&gt;): <a href="../sui/group_ops.md#sui_group_ops_Element">sui::group_ops::Element</a>&lt;G&gt;
 </code></pre>
 
 
@@ -247,7 +247,7 @@ Generic Move and native functions for group operations.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/group_ops.md#sui_group_ops_mul">mul</a>&lt;S, G&gt;(type_: u8, scalar: &<a href="../sui/group_ops.md#sui_group_ops_Element">Element</a>&lt;S&gt;, e: &<a href="../sui/group_ops.md#sui_group_ops_Element">Element</a>&lt;G&gt;): <a href="../sui/group_ops.md#sui_group_ops_Element">Element</a>&lt;G&gt; {
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/group_ops.md#sui_group_ops_mul">mul</a>&lt;S, G&gt;(type_: u8, scalar: &<a href="../sui/group_ops.md#sui_group_ops_Element">Element</a>&lt;S&gt;, e: &<a href="../sui/group_ops.md#sui_group_ops_Element">Element</a>&lt;G&gt;): <a href="../sui/group_ops.md#sui_group_ops_Element">Element</a>&lt;G&gt; {
     <a href="../sui/group_ops.md#sui_group_ops_Element">Element</a>&lt;G&gt; { <a href="../sui/group_ops.md#sui_group_ops_bytes">bytes</a>: <a href="../sui/group_ops.md#sui_group_ops_internal_mul">internal_mul</a>(type_, &scalar.<a href="../sui/group_ops.md#sui_group_ops_bytes">bytes</a>, &e.<a href="../sui/group_ops.md#sui_group_ops_bytes">bytes</a>) }
 }
 </code></pre>
@@ -263,7 +263,7 @@ Generic Move and native functions for group operations.
 Fails if scalar = 0. Else returns 1/scalar * e.
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/group_ops.md#sui_group_ops_div">div</a>&lt;S, G&gt;(type_: u8, scalar: &<a href="../sui/group_ops.md#sui_group_ops_Element">sui::group_ops::Element</a>&lt;S&gt;, e: &<a href="../sui/group_ops.md#sui_group_ops_Element">sui::group_ops::Element</a>&lt;G&gt;): <a href="../sui/group_ops.md#sui_group_ops_Element">sui::group_ops::Element</a>&lt;G&gt;
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/group_ops.md#sui_group_ops_div">div</a>&lt;S, G&gt;(type_: u8, scalar: &<a href="../sui/group_ops.md#sui_group_ops_Element">sui::group_ops::Element</a>&lt;S&gt;, e: &<a href="../sui/group_ops.md#sui_group_ops_Element">sui::group_ops::Element</a>&lt;G&gt;): <a href="../sui/group_ops.md#sui_group_ops_Element">sui::group_ops::Element</a>&lt;G&gt;
 </code></pre>
 
 
@@ -272,7 +272,7 @@ Fails if scalar = 0. Else returns 1/scalar * e.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/group_ops.md#sui_group_ops_div">div</a>&lt;S, G&gt;(type_: u8, scalar: &<a href="../sui/group_ops.md#sui_group_ops_Element">Element</a>&lt;S&gt;, e: &<a href="../sui/group_ops.md#sui_group_ops_Element">Element</a>&lt;G&gt;): <a href="../sui/group_ops.md#sui_group_ops_Element">Element</a>&lt;G&gt; {
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/group_ops.md#sui_group_ops_div">div</a>&lt;S, G&gt;(type_: u8, scalar: &<a href="../sui/group_ops.md#sui_group_ops_Element">Element</a>&lt;S&gt;, e: &<a href="../sui/group_ops.md#sui_group_ops_Element">Element</a>&lt;G&gt;): <a href="../sui/group_ops.md#sui_group_ops_Element">Element</a>&lt;G&gt; {
     <a href="../sui/group_ops.md#sui_group_ops_Element">Element</a>&lt;G&gt; { <a href="../sui/group_ops.md#sui_group_ops_bytes">bytes</a>: <a href="../sui/group_ops.md#sui_group_ops_internal_div">internal_div</a>(type_, &scalar.<a href="../sui/group_ops.md#sui_group_ops_bytes">bytes</a>, &e.<a href="../sui/group_ops.md#sui_group_ops_bytes">bytes</a>) }
 }
 </code></pre>
@@ -287,7 +287,7 @@ Fails if scalar = 0. Else returns 1/scalar * e.
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/group_ops.md#sui_group_ops_hash_to">hash_to</a>&lt;G&gt;(type_: u8, m: &vector&lt;u8&gt;): <a href="../sui/group_ops.md#sui_group_ops_Element">sui::group_ops::Element</a>&lt;G&gt;
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/group_ops.md#sui_group_ops_hash_to">hash_to</a>&lt;G&gt;(type_: u8, m: &vector&lt;u8&gt;): <a href="../sui/group_ops.md#sui_group_ops_Element">sui::group_ops::Element</a>&lt;G&gt;
 </code></pre>
 
 
@@ -296,7 +296,7 @@ Fails if scalar = 0. Else returns 1/scalar * e.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/group_ops.md#sui_group_ops_hash_to">hash_to</a>&lt;G&gt;(type_: u8, m: &vector&lt;u8&gt;): <a href="../sui/group_ops.md#sui_group_ops_Element">Element</a>&lt;G&gt; {
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/group_ops.md#sui_group_ops_hash_to">hash_to</a>&lt;G&gt;(type_: u8, m: &vector&lt;u8&gt;): <a href="../sui/group_ops.md#sui_group_ops_Element">Element</a>&lt;G&gt; {
     <a href="../sui/group_ops.md#sui_group_ops_Element">Element</a>&lt;G&gt; { <a href="../sui/group_ops.md#sui_group_ops_bytes">bytes</a>: <a href="../sui/group_ops.md#sui_group_ops_internal_hash_to">internal_hash_to</a>(type_, m) }
 }
 </code></pre>
@@ -314,7 +314,7 @@ Aborts with <code><a href="../sui/group_ops.md#sui_group_ops_EInputTooLong">EInp
 This function is currently only enabled on Devnet.
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/group_ops.md#sui_group_ops_multi_scalar_multiplication">multi_scalar_multiplication</a>&lt;S, G&gt;(type_: u8, scalars: &vector&lt;<a href="../sui/group_ops.md#sui_group_ops_Element">sui::group_ops::Element</a>&lt;S&gt;&gt;, elements: &vector&lt;<a href="../sui/group_ops.md#sui_group_ops_Element">sui::group_ops::Element</a>&lt;G&gt;&gt;): <a href="../sui/group_ops.md#sui_group_ops_Element">sui::group_ops::Element</a>&lt;G&gt;
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/group_ops.md#sui_group_ops_multi_scalar_multiplication">multi_scalar_multiplication</a>&lt;S, G&gt;(type_: u8, scalars: &vector&lt;<a href="../sui/group_ops.md#sui_group_ops_Element">sui::group_ops::Element</a>&lt;S&gt;&gt;, elements: &vector&lt;<a href="../sui/group_ops.md#sui_group_ops_Element">sui::group_ops::Element</a>&lt;G&gt;&gt;): <a href="../sui/group_ops.md#sui_group_ops_Element">sui::group_ops::Element</a>&lt;G&gt;
 </code></pre>
 
 
@@ -323,7 +323,7 @@ This function is currently only enabled on Devnet.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/group_ops.md#sui_group_ops_multi_scalar_multiplication">multi_scalar_multiplication</a>&lt;S, G&gt;(
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/group_ops.md#sui_group_ops_multi_scalar_multiplication">multi_scalar_multiplication</a>&lt;S, G&gt;(
     type_: u8,
     scalars: &vector&lt;<a href="../sui/group_ops.md#sui_group_ops_Element">Element</a>&lt;S&gt;&gt;,
     elements: &vector&lt;<a href="../sui/group_ops.md#sui_group_ops_Element">Element</a>&lt;G&gt;&gt;,
@@ -354,7 +354,7 @@ This function is currently only enabled on Devnet.
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/group_ops.md#sui_group_ops_pairing">pairing</a>&lt;G1, G2, G3&gt;(type_: u8, e1: &<a href="../sui/group_ops.md#sui_group_ops_Element">sui::group_ops::Element</a>&lt;G1&gt;, e2: &<a href="../sui/group_ops.md#sui_group_ops_Element">sui::group_ops::Element</a>&lt;G2&gt;): <a href="../sui/group_ops.md#sui_group_ops_Element">sui::group_ops::Element</a>&lt;G3&gt;
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/group_ops.md#sui_group_ops_pairing">pairing</a>&lt;G1, G2, G3&gt;(type_: u8, e1: &<a href="../sui/group_ops.md#sui_group_ops_Element">sui::group_ops::Element</a>&lt;G1&gt;, e2: &<a href="../sui/group_ops.md#sui_group_ops_Element">sui::group_ops::Element</a>&lt;G2&gt;): <a href="../sui/group_ops.md#sui_group_ops_Element">sui::group_ops::Element</a>&lt;G3&gt;
 </code></pre>
 
 
@@ -363,7 +363,7 @@ This function is currently only enabled on Devnet.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/group_ops.md#sui_group_ops_pairing">pairing</a>&lt;G1, G2, G3&gt;(
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/group_ops.md#sui_group_ops_pairing">pairing</a>&lt;G1, G2, G3&gt;(
     type_: u8,
     e1: &<a href="../sui/group_ops.md#sui_group_ops_Element">Element</a>&lt;G1&gt;,
     e2: &<a href="../sui/group_ops.md#sui_group_ops_Element">Element</a>&lt;G2&gt;,
@@ -382,7 +382,7 @@ This function is currently only enabled on Devnet.
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/group_ops.md#sui_group_ops_convert">convert</a>&lt;From, To&gt;(from_type_: u8, to_type_: u8, e: &<a href="../sui/group_ops.md#sui_group_ops_Element">sui::group_ops::Element</a>&lt;From&gt;): <a href="../sui/group_ops.md#sui_group_ops_Element">sui::group_ops::Element</a>&lt;To&gt;
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/group_ops.md#sui_group_ops_convert">convert</a>&lt;From, To&gt;(from_type_: u8, to_type_: u8, e: &<a href="../sui/group_ops.md#sui_group_ops_Element">sui::group_ops::Element</a>&lt;From&gt;): <a href="../sui/group_ops.md#sui_group_ops_Element">sui::group_ops::Element</a>&lt;To&gt;
 </code></pre>
 
 
@@ -391,7 +391,7 @@ This function is currently only enabled on Devnet.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/group_ops.md#sui_group_ops_convert">convert</a>&lt;From, To&gt;(
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/group_ops.md#sui_group_ops_convert">convert</a>&lt;From, To&gt;(
     from_type_: u8,
     to_type_: u8,
     e: &<a href="../sui/group_ops.md#sui_group_ops_Element">Element</a>&lt;From&gt;,
@@ -410,7 +410,7 @@ This function is currently only enabled on Devnet.
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/group_ops.md#sui_group_ops_sum">sum</a>&lt;G&gt;(type_: u8, terms: &vector&lt;<a href="../sui/group_ops.md#sui_group_ops_Element">sui::group_ops::Element</a>&lt;G&gt;&gt;): <a href="../sui/group_ops.md#sui_group_ops_Element">sui::group_ops::Element</a>&lt;G&gt;
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/group_ops.md#sui_group_ops_sum">sum</a>&lt;G&gt;(type_: u8, terms: &vector&lt;<a href="../sui/group_ops.md#sui_group_ops_Element">sui::group_ops::Element</a>&lt;G&gt;&gt;): <a href="../sui/group_ops.md#sui_group_ops_Element">sui::group_ops::Element</a>&lt;G&gt;
 </code></pre>
 
 
@@ -419,7 +419,7 @@ This function is currently only enabled on Devnet.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/group_ops.md#sui_group_ops_sum">sum</a>&lt;G&gt;(type_: u8, terms: &vector&lt;<a href="../sui/group_ops.md#sui_group_ops_Element">Element</a>&lt;G&gt;&gt;): <a href="../sui/group_ops.md#sui_group_ops_Element">Element</a>&lt;G&gt; {
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/group_ops.md#sui_group_ops_sum">sum</a>&lt;G&gt;(type_: u8, terms: &vector&lt;<a href="../sui/group_ops.md#sui_group_ops_Element">Element</a>&lt;G&gt;&gt;): <a href="../sui/group_ops.md#sui_group_ops_Element">Element</a>&lt;G&gt; {
     <a href="../sui/group_ops.md#sui_group_ops_Element">Element</a>&lt;G&gt; { <a href="../sui/group_ops.md#sui_group_ops_bytes">bytes</a>: <a href="../sui/group_ops.md#sui_group_ops_internal_sum">internal_sum</a>(type_, &(*terms).map!(|x| x.<a href="../sui/group_ops.md#sui_group_ops_bytes">bytes</a>)) }
 }
 </code></pre>
@@ -658,7 +658,7 @@ This function is currently only enabled on Devnet.
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/group_ops.md#sui_group_ops_set_as_prefix">set_as_prefix</a>(x: u64, big_endian: bool, buffer: &<b>mut</b> vector&lt;u8&gt;)
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/group_ops.md#sui_group_ops_set_as_prefix">set_as_prefix</a>(x: u64, big_endian: bool, buffer: &<b>mut</b> vector&lt;u8&gt;)
 </code></pre>
 
 
@@ -667,10 +667,10 @@ This function is currently only enabled on Devnet.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/group_ops.md#sui_group_ops_set_as_prefix">set_as_prefix</a>(x: u64, big_endian: bool, buffer: &<b>mut</b> vector&lt;u8&gt;) {
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/group_ops.md#sui_group_ops_set_as_prefix">set_as_prefix</a>(x: u64, big_endian: bool, buffer: &<b>mut</b> vector&lt;u8&gt;) {
     <b>let</b> buffer_len = buffer.length();
     <b>assert</b>!(buffer_len &gt; 7, <a href="../sui/group_ops.md#sui_group_ops_EInvalidBufferLength">EInvalidBufferLength</a>);
-    <b>let</b> x_as_bytes = <a href="../sui/bcs.md#sui_bcs_to_bytes">bcs::to_bytes</a>(&x); // little endian
+    <b>let</b> x_as_bytes = bcs::to_bytes(&x); // little endian
     <b>let</b> <b>mut</b> i = 0;
     <b>while</b> (i &lt; 8) {
         <b>let</b> position = <b>if</b> (big_endian) {

--- a/crates/sui-framework/docs/sui/hex.md
+++ b/crates/sui-framework/docs/sui/hex.md
@@ -92,7 +92,7 @@ Aborts if the hex string does not have an even number of characters (as each hex
 Aborts if the hex string contains non-valid hex characters (valid characters are 0 - 9, a - f, A - F)
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/hex.md#sui_hex_decode">decode</a>(<a href="../sui/hex.md#sui_hex">hex</a>: vector&lt;u8&gt;): vector&lt;u8&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/hex.md#sui_hex_decode">decode</a>(hex: vector&lt;u8&gt;): vector&lt;u8&gt;
 </code></pre>
 
 
@@ -101,11 +101,11 @@ Aborts if the hex string contains non-valid hex characters (valid characters are
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/hex.md#sui_hex_decode">decode</a>(<a href="../sui/hex.md#sui_hex">hex</a>: vector&lt;u8&gt;): vector&lt;u8&gt; {
-    <b>let</b> (<b>mut</b> i, <b>mut</b> r, l) = (0, vector[], <a href="../sui/hex.md#sui_hex">hex</a>.length());
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/hex.md#sui_hex_decode">decode</a>(hex: vector&lt;u8&gt;): vector&lt;u8&gt; {
+    <b>let</b> (<b>mut</b> i, <b>mut</b> r, l) = (0, vector[], hex.length());
     <b>assert</b>!(l % 2 == 0, <a href="../sui/hex.md#sui_hex_EInvalidHexLength">EInvalidHexLength</a>);
     <b>while</b> (i &lt; l) {
-        <b>let</b> decimal = <a href="../sui/hex.md#sui_hex_decode_byte">decode_byte</a>(<a href="../sui/hex.md#sui_hex">hex</a>[i]) * 16 + <a href="../sui/hex.md#sui_hex_decode_byte">decode_byte</a>(<a href="../sui/hex.md#sui_hex">hex</a>[i + 1]);
+        <b>let</b> decimal = <a href="../sui/hex.md#sui_hex_decode_byte">decode_byte</a>(hex[i]) * 16 + <a href="../sui/hex.md#sui_hex_decode_byte">decode_byte</a>(hex[i + 1]);
         r.push_back(decimal);
         i = i + 2;
     };
@@ -123,7 +123,7 @@ Aborts if the hex string contains non-valid hex characters (valid characters are
 
 
 
-<pre><code><b>fun</b> <a href="../sui/hex.md#sui_hex_decode_byte">decode_byte</a>(<a href="../sui/hex.md#sui_hex">hex</a>: u8): u8
+<pre><code><b>fun</b> <a href="../sui/hex.md#sui_hex_decode_byte">decode_byte</a>(hex: u8): u8
 </code></pre>
 
 
@@ -132,13 +132,13 @@ Aborts if the hex string contains non-valid hex characters (valid characters are
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="../sui/hex.md#sui_hex_decode_byte">decode_byte</a>(<a href="../sui/hex.md#sui_hex">hex</a>: u8): u8 {
-    <b>if</b> (48 &lt;= <a href="../sui/hex.md#sui_hex">hex</a> && <a href="../sui/hex.md#sui_hex">hex</a> &lt; 58) {
-        <a href="../sui/hex.md#sui_hex">hex</a> - 48
-    } <b>else</b> <b>if</b> (65 &lt;= <a href="../sui/hex.md#sui_hex">hex</a> && <a href="../sui/hex.md#sui_hex">hex</a> &lt; 71) {
-        10 + <a href="../sui/hex.md#sui_hex">hex</a> - 65
-    } <b>else</b> <b>if</b> (97 &lt;= <a href="../sui/hex.md#sui_hex">hex</a> && <a href="../sui/hex.md#sui_hex">hex</a> &lt; 103) {
-        10 + <a href="../sui/hex.md#sui_hex">hex</a> - 97
+<pre><code><b>fun</b> <a href="../sui/hex.md#sui_hex_decode_byte">decode_byte</a>(hex: u8): u8 {
+    <b>if</b> (48 &lt;= hex && hex &lt; 58) {
+        hex - 48
+    } <b>else</b> <b>if</b> (65 &lt;= hex && hex &lt; 71) {
+        10 + hex - 65
+    } <b>else</b> <b>if</b> (97 &lt;= hex && hex &lt; 103) {
+        10 + hex - 97
     } <b>else</b> {
         <b>abort</b> <a href="../sui/hex.md#sui_hex_ENotValidHexCharacter">ENotValidHexCharacter</a>
     }

--- a/crates/sui-framework/docs/sui/kiosk.md
+++ b/crates/sui-framework/docs/sui/kiosk.md
@@ -44,7 +44,7 @@ way to move the asset out of the Kiosk is to <code><a href="../sui/kiosk.md#sui_
 
 - <code>listed</code> - A <code><a href="../sui/kiosk.md#sui_kiosk_place">place</a></code>d or a <code><a href="../sui/kiosk.md#sui_kiosk_lock">lock</a></code>ed item can be <code><a href="../sui/kiosk.md#sui_kiosk_list">list</a></code>ed for a fixed price
 allowing anyone to <code><a href="../sui/kiosk.md#sui_kiosk_purchase">purchase</a></code> it from the Kiosk. While listed, an item can
-not be taken or modified. However, an immutable borrow via <code><a href="../sui/borrow.md#sui_borrow">borrow</a></code> call is
+not be taken or modified. However, an immutable borrow via <code><a href="../sui/kiosk.md#sui_kiosk_borrow">borrow</a></code> call is
 still available. The <code><a href="../sui/kiosk.md#sui_kiosk_delist">delist</a></code> function returns the asset to the previous
 state.
 
@@ -96,7 +96,7 @@ Kiosk -> (Item, TransferRequest)
 ... TransferRequest ------> Club Membership Transfer Policy
 ```
 
-See <code><a href="../sui/transfer_policy.md#sui_transfer_policy">transfer_policy</a></code> module for more details on how they function.
+See <code>transfer_policy</code> module for more details on how they function.
 
 
         -  [Principles and philosophy:](#@Principles_and_philosophy:_0)
@@ -249,7 +249,7 @@ needs to be approved via the <code>TransferPolicy</code>.
 <dd>
  [DEPRECATED] Please, don't use the <code>allow_extensions</code> and the matching
  <code><a href="../sui/kiosk.md#sui_kiosk_set_allow_extensions">set_allow_extensions</a></code> function - it is a legacy feature that is being
- replaced by the <code><a href="../sui/kiosk_extension.md#sui_kiosk_extension">kiosk_extension</a></code> module and its Extensions API.
+ replaced by the <code>kiosk_extension</code> module and its Extensions API.
  Exposes <code><a href="../sui/kiosk.md#sui_kiosk_uid_mut">uid_mut</a></code> publicly when set to <code><b>true</b></code>, set to <code><b>false</b></code> by default.
 </dd>
 </dl>
@@ -485,7 +485,7 @@ type-indexed which allows for searching for offers of a specific <code>T</code>
 
 <dl>
 <dt>
-<code><a href="../sui/kiosk.md#sui_kiosk">kiosk</a>: <a href="../sui/object.md#sui_object_ID">sui::object::ID</a></code>
+<code>kiosk: <a href="../sui/object.md#sui_object_ID">sui::object::ID</a></code>
 </dt>
 <dd>
 </dd>
@@ -530,7 +530,7 @@ by the trading module / extension.
 
 <dl>
 <dt>
-<code><a href="../sui/kiosk.md#sui_kiosk">kiosk</a>: <a href="../sui/object.md#sui_object_ID">sui::object::ID</a></code>
+<code>kiosk: <a href="../sui/object.md#sui_object_ID">sui::object::ID</a></code>
 </dt>
 <dd>
 </dd>
@@ -568,7 +568,7 @@ to close tracked offers.
 
 <dl>
 <dt>
-<code><a href="../sui/kiosk.md#sui_kiosk">kiosk</a>: <a href="../sui/object.md#sui_object_ID">sui::object::ID</a></code>
+<code>kiosk: <a href="../sui/object.md#sui_object_ID">sui::object::ID</a></code>
 </dt>
 <dd>
 </dd>
@@ -735,9 +735,9 @@ Creates a new Kiosk in a default configuration: sender receives the
 
 
 <pre><code><b>entry</b> <b>fun</b> <a href="../sui/kiosk.md#sui_kiosk_default">default</a>(ctx: &<b>mut</b> TxContext) {
-    <b>let</b> (<a href="../sui/kiosk.md#sui_kiosk">kiosk</a>, cap) = <a href="../sui/kiosk.md#sui_kiosk_new">new</a>(ctx);
+    <b>let</b> (kiosk, cap) = <a href="../sui/kiosk.md#sui_kiosk_new">new</a>(ctx);
     <a href="../sui/transfer.md#sui_transfer_transfer">sui::transfer::transfer</a>(cap, ctx.sender());
-    <a href="../sui/transfer.md#sui_transfer_share_object">sui::transfer::share_object</a>(<a href="../sui/kiosk.md#sui_kiosk">kiosk</a>);
+    <a href="../sui/transfer.md#sui_transfer_share_object">sui::transfer::share_object</a>(kiosk);
 }
 </code></pre>
 
@@ -762,18 +762,18 @@ Creates a new <code><a href="../sui/kiosk.md#sui_kiosk_Kiosk">Kiosk</a></code> w
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/kiosk.md#sui_kiosk_new">new</a>(ctx: &<b>mut</b> TxContext): (<a href="../sui/kiosk.md#sui_kiosk_Kiosk">Kiosk</a>, <a href="../sui/kiosk.md#sui_kiosk_KioskOwnerCap">KioskOwnerCap</a>) {
-    <b>let</b> <a href="../sui/kiosk.md#sui_kiosk">kiosk</a> = <a href="../sui/kiosk.md#sui_kiosk_Kiosk">Kiosk</a> {
-        id: <a href="../sui/object.md#sui_object_new">object::new</a>(ctx),
-        profits: <a href="../sui/balance.md#sui_balance_zero">balance::zero</a>(),
+    <b>let</b> kiosk = <a href="../sui/kiosk.md#sui_kiosk_Kiosk">Kiosk</a> {
+        id: object::new(ctx),
+        profits: balance::zero(),
         <a href="../sui/kiosk.md#sui_kiosk_owner">owner</a>: ctx.sender(),
         <a href="../sui/kiosk.md#sui_kiosk_item_count">item_count</a>: 0,
         allow_extensions: <b>false</b>,
     };
     <b>let</b> cap = <a href="../sui/kiosk.md#sui_kiosk_KioskOwnerCap">KioskOwnerCap</a> {
-        id: <a href="../sui/object.md#sui_object_new">object::new</a>(ctx),
-        `<b>for</b>`: <a href="../sui/object.md#sui_object_id">object::id</a>(&<a href="../sui/kiosk.md#sui_kiosk">kiosk</a>),
+        id: object::new(ctx),
+        `<b>for</b>`: object::id(&kiosk),
     };
-    (<a href="../sui/kiosk.md#sui_kiosk">kiosk</a>, cap)
+    (kiosk, cap)
 }
 </code></pre>
 
@@ -987,7 +987,7 @@ Performs an authorization check to make sure only owner can sell.
     <b>assert</b>!(self.<a href="../sui/kiosk.md#sui_kiosk_has_item_with_type">has_item_with_type</a>&lt;T&gt;(id), <a href="../sui/kiosk.md#sui_kiosk_EItemNotFound">EItemNotFound</a>);
     <b>assert</b>!(!self.<a href="../sui/kiosk.md#sui_kiosk_is_listed_exclusively">is_listed_exclusively</a>(id), <a href="../sui/kiosk.md#sui_kiosk_EListedExclusively">EListedExclusively</a>);
     df::add(&<b>mut</b> self.id, <a href="../sui/kiosk.md#sui_kiosk_Listing">Listing</a> { id, is_exclusive: <b>false</b> }, price);
-    <a href="../sui/event.md#sui_event_emit">event::emit</a>(<a href="../sui/kiosk.md#sui_kiosk_ItemListed">ItemListed</a>&lt;T&gt; { <a href="../sui/kiosk.md#sui_kiosk">kiosk</a>: <a href="../sui/object.md#sui_object_id">object::id</a>(self), id, price })
+    event::emit(<a href="../sui/kiosk.md#sui_kiosk_ItemListed">ItemListed</a>&lt;T&gt; { kiosk: object::id(self), id, price })
 }
 </code></pre>
 
@@ -1017,7 +1017,7 @@ Calls <code><a href="../sui/kiosk.md#sui_kiosk_place">place</a></code> and <code
     item: T,
     price: u64,
 ) {
-    <b>let</b> id = <a href="../sui/object.md#sui_object_id">object::id</a>(&item);
+    <b>let</b> id = object::id(&item);
     self.<a href="../sui/kiosk.md#sui_kiosk_place">place</a>(cap, item);
     self.<a href="../sui/kiosk.md#sui_kiosk_list">list</a>&lt;T&gt;(cap, id, price)
 }
@@ -1050,7 +1050,7 @@ user Kiosk. Can only be performed by the owner of the <code><a href="../sui/kios
     <b>assert</b>!(!self.<a href="../sui/kiosk.md#sui_kiosk_is_listed_exclusively">is_listed_exclusively</a>(id), <a href="../sui/kiosk.md#sui_kiosk_EListedExclusively">EListedExclusively</a>);
     <b>assert</b>!(self.<a href="../sui/kiosk.md#sui_kiosk_is_listed">is_listed</a>(id), <a href="../sui/kiosk.md#sui_kiosk_ENotListed">ENotListed</a>);
     df::remove&lt;<a href="../sui/kiosk.md#sui_kiosk_Listing">Listing</a>, u64&gt;(&<b>mut</b> self.id, <a href="../sui/kiosk.md#sui_kiosk_Listing">Listing</a> { id, is_exclusive: <b>false</b> });
-    <a href="../sui/event.md#sui_event_emit">event::emit</a>(<a href="../sui/kiosk.md#sui_kiosk_ItemDelisted">ItemDelisted</a>&lt;T&gt; { <a href="../sui/kiosk.md#sui_kiosk">kiosk</a>: <a href="../sui/object.md#sui_object_id">object::id</a>(self), id })
+    event::emit(<a href="../sui/kiosk.md#sui_kiosk_ItemDelisted">ItemDelisted</a>&lt;T&gt; { kiosk: object::id(self), id })
 }
 </code></pre>
 
@@ -1090,9 +1090,9 @@ finalized.
     self.<a href="../sui/kiosk.md#sui_kiosk_item_count">item_count</a> = self.<a href="../sui/kiosk.md#sui_kiosk_item_count">item_count</a> - 1;
     <b>assert</b>!(price == payment.value(), <a href="../sui/kiosk.md#sui_kiosk_EIncorrectAmount">EIncorrectAmount</a>);
     df::remove_if_exists&lt;<a href="../sui/kiosk.md#sui_kiosk_Lock">Lock</a>, bool&gt;(&<b>mut</b> self.id, <a href="../sui/kiosk.md#sui_kiosk_Lock">Lock</a> { id });
-    <a href="../sui/coin.md#sui_coin_put">coin::put</a>(&<b>mut</b> self.profits, payment);
-    <a href="../sui/event.md#sui_event_emit">event::emit</a>(<a href="../sui/kiosk.md#sui_kiosk_ItemPurchased">ItemPurchased</a>&lt;T&gt; { <a href="../sui/kiosk.md#sui_kiosk">kiosk</a>: <a href="../sui/object.md#sui_object_id">object::id</a>(self), id, price });
-    (inner, <a href="../sui/transfer_policy.md#sui_transfer_policy_new_request">transfer_policy::new_request</a>(id, price, <a href="../sui/object.md#sui_object_id">object::id</a>(self)))
+    coin::put(&<b>mut</b> self.profits, payment);
+    event::emit(<a href="../sui/kiosk.md#sui_kiosk_ItemPurchased">ItemPurchased</a>&lt;T&gt; { kiosk: object::id(self), id, price });
+    (inner, transfer_policy::new_request(id, price, object::id(self)))
 }
 </code></pre>
 
@@ -1131,8 +1131,8 @@ for any price equal or higher than the <code>min_price</code>.
     <a href="../sui/kiosk.md#sui_kiosk_PurchaseCap">PurchaseCap</a>&lt;T&gt; {
         min_price,
         item_id: id,
-        id: <a href="../sui/object.md#sui_object_new">object::new</a>(ctx),
-        kiosk_id: <a href="../sui/object.md#sui_object_id">object::id</a>(self),
+        id: object::new(ctx),
+        kiosk_id: object::id(self),
     }
 }
 </code></pre>
@@ -1168,13 +1168,13 @@ as the price for the listing making sure it's no less than <code>min_amount</cod
     <b>let</b> id = item_id;
     <b>let</b> paid = payment.value();
     <b>assert</b>!(paid &gt;= min_price, <a href="../sui/kiosk.md#sui_kiosk_EIncorrectAmount">EIncorrectAmount</a>);
-    <b>assert</b>!(<a href="../sui/object.md#sui_object_id">object::id</a>(self) == kiosk_id, <a href="../sui/kiosk.md#sui_kiosk_EWrongKiosk">EWrongKiosk</a>);
+    <b>assert</b>!(object::id(self) == kiosk_id, <a href="../sui/kiosk.md#sui_kiosk_EWrongKiosk">EWrongKiosk</a>);
     df::remove&lt;<a href="../sui/kiosk.md#sui_kiosk_Listing">Listing</a>, u64&gt;(&<b>mut</b> self.id, <a href="../sui/kiosk.md#sui_kiosk_Listing">Listing</a> { id, is_exclusive: <b>true</b> });
-    <a href="../sui/coin.md#sui_coin_put">coin::put</a>(&<b>mut</b> self.profits, payment);
+    coin::put(&<b>mut</b> self.profits, payment);
     self.<a href="../sui/kiosk.md#sui_kiosk_item_count">item_count</a> = self.<a href="../sui/kiosk.md#sui_kiosk_item_count">item_count</a> - 1;
     df::remove_if_exists&lt;<a href="../sui/kiosk.md#sui_kiosk_Lock">Lock</a>, bool&gt;(&<b>mut</b> self.id, <a href="../sui/kiosk.md#sui_kiosk_Lock">Lock</a> { id });
     <b>let</b> item = dof::remove&lt;<a href="../sui/kiosk.md#sui_kiosk_Item">Item</a>, T&gt;(&<b>mut</b> self.id, <a href="../sui/kiosk.md#sui_kiosk_Item">Item</a> { id });
-    (item, <a href="../sui/transfer_policy.md#sui_transfer_policy_new_request">transfer_policy::new_request</a>(id, paid, <a href="../sui/object.md#sui_object_id">object::id</a>(self)))
+    (item, transfer_policy::new_request(id, paid, object::id(self)))
 }
 </code></pre>
 
@@ -1201,7 +1201,7 @@ allow the item for taking. Can only be returned to its <code><a href="../sui/kio
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/kiosk.md#sui_kiosk_return_purchase_cap">return_purchase_cap</a>&lt;T: key + store&gt;(self: &<b>mut</b> <a href="../sui/kiosk.md#sui_kiosk_Kiosk">Kiosk</a>, purchase_cap: <a href="../sui/kiosk.md#sui_kiosk_PurchaseCap">PurchaseCap</a>&lt;T&gt;) {
     <b>let</b> <a href="../sui/kiosk.md#sui_kiosk_PurchaseCap">PurchaseCap</a> { id, item_id, kiosk_id, min_price: _ } = purchase_cap;
-    <b>assert</b>!(<a href="../sui/object.md#sui_object_id">object::id</a>(self) == kiosk_id, <a href="../sui/kiosk.md#sui_kiosk_EWrongKiosk">EWrongKiosk</a>);
+    <b>assert</b>!(object::id(self) == kiosk_id, <a href="../sui/kiosk.md#sui_kiosk_EWrongKiosk">EWrongKiosk</a>);
     df::remove&lt;<a href="../sui/kiosk.md#sui_kiosk_Listing">Listing</a>, u64&gt;(&<b>mut</b> self.id, <a href="../sui/kiosk.md#sui_kiosk_Listing">Listing</a> { id: item_id, is_exclusive: <b>true</b> });
     id.delete()
 }
@@ -1241,7 +1241,7 @@ Withdraw profits from the Kiosk.
     } <b>else</b> {
         self.profits.value()
     };
-    <a href="../sui/coin.md#sui_coin_take">coin::take</a>(&<b>mut</b> self.profits, amount, ctx)
+    coin::take(&<b>mut</b> self.profits, amount, ctx)
 }
 </code></pre>
 
@@ -1256,7 +1256,7 @@ Withdraw profits from the Kiosk.
 Internal: "lock" an item disabling the <code><a href="../sui/kiosk.md#sui_kiosk_take">take</a></code> action.
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/kiosk.md#sui_kiosk_lock_internal">lock_internal</a>&lt;T: key, store&gt;(self: &<b>mut</b> <a href="../sui/kiosk.md#sui_kiosk_Kiosk">sui::kiosk::Kiosk</a>, item: T)
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/kiosk.md#sui_kiosk_lock_internal">lock_internal</a>&lt;T: key, store&gt;(self: &<b>mut</b> <a href="../sui/kiosk.md#sui_kiosk_Kiosk">sui::kiosk::Kiosk</a>, item: T)
 </code></pre>
 
 
@@ -1265,8 +1265,8 @@ Internal: "lock" an item disabling the <code><a href="../sui/kiosk.md#sui_kiosk_
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/kiosk.md#sui_kiosk_lock_internal">lock_internal</a>&lt;T: key + store&gt;(self: &<b>mut</b> <a href="../sui/kiosk.md#sui_kiosk_Kiosk">Kiosk</a>, item: T) {
-    df::add(&<b>mut</b> self.id, <a href="../sui/kiosk.md#sui_kiosk_Lock">Lock</a> { id: <a href="../sui/object.md#sui_object_id">object::id</a>(&item) }, <b>true</b>);
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/kiosk.md#sui_kiosk_lock_internal">lock_internal</a>&lt;T: key + store&gt;(self: &<b>mut</b> <a href="../sui/kiosk.md#sui_kiosk_Kiosk">Kiosk</a>, item: T) {
+    df::add(&<b>mut</b> self.id, <a href="../sui/kiosk.md#sui_kiosk_Lock">Lock</a> { id: object::id(&item) }, <b>true</b>);
     self.<a href="../sui/kiosk.md#sui_kiosk_place_internal">place_internal</a>(item)
 }
 </code></pre>
@@ -1282,7 +1282,7 @@ Internal: "lock" an item disabling the <code><a href="../sui/kiosk.md#sui_kiosk_
 Internal: "place" an item to the Kiosk and increment the item count.
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/kiosk.md#sui_kiosk_place_internal">place_internal</a>&lt;T: key, store&gt;(self: &<b>mut</b> <a href="../sui/kiosk.md#sui_kiosk_Kiosk">sui::kiosk::Kiosk</a>, item: T)
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/kiosk.md#sui_kiosk_place_internal">place_internal</a>&lt;T: key, store&gt;(self: &<b>mut</b> <a href="../sui/kiosk.md#sui_kiosk_Kiosk">sui::kiosk::Kiosk</a>, item: T)
 </code></pre>
 
 
@@ -1291,9 +1291,9 @@ Internal: "place" an item to the Kiosk and increment the item count.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/kiosk.md#sui_kiosk_place_internal">place_internal</a>&lt;T: key + store&gt;(self: &<b>mut</b> <a href="../sui/kiosk.md#sui_kiosk_Kiosk">Kiosk</a>, item: T) {
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/kiosk.md#sui_kiosk_place_internal">place_internal</a>&lt;T: key + store&gt;(self: &<b>mut</b> <a href="../sui/kiosk.md#sui_kiosk_Kiosk">Kiosk</a>, item: T) {
     self.<a href="../sui/kiosk.md#sui_kiosk_item_count">item_count</a> = self.<a href="../sui/kiosk.md#sui_kiosk_item_count">item_count</a> + 1;
-    dof::add(&<b>mut</b> self.id, <a href="../sui/kiosk.md#sui_kiosk_Item">Item</a> { id: <a href="../sui/object.md#sui_object_id">object::id</a>(&item) }, item)
+    dof::add(&<b>mut</b> self.id, <a href="../sui/kiosk.md#sui_kiosk_Item">Item</a> { id: object::id(&item) }, item)
 }
 </code></pre>
 
@@ -1308,7 +1308,7 @@ Internal: "place" an item to the Kiosk and increment the item count.
 Internal: get a mutable access to the UID.
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/kiosk.md#sui_kiosk_uid_mut_internal">uid_mut_internal</a>(self: &<b>mut</b> <a href="../sui/kiosk.md#sui_kiosk_Kiosk">sui::kiosk::Kiosk</a>): &<b>mut</b> <a href="../sui/object.md#sui_object_UID">sui::object::UID</a>
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/kiosk.md#sui_kiosk_uid_mut_internal">uid_mut_internal</a>(self: &<b>mut</b> <a href="../sui/kiosk.md#sui_kiosk_Kiosk">sui::kiosk::Kiosk</a>): &<b>mut</b> <a href="../sui/object.md#sui_object_UID">sui::object::UID</a>
 </code></pre>
 
 
@@ -1317,7 +1317,7 @@ Internal: get a mutable access to the UID.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/kiosk.md#sui_kiosk_uid_mut_internal">uid_mut_internal</a>(self: &<b>mut</b> <a href="../sui/kiosk.md#sui_kiosk_Kiosk">Kiosk</a>): &<b>mut</b> UID {
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/kiosk.md#sui_kiosk_uid_mut_internal">uid_mut_internal</a>(self: &<b>mut</b> <a href="../sui/kiosk.md#sui_kiosk_Kiosk">Kiosk</a>): &<b>mut</b> UID {
     &<b>mut</b> self.id
 }
 </code></pre>
@@ -1471,7 +1471,7 @@ Check whether the <code><a href="../sui/kiosk.md#sui_kiosk_KioskOwnerCap">KioskO
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/kiosk.md#sui_kiosk_has_access">has_access</a>(self: &<b>mut</b> <a href="../sui/kiosk.md#sui_kiosk_Kiosk">Kiosk</a>, cap: &<a href="../sui/kiosk.md#sui_kiosk_KioskOwnerCap">KioskOwnerCap</a>): bool {
-    <a href="../sui/object.md#sui_object_id">object::id</a>(self) == cap.`<b>for</b>`
+    object::id(self) == cap.`<b>for</b>`
 }
 </code></pre>
 
@@ -1694,11 +1694,11 @@ Get mutable access to <code>profits</code> - owner only action.
 
 ## Function `borrow`
 
-Immutably borrow an item from the <code><a href="../sui/kiosk.md#sui_kiosk_Kiosk">Kiosk</a></code>. Any item can be <code><a href="../sui/borrow.md#sui_borrow">borrow</a></code>ed
+Immutably borrow an item from the <code><a href="../sui/kiosk.md#sui_kiosk_Kiosk">Kiosk</a></code>. Any item can be <code><a href="../sui/kiosk.md#sui_kiosk_borrow">borrow</a></code>ed
 at any time.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/borrow.md#sui_borrow">borrow</a>&lt;T: key, store&gt;(self: &<a href="../sui/kiosk.md#sui_kiosk_Kiosk">sui::kiosk::Kiosk</a>, cap: &<a href="../sui/kiosk.md#sui_kiosk_KioskOwnerCap">sui::kiosk::KioskOwnerCap</a>, id: <a href="../sui/object.md#sui_object_ID">sui::object::ID</a>): &T
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/kiosk.md#sui_kiosk_borrow">borrow</a>&lt;T: key, store&gt;(self: &<a href="../sui/kiosk.md#sui_kiosk_Kiosk">sui::kiosk::Kiosk</a>, cap: &<a href="../sui/kiosk.md#sui_kiosk_KioskOwnerCap">sui::kiosk::KioskOwnerCap</a>, id: <a href="../sui/object.md#sui_object_ID">sui::object::ID</a>): &T
 </code></pre>
 
 
@@ -1707,8 +1707,8 @@ at any time.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/borrow.md#sui_borrow">borrow</a>&lt;T: key + store&gt;(self: &<a href="../sui/kiosk.md#sui_kiosk_Kiosk">Kiosk</a>, cap: &<a href="../sui/kiosk.md#sui_kiosk_KioskOwnerCap">KioskOwnerCap</a>, id: ID): &T {
-    <b>assert</b>!(<a href="../sui/object.md#sui_object_id">object::id</a>(self) == cap.`<b>for</b>`, <a href="../sui/kiosk.md#sui_kiosk_ENotOwner">ENotOwner</a>);
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/kiosk.md#sui_kiosk_borrow">borrow</a>&lt;T: key + store&gt;(self: &<a href="../sui/kiosk.md#sui_kiosk_Kiosk">Kiosk</a>, cap: &<a href="../sui/kiosk.md#sui_kiosk_KioskOwnerCap">KioskOwnerCap</a>, id: ID): &T {
+    <b>assert</b>!(object::id(self) == cap.`<b>for</b>`, <a href="../sui/kiosk.md#sui_kiosk_ENotOwner">ENotOwner</a>);
     <b>assert</b>!(self.<a href="../sui/kiosk.md#sui_kiosk_has_item">has_item</a>(id), <a href="../sui/kiosk.md#sui_kiosk_EItemNotFound">EItemNotFound</a>);
     dof::borrow(&self.id, <a href="../sui/kiosk.md#sui_kiosk_Item">Item</a> { id })
 }
@@ -1768,7 +1768,7 @@ Item can be <code><a href="../sui/kiosk.md#sui_kiosk_borrow_val">borrow_val</a><
     <b>assert</b>!(self.<a href="../sui/kiosk.md#sui_kiosk_has_access">has_access</a>(cap), <a href="../sui/kiosk.md#sui_kiosk_ENotOwner">ENotOwner</a>);
     <b>assert</b>!(self.<a href="../sui/kiosk.md#sui_kiosk_has_item">has_item</a>(id), <a href="../sui/kiosk.md#sui_kiosk_EItemNotFound">EItemNotFound</a>);
     <b>assert</b>!(!self.<a href="../sui/kiosk.md#sui_kiosk_is_listed">is_listed</a>(id), <a href="../sui/kiosk.md#sui_kiosk_EItemIsListed">EItemIsListed</a>);
-    (dof::remove(&<b>mut</b> self.id, <a href="../sui/kiosk.md#sui_kiosk_Item">Item</a> { id }), <a href="../sui/kiosk.md#sui_kiosk_Borrow">Borrow</a> { kiosk_id: <a href="../sui/object.md#sui_object_id">object::id</a>(self), item_id: id })
+    (dof::remove(&<b>mut</b> self.id, <a href="../sui/kiosk.md#sui_kiosk_Item">Item</a> { id }), <a href="../sui/kiosk.md#sui_kiosk_Borrow">Borrow</a> { kiosk_id: object::id(self), item_id: id })
 }
 </code></pre>
 
@@ -1784,7 +1784,7 @@ Return the borrowed item to the <code><a href="../sui/kiosk.md#sui_kiosk_Kiosk">
 if <code><a href="../sui/kiosk.md#sui_kiosk_borrow_val">borrow_val</a></code> is used.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/kiosk.md#sui_kiosk_return_val">return_val</a>&lt;T: key, store&gt;(self: &<b>mut</b> <a href="../sui/kiosk.md#sui_kiosk_Kiosk">sui::kiosk::Kiosk</a>, item: T, <a href="../sui/borrow.md#sui_borrow">borrow</a>: <a href="../sui/kiosk.md#sui_kiosk_Borrow">sui::kiosk::Borrow</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/kiosk.md#sui_kiosk_return_val">return_val</a>&lt;T: key, store&gt;(self: &<b>mut</b> <a href="../sui/kiosk.md#sui_kiosk_Kiosk">sui::kiosk::Kiosk</a>, item: T, <a href="../sui/kiosk.md#sui_kiosk_borrow">borrow</a>: <a href="../sui/kiosk.md#sui_kiosk_Borrow">sui::kiosk::Borrow</a>)
 </code></pre>
 
 
@@ -1793,10 +1793,10 @@ if <code><a href="../sui/kiosk.md#sui_kiosk_borrow_val">borrow_val</a></code> is
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/kiosk.md#sui_kiosk_return_val">return_val</a>&lt;T: key + store&gt;(self: &<b>mut</b> <a href="../sui/kiosk.md#sui_kiosk_Kiosk">Kiosk</a>, item: T, <a href="../sui/borrow.md#sui_borrow">borrow</a>: <a href="../sui/kiosk.md#sui_kiosk_Borrow">Borrow</a>) {
-    <b>let</b> <a href="../sui/kiosk.md#sui_kiosk_Borrow">Borrow</a> { kiosk_id, item_id } = <a href="../sui/borrow.md#sui_borrow">borrow</a>;
-    <b>assert</b>!(<a href="../sui/object.md#sui_object_id">object::id</a>(self) == kiosk_id, <a href="../sui/kiosk.md#sui_kiosk_EWrongKiosk">EWrongKiosk</a>);
-    <b>assert</b>!(<a href="../sui/object.md#sui_object_id">object::id</a>(&item) == item_id, <a href="../sui/kiosk.md#sui_kiosk_EItemMismatch">EItemMismatch</a>);
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/kiosk.md#sui_kiosk_return_val">return_val</a>&lt;T: key + store&gt;(self: &<b>mut</b> <a href="../sui/kiosk.md#sui_kiosk_Kiosk">Kiosk</a>, item: T, <a href="../sui/kiosk.md#sui_kiosk_borrow">borrow</a>: <a href="../sui/kiosk.md#sui_kiosk_Borrow">Borrow</a>) {
+    <b>let</b> <a href="../sui/kiosk.md#sui_kiosk_Borrow">Borrow</a> { kiosk_id, item_id } = <a href="../sui/kiosk.md#sui_kiosk_borrow">borrow</a>;
+    <b>assert</b>!(object::id(self) == kiosk_id, <a href="../sui/kiosk.md#sui_kiosk_EWrongKiosk">EWrongKiosk</a>);
+    <b>assert</b>!(object::id(&item) == item_id, <a href="../sui/kiosk.md#sui_kiosk_EItemMismatch">EItemMismatch</a>);
     dof::add(&<b>mut</b> self.id, <a href="../sui/kiosk.md#sui_kiosk_Item">Item</a> { id: item_id }, item);
 }
 </code></pre>

--- a/crates/sui-framework/docs/sui/kiosk_extension.md
+++ b/crates/sui-framework/docs/sui/kiosk_extension.md
@@ -9,7 +9,7 @@ A Kiosk Extension is a module that implements any functionality on top of
 the <code>Kiosk</code> without discarding nor blocking the base. Given that <code>Kiosk</code>
 itself is a trading primitive, most of the extensions are expected to be
 related to trading. However, there's no limit to what can be built using the
-<code><a href="../sui/kiosk_extension.md#sui_kiosk_extension">kiosk_extension</a></code> module, as it gives certain benefits such as using <code>Kiosk</code>
+<code>kiosk_extension</code> module, as it gives certain benefits such as using <code>Kiosk</code>
 as the storage for any type of data / assets.
 
 
@@ -48,7 +48,7 @@ default trading functionality.
 - Trading functionality can utilize the <code>PurchaseCap</code> to build a custom
 logic around the purchase flow. However, it should be carefully managed to
 prevent asset locking.
-- <code><a href="../sui/kiosk_extension.md#sui_kiosk_extension">kiosk_extension</a></code> is a friend module to <code><a href="../sui/kiosk.md#sui_kiosk">kiosk</a></code> and has access to its
+- <code>kiosk_extension</code> is a friend module to <code>kiosk</code> and has access to its
 internal functions (such as <code>place_internal</code> and <code>lock_internal</code> to
 implement custom authorization scheme for <code><a href="../sui/kiosk_extension.md#sui_kiosk_extension_place">place</a></code> and <code><a href="../sui/kiosk_extension.md#sui_kiosk_extension_lock">lock</a></code> respectively).
 
@@ -285,7 +285,7 @@ permissions in the custom <code><a href="../sui/kiosk_extension.md#sui_kiosk_ext
         self.uid_mut_as_owner(cap),
         <a href="../sui/kiosk_extension.md#sui_kiosk_extension_ExtensionKey">ExtensionKey</a>&lt;Ext&gt; {},
         <a href="../sui/kiosk_extension.md#sui_kiosk_extension_Extension">Extension</a> {
-            <a href="../sui/kiosk_extension.md#sui_kiosk_extension_storage">storage</a>: <a href="../sui/bag.md#sui_bag_new">bag::new</a>(ctx),
+            <a href="../sui/kiosk_extension.md#sui_kiosk_extension_storage">storage</a>: bag::new(ctx),
             permissions,
             <a href="../sui/kiosk_extension.md#sui_kiosk_extension_is_enabled">is_enabled</a>: <b>true</b>,
         },

--- a/crates/sui-framework/docs/sui/linked_table.md
+++ b/crates/sui-framework/docs/sui/linked_table.md
@@ -167,7 +167,7 @@ Creates a new, empty table
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/linked_table.md#sui_linked_table_new">new</a>&lt;K: <b>copy</b> + <a href="../sui/linked_table.md#sui_linked_table_drop">drop</a> + store, V: store&gt;(ctx: &<b>mut</b> TxContext): <a href="../sui/linked_table.md#sui_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt; {
     <a href="../sui/linked_table.md#sui_linked_table_LinkedTable">LinkedTable</a> {
-        id: <a href="../sui/object.md#sui_object_new">object::new</a>(ctx),
+        id: object::new(ctx),
         size: 0,
         head: option::none(),
         tail: option::none(),
@@ -186,7 +186,7 @@ Creates a new, empty table
 Returns the key for the first element in the table, or None if the table is empty
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/linked_table.md#sui_linked_table_front">front</a>&lt;K: <b>copy</b>, <a href="../sui/linked_table.md#sui_linked_table_drop">drop</a>, store, V: store&gt;(<a href="../sui/table.md#sui_table">table</a>: &<a href="../sui/linked_table.md#sui_linked_table_LinkedTable">sui::linked_table::LinkedTable</a>&lt;K, V&gt;): &<a href="../std/option.md#std_option_Option">std::option::Option</a>&lt;K&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/linked_table.md#sui_linked_table_front">front</a>&lt;K: <b>copy</b>, <a href="../sui/linked_table.md#sui_linked_table_drop">drop</a>, store, V: store&gt;(table: &<a href="../sui/linked_table.md#sui_linked_table_LinkedTable">sui::linked_table::LinkedTable</a>&lt;K, V&gt;): &<a href="../std/option.md#std_option_Option">std::option::Option</a>&lt;K&gt;
 </code></pre>
 
 
@@ -195,8 +195,8 @@ Returns the key for the first element in the table, or None if the table is empt
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/linked_table.md#sui_linked_table_front">front</a>&lt;K: <b>copy</b> + <a href="../sui/linked_table.md#sui_linked_table_drop">drop</a> + store, V: store&gt;(<a href="../sui/table.md#sui_table">table</a>: &<a href="../sui/linked_table.md#sui_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;): &Option&lt;K&gt; {
-    &<a href="../sui/table.md#sui_table">table</a>.head
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/linked_table.md#sui_linked_table_front">front</a>&lt;K: <b>copy</b> + <a href="../sui/linked_table.md#sui_linked_table_drop">drop</a> + store, V: store&gt;(table: &<a href="../sui/linked_table.md#sui_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;): &Option&lt;K&gt; {
+    &table.head
 }
 </code></pre>
 
@@ -211,7 +211,7 @@ Returns the key for the first element in the table, or None if the table is empt
 Returns the key for the last element in the table, or None if the table is empty
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/linked_table.md#sui_linked_table_back">back</a>&lt;K: <b>copy</b>, <a href="../sui/linked_table.md#sui_linked_table_drop">drop</a>, store, V: store&gt;(<a href="../sui/table.md#sui_table">table</a>: &<a href="../sui/linked_table.md#sui_linked_table_LinkedTable">sui::linked_table::LinkedTable</a>&lt;K, V&gt;): &<a href="../std/option.md#std_option_Option">std::option::Option</a>&lt;K&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/linked_table.md#sui_linked_table_back">back</a>&lt;K: <b>copy</b>, <a href="../sui/linked_table.md#sui_linked_table_drop">drop</a>, store, V: store&gt;(table: &<a href="../sui/linked_table.md#sui_linked_table_LinkedTable">sui::linked_table::LinkedTable</a>&lt;K, V&gt;): &<a href="../std/option.md#std_option_Option">std::option::Option</a>&lt;K&gt;
 </code></pre>
 
 
@@ -220,8 +220,8 @@ Returns the key for the last element in the table, or None if the table is empty
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/linked_table.md#sui_linked_table_back">back</a>&lt;K: <b>copy</b> + <a href="../sui/linked_table.md#sui_linked_table_drop">drop</a> + store, V: store&gt;(<a href="../sui/table.md#sui_table">table</a>: &<a href="../sui/linked_table.md#sui_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;): &Option&lt;K&gt; {
-    &<a href="../sui/table.md#sui_table">table</a>.tail
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/linked_table.md#sui_linked_table_back">back</a>&lt;K: <b>copy</b> + <a href="../sui/linked_table.md#sui_linked_table_drop">drop</a> + store, V: store&gt;(table: &<a href="../sui/linked_table.md#sui_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;): &Option&lt;K&gt; {
+    &table.tail
 }
 </code></pre>
 
@@ -239,7 +239,7 @@ Aborts with <code><a href="../sui/dynamic_field.md#sui_dynamic_field_EFieldAlrea
 that key <code>k: K</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/linked_table.md#sui_linked_table_push_front">push_front</a>&lt;K: <b>copy</b>, <a href="../sui/linked_table.md#sui_linked_table_drop">drop</a>, store, V: store&gt;(<a href="../sui/table.md#sui_table">table</a>: &<b>mut</b> <a href="../sui/linked_table.md#sui_linked_table_LinkedTable">sui::linked_table::LinkedTable</a>&lt;K, V&gt;, k: K, value: V)
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/linked_table.md#sui_linked_table_push_front">push_front</a>&lt;K: <b>copy</b>, <a href="../sui/linked_table.md#sui_linked_table_drop">drop</a>, store, V: store&gt;(table: &<b>mut</b> <a href="../sui/linked_table.md#sui_linked_table_LinkedTable">sui::linked_table::LinkedTable</a>&lt;K, V&gt;, k: K, value: V)
 </code></pre>
 
 
@@ -249,22 +249,22 @@ that key <code>k: K</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/linked_table.md#sui_linked_table_push_front">push_front</a>&lt;K: <b>copy</b> + <a href="../sui/linked_table.md#sui_linked_table_drop">drop</a> + store, V: store&gt;(
-    <a href="../sui/table.md#sui_table">table</a>: &<b>mut</b> <a href="../sui/linked_table.md#sui_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;,
+    table: &<b>mut</b> <a href="../sui/linked_table.md#sui_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;,
     k: K,
     value: V,
 ) {
-    <b>let</b> old_head = <a href="../sui/table.md#sui_table">table</a>.head.swap_or_fill(k);
-    <b>if</b> (<a href="../sui/table.md#sui_table">table</a>.tail.is_none()) <a href="../sui/table.md#sui_table">table</a>.tail.fill(k);
+    <b>let</b> old_head = table.head.swap_or_fill(k);
+    <b>if</b> (table.tail.is_none()) table.tail.fill(k);
     <b>let</b> <a href="../sui/linked_table.md#sui_linked_table_prev">prev</a> = option::none();
     <b>let</b> <a href="../sui/linked_table.md#sui_linked_table_next">next</a> = <b>if</b> (old_head.is_some()) {
         <b>let</b> old_head_k = old_head.destroy_some();
-        field::borrow_mut&lt;K, <a href="../sui/linked_table.md#sui_linked_table_Node">Node</a>&lt;K, V&gt;&gt;(&<b>mut</b> <a href="../sui/table.md#sui_table">table</a>.id, old_head_k).<a href="../sui/linked_table.md#sui_linked_table_prev">prev</a> = option::some(k);
+        field::borrow_mut&lt;K, <a href="../sui/linked_table.md#sui_linked_table_Node">Node</a>&lt;K, V&gt;&gt;(&<b>mut</b> table.id, old_head_k).<a href="../sui/linked_table.md#sui_linked_table_prev">prev</a> = option::some(k);
         option::some(old_head_k)
     } <b>else</b> {
         option::none()
     };
-    field::add(&<b>mut</b> <a href="../sui/table.md#sui_table">table</a>.id, k, <a href="../sui/linked_table.md#sui_linked_table_Node">Node</a> { <a href="../sui/linked_table.md#sui_linked_table_prev">prev</a>, <a href="../sui/linked_table.md#sui_linked_table_next">next</a>, value });
-    <a href="../sui/table.md#sui_table">table</a>.size = <a href="../sui/table.md#sui_table">table</a>.size + 1;
+    field::add(&<b>mut</b> table.id, k, <a href="../sui/linked_table.md#sui_linked_table_Node">Node</a> { <a href="../sui/linked_table.md#sui_linked_table_prev">prev</a>, <a href="../sui/linked_table.md#sui_linked_table_next">next</a>, value });
+    table.size = table.size + 1;
 }
 </code></pre>
 
@@ -282,7 +282,7 @@ Aborts with <code><a href="../sui/dynamic_field.md#sui_dynamic_field_EFieldAlrea
 that key <code>k: K</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/linked_table.md#sui_linked_table_push_back">push_back</a>&lt;K: <b>copy</b>, <a href="../sui/linked_table.md#sui_linked_table_drop">drop</a>, store, V: store&gt;(<a href="../sui/table.md#sui_table">table</a>: &<b>mut</b> <a href="../sui/linked_table.md#sui_linked_table_LinkedTable">sui::linked_table::LinkedTable</a>&lt;K, V&gt;, k: K, value: V)
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/linked_table.md#sui_linked_table_push_back">push_back</a>&lt;K: <b>copy</b>, <a href="../sui/linked_table.md#sui_linked_table_drop">drop</a>, store, V: store&gt;(table: &<b>mut</b> <a href="../sui/linked_table.md#sui_linked_table_LinkedTable">sui::linked_table::LinkedTable</a>&lt;K, V&gt;, k: K, value: V)
 </code></pre>
 
 
@@ -292,22 +292,22 @@ that key <code>k: K</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/linked_table.md#sui_linked_table_push_back">push_back</a>&lt;K: <b>copy</b> + <a href="../sui/linked_table.md#sui_linked_table_drop">drop</a> + store, V: store&gt;(
-    <a href="../sui/table.md#sui_table">table</a>: &<b>mut</b> <a href="../sui/linked_table.md#sui_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;,
+    table: &<b>mut</b> <a href="../sui/linked_table.md#sui_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;,
     k: K,
     value: V,
 ) {
-    <b>if</b> (<a href="../sui/table.md#sui_table">table</a>.head.is_none()) <a href="../sui/table.md#sui_table">table</a>.head.fill(k);
-    <b>let</b> old_tail = <a href="../sui/table.md#sui_table">table</a>.tail.swap_or_fill(k);
+    <b>if</b> (table.head.is_none()) table.head.fill(k);
+    <b>let</b> old_tail = table.tail.swap_or_fill(k);
     <b>let</b> <a href="../sui/linked_table.md#sui_linked_table_prev">prev</a> = <b>if</b> (old_tail.is_some()) {
         <b>let</b> old_tail_k = old_tail.destroy_some();
-        field::borrow_mut&lt;K, <a href="../sui/linked_table.md#sui_linked_table_Node">Node</a>&lt;K, V&gt;&gt;(&<b>mut</b> <a href="../sui/table.md#sui_table">table</a>.id, old_tail_k).<a href="../sui/linked_table.md#sui_linked_table_next">next</a> = option::some(k);
+        field::borrow_mut&lt;K, <a href="../sui/linked_table.md#sui_linked_table_Node">Node</a>&lt;K, V&gt;&gt;(&<b>mut</b> table.id, old_tail_k).<a href="../sui/linked_table.md#sui_linked_table_next">next</a> = option::some(k);
         option::some(old_tail_k)
     } <b>else</b> {
         option::none()
     };
     <b>let</b> <a href="../sui/linked_table.md#sui_linked_table_next">next</a> = option::none();
-    field::add(&<b>mut</b> <a href="../sui/table.md#sui_table">table</a>.id, k, <a href="../sui/linked_table.md#sui_linked_table_Node">Node</a> { <a href="../sui/linked_table.md#sui_linked_table_prev">prev</a>, <a href="../sui/linked_table.md#sui_linked_table_next">next</a>, value });
-    <a href="../sui/table.md#sui_table">table</a>.size = <a href="../sui/table.md#sui_table">table</a>.size + 1;
+    field::add(&<b>mut</b> table.id, k, <a href="../sui/linked_table.md#sui_linked_table_Node">Node</a> { <a href="../sui/linked_table.md#sui_linked_table_prev">prev</a>, <a href="../sui/linked_table.md#sui_linked_table_next">next</a>, value });
+    table.size = table.size + 1;
 }
 </code></pre>
 
@@ -319,12 +319,12 @@ that key <code>k: K</code>.
 
 ## Function `borrow`
 
-Immutable borrows the value associated with the key in the table <code><a href="../sui/table.md#sui_table">table</a>: &<a href="../sui/linked_table.md#sui_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;</code>.
+Immutable borrows the value associated with the key in the table <code>table: &<a href="../sui/linked_table.md#sui_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;</code>.
 Aborts with <code><a href="../sui/dynamic_field.md#sui_dynamic_field_EFieldDoesNotExist">sui::dynamic_field::EFieldDoesNotExist</a></code> if the table does not have an entry with
 that key <code>k: K</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/borrow.md#sui_borrow">borrow</a>&lt;K: <b>copy</b>, <a href="../sui/linked_table.md#sui_linked_table_drop">drop</a>, store, V: store&gt;(<a href="../sui/table.md#sui_table">table</a>: &<a href="../sui/linked_table.md#sui_linked_table_LinkedTable">sui::linked_table::LinkedTable</a>&lt;K, V&gt;, k: K): &V
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/linked_table.md#sui_linked_table_borrow">borrow</a>&lt;K: <b>copy</b>, <a href="../sui/linked_table.md#sui_linked_table_drop">drop</a>, store, V: store&gt;(table: &<a href="../sui/linked_table.md#sui_linked_table_LinkedTable">sui::linked_table::LinkedTable</a>&lt;K, V&gt;, k: K): &V
 </code></pre>
 
 
@@ -333,8 +333,8 @@ that key <code>k: K</code>.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/borrow.md#sui_borrow">borrow</a>&lt;K: <b>copy</b> + <a href="../sui/linked_table.md#sui_linked_table_drop">drop</a> + store, V: store&gt;(<a href="../sui/table.md#sui_table">table</a>: &<a href="../sui/linked_table.md#sui_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;, k: K): &V {
-    &field::borrow&lt;K, <a href="../sui/linked_table.md#sui_linked_table_Node">Node</a>&lt;K, V&gt;&gt;(&<a href="../sui/table.md#sui_table">table</a>.id, k).value
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/linked_table.md#sui_linked_table_borrow">borrow</a>&lt;K: <b>copy</b> + <a href="../sui/linked_table.md#sui_linked_table_drop">drop</a> + store, V: store&gt;(table: &<a href="../sui/linked_table.md#sui_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;, k: K): &V {
+    &field::borrow&lt;K, <a href="../sui/linked_table.md#sui_linked_table_Node">Node</a>&lt;K, V&gt;&gt;(&table.id, k).value
 }
 </code></pre>
 
@@ -346,12 +346,12 @@ that key <code>k: K</code>.
 
 ## Function `borrow_mut`
 
-Mutably borrows the value associated with the key in the table <code><a href="../sui/table.md#sui_table">table</a>: &<b>mut</b> <a href="../sui/linked_table.md#sui_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;</code>.
+Mutably borrows the value associated with the key in the table <code>table: &<b>mut</b> <a href="../sui/linked_table.md#sui_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;</code>.
 Aborts with <code><a href="../sui/dynamic_field.md#sui_dynamic_field_EFieldDoesNotExist">sui::dynamic_field::EFieldDoesNotExist</a></code> if the table does not have an entry with
 that key <code>k: K</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/linked_table.md#sui_linked_table_borrow_mut">borrow_mut</a>&lt;K: <b>copy</b>, <a href="../sui/linked_table.md#sui_linked_table_drop">drop</a>, store, V: store&gt;(<a href="../sui/table.md#sui_table">table</a>: &<b>mut</b> <a href="../sui/linked_table.md#sui_linked_table_LinkedTable">sui::linked_table::LinkedTable</a>&lt;K, V&gt;, k: K): &<b>mut</b> V
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/linked_table.md#sui_linked_table_borrow_mut">borrow_mut</a>&lt;K: <b>copy</b>, <a href="../sui/linked_table.md#sui_linked_table_drop">drop</a>, store, V: store&gt;(table: &<b>mut</b> <a href="../sui/linked_table.md#sui_linked_table_LinkedTable">sui::linked_table::LinkedTable</a>&lt;K, V&gt;, k: K): &<b>mut</b> V
 </code></pre>
 
 
@@ -361,10 +361,10 @@ that key <code>k: K</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/linked_table.md#sui_linked_table_borrow_mut">borrow_mut</a>&lt;K: <b>copy</b> + <a href="../sui/linked_table.md#sui_linked_table_drop">drop</a> + store, V: store&gt;(
-    <a href="../sui/table.md#sui_table">table</a>: &<b>mut</b> <a href="../sui/linked_table.md#sui_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;,
+    table: &<b>mut</b> <a href="../sui/linked_table.md#sui_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;,
     k: K,
 ): &<b>mut</b> V {
-    &<b>mut</b> field::borrow_mut&lt;K, <a href="../sui/linked_table.md#sui_linked_table_Node">Node</a>&lt;K, V&gt;&gt;(&<b>mut</b> <a href="../sui/table.md#sui_table">table</a>.id, k).value
+    &<b>mut</b> field::borrow_mut&lt;K, <a href="../sui/linked_table.md#sui_linked_table_Node">Node</a>&lt;K, V&gt;&gt;(&<b>mut</b> table.id, k).value
 }
 </code></pre>
 
@@ -377,12 +377,12 @@ that key <code>k: K</code>.
 ## Function `prev`
 
 Borrows the key for the previous entry of the specified key <code>k: K</code> in the table
-<code><a href="../sui/table.md#sui_table">table</a>: &<a href="../sui/linked_table.md#sui_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;</code>. Returns None if the entry does not have a predecessor.
+<code>table: &<a href="../sui/linked_table.md#sui_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;</code>. Returns None if the entry does not have a predecessor.
 Aborts with <code><a href="../sui/dynamic_field.md#sui_dynamic_field_EFieldDoesNotExist">sui::dynamic_field::EFieldDoesNotExist</a></code> if the table does not have an entry with
 that key <code>k: K</code>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/linked_table.md#sui_linked_table_prev">prev</a>&lt;K: <b>copy</b>, <a href="../sui/linked_table.md#sui_linked_table_drop">drop</a>, store, V: store&gt;(<a href="../sui/table.md#sui_table">table</a>: &<a href="../sui/linked_table.md#sui_linked_table_LinkedTable">sui::linked_table::LinkedTable</a>&lt;K, V&gt;, k: K): &<a href="../std/option.md#std_option_Option">std::option::Option</a>&lt;K&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/linked_table.md#sui_linked_table_prev">prev</a>&lt;K: <b>copy</b>, <a href="../sui/linked_table.md#sui_linked_table_drop">drop</a>, store, V: store&gt;(table: &<a href="../sui/linked_table.md#sui_linked_table_LinkedTable">sui::linked_table::LinkedTable</a>&lt;K, V&gt;, k: K): &<a href="../std/option.md#std_option_Option">std::option::Option</a>&lt;K&gt;
 </code></pre>
 
 
@@ -391,8 +391,8 @@ that key <code>k: K</code>
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/linked_table.md#sui_linked_table_prev">prev</a>&lt;K: <b>copy</b> + <a href="../sui/linked_table.md#sui_linked_table_drop">drop</a> + store, V: store&gt;(<a href="../sui/table.md#sui_table">table</a>: &<a href="../sui/linked_table.md#sui_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;, k: K): &Option&lt;K&gt; {
-    &field::borrow&lt;K, <a href="../sui/linked_table.md#sui_linked_table_Node">Node</a>&lt;K, V&gt;&gt;(&<a href="../sui/table.md#sui_table">table</a>.id, k).<a href="../sui/linked_table.md#sui_linked_table_prev">prev</a>
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/linked_table.md#sui_linked_table_prev">prev</a>&lt;K: <b>copy</b> + <a href="../sui/linked_table.md#sui_linked_table_drop">drop</a> + store, V: store&gt;(table: &<a href="../sui/linked_table.md#sui_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;, k: K): &Option&lt;K&gt; {
+    &field::borrow&lt;K, <a href="../sui/linked_table.md#sui_linked_table_Node">Node</a>&lt;K, V&gt;&gt;(&table.id, k).<a href="../sui/linked_table.md#sui_linked_table_prev">prev</a>
 }
 </code></pre>
 
@@ -405,12 +405,12 @@ that key <code>k: K</code>
 ## Function `next`
 
 Borrows the key for the next entry of the specified key <code>k: K</code> in the table
-<code><a href="../sui/table.md#sui_table">table</a>: &<a href="../sui/linked_table.md#sui_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;</code>. Returns None if the entry does not have a successor.
+<code>table: &<a href="../sui/linked_table.md#sui_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;</code>. Returns None if the entry does not have a successor.
 Aborts with <code><a href="../sui/dynamic_field.md#sui_dynamic_field_EFieldDoesNotExist">sui::dynamic_field::EFieldDoesNotExist</a></code> if the table does not have an entry with
 that key <code>k: K</code>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/linked_table.md#sui_linked_table_next">next</a>&lt;K: <b>copy</b>, <a href="../sui/linked_table.md#sui_linked_table_drop">drop</a>, store, V: store&gt;(<a href="../sui/table.md#sui_table">table</a>: &<a href="../sui/linked_table.md#sui_linked_table_LinkedTable">sui::linked_table::LinkedTable</a>&lt;K, V&gt;, k: K): &<a href="../std/option.md#std_option_Option">std::option::Option</a>&lt;K&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/linked_table.md#sui_linked_table_next">next</a>&lt;K: <b>copy</b>, <a href="../sui/linked_table.md#sui_linked_table_drop">drop</a>, store, V: store&gt;(table: &<a href="../sui/linked_table.md#sui_linked_table_LinkedTable">sui::linked_table::LinkedTable</a>&lt;K, V&gt;, k: K): &<a href="../std/option.md#std_option_Option">std::option::Option</a>&lt;K&gt;
 </code></pre>
 
 
@@ -419,8 +419,8 @@ that key <code>k: K</code>
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/linked_table.md#sui_linked_table_next">next</a>&lt;K: <b>copy</b> + <a href="../sui/linked_table.md#sui_linked_table_drop">drop</a> + store, V: store&gt;(<a href="../sui/table.md#sui_table">table</a>: &<a href="../sui/linked_table.md#sui_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;, k: K): &Option&lt;K&gt; {
-    &field::borrow&lt;K, <a href="../sui/linked_table.md#sui_linked_table_Node">Node</a>&lt;K, V&gt;&gt;(&<a href="../sui/table.md#sui_table">table</a>.id, k).<a href="../sui/linked_table.md#sui_linked_table_next">next</a>
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/linked_table.md#sui_linked_table_next">next</a>&lt;K: <b>copy</b> + <a href="../sui/linked_table.md#sui_linked_table_drop">drop</a> + store, V: store&gt;(table: &<a href="../sui/linked_table.md#sui_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;, k: K): &Option&lt;K&gt; {
+    &field::borrow&lt;K, <a href="../sui/linked_table.md#sui_linked_table_Node">Node</a>&lt;K, V&gt;&gt;(&table.id, k).<a href="../sui/linked_table.md#sui_linked_table_next">next</a>
 }
 </code></pre>
 
@@ -432,13 +432,13 @@ that key <code>k: K</code>
 
 ## Function `remove`
 
-Removes the key-value pair in the table <code><a href="../sui/table.md#sui_table">table</a>: &<b>mut</b> <a href="../sui/linked_table.md#sui_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;</code> and returns the value.
+Removes the key-value pair in the table <code>table: &<b>mut</b> <a href="../sui/linked_table.md#sui_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;</code> and returns the value.
 This splices the element out of the ordering.
 Aborts with <code><a href="../sui/dynamic_field.md#sui_dynamic_field_EFieldDoesNotExist">sui::dynamic_field::EFieldDoesNotExist</a></code> if the table does not have an entry with
 that key <code>k: K</code>. Note: this is also what happens when the table is empty.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/linked_table.md#sui_linked_table_remove">remove</a>&lt;K: <b>copy</b>, <a href="../sui/linked_table.md#sui_linked_table_drop">drop</a>, store, V: store&gt;(<a href="../sui/table.md#sui_table">table</a>: &<b>mut</b> <a href="../sui/linked_table.md#sui_linked_table_LinkedTable">sui::linked_table::LinkedTable</a>&lt;K, V&gt;, k: K): V
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/linked_table.md#sui_linked_table_remove">remove</a>&lt;K: <b>copy</b>, <a href="../sui/linked_table.md#sui_linked_table_drop">drop</a>, store, V: store&gt;(table: &<b>mut</b> <a href="../sui/linked_table.md#sui_linked_table_LinkedTable">sui::linked_table::LinkedTable</a>&lt;K, V&gt;, k: K): V
 </code></pre>
 
 
@@ -447,17 +447,17 @@ that key <code>k: K</code>. Note: this is also what happens when the table is em
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/linked_table.md#sui_linked_table_remove">remove</a>&lt;K: <b>copy</b> + <a href="../sui/linked_table.md#sui_linked_table_drop">drop</a> + store, V: store&gt;(<a href="../sui/table.md#sui_table">table</a>: &<b>mut</b> <a href="../sui/linked_table.md#sui_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;, k: K): V {
-    <b>let</b> <a href="../sui/linked_table.md#sui_linked_table_Node">Node</a>&lt;K, V&gt; { <a href="../sui/linked_table.md#sui_linked_table_prev">prev</a>, <a href="../sui/linked_table.md#sui_linked_table_next">next</a>, value } = field::remove(&<b>mut</b> <a href="../sui/table.md#sui_table">table</a>.id, k);
-    <a href="../sui/table.md#sui_table">table</a>.size = <a href="../sui/table.md#sui_table">table</a>.size - 1;
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/linked_table.md#sui_linked_table_remove">remove</a>&lt;K: <b>copy</b> + <a href="../sui/linked_table.md#sui_linked_table_drop">drop</a> + store, V: store&gt;(table: &<b>mut</b> <a href="../sui/linked_table.md#sui_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;, k: K): V {
+    <b>let</b> <a href="../sui/linked_table.md#sui_linked_table_Node">Node</a>&lt;K, V&gt; { <a href="../sui/linked_table.md#sui_linked_table_prev">prev</a>, <a href="../sui/linked_table.md#sui_linked_table_next">next</a>, value } = field::remove(&<b>mut</b> table.id, k);
+    table.size = table.size - 1;
     <b>if</b> (<a href="../sui/linked_table.md#sui_linked_table_prev">prev</a>.is_some()) {
-        field::borrow_mut&lt;K, <a href="../sui/linked_table.md#sui_linked_table_Node">Node</a>&lt;K, V&gt;&gt;(&<b>mut</b> <a href="../sui/table.md#sui_table">table</a>.id, *<a href="../sui/linked_table.md#sui_linked_table_prev">prev</a>.<a href="../sui/borrow.md#sui_borrow">borrow</a>()).<a href="../sui/linked_table.md#sui_linked_table_next">next</a> = <a href="../sui/linked_table.md#sui_linked_table_next">next</a>
+        field::borrow_mut&lt;K, <a href="../sui/linked_table.md#sui_linked_table_Node">Node</a>&lt;K, V&gt;&gt;(&<b>mut</b> table.id, *<a href="../sui/linked_table.md#sui_linked_table_prev">prev</a>.<a href="../sui/linked_table.md#sui_linked_table_borrow">borrow</a>()).<a href="../sui/linked_table.md#sui_linked_table_next">next</a> = <a href="../sui/linked_table.md#sui_linked_table_next">next</a>
     };
     <b>if</b> (<a href="../sui/linked_table.md#sui_linked_table_next">next</a>.is_some()) {
-        field::borrow_mut&lt;K, <a href="../sui/linked_table.md#sui_linked_table_Node">Node</a>&lt;K, V&gt;&gt;(&<b>mut</b> <a href="../sui/table.md#sui_table">table</a>.id, *<a href="../sui/linked_table.md#sui_linked_table_next">next</a>.<a href="../sui/borrow.md#sui_borrow">borrow</a>()).<a href="../sui/linked_table.md#sui_linked_table_prev">prev</a> = <a href="../sui/linked_table.md#sui_linked_table_prev">prev</a>
+        field::borrow_mut&lt;K, <a href="../sui/linked_table.md#sui_linked_table_Node">Node</a>&lt;K, V&gt;&gt;(&<b>mut</b> table.id, *<a href="../sui/linked_table.md#sui_linked_table_next">next</a>.<a href="../sui/linked_table.md#sui_linked_table_borrow">borrow</a>()).<a href="../sui/linked_table.md#sui_linked_table_prev">prev</a> = <a href="../sui/linked_table.md#sui_linked_table_prev">prev</a>
     };
-    <b>if</b> (<a href="../sui/table.md#sui_table">table</a>.head.<a href="../sui/borrow.md#sui_borrow">borrow</a>() == &k) <a href="../sui/table.md#sui_table">table</a>.head = <a href="../sui/linked_table.md#sui_linked_table_next">next</a>;
-    <b>if</b> (<a href="../sui/table.md#sui_table">table</a>.tail.<a href="../sui/borrow.md#sui_borrow">borrow</a>() == &k) <a href="../sui/table.md#sui_table">table</a>.tail = <a href="../sui/linked_table.md#sui_linked_table_prev">prev</a>;
+    <b>if</b> (table.head.<a href="../sui/linked_table.md#sui_linked_table_borrow">borrow</a>() == &k) table.head = <a href="../sui/linked_table.md#sui_linked_table_next">next</a>;
+    <b>if</b> (table.tail.<a href="../sui/linked_table.md#sui_linked_table_borrow">borrow</a>() == &k) table.tail = <a href="../sui/linked_table.md#sui_linked_table_prev">prev</a>;
     value
 }
 </code></pre>
@@ -470,11 +470,11 @@ that key <code>k: K</code>. Note: this is also what happens when the table is em
 
 ## Function `pop_front`
 
-Removes the front of the table <code><a href="../sui/table.md#sui_table">table</a>: &<b>mut</b> <a href="../sui/linked_table.md#sui_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;</code>, returns the key and value.
+Removes the front of the table <code>table: &<b>mut</b> <a href="../sui/linked_table.md#sui_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;</code>, returns the key and value.
 Aborts with <code><a href="../sui/linked_table.md#sui_linked_table_ETableIsEmpty">ETableIsEmpty</a></code> if the table is empty
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/linked_table.md#sui_linked_table_pop_front">pop_front</a>&lt;K: <b>copy</b>, <a href="../sui/linked_table.md#sui_linked_table_drop">drop</a>, store, V: store&gt;(<a href="../sui/table.md#sui_table">table</a>: &<b>mut</b> <a href="../sui/linked_table.md#sui_linked_table_LinkedTable">sui::linked_table::LinkedTable</a>&lt;K, V&gt;): (K, V)
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/linked_table.md#sui_linked_table_pop_front">pop_front</a>&lt;K: <b>copy</b>, <a href="../sui/linked_table.md#sui_linked_table_drop">drop</a>, store, V: store&gt;(table: &<b>mut</b> <a href="../sui/linked_table.md#sui_linked_table_LinkedTable">sui::linked_table::LinkedTable</a>&lt;K, V&gt;): (K, V)
 </code></pre>
 
 
@@ -483,10 +483,10 @@ Aborts with <code><a href="../sui/linked_table.md#sui_linked_table_ETableIsEmpty
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/linked_table.md#sui_linked_table_pop_front">pop_front</a>&lt;K: <b>copy</b> + <a href="../sui/linked_table.md#sui_linked_table_drop">drop</a> + store, V: store&gt;(<a href="../sui/table.md#sui_table">table</a>: &<b>mut</b> <a href="../sui/linked_table.md#sui_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;): (K, V) {
-    <b>assert</b>!(<a href="../sui/table.md#sui_table">table</a>.head.is_some(), <a href="../sui/linked_table.md#sui_linked_table_ETableIsEmpty">ETableIsEmpty</a>);
-    <b>let</b> head = *<a href="../sui/table.md#sui_table">table</a>.head.<a href="../sui/borrow.md#sui_borrow">borrow</a>();
-    (head, <a href="../sui/table.md#sui_table">table</a>.<a href="../sui/linked_table.md#sui_linked_table_remove">remove</a>(head))
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/linked_table.md#sui_linked_table_pop_front">pop_front</a>&lt;K: <b>copy</b> + <a href="../sui/linked_table.md#sui_linked_table_drop">drop</a> + store, V: store&gt;(table: &<b>mut</b> <a href="../sui/linked_table.md#sui_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;): (K, V) {
+    <b>assert</b>!(table.head.is_some(), <a href="../sui/linked_table.md#sui_linked_table_ETableIsEmpty">ETableIsEmpty</a>);
+    <b>let</b> head = *table.head.<a href="../sui/linked_table.md#sui_linked_table_borrow">borrow</a>();
+    (head, table.<a href="../sui/linked_table.md#sui_linked_table_remove">remove</a>(head))
 }
 </code></pre>
 
@@ -498,11 +498,11 @@ Aborts with <code><a href="../sui/linked_table.md#sui_linked_table_ETableIsEmpty
 
 ## Function `pop_back`
 
-Removes the back of the table <code><a href="../sui/table.md#sui_table">table</a>: &<b>mut</b> <a href="../sui/linked_table.md#sui_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;</code>, returns the key and value.
+Removes the back of the table <code>table: &<b>mut</b> <a href="../sui/linked_table.md#sui_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;</code>, returns the key and value.
 Aborts with <code><a href="../sui/linked_table.md#sui_linked_table_ETableIsEmpty">ETableIsEmpty</a></code> if the table is empty
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/linked_table.md#sui_linked_table_pop_back">pop_back</a>&lt;K: <b>copy</b>, <a href="../sui/linked_table.md#sui_linked_table_drop">drop</a>, store, V: store&gt;(<a href="../sui/table.md#sui_table">table</a>: &<b>mut</b> <a href="../sui/linked_table.md#sui_linked_table_LinkedTable">sui::linked_table::LinkedTable</a>&lt;K, V&gt;): (K, V)
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/linked_table.md#sui_linked_table_pop_back">pop_back</a>&lt;K: <b>copy</b>, <a href="../sui/linked_table.md#sui_linked_table_drop">drop</a>, store, V: store&gt;(table: &<b>mut</b> <a href="../sui/linked_table.md#sui_linked_table_LinkedTable">sui::linked_table::LinkedTable</a>&lt;K, V&gt;): (K, V)
 </code></pre>
 
 
@@ -511,10 +511,10 @@ Aborts with <code><a href="../sui/linked_table.md#sui_linked_table_ETableIsEmpty
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/linked_table.md#sui_linked_table_pop_back">pop_back</a>&lt;K: <b>copy</b> + <a href="../sui/linked_table.md#sui_linked_table_drop">drop</a> + store, V: store&gt;(<a href="../sui/table.md#sui_table">table</a>: &<b>mut</b> <a href="../sui/linked_table.md#sui_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;): (K, V) {
-    <b>assert</b>!(<a href="../sui/table.md#sui_table">table</a>.tail.is_some(), <a href="../sui/linked_table.md#sui_linked_table_ETableIsEmpty">ETableIsEmpty</a>);
-    <b>let</b> tail = *<a href="../sui/table.md#sui_table">table</a>.tail.<a href="../sui/borrow.md#sui_borrow">borrow</a>();
-    (tail, <a href="../sui/table.md#sui_table">table</a>.<a href="../sui/linked_table.md#sui_linked_table_remove">remove</a>(tail))
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/linked_table.md#sui_linked_table_pop_back">pop_back</a>&lt;K: <b>copy</b> + <a href="../sui/linked_table.md#sui_linked_table_drop">drop</a> + store, V: store&gt;(table: &<b>mut</b> <a href="../sui/linked_table.md#sui_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;): (K, V) {
+    <b>assert</b>!(table.tail.is_some(), <a href="../sui/linked_table.md#sui_linked_table_ETableIsEmpty">ETableIsEmpty</a>);
+    <b>let</b> tail = *table.tail.<a href="../sui/linked_table.md#sui_linked_table_borrow">borrow</a>();
+    (tail, table.<a href="../sui/linked_table.md#sui_linked_table_remove">remove</a>(tail))
 }
 </code></pre>
 
@@ -527,10 +527,10 @@ Aborts with <code><a href="../sui/linked_table.md#sui_linked_table_ETableIsEmpty
 ## Function `contains`
 
 Returns true iff there is a value associated with the key <code>k: K</code> in table
-<code><a href="../sui/table.md#sui_table">table</a>: &<a href="../sui/linked_table.md#sui_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;</code>
+<code>table: &<a href="../sui/linked_table.md#sui_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;</code>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/linked_table.md#sui_linked_table_contains">contains</a>&lt;K: <b>copy</b>, <a href="../sui/linked_table.md#sui_linked_table_drop">drop</a>, store, V: store&gt;(<a href="../sui/table.md#sui_table">table</a>: &<a href="../sui/linked_table.md#sui_linked_table_LinkedTable">sui::linked_table::LinkedTable</a>&lt;K, V&gt;, k: K): bool
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/linked_table.md#sui_linked_table_contains">contains</a>&lt;K: <b>copy</b>, <a href="../sui/linked_table.md#sui_linked_table_drop">drop</a>, store, V: store&gt;(table: &<a href="../sui/linked_table.md#sui_linked_table_LinkedTable">sui::linked_table::LinkedTable</a>&lt;K, V&gt;, k: K): bool
 </code></pre>
 
 
@@ -539,8 +539,8 @@ Returns true iff there is a value associated with the key <code>k: K</code> in t
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/linked_table.md#sui_linked_table_contains">contains</a>&lt;K: <b>copy</b> + <a href="../sui/linked_table.md#sui_linked_table_drop">drop</a> + store, V: store&gt;(<a href="../sui/table.md#sui_table">table</a>: &<a href="../sui/linked_table.md#sui_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;, k: K): bool {
-    field::exists_with_type&lt;K, <a href="../sui/linked_table.md#sui_linked_table_Node">Node</a>&lt;K, V&gt;&gt;(&<a href="../sui/table.md#sui_table">table</a>.id, k)
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/linked_table.md#sui_linked_table_contains">contains</a>&lt;K: <b>copy</b> + <a href="../sui/linked_table.md#sui_linked_table_drop">drop</a> + store, V: store&gt;(table: &<a href="../sui/linked_table.md#sui_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;, k: K): bool {
+    field::exists_with_type&lt;K, <a href="../sui/linked_table.md#sui_linked_table_Node">Node</a>&lt;K, V&gt;&gt;(&table.id, k)
 }
 </code></pre>
 
@@ -555,7 +555,7 @@ Returns true iff there is a value associated with the key <code>k: K</code> in t
 Returns the size of the table, the number of key-value pairs
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/linked_table.md#sui_linked_table_length">length</a>&lt;K: <b>copy</b>, <a href="../sui/linked_table.md#sui_linked_table_drop">drop</a>, store, V: store&gt;(<a href="../sui/table.md#sui_table">table</a>: &<a href="../sui/linked_table.md#sui_linked_table_LinkedTable">sui::linked_table::LinkedTable</a>&lt;K, V&gt;): u64
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/linked_table.md#sui_linked_table_length">length</a>&lt;K: <b>copy</b>, <a href="../sui/linked_table.md#sui_linked_table_drop">drop</a>, store, V: store&gt;(table: &<a href="../sui/linked_table.md#sui_linked_table_LinkedTable">sui::linked_table::LinkedTable</a>&lt;K, V&gt;): u64
 </code></pre>
 
 
@@ -564,8 +564,8 @@ Returns the size of the table, the number of key-value pairs
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/linked_table.md#sui_linked_table_length">length</a>&lt;K: <b>copy</b> + <a href="../sui/linked_table.md#sui_linked_table_drop">drop</a> + store, V: store&gt;(<a href="../sui/table.md#sui_table">table</a>: &<a href="../sui/linked_table.md#sui_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;): u64 {
-    <a href="../sui/table.md#sui_table">table</a>.size
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/linked_table.md#sui_linked_table_length">length</a>&lt;K: <b>copy</b> + <a href="../sui/linked_table.md#sui_linked_table_drop">drop</a> + store, V: store&gt;(table: &<a href="../sui/linked_table.md#sui_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;): u64 {
+    table.size
 }
 </code></pre>
 
@@ -580,7 +580,7 @@ Returns the size of the table, the number of key-value pairs
 Returns true iff the table is empty (if <code><a href="../sui/linked_table.md#sui_linked_table_length">length</a></code> returns <code>0</code>)
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/linked_table.md#sui_linked_table_is_empty">is_empty</a>&lt;K: <b>copy</b>, <a href="../sui/linked_table.md#sui_linked_table_drop">drop</a>, store, V: store&gt;(<a href="../sui/table.md#sui_table">table</a>: &<a href="../sui/linked_table.md#sui_linked_table_LinkedTable">sui::linked_table::LinkedTable</a>&lt;K, V&gt;): bool
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/linked_table.md#sui_linked_table_is_empty">is_empty</a>&lt;K: <b>copy</b>, <a href="../sui/linked_table.md#sui_linked_table_drop">drop</a>, store, V: store&gt;(table: &<a href="../sui/linked_table.md#sui_linked_table_LinkedTable">sui::linked_table::LinkedTable</a>&lt;K, V&gt;): bool
 </code></pre>
 
 
@@ -589,8 +589,8 @@ Returns true iff the table is empty (if <code><a href="../sui/linked_table.md#su
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/linked_table.md#sui_linked_table_is_empty">is_empty</a>&lt;K: <b>copy</b> + <a href="../sui/linked_table.md#sui_linked_table_drop">drop</a> + store, V: store&gt;(<a href="../sui/table.md#sui_table">table</a>: &<a href="../sui/linked_table.md#sui_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;): bool {
-    <a href="../sui/table.md#sui_table">table</a>.size == 0
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/linked_table.md#sui_linked_table_is_empty">is_empty</a>&lt;K: <b>copy</b> + <a href="../sui/linked_table.md#sui_linked_table_drop">drop</a> + store, V: store&gt;(table: &<a href="../sui/linked_table.md#sui_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;): bool {
+    table.size == 0
 }
 </code></pre>
 
@@ -606,7 +606,7 @@ Destroys an empty table
 Aborts with <code><a href="../sui/linked_table.md#sui_linked_table_ETableNotEmpty">ETableNotEmpty</a></code> if the table still contains values
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/linked_table.md#sui_linked_table_destroy_empty">destroy_empty</a>&lt;K: <b>copy</b>, <a href="../sui/linked_table.md#sui_linked_table_drop">drop</a>, store, V: store&gt;(<a href="../sui/table.md#sui_table">table</a>: <a href="../sui/linked_table.md#sui_linked_table_LinkedTable">sui::linked_table::LinkedTable</a>&lt;K, V&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/linked_table.md#sui_linked_table_destroy_empty">destroy_empty</a>&lt;K: <b>copy</b>, <a href="../sui/linked_table.md#sui_linked_table_drop">drop</a>, store, V: store&gt;(table: <a href="../sui/linked_table.md#sui_linked_table_LinkedTable">sui::linked_table::LinkedTable</a>&lt;K, V&gt;)
 </code></pre>
 
 
@@ -615,8 +615,8 @@ Aborts with <code><a href="../sui/linked_table.md#sui_linked_table_ETableNotEmpt
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/linked_table.md#sui_linked_table_destroy_empty">destroy_empty</a>&lt;K: <b>copy</b> + <a href="../sui/linked_table.md#sui_linked_table_drop">drop</a> + store, V: store&gt;(<a href="../sui/table.md#sui_table">table</a>: <a href="../sui/linked_table.md#sui_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;) {
-    <b>let</b> <a href="../sui/linked_table.md#sui_linked_table_LinkedTable">LinkedTable</a> { id, size, head: _, tail: _ } = <a href="../sui/table.md#sui_table">table</a>;
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/linked_table.md#sui_linked_table_destroy_empty">destroy_empty</a>&lt;K: <b>copy</b> + <a href="../sui/linked_table.md#sui_linked_table_drop">drop</a> + store, V: store&gt;(table: <a href="../sui/linked_table.md#sui_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;) {
+    <b>let</b> <a href="../sui/linked_table.md#sui_linked_table_LinkedTable">LinkedTable</a> { id, size, head: _, tail: _ } = table;
     <b>assert</b>!(size == 0, <a href="../sui/linked_table.md#sui_linked_table_ETableNotEmpty">ETableNotEmpty</a>);
     id.delete()
 }
@@ -634,7 +634,7 @@ Drop a possibly non-empty table.
 Usable only if the value type <code>V</code> has the <code><a href="../sui/linked_table.md#sui_linked_table_drop">drop</a></code> ability
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/linked_table.md#sui_linked_table_drop">drop</a>&lt;K: <b>copy</b>, <a href="../sui/linked_table.md#sui_linked_table_drop">drop</a>, store, V: <a href="../sui/linked_table.md#sui_linked_table_drop">drop</a>, store&gt;(<a href="../sui/table.md#sui_table">table</a>: <a href="../sui/linked_table.md#sui_linked_table_LinkedTable">sui::linked_table::LinkedTable</a>&lt;K, V&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/linked_table.md#sui_linked_table_drop">drop</a>&lt;K: <b>copy</b>, <a href="../sui/linked_table.md#sui_linked_table_drop">drop</a>, store, V: <a href="../sui/linked_table.md#sui_linked_table_drop">drop</a>, store&gt;(table: <a href="../sui/linked_table.md#sui_linked_table_LinkedTable">sui::linked_table::LinkedTable</a>&lt;K, V&gt;)
 </code></pre>
 
 
@@ -643,8 +643,8 @@ Usable only if the value type <code>V</code> has the <code><a href="../sui/linke
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/linked_table.md#sui_linked_table_drop">drop</a>&lt;K: <b>copy</b> + <a href="../sui/linked_table.md#sui_linked_table_drop">drop</a> + store, V: <a href="../sui/linked_table.md#sui_linked_table_drop">drop</a> + store&gt;(<a href="../sui/table.md#sui_table">table</a>: <a href="../sui/linked_table.md#sui_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;) {
-    <b>let</b> <a href="../sui/linked_table.md#sui_linked_table_LinkedTable">LinkedTable</a> { id, size: _, head: _, tail: _ } = <a href="../sui/table.md#sui_table">table</a>;
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/linked_table.md#sui_linked_table_drop">drop</a>&lt;K: <b>copy</b> + <a href="../sui/linked_table.md#sui_linked_table_drop">drop</a> + store, V: <a href="../sui/linked_table.md#sui_linked_table_drop">drop</a> + store&gt;(table: <a href="../sui/linked_table.md#sui_linked_table_LinkedTable">LinkedTable</a>&lt;K, V&gt;) {
+    <b>let</b> <a href="../sui/linked_table.md#sui_linked_table_LinkedTable">LinkedTable</a> { id, size: _, head: _, tail: _ } = table;
     id.delete()
 }
 </code></pre>

--- a/crates/sui-framework/docs/sui/nitro_attestation.md
+++ b/crates/sui-framework/docs/sui/nitro_attestation.md
@@ -191,7 +191,7 @@ Returns the parsed NitroAttestationDocument after verifying the attestation,
 may abort with errors described above.
 
 
-<pre><code><b>entry</b> <b>fun</b> <a href="../sui/nitro_attestation.md#sui_nitro_attestation_load_nitro_attestation">load_nitro_attestation</a>(attestation: vector&lt;u8&gt;, <a href="../sui/clock.md#sui_clock">clock</a>: &<a href="../sui/clock.md#sui_clock_Clock">sui::clock::Clock</a>): <a href="../sui/nitro_attestation.md#sui_nitro_attestation_NitroAttestationDocument">sui::nitro_attestation::NitroAttestationDocument</a>
+<pre><code><b>entry</b> <b>fun</b> <a href="../sui/nitro_attestation.md#sui_nitro_attestation_load_nitro_attestation">load_nitro_attestation</a>(attestation: vector&lt;u8&gt;, clock: &<a href="../sui/clock.md#sui_clock_Clock">sui::clock::Clock</a>): <a href="../sui/nitro_attestation.md#sui_nitro_attestation_NitroAttestationDocument">sui::nitro_attestation::NitroAttestationDocument</a>
 </code></pre>
 
 
@@ -200,8 +200,8 @@ may abort with errors described above.
 <summary>Implementation</summary>
 
 
-<pre><code><b>entry</b> <b>fun</b> <a href="../sui/nitro_attestation.md#sui_nitro_attestation_load_nitro_attestation">load_nitro_attestation</a>(attestation: vector&lt;u8&gt;, <a href="../sui/clock.md#sui_clock">clock</a>: &Clock): <a href="../sui/nitro_attestation.md#sui_nitro_attestation_NitroAttestationDocument">NitroAttestationDocument</a> {
-    <a href="../sui/nitro_attestation.md#sui_nitro_attestation_load_nitro_attestation_internal">load_nitro_attestation_internal</a>(&attestation, <a href="../sui/clock.md#sui_clock_timestamp_ms">clock::timestamp_ms</a>(<a href="../sui/clock.md#sui_clock">clock</a>))
+<pre><code><b>entry</b> <b>fun</b> <a href="../sui/nitro_attestation.md#sui_nitro_attestation_load_nitro_attestation">load_nitro_attestation</a>(attestation: vector&lt;u8&gt;, clock: &Clock): <a href="../sui/nitro_attestation.md#sui_nitro_attestation_NitroAttestationDocument">NitroAttestationDocument</a> {
+    <a href="../sui/nitro_attestation.md#sui_nitro_attestation_load_nitro_attestation_internal">load_nitro_attestation_internal</a>(&attestation, clock::timestamp_ms(clock))
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/sui/object.md
+++ b/crates/sui-framework/docs/sui/object.md
@@ -61,7 +61,7 @@ An object ID. This is used to reference Sui Objects.
 This is *not* guaranteed to be globally unique--anyone can create an <code><a href="../sui/object.md#sui_object_ID">ID</a></code> from a <code><a href="../sui/object.md#sui_object_UID">UID</a></code> or
 from an object, and ID's can be freely copied and dropped.
 Here, the values are not globally unique because there can be multiple values of type <code><a href="../sui/object.md#sui_object_ID">ID</a></code>
-with the same underlying bytes. For example, <code><a href="../sui/object.md#sui_object_id">object::id</a>(&obj)</code> can be called as many times
+with the same underlying bytes. For example, <code>object::id(&obj)</code> can be called as many times
 as you want for a given <code>obj</code>, and each <code><a href="../sui/object.md#sui_object_ID">ID</a></code> value will be identical.
 
 
@@ -249,7 +249,7 @@ Get the raw bytes of a <code><a href="../sui/object.md#sui_object_ID">ID</a></co
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/object.md#sui_object_id_to_bytes">id_to_bytes</a>(<a href="../sui/object.md#sui_object_id">id</a>: &<a href="../sui/object.md#sui_object_ID">ID</a>): vector&lt;u8&gt; {
-    <a href="../sui/bcs.md#sui_bcs_to_bytes">bcs::to_bytes</a>(&<a href="../sui/object.md#sui_object_id">id</a>.bytes)
+    bcs::to_bytes(&<a href="../sui/object.md#sui_object_id">id</a>.bytes)
 }
 </code></pre>
 
@@ -299,7 +299,7 @@ Make an <code><a href="../sui/object.md#sui_object_ID">ID</a></code> from raw by
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/object.md#sui_object_id_from_bytes">id_from_bytes</a>(bytes: vector&lt;u8&gt;): <a href="../sui/object.md#sui_object_ID">ID</a> {
-    <a href="../sui/address.md#sui_address_from_bytes">address::from_bytes</a>(bytes).to_id()
+    address::from_bytes(bytes).to_id()
 }
 </code></pre>
 
@@ -366,10 +366,10 @@ This should only be called once from <code>sui_system</code>.
 ## Function `clock`
 
 Create the <code><a href="../sui/object.md#sui_object_UID">UID</a></code> for the singleton <code>Clock</code> object.
-This should only be called once from <code><a href="../sui/clock.md#sui_clock">clock</a></code>.
+This should only be called once from <code><a href="../sui/object.md#sui_object_clock">clock</a></code>.
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/clock.md#sui_clock">clock</a>(): <a href="../sui/object.md#sui_object_UID">sui::object::UID</a>
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/object.md#sui_object_clock">clock</a>(): <a href="../sui/object.md#sui_object_UID">sui::object::UID</a>
 </code></pre>
 
 
@@ -378,7 +378,7 @@ This should only be called once from <code><a href="../sui/clock.md#sui_clock">c
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/clock.md#sui_clock">clock</a>(): <a href="../sui/object.md#sui_object_UID">UID</a> {
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/object.md#sui_object_clock">clock</a>(): <a href="../sui/object.md#sui_object_UID">UID</a> {
     <a href="../sui/object.md#sui_object_UID">UID</a> {
         <a href="../sui/object.md#sui_object_id">id</a>: <a href="../sui/object.md#sui_object_ID">ID</a> { bytes: <a href="../sui/object.md#sui_object_SUI_CLOCK_OBJECT_ID">SUI_CLOCK_OBJECT_ID</a> },
     }
@@ -394,10 +394,10 @@ This should only be called once from <code><a href="../sui/clock.md#sui_clock">c
 ## Function `authenticator_state`
 
 Create the <code><a href="../sui/object.md#sui_object_UID">UID</a></code> for the singleton <code>AuthenticatorState</code> object.
-This should only be called once from <code><a href="../sui/authenticator_state.md#sui_authenticator_state">authenticator_state</a></code>.
+This should only be called once from <code><a href="../sui/object.md#sui_object_authenticator_state">authenticator_state</a></code>.
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/authenticator_state.md#sui_authenticator_state">authenticator_state</a>(): <a href="../sui/object.md#sui_object_UID">sui::object::UID</a>
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/object.md#sui_object_authenticator_state">authenticator_state</a>(): <a href="../sui/object.md#sui_object_UID">sui::object::UID</a>
 </code></pre>
 
 
@@ -406,7 +406,7 @@ This should only be called once from <code><a href="../sui/authenticator_state.m
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/authenticator_state.md#sui_authenticator_state">authenticator_state</a>(): <a href="../sui/object.md#sui_object_UID">UID</a> {
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/object.md#sui_object_authenticator_state">authenticator_state</a>(): <a href="../sui/object.md#sui_object_UID">UID</a> {
     <a href="../sui/object.md#sui_object_UID">UID</a> {
         <a href="../sui/object.md#sui_object_id">id</a>: <a href="../sui/object.md#sui_object_ID">ID</a> { bytes: <a href="../sui/object.md#sui_object_SUI_AUTHENTICATOR_STATE_ID">SUI_AUTHENTICATOR_STATE_ID</a> },
     }
@@ -422,10 +422,10 @@ This should only be called once from <code><a href="../sui/authenticator_state.m
 ## Function `randomness_state`
 
 Create the <code><a href="../sui/object.md#sui_object_UID">UID</a></code> for the singleton <code>Random</code> object.
-This should only be called once from <code><a href="../sui/random.md#sui_random">random</a></code>.
+This should only be called once from <code>random</code>.
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/object.md#sui_object_randomness_state">randomness_state</a>(): <a href="../sui/object.md#sui_object_UID">sui::object::UID</a>
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/object.md#sui_object_randomness_state">randomness_state</a>(): <a href="../sui/object.md#sui_object_UID">sui::object::UID</a>
 </code></pre>
 
 
@@ -434,7 +434,7 @@ This should only be called once from <code><a href="../sui/random.md#sui_random"
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/object.md#sui_object_randomness_state">randomness_state</a>(): <a href="../sui/object.md#sui_object_UID">UID</a> {
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/object.md#sui_object_randomness_state">randomness_state</a>(): <a href="../sui/object.md#sui_object_UID">UID</a> {
     <a href="../sui/object.md#sui_object_UID">UID</a> {
         <a href="../sui/object.md#sui_object_id">id</a>: <a href="../sui/object.md#sui_object_ID">ID</a> { bytes: <a href="../sui/object.md#sui_object_SUI_RANDOM_ID">SUI_RANDOM_ID</a> },
     }
@@ -450,10 +450,10 @@ This should only be called once from <code><a href="../sui/random.md#sui_random"
 ## Function `sui_deny_list_object_id`
 
 Create the <code><a href="../sui/object.md#sui_object_UID">UID</a></code> for the singleton <code>DenyList</code> object.
-This should only be called once from <code><a href="../sui/deny_list.md#sui_deny_list">deny_list</a></code>.
+This should only be called once from <code>deny_list</code>.
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/object.md#sui_object_sui_deny_list_object_id">sui_deny_list_object_id</a>(): <a href="../sui/object.md#sui_object_UID">sui::object::UID</a>
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/object.md#sui_object_sui_deny_list_object_id">sui_deny_list_object_id</a>(): <a href="../sui/object.md#sui_object_UID">sui::object::UID</a>
 </code></pre>
 
 
@@ -462,7 +462,7 @@ This should only be called once from <code><a href="../sui/deny_list.md#sui_deny
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/object.md#sui_object_sui_deny_list_object_id">sui_deny_list_object_id</a>(): <a href="../sui/object.md#sui_object_UID">UID</a> {
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/object.md#sui_object_sui_deny_list_object_id">sui_deny_list_object_id</a>(): <a href="../sui/object.md#sui_object_UID">UID</a> {
     <a href="../sui/object.md#sui_object_UID">UID</a> {
         <a href="../sui/object.md#sui_object_id">id</a>: <a href="../sui/object.md#sui_object_ID">ID</a> { bytes: <a href="../sui/object.md#sui_object_SUI_DENY_LIST_OBJECT_ID">SUI_DENY_LIST_OBJECT_ID</a> },
     }
@@ -479,7 +479,7 @@ This should only be called once from <code><a href="../sui/deny_list.md#sui_deny
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/object.md#sui_object_sui_accumulator_root_object_id">sui_accumulator_root_object_id</a>(): <a href="../sui/object.md#sui_object_UID">sui::object::UID</a>
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/object.md#sui_object_sui_accumulator_root_object_id">sui_accumulator_root_object_id</a>(): <a href="../sui/object.md#sui_object_UID">sui::object::UID</a>
 </code></pre>
 
 
@@ -488,7 +488,7 @@ This should only be called once from <code><a href="../sui/deny_list.md#sui_deny
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/object.md#sui_object_sui_accumulator_root_object_id">sui_accumulator_root_object_id</a>(): <a href="../sui/object.md#sui_object_UID">UID</a> {
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/object.md#sui_object_sui_accumulator_root_object_id">sui_accumulator_root_object_id</a>(): <a href="../sui/object.md#sui_object_UID">UID</a> {
     <a href="../sui/object.md#sui_object_UID">UID</a> {
         <a href="../sui/object.md#sui_object_id">id</a>: <a href="../sui/object.md#sui_object_ID">ID</a> { bytes: <a href="../sui/object.md#sui_object_SUI_ACCUMULATOR_ROOT_OBJECT_ID">SUI_ACCUMULATOR_ROOT_OBJECT_ID</a> },
     }
@@ -505,7 +505,7 @@ This should only be called once from <code><a href="../sui/deny_list.md#sui_deny
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/object.md#sui_object_sui_accumulator_root_address">sui_accumulator_root_address</a>(): <b>address</b>
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/object.md#sui_object_sui_accumulator_root_address">sui_accumulator_root_address</a>(): <b>address</b>
 </code></pre>
 
 
@@ -514,7 +514,7 @@ This should only be called once from <code><a href="../sui/deny_list.md#sui_deny
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/object.md#sui_object_sui_accumulator_root_address">sui_accumulator_root_address</a>(): <b>address</b> {
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/object.md#sui_object_sui_accumulator_root_address">sui_accumulator_root_address</a>(): <b>address</b> {
     <a href="../sui/object.md#sui_object_SUI_ACCUMULATOR_ROOT_OBJECT_ID">SUI_ACCUMULATOR_ROOT_OBJECT_ID</a>
 }
 </code></pre>
@@ -528,10 +528,10 @@ This should only be called once from <code><a href="../sui/deny_list.md#sui_deny
 ## Function `sui_coin_registry_object_id`
 
 Create the <code><a href="../sui/object.md#sui_object_UID">UID</a></code> for the singleton <code>CoinRegistry</code> object.
-This should only be called once from <code><a href="../sui/coin_registry.md#sui_coin_registry">coin_registry</a></code>.
+This should only be called once from <code>coin_registry</code>.
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/object.md#sui_object_sui_coin_registry_object_id">sui_coin_registry_object_id</a>(): <a href="../sui/object.md#sui_object_UID">sui::object::UID</a>
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/object.md#sui_object_sui_coin_registry_object_id">sui_coin_registry_object_id</a>(): <a href="../sui/object.md#sui_object_UID">sui::object::UID</a>
 </code></pre>
 
 
@@ -540,7 +540,7 @@ This should only be called once from <code><a href="../sui/coin_registry.md#sui_
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/object.md#sui_object_sui_coin_registry_object_id">sui_coin_registry_object_id</a>(): <a href="../sui/object.md#sui_object_UID">UID</a> {
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/object.md#sui_object_sui_coin_registry_object_id">sui_coin_registry_object_id</a>(): <a href="../sui/object.md#sui_object_UID">UID</a> {
     <a href="../sui/object.md#sui_object_UID">UID</a> {
         <a href="../sui/object.md#sui_object_id">id</a>: <a href="../sui/object.md#sui_object_ID">ID</a> { bytes: <a href="../sui/object.md#sui_object_SUI_COIN_REGISTRY_OBJECT_ID">SUI_COIN_REGISTRY_OBJECT_ID</a> },
     }
@@ -557,7 +557,7 @@ This should only be called once from <code><a href="../sui/coin_registry.md#sui_
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/object.md#sui_object_sui_coin_registry_address">sui_coin_registry_address</a>(): <b>address</b>
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/object.md#sui_object_sui_coin_registry_address">sui_coin_registry_address</a>(): <b>address</b>
 </code></pre>
 
 
@@ -566,7 +566,7 @@ This should only be called once from <code><a href="../sui/coin_registry.md#sui_
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/object.md#sui_object_sui_coin_registry_address">sui_coin_registry_address</a>(): <b>address</b> {
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/object.md#sui_object_sui_coin_registry_address">sui_coin_registry_address</a>(): <b>address</b> {
     <a href="../sui/object.md#sui_object_SUI_COIN_REGISTRY_OBJECT_ID">SUI_COIN_REGISTRY_OBJECT_ID</a>
 }
 </code></pre>
@@ -580,10 +580,10 @@ This should only be called once from <code><a href="../sui/coin_registry.md#sui_
 ## Function `sui_display_registry_object_id`
 
 Create the <code><a href="../sui/object.md#sui_object_UID">UID</a></code> for the singleton <code>DisplayRegistry</code> object.
-This should only be called once from <code><a href="../sui/display_registry.md#sui_display_registry">display_registry</a></code>.
+This should only be called once from <code>display_registry</code>.
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/object.md#sui_object_sui_display_registry_object_id">sui_display_registry_object_id</a>(): <a href="../sui/object.md#sui_object_UID">sui::object::UID</a>
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/object.md#sui_object_sui_display_registry_object_id">sui_display_registry_object_id</a>(): <a href="../sui/object.md#sui_object_UID">sui::object::UID</a>
 </code></pre>
 
 
@@ -592,7 +592,7 @@ This should only be called once from <code><a href="../sui/display_registry.md#s
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/object.md#sui_object_sui_display_registry_object_id">sui_display_registry_object_id</a>(): <a href="../sui/object.md#sui_object_UID">UID</a> {
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/object.md#sui_object_sui_display_registry_object_id">sui_display_registry_object_id</a>(): <a href="../sui/object.md#sui_object_UID">UID</a> {
     <a href="../sui/object.md#sui_object_UID">UID</a> {
         <a href="../sui/object.md#sui_object_id">id</a>: <a href="../sui/object.md#sui_object_ID">ID</a> { bytes: <a href="../sui/object.md#sui_object_SUI_DISPLAY_REGISTRY_OBJECT_ID">SUI_DISPLAY_REGISTRY_OBJECT_ID</a> },
     }
@@ -609,7 +609,7 @@ This should only be called once from <code><a href="../sui/display_registry.md#s
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/object.md#sui_object_sui_display_registry_address">sui_display_registry_address</a>(): <b>address</b>
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/object.md#sui_object_sui_display_registry_address">sui_display_registry_address</a>(): <b>address</b>
 </code></pre>
 
 
@@ -618,7 +618,7 @@ This should only be called once from <code><a href="../sui/display_registry.md#s
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/object.md#sui_object_sui_display_registry_address">sui_display_registry_address</a>(): <b>address</b> {
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/object.md#sui_object_sui_display_registry_address">sui_display_registry_address</a>(): <b>address</b> {
     <a href="../sui/object.md#sui_object_SUI_DISPLAY_REGISTRY_OBJECT_ID">SUI_DISPLAY_REGISTRY_OBJECT_ID</a>
 }
 </code></pre>
@@ -660,10 +660,10 @@ This should only be called once from <code><a href="../sui/object.md#sui_object_
 ## Function `address_alias_state`
 
 Create the <code><a href="../sui/object.md#sui_object_UID">UID</a></code> for the singleton <code>AddressAliasState</code> object.
-This should only be called once from <code><a href="../sui/address_alias.md#sui_address_alias">address_alias</a></code>.
+This should only be called once from <code>address_alias</code>.
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/object.md#sui_object_address_alias_state">address_alias_state</a>(): <a href="../sui/object.md#sui_object_UID">sui::object::UID</a>
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/object.md#sui_object_address_alias_state">address_alias_state</a>(): <a href="../sui/object.md#sui_object_UID">sui::object::UID</a>
 </code></pre>
 
 
@@ -672,7 +672,7 @@ This should only be called once from <code><a href="../sui/address_alias.md#sui_
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/object.md#sui_object_address_alias_state">address_alias_state</a>(): <a href="../sui/object.md#sui_object_UID">UID</a> {
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/object.md#sui_object_address_alias_state">address_alias_state</a>(): <a href="../sui/object.md#sui_object_UID">UID</a> {
     <a href="../sui/object.md#sui_object_UID">UID</a> {
         <a href="../sui/object.md#sui_object_id">id</a>: <a href="../sui/object.md#sui_object_ID">ID</a> { bytes: <a href="../sui/object.md#sui_object_SUI_ADDRESS_ALIAS_STATE_ID">SUI_ADDRESS_ALIAS_STATE_ID</a> },
     }
@@ -750,7 +750,7 @@ Get the raw bytes of a <code><a href="../sui/object.md#sui_object_UID">UID</a></
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/object.md#sui_object_uid_to_bytes">uid_to_bytes</a>(uid: &<a href="../sui/object.md#sui_object_UID">UID</a>): vector&lt;u8&gt; {
-    <a href="../sui/bcs.md#sui_bcs_to_bytes">bcs::to_bytes</a>(&uid.<a href="../sui/object.md#sui_object_id">id</a>.bytes)
+    bcs::to_bytes(&uid.<a href="../sui/object.md#sui_object_id">id</a>.bytes)
 }
 </code></pre>
 
@@ -908,7 +908,7 @@ Get the raw bytes for the underlying <code><a href="../sui/object.md#sui_object_
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/object.md#sui_object_id_bytes">id_bytes</a>&lt;T: key&gt;(obj: &T): vector&lt;u8&gt; {
-    <a href="../sui/bcs.md#sui_bcs_to_bytes">bcs::to_bytes</a>(&<a href="../sui/object.md#sui_object_borrow_uid">borrow_uid</a>(obj).<a href="../sui/object.md#sui_object_id">id</a>)
+    bcs::to_bytes(&<a href="../sui/object.md#sui_object_borrow_uid">borrow_uid</a>(obj).<a href="../sui/object.md#sui_object_id">id</a>)
 }
 </code></pre>
 
@@ -975,7 +975,7 @@ restrictable in the object's module.
 Generate a new UID specifically used for creating a UID from a hash
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/object.md#sui_object_new_uid_from_hash">new_uid_from_hash</a>(bytes: <b>address</b>): <a href="../sui/object.md#sui_object_UID">sui::object::UID</a>
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/object.md#sui_object_new_uid_from_hash">new_uid_from_hash</a>(bytes: <b>address</b>): <a href="../sui/object.md#sui_object_UID">sui::object::UID</a>
 </code></pre>
 
 
@@ -984,7 +984,7 @@ Generate a new UID specifically used for creating a UID from a hash
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/object.md#sui_object_new_uid_from_hash">new_uid_from_hash</a>(bytes: <b>address</b>): <a href="../sui/object.md#sui_object_UID">UID</a> {
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/object.md#sui_object_new_uid_from_hash">new_uid_from_hash</a>(bytes: <b>address</b>): <a href="../sui/object.md#sui_object_UID">UID</a> {
     <a href="../sui/object.md#sui_object_record_new_uid">record_new_uid</a>(bytes);
     <a href="../sui/object.md#sui_object_UID">UID</a> { <a href="../sui/object.md#sui_object_id">id</a>: <a href="../sui/object.md#sui_object_ID">ID</a> { bytes } }
 }

--- a/crates/sui-framework/docs/sui/object_bag.md
+++ b/crates/sui-framework/docs/sui/object_bag.md
@@ -103,7 +103,7 @@ Creates a new, empty bag
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/object_bag.md#sui_object_bag_new">new</a>(ctx: &<b>mut</b> TxContext): <a href="../sui/object_bag.md#sui_object_bag_ObjectBag">ObjectBag</a> {
     <a href="../sui/object_bag.md#sui_object_bag_ObjectBag">ObjectBag</a> {
-        id: <a href="../sui/object.md#sui_object_new">object::new</a>(ctx),
+        id: object::new(ctx),
         size: 0,
     }
 }
@@ -117,12 +117,12 @@ Creates a new, empty bag
 
 ## Function `add`
 
-Adds a key-value pair to the bag <code><a href="../sui/bag.md#sui_bag">bag</a>: &<b>mut</b> <a href="../sui/object_bag.md#sui_object_bag_ObjectBag">ObjectBag</a></code>
+Adds a key-value pair to the bag <code>bag: &<b>mut</b> <a href="../sui/object_bag.md#sui_object_bag_ObjectBag">ObjectBag</a></code>
 Aborts with <code><a href="../sui/dynamic_field.md#sui_dynamic_field_EFieldAlreadyExists">sui::dynamic_field::EFieldAlreadyExists</a></code> if the bag already has an entry with
 that key <code>k: K</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/object_bag.md#sui_object_bag_add">add</a>&lt;K: <b>copy</b>, drop, store, V: key, store&gt;(<a href="../sui/bag.md#sui_bag">bag</a>: &<b>mut</b> <a href="../sui/object_bag.md#sui_object_bag_ObjectBag">sui::object_bag::ObjectBag</a>, k: K, v: V)
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/object_bag.md#sui_object_bag_add">add</a>&lt;K: <b>copy</b>, drop, store, V: key, store&gt;(bag: &<b>mut</b> <a href="../sui/object_bag.md#sui_object_bag_ObjectBag">sui::object_bag::ObjectBag</a>, k: K, v: V)
 </code></pre>
 
 
@@ -131,9 +131,9 @@ that key <code>k: K</code>.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/object_bag.md#sui_object_bag_add">add</a>&lt;K: <b>copy</b> + drop + store, V: key + store&gt;(<a href="../sui/bag.md#sui_bag">bag</a>: &<b>mut</b> <a href="../sui/object_bag.md#sui_object_bag_ObjectBag">ObjectBag</a>, k: K, v: V) {
-    ofield::add(&<b>mut</b> <a href="../sui/bag.md#sui_bag">bag</a>.id, k, v);
-    <a href="../sui/bag.md#sui_bag">bag</a>.size = <a href="../sui/bag.md#sui_bag">bag</a>.size + 1;
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/object_bag.md#sui_object_bag_add">add</a>&lt;K: <b>copy</b> + drop + store, V: key + store&gt;(bag: &<b>mut</b> <a href="../sui/object_bag.md#sui_object_bag_ObjectBag">ObjectBag</a>, k: K, v: V) {
+    ofield::add(&<b>mut</b> bag.id, k, v);
+    bag.size = bag.size + 1;
 }
 </code></pre>
 
@@ -145,14 +145,14 @@ that key <code>k: K</code>.
 
 ## Function `borrow`
 
-Immutably borrows the value associated with the key in the bag <code><a href="../sui/bag.md#sui_bag">bag</a>: &<a href="../sui/object_bag.md#sui_object_bag_ObjectBag">ObjectBag</a></code>.
+Immutably borrows the value associated with the key in the bag <code>bag: &<a href="../sui/object_bag.md#sui_object_bag_ObjectBag">ObjectBag</a></code>.
 Aborts with <code><a href="../sui/dynamic_field.md#sui_dynamic_field_EFieldDoesNotExist">sui::dynamic_field::EFieldDoesNotExist</a></code> if the bag does not have an entry with
 that key <code>k: K</code>.
 Aborts with <code><a href="../sui/dynamic_field.md#sui_dynamic_field_EFieldTypeMismatch">sui::dynamic_field::EFieldTypeMismatch</a></code> if the bag has an entry for the key, but
 the value does not have the specified type.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/borrow.md#sui_borrow">borrow</a>&lt;K: <b>copy</b>, drop, store, V: key, store&gt;(<a href="../sui/bag.md#sui_bag">bag</a>: &<a href="../sui/object_bag.md#sui_object_bag_ObjectBag">sui::object_bag::ObjectBag</a>, k: K): &V
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/object_bag.md#sui_object_bag_borrow">borrow</a>&lt;K: <b>copy</b>, drop, store, V: key, store&gt;(bag: &<a href="../sui/object_bag.md#sui_object_bag_ObjectBag">sui::object_bag::ObjectBag</a>, k: K): &V
 </code></pre>
 
 
@@ -161,8 +161,8 @@ the value does not have the specified type.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/borrow.md#sui_borrow">borrow</a>&lt;K: <b>copy</b> + drop + store, V: key + store&gt;(<a href="../sui/bag.md#sui_bag">bag</a>: &<a href="../sui/object_bag.md#sui_object_bag_ObjectBag">ObjectBag</a>, k: K): &V {
-    ofield::borrow(&<a href="../sui/bag.md#sui_bag">bag</a>.id, k)
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/object_bag.md#sui_object_bag_borrow">borrow</a>&lt;K: <b>copy</b> + drop + store, V: key + store&gt;(bag: &<a href="../sui/object_bag.md#sui_object_bag_ObjectBag">ObjectBag</a>, k: K): &V {
+    ofield::borrow(&bag.id, k)
 }
 </code></pre>
 
@@ -174,14 +174,14 @@ the value does not have the specified type.
 
 ## Function `borrow_mut`
 
-Mutably borrows the value associated with the key in the bag <code><a href="../sui/bag.md#sui_bag">bag</a>: &<b>mut</b> <a href="../sui/object_bag.md#sui_object_bag_ObjectBag">ObjectBag</a></code>.
+Mutably borrows the value associated with the key in the bag <code>bag: &<b>mut</b> <a href="../sui/object_bag.md#sui_object_bag_ObjectBag">ObjectBag</a></code>.
 Aborts with <code><a href="../sui/dynamic_field.md#sui_dynamic_field_EFieldDoesNotExist">sui::dynamic_field::EFieldDoesNotExist</a></code> if the bag does not have an entry with
 that key <code>k: K</code>.
 Aborts with <code><a href="../sui/dynamic_field.md#sui_dynamic_field_EFieldTypeMismatch">sui::dynamic_field::EFieldTypeMismatch</a></code> if the bag has an entry for the key, but
 the value does not have the specified type.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/object_bag.md#sui_object_bag_borrow_mut">borrow_mut</a>&lt;K: <b>copy</b>, drop, store, V: key, store&gt;(<a href="../sui/bag.md#sui_bag">bag</a>: &<b>mut</b> <a href="../sui/object_bag.md#sui_object_bag_ObjectBag">sui::object_bag::ObjectBag</a>, k: K): &<b>mut</b> V
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/object_bag.md#sui_object_bag_borrow_mut">borrow_mut</a>&lt;K: <b>copy</b>, drop, store, V: key, store&gt;(bag: &<b>mut</b> <a href="../sui/object_bag.md#sui_object_bag_ObjectBag">sui::object_bag::ObjectBag</a>, k: K): &<b>mut</b> V
 </code></pre>
 
 
@@ -190,8 +190,8 @@ the value does not have the specified type.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/object_bag.md#sui_object_bag_borrow_mut">borrow_mut</a>&lt;K: <b>copy</b> + drop + store, V: key + store&gt;(<a href="../sui/bag.md#sui_bag">bag</a>: &<b>mut</b> <a href="../sui/object_bag.md#sui_object_bag_ObjectBag">ObjectBag</a>, k: K): &<b>mut</b> V {
-    ofield::borrow_mut(&<b>mut</b> <a href="../sui/bag.md#sui_bag">bag</a>.id, k)
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/object_bag.md#sui_object_bag_borrow_mut">borrow_mut</a>&lt;K: <b>copy</b> + drop + store, V: key + store&gt;(bag: &<b>mut</b> <a href="../sui/object_bag.md#sui_object_bag_ObjectBag">ObjectBag</a>, k: K): &<b>mut</b> V {
+    ofield::borrow_mut(&<b>mut</b> bag.id, k)
 }
 </code></pre>
 
@@ -203,14 +203,14 @@ the value does not have the specified type.
 
 ## Function `remove`
 
-Mutably borrows the key-value pair in the bag <code><a href="../sui/bag.md#sui_bag">bag</a>: &<b>mut</b> <a href="../sui/object_bag.md#sui_object_bag_ObjectBag">ObjectBag</a></code> and returns the value.
+Mutably borrows the key-value pair in the bag <code>bag: &<b>mut</b> <a href="../sui/object_bag.md#sui_object_bag_ObjectBag">ObjectBag</a></code> and returns the value.
 Aborts with <code><a href="../sui/dynamic_field.md#sui_dynamic_field_EFieldDoesNotExist">sui::dynamic_field::EFieldDoesNotExist</a></code> if the bag does not have an entry with
 that key <code>k: K</code>.
 Aborts with <code><a href="../sui/dynamic_field.md#sui_dynamic_field_EFieldTypeMismatch">sui::dynamic_field::EFieldTypeMismatch</a></code> if the bag has an entry for the key, but
 the value does not have the specified type.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/object_bag.md#sui_object_bag_remove">remove</a>&lt;K: <b>copy</b>, drop, store, V: key, store&gt;(<a href="../sui/bag.md#sui_bag">bag</a>: &<b>mut</b> <a href="../sui/object_bag.md#sui_object_bag_ObjectBag">sui::object_bag::ObjectBag</a>, k: K): V
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/object_bag.md#sui_object_bag_remove">remove</a>&lt;K: <b>copy</b>, drop, store, V: key, store&gt;(bag: &<b>mut</b> <a href="../sui/object_bag.md#sui_object_bag_ObjectBag">sui::object_bag::ObjectBag</a>, k: K): V
 </code></pre>
 
 
@@ -219,9 +219,9 @@ the value does not have the specified type.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/object_bag.md#sui_object_bag_remove">remove</a>&lt;K: <b>copy</b> + drop + store, V: key + store&gt;(<a href="../sui/bag.md#sui_bag">bag</a>: &<b>mut</b> <a href="../sui/object_bag.md#sui_object_bag_ObjectBag">ObjectBag</a>, k: K): V {
-    <b>let</b> v = ofield::remove(&<b>mut</b> <a href="../sui/bag.md#sui_bag">bag</a>.id, k);
-    <a href="../sui/bag.md#sui_bag">bag</a>.size = <a href="../sui/bag.md#sui_bag">bag</a>.size - 1;
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/object_bag.md#sui_object_bag_remove">remove</a>&lt;K: <b>copy</b> + drop + store, V: key + store&gt;(bag: &<b>mut</b> <a href="../sui/object_bag.md#sui_object_bag_ObjectBag">ObjectBag</a>, k: K): V {
+    <b>let</b> v = ofield::remove(&<b>mut</b> bag.id, k);
+    bag.size = bag.size - 1;
     v
 }
 </code></pre>
@@ -234,10 +234,10 @@ the value does not have the specified type.
 
 ## Function `contains`
 
-Returns true iff there is an value associated with the key <code>k: K</code> in the bag <code><a href="../sui/bag.md#sui_bag">bag</a>: &<a href="../sui/object_bag.md#sui_object_bag_ObjectBag">ObjectBag</a></code>
+Returns true iff there is an value associated with the key <code>k: K</code> in the bag <code>bag: &<a href="../sui/object_bag.md#sui_object_bag_ObjectBag">ObjectBag</a></code>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/object_bag.md#sui_object_bag_contains">contains</a>&lt;K: <b>copy</b>, drop, store&gt;(<a href="../sui/bag.md#sui_bag">bag</a>: &<a href="../sui/object_bag.md#sui_object_bag_ObjectBag">sui::object_bag::ObjectBag</a>, k: K): bool
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/object_bag.md#sui_object_bag_contains">contains</a>&lt;K: <b>copy</b>, drop, store&gt;(bag: &<a href="../sui/object_bag.md#sui_object_bag_ObjectBag">sui::object_bag::ObjectBag</a>, k: K): bool
 </code></pre>
 
 
@@ -246,8 +246,8 @@ Returns true iff there is an value associated with the key <code>k: K</code> in 
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/object_bag.md#sui_object_bag_contains">contains</a>&lt;K: <b>copy</b> + drop + store&gt;(<a href="../sui/bag.md#sui_bag">bag</a>: &<a href="../sui/object_bag.md#sui_object_bag_ObjectBag">ObjectBag</a>, k: K): bool {
-    ofield::exists_&lt;K&gt;(&<a href="../sui/bag.md#sui_bag">bag</a>.id, k)
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/object_bag.md#sui_object_bag_contains">contains</a>&lt;K: <b>copy</b> + drop + store&gt;(bag: &<a href="../sui/object_bag.md#sui_object_bag_ObjectBag">ObjectBag</a>, k: K): bool {
+    ofield::exists_&lt;K&gt;(&bag.id, k)
 }
 </code></pre>
 
@@ -259,11 +259,11 @@ Returns true iff there is an value associated with the key <code>k: K</code> in 
 
 ## Function `contains_with_type`
 
-Returns true iff there is an value associated with the key <code>k: K</code> in the bag <code><a href="../sui/bag.md#sui_bag">bag</a>: &<a href="../sui/object_bag.md#sui_object_bag_ObjectBag">ObjectBag</a></code>
+Returns true iff there is an value associated with the key <code>k: K</code> in the bag <code>bag: &<a href="../sui/object_bag.md#sui_object_bag_ObjectBag">ObjectBag</a></code>
 with an assigned value of type <code>V</code>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/object_bag.md#sui_object_bag_contains_with_type">contains_with_type</a>&lt;K: <b>copy</b>, drop, store, V: key, store&gt;(<a href="../sui/bag.md#sui_bag">bag</a>: &<a href="../sui/object_bag.md#sui_object_bag_ObjectBag">sui::object_bag::ObjectBag</a>, k: K): bool
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/object_bag.md#sui_object_bag_contains_with_type">contains_with_type</a>&lt;K: <b>copy</b>, drop, store, V: key, store&gt;(bag: &<a href="../sui/object_bag.md#sui_object_bag_ObjectBag">sui::object_bag::ObjectBag</a>, k: K): bool
 </code></pre>
 
 
@@ -272,8 +272,8 @@ with an assigned value of type <code>V</code>
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/object_bag.md#sui_object_bag_contains_with_type">contains_with_type</a>&lt;K: <b>copy</b> + drop + store, V: key + store&gt;(<a href="../sui/bag.md#sui_bag">bag</a>: &<a href="../sui/object_bag.md#sui_object_bag_ObjectBag">ObjectBag</a>, k: K): bool {
-    ofield::exists_with_type&lt;K, V&gt;(&<a href="../sui/bag.md#sui_bag">bag</a>.id, k)
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/object_bag.md#sui_object_bag_contains_with_type">contains_with_type</a>&lt;K: <b>copy</b> + drop + store, V: key + store&gt;(bag: &<a href="../sui/object_bag.md#sui_object_bag_ObjectBag">ObjectBag</a>, k: K): bool {
+    ofield::exists_with_type&lt;K, V&gt;(&bag.id, k)
 }
 </code></pre>
 
@@ -288,7 +288,7 @@ with an assigned value of type <code>V</code>
 Returns the size of the bag, the number of key-value pairs
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/object_bag.md#sui_object_bag_length">length</a>(<a href="../sui/bag.md#sui_bag">bag</a>: &<a href="../sui/object_bag.md#sui_object_bag_ObjectBag">sui::object_bag::ObjectBag</a>): u64
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/object_bag.md#sui_object_bag_length">length</a>(bag: &<a href="../sui/object_bag.md#sui_object_bag_ObjectBag">sui::object_bag::ObjectBag</a>): u64
 </code></pre>
 
 
@@ -297,8 +297,8 @@ Returns the size of the bag, the number of key-value pairs
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/object_bag.md#sui_object_bag_length">length</a>(<a href="../sui/bag.md#sui_bag">bag</a>: &<a href="../sui/object_bag.md#sui_object_bag_ObjectBag">ObjectBag</a>): u64 {
-    <a href="../sui/bag.md#sui_bag">bag</a>.size
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/object_bag.md#sui_object_bag_length">length</a>(bag: &<a href="../sui/object_bag.md#sui_object_bag_ObjectBag">ObjectBag</a>): u64 {
+    bag.size
 }
 </code></pre>
 
@@ -313,7 +313,7 @@ Returns the size of the bag, the number of key-value pairs
 Returns true iff the bag is empty (if <code><a href="../sui/object_bag.md#sui_object_bag_length">length</a></code> returns <code>0</code>)
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/object_bag.md#sui_object_bag_is_empty">is_empty</a>(<a href="../sui/bag.md#sui_bag">bag</a>: &<a href="../sui/object_bag.md#sui_object_bag_ObjectBag">sui::object_bag::ObjectBag</a>): bool
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/object_bag.md#sui_object_bag_is_empty">is_empty</a>(bag: &<a href="../sui/object_bag.md#sui_object_bag_ObjectBag">sui::object_bag::ObjectBag</a>): bool
 </code></pre>
 
 
@@ -322,8 +322,8 @@ Returns true iff the bag is empty (if <code><a href="../sui/object_bag.md#sui_ob
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/object_bag.md#sui_object_bag_is_empty">is_empty</a>(<a href="../sui/bag.md#sui_bag">bag</a>: &<a href="../sui/object_bag.md#sui_object_bag_ObjectBag">ObjectBag</a>): bool {
-    <a href="../sui/bag.md#sui_bag">bag</a>.size == 0
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/object_bag.md#sui_object_bag_is_empty">is_empty</a>(bag: &<a href="../sui/object_bag.md#sui_object_bag_ObjectBag">ObjectBag</a>): bool {
+    bag.size == 0
 }
 </code></pre>
 
@@ -339,7 +339,7 @@ Destroys an empty bag
 Aborts with <code><a href="../sui/object_bag.md#sui_object_bag_EBagNotEmpty">EBagNotEmpty</a></code> if the bag still contains values
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/object_bag.md#sui_object_bag_destroy_empty">destroy_empty</a>(<a href="../sui/bag.md#sui_bag">bag</a>: <a href="../sui/object_bag.md#sui_object_bag_ObjectBag">sui::object_bag::ObjectBag</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/object_bag.md#sui_object_bag_destroy_empty">destroy_empty</a>(bag: <a href="../sui/object_bag.md#sui_object_bag_ObjectBag">sui::object_bag::ObjectBag</a>)
 </code></pre>
 
 
@@ -348,8 +348,8 @@ Aborts with <code><a href="../sui/object_bag.md#sui_object_bag_EBagNotEmpty">EBa
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/object_bag.md#sui_object_bag_destroy_empty">destroy_empty</a>(<a href="../sui/bag.md#sui_bag">bag</a>: <a href="../sui/object_bag.md#sui_object_bag_ObjectBag">ObjectBag</a>) {
-    <b>let</b> <a href="../sui/object_bag.md#sui_object_bag_ObjectBag">ObjectBag</a> { id, size } = <a href="../sui/bag.md#sui_bag">bag</a>;
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/object_bag.md#sui_object_bag_destroy_empty">destroy_empty</a>(bag: <a href="../sui/object_bag.md#sui_object_bag_ObjectBag">ObjectBag</a>) {
+    <b>let</b> <a href="../sui/object_bag.md#sui_object_bag_ObjectBag">ObjectBag</a> { id, size } = bag;
     <b>assert</b>!(size == 0, <a href="../sui/object_bag.md#sui_object_bag_EBagNotEmpty">EBagNotEmpty</a>);
     id.delete()
 }
@@ -367,7 +367,7 @@ Returns the ID of the object associated with the key if the bag has an entry wit
 Returns none otherwise
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/object_bag.md#sui_object_bag_value_id">value_id</a>&lt;K: <b>copy</b>, drop, store&gt;(<a href="../sui/bag.md#sui_bag">bag</a>: &<a href="../sui/object_bag.md#sui_object_bag_ObjectBag">sui::object_bag::ObjectBag</a>, k: K): <a href="../std/option.md#std_option_Option">std::option::Option</a>&lt;<a href="../sui/object.md#sui_object_ID">sui::object::ID</a>&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/object_bag.md#sui_object_bag_value_id">value_id</a>&lt;K: <b>copy</b>, drop, store&gt;(bag: &<a href="../sui/object_bag.md#sui_object_bag_ObjectBag">sui::object_bag::ObjectBag</a>, k: K): <a href="../std/option.md#std_option_Option">std::option::Option</a>&lt;<a href="../sui/object.md#sui_object_ID">sui::object::ID</a>&gt;
 </code></pre>
 
 
@@ -376,8 +376,8 @@ Returns none otherwise
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/object_bag.md#sui_object_bag_value_id">value_id</a>&lt;K: <b>copy</b> + drop + store&gt;(<a href="../sui/bag.md#sui_bag">bag</a>: &<a href="../sui/object_bag.md#sui_object_bag_ObjectBag">ObjectBag</a>, k: K): Option&lt;ID&gt; {
-    ofield::id(&<a href="../sui/bag.md#sui_bag">bag</a>.id, k)
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/object_bag.md#sui_object_bag_value_id">value_id</a>&lt;K: <b>copy</b> + drop + store&gt;(bag: &<a href="../sui/object_bag.md#sui_object_bag_ObjectBag">ObjectBag</a>, k: K): Option&lt;ID&gt; {
+    ofield::id(&bag.id, k)
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/sui/object_table.md
+++ b/crates/sui-framework/docs/sui/object_table.md
@@ -102,7 +102,7 @@ Creates a new, empty table
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/object_table.md#sui_object_table_new">new</a>&lt;K: <b>copy</b> + drop + store, V: key + store&gt;(ctx: &<b>mut</b> TxContext): <a href="../sui/object_table.md#sui_object_table_ObjectTable">ObjectTable</a>&lt;K, V&gt; {
     <a href="../sui/object_table.md#sui_object_table_ObjectTable">ObjectTable</a> {
-        id: <a href="../sui/object.md#sui_object_new">object::new</a>(ctx),
+        id: object::new(ctx),
         size: 0,
     }
 }
@@ -116,12 +116,12 @@ Creates a new, empty table
 
 ## Function `add`
 
-Adds a key-value pair to the table <code><a href="../sui/table.md#sui_table">table</a>: &<b>mut</b> <a href="../sui/object_table.md#sui_object_table_ObjectTable">ObjectTable</a>&lt;K, V&gt;</code>
+Adds a key-value pair to the table <code>table: &<b>mut</b> <a href="../sui/object_table.md#sui_object_table_ObjectTable">ObjectTable</a>&lt;K, V&gt;</code>
 Aborts with <code><a href="../sui/dynamic_field.md#sui_dynamic_field_EFieldAlreadyExists">sui::dynamic_field::EFieldAlreadyExists</a></code> if the table already has an entry with
 that key <code>k: K</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/object_table.md#sui_object_table_add">add</a>&lt;K: <b>copy</b>, drop, store, V: key, store&gt;(<a href="../sui/table.md#sui_table">table</a>: &<b>mut</b> <a href="../sui/object_table.md#sui_object_table_ObjectTable">sui::object_table::ObjectTable</a>&lt;K, V&gt;, k: K, v: V)
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/object_table.md#sui_object_table_add">add</a>&lt;K: <b>copy</b>, drop, store, V: key, store&gt;(table: &<b>mut</b> <a href="../sui/object_table.md#sui_object_table_ObjectTable">sui::object_table::ObjectTable</a>&lt;K, V&gt;, k: K, v: V)
 </code></pre>
 
 
@@ -130,9 +130,9 @@ that key <code>k: K</code>.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/object_table.md#sui_object_table_add">add</a>&lt;K: <b>copy</b> + drop + store, V: key + store&gt;(<a href="../sui/table.md#sui_table">table</a>: &<b>mut</b> <a href="../sui/object_table.md#sui_object_table_ObjectTable">ObjectTable</a>&lt;K, V&gt;, k: K, v: V) {
-    ofield::add(&<b>mut</b> <a href="../sui/table.md#sui_table">table</a>.id, k, v);
-    <a href="../sui/table.md#sui_table">table</a>.size = <a href="../sui/table.md#sui_table">table</a>.size + 1;
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/object_table.md#sui_object_table_add">add</a>&lt;K: <b>copy</b> + drop + store, V: key + store&gt;(table: &<b>mut</b> <a href="../sui/object_table.md#sui_object_table_ObjectTable">ObjectTable</a>&lt;K, V&gt;, k: K, v: V) {
+    ofield::add(&<b>mut</b> table.id, k, v);
+    table.size = table.size + 1;
 }
 </code></pre>
 
@@ -144,12 +144,12 @@ that key <code>k: K</code>.
 
 ## Function `borrow`
 
-Immutable borrows the value associated with the key in the table <code><a href="../sui/table.md#sui_table">table</a>: &<a href="../sui/object_table.md#sui_object_table_ObjectTable">ObjectTable</a>&lt;K, V&gt;</code>.
+Immutable borrows the value associated with the key in the table <code>table: &<a href="../sui/object_table.md#sui_object_table_ObjectTable">ObjectTable</a>&lt;K, V&gt;</code>.
 Aborts with <code><a href="../sui/dynamic_field.md#sui_dynamic_field_EFieldDoesNotExist">sui::dynamic_field::EFieldDoesNotExist</a></code> if the table does not have an entry with
 that key <code>k: K</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/borrow.md#sui_borrow">borrow</a>&lt;K: <b>copy</b>, drop, store, V: key, store&gt;(<a href="../sui/table.md#sui_table">table</a>: &<a href="../sui/object_table.md#sui_object_table_ObjectTable">sui::object_table::ObjectTable</a>&lt;K, V&gt;, k: K): &V
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/object_table.md#sui_object_table_borrow">borrow</a>&lt;K: <b>copy</b>, drop, store, V: key, store&gt;(table: &<a href="../sui/object_table.md#sui_object_table_ObjectTable">sui::object_table::ObjectTable</a>&lt;K, V&gt;, k: K): &V
 </code></pre>
 
 
@@ -158,8 +158,8 @@ that key <code>k: K</code>.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/borrow.md#sui_borrow">borrow</a>&lt;K: <b>copy</b> + drop + store, V: key + store&gt;(<a href="../sui/table.md#sui_table">table</a>: &<a href="../sui/object_table.md#sui_object_table_ObjectTable">ObjectTable</a>&lt;K, V&gt;, k: K): &V {
-    ofield::borrow(&<a href="../sui/table.md#sui_table">table</a>.id, k)
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/object_table.md#sui_object_table_borrow">borrow</a>&lt;K: <b>copy</b> + drop + store, V: key + store&gt;(table: &<a href="../sui/object_table.md#sui_object_table_ObjectTable">ObjectTable</a>&lt;K, V&gt;, k: K): &V {
+    ofield::borrow(&table.id, k)
 }
 </code></pre>
 
@@ -171,12 +171,12 @@ that key <code>k: K</code>.
 
 ## Function `borrow_mut`
 
-Mutably borrows the value associated with the key in the table <code><a href="../sui/table.md#sui_table">table</a>: &<b>mut</b> <a href="../sui/object_table.md#sui_object_table_ObjectTable">ObjectTable</a>&lt;K, V&gt;</code>.
+Mutably borrows the value associated with the key in the table <code>table: &<b>mut</b> <a href="../sui/object_table.md#sui_object_table_ObjectTable">ObjectTable</a>&lt;K, V&gt;</code>.
 Aborts with <code><a href="../sui/dynamic_field.md#sui_dynamic_field_EFieldDoesNotExist">sui::dynamic_field::EFieldDoesNotExist</a></code> if the table does not have an entry with
 that key <code>k: K</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/object_table.md#sui_object_table_borrow_mut">borrow_mut</a>&lt;K: <b>copy</b>, drop, store, V: key, store&gt;(<a href="../sui/table.md#sui_table">table</a>: &<b>mut</b> <a href="../sui/object_table.md#sui_object_table_ObjectTable">sui::object_table::ObjectTable</a>&lt;K, V&gt;, k: K): &<b>mut</b> V
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/object_table.md#sui_object_table_borrow_mut">borrow_mut</a>&lt;K: <b>copy</b>, drop, store, V: key, store&gt;(table: &<b>mut</b> <a href="../sui/object_table.md#sui_object_table_ObjectTable">sui::object_table::ObjectTable</a>&lt;K, V&gt;, k: K): &<b>mut</b> V
 </code></pre>
 
 
@@ -186,10 +186,10 @@ that key <code>k: K</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/object_table.md#sui_object_table_borrow_mut">borrow_mut</a>&lt;K: <b>copy</b> + drop + store, V: key + store&gt;(
-    <a href="../sui/table.md#sui_table">table</a>: &<b>mut</b> <a href="../sui/object_table.md#sui_object_table_ObjectTable">ObjectTable</a>&lt;K, V&gt;,
+    table: &<b>mut</b> <a href="../sui/object_table.md#sui_object_table_ObjectTable">ObjectTable</a>&lt;K, V&gt;,
     k: K,
 ): &<b>mut</b> V {
-    ofield::borrow_mut(&<b>mut</b> <a href="../sui/table.md#sui_table">table</a>.id, k)
+    ofield::borrow_mut(&<b>mut</b> table.id, k)
 }
 </code></pre>
 
@@ -201,12 +201,12 @@ that key <code>k: K</code>.
 
 ## Function `remove`
 
-Removes the key-value pair in the table <code><a href="../sui/table.md#sui_table">table</a>: &<b>mut</b> <a href="../sui/object_table.md#sui_object_table_ObjectTable">ObjectTable</a>&lt;K, V&gt;</code> and returns the value.
+Removes the key-value pair in the table <code>table: &<b>mut</b> <a href="../sui/object_table.md#sui_object_table_ObjectTable">ObjectTable</a>&lt;K, V&gt;</code> and returns the value.
 Aborts with <code><a href="../sui/dynamic_field.md#sui_dynamic_field_EFieldDoesNotExist">sui::dynamic_field::EFieldDoesNotExist</a></code> if the table does not have an entry with
 that key <code>k: K</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/object_table.md#sui_object_table_remove">remove</a>&lt;K: <b>copy</b>, drop, store, V: key, store&gt;(<a href="../sui/table.md#sui_table">table</a>: &<b>mut</b> <a href="../sui/object_table.md#sui_object_table_ObjectTable">sui::object_table::ObjectTable</a>&lt;K, V&gt;, k: K): V
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/object_table.md#sui_object_table_remove">remove</a>&lt;K: <b>copy</b>, drop, store, V: key, store&gt;(table: &<b>mut</b> <a href="../sui/object_table.md#sui_object_table_ObjectTable">sui::object_table::ObjectTable</a>&lt;K, V&gt;, k: K): V
 </code></pre>
 
 
@@ -215,9 +215,9 @@ that key <code>k: K</code>.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/object_table.md#sui_object_table_remove">remove</a>&lt;K: <b>copy</b> + drop + store, V: key + store&gt;(<a href="../sui/table.md#sui_table">table</a>: &<b>mut</b> <a href="../sui/object_table.md#sui_object_table_ObjectTable">ObjectTable</a>&lt;K, V&gt;, k: K): V {
-    <b>let</b> v = ofield::remove(&<b>mut</b> <a href="../sui/table.md#sui_table">table</a>.id, k);
-    <a href="../sui/table.md#sui_table">table</a>.size = <a href="../sui/table.md#sui_table">table</a>.size - 1;
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/object_table.md#sui_object_table_remove">remove</a>&lt;K: <b>copy</b> + drop + store, V: key + store&gt;(table: &<b>mut</b> <a href="../sui/object_table.md#sui_object_table_ObjectTable">ObjectTable</a>&lt;K, V&gt;, k: K): V {
+    <b>let</b> v = ofield::remove(&<b>mut</b> table.id, k);
+    table.size = table.size - 1;
     v
 }
 </code></pre>
@@ -231,10 +231,10 @@ that key <code>k: K</code>.
 ## Function `contains`
 
 Returns true if there is a value associated with the key <code>k: K</code> in table
-<code><a href="../sui/table.md#sui_table">table</a>: &<a href="../sui/object_table.md#sui_object_table_ObjectTable">ObjectTable</a>&lt;K, V&gt;</code>
+<code>table: &<a href="../sui/object_table.md#sui_object_table_ObjectTable">ObjectTable</a>&lt;K, V&gt;</code>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/object_table.md#sui_object_table_contains">contains</a>&lt;K: <b>copy</b>, drop, store, V: key, store&gt;(<a href="../sui/table.md#sui_table">table</a>: &<a href="../sui/object_table.md#sui_object_table_ObjectTable">sui::object_table::ObjectTable</a>&lt;K, V&gt;, k: K): bool
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/object_table.md#sui_object_table_contains">contains</a>&lt;K: <b>copy</b>, drop, store, V: key, store&gt;(table: &<a href="../sui/object_table.md#sui_object_table_ObjectTable">sui::object_table::ObjectTable</a>&lt;K, V&gt;, k: K): bool
 </code></pre>
 
 
@@ -243,8 +243,8 @@ Returns true if there is a value associated with the key <code>k: K</code> in ta
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/object_table.md#sui_object_table_contains">contains</a>&lt;K: <b>copy</b> + drop + store, V: key + store&gt;(<a href="../sui/table.md#sui_table">table</a>: &<a href="../sui/object_table.md#sui_object_table_ObjectTable">ObjectTable</a>&lt;K, V&gt;, k: K): bool {
-    ofield::exists_&lt;K&gt;(&<a href="../sui/table.md#sui_table">table</a>.id, k)
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/object_table.md#sui_object_table_contains">contains</a>&lt;K: <b>copy</b> + drop + store, V: key + store&gt;(table: &<a href="../sui/object_table.md#sui_object_table_ObjectTable">ObjectTable</a>&lt;K, V&gt;, k: K): bool {
+    ofield::exists_&lt;K&gt;(&table.id, k)
 }
 </code></pre>
 
@@ -259,7 +259,7 @@ Returns true if there is a value associated with the key <code>k: K</code> in ta
 Returns the size of the table, the number of key-value pairs
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/object_table.md#sui_object_table_length">length</a>&lt;K: <b>copy</b>, drop, store, V: key, store&gt;(<a href="../sui/table.md#sui_table">table</a>: &<a href="../sui/object_table.md#sui_object_table_ObjectTable">sui::object_table::ObjectTable</a>&lt;K, V&gt;): u64
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/object_table.md#sui_object_table_length">length</a>&lt;K: <b>copy</b>, drop, store, V: key, store&gt;(table: &<a href="../sui/object_table.md#sui_object_table_ObjectTable">sui::object_table::ObjectTable</a>&lt;K, V&gt;): u64
 </code></pre>
 
 
@@ -268,8 +268,8 @@ Returns the size of the table, the number of key-value pairs
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/object_table.md#sui_object_table_length">length</a>&lt;K: <b>copy</b> + drop + store, V: key + store&gt;(<a href="../sui/table.md#sui_table">table</a>: &<a href="../sui/object_table.md#sui_object_table_ObjectTable">ObjectTable</a>&lt;K, V&gt;): u64 {
-    <a href="../sui/table.md#sui_table">table</a>.size
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/object_table.md#sui_object_table_length">length</a>&lt;K: <b>copy</b> + drop + store, V: key + store&gt;(table: &<a href="../sui/object_table.md#sui_object_table_ObjectTable">ObjectTable</a>&lt;K, V&gt;): u64 {
+    table.size
 }
 </code></pre>
 
@@ -284,7 +284,7 @@ Returns the size of the table, the number of key-value pairs
 Returns true if the table is empty (if <code><a href="../sui/object_table.md#sui_object_table_length">length</a></code> returns <code>0</code>)
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/object_table.md#sui_object_table_is_empty">is_empty</a>&lt;K: <b>copy</b>, drop, store, V: key, store&gt;(<a href="../sui/table.md#sui_table">table</a>: &<a href="../sui/object_table.md#sui_object_table_ObjectTable">sui::object_table::ObjectTable</a>&lt;K, V&gt;): bool
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/object_table.md#sui_object_table_is_empty">is_empty</a>&lt;K: <b>copy</b>, drop, store, V: key, store&gt;(table: &<a href="../sui/object_table.md#sui_object_table_ObjectTable">sui::object_table::ObjectTable</a>&lt;K, V&gt;): bool
 </code></pre>
 
 
@@ -293,8 +293,8 @@ Returns true if the table is empty (if <code><a href="../sui/object_table.md#sui
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/object_table.md#sui_object_table_is_empty">is_empty</a>&lt;K: <b>copy</b> + drop + store, V: key + store&gt;(<a href="../sui/table.md#sui_table">table</a>: &<a href="../sui/object_table.md#sui_object_table_ObjectTable">ObjectTable</a>&lt;K, V&gt;): bool {
-    <a href="../sui/table.md#sui_table">table</a>.size == 0
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/object_table.md#sui_object_table_is_empty">is_empty</a>&lt;K: <b>copy</b> + drop + store, V: key + store&gt;(table: &<a href="../sui/object_table.md#sui_object_table_ObjectTable">ObjectTable</a>&lt;K, V&gt;): bool {
+    table.size == 0
 }
 </code></pre>
 
@@ -310,7 +310,7 @@ Destroys an empty table
 Aborts with <code><a href="../sui/object_table.md#sui_object_table_ETableNotEmpty">ETableNotEmpty</a></code> if the table still contains values
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/object_table.md#sui_object_table_destroy_empty">destroy_empty</a>&lt;K: <b>copy</b>, drop, store, V: key, store&gt;(<a href="../sui/table.md#sui_table">table</a>: <a href="../sui/object_table.md#sui_object_table_ObjectTable">sui::object_table::ObjectTable</a>&lt;K, V&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/object_table.md#sui_object_table_destroy_empty">destroy_empty</a>&lt;K: <b>copy</b>, drop, store, V: key, store&gt;(table: <a href="../sui/object_table.md#sui_object_table_ObjectTable">sui::object_table::ObjectTable</a>&lt;K, V&gt;)
 </code></pre>
 
 
@@ -319,8 +319,8 @@ Aborts with <code><a href="../sui/object_table.md#sui_object_table_ETableNotEmpt
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/object_table.md#sui_object_table_destroy_empty">destroy_empty</a>&lt;K: <b>copy</b> + drop + store, V: key + store&gt;(<a href="../sui/table.md#sui_table">table</a>: <a href="../sui/object_table.md#sui_object_table_ObjectTable">ObjectTable</a>&lt;K, V&gt;) {
-    <b>let</b> <a href="../sui/object_table.md#sui_object_table_ObjectTable">ObjectTable</a> { id, size } = <a href="../sui/table.md#sui_table">table</a>;
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/object_table.md#sui_object_table_destroy_empty">destroy_empty</a>&lt;K: <b>copy</b> + drop + store, V: key + store&gt;(table: <a href="../sui/object_table.md#sui_object_table_ObjectTable">ObjectTable</a>&lt;K, V&gt;) {
+    <b>let</b> <a href="../sui/object_table.md#sui_object_table_ObjectTable">ObjectTable</a> { id, size } = table;
     <b>assert</b>!(size == 0, <a href="../sui/object_table.md#sui_object_table_ETableNotEmpty">ETableNotEmpty</a>);
     id.delete()
 }
@@ -338,7 +338,7 @@ Returns the ID of the object associated with the key if the table has an entry w
 Returns none otherwise
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/object_table.md#sui_object_table_value_id">value_id</a>&lt;K: <b>copy</b>, drop, store, V: key, store&gt;(<a href="../sui/table.md#sui_table">table</a>: &<a href="../sui/object_table.md#sui_object_table_ObjectTable">sui::object_table::ObjectTable</a>&lt;K, V&gt;, k: K): <a href="../std/option.md#std_option_Option">std::option::Option</a>&lt;<a href="../sui/object.md#sui_object_ID">sui::object::ID</a>&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/object_table.md#sui_object_table_value_id">value_id</a>&lt;K: <b>copy</b>, drop, store, V: key, store&gt;(table: &<a href="../sui/object_table.md#sui_object_table_ObjectTable">sui::object_table::ObjectTable</a>&lt;K, V&gt;, k: K): <a href="../std/option.md#std_option_Option">std::option::Option</a>&lt;<a href="../sui/object.md#sui_object_ID">sui::object::ID</a>&gt;
 </code></pre>
 
 
@@ -348,10 +348,10 @@ Returns none otherwise
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/object_table.md#sui_object_table_value_id">value_id</a>&lt;K: <b>copy</b> + drop + store, V: key + store&gt;(
-    <a href="../sui/table.md#sui_table">table</a>: &<a href="../sui/object_table.md#sui_object_table_ObjectTable">ObjectTable</a>&lt;K, V&gt;,
+    table: &<a href="../sui/object_table.md#sui_object_table_ObjectTable">ObjectTable</a>&lt;K, V&gt;,
     k: K,
 ): Option&lt;ID&gt; {
-    ofield::id(&<a href="../sui/table.md#sui_table">table</a>.id, k)
+    ofield::id(&table.id, k)
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/sui/package.md
+++ b/crates/sui-framework/docs/sui/package.md
@@ -704,13 +704,13 @@ package.  This ticket only authorizes an upgrade to a package
 that matches this digest.  A package's contents are identified
 by two things:
 
-- modules: [[u8]]       a list of the package's module contents
-- deps:    [[u8; 32]]   a list of 32 byte ObjectIDs of the
-package's transitive dependencies
+ - modules: [[u8]]       a list of the package's module contents
+ - deps:    [[u8; 32]]   a list of 32 byte ObjectIDs of the
+                         package's transitive dependencies
 
 A package's digest is calculated as:
 
-sha3_256(sort(modules ++ deps))
+  sha3_256(sort(modules ++ deps))
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/package.md#sui_package_ticket_digest">ticket_digest</a>(ticket: &<a href="../sui/package.md#sui_package_UpgradeTicket">sui::package::UpgradeTicket</a>): &vector&lt;u8&gt;

--- a/crates/sui-framework/docs/sui/package.md
+++ b/crates/sui-framework/docs/sui/package.md
@@ -83,7 +83,7 @@ a type originated from.
 <dd>
 </dd>
 <dt>
-<code><a href="../sui/package.md#sui_package">package</a>: <a href="../std/ascii.md#std_ascii_String">std::ascii::String</a></code>
+<code>package: <a href="../std/ascii.md#std_ascii_String">std::ascii::String</a></code>
 </dt>
 <dd>
 </dd>
@@ -120,7 +120,7 @@ Capability controlling the ability to upgrade a package.
 <dd>
 </dd>
 <dt>
-<code><a href="../sui/package.md#sui_package">package</a>: <a href="../sui/object.md#sui_object_ID">sui::object::ID</a></code>
+<code>package: <a href="../sui/object.md#sui_object_ID">sui::object::ID</a></code>
 </dt>
 <dd>
  (Mutable) ID of the package that can be upgraded.
@@ -174,7 +174,7 @@ progress.
  (Immutable) ID of the <code><a href="../sui/package.md#sui_package_UpgradeCap">UpgradeCap</a></code> this originated from.
 </dd>
 <dt>
-<code><a href="../sui/package.md#sui_package">package</a>: <a href="../sui/object.md#sui_object_ID">sui::object::ID</a></code>
+<code>package: <a href="../sui/object.md#sui_object_ID">sui::object::ID</a></code>
 </dt>
 <dd>
  (Immutable) ID of the package that can be upgraded.
@@ -225,7 +225,7 @@ the end of the transaction that performed the upgrade.
  (Immutable) ID of the <code><a href="../sui/package.md#sui_package_UpgradeCap">UpgradeCap</a></code> this originated from.
 </dd>
 <dt>
-<code><a href="../sui/package.md#sui_package">package</a>: <a href="../sui/object.md#sui_object_ID">sui::object::ID</a></code>
+<code>package: <a href="../sui/object.md#sui_object_ID">sui::object::ID</a></code>
 </dt>
 <dd>
  (Immutable) ID of the package after it was upgraded.
@@ -343,11 +343,11 @@ but multiple per package (!).
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/package.md#sui_package_claim">claim</a>&lt;OTW: drop&gt;(otw: OTW, ctx: &<b>mut</b> TxContext): <a href="../sui/package.md#sui_package_Publisher">Publisher</a> {
-    <b>assert</b>!(<a href="../sui/types.md#sui_types_is_one_time_witness">types::is_one_time_witness</a>(&otw), <a href="../sui/package.md#sui_package_ENotOneTimeWitness">ENotOneTimeWitness</a>);
+    <b>assert</b>!(types::is_one_time_witness(&otw), <a href="../sui/package.md#sui_package_ENotOneTimeWitness">ENotOneTimeWitness</a>);
     <b>let</b> type_name = type_name::with_original_ids&lt;OTW&gt;();
     <a href="../sui/package.md#sui_package_Publisher">Publisher</a> {
-        id: <a href="../sui/object.md#sui_object_new">object::new</a>(ctx),
-        <a href="../sui/package.md#sui_package">package</a>: type_name.address_string(),
+        id: object::new(ctx),
+        package: type_name.address_string(),
         module_name: type_name.module_string(),
     }
 }
@@ -402,7 +402,7 @@ associated with it.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/package.md#sui_package_burn_publisher">burn_publisher</a>(self: <a href="../sui/package.md#sui_package_Publisher">Publisher</a>) {
-    <b>let</b> <a href="../sui/package.md#sui_package_Publisher">Publisher</a> { id, <a href="../sui/package.md#sui_package">package</a>: _, module_name: _ } = self;
+    <b>let</b> <a href="../sui/package.md#sui_package_Publisher">Publisher</a> { id, package: _, module_name: _ } = self;
     id.delete();
 }
 </code></pre>
@@ -428,7 +428,7 @@ Check whether type belongs to the same package as the publisher object.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/package.md#sui_package_from_package">from_package</a>&lt;T&gt;(self: &<a href="../sui/package.md#sui_package_Publisher">Publisher</a>): bool {
-    type_name::with_original_ids&lt;T&gt;().address_string() == self.<a href="../sui/package.md#sui_package">package</a>
+    type_name::with_original_ids&lt;T&gt;().address_string() == self.package
 }
 </code></pre>
 
@@ -454,7 +454,7 @@ Check whether a type belongs to the same module as the publisher object.
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/package.md#sui_package_from_module">from_module</a>&lt;T&gt;(self: &<a href="../sui/package.md#sui_package_Publisher">Publisher</a>): bool {
     <b>let</b> type_name = type_name::with_original_ids&lt;T&gt;();
-    (type_name.address_string() == self.<a href="../sui/package.md#sui_package">package</a>) && (type_name.module_string() == self.module_name)
+    (type_name.address_string() == self.package) && (type_name.module_string() == self.module_name)
 }
 </code></pre>
 
@@ -504,7 +504,7 @@ Read the package address string.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/package.md#sui_package_published_package">published_package</a>(self: &<a href="../sui/package.md#sui_package_Publisher">Publisher</a>): &String {
-    &self.<a href="../sui/package.md#sui_package">package</a>
+    &self.package
 }
 </code></pre>
 
@@ -533,7 +533,7 @@ package.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/package.md#sui_package_upgrade_package">upgrade_package</a>(cap: &<a href="../sui/package.md#sui_package_UpgradeCap">UpgradeCap</a>): ID {
-    cap.<a href="../sui/package.md#sui_package">package</a>
+    cap.package
 }
 </code></pre>
 
@@ -610,7 +610,7 @@ The package that this ticket is authorized to upgrade
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/package.md#sui_package_ticket_package">ticket_package</a>(ticket: &<a href="../sui/package.md#sui_package_UpgradeTicket">UpgradeTicket</a>): ID {
-    ticket.<a href="../sui/package.md#sui_package">package</a>
+    ticket.package
 }
 </code></pre>
 
@@ -687,7 +687,7 @@ the package, as of the upgrade represented by this <code>receipt</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/package.md#sui_package_receipt_package">receipt_package</a>(receipt: &<a href="../sui/package.md#sui_package_UpgradeReceipt">UpgradeReceipt</a>): ID {
-    receipt.<a href="../sui/package.md#sui_package">package</a>
+    receipt.package
 }
 </code></pre>
 
@@ -867,7 +867,7 @@ Discard the <code><a href="../sui/package.md#sui_package_UpgradeCap">UpgradeCap<
 
 
 <pre><code><b>public</b> <b>entry</b> <b>fun</b> <a href="../sui/package.md#sui_package_make_immutable">make_immutable</a>(cap: <a href="../sui/package.md#sui_package_UpgradeCap">UpgradeCap</a>) {
-    <b>let</b> <a href="../sui/package.md#sui_package_UpgradeCap">UpgradeCap</a> { id, <a href="../sui/package.md#sui_package">package</a>: _, <a href="../sui/package.md#sui_package_version">version</a>: _, policy: _ } = cap;
+    <b>let</b> <a href="../sui/package.md#sui_package_UpgradeCap">UpgradeCap</a> { id, package: _, <a href="../sui/package.md#sui_package_version">version</a>: _, policy: _ } = cap;
     id.delete();
 }
 </code></pre>
@@ -903,13 +903,13 @@ for the upgrade to succeed.
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/package.md#sui_package_authorize_upgrade">authorize_upgrade</a>(cap: &<b>mut</b> <a href="../sui/package.md#sui_package_UpgradeCap">UpgradeCap</a>, policy: u8, digest: vector&lt;u8&gt;): <a href="../sui/package.md#sui_package_UpgradeTicket">UpgradeTicket</a> {
     <b>let</b> id_zero = @0x0.to_id();
-    <b>assert</b>!(cap.<a href="../sui/package.md#sui_package">package</a> != id_zero, <a href="../sui/package.md#sui_package_EAlreadyAuthorized">EAlreadyAuthorized</a>);
+    <b>assert</b>!(cap.package != id_zero, <a href="../sui/package.md#sui_package_EAlreadyAuthorized">EAlreadyAuthorized</a>);
     <b>assert</b>!(policy &gt;= cap.policy, <a href="../sui/package.md#sui_package_ETooPermissive">ETooPermissive</a>);
-    <b>let</b> <a href="../sui/package.md#sui_package">package</a> = cap.<a href="../sui/package.md#sui_package">package</a>;
-    cap.<a href="../sui/package.md#sui_package">package</a> = id_zero;
+    <b>let</b> package = cap.package;
+    cap.package = id_zero;
     <a href="../sui/package.md#sui_package_UpgradeTicket">UpgradeTicket</a> {
-        cap: <a href="../sui/object.md#sui_object_id">object::id</a>(cap),
-        <a href="../sui/package.md#sui_package">package</a>,
+        cap: object::id(cap),
+        package,
         policy,
         digest,
     }
@@ -938,10 +938,10 @@ the upgrade.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/package.md#sui_package_commit_upgrade">commit_upgrade</a>(cap: &<b>mut</b> <a href="../sui/package.md#sui_package_UpgradeCap">UpgradeCap</a>, receipt: <a href="../sui/package.md#sui_package_UpgradeReceipt">UpgradeReceipt</a>) {
-    <b>let</b> <a href="../sui/package.md#sui_package_UpgradeReceipt">UpgradeReceipt</a> { cap: cap_id, <a href="../sui/package.md#sui_package">package</a> } = receipt;
-    <b>assert</b>!(<a href="../sui/object.md#sui_object_id">object::id</a>(cap) == cap_id, <a href="../sui/package.md#sui_package_EWrongUpgradeCap">EWrongUpgradeCap</a>);
-    <b>assert</b>!(cap.<a href="../sui/package.md#sui_package">package</a>.to_address() == @0x0, <a href="../sui/package.md#sui_package_ENotAuthorized">ENotAuthorized</a>);
-    cap.<a href="../sui/package.md#sui_package">package</a> = <a href="../sui/package.md#sui_package">package</a>;
+    <b>let</b> <a href="../sui/package.md#sui_package_UpgradeReceipt">UpgradeReceipt</a> { cap: cap_id, package } = receipt;
+    <b>assert</b>!(object::id(cap) == cap_id, <a href="../sui/package.md#sui_package_EWrongUpgradeCap">EWrongUpgradeCap</a>);
+    <b>assert</b>!(cap.package.to_address() == @0x0, <a href="../sui/package.md#sui_package_ENotAuthorized">ENotAuthorized</a>);
+    cap.package = package;
     cap.<a href="../sui/package.md#sui_package_version">version</a> = cap.<a href="../sui/package.md#sui_package_version">version</a> + 1;
 }
 </code></pre>

--- a/crates/sui-framework/docs/sui/party.md
+++ b/crates/sui-framework/docs/sui/party.md
@@ -195,7 +195,7 @@ has any permissions. And there are no default permissions.
 A helper <code><b>macro</b></code> that calls <code><a href="../sui/transfer.md#sui_transfer_party_transfer">sui::transfer::party_transfer</a></code>.
 
 
-<pre><code><b>public</b> <b>macro</b> <b>fun</b> <a href="../sui/transfer.md#sui_transfer">transfer</a>&lt;$T: key&gt;($self: <a href="../sui/party.md#sui_party_Party">sui::party::Party</a>, $obj: $T)
+<pre><code><b>public</b> <b>macro</b> <b>fun</b> <a href="../sui/party.md#sui_party_transfer">transfer</a>&lt;$T: key&gt;($self: <a href="../sui/party.md#sui_party_Party">sui::party::Party</a>, $obj: $T)
 </code></pre>
 
 
@@ -204,7 +204,7 @@ A helper <code><b>macro</b></code> that calls <code><a href="../sui/transfer.md#
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>macro</b> <b>fun</b> <a href="../sui/transfer.md#sui_transfer">transfer</a>&lt;$T: key&gt;($self: <a href="../sui/party.md#sui_party_Party">Party</a>, $obj: $T) {
+<pre><code><b>public</b> <b>macro</b> <b>fun</b> <a href="../sui/party.md#sui_party_transfer">transfer</a>&lt;$T: key&gt;($self: <a href="../sui/party.md#sui_party_Party">Party</a>, $obj: $T) {
     <b>let</b> mp = $self;
     <a href="../sui/transfer.md#sui_transfer_party_transfer">sui::transfer::party_transfer</a>($obj, mp)
 }
@@ -258,7 +258,7 @@ A helper <code><b>macro</b></code> that calls <code><a href="../sui/transfer.md#
 <pre><code><b>fun</b> <a href="../sui/party.md#sui_party_empty">empty</a>(): <a href="../sui/party.md#sui_party_Party">Party</a> {
 <a href="../sui/party.md#sui_party_Party">Party</a> {
 default: <a href="../sui/party.md#sui_party_Permissions">Permissions</a>(<a href="../sui/party.md#sui_party_NO_PERMISSIONS">NO_PERMISSIONS</a>),
-members: <a href="../sui/vec_map.md#sui_vec_map_empty">vec_map::empty</a>(),
+members: vec_map::empty(),
 }
 }
 </code></pre>
@@ -300,7 +300,7 @@ p.members.insert(<b>address</b>, permissions);
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/party.md#sui_party_is_single_owner">is_single_owner</a>(p: &<a href="../sui/party.md#sui_party_Party">sui::party::Party</a>): bool
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/party.md#sui_party_is_single_owner">is_single_owner</a>(p: &<a href="../sui/party.md#sui_party_Party">sui::party::Party</a>): bool
 </code></pre>
 
 
@@ -309,7 +309,7 @@ p.members.insert(<b>address</b>, permissions);
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/party.md#sui_party_is_single_owner">is_single_owner</a>(p: &<a href="../sui/party.md#sui_party_Party">Party</a>): bool {
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/party.md#sui_party_is_single_owner">is_single_owner</a>(p: &<a href="../sui/party.md#sui_party_Party">Party</a>): bool {
     p.default.0 == <a href="../sui/party.md#sui_party_NO_PERMISSIONS">NO_PERMISSIONS</a> &&
     p.members.length() == 1 &&
     { <b>let</b> (_, m) = p.members.get_entry_by_idx(0); m.0 == <a href="../sui/party.md#sui_party_ALL_PERMISSIONS">ALL_PERMISSIONS</a> }
@@ -326,7 +326,7 @@ p.members.insert(<b>address</b>, permissions);
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/party.md#sui_party_into_native">into_native</a>(p: <a href="../sui/party.md#sui_party_Party">sui::party::Party</a>): (u64, vector&lt;<b>address</b>&gt;, vector&lt;u64&gt;)
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/party.md#sui_party_into_native">into_native</a>(p: <a href="../sui/party.md#sui_party_Party">sui::party::Party</a>): (u64, vector&lt;<b>address</b>&gt;, vector&lt;u64&gt;)
 </code></pre>
 
 
@@ -335,7 +335,7 @@ p.members.insert(<b>address</b>, permissions);
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/party.md#sui_party_into_native">into_native</a>(p: <a href="../sui/party.md#sui_party_Party">Party</a>): (u64, vector&lt;<b>address</b>&gt;, vector&lt;u64&gt;) {
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/party.md#sui_party_into_native">into_native</a>(p: <a href="../sui/party.md#sui_party_Party">Party</a>): (u64, vector&lt;<b>address</b>&gt;, vector&lt;u64&gt;) {
     <b>let</b> <a href="../sui/party.md#sui_party_Party">Party</a> { default, members } = p;
     <b>let</b> (addresses, permissions) = members.into_keys_values();
     <b>let</b> permissions = permissions.map!(|<a href="../sui/party.md#sui_party_Permissions">Permissions</a>(x)| x);

--- a/crates/sui-framework/docs/sui/pay.md
+++ b/crates/sui-framework/docs/sui/pay.md
@@ -86,7 +86,7 @@ Transfer <code>c</code> to the sender of the current transaction
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/pay.md#sui_pay_keep">keep</a>&lt;T&gt;(c: Coin&lt;T&gt;, ctx: &TxContext) {
-    <a href="../sui/transfer.md#sui_transfer_public_transfer">transfer::public_transfer</a>(c, ctx.sender())
+    transfer::public_transfer(c, ctx.sender())
 }
 </code></pre>
 
@@ -98,11 +98,11 @@ Transfer <code>c</code> to the sender of the current transaction
 
 ## Function `split`
 
-Split <code><a href="../sui/coin.md#sui_coin">coin</a></code> to two coins, one with balance <code>split_amount</code>,
-and the remaining balance is left in <code><a href="../sui/coin.md#sui_coin">coin</a></code>.
+Split <code>coin</code> to two coins, one with balance <code>split_amount</code>,
+and the remaining balance is left in <code>coin</code>.
 
 
-<pre><code><b>public</b> <b>entry</b> <b>fun</b> <a href="../sui/pay.md#sui_pay_split">split</a>&lt;T&gt;(<a href="../sui/coin.md#sui_coin">coin</a>: &<b>mut</b> <a href="../sui/coin.md#sui_coin_Coin">sui::coin::Coin</a>&lt;T&gt;, split_amount: u64, ctx: &<b>mut</b> <a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>)
+<pre><code><b>public</b> <b>entry</b> <b>fun</b> <a href="../sui/pay.md#sui_pay_split">split</a>&lt;T&gt;(coin: &<b>mut</b> <a href="../sui/coin.md#sui_coin_Coin">sui::coin::Coin</a>&lt;T&gt;, split_amount: u64, ctx: &<b>mut</b> <a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -111,8 +111,8 @@ and the remaining balance is left in <code><a href="../sui/coin.md#sui_coin">coi
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>entry</b> <b>fun</b> <a href="../sui/pay.md#sui_pay_split">split</a>&lt;T&gt;(<a href="../sui/coin.md#sui_coin">coin</a>: &<b>mut</b> Coin&lt;T&gt;, split_amount: u64, ctx: &<b>mut</b> TxContext) {
-    <a href="../sui/pay.md#sui_pay_keep">keep</a>(<a href="../sui/coin.md#sui_coin">coin</a>.<a href="../sui/pay.md#sui_pay_split">split</a>(split_amount, ctx), ctx)
+<pre><code><b>public</b> <b>entry</b> <b>fun</b> <a href="../sui/pay.md#sui_pay_split">split</a>&lt;T&gt;(coin: &<b>mut</b> Coin&lt;T&gt;, split_amount: u64, ctx: &<b>mut</b> TxContext) {
+    <a href="../sui/pay.md#sui_pay_keep">keep</a>(coin.<a href="../sui/pay.md#sui_pay_split">split</a>(split_amount, ctx), ctx)
 }
 </code></pre>
 
@@ -169,7 +169,7 @@ Aborts with <code><a href="../sui/balance.md#sui_balance_ENotEnough">sui::balanc
     recipient: <b>address</b>,
     ctx: &<b>mut</b> TxContext,
 ) {
-    <a href="../sui/transfer.md#sui_transfer_public_transfer">transfer::public_transfer</a>(c.<a href="../sui/pay.md#sui_pay_split">split</a>(amount, ctx), recipient)
+    transfer::public_transfer(c.<a href="../sui/pay.md#sui_pay_split">split</a>(amount, ctx), recipient)
 }
 </code></pre>
 
@@ -195,7 +195,7 @@ not evenly divisible by <code>n</code>, the remainder is left in <code>self</cod
 
 
 <pre><code><b>public</b> <b>entry</b> <b>fun</b> <a href="../sui/pay.md#sui_pay_divide_and_keep">divide_and_keep</a>&lt;T&gt;(self: &<b>mut</b> Coin&lt;T&gt;, n: u64, ctx: &<b>mut</b> TxContext) {
-    self.divide_into_n(n, ctx).destroy!(|<a href="../sui/coin.md#sui_coin">coin</a>| <a href="../sui/transfer.md#sui_transfer_public_transfer">transfer::public_transfer</a>(<a href="../sui/coin.md#sui_coin">coin</a>, ctx.sender()));
+    self.divide_into_n(n, ctx).destroy!(|coin| transfer::public_transfer(coin, ctx.sender()));
 }
 </code></pre>
 
@@ -207,11 +207,11 @@ not evenly divisible by <code>n</code>, the remainder is left in <code>self</cod
 
 ## Function `join`
 
-Join <code><a href="../sui/coin.md#sui_coin">coin</a></code> into <code>self</code>. Re-exports <code><a href="../sui/coin.md#sui_coin_join">coin::join</a></code> function.
-Deprecated: you should call <code><a href="../sui/coin.md#sui_coin">coin</a>.<a href="../sui/pay.md#sui_pay_join">join</a>(other)</code> directly.
+Join <code>coin</code> into <code>self</code>. Re-exports <code>coin::join</code> function.
+Deprecated: you should call <code>coin.<a href="../sui/pay.md#sui_pay_join">join</a>(other)</code> directly.
 
 
-<pre><code><b>public</b> <b>entry</b> <b>fun</b> <a href="../sui/pay.md#sui_pay_join">join</a>&lt;T&gt;(self: &<b>mut</b> <a href="../sui/coin.md#sui_coin_Coin">sui::coin::Coin</a>&lt;T&gt;, <a href="../sui/coin.md#sui_coin">coin</a>: <a href="../sui/coin.md#sui_coin_Coin">sui::coin::Coin</a>&lt;T&gt;)
+<pre><code><b>public</b> <b>entry</b> <b>fun</b> <a href="../sui/pay.md#sui_pay_join">join</a>&lt;T&gt;(self: &<b>mut</b> <a href="../sui/coin.md#sui_coin_Coin">sui::coin::Coin</a>&lt;T&gt;, coin: <a href="../sui/coin.md#sui_coin_Coin">sui::coin::Coin</a>&lt;T&gt;)
 </code></pre>
 
 
@@ -220,8 +220,8 @@ Deprecated: you should call <code><a href="../sui/coin.md#sui_coin">coin</a>.<a 
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>entry</b> <b>fun</b> <a href="../sui/pay.md#sui_pay_join">join</a>&lt;T&gt;(self: &<b>mut</b> Coin&lt;T&gt;, <a href="../sui/coin.md#sui_coin">coin</a>: Coin&lt;T&gt;) {
-    self.<a href="../sui/pay.md#sui_pay_join">join</a>(<a href="../sui/coin.md#sui_coin">coin</a>)
+<pre><code><b>public</b> <b>entry</b> <b>fun</b> <a href="../sui/pay.md#sui_pay_join">join</a>&lt;T&gt;(self: &<b>mut</b> Coin&lt;T&gt;, coin: Coin&lt;T&gt;) {
+    self.<a href="../sui/pay.md#sui_pay_join">join</a>(coin)
 }
 </code></pre>
 
@@ -246,7 +246,7 @@ Join everything in <code>coins</code> with <code>self</code>
 
 
 <pre><code><b>public</b> <b>entry</b> <b>fun</b> <a href="../sui/pay.md#sui_pay_join_vec">join_vec</a>&lt;T&gt;(self: &<b>mut</b> Coin&lt;T&gt;, coins: vector&lt;Coin&lt;T&gt;&gt;) {
-    coins.destroy!(|<a href="../sui/coin.md#sui_coin">coin</a>| self.<a href="../sui/pay.md#sui_pay_join">join</a>(<a href="../sui/coin.md#sui_coin">coin</a>));
+    coins.destroy!(|coin| self.<a href="../sui/pay.md#sui_pay_join">join</a>(coin));
 }
 </code></pre>
 
@@ -274,7 +274,7 @@ Join a vector of <code>Coin</code> into a single object and transfer it to <code
     <b>assert</b>!(coins.length() &gt; 0, <a href="../sui/pay.md#sui_pay_ENoCoins">ENoCoins</a>);
     <b>let</b> <b>mut</b> self = coins.pop_back();
     <a href="../sui/pay.md#sui_pay_join_vec">join_vec</a>(&<b>mut</b> self, coins);
-    <a href="../sui/transfer.md#sui_transfer_public_transfer">transfer::public_transfer</a>(self, receiver)
+    transfer::public_transfer(self, receiver)
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/sui/poseidon.md
+++ b/crates/sui-framework/docs/sui/poseidon.md
@@ -110,10 +110,10 @@ If more than 16 inputs are provided, the function will abort with ETooManyInputs
     <b>assert</b>!(data.length() &lt;= <a href="../sui/poseidon.md#sui_poseidon_MAX_INPUTS">MAX_INPUTS</a>, <a href="../sui/poseidon.md#sui_poseidon_ETooManyInputs">ETooManyInputs</a>);
     <b>let</b> b = data.map_ref!(|e| {
         <b>assert</b>!(*e &lt; <a href="../sui/poseidon.md#sui_poseidon_BN254_MAX">BN254_MAX</a>, <a href="../sui/poseidon.md#sui_poseidon_ENonCanonicalInput">ENonCanonicalInput</a>);
-        <a href="../sui/bcs.md#sui_bcs_to_bytes">bcs::to_bytes</a>(e)
+        bcs::to_bytes(e)
     });
     <b>let</b> binary_output = <a href="../sui/poseidon.md#sui_poseidon_poseidon_bn254_internal">poseidon_bn254_internal</a>(&b);
-    <a href="../sui/bcs.md#sui_bcs_new">bcs::new</a>(binary_output).peel_u256()
+    bcs::new(binary_output).peel_u256()
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/sui/protocol_config.md
+++ b/crates/sui-framework/docs/sui/protocol_config.md
@@ -33,8 +33,8 @@ We should never need to expose this to user packages.
 ### Arguments
 
 * <code>feature_flag_name</code> - The name of the feature flag as bytes (e.g., b"enable_vdf")
-- It is expected to be a valid UTF-8 string
-- The flag should exist in the protocol config
+  - It is expected to be a valid UTF-8 string
+  - The flag should exist in the protocol config
 
 
 <a name="@Returns_1"></a>
@@ -53,7 +53,7 @@ We should never need to expose this to user packages.
 use sui::protocol_config;
 
 if (protocol_config::is_feature_enabled(b"enable_accumulators")) {
-// Accumulators are available
+    // Accumulators are available
 };
 ```
 

--- a/crates/sui-framework/docs/sui/protocol_config.md
+++ b/crates/sui-framework/docs/sui/protocol_config.md
@@ -58,7 +58,7 @@ if (protocol_config::is_feature_enabled(b"enable_accumulators")) {
 ```
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/protocol_config.md#sui_protocol_config_is_feature_enabled">is_feature_enabled</a>(feature_flag_name: vector&lt;u8&gt;): bool
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/protocol_config.md#sui_protocol_config_is_feature_enabled">is_feature_enabled</a>(feature_flag_name: vector&lt;u8&gt;): bool
 </code></pre>
 
 
@@ -67,7 +67,7 @@ if (protocol_config::is_feature_enabled(b"enable_accumulators")) {
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>native</b> <b>fun</b> <a href="../sui/protocol_config.md#sui_protocol_config_is_feature_enabled">is_feature_enabled</a>(feature_flag_name: vector&lt;u8&gt;): bool;
+<pre><code><b>public</b>(package) <b>native</b> <b>fun</b> <a href="../sui/protocol_config.md#sui_protocol_config_is_feature_enabled">is_feature_enabled</a>(feature_flag_name: vector&lt;u8&gt;): bool;
 </code></pre>
 
 

--- a/crates/sui-framework/docs/sui/random.md
+++ b/crates/sui-framework/docs/sui/random.md
@@ -268,10 +268,10 @@ Can only be called by genesis or change_epoch transactions.
         random_bytes: vector[],
     };
     <b>let</b> self = <a href="../sui/random.md#sui_random_Random">Random</a> {
-        id: <a href="../sui/object.md#sui_object_randomness_state">object::randomness_state</a>(),
-        inner: <a href="../sui/versioned.md#sui_versioned_create">versioned::create</a>(version, inner, ctx),
+        id: object::randomness_state(),
+        inner: versioned::create(version, inner, ctx),
     };
-    <a href="../sui/transfer.md#sui_transfer_share_object">transfer::share_object</a>(self);
+    transfer::share_object(self);
 }
 </code></pre>
 
@@ -295,8 +295,8 @@ Can only be called by genesis or change_epoch transactions.
 
 
 <pre><code><b>fun</b> <a href="../sui/random.md#sui_random_load_inner_mut">load_inner_mut</a>(self: &<b>mut</b> <a href="../sui/random.md#sui_random_Random">Random</a>): &<b>mut</b> <a href="../sui/random.md#sui_random_RandomInner">RandomInner</a> {
-    <b>let</b> version = <a href="../sui/versioned.md#sui_versioned_version">versioned::version</a>(&self.inner);
-    // Replace this with a lazy update function when we add a new version of the inner <a href="../sui/object.md#sui_object">object</a>.
+    <b>let</b> version = versioned::version(&self.inner);
+    // Replace this with a lazy update function when we add a new version of the inner object.
     <b>assert</b>!(version == <a href="../sui/random.md#sui_random_CURRENT_VERSION">CURRENT_VERSION</a>, <a href="../sui/random.md#sui_random_EWrongInnerVersion">EWrongInnerVersion</a>);
     <b>let</b> inner: &<b>mut</b> <a href="../sui/random.md#sui_random_RandomInner">RandomInner</a> = self.inner.load_value_mut();
     <b>assert</b>!(inner.version == version, <a href="../sui/random.md#sui_random_EWrongInnerVersion">EWrongInnerVersion</a>);
@@ -325,7 +325,7 @@ Can only be called by genesis or change_epoch transactions.
 
 <pre><code><b>fun</b> <a href="../sui/random.md#sui_random_load_inner">load_inner</a>(self: &<a href="../sui/random.md#sui_random_Random">Random</a>): &<a href="../sui/random.md#sui_random_RandomInner">RandomInner</a> {
     <b>let</b> version = self.inner.version();
-    // Replace this with a lazy update function when we add a new version of the inner <a href="../sui/object.md#sui_object">object</a>.
+    // Replace this with a lazy update function when we add a new version of the inner object.
     <b>assert</b>!(version == <a href="../sui/random.md#sui_random_CURRENT_VERSION">CURRENT_VERSION</a>, <a href="../sui/random.md#sui_random_EWrongInnerVersion">EWrongInnerVersion</a>);
     <b>let</b> inner: &<a href="../sui/random.md#sui_random_RandomInner">RandomInner</a> = self.inner.load_value();
     <b>assert</b>!(inner.version == version, <a href="../sui/random.md#sui_random_EWrongInnerVersion">EWrongInnerVersion</a>);
@@ -441,7 +441,7 @@ Get the next block of 32 random bytes.
 
 <pre><code><b>fun</b> <a href="../sui/random.md#sui_random_derive_next_block">derive_next_block</a>(g: &<b>mut</b> <a href="../sui/random.md#sui_random_RandomGenerator">RandomGenerator</a>): vector&lt;u8&gt; {
     g.counter = g.counter + 1;
-    hmac_sha3_256(&g.seed, &<a href="../sui/bcs.md#sui_bcs_to_bytes">bcs::to_bytes</a>(&g.counter))
+    hmac_sha3_256(&g.seed, &bcs::to_bytes(&g.counter))
 }
 </code></pre>
 
@@ -726,8 +726,8 @@ than the actual type used by the caller function to limit the bias by 2^{-64}).
     <b>let</b> max = $max;
     <b>assert</b>!(min &lt;= max, <a href="../sui/random.md#sui_random_EInvalidRange">EInvalidRange</a>);
     <b>if</b> (min == max) <b>return</b> min;
-    // Pick a <a href="../sui/random.md#sui_random">random</a> number in [0, max - min] by generating a <a href="../sui/random.md#sui_random">random</a> number that is larger than max-min, and taking
-    // the modulo of the <a href="../sui/random.md#sui_random">random</a> number by the range size. Then add the min to the result to get a number in
+    // Pick a random number in [0, max - min] by generating a random number that is larger than max-min, and taking
+    // the modulo of the random number by the range size. Then add the min to the result to get a number in
     // [min, max].
     <b>let</b> range_size = (max - min) <b>as</b> u256 + 1;
     <b>let</b> rand = <a href="../sui/random.md#sui_random_uint_from_bytes">uint_from_bytes</a>!($g, $num_of_bytes);

--- a/crates/sui-framework/docs/sui/ristretto255.md
+++ b/crates/sui-framework/docs/sui/ristretto255.md
@@ -159,7 +159,7 @@ Only available in devnet.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/ristretto255.md#sui_ristretto255_scalar_from_bytes">scalar_from_bytes</a>(bytes: &vector&lt;u8&gt;): Element&lt;<a href="../sui/ristretto255.md#sui_ristretto255_Scalar">Scalar</a>&gt; {
-    <a href="../sui/group_ops.md#sui_group_ops_from_bytes">group_ops::from_bytes</a>(<a href="../sui/ristretto255.md#sui_ristretto255_SCALAR_TYPE">SCALAR_TYPE</a>, *bytes, <b>false</b>)
+    group_ops::from_bytes(<a href="../sui/ristretto255.md#sui_ristretto255_SCALAR_TYPE">SCALAR_TYPE</a>, *bytes, <b>false</b>)
 }
 </code></pre>
 
@@ -184,8 +184,8 @@ Only available in devnet.
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/ristretto255.md#sui_ristretto255_scalar_from_u64">scalar_from_u64</a>(x: u64): Element&lt;<a href="../sui/ristretto255.md#sui_ristretto255_Scalar">Scalar</a>&gt; {
     <b>let</b> scalar: u256 = x <b>as</b> u256;
-    <b>let</b> bytes = <a href="../sui/bcs.md#sui_bcs_to_bytes">bcs::to_bytes</a>(&scalar);
-    <a href="../sui/group_ops.md#sui_group_ops_from_bytes">group_ops::from_bytes</a>(<a href="../sui/ristretto255.md#sui_ristretto255_SCALAR_TYPE">SCALAR_TYPE</a>, bytes, <b>true</b>)
+    <b>let</b> bytes = bcs::to_bytes(&scalar);
+    group_ops::from_bytes(<a href="../sui/ristretto255.md#sui_ristretto255_SCALAR_TYPE">SCALAR_TYPE</a>, bytes, <b>true</b>)
 }
 </code></pre>
 
@@ -209,7 +209,7 @@ Only available in devnet.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/ristretto255.md#sui_ristretto255_scalar_zero">scalar_zero</a>(): Element&lt;<a href="../sui/ristretto255.md#sui_ristretto255_Scalar">Scalar</a>&gt; {
-    <a href="../sui/group_ops.md#sui_group_ops_from_bytes">group_ops::from_bytes</a>(<a href="../sui/ristretto255.md#sui_ristretto255_SCALAR_TYPE">SCALAR_TYPE</a>, <a href="../sui/ristretto255.md#sui_ristretto255_SCALAR_ZERO_BYTES">SCALAR_ZERO_BYTES</a>, <b>true</b>)
+    group_ops::from_bytes(<a href="../sui/ristretto255.md#sui_ristretto255_SCALAR_TYPE">SCALAR_TYPE</a>, <a href="../sui/ristretto255.md#sui_ristretto255_SCALAR_ZERO_BYTES">SCALAR_ZERO_BYTES</a>, <b>true</b>)
 }
 </code></pre>
 
@@ -233,7 +233,7 @@ Only available in devnet.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/ristretto255.md#sui_ristretto255_scalar_one">scalar_one</a>(): Element&lt;<a href="../sui/ristretto255.md#sui_ristretto255_Scalar">Scalar</a>&gt; {
-    <a href="../sui/group_ops.md#sui_group_ops_from_bytes">group_ops::from_bytes</a>(<a href="../sui/ristretto255.md#sui_ristretto255_SCALAR_TYPE">SCALAR_TYPE</a>, <a href="../sui/ristretto255.md#sui_ristretto255_SCALAR_ONE_BYTES">SCALAR_ONE_BYTES</a>, <b>true</b>)
+    group_ops::from_bytes(<a href="../sui/ristretto255.md#sui_ristretto255_SCALAR_TYPE">SCALAR_TYPE</a>, <a href="../sui/ristretto255.md#sui_ristretto255_SCALAR_ONE_BYTES">SCALAR_ONE_BYTES</a>, <b>true</b>)
 }
 </code></pre>
 
@@ -257,7 +257,7 @@ Only available in devnet.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/ristretto255.md#sui_ristretto255_scalar_add">scalar_add</a>(e1: &Element&lt;<a href="../sui/ristretto255.md#sui_ristretto255_Scalar">Scalar</a>&gt;, e2: &Element&lt;<a href="../sui/ristretto255.md#sui_ristretto255_Scalar">Scalar</a>&gt;): Element&lt;<a href="../sui/ristretto255.md#sui_ristretto255_Scalar">Scalar</a>&gt; {
-    <a href="../sui/group_ops.md#sui_group_ops_add">group_ops::add</a>(<a href="../sui/ristretto255.md#sui_ristretto255_SCALAR_TYPE">SCALAR_TYPE</a>, e1, e2)
+    group_ops::add(<a href="../sui/ristretto255.md#sui_ristretto255_SCALAR_TYPE">SCALAR_TYPE</a>, e1, e2)
 }
 </code></pre>
 
@@ -281,7 +281,7 @@ Only available in devnet.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/ristretto255.md#sui_ristretto255_scalar_sub">scalar_sub</a>(e1: &Element&lt;<a href="../sui/ristretto255.md#sui_ristretto255_Scalar">Scalar</a>&gt;, e2: &Element&lt;<a href="../sui/ristretto255.md#sui_ristretto255_Scalar">Scalar</a>&gt;): Element&lt;<a href="../sui/ristretto255.md#sui_ristretto255_Scalar">Scalar</a>&gt; {
-    <a href="../sui/group_ops.md#sui_group_ops_sub">group_ops::sub</a>(<a href="../sui/ristretto255.md#sui_ristretto255_SCALAR_TYPE">SCALAR_TYPE</a>, e1, e2)
+    group_ops::sub(<a href="../sui/ristretto255.md#sui_ristretto255_SCALAR_TYPE">SCALAR_TYPE</a>, e1, e2)
 }
 </code></pre>
 
@@ -305,7 +305,7 @@ Only available in devnet.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/ristretto255.md#sui_ristretto255_scalar_mul">scalar_mul</a>(e1: &Element&lt;<a href="../sui/ristretto255.md#sui_ristretto255_Scalar">Scalar</a>&gt;, e2: &Element&lt;<a href="../sui/ristretto255.md#sui_ristretto255_Scalar">Scalar</a>&gt;): Element&lt;<a href="../sui/ristretto255.md#sui_ristretto255_Scalar">Scalar</a>&gt; {
-    <a href="../sui/group_ops.md#sui_group_ops_mul">group_ops::mul</a>(<a href="../sui/ristretto255.md#sui_ristretto255_SCALAR_TYPE">SCALAR_TYPE</a>, e1, e2)
+    group_ops::mul(<a href="../sui/ristretto255.md#sui_ristretto255_SCALAR_TYPE">SCALAR_TYPE</a>, e1, e2)
 }
 </code></pre>
 
@@ -330,7 +330,7 @@ Returns e2/e1, fails if a is zero.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/ristretto255.md#sui_ristretto255_scalar_div">scalar_div</a>(e1: &Element&lt;<a href="../sui/ristretto255.md#sui_ristretto255_Scalar">Scalar</a>&gt;, e2: &Element&lt;<a href="../sui/ristretto255.md#sui_ristretto255_Scalar">Scalar</a>&gt;): Element&lt;<a href="../sui/ristretto255.md#sui_ristretto255_Scalar">Scalar</a>&gt; {
-    <a href="../sui/group_ops.md#sui_group_ops_div">group_ops::div</a>(<a href="../sui/ristretto255.md#sui_ristretto255_SCALAR_TYPE">SCALAR_TYPE</a>, e1, e2)
+    group_ops::div(<a href="../sui/ristretto255.md#sui_ristretto255_SCALAR_TYPE">SCALAR_TYPE</a>, e1, e2)
 }
 </code></pre>
 
@@ -402,7 +402,7 @@ Returns e2/e1, fails if a is zero.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/ristretto255.md#sui_ristretto255_g_from_bytes">g_from_bytes</a>(bytes: &vector&lt;u8&gt;): Element&lt;<a href="../sui/ristretto255.md#sui_ristretto255_G">G</a>&gt; {
-    <a href="../sui/group_ops.md#sui_group_ops_from_bytes">group_ops::from_bytes</a>(<a href="../sui/ristretto255.md#sui_ristretto255_G_TYPE">G_TYPE</a>, *bytes, <b>false</b>)
+    group_ops::from_bytes(<a href="../sui/ristretto255.md#sui_ristretto255_G_TYPE">G_TYPE</a>, *bytes, <b>false</b>)
 }
 </code></pre>
 
@@ -426,7 +426,7 @@ Returns e2/e1, fails if a is zero.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/ristretto255.md#sui_ristretto255_g_identity">g_identity</a>(): Element&lt;<a href="../sui/ristretto255.md#sui_ristretto255_G">G</a>&gt; {
-    <a href="../sui/group_ops.md#sui_group_ops_from_bytes">group_ops::from_bytes</a>(<a href="../sui/ristretto255.md#sui_ristretto255_G_TYPE">G_TYPE</a>, <a href="../sui/ristretto255.md#sui_ristretto255_IDENTITY_BYTES">IDENTITY_BYTES</a>, <b>true</b>)
+    group_ops::from_bytes(<a href="../sui/ristretto255.md#sui_ristretto255_G_TYPE">G_TYPE</a>, <a href="../sui/ristretto255.md#sui_ristretto255_IDENTITY_BYTES">IDENTITY_BYTES</a>, <b>true</b>)
 }
 </code></pre>
 
@@ -450,7 +450,7 @@ Returns e2/e1, fails if a is zero.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/ristretto255.md#sui_ristretto255_g_generator">g_generator</a>(): Element&lt;<a href="../sui/ristretto255.md#sui_ristretto255_G">G</a>&gt; {
-    <a href="../sui/group_ops.md#sui_group_ops_from_bytes">group_ops::from_bytes</a>(<a href="../sui/ristretto255.md#sui_ristretto255_G_TYPE">G_TYPE</a>, <a href="../sui/ristretto255.md#sui_ristretto255_GENERATOR_BYTES">GENERATOR_BYTES</a>, <b>true</b>)
+    group_ops::from_bytes(<a href="../sui/ristretto255.md#sui_ristretto255_G_TYPE">G_TYPE</a>, <a href="../sui/ristretto255.md#sui_ristretto255_GENERATOR_BYTES">GENERATOR_BYTES</a>, <b>true</b>)
 }
 </code></pre>
 
@@ -474,7 +474,7 @@ Returns e2/e1, fails if a is zero.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/ristretto255.md#sui_ristretto255_g_add">g_add</a>(e1: &Element&lt;<a href="../sui/ristretto255.md#sui_ristretto255_G">G</a>&gt;, e2: &Element&lt;<a href="../sui/ristretto255.md#sui_ristretto255_G">G</a>&gt;): Element&lt;<a href="../sui/ristretto255.md#sui_ristretto255_G">G</a>&gt; {
-    <a href="../sui/group_ops.md#sui_group_ops_add">group_ops::add</a>(<a href="../sui/ristretto255.md#sui_ristretto255_G_TYPE">G_TYPE</a>, e1, e2)
+    group_ops::add(<a href="../sui/ristretto255.md#sui_ristretto255_G_TYPE">G_TYPE</a>, e1, e2)
 }
 </code></pre>
 
@@ -498,7 +498,7 @@ Returns e2/e1, fails if a is zero.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/ristretto255.md#sui_ristretto255_g_sub">g_sub</a>(e1: &Element&lt;<a href="../sui/ristretto255.md#sui_ristretto255_G">G</a>&gt;, e2: &Element&lt;<a href="../sui/ristretto255.md#sui_ristretto255_G">G</a>&gt;): Element&lt;<a href="../sui/ristretto255.md#sui_ristretto255_G">G</a>&gt; {
-    <a href="../sui/group_ops.md#sui_group_ops_sub">group_ops::sub</a>(<a href="../sui/ristretto255.md#sui_ristretto255_G_TYPE">G_TYPE</a>, e1, e2)
+    group_ops::sub(<a href="../sui/ristretto255.md#sui_ristretto255_G_TYPE">G_TYPE</a>, e1, e2)
 }
 </code></pre>
 
@@ -522,7 +522,7 @@ Returns e2/e1, fails if a is zero.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/ristretto255.md#sui_ristretto255_g_mul">g_mul</a>(e1: &Element&lt;<a href="../sui/ristretto255.md#sui_ristretto255_Scalar">Scalar</a>&gt;, e2: &Element&lt;<a href="../sui/ristretto255.md#sui_ristretto255_G">G</a>&gt;): Element&lt;<a href="../sui/ristretto255.md#sui_ristretto255_G">G</a>&gt; {
-    <a href="../sui/group_ops.md#sui_group_ops_mul">group_ops::mul</a>(<a href="../sui/ristretto255.md#sui_ristretto255_G_TYPE">G_TYPE</a>, e1, e2)
+    group_ops::mul(<a href="../sui/ristretto255.md#sui_ristretto255_G_TYPE">G_TYPE</a>, e1, e2)
 }
 </code></pre>
 
@@ -547,7 +547,7 @@ Returns e2 / e1, fails if scalar is zero.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/ristretto255.md#sui_ristretto255_g_div">g_div</a>(e1: &Element&lt;<a href="../sui/ristretto255.md#sui_ristretto255_Scalar">Scalar</a>&gt;, e2: &Element&lt;<a href="../sui/ristretto255.md#sui_ristretto255_G">G</a>&gt;): Element&lt;<a href="../sui/ristretto255.md#sui_ristretto255_G">G</a>&gt; {
-    <a href="../sui/group_ops.md#sui_group_ops_div">group_ops::div</a>(<a href="../sui/ristretto255.md#sui_ristretto255_G_TYPE">G_TYPE</a>, e1, e2)
+    group_ops::div(<a href="../sui/ristretto255.md#sui_ristretto255_G_TYPE">G_TYPE</a>, e1, e2)
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/sui/sui.md
+++ b/crates/sui-framework/docs/sui/sui.md
@@ -147,17 +147,17 @@ This should be called only once during genesis creation.
 <pre><code><b>fun</b> <a href="../sui/sui.md#sui_sui_new">new</a>(ctx: &<b>mut</b> TxContext): Balance&lt;<a href="../sui/sui.md#sui_sui_SUI">SUI</a>&gt; {
     <b>assert</b>!(ctx.sender() == @0x0, <a href="../sui/sui.md#sui_sui_ENotSystemAddress">ENotSystemAddress</a>);
     <b>assert</b>!(ctx.epoch() == 0, <a href="../sui/sui.md#sui_sui_EAlreadyMinted">EAlreadyMinted</a>);
-    <b>let</b> (treasury, metadata) = <a href="../sui/coin.md#sui_coin_create_currency">coin::create_currency</a>(
+    <b>let</b> (treasury, metadata) = coin::create_currency(
         <a href="../sui/sui.md#sui_sui_SUI">SUI</a> {},
         9,
         b"<a href="../sui/sui.md#sui_sui_SUI">SUI</a>",
         b"Sui",
-        // TODO: add appropriate description and logo <a href="../sui/url.md#sui_url">url</a>
+        // TODO: add appropriate description and logo url
         b"",
         option::none(),
         ctx,
     );
-    <a href="../sui/transfer.md#sui_transfer_public_freeze_object">transfer::public_freeze_object</a>(metadata);
+    transfer::public_freeze_object(metadata);
     <b>let</b> <b>mut</b> supply = treasury.treasury_into_supply();
     <b>let</b> total_sui = supply.increase_supply(<a href="../sui/sui.md#sui_sui_TOTAL_SUPPLY_MIST">TOTAL_SUPPLY_MIST</a>);
     supply.destroy_supply();
@@ -175,7 +175,7 @@ This should be called only once during genesis creation.
 
 
 
-<pre><code><b>public</b> <b>entry</b> <b>fun</b> <a href="../sui/transfer.md#sui_transfer">transfer</a>(c: <a href="../sui/coin.md#sui_coin_Coin">sui::coin::Coin</a>&lt;<a href="../sui/sui.md#sui_sui_SUI">sui::sui::SUI</a>&gt;, recipient: <b>address</b>)
+<pre><code><b>public</b> <b>entry</b> <b>fun</b> <a href="../sui/sui.md#sui_sui_transfer">transfer</a>(c: <a href="../sui/coin.md#sui_coin_Coin">sui::coin::Coin</a>&lt;<a href="../sui/sui.md#sui_sui_SUI">sui::sui::SUI</a>&gt;, recipient: <b>address</b>)
 </code></pre>
 
 
@@ -184,8 +184,8 @@ This should be called only once during genesis creation.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>entry</b> <b>fun</b> <a href="../sui/transfer.md#sui_transfer">transfer</a>(c: <a href="../sui/coin.md#sui_coin_Coin">coin::Coin</a>&lt;<a href="../sui/sui.md#sui_sui_SUI">SUI</a>&gt;, recipient: <b>address</b>) {
-    <a href="../sui/transfer.md#sui_transfer_public_transfer">transfer::public_transfer</a>(c, recipient)
+<pre><code><b>public</b> <b>entry</b> <b>fun</b> <a href="../sui/sui.md#sui_sui_transfer">transfer</a>(c: coin::Coin&lt;<a href="../sui/sui.md#sui_sui_SUI">SUI</a>&gt;, recipient: <b>address</b>) {
+    transfer::public_transfer(c, recipient)
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/sui/table.md
+++ b/crates/sui-framework/docs/sui/table.md
@@ -112,7 +112,7 @@ Creates a new, empty table
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/table.md#sui_table_new">new</a>&lt;K: <b>copy</b> + <a href="../sui/table.md#sui_table_drop">drop</a> + store, V: store&gt;(ctx: &<b>mut</b> TxContext): <a href="../sui/table.md#sui_table_Table">Table</a>&lt;K, V&gt; {
     <a href="../sui/table.md#sui_table_Table">Table</a> {
-        id: <a href="../sui/object.md#sui_object_new">object::new</a>(ctx),
+        id: object::new(ctx),
         size: 0,
     }
 }
@@ -126,12 +126,12 @@ Creates a new, empty table
 
 ## Function `add`
 
-Adds a key-value pair to the table <code><a href="../sui/table.md#sui_table">table</a>: &<b>mut</b> <a href="../sui/table.md#sui_table_Table">Table</a>&lt;K, V&gt;</code>
+Adds a key-value pair to the table <code>table: &<b>mut</b> <a href="../sui/table.md#sui_table_Table">Table</a>&lt;K, V&gt;</code>
 Aborts with <code><a href="../sui/dynamic_field.md#sui_dynamic_field_EFieldAlreadyExists">sui::dynamic_field::EFieldAlreadyExists</a></code> if the table already has an entry with
 that key <code>k: K</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/table.md#sui_table_add">add</a>&lt;K: <b>copy</b>, <a href="../sui/table.md#sui_table_drop">drop</a>, store, V: store&gt;(<a href="../sui/table.md#sui_table">table</a>: &<b>mut</b> <a href="../sui/table.md#sui_table_Table">sui::table::Table</a>&lt;K, V&gt;, k: K, v: V)
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/table.md#sui_table_add">add</a>&lt;K: <b>copy</b>, <a href="../sui/table.md#sui_table_drop">drop</a>, store, V: store&gt;(table: &<b>mut</b> <a href="../sui/table.md#sui_table_Table">sui::table::Table</a>&lt;K, V&gt;, k: K, v: V)
 </code></pre>
 
 
@@ -140,9 +140,9 @@ that key <code>k: K</code>.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/table.md#sui_table_add">add</a>&lt;K: <b>copy</b> + <a href="../sui/table.md#sui_table_drop">drop</a> + store, V: store&gt;(<a href="../sui/table.md#sui_table">table</a>: &<b>mut</b> <a href="../sui/table.md#sui_table_Table">Table</a>&lt;K, V&gt;, k: K, v: V) {
-    field::add(&<b>mut</b> <a href="../sui/table.md#sui_table">table</a>.id, k, v);
-    <a href="../sui/table.md#sui_table">table</a>.size = <a href="../sui/table.md#sui_table">table</a>.size + 1;
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/table.md#sui_table_add">add</a>&lt;K: <b>copy</b> + <a href="../sui/table.md#sui_table_drop">drop</a> + store, V: store&gt;(table: &<b>mut</b> <a href="../sui/table.md#sui_table_Table">Table</a>&lt;K, V&gt;, k: K, v: V) {
+    field::add(&<b>mut</b> table.id, k, v);
+    table.size = table.size + 1;
 }
 </code></pre>
 
@@ -154,12 +154,12 @@ that key <code>k: K</code>.
 
 ## Function `borrow`
 
-Immutable borrows the value associated with the key in the table <code><a href="../sui/table.md#sui_table">table</a>: &<a href="../sui/table.md#sui_table_Table">Table</a>&lt;K, V&gt;</code>.
+Immutable borrows the value associated with the key in the table <code>table: &<a href="../sui/table.md#sui_table_Table">Table</a>&lt;K, V&gt;</code>.
 Aborts with <code><a href="../sui/dynamic_field.md#sui_dynamic_field_EFieldDoesNotExist">sui::dynamic_field::EFieldDoesNotExist</a></code> if the table does not have an entry with
 that key <code>k: K</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/borrow.md#sui_borrow">borrow</a>&lt;K: <b>copy</b>, <a href="../sui/table.md#sui_table_drop">drop</a>, store, V: store&gt;(<a href="../sui/table.md#sui_table">table</a>: &<a href="../sui/table.md#sui_table_Table">sui::table::Table</a>&lt;K, V&gt;, k: K): &V
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/table.md#sui_table_borrow">borrow</a>&lt;K: <b>copy</b>, <a href="../sui/table.md#sui_table_drop">drop</a>, store, V: store&gt;(table: &<a href="../sui/table.md#sui_table_Table">sui::table::Table</a>&lt;K, V&gt;, k: K): &V
 </code></pre>
 
 
@@ -168,8 +168,8 @@ that key <code>k: K</code>.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/borrow.md#sui_borrow">borrow</a>&lt;K: <b>copy</b> + <a href="../sui/table.md#sui_table_drop">drop</a> + store, V: store&gt;(<a href="../sui/table.md#sui_table">table</a>: &<a href="../sui/table.md#sui_table_Table">Table</a>&lt;K, V&gt;, k: K): &V {
-    field::borrow(&<a href="../sui/table.md#sui_table">table</a>.id, k)
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/table.md#sui_table_borrow">borrow</a>&lt;K: <b>copy</b> + <a href="../sui/table.md#sui_table_drop">drop</a> + store, V: store&gt;(table: &<a href="../sui/table.md#sui_table_Table">Table</a>&lt;K, V&gt;, k: K): &V {
+    field::borrow(&table.id, k)
 }
 </code></pre>
 
@@ -181,12 +181,12 @@ that key <code>k: K</code>.
 
 ## Function `borrow_mut`
 
-Mutably borrows the value associated with the key in the table <code><a href="../sui/table.md#sui_table">table</a>: &<b>mut</b> <a href="../sui/table.md#sui_table_Table">Table</a>&lt;K, V&gt;</code>.
+Mutably borrows the value associated with the key in the table <code>table: &<b>mut</b> <a href="../sui/table.md#sui_table_Table">Table</a>&lt;K, V&gt;</code>.
 Aborts with <code><a href="../sui/dynamic_field.md#sui_dynamic_field_EFieldDoesNotExist">sui::dynamic_field::EFieldDoesNotExist</a></code> if the table does not have an entry with
 that key <code>k: K</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/table.md#sui_table_borrow_mut">borrow_mut</a>&lt;K: <b>copy</b>, <a href="../sui/table.md#sui_table_drop">drop</a>, store, V: store&gt;(<a href="../sui/table.md#sui_table">table</a>: &<b>mut</b> <a href="../sui/table.md#sui_table_Table">sui::table::Table</a>&lt;K, V&gt;, k: K): &<b>mut</b> V
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/table.md#sui_table_borrow_mut">borrow_mut</a>&lt;K: <b>copy</b>, <a href="../sui/table.md#sui_table_drop">drop</a>, store, V: store&gt;(table: &<b>mut</b> <a href="../sui/table.md#sui_table_Table">sui::table::Table</a>&lt;K, V&gt;, k: K): &<b>mut</b> V
 </code></pre>
 
 
@@ -195,8 +195,8 @@ that key <code>k: K</code>.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/table.md#sui_table_borrow_mut">borrow_mut</a>&lt;K: <b>copy</b> + <a href="../sui/table.md#sui_table_drop">drop</a> + store, V: store&gt;(<a href="../sui/table.md#sui_table">table</a>: &<b>mut</b> <a href="../sui/table.md#sui_table_Table">Table</a>&lt;K, V&gt;, k: K): &<b>mut</b> V {
-    field::borrow_mut(&<b>mut</b> <a href="../sui/table.md#sui_table">table</a>.id, k)
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/table.md#sui_table_borrow_mut">borrow_mut</a>&lt;K: <b>copy</b> + <a href="../sui/table.md#sui_table_drop">drop</a> + store, V: store&gt;(table: &<b>mut</b> <a href="../sui/table.md#sui_table_Table">Table</a>&lt;K, V&gt;, k: K): &<b>mut</b> V {
+    field::borrow_mut(&<b>mut</b> table.id, k)
 }
 </code></pre>
 
@@ -208,12 +208,12 @@ that key <code>k: K</code>.
 
 ## Function `remove`
 
-Removes the key-value pair in the table <code><a href="../sui/table.md#sui_table">table</a>: &<b>mut</b> <a href="../sui/table.md#sui_table_Table">Table</a>&lt;K, V&gt;</code> and returns the value.
+Removes the key-value pair in the table <code>table: &<b>mut</b> <a href="../sui/table.md#sui_table_Table">Table</a>&lt;K, V&gt;</code> and returns the value.
 Aborts with <code><a href="../sui/dynamic_field.md#sui_dynamic_field_EFieldDoesNotExist">sui::dynamic_field::EFieldDoesNotExist</a></code> if the table does not have an entry with
 that key <code>k: K</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/table.md#sui_table_remove">remove</a>&lt;K: <b>copy</b>, <a href="../sui/table.md#sui_table_drop">drop</a>, store, V: store&gt;(<a href="../sui/table.md#sui_table">table</a>: &<b>mut</b> <a href="../sui/table.md#sui_table_Table">sui::table::Table</a>&lt;K, V&gt;, k: K): V
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/table.md#sui_table_remove">remove</a>&lt;K: <b>copy</b>, <a href="../sui/table.md#sui_table_drop">drop</a>, store, V: store&gt;(table: &<b>mut</b> <a href="../sui/table.md#sui_table_Table">sui::table::Table</a>&lt;K, V&gt;, k: K): V
 </code></pre>
 
 
@@ -222,9 +222,9 @@ that key <code>k: K</code>.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/table.md#sui_table_remove">remove</a>&lt;K: <b>copy</b> + <a href="../sui/table.md#sui_table_drop">drop</a> + store, V: store&gt;(<a href="../sui/table.md#sui_table">table</a>: &<b>mut</b> <a href="../sui/table.md#sui_table_Table">Table</a>&lt;K, V&gt;, k: K): V {
-    <b>let</b> v = field::remove(&<b>mut</b> <a href="../sui/table.md#sui_table">table</a>.id, k);
-    <a href="../sui/table.md#sui_table">table</a>.size = <a href="../sui/table.md#sui_table">table</a>.size - 1;
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/table.md#sui_table_remove">remove</a>&lt;K: <b>copy</b> + <a href="../sui/table.md#sui_table_drop">drop</a> + store, V: store&gt;(table: &<b>mut</b> <a href="../sui/table.md#sui_table_Table">Table</a>&lt;K, V&gt;, k: K): V {
+    <b>let</b> v = field::remove(&<b>mut</b> table.id, k);
+    table.size = table.size - 1;
     v
 }
 </code></pre>
@@ -237,10 +237,10 @@ that key <code>k: K</code>.
 
 ## Function `contains`
 
-Returns true if there is a value associated with the key <code>k: K</code> in table <code><a href="../sui/table.md#sui_table">table</a>: &<a href="../sui/table.md#sui_table_Table">Table</a>&lt;K, V&gt;</code>
+Returns true if there is a value associated with the key <code>k: K</code> in table <code>table: &<a href="../sui/table.md#sui_table_Table">Table</a>&lt;K, V&gt;</code>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/table.md#sui_table_contains">contains</a>&lt;K: <b>copy</b>, <a href="../sui/table.md#sui_table_drop">drop</a>, store, V: store&gt;(<a href="../sui/table.md#sui_table">table</a>: &<a href="../sui/table.md#sui_table_Table">sui::table::Table</a>&lt;K, V&gt;, k: K): bool
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/table.md#sui_table_contains">contains</a>&lt;K: <b>copy</b>, <a href="../sui/table.md#sui_table_drop">drop</a>, store, V: store&gt;(table: &<a href="../sui/table.md#sui_table_Table">sui::table::Table</a>&lt;K, V&gt;, k: K): bool
 </code></pre>
 
 
@@ -249,8 +249,8 @@ Returns true if there is a value associated with the key <code>k: K</code> in ta
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/table.md#sui_table_contains">contains</a>&lt;K: <b>copy</b> + <a href="../sui/table.md#sui_table_drop">drop</a> + store, V: store&gt;(<a href="../sui/table.md#sui_table">table</a>: &<a href="../sui/table.md#sui_table_Table">Table</a>&lt;K, V&gt;, k: K): bool {
-    field::exists_with_type&lt;K, V&gt;(&<a href="../sui/table.md#sui_table">table</a>.id, k)
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/table.md#sui_table_contains">contains</a>&lt;K: <b>copy</b> + <a href="../sui/table.md#sui_table_drop">drop</a> + store, V: store&gt;(table: &<a href="../sui/table.md#sui_table_Table">Table</a>&lt;K, V&gt;, k: K): bool {
+    field::exists_with_type&lt;K, V&gt;(&table.id, k)
 }
 </code></pre>
 
@@ -265,7 +265,7 @@ Returns true if there is a value associated with the key <code>k: K</code> in ta
 Returns the size of the table, the number of key-value pairs
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/table.md#sui_table_length">length</a>&lt;K: <b>copy</b>, <a href="../sui/table.md#sui_table_drop">drop</a>, store, V: store&gt;(<a href="../sui/table.md#sui_table">table</a>: &<a href="../sui/table.md#sui_table_Table">sui::table::Table</a>&lt;K, V&gt;): u64
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/table.md#sui_table_length">length</a>&lt;K: <b>copy</b>, <a href="../sui/table.md#sui_table_drop">drop</a>, store, V: store&gt;(table: &<a href="../sui/table.md#sui_table_Table">sui::table::Table</a>&lt;K, V&gt;): u64
 </code></pre>
 
 
@@ -274,8 +274,8 @@ Returns the size of the table, the number of key-value pairs
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/table.md#sui_table_length">length</a>&lt;K: <b>copy</b> + <a href="../sui/table.md#sui_table_drop">drop</a> + store, V: store&gt;(<a href="../sui/table.md#sui_table">table</a>: &<a href="../sui/table.md#sui_table_Table">Table</a>&lt;K, V&gt;): u64 {
-    <a href="../sui/table.md#sui_table">table</a>.size
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/table.md#sui_table_length">length</a>&lt;K: <b>copy</b> + <a href="../sui/table.md#sui_table_drop">drop</a> + store, V: store&gt;(table: &<a href="../sui/table.md#sui_table_Table">Table</a>&lt;K, V&gt;): u64 {
+    table.size
 }
 </code></pre>
 
@@ -290,7 +290,7 @@ Returns the size of the table, the number of key-value pairs
 Returns true if the table is empty (if <code><a href="../sui/table.md#sui_table_length">length</a></code> returns <code>0</code>)
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/table.md#sui_table_is_empty">is_empty</a>&lt;K: <b>copy</b>, <a href="../sui/table.md#sui_table_drop">drop</a>, store, V: store&gt;(<a href="../sui/table.md#sui_table">table</a>: &<a href="../sui/table.md#sui_table_Table">sui::table::Table</a>&lt;K, V&gt;): bool
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/table.md#sui_table_is_empty">is_empty</a>&lt;K: <b>copy</b>, <a href="../sui/table.md#sui_table_drop">drop</a>, store, V: store&gt;(table: &<a href="../sui/table.md#sui_table_Table">sui::table::Table</a>&lt;K, V&gt;): bool
 </code></pre>
 
 
@@ -299,8 +299,8 @@ Returns true if the table is empty (if <code><a href="../sui/table.md#sui_table_
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/table.md#sui_table_is_empty">is_empty</a>&lt;K: <b>copy</b> + <a href="../sui/table.md#sui_table_drop">drop</a> + store, V: store&gt;(<a href="../sui/table.md#sui_table">table</a>: &<a href="../sui/table.md#sui_table_Table">Table</a>&lt;K, V&gt;): bool {
-    <a href="../sui/table.md#sui_table">table</a>.size == 0
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/table.md#sui_table_is_empty">is_empty</a>&lt;K: <b>copy</b> + <a href="../sui/table.md#sui_table_drop">drop</a> + store, V: store&gt;(table: &<a href="../sui/table.md#sui_table_Table">Table</a>&lt;K, V&gt;): bool {
+    table.size == 0
 }
 </code></pre>
 
@@ -316,7 +316,7 @@ Destroys an empty table
 Aborts with <code><a href="../sui/table.md#sui_table_ETableNotEmpty">ETableNotEmpty</a></code> if the table still contains values
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/table.md#sui_table_destroy_empty">destroy_empty</a>&lt;K: <b>copy</b>, <a href="../sui/table.md#sui_table_drop">drop</a>, store, V: store&gt;(<a href="../sui/table.md#sui_table">table</a>: <a href="../sui/table.md#sui_table_Table">sui::table::Table</a>&lt;K, V&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/table.md#sui_table_destroy_empty">destroy_empty</a>&lt;K: <b>copy</b>, <a href="../sui/table.md#sui_table_drop">drop</a>, store, V: store&gt;(table: <a href="../sui/table.md#sui_table_Table">sui::table::Table</a>&lt;K, V&gt;)
 </code></pre>
 
 
@@ -325,8 +325,8 @@ Aborts with <code><a href="../sui/table.md#sui_table_ETableNotEmpty">ETableNotEm
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/table.md#sui_table_destroy_empty">destroy_empty</a>&lt;K: <b>copy</b> + <a href="../sui/table.md#sui_table_drop">drop</a> + store, V: store&gt;(<a href="../sui/table.md#sui_table">table</a>: <a href="../sui/table.md#sui_table_Table">Table</a>&lt;K, V&gt;) {
-    <b>let</b> <a href="../sui/table.md#sui_table_Table">Table</a> { id, size } = <a href="../sui/table.md#sui_table">table</a>;
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/table.md#sui_table_destroy_empty">destroy_empty</a>&lt;K: <b>copy</b> + <a href="../sui/table.md#sui_table_drop">drop</a> + store, V: store&gt;(table: <a href="../sui/table.md#sui_table_Table">Table</a>&lt;K, V&gt;) {
+    <b>let</b> <a href="../sui/table.md#sui_table_Table">Table</a> { id, size } = table;
     <b>assert</b>!(size == 0, <a href="../sui/table.md#sui_table_ETableNotEmpty">ETableNotEmpty</a>);
     id.delete()
 }
@@ -344,7 +344,7 @@ Drop a possibly non-empty table.
 Usable only if the value type <code>V</code> has the <code><a href="../sui/table.md#sui_table_drop">drop</a></code> ability
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/table.md#sui_table_drop">drop</a>&lt;K: <b>copy</b>, <a href="../sui/table.md#sui_table_drop">drop</a>, store, V: <a href="../sui/table.md#sui_table_drop">drop</a>, store&gt;(<a href="../sui/table.md#sui_table">table</a>: <a href="../sui/table.md#sui_table_Table">sui::table::Table</a>&lt;K, V&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/table.md#sui_table_drop">drop</a>&lt;K: <b>copy</b>, <a href="../sui/table.md#sui_table_drop">drop</a>, store, V: <a href="../sui/table.md#sui_table_drop">drop</a>, store&gt;(table: <a href="../sui/table.md#sui_table_Table">sui::table::Table</a>&lt;K, V&gt;)
 </code></pre>
 
 
@@ -353,8 +353,8 @@ Usable only if the value type <code>V</code> has the <code><a href="../sui/table
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/table.md#sui_table_drop">drop</a>&lt;K: <b>copy</b> + <a href="../sui/table.md#sui_table_drop">drop</a> + store, V: <a href="../sui/table.md#sui_table_drop">drop</a> + store&gt;(<a href="../sui/table.md#sui_table">table</a>: <a href="../sui/table.md#sui_table_Table">Table</a>&lt;K, V&gt;) {
-    <b>let</b> <a href="../sui/table.md#sui_table_Table">Table</a> { id, size: _ } = <a href="../sui/table.md#sui_table">table</a>;
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/table.md#sui_table_drop">drop</a>&lt;K: <b>copy</b> + <a href="../sui/table.md#sui_table_drop">drop</a> + store, V: <a href="../sui/table.md#sui_table_drop">drop</a> + store&gt;(table: <a href="../sui/table.md#sui_table_Table">Table</a>&lt;K, V&gt;) {
+    <b>let</b> <a href="../sui/table.md#sui_table_Table">Table</a> { id, size: _ } = table;
     id.delete()
 }
 </code></pre>

--- a/crates/sui-framework/docs/sui/table_vec.md
+++ b/crates/sui-framework/docs/sui/table_vec.md
@@ -104,7 +104,7 @@ Create an empty TableVec.
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/table_vec.md#sui_table_vec_empty">empty</a>&lt;Element: store&gt;(ctx: &<b>mut</b> TxContext): <a href="../sui/table_vec.md#sui_table_vec_TableVec">TableVec</a>&lt;Element&gt; {
     <a href="../sui/table_vec.md#sui_table_vec_TableVec">TableVec</a> {
-        contents: <a href="../sui/table.md#sui_table_new">table::new</a>(ctx),
+        contents: table::new(ctx),
     }
 }
 </code></pre>
@@ -198,7 +198,7 @@ Acquire an immutable reference to the <code>i</code>th element of the TableVec <
 Aborts if <code>i</code> is out of bounds.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/borrow.md#sui_borrow">borrow</a>&lt;Element: store&gt;(t: &<a href="../sui/table_vec.md#sui_table_vec_TableVec">sui::table_vec::TableVec</a>&lt;Element&gt;, i: u64): &Element
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/table_vec.md#sui_table_vec_borrow">borrow</a>&lt;Element: store&gt;(t: &<a href="../sui/table_vec.md#sui_table_vec_TableVec">sui::table_vec::TableVec</a>&lt;Element&gt;, i: u64): &Element
 </code></pre>
 
 
@@ -207,7 +207,7 @@ Aborts if <code>i</code> is out of bounds.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/borrow.md#sui_borrow">borrow</a>&lt;Element: store&gt;(t: &<a href="../sui/table_vec.md#sui_table_vec_TableVec">TableVec</a>&lt;Element&gt;, i: u64): &Element {
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/table_vec.md#sui_table_vec_borrow">borrow</a>&lt;Element: store&gt;(t: &<a href="../sui/table_vec.md#sui_table_vec_TableVec">TableVec</a>&lt;Element&gt;, i: u64): &Element {
     <b>assert</b>!(t.<a href="../sui/table_vec.md#sui_table_vec_length">length</a>() &gt; i, <a href="../sui/table_vec.md#sui_table_vec_EIndexOutOfBound">EIndexOutOfBound</a>);
     &t.contents[i]
 }

--- a/crates/sui-framework/docs/sui/token.md
+++ b/crates/sui-framework/docs/sui/token.md
@@ -138,7 +138,7 @@ and actions performed on it must be confirmed in a matching <code><a href="../su
 <dd>
 </dd>
 <dt>
-<code><a href="../sui/balance.md#sui_balance">balance</a>: <a href="../sui/balance.md#sui_balance_Balance">sui::balance::Balance</a>&lt;T&gt;</code>
+<code>balance: <a href="../sui/balance.md#sui_balance_Balance">sui::balance::Balance</a>&lt;T&gt;</code>
 </dt>
 <dd>
  The Balance of the <code><a href="../sui/token.md#sui_token_Token">Token</a></code>.
@@ -258,7 +258,7 @@ or <code><a href="../sui/token.md#sui_token_confirm_request_mut">confirm_request
 </dt>
 <dd>
  Name of the Action to look up in the Policy. Name can be one of the
- default actions: <code><a href="../sui/transfer.md#sui_transfer">transfer</a></code>, <code><a href="../sui/token.md#sui_token_spend">spend</a></code>, <code><a href="../sui/token.md#sui_token_to_coin">to_coin</a></code>, <code><a href="../sui/token.md#sui_token_from_coin">from_coin</a></code> or a
+ default actions: <code><a href="../sui/token.md#sui_token_transfer">transfer</a></code>, <code><a href="../sui/token.md#sui_token_spend">spend</a></code>, <code><a href="../sui/token.md#sui_token_to_coin">to_coin</a></code>, <code><a href="../sui/token.md#sui_token_from_coin">from_coin</a></code> or a
  custom action.
 </dd>
 <dt>
@@ -277,7 +277,7 @@ or <code><a href="../sui/token.md#sui_token_confirm_request_mut">confirm_request
 <code><a href="../sui/token.md#sui_token_recipient">recipient</a>: <a href="../std/option.md#std_option_Option">std::option::Option</a>&lt;<b>address</b>&gt;</code>
 </dt>
 <dd>
- Recipient is only available in <code><a href="../sui/transfer.md#sui_transfer">transfer</a></code> action.
+ Recipient is only available in <code><a href="../sui/token.md#sui_token_transfer">transfer</a></code> action.
 </dd>
 <dt>
 <code><a href="../sui/token.md#sui_token_spent_balance">spent_balance</a>: <a href="../std/option.md#std_option_Option">std::option::Option</a>&lt;<a href="../sui/balance.md#sui_balance_Balance">sui::balance::Balance</a>&lt;T&gt;&gt;</code>
@@ -463,7 +463,7 @@ A Tag for the <code><a href="../sui/token.md#sui_token_spend">spend</a></code> a
 
 <a name="sui_token_TRANSFER"></a>
 
-A Tag for the <code><a href="../sui/transfer.md#sui_transfer">transfer</a></code> action.
+A Tag for the <code><a href="../sui/token.md#sui_token_transfer">transfer</a></code> action.
 
 
 <pre><code><b>const</b> <a href="../sui/token.md#sui_token_TRANSFER">TRANSFER</a>: vector&lt;u8&gt; = vector[116, 114, 97, 110, 115, 102, 101, 114];
@@ -516,13 +516,13 @@ hence it is safe to use it for authorization.
     ctx: &<b>mut</b> TxContext,
 ): (<a href="../sui/token.md#sui_token_TokenPolicy">TokenPolicy</a>&lt;T&gt;, <a href="../sui/token.md#sui_token_TokenPolicyCap">TokenPolicyCap</a>&lt;T&gt;) {
     <b>let</b> policy = <a href="../sui/token.md#sui_token_TokenPolicy">TokenPolicy</a> {
-        id: <a href="../sui/object.md#sui_object_new">object::new</a>(ctx),
-        <a href="../sui/token.md#sui_token_spent_balance">spent_balance</a>: <a href="../sui/balance.md#sui_balance_zero">balance::zero</a>(),
-        <a href="../sui/token.md#sui_token_rules">rules</a>: <a href="../sui/vec_map.md#sui_vec_map_empty">vec_map::empty</a>(),
+        id: object::new(ctx),
+        <a href="../sui/token.md#sui_token_spent_balance">spent_balance</a>: balance::zero(),
+        <a href="../sui/token.md#sui_token_rules">rules</a>: vec_map::empty(),
     };
     <b>let</b> cap = <a href="../sui/token.md#sui_token_TokenPolicyCap">TokenPolicyCap</a> {
-        id: <a href="../sui/object.md#sui_object_new">object::new</a>(ctx),
-        `<b>for</b>`: <a href="../sui/object.md#sui_object_id">object::id</a>(&policy),
+        id: object::new(ctx),
+        `<b>for</b>`: object::id(&policy),
     };
     (policy, cap)
 }
@@ -550,11 +550,11 @@ shared after initialization.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/token.md#sui_token_share_policy">share_policy</a>&lt;T&gt;(policy: <a href="../sui/token.md#sui_token_TokenPolicy">TokenPolicy</a>&lt;T&gt;) {
-    <a href="../sui/event.md#sui_event_emit">event::emit</a>(<a href="../sui/token.md#sui_token_TokenPolicyCreated">TokenPolicyCreated</a>&lt;T&gt; {
-        id: <a href="../sui/object.md#sui_object_id">object::id</a>(&policy),
+    event::emit(<a href="../sui/token.md#sui_token_TokenPolicyCreated">TokenPolicyCreated</a>&lt;T&gt; {
+        id: object::id(&policy),
         is_mutable: <b>true</b>,
     });
-    <a href="../sui/transfer.md#sui_transfer_share_object">transfer::share_object</a>(policy)
+    transfer::share_object(policy)
 }
 </code></pre>
 
@@ -571,7 +571,7 @@ Transfer a <code><a href="../sui/token.md#sui_token_Token">Token</a></code> to a
 to be used in verification.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/transfer.md#sui_transfer">transfer</a>&lt;T&gt;(t: <a href="../sui/token.md#sui_token_Token">sui::token::Token</a>&lt;T&gt;, <a href="../sui/token.md#sui_token_recipient">recipient</a>: <b>address</b>, ctx: &<b>mut</b> <a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>): <a href="../sui/token.md#sui_token_ActionRequest">sui::token::ActionRequest</a>&lt;T&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/token.md#sui_token_transfer">transfer</a>&lt;T&gt;(t: <a href="../sui/token.md#sui_token_Token">sui::token::Token</a>&lt;T&gt;, <a href="../sui/token.md#sui_token_recipient">recipient</a>: <b>address</b>, ctx: &<b>mut</b> <a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>): <a href="../sui/token.md#sui_token_ActionRequest">sui::token::ActionRequest</a>&lt;T&gt;
 </code></pre>
 
 
@@ -580,9 +580,9 @@ to be used in verification.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/transfer.md#sui_transfer">transfer</a>&lt;T&gt;(t: <a href="../sui/token.md#sui_token_Token">Token</a>&lt;T&gt;, <a href="../sui/token.md#sui_token_recipient">recipient</a>: <b>address</b>, ctx: &<b>mut</b> TxContext): <a href="../sui/token.md#sui_token_ActionRequest">ActionRequest</a>&lt;T&gt; {
-    <b>let</b> <a href="../sui/token.md#sui_token_amount">amount</a> = t.<a href="../sui/balance.md#sui_balance">balance</a>.<a href="../sui/token.md#sui_token_value">value</a>();
-    <a href="../sui/transfer.md#sui_transfer_transfer">transfer::transfer</a>(t, <a href="../sui/token.md#sui_token_recipient">recipient</a>);
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/token.md#sui_token_transfer">transfer</a>&lt;T&gt;(t: <a href="../sui/token.md#sui_token_Token">Token</a>&lt;T&gt;, <a href="../sui/token.md#sui_token_recipient">recipient</a>: <b>address</b>, ctx: &<b>mut</b> TxContext): <a href="../sui/token.md#sui_token_ActionRequest">ActionRequest</a>&lt;T&gt; {
+    <b>let</b> <a href="../sui/token.md#sui_token_amount">amount</a> = t.balance.<a href="../sui/token.md#sui_token_value">value</a>();
+    transfer::transfer(t, <a href="../sui/token.md#sui_token_recipient">recipient</a>);
     <a href="../sui/token.md#sui_token_new_request">new_request</a>(
         <a href="../sui/token.md#sui_token_transfer_action">transfer_action</a>(),
         <a href="../sui/token.md#sui_token_amount">amount</a>,
@@ -619,13 +619,13 @@ request and join the spent balance with the <code><a href="../sui/token.md#sui_t
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/token.md#sui_token_spend">spend</a>&lt;T&gt;(t: <a href="../sui/token.md#sui_token_Token">Token</a>&lt;T&gt;, ctx: &<b>mut</b> TxContext): <a href="../sui/token.md#sui_token_ActionRequest">ActionRequest</a>&lt;T&gt; {
-    <b>let</b> <a href="../sui/token.md#sui_token_Token">Token</a> { id, <a href="../sui/balance.md#sui_balance">balance</a> } = t;
+    <b>let</b> <a href="../sui/token.md#sui_token_Token">Token</a> { id, balance } = t;
     id.delete();
     <a href="../sui/token.md#sui_token_new_request">new_request</a>(
         <a href="../sui/token.md#sui_token_spend_action">spend_action</a>(),
-        <a href="../sui/balance.md#sui_balance">balance</a>.<a href="../sui/token.md#sui_token_value">value</a>(),
+        balance.<a href="../sui/token.md#sui_token_value">value</a>(),
         option::none(),
-        option::some(<a href="../sui/balance.md#sui_balance">balance</a>),
+        option::some(balance),
         ctx,
     )
 }
@@ -653,11 +653,11 @@ Convert <code><a href="../sui/token.md#sui_token_Token">Token</a></code> into an
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/token.md#sui_token_to_coin">to_coin</a>&lt;T&gt;(t: <a href="../sui/token.md#sui_token_Token">Token</a>&lt;T&gt;, ctx: &<b>mut</b> TxContext): (Coin&lt;T&gt;, <a href="../sui/token.md#sui_token_ActionRequest">ActionRequest</a>&lt;T&gt;) {
-    <b>let</b> <a href="../sui/token.md#sui_token_Token">Token</a> { id, <a href="../sui/balance.md#sui_balance">balance</a> } = t;
-    <b>let</b> <a href="../sui/token.md#sui_token_amount">amount</a> = <a href="../sui/balance.md#sui_balance">balance</a>.<a href="../sui/token.md#sui_token_value">value</a>();
+    <b>let</b> <a href="../sui/token.md#sui_token_Token">Token</a> { id, balance } = t;
+    <b>let</b> <a href="../sui/token.md#sui_token_amount">amount</a> = balance.<a href="../sui/token.md#sui_token_value">value</a>();
     id.delete();
     (
-        <a href="../sui/balance.md#sui_balance">balance</a>.into_coin(ctx),
+        balance.into_coin(ctx),
         <a href="../sui/token.md#sui_token_new_request">new_request</a>(
             <a href="../sui/token.md#sui_token_to_coin_action">to_coin_action</a>(),
             <a href="../sui/token.md#sui_token_amount">amount</a>,
@@ -681,7 +681,7 @@ Convert an open <code>Coin</code> into a <code><a href="../sui/token.md#sui_toke
 the "from_coin" action.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/token.md#sui_token_from_coin">from_coin</a>&lt;T&gt;(<a href="../sui/coin.md#sui_coin">coin</a>: <a href="../sui/coin.md#sui_coin_Coin">sui::coin::Coin</a>&lt;T&gt;, ctx: &<b>mut</b> <a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>): (<a href="../sui/token.md#sui_token_Token">sui::token::Token</a>&lt;T&gt;, <a href="../sui/token.md#sui_token_ActionRequest">sui::token::ActionRequest</a>&lt;T&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/token.md#sui_token_from_coin">from_coin</a>&lt;T&gt;(coin: <a href="../sui/coin.md#sui_coin_Coin">sui::coin::Coin</a>&lt;T&gt;, ctx: &<b>mut</b> <a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>): (<a href="../sui/token.md#sui_token_Token">sui::token::Token</a>&lt;T&gt;, <a href="../sui/token.md#sui_token_ActionRequest">sui::token::ActionRequest</a>&lt;T&gt;)
 </code></pre>
 
 
@@ -690,14 +690,14 @@ the "from_coin" action.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/token.md#sui_token_from_coin">from_coin</a>&lt;T&gt;(<a href="../sui/coin.md#sui_coin">coin</a>: Coin&lt;T&gt;, ctx: &<b>mut</b> TxContext): (<a href="../sui/token.md#sui_token_Token">Token</a>&lt;T&gt;, <a href="../sui/token.md#sui_token_ActionRequest">ActionRequest</a>&lt;T&gt;) {
-    <b>let</b> <a href="../sui/token.md#sui_token_amount">amount</a> = <a href="../sui/coin.md#sui_coin">coin</a>.<a href="../sui/token.md#sui_token_value">value</a>();
-    <b>let</b> <a href="../sui/token.md#sui_token">token</a> = <a href="../sui/token.md#sui_token_Token">Token</a> {
-        id: <a href="../sui/object.md#sui_object_new">object::new</a>(ctx),
-        <a href="../sui/balance.md#sui_balance">balance</a>: <a href="../sui/coin.md#sui_coin">coin</a>.into_balance(),
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/token.md#sui_token_from_coin">from_coin</a>&lt;T&gt;(coin: Coin&lt;T&gt;, ctx: &<b>mut</b> TxContext): (<a href="../sui/token.md#sui_token_Token">Token</a>&lt;T&gt;, <a href="../sui/token.md#sui_token_ActionRequest">ActionRequest</a>&lt;T&gt;) {
+    <b>let</b> <a href="../sui/token.md#sui_token_amount">amount</a> = coin.<a href="../sui/token.md#sui_token_value">value</a>();
+    <b>let</b> token = <a href="../sui/token.md#sui_token_Token">Token</a> {
+        id: object::new(ctx),
+        balance: coin.into_balance(),
     };
     (
-        <a href="../sui/token.md#sui_token">token</a>,
+        token,
         <a href="../sui/token.md#sui_token_new_request">new_request</a>(
             <a href="../sui/token.md#sui_token_from_coin_action">from_coin_action</a>(),
             <a href="../sui/token.md#sui_token_amount">amount</a>,
@@ -720,7 +720,7 @@ the "from_coin" action.
 Join two <code><a href="../sui/token.md#sui_token_Token">Token</a></code>s into one, always available.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/token.md#sui_token_join">join</a>&lt;T&gt;(<a href="../sui/token.md#sui_token">token</a>: &<b>mut</b> <a href="../sui/token.md#sui_token_Token">sui::token::Token</a>&lt;T&gt;, another: <a href="../sui/token.md#sui_token_Token">sui::token::Token</a>&lt;T&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/token.md#sui_token_join">join</a>&lt;T&gt;(token: &<b>mut</b> <a href="../sui/token.md#sui_token_Token">sui::token::Token</a>&lt;T&gt;, another: <a href="../sui/token.md#sui_token_Token">sui::token::Token</a>&lt;T&gt;)
 </code></pre>
 
 
@@ -729,9 +729,9 @@ Join two <code><a href="../sui/token.md#sui_token_Token">Token</a></code>s into 
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/token.md#sui_token_join">join</a>&lt;T&gt;(<a href="../sui/token.md#sui_token">token</a>: &<b>mut</b> <a href="../sui/token.md#sui_token_Token">Token</a>&lt;T&gt;, another: <a href="../sui/token.md#sui_token_Token">Token</a>&lt;T&gt;) {
-    <b>let</b> <a href="../sui/token.md#sui_token_Token">Token</a> { id, <a href="../sui/balance.md#sui_balance">balance</a> } = another;
-    <a href="../sui/token.md#sui_token">token</a>.<a href="../sui/balance.md#sui_balance">balance</a>.<a href="../sui/token.md#sui_token_join">join</a>(<a href="../sui/balance.md#sui_balance">balance</a>);
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/token.md#sui_token_join">join</a>&lt;T&gt;(token: &<b>mut</b> <a href="../sui/token.md#sui_token_Token">Token</a>&lt;T&gt;, another: <a href="../sui/token.md#sui_token_Token">Token</a>&lt;T&gt;) {
+    <b>let</b> <a href="../sui/token.md#sui_token_Token">Token</a> { id, balance } = another;
+    token.balance.<a href="../sui/token.md#sui_token_join">join</a>(balance);
     id.delete();
 }
 </code></pre>
@@ -745,10 +745,10 @@ Join two <code><a href="../sui/token.md#sui_token_Token">Token</a></code>s into 
 ## Function `split`
 
 Split a <code><a href="../sui/token.md#sui_token_Token">Token</a></code> with <code><a href="../sui/token.md#sui_token_amount">amount</a></code>.
-Aborts if the <code><a href="../sui/token.md#sui_token_Token">Token</a>.<a href="../sui/balance.md#sui_balance">balance</a></code> is lower than <code><a href="../sui/token.md#sui_token_amount">amount</a></code>.
+Aborts if the <code><a href="../sui/token.md#sui_token_Token">Token</a>.balance</code> is lower than <code><a href="../sui/token.md#sui_token_amount">amount</a></code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/token.md#sui_token_split">split</a>&lt;T&gt;(<a href="../sui/token.md#sui_token">token</a>: &<b>mut</b> <a href="../sui/token.md#sui_token_Token">sui::token::Token</a>&lt;T&gt;, <a href="../sui/token.md#sui_token_amount">amount</a>: u64, ctx: &<b>mut</b> <a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>): <a href="../sui/token.md#sui_token_Token">sui::token::Token</a>&lt;T&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/token.md#sui_token_split">split</a>&lt;T&gt;(token: &<b>mut</b> <a href="../sui/token.md#sui_token_Token">sui::token::Token</a>&lt;T&gt;, <a href="../sui/token.md#sui_token_amount">amount</a>: u64, ctx: &<b>mut</b> <a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>): <a href="../sui/token.md#sui_token_Token">sui::token::Token</a>&lt;T&gt;
 </code></pre>
 
 
@@ -757,11 +757,11 @@ Aborts if the <code><a href="../sui/token.md#sui_token_Token">Token</a>.<a href=
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/token.md#sui_token_split">split</a>&lt;T&gt;(<a href="../sui/token.md#sui_token">token</a>: &<b>mut</b> <a href="../sui/token.md#sui_token_Token">Token</a>&lt;T&gt;, <a href="../sui/token.md#sui_token_amount">amount</a>: u64, ctx: &<b>mut</b> TxContext): <a href="../sui/token.md#sui_token_Token">Token</a>&lt;T&gt; {
-    <b>assert</b>!(<a href="../sui/token.md#sui_token">token</a>.<a href="../sui/balance.md#sui_balance">balance</a>.<a href="../sui/token.md#sui_token_value">value</a>() &gt;= <a href="../sui/token.md#sui_token_amount">amount</a>, <a href="../sui/token.md#sui_token_EBalanceTooLow">EBalanceTooLow</a>);
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/token.md#sui_token_split">split</a>&lt;T&gt;(token: &<b>mut</b> <a href="../sui/token.md#sui_token_Token">Token</a>&lt;T&gt;, <a href="../sui/token.md#sui_token_amount">amount</a>: u64, ctx: &<b>mut</b> TxContext): <a href="../sui/token.md#sui_token_Token">Token</a>&lt;T&gt; {
+    <b>assert</b>!(token.balance.<a href="../sui/token.md#sui_token_value">value</a>() &gt;= <a href="../sui/token.md#sui_token_amount">amount</a>, <a href="../sui/token.md#sui_token_EBalanceTooLow">EBalanceTooLow</a>);
     <a href="../sui/token.md#sui_token_Token">Token</a> {
-        id: <a href="../sui/object.md#sui_object_new">object::new</a>(ctx),
-        <a href="../sui/balance.md#sui_balance">balance</a>: <a href="../sui/token.md#sui_token">token</a>.<a href="../sui/balance.md#sui_balance">balance</a>.<a href="../sui/token.md#sui_token_split">split</a>(<a href="../sui/token.md#sui_token_amount">amount</a>),
+        id: object::new(ctx),
+        balance: token.balance.<a href="../sui/token.md#sui_token_split">split</a>(<a href="../sui/token.md#sui_token_amount">amount</a>),
     }
 }
 </code></pre>
@@ -788,8 +788,8 @@ Create a zero <code><a href="../sui/token.md#sui_token_Token">Token</a></code>.
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/token.md#sui_token_zero">zero</a>&lt;T&gt;(ctx: &<b>mut</b> TxContext): <a href="../sui/token.md#sui_token_Token">Token</a>&lt;T&gt; {
     <a href="../sui/token.md#sui_token_Token">Token</a> {
-        id: <a href="../sui/object.md#sui_object_new">object::new</a>(ctx),
-        <a href="../sui/balance.md#sui_balance">balance</a>: <a href="../sui/balance.md#sui_balance_zero">balance::zero</a>(),
+        id: object::new(ctx),
+        balance: balance::zero(),
     }
 }
 </code></pre>
@@ -803,10 +803,10 @@ Create a zero <code><a href="../sui/token.md#sui_token_Token">Token</a></code>.
 ## Function `destroy_zero`
 
 Destroy an empty <code><a href="../sui/token.md#sui_token_Token">Token</a></code>, fails if the balance is non-zero.
-Aborts if the <code><a href="../sui/token.md#sui_token_Token">Token</a>.<a href="../sui/balance.md#sui_balance">balance</a></code> is not zero.
+Aborts if the <code><a href="../sui/token.md#sui_token_Token">Token</a>.balance</code> is not zero.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/token.md#sui_token_destroy_zero">destroy_zero</a>&lt;T&gt;(<a href="../sui/token.md#sui_token">token</a>: <a href="../sui/token.md#sui_token_Token">sui::token::Token</a>&lt;T&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/token.md#sui_token_destroy_zero">destroy_zero</a>&lt;T&gt;(token: <a href="../sui/token.md#sui_token_Token">sui::token::Token</a>&lt;T&gt;)
 </code></pre>
 
 
@@ -815,10 +815,10 @@ Aborts if the <code><a href="../sui/token.md#sui_token_Token">Token</a>.<a href=
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/token.md#sui_token_destroy_zero">destroy_zero</a>&lt;T&gt;(<a href="../sui/token.md#sui_token">token</a>: <a href="../sui/token.md#sui_token_Token">Token</a>&lt;T&gt;) {
-    <b>let</b> <a href="../sui/token.md#sui_token_Token">Token</a> { id, <a href="../sui/balance.md#sui_balance">balance</a> } = <a href="../sui/token.md#sui_token">token</a>;
-    <b>assert</b>!(<a href="../sui/balance.md#sui_balance">balance</a>.<a href="../sui/token.md#sui_token_value">value</a>() == 0, <a href="../sui/token.md#sui_token_ENotZero">ENotZero</a>);
-    <a href="../sui/balance.md#sui_balance">balance</a>.<a href="../sui/token.md#sui_token_destroy_zero">destroy_zero</a>();
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/token.md#sui_token_destroy_zero">destroy_zero</a>&lt;T&gt;(token: <a href="../sui/token.md#sui_token_Token">Token</a>&lt;T&gt;) {
+    <b>let</b> <a href="../sui/token.md#sui_token_Token">Token</a> { id, balance } = token;
+    <b>assert</b>!(balance.<a href="../sui/token.md#sui_token_value">value</a>() == 0, <a href="../sui/token.md#sui_token_ENotZero">ENotZero</a>);
+    balance.<a href="../sui/token.md#sui_token_destroy_zero">destroy_zero</a>();
     id.delete();
 }
 </code></pre>
@@ -834,7 +834,7 @@ Aborts if the <code><a href="../sui/token.md#sui_token_Token">Token</a>.<a href=
 Transfer the <code><a href="../sui/token.md#sui_token_Token">Token</a></code> to the transaction sender.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/token.md#sui_token_keep">keep</a>&lt;T&gt;(<a href="../sui/token.md#sui_token">token</a>: <a href="../sui/token.md#sui_token_Token">sui::token::Token</a>&lt;T&gt;, ctx: &<b>mut</b> <a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/token.md#sui_token_keep">keep</a>&lt;T&gt;(token: <a href="../sui/token.md#sui_token_Token">sui::token::Token</a>&lt;T&gt;, ctx: &<b>mut</b> <a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -843,8 +843,8 @@ Transfer the <code><a href="../sui/token.md#sui_token_Token">Token</a></code> to
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/token.md#sui_token_keep">keep</a>&lt;T&gt;(<a href="../sui/token.md#sui_token">token</a>: <a href="../sui/token.md#sui_token_Token">Token</a>&lt;T&gt;, ctx: &<b>mut</b> TxContext) {
-    <a href="../sui/transfer.md#sui_transfer_transfer">transfer::transfer</a>(<a href="../sui/token.md#sui_token">token</a>, ctx.<a href="../sui/token.md#sui_token_sender">sender</a>())
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/token.md#sui_token_keep">keep</a>&lt;T&gt;(token: <a href="../sui/token.md#sui_token_Token">Token</a>&lt;T&gt;, ctx: &<b>mut</b> TxContext) {
+    transfer::transfer(token, ctx.<a href="../sui/token.md#sui_token_sender">sender</a>())
 }
 </code></pre>
 
@@ -882,7 +882,7 @@ Publicly available method to allow for custom actions.
         <a href="../sui/token.md#sui_token_recipient">recipient</a>,
         <a href="../sui/token.md#sui_token_spent_balance">spent_balance</a>,
         <a href="../sui/token.md#sui_token_sender">sender</a>: ctx.<a href="../sui/token.md#sui_token_sender">sender</a>(),
-        <a href="../sui/token.md#sui_token_approvals">approvals</a>: <a href="../sui/vec_set.md#sui_vec_set_empty">vec_set::empty</a>(),
+        <a href="../sui/token.md#sui_token_approvals">approvals</a>: vec_set::empty(),
     }
 }
 </code></pre>
@@ -1121,7 +1121,7 @@ Rule itself. Configuration is stored per <code>Rule</code> and not per <code>Rul
 the <code><a href="../sui/token.md#sui_token_TokenPolicy">TokenPolicy</a></code> owner.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/token.md#sui_token_add_rule_config">add_rule_config</a>&lt;T, Rule: drop, Config: store&gt;(_rule: Rule, self: &<b>mut</b> <a href="../sui/token.md#sui_token_TokenPolicy">sui::token::TokenPolicy</a>&lt;T&gt;, cap: &<a href="../sui/token.md#sui_token_TokenPolicyCap">sui::token::TokenPolicyCap</a>&lt;T&gt;, <a href="../sui/config.md#sui_config">config</a>: Config, _ctx: &<b>mut</b> <a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/token.md#sui_token_add_rule_config">add_rule_config</a>&lt;T, Rule: drop, Config: store&gt;(_rule: Rule, self: &<b>mut</b> <a href="../sui/token.md#sui_token_TokenPolicy">sui::token::TokenPolicy</a>&lt;T&gt;, cap: &<a href="../sui/token.md#sui_token_TokenPolicyCap">sui::token::TokenPolicyCap</a>&lt;T&gt;, config: Config, _ctx: &<b>mut</b> <a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -1134,11 +1134,11 @@ the <code><a href="../sui/token.md#sui_token_TokenPolicy">TokenPolicy</a></code>
     _rule: Rule,
     self: &<b>mut</b> <a href="../sui/token.md#sui_token_TokenPolicy">TokenPolicy</a>&lt;T&gt;,
     cap: &<a href="../sui/token.md#sui_token_TokenPolicyCap">TokenPolicyCap</a>&lt;T&gt;,
-    <a href="../sui/config.md#sui_config">config</a>: Config,
+    config: Config,
     _ctx: &<b>mut</b> TxContext,
 ) {
-    <b>assert</b>!(<a href="../sui/object.md#sui_object_id">object::id</a>(self) == cap.`<b>for</b>`, <a href="../sui/token.md#sui_token_ENotAuthorized">ENotAuthorized</a>);
-    df::add(&<b>mut</b> self.id, <a href="../sui/token.md#sui_token_key">key</a>&lt;Rule&gt;(), <a href="../sui/config.md#sui_config">config</a>)
+    <b>assert</b>!(object::id(self) == cap.`<b>for</b>`, <a href="../sui/token.md#sui_token_ENotAuthorized">ENotAuthorized</a>);
+    df::add(&<b>mut</b> self.id, <a href="../sui/token.md#sui_token_key">key</a>&lt;Rule&gt;(), config)
 }
 </code></pre>
 
@@ -1207,7 +1207,7 @@ Aborts if:
     cap: &<a href="../sui/token.md#sui_token_TokenPolicyCap">TokenPolicyCap</a>&lt;T&gt;,
 ): &<b>mut</b> Config {
     <b>assert</b>!(<a href="../sui/token.md#sui_token_has_rule_config_with_type">has_rule_config_with_type</a>&lt;T, Rule, Config&gt;(self), <a href="../sui/token.md#sui_token_ENoConfig">ENoConfig</a>);
-    <b>assert</b>!(<a href="../sui/object.md#sui_object_id">object::id</a>(self) == cap.`<b>for</b>`, <a href="../sui/token.md#sui_token_ENotAuthorized">ENotAuthorized</a>);
+    <b>assert</b>!(object::id(self) == cap.`<b>for</b>`, <a href="../sui/token.md#sui_token_ENotAuthorized">ENotAuthorized</a>);
     df::borrow_mut(&<b>mut</b> self.id, <a href="../sui/token.md#sui_token_key">key</a>&lt;Rule&gt;())
 }
 </code></pre>
@@ -1247,7 +1247,7 @@ Aborts if:
     _ctx: &<b>mut</b> TxContext,
 ): Config {
     <b>assert</b>!(<a href="../sui/token.md#sui_token_has_rule_config_with_type">has_rule_config_with_type</a>&lt;T, Rule, Config&gt;(self), <a href="../sui/token.md#sui_token_ENoConfig">ENoConfig</a>);
-    <b>assert</b>!(<a href="../sui/object.md#sui_object_id">object::id</a>(self) == cap.`<b>for</b>`, <a href="../sui/token.md#sui_token_ENotAuthorized">ENotAuthorized</a>);
+    <b>assert</b>!(object::id(self) == cap.`<b>for</b>`, <a href="../sui/token.md#sui_token_ENotAuthorized">ENotAuthorized</a>);
     df::remove(&<b>mut</b> self.id, <a href="../sui/token.md#sui_token_key">key</a>&lt;Rule&gt;())
 }
 </code></pre>
@@ -1333,8 +1333,8 @@ Aborts if the <code><a href="../sui/token.md#sui_token_TokenPolicyCap">TokenPoli
     <a href="../sui/token.md#sui_token_action">action</a>: String,
     _ctx: &<b>mut</b> TxContext,
 ) {
-    <b>assert</b>!(<a href="../sui/object.md#sui_object_id">object::id</a>(self) == cap.`<b>for</b>`, <a href="../sui/token.md#sui_token_ENotAuthorized">ENotAuthorized</a>);
-    self.<a href="../sui/token.md#sui_token_rules">rules</a>.insert(<a href="../sui/token.md#sui_token_action">action</a>, <a href="../sui/vec_set.md#sui_vec_set_empty">vec_set::empty</a>());
+    <b>assert</b>!(object::id(self) == cap.`<b>for</b>`, <a href="../sui/token.md#sui_token_ENotAuthorized">ENotAuthorized</a>);
+    self.<a href="../sui/token.md#sui_token_rules">rules</a>.insert(<a href="../sui/token.md#sui_token_action">action</a>, vec_set::empty());
 }
 </code></pre>
 
@@ -1367,7 +1367,7 @@ Aborts if the <code><a href="../sui/token.md#sui_token_TokenPolicyCap">TokenPoli
     <a href="../sui/token.md#sui_token_action">action</a>: String,
     _ctx: &<b>mut</b> TxContext,
 ) {
-    <b>assert</b>!(<a href="../sui/object.md#sui_object_id">object::id</a>(self) == cap.`<b>for</b>`, <a href="../sui/token.md#sui_token_ENotAuthorized">ENotAuthorized</a>);
+    <b>assert</b>!(object::id(self) == cap.`<b>for</b>`, <a href="../sui/token.md#sui_token_ENotAuthorized">ENotAuthorized</a>);
     self.<a href="../sui/token.md#sui_token_rules">rules</a>.remove(&<a href="../sui/token.md#sui_token_action">action</a>);
 }
 </code></pre>
@@ -1400,7 +1400,7 @@ Aborts if the <code><a href="../sui/token.md#sui_token_TokenPolicyCap">TokenPoli
     <a href="../sui/token.md#sui_token_action">action</a>: String,
     ctx: &<b>mut</b> TxContext,
 ) {
-    <b>assert</b>!(<a href="../sui/object.md#sui_object_id">object::id</a>(self) == cap.`<b>for</b>`, <a href="../sui/token.md#sui_token_ENotAuthorized">ENotAuthorized</a>);
+    <b>assert</b>!(object::id(self) == cap.`<b>for</b>`, <a href="../sui/token.md#sui_token_ENotAuthorized">ENotAuthorized</a>);
     <b>if</b> (!self.<a href="../sui/token.md#sui_token_rules">rules</a>.contains(&<a href="../sui/token.md#sui_token_action">action</a>)) {
         <a href="../sui/token.md#sui_token_allow">allow</a>(self, cap, <a href="../sui/token.md#sui_token_action">action</a>, ctx);
     };
@@ -1437,7 +1437,7 @@ Aborts if the <code><a href="../sui/token.md#sui_token_TokenPolicyCap">TokenPoli
     <a href="../sui/token.md#sui_token_action">action</a>: String,
     _ctx: &<b>mut</b> TxContext,
 ) {
-    <b>assert</b>!(<a href="../sui/object.md#sui_object_id">object::id</a>(self) == cap.`<b>for</b>`, <a href="../sui/token.md#sui_token_ENotAuthorized">ENotAuthorized</a>);
+    <b>assert</b>!(object::id(self) == cap.`<b>for</b>`, <a href="../sui/token.md#sui_token_ENotAuthorized">ENotAuthorized</a>);
     self.<a href="../sui/token.md#sui_token_rules">rules</a>.get_mut(&<a href="../sui/token.md#sui_token_action">action</a>).remove(&type_name::with_defining_ids&lt;Rule&gt;())
 }
 </code></pre>
@@ -1463,8 +1463,8 @@ Mint a <code><a href="../sui/token.md#sui_token_Token">Token</a></code> with a g
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/token.md#sui_token_mint">mint</a>&lt;T&gt;(cap: &<b>mut</b> TreasuryCap&lt;T&gt;, <a href="../sui/token.md#sui_token_amount">amount</a>: u64, ctx: &<b>mut</b> TxContext): <a href="../sui/token.md#sui_token_Token">Token</a>&lt;T&gt; {
-    <b>let</b> <a href="../sui/balance.md#sui_balance">balance</a> = cap.supply_mut().increase_supply(<a href="../sui/token.md#sui_token_amount">amount</a>);
-    <a href="../sui/token.md#sui_token_Token">Token</a> { id: <a href="../sui/object.md#sui_object_new">object::new</a>(ctx), <a href="../sui/balance.md#sui_balance">balance</a> }
+    <b>let</b> balance = cap.supply_mut().increase_supply(<a href="../sui/token.md#sui_token_amount">amount</a>);
+    <a href="../sui/token.md#sui_token_Token">Token</a> { id: object::new(ctx), balance }
 }
 </code></pre>
 
@@ -1479,7 +1479,7 @@ Mint a <code><a href="../sui/token.md#sui_token_Token">Token</a></code> with a g
 Burn a <code><a href="../sui/token.md#sui_token_Token">Token</a></code> using the <code>TreasuryCap</code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/token.md#sui_token_burn">burn</a>&lt;T&gt;(cap: &<b>mut</b> <a href="../sui/coin.md#sui_coin_TreasuryCap">sui::coin::TreasuryCap</a>&lt;T&gt;, <a href="../sui/token.md#sui_token">token</a>: <a href="../sui/token.md#sui_token_Token">sui::token::Token</a>&lt;T&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/token.md#sui_token_burn">burn</a>&lt;T&gt;(cap: &<b>mut</b> <a href="../sui/coin.md#sui_coin_TreasuryCap">sui::coin::TreasuryCap</a>&lt;T&gt;, token: <a href="../sui/token.md#sui_token_Token">sui::token::Token</a>&lt;T&gt;)
 </code></pre>
 
 
@@ -1488,9 +1488,9 @@ Burn a <code><a href="../sui/token.md#sui_token_Token">Token</a></code> using th
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/token.md#sui_token_burn">burn</a>&lt;T&gt;(cap: &<b>mut</b> TreasuryCap&lt;T&gt;, <a href="../sui/token.md#sui_token">token</a>: <a href="../sui/token.md#sui_token_Token">Token</a>&lt;T&gt;) {
-    <b>let</b> <a href="../sui/token.md#sui_token_Token">Token</a> { id, <a href="../sui/balance.md#sui_balance">balance</a> } = <a href="../sui/token.md#sui_token">token</a>;
-    cap.supply_mut().decrease_supply(<a href="../sui/balance.md#sui_balance">balance</a>);
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/token.md#sui_token_burn">burn</a>&lt;T&gt;(cap: &<b>mut</b> TreasuryCap&lt;T&gt;, token: <a href="../sui/token.md#sui_token_Token">Token</a>&lt;T&gt;) {
+    <b>let</b> <a href="../sui/token.md#sui_token_Token">Token</a> { id, balance } = token;
+    cap.supply_mut().decrease_supply(balance);
     id.delete();
 }
 </code></pre>
@@ -1522,8 +1522,8 @@ action is only available to the <code>TreasuryCap</code> owner.
     _ctx: &<b>mut</b> TxContext,
 ): u64 {
     <b>let</b> <a href="../sui/token.md#sui_token_amount">amount</a> = self.<a href="../sui/token.md#sui_token_spent_balance">spent_balance</a>.<a href="../sui/token.md#sui_token_value">value</a>();
-    <b>let</b> <a href="../sui/balance.md#sui_balance">balance</a> = self.<a href="../sui/token.md#sui_token_spent_balance">spent_balance</a>.<a href="../sui/token.md#sui_token_split">split</a>(<a href="../sui/token.md#sui_token_amount">amount</a>);
-    cap.supply_mut().decrease_supply(<a href="../sui/balance.md#sui_balance">balance</a>)
+    <b>let</b> balance = self.<a href="../sui/token.md#sui_token_spent_balance">spent_balance</a>.<a href="../sui/token.md#sui_token_split">split</a>(<a href="../sui/token.md#sui_token_amount">amount</a>);
+    cap.supply_mut().decrease_supply(balance)
 }
 </code></pre>
 
@@ -1610,7 +1610,7 @@ Returns the <code><a href="../sui/token.md#sui_token_spent_balance">spent_balanc
 
 ## Function `value`
 
-Returns the <code><a href="../sui/balance.md#sui_balance">balance</a></code> of the <code><a href="../sui/token.md#sui_token_Token">Token</a></code>.
+Returns the <code>balance</code> of the <code><a href="../sui/token.md#sui_token_Token">Token</a></code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/token.md#sui_token_value">value</a>&lt;T&gt;(t: &<a href="../sui/token.md#sui_token_Token">sui::token::Token</a>&lt;T&gt;): u64
@@ -1623,7 +1623,7 @@ Returns the <code><a href="../sui/balance.md#sui_balance">balance</a></code> of 
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/token.md#sui_token_value">value</a>&lt;T&gt;(t: &<a href="../sui/token.md#sui_token_Token">Token</a>&lt;T&gt;): u64 {
-    t.<a href="../sui/balance.md#sui_balance">balance</a>.<a href="../sui/token.md#sui_token_value">value</a>()
+    t.balance.<a href="../sui/token.md#sui_token_value">value</a>()
 }
 </code></pre>
 
@@ -1872,7 +1872,7 @@ Burned balance of the <code><a href="../sui/token.md#sui_token_ActionRequest">Ac
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/token.md#sui_token_spent">spent</a>&lt;T&gt;(self: &<a href="../sui/token.md#sui_token_ActionRequest">ActionRequest</a>&lt;T&gt;): Option&lt;u64&gt; {
     <b>if</b> (self.<a href="../sui/token.md#sui_token_spent_balance">spent_balance</a>.is_some()) {
-        option::some(self.<a href="../sui/token.md#sui_token_spent_balance">spent_balance</a>.<a href="../sui/borrow.md#sui_borrow">borrow</a>().<a href="../sui/token.md#sui_token_value">value</a>())
+        option::some(self.<a href="../sui/token.md#sui_token_spent_balance">spent_balance</a>.borrow().<a href="../sui/token.md#sui_token_value">value</a>())
     } <b>else</b> {
         option::none()
     }

--- a/crates/sui-framework/docs/sui/transfer.md
+++ b/crates/sui-framework/docs/sui/transfer.md
@@ -149,7 +149,7 @@ Operation is not yet supported by the network. The functionality might still be 
 
 
 <pre><code>#[error]
-<b>const</b> <a href="../sui/transfer.md#sui_transfer_EInvalidPartyPermissions">EInvalidPartyPermissions</a>: vector&lt;u8&gt; = b"Party <a href="../sui/transfer.md#sui_transfer">transfer</a> is currently limited to one <a href="../sui/party.md#sui_party">party</a>.";
+<b>const</b> <a href="../sui/transfer.md#sui_transfer_EInvalidPartyPermissions">EInvalidPartyPermissions</a>: vector&lt;u8&gt; = b"Party <a href="../sui/transfer.md#sui_transfer_transfer">transfer</a> is currently limited to one party.";
 </code></pre>
 
 
@@ -163,11 +163,11 @@ which (in turn) ensures that <code>obj</code> has a globally unique ID. Note tha
 address represents an object ID, the <code>obj</code> sent will be inaccessible after the transfer
 (though they will be retrievable at a future date once new features are added).
 This function has custom rules performed by the Sui Move bytecode verifier that ensures
-that <code>T</code> is an object defined in the module where <code><a href="../sui/transfer.md#sui_transfer">transfer</a></code> is invoked. Use
+that <code>T</code> is an object defined in the module where <code><a href="../sui/transfer.md#sui_transfer_transfer">transfer</a></code> is invoked. Use
 <code><a href="../sui/transfer.md#sui_transfer_public_transfer">public_transfer</a></code> to transfer an object with <code>store</code> outside of its module.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/transfer.md#sui_transfer">transfer</a>&lt;T: key&gt;(obj: T, recipient: <b>address</b>)
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/transfer.md#sui_transfer_transfer">transfer</a>&lt;T: key&gt;(obj: T, recipient: <b>address</b>)
 </code></pre>
 
 
@@ -176,7 +176,7 @@ that <code>T</code> is an object defined in the module where <code><a href="../s
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/transfer.md#sui_transfer">transfer</a>&lt;T: key&gt;(obj: T, recipient: <b>address</b>) {
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/transfer.md#sui_transfer_transfer">transfer</a>&lt;T: key&gt;(obj: T, recipient: <b>address</b>) {
     <a href="../sui/transfer.md#sui_transfer_transfer_impl">transfer_impl</a>(obj, recipient)
 }
 </code></pre>
@@ -218,19 +218,19 @@ The object must have <code>store</code> to be transferred outside of its module.
 
 ## Function `party_transfer`
 
-Transfer ownership of <code>obj</code> to the <code><a href="../sui/party.md#sui_party">party</a></code>. This transfer behaves similar to both
-<code><a href="../sui/transfer.md#sui_transfer">transfer</a></code> and <code><a href="../sui/transfer.md#sui_transfer_share_object">share_object</a></code>. It is similar to <code><a href="../sui/transfer.md#sui_transfer">transfer</a></code> in that the object is authorized for
-use only by the recipient(s), in this case the <code><a href="../sui/party.md#sui_party">party</a></code>. This means that only the members
+Transfer ownership of <code>obj</code> to the <code>party</code>. This transfer behaves similar to both
+<code><a href="../sui/transfer.md#sui_transfer_transfer">transfer</a></code> and <code><a href="../sui/transfer.md#sui_transfer_share_object">share_object</a></code>. It is similar to <code><a href="../sui/transfer.md#sui_transfer_transfer">transfer</a></code> in that the object is authorized for
+use only by the recipient(s), in this case the <code>party</code>. This means that only the members
 can use the object as an input to a transaction. It is similar to <code><a href="../sui/transfer.md#sui_transfer_share_object">share_object</a></code> two ways. One
 in that the object can potentially be used by anyone, as defined by the <code>default</code> permissions of
 the <code>Party</code> value. The other in that the object must be used in consensus and cannot be
 used in the fast path.
 This function has custom rules performed by the Sui Move bytecode verifier that ensures that <code>T</code>
-is an object defined in the module where <code><a href="../sui/transfer.md#sui_transfer">transfer</a></code> is invoked. Use <code><a href="../sui/transfer.md#sui_transfer_public_party_transfer">public_party_transfer</a></code>
+is an object defined in the module where <code><a href="../sui/transfer.md#sui_transfer_transfer">transfer</a></code> is invoked. Use <code><a href="../sui/transfer.md#sui_transfer_public_party_transfer">public_party_transfer</a></code>
 to transfer an object with <code>store</code> outside of its module.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/transfer.md#sui_transfer_party_transfer">party_transfer</a>&lt;T: key&gt;(obj: T, <a href="../sui/party.md#sui_party">party</a>: <a href="../sui/party.md#sui_party_Party">sui::party::Party</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/transfer.md#sui_transfer_party_transfer">party_transfer</a>&lt;T: key&gt;(obj: T, party: <a href="../sui/party.md#sui_party_Party">sui::party::Party</a>)
 </code></pre>
 
 
@@ -239,9 +239,9 @@ to transfer an object with <code>store</code> outside of its module.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/transfer.md#sui_transfer_party_transfer">party_transfer</a>&lt;T: key&gt;(obj: T, <a href="../sui/party.md#sui_party">party</a>: <a href="../sui/party.md#sui_party_Party">sui::party::Party</a>) {
-    <b>assert</b>!(<a href="../sui/party.md#sui_party">party</a>.is_single_owner(), <a href="../sui/transfer.md#sui_transfer_EInvalidPartyPermissions">EInvalidPartyPermissions</a>);
-    <b>let</b> (default, addresses, permissions) = <a href="../sui/party.md#sui_party">party</a>.into_native();
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/transfer.md#sui_transfer_party_transfer">party_transfer</a>&lt;T: key&gt;(obj: T, party: <a href="../sui/party.md#sui_party_Party">sui::party::Party</a>) {
+    <b>assert</b>!(party.is_single_owner(), <a href="../sui/transfer.md#sui_transfer_EInvalidPartyPermissions">EInvalidPartyPermissions</a>);
+    <b>let</b> (default, addresses, permissions) = party.into_native();
     <a href="../sui/transfer.md#sui_transfer_party_transfer_impl">party_transfer_impl</a>(obj, default, addresses, permissions)
 }
 </code></pre>
@@ -254,9 +254,9 @@ to transfer an object with <code>store</code> outside of its module.
 
 ## Function `public_party_transfer`
 
-Transfer ownership of <code>obj</code> to the <code><a href="../sui/party.md#sui_party">party</a></code>. This transfer behaves similar to both
-<code><a href="../sui/transfer.md#sui_transfer">transfer</a></code> and <code><a href="../sui/transfer.md#sui_transfer_share_object">share_object</a></code>. It is similar to <code><a href="../sui/transfer.md#sui_transfer">transfer</a></code> in that the object is authorized for
-use only by the recipient(s), in this case the <code><a href="../sui/party.md#sui_party">party</a></code>. This means that only the members
+Transfer ownership of <code>obj</code> to the <code>party</code>. This transfer behaves similar to both
+<code><a href="../sui/transfer.md#sui_transfer_transfer">transfer</a></code> and <code><a href="../sui/transfer.md#sui_transfer_share_object">share_object</a></code>. It is similar to <code><a href="../sui/transfer.md#sui_transfer_transfer">transfer</a></code> in that the object is authorized for
+use only by the recipient(s), in this case the <code>party</code>. This means that only the members
 can use the object as an input to a transaction. It is similar to <code><a href="../sui/transfer.md#sui_transfer_share_object">share_object</a></code> two ways. One
 in that the object can potentially be used by anyone, as defined by the <code>default</code> permissions of
 the <code>Party</code> value. The other in that the object must be used in consensus and cannot be
@@ -264,7 +264,7 @@ used in the fast path.
 The object must have <code>store</code> to be transferred outside of its module.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/transfer.md#sui_transfer_public_party_transfer">public_party_transfer</a>&lt;T: key, store&gt;(obj: T, <a href="../sui/party.md#sui_party">party</a>: <a href="../sui/party.md#sui_party_Party">sui::party::Party</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/transfer.md#sui_transfer_public_party_transfer">public_party_transfer</a>&lt;T: key, store&gt;(obj: T, party: <a href="../sui/party.md#sui_party_Party">sui::party::Party</a>)
 </code></pre>
 
 
@@ -273,9 +273,9 @@ The object must have <code>store</code> to be transferred outside of its module.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/transfer.md#sui_transfer_public_party_transfer">public_party_transfer</a>&lt;T: key + store&gt;(obj: T, <a href="../sui/party.md#sui_party">party</a>: <a href="../sui/party.md#sui_party_Party">sui::party::Party</a>) {
-    <b>assert</b>!(<a href="../sui/party.md#sui_party">party</a>.is_single_owner(), <a href="../sui/transfer.md#sui_transfer_EInvalidPartyPermissions">EInvalidPartyPermissions</a>);
-    <b>let</b> (default, addresses, permissions) = <a href="../sui/party.md#sui_party">party</a>.into_native();
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/transfer.md#sui_transfer_public_party_transfer">public_party_transfer</a>&lt;T: key + store&gt;(obj: T, party: <a href="../sui/party.md#sui_party_Party">sui::party::Party</a>) {
+    <b>assert</b>!(party.is_single_owner(), <a href="../sui/transfer.md#sui_transfer_EInvalidPartyPermissions">EInvalidPartyPermissions</a>);
+    <b>let</b> (default, addresses, permissions) = party.into_native();
     <a href="../sui/transfer.md#sui_transfer_party_transfer_impl">party_transfer_impl</a>(obj, default, addresses, permissions)
 }
 </code></pre>
@@ -491,7 +491,7 @@ Return the object ID that the given <code><a href="../sui/transfer.md#sui_transf
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/transfer.md#sui_transfer_freeze_object_impl">freeze_object_impl</a>&lt;T: key&gt;(obj: T)
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/transfer.md#sui_transfer_freeze_object_impl">freeze_object_impl</a>&lt;T: key&gt;(obj: T)
 </code></pre>
 
 
@@ -500,7 +500,7 @@ Return the object ID that the given <code><a href="../sui/transfer.md#sui_transf
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>native</b> <b>fun</b> <a href="../sui/transfer.md#sui_transfer_freeze_object_impl">freeze_object_impl</a>&lt;T: key&gt;(obj: T);
+<pre><code><b>public</b>(package) <b>native</b> <b>fun</b> <a href="../sui/transfer.md#sui_transfer_freeze_object_impl">freeze_object_impl</a>&lt;T: key&gt;(obj: T);
 </code></pre>
 
 
@@ -513,7 +513,7 @@ Return the object ID that the given <code><a href="../sui/transfer.md#sui_transf
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/transfer.md#sui_transfer_share_object_impl">share_object_impl</a>&lt;T: key&gt;(obj: T)
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/transfer.md#sui_transfer_share_object_impl">share_object_impl</a>&lt;T: key&gt;(obj: T)
 </code></pre>
 
 
@@ -522,7 +522,7 @@ Return the object ID that the given <code><a href="../sui/transfer.md#sui_transf
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>native</b> <b>fun</b> <a href="../sui/transfer.md#sui_transfer_share_object_impl">share_object_impl</a>&lt;T: key&gt;(obj: T);
+<pre><code><b>public</b>(package) <b>native</b> <b>fun</b> <a href="../sui/transfer.md#sui_transfer_share_object_impl">share_object_impl</a>&lt;T: key&gt;(obj: T);
 </code></pre>
 
 
@@ -535,7 +535,7 @@ Return the object ID that the given <code><a href="../sui/transfer.md#sui_transf
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/transfer.md#sui_transfer_party_transfer_impl">party_transfer_impl</a>&lt;T: key&gt;(obj: T, default_permissions: u64, addresses: vector&lt;<b>address</b>&gt;, permissions: vector&lt;u64&gt;)
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/transfer.md#sui_transfer_party_transfer_impl">party_transfer_impl</a>&lt;T: key&gt;(obj: T, default_permissions: u64, addresses: vector&lt;<b>address</b>&gt;, permissions: vector&lt;u64&gt;)
 </code></pre>
 
 
@@ -544,7 +544,7 @@ Return the object ID that the given <code><a href="../sui/transfer.md#sui_transf
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>native</b> <b>fun</b> <a href="../sui/transfer.md#sui_transfer_party_transfer_impl">party_transfer_impl</a>&lt;T: key&gt;(
+<pre><code><b>public</b>(package) <b>native</b> <b>fun</b> <a href="../sui/transfer.md#sui_transfer_party_transfer_impl">party_transfer_impl</a>&lt;T: key&gt;(
     obj: T,
     default_permissions: u64,
     addresses: vector&lt;<b>address</b>&gt;,
@@ -562,7 +562,7 @@ Return the object ID that the given <code><a href="../sui/transfer.md#sui_transf
 
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> <a href="../sui/transfer.md#sui_transfer_transfer_impl">transfer_impl</a>&lt;T: key&gt;(obj: T, recipient: <b>address</b>)
+<pre><code><b>public</b>(package) <b>fun</b> <a href="../sui/transfer.md#sui_transfer_transfer_impl">transfer_impl</a>&lt;T: key&gt;(obj: T, recipient: <b>address</b>)
 </code></pre>
 
 
@@ -571,7 +571,7 @@ Return the object ID that the given <code><a href="../sui/transfer.md#sui_transf
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>native</b> <b>fun</b> <a href="../sui/transfer.md#sui_transfer_transfer_impl">transfer_impl</a>&lt;T: key&gt;(obj: T, recipient: <b>address</b>);
+<pre><code><b>public</b>(package) <b>native</b> <b>fun</b> <a href="../sui/transfer.md#sui_transfer_transfer_impl">transfer_impl</a>&lt;T: key&gt;(obj: T, recipient: <b>address</b>);
 </code></pre>
 
 

--- a/crates/sui-framework/docs/sui/transfer_policy.md
+++ b/crates/sui-framework/docs/sui/transfer_policy.md
@@ -170,7 +170,7 @@ policies can be used to confirm the <code><a href="../sui/transfer_policy.md#sui
 <dd>
 </dd>
 <dt>
-<code><a href="../sui/balance.md#sui_balance">balance</a>: <a href="../sui/balance.md#sui_balance_Balance">sui::balance::Balance</a>&lt;<a href="../sui/sui.md#sui_sui_SUI">sui::sui::SUI</a>&gt;</code>
+<code>balance: <a href="../sui/balance.md#sui_balance_Balance">sui::balance::Balance</a>&lt;<a href="../sui/sui.md#sui_sui_SUI">sui::sui::SUI</a>&gt;</code>
 </dt>
 <dd>
  The Balance of the <code><a href="../sui/transfer_policy.md#sui_transfer_policy_TransferPolicy">TransferPolicy</a></code> which collects <code>SUI</code>.
@@ -387,7 +387,7 @@ the transaction will fail.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/transfer_policy.md#sui_transfer_policy_new_request">new_request</a>&lt;T&gt;(<a href="../sui/transfer_policy.md#sui_transfer_policy_item">item</a>: ID, <a href="../sui/transfer_policy.md#sui_transfer_policy_paid">paid</a>: u64, <a href="../sui/transfer_policy.md#sui_transfer_policy_from">from</a>: ID): <a href="../sui/transfer_policy.md#sui_transfer_policy_TransferRequest">TransferRequest</a>&lt;T&gt; {
-    <a href="../sui/transfer_policy.md#sui_transfer_policy_TransferRequest">TransferRequest</a> { <a href="../sui/transfer_policy.md#sui_transfer_policy_item">item</a>, <a href="../sui/transfer_policy.md#sui_transfer_policy_paid">paid</a>, <a href="../sui/transfer_policy.md#sui_transfer_policy_from">from</a>, receipts: <a href="../sui/vec_set.md#sui_vec_set_empty">vec_set::empty</a>() }
+    <a href="../sui/transfer_policy.md#sui_transfer_policy_TransferRequest">TransferRequest</a> { <a href="../sui/transfer_policy.md#sui_transfer_policy_item">item</a>, <a href="../sui/transfer_policy.md#sui_transfer_policy_paid">paid</a>, <a href="../sui/transfer_policy.md#sui_transfer_policy_from">from</a>, receipts: vec_set::empty() }
 }
 </code></pre>
 
@@ -415,13 +415,13 @@ available for use, the type can not be traded in kiosks.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/transfer_policy.md#sui_transfer_policy_new">new</a>&lt;T&gt;(pub: &Publisher, ctx: &<b>mut</b> TxContext): (<a href="../sui/transfer_policy.md#sui_transfer_policy_TransferPolicy">TransferPolicy</a>&lt;T&gt;, <a href="../sui/transfer_policy.md#sui_transfer_policy_TransferPolicyCap">TransferPolicyCap</a>&lt;T&gt;) {
-    <b>assert</b>!(<a href="../sui/package.md#sui_package_from_package">package::from_package</a>&lt;T&gt;(pub), 0);
-    <b>let</b> id = <a href="../sui/object.md#sui_object_new">object::new</a>(ctx);
+    <b>assert</b>!(package::from_package&lt;T&gt;(pub), 0);
+    <b>let</b> id = object::new(ctx);
     <b>let</b> policy_id = id.to_inner();
-    <a href="../sui/event.md#sui_event_emit">event::emit</a>(<a href="../sui/transfer_policy.md#sui_transfer_policy_TransferPolicyCreated">TransferPolicyCreated</a>&lt;T&gt; { id: policy_id });
+    event::emit(<a href="../sui/transfer_policy.md#sui_transfer_policy_TransferPolicyCreated">TransferPolicyCreated</a>&lt;T&gt; { id: policy_id });
     (
-        <a href="../sui/transfer_policy.md#sui_transfer_policy_TransferPolicy">TransferPolicy</a> { id, <a href="../sui/transfer_policy.md#sui_transfer_policy_rules">rules</a>: <a href="../sui/vec_set.md#sui_vec_set_empty">vec_set::empty</a>(), <a href="../sui/balance.md#sui_balance">balance</a>: <a href="../sui/balance.md#sui_balance_zero">balance::zero</a>() },
-        <a href="../sui/transfer_policy.md#sui_transfer_policy_TransferPolicyCap">TransferPolicyCap</a> { id: <a href="../sui/object.md#sui_object_new">object::new</a>(ctx), policy_id },
+        <a href="../sui/transfer_policy.md#sui_transfer_policy_TransferPolicy">TransferPolicy</a> { id, <a href="../sui/transfer_policy.md#sui_transfer_policy_rules">rules</a>: vec_set::empty(), balance: balance::zero() },
+        <a href="../sui/transfer_policy.md#sui_transfer_policy_TransferPolicyCap">TransferPolicyCap</a> { id: object::new(ctx), policy_id },
     )
 }
 </code></pre>
@@ -482,15 +482,15 @@ is not specified, all profits are withdrawn.
     amount: Option&lt;u64&gt;,
     ctx: &<b>mut</b> TxContext,
 ): Coin&lt;SUI&gt; {
-    <b>assert</b>!(<a href="../sui/object.md#sui_object_id">object::id</a>(self) == cap.policy_id, <a href="../sui/transfer_policy.md#sui_transfer_policy_ENotOwner">ENotOwner</a>);
+    <b>assert</b>!(object::id(self) == cap.policy_id, <a href="../sui/transfer_policy.md#sui_transfer_policy_ENotOwner">ENotOwner</a>);
     <b>let</b> amount = <b>if</b> (amount.is_some()) {
         <b>let</b> amt = amount.destroy_some();
-        <b>assert</b>!(amt &lt;= self.<a href="../sui/balance.md#sui_balance">balance</a>.value(), <a href="../sui/transfer_policy.md#sui_transfer_policy_ENotEnough">ENotEnough</a>);
+        <b>assert</b>!(amt &lt;= self.balance.value(), <a href="../sui/transfer_policy.md#sui_transfer_policy_ENotEnough">ENotEnough</a>);
         amt
     } <b>else</b> {
-        self.<a href="../sui/balance.md#sui_balance">balance</a>.value()
+        self.balance.value()
     };
-    <a href="../sui/coin.md#sui_coin_take">coin::take</a>(&<b>mut</b> self.<a href="../sui/balance.md#sui_balance">balance</a>, amount, ctx)
+    coin::take(&<b>mut</b> self.balance, amount, ctx)
 }
 </code></pre>
 
@@ -520,13 +520,13 @@ Can be performed by any party as long as they own it.
     cap: <a href="../sui/transfer_policy.md#sui_transfer_policy_TransferPolicyCap">TransferPolicyCap</a>&lt;T&gt;,
     ctx: &<b>mut</b> TxContext,
 ): Coin&lt;SUI&gt; {
-    <b>assert</b>!(<a href="../sui/object.md#sui_object_id">object::id</a>(&self) == cap.policy_id, <a href="../sui/transfer_policy.md#sui_transfer_policy_ENotOwner">ENotOwner</a>);
+    <b>assert</b>!(object::id(&self) == cap.policy_id, <a href="../sui/transfer_policy.md#sui_transfer_policy_ENotOwner">ENotOwner</a>);
     <b>let</b> <a href="../sui/transfer_policy.md#sui_transfer_policy_TransferPolicyCap">TransferPolicyCap</a> { id: cap_id, policy_id } = cap;
-    <b>let</b> <a href="../sui/transfer_policy.md#sui_transfer_policy_TransferPolicy">TransferPolicy</a> { id, <a href="../sui/transfer_policy.md#sui_transfer_policy_rules">rules</a>: _, <a href="../sui/balance.md#sui_balance">balance</a> } = self;
+    <b>let</b> <a href="../sui/transfer_policy.md#sui_transfer_policy_TransferPolicy">TransferPolicy</a> { id, <a href="../sui/transfer_policy.md#sui_transfer_policy_rules">rules</a>: _, balance } = self;
     id.delete();
     cap_id.delete();
-    <a href="../sui/event.md#sui_event_emit">event::emit</a>(<a href="../sui/transfer_policy.md#sui_transfer_policy_TransferPolicyDestroyed">TransferPolicyDestroyed</a>&lt;T&gt; { id: policy_id });
-    <a href="../sui/balance.md#sui_balance">balance</a>.into_coin(ctx)
+    event::emit(<a href="../sui/transfer_policy.md#sui_transfer_policy_TransferPolicyDestroyed">TransferPolicyDestroyed</a>&lt;T&gt; { id: policy_id });
+    balance.into_coin(ctx)
 }
 </code></pre>
 
@@ -606,7 +606,7 @@ even if graceful unpacking has not been implemented in a "rule module".
     cap: &<a href="../sui/transfer_policy.md#sui_transfer_policy_TransferPolicyCap">TransferPolicyCap</a>&lt;T&gt;,
     cfg: Config,
 ) {
-    <b>assert</b>!(<a href="../sui/object.md#sui_object_id">object::id</a>(policy) == cap.policy_id, <a href="../sui/transfer_policy.md#sui_transfer_policy_ENotOwner">ENotOwner</a>);
+    <b>assert</b>!(object::id(policy) == cap.policy_id, <a href="../sui/transfer_policy.md#sui_transfer_policy_ENotOwner">ENotOwner</a>);
     <b>assert</b>!(!<a href="../sui/transfer_policy.md#sui_transfer_policy_has_rule">has_rule</a>&lt;T, Rule&gt;(policy), <a href="../sui/transfer_policy.md#sui_transfer_policy_ERuleAlreadySet">ERuleAlreadySet</a>);
     df::add(&<b>mut</b> policy.id, <a href="../sui/transfer_policy.md#sui_transfer_policy_RuleKey">RuleKey</a>&lt;Rule&gt; {}, cfg);
     policy.<a href="../sui/transfer_policy.md#sui_transfer_policy_rules">rules</a>.insert(type_name::with_defining_ids&lt;Rule&gt;())
@@ -652,7 +652,7 @@ Get the custom Config for the Rule (can be only one per "Rule" type).
 Add some <code>SUI</code> to the balance of a <code><a href="../sui/transfer_policy.md#sui_transfer_policy_TransferPolicy">TransferPolicy</a></code>.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/transfer_policy.md#sui_transfer_policy_add_to_balance">add_to_balance</a>&lt;T, Rule: drop&gt;(_: Rule, policy: &<b>mut</b> <a href="../sui/transfer_policy.md#sui_transfer_policy_TransferPolicy">sui::transfer_policy::TransferPolicy</a>&lt;T&gt;, <a href="../sui/coin.md#sui_coin">coin</a>: <a href="../sui/coin.md#sui_coin_Coin">sui::coin::Coin</a>&lt;<a href="../sui/sui.md#sui_sui_SUI">sui::sui::SUI</a>&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/transfer_policy.md#sui_transfer_policy_add_to_balance">add_to_balance</a>&lt;T, Rule: drop&gt;(_: Rule, policy: &<b>mut</b> <a href="../sui/transfer_policy.md#sui_transfer_policy_TransferPolicy">sui::transfer_policy::TransferPolicy</a>&lt;T&gt;, coin: <a href="../sui/coin.md#sui_coin_Coin">sui::coin::Coin</a>&lt;<a href="../sui/sui.md#sui_sui_SUI">sui::sui::SUI</a>&gt;)
 </code></pre>
 
 
@@ -661,9 +661,9 @@ Add some <code>SUI</code> to the balance of a <code><a href="../sui/transfer_pol
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/transfer_policy.md#sui_transfer_policy_add_to_balance">add_to_balance</a>&lt;T, Rule: drop&gt;(_: Rule, policy: &<b>mut</b> <a href="../sui/transfer_policy.md#sui_transfer_policy_TransferPolicy">TransferPolicy</a>&lt;T&gt;, <a href="../sui/coin.md#sui_coin">coin</a>: Coin&lt;SUI&gt;) {
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/transfer_policy.md#sui_transfer_policy_add_to_balance">add_to_balance</a>&lt;T, Rule: drop&gt;(_: Rule, policy: &<b>mut</b> <a href="../sui/transfer_policy.md#sui_transfer_policy_TransferPolicy">TransferPolicy</a>&lt;T&gt;, coin: Coin&lt;SUI&gt;) {
     <b>assert</b>!(<a href="../sui/transfer_policy.md#sui_transfer_policy_has_rule">has_rule</a>&lt;T, Rule&gt;(policy), <a href="../sui/transfer_policy.md#sui_transfer_policy_EUnknownRequirement">EUnknownRequirement</a>);
-    <a href="../sui/coin.md#sui_coin_put">coin::put</a>(&<b>mut</b> policy.<a href="../sui/balance.md#sui_balance">balance</a>, <a href="../sui/coin.md#sui_coin">coin</a>)
+    coin::put(&<b>mut</b> policy.balance, coin)
 }
 </code></pre>
 
@@ -742,7 +742,7 @@ Remove the Rule from the <code><a href="../sui/transfer_policy.md#sui_transfer_p
     policy: &<b>mut</b> <a href="../sui/transfer_policy.md#sui_transfer_policy_TransferPolicy">TransferPolicy</a>&lt;T&gt;,
     cap: &<a href="../sui/transfer_policy.md#sui_transfer_policy_TransferPolicyCap">TransferPolicyCap</a>&lt;T&gt;,
 ) {
-    <b>assert</b>!(<a href="../sui/object.md#sui_object_id">object::id</a>(policy) == cap.policy_id, <a href="../sui/transfer_policy.md#sui_transfer_policy_ENotOwner">ENotOwner</a>);
+    <b>assert</b>!(object::id(policy) == cap.policy_id, <a href="../sui/transfer_policy.md#sui_transfer_policy_ENotOwner">ENotOwner</a>);
     <b>let</b> _: Config = df::remove(&<b>mut</b> policy.id, <a href="../sui/transfer_policy.md#sui_transfer_policy_RuleKey">RuleKey</a>&lt;Rule&gt; {});
     policy.<a href="../sui/transfer_policy.md#sui_transfer_policy_rules">rules</a>.remove(&type_name::with_defining_ids&lt;Rule&gt;());
 }
@@ -793,7 +793,7 @@ to the <code><a href="../sui/transfer_policy.md#sui_transfer_policy_TransferPoli
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/transfer_policy.md#sui_transfer_policy_uid_mut_as_owner">uid_mut_as_owner</a>&lt;T&gt;(self: &<b>mut</b> <a href="../sui/transfer_policy.md#sui_transfer_policy_TransferPolicy">TransferPolicy</a>&lt;T&gt;, cap: &<a href="../sui/transfer_policy.md#sui_transfer_policy_TransferPolicyCap">TransferPolicyCap</a>&lt;T&gt;): &<b>mut</b> UID {
-    <b>assert</b>!(<a href="../sui/object.md#sui_object_id">object::id</a>(self) == cap.policy_id, <a href="../sui/transfer_policy.md#sui_transfer_policy_ENotOwner">ENotOwner</a>);
+    <b>assert</b>!(object::id(self) == cap.policy_id, <a href="../sui/transfer_policy.md#sui_transfer_policy_ENotOwner">ENotOwner</a>);
     &<b>mut</b> self.id
 }
 </code></pre>

--- a/crates/sui-framework/docs/sui/url.md
+++ b/crates/sui-framework/docs/sui/url.md
@@ -37,7 +37,7 @@ Standard Uniform Resource Locator (URL) string.
 
 <dl>
 <dt>
-<code><a href="../sui/url.md#sui_url">url</a>: <a href="../std/ascii.md#std_ascii_String">std::ascii::String</a></code>
+<code>url: <a href="../std/ascii.md#std_ascii_String">std::ascii::String</a></code>
 </dt>
 <dd>
 </dd>
@@ -53,7 +53,7 @@ Standard Uniform Resource Locator (URL) string.
 Create a <code><a href="../sui/url.md#sui_url_Url">Url</a></code>, with no validation
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/url.md#sui_url_new_unsafe">new_unsafe</a>(<a href="../sui/url.md#sui_url">url</a>: <a href="../std/ascii.md#std_ascii_String">std::ascii::String</a>): <a href="../sui/url.md#sui_url_Url">sui::url::Url</a>
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/url.md#sui_url_new_unsafe">new_unsafe</a>(url: <a href="../std/ascii.md#std_ascii_String">std::ascii::String</a>): <a href="../sui/url.md#sui_url_Url">sui::url::Url</a>
 </code></pre>
 
 
@@ -62,8 +62,8 @@ Create a <code><a href="../sui/url.md#sui_url_Url">Url</a></code>, with no valid
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/url.md#sui_url_new_unsafe">new_unsafe</a>(<a href="../sui/url.md#sui_url">url</a>: String): <a href="../sui/url.md#sui_url_Url">Url</a> {
-    <a href="../sui/url.md#sui_url_Url">Url</a> { <a href="../sui/url.md#sui_url">url</a> }
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/url.md#sui_url_new_unsafe">new_unsafe</a>(url: String): <a href="../sui/url.md#sui_url_Url">Url</a> {
+    <a href="../sui/url.md#sui_url_Url">Url</a> { url }
 }
 </code></pre>
 
@@ -89,8 +89,8 @@ Note: this will abort if <code>bytes</code> is not valid ASCII
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/url.md#sui_url_new_unsafe_from_bytes">new_unsafe_from_bytes</a>(bytes: vector&lt;u8&gt;): <a href="../sui/url.md#sui_url_Url">Url</a> {
-    <b>let</b> <a href="../sui/url.md#sui_url">url</a> = bytes.to_ascii_string();
-    <a href="../sui/url.md#sui_url_Url">Url</a> { <a href="../sui/url.md#sui_url">url</a> }
+    <b>let</b> url = bytes.to_ascii_string();
+    <a href="../sui/url.md#sui_url_Url">Url</a> { url }
 }
 </code></pre>
 
@@ -115,7 +115,7 @@ Get inner URL
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/url.md#sui_url_inner_url">inner_url</a>(self: &<a href="../sui/url.md#sui_url_Url">Url</a>): String {
-    self.<a href="../sui/url.md#sui_url">url</a>
+    self.url
 }
 </code></pre>
 
@@ -130,7 +130,7 @@ Get inner URL
 Update the inner URL
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/url.md#sui_url_update">update</a>(self: &<b>mut</b> <a href="../sui/url.md#sui_url_Url">sui::url::Url</a>, <a href="../sui/url.md#sui_url">url</a>: <a href="../std/ascii.md#std_ascii_String">std::ascii::String</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/url.md#sui_url_update">update</a>(self: &<b>mut</b> <a href="../sui/url.md#sui_url_Url">sui::url::Url</a>, url: <a href="../std/ascii.md#std_ascii_String">std::ascii::String</a>)
 </code></pre>
 
 
@@ -139,8 +139,8 @@ Update the inner URL
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="../sui/url.md#sui_url_update">update</a>(self: &<b>mut</b> <a href="../sui/url.md#sui_url_Url">Url</a>, <a href="../sui/url.md#sui_url">url</a>: String) {
-    self.<a href="../sui/url.md#sui_url">url</a> = <a href="../sui/url.md#sui_url">url</a>;
+<pre><code><b>public</b> <b>fun</b> <a href="../sui/url.md#sui_url_update">update</a>(self: &<b>mut</b> <a href="../sui/url.md#sui_url_Url">Url</a>, url: String) {
+    self.url = url;
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/sui/versioned.md
+++ b/crates/sui-framework/docs/sui/versioned.md
@@ -133,10 +133,10 @@ Create a new Versioned object that contains a initial value of type <code>T</cod
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/versioned.md#sui_versioned_create">create</a>&lt;T: store&gt;(init_version: u64, init_value: T, ctx: &<b>mut</b> TxContext): <a href="../sui/versioned.md#sui_versioned_Versioned">Versioned</a> {
     <b>let</b> <b>mut</b> self = <a href="../sui/versioned.md#sui_versioned_Versioned">Versioned</a> {
-        id: <a href="../sui/object.md#sui_object_new">object::new</a>(ctx),
+        id: object::new(ctx),
         <a href="../sui/versioned.md#sui_versioned_version">version</a>: init_version,
     };
-    <a href="../sui/dynamic_field.md#sui_dynamic_field_add">dynamic_field::add</a>(&<b>mut</b> self.id, init_version, init_value);
+    dynamic_field::add(&<b>mut</b> self.id, init_version, init_value);
     self
 }
 </code></pre>
@@ -188,7 +188,7 @@ If the type mismatch, the load will fail.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/versioned.md#sui_versioned_load_value">load_value</a>&lt;T: store&gt;(self: &<a href="../sui/versioned.md#sui_versioned_Versioned">Versioned</a>): &T {
-    <a href="../sui/dynamic_field.md#sui_dynamic_field_borrow">dynamic_field::borrow</a>(&self.id, self.<a href="../sui/versioned.md#sui_versioned_version">version</a>)
+    dynamic_field::borrow(&self.id, self.<a href="../sui/versioned.md#sui_versioned_version">version</a>)
 }
 </code></pre>
 
@@ -213,7 +213,7 @@ Similar to load_value, but return a mutable reference.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/versioned.md#sui_versioned_load_value_mut">load_value_mut</a>&lt;T: store&gt;(self: &<b>mut</b> <a href="../sui/versioned.md#sui_versioned_Versioned">Versioned</a>): &<b>mut</b> T {
-    <a href="../sui/dynamic_field.md#sui_dynamic_field_borrow_mut">dynamic_field::borrow_mut</a>(&<b>mut</b> self.id, self.<a href="../sui/versioned.md#sui_versioned_version">version</a>)
+    dynamic_field::borrow_mut(&<b>mut</b> self.id, self.<a href="../sui/versioned.md#sui_versioned_version">version</a>)
 }
 </code></pre>
 
@@ -240,9 +240,9 @@ and must be used when we upgrade.
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/versioned.md#sui_versioned_remove_value_for_upgrade">remove_value_for_upgrade</a>&lt;T: store&gt;(self: &<b>mut</b> <a href="../sui/versioned.md#sui_versioned_Versioned">Versioned</a>): (T, <a href="../sui/versioned.md#sui_versioned_VersionChangeCap">VersionChangeCap</a>) {
     (
-        <a href="../sui/dynamic_field.md#sui_dynamic_field_remove">dynamic_field::remove</a>(&<b>mut</b> self.id, self.<a href="../sui/versioned.md#sui_versioned_version">version</a>),
+        dynamic_field::remove(&<b>mut</b> self.id, self.<a href="../sui/versioned.md#sui_versioned_version">version</a>),
         <a href="../sui/versioned.md#sui_versioned_VersionChangeCap">VersionChangeCap</a> {
-            versioned_id: <a href="../sui/object.md#sui_object_id">object::id</a>(self),
+            versioned_id: object::id(self),
             old_version: self.<a href="../sui/versioned.md#sui_versioned_version">version</a>,
         },
     )
@@ -277,9 +277,9 @@ by calling remove_value_for_upgrade.
     cap: <a href="../sui/versioned.md#sui_versioned_VersionChangeCap">VersionChangeCap</a>,
 ) {
     <b>let</b> <a href="../sui/versioned.md#sui_versioned_VersionChangeCap">VersionChangeCap</a> { versioned_id, old_version } = cap;
-    <b>assert</b>!(versioned_id == <a href="../sui/object.md#sui_object_id">object::id</a>(self), <a href="../sui/versioned.md#sui_versioned_EInvalidUpgrade">EInvalidUpgrade</a>);
+    <b>assert</b>!(versioned_id == object::id(self), <a href="../sui/versioned.md#sui_versioned_EInvalidUpgrade">EInvalidUpgrade</a>);
     <b>assert</b>!(old_version &lt; new_version, <a href="../sui/versioned.md#sui_versioned_EInvalidUpgrade">EInvalidUpgrade</a>);
-    <a href="../sui/dynamic_field.md#sui_dynamic_field_add">dynamic_field::add</a>(&<b>mut</b> self.id, new_version, new_value);
+    dynamic_field::add(&<b>mut</b> self.id, new_version, new_value);
     self.<a href="../sui/versioned.md#sui_versioned_version">version</a> = new_version;
 }
 </code></pre>
@@ -306,7 +306,7 @@ Destroy this Versioned container, and return the inner object.
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/versioned.md#sui_versioned_destroy">destroy</a>&lt;T: store&gt;(self: <a href="../sui/versioned.md#sui_versioned_Versioned">Versioned</a>): T {
     <b>let</b> <a href="../sui/versioned.md#sui_versioned_Versioned">Versioned</a> { <b>mut</b> id, <a href="../sui/versioned.md#sui_versioned_version">version</a> } = self;
-    <b>let</b> ret = <a href="../sui/dynamic_field.md#sui_dynamic_field_remove">dynamic_field::remove</a>(&<b>mut</b> id, <a href="../sui/versioned.md#sui_versioned_version">version</a>);
+    <b>let</b> ret = dynamic_field::remove(&<b>mut</b> id, <a href="../sui/versioned.md#sui_versioned_version">version</a>);
     id.delete();
     ret
 }

--- a/crates/sui-framework/docs/sui/zklogin_verified_issuer.md
+++ b/crates/sui-framework/docs/sui/zklogin_verified_issuer.md
@@ -194,9 +194,9 @@ Aborts with <code><a href="../sui/zklogin_verified_issuer.md#sui_zklogin_verifie
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/zklogin_verified_issuer.md#sui_zklogin_verified_issuer_verify_zklogin_issuer">verify_zklogin_issuer</a>(address_seed: u256, <a href="../sui/zklogin_verified_issuer.md#sui_zklogin_verified_issuer_issuer">issuer</a>: String, ctx: &<b>mut</b> TxContext) {
     <b>let</b> sender = ctx.sender();
     <b>assert</b>!(<a href="../sui/zklogin_verified_issuer.md#sui_zklogin_verified_issuer_check_zklogin_issuer">check_zklogin_issuer</a>(sender, address_seed, &<a href="../sui/zklogin_verified_issuer.md#sui_zklogin_verified_issuer_issuer">issuer</a>), <a href="../sui/zklogin_verified_issuer.md#sui_zklogin_verified_issuer_EInvalidProof">EInvalidProof</a>);
-    <a href="../sui/transfer.md#sui_transfer_transfer">transfer::transfer</a>(
+    transfer::transfer(
         <a href="../sui/zklogin_verified_issuer.md#sui_zklogin_verified_issuer_VerifiedIssuer">VerifiedIssuer</a> {
-            id: <a href="../sui/object.md#sui_object_new">object::new</a>(ctx),
+            id: object::new(ctx),
             <a href="../sui/zklogin_verified_issuer.md#sui_zklogin_verified_issuer_owner">owner</a>: sender,
             <a href="../sui/zklogin_verified_issuer.md#sui_zklogin_verified_issuer_issuer">issuer</a>,
         },

--- a/crates/sui-framework/docs/sui_system/staking_pool.md
+++ b/crates/sui-framework/docs/sui_system/staking_pool.md
@@ -1099,12 +1099,12 @@ Called at epoch boundaries to process the pending stake.
 ## Function `withdraw_rewards`
 
 This function does the following:
-1. Calculates the total amount of SUI (including principal and rewards) that the provided pool tokens represent
-at the current exchange rate.
-2. Using the above number and the given <code>principal_withdraw_amount</code>, calculates the rewards portion of the
-stake we should withdraw.
-3. Withdraws the rewards portion from the rewards pool at the current exchange rate. We only withdraw the rewards
-portion because the principal portion was already taken out of the staker's self custodied StakedSui.
+    1. Calculates the total amount of SUI (including principal and rewards) that the provided pool tokens represent
+       at the current exchange rate.
+    2. Using the above number and the given <code>principal_withdraw_amount</code>, calculates the rewards portion of the
+       stake we should withdraw.
+    3. Withdraws the rewards portion from the rewards pool at the current exchange rate. We only withdraw the rewards
+       portion because the principal portion was already taken out of the staker's self custodied StakedSui.
 
 
 <pre><code><b>fun</b> <a href="../sui_system/staking_pool.md#sui_system_staking_pool_withdraw_rewards">withdraw_rewards</a>(pool: &<b>mut</b> <a href="../sui_system/staking_pool.md#sui_system_staking_pool_StakingPool">sui_system::staking_pool::StakingPool</a>, principal_withdraw_amount: u64, pool_token_withdraw_amount: u64, epoch: u64): <a href="../sui/balance.md#sui_balance_Balance">sui::balance::Balance</a>&lt;<a href="../sui/sui.md#sui_sui_SUI">sui::sui::SUI</a>&gt;

--- a/crates/sui-framework/docs/sui_system/storage_fund.md
+++ b/crates/sui-framework/docs/sui_system/storage_fund.md
@@ -56,12 +56,12 @@ title: Module `sui_system::storage_fund`
 
 Struct representing the storage fund, containing two <code>Balance</code>s:
 - <code><a href="../sui_system/storage_fund.md#sui_system_storage_fund_total_object_storage_rebates">total_object_storage_rebates</a></code> has the invariant that it's the sum of <code>storage_rebate</code> of
-all objects currently stored on-chain. To maintain this invariant, the only inflow of this
-balance is storage charges collected from transactions, and the only outflow is storage rebates
-of transactions, including both the portion refunded to the transaction senders as well as
-the non-refundable portion taken out and put into <code>non_refundable_balance</code>.
+   all objects currently stored on-chain. To maintain this invariant, the only inflow of this
+   balance is storage charges collected from transactions, and the only outflow is storage rebates
+   of transactions, including both the portion refunded to the transaction senders as well as
+   the non-refundable portion taken out and put into <code>non_refundable_balance</code>.
 - <code>non_refundable_balance</code> contains any remaining inflow of the storage fund that should not
-be taken out of the fund.
+   be taken out of the fund.
 
 
 <pre><code><b>public</b> <b>struct</b> <a href="../sui_system/storage_fund.md#sui_system_storage_fund_StorageFund">StorageFund</a> <b>has</b> store

--- a/crates/sui-framework/docs/sui_system/sui_system.md
+++ b/crates/sui-framework/docs/sui_system/sui_system.md
@@ -15,9 +15,9 @@ To properly upgrade the <code>SuiSystemStateInner</code> type, we need to ship a
 1. Define a new <code>SuiSystemStateInner</code>type (e.g. <code>SuiSystemStateInnerV2</code>).
 2. Define a data migration function that migrates the old <code>SuiSystemStateInner</code> to the new one (i.e. SuiSystemStateInnerV2).
 3. Replace all uses of <code>SuiSystemStateInner</code> with <code>SuiSystemStateInnerV2</code> in both sui_system.move and sui_system_state_inner.move,
-with the exception of the <code><a href="../sui_system/sui_system_state_inner.md#sui_system_sui_system_state_inner_create">sui_system_state_inner::create</a></code> function, which should always return the genesis type.
+   with the exception of the <code><a href="../sui_system/sui_system_state_inner.md#sui_system_sui_system_state_inner_create">sui_system_state_inner::create</a></code> function, which should always return the genesis type.
 4. Inside <code><a href="../sui_system/sui_system.md#sui_system_sui_system_load_inner_maybe_upgrade">load_inner_maybe_upgrade</a></code> function, check the current version in the wrapper, and if it's not the latest version,
-call the data migration function to upgrade the inner object. Make sure to also update the version in the wrapper.
+  call the data migration function to upgrade the inner object. Make sure to also update the version in the wrapper.
 A detailed example can be found in sui/tests/framework_upgrades/mock_sui_systems/shallow_upgrade.
 Along with the Move change, we also need to update the Rust code to support the new type. This includes:
 1. Define a new <code>SuiSystemStateInner</code> struct type that matches the new Move type, and implement the SuiSystemStateTrait.
@@ -32,7 +32,7 @@ To upgrade Validator type, besides everything above, we also need to:
 2. Define a data migration function that migrates the old Validator to the new one (i.e. ValidatorV2).
 3. Replace all uses of Validator with ValidatorV2 except the genesis creation function.
 4. In validator_wrapper::upgrade_to_latest, check the current version in the wrapper, and if it's not the latest version,
-call the data migration function to upgrade it.
+ call the data migration function to upgrade it.
 In Rust, we also need to add a new case in <code>get_validator_from_table</code>.
 Note that it is possible to upgrade SuiSystemStateInner without upgrading Validator, but not the other way around.
 And when we only upgrade SuiSystemStateInner, the version of Validator in the wrapper will not be updated, and hence may become
@@ -1556,7 +1556,7 @@ This function should be called at the end of an epoch, and advances the system t
 It does the following things:
 1. Add storage charge to the storage fund.
 2. Burn the storage rebates from the storage fund. These are already refunded to transaction sender's
-gas coins.
+   gas coins.
 3. Distribute computation charge to validator stake.
 4. Update all validators.
 

--- a/crates/sui-framework/docs/sui_system/sui_system_state_inner.md
+++ b/crates/sui-framework/docs/sui_system/sui_system_state_inner.md
@@ -2202,7 +2202,7 @@ This function should be called at the end of an epoch, and advances the system t
 It does the following things:
 1. Add storage charge to the storage fund.
 2. Burn the storage rebates from the storage fund. These are already refunded to transaction sender's
-gas coins.
+   gas coins.
 3. Distribute computation charge to validator stake.
 4. Update all validators.
 

--- a/crates/sui-framework/docs/sui_system/validator_set.md
+++ b/crates/sui-framework/docs/sui_system/validator_set.md
@@ -1001,9 +1001,9 @@ Aborts in case the staking amount is smaller than MIN_STAKING_THRESHOLD
 Called by <code><a href="../sui_system/sui_system.md#sui_system_sui_system">sui_system</a></code>, to withdraw some share of a stake from the validator. The share to withdraw
 is denoted by <code>principal_withdraw_amount</code>. One of two things occurs in this function:
 1. If the <code>staked_sui</code> is staked with an active validator, the request is added to the validator's
-staking pool's pending stake withdraw entries, processed at the end of the epoch.
+   staking pool's pending stake withdraw entries, processed at the end of the epoch.
 2. If the <code>staked_sui</code> was staked with a validator that is no longer active,
-the stake and any rewards corresponding to it will be immediately processed.
+   the stake and any rewards corresponding to it will be immediately processed.
 
 
 <pre><code><b>public</b>(package) <b>fun</b> <a href="../sui_system/validator_set.md#sui_system_validator_set_request_withdraw_stake">request_withdraw_stake</a>(self: &<b>mut</b> <a href="../sui_system/validator_set.md#sui_system_validator_set_ValidatorSet">sui_system::validator_set::ValidatorSet</a>, staked_sui: <a href="../sui_system/staking_pool.md#sui_system_staking_pool_StakedSui">sui_system::staking_pool::StakedSui</a>, ctx: &<a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>): <a href="../sui/balance.md#sui_balance_Balance">sui::balance::Balance</a>&lt;<a href="../sui/sui.md#sui_sui_SUI">sui::sui::SUI</a>&gt;
@@ -1120,11 +1120,11 @@ the stake and any rewards corresponding to it will be immediately processed.
 
 Update the validator set at the end of epoch.
 It does the following things:
-1. Distribute stake award.
-2. Process pending stake deposits and withdraws for each validator (<code>adjust_stake</code>).
-3. Process pending stake deposits, and withdraws.
-4. Process pending validator application and withdraws.
-5. At the end, we calculate the total stake for the new epoch.
+  1. Distribute stake award.
+  2. Process pending stake deposits and withdraws for each validator (<code>adjust_stake</code>).
+  3. Process pending stake deposits, and withdraws.
+  4. Process pending validator application and withdraws.
+  5. At the end, we calculate the total stake for the new epoch.
 
 
 <pre><code><b>public</b>(package) <b>fun</b> <a href="../sui_system/validator_set.md#sui_system_validator_set_advance_epoch">advance_epoch</a>(self: &<b>mut</b> <a href="../sui_system/validator_set.md#sui_system_validator_set_ValidatorSet">sui_system::validator_set::ValidatorSet</a>, computation_reward: &<b>mut</b> <a href="../sui/balance.md#sui_balance_Balance">sui::balance::Balance</a>&lt;<a href="../sui/sui.md#sui_sui_SUI">sui::sui::SUI</a>&gt;, storage_fund_reward: &<b>mut</b> <a href="../sui/balance.md#sui_balance_Balance">sui::balance::Balance</a>&lt;<a href="../sui/sui.md#sui_sui_SUI">sui::sui::SUI</a>&gt;, validator_report_records: &<b>mut</b> <a href="../sui/vec_map.md#sui_vec_map_VecMap">sui::vec_map::VecMap</a>&lt;<b>address</b>, <a href="../sui/vec_set.md#sui_vec_set_VecSet">sui::vec_set::VecSet</a>&lt;<b>address</b>&gt;&gt;, reward_slashing_rate: u64, low_stake_grace_period: u64, ctx: &<b>mut</b> <a href="../sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>)
@@ -1245,9 +1245,9 @@ It does the following things:
 This function does the following:
 - removes validators from <code>at_risk</code> group if their voting power is above the LOW threshold
 - increments the number of epochs a validator has been below the LOW threshold but above the
-VERY LOW threshold
+    VERY LOW threshold
 - removes validators from the active set if they have been below the LOW threshold for more than
-<code>low_stake_grace_period</code> epochs
+    <code>low_stake_grace_period</code> epochs
 - removes validators from the active set immediately if they are below the VERY LOW threshold
 - activates pending validators if they have sufficient voting power
 

--- a/external-crates/move/crates/move-cli/tests/build_tests/docgen_diamond_dep/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/build_tests/docgen_diamond_dep/Move.toml
@@ -1,0 +1,11 @@
+[package]
+name = "Diamond"
+edition = "2024"
+
+[dependencies]
+# Direct dep on Shared AND indirect dep through Middle → Shared
+Shared = { local = "dep_shared" }
+Middle = { local = "dep_middle" }
+
+[addresses]
+diamond = "0x42"

--- a/external-crates/move/crates/move-cli/tests/build_tests/docgen_diamond_dep/args.exp
+++ b/external-crates/move/crates/move-cli/tests/build_tests/docgen_diamond_dep/args.exp
@@ -1,0 +1,269 @@
+Command `build`:
+INCLUDING DEPENDENCY Middle
+INCLUDING DEPENDENCY Shared
+BUILDING Diamond
+Command `docgen --output-directory doc`:
+INCLUDING DEPENDENCY Middle
+INCLUDING DEPENDENCY Shared
+BUILDING Diamond
+Generated "doc/shared/token.md"
+Generated "doc/middle/wallet.md"
+Generated "doc/diamond/exchange.md"
+
+Documentation generation successful!
+External Command `find doc -type f | sort`:
+doc/diamond/exchange.md
+doc/middle/wallet.md
+doc/shared/token.md
+External Command `cat doc/diamond/exchange.md`:
+<a name="diamond_exchange"></a>
+
+# Module `diamond::exchange`
+
+
+<a name="@Exchange_0"></a>
+
+## Exchange
+
+
+Uses <code><a href="../shared/token.md#shared_token">shared::token</a></code> directly AND <code><a href="../middle/wallet.md#middle_wallet">middle::wallet</a></code> which also depends on <code><a href="../shared/token.md#shared_token">shared::token</a></code>.
+This creates a diamond dependency: Diamond → Shared, Diamond → Middle → Shared.
+
+
+-  [Exchange](#@Exchange_0)
+-  [Function `round_trip`](#diamond_exchange_round_trip)
+
+
+<pre><code><b>use</b> <a href="../middle/wallet.md#middle_wallet">middle::wallet</a>;
+<b>use</b> <a href="../shared/token.md#shared_token">shared::token</a>;
+</code></pre>
+
+
+
+<a name="diamond_exchange_round_trip"></a>
+
+## Function `round_trip`
+
+Mint a token and put it in a wallet, then read both values.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../diamond/exchange.md#diamond_exchange_round_trip">round_trip</a>(amount: u64): (u64, u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../diamond/exchange.md#diamond_exchange_round_trip">round_trip</a>(amount: u64): (u64, u64) {
+    <b>let</b> t: Token = token::mint(amount);
+    <b>let</b> w: Wallet = wallet::new(amount);
+    (token::value(&t), wallet::balance(&w))
+}
+</code></pre>
+
+
+
+</details>
+External Command `cat doc/shared/token.md`:
+<a name="shared_token"></a>
+
+# Module `shared::token`
+
+
+<a name="@Token_0"></a>
+
+## Token
+
+
+A shared token type used by multiple packages.
+
+
+-  [Token](#@Token_0)
+-  [Struct `Token`](#shared_token_Token)
+-  [Function `mint`](#shared_token_mint)
+-  [Function `value`](#shared_token_value)
+
+
+<pre><code></code></pre>
+
+
+
+<a name="shared_token_Token"></a>
+
+## Struct `Token`
+
+A token with a value.
+
+
+<pre><code><b>public</b> <b>struct</b> <a href="../shared/token.md#shared_token_Token">Token</a> <b>has</b> <b>copy</b>, drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code><a href="../shared/token.md#shared_token_value">value</a>: u64</code>
+</dt>
+<dd>
+</dd>
+</dl>
+
+
+</details>
+
+<a name="shared_token_mint"></a>
+
+## Function `mint`
+
+Create a new token.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../shared/token.md#shared_token_mint">mint</a>(<a href="../shared/token.md#shared_token_value">value</a>: u64): <a href="../shared/token.md#shared_token_Token">shared::token::Token</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../shared/token.md#shared_token_mint">mint</a>(<a href="../shared/token.md#shared_token_value">value</a>: u64): <a href="../shared/token.md#shared_token_Token">Token</a> {
+    <a href="../shared/token.md#shared_token_Token">Token</a> { <a href="../shared/token.md#shared_token_value">value</a> }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="shared_token_value"></a>
+
+## Function `value`
+
+Get the token value.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../shared/token.md#shared_token_value">value</a>(t: &<a href="../shared/token.md#shared_token_Token">shared::token::Token</a>): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../shared/token.md#shared_token_value">value</a>(t: &<a href="../shared/token.md#shared_token_Token">Token</a>): u64 {
+    t.<a href="../shared/token.md#shared_token_value">value</a>
+}
+</code></pre>
+
+
+
+</details>
+External Command `cat doc/middle/wallet.md`:
+<a name="middle_wallet"></a>
+
+# Module `middle::wallet`
+
+
+<a name="@Wallet_0"></a>
+
+## Wallet
+
+
+A wallet holding a <code><a href="../shared/token.md#shared_token_Token">shared::token::Token</a></code>.
+
+
+-  [Wallet](#@Wallet_0)
+-  [Struct `Wallet`](#middle_wallet_Wallet)
+-  [Function `new`](#middle_wallet_new)
+-  [Function `balance`](#middle_wallet_balance)
+
+
+<pre><code><b>use</b> <a href="../shared/token.md#shared_token">shared::token</a>;
+</code></pre>
+
+
+
+<a name="middle_wallet_Wallet"></a>
+
+## Struct `Wallet`
+
+A wallet with a single token.
+
+
+<pre><code><b>public</b> <b>struct</b> <a href="../middle/wallet.md#middle_wallet_Wallet">Wallet</a> <b>has</b> <b>copy</b>, drop
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>held: <a href="../shared/token.md#shared_token_Token">shared::token::Token</a></code>
+</dt>
+<dd>
+</dd>
+</dl>
+
+
+</details>
+
+<a name="middle_wallet_new"></a>
+
+## Function `new`
+
+Create a wallet with a freshly minted token.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../middle/wallet.md#middle_wallet_new">new</a>(amount: u64): <a href="../middle/wallet.md#middle_wallet_Wallet">middle::wallet::Wallet</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../middle/wallet.md#middle_wallet_new">new</a>(amount: u64): <a href="../middle/wallet.md#middle_wallet_Wallet">Wallet</a> {
+    <a href="../middle/wallet.md#middle_wallet_Wallet">Wallet</a> { held: token::mint(amount) }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="middle_wallet_balance"></a>
+
+## Function `balance`
+
+Get the balance.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../middle/wallet.md#middle_wallet_balance">balance</a>(w: &<a href="../middle/wallet.md#middle_wallet_Wallet">middle::wallet::Wallet</a>): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../middle/wallet.md#middle_wallet_balance">balance</a>(w: &<a href="../middle/wallet.md#middle_wallet_Wallet">Wallet</a>): u64 {
+    token::value(&w.held)
+}
+</code></pre>
+
+
+
+</details>

--- a/external-crates/move/crates/move-cli/tests/build_tests/docgen_diamond_dep/args.txt
+++ b/external-crates/move/crates/move-cli/tests/build_tests/docgen_diamond_dep/args.txt
@@ -1,0 +1,11 @@
+build
+docgen --output-directory doc
+# Diamond dependency: Root depends on Shared directly AND through Middle
+# Shared should appear only once
+> find doc -type f | sort
+# Root package
+> cat doc/diamond/exchange.md
+# Direct + transitive dep (Shared appears via both paths)
+> cat doc/shared/token.md
+# Middle dep (also depends on Shared)
+> cat doc/middle/wallet.md

--- a/external-crates/move/crates/move-cli/tests/build_tests/docgen_diamond_dep/dep_middle/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/build_tests/docgen_diamond_dep/dep_middle/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "Middle"
+edition = "2024"
+
+[dependencies]
+Shared = { local = "../dep_shared" }
+
+[addresses]
+middle = "0x20"

--- a/external-crates/move/crates/move-cli/tests/build_tests/docgen_diamond_dep/dep_middle/sources/wallet.move
+++ b/external-crates/move/crates/move-cli/tests/build_tests/docgen_diamond_dep/dep_middle/sources/wallet.move
@@ -1,0 +1,24 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// # Wallet
+///
+/// A wallet holding a `shared::token::Token`.
+module middle::wallet {
+    use shared::token::{Self, Token};
+
+    /// A wallet with a single token.
+    public struct Wallet has copy, drop {
+        held: Token,
+    }
+
+    /// Create a wallet with a freshly minted token.
+    public fun new(amount: u64): Wallet {
+        Wallet { held: token::mint(amount) }
+    }
+
+    /// Get the balance.
+    public fun balance(w: &Wallet): u64 {
+        token::value(&w.held)
+    }
+}

--- a/external-crates/move/crates/move-cli/tests/build_tests/docgen_diamond_dep/dep_shared/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/build_tests/docgen_diamond_dep/dep_shared/Move.toml
@@ -1,0 +1,6 @@
+[package]
+name = "Shared"
+edition = "2024"
+
+[addresses]
+shared = "0x10"

--- a/external-crates/move/crates/move-cli/tests/build_tests/docgen_diamond_dep/dep_shared/sources/token.move
+++ b/external-crates/move/crates/move-cli/tests/build_tests/docgen_diamond_dep/dep_shared/sources/token.move
@@ -1,0 +1,22 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// # Token
+///
+/// A shared token type used by multiple packages.
+module shared::token {
+    /// A token with a value.
+    public struct Token has copy, drop, store {
+        value: u64,
+    }
+
+    /// Create a new token.
+    public fun mint(value: u64): Token {
+        Token { value }
+    }
+
+    /// Get the token value.
+    public fun value(t: &Token): u64 {
+        t.value
+    }
+}

--- a/external-crates/move/crates/move-cli/tests/build_tests/docgen_diamond_dep/sources/exchange.move
+++ b/external-crates/move/crates/move-cli/tests/build_tests/docgen_diamond_dep/sources/exchange.move
@@ -1,0 +1,18 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// # Exchange
+///
+/// Uses `shared::token` directly AND `middle::wallet` which also depends on `shared::token`.
+/// This creates a diamond dependency: Diamond → Shared, Diamond → Middle → Shared.
+module diamond::exchange {
+    use shared::token::{Self, Token};
+    use middle::wallet::{Self, Wallet};
+
+    /// Mint a token and put it in a wallet, then read both values.
+    public fun round_trip(amount: u64): (u64, u64) {
+        let t: Token = token::mint(amount);
+        let w: Wallet = wallet::new(amount);
+        (token::value(&t), wallet::balance(&w))
+    }
+}

--- a/external-crates/move/crates/move-cli/tests/build_tests/docgen_same_module_name/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/build_tests/docgen_same_module_name/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "RootPkg"
+edition = "2024"
+
+[dependencies]
+DepPkg = { local = "dep" }
+
+[addresses]
+root_addr = "0x42"

--- a/external-crates/move/crates/move-cli/tests/build_tests/docgen_same_module_name/args.exp
+++ b/external-crates/move/crates/move-cli/tests/build_tests/docgen_same_module_name/args.exp
@@ -1,0 +1,106 @@
+Command `build`:
+INCLUDING DEPENDENCY DepPkg
+BUILDING RootPkg
+Command `docgen --output-directory doc`:
+INCLUDING DEPENDENCY DepPkg
+BUILDING RootPkg
+Generated "doc/dep_addr/utils.md"
+Generated "doc/root_addr/utils.md"
+
+Documentation generation successful!
+External Command `find doc -type f | sort`:
+doc/dep_addr/utils.md
+doc/root_addr/utils.md
+External Command `cat doc/root_addr/utils.md`:
+<a name="root_addr_utils"></a>
+
+# Module `root_addr::utils`
+
+
+<a name="@Root_Utils_0"></a>
+
+## Root Utils
+
+
+Utility module in the root package — same module name as <code><a href="../dep_addr/utils.md#dep_addr_utils">dep_addr::utils</a></code>.
+
+
+-  [Root Utils](#@Root_Utils_0)
+-  [Function `combined`](#root_addr_utils_combined)
+
+
+<pre><code><b>use</b> <a href="../dep_addr/utils.md#dep_addr_utils">dep_addr::utils</a>;
+</code></pre>
+
+
+
+<a name="root_addr_utils_combined"></a>
+
+## Function `combined`
+
+Calls into the dependency's identically-named module.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../root_addr/utils.md#root_addr_utils_combined">combined</a>(): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../root_addr/utils.md#root_addr_utils_combined">combined</a>(): u64 {
+    dep_utils::dep_helper() + 1
+}
+</code></pre>
+
+
+
+</details>
+External Command `cat doc/dep_addr/utils.md`:
+<a name="dep_addr_utils"></a>
+
+# Module `dep_addr::utils`
+
+
+<a name="@Dep_Utils_0"></a>
+
+## Dep Utils
+
+
+Utility module in the dependency package.
+
+
+-  [Dep Utils](#@Dep_Utils_0)
+-  [Function `dep_helper`](#dep_addr_utils_dep_helper)
+
+
+<pre><code></code></pre>
+
+
+
+<a name="dep_addr_utils_dep_helper"></a>
+
+## Function `dep_helper`
+
+A helper value.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../dep_addr/utils.md#dep_addr_utils_dep_helper">dep_helper</a>(): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../dep_addr/utils.md#dep_addr_utils_dep_helper">dep_helper</a>(): u64 {
+    42
+}
+</code></pre>
+
+
+
+</details>

--- a/external-crates/move/crates/move-cli/tests/build_tests/docgen_same_module_name/args.txt
+++ b/external-crates/move/crates/move-cli/tests/build_tests/docgen_same_module_name/args.txt
@@ -1,0 +1,8 @@
+build
+docgen --output-directory doc
+# Both packages have a module named "utils" — check they get separate files
+> find doc -type f | sort
+# Root package's utils
+> cat doc/root_addr/utils.md
+# Dependency's utils (same source file name, different package)
+> cat doc/dep_addr/utils.md

--- a/external-crates/move/crates/move-cli/tests/build_tests/docgen_same_module_name/dep/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/build_tests/docgen_same_module_name/dep/Move.toml
@@ -1,0 +1,6 @@
+[package]
+name = "DepPkg"
+edition = "2024"
+
+[addresses]
+dep_addr = "0x10"

--- a/external-crates/move/crates/move-cli/tests/build_tests/docgen_same_module_name/dep/sources/utils.move
+++ b/external-crates/move/crates/move-cli/tests/build_tests/docgen_same_module_name/dep/sources/utils.move
@@ -1,0 +1,12 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// # Dep Utils
+///
+/// Utility module in the dependency package.
+module dep_addr::utils {
+    /// A helper value.
+    public fun dep_helper(): u64 {
+        42
+    }
+}

--- a/external-crates/move/crates/move-cli/tests/build_tests/docgen_same_module_name/sources/utils.move
+++ b/external-crates/move/crates/move-cli/tests/build_tests/docgen_same_module_name/sources/utils.move
@@ -1,0 +1,14 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// # Root Utils
+///
+/// Utility module in the root package — same module name as `dep_addr::utils`.
+module root_addr::utils {
+    use dep_addr::utils as dep_utils;
+
+    /// Calls into the dependency's identically-named module.
+    public fun combined(): u64 {
+        dep_utils::dep_helper() + 1
+    }
+}

--- a/external-crates/move/crates/move-cli/tests/build_tests/docgen_transitive_deps/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/build_tests/docgen_transitive_deps/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "Root"
+edition = "2024"
+
+[dependencies]
+Mid = { local = "dep_mid" }
+
+[addresses]
+root = "0x42"

--- a/external-crates/move/crates/move-cli/tests/build_tests/docgen_transitive_deps/args.exp
+++ b/external-crates/move/crates/move-cli/tests/build_tests/docgen_transitive_deps/args.exp
@@ -1,0 +1,273 @@
+Command `build`:
+INCLUDING DEPENDENCY Leaf
+INCLUDING DEPENDENCY Mid
+BUILDING Root
+Command `docgen --output-directory doc`:
+INCLUDING DEPENDENCY Leaf
+INCLUDING DEPENDENCY Mid
+BUILDING Root
+Generated "doc/leaf/base.md"
+Generated "doc/mid/registry.md"
+Generated "doc/root/app.md"
+
+Documentation generation successful!
+External Command `find doc -type f | sort`:
+doc/leaf/base.md
+doc/mid/registry.md
+doc/root/app.md
+External Command `cat doc/root/app.md`:
+<a name="root_app"></a>
+
+# Module `root::app`
+
+
+<a name="@App_0"></a>
+
+## App
+
+
+Root application using types from both direct (Mid) and transitive (Leaf) dependencies.
+
+
+-  [App](#@App_0)
+-  [Function `create_and_read`](#root_app_create_and_read)
+
+
+<pre><code><b>use</b> <a href="../leaf/base.md#leaf_base">leaf::base</a>;
+<b>use</b> <a href="../mid/registry.md#mid_registry">mid::registry</a>;
+</code></pre>
+
+
+
+<a name="root_app_create_and_read"></a>
+
+## Function `create_and_read`
+
+Create an entry and return its inner id value.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../root/app.md#root_app_create_and_read">create_and_read</a>(v: u64, tag: u64): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../root/app.md#root_app_create_and_read">create_and_read</a>(v: u64, tag: u64): u64 {
+    <b>let</b> <b>entry</b>: Entry = registry::new_entry(v, tag);
+    <b>let</b> id = registry::entry_id(&<b>entry</b>);
+    base::inner(id)
+}
+</code></pre>
+
+
+
+</details>
+External Command `cat doc/mid/registry.md`:
+<a name="mid_registry"></a>
+
+# Module `mid::registry`
+
+
+<a name="@Registry_0"></a>
+
+## Registry
+
+
+A registry that maps <code><a href="../leaf/base.md#leaf_base_Id">leaf::base::Id</a></code> values to names.
+
+
+-  [Registry](#@Registry_0)
+-  [Struct `Entry`](#mid_registry_Entry)
+-  [Function `new_entry`](#mid_registry_new_entry)
+-  [Function `entry_id`](#mid_registry_entry_id)
+
+
+<pre><code><b>use</b> <a href="../leaf/base.md#leaf_base">leaf::base</a>;
+</code></pre>
+
+
+
+<a name="mid_registry_Entry"></a>
+
+## Struct `Entry`
+
+A named entry in the registry.
+
+
+<pre><code><b>public</b> <b>struct</b> <a href="../mid/registry.md#mid_registry_Entry">Entry</a> <b>has</b> <b>copy</b>, drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>id: <a href="../leaf/base.md#leaf_base_Id">leaf::base::Id</a></code>
+</dt>
+<dd>
+</dd>
+<dt>
+<code>tag: u64</code>
+</dt>
+<dd>
+</dd>
+</dl>
+
+
+</details>
+
+<a name="mid_registry_new_entry"></a>
+
+## Function `new_entry`
+
+Create a new entry.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../mid/registry.md#mid_registry_new_entry">new_entry</a>(v: u64, tag: u64): <a href="../mid/registry.md#mid_registry_Entry">mid::registry::Entry</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../mid/registry.md#mid_registry_new_entry">new_entry</a>(v: u64, tag: u64): <a href="../mid/registry.md#mid_registry_Entry">Entry</a> {
+    <a href="../mid/registry.md#mid_registry_Entry">Entry</a> { id: base::new_id(v), tag }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="mid_registry_entry_id"></a>
+
+## Function `entry_id`
+
+Get the id of an entry.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../mid/registry.md#mid_registry_entry_id">entry_id</a>(e: &<a href="../mid/registry.md#mid_registry_Entry">mid::registry::Entry</a>): &<a href="../leaf/base.md#leaf_base_Id">leaf::base::Id</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../mid/registry.md#mid_registry_entry_id">entry_id</a>(e: &<a href="../mid/registry.md#mid_registry_Entry">Entry</a>): &Id {
+    &e.id
+}
+</code></pre>
+
+
+
+</details>
+External Command `cat doc/leaf/base.md`:
+<a name="leaf_base"></a>
+
+# Module `leaf::base`
+
+
+<a name="@Base_Types_0"></a>
+
+## Base Types
+
+
+Foundational types used throughout the dependency chain.
+
+
+-  [Base Types](#@Base_Types_0)
+-  [Struct `Id`](#leaf_base_Id)
+-  [Function `new_id`](#leaf_base_new_id)
+-  [Function `inner`](#leaf_base_inner)
+
+
+<pre><code></code></pre>
+
+
+
+<a name="leaf_base_Id"></a>
+
+## Struct `Id`
+
+A unique identifier.
+
+
+<pre><code><b>public</b> <b>struct</b> <a href="../leaf/base.md#leaf_base_Id">Id</a> <b>has</b> <b>copy</b>, drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code><a href="../leaf/base.md#leaf_base_inner">inner</a>: u64</code>
+</dt>
+<dd>
+</dd>
+</dl>
+
+
+</details>
+
+<a name="leaf_base_new_id"></a>
+
+## Function `new_id`
+
+Create a new Id.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../leaf/base.md#leaf_base_new_id">new_id</a>(v: u64): <a href="../leaf/base.md#leaf_base_Id">leaf::base::Id</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../leaf/base.md#leaf_base_new_id">new_id</a>(v: u64): <a href="../leaf/base.md#leaf_base_Id">Id</a> {
+    <a href="../leaf/base.md#leaf_base_Id">Id</a> { <a href="../leaf/base.md#leaf_base_inner">inner</a>: v }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="leaf_base_inner"></a>
+
+## Function `inner`
+
+Get the inner value.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../leaf/base.md#leaf_base_inner">inner</a>(id: &<a href="../leaf/base.md#leaf_base_Id">leaf::base::Id</a>): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../leaf/base.md#leaf_base_inner">inner</a>(id: &<a href="../leaf/base.md#leaf_base_Id">Id</a>): u64 {
+    id.<a href="../leaf/base.md#leaf_base_inner">inner</a>
+}
+</code></pre>
+
+
+
+</details>

--- a/external-crates/move/crates/move-cli/tests/build_tests/docgen_transitive_deps/args.txt
+++ b/external-crates/move/crates/move-cli/tests/build_tests/docgen_transitive_deps/args.txt
@@ -1,0 +1,10 @@
+build
+docgen --output-directory doc
+# Show generated directory structure: root + direct dep + transitive dep
+> find doc -type f | sort
+# Root package module
+> cat doc/root/app.md
+# Direct dependency (Mid)
+> cat doc/mid/registry.md
+# Transitive dependency (Leaf, pulled in through Mid)
+> cat doc/leaf/base.md

--- a/external-crates/move/crates/move-cli/tests/build_tests/docgen_transitive_deps/dep_leaf/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/build_tests/docgen_transitive_deps/dep_leaf/Move.toml
@@ -1,0 +1,6 @@
+[package]
+name = "Leaf"
+edition = "2024"
+
+[addresses]
+leaf = "0x10"

--- a/external-crates/move/crates/move-cli/tests/build_tests/docgen_transitive_deps/dep_leaf/sources/base.move
+++ b/external-crates/move/crates/move-cli/tests/build_tests/docgen_transitive_deps/dep_leaf/sources/base.move
@@ -1,0 +1,22 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// # Base Types
+///
+/// Foundational types used throughout the dependency chain.
+module leaf::base {
+    /// A unique identifier.
+    public struct Id has copy, drop, store {
+        inner: u64,
+    }
+
+    /// Create a new Id.
+    public fun new_id(v: u64): Id {
+        Id { inner: v }
+    }
+
+    /// Get the inner value.
+    public fun inner(id: &Id): u64 {
+        id.inner
+    }
+}

--- a/external-crates/move/crates/move-cli/tests/build_tests/docgen_transitive_deps/dep_mid/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/build_tests/docgen_transitive_deps/dep_mid/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "Mid"
+edition = "2024"
+
+[dependencies]
+Leaf = { local = "../dep_leaf" }
+
+[addresses]
+mid = "0x20"

--- a/external-crates/move/crates/move-cli/tests/build_tests/docgen_transitive_deps/dep_mid/sources/registry.move
+++ b/external-crates/move/crates/move-cli/tests/build_tests/docgen_transitive_deps/dep_mid/sources/registry.move
@@ -1,0 +1,25 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// # Registry
+///
+/// A registry that maps `leaf::base::Id` values to names.
+module mid::registry {
+    use leaf::base::{Self, Id};
+
+    /// A named entry in the registry.
+    public struct Entry has copy, drop, store {
+        id: Id,
+        tag: u64,
+    }
+
+    /// Create a new entry.
+    public fun new_entry(v: u64, tag: u64): Entry {
+        Entry { id: base::new_id(v), tag }
+    }
+
+    /// Get the id of an entry.
+    public fun entry_id(e: &Entry): &Id {
+        &e.id
+    }
+}

--- a/external-crates/move/crates/move-cli/tests/build_tests/docgen_transitive_deps/sources/app.move
+++ b/external-crates/move/crates/move-cli/tests/build_tests/docgen_transitive_deps/sources/app.move
@@ -1,0 +1,17 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// # App
+///
+/// Root application using types from both direct (Mid) and transitive (Leaf) dependencies.
+module root::app {
+    use mid::registry::{Self, Entry};
+    use leaf::base;
+
+    /// Create an entry and return its inner id value.
+    public fun create_and_read(v: u64, tag: u64): u64 {
+        let entry: Entry = registry::new_entry(v, tag);
+        let id = registry::entry_id(&entry);
+        base::inner(id)
+    }
+}

--- a/external-crates/move/crates/move-cli/tests/build_tests/docgen_with_dep/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/build_tests/docgen_with_dep/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "App"
+edition = "2024"
+
+[dependencies]
+Helper = { local = "dep" }
+
+[addresses]
+app = "0x42"

--- a/external-crates/move/crates/move-cli/tests/build_tests/docgen_with_dep/args.exp
+++ b/external-crates/move/crates/move-cli/tests/build_tests/docgen_with_dep/args.exp
@@ -1,0 +1,281 @@
+Command `build`:
+INCLUDING DEPENDENCY Helper
+BUILDING App
+Command `docgen --output-directory doc`:
+INCLUDING DEPENDENCY Helper
+BUILDING App
+Generated "doc/app/tracker.md"
+Generated "doc/helper/utils.md"
+
+Documentation generation successful!
+External Command `find doc -type f | sort`:
+doc/app/tracker.md
+doc/helper/utils.md
+External Command `cat doc/app/tracker.md`:
+<a name="app_tracker"></a>
+
+# Module `app::tracker`
+
+
+<a name="@Tracker_0"></a>
+
+## Tracker
+
+
+Uses <code><a href="../helper/utils.md#helper_utils_Counter">helper::utils::Counter</a></code> from a dependency package.
+
+Nested list in module doc:
+
+- Top level
+  - Nested item
+    - Deeply nested
+- Another top level
+
+
+-  [Tracker](#@Tracker_0)
+-  [Struct `Tracker`](#app_tracker_Tracker)
+-  [Function `new`](#app_tracker_new)
+-  [Function `record`](#app_tracker_record)
+-  [Function `count`](#app_tracker_count)
+
+
+<pre><code><b>use</b> <a href="../helper/utils.md#helper_utils">helper::utils</a>;
+</code></pre>
+
+
+
+<a name="app_tracker_Tracker"></a>
+
+## Struct `Tracker`
+
+A named tracker wrapping a counter.
+
+
+<pre><code><b>public</b> <b>struct</b> <a href="../app/tracker.md#app_tracker_Tracker">Tracker</a> <b>has</b> <b>copy</b>, drop
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>name: u64</code>
+</dt>
+<dd>
+</dd>
+<dt>
+<code>counter: <a href="../helper/utils.md#helper_utils_Counter">helper::utils::Counter</a></code>
+</dt>
+<dd>
+</dd>
+</dl>
+
+
+</details>
+
+<a name="app_tracker_new"></a>
+
+## Function `new`
+
+Create a new tracker.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../app/tracker.md#app_tracker_new">new</a>(name: u64): <a href="../app/tracker.md#app_tracker_Tracker">app::tracker::Tracker</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../app/tracker.md#app_tracker_new">new</a>(name: u64): <a href="../app/tracker.md#app_tracker_Tracker">Tracker</a> {
+    <a href="../app/tracker.md#app_tracker_Tracker">Tracker</a> {
+        name,
+        counter: utils::new(),
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="app_tracker_record"></a>
+
+## Function `record`
+
+Record an event.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../app/tracker.md#app_tracker_record">record</a>(t: &<b>mut</b> <a href="../app/tracker.md#app_tracker_Tracker">app::tracker::Tracker</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../app/tracker.md#app_tracker_record">record</a>(t: &<b>mut</b> <a href="../app/tracker.md#app_tracker_Tracker">Tracker</a>) {
+    utils::increment(&<b>mut</b> t.counter);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="app_tracker_count"></a>
+
+## Function `count`
+
+Get event count.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../app/tracker.md#app_tracker_count">count</a>(t: &<a href="../app/tracker.md#app_tracker_Tracker">app::tracker::Tracker</a>): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../app/tracker.md#app_tracker_count">count</a>(t: &<a href="../app/tracker.md#app_tracker_Tracker">Tracker</a>): u64 {
+    utils::value(&t.counter)
+}
+</code></pre>
+
+
+
+</details>
+External Command `cat doc/helper/utils.md`:
+<a name="helper_utils"></a>
+
+# Module `helper::utils`
+
+
+<a name="@Utilities_0"></a>
+
+## Utilities
+
+
+Shared utility types.
+
+
+-  [Utilities](#@Utilities_0)
+-  [Struct `Counter`](#helper_utils_Counter)
+-  [Function `new`](#helper_utils_new)
+-  [Function `increment`](#helper_utils_increment)
+-  [Function `value`](#helper_utils_value)
+
+
+<pre><code></code></pre>
+
+
+
+<a name="helper_utils_Counter"></a>
+
+## Struct `Counter`
+
+A simple counter.
+
+
+<pre><code><b>public</b> <b>struct</b> <a href="../helper/utils.md#helper_utils_Counter">Counter</a> <b>has</b> <b>copy</b>, drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code><a href="../helper/utils.md#helper_utils_value">value</a>: u64</code>
+</dt>
+<dd>
+</dd>
+</dl>
+
+
+</details>
+
+<a name="helper_utils_new"></a>
+
+## Function `new`
+
+Create a new counter starting at zero.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../helper/utils.md#helper_utils_new">new</a>(): <a href="../helper/utils.md#helper_utils_Counter">helper::utils::Counter</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../helper/utils.md#helper_utils_new">new</a>(): <a href="../helper/utils.md#helper_utils_Counter">Counter</a> {
+    <a href="../helper/utils.md#helper_utils_Counter">Counter</a> { <a href="../helper/utils.md#helper_utils_value">value</a>: 0 }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="helper_utils_increment"></a>
+
+## Function `increment`
+
+Increment by one.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../helper/utils.md#helper_utils_increment">increment</a>(c: &<b>mut</b> <a href="../helper/utils.md#helper_utils_Counter">helper::utils::Counter</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../helper/utils.md#helper_utils_increment">increment</a>(c: &<b>mut</b> <a href="../helper/utils.md#helper_utils_Counter">Counter</a>) {
+    c.<a href="../helper/utils.md#helper_utils_value">value</a> = c.<a href="../helper/utils.md#helper_utils_value">value</a> + 1;
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="helper_utils_value"></a>
+
+## Function `value`
+
+Get the current value.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../helper/utils.md#helper_utils_value">value</a>(c: &<a href="../helper/utils.md#helper_utils_Counter">helper::utils::Counter</a>): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="../helper/utils.md#helper_utils_value">value</a>(c: &<a href="../helper/utils.md#helper_utils_Counter">Counter</a>): u64 {
+    c.<a href="../helper/utils.md#helper_utils_value">value</a>
+}
+</code></pre>
+
+
+
+</details>

--- a/external-crates/move/crates/move-cli/tests/build_tests/docgen_with_dep/args.txt
+++ b/external-crates/move/crates/move-cli/tests/build_tests/docgen_with_dep/args.txt
@@ -1,0 +1,8 @@
+build
+docgen --output-directory doc
+# Show the generated directory structure (root package + dependency docs)
+> find doc -type f | sort
+# Root package module
+> cat doc/app/tracker.md
+# Dependency module (flat, no dependencies/ prefix)
+> cat doc/helper/utils.md

--- a/external-crates/move/crates/move-cli/tests/build_tests/docgen_with_dep/dep/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/build_tests/docgen_with_dep/dep/Move.toml
@@ -1,0 +1,6 @@
+[package]
+name = "Helper"
+edition = "2024"
+
+[addresses]
+helper = "0x99"

--- a/external-crates/move/crates/move-cli/tests/build_tests/docgen_with_dep/dep/sources/utils.move
+++ b/external-crates/move/crates/move-cli/tests/build_tests/docgen_with_dep/dep/sources/utils.move
@@ -1,0 +1,27 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// # Utilities
+///
+/// Shared utility types.
+module helper::utils {
+    /// A simple counter.
+    public struct Counter has copy, drop, store {
+        value: u64,
+    }
+
+    /// Create a new counter starting at zero.
+    public fun new(): Counter {
+        Counter { value: 0 }
+    }
+
+    /// Increment by one.
+    public fun increment(c: &mut Counter) {
+        c.value = c.value + 1;
+    }
+
+    /// Get the current value.
+    public fun value(c: &Counter): u64 {
+        c.value
+    }
+}

--- a/external-crates/move/crates/move-cli/tests/build_tests/docgen_with_dep/sources/tracker.move
+++ b/external-crates/move/crates/move-cli/tests/build_tests/docgen_with_dep/sources/tracker.move
@@ -1,0 +1,40 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// # Tracker
+///
+/// Uses `helper::utils::Counter` from a dependency package.
+///
+/// Nested list in module doc:
+///
+/// - Top level
+///   - Nested item
+///     - Deeply nested
+/// - Another top level
+module app::tracker {
+    use helper::utils::{Self, Counter};
+
+    /// A named tracker wrapping a counter.
+    public struct Tracker has copy, drop {
+        name: u64,
+        counter: Counter,
+    }
+
+    /// Create a new tracker.
+    public fun new(name: u64): Tracker {
+        Tracker {
+            name,
+            counter: utils::new(),
+        }
+    }
+
+    /// Record an event.
+    public fun record(t: &mut Tracker) {
+        utils::increment(&mut t.counter);
+    }
+
+    /// Get event count.
+    public fun count(t: &Tracker): u64 {
+        utils::value(&t.counter)
+    }
+}

--- a/external-crates/move/crates/move-docgen-tests/tests/move/code_block_indent/Move.toml
+++ b/external-crates/move/crates/move-docgen-tests/tests/move/code_block_indent/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "Test"
+edition = "2024"
+
+[dependencies]
+MoveStdlib = { local = "../../../../move-stdlib/", addr_subst = { "std" = "0x1" } }
+
+[addresses]
+a = "0x42"

--- a/external-crates/move/crates/move-docgen-tests/tests/move/code_block_indent/a__m.md@collapsed_sections.snap
+++ b/external-crates/move/crates/move-docgen-tests/tests/move/code_block_indent/a__m.md@collapsed_sections.snap
@@ -1,0 +1,78 @@
+---
+source: crates/move-docgen-tests/tests/testsuite.rs
+assertion_line: 74
+info:
+  section_level_start: 1
+  exclude_private_fun: false
+  exclude_impl: false
+  toc_depth: 3
+  no_collapsed_sections: true
+  include_dep_diagrams: false
+  include_call_diagrams: false
+---
+<a name="a_m"></a>
+
+# Module `a::m`
+
+
+<a name="@Code_Block_Formatting_0"></a>
+
+## Code Block Formatting
+
+
+Indented code inside a fenced block should be preserved:
+
+```
+fun example() {
+    let x = 1;
+    if (x > 0) {
+        let y = x + 1;
+    };
+}
+```
+
+Text after code block with a nested list:
+
+- Item one
+  - Nested item
+
+
+-  [Code Block Formatting](#@Code_Block_Formatting_0)
+-  [Function `with_code_blocks`](#a_m_with_code_blocks)
+
+
+<pre><code></code></pre>
+
+
+
+<a name="a_m_with_code_blocks"></a>
+
+## Function `with_code_blocks`
+
+Function with code block in doc:
+
+```
+let v = vector[1, 2, 3];
+let sum = 0;
+while (!vector::is_empty(&v)) {
+    sum = sum + vector::pop_back(&mut v);
+};
+```
+
+And indented code block:
+
+  ```
+  indented_block();
+  ```
+
+
+<pre><code><b>entry</b> <b>fun</b> <a href="../a/m.md#a_m_with_code_blocks">with_code_blocks</a>()
+</code></pre>
+
+
+
+##### Implementation
+
+
+<pre><code><b>entry</b> <b>fun</b> <a href="../a/m.md#a_m_with_code_blocks">with_code_blocks</a>() { }
+</code></pre>

--- a/external-crates/move/crates/move-docgen-tests/tests/move/code_block_indent/a__m.md@default.snap
+++ b/external-crates/move/crates/move-docgen-tests/tests/move/code_block_indent/a__m.md@default.snap
@@ -1,0 +1,83 @@
+---
+source: crates/move-docgen-tests/tests/testsuite.rs
+assertion_line: 74
+info:
+  section_level_start: 1
+  exclude_private_fun: false
+  exclude_impl: false
+  toc_depth: 3
+  no_collapsed_sections: false
+  include_dep_diagrams: false
+  include_call_diagrams: false
+---
+<a name="a_m"></a>
+
+# Module `a::m`
+
+
+<a name="@Code_Block_Formatting_0"></a>
+
+## Code Block Formatting
+
+
+Indented code inside a fenced block should be preserved:
+
+```
+fun example() {
+    let x = 1;
+    if (x > 0) {
+        let y = x + 1;
+    };
+}
+```
+
+Text after code block with a nested list:
+
+- Item one
+  - Nested item
+
+
+-  [Code Block Formatting](#@Code_Block_Formatting_0)
+-  [Function `with_code_blocks`](#a_m_with_code_blocks)
+
+
+<pre><code></code></pre>
+
+
+
+<a name="a_m_with_code_blocks"></a>
+
+## Function `with_code_blocks`
+
+Function with code block in doc:
+
+```
+let v = vector[1, 2, 3];
+let sum = 0;
+while (!vector::is_empty(&v)) {
+    sum = sum + vector::pop_back(&mut v);
+};
+```
+
+And indented code block:
+
+  ```
+  indented_block();
+  ```
+
+
+<pre><code><b>entry</b> <b>fun</b> <a href="../a/m.md#a_m_with_code_blocks">with_code_blocks</a>()
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>entry</b> <b>fun</b> <a href="../a/m.md#a_m_with_code_blocks">with_code_blocks</a>() { }
+</code></pre>
+
+
+
+</details>

--- a/external-crates/move/crates/move-docgen-tests/tests/move/code_block_indent/sources/m.move
+++ b/external-crates/move/crates/move-docgen-tests/tests/move/code_block_indent/sources/m.move
@@ -1,0 +1,38 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// # Code Block Formatting
+///
+/// Indented code inside a fenced block should be preserved:
+///
+/// ```
+/// fun example() {
+///     let x = 1;
+///     if (x > 0) {
+///         let y = x + 1;
+///     };
+/// }
+/// ```
+///
+/// Text after code block with a nested list:
+///
+/// - Item one
+///   - Nested item
+module a::m {
+    /// Function with code block in doc:
+    ///
+    /// ```
+    /// let v = vector[1, 2, 3];
+    /// let sum = 0;
+    /// while (!vector::is_empty(&v)) {
+    ///     sum = sum + vector::pop_back(&mut v);
+    /// };
+    /// ```
+    ///
+    /// And indented code block:
+    ///
+    ///   ```
+    ///   indented_block();
+    ///   ```
+    entry fun with_code_blocks() { }
+}

--- a/external-crates/move/crates/move-docgen-tests/tests/move/nested_lists/Move.toml
+++ b/external-crates/move/crates/move-docgen-tests/tests/move/nested_lists/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "Test"
+edition = "2024"
+
+[dependencies]
+MoveStdlib = { local = "../../../../move-stdlib/", addr_subst = { "std" = "0x1" } }
+
+[addresses]
+a = "0x42"

--- a/external-crates/move/crates/move-docgen-tests/tests/move/nested_lists/a__m.md@collapsed_sections.snap
+++ b/external-crates/move/crates/move-docgen-tests/tests/move/nested_lists/a__m.md@collapsed_sections.snap
@@ -1,0 +1,98 @@
+---
+source: crates/move-docgen-tests/tests/testsuite.rs
+assertion_line: 74
+info:
+  section_level_start: 1
+  exclude_private_fun: false
+  exclude_impl: false
+  toc_depth: 3
+  no_collapsed_sections: true
+  include_dep_diagrams: false
+  include_call_diagrams: false
+---
+<a name="a_m"></a>
+
+# Module `a::m`
+
+
+<a name="@Nested_Bullet_Points_0"></a>
+
+## Nested Bullet Points
+
+
+- Item one
+  - Nested item one-a
+  - Nested item one-b
+    - Deeply nested item one-b-i
+    - Deeply nested item one-b-ii
+  - Nested item one-c
+- Item two
+- Item three
+  - Nested item three-a
+
+
+<a name="@Nested_Enumerated_Lists_1"></a>
+
+## Nested Enumerated Lists
+
+
+1. First item
+   1. Sub-item one
+   2. Sub-item two
+      1. Sub-sub-item one
+      2. Sub-sub-item two
+   3. Sub-item three
+2. Second item
+3. Third item
+   1. Sub-item one
+
+
+<a name="@Mixed_Nested_Lists_2"></a>
+
+## Mixed Nested Lists
+
+
+1. Ordered item one
+   - Unordered sub-item a
+   - Unordered sub-item b
+     1. Back to ordered
+     2. Still ordered
+2. Ordered item two
+  - Mixed sub-item
+
+
+-  [Nested Bullet Points](#@Nested_Bullet_Points_0)
+-  [Nested Enumerated Lists](#@Nested_Enumerated_Lists_1)
+-  [Mixed Nested Lists](#@Mixed_Nested_Lists_2)
+-  [Function `nested_list_fn`](#a_m_nested_list_fn)
+
+
+<pre><code></code></pre>
+
+
+
+<a name="a_m_nested_list_fn"></a>
+
+## Function `nested_list_fn`
+
+- Top-level bullet
+  - Nested bullet in function doc
+    - Deeply nested bullet
+- Another top-level bullet
+
+1. First step
+   1. Sub-step one
+   2. Sub-step two
+2. Second step
+
+
+<pre><code><b>entry</b> <b>fun</b> <a href="../a/m.md#a_m_nested_list_fn">nested_list_fn</a>()
+</code></pre>
+
+
+
+##### Implementation
+
+
+<pre><code><b>entry</b> <b>fun</b> <a href="../a/m.md#a_m_nested_list_fn">nested_list_fn</a>() { }
+</code></pre>

--- a/external-crates/move/crates/move-docgen-tests/tests/move/nested_lists/a__m.md@default.snap
+++ b/external-crates/move/crates/move-docgen-tests/tests/move/nested_lists/a__m.md@default.snap
@@ -1,0 +1,103 @@
+---
+source: crates/move-docgen-tests/tests/testsuite.rs
+assertion_line: 74
+info:
+  section_level_start: 1
+  exclude_private_fun: false
+  exclude_impl: false
+  toc_depth: 3
+  no_collapsed_sections: false
+  include_dep_diagrams: false
+  include_call_diagrams: false
+---
+<a name="a_m"></a>
+
+# Module `a::m`
+
+
+<a name="@Nested_Bullet_Points_0"></a>
+
+## Nested Bullet Points
+
+
+- Item one
+  - Nested item one-a
+  - Nested item one-b
+    - Deeply nested item one-b-i
+    - Deeply nested item one-b-ii
+  - Nested item one-c
+- Item two
+- Item three
+  - Nested item three-a
+
+
+<a name="@Nested_Enumerated_Lists_1"></a>
+
+## Nested Enumerated Lists
+
+
+1. First item
+   1. Sub-item one
+   2. Sub-item two
+      1. Sub-sub-item one
+      2. Sub-sub-item two
+   3. Sub-item three
+2. Second item
+3. Third item
+   1. Sub-item one
+
+
+<a name="@Mixed_Nested_Lists_2"></a>
+
+## Mixed Nested Lists
+
+
+1. Ordered item one
+   - Unordered sub-item a
+   - Unordered sub-item b
+     1. Back to ordered
+     2. Still ordered
+2. Ordered item two
+  - Mixed sub-item
+
+
+-  [Nested Bullet Points](#@Nested_Bullet_Points_0)
+-  [Nested Enumerated Lists](#@Nested_Enumerated_Lists_1)
+-  [Mixed Nested Lists](#@Mixed_Nested_Lists_2)
+-  [Function `nested_list_fn`](#a_m_nested_list_fn)
+
+
+<pre><code></code></pre>
+
+
+
+<a name="a_m_nested_list_fn"></a>
+
+## Function `nested_list_fn`
+
+- Top-level bullet
+  - Nested bullet in function doc
+    - Deeply nested bullet
+- Another top-level bullet
+
+1. First step
+   1. Sub-step one
+   2. Sub-step two
+2. Second step
+
+
+<pre><code><b>entry</b> <b>fun</b> <a href="../a/m.md#a_m_nested_list_fn">nested_list_fn</a>()
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>entry</b> <b>fun</b> <a href="../a/m.md#a_m_nested_list_fn">nested_list_fn</a>() { }
+</code></pre>
+
+
+
+</details>

--- a/external-crates/move/crates/move-docgen-tests/tests/move/nested_lists/sources/m.move
+++ b/external-crates/move/crates/move-docgen-tests/tests/move/nested_lists/sources/m.move
@@ -1,0 +1,45 @@
+/// # Nested Bullet Points
+///
+/// - Item one
+///   - Nested item one-a
+///   - Nested item one-b
+///     - Deeply nested item one-b-i
+///     - Deeply nested item one-b-ii
+///   - Nested item one-c
+/// - Item two
+/// - Item three
+///   - Nested item three-a
+///
+/// # Nested Enumerated Lists
+///
+/// 1. First item
+///    1. Sub-item one
+///    2. Sub-item two
+///       1. Sub-sub-item one
+///       2. Sub-sub-item two
+///    3. Sub-item three
+/// 2. Second item
+/// 3. Third item
+///    1. Sub-item one
+///
+/// # Mixed Nested Lists
+///
+/// 1. Ordered item one
+///    - Unordered sub-item a
+///    - Unordered sub-item b
+///      1. Back to ordered
+///      2. Still ordered
+/// 2. Ordered item two
+///   - Mixed sub-item
+module a::m {
+    /// - Top-level bullet
+    ///   - Nested bullet in function doc
+    ///     - Deeply nested bullet
+    /// - Another top-level bullet
+    ///
+    /// 1. First step
+    ///    1. Sub-step one
+    ///    2. Sub-step two
+    /// 2. Second step
+    entry fun nested_list_fn() { }
+}

--- a/external-crates/move/crates/move-docgen-tests/tests/testsuite.rs
+++ b/external-crates/move/crates/move-docgen-tests/tests/testsuite.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use move_command_line_common::testing::insta_assert;
+use move_compiler::parser::ast::TargetKind;
 use move_docgen::{Docgen, DocgenFlags, DocgenOptions};
 use move_package_alt::{RootPackage, Vanilla};
 use move_package_alt_compilation::build_config::BuildConfig;
@@ -65,9 +66,31 @@ fn test_impl(toml_path: &Path, flags: DocgenFlags, test_case: &str) -> datatest_
     let options = options(root_doc_template, flags);
     let docgen = Docgen::new(&model, &options);
     let file_contents = docgen.generate(&model)?;
+    // Determine root package directory prefix to filter out dependency docs.
+    // Template output files sit at top level (no `/` prefix) and should also be included.
+    let root_pkg_dir = model
+        .modules()
+        .find(|m| {
+            matches!(
+                m.info().target_kind,
+                TargetKind::Source {
+                    is_root_package: true
+                }
+            )
+        })
+        .map(|m| {
+            m.package()
+                .name()
+                .map(|n| n.to_string())
+                .unwrap_or_else(|| m.id().address.to_string())
+        })
+        .expect("must have at least one root package module");
+    let root_prefix = format!("{}/", root_pkg_dir);
     let [(path, contents)] = file_contents
         .iter()
-        .filter(|(path, _contents)| !path.contains("dependencies"))
+        .filter(|(path, _contents)| {
+            path.starts_with(&root_prefix) || !path.contains('/')
+        })
         .collect::<Vec<_>>()
         .try_into()
         .expect("Test infra supports only one output file currently");

--- a/external-crates/move/crates/move-docgen/src/docgen.rs
+++ b/external-crates/move/crates/move-docgen/src/docgen.rs
@@ -1268,10 +1268,26 @@ impl<'env> Docgen<'env> {
         }
     }
 
+    /// Returns the minimum leading whitespace count across all non-empty lines.
+    fn min_indent(text: &str) -> usize {
+        text.lines()
+            .filter(|line| !line.trim().is_empty())
+            .map(|line| line.len() - line.trim_start().len())
+            .min()
+            .unwrap_or(0)
+    }
+
     /// Outputs documentation text.
     fn doc_text_general(&mut self, env: &Model, for_root: bool, text: &str) {
-        for line in self.decorate_text(env, text).lines() {
-            let line = line.trim();
+        let decorated = self.decorate_text(env, text);
+        let min_indent = Self::min_indent(&decorated);
+        for line in decorated.lines() {
+            let line = if line.trim().is_empty() {
+                ""
+            } else {
+                &line[min_indent..]
+            };
+            let line = line.trim_end();
             if line.starts_with('#') {
                 let mut i = 1;
                 while line[i..].starts_with('#') {

--- a/external-crates/move/crates/move-docgen/src/docgen.rs
+++ b/external-crates/move/crates/move-docgen/src/docgen.rs
@@ -472,11 +472,7 @@ impl<'env> Docgen<'env> {
                     })
                 })
                 .unwrap_or_else(|| {
-                    format!(
-                        "dependencies/{}/{}",
-                        package_name,
-                        file_name.to_string_lossy(),
-                    )
+                    format!("{}/{}", package_name, file_name.to_string_lossy())
                 })
         } else {
             // We will generate this file in the provided output directory.
@@ -1542,26 +1538,7 @@ impl<'env> Docgen<'env> {
         let Some(info) = self.infos.get(&module_env.id()) else {
             return String::new();
         };
-        let extension = if !self
-            .current_module
-            .as_ref()
-            .map(|id| module_env.model().module(id))
-            .map(|x| {
-                matches!(
-                    x.info().target_kind,
-                    TargetKind::Source {
-                        is_root_package: true
-                    }
-                )
-            })
-            .unwrap_or(true)
-        {
-            "../../"
-        } else if !info.is_included {
-            "../"
-        } else {
-            ""
-        };
+        let extension = if !info.is_included { "../" } else { "" };
         format!("{}{}#{}", extension, info.target_file, info.label)
     }
 

--- a/external-crates/move/crates/move-stdlib/docs/std/internal.md
+++ b/external-crates/move/crates/move-stdlib/docs/std/internal.md
@@ -13,8 +13,8 @@ module example::use_permit;
 public struct MyType { /* ... */ }
 
 public fun test_permit() {
-let permit = internal::permit<MyType>();
-/* external_module::call_with_permit(permit); */
+   let permit = internal::permit<MyType>();
+   /* external_module::call_with_permit(permit); */
 }
 ```
 
@@ -26,7 +26,7 @@ To write a function that is guarded by a <code><a href="../std/internal.md#std_i
 module example::type_registry;
 
 public fun register_type<T>(_: internal::Permit<T> /* ... */) {
-/* ... */
+  /* ... */
 }
 ```
 


### PR DESCRIPTION
## Description 

Update the generated documentation structure to be flat (i.e., so all dependencies, both immediate and transitive al flattened into a one-level-deep directory).

templates, and the like live at the top level still.

## Test plan 

CI + 👀 on the newly-generated docs.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
