### PR TITLE
[chore] Update tidehunter to 44f3000, remove with_unloaded_iterator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8481,7 +8481,7 @@ dependencies = [
 [[package]]
 name = "minibytes"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/tidehunter.git?rev=44f3000abbb98ed657f83973fa412ad1ba108fa3#44f3000abbb98ed657f83973fa412ad1ba108fa3"
+source = "git+https://github.com/mystenlabs/tidehunter.git?rev=641675ae80ab625e1b3d72f66eae494cee0f0d2b#641675ae80ab625e1b3d72f66eae494cee0f0d2b"
 dependencies = [
  "bytes",
  "memmap2 0.7.1",
@@ -18224,7 +18224,7 @@ dependencies = [
 [[package]]
 name = "tidehunter"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/tidehunter.git?rev=44f3000abbb98ed657f83973fa412ad1ba108fa3#44f3000abbb98ed657f83973fa412ad1ba108fa3"
+source = "git+https://github.com/mystenlabs/tidehunter.git?rev=641675ae80ab625e1b3d72f66eae494cee0f0d2b#641675ae80ab625e1b3d72f66eae494cee0f0d2b"
 dependencies = [
  "arc-swap",
  "bincode 1.3.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8481,7 +8481,7 @@ dependencies = [
 [[package]]
 name = "minibytes"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/tidehunter.git?rev=7fddd55cf8cb27ee10803fb772d7618134a8d138#7fddd55cf8cb27ee10803fb772d7618134a8d138"
+source = "git+https://github.com/mystenlabs/tidehunter.git?rev=44f3000abbb98ed657f83973fa412ad1ba108fa3#44f3000abbb98ed657f83973fa412ad1ba108fa3"
 dependencies = [
  "bytes",
  "memmap2 0.7.1",
@@ -18224,7 +18224,7 @@ dependencies = [
 [[package]]
 name = "tidehunter"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/tidehunter.git?rev=7fddd55cf8cb27ee10803fb772d7618134a8d138#7fddd55cf8cb27ee10803fb772d7618134a8d138"
+source = "git+https://github.com/mystenlabs/tidehunter.git?rev=44f3000abbb98ed657f83973fa412ad1ba108fa3#44f3000abbb98ed657f83973fa412ad1ba108fa3"
 dependencies = [
  "arc-swap",
  "bincode 1.3.3",

--- a/crates/sui-core/src/authority/authority_store_tables.rs
+++ b/crates/sui-core/src/authority/authority_store_tables.rs
@@ -234,7 +234,6 @@ impl AuthorityPerpetualTables {
 
         let mut objects_config = KeySpaceConfig::new()
             .with_max_dirty_keys(4096)
-            .with_unloaded_iterator(true)
             .with_value_cache_size(value_cache_size);
         if matches!(db_options_override, Some(options) if options.is_validator) {
             objects_config = objects_config.with_compactor(Box::new(objects_compactor));

--- a/crates/typed-store/Cargo.toml
+++ b/crates/typed-store/Cargo.toml
@@ -39,7 +39,7 @@ itertools.workspace = true
 mysten-common.workspace = true
 mysten-metrics.workspace = true
 [target.'cfg(not(windows))'.dependencies]
-tidehunter = {git = "https://github.com/mystenlabs/tidehunter.git", rev = "7fddd55cf8cb27ee10803fb772d7618134a8d138", version = "0.1.0", optional = true}
+tidehunter = {git = "https://github.com/mystenlabs/tidehunter.git", rev = "44f3000abbb98ed657f83973fa412ad1ba108fa3", version = "0.1.0", optional = true}
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 rocksdb = { version = "0.22.0", default-features = false, features = ["jemalloc"] }

--- a/crates/typed-store/Cargo.toml
+++ b/crates/typed-store/Cargo.toml
@@ -39,7 +39,7 @@ itertools.workspace = true
 mysten-common.workspace = true
 mysten-metrics.workspace = true
 [target.'cfg(not(windows))'.dependencies]
-tidehunter = {git = "https://github.com/mystenlabs/tidehunter.git", rev = "44f3000abbb98ed657f83973fa412ad1ba108fa3", version = "0.1.0", optional = true}
+tidehunter = {git = "https://github.com/mystenlabs/tidehunter.git", rev = "641675ae80ab625e1b3d72f66eae494cee0f0d2b", version = "0.1.0", optional = true}
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 rocksdb = { version = "0.22.0", default-features = false, features = ["jemalloc"] }


### PR DESCRIPTION
## Summary
- Updates tidehunter git dependency to `44f3000abbb98ed657f83973fa412ad1ba108fa3`
- Removes the `.with_unloaded_iterator(true)` call from `authority_store_tables.rs`

## Test plan
- [ ] Deploy to private-testnet with `build_with_tidehunter=true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)