### PR TITLE
Skip address balance ToAddress test when accumulators disabled

### DIFF
--- a/crates/sui-json-rpc-tests/tests/transaction_tests.rs
+++ b/crates/sui-json-rpc-tests/tests/transaction_tests.rs
@@ -453,6 +453,16 @@ async fn test_query_transaction_blocks_to_address() -> Result<(), anyhow::Error>
     let cluster = TestClusterBuilder::new().build().await;
     let http_client = cluster.rpc_client();
 
+    let accumulators_enabled = cluster.fullnode_handle.sui_node.with(|node| {
+        node.state()
+            .epoch_store_for_testing()
+            .protocol_config()
+            .enable_accumulators()
+    });
+    if !accumulators_enabled {
+        return Ok(());
+    }
+
     let recipient = SuiAddress::random_for_testing_only();
 
     // Send SUI to the recipient so the address appears in the index.


### PR DESCRIPTION
## Summary
- `test_query_transaction_blocks_to_address` (from #26087) fails in `simtest-mainnet` because it uses `make_transfer_sui_address_balance_transaction` which requires accumulators, but accumulators are not enabled on mainnet config
- Skip the test early when `enable_accumulators()` returns false

## Test plan
- [x] The test will now be skipped in simtest-mainnet (accumulators disabled)
- [x] The test continues to run normally in simtest (accumulators enabled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)