### PR TITLE
Spawn node for new validator in voting power decrease tests

### DIFF
--- a/crates/sui-e2e-tests/tests/reconfiguration_tests.rs
+++ b/crates/sui-e2e-tests/tests/reconfiguration_tests.rs
@@ -485,6 +485,8 @@ async fn test_reconfig_with_voting_power_decrease() {
     execute_add_validator_transactions(&mut test_cluster, &new_validator, Some(min_join_stake))
         .await;
 
+    let _new_validator_handle = test_cluster.spawn_new_validator(new_validator).await;
+
     test_cluster.trigger_reconfiguration().await;
 
     // Check that a new validator has joined the committee.
@@ -645,6 +647,8 @@ async fn test_reconfig_with_voting_power_decrease_immediate_removal() {
 
     execute_add_validator_transactions(&mut test_cluster, &new_validator, Some(min_join_stake))
         .await;
+
+    let _new_validator_handle = test_cluster.spawn_new_validator(new_validator).await;
 
     test_cluster.trigger_reconfiguration().await;
 


### PR DESCRIPTION
## Summary

- `test_reconfig_with_voting_power_decrease` and `test_reconfig_with_voting_power_decrease_immediate_removal` add a validator candidate to the committee without spawning a node for it
- This "phantom" validator causes consensus commit sync timeouts on other validators, which can lag far enough behind to stall the epoch transition permanently
- Fix: spawn a node for the new validator before triggering reconfiguration, so all committee members participate in consensus

## Root cause

The commit syncer tries peers sequentially with long timeouts (up to 80s per peer). When the phantom validator is selected early in the shuffled peer list, the syncing validator blocks for the full timeout before trying the next peer. This causes it to fall ~120 rounds behind in consensus, preventing the epoch-closing checkpoint from being finalized.

## Test plan

- Reproduced `test_reconfig_with_voting_power_decrease` failure with `MSIM_TEST_SEED=1774345109 MSIM_TEST_NUM=30`
- Verified all 30 iterations pass with the fix