### PR TITLE
Revert "[test] Add gRPC channel to TestCluster to deflake e2e tests #25943"

### DIFF
--- a/crates/sui-e2e-tests/tests/authenticated_events_api_tests.rs
+++ b/crates/sui-e2e-tests/tests/authenticated_events_api_tests.rs
@@ -4,7 +4,7 @@
 use itertools::Itertools;
 use move_core_types::language_storage::StructTag;
 use std::str::FromStr;
-
+use std::time::Duration;
 use sui_keys::keystore::AccountKeystore;
 use sui_light_client::authenticated_events::mmr::apply_stream_updates;
 use sui_light_client::proof::base::{Proof, ProofContents, ProofTarget, ProofVerifier};
@@ -170,8 +170,37 @@ async fn emit_large_test_event(
     test_cluster.sign_and_execute_transaction(&tx_data).await
 }
 
+/// Connect to an rpc client with timeout and retry logic.
+///
+/// gRPC connection establishment can hang indefinitely if the remote peer is unable to complete
+/// connection establishment. This helper ensures we always have bounded connection times and
+/// can retry on transient failures.
+async fn connect_with_retry<T, F, Fut>(connect_fn: F) -> T
+where
+    F: Fn() -> Fut,
+    Fut: std::future::Future<Output = Result<T, tonic::transport::Error>>,
+{
+    const MAX_RETRIES: u32 = 10;
+    const CONNECT_TIMEOUT: Duration = Duration::from_secs(1);
+
+    for attempt in 0..MAX_RETRIES {
+        match tokio::time::timeout(CONNECT_TIMEOUT, connect_fn()).await {
+            Ok(Ok(client)) => return client,
+            Ok(Err(e)) if attempt + 1 < MAX_RETRIES => {
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            }
+            Ok(Err(e)) => panic!("failed to connect after {MAX_RETRIES} attempts: {e}"),
+            Err(_) if attempt + 1 < MAX_RETRIES => {
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            }
+            Err(_) => panic!("connection timed out after {MAX_RETRIES} attempts"),
+        }
+    }
+    unreachable!()
+}
+
 async fn query_authenticated_events(
-    channel: tonic::transport::Channel,
+    rpc_url: &str,
     stream_id: &str,
     start_checkpoint: u64,
     page_size: Option<u32>,
@@ -179,7 +208,7 @@ async fn query_authenticated_events(
     sui_rpc_api::grpc::alpha::event_service_proto::ListAuthenticatedEventsResponse,
     tonic::Status,
 > {
-    let mut client = EventServiceClient::new(channel);
+    let mut client = connect_with_retry(|| EventServiceClient::connect(rpc_url.to_owned())).await;
 
     let mut req = ListAuthenticatedEventsRequest::default();
     req.stream_id = Some(stream_id.to_string());
@@ -194,12 +223,13 @@ async fn query_authenticated_events(
 }
 
 async fn list_authenticated_events(
-    channel: tonic::transport::Channel,
+    rpc_url: &str,
     stream_id: &str,
     start_checkpoint: u64,
     page_size: Option<u32>,
 ) -> Vec<AuthenticatedEvent> {
-    let mut event_client = EventServiceClient::new(channel.clone());
+    let mut event_client =
+        connect_with_retry(|| EventServiceClient::connect(rpc_url.to_owned())).await;
 
     let mut all_events = Vec::new();
     let mut page_token: Option<Vec<u8>> = None;
@@ -249,9 +279,12 @@ async fn verify_events_with_stream_head(
     let stream_id = sui_types::base_types::SuiAddress::from(package_id);
     let event_stream_head_id = get_event_stream_head_object_id(stream_id).unwrap();
 
-    let mut proof_client = ProofServiceClient::new(test_cluster.grpc_channel());
+    let mut proof_client =
+        connect_with_retry(|| ProofServiceClient::connect(test_cluster.rpc_url().to_owned())).await;
 
-    let mut ledger_client = LedgerServiceClient::new(test_cluster.grpc_channel());
+    let mut ledger_client =
+        connect_with_retry(|| LedgerServiceClient::connect(test_cluster.rpc_url().to_owned()))
+            .await;
 
     let current_epoch = test_cluster
         .fullnode_handle
@@ -486,7 +519,9 @@ async fn get_last_checkpoint_of_epoch(
 }
 
 async fn get_genesis_committee(test_cluster: &TestCluster) -> Result<Committee, String> {
-    let mut ledger_client = LedgerServiceClient::new(test_cluster.grpc_channel());
+    let mut ledger_client =
+        connect_with_retry(|| LedgerServiceClient::connect(test_cluster.rpc_url().to_owned()))
+            .await;
 
     get_committee_for_epoch_via_api(&mut ledger_client, 0).await
 }
@@ -731,13 +766,8 @@ async fn list_authenticated_events_end_to_end() {
         emit_test_event(&test_cluster, package_id, sender, 100 + i).await;
     }
 
-    let all_events = list_authenticated_events(
-        test_cluster.grpc_channel(),
-        &package_id.to_string(),
-        0,
-        None,
-    )
-    .await;
+    let all_events =
+        list_authenticated_events(test_cluster.rpc_url(), &package_id.to_string(), 0, None).await;
 
     let count = all_events.len();
     assert_eq!(count, 10, "expected 10 authenticated events, got {count}");
@@ -764,14 +794,10 @@ async fn list_authenticated_events_page_size_validation() {
         .await;
     let sender = test_cluster.wallet.config.keystore.addresses()[0];
 
-    let response = query_authenticated_events(
-        test_cluster.grpc_channel(),
-        &sender.to_string(),
-        0,
-        Some(1500),
-    )
-    .await
-    .unwrap();
+    let response =
+        query_authenticated_events(test_cluster.rpc_url(), &sender.to_string(), 0, Some(1500))
+            .await
+            .unwrap();
 
     assert!(response.events.is_empty());
 }
@@ -787,13 +813,13 @@ async fn list_authenticated_events_start_beyond_highest() {
     let sender = test_cluster.wallet.config.keystore.addresses()[0];
 
     let probe_response =
-        query_authenticated_events(test_cluster.grpc_channel(), &sender.to_string(), 0, Some(1))
+        query_authenticated_events(test_cluster.rpc_url(), &sender.to_string(), 0, Some(1))
             .await
             .unwrap();
     let highest = probe_response.highest_indexed_checkpoint.unwrap_or(0);
 
     let response = query_authenticated_events(
-        test_cluster.grpc_channel(),
+        test_cluster.rpc_url(),
         &sender.to_string(),
         highest + 1000,
         Some(10),
@@ -814,14 +840,10 @@ async fn list_authenticated_events_pruned_checkpoint_error() {
         .await;
     let sender = test_cluster.wallet.config.keystore.addresses()[0];
 
-    let response = query_authenticated_events(
-        test_cluster.grpc_channel(),
-        &sender.to_string(),
-        0,
-        Some(10),
-    )
-    .await
-    .unwrap();
+    let response =
+        query_authenticated_events(test_cluster.rpc_url(), &sender.to_string(), 0, Some(10))
+            .await
+            .unwrap();
 
     assert!(response.events.is_empty());
 }
@@ -837,13 +859,8 @@ async fn authenticated_events_disabled_test() {
     let test_cluster = test_cluster::TestClusterBuilder::new().build().await;
     let sender = test_cluster.wallet.config.keystore.addresses()[0];
 
-    let result = query_authenticated_events(
-        test_cluster.grpc_channel(),
-        &sender.to_string(),
-        0,
-        Some(10),
-    )
-    .await;
+    let result =
+        query_authenticated_events(test_cluster.rpc_url(), &sender.to_string(), 0, Some(10)).await;
 
     assert!(
         result.is_err(),
@@ -886,7 +903,7 @@ async fn authenticated_events_backfill_test() {
         emit_test_event(&test_cluster, package_id, sender, 200 + i).await;
     }
 
-    let indexing_channel = {
+    let rpc_url_with_indexing = {
         let mut new_fullnode_config = test_cluster
             .fullnode_config_builder()
             .build(&mut rand::rngs::OsRng, test_cluster.swarm.config());
@@ -900,13 +917,13 @@ async fn authenticated_events_backfill_test() {
             .start_fullnode_from_config(new_fullnode_config)
             .await;
 
-        test_cluster::FullNodeHandle::connect_channel_with_retry(&new_fullnode_handle.rpc_url).await
+        new_fullnode_handle.rpc_url.clone()
     };
 
     let start = tokio::time::Instant::now();
     let response = loop {
         let response =
-            query_authenticated_events(indexing_channel.clone(), &package_id.to_string(), 0, None)
+            query_authenticated_events(&rpc_url_with_indexing, &package_id.to_string(), 0, None)
                 .await
                 .unwrap();
 
@@ -952,7 +969,8 @@ async fn authenticated_events_multiple_events_per_transaction() {
 
     let _response = emit_multiple_test_events(&test_cluster, package_id, sender, 100, 3).await;
 
-    let mut event_client = EventServiceClient::new(test_cluster.grpc_channel());
+    let mut event_client =
+        connect_with_retry(|| EventServiceClient::connect(test_cluster.rpc_url().to_owned())).await;
 
     let mut req = ListAuthenticatedEventsRequest::default();
     req.stream_id = Some(package_id.to_string());
@@ -1031,13 +1049,9 @@ async fn test_pagination() {
         emit_multiple_test_events(&test_cluster, package_id, sender, i * 5, 5).await;
     }
 
-    let all_events = list_authenticated_events(
-        test_cluster.grpc_channel(),
-        &package_id.to_string(),
-        0,
-        Some(7),
-    )
-    .await;
+    let all_events =
+        list_authenticated_events(test_cluster.rpc_url(), &package_id.to_string(), 0, Some(7))
+            .await;
 
     assert_eq!(
         all_events.len(),
@@ -1077,7 +1091,8 @@ async fn test_object_inclusion_proof_error_code() {
             .unwrap()
     });
 
-    let mut proof_client = ProofServiceClient::new(test_cluster.grpc_channel());
+    let mut proof_client =
+        connect_with_retry(|| ProofServiceClient::connect(test_cluster.rpc_url().to_owned())).await;
 
     let mut req = GetObjectInclusionProofRequest::default();
     req.object_id = Some(event_stream_head_id.to_string());
@@ -1129,7 +1144,8 @@ async fn test_size_based_pagination() {
     emit_large_test_event(&test_cluster, package_id, sender, 3, 200_000).await;
     emit_large_test_event(&test_cluster, package_id, sender, 4, 200_000).await;
 
-    let mut event_client = EventServiceClient::new(test_cluster.grpc_channel());
+    let mut event_client =
+        connect_with_retry(|| EventServiceClient::connect(test_cluster.rpc_url().to_owned())).await;
 
     let mut req = ListAuthenticatedEventsRequest::default();
     req.stream_id = Some(package_id.to_string());
@@ -1159,13 +1175,9 @@ async fn test_size_based_pagination() {
         "Should have next_page_token since not all events were returned"
     );
 
-    let all_events = list_authenticated_events(
-        test_cluster.grpc_channel(),
-        &package_id.to_string(),
-        0,
-        Some(10),
-    )
-    .await;
+    let all_events =
+        list_authenticated_events(test_cluster.rpc_url(), &package_id.to_string(), 0, Some(10))
+            .await;
 
     assert_eq!(
         all_events.len(),
@@ -1289,13 +1301,8 @@ async fn authenticated_events_multiple_commits_per_checkpoint() {
         .collect();
     futures::future::try_join_all(bundle_tasks).await.unwrap();
 
-    let all_events = list_authenticated_events(
-        test_cluster.grpc_channel(),
-        &package_id.to_string(),
-        0,
-        None,
-    )
-    .await;
+    let all_events =
+        list_authenticated_events(test_cluster.rpc_url(), &package_id.to_string(), 0, None).await;
 
     assert_eq!(
         all_events.len(),

--- a/crates/sui-e2e-tests/tests/authenticated_events_client_test.rs
+++ b/crates/sui-e2e-tests/tests/authenticated_events_client_test.rs
@@ -4,7 +4,7 @@
 use futures::StreamExt;
 use move_core_types::identifier::Identifier;
 use std::sync::Arc;
-
+use std::time::Duration;
 use sui_keys::keystore::AccountKeystore;
 use sui_light_client::authenticated_events::AuthenticatedEventsClient;
 use sui_macros::sim_test;
@@ -149,8 +149,34 @@ async fn emit_events_batch(
     test_cluster.sign_and_execute_transaction(&tx_data).await;
 }
 
+async fn connect_with_retry<T, F, Fut>(connect_fn: F) -> T
+where
+    F: Fn() -> Fut,
+    Fut: std::future::Future<Output = Result<T, tonic::transport::Error>>,
+{
+    const MAX_RETRIES: u32 = 10;
+    const CONNECT_TIMEOUT: Duration = Duration::from_secs(1);
+
+    for attempt in 0..MAX_RETRIES {
+        match tokio::time::timeout(CONNECT_TIMEOUT, connect_fn()).await {
+            Ok(Ok(client)) => return client,
+            Ok(Err(e)) if attempt + 1 < MAX_RETRIES => {
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            }
+            Ok(Err(e)) => panic!("failed to connect after {MAX_RETRIES} attempts: {e}"),
+            Err(_) if attempt + 1 < MAX_RETRIES => {
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            }
+            Err(_) => panic!("connection timed out after {MAX_RETRIES} attempts"),
+        }
+    }
+    unreachable!()
+}
+
 async fn get_genesis_committee(test_cluster: &TestCluster) -> Committee {
-    let mut ledger_client = LedgerServiceClient::new(test_cluster.grpc_channel());
+    let mut ledger_client =
+        connect_with_retry(|| LedgerServiceClient::connect(test_cluster.rpc_url().to_owned()))
+            .await;
 
     let response = ledger_client
         .get_epoch(GetEpochRequest::new(0).with_read_mask(FieldMask::from_paths(["committee"])))

--- a/crates/sui-e2e-tests/tests/get_object_inclusion_proof_tests.rs
+++ b/crates/sui-e2e-tests/tests/get_object_inclusion_proof_tests.rs
@@ -43,7 +43,9 @@ async fn test_feature_flag_disabled() {
         .build()
         .await;
 
-    let mut proof_client = ProofServiceClient::new(test_cluster.grpc_channel());
+    let mut proof_client = ProofServiceClient::connect(test_cluster.rpc_url().to_owned())
+        .await
+        .unwrap();
 
     let mut req = GetObjectInclusionProofRequest::default();
     req.object_id = Some(ObjectID::random().to_string());
@@ -68,7 +70,9 @@ async fn test_missing_object_id() {
         .build()
         .await;
 
-    let mut proof_client = ProofServiceClient::new(test_cluster.grpc_channel());
+    let mut proof_client = ProofServiceClient::connect(test_cluster.rpc_url().to_owned())
+        .await
+        .unwrap();
 
     let mut req = GetObjectInclusionProofRequest::default();
     req.object_id = None;
@@ -90,7 +94,9 @@ async fn test_empty_object_id() {
         .build()
         .await;
 
-    let mut proof_client = ProofServiceClient::new(test_cluster.grpc_channel());
+    let mut proof_client = ProofServiceClient::connect(test_cluster.rpc_url().to_owned())
+        .await
+        .unwrap();
 
     let mut req = GetObjectInclusionProofRequest::default();
     req.object_id = Some("".to_string());
@@ -112,7 +118,9 @@ async fn test_invalid_object_id_format() {
         .build()
         .await;
 
-    let mut proof_client = ProofServiceClient::new(test_cluster.grpc_channel());
+    let mut proof_client = ProofServiceClient::connect(test_cluster.rpc_url().to_owned())
+        .await
+        .unwrap();
 
     let mut req = GetObjectInclusionProofRequest::default();
     req.object_id = Some("invalid_object_id".to_string());
@@ -136,7 +144,9 @@ async fn test_missing_checkpoint() {
 
     let object_id = get_test_object(&test_cluster).await;
 
-    let mut proof_client = ProofServiceClient::new(test_cluster.grpc_channel());
+    let mut proof_client = ProofServiceClient::connect(test_cluster.rpc_url().to_owned())
+        .await
+        .unwrap();
 
     let mut req = GetObjectInclusionProofRequest::default();
     req.object_id = Some(object_id.to_string());
@@ -160,7 +170,9 @@ async fn test_checkpoint_not_yet_indexed() {
 
     let object_id = get_test_object(&test_cluster).await;
 
-    let mut proof_client = ProofServiceClient::new(test_cluster.grpc_channel());
+    let mut proof_client = ProofServiceClient::connect(test_cluster.rpc_url().to_owned())
+        .await
+        .unwrap();
 
     let mut req = GetObjectInclusionProofRequest::default();
     req.object_id = Some(object_id.to_string());
@@ -187,7 +199,9 @@ async fn test_object_not_found_in_checkpoint() {
 
     let non_existent_object_id = ObjectID::random();
 
-    let mut proof_client = ProofServiceClient::new(test_cluster.grpc_channel());
+    let mut proof_client = ProofServiceClient::connect(test_cluster.rpc_url().to_owned())
+        .await
+        .unwrap();
 
     let mut req = GetObjectInclusionProofRequest::default();
     req.object_id = Some(non_existent_object_id.to_string());
@@ -214,7 +228,9 @@ async fn test_valid_request() {
     let state = test_cluster.fullnode_handle.sui_node.state();
     let latest_checkpoint = state.get_latest_checkpoint_sequence_number().unwrap();
 
-    let mut proof_client = ProofServiceClient::new(test_cluster.grpc_channel());
+    let mut proof_client = ProofServiceClient::connect(test_cluster.rpc_url().to_owned())
+        .await
+        .unwrap();
 
     let mut found_checkpoint = None;
     for checkpoint_seq in 0..=latest_checkpoint {

--- a/crates/sui-e2e-tests/tests/party_objects_tests.rs
+++ b/crates/sui-e2e-tests/tests/party_objects_tests.rs
@@ -581,7 +581,11 @@ async fn party_object_grpc() {
     let object_id_str = object_id.to_canonical_string(true);
     let object_initial_shared_version = object.1;
 
-    let channel = test_cluster.grpc_channel();
+    let channel = tonic::transport::Channel::from_shared(test_cluster.rpc_url().to_owned())
+        .unwrap()
+        .connect()
+        .await
+        .unwrap();
 
     let mut live_data_service_client = StateServiceClient::new(channel.clone());
     let mut ledger_service_client = LedgerServiceClient::new(channel);
@@ -718,7 +722,11 @@ async fn party_coin_grpc() {
     use sui_types::transaction::{CallArg, ObjectArg, TransactionData};
 
     let cluster = TestClusterBuilder::new().build().await;
-    let channel = cluster.grpc_channel();
+    let channel = tonic::transport::Channel::from_shared(cluster.rpc_url().to_owned())
+        .unwrap()
+        .connect()
+        .await
+        .unwrap();
 
     let mut live_data_service_client = StateServiceClient::new(channel.clone());
     let mut execution_client = TransactionExecutionServiceClient::new(channel.clone());

--- a/crates/sui-e2e-tests/tests/rpc/v2/ledger_service/get_checkpoint.rs
+++ b/crates/sui-e2e-tests/tests/rpc/v2/ledger_service/get_checkpoint.rs
@@ -23,7 +23,9 @@ async fn get_checkpoint() {
     let _transaction_digest = transfer_coin(&test_cluster.wallet).await;
     let transaction_digest = stake_with_validator(&test_cluster).await;
 
-    let mut client = LedgerServiceClient::new(test_cluster.grpc_channel());
+    let mut client = LedgerServiceClient::connect(test_cluster.rpc_url().to_owned())
+        .await
+        .unwrap();
 
     // Request with no provided read_mask
     let Checkpoint {

--- a/crates/sui-e2e-tests/tests/rpc/v2/ledger_service/get_epoch.rs
+++ b/crates/sui-e2e-tests/tests/rpc/v2/ledger_service/get_epoch.rs
@@ -15,7 +15,9 @@ async fn get_epoch() {
         .build()
         .await;
 
-    let mut client = LedgerServiceClient::new(test_cluster.grpc_channel());
+    let mut client = LedgerServiceClient::connect(test_cluster.rpc_url().to_owned())
+        .await
+        .unwrap();
 
     let latest_epoch = client
         .get_epoch(GetEpochRequest::latest().with_read_mask(FieldMask::from_str("*")))

--- a/crates/sui-e2e-tests/tests/rpc/v2/ledger_service/get_object.rs
+++ b/crates/sui-e2e-tests/tests/rpc/v2/ledger_service/get_object.rs
@@ -21,7 +21,9 @@ async fn get_object() {
 
     let id: Address = "0x5".parse().unwrap();
 
-    let mut client = LedgerServiceClient::new(test_cluster.grpc_channel());
+    let mut client = LedgerServiceClient::connect(test_cluster.rpc_url().to_owned())
+        .await
+        .unwrap();
 
     // Request with no provided read_mask
     let Object {
@@ -158,7 +160,9 @@ async fn batch_get_objects() {
         .build()
         .await;
 
-    let mut client = LedgerServiceClient::new(test_cluster.grpc_channel());
+    let mut client = LedgerServiceClient::connect(test_cluster.rpc_url().to_owned())
+        .await
+        .unwrap();
 
     let BatchGetObjectsResponse { objects, .. } = client
         .batch_get_objects({

--- a/crates/sui-e2e-tests/tests/rpc/v2/ledger_service/get_service_info.rs
+++ b/crates/sui-e2e-tests/tests/rpc/v2/ledger_service/get_service_info.rs
@@ -17,7 +17,9 @@ async fn get_service_info() {
         .build()
         .await;
 
-    let mut grpc_client = LedgerServiceClient::new(test_cluster.grpc_channel());
+    let mut grpc_client = LedgerServiceClient::connect(test_cluster.rpc_url().to_owned())
+        .await
+        .unwrap();
 
     let GetServiceInfoResponse {
         chain_id,
@@ -55,7 +57,9 @@ async fn chain_id_is_base58_digest() {
     let chain_identifier = test_cluster.get_chain_identifier();
     let expected_digest = Digest::new(chain_identifier.as_bytes().to_owned());
 
-    let mut grpc_client = LedgerServiceClient::new(test_cluster.grpc_channel());
+    let mut grpc_client = LedgerServiceClient::connect(test_cluster.rpc_url().to_owned())
+        .await
+        .unwrap();
 
     let response = grpc_client
         .get_service_info(GetServiceInfoRequest::default())

--- a/crates/sui-e2e-tests/tests/rpc/v2/ledger_service/get_transaction.rs
+++ b/crates/sui-e2e-tests/tests/rpc/v2/ledger_service/get_transaction.rs
@@ -18,7 +18,9 @@ async fn get_transaction() {
 
     let transaction_digest = stake_with_validator(&test_cluster).await;
 
-    let mut client = LedgerServiceClient::new(test_cluster.grpc_channel());
+    let mut client = LedgerServiceClient::connect(test_cluster.rpc_url().to_owned())
+        .await
+        .unwrap();
 
     // Request with no provided read_mask
     let ExecutedTransaction {

--- a/crates/sui-e2e-tests/tests/rpc/v2/move_package_service/get_datatype.rs
+++ b/crates/sui-e2e-tests/tests/rpc/v2/move_package_service/get_datatype.rs
@@ -16,7 +16,9 @@ async fn test_get_struct_datatype() {
         .build()
         .await;
 
-    let mut service = MovePackageServiceClient::new(cluster.grpc_channel());
+    let mut service = MovePackageServiceClient::connect(cluster.rpc_url().to_owned())
+        .await
+        .unwrap();
 
     let mut request = GetDatatypeRequest::default();
     request.package_id = Some("0x3".to_string());
@@ -36,7 +38,9 @@ async fn test_get_datatype_not_found() {
         .build()
         .await;
 
-    let mut service = MovePackageServiceClient::new(cluster.grpc_channel());
+    let mut service = MovePackageServiceClient::connect(cluster.rpc_url().to_owned())
+        .await
+        .unwrap();
 
     // Test non-existent datatype
     let mut request = GetDatatypeRequest::default();
@@ -60,7 +64,9 @@ async fn test_get_datatype_invalid_package() {
         .build()
         .await;
 
-    let mut service = MovePackageServiceClient::new(cluster.grpc_channel());
+    let mut service = MovePackageServiceClient::connect(cluster.rpc_url().to_owned())
+        .await
+        .unwrap();
 
     // Test invalid package ID
     let mut request = GetDatatypeRequest::default();
@@ -80,7 +86,9 @@ async fn test_get_datatype_module_not_found() {
         .build()
         .await;
 
-    let mut service = MovePackageServiceClient::new(cluster.grpc_channel());
+    let mut service = MovePackageServiceClient::connect(cluster.rpc_url().to_owned())
+        .await
+        .unwrap();
 
     // Test non-existent module
     let mut request = GetDatatypeRequest::default();
@@ -100,7 +108,9 @@ async fn test_get_datatype_missing_package_id() {
         .build()
         .await;
 
-    let mut service = MovePackageServiceClient::new(cluster.grpc_channel());
+    let mut service = MovePackageServiceClient::connect(cluster.rpc_url().to_owned())
+        .await
+        .unwrap();
 
     let mut request = GetDatatypeRequest::default();
     request.package_id = None;
@@ -119,7 +129,9 @@ async fn test_get_datatype_missing_module_name() {
         .build()
         .await;
 
-    let mut service = MovePackageServiceClient::new(cluster.grpc_channel());
+    let mut service = MovePackageServiceClient::connect(cluster.rpc_url().to_owned())
+        .await
+        .unwrap();
 
     let mut request = GetDatatypeRequest::default();
     request.package_id = Some("0x3".to_string());
@@ -138,7 +150,9 @@ async fn test_get_datatype_missing_name() {
         .build()
         .await;
 
-    let mut service = MovePackageServiceClient::new(cluster.grpc_channel());
+    let mut service = MovePackageServiceClient::connect(cluster.rpc_url().to_owned())
+        .await
+        .unwrap();
 
     let mut request = GetDatatypeRequest::default();
     request.package_id = Some("0x3".to_string());

--- a/crates/sui-e2e-tests/tests/rpc/v2/move_package_service/get_function.rs
+++ b/crates/sui-e2e-tests/tests/rpc/v2/move_package_service/get_function.rs
@@ -14,7 +14,9 @@ async fn test_get_function_validator_cap() {
         .with_num_validators(1)
         .build()
         .await;
-    let mut service = MovePackageServiceClient::new(cluster.grpc_channel());
+    let mut service = MovePackageServiceClient::connect(cluster.rpc_url().to_owned())
+        .await
+        .unwrap();
 
     let mut request = GetFunctionRequest::default();
     request.package_id = Some("0x3".to_string());
@@ -33,7 +35,9 @@ async fn test_get_function_not_found() {
         .with_num_validators(1)
         .build()
         .await;
-    let mut service = MovePackageServiceClient::new(cluster.grpc_channel());
+    let mut service = MovePackageServiceClient::connect(cluster.rpc_url().to_owned())
+        .await
+        .unwrap();
 
     let mut request = GetFunctionRequest::default();
     request.package_id = Some("0x3".to_string());
@@ -51,7 +55,9 @@ async fn test_get_function_invalid_hex() {
         .with_num_validators(1)
         .build()
         .await;
-    let mut service = MovePackageServiceClient::new(cluster.grpc_channel());
+    let mut service = MovePackageServiceClient::connect(cluster.rpc_url().to_owned())
+        .await
+        .unwrap();
 
     let mut request = GetFunctionRequest::default();
     request.package_id = Some("0xGGGG".to_string());
@@ -69,7 +75,9 @@ async fn test_get_function_missing_package_id() {
         .with_num_validators(1)
         .build()
         .await;
-    let mut service = MovePackageServiceClient::new(cluster.grpc_channel());
+    let mut service = MovePackageServiceClient::connect(cluster.rpc_url().to_owned())
+        .await
+        .unwrap();
 
     let mut request = GetFunctionRequest::default();
     request.package_id = None;
@@ -87,7 +95,9 @@ async fn test_get_function_missing_module_name() {
         .with_num_validators(1)
         .build()
         .await;
-    let mut service = MovePackageServiceClient::new(cluster.grpc_channel());
+    let mut service = MovePackageServiceClient::connect(cluster.rpc_url().to_owned())
+        .await
+        .unwrap();
 
     let mut request = GetFunctionRequest::default();
     request.package_id = Some("0x3".to_string());
@@ -105,7 +115,9 @@ async fn test_get_function_missing_name() {
         .with_num_validators(1)
         .build()
         .await;
-    let mut service = MovePackageServiceClient::new(cluster.grpc_channel());
+    let mut service = MovePackageServiceClient::connect(cluster.rpc_url().to_owned())
+        .await
+        .unwrap();
 
     let mut request = GetFunctionRequest::default();
     request.package_id = Some("0x3".to_string());

--- a/crates/sui-e2e-tests/tests/rpc/v2/move_package_service/get_package.rs
+++ b/crates/sui-e2e-tests/tests/rpc/v2/move_package_service/get_package.rs
@@ -15,7 +15,9 @@ async fn test_get_package_system() {
         .with_num_validators(1)
         .build()
         .await;
-    let mut service = MovePackageServiceClient::new(cluster.grpc_channel());
+    let mut service = MovePackageServiceClient::connect(cluster.rpc_url().to_owned())
+        .await
+        .unwrap();
 
     let mut request = GetPackageRequest::default();
     request.package_id = Some("0x3".to_string());
@@ -32,7 +34,9 @@ async fn test_get_package_not_found() {
         .with_num_validators(1)
         .build()
         .await;
-    let mut service = MovePackageServiceClient::new(cluster.grpc_channel());
+    let mut service = MovePackageServiceClient::connect(cluster.rpc_url().to_owned())
+        .await
+        .unwrap();
 
     let mut request = GetPackageRequest::default();
     request.package_id =
@@ -48,7 +52,9 @@ async fn test_get_package_invalid_hex() {
         .with_num_validators(1)
         .build()
         .await;
-    let mut service = MovePackageServiceClient::new(cluster.grpc_channel());
+    let mut service = MovePackageServiceClient::connect(cluster.rpc_url().to_owned())
+        .await
+        .unwrap();
 
     let mut request = GetPackageRequest::default();
     request.package_id = Some("0xINVALID".to_string());
@@ -64,7 +70,9 @@ async fn test_get_package_missing_id() {
         .with_num_validators(1)
         .build()
         .await;
-    let mut service = MovePackageServiceClient::new(cluster.grpc_channel());
+    let mut service = MovePackageServiceClient::connect(cluster.rpc_url().to_owned())
+        .await
+        .unwrap();
 
     let request = GetPackageRequest::default();
 

--- a/crates/sui-e2e-tests/tests/rpc/v2/move_package_service/list_package_versions.rs
+++ b/crates/sui-e2e-tests/tests/rpc/v2/move_package_service/list_package_versions.rs
@@ -21,7 +21,9 @@ async fn test_list_package_versions_system_package() {
         .with_num_validators(1)
         .build()
         .await;
-    let mut service = MovePackageServiceClient::new(cluster.grpc_channel());
+    let mut service = MovePackageServiceClient::connect(cluster.rpc_url().to_owned())
+        .await
+        .unwrap();
 
     let mut request = ListPackageVersionsRequest::default();
     request.package_id = Some("0x2".to_string());
@@ -45,7 +47,9 @@ async fn test_list_package_versions_with_upgrades() {
         .with_num_validators(1)
         .build()
         .await;
-    let mut service = MovePackageServiceClient::new(cluster.grpc_channel());
+    let mut service = MovePackageServiceClient::connect(cluster.rpc_url().to_owned())
+        .await
+        .unwrap();
 
     let mut test_package_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     test_package_path.push("tests/move_test_code");
@@ -312,7 +316,9 @@ async fn test_list_package_versions_not_found() {
         .with_num_validators(1)
         .build()
         .await;
-    let mut service = MovePackageServiceClient::new(cluster.grpc_channel());
+    let mut service = MovePackageServiceClient::connect(cluster.rpc_url().to_owned())
+        .await
+        .unwrap();
 
     let mut request = ListPackageVersionsRequest::default();
     request.package_id =
@@ -328,7 +334,9 @@ async fn test_list_package_versions_invalid_package_id() {
         .with_num_validators(1)
         .build()
         .await;
-    let mut service = MovePackageServiceClient::new(cluster.grpc_channel());
+    let mut service = MovePackageServiceClient::connect(cluster.rpc_url().to_owned())
+        .await
+        .unwrap();
 
     let mut request = ListPackageVersionsRequest::default();
     request.package_id = Some("invalid-package-id".to_string());
@@ -348,7 +356,9 @@ async fn test_list_package_versions_missing_package_id() {
         .with_num_validators(1)
         .build()
         .await;
-    let mut service = MovePackageServiceClient::new(cluster.grpc_channel());
+    let mut service = MovePackageServiceClient::connect(cluster.rpc_url().to_owned())
+        .await
+        .unwrap();
 
     let request = ListPackageVersionsRequest::default();
 
@@ -367,7 +377,9 @@ async fn test_list_package_versions_invalid_pagination() {
         .with_num_validators(1)
         .build()
         .await;
-    let mut service = MovePackageServiceClient::new(cluster.grpc_channel());
+    let mut service = MovePackageServiceClient::connect(cluster.rpc_url().to_owned())
+        .await
+        .unwrap();
 
     // Test 1: Invalid page token encoding
     let mut request = ListPackageVersionsRequest::default();

--- a/crates/sui-e2e-tests/tests/rpc/v2/signature_verification_service.rs
+++ b/crates/sui-e2e-tests/tests/rpc/v2/signature_verification_service.rs
@@ -29,7 +29,9 @@ async fn test_verify_signature_zklogin() -> Result<(), anyhow::Error> {
     test_cluster.wait_for_epoch(Some(1)).await;
     test_cluster.wait_for_authenticator_state_update().await;
 
-    let mut client = SignatureVerificationServiceClient::new(test_cluster.grpc_channel());
+    let mut client = SignatureVerificationServiceClient::connect(test_cluster.rpc_url().to_owned())
+        .await
+        .unwrap();
 
     // Construct a valid zkLogin transaction data, signature.
     let (kp, pk_zklogin, inputs) = &sui_types::utils::load_test_vectors(

--- a/crates/sui-e2e-tests/tests/rpc/v2/state_service/get_coin_info.rs
+++ b/crates/sui-e2e-tests/tests/rpc/v2/state_service/get_coin_info.rs
@@ -30,7 +30,7 @@ async fn get_coin_info_sui() {
         .build()
         .await;
 
-    let mut grpc_client = get_grpc_client(&test_cluster);
+    let mut grpc_client = get_grpc_client(&test_cluster).await;
 
     let coin_type_sdk: TypeTag = "0x2::sui::SUI".parse().unwrap();
     let mut request = GetCoinInfoRequest::default();
@@ -88,7 +88,7 @@ async fn test_get_coin_info_registry_coin() {
         .build()
         .await;
 
-    let mut grpc_client = get_grpc_client(&test_cluster);
+    let mut grpc_client = get_grpc_client(&test_cluster).await;
 
     let address = test_cluster.get_address_0();
 
@@ -296,7 +296,7 @@ async fn test_get_coin_info_burnonly_coin() {
         .build()
         .await;
 
-    let mut grpc_client = get_grpc_client(&test_cluster);
+    let mut grpc_client = get_grpc_client(&test_cluster).await;
 
     let address = test_cluster.get_address_0();
 
@@ -438,7 +438,7 @@ async fn test_get_coin_info_regulated_coin() {
         .build()
         .await;
 
-    let mut grpc_client = get_grpc_client(&test_cluster);
+    let mut grpc_client = get_grpc_client(&test_cluster).await;
 
     let address = test_cluster.get_address_0();
 
@@ -491,7 +491,7 @@ async fn test_get_coin_info_non_otw_coin() {
         .build()
         .await;
 
-    let mut grpc_client = get_grpc_client(&test_cluster);
+    let mut grpc_client = get_grpc_client(&test_cluster).await;
 
     let address = test_cluster.get_address_0();
 
@@ -576,7 +576,7 @@ async fn test_get_coin_info_legacy_coin() {
         .build()
         .await;
 
-    let mut grpc_client = get_grpc_client(&test_cluster);
+    let mut grpc_client = get_grpc_client(&test_cluster).await;
 
     let address = test_cluster.get_address_0();
 
@@ -898,7 +898,9 @@ async fn publish_non_otw_coin(
     let registry_obj_response = {
         let mut ledger_client = {
             use sui_rpc::proto::sui::rpc::v2::ledger_service_client::LedgerServiceClient;
-            LedgerServiceClient::new(test_cluster.grpc_channel())
+            LedgerServiceClient::connect(test_cluster.rpc_url().to_owned())
+                .await
+                .expect("Failed to connect to ledger service")
         };
 
         use sui_rpc::proto::sui::rpc::v2::GetObjectRequest;
@@ -999,7 +1001,9 @@ async fn finalize_registration(
     use sui_rpc::proto::sui::rpc::v2::{GetObjectRequest, ListOwnedObjectsRequest};
     use sui_types::base_types::SequenceNumber;
 
-    let mut ledger_client = LedgerServiceClient::new(test_cluster.grpc_channel());
+    let mut ledger_client = LedgerServiceClient::connect(test_cluster.rpc_url().to_owned())
+        .await
+        .expect("Failed to connect to ledger service");
 
     // Get the CoinRegistry object info to find its initial version
     let registry_obj_response = ledger_client
@@ -1026,7 +1030,7 @@ async fn finalize_registration(
         .expect("CoinRegistry should be a shared object with an initial version");
 
     // Now find the Currency object that was transferred to the CoinRegistry
-    let mut grpc_client = get_grpc_client(test_cluster);
+    let mut grpc_client = get_grpc_client(test_cluster).await;
 
     let registry_owned = grpc_client
         .list_owned_objects({
@@ -1142,7 +1146,7 @@ async fn test_invalid_coin_type() {
         .with_num_validators(1)
         .build()
         .await;
-    let mut grpc_client = get_grpc_client(&test_cluster);
+    let mut grpc_client = get_grpc_client(&test_cluster).await;
 
     // Test with malformed coin type
     let mut request = GetCoinInfoRequest::default();
@@ -1168,8 +1172,10 @@ async fn test_invalid_coin_type() {
     assert!(error.message().contains("not found"));
 }
 
-fn get_grpc_client(
+async fn get_grpc_client(
     test_cluster: &test_cluster::TestCluster,
 ) -> StateServiceClient<tonic::transport::Channel> {
-    StateServiceClient::new(test_cluster.grpc_channel())
+    StateServiceClient::connect(test_cluster.rpc_url().to_owned())
+        .await
+        .unwrap()
 }

--- a/crates/sui-e2e-tests/tests/rpc/v2/subscription_service.rs
+++ b/crates/sui-e2e-tests/tests/rpc/v2/subscription_service.rs
@@ -19,7 +19,9 @@ async fn subscribe_checkpoint() {
 
     let _transaction_digest = transfer_coin(&test_cluster.wallet).await;
 
-    let mut client = SubscriptionServiceClient::new(test_cluster.grpc_channel());
+    let mut client = SubscriptionServiceClient::connect(test_cluster.rpc_url().to_owned())
+        .await
+        .unwrap();
 
     let mut request = SubscribeCheckpointsRequest::default();
     request.read_mask = Some(FieldMask::from_str("sequence_number"));

--- a/crates/sui-e2e-tests/tests/rpc/v2/transaction_execution_service/mod.rs
+++ b/crates/sui-e2e-tests/tests/rpc/v2/transaction_execution_service/mod.rs
@@ -27,7 +27,9 @@ async fn execute_transaction_transfer() {
         .build()
         .await;
 
-    let mut client = TransactionExecutionServiceClient::new(test_cluster.grpc_channel());
+    let mut client = TransactionExecutionServiceClient::connect(test_cluster.rpc_url().to_owned())
+        .await
+        .unwrap();
     let address = SuiAddress::random_for_testing_only();
     let amount = 9;
 

--- a/crates/sui-e2e-tests/tests/rpc/v2/transaction_execution_service/resolve.rs
+++ b/crates/sui-e2e-tests/tests/rpc/v2/transaction_execution_service/resolve.rs
@@ -66,7 +66,10 @@ async fn resolve_transaction_simple_transfer() {
         .await;
 
     let mut client = Client::new(test_cluster.rpc_url()).unwrap();
-    let mut alpha_client = TransactionExecutionServiceClient::new(test_cluster.grpc_channel());
+    let mut alpha_client =
+        TransactionExecutionServiceClient::connect(test_cluster.rpc_url().to_owned())
+            .await
+            .unwrap();
     let recipient = SuiAddress::random_for_testing_only();
 
     let (sender, mut gas) = test_cluster.wallet.get_one_account().await.unwrap();
@@ -126,7 +129,10 @@ async fn resolve_transaction_transfer_with_sponsor() {
         .await;
 
     let mut client = Client::new(test_cluster.rpc_url()).unwrap();
-    let mut alpha_client = TransactionExecutionServiceClient::new(test_cluster.grpc_channel());
+    let mut alpha_client =
+        TransactionExecutionServiceClient::connect(test_cluster.rpc_url().to_owned())
+            .await
+            .unwrap();
     let recipient = SuiAddress::random_for_testing_only();
 
     let (sender, gas) = test_cluster.wallet.get_one_account().await.unwrap();
@@ -207,7 +213,10 @@ async fn resolve_transaction_borrowed_shared_object() {
         .await;
 
     let mut client = Client::new(test_cluster.rpc_url()).unwrap();
-    let mut alpha_client = TransactionExecutionServiceClient::new(test_cluster.grpc_channel());
+    let mut alpha_client =
+        TransactionExecutionServiceClient::connect(test_cluster.rpc_url().to_owned())
+            .await
+            .unwrap();
 
     let sender = test_cluster.wallet.get_addresses()[0];
 
@@ -258,7 +267,10 @@ async fn resolve_transaction_mutable_shared_object() {
         .await;
 
     let mut client = Client::new(test_cluster.rpc_url()).unwrap();
-    let mut alpha_client = TransactionExecutionServiceClient::new(test_cluster.grpc_channel());
+    let mut alpha_client =
+        TransactionExecutionServiceClient::connect(test_cluster.rpc_url().to_owned())
+            .await
+            .unwrap();
 
     let (sender, mut gas) = test_cluster.wallet.get_one_account().await.unwrap();
     gas.sort_by_key(|object_ref| object_ref.0);
@@ -328,7 +340,10 @@ async fn resolve_transaction_insufficient_gas() {
         .with_num_validators(1)
         .build()
         .await;
-    let mut alpha_client = TransactionExecutionServiceClient::new(test_cluster.grpc_channel());
+    let mut alpha_client =
+        TransactionExecutionServiceClient::connect(test_cluster.rpc_url().to_owned())
+            .await
+            .unwrap();
 
     // Test the case where we don't have enough coins/gas for the required budget
     let mut unresolved_transaction = Transaction::default();
@@ -376,7 +391,10 @@ async fn resolve_transaction_gas_budget_clamping() {
         .await;
 
     let mut client = Client::new(test_cluster.rpc_url()).unwrap();
-    let mut alpha_client = TransactionExecutionServiceClient::new(test_cluster.grpc_channel());
+    let mut alpha_client =
+        TransactionExecutionServiceClient::connect(test_cluster.rpc_url().to_owned())
+            .await
+            .unwrap();
 
     let (sender, gas_coins) = test_cluster.wallet.get_one_account().await.unwrap();
 
@@ -447,7 +465,10 @@ async fn resolve_transaction_insufficient_gas_with_payment_objects() {
         .with_num_validators(1)
         .build()
         .await;
-    let mut alpha_client = TransactionExecutionServiceClient::new(test_cluster.grpc_channel());
+    let mut alpha_client =
+        TransactionExecutionServiceClient::connect(test_cluster.rpc_url().to_owned())
+            .await
+            .unwrap();
 
     let (sender, gas_coins) = test_cluster.wallet.get_one_account().await.unwrap();
 
@@ -591,7 +612,10 @@ async fn resolve_transaction_shared_object_with_generic_type_parameter() {
         .await;
 
     let mut client = Client::new(test_cluster.rpc_url()).unwrap();
-    let mut alpha_client = TransactionExecutionServiceClient::new(test_cluster.grpc_channel());
+    let mut alpha_client =
+        TransactionExecutionServiceClient::connect(test_cluster.rpc_url().to_owned())
+            .await
+            .unwrap();
 
     // Create a party object (which is a shared object with ConsensusAddressOwner)
     let (package, party_object) =

--- a/crates/sui-e2e-tests/tests/transfer_to_object_tests.rs
+++ b/crates/sui-e2e-tests/tests/transfer_to_object_tests.rs
@@ -273,7 +273,9 @@ impl TestEnvironment {
         };
 
         let sender = self.test_cluster.get_address_0();
-        let mut client = TransactionExecutionServiceClient::new(self.test_cluster.grpc_channel());
+        let mut client =
+            TransactionExecutionServiceClient::connect(self.test_cluster.rpc_url().to_owned())
+                .await?;
 
         let mut unresolved_transaction = Transaction::default();
         unresolved_transaction.kind = Some(TransactionKind::from({

--- a/crates/test-cluster/src/lib.rs
+++ b/crates/test-cluster/src/lib.rs
@@ -76,7 +76,6 @@ pub struct FullNodeHandle {
     #[deprecated = "use grpc_client"]
     pub rpc_client: HttpClient,
     pub grpc_client: Client,
-    pub grpc_channel: tonic::transport::Channel,
     pub rpc_url: String,
 }
 
@@ -88,20 +87,6 @@ impl FullNodeHandle {
         let sui_client = SuiClientBuilder::default().build(&rpc_url).await.unwrap();
         let grpc_client = Client::new(&rpc_url).unwrap();
 
-        // Eagerly connect a shared gRPC channel with retry logic. Tests should
-        // create tonic service clients via `XxxServiceClient::new(channel)` instead
-        // of `XxxServiceClient::connect(url)` so that connections are established
-        // once during cluster setup rather than ad-hoc in each test.
-        let grpc_channel = Self::connect_channel_with_retry(&rpc_url).await;
-
-        // Warm up the sui_rpc_api::Client's internal lazy channel. Without this,
-        // the connect_lazy() channel may time out on its first use under MSIM's
-        // deterministic scheduler on certain seeds.
-        grpc_client
-            .get_reference_gas_price()
-            .await
-            .expect("failed to warm up grpc client");
-
         Self {
             sui_node,
             #[allow(deprecated)]
@@ -109,52 +94,8 @@ impl FullNodeHandle {
             #[allow(deprecated)]
             rpc_client,
             grpc_client,
-            grpc_channel,
             rpc_url,
         }
-    }
-
-    /// Connect a tonic channel to the given URL with retries.
-    ///
-    /// In the simulator (MSIM), deterministic scheduling can cause gRPC connection
-    /// handshakes to exceed timeouts on certain seeds. This method retries to ensure
-    /// test infrastructure setup is robust regardless of seed.
-    ///
-    /// Use [`TestCluster::grpc_channel()`] when connecting to the test cluster's
-    /// fullnode. Use this method directly only when connecting to a custom URL
-    /// (e.g. a separately-spawned fullnode with different configuration).
-    pub async fn connect_channel_with_retry(url: &str) -> tonic::transport::Channel {
-        const MAX_RETRIES: u32 = 10;
-        const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
-
-        let endpoint = tonic::transport::Endpoint::from_shared(url.to_string())
-            .expect("invalid grpc url")
-            .connect_timeout(CONNECT_TIMEOUT);
-
-        for attempt in 0..MAX_RETRIES {
-            match tokio::time::timeout(CONNECT_TIMEOUT, endpoint.connect()).await {
-                Ok(Ok(channel)) => return channel,
-                Ok(Err(e)) if attempt + 1 < MAX_RETRIES => {
-                    info!(
-                        "grpc channel connect attempt {} failed: {e}, retrying",
-                        attempt + 1
-                    );
-                    tokio::time::sleep(Duration::from_millis(100)).await;
-                }
-                Ok(Err(e)) => {
-                    panic!("grpc channel connect failed after {MAX_RETRIES} attempts: {e}")
-                }
-                Err(_) if attempt + 1 < MAX_RETRIES => {
-                    info!(
-                        "grpc channel connect attempt {} timed out, retrying",
-                        attempt + 1
-                    );
-                    tokio::time::sleep(Duration::from_millis(100)).await;
-                }
-                Err(_) => panic!("grpc channel connect timed out after {MAX_RETRIES} attempts"),
-            }
-        }
-        unreachable!()
     }
 }
 
@@ -179,20 +120,6 @@ impl TestCluster {
 
     pub fn grpc_client(&self) -> Client {
         self.fullnode_handle.grpc_client.clone()
-    }
-
-    /// Returns a pre-connected gRPC channel to the fullnode.
-    ///
-    /// Use this to create tonic service clients in tests:
-    /// ```ignore
-    /// let mut client = LedgerServiceClient::new(test_cluster.grpc_channel());
-    /// ```
-    ///
-    /// This channel is connected during test cluster setup with retry logic,
-    /// so it is resilient to MSIM scheduling-induced connection timeouts.
-    /// Prefer this over `XxxServiceClient::connect(url)` which has no retry.
-    pub fn grpc_channel(&self) -> tonic::transport::Channel {
-        self.fullnode_handle.grpc_channel.clone()
     }
 
     pub fn rpc_url(&self) -> &str {


### PR DESCRIPTION
## Description 

This reverts commit efd31cd30ccf1ee57f566a74684401e272202e37.

The eager gRPC channel warmup added during FullNodeHandle::new() changes MSIM deterministic scheduler timing, causing consensus livelock after validator restart on ~1% of seeds. This breaks:
- test_framework_upgrade_conflicting_versions
- test_framework_upgrade_conflicting_versions_no_quorum
- test_reconfig_with_voting_power_decrease_immediate_removal

Confirmed via local seed search: 2/200 failing seeds on main, 0/200 after this revert (for both conflicting_versions tests).
Plus full simtest run: https://github.com/MystenLabs/sui/actions/runs/23710714717

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
