### PR TITLE
feat: Update gamma prime aws cognito provider

### DIFF
--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -757,8 +757,8 @@ pub fn default_zklogin_oauth_providers() -> BTreeMap<Chain, BTreeSet<String>> {
         "EveFrontier".to_string(),
         "TestEveFrontier".to_string(),
         "AwsTenant-region:ap-southeast-1-tenant_id:ap-southeast-1_2QQPyQXDz".to_string(), // Decot, external partner
-        "AwsTenant-region:eu-north-1-tenant_id:eu-north-1_rz7IVMOR5".to_string(), // test Gamma Prime, external partner
-        "AwsTenant-region:eu-north-1-tenant_id:eu-north-1_K3XgRburu".to_string(), // Gamma Prime, external partner
+        "AwsTenant-region:eu-north-1-tenant_id:eu-north-1_Bpct2JyBg".to_string(), // test Gamma Prime, external partner
+        "AwsTenant-region:eu-north-1-tenant_id:eu-north-1_4HdQTpt3E".to_string(), // Gamma Prime, external partner
     ]);
 
     // providers that are available for mainnet and testnet.

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -112,8 +112,8 @@ validator_configs:
         - Apple
         - Arden
         - "AwsTenant-region:ap-southeast-1-tenant_id:ap-southeast-1_2QQPyQXDz"
-        - "AwsTenant-region:eu-north-1-tenant_id:eu-north-1_K3XgRburu"
-        - "AwsTenant-region:eu-north-1-tenant_id:eu-north-1_rz7IVMOR5"
+        - "AwsTenant-region:eu-north-1-tenant_id:eu-north-1_4HdQTpt3E"
+        - "AwsTenant-region:eu-north-1-tenant_id:eu-north-1_Bpct2JyBg"
         - "AwsTenant-region:eu-west-3-tenant_id:eu-west-3_gGVCx53Es"
         - Credenza3
         - EveFrontier
@@ -282,8 +282,8 @@ validator_configs:
         - Apple
         - Arden
         - "AwsTenant-region:ap-southeast-1-tenant_id:ap-southeast-1_2QQPyQXDz"
-        - "AwsTenant-region:eu-north-1-tenant_id:eu-north-1_K3XgRburu"
-        - "AwsTenant-region:eu-north-1-tenant_id:eu-north-1_rz7IVMOR5"
+        - "AwsTenant-region:eu-north-1-tenant_id:eu-north-1_4HdQTpt3E"
+        - "AwsTenant-region:eu-north-1-tenant_id:eu-north-1_Bpct2JyBg"
         - "AwsTenant-region:eu-west-3-tenant_id:eu-west-3_gGVCx53Es"
         - Credenza3
         - EveFrontier
@@ -452,8 +452,8 @@ validator_configs:
         - Apple
         - Arden
         - "AwsTenant-region:ap-southeast-1-tenant_id:ap-southeast-1_2QQPyQXDz"
-        - "AwsTenant-region:eu-north-1-tenant_id:eu-north-1_K3XgRburu"
-        - "AwsTenant-region:eu-north-1-tenant_id:eu-north-1_rz7IVMOR5"
+        - "AwsTenant-region:eu-north-1-tenant_id:eu-north-1_4HdQTpt3E"
+        - "AwsTenant-region:eu-north-1-tenant_id:eu-north-1_Bpct2JyBg"
         - "AwsTenant-region:eu-west-3-tenant_id:eu-west-3_gGVCx53Es"
         - Credenza3
         - EveFrontier
@@ -622,8 +622,8 @@ validator_configs:
         - Apple
         - Arden
         - "AwsTenant-region:ap-southeast-1-tenant_id:ap-southeast-1_2QQPyQXDz"
-        - "AwsTenant-region:eu-north-1-tenant_id:eu-north-1_K3XgRburu"
-        - "AwsTenant-region:eu-north-1-tenant_id:eu-north-1_rz7IVMOR5"
+        - "AwsTenant-region:eu-north-1-tenant_id:eu-north-1_4HdQTpt3E"
+        - "AwsTenant-region:eu-north-1-tenant_id:eu-north-1_Bpct2JyBg"
         - "AwsTenant-region:eu-west-3-tenant_id:eu-west-3_gGVCx53Es"
         - Credenza3
         - EveFrontier
@@ -792,8 +792,8 @@ validator_configs:
         - Apple
         - Arden
         - "AwsTenant-region:ap-southeast-1-tenant_id:ap-southeast-1_2QQPyQXDz"
-        - "AwsTenant-region:eu-north-1-tenant_id:eu-north-1_K3XgRburu"
-        - "AwsTenant-region:eu-north-1-tenant_id:eu-north-1_rz7IVMOR5"
+        - "AwsTenant-region:eu-north-1-tenant_id:eu-north-1_4HdQTpt3E"
+        - "AwsTenant-region:eu-north-1-tenant_id:eu-north-1_Bpct2JyBg"
         - "AwsTenant-region:eu-west-3-tenant_id:eu-west-3_gGVCx53Es"
         - Credenza3
         - EveFrontier
@@ -962,8 +962,8 @@ validator_configs:
         - Apple
         - Arden
         - "AwsTenant-region:ap-southeast-1-tenant_id:ap-southeast-1_2QQPyQXDz"
-        - "AwsTenant-region:eu-north-1-tenant_id:eu-north-1_K3XgRburu"
-        - "AwsTenant-region:eu-north-1-tenant_id:eu-north-1_rz7IVMOR5"
+        - "AwsTenant-region:eu-north-1-tenant_id:eu-north-1_4HdQTpt3E"
+        - "AwsTenant-region:eu-north-1-tenant_id:eu-north-1_Bpct2JyBg"
         - "AwsTenant-region:eu-west-3-tenant_id:eu-west-3_gGVCx53Es"
         - Credenza3
         - EveFrontier
@@ -1132,8 +1132,8 @@ validator_configs:
         - Apple
         - Arden
         - "AwsTenant-region:ap-southeast-1-tenant_id:ap-southeast-1_2QQPyQXDz"
-        - "AwsTenant-region:eu-north-1-tenant_id:eu-north-1_K3XgRburu"
-        - "AwsTenant-region:eu-north-1-tenant_id:eu-north-1_rz7IVMOR5"
+        - "AwsTenant-region:eu-north-1-tenant_id:eu-north-1_4HdQTpt3E"
+        - "AwsTenant-region:eu-north-1-tenant_id:eu-north-1_Bpct2JyBg"
         - "AwsTenant-region:eu-west-3-tenant_id:eu-west-3_gGVCx53Es"
         - Credenza3
         - EveFrontier


### PR DESCRIPTION
This updated the config of a new aws tenant for devnet for zklogin.
Adds an aws cognito zklogin provider for gamma prime according to guide:
https://www.notion.so/mystenlabs/New-zkLogin-Provider-Onboarding-Process-Runbook-9d9d2895d7d9455ca29830041a97e74d

Test plan
How did you test the new or updated feature?
I followed the test plan mentioned in the [notion doc](https://www.notion.so/mystenlabs/New-zkLogin-Provider-Onboarding-Process-Runbook-9d9d2895d7d9455ca29830041a97e74d) where I essentially get a valid resp from prover for the jwt and then send a successful txn to localnet.
Other resources
https://gist.github.com/StefPler/264dbb7762a4bf2359e8ecf05cbd120a
https://github.com/MystenLabs/sui/pull/18635

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
