### PR TITLE
ci: add cargo problem matcher for structured build error annotations

### DIFF
--- a/.github/matchers/cargo.json
+++ b/.github/matchers/cargo.json
@@ -1,0 +1,41 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "cargo-error",
+      "severity": "error",
+      "pattern": [
+        {
+          "regexp": "^error(\\[E\\d+\\])?:\\s+(.+)$",
+          "message": 2,
+          "code": 1
+        },
+        {
+          "regexp": "^\\s+-->\\s+(.+):(\\d+):(\\d+)$",
+          "file": 1,
+          "line": 2,
+          "column": 3
+        }
+      ]
+    },
+    {
+      "owner": "cargo-could-not-compile",
+      "severity": "error",
+      "pattern": [
+        {
+          "regexp": "^error: could not compile `(.+)`",
+          "message": 0
+        }
+      ]
+    },
+    {
+      "owner": "cargo-linker",
+      "severity": "error",
+      "pattern": [
+        {
+          "regexp": "^error: linking with `.+` failed",
+          "message": 0
+        }
+      ]
+    }
+  ]
+}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -38,6 +38,8 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           key-prefix: ubuntu-ghcloud
+      - name: Register cargo problem matcher
+        run: echo "::add-matcher::.github/matchers/cargo.json"
       - name: cargo build
         run: cargo build --all-targets --all-features --release
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,6 +173,9 @@ jobs:
         shell: bash
         run: echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
 
+      - name: Register cargo problem matcher
+        run: echo "::add-matcher::.github/matchers/cargo.json"
+
       - name: Cargo build for ${{ matrix.os }} platform
         if: ${{ env.s3_existing_archive == '' }}
         shell: bash

--- a/.github/workflows/sccache-warmup.yml
+++ b/.github/workflows/sccache-warmup.yml
@@ -93,6 +93,9 @@ jobs:
 
       - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # pin@v0.0.9
 
+      - name: Register cargo problem matcher
+        run: echo "::add-matcher::.github/matchers/cargo.json"
+
       # All platforms: release builds (matches release.yml)
       - name: Build release binaries
         shell: bash


### PR DESCRIPTION
## Summary
- Add `.github/matchers/cargo.json` with Rust problem matcher patterns for compiler errors (`error[E...]` with file:line:col), `could not compile`, and linker errors
- Register the matcher in `nightly.yml`, `sccache-warmup.yml`, and `release.yml` before cargo build steps

When registered, GitHub Actions automatically converts matching log output into structured annotations with file path, line number, column, and error message. These annotations are queryable via the Check Runs API (`/check-runs/{id}/annotations`), enabling the sui-operations `triage-analyze` action to extract structured error data without log scraping.

**Companion PR:** MystenLabs/sui-operations#7525 (upgrades triage-analyze to prefer rich annotations from problem matchers)

## Test plan
- [x] Problem matcher JSON validates against the [GitHub Actions problem matcher schema](https://github.com/actions/toolkit/blob/main/docs/problem-matchers.md)
- [x] Regex patterns tested against sample Rust compiler output: `error[E0425]: cannot find value 'x'` + `  --> src/foo.rs:42:5`
- [x] Matcher registration is before all cargo build steps in each workflow
- [x] No functional change to build commands — only adds annotation capture

🤖 Generated with [Claude Code](https://claude.com/claude-code)