### PR TITLE
feat: proposal for OWS encrypted keystore backend

### DIFF
--- a/crates/sui-keys/src/ows_keystore_proposal.md
+++ b/crates/sui-keys/src/ows_keystore_proposal.md
@@ -1,0 +1,11 @@
+// NOTE: This is a proposal for adding OWS keystore support.
+// The Keystore enum would gain an Ows variant:
+//
+//   pub enum Keystore {
+//       File(FileBasedKeystore),
+//       InMem(InMemKeystore),
+//       Ows(OWSKeystore),  // <-- new
+//   }
+//
+// OWSKeystore would implement AccountKeystore by decrypting keys
+// from the OWS vault via ows-lib crate.


### PR DESCRIPTION
## Problem

`sui.keystore` stores private keys as plaintext Base64 strings in a JSON file:
```json
["AO2qBb...", "ALsXBb..."]
```
File permissions (0o600) are the only protection.

## Proposal

Add an `Ows` variant to the `Keystore` enum in `crates/sui-keys/src/keystore.rs`:

```rust
pub enum Keystore {
    File(FileBasedKeystore),
    InMem(InMemKeystore),
    Ows(OwsKeystore),  // new
}
```

`OwsKeystore` would implement `AccountKeystore` by decrypting keys from an [OWS](https://openwallet.sh) vault (AES-256-GCM, scrypt KDF) via the published `ows-lib` crate.

One wallet created with `ows wallet create` works in Sui CLI, Solana CLI, Foundry, and any other OWS-integrated tool.