### PR TITLE
display: implicit `:json` transform

### DIFF
--- a/crates/sui-display/src/v2/interpreter.rs
+++ b/crates/sui-display/src/v2/interpreter.rs
@@ -55,17 +55,14 @@ impl<S: V::Store> Interpreter<S> {
                     offset,
                     alternates,
                     transform,
-                }) => {
-                    let transform = transform.unwrap_or_default();
-                    Ok(self
-                        .eval_alts(alternates)
-                        .await?
-                        .map(move |value| V::Strand::Value {
-                            value,
-                            transform,
-                            offset: *offset,
-                        }))
-                }
+                }) => Ok(self
+                    .eval_alts(alternates)
+                    .await?
+                    .map(move |value| V::Strand::Value {
+                        value,
+                        transform: *transform,
+                        offset: *offset,
+                    })),
             }
         }))
         .await

--- a/crates/sui-display/src/v2/mod.rs
+++ b/crates/sui-display/src/v2/mod.rs
@@ -2528,6 +2528,82 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_format_single_bare_expression_falls_back_to_json() {
+        #[derive(serde::Serialize)]
+        enum Status<'s> {
+            Pending(&'s str),
+        }
+
+        let bytes = bcs::to_bytes(&(
+            (42u64, "hello"),
+            Status::Pending("ready"),
+            vec![1u64, 2u64, 3u64],
+        ))
+        .unwrap();
+
+        let layout = struct_(
+            "0x1::m::S",
+            vec![
+                (
+                    "st",
+                    struct_(
+                        "0x1::m::Inner",
+                        vec![
+                            ("count", L::U64),
+                            ("label", L::Struct(Box::new(move_ascii_str_layout()))),
+                        ],
+                    ),
+                ),
+                (
+                    "en",
+                    enum_(
+                        "0x1::m::Status",
+                        vec![(
+                            "Pending",
+                            vec![("message", L::Struct(Box::new(move_ascii_str_layout())))],
+                        )],
+                    ),
+                ),
+                ("vs", vector_(L::U64)),
+            ],
+        );
+
+        let store = MockStore::default();
+        let root = OwnedSlice { bytes, layout };
+        let interpreter = Interpreter::new(root, store);
+
+        let formats = ["{st}", "{en}", "{vs}"];
+        let mut output = Vec::with_capacity(formats.len());
+        for s in formats {
+            let format = Format::parse(Limits::default(), s).unwrap();
+            output.push(
+                format
+                    .format::<serde_json::Value>(&interpreter, usize::MAX, usize::MAX)
+                    .await
+                    .unwrap(),
+            );
+        }
+
+        assert_json_snapshot!(output, @r###"
+        [
+          {
+            "count": "42",
+            "label": "hello"
+          },
+          {
+            "@variant": "Pending",
+            "message": "ready"
+          },
+          [
+            "1",
+            "2",
+            "3"
+          ]
+        ]
+        "###);
+    }
+
+    #[tokio::test]
     async fn test_display_field_errors() {
         let bytes = bcs::to_bytes(&0u8).unwrap();
         let layout = struct_("0x1::m::S", vec![("byte", L::U8)]);

--- a/crates/sui-display/src/v2/parser.rs
+++ b/crates/sui-display/src/v2/parser.rs
@@ -143,13 +143,12 @@ pub enum Fields<'s> {
 }
 
 /// Ways to modify a value before displaying it.
-#[derive(Default, Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 pub enum Transform {
     Base64(Base64Modifier),
     Bcs(Base64Modifier),
     Hex,
     Json,
-    #[default]
     Str,
     Timestamp,
     Url,

--- a/crates/sui-display/src/v2/value.rs
+++ b/crates/sui-display/src/v2/value.rs
@@ -55,7 +55,7 @@ pub enum Strand<'s> {
     Value {
         offset: usize,
         value: Value<'s>,
-        transform: Transform,
+        transform: Option<Transform>,
     },
 }
 
@@ -343,7 +343,10 @@ impl Atom<'_> {
     }
 
     /// Format the atom as a string.
-    fn format_as_str(&self, w: &mut writer::StringWriter<'_>) -> Result<(), FormatError> {
+    pub(crate) fn format_as_str(
+        &self,
+        w: &mut writer::StringWriter<'_>,
+    ) -> Result<(), FormatError> {
         match self {
             Atom::Address(a) => write!(w, "{}", a.to_canonical_display(true))?,
             Atom::Bool(b) => write!(w, "{b}")?,

--- a/crates/sui-display/src/v2/writer.rs
+++ b/crates/sui-display/src/v2/writer.rs
@@ -97,15 +97,34 @@ pub(crate) fn write<F: RV::Format>(
     meter: Meter<'_>,
     mut strands: Vec<V::Strand<'_>>,
 ) -> Result<F, FormatError> {
-    if matches!(&strands[..], [V::Strand::Value { transform, .. }] if *transform == Transform::Json)
-    {
-        let V::Strand::Value { offset, value, .. } = strands.pop().unwrap() else {
+    if matches!(
+        &strands[..],
+        [V::Strand::Value {
+            transform: None | Some(Transform::Json),
+            ..
+        }]
+    ) {
+        let V::Strand::Value {
+            offset,
+            value,
+            transform,
+        } = strands.pop().unwrap()
+        else {
             unreachable!();
         };
 
-        return value
-            .format_json(meter)
-            .map_err(|e| e.for_expr_at_offset(offset));
+        return if transform.is_none()
+            && let Ok(atom) = V::Atom::try_from(value.clone())
+        {
+            let mut writer = StringWriter::new(meter);
+            atom.format_as_str(&mut writer)
+                .map_err(|e| e.for_expr_at_offset(offset))?;
+            Ok(writer.finish())
+        } else {
+            value
+                .format_json(meter)
+                .map_err(|e| e.for_expr_at_offset(offset))
+        };
     }
 
     let mut writer = StringWriter::new(meter);
@@ -120,7 +139,7 @@ pub(crate) fn write<F: RV::Format>(
                 value,
                 transform,
             } => value
-                .format(transform, &mut writer)
+                .format(transform.unwrap_or(Transform::Str), &mut writer)
                 .map_err(|e| e.for_expr_at_offset(offset))?,
         }
     }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/objects/display/display_v2_bare_expr.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/objects/display/display_v2_bare_expr.move
@@ -1,0 +1,76 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --accounts A --addresses test=0x0 --simulator --protocol-version 118
+
+//# publish --sender A
+module test::mod {
+  use std::string::String;
+  use sui::display_registry::DisplayCap;
+  use sui::display_registry::DisplayRegistry;
+
+  public enum Status has copy, drop, store {
+    Pending { message: String },
+  }
+
+  public struct Inner has copy, drop, store {
+    count: u64,
+    label: String,
+  }
+
+  public struct Foo has key, store {
+    id: UID,
+    label: String,
+    inner: Inner,
+    status: Status,
+    nums: vector<u64>,
+  }
+
+  public fun display(registry: &mut DisplayRegistry, ctx: &mut TxContext): DisplayCap<Foo> {
+    let (mut display, cap) = registry.new(internal::permit(), ctx);
+    display.set(&cap, "label_implicit", "{label}");
+    display.set(&cap, "inner_implicit", "{inner}");
+    display.set(&cap, "status_implicit", "{status}");
+    display.set(&cap, "nums_implicit", "{nums}");
+    display.set(&cap, "inner_json", "{inner:json}");
+    display.share();
+    cap
+  }
+
+  public fun new(ctx: &mut TxContext): Foo {
+    Foo {
+      id: object::new(ctx),
+      label: b"hello".to_string(),
+      inner: Inner {
+        count: 42,
+        label: b"inside".to_string(),
+      },
+      status: Status::Pending { message: b"ready".to_string() },
+      nums: vector[1, 2, 3],
+    }
+  }
+}
+
+//# programmable --sender A --inputs object(0xd) @A
+//> 0: test::mod::display(Input(0));
+//> 1: TransferObjects([Result(0)], Input(1))
+
+//# programmable --sender A --inputs @A
+//> 0: test::mod::new();
+//> 1: TransferObjects([Result(0)], Input(0))
+
+//# create-checkpoint
+
+//# run-graphql
+{
+  object(address: "@{obj_3_0}") {
+    asMoveObject {
+      contents {
+        display {
+          output
+          errors
+        }
+      }
+    }
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/objects/display/display_v2_bare_expr.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/objects/display/display_v2_bare_expr.snap
@@ -1,0 +1,69 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 6 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-52:
+//# publish --sender A
+created: object(1,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 10883200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 54-56:
+//# programmable --sender A --inputs object(0xd) @A
+//> 0: test::mod::display(Input(0));
+//> 1: TransferObjects([Result(0)], Input(1))
+created: object(2,0), object(2,1), object(2,2)
+mutated: 0x000000000000000000000000000000000000000000000000000000000000000d, object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 9446800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 3, lines 58-60:
+//# programmable --sender A --inputs @A
+//> 0: test::mod::new();
+//> 1: TransferObjects([Result(0)], Input(0))
+created: object(3,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2629600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 4, line 62:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 5, lines 64-76:
+//# run-graphql
+Response: {
+  "data": {
+    "object": {
+      "asMoveObject": {
+        "contents": {
+          "display": {
+            "output": {
+              "label_implicit": "hello",
+              "inner_implicit": {
+                "count": "42",
+                "label": "inside"
+              },
+              "status_implicit": {
+                "@variant": "Pending",
+                "message": "ready"
+              },
+              "nums_implicit": [
+                "1",
+                "2",
+                "3"
+              ],
+              "inner_json": {
+                "count": "42",
+                "label": "inside"
+              }
+            },
+            "errors": null
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description

Make it so that if a format string contains just `"{...}"` with no transform, and the expression evaluates to some kind of aggregate (struct, enum, vector), then we implicitly apply the `:json` transform to it, rather than the `:str` transform.

## Test plan

New unit test for implicit JSON, and a new GraphQL E2E test:

```
$ cargo nextest run -p sui-display -- test_format_single_bare_expression_falls_back_to_json
$ cargo nextest run -p sui-indexer-alt-e2e-tests -- test_display_v2_bare_expr
```

## Stack

- #26061 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [x] gRPC: Display v2: Implicitly format fields using the `json` transform, if the `str` transform would not work for them.
- [x] JSON-RPC: Display v2: Implicitly format fields using the `json` transform, if the `str` transform would not work for them.
- [x] GraphQL: Display v2: Implicitly format fields using the `json` transform, if the `str` transform would not work for them.
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
