### PR TITLE
fix(simtest): wait for tx settlement in party_object_read test

### DIFF
--- a/crates/sui-e2e-tests/tests/party_objects_tests.rs
+++ b/crates/sui-e2e-tests/tests/party_objects_tests.rs
@@ -520,6 +520,13 @@ async fn party_object_read() {
         .expect("Party object should be mutated");
     object_initial_shared_version = mutated_party.1.start_version().unwrap();
 
+    // Wait for the transfer to settle across the cluster before issuing reads with the
+    // new initial_shared_version. Without this, submit_and_execute may route the next
+    // read to a validator that hasn't executed the transfer yet, causing ObjectNotFound.
+    test_cluster
+        .wait_for_tx_settlement(&[*signed_transfer.digest()])
+        .await;
+
     // Make some more transactions that read the party object from the new owner.
     for gas_coin in gas_coins_account2.iter().take(num_reads / 2) {
         let transaction = test_cluster


### PR DESCRIPTION
After transferring a party object to a new ConsensusAddressOwner, the test immediately issues read transactions using the new initial_shared_version. Since submit_and_execute routes to a random validator, the read may hit a validator that hasn't executed the transfer yet, causing ObjectNotFound (version: None).

Fix by calling wait_for_tx_settlement after the transfer to ensure the transaction is checkpointed and propagated cluster-wide before issuing reads with the new shared version.

Repro seed: MSIM_TEST_SEED=12090938599566214721

## Description 

Describe the changes or additions included in this PR.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
