### PR TITLE
sui-rpc-api: cap the number of signatures in execute transaction

### DIFF
--- a/crates/sui-e2e-tests/tests/rpc/v2/transaction_execution_service/mod.rs
+++ b/crates/sui-e2e-tests/tests/rpc/v2/transaction_execution_service/mod.rs
@@ -174,6 +174,53 @@ async fn execute_transaction_publish_with_event_json() {
     );
 }
 
+#[sim_test]
+async fn execute_transaction_too_many_signatures() {
+    let test_cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
+        .build()
+        .await;
+
+    let mut client = TransactionExecutionServiceClient::new(test_cluster.grpc_channel());
+
+    let txn =
+        make_transfer_sui_transaction(&test_cluster.wallet, Some(SuiAddress::ZERO), None).await;
+
+    let signatures: Vec<UserSignature> = txn
+        .tx_signatures()
+        .iter()
+        .map(|s| {
+            let mut message = UserSignature::default();
+            message.bcs = Some(Bcs::from(s.as_ref().to_owned()));
+            message
+        })
+        .collect();
+
+    // Provide 3 copies of the signature to exceed the limit of 2.
+    let too_many_signatures = vec![signatures[0].clone(); 3];
+
+    let error = client
+        .execute_transaction({
+            let mut message = ExecuteTransactionRequest::default();
+            message.transaction = Some({
+                let mut message = Transaction::default();
+                message.bcs = Some(Bcs::serialize(txn.transaction_data()).unwrap());
+                message
+            });
+            message.signatures = too_many_signatures;
+            message
+        })
+        .await
+        .unwrap_err();
+
+    assert_eq!(error.code(), tonic::Code::InvalidArgument);
+    assert!(
+        error.message().contains("exceeds the maximum allowed"),
+        "unexpected error message: {}",
+        error.message()
+    );
+}
+
 /// Test that object JSON is rendered correctly for objects created by a newly published package.
 ///
 /// This is a regression test for a bug where object JSON rendering would fail with a LINKER_ERROR

--- a/crates/sui-rpc-api/src/grpc/v2/transaction_execution_service/mod.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/transaction_execution_service/mod.rs
@@ -52,6 +52,9 @@ impl TransactionExecutionService for RpcService {
 }
 
 pub const EXECUTE_TRANSACTION_READ_MASK_DEFAULT: &str = "effects";
+// Current maximum number of supported UserSignature's,
+// one for the sender and one for an optional sponsor
+const MAX_NUMBER_OF_SIGNATURES: usize = 2;
 
 #[tracing::instrument(skip(service, executor))]
 pub async fn execute_transaction(
@@ -69,6 +72,17 @@ pub async fn execute_transaction(
                 .with_description(format!("invalid transaction: {e}"))
                 .with_reason(ErrorReason::FieldInvalid)
         })?;
+
+    if request.signatures.len() > MAX_NUMBER_OF_SIGNATURES {
+        return Err(FieldViolation::new("signatures")
+            .with_description(format!(
+                "{} provided signatures exceeds the maximum allowed of {}",
+                request.signatures.len(),
+                MAX_NUMBER_OF_SIGNATURES
+            ))
+            .with_reason(ErrorReason::FieldInvalid)
+            .into());
+    }
 
     let signatures = request
         .signatures


### PR DESCRIPTION
Previously, the gRPC execute_transaction endpoint accepted an unbounded number of `UserSignature`s. Since a transaction can only have a sender and an optional sponsor, more than two signatures are never valid. With this commit, requests with more than two signatures are rejected early with an `InvalidArgument` error.

## Description 

Describe the changes or additions included in this PR.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
