### PR TITLE
Restore Universal compaction for consensus BLOCKS_CF on mainnet

### DIFF
--- a/consensus/core/src/storage/rocksdb_store.rs
+++ b/consensus/core/src/storage/rocksdb_store.rs
@@ -67,11 +67,18 @@ impl RocksDBStore {
         } else {
             default_db_options().optimize_for_write_throughput()
         };
+        // BLOCKS_CF only receives inserts (no deletions) and is dropped with the DB at epoch
+        // boundary. Use Universal compaction (or FIFO when enabled) which handles this
+        // pattern better than Level compaction.
+        let blocks_cf_options = if use_fifo_compaction {
+            default_db_options().optimize_for_no_deletion()
+        } else {
+            default_db_options().optimize_for_write_throughput_no_deletion()
+        };
         let column_family_options = DBMapTableConfigMap::new(BTreeMap::from([
             (
                 Self::BLOCKS_CF.to_string(),
-                cf_options
-                    .clone()
+                blocks_cf_options
                     // Using larger block is ok since there is not much point reads on the cf.
                     .set_block_options(512, 128 << 10),
             ),

--- a/crates/typed-store/src/rocks/options.rs
+++ b/crates/typed-store/src/rocks/options.rs
@@ -200,7 +200,61 @@ impl DBOptions {
         self
     }
 
-    // Optimize tables receiving significant insertions without any deletions.
+    // Optimize tables receiving significant insertions, without any deletions.
+    // Uses Universal compaction which is better suited for write-heavy workloads
+    // where data is never deleted (only dropped with the DB at epoch boundary).
+    pub fn optimize_for_write_throughput_no_deletion(mut self) -> DBOptions {
+        // Increase write buffer size to 256MiB.
+        let write_buffer_size = read_size_from_env(ENV_VAR_MAX_WRITE_BUFFER_SIZE_MB)
+            .unwrap_or(DEFAULT_MAX_WRITE_BUFFER_SIZE_MB)
+            * 1024
+            * 1024;
+        self.options.set_write_buffer_size(write_buffer_size);
+        // Increase write buffers to keep to 6 before slowing down writes.
+        let max_write_buffer_number = read_size_from_env(ENV_VAR_MAX_WRITE_BUFFER_NUMBER)
+            .unwrap_or(DEFAULT_MAX_WRITE_BUFFER_NUMBER);
+        self.options
+            .set_max_write_buffer_number(max_write_buffer_number.try_into().unwrap());
+        // Keep 1 write buffer so recent writes can be read from memory.
+        self.options
+            .set_max_write_buffer_size_to_maintain((write_buffer_size).try_into().unwrap());
+
+        // Switch to universal compactions.
+        self.options
+            .set_compaction_style(rocksdb::DBCompactionStyle::Universal);
+        let mut compaction_options = rocksdb::UniversalCompactOptions::default();
+        compaction_options.set_max_size_amplification_percent(10000);
+        compaction_options.set_stop_style(rocksdb::UniversalCompactionStopStyle::Similar);
+        self.options
+            .set_universal_compaction_options(&compaction_options);
+
+        let max_level_zero_file_num = read_size_from_env(ENV_VAR_L0_NUM_FILES_COMPACTION_TRIGGER)
+            .unwrap_or(DEFAULT_UNIVERSAL_COMPACTION_L0_NUM_FILES_COMPACTION_TRIGGER);
+        self.options.set_level_zero_file_num_compaction_trigger(
+            max_level_zero_file_num.try_into().unwrap(),
+        );
+        self.options.set_level_zero_slowdown_writes_trigger(
+            (max_level_zero_file_num * 12).try_into().unwrap(),
+        );
+        self.options
+            .set_level_zero_stop_writes_trigger((max_level_zero_file_num * 16).try_into().unwrap());
+
+        // Increase sst file size to 128MiB.
+        self.options.set_target_file_size_base(
+            read_size_from_env(ENV_VAR_TARGET_FILE_SIZE_BASE_MB)
+                .unwrap_or(DEFAULT_TARGET_FILE_SIZE_BASE_MB) as u64
+                * 1024
+                * 1024,
+        );
+
+        // This should be a no-op for universal compaction but increasing it to be safe.
+        self.options
+            .set_max_bytes_for_level_base((write_buffer_size * max_level_zero_file_num) as u64);
+
+        self
+    }
+
+    // Optimize tables receiving significant insertions without any deletions, using FIFO compaction.
     // These tables are dropped with the DBs, for example the epoch and consensus DBs.
     pub fn optimize_for_no_deletion(mut self) -> DBOptions {
         // Increase write buffer size to 256MiB.


### PR DESCRIPTION
#26010 accidentally changed the compaction strategy for the BLOCKS_CF column family on mainnet. The old code used optimize_for_write_throughput_no_deletion() (Universal compaction, L0 trigger=80) for BLOCKS_CF, while other CFs used optimize_for_write_throughput() (Level compaction, L0 trigger=4).

When #26010 introduced FIFO compaction gated behind use_fifo_compaction && chain != Mainnet, it removed optimize_for_write_throughput_no_deletion() and replaced it with optimize_for_no_deletion() (FIFO). On mainnet where FIFO is disabled, ALL CFs including BLOCKS_CF fell through to optimize_for_write_throughput() (Level compaction, L0 trigger=4).

Opening an existing consensus DB (created with Universal compaction) under Level compaction with a much lower L0 trigger causes a compaction storm that can block consensus startup indefinitely. This prevents ConsensusAuthority::start() from completing, which blocks the TransactionClient from being set, stalling the entire validator.

Fix: restore optimize_for_write_throughput_no_deletion() with Universal compaction and use it for BLOCKS_CF in the non-FIFO path, matching the pre-#26010 behavior.

## Description 

Describe the changes or additions included in this PR.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
