### PR TITLE
Fix string parsing bug

### DIFF
--- a/crates/sui-kvstore/src/bigtable/client/mod.rs
+++ b/crates/sui-kvstore/src/bigtable/client/mod.rs
@@ -204,8 +204,8 @@ impl BigTableClient {
             Some(p) => p,
             None => token_provider.project_id().await?.to_string(),
         };
-        let instance_name = format!("projects/{}/instances/{}/", project_id, instance_id);
-        let table_prefix = format!("{}tables/", instance_name);
+        let instance_name = format!("projects/{}/instances/{}", project_id, instance_id);
+        let table_prefix = format!("{}/tables/", instance_name);
         let primer = BigtablePrimer {
             instance_name,
             policy: policy.to_string(),


### PR DESCRIPTION
## Description

Removes trailing slash from the Bigtable instance_name string, which caused ping_and_warm channel priming to fail with an "invalid argument" error from the Bigtable API.

## Test plan

I will verify the warning logs are gone when this makes it to devnet.
