### PR TITLE
[Block Streaming] Introduce the PeersPool & Refactor synchornizer

### DIFF
--- a/consensus/config/src/crypto.rs
+++ b/consensus/config/src/crypto.rs
@@ -22,7 +22,7 @@ use serde::{Deserialize, Serialize};
 use shared_crypto::intent::INTENT_PREFIX_LENGTH;
 
 /// Network key is used for TLS and as the network identity of the authority.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct NetworkPublicKey(ed25519::Ed25519PublicKey);
 pub struct NetworkPrivateKey(ed25519::Ed25519PrivateKey);
 pub struct NetworkKeyPair(ed25519::Ed25519KeyPair);

--- a/consensus/config/src/crypto.rs
+++ b/consensus/config/src/crypto.rs
@@ -22,7 +22,7 @@ use serde::{Deserialize, Serialize};
 use shared_crypto::intent::INTENT_PREFIX_LENGTH;
 
 /// Network key is used for TLS and as the network identity of the authority.
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct NetworkPublicKey(ed25519::Ed25519PublicKey);
 pub struct NetworkPrivateKey(ed25519::Ed25519PrivateKey);
 pub struct NetworkKeyPair(ed25519::Ed25519KeyPair);

--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -795,7 +795,7 @@ mod tests {
             ..Default::default()
         };
 
-        let (observer_commit_consumer, observer_commit_receiver) = CommitConsumerArgs::new(0, 0);
+        let (observer_commit_consumer, _observer_commit_receiver) = CommitConsumerArgs::new(0, 0);
         let observer = ConsensusAuthority::start(
             network_type,
             0,
@@ -811,8 +811,6 @@ mod tests {
             0,
         )
         .await;
-
-        commit_receivers.push(observer_commit_receiver);
 
         // Give Observer more time to connect and sync
         sleep(Duration::from_secs(5)).await;

--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -486,7 +486,7 @@ where
                 {
                     PeerId::Validator(index)
                 } else {
-                    PeerId::Observer(peer_record.public_key.clone())
+                    PeerId::Observer(Box::new(peer_record.public_key.clone()))
                 };
 
                 info!("Observer subscribing to peer: {:?}", peer_id);

--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -437,6 +437,7 @@ where
                     block_verifier,
                     commit_vote_monitor.clone(),
                     transaction_vote_tracker.clone(),
+                    synchronizer.clone(),
                 ));
                 network_manager
                     .start_observer_server(observer_service)
@@ -455,6 +456,7 @@ where
                 block_verifier,
                 commit_vote_monitor.clone(),
                 transaction_vote_tracker.clone(),
+                synchronizer.clone(),
             ));
 
             let observer_subscriber = ObserverSubscriber::new(

--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -34,7 +34,7 @@ use crate::{
     },
     observer_service::ObserverService,
     observer_subscriber::ObserverSubscriber,
-    peers_pool::{PeerServer, PeersPool},
+    peers_pool::PeersPool,
     round_prober::{RoundProber, RoundProberHandle},
     round_tracker::RoundTracker,
     storage::rocksdb_store::RocksDBStore,
@@ -451,27 +451,6 @@ where
 
             (SubscriberType::Validator(s), round_prober_handle)
         } else {
-            // Register all the observer peers in the peers pool
-            for peer in context.parameters.tonic.observer_peers.iter() {
-                // If the peer's public key is in the committe, then register it as a validator.
-                if let Some((index, _)) = context
-                    .committee
-                    .authorities()
-                    .find(|(_, authority)| authority.network_key == peer.public_key)
-                {
-                    peers_pool
-                        .register_validator(
-                            index,
-                            vec![PeerServer::Validator, PeerServer::Observer],
-                        )
-                        .expect("Failed to register validator");
-                } else {
-                    // Otherwise this is another Observer peer and we register it as such. This peer we know that
-                    // it will support the Observer server.
-                    peers_pool.register_observer(peer.public_key.clone());
-                }
-            }
-
             // Observer node: subscribe to specified peer(s) using ObserverSubscriber
             let observer_client = network_manager.observer_client();
             let observer_service = Arc::new(ObserverService::new(
@@ -816,7 +795,7 @@ mod tests {
             ..Default::default()
         };
 
-        let (observer_commit_consumer, _observer_commit_receiver) = CommitConsumerArgs::new(0, 0);
+        let (observer_commit_consumer, observer_commit_receiver) = CommitConsumerArgs::new(0, 0);
         let observer = ConsensusAuthority::start(
             network_type,
             0,
@@ -832,6 +811,8 @@ mod tests {
             0,
         )
         .await;
+
+        commit_receivers.push(observer_commit_receiver);
 
         // Give Observer more time to connect and sync
         sleep(Duration::from_secs(5)).await;
@@ -852,7 +833,7 @@ mod tests {
             let mut expected_transactions = submitted_transactions.clone();
             loop {
                 let committed_subdag =
-                    tokio::time::timeout(Duration::from_secs(1), receiver.recv())
+                    tokio::time::timeout(Duration::from_secs(3), receiver.recv())
                         .await
                         .unwrap()
                         .unwrap();

--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -34,6 +34,7 @@ use crate::{
     },
     observer_service::ObserverService,
     observer_subscriber::ObserverSubscriber,
+    peers_pool::{PeerServer, PeersPool},
     round_prober::{RoundProber, RoundProberHandle},
     round_tracker::RoundTracker,
     storage::rocksdb_store::RocksDBStore,
@@ -358,6 +359,9 @@ where
 
         let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
 
+        // Create the PeersPool
+        let peers_pool = Arc::new(PeersPool::new(context.clone()));
+
         let synchronizer = Synchronizer::start(
             synchronizer_client.clone(),
             context.clone(),
@@ -367,6 +371,7 @@ where
             transaction_vote_tracker.clone(),
             round_tracker.clone(),
             dag_state.clone(),
+            peers_pool.clone(),
             sync_last_known_own_block,
         );
 
@@ -446,6 +451,27 @@ where
 
             (SubscriberType::Validator(s), round_prober_handle)
         } else {
+            // Register all the observer peers in the peers pool
+            for peer in context.parameters.tonic.observer_peers.iter() {
+                // If the peer's public key is in the committe, then register it as a validator.
+                if let Some((index, _)) = context
+                    .committee
+                    .authorities()
+                    .find(|(_, authority)| authority.network_key == peer.public_key)
+                {
+                    peers_pool
+                        .register_validator(
+                            index,
+                            vec![PeerServer::Validator, PeerServer::Observer],
+                        )
+                        .expect("Failed to register validator");
+                } else {
+                    // Otherwise this is another Observer peer and we register it as such. This peer we know that
+                    // it will support the Observer server.
+                    peers_pool.register_observer(peer.public_key.clone());
+                }
+            }
+
             // Observer node: subscribe to specified peer(s) using ObserverSubscriber
             let observer_client = network_manager.observer_client();
             let observer_service = Arc::new(ObserverService::new(

--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -831,7 +831,7 @@ mod tests {
             let mut expected_transactions = submitted_transactions.clone();
             loop {
                 let committed_subdag =
-                    tokio::time::timeout(Duration::from_secs(3), receiver.recv())
+                    tokio::time::timeout(Duration::from_secs(1), receiver.recv())
                         .await
                         .unwrap()
                         .unwrap();

--- a/consensus/core/src/authority_service.rs
+++ b/consensus/core/src/authority_service.rs
@@ -308,7 +308,7 @@ impl<C: CoreThreadDispatcher> ValidatorNetworkService for AuthorityService<C> {
                 // It only waits for synchronizer to queue the request to a peer.
                 // When this fails, it usually means the queue is full.
                 // The fetch will retry from other peers via live and periodic syncs.
-                if let Err(err) = synchronizer.fetch_blocks(missing_ancestors, peer).await {
+                if let Err(err) = synchronizer.fetch_blocks(missing_ancestors, PeerId::Validator(peer)).await {
                     debug!("Failed to fetch missing ancestors via synchronizer: {err}");
                 }
             });
@@ -331,7 +331,7 @@ impl<C: CoreThreadDispatcher> ValidatorNetworkService for AuthorityService<C> {
             let synchronizer = self.synchronizer.clone();
             spawn_monitored_task!(async move {
                 if let Err(err) = synchronizer
-                    .fetch_blocks(missing_excluded_ancestors, peer)
+                    .fetch_blocks(missing_excluded_ancestors, PeerId::Validator(peer))
                     .await
                 {
                     debug!("Failed to fetch excluded ancestors via synchronizer: {err}");

--- a/consensus/core/src/authority_service.rs
+++ b/consensus/core/src/authority_service.rs
@@ -308,7 +308,10 @@ impl<C: CoreThreadDispatcher> ValidatorNetworkService for AuthorityService<C> {
                 // It only waits for synchronizer to queue the request to a peer.
                 // When this fails, it usually means the queue is full.
                 // The fetch will retry from other peers via live and periodic syncs.
-                if let Err(err) = synchronizer.fetch_blocks(missing_ancestors, PeerId::Validator(peer)).await {
+                if let Err(err) = synchronizer
+                    .fetch_blocks(missing_ancestors, PeerId::Validator(peer))
+                    .await
+                {
                     debug!("Failed to fetch missing ancestors via synchronizer: {err}");
                 }
             });

--- a/consensus/core/src/authority_service.rs
+++ b/consensus/core/src/authority_service.rs
@@ -939,6 +939,7 @@ mod tests {
             BlockStream, ExtendedSerializedBlock, ObserverNetworkClient, SynchronizerClient,
             ValidatorNetworkClient, ValidatorNetworkService,
         },
+        peers_pool::PeersPool,
         round_tracker::RoundTracker,
         storage::mem_store::MemStore,
         synchronizer::Synchronizer,
@@ -1113,6 +1114,7 @@ mod tests {
         let transaction_vote_tracker =
             TransactionVoteTracker::new(context.clone(), block_verifier.clone(), dag_state.clone());
         let round_tracker = Arc::new(RwLock::new(RoundTracker::new(context.clone(), vec![])));
+        let peers_pool = Arc::new(PeersPool::new(context.clone()));
         let synchronizer = Synchronizer::start(
             network_client,
             context.clone(),
@@ -1122,6 +1124,7 @@ mod tests {
             transaction_vote_tracker.clone(),
             round_tracker.clone(),
             dag_state.clone(),
+            peers_pool.clone(),
             false,
         );
         let authority_service = Arc::new(AuthorityService::new(
@@ -1232,6 +1235,7 @@ mod tests {
         let transaction_vote_tracker =
             TransactionVoteTracker::new(context.clone(), block_verifier.clone(), dag_state.clone());
         let round_tracker = Arc::new(RwLock::new(RoundTracker::new(context.clone(), vec![])));
+        let peers_pool = Arc::new(PeersPool::new(context.clone()));
         let synchronizer = Synchronizer::start(
             network_client,
             context.clone(),
@@ -1241,6 +1245,7 @@ mod tests {
             transaction_vote_tracker.clone(),
             round_tracker.clone(),
             dag_state.clone(),
+            peers_pool.clone(),
             false,
         );
         let authority_service = Arc::new(AuthorityService::new(
@@ -1441,6 +1446,7 @@ mod tests {
         let transaction_vote_tracker =
             TransactionVoteTracker::new(context.clone(), block_verifier.clone(), dag_state.clone());
         let round_tracker = Arc::new(RwLock::new(RoundTracker::new(context.clone(), vec![])));
+        let peers_pool = Arc::new(PeersPool::new(context.clone()));
         let synchronizer = Synchronizer::start(
             network_client,
             context.clone(),
@@ -1450,6 +1456,7 @@ mod tests {
             transaction_vote_tracker.clone(),
             round_tracker.clone(),
             dag_state.clone(),
+            peers_pool.clone(),
             true,
         );
         let authority_service = Arc::new(AuthorityService::new(
@@ -1513,6 +1520,7 @@ mod tests {
         let transaction_vote_tracker =
             TransactionVoteTracker::new(context.clone(), block_verifier.clone(), dag_state.clone());
         let round_tracker = Arc::new(RwLock::new(RoundTracker::new(context.clone(), vec![])));
+        let peers_pool = Arc::new(PeersPool::new(context.clone()));
         let synchronizer = Synchronizer::start(
             network_client,
             context.clone(),
@@ -1522,6 +1530,7 @@ mod tests {
             transaction_vote_tracker.clone(),
             round_tracker.clone(),
             dag_state.clone(),
+            peers_pool.clone(),
             false,
         );
 
@@ -1602,6 +1611,7 @@ mod tests {
         let transaction_vote_tracker =
             TransactionVoteTracker::new(context.clone(), block_verifier.clone(), dag_state.clone());
         let round_tracker = Arc::new(RwLock::new(RoundTracker::new(context.clone(), vec![])));
+        let peers_pool = Arc::new(PeersPool::new(context.clone()));
         let synchronizer = Synchronizer::start(
             network_client,
             context.clone(),
@@ -1611,6 +1621,7 @@ mod tests {
             transaction_vote_tracker.clone(),
             round_tracker.clone(),
             dag_state.clone(),
+            peers_pool.clone(),
             false,
         );
 

--- a/consensus/core/src/error.rs
+++ b/consensus/core/src/error.rs
@@ -92,7 +92,13 @@ pub enum ConsensusError {
     SignatureVerificationFailure(FastCryptoError),
 
     #[error("Synchronizer for fetching blocks directly from {0} is saturated")]
-    SynchronizerSaturated(AuthorityIndex),
+    SynchronizerSaturated(String),
+
+    #[error("Peer {0} is unavailable")]
+    PeerUnavailable(String),
+
+    #[error("Peer {0} not found")]
+    PeerNotFound(String),
 
     #[error("Block {block_ref:?} rejected: {reason}")]
     BlockRejected { block_ref: BlockRef, reason: String },

--- a/consensus/core/src/error.rs
+++ b/consensus/core/src/error.rs
@@ -97,7 +97,7 @@ pub enum ConsensusError {
     #[error("Peer {0} is unavailable")]
     PeerUnavailable(String),
 
-    #[error("Peer {0} not found")]
+    #[error("Peer not found for block synchronization: {0}")]
     PeerNotFound(String),
 
     #[error("Block {block_ref:?} rejected: {reason}")]

--- a/consensus/core/src/lib.rs
+++ b/consensus/core/src/lib.rs
@@ -28,6 +28,7 @@ mod metrics;
 mod network;
 mod observer_service;
 mod observer_subscriber;
+mod peers_pool;
 mod proposer;
 mod round_prober;
 mod round_tracker;

--- a/consensus/core/src/network/mod.rs
+++ b/consensus/core/src/network/mod.rs
@@ -56,16 +56,40 @@ impl Display for PeerId {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             PeerId::Validator(authority) => write!(f, "[{}]", authority),
-            PeerId::Observer(node_id) => write!(f, "[{:?}]", node_id),
+            PeerId::Observer(node_id) => {
+                let bytes = node_id.to_bytes();
+                write!(
+                    f,
+                    "[Observer:{:02x}{:02x}{:02x}{:02x}]",
+                    bytes[0], bytes[1], bytes[2], bytes[3]
+                )
+            }
         }
     }
 }
 
 impl PeerId {
+    /// Returns a human-readable name suitable for logging. For observers, prints
+    /// the first 8 hex digits of the public key.
     pub(crate) fn hostname(&self, context: &Context) -> String {
         match self {
             PeerId::Validator(index) => context.committee.authority(*index).hostname.to_string(),
-            PeerId::Observer(_) => format!("[Observer]{:?}", self),
+            PeerId::Observer(node_id) => {
+                let bytes = node_id.to_bytes();
+                format!(
+                    "[Observer]{:02x}{:02x}{:02x}{:02x}",
+                    bytes[0], bytes[1], bytes[2], bytes[3]
+                )
+            }
+        }
+    }
+
+    /// Returns a short label suitable for use in metrics. Does not include
+    /// full public keys to avoid high-cardinality metric labels.
+    pub(crate) fn labelname(&self, context: &Context) -> String {
+        match self {
+            PeerId::Validator(index) => context.committee.authority(*index).hostname.to_string(),
+            PeerId::Observer(_) => "observer".to_string(),
         }
     }
 }

--- a/consensus/core/src/network/mod.rs
+++ b/consensus/core/src/network/mod.rs
@@ -28,6 +28,7 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use consensus_config::{AuthorityIndex, NetworkKeyPair, NetworkPublicKey};
 use consensus_types::block::{BlockRef, Round};
+use fastcrypto::encoding::{Encoding, Hex};
 use futures::Stream;
 use mysten_network::{Multiaddr, multiaddr::Protocol};
 
@@ -39,7 +40,6 @@ use crate::{
 };
 
 /// Identifies an observer node by its network public key.
-#[allow(unused)]
 pub(crate) type NodeId = NetworkPublicKey;
 
 /// Identifies a peer in the network, which can be either a validator or an observer.
@@ -60,11 +60,8 @@ impl Display for PeerId {
             PeerId::Validator(authority) => write!(f, "[{}]", authority),
             PeerId::Observer(node_id) => {
                 let bytes = node_id.to_bytes();
-                write!(
-                    f,
-                    "[Observer:{:02x}{:02x}{:02x}{:02x}]",
-                    bytes[0], bytes[1], bytes[2], bytes[3]
-                )
+                let s = Hex::encode(bytes.get(0..4).ok_or(std::fmt::Error)?);
+                write!(f, "o#{}..", s)
             }
         }
     }

--- a/consensus/core/src/network/mod.rs
+++ b/consensus/core/src/network/mod.rs
@@ -61,6 +61,15 @@ impl Display for PeerId {
     }
 }
 
+impl PeerId {
+    pub(crate) fn hostname(&self, context: &Context) -> String {
+        match self {
+            PeerId::Validator(index) => context.committee.authority(*index).hostname.to_string(),
+            PeerId::Observer(_) => format!("[Observer]{:?}", self),
+        }
+    }
+}
+
 // Tonic generated RPC stubs.
 mod tonic_gen {
     include!(concat!(env!("OUT_DIR"), "/consensus.ConsensusService.rs"));

--- a/consensus/core/src/network/mod.rs
+++ b/consensus/core/src/network/mod.rs
@@ -43,13 +43,15 @@ use crate::{
 pub(crate) type NodeId = NetworkPublicKey;
 
 /// Identifies a peer in the network, which can be either a validator or an observer.
+/// The Observer variant is boxed to keep the enum small, since `NodeId` (32 bytes) is
+/// much larger than `AuthorityIndex` (4 bytes).
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) enum PeerId {
     /// A validator node identified by its authority index.
     Validator(AuthorityIndex),
     /// An observer node identified by its network public key.
     #[allow(dead_code)]
-    Observer(NodeId),
+    Observer(Box<NodeId>),
 }
 
 impl Display for PeerId {

--- a/consensus/core/src/network/observer.rs
+++ b/consensus/core/src/network/observer.rs
@@ -148,7 +148,7 @@ impl ChannelPool {
                 .authority(authority)
                 .network_key
                 .clone(),
-            PeerId::Observer(node_id) => node_id.clone(),
+            PeerId::Observer(node_id) => (*node_id).clone(),
         };
 
         // Check if the peer is in the observer peers pool. If not return an error.

--- a/consensus/core/src/observer_service.rs
+++ b/consensus/core/src/observer_service.rs
@@ -314,14 +314,7 @@ mod tests {
 
     // Helper function to create a mock synchronizer for tests
     fn create_mock_synchronizer() -> Arc<SynchronizerHandle> {
-        use tokio::sync::mpsc;
-        use tokio::task::JoinSet;
-
-        let (tx, _rx) = mpsc::channel(1);
-        Arc::new(SynchronizerHandle {
-            commands_sender: tx,
-            tasks: tokio::sync::Mutex::new(JoinSet::new()),
-        })
+        SynchronizerHandle::new_for_test()
     }
 
     #[tokio::test]
@@ -342,7 +335,6 @@ mod tests {
         let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
         let transaction_vote_tracker =
             TransactionVoteTracker::new(context.clone(), block_verifier.clone(), dag_state.clone());
-            let synchronizer = create_mock_synchronizer();
 
         let observer_service = ObserverService::new(
             context.clone(),
@@ -352,7 +344,7 @@ mod tests {
             block_verifier,
             commit_vote_monitor,
             transaction_vote_tracker,
-            synchronizer,
+            create_mock_synchronizer(),
         );
 
         // Observer starts with no blocks seen
@@ -424,7 +416,7 @@ mod tests {
             block_verifier,
             commit_vote_monitor,
             transaction_vote_tracker,
-            synchronizer,
+            create_mock_synchronizer(),
         );
 
         let peer = keys[0].0.public().clone();

--- a/consensus/core/src/observer_service.rs
+++ b/consensus/core/src/observer_service.rs
@@ -406,7 +406,6 @@ mod tests {
         let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
         let transaction_vote_tracker =
             TransactionVoteTracker::new(context.clone(), block_verifier.clone(), dag_state.clone());
-        let synchronizer = create_mock_synchronizer();
 
         let observer_service = ObserverService::new(
             context.clone(),

--- a/consensus/core/src/observer_service.rs
+++ b/consensus/core/src/observer_service.rs
@@ -25,6 +25,7 @@ use crate::{
     network::{
         NodeId, ObserverBlockStream, ObserverBlockStreamItem, ObserverNetworkService, PeerId,
     },
+    synchronizer::SynchronizerHandle,
 };
 
 // Is used to calculate the threshold for blocking blocks when the commit index is lagging too far from the quorum commit index.
@@ -42,6 +43,7 @@ pub(crate) struct ObserverService {
     block_verifier: Arc<dyn BlockVerifier>,
     commit_vote_monitor: Arc<CommitVoteMonitor>,
     transaction_vote_tracker: TransactionVoteTracker,
+    synchronizer: Arc<SynchronizerHandle>,
 }
 
 impl ObserverService {
@@ -53,6 +55,7 @@ impl ObserverService {
         block_verifier: Arc<dyn BlockVerifier>,
         commit_vote_monitor: Arc<CommitVoteMonitor>,
         transaction_vote_tracker: TransactionVoteTracker,
+        synchronizer: Arc<SynchronizerHandle>,
     ) -> Self {
         let subscription_counter = Arc::new(SubscriptionCounter::new(context.clone()));
         Self {
@@ -64,6 +67,7 @@ impl ObserverService {
             block_verifier,
             commit_vote_monitor,
             transaction_vote_tracker,
+            synchronizer,
         }
     }
 }
@@ -191,9 +195,7 @@ impl ObserverNetworkService for ObserverService {
             .await
             .map_err(|_| ConsensusError::Shutdown)?;
 
-        // TODO: Schedule fetching missing ancestors from this peer in the background.
-        // This requires the refactored synchronizer that supports PeerId (from the
-        // consensus-synchronizer-peers-pool branch). For now, just record metrics.
+        // Schedule fetching missing ancestors from this peer in the background.
         if !missing_ancestors.is_empty() {
             self.context
                 .metrics
@@ -202,10 +204,16 @@ impl ObserverNetworkService for ObserverService {
                 .with_label_values(&[block_author_hostname])
                 .inc_by(missing_ancestors.len() as u64);
 
-            tracing::debug!(
-                "Block has {} missing ancestors that need to be fetched",
-                missing_ancestors.len()
-            );
+            let synchronizer = self.synchronizer.clone();
+            mysten_metrics::spawn_monitored_task!(async move {
+                // This does not wait for the fetch request to complete.
+                // It only waits for synchronizer to queue the request to a peer.
+                // When this fails, it usually means the queue is full.
+                // The fetch will retry from other peers via live and periodic syncs.
+                if let Err(err) = synchronizer.fetch_blocks(missing_ancestors, peer).await {
+                    tracing::debug!("Failed to fetch missing ancestors via synchronizer: {err}");
+                }
+            });
         }
 
         Ok(())
@@ -304,6 +312,18 @@ mod tests {
         storage::mem_store::MemStore,
     };
 
+    // Helper function to create a mock synchronizer for tests
+    fn create_mock_synchronizer() -> Arc<SynchronizerHandle> {
+        use tokio::sync::mpsc;
+        use tokio::task::JoinSet;
+
+        let (tx, _rx) = mpsc::channel(1);
+        Arc::new(SynchronizerHandle {
+            commands_sender: tx,
+            tasks: tokio::sync::Mutex::new(JoinSet::new()),
+        })
+    }
+
     #[tokio::test]
     async fn test_observer_stream_receives_broadcast_blocks() {
         telemetry_subscribers::init_for_testing();
@@ -322,6 +342,7 @@ mod tests {
         let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
         let transaction_vote_tracker =
             TransactionVoteTracker::new(context.clone(), block_verifier.clone(), dag_state.clone());
+            let synchronizer = create_mock_synchronizer();
 
         let observer_service = ObserverService::new(
             context.clone(),
@@ -331,6 +352,7 @@ mod tests {
             block_verifier,
             commit_vote_monitor,
             transaction_vote_tracker,
+            synchronizer,
         );
 
         // Observer starts with no blocks seen
@@ -392,6 +414,7 @@ mod tests {
         let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
         let transaction_vote_tracker =
             TransactionVoteTracker::new(context.clone(), block_verifier.clone(), dag_state.clone());
+        let synchronizer = create_mock_synchronizer();
 
         let observer_service = ObserverService::new(
             context.clone(),
@@ -401,6 +424,7 @@ mod tests {
             block_verifier,
             commit_vote_monitor,
             transaction_vote_tracker,
+            synchronizer,
         );
 
         let peer = keys[0].0.public().clone();

--- a/consensus/core/src/observer_service.rs
+++ b/consensus/core/src/observer_service.rs
@@ -258,7 +258,7 @@ impl ObserverNetworkService for ObserverService {
             );
 
         let live_stream = BroadcastStream::<(VerifiedBlock, CommitIndex)>::new(
-            PeerId::Observer(peer),
+            PeerId::Observer(Box::new(peer)),
             self.rx_accepted_block_broadcast.resubscribe(),
             self.subscription_counter.clone(),
         )

--- a/consensus/core/src/peers_pool.rs
+++ b/consensus/core/src/peers_pool.rs
@@ -15,13 +15,13 @@ use crate::{
     network::{NodeId, PeerId},
 };
 
-/// The server types that a peer can support.
-/// A peer may support multiple server types.
+/// The service types that a peer can support.
+/// A peer may support multiple service types.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub(crate) enum PeerServer {
-    /// The validator consensus server for validator-to-validator communication
+pub(crate) enum PeerService {
+    /// The validator consensus service for validator-to-validator communication
     Validator,
-    /// The observer server for streaming blocks and serving observer requests
+    /// The observer service for streaming blocks and serving observer requests
     #[allow(dead_code)]
     Observer,
 }
@@ -29,36 +29,36 @@ pub(crate) enum PeerServer {
 /// Information about a registered peer
 #[derive(Debug, Clone)]
 struct PeerInfo {
-    /// The server types this peer supports
-    supported_servers: BTreeSet<PeerServer>,
+    /// The services this peer supports
+    supported_services: BTreeSet<PeerService>,
 }
 
-/// Pool of available peers (both validators and observers) that can be used for communication.
-/// This pool tracks which peers are registered, what servers they support, and their availability for synchronization.
+/// Pool of known peers (both validators and observers) that can be used for communication.
+/// This pool tracks which peers are registered, what services they support, and their availability for synchronization.
 ///
 /// The pool is used to:
-/// - Register peers with their supported servers when they connect
-/// - Check if a peer is available and supports the required server
+/// - Register peers with their supported services when they connect
+/// - Check if a peer is known and supports the required service
 /// - Remove peers
-/// - Get lists of available peers filtered by server support
+/// - Get lists of known peers filtered by service support
 pub(crate) struct PeersPool {
-    /// Registered peers with their supported servers
+    /// Registered peers with their supported services
     registered_peers: RwLock<BTreeMap<PeerId, PeerInfo>>,
     /// Context for accessing committee information and current node type
     context: Arc<Context>,
 }
 
 impl PeersPool {
-    // Initializes the peers pool with the committee as peers with the Validator server as available.
+    // Initializes the peers pool with the committee as peers with the Validator service as known.
     pub(crate) fn new(context: Arc<Context>) -> Self {
         let s = Self {
             registered_peers: RwLock::new(BTreeMap::new()),
             context: context.clone(),
         };
 
-        // Register the committee as peers with the Validator server as available.
+        // Register the committee as peers with the Validator service as known.
         for (index, _) in context.committee.authorities() {
-            s.register_validator(index, vec![PeerServer::Validator])
+            s.register_validator(index, vec![PeerService::Validator])
                 .unwrap();
         }
 
@@ -70,11 +70,11 @@ impl PeersPool {
                 .authorities()
                 .find(|(_, authority)| authority.network_key == peer.public_key)
             {
-                s.register_validator(index, vec![PeerServer::Validator, PeerServer::Observer])
+                s.register_validator(index, vec![PeerService::Validator, PeerService::Observer])
                     .expect("Failed to register validator");
             } else {
                 // Otherwise this is another Observer peer and we register it as such. This peer we know that
-                // it will support the Observer server.
+                // it will support the Observer service.
                 s.register_observer(peer.public_key.clone());
             }
         }
@@ -82,13 +82,13 @@ impl PeersPool {
         s
     }
 
-    /// Registers a validator as available in the pool with its supported servers.
+    /// Registers a validator as known in the pool with its supported services.
     /// Note: this method will override the peer if it already exists in the pool.
     #[allow(dead_code)]
     pub(crate) fn register_validator(
         &self,
         authority_index: AuthorityIndex,
-        mut supported_servers: Vec<PeerServer>,
+        mut supported_services: Vec<PeerService>,
     ) -> ConsensusResult<()> {
         if !self.context.committee.is_valid_index(authority_index) {
             return Err(ConsensusError::InvalidAuthorityIndex {
@@ -97,31 +97,31 @@ impl PeersPool {
             });
         }
 
-        // We always ensure that whoever registers a validator supports the Validator server.
-        if !supported_servers.contains(&PeerServer::Validator) {
-            supported_servers.push(PeerServer::Validator);
+        // We always ensure that whoever registers a validator supports the Validator service.
+        if !supported_services.contains(&PeerService::Validator) {
+            supported_services.push(PeerService::Validator);
         }
         let mut peers = self.registered_peers.write();
         peers.insert(
             PeerId::Validator(authority_index),
             PeerInfo {
-                supported_servers: supported_servers.into_iter().collect(),
+                supported_services: supported_services.into_iter().collect(),
             },
         );
 
         Ok(())
     }
 
-    /// Registers an observer as available in the pool.
-    /// Note that we do not allow observers to register with supported servers other than Observer. This is done for safety
-    /// as only validators are supposed to support both the Validator and Observer servers.
+    /// Registers an observer as known in the pool.
+    /// Note that we do not allow observers to register with supported services other than Observer. This is done for safety
+    /// as only validators are supposed to support both the Validator and Observer services.
     #[allow(dead_code)]
     pub(crate) fn register_observer(&self, node_id: NodeId) {
         let mut peers = self.registered_peers.write();
         peers.insert(
             PeerId::Observer(node_id),
             PeerInfo {
-                supported_servers: vec![PeerServer::Observer].into_iter().collect(),
+                supported_services: vec![PeerService::Observer].into_iter().collect(),
             },
         );
     }
@@ -133,22 +133,22 @@ impl PeersPool {
         peers.remove(peer);
     }
 
-    /// Checks if a peer is available for fetching blocks/commits
+    /// Checks if a peer is known for fetching blocks/commits
     /// Takes into account:
-    /// - For validators: always available unless it's our own node
+    /// - For validators: always known unless it's our own node
     /// - For observers: must be registered in the pool
-    /// - The peer must support at least one of the required servers
+    /// - The peer must support at least one of the required services
     /// - The peer is not our own node (when a validator)
-    pub(crate) fn is_peer_available(&self, peer: &PeerId) -> bool {
-        self.is_peer_available_for_servers(peer, &[])
+    pub(crate) fn is_peer_known(&self, peer: &PeerId) -> bool {
+        self.is_peer_known_for_services(peer, &[])
     }
 
-    /// Checks if a peer is available and supports at least one of the specified servers.
-    /// If no servers are specified, just checks basic availability.
-    pub(crate) fn is_peer_available_for_servers(
+    /// Checks if a peer is known and supports at least one of the specified services.
+    /// If no services are specified, just checks basic availability.
+    pub(crate) fn is_peer_known_for_services(
         &self,
         peer: &PeerId,
-        required_servers: &[PeerServer],
+        required_services: &[PeerService],
     ) -> bool {
         // Don't fetch from ourselves
         if let PeerId::Validator(index) = peer
@@ -160,14 +160,14 @@ impl PeersPool {
         // Check if peer is registered
         let peers = self.registered_peers.read();
         if let Some(info) = peers.get(peer) {
-            // If no specific server required, peer is available
-            if required_servers.is_empty() {
+            // If no specific service required, peer is known
+            if required_services.is_empty() {
                 true
             } else {
-                // Check if peer supports any required server
-                required_servers
+                // Check if peer supports any required service
+                required_services
                     .iter()
-                    .any(|server| info.supported_servers.contains(server))
+                    .any(|service| info.supported_services.contains(service))
             }
         } else {
             // Peer not registered (should not happen for validators after initialization)
@@ -175,23 +175,23 @@ impl PeersPool {
         }
     }
 
-    /// Gets all available peers based that are compatible with the current node.
+    /// Gets all known peers that are compatible with the current node.
     #[allow(dead_code)]
-    pub(crate) fn get_available_peers(&self) -> Vec<PeerId> {
-        let compatible_servers = self.get_compatible_servers();
-        self.get_available_peers_for_servers(&compatible_servers)
+    pub(crate) fn get_known_peers(&self) -> Vec<PeerId> {
+        let compatible_services = self.get_compatible_services();
+        self.get_known_peers_for_services(&compatible_services)
     }
 
-    /// Gets available peers that support at least one of the specified servers
+    /// Gets known peers that support at least one of the specified services
     ///
-    /// When an empty `filter_servers` is provided, all available peers are returned.
+    /// When an empty `filter_services` is provided, all known peers are returned.
     ///
     /// Note: This method does NOT check node compatibility. If you want to ensure
-    /// only compatible peers are returned, use `get_available_peers()`
+    /// only compatible peers are returned, use `get_known_peers()`
     #[allow(dead_code)]
-    pub(crate) fn get_available_peers_for_servers(
+    pub(crate) fn get_known_peers_for_services(
         &self,
-        filter_servers: &[PeerServer],
+        filter_services: &[PeerService],
     ) -> Vec<PeerId> {
         let mut peers = Vec::new();
         let registered = self.registered_peers.read();
@@ -204,11 +204,11 @@ impl PeersPool {
                 continue;
             }
 
-            // Check if peer supports any of the required servers
-            if filter_servers.is_empty()
-                || filter_servers
+            // Check if peer supports any of the required services
+            if filter_services.is_empty()
+                || filter_services
                     .iter()
-                    .any(|server| info.supported_servers.contains(server))
+                    .any(|service| info.supported_services.contains(service))
             {
                 peers.push(peer.clone());
             }
@@ -217,17 +217,15 @@ impl PeersPool {
         peers
     }
 
-    /// Gets the compatible servers based on the current node type
-    /// - If we're a Validator node: can talk to both Validator and Observer servers
-    /// - If we're an Observer node: can only talk to Observer servers
+    /// Gets the compatible services based on the current node type
+    /// - If we're a Validator node: can talk to both Validator and Observer services
+    /// - If we're an Observer node: can only talk to Observer services
     #[allow(dead_code)]
-    fn get_compatible_servers(&self) -> Vec<PeerServer> {
+    fn get_compatible_services(&self) -> Vec<PeerService> {
         if self.context.is_validator() {
-            // Validators can talk to both Validator and Observer servers
-            vec![PeerServer::Validator, PeerServer::Observer]
+            vec![PeerService::Validator, PeerService::Observer]
         } else {
-            // Observers can only talk to Observer servers
-            vec![PeerServer::Observer]
+            vec![PeerService::Observer]
         }
     }
 }
@@ -251,20 +249,20 @@ mod tests {
         pool.register_observer(observer1.clone());
         pool.register_observer(observer2.clone());
 
-        // Check they're available
-        assert!(pool.is_peer_available(&PeerId::Observer(observer1.clone())));
-        assert!(pool.is_peer_available(&PeerId::Observer(observer2.clone())));
+        // Check they're known
+        assert!(pool.is_peer_known(&PeerId::Observer(observer1.clone())));
+        assert!(pool.is_peer_known(&PeerId::Observer(observer2.clone())));
 
-        // Validators should be available (except our own)
-        assert!(!pool.is_peer_available(&PeerId::Validator(AuthorityIndex::new_for_test(0))));
-        assert!(pool.is_peer_available(&PeerId::Validator(AuthorityIndex::new_for_test(1))));
+        // Validators should be known (except our own)
+        assert!(!pool.is_peer_known(&PeerId::Validator(AuthorityIndex::new_for_test(0))));
+        assert!(pool.is_peer_known(&PeerId::Validator(AuthorityIndex::new_for_test(1))));
 
         // Check server filtering
-        let validator_peers = pool.get_available_peers_for_servers(&[PeerServer::Validator]);
+        let validator_peers = pool.get_known_peers_for_services(&[PeerService::Validator]);
         // Should have 3 validators (excluding our own index 0)
         assert_eq!(validator_peers.len(), 3);
 
-        let observer_peers = pool.get_available_peers_for_servers(&[PeerServer::Observer]);
+        let observer_peers = pool.get_known_peers_for_services(&[PeerService::Observer]);
         // Should have 2 observers
         assert_eq!(observer_peers.len(), 2);
     }
@@ -278,17 +276,17 @@ mod tests {
         let observer = NetworkKeyPair::generate(&mut rand::thread_rng()).public();
         let observer_peer = PeerId::Observer(observer.clone());
 
-        // Register and verify available
+        // Register and verify known
         pool.register_observer(observer);
-        assert!(pool.is_peer_available(&observer_peer));
+        assert!(pool.is_peer_known(&observer_peer));
 
-        // Remove and verify not available
+        // Remove and verify not known
         pool.remove_peer(&observer_peer);
-        assert!(!pool.is_peer_available(&observer_peer));
+        assert!(!pool.is_peer_known(&observer_peer));
     }
 
     #[test]
-    fn test_get_available_peers_as_validator() {
+    fn test_get_known_peers_as_validator() {
         let (mut context, _) = Context::new_for_test(3);
         context.own_index = AuthorityIndex::new_for_test(1);
         // This is a validator node (own_index is within committee range)
@@ -298,7 +296,7 @@ mod tests {
         let observer = NetworkKeyPair::generate(&mut rand::thread_rng()).public();
         pool.register_observer(observer.clone());
 
-        let peers = pool.get_available_peers();
+        let peers = pool.get_known_peers();
         // As a validator, should have 2 validators (0 and 2, excluding our own 1) and 1 observer
         assert_eq!(peers.len(), 3);
         assert!(peers.contains(&PeerId::Validator(AuthorityIndex::new_for_test(0))));
@@ -308,7 +306,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_available_peers_as_observer() {
+    fn test_get_known_peers_as_observer() {
         let (mut context, _) = Context::new_for_test(3);
         // Set own_index to a value outside committee range to simulate an observer node
         context.own_index = AuthorityIndex::new_for_test(10);
@@ -320,10 +318,10 @@ mod tests {
         pool.register_observer(observer1.clone());
 
         // Register a validator with Observer server (e.g., it has an observer port open)
-        pool.register_validator(AuthorityIndex::new_for_test(1), vec![PeerServer::Observer])
+        pool.register_validator(AuthorityIndex::new_for_test(1), vec![PeerService::Observer])
             .unwrap();
 
-        let peers = pool.get_available_peers();
+        let peers = pool.get_known_peers();
         // As an observer, should only see peers that support Observer server
         assert_eq!(peers.len(), 2);
         assert!(peers.contains(&PeerId::Observer(observer1)));
@@ -344,7 +342,7 @@ mod tests {
         // Register a validator with both servers
         pool.register_validator(
             AuthorityIndex::new_for_test(0),
-            vec![PeerServer::Validator, PeerServer::Observer],
+            vec![PeerService::Validator, PeerService::Observer],
         )
         .unwrap();
 
@@ -352,22 +350,22 @@ mod tests {
         let observer = NetworkKeyPair::generate(&mut rand::thread_rng()).public();
         pool.register_observer(observer.clone());
 
-        // As an observer node, get_available_peers() should only return peers that support Observer server
+        // As an observer node, get_known_peers() should only return peers that support Observer server
         // (because observers can only communicate with Observer servers)
-        let available_peers = pool.get_available_peers();
-        assert_eq!(available_peers.len(), 2); // The validator with Observer server and the observer
-        assert!(available_peers.contains(&PeerId::Validator(AuthorityIndex::new_for_test(0))));
-        assert!(available_peers.contains(&PeerId::Observer(observer.clone())));
+        let known_peers = pool.get_known_peers();
+        assert_eq!(known_peers.len(), 2); // The validator with Observer server and the observer
+        assert!(known_peers.contains(&PeerId::Validator(AuthorityIndex::new_for_test(0))));
+        assert!(known_peers.contains(&PeerId::Observer(observer.clone())));
 
         // Direct filtering for Validator server should still return the peers that support it,
         // but this doesn't check compatibility
-        let validator_peers = pool.get_available_peers_for_servers(&[PeerServer::Validator]);
+        let validator_peers = pool.get_known_peers_for_services(&[PeerService::Validator]);
         // Should have all validators (3 total, but our node with index 10 is not in the committee)
         // Plus the validator we just registered with both servers
         assert!(validator_peers.len() >= 3);
 
         // Filtering for Observer server should return peers that support it
-        let observer_peers = pool.get_available_peers_for_servers(&[PeerServer::Observer]);
+        let observer_peers = pool.get_known_peers_for_services(&[PeerService::Observer]);
         assert_eq!(observer_peers.len(), 2); // The validator with Observer server and the observer
         assert!(observer_peers.contains(&PeerId::Validator(AuthorityIndex::new_for_test(0))));
         assert!(observer_peers.contains(&PeerId::Observer(observer)));
@@ -391,18 +389,18 @@ mod tests {
         // Register a validator with both servers
         pool.register_validator(
             AuthorityIndex::new_for_test(1),
-            vec![PeerServer::Validator, PeerServer::Observer],
+            vec![PeerService::Validator, PeerService::Observer],
         )
         .unwrap();
 
         // Filter for Validator server only
-        let validator_peers = pool.get_available_peers_for_servers(&[PeerServer::Validator]);
+        let validator_peers = pool.get_known_peers_for_services(&[PeerService::Validator]);
         // Should get: validator 1 (registered with both), validators 2 and 3 (default with Validator)
         // Note: observers cannot have Validator server with the new API
         assert_eq!(validator_peers.len(), 3);
 
         // Filter for Observer server only
-        let observer_peers = pool.get_available_peers_for_servers(&[PeerServer::Observer]);
+        let observer_peers = pool.get_known_peers_for_services(&[PeerService::Observer]);
         // Should get: observer1, observer2, and validator 1
         assert_eq!(observer_peers.len(), 3);
         assert!(observer_peers.contains(&PeerId::Observer(observer1)));

--- a/consensus/core/src/peers_pool.rs
+++ b/consensus/core/src/peers_pool.rs
@@ -62,6 +62,23 @@ impl PeersPool {
                 .unwrap();
         }
 
+        // Register all the observer peers in the peers pool
+        for peer in context.parameters.tonic.observer_peers.iter() {
+            // If the peer's public key is in the committe, then register it as a validator.
+            if let Some((index, _)) = context
+                .committee
+                .authorities()
+                .find(|(_, authority)| authority.network_key == peer.public_key)
+            {
+                s.register_validator(index, vec![PeerServer::Validator, PeerServer::Observer])
+                    .expect("Failed to register validator");
+            } else {
+                // Otherwise this is another Observer peer and we register it as such. This peer we know that
+                // it will support the Observer server.
+                s.register_observer(peer.public_key.clone());
+            }
+        }
+
         s
     }
 

--- a/consensus/core/src/peers_pool.rs
+++ b/consensus/core/src/peers_pool.rs
@@ -1,0 +1,382 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    sync::Arc,
+};
+
+use parking_lot::RwLock;
+
+use crate::{context::Context, network::PeerId};
+
+/// The server types that a peer can support.
+/// A peer may support multiple server types.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum PeerServer {
+    /// The validator consensus server for validator-to-validator communication
+    Validator,
+    /// The observer server for streaming blocks and serving observer requests
+    #[allow(dead_code)]
+    Observer,
+}
+
+/// Information about a registered peer
+#[derive(Debug, Clone)]
+struct PeerInfo {
+    /// The server types this peer supports
+    supported_servers: BTreeSet<PeerServer>,
+}
+
+/// Pool of available peers (both validators and observers) that can be used for communication.
+/// This pool tracks which peers are registered, what servers they support, and their availability for synchronization.
+///
+/// The pool is used to:
+/// - Register peers with their supported servers when they connect
+/// - Check if a peer is available and supports the required server
+/// - Remove peers
+/// - Get lists of available peers filtered by server support
+pub(crate) struct PeersPool {
+    /// Registered peers with their supported servers
+    registered_peers: RwLock<BTreeMap<PeerId, PeerInfo>>,
+    /// Context for accessing committee information and current node type
+    context: Arc<Context>,
+}
+
+impl PeersPool {
+    // Initializes the peers pool with the committee as peers with the Validator server as available.
+    pub(crate) fn new(context: Arc<Context>) -> Arc<Self> {
+        // Register the committee as peers with the Validator server as available.
+        let mut registered_peers = BTreeMap::new();
+        for (index, _) in context.committee.authorities() {
+            let peer = PeerId::Validator(index);
+            registered_peers.insert(
+                peer,
+                PeerInfo {
+                    supported_servers: vec![PeerServer::Validator].into_iter().collect(),
+                },
+            );
+        }
+
+        Arc::new(Self {
+            registered_peers: RwLock::new(registered_peers),
+            context,
+        })
+    }
+
+    /// Registers a peer as available in the pool with its supported servers.
+    /// Note: this method will override the peer if it already exists in the pool.
+    #[allow(dead_code)]
+    pub(crate) fn register_peer(&self, peer: PeerId, supported_servers: Vec<PeerServer>) {
+        let mut peers = self.registered_peers.write();
+        peers.insert(
+            peer,
+            PeerInfo {
+                supported_servers: supported_servers.into_iter().collect(),
+            },
+        );
+    }
+
+    /// Removes a peer from the pool
+    #[allow(dead_code)]
+    pub(crate) fn remove_peer(&self, peer: &PeerId) {
+        let mut peers = self.registered_peers.write();
+        peers.remove(peer);
+    }
+
+    /// Checks if a peer is available for fetching blocks/commits
+    /// Takes into account:
+    /// - For validators: always available unless it's our own node
+    /// - For observers: must be registered in the pool
+    /// - The peer must support at least one of the required servers
+    /// - The peer is not our own node (when a validator)
+    pub(crate) fn is_peer_available(&self, peer: &PeerId) -> bool {
+        self.is_peer_available_for_servers(peer, &[])
+    }
+
+    /// Checks if a peer is available and supports at least one of the specified servers.
+    /// If no servers are specified, just checks basic availability.
+    pub(crate) fn is_peer_available_for_servers(
+        &self,
+        peer: &PeerId,
+        required_servers: &[PeerServer],
+    ) -> bool {
+        // Don't fetch from ourselves
+        if let PeerId::Validator(index) = peer
+            && *index == self.context.own_index
+        {
+            return false;
+        }
+
+        // Check if peer is registered
+        let peers = self.registered_peers.read();
+        if let Some(info) = peers.get(peer) {
+            // If no specific server required, peer is available
+            if required_servers.is_empty() {
+                true
+            } else {
+                // Check if peer supports any required server
+                required_servers
+                    .iter()
+                    .any(|server| info.supported_servers.contains(server))
+            }
+        } else {
+            // Peer not registered (should not happen for validators after initialization)
+            false
+        }
+    }
+
+    /// Gets all available peers based that are compatible with the current node.
+    #[allow(dead_code)]
+    pub(crate) fn get_available_peers(&self) -> Vec<PeerId> {
+        let compatible_servers = self.get_compatible_servers();
+        self.get_available_peers_for_servers(&compatible_servers)
+    }
+
+    /// Gets available peers that support at least one of the specified servers
+    ///
+    /// When an empty `filter_servers` is provided, all available peers are returned.
+    ///
+    /// Note: This method does NOT check node compatibility. If you want to ensure
+    /// only compatible peers are returned, use `get_available_peers()`
+    #[allow(dead_code)]
+    pub(crate) fn get_available_peers_for_servers(
+        &self,
+        filter_servers: &[PeerServer],
+    ) -> Vec<PeerId> {
+        let mut peers = Vec::new();
+        let registered = self.registered_peers.read();
+
+        for (peer, info) in registered.iter() {
+            // Skip our own validator index
+            if let PeerId::Validator(index) = peer
+                && *index == self.context.own_index
+            {
+                continue;
+            }
+
+            // Check if peer supports any of the required servers
+            if filter_servers.is_empty()
+                || filter_servers
+                    .iter()
+                    .any(|server| info.supported_servers.contains(server))
+            {
+                peers.push(peer.clone());
+            }
+        }
+
+        peers
+    }
+
+    /// Gets the compatible servers based on the current node type
+    /// - If we're a Validator node: can talk to both Validator and Observer servers
+    /// - If we're an Observer node: can only talk to Observer servers
+    #[allow(dead_code)]
+    fn get_compatible_servers(&self) -> Vec<PeerServer> {
+        if self.context.is_validator() {
+            // Validators can talk to both Validator and Observer servers
+            vec![PeerServer::Validator, PeerServer::Observer]
+        } else {
+            // Observers can only talk to Observer servers
+            vec![PeerServer::Observer]
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use consensus_config::{AuthorityIndex, NetworkKeyPair};
+
+    #[test]
+    fn test_peers_pool_basic() {
+        let (mut context, _) = Context::new_for_test(4);
+        context.own_index = AuthorityIndex::new_for_test(0);
+        // This is a validator node (own_index is within committee range)
+        let context = Arc::new(context);
+        let pool = PeersPool::new(context.clone());
+
+        // Register some observers with Observer server
+        let observer1 = NetworkKeyPair::generate(&mut rand::thread_rng()).public();
+        let observer2 = NetworkKeyPair::generate(&mut rand::thread_rng()).public();
+        pool.register_peer(
+            PeerId::Observer(observer1.clone()),
+            vec![PeerServer::Observer],
+        );
+        pool.register_peer(
+            PeerId::Observer(observer2.clone()),
+            vec![PeerServer::Observer],
+        );
+
+        // Check they're available
+        assert!(pool.is_peer_available(&PeerId::Observer(observer1.clone())));
+        assert!(pool.is_peer_available(&PeerId::Observer(observer2.clone())));
+
+        // Validators should be available (except our own)
+        assert!(!pool.is_peer_available(&PeerId::Validator(AuthorityIndex::new_for_test(0))));
+        assert!(pool.is_peer_available(&PeerId::Validator(AuthorityIndex::new_for_test(1))));
+
+        // Check server filtering
+        let validator_peers = pool.get_available_peers_for_servers(&[PeerServer::Validator]);
+        // Should have 3 validators (excluding our own index 0)
+        assert_eq!(validator_peers.len(), 3);
+
+        let observer_peers = pool.get_available_peers_for_servers(&[PeerServer::Observer]);
+        // Should have 2 observers
+        assert_eq!(observer_peers.len(), 2);
+    }
+
+    #[test]
+    fn test_peers_pool_remove() {
+        let (context, _) = Context::new_for_test(4);
+        let context = Arc::new(context);
+        let pool = PeersPool::new(context.clone());
+
+        let observer = NetworkKeyPair::generate(&mut rand::thread_rng()).public();
+        let observer_peer = PeerId::Observer(observer.clone());
+
+        // Register and verify available
+        pool.register_peer(observer_peer.clone(), vec![PeerServer::Observer]);
+        assert!(pool.is_peer_available(&observer_peer));
+
+        // Remove and verify not available
+        pool.remove_peer(&observer_peer);
+        assert!(!pool.is_peer_available(&observer_peer));
+    }
+
+    #[test]
+    fn test_get_available_peers_as_validator() {
+        let (mut context, _) = Context::new_for_test(3);
+        context.own_index = AuthorityIndex::new_for_test(1);
+        // This is a validator node (own_index is within committee range)
+        let context = Arc::new(context);
+        let pool = PeersPool::new(context.clone());
+
+        let observer = NetworkKeyPair::generate(&mut rand::thread_rng()).public();
+        pool.register_peer(
+            PeerId::Observer(observer.clone()),
+            vec![PeerServer::Observer],
+        );
+
+        let peers = pool.get_available_peers();
+        // As a validator, should have 2 validators (0 and 2, excluding our own 1) and 1 observer
+        assert_eq!(peers.len(), 3);
+        assert!(peers.contains(&PeerId::Validator(AuthorityIndex::new_for_test(0))));
+        assert!(peers.contains(&PeerId::Validator(AuthorityIndex::new_for_test(2))));
+        assert!(peers.contains(&PeerId::Observer(observer)));
+        assert!(!peers.contains(&PeerId::Validator(AuthorityIndex::new_for_test(1))));
+    }
+
+    #[test]
+    fn test_get_available_peers_as_observer() {
+        let (mut context, _) = Context::new_for_test(3);
+        // Set own_index to a value outside committee range to simulate an observer node
+        context.own_index = AuthorityIndex::new_for_test(10);
+        let context = Arc::new(context);
+        let pool = PeersPool::new(context.clone());
+
+        // Register an observer with Observer server
+        let observer1 = NetworkKeyPair::generate(&mut rand::thread_rng()).public();
+        pool.register_peer(
+            PeerId::Observer(observer1.clone()),
+            vec![PeerServer::Observer],
+        );
+
+        // Register a validator with Observer server (e.g., it has an observer port open)
+        pool.register_peer(
+            PeerId::Validator(AuthorityIndex::new_for_test(1)),
+            vec![PeerServer::Observer],
+        );
+
+        let peers = pool.get_available_peers();
+        // As an observer, should only see peers that support Observer server
+        assert_eq!(peers.len(), 2);
+        assert!(peers.contains(&PeerId::Observer(observer1)));
+        assert!(peers.contains(&PeerId::Validator(AuthorityIndex::new_for_test(1))));
+
+        // Should not see validators that only support Validator server
+        assert!(!peers.contains(&PeerId::Validator(AuthorityIndex::new_for_test(2))));
+    }
+
+    #[test]
+    fn test_compatible_server_filtering() {
+        let (mut context, _) = Context::new_for_test(3);
+        // Set as an observer node
+        context.own_index = AuthorityIndex::new_for_test(10);
+        let context = Arc::new(context);
+        let pool = PeersPool::new(context.clone());
+
+        // Register a validator with both servers
+        pool.register_peer(
+            PeerId::Validator(AuthorityIndex::new_for_test(0)),
+            vec![PeerServer::Validator, PeerServer::Observer],
+        );
+
+        // Register an observer with Observer server
+        let observer = NetworkKeyPair::generate(&mut rand::thread_rng()).public();
+        pool.register_peer(
+            PeerId::Observer(observer.clone()),
+            vec![PeerServer::Observer],
+        );
+
+        // As an observer node, get_available_peers() should only return peers that support Observer server
+        // (because observers can only communicate with Observer servers)
+        let available_peers = pool.get_available_peers();
+        assert_eq!(available_peers.len(), 2); // The validator with Observer server and the observer
+        assert!(available_peers.contains(&PeerId::Validator(AuthorityIndex::new_for_test(0))));
+        assert!(available_peers.contains(&PeerId::Observer(observer.clone())));
+
+        // Direct filtering for Validator server should still return the peers that support it,
+        // but this doesn't check compatibility
+        let validator_peers = pool.get_available_peers_for_servers(&[PeerServer::Validator]);
+        // Should have all validators (3 total, but our node with index 10 is not in the committee)
+        // Plus the validator we just registered with both servers
+        assert!(validator_peers.len() >= 3);
+
+        // Filtering for Observer server should return peers that support it
+        let observer_peers = pool.get_available_peers_for_servers(&[PeerServer::Observer]);
+        assert_eq!(observer_peers.len(), 2); // The validator with Observer server and the observer
+        assert!(observer_peers.contains(&PeerId::Validator(AuthorityIndex::new_for_test(0))));
+        assert!(observer_peers.contains(&PeerId::Observer(observer)));
+    }
+
+    #[test]
+    fn test_server_filtering() {
+        let (mut context, _) = Context::new_for_test(4);
+        context.own_index = AuthorityIndex::new_for_test(0);
+        // This is a validator node (own_index is within committee range)
+        let context = Arc::new(context);
+        let pool = PeersPool::new(context.clone());
+
+        // Register observers with different server combinations
+        let observer1 = NetworkKeyPair::generate(&mut rand::thread_rng()).public();
+        let observer2 = NetworkKeyPair::generate(&mut rand::thread_rng()).public();
+        pool.register_peer(
+            PeerId::Observer(observer1.clone()),
+            vec![PeerServer::Observer],
+        );
+        pool.register_peer(
+            PeerId::Observer(observer2.clone()),
+            vec![PeerServer::Observer, PeerServer::Validator],
+        );
+
+        // Register a validator with both servers
+        pool.register_peer(
+            PeerId::Validator(AuthorityIndex::new_for_test(1)),
+            vec![PeerServer::Validator, PeerServer::Observer],
+        );
+
+        // Filter for Validator server only
+        let validator_peers = pool.get_available_peers_for_servers(&[PeerServer::Validator]);
+        // Should get: validator 1 (registered with both), validators 2 and 3 (assumed), and observer2
+        assert!(validator_peers.len() >= 3);
+
+        // Filter for Observer server only
+        let observer_peers = pool.get_available_peers_for_servers(&[PeerServer::Observer]);
+        // Should get: observer1, observer2, and validator 1
+        assert_eq!(observer_peers.len(), 3);
+        assert!(observer_peers.contains(&PeerId::Observer(observer1)));
+        assert!(observer_peers.contains(&PeerId::Observer(observer2)));
+        assert!(observer_peers.contains(&PeerId::Validator(AuthorityIndex::new_for_test(1))));
+    }
+}

--- a/consensus/core/src/peers_pool.rs
+++ b/consensus/core/src/peers_pool.rs
@@ -63,7 +63,7 @@ impl PeersPool {
         }
 
         // Register all the observer peers in the peers pool
-        for peer in context.parameters.tonic.observer_peers.iter() {
+        for peer in context.parameters.observer.peers.iter() {
             // If the peer's public key is in the committe, then register it as a validator.
             if let Some((index, _)) = context
                 .committee

--- a/consensus/core/src/peers_pool.rs
+++ b/consensus/core/src/peers_pool.rs
@@ -6,9 +6,14 @@ use std::{
     sync::Arc,
 };
 
+use consensus_config::AuthorityIndex;
 use parking_lot::RwLock;
 
-use crate::{context::Context, network::PeerId};
+use crate::{
+    context::Context,
+    error::{ConsensusError, ConsensusResult},
+    network::{NodeId, PeerId},
+};
 
 /// The server types that a peer can support.
 /// A peer may support multiple server types.
@@ -46,33 +51,60 @@ pub(crate) struct PeersPool {
 impl PeersPool {
     // Initializes the peers pool with the committee as peers with the Validator server as available.
     pub(crate) fn new(context: Arc<Context>) -> Arc<Self> {
+        let s = Self {
+            registered_peers: RwLock::new(BTreeMap::new()),
+            context: context.clone(),
+        };
+
         // Register the committee as peers with the Validator server as available.
-        let mut registered_peers = BTreeMap::new();
         for (index, _) in context.committee.authorities() {
-            let peer = PeerId::Validator(index);
-            registered_peers.insert(
-                peer,
-                PeerInfo {
-                    supported_servers: vec![PeerServer::Validator].into_iter().collect(),
-                },
-            );
+            s.register_validator(index, vec![PeerServer::Validator])
+                .unwrap();
         }
 
-        Arc::new(Self {
-            registered_peers: RwLock::new(registered_peers),
-            context,
-        })
+        Arc::new(s)
     }
 
-    /// Registers a peer as available in the pool with its supported servers.
+    /// Registers a validator as available in the pool with its supported servers.
     /// Note: this method will override the peer if it already exists in the pool.
     #[allow(dead_code)]
-    pub(crate) fn register_peer(&self, peer: PeerId, supported_servers: Vec<PeerServer>) {
+    pub(crate) fn register_validator(
+        &self,
+        authority_index: AuthorityIndex,
+        mut supported_servers: Vec<PeerServer>,
+    ) -> ConsensusResult<()> {
+        if !self.context.committee.is_valid_index(authority_index) {
+            return Err(ConsensusError::InvalidAuthorityIndex {
+                index: authority_index,
+                max: self.context.committee.size(),
+            });
+        }
+
+        // We always ensure that whoever registers a validator supports the Validator server.
+        if !supported_servers.contains(&PeerServer::Validator) {
+            supported_servers.push(PeerServer::Validator);
+        }
         let mut peers = self.registered_peers.write();
         peers.insert(
-            peer,
+            PeerId::Validator(authority_index),
             PeerInfo {
                 supported_servers: supported_servers.into_iter().collect(),
+            },
+        );
+
+        Ok(())
+    }
+
+    /// Registers an observer as available in the pool.
+    /// Note that we do not allow observers to register with supported servers other than Observer. This is done for safety
+    /// as only validators are supposed to support both the Validator and Observer servers.
+    #[allow(dead_code)]
+    pub(crate) fn register_observer(&self, node_id: NodeId) {
+        let mut peers = self.registered_peers.write();
+        peers.insert(
+            PeerId::Observer(node_id),
+            PeerInfo {
+                supported_servers: vec![PeerServer::Observer].into_iter().collect(),
             },
         );
     }
@@ -196,17 +228,11 @@ mod tests {
         let context = Arc::new(context);
         let pool = PeersPool::new(context.clone());
 
-        // Register some observers with Observer server
+        // Register some observers
         let observer1 = NetworkKeyPair::generate(&mut rand::thread_rng()).public();
         let observer2 = NetworkKeyPair::generate(&mut rand::thread_rng()).public();
-        pool.register_peer(
-            PeerId::Observer(observer1.clone()),
-            vec![PeerServer::Observer],
-        );
-        pool.register_peer(
-            PeerId::Observer(observer2.clone()),
-            vec![PeerServer::Observer],
-        );
+        pool.register_observer(observer1.clone());
+        pool.register_observer(observer2.clone());
 
         // Check they're available
         assert!(pool.is_peer_available(&PeerId::Observer(observer1.clone())));
@@ -236,7 +262,7 @@ mod tests {
         let observer_peer = PeerId::Observer(observer.clone());
 
         // Register and verify available
-        pool.register_peer(observer_peer.clone(), vec![PeerServer::Observer]);
+        pool.register_observer(observer);
         assert!(pool.is_peer_available(&observer_peer));
 
         // Remove and verify not available
@@ -253,10 +279,7 @@ mod tests {
         let pool = PeersPool::new(context.clone());
 
         let observer = NetworkKeyPair::generate(&mut rand::thread_rng()).public();
-        pool.register_peer(
-            PeerId::Observer(observer.clone()),
-            vec![PeerServer::Observer],
-        );
+        pool.register_observer(observer.clone());
 
         let peers = pool.get_available_peers();
         // As a validator, should have 2 validators (0 and 2, excluding our own 1) and 1 observer
@@ -275,18 +298,13 @@ mod tests {
         let context = Arc::new(context);
         let pool = PeersPool::new(context.clone());
 
-        // Register an observer with Observer server
+        // Register an observer
         let observer1 = NetworkKeyPair::generate(&mut rand::thread_rng()).public();
-        pool.register_peer(
-            PeerId::Observer(observer1.clone()),
-            vec![PeerServer::Observer],
-        );
+        pool.register_observer(observer1.clone());
 
         // Register a validator with Observer server (e.g., it has an observer port open)
-        pool.register_peer(
-            PeerId::Validator(AuthorityIndex::new_for_test(1)),
-            vec![PeerServer::Observer],
-        );
+        pool.register_validator(AuthorityIndex::new_for_test(1), vec![PeerServer::Observer])
+            .unwrap();
 
         let peers = pool.get_available_peers();
         // As an observer, should only see peers that support Observer server
@@ -307,17 +325,15 @@ mod tests {
         let pool = PeersPool::new(context.clone());
 
         // Register a validator with both servers
-        pool.register_peer(
-            PeerId::Validator(AuthorityIndex::new_for_test(0)),
+        pool.register_validator(
+            AuthorityIndex::new_for_test(0),
             vec![PeerServer::Validator, PeerServer::Observer],
-        );
+        )
+        .unwrap();
 
-        // Register an observer with Observer server
+        // Register an observer
         let observer = NetworkKeyPair::generate(&mut rand::thread_rng()).public();
-        pool.register_peer(
-            PeerId::Observer(observer.clone()),
-            vec![PeerServer::Observer],
-        );
+        pool.register_observer(observer.clone());
 
         // As an observer node, get_available_peers() should only return peers that support Observer server
         // (because observers can only communicate with Observer servers)
@@ -348,28 +364,25 @@ mod tests {
         let context = Arc::new(context);
         let pool = PeersPool::new(context.clone());
 
-        // Register observers with different server combinations
+        // Register observers
         let observer1 = NetworkKeyPair::generate(&mut rand::thread_rng()).public();
         let observer2 = NetworkKeyPair::generate(&mut rand::thread_rng()).public();
-        pool.register_peer(
-            PeerId::Observer(observer1.clone()),
-            vec![PeerServer::Observer],
-        );
-        pool.register_peer(
-            PeerId::Observer(observer2.clone()),
-            vec![PeerServer::Observer, PeerServer::Validator],
-        );
+        pool.register_observer(observer1.clone());
+        // Note: register_observer only sets Observer server, cannot add Validator server to observers
+        pool.register_observer(observer2.clone());
 
         // Register a validator with both servers
-        pool.register_peer(
-            PeerId::Validator(AuthorityIndex::new_for_test(1)),
+        pool.register_validator(
+            AuthorityIndex::new_for_test(1),
             vec![PeerServer::Validator, PeerServer::Observer],
-        );
+        )
+        .unwrap();
 
         // Filter for Validator server only
         let validator_peers = pool.get_available_peers_for_servers(&[PeerServer::Validator]);
-        // Should get: validator 1 (registered with both), validators 2 and 3 (assumed), and observer2
-        assert!(validator_peers.len() >= 3);
+        // Should get: validator 1 (registered with both), validators 2 and 3 (default with Validator)
+        // Note: observers cannot have Validator server with the new API
+        assert_eq!(validator_peers.len(), 3);
 
         // Filter for Observer server only
         let observer_peers = pool.get_available_peers_for_servers(&[PeerServer::Observer]);

--- a/consensus/core/src/peers_pool.rs
+++ b/consensus/core/src/peers_pool.rs
@@ -119,7 +119,7 @@ impl PeersPool {
     pub(crate) fn register_observer(&self, node_id: NodeId) {
         let mut peers = self.registered_peers.write();
         peers.insert(
-            PeerId::Observer(node_id),
+            PeerId::Observer(Box::new(node_id)),
             PeerInfo {
                 supported_services: vec![PeerService::Observer].into_iter().collect(),
             },
@@ -250,8 +250,8 @@ mod tests {
         pool.register_observer(observer2.clone());
 
         // Check they're known
-        assert!(pool.is_peer_known(&PeerId::Observer(observer1.clone())));
-        assert!(pool.is_peer_known(&PeerId::Observer(observer2.clone())));
+        assert!(pool.is_peer_known(&PeerId::Observer(Box::new(observer1.clone()))));
+        assert!(pool.is_peer_known(&PeerId::Observer(Box::new(observer2.clone()))));
 
         // Validators should be known (except our own)
         assert!(!pool.is_peer_known(&PeerId::Validator(AuthorityIndex::new_for_test(0))));
@@ -274,7 +274,7 @@ mod tests {
         let pool = PeersPool::new(context.clone());
 
         let observer = NetworkKeyPair::generate(&mut rand::thread_rng()).public();
-        let observer_peer = PeerId::Observer(observer.clone());
+        let observer_peer = PeerId::Observer(Box::new(observer.clone()));
 
         // Register and verify known
         pool.register_observer(observer);
@@ -301,7 +301,7 @@ mod tests {
         assert_eq!(peers.len(), 3);
         assert!(peers.contains(&PeerId::Validator(AuthorityIndex::new_for_test(0))));
         assert!(peers.contains(&PeerId::Validator(AuthorityIndex::new_for_test(2))));
-        assert!(peers.contains(&PeerId::Observer(observer)));
+        assert!(peers.contains(&PeerId::Observer(Box::new(observer))));
         assert!(!peers.contains(&PeerId::Validator(AuthorityIndex::new_for_test(1))));
     }
 
@@ -324,7 +324,7 @@ mod tests {
         let peers = pool.get_known_peers();
         // As an observer, should only see peers that support Observer server
         assert_eq!(peers.len(), 2);
-        assert!(peers.contains(&PeerId::Observer(observer1)));
+        assert!(peers.contains(&PeerId::Observer(Box::new(observer1))));
         assert!(peers.contains(&PeerId::Validator(AuthorityIndex::new_for_test(1))));
 
         // Should not see validators that only support Validator server
@@ -355,7 +355,7 @@ mod tests {
         let known_peers = pool.get_known_peers();
         assert_eq!(known_peers.len(), 2); // The validator with Observer server and the observer
         assert!(known_peers.contains(&PeerId::Validator(AuthorityIndex::new_for_test(0))));
-        assert!(known_peers.contains(&PeerId::Observer(observer.clone())));
+        assert!(known_peers.contains(&PeerId::Observer(Box::new(observer.clone()))));
 
         // Direct filtering for Validator server should still return the peers that support it,
         // but this doesn't check compatibility
@@ -368,7 +368,7 @@ mod tests {
         let observer_peers = pool.get_known_peers_for_services(&[PeerService::Observer]);
         assert_eq!(observer_peers.len(), 2); // The validator with Observer server and the observer
         assert!(observer_peers.contains(&PeerId::Validator(AuthorityIndex::new_for_test(0))));
-        assert!(observer_peers.contains(&PeerId::Observer(observer)));
+        assert!(observer_peers.contains(&PeerId::Observer(Box::new(observer))));
     }
 
     #[tokio::test]
@@ -403,8 +403,8 @@ mod tests {
         let observer_peers = pool.get_known_peers_for_services(&[PeerService::Observer]);
         // Should get: observer1, observer2, and validator 1
         assert_eq!(observer_peers.len(), 3);
-        assert!(observer_peers.contains(&PeerId::Observer(observer1)));
-        assert!(observer_peers.contains(&PeerId::Observer(observer2)));
+        assert!(observer_peers.contains(&PeerId::Observer(Box::new(observer1))));
+        assert!(observer_peers.contains(&PeerId::Observer(Box::new(observer2))));
         assert!(observer_peers.contains(&PeerId::Validator(AuthorityIndex::new_for_test(1))));
     }
 }

--- a/consensus/core/src/peers_pool.rs
+++ b/consensus/core/src/peers_pool.rs
@@ -50,7 +50,7 @@ pub(crate) struct PeersPool {
 
 impl PeersPool {
     // Initializes the peers pool with the committee as peers with the Validator server as available.
-    pub(crate) fn new(context: Arc<Context>) -> Arc<Self> {
+    pub(crate) fn new(context: Arc<Context>) -> Self {
         let s = Self {
             registered_peers: RwLock::new(BTreeMap::new()),
             context: context.clone(),
@@ -62,7 +62,7 @@ impl PeersPool {
                 .unwrap();
         }
 
-        Arc::new(s)
+        s
     }
 
     /// Registers a validator as available in the pool with its supported servers.

--- a/consensus/core/src/peers_pool.rs
+++ b/consensus/core/src/peers_pool.rs
@@ -235,8 +235,8 @@ mod tests {
     use super::*;
     use consensus_config::{AuthorityIndex, NetworkKeyPair};
 
-    #[test]
-    fn test_peers_pool_basic() {
+    #[tokio::test]
+    async fn test_peers_pool_basic() {
         let (mut context, _) = Context::new_for_test(4);
         context.own_index = AuthorityIndex::new_for_test(0);
         // This is a validator node (own_index is within committee range)
@@ -267,8 +267,8 @@ mod tests {
         assert_eq!(observer_peers.len(), 2);
     }
 
-    #[test]
-    fn test_peers_pool_remove() {
+    #[tokio::test]
+    async fn test_peers_pool_remove() {
         let (context, _) = Context::new_for_test(4);
         let context = Arc::new(context);
         let pool = PeersPool::new(context.clone());
@@ -285,8 +285,8 @@ mod tests {
         assert!(!pool.is_peer_known(&observer_peer));
     }
 
-    #[test]
-    fn test_get_known_peers_as_validator() {
+    #[tokio::test]
+    async fn test_get_known_peers_as_validator() {
         let (mut context, _) = Context::new_for_test(3);
         context.own_index = AuthorityIndex::new_for_test(1);
         // This is a validator node (own_index is within committee range)
@@ -305,8 +305,8 @@ mod tests {
         assert!(!peers.contains(&PeerId::Validator(AuthorityIndex::new_for_test(1))));
     }
 
-    #[test]
-    fn test_get_known_peers_as_observer() {
+    #[tokio::test]
+    async fn test_get_known_peers_as_observer() {
         let (mut context, _) = Context::new_for_test(3);
         // Set own_index to a value outside committee range to simulate an observer node
         context.own_index = AuthorityIndex::new_for_test(10);
@@ -331,8 +331,8 @@ mod tests {
         assert!(!peers.contains(&PeerId::Validator(AuthorityIndex::new_for_test(2))));
     }
 
-    #[test]
-    fn test_compatible_server_filtering() {
+    #[tokio::test]
+    async fn test_compatible_server_filtering() {
         let (mut context, _) = Context::new_for_test(3);
         // Set as an observer node
         context.own_index = AuthorityIndex::new_for_test(10);
@@ -371,8 +371,8 @@ mod tests {
         assert!(observer_peers.contains(&PeerId::Observer(observer)));
     }
 
-    #[test]
-    fn test_server_filtering() {
+    #[tokio::test]
+    async fn test_server_filtering() {
         let (mut context, _) = Context::new_for_test(4);
         context.own_index = AuthorityIndex::new_for_test(0);
         // This is a validator node (own_index is within committee range)

--- a/consensus/core/src/synchronizer.rs
+++ b/consensus/core/src/synchronizer.rs
@@ -298,9 +298,10 @@ where
         let mut fetch_block_senders = BTreeMap::new();
         let mut tasks = JoinSet::new();
 
-        // Create fetch tasks for all available peers (validators and observers)
-        let available_peers = peers_pool.get_available_peers();
-        for peer in available_peers {
+        // Create fetch tasks for all known peers (validators and observers)
+        // TODO: refactor to update the sender tasks based on the registered/removed pool peers.
+        let known_peers = peers_pool.get_known_peers();
+        for peer in known_peers {
             let (sender, receiver) =
                 channel("consensus_synchronizer_fetches", FETCH_BLOCKS_CONCURRENCY);
             let fetch_blocks_from_peer_async = Self::fetch_blocks_from_peer(
@@ -374,7 +375,7 @@ where
                     match command {
                         Command::FetchBlocks{ missing_block_refs, peer, result } => {
                             // Check if peer is available. This check also makes sure that we are not trying to fetch from ourselves.
-                            if !self.peers_pool.is_peer_available(&peer) {
+                            if !self.peers_pool.is_peer_known(&peer) {
                                 result.send(Err(ConsensusError::PeerUnavailable(format!("{:?}", peer)))).ok();
                                 continue;
                             }
@@ -398,17 +399,14 @@ where
                             let r = self
                                 .fetch_block_senders
                                 .get(&peer)
-                                .ok_or(ConsensusError::PeerNotFound(format!("{:?}", peer)))
+                                .ok_or(ConsensusError::PeerNotFound(format!("Peer {} not found in fetch_block_senders", peer)))
                                 .and_then(|sender| {
                                     sender
                                         .try_send(blocks_guard)
                                         .map_err(|err| {
                                             match err {
                                                 TrySendError::Full(_) => {
-                                                    let peer_name = match peer.as_ref() {
-                                                        PeerId::Validator(index) => self.context.committee.authority(*index).hostname.as_str(),
-                                                        PeerId::Observer(_) => "observer",
-                                                    };
+                                                    let peer_name = peer.labelname(&self.context);
                                                     self.context
                                                         .metrics
                                                         .node_metrics
@@ -503,10 +501,6 @@ where
         _peers_pool: Arc<PeersPool>,
     ) {
         const MAX_RETRIES: u32 = 3;
-        let peer_name = match &peer {
-            PeerId::Validator(index) => context.committee.authority(*index).hostname.clone(),
-            PeerId::Observer(node_id) => format!("observer_{:?}", node_id),
-        };
         let mut requests = FuturesUnordered::new();
 
         loop {
@@ -531,16 +525,16 @@ where
                                 round_tracker.clone(),
                                 "live"
                             ).await {
-                                warn!("Error while processing fetched blocks from peer {peer_name}: {err}");
-                                context.metrics.node_metrics.synchronizer_process_fetched_failures.with_label_values(&[peer_name.as_str(), "live"]).inc();
+                                warn!("Error while processing fetched blocks from peer {}: {err}", peer.hostname(&context));
+                                context.metrics.node_metrics.synchronizer_process_fetched_failures.with_label_values(&[peer.labelname(&context).as_str(), "live"]).inc();
                             }
                         },
                         Err(_) => {
-                            context.metrics.node_metrics.synchronizer_fetch_failures.with_label_values(&[peer_name.as_str(), "live"]).inc();
+                            context.metrics.node_metrics.synchronizer_fetch_failures.with_label_values(&[peer.labelname(&context).as_str(), "live"]).inc();
                             if retries <= MAX_RETRIES {
                                 requests.push(Self::fetch_blocks_request(network_client.clone(), peer.clone(), blocks_guard, fetch_after_rounds, true, FETCH_REQUEST_TIMEOUT, retries))
                             } else {
-                                warn!("Max retries {retries} reached while trying to fetch blocks from peer {peer_name}.");
+                                warn!("Max retries {retries} reached while trying to fetch blocks from peer {}.", peer.hostname(&context));
                                 // we don't necessarily need to do, but dropping the guard here to unlock the blocks
                                 drop(blocks_guard);
                             }
@@ -548,7 +542,7 @@ where
                     }
                 },
                 else => {
-                    info!("Fetching blocks from peer {peer} task will now abort.");
+                    info!("Fetching blocks from peer {} task will now abort.", peer.hostname(&context));
                     break;
                 }
             }
@@ -614,13 +608,9 @@ where
         }
 
         let metrics = &context.metrics.node_metrics;
-        let peer_name = match &peer {
-            PeerId::Validator(index) => context.committee.authority(*index).hostname.as_str(),
-            PeerId::Observer(_) => "observer",
-        };
         metrics
             .synchronizer_fetched_blocks_by_peer
-            .with_label_values(&[peer_name, sync_method])
+            .with_label_values(&[peer.labelname(&context).as_str(), sync_method])
             .inc_by(blocks.len() as u64);
         for block in &blocks {
             let block_hostname = &context.committee.authority(block.author()).hostname;
@@ -702,7 +692,7 @@ where
             let (verified_block, reject_txn_votes) = block_verifier
                 .verify_and_vote(signed_block, serialized_block)
                 .tap_err(|e| {
-                    let peer_name = peer.hostname(context);
+                    let peer_label = peer.labelname(context);
                     let peer_type = match &peer {
                         PeerId::Validator(_) => "validator",
                         PeerId::Observer(_) => "observer",
@@ -712,13 +702,13 @@ where
                         .node_metrics
                         .invalid_blocks
                         .with_label_values(&[
-                            peer_name.as_str(),
+                            peer_label.as_str(),
                             "synchronizer",
                             e.clone().name(),
                             peer_type,
                         ])
                         .inc();
-                    info!("Invalid block received from {:?}: {}", peer, e);
+                    info!("Invalid block received from {}: {}", peer, e);
                 })?;
 
             // TODO: improve efficiency, maybe suspend and continue processing the block asynchronously.
@@ -1163,12 +1153,8 @@ where
 
         // Pick a random peer (excluding self).
         // Get available peers from the PeersPool
-        let mut peers = peers_pool.get_available_peers();
-        let available_peers_count = peers.len();
-        assert!(
-            available_peers_count > 0,
-            "No available peers to fetch blocks from. This shouldn't really happen."
-        );
+        let mut peers = peers_pool.get_known_peers();
+        assert!(!peers.is_empty(), "No known peers to fetch blocks from");
 
         if cfg!(not(test)) {
             peers.shuffle(&mut ThreadRng::default());
@@ -1239,20 +1225,16 @@ where
                 .push(*block_ref);
         }
 
-        // Get available peers from the PeersPool
-        let mut peers = peers_pool.get_available_peers();
+        // Get known peers from the PeersPool
+        let mut peers = peers_pool.get_known_peers();
 
         // Distribute the same number of authorities into each peer to sync.
-        // Use the number of available peers from the pool, capped at MAX_PERIODIC_SYNC_PEERS
-        let available_peers_count = peers.len();
-        assert!(
-            available_peers_count > 0,
-            "No available peers to fetch blocks from. This shouldn't really happen."
-        );
+        // Use the number of known peers from the pool, capped at MAX_PERIODIC_SYNC_PEERS
+        assert!(!peers.is_empty(), "No known peers to fetch blocks from");
 
         let num_authorities_per_peer = authorities
             .len()
-            .div_ceil(available_peers_count.min(MAX_PERIODIC_SYNC_PEERS));
+            .div_ceil(peers.len().min(MAX_PERIODIC_SYNC_PEERS));
 
         // Update metrics related to missing blocks.
         let mut missing_blocks_per_authority = vec![0; context.committee.size()];
@@ -1301,7 +1283,7 @@ where
                 debug_fatal!("No more peers left to fetch blocks!");
                 break;
             };
-            let peer_hostname = peer.hostname(&context);
+            let peer_name = peer.hostname(&context);
             // Fetch from the lowest round missing blocks to ensure progress.
             // This may reduce efficiency and increase the chance of duplicated data transfer in edge cases.
             let block_refs = batch
@@ -1319,7 +1301,7 @@ where
             {
                 info!(
                     "Periodic sync of {} missing blocks from peer {} {:?}: {}",
-                    peer_hostname.as_str(),
+                    peer_name.as_str(),
                     block_refs.len(),
                     peer,
                     block_refs

--- a/consensus/core/src/synchronizer.rs
+++ b/consensus/core/src/synchronizer.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use std::{
-    collections::{BTreeMap, BTreeSet, HashMap},
+    collections::{BTreeMap, BTreeSet},
     sync::Arc,
     time::Duration,
 };
@@ -27,7 +27,7 @@ use tokio::{
     task::{JoinError, JoinSet},
     time::{Instant, sleep, sleep_until, timeout},
 };
-use tracing::{debug, error, info, trace, warn};
+use tracing::{debug, info, trace, warn};
 
 use crate::{
     BlockAPI,
@@ -39,6 +39,7 @@ use crate::{
     dag_state::DagState,
     error::{ConsensusError, ConsensusResult},
     network::{ObserverNetworkClient, PeerId, SynchronizerClient, ValidatorNetworkClient},
+    peers_pool::PeersPool,
     round_tracker::RoundTracker,
 };
 use crate::{
@@ -64,51 +65,49 @@ const COMMIT_PROGRESS_TIMEOUT: Duration = Duration::from_secs(10);
 struct BlocksGuard {
     map: Arc<InflightBlocksMap>,
     block_refs: BTreeSet<BlockRef>,
-    peer: AuthorityIndex,
+    peer: PeerId,
 }
 
 impl Drop for BlocksGuard {
     fn drop(&mut self) {
-        self.map.unlock_blocks(&self.block_refs, self.peer);
+        self.map.unlock_blocks(&self.block_refs, self.peer.clone());
     }
 }
 
-// Keeps a mapping between the missing blocks that have been instructed to be fetched and the authorities
-// that are currently fetching them. For a block ref there is a maximum number of authorities that can
-// concurrently fetch it. The authority ids that are currently fetching a block are set on the corresponding
+// Keeps a mapping between the missing blocks that have been instructed to be fetched and the peers
+// that are currently fetching them. For a block ref there is a maximum number of peers that can
+// concurrently fetch it. The peer ids that are currently fetching a block are set on the corresponding
 // `BTreeSet` and basically they act as "locks".
 struct InflightBlocksMap {
-    inner: Mutex<HashMap<BlockRef, BTreeSet<AuthorityIndex>>>,
+    inner: Mutex<BTreeMap<BlockRef, BTreeSet<PeerId>>>,
 }
 
 impl InflightBlocksMap {
     fn new() -> Arc<Self> {
         Arc::new(Self {
-            inner: Mutex::new(HashMap::new()),
+            inner: Mutex::new(BTreeMap::new()),
         })
     }
 
-    /// Locks the blocks to be fetched for the assigned `peer_index`. We want to avoid re-fetching the
-    /// missing blocks from too many authorities at the same time, thus we limit the concurrency
+    /// Locks the blocks to be fetched for the assigned `peer`. We want to avoid re-fetching the
+    /// missing blocks from too many peers at the same time, thus we limit the concurrency
     /// per block by attempting to lock per block. If a block is already fetched by the maximum allowed
-    /// number of authorities, then the block ref will not be included in the returned set. The method
+    /// number of peers, then the block ref will not be included in the returned set. The method
     /// returns all the block refs that have been successfully locked and allowed to be fetched.
     fn lock_blocks(
         self: &Arc<Self>,
         missing_block_refs: BTreeSet<BlockRef>,
-        peer: AuthorityIndex,
+        peer: PeerId,
     ) -> Option<BlocksGuard> {
         let mut blocks = BTreeSet::new();
         let mut inner = self.inner.lock();
 
         for block_ref in missing_block_refs {
-            // check that the number of authorities that are already instructed to fetch the block is not
-            // higher than the allowed and the `peer_index` has not already been instructed to do that.
-            let authorities = inner.entry(block_ref).or_default();
-            if authorities.len() < MAX_AUTHORITIES_TO_FETCH_PER_BLOCK
-                && authorities.get(&peer).is_none()
-            {
-                assert!(authorities.insert(peer));
+            // check that the number of peers that are already instructed to fetch the block is not
+            // higher than the allowed and the `peer` has not already been instructed to do that.
+            let peers = inner.entry(block_ref).or_default();
+            if peers.len() < MAX_AUTHORITIES_TO_FETCH_PER_BLOCK && peers.get(&peer).is_none() {
+                assert!(peers.insert(peer.clone()));
                 blocks.insert(block_ref);
             }
         }
@@ -127,18 +126,18 @@ impl InflightBlocksMap {
     /// Unlocks the provided block references for the given `peer`. The unlocking is strict, meaning that
     /// if this method is called for a specific block ref and peer more times than the corresponding lock
     /// has been called, it will panic.
-    fn unlock_blocks(self: &Arc<Self>, block_refs: &BTreeSet<BlockRef>, peer: AuthorityIndex) {
+    fn unlock_blocks(self: &Arc<Self>, block_refs: &BTreeSet<BlockRef>, peer: PeerId) {
         // Now mark all the blocks as fetched from the map
         let mut blocks_to_fetch = self.inner.lock();
         for block_ref in block_refs {
-            let authorities = blocks_to_fetch
+            let peers = blocks_to_fetch
                 .get_mut(block_ref)
                 .expect("Should have found a non empty map");
 
-            assert!(authorities.remove(&peer), "Peer index should be present!");
+            assert!(peers.remove(&peer), "Peer should be present!");
 
             // if the last one then just clean up
-            if authorities.is_empty() {
+            if peers.is_empty() {
                 blocks_to_fetch.remove(block_ref);
             }
         }
@@ -150,7 +149,7 @@ impl InflightBlocksMap {
     fn swap_locks(
         self: &Arc<Self>,
         blocks_guard: BlocksGuard,
-        peer: AuthorityIndex,
+        peer: PeerId,
     ) -> Option<BlocksGuard> {
         let block_refs = blocks_guard.block_refs.clone();
 
@@ -171,7 +170,7 @@ impl InflightBlocksMap {
 enum Command {
     FetchBlocks {
         missing_block_refs: BTreeSet<BlockRef>,
-        peer_index: AuthorityIndex,
+        peer: Box<PeerId>,
         result: oneshot::Sender<Result<(), ConsensusError>>,
     },
     FetchOwnLastBlock,
@@ -185,17 +184,17 @@ pub(crate) struct SynchronizerHandle {
 
 impl SynchronizerHandle {
     /// Explicitly asks from the synchronizer to fetch the blocks - provided the block_refs set - from
-    /// the peer authority.
+    /// the peer.
     pub(crate) async fn fetch_blocks(
         &self,
         missing_block_refs: BTreeSet<BlockRef>,
-        peer_index: AuthorityIndex,
+        peer: PeerId,
     ) -> ConsensusResult<()> {
         let (sender, receiver) = oneshot::channel();
         self.commands_sender
             .send(Command::FetchBlocks {
                 missing_block_refs,
-                peer_index,
+                peer: Box::new(peer),
                 result: sender,
             })
             .await
@@ -242,7 +241,7 @@ pub(crate) struct Synchronizer<
 > {
     context: Arc<Context>,
     commands_receiver: Receiver<Command>,
-    fetch_block_senders: BTreeMap<AuthorityIndex, Sender<BlocksGuard>>,
+    fetch_block_senders: BTreeMap<PeerId, Sender<BlocksGuard>>,
     core_dispatcher: Arc<D>,
     commit_vote_monitor: Arc<CommitVoteMonitor>,
     dag_state: Arc<RwLock<DagState>>,
@@ -258,6 +257,7 @@ pub(crate) struct Synchronizer<
     last_commit_change_time: Instant,
     // When commit is not progressing, commit sync fails over to periodic sync for catchup.
     commit_sync_failover: bool,
+    peers_pool: Arc<PeersPool>,
 }
 
 impl<V, D, VC, OC> Synchronizer<V, D, VC, OC>
@@ -281,18 +281,22 @@ where
         let (commands_sender, commands_receiver) =
             channel("consensus_synchronizer_commands", 1_000);
         let inflight_blocks_map = InflightBlocksMap::new();
+        let peers_pool = PeersPool::new(context.clone());
 
         // Spawn the tasks to fetch the blocks from the others
         let mut fetch_block_senders = BTreeMap::new();
         let mut tasks = JoinSet::new();
+
+        // Create fetch tasks for validators
         for (index, _) in context.committee.authorities() {
             if index == context.own_index {
                 continue;
             }
+            let peer = PeerId::Validator(index);
             let (sender, receiver) =
                 channel("consensus_synchronizer_fetches", FETCH_BLOCKS_CONCURRENCY);
-            let fetch_blocks_from_authority_async = Self::fetch_blocks_from_authority(
-                index,
+            let fetch_blocks_from_peer_async = Self::fetch_blocks_from_peer(
+                peer.clone(),
                 network_client.clone(),
                 block_verifier.clone(),
                 transaction_vote_tracker.clone(),
@@ -303,9 +307,10 @@ where
                 receiver,
                 commands_sender.clone(),
                 round_tracker.clone(),
+                peers_pool.clone(),
             );
-            tasks.spawn(monitored_future!(fetch_blocks_from_authority_async));
-            fetch_block_senders.insert(index, sender);
+            tasks.spawn(monitored_future!(fetch_blocks_from_peer_async));
+            fetch_block_senders.insert(peer, sender);
         }
 
         let commands_sender_clone = commands_sender.clone();
@@ -336,6 +341,7 @@ where
                 last_changed_commit_index: 0,
                 last_commit_change_time: Instant::now(),
                 commit_sync_failover: false,
+                peers_pool,
             };
             s.run().await;
         }));
@@ -358,9 +364,10 @@ where
             tokio::select! {
                 Some(command) = self.commands_receiver.recv() => {
                     match command {
-                        Command::FetchBlocks{ missing_block_refs, peer_index, result } => {
-                            if peer_index == self.context.own_index {
-                                error!("We should never attempt to fetch blocks from our own node");
+                        Command::FetchBlocks{ missing_block_refs, peer, result } => {
+                            // Check if peer is available. This check also makes sure that we are not trying to fetch from ourselves.
+                            if !self.peers_pool.is_peer_available(&peer) {
+                                result.send(Err(ConsensusError::PeerUnavailable(format!("{:?}", peer)))).ok();
                                 continue;
                             }
 
@@ -372,7 +379,7 @@ where
                                 .take(self.context.parameters.max_blocks_per_sync)
                                 .collect();
 
-                            let blocks_guard = self.inflight_blocks_map.lock_blocks(missing_block_refs, peer_index);
+                            let blocks_guard = self.inflight_blocks_map.lock_blocks(missing_block_refs, (*peer).clone());
                             let Some(blocks_guard) = blocks_guard else {
                                 result.send(Ok(())).ok();
                                 continue;
@@ -382,23 +389,29 @@ where
                             // synchronization task will handle any still missing blocks in next run.
                             let r = self
                                 .fetch_block_senders
-                                .get(&peer_index)
-                                .expect("Fatal error, sender should be present")
-                                .try_send(blocks_guard)
-                                .map_err(|err| {
-                                    match err {
-                                        TrySendError::Full(_) => {
-                                            let peer_hostname = &self.context.committee.authority(peer_index).hostname;
-                                            self.context
-                                                .metrics
-                                                .node_metrics
-                                                .synchronizer_skipped_fetch_requests
-                                                .with_label_values(&[peer_hostname])
-                                                .inc();
-                                            ConsensusError::SynchronizerSaturated(peer_index)
-                                        },
-                                        TrySendError::Closed(_) => ConsensusError::Shutdown
-                                    }
+                                .get(&peer)
+                                .ok_or(ConsensusError::PeerNotFound(format!("{:?}", peer)))
+                                .and_then(|sender| {
+                                    sender
+                                        .try_send(blocks_guard)
+                                        .map_err(|err| {
+                                            match err {
+                                                TrySendError::Full(_) => {
+                                                    let peer_name = match peer.as_ref() {
+                                                        PeerId::Validator(index) => self.context.committee.authority(*index).hostname.as_str(),
+                                                        PeerId::Observer(_) => "observer",
+                                                    };
+                                                    self.context
+                                                        .metrics
+                                                        .node_metrics
+                                                        .synchronizer_skipped_fetch_requests
+                                                        .with_label_values(&[peer_name])
+                                                        .inc();
+                                                    ConsensusError::SynchronizerSaturated(format!("{:?}", peer))
+                                                },
+                                                TrySendError::Closed(_) => ConsensusError::Shutdown
+                                            }
+                                        })
                                 });
 
                             result.send(r).ok();
@@ -467,8 +480,8 @@ where
         }
     }
 
-    async fn fetch_blocks_from_authority(
-        peer_index: AuthorityIndex,
+    async fn fetch_blocks_from_peer(
+        peer: PeerId,
         network_client: Arc<SynchronizerClient<VC, OC>>,
         block_verifier: Arc<V>,
         transaction_vote_tracker: TransactionVoteTracker,
@@ -479,9 +492,13 @@ where
         mut receiver: Receiver<BlocksGuard>,
         commands_sender: Sender<Command>,
         round_tracker: Arc<RwLock<RoundTracker>>,
+        _peers_pool: Arc<PeersPool>,
     ) {
         const MAX_RETRIES: u32 = 3;
-        let peer_hostname = &context.committee.authority(peer_index).hostname;
+        let peer_name = match &peer {
+            PeerId::Validator(index) => context.committee.authority(*index).hostname.clone(),
+            PeerId::Observer(node_id) => format!("observer_{:?}", node_id),
+        };
         let mut requests = FuturesUnordered::new();
 
         loop {
@@ -489,13 +506,13 @@ where
                 Some(blocks_guard) = receiver.recv(), if requests.len() < FETCH_BLOCKS_CONCURRENCY => {
                     let fetch_after_rounds = Self::get_fetch_after_rounds(&context, dag_state.clone());
 
-                    requests.push(Self::fetch_blocks_request(network_client.clone(), peer_index, blocks_guard, fetch_after_rounds, true, FETCH_REQUEST_TIMEOUT, 1))
+                    requests.push(Self::fetch_blocks_request(network_client.clone(), peer.clone(), blocks_guard, fetch_after_rounds, true, FETCH_REQUEST_TIMEOUT, 1))
                 },
                 Some((response, blocks_guard, retries, _peer, fetch_after_rounds)) = requests.next() => {
                     match response {
                         Ok(blocks) => {
                             if let Err(err) = Self::process_fetched_blocks(blocks,
-                                peer_index,
+                                fetch_peer.clone(),
                                 blocks_guard,
                                 core_dispatcher.clone(),
                                 block_verifier.clone(),
@@ -506,16 +523,16 @@ where
                                 round_tracker.clone(),
                                 "live"
                             ).await {
-                                warn!("Error while processing fetched blocks from peer {peer_index} {peer_hostname}: {err}");
-                                context.metrics.node_metrics.synchronizer_process_fetched_failures.with_label_values(&[peer_hostname.as_str(), "live"]).inc();
+                                warn!("Error while processing fetched blocks from peer {fetch_peer} {peer_name}: {err}");
+                                context.metrics.node_metrics.synchronizer_process_fetched_failures.with_label_values(&[peer_name.as_str(), "live"]).inc();
                             }
                         },
                         Err(_) => {
-                            context.metrics.node_metrics.synchronizer_fetch_failures.with_label_values(&[peer_hostname.as_str(), "live"]).inc();
+                            context.metrics.node_metrics.synchronizer_fetch_failures.with_label_values(&[peer_name.as_str(), "live"]).inc();
                             if retries <= MAX_RETRIES {
-                                requests.push(Self::fetch_blocks_request(network_client.clone(), peer_index, blocks_guard, fetch_after_rounds, true, FETCH_REQUEST_TIMEOUT, retries))
+                                requests.push(Self::fetch_blocks_request(network_client.clone(), fetch_peer.clone(), blocks_guard, fetch_after_rounds, true, FETCH_REQUEST_TIMEOUT, retries))
                             } else {
-                                warn!("Max retries {retries} reached while trying to fetch blocks from peer {peer_index} {peer_hostname}.");
+                                warn!("Max retries {retries} reached while trying to fetch blocks from peer {fetch_peer} {peer_name}.");
                                 // we don't necessarily need to do, but dropping the guard here to unlock the blocks
                                 drop(blocks_guard);
                             }
@@ -523,18 +540,18 @@ where
                     }
                 },
                 else => {
-                    info!("Fetching blocks from authority {peer_index} task will now abort.");
+                    info!("Fetching blocks from peer {peer} task will now abort.");
                     break;
                 }
             }
         }
     }
 
-    /// Processes the requested raw fetched blocks from peer `peer_index`. If no error is returned then
+    /// Processes the requested raw fetched blocks from peer. If no error is returned then
     /// the verified blocks are immediately sent to Core for processing.
     async fn process_fetched_blocks(
         mut serialized_blocks: Vec<Bytes>,
-        peer_index: AuthorityIndex,
+        peer: PeerId,
         requested_blocks_guard: BlocksGuard,
         core_dispatcher: Arc<D>,
         block_verifier: Arc<V>,
@@ -557,13 +574,14 @@ where
             .spawn_blocking({
                 let block_verifier = block_verifier.clone();
                 let context = context.clone();
+                let peer = peer.clone();
                 move || {
                     Self::verify_blocks(
                         serialized_blocks,
                         block_verifier,
                         transaction_vote_tracker,
                         &context,
-                        peer_index,
+                        peer,
                     )
                 }
             })
@@ -588,10 +606,13 @@ where
         }
 
         let metrics = &context.metrics.node_metrics;
-        let peer_hostname = &context.committee.authority(peer_index).hostname;
+        let peer_name = match &peer {
+            PeerId::Validator(index) => context.committee.authority(*index).hostname.as_str(),
+            PeerId::Observer(_) => "observer",
+        };
         metrics
             .synchronizer_fetched_blocks_by_peer
-            .with_label_values(&[peer_hostname.as_str(), sync_method])
+            .with_label_values(&[peer_name, sync_method])
             .inc_by(blocks.len() as u64);
         for block in &blocks {
             let block_hostname = &context.committee.authority(block.author()).hostname;
@@ -602,8 +623,9 @@ where
         }
 
         debug!(
-            "Synced {} missing blocks from peer {peer_index} {peer_hostname}: {}",
+            "Synced {} missing blocks from peer {:?}: {}",
             blocks.len(),
+            peer,
             blocks.iter().map(|b| b.reference().to_string()).join(", "),
         );
 
@@ -660,7 +682,7 @@ where
         block_verifier: Arc<V>,
         transaction_vote_tracker: TransactionVoteTracker,
         context: &Context,
-        peer_index: AuthorityIndex,
+        peer: PeerId,
     ) -> ConsensusResult<Vec<VerifiedBlock>> {
         let mut verified_blocks = Vec::new();
         let mut voted_blocks = Vec::new();
@@ -672,14 +694,19 @@ where
             let (verified_block, reject_txn_votes) = block_verifier
                 .verify_and_vote(signed_block, serialized_block)
                 .tap_err(|e| {
-                    let hostname = context.committee.authority(peer_index).hostname.clone();
+                    let peer_name = match &peer {
+                        PeerId::Validator(index) => {
+                            context.committee.authority(*index).hostname.clone()
+                        }
+                        PeerId::Observer(_) => "observer".to_string(),
+                    };
                     context
                         .metrics
                         .node_metrics
                         .invalid_blocks
-                        .with_label_values(&[hostname.as_str(), "synchronizer", e.clone().name()])
+                        .with_label_values(&[peer_name.as_str(), "synchronizer", e.clone().name()])
                         .inc();
-                    info!("Invalid block received from {}: {}", peer_index, e);
+                    info!("Invalid block received from {:?}: {}", peer, e);
                 })?;
 
             // TODO: improve efficiency, maybe suspend and continue processing the block asynchronously.
@@ -718,7 +745,7 @@ where
 
     async fn fetch_blocks_request(
         network_client: Arc<SynchronizerClient<VC, OC>>,
-        peer: AuthorityIndex,
+        peer: PeerId,
         blocks_guard: BlocksGuard,
         fetch_after_rounds: Vec<Round>,
         fetch_missing_ancestors: bool,
@@ -728,15 +755,14 @@ where
         ConsensusResult<Vec<Bytes>>,
         BlocksGuard,
         u32,
-        AuthorityIndex,
+        PeerId,
         Vec<Round>,
     ) {
-        use crate::network::PeerId;
         let start = Instant::now();
         let resp = timeout(
             request_timeout,
             network_client.fetch_blocks(
-                PeerId::Validator(peer),
+                peer.clone(),
                 blocks_guard
                     .block_refs
                     .clone()
@@ -993,7 +1019,7 @@ where
 
                     if let Err(err) = Self::process_fetched_blocks(
                         fetched_blocks,
-                        peer,
+                        peer.clone(),
                         blocks_guard,
                         core_dispatcher.clone(),
                         block_verifier.clone(),
@@ -1007,16 +1033,20 @@ where
                     .await
                     {
                         warn!(
-                            "Error occurred while processing fetched blocks from peer {peer}: {err}"
+                            "Error occurred while processing fetched blocks from peer {:?}: {err}",
+                            peer
                         );
+                        let peer_name = match &peer {
+                            PeerId::Validator(index) => {
+                                context.committee.authority(*index).hostname.as_str()
+                            }
+                            PeerId::Observer(_) => "observer",
+                        };
                         context
                             .metrics
                             .node_metrics
                             .synchronizer_process_fetched_failures
-                            .with_label_values(&[
-                                context.committee.authority(peer).hostname.as_str(),
-                                "periodic",
-                            ])
+                            .with_label_values(&[peer_name, "periodic"])
                             .inc();
                     }
                 }
@@ -1112,7 +1142,7 @@ where
         inflight_blocks: Arc<InflightBlocksMap>,
         network_client: Arc<SynchronizerClient<VC, OC>>,
         dag_state: Arc<RwLock<DagState>>,
-    ) -> Vec<(BlocksGuard, Vec<Bytes>, AuthorityIndex)> {
+    ) -> Vec<(BlocksGuard, Vec<Bytes>, PeerId)> {
         let fetch_after_rounds = Self::get_fetch_after_rounds(&context, dag_state.clone());
 
         // Pick a random peer (excluding self).
@@ -1155,24 +1185,24 @@ where
         let blocks_guard = BlocksGuard {
             map: inflight_blocks,
             block_refs: BTreeSet::new(),
-            peer,
+            peer: PeerId::Validator(peer),
         };
 
-        vec![(blocks_guard, serialized_blocks, peer)]
+        vec![(blocks_guard, serialized_blocks, PeerId::Validator(peer))]
     }
 
     /// Fetches the `missing_blocks` from peers. Requests the same number of authorities with missing blocks from each peer.
     /// Each response from peer can contain the requested blocks, and additional blocks from the last accepted round for
     /// authorities with missing blocks.
     /// Each element of the vector is a tuple which contains the requested missing block refs, the returned blocks and
-    /// the peer authority index.
+    /// the peer.
     async fn fetch_blocks_from_authorities(
         context: Arc<Context>,
         inflight_blocks: Arc<InflightBlocksMap>,
         network_client: Arc<SynchronizerClient<VC, OC>>,
         missing_blocks: BTreeSet<BlockRef>,
         dag_state: Arc<RwLock<DagState>>,
-    ) -> Vec<(BlocksGuard, Vec<Bytes>, AuthorityIndex)> {
+    ) -> Vec<(BlocksGuard, Vec<Bytes>, PeerId)> {
         // Preliminary truncation of missing blocks to fetch. Since each peer can have different
         // number of missing blocks and the fetching is batched by peer, so keep more than max_blocks_per_fetch
         // per peer on average.
@@ -1221,7 +1251,9 @@ where
         let mut peers = context
             .committee
             .authorities()
-            .filter_map(|(peer_index, _)| (peer_index != context.own_index).then_some(peer_index))
+            .filter_map(|(peer_index, _)| {
+                (peer_index != context.own_index).then_some(PeerId::Validator(peer_index))
+            })
             .collect::<Vec<_>>();
 
         // TODO: probably inject the RNG to allow unit testing - this is a work around for now.
@@ -1248,7 +1280,10 @@ where
                 debug_fatal!("No more peers left to fetch blocks!");
                 break;
             };
-            let peer_hostname = &context.committee.authority(peer).hostname;
+            let _peer_hostname = match &peer {
+                PeerId::Validator(index) => context.committee.authority(*index).hostname.as_str(),
+                PeerId::Observer(_) => "observer",
+            };
             // Fetch from the lowest round missing blocks to ensure progress.
             // This may reduce efficiency and increase the chance of duplicated data transfer in edge cases.
             let block_refs = batch
@@ -1261,12 +1296,13 @@ where
                 .collect::<BTreeSet<_>>();
 
             // lock the blocks to be fetched. If no lock can be acquired for any of the blocks then don't bother
-            if let Some(blocks_guard) = inflight_blocks.lock_blocks(block_refs.clone(), peer) {
+            if let Some(blocks_guard) =
+                inflight_blocks.lock_blocks(block_refs.clone(), peer.clone())
+            {
                 info!(
-                    "Periodic sync of {} missing blocks from peer {} {}: {}",
+                    "Periodic sync of {} missing blocks from peer {:?}: {}",
                     block_refs.len(),
                     peer,
-                    peer_hostname,
                     block_refs
                         .iter()
                         .map(|b| b.to_string())
@@ -1292,11 +1328,15 @@ where
 
         loop {
             tokio::select! {
-                Some((response, blocks_guard, _retries, peer_index, fetch_after_rounds)) = request_futures.next() => {
-                    let peer_hostname = &context.committee.authority(peer_index).hostname;
+                Some((response, blocks_guard, _retries, peer, fetch_after_rounds)) = request_futures.next() => {
+                    let peer_name = match &peer {
+                        PeerId::Validator(index) => context.committee.authority(*index).hostname.as_str(),
+                        PeerId::Observer(_) => "observer",
+                    };
+
                     match response {
                         Ok(fetched_blocks) => {
-                            results.push((blocks_guard, fetched_blocks, peer_index));
+                            results.push((blocks_guard, fetched_blocks, peer));
 
                             // no more pending requests are left, just break the loop
                             if request_futures.is_empty() {
@@ -1304,15 +1344,15 @@ where
                             }
                         },
                         Err(_) => {
-                            context.metrics.node_metrics.synchronizer_fetch_failures.with_label_values(&[peer_hostname.as_str(), "periodic"]).inc();
+                            context.metrics.node_metrics.synchronizer_fetch_failures.with_label_values(&[peer_name, "periodic"]).inc();
                             // try again if there is any peer left
                             if let Some(next_peer) = peers.next() {
                                 // do best effort to lock guards. If we can't lock then don't bother at this run.
-                                if let Some(blocks_guard) = inflight_blocks.swap_locks(blocks_guard, next_peer) {
+                                if let Some(blocks_guard) = inflight_blocks.swap_locks(blocks_guard, next_peer.clone()) {
                                     info!(
-                                        "Retrying syncing {} missing blocks from peer {}: {}",
+                                        "Retrying syncing {} missing blocks from peer {:?}: {}",
                                         blocks_guard.block_refs.len(),
-                                        peer_hostname,
+                                        next_peer,
                                         blocks_guard.block_refs
                                             .iter()
                                             .map(|b| b.to_string())
@@ -1329,7 +1369,7 @@ where
                                         1,
                                     ));
                                 } else {
-                                    debug!("Couldn't acquire locks to fetch blocks from peer {next_peer}.")
+                                    debug!("Couldn't acquire locks to fetch blocks from peer {:?}.", next_peer)
                                 }
                             } else {
                                 debug!("No more peers left to fetch blocks");
@@ -1374,7 +1414,9 @@ mod tests {
         core_thread::CoreThreadDispatcher,
         dag_state::DagState,
         error::{ConsensusError, ConsensusResult},
-        network::{BlockStream, ObserverNetworkClient, SynchronizerClient, ValidatorNetworkClient},
+        network::{
+            BlockStream, ObserverNetworkClient, PeerId, SynchronizerClient, ValidatorNetworkClient,
+        },
         storage::mem_store::MemStore,
         synchronizer::{
             COMMIT_PROGRESS_TIMEOUT, FETCH_BLOCKS_CONCURRENCY, FETCH_REQUEST_TIMEOUT,
@@ -1593,28 +1635,30 @@ mod tests {
             // Try to acquire the block locks for authorities 1 & 2
             for i in 1..=2 {
                 let authority = AuthorityIndex::new_for_test(i);
+                let peer = PeerId::Validator(authority);
 
-                let guard = map.lock_blocks(missing_block_refs.clone(), authority);
+                let guard = map.lock_blocks(missing_block_refs.clone(), peer.clone());
                 let guard = guard.expect("Guard should be created");
                 assert_eq!(guard.block_refs.len(), 4);
 
                 all_guards.push(guard);
 
                 // trying to acquire any of them again will not succeed
-                let guard = map.lock_blocks(missing_block_refs.clone(), authority);
+                let guard = map.lock_blocks(missing_block_refs.clone(), peer);
                 assert!(guard.is_none());
             }
 
             // Trying to acquire for authority 3 it will fail - as we have maxed out the number of allowed peers
             let authority_3 = AuthorityIndex::new_for_test(3);
+            let peer_3 = PeerId::Validator(authority_3);
 
-            let guard = map.lock_blocks(missing_block_refs.clone(), authority_3);
+            let guard = map.lock_blocks(missing_block_refs.clone(), peer_3.clone());
             assert!(guard.is_none());
 
             // Explicitly drop the guard of authority 1 and try for authority 3 again - it will now succeed
             drop(all_guards.remove(0));
 
-            let guard = map.lock_blocks(missing_block_refs.clone(), authority_3);
+            let guard = map.lock_blocks(missing_block_refs.clone(), peer_3);
             let guard = guard.expect("Guard should be successfully acquired");
 
             assert_eq!(guard.block_refs, missing_block_refs);
@@ -1630,13 +1674,13 @@ mod tests {
         {
             // acquire a lock for authority 1
             let authority_1 = AuthorityIndex::new_for_test(1);
-            let guard = map
-                .lock_blocks(missing_block_refs.clone(), authority_1)
-                .unwrap();
+            let peer_1 = PeerId::Validator(authority_1);
+            let guard = map.lock_blocks(missing_block_refs.clone(), peer_1).unwrap();
 
             // Now swap the locks for authority 2
             let authority_2 = AuthorityIndex::new_for_test(2);
-            let guard = map.swap_locks(guard, authority_2);
+            let peer_2 = PeerId::Validator(authority_2);
+            let guard = map.swap_locks(guard, peer_2);
 
             assert_eq!(guard.unwrap().block_refs, missing_block_refs);
         }
@@ -1690,7 +1734,12 @@ mod tests {
             .await;
 
         // WHEN request missing blocks from peer 1
-        assert!(handle.fetch_blocks(missing_blocks, peer).await.is_ok());
+        assert!(
+            handle
+                .fetch_blocks(missing_blocks, PeerId::Validator(peer))
+                .await
+                .is_ok()
+        );
 
         // Wait a little bit until those have been added in core
         sleep(Duration::from_millis(1_000)).await;
@@ -1757,14 +1806,22 @@ mod tests {
             // WHEN requesting to fetch the blocks, it should not succeed for the last request and get
             // an error with "saturated" synchronizer
             if iter.peek().is_none() {
-                match handle.fetch_blocks(missing_blocks, peer).await {
-                    Err(ConsensusError::SynchronizerSaturated(index)) => {
-                        assert_eq!(index, peer);
+                match handle
+                    .fetch_blocks(missing_blocks, PeerId::Validator(peer))
+                    .await
+                {
+                    Err(ConsensusError::SynchronizerSaturated(peer_str)) => {
+                        assert_eq!(peer_str, format!("{:?}", PeerId::Validator(peer)));
                     }
                     _ => panic!("A saturated synchronizer error was expected"),
                 }
             } else {
-                assert!(handle.fetch_blocks(missing_blocks, peer).await.is_ok());
+                assert!(
+                    handle
+                        .fetch_blocks(missing_blocks, PeerId::Validator(peer))
+                        .await
+                        .is_ok()
+                );
             }
         }
     }
@@ -2302,11 +2359,12 @@ mod tests {
 
         // GIVEN peer to fetch blocks from
         let peer_index = AuthorityIndex::new_for_test(2);
+        let peer = PeerId::Validator(peer_index);
 
         // Create blocks_guard
         let inflight_blocks_map = InflightBlocksMap::new();
         let blocks_guard = inflight_blocks_map
-            .lock_blocks(expected_block_refs.clone(), peer_index)
+            .lock_blocks(expected_block_refs.clone(), peer.clone())
             .expect("Failed to lock blocks");
 
         assert_eq!(
@@ -2322,7 +2380,7 @@ mod tests {
             MockNetworkClient,
         >::process_fetched_blocks(
             expected_serialized_blocks,
-            peer_index,
+            peer,
             blocks_guard, // The guard is consumed here
             core_dispatcher.clone(),
             block_verifier,

--- a/consensus/core/src/synchronizer.rs
+++ b/consensus/core/src/synchronizer.rs
@@ -178,8 +178,8 @@ enum Command {
 }
 
 pub(crate) struct SynchronizerHandle {
-    commands_sender: Sender<Command>,
-    tasks: tokio::sync::Mutex<JoinSet<()>>,
+    pub(crate) commands_sender: Sender<Command>,
+    pub(crate) tasks: tokio::sync::Mutex<JoinSet<()>>,
 }
 
 impl SynchronizerHandle {
@@ -512,7 +512,7 @@ where
                     match response {
                         Ok(blocks) => {
                             if let Err(err) = Self::process_fetched_blocks(blocks,
-                                fetch_peer.clone(),
+                                peer.clone(),
                                 blocks_guard,
                                 core_dispatcher.clone(),
                                 block_verifier.clone(),
@@ -523,16 +523,16 @@ where
                                 round_tracker.clone(),
                                 "live"
                             ).await {
-                                warn!("Error while processing fetched blocks from peer {fetch_peer} {peer_name}: {err}");
+                                warn!("Error while processing fetched blocks from peer {peer_name}: {err}");
                                 context.metrics.node_metrics.synchronizer_process_fetched_failures.with_label_values(&[peer_name.as_str(), "live"]).inc();
                             }
                         },
                         Err(_) => {
                             context.metrics.node_metrics.synchronizer_fetch_failures.with_label_values(&[peer_name.as_str(), "live"]).inc();
                             if retries <= MAX_RETRIES {
-                                requests.push(Self::fetch_blocks_request(network_client.clone(), fetch_peer.clone(), blocks_guard, fetch_after_rounds, true, FETCH_REQUEST_TIMEOUT, retries))
+                                requests.push(Self::fetch_blocks_request(network_client.clone(), peer.clone(), blocks_guard, fetch_after_rounds, true, FETCH_REQUEST_TIMEOUT, retries))
                             } else {
-                                warn!("Max retries {retries} reached while trying to fetch blocks from peer {fetch_peer} {peer_name}.");
+                                warn!("Max retries {retries} reached while trying to fetch blocks from peer {peer_name}.");
                                 // we don't necessarily need to do, but dropping the guard here to unlock the blocks
                                 drop(blocks_guard);
                             }

--- a/consensus/core/src/synchronizer.rs
+++ b/consensus/core/src/synchronizer.rs
@@ -298,12 +298,9 @@ where
         let mut fetch_block_senders = BTreeMap::new();
         let mut tasks = JoinSet::new();
 
-        // Create fetch tasks for validators
-        for (index, _) in context.committee.authorities() {
-            if index == context.own_index {
-                continue;
-            }
-            let peer = PeerId::Validator(index);
+        // Create fetch tasks for all available peers (validators and observers)
+        let available_peers = peers_pool.get_available_peers();
+        for peer in available_peers {
             let (sender, receiver) =
                 channel("consensus_synchronizer_fetches", FETCH_BLOCKS_CONCURRENCY);
             let fetch_blocks_from_peer_async = Self::fetch_blocks_from_peer(
@@ -705,12 +702,10 @@ where
             let (verified_block, reject_txn_votes) = block_verifier
                 .verify_and_vote(signed_block, serialized_block)
                 .tap_err(|e| {
-                    let (peer_name, peer_type) = match &peer {
-                        PeerId::Validator(index) => (
-                            context.committee.authority(*index).hostname.clone(),
-                            "validator",
-                        ),
-                        PeerId::Observer(_) => ("observer".to_string(), "observer"),
+                    let peer_name = peer.hostname(context);
+                    let peer_type = match &peer {
+                        PeerId::Validator(_) => "validator",
+                        PeerId::Observer(_) => "observer",
                     };
                     context
                         .metrics
@@ -971,6 +966,7 @@ where
         let commands_sender = self.commands_sender.clone();
         let dag_state = self.dag_state.clone();
         let round_tracker = self.round_tracker.clone();
+        let peers_pool = self.peers_pool.clone();
 
         let mut missing_blocks = self
             .core_dispatcher
@@ -1009,12 +1005,13 @@ where
                 } else {
                     let _scope = monitored_scope("BlockSync::Periodic::MissingBlocks");
                     // Fetch blocks from 1 to MAX_PERIODIC_SYNC_PEERS peers
-                    Self::fetch_blocks_from_authorities(
+                    Self::fetch_blocks_from_peers(
                         context.clone(),
                         blocks_to_fetch.clone(),
                         network_client,
                         missing_blocks,
                         dag_state,
+                        peers_pool,
                     )
                     .await
                 };
@@ -1213,12 +1210,13 @@ where
     /// authorities with missing blocks.
     /// Each element of the vector is a tuple which contains the requested missing block refs, the returned blocks and
     /// the peer.
-    async fn fetch_blocks_from_authorities(
+    async fn fetch_blocks_from_peers(
         context: Arc<Context>,
         inflight_blocks: Arc<InflightBlocksMap>,
         network_client: Arc<SynchronizerClient<VC, OC>>,
         missing_blocks: BTreeSet<BlockRef>,
         dag_state: Arc<RwLock<DagState>>,
+        peers_pool: Arc<PeersPool>,
     ) -> Vec<(BlocksGuard, Vec<Bytes>, PeerId)> {
         // Preliminary truncation of missing blocks to fetch. Since each peer can have different
         // number of missing blocks and the fetching is batched by peer, so keep more than max_blocks_per_fetch
@@ -1236,11 +1234,21 @@ where
                 .or_default()
                 .push(*block_ref);
         }
+
+        // Get available peers from the PeersPool
+        let mut peers = peers_pool.get_available_peers();
+
         // Distribute the same number of authorities into each peer to sync.
-        // When running this function, context.committee.size() is always greater than 1.
+        // Use the number of available peers from the pool, capped at MAX_PERIODIC_SYNC_PEERS
+        let available_peers_count = peers.len();
+        assert!(
+            available_peers_count > 0,
+            "No available peers to fetch blocks from. This shouldn't really happen."
+        );
+
         let num_authorities_per_peer = authorities
             .len()
-            .div_ceil((context.committee.size() - 1).min(MAX_PERIODIC_SYNC_PEERS));
+            .div_ceil(available_peers_count.min(MAX_PERIODIC_SYNC_PEERS));
 
         // Update metrics related to missing blocks.
         let mut missing_blocks_per_authority = vec![0; context.committee.size()];
@@ -1264,14 +1272,6 @@ where
                 .with_label_values(&[&authority.hostname])
                 .set(missing as i64);
         }
-
-        let mut peers = context
-            .committee
-            .authorities()
-            .filter_map(|(peer_index, _)| {
-                (peer_index != context.own_index).then_some(PeerId::Validator(peer_index))
-            })
-            .collect::<Vec<_>>();
 
         // TODO: probably inject the RNG to allow unit testing - this is a work around for now.
         if cfg!(not(test)) {
@@ -1297,10 +1297,7 @@ where
                 debug_fatal!("No more peers left to fetch blocks!");
                 break;
             };
-            let _peer_hostname = match &peer {
-                PeerId::Validator(index) => context.committee.authority(*index).hostname.as_str(),
-                PeerId::Observer(_) => "observer",
-            };
+            let peer_hostname = peer.hostname(&context);
             // Fetch from the lowest round missing blocks to ensure progress.
             // This may reduce efficiency and increase the chance of duplicated data transfer in edge cases.
             let block_refs = batch
@@ -1317,7 +1314,8 @@ where
                 inflight_blocks.lock_blocks(block_refs.clone(), peer.clone())
             {
                 info!(
-                    "Periodic sync of {} missing blocks from peer {:?}: {}",
+                    "Periodic sync of {} missing blocks from peer {} {:?}: {}",
+                    peer_hostname.as_str(),
                     block_refs.len(),
                     peer,
                     block_refs
@@ -1350,7 +1348,6 @@ where
                         PeerId::Validator(index) => context.committee.authority(*index).hostname.as_str(),
                         PeerId::Observer(_) => "observer",
                     };
-
                     match response {
                         Ok(fetched_blocks) => {
                             results.push((blocks_guard, fetched_blocks, peer));

--- a/consensus/core/src/synchronizer.rs
+++ b/consensus/core/src/synchronizer.rs
@@ -1032,17 +1032,12 @@ where
                             "Error occurred while processing fetched blocks from peer {:?}: {err}",
                             peer
                         );
-                        let peer_name = match &peer {
-                            PeerId::Validator(index) => {
-                                context.committee.authority(*index).hostname.as_str()
-                            }
-                            PeerId::Observer(_) => "observer",
-                        };
+                        let peer_name = peer.labelname(&context);
                         context
                             .metrics
                             .node_metrics
                             .synchronizer_process_fetched_failures
-                            .with_label_values(&[peer_name, "periodic"])
+                            .with_label_values(&[peer_name.as_str(), "periodic"])
                             .inc();
                     }
                 }
@@ -1145,6 +1140,9 @@ where
         // Pick a random peer (excluding self).
         // Get available peers from the PeersPool
         let mut peers = peers_pool.get_known_peers();
+
+        // TODO: in the future it would be possible, temporarily, for an Observer node to not have peers to fetch from.
+        // We should change this assertion to allow for this case.
         assert!(!peers.is_empty(), "No known peers to fetch blocks from");
 
         if cfg!(not(test)) {
@@ -1221,6 +1219,8 @@ where
 
         // Distribute the same number of authorities into each peer to sync.
         // Use the number of known peers from the pool, capped at MAX_PERIODIC_SYNC_PEERS
+        // TODO: in the future it would be possible, temporarily, for an Observer node to not have peers to fetch from.
+        // We should change this assertion to allow for this case.
         assert!(!peers.is_empty(), "No known peers to fetch blocks from");
 
         let num_authorities_per_peer = authorities
@@ -1321,10 +1321,6 @@ where
         loop {
             tokio::select! {
                 Some((response, blocks_guard, _retries, peer, fetch_after_rounds)) = request_futures.next() => {
-                    let peer_name = match &peer {
-                        PeerId::Validator(index) => context.committee.authority(*index).hostname.as_str(),
-                        PeerId::Observer(_) => "observer",
-                    };
                     match response {
                         Ok(fetched_blocks) => {
                             results.push((blocks_guard, fetched_blocks, peer));
@@ -1335,7 +1331,8 @@ where
                             }
                         },
                         Err(_) => {
-                            context.metrics.node_metrics.synchronizer_fetch_failures.with_label_values(&[peer_name, "periodic"]).inc();
+                            let peer_name = peer.labelname(&context);
+                            context.metrics.node_metrics.synchronizer_fetch_failures.with_label_values(&[peer_name.as_str(), "periodic"]).inc();
                             // try again if there is any peer left
                             if let Some(next_peer) = peers.next() {
                                 // do best effort to lock guards. If we can't lock then don't bother at this run.

--- a/consensus/core/src/synchronizer.rs
+++ b/consensus/core/src/synchronizer.rs
@@ -170,7 +170,7 @@ impl InflightBlocksMap {
 enum Command {
     FetchBlocks {
         missing_block_refs: BTreeSet<BlockRef>,
-        peer: Box<PeerId>,
+        peer: PeerId,
         result: oneshot::Sender<Result<(), ConsensusError>>,
     },
     FetchOwnLastBlock,
@@ -194,7 +194,7 @@ impl SynchronizerHandle {
         self.commands_sender
             .send(Command::FetchBlocks {
                 missing_block_refs,
-                peer: Box::new(peer),
+                peer,
                 result: sender,
             })
             .await
@@ -388,7 +388,7 @@ where
                                 .take(self.context.parameters.max_blocks_per_sync)
                                 .collect();
 
-                            let blocks_guard = self.inflight_blocks_map.lock_blocks(missing_block_refs, (*peer).clone());
+                            let blocks_guard = self.inflight_blocks_map.lock_blocks(missing_block_refs, peer.clone());
                             let Some(blocks_guard) = blocks_guard else {
                                 result.send(Ok(())).ok();
                                 continue;

--- a/consensus/core/src/synchronizer.rs
+++ b/consensus/core/src/synchronizer.rs
@@ -693,20 +693,11 @@ where
                 .verify_and_vote(signed_block, serialized_block)
                 .tap_err(|e| {
                     let peer_label = peer.labelname(context);
-                    let peer_type = match &peer {
-                        PeerId::Validator(_) => "validator",
-                        PeerId::Observer(_) => "observer",
-                    };
                     context
                         .metrics
                         .node_metrics
                         .invalid_blocks
-                        .with_label_values(&[
-                            peer_label.as_str(),
-                            "synchronizer",
-                            e.clone().name(),
-                            peer_type,
-                        ])
+                        .with_label_values(&[peer_label.as_str(), "synchronizer", e.clone().name()])
                         .inc();
                     info!("Invalid block received from {}: {}", peer, e);
                 })?;
@@ -833,7 +824,7 @@ where
                                 .metrics
                                 .node_metrics
                                 .invalid_blocks
-                                .with_label_values(&[hostname.as_str(), "synchronizer_own_block", err.clone().name(), "validator"])
+                                .with_label_values(&[hostname.as_str(), "synchronizer_own_block", err.clone().name()])
                                 .inc();
                             warn!("Invalid block received from {}: {}", authority_index, err);
                         })?;

--- a/consensus/core/src/synchronizer.rs
+++ b/consensus/core/src/synchronizer.rs
@@ -178,8 +178,8 @@ enum Command {
 }
 
 pub(crate) struct SynchronizerHandle {
-    pub(crate) commands_sender: Sender<Command>,
-    pub(crate) tasks: tokio::sync::Mutex<JoinSet<()>>,
+    commands_sender: Sender<Command>,
+    tasks: tokio::sync::Mutex<JoinSet<()>>,
 }
 
 impl SynchronizerHandle {
@@ -287,12 +287,12 @@ where
         transaction_vote_tracker: TransactionVoteTracker,
         round_tracker: Arc<RwLock<RoundTracker>>,
         dag_state: Arc<RwLock<DagState>>,
+        peers_pool: Arc<PeersPool>,
         sync_last_known_own_block: bool,
     ) -> Arc<SynchronizerHandle> {
         let (commands_sender, commands_receiver) =
             channel("consensus_synchronizer_commands", 1_000);
         let inflight_blocks_map = InflightBlocksMap::new();
-        let peers_pool = PeersPool::new(context.clone());
 
         // Spawn the tasks to fetch the blocks from the others
         let mut fetch_block_senders = BTreeMap::new();
@@ -1442,7 +1442,8 @@ mod tests {
     };
     use crate::{
         authority_service::COMMIT_LAG_MULTIPLIER, core_thread::MockCoreThreadDispatcher,
-        round_tracker::RoundTracker, transaction_vote_tracker::TransactionVoteTracker,
+        transaction_vote_tracker::TransactionVoteTracker,
+        peers_pool::PeersPool, round_tracker::RoundTracker,
     };
 
     type FetchRequestKey = (Vec<BlockRef>, AuthorityIndex);
@@ -1723,15 +1724,17 @@ mod tests {
             Some(mock_client.clone()),
             Some(mock_client.clone()),
         ));
+        let peers_pool = Arc::new(PeersPool::new(context.clone()));
         let handle = Synchronizer::start(
             network_client,
-            context,
+            context.clone(),
             core_dispatcher.clone(),
             commit_vote_monitor,
             block_verifier,
             transaction_vote_tracker,
             round_tracker,
             dag_state,
+            peers_pool.clone(),
             false,
         );
 
@@ -1786,15 +1789,17 @@ mod tests {
             Some(mock_client.clone()),
             Some(mock_client.clone()),
         ));
+        let peers_pool = Arc::new(PeersPool::new(context.clone()));
         let handle = Synchronizer::start(
             network_client,
-            context,
+            context.clone(),
             core_dispatcher.clone(),
             commit_vote_monitor,
             block_verifier,
             transaction_vote_tracker,
             round_tracker,
             dag_state,
+            peers_pool.clone(),
             false,
         );
 
@@ -1896,15 +1901,17 @@ mod tests {
             Some(mock_client.clone()),
             Some(mock_client.clone()),
         ));
+        let peers_pool = Arc::new(PeersPool::new(context.clone()));
         let _handle = Synchronizer::start(
             network_client,
-            context,
+            context.clone(),
             core_dispatcher.clone(),
             commit_vote_monitor,
             block_verifier,
             transaction_vote_tracker,
             round_tracker,
             dag_state,
+            peers_pool.clone(),
             false,
         );
 
@@ -1999,6 +2006,7 @@ mod tests {
             Some(mock_client.clone()),
             Some(mock_client.clone()),
         ));
+        let peers_pool = Arc::new(PeersPool::new(context.clone()));
         let _handle = Synchronizer::start(
             network_client,
             context.clone(),
@@ -2008,6 +2016,7 @@ mod tests {
             transaction_vote_tracker,
             round_tracker,
             dag_state.clone(),
+            peers_pool.clone(),
             false,
         );
 
@@ -2122,6 +2131,7 @@ mod tests {
             Some(mock_client.clone()),
             Some(mock_client.clone()),
         ));
+        let peers_pool = Arc::new(PeersPool::new(context.clone()));
         let _handle = Synchronizer::start(
             network_client,
             context.clone(),
@@ -2131,6 +2141,7 @@ mod tests {
             transaction_vote_tracker,
             round_tracker,
             dag_state.clone(),
+            peers_pool.clone(),
             false,
         );
 
@@ -2294,6 +2305,7 @@ mod tests {
             Some(mock_client.clone()),
             Some(mock_client.clone()),
         ));
+        let peers_pool = Arc::new(PeersPool::new(context.clone()));
         let handle = Synchronizer::start(
             network_client,
             context.clone(),
@@ -2303,6 +2315,7 @@ mod tests {
             transaction_vote_tracker,
             round_tracker,
             dag_state,
+            peers_pool.clone(),
             true,
         );
 

--- a/consensus/core/src/synchronizer.rs
+++ b/consensus/core/src/synchronizer.rs
@@ -210,6 +210,17 @@ impl SynchronizerHandle {
         }
         Ok(())
     }
+
+    #[cfg(test)]
+    /// Creates a mock synchronizer handle for testing
+    pub(crate) fn new_for_test() -> Arc<Self> {
+        use tokio::task::JoinSet;
+        let (tx, _rx) = channel("test_synchronizer", 1);
+        Arc::new(Self {
+            commands_sender: tx,
+            tasks: tokio::sync::Mutex::new(JoinSet::new()),
+        })
+    }
 }
 
 /// `Synchronizer` oversees live block synchronization, crucial for node progress. Live synchronization
@@ -694,17 +705,23 @@ where
             let (verified_block, reject_txn_votes) = block_verifier
                 .verify_and_vote(signed_block, serialized_block)
                 .tap_err(|e| {
-                    let peer_name = match &peer {
-                        PeerId::Validator(index) => {
-                            context.committee.authority(*index).hostname.clone()
-                        }
-                        PeerId::Observer(_) => "observer".to_string(),
+                    let (peer_name, peer_type) = match &peer {
+                        PeerId::Validator(index) => (
+                            context.committee.authority(*index).hostname.clone(),
+                            "validator",
+                        ),
+                        PeerId::Observer(_) => ("observer".to_string(), "observer"),
                     };
                     context
                         .metrics
                         .node_metrics
                         .invalid_blocks
-                        .with_label_values(&[peer_name.as_str(), "synchronizer", e.clone().name()])
+                        .with_label_values(&[
+                            peer_name.as_str(),
+                            "synchronizer",
+                            e.clone().name(),
+                            peer_type,
+                        ])
                         .inc();
                     info!("Invalid block received from {:?}: {}", peer, e);
                 })?;
@@ -831,7 +848,7 @@ where
                                 .metrics
                                 .node_metrics
                                 .invalid_blocks
-                                .with_label_values(&[hostname.as_str(), "synchronizer_own_block", err.clone().name()])
+                                .with_label_values(&[hostname.as_str(), "synchronizer_own_block", err.clone().name(), "validator"])
                                 .inc();
                             warn!("Invalid block received from {}: {}", authority_index, err);
                         })?;

--- a/consensus/core/src/synchronizer.rs
+++ b/consensus/core/src/synchronizer.rs
@@ -1000,6 +1000,7 @@ where
                         blocks_to_fetch.clone(),
                         network_client,
                         dag_state,
+                        peers_pool,
                     )
                     .await
                 } else {
@@ -1156,26 +1157,29 @@ where
         inflight_blocks: Arc<InflightBlocksMap>,
         network_client: Arc<SynchronizerClient<VC, OC>>,
         dag_state: Arc<RwLock<DagState>>,
+        peers_pool: Arc<PeersPool>,
     ) -> Vec<(BlocksGuard, Vec<Bytes>, PeerId)> {
         let fetch_after_rounds = Self::get_fetch_after_rounds(&context, dag_state.clone());
 
         // Pick a random peer (excluding self).
-        let mut peers: Vec<AuthorityIndex> = context
-            .committee
-            .authorities()
-            .filter_map(|(index, _)| (index != context.own_index).then_some(index))
-            .collect();
+        // Get available peers from the PeersPool
+        let mut peers = peers_pool.get_available_peers();
+        let available_peers_count = peers.len();
+        assert!(
+            available_peers_count > 0,
+            "No available peers to fetch blocks from. This shouldn't really happen."
+        );
+
         if cfg!(not(test)) {
             peers.shuffle(&mut ThreadRng::default());
         }
-        let peer = *peers
-            .first()
-            .expect("Committee should have more than 1 member");
+
+        let peer = peers.first().unwrap().clone();
 
         let response = timeout(
             FETCH_REQUEST_TIMEOUT,
             network_client.fetch_blocks(
-                PeerId::Validator(peer),
+                peer.clone(),
                 vec![],
                 fetch_after_rounds,
                 false,
@@ -1199,10 +1203,10 @@ where
         let blocks_guard = BlocksGuard {
             map: inflight_blocks,
             block_refs: BTreeSet::new(),
-            peer: PeerId::Validator(peer),
+            peer: peer.clone(),
         };
 
-        vec![(blocks_guard, serialized_blocks, PeerId::Validator(peer))]
+        vec![(blocks_guard, serialized_blocks, peer)]
     }
 
     /// Fetches the `missing_blocks` from peers. Requests the same number of authorities with missing blocks from each peer.
@@ -1439,8 +1443,8 @@ mod tests {
     };
     use crate::{
         authority_service::COMMIT_LAG_MULTIPLIER, core_thread::MockCoreThreadDispatcher,
-        transaction_vote_tracker::TransactionVoteTracker,
         peers_pool::PeersPool, round_tracker::RoundTracker,
+        transaction_vote_tracker::TransactionVoteTracker,
     };
 
     type FetchRequestKey = (Vec<BlockRef>, AuthorityIndex);


### PR DESCRIPTION
## Description 

This PR is introducing the `PeersPool` which from now on will act as a billboard to keep the peers available to communicate with and their available interfaces/servers that they support (Validator, Observer). On the longer term the `PeersPool` will be updated dynamically from peers (other Observers) that join the network and make their selfs available.

The `synchronizer` has been refactored to support the `PeersPool` so the Observer nodes can also synchronize missing blocks from the peer.

## Test plan 

How did you test the new or updated feature?

CI

## Next

- https://github.com/MystenLabs/sui/pull/25997

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
