### PR TITLE
[move][cleanup/easy] Macro hygiene cleanup across Move crates

### DIFF
--- a/external-crates/move/crates/move-binary-format/src/lib.rs
+++ b/external-crates/move/crates/move-binary-format/src/lib.rs
@@ -137,7 +137,7 @@ macro_rules! safe_unwrap {
         match $e {
             Some(x) => x,
             None => {
-                let err = move_binary_format::errors::PartialVMError::new(
+                let err = $crate::errors::PartialVMError::new(
                     move_core_types::vm_status::StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR,
                 )
                 .with_message(format!("{}:{} (none)", file!(), line!()));
@@ -158,7 +158,7 @@ macro_rules! safe_unwrap_err {
         match $e {
             Ok(x) => x,
             Err(e) => {
-                let err = move_binary_format::errors::PartialVMError::new(
+                let err = $crate::errors::PartialVMError::new(
                     move_core_types::vm_status::StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR,
                 )
                 .with_message(format!("{}:{} {:#}", file!(), line!(), e));

--- a/external-crates/move/crates/move-package-alt/src/logging.rs
+++ b/external-crates/move/crates/move-package-alt/src/logging.rs
@@ -4,14 +4,14 @@
 // User logging wrappers for outputting structured messages to the user.
 macro_rules! user_warning {
     ($($arg:tt)*) => {{
-        use colored::Colorize;
+        use ::colored::Colorize;
         eprintln!("[{}] {}", "WARNING".bold().yellow(), format!($($arg)*));
     }};
     }
 
 macro_rules! user_note {
     ($($arg:tt)*) => {{
-        use colored::Colorize;
+        use ::colored::Colorize;
         eprintln!("[{}] {}", "NOTE".bold().yellow(), format!($($arg)*));
     }};
 }
@@ -24,7 +24,7 @@ macro_rules! user_info {
 
 macro_rules! user_error {
     ($($arg:tt)*) => {{
-        use colored::Colorize;
+        use ::colored::Colorize;
         eprintln!("[{}] {}", "ERROR".bold().red(), format!($($arg)*));
     }};
 }

--- a/external-crates/move/crates/move-vm-runtime/src/natives/functions.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/natives/functions.rs
@@ -339,12 +339,11 @@ impl<'b> NativeContext<'_, 'b, '_> {
 #[macro_export]
 macro_rules! native_charge_gas_early_exit {
     ($native_context:ident, $cost:expr) => {{
-        use move_core_types::vm_status::sub_status::NFE_OUT_OF_GAS;
         if !$native_context.charge_gas($cost)? {
             // Exhausted all in budget. terminate early
-            return Ok(NativeResult::err(
+            return Ok($crate::natives::functions::NativeResult::err(
                 $native_context.gas_budget(),
-                NFE_OUT_OF_GAS,
+                ::move_core_types::vm_status::sub_status::NFE_OUT_OF_GAS,
             ));
         }
     }};


### PR DESCRIPTION
## Description 

- Replace self-referencing by fully qualified crate name with $crate:: in safe_unwrap! and safe_unwrap_err! (move-binary-format)
- Remove bare use import and qualify all types with $crate::/::extern_crate:: in native_charge_gas_early_exit! (move-vm-runtime)
- Use absolute paths (::colored::) for external crate imports inside user_warning!, user_note!, and user_error! macro bodies (move-package-alt)
- No behavioral changes — all fixes are purely syntactic path qualification

## Test plan 

CI 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
