### PR TITLE
feat(sui-bridge-indexer-alt): flatten IngestionClientArgs for GCS support

### DIFF
--- a/crates/sui-bridge-indexer-alt/src/main.rs
+++ b/crates/sui-bridge-indexer-alt/src/main.rs
@@ -34,8 +34,8 @@ struct Args {
         default_value = "postgres://postgres:postgrespw@localhost:5432/bridge"
     )]
     database_url: Url,
-    #[clap(env, long, default_value = "https://checkpoints.mainnet.sui.io")]
-    remote_store_url: Url,
+    #[command(flatten)]
+    ingestion: IngestionClientArgs,
     #[command(flatten)]
     streaming: StreamingClientArgs,
 }
@@ -50,7 +50,7 @@ async fn main() -> Result<(), anyhow::Error> {
         indexer_args,
         metrics_address,
         database_url,
-        remote_store_url,
+        ingestion,
         streaming,
     } = Args::parse();
 
@@ -69,10 +69,7 @@ async fn main() -> Result<(), anyhow::Error> {
         db_args,
         indexer_args,
         ClientArgs {
-            ingestion: IngestionClientArgs {
-                remote_store_url: Some(remote_store_url),
-                ..Default::default()
-            },
+            ingestion,
             streaming,
         },
         Default::default(),


### PR DESCRIPTION
## Summary

Replace manual `remote_store_url` field with flattened `IngestionClientArgs` to expose all ingestion options including `--remote-store-gcs` for direct GCS bucket access with workload identity.

## Changes

- Remove `#[clap(env, long)] remote_store_url: Url` field
- Add `#[command(flatten)] ingestion: IngestionClientArgs`
- Pass flattened `ingestion` directly to `ClientArgs`

This exposes all ingestion options from the framework:
- `--remote-store-url` (HTTP/HTTPS)
- `--remote-store-gcs` (GCS bucket name)
- `--remote-store-s3` (S3 bucket)
- `--remote-store-azure` (Azure blob)
- `--local-ingestion-path`
- `--rpc-api-url`

## Test plan

- [x] `cargo check -p sui-bridge-indexer-alt` passes
- [ ] Deploy to testnet/mainnet with `--remote-store-gcs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)