### PR TITLE
[move] disallow orphaned tables  (#26095)

### DIFF
--- a/crates/sui-core/src/authority/snapshots/sui_core__authority__execution_time_estimator__tests__execution_time_observer_v120.snap
+++ b/crates/sui-core/src/authority/snapshots/sui_core__authority__execution_time_estimator__tests__execution_time_observer_v120.snap
@@ -1,0 +1,141 @@
+---
+source: crates/sui-core/src/authority/execution_time_estimator.rs
+expression: snapshot_data
+---
+protocol_version: 120
+consensus_observations:
+  - - MakeMoveVec
+    - observations:
+        - - 3
+          - secs: 0
+            nanos: 16000000
+        - - 4
+          - secs: 0
+            nanos: 28000000
+        - - 6
+          - secs: 0
+            nanos: 19000000
+        - - 4
+          - secs: 0
+            nanos: 26000000
+      stake_weighted_median:
+        secs: 0
+        nanos: 26000000
+  - - MergeCoins
+    - observations:
+        - - 6
+          - secs: 0
+            nanos: 63000000
+        - - 1
+          - secs: 0
+            nanos: 21000000
+        - - 10
+          - secs: 0
+            nanos: 53000000
+        - - 8
+          - secs: 0
+            nanos: 28000000
+      stake_weighted_median:
+        secs: 0
+        nanos: 53000000
+  - - SplitCoins
+    - observations:
+        - - 6
+          - secs: 0
+            nanos: 22000000
+        - - 0
+          - ~
+        - - 8
+          - secs: 0
+            nanos: 69000000
+        - - 3
+          - secs: 0
+            nanos: 61000000
+      stake_weighted_median:
+        secs: 0
+        nanos: 61000000
+  - - Upgrade
+    - observations:
+        - - 0
+          - ~
+        - - 5
+          - secs: 0
+            nanos: 924000000
+        - - 6
+          - secs: 0
+            nanos: 981000000
+        - - 4
+          - secs: 0
+            nanos: 587000000
+      stake_weighted_median:
+        secs: 0
+        nanos: 924000000
+  - - MoveEntryPoint:
+        package: "0x0000000000000000000000000000000000000000000000000000000000000001"
+        module: coin
+        function: transfer
+        type_arguments: []
+    - observations:
+        - - 9
+          - secs: 0
+            nanos: 186000000
+        - - 6
+          - secs: 0
+            nanos: 162000000
+        - - 9
+          - secs: 0
+            nanos: 268000000
+        - - 7
+          - secs: 0
+            nanos: 261000000
+      stake_weighted_median:
+        secs: 0
+        nanos: 261000000
+  - - MoveEntryPoint:
+        package: "0x0000000000000000000000000000000000000000000000000000000000000002"
+        module: nft
+        function: mint
+        type_arguments: []
+    - observations:
+        - - 5
+          - secs: 0
+            nanos: 282000000
+        - - 0
+          - ~
+        - - 7
+          - secs: 0
+            nanos: 56000000
+        - - 8
+          - secs: 0
+            nanos: 499000000
+      stake_weighted_median:
+        secs: 0
+        nanos: 282000000
+transaction_estimates:
+  - - coin_transfer_call
+    - secs: 0
+      nanos: 261000000
+  - - mixed_move_calls
+    - secs: 0
+      nanos: 543000000
+  - - native_commands_with_observations
+    - secs: 0
+      nanos: 282000000
+  - - transfer_objects_3_items
+    - secs: 0
+      nanos: 4000000
+  - - split_coins_2_amounts
+    - secs: 0
+      nanos: 183000000
+  - - merge_coins_1_sources
+    - secs: 0
+      nanos: 106000000
+  - - make_move_vec_1_elements
+    - secs: 0
+      nanos: 52000000
+  - - mixed_commands
+    - secs: 0
+      nanos: 126000000
+  - - upgrade_package
+    - secs: 0
+      nanos: 924000000

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/display/display_v2.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/display/display_v2.snap
@@ -57,9 +57,9 @@ Response: {
   "result": [
     {
       "data": {
-        "objectId": "0x6e2411c413cbbdb88504e1aaed0906e5608b8b06b8611d535b6231b0d21331a7",
+        "objectId": "0x7bd8a4ce8ee7f34890cbd4d194b89813c4a8bb722cc646915183ff3b7a4ffe5f",
         "version": "4",
-        "digest": "EKdovuK4o7db2dZBa8fWtgSjddTb7pYbmNchAqRp8Fef",
+        "digest": "1bnHMrTNKAgRaEnih77VLQSLA5KPDjPZ7LwZoGApx5E",
         "display": {
           "data": {
             "bar": "bar is 42!",
@@ -83,9 +83,9 @@ Response: {
     },
     {
       "data": {
-        "objectId": "0xb347df38e290cfa185224bfebea8b75f5ec9b0e45551f4607d476f259a1d0876",
+        "objectId": "0xb9f6ab4fc099641599ad95bdc5503d368b30f8b215f81ed7b7bf30059e2864dd",
         "version": "6",
-        "digest": "6eesV233MpJXdMa1TovHAn5J51MxEcw68Cj5EAwuGrzx",
+        "digest": "9azVBjCe3KV3Kv3886UHmGzKhukwgktwtmsDtK2RfcK1",
         "display": {
           "data": {
             "bar": "bar is 42!",

--- a/crates/sui-open-rpc/tests/snapshots/generate_spec__openrpc.snap.json
+++ b/crates/sui-open-rpc/tests/snapshots/generate_spec__openrpc.snap.json
@@ -1294,7 +1294,7 @@
             "name": "Result",
             "value": {
               "minSupportedProtocolVersion": "1",
-              "maxSupportedProtocolVersion": "119",
+              "maxSupportedProtocolVersion": "120",
               "protocolVersion": "6",
               "featureFlags": {
                 "abstract_size_in_object_runtime": false,
@@ -1347,6 +1347,7 @@
                 "disable_preconsensus_locking": false,
                 "disallow_adding_abilities_on_upgrade": false,
                 "disallow_change_struct_type_params_on_upgrade": false,
+                "disallow_jump_orphans": false,
                 "disallow_new_modules_in_deps_only_packages": false,
                 "disallow_self_identifier": false,
                 "enable_accumulators": false,

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -24,7 +24,7 @@ use tracing::{info, warn};
 
 /// The minimum and maximum protocol versions supported by this build.
 const MIN_PROTOCOL_VERSION: u64 = 1;
-const MAX_PROTOCOL_VERSION: u64 = 119;
+const MAX_PROTOCOL_VERSION: u64 = 120;
 
 const TESTNET_USDC: &str =
     "0xa1ec7fc00a6f40db9693ad1415d0c193ad3906494428cf252621037bd7117e29::usdc::USDC";
@@ -310,6 +310,7 @@ const TESTNET_USDC: &str =
 // Version 117: Update Sui System metadata handling.
 // Version 118: Adds `transfer_migration_cap` to display registry
 // Version 119: Enable the new VM.
+// Version 120: Disallow unused jump tables
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
@@ -1040,6 +1041,9 @@ struct FeatureFlags {
 
     #[serde(skip_serializing_if = "is_false")]
     enable_gasless: bool,
+
+    #[serde(skip_serializing_if = "is_false")]
+    disallow_jump_orphans: bool,
 }
 
 fn is_false(b: &bool) -> bool {
@@ -2722,6 +2726,10 @@ impl ProtocolConfig {
 
     pub fn get_gasless_max_pure_input_bytes(&self) -> u64 {
         self.gasless_max_pure_input_bytes.unwrap_or(u64::MAX)
+    }
+
+    pub fn disallow_jump_orphans(&self) -> bool {
+        self.feature_flags.disallow_jump_orphans
     }
 }
 
@@ -4768,6 +4776,9 @@ impl ProtocolConfig {
                     cfg.transfer_receive_object_cost_per_byte = Some(1);
                     cfg.transfer_receive_object_type_cost_per_byte = Some(2);
                 }
+                120 => {
+                    cfg.feature_flags.disallow_jump_orphans = true;
+                }
                 // Use this template when making changes:
                 //
                 //     // modify an existing constant.
@@ -4872,6 +4883,7 @@ impl ProtocolConfig {
             deprecate_global_storage_ops,
             disable_entry_point_signature_check: self.disable_entry_point_signature_check(),
             switch_to_regex_reference_safety: false,
+            disallow_jump_orphans: self.disallow_jump_orphans(),
         }
     }
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_120.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_120.snap
@@ -1,0 +1,676 @@
+---
+source: crates/sui-protocol-config/src/lib.rs
+expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
+---
+version: 120
+feature_flags:
+  package_upgrades: true
+  commit_root_state_digest: true
+  advance_epoch_start_time_in_safe_mode: true
+  loaded_child_objects_fixed: true
+  missing_type_is_compatibility_error: true
+  scoring_decision_with_validity_cutoff: true
+  consensus_order_end_of_epoch_last: true
+  disallow_adding_abilities_on_upgrade: true
+  disable_invariant_violation_check_in_swap_loc: true
+  advance_to_highest_supported_protocol_version: true
+  ban_entry_init: true
+  package_digest_hash_module: true
+  disallow_change_struct_type_params_on_upgrade: true
+  no_extraneous_module_bytes: true
+  narwhal_versioned_metadata: true
+  zklogin_auth: true
+  consensus_transaction_ordering: ByGasPrice
+  simplified_unwrap_then_delete: true
+  upgraded_multisig_supported: true
+  txn_base_cost_as_multiplier: true
+  shared_object_deletion: true
+  narwhal_new_leader_election_schedule: true
+  loaded_child_object_format: true
+  enable_jwk_consensus_updates: true
+  end_of_epoch_transaction_supported: true
+  simple_conservation_checks: true
+  loaded_child_object_format_type: true
+  receive_objects: true
+  consensus_checkpoint_signature_key_includes_digest: true
+  random_beacon: true
+  bridge: true
+  enable_effects_v2: true
+  narwhal_certificate_v2: true
+  verify_legacy_zklogin_address: true
+  recompute_has_public_transfer_in_execution: true
+  accept_zklogin_in_multisig: true
+  accept_passkey_in_multisig: true
+  validate_zklogin_public_identifier: true
+  include_consensus_digest_in_prologue: true
+  hardened_otw_check: true
+  allow_receiving_object_id: true
+  enable_poseidon: true
+  enable_coin_deny_list: true
+  enable_group_ops_native_functions: true
+  enable_nitro_attestation: true
+  enable_nitro_attestation_upgraded_parsing: true
+  enable_nitro_attestation_all_nonzero_pcrs_parsing: true
+  enable_nitro_attestation_always_include_required_pcrs_parsing: true
+  reject_mutable_random_on_entry_functions: true
+  per_object_congestion_control_mode:
+    ExecutionTimeEstimate:
+      target_utilization: 50
+      allowed_txn_cost_overage_burst_limit_us: 500000
+      randomness_scalar: 20
+      max_estimate_us: 1500000
+      stored_observations_num_included_checkpoints: 10
+      stored_observations_limit: 180
+      stake_weighted_median_threshold: 3334
+      default_none_duration_for_new_keys: true
+      observations_chunk_size: 18
+  consensus_choice: Mysticeti
+  consensus_network: Tonic
+  correct_gas_payment_limit_check: true
+  zklogin_max_epoch_upper_bound_delta: 30
+  mysticeti_leader_scoring_and_schedule: true
+  reshare_at_same_initial_version: true
+  resolve_abort_locations_to_package_id: true
+  mysticeti_use_committed_subdag_digest: true
+  record_consensus_determined_version_assignments_in_prologue: true
+  record_consensus_determined_version_assignments_in_prologue_v2: true
+  fresh_vm_on_framework_upgrade: true
+  prepend_prologue_tx_in_consensus_commit_in_checkpoints: true
+  mysticeti_num_leaders_per_round: 1
+  soft_bundle: true
+  enable_coin_deny_list_v2: true
+  passkey_auth: true
+  authority_capabilities_v2: true
+  rethrow_serialization_type_layout_errors: true
+  consensus_distributed_vote_scoring_strategy: true
+  consensus_round_prober: true
+  validate_identifier_inputs: true
+  disallow_self_identifier: true
+  mysticeti_fastpath: true
+  disable_preconsensus_locking: true
+  relocate_event_module: true
+  uncompressed_g1_group_elements: true
+  disallow_new_modules_in_deps_only_packages: true
+  consensus_smart_ancestor_selection: true
+  consensus_round_prober_probe_accepted_rounds: true
+  native_charging_v2: true
+  consensus_linearize_subdag_v2: true
+  convert_type_argument_error: true
+  variant_nodes: true
+  consensus_zstd_compression: true
+  minimize_child_object_mutations: true
+  record_additional_state_digest_in_prologue: true
+  move_native_context: true
+  consensus_median_based_commit_timestamp: true
+  normalize_ptb_arguments: true
+  consensus_batched_block_sync: true
+  enforce_checkpoint_timestamp_monotonicity: true
+  max_ptb_value_size_v2: true
+  resolve_type_input_ids_to_defining_id: true
+  enable_party_transfer: true
+  allow_unbounded_system_objects: true
+  type_tags_in_object_runtime: true
+  create_root_accumulator_object: true
+  address_balance_gas_check_rgp_at_signing: true
+  enable_multi_epoch_transaction_expiration: true
+  relax_valid_during_for_owned_inputs: true
+  enable_ptb_execution_v2: true
+  better_adapter_type_resolution_errors: true
+  record_time_estimate_processed: true
+  dependency_linkage_error: true
+  additional_multisig_checks: true
+  ignore_execution_time_observations_after_certs_closed: true
+  debug_fatal_on_move_invariant_violation: true
+  additional_consensus_digest_indirect_state: true
+  check_for_init_during_upgrade: true
+  use_mfp_txns_in_load_initial_object_debts: true
+  cancel_for_failed_dkg_early: true
+  enable_coin_registry: true
+  abstract_size_in_object_runtime: true
+  object_runtime_charge_cache_load_gas: true
+  additional_borrow_checks: true
+  use_new_commit_handler: true
+  better_loader_errors: true
+  generate_df_type_layouts: true
+  enable_display_registry: true
+  private_generics_verifier_v2: true
+  deprecate_global_storage_ops: true
+  normalize_depth_formula: true
+  consensus_skip_gced_accept_votes: true
+  include_cancelled_randomness_txns_in_prologue: true
+  address_aliases: true
+  fix_checkpoint_signature_mapping: true
+  consensus_skip_gced_blocks_in_direct_finalization: true
+  gas_rounding_halve_digits: true
+  flexible_tx_context_positions: true
+  disable_entry_point_signature_check: true
+  restrict_hot_or_not_entry_functions: true
+  consensus_always_accept_system_transactions: true
+  validator_metadata_verify_v2: true
+  randomize_checkpoint_tx_limit_in_tests: true
+  gasless_transaction_drop_safety: true
+  merge_randomness_into_checkpoint: true
+  use_coin_party_owner: true
+  disallow_jump_orphans: true
+max_tx_size_bytes: 131072
+max_input_objects: 2048
+max_size_written_objects: 5000000
+max_size_written_objects_system_tx: 50000000
+max_serialized_tx_effects_size_bytes: 524288
+max_serialized_tx_effects_size_bytes_system_tx: 8388608
+max_gas_payment_objects: 256
+max_modules_in_publish: 64
+max_package_dependencies: 32
+max_arguments: 512
+max_type_arguments: 16
+max_type_argument_depth: 16
+max_pure_argument_size: 16384
+max_programmable_tx_commands: 1024
+move_binary_format_version: 7
+min_move_binary_format_version: 6
+binary_module_handles: 100
+binary_struct_handles: 300
+binary_function_handles: 1500
+binary_function_instantiations: 750
+binary_signatures: 1000
+binary_constant_pool: 4000
+binary_identifiers: 10000
+binary_address_identifiers: 100
+binary_struct_defs: 200
+binary_struct_def_instantiations: 100
+binary_function_defs: 1000
+binary_field_handles: 500
+binary_field_instantiations: 250
+binary_friend_decls: 100
+binary_variant_handles: 1024
+binary_variant_instantiation_handles: 1024
+max_move_object_size: 256000
+max_move_package_size: 102400
+max_publish_or_upgrade_per_ptb: 5
+max_tx_gas: 50000000000000
+max_gas_price: 50000000000
+max_gas_price_rgp_factor_for_aborted_transactions: 100
+max_gas_computation_bucket: 5000000
+gas_rounding_step: 1000
+max_loop_depth: 5
+max_generic_instantiation_length: 32
+max_function_parameters: 128
+max_basic_blocks: 1024
+max_value_stack_size: 1024
+max_type_nodes: 256
+max_push_size: 10000
+max_struct_definitions: 200
+max_function_definitions: 1000
+max_fields_in_struct: 32
+max_dependency_depth: 100
+max_num_event_emit: 1024
+max_num_new_move_object_ids: 2048
+max_num_new_move_object_ids_system_tx: 32768
+max_num_deleted_move_object_ids: 2048
+max_num_deleted_move_object_ids_system_tx: 32768
+max_num_transferred_move_object_ids: 2048
+max_num_transferred_move_object_ids_system_tx: 32768
+max_event_emit_size: 256000
+max_event_emit_size_total: 65536000
+max_move_vector_len: 262144
+max_move_identifier_len: 128
+max_move_value_depth: 128
+max_move_enum_variants: 127
+max_back_edges_per_function: 10000
+max_back_edges_per_module: 10000
+max_verifier_meter_ticks_per_function: 16000000
+max_meter_ticks_per_module: 16000000
+max_meter_ticks_per_package: 16000000
+object_runtime_max_num_cached_objects: 1000
+object_runtime_max_num_cached_objects_system_tx: 16000
+object_runtime_max_num_store_entries: 1000
+object_runtime_max_num_store_entries_system_tx: 16000
+base_tx_cost_fixed: 1000
+package_publish_cost_fixed: 1000
+base_tx_cost_per_byte: 0
+package_publish_cost_per_byte: 80
+obj_access_cost_read_per_byte: 15
+obj_access_cost_mutate_per_byte: 40
+obj_access_cost_delete_per_byte: 40
+obj_access_cost_verify_per_byte: 200
+max_type_to_layout_nodes: 512
+max_ptb_value_size: 1048576
+gas_model_version: 11
+obj_data_cost_refundable: 100
+obj_metadata_cost_non_refundable: 50
+storage_rebate_rate: 9900
+storage_fund_reinvest_rate: 500
+reward_slashing_rate: 10000
+storage_gas_price: 76
+accumulator_object_storage_cost: 7600
+max_transactions_per_checkpoint: 20000
+max_checkpoint_size_bytes: 31457280
+buffer_stake_for_protocol_upgrade_bps: 5000
+address_from_bytes_cost_base: 52
+address_to_u256_cost_base: 52
+address_from_u256_cost_base: 52
+config_read_setting_impl_cost_base: 100
+config_read_setting_impl_cost_per_byte: 40
+dynamic_field_hash_type_and_key_cost_base: 52
+dynamic_field_hash_type_and_key_type_cost_per_byte: 2
+dynamic_field_hash_type_and_key_value_cost_per_byte: 2
+dynamic_field_hash_type_and_key_type_tag_cost_per_byte: 2
+dynamic_field_add_child_object_cost_base: 52
+dynamic_field_add_child_object_type_cost_per_byte: 10
+dynamic_field_add_child_object_value_cost_per_byte: 1
+dynamic_field_add_child_object_struct_tag_cost_per_byte: 10
+dynamic_field_borrow_child_object_cost_base: 52
+dynamic_field_borrow_child_object_child_ref_cost_per_byte: 1
+dynamic_field_borrow_child_object_type_cost_per_byte: 10
+dynamic_field_remove_child_object_cost_base: 52
+dynamic_field_remove_child_object_child_cost_per_byte: 1
+dynamic_field_remove_child_object_type_cost_per_byte: 2
+dynamic_field_has_child_object_cost_base: 52
+dynamic_field_has_child_object_with_ty_cost_base: 52
+dynamic_field_has_child_object_with_ty_type_cost_per_byte: 2
+dynamic_field_has_child_object_with_ty_type_tag_cost_per_byte: 2
+event_emit_cost_base: 52
+event_emit_value_size_derivation_cost_per_byte: 2
+event_emit_tag_size_derivation_cost_per_byte: 5
+event_emit_output_cost_per_byte: 10
+event_emit_auth_stream_cost: 52
+object_borrow_uid_cost_base: 52
+object_delete_impl_cost_base: 52
+object_record_new_uid_cost_base: 52
+transfer_transfer_internal_cost_base: 52
+transfer_party_transfer_internal_cost_base: 52
+transfer_freeze_object_cost_base: 52
+transfer_share_object_cost_base: 52
+transfer_receive_object_cost_base: 52
+transfer_receive_object_cost_per_byte: 1
+transfer_receive_object_type_cost_per_byte: 2
+tx_context_derive_id_cost_base: 52
+tx_context_fresh_id_cost_base: 52
+tx_context_sender_cost_base: 30
+tx_context_epoch_cost_base: 30
+tx_context_epoch_timestamp_ms_cost_base: 30
+tx_context_sponsor_cost_base: 30
+tx_context_rgp_cost_base: 30
+tx_context_gas_price_cost_base: 30
+tx_context_gas_budget_cost_base: 30
+tx_context_ids_created_cost_base: 30
+tx_context_replace_cost_base: 30
+types_is_one_time_witness_cost_base: 52
+types_is_one_time_witness_type_tag_cost_per_byte: 2
+types_is_one_time_witness_type_cost_per_byte: 2
+validator_validate_metadata_cost_base: 20000
+validator_validate_metadata_data_cost_per_byte: 2
+crypto_invalid_arguments_cost: 100
+bls12381_bls12381_min_sig_verify_cost_base: 44064
+bls12381_bls12381_min_sig_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_sig_verify_msg_cost_per_block: 2
+bls12381_bls12381_min_pk_verify_cost_base: 49282
+bls12381_bls12381_min_pk_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_pk_verify_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_keccak256_cost_base: 500
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_sha256_cost_base: 500
+ecdsa_k1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_k1_decompress_pubkey_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_cost_base: 1470
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_k1_secp256k1_verify_sha256_cost_base: 1470
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_keccak256_cost_base: 1173
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_sha256_cost_base: 1173
+ecdsa_r1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_keccak256_cost_base: 4225
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_sha256_cost_base: 4225
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_block: 2
+ecvrf_ecvrf_verify_cost_base: 4848
+ecvrf_ecvrf_verify_alpha_string_cost_per_byte: 2
+ecvrf_ecvrf_verify_alpha_string_cost_per_block: 2
+ed25519_ed25519_verify_cost_base: 1802
+ed25519_ed25519_verify_msg_cost_per_byte: 2
+ed25519_ed25519_verify_msg_cost_per_block: 2
+groth16_prepare_verifying_key_bls12381_cost_base: 53838
+groth16_prepare_verifying_key_bn254_cost_base: 82010
+groth16_verify_groth16_proof_internal_bls12381_cost_base: 72090
+groth16_verify_groth16_proof_internal_bls12381_cost_per_public_input: 8213
+groth16_verify_groth16_proof_internal_bn254_cost_base: 115502
+groth16_verify_groth16_proof_internal_bn254_cost_per_public_input: 9484
+groth16_verify_groth16_proof_internal_public_input_cost_per_byte: 2
+hash_blake2b256_cost_base: 10
+hash_blake2b256_data_cost_per_byte: 2
+hash_blake2b256_data_cost_per_block: 2
+hash_keccak256_cost_base: 10
+hash_keccak256_data_cost_per_byte: 2
+hash_keccak256_data_cost_per_block: 2
+poseidon_bn254_cost_base: 260
+poseidon_bn254_cost_per_block: 388
+group_ops_bls12381_decode_scalar_cost: 7
+group_ops_bls12381_decode_g1_cost: 2848
+group_ops_bls12381_decode_g2_cost: 3770
+group_ops_bls12381_decode_gt_cost: 3068
+group_ops_bls12381_scalar_add_cost: 10
+group_ops_bls12381_g1_add_cost: 1556
+group_ops_bls12381_g2_add_cost: 3048
+group_ops_bls12381_gt_add_cost: 188
+group_ops_bls12381_scalar_sub_cost: 10
+group_ops_bls12381_g1_sub_cost: 1550
+group_ops_bls12381_g2_sub_cost: 3019
+group_ops_bls12381_gt_sub_cost: 497
+group_ops_bls12381_scalar_mul_cost: 11
+group_ops_bls12381_g1_mul_cost: 4842
+group_ops_bls12381_g2_mul_cost: 9108
+group_ops_bls12381_gt_mul_cost: 27490
+group_ops_bls12381_scalar_div_cost: 91
+group_ops_bls12381_g1_div_cost: 5091
+group_ops_bls12381_g2_div_cost: 9206
+group_ops_bls12381_gt_div_cost: 27804
+group_ops_bls12381_g1_hash_to_base_cost: 2962
+group_ops_bls12381_g2_hash_to_base_cost: 8688
+group_ops_bls12381_g1_hash_to_cost_per_byte: 2
+group_ops_bls12381_g2_hash_to_cost_per_byte: 2
+group_ops_bls12381_g1_msm_base_cost: 62648
+group_ops_bls12381_g2_msm_base_cost: 131192
+group_ops_bls12381_g1_msm_base_cost_per_input: 1333
+group_ops_bls12381_g2_msm_base_cost_per_input: 3216
+group_ops_bls12381_msm_max_len: 32
+group_ops_bls12381_pairing_cost: 26897
+group_ops_bls12381_g1_to_uncompressed_g1_cost: 2099
+group_ops_bls12381_uncompressed_g1_to_g1_cost: 677
+group_ops_bls12381_uncompressed_g1_sum_base_cost: 77
+group_ops_bls12381_uncompressed_g1_sum_cost_per_term: 26
+group_ops_bls12381_uncompressed_g1_sum_max_terms: 1200
+group_ops_ristretto_decode_scalar_cost: 7
+group_ops_ristretto_decode_point_cost: 200
+group_ops_ristretto_scalar_add_cost: 10
+group_ops_ristretto_point_add_cost: 500
+group_ops_ristretto_scalar_sub_cost: 10
+group_ops_ristretto_point_sub_cost: 500
+group_ops_ristretto_scalar_mul_cost: 11
+group_ops_ristretto_point_mul_cost: 1200
+group_ops_ristretto_scalar_div_cost: 151
+group_ops_ristretto_point_div_cost: 2500
+hmac_hmac_sha3_256_cost_base: 52
+hmac_hmac_sha3_256_input_cost_per_byte: 2
+hmac_hmac_sha3_256_input_cost_per_block: 2
+check_zklogin_id_cost_base: 200
+check_zklogin_issuer_cost_base: 200
+nitro_attestation_parse_base_cost: 2650
+nitro_attestation_parse_cost_per_byte: 50
+nitro_attestation_verify_base_cost: 2481600
+nitro_attestation_verify_cost_per_cert: 2618450
+bcs_per_byte_serialized_cost: 2
+bcs_legacy_min_output_size_cost: 1
+bcs_failure_cost: 52
+hash_sha2_256_base_cost: 52
+hash_sha2_256_per_byte_cost: 2
+hash_sha2_256_legacy_min_input_len_cost: 1
+hash_sha3_256_base_cost: 52
+hash_sha3_256_per_byte_cost: 2
+hash_sha3_256_legacy_min_input_len_cost: 1
+type_name_get_base_cost: 52
+type_name_get_per_byte_cost: 2
+type_name_id_base_cost: 52
+string_check_utf8_base_cost: 52
+string_check_utf8_per_byte_cost: 2
+string_is_char_boundary_base_cost: 52
+string_sub_string_base_cost: 52
+string_sub_string_per_byte_cost: 2
+string_index_of_base_cost: 52
+string_index_of_per_byte_pattern_cost: 2
+string_index_of_per_byte_searched_cost: 2
+vector_empty_base_cost: 52
+vector_length_base_cost: 52
+vector_push_back_base_cost: 52
+vector_push_back_legacy_per_abstract_memory_unit_cost: 2
+vector_borrow_base_cost: 52
+vector_pop_back_base_cost: 52
+vector_destroy_empty_base_cost: 52
+vector_swap_base_cost: 52
+debug_print_base_cost: 52
+debug_print_stack_trace_base_cost: 52
+execution_version: 4
+consensus_bad_nodes_stake_threshold: 30
+max_jwk_votes_per_validator_per_epoch: 240
+max_age_of_jwk_in_epochs: 1
+random_beacon_reduction_allowed_delta: 800
+random_beacon_reduction_lower_bound: 500
+random_beacon_dkg_timeout_round: 3000
+random_beacon_min_round_interval_ms: 500
+random_beacon_dkg_version: 1
+consensus_max_transaction_size_bytes: 262144
+consensus_max_transactions_in_block_bytes: 524288
+consensus_max_num_transactions_in_block: 512
+consensus_voting_rounds: 40
+max_accumulated_txn_cost_per_object_in_narwhal_commit: 40
+max_deferral_rounds_for_congestion_control: 10
+max_txn_cost_overage_per_object_in_commit: 18446744073709551615
+allowed_txn_cost_overage_burst_per_object_in_commit: 370000000
+min_checkpoint_interval_ms: 200
+checkpoint_summary_version_specific_data: 1
+max_soft_bundle_size: 5
+bridge_should_try_to_finalize_committee: true
+max_accumulated_txn_cost_per_object_in_mysticeti_commit: 37000000
+max_accumulated_randomness_txn_cost_per_object_in_mysticeti_commit: 7400000
+consensus_gc_depth: 60
+gas_budget_based_txn_cost_cap_factor: 400000
+gas_budget_based_txn_cost_absolute_cap_commit_count: 50
+sip_45_consensus_amplification_threshold: 5
+use_object_per_epoch_marker_table_v2: true
+consensus_commit_rate_estimation_window_size: 10
+aliased_addresses:
+  - original:
+      - 205
+      - 137
+      - 98
+      - 218
+      - 210
+      - 120
+      - 216
+      - 181
+      - 15
+      - 160
+      - 249
+      - 235
+      - 1
+      - 134
+      - 191
+      - 164
+      - 203
+      - 222
+      - 204
+      - 109
+      - 89
+      - 55
+      - 114
+      - 20
+      - 200
+      - 141
+      - 2
+      - 134
+      - 160
+      - 172
+      - 149
+      - 98
+    aliased:
+      - 11
+      - 45
+      - 163
+      - 39
+      - 186
+      - 106
+      - 76
+      - 172
+      - 190
+      - 117
+      - 221
+      - 221
+      - 80
+      - 230
+      - 232
+      - 187
+      - 248
+      - 29
+      - 100
+      - 150
+      - 233
+      - 45
+      - 102
+      - 175
+      - 145
+      - 84
+      - 198
+      - 28
+      - 119
+      - 247
+      - 51
+      - 47
+    allowed_tx_digests:
+      - - 2
+        - 145
+        - 170
+        - 78
+        - 99
+        - 246
+        - 130
+        - 221
+        - 11
+        - 53
+        - 228
+        - 241
+        - 202
+        - 113
+        - 56
+        - 105
+        - 120
+        - 236
+        - 143
+        - 114
+        - 165
+        - 106
+        - 212
+        - 165
+        - 196
+        - 178
+        - 239
+        - 253
+        - 97
+        - 66
+        - 98
+        - 197
+  - original:
+      - 226
+      - 139
+      - 80
+      - 206
+      - 241
+      - 214
+      - 51
+      - 234
+      - 67
+      - 211
+      - 41
+      - 106
+      - 63
+      - 107
+      - 103
+      - 255
+      - 3
+      - 18
+      - 165
+      - 241
+      - 169
+      - 159
+      - 10
+      - 247
+      - 83
+      - 200
+      - 91
+      - 139
+      - 93
+      - 232
+      - 255
+      - 6
+    aliased:
+      - 11
+      - 45
+      - 163
+      - 39
+      - 186
+      - 106
+      - 76
+      - 172
+      - 190
+      - 117
+      - 221
+      - 221
+      - 80
+      - 230
+      - 232
+      - 187
+      - 248
+      - 29
+      - 100
+      - 150
+      - 233
+      - 45
+      - 102
+      - 175
+      - 145
+      - 84
+      - 198
+      - 28
+      - 119
+      - 247
+      - 51
+      - 47
+    allowed_tx_digests:
+      - - 253
+        - 118
+        - 94
+        - 221
+        - 205
+        - 105
+        - 164
+        - 185
+        - 146
+        - 65
+        - 207
+        - 179
+        - 194
+        - 136
+        - 51
+        - 126
+        - 222
+        - 28
+        - 78
+        - 230
+        - 151
+        - 0
+        - 147
+        - 120
+        - 44
+        - 55
+        - 155
+        - 111
+        - 243
+        - 35
+        - 173
+        - 119
+translation_per_command_base_charge: 1
+translation_per_input_base_charge: 1
+translation_pure_input_per_byte_charge: 1
+translation_per_type_node_charge: 1
+translation_per_reference_node_charge: 1
+translation_per_linkage_entry_charge: 10
+max_updates_per_settlement_txn: 100
+gasless_max_unused_inputs: 1
+gasless_max_pure_input_bytes: 32

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_120.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_120.snap
@@ -1,0 +1,490 @@
+---
+source: crates/sui-protocol-config/src/lib.rs
+expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
+---
+version: 120
+feature_flags:
+  package_upgrades: true
+  commit_root_state_digest: true
+  advance_epoch_start_time_in_safe_mode: true
+  loaded_child_objects_fixed: true
+  missing_type_is_compatibility_error: true
+  scoring_decision_with_validity_cutoff: true
+  consensus_order_end_of_epoch_last: true
+  disallow_adding_abilities_on_upgrade: true
+  disable_invariant_violation_check_in_swap_loc: true
+  advance_to_highest_supported_protocol_version: true
+  ban_entry_init: true
+  package_digest_hash_module: true
+  disallow_change_struct_type_params_on_upgrade: true
+  no_extraneous_module_bytes: true
+  narwhal_versioned_metadata: true
+  zklogin_auth: true
+  consensus_transaction_ordering: ByGasPrice
+  simplified_unwrap_then_delete: true
+  upgraded_multisig_supported: true
+  txn_base_cost_as_multiplier: true
+  shared_object_deletion: true
+  narwhal_new_leader_election_schedule: true
+  loaded_child_object_format: true
+  enable_jwk_consensus_updates: true
+  end_of_epoch_transaction_supported: true
+  simple_conservation_checks: true
+  loaded_child_object_format_type: true
+  receive_objects: true
+  consensus_checkpoint_signature_key_includes_digest: true
+  random_beacon: true
+  bridge: true
+  enable_effects_v2: true
+  narwhal_certificate_v2: true
+  verify_legacy_zklogin_address: true
+  recompute_has_public_transfer_in_execution: true
+  accept_zklogin_in_multisig: true
+  accept_passkey_in_multisig: true
+  validate_zklogin_public_identifier: true
+  include_consensus_digest_in_prologue: true
+  hardened_otw_check: true
+  allow_receiving_object_id: true
+  enable_poseidon: true
+  enable_coin_deny_list: true
+  enable_group_ops_native_functions: true
+  enable_nitro_attestation: true
+  enable_nitro_attestation_upgraded_parsing: true
+  enable_nitro_attestation_all_nonzero_pcrs_parsing: true
+  enable_nitro_attestation_always_include_required_pcrs_parsing: true
+  reject_mutable_random_on_entry_functions: true
+  per_object_congestion_control_mode:
+    ExecutionTimeEstimate:
+      target_utilization: 50
+      allowed_txn_cost_overage_burst_limit_us: 500000
+      randomness_scalar: 20
+      max_estimate_us: 1500000
+      stored_observations_num_included_checkpoints: 10
+      stored_observations_limit: 180
+      stake_weighted_median_threshold: 3334
+      default_none_duration_for_new_keys: true
+      observations_chunk_size: 18
+  consensus_choice: Mysticeti
+  consensus_network: Tonic
+  correct_gas_payment_limit_check: true
+  zklogin_max_epoch_upper_bound_delta: 30
+  mysticeti_leader_scoring_and_schedule: true
+  reshare_at_same_initial_version: true
+  resolve_abort_locations_to_package_id: true
+  mysticeti_use_committed_subdag_digest: true
+  record_consensus_determined_version_assignments_in_prologue: true
+  record_consensus_determined_version_assignments_in_prologue_v2: true
+  fresh_vm_on_framework_upgrade: true
+  prepend_prologue_tx_in_consensus_commit_in_checkpoints: true
+  mysticeti_num_leaders_per_round: 1
+  soft_bundle: true
+  enable_coin_deny_list_v2: true
+  passkey_auth: true
+  authority_capabilities_v2: true
+  rethrow_serialization_type_layout_errors: true
+  consensus_distributed_vote_scoring_strategy: true
+  consensus_round_prober: true
+  validate_identifier_inputs: true
+  disallow_self_identifier: true
+  mysticeti_fastpath: true
+  disable_preconsensus_locking: true
+  relocate_event_module: true
+  uncompressed_g1_group_elements: true
+  disallow_new_modules_in_deps_only_packages: true
+  consensus_smart_ancestor_selection: true
+  consensus_round_prober_probe_accepted_rounds: true
+  native_charging_v2: true
+  consensus_linearize_subdag_v2: true
+  convert_type_argument_error: true
+  variant_nodes: true
+  consensus_zstd_compression: true
+  minimize_child_object_mutations: true
+  record_additional_state_digest_in_prologue: true
+  move_native_context: true
+  consensus_median_based_commit_timestamp: true
+  normalize_ptb_arguments: true
+  consensus_batched_block_sync: true
+  enforce_checkpoint_timestamp_monotonicity: true
+  max_ptb_value_size_v2: true
+  resolve_type_input_ids_to_defining_id: true
+  enable_party_transfer: true
+  allow_unbounded_system_objects: true
+  type_tags_in_object_runtime: true
+  enable_accumulators: true
+  enable_coin_reservation_obj_refs: true
+  create_root_accumulator_object: true
+  enable_authenticated_event_streams: true
+  enable_address_balance_gas_payments: true
+  address_balance_gas_check_rgp_at_signing: true
+  enable_multi_epoch_transaction_expiration: true
+  relax_valid_during_for_owned_inputs: true
+  enable_ptb_execution_v2: true
+  better_adapter_type_resolution_errors: true
+  record_time_estimate_processed: true
+  dependency_linkage_error: true
+  additional_multisig_checks: true
+  ignore_execution_time_observations_after_certs_closed: true
+  debug_fatal_on_move_invariant_violation: true
+  additional_consensus_digest_indirect_state: true
+  check_for_init_during_upgrade: true
+  include_checkpoint_artifacts_digest_in_summary: true
+  use_mfp_txns_in_load_initial_object_debts: true
+  cancel_for_failed_dkg_early: true
+  enable_coin_registry: true
+  abstract_size_in_object_runtime: true
+  object_runtime_charge_cache_load_gas: true
+  additional_borrow_checks: true
+  use_new_commit_handler: true
+  better_loader_errors: true
+  generate_df_type_layouts: true
+  enable_display_registry: true
+  private_generics_verifier_v2: true
+  deprecate_global_storage_ops: true
+  normalize_depth_formula: true
+  consensus_skip_gced_accept_votes: true
+  include_cancelled_randomness_txns_in_prologue: true
+  address_aliases: true
+  fix_checkpoint_signature_mapping: true
+  enable_object_funds_withdraw: true
+  consensus_skip_gced_blocks_in_direct_finalization: true
+  gas_rounding_halve_digits: true
+  flexible_tx_context_positions: true
+  disable_entry_point_signature_check: true
+  convert_withdrawal_compatibility_ptb_arguments: true
+  restrict_hot_or_not_entry_functions: true
+  split_checkpoints_in_consensus_handler: true
+  consensus_always_accept_system_transactions: true
+  validator_metadata_verify_v2: true
+  randomize_checkpoint_tx_limit_in_tests: true
+  gasless_transaction_drop_safety: true
+  merge_randomness_into_checkpoint: true
+  use_coin_party_owner: true
+  enable_gasless: true
+  disallow_jump_orphans: true
+max_tx_size_bytes: 131072
+max_input_objects: 2048
+max_size_written_objects: 5000000
+max_size_written_objects_system_tx: 50000000
+max_serialized_tx_effects_size_bytes: 524288
+max_serialized_tx_effects_size_bytes_system_tx: 8388608
+max_gas_payment_objects: 256
+max_modules_in_publish: 64
+max_package_dependencies: 32
+max_arguments: 512
+max_type_arguments: 16
+max_type_argument_depth: 16
+max_pure_argument_size: 16384
+max_programmable_tx_commands: 1024
+move_binary_format_version: 7
+min_move_binary_format_version: 6
+binary_module_handles: 100
+binary_struct_handles: 300
+binary_function_handles: 1500
+binary_function_instantiations: 750
+binary_signatures: 1000
+binary_constant_pool: 4000
+binary_identifiers: 10000
+binary_address_identifiers: 100
+binary_struct_defs: 200
+binary_struct_def_instantiations: 100
+binary_function_defs: 1000
+binary_field_handles: 500
+binary_field_instantiations: 250
+binary_friend_decls: 100
+binary_variant_handles: 1024
+binary_variant_instantiation_handles: 1024
+max_move_object_size: 256000
+max_move_package_size: 102400
+max_publish_or_upgrade_per_ptb: 5
+max_tx_gas: 50000000000000
+max_gas_price: 50000000000
+max_gas_price_rgp_factor_for_aborted_transactions: 100
+max_gas_computation_bucket: 5000000
+gas_rounding_step: 1000
+max_loop_depth: 5
+max_generic_instantiation_length: 32
+max_function_parameters: 128
+max_basic_blocks: 1024
+max_value_stack_size: 1024
+max_type_nodes: 256
+max_push_size: 10000
+max_struct_definitions: 200
+max_function_definitions: 1000
+max_fields_in_struct: 32
+max_dependency_depth: 100
+max_num_event_emit: 1024
+max_num_new_move_object_ids: 2048
+max_num_new_move_object_ids_system_tx: 32768
+max_num_deleted_move_object_ids: 2048
+max_num_deleted_move_object_ids_system_tx: 32768
+max_num_transferred_move_object_ids: 2048
+max_num_transferred_move_object_ids_system_tx: 32768
+max_event_emit_size: 256000
+max_event_emit_size_total: 65536000
+max_move_vector_len: 262144
+max_move_identifier_len: 128
+max_move_value_depth: 128
+max_move_enum_variants: 127
+max_back_edges_per_function: 10000
+max_back_edges_per_module: 10000
+max_verifier_meter_ticks_per_function: 16000000
+max_meter_ticks_per_module: 16000000
+max_meter_ticks_per_package: 16000000
+object_runtime_max_num_cached_objects: 1000
+object_runtime_max_num_cached_objects_system_tx: 16000
+object_runtime_max_num_store_entries: 1000
+object_runtime_max_num_store_entries_system_tx: 16000
+base_tx_cost_fixed: 1000
+package_publish_cost_fixed: 1000
+base_tx_cost_per_byte: 0
+package_publish_cost_per_byte: 80
+obj_access_cost_read_per_byte: 15
+obj_access_cost_mutate_per_byte: 40
+obj_access_cost_delete_per_byte: 40
+obj_access_cost_verify_per_byte: 200
+max_type_to_layout_nodes: 512
+max_ptb_value_size: 1048576
+gas_model_version: 11
+obj_data_cost_refundable: 100
+obj_metadata_cost_non_refundable: 50
+storage_rebate_rate: 9900
+storage_fund_reinvest_rate: 500
+reward_slashing_rate: 10000
+storage_gas_price: 76
+accumulator_object_storage_cost: 7600
+max_transactions_per_checkpoint: 20000
+max_checkpoint_size_bytes: 31457280
+buffer_stake_for_protocol_upgrade_bps: 5000
+address_from_bytes_cost_base: 52
+address_to_u256_cost_base: 52
+address_from_u256_cost_base: 52
+config_read_setting_impl_cost_base: 100
+config_read_setting_impl_cost_per_byte: 40
+dynamic_field_hash_type_and_key_cost_base: 52
+dynamic_field_hash_type_and_key_type_cost_per_byte: 2
+dynamic_field_hash_type_and_key_value_cost_per_byte: 2
+dynamic_field_hash_type_and_key_type_tag_cost_per_byte: 2
+dynamic_field_add_child_object_cost_base: 52
+dynamic_field_add_child_object_type_cost_per_byte: 10
+dynamic_field_add_child_object_value_cost_per_byte: 1
+dynamic_field_add_child_object_struct_tag_cost_per_byte: 10
+dynamic_field_borrow_child_object_cost_base: 52
+dynamic_field_borrow_child_object_child_ref_cost_per_byte: 1
+dynamic_field_borrow_child_object_type_cost_per_byte: 10
+dynamic_field_remove_child_object_cost_base: 52
+dynamic_field_remove_child_object_child_cost_per_byte: 1
+dynamic_field_remove_child_object_type_cost_per_byte: 2
+dynamic_field_has_child_object_cost_base: 52
+dynamic_field_has_child_object_with_ty_cost_base: 52
+dynamic_field_has_child_object_with_ty_type_cost_per_byte: 2
+dynamic_field_has_child_object_with_ty_type_tag_cost_per_byte: 2
+event_emit_cost_base: 52
+event_emit_value_size_derivation_cost_per_byte: 2
+event_emit_tag_size_derivation_cost_per_byte: 5
+event_emit_output_cost_per_byte: 10
+event_emit_auth_stream_cost: 52
+object_borrow_uid_cost_base: 52
+object_delete_impl_cost_base: 52
+object_record_new_uid_cost_base: 52
+transfer_transfer_internal_cost_base: 52
+transfer_party_transfer_internal_cost_base: 52
+transfer_freeze_object_cost_base: 52
+transfer_share_object_cost_base: 52
+transfer_receive_object_cost_base: 52
+transfer_receive_object_cost_per_byte: 1
+transfer_receive_object_type_cost_per_byte: 2
+tx_context_derive_id_cost_base: 52
+tx_context_fresh_id_cost_base: 52
+tx_context_sender_cost_base: 30
+tx_context_epoch_cost_base: 30
+tx_context_epoch_timestamp_ms_cost_base: 30
+tx_context_sponsor_cost_base: 30
+tx_context_rgp_cost_base: 30
+tx_context_gas_price_cost_base: 30
+tx_context_gas_budget_cost_base: 30
+tx_context_ids_created_cost_base: 30
+tx_context_replace_cost_base: 30
+types_is_one_time_witness_cost_base: 52
+types_is_one_time_witness_type_tag_cost_per_byte: 2
+types_is_one_time_witness_type_cost_per_byte: 2
+validator_validate_metadata_cost_base: 20000
+validator_validate_metadata_data_cost_per_byte: 2
+crypto_invalid_arguments_cost: 100
+bls12381_bls12381_min_sig_verify_cost_base: 44064
+bls12381_bls12381_min_sig_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_sig_verify_msg_cost_per_block: 2
+bls12381_bls12381_min_pk_verify_cost_base: 49282
+bls12381_bls12381_min_pk_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_pk_verify_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_keccak256_cost_base: 500
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_sha256_cost_base: 500
+ecdsa_k1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_k1_decompress_pubkey_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_cost_base: 1470
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_k1_secp256k1_verify_sha256_cost_base: 1470
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_keccak256_cost_base: 1173
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_sha256_cost_base: 1173
+ecdsa_r1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_keccak256_cost_base: 4225
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_sha256_cost_base: 4225
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_block: 2
+ecvrf_ecvrf_verify_cost_base: 4848
+ecvrf_ecvrf_verify_alpha_string_cost_per_byte: 2
+ecvrf_ecvrf_verify_alpha_string_cost_per_block: 2
+ed25519_ed25519_verify_cost_base: 1802
+ed25519_ed25519_verify_msg_cost_per_byte: 2
+ed25519_ed25519_verify_msg_cost_per_block: 2
+groth16_prepare_verifying_key_bls12381_cost_base: 53838
+groth16_prepare_verifying_key_bn254_cost_base: 82010
+groth16_verify_groth16_proof_internal_bls12381_cost_base: 72090
+groth16_verify_groth16_proof_internal_bls12381_cost_per_public_input: 8213
+groth16_verify_groth16_proof_internal_bn254_cost_base: 115502
+groth16_verify_groth16_proof_internal_bn254_cost_per_public_input: 9484
+groth16_verify_groth16_proof_internal_public_input_cost_per_byte: 2
+hash_blake2b256_cost_base: 10
+hash_blake2b256_data_cost_per_byte: 2
+hash_blake2b256_data_cost_per_block: 2
+hash_keccak256_cost_base: 10
+hash_keccak256_data_cost_per_byte: 2
+hash_keccak256_data_cost_per_block: 2
+poseidon_bn254_cost_base: 260
+poseidon_bn254_cost_per_block: 388
+group_ops_bls12381_decode_scalar_cost: 7
+group_ops_bls12381_decode_g1_cost: 2848
+group_ops_bls12381_decode_g2_cost: 3770
+group_ops_bls12381_decode_gt_cost: 3068
+group_ops_bls12381_scalar_add_cost: 10
+group_ops_bls12381_g1_add_cost: 1556
+group_ops_bls12381_g2_add_cost: 3048
+group_ops_bls12381_gt_add_cost: 188
+group_ops_bls12381_scalar_sub_cost: 10
+group_ops_bls12381_g1_sub_cost: 1550
+group_ops_bls12381_g2_sub_cost: 3019
+group_ops_bls12381_gt_sub_cost: 497
+group_ops_bls12381_scalar_mul_cost: 11
+group_ops_bls12381_g1_mul_cost: 4842
+group_ops_bls12381_g2_mul_cost: 9108
+group_ops_bls12381_gt_mul_cost: 27490
+group_ops_bls12381_scalar_div_cost: 91
+group_ops_bls12381_g1_div_cost: 5091
+group_ops_bls12381_g2_div_cost: 9206
+group_ops_bls12381_gt_div_cost: 27804
+group_ops_bls12381_g1_hash_to_base_cost: 2962
+group_ops_bls12381_g2_hash_to_base_cost: 8688
+group_ops_bls12381_g1_hash_to_cost_per_byte: 2
+group_ops_bls12381_g2_hash_to_cost_per_byte: 2
+group_ops_bls12381_g1_msm_base_cost: 62648
+group_ops_bls12381_g2_msm_base_cost: 131192
+group_ops_bls12381_g1_msm_base_cost_per_input: 1333
+group_ops_bls12381_g2_msm_base_cost_per_input: 3216
+group_ops_bls12381_msm_max_len: 32
+group_ops_bls12381_pairing_cost: 26897
+group_ops_bls12381_g1_to_uncompressed_g1_cost: 2099
+group_ops_bls12381_uncompressed_g1_to_g1_cost: 677
+group_ops_bls12381_uncompressed_g1_sum_base_cost: 77
+group_ops_bls12381_uncompressed_g1_sum_cost_per_term: 26
+group_ops_bls12381_uncompressed_g1_sum_max_terms: 1200
+group_ops_ristretto_decode_scalar_cost: 7
+group_ops_ristretto_decode_point_cost: 200
+group_ops_ristretto_scalar_add_cost: 10
+group_ops_ristretto_point_add_cost: 500
+group_ops_ristretto_scalar_sub_cost: 10
+group_ops_ristretto_point_sub_cost: 500
+group_ops_ristretto_scalar_mul_cost: 11
+group_ops_ristretto_point_mul_cost: 1200
+group_ops_ristretto_scalar_div_cost: 151
+group_ops_ristretto_point_div_cost: 2500
+hmac_hmac_sha3_256_cost_base: 52
+hmac_hmac_sha3_256_input_cost_per_byte: 2
+hmac_hmac_sha3_256_input_cost_per_block: 2
+check_zklogin_id_cost_base: 200
+check_zklogin_issuer_cost_base: 200
+nitro_attestation_parse_base_cost: 2650
+nitro_attestation_parse_cost_per_byte: 50
+nitro_attestation_verify_base_cost: 2481600
+nitro_attestation_verify_cost_per_cert: 2618450
+bcs_per_byte_serialized_cost: 2
+bcs_legacy_min_output_size_cost: 1
+bcs_failure_cost: 52
+hash_sha2_256_base_cost: 52
+hash_sha2_256_per_byte_cost: 2
+hash_sha2_256_legacy_min_input_len_cost: 1
+hash_sha3_256_base_cost: 52
+hash_sha3_256_per_byte_cost: 2
+hash_sha3_256_legacy_min_input_len_cost: 1
+type_name_get_base_cost: 52
+type_name_get_per_byte_cost: 2
+type_name_id_base_cost: 52
+string_check_utf8_base_cost: 52
+string_check_utf8_per_byte_cost: 2
+string_is_char_boundary_base_cost: 52
+string_sub_string_base_cost: 52
+string_sub_string_per_byte_cost: 2
+string_index_of_base_cost: 52
+string_index_of_per_byte_pattern_cost: 2
+string_index_of_per_byte_searched_cost: 2
+vector_empty_base_cost: 52
+vector_length_base_cost: 52
+vector_push_back_base_cost: 52
+vector_push_back_legacy_per_abstract_memory_unit_cost: 2
+vector_borrow_base_cost: 52
+vector_pop_back_base_cost: 52
+vector_destroy_empty_base_cost: 52
+vector_swap_base_cost: 52
+debug_print_base_cost: 52
+debug_print_stack_trace_base_cost: 52
+execution_version: 4
+consensus_bad_nodes_stake_threshold: 30
+max_jwk_votes_per_validator_per_epoch: 240
+max_age_of_jwk_in_epochs: 1
+random_beacon_reduction_allowed_delta: 800
+random_beacon_reduction_lower_bound: 500
+random_beacon_dkg_timeout_round: 3000
+random_beacon_min_round_interval_ms: 500
+random_beacon_dkg_version: 1
+consensus_max_transaction_size_bytes: 262144
+consensus_max_transactions_in_block_bytes: 524288
+consensus_max_num_transactions_in_block: 512
+consensus_voting_rounds: 40
+max_accumulated_txn_cost_per_object_in_narwhal_commit: 40
+max_deferral_rounds_for_congestion_control: 10
+max_txn_cost_overage_per_object_in_commit: 18446744073709551615
+allowed_txn_cost_overage_burst_per_object_in_commit: 370000000
+min_checkpoint_interval_ms: 200
+checkpoint_summary_version_specific_data: 1
+max_soft_bundle_size: 5
+bridge_should_try_to_finalize_committee: true
+max_accumulated_txn_cost_per_object_in_mysticeti_commit: 37000000
+max_accumulated_randomness_txn_cost_per_object_in_mysticeti_commit: 7400000
+consensus_gc_depth: 60
+gas_budget_based_txn_cost_cap_factor: 400000
+gas_budget_based_txn_cost_absolute_cap_commit_count: 50
+sip_45_consensus_amplification_threshold: 5
+use_object_per_epoch_marker_table_v2: true
+consensus_commit_rate_estimation_window_size: 10
+translation_per_command_base_charge: 1
+translation_per_input_base_charge: 1
+translation_pure_input_per_byte_charge: 1
+translation_per_type_node_charge: 1
+translation_per_reference_node_charge: 1
+translation_per_linkage_entry_charge: 10
+max_updates_per_settlement_txn: 100
+gasless_max_computation_units: 50000
+gasless_allowed_token_types:
+  - - "0xa1ec7fc00a6f40db9693ad1415d0c193ad3906494428cf252621037bd7117e29::usdc::USDC"
+    - 0
+gasless_max_unused_inputs: 1
+gasless_max_pure_input_bytes: 32

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_120.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_120.snap
@@ -1,0 +1,493 @@
+---
+source: crates/sui-protocol-config/src/lib.rs
+expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
+---
+version: 120
+feature_flags:
+  package_upgrades: true
+  commit_root_state_digest: true
+  advance_epoch_start_time_in_safe_mode: true
+  loaded_child_objects_fixed: true
+  missing_type_is_compatibility_error: true
+  scoring_decision_with_validity_cutoff: true
+  consensus_order_end_of_epoch_last: true
+  disallow_adding_abilities_on_upgrade: true
+  disable_invariant_violation_check_in_swap_loc: true
+  advance_to_highest_supported_protocol_version: true
+  ban_entry_init: true
+  package_digest_hash_module: true
+  disallow_change_struct_type_params_on_upgrade: true
+  no_extraneous_module_bytes: true
+  narwhal_versioned_metadata: true
+  zklogin_auth: true
+  consensus_transaction_ordering: ByGasPrice
+  simplified_unwrap_then_delete: true
+  upgraded_multisig_supported: true
+  txn_base_cost_as_multiplier: true
+  shared_object_deletion: true
+  narwhal_new_leader_election_schedule: true
+  loaded_child_object_format: true
+  enable_jwk_consensus_updates: true
+  end_of_epoch_transaction_supported: true
+  simple_conservation_checks: true
+  loaded_child_object_format_type: true
+  receive_objects: true
+  consensus_checkpoint_signature_key_includes_digest: true
+  random_beacon: true
+  bridge: true
+  enable_effects_v2: true
+  narwhal_certificate_v2: true
+  verify_legacy_zklogin_address: true
+  recompute_has_public_transfer_in_execution: true
+  accept_zklogin_in_multisig: true
+  accept_passkey_in_multisig: true
+  validate_zklogin_public_identifier: true
+  include_consensus_digest_in_prologue: true
+  hardened_otw_check: true
+  allow_receiving_object_id: true
+  enable_poseidon: true
+  enable_coin_deny_list: true
+  enable_group_ops_native_functions: true
+  enable_group_ops_native_function_msm: true
+  enable_ristretto255_group_ops: true
+  enable_nitro_attestation: true
+  enable_nitro_attestation_upgraded_parsing: true
+  enable_nitro_attestation_all_nonzero_pcrs_parsing: true
+  enable_nitro_attestation_always_include_required_pcrs_parsing: true
+  reject_mutable_random_on_entry_functions: true
+  per_object_congestion_control_mode:
+    ExecutionTimeEstimate:
+      target_utilization: 50
+      allowed_txn_cost_overage_burst_limit_us: 500000
+      randomness_scalar: 20
+      max_estimate_us: 1500000
+      stored_observations_num_included_checkpoints: 10
+      stored_observations_limit: 180
+      stake_weighted_median_threshold: 3334
+      default_none_duration_for_new_keys: true
+      observations_chunk_size: 18
+  consensus_choice: Mysticeti
+  consensus_network: Tonic
+  correct_gas_payment_limit_check: true
+  zklogin_max_epoch_upper_bound_delta: 30
+  mysticeti_leader_scoring_and_schedule: true
+  reshare_at_same_initial_version: true
+  resolve_abort_locations_to_package_id: true
+  mysticeti_use_committed_subdag_digest: true
+  enable_vdf: true
+  record_consensus_determined_version_assignments_in_prologue: true
+  record_consensus_determined_version_assignments_in_prologue_v2: true
+  fresh_vm_on_framework_upgrade: true
+  prepend_prologue_tx_in_consensus_commit_in_checkpoints: true
+  mysticeti_num_leaders_per_round: 1
+  soft_bundle: true
+  enable_coin_deny_list_v2: true
+  passkey_auth: true
+  authority_capabilities_v2: true
+  rethrow_serialization_type_layout_errors: true
+  consensus_distributed_vote_scoring_strategy: true
+  consensus_round_prober: true
+  validate_identifier_inputs: true
+  disallow_self_identifier: true
+  mysticeti_fastpath: true
+  disable_preconsensus_locking: true
+  relocate_event_module: true
+  uncompressed_g1_group_elements: true
+  disallow_new_modules_in_deps_only_packages: true
+  consensus_smart_ancestor_selection: true
+  consensus_round_prober_probe_accepted_rounds: true
+  native_charging_v2: true
+  consensus_linearize_subdag_v2: true
+  convert_type_argument_error: true
+  variant_nodes: true
+  consensus_zstd_compression: true
+  minimize_child_object_mutations: true
+  record_additional_state_digest_in_prologue: true
+  move_native_context: true
+  consensus_median_based_commit_timestamp: true
+  normalize_ptb_arguments: true
+  consensus_batched_block_sync: true
+  enforce_checkpoint_timestamp_monotonicity: true
+  max_ptb_value_size_v2: true
+  resolve_type_input_ids_to_defining_id: true
+  enable_party_transfer: true
+  allow_unbounded_system_objects: true
+  type_tags_in_object_runtime: true
+  enable_accumulators: true
+  enable_coin_reservation_obj_refs: true
+  create_root_accumulator_object: true
+  enable_authenticated_event_streams: true
+  enable_address_balance_gas_payments: true
+  address_balance_gas_check_rgp_at_signing: true
+  enable_multi_epoch_transaction_expiration: true
+  relax_valid_during_for_owned_inputs: true
+  enable_ptb_execution_v2: true
+  better_adapter_type_resolution_errors: true
+  record_time_estimate_processed: true
+  dependency_linkage_error: true
+  additional_multisig_checks: true
+  ignore_execution_time_observations_after_certs_closed: true
+  debug_fatal_on_move_invariant_violation: true
+  additional_consensus_digest_indirect_state: true
+  check_for_init_during_upgrade: true
+  include_checkpoint_artifacts_digest_in_summary: true
+  use_mfp_txns_in_load_initial_object_debts: true
+  cancel_for_failed_dkg_early: true
+  enable_coin_registry: true
+  abstract_size_in_object_runtime: true
+  object_runtime_charge_cache_load_gas: true
+  additional_borrow_checks: true
+  use_new_commit_handler: true
+  better_loader_errors: true
+  generate_df_type_layouts: true
+  enable_display_registry: true
+  private_generics_verifier_v2: true
+  deprecate_global_storage_ops: true
+  normalize_depth_formula: true
+  consensus_skip_gced_accept_votes: true
+  include_cancelled_randomness_txns_in_prologue: true
+  address_aliases: true
+  fix_checkpoint_signature_mapping: true
+  enable_object_funds_withdraw: true
+  consensus_skip_gced_blocks_in_direct_finalization: true
+  gas_rounding_halve_digits: true
+  flexible_tx_context_positions: true
+  disable_entry_point_signature_check: true
+  convert_withdrawal_compatibility_ptb_arguments: true
+  restrict_hot_or_not_entry_functions: true
+  split_checkpoints_in_consensus_handler: true
+  consensus_always_accept_system_transactions: true
+  validator_metadata_verify_v2: true
+  randomize_checkpoint_tx_limit_in_tests: true
+  gasless_transaction_drop_safety: true
+  merge_randomness_into_checkpoint: true
+  use_coin_party_owner: true
+  enable_gasless: true
+  disallow_jump_orphans: true
+max_tx_size_bytes: 131072
+max_input_objects: 2048
+max_size_written_objects: 5000000
+max_size_written_objects_system_tx: 50000000
+max_serialized_tx_effects_size_bytes: 524288
+max_serialized_tx_effects_size_bytes_system_tx: 8388608
+max_gas_payment_objects: 256
+max_modules_in_publish: 64
+max_package_dependencies: 32
+max_arguments: 512
+max_type_arguments: 16
+max_type_argument_depth: 16
+max_pure_argument_size: 16384
+max_programmable_tx_commands: 1024
+move_binary_format_version: 7
+min_move_binary_format_version: 6
+binary_module_handles: 100
+binary_struct_handles: 300
+binary_function_handles: 1500
+binary_function_instantiations: 750
+binary_signatures: 1000
+binary_constant_pool: 4000
+binary_identifiers: 10000
+binary_address_identifiers: 100
+binary_struct_defs: 200
+binary_struct_def_instantiations: 100
+binary_function_defs: 1000
+binary_field_handles: 500
+binary_field_instantiations: 250
+binary_friend_decls: 100
+binary_variant_handles: 1024
+binary_variant_instantiation_handles: 1024
+max_move_object_size: 256000
+max_move_package_size: 102400
+max_publish_or_upgrade_per_ptb: 5
+max_tx_gas: 50000000000000
+max_gas_price: 50000000000
+max_gas_price_rgp_factor_for_aborted_transactions: 100
+max_gas_computation_bucket: 5000000
+gas_rounding_step: 1000
+max_loop_depth: 5
+max_generic_instantiation_length: 32
+max_function_parameters: 128
+max_basic_blocks: 1024
+max_value_stack_size: 1024
+max_type_nodes: 256
+max_push_size: 10000
+max_struct_definitions: 200
+max_function_definitions: 1000
+max_fields_in_struct: 32
+max_dependency_depth: 100
+max_num_event_emit: 1024
+max_num_new_move_object_ids: 2048
+max_num_new_move_object_ids_system_tx: 32768
+max_num_deleted_move_object_ids: 2048
+max_num_deleted_move_object_ids_system_tx: 32768
+max_num_transferred_move_object_ids: 2048
+max_num_transferred_move_object_ids_system_tx: 32768
+max_event_emit_size: 256000
+max_event_emit_size_total: 65536000
+max_move_vector_len: 262144
+max_move_identifier_len: 128
+max_move_value_depth: 128
+max_move_enum_variants: 127
+max_back_edges_per_function: 10000
+max_back_edges_per_module: 10000
+max_verifier_meter_ticks_per_function: 16000000
+max_meter_ticks_per_module: 16000000
+max_meter_ticks_per_package: 16000000
+object_runtime_max_num_cached_objects: 1000
+object_runtime_max_num_cached_objects_system_tx: 16000
+object_runtime_max_num_store_entries: 1000
+object_runtime_max_num_store_entries_system_tx: 16000
+base_tx_cost_fixed: 1000
+package_publish_cost_fixed: 1000
+base_tx_cost_per_byte: 0
+package_publish_cost_per_byte: 80
+obj_access_cost_read_per_byte: 15
+obj_access_cost_mutate_per_byte: 40
+obj_access_cost_delete_per_byte: 40
+obj_access_cost_verify_per_byte: 200
+max_type_to_layout_nodes: 512
+max_ptb_value_size: 1048576
+gas_model_version: 11
+obj_data_cost_refundable: 100
+obj_metadata_cost_non_refundable: 50
+storage_rebate_rate: 9900
+storage_fund_reinvest_rate: 500
+reward_slashing_rate: 10000
+storage_gas_price: 76
+accumulator_object_storage_cost: 7600
+max_transactions_per_checkpoint: 20000
+max_checkpoint_size_bytes: 31457280
+buffer_stake_for_protocol_upgrade_bps: 5000
+address_from_bytes_cost_base: 52
+address_to_u256_cost_base: 52
+address_from_u256_cost_base: 52
+config_read_setting_impl_cost_base: 100
+config_read_setting_impl_cost_per_byte: 40
+dynamic_field_hash_type_and_key_cost_base: 52
+dynamic_field_hash_type_and_key_type_cost_per_byte: 2
+dynamic_field_hash_type_and_key_value_cost_per_byte: 2
+dynamic_field_hash_type_and_key_type_tag_cost_per_byte: 2
+dynamic_field_add_child_object_cost_base: 52
+dynamic_field_add_child_object_type_cost_per_byte: 10
+dynamic_field_add_child_object_value_cost_per_byte: 1
+dynamic_field_add_child_object_struct_tag_cost_per_byte: 10
+dynamic_field_borrow_child_object_cost_base: 52
+dynamic_field_borrow_child_object_child_ref_cost_per_byte: 1
+dynamic_field_borrow_child_object_type_cost_per_byte: 10
+dynamic_field_remove_child_object_cost_base: 52
+dynamic_field_remove_child_object_child_cost_per_byte: 1
+dynamic_field_remove_child_object_type_cost_per_byte: 2
+dynamic_field_has_child_object_cost_base: 52
+dynamic_field_has_child_object_with_ty_cost_base: 52
+dynamic_field_has_child_object_with_ty_type_cost_per_byte: 2
+dynamic_field_has_child_object_with_ty_type_tag_cost_per_byte: 2
+event_emit_cost_base: 52
+event_emit_value_size_derivation_cost_per_byte: 2
+event_emit_tag_size_derivation_cost_per_byte: 5
+event_emit_output_cost_per_byte: 10
+event_emit_auth_stream_cost: 52
+object_borrow_uid_cost_base: 52
+object_delete_impl_cost_base: 52
+object_record_new_uid_cost_base: 52
+transfer_transfer_internal_cost_base: 52
+transfer_party_transfer_internal_cost_base: 52
+transfer_freeze_object_cost_base: 52
+transfer_share_object_cost_base: 52
+transfer_receive_object_cost_base: 52
+transfer_receive_object_cost_per_byte: 1
+transfer_receive_object_type_cost_per_byte: 2
+tx_context_derive_id_cost_base: 52
+tx_context_fresh_id_cost_base: 52
+tx_context_sender_cost_base: 30
+tx_context_epoch_cost_base: 30
+tx_context_epoch_timestamp_ms_cost_base: 30
+tx_context_sponsor_cost_base: 30
+tx_context_rgp_cost_base: 30
+tx_context_gas_price_cost_base: 30
+tx_context_gas_budget_cost_base: 30
+tx_context_ids_created_cost_base: 30
+tx_context_replace_cost_base: 30
+types_is_one_time_witness_cost_base: 52
+types_is_one_time_witness_type_tag_cost_per_byte: 2
+types_is_one_time_witness_type_cost_per_byte: 2
+validator_validate_metadata_cost_base: 20000
+validator_validate_metadata_data_cost_per_byte: 2
+crypto_invalid_arguments_cost: 100
+bls12381_bls12381_min_sig_verify_cost_base: 44064
+bls12381_bls12381_min_sig_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_sig_verify_msg_cost_per_block: 2
+bls12381_bls12381_min_pk_verify_cost_base: 49282
+bls12381_bls12381_min_pk_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_pk_verify_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_keccak256_cost_base: 500
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_sha256_cost_base: 500
+ecdsa_k1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_k1_decompress_pubkey_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_cost_base: 1470
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_k1_secp256k1_verify_sha256_cost_base: 1470
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_keccak256_cost_base: 1173
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_sha256_cost_base: 1173
+ecdsa_r1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_keccak256_cost_base: 4225
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_sha256_cost_base: 4225
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_block: 2
+ecvrf_ecvrf_verify_cost_base: 4848
+ecvrf_ecvrf_verify_alpha_string_cost_per_byte: 2
+ecvrf_ecvrf_verify_alpha_string_cost_per_block: 2
+ed25519_ed25519_verify_cost_base: 1802
+ed25519_ed25519_verify_msg_cost_per_byte: 2
+ed25519_ed25519_verify_msg_cost_per_block: 2
+groth16_prepare_verifying_key_bls12381_cost_base: 53838
+groth16_prepare_verifying_key_bn254_cost_base: 82010
+groth16_verify_groth16_proof_internal_bls12381_cost_base: 72090
+groth16_verify_groth16_proof_internal_bls12381_cost_per_public_input: 8213
+groth16_verify_groth16_proof_internal_bn254_cost_base: 115502
+groth16_verify_groth16_proof_internal_bn254_cost_per_public_input: 9484
+groth16_verify_groth16_proof_internal_public_input_cost_per_byte: 2
+hash_blake2b256_cost_base: 10
+hash_blake2b256_data_cost_per_byte: 2
+hash_blake2b256_data_cost_per_block: 2
+hash_keccak256_cost_base: 10
+hash_keccak256_data_cost_per_byte: 2
+hash_keccak256_data_cost_per_block: 2
+poseidon_bn254_cost_base: 260
+poseidon_bn254_cost_per_block: 388
+group_ops_bls12381_decode_scalar_cost: 7
+group_ops_bls12381_decode_g1_cost: 2848
+group_ops_bls12381_decode_g2_cost: 3770
+group_ops_bls12381_decode_gt_cost: 3068
+group_ops_bls12381_scalar_add_cost: 10
+group_ops_bls12381_g1_add_cost: 1556
+group_ops_bls12381_g2_add_cost: 3048
+group_ops_bls12381_gt_add_cost: 188
+group_ops_bls12381_scalar_sub_cost: 10
+group_ops_bls12381_g1_sub_cost: 1550
+group_ops_bls12381_g2_sub_cost: 3019
+group_ops_bls12381_gt_sub_cost: 497
+group_ops_bls12381_scalar_mul_cost: 11
+group_ops_bls12381_g1_mul_cost: 4842
+group_ops_bls12381_g2_mul_cost: 9108
+group_ops_bls12381_gt_mul_cost: 27490
+group_ops_bls12381_scalar_div_cost: 91
+group_ops_bls12381_g1_div_cost: 5091
+group_ops_bls12381_g2_div_cost: 9206
+group_ops_bls12381_gt_div_cost: 27804
+group_ops_bls12381_g1_hash_to_base_cost: 2962
+group_ops_bls12381_g2_hash_to_base_cost: 8688
+group_ops_bls12381_g1_hash_to_cost_per_byte: 2
+group_ops_bls12381_g2_hash_to_cost_per_byte: 2
+group_ops_bls12381_g1_msm_base_cost: 62648
+group_ops_bls12381_g2_msm_base_cost: 131192
+group_ops_bls12381_g1_msm_base_cost_per_input: 1333
+group_ops_bls12381_g2_msm_base_cost_per_input: 3216
+group_ops_bls12381_msm_max_len: 32
+group_ops_bls12381_pairing_cost: 26897
+group_ops_bls12381_g1_to_uncompressed_g1_cost: 2099
+group_ops_bls12381_uncompressed_g1_to_g1_cost: 677
+group_ops_bls12381_uncompressed_g1_sum_base_cost: 77
+group_ops_bls12381_uncompressed_g1_sum_cost_per_term: 26
+group_ops_bls12381_uncompressed_g1_sum_max_terms: 1200
+group_ops_ristretto_decode_scalar_cost: 7
+group_ops_ristretto_decode_point_cost: 200
+group_ops_ristretto_scalar_add_cost: 10
+group_ops_ristretto_point_add_cost: 500
+group_ops_ristretto_scalar_sub_cost: 10
+group_ops_ristretto_point_sub_cost: 500
+group_ops_ristretto_scalar_mul_cost: 11
+group_ops_ristretto_point_mul_cost: 1200
+group_ops_ristretto_scalar_div_cost: 151
+group_ops_ristretto_point_div_cost: 2500
+hmac_hmac_sha3_256_cost_base: 52
+hmac_hmac_sha3_256_input_cost_per_byte: 2
+hmac_hmac_sha3_256_input_cost_per_block: 2
+check_zklogin_id_cost_base: 200
+check_zklogin_issuer_cost_base: 200
+vdf_verify_vdf_cost: 1500
+vdf_hash_to_input_cost: 100
+nitro_attestation_parse_base_cost: 2650
+nitro_attestation_parse_cost_per_byte: 50
+nitro_attestation_verify_base_cost: 2481600
+nitro_attestation_verify_cost_per_cert: 2618450
+bcs_per_byte_serialized_cost: 2
+bcs_legacy_min_output_size_cost: 1
+bcs_failure_cost: 52
+hash_sha2_256_base_cost: 52
+hash_sha2_256_per_byte_cost: 2
+hash_sha2_256_legacy_min_input_len_cost: 1
+hash_sha3_256_base_cost: 52
+hash_sha3_256_per_byte_cost: 2
+hash_sha3_256_legacy_min_input_len_cost: 1
+type_name_get_base_cost: 52
+type_name_get_per_byte_cost: 2
+type_name_id_base_cost: 52
+string_check_utf8_base_cost: 52
+string_check_utf8_per_byte_cost: 2
+string_is_char_boundary_base_cost: 52
+string_sub_string_base_cost: 52
+string_sub_string_per_byte_cost: 2
+string_index_of_base_cost: 52
+string_index_of_per_byte_pattern_cost: 2
+string_index_of_per_byte_searched_cost: 2
+vector_empty_base_cost: 52
+vector_length_base_cost: 52
+vector_push_back_base_cost: 52
+vector_push_back_legacy_per_abstract_memory_unit_cost: 2
+vector_borrow_base_cost: 52
+vector_pop_back_base_cost: 52
+vector_destroy_empty_base_cost: 52
+vector_swap_base_cost: 52
+debug_print_base_cost: 52
+debug_print_stack_trace_base_cost: 52
+execution_version: 4
+consensus_bad_nodes_stake_threshold: 30
+max_jwk_votes_per_validator_per_epoch: 240
+max_age_of_jwk_in_epochs: 1
+random_beacon_reduction_allowed_delta: 800
+random_beacon_reduction_lower_bound: 500
+random_beacon_dkg_timeout_round: 3000
+random_beacon_min_round_interval_ms: 500
+random_beacon_dkg_version: 1
+consensus_max_transaction_size_bytes: 262144
+consensus_max_transactions_in_block_bytes: 524288
+consensus_max_num_transactions_in_block: 512
+consensus_voting_rounds: 40
+max_accumulated_txn_cost_per_object_in_narwhal_commit: 40
+max_deferral_rounds_for_congestion_control: 10
+max_txn_cost_overage_per_object_in_commit: 18446744073709551615
+allowed_txn_cost_overage_burst_per_object_in_commit: 370000000
+min_checkpoint_interval_ms: 200
+checkpoint_summary_version_specific_data: 1
+max_soft_bundle_size: 5
+bridge_should_try_to_finalize_committee: true
+max_accumulated_txn_cost_per_object_in_mysticeti_commit: 37000000
+max_accumulated_randomness_txn_cost_per_object_in_mysticeti_commit: 7400000
+consensus_gc_depth: 60
+gas_budget_based_txn_cost_cap_factor: 400000
+gas_budget_based_txn_cost_absolute_cap_commit_count: 50
+sip_45_consensus_amplification_threshold: 5
+use_object_per_epoch_marker_table_v2: true
+consensus_commit_rate_estimation_window_size: 10
+translation_per_command_base_charge: 1
+translation_per_input_base_charge: 1
+translation_pure_input_per_byte_charge: 1
+translation_per_type_node_charge: 1
+translation_per_reference_node_charge: 1
+translation_per_linkage_entry_charge: 10
+max_updates_per_settlement_txn: 100
+gasless_max_computation_units: 50000
+gasless_allowed_token_types: []
+gasless_max_unused_inputs: 1
+gasless_max_pure_input_bytes: 32

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__genesis_config_snapshot_matches.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__genesis_config_snapshot_matches.snap
@@ -6,7 +6,7 @@ ssfn_config_info: ~
 validator_config_info: ~
 parameters:
   chain_start_timestamp_ms: 0
-  protocol_version: 119
+  protocol_version: 120
   allow_insertion_of_extra_objects: true
   epoch_duration_ms: 86400000
   stake_subsidy_start_epoch: 0

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
@@ -3,7 +3,7 @@ source: crates/sui-swarm-config/tests/snapshot_tests.rs
 expression: genesis.sui_system_object().into_genesis_version_for_tooling()
 ---
 epoch: 0
-protocol_version: 119
+protocol_version: 120
 system_state_version: 1
 validators:
   total_stake: 20000000000000000
@@ -240,13 +240,13 @@ validators:
         next_epoch_worker_address: ~
         extra_fields:
           id:
-            id: "0xaab03d5ffc17eb7b2346dea0cbb9524b30e5ca4e6b6fee2ac2816f78c874442a"
+            id: "0x423ca271a3a6aebeaf9ab9a20e2cf8ddde9122cb1d976ccaa0551e58f47597cf"
           size: 0
       voting_power: 10000
-      operation_cap_id: "0xe94b07c832b1c446ac7495a09076b4a21a161bc9df2d46ccf348a5be0daea710"
+      operation_cap_id: "0x01840a4e8d9db935ad2838e804eb368f8657feefab5ec86ec82be2e4571b0fda"
       gas_price: 1000
       staking_pool:
-        id: "0xc91b55899f7d06ea470b4fe421277c77c507bd4d3fcbc03a44642e609661514d"
+        id: "0x746a1cf246e88e517bf15dfb1e6b7ee1c169c0593b3c0d95a647051723825fe2"
         activation_epoch: 0
         deactivation_epoch: ~
         sui_balance: 20000000000000000
@@ -254,14 +254,14 @@ validators:
           value: 0
         pool_token_balance: 20000000000000000
         exchange_rates:
-          id: "0x042fb56f1b7f29ecb927472ae2d63b4060765679aab548278d11e3ef735ecbe1"
+          id: "0x6e9a8b08ba7931ab435b30c7b9ebb7064b031cef2d2462cd78c840919ba8a475"
           size: 1
         pending_stake: 0
         pending_total_sui_withdraw: 0
         pending_pool_token_withdraw: 0
         extra_fields:
           id:
-            id: "0xef2523012b80d006edc0b586bc9a7e49ab7fb06fb362be40450aa2718cb79d9b"
+            id: "0x5f6f3faffa2da84921541ee44fbf2af12f3f0b542d46b3276f2d4f4819c0e70f"
           size: 0
       commission_rate: 200
       next_epoch_stake: 20000000000000000
@@ -269,27 +269,27 @@ validators:
       next_epoch_commission_rate: 200
       extra_fields:
         id:
-          id: "0xdade19c90639581f52b3d8c28966c824b34f7809f0f7a008d91d6df6bba3a74c"
+          id: "0x4b276a7ab9e32cf6ccf7605f854dd6f1a59dbd1d6865f88b8e7d03f340a645d6"
         size: 0
   pending_active_validators:
     contents:
-      id: "0xea5c45cae5c409cad53bcba5b6679395a7e357c39a62bfa93bafbdb0f8033ed8"
+      id: "0x6f0c9ad96ab71c0285733800bf9ff6dc691565e05a73051cc4f0c90290fc469c"
       size: 0
   pending_removals: []
   staking_pool_mappings:
-    id: "0x188c2df844af69f3527e2d6a29917d5a3577303c2c7ff28af615986bb4f772aa"
+    id: "0x6c557938f4d964574c22d5ca85219973c0ab60ac2ef6e27c8fd6622b3363efe6"
     size: 1
   inactive_validators:
-    id: "0xf39d0318b5bf1ec19a6a1b491cfcc612bf5e8066d692145166544a1abf85b26b"
+    id: "0x7d27f4fb3d2850ccff939df930397d5b10fec4a61297ac01a600cfe9517f1916"
     size: 0
   validator_candidates:
-    id: "0x46309bfab7b99123efcb2bcb36e1ab15e95bbe6cdccf7242c276c07a63b38340"
+    id: "0x31abffd280b96d7b4afc4055e9b23779990f501fc8e0b60bd87375e7e4ca0e94"
     size: 0
   at_risk_validators:
     contents: []
   extra_fields:
     id:
-      id: "0x1cb05eaa762395ae8e927210a2cc713b843f2a29de5afb83a674d1aa48d89ee7"
+      id: "0xda9de7e34207b0684e7369d3a35e66dda935c6edc19716b3413de57507ba97ed"
     size: 0
 storage_fund:
   total_object_storage_rebates:
@@ -306,7 +306,7 @@ parameters:
   validator_low_stake_grace_period: 7
   extra_fields:
     id:
-      id: "0x5d590679cbd24b86902e235babc2d3935a256e2f3b8218a83c81f484c09898c8"
+      id: "0x59bbbfb9f9dfd4dfda17503fa902f3ad7979496e3406c49606eb452c79302ee2"
     size: 0
 reference_gas_price: 1000
 validator_report_records:
@@ -320,7 +320,7 @@ stake_subsidy:
   stake_subsidy_decrease_rate: 1000
   extra_fields:
     id:
-      id: "0x4e53bce42cee803cc947ea16cacb143053d7ed0892fdfacbe84178ef9e57657c"
+      id: "0xe39a5f2c947fe0971ab94310891c3818bf8cd4e883154455496f3164ade11211"
     size: 0
 safe_mode: false
 safe_mode_storage_rewards:
@@ -332,5 +332,5 @@ safe_mode_non_refundable_storage_fee: 0
 epoch_start_timestamp_ms: 10
 extra_fields:
   id:
-    id: "0x6e6d6d1b4a597c7e05d6d483a8201406bc5d60828849a3d5b1ffe8ea1fd3e787"
+    id: "0x931386d6e74b520cb2d8718c42e95aedfb9a913293ecc2591b288b23c1951456"
   size: 0

--- a/external-crates/move/crates/bytecode-verifier-tests/src/unit_tests/mod.rs
+++ b/external-crates/move/crates/bytecode-verifier-tests/src/unit_tests/mod.rs
@@ -60,6 +60,7 @@ pub(crate) fn production_config() -> (VerifierConfig, MeterConfig) {
             deprecate_global_storage_ops: true,
             disable_entry_point_signature_check: true,
             switch_to_regex_reference_safety: false,
+            disallow_jump_orphans: true,
         },
         MeterConfig::old_default(),
     )

--- a/external-crates/move/crates/move-bytecode-verifier/src/code_unit_verifier.rs
+++ b/external-crates/move/crates/move-bytecode-verifier/src/code_unit_verifier.rs
@@ -7,8 +7,8 @@
 //! abstract_interpreter.rs. CodeUnitVerifier simply orchestrates calls into these two files.
 use crate::{
     ability_cache::AbilityCache, absint::FunctionContext, acquires_list_verifier::AcquiresVerifier,
-    control_flow, locals_safety, reference_safety, regex_reference_safety,
-    stack_usage_verifier::StackUsageVerifier, type_safety,
+    control_flow, jump_table_usage_verifier, locals_safety, reference_safety,
+    regex_reference_safety, stack_usage_verifier::StackUsageVerifier, type_safety,
 };
 use move_abstract_interpreter::control_flow_graph::ControlFlowGraph;
 use move_binary_format::{
@@ -180,6 +180,14 @@ impl<'env> CodeUnitVerifier<'env, '_> {
             meter,
         )?;
         locals_safety::verify(self.module, &self.function_context, ability_cache, meter)?;
+        if verifier_config.disallow_jump_orphans {
+            jump_table_usage_verifier::verify(
+                verifier_config,
+                self.module,
+                &self.function_context,
+                meter,
+            )?;
+        }
         if verifier_config.switch_to_regex_reference_safety {
             regex_reference_safety::verify(
                 verifier_config,

--- a/external-crates/move/crates/move-bytecode-verifier/src/jump_table_usage_verifier.rs
+++ b/external-crates/move/crates/move-bytecode-verifier/src/jump_table_usage_verifier.rs
@@ -1,0 +1,123 @@
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::absint::FunctionContext;
+use move_binary_format::{
+    errors::PartialVMResult,
+    file_format::{Bytecode, CompiledModule},
+    partial_vm_error,
+};
+use move_bytecode_verifier_meter::Meter;
+use move_vm_config::verifier::VerifierConfig;
+use std::collections::BTreeSet;
+
+// Verifies that all jump tables defined in the function are used by a `VariantSwitch` instruction.
+// This is a sanity check to ensure that the function does not contain dead jump tables, which
+// while not unsound, are likely indicative of an issue in the compiler or a "smelly" input module
+// and we should reject it.
+pub(crate) fn verify(
+    _config: &VerifierConfig,
+    _module: &CompiledModule,
+    function_context: &FunctionContext,
+    _meter: &mut (impl Meter + ?Sized),
+) -> PartialVMResult<()> {
+    let mut seen = BTreeSet::new();
+    for bytecode in function_context.code().code.iter() {
+        match bytecode {
+            Bytecode::VariantSwitch(variant_jump_table_index) => {
+                seen.insert(*variant_jump_table_index);
+            }
+            Bytecode::Pop
+            | Bytecode::Ret
+            | Bytecode::BrTrue(_)
+            | Bytecode::BrFalse(_)
+            | Bytecode::Branch(_)
+            | Bytecode::LdU8(_)
+            | Bytecode::LdU64(_)
+            | Bytecode::LdU128(_)
+            | Bytecode::CastU8
+            | Bytecode::CastU64
+            | Bytecode::CastU128
+            | Bytecode::LdConst(_)
+            | Bytecode::LdTrue
+            | Bytecode::LdFalse
+            | Bytecode::CopyLoc(_)
+            | Bytecode::MoveLoc(_)
+            | Bytecode::StLoc(_)
+            | Bytecode::Call(_)
+            | Bytecode::CallGeneric(_)
+            | Bytecode::Pack(_)
+            | Bytecode::PackGeneric(_)
+            | Bytecode::Unpack(_)
+            | Bytecode::UnpackGeneric(_)
+            | Bytecode::ReadRef
+            | Bytecode::WriteRef
+            | Bytecode::FreezeRef
+            | Bytecode::MutBorrowLoc(_)
+            | Bytecode::ImmBorrowLoc(_)
+            | Bytecode::MutBorrowField(_)
+            | Bytecode::MutBorrowFieldGeneric(_)
+            | Bytecode::ImmBorrowField(_)
+            | Bytecode::ImmBorrowFieldGeneric(_)
+            | Bytecode::Add
+            | Bytecode::Sub
+            | Bytecode::Mul
+            | Bytecode::Mod
+            | Bytecode::Div
+            | Bytecode::BitOr
+            | Bytecode::BitAnd
+            | Bytecode::Xor
+            | Bytecode::Or
+            | Bytecode::And
+            | Bytecode::Not
+            | Bytecode::Eq
+            | Bytecode::Neq
+            | Bytecode::Lt
+            | Bytecode::Gt
+            | Bytecode::Le
+            | Bytecode::Ge
+            | Bytecode::Abort
+            | Bytecode::Nop
+            | Bytecode::Shl
+            | Bytecode::Shr
+            | Bytecode::VecPack(_, _)
+            | Bytecode::VecLen(_)
+            | Bytecode::VecImmBorrow(_)
+            | Bytecode::VecMutBorrow(_)
+            | Bytecode::VecPushBack(_)
+            | Bytecode::VecPopBack(_)
+            | Bytecode::VecUnpack(_, _)
+            | Bytecode::VecSwap(_)
+            | Bytecode::LdU16(_)
+            | Bytecode::LdU32(_)
+            | Bytecode::LdU256(_)
+            | Bytecode::CastU16
+            | Bytecode::CastU32
+            | Bytecode::CastU256
+            | Bytecode::PackVariant(_)
+            | Bytecode::PackVariantGeneric(_)
+            | Bytecode::UnpackVariant(_)
+            | Bytecode::UnpackVariantImmRef(_)
+            | Bytecode::UnpackVariantMutRef(_)
+            | Bytecode::UnpackVariantGeneric(_)
+            | Bytecode::UnpackVariantGenericImmRef(_)
+            | Bytecode::UnpackVariantGenericMutRef(_)
+            | Bytecode::ExistsDeprecated(_)
+            | Bytecode::ExistsGenericDeprecated(_)
+            | Bytecode::MoveFromDeprecated(_)
+            | Bytecode::MoveFromGenericDeprecated(_)
+            | Bytecode::MoveToDeprecated(_)
+            | Bytecode::MoveToGenericDeprecated(_)
+            | Bytecode::MutBorrowGlobalDeprecated(_)
+            | Bytecode::MutBorrowGlobalGenericDeprecated(_)
+            | Bytecode::ImmBorrowGlobalDeprecated(_)
+            | Bytecode::ImmBorrowGlobalGenericDeprecated(_) => (),
+        }
+    }
+
+    if seen.len() != function_context.code().jump_tables.len() {
+        return Err(partial_vm_error!(INVALID_ENUM_SWITCH));
+    }
+
+    Ok(())
+}

--- a/external-crates/move/crates/move-bytecode-verifier/src/lib.rs
+++ b/external-crates/move/crates/move-bytecode-verifier/src/lib.rs
@@ -42,6 +42,7 @@ pub use verifier::{
 };
 
 mod acquires_list_verifier;
+mod jump_table_usage_verifier;
 mod locals_safety;
 mod reference_safety;
 pub mod regex_reference_safety;

--- a/external-crates/move/crates/move-vm-config/src/verifier.rs
+++ b/external-crates/move/crates/move-vm-config/src/verifier.rs
@@ -38,6 +38,7 @@ pub struct VerifierConfig {
     pub disable_entry_point_signature_check: bool,
     /// If true, the verifier will run only the regex reference safety check.
     pub switch_to_regex_reference_safety: bool,
+    pub disallow_jump_orphans: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -90,6 +91,7 @@ impl Default for VerifierConfig {
             deprecate_global_storage_ops: true,
             disable_entry_point_signature_check: false,
             switch_to_regex_reference_safety: false,
+            disallow_jump_orphans: true,
         }
     }
 }

--- a/external-crates/move/move-execution/v0/crates/bytecode-verifier-tests/src/unit_tests/mod.rs
+++ b/external-crates/move/move-execution/v0/crates/bytecode-verifier-tests/src/unit_tests/mod.rs
@@ -60,6 +60,7 @@ pub(crate) fn production_config() -> (VerifierConfig, MeterConfig) {
             deprecate_global_storage_ops: false,
             disable_entry_point_signature_check: false,
             switch_to_regex_reference_safety: false,
+            disallow_jump_orphans: false,
         },
         MeterConfig::old_default(),
     )

--- a/external-crates/move/move-execution/v1/crates/bytecode-verifier-tests/src/unit_tests/mod.rs
+++ b/external-crates/move/move-execution/v1/crates/bytecode-verifier-tests/src/unit_tests/mod.rs
@@ -60,6 +60,7 @@ pub(crate) fn production_config() -> (VerifierConfig, MeterConfig) {
             deprecate_global_storage_ops: false,
             disable_entry_point_signature_check: false,
             switch_to_regex_reference_safety: false,
+            disallow_jump_orphans: false,
         },
         MeterConfig::old_default(),
     )

--- a/external-crates/move/move-execution/v2/crates/bytecode-verifier-tests/src/unit_tests/mod.rs
+++ b/external-crates/move/move-execution/v2/crates/bytecode-verifier-tests/src/unit_tests/mod.rs
@@ -60,6 +60,7 @@ pub(crate) fn production_config() -> (VerifierConfig, MeterConfig) {
             deprecate_global_storage_ops: false,
             disable_entry_point_signature_check: false,
             switch_to_regex_reference_safety: false,
+            disallow_jump_orphans: false,
         },
         MeterConfig::old_default(),
     )

--- a/external-crates/move/move-execution/v3/crates/bytecode-verifier-tests/src/unit_tests/mod.rs
+++ b/external-crates/move/move-execution/v3/crates/bytecode-verifier-tests/src/unit_tests/mod.rs
@@ -60,6 +60,7 @@ pub(crate) fn production_config() -> (VerifierConfig, MeterConfig) {
             deprecate_global_storage_ops: true,
             disable_entry_point_signature_check: true,
             switch_to_regex_reference_safety: false,
+            disallow_jump_orphans: false,
         },
         MeterConfig::old_default(),
     )


### PR DESCRIPTION
## Description 

Bit of cleanliness enforcement -- don't allow orphaned jumps.

## Test plan 

CI + local testing

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 
- [X] Protocol: adds an additional check in protocol version 120 to enforce cleanliness around jumps.
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
