### PR TITLE
[cherry-pick to 1.68.0] graphql-alt: add tls config to FN client and enforce URL validation (#25963)

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_execute_transaction_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_execute_transaction_tests.rs
@@ -122,7 +122,7 @@ impl GraphQlTestCluster {
         };
 
         let fullnode_args = FullnodeArgs {
-            fullnode_rpc_url: Some(validator_cluster.rpc_url().to_string()),
+            fullnode_rpc_url: Some(validator_cluster.rpc_url().parse().unwrap()),
         };
 
         // Start GraphQL server that connects directly to TestCluster's RPC

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_simulate_transaction_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_simulate_transaction_tests.rs
@@ -160,7 +160,7 @@ impl GraphQlTestCluster {
         let database_url = database.database().url().clone();
 
         let fullnode_args = FullnodeArgs {
-            fullnode_rpc_url: Some(validator_cluster.rpc_url().to_string()),
+            fullnode_rpc_url: Some(validator_cluster.rpc_url().parse().unwrap()),
         };
         let client_args = ClientArgs {
             ingestion: IngestionClientArgs {

--- a/crates/sui-indexer-alt-reader/src/fullnode_client.rs
+++ b/crates/sui-indexer-alt-reader/src/fullnode_client.rs
@@ -13,7 +13,9 @@ use sui_types::signature::GenericSignature;
 use sui_types::transaction::Transaction;
 use sui_types::transaction::TransactionData;
 use tonic::transport::Channel;
+use tonic::transport::ClientTlsConfig;
 use tracing::instrument;
+use url::Url;
 
 use crate::metrics::FullnodeClientMetrics;
 
@@ -21,7 +23,7 @@ use crate::metrics::FullnodeClientMetrics;
 pub struct FullnodeArgs {
     /// gRPC URL for full node operations such as executeTransaction and simulateTransaction.
     #[clap(long)]
-    pub fullnode_rpc_url: Option<String>,
+    pub fullnode_rpc_url: Option<Url>,
 }
 
 /// A client for executing and simulating transactions via the full node gRPC service.
@@ -50,10 +52,16 @@ impl FullnodeClient {
         registry: &Registry,
     ) -> Result<Self, Error> {
         let execution_client = if let Some(url) = &args.fullnode_rpc_url {
-            let channel = Channel::from_shared(url.clone())
-                .context("Failed to create channel for gRPC endpoint")?
-                .connect_lazy();
+            let mut endpoint = Channel::from_shared(url.to_string())
+                .context("Failed to create channel for gRPC endpoint")?;
 
+            if url.scheme() == "https" {
+                endpoint = endpoint
+                    .tls_config(ClientTlsConfig::new().with_native_roots())
+                    .context("Failed to configure TLS for gRPC endpoint")?;
+            }
+
+            let channel = endpoint.connect_lazy();
             Some(TransactionExecutionServiceClient::new(channel))
         } else {
             None
@@ -196,5 +204,46 @@ impl FullnodeClient {
         }
 
         response
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn fn_client(url: Option<&str>) -> Result<FullnodeClient, Error> {
+        let args = FullnodeArgs {
+            fullnode_rpc_url: url.map(|u| Url::parse(u).unwrap()),
+        };
+        let registry = Registry::new();
+        FullnodeClient::new(None, args, &registry).await
+    }
+
+    #[tokio::test]
+    async fn no_url_means_not_configured() {
+        let client = fn_client(None).await.unwrap();
+        assert!(client.execution_client.is_none());
+    }
+
+    #[tokio::test]
+    async fn http_url_creates_client() {
+        assert!(
+            fn_client(Some("http://localhost:9000"))
+                .await
+                .unwrap()
+                .execution_client
+                .is_some()
+        );
+    }
+
+    #[tokio::test]
+    async fn https_url_creates_client() {
+        assert!(
+            fn_client(Some("https://fn.example.com"))
+                .await
+                .unwrap()
+                .execution_client
+                .is_some()
+        );
     }
 }

--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -1164,7 +1164,7 @@ async fn start(
         };
 
         let fullnode_args = FullnodeArgs {
-            fullnode_rpc_url: Some(fullnode_rpc_url.clone()),
+            fullnode_rpc_url: Some(socket_addr_to_url(fullnode_rpc_address)?),
         };
 
         let mut graphql_config = GraphQlConfig::default();


### PR DESCRIPTION
## Description 
 Cherry-pick of #25963 to `releases/sui-v1.67.0-release` 

- Add tls configs for providers who want to use public facing FNs with GraphQL
- `--fullnode-rpc-url` on GraphQL when provided, is now parsed as a `Url` by clap

Original commit: ddf2a8d0214bfa8a06e540bad681027b26fea7b5"

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:

## Description 

Describe the changes or additions included in this PR.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
