### PR TITLE
docs fix: Update address reference link in Sui Move concepts

### DIFF
--- a/docs/content/concepts/sui-move-concepts.mdx
+++ b/docs/content/concepts/sui-move-concepts.mdx
@@ -44,7 +44,7 @@ In Move on Diem, there is a 16 byte `address` type used to represent account add
 
 Sui doesn't have global storage, so `address` is repurposed as a 32 byte identifier used for both objects and accounts. Each transaction is signed by an account (the sender) that is accessible from the transaction context, and each object stores its `address` wrapped in its `id: UID` field.
 
-See the [address section](https://move-book.com/reference/primitive-types/address.html) in The Move Book for an overview on addresses and refer to <UnsafeLink href="/references/framework/sui-framework/sui_sui/object">object.move</UnsafeLink> in the Sui framework for implementation details.
+See the [address section](https://move-book.com/reference/primitive-types/address.html) in The Move Book for an overview on addresses and refer to [sui::object](/references/framework/sui_sui/object) in the Sui framework for implementation details.
 
 ### Object with key ability, globally unique IDs {#global-unique}
 


### PR DESCRIPTION
docs fix

## Description 

Update address reference link in Sui Move concepts because previous one doesn't exists anymore
