### PR TITLE
Gate coin reservation JSON-RPC responses on protocol config

### DIFF
--- a/crates/sui-e2e-tests/tests/address_balance_rpc_tests.rs
+++ b/crates/sui-e2e-tests/tests/address_balance_rpc_tests.rs
@@ -11,6 +11,7 @@ use sui_json_rpc_types::{
     Balance as RpcBalance, CoinPage, SuiData, SuiObjectDataOptions, SuiObjectResponse,
 };
 use sui_macros::*;
+use sui_types::error::SuiObjectResponseError;
 use sui_types::{
     base_types::{ObjectID, SuiAddress},
     coin_reservation::ParsedDigest,
@@ -686,4 +687,81 @@ async fn test_get_balance_includes_address_balance() {
             "Address balance should be reported"
         );
     }
+}
+
+#[sim_test]
+async fn test_no_fake_coins_when_coin_reservations_disabled() {
+    // Enable address balances but explicitly disable coin reservations.
+    // Verify that getCoins does not return fake coins.
+    let mut test_env = TestEnvBuilder::new()
+        .with_proto_override_cb(Box::new(|_, mut cfg| {
+            cfg.enable_address_balance_gas_payments_for_testing();
+            cfg.disable_coin_reservation_for_testing();
+            cfg
+        }))
+        .build()
+        .await;
+
+    let (sender, _) = test_env.get_sender_and_gas(0);
+    test_env
+        .fund_one_address_balance(sender, 1_000_000_000)
+        .await;
+
+    let counts = get_coins_counts(&test_env, sender, None).await;
+    assert_eq!(
+        counts.fake_coins, 0,
+        "No fake coins should be returned when coin reservations are disabled"
+    );
+
+    let all_counts = get_all_coins_counts(&test_env, sender).await;
+    assert_eq!(
+        all_counts.fake_coins, 0,
+        "getAllCoins should not return fake coins when coin reservations are disabled"
+    );
+}
+
+#[sim_test]
+async fn test_get_object_no_fake_coin_when_coin_reservations_disabled() {
+    // Enable address balances but explicitly disable coin reservations.
+    // Verify that sui_getObject does not return a fake coin for a masked object ID.
+    let mut test_env = TestEnvBuilder::new()
+        .with_proto_override_cb(Box::new(|_, mut cfg| {
+            cfg.enable_address_balance_gas_payments_for_testing();
+            cfg.disable_coin_reservation_for_testing();
+            cfg
+        }))
+        .build()
+        .await;
+
+    let (sender, _) = test_env.get_sender_and_gas(0);
+    let amount = 1_000_000_000u64;
+    test_env.fund_one_address_balance(sender, amount).await;
+
+    // Create a masked object ID as if coin reservations were enabled.
+    let fake_coin_ref = test_env.encode_coin_reservation(sender, 0, amount);
+    let masked_object_id = fake_coin_ref.0;
+
+    let params = rpc_params![
+        masked_object_id,
+        SuiObjectDataOptions::new().with_content().with_owner()
+    ];
+    let response: SuiObjectResponse = test_env
+        .cluster
+        .fullnode_handle
+        .rpc_client
+        .request("sui_getObject", params)
+        .await
+        .unwrap();
+
+    assert!(
+        response.data.is_none(),
+        "sui_getObject should not return a fake coin when coin reservations are disabled"
+    );
+    assert!(
+        matches!(
+            response.error,
+            Some(SuiObjectResponseError::NotExists { .. })
+        ),
+        "Expected NotExists error for masked object ID when coin reservations disabled"
+    );
 }

--- a/crates/sui-json-rpc/src/authority_state.rs
+++ b/crates/sui-json-rpc/src/authority_state.rs
@@ -251,8 +251,14 @@ impl StateRead for AuthorityState {
     fn get_object_read(&self, object_id: &ObjectID) -> StateReadResult<ObjectRead> {
         let result = self.get_object_read(object_id)?;
 
-        // If object not found, check if this is a masked object ID (fake coin request).
-        if let ObjectRead::NotExists(object_id) = result {
+        // If object not found and coin reservations are enabled, check if this is a
+        // masked object ID (fake coin request).
+        if let ObjectRead::NotExists(object_id) = result
+            && self
+                .load_epoch_store_one_call_per_task()
+                .protocol_config()
+                .enable_coin_reservation_obj_refs()
+        {
             let chain_identifier = self.get_chain_identifier();
             let unmasked_id = coin_reservation::mask_or_unmask_id(object_id, chain_identifier);
 
@@ -501,8 +507,15 @@ impl StateRead for AuthorityState {
             }
         }
 
-        // Build fake coins map.
-        let fake_coins: HashMap<String, SuiCoin> = if one_coin_type_only {
+        // Build fake coins map (only when coin reservations are enabled).
+        let coin_reservations_enabled = self
+            .load_epoch_store_one_call_per_task()
+            .protocol_config()
+            .enable_coin_reservation_obj_refs();
+
+        let fake_coins: HashMap<String, SuiCoin> = if !coin_reservations_enabled {
+            HashMap::new()
+        } else if one_coin_type_only {
             let balance_type_tag = sui_types::parse_sui_type_tag(&cursor.0)
                 .map_err(|e| anyhow::anyhow!("Invalid coin type: {} - {}", cursor.0, e))?;
             let balance_type = Balance::type_tag(balance_type_tag);


### PR DESCRIPTION
## Summary
- PRs #25916 and #25957 introduced JSON-RPC code that returns fake coins (coin reservations) for address balances, but the `get_object_read` and `get_owned_coins` implementations in the `StateRead` trait don't check whether `enable_coin_reservation_obj_refs` is enabled in protocol config
- Added protocol config gating to both methods so fake coins are only returned when the feature is actually enabled on the network
- The gRPC simulate path (PR #25957) already had proper gating; this fixes the JSON-RPC path (PR #25916)

## Test plan
- [x] Added `test_no_fake_coins_when_coin_reservations_disabled` — verifies `getCoins` and `getAllCoins` return zero fake coins when address balances are enabled but coin reservations are not
- [x] Added `test_get_object_no_fake_coin_when_coin_reservations_disabled` — verifies `sui_getObject` returns `NotExists` for masked object IDs when coin reservations are disabled
- [x] Verified both tests fail without the fix and pass with it
- [x] All 13 existing `address_balance_rpc_tests` simtests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)