### PR TITLE
Wire up more archival read masks to the bigtable requests

### DIFF
--- a/crates/sui-indexer-alt-reader/src/checkpoints.rs
+++ b/crates/sui-indexer-alt-reader/src/checkpoints.rs
@@ -78,11 +78,11 @@ impl Loader<CheckpointKey> for BigtableReader {
             .checkpoints(&checkpoint_keys)
             .await?
             .into_iter()
-            .map(|c| {
-                (
-                    CheckpointKey(c.summary.sequence_number),
-                    (c.summary, c.contents, c.signatures),
-                )
+            .filter_map(|c| {
+                Some((
+                    CheckpointKey(c.summary.as_ref()?.sequence_number),
+                    (c.summary?, c.contents?, c.signatures?),
+                ))
             })
             .collect())
     }

--- a/crates/sui-kv-rpc/src/lib.rs
+++ b/crates/sui-kv-rpc/src/lib.rs
@@ -79,7 +79,8 @@ impl KvRpcServer {
             .await?
             .pop()
             .expect("failed to fetch genesis checkpoint from the KV store");
-        let chain_id = ChainIdentifier::from(genesis.summary.digest());
+        let summary = genesis.summary.expect("genesis checkpoint missing summary");
+        let chain_id = ChainIdentifier::from(summary.digest());
         Ok(Self::init(
             client,
             chain_id,

--- a/crates/sui-kv-rpc/src/v2/get_checkpoint.rs
+++ b/crates/sui-kv-rpc/src/v2/get_checkpoint.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use sui_data_ingestion_core::{CheckpointReader, create_remote_store_client};
+use sui_kvstore::tables::checkpoints::col;
 use sui_kvstore::{BigTableClient, CHECKPOINTS_PIPELINE, KeyValueStoreReader};
 use sui_rpc::field::{FieldMask, FieldMaskTree, FieldMaskUtil};
 use sui_rpc::merge::Merge;
@@ -30,6 +31,7 @@ pub async fn get_checkpoint(
         })?;
         FieldMaskTree::from(read_mask)
     };
+    let columns = checkpoint_columns(&read_mask);
     let checkpoint = match request.checkpoint_id {
         Some(CheckpointId::Digest(digest)) => {
             let digest = digest.parse::<CheckpointDigest>().map_err(|e| {
@@ -38,12 +40,12 @@ pub async fn get_checkpoint(
                     .with_reason(ErrorReason::FieldInvalid)
             })?;
             client
-                .get_checkpoint_by_digest(digest)
+                .get_checkpoint_by_digest_filtered(digest, Some(&columns))
                 .await?
                 .ok_or(CheckpointNotFoundError::digest(digest.into()))?
         }
         Some(CheckpointId::SequenceNumber(sequence_number)) => client
-            .get_checkpoints(&[sequence_number])
+            .get_checkpoints_filtered(&[sequence_number], Some(&columns))
             .await?
             .pop()
             .ok_or(CheckpointNotFoundError::sequence_number(sequence_number))?,
@@ -54,22 +56,35 @@ pub async fn get_checkpoint(
                 .map(|wm| wm.checkpoint_hi_inclusive)
                 .ok_or(CheckpointNotFoundError::sequence_number(0))?;
             client
-                .get_checkpoints(&[sequence_number])
+                .get_checkpoints_filtered(&[sequence_number], Some(&columns))
                 .await?
                 .pop()
                 .ok_or(CheckpointNotFoundError::sequence_number(sequence_number))?
         }
     };
-    let sequence_number = checkpoint.summary.sequence_number;
+
+    let summary = checkpoint
+        .summary
+        .ok_or_else(|| anyhow::anyhow!("checkpoint summary missing"))?;
+    let sequence_number = summary.sequence_number;
     let mut message = Checkpoint::default();
-    let summary: sui_sdk_types::CheckpointSummary = checkpoint.summary.try_into()?;
-    let signatures: sui_sdk_types::ValidatorAggregatedSignature = checkpoint.signatures.into();
+    let summary: sui_sdk_types::CheckpointSummary = summary.try_into()?;
     message.merge(&summary, &read_mask);
-    message.merge(signatures, &read_mask);
+
+    if read_mask.contains(Checkpoint::SIGNATURE_FIELD) {
+        let signatures = checkpoint
+            .signatures
+            .ok_or_else(|| anyhow::anyhow!("checkpoint signatures missing"))?;
+        let signatures: sui_sdk_types::ValidatorAggregatedSignature = signatures.into();
+        message.merge(signatures, &read_mask);
+    }
 
     if read_mask.contains(Checkpoint::CONTENTS_FIELD.name) {
+        let contents = checkpoint
+            .contents
+            .ok_or_else(|| anyhow::anyhow!("checkpoint contents missing"))?;
         message.merge(
-            sui_sdk_types::CheckpointContents::try_from(checkpoint.contents)?,
+            sui_sdk_types::CheckpointContents::try_from(contents)?,
             &read_mask,
         );
     }
@@ -89,4 +104,20 @@ pub async fn get_checkpoint(
     }
 
     Ok(GetCheckpointResponse::new(message))
+}
+
+/// Compute the set of BigTable columns needed for the given read mask.
+/// Always includes `s` (summary) since it provides sequence_number, digest, etc.
+/// Only includes `sg` (signatures) and `c` (contents) when needed.
+fn checkpoint_columns(mask: &FieldMaskTree) -> Vec<&'static str> {
+    let mut columns = vec![col::SUMMARY];
+
+    if mask.contains(Checkpoint::SIGNATURE_FIELD) {
+        columns.push(col::SIGNATURES);
+    }
+    if mask.contains(Checkpoint::CONTENTS_FIELD) {
+        columns.push(col::CONTENTS);
+    }
+
+    columns
 }

--- a/crates/sui-kv-rpc/src/v2/get_epoch.rs
+++ b/crates/sui-kv-rpc/src/v2/get_epoch.rs
@@ -1,7 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use sui_kvstore::{BigTableClient, KeyValueStoreReader};
+use sui_kvstore::BigTableClient;
+use sui_kvstore::tables::epochs::col;
 use sui_protocol_config::{Chain, ProtocolConfig};
 use sui_rpc::field::{FieldMask, FieldMaskTree, FieldMaskUtil};
 use sui_rpc::merge::Merge;
@@ -37,10 +38,14 @@ pub async fn get_epoch(
 
     let mut message = Epoch::default();
 
+    let columns = epoch_columns(&read_mask);
     let maybe_epoch_info = if let Some(epoch) = request.epoch {
-        client.get_epoch(epoch).await?
+        client
+            .get_epochs_filtered(&[epoch], Some(&columns))
+            .await?
+            .pop()
     } else {
-        client.get_latest_epoch().await?
+        client.get_latest_epoch_filtered(Some(&columns)).await?
     };
 
     let Some(epoch_info) = maybe_epoch_info else {
@@ -85,4 +90,34 @@ pub async fn get_epoch(
         });
     }
     Ok(GetEpochResponse::new(message))
+}
+
+/// Compute the set of BigTable columns needed for the given read mask.
+/// Always includes `ep` (epoch number, small).
+fn epoch_columns(mask: &FieldMaskTree) -> Vec<&'static str> {
+    let mut columns = vec![col::EPOCH];
+
+    if mask.contains(Epoch::FIRST_CHECKPOINT_FIELD.name) {
+        columns.push(col::START_CHECKPOINT);
+    }
+    if mask.contains(Epoch::LAST_CHECKPOINT_FIELD.name) {
+        columns.push(col::END_CHECKPOINT);
+    }
+    if mask.contains(Epoch::START_FIELD.name) {
+        columns.push(col::START_TIMESTAMP);
+    }
+    if mask.contains(Epoch::END_FIELD.name) {
+        columns.push(col::END_TIMESTAMP);
+    }
+    if mask.contains(Epoch::REFERENCE_GAS_PRICE_FIELD.name) {
+        columns.push(col::REFERENCE_GAS_PRICE);
+    }
+    if mask.subtree(Epoch::PROTOCOL_CONFIG_FIELD.name).is_some() {
+        columns.push(col::PROTOCOL_VERSION);
+    }
+    if mask.contains(Epoch::COMMITTEE_FIELD.name) {
+        columns.push(col::SYSTEM_STATE);
+    }
+
+    columns
 }

--- a/crates/sui-kvstore/src/bigtable/client/mod.rs
+++ b/crates/sui-kvstore/src/bigtable/client/mod.rs
@@ -258,6 +258,112 @@ impl BigTableClient {
         Ok(result)
     }
 
+    /// Fetch epochs with an optional column filter for partial reads.
+    /// When `columns` is None, all columns are fetched. When Some, only the
+    /// specified column qualifiers are fetched (e.g. `&["ep", "sc", "pv"]`).
+    pub async fn get_epochs_filtered(
+        &mut self,
+        epoch_ids: &[EpochId],
+        columns: Option<&[&str]>,
+    ) -> Result<Vec<EpochData>> {
+        let keys = epoch_ids
+            .iter()
+            .map(|id| tables::epochs::encode_key(*id))
+            .collect();
+        let filter = columns.map(|cols| {
+            let pattern = format!("^({})$", cols.join("|"));
+            RowFilter {
+                filter: Some(Filter::ColumnQualifierRegexFilter(pattern.into())),
+            }
+        });
+        let mut result = vec![];
+        for (_, row) in self.multi_get(tables::epochs::NAME, keys, filter).await? {
+            result.push(tables::epochs::decode(&row)?);
+        }
+        Ok(result)
+    }
+
+    /// Fetch the latest epoch with an optional column filter for partial reads.
+    pub async fn get_latest_epoch_filtered(
+        &mut self,
+        columns: Option<&[&str]>,
+    ) -> Result<Option<EpochData>> {
+        let upper_limit = tables::epochs::encode_key_upper_bound();
+        let filter = columns.map(|cols| {
+            let pattern = format!("^({})$", cols.join("|"));
+            RowFilter {
+                filter: Some(Filter::ColumnQualifierRegexFilter(pattern.into())),
+            }
+        });
+        match self
+            .range_scan(
+                tables::epochs::NAME,
+                None,
+                Some(upper_limit),
+                1,
+                true,
+                filter,
+            )
+            .await?
+            .pop()
+        {
+            Some((_, row)) => Ok(Some(tables::epochs::decode(&row)?)),
+            None => Ok(None),
+        }
+    }
+
+    /// Fetch checkpoints with an optional column filter for partial reads.
+    /// When `columns` is None, all columns are fetched. When Some, only the
+    /// specified column qualifiers are fetched (e.g. `&["s", "sg"]`).
+    pub async fn get_checkpoints_filtered(
+        &mut self,
+        sequence_numbers: &[CheckpointSequenceNumber],
+        columns: Option<&[&str]>,
+    ) -> Result<Vec<CheckpointData>> {
+        let keys = sequence_numbers
+            .iter()
+            .copied()
+            .map(tables::checkpoints::encode_key)
+            .collect();
+        let filter = columns.map(|cols| {
+            let pattern = format!("^({})$", cols.join("|"));
+            RowFilter {
+                filter: Some(Filter::ColumnQualifierRegexFilter(pattern.into())),
+            }
+        });
+        let mut checkpoints = vec![];
+        for (_, row) in self
+            .multi_get(tables::checkpoints::NAME, keys, filter)
+            .await?
+        {
+            checkpoints.push(tables::checkpoints::decode(&row)?);
+        }
+        Ok(checkpoints)
+    }
+
+    /// Fetch a checkpoint by digest with an optional column filter.
+    pub async fn get_checkpoint_by_digest_filtered(
+        &mut self,
+        digest: CheckpointDigest,
+        columns: Option<&[&str]>,
+    ) -> Result<Option<CheckpointData>> {
+        let key = tables::checkpoints_by_digest::encode_key(&digest);
+        let mut response = self
+            .multi_get(tables::checkpoints_by_digest::NAME, vec![key], None)
+            .await?;
+        if let Some((_, row)) = response.pop() {
+            let sequence_number = tables::checkpoints_by_digest::decode(&row)?;
+            if let Some(chk) = self
+                .get_checkpoints_filtered(&[sequence_number], columns)
+                .await?
+                .pop()
+            {
+                return Ok(Some(chk));
+            }
+        }
+        Ok(None)
+    }
+
     /// Get the pipeline watermark from the watermarks table.
     pub async fn get_pipeline_watermark(&mut self, pipeline: &str) -> Result<Option<Watermark>> {
         let pipeline_key = tables::watermarks::encode_key(pipeline);
@@ -577,6 +683,7 @@ impl BigTableClient {
 
     /// Scan a range of rows with optional start/end keys, limit, and direction.
     /// Applies `CellsPerColumnLimitFilter(1)` like `multi_get_internal`.
+    /// An optional column filter can be provided to restrict which columns are fetched.
     pub(crate) async fn range_scan(
         &mut self,
         table_name: &str,
@@ -584,10 +691,11 @@ impl BigTableClient {
         end_key: Option<Bytes>,
         limit: i64,
         reversed: bool,
+        filter: Option<RowFilter>,
     ) -> Result<Vec<(Bytes, Vec<(Bytes, Bytes)>)>> {
         let start_time = Instant::now();
         let result = self
-            .range_scan_internal(table_name, start_key, end_key, limit, reversed)
+            .range_scan_internal(table_name, start_key, end_key, limit, reversed, filter)
             .await;
         let elapsed_ms = start_time.elapsed().as_millis() as f64;
         let labels = [&self.client_name, table_name];
@@ -620,13 +728,22 @@ impl BigTableClient {
         end_key: Option<Bytes>,
         limit: i64,
         reversed: bool,
+        filter: Option<RowFilter>,
     ) -> Result<Vec<(Bytes, Vec<(Bytes, Bytes)>)>> {
         let range = RowRange {
             start_key: start_key.map(StartKey::StartKeyClosed),
             end_key: end_key.map(EndKey::EndKeyClosed),
         };
-        let filter = Some(RowFilter {
+        let version_filter = RowFilter {
             filter: Some(Filter::CellsPerColumnLimitFilter(1)),
+        };
+        let filter = Some(match filter {
+            Some(filter) => RowFilter {
+                filter: Some(Filter::Chain(Chain {
+                    filters: vec![filter, version_filter],
+                })),
+            },
+            None => version_filter,
         });
         let request = ReadRowsRequest {
             table_name: format!("{}{}", self.table_prefix, table_name),
@@ -682,36 +799,14 @@ impl KeyValueStoreReader for BigTableClient {
         &mut self,
         sequence_numbers: &[CheckpointSequenceNumber],
     ) -> Result<Vec<CheckpointData>> {
-        let keys = sequence_numbers
-            .iter()
-            .copied()
-            .map(tables::checkpoints::encode_key)
-            .collect();
-        let mut checkpoints = vec![];
-        for (_, row) in self
-            .multi_get(tables::checkpoints::NAME, keys, None)
-            .await?
-        {
-            checkpoints.push(tables::checkpoints::decode(&row)?);
-        }
-        Ok(checkpoints)
+        self.get_checkpoints_filtered(sequence_numbers, None).await
     }
 
     async fn get_checkpoint_by_digest(
         &mut self,
         digest: CheckpointDigest,
     ) -> Result<Option<CheckpointData>> {
-        let key = tables::checkpoints_by_digest::encode_key(&digest);
-        let mut response = self
-            .multi_get(tables::checkpoints_by_digest::NAME, vec![key], None)
-            .await?;
-        if let Some((_, row)) = response.pop() {
-            let sequence_number = tables::checkpoints_by_digest::decode(&row)?;
-            if let Some(chk) = self.get_checkpoints(&[sequence_number]).await?.pop() {
-                return Ok(Some(chk));
-            }
-        }
-        Ok(None)
+        self.get_checkpoint_by_digest_filtered(digest, None).await
     }
 
     async fn get_watermark_for_pipelines(
@@ -744,7 +839,14 @@ impl KeyValueStoreReader for BigTableClient {
     async fn get_latest_object(&mut self, object_id: &ObjectID) -> Result<Option<Object>> {
         let upper_limit = Bytes::from(Self::raw_object_key(&ObjectKey::max_for_id(object_id)));
         if let Some((_, row)) = self
-            .range_scan(tables::objects::NAME, None, Some(upper_limit), 1, true)
+            .range_scan(
+                tables::objects::NAME,
+                None,
+                Some(upper_limit),
+                1,
+                true,
+                None,
+            )
             .await?
             .pop()
         {
@@ -754,15 +856,7 @@ impl KeyValueStoreReader for BigTableClient {
     }
 
     async fn get_epoch(&mut self, epoch_id: EpochId) -> Result<Option<EpochData>> {
-        let key = tables::epochs::encode_key(epoch_id);
-        match self
-            .multi_get(tables::epochs::NAME, vec![key], None)
-            .await?
-            .pop()
-        {
-            Some((_, row)) => Ok(Some(tables::epochs::decode(&row)?)),
-            None => Ok(None),
-        }
+        Ok(self.get_epochs_filtered(&[epoch_id], None).await?.pop())
     }
 
     async fn get_protocol_configs(
@@ -781,15 +875,7 @@ impl KeyValueStoreReader for BigTableClient {
     }
 
     async fn get_latest_epoch(&mut self) -> Result<Option<EpochData>> {
-        let upper_limit = tables::epochs::encode_key_upper_bound();
-        match self
-            .range_scan(tables::epochs::NAME, None, Some(upper_limit), 1, true)
-            .await?
-            .pop()
-        {
-            Some((_, row)) => Ok(Some(tables::epochs::decode(&row)?)),
-            None => Ok(None),
-        }
+        self.get_latest_epoch_filtered(None).await
     }
 
     async fn get_events_for_transactions(
@@ -890,6 +976,7 @@ impl KeyValueStoreReader for BigTableClient {
                 Some(end_key),
                 50,
                 true,
+                None,
             )
             .await?;
 
@@ -932,6 +1019,7 @@ impl KeyValueStoreReader for BigTableClient {
                 Some(end_key),
                 fetch_limit,
                 descending,
+                None,
             )
             .await?;
 
@@ -974,6 +1062,7 @@ impl KeyValueStoreReader for BigTableClient {
                 Some(end_key),
                 limit as i64,
                 descending,
+                None,
             )
             .await?;
 
@@ -1013,6 +1102,7 @@ impl KeyValueStoreReader for BigTableClient {
                 end_key,
                 limit as i64,
                 false,
+                None,
             )
             .await?;
 

--- a/crates/sui-kvstore/src/lib.rs
+++ b/crates/sui-kvstore/src/lib.rs
@@ -124,9 +124,9 @@ pub struct BigTableIndexer {
 
 #[derive(Clone, Debug)]
 pub struct CheckpointData {
-    pub summary: CheckpointSummary,
-    pub contents: CheckpointContents,
-    pub signatures: AuthorityStrongQuorumSignInfo,
+    pub summary: Option<CheckpointSummary>,
+    pub contents: Option<CheckpointContents>,
+    pub signatures: Option<AuthorityStrongQuorumSignInfo>,
 }
 
 #[derive(Clone, Debug)]

--- a/crates/sui-kvstore/src/tables/checkpoints.rs
+++ b/crates/sui-kvstore/src/tables/checkpoints.rs
@@ -3,7 +3,7 @@
 
 //! Checkpoints table: stores full checkpoint data indexed by sequence number.
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use bytes::Bytes;
 use sui_types::crypto::AuthorityStrongQuorumSignInfo;
 use sui_types::messages_checkpoint::{
@@ -51,8 +51,8 @@ pub fn decode(row: &[(Bytes, Bytes)]) -> Result<CheckpointData> {
     }
 
     Ok(CheckpointData {
-        summary: summary.context("summary field is missing")?,
-        contents: contents.context("contents field is missing")?,
-        signatures: signatures.context("signatures field is missing")?,
+        summary,
+        contents,
+        signatures,
     })
 }

--- a/crates/sui-kvstore/tests/e2e.rs
+++ b/crates/sui-kvstore/tests/e2e.rs
@@ -26,6 +26,7 @@ use sui_kvstore::BigTableStore;
 use sui_kvstore::IndexerConfig;
 use sui_kvstore::KeyValueStoreReader;
 use sui_kvstore::PipelineLayer;
+use sui_kvstore::tables::{checkpoints, epochs, transactions};
 use sui_kvstore::testing::BigTableEmulator;
 use sui_kvstore::testing::INSTANCE_ID;
 use sui_kvstore::testing::create_tables;
@@ -352,33 +353,34 @@ async fn test_indexer_e2e() -> Result<()> {
 
     // -- Column-filtered partial reads --
     // Fetch with only effects + checkpoint columns — no td, sg, ev, or bc.
-    {
-        use sui_kvstore::tables::transactions::col;
-        let partial = harness
-            .bigtable_client()
-            .get_transactions_filtered(
-                &tx_digests,
-                Some(&[col::EFFECTS, col::CHECKPOINT_NUMBER, col::TIMESTAMP]),
-            )
-            .await?;
-        assert_eq!(partial.len(), tx_digests.len());
-        for tx in &partial {
-            // digest comes from the row key, always present
-            assert!(tx_digests.contains(&tx.digest));
-            // td was not fetched
-            assert!(tx.transaction_data.is_none(), "td should be absent");
-            // sg was not fetched
-            assert!(tx.signatures.is_none(), "sg should be absent");
-            // ef was fetched
-            assert!(tx.effects.is_some(), "ef should be present");
-            // ev was not fetched
-            assert!(tx.events.is_none(), "ev should be absent");
-            // bc was not fetched
-            assert!(tx.balance_changes.is_empty(), "bc should be empty");
-            // metadata always present
-            assert!(tx.checkpoint_number > 0);
-            assert!(tx.timestamp > 0);
-        }
+    let partial = harness
+        .bigtable_client()
+        .get_transactions_filtered(
+            &tx_digests,
+            Some(&[
+                transactions::col::EFFECTS,
+                transactions::col::CHECKPOINT_NUMBER,
+                transactions::col::TIMESTAMP,
+            ]),
+        )
+        .await?;
+    assert_eq!(partial.len(), tx_digests.len());
+    for tx in &partial {
+        // digest comes from the row key, always present
+        assert!(tx_digests.contains(&tx.digest));
+        // td was not fetched
+        assert!(tx.transaction_data.is_none(), "td should be absent");
+        // sg was not fetched
+        assert!(tx.signatures.is_none(), "sg should be absent");
+        // ef was fetched
+        assert!(tx.effects.is_some(), "ef should be present");
+        // ev was not fetched
+        assert!(tx.events.is_none(), "ev should be absent");
+        // bc was not fetched
+        assert!(tx.balance_changes.is_empty(), "bc should be empty");
+        // metadata always present
+        assert!(tx.checkpoint_number > 0);
+        assert!(tx.timestamp > 0);
     }
 
     // -- Balance changes parity with fullnode gRPC batch_get_transactions --
@@ -476,21 +478,23 @@ async fn test_indexer_e2e() -> Result<()> {
         .await?;
     assert_eq!(checkpoints.len(), checkpoint_numbers.len());
     for cp in &checkpoints {
-        assert!(checkpoint_numbers.contains(&cp.summary.sequence_number));
-        assert!(cp.summary.epoch == 0);
+        let summary = cp.summary.as_ref().unwrap();
+        let contents = cp.contents.as_ref().unwrap();
+        assert!(checkpoint_numbers.contains(&summary.sequence_number));
+        assert!(summary.epoch == 0);
 
-        let content_digests: Vec<_> = cp.contents.iter().map(|ed| ed.transaction).collect();
+        let content_digests: Vec<_> = contents.iter().map(|ed| ed.transaction).collect();
         let expected: Vec<_> = tx_digests
             .iter()
             .zip(&tx_checkpoints)
-            .filter(|(_, cp_num)| **cp_num == cp.summary.sequence_number)
+            .filter(|(_, cp_num)| **cp_num == summary.sequence_number)
             .map(|(d, _)| *d)
             .collect();
         for d in &expected {
             assert!(
                 content_digests.contains(d),
                 "checkpoint {} should contain txn {}",
-                cp.summary.sequence_number,
+                summary.sequence_number,
                 d,
             );
         }
@@ -498,15 +502,16 @@ async fn test_indexer_e2e() -> Result<()> {
 
     // -- Checkpoint-by-digest reverse index --
     for cp in &checkpoints {
-        let digest = cp.summary.digest();
+        let summary = cp.summary.as_ref().unwrap();
+        let digest = summary.digest();
         let found = harness
             .bigtable_client()
             .get_checkpoint_by_digest(digest)
             .await?;
         assert!(found.is_some(), "checkpoint by digest should exist");
         assert_eq!(
-            found.unwrap().summary.sequence_number,
-            cp.summary.sequence_number
+            found.unwrap().summary.as_ref().unwrap().sequence_number,
+            summary.sequence_number
         );
     }
 
@@ -650,6 +655,81 @@ async fn test_indexer_e2e() -> Result<()> {
     let latest = harness.bigtable_client().get_latest_epoch().await?;
     assert!(latest.is_some());
     assert!(latest.unwrap().epoch.unwrap() >= 1);
+
+    // -- Column-filtered checkpoint partial reads --
+    // Fetch with only summary column — no signatures or contents.
+    let partial = harness
+        .bigtable_client()
+        .get_checkpoints_filtered(&checkpoint_numbers, Some(&[checkpoints::col::SUMMARY]))
+        .await?;
+    assert_eq!(partial.len(), checkpoint_numbers.len());
+    for cp in &partial {
+        assert!(cp.summary.is_some(), "summary should be present");
+        assert!(cp.signatures.is_none(), "signatures should be absent");
+        assert!(cp.contents.is_none(), "contents should be absent");
+    }
+
+    // Fetch checkpoint by digest with only summary — verify two-step lookup works with filter.
+    let first_cp = checkpoints.first().unwrap();
+    let digest = first_cp.summary.as_ref().unwrap().digest();
+    let partial = harness
+        .bigtable_client()
+        .get_checkpoint_by_digest_filtered(digest, Some(&[checkpoints::col::SUMMARY]))
+        .await?
+        .expect("checkpoint by digest should exist");
+    assert!(partial.summary.is_some(), "summary should be present");
+    assert!(partial.signatures.is_none(), "signatures should be absent");
+    assert!(partial.contents.is_none(), "contents should be absent");
+
+    // -- Column-filtered epoch partial reads --
+    // Fetch epoch with only small scalar columns — no system_state.
+    let partial = harness
+        .bigtable_client()
+        .get_epochs_filtered(
+            &[0],
+            Some(&[
+                epochs::col::EPOCH,
+                epochs::col::START_CHECKPOINT,
+                epochs::col::PROTOCOL_VERSION,
+            ]),
+        )
+        .await?;
+    assert_eq!(partial.len(), 1);
+    let ep = &partial[0];
+    assert_eq!(ep.epoch, Some(0));
+    assert!(
+        ep.start_checkpoint.is_some(),
+        "start_checkpoint should be present"
+    );
+    assert!(
+        ep.protocol_version.is_some(),
+        "protocol_version should be present"
+    );
+    assert!(ep.system_state.is_none(), "system_state should be absent");
+    assert!(
+        ep.reference_gas_price.is_none(),
+        "reference_gas_price should be absent"
+    );
+
+    // Fetch latest epoch with column filter.
+    let partial = harness
+        .bigtable_client()
+        .get_latest_epoch_filtered(Some(&[epochs::col::EPOCH, epochs::col::START_TIMESTAMP]))
+        .await?
+        .expect("latest epoch should exist");
+    assert!(partial.epoch.is_some());
+    assert!(
+        partial.start_timestamp_ms.is_some(),
+        "start_timestamp should be present"
+    );
+    assert!(
+        partial.system_state.is_none(),
+        "system_state should be absent"
+    );
+    assert!(
+        partial.end_checkpoint.is_none(),
+        "end_checkpoint should be absent"
+    );
 
     Ok(())
 }


### PR DESCRIPTION
## Description

Avoid reading data from bigtable that isn't needed to render the grpc response based on the read mask.

## Test plan

Unit tests
