### PR TITLE
dual-write-consensus-clickhouse

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3492,6 +3492,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cityhash-rs"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93a719913643003b84bd13022b4b7e703c09342cd03b679c4641c7d2e50dc34d"
+
+[[package]]
 name = "clang-sys"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3559,6 +3565,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38508a63f4979f0048febc9966fadbd48e5dab31fd0ec6a3f151bbf4a74f7423"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "clickhouse"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3093f817c4f81c8bd174ed8dd30eac785821a8a7eef27a7dcb7f8cd0d0f6548"
+dependencies = [
+ "bstr",
+ "bytes",
+ "cityhash-rs",
+ "clickhouse-derive",
+ "futures",
+ "futures-channel",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-rustls",
+ "hyper-util",
+ "lz4_flex",
+ "quanta 0.12.6",
+ "replace_with",
+ "sealed",
+ "serde",
+ "static_assertions",
+ "thiserror 1.0.69",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "clickhouse-derive"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d70f3e2893f7d3e017eeacdc9a708fbc29a10488e3ebca21f9df6a5d2b616dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3708,6 +3753,7 @@ dependencies = [
  "bcs",
  "bytes",
  "cfg-if",
+ "clickhouse",
  "consensus-config",
  "consensus-types",
  "criterion",
@@ -6302,7 +6348,7 @@ dependencies = [
  "no-std-compat",
  "nonzero_ext",
  "parking_lot 0.12.3",
- "quanta",
+ "quanta 0.11.1",
  "rand 0.8.5",
  "smallvec",
 ]
@@ -7886,7 +7932,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -11643,7 +11689,22 @@ dependencies = [
  "libc",
  "mach2",
  "once_cell",
- "raw-cpuid",
+ "raw-cpuid 10.6.0",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
+name = "quanta"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid 11.6.0",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "web-sys",
  "winapi",
@@ -12040,6 +12101,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags 2.11.0",
+]
+
+[[package]]
 name = "rayon"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12203,6 +12273,12 @@ name = "regex-syntax"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
+name = "replace_with"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51743d3e274e2b18df81c4dc6caf8a5b8e15dbe799e0dca05c7617380094e884"
 
 [[package]]
 name = "reqwest"
@@ -12920,6 +12996,18 @@ name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
+name = "sealed"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4a8caec23b7800fb97971a1c6ae365b6239aaeddfb934d6265f8505e795699d"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "sec1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -337,6 +337,7 @@ cached = "0.43.0"
 camino = "1.1.1"
 cfg-if = "1.0.0"
 chrono = { version = "=0.4.39", features = ["clock", "serde"] }
+clickhouse = { version = "0.12.2", features = ["rustls-tls", "lz4", "inserter"] }
 clap = { version = "4.4", features = ["derive", "wrap_help"] }
 clap_complete = "4.4"
 codespan-reporting = "0.11.1"

--- a/consensus/config/src/parameters.rs
+++ b/consensus/config/src/parameters.rs
@@ -96,6 +96,9 @@ pub struct Parameters {
     #[serde(default = "Parameters::default_use_fifo_compaction")]
     pub use_fifo_compaction: bool,
 
+    #[serde(default = "ClickHouseParameters::default")]
+    pub clickhouse: ClickHouseParameters,
+
     /// Tonic network settings.
     #[serde(default = "TonicParameters::default")]
     pub tonic: TonicParameters,
@@ -227,6 +230,7 @@ impl Default for Parameters {
             commit_sync_batch_size: Parameters::default_commit_sync_batch_size(),
             commit_sync_batches_ahead: Parameters::default_commit_sync_batches_ahead(),
             use_fifo_compaction: Parameters::default_use_fifo_compaction(),
+            clickhouse: ClickHouseParameters::default(),
             tonic: TonicParameters::default(),
             internal: InternalParameters::default(),
             listen_address_override: None,
@@ -338,6 +342,52 @@ impl Default for InternalParameters {
         Self {
             skip_equivocation_validation: InternalParameters::default_skip_equivocation_validation(
             ),
+        }
+    }
+}
+
+/// Configuration for the optional ClickHouse debug writer.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct ClickHouseParameters {
+    #[serde(default)]
+    pub enabled: bool,
+
+    #[serde(default = "ClickHouseParameters::default_url")]
+    pub url: String,
+
+    #[serde(default = "ClickHouseParameters::default_database")]
+    pub database: String,
+
+    /// Includes full BCS-serialized block/commit bytes. ~10-50 TB per 2 epochs at mainnet load.
+    #[serde(default)]
+    pub include_raw_bytes: bool,
+
+    #[serde(default = "ClickHouseParameters::default_channel_capacity")]
+    pub channel_capacity: usize,
+}
+
+impl ClickHouseParameters {
+    fn default_url() -> String {
+        "http://localhost:8123".to_string()
+    }
+
+    fn default_database() -> String {
+        "consensus_debug".to_string()
+    }
+
+    fn default_channel_capacity() -> usize {
+        1024
+    }
+}
+
+impl Default for ClickHouseParameters {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            url: Self::default_url(),
+            database: Self::default_database(),
+            include_raw_bytes: false,
+            channel_capacity: Self::default_channel_capacity(),
         }
     }
 }

--- a/consensus/config/src/parameters.rs
+++ b/consensus/config/src/parameters.rs
@@ -358,6 +358,12 @@ pub struct ClickHouseParameters {
     #[serde(default = "ClickHouseParameters::default_database")]
     pub database: String,
 
+    #[serde(default)]
+    pub user: Option<String>,
+
+    #[serde(default)]
+    pub password: Option<String>,
+
     /// Includes full BCS-serialized block/commit bytes. ~10-50 TB per 2 epochs at mainnet load.
     #[serde(default)]
     pub include_raw_bytes: bool,
@@ -386,6 +392,8 @@ impl Default for ClickHouseParameters {
             enabled: false,
             url: Self::default_url(),
             database: Self::default_database(),
+            user: None,
+            password: None,
             include_raw_bytes: false,
             channel_capacity: Self::default_channel_capacity(),
         }

--- a/consensus/core/Cargo.toml
+++ b/consensus/core/Cargo.toml
@@ -9,6 +9,9 @@ publish = false
 [lints]
 workspace = true
 
+[features]
+clickhouse-debug = ["dep:clickhouse"]
+
 [dependencies]
 anyhow.workspace = true
 arc-swap.workspace = true
@@ -17,6 +20,7 @@ base64.workspace = true
 bcs.workspace = true
 bytes.workspace = true
 cfg-if.workspace = true
+clickhouse = { workspace = true, optional = true }
 consensus-config.workspace = true
 consensus-types.workspace = true
 dashmap.workspace = true

--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -488,10 +488,17 @@ where
         self.subscriber.stop();
         self.network_manager.stop().await;
 
+        // The DualWriteStore sender is dropped when DagState and other components above are
+        // stopped, which causes the writer's recv() loop to exit naturally. We await with a
+        // timeout as a safety net, falling back to abort if it doesn't finish.
         #[cfg(feature = "clickhouse-debug")]
         if let Some(handle) = self.clickhouse_writer_handle {
-            handle.abort();
-            let _ = handle.await;
+            tokio::select! {
+                _ = handle => {}
+                _ = tokio::time::sleep(std::time::Duration::from_secs(5)) => {
+                    warn!("ClickHouse debug writer did not shut down within 5s");
+                }
+            }
         }
 
         self.context

--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -143,6 +143,8 @@ where
     core_thread_handle: CoreThreadHandle,
     subscriber: Subscriber<N::ValidatorClient, AuthorityService<ChannelCoreThreadDispatcher>>,
     network_manager: N,
+    #[cfg(feature = "clickhouse-debug")]
+    clickhouse_writer_handle: Option<JoinHandle<()>>,
 }
 
 impl<N> AuthorityNode<N>
@@ -238,11 +240,50 @@ where
         ));
 
         let store_path = context.parameters.db_path.as_path().to_str().unwrap();
-        let store = Arc::new(RocksDBStore::new(
+        let rocksdb_store = Arc::new(RocksDBStore::new(
             store_path,
             context.parameters.use_fifo_compaction
                 && context.protocol_config.chain() != ChainType::Mainnet,
         ));
+
+        #[cfg(feature = "clickhouse-debug")]
+        let (store, clickhouse_writer_handle): (
+            Arc<dyn super::storage::Store>,
+            Option<JoinHandle<()>>,
+        ) = {
+            if context.parameters.clickhouse.enabled {
+                use super::storage::clickhouse_writer::{ClickHouseWriter, DualWriteStore};
+
+                let (sender, receiver) =
+                    tokio::sync::mpsc::channel(context.parameters.clickhouse.channel_capacity);
+                let writer = ClickHouseWriter::new(&context.parameters.clickhouse, receiver);
+                let handle = spawn_logged_monitored_task!(writer.run(), "clickhouse_debug_writer");
+                let dual_store = DualWriteStore::new(
+                    rocksdb_store,
+                    sender,
+                    context.committee.epoch(),
+                    context.parameters.clickhouse.include_raw_bytes,
+                );
+                info!(
+                    "ClickHouse debug writer enabled, writing to {}",
+                    context.parameters.clickhouse.url
+                );
+                (Arc::new(dual_store), Some(handle))
+            } else {
+                (rocksdb_store, None)
+            }
+        };
+
+        #[cfg(not(feature = "clickhouse-debug"))]
+        let store: Arc<dyn super::storage::Store> = {
+            if context.parameters.clickhouse.enabled {
+                warn!(
+                    "ClickHouse debug writer enabled in config but 'clickhouse-debug' feature is not compiled. Ignoring."
+                );
+            }
+            rocksdb_store
+        };
+
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
 
         let block_verifier = Arc::new(SignedBlockVerifier::new(
@@ -416,6 +457,8 @@ where
             core_thread_handle,
             subscriber,
             network_manager,
+            #[cfg(feature = "clickhouse-debug")]
+            clickhouse_writer_handle,
         }
     }
 
@@ -444,6 +487,12 @@ where
         // Stop block subscriptions before stopping network server.
         self.subscriber.stop();
         self.network_manager.stop().await;
+
+        #[cfg(feature = "clickhouse-debug")]
+        if let Some(handle) = self.clickhouse_writer_handle {
+            handle.abort();
+            let _ = handle.await;
+        }
 
         self.context
             .metrics

--- a/consensus/core/src/storage/clickhouse_writer.rs
+++ b/consensus/core/src/storage/clickhouse_writer.rs
@@ -130,6 +130,7 @@ impl DualWriteStore {
 
     fn extract_commit_row(&self, commit: &TrustedCommit) -> CommitRow {
         CommitRow {
+            // Commits don't carry epoch in their serialized form, so we use the epoch from context.
             epoch: self.epoch,
             commit_index: commit.index(),
             commit_digest: hex_encode(&commit.digest().into_inner()),
@@ -369,10 +370,16 @@ impl ClickHouseWriter {
         config: &ClickHouseParameters,
         receiver: mpsc::Receiver<ClickHouseWriteBatch>,
     ) -> Self {
-        let client = Client::default()
+        let mut client = Client::default()
             .with_url(&config.url)
             .with_database(&config.database)
             .with_compression(clickhouse::Compression::Lz4);
+        if let Some(user) = &config.user {
+            client = client.with_user(user);
+        }
+        if let Some(password) = &config.password {
+            client = client.with_password(password);
+        }
         Self { client, receiver }
     }
 

--- a/consensus/core/src/storage/clickhouse_writer.rs
+++ b/consensus/core/src/storage/clickhouse_writer.rs
@@ -1,0 +1,655 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use clickhouse::{Client, Row};
+use consensus_config::{AuthorityIndex, ClickHouseParameters};
+use consensus_types::block::{BlockRef, Round, TransactionIndex};
+use serde::Serialize;
+use tokio::sync::mpsc;
+use tracing::warn;
+
+use super::{CommitInfo, Store, WriteBatch};
+use crate::block::{BlockAPI as _, VerifiedBlock};
+use crate::commit::{CommitAPI as _, CommitIndex, CommitRef, TrustedCommit};
+use crate::error::ConsensusResult;
+
+fn hex_encode(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+#[derive(Row, Serialize)]
+pub(crate) struct BlockRow {
+    pub epoch: u64,
+    pub round: u32,
+    pub author: u32,
+    pub digest: String,
+    pub timestamp_ms: u64,
+    pub num_transactions: u32,
+    pub num_ancestors: u32,
+    pub num_commit_votes: u32,
+    pub num_misbehavior_reports: u32,
+    pub serialized_size_bytes: u32,
+    pub raw_bytes: Vec<u8>,
+}
+
+#[derive(Row, Serialize)]
+pub(crate) struct CommitRow {
+    pub epoch: u64,
+    pub commit_index: u32,
+    pub commit_digest: String,
+    pub previous_digest: String,
+    pub timestamp_ms: u64,
+    pub leader_round: u32,
+    pub leader_author: u32,
+    pub leader_digest: String,
+    pub num_blocks: u32,
+    pub serialized_size_bytes: u32,
+    pub raw_bytes: Vec<u8>,
+}
+
+#[derive(Row, Serialize)]
+pub(crate) struct CommitInfoRow {
+    pub epoch: u64,
+    pub commit_index: u32,
+    pub commit_digest: String,
+    pub committed_rounds: Vec<u32>,
+    pub reputation_scores: Vec<u64>,
+    pub score_commit_range_start: u32,
+    pub score_commit_range_end: u32,
+}
+
+#[derive(Row, Serialize)]
+pub(crate) struct FinalizedCommitRow {
+    pub epoch: u64,
+    pub commit_index: u32,
+    pub commit_digest: String,
+    pub num_blocks_with_rejections: u32,
+    pub total_rejected_transactions: u32,
+}
+
+pub(crate) struct ClickHouseWriteBatch {
+    pub blocks: Vec<BlockRow>,
+    pub commits: Vec<CommitRow>,
+    pub commit_info: Vec<CommitInfoRow>,
+    pub finalized_commits: Vec<FinalizedCommitRow>,
+}
+
+impl ClickHouseWriteBatch {
+    fn is_empty(&self) -> bool {
+        self.blocks.is_empty()
+            && self.commits.is_empty()
+            && self.commit_info.is_empty()
+            && self.finalized_commits.is_empty()
+    }
+}
+
+pub(crate) struct DualWriteStore {
+    inner: Arc<dyn Store>,
+    sender: mpsc::Sender<ClickHouseWriteBatch>,
+    epoch: u64,
+    include_raw_bytes: bool,
+}
+
+impl DualWriteStore {
+    pub fn new(
+        inner: Arc<dyn Store>,
+        sender: mpsc::Sender<ClickHouseWriteBatch>,
+        epoch: u64,
+        include_raw_bytes: bool,
+    ) -> Self {
+        Self {
+            inner,
+            sender,
+            epoch,
+            include_raw_bytes,
+        }
+    }
+
+    fn extract_block_row(&self, block: &VerifiedBlock) -> BlockRow {
+        BlockRow {
+            epoch: block.epoch(),
+            round: block.round(),
+            author: block.author().value() as u32,
+            digest: hex_encode(&block.digest().0),
+            timestamp_ms: block.timestamp_ms(),
+            num_transactions: block.transactions().len() as u32,
+            num_ancestors: block.ancestors().len() as u32,
+            num_commit_votes: block.commit_votes().len() as u32,
+            num_misbehavior_reports: block.misbehavior_reports().len() as u32,
+            serialized_size_bytes: block.serialized().len() as u32,
+            raw_bytes: if self.include_raw_bytes {
+                block.serialized().to_vec()
+            } else {
+                vec![]
+            },
+        }
+    }
+
+    fn extract_commit_row(&self, commit: &TrustedCommit) -> CommitRow {
+        CommitRow {
+            epoch: self.epoch,
+            commit_index: commit.index(),
+            commit_digest: hex_encode(&commit.digest().into_inner()),
+            previous_digest: hex_encode(&commit.previous_digest().into_inner()),
+            timestamp_ms: commit.timestamp_ms(),
+            leader_round: commit.leader().round,
+            leader_author: commit.leader().author.value() as u32,
+            leader_digest: hex_encode(&commit.leader().digest.0),
+            num_blocks: commit.blocks().len() as u32,
+            serialized_size_bytes: commit.serialized().len() as u32,
+            raw_bytes: if self.include_raw_bytes {
+                commit.serialized().to_vec()
+            } else {
+                vec![]
+            },
+        }
+    }
+
+    fn extract_commit_info_row(&self, commit_ref: &CommitRef, info: &CommitInfo) -> CommitInfoRow {
+        CommitInfoRow {
+            epoch: self.epoch,
+            commit_index: commit_ref.index,
+            commit_digest: hex_encode(&commit_ref.digest.into_inner()),
+            committed_rounds: info.committed_rounds.clone(),
+            reputation_scores: info.reputation_scores.scores_per_authority.clone(),
+            score_commit_range_start: info.reputation_scores.commit_range.start(),
+            score_commit_range_end: info.reputation_scores.commit_range.end(),
+        }
+    }
+
+    fn extract_finalized_commit_row(
+        &self,
+        commit_ref: &CommitRef,
+        rejected_txns: &BTreeMap<BlockRef, Vec<TransactionIndex>>,
+    ) -> FinalizedCommitRow {
+        FinalizedCommitRow {
+            epoch: self.epoch,
+            commit_index: commit_ref.index,
+            commit_digest: hex_encode(&commit_ref.digest.into_inner()),
+            num_blocks_with_rejections: rejected_txns.len() as u32,
+            total_rejected_transactions: rejected_txns.values().map(|v| v.len() as u32).sum(),
+        }
+    }
+
+    fn extract_metadata(&self, write_batch: &WriteBatch) -> ClickHouseWriteBatch {
+        ClickHouseWriteBatch {
+            blocks: write_batch
+                .blocks
+                .iter()
+                .map(|b| self.extract_block_row(b))
+                .collect(),
+            commits: write_batch
+                .commits
+                .iter()
+                .map(|c| self.extract_commit_row(c))
+                .collect(),
+            commit_info: write_batch
+                .commit_info
+                .iter()
+                .map(|(r, i)| self.extract_commit_info_row(r, i))
+                .collect(),
+            finalized_commits: write_batch
+                .finalized_commits
+                .iter()
+                .map(|(r, t)| self.extract_finalized_commit_row(r, t))
+                .collect(),
+        }
+    }
+}
+
+impl Store for DualWriteStore {
+    fn write(&self, write_batch: WriteBatch) -> ConsensusResult<()> {
+        // Extract metadata by borrowing before the batch is moved to the inner store.
+        let ch_batch = self.extract_metadata(&write_batch);
+        self.inner.write(write_batch)?;
+        if !ch_batch.is_empty() {
+            if let Err(e) = self.sender.try_send(ch_batch) {
+                warn!(
+                    "ClickHouse debug writer channel full or closed, dropping batch: {}",
+                    e
+                );
+            }
+        }
+        Ok(())
+    }
+
+    fn read_blocks(&self, refs: &[BlockRef]) -> ConsensusResult<Vec<Option<VerifiedBlock>>> {
+        self.inner.read_blocks(refs)
+    }
+
+    fn contains_blocks(&self, refs: &[BlockRef]) -> ConsensusResult<Vec<bool>> {
+        self.inner.contains_blocks(refs)
+    }
+
+    fn scan_blocks_by_author(
+        &self,
+        author: AuthorityIndex,
+        start_round: Round,
+    ) -> ConsensusResult<Vec<VerifiedBlock>> {
+        self.inner.scan_blocks_by_author(author, start_round)
+    }
+
+    fn scan_last_blocks_by_author(
+        &self,
+        author: AuthorityIndex,
+        num_of_rounds: u64,
+        before_round: Option<Round>,
+    ) -> ConsensusResult<Vec<VerifiedBlock>> {
+        self.inner
+            .scan_last_blocks_by_author(author, num_of_rounds, before_round)
+    }
+
+    fn read_last_commit(&self) -> ConsensusResult<Option<TrustedCommit>> {
+        self.inner.read_last_commit()
+    }
+
+    fn scan_commits(
+        &self,
+        range: crate::commit::CommitRange,
+    ) -> ConsensusResult<Vec<TrustedCommit>> {
+        self.inner.scan_commits(range)
+    }
+
+    fn read_commit_votes(&self, commit_index: CommitIndex) -> ConsensusResult<Vec<BlockRef>> {
+        self.inner.read_commit_votes(commit_index)
+    }
+
+    fn read_last_commit_info(&self) -> ConsensusResult<Option<(CommitRef, CommitInfo)>> {
+        self.inner.read_last_commit_info()
+    }
+
+    fn read_last_finalized_commit(&self) -> ConsensusResult<Option<CommitRef>> {
+        self.inner.read_last_finalized_commit()
+    }
+
+    fn read_rejected_transactions(
+        &self,
+        commit_ref: CommitRef,
+    ) -> ConsensusResult<Option<BTreeMap<BlockRef, Vec<TransactionIndex>>>> {
+        self.inner.read_rejected_transactions(commit_ref)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ClickHouseWriter — async background task
+// ---------------------------------------------------------------------------
+
+const CREATE_BLOCKS_TABLE: &str = "
+CREATE TABLE IF NOT EXISTS consensus_blocks
+(
+    epoch                    UInt64,
+    round                    UInt32,
+    author                   UInt32,
+    digest                   String,
+    timestamp_ms             UInt64,
+    num_transactions         UInt32,
+    num_ancestors            UInt32,
+    num_commit_votes         UInt32,
+    num_misbehavior_reports  UInt32,
+    serialized_size_bytes    UInt32,
+    raw_bytes                String,
+    inserted_at              DateTime DEFAULT now()
+)
+ENGINE = MergeTree()
+PARTITION BY epoch
+ORDER BY (epoch, author, round, digest)
+TTL inserted_at + INTERVAL 48 HOUR
+SETTINGS index_granularity = 8192
+";
+
+const CREATE_COMMITS_TABLE: &str = "
+CREATE TABLE IF NOT EXISTS consensus_commits
+(
+    epoch                UInt64,
+    commit_index         UInt32,
+    commit_digest        String,
+    previous_digest      String,
+    timestamp_ms         UInt64,
+    leader_round         UInt32,
+    leader_author        UInt32,
+    leader_digest        String,
+    num_blocks           UInt32,
+    serialized_size_bytes UInt32,
+    raw_bytes            String,
+    inserted_at          DateTime DEFAULT now()
+)
+ENGINE = MergeTree()
+PARTITION BY epoch
+ORDER BY (epoch, commit_index, commit_digest)
+TTL inserted_at + INTERVAL 48 HOUR
+SETTINGS index_granularity = 8192
+";
+
+const CREATE_COMMIT_INFO_TABLE: &str = "
+CREATE TABLE IF NOT EXISTS consensus_commit_info
+(
+    epoch                    UInt64,
+    commit_index             UInt32,
+    commit_digest            String,
+    committed_rounds         Array(UInt32),
+    reputation_scores        Array(UInt64),
+    score_commit_range_start UInt32,
+    score_commit_range_end   UInt32,
+    inserted_at              DateTime DEFAULT now()
+)
+ENGINE = MergeTree()
+PARTITION BY epoch
+ORDER BY (epoch, commit_index, commit_digest)
+TTL inserted_at + INTERVAL 48 HOUR
+SETTINGS index_granularity = 8192
+";
+
+const CREATE_FINALIZED_COMMITS_TABLE: &str = "
+CREATE TABLE IF NOT EXISTS consensus_finalized_commits
+(
+    epoch                        UInt64,
+    commit_index                 UInt32,
+    commit_digest                String,
+    num_blocks_with_rejections   UInt32,
+    total_rejected_transactions  UInt32,
+    inserted_at                  DateTime DEFAULT now()
+)
+ENGINE = MergeTree()
+PARTITION BY epoch
+ORDER BY (epoch, commit_index, commit_digest)
+TTL inserted_at + INTERVAL 48 HOUR
+SETTINGS index_granularity = 8192
+";
+
+pub(crate) struct ClickHouseWriter {
+    client: Client,
+    receiver: mpsc::Receiver<ClickHouseWriteBatch>,
+}
+
+impl ClickHouseWriter {
+    pub fn new(
+        config: &ClickHouseParameters,
+        receiver: mpsc::Receiver<ClickHouseWriteBatch>,
+    ) -> Self {
+        let client = Client::default()
+            .with_url(&config.url)
+            .with_database(&config.database)
+            .with_compression(clickhouse::Compression::Lz4);
+        Self { client, receiver }
+    }
+
+    async fn create_tables(&self) {
+        for ddl in [
+            CREATE_BLOCKS_TABLE,
+            CREATE_COMMITS_TABLE,
+            CREATE_COMMIT_INFO_TABLE,
+            CREATE_FINALIZED_COMMITS_TABLE,
+        ] {
+            if let Err(e) = self.client.query(ddl).execute().await {
+                warn!("ClickHouse debug writer: failed to create table: {}", e);
+            }
+        }
+    }
+
+    async fn insert_batch(&self, batch: ClickHouseWriteBatch) {
+        if !batch.blocks.is_empty() {
+            if let Err(e) = self.insert_rows("consensus_blocks", &batch.blocks).await {
+                warn!("ClickHouse debug writer: failed to insert blocks: {}", e);
+            }
+        }
+        if !batch.commits.is_empty() {
+            if let Err(e) = self.insert_rows("consensus_commits", &batch.commits).await {
+                warn!("ClickHouse debug writer: failed to insert commits: {}", e);
+            }
+        }
+        if !batch.commit_info.is_empty() {
+            if let Err(e) = self
+                .insert_rows("consensus_commit_info", &batch.commit_info)
+                .await
+            {
+                warn!(
+                    "ClickHouse debug writer: failed to insert commit_info: {}",
+                    e
+                );
+            }
+        }
+        if !batch.finalized_commits.is_empty() {
+            if let Err(e) = self
+                .insert_rows("consensus_finalized_commits", &batch.finalized_commits)
+                .await
+            {
+                warn!(
+                    "ClickHouse debug writer: failed to insert finalized_commits: {}",
+                    e
+                );
+            }
+        }
+    }
+
+    async fn insert_rows<T: Row + Serialize>(
+        &self,
+        table: &str,
+        rows: &[T],
+    ) -> Result<(), clickhouse::error::Error> {
+        let mut inserter = self.client.insert(table)?;
+        for row in rows {
+            inserter.write(row).await?;
+        }
+        inserter.end().await
+    }
+
+    pub async fn run(mut self) {
+        self.create_tables().await;
+
+        while let Some(batch) = self.receiver.recv().await {
+            // Coalesce ready batches to reduce ClickHouse round-trips.
+            let mut coalesced = batch;
+            for _ in 0..64 {
+                match self.receiver.try_recv() {
+                    Ok(extra) => {
+                        coalesced.blocks.extend(extra.blocks);
+                        coalesced.commits.extend(extra.commits);
+                        coalesced.commit_info.extend(extra.commit_info);
+                        coalesced.finalized_commits.extend(extra.finalized_commits);
+                    }
+                    Err(_) => break,
+                }
+            }
+
+            self.insert_batch(coalesced).await;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::block::TestBlock;
+    use crate::commit::TrustedCommit;
+    use crate::leader_scoring::ReputationScores;
+    use crate::storage::mem_store::MemStore;
+    use consensus_config::AuthorityIndex;
+    use consensus_types::block::BlockRef;
+
+    fn make_test_block() -> VerifiedBlock {
+        VerifiedBlock::new_for_test(
+            TestBlock::new(1, 0)
+                .set_ancestors(vec![BlockRef::MIN])
+                .build(),
+        )
+    }
+
+    fn make_test_commit() -> TrustedCommit {
+        TrustedCommit::new_for_test(
+            1,
+            Default::default(),
+            1000,
+            BlockRef::MIN,
+            vec![BlockRef::MIN],
+        )
+    }
+
+    #[test]
+    fn test_dual_write_store_forwards_to_inner() {
+        let mem_store = Arc::new(MemStore::new());
+        let (sender, mut receiver) = mpsc::channel(16);
+        let dual = DualWriteStore::new(mem_store.clone(), sender, 42, false);
+
+        let block = make_test_block();
+        let block_ref = block.reference();
+
+        let batch = WriteBatch::new(vec![block], vec![], vec![], vec![]);
+        dual.write(batch).unwrap();
+
+        // Verify inner store received the block.
+        let read = mem_store.read_blocks(&[block_ref]).unwrap();
+        assert!(read[0].is_some());
+
+        // Verify channel received extracted metadata.
+        let ch_batch = receiver.try_recv().unwrap();
+        assert_eq!(ch_batch.blocks.len(), 1);
+        assert_eq!(ch_batch.blocks[0].round, 1);
+        assert_eq!(ch_batch.blocks[0].author, 0);
+        // Block epoch comes from the block itself (0 for test blocks).
+        assert_eq!(ch_batch.blocks[0].epoch, 0);
+    }
+
+    #[test]
+    fn test_dual_write_store_channel_full_does_not_block() {
+        let mem_store = Arc::new(MemStore::new());
+        let (sender, _receiver) = mpsc::channel(1);
+        let dual = DualWriteStore::new(mem_store.clone(), sender, 0, false);
+
+        // Fill the channel.
+        let block1 = make_test_block();
+        let batch1 = WriteBatch::new(vec![block1], vec![], vec![], vec![]);
+        dual.write(batch1).unwrap();
+
+        // Second write should succeed (inner store) even though channel is full.
+        let block2 = make_test_block();
+        let block2_ref = block2.reference();
+        let batch2 = WriteBatch::new(vec![block2], vec![], vec![], vec![]);
+        dual.write(batch2).unwrap();
+
+        // Inner store still has the block.
+        let read = mem_store.read_blocks(&[block2_ref]).unwrap();
+        assert!(read[0].is_some());
+    }
+
+    #[test]
+    fn test_metadata_extraction_blocks() {
+        let mem_store = Arc::new(MemStore::new());
+        let (sender, mut receiver) = mpsc::channel(16);
+        let dual = DualWriteStore::new(mem_store, sender, 10, false);
+
+        let block = make_test_block();
+        let batch = WriteBatch::new(vec![block.clone()], vec![], vec![], vec![]);
+        dual.write(batch).unwrap();
+
+        let ch_batch = receiver.try_recv().unwrap();
+        let row = &ch_batch.blocks[0];
+        assert_eq!(row.epoch, block.epoch());
+        assert_eq!(row.round, block.round());
+        assert_eq!(row.author, block.author().value() as u32);
+        assert_eq!(row.digest, hex_encode(&block.digest().0));
+        assert_eq!(row.num_transactions, block.transactions().len() as u32);
+        assert_eq!(row.num_ancestors, block.ancestors().len() as u32);
+        assert_eq!(row.serialized_size_bytes, block.serialized().len() as u32);
+        assert!(row.raw_bytes.is_empty());
+    }
+
+    #[test]
+    fn test_metadata_extraction_with_raw_bytes() {
+        let mem_store = Arc::new(MemStore::new());
+        let (sender, mut receiver) = mpsc::channel(16);
+        let dual = DualWriteStore::new(mem_store, sender, 10, true);
+
+        let block = make_test_block();
+        let expected_bytes = block.serialized().to_vec();
+        let batch = WriteBatch::new(vec![block], vec![], vec![], vec![]);
+        dual.write(batch).unwrap();
+
+        let ch_batch = receiver.try_recv().unwrap();
+        assert_eq!(ch_batch.blocks[0].raw_bytes, expected_bytes);
+    }
+
+    #[test]
+    fn test_metadata_extraction_commits() {
+        let mem_store = Arc::new(MemStore::new());
+        let (sender, mut receiver) = mpsc::channel(16);
+        let dual = DualWriteStore::new(mem_store, sender, 5, false);
+
+        let commit = make_test_commit();
+        let batch = WriteBatch::new(vec![], vec![commit.clone()], vec![], vec![]);
+        dual.write(batch).unwrap();
+
+        let ch_batch = receiver.try_recv().unwrap();
+        assert_eq!(ch_batch.commits.len(), 1);
+        let row = &ch_batch.commits[0];
+        assert_eq!(row.epoch, 5);
+        assert_eq!(row.commit_index, commit.index());
+        assert_eq!(row.num_blocks, commit.blocks().len() as u32);
+    }
+
+    #[test]
+    fn test_metadata_extraction_commit_info() {
+        let mem_store = Arc::new(MemStore::new());
+        let (sender, mut receiver) = mpsc::channel(16);
+        let dual = DualWriteStore::new(mem_store, sender, 7, false);
+
+        let commit_ref = CommitRef::new(3, Default::default());
+        let scores = ReputationScores::new((1..=10).into(), vec![100, 200, 300]);
+        let info = CommitInfo {
+            committed_rounds: vec![1, 2, 3],
+            reputation_scores: scores,
+        };
+
+        let batch = WriteBatch::new(vec![], vec![], vec![(commit_ref, info)], vec![]);
+        dual.write(batch).unwrap();
+
+        let ch_batch = receiver.try_recv().unwrap();
+        assert_eq!(ch_batch.commit_info.len(), 1);
+        let row = &ch_batch.commit_info[0];
+        assert_eq!(row.epoch, 7);
+        assert_eq!(row.commit_index, 3);
+        assert_eq!(row.committed_rounds, vec![1, 2, 3]);
+        assert_eq!(row.reputation_scores, vec![100, 200, 300]);
+        assert_eq!(row.score_commit_range_start, 1);
+        assert_eq!(row.score_commit_range_end, 10);
+    }
+
+    #[test]
+    fn test_metadata_extraction_finalized_commits() {
+        let mem_store = Arc::new(MemStore::new());
+        let (sender, mut receiver) = mpsc::channel(16);
+        let dual = DualWriteStore::new(mem_store, sender, 1, false);
+
+        let commit_ref = CommitRef::new(5, Default::default());
+        let mut rejected = BTreeMap::new();
+        rejected.insert(BlockRef::MIN, vec![0, 2, 4]);
+        rejected.insert(
+            BlockRef::new(1, AuthorityIndex::ZERO, Default::default()),
+            vec![1],
+        );
+
+        let batch = WriteBatch::new(vec![], vec![], vec![], vec![(commit_ref, rejected)]);
+        dual.write(batch).unwrap();
+
+        let ch_batch = receiver.try_recv().unwrap();
+        assert_eq!(ch_batch.finalized_commits.len(), 1);
+        let row = &ch_batch.finalized_commits[0];
+        assert_eq!(row.commit_index, 5);
+        assert_eq!(row.num_blocks_with_rejections, 2);
+        assert_eq!(row.total_rejected_transactions, 4);
+    }
+
+    #[test]
+    fn test_empty_batch_no_channel_send() {
+        let mem_store = Arc::new(MemStore::new());
+        let (sender, mut receiver) = mpsc::channel(16);
+        let dual = DualWriteStore::new(mem_store, sender, 0, false);
+
+        let batch = WriteBatch::default();
+        dual.write(batch).unwrap();
+
+        assert!(receiver.try_recv().is_err());
+    }
+}

--- a/consensus/core/src/storage/mod.rs
+++ b/consensus/core/src/storage/mod.rs
@@ -4,6 +4,9 @@
 pub mod mem_store;
 pub mod rocksdb_store;
 
+#[cfg(feature = "clickhouse-debug")]
+pub(crate) mod clickhouse_writer;
+
 #[cfg(test)]
 mod store_tests;
 


### PR DESCRIPTION
## Description 

- Adds an optional ClickHouse dual-write layer for consensus data, enabling SQL-queryable observability into blocks, commits, commit info, and finalized commits
- Implemented as a `DualWriteStore` wrapper that intercepts `Store::write()` calls, extracts lightweight metadata rows (counts, sizes, digests — not full transaction payloads), and sends them over a bounded mpsc channel to a background `ClickHouseWriter` task.
- Zero impact on the consensus hot path: feature is compile-time gated behind a Cargo feature flag, disabled by default. When enabled, the ClickHouse write is async and non-blocking.
- ClickHouse tables are partitioned by epoch with a 48-hour TTL, mirroring the ephemeral nature of the RocksDB consensus store.
- Raw BCS bytes are optional (include_raw_bytes config flag), defaulting to off

## Test plan 

- Added unit test coverage for the new `DualWriteStore`.

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [x] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
