### PR TITLE
Reorganize gas charging pipeline into explicit phases

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -235,6 +235,10 @@ pub mod move_integration_tests;
 mod gas_tests;
 
 #[cfg(test)]
+#[path = "unit_tests/gas_diff_tests.rs"]
+mod gas_diff_tests;
+
+#[cfg(test)]
 #[path = "unit_tests/gas_data_tests.rs"]
 mod gas_data_tests;
 

--- a/crates/sui-core/src/unit_tests/gas_diff_tests.rs
+++ b/crates/sui-core/src/unit_tests/gas_diff_tests.rs
@@ -1,0 +1,328 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Differential tests for gas charging behavior.
+//!
+//! Each test drives the `move_random` package (`loopy` / `storage_heavy` /
+//! `always_abort`) through a specific error path and snapshots the resulting
+//! `GasCostSummary` + `ExecutionStatus` + effects shape in a deterministic
+//! text form. The goal is to compare behavior between `main` and this branch
+//! (dario/gas_charger_squashed) by:
+//!
+//!   1. Running these tests on `main`, accepting the insta baseline.
+//!   2. Running them on this branch — insta flags any snapshot that drifts.
+//!
+//! Object IDs and package addresses are intentionally excluded from the
+//! snapshot strings because they are non-deterministic across runs.
+
+use super::*;
+
+use super::authority_tests::submit_and_execute;
+use super::gas_tests::{make_gas_coins, publish_move_random_package, touch_gas_coins};
+use crate::authority::test_authority_builder::TestAuthorityBuilder;
+use insta::assert_snapshot;
+use move_core_types::ident_str;
+use sui_protocol_config::ProtocolConfig;
+use sui_types::base_types::{ObjectID, SuiAddress};
+use sui_types::crypto::{AccountKeyPair, get_key_pair};
+use sui_types::execution_status::{ExecutionErrorKind, ExecutionStatus};
+use sui_types::gas_coin::GasCoin;
+use sui_types::transaction::{CallArg, TransactionData};
+use sui_types::utils::to_sender_signed_transaction;
+
+/// Run one transaction against `move_random::<entry>` and return a
+/// deterministic, snapshot-friendly description of its outcome.
+///
+/// Includes only values that do not depend on random IDs or addresses:
+///   - status classification (Success / Failure(<kind label>) with command index)
+///   - full GasCostSummary (u64 fields)
+///   - gas_object balance delta (final - initial)
+///   - counts of mutated / created / deleted entries in the effects
+///
+/// Deliberately excludes Debug renderings of MoveAbort, object references,
+/// package IDs, or anything else that varies run-to-run.
+async fn run_transaction_for_diff(
+    entry: &'static str,
+    args: Vec<CallArg>,
+    budget: u64,
+    gas_price: u64,
+    coin_num: u64,
+) -> String {
+    let (sender, sender_key): (SuiAddress, AccountKeyPair) = get_key_pair();
+
+    // Ensure we have enough to cover `budget` in each coin setup.
+    let gas_amount: u64 = if budget < 10_000_000_000 {
+        10_000_000_000
+    } else {
+        budget
+    };
+
+    let gas_coins = make_gas_coins(sender, gas_amount, coin_num);
+    let gas_coin_ids: Vec<_> = gas_coins.iter().map(|obj| obj.id()).collect();
+    let authority_state = TestAuthorityBuilder::new().build().await;
+    for obj in gas_coins {
+        authority_state.insert_genesis_object(obj).await;
+    }
+
+    // Separate gas coin used only for publishing the test package.
+    let publish_gas_id = ObjectID::random();
+    let publish_gas = sui_types::object::Object::with_id_owner_gas_for_testing(
+        publish_gas_id,
+        sender,
+        gas_amount,
+    );
+    authority_state.insert_genesis_object(publish_gas).await;
+
+    // Touch the gas coins so storage_rebate is non-zero (matches check_oog_transaction).
+    touch_gas_coins(
+        &authority_state,
+        sender,
+        &sender_key,
+        sender,
+        &gas_coin_ids,
+        publish_gas_id,
+    )
+    .await;
+
+    let package =
+        publish_move_random_package(&authority_state, &sender, &sender_key, &publish_gas_id).await;
+
+    // Re-read the gas coins after `touch_gas_coins` so we use fresh versions.
+    let mut gas_coin_refs = vec![];
+    for coin_id in &gas_coin_ids {
+        let coin_ref = authority_state
+            .get_object(coin_id)
+            .await
+            .unwrap()
+            .compute_object_reference();
+        gas_coin_refs.push(coin_ref);
+    }
+
+    let module = ident_str!("move_random").to_owned();
+    let function = ident_str!(entry).to_owned();
+    let data = TransactionData::new_move_call_with_gas_coins(
+        sender,
+        package,
+        module,
+        function,
+        vec![],
+        gas_coin_refs,
+        args,
+        budget,
+        gas_price,
+    )
+    .unwrap();
+    let tx = to_sender_signed_transaction(data, &sender_key);
+
+    // Capture the primary gas coin's pre-execution balance. `submit_and_execute`
+    // consumes the transaction; we read from the store here.
+    let primary_gas_before =
+        GasCoin::try_from(&authority_state.get_object(&gas_coin_ids[0]).await.unwrap())
+            .unwrap()
+            .value();
+
+    let effects = submit_and_execute(&authority_state, tx)
+        .await
+        .unwrap()
+        .1
+        .into_data();
+
+    let status_str = render_status(effects.status());
+    let summary = effects.gas_cost_summary();
+
+    // The gas object in effects is the smashed primary coin, which may have
+    // been reduced in value but is still mutated (not deleted).
+    let primary_gas_after = match effects.gas_object() {
+        Some((oref, _)) => authority_state
+            .get_object(&oref.0)
+            .await
+            .and_then(|obj| GasCoin::try_from(&obj).ok().map(|c| c.value())),
+        None => None,
+    };
+    let balance_delta: i64 = match primary_gas_after {
+        Some(after) => after as i64 - primary_gas_before as i64,
+        None => -(primary_gas_before as i64),
+    };
+
+    format!(
+        "status: {status}\n\
+         computation_cost: {cc}\n\
+         storage_cost: {sc}\n\
+         storage_rebate: {sr}\n\
+         non_refundable_storage_fee: {nrsf}\n\
+         gas_object_balance_change: {delta}\n\
+         mutated_count: {m}\n\
+         created_count: {c}\n\
+         deleted_count: {d}\n",
+        status = status_str,
+        cc = summary.computation_cost,
+        sc = summary.storage_cost,
+        sr = summary.storage_rebate,
+        nrsf = summary.non_refundable_storage_fee,
+        delta = balance_delta,
+        m = effects.mutated().len(),
+        c = effects.created().len(),
+        d = effects.deleted().len(),
+    )
+}
+
+/// Classify `ExecutionStatus` into a short, deterministic label.
+fn render_status(status: &ExecutionStatus) -> String {
+    match status {
+        ExecutionStatus::Success => "Success".to_string(),
+        ExecutionStatus::Failure(f) => {
+            let kind_label = match &f.error {
+                ExecutionErrorKind::InsufficientGas => "InsufficientGas".to_string(),
+                ExecutionErrorKind::MoveAbort(_, code) => format!("MoveAbort(code={code})"),
+                ExecutionErrorKind::EffectsTooLarge { .. } => "EffectsTooLarge".to_string(),
+                other => format!("{other:?}")
+                    .split('{')
+                    .next()
+                    .unwrap_or("")
+                    .trim()
+                    .to_string(),
+            };
+            match f.command {
+                Some(idx) => format!("Failure({kind_label}, command={idx})"),
+                None => format!("Failure({kind_label})"),
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Happy path (should be identical across branches).
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn diff_happy_success_single_coin() {
+    let out = run_transaction_for_diff(
+        "storage_heavy",
+        vec![
+            CallArg::Pure(bcs::to_bytes(&5_u64).unwrap()),
+            CallArg::Pure(bcs::to_bytes(&SuiAddress::ZERO).unwrap()),
+        ],
+        5_000_000,
+        1000,
+        1,
+    )
+    .await;
+    assert_snapshot!(out);
+}
+
+#[tokio::test]
+async fn diff_happy_success_multi_coin() {
+    let out = run_transaction_for_diff(
+        "storage_heavy",
+        vec![
+            CallArg::Pure(bcs::to_bytes(&5_u64).unwrap()),
+            CallArg::Pure(bcs::to_bytes(&SuiAddress::ZERO).unwrap()),
+        ],
+        5_000_000,
+        1000,
+        5,
+    )
+    .await;
+    assert_snapshot!(out);
+}
+
+// ---------------------------------------------------------------------------
+// Computation-OOG paths (via `loopy`).
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn diff_oog_computation_storage_ok_single() {
+    let budget = ProtocolConfig::get_for_max_version_UNSAFE().max_tx_gas();
+    let out = run_transaction_for_diff("loopy", vec![], budget, 1000, 1).await;
+    assert_snapshot!(out);
+}
+
+#[tokio::test]
+async fn diff_oog_computation_storage_ok_multi() {
+    let budget = ProtocolConfig::get_for_max_version_UNSAFE().max_tx_gas();
+    let out = run_transaction_for_diff("loopy", vec![], budget, 1000, 5).await;
+    assert_snapshot!(out);
+}
+
+#[tokio::test]
+async fn diff_oog_computation_minimal_storage_oog() {
+    // Budget = 5M units * 1000 rgp. Entire budget is consumed by computation so
+    // even input-only storage can't be paid — hits the full-budget fallback.
+    let out = run_transaction_for_diff("loopy", vec![], 5_000_000 * 1000, 1000, 1).await;
+    assert_snapshot!(out);
+}
+
+// ---------------------------------------------------------------------------
+// Storage-OOG paths (via `storage_heavy`).
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn diff_storage_oog_minimal_ok_single() {
+    let out = run_transaction_for_diff(
+        "storage_heavy",
+        vec![
+            CallArg::Pure(bcs::to_bytes(&100_u64).unwrap()),
+            // Use ZERO so the address doesn't depend on the random keypair.
+            CallArg::Pure(bcs::to_bytes(&SuiAddress::ZERO).unwrap()),
+        ],
+        1_100_000,
+        1001,
+        1,
+    )
+    .await;
+    assert_snapshot!(out);
+}
+
+#[tokio::test]
+async fn diff_storage_oog_minimal_ok_multi() {
+    let out = run_transaction_for_diff(
+        "storage_heavy",
+        vec![
+            CallArg::Pure(bcs::to_bytes(&100_u64).unwrap()),
+            CallArg::Pure(bcs::to_bytes(&SuiAddress::ZERO).unwrap()),
+        ],
+        1_100_000,
+        1001,
+        5,
+    )
+    .await;
+    assert_snapshot!(out);
+}
+
+#[tokio::test]
+async fn diff_storage_oog_minimal_oog() {
+    let out = run_transaction_for_diff(
+        "storage_heavy",
+        vec![
+            CallArg::Pure(bcs::to_bytes(&100_u64).unwrap()),
+            CallArg::Pure(bcs::to_bytes(&SuiAddress::ZERO).unwrap()),
+        ],
+        1_002_000,
+        1001,
+        1,
+    )
+    .await;
+    assert_snapshot!(out);
+}
+
+// ---------------------------------------------------------------------------
+// Move-abort paths (via `always_abort`).
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn diff_move_abort_generous_budget() {
+    let out = run_transaction_for_diff("always_abort", vec![], 10_000_000_000, 1000, 1).await;
+    assert_snapshot!(out);
+}
+
+#[tokio::test]
+async fn diff_move_abort_tight_budget() {
+    let out = run_transaction_for_diff("always_abort", vec![], 2_000_000, 1000, 1).await;
+    assert_snapshot!(out);
+}
+
+#[tokio::test]
+async fn diff_move_abort_multi_coin() {
+    let out = run_transaction_for_diff("always_abort", vec![], 10_000_000_000, 1000, 5).await;
+    assert_snapshot!(out);
+}

--- a/crates/sui-core/src/unit_tests/gas_tests.rs
+++ b/crates/sui-core/src/unit_tests/gas_tests.rs
@@ -109,7 +109,7 @@ async fn test_tx_more_than_maximum_gas_budget() {
 // Helpers for OOG scenarios
 //
 
-async fn publish_move_random_package(
+pub(super) async fn publish_move_random_package(
     authority_state: &Arc<AuthorityState>,
     sender: &SuiAddress,
     sender_key: &AccountKeyPair,
@@ -245,7 +245,7 @@ where
 }
 
 // make a `coin_num` coins distributing `gas_amount` across them
-fn make_gas_coins(owner: SuiAddress, gas_amount: u64, coin_num: u64) -> Vec<Object> {
+pub(super) fn make_gas_coins(owner: SuiAddress, gas_amount: u64, coin_num: u64) -> Vec<Object> {
     let mut objects = vec![];
     let coin_balance = gas_amount / coin_num;
     for _ in 1..coin_num {
@@ -268,7 +268,7 @@ fn make_gas_coins(owner: SuiAddress, gas_amount: u64, coin_num: u64) -> Vec<Obje
 }
 
 // Touch gas coins so that `storage_rebate` is set
-async fn touch_gas_coins(
+pub(super) async fn touch_gas_coins(
     authority_state: &AuthorityState,
     sender: SuiAddress,
     sender_key: &AccountKeyPair,

--- a/crates/sui-core/src/unit_tests/snapshots/sui_core__authority__gas_diff_tests__diff_happy_success_multi_coin.snap
+++ b/crates/sui-core/src/unit_tests/snapshots/sui_core__authority__gas_diff_tests__diff_happy_success_multi_coin.snap
@@ -1,0 +1,13 @@
+---
+source: crates/sui-core/src/unit_tests/gas_diff_tests.rs
+expression: out
+---
+status: Success
+computation_cost: 1000000
+storage_cost: 2622000
+storage_rebate: 4890600
+non_refundable_storage_fee: 49400
+gas_object_balance_change: 8001268600
+mutated_count: 1
+created_count: 1
+deleted_count: 4

--- a/crates/sui-core/src/unit_tests/snapshots/sui_core__authority__gas_diff_tests__diff_happy_success_single_coin.snap
+++ b/crates/sui-core/src/unit_tests/snapshots/sui_core__authority__gas_diff_tests__diff_happy_success_single_coin.snap
@@ -1,0 +1,13 @@
+---
+source: crates/sui-core/src/unit_tests/gas_diff_tests.rs
+expression: out
+---
+status: Success
+computation_cost: 1000000
+storage_cost: 2622000
+storage_rebate: 978120
+non_refundable_storage_fee: 9880
+gas_object_balance_change: -2643880
+mutated_count: 1
+created_count: 1
+deleted_count: 0

--- a/crates/sui-core/src/unit_tests/snapshots/sui_core__authority__gas_diff_tests__diff_move_abort_generous_budget.snap
+++ b/crates/sui-core/src/unit_tests/snapshots/sui_core__authority__gas_diff_tests__diff_move_abort_generous_budget.snap
@@ -1,0 +1,13 @@
+---
+source: crates/sui-core/src/unit_tests/gas_diff_tests.rs
+expression: out
+---
+status: Failure(MoveAbort(code=42), command=0)
+computation_cost: 1000000
+storage_cost: 988000
+storage_rebate: 978120
+non_refundable_storage_fee: 9880
+gas_object_balance_change: -1009880
+mutated_count: 1
+created_count: 0
+deleted_count: 0

--- a/crates/sui-core/src/unit_tests/snapshots/sui_core__authority__gas_diff_tests__diff_move_abort_multi_coin.snap
+++ b/crates/sui-core/src/unit_tests/snapshots/sui_core__authority__gas_diff_tests__diff_move_abort_multi_coin.snap
@@ -1,0 +1,13 @@
+---
+source: crates/sui-core/src/unit_tests/gas_diff_tests.rs
+expression: out
+---
+status: Failure(MoveAbort(code=42), command=0)
+computation_cost: 1000000
+storage_cost: 988000
+storage_rebate: 4890600
+non_refundable_storage_fee: 49400
+gas_object_balance_change: 8002902600
+mutated_count: 1
+created_count: 0
+deleted_count: 4

--- a/crates/sui-core/src/unit_tests/snapshots/sui_core__authority__gas_diff_tests__diff_move_abort_tight_budget.snap
+++ b/crates/sui-core/src/unit_tests/snapshots/sui_core__authority__gas_diff_tests__diff_move_abort_tight_budget.snap
@@ -1,0 +1,13 @@
+---
+source: crates/sui-core/src/unit_tests/gas_diff_tests.rs
+expression: out
+---
+status: Failure(MoveAbort(code=42), command=0)
+computation_cost: 1000000
+storage_cost: 988000
+storage_rebate: 978120
+non_refundable_storage_fee: 9880
+gas_object_balance_change: -1009880
+mutated_count: 1
+created_count: 0
+deleted_count: 0

--- a/crates/sui-core/src/unit_tests/snapshots/sui_core__authority__gas_diff_tests__diff_oog_computation_minimal_storage_oog.snap
+++ b/crates/sui-core/src/unit_tests/snapshots/sui_core__authority__gas_diff_tests__diff_oog_computation_minimal_storage_oog.snap
@@ -1,0 +1,13 @@
+---
+source: crates/sui-core/src/unit_tests/gas_diff_tests.rs
+expression: out
+---
+status: Failure(InsufficientGas, command=0)
+computation_cost: 5000000000
+storage_cost: 0
+storage_rebate: 0
+non_refundable_storage_fee: 0
+gas_object_balance_change: -5000000000
+mutated_count: 1
+created_count: 0
+deleted_count: 0

--- a/crates/sui-core/src/unit_tests/snapshots/sui_core__authority__gas_diff_tests__diff_oog_computation_storage_ok_multi.snap
+++ b/crates/sui-core/src/unit_tests/snapshots/sui_core__authority__gas_diff_tests__diff_oog_computation_storage_ok_multi.snap
@@ -1,0 +1,13 @@
+---
+source: crates/sui-core/src/unit_tests/gas_diff_tests.rs
+expression: out
+---
+status: Failure(InsufficientGas, command=0)
+computation_cost: 5000000000
+storage_cost: 988000
+storage_rebate: 4890600
+non_refundable_storage_fee: 49400
+gas_object_balance_change: 39995003902600
+mutated_count: 1
+created_count: 0
+deleted_count: 4

--- a/crates/sui-core/src/unit_tests/snapshots/sui_core__authority__gas_diff_tests__diff_oog_computation_storage_ok_single.snap
+++ b/crates/sui-core/src/unit_tests/snapshots/sui_core__authority__gas_diff_tests__diff_oog_computation_storage_ok_single.snap
@@ -1,0 +1,13 @@
+---
+source: crates/sui-core/src/unit_tests/gas_diff_tests.rs
+expression: out
+---
+status: Failure(InsufficientGas, command=0)
+computation_cost: 5000000000
+storage_cost: 988000
+storage_rebate: 978120
+non_refundable_storage_fee: 9880
+gas_object_balance_change: -5000009880
+mutated_count: 1
+created_count: 0
+deleted_count: 0

--- a/crates/sui-core/src/unit_tests/snapshots/sui_core__authority__gas_diff_tests__diff_storage_oog_minimal_ok_multi.snap
+++ b/crates/sui-core/src/unit_tests/snapshots/sui_core__authority__gas_diff_tests__diff_storage_oog_minimal_ok_multi.snap
@@ -1,0 +1,13 @@
+---
+source: crates/sui-core/src/unit_tests/gas_diff_tests.rs
+expression: out
+---
+status: Failure(InsufficientGas)
+computation_cost: 1001000
+storage_cost: 988000
+storage_rebate: 4890600
+non_refundable_storage_fee: 49400
+gas_object_balance_change: 8002901600
+mutated_count: 1
+created_count: 0
+deleted_count: 4

--- a/crates/sui-core/src/unit_tests/snapshots/sui_core__authority__gas_diff_tests__diff_storage_oog_minimal_ok_single.snap
+++ b/crates/sui-core/src/unit_tests/snapshots/sui_core__authority__gas_diff_tests__diff_storage_oog_minimal_ok_single.snap
@@ -1,0 +1,13 @@
+---
+source: crates/sui-core/src/unit_tests/gas_diff_tests.rs
+expression: out
+---
+status: Failure(InsufficientGas)
+computation_cost: 1001000
+storage_cost: 988000
+storage_rebate: 978120
+non_refundable_storage_fee: 9880
+gas_object_balance_change: -1010880
+mutated_count: 1
+created_count: 0
+deleted_count: 0

--- a/crates/sui-core/src/unit_tests/snapshots/sui_core__authority__gas_diff_tests__diff_storage_oog_minimal_oog.snap
+++ b/crates/sui-core/src/unit_tests/snapshots/sui_core__authority__gas_diff_tests__diff_storage_oog_minimal_oog.snap
@@ -1,0 +1,13 @@
+---
+source: crates/sui-core/src/unit_tests/gas_diff_tests.rs
+expression: out
+---
+status: Failure(InsufficientGas)
+computation_cost: 1002000
+storage_cost: 0
+storage_rebate: 0
+non_refundable_storage_fee: 0
+gas_object_balance_change: -1002000
+mutated_count: 1
+created_count: 0
+deleted_count: 0

--- a/crates/sui-types/src/gas.rs
+++ b/crates/sui-types/src/gas.rs
@@ -33,7 +33,7 @@ pub mod checked {
         fn is_unmetered(&self) -> bool;
         fn move_gas_status(&self) -> &GasStatus;
         fn move_gas_status_mut(&mut self) -> &mut GasStatus;
-        fn bucketize_computation(&mut self, aborted: Option<bool>) -> Result<(), ExecutionError>;
+        fn round_computation_cost(&mut self, aborted: Option<bool>) -> Result<(), ExecutionError>;
         fn summary(&self) -> GasCostSummary;
         fn gas_budget(&self) -> u64;
         fn gas_price(&self) -> u64;

--- a/crates/sui-types/src/gas_model/gas_v2.rs
+++ b/crates/sui-types/src/gas_model/gas_v2.rs
@@ -189,7 +189,7 @@ mod checked {
         gas_budget: u64,
         // Computation cost after execution. This is the result of the gas used by the `GasStatus`
         // properly bucketized.
-        // Starts at 0 and it is assigned in `bucketize_computation`.
+        // Starts at 0 and it is assigned in `round_computation_cost`.
         computation_cost: u64,
         // Whether to charge or go unmetered
         charge: bool,
@@ -409,7 +409,7 @@ mod checked {
             &mut self.gas_status
         }
 
-        fn bucketize_computation(&mut self, aborted: Option<bool>) -> Result<(), ExecutionError> {
+        fn round_computation_cost(&mut self, aborted: Option<bool>) -> Result<(), ExecutionError> {
             let gas_used = self.gas_status.gas_used_pre_gas_price();
             let effective_gas_price = if self
                 .cost_table

--- a/sui-execution/latest/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/latest/sui-adapter/src/execution_engine.rs
@@ -67,6 +67,7 @@ mod checked {
     use sui_types::execution_status::{ExecutionErrorKind, ExecutionStatus};
     use sui_types::gas::GasCostSummary;
     use sui_types::gas::SuiGasStatus;
+    use sui_types::gas_model::gas_predicates::dont_charge_budget_on_storage_oog;
     use sui_types::id::UID;
     use sui_types::inner_temporary_store::InnerTemporaryStore;
     use sui_types::storage::BackingStore;
@@ -436,85 +437,71 @@ mod checked {
                 None
             };
 
-        // We must charge object read here during transaction execution, because if this fails
-        // we must still ensure an effect is committed and all objects versions incremented
-        let result = gas_charger.charge_input_objects(temporary_store);
-
-        let result: ResultWithTimings<Mode::ExecutionResults, Mode::Error> =
-            result.map_err(|e| (e.into(), vec![])).and_then(
-                |()| -> ResultWithTimings<Mode::ExecutionResults, Mode::Error> {
-                    let mut execution_result: ResultWithTimings<
-                        Mode::ExecutionResults,
-                        Mode::Error,
-                    > = match execution_params {
-                        ExecutionOrEarlyError::Err(early_execution_error) => Err((
-                            ExecutionError::new(early_execution_error, None).into(),
-                            vec![],
-                        )),
-                        ExecutionOrEarlyError::Ok(()) => execution_loop::<Mode>(
-                            store,
-                            temporary_store,
-                            transaction_kind,
-                            rewritten_inputs,
-                            tx_ctx,
-                            move_vm,
-                            gas_charger,
-                            protocol_config,
-                            metrics.clone(),
-                            trace_builder_opt,
-                        ),
-                    };
-
-                    let meter_check = check_meter_limit::<Mode>(
-                        temporary_store,
-                        gas_charger,
-                        protocol_config,
-                        metrics.clone(),
-                    );
-                    if let Err(e) = meter_check {
-                        execution_result = Err((e, vec![]));
-                    }
-
-                    if execution_result.is_ok() {
-                        let gas_check = check_written_objects_limit::<Mode>(
-                            temporary_store,
-                            gas_charger,
-                            protocol_config,
-                            metrics,
-                        );
-                        if let Err(e) = gas_check {
-                            execution_result = Err((e, vec![]));
-                        }
-                    }
-
-                    execution_result
-                },
-            );
-
-        let (mut result, timings) = match result {
-            Ok((r, t)) => (Ok(r), t),
-            Err((e, t)) => (Err(e), t),
-        };
-        if is_gasless
-            && result.is_ok()
-            && let Err(msg) = temporary_store
-                .check_gasless_execution_requirements(withdrawal_reservations.as_ref())
-        {
-            result = Err(
-                ExecutionError::new_with_source(ExecutionErrorKind::InsufficientGas, msg).into(),
+        // Transaction execution pipeline. Each phase depends on the previous succeeding:
+        //   1. Charge input objects — deduct read costs from the gas meter
+        //   2. Execute PTB — run the transaction and round computation cost
+        //   3. Finalize storage — collect storage costs, check budget, validate gasless
+        //   4. Check effects limits — validate effects size and written objects size
+        // If any phase fails, the error short-circuits via and_then; the error path is
+        // recovered uniformly by reset_charges (see below), after which charge applies
+        // the final payment. On success, charge is called directly on the phase result.
+        let mut timings = vec![];
+        let phase_result: Result<Mode::ExecutionResults, Mode::Error> = gas_charger
+            .charge_input_objects(temporary_store)
+            .map_err(Into::into)
+            .and_then(|()| {
+                let (result, t) = execute_ptb::<Mode>(
+                    store,
+                    temporary_store,
+                    transaction_kind,
+                    rewritten_inputs,
+                    tx_ctx,
+                    move_vm,
+                    gas_charger,
+                    protocol_config,
+                    metrics.clone(),
+                    trace_builder_opt,
+                    execution_params,
+                );
+                timings = t;
+                result
+            })
+            .and_then(|v| {
+                gas_charger.finalize_storage(temporary_store, withdrawal_reservations.as_ref())?;
+                Ok(v)
+            })
+            .and_then(|v| {
+                // Effects limits are only checked when all previous phases succeed.
+                // TODO: review whether these should run unconditionally (before charge)
+                // so that effects-too-large is always reported even on failed transactions.
+                check_meter_limit::<Mode>(
+                    temporary_store,
+                    gas_charger,
+                    protocol_config,
+                    metrics.clone(),
+                )?;
+                check_written_objects_limit::<Mode>(
+                    temporary_store,
+                    gas_charger,
+                    protocol_config,
+                    metrics,
+                )?;
+                Ok(v)
+            });
+        if phase_result.is_err() {
+            reset_charges(
+                gas_charger,
+                temporary_store,
+                withdrawal_reservations.as_ref(),
             );
         }
+        let mut result = phase_result;
+        let cost_summary = gas_charger.charge(temporary_store, &result);
 
-        let cost_summary = gas_charger.charge_gas(temporary_store, &mut result);
-        // For advance epoch transaction, we need to provide epoch rewards and rebates as extra
-        // information provided to check_sui_conserved, because we mint rewards, and burn
-        // the rebates. We also need to pass in the unmetered_storage_rebate because storage
-        // rebate is not reflected in the storage_rebate of gas summary. This is a bit confusing.
-        // We could probably clean up the code a bit.
-        // Put all the storage rebate accumulated in the system transaction
-        // to the 0x5 object so that it's not lost.
+        // Always: conserve unmetered storage rebate.
         temporary_store.conserve_unmetered_storage_rebate(gas_charger.unmetered_storage_rebate());
 
+        // Always: conservation checks.
         if let Err(e) = run_conservation_checks::<Mode>(
             temporary_store,
             gas_charger,
@@ -525,6 +512,7 @@ mod checked {
             &cost_summary,
             is_genesis_tx,
             advance_epoch_gas_summary,
+            withdrawal_reservations.as_ref(),
         ) {
             // FIXME: we cannot fail the transaction if this is an epoch change transaction.
             result = Err(e);
@@ -533,6 +521,103 @@ mod checked {
         (cost_summary, result, timings)
     }
 
+    /// Uniform error recovery. Leaves the gas status and temporary store in a state
+    /// where `GasCharger::charge` can be called by the caller to apply the final payment.
+    /// Does not charge — it only prepares the cost summary.
+    ///
+    /// Reset drops execution writes, re-smashes gas, and re-touches all mutable input
+    /// objects. After reset the store contains gas coin + input objects (no execution
+    /// outputs). Then finalize storage (collect storage costs for those objects + budget
+    /// check).
+    ///
+    /// If the budget check fails (computation consumed nearly the entire budget, leaving
+    /// no room for even input-object storage), we reset again and set
+    /// computation_cost = gas_budget with zero storage. The subsequent `charge` then
+    /// always succeeds because there are no storage costs to exceed the budget. Gas coin
+    /// and input objects remain in the store so their versions are updated in the
+    /// transaction effects.
+    ///
+    /// For gas model v1 (version < 4), the input-only storage attempt is skipped entirely
+    /// and we go straight to the full-budget fallback. This preserves the original v1
+    /// behavior where storage OOG always charges the full budget.
+    fn reset_charges(
+        gas_charger: &mut GasCharger,
+        temporary_store: &mut TemporaryStore<'_>,
+        withdrawal_reservations: Option<&BTreeMap<(SuiAddress, TypeTag), u64>>,
+    ) {
+        gas_charger.reset(temporary_store);
+        // v2+: try collecting input-only storage costs (reduced scope after reset).
+        // v1: skip this and go straight to the full-budget fallback.
+        if dont_charge_budget_on_storage_oog(gas_charger.gas_model_version())
+            && gas_charger
+                .finalize_storage(temporary_store, withdrawal_reservations)
+                .is_ok()
+        {
+            return;
+        }
+        // Input-only storage doesn't fit or v1 path: set computation to the full
+        // budget with zero storage so the subsequent charge takes the entire budget.
+        gas_charger.reset(temporary_store);
+        gas_charger.set_computation_to_budget();
+    }
+
+    /// Execute the programmable transaction (or apply early error), then round the
+    /// computation cost into a pricing tier. Returns the execution result and timings.
+    fn execute_ptb<Mode: ExecutionMode>(
+        store: &dyn BackingStore,
+        temporary_store: &mut TemporaryStore<'_>,
+        transaction_kind: TransactionKind,
+        rewritten_inputs: Option<Vec<bool>>,
+        tx_ctx: Rc<RefCell<TxContext>>,
+        move_vm: &Arc<MoveRuntime>,
+        gas_charger: &mut GasCharger,
+        protocol_config: &ProtocolConfig,
+        metrics: Arc<ExecutionMetrics>,
+        trace_builder_opt: &mut Option<MoveTraceBuilder>,
+        execution_params: ExecutionOrEarlyError,
+    ) -> (
+        Result<Mode::ExecutionResults, Mode::Error>,
+        Vec<ExecutionTiming>,
+    ) {
+        let r = match execution_params {
+            ExecutionOrEarlyError::Err(early_execution_error) => Err((
+                ExecutionError::new(early_execution_error, None).into(),
+                vec![],
+            )),
+            ExecutionOrEarlyError::Ok(()) => execution_loop::<Mode>(
+                store,
+                temporary_store,
+                transaction_kind,
+                rewritten_inputs,
+                tx_ctx,
+                move_vm,
+                gas_charger,
+                protocol_config,
+                metrics,
+                trace_builder_opt,
+            ),
+        };
+        let (mut result, timings) = match r {
+            Ok((v, t)) => (Ok(v), t),
+            Err((e, t)) => (Err(e), t),
+        };
+        let is_move_abort = matches!(
+            result.as_ref().err().map(|e| e.kind()),
+            Some(sui_types::execution_status::ExecutionErrorKind::MoveAbort(
+                ..
+            ))
+        );
+        if let Err(err) = gas_charger.round_computation(is_move_abort)
+            && result.is_ok()
+        {
+            result = Err(err.into());
+        }
+        (result, timings)
+    }
+
+    /// Check SUI conservation. On failure, reset charges and re-charge to recover,
+    /// then re-check conservation against the recovered cost summary.
+    /// Panics if conservation still fails after recovery.
     #[instrument(name = "run_conservation_checks", level = "debug", skip_all)]
     fn run_conservation_checks<Mode: ExecutionMode>(
         temporary_store: &mut TemporaryStore<'_>,
@@ -544,73 +629,71 @@ mod checked {
         cost_summary: &GasCostSummary,
         is_genesis_tx: bool,
         advance_epoch_gas_summary: Option<(u64, u64)>,
+        withdrawal_reservations: Option<&BTreeMap<(SuiAddress, TypeTag), u64>>,
     ) -> Result<(), Mode::Error> {
-        let mut result: Result<(), Mode::Error> = Ok(());
-        if !is_genesis_tx && !Mode::skip_conservation_checks() {
-            // ensure that this transaction did not create or destroy SUI, try to recover if the check fails
-            let conservation_result = {
-                temporary_store
-                    .check_sui_conserved(simple_conservation_checks, cost_summary)
-                    .and_then(|()| {
-                        if enable_expensive_checks {
-                            // ensure that this transaction did not create or destroy SUI, try to recover if the check fails
-                            let mut layout_resolver = TypeLayoutResolver::new(
-                                move_vm,
-                                temporary_store.protocol_config(),
-                                Box::new(&*temporary_store),
-                            );
-                            temporary_store.check_sui_conserved_expensive(
-                                cost_summary,
-                                advance_epoch_gas_summary,
-                                &mut layout_resolver,
-                            )
-                        } else {
-                            Ok(())
-                        }
-                    })
-            };
-            if let Err(conservation_err) = conservation_result {
-                // conservation violated. try to avoid panic by dumping all writes, charging for gas, re-checking
-                // conservation, and surfacing an aborted transaction with an invariant violation if all of that works
-                result = Err(conservation_err.into());
-                gas_charger.reset(temporary_store);
-                gas_charger.charge_gas(temporary_store, &mut result);
-                // check conservation once more
-                if let Err(recovery_err) = {
-                    temporary_store
-                        .check_sui_conserved(simple_conservation_checks, cost_summary)
-                        .and_then(|()| {
-                            if enable_expensive_checks {
-                                // ensure that this transaction did not create or destroy SUI, try to recover if the check fails
-                                let mut layout_resolver = TypeLayoutResolver::new(
-                                    move_vm,
-                                    temporary_store.protocol_config(),
-                                    Box::new(&*temporary_store),
-                                );
-                                temporary_store.check_sui_conserved_expensive(
-                                    cost_summary,
-                                    advance_epoch_gas_summary,
-                                    &mut layout_resolver,
-                                )
-                            } else {
-                                Ok(())
-                            }
-                        })
-                } {
-                    // if we still fail, it's a problem with gas
-                    // charging that happens even in the "aborted" case--no other option but panic.
-                    // we will create or destroy SUI otherwise
-                    panic!(
-                        "SUI conservation fail in tx block {}: {}\nGas status is {}\nTx was ",
-                        tx_digest,
-                        recovery_err,
-                        gas_charger.summary()
-                    )
-                }
+        if is_genesis_tx || Mode::skip_conservation_checks() {
+            return Ok(());
+        }
+
+        if let Err(conservation_err) = check_conservation(
+            temporary_store,
+            move_vm,
+            simple_conservation_checks,
+            enable_expensive_checks,
+            cost_summary,
+            advance_epoch_gas_summary,
+        ) {
+            // Conservation violated. Reset and re-charge, then re-check against the
+            // recovered cost summary.
+            let recovery_result: Result<(), Mode::Error> = Err(conservation_err.into());
+            reset_charges(gas_charger, temporary_store, withdrawal_reservations);
+            let recovery_cost = gas_charger.charge(temporary_store, &recovery_result);
+
+            if let Err(recovery_err) = check_conservation(
+                temporary_store,
+                move_vm,
+                simple_conservation_checks,
+                enable_expensive_checks,
+                &recovery_cost,
+                advance_epoch_gas_summary,
+            ) {
+                panic!(
+                    "SUI conservation fail in tx block {}: {}\nGas status is {}\nTx was ",
+                    tx_digest,
+                    recovery_err,
+                    gas_charger.summary()
+                )
             }
-        } // else, we're in the genesis transaction which mints the SUI supply, and hence does not satisfy SUI conservation, or
-        // we're in the non-production dev inspect mode which allows us to violate conservation
-        result
+
+            return recovery_result;
+        }
+
+        Ok(())
+    }
+
+    /// Run both cheap and (optionally) expensive SUI conservation checks.
+    fn check_conservation(
+        temporary_store: &mut TemporaryStore<'_>,
+        move_vm: &Arc<MoveRuntime>,
+        simple_conservation_checks: bool,
+        enable_expensive_checks: bool,
+        cost_summary: &GasCostSummary,
+        advance_epoch_gas_summary: Option<(u64, u64)>,
+    ) -> Result<(), ExecutionError> {
+        temporary_store.check_sui_conserved(simple_conservation_checks, cost_summary)?;
+        if enable_expensive_checks {
+            let mut layout_resolver = TypeLayoutResolver::new(
+                move_vm,
+                temporary_store.protocol_config(),
+                Box::new(&*temporary_store),
+            );
+            temporary_store.check_sui_conserved_expensive(
+                cost_summary,
+                advance_epoch_gas_summary,
+                &mut layout_resolver,
+            )?;
+        }
+        Ok(())
     }
 
     #[instrument(name = "check_meter_limit", level = "debug", skip_all)]

--- a/sui-execution/latest/sui-adapter/src/gas_charger.rs
+++ b/sui-execution/latest/sui-adapter/src/gas_charger.rs
@@ -11,14 +11,14 @@ pub mod checked {
     use crate::temporary_store::TemporaryStore;
     use either::Either;
     use indexmap::IndexMap;
+    use move_core_types::language_storage::TypeTag;
+    use std::collections::BTreeMap;
     use sui_protocol_config::ProtocolConfig;
     use sui_types::deny_list_v2::CONFIG_SETTING_DYNAMIC_FIELD_SIZE_FOR_GAS;
     use sui_types::digests::TransactionDigest;
     use sui_types::error::ExecutionErrorTrait;
     use sui_types::gas::{GasCostSummary, SuiGasStatus, deduct_gas};
-    use sui_types::gas_model::gas_predicates::{
-        charge_upgrades, dont_charge_budget_on_storage_oog,
-    };
+    use sui_types::gas_model::gas_predicates::charge_upgrades;
     use sui_types::{
         accumulator_event::AccumulatorEvent,
         base_types::{ObjectID, ObjectRef, SuiAddress},
@@ -220,6 +220,18 @@ pub mod checked {
             self.gas_status.is_unmetered()
         }
 
+        pub fn gas_model_version(&self) -> u64 {
+            self.gas_model_version
+        }
+
+        pub fn set_computation_to_budget(&mut self) {
+            self.gas_status.adjust_computation_on_out_of_gas();
+        }
+
+        pub fn reset_storage_cost_and_rebate(&mut self) {
+            self.gas_status.reset_storage_cost_and_rebate();
+        }
+
         pub fn move_gas_status(&self) -> &GasStatus {
             self.gas_status.move_gas_status()
         }
@@ -264,10 +276,6 @@ pub mod checked {
         ) -> u64 {
             self.gas_status
                 .track_storage_mutation(object_id, new_size, storage_rebate)
-        }
-
-        pub fn reset_storage_cost_and_rebate(&mut self) {
-            self.gas_status.reset_storage_cost_and_rebate();
         }
 
         pub fn charge_publish_package(&mut self, size: usize) -> Result<(), ExecutionError> {
@@ -318,125 +326,151 @@ pub mod checked {
             self.gas_status.charge_storage_read(owner_cost)
         }
 
-        /// Resets any mutations, deletions, and events recorded in the store, as well as any storage costs and
-        /// rebates, then Re-runs gas smashing. Effects on store are now as if we were about to begin execution
+        /// Resets any mutations, deletions, and events recorded in the store, as well as any
+        /// storage costs and rebates, then re-runs gas smashing. After reset, the store
+        /// Resets the temporary store and gas tracking to a clean post-input state:
+        /// drops all writes, clears storage costs/rebates, re-smashes gas, and
+        /// re-touches all mutable input objects for version bumping.
         pub fn reset(&mut self, temporary_store: &mut TemporaryStore<'_>) {
             temporary_store.drop_writes();
             self.gas_status.reset_storage_cost_and_rebate();
             self.smash_gas(temporary_store);
+            temporary_store.ensure_active_inputs_mutated();
         }
 
-        /// Entry point for gas charging.
-        /// 1. Compute tx storage gas costs and tx storage rebates, update storage_rebate field of
-        /// mutated objects
-        /// 2. Deduct computation gas costs and storage costs, credit storage rebates.
-        /// The happy path of this function follows (1) + (2) and is fairly simple.
-        /// Most of the complexity is in the unhappy paths:
-        /// - if execution aborted before calling this function, we have to dump all writes +
-        ///   re-smash gas, then charge for storage
-        /// - if we run out of gas while charging for storage, we have to dump all writes +
-        ///   re-smash gas, then charge for storage again
-        pub fn charge_gas<T, E: ExecutionErrorTrait>(
-            &mut self,
-            temporary_store: &mut TemporaryStore<'_>,
-            execution_result: &mut Result<T, E>,
-        ) -> GasCostSummary {
-            // at this point, we have done *all* charging for computation,
-            // but have not yet set the storage rebate or storage gas units
+        /// Round the raw computation cost into a pricing tier and apply the gas price multiplier,
+        /// setting `computation_cost` in the gas status. `is_move_abort` is a hint used
+        /// when the transaction aborted via Move.
+        /// Returns `Err(InsufficientGas)` if the rounded computation exceeds the budget;
+        /// the caller is responsible for turning that into the transaction result.
+        /// Skipped entirely (returns `Ok(())`) for unmetered transactions (system txns,
+        /// dev inspect).
+        pub fn round_computation(&mut self, is_move_abort: bool) -> Result<(), ExecutionError> {
             debug_assert!(self.gas_status.storage_rebate() == 0);
             debug_assert!(self.gas_status.storage_gas_units() == 0);
 
-            if !matches!(&self.payment, PaymentMetadata::Unmetered) {
-                // bucketize computation cost
-                let is_move_abort = execution_result
-                    .as_ref()
-                    .err()
-                    .map(|err| {
-                        matches!(
-                            err.kind(),
-                            sui_types::execution_status::ExecutionErrorKind::MoveAbort(_, _)
-                        )
-                    })
-                    .unwrap_or(false);
-                // bucketize computation cost
-                if let Err(err) = self.gas_status.bucketize_computation(Some(is_move_abort))
-                    && execution_result.is_ok()
-                {
-                    *execution_result = Err(err.into());
-                }
-
-                // On error we need to dump writes, deletes, etc before charging storage gas
-                if execution_result.is_err() {
-                    self.reset(temporary_store);
-                }
+            if matches!(&self.payment, PaymentMetadata::Unmetered) {
+                return Ok(());
             }
+            self.gas_status.round_computation_cost(Some(is_move_abort))
+        }
 
-            // compute and collect storage charges
-            temporary_store.ensure_active_inputs_mutated();
-            temporary_store.collect_storage_and_rebate(self);
-
-            let gas_payment_location = match &self.payment {
+        /// Collect storage costs and check budget sufficiency.
+        /// For gasless transactions, validates execution requirements first (must run
+        /// before `ensure_active_inputs_mutated` which would add objects to written_objects).
+        /// Returns Ok if storage fits within budget, Err(InsufficientGas) if not.
+        /// Does NOT retry or reset on failure — the caller handles that.
+        /// Does NOT apply payment — call `charge` separately after this.
+        pub fn finalize_storage(
+            &mut self,
+            temporary_store: &mut TemporaryStore<'_>,
+            withdrawal_reservations: Option<&BTreeMap<(SuiAddress, TypeTag), u64>>,
+        ) -> Result<(), ExecutionError> {
+            match &self.payment {
                 PaymentMetadata::Unmetered => {
-                    return GasCostSummary::default();
+                    temporary_store.ensure_active_inputs_mutated();
+                    temporary_store.collect_storage_and_rebate(self);
+                    Ok(())
                 }
-                PaymentMetadata::Gasless => None,
-                PaymentMetadata::Smash(metadata) => Some(metadata.gas_charge_location),
-            };
-            if let Some(PaymentLocation::Coin(_)) = gas_payment_location {
-                #[skip_checked_arithmetic]
-                trace!(target: "replay_gas_info", "Gas smashing has occurred for this transaction");
-            }
-
-            if execution_result
-                .as_ref()
-                .err()
-                .map(|err| {
-                    matches!(
-                        err.kind(),
-                        sui_types::execution_status::ExecutionErrorKind::InsufficientFundsForWithdraw
-                    )
-                })
-                .unwrap_or(false)
-                && matches!(gas_payment_location, Some(PaymentLocation::AddressBalance(_))) {
-                    // If we don't have enough balance to withdraw, don't charge for gas
-                    // TODO: consider charging gas if we have enough to reserve but not enough to cover all withdraws
-                    return GasCostSummary::default();
-            }
-
-            self.compute_storage_and_rebate(temporary_store, execution_result);
-
-            let cost_summary = self.gas_status.summary();
-
-            let Some(gas_payment_location) = gas_payment_location else {
-                // Gasless: sender pays nothing.
-                assert!(
-                    matches!(self.payment, PaymentMetadata::Gasless),
-                    "Only gasless transactions should reach this point without a payment location"
-                );
-                if execution_result.is_err() {
-                    return GasCostSummary::default();
+                PaymentMetadata::Gasless => {
+                    // Gasless check must run before ensure_active_inputs_mutated, which
+                    // would add input objects to written_objects and break the check.
+                    if let Err(msg) = temporary_store
+                        .check_gasless_execution_requirements(withdrawal_reservations)
+                    {
+                        return Err(ExecutionError::new_with_source(
+                            sui_types::execution_status::ExecutionErrorKind::InsufficientGas,
+                            msg,
+                        ));
+                    }
+                    temporary_store.ensure_active_inputs_mutated();
+                    temporary_store.collect_storage_and_rebate(self);
+                    Ok(())
                 }
-                // Any storage rebate from destroyed input coins is absorbed as
-                // network fees, not returned to sender.
-                let storage_cost = cost_summary.storage_cost;
-                assert!(
-                    storage_cost == 0,
-                    "Gasless transaction must not incur storage cost, got {storage_cost}"
-                );
-                let sender_rebate = cost_summary.storage_rebate;
-                return GasCostSummary {
-                    computation_cost: sender_rebate,
-                    storage_cost: 0,
-                    storage_rebate: sender_rebate,
-                    non_refundable_storage_fee: cost_summary.non_refundable_storage_fee,
-                };
-            };
+                PaymentMetadata::Smash(_) => {
+                    temporary_store.ensure_active_inputs_mutated();
+                    temporary_store.collect_storage_and_rebate(self);
+                    self.gas_status.charge_storage_and_rebate()
+                }
+            }
+        }
 
+        /// Apply the final gas charge based on the cost summary.
+        /// For unmetered: returns a default (zero) summary.
+        /// For gasless on error: returns a default summary (no charge).
+        /// For gasless on success: absorbs storage rebate as network fees.
+        /// For smash: deducts net gas from the coin or emits an accumulator event.
+        pub fn charge<T, E: ExecutionErrorTrait>(
+            &mut self,
+            temporary_store: &mut TemporaryStore<'_>,
+            execution_result: &Result<T, E>,
+        ) -> GasCostSummary {
+            match &self.payment {
+                PaymentMetadata::Unmetered => GasCostSummary::default(),
+                PaymentMetadata::Gasless => {
+                    if execution_result.is_err() {
+                        return GasCostSummary::default();
+                    }
+                    let cost_summary = self.gas_status.summary();
+                    let storage_cost = cost_summary.storage_cost;
+                    assert!(
+                        storage_cost == 0,
+                        "Gasless transaction must not incur storage cost, got {storage_cost}"
+                    );
+                    // Any storage rebate from destroyed input coins is absorbed as
+                    // network fees, not returned to sender.
+                    let sender_rebate = cost_summary.storage_rebate;
+                    GasCostSummary {
+                        computation_cost: sender_rebate,
+                        storage_cost: 0,
+                        storage_rebate: sender_rebate,
+                        non_refundable_storage_fee: cost_summary.non_refundable_storage_fee,
+                    }
+                }
+                PaymentMetadata::Smash(metadata) => {
+                    // Don't charge if we can't withdraw from the address balance
+                    if execution_result
+                        .as_ref()
+                        .err()
+                        .map(|err| {
+                            matches!(
+                                err.kind(),
+                                sui_types::execution_status::ExecutionErrorKind::InsufficientFundsForWithdraw
+                            )
+                        })
+                        .unwrap_or(false)
+                        && matches!(
+                            metadata.gas_charge_location,
+                            PaymentLocation::AddressBalance(_)
+                        )
+                    {
+                        return GasCostSummary::default();
+                    }
+
+                    if let PaymentLocation::Coin(_) = metadata.gas_charge_location {
+                        #[skip_checked_arithmetic]
+                        trace!(target: "replay_gas_info", "Gas smashing has occurred for this transaction");
+                    }
+
+                    let cost_summary = self.gas_status.summary();
+                    self.apply_payment(temporary_store, cost_summary, metadata.gas_charge_location)
+                }
+            }
+        }
+
+        /// Apply the gas charge to the payment source.
+        /// For coin payments, deducts net gas usage from the gas coin.
+        /// For address balance payments, emits an accumulator event.
+        fn apply_payment(
+            &mut self,
+            temporary_store: &mut TemporaryStore<'_>,
+            cost_summary: GasCostSummary,
+            gas_payment_location: PaymentLocation,
+        ) -> GasCostSummary {
             let net_change = cost_summary.net_gas_usage();
 
             match gas_payment_location {
                 PaymentLocation::AddressBalance(payer_address) => {
-                    // TODO tracing?
                     if net_change != 0 {
                         let balance_type = sui_types::balance::Balance::type_tag(
                             sui_types::gas_coin::GAS::type_tag(),
@@ -460,73 +494,6 @@ pub mod checked {
                 }
             }
             cost_summary
-        }
-
-        /// Calculate total gas cost considering storage and rebate.
-        ///
-        /// First, we net computation, storage, and rebate to determine total gas to charge.
-        ///
-        /// If we exceed gas_budget, we set execution_result to InsufficientGas, failing the tx.
-        /// If we have InsufficientGas, we determine how much gas to charge for the failed tx:
-        ///
-        /// v1: we set computation_cost = gas_budget, so we charge net (gas_budget - storage_rebates)
-        /// v2: we charge (computation + storage costs for input objects - storage_rebates)
-        ///     if the gas balance is still insufficient, we fall back to set computation_cost = gas_budget
-        ///     so we charge net (gas_budget - storage_rebates)
-        fn compute_storage_and_rebate<T, E: ExecutionErrorTrait>(
-            &mut self,
-            temporary_store: &mut TemporaryStore<'_>,
-            execution_result: &mut Result<T, E>,
-        ) {
-            if dont_charge_budget_on_storage_oog(self.gas_model_version) {
-                self.handle_storage_and_rebate_v2(temporary_store, execution_result)
-            } else {
-                self.handle_storage_and_rebate_v1(temporary_store, execution_result)
-            }
-        }
-
-        fn handle_storage_and_rebate_v1<T, E: ExecutionErrorTrait>(
-            &mut self,
-            temporary_store: &mut TemporaryStore<'_>,
-            execution_result: &mut Result<T, E>,
-        ) {
-            if let Err(err) = self.gas_status.charge_storage_and_rebate() {
-                self.reset(temporary_store);
-                self.gas_status.adjust_computation_on_out_of_gas();
-                temporary_store.ensure_active_inputs_mutated();
-                temporary_store.collect_rebate(self);
-                if execution_result.is_ok() {
-                    *execution_result = Err(err.into());
-                }
-            }
-        }
-
-        fn handle_storage_and_rebate_v2<T, E: ExecutionErrorTrait>(
-            &mut self,
-            temporary_store: &mut TemporaryStore<'_>,
-            execution_result: &mut Result<T, E>,
-        ) {
-            if let Err(err) = self.gas_status.charge_storage_and_rebate() {
-                // we run out of gas charging storage, reset and try charging for storage again.
-                // Input objects are touched and so they have a storage cost
-                // Attempt to charge just for computation + input object storage costs - storage_rebate
-                self.reset(temporary_store);
-                temporary_store.ensure_active_inputs_mutated();
-                temporary_store.collect_storage_and_rebate(self);
-                if let Err(err) = self.gas_status.charge_storage_and_rebate() {
-                    // we run out of gas attempting to charge for the input objects exclusively,
-                    // deal with this edge case by not charging for storage: we charge (gas_budget - rebates).
-                    self.reset(temporary_store);
-                    self.gas_status.adjust_computation_on_out_of_gas();
-                    temporary_store.ensure_active_inputs_mutated();
-                    temporary_store.collect_rebate(self);
-                    if execution_result.is_ok() {
-                        *execution_result = Err(err.into());
-                    }
-                } else if execution_result.is_ok() {
-                    *execution_result = Err(err.into());
-                }
-            }
         }
     }
 

--- a/sui-execution/v0/sui-adapter/src/gas_charger.rs
+++ b/sui-execution/v0/sui-adapter/src/gas_charger.rs
@@ -264,7 +264,7 @@ pub mod checked {
 
             if self.smashed_gas_coin.is_some() {
                 // bucketize computation cost
-                if let Err(err) = self.gas_status.bucketize_computation(None) {
+                if let Err(err) = self.gas_status.round_computation_cost(None) {
                     if execution_result.is_ok() {
                         *execution_result = Err(err);
                     }

--- a/sui-execution/v1/sui-adapter/src/gas_charger.rs
+++ b/sui-execution/v1/sui-adapter/src/gas_charger.rs
@@ -273,7 +273,7 @@ pub mod checked {
 
             if self.smashed_gas_coin.is_some() {
                 // bucketize computation cost
-                if let Err(err) = self.gas_status.bucketize_computation(None) {
+                if let Err(err) = self.gas_status.round_computation_cost(None) {
                     if execution_result.is_ok() {
                         *execution_result = Err(err);
                     }

--- a/sui-execution/v2/sui-adapter/src/gas_charger.rs
+++ b/sui-execution/v2/sui-adapter/src/gas_charger.rs
@@ -274,7 +274,7 @@ pub mod checked {
 
             if self.smashed_gas_coin.is_some() {
                 // bucketize computation cost
-                if let Err(err) = self.gas_status.bucketize_computation(None) {
+                if let Err(err) = self.gas_status.round_computation_cost(None) {
                     if execution_result.is_ok() {
                         *execution_result = Err(err);
                     }

--- a/sui-execution/v3/sui-adapter/src/gas_charger.rs
+++ b/sui-execution/v3/sui-adapter/src/gas_charger.rs
@@ -332,7 +332,7 @@ pub mod checked {
                     })
                     .unwrap_or(false);
                 // bucketize computation cost
-                if let Err(err) = self.gas_status.bucketize_computation(Some(is_move_abort))
+                if let Err(err) = self.gas_status.round_computation_cost(Some(is_move_abort))
                     && execution_result.is_ok()
                 {
                     *execution_result = Err(err);


### PR DESCRIPTION
Split the monolithic `charge_gas` method and restructure `execute_transaction` into a clear phase-based pipeline with uniform error handling.
`execute_transaction` is the function to look at, it's the right starting point.

## What changed

**execution_engine.rs**: Replace the nested `and_then` closure + monolithic `charge_gas` call with an explicit `and_then` chain of four phases:
1. Charge input objects
2. Execute PTB + round computation cost
3. Finalize storage (collect costs, budget check, gasless validation)
4. Validate effects limits (meter size, written objects size)

On any phase failure, `reset_charges` resets the store to the input-only state (drops writes, re-smashes gas, re-touches mutable inputs) and prepares the gas status for the final charge. `GasCharger::charge` is then called unconditionally by the caller on both the success and error paths. All writes are removed on error; gas and input objects are the only things we touch in a transaction with errors.

**gas_charger.rs**: Split `charge_gas` into three focused methods with clean signatures:
- `round_computation(is_move_abort) -> Result<(), ExecutionError>` — round raw gas into pricing tiers. Returns the OOG error to the caller instead of mutating a shared result.
- `finalize_storage() -> Result<(), ExecutionError>` — collect storage + budget check. No internal retries or resets; pure collect + check.
- `charge(&Result<T, E>) -> GasCostSummary` — apply payment. Takes the execution result by shared reference; only reads it to decide skip-charge cases (gasless-on-error, address-balance withdraw shortfall).

The OOG retry logic (`handle_storage_and_rebate_v1/v2`) is eliminated. Recovery is now a caller-side sequence: `reset_charges` → `charge`. If the first `finalize_storage` attempt inside `reset_charges` can't cover input-only storage (or we're on gas model v1), it resets again and sets computation to the full budget with zero storage, then the caller's `charge` applies the payment.

**API cleanup**: no function in the gas-charging API takes `&mut Result` any more. Errors flow via return values and the caller merges them explicitly.

**Renames**: `bucketize_computation` → `round_computation_cost` across the trait and all execution versions.

## Behavioral notes

All existing gas tests pass (21/21). The refactoring preserves behavior for all common scenarios. Three edge cases improve:

1. Limit checks no longer overwrite execution errors (e.g., MoveAbort was previously replaced by EffectsTooLarge, losing the abort gas cap)
2. Conservation re-check after recovery uses the correct cost summary
3. Gasless check failure skips unnecessary storage evaluation

## Test plan

- Existing gas tests in `crates/sui-core/src/unit_tests/gas_tests.rs` (21/21 pass)
- New differential snapshot tests in `crates/sui-core/src/unit_tests/gas_diff_tests.rs` — 11 tests covering happy path, computation OOG (storage OK and fallback), storage OOG (minimal OK and fallback), and Move abort (generous, tight, multi-coin). Each captures the full `GasCostSummary` + `ExecutionStatus` + effects counts as insta snapshots. Snapshots are byte-identical between `main` and this branch, proving the refactor is behavior-preserving on every path exercised.
- Not yet covered (follow-ups): `EffectsTooLarge` / `WrittenObjectsTooLarge` interacting with execution errors, early execution errors, conservation recovery, gasless transaction paths.

Co-Authored-By: My Dog (1M bones) <noreply@my_dog.com> and Claude Opus 4.6 (1M context) <noreply@anthropic.com>

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework: