### PR TITLE
indexer: remove unused function

### DIFF
--- a/crates/sui-indexer-alt-framework-store-traits/src/lib.rs
+++ b/crates/sui-indexer-alt-framework-store-traits/src/lib.rs
@@ -3,7 +3,6 @@
 
 use std::time::Duration;
 
-use anyhow::Context;
 use async_trait::async_trait;
 use chrono::DateTime;
 use chrono::Utc;
@@ -169,13 +168,6 @@ pub trait SequentialStore: for<'c> Store<Connection<'c> = Self::SequentialConnec
     type SequentialConnection<'c>: SequentialConnection
     where
         Self: 'c;
-
-    async fn sequential_connect<'c>(&'c self) -> anyhow::Result<Self::SequentialConnection<'c>> {
-        Ok(self
-            .connect()
-            .await
-            .context("Failed to establish sequential connection to store")?)
-    }
 
     async fn transaction<'a, R, F>(&self, f: F) -> anyhow::Result<R>
     where


### PR DESCRIPTION
## Description

`SequentialStore::sequential_connect` is vestigial and no longer used.

## Test plan

```
$ cargo nextest run -p sui-indexer-alt-framework -p sui-indexer-alt
```
---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [x] Indexing Framework: Removes `SequentialStore::sequential_connect` which was introduced in a recent refactoring but is not used.
