### PR TITLE
[autodebug] Fix party_object_read flaky simtest

### DIFF
--- a/crates/sui-e2e-tests/tests/party_objects_tests.rs
+++ b/crates/sui-e2e-tests/tests/party_objects_tests.rs
@@ -510,7 +510,8 @@ async fn party_object_read() {
         .submit_and_execute(signed_transfer.clone(), None)
         .await
         .unwrap();
-    all_digests.push(*signed_transfer.digest());
+    let transfer_digest = *signed_transfer.digest();
+    all_digests.push(transfer_digest);
 
     // Find the party object in the mutated objects and get its new start version
     let mutated_party = transfer_effects
@@ -519,6 +520,20 @@ async fn party_object_read() {
         .find(|obj| matches!(obj.1, Owner::ConsensusAddressOwner { .. }))
         .expect("Party object should be mutated");
     object_initial_shared_version = mutated_party.1.start_version().unwrap();
+
+    // Wait for all validators to execute the transfer before submitting reads with the
+    // new initial_shared_version. Without this, a validator that hasn't processed the
+    // transfer yet will reject the read (full_id mismatch on start_version).
+    for handle in test_cluster.all_node_handles() {
+        handle
+            .with_async(|node| async move {
+                node.state()
+                    .get_transaction_cache_reader()
+                    .notify_read_executed_effects("", &[transfer_digest])
+                    .await;
+            })
+            .await;
+    }
 
     // Make some more transactions that read the party object from the new owner.
     for gas_coin in gas_coins_account2.iter().take(num_reads / 2) {


### PR DESCRIPTION
## Summary

Fix flaky `party_object_read` simtest failure (1/200 seed failure rate).

**Root cause:** After transferring a party object, the test immediately submits read transactions using the new `initial_shared_version`. `submit_and_execute` picks a random validator — if that validator hasn't yet executed the transfer, its cache still has the old `start_version`, causing a `full_id` mismatch (`SequenceNumber(2)` vs `SequenceNumber(3)`) and `ObjectNotFound` rejection.

**Fix:** Wait for all validators to execute the transfer transaction before issuing reads with the new `initial_shared_version`.

- Failing CI run: https://github.com/MystenLabs/sui/actions/runs/23790030067
- Local failing seed: `1774978096117`
- Seed search after fix: 200/200 passed