### PR TITLE
[effects] switch gas_object method to optional

### DIFF
--- a/crates/sui-analytics-indexer/src/handlers/tables/transaction.rs
+++ b/crates/sui-analytics-indexer/src/handlers/tables/transaction.rs
@@ -8,11 +8,13 @@ use std::sync::Arc;
 use anyhow::Result;
 use async_trait::async_trait;
 use sui_indexer_alt_framework::pipeline::Processor;
-use sui_types::base_types::EpochId;
+use sui_types::base_types::{EpochId, ObjectID, SequenceNumber, SuiAddress};
+use sui_types::digests::ObjectDigest;
 use sui_types::digests::TransactionDigest;
 use sui_types::effects::TransactionEffectsAPI;
 use sui_types::full_checkpoint_content::Checkpoint;
 use sui_types::messages_checkpoint::CheckpointContents;
+use sui_types::object::Owner;
 use sui_types::transaction::Command;
 use sui_types::transaction::TransactionDataAPI;
 use sui_types::transaction::TransactionKind;
@@ -51,7 +53,10 @@ impl Processor for TransactionProcessor {
         for executed_transaction in &checkpoint.transactions {
             let effects = &executed_transaction.effects;
             let txn_data = &executed_transaction.transaction;
-            let gas_object = effects.gas_object();
+            let gas_object = effects.gas_object().unwrap_or((
+                (ObjectID::ZERO, SequenceNumber::default(), ObjectDigest::MIN),
+                Owner::AddressOwner(SuiAddress::default()),
+            ));
             let gas_summary = effects.gas_cost_summary();
             let move_calls_vec = txn_data.move_calls();
             let packages: BTreeSet<_> = move_calls_vec

--- a/crates/sui-benchmark/src/lib.rs
+++ b/crates/sui-benchmark/src/lib.rs
@@ -152,9 +152,9 @@ impl ExecutionEffects {
     pub fn gas_object(&self) -> (ObjectRef, Owner) {
         match self {
             ExecutionEffects::FinalizedTransactionEffects(effects, ..) => {
-                effects.data().gas_object()
+                effects.data().gas_object().unwrap()
             }
-            ExecutionEffects::ExecutedTransaction(txn) => txn.effects.gas_object(),
+            ExecutionEffects::ExecutedTransaction(txn) => txn.effects.gas_object().unwrap(),
         }
     }
 

--- a/crates/sui-benchmark/src/workloads/composite/mod.rs
+++ b/crates/sui-benchmark/src/workloads/composite/mod.rs
@@ -75,7 +75,7 @@ fn authenticated_events_disabled(protocol_config: Option<&ProtocolConfig>) -> bo
 
 macro_rules! update_gas {
     ($gas:expr, $effects:expr) => {{
-        let new_gas_ref = $effects.gas_object().0;
+        let (new_gas_ref, _) = $effects.gas_object();
         if new_gas_ref.0 == ObjectID::ZERO {
             info!("No gas object, skipping update");
             return;

--- a/crates/sui-core/src/accumulators/object_funds_checker/integration_tests.rs
+++ b/crates/sui-core/src/accumulators/object_funds_checker/integration_tests.rs
@@ -73,7 +73,7 @@ impl TestEnv {
             .unwrap()
             .0
             .0;
-        let gas = effects.gas_object().0;
+        let gas = effects.gas_object().unwrap().0;
 
         let tx = TestTransactionBuilder::new(sender, gas, rgp)
             .move_call(package_id, "object_balance", "new_owned", vec![])

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -2605,7 +2605,8 @@ async fn test_get_latest_parent_entry() {
     .unwrap();
     let (new_object_id2, seq2, _) = effects.created()[0].0;
 
-    let update_version = SequenceNumber::lamport_increment([seq1, seq2, effects.gas_object().0.1]);
+    let update_version =
+        SequenceNumber::lamport_increment([seq1, seq2, effects.gas_object().unwrap().0.1]);
 
     let effects = call_move(
         &authority_state,
@@ -2632,7 +2633,8 @@ async fn test_get_latest_parent_entry() {
     assert_eq!(obj_ref.0, new_object_id1);
     assert_eq!(obj_ref.1, update_version);
 
-    let delete_version = SequenceNumber::lamport_increment([obj_ref.1, effects.gas_object().0.1]);
+    let delete_version =
+        SequenceNumber::lamport_increment([obj_ref.1, effects.gas_object().unwrap().0.1]);
 
     let _effects = call_move(
         &authority_state,
@@ -3045,8 +3047,11 @@ async fn test_transfer_sui_no_amount() {
     // and got transferred. Also check on its version and new balance.
     assert!(effects.status().is_ok());
     assert!(effects.mutated_excluding_gas().is_empty());
-    assert!(gas_ref.1 < effects.gas_object().0.1);
-    assert_eq!(effects.gas_object().1, Owner::AddressOwner(recipient));
+    assert!(gas_ref.1 < effects.gas_object().unwrap().0.1);
+    assert_eq!(
+        effects.gas_object().unwrap().1,
+        Owner::AddressOwner(recipient)
+    );
     let new_balance =
         sui_types::gas::get_gas_balance(&authority_state.get_object(&gas_object_id).await.unwrap())
             .unwrap();
@@ -3091,8 +3096,8 @@ async fn test_transfer_sui_with_amount() {
         .await
         .unwrap();
     assert_eq!(sui_types::gas::get_gas_balance(&new_gas).unwrap(), 500);
-    assert!(gas_ref.1 < effects.gas_object().0.1);
-    assert_eq!(effects.gas_object().1, Owner::AddressOwner(sender));
+    assert!(gas_ref.1 < effects.gas_object().unwrap().0.1);
+    assert_eq!(effects.gas_object().unwrap().1, Owner::AddressOwner(sender));
     let new_balance =
         sui_types::gas::get_gas_balance(&authority_state.get_object(&gas_object_id).await.unwrap())
             .unwrap();
@@ -3192,7 +3197,7 @@ async fn test_clear_cache_reverts_wrap_move_call() {
             ident_str!("object_basics").to_owned(),
             ident_str!("wrap").to_owned(),
             vec![],
-            create_effects.gas_object().0,
+            create_effects.gas_object().unwrap().0,
             vec![CallArg::Object(ObjectArg::ImmOrOwnedObject(object_v0))],
             TEST_ONLY_GAS_UNIT_FOR_OBJECT_BASICS * rgp,
             rgp,
@@ -3227,7 +3232,7 @@ async fn test_clear_cache_reverts_wrap_move_call() {
 
     // The gas is uncharged
     let gas = cache.get_object(&gas_object_id).unwrap();
-    assert_eq!(gas.version(), create_effects.gas_object().0.1);
+    assert_eq!(gas.version(), create_effects.gas_object().unwrap().0.1);
 }
 
 #[tokio::test]
@@ -3287,7 +3292,7 @@ async fn test_clear_cache_reverts_unwrap_move_call() {
             ident_str!("object_basics").to_owned(),
             ident_str!("unwrap").to_owned(),
             vec![],
-            wrap_effects.gas_object().0,
+            wrap_effects.gas_object().unwrap().0,
             vec![CallArg::Object(ObjectArg::ImmOrOwnedObject(wrapper_v0))],
             TEST_ONLY_GAS_UNIT_FOR_OBJECT_BASICS * rgp,
             rgp,
@@ -3322,7 +3327,7 @@ async fn test_clear_cache_reverts_unwrap_move_call() {
 
     // The gas is uncharged
     let gas = cache.get_object(&gas_object_id).unwrap();
-    assert_eq!(gas.version(), wrap_effects.gas_object().0.1);
+    assert_eq!(gas.version(), wrap_effects.gas_object().unwrap().0.1);
 }
 
 #[tokio::test]
@@ -3389,7 +3394,7 @@ async fn create_and_retrieve_df_info(function: &IdentStr) -> (SuiAddress, Vec<Dy
             ident_str!("object_basics").to_owned(),
             function.to_owned(),
             vec![],
-            create_inner_effects.gas_object().0,
+            create_inner_effects.gas_object().unwrap().0,
             vec![
                 CallArg::Object(ObjectArg::ImmOrOwnedObject(outer_v0)),
                 CallArg::Object(ObjectArg::ImmOrOwnedObject(inner_v0)),
@@ -3551,7 +3556,7 @@ async fn test_clear_cache_removes_added_ofield() {
             ident_str!("object_basics").to_owned(),
             ident_str!("add_ofield").to_owned(),
             vec![],
-            create_inner_effects.gas_object().0,
+            create_inner_effects.gas_object().unwrap().0,
             vec![
                 CallArg::Object(ObjectArg::ImmOrOwnedObject(outer_v0)),
                 CallArg::Object(ObjectArg::ImmOrOwnedObject(inner_v0)),
@@ -3673,7 +3678,7 @@ async fn test_clear_cache_reverts_removed_ofield() {
             ident_str!("object_basics").to_owned(),
             ident_str!("remove_ofield").to_owned(),
             vec![],
-            add_effects.gas_object().0,
+            add_effects.gas_object().unwrap().0,
             vec![CallArg::Object(ObjectArg::ImmOrOwnedObject(outer_v1))],
             TEST_ONLY_GAS_UNIT_FOR_OBJECT_BASICS * rgp,
             rgp,
@@ -5246,7 +5251,7 @@ async fn test_gas_smashing() {
             assert!(effects.status().is_err());
         }
         // gas object in effects is first coin in vector of coins
-        assert_eq!(gas_coin_ids[0], effects.gas_object().0.0);
+        assert_eq!(gas_coin_ids[0], effects.gas_object().unwrap().0.0);
         // object is created on success and gas at position 0 mutated
         let created = usize::from(success);
         assert_eq!(
@@ -5548,7 +5553,7 @@ async fn test_publish_transitive_dependencies_ok() {
         .1
         .into_data();
     let ((package_c_id, _, _), _) = txn_effects.created()[0];
-    let gas_ref = txn_effects.gas_object().0;
+    let gas_ref = txn_effects.gas_object().unwrap().0;
 
     // Publish `package B`
     let mut package_b_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
@@ -5584,7 +5589,7 @@ async fn test_publish_transitive_dependencies_ok() {
         .1
         .into_data();
     let ((package_b_id, _, _), _) = txn_effects.created()[0];
-    let gas_ref = txn_effects.gas_object().0;
+    let gas_ref = txn_effects.gas_object().unwrap().0;
 
     // Publish `package A`
     let mut package_a_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
@@ -5621,7 +5626,7 @@ async fn test_publish_transitive_dependencies_ok() {
         .1
         .into_data();
     let ((package_a_id, _, _), _) = txn_effects.created()[0];
-    let gas_ref = txn_effects.gas_object().0;
+    let gas_ref = txn_effects.gas_object().unwrap().0;
 
     // Publish `package root`
     let mut package_root_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));

--- a/crates/sui-core/src/unit_tests/coin_deny_list_tests.rs
+++ b/crates/sui-core/src/unit_tests/coin_deny_list_tests.rs
@@ -248,7 +248,7 @@ async fn test_regulated_coin_v2_funds_withdraw_deny() {
             .unwrap()
             .1;
         assert!(effects.status().is_ok(), "Funding should succeed");
-        env_gas_ref = effects.gas_object().0;
+        env_gas_ref = effects.gas_object().unwrap().0;
 
         env.authority
             .settle_accumulator_for_testing(std::slice::from_ref(&effects), None)

--- a/crates/sui-core/src/unit_tests/gas_tests.rs
+++ b/crates/sui-core/src/unit_tests/gas_tests.rs
@@ -222,7 +222,7 @@ where
         ExecutionErrorKind::InsufficientGas
     );
     // gas object in effects is first coin in vector of coins
-    assert_eq!(gas_coin_ids[0], effects.gas_object().0.0);
+    assert_eq!(gas_coin_ids[0], effects.gas_object().unwrap().0.0);
     //  gas at position 0 mutated
     assert_eq!(effects.mutated().len(), 1);
     // extra coins are deleted
@@ -235,7 +235,7 @@ where
                 .any(|deleted| deleted.0 == *gas_coin_id)
         );
     }
-    let gas_ref = effects.gas_object().0;
+    let gas_ref = effects.gas_object().unwrap().0;
     let gas_object = authority_state.get_object(&gas_ref.0).await.unwrap();
     let final_value = GasCoin::try_from(&gas_object)?.value();
     let summary = effects.gas_cost_summary();

--- a/crates/sui-core/src/unit_tests/move_integration_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_integration_tests.rs
@@ -80,7 +80,7 @@ async fn test_object_wrapping_unwrapping() {
     assert_eq!(child_object_ref.1, create_child_version);
 
     let wrapped_version =
-        SequenceNumber::lamport_increment([child_object_ref.1, effects.gas_object().0.1]);
+        SequenceNumber::lamport_increment([child_object_ref.1, effects.gas_object().unwrap().0.1]);
 
     // Create a Parent object, by wrapping the child object.
     let effects = call_move(
@@ -125,7 +125,7 @@ async fn test_object_wrapping_unwrapping() {
     assert_eq!(parent_object_ref.1, wrapped_version);
 
     let unwrapped_version =
-        SequenceNumber::lamport_increment([parent_object_ref.1, effects.gas_object().0.1]);
+        SequenceNumber::lamport_increment([parent_object_ref.1, effects.gas_object().unwrap().0.1]);
 
     // Extract the child out of the parent.
     let effects = call_move(
@@ -164,7 +164,7 @@ async fn test_object_wrapping_unwrapping() {
     let rewrap_version = SequenceNumber::lamport_increment([
         parent_object_ref.1,
         child_object_ref.1,
-        effects.gas_object().0.1,
+        effects.gas_object().unwrap().0.1,
     ]);
 
     // Wrap the child to the parent again.
@@ -203,7 +203,7 @@ async fn test_object_wrapping_unwrapping() {
     let parent_object_ref = effects.mutated_excluding_gas().first().unwrap().0;
 
     let deleted_version =
-        SequenceNumber::lamport_increment([parent_object_ref.1, effects.gas_object().0.1]);
+        SequenceNumber::lamport_increment([parent_object_ref.1, effects.gas_object().unwrap().0.1]);
 
     // Now delete the parent object, which will in turn delete the child object.
     let effects = call_move(

--- a/crates/sui-e2e-tests/tests/address_balance_tests.rs
+++ b/crates/sui-e2e-tests/tests/address_balance_tests.rs
@@ -2454,7 +2454,11 @@ async fn test_address_balance_large_rebate() {
     let created_object_ref = effects
         .created()
         .iter()
-        .find(|(obj_ref, _)| obj_ref.0 != effects.gas_object().0.0)
+        .find(|(obj_ref, _)| {
+            effects
+                .gas_object()
+                .is_none_or(|(gas_ref, _)| obj_ref.0 != gas_ref.0)
+        })
         .map(|(obj_ref, _)| *obj_ref)
         .expect("Should have created an object");
 
@@ -3145,7 +3149,7 @@ async fn address_balance_stress_test() {
                             } else {
                                 exec_failure_count.fetch_add(1, Ordering::Relaxed);
                             }
-                            current_gas = effects.gas_object().0;
+                            current_gas = effects.gas_object().unwrap().0;
                         }
                         Err(err) => {
                             let err_str = err.to_string();

--- a/crates/sui-e2e-tests/tests/full_node_tests.rs
+++ b/crates/sui-e2e-tests/tests/full_node_tests.rs
@@ -1221,7 +1221,7 @@ async fn test_access_old_object_pruned() {
         .sign_and_execute_transaction(&tx_builder.transfer_sui(None, sender).build())
         .await
         .effects;
-    let new_gas_version = effects.gas_object().0.1;
+    let new_gas_version = effects.gas_object().unwrap().0.1;
     test_cluster.trigger_reconfiguration().await;
     // Construct a new transaction that uses the old gas object reference.
     let tx = test_cluster

--- a/crates/sui-e2e-tests/tests/grpc_simulate_gas_coin_tests.rs
+++ b/crates/sui-e2e-tests/tests/grpc_simulate_gas_coin_tests.rs
@@ -644,7 +644,7 @@ async fn test_combined_ab_and_coins_needed() {
         .expect("Should have created a coin for limited_sender");
 
     // Fund limited_sender's address balance with 5 SUI (from genesis account)
-    let (genesis_sender, genesis_gas) = test_env.get_sender_and_gas(0);
+    let genesis_gas = test_env.get_gas_for_sender(genesis_sender)[0];
     let ab_amount = 5 * MIST_PER_SUI;
     let fund_ab_tx = TestTransactionBuilder::new(genesis_sender, genesis_gas, test_env.rgp)
         .transfer_sui_to_address_balance(

--- a/crates/sui-indexer-alt-e2e-tests/tests/consistent_store_address_balance_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/consistent_store_address_balance_tests.rs
@@ -1180,5 +1180,5 @@ fn run_tx_and_return_gas(
         .execute_transaction(Transaction::from_data_and_signer(data, vec![signer]))
         .expect("Failed to execute transaction");
     assert!(fx.status().is_ok(), "Transaction failed: {:?}", fx.status());
-    fx.gas_object().0
+    fx.gas_object().unwrap().0
 }

--- a/crates/sui-indexer-alt-e2e-tests/tests/consistent_store_balance_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/consistent_store_balance_tests.rs
@@ -382,7 +382,7 @@ async fn test_transfers() {
     cluster.create_checkpoint().await;
 
     gas_budget = (gas_budget as i64 - 1000 - fx.gas_cost_summary().net_gas_usage()) as u64;
-    a_gas = fx.gas_object().0;
+    a_gas = fx.gas_object().unwrap().0;
 
     // A still controls the budget
     assert_eq!(

--- a/crates/sui-indexer-alt-e2e-tests/tests/consistent_store_list_owned_objects_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/consistent_store_list_owned_objects_tests.rs
@@ -199,13 +199,13 @@ async fn test_address_owner() {
     for (i, coin) in coins {
         let fx = transfer_object(&mut cluster, a, &akp, a_gas, coin, c);
         objects.insert((!i, coin.0), find::address_mutated(&fx).unwrap());
-        a_gas = fx.gas_object().0;
+        a_gas = fx.gas_object().unwrap().0;
     }
 
     for bag in bags.into_values() {
         let fx = transfer_object(&mut cluster, b, &bkp, b_gas, bag, c);
         objects.insert((0, bag.0), find::address_mutated(&fx).unwrap());
-        b_gas = fx.gas_object().0;
+        b_gas = fx.gas_object().unwrap().0;
     }
 
     cluster.create_checkpoint().await;
@@ -636,7 +636,7 @@ async fn test_coin_balance_change_cleanup() {
     );
 
     // Update gas reference
-    a_gas = fx.gas_object().0;
+    a_gas = fx.gas_object().unwrap().0;
     let new_coin = find::address_owned(&fx).expect("Failed to find new coin");
 
     cluster.create_checkpoint().await;

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transaction_effects/address_balance_gas_effects.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transaction_effects/address_balance_gas_effects.move
@@ -1,0 +1,66 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 108 --accounts A --addresses test=0x0 --enable-accumulators --simulator --enable-address-balance-gas-payments
+
+//# programmable --sender A --inputs 1000000000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::into_balance<sui::sui::SUI>(Result(0));
+//> 2: sui::balance::send_funds<sui::sui::SUI>(Result(1), Input(1));
+
+//# publish
+module test::mod {
+    public fun fails() {
+        abort 42
+    }
+
+    public fun succeeds() {
+        // do nothing
+    }
+}
+
+//# create-checkpoint
+
+//# programmable --sender A --address-balance-gas --inputs 1000
+//> 0: test::mod::fails()
+
+//# programmable --sender A --address-balance-gas
+//> 0: test::mod::succeeds()
+
+//# create-checkpoint
+
+//# run-graphql
+{
+  failed: transactionEffects(digest: "@{digest_4}") { ...E }
+  success: transactionEffects(digest: "@{digest_5}") { ...E }
+}
+
+fragment E on TransactionEffects {
+  status
+
+  transaction {
+    sender { address }
+  }
+
+  gasEffects {
+    gasObject {
+      address
+      version
+      digest
+    }
+    gasSummary {
+      computationCost
+      storageCost
+      storageRebate
+      nonRefundableStorageFee
+    }
+  }
+
+  balanceChanges {
+    nodes {
+      owner { address }
+      coinType { repr }
+      amount
+    }
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transaction_effects/address_balance_gas_effects.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transaction_effects/address_balance_gas_effects.snap
@@ -1,0 +1,109 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 8 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-9:
+//# programmable --sender A --inputs 1000000000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::into_balance<sui::sui::SUI>(Result(0));
+//> 2: sui::balance::send_funds<sui::sui::SUI>(Result(1), Input(1));
+mutated: object(0,0)
+accumulators_written: (object(1,0), A, sui::balance::Balance<sui::sui::SUI>, Merge, 1000000000)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 11-20:
+//# publish
+created: object(2,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 3663200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, line 22:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 4, lines 24-25:
+//# programmable --sender A --address-balance-gas --inputs 1000
+//> 0: test::mod::fails()
+Error: Transaction Effects Status: Move Runtime Abort. Location: test::mod::fails (function index 0) at offset 1, Abort Code: 42
+Debug of error: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("mod") }, function: 0, instruction: 1, function_name: Some("fails") }, 42) at command Some(0)
+
+task 5, lines 27-28:
+//# programmable --sender A --address-balance-gas
+//> 0: test::mod::succeeds()
+accumulators_written: (object(1,0), A, sui::balance::Balance<sui::sui::SUI>, Split, 1000000)
+gas summary: computation_cost: 1000000, storage_cost: 0,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 6, line 30:
+//# create-checkpoint
+Checkpoint created: 2
+
+task 7, lines 32-66:
+//# run-graphql
+Response: {
+  "data": {
+    "failed": {
+      "status": "FAILURE",
+      "transaction": {
+        "sender": {
+          "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+        }
+      },
+      "gasEffects": {
+        "gasObject": null,
+        "gasSummary": {
+          "computationCost": 1000000,
+          "storageCost": 0,
+          "storageRebate": 0,
+          "nonRefundableStorageFee": 0
+        }
+      },
+      "balanceChanges": {
+        "nodes": [
+          {
+            "owner": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "coinType": {
+              "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI"
+            },
+            "amount": "-1000000"
+          }
+        ]
+      }
+    },
+    "success": {
+      "status": "SUCCESS",
+      "transaction": {
+        "sender": {
+          "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+        }
+      },
+      "gasEffects": {
+        "gasObject": null,
+        "gasSummary": {
+          "computationCost": 1000000,
+          "storageCost": 0,
+          "storageRebate": 0,
+          "nonRefundableStorageFee": 0
+        }
+      },
+      "balanceChanges": {
+        "nodes": [
+          {
+            "owner": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "coinType": {
+              "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI"
+            },
+            "amount": "-1000000"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transaction_effects/gas_effects.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transaction_effects/gas_effects.snap
@@ -83,11 +83,7 @@ Response: {
   "data": {
     "functionCallTransaction": {
       "gasEffects": {
-        "gasObject": {
-          "address": "0x0000000000000000000000000000000000000000000000000000000000000000",
-          "version": 0,
-          "digest": "11111111111111111111111111111111"
-        },
+        "gasObject": null,
         "gasSummary": {
           "computationCost": 0,
           "storageCost": 0,

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_coin_registry_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_coin_registry_tests.rs
@@ -108,7 +108,7 @@ async fn test_fixed_supply() {
     let (a, kp, fx) = coin_registry::publish(&mut cluster, "fixed_supply").await;
     let package = find::immutable(&fx).unwrap().0;
     let currency = find::address_owned_by(&fx, SUI_COIN_REGISTRY_ADDRESS.into()).unwrap();
-    let gas = fx.gas_object().0;
+    let gas = fx.gas_object().unwrap().0;
 
     coin_registry::finalize(&mut cluster, a, &kp, package, "fixed", currency, gas).await;
     cluster.create_checkpoint().await;
@@ -144,7 +144,7 @@ async fn test_dynamic() {
     let mut cluster = FullCluster::new().await.unwrap();
     let (sender, kp, fx) = coin_registry::publish(&mut cluster, "dynamic").await;
     let package = find::immutable(&fx).unwrap().0;
-    let gas = fx.gas_object().0;
+    let gas = fx.gas_object().unwrap().0;
 
     // Create a dynamic currency
     let coin_type = StructTag {
@@ -190,14 +190,14 @@ async fn test_burn_only() {
     let package = find::immutable(&fx).unwrap().0;
     let currency = find::address_owned_by(&fx, SUI_COIN_REGISTRY_ADDRESS.into()).unwrap();
     let coin = find::address_owned_by(&fx, sender).unwrap();
-    let gas = fx.gas_object().0;
+    let gas = fx.gas_object().unwrap().0;
 
     let fx =
         coin_registry::finalize(&mut cluster, sender, &kp, package, "burn", currency, gas).await;
 
     cluster.create_checkpoint().await;
     let currency = find::shared(&fx).unwrap();
-    let gas = fx.gas_object().0;
+    let gas = fx.gas_object().unwrap().0;
 
     let metadata = query_metadata(&cluster, &format!("{package}::burn::BURN")).await;
     assert_debug_snapshot!(metadata, @r###"
@@ -255,13 +255,13 @@ async fn test_unknown() {
     let currency = find::address_owned_by(&fx, SUI_COIN_REGISTRY_ADDRESS.into()).unwrap();
     let coin = find::address_owned_by(&fx, sender).unwrap();
     let treasury_cap = find::shared(&fx).unwrap();
-    let gas = fx.gas_object().0;
+    let gas = fx.gas_object().unwrap().0;
 
     let fx =
         coin_registry::finalize(&mut cluster, sender, &kp, package, "unknown", currency, gas).await;
 
     cluster.create_checkpoint().await;
-    let gas = fx.gas_object().0;
+    let gas = fx.gas_object().unwrap().0;
 
     let metadata = query_metadata(&cluster, &format!("{package}::unknown::UNKNOWN")).await;
     assert_debug_snapshot!(metadata, @r###"
@@ -300,7 +300,7 @@ async fn test_unknown() {
     .await;
 
     cluster.create_checkpoint().await;
-    let gas = fx.gas_object().0;
+    let gas = fx.gas_object().unwrap().0;
     let coin = find::address_mutated(&fx).unwrap();
 
     // `supply` should reflect the burn operation.
@@ -325,7 +325,7 @@ async fn test_unknown() {
     .await;
 
     cluster.create_checkpoint().await;
-    let gas = fx.gas_object().0;
+    let gas = fx.gas_object().unwrap().0;
 
     // `supply` should be `None` while the treasury cap is hidden.
     assert_eq!(
@@ -351,7 +351,7 @@ async fn test_unknown() {
     .await;
 
     cluster.create_checkpoint().await;
-    let gas = fx.gas_object().0;
+    let gas = fx.gas_object().unwrap().0;
 
     // `supply` has been modified but it is still `None` while the treasury cap is hidden.
     assert_eq!(
@@ -393,7 +393,7 @@ async fn test_legacy() {
 
     cluster.create_checkpoint().await;
     let outputs = query_owned_outputs(&cluster, sender).await;
-    let gas = fx.gas_object().0;
+    let gas = fx.gas_object().unwrap().0;
 
     let metadata = query_metadata(&cluster, &outputs.coin_type.to_canonical_string(true)).await;
     assert_debug_snapshot!(metadata, @r###"
@@ -435,7 +435,7 @@ async fn test_regulated() {
     let (a, kp, fx) = coin_registry::publish(&mut cluster, "regulated").await;
     let package = find::immutable(&fx).unwrap().0;
     let currency = find::address_owned_by(&fx, SUI_COIN_REGISTRY_ADDRESS.into()).unwrap();
-    let gas = fx.gas_object().0;
+    let gas = fx.gas_object().unwrap().0;
 
     coin_registry::finalize(&mut cluster, a, &kp, package, "regulated", currency, gas).await;
     cluster.create_checkpoint().await;
@@ -473,7 +473,7 @@ async fn test_legacy_regulated_migrate_deny_cap() {
 
     cluster.create_checkpoint().await;
     let outputs = query_owned_outputs(&cluster, sender).await;
-    let gas = fx.gas_object().0;
+    let gas = fx.gas_object().unwrap().0;
 
     let metadata = query_metadata(&cluster, &outputs.coin_type.to_canonical_string(true)).await;
     assert_debug_snapshot!(metadata, @r###"
@@ -502,7 +502,7 @@ async fn test_legacy_regulated_migrate_deny_cap() {
     cluster.create_checkpoint().await;
     let outputs = query_owned_outputs(&cluster, sender).await;
     let currency = find::shared(&fx).unwrap(); // The migrated Currency<T> object
-    let gas = fx.gas_object().0;
+    let gas = fx.gas_object().unwrap().0;
 
     // Query the coin metadata again after migration - should produce the same results
     let migrated = query_metadata(&cluster, &outputs.coin_type.to_canonical_string(true)).await;
@@ -539,7 +539,7 @@ async fn test_legacy_regulated_migrate_regulated_metadata() {
                 .then_some(oref)
         })
         .unwrap();
-    let gas = fx.gas_object().0;
+    let gas = fx.gas_object().unwrap().0;
 
     let metadata = query_metadata(&cluster, &outputs.coin_type.to_canonical_string(true)).await;
     assert_debug_snapshot!(metadata, @r###"
@@ -568,7 +568,7 @@ async fn test_legacy_regulated_migrate_regulated_metadata() {
     cluster.create_checkpoint().await;
     let outputs = query_owned_outputs(&cluster, sender).await;
     let currency = find::shared(&fx).unwrap(); // The migrated Currency<T> object
-    let gas = fx.gas_object().0;
+    let gas = fx.gas_object().unwrap().0;
 
     // Query the coin metadata again after migration - should produce the same results
     let migrated = query_metadata(&cluster, &outputs.coin_type.to_canonical_string(true)).await;

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_name_service_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_name_service_tests.rs
@@ -476,7 +476,7 @@ impl SuiNSCluster {
 
         let data = TransactionData::new_programmable(
             sender,
-            vec![fx.gas_object().0],
+            vec![fx.gas_object().unwrap().0],
             builder.finish(),
             DEFAULT_GAS_BUDGET,
             sim.reference_gas_price(),
@@ -507,7 +507,7 @@ impl SuiNSCluster {
 
         let data = TransactionData::new_programmable(
             sender,
-            vec![fx.gas_object().0],
+            vec![fx.gas_object().unwrap().0],
             builder.finish(),
             DEFAULT_GAS_BUDGET,
             sim.reference_gas_price(),

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc_coin_registry_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc_coin_registry_tests.rs
@@ -54,7 +54,7 @@ async fn test_fixed_supply() {
     let (a, kp, fx) = coin_registry::publish(&mut cluster, "fixed_supply").await;
     let package = find::immutable(&fx).unwrap().0;
     let currency = find::address_owned_by(&fx, SUI_COIN_REGISTRY_ADDRESS.into()).unwrap();
-    let gas = fx.gas_object().0;
+    let gas = fx.gas_object().unwrap().0;
 
     coin_registry::finalize(&mut cluster, a, &kp, package, "fixed", currency, gas).await;
     cluster.create_checkpoint().await;
@@ -78,7 +78,7 @@ async fn test_dynamic() {
     let mut cluster = FullCluster::new().await.unwrap();
     let (sender, kp, fx) = coin_registry::publish(&mut cluster, "dynamic").await;
     let package = find::immutable(&fx).unwrap().0;
-    let gas = fx.gas_object().0;
+    let gas = fx.gas_object().unwrap().0;
 
     // Create a dynamic currency
     let coin_type = StructTag {
@@ -111,7 +111,7 @@ async fn test_burn_only() {
     let (sender, kp, fx) = coin_registry::publish(&mut cluster, "burn_only").await;
     let package = find::immutable(&fx).unwrap().0;
     let currency = find::address_owned_by(&fx, SUI_COIN_REGISTRY_ADDRESS.into()).unwrap();
-    let gas = fx.gas_object().0;
+    let gas = fx.gas_object().unwrap().0;
 
     coin_registry::finalize(&mut cluster, sender, &kp, package, "burn", currency, gas).await;
     cluster.create_checkpoint().await;
@@ -136,7 +136,7 @@ async fn test_unknown() {
     let (sender, kp, fx) = coin_registry::publish(&mut cluster, "unknown").await;
     let package = find::immutable(&fx).unwrap().0;
     let currency = find::address_owned_by(&fx, SUI_COIN_REGISTRY_ADDRESS.into()).unwrap();
-    let gas = fx.gas_object().0;
+    let gas = fx.gas_object().unwrap().0;
 
     coin_registry::finalize(&mut cluster, sender, &kp, package, "unknown", currency, gas).await;
     cluster.create_checkpoint().await;
@@ -162,7 +162,7 @@ async fn test_legacy() {
 
     cluster.create_checkpoint().await;
     let outputs = query_owned_outputs(&cluster, sender).await;
-    let gas = fx.gas_object().0;
+    let gas = fx.gas_object().unwrap().0;
 
     let metadata = query_metadata(&cluster, &outputs.coin_type.to_canonical_string(true)).await;
     assert_debug_snapshot!(metadata, @r###"
@@ -194,7 +194,7 @@ async fn test_regulated() {
     let (a, kp, fx) = coin_registry::publish(&mut cluster, "regulated").await;
     let package = find::immutable(&fx).unwrap().0;
     let currency = find::address_owned_by(&fx, SUI_COIN_REGISTRY_ADDRESS.into()).unwrap();
-    let gas = fx.gas_object().0;
+    let gas = fx.gas_object().unwrap().0;
 
     coin_registry::finalize(&mut cluster, a, &kp, package, "regulated", currency, gas).await;
     cluster.create_checkpoint().await;

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc_name_service_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc_name_service_tests.rs
@@ -358,7 +358,7 @@ impl SuiNSCluster {
 
         let data = TransactionData::new_programmable(
             sender,
-            vec![fx.gas_object().0],
+            vec![fx.gas_object().unwrap().0],
             builder.finish(),
             DEFAULT_GAS_BUDGET,
             sim.reference_gas_price(),
@@ -389,7 +389,7 @@ impl SuiNSCluster {
 
         let data = TransactionData::new_programmable(
             sender,
-            vec![fx.gas_object().0],
+            vec![fx.gas_object().unwrap().0],
             builder.finish(),
             DEFAULT_GAS_BUDGET,
             sim.reference_gas_price(),

--- a/crates/sui-indexer-alt-graphql/src/api/types/gas_effects.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/gas_effects.rs
@@ -20,8 +20,9 @@ pub(crate) struct GasEffects {
 
 impl GasEffects {
     pub(crate) fn from_effects(scope: Scope, effects: &NativeTransactionEffects) -> Self {
-        let ((id, version, digest), _owner) = effects.gas_object();
-        let gas_object = Some(Object::with_ref(&scope, id.into(), version, digest));
+        let gas_object = effects.gas_object().map(|((id, version, digest), _owner)| {
+            Object::with_ref(&scope, id.into(), version, digest)
+        });
         let gas_summary = Some(effects.gas_cost_summary().clone().into());
 
         Self {

--- a/crates/sui-indexer-alt/src/handlers/tx_balance_changes.rs
+++ b/crates/sui-indexer-alt/src/handlers/tx_balance_changes.rs
@@ -15,9 +15,7 @@ use sui_indexer_alt_framework::pipeline::Processor;
 use sui_indexer_alt_framework::postgres::Connection;
 use sui_indexer_alt_framework::postgres::handler::Handler;
 use sui_indexer_alt_framework::types::coin::Coin;
-use sui_indexer_alt_framework::types::effects::TransactionEffectsAPI;
 use sui_indexer_alt_framework::types::full_checkpoint_content::Checkpoint;
-use sui_indexer_alt_framework::types::gas_coin::GAS;
 use sui_indexer_alt_schema::schema::tx_balance_changes;
 use sui_indexer_alt_schema::transactions::BalanceChange;
 use sui_indexer_alt_schema::transactions::StoredTxBalanceChange;
@@ -99,18 +97,6 @@ fn balance_changes(
     transaction: &ExecutedTransaction,
     checkpoint: &Checkpoint,
 ) -> Result<Vec<BalanceChange>> {
-    // Shortcut if the transaction failed -- we know that only gas was charged.
-    if transaction.effects.status().is_err() {
-        let net_gas_usage = transaction.effects.gas_cost_summary().net_gas_usage();
-        return Ok(Vec::from_iter((net_gas_usage > 0).then(|| {
-            BalanceChange::V1 {
-                owner: transaction.effects.gas_object().1,
-                coin_type: GAS::type_tag().to_canonical_string(true),
-                amount: -(net_gas_usage as i128),
-            }
-        })));
-    }
-
     let mut changes = BTreeMap::new();
 
     // First gather address balance changes from accumulator events.

--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -1072,10 +1072,20 @@ impl TryFrom<TransactionEffects> for SuiTransactionBlockEffects {
                 deleted: to_sui_object_ref(effect.deleted().to_vec()),
                 unwrapped_then_deleted: to_sui_object_ref(effect.unwrapped_then_deleted().to_vec()),
                 wrapped: to_sui_object_ref(effect.wrapped().to_vec()),
-                gas_object: OwnedObjectRef {
-                    owner: effect.gas_object().1,
-                    reference: effect.gas_object().0.into(),
-                },
+                gas_object: effect.gas_object().map_or_else(
+                    || OwnedObjectRef {
+                        owner: Owner::AddressOwner(SuiAddress::default()),
+                        reference: SuiObjectRef {
+                            object_id: ObjectID::ZERO,
+                            version: SequenceNumber::default(),
+                            digest: ObjectDigest::MIN,
+                        },
+                    },
+                    |(obj_ref, owner)| OwnedObjectRef {
+                        owner,
+                        reference: obj_ref.into(),
+                    },
+                ),
                 events_digest: effect.events_digest().copied(),
                 dependencies: effect.dependencies().to_vec(),
                 abort_error: effect

--- a/crates/sui-oracle/src/lib.rs
+++ b/crates/sui-oracle/src/lib.rs
@@ -494,7 +494,10 @@ impl OnChainDataUploader {
         let effects = response.effects;
 
         // It's critical to update the gas object reference for next transaction
-        self.gas_obj_ref = effects.gas_object().0;
+        self.gas_obj_ref = effects
+            .gas_object()
+            .expect("oracle transaction always has a gas object")
+            .0;
 
         let success = effects.status().is_ok();
 

--- a/crates/sui-single-node-benchmark/src/benchmark_context.rs
+++ b/crates/sui-single-node-benchmark/src/benchmark_context.rs
@@ -130,7 +130,7 @@ impl BenchmarkContext {
                 .next()
                 .unwrap();
             root_objects.insert(owner, root_object);
-            let gas_object = effects.gas_object().0;
+            let gas_object = effects.gas_object().unwrap().0;
             new_gas_objects.insert(gas_object.0, gas_object);
         }
         self.refresh_gas_objects(new_gas_objects);
@@ -189,7 +189,7 @@ impl BenchmarkContext {
                 .next()
                 .unwrap();
             shared_objects.push(shared_object);
-            let gas_object = effects.gas_object().0;
+            let gas_object = effects.gas_object().unwrap().0;
             new_gas_objects.insert(gas_object.0, gas_object);
             // Make sure to commit them to DB. This is needed by both the execution-only mode
             // and the checkpoint-executor mode. For execution-only mode, we iterate through all

--- a/crates/sui-single-node-benchmark/src/single_node.rs
+++ b/crates/sui-single-node-benchmark/src/single_node.rs
@@ -105,7 +105,7 @@ impl SingleValidator {
             .filter_map(|(oref, owner, _)| owner.is_immutable().then_some(oref))
             .next()
             .unwrap();
-        let updated_gas = effects.gas_object().0;
+        let updated_gas = effects.gas_object().unwrap().0;
         (package, updated_gas)
     }
 

--- a/crates/sui-synthetic-ingestion/src/synthetic_ingestion.rs
+++ b/crates/sui-synthetic-ingestion/src/synthetic_ingestion.rs
@@ -76,7 +76,7 @@ pub async fn generate_ingestion(config: Config) {
                 .build();
             let tx = to_sender_signed_transaction(tx_data, &keypair);
             let (effects, _) = sim.execute_transaction(tx).unwrap();
-            gas_object = effects.gas_object().0;
+            gas_object = effects.gas_object().unwrap().0;
             tx_count += 1;
         }
         let checkpoint = sim.create_checkpoint();

--- a/crates/sui-types/src/effects/effects_v1.rs
+++ b/crates/sui-types/src/effects/effects_v1.rs
@@ -310,8 +310,8 @@ impl TransactionEffectsAPI for TransactionEffectsV1 {
         vec![]
     }
 
-    fn gas_object(&self) -> (ObjectRef, Owner) {
-        self.gas_object.clone()
+    fn gas_object(&self) -> Option<(ObjectRef, Owner)> {
+        Some(self.gas_object.clone())
     }
     fn events_digest(&self) -> Option<&TransactionEventsDigest> {
         self.events_digest.as_ref()

--- a/crates/sui-types/src/effects/effects_v2.rs
+++ b/crates/sui-types/src/effects/effects_v2.rs
@@ -437,9 +437,9 @@ impl TransactionEffectsAPI for TransactionEffectsV2 {
             .collect()
     }
 
-    fn gas_object(&self) -> (ObjectRef, Owner) {
-        if let Some(gas_object_index) = self.gas_object_index {
-            let entry = &self.changed_objects[gas_object_index as usize];
+    fn gas_object(&self) -> Option<(ObjectRef, Owner)> {
+        self.gas_object_index.map(|index| {
+            let entry = &self.changed_objects[index as usize];
             match &entry.1.output_state {
                 ObjectOut::ObjectWrite((digest, owner)) => {
                     ((entry.0, self.lamport_version, *digest), owner.clone())
@@ -458,12 +458,7 @@ impl TransactionEffectsAPI for TransactionEffectsV2 {
                 }
                 _ => panic!("Gas object must be an ObjectWrite or Deleted in changed_objects"),
             }
-        } else {
-            (
-                (ObjectID::ZERO, SequenceNumber::default(), ObjectDigest::MIN),
-                Owner::AddressOwner(SuiAddress::default()),
-            )
-        }
+        })
     }
 
     fn events_digest(&self) -> Option<&TransactionEventsDigest> {
@@ -754,9 +749,10 @@ impl TransactionEffectsV2 {
                 }
             }
         }
-        // Make sure that gas object exists in changed_objects.
-        let (_, owner) = self.gas_object();
-        assert!(matches!(owner, Owner::AddressOwner(_)));
+        // Make sure that gas object, if present, has an address owner.
+        if let Some((_, owner)) = self.gas_object() {
+            assert!(matches!(owner, Owner::AddressOwner(_)));
+        }
 
         for (id, _) in &self.unchanged_consensus_objects {
             assert!(

--- a/crates/sui-types/src/effects/mod.rs
+++ b/crates/sui-types/src/effects/mod.rs
@@ -253,10 +253,10 @@ impl TransactionEffects {
 
     /// Return an iterator of mutated objects, but excluding the gas object.
     pub fn mutated_excluding_gas(&self) -> Vec<(ObjectRef, Owner)> {
-        let gas_id = self.gas_object().0.0;
+        let gas_id = self.gas_object().map(|(oref, _)| oref.0);
         self.mutated()
             .into_iter()
-            .filter(|o| o.0.0 != gas_id)
+            .filter(|o| Some(o.0.0) != gas_id)
             .collect()
     }
 
@@ -358,10 +358,7 @@ pub trait TransactionEffectsAPI {
     /// Returns the gas object ref and owner. When the gas object was deleted (e.g. send_funds
     /// consuming the gas coin), the object ID is preserved, the digest is set to
     /// `ObjectDigest::OBJECT_DIGEST_DELETED` and the owner is set to a dummy address.
-    // TODO: We should consider having this function to return Option.
-    // When the gas object is not available (i.e. system transaction), we currently return
-    // dummy object ref and owner. This is not ideal.
-    fn gas_object(&self) -> (ObjectRef, Owner);
+    fn gas_object(&self) -> Option<(ObjectRef, Owner)>;
 
     fn events_digest(&self) -> Option<&TransactionEventsDigest>;
     fn dependencies(&self) -> &[TransactionDigest];

--- a/crates/sui-types/src/rpc_proto_conversions.rs
+++ b/crates/sui-types/src/rpc_proto_conversions.rs
@@ -3098,8 +3098,10 @@ impl Merge<&crate::effects::TransactionEffectsV1> for TransactionEffects {
                 }
             }
 
-            if mask.contains(Self::GAS_OBJECT_FIELD.name) {
-                let gas_object_id = value.gas_object().0.0.to_canonical_string(true);
+            if mask.contains(Self::GAS_OBJECT_FIELD.name)
+                && let Some(((gas_id, _, _), _)) = value.gas_object()
+            {
+                let gas_object_id = gas_id.to_canonical_string(true);
                 self.gas_object = changed_objects
                     .iter()
                     .find(|object| object.object_id() == gas_object_id)

--- a/crates/sui/tests/cli_tests.rs
+++ b/crates/sui/tests/cli_tests.rs
@@ -609,7 +609,7 @@ async fn test_ptb_publish_and_complex_arg_resolution() -> Result<(), anyhow::Err
 
     let effects = response.effects;
     assert!(effects.status().is_ok());
-    assert_eq!(effects.gas_object().0.0, gas_obj_id);
+    assert_eq!(effects.gas_object().unwrap().0.0, gas_obj_id);
     let package = effects
         .created()
         .into_iter()
@@ -872,7 +872,7 @@ async fn test_move_call_args_linter_command() -> Result<(), anyhow::Error> {
             "Command failed: {:?}",
             response
         );
-        assert_eq!(response.effects.gas_object().0.0, gas_obj_id);
+        assert_eq!(response.effects.gas_object().unwrap().0.0, gas_obj_id);
         response
             .effects
             .created()
@@ -1139,7 +1139,7 @@ async fn test_package_publish_command() -> Result<(), anyhow::Error> {
     resp.print(true);
 
     let obj_ids = if let SuiClientCommandResult::TransactionBlock(response) = resp {
-        assert_eq!(response.effects.gas_object().0.0, gas_obj_id);
+        assert_eq!(response.effects.gas_object().unwrap().0.0, gas_obj_id);
         response
             .effects
             .created()
@@ -1203,7 +1203,7 @@ async fn test_package_management_on_publish_command() -> Result<(), anyhow::Erro
     // Get Package ID and version
     let (expect_original_id, expect_version, _) =
         if let SuiClientCommandResult::TransactionBlock(response) = resp {
-            assert_eq!(response.effects.gas_object().0.0, gas_obj_id);
+            assert_eq!(response.effects.gas_object().unwrap().0.0, gas_obj_id);
             response
                 .get_new_package_obj()
                 .ok_or_else(|| anyhow::anyhow!("No package object response"))?
@@ -1276,7 +1276,7 @@ async fn test_delete_shared_object() -> Result<(), anyhow::Error> {
     .await?;
 
     let owned_obj_ids = if let SuiClientCommandResult::TransactionBlock(response) = resp {
-        assert_eq!(response.effects.gas_object().0.0, gas_obj_id);
+        assert_eq!(response.effects.gas_object().unwrap().0.0, gas_obj_id);
         let x = response.effects;
         x.created()
     } else {
@@ -1385,7 +1385,7 @@ async fn test_receive_argument() -> Result<(), anyhow::Error> {
     .await?;
 
     let owned_obj_ids = if let SuiClientCommandResult::TransactionBlock(response) = resp {
-        assert_eq!(response.effects.gas_object().0.0, gas_obj_id);
+        assert_eq!(response.effects.gas_object().unwrap().0.0, gas_obj_id);
         let x = response.effects;
         x.created()
     } else {
@@ -1511,7 +1511,7 @@ async fn test_receive_argument_by_immut_ref() -> Result<(), anyhow::Error> {
     .await?;
 
     let owned_obj_ids = if let SuiClientCommandResult::TransactionBlock(response) = resp {
-        assert_eq!(response.effects.gas_object().0.0, gas_obj_id);
+        assert_eq!(response.effects.gas_object().unwrap().0.0, gas_obj_id);
         let x = response.effects;
         x.created()
     } else {
@@ -1637,7 +1637,7 @@ async fn test_receive_argument_by_mut_ref() -> Result<(), anyhow::Error> {
     .await?;
 
     let owned_obj_ids = if let SuiClientCommandResult::TransactionBlock(response) = resp {
-        assert_eq!(response.effects.gas_object().0.0, gas_obj_id);
+        assert_eq!(response.effects.gas_object().unwrap().0.0, gas_obj_id);
         let x = response.effects;
         x.created()
     } else {
@@ -1768,7 +1768,7 @@ async fn test_package_publish_command_with_unpublished_dependency_succeeds()
     resp.print(true);
 
     let obj_ids = if let SuiClientCommandResult::TransactionBlock(response) = resp {
-        assert_eq!(response.effects.gas_object().0.0, gas_obj_id);
+        assert_eq!(response.effects.gas_object().unwrap().0.0, gas_obj_id);
         response
             .effects
             .created()
@@ -2050,7 +2050,7 @@ async fn test_package_upgrade_command() -> Result<(), anyhow::Error> {
     let effects = response.effects;
 
     assert!(effects.status().is_ok());
-    assert_eq!(effects.gas_object().0.0, gas_obj_id);
+    assert_eq!(effects.gas_object().unwrap().0.0, gas_obj_id);
 
     // Now run the upgrade
     let resp = SuiClientCommands::Upgrade(UpgradeArgs {
@@ -2081,7 +2081,7 @@ async fn test_package_upgrade_command() -> Result<(), anyhow::Error> {
     let effects = response.effects;
 
     assert!(effects.status().is_ok());
-    assert_eq!(effects.gas_object().0.0, gas_obj_id);
+    assert_eq!(effects.gas_object().unwrap().0.0, gas_obj_id);
 
     let obj_ids = effects
         .created()
@@ -2144,7 +2144,7 @@ async fn test_package_management_on_upgrade_command() -> Result<(), anyhow::Erro
     let effects = &publish_response.effects;
 
     assert!(effects.status().is_ok());
-    assert_eq!(effects.gas_object().0.0, gas_obj_id);
+    assert_eq!(effects.gas_object().unwrap().0.0, gas_obj_id);
 
     // Now run the upgrade
     let upgrade_response = SuiClientCommands::Upgrade(UpgradeArgs {
@@ -2175,7 +2175,7 @@ async fn test_package_management_on_upgrade_command() -> Result<(), anyhow::Erro
     // Get Upgraded Package ID and version
     let (expect_upgrade_latest_id, expect_upgrade_version, _) =
         if let SuiClientCommandResult::TransactionBlock(response) = upgrade_response {
-            assert_eq!(response.effects.gas_object().0.0, gas_obj_id);
+            assert_eq!(response.effects.gas_object().unwrap().0.0, gas_obj_id);
             response
                 .get_new_package_obj()
                 .ok_or_else(|| anyhow::anyhow!("No package object response"))?
@@ -2243,7 +2243,7 @@ async fn test_native_transfer() -> Result<(), anyhow::Error> {
             "Command failed: {:?}",
             response
         );
-        assert_eq!(response.effects.gas_object().0.0, gas_obj_id);
+        assert_eq!(response.effects.gas_object().unwrap().0.0, gas_obj_id);
         (
             response.effects.mutated().first().unwrap().0.0,
             response.effects.mutated().get(1).unwrap().0.0,
@@ -2587,7 +2587,7 @@ async fn test_merge_coin() -> Result<(), anyhow::Error> {
     .await?;
     let g = if let SuiClientCommandResult::TransactionBlock(r) = resp {
         assert!(r.effects.status().is_ok(), "Command failed: {:?}", r);
-        assert_eq!(r.effects.gas_object().0.0, gas);
+        assert_eq!(r.effects.gas_object().unwrap().0.0, gas);
         let object_id = r
             .effects
             .mutated_excluding_gas()
@@ -2684,7 +2684,7 @@ async fn test_split_coin() -> Result<(), anyhow::Error> {
 
     let (updated_coin, new_coins) = if let SuiClientCommandResult::TransactionBlock(r) = resp {
         assert!(r.effects.status().is_ok(), "Command failed: {:?}", r);
-        assert_eq!(r.effects.gas_object().0.0, gas);
+        assert_eq!(r.effects.gas_object().unwrap().0.0, gas);
         let updated_object_id = r
             .effects
             .mutated_excluding_gas()
@@ -3143,7 +3143,7 @@ fn assert_dry_run(dry_run: SuiClientCommandResult, object_id: ObjectID, command:
             "{command} dry run test effects is not success"
         );
         assert_eq!(
-            response.transaction.effects.gas_object().0.0,
+            response.transaction.effects.gas_object().unwrap().0.0,
             object_id,
             "{command} dry run test failed, gas object used is not the expected one"
         );
@@ -3224,7 +3224,10 @@ async fn test_dry_run() -> Result<(), anyhow::Error> {
 
     if let SuiClientCommandResult::DryRun(response) = pay_dry_run {
         assert!(response.transaction.effects.status().is_ok());
-        assert_ne!(response.transaction.effects.gas_object().0.0, object_id);
+        assert_ne!(
+            response.transaction.effects.gas_object().unwrap().0.0,
+            object_id
+        );
     } else {
         panic!("Pay dry run failed");
     }
@@ -3380,7 +3383,7 @@ async fn test_pay() -> Result<(), anyhow::Error> {
         // check tx status
         assert!(response.effects.status().is_ok());
         // check gas coin used
-        assert_eq!(response.effects.gas_object().0.0, object_id3);
+        assert_eq!(response.effects.gas_object().unwrap().0.0, object_id3);
         let objs_refs = client.get_owned_objects(address2, None, None, None).await?;
         assert!(objs_refs.next_page_token.is_none());
         assert_eq!(objs_refs.items.len(), 1);
@@ -3432,7 +3435,7 @@ async fn test_pay_sui() -> Result<(), anyhow::Error> {
     if let SuiClientCommandResult::TransactionBlock(response) = pay_sui {
         assert!(response.effects.status().is_ok());
         // check gas coin used
-        assert_eq!(response.effects.gas_object().0.0, object_id1);
+        assert_eq!(response.effects.gas_object().unwrap().0.0, object_id1);
         let objs_refs = client.get_owned_objects(address2, None, None, None).await?;
         assert!(objs_refs.next_page_token.is_none());
         assert_eq!(objs_refs.items.len(), 1);
@@ -3481,7 +3484,7 @@ async fn test_pay_all_sui() -> Result<(), anyhow::Error> {
         let objs_refs = client.get_owned_objects(address2, None, None, None).await?;
         assert!(objs_refs.next_page_token.is_none());
         assert_eq!(objs_refs.items.len(), 1);
-        assert_eq!(response.effects.gas_object().0.0, object_id1);
+        assert_eq!(response.effects.gas_object().unwrap().0.0, object_id1);
     } else {
         panic!("PayAllSui test failed");
     }
@@ -3531,7 +3534,7 @@ async fn test_transfer() -> Result<(), anyhow::Error> {
     // we check if object1 is owned by address 2 and if the gas object used is object_id2
     if let SuiClientCommandResult::TransactionBlock(response) = transfer {
         assert!(response.effects.status().is_ok());
-        assert_eq!(response.effects.gas_object().0.0, object_id2);
+        assert_eq!(response.effects.gas_object().unwrap().0.0, object_id2);
         let objs_refs = client.get_owned_objects(address2, None, None, None).await?;
         assert!(objs_refs.next_page_token.is_none());
         assert_eq!(objs_refs.items.len(), 1);
@@ -3569,7 +3572,7 @@ async fn test_transfer_sui() -> Result<(), anyhow::Error> {
     // is correct
     if let SuiClientCommandResult::TransactionBlock(response) = transfer_sui {
         assert!(response.effects.status().is_ok());
-        assert_eq!(response.effects.gas_object().0.0, object_id1);
+        assert_eq!(response.effects.gas_object().unwrap().0.0, object_id1);
         let objs_refs = client.get_owned_objects(address2, None, None, None).await?;
         assert!(objs_refs.next_page_token.is_none());
         assert_eq!(objs_refs.items.len(), 1);
@@ -3593,7 +3596,7 @@ async fn test_transfer_sui() -> Result<(), anyhow::Error> {
     .await?;
     if let SuiClientCommandResult::TransactionBlock(response) = transfer_sui {
         assert!(response.effects.status().is_ok());
-        assert_eq!(response.effects.gas_object().0.0, object_id1);
+        assert_eq!(response.effects.gas_object().unwrap().0.0, object_id1);
         let objs_refs = client.get_owned_objects(address2, None, None, None).await?;
         assert!(objs_refs.next_page_token.is_none());
         assert_eq!(
@@ -3657,7 +3660,7 @@ async fn test_transfer_gas_smash() -> Result<(), anyhow::Error> {
     };
 
     assert!(response.effects.status().is_ok());
-    assert_eq!(response.effects.gas_object().0.0, object_id0);
+    assert_eq!(response.effects.gas_object().unwrap().0.0, object_id0);
     let objs_refs = client.get_owned_objects(address2, None, None, None).await?;
     assert!(objs_refs.next_page_token.is_none());
     assert_eq!(objs_refs.items.len(), 1);
@@ -3765,7 +3768,7 @@ async fn test_transfer_serialized_data() -> Result<(), anyhow::Error> {
     let effects = &response.effects;
 
     assert!(effects.status().is_ok());
-    assert_eq!(effects.gas_object().0.0, o[1]);
+    assert_eq!(effects.gas_object().unwrap().0.0, o[1]);
 
     let a1_objs = client.get_owned_objects(a[1], None, None, None).await?;
     assert!(a1_objs.next_page_token.is_none());
@@ -3822,7 +3825,7 @@ async fn test_transfer_serialized_kind() -> Result<(), anyhow::Error> {
     let effects = &response.effects;
 
     assert!(effects.status().is_ok());
-    assert_eq!(effects.gas_object().0.0, o[1]);
+    assert_eq!(effects.gas_object().unwrap().0.0, o[1]);
 
     let a1_objs = client.get_owned_objects(a[1], None, None, None).await?;
     assert!(a1_objs.next_page_token.is_none());
@@ -3859,7 +3862,7 @@ async fn test_gas_estimation() -> Result<(), anyhow::Error> {
     .unwrap();
     if let SuiClientCommandResult::TransactionBlock(response) = transfer_sui_cmd {
         assert!(response.effects.status().is_ok());
-        let gas_used = response.effects.gas_object().0.0;
+        let gas_used = response.effects.gas_object().unwrap().0.0;
         assert_eq!(gas_used, object_id1);
         assert!(response.effects.gas_cost_summary().gas_used() <= gas_estimate.unwrap());
     } else {
@@ -3916,7 +3919,7 @@ async fn test_custom_sender() -> Result<(), anyhow::Error> {
     let effects = &response.effects;
 
     assert!(effects.status().is_ok());
-    assert_eq!(effects.gas_object().0.0, o[1]);
+    assert_eq!(effects.gas_object().unwrap().0.0, o[1]);
 
     let a1_objs = client.get_owned_objects(a[1], None, None, None).await?;
     assert!(a1_objs.next_page_token.is_none());
@@ -4023,7 +4026,7 @@ async fn test_clever_errors() -> Result<(), anyhow::Error> {
     let effects = response.effects;
 
     assert!(effects.status().is_ok());
-    assert_eq!(effects.gas_object().0.0, gas_obj_id);
+    assert_eq!(effects.gas_object().unwrap().0.0, gas_obj_id);
     let package = effects
         .created()
         .into_iter()
@@ -4577,7 +4580,7 @@ async fn test_party_transfer() -> Result<(), anyhow::Error> {
     };
 
     assert!(response.effects.status().is_ok());
-    assert_eq!(response.effects.gas_object().0.0, object_id2);
+    assert_eq!(response.effects.gas_object().unwrap().0.0, object_id2);
 
     let object = client.get_object(object_id1).await?;
 

--- a/crates/test-cluster/src/addr_balance_test_env.rs
+++ b/crates/test-cluster/src/addr_balance_test_env.rs
@@ -148,7 +148,7 @@ impl TestEnv {
             .await
             .unwrap();
         // update the gas object we used.
-        self.gas_objects.get_mut(&address).unwrap()[0] = effects.gas_object().0;
+        self.gas_objects.get_mut(&address).unwrap()[0] = effects.gas_object().unwrap().0;
         self.cluster.wait_for_tx_settlement(&[digest]).await;
     }
 


### PR DESCRIPTION
## Description 

switches effects' gas_object method to optional.
Analytics and JSON RPC still convert None results internally to a dummy response

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
