### PR TITLE
Cap gasless tx at 16 KiB, raise max_tps to 300, lower max_computation_units to 5_000

### DIFF
--- a/crates/sui-core/src/unit_tests/transaction_tests.rs
+++ b/crates/sui-core/src/unit_tests/transaction_tests.rs
@@ -1777,4 +1777,66 @@ mod gasless_input_tests {
             result
         );
     }
+
+    #[sim_test]
+    async fn test_gasless_tx_within_size_limit_succeeds() {
+        let (authority, sender, keypair, chain) = setup_gasless_authority(|_| {}).await;
+
+        let inputs = vec![
+            CallArg::Pure(bcs::to_bytes(&100u64).unwrap()),
+            CallArg::Pure(bcs::to_bytes(&SuiAddress::ZERO).unwrap()),
+        ];
+        let pt = build_pt_with_inputs(inputs, vec![send_funds_call(test_token())]);
+        let tx_data = build_gasless_transaction(sender, pt, chain);
+        let tx = to_sender_signed_transaction(tx_data, &keypair);
+
+        let epoch_store = authority.load_epoch_store_one_call_per_task();
+        let result = tx.validity_check(&epoch_store.tx_validity_check_context());
+
+        assert!(
+            result.is_ok(),
+            "Small gasless tx should pass size check, got: {:?}",
+            result
+        );
+    }
+
+    #[sim_test]
+    async fn test_gasless_tx_exceeding_size_limit_rejected() {
+        let (authority, sender, keypair, chain) = setup_gasless_authority(|_| {}).await;
+
+        // Build a valid gasless tx that exceeds 16 KiB: ~110 send_funds calls
+        // (each ~150 bytes serialized) pushes past the limit.
+        let num_sends = 110;
+        let token = test_token();
+        let mut inputs: Vec<CallArg> = Vec::new();
+        let mut commands: Vec<Command> = Vec::new();
+
+        for i in 0..num_sends {
+            let amount_idx = (i * 2) as u16;
+            let recipient_idx = (i * 2 + 1) as u16;
+            inputs.push(CallArg::Pure(bcs::to_bytes(&100u64).unwrap()));
+            inputs.push(CallArg::Pure(bcs::to_bytes(&SuiAddress::ZERO).unwrap()));
+            commands.push(Command::MoveCall(Box::new(ProgrammableMoveCall {
+                package: SUI_FRAMEWORK_PACKAGE_ID,
+                module: "balance".to_string(),
+                function: "send_funds".to_string(),
+                type_arguments: vec![TypeInput::from(token.clone())],
+                arguments: vec![Argument::Input(amount_idx), Argument::Input(recipient_idx)],
+            })));
+        }
+
+        let pt = build_pt_with_inputs(inputs, commands);
+        let tx_data = build_gasless_transaction(sender, pt, chain);
+        let tx = to_sender_signed_transaction(tx_data, &keypair);
+
+        let epoch_store = authority.load_epoch_store_one_call_per_task();
+        let result = tx.validity_check(&epoch_store.tx_validity_check_context());
+
+        assert!(result.is_err(), "Oversized gasless tx should be rejected");
+        let err_str = result.unwrap_err().to_string();
+        assert!(
+            err_str.contains("gasless transaction size exceeded"),
+            "Expected gasless size limit error, got: {err_str}"
+        );
+    }
 }

--- a/crates/sui-open-rpc/tests/snapshots/generate_spec__openrpc.snap.json
+++ b/crates/sui-open-rpc/tests/snapshots/generate_spec__openrpc.snap.json
@@ -1701,6 +1701,7 @@
                 "gasless_max_computation_units": null,
                 "gasless_max_pure_input_bytes": null,
                 "gasless_max_tps": null,
+                "gasless_max_tx_size_bytes": null,
                 "gasless_max_unused_inputs": null,
                 "groth16_prepare_verifying_key_bls12381_cost_base": {
                   "u64": "52"

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -1961,6 +1961,10 @@ pub struct ProtocolConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[skip_accessor]
     include_special_package_amendments: Option<Arc<Amendments>>,
+
+    /// Maximum serialized size in bytes of a gasless transaction (SenderSignedData).
+    /// Bounds the persistent storage impact of each admitted gasless transaction.
+    gasless_max_tx_size_bytes: Option<u64>,
 }
 
 /// An aliased address.
@@ -2769,6 +2773,10 @@ impl ProtocolConfig {
         self.gasless_max_pure_input_bytes.unwrap_or(u64::MAX)
     }
 
+    pub fn get_gasless_max_tx_size_bytes(&self) -> u64 {
+        self.gasless_max_tx_size_bytes.unwrap_or(u64::MAX)
+    }
+
     pub fn disallow_jump_orphans(&self) -> bool {
         self.feature_flags.disallow_jump_orphans
     }
@@ -3371,6 +3379,7 @@ impl ProtocolConfig {
             gasless_max_pure_input_bytes: None,
             gasless_max_tps: None,
             include_special_package_amendments: None,
+            gasless_max_tx_size_bytes: None,
             // When adding a new constant, set it to None in the earliest version, like this:
             // new_constant: None,
         };
@@ -4848,6 +4857,9 @@ impl ProtocolConfig {
                         Chain::Testnet => Some(TESTNET_LINKAGE_AMENDMENTS.clone()),
                         Chain::Unknown => None,
                     };
+                    cfg.gasless_max_tx_size_bytes = Some(16 * 1024);
+                    cfg.gasless_max_tps = Some(300);
+                    cfg.gasless_max_computation_units = Some(5_000);
                 }
                 // Use this template when making changes:
                 //
@@ -5244,9 +5256,10 @@ impl ProtocolConfig {
         self.enable_address_balance_gas_payments_for_testing();
         self.feature_flags.enable_gasless = true;
         self.feature_flags.gasless_verify_remaining_balance = true;
-        self.gasless_max_computation_units = Some(50_000);
+        self.gasless_max_computation_units = Some(5_000);
         self.gasless_allowed_token_types = Some(vec![]);
         self.gasless_max_tps = Some(1000);
+        self.gasless_max_tx_size_bytes = Some(16 * 1024);
     }
 
     pub fn disable_gasless_for_testing(&mut self) {

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_122.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_122.snap
@@ -676,8 +676,10 @@ translation_per_type_node_charge: 1
 translation_per_reference_node_charge: 1
 translation_per_linkage_entry_charge: 10
 max_updates_per_settlement_txn: 100
+gasless_max_computation_units: 5000
 gasless_max_unused_inputs: 1
 gasless_max_pure_input_bytes: 32
+gasless_max_tps: 300
 include_special_package_amendments:
   0139cc6e573fac2726fda782e1df80eb3a61eee5721014f262f8b983784799bd:
     64213b0e4a52bac468d4ac3f140242f70714381653a1919a6d57cd49c628207a: 64213b0e4a52bac468d4ac3f140242f70714381653a1919a6d57cd49c628207a
@@ -1214,3 +1216,4 @@ include_special_package_amendments:
   fed8ff791ee1476d3ddc1db512847cf8b1e0685a1a87ddce559eddca29fcbb0e:
     "0000000000000000000000000000000000000000000000000000000000000003": "0000000000000000000000000000000000000000000000000000000000000003"
     859de5e155d57462d3fe0aeb980b9a3f9cdccf76522d9499f372789183440aca: 859de5e155d57462d3fe0aeb980b9a3f9cdccf76522d9499f372789183440aca
+gasless_max_tx_size_bytes: 16384

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_122.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_122.snap
@@ -487,13 +487,13 @@ translation_per_type_node_charge: 1
 translation_per_reference_node_charge: 1
 translation_per_linkage_entry_charge: 10
 max_updates_per_settlement_txn: 100
-gasless_max_computation_units: 50000
+gasless_max_computation_units: 5000
 gasless_allowed_token_types:
   - - "0xa1ec7fc00a6f40db9693ad1415d0c193ad3906494428cf252621037bd7117e29::usdc::USDC"
     - 0
 gasless_max_unused_inputs: 1
 gasless_max_pure_input_bytes: 32
-gasless_max_tps: 50
+gasless_max_tps: 300
 include_special_package_amendments:
   05f44ea0792b98501280b5191e26b6eb3d1ad3a4082fd9f363e04be48e7e1598:
     cc029e2810f17f9f43f52262f40026a71fbdca40ed3803ad2884994361910b7e: cc029e2810f17f9f43f52262f40026a71fbdca40ed3803ad2884994361910b7e
@@ -625,3 +625,4 @@ include_special_package_amendments:
     fc127e3f9318fc874f94e464b1ee06ec01da31ca85479b8ebd3fa068f11a5b7d: a883e07d89008ce6b35c793903f7cdb3e2f4af404d204d42242cc5c4e48e7e3b
   fe81f839956929404c3ceff16b4091f330aedfc8aca1feec37344c9be9b783e0:
     bd8fc1947cf119350184107a3087e2dc27efefa0dd82e25a1f699069fe81a585: 0717a13f43deaf5345682153e3633f76cdcf695405959697fcd63f63f289320b
+gasless_max_tx_size_bytes: 16384

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_122.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_122.snap
@@ -493,8 +493,9 @@ translation_per_type_node_charge: 1
 translation_per_reference_node_charge: 1
 translation_per_linkage_entry_charge: 10
 max_updates_per_settlement_txn: 100
-gasless_max_computation_units: 50000
+gasless_max_computation_units: 5000
 gasless_allowed_token_types: []
 gasless_max_unused_inputs: 1
 gasless_max_pure_input_bytes: 32
-gasless_max_tps: 50
+gasless_max_tps: 300
+gasless_max_tx_size_bytes: 16384

--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -3900,6 +3900,22 @@ impl SenderSignedData {
             .into()
         );
 
+        if context.config.enable_gasless() && tx_data.is_gasless_transaction() {
+            let gasless_max = context.config.get_gasless_max_tx_size_bytes();
+            fp_ensure!(
+                tx_size as u64 <= gasless_max,
+                SuiErrorKind::UserInputError {
+                    error: UserInputError::SizeLimitExceeded {
+                        limit: format!(
+                            "serialized gasless transaction size exceeded maximum of {gasless_max}"
+                        ),
+                        value: tx_size.to_string(),
+                    }
+                }
+                .into()
+            );
+        }
+
         tx_data.validity_check(context)?;
 
         Ok(tx_size)


### PR DESCRIPTION
## Summary

Two changes in protocol version 122 to enable a safe gasless launch at higher TPS:

1. **New protocol config `gasless_max_tx_size_bytes = 16384`** (all chains). Enforced in `SenderSignedData::validity_check` alongside the general `max_tx_size_bytes`. Bounds worst-case persistent storage per admitted gasless transaction at ~16 KiB (vs. the ~128 KiB ceiling of the general cap).
2. **`gasless_max_tps` raised from 50 to 300** on Testnet/Devnet. Still unset on Mainnet (gasless remains gated off there).

## Test plan
- [x] `sui-protocol-config` snapshot tests pass
- [x] `sui-open-rpc` spec snapshot regenerated
- [x] `sui-types` lib tests pass
- [x] `cargo xclippy -D warnings` clean
- [ ] Gasless e2e tests (`sui-e2e-tests::gasless_tests`) — covered by CI