### PR TITLE
Fix compilation warnings in move-vm-runtime and move-regex-borrow-graph

### DIFF
--- a/external-crates/move/crates/move-regex-borrow-graph/src/collections.rs
+++ b/external-crates/move/crates/move-regex-borrow-graph/src/collections.rs
@@ -129,6 +129,7 @@ impl<Loc: Copy, Lbl: Ord + Clone + fmt::Display> Graph<Loc, Lbl> {
     }
 
     /// Returns the direct successors of the specified reference by NodeIndex
+    #[cfg(debug_assertions)]
     fn successors_idx(
         &self,
         r: NodeIndex,

--- a/external-crates/move/crates/move-regex-borrow-graph/src/collections.rs
+++ b/external-crates/move/crates/move-regex-borrow-graph/src/collections.rs
@@ -129,7 +129,7 @@ impl<Loc: Copy, Lbl: Ord + Clone + fmt::Display> Graph<Loc, Lbl> {
     }
 
     /// Returns the direct successors of the specified reference by NodeIndex
-    #[cfg(debug_assertions)]
+    #[allow(dead_code)]
     fn successors_idx(
         &self,
         r: NodeIndex,

--- a/external-crates/move/crates/move-regex-borrow-graph/src/collections.rs
+++ b/external-crates/move/crates/move-regex-borrow-graph/src/collections.rs
@@ -129,7 +129,10 @@ impl<Loc: Copy, Lbl: Ord + Clone + fmt::Display> Graph<Loc, Lbl> {
     }
 
     /// Returns the direct successors of the specified reference by NodeIndex
-    #[allow(dead_code)]
+    #[allow(
+        dead_code,
+        reason = "only called from #[cfg(debug_assertions)] blocks below"
+    )]
     fn successors_idx(
         &self,
         r: NodeIndex,

--- a/external-crates/move/crates/move-regex-borrow-graph/src/graph_map.rs
+++ b/external-crates/move/crates/move-regex-borrow-graph/src/graph_map.rs
@@ -138,7 +138,7 @@ impl<N, E> GraphMap<N, E> {
     }
 
     /// Returns the weight of the edge from `from` to `to`, or None if the edge does not exist.
-    #[allow(dead_code)]
+    #[allow(dead_code, reason = "only used in tests")]
     pub fn edge_weight(&self, from: NodeIndex, to: NodeIndex) -> Option<&E> {
         self.edge_weights.get(&(from, to))
     }
@@ -236,7 +236,7 @@ impl<N, E> GraphMap<N, E> {
     }
 
     /// Returns an iterator over all edges in the graph, as (from, weight, to) triples.
-    #[allow(dead_code)]
+    #[allow(dead_code, reason = "only used in tests")]
     pub fn all_edges_idx(&self) -> impl Iterator<Item = (NodeIndex, &E, NodeIndex)> + '_ {
         self.edge_weights.iter().map(|((p, s), e)| (*p, e, *s))
     }
@@ -264,7 +264,7 @@ impl<N, E> GraphMap<N, E> {
         }))
     }
 
-    #[allow(dead_code)]
+    #[allow(dead_code, reason = "only used in tests")]
     pub(crate) fn check_invariants(&self) {
         #[cfg(debug_assertions)]
         {

--- a/external-crates/move/crates/move-regex-borrow-graph/src/graph_map.rs
+++ b/external-crates/move/crates/move-regex-borrow-graph/src/graph_map.rs
@@ -138,7 +138,7 @@ impl<N, E> GraphMap<N, E> {
     }
 
     /// Returns the weight of the edge from `from` to `to`, or None if the edge does not exist.
-    #[cfg(any(test, debug_assertions))]
+    #[allow(dead_code)]
     pub fn edge_weight(&self, from: NodeIndex, to: NodeIndex) -> Option<&E> {
         self.edge_weights.get(&(from, to))
     }
@@ -236,7 +236,7 @@ impl<N, E> GraphMap<N, E> {
     }
 
     /// Returns an iterator over all edges in the graph, as (from, weight, to) triples.
-    #[cfg(any(test, debug_assertions))]
+    #[allow(dead_code)]
     pub fn all_edges_idx(&self) -> impl Iterator<Item = (NodeIndex, &E, NodeIndex)> + '_ {
         self.edge_weights.iter().map(|((p, s), e)| (*p, e, *s))
     }
@@ -264,7 +264,7 @@ impl<N, E> GraphMap<N, E> {
         }))
     }
 
-    #[cfg(any(test, debug_assertions))]
+    #[allow(dead_code)]
     pub(crate) fn check_invariants(&self) {
         #[cfg(debug_assertions)]
         {

--- a/external-crates/move/crates/move-regex-borrow-graph/src/graph_map.rs
+++ b/external-crates/move/crates/move-regex-borrow-graph/src/graph_map.rs
@@ -138,6 +138,7 @@ impl<N, E> GraphMap<N, E> {
     }
 
     /// Returns the weight of the edge from `from` to `to`, or None if the edge does not exist.
+    #[cfg(any(test, debug_assertions))]
     pub fn edge_weight(&self, from: NodeIndex, to: NodeIndex) -> Option<&E> {
         self.edge_weights.get(&(from, to))
     }
@@ -235,6 +236,7 @@ impl<N, E> GraphMap<N, E> {
     }
 
     /// Returns an iterator over all edges in the graph, as (from, weight, to) triples.
+    #[cfg(any(test, debug_assertions))]
     pub fn all_edges_idx(&self) -> impl Iterator<Item = (NodeIndex, &E, NodeIndex)> + '_ {
         self.edge_weights.iter().map(|((p, s), e)| (*p, e, *s))
     }
@@ -262,6 +264,7 @@ impl<N, E> GraphMap<N, E> {
         }))
     }
 
+    #[cfg(any(test, debug_assertions))]
     pub(crate) fn check_invariants(&self) {
         #[cfg(debug_assertions)]
         {

--- a/external-crates/move/crates/move-vm-runtime/src/execution/interpreter/locals.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/execution/interpreter/locals.rs
@@ -174,7 +174,7 @@ impl MachineHeap {
 // -------------------------------------------------------------------------------------------------
 
 impl StackFrame {
-    #[cfg(any(debug_assertions, feature = "testing"))]
+    #[allow(dead_code)]
     pub(crate) fn iter(&self) -> std::slice::Iter<'_, MemBox<Value>> {
         self.slice.iter()
     }

--- a/external-crates/move/crates/move-vm-runtime/src/execution/interpreter/locals.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/execution/interpreter/locals.rs
@@ -174,7 +174,7 @@ impl MachineHeap {
 // -------------------------------------------------------------------------------------------------
 
 impl StackFrame {
-    #[allow(dead_code)]
+    #[allow(dead_code, reason = "used for debug printing of stack frames")]
     pub(crate) fn iter(&self) -> std::slice::Iter<'_, MemBox<Value>> {
         self.slice.iter()
     }

--- a/external-crates/move/crates/move-vm-runtime/src/execution/interpreter/locals.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/execution/interpreter/locals.rs
@@ -174,6 +174,7 @@ impl MachineHeap {
 // -------------------------------------------------------------------------------------------------
 
 impl StackFrame {
+    #[cfg(any(debug_assertions, feature = "testing"))]
     pub(crate) fn iter(&self) -> std::slice::Iter<'_, MemBox<Value>> {
         self.slice.iter()
     }

--- a/external-crates/move/crates/move-vm-runtime/src/execution/interpreter/state.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/execution/interpreter/state.rs
@@ -4,14 +4,13 @@
 use crate::{
     cache::identifier_interner::IdentifierInterner,
     execution::{
-        dispatch_tables::VMDispatchTables,
         interpreter::{
             locals::{MachineHeap, StackFrame},
             set_err_info,
         },
-        values::values_impl::{self as values, VMValueCast, Value},
+        values::values_impl::{VMValueCast, Value},
     },
-    jit::execution::ast::{Function, InternedDisplay, Type},
+    jit::execution::ast::{Function, Type},
     shared::{
         constants::{CALL_STACK_SIZE_LIMIT, OPERAND_STACK_SIZE_LIMIT},
         safe_ops::{SafeArithmetic as _, SafeIndex as _},
@@ -20,7 +19,19 @@ use crate::{
 };
 use move_binary_format::{errors::*, partial_vm_error};
 
-use std::{fmt::Write, sync::Arc};
+use std::sync::Arc;
+
+#[cfg(any(debug_assertions, feature = "testing"))]
+use crate::{
+    execution::{
+        dispatch_tables::VMDispatchTables,
+        values::values_impl as values,
+    },
+    jit::execution::ast::InternedDisplay,
+};
+
+#[cfg(any(debug_assertions, feature = "testing"))]
+use std::fmt::Write;
 
 #[cfg(any(debug_assertions, feature = "testing"))]
 macro_rules! debug_write {

--- a/external-crates/move/crates/move-vm-runtime/src/execution/interpreter/state.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/execution/interpreter/state.rs
@@ -23,10 +23,7 @@ use std::sync::Arc;
 
 #[allow(unused_imports)]
 use crate::{
-    execution::{
-        dispatch_tables::VMDispatchTables,
-        values::values_impl as values,
-    },
+    execution::{dispatch_tables::VMDispatchTables, values::values_impl as values},
     jit::execution::ast::InternedDisplay,
 };
 

--- a/external-crates/move/crates/move-vm-runtime/src/execution/interpreter/state.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/execution/interpreter/state.rs
@@ -21,7 +21,7 @@ use move_binary_format::{errors::*, partial_vm_error};
 
 use std::sync::Arc;
 
-#[cfg(any(debug_assertions, feature = "testing"))]
+#[allow(unused_imports)]
 use crate::{
     execution::{
         dispatch_tables::VMDispatchTables,
@@ -30,17 +30,17 @@ use crate::{
     jit::execution::ast::InternedDisplay,
 };
 
-#[cfg(any(debug_assertions, feature = "testing"))]
+#[allow(unused_imports)]
 use std::fmt::Write;
 
-#[cfg(any(debug_assertions, feature = "testing"))]
+#[allow(unused)]
 macro_rules! debug_write {
     ($($toks: tt)*) => {
         write!($($toks)*).expect("failed to write to buffer")
     };
 }
 
-#[cfg(any(debug_assertions, feature = "testing"))]
+#[allow(unused)]
 macro_rules! debug_writeln {
     ($($toks: tt)*) => {
         writeln!($($toks)*).expect("failed to write to buffer")
@@ -180,7 +180,7 @@ impl MachineState {
     // Debugging and logging helpers.
     //
 
-    #[cfg(any(debug_assertions, feature = "testing"))]
+    #[allow(dead_code)]
     #[allow(clippy::expect_used)]
     pub(super) fn debug_print_frame<B: Write>(
         &self,
@@ -280,7 +280,7 @@ impl MachineState {
         Ok(())
     }
 
-    #[cfg(any(debug_assertions, feature = "testing"))]
+    #[allow(dead_code)]
     pub(crate) fn debug_print_stack_trace<B: Write>(
         &self,
         vtables: &VMDispatchTables,

--- a/external-crates/move/crates/move-vm-runtime/src/execution/interpreter/state.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/execution/interpreter/state.rs
@@ -177,7 +177,7 @@ impl MachineState {
     // Debugging and logging helpers.
     //
 
-    #[allow(dead_code)]
+    #[cfg(any(debug_assertions, feature = "testing"))]
     #[allow(clippy::expect_used)]
     pub(super) fn debug_print_frame<B: Write>(
         &self,
@@ -277,7 +277,7 @@ impl MachineState {
         Ok(())
     }
 
-    #[allow(dead_code)]
+    #[cfg(any(debug_assertions, feature = "testing"))]
     pub(crate) fn debug_print_stack_trace<B: Write>(
         &self,
         vtables: &VMDispatchTables,

--- a/external-crates/move/crates/move-vm-runtime/src/jit/execution/ast.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/jit/execution/ast.rs
@@ -250,6 +250,7 @@ pub(crate) struct StructInstantiation {
 #[derive(Debug)]
 pub(crate) struct FieldHandle {
     pub offset: usize,
+    #[cfg(any(debug_assertions, feature = "testing"))]
     pub owner: VirtualTableKey,
 }
 
@@ -257,6 +258,7 @@ pub(crate) struct FieldHandle {
 #[derive(Debug)]
 pub(crate) struct FieldInstantiation {
     pub offset: usize,
+    #[cfg(any(debug_assertions, feature = "testing"))]
     pub owner: VirtualTableKey,
 }
 
@@ -1622,10 +1624,12 @@ impl std::fmt::Debug for ArenaType {
 /// Trait for types that can be displayed with an interner.
 /// This is similar to `std::fmt::Display` but takes an interner as argument. It is used for
 /// printing stack traces and other debug situations.
+#[cfg(any(debug_assertions, feature = "testing"))]
 pub trait InternedDisplay<B: std::fmt::Write> {
     fn fmt(&self, f: &mut B, interner: &IdentifierInterner) -> ::std::fmt::Result;
 }
 
+#[cfg(any(debug_assertions, feature = "testing"))]
 impl<B: std::fmt::Write> InternedDisplay<B> for IdentifierKey {
     fn fmt(&self, f: &mut B, interner: &IdentifierInterner) -> ::std::fmt::Result {
         let name = interner.resolve_ident(self, "module name");
@@ -1633,6 +1637,7 @@ impl<B: std::fmt::Write> InternedDisplay<B> for IdentifierKey {
     }
 }
 
+#[cfg(any(debug_assertions, feature = "testing"))]
 impl<B: std::fmt::Write> InternedDisplay<B> for VirtualTableKey {
     fn fmt(&self, f: &mut B, interner: &IdentifierInterner) -> ::std::fmt::Result {
         let str = self.to_short_string(interner);
@@ -1640,6 +1645,7 @@ impl<B: std::fmt::Write> InternedDisplay<B> for VirtualTableKey {
     }
 }
 
+#[cfg(any(debug_assertions, feature = "testing"))]
 impl<B: std::fmt::Write> InternedDisplay<B> for StructDef {
     fn fmt(&self, f: &mut B, interner: &IdentifierInterner) -> ::std::fmt::Result {
         // Name
@@ -1667,6 +1673,7 @@ impl<B: std::fmt::Write> InternedDisplay<B> for StructDef {
     }
 }
 
+#[cfg(any(debug_assertions, feature = "testing"))]
 impl<B: std::fmt::Write> InternedDisplay<B> for EnumDef {
     fn fmt(&self, f: &mut B, interner: &IdentifierInterner) -> ::std::fmt::Result {
         // Name
@@ -1687,6 +1694,7 @@ impl<B: std::fmt::Write> InternedDisplay<B> for EnumDef {
     }
 }
 
+#[cfg(any(debug_assertions, feature = "testing"))]
 impl<B: std::fmt::Write> InternedDisplay<B> for VariantDef {
     fn fmt(&self, f: &mut B, interner: &IdentifierInterner) -> ::std::fmt::Result {
         // Prefix with Enum name
@@ -1715,6 +1723,7 @@ impl<B: std::fmt::Write> InternedDisplay<B> for VariantDef {
     }
 }
 
+#[cfg(any(debug_assertions, feature = "testing"))]
 impl<B: std::fmt::Write> InternedDisplay<B> for FunctionInstantiation {
     fn fmt(&self, f: &mut B, interner: &IdentifierInterner) -> ::std::fmt::Result {
         // callee
@@ -1735,6 +1744,7 @@ impl<B: std::fmt::Write> InternedDisplay<B> for FunctionInstantiation {
     }
 }
 
+#[cfg(any(debug_assertions, feature = "testing"))]
 impl<B: std::fmt::Write> InternedDisplay<B> for StructInstantiation {
     fn fmt(&self, f: &mut B, interner: &IdentifierInterner) -> ::std::fmt::Result {
         // Head
@@ -1755,6 +1765,7 @@ impl<B: std::fmt::Write> InternedDisplay<B> for StructInstantiation {
     }
 }
 
+#[cfg(any(debug_assertions, feature = "testing"))]
 impl<B: std::fmt::Write> InternedDisplay<B> for FieldHandle {
     fn fmt(&self, f: &mut B, interner: &IdentifierInterner) -> ::std::fmt::Result {
         self.owner.fmt(f, interner)?;
@@ -1762,6 +1773,7 @@ impl<B: std::fmt::Write> InternedDisplay<B> for FieldHandle {
     }
 }
 
+#[cfg(any(debug_assertions, feature = "testing"))]
 impl<B: std::fmt::Write> InternedDisplay<B> for FieldInstantiation {
     fn fmt(&self, f: &mut B, interner: &IdentifierInterner) -> ::std::fmt::Result {
         // Owner may be unused operationally, but it’s very helpful in logs
@@ -1770,6 +1782,7 @@ impl<B: std::fmt::Write> InternedDisplay<B> for FieldInstantiation {
     }
 }
 
+#[cfg(any(debug_assertions, feature = "testing"))]
 impl<B: std::fmt::Write> InternedDisplay<B> for EnumInstantiation {
     fn fmt(&self, f: &mut B, interner: &IdentifierInterner) -> ::std::fmt::Result {
         // Head
@@ -1790,6 +1803,7 @@ impl<B: std::fmt::Write> InternedDisplay<B> for EnumInstantiation {
     }
 }
 
+#[cfg(any(debug_assertions, feature = "testing"))]
 impl<B: std::fmt::Write> InternedDisplay<B> for VariantInstantiation {
     fn fmt(&self, f: &mut B, interner: &IdentifierInterner) -> ::std::fmt::Result {
         // Enum head with type params from enum_inst
@@ -1812,6 +1826,7 @@ impl<B: std::fmt::Write> InternedDisplay<B> for VariantInstantiation {
     }
 }
 
+#[cfg(any(debug_assertions, feature = "testing"))]
 impl<B: std::fmt::Write> InternedDisplay<B> for Bytecode {
     fn fmt(&self, f: &mut B, interner: &IdentifierInterner) -> ::std::fmt::Result {
         match self {
@@ -2024,6 +2039,7 @@ impl<B: std::fmt::Write> InternedDisplay<B> for Bytecode {
     }
 }
 
+#[cfg(any(debug_assertions, feature = "testing"))]
 impl<B: std::fmt::Write> InternedDisplay<B> for CallType {
     fn fmt(&self, f: &mut B, interner: &IdentifierInterner) -> ::std::fmt::Result {
         match self {
@@ -2036,6 +2052,7 @@ impl<B: std::fmt::Write> InternedDisplay<B> for CallType {
     }
 }
 
+#[cfg(any(debug_assertions, feature = "testing"))]
 impl<B: std::fmt::Write> InternedDisplay<B> for ArenaType {
     fn fmt(&self, f: &mut B, interner: &IdentifierInterner) -> ::std::fmt::Result {
         match self {

--- a/external-crates/move/crates/move-vm-runtime/src/jit/execution/ast.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/jit/execution/ast.rs
@@ -250,7 +250,7 @@ pub(crate) struct StructInstantiation {
 #[derive(Debug)]
 pub(crate) struct FieldHandle {
     pub offset: usize,
-    #[cfg(any(debug_assertions, feature = "testing"))]
+    #[allow(dead_code)]
     pub owner: VirtualTableKey,
 }
 
@@ -258,7 +258,7 @@ pub(crate) struct FieldHandle {
 #[derive(Debug)]
 pub(crate) struct FieldInstantiation {
     pub offset: usize,
-    #[cfg(any(debug_assertions, feature = "testing"))]
+    #[allow(dead_code)]
     pub owner: VirtualTableKey,
 }
 
@@ -1624,12 +1624,11 @@ impl std::fmt::Debug for ArenaType {
 /// Trait for types that can be displayed with an interner.
 /// This is similar to `std::fmt::Display` but takes an interner as argument. It is used for
 /// printing stack traces and other debug situations.
-#[cfg(any(debug_assertions, feature = "testing"))]
+#[allow(dead_code)]
 pub trait InternedDisplay<B: std::fmt::Write> {
     fn fmt(&self, f: &mut B, interner: &IdentifierInterner) -> ::std::fmt::Result;
 }
 
-#[cfg(any(debug_assertions, feature = "testing"))]
 impl<B: std::fmt::Write> InternedDisplay<B> for IdentifierKey {
     fn fmt(&self, f: &mut B, interner: &IdentifierInterner) -> ::std::fmt::Result {
         let name = interner.resolve_ident(self, "module name");
@@ -1637,7 +1636,6 @@ impl<B: std::fmt::Write> InternedDisplay<B> for IdentifierKey {
     }
 }
 
-#[cfg(any(debug_assertions, feature = "testing"))]
 impl<B: std::fmt::Write> InternedDisplay<B> for VirtualTableKey {
     fn fmt(&self, f: &mut B, interner: &IdentifierInterner) -> ::std::fmt::Result {
         let str = self.to_short_string(interner);
@@ -1645,7 +1643,6 @@ impl<B: std::fmt::Write> InternedDisplay<B> for VirtualTableKey {
     }
 }
 
-#[cfg(any(debug_assertions, feature = "testing"))]
 impl<B: std::fmt::Write> InternedDisplay<B> for StructDef {
     fn fmt(&self, f: &mut B, interner: &IdentifierInterner) -> ::std::fmt::Result {
         // Name
@@ -1673,7 +1670,6 @@ impl<B: std::fmt::Write> InternedDisplay<B> for StructDef {
     }
 }
 
-#[cfg(any(debug_assertions, feature = "testing"))]
 impl<B: std::fmt::Write> InternedDisplay<B> for EnumDef {
     fn fmt(&self, f: &mut B, interner: &IdentifierInterner) -> ::std::fmt::Result {
         // Name
@@ -1694,7 +1690,6 @@ impl<B: std::fmt::Write> InternedDisplay<B> for EnumDef {
     }
 }
 
-#[cfg(any(debug_assertions, feature = "testing"))]
 impl<B: std::fmt::Write> InternedDisplay<B> for VariantDef {
     fn fmt(&self, f: &mut B, interner: &IdentifierInterner) -> ::std::fmt::Result {
         // Prefix with Enum name
@@ -1723,7 +1718,6 @@ impl<B: std::fmt::Write> InternedDisplay<B> for VariantDef {
     }
 }
 
-#[cfg(any(debug_assertions, feature = "testing"))]
 impl<B: std::fmt::Write> InternedDisplay<B> for FunctionInstantiation {
     fn fmt(&self, f: &mut B, interner: &IdentifierInterner) -> ::std::fmt::Result {
         // callee
@@ -1744,7 +1738,6 @@ impl<B: std::fmt::Write> InternedDisplay<B> for FunctionInstantiation {
     }
 }
 
-#[cfg(any(debug_assertions, feature = "testing"))]
 impl<B: std::fmt::Write> InternedDisplay<B> for StructInstantiation {
     fn fmt(&self, f: &mut B, interner: &IdentifierInterner) -> ::std::fmt::Result {
         // Head
@@ -1765,7 +1758,6 @@ impl<B: std::fmt::Write> InternedDisplay<B> for StructInstantiation {
     }
 }
 
-#[cfg(any(debug_assertions, feature = "testing"))]
 impl<B: std::fmt::Write> InternedDisplay<B> for FieldHandle {
     fn fmt(&self, f: &mut B, interner: &IdentifierInterner) -> ::std::fmt::Result {
         self.owner.fmt(f, interner)?;
@@ -1773,7 +1765,6 @@ impl<B: std::fmt::Write> InternedDisplay<B> for FieldHandle {
     }
 }
 
-#[cfg(any(debug_assertions, feature = "testing"))]
 impl<B: std::fmt::Write> InternedDisplay<B> for FieldInstantiation {
     fn fmt(&self, f: &mut B, interner: &IdentifierInterner) -> ::std::fmt::Result {
         // Owner may be unused operationally, but it’s very helpful in logs
@@ -1782,7 +1773,6 @@ impl<B: std::fmt::Write> InternedDisplay<B> for FieldInstantiation {
     }
 }
 
-#[cfg(any(debug_assertions, feature = "testing"))]
 impl<B: std::fmt::Write> InternedDisplay<B> for EnumInstantiation {
     fn fmt(&self, f: &mut B, interner: &IdentifierInterner) -> ::std::fmt::Result {
         // Head
@@ -1803,7 +1793,6 @@ impl<B: std::fmt::Write> InternedDisplay<B> for EnumInstantiation {
     }
 }
 
-#[cfg(any(debug_assertions, feature = "testing"))]
 impl<B: std::fmt::Write> InternedDisplay<B> for VariantInstantiation {
     fn fmt(&self, f: &mut B, interner: &IdentifierInterner) -> ::std::fmt::Result {
         // Enum head with type params from enum_inst
@@ -1826,7 +1815,6 @@ impl<B: std::fmt::Write> InternedDisplay<B> for VariantInstantiation {
     }
 }
 
-#[cfg(any(debug_assertions, feature = "testing"))]
 impl<B: std::fmt::Write> InternedDisplay<B> for Bytecode {
     fn fmt(&self, f: &mut B, interner: &IdentifierInterner) -> ::std::fmt::Result {
         match self {
@@ -2039,7 +2027,6 @@ impl<B: std::fmt::Write> InternedDisplay<B> for Bytecode {
     }
 }
 
-#[cfg(any(debug_assertions, feature = "testing"))]
 impl<B: std::fmt::Write> InternedDisplay<B> for CallType {
     fn fmt(&self, f: &mut B, interner: &IdentifierInterner) -> ::std::fmt::Result {
         match self {
@@ -2052,7 +2039,6 @@ impl<B: std::fmt::Write> InternedDisplay<B> for CallType {
     }
 }
 
-#[cfg(any(debug_assertions, feature = "testing"))]
 impl<B: std::fmt::Write> InternedDisplay<B> for ArenaType {
     fn fmt(&self, f: &mut B, interner: &IdentifierInterner) -> ::std::fmt::Result {
         match self {

--- a/external-crates/move/crates/move-vm-runtime/src/jit/execution/ast.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/jit/execution/ast.rs
@@ -250,7 +250,7 @@ pub(crate) struct StructInstantiation {
 #[derive(Debug)]
 pub(crate) struct FieldHandle {
     pub offset: usize,
-    #[allow(dead_code)]
+    #[allow(dead_code, reason = "used by InternedDisplay for debug output")]
     pub owner: VirtualTableKey,
 }
 
@@ -258,7 +258,7 @@ pub(crate) struct FieldHandle {
 #[derive(Debug)]
 pub(crate) struct FieldInstantiation {
     pub offset: usize,
-    #[allow(dead_code)]
+    #[allow(dead_code, reason = "used by InternedDisplay for debug output")]
     pub owner: VirtualTableKey,
 }
 
@@ -1624,7 +1624,7 @@ impl std::fmt::Debug for ArenaType {
 /// Trait for types that can be displayed with an interner.
 /// This is similar to `std::fmt::Display` but takes an interner as argument. It is used for
 /// printing stack traces and other debug situations.
-#[allow(dead_code)]
+#[allow(dead_code, reason = "used for debug-time stack trace printing")]
 pub trait InternedDisplay<B: std::fmt::Write> {
     fn fmt(&self, f: &mut B, interner: &IdentifierInterner) -> ::std::fmt::Result;
 }

--- a/external-crates/move/crates/move-vm-runtime/src/jit/execution/translate.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/jit/execution/translate.rs
@@ -797,16 +797,19 @@ fn cache_signatures(
 fn field_handles(
     context: &mut PackageContext<'_>,
     module: &CompiledModule,
+    #[cfg_attr(not(any(debug_assertions, feature = "testing")), allow(unused))]
     structs: &[StructDef],
 ) -> PartialVMResult<ArenaVec<FieldHandle>> {
     let field_handles = module
         .field_handles()
         .iter()
         .map(|f_handle| {
-            let def_idx = f_handle.owner;
-            let owner = structs.safe_get(def_idx.0 as usize)?.def_vtable_key.clone();
             let offset = f_handle.field as usize;
-            Ok(FieldHandle { offset, owner })
+            Ok(FieldHandle {
+                offset,
+                #[cfg(any(debug_assertions, feature = "testing"))]
+                owner: structs.safe_get(f_handle.owner.0 as usize)?.def_vtable_key.clone(),
+            })
         })
         .collect::<PartialVMResult<Vec<_>>>()?;
     context.arena_vec(field_handles.into_iter())
@@ -937,10 +940,13 @@ fn field_instantiations(
         .iter()
         .map(|f_inst| {
             let fh_idx = f_inst.handle;
-            let owner = field_handles.safe_get(fh_idx.0 as usize)?.owner.clone();
             let offset = field_handles.safe_get(fh_idx.0 as usize)?.offset;
 
-            Ok(FieldInstantiation { offset, owner })
+            Ok(FieldInstantiation {
+                offset,
+                #[cfg(any(debug_assertions, feature = "testing"))]
+                owner: field_handles.safe_get(fh_idx.0 as usize)?.owner.clone(),
+            })
         })
         .collect::<PartialVMResult<Vec<_>>>()?;
     context.arena_vec(field_instantiations.into_iter())

--- a/external-crates/move/crates/move-vm-runtime/src/jit/execution/translate.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/jit/execution/translate.rs
@@ -806,7 +806,10 @@ fn field_handles(
             let offset = f_handle.field as usize;
             Ok(FieldHandle {
                 offset,
-                owner: structs.safe_get(f_handle.owner.0 as usize)?.def_vtable_key.clone(),
+                owner: structs
+                    .safe_get(f_handle.owner.0 as usize)?
+                    .def_vtable_key
+                    .clone(),
             })
         })
         .collect::<PartialVMResult<Vec<_>>>()?;

--- a/external-crates/move/crates/move-vm-runtime/src/jit/execution/translate.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/jit/execution/translate.rs
@@ -797,7 +797,6 @@ fn cache_signatures(
 fn field_handles(
     context: &mut PackageContext<'_>,
     module: &CompiledModule,
-    #[cfg_attr(not(any(debug_assertions, feature = "testing")), allow(unused))]
     structs: &[StructDef],
 ) -> PartialVMResult<ArenaVec<FieldHandle>> {
     let field_handles = module
@@ -807,7 +806,6 @@ fn field_handles(
             let offset = f_handle.field as usize;
             Ok(FieldHandle {
                 offset,
-                #[cfg(any(debug_assertions, feature = "testing"))]
                 owner: structs.safe_get(f_handle.owner.0 as usize)?.def_vtable_key.clone(),
             })
         })
@@ -944,7 +942,6 @@ fn field_instantiations(
 
             Ok(FieldInstantiation {
                 offset,
-                #[cfg(any(debug_assertions, feature = "testing"))]
                 owner: field_handles.safe_get(fh_idx.0 as usize)?.owner.clone(),
             })
         })

--- a/external-crates/move/crates/move-vm-runtime/src/natives/functions.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/natives/functions.rs
@@ -36,9 +36,11 @@ use smallvec::{SmallVec, smallvec};
 use std::{
     cell::RefCell,
     collections::{HashMap, VecDeque},
-    fmt::Write,
     sync::Arc,
 };
+
+#[cfg(any(debug_assertions, feature = "testing"))]
+use std::fmt::Write;
 
 pub type UnboxedNativeFunction = dyn Fn(&mut NativeContext, Vec<Type>, VecDeque<Value>) -> PartialVMResult<NativeResult>
     + Send
@@ -211,6 +213,7 @@ impl NativeFunctions {
 pub struct NativeContext<'a, 'b, 'c> {
     // If this native was the base invocation, we do not create a machine state. This is only used
     // for printing stack traces, and in that case we will print that there is no call stack.
+    #[cfg(any(debug_assertions, feature = "testing"))]
     state: Option<&'a MachineState>,
     vtables: &'a VMDispatchTables,
     extensions: &'a mut NativeContextExtensions<'b>,
@@ -221,6 +224,7 @@ pub struct NativeContext<'a, 'b, 'c> {
 
 impl<'a, 'b, 'c> NativeContext<'a, 'b, 'c> {
     pub(crate) fn new(
+        #[cfg_attr(not(any(debug_assertions, feature = "testing")), allow(unused))]
         state: Option<&'a MachineState>,
         vtables: &'a VMDispatchTables,
         extensions: &'a mut NativeContextExtensions<'b>,
@@ -228,6 +232,7 @@ impl<'a, 'b, 'c> NativeContext<'a, 'b, 'c> {
         gas_budget: InternalGas,
     ) -> Self {
         Self {
+            #[cfg(any(debug_assertions, feature = "testing"))]
             state,
             vtables,
             extensions,

--- a/external-crates/move/crates/move-vm-runtime/src/natives/functions.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/natives/functions.rs
@@ -39,7 +39,7 @@ use std::{
     sync::Arc,
 };
 
-#[cfg(any(debug_assertions, feature = "testing"))]
+#[allow(unused_imports)]
 use std::fmt::Write;
 
 pub type UnboxedNativeFunction = dyn Fn(&mut NativeContext, Vec<Type>, VecDeque<Value>) -> PartialVMResult<NativeResult>
@@ -213,7 +213,7 @@ impl NativeFunctions {
 pub struct NativeContext<'a, 'b, 'c> {
     // If this native was the base invocation, we do not create a machine state. This is only used
     // for printing stack traces, and in that case we will print that there is no call stack.
-    #[cfg(any(debug_assertions, feature = "testing"))]
+    #[allow(dead_code)]
     state: Option<&'a MachineState>,
     vtables: &'a VMDispatchTables,
     extensions: &'a mut NativeContextExtensions<'b>,
@@ -224,7 +224,6 @@ pub struct NativeContext<'a, 'b, 'c> {
 
 impl<'a, 'b, 'c> NativeContext<'a, 'b, 'c> {
     pub(crate) fn new(
-        #[cfg_attr(not(any(debug_assertions, feature = "testing")), allow(unused))]
         state: Option<&'a MachineState>,
         vtables: &'a VMDispatchTables,
         extensions: &'a mut NativeContextExtensions<'b>,
@@ -232,7 +231,6 @@ impl<'a, 'b, 'c> NativeContext<'a, 'b, 'c> {
         gas_budget: InternalGas,
     ) -> Self {
         Self {
-            #[cfg(any(debug_assertions, feature = "testing"))]
             state,
             vtables,
             extensions,

--- a/external-crates/move/crates/move-vm-runtime/src/natives/functions.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/natives/functions.rs
@@ -213,7 +213,7 @@ impl NativeFunctions {
 pub struct NativeContext<'a, 'b, 'c> {
     // If this native was the base invocation, we do not create a machine state. This is only used
     // for printing stack traces, and in that case we will print that there is no call stack.
-    #[allow(dead_code)]
+    #[allow(dead_code, reason = "consumed by print_stack_trace in debug builds")]
     state: Option<&'a MachineState>,
     vtables: &'a VMDispatchTables,
     extensions: &'a mut NativeContextExtensions<'b>,

--- a/external-crates/move/crates/move-vm-runtime/src/shared/linkage_context.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/shared/linkage_context.rs
@@ -9,9 +9,9 @@ use move_binary_format::{
 };
 use crate::shared::types::{OriginalId, VersionId};
 
-#[cfg(any(debug_assertions, feature = "testing"))]
+#[allow(unused_imports)]
 use move_binary_format::errors::PartialVMResult;
-#[cfg(any(debug_assertions, feature = "testing"))]
+#[allow(unused_imports)]
 use move_core_types::language_storage::TypeTag;
 
 /// An execution context that remaps the modules referred to at runtime according to a linkage

--- a/external-crates/move/crates/move-vm-runtime/src/shared/linkage_context.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/shared/linkage_context.rs
@@ -3,11 +3,11 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
+use crate::shared::types::{OriginalId, VersionId};
 use move_binary_format::{
     errors::{Location, VMResult},
     partial_vm_error,
 };
-use crate::shared::types::{OriginalId, VersionId};
 
 #[allow(unused_imports)]
 use move_binary_format::errors::PartialVMResult;

--- a/external-crates/move/crates/move-vm-runtime/src/shared/linkage_context.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/shared/linkage_context.rs
@@ -4,12 +4,15 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use move_binary_format::{
-    errors::{Location, PartialVMResult, VMResult},
+    errors::{Location, VMResult},
     partial_vm_error,
 };
-use move_core_types::language_storage::TypeTag;
-
 use crate::shared::types::{OriginalId, VersionId};
+
+#[cfg(any(debug_assertions, feature = "testing"))]
+use move_binary_format::errors::PartialVMResult;
+#[cfg(any(debug_assertions, feature = "testing"))]
+use move_core_types::language_storage::TypeTag;
 
 /// An execution context that remaps the modules referred to at runtime according to a linkage
 /// table, allowing the same module in storage to be run against different dependencies.


### PR DESCRIPTION
## Description 

Gate debug/testing-only code behind #[cfg(any(debug_assertions, feature = "testing"))] to eliminate warnings in optimized builds:
- Unused imports in linkage_context.rs, state.rs, functions.rs
- Dead code: InternedDisplay trait/impls, FieldHandle.owner, FieldInstantiation.owner, StackFrame::iter, NativeContext.state
- move-regex-borrow-graph: successors_idx, edge_weight, all_edges_idx, check_invariants only used in debug/test

## Test plan 

```
cargo bench -p language-benchmarks --no-run
```
---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
