### PR TITLE
fix(docs): add lines prop support to ImportContent and fix OpenZeppelin code examples

### DIFF
--- a/docs/content/guides/developer/packages/openzeppelin.mdx
+++ b/docs/content/guides/developer/packages/openzeppelin.mdx
@@ -19,6 +19,7 @@ Use the `openzeppelin_math` package when you need arithmetic behavior that is pr
 <ImportContent
 	source="/content/contracts-sui/1.x/math.mdx"
 	mode="code"
+	language="move"
 	org="OpenZeppelin"
 	repo="docs"
 	lines="29-38"
@@ -36,6 +37,7 @@ Use the `openzeppelin_access` package when direct object transfer is too permiss
 <ImportContent
 	source="/content/contracts-sui/1.x/access.mdx"
 	mode="code"
+	language="move"
 	org="OpenZeppelin"
 	repo="docs"
 	lines="31-45"

--- a/docs/site/src/shared/components/ImportContent/index.tsx
+++ b/docs/site/src/shared/components/ImportContent/index.tsx
@@ -125,6 +125,7 @@ type Props = {
   dep?: string;
   test?: string; // target test blocks
   highlight?: string;
+  lines?: string; // line range to extract, e.g. "29-38"
   noComments?: boolean; // if included, remove ALL code comments
   noTests?: boolean; // if included, don't include tests
   noTitle?: boolean;
@@ -155,6 +156,7 @@ export default function ImportContent({
   component,
   test,
   highlight,
+  lines,
   style,
   org,
   repo,
@@ -323,6 +325,18 @@ export default function ImportContent({
       /\[dependencies\]\nsui\s?=\s?{\s?local\s?=.*sui-framework.*\n/i,
       "[dependencies]",
     );
+
+  if (lines) {
+    const parts = lines.split("-").map((n) => parseInt(n, 10));
+    const start = parts[0];
+    const end = parts[1] ?? parts[0];
+    if (!isNaN(start) && !isNaN(end)) {
+      out = out
+        .split("\n")
+        .slice(start - 1, end)
+        .join("\n");
+    }
+  }
 
   if (tag) {
     out = utils.returnTag(out, tag);


### PR DESCRIPTION
## Description
The ImportContent component supports fetching source files from external GitHub repositories and displaying specific code extracts. Two new doc pages for the OpenZeppelin packages use this component with a `lines` prop to extract specific line ranges from MDX documentation files.

## The Problem
`lines` was not a defined prop in ImportContent. The component silently ignored it, fetched the entire MDX file, and rendered it as a raw markdown code block instead of the intended Move code snippet. Additionally, since the source files have a .mdx extension, the component defaulted the syntax highlighting language to "markdown" rather than "move".

## The Fix Applied

- Added lines?: string prop to ImportContent (e.g. "29-38"), applied as a 1-indexed inclusive line slice on the fetched content before any further extraction or comment stripping.
- Added language="move" to both ImportContent usages in openzeppelin.mdx to correctly highlight the extracted Move code regardless of the source file's extension.