### PR TITLE
rpc-visitor: unwrap `TypeName`

### DIFF
--- a/crates/sui-display/src/v2/value.rs
+++ b/crates/sui-display/src/v2/value.rs
@@ -23,6 +23,7 @@ use sui_types::base_types::RESOLVED_UTF8_STR;
 use sui_types::base_types::SuiAddress;
 use sui_types::base_types::move_ascii_str_layout;
 use sui_types::base_types::move_utf8_str_layout;
+use sui_types::base_types::type_name_layout;
 use sui_types::base_types::url_layout;
 use sui_types::derived_object::derive_object_id;
 use sui_types::dynamic_field::DynamicFieldInfo;
@@ -807,6 +808,7 @@ impl<'s> TryFrom<Value<'s>> for Atom<'s> {
                     if [
                         move_ascii_str_layout(),
                         move_utf8_str_layout(),
+                        type_name_layout(),
                         url_layout(),
                     ]
                     .contains(layout.as_ref()) =>
@@ -1362,9 +1364,11 @@ pub(crate) mod tests {
         let u256_bytes = bcs::to_bytes(&U256::from(42u64)).unwrap();
         let addr_bytes = bcs::to_bytes(&AccountAddress::from_str("0x42").unwrap()).unwrap();
         let str_bytes = bcs::to_bytes("hello").unwrap();
+        let type_name_bytes = bcs::to_bytes("0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>").unwrap();
         let vec_bytes = bcs::to_bytes(&vec![1u8, 2, 3]).unwrap();
 
         let str_layout = L::Struct(Box::new(move_utf8_str_layout()));
+        let type_name_layout = L::Struct(Box::new(type_name_layout()));
         let vec_layout = L::Vector(Box::new(L::U8));
 
         let values = vec![
@@ -1405,6 +1409,10 @@ pub(crate) mod tests {
                 bytes: &str_bytes,
             }),
             Value::Slice(Slice {
+                layout: &type_name_layout,
+                bytes: &type_name_bytes,
+            }),
+            Value::Slice(Slice {
                 layout: &vec_layout,
                 bytes: &vec_bytes,
             }),
@@ -1420,6 +1428,7 @@ pub(crate) mod tests {
             Atom::U256(U256::from(42u64)),
             Atom::Address(AccountAddress::from_str("0x42").unwrap()),
             Atom::Bytes(Cow::Borrowed("hello".as_bytes())),
+            Atom::Bytes(Cow::Borrowed("0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>".as_bytes())),
             Atom::Bytes(Cow::Borrowed(&[1, 2, 3])),
         ];
 

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/objects/display/type_name.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/objects/display/type_name.move
@@ -1,0 +1,40 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --accounts A --addresses test=0x0 --simulator --protocol-version 118
+
+//# publish --sender A
+module test::mod {
+  use std::type_name::{Self, TypeName};
+
+  public struct Foo has key, store {
+    id: UID,
+    tn: TypeName,
+  }
+
+  public fun new(ctx: &mut TxContext): Foo {
+    Foo {
+      id: object::new(ctx),
+      tn: type_name::with_original_ids<vector<Foo>>(),
+    }
+  }
+}
+
+//# programmable --sender A --inputs @A
+//> 0: test::mod::new();
+//> 1: TransferObjects([Result(0)], Input(0))
+
+//# create-checkpoint
+
+//# run-graphql
+{
+  object(address: "@{obj_2_0}") {
+    asMoveObject {
+      contents {
+        json
+        typeAsJson: format(format: "{tn:json}")
+        typeAsStr: format(format: "{tn}")
+      }
+    }
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/objects/display/type_name.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/objects/display/type_name.snap
@@ -1,0 +1,44 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 5 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-21:
+//# publish --sender A
+created: object(1,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 5403600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 23-25:
+//# programmable --sender A --inputs @A
+//> 0: test::mod::new();
+//> 1: TransferObjects([Result(0)], Input(0))
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2857600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 3, line 27:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 4, lines 29-40:
+//# run-graphql
+Response: {
+  "data": {
+    "object": {
+      "asMoveObject": {
+        "contents": {
+          "json": {
+            "id": "0xdf243002c0e2a03803b05b0591f4afbefad01cd45a565c784e9a8f9b8a26d8ec",
+            "tn": "vector<877b45a9854b1b058b4c04792c2d2aa2df7a13065283b14050074ce2cdfff0bf::mod::Foo>"
+          },
+          "typeAsJson": "vector<877b45a9854b1b058b4c04792c2d2aa2df7a13065283b14050074ce2cdfff0bf::mod::Foo>",
+          "typeAsStr": "vector<877b45a9854b1b058b4c04792c2d2aa2df7a13065283b14050074ce2cdfff0bf::mod::Foo>"
+        }
+      }
+    }
+  }
+}

--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -1116,6 +1116,14 @@ pub const RESOLVED_UTF8_STR: (&AccountAddress, &IdentStr, &IdentStr) = (
     STD_UTF8_STRUCT_NAME,
 );
 
+pub const STD_TYPE_NAME_MODULE_NAME: &IdentStr = ident_str!("type_name");
+pub const STD_TYPE_NAME_STRUCT_NAME: &IdentStr = ident_str!("TypeName");
+pub const RESOLVED_STD_TYPE_NAME: (&AccountAddress, &IdentStr, &IdentStr) = (
+    &MOVE_STDLIB_ADDRESS,
+    STD_TYPE_NAME_MODULE_NAME,
+    STD_TYPE_NAME_STRUCT_NAME,
+);
+
 pub const TX_CONTEXT_MODULE_NAME: &IdentStr = ident_str!("tx_context");
 pub const TX_CONTEXT_STRUCT_NAME: &IdentStr = ident_str!("TxContext");
 pub const RESOLVED_TX_CONTEXT: (&AccountAddress, &IdentStr, &IdentStr) = (
@@ -1171,6 +1179,21 @@ pub fn url_layout() -> A::MoveStructLayout {
         },
         fields: vec![A::MoveFieldLayout::new(
             ident_str!("url").to_owned(),
+            A::MoveTypeLayout::Struct(Box::new(move_ascii_str_layout())),
+        )],
+    }
+}
+
+pub fn type_name_layout() -> A::MoveStructLayout {
+    A::MoveStructLayout {
+        type_: StructTag {
+            address: MOVE_STDLIB_ADDRESS,
+            module: STD_TYPE_NAME_MODULE_NAME.to_owned(),
+            name: STD_TYPE_NAME_STRUCT_NAME.to_owned(),
+            type_params: vec![],
+        },
+        fields: vec![A::MoveFieldLayout::new(
+            ident_str!("name").into(),
             A::MoveTypeLayout::Struct(Box::new(move_ascii_str_layout())),
         )],
     }

--- a/crates/sui-types/src/object/rpc_visitor/mod.rs
+++ b/crates/sui-types/src/object/rpc_visitor/mod.rs
@@ -23,6 +23,7 @@ use crate::balance::Balance;
 use crate::base_types::RESOLVED_STD_OPTION;
 use crate::base_types::move_ascii_str_layout;
 use crate::base_types::move_utf8_str_layout;
+use crate::base_types::type_name_layout;
 use crate::base_types::url_layout;
 use crate::id::ID;
 use crate::id::UID;
@@ -180,9 +181,10 @@ impl<'b, 'l, F: Format, M: Meter> AV::Visitor<'b, 'l> for RpcVisitor<F, M> {
 
         if layout == &move_ascii_str_layout()
             || layout == &move_utf8_str_layout()
+            || layout == &type_name_layout()
             || layout == &url_layout()
         {
-            // 0x1::ascii::String or 0x1::string::String or 0x2::url::Url
+            // 0x1::ascii::String or 0x1::string::String or 0x1::type_name::TypeName or 0x2::url::Url
 
             let lo = driver.position();
             driver.skip_field()?;
@@ -368,9 +370,7 @@ mod tests {
 
     #[test]
     fn json_ascii_string() {
-        let l = struct_!("0x1::ascii::String" {
-            "bytes": vector_!(L::U8)
-        });
+        let l = A::MoveTypeLayout::Struct(Box::new(move_ascii_str_layout()));
         let actual = json(l, "The quick brown fox");
         let expect = json!("The quick brown fox");
         assert_eq!(expect, actual);
@@ -378,21 +378,28 @@ mod tests {
 
     #[test]
     fn json_utf8_string() {
-        let l = struct_!("0x1::string::String" {
-            "bytes": vector_!(L::U8)
-        });
+        let l = A::MoveTypeLayout::Struct(Box::new(move_utf8_str_layout()));
         let actual = json(l, "The quick brown fox");
         let expect = json!("The quick brown fox");
         assert_eq!(expect, actual);
     }
 
     #[test]
+    fn json_type_name() {
+        let l = A::MoveTypeLayout::Struct(Box::new(type_name_layout()));
+        let actual = json(
+            l,
+            "0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>",
+        );
+        let expect = json!(
+            "0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+        );
+        assert_eq!(expect, actual);
+    }
+
+    #[test]
     fn json_url() {
-        let l = struct_!("0x2::url::Url" {
-            "url": struct_!("0x1::ascii::String" {
-                "bytes": vector_!(L::U8)
-            })
-        });
+        let l = A::MoveTypeLayout::Struct(Box::new(url_layout()));
         let actual = json(l, "https://example.com");
         let expect = json!("https://example.com");
         assert_eq!(expect, actual);


### PR DESCRIPTION
## Description

Detect `0x1::type_name::TypeName` as a special case, for representing Move Values in RPCs (gRPC, GraphQL, Display), unwrapping it to be represented as just its inner string.

Note that for historical reasons, `TypeName` does not introduce a leading `0x` for hexadecimal addresses.

## Test plan

New unit tests:

```
$ cargo nextest run -p sui-display -p sui-types
```

New E2E test in GraphQL:

```
$ cargo nextest run            \
  -p sui-indexer-alt-e2e-tests \
  --test transactional_tests   \
  -- test_graphql_display_type_name
```

## Stack

- #26061 
- #26062 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [x] gRPC: When `0x1::type_name::TypeName` Move values show up in structured outputs, it will show up as a simple string representation of the type, rather than an object with a `name` field.
- [x] JSON-RPC: When `0x1::type_name::TypeName` Move values show up in structured outputs, it will show up as a simple string representation of the type, rather than an object with a `name` field.
- [x] GraphQL: When `0x1::type_name::TypeName` Move values show up in structured outputs, it will show up as a simple string representation of the type, rather than an object with a `name` field.
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
