### PR TITLE
Tighten epoch check in update_randomness_state

### DIFF
--- a/crates/sui-framework/packages/sui-framework/sources/random.move
+++ b/crates/sui-framework/packages/sui-framework/sources/random.move
@@ -107,7 +107,7 @@ fun update_randomness_state(
         // randomness ever being generated in that epoch.
         assert!(
             (epoch > inner.epoch && new_round == 0) ||
-                    (new_round == inner.randomness_round + 1),
+                    (epoch == inner.epoch && new_round == inner.randomness_round + 1),
             EInvalidRandomnessUpdate,
         );
     };


### PR DESCRIPTION
## Summary

The second validation branch in `update_randomness_state` (`random.move:110`) accepts round increments without checking the epoch:

```move
assert!(
    (epoch > inner.epoch && new_round == 0) ||
            (new_round == inner.randomness_round + 1),  // no epoch check
    EInvalidRandomnessUpdate,
);
```

This means if epoch jumps (e.g., 5 → 7), a round increment (e.g., round 3 → 4) would pass validation instead of requiring a reset to round 0 for the new epoch.

**Fix:** Add `epoch == inner.epoch` to the second branch so rounds can only increment within the same epoch:

```move
(epoch == inner.epoch && new_round == inner.randomness_round + 1)
```

This makes the Move-side validation match the invariant described in the comment on L105-107: *"Subsequent updates should either increase epoch or increment randomness_round."*

**Note:** The Rust side (`authority.rs`) already enforces epoch matching before constructing the system transaction, so this is a defense-in-depth hardening — the Move contract should independently enforce its own invariants.

## Test plan

- [ ] Existing `random` tests continue to pass (no behavioral change for valid inputs)
- [ ] Invalid cross-epoch round increments are now correctly rejected at the Move level