### PR TITLE
sui-core: index address balance recipients in jsonrpc index

### DIFF
--- a/crates/sui-core/src/jsonrpc_index.rs
+++ b/crates/sui-core/src/jsonrpc_index.rs
@@ -1112,15 +1112,20 @@ impl IndexStore {
                 .map(|(obj_id, module, function)| ((obj_id, module, function, sequence), *digest)),
         )?;
 
-        batch.insert_batch(
-            &self.tables.transactions_to_addr,
-            mutated_objects.filter_map(|(_, owner)| {
+        // objects sent to addresses and accumulator events
+        let affected_addresses = mutated_objects
+            .filter_map(|(_, owner)| {
                 owner
                     .get_address_owner_address()
                     .ok()
                     .map(|addr| ((addr, sequence), digest))
-            }),
-        )?;
+            })
+            .chain(
+                accumulator_events
+                    .iter()
+                    .map(|event| ((event.write.address.address, sequence), digest)),
+            );
+        batch.insert_batch(&self.tables.transactions_to_addr, affected_addresses)?;
 
         // Coin Index
         let cache_updates = self.index_coin(

--- a/crates/sui-json-rpc-tests/tests/transaction_tests.rs
+++ b/crates/sui-json-rpc-tests/tests/transaction_tests.rs
@@ -449,6 +449,44 @@ async fn test_query_transaction_blocks() -> Result<(), anyhow::Error> {
 }
 
 #[sim_test]
+async fn test_query_transaction_blocks_to_address() -> Result<(), anyhow::Error> {
+    let cluster = TestClusterBuilder::new().build().await;
+    let http_client = cluster.rpc_client();
+
+    let recipient = SuiAddress::random_for_testing_only();
+
+    // Send SUI to the recipient so the address appears in the index.
+    let tx = sui_test_transaction_builder::make_transfer_sui_address_balance_transaction(
+        &cluster.wallet,
+        Some(recipient),
+        1000,
+    )
+    .await;
+    let (tx_bytes, signatures) = tx.to_tx_bytes_and_signatures();
+
+    let response = http_client
+        .execute_transaction_block(
+            tx_bytes,
+            signatures,
+            Some(SuiTransactionBlockResponseOptions::new()),
+            Some(ExecuteTransactionRequestType::WaitForLocalExecution),
+        )
+        .await?;
+
+    // Query transactions where the recipient received funds.
+    let query =
+        SuiTransactionBlockResponseQuery::new_with_filter(TransactionFilter::ToAddress(recipient));
+    let result = http_client
+        .query_transaction_blocks(query, None, Some(10), Some(false))
+        .await?;
+
+    assert_eq!(1, result.data.len());
+    assert_eq!(response.digest, result.data[0].digest);
+
+    Ok(())
+}
+
+#[sim_test]
 async fn test_display_transaction_block_with_empty_balance_changes() {
     let cluster = TestClusterBuilder::new()
         .with_epoch_duration_ms(10_000)


### PR DESCRIPTION
Previously, the `transactions_to_addr` index only tracked addresses that received objects via `mutated_objects`. With address balances, a recipient can receive funds through accumulator events without any object ownership change. Now include accumulator event addresses in the index so that `queryTransactionBlocks` with `ToAddress` returns transactions involving address balance transfers.

Fixes: #26081

## Description 

Describe the changes or additions included in this PR.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
