### PR TITLE
sui-indexer-alt-e2e-tests: bump graphql_zklogin_tests graphql timeout

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_zklogin_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_zklogin_tests.rs
@@ -102,7 +102,7 @@ impl FullCluster {
         // Trigger an epoch change and wait until GraphQL sees Epoch 1
         onchain.trigger_reconfiguration().await;
         onchain.wait_for_authenticator_state_update().await;
-        tokio::time::timeout(Duration::from_secs(20), async {
+        tokio::time::timeout(Duration::from_secs(30), async {
             let mut interval = interval(Duration::from_millis(200));
             loop {
                 interval.tick().await;


### PR DESCRIPTION
## Description 

Increases the graphql timeout again to reduce flakes locally like in #25914.

## Test plan 

`cargo nextest run -p sui-indexer-alt-e2e-tests` passing locally.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
