### PR TITLE
[e2e] fix test_alias_changes flake by waiting for enable tx settlement

### DIFF
--- a/crates/sui-e2e-tests/tests/alias_tests.rs
+++ b/crates/sui-e2e-tests/tests/alias_tests.rs
@@ -155,6 +155,10 @@ async fn test_alias_changes() {
 
     let enable_effects = submit_and_wait_for_effects(&client, enable_tx).await;
     assert!(enable_effects.status().is_ok());
+    // Wait for all validators to execute the `enable` tx.
+    test_cluster
+        .wait_for_tx_settlement(&[*enable_effects.transaction_digest()])
+        .await;
 
     // Get the AddressAliases object created by enable
     let address_aliases_ref = enable_effects


### PR DESCRIPTION
## Summary
- Fix intermittent failure in `test_alias_changes` (failed on iteration 19/20, seed 4616056488367146196)
- Root cause: after the `enable` tx creates the `AddressAliases` object on the submitting validator, the next transaction's alias claim mismatches on other validators that haven't executed `enable` yet, causing consensus rejection
- Add `wait_for_tx_settlement` after `enable`, matching the existing pattern already used for `add` and `remove` in the same test

## Test plan
- [ ] Run `test_alias_changes` with `--count 20` to verify the flake is fixed
- [ ] Confirm `test_alias_race` still passes (it intentionally tests the rejection path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)