### PR TITLE
[Block Streaming] introduce the BlockSyncService and implement the Observer client and server sync endpoints

### DIFF
--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -805,7 +805,7 @@ mod tests {
             ..Default::default()
         };
 
-        let (observer_commit_consumer, _observer_commit_receiver) = CommitConsumerArgs::new(0, 0);
+        let (observer_commit_consumer, observer_commit_receiver) = CommitConsumerArgs::new(0, 0);
         let observer = ConsensusAuthority::start(
             network_type,
             0,
@@ -821,6 +821,9 @@ mod tests {
             0,
         )
         .await;
+        // The relevant endpoints are now implemented for the synchronizer and commit_syncer components, so the Observer node should be able to catch up and
+        // fetch blocks beyond the latest ones that are fetched from the stream.
+        commit_receivers.push(observer_commit_receiver);
 
         // Give Observer more time to connect and sync
         sleep(Duration::from_secs(5)).await;

--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -386,6 +386,7 @@ where
             round_tracker.clone(),
             commit_syncer_client.clone(),
             dag_state.clone(),
+            peers_pool.clone(),
         )
         .start();
 

--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -18,6 +18,7 @@ use crate::{
     BlockAPI as _, CommitConsumerArgs,
     authority_service::AuthorityService,
     block_manager::BlockManager,
+    block_sync_service::BlockSyncService,
     block_verifier::SignedBlockVerifier,
     commit_observer::CommitObserver,
     commit_syncer::{CommitSyncer, CommitSyncerHandle},
@@ -388,6 +389,13 @@ where
         )
         .start();
 
+        // Create BlockSyncService that will be shared by both AuthorityService and ObserverService
+        let block_sync_service = Arc::new(BlockSyncService::new(
+            context.clone(),
+            dag_state.clone(),
+            store.clone(),
+        ));
+
         let (subscriber, round_prober_handle) = if context.is_validator() {
             let authority_service = Arc::new(AuthorityService::new(
                 context.clone(),
@@ -399,7 +407,7 @@ where
                 signals_receivers.block_broadcast_receiver(),
                 transaction_vote_tracker.clone(),
                 dag_state.clone(),
-                store.clone(),
+                block_sync_service.clone(),
             ));
 
             // Start the validator server if this is a validator node.
@@ -443,6 +451,7 @@ where
                     commit_vote_monitor.clone(),
                     transaction_vote_tracker.clone(),
                     synchronizer.clone(),
+                    block_sync_service.clone(),
                 ));
                 network_manager
                     .start_observer_server(observer_service)
@@ -462,6 +471,7 @@ where
                 commit_vote_monitor.clone(),
                 transaction_vote_tracker.clone(),
                 synchronizer.clone(),
+                block_sync_service.clone(),
             ));
 
             let observer_subscriber = ObserverSubscriber::new(

--- a/consensus/core/src/authority_service.rs
+++ b/consensus/core/src/authority_service.rs
@@ -1,13 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{
-    cmp::Reverse,
-    collections::{BTreeMap, BTreeSet, BinaryHeap},
-    pin::Pin,
-    sync::Arc,
-    time::Duration,
-};
+use std::{collections::BTreeMap, pin::Pin, sync::Arc, time::Duration};
 
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -16,7 +10,6 @@ use consensus_types::block::{BlockRef, Round};
 use futures::{Stream, StreamExt, ready, stream, task};
 use mysten_metrics::spawn_monitored_task;
 use parking_lot::RwLock;
-use rand::seq::SliceRandom as _;
 use sui_macros::fail_point_async;
 use tap::TapFallible;
 use tokio::sync::broadcast;
@@ -24,10 +17,10 @@ use tokio_util::sync::ReusableBoxFuture;
 use tracing::{debug, info, warn};
 
 use crate::{
-    CommitIndex,
     block::{BlockAPI as _, ExtendedBlock, GENESIS_ROUND, SignedBlock, VerifiedBlock},
+    block_sync_service::BlockSyncService,
     block_verifier::BlockVerifier,
-    commit::{CommitAPI as _, CommitRange, TrustedCommit},
+    commit::{CommitRange, TrustedCommit},
     commit_vote_monitor::CommitVoteMonitor,
     context::Context,
     core_thread::CoreThreadDispatcher,
@@ -38,8 +31,6 @@ use crate::{
         ObserverNetworkService, PeerId, ValidatorNetworkService,
     },
     round_tracker::RoundTracker,
-    stake_aggregator::{QuorumThreshold, StakeAggregator},
-    storage::Store,
     synchronizer::SynchronizerHandle,
     transaction_vote_tracker::TransactionVoteTracker,
 };
@@ -57,8 +48,8 @@ pub(crate) struct AuthorityService<C: CoreThreadDispatcher> {
     subscription_counter: Arc<SubscriptionCounter>,
     transaction_vote_tracker: TransactionVoteTracker,
     dag_state: Arc<RwLock<DagState>>,
-    store: Arc<dyn Store>,
     round_tracker: Arc<RwLock<RoundTracker>>,
+    block_sync_service: Arc<BlockSyncService>,
 }
 
 impl<C: CoreThreadDispatcher> AuthorityService<C> {
@@ -72,7 +63,7 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
         rx_block_broadcast: broadcast::Receiver<ExtendedBlock>,
         transaction_vote_tracker: TransactionVoteTracker,
         dag_state: Arc<RwLock<DagState>>,
-        store: Arc<dyn Store>,
+        block_sync_service: Arc<BlockSyncService>,
     ) -> Self {
         let subscription_counter = Arc::new(SubscriptionCounter::new(context.clone()));
         Self {
@@ -85,8 +76,8 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
             subscription_counter,
             transaction_vote_tracker,
             dag_state,
-            store,
             round_tracker,
+            block_sync_service,
         }
     }
 
@@ -415,145 +406,16 @@ impl<C: CoreThreadDispatcher> ValidatorNetworkService for AuthorityService<C> {
     async fn handle_fetch_blocks(
         &self,
         _peer: AuthorityIndex,
-        mut block_refs: Vec<BlockRef>,
+        block_refs: Vec<BlockRef>,
         fetch_after_rounds: Vec<Round>,
         fetch_missing_ancestors: bool,
     ) -> ConsensusResult<Vec<Bytes>> {
         fail_point_async!("consensus-rpc-response");
 
-        if block_refs.is_empty() && (fetch_missing_ancestors || fetch_after_rounds.is_empty()) {
-            return Err(ConsensusError::InvalidFetchBlocksRequest("When no block refs are provided, fetch_after_rounds must be provided and fetch_missing_ancestors must be false".to_string()));
-        }
-        if !fetch_after_rounds.is_empty()
-            && fetch_after_rounds.len() != self.context.committee.size()
-        {
-            return Err(ConsensusError::InvalidSizeOfHighestAcceptedRounds(
-                fetch_after_rounds.len(),
-                self.context.committee.size(),
-            ));
-        }
-
-        // Finds the suitable limit of # of blocks to return.
-        let max_response_num_blocks = if !fetch_after_rounds.is_empty() && !block_refs.is_empty() {
-            self.context.parameters.max_blocks_per_sync
-        } else {
-            self.context.parameters.max_blocks_per_fetch
-        };
-        if block_refs.len() > max_response_num_blocks {
-            block_refs.truncate(max_response_num_blocks);
-        }
-
-        // Validate the requested block refs.
-        for block in &block_refs {
-            if !self.context.committee.is_valid_index(block.author) {
-                return Err(ConsensusError::InvalidAuthorityIndex {
-                    index: block.author,
-                    max: self.context.committee.size(),
-                });
-            }
-            if block.round == GENESIS_ROUND {
-                return Err(ConsensusError::UnexpectedGenesisBlockRequested);
-            }
-        }
-
-        // Get the requested blocks first.
-        let mut blocks = self
-            .dag_state
-            .read()
-            .get_blocks(&block_refs)
-            .into_iter()
-            .flatten()
-            .collect::<Vec<_>>();
-
-        // When fetch_missing_ancestors is true, fetch missing ancestors of the requested blocks.
-        // Otherwise, fetch additional blocks depth-first from the requested block authorities.
-        if blocks.len() < max_response_num_blocks && !fetch_after_rounds.is_empty() {
-            if fetch_missing_ancestors {
-                // Get unique missing ancestor blocks of the requested blocks (validated to be non-empty).
-                // fetch_after_rounds will only be used to filter out already accepted blocks.
-                let missing_ancestors = blocks
-                    .iter()
-                    .flat_map(|block| block.ancestors().to_vec())
-                    .filter(|block_ref| fetch_after_rounds[block_ref.author] < block_ref.round)
-                    .collect::<BTreeSet<_>>()
-                    .into_iter()
-                    .collect::<Vec<_>>();
-
-                // If there are too many missing ancestors, randomly select a subset to avoid
-                // fetching duplicated blocks across peers.
-                let selected_num_blocks = max_response_num_blocks
-                    .saturating_sub(blocks.len())
-                    .min(missing_ancestors.len());
-                if selected_num_blocks > 0 {
-                    let selected_ancestor_refs = missing_ancestors
-                        .choose_multiple(&mut mysten_common::random::get_rng(), selected_num_blocks)
-                        .copied()
-                        .collect::<Vec<_>>();
-                    let ancestor_blocks = self
-                        .dag_state
-                        .read()
-                        .get_blocks(&selected_ancestor_refs)
-                        .into_iter()
-                        .flatten();
-                    blocks.extend(ancestor_blocks);
-                }
-            } else {
-                // Get additional blocks from authorities with missing block.
-                // Compute the fetch round per requested authority, or all authorities.
-                let mut limit_rounds = BTreeMap::<AuthorityIndex, Round>::new();
-                if block_refs.is_empty() {
-                    let dag_state = self.dag_state.read();
-                    for (index, _authority) in self.context.committee.authorities() {
-                        let last_block = dag_state.get_last_block_for_authority(index);
-                        limit_rounds.insert(index, last_block.round());
-                    }
-                } else {
-                    for block_ref in &block_refs {
-                        let entry = limit_rounds
-                            .entry(block_ref.author)
-                            .or_insert(block_ref.round);
-                        *entry = (*entry).min(block_ref.round);
-                    }
-                }
-
-                // Use a min-heap to fetch blocks across authorities in ascending round order.
-                // Each entry is (fetch_start_round, authority, limit_round).
-                let mut heap = BinaryHeap::new();
-                for (authority, limit_round) in &limit_rounds {
-                    let fetch_start = fetch_after_rounds[*authority] + 1;
-                    if fetch_start < *limit_round {
-                        heap.push(Reverse((fetch_start, *authority, *limit_round)));
-                    }
-                }
-
-                while let Some(Reverse((fetch_start, authority, limit_round))) = heap.pop() {
-                    let fetched = self.store.scan_blocks_by_author_in_range(
-                        authority,
-                        fetch_start,
-                        limit_round,
-                        1,
-                    )?;
-                    if let Some(block) = fetched.into_iter().next() {
-                        let next_start = block.round() + 1;
-                        blocks.push(block);
-                        if blocks.len() >= max_response_num_blocks {
-                            blocks.truncate(max_response_num_blocks);
-                            break;
-                        }
-                        if next_start < limit_round {
-                            heap.push(Reverse((next_start, authority, limit_round)));
-                        }
-                    }
-                }
-            }
-        }
-
-        // Return the serialized blocks
-        let bytes = blocks
-            .into_iter()
-            .map(|block| block.serialized().clone())
-            .collect::<Vec<_>>();
-        Ok(bytes)
+        // Delegate to BlockSyncService
+        self.block_sync_service
+            .fetch_blocks(block_refs, fetch_after_rounds, fetch_missing_ancestors)
+            .await
     }
 
     async fn handle_fetch_commits(
@@ -563,47 +425,8 @@ impl<C: CoreThreadDispatcher> ValidatorNetworkService for AuthorityService<C> {
     ) -> ConsensusResult<(Vec<TrustedCommit>, Vec<VerifiedBlock>)> {
         fail_point_async!("consensus-rpc-response");
 
-        // Compute an inclusive end index and bound the maximum number of commits scanned.
-        let inclusive_end = commit_range.end().min(
-            commit_range.start() + self.context.parameters.commit_sync_batch_size as CommitIndex
-                - 1,
-        );
-        let mut commits = self
-            .store
-            .scan_commits((commit_range.start()..=inclusive_end).into())?;
-        let mut certifier_block_refs = vec![];
-        'commit: while let Some(c) = commits.last() {
-            let index = c.index();
-            let votes = self.store.read_commit_votes(index)?;
-            let mut stake_aggregator = StakeAggregator::<QuorumThreshold>::new();
-            for v in &votes {
-                stake_aggregator.add(v.author, &self.context.committee);
-            }
-            if stake_aggregator.reached_threshold(&self.context.committee) {
-                certifier_block_refs = votes;
-                break 'commit;
-            } else {
-                debug!(
-                    "Commit {} votes did not reach quorum to certify, {} < {}, skipping",
-                    index,
-                    stake_aggregator.stake(),
-                    stake_aggregator.threshold(&self.context.committee)
-                );
-                self.context
-                    .metrics
-                    .node_metrics
-                    .commit_sync_fetch_commits_handler_uncertified_skipped
-                    .inc();
-                commits.pop();
-            }
-        }
-        let certifier_blocks = self
-            .store
-            .read_blocks(&certifier_block_refs)?
-            .into_iter()
-            .flatten()
-            .collect();
-        Ok((commits, certifier_blocks))
+        // Delegate to BlockSyncService
+        self.block_sync_service.fetch_commits(commit_range).await
     }
 
     async fn handle_fetch_latest_blocks(
@@ -613,43 +436,10 @@ impl<C: CoreThreadDispatcher> ValidatorNetworkService for AuthorityService<C> {
     ) -> ConsensusResult<Vec<Bytes>> {
         fail_point_async!("consensus-rpc-response");
 
-        if authorities.len() > self.context.committee.size() {
-            return Err(ConsensusError::TooManyAuthoritiesProvided(peer));
-        }
-
-        // Ensure that those are valid authorities
-        for authority in &authorities {
-            if !self.context.committee.is_valid_index(*authority) {
-                return Err(ConsensusError::InvalidAuthorityIndex {
-                    index: *authority,
-                    max: self.context.committee.size(),
-                });
-            }
-        }
-
-        // Read from the dag state to find the latest blocks.
-        // TODO: at the moment we don't look into the block manager for suspended blocks. Ideally we
-        // want in the future if we think we would like to tackle the majority of cases.
-        let mut blocks = vec![];
-        let dag_state = self.dag_state.read();
-        for authority in authorities {
-            let block = dag_state.get_last_block_for_authority(authority);
-
-            debug!("Latest block for {authority}: {block:?} as requested from {peer}");
-
-            // no reason to serve back the genesis block - it's equal as if it has not received any block
-            if block.round() != GENESIS_ROUND {
-                blocks.push(block);
-            }
-        }
-
-        // Return the serialised blocks
-        let result = blocks
-            .into_iter()
-            .map(|block| block.serialized().clone())
-            .collect::<Vec<_>>();
-
-        Ok(result)
+        // Delegate to BlockSyncService
+        self.block_sync_service
+            .fetch_latest_blocks(peer, authorities)
+            .await
     }
 
     async fn handle_get_latest_rounds(
@@ -699,6 +489,8 @@ impl<C: CoreThreadDispatcher> ObserverNetworkService for AuthorityService<C> {
         &self,
         _peer: NodeId,
         _block_refs: Vec<BlockRef>,
+        _highest_accepted_rounds: Vec<Round>,
+        _breadth_first: bool,
     ) -> ConsensusResult<Vec<Bytes>> {
         // TODO: implement observer fetch blocks, similar to validator fetch_blocks but
         // without highest_accepted_rounds.
@@ -929,6 +721,7 @@ mod tests {
     use crate::{
         authority_service::AuthorityService,
         block::{BlockAPI, SignedBlock, TestBlock, VerifiedBlock},
+        block_sync_service::BlockSyncService,
         commit::{CertifiedCommits, CommitRange},
         commit_vote_monitor::CommitVoteMonitor,
         context::Context,
@@ -1080,6 +873,8 @@ mod tests {
             &self,
             _peer: crate::network::PeerId,
             _block_refs: Vec<BlockRef>,
+            _highest_accepted_rounds: Vec<Round>,
+            _breadth_first: bool,
             _timeout: Duration,
         ) -> ConsensusResult<Vec<Bytes>> {
             unimplemented!("Unimplemented")
@@ -1127,6 +922,11 @@ mod tests {
             peers_pool.clone(),
             false,
         );
+        let block_sync_service = Arc::new(BlockSyncService::new(
+            context.clone(),
+            dag_state.clone(),
+            store.clone(),
+        ));
         let authority_service = Arc::new(AuthorityService::new(
             context.clone(),
             block_verifier,
@@ -1137,7 +937,7 @@ mod tests {
             rx_block_broadcast,
             transaction_vote_tracker,
             dag_state,
-            store,
+            block_sync_service,
         ));
 
         // Test delaying blocks with time drift.
@@ -1248,6 +1048,11 @@ mod tests {
             peers_pool.clone(),
             false,
         );
+        let block_sync_service = Arc::new(BlockSyncService::new(
+            context.clone(),
+            dag_state.clone(),
+            store.clone(),
+        ));
         let authority_service = Arc::new(AuthorityService::new(
             context.clone(),
             block_verifier,
@@ -1258,7 +1063,7 @@ mod tests {
             rx_block_broadcast,
             transaction_vote_tracker,
             dag_state.clone(),
-            store,
+            block_sync_service,
         ));
 
         // GIVEN: 40 rounds of blocks in the dag state.
@@ -1459,6 +1264,11 @@ mod tests {
             peers_pool.clone(),
             true,
         );
+        let block_sync_service = Arc::new(BlockSyncService::new(
+            context.clone(),
+            dag_state.clone(),
+            store.clone(),
+        ));
         let authority_service = Arc::new(AuthorityService::new(
             context.clone(),
             block_verifier,
@@ -1469,7 +1279,7 @@ mod tests {
             rx_block_broadcast,
             transaction_vote_tracker,
             dag_state.clone(),
-            store,
+            block_sync_service,
         ));
 
         // Create some blocks for a few authorities. Create some equivocations as well and store in dag state.
@@ -1533,6 +1343,11 @@ mod tests {
             peers_pool.clone(),
             false,
         );
+        let block_sync_service = Arc::new(BlockSyncService::new(
+            context.clone(),
+            dag_state.clone(),
+            store.clone(),
+        ));
 
         // Create 3 proposed blocks at rounds 5, 10, 15 for own authority (index 0)
         dag_state
@@ -1555,7 +1370,7 @@ mod tests {
             rx_block_broadcast,
             transaction_vote_tracker,
             dag_state.clone(),
-            store,
+            block_sync_service,
         ));
 
         let peer = context.committee.to_authority_index(1).unwrap();
@@ -1624,6 +1439,11 @@ mod tests {
             peers_pool.clone(),
             false,
         );
+        let block_sync_service = Arc::new(BlockSyncService::new(
+            context.clone(),
+            dag_state.clone(),
+            store.clone(),
+        ));
 
         // No blocks added to DagState - only genesis exists
 
@@ -1637,7 +1457,7 @@ mod tests {
             rx_block_broadcast,
             transaction_vote_tracker,
             dag_state.clone(),
-            store,
+            block_sync_service,
         ));
 
         let peer = context.committee.to_authority_index(1).unwrap();

--- a/consensus/core/src/authority_service.rs
+++ b/consensus/core/src/authority_service.rs
@@ -26,10 +26,7 @@ use crate::{
     core_thread::CoreThreadDispatcher,
     dag_state::DagState,
     error::{ConsensusError, ConsensusResult},
-    network::{
-        BlockStream, ExtendedSerializedBlock, NodeId, ObserverBlockStream, ObserverBlockStreamItem,
-        ObserverNetworkService, PeerId, ValidatorNetworkService,
-    },
+    network::{BlockStream, ExtendedSerializedBlock, PeerId, ValidatorNetworkService},
     round_tracker::RoundTracker,
     synchronizer::SynchronizerHandle,
     transaction_vote_tracker::TransactionVoteTracker,
@@ -463,53 +460,6 @@ impl<C: CoreThreadDispatcher> ValidatorNetworkService for AuthorityService<C> {
     }
 }
 
-#[async_trait]
-impl<C: CoreThreadDispatcher> ObserverNetworkService for AuthorityService<C> {
-    async fn handle_block(
-        &self,
-        _peer: PeerId,
-        _item: ObserverBlockStreamItem,
-    ) -> ConsensusResult<()> {
-        // TODO: implement observer block handling, similar to validator block handling.
-        Err(ConsensusError::NetworkRequest(
-            "Observer block handling not yet implemented".to_string(),
-        ))
-    }
-
-    async fn handle_stream_blocks(
-        &self,
-        _peer: NodeId,
-        _highest_round_per_authority: Vec<u64>,
-    ) -> ConsensusResult<ObserverBlockStream> {
-        // TODO: Implement observer block streaming
-        todo!("Observer block streaming not yet implemented")
-    }
-
-    async fn handle_fetch_blocks(
-        &self,
-        _peer: NodeId,
-        _block_refs: Vec<BlockRef>,
-        _highest_accepted_rounds: Vec<Round>,
-        _breadth_first: bool,
-    ) -> ConsensusResult<Vec<Bytes>> {
-        // TODO: implement observer fetch blocks, similar to validator fetch_blocks but
-        // without highest_accepted_rounds.
-        Err(ConsensusError::NetworkRequest(
-            "Observer fetch blocks not yet implemented".to_string(),
-        ))
-    }
-
-    async fn handle_fetch_commits(
-        &self,
-        _peer: NodeId,
-        _commit_range: CommitRange,
-    ) -> ConsensusResult<(Vec<TrustedCommit>, Vec<VerifiedBlock>)> {
-        // TODO: implement observer fetch commits, similar to validator fetch_commits.
-        Err(ConsensusError::NetworkRequest(
-            "Observer fetch commits not yet implemented".to_string(),
-        ))
-    }
-}
 struct Counter {
     count: usize,
     subscriptions_by_peer: BTreeMap<PeerId, usize>,
@@ -873,8 +823,8 @@ mod tests {
             &self,
             _peer: crate::network::PeerId,
             _block_refs: Vec<BlockRef>,
-            _highest_accepted_rounds: Vec<Round>,
-            _breadth_first: bool,
+            _fetch_after_rounds: Vec<Round>,
+            _fetch_missing_ancestors: bool,
             _timeout: Duration,
         ) -> ConsensusResult<Vec<Bytes>> {
             unimplemented!("Unimplemented")

--- a/consensus/core/src/block_sync_service.rs
+++ b/consensus/core/src/block_sync_service.rs
@@ -281,6 +281,8 @@ impl BlockSyncService {
         }
 
         // Read from the dag state to find the latest blocks
+        // TODO: at the moment we don't look into the block manager for suspended blocks. Ideally we
+        // want in the future if we think we would like to tackle the majority of cases.
         let mut blocks = vec![];
         let dag_state = self.dag_state.read();
         for authority in authorities {
@@ -288,7 +290,7 @@ impl BlockSyncService {
 
             debug!("Latest block for {authority}: {block:?}");
 
-            // No reason to serve back the genesis block
+            // no reason to serve back the genesis block - it's equal as if it has not received any block
             if block.round() != GENESIS_ROUND {
                 blocks.push(block);
             }

--- a/consensus/core/src/block_sync_service.rs
+++ b/consensus/core/src/block_sync_service.rs
@@ -1,0 +1,300 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{
+    cmp::Reverse,
+    collections::{BTreeMap, BTreeSet, BinaryHeap},
+    sync::Arc,
+};
+
+use bytes::Bytes;
+use consensus_config::AuthorityIndex;
+use consensus_types::block::{BlockRef, Round};
+use parking_lot::RwLock;
+use rand::seq::SliceRandom;
+use tracing::debug;
+
+use crate::{
+    CommitIndex, VerifiedBlock,
+    block::{BlockAPI, GENESIS_ROUND},
+    commit::{CommitAPI, CommitRange, TrustedCommit},
+    context::Context,
+    dag_state::DagState,
+    error::{ConsensusError, ConsensusResult},
+    stake_aggregator::{QuorumThreshold, StakeAggregator},
+    storage::Store,
+};
+
+/// Provides shared block synchronization functionality for both AuthorityService and ObserverService.
+/// This service handles fetch requests from synchronizer and commit_syncer components,
+/// eliminating code duplication between the two network services.
+pub(crate) struct BlockSyncService {
+    context: Arc<Context>,
+    dag_state: Arc<RwLock<DagState>>,
+    store: Arc<dyn Store>,
+}
+
+impl BlockSyncService {
+    pub fn new(
+        context: Arc<Context>,
+        dag_state: Arc<RwLock<DagState>>,
+        store: Arc<dyn Store>,
+    ) -> Self {
+        Self {
+            context,
+            dag_state,
+            store,
+        }
+    }
+
+    /// Fetches blocks from the DAG state based on the provided block references.
+    ///
+    /// This method handles two types of requests:
+    /// 1. Missing block for block sync (when highest_accepted_rounds is provided):
+    ///    - Returns up to max_blocks_per_sync blocks
+    ///    - Can fetch ancestors if breadth_first is true
+    ///    - Can fetch additional blocks from authorities with missing blocks
+    /// 2. Committed block for commit sync (when highest_accepted_rounds is empty):
+    ///    - Returns up to max_blocks_per_fetch blocks
+    ///    - Simple fetch of requested blocks only
+    pub async fn fetch_blocks(
+        &self,
+        mut block_refs: Vec<BlockRef>,
+        fetch_after_rounds: Vec<Round>,
+        fetch_missing_ancestors: bool,
+    ) -> ConsensusResult<Vec<Bytes>> {
+        if block_refs.is_empty() && (fetch_missing_ancestors || fetch_after_rounds.is_empty()) {
+            return Err(ConsensusError::InvalidFetchBlocksRequest("When no block refs are provided, fetch_after_rounds must be provided and fetch_missing_ancestors must be false".to_string()));
+        }
+        if !fetch_after_rounds.is_empty()
+            && fetch_after_rounds.len() != self.context.committee.size()
+        {
+            return Err(ConsensusError::InvalidSizeOfHighestAcceptedRounds(
+                fetch_after_rounds.len(),
+                self.context.committee.size(),
+            ));
+        }
+
+        // Finds the suitable limit of # of blocks to return.
+        let max_response_num_blocks = if !fetch_after_rounds.is_empty() && !block_refs.is_empty() {
+            self.context.parameters.max_blocks_per_sync
+        } else {
+            self.context.parameters.max_blocks_per_fetch
+        };
+        if block_refs.len() > max_response_num_blocks {
+            block_refs.truncate(max_response_num_blocks);
+        }
+
+        // Validate the requested block refs.
+        for block in &block_refs {
+            if !self.context.committee.is_valid_index(block.author) {
+                return Err(ConsensusError::InvalidAuthorityIndex {
+                    index: block.author,
+                    max: self.context.committee.size(),
+                });
+            }
+            if block.round == GENESIS_ROUND {
+                return Err(ConsensusError::UnexpectedGenesisBlockRequested);
+            }
+        }
+
+        // Get the requested blocks first.
+        let mut blocks = self
+            .dag_state
+            .read()
+            .get_blocks(&block_refs)
+            .into_iter()
+            .flatten()
+            .collect::<Vec<_>>();
+
+        // When fetch_missing_ancestors is true, fetch missing ancestors of the requested blocks.
+        // Otherwise, fetch additional blocks depth-first from the requested block authorities.
+        if blocks.len() < max_response_num_blocks && !fetch_after_rounds.is_empty() {
+            if fetch_missing_ancestors {
+                // Get unique missing ancestor blocks of the requested blocks (validated to be non-empty).
+                // fetch_after_rounds will only be used to filter out already accepted blocks.
+                let missing_ancestors = blocks
+                    .iter()
+                    .flat_map(|block| block.ancestors().to_vec())
+                    .filter(|block_ref| fetch_after_rounds[block_ref.author] < block_ref.round)
+                    .collect::<BTreeSet<_>>()
+                    .into_iter()
+                    .collect::<Vec<_>>();
+
+                // If there are too many missing ancestors, randomly select a subset to avoid
+                // fetching duplicated blocks across peers.
+                let selected_num_blocks = max_response_num_blocks
+                    .saturating_sub(blocks.len())
+                    .min(missing_ancestors.len());
+                if selected_num_blocks > 0 {
+                    let selected_ancestor_refs = missing_ancestors
+                        .choose_multiple(&mut mysten_common::random::get_rng(), selected_num_blocks)
+                        .copied()
+                        .collect::<Vec<_>>();
+                    let ancestor_blocks = self
+                        .dag_state
+                        .read()
+                        .get_blocks(&selected_ancestor_refs)
+                        .into_iter()
+                        .flatten();
+                    blocks.extend(ancestor_blocks);
+                }
+            } else {
+                // Get additional blocks from authorities with missing block.
+                // Compute the fetch round per requested authority, or all authorities.
+                let mut limit_rounds = BTreeMap::<AuthorityIndex, Round>::new();
+                if block_refs.is_empty() {
+                    let dag_state = self.dag_state.read();
+                    for (index, _authority) in self.context.committee.authorities() {
+                        let last_block = dag_state.get_last_block_for_authority(index);
+                        limit_rounds.insert(index, last_block.round());
+                    }
+                } else {
+                    for block_ref in &block_refs {
+                        let entry = limit_rounds
+                            .entry(block_ref.author)
+                            .or_insert(block_ref.round);
+                        *entry = (*entry).min(block_ref.round);
+                    }
+                }
+
+                // Use a min-heap to fetch blocks across authorities in ascending round order.
+                // Each entry is (fetch_start_round, authority, limit_round).
+                let mut heap = BinaryHeap::new();
+                for (authority, limit_round) in &limit_rounds {
+                    let fetch_start = fetch_after_rounds[*authority] + 1;
+                    if fetch_start < *limit_round {
+                        heap.push(Reverse((fetch_start, *authority, *limit_round)));
+                    }
+                }
+
+                while let Some(Reverse((fetch_start, authority, limit_round))) = heap.pop() {
+                    let fetched = self.store.scan_blocks_by_author_in_range(
+                        authority,
+                        fetch_start,
+                        limit_round,
+                        1,
+                    )?;
+                    if let Some(block) = fetched.into_iter().next() {
+                        let next_start = block.round() + 1;
+                        blocks.push(block);
+                        if blocks.len() >= max_response_num_blocks {
+                            blocks.truncate(max_response_num_blocks);
+                            break;
+                        }
+                        if next_start < limit_round {
+                            heap.push(Reverse((next_start, authority, limit_round)));
+                        }
+                    }
+                }
+            }
+        }
+
+        // Return the serialized blocks
+        let bytes = blocks
+            .into_iter()
+            .map(|block| block.serialized().clone())
+            .collect::<Vec<_>>();
+        Ok(bytes)
+    }
+
+    /// Fetches commits and their certifying blocks from the store.
+    ///
+    /// Returns commits within the specified range along with the blocks that certify
+    /// the last commit (if it has reached quorum).
+    pub async fn fetch_commits(
+        &self,
+        commit_range: CommitRange,
+    ) -> ConsensusResult<(Vec<TrustedCommit>, Vec<VerifiedBlock>)> {
+        // Compute an inclusive end index and bound the maximum number of commits scanned
+        let inclusive_end = commit_range.end().min(
+            commit_range.start() + self.context.parameters.commit_sync_batch_size as CommitIndex
+                - 1,
+        );
+        let mut commits = self
+            .store
+            .scan_commits((commit_range.start()..=inclusive_end).into())?;
+
+        let mut certifier_block_refs = vec![];
+
+        // Find the last commit that has reached quorum
+        'commit: while let Some(c) = commits.last() {
+            let index = c.index();
+            let votes = self.store.read_commit_votes(index)?;
+            let mut stake_aggregator = StakeAggregator::<QuorumThreshold>::new();
+            for v in &votes {
+                stake_aggregator.add(v.author, &self.context.committee);
+            }
+            if stake_aggregator.reached_threshold(&self.context.committee) {
+                certifier_block_refs = votes;
+                break 'commit;
+            } else {
+                debug!(
+                    "Commit {} votes did not reach quorum to certify, {} < {}, skipping",
+                    index,
+                    stake_aggregator.stake(),
+                    stake_aggregator.threshold(&self.context.committee)
+                );
+                self.context
+                    .metrics
+                    .node_metrics
+                    .commit_sync_fetch_commits_handler_uncertified_skipped
+                    .inc();
+                commits.pop();
+            }
+        }
+
+        // Fetch the certifier blocks
+        let certifier_blocks = self
+            .store
+            .read_blocks(&certifier_block_refs)?
+            .into_iter()
+            .flatten()
+            .collect();
+
+        Ok((commits, certifier_blocks))
+    }
+
+    /// Fetches the latest blocks for the specified authorities.
+    pub async fn fetch_latest_blocks(
+        &self,
+        peer: AuthorityIndex,
+        authorities: Vec<AuthorityIndex>,
+    ) -> ConsensusResult<Vec<Bytes>> {
+        if authorities.len() > self.context.committee.size() {
+            return Err(ConsensusError::TooManyAuthoritiesProvided(peer));
+        }
+
+        // Ensure that those are valid authorities
+        for authority in &authorities {
+            if !self.context.committee.is_valid_index(*authority) {
+                return Err(ConsensusError::InvalidAuthorityIndex {
+                    index: *authority,
+                    max: self.context.committee.size(),
+                });
+            }
+        }
+
+        // Read from the dag state to find the latest blocks
+        let mut blocks = vec![];
+        let dag_state = self.dag_state.read();
+        for authority in authorities {
+            let block = dag_state.get_last_block_for_authority(authority);
+
+            debug!("Latest block for {authority}: {block:?}");
+
+            // No reason to serve back the genesis block
+            if block.round() != GENESIS_ROUND {
+                blocks.push(block);
+            }
+        }
+
+        // Return the serialised blocks
+        let result = blocks
+            .into_iter()
+            .map(|block| block.serialized().clone())
+            .collect::<Vec<_>>();
+
+        Ok(result)
+    }
+}

--- a/consensus/core/src/block_sync_service.rs
+++ b/consensus/core/src/block_sync_service.rs
@@ -47,16 +47,21 @@ impl BlockSyncService {
         }
     }
 
-    /// Fetches blocks from the DAG state based on the provided block references.
-    ///
-    /// This method handles two types of requests:
-    /// 1. Missing block for block sync (when highest_accepted_rounds is provided):
-    ///    - Returns up to max_blocks_per_sync blocks
-    ///    - Can fetch ancestors if breadth_first is true
-    ///    - Can fetch additional blocks from authorities with missing blocks
-    /// 2. Committed block for commit sync (when highest_accepted_rounds is empty):
-    ///    - Returns up to max_blocks_per_fetch blocks
-    ///    - Simple fetch of requested blocks only
+    // Handles 3 types of requests:
+    // 1. Live sync:
+    //    - Both missing block refs and highest accepted rounds are specified.
+    //    - fetch_missing_ancestors is true.
+    //    - response returns max_blocks_per_sync blocks.
+    // 2. Periodic sync:
+    //    - Highest accepted rounds must be specified.
+    //    - Missing block refs are optional.
+    //    - fetch_missing_ancestors is false (default).
+    //    - response returns max_blocks_per_fetch blocks.
+    // 3. Commit sync:
+    //    - Missing block refs are specified.
+    //    - Highest accepted rounds are empty.
+    //    - fetch_missing_ancestors is false (default).
+    //    - response returns max_blocks_per_fetch blocks.
     pub async fn fetch_blocks(
         &self,
         mut block_refs: Vec<BlockRef>,

--- a/consensus/core/src/commit_syncer.rs
+++ b/consensus/core/src/commit_syncer.rs
@@ -504,25 +504,33 @@ where
                         return (commit_range.end(), commits);
                     }
                     Ok(Err(e)) => {
-                        let peer_name = peer.hostname(&inner.context);
-                        warn!("Failed to fetch {commit_range:?} from {peer_name}: {}", e);
+                        warn!(
+                            "Failed to fetch {commit_range:?} from {}: {}",
+                            peer.hostname(&inner.context),
+                            e
+                        );
                         inner
                             .context
                             .metrics
                             .node_metrics
                             .commit_sync_fetch_once_errors
-                            .with_label_values(&[peer_name.as_str(), e.name()])
+                            .with_label_values(&[peer.labelname(&inner.context).as_str(), e.name()])
                             .inc();
                     }
                     Err(_) => {
-                        let peer_name = peer.hostname(&inner.context);
-                        warn!("Timed out fetching {commit_range:?} from {peer}",);
+                        warn!(
+                            "Timed out fetching {commit_range:?} from {}",
+                            peer.hostname(&inner.context)
+                        );
                         inner
                             .context
                             .metrics
                             .node_metrics
                             .commit_sync_fetch_once_errors
-                            .with_label_values(&[peer_name.as_str(), "FetchTimeout"])
+                            .with_label_values(&[
+                                peer.labelname(&inner.context).as_str(),
+                                "FetchTimeout",
+                            ])
                             .inc();
                     }
                 }
@@ -663,13 +671,15 @@ where
                 continue;
             };
             // Extract hostname based on peer type
-            let peer_hostname = target_peer.hostname(&inner.context);
             inner
                 .context
                 .metrics
                 .node_metrics
                 .block_timestamp_drift_ms
-                .with_label_values(&[peer_hostname.as_str(), "commit_syncer"])
+                .with_label_values(&[
+                    target_peer.labelname(&inner.context).as_str(),
+                    "commit_syncer",
+                ])
                 .inc_by(forward_drift);
         }
 

--- a/consensus/core/src/commit_syncer.rs
+++ b/consensus/core/src/commit_syncer.rs
@@ -60,7 +60,8 @@ use crate::{
     core_thread::CoreThreadDispatcher,
     dag_state::DagState,
     error::{ConsensusError, ConsensusResult},
-    network::{CommitSyncerClient, ObserverNetworkClient, ValidatorNetworkClient},
+    network::{CommitSyncerClient, ObserverNetworkClient, PeerId, ValidatorNetworkClient},
+    peers_pool::PeersPool,
     round_tracker::RoundTracker,
     stake_aggregator::{QuorumThreshold, StakeAggregator},
     transaction_vote_tracker::TransactionVoteTracker,
@@ -124,6 +125,7 @@ where
         round_tracker: Arc<RwLock<RoundTracker>>,
         network_client: Arc<CommitSyncerClient<VC, OC>>,
         dag_state: Arc<RwLock<DagState>>,
+        peers_pool: Arc<PeersPool>,
     ) -> Self {
         let inner = Arc::new(Inner {
             context,
@@ -135,6 +137,7 @@ where
             round_tracker,
             network_client,
             dag_state,
+            peers_pool,
         });
         let synced_commit_index = inner.dag_state.read().last_commit_index();
         CommitSyncer {
@@ -389,23 +392,41 @@ where
     }
 
     fn try_start_fetches(&mut self) {
-        // Cap parallel fetches based on configured limit and committee size, to avoid overloading the network.
+        // Cap parallel fetches based on configured limit and available peers, to avoid overloading the network.
         // Also when there are too many fetched blocks that cannot be sent to Core before an earlier fetch
         // has not finished, reduce parallelism so the earlier fetch can retry on a better host and succeed.
-        let target_parallel_fetches = self
-            .inner
-            .context
-            .parameters
-            .commit_sync_parallel_fetches
-            .min(self.inner.context.committee.size() * 2 / 3)
-            .min(
-                self.inner
-                    .context
-                    .parameters
-                    .commit_sync_batches_ahead
-                    .saturating_sub(self.fetched_ranges.len()),
-            )
-            .max(1);
+        // For validators, use committee size for the calculation. For observers, don't apply the 2/3 limit.
+        let available_peers_count = self.inner.peers_pool.get_available_peers().len();
+        let target_parallel_fetches = if self.inner.context.is_validator() {
+            self.inner
+                .context
+                .parameters
+                .commit_sync_parallel_fetches
+                .min(available_peers_count * 2 / 3)
+                .min(
+                    self.inner
+                        .context
+                        .parameters
+                        .commit_sync_batches_ahead
+                        .saturating_sub(self.fetched_ranges.len()),
+                )
+                .max(1)
+        } else {
+            // For observers, currently the node is probably connected only to another peer. In the future probably more observer peers might be available
+            // to sync from. That's why we do not cap the number of parallel fetches by the number of available peers.
+            self.inner
+                .context
+                .parameters
+                .commit_sync_parallel_fetches
+                .min(
+                    self.inner
+                        .context
+                        .parameters
+                        .commit_sync_batches_ahead
+                        .saturating_sub(self.fetched_ranges.len()),
+                )
+                .max(1)
+        };
         // Start new fetches if there are pending batches and available slots.
         loop {
             if self.inflight_fetches.len() >= target_parallel_fetches {
@@ -453,21 +474,10 @@ where
             .start_timer();
         info!("Starting to fetch commits in {commit_range:?} ...",);
         loop {
-            // Attempt to fetch commits and blocks through min(committee size, MAX_NUM_TARGETS) peers.
-            let mut target_authorities = inner
-                .context
-                .committee
-                .authorities()
-                .filter_map(|(i, _)| {
-                    if i != inner.context.own_index {
-                        Some(i)
-                    } else {
-                        None
-                    }
-                })
-                .collect_vec();
-            target_authorities.shuffle(&mut ThreadRng::default());
-            target_authorities.truncate(MAX_NUM_TARGETS);
+            // Attempt to fetch commits and blocks through min(available peers count, MAX_NUM_TARGETS) peers.
+            let mut target_peers = inner.peers_pool.get_available_peers();
+            target_peers.shuffle(&mut ThreadRng::default());
+            target_peers.truncate(MAX_NUM_TARGETS);
             // Increase timeout multiplier for each loop until MAX_TIMEOUT_MULTIPLIER.
             timeout_multiplier = (timeout_multiplier + 1).min(MAX_TIMEOUT_MULTIPLIER);
             let request_timeout = base_timeout * timeout_multiplier;
@@ -477,13 +487,13 @@ where
             // - Time spent on pipelining requests to fetch blocks.
             // - Another headroom to allow fetch_once() to timeout gracefully if possible.
             let fetch_timeout = request_timeout * 4;
-            // Try fetching from selected target authority.
-            for authority in target_authorities {
+            // Try fetching from selected target peers.
+            for peer in target_peers {
                 match tokio::time::timeout(
                     fetch_timeout,
                     Self::fetch_once(
                         inner.clone(),
-                        authority,
+                        peer.clone(),
                         commit_range.clone(),
                         request_timeout,
                     ),
@@ -495,35 +505,25 @@ where
                         return (commit_range.end(), commits);
                     }
                     Ok(Err(e)) => {
-                        let hostname = inner
-                            .context
-                            .committee
-                            .authority(authority)
-                            .hostname
-                            .clone();
-                        warn!("Failed to fetch {commit_range:?} from {hostname}: {}", e);
+                        let peer_name = peer.hostname(&inner.context);
+                        warn!("Failed to fetch {commit_range:?} from {peer_name}: {}", e);
                         inner
                             .context
                             .metrics
                             .node_metrics
                             .commit_sync_fetch_once_errors
-                            .with_label_values(&[hostname.as_str(), e.name()])
+                            .with_label_values(&[peer_name.as_str(), e.name()])
                             .inc();
                     }
                     Err(_) => {
-                        let hostname = inner
-                            .context
-                            .committee
-                            .authority(authority)
-                            .hostname
-                            .clone();
-                        warn!("Timed out fetching {commit_range:?} from {authority}",);
+                        let peer_name = peer.hostname(&inner.context);
+                        warn!("Timed out fetching {commit_range:?} from {peer}",);
                         inner
                             .context
                             .metrics
                             .node_metrics
                             .commit_sync_fetch_once_errors
-                            .with_label_values(&[hostname.as_str(), "FetchTimeout"])
+                            .with_label_values(&[peer_name.as_str(), "FetchTimeout"])
                             .inc();
                     }
                 }
@@ -533,12 +533,12 @@ where
         }
     }
 
-    // Fetches commits and blocks from a single authority. At a high level, first the commits are
+    // Fetches commits and blocks from a single peer. At a high level, first the commits are
     // fetched and verified. After that, blocks referenced in the certified commits are fetched
     // and sent to Core for processing.
     async fn fetch_once(
         inner: Arc<Inner<VC, OC>>,
-        target_authority: AuthorityIndex,
+        target_peer: PeerId,
         commit_range: CommitRange,
         timeout: Duration,
     ) -> ConsensusResult<CertifiedCommits> {
@@ -555,7 +555,7 @@ where
         inner
             .network_client
             .probe_connectivity(
-                crate::network::PeerId::Validator(target_authority),
+                target_peer.clone(),
                 probe_timeout,
             )
             .await?;
@@ -563,11 +563,7 @@ where
         // 1. Fetch commits in the commit range from the target authority.
         let (serialized_commits, serialized_blocks) = inner
             .network_client
-            .fetch_commits(
-                crate::network::PeerId::Validator(target_authority),
-                commit_range.clone(),
-                timeout,
-            )
+            .fetch_commits(target_peer.clone(), commit_range.clone(), timeout)
             .await?;
 
         // 2. Verify the response contains blocks that can certify the last returned commit,
@@ -576,13 +572,9 @@ where
         let (commits, vote_blocks) = Handle::current()
             .spawn_blocking({
                 let inner = inner.clone();
+                let peer = target_peer.clone();
                 move || {
-                    inner.verify_commits(
-                        target_authority,
-                        commit_range,
-                        serialized_commits,
-                        serialized_blocks,
-                    )
+                    inner.verify_commits(peer, commit_range, serialized_commits, serialized_blocks)
                 }
             })
             .await
@@ -600,6 +592,7 @@ where
             .enumerate()
             .map(|(i, request_block_refs)| {
                 let inner = inner.clone();
+                let peer = target_peer.clone();
                 async move {
                     // 4. Send out pipelined fetch requests to avoid overloading the target authority.
                     sleep(timeout * i as u32 / num_chunks).await;
@@ -607,7 +600,7 @@ where
                     let serialized_blocks = inner
                         .network_client
                         .fetch_blocks(
-                            crate::network::PeerId::Validator(target_authority),
+                            peer.clone(),
                             request_block_refs.to_vec(),
                             vec![],
                             false,
@@ -617,7 +610,7 @@ where
                     // 5. Verify the same number of blocks are returned as requested.
                     if request_block_refs.len() != serialized_blocks.len() {
                         return Err(ConsensusError::UnexpectedNumberOfBlocksFetched {
-                            authority: target_authority,
+                            peer: peer.to_string(), // Convert to string for error
                             requested: request_block_refs.len(),
                             received: serialized_blocks.len(),
                         });
@@ -647,7 +640,7 @@ where
                         );
                         if *requested_block_ref != received_block_ref {
                             return Err(ConsensusError::UnexpectedBlockForCommit {
-                                peer: target_authority,
+                                peer: peer.to_string(), // Convert to string for error
                                 requested: *requested_block_ref,
                                 received: received_block_ref,
                             });
@@ -673,7 +666,8 @@ where
             if forward_drift == 0 {
                 continue;
             };
-            let peer_hostname = &inner.context.committee.authority(target_authority).hostname;
+            // Extract hostname based on peer type
+            let peer_hostname = target_peer.hostname(&inner.context);
             inner
                 .context
                 .metrics
@@ -788,6 +782,7 @@ struct Inner<VC: ValidatorNetworkClient, OC: ObserverNetworkClient> {
     round_tracker: Arc<RwLock<RoundTracker>>,
     network_client: Arc<CommitSyncerClient<VC, OC>>,
     dag_state: Arc<RwLock<DagState>>,
+    peers_pool: Arc<PeersPool>,
 }
 
 impl<VC: ValidatorNetworkClient, OC: ObserverNetworkClient> Inner<VC, OC> {
@@ -795,7 +790,7 @@ impl<VC: ValidatorNetworkClient, OC: ObserverNetworkClient> Inner<VC, OC> {
     /// method returns the trusted commits and the votes as verified blocks.
     fn verify_commits(
         &self,
-        peer: AuthorityIndex,
+        peer: PeerId,
         commit_range: CommitRange,
         serialized_commits: Vec<Bytes>,
         serialized_vote_blocks: Vec<Bytes>,
@@ -809,8 +804,13 @@ impl<VC: ValidatorNetworkClient, OC: ObserverNetworkClient> Inner<VC, OC> {
             if commits.is_empty() {
                 // start is inclusive, so first commit must be at the start index.
                 if commit.index() != commit_range.start() {
+                    // Extract authority index if it's a validator, otherwise use MAX
+                    let authority = match peer {
+                        PeerId::Validator(idx) => idx,
+                        PeerId::Observer(_) => AuthorityIndex::MAX,
+                    };
                     return Err(ConsensusError::UnexpectedStartCommit {
-                        peer,
+                        peer: authority,
                         start: commit_range.start(),
                         commit: Box::new(commit),
                     });
@@ -822,8 +822,13 @@ impl<VC: ValidatorNetworkClient, OC: ObserverNetworkClient> Inner<VC, OC> {
                 if commit.index() != last_commit.index() + 1
                     || &commit.previous_digest() != last_commit_digest
                 {
+                    // Extract authority index if it's a validator, otherwise use MAX
+                    let authority = match peer {
+                        PeerId::Validator(idx) => idx,
+                        PeerId::Observer(_) => AuthorityIndex::MAX,
+                    };
                     return Err(ConsensusError::UnexpectedCommitSequence {
-                        peer,
+                        peer: authority,
                         prev_commit: Box::new(last_commit.clone()),
                         curr_commit: Box::new(commit),
                     });
@@ -836,7 +841,12 @@ impl<VC: ValidatorNetworkClient, OC: ObserverNetworkClient> Inner<VC, OC> {
             commits.push((digest, commit));
         }
         let Some((end_commit_digest, end_commit)) = commits.last() else {
-            return Err(ConsensusError::NoCommitReceived { peer });
+            // Extract authority index if it's a validator, otherwise use MAX
+            let authority = match peer {
+                PeerId::Validator(idx) => idx,
+                PeerId::Observer(_) => AuthorityIndex::MAX,
+            };
+            return Err(ConsensusError::NoCommitReceived { peer: authority });
         };
 
         // Parse and verify blocks. Then accumulate votes on the end commit.
@@ -864,9 +874,14 @@ impl<VC: ValidatorNetworkClient, OC: ObserverNetworkClient> Inner<VC, OC> {
 
         // Check if the end commit has enough votes.
         if !stake_aggregator.reached_threshold(&self.context.committee) {
+            // Extract authority index if it's a validator, otherwise use MAX
+            let authority = match peer {
+                PeerId::Validator(idx) => idx,
+                PeerId::Observer(_) => AuthorityIndex::MAX,
+            };
             return Err(ConsensusError::NotEnoughCommitVotes {
                 stake: stake_aggregator.stake(),
-                peer,
+                peer: authority,
                 commit: Box::new(end_commit.clone()),
             });
         }
@@ -902,6 +917,7 @@ mod tests {
         dag_state::DagState,
         error::ConsensusResult,
         network::{BlockStream, CommitSyncerClient, ObserverNetworkClient, ValidatorNetworkClient},
+        peers_pool::PeersPool,
         round_tracker::RoundTracker,
         storage::mem_store::MemStore,
         transaction_vote_tracker::TransactionVoteTracker,
@@ -1033,6 +1049,7 @@ mod tests {
         let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
         let commit_consumer_monitor = Arc::new(CommitConsumerMonitor::new(0, 0));
         let round_tracker = Arc::new(RwLock::new(RoundTracker::new(context.clone(), vec![])));
+        let peers_pool = Arc::new(PeersPool::new(context.clone()));
         let mut commit_syncer = CommitSyncer::new(
             context,
             core_thread_dispatcher,
@@ -1043,6 +1060,7 @@ mod tests {
             round_tracker,
             network_client,
             dag_state,
+            peers_pool,
         );
 
         // Check initial state.

--- a/consensus/core/src/commit_syncer.rs
+++ b/consensus/core/src/commit_syncer.rs
@@ -900,7 +900,7 @@ mod tests {
     use std::{sync::Arc, time::Duration};
 
     use bytes::Bytes;
-    use consensus_config::{AuthorityIndex, Parameters};
+    use consensus_config::{AuthorityIndex, NetworkKeyPair, Parameters};
     use consensus_types::block::{BlockRef, Round};
     use mysten_common::ZipDebugEqIteratorExt;
     use parking_lot::RwLock;
@@ -917,7 +917,7 @@ mod tests {
         dag_state::DagState,
         error::ConsensusResult,
         network::{BlockStream, CommitSyncerClient, ObserverNetworkClient, ValidatorNetworkClient},
-        peers_pool::PeersPool,
+        peers_pool::{PeerServer, PeersPool},
         round_tracker::RoundTracker,
         storage::mem_store::MemStore,
         transaction_vote_tracker::TransactionVoteTracker,
@@ -1014,6 +1014,225 @@ mod tests {
             _timeout: Duration,
         ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>)> {
             unimplemented!("Unimplemented")
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn commit_syncer_observer_node_basic() {
+        // Test basic Observer node behavior for commit syncing
+        // An Observer node should be able to sync from both validator and observer peers
+
+        // Create an Observer node context (own_index = MAX)
+        let (mut context, _) = Context::new_for_test(4);
+        context.own_index = AuthorityIndex::MAX; // Mark this as an observer node
+        context.parameters = Parameters {
+            commit_sync_batch_size: 5,
+            commit_sync_batches_ahead: 10,
+            commit_sync_parallel_fetches: 5,
+            max_blocks_per_fetch: 5,
+            ..context.parameters
+        };
+        let context = Arc::new(context);
+
+        // Setup observer node commit syncer
+        let block_verifier = Arc::new(NoopBlockVerifier {});
+        let core_thread_dispatcher = Arc::new(MockCoreThreadDispatcher::default());
+        let mock_client = Arc::new(FakeNetworkClient::default());
+        let network_client = Arc::new(CommitSyncerClient::new(
+            context.clone(),
+            Some(mock_client.clone()),
+            Some(mock_client.clone()),
+        ));
+        let store = Arc::new(MemStore::new());
+        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
+        let (blocks_sender, _blocks_receiver) =
+            monitored_mpsc::unbounded_channel("consensus_block_output");
+        let transaction_certifier = TransactionCertifier::new(
+            context.clone(),
+            block_verifier.clone(),
+            dag_state.clone(),
+            blocks_sender,
+        );
+        let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
+        let commit_consumer_monitor = Arc::new(CommitConsumerMonitor::new(0, 0));
+        let round_tracker = Arc::new(RwLock::new(RoundTracker::new(context.clone(), vec![])));
+
+        // Create PeersPool - Observer typically connects to one validator
+        let peers_pool = Arc::new(PeersPool::new(context.clone()));
+        // Register the validator peer that the observer connects to
+        peers_pool
+            .register_validator(
+                AuthorityIndex::new_for_test(0),
+                vec![PeerServer::Validator, PeerServer::Observer],
+            )
+            .unwrap();
+
+        let mut commit_syncer = CommitSyncer::new(
+            context.clone(),
+            core_thread_dispatcher,
+            commit_vote_monitor.clone(),
+            commit_consumer_monitor.clone(),
+            block_verifier,
+            transaction_certifier,
+            round_tracker,
+            network_client,
+            dag_state,
+            peers_pool.clone(),
+        );
+
+        // Verify this is recognized as an observer
+        assert!(!context.is_validator(), "Should be an observer node");
+
+        // Simulate the observer seeing commits from its connected validator
+        for i in 0..3 {
+            let test_block = TestBlock::new(10, i)
+                .set_commit_votes(vec![CommitRef::new(5, CommitDigest::MIN)])
+                .build();
+            let block = VerifiedBlock::new_for_test(test_block);
+            commit_vote_monitor.observe_block(&block);
+        }
+
+        // Observer should be able to schedule commit fetches
+        commit_syncer.try_schedule_once();
+        assert_eq!(commit_syncer.pending_fetches().len(), 1);
+        assert_eq!(commit_syncer.highest_scheduled_index(), Some(5));
+
+        // Start fetches - observer should be able to fetch from its single peer
+        commit_syncer.try_start_fetches();
+        assert_eq!(
+            commit_syncer.inflight_fetches.len(),
+            1,
+            "Should start fetch from single peer"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn commit_syncer_observer_with_multiple_peers() {
+        // Test Observer node behavior when connected to multiple peers
+        // This simulates an observer that can sync from multiple sources
+
+        let (mut context, _) = Context::new_for_test(4);
+        context.own_index = AuthorityIndex::MAX; // Observer node
+        context.parameters = Parameters {
+            commit_sync_batch_size: 5,
+            commit_sync_batches_ahead: 10,
+            commit_sync_parallel_fetches: 8, // Allow more parallelism
+            max_blocks_per_fetch: 5,
+            ..context.parameters
+        };
+        let context = Arc::new(context);
+
+        // Setup
+        let block_verifier = Arc::new(NoopBlockVerifier {});
+        let core_thread_dispatcher = Arc::new(MockCoreThreadDispatcher::default());
+        let network_client = Arc::new(CommitSyncerClient::new(
+            context.clone(),
+            Some(Arc::new(FakeNetworkClient::default())),
+            Some(Arc::new(FakeNetworkClient::default())),
+        ));
+        let store = Arc::new(MemStore::new());
+        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
+        let (blocks_sender, _) = monitored_mpsc::unbounded_channel("consensus_block_output");
+        let transaction_certifier = TransactionCertifier::new(
+            context.clone(),
+            block_verifier.clone(),
+            dag_state.clone(),
+            blocks_sender,
+        );
+        let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
+        let commit_consumer_monitor = Arc::new(CommitConsumerMonitor::new(0, 0));
+        let round_tracker = Arc::new(RwLock::new(RoundTracker::new(context.clone(), vec![])));
+
+        // Create PeersPool with multiple peers (validators and another observer)
+        let peers_pool = Arc::new(PeersPool::new(context.clone()));
+        // Register multiple validator peers
+        peers_pool
+            .register_validator(
+                AuthorityIndex::new_for_test(0),
+                vec![PeerServer::Validator, PeerServer::Observer],
+            )
+            .unwrap();
+        peers_pool
+            .register_validator(
+                AuthorityIndex::new_for_test(1),
+                vec![PeerServer::Validator, PeerServer::Observer],
+            )
+            .unwrap();
+        peers_pool
+            .register_validator(
+                AuthorityIndex::new_for_test(2),
+                vec![PeerServer::Validator, PeerServer::Observer],
+            )
+            .unwrap();
+
+        // Now register another observer peer (simulating observer-to-observer sync)
+        let observer_peer = NetworkKeyPair::generate(&mut rand::thread_rng()).public();
+        peers_pool.register_observer(observer_peer);
+
+        let mut commit_syncer = CommitSyncer::new(
+            context.clone(),
+            core_thread_dispatcher,
+            commit_vote_monitor.clone(),
+            commit_consumer_monitor.clone(),
+            block_verifier,
+            transaction_certifier,
+            round_tracker,
+            network_client,
+            dag_state,
+            peers_pool.clone(),
+        );
+
+        // Simulate heavy commit load that requires parallel fetching
+        for i in 0..3 {
+            let test_block = TestBlock::new(100, i)
+                .set_commit_votes(vec![CommitRef::new(50, CommitDigest::MIN)])
+                .build();
+            let block = VerifiedBlock::new_for_test(test_block);
+            commit_vote_monitor.observe_block(&block);
+        }
+
+        commit_syncer.try_schedule_once();
+
+        // Should schedule multiple batches
+        let pending_fetches = commit_syncer.pending_fetches().len();
+        assert!(pending_fetches > 0, "Should schedule fetches");
+
+        // Start fetches - observer should utilize multiple peers in parallel
+        commit_syncer.try_start_fetches();
+
+        // Observer with 4 peers (3 validators + 1 observer) should be able to
+        // fetch from multiple peers in parallel, not limited by 2/3 rule
+        let inflight = commit_syncer.inflight_fetches.len();
+        let available_peers = peers_pool.get_available_peers().len();
+
+        assert_eq!(
+            available_peers, 4,
+            "Should have 3 validators + 1 observer peer"
+        );
+
+        // Observer should be able to use full parallelism up to configured limit
+        // Not restricted by the validator's 2/3 limitation
+        let max_parallel = context
+            .parameters
+            .commit_sync_parallel_fetches
+            .min(pending_fetches)
+            .min(context.parameters.commit_sync_batches_ahead);
+
+        assert!(
+            inflight <= max_parallel,
+            "Observer should respect configured parallelism limit: {} <= {}",
+            inflight,
+            max_parallel
+        );
+
+        // Verify observer can potentially use more parallelism than a validator would
+        // A validator with 4 peers would be limited to 4 * 2/3 = 2 parallel fetches
+        // But an observer can use more
+        if pending_fetches >= 3 {
+            assert!(
+                max_parallel > 2,
+                "Observer should be able to use more parallelism than validator's 2/3 limit"
+            );
         }
     }
 

--- a/consensus/core/src/commit_syncer.rs
+++ b/consensus/core/src/commit_syncer.rs
@@ -984,6 +984,8 @@ mod tests {
             &self,
             _peer: crate::network::PeerId,
             _block_refs: Vec<BlockRef>,
+            _highest_accepted_rounds: Vec<Round>,
+            _breadth_first: bool,
             _timeout: Duration,
         ) -> ConsensusResult<Vec<Bytes>> {
             unimplemented!("Unimplemented")

--- a/consensus/core/src/commit_syncer.rs
+++ b/consensus/core/src/commit_syncer.rs
@@ -392,17 +392,17 @@ where
     }
 
     fn try_start_fetches(&mut self) {
-        // Cap parallel fetches based on configured limit and available peers, to avoid overloading the network.
+        // Cap parallel fetches based on configured limit and known peers, to avoid overloading the network.
         // Also when there are too many fetched blocks that cannot be sent to Core before an earlier fetch
         // has not finished, reduce parallelism so the earlier fetch can retry on a better host and succeed.
         // For validators, use committee size for the calculation. For observers, don't apply the 2/3 limit.
-        let available_peers_count = self.inner.peers_pool.get_available_peers().len();
+        let known_peers_count = self.inner.peers_pool.get_known_peers().len();
         let target_parallel_fetches = if self.inner.context.is_validator() {
             self.inner
                 .context
                 .parameters
                 .commit_sync_parallel_fetches
-                .min(available_peers_count * 2 / 3)
+                .min(known_peers_count * 2 / 3)
                 .min(
                     self.inner
                         .context
@@ -413,7 +413,7 @@ where
                 .max(1)
         } else {
             // For observers, currently the node is probably connected only to another peer. In the future probably more observer peers might be available
-            // to sync from. That's why we do not cap the number of parallel fetches by the number of available peers.
+            // to sync from. That's why we do not cap the number of parallel fetches by the number of known peers.
             self.inner
                 .context
                 .parameters
@@ -475,7 +475,7 @@ where
         info!("Starting to fetch commits in {commit_range:?} ...",);
         loop {
             // Attempt to fetch commits and blocks through min(available peers count, MAX_NUM_TARGETS) peers.
-            let mut target_peers = inner.peers_pool.get_available_peers();
+            let mut target_peers = inner.peers_pool.get_known_peers();
             target_peers.shuffle(&mut ThreadRng::default());
             target_peers.truncate(MAX_NUM_TARGETS);
             // Increase timeout multiplier for each loop until MAX_TIMEOUT_MULTIPLIER.
@@ -914,7 +914,7 @@ mod tests {
         dag_state::DagState,
         error::ConsensusResult,
         network::{BlockStream, CommitSyncerClient, ObserverNetworkClient, ValidatorNetworkClient},
-        peers_pool::{PeerServer, PeersPool},
+        peers_pool::{PeerService, PeersPool},
         round_tracker::RoundTracker,
         storage::mem_store::MemStore,
         transaction_vote_tracker::TransactionVoteTracker,
@@ -1054,7 +1054,7 @@ mod tests {
         peers_pool
             .register_validator(
                 AuthorityIndex::new_for_test(0),
-                vec![PeerServer::Validator, PeerServer::Observer],
+                vec![PeerService::Validator, PeerService::Observer],
             )
             .unwrap();
 
@@ -1135,19 +1135,19 @@ mod tests {
         peers_pool
             .register_validator(
                 AuthorityIndex::new_for_test(0),
-                vec![PeerServer::Validator, PeerServer::Observer],
+                vec![PeerService::Validator, PeerService::Observer],
             )
             .unwrap();
         peers_pool
             .register_validator(
                 AuthorityIndex::new_for_test(1),
-                vec![PeerServer::Validator, PeerServer::Observer],
+                vec![PeerService::Validator, PeerService::Observer],
             )
             .unwrap();
         peers_pool
             .register_validator(
                 AuthorityIndex::new_for_test(2),
-                vec![PeerServer::Validator, PeerServer::Observer],
+                vec![PeerService::Validator, PeerService::Observer],
             )
             .unwrap();
 
@@ -1189,12 +1189,9 @@ mod tests {
         // Observer with 4 peers (3 validators + 1 observer) should be able to
         // fetch from multiple peers in parallel, not limited by 2/3 rule
         let inflight = commit_syncer.inflight_fetches.len();
-        let available_peers = peers_pool.get_available_peers().len();
+        let known_peers = peers_pool.get_known_peers().len();
 
-        assert_eq!(
-            available_peers, 4,
-            "Should have 3 validators + 1 observer peer"
-        );
+        assert_eq!(known_peers, 4, "Should have 3 validators + 1 observer peer");
 
         // Observer should be able to use full parallelism up to configured limit
         // Not restricted by the validator's 2/3 limitation

--- a/consensus/core/src/commit_syncer.rs
+++ b/consensus/core/src/commit_syncer.rs
@@ -31,7 +31,6 @@ use std::{
 };
 
 use bytes::Bytes;
-use consensus_config::AuthorityIndex;
 use consensus_types::block::BlockRef;
 use futures::{StreamExt as _, stream::FuturesOrdered};
 use itertools::Itertools as _;
@@ -607,7 +606,7 @@ where
                     // 5. Verify the same number of blocks are returned as requested.
                     if request_block_refs.len() != serialized_blocks.len() {
                         return Err(ConsensusError::UnexpectedNumberOfBlocksFetched {
-                            peer: peer.to_string(), // Convert to string for error
+                            peer,
                             requested: request_block_refs.len(),
                             received: serialized_blocks.len(),
                         });
@@ -637,7 +636,7 @@ where
                         );
                         if *requested_block_ref != received_block_ref {
                             return Err(ConsensusError::UnexpectedBlockForCommit {
-                                peer: peer.to_string(), // Convert to string for error
+                                peer,
                                 requested: *requested_block_ref,
                                 received: received_block_ref,
                             });
@@ -801,13 +800,8 @@ impl<VC: ValidatorNetworkClient, OC: ObserverNetworkClient> Inner<VC, OC> {
             if commits.is_empty() {
                 // start is inclusive, so first commit must be at the start index.
                 if commit.index() != commit_range.start() {
-                    // Extract authority index if it's a validator, otherwise use MAX
-                    let authority = match peer {
-                        PeerId::Validator(idx) => idx,
-                        PeerId::Observer(_) => AuthorityIndex::MAX,
-                    };
                     return Err(ConsensusError::UnexpectedStartCommit {
-                        peer: authority,
+                        peer,
                         start: commit_range.start(),
                         commit: Box::new(commit),
                     });
@@ -819,13 +813,8 @@ impl<VC: ValidatorNetworkClient, OC: ObserverNetworkClient> Inner<VC, OC> {
                 if commit.index() != last_commit.index() + 1
                     || &commit.previous_digest() != last_commit_digest
                 {
-                    // Extract authority index if it's a validator, otherwise use MAX
-                    let authority = match peer {
-                        PeerId::Validator(idx) => idx,
-                        PeerId::Observer(_) => AuthorityIndex::MAX,
-                    };
                     return Err(ConsensusError::UnexpectedCommitSequence {
-                        peer: authority,
+                        peer,
                         prev_commit: Box::new(last_commit.clone()),
                         curr_commit: Box::new(commit),
                     });
@@ -838,12 +827,7 @@ impl<VC: ValidatorNetworkClient, OC: ObserverNetworkClient> Inner<VC, OC> {
             commits.push((digest, commit));
         }
         let Some((end_commit_digest, end_commit)) = commits.last() else {
-            // Extract authority index if it's a validator, otherwise use MAX
-            let authority = match peer {
-                PeerId::Validator(idx) => idx,
-                PeerId::Observer(_) => AuthorityIndex::MAX,
-            };
-            return Err(ConsensusError::NoCommitReceived { peer: authority });
+            return Err(ConsensusError::NoCommitReceived { peer });
         };
 
         // Parse and verify blocks. Then accumulate votes on the end commit.
@@ -871,14 +855,9 @@ impl<VC: ValidatorNetworkClient, OC: ObserverNetworkClient> Inner<VC, OC> {
 
         // Check if the end commit has enough votes.
         if !stake_aggregator.reached_threshold(&self.context.committee) {
-            // Extract authority index if it's a validator, otherwise use MAX
-            let authority = match peer {
-                PeerId::Validator(idx) => idx,
-                PeerId::Observer(_) => AuthorityIndex::MAX,
-            };
             return Err(ConsensusError::NotEnoughCommitVotes {
                 stake: stake_aggregator.stake(),
-                peer: authority,
+                peer,
                 commit: Box::new(end_commit.clone()),
             });
         }

--- a/consensus/core/src/commit_syncer.rs
+++ b/consensus/core/src/commit_syncer.rs
@@ -554,10 +554,7 @@ where
         let probe_timeout = inner.context.parameters.commit_sync_probe_timeout;
         inner
             .network_client
-            .probe_connectivity(
-                target_peer.clone(),
-                probe_timeout,
-            )
+            .probe_connectivity(target_peer.clone(), probe_timeout)
             .await?;
 
         // 1. Fetch commits in the commit range from the target authority.
@@ -1045,14 +1042,8 @@ mod tests {
         ));
         let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
-        let (blocks_sender, _blocks_receiver) =
-            monitored_mpsc::unbounded_channel("consensus_block_output");
-        let transaction_certifier = TransactionCertifier::new(
-            context.clone(),
-            block_verifier.clone(),
-            dag_state.clone(),
-            blocks_sender,
-        );
+        let transaction_vote_tracker =
+            TransactionVoteTracker::new(context.clone(), block_verifier.clone(), dag_state.clone());
         let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
         let commit_consumer_monitor = Arc::new(CommitConsumerMonitor::new(0, 0));
         let round_tracker = Arc::new(RwLock::new(RoundTracker::new(context.clone(), vec![])));
@@ -1073,7 +1064,7 @@ mod tests {
             commit_vote_monitor.clone(),
             commit_consumer_monitor.clone(),
             block_verifier,
-            transaction_certifier,
+            transaction_vote_tracker,
             round_tracker,
             network_client,
             dag_state,
@@ -1132,13 +1123,8 @@ mod tests {
         ));
         let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
-        let (blocks_sender, _) = monitored_mpsc::unbounded_channel("consensus_block_output");
-        let transaction_certifier = TransactionCertifier::new(
-            context.clone(),
-            block_verifier.clone(),
-            dag_state.clone(),
-            blocks_sender,
-        );
+        let transaction_vote_tracker =
+            TransactionVoteTracker::new(context.clone(), block_verifier.clone(), dag_state.clone());
         let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
         let commit_consumer_monitor = Arc::new(CommitConsumerMonitor::new(0, 0));
         let round_tracker = Arc::new(RwLock::new(RoundTracker::new(context.clone(), vec![])));
@@ -1175,7 +1161,7 @@ mod tests {
             commit_vote_monitor.clone(),
             commit_consumer_monitor.clone(),
             block_verifier,
-            transaction_certifier,
+            transaction_vote_tracker,
             round_tracker,
             network_client,
             dag_state,

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -288,6 +288,13 @@ impl Core {
             // Read commit index once for the entire batch to avoid repeated lock acquisitions.
             let commit_index = self.dag_state.read().last_commit_index();
             for block in &accepted_blocks {
+                tracing::info!(
+                    "{} Core accepted round {}, author {} at timestamp: {}",
+                    self.context.own_index,
+                    block.round(),
+                    block.author(),
+                    block.timestamp_ms()
+                );
                 self.signals.new_accepted_block(block.clone(), commit_index);
             }
         }

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -288,7 +288,7 @@ impl Core {
             // Read commit index once for the entire batch to avoid repeated lock acquisitions.
             let commit_index = self.dag_state.read().last_commit_index();
             for block in &accepted_blocks {
-                tracing::info!(
+                tracing::trace!(
                     "{} Core accepted round {}, author {} at timestamp: {}",
                     self.context.own_index,
                     block.round(),

--- a/consensus/core/src/error.rs
+++ b/consensus/core/src/error.rs
@@ -8,7 +8,10 @@ use strum_macros::IntoStaticStr;
 use thiserror::Error;
 use typed_store::TypedStoreError;
 
-use crate::commit::{Commit, CommitIndex};
+use crate::{
+    commit::{Commit, CommitIndex},
+    network::PeerId,
+};
 
 /// Errors that can occur when processing blocks, reading from storage, or encountering shutdown.
 #[derive(Clone, Debug, Error, IntoStaticStr)]
@@ -45,7 +48,7 @@ pub enum ConsensusError {
 
     #[error("Expected {requested} but received {received} blocks returned from peer {peer}")]
     UnexpectedNumberOfBlocksFetched {
-        peer: String, // Use String instead of PeerId to avoid large error size
+        peer: PeerId,
         requested: usize,
         received: usize,
     },
@@ -129,13 +132,13 @@ pub enum ConsensusError {
     InvalidTransaction(String),
 
     #[error("Received no commit from peer {peer}")]
-    NoCommitReceived { peer: AuthorityIndex },
+    NoCommitReceived { peer: PeerId },
 
     #[error(
         "Received unexpected start commit from peer {peer}: requested {start}, received {commit:?}"
     )]
     UnexpectedStartCommit {
-        peer: AuthorityIndex,
+        peer: PeerId,
         start: CommitIndex,
         commit: Box<Commit>,
     },
@@ -144,7 +147,7 @@ pub enum ConsensusError {
         "Received unexpected commit sequence from peer {peer}: {prev_commit:?}, {curr_commit:?}"
     )]
     UnexpectedCommitSequence {
-        peer: AuthorityIndex,
+        peer: PeerId,
         prev_commit: Box<Commit>,
         curr_commit: Box<Commit>,
     },
@@ -152,13 +155,13 @@ pub enum ConsensusError {
     #[error("Not enough votes ({stake}) on end commit from peer {peer}: {commit:?}")]
     NotEnoughCommitVotes {
         stake: Stake,
-        peer: AuthorityIndex,
+        peer: PeerId,
         commit: Box<Commit>,
     },
 
     #[error("Received unexpected block from peer {peer}: {requested:?} vs {received:?}")]
     UnexpectedBlockForCommit {
-        peer: String, // Use String instead of PeerId to avoid large error size
+        peer: PeerId,
         requested: BlockRef,
         received: BlockRef,
     },

--- a/consensus/core/src/error.rs
+++ b/consensus/core/src/error.rs
@@ -43,11 +43,9 @@ pub enum ConsensusError {
     #[error("Genesis blocks should not be queried!")]
     UnexpectedGenesisBlockRequested,
 
-    #[error(
-        "Expected {requested} but received {received} blocks returned from authority {authority}"
-    )]
+    #[error("Expected {requested} but received {received} blocks returned from peer {peer}")]
     UnexpectedNumberOfBlocksFetched {
-        authority: AuthorityIndex,
+        peer: String, // Use String instead of PeerId to avoid large error size
         requested: usize,
         received: usize,
     },
@@ -160,7 +158,7 @@ pub enum ConsensusError {
 
     #[error("Received unexpected block from peer {peer}: {requested:?} vs {received:?}")]
     UnexpectedBlockForCommit {
-        peer: AuthorityIndex,
+        peer: String, // Use String instead of PeerId to avoid large error size
         requested: BlockRef,
         received: BlockRef,
     },

--- a/consensus/core/src/lib.rs
+++ b/consensus/core/src/lib.rs
@@ -8,6 +8,7 @@ mod authority_service;
 mod base_committer;
 mod block;
 mod block_manager;
+mod block_sync_service;
 mod block_verifier;
 mod commit;
 mod commit_consumer;

--- a/consensus/core/src/network/clients.rs
+++ b/consensus/core/src/network/clients.rs
@@ -75,7 +75,15 @@ where
             let client = self.observer_client.as_ref().ok_or_else(|| {
                 ConsensusError::NetworkConfig("Observer client not available".to_string())
             })?;
-            client.fetch_blocks(peer, block_refs, timeout).await
+            client
+                .fetch_blocks(
+                    peer,
+                    block_refs,
+                    fetch_after_rounds,
+                    fetch_missing_ancestors,
+                    timeout,
+                )
+                .await
         }
     }
 
@@ -188,7 +196,15 @@ where
             let client = self.observer_client.as_ref().ok_or_else(|| {
                 ConsensusError::NetworkConfig("Observer client not available".to_string())
             })?;
-            client.fetch_blocks(peer, block_refs, timeout).await
+            client
+                .fetch_blocks(
+                    peer,
+                    block_refs,
+                    fetch_after_rounds,
+                    fetch_missing_ancestors,
+                    timeout,
+                )
+                .await
         }
     }
 }

--- a/consensus/core/src/network/mod.rs
+++ b/consensus/core/src/network/mod.rs
@@ -40,13 +40,13 @@ use crate::{
 };
 
 /// Identifies an observer node by its network public key.
-pub(crate) type NodeId = NetworkPublicKey;
+pub type NodeId = NetworkPublicKey;
 
 /// Identifies a peer in the network, which can be either a validator or an observer.
 /// The Observer variant is boxed to keep the enum small, since `NodeId` (32 bytes) is
 /// much larger than `AuthorityIndex` (4 bytes).
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub(crate) enum PeerId {
+pub enum PeerId {
     /// A validator node identified by its authority index.
     Validator(AuthorityIndex),
     /// An observer node identified by its network public key.

--- a/consensus/core/src/network/mod.rs
+++ b/consensus/core/src/network/mod.rs
@@ -284,8 +284,8 @@ pub(crate) trait ObserverNetworkService: Send + Sync + 'static {
         &self,
         peer: NodeId,
         block_refs: Vec<BlockRef>,
-        highest_accepted_rounds: Vec<Round>,
-        breadth_first: bool,
+        fetch_after_rounds: Vec<Round>,
+        fetch_missing_ancestors: bool,
     ) -> ConsensusResult<Vec<Bytes>>;
 
     /// Handles the request to fetch commits by index range from an observer peer.

--- a/consensus/core/src/network/mod.rs
+++ b/consensus/core/src/network/mod.rs
@@ -284,6 +284,8 @@ pub(crate) trait ObserverNetworkService: Send + Sync + 'static {
         &self,
         peer: NodeId,
         block_refs: Vec<BlockRef>,
+        highest_accepted_rounds: Vec<Round>,
+        breadth_first: bool,
     ) -> ConsensusResult<Vec<Bytes>>;
 
     /// Handles the request to fetch commits by index range from an observer peer.
@@ -317,6 +319,8 @@ pub(crate) trait ObserverNetworkClient: Send + Sync + Sized + 'static {
         &self,
         peer: PeerId,
         block_refs: Vec<BlockRef>,
+        fetch_after_rounds: Vec<Round>,
+        fetch_missing_ancestors: bool,
         timeout: Duration,
     ) -> ConsensusResult<Vec<Bytes>>;
 

--- a/consensus/core/src/network/observer.rs
+++ b/consensus/core/src/network/observer.rs
@@ -6,7 +6,7 @@ use std::{collections::BTreeMap, pin::Pin, sync::Arc, time::Duration};
 use async_trait::async_trait;
 use bytes::Bytes;
 use consensus_config::{NetworkKeyPair, NetworkPublicKey};
-use consensus_types::block::BlockRef;
+use consensus_types::block::{BlockRef, Round};
 use futures::{Stream, StreamExt as _, stream};
 use mysten_network::{Multiaddr, callback::CallbackLayer};
 use parking_lot::RwLock;
@@ -67,6 +67,10 @@ pub(crate) struct BlockStreamResponse {
 pub(crate) struct FetchBlocksRequest {
     #[prost(bytes = "vec", repeated, tag = "1")]
     pub(crate) block_refs: Vec<Vec<u8>>,
+    #[prost(uint64, repeated, tag = "2")]
+    pub(crate) highest_accepted_rounds: Vec<u64>,
+    #[prost(bool, tag = "3")]
+    pub(crate) breadth_first: bool,
 }
 
 #[derive(Clone, prost::Message)]
@@ -297,6 +301,8 @@ impl ObserverNetworkClient for TonicObserverClient {
         &self,
         _peer: PeerId,
         _block_refs: Vec<BlockRef>,
+        _highest_accepted_rounds: Vec<Round>,
+        _breadth_first: bool,
         _timeout: Duration,
     ) -> ConsensusResult<Vec<Bytes>> {
         // TODO: Implement block fetching for observers

--- a/consensus/core/src/network/observer.rs
+++ b/consensus/core/src/network/observer.rs
@@ -350,7 +350,7 @@ impl ObserverNetworkClient for TonicObserverClient {
             * self
                 .context
                 .protocol_config
-                .consensus_max_transactions_in_block_bytes() as usize
+                .max_transactions_in_block_bytes() as usize
             * 2;
         let mut blocks = vec![];
         let mut total_fetched_bytes = 0;

--- a/consensus/core/src/network/observer.rs
+++ b/consensus/core/src/network/observer.rs
@@ -70,18 +70,16 @@ pub(crate) struct BlockStreamResponse {
 pub(crate) struct FetchBlocksRequest {
     #[prost(bytes = "vec", repeated, tag = "1")]
     block_refs: Vec<Vec<u8>>,
-    // The highest accepted round per authority. The vector represents the round for each authority
-    // and its length should be the same as the committee size.
+    // The round per authority after which blocks should be fetched. The vector represents the round
+    // for each authority and its length should be the same as the committee size.
     // When this field is non-empty, additional ancestors of the requested blocks can be fetched.
     #[prost(uint32, repeated, tag = "2")]
-    highest_accepted_rounds: Vec<Round>,
-    // When true, this indicates that missing ancestors should be added breadth-first, by searching through
-    // missing ancestors of the requested blocks.
-    // When false, this indicates that missing ancestors should be added depth-first, by adding missing
-    // ancestors from the requested block authorities.
-    // This field is only meaningful when highest_accepted_rounds is non-empty.
+    fetch_after_rounds: Vec<Round>,
+    // When true, missing ancestors of the requested blocks will be fetched as well.
+    // When false, additional blocks are fetched depth-first from the requested block authorities.
+    // This field is only meaningful when fetch_after_rounds is non-empty.
     #[prost(bool, tag = "3")]
-    breadth_first: bool,
+    fetch_missing_ancestors: bool,
 }
 
 #[derive(Clone, prost::Message)]
@@ -312,8 +310,8 @@ impl ObserverNetworkClient for TonicObserverClient {
         &self,
         peer: PeerId,
         block_refs: Vec<BlockRef>,
-        highest_accepted_rounds: Vec<Round>,
-        breadth_first: bool,
+        fetch_after_rounds: Vec<Round>,
+        fetch_missing_ancestors: bool,
         timeout: Duration,
     ) -> ConsensusResult<Vec<Bytes>> {
         let mut client = self.get_client(peer, timeout).await?;
@@ -328,8 +326,8 @@ impl ObserverNetworkClient for TonicObserverClient {
                     }
                 })
                 .collect(),
-            highest_accepted_rounds,
-            breadth_first,
+            fetch_after_rounds,
+            fetch_missing_ancestors,
         });
         request.set_timeout(timeout);
 
@@ -522,11 +520,16 @@ impl<S: ObserverNetworkService> ObserverService for ObserverServiceProxy<S> {
                 }
             })
             .collect();
-        let highest_accepted_rounds = inner.highest_accepted_rounds;
-        let breadth_first = inner.breadth_first;
+        let fetch_after_rounds = inner.fetch_after_rounds;
+        let fetch_missing_ancestors = inner.fetch_missing_ancestors;
         let blocks = self
             .service
-            .handle_fetch_blocks(peer_id, block_refs, highest_accepted_rounds, breadth_first)
+            .handle_fetch_blocks(
+                peer_id,
+                block_refs,
+                fetch_after_rounds,
+                fetch_missing_ancestors,
+            )
             .await
             .map_err(|e| tonic::Status::internal(format!("{e:?}")))?;
         let responses: std::vec::IntoIter<Result<FetchBlocksResponse, tonic::Status>> =

--- a/consensus/core/src/network/observer.rs
+++ b/consensus/core/src/network/observer.rs
@@ -13,14 +13,17 @@ use parking_lot::RwLock;
 use tokio_stream::Iter;
 use tonic::{Request, Response, Streaming};
 use tower_http::trace::{DefaultMakeSpan, DefaultOnFailure, TraceLayer};
-use tracing::{debug, trace};
+use tracing::{debug, info, trace, warn};
 
 use crate::{
     CommitRange, Context,
     error::{ConsensusError, ConsensusResult},
     network::{
-        ObserverBlockStream, ObserverNetworkClient, PeerId, metrics_layer::MetricsCallbackMaker,
-        observer::block_stream_request::Command, to_host_port_str, tonic_network::Channel,
+        ObserverBlockStream, ObserverNetworkClient, PeerId,
+        metrics_layer::MetricsCallbackMaker,
+        observer::block_stream_request::Command,
+        to_host_port_str,
+        tonic_network::{Channel, MAX_FETCH_RESPONSE_BYTES, chunk_blocks},
         tonic_tls::certificate_server_name,
     },
 };
@@ -66,11 +69,19 @@ pub(crate) struct BlockStreamResponse {
 #[derive(Clone, prost::Message)]
 pub(crate) struct FetchBlocksRequest {
     #[prost(bytes = "vec", repeated, tag = "1")]
-    pub(crate) block_refs: Vec<Vec<u8>>,
-    #[prost(uint64, repeated, tag = "2")]
-    pub(crate) highest_accepted_rounds: Vec<u64>,
+    block_refs: Vec<Vec<u8>>,
+    // The highest accepted round per authority. The vector represents the round for each authority
+    // and its length should be the same as the committee size.
+    // When this field is non-empty, additional ancestors of the requested blocks can be fetched.
+    #[prost(uint32, repeated, tag = "2")]
+    highest_accepted_rounds: Vec<Round>,
+    // When true, this indicates that missing ancestors should be added breadth-first, by searching through
+    // missing ancestors of the requested blocks.
+    // When false, this indicates that missing ancestors should be added depth-first, by adding missing
+    // ancestors from the requested block authorities.
+    // This field is only meaningful when highest_accepted_rounds is non-empty.
     #[prost(bool, tag = "3")]
-    pub(crate) breadth_first: bool,
+    breadth_first: bool,
 }
 
 #[derive(Clone, prost::Message)]
@@ -299,28 +310,106 @@ impl ObserverNetworkClient for TonicObserverClient {
 
     async fn fetch_blocks(
         &self,
-        _peer: PeerId,
-        _block_refs: Vec<BlockRef>,
-        _highest_accepted_rounds: Vec<Round>,
-        _breadth_first: bool,
-        _timeout: Duration,
+        peer: PeerId,
+        block_refs: Vec<BlockRef>,
+        highest_accepted_rounds: Vec<Round>,
+        breadth_first: bool,
+        timeout: Duration,
     ) -> ConsensusResult<Vec<Bytes>> {
-        // TODO: Implement block fetching for observers
-        Err(ConsensusError::NetworkRequest(
-            "fetch_blocks not yet implemented".to_string(),
-        ))
+        let mut client = self.get_client(peer, timeout).await?;
+        let mut request = Request::new(FetchBlocksRequest {
+            block_refs: block_refs
+                .iter()
+                .filter_map(|r| match bcs::to_bytes(r) {
+                    Ok(serialized) => Some(serialized),
+                    Err(e) => {
+                        debug!("Failed to serialize block ref {:?}: {e:?}", r);
+                        None
+                    }
+                })
+                .collect(),
+            highest_accepted_rounds,
+            breadth_first,
+        });
+        request.set_timeout(timeout);
+
+        let mut stream = client
+            .fetch_blocks(request)
+            .await
+            .map_err(|e| {
+                if e.code() == tonic::Code::DeadlineExceeded {
+                    ConsensusError::NetworkRequestTimeout(format!("fetch_blocks failed: {e:?}"))
+                } else {
+                    ConsensusError::NetworkRequest(format!("fetch_blocks failed: {e:?}"))
+                }
+            })?
+            .into_inner();
+
+        // Allow twice the max total size of transactions in the fetched blocks.
+        let max_allowed_bytes = block_refs.len()
+            * self
+                .context
+                .protocol_config
+                .consensus_max_transactions_in_block_bytes() as usize
+            * 2;
+        let mut blocks = vec![];
+        let mut total_fetched_bytes = 0;
+        loop {
+            match stream.message().await {
+                Ok(Some(response)) => {
+                    for b in &response.blocks {
+                        total_fetched_bytes += b.len();
+                    }
+                    blocks.extend(response.blocks);
+                    if total_fetched_bytes > max_allowed_bytes {
+                        info!(
+                            "fetch_blocks() fetched bytes exceeded limit: {} > {}, terminating stream.",
+                            total_fetched_bytes, max_allowed_bytes,
+                        );
+                        break;
+                    }
+                }
+                Ok(None) => {
+                    break;
+                }
+                Err(e) => {
+                    if blocks.is_empty() {
+                        if e.code() == tonic::Code::DeadlineExceeded {
+                            return Err(ConsensusError::NetworkRequestTimeout(format!(
+                                "fetch_blocks failed mid-stream: {e:?}"
+                            )));
+                        }
+                        return Err(ConsensusError::NetworkRequest(format!(
+                            "fetch_blocks failed mid-stream: {e:?}"
+                        )));
+                    } else {
+                        warn!("fetch_blocks failed mid-stream: {e:?}");
+                        break;
+                    }
+                }
+            }
+        }
+        Ok(blocks)
     }
 
     async fn fetch_commits(
         &self,
-        _peer: PeerId,
-        _commit_range: CommitRange,
-        _timeout: Duration,
+        peer: PeerId,
+        commit_range: CommitRange,
+        timeout: Duration,
     ) -> ConsensusResult<(Vec<Bytes>, Vec<Bytes>)> {
-        // TODO: Implement commit fetching for observers
-        Err(ConsensusError::NetworkRequest(
-            "fetch_commits not yet implemented".to_string(),
-        ))
+        let mut client = self.get_client(peer, timeout).await?;
+        let mut request = Request::new(FetchCommitsRequest {
+            start: commit_range.start(),
+            end: commit_range.end(),
+        });
+        request.set_timeout(timeout);
+        let response = client
+            .fetch_commits(request)
+            .await
+            .map_err(|e| ConsensusError::NetworkRequest(format!("fetch_commits failed: {e:?}")))?;
+        let response = response.into_inner();
+        Ok((response.commits, response.certifier_blocks))
     }
 }
 
@@ -410,22 +499,77 @@ impl<S: ObserverNetworkService> ObserverService for ObserverServiceProxy<S> {
 
     async fn fetch_blocks(
         &self,
-        _request: Request<FetchBlocksRequest>,
+        request: Request<FetchBlocksRequest>,
     ) -> Result<Response<Self::FetchBlocksStream>, tonic::Status> {
-        // TODO: Implement fetch_blocks for observer nodes
-        Err(tonic::Status::unimplemented(
-            "fetch_blocks not yet implemented for observers",
-        ))
+        let peer_id = request
+            .extensions()
+            .get::<ObserverPeerInfo>()
+            .map(|info| info.public_key.clone())
+            .ok_or_else(|| {
+                tonic::Status::unauthenticated(
+                    "Observer peer info not found in request. TLS authentication required.",
+                )
+            })?;
+        let inner = request.into_inner();
+        let block_refs = inner
+            .block_refs
+            .into_iter()
+            .filter_map(|serialized| match bcs::from_bytes(&serialized) {
+                Ok(r) => Some(r),
+                Err(e) => {
+                    debug!("Failed to deserialize block ref {:?}: {e:?}", serialized);
+                    None
+                }
+            })
+            .collect();
+        let highest_accepted_rounds = inner.highest_accepted_rounds;
+        let breadth_first = inner.breadth_first;
+        let blocks = self
+            .service
+            .handle_fetch_blocks(peer_id, block_refs, highest_accepted_rounds, breadth_first)
+            .await
+            .map_err(|e| tonic::Status::internal(format!("{e:?}")))?;
+        let responses: std::vec::IntoIter<Result<FetchBlocksResponse, tonic::Status>> =
+            chunk_blocks(blocks, MAX_FETCH_RESPONSE_BYTES)
+                .into_iter()
+                .map(|blocks| Ok(FetchBlocksResponse { blocks }))
+                .collect::<Vec<_>>()
+                .into_iter();
+        let stream = tokio_stream::iter(responses);
+        Ok(Response::new(stream))
     }
 
     async fn fetch_commits(
         &self,
-        _request: Request<FetchCommitsRequest>,
+        request: Request<FetchCommitsRequest>,
     ) -> Result<Response<FetchCommitsResponse>, tonic::Status> {
-        // TODO: Implement fetch_commits for observer nodes
-        Err(tonic::Status::unimplemented(
-            "fetch_commits not yet implemented for observers",
-        ))
+        let peer_id = request
+            .extensions()
+            .get::<ObserverPeerInfo>()
+            .map(|info| info.public_key.clone())
+            .ok_or_else(|| {
+                tonic::Status::unauthenticated(
+                    "Observer peer info not found in request. TLS authentication required.",
+                )
+            })?;
+        let request = request.into_inner();
+        let (commits, certifier_blocks) = self
+            .service
+            .handle_fetch_commits(peer_id, (request.start..=request.end).into())
+            .await
+            .map_err(|e| tonic::Status::internal(format!("{e:?}")))?;
+        let commits = commits
+            .into_iter()
+            .map(|c| c.serialized().clone())
+            .collect();
+        let certifier_blocks = certifier_blocks
+            .into_iter()
+            .map(|b| b.serialized().clone())
+            .collect();
+        Ok(Response::new(FetchCommitsResponse {
+            commits,
+            certifier_blocks,
+        }))
     }
 }
 

--- a/consensus/core/src/network/test_network.rs
+++ b/consensus/core/src/network/test_network.rs
@@ -184,6 +184,8 @@ impl ObserverNetworkService for Mutex<TestService> {
         &self,
         _peer: NodeId,
         _block_refs: Vec<BlockRef>,
+        _highest_accepted_rounds: Vec<Round>,
+        _breadth_first: bool,
     ) -> ConsensusResult<Vec<Bytes>> {
         unimplemented!("ObserverNetworkService fetch_blocks not implemented for TestService")
     }

--- a/consensus/core/src/network/test_network.rs
+++ b/consensus/core/src/network/test_network.rs
@@ -184,8 +184,8 @@ impl ObserverNetworkService for Mutex<TestService> {
         &self,
         _peer: NodeId,
         _block_refs: Vec<BlockRef>,
-        _highest_accepted_rounds: Vec<Round>,
-        _breadth_first: bool,
+        _fetch_after_rounds: Vec<Round>,
+        _fetch_missing_ancestors: bool,
     ) -> ConsensusResult<Vec<Bytes>> {
         unimplemented!("ObserverNetworkService fetch_blocks not implemented for TestService")
     }

--- a/consensus/core/src/observer_service.rs
+++ b/consensus/core/src/observer_service.rs
@@ -5,7 +5,7 @@ use std::{sync::Arc, time::Duration};
 
 use async_trait::async_trait;
 use bytes::Bytes;
-use consensus_types::block::BlockRef;
+use consensus_types::block::{BlockRef, Round};
 use futures::{StreamExt as _, stream};
 use parking_lot::RwLock;
 use sui_macros::fail_point_async;
@@ -16,6 +16,7 @@ use crate::{
     BlockVerifier, TransactionVoteTracker,
     authority_service::{BroadcastStream, SubscriptionCounter},
     block::{BlockAPI as _, SignedBlock, VerifiedBlock},
+    block_sync_service::BlockSyncService,
     commit::{CommitIndex, CommitRange, TrustedCommit},
     commit_vote_monitor::CommitVoteMonitor,
     context::Context,
@@ -44,6 +45,8 @@ pub(crate) struct ObserverService {
     commit_vote_monitor: Arc<CommitVoteMonitor>,
     transaction_vote_tracker: TransactionVoteTracker,
     synchronizer: Arc<SynchronizerHandle>,
+    #[allow(dead_code)]
+    block_sync_service: Arc<BlockSyncService>,
 }
 
 impl ObserverService {
@@ -56,6 +59,7 @@ impl ObserverService {
         commit_vote_monitor: Arc<CommitVoteMonitor>,
         transaction_vote_tracker: TransactionVoteTracker,
         synchronizer: Arc<SynchronizerHandle>,
+        block_sync_service: Arc<BlockSyncService>,
     ) -> Self {
         let subscription_counter = Arc::new(SubscriptionCounter::new(context.clone()));
         Self {
@@ -68,6 +72,7 @@ impl ObserverService {
             commit_vote_monitor,
             transaction_vote_tracker,
             synchronizer,
+            block_sync_service,
         }
     }
 }
@@ -273,24 +278,27 @@ impl ObserverNetworkService for ObserverService {
     async fn handle_fetch_blocks(
         &self,
         _peer: NodeId,
-        _block_refs: Vec<BlockRef>,
+        block_refs: Vec<BlockRef>,
+        highest_accepted_rounds: Vec<Round>,
+        breadth_first: bool,
     ) -> ConsensusResult<Vec<Bytes>> {
-        // TODO: implement observer fetch blocks, similar to validator fetch_blocks but
-        // without highest_accepted_rounds.
-        Err(ConsensusError::NetworkRequest(
-            "Observer fetch blocks not yet implemented".to_string(),
-        ))
+        fail_point_async!("consensus-rpc-response");
+
+        // Delegate to BlockSyncService (for observer, no highest_accepted_rounds)
+        self.block_sync_service
+            .fetch_blocks(block_refs, highest_accepted_rounds, breadth_first)
+            .await
     }
 
     async fn handle_fetch_commits(
         &self,
         _peer: NodeId,
-        _commit_range: CommitRange,
+        commit_range: CommitRange,
     ) -> ConsensusResult<(Vec<TrustedCommit>, Vec<VerifiedBlock>)> {
-        // TODO: implement observer fetch commits, similar to validator fetch_commits.
-        Err(ConsensusError::NetworkRequest(
-            "Observer fetch commits not yet implemented".to_string(),
-        ))
+        fail_point_async!("consensus-rpc-response");
+
+        // Delegate to BlockSyncService
+        self.block_sync_service.fetch_commits(commit_range).await
     }
 }
 
@@ -324,7 +332,7 @@ mod tests {
         let context = Arc::new(context);
 
         let store = Arc::new(MemStore::new());
-        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
+        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
 
         let (tx_accepted_block, rx_accepted_block) =
             broadcast::channel::<(VerifiedBlock, CommitIndex)>(100);
@@ -336,6 +344,11 @@ mod tests {
         let transaction_vote_tracker =
             TransactionVoteTracker::new(context.clone(), block_verifier.clone(), dag_state.clone());
 
+        let block_sync_service = Arc::new(BlockSyncService::new(
+            context.clone(),
+            dag_state.clone(),
+            store.clone(),
+        ));
         let observer_service = ObserverService::new(
             context.clone(),
             core_dispatcher,
@@ -345,6 +358,7 @@ mod tests {
             commit_vote_monitor,
             transaction_vote_tracker,
             create_mock_synchronizer(),
+            block_sync_service,
         );
 
         // Observer starts with no blocks seen
@@ -395,7 +409,7 @@ mod tests {
         let context = Arc::new(context);
 
         let store = Arc::new(MemStore::new());
-        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
+        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
 
         let (_tx_accepted_block, rx_accepted_block) =
             broadcast::channel::<(VerifiedBlock, CommitIndex)>(100);
@@ -407,6 +421,11 @@ mod tests {
         let transaction_vote_tracker =
             TransactionVoteTracker::new(context.clone(), block_verifier.clone(), dag_state.clone());
 
+        let block_sync_service = Arc::new(BlockSyncService::new(
+            context.clone(),
+            dag_state.clone(),
+            store.clone(),
+        ));
         let observer_service = ObserverService::new(
             context.clone(),
             core_dispatcher,
@@ -416,6 +435,7 @@ mod tests {
             commit_vote_monitor,
             transaction_vote_tracker,
             create_mock_synchronizer(),
+            block_sync_service,
         );
 
         let peer = keys[0].0.public().clone();

--- a/consensus/core/src/observer_service.rs
+++ b/consensus/core/src/observer_service.rs
@@ -45,7 +45,6 @@ pub(crate) struct ObserverService {
     commit_vote_monitor: Arc<CommitVoteMonitor>,
     transaction_vote_tracker: TransactionVoteTracker,
     synchronizer: Arc<SynchronizerHandle>,
-    #[allow(dead_code)]
     block_sync_service: Arc<BlockSyncService>,
 }
 

--- a/consensus/core/src/observer_service.rs
+++ b/consensus/core/src/observer_service.rs
@@ -279,14 +279,14 @@ impl ObserverNetworkService for ObserverService {
         &self,
         _peer: NodeId,
         block_refs: Vec<BlockRef>,
-        highest_accepted_rounds: Vec<Round>,
-        breadth_first: bool,
+        fetch_after_rounds: Vec<Round>,
+        fetch_missing_ancestors: bool,
     ) -> ConsensusResult<Vec<Bytes>> {
         fail_point_async!("consensus-rpc-response");
 
-        // Delegate to BlockSyncService (for observer, no highest_accepted_rounds)
+        // Delegate to BlockSyncService
         self.block_sync_service
-            .fetch_blocks(block_refs, highest_accepted_rounds, breadth_first)
+            .fetch_blocks(block_refs, fetch_after_rounds, fetch_missing_ancestors)
             .await
     }
 

--- a/consensus/core/src/observer_subscriber.rs
+++ b/consensus/core/src/observer_subscriber.rs
@@ -302,8 +302,8 @@ mod tests {
             &self,
             _peer: PeerId,
             _block_refs: Vec<BlockRef>,
-            _highest_accepted_rounds: Vec<Round>,
-            _breadth_first: bool,
+            _fetch_after_rounds: Vec<Round>,
+            _fetch_missing_ancestors: bool,
             _timeout: Duration,
         ) -> ConsensusResult<Vec<Bytes>> {
             unimplemented!("Unimplemented")
@@ -354,8 +354,8 @@ mod tests {
             &self,
             _peer: NodeId,
             _block_refs: Vec<BlockRef>,
-            _highest_accepted_rounds: Vec<Round>,
-            _breadth_first: bool,
+            _fetch_after_rounds: Vec<Round>,
+            _fetch_missing_ancestors: bool,
         ) -> ConsensusResult<Vec<Bytes>> {
             unimplemented!("Unimplemented")
         }

--- a/consensus/core/src/observer_subscriber.rs
+++ b/consensus/core/src/observer_subscriber.rs
@@ -249,7 +249,7 @@ mod tests {
 
     use async_trait::async_trait;
     use bytes::Bytes;
-    use consensus_types::block::BlockRef;
+    use consensus_types::block::{BlockRef, Round};
     use futures::stream;
     use parking_lot::{Mutex, RwLock};
     use tokio::time::sleep;
@@ -302,6 +302,8 @@ mod tests {
             &self,
             _peer: PeerId,
             _block_refs: Vec<BlockRef>,
+            _highest_accepted_rounds: Vec<Round>,
+            _breadth_first: bool,
             _timeout: Duration,
         ) -> ConsensusResult<Vec<Bytes>> {
             unimplemented!("Unimplemented")
@@ -352,6 +354,8 @@ mod tests {
             &self,
             _peer: NodeId,
             _block_refs: Vec<BlockRef>,
+            _highest_accepted_rounds: Vec<Round>,
+            _breadth_first: bool,
         ) -> ConsensusResult<Vec<Bytes>> {
             unimplemented!("Unimplemented")
         }

--- a/consensus/core/src/synchronizer.rs
+++ b/consensus/core/src/synchronizer.rs
@@ -1590,8 +1590,8 @@ mod tests {
             &self,
             _peer: crate::network::PeerId,
             _block_refs: Vec<BlockRef>,
-            _highest_accepted_rounds: Vec<Round>,
-            _breadth_first: bool,
+            _fetch_after_rounds: Vec<Round>,
+            _fetch_missing_ancestors: bool,
             _timeout: Duration,
         ) -> ConsensusResult<Vec<Bytes>> {
             unimplemented!("Observer fetch_blocks not implemented in mock")

--- a/consensus/core/src/synchronizer.rs
+++ b/consensus/core/src/synchronizer.rs
@@ -1590,6 +1590,8 @@ mod tests {
             &self,
             _peer: crate::network::PeerId,
             _block_refs: Vec<BlockRef>,
+            _highest_accepted_rounds: Vec<Round>,
+            _breadth_first: bool,
             _timeout: Duration,
         ) -> ConsensusResult<Vec<Bytes>> {
             unimplemented!("Observer fetch_blocks not implemented in mock")

--- a/consensus/simtests/src/node.rs
+++ b/consensus/simtests/src/node.rs
@@ -26,6 +26,8 @@ use tracing::{info, trace};
 
 #[derive(Clone)]
 pub struct Config {
+    // When this is an Observer node, then a dummy value is used not overlapping with the validator indices
+    // TODO: use a parameter for Observer nodes
     pub authority_index: AuthorityIndex,
     pub db_dir: Arc<TempDir>,
     pub committee: Committee,
@@ -34,6 +36,11 @@ pub struct Config {
     pub clock_drift: BlockTimestampMs,
     pub protocol_config: ConsensusProtocolConfig,
     pub transaction_verifier: Arc<dyn TransactionVerifier>,
+    pub parameters: Parameters,
+    /// Optional network keypair for Observer nodes (which are not part of the committee)
+    pub observer_network_keypair: Option<NetworkKeyPair>,
+    /// Optional pre-allocated IP for Observer nodes (allows controlled IP assignment in tests)
+    pub observer_ip: Option<String>,
 }
 
 pub struct AuthorityNode {
@@ -58,7 +65,12 @@ impl AuthorityNode {
 
     /// Start this Node
     pub async fn start(&self) -> Result<()> {
-        info!(index = %self.config.authority_index, "starting in-memory node");
+        let node_type = if self.config.observer_network_keypair.is_some() {
+            "Observer"
+        } else {
+            "Validator"
+        };
+        info!(index = %self.config.authority_index, node_type = node_type, "starting in-memory node");
         let config = self.config.clone();
         *self.inner.lock() = Some(AuthorityNodeInner::spawn(config).await);
         Ok(())
@@ -116,9 +128,14 @@ impl AuthorityNode {
 
     /// Stop this Node
     pub fn stop(&self) {
-        info!(index =% self.config.authority_index, "stopping in-memory node");
+        let node_type = if self.config.observer_network_keypair.is_some() {
+            "Observer"
+        } else {
+            "Validator"
+        };
+        info!(index =% self.config.authority_index, node_type = node_type, "stopping in-memory node");
         *self.inner.lock() = None;
-        info!(index =% self.config.authority_index, "node stopped");
+        info!(index =% self.config.authority_index, node_type = node_type, "node stopped");
     }
 
     /// If this Node is currently running
@@ -159,18 +176,35 @@ impl AuthorityNodeInner {
         let handle = sui_simulator::runtime::Handle::current();
         let builder = handle.create_node();
 
-        let authority = config.committee.authority(config.authority_index);
-        let socket_addr = to_socket_addr(&authority.address).unwrap();
-        let ip = match socket_addr {
-            SocketAddr::V4(v4) => IpAddr::V4(*v4.ip()),
-            _ => panic!("unsupported protocol"),
+        // Determine IP address and node name based on whether this is an Observer node
+        let (ip, node_name) = if config.observer_network_keypair.is_some() {
+            // Observer node: use pre-allocated IP if provided, otherwise get a new one
+            let ip_str = if let Some(ref observer_ip) = config.observer_ip {
+                observer_ip.clone()
+            } else {
+                panic!("Observer IP not provided");
+            };
+            let ip: IpAddr = ip_str.parse().expect("Failed to parse IP address");
+
+            // For Observer nodes, use "Observer" as the name prefix
+            (ip, format!("Observer-{}", config.authority_index))
+        } else {
+            // Validator node: use the committee-defined address
+            let authority = config.committee.authority(config.authority_index);
+            let socket_addr = to_socket_addr(&authority.address).unwrap();
+            let ip = match socket_addr {
+                SocketAddr::V4(v4) => IpAddr::V4(*v4.ip()),
+                _ => panic!("unsupported protocol"),
+            };
+            (ip, format!("{}", config.authority_index))
         };
+
         let init_receiver_swap = Arc::new(ArcSwapOption::empty());
         let int_receiver_swap_clone = init_receiver_swap.clone();
 
         let node = builder
             .ip(ip)
-            .name(format!("{}", config.authority_index))
+            .name(node_name)
             .init(move || {
                 info!("Node restarted");
                 let config = config.clone();
@@ -264,29 +298,31 @@ pub(crate) async fn make_authority(
 ) {
     let Config {
         authority_index,
-        db_dir,
+        db_dir: _,
         committee,
         keypairs,
         boot_counter,
         protocol_config,
         clock_drift,
         transaction_verifier,
+        parameters,
+        observer_network_keypair,
+        observer_ip: _, // Not used in make_authority, only used in spawn
     } = config;
 
     let registry = Registry::new();
 
-    // Cache less blocks to exercise commit sync.
-    let parameters = Parameters {
-        db_path: db_dir.path().to_path_buf(),
-        dag_state_cached_rounds: 5,
-        commit_sync_parallel_fetches: 2,
-        commit_sync_batch_size: 3,
-        sync_last_known_own_block_timeout: Duration::from_millis(2_000),
-        ..Default::default()
-    };
-
-    let protocol_keypair = keypairs[authority_index].1.clone();
-    let network_keypair = keypairs[authority_index].0.clone();
+    // Determine if this is an Observer node or a Validator node
+    let (protocol_keypair, network_keypair) =
+        if let Some(observer_keypair) = observer_network_keypair {
+            // Observer node: no protocol keypair, use the provided observer network keypair
+            (None, observer_keypair)
+        } else {
+            // Validator node: use keypairs from the committee
+            let protocol_keypair = keypairs[authority_index].1.clone();
+            let network_keypair = keypairs[authority_index].0.clone();
+            (Some(protocol_keypair), network_keypair)
+        };
 
     let (commit_consumer, commit_receiver) = CommitConsumerArgs::new(0, 0);
     let commit_consumer_monitor = commit_consumer.monitor();
@@ -297,7 +333,7 @@ pub(crate) async fn make_authority(
         committee,
         parameters,
         protocol_config,
-        Some(protocol_keypair),
+        protocol_keypair,
         network_keypair,
         Arc::new(Clock::new_for_test(clock_drift)),
         transaction_verifier,
@@ -308,4 +344,14 @@ pub(crate) async fn make_authority(
     .await;
 
     (authority, commit_receiver, commit_consumer_monitor)
+}
+
+pub fn default_parameters() -> Parameters {
+    Parameters {
+        dag_state_cached_rounds: 5,
+        commit_sync_parallel_fetches: 2,
+        commit_sync_batch_size: 3,
+        sync_last_known_own_block_timeout: Duration::from_millis(2_000),
+        ..Default::default()
+    }
 }

--- a/consensus/simtests/tests/consensus_tests.rs
+++ b/consensus/simtests/tests/consensus_tests.rs
@@ -7,7 +7,8 @@ mod consensus_tests {
     use std::{sync::Arc, time::Duration};
 
     use consensus_config::{
-        Authority, AuthorityIndex, AuthorityName, Committee, ConsensusProtocolConfig, Epoch, NetworkKeyPair, Parameters, ProtocolKeyPair, Stake
+        Authority, AuthorityIndex, AuthorityName, Committee, ConsensusProtocolConfig, Epoch,
+        NetworkKeyPair, Parameters, ProtocolKeyPair, Stake,
     };
     use consensus_core::NoopTransactionVerifier;
     use consensus_core::{BlockAPI, BlockStatus, TransactionVerifier, ValidationError};

--- a/consensus/simtests/tests/consensus_tests.rs
+++ b/consensus/simtests/tests/consensus_tests.rs
@@ -365,7 +365,7 @@ mod consensus_tests {
             let db_dir = Arc::new(TempDir::new().unwrap());
             let mut parameters = default_parameters();
             parameters.db_path = db_dir.path().to_path_buf();
-            parameters.tonic.observer_server_port = Some(9600 + authority_index.value() as u16);
+            parameters.observer.server_port = Some(9600 + authority_index.value() as u16);
 
             let config = Config {
                 authority_index,
@@ -409,11 +409,11 @@ mod consensus_tests {
 
         let mut observer1_params = default_parameters();
         observer1_params.db_path = observer1_dir.path().to_path_buf();
-        observer1_params.tonic = consensus_config::TonicParameters {
+        observer1_params.observer = consensus_config::ObserverParameters {
             // Enable observer server on Observer 1 (port 9610) so Observer 2 can connect
-            observer_server_port: Some(9610),
+            server_port: Some(9610),
             // Connect to validator 0's observer server port
-            observer_peers: vec![consensus_config::PeerRecord {
+            peers: vec![consensus_config::PeerRecord {
                 public_key: validator_info.network_key.clone(),
                 address: validator_observer_address,
             }],
@@ -455,9 +455,9 @@ mod consensus_tests {
 
         let mut observer2_params = default_parameters();
         observer2_params.db_path = observer2_dir.path().to_path_buf();
-        observer2_params.tonic = consensus_config::TonicParameters {
+        observer2_params.observer = consensus_config::ObserverParameters {
             // Configure to connect to Observer 1's observer server at port 9610
-            observer_peers: vec![consensus_config::PeerRecord {
+            peers: vec![consensus_config::PeerRecord {
                 public_key: observer1_keypair.public().clone(),
                 address: observer1_address,
             }],

--- a/consensus/simtests/tests/consensus_tests.rs
+++ b/consensus/simtests/tests/consensus_tests.rs
@@ -7,8 +7,7 @@ mod consensus_tests {
     use std::{sync::Arc, time::Duration};
 
     use consensus_config::{
-        Authority, AuthorityIndex, AuthorityName, Committee, ConsensusProtocolConfig, Epoch,
-        NetworkKeyPair, ProtocolKeyPair, Stake,
+        Authority, AuthorityIndex, AuthorityName, Committee, ConsensusProtocolConfig, Epoch, NetworkKeyPair, Parameters, ProtocolKeyPair, Stake
     };
     use consensus_core::NoopTransactionVerifier;
     use consensus_core::{BlockAPI, BlockStatus, TransactionVerifier, ValidationError};
@@ -16,7 +15,7 @@ mod consensus_tests {
     use consensus_types::block::{BlockRef, TransactionIndex};
     use fastcrypto::traits::{KeyPair as _, ToFromBytes as _};
     use mysten_metrics::RegistryService;
-    use mysten_network::Multiaddr;
+    use mysten_network::{Multiaddr, multiaddr::Protocol};
     use prometheus::Registry;
     use rand::{Rng, SeedableRng as _, rngs::StdRng};
     use sui_config::local_ip_utils;
@@ -67,15 +66,22 @@ mod consensus_tests {
         for (authority_index, _authority_info) in committee.authorities() {
             // Introduce a non-trivial clock drift for the first node (it's time will be ahead of the others). This will provide extra reassurance
             // around the block timestamp checks.
+            let db_dir = Arc::new(TempDir::new().unwrap());
+            let mut params = default_parameters();
+            params.db_path = db_dir.path().to_path_buf();
+
             let config = Config {
                 authority_index,
-                db_dir: Arc::new(TempDir::new().unwrap()),
+                db_dir,
                 committee: committee.clone(),
                 keypairs: keypairs.clone(),
                 boot_counter: boot_counters[authority_index],
                 protocol_config: protocol_config.clone(),
                 clock_drift: clock_drifts[authority_index.value() as usize],
                 transaction_verifier: Arc::new(NoopTransactionVerifier {}),
+                parameters: params,
+                observer_network_keypair: None,
+                observer_ip: None,
             };
             let node = AuthorityNode::new(config);
 
@@ -153,9 +159,13 @@ mod consensus_tests {
         for (authority_index, _authority_info) in committee.authorities() {
             // Introduce clock drifts for the first three nodes (their time will be ahead of the others).
             // This will provide extra reassurance around the block timestamp checks.
+            let db_dir = Arc::new(TempDir::new().unwrap());
+            let mut params = default_parameters();
+            params.db_path = db_dir.path().to_path_buf();
+
             let config = Config {
                 authority_index,
-                db_dir: Arc::new(TempDir::new().unwrap()),
+                db_dir,
                 committee: committee.clone(),
                 keypairs: keypairs.clone(),
                 boot_counter: boot_counters[authority_index],
@@ -164,6 +174,9 @@ mod consensus_tests {
                 transaction_verifier: Arc::new(RandomizedTransactionVerifier::new(
                     REJECTION_PROBABILITY,
                 )),
+                parameters: params,
+                observer_network_keypair: None,
+                observer_ip: None,
             };
             let node = AuthorityNode::new(config);
             node.start().await.unwrap();
@@ -325,6 +338,210 @@ mod consensus_tests {
             total_rejected_transactions
         );
     }
+
+    // Test with multiple Observer nodes in a chain
+    #[sim_test(config = "test_config()")]
+    async fn test_observer_chain_connectivity() {
+        telemetry_subscribers::init_for_testing();
+        let db_registry = Registry::new();
+        DBMetrics::init(RegistryService::new(db_registry));
+
+        const NUM_OF_AUTHORITIES: usize = 4;
+        const NUM_TRANSACTIONS: u16 = 300;
+
+        // Create committee and validators
+        let (committee, keypairs) = local_committee_and_keys(0, [1; NUM_OF_AUTHORITIES].to_vec());
+        let mut protocol_config = ConsensusProtocolConfig::for_testing();
+        protocol_config.set_gc_depth_for_testing(5);
+
+        let mut authorities = Vec::with_capacity(committee.size());
+        let mut transaction_clients = Vec::with_capacity(committee.size());
+        let mut boot_counters = [0; NUM_OF_AUTHORITIES];
+
+        // Start validators with observer server support enabled
+        // Note: In production, validators would need observer server ports configured
+        for (authority_index, _) in committee.authorities() {
+            let db_dir = Arc::new(TempDir::new().unwrap());
+            let mut parameters = default_parameters();
+            parameters.db_path = db_dir.path().to_path_buf();
+            parameters.tonic.observer_server_port = Some(9600 + authority_index.value() as u16);
+
+            let config = Config {
+                authority_index,
+                db_dir,
+                committee: committee.clone(),
+                keypairs: keypairs.clone(),
+                boot_counter: boot_counters[authority_index],
+                protocol_config: protocol_config.clone(),
+                clock_drift: 0,
+                transaction_verifier: Arc::new(NoopTransactionVerifier {}),
+                parameters,
+                observer_network_keypair: None,
+                observer_ip: None,
+            };
+            let node = AuthorityNode::new(config);
+            node.start().await.unwrap();
+            node.spawn_committed_subdag_consumer().unwrap();
+            transaction_clients.push(node.transaction_client());
+            boot_counters[authority_index] += 1;
+            authorities.push(node);
+        }
+
+        // Pre-allocate IPs for Observer nodes so we can configure them properly
+        let observer1_ip = local_ip_utils::get_new_ip();
+        let observer2_ip = local_ip_utils::get_new_ip();
+
+        // Create Observer 1 - connects to validator
+        let observer1_dir = Arc::new(TempDir::new().unwrap());
+        let observer1_keypair =
+            NetworkKeyPair::generate(&mut rand::rngs::StdRng::from_seed([42; 32]));
+
+        // Configure Observer 1 to connect to validator 0's observer server port
+        let validator_index = AuthorityIndex::new_for_test(0);
+        let validator_info = committee.authority(validator_index);
+
+        // Extract IP from validator's address and swap port to observer port
+        let validator_observer_port = 9600 + validator_index.value() as u16;
+        let validator_observer_address =
+            replace_port_in_multiaddr(&validator_info.address, validator_observer_port)
+                .expect("Failed to create observer address");
+
+        let mut observer1_params = default_parameters();
+        observer1_params.db_path = observer1_dir.path().to_path_buf();
+        observer1_params.tonic = consensus_config::TonicParameters {
+            // Enable observer server on Observer 1 (port 9610) so Observer 2 can connect
+            observer_server_port: Some(9610),
+            // Connect to validator 0's observer server port
+            observer_peers: vec![consensus_config::PeerRecord {
+                public_key: validator_info.network_key.clone(),
+                address: validator_observer_address,
+            }],
+            ..Default::default()
+        };
+
+        tracing::info!(
+            "Starting Observer 1 (connects to validator) with IP {}",
+            observer1_ip
+        );
+
+        // Create Observer 1 using AuthorityNode with pre-allocated IP
+        let observer1_config = Config {
+            authority_index: AuthorityIndex::new_for_test(100), // Use a high index for Observer
+            db_dir: observer1_dir,
+            committee: committee.clone(),
+            keypairs: keypairs.clone(), // Observer won't use these
+            boot_counter: 0,
+            protocol_config: protocol_config.clone(),
+            clock_drift: 0,
+            transaction_verifier: Arc::new(NoopTransactionVerifier {}),
+            parameters: observer1_params,
+            observer_network_keypair: Some(observer1_keypair.clone()),
+            observer_ip: Some(observer1_ip.clone()), // Pass the pre-allocated IP
+        };
+
+        let observer1 = AuthorityNode::new(observer1_config);
+        observer1.start().await.unwrap();
+        observer1.spawn_committed_subdag_consumer().unwrap();
+        let observer1_monitor = observer1.commit_consumer_monitor();
+
+        // Create Observer 2 - connects to Observer 1
+        let observer2_dir = Arc::new(TempDir::new().unwrap());
+        let observer2_keypair =
+            NetworkKeyPair::generate(&mut rand::rngs::StdRng::from_seed([99; 32]));
+
+        // Create an address for Observer 1's observer server using the pre-allocated IP
+        let observer1_address = format!("/ip4/{}/udp/9610", observer1_ip).parse().unwrap();
+
+        let mut observer2_params = default_parameters();
+        observer2_params.db_path = observer2_dir.path().to_path_buf();
+        observer2_params.tonic = consensus_config::TonicParameters {
+            // Configure to connect to Observer 1's observer server at port 9610
+            observer_peers: vec![consensus_config::PeerRecord {
+                public_key: observer1_keypair.public().clone(),
+                address: observer1_address,
+            }],
+            ..Default::default()
+        };
+
+        tracing::info!(
+            "Starting Observer 2 (connects to Observer 1) with IP {}",
+            observer2_ip
+        );
+
+        // Create Observer 2 using AuthorityNode with pre-allocated IP
+        let observer2_config = Config {
+            authority_index: AuthorityIndex::new_for_test(101), // Use a different high index for Observer 2
+            db_dir: observer2_dir,
+            committee: committee.clone(),
+            keypairs: keypairs.clone(), // Observer won't use these
+            boot_counter: 0,
+            protocol_config: protocol_config.clone(),
+            clock_drift: 0,
+            transaction_verifier: Arc::new(NoopTransactionVerifier {}),
+            parameters: observer2_params,
+            observer_network_keypair: Some(observer2_keypair.clone()),
+            observer_ip: Some(observer2_ip.clone()), // Pass the pre-allocated IP
+        };
+
+        let observer2 = AuthorityNode::new(observer2_config);
+        observer2.start().await.unwrap();
+        observer2.spawn_committed_subdag_consumer().unwrap();
+        let observer2_monitor = observer2.commit_consumer_monitor();
+
+        // Wait for all nodes to establish connections
+        tracing::info!("Waiting for nodes to establish connections...");
+        sleep(Duration::from_secs(5)).await;
+
+        // Submit transactions from validators
+        tracing::info!("Submitting {} transactions", NUM_TRANSACTIONS);
+        for i in 0..NUM_TRANSACTIONS {
+            let txn = vec![i as u8; 16];
+            transaction_clients[i as usize % transaction_clients.len()]
+                .submit(vec![txn])
+                .await
+                .unwrap();
+            if i % 50 == 0 {
+                sleep(Duration::from_millis(200)).await;
+            }
+        }
+
+        // Wait for processing and syncing
+        tracing::info!("Waiting for processing and syncing...");
+        sleep(Duration::from_secs(15)).await;
+
+        // Check progress of all nodes
+        let validator_commits = authorities[0]
+            .commit_consumer_monitor()
+            .highest_handled_commit();
+        let observer1_commits = observer1_monitor.highest_handled_commit();
+        let observer2_commits = observer2_monitor.highest_handled_commit();
+
+        // Validators should definitely make progress
+        assert!(
+            validator_commits > 10,
+            "Validators should make significant progress"
+        );
+
+        // Give observers a chance to sync by checking if they're making progress
+        // Note: Observers may take time to sync, so we check for any progress
+        const MAX_COMMIT_DIFFERENCE: u32 = 10;
+        assert!(
+            validator_commits - observer1_commits <= MAX_COMMIT_DIFFERENCE,
+            "Observer 1 should make progress"
+        );
+        assert!(
+            validator_commits - observer2_commits <= MAX_COMMIT_DIFFERENCE,
+            "Observer 2 should make progress"
+        );
+
+        // Clean up
+        observer1.stop();
+        observer2.stop();
+        for authority in authorities {
+            authority.stop();
+        }
+    }
+
     /// Creates a committee for local testing, and the corresponding key pairs for the authorities.
     pub fn local_committee_and_keys(
         epoch: Epoch,
@@ -357,6 +574,30 @@ mod consensus_tests {
         let ip = local_ip_utils::get_new_ip();
 
         local_ip_utils::new_udp_address_for_testing(&ip)
+    }
+
+    // Helper function to create default parameters with custom db_path
+    fn default_parameters() -> Parameters {
+        consensus_simtests::node::default_parameters()
+    }
+
+    // Helper function to replace the port in a Multiaddr
+    fn replace_port_in_multiaddr(addr: &Multiaddr, new_port: u16) -> Result<Multiaddr, String> {
+        let mut iter = addr.iter();
+        match (iter.next(), iter.next()) {
+            (Some(Protocol::Ip4(ipaddr)), Some(Protocol::Udp(_))) => {
+                Ok(format!("/ip4/{}/udp/{}", ipaddr, new_port).parse().unwrap())
+            }
+            (Some(Protocol::Ip6(ipaddr)), Some(Protocol::Udp(_))) => {
+                Ok(format!("/ip6/{}/udp/{}", ipaddr, new_port).parse().unwrap())
+            }
+            (Some(Protocol::Dns(hostname)), Some(Protocol::Udp(_))) => {
+                Ok(format!("/dns/{}/udp/{}", hostname, new_port)
+                    .parse()
+                    .unwrap())
+            }
+            _ => Err(format!("Unsupported multiaddr format: {}", addr)),
+        }
     }
 
     // Transaction verifier with randomized voting.


### PR DESCRIPTION
## Description 

This PR is extracting the common processing logic for synchronising blocks and commits to the `BlockSyncService` as the same logic - at least for now - will be used for both the `AuthorityService` and the `ObserverService` endpoints.

The PR also implements the client & server endpoints `fetch_blocks` and `fetch_commits` for the Observer server. After this PR all the Observer endpoints should be working end to end. The `commit_syncer` is also refactored to use the `PeersPool`.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
