### PR TITLE
sui-indexer-alt-framework: replace futures::stream::Peekable with tokio_stream::adapters::Peekable

### DIFF
--- a/crates/sui-indexer-alt-framework/src/ingestion/broadcaster.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/broadcaster.rs
@@ -302,7 +302,7 @@ where
         }
     };
 
-    let checkpoint_envelope = match std::pin::Pin::new(&mut stream).peek().await {
+    let checkpoint_envelope = match stream.peek().await {
         Some(Ok(checkpoint)) => CheckpointEnvelope {
             checkpoint: Arc::new(checkpoint.clone()),
             chain_id,

--- a/crates/sui-indexer-alt-framework/src/ingestion/streaming_client.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/streaming_client.rs
@@ -8,12 +8,12 @@ use anyhow::anyhow;
 use async_trait::async_trait;
 use futures::StreamExt;
 use futures::stream::BoxStream;
-use futures::stream::Peekable;
 use sui_rpc::headers::X_SUI_CHAIN_ID;
 use sui_rpc::proto::sui::rpc::v2::SubscribeCheckpointsRequest;
 use sui_rpc::proto::sui::rpc::v2::subscription_service_client::SubscriptionServiceClient;
 use sui_types::digests::ChainIdentifier;
 use sui_types::messages_checkpoint::CheckpointDigest;
+use tokio_stream::adapters::Peekable;
 use tonic::Status;
 use tonic::transport::Endpoint;
 use tonic::transport::Uri;
@@ -109,15 +109,15 @@ fn wrap_stream(
     stream: impl futures::Stream<Item = Result<Checkpoint>> + Send + 'static,
     statement_timeout: Duration,
 ) -> Peekable<BoxStream<'static, Result<Checkpoint>>> {
-    tokio_stream::StreamExt::timeout(stream, statement_timeout)
+    let stream = tokio_stream::StreamExt::timeout(stream, statement_timeout)
         .map(move |result| match result {
             Err(_elapsed) => Err(Error::StreamingError(anyhow!(
                 "Statement timeout after {statement_timeout:?}"
             ))),
             Ok(result) => result,
         })
-        .boxed()
-        .peekable()
+        .boxed();
+    tokio_stream::StreamExt::peekable(stream)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Description 

This PR changes the `CheckpointStream::stream` from `futures::stream::Peekable` (takes `self: Pin<&mut Self>:`) to `tokio_stream::adapters::Peekable` (takes `&mut self`) to simplify call sites from `Pin::new(&mut stream).peek()` to `stream.peek()`.

## Test plan 

This affects the compiler, no runtime changes.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
