### PR TITLE
[cherry-pick][move] Add additional argument checking in move calls (#26049)

### DIFF
--- a/crates/sui-adapter-transactional-tests/tests/entry_points/object_type_mismatch.move
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/object_type_mismatch.move
@@ -1,0 +1,120 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Tests passing objects of the wrong type to entry functions
+
+//# init --addresses test=0x0 --accounts A
+
+//# publish
+module test::m;
+
+public struct ObjA has key, store {
+    id: UID,
+}
+
+public struct ObjB has key, store {
+    id: UID,
+}
+
+public struct Wrapper<phantom T> has key, store {
+    id: UID,
+}
+
+public entry fun mint_a(ctx: &mut TxContext) {
+    transfer::public_transfer(ObjA { id: object::new(ctx) }, ctx.sender())
+}
+
+public entry fun mint_b(ctx: &mut TxContext) {
+    transfer::public_transfer(ObjB { id: object::new(ctx) }, ctx.sender())
+}
+
+public entry fun mint_wrapper_u64(ctx: &mut TxContext) {
+    transfer::public_transfer(Wrapper<u64> { id: object::new(ctx) }, ctx.sender())
+}
+
+public entry fun mint_wrapper_bool(ctx: &mut TxContext) {
+    transfer::public_transfer(Wrapper<bool> { id: object::new(ctx) }, ctx.sender())
+}
+
+public entry fun take_a(_o: &ObjA) {}
+public entry fun take_b(_o: &ObjB) {}
+public entry fun take_wrapper_u64(_o: &Wrapper<u64>) {}
+public entry fun take_wrapper_bool(_o: &Wrapper<bool>) {}
+public entry fun take_generic<T: key + store>(_o: &T) {}
+
+public entry fun take_a_mut(_o: &mut ObjA) {}
+public entry fun take_wrapper_u64_mut(_o: &mut Wrapper<u64>) {}
+public entry fun take_wrapper_bool_mut(_o: &mut Wrapper<bool>) {}
+
+public entry fun destroy_a(o: ObjA) { let ObjA { id } = o; object::delete(id) }
+public entry fun destroy_b(o: ObjB) { let ObjB { id } = o; object::delete(id) }
+public entry fun destroy_wrapper_u64(o: Wrapper<u64>) { let Wrapper { id } = o; object::delete(id) }
+public entry fun destroy_wrapper_bool(o: Wrapper<bool>) { let Wrapper { id } = o; object::delete(id) }
+
+// mint one of each
+// object(2,0) = ObjA
+//# run test::m::mint_a --sender A
+
+// object(3,0) = ObjB
+//# run test::m::mint_b --sender A
+
+// object(4,0) = Wrapper<u64>
+//# run test::m::mint_wrapper_u64 --sender A
+
+// object(5,0) = Wrapper<bool>
+//# run test::m::mint_wrapper_bool --sender A
+
+// pass ObjB where &ObjA expected
+//# run test::m::take_a --sender A --args object(3,0)
+
+// pass ObjA where &ObjB expected
+//# run test::m::take_b --sender A --args object(2,0)
+
+// pass Wrapper<bool> where &Wrapper<u64> expected
+//# run test::m::take_wrapper_u64 --sender A --args object(5,0)
+
+// pass Wrapper<u64> where &Wrapper<bool> expected
+//# run test::m::take_wrapper_bool --sender A --args object(4,0)
+
+// pass ObjA where &T expected with T=ObjB
+//# run test::m::take_generic --type-args test::m::ObjB --sender A --args object(2,0)
+
+// &mut ref mismatches: pass ObjB where &mut ObjA expected
+//# run test::m::take_a_mut --sender A --args object(3,0)
+
+// pass Wrapper<bool> where &mut Wrapper<u64> expected
+//# run test::m::take_wrapper_u64_mut --sender A --args object(5,0)
+
+// pass Wrapper<u64> where &mut Wrapper<bool> expected
+//# run test::m::take_wrapper_bool_mut --sender A --args object(4,0)
+
+// happy paths (immutable ref)
+//# run test::m::take_a --sender A --args object(2,0)
+
+//# run test::m::take_wrapper_u64 --sender A --args object(4,0)
+
+//# run test::m::take_generic --type-args test::m::ObjA --sender A --args object(2,0)
+
+// happy paths (mutable ref)
+//# run test::m::take_a_mut --sender A --args object(2,0)
+
+//# run test::m::take_wrapper_u64_mut --sender A --args object(4,0)
+
+// by-value mismatches (these consume the object, so test mismatches first)
+// pass ObjB where ObjA expected
+//# run test::m::destroy_a --sender A --args object(3,0)
+
+// pass Wrapper<bool> where Wrapper<u64> expected
+//# run test::m::destroy_wrapper_u64 --sender A --args object(5,0)
+
+// pass Wrapper<u64> where Wrapper<bool> expected
+//# run test::m::destroy_wrapper_bool --sender A --args object(4,0)
+
+// happy paths (by value, consume the objects last)
+//# run test::m::destroy_a --sender A --args object(2,0)
+
+//# run test::m::destroy_wrapper_u64 --sender A --args object(4,0)
+
+//# run test::m::destroy_wrapper_bool --sender A --args object(5,0)
+
+//# run test::m::destroy_b --sender A --args object(3,0)

--- a/crates/sui-adapter-transactional-tests/tests/entry_points/object_type_mismatch.snap
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/object_type_mismatch.snap
@@ -1,0 +1,142 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+assertion_line: 908
+---
+processed 26 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 8-55:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 10320800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 56-58:
+//# run test::m::mint_a --sender A
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2219200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, lines 59-61:
+//# run test::m::mint_b --sender A
+created: object(3,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2219200,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 4, lines 62-64:
+//# run test::m::mint_wrapper_u64 --sender A
+created: object(4,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2249600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 5, lines 65-67:
+//# run test::m::mint_wrapper_bool --sender A
+created: object(5,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2249600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 6, lines 68-70:
+//# run test::m::take_a --sender A --args object(3,0)
+Error: Transaction Effects Status: Invalid command argument at 0. The type of the value does not match the expected type
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: TypeMismatch }, source: None, command: Some(0) } }
+
+task 7, lines 71-73:
+//# run test::m::take_b --sender A --args object(2,0)
+Error: Transaction Effects Status: Invalid command argument at 0. The type of the value does not match the expected type
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: TypeMismatch }, source: None, command: Some(0) } }
+
+task 8, lines 74-76:
+//# run test::m::take_wrapper_u64 --sender A --args object(5,0)
+Error: Transaction Effects Status: Invalid command argument at 0. The type of the value does not match the expected type
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: TypeMismatch }, source: None, command: Some(0) } }
+
+task 9, lines 77-79:
+//# run test::m::take_wrapper_bool --sender A --args object(4,0)
+Error: Transaction Effects Status: Invalid command argument at 0. The type of the value does not match the expected type
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: TypeMismatch }, source: None, command: Some(0) } }
+
+task 10, lines 80-82:
+//# run test::m::take_generic --type-args test::m::ObjB --sender A --args object(2,0)
+Error: Transaction Effects Status: Invalid command argument at 0. The type of the value does not match the expected type
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: TypeMismatch }, source: None, command: Some(0) } }
+
+task 11, lines 83-85:
+//# run test::m::take_a_mut --sender A --args object(3,0)
+Error: Transaction Effects Status: Invalid command argument at 0. The type of the value does not match the expected type
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: TypeMismatch }, source: None, command: Some(0) } }
+
+task 12, lines 86-88:
+//# run test::m::take_wrapper_u64_mut --sender A --args object(5,0)
+Error: Transaction Effects Status: Invalid command argument at 0. The type of the value does not match the expected type
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: TypeMismatch }, source: None, command: Some(0) } }
+
+task 13, lines 89-91:
+//# run test::m::take_wrapper_bool_mut --sender A --args object(4,0)
+Error: Transaction Effects Status: Invalid command argument at 0. The type of the value does not match the expected type
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: TypeMismatch }, source: None, command: Some(0) } }
+
+task 14, line 92:
+//# run test::m::take_a --sender A --args object(2,0)
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 2219200,  storage_rebate: 2197008, non_refundable_storage_fee: 22192
+
+task 15, line 94:
+//# run test::m::take_wrapper_u64 --sender A --args object(4,0)
+mutated: object(0,0), object(4,0)
+gas summary: computation_cost: 1000000, storage_cost: 2249600,  storage_rebate: 2227104, non_refundable_storage_fee: 22496
+
+task 16, lines 96-98:
+//# run test::m::take_generic --type-args test::m::ObjA --sender A --args object(2,0)
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 2219200,  storage_rebate: 2197008, non_refundable_storage_fee: 22192
+
+task 17, line 99:
+//# run test::m::take_a_mut --sender A --args object(2,0)
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 2219200,  storage_rebate: 2197008, non_refundable_storage_fee: 22192
+
+task 18, lines 101-104:
+//# run test::m::take_wrapper_u64_mut --sender A --args object(4,0)
+mutated: object(0,0), object(4,0)
+gas summary: computation_cost: 1000000, storage_cost: 2249600,  storage_rebate: 2227104, non_refundable_storage_fee: 22496
+
+task 19, lines 105-107:
+//# run test::m::destroy_a --sender A --args object(3,0)
+Error: Transaction Effects Status: Invalid command argument at 0. The type of the value does not match the expected type
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: TypeMismatch }, source: None, command: Some(0) } }
+
+task 20, lines 108-110:
+//# run test::m::destroy_wrapper_u64 --sender A --args object(5,0)
+Error: Transaction Effects Status: Invalid command argument at 0. The type of the value does not match the expected type
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: TypeMismatch }, source: None, command: Some(0) } }
+
+task 21, lines 111-113:
+//# run test::m::destroy_wrapper_bool --sender A --args object(4,0)
+Error: Transaction Effects Status: Invalid command argument at 0. The type of the value does not match the expected type
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: TypeMismatch }, source: None, command: Some(0) } }
+
+task 22, line 114:
+//# run test::m::destroy_a --sender A --args object(2,0)
+mutated: object(0,0)
+deleted: object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 2197008, non_refundable_storage_fee: 22192
+
+task 23, line 116:
+//# run test::m::destroy_wrapper_u64 --sender A --args object(4,0)
+mutated: object(0,0)
+deleted: object(4,0)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 2227104, non_refundable_storage_fee: 22496
+
+task 24, line 118:
+//# run test::m::destroy_wrapper_bool --sender A --args object(5,0)
+mutated: object(0,0)
+deleted: object(5,0)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 2227104, non_refundable_storage_fee: 22496
+
+task 25, line 120:
+//# run test::m::destroy_b --sender A --args object(3,0)
+mutated: object(0,0)
+deleted: object(3,0)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 2197008, non_refundable_storage_fee: 22192

--- a/crates/sui-adapter-transactional-tests/tests/entry_points/type_arg_arity.move
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/type_arg_arity.move
@@ -1,0 +1,35 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Tests function type argument count mismatches
+
+//# init --addresses test=0x0
+
+//# publish
+module test::m;
+
+entry fun no_ty_args() {}
+entry fun one_ty_arg<T>() {}
+entry fun two_ty_args<T, U>() {}
+
+// non-generic function called with type args
+//# run test::m::no_ty_args --type-args u64
+
+// 1 type param, 0 type args
+//# run test::m::one_ty_arg
+
+// 1 type param, 2 type args
+//# run test::m::one_ty_arg --type-args u64 bool
+
+// 2 type params, 1 type arg
+//# run test::m::two_ty_args --type-args u64
+
+// 2 type params, 3 type args
+//# run test::m::two_ty_args --type-args u64 bool u8
+
+// happy paths
+//# run test::m::no_ty_args
+
+//# run test::m::one_ty_arg --type-args u64
+
+//# run test::m::two_ty_args --type-args u64 bool

--- a/crates/sui-adapter-transactional-tests/tests/entry_points/type_arg_arity.snap
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/type_arg_arity.snap
@@ -1,0 +1,51 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+assertion_line: 908
+---
+processed 10 tasks
+
+task 1, lines 8-15:
+//# publish
+created: object(1,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 3830400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 16-18:
+//# run test::m::no_ty_args --type-args u64
+Error: Transaction Effects Status: Move Bytecode Verification Error. Please run the Bytecode Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: VMVerificationOrDeserializationError, source: Some(VMError { major_status: NUMBER_OF_TYPE_ARGUMENTS_MISMATCH, sub_status: None, message: None, exec_state: None, location: Module(ModuleId { address: test, name: Identifier("m") }), indices: [], offsets: [] }), command: Some(0) } }
+
+task 3, lines 19-21:
+//# run test::m::one_ty_arg
+Error: Transaction Effects Status: Move Bytecode Verification Error. Please run the Bytecode Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: VMVerificationOrDeserializationError, source: Some(VMError { major_status: NUMBER_OF_TYPE_ARGUMENTS_MISMATCH, sub_status: None, message: None, exec_state: None, location: Module(ModuleId { address: test, name: Identifier("m") }), indices: [], offsets: [] }), command: Some(0) } }
+
+task 4, lines 22-24:
+//# run test::m::one_ty_arg --type-args u64 bool
+Error: Transaction Effects Status: Move Bytecode Verification Error. Please run the Bytecode Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: VMVerificationOrDeserializationError, source: Some(VMError { major_status: NUMBER_OF_TYPE_ARGUMENTS_MISMATCH, sub_status: None, message: None, exec_state: None, location: Module(ModuleId { address: test, name: Identifier("m") }), indices: [], offsets: [] }), command: Some(0) } }
+
+task 5, lines 25-27:
+//# run test::m::two_ty_args --type-args u64
+Error: Transaction Effects Status: Move Bytecode Verification Error. Please run the Bytecode Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: VMVerificationOrDeserializationError, source: Some(VMError { major_status: NUMBER_OF_TYPE_ARGUMENTS_MISMATCH, sub_status: None, message: None, exec_state: None, location: Module(ModuleId { address: test, name: Identifier("m") }), indices: [], offsets: [] }), command: Some(0) } }
+
+task 6, lines 28-30:
+//# run test::m::two_ty_args --type-args u64 bool u8
+Error: Transaction Effects Status: Move Bytecode Verification Error. Please run the Bytecode Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: VMVerificationOrDeserializationError, source: Some(VMError { major_status: NUMBER_OF_TYPE_ARGUMENTS_MISMATCH, sub_status: None, message: None, exec_state: None, location: Module(ModuleId { address: test, name: Identifier("m") }), indices: [], offsets: [] }), command: Some(0) } }
+
+task 7, line 31:
+//# run test::m::no_ty_args
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 8, line 33:
+//# run test::m::one_ty_arg --type-args u64
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 9, line 35:
+//# run test::m::two_ty_args --type-args u64 bool
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880

--- a/crates/sui-adapter-transactional-tests/tests/entry_points/type_arg_constraints.move
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/type_arg_constraints.move
@@ -1,0 +1,45 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Tests function type parameter ability constraint violations
+
+//# init --addresses test=0x0
+
+//# publish
+module test::m;
+
+public struct NoCopy has drop {}
+public struct NoDrop has copy {}
+public struct NoStore has copy, drop {}
+public struct HasAll has copy, drop, store {}
+
+entry fun needs_copy<T: copy>() {}
+entry fun needs_drop<T: drop>() {}
+entry fun needs_store<T: store>() {}
+entry fun needs_copy_drop<T: copy + drop>() {}
+entry fun needs_copy_drop_store<T: copy + drop + store>() {}
+
+// NoCopy has drop but not copy
+//# run test::m::needs_copy --type-args test::m::NoCopy
+
+// NoDrop has copy but not drop
+//# run test::m::needs_drop --type-args test::m::NoDrop
+
+// NoStore has copy+drop but not store
+//# run test::m::needs_store --type-args test::m::NoStore
+
+// needs_copy_drop: NoCopy missing copy
+//# run test::m::needs_copy_drop --type-args test::m::NoCopy
+
+// needs_copy_drop: NoDrop missing drop
+//# run test::m::needs_copy_drop --type-args test::m::NoDrop
+
+// needs_copy_drop_store: NoStore missing store
+//# run test::m::needs_copy_drop_store --type-args test::m::NoStore
+
+// happy paths
+//# run test::m::needs_copy --type-args u64
+
+//# run test::m::needs_copy_drop --type-args u64
+
+//# run test::m::needs_copy_drop_store --type-args test::m::HasAll

--- a/crates/sui-adapter-transactional-tests/tests/entry_points/type_arg_constraints.snap
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/type_arg_constraints.snap
@@ -1,0 +1,56 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+assertion_line: 908
+---
+processed 11 tasks
+
+task 1, lines 8-22:
+//# publish
+created: object(1,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 6178800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 23-25:
+//# run test::m::needs_copy --type-args test::m::NoCopy
+Error: Transaction Effects Status: Move Bytecode Verification Error. Please run the Bytecode Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: VMVerificationOrDeserializationError, source: Some(VMError { major_status: CONSTRAINT_NOT_SATISFIED, sub_status: None, message: None, exec_state: None, location: Module(ModuleId { address: test, name: Identifier("m") }), indices: [], offsets: [] }), command: Some(0) } }
+
+task 3, lines 26-28:
+//# run test::m::needs_drop --type-args test::m::NoDrop
+Error: Transaction Effects Status: Move Bytecode Verification Error. Please run the Bytecode Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: VMVerificationOrDeserializationError, source: Some(VMError { major_status: CONSTRAINT_NOT_SATISFIED, sub_status: None, message: None, exec_state: None, location: Module(ModuleId { address: test, name: Identifier("m") }), indices: [], offsets: [] }), command: Some(0) } }
+
+task 4, lines 29-31:
+//# run test::m::needs_store --type-args test::m::NoStore
+Error: Transaction Effects Status: Move Bytecode Verification Error. Please run the Bytecode Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: VMVerificationOrDeserializationError, source: Some(VMError { major_status: CONSTRAINT_NOT_SATISFIED, sub_status: None, message: None, exec_state: None, location: Module(ModuleId { address: test, name: Identifier("m") }), indices: [], offsets: [] }), command: Some(0) } }
+
+task 5, lines 32-34:
+//# run test::m::needs_copy_drop --type-args test::m::NoCopy
+Error: Transaction Effects Status: Move Bytecode Verification Error. Please run the Bytecode Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: VMVerificationOrDeserializationError, source: Some(VMError { major_status: CONSTRAINT_NOT_SATISFIED, sub_status: None, message: None, exec_state: None, location: Module(ModuleId { address: test, name: Identifier("m") }), indices: [], offsets: [] }), command: Some(0) } }
+
+task 6, lines 35-37:
+//# run test::m::needs_copy_drop --type-args test::m::NoDrop
+Error: Transaction Effects Status: Move Bytecode Verification Error. Please run the Bytecode Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: VMVerificationOrDeserializationError, source: Some(VMError { major_status: CONSTRAINT_NOT_SATISFIED, sub_status: None, message: None, exec_state: None, location: Module(ModuleId { address: test, name: Identifier("m") }), indices: [], offsets: [] }), command: Some(0) } }
+
+task 7, lines 38-40:
+//# run test::m::needs_copy_drop_store --type-args test::m::NoStore
+Error: Transaction Effects Status: Move Bytecode Verification Error. Please run the Bytecode Verifier for more information.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: VMVerificationOrDeserializationError, source: Some(VMError { major_status: CONSTRAINT_NOT_SATISFIED, sub_status: None, message: None, exec_state: None, location: Module(ModuleId { address: test, name: Identifier("m") }), indices: [], offsets: [] }), command: Some(0) } }
+
+task 8, line 41:
+//# run test::m::needs_copy --type-args u64
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 9, line 43:
+//# run test::m::needs_copy_drop --type-args u64
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 10, line 45:
+//# run test::m::needs_copy_drop_store --type-args test::m::HasAll
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880

--- a/crates/sui-adapter-transactional-tests/tests/entry_points/type_arg_value_mismatch.move
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/type_arg_value_mismatch.move
@@ -1,0 +1,32 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Tests where type instantiation and value BCS encoding are inconsistent
+
+//# init --addresses test=0x0
+
+//# publish
+module test::m;
+
+entry fun take_val<T: copy + drop>(_x: T) {}
+entry fun take_vec<T: copy + drop>(_x: vector<T>) {}
+entry fun take_two<T: copy + drop>(_x: T, _y: T) {}
+
+// T=bool but value is u64
+//# run test::m::take_val --type-args bool --args 42u64
+
+// T=u64 but value is bool
+//# run test::m::take_val --type-args u64 --args true
+
+// T=bool but vector contains u64 elements
+//# run test::m::take_vec --type-args bool --args vector[42u64]
+
+// T=u64, first arg correct, second arg is bool
+//# run test::m::take_two --type-args u64 --args 42u64 true
+
+// happy paths
+//# run test::m::take_val --type-args u64 --args 42u64
+
+//# run test::m::take_vec --type-args u64 --args vector[42u64]
+
+//# run test::m::take_two --type-args u64 --args 42u64 42u64

--- a/crates/sui-adapter-transactional-tests/tests/entry_points/type_arg_value_mismatch.snap
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/type_arg_value_mismatch.snap
@@ -1,0 +1,46 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+assertion_line: 908
+---
+processed 9 tasks
+
+task 1, lines 8-15:
+//# publish
+created: object(1,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 3868400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 16-18:
+//# run test::m::take_val --type-args bool --args 42u64
+Error: Transaction Effects Status: Invalid command argument at 0. The argument cannot be deserialized into a value of the specified type
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidBCSBytes }, source: Some("Function expects bool but provided argument's value does not match"), command: Some(0) } }
+
+task 3, lines 19-21:
+//# run test::m::take_val --type-args u64 --args true
+Error: Transaction Effects Status: Invalid command argument at 0. The argument cannot be deserialized into a value of the specified type
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidBCSBytes }, source: Some("Function expects u64 but provided argument's value does not match"), command: Some(0) } }
+
+task 4, lines 22-24:
+//# run test::m::take_vec --type-args bool --args vector[42u64]
+Error: Transaction Effects Status: Invalid command argument at 0. The argument cannot be deserialized into a value of the specified type
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidBCSBytes }, source: Some("Function expects vector<bool> but provided argument's value does not match"), command: Some(0) } }
+
+task 5, lines 25-27:
+//# run test::m::take_two --type-args u64 --args 42u64 true
+Error: Transaction Effects Status: Invalid command argument at 1. The argument cannot be deserialized into a value of the specified type
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 1, kind: InvalidBCSBytes }, source: Some("Function expects u64 but provided argument's value does not match"), command: Some(0) } }
+
+task 6, line 28:
+//# run test::m::take_val --type-args u64 --args 42u64
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 7, line 30:
+//# run test::m::take_vec --type-args u64 --args vector[42u64]
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 8, line 32:
+//# run test::m::take_two --type-args u64 --args 42u64 42u64
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880

--- a/crates/sui-adapter-transactional-tests/tests/entry_points/value_arg_arity.move
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/value_arg_arity.move
@@ -1,0 +1,29 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Tests value argument count mismatches
+
+//# init --addresses test=0x0
+
+//# publish
+module test::m;
+
+entry fun no_args() {}
+entry fun one_arg(_x: u64) {}
+entry fun two_args(_x: u64, _y: bool) {}
+
+// 0 params, 1 arg
+//# run test::m::no_args --args 42u64
+
+// 1 param, 0 args
+//# run test::m::one_arg
+
+// 2 params, 3 args
+//# run test::m::two_args --args 42u64 true false
+
+// happy paths
+//# run test::m::no_args
+
+//# run test::m::one_arg --args 42u64
+
+//# run test::m::two_args --args 42u64 true

--- a/crates/sui-adapter-transactional-tests/tests/entry_points/value_arg_arity.snap
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/value_arg_arity.snap
@@ -1,0 +1,41 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+assertion_line: 908
+---
+processed 8 tasks
+
+task 1, lines 8-15:
+//# publish
+created: object(1,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 3777200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 16-18:
+//# run test::m::no_args --args 42u64
+Error: Transaction Effects Status: Arity mismatch for Move function. The number of arguments does not match the number of parameters
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ArityMismatch, source: Some("Expected 0 arguments calling function 'test::m::no_args', but found 1"), command: Some(0) } }
+
+task 3, lines 19-21:
+//# run test::m::one_arg
+Error: Transaction Effects Status: Arity mismatch for Move function. The number of arguments does not match the number of parameters
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ArityMismatch, source: Some("Expected 1 argument calling function 'test::m::one_arg', but found 0"), command: Some(0) } }
+
+task 4, lines 22-24:
+//# run test::m::two_args --args 42u64 true false
+Error: Transaction Effects Status: Arity mismatch for Move function. The number of arguments does not match the number of parameters
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: ArityMismatch, source: Some("Expected 2 arguments calling function 'test::m::two_args', but found 3"), command: Some(0) } }
+
+task 5, line 25:
+//# run test::m::no_args
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 6, line 27:
+//# run test::m::one_arg --args 42u64
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 7, line 29:
+//# run test::m::two_args --args 42u64 true
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880

--- a/external-crates/move/crates/move-vm-runtime/src/execution/vm.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/execution/vm.rs
@@ -351,6 +351,28 @@ impl<'extensions> MoveVM<'extensions> {
                     return_type: _,
                 } = self.find_function(original_id, function_name, &type_arguments)?;
 
+                if args.len() != function.to_ref().parameters.len() {
+                    return Err(partial_vm_error!(
+                        NUMBER_OF_ARGUMENTS_MISMATCH,
+                        "argument length mismatch: expected {} got {}",
+                        function.to_ref().parameters.len(),
+                        args.len(),
+                    )
+                    .finish(Location::Module(function.module_id(&self.interner))));
+                }
+
+                // Internal type error if we get here -- `find_function` should have already
+                // verified the type arguments as part of the type resolution that it performs.
+                if type_arguments.len() != function.to_ref().type_parameters().len() {
+                    return Err(partial_vm_error!(
+                        INTERNAL_TYPE_ERROR,
+                        "type argument length mismatch: expected {} got {}.",
+                        function.to_ref().type_parameters().len(),
+                        type_arguments.len(),
+                    )
+                    .finish(Location::Module(function.module_id(&self.interner))));
+                }
+
                 if !bypass_declared_entry_check && !function.to_ref().is_entry {
                     return Err(partial_vm_error!(EXECUTE_ENTRY_FUNCTION_CALLED_ON_NON_ENTRY_FUNCTION)
                     .finish(Location::Module(function.module_id(&self.interner))));

--- a/external-crates/move/crates/move-vm-runtime/src/unit_tests/function_arg_tests.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/unit_tests/function_arg_tests.rs
@@ -7,9 +7,9 @@ use crate::{
         compilation_utils::{as_module, compile_units},
         in_memory_test_adapter::InMemoryTestAdapter,
         storage::StoredPackage,
-        vm_arguments::ValueFrame,
         vm_test_adapter::VMTestAdapter,
     },
+    execution::{interpreter::locals::BaseHeap, values::Value},
     shared::gas::UnmeteredGasMeter,
 };
 use move_binary_format::errors::VMResult;
@@ -17,7 +17,6 @@ use move_core_types::{
     account_address::AccountAddress,
     identifier::Identifier,
     language_storage::{ModuleId, TypeTag},
-    runtime_value::{MoveStruct, MoveValue},
     u256::U256,
     vm_status::StatusCode,
 };
@@ -28,7 +27,7 @@ fn run(
     ty_params: &[&str],
     params: &[&str],
     ty_arg_tags: Vec<TypeTag>,
-    args: Vec<MoveValue>,
+    args: Vec<Value>,
 ) -> VMResult<()> {
     let ty_params = ty_params
         .iter()
@@ -72,31 +71,31 @@ fn run(
         .map(|tag| sess.load_type(&tag))
         .collect::<VMResult<_>>()?;
 
-    ValueFrame::serialized_call(
-        &mut sess,
+    sess.execute_function_bypass_visibility(
         &module_id,
         &fun_name,
         ty_args,
-        args.into_iter()
-            .map(|v| v.simple_serialize().unwrap())
-            .collect(),
+        args,
         &mut UnmeteredGasMeter,
         None,
-        true,
     )?;
 
     Ok(())
 }
 
-fn expect_err(params: &[&str], args: Vec<MoveValue>, expected_status: StatusCode) {
+fn expect_err(params: &[&str], args: Vec<Value>, expected_status: StatusCode) {
     assert!(run(&[], params, vec![], args).unwrap_err().major_status() == expected_status);
+}
+
+fn expect_ok(params: &[&str], args: Vec<Value>) {
+    run(&[], params, vec![], args).unwrap()
 }
 
 fn expect_err_generic(
     ty_params: &[&str],
     params: &[&str],
     ty_args: Vec<TypeTag>,
-    args: Vec<MoveValue>,
+    args: Vec<Value>,
     expected_status: StatusCode,
 ) {
     assert!(
@@ -107,17 +106,14 @@ fn expect_err_generic(
     );
 }
 
-fn expect_ok(params: &[&str], args: Vec<MoveValue>) {
-    run(&[], params, vec![], args).unwrap()
+fn expect_ok_generic(ty_params: &[&str], params: &[&str], ty_args: Vec<TypeTag>, args: Vec<Value>) {
+    run(ty_params, params, ty_args, args).unwrap()
 }
 
-fn expect_ok_generic(
-    ty_params: &[&str],
-    params: &[&str],
-    ty_args: Vec<TypeTag>,
-    args: Vec<MoveValue>,
-) {
-    run(ty_params, params, ty_args, args).unwrap()
+/// Helper: wrap a `Value` in an immutable reference via a `BaseHeap`.
+fn make_ref(heap: &mut BaseHeap, value: Value) -> Value {
+    let (_id, ref_val) = heap.allocate_and_borrow_loc(value).unwrap();
+    ref_val
 }
 
 #[test]
@@ -129,7 +125,7 @@ fn expected_0_args_got_0() {
 fn expected_0_args_got_1() {
     expect_err(
         &[],
-        vec![MoveValue::U64(0)],
+        vec![Value::u64(0)],
         StatusCode::NUMBER_OF_ARGUMENTS_MISMATCH,
     )
 }
@@ -143,7 +139,7 @@ fn expected_1_arg_got_0() {
 fn expected_2_arg_got_1() {
     expect_err(
         &["u64", "bool"],
-        vec![MoveValue::U64(0)],
+        vec![Value::u64(0)],
         StatusCode::NUMBER_OF_ARGUMENTS_MISMATCH,
     )
 }
@@ -152,60 +148,47 @@ fn expected_2_arg_got_1() {
 fn expected_2_arg_got_3() {
     expect_err(
         &["u64", "bool"],
-        vec![
-            MoveValue::U64(0),
-            MoveValue::Bool(true),
-            MoveValue::Bool(false),
-        ],
+        vec![Value::u64(0), Value::bool(true), Value::bool(false)],
         StatusCode::NUMBER_OF_ARGUMENTS_MISMATCH,
     )
 }
 
 #[test]
 fn expected_u64_got_u64() {
-    expect_ok(&["u64"], vec![MoveValue::U64(0)])
+    expect_ok(&["u64"], vec![Value::u64(0)])
 }
 
 #[test]
 #[allow(non_snake_case)]
 fn expected_Foo_got_Foo() {
-    expect_ok(
-        &["Foo"],
-        vec![MoveValue::Struct(MoveStruct::new(vec![MoveValue::U64(0)]))],
-    )
+    expect_ok(&["Foo"], vec![Value::make_struct(vec![Value::u64(0)])])
 }
 
 #[test]
 fn expected_signer_ref_got_signer() {
-    expect_ok(&["&signer"], vec![MoveValue::Signer(TEST_ADDR)])
+    let mut heap = BaseHeap::new();
+    let signer_ref = make_ref(&mut heap, Value::signer(TEST_ADDR));
+    expect_ok(&["&signer"], vec![signer_ref])
 }
 
 #[test]
 fn expected_u64_signer_ref_got_u64_signer() {
-    expect_ok(
-        &["u64", "&signer"],
-        vec![MoveValue::U64(0), MoveValue::Signer(TEST_ADDR)],
-    )
-}
-
-#[test]
-fn expected_u64_got_bool() {
-    expect_err(
-        &["u64"],
-        vec![MoveValue::Bool(false)],
-        StatusCode::FAILED_TO_DESERIALIZE_ARGUMENT,
-    )
+    let mut heap = BaseHeap::new();
+    let signer_ref = make_ref(&mut heap, Value::signer(TEST_ADDR));
+    expect_ok(&["u64", "&signer"], vec![Value::u64(0), signer_ref])
 }
 
 #[test]
 fn param_type_u64_ref() {
-    expect_ok(&["&u64"], vec![MoveValue::U64(0)])
+    let mut heap = BaseHeap::new();
+    let u64_ref = make_ref(&mut heap, Value::u64(0));
+    expect_ok(&["&u64"], vec![u64_ref])
 }
 
 #[test]
 #[allow(non_snake_case)]
 fn expected_T__T_got_u64__u64() {
-    expect_ok_generic(&["T"], &["T"], vec![TypeTag::U64], vec![MoveValue::U64(0)])
+    expect_ok_generic(&["T"], &["T"], vec![TypeTag::U64], vec![Value::u64(0)])
 }
 
 #[test]
@@ -215,11 +198,7 @@ fn expected_A_B__A_u64_vector_B_got_u8_u128__u8_u64_vector_u128() {
         &["A", "B"],
         &["A", "u64", "vector<B>"],
         vec![TypeTag::U8, TypeTag::U128],
-        vec![
-            MoveValue::U8(0),
-            MoveValue::U64(0),
-            MoveValue::Vector(vec![MoveValue::U128(0), MoveValue::U128(0)]),
-        ],
+        vec![Value::u8(0), Value::u64(0), Value::vector_u128(vec![0, 0])],
     )
 }
 
@@ -231,12 +210,9 @@ fn expected_A_B__A_u32_vector_B_got_u16_u256__u16_u32_vector_u256() {
         &["A", "u32", "vector<B>"],
         vec![TypeTag::U16, TypeTag::U256],
         vec![
-            MoveValue::U16(0),
-            MoveValue::U32(0),
-            MoveValue::Vector(vec![
-                MoveValue::U256(U256::from(0u8)),
-                MoveValue::U256(U256::from(0u8)),
-            ]),
+            Value::u16(0),
+            Value::u32(0),
+            Value::vector_u256(vec![U256::from(0u8), U256::from(0u8)]),
         ],
     )
 }
@@ -248,9 +224,7 @@ fn expected_T__Bar_T_got_bool__Bar_bool() {
         &["T"],
         &["Bar<T>"],
         vec![TypeTag::Bool],
-        vec![MoveValue::Struct(MoveStruct::new(vec![MoveValue::Bool(
-            false,
-        )]))],
+        vec![Value::make_struct(vec![Value::bool(false)])],
     )
 }
 
@@ -261,36 +235,69 @@ fn expected_T__T_got_bool__bool() {
         &["T"],
         &["T"],
         vec![TypeTag::Bool],
-        vec![MoveValue::Bool(false)],
-    )
-}
-
-#[test]
-#[allow(non_snake_case)]
-fn expected_T__T_got_bool__u64() {
-    expect_err_generic(
-        &["T"],
-        &["T"],
-        vec![TypeTag::Bool],
-        vec![MoveValue::U64(0)],
-        StatusCode::FAILED_TO_DESERIALIZE_ARGUMENT,
+        vec![Value::bool(false)],
     )
 }
 
 #[test]
 #[allow(non_snake_case)]
 fn expected_T__T_ref_got_u64__u64() {
-    expect_ok_generic(&["T"], &["&T"], vec![TypeTag::U64], vec![MoveValue::U64(0)])
+    let mut heap = BaseHeap::new();
+    let u64_ref = make_ref(&mut heap, Value::u64(0));
+    expect_ok_generic(&["T"], &["&T"], vec![TypeTag::U64], vec![u64_ref])
 }
 
 #[test]
-#[allow(non_snake_case)]
-fn expected_T__Bar_T_got_bool__Bar_u64() {
+fn expected_1_ty_arg_got_0() {
     expect_err_generic(
         &["T"],
-        &["Bar<T>"],
-        vec![TypeTag::Bool],
-        vec![MoveValue::Struct(MoveStruct::new(vec![MoveValue::U64(0)]))],
-        StatusCode::FAILED_TO_DESERIALIZE_ARGUMENT,
+        &["T"],
+        vec![],
+        vec![Value::u64(0)],
+        StatusCode::NUMBER_OF_TYPE_ARGUMENTS_MISMATCH,
+    )
+}
+
+#[test]
+fn expected_1_ty_arg_got_2() {
+    expect_err_generic(
+        &["T"],
+        &["T"],
+        vec![TypeTag::U64, TypeTag::Bool],
+        vec![Value::u64(0)],
+        StatusCode::NUMBER_OF_TYPE_ARGUMENTS_MISMATCH,
+    )
+}
+
+#[test]
+fn expected_0_ty_args_got_1() {
+    expect_err_generic(
+        &[],
+        &["u64"],
+        vec![TypeTag::U64],
+        vec![Value::u64(0)],
+        StatusCode::NUMBER_OF_TYPE_ARGUMENTS_MISMATCH,
+    )
+}
+
+#[test]
+fn expected_2_ty_args_got_1() {
+    expect_err_generic(
+        &["A", "B"],
+        &["A", "B"],
+        vec![TypeTag::U64],
+        vec![Value::u64(0), Value::bool(false)],
+        StatusCode::NUMBER_OF_TYPE_ARGUMENTS_MISMATCH,
+    )
+}
+
+#[test]
+fn expected_2_ty_args_got_3() {
+    expect_err_generic(
+        &["A", "B"],
+        &["A", "B"],
+        vec![TypeTag::U64, TypeTag::Bool, TypeTag::U8],
+        vec![Value::u64(0), Value::bool(false)],
+        StatusCode::NUMBER_OF_TYPE_ARGUMENTS_MISMATCH,
     )
 }


### PR DESCRIPTION
## Description

Cherry-picking out of an abundance of caution, but change doesn't need to be protocol gated as this is already checked and rechecked in multiple places today already. 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
