### PR TITLE
sui-indexer-alt-framework: reduce copied and pasted test code

### DIFF
--- a/crates/sui-indexer-alt-framework/src/lib.rs
+++ b/crates/sui-indexer-alt-framework/src/lib.rs
@@ -602,6 +602,93 @@ mod tests {
     test_pipeline!(SequentialHandler, "sequential_handler");
     test_pipeline!(MockCheckpointSequenceNumberHandler, "test");
 
+    /// If `ingestion_data` is `Some((num_checkpoints, checkpoint_size))`, synthetic ingestion
+    /// data will be generated in the temp directory before creating the indexer.
+    async fn create_test_indexer(
+        store: MockStore,
+        indexer_args: IndexerArgs,
+        registry: &Registry,
+        ingestion_data: Option<(u64, u64)>,
+    ) -> (Indexer<MockStore>, tempfile::TempDir) {
+        let temp_dir = tempfile::tempdir().unwrap();
+        if let Some((num_checkpoints, checkpoint_size)) = ingestion_data {
+            synthetic_ingestion::generate_ingestion(synthetic_ingestion::Config {
+                ingestion_dir: temp_dir.path().to_owned(),
+                starting_checkpoint: 0,
+                num_checkpoints,
+                checkpoint_size,
+            })
+            .await;
+        }
+        let client_args = ClientArgs {
+            ingestion: IngestionClientArgs {
+                local_ingestion_path: Some(temp_dir.path().to_owned()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let indexer = Indexer::new(
+            store,
+            indexer_args,
+            client_args,
+            IngestionConfig::default(),
+            None,
+            registry,
+        )
+        .await
+        .unwrap();
+        (indexer, temp_dir)
+    }
+
+    async fn set_committer_watermark(
+        conn: &mut <MockStore as Store>::Connection<'_>,
+        name: &str,
+        hi: u64,
+    ) {
+        conn.set_committer_watermark(
+            name,
+            CommitterWatermark {
+                checkpoint_hi_inclusive: hi,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+    }
+
+    async fn add_concurrent<H: concurrent::Handler<Store = MockStore>>(
+        indexer: &mut Indexer<MockStore>,
+        handler: H,
+    ) {
+        indexer
+            .concurrent_pipeline(handler, ConcurrentConfig::default())
+            .await
+            .unwrap();
+    }
+
+    async fn add_sequential<H: sequential::Handler<Store = MockStore>>(
+        indexer: &mut Indexer<MockStore>,
+        handler: H,
+    ) {
+        indexer
+            .sequential_pipeline(handler, SequentialConfig::default())
+            .await
+            .unwrap();
+    }
+
+    macro_rules! assert_out_of_order {
+        ($metrics:expr, $pipeline:expr, $expected:expr) => {
+            assert_eq!(
+                $metrics
+                    .total_watermarks_out_of_order
+                    .get_metric_with_label_values(&[$pipeline])
+                    .unwrap()
+                    .get(),
+                $expected,
+            );
+        };
+    }
+
     async fn test_init_watermark(
         first_checkpoint: Option<u64>,
         is_concurrent: bool,
@@ -617,37 +704,13 @@ mod tests {
             first_checkpoint,
             ..IndexerArgs::default()
         };
-        let temp_dir = tempfile::tempdir().unwrap();
-        let client_args = ClientArgs {
-            ingestion: IngestionClientArgs {
-                local_ingestion_path: Some(temp_dir.path().to_owned()),
-                ..Default::default()
-            },
-            ..Default::default()
-        };
-        let ingestion_config = IngestionConfig::default();
-
-        let mut indexer = Indexer::new(
-            store.clone(),
-            indexer_args,
-            client_args,
-            ingestion_config,
-            None,
-            &registry,
-        )
-        .await
-        .unwrap();
+        let (mut indexer, _temp_dir) =
+            create_test_indexer(store.clone(), indexer_args, &registry, None).await;
 
         if is_concurrent {
-            indexer
-                .concurrent_pipeline::<A>(A, ConcurrentConfig::default())
-                .await
-                .unwrap();
+            add_concurrent(&mut indexer, A).await;
         } else {
-            indexer
-                .sequential_pipeline::<A>(A, SequentialConfig::default())
-                .await
-                .unwrap();
+            add_sequential(&mut indexer, A).await;
         }
 
         (
@@ -704,87 +767,24 @@ mod tests {
         let mut conn = store.connect().await.unwrap();
 
         conn.init_watermark(A::NAME, Some(0)).await.unwrap();
-        conn.set_committer_watermark(
-            A::NAME,
-            CommitterWatermark {
-                checkpoint_hi_inclusive: 100,
-                ..Default::default()
-            },
-        )
-        .await
-        .unwrap();
+        set_committer_watermark(&mut conn, A::NAME, 100).await;
 
         conn.init_watermark(B::NAME, Some(0)).await.unwrap();
-        conn.set_committer_watermark(
-            B::NAME,
-            CommitterWatermark {
-                checkpoint_hi_inclusive: 10,
-                ..Default::default()
-            },
-        )
-        .await
-        .unwrap();
+        set_committer_watermark(&mut conn, B::NAME, 10).await;
 
         conn.init_watermark(C::NAME, Some(0)).await.unwrap();
-        conn.set_committer_watermark(
-            C::NAME,
-            CommitterWatermark {
-                checkpoint_hi_inclusive: 1,
-                ..Default::default()
-            },
-        )
-        .await
-        .unwrap();
+        set_committer_watermark(&mut conn, C::NAME, 1).await;
 
         conn.init_watermark(D::NAME, Some(0)).await.unwrap();
-        conn.set_committer_watermark(
-            D::NAME,
-            CommitterWatermark {
-                checkpoint_hi_inclusive: 50,
-                ..Default::default()
-            },
-        )
-        .await
-        .unwrap();
+        set_committer_watermark(&mut conn, D::NAME, 50).await;
 
-        let indexer_args = IndexerArgs::default();
-        let temp_dir = tempfile::tempdir().unwrap();
-        let client_args = ClientArgs {
-            ingestion: IngestionClientArgs {
-                local_ingestion_path: Some(temp_dir.path().to_owned()),
-                ..Default::default()
-            },
-            ..Default::default()
-        };
-        let ingestion_config = IngestionConfig::default();
+        let (mut indexer, _temp_dir) =
+            create_test_indexer(store, IndexerArgs::default(), &registry, None).await;
 
-        let mut indexer = Indexer::new(
-            store,
-            indexer_args,
-            client_args,
-            ingestion_config,
-            None,
-            &registry,
-        )
-        .await
-        .unwrap();
-
-        indexer
-            .concurrent_pipeline::<A>(A, ConcurrentConfig::default())
-            .await
-            .unwrap();
-        indexer
-            .concurrent_pipeline::<B>(B, ConcurrentConfig::default())
-            .await
-            .unwrap();
-        indexer
-            .sequential_pipeline::<C>(C, SequentialConfig::default())
-            .await
-            .unwrap();
-        indexer
-            .sequential_pipeline::<D>(D, SequentialConfig::default())
-            .await
-            .unwrap();
+        add_concurrent(&mut indexer, A).await;
+        add_concurrent(&mut indexer, B).await;
+        add_sequential(&mut indexer, C).await;
+        add_sequential(&mut indexer, D).await;
 
         assert_eq!(indexer.first_checkpoint, None);
         assert_eq!(indexer.last_checkpoint, None);
@@ -804,63 +804,16 @@ mod tests {
         test_pipeline!(D, "sequential_d");
 
         let mut conn = store.connect().await.unwrap();
-        conn.set_committer_watermark(
-            B::NAME,
-            CommitterWatermark {
-                checkpoint_hi_inclusive: 10,
-                ..Default::default()
-            },
-        )
-        .await
-        .unwrap();
-        conn.set_committer_watermark(
-            C::NAME,
-            CommitterWatermark {
-                checkpoint_hi_inclusive: 1,
-                ..Default::default()
-            },
-        )
-        .await
-        .unwrap();
+        set_committer_watermark(&mut conn, B::NAME, 10).await;
+        set_committer_watermark(&mut conn, C::NAME, 1).await;
 
-        let indexer_args = IndexerArgs::default();
-        let temp_dir = tempfile::tempdir().unwrap();
-        let client_args = ClientArgs {
-            ingestion: IngestionClientArgs {
-                local_ingestion_path: Some(temp_dir.path().to_owned()),
-                ..Default::default()
-            },
-            ..Default::default()
-        };
-        let ingestion_config = IngestionConfig::default();
+        let (mut indexer, _temp_dir) =
+            create_test_indexer(store, IndexerArgs::default(), &registry, None).await;
 
-        let mut indexer = Indexer::new(
-            store,
-            indexer_args,
-            client_args,
-            ingestion_config,
-            None,
-            &registry,
-        )
-        .await
-        .unwrap();
-
-        indexer
-            .concurrent_pipeline::<A>(A, ConcurrentConfig::default())
-            .await
-            .unwrap();
-        indexer
-            .concurrent_pipeline::<B>(B, ConcurrentConfig::default())
-            .await
-            .unwrap();
-        indexer
-            .sequential_pipeline::<C>(C, SequentialConfig::default())
-            .await
-            .unwrap();
-        indexer
-            .sequential_pipeline::<D>(D, SequentialConfig::default())
-            .await
-            .unwrap();
+        add_concurrent(&mut indexer, A).await;
+        add_concurrent(&mut indexer, B).await;
+        add_sequential(&mut indexer, C).await;
+        add_sequential(&mut indexer, D).await;
 
         assert_eq!(indexer.first_checkpoint, None);
         assert_eq!(indexer.last_checkpoint, None);
@@ -880,75 +833,18 @@ mod tests {
         test_pipeline!(D, "sequential_d");
 
         let mut conn = store.connect().await.unwrap();
-        conn.set_committer_watermark(
-            A::NAME,
-            CommitterWatermark {
-                checkpoint_hi_inclusive: 100,
-                ..Default::default()
-            },
-        )
-        .await
-        .unwrap();
-        conn.set_committer_watermark(
-            B::NAME,
-            CommitterWatermark {
-                checkpoint_hi_inclusive: 10,
-                ..Default::default()
-            },
-        )
-        .await
-        .unwrap();
-        conn.set_committer_watermark(
-            C::NAME,
-            CommitterWatermark {
-                checkpoint_hi_inclusive: 1,
-                ..Default::default()
-            },
-        )
-        .await
-        .unwrap();
-        conn.set_committer_watermark(D::NAME, CommitterWatermark::default())
-            .await
-            .unwrap();
+        set_committer_watermark(&mut conn, A::NAME, 100).await;
+        set_committer_watermark(&mut conn, B::NAME, 10).await;
+        set_committer_watermark(&mut conn, C::NAME, 1).await;
+        set_committer_watermark(&mut conn, D::NAME, 0).await;
 
-        let indexer_args = IndexerArgs::default();
-        let temp_dir = tempfile::tempdir().unwrap();
-        let client_args = ClientArgs {
-            ingestion: IngestionClientArgs {
-                local_ingestion_path: Some(temp_dir.path().to_owned()),
-                ..Default::default()
-            },
-            ..Default::default()
-        };
-        let ingestion_config = IngestionConfig::default();
+        let (mut indexer, _temp_dir) =
+            create_test_indexer(store, IndexerArgs::default(), &registry, None).await;
 
-        let mut indexer = Indexer::new(
-            store,
-            indexer_args,
-            client_args,
-            ingestion_config,
-            None,
-            &registry,
-        )
-        .await
-        .unwrap();
-
-        indexer
-            .concurrent_pipeline::<A>(A, ConcurrentConfig::default())
-            .await
-            .unwrap();
-        indexer
-            .concurrent_pipeline::<B>(B, ConcurrentConfig::default())
-            .await
-            .unwrap();
-        indexer
-            .sequential_pipeline::<C>(C, SequentialConfig::default())
-            .await
-            .unwrap();
-        indexer
-            .sequential_pipeline::<D>(D, SequentialConfig::default())
-            .await
-            .unwrap();
+        add_concurrent(&mut indexer, A).await;
+        add_concurrent(&mut indexer, B).await;
+        add_sequential(&mut indexer, C).await;
+        add_sequential(&mut indexer, D).await;
 
         assert_eq!(indexer.next_checkpoint, 1);
     }
@@ -966,66 +862,20 @@ mod tests {
         test_pipeline!(D, "sequential_d");
 
         let mut conn = store.connect().await.unwrap();
-        conn.set_committer_watermark(
-            B::NAME,
-            CommitterWatermark {
-                checkpoint_hi_inclusive: 50,
-                ..Default::default()
-            },
-        )
-        .await
-        .unwrap();
-        conn.set_committer_watermark(
-            C::NAME,
-            CommitterWatermark {
-                checkpoint_hi_inclusive: 10,
-                ..Default::default()
-            },
-        )
-        .await
-        .unwrap();
+        set_committer_watermark(&mut conn, B::NAME, 50).await;
+        set_committer_watermark(&mut conn, C::NAME, 10).await;
 
         let indexer_args = IndexerArgs {
             first_checkpoint: Some(5),
             ..Default::default()
         };
-        let temp_dir = tempfile::tempdir().unwrap();
-        let client_args = ClientArgs {
-            ingestion: IngestionClientArgs {
-                local_ingestion_path: Some(temp_dir.path().to_owned()),
-                ..Default::default()
-            },
-            ..Default::default()
-        };
-        let ingestion_config = IngestionConfig::default();
+        let (mut indexer, _temp_dir) =
+            create_test_indexer(store, indexer_args, &registry, None).await;
 
-        let mut indexer = Indexer::new(
-            store,
-            indexer_args,
-            client_args,
-            ingestion_config,
-            None,
-            &registry,
-        )
-        .await
-        .unwrap();
-
-        indexer
-            .concurrent_pipeline::<A>(A, ConcurrentConfig::default())
-            .await
-            .unwrap();
-        indexer
-            .concurrent_pipeline::<B>(B, ConcurrentConfig::default())
-            .await
-            .unwrap();
-        indexer
-            .sequential_pipeline::<C>(C, SequentialConfig::default())
-            .await
-            .unwrap();
-        indexer
-            .sequential_pipeline::<D>(D, SequentialConfig::default())
-            .await
-            .unwrap();
+        add_concurrent(&mut indexer, A).await;
+        add_concurrent(&mut indexer, B).await;
+        add_sequential(&mut indexer, C).await;
+        add_sequential(&mut indexer, D).await;
 
         assert_eq!(indexer.first_checkpoint, Some(5));
         assert_eq!(indexer.last_checkpoint, None);
@@ -1044,58 +894,18 @@ mod tests {
         test_pipeline!(C, "sequential_c");
 
         let mut conn = store.connect().await.unwrap();
-        conn.set_committer_watermark(
-            B::NAME,
-            CommitterWatermark {
-                checkpoint_hi_inclusive: 50,
-                ..Default::default()
-            },
-        )
-        .await
-        .unwrap();
-        conn.set_committer_watermark(
-            C::NAME,
-            CommitterWatermark {
-                checkpoint_hi_inclusive: 10,
-                ..Default::default()
-            },
-        )
-        .await
-        .unwrap();
+        set_committer_watermark(&mut conn, B::NAME, 50).await;
+        set_committer_watermark(&mut conn, C::NAME, 10).await;
 
         let indexer_args = IndexerArgs {
             first_checkpoint: Some(5),
             ..Default::default()
         };
-        let temp_dir = tempfile::tempdir().unwrap();
-        let client_args = ClientArgs {
-            ingestion: IngestionClientArgs {
-                local_ingestion_path: Some(temp_dir.path().to_owned()),
-                ..Default::default()
-            },
-            ..Default::default()
-        };
-        let ingestion_config = IngestionConfig::default();
+        let (mut indexer, _temp_dir) =
+            create_test_indexer(store, indexer_args, &registry, None).await;
 
-        let mut indexer = Indexer::new(
-            store,
-            indexer_args,
-            client_args,
-            ingestion_config,
-            None,
-            &registry,
-        )
-        .await
-        .unwrap();
-
-        indexer
-            .concurrent_pipeline::<B>(B, ConcurrentConfig::default())
-            .await
-            .unwrap();
-        indexer
-            .sequential_pipeline::<C>(C, SequentialConfig::default())
-            .await
-            .unwrap();
+        add_concurrent(&mut indexer, B).await;
+        add_sequential(&mut indexer, C).await;
 
         assert_eq!(indexer.first_checkpoint, Some(5));
         assert_eq!(indexer.last_checkpoint, None);
@@ -1116,64 +926,19 @@ mod tests {
         test_pipeline!(C, "sequential_c");
 
         let mut conn = store.connect().await.unwrap();
-        conn.set_committer_watermark(
-            B::NAME,
-            CommitterWatermark {
-                checkpoint_hi_inclusive: 50,
-                ..Default::default()
-            },
-        )
-        .await
-        .unwrap();
-        conn.set_committer_watermark(
-            C::NAME,
-            CommitterWatermark {
-                checkpoint_hi_inclusive: 10,
-                ..Default::default()
-            },
-        )
-        .await
-        .unwrap();
+        set_committer_watermark(&mut conn, B::NAME, 50).await;
+        set_committer_watermark(&mut conn, C::NAME, 10).await;
 
         let indexer_args = IndexerArgs {
             first_checkpoint: Some(24),
             ..Default::default()
         };
-        let temp_dir = tempfile::tempdir().unwrap();
-        let client_args = ClientArgs {
-            ingestion: IngestionClientArgs {
-                local_ingestion_path: Some(temp_dir.path().to_owned()),
-                ..Default::default()
-            },
-            ..Default::default()
-        };
-        let ingestion_config = IngestionConfig::default();
+        let (mut indexer, _temp_dir) =
+            create_test_indexer(store, indexer_args, &registry, None).await;
 
-        let mut indexer = Indexer::new(
-            store,
-            indexer_args,
-            client_args,
-            ingestion_config,
-            None,
-            &registry,
-        )
-        .await
-        .unwrap();
-
-        indexer
-            .concurrent_pipeline::<A>(A, ConcurrentConfig::default())
-            .await
-            .unwrap();
-
-        indexer
-            .concurrent_pipeline::<B>(B, ConcurrentConfig::default())
-            .await
-            .unwrap();
-
-        indexer
-            .sequential_pipeline::<C>(C, SequentialConfig::default())
-            .await
-            .unwrap();
+        add_concurrent(&mut indexer, A).await;
+        add_concurrent(&mut indexer, B).await;
+        add_sequential(&mut indexer, C).await;
 
         assert_eq!(indexer.first_checkpoint, Some(24));
         assert_eq!(indexer.last_checkpoint, None);
@@ -1193,95 +958,22 @@ mod tests {
         test_pipeline!(D, "sequential_d");
 
         let mut conn = store.connect().await.unwrap();
-        conn.set_committer_watermark(
-            A::NAME,
-            CommitterWatermark {
-                checkpoint_hi_inclusive: 5,
-                ..Default::default()
-            },
-        )
-        .await
-        .unwrap();
-        conn.set_committer_watermark(
-            B::NAME,
-            CommitterWatermark {
-                checkpoint_hi_inclusive: 10,
-                ..Default::default()
-            },
-        )
-        .await
-        .unwrap();
-        conn.set_committer_watermark(
-            C::NAME,
-            CommitterWatermark {
-                checkpoint_hi_inclusive: 15,
-                ..Default::default()
-            },
-        )
-        .await
-        .unwrap();
-        conn.set_committer_watermark(
-            D::NAME,
-            CommitterWatermark {
-                checkpoint_hi_inclusive: 20,
-                ..Default::default()
-            },
-        )
-        .await
-        .unwrap();
-
-        // Create synthetic ingestion data
-        let temp_dir = tempfile::tempdir().unwrap();
-        synthetic_ingestion::generate_ingestion(synthetic_ingestion::Config {
-            ingestion_dir: temp_dir.path().to_owned(),
-            starting_checkpoint: 0,
-            num_checkpoints: 30,
-            checkpoint_size: 1,
-        })
-        .await;
+        set_committer_watermark(&mut conn, A::NAME, 5).await;
+        set_committer_watermark(&mut conn, B::NAME, 10).await;
+        set_committer_watermark(&mut conn, C::NAME, 15).await;
+        set_committer_watermark(&mut conn, D::NAME, 20).await;
 
         let indexer_args = IndexerArgs {
             last_checkpoint: Some(29),
             ..Default::default()
         };
+        let (mut indexer, _temp_dir) =
+            create_test_indexer(store.clone(), indexer_args, &registry, Some((30, 1))).await;
 
-        let client_args = ClientArgs {
-            ingestion: IngestionClientArgs {
-                local_ingestion_path: Some(temp_dir.path().to_owned()),
-                ..Default::default()
-            },
-            ..Default::default()
-        };
-
-        let ingestion_config = IngestionConfig::default();
-
-        let mut indexer = Indexer::new(
-            store.clone(),
-            indexer_args,
-            client_args,
-            ingestion_config,
-            None,
-            &registry,
-        )
-        .await
-        .unwrap();
-
-        indexer
-            .concurrent_pipeline::<A>(A, ConcurrentConfig::default())
-            .await
-            .unwrap();
-        indexer
-            .concurrent_pipeline::<B>(B, ConcurrentConfig::default())
-            .await
-            .unwrap();
-        indexer
-            .sequential_pipeline::<C>(C, SequentialConfig::default())
-            .await
-            .unwrap();
-        indexer
-            .sequential_pipeline::<D>(D, SequentialConfig::default())
-            .await
-            .unwrap();
+        add_concurrent(&mut indexer, A).await;
+        add_concurrent(&mut indexer, B).await;
+        add_sequential(&mut indexer, C).await;
+        add_sequential(&mut indexer, D).await;
 
         let ingestion_metrics = indexer.ingestion_metrics().clone();
         let indexer_metrics = indexer.indexer_metrics().clone();
@@ -1289,180 +981,10 @@ mod tests {
         indexer.run().await.unwrap().join().await.unwrap();
 
         assert_eq!(ingestion_metrics.total_ingested_checkpoints.get(), 24);
-        assert_eq!(
-            indexer_metrics
-                .total_watermarks_out_of_order
-                .get_metric_with_label_values(&[A::NAME])
-                .unwrap()
-                .get(),
-            0
-        );
-        assert_eq!(
-            indexer_metrics
-                .total_watermarks_out_of_order
-                .get_metric_with_label_values(&[B::NAME])
-                .unwrap()
-                .get(),
-            5
-        );
-        assert_eq!(
-            indexer_metrics
-                .total_watermarks_out_of_order
-                .get_metric_with_label_values(&[C::NAME])
-                .unwrap()
-                .get(),
-            10
-        );
-        assert_eq!(
-            indexer_metrics
-                .total_watermarks_out_of_order
-                .get_metric_with_label_values(&[D::NAME])
-                .unwrap()
-                .get(),
-            15
-        );
-    }
-
-    // test ingestion, no pipelines missing watermarks, first_checkpoint provided
-    #[tokio::test]
-    async fn test_indexer_ingestion_existing_watermarks_ignore_first_checkpoint() {
-        let registry = Registry::new();
-        let store = MockStore::default();
-
-        test_pipeline!(A, "concurrent_a");
-        test_pipeline!(B, "concurrent_b");
-        test_pipeline!(C, "sequential_c");
-        test_pipeline!(D, "sequential_d");
-
-        let mut conn = store.connect().await.unwrap();
-        conn.set_committer_watermark(
-            A::NAME,
-            CommitterWatermark {
-                checkpoint_hi_inclusive: 5,
-                ..Default::default()
-            },
-        )
-        .await
-        .unwrap();
-        conn.set_committer_watermark(
-            B::NAME,
-            CommitterWatermark {
-                checkpoint_hi_inclusive: 10,
-                ..Default::default()
-            },
-        )
-        .await
-        .unwrap();
-        conn.set_committer_watermark(
-            C::NAME,
-            CommitterWatermark {
-                checkpoint_hi_inclusive: 15,
-                ..Default::default()
-            },
-        )
-        .await
-        .unwrap();
-        conn.set_committer_watermark(
-            D::NAME,
-            CommitterWatermark {
-                checkpoint_hi_inclusive: 20,
-                ..Default::default()
-            },
-        )
-        .await
-        .unwrap();
-
-        // Create synthetic ingestion data
-        let temp_dir = tempfile::tempdir().unwrap();
-        synthetic_ingestion::generate_ingestion(synthetic_ingestion::Config {
-            ingestion_dir: temp_dir.path().to_owned(),
-            starting_checkpoint: 0,
-            num_checkpoints: 30,
-            checkpoint_size: 1,
-        })
-        .await;
-
-        let indexer_args = IndexerArgs {
-            first_checkpoint: Some(3),
-            last_checkpoint: Some(29),
-            ..Default::default()
-        };
-
-        let client_args = ClientArgs {
-            ingestion: IngestionClientArgs {
-                local_ingestion_path: Some(temp_dir.path().to_owned()),
-                ..Default::default()
-            },
-            ..Default::default()
-        };
-
-        let ingestion_config = IngestionConfig::default();
-
-        let mut indexer = Indexer::new(
-            store.clone(),
-            indexer_args,
-            client_args,
-            ingestion_config,
-            None,
-            &registry,
-        )
-        .await
-        .unwrap();
-
-        indexer
-            .concurrent_pipeline::<A>(A, ConcurrentConfig::default())
-            .await
-            .unwrap();
-        indexer
-            .concurrent_pipeline::<B>(B, ConcurrentConfig::default())
-            .await
-            .unwrap();
-        indexer
-            .sequential_pipeline::<C>(C, SequentialConfig::default())
-            .await
-            .unwrap();
-        indexer
-            .sequential_pipeline::<D>(D, SequentialConfig::default())
-            .await
-            .unwrap();
-
-        let ingestion_metrics = indexer.ingestion_metrics().clone();
-        let metrics = indexer.indexer_metrics().clone();
-        indexer.run().await.unwrap().join().await.unwrap();
-
-        assert_eq!(ingestion_metrics.total_ingested_checkpoints.get(), 24);
-        assert_eq!(
-            metrics
-                .total_watermarks_out_of_order
-                .get_metric_with_label_values(&[A::NAME])
-                .unwrap()
-                .get(),
-            0
-        );
-        assert_eq!(
-            metrics
-                .total_watermarks_out_of_order
-                .get_metric_with_label_values(&[B::NAME])
-                .unwrap()
-                .get(),
-            5
-        );
-        assert_eq!(
-            metrics
-                .total_watermarks_out_of_order
-                .get_metric_with_label_values(&[C::NAME])
-                .unwrap()
-                .get(),
-            10
-        );
-        assert_eq!(
-            metrics
-                .total_watermarks_out_of_order
-                .get_metric_with_label_values(&[D::NAME])
-                .unwrap()
-                .get(),
-            15
-        );
+        assert_out_of_order!(indexer_metrics, A::NAME, 0);
+        assert_out_of_order!(indexer_metrics, B::NAME, 5);
+        assert_out_of_order!(indexer_metrics, C::NAME, 10);
+        assert_out_of_order!(indexer_metrics, D::NAME, 15);
     }
 
     // test ingestion, some pipelines missing watermarks, no first_checkpoint provided
@@ -1477,124 +999,31 @@ mod tests {
         test_pipeline!(D, "sequential_d");
 
         let mut conn = store.connect().await.unwrap();
-        conn.set_committer_watermark(
-            B::NAME,
-            CommitterWatermark {
-                checkpoint_hi_inclusive: 10,
-                ..Default::default()
-            },
-        )
-        .await
-        .unwrap();
-        conn.set_committer_watermark(
-            C::NAME,
-            CommitterWatermark {
-                checkpoint_hi_inclusive: 15,
-                ..Default::default()
-            },
-        )
-        .await
-        .unwrap();
-        conn.set_committer_watermark(
-            D::NAME,
-            CommitterWatermark {
-                checkpoint_hi_inclusive: 20,
-                ..Default::default()
-            },
-        )
-        .await
-        .unwrap();
-
-        // Create synthetic ingestion data
-        let temp_dir = tempfile::tempdir().unwrap();
-        synthetic_ingestion::generate_ingestion(synthetic_ingestion::Config {
-            ingestion_dir: temp_dir.path().to_owned(),
-            starting_checkpoint: 0,
-            num_checkpoints: 30,
-            checkpoint_size: 1,
-        })
-        .await;
+        set_committer_watermark(&mut conn, B::NAME, 10).await;
+        set_committer_watermark(&mut conn, C::NAME, 15).await;
+        set_committer_watermark(&mut conn, D::NAME, 20).await;
 
         let indexer_args = IndexerArgs {
             last_checkpoint: Some(29),
             ..Default::default()
         };
+        let (mut indexer, _temp_dir) =
+            create_test_indexer(store.clone(), indexer_args, &registry, Some((30, 1))).await;
 
-        let client_args = ClientArgs {
-            ingestion: IngestionClientArgs {
-                local_ingestion_path: Some(temp_dir.path().to_owned()),
-                ..Default::default()
-            },
-            ..Default::default()
-        };
-
-        let ingestion_config = IngestionConfig::default();
-
-        let mut indexer = Indexer::new(
-            store.clone(),
-            indexer_args,
-            client_args,
-            ingestion_config,
-            None,
-            &registry,
-        )
-        .await
-        .unwrap();
-
-        indexer
-            .concurrent_pipeline::<A>(A, ConcurrentConfig::default())
-            .await
-            .unwrap();
-        indexer
-            .concurrent_pipeline::<B>(B, ConcurrentConfig::default())
-            .await
-            .unwrap();
-        indexer
-            .sequential_pipeline::<C>(C, SequentialConfig::default())
-            .await
-            .unwrap();
-        indexer
-            .sequential_pipeline::<D>(D, SequentialConfig::default())
-            .await
-            .unwrap();
+        add_concurrent(&mut indexer, A).await;
+        add_concurrent(&mut indexer, B).await;
+        add_sequential(&mut indexer, C).await;
+        add_sequential(&mut indexer, D).await;
 
         let ingestion_metrics = indexer.ingestion_metrics().clone();
         let metrics = indexer.indexer_metrics().clone();
         indexer.run().await.unwrap().join().await.unwrap();
 
         assert_eq!(ingestion_metrics.total_ingested_checkpoints.get(), 30);
-        assert_eq!(
-            metrics
-                .total_watermarks_out_of_order
-                .get_metric_with_label_values(&[A::NAME])
-                .unwrap()
-                .get(),
-            0
-        );
-        assert_eq!(
-            metrics
-                .total_watermarks_out_of_order
-                .get_metric_with_label_values(&[B::NAME])
-                .unwrap()
-                .get(),
-            11
-        );
-        assert_eq!(
-            metrics
-                .total_watermarks_out_of_order
-                .get_metric_with_label_values(&[C::NAME])
-                .unwrap()
-                .get(),
-            16
-        );
-        assert_eq!(
-            metrics
-                .total_watermarks_out_of_order
-                .get_metric_with_label_values(&[D::NAME])
-                .unwrap()
-                .get(),
-            21
-        );
+        assert_out_of_order!(metrics, A::NAME, 0);
+        assert_out_of_order!(metrics, B::NAME, 11);
+        assert_out_of_order!(metrics, C::NAME, 16);
+        assert_out_of_order!(metrics, D::NAME, 21);
     }
 
     // test ingestion, some pipelines missing watermarks, use first_checkpoint
@@ -1609,125 +1038,32 @@ mod tests {
         test_pipeline!(D, "sequential_d");
 
         let mut conn = store.connect().await.unwrap();
-        conn.set_committer_watermark(
-            B::NAME,
-            CommitterWatermark {
-                checkpoint_hi_inclusive: 10,
-                ..Default::default()
-            },
-        )
-        .await
-        .unwrap();
-        conn.set_committer_watermark(
-            C::NAME,
-            CommitterWatermark {
-                checkpoint_hi_inclusive: 15,
-                ..Default::default()
-            },
-        )
-        .await
-        .unwrap();
-        conn.set_committer_watermark(
-            D::NAME,
-            CommitterWatermark {
-                checkpoint_hi_inclusive: 20,
-                ..Default::default()
-            },
-        )
-        .await
-        .unwrap();
-
-        // Create synthetic ingestion data
-        let temp_dir = tempfile::tempdir().unwrap();
-        synthetic_ingestion::generate_ingestion(synthetic_ingestion::Config {
-            ingestion_dir: temp_dir.path().to_owned(),
-            starting_checkpoint: 0,
-            num_checkpoints: 30,
-            checkpoint_size: 1,
-        })
-        .await;
+        set_committer_watermark(&mut conn, B::NAME, 10).await;
+        set_committer_watermark(&mut conn, C::NAME, 15).await;
+        set_committer_watermark(&mut conn, D::NAME, 20).await;
 
         let indexer_args = IndexerArgs {
             first_checkpoint: Some(10),
             last_checkpoint: Some(29),
             ..Default::default()
         };
+        let (mut indexer, _temp_dir) =
+            create_test_indexer(store.clone(), indexer_args, &registry, Some((30, 1))).await;
 
-        let client_args = ClientArgs {
-            ingestion: IngestionClientArgs {
-                local_ingestion_path: Some(temp_dir.path().to_owned()),
-                ..Default::default()
-            },
-            ..Default::default()
-        };
-
-        let ingestion_config = IngestionConfig::default();
-
-        let mut indexer = Indexer::new(
-            store.clone(),
-            indexer_args,
-            client_args,
-            ingestion_config,
-            None,
-            &registry,
-        )
-        .await
-        .unwrap();
-
-        indexer
-            .concurrent_pipeline::<A>(A, ConcurrentConfig::default())
-            .await
-            .unwrap();
-        indexer
-            .concurrent_pipeline::<B>(B, ConcurrentConfig::default())
-            .await
-            .unwrap();
-        indexer
-            .sequential_pipeline::<C>(C, SequentialConfig::default())
-            .await
-            .unwrap();
-        indexer
-            .sequential_pipeline::<D>(D, SequentialConfig::default())
-            .await
-            .unwrap();
+        add_concurrent(&mut indexer, A).await;
+        add_concurrent(&mut indexer, B).await;
+        add_sequential(&mut indexer, C).await;
+        add_sequential(&mut indexer, D).await;
 
         let ingestion_metrics = indexer.ingestion_metrics().clone();
         let metrics = indexer.indexer_metrics().clone();
         indexer.run().await.unwrap().join().await.unwrap();
 
         assert_eq!(ingestion_metrics.total_ingested_checkpoints.get(), 20);
-        assert_eq!(
-            metrics
-                .total_watermarks_out_of_order
-                .get_metric_with_label_values(&[A::NAME])
-                .unwrap()
-                .get(),
-            0
-        );
-        assert_eq!(
-            metrics
-                .total_watermarks_out_of_order
-                .get_metric_with_label_values(&[B::NAME])
-                .unwrap()
-                .get(),
-            1
-        );
-        assert_eq!(
-            metrics
-                .total_watermarks_out_of_order
-                .get_metric_with_label_values(&[C::NAME])
-                .unwrap()
-                .get(),
-            6
-        );
-        assert_eq!(
-            metrics
-                .total_watermarks_out_of_order
-                .get_metric_with_label_values(&[D::NAME])
-                .unwrap()
-                .get(),
-            11
-        );
+        assert_out_of_order!(metrics, A::NAME, 0);
+        assert_out_of_order!(metrics, B::NAME, 1);
+        assert_out_of_order!(metrics, C::NAME, 6);
+        assert_out_of_order!(metrics, D::NAME, 11);
     }
 
     #[tokio::test]
@@ -1773,44 +1109,9 @@ mod tests {
         let registry = Registry::new();
         let store = MockStore::default();
 
-        // Set up different watermarks for three different sequential pipelines
         let mut conn = store.connect().await.unwrap();
-
-        // First handler at checkpoint 10
-        conn.set_committer_watermark(
-            MockHandler::NAME,
-            CommitterWatermark {
-                epoch_hi_inclusive: 0,
-                checkpoint_hi_inclusive: 10,
-                tx_hi: 20,
-                timestamp_ms_hi_inclusive: 10000,
-            },
-        )
-        .await
-        .unwrap();
-
-        // SequentialHandler at checkpoint 5
-        conn.set_committer_watermark(
-            SequentialHandler::NAME,
-            CommitterWatermark {
-                epoch_hi_inclusive: 0,
-                checkpoint_hi_inclusive: 5,
-                tx_hi: 10,
-                timestamp_ms_hi_inclusive: 5000,
-            },
-        )
-        .await
-        .unwrap();
-
-        // Create synthetic ingestion data
-        let temp_dir = tempfile::tempdir().unwrap();
-        synthetic_ingestion::generate_ingestion(synthetic_ingestion::Config {
-            ingestion_dir: temp_dir.path().to_owned(),
-            starting_checkpoint: 0,
-            num_checkpoints: 20,
-            checkpoint_size: 2,
-        })
-        .await;
+        set_committer_watermark(&mut conn, MockHandler::NAME, 10).await;
+        set_committer_watermark(&mut conn, SequentialHandler::NAME, 5).await;
 
         let indexer_args = IndexerArgs {
             first_checkpoint: None,
@@ -1818,33 +1119,11 @@ mod tests {
             pipeline: vec![],
             ..Default::default()
         };
-
-        let client_args = ClientArgs {
-            ingestion: IngestionClientArgs {
-                local_ingestion_path: Some(temp_dir.path().to_owned()),
-                ..Default::default()
-            },
-            ..Default::default()
-        };
-
-        let ingestion_config = IngestionConfig::default();
-
-        let mut indexer = Indexer::new(
-            store.clone(),
-            indexer_args,
-            client_args,
-            ingestion_config,
-            None,
-            &registry,
-        )
-        .await
-        .unwrap();
+        let (mut indexer, _temp_dir) =
+            create_test_indexer(store.clone(), indexer_args, &registry, Some((20, 2))).await;
 
         // Add first sequential pipeline
-        indexer
-            .sequential_pipeline(MockHandler, SequentialConfig::default())
-            .await
-            .unwrap();
+        add_sequential(&mut indexer, MockHandler).await;
 
         // Verify next_sequential_checkpoint is set correctly (10 + 1 = 11)
         assert_eq!(
@@ -1854,10 +1133,7 @@ mod tests {
         );
 
         // Add second sequential pipeline
-        indexer
-            .sequential_pipeline(SequentialHandler, SequentialConfig::default())
-            .await
-            .unwrap();
+        add_sequential(&mut indexer, SequentialHandler).await;
 
         // Should change to 6 (minimum of 6 and 11)
         assert_eq!(
@@ -1891,15 +1167,7 @@ mod tests {
         // Mock the store as if we have a main pipeline with a committer watermark at `10` and a
         // reader watermark at `7`.
         let mut conn = store.connect().await.unwrap();
-        conn.set_committer_watermark(
-            MockCheckpointSequenceNumberHandler::NAME,
-            CommitterWatermark {
-                checkpoint_hi_inclusive: 10,
-                ..Default::default()
-            },
-        )
-        .await
-        .unwrap();
+        set_committer_watermark(&mut conn, MockCheckpointSequenceNumberHandler::NAME, 10).await;
         conn.set_reader_watermark(MockCheckpointSequenceNumberHandler::NAME, 7)
             .await
             .unwrap();
@@ -1912,42 +1180,10 @@ mod tests {
             task: TaskArgs::tasked("task".to_string(), 10),
             ..Default::default()
         };
-        let temp_dir = tempfile::tempdir().unwrap();
-        synthetic_ingestion::generate_ingestion(synthetic_ingestion::Config {
-            ingestion_dir: temp_dir.path().to_owned(),
-            starting_checkpoint: 0,
-            num_checkpoints: 16,
-            checkpoint_size: 2,
-        })
-        .await;
+        let (mut tasked_indexer, _temp_dir) =
+            create_test_indexer(store.clone(), indexer_args, &registry, Some((16, 2))).await;
 
-        let client_args = ClientArgs {
-            ingestion: IngestionClientArgs {
-                local_ingestion_path: Some(temp_dir.path().to_owned()),
-                ..Default::default()
-            },
-            ..Default::default()
-        };
-
-        let ingestion_config = IngestionConfig::default();
-
-        let mut tasked_indexer = Indexer::new(
-            store.clone(),
-            indexer_args,
-            client_args,
-            ingestion_config,
-            None,
-            &registry,
-        )
-        .await
-        .unwrap();
-
-        let _ = tasked_indexer
-            .concurrent_pipeline(
-                MockCheckpointSequenceNumberHandler,
-                ConcurrentConfig::default(),
-            )
-            .await;
+        add_concurrent(&mut tasked_indexer, MockCheckpointSequenceNumberHandler).await;
 
         let ingestion_metrics = tasked_indexer.ingestion_metrics().clone();
         let metrics = tasked_indexer.indexer_metrics().clone();
@@ -1983,15 +1219,7 @@ mod tests {
         let store = MockStore::default();
 
         let mut conn = store.connect().await.unwrap();
-        conn.set_committer_watermark(
-            "test",
-            CommitterWatermark {
-                checkpoint_hi_inclusive: 10,
-                ..Default::default()
-            },
-        )
-        .await
-        .unwrap();
+        set_committer_watermark(&mut conn, "test", 10).await;
         conn.set_reader_watermark("test", 5).await.unwrap();
 
         // Start a tasked indexer that will ingest from checkpoint 9 and go past the main pipeline's
@@ -2002,42 +1230,10 @@ mod tests {
             task: TaskArgs::tasked("task".to_string(), 10),
             ..Default::default()
         };
-        let temp_dir = tempfile::tempdir().unwrap();
-        synthetic_ingestion::generate_ingestion(synthetic_ingestion::Config {
-            ingestion_dir: temp_dir.path().to_owned(),
-            starting_checkpoint: 0,
-            num_checkpoints: 26,
-            checkpoint_size: 2,
-        })
-        .await;
+        let (mut tasked_indexer, _temp_dir) =
+            create_test_indexer(store.clone(), indexer_args, &registry, Some((26, 2))).await;
 
-        let client_args = ClientArgs {
-            ingestion: IngestionClientArgs {
-                local_ingestion_path: Some(temp_dir.path().to_owned()),
-                ..Default::default()
-            },
-            ..Default::default()
-        };
-
-        let ingestion_config = IngestionConfig::default();
-
-        let mut tasked_indexer = Indexer::new(
-            store.clone(),
-            indexer_args,
-            client_args,
-            ingestion_config,
-            None,
-            &registry,
-        )
-        .await
-        .unwrap();
-
-        let _ = tasked_indexer
-            .concurrent_pipeline(
-                MockCheckpointSequenceNumberHandler,
-                ConcurrentConfig::default(),
-            )
-            .await;
+        add_concurrent(&mut tasked_indexer, MockCheckpointSequenceNumberHandler).await;
 
         let ingestion_metrics = tasked_indexer.ingestion_metrics().clone();
         let metrics = tasked_indexer.indexer_metrics().clone();
@@ -2045,14 +1241,7 @@ mod tests {
         tasked_indexer.run().await.unwrap().join().await.unwrap();
 
         assert_eq!(ingestion_metrics.total_ingested_checkpoints.get(), 17);
-        assert_eq!(
-            metrics
-                .total_watermarks_out_of_order
-                .get_metric_with_label_values(&["test"])
-                .unwrap()
-                .get(),
-            0
-        );
+        assert_out_of_order!(metrics, "test", 0);
         assert_eq!(
             metrics
                 .total_collector_skipped_checkpoints
@@ -2087,49 +1276,17 @@ mod tests {
         let store = MockStore::default();
         let mut conn = store.connect().await.unwrap();
         // Set the main pipeline watermark.
-        conn.set_committer_watermark(
-            ControllableHandler::NAME,
-            CommitterWatermark {
-                checkpoint_hi_inclusive: 11,
-                ..Default::default()
-            },
-        )
-        .await
-        .unwrap();
+        set_committer_watermark(&mut conn, ControllableHandler::NAME, 11).await;
 
         // Generate 500 checkpoints upfront, for the indexer to process all at once.
-        let temp_dir = tempfile::tempdir().unwrap();
-        synthetic_ingestion::generate_ingestion(synthetic_ingestion::Config {
-            ingestion_dir: temp_dir.path().to_owned(),
-            starting_checkpoint: 0,
-            num_checkpoints: 501,
-            checkpoint_size: 2,
-        })
-        .await;
         let indexer_args = IndexerArgs {
             first_checkpoint: Some(0),
             last_checkpoint: Some(500),
             task: TaskArgs::tasked("task".to_string(), 10 /* reader_interval_ms */),
             ..Default::default()
         };
-        let client_args = ClientArgs {
-            ingestion: IngestionClientArgs {
-                local_ingestion_path: Some(temp_dir.path().to_owned()),
-                ..Default::default()
-            },
-            ..Default::default()
-        };
-        let ingestion_config = IngestionConfig::default();
-        let mut tasked_indexer = Indexer::new(
-            store.clone(),
-            indexer_args,
-            client_args,
-            ingestion_config,
-            None,
-            &registry,
-        )
-        .await
-        .unwrap();
+        let (mut tasked_indexer, _temp_dir) =
+            create_test_indexer(store.clone(), indexer_args, &registry, Some((501, 2))).await;
         let mut allow_process = 10;
         // Limit the pipeline to process only checkpoints `[0, 10]`.
         let (controllable_handler, process_below) = ControllableHandler::with_limit(allow_process);


### PR DESCRIPTION
It is hard to see what these test cases are testing because most of the code is copied and pasted boilerplate to initialize the indexer and database. This change adds helper methods to reduce this boiler plate.

---

Added helper methods:
  - create_test_indexer — creates an Indexer<MockStore> with a temp dir and default client/ingestion config. Takes an optional ingestion_data: Option<(u64, u64)> to generate synthetic checkpoint
  data.
  - set_committer_watermark — calls conn.set_committer_watermark with only checkpoint_hi_inclusive set, defaulting the rest.
  - add_concurrent — registers a concurrent pipeline with default config on an indexer.
  - add_sequential — registers a sequential pipeline with default config on an indexer.
  - test_init_watermark — (pre-existing) sets up an indexer with a single pipeline and returns its watermarks.

Added helper macros:
  - assert_out_of_order — asserts the total_watermarks_out_of_order metric value for a given pipeline name.

Additional changes:
  - Removed test_indexer_ingestion_existing_watermarks_ignore_first_checkpoint — it was redundant with the no-first-checkpoint variant (identical watermarks, identical assertions; the
  "first_checkpoint ignored" behavior is already unit-tested by test_next_checkpoint_ignore_first_checkpoint).
  - Simplified test_multiple_sequential_pipelines_next_checkpoint — replaced two verbose set_committer_watermark calls (with all explicit fields) with set_watermark, since only
  checkpoint_hi_inclusive matters for the test's assertions.


## Description 

Describe the changes or additions included in this PR.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
