### PR TITLE
sui-indexer-alt-consistent-store: implement accepts_chain_id

### DIFF
--- a/crates/sui-indexer-alt-consistent-store/src/db/mod.rs
+++ b/crates/sui-indexer-alt-consistent-store/src/db/mod.rs
@@ -35,6 +35,10 @@ const WATERMARK_CF: &str = "$watermark";
 /// Name of the column family the database adds, to track restoration progress.
 const RESTORE_CF: &str = "$restore";
 
+/// Name of the column family the database adds, to record the chain_id that each pipeline has
+/// been indexing data for.
+const CHAIN_ID_CF: &str = "$chain_id";
+
 // Constants for periodic metrics reporting
 const METRICS_ERROR: i64 = -1;
 
@@ -115,6 +119,11 @@ struct Inner {
     #[covariant]
     restore_cf: Arc<rocksdb::BoundColumnFamily<'this>>,
 
+    /// ColumnFamily in `db` that per-pipeline chain_ids are written to.
+    #[borrows(db)]
+    #[covariant]
+    chain_id_cf: Arc<rocksdb::BoundColumnFamily<'this>>,
+
     /// Snapshots from `db`, ordered by checkpoint sequence number, along with their watermarks.
     #[borrows()]
     #[covariant]
@@ -167,18 +176,20 @@ impl Db {
     /// Open the database at `path`, with the given `capacity` for snapshots.
     ///
     /// `options` are passed to RocksDB to configure the database, and `cfs` denotes the column
-    /// families to open. The database will inject its own column family for watermarks, and set
-    /// the option to create missing column families.
+    /// families to open. The database will inject its own column families for internal bookkeeping
+    /// (watermarks, restore progress, chain ID), and set the option to create missing column
+    /// families.
     pub(crate) fn open<'c>(
         path: impl AsRef<Path>,
         mut options: rocksdb::Options,
         capacity: usize,
         cfs: impl IntoIterator<Item = (&'c str, rocksdb::Options)>,
     ) -> Result<Self, Error> {
-        // Add a column family for watermarks, which are managed by the database.
+        // Add column families managed by the database.
         let mut cfs: Vec<_> = cfs.into_iter().collect();
         cfs.push((WATERMARK_CF, rocksdb::Options::default()));
         cfs.push((RESTORE_CF, rocksdb::Options::default()));
+        cfs.push((CHAIN_ID_CF, rocksdb::Options::default()));
         options.create_missing_column_families(true);
 
         let db = rocksdb::DB::open_cf_with_opts(&options, path, cfs)?;
@@ -187,6 +198,7 @@ impl Db {
             db,
             |db| db.cf_handle(WATERMARK_CF).context("WATERMARK_CF not found"),
             |db| db.cf_handle(RESTORE_CF).context("RESTORE_CF not found"),
+            |db| db.cf_handle(CHAIN_ID_CF).context("CHAIN_ID_CF not found"),
             BTreeMap::new(),
         )?;
 
@@ -359,6 +371,40 @@ impl Db {
             Ok(Some(
                 bcs::from_bytes(&watermark).context("Failed to deserialize watermark")?,
             ))
+        })
+    }
+
+    /// Check whether `pipeline` can accept data for the chain identified by `chain_id`.
+    ///
+    /// On the first call for a pipeline this records the chain_id and returns `true`. On
+    /// subsequent calls it returns `true` only if `chain_id` matches the previously recorded
+    /// value. This guards against pointing the indexer at a database that was previously
+    /// populated with data from a different chain.
+    pub(crate) fn accepts_chain_id(
+        &self,
+        pipeline: &str,
+        chain_id: [u8; 32],
+    ) -> Result<bool, Error> {
+        self.0.read().expect("poisoned").with(|f| {
+            let p = key::encode(pipeline.as_bytes());
+
+            match f.db.get_pinned_cf(f.chain_id_cf, &p)? {
+                Some(existing) => {
+                    let stored_len = existing.len();
+                    let stored: [u8; 32] = existing.as_ref().try_into().map_err(|_| {
+                        Error::Internal(anyhow::anyhow!(
+                            "stored chain_id for pipeline {pipeline:?} has wrong length: {stored_len}",
+                        ))
+                    })?;
+                    Ok(stored == chain_id)
+                }
+                None => {
+                    let mut batch = rocksdb::WriteBatch::default();
+                    batch.put_cf(f.chain_id_cf, &p, chain_id);
+                    f.db.write_opt(batch, &sync_write_options())?;
+                    Ok(true)
+                }
+            }
         })
     }
 

--- a/crates/sui-indexer-alt-consistent-store/src/store/mod.rs
+++ b/crates/sui-indexer-alt-consistent-store/src/store/mod.rs
@@ -264,6 +264,21 @@ mod tests {
         fn store(&self) -> Store<TestSchema> {
             Store::open(self.0.path().join("db"), DbConfig::default(), 4, None).unwrap()
         }
+
+        fn db(&self) -> (Arc<Db>, TestSchema) {
+            let db_options: rocksdb::Options = DbConfig::default().into();
+            let db = Arc::new(
+                Db::open(
+                    self.0.path().join("db"),
+                    db_options.clone(),
+                    4,
+                    TestSchema::cfs(&db_options),
+                )
+                .unwrap(),
+            );
+            let schema = TestSchema::open(&db).unwrap();
+            (db, schema)
+        }
     }
 
     async fn wait_until<F, R>(f: F) -> Result<(), Elapsed>
@@ -314,16 +329,13 @@ mod tests {
 
     #[tokio::test]
     async fn test_open() {
-        let d = tempfile::tempdir().unwrap();
-        let _store: Store<TestSchema> =
-            Store::open(d.path().join("db"), DbConfig::default(), 4, None).unwrap();
+        let _db = TestDb::new();
     }
 
     #[tokio::test]
     async fn test_no_queue() {
-        let d = tempfile::tempdir().unwrap();
-        let store: Store<TestSchema> =
-            Store::open(d.path().join("db"), DbConfig::default(), 4, None).unwrap();
+        let db = TestDb::new();
+        let store = db.store();
 
         // If the store is not associated with a synchronizer, all writes will fail.
         let err = write(&store, "test", 0, |s, b| {
@@ -340,9 +352,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_single_pipeline() {
-        let d = tempfile::tempdir().unwrap();
-        let store: Store<TestSchema> =
-            Store::open(d.path().join("db"), DbConfig::default(), 4, None).unwrap();
+        let db = TestDb::new();
+        let store = db.store();
 
         let stride = 1;
         let buffer_size = 10;
@@ -371,9 +382,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_multiple_pipelines() {
-        let d = tempfile::tempdir().unwrap();
-        let store: Store<TestSchema> =
-            Store::open(d.path().join("db"), DbConfig::default(), 4, None).unwrap();
+        let db = TestDb::new();
+        let store = db.store();
 
         let stride = 1;
         let buffer_size = 10;
@@ -415,23 +425,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_single_pipeline_existing() {
-        let d = tempfile::tempdir().unwrap();
-        let snapshots = 4;
+        let test_db = TestDb::new();
 
         {
             // Initialize the database with some data for the pipeline
-            let db_options: rocksdb::Options = DbConfig::default().into();
-            let db = Arc::new(
-                Db::open(
-                    d.path().join("db"),
-                    db_options.clone(),
-                    snapshots as usize,
-                    TestSchema::cfs(&db_options),
-                )
-                .unwrap(),
-            );
-
-            let schema = TestSchema::open(&db).unwrap();
+            let (db, schema) = test_db.db();
 
             let mut batch = rocksdb::WriteBatch::default();
             schema.b.insert(42, "x".to_owned(), &mut batch).unwrap();
@@ -439,8 +437,7 @@ mod tests {
                 .unwrap();
         }
 
-        let store: Store<TestSchema> =
-            Store::open(d.path().join("db"), DbConfig::default(), snapshots, None).unwrap();
+        let store = test_db.store();
 
         let stride = 1;
         let buffer_size = 10;
@@ -459,23 +456,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_multiple_pipeline_existing() {
-        let d = tempfile::tempdir().unwrap();
-        let snapshots: u64 = 4;
+        let test_db = TestDb::new();
 
         {
             // Initialize the database with some data for both pipelines
-            let db_options: rocksdb::Options = DbConfig::default().into();
-            let db = Arc::new(
-                Db::open(
-                    d.path().join("db"),
-                    db_options.clone(),
-                    snapshots as usize,
-                    TestSchema::cfs(&db_options),
-                )
-                .unwrap(),
-            );
-
-            let schema = TestSchema::open(&db).unwrap();
+            let (db, schema) = test_db.db();
 
             let mut batch = rocksdb::WriteBatch::default();
             schema.a.insert("x".to_owned(), 42, &mut batch).unwrap();
@@ -488,8 +473,7 @@ mod tests {
                 .unwrap();
         }
 
-        let store: Store<TestSchema> =
-            Store::open(d.path().join("db"), DbConfig::default(), snapshots, None).unwrap();
+        let store = test_db.store();
 
         let stride = 1;
         let buffer_size = 10;
@@ -509,23 +493,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_multiple_pipeline_catchup() {
-        let d = tempfile::tempdir().unwrap();
-        let snapshots = 4;
+        let test_db = TestDb::new();
 
         {
             // Initialize the database with some data for one of the pipelines.
-            let db_options: rocksdb::Options = DbConfig::default().into();
-            let db = Arc::new(
-                Db::open(
-                    d.path().join("db"),
-                    db_options.clone(),
-                    snapshots,
-                    TestSchema::cfs(&db_options),
-                )
-                .unwrap(),
-            );
-
-            let schema = TestSchema::open(&db).unwrap();
+            let (db, schema) = test_db.db();
 
             let mut batch = rocksdb::WriteBatch::default();
             schema.b.insert(42, "x".to_owned(), &mut batch).unwrap();
@@ -533,8 +505,7 @@ mod tests {
                 .unwrap();
         }
 
-        let store: Store<TestSchema> =
-            Store::open(d.path().join("db"), DbConfig::default(), 4, None).unwrap();
+        let store = test_db.store();
 
         let stride = 1;
         let buffer_size = 10;
@@ -594,10 +565,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_missing_pipeline() {
-        let d = tempfile::tempdir().unwrap();
-
-        let store: Store<TestSchema> =
-            Store::open(d.path().join("db"), DbConfig::default(), 4, None).unwrap();
+        let db = TestDb::new();
+        let store = db.store();
 
         let stride = 1;
         let buffer_size = 10;
@@ -620,10 +589,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_no_pipelines() {
-        let d = tempfile::tempdir().unwrap();
-
-        let store: Store<TestSchema> =
-            Store::open(d.path().join("db"), DbConfig::default(), 4, None).unwrap();
+        let db = TestDb::new();
+        let store = db.store();
 
         let stride = 1;
         let buffer_size = 10;
@@ -640,10 +607,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_first_checkpoint() {
-        let d = tempfile::tempdir().unwrap();
-
-        let store: Store<TestSchema> =
-            Store::open(d.path().join("db"), DbConfig::default(), 4, None).unwrap();
+        let db = TestDb::new();
+        let store = db.store();
 
         let stride = 1;
         let buffer_size = 10;
@@ -674,10 +639,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_stride() {
-        let d = tempfile::tempdir().unwrap();
-
-        let store: Store<TestSchema> =
-            Store::open(d.path().join("db"), DbConfig::default(), 4, None).unwrap();
+        let db = TestDb::new();
+        let store = db.store();
 
         let stride = 3;
         let buffer_size = 10;
@@ -800,10 +763,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_no_watermark() {
-        let d = tempfile::tempdir().unwrap();
-
-        let store: Store<TestSchema> =
-            Store::open(d.path().join("db"), DbConfig::default(), 4, None).unwrap();
+        let db = TestDb::new();
+        let store = db.store();
 
         let stride = 1;
         let buffer_size = 10;
@@ -834,10 +795,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_out_of_order_batch() {
-        let d = tempfile::tempdir().unwrap();
-
-        let store: Store<TestSchema> =
-            Store::open(d.path().join("db"), DbConfig::default(), 4, None).unwrap();
+        let db = TestDb::new();
+        let store = db.store();
 
         let stride = 1;
         let buffer_size = 10;

--- a/crates/sui-indexer-alt-consistent-store/src/store/mod.rs
+++ b/crates/sui-indexer-alt-consistent-store/src/store/mod.rs
@@ -177,13 +177,17 @@ impl<S: Send + Sync> store::Connection for Connection<'_, S> {
             .await
     }
 
+    /// Stores the `chain_id` for `pipeline_task` on first call, and on subsequent calls verifies
+    /// that the provided `chain_id` matches the stored value.
+    ///
+    /// This guards against pointing the indexer at a database that was previously populated with
+    /// data from a different chain.
     async fn accepts_chain_id(
         &mut self,
-        _pipeline_task: &str,
-        _chain_id: [u8; 32],
+        pipeline_task: &str,
+        chain_id: [u8; 32],
     ) -> anyhow::Result<bool> {
-        // TODO: Implement storing chain_id
-        Ok(true)
+        Ok(self.store.0.db.accepts_chain_id(pipeline_task, chain_id)?)
     }
 
     async fn committer_watermark(
@@ -247,6 +251,18 @@ mod tests {
                 a: DbMap::new(db.clone(), "a"),
                 b: DbMap::new(db.clone(), "b"),
             })
+        }
+    }
+
+    struct TestDb(tempfile::TempDir);
+
+    impl TestDb {
+        fn new() -> Self {
+            Self(tempfile::tempdir().unwrap())
+        }
+
+        fn store(&self) -> Store<TestSchema> {
+            Store::open(self.0.path().join("db"), DbConfig::default(), 4, None).unwrap()
         }
     }
 
@@ -711,6 +727,75 @@ mod tests {
 
         // Going back beyond the first checkpoint results in an empty range.
         assert_eq!(None, d.snapshot_range(1));
+    }
+
+    #[tokio::test]
+    async fn test_accepts_chain_id_first_call_writes_and_accepts() {
+        let db = TestDb::new();
+        let store = db.store();
+
+        let mut conn = store.connect().await.unwrap();
+        assert!(conn.accepts_chain_id("test", [1u8; 32]).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_accepts_chain_id_matching_accepts() {
+        let db = TestDb::new();
+        let store = db.store();
+
+        let mut conn = store.connect().await.unwrap();
+        let chain_id = [1u8; 32];
+        assert!(conn.accepts_chain_id("test", chain_id).await.unwrap());
+        // Second call with the same chain_id should also accept.
+        assert!(conn.accepts_chain_id("test", chain_id).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_accepts_chain_id_mismatching_rejects() {
+        let db = TestDb::new();
+        let store = db.store();
+
+        let mut conn = store.connect().await.unwrap();
+        let chain_id_a = [1u8; 32];
+        let chain_id_b = [2u8; 32];
+        assert!(conn.accepts_chain_id("test", chain_id_a).await.unwrap());
+        assert!(!conn.accepts_chain_id("test", chain_id_b).await.unwrap());
+
+        // The originally stored chain_id is still accepted.
+        assert!(conn.accepts_chain_id("test", chain_id_a).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_accepts_chain_id_distinct_pipelines() {
+        let db = TestDb::new();
+        let store = db.store();
+
+        let mut conn = store.connect().await.unwrap();
+        let chain_id_a = [1u8; 32];
+        let chain_id_b = [2u8; 32];
+        // Different pipelines are tracked independently.
+        assert!(conn.accepts_chain_id("a", chain_id_a).await.unwrap());
+        assert!(conn.accepts_chain_id("b", chain_id_b).await.unwrap());
+        assert!(conn.accepts_chain_id("a", chain_id_a).await.unwrap());
+        assert!(conn.accepts_chain_id("b", chain_id_b).await.unwrap());
+        assert!(!conn.accepts_chain_id("a", chain_id_b).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_accepts_chain_id_persists_across_reopen() {
+        let db = TestDb::new();
+        let chain_id = [7u8; 32];
+
+        {
+            let store = db.store();
+            let mut conn = store.connect().await.unwrap();
+            assert!(conn.accepts_chain_id("test", chain_id).await.unwrap());
+        }
+
+        let store = db.store();
+        let mut conn = store.connect().await.unwrap();
+        assert!(conn.accepts_chain_id("test", chain_id).await.unwrap());
+        assert!(!conn.accepts_chain_id("test", [0u8; 32]).await.unwrap());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Description 

**Commit 1:**

- Adds a new $chain_id RocksDB column family to the consistent store's internal bookkeeping (alongside existing $watermark and $restore CFs).
- Implements Db::accepts_chain_id() — on the first call for a given pipeline it persists the chain ID and returns true; on subsequent calls it returns true only if the chain ID matches the stored value. This guards against accidentally pointing the indexer at a database populated from a different chain.                                               
- Wires the method into the store::Connection trait impl, replacing the previous TODO stub that always returned true.

**Commit 2:**

Introduces a TestDb helper struct that wraps a tempfile::TempDir and provides .store() and .db() convenience methods for creating a Store or raw (Db, TestSchema).           


## Test plan 

Added unit tests for new features.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [x] Indexing Framework: Implement `accepts_chain_id` in consistent store.
