### PR TITLE
[move-compiler] Fix incorrect loc used in eq/neq borrow dereference check

### DIFF
--- a/external-crates/move/crates/move-compiler/src/cfgir/borrows/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/borrows/mod.rs
@@ -377,7 +377,7 @@ fn exp(context: &mut Context, parent_e: &Exp) -> Values {
                 assert!(errors.is_empty(), "ICE eq freezing failed");
             }
             if v2.is_ref() {
-                let (errors, _) = context.borrow_state.dereference(e1.exp.loc, v2);
+                let (errors, _) = context.borrow_state.dereference(e2.exp.loc, v2);
                 assert!(errors.is_empty(), "ICE eq freezing failed");
             }
             svalue()


### PR DESCRIPTION
## Summary

- Fix a bug in `cfgir/borrows/mod.rs` where the dereference check for `v2` in equality/inequality comparisons was using `e1.exp.loc` instead of `e2.exp.loc`.
- `v2` corresponds to `e2`, so its dereference location should reference `e2.exp.loc` for correct error reporting.

## Test plan

- Existing compiler tests continue to pass.
- This is a correctness fix for an internal assertion path — the wrong loc would only surface if the ICE assertion failed, but using the correct operand location is important for diagnostics.