### PR TITLE
Wire up transaction read masks to Bigtable Client

### DIFF
--- a/crates/sui-indexer-alt-reader/src/kv_loader.rs
+++ b/crates/sui-indexer-alt-reader/src/kv_loader.rs
@@ -304,7 +304,10 @@ impl TransactionContents {
         match self {
             Self::Pg(stored) => bcs::from_bytes(&stored.raw_transaction)
                 .context("Failed to deserialize transaction data"),
-            Self::Bigtable(kv) => Ok(kv.transaction.data().transaction_data().clone()),
+            Self::Bigtable(kv) => kv
+                .transaction_data
+                .clone()
+                .context("transaction_data missing from bigtable data"),
             Self::LedgerGrpc(txn) => Ok(txn.transaction_data.as_ref().clone()),
             Self::ExecutedTransaction {
                 transaction_data, ..
@@ -316,7 +319,7 @@ impl TransactionContents {
         match self {
             Self::Pg(stored) => TransactionDigest::try_from(stored.tx_digest.clone())
                 .context("Failed to deserialize transaction digest"),
-            Self::Bigtable(kv) => Ok(*kv.transaction.digest()),
+            Self::Bigtable(kv) => Ok(kv.digest),
             Self::LedgerGrpc(txn) => Ok(*txn.effects.as_ref().transaction_digest()),
             Self::ExecutedTransaction { effects, .. } => Ok(*effects.as_ref().transaction_digest()),
         }
@@ -330,7 +333,11 @@ impl TransactionContents {
 
                 Ok(effects.digest())
             }
-            Self::Bigtable(kv) => Ok(kv.effects.digest()),
+            Self::Bigtable(kv) => Ok(kv
+                .effects
+                .as_ref()
+                .context("effects missing from bigtable data")?
+                .digest()),
             Self::LedgerGrpc(txn) => Ok(txn.effects.digest()),
             Self::ExecutedTransaction { effects, .. } => Ok(effects.digest()),
         }
@@ -341,7 +348,10 @@ impl TransactionContents {
             Self::Pg(stored) => {
                 bcs::from_bytes(&stored.user_signatures).context("Failed to deserialize signatures")
             }
-            Self::Bigtable(kv) => Ok(kv.transaction.tx_signatures().to_vec()),
+            Self::Bigtable(kv) => kv
+                .signatures
+                .clone()
+                .context("signatures missing from bigtable data"),
             Self::LedgerGrpc(txn) => Ok(txn.signatures.clone()),
             Self::ExecutedTransaction { signatures, .. } => Ok(signatures.clone()),
         }
@@ -352,7 +362,10 @@ impl TransactionContents {
             Self::Pg(stored) => {
                 bcs::from_bytes(&stored.raw_effects).context("Failed to deserialize effects")
             }
-            Self::Bigtable(kv) => Ok(kv.effects.clone()),
+            Self::Bigtable(kv) => kv
+                .effects
+                .clone()
+                .context("effects missing from bigtable data"),
             Self::LedgerGrpc(txn) => Ok(txn.effects.as_ref().clone()),
             Self::ExecutedTransaction { effects, .. } => Ok(effects.as_ref().clone()),
         }
@@ -436,8 +449,13 @@ impl TransactionContents {
     pub fn raw_transaction(&self) -> anyhow::Result<Vec<u8>> {
         match self {
             Self::Pg(stored) => Ok(stored.raw_transaction.clone()),
-            Self::Bigtable(kv) => bcs::to_bytes(kv.transaction.data().transaction_data())
-                .context("Failed to serialize transaction"),
+            Self::Bigtable(kv) => {
+                let tx_data = kv
+                    .transaction_data
+                    .as_ref()
+                    .context("transaction_data missing from bigtable data")?;
+                bcs::to_bytes(tx_data).context("Failed to serialize transaction")
+            }
             Self::LedgerGrpc(txn) => bcs::to_bytes(txn.transaction_data.as_ref())
                 .context("Failed to serialize transaction"),
             Self::ExecutedTransaction {
@@ -451,7 +469,13 @@ impl TransactionContents {
     pub fn raw_effects(&self) -> anyhow::Result<Vec<u8>> {
         match self {
             Self::Pg(stored) => Ok(stored.raw_effects.clone()),
-            Self::Bigtable(kv) => bcs::to_bytes(&kv.effects).context("Failed to serialize effects"),
+            Self::Bigtable(kv) => {
+                let effects = kv
+                    .effects
+                    .as_ref()
+                    .context("effects missing from bigtable data")?;
+                bcs::to_bytes(effects).context("Failed to serialize effects")
+            }
             Self::LedgerGrpc(txn) => {
                 bcs::to_bytes(txn.effects.as_ref()).context("Failed to serialize effects")
             }

--- a/crates/sui-indexer-alt-reader/src/transactions.rs
+++ b/crates/sui-indexer-alt-reader/src/transactions.rs
@@ -82,7 +82,7 @@ impl Loader<TransactionKey> for BigtableReader {
             .transactions(&digests)
             .await?
             .into_iter()
-            .map(|t| (TransactionKey(*t.transaction.digest()), t))
+            .map(|t| (TransactionKey(t.digest), t))
             .collect())
     }
 }

--- a/crates/sui-kv-rpc/src/v2/get_transaction.rs
+++ b/crates/sui-kv-rpc/src/v2/get_transaction.rs
@@ -3,7 +3,8 @@
 
 use std::collections::HashMap;
 use std::str::FromStr;
-use sui_kvstore::{BigTableClient, KeyValueStoreReader, TransactionData};
+use sui_kvstore::tables::transactions::col;
+use sui_kvstore::{BigTableClient, TransactionData};
 use sui_rpc::field::{FieldMask, FieldMaskTree, FieldMaskUtil};
 use sui_rpc::merge::Merge;
 use sui_rpc::proto::sui::rpc::v2::{
@@ -52,7 +53,10 @@ pub async fn get_transaction(
 
     let read_mask = validate_read_mask(request.read_mask)?;
 
-    let mut response = client.get_transactions(&[transaction_digest]).await?;
+    let columns = transaction_columns(&read_mask);
+    let mut response = client
+        .get_transactions_filtered(&[transaction_digest], Some(&columns))
+        .await?;
     let transaction = response
         .pop()
         .ok_or(TransactionNotFoundError(transaction_digest.into()))?;
@@ -81,11 +85,12 @@ pub async fn batch_get_transactions(
         .iter()
         .map(|digest| TransactionDigest::from_str(digest))
         .collect::<Result<Vec<_>, _>>()?;
+    let columns = transaction_columns(&read_mask);
     let response: HashMap<_, _> = client
-        .get_transactions(&digests)
+        .get_transactions_filtered(&digests, Some(&columns))
         .await?
         .into_iter()
-        .map(|tx| (*tx.transaction.digest(), tx))
+        .map(|tx| (tx.digest, tx))
         .collect();
 
     let transactions = digests
@@ -111,19 +116,20 @@ fn transaction_to_response(
     let mut message = ExecutedTransaction::default();
 
     if mask.contains(ExecutedTransaction::DIGEST_FIELD.name) {
-        message.digest = Some(source.transaction.digest().to_string());
+        message.digest = Some(source.digest.to_string());
     }
 
-    if let Some(submask) = mask.subtree(ExecutedTransaction::TRANSACTION_FIELD.name) {
-        let transaction =
-            sui_sdk_types::Transaction::try_from(source.transaction.transaction_data().clone())?;
+    if let Some(submask) = mask.subtree(ExecutedTransaction::TRANSACTION_FIELD.name)
+        && let Some(tx_data) = &source.transaction_data
+    {
+        let transaction = sui_sdk_types::Transaction::try_from(tx_data.clone())?;
         message.transaction = Some(Transaction::merge_from(transaction, &submask));
     }
 
-    if let Some(submask) = mask.subtree(ExecutedTransaction::SIGNATURES_FIELD.name) {
-        message.signatures = source
-            .transaction
-            .tx_signatures()
+    if let Some(submask) = mask.subtree(ExecutedTransaction::SIGNATURES_FIELD.name)
+        && let Some(sigs) = &source.signatures
+    {
+        message.signatures = sigs
             .iter()
             .map(|s| {
                 sui_sdk_types::UserSignature::try_from(s.clone())
@@ -132,9 +138,11 @@ fn transaction_to_response(
             .collect::<Result<_, _>>()?;
     }
 
-    if let Some(submask) = mask.subtree(ExecutedTransaction::EFFECTS_FIELD.name) {
+    if let Some(submask) = mask.subtree(ExecutedTransaction::EFFECTS_FIELD.name)
+        && let Some(effects) = source.effects
+    {
         let mut effects = TransactionEffects::merge_from(
-            &sui_sdk_types::TransactionEffects::try_from(source.effects)?,
+            &sui_sdk_types::TransactionEffects::try_from(effects)?,
             &submask,
         );
         if submask.contains(TransactionEffects::UNCHANGED_LOADED_RUNTIME_OBJECTS_FIELD.name) {
@@ -171,6 +179,45 @@ fn transaction_to_response(
     Ok(message)
 }
 
+/// Compute the set of BigTable columns needed for the given read mask.
+/// Always includes `cn` and `ts` (small metadata).
+/// Only includes `td`, `sg`, `ef`, `ev`, `bc`, and `ul` when the corresponding fields
+/// are in the mask.
+fn transaction_columns(mask: &FieldMaskTree) -> Vec<&'static str> {
+    let mut columns = vec![col::CHECKPOINT_NUMBER, col::TIMESTAMP];
+
+    if mask
+        .subtree(ExecutedTransaction::TRANSACTION_FIELD.name)
+        .is_some()
+    {
+        columns.push(col::DATA);
+    }
+    if mask
+        .subtree(ExecutedTransaction::SIGNATURES_FIELD.name)
+        .is_some()
+    {
+        columns.push(col::SIGNATURES);
+    }
+    if let Some(effects_submask) = mask.subtree(ExecutedTransaction::EFFECTS_FIELD.name) {
+        columns.push(col::EFFECTS);
+        if effects_submask.contains(TransactionEffects::UNCHANGED_LOADED_RUNTIME_OBJECTS_FIELD.name)
+        {
+            columns.push(col::UNCHANGED_LOADED);
+        }
+    }
+    if mask
+        .subtree(ExecutedTransaction::EVENTS_FIELD.name)
+        .is_some()
+    {
+        columns.push(col::EVENTS);
+    }
+    if mask.contains(ExecutedTransaction::BALANCE_CHANGES_FIELD.name) {
+        columns.push(col::BALANCE_CHANGES);
+    }
+
+    columns
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -188,7 +235,9 @@ mod tests {
         SenderSignedData, Transaction, TransactionData as SuiTransactionData,
     };
 
-    fn test_transaction() -> Transaction {
+    use sui_types::digests::TransactionDigest;
+
+    fn test_tx_data() -> (TransactionDigest, SuiTransactionData) {
         let sender = SuiAddress::random_for_testing_only();
         let gas = Object::immutable_with_id_for_testing(ObjectID::random());
         let pt = {
@@ -203,21 +252,25 @@ mod tests {
             1_000_000,
             1,
         );
-        Transaction::new(SenderSignedData::new(data, vec![]))
+        let tx = Transaction::new(SenderSignedData::new(data.clone(), vec![]));
+        (*tx.digest(), data)
     }
 
     #[test]
     fn transaction_to_response_returns_balance_changes_when_requested() {
-        let transaction = test_transaction();
-        let effects = TestEffectsBuilder::new(transaction.data()).build();
+        let (digest, tx_data) = test_tx_data();
+        let tx = Transaction::new(SenderSignedData::new(tx_data.clone(), vec![]));
+        let effects = TestEffectsBuilder::new(tx.data()).build();
         let balance_change = BalanceChange {
             address: SuiAddress::random_for_testing_only(),
             coin_type: TypeTag::U64,
             amount: 42,
         };
         let source = KvTransactionData {
-            transaction,
-            effects,
+            digest,
+            transaction_data: Some(tx_data),
+            signatures: Some(vec![]),
+            effects: Some(effects),
             events: None,
             checkpoint_number: 7,
             timestamp: 42,
@@ -236,12 +289,15 @@ mod tests {
 
     #[test]
     fn transaction_to_response_returns_unchanged_loaded_runtime_objects_when_requested() {
-        let transaction = test_transaction();
-        let effects = TestEffectsBuilder::new(transaction.data()).build();
+        let (digest, tx_data) = test_tx_data();
+        let tx = Transaction::new(SenderSignedData::new(tx_data.clone(), vec![]));
+        let effects = TestEffectsBuilder::new(tx.data()).build();
         let obj_key = ObjectKey(ObjectID::random(), 3.into());
         let source = KvTransactionData {
-            transaction,
-            effects,
+            digest,
+            transaction_data: Some(tx_data),
+            signatures: Some(vec![]),
+            effects: Some(effects),
             events: None,
             checkpoint_number: 7,
             timestamp: 42,

--- a/crates/sui-kvstore/src/bigtable/client/mod.rs
+++ b/crates/sui-kvstore/src/bigtable/client/mod.rs
@@ -226,6 +226,38 @@ impl BigTableClient {
         })
     }
 
+    /// Fetch transactions with an optional column filter for partial reads.
+    /// When `columns` is None, all columns are fetched. When Some, only the
+    /// specified column qualifiers are fetched (e.g. `&["td", "ef", "ts", "cn"]`).
+    pub async fn get_transactions_filtered(
+        &mut self,
+        transactions: &[TransactionDigest],
+        columns: Option<&[&str]>,
+    ) -> Result<Vec<TransactionData>> {
+        let keys = transactions
+            .iter()
+            .map(tables::transactions::encode_key)
+            .collect();
+        let filter = columns.map(|cols| {
+            let pattern = format!("^({})$", cols.join("|"));
+            RowFilter {
+                filter: Some(Filter::ColumnQualifierRegexFilter(pattern.into())),
+            }
+        });
+        let mut result = vec![];
+        for (key, row) in self
+            .multi_get(tables::transactions::NAME, keys, filter)
+            .await?
+        {
+            let digest = TransactionDigest::from(
+                <[u8; 32]>::try_from(key.as_ref())
+                    .context("invalid transaction digest key length")?,
+            );
+            result.push(tables::transactions::decode(digest, &row)?);
+        }
+        Ok(result)
+    }
+
     /// Get the pipeline watermark from the watermarks table.
     pub async fn get_pipeline_watermark(&mut self, pipeline: &str) -> Result<Option<Watermark>> {
         let pipeline_key = tables::watermarks::encode_key(pipeline);
@@ -643,18 +675,7 @@ impl KeyValueStoreReader for BigTableClient {
         &mut self,
         transactions: &[TransactionDigest],
     ) -> Result<Vec<TransactionData>> {
-        let keys = transactions
-            .iter()
-            .map(tables::transactions::encode_key)
-            .collect();
-        let mut result = vec![];
-        for (_, row) in self
-            .multi_get(tables::transactions::NAME, keys, None)
-            .await?
-        {
-            result.push(tables::transactions::decode(&row)?);
-        }
-        Ok(result)
+        self.get_transactions_filtered(transactions, None).await
     }
 
     async fn get_checkpoints(

--- a/crates/sui-kvstore/src/handlers/transactions.rs
+++ b/crates/sui-kvstore/src/handlers/transactions.rs
@@ -6,7 +6,6 @@ use std::sync::Arc;
 use sui_indexer_alt_framework::pipeline::Processor;
 use sui_types::balance_change::derive_balance_changes_2;
 use sui_types::full_checkpoint_content::Checkpoint;
-use sui_types::transaction::Transaction;
 
 use crate::bigtable::proto::bigtable::v2::mutate_rows_request::Entry;
 use crate::handlers::BigTableProcessor;
@@ -28,13 +27,13 @@ impl Processor for TransactionsPipeline {
 
         for tx in &checkpoint.transactions {
             let balance_changes = derive_balance_changes_2(&tx.effects, &checkpoint.object_set);
-            let transaction =
-                Transaction::from_generic_sig_data(tx.transaction.clone(), tx.signatures.clone());
+            let digest = tx.transaction.digest();
 
             let entry = tables::make_entry(
-                tables::transactions::encode_key(transaction.digest()),
+                tables::transactions::encode_key(&digest),
                 tables::transactions::encode(
-                    &transaction,
+                    &tx.transaction,
+                    &tx.signatures,
                     &tx.effects,
                     &tx.events,
                     checkpoint_number,

--- a/crates/sui-kvstore/src/lib.rs
+++ b/crates/sui-kvstore/src/lib.rs
@@ -37,7 +37,9 @@ use sui_types::messages_checkpoint::CheckpointContents;
 use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 use sui_types::messages_checkpoint::CheckpointSummary;
 use sui_types::object::Object;
+use sui_types::signature::GenericSignature;
 use sui_types::storage::ObjectKey;
+use sui_types::transaction::SenderSignedData;
 use sui_types::transaction::Transaction;
 
 pub use crate::bigtable::client::BigTableClient;
@@ -128,13 +130,24 @@ pub struct CheckpointData {
 
 #[derive(Clone, Debug)]
 pub struct TransactionData {
-    pub transaction: Transaction,
-    pub effects: TransactionEffects,
+    pub digest: TransactionDigest,
+    pub transaction_data: Option<sui_types::transaction::TransactionData>,
+    pub signatures: Option<Vec<GenericSignature>>,
+    pub effects: Option<TransactionEffects>,
     pub events: Option<TransactionEvents>,
     pub checkpoint_number: CheckpointSequenceNumber,
     pub timestamp: u64,
     pub balance_changes: Vec<BalanceChange>,
     pub unchanged_loaded_runtime_objects: Vec<ObjectKey>,
+}
+
+impl TransactionData {
+    /// Reconstruct the full Transaction when both data and signatures are present.
+    pub fn transaction(&self) -> Option<Transaction> {
+        let data = self.transaction_data.clone()?;
+        let sigs = self.signatures.clone().unwrap_or_default();
+        Some(Transaction::new(SenderSignedData::new(data, sigs)))
+    }
 }
 
 /// Partial transaction and events for when we only need transaction content for events

--- a/crates/sui-kvstore/src/tables/transactions.rs
+++ b/crates/sui-kvstore/src/tables/transactions.rs
@@ -39,7 +39,8 @@ pub fn encode_key(digest: &TransactionDigest) -> Vec<u8> {
 /// Writes 8 columns by default (or 9 when `write_legacy_data()` is enabled, which adds
 /// the deprecated TX column).
 pub fn encode(
-    transaction: &Transaction,
+    transaction_data: &sui_types::transaction::TransactionData,
+    signatures: &[GenericSignature],
     effects: &TransactionEffects,
     events: &Option<TransactionEvents>,
     checkpoint_number: CheckpointSequenceNumber,
@@ -50,7 +51,11 @@ pub fn encode(
     let mut cols = Vec::with_capacity(if write_legacy_data() { 9 } else { 8 });
 
     if write_legacy_data() {
-        cols.push((col::TX, Bytes::from(bcs::to_bytes(transaction)?)));
+        let transaction = Transaction::new(SenderSignedData::new(
+            transaction_data.clone(),
+            signatures.to_vec(),
+        ));
+        cols.push((col::TX, Bytes::from(bcs::to_bytes(&transaction)?)));
     }
 
     cols.extend([
@@ -61,14 +66,8 @@ pub fn encode(
             col::CHECKPOINT_NUMBER,
             Bytes::from(bcs::to_bytes(&checkpoint_number)?),
         ),
-        (
-            col::DATA,
-            Bytes::from(bcs::to_bytes(&transaction.data().intent_message().value)?),
-        ),
-        (
-            col::SIGNATURES,
-            Bytes::from(bcs::to_bytes(transaction.data().tx_signatures())?),
-        ),
+        (col::DATA, Bytes::from(bcs::to_bytes(transaction_data)?)),
+        (col::SIGNATURES, Bytes::from(bcs::to_bytes(signatures)?)),
         (
             col::BALANCE_CHANGES,
             Bytes::from(bcs::to_bytes(balance_changes)?),
@@ -82,9 +81,9 @@ pub fn encode(
     Ok(cols)
 }
 
-pub fn decode(row: &[(Bytes, Bytes)]) -> Result<TransactionData> {
-    let mut tx_data: Option<sui_types::transaction::TransactionData> = None;
-    let mut tx_signatures: Option<Vec<GenericSignature>> = None;
+pub fn decode(digest: TransactionDigest, row: &[(Bytes, Bytes)]) -> Result<TransactionData> {
+    let mut tx_data = None;
+    let mut tx_signatures = None;
 
     let mut effects = None;
     let mut events = None;
@@ -107,17 +106,14 @@ pub fn decode(row: &[(Bytes, Bytes)]) -> Result<TransactionData> {
         }
     }
 
-    let transaction = {
-        let data = tx_data.context("transaction data field is missing")?;
-        let sigs = tx_signatures.context("transaction signatures field is missing")?;
-        let sender_signed_data = SenderSignedData::new(data, sigs);
-        Transaction::new(sender_signed_data)
-    };
-
     Ok(TransactionData {
-        transaction,
-        effects: effects.context("effects field is missing")?,
-        events: events.context("events field is missing")?,
+        digest,
+        transaction_data: tx_data,
+        signatures: tx_signatures,
+        effects,
+        // events column stores Option<TransactionEvents>; flatten the double-Option
+        // from "column present with value" vs "column not fetched"
+        events: events.flatten(),
         timestamp,
         checkpoint_number,
         balance_changes,
@@ -162,7 +158,7 @@ mod tests {
     use sui_types::storage::ObjectKey;
     use sui_types::transaction::{SenderSignedData, Transaction, TransactionData};
 
-    fn test_transaction() -> Transaction {
+    fn test_tx_data() -> (TransactionDigest, TransactionData) {
         let sender = SuiAddress::random_for_testing_only();
         let gas = Object::immutable_with_id_for_testing(ObjectID::random());
         let pt = {
@@ -177,13 +173,15 @@ mod tests {
             1_000_000,
             1,
         );
-        Transaction::new(SenderSignedData::new(data, vec![]))
+        let tx = Transaction::new(SenderSignedData::new(data.clone(), vec![]));
+        (*tx.digest(), data)
     }
 
     #[test]
     fn encode_decode_round_trip() {
-        let transaction = test_transaction();
-        let effects = TestEffectsBuilder::new(transaction.data()).build();
+        let (digest, tx_data) = test_tx_data();
+        let tx = Transaction::new(SenderSignedData::new(tx_data.clone(), vec![]));
+        let effects = TestEffectsBuilder::new(tx.data()).build();
         let balance_change = BalanceChange {
             address: SuiAddress::random_for_testing_only(),
             coin_type: TypeTag::U64,
@@ -192,7 +190,8 @@ mod tests {
         let obj_key = ObjectKey(ObjectID::random(), 3.into());
 
         let encoded = encode(
-            &transaction,
+            &tx_data,
+            &[],
             &effects,
             &None,
             7,
@@ -206,8 +205,10 @@ mod tests {
             .map(|(column, value)| (Bytes::from_static(column.as_bytes()), value))
             .collect();
 
-        let decoded = decode(&row).expect("decoding should succeed");
+        let decoded = decode(digest, &row).expect("decoding should succeed");
 
+        assert_eq!(decoded.digest, digest);
+        assert_eq!(decoded.transaction_data.unwrap(), tx_data);
         assert_eq!(decoded.balance_changes, vec![balance_change]);
         assert_eq!(decoded.unchanged_loaded_runtime_objects, vec![obj_key]);
     }

--- a/crates/sui-kvstore/tests/e2e.rs
+++ b/crates/sui-kvstore/tests/e2e.rs
@@ -509,11 +509,42 @@ async fn test_indexer_e2e() -> Result<()> {
     for signed in &signed_txns {
         let indexed = transactions
             .iter()
-            .find(|td| td.transaction.digest() == signed.digest())
+            .find(|td| td.digest == *signed.digest())
             .unwrap_or_else(|| panic!("transaction {} not found in results", signed.digest()));
-        assert_eq!(indexed.transaction, *signed);
+        assert_eq!(indexed.transaction().unwrap(), *signed);
         assert!(indexed.checkpoint_number > 0);
         assert!(indexed.timestamp > 0);
+    }
+
+    // -- Column-filtered partial reads --
+    // Fetch with only effects + checkpoint columns — no td, sg, ev, or bc.
+    {
+        use sui_kvstore::tables::transactions::col;
+        let partial = harness
+            .bigtable_client()
+            .get_transactions_filtered(
+                &tx_digests,
+                Some(&[col::EFFECTS, col::CHECKPOINT_NUMBER, col::TIMESTAMP]),
+            )
+            .await?;
+        assert_eq!(partial.len(), tx_digests.len());
+        for tx in &partial {
+            // digest comes from the row key, always present
+            assert!(tx_digests.contains(&tx.digest));
+            // td was not fetched
+            assert!(tx.transaction_data.is_none(), "td should be absent");
+            // sg was not fetched
+            assert!(tx.signatures.is_none(), "sg should be absent");
+            // ef was fetched
+            assert!(tx.effects.is_some(), "ef should be present");
+            // ev was not fetched
+            assert!(tx.events.is_none(), "ev should be absent");
+            // bc was not fetched
+            assert!(tx.balance_changes.is_empty(), "bc should be empty");
+            // metadata always present
+            assert!(tx.checkpoint_number > 0);
+            assert!(tx.timestamp > 0);
+        }
     }
 
     // -- Balance changes parity with fullnode gRPC batch_get_transactions --
@@ -648,7 +679,9 @@ async fn test_indexer_e2e() -> Result<()> {
     // -- Objects lookup --
     let mut object_keys: Vec<ObjectKey> = Vec::new();
     for tx_data in &transactions {
-        for (obj_ref, _owner, _write_kind) in tx_data.effects.all_changed_objects() {
+        for (obj_ref, _owner, _write_kind) in
+            tx_data.effects.as_ref().unwrap().all_changed_objects()
+        {
             object_keys.push(ObjectKey(obj_ref.0, obj_ref.1));
         }
     }
@@ -673,7 +706,7 @@ async fn test_indexer_e2e() -> Result<()> {
         .get_transactions(&[publish_digest])
         .await?;
     let publish_tx_data = publish_txns.first().context("publish tx not found")?;
-    let created = publish_tx_data.effects.created();
+    let created = publish_tx_data.effects.as_ref().unwrap().created();
     let (package_ref, _) = created
         .iter()
         .find(|(_, owner)| *owner == Owner::Immutable)


### PR DESCRIPTION
## Description

Wiring up the transaction read masks to the bigtable client to avoid loading data from the DB that we aren't going to render in the gRPC response.
