### PR TITLE
fix(graphql): fix Display v2 scoping issue

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/objects/display/display_v2_scope.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/objects/display/display_v2_scope.move
@@ -1,0 +1,60 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --accounts A --addresses test=0x0 --simulator --protocol-version 118
+
+//# publish --sender A
+module test::mod {
+  use std::string::String;
+  use sui::display_registry::DisplayCap;
+  use sui::display_registry::DisplayRegistry;
+
+  public struct Foo has key, store {
+    id: UID,
+    bar: Bar,
+  }
+
+  public struct Bar has store {
+    label: String,
+    count: u64,
+  }
+
+  public fun new(label: String, count: u64, ctx: &mut TxContext): Foo {
+    Foo {
+      id: object::new(ctx),
+      bar: Bar { label, count },
+    }
+  }
+
+  public fun display(registry: &mut DisplayRegistry, ctx: &mut TxContext): DisplayCap<Foo> {
+    let (mut display, cap) = registry.new(internal::permit(), ctx);
+    display.set(&cap, "label", "{bar.label}");
+    display.set(&cap, "bar", "{bar:json}");
+    display.share();
+    cap
+  }
+}
+
+//# programmable --sender A --inputs @A "hello" 42u64
+//> 0: test::mod::new(Input(1), Input(2));
+//> 1: TransferObjects([Result(0)], Input(0))
+
+//# programmable --sender A --inputs object(0xd) @A
+//> 0: test::mod::display(Input(0));
+//> 1: TransferObjects([Result(0)], Input(1))
+
+//# create-checkpoint
+
+//# run-graphql
+{
+  object(address: "@{obj_2_0}") {
+    asMoveObject {
+      contents {
+        display {
+          output
+          errors
+        }
+      }
+    }
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/objects/display/display_v2_scope.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/objects/display/display_v2_scope.snap
@@ -1,0 +1,56 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 6 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-36:
+//# publish --sender A
+created: object(1,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 8390400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 38-40:
+//# programmable --sender A --inputs @A "hello" 42u64
+//> 0: test::mod::new(Input(1), Input(2));
+//> 1: TransferObjects([Result(0)], Input(0))
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2333200,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 3, lines 42-44:
+//# programmable --sender A --inputs object(0xd) @A
+//> 0: test::mod::display(Input(0));
+//> 1: TransferObjects([Result(0)], Input(1))
+created: object(3,0), object(3,1), object(3,2)
+mutated: 0x000000000000000000000000000000000000000000000000000000000000000d, object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 8816000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 4, line 46:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 5, lines 48-60:
+//# run-graphql
+Response: {
+  "data": {
+    "object": {
+      "asMoveObject": {
+        "contents": {
+          "display": {
+            "output": {
+              "label": "hello",
+              "bar": {
+                "label": "hello",
+                "count": "42"
+              }
+            },
+            "errors": null
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/sui-indexer-alt-graphql/src/api/types/display.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/display.rs
@@ -58,6 +58,11 @@ pub(crate) async fn display_v2(
     let object_id = display_registry::display_object_id(type_.into())
         .context("Failed to derive Display V2 object ID")?;
 
+    // Display registry objects are global objects, not children of the value being rendered.
+    // Ignore any root-version bound inherited from the value so a newer Display v2 object can
+    // still be resolved for older objects.
+    let scope = scope.without_root_bound();
+
     let Some(object) = Object::latest(ctx, scope, object_id.into()).await? else {
         return Ok(None);
     };


### PR DESCRIPTION
## Description

Fixes an issue where GraphQL would bound the version of the Display v2 format for an object by the version of the type being displayed, which would cause valid Display v2 formats to be discarded.

## Test plan

Introduced a regression test:

```
$ cargo nextest run            \
  -p sui-indexer-alt-e2e-tests \
  --test transactional_tests   \
  -- graphql/objects/display/display_v2_scope
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [x] GraphQL: Bugfix in how GraphQL fetches Display v2 formats
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
