### PR TITLE
sui-analytics-indexer: implement accepts_chain_id

### DIFF
--- a/crates/sui-analytics-indexer/src/store/live.rs
+++ b/crates/sui-analytics-indexer/src/store/live.rs
@@ -34,6 +34,10 @@ impl LiveStore {
         Self { object_store }
     }
 
+    pub(crate) fn object_store(&self) -> &Arc<dyn ObjectStore> {
+        &self.object_store
+    }
+
     /// Determine the watermark by scanning file names in the object store.
     ///
     /// 1. Find epoch directories under `{pipeline}/epoch_*`
@@ -222,6 +226,30 @@ mod tests {
         store.put(&path, payload).await.unwrap();
     }
 
+    /// Build an in-memory `AnalyticsStore` plus the raw object store handle so tests can
+    /// both drive the connection and inspect the underlying bytes.
+    fn in_memory_store() -> (Arc<dyn object_store::ObjectStore>, AnalyticsStore) {
+        let object_store: Arc<dyn object_store::ObjectStore> = Arc::new(InMemory::new());
+        let config = test_config(object_store.clone());
+        let store = AnalyticsStore::new(object_store.clone(), config, test_metrics());
+        (object_store, store)
+    }
+
+    async fn read_stored_chain_id(
+        object_store: &Arc<dyn object_store::ObjectStore>,
+        pipeline_task: &str,
+    ) -> Vec<u8> {
+        let path = ObjectPath::from(format!("_metadata/chain_id/{pipeline_task}"));
+        object_store
+            .get(&path)
+            .await
+            .unwrap()
+            .bytes()
+            .await
+            .unwrap()
+            .to_vec()
+    }
+
     #[tokio::test]
     async fn test_committer_watermark_multiple_epochs() {
         let object_store: Arc<dyn object_store::ObjectStore> = Arc::new(InMemory::new());
@@ -243,5 +271,55 @@ mod tests {
         // Should use latest epoch (1) and max checkpoint from that epoch
         assert_eq!(watermark.epoch_hi_inclusive, 1);
         assert_eq!(watermark.checkpoint_hi_inclusive, 399); // max(300, 400) - 1
+    }
+
+    #[tokio::test]
+    async fn test_accepts_chain_id_first_call_writes_and_accepts() {
+        let (object_store, store) = in_memory_store();
+        let mut conn = store.connect().await.unwrap();
+
+        let chain_id = [1u8; 32];
+        assert!(conn.accepts_chain_id("Checkpoint", chain_id).await.unwrap());
+        assert_eq!(
+            read_stored_chain_id(&object_store, "Checkpoint").await,
+            chain_id
+        );
+    }
+
+    #[tokio::test]
+    async fn test_accepts_chain_id_matching_accepts() {
+        let (_object_store, store) = in_memory_store();
+        let mut conn = store.connect().await.unwrap();
+
+        let chain_id = [1u8; 32];
+        assert!(conn.accepts_chain_id("Checkpoint", chain_id).await.unwrap());
+        // Second call with the same chain_id should also accept
+        assert!(conn.accepts_chain_id("Checkpoint", chain_id).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_accepts_chain_id_mismatching_rejects() {
+        let (object_store, store) = in_memory_store();
+        let mut conn = store.connect().await.unwrap();
+
+        let chain_id_a = [1u8; 32];
+        let chain_id_b = [2u8; 32];
+        assert!(
+            conn.accepts_chain_id("Checkpoint", chain_id_a)
+                .await
+                .unwrap()
+        );
+        assert!(
+            !conn
+                .accepts_chain_id("Checkpoint", chain_id_b)
+                .await
+                .unwrap()
+        );
+
+        // Stored bytes are unchanged (still chain_id_a)
+        assert_eq!(
+            read_stored_chain_id(&object_store, "Checkpoint").await,
+            chain_id_a
+        );
     }
 }

--- a/crates/sui-analytics-indexer/src/store/migration.rs
+++ b/crates/sui-analytics-indexer/src/store/migration.rs
@@ -209,6 +209,10 @@ impl MigrationStore {
         &self.migration_id
     }
 
+    pub(crate) fn object_store(&self) -> &Arc<dyn ObjectStore> {
+        &self.object_store
+    }
+
     pub fn file_ranges(&self) -> &Arc<RwLock<HashMap<String, FileRangeIndex>>> {
         &self.file_ranges
     }

--- a/crates/sui-analytics-indexer/src/store/mod.rs
+++ b/crates/sui-analytics-indexer/src/store/mod.rs
@@ -23,8 +23,13 @@ use std::sync::RwLock;
 use std::time::Duration;
 use std::time::Instant;
 
-use anyhow::Result;
+use anyhow::Context;
 use async_trait::async_trait;
+use object_store::Error as ObjectStoreError;
+use object_store::ObjectStore;
+use object_store::ObjectStoreExt as _;
+use object_store::PutMode;
+use object_store::PutOptions;
 use object_store::PutPayload;
 use object_store::path::Path as ObjectPath;
 use scoped_futures::ScopedBoxFuture;
@@ -162,6 +167,14 @@ pub struct AnalyticsConnection<'a> {
 }
 
 impl StoreMode {
+    /// Access the underlying object store, regardless of mode.
+    pub(crate) fn object_store(&self) -> &Arc<dyn ObjectStore> {
+        match self {
+            StoreMode::Live(store) => store.object_store(),
+            StoreMode::Migration(store) => store.object_store(),
+        }
+    }
+
     /// Split a batch of checkpoints into files.
     ///
     /// Delegates to mode-specific splitting logic:
@@ -287,7 +300,7 @@ impl AnalyticsStore {
         &self,
         first_checkpoint: Option<u64>,
         last_checkpoint: Option<u64>,
-    ) -> Result<(Option<u64>, Option<u64>)> {
+    ) -> anyhow::Result<(Option<u64>, Option<u64>)> {
         match &self.mode {
             StoreMode::Live(_) => Ok((first_checkpoint, last_checkpoint)),
             StoreMode::Migration(store) => {
@@ -533,7 +546,7 @@ impl<'a> AnalyticsConnection<'a> {
     pub async fn commit_batch<P: Processor>(
         &mut self,
         batch_from_framework: &[CheckpointRows],
-    ) -> Result<usize> {
+    ) -> anyhow::Result<usize> {
         let pipeline = P::NAME;
         let pipeline_config = self.pipeline_config(pipeline);
 
@@ -629,18 +642,51 @@ impl Connection for AnalyticsConnection<'_> {
         &mut self,
         pipeline_task: &str,
         checkpoint_hi_inclusive: Option<u64>,
-    ) -> Result<Option<InitWatermark>> {
+    ) -> anyhow::Result<Option<InitWatermark>> {
         self.delegate_to_committer_watermark(pipeline_task, checkpoint_hi_inclusive)
             .await
     }
 
+    /// Stores the chain_id at `_metadata/chain_id/{pipeline_task}` on first call,
+    /// and on subsequent calls verifies that the provided chain_id matches the stored value.
+    ///
+    /// This guards against pointing the indexer at an object store that was previously
+    /// populated with data from a different chain.
     async fn accepts_chain_id(
         &mut self,
-        _pipeline_task: &str,
-        _chain_id: [u8; 32],
+        pipeline_task: &str,
+        chain_id: [u8; 32],
     ) -> anyhow::Result<bool> {
-        // TODO: Implement storing chain_id
-        Ok(true)
+        let object_store = self.store.mode.object_store();
+        let path = chain_id_path(pipeline_task);
+
+        // Try to claim the path with a conditional create first. If it doesn't exist,
+        // we win the race and accept. If it already exists, fall back to read + compare.
+        match object_store
+            .put_opts(
+                &path,
+                chain_id.to_vec().into(),
+                PutOptions {
+                    mode: PutMode::Create,
+                    ..Default::default()
+                },
+            )
+            .await
+        {
+            Ok(_) => Ok(true),
+            Err(ObjectStoreError::AlreadyExists { .. }) => {
+                let bytes = object_store.get(&path).await?.bytes().await?;
+                let stored: [u8; 32] = bytes.as_ref().try_into().ok().with_context(|| {
+                    format!(
+                        "stored chain_id at {} has wrong length: {}",
+                        path,
+                        bytes.len()
+                    )
+                })?;
+                Ok(stored == chain_id)
+            }
+            Err(e) => Err(e.into()),
+        }
     }
 
     /// Determine the watermark.
@@ -678,6 +724,12 @@ impl Connection for AnalyticsConnection<'_> {
 
 #[async_trait]
 impl SequentialConnection for AnalyticsConnection<'_> {}
+
+/// Construct the object store path for a chain_id file.
+/// Path format: `_metadata/chain_id/{pipeline_task}`
+pub(crate) fn chain_id_path(pipeline_task: &str) -> ObjectPath {
+    ObjectPath::from(format!("_metadata/chain_id/{}", pipeline_task))
+}
 
 /// Construct the object store path for an analytics file.
 /// Path format: {pipeline}/epoch_{epoch}/{start}_{end}.{ext}


### PR DESCRIPTION
## Description 

Replaced the `accepts_chain_id` stub with an impl that stores the 32-byte `chain_id` at `_metadata/chain_id/{pipeline_task}`. Uses `PutMode::Create` to claim the file on first call; on `AlreadyExists`, reads it back and returns whether it matches.

## Test plan 

Added new unit tests.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [x] Indexing Framework: Implement `accepts_chain_id` in analytics indexer.
