### PR TITLE
sui-indexer-alt-framework: fix indexer startup during streaming hang

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -440,7 +440,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.17",
  "tokio",
- "tower 0.5.2",
+ "tower 0.5.3",
  "tracing",
  "url",
 ]
@@ -571,7 +571,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-stream",
- "tower 0.5.2",
+ "tower 0.5.3",
  "tracing",
  "wasmtimer",
 ]
@@ -617,7 +617,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-stream",
- "tower 0.5.2",
+ "tower 0.5.3",
  "tracing",
  "url",
  "wasmtimer",
@@ -799,7 +799,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.17",
  "tokio",
- "tower 0.5.2",
+ "tower 0.5.3",
  "tracing",
  "url",
  "wasmtimer",
@@ -815,7 +815,7 @@ dependencies = [
  "alloy-transport",
  "reqwest",
  "serde_json",
- "tower 0.5.2",
+ "tower 0.5.3",
  "tracing",
  "url",
 ]
@@ -2214,7 +2214,7 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
- "tower 0.5.2",
+ "tower 0.5.3",
  "tracing",
 ]
 
@@ -2406,7 +2406,7 @@ dependencies = [
  "sync_wrapper 1.0.2",
  "tokio",
  "tokio-tungstenite 0.26.2",
- "tower 0.5.2",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -2494,7 +2494,7 @@ dependencies = [
  "pin-project-lite",
  "rustversion",
  "serde",
- "tower 0.5.2",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
 ]
@@ -3747,7 +3747,7 @@ dependencies = [
  "tonic-build",
  "tonic-prost",
  "tonic-rustls",
- "tower 0.5.2",
+ "tower 0.5.3",
  "tower-http 0.5.2",
  "tracing",
  "typed-store",
@@ -7911,7 +7911,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -9751,7 +9751,7 @@ dependencies = [
  "tokio-stream",
  "tonic 0.14.3",
  "tonic-health",
- "tower 0.5.2",
+ "tower 0.5.3",
  "tower-http 0.5.2",
  "tracing",
 ]
@@ -9769,7 +9769,7 @@ dependencies = [
  "simple-server-timing-header",
  "telemetry-subscribers",
  "tokio",
- "tower 0.5.2",
+ "tower 0.5.3",
  "tracing",
 ]
 
@@ -11736,7 +11736,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls",
- "socket2 0.6.0",
+ "socket2 0.5.6",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -12262,7 +12262,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-util 0.7.18",
- "tower 0.5.2",
+ "tower 0.5.3",
  "tower-http 0.6.8",
  "tower-service",
  "url",
@@ -14144,7 +14144,7 @@ dependencies = [
  "tokio",
  "toml 0.7.4",
  "toml_edit 0.19.10",
- "tower 0.5.2",
+ "tower 0.5.3",
  "tower-http 0.5.2",
  "tracing",
  "unescape",
@@ -14494,7 +14494,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tonic 0.14.3",
- "tower 0.5.2",
+ "tower 0.5.3",
  "tracing",
  "typed-store",
  "url",
@@ -14840,8 +14840,8 @@ dependencies = [
 
 [[package]]
 name = "sui-crypto"
-version = "0.2.0"
-source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=e5c53de2e9570229b63bd0508b43f27c11cb5f76#e5c53de2e9570229b63bd0508b43f27c11cb5f76"
+version = "0.3.0"
+source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=e494a36a76a0aab8c5d66d5557995faee5c1fb09#e494a36a76a0aab8c5d66d5557995faee5c1fb09"
 dependencies = [
  "ark-bn254",
  "ark-ff 0.4.2",
@@ -15105,7 +15105,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tonic 0.14.3",
- "tower 0.5.2",
+ "tower 0.5.3",
  "tower-http 0.5.2",
  "tracing",
  "uuid",
@@ -15260,7 +15260,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-util 0.7.18",
- "tower 0.5.2",
+ "tower 0.5.3",
  "tracing",
 ]
 
@@ -15361,7 +15361,7 @@ dependencies = [
  "tonic 0.14.3",
  "tonic-health",
  "tonic-reflection",
- "tower 0.5.2",
+ "tower 0.5.3",
  "tracing",
  "url",
  "zstd 0.12.3+zstd.1.5.2",
@@ -15446,9 +15446,10 @@ dependencies = [
  "diesel-async",
  "diesel_migrations",
  "futures",
+ "http 1.3.1",
+ "mysten-network",
  "num_cpus",
  "object_store 0.13.0",
- "pin-project-lite",
  "prometheus",
  "prost 0.14.1",
  "prost-types 0.14.1",
@@ -15774,7 +15775,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tokio-util 0.7.18",
- "tower 0.5.2",
+ "tower 0.5.3",
  "tower-http 0.5.2",
  "tracing",
  "typed-store-error",
@@ -16319,7 +16320,7 @@ dependencies = [
  "tonic-build",
  "tonic-health",
  "tonic-prost",
- "tower 0.5.2",
+ "tower 0.5.3",
  "tower-http 0.5.2",
  "tracing",
  "url",
@@ -16376,7 +16377,7 @@ dependencies = [
  "telemetry-subscribers",
  "tikv-jemallocator",
  "tokio",
- "tower 0.5.2",
+ "tower 0.5.3",
  "tower-http 0.5.2",
  "tracing",
  "typed-store",
@@ -16527,7 +16528,7 @@ dependencies = [
  "sui-types",
  "thiserror 1.0.69",
  "tokio",
- "tower 0.5.2",
+ "tower 0.5.3",
 ]
 
 [[package]]
@@ -16637,7 +16638,7 @@ dependencies = [
  "sui-types",
  "telemetry-subscribers",
  "tokio",
- "tower 0.5.2",
+ "tower 0.5.3",
  "tower-http 0.5.2",
  "tracing",
  "url",
@@ -16788,14 +16789,15 @@ dependencies = [
 
 [[package]]
 name = "sui-rpc"
-version = "0.2.2"
-source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=e5c53de2e9570229b63bd0508b43f27c11cb5f76#e5c53de2e9570229b63bd0508b43f27c11cb5f76"
+version = "0.3.0"
+source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=e494a36a76a0aab8c5d66d5557995faee5c1fb09#e494a36a76a0aab8c5d66d5557995faee5c1fb09"
 dependencies = [
  "base64 0.22.1",
  "bcs",
  "bytes",
  "futures",
  "http 1.3.1",
+ "http-body 1.0.1",
  "prost 0.14.1",
  "prost-types 0.14.1",
  "serde",
@@ -16805,6 +16807,7 @@ dependencies = [
  "tokio",
  "tonic 0.14.3",
  "tonic-prost",
+ "tower 0.5.3",
 ]
 
 [[package]]
@@ -16857,7 +16860,7 @@ dependencies = [
  "tonic-prost-build",
  "tonic-reflection",
  "tonic-web",
- "tower 0.5.2",
+ "tower 0.5.3",
  "tracing",
  "url",
  "walkdir",
@@ -16982,8 +16985,8 @@ dependencies = [
 
 [[package]]
 name = "sui-sdk-types"
-version = "0.2.2"
-source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=e5c53de2e9570229b63bd0508b43f27c11cb5f76#e5c53de2e9570229b63bd0508b43f27c11cb5f76"
+version = "0.3.0"
+source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=e494a36a76a0aab8c5d66d5557995faee5c1fb09#e494a36a76a0aab8c5d66d5557995faee5c1fb09"
 dependencies = [
  "base64ct",
  "bcs",
@@ -17045,7 +17048,7 @@ dependencies = [
  "sui-types",
  "telemetry-subscribers",
  "tempfile",
- "tower 0.5.2",
+ "tower 0.5.3",
  "tracing",
 ]
 
@@ -18702,7 +18705,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-stream",
- "tower 0.5.2",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -18797,7 +18800,7 @@ dependencies = [
  "tokio-rustls",
  "tokio-stream",
  "tonic 0.14.3",
- "tower 0.5.2",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -18857,9 +18860,9 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -18924,7 +18927,7 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-util 0.7.18",
- "tower 0.5.2",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -665,9 +665,9 @@ anemo-cli = { git = "https://github.com/mystenlabs/anemo.git", rev = "9248f8d395
 anemo-tower = { git = "https://github.com/mystenlabs/anemo.git", rev = "9248f8d3951df750360308df22618e5978ad6dc0" }
 
 # core-types from the new sdk for use in gRPC
-sui-sdk-types = { git = "https://github.com/MystenLabs/sui-rust-sdk.git", rev = "e5c53de2e9570229b63bd0508b43f27c11cb5f76", features = [ "hash", "serde" ] }
-sui-crypto = { git = "https://github.com/MystenLabs/sui-rust-sdk.git", rev = "e5c53de2e9570229b63bd0508b43f27c11cb5f76", features = [ "ed25519", "secp256r1", "secp256k1", "passkey", "zklogin" ] }
-sui-rpc = { git = "https://github.com/MystenLabs/sui-rust-sdk.git", rev = "e5c53de2e9570229b63bd0508b43f27c11cb5f76" }
+sui-sdk-types = { git = "https://github.com/MystenLabs/sui-rust-sdk.git", rev = "e494a36a76a0aab8c5d66d5557995faee5c1fb09", features = [ "hash", "serde" ] }
+sui-crypto = { git = "https://github.com/MystenLabs/sui-rust-sdk.git", rev = "e494a36a76a0aab8c5d66d5557995faee5c1fb09", features = [ "ed25519", "secp256r1", "secp256k1", "passkey", "zklogin" ] }
+sui-rpc = { git = "https://github.com/MystenLabs/sui-rust-sdk.git", rev = "e494a36a76a0aab8c5d66d5557995faee5c1fb09" }
 
 ### Workspace Members ###
 anemo-benchmark = { path = "crates/anemo-benchmark" }

--- a/crates/sui-bridge-indexer-alt/src/handlers/token_transfer_data_handler.rs
+++ b/crates/sui-bridge-indexer-alt/src/handlers/token_transfer_data_handler.rs
@@ -95,7 +95,7 @@ impl Handler for TokenTransferDataHandler {
     async fn commit<'a>(
         values: &[Self::Value],
         conn: &mut Connection<'a>,
-    ) -> sui_indexer_alt_framework::Result<usize> {
+    ) -> anyhow::Result<usize> {
         Ok(diesel::insert_into(token_transfer_data::table)
             .values(values)
             .on_conflict_do_nothing()

--- a/crates/sui-indexer-alt-consistent-store/src/restore/formal_snapshot.rs
+++ b/crates/sui-indexer-alt-consistent-store/src/restore/formal_snapshot.rs
@@ -146,7 +146,7 @@ impl FormalSnapshot {
         info!(epoch, "Connected to valid formal snapshot");
 
         // Use the remote store to associate the epoch with a watermark pointing to its last
-        // transaction.
+        // transaction. We only use `end_of_epoch_checkpoints` here, so no byte counter is needed.
         let client = StoreIngestionClient::new(
             HttpBuilder::new()
                 .with_url(snapshot_args.remote_store_url.to_string())
@@ -154,6 +154,7 @@ impl FormalSnapshot {
                 .build()
                 .map(Arc::new)
                 .context("Failed to connect to remote checkpoint store")?,
+            None,
         );
 
         let end_of_epoch_checkpoints: Vec<_> = client

--- a/crates/sui-indexer-alt-framework/Cargo.toml
+++ b/crates/sui-indexer-alt-framework/Cargo.toml
@@ -19,8 +19,9 @@ diesel = { workspace = true, features = ["chrono"] }
 diesel-async = { workspace = true, features = ["bb8", "postgres", "async-connection-wrapper"] }
 diesel_migrations.workspace = true
 futures.workspace = true
+http.workspace = true
+mysten-network.workspace = true
 num_cpus.workspace = true
-pin-project-lite.workspace = true
 prometheus.workspace = true
 object_store.workspace = true
 serde_json.workspace = true

--- a/crates/sui-indexer-alt-framework/src/cluster.rs
+++ b/crates/sui-indexer-alt-framework/src/cluster.rs
@@ -15,7 +15,6 @@ use url::Url;
 
 use crate::Indexer;
 use crate::IndexerArgs;
-use crate::Result;
 use crate::ingestion::ClientArgs;
 use crate::ingestion::IngestionConfig;
 use crate::metrics::IndexerMetrics;
@@ -145,7 +144,7 @@ impl IndexerClusterBuilder {
     /// - Required fields are missing
     /// - Database connection cannot be established
     /// - Metrics registry creation fails
-    pub async fn build(self) -> Result<IndexerCluster> {
+    pub async fn build(self) -> anyhow::Result<IndexerCluster> {
         let database_url = self.database_url.context("database_url is required")?;
 
         tracing_subscriber::fmt::init();
@@ -191,7 +190,7 @@ impl IndexerCluster {
     /// Starts the indexer and metrics service, returning a handle over the service's tasks.
     /// The service will exit when the indexer has finished processing all the checkpoints it was
     /// configured to process, or when it is instructed to shut down.
-    pub async fn run(self) -> Result<Service> {
+    pub async fn run(self) -> anyhow::Result<Service> {
         let s_indexer = self.indexer.run().await?;
         let s_metrics = self.metrics.run().await?;
 

--- a/crates/sui-indexer-alt-framework/src/ingestion/broadcaster.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/broadcaster.rs
@@ -457,7 +457,7 @@ mod tests {
     use tokio::time::timeout;
 
     use crate::ingestion::IngestionConfig;
-    use crate::ingestion::ingestion_client::CheckpointData;
+    use crate::ingestion::decode;
     use crate::ingestion::ingestion_client::CheckpointResult;
     use crate::ingestion::ingestion_client::IngestionClientTrait;
     use crate::ingestion::streaming_client::test_utils::MockStreamingClient;
@@ -479,7 +479,11 @@ mod tests {
             async fn checkpoint(&self, checkpoint: u64) -> CheckpointResult {
                 // Return mock checkpoint data for any checkpoint number
                 let bytes = test_checkpoint_data(checkpoint);
-                Ok(CheckpointData::Raw(bytes.into()))
+                Ok(decode::checkpoint(&bytes).unwrap())
+            }
+
+            async fn latest_checkpoint_number(&self) -> anyhow::Result<u64> {
+                Ok(0)
             }
         }
 

--- a/crates/sui-indexer-alt-framework/src/ingestion/byte_count.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/byte_count.rs
@@ -1,0 +1,87 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use bytes::Buf;
+use mysten_network::callback::{MakeCallbackHandler, ResponseHandler};
+use prometheus::IntCounter;
+
+/// A [`MakeCallbackHandler`] that increments an [`IntCounter`] by the number of bytes observed
+/// in the response body of each request.
+#[derive(Clone)]
+pub(crate) struct ByteCountMakeCallbackHandler {
+    counter: IntCounter,
+}
+
+impl ByteCountMakeCallbackHandler {
+    pub(crate) fn new(counter: IntCounter) -> Self {
+        Self { counter }
+    }
+}
+
+impl MakeCallbackHandler for ByteCountMakeCallbackHandler {
+    type Handler = ByteCountResponseHandler;
+
+    fn make_handler(&self, _request: &http::request::Parts) -> Self::Handler {
+        ByteCountResponseHandler {
+            counter: self.counter.clone(),
+        }
+    }
+}
+
+pub(crate) struct ByteCountResponseHandler {
+    counter: IntCounter,
+}
+
+impl ResponseHandler for ByteCountResponseHandler {
+    fn on_response(&mut self, _response: &http::response::Parts) {}
+
+    fn on_error<E>(&mut self, _error: &E)
+    where
+        E: std::fmt::Display + 'static,
+    {
+    }
+
+    fn on_body_chunk<B>(&mut self, chunk: &B)
+    where
+        B: Buf,
+    {
+        self.counter.inc_by(chunk.remaining() as u64);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use bytes::Bytes;
+
+    fn run_byte_count(frames: &[&'static str]) -> u64 {
+        let counter = IntCounter::new("test_bytes", "test").unwrap();
+        let make = ByteCountMakeCallbackHandler::new(counter.clone());
+
+        let request = http::Request::new(());
+        let (parts, _) = request.into_parts();
+        let mut handler = make.make_handler(&parts);
+
+        for frame in frames {
+            handler.on_body_chunk(&Bytes::from_static(frame.as_bytes()));
+        }
+
+        counter.get()
+    }
+
+    #[test]
+    fn test_byte_count_0_frames() {
+        assert_eq!(run_byte_count(&[]), 0);
+    }
+
+    #[test]
+    fn test_byte_count_1_frame() {
+        assert_eq!(run_byte_count(&["a"]), 1);
+    }
+
+    #[test]
+    fn test_byte_count_2_frames() {
+        assert_eq!(run_byte_count(&["a", "bb"]), 3);
+    }
+}

--- a/crates/sui-indexer-alt-framework/src/ingestion/decode.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/decode.rs
@@ -16,7 +16,7 @@ pub enum Error {
     Deserialization(#[from] prost::DecodeError),
 
     #[error("Failed to convert checkpoint protobuf to checkpoint data: {0}")]
-    ProtoConversion(#[from] Box<TryFromProtoError>),
+    ProtoConversion(#[from] TryFromProtoError),
 }
 
 impl Error {
@@ -34,5 +34,5 @@ impl Error {
 pub(crate) fn checkpoint(bytes: &[u8]) -> Result<Checkpoint, Error> {
     let decompressed = zstd::decode_all(bytes)?;
     let proto_checkpoint = proto::Checkpoint::decode(&decompressed[..])?;
-    Ok(Checkpoint::try_from(&proto_checkpoint).map_err(Box::new)?)
+    Ok(Checkpoint::try_from(&proto_checkpoint)?)
 }

--- a/crates/sui-indexer-alt-framework/src/ingestion/error.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/error.rs
@@ -8,11 +8,17 @@ pub enum Error {
     #[error("Checkpoint {0} not found")]
     NotFound(u64),
 
-    #[error("Failed to deserialize checkpoint {0}: {1}")]
-    DeserializationError(u64, #[source] anyhow::Error),
+    #[error("Failed to decode checkpoint {0}: {1}")]
+    DecodeError(u64, #[source] anyhow::Error),
 
     #[error("Failed to fetch checkpoint {0}: {1}")]
     FetchError(u64, #[source] anyhow::Error),
+
+    #[error("Failed to fetch chain id for checkpoint {0}: {1}")]
+    ChainIdError(u64, #[source] anyhow::Error),
+
+    #[error("Failed to fetch latest checkpoint: {0}")]
+    LatestCheckpointError(#[source] anyhow::Error),
 
     #[error(transparent)]
     ObjectStoreError(#[from] object_store::Error),

--- a/crates/sui-indexer-alt-framework/src/ingestion/ingestion_client.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/ingestion_client.rs
@@ -10,8 +10,8 @@ use async_trait::async_trait;
 use backoff::Error as BE;
 use backoff::ExponentialBackoff;
 use backoff::backoff::Constant;
-use bytes::Bytes;
 use clap::ArgGroup;
+use mysten_network::callback::CallbackLayer;
 use object_store::ClientOptions;
 use object_store::ObjectStore;
 use object_store::aws::AmazonS3Builder;
@@ -26,13 +26,13 @@ use sui_rpc::client::HeadersInterceptor;
 use sui_types::digests::ChainIdentifier;
 use tokio::sync::OnceCell;
 use tracing::debug;
-use tracing::error;
 use tracing::warn;
 use url::Url;
 
 use crate::ingestion::Error as IE;
 use crate::ingestion::MAX_GRPC_MESSAGE_SIZE_BYTES;
 use crate::ingestion::Result as IngestionResult;
+use crate::ingestion::byte_count::ByteCountMakeCallbackHandler;
 use crate::ingestion::decode;
 use crate::ingestion::store_client::StoreIngestionClient;
 use crate::metrics::CheckpointLagMetricReporter;
@@ -54,6 +54,8 @@ pub(crate) trait IngestionClientTrait: Send + Sync {
     async fn chain_id(&self) -> anyhow::Result<ChainIdentifier>;
 
     async fn checkpoint(&self, checkpoint: u64) -> CheckpointResult;
+
+    async fn latest_checkpoint_number(&self) -> anyhow::Result<u64>;
 }
 
 #[derive(clap::Args, Clone, Debug)]
@@ -145,28 +147,13 @@ impl IngestionClientArgs {
 pub enum CheckpointError {
     #[error("Checkpoint not found")]
     NotFound,
-    #[error("Failed to fetch checkpoint due to {reason}: {error}")]
-    Transient {
-        reason: &'static str,
-        #[source]
-        error: anyhow::Error,
-    },
-    #[error("Permanent error in {reason}: {error}")]
-    Permanent {
-        reason: &'static str,
-        #[source]
-        error: anyhow::Error,
-    },
+    #[error("Failed to fetch checkpoint: {0}")]
+    Fetch(#[from] anyhow::Error),
+    #[error("Failed to decode checkpoint: {0}")]
+    Decode(#[from] decode::Error),
 }
 
-pub type CheckpointResult = Result<CheckpointData, CheckpointError>;
-
-#[derive(Clone)]
-#[allow(clippy::large_enum_variant)]
-pub enum CheckpointData {
-    Raw(Bytes),
-    Checkpoint(Checkpoint),
-}
+pub type CheckpointResult = Result<Checkpoint, CheckpointError>;
 
 #[derive(Clone)]
 pub struct IngestionClient {
@@ -246,7 +233,10 @@ impl IngestionClient {
         store: Arc<dyn ObjectStore>,
         metrics: Arc<IngestionMetrics>,
     ) -> IngestionResult<Self> {
-        let client = Arc::new(StoreIngestionClient::new(store));
+        let client = Arc::new(StoreIngestionClient::new(
+            store,
+            Some(metrics.total_ingested_bytes.clone()),
+        ));
         Ok(Self::new_impl(client, metrics))
     }
 
@@ -257,15 +247,18 @@ impl IngestionClient {
         password: Option<String>,
         metrics: Arc<IngestionMetrics>,
     ) -> IngestionResult<Self> {
+        let byte_count_layer = CallbackLayer::new(ByteCountMakeCallbackHandler::new(
+            metrics.total_ingested_bytes.clone(),
+        ));
+        let client = Client::new(url.to_string())?
+            .with_max_decoding_message_size(MAX_GRPC_MESSAGE_SIZE_BYTES)
+            .request_layer(byte_count_layer);
         let client = if let Some(username) = username {
             let mut headers = HeadersInterceptor::new();
             headers.basic_auth(username, password);
-            Client::new(url.to_string())?
-                .with_headers(headers)
-                .with_max_decoding_message_size(MAX_GRPC_MESSAGE_SIZE_BYTES)
+            client.with_headers(headers)
         } else {
-            Client::new(url.to_string())?
-                .with_max_decoding_message_size(MAX_GRPC_MESSAGE_SIZE_BYTES)
+            client
         };
         Ok(Self::new_impl(Arc::new(client), metrics))
     }
@@ -316,63 +309,46 @@ impl IngestionClient {
     /// Fetch checkpoint data by sequence number.
     ///
     /// Repeatedly retries transient errors with an exponential backoff (up to
-    /// `MAX_TRANSIENT_RETRY_INTERVAL`). Transient errors are either defined by the client
-    /// implementation that returns a [CheckpointError::Transient] error variant, or within
-    /// this function if we fail to deserialize the result as [Checkpoint].
+    /// `MAX_TRANSIENT_RETRY_INTERVAL`). Transient errors are defined by the client
+    /// implementation that returns a [CheckpointError::Fetch] or [CheckpointError::Decode] error
+    /// variant.
     ///
     /// The function will immediately return if the checkpoint is not found.
     pub async fn checkpoint(&self, cp_sequence_number: u64) -> IngestionResult<CheckpointEnvelope> {
         let client = self.client.clone();
-        let checkpoint_data_fut =
-            retry_transient_with_slow_monitor(
-                "checkpoint",
-                move || {
-                    let client = client.clone();
-                    async move {
-                        let checkpoint_data = client.checkpoint(cp_sequence_number).await.map_err(
-                            |err| match err {
-                                CheckpointError::NotFound => {
-                                    BE::permanent(IE::NotFound(cp_sequence_number))
-                                }
-                                CheckpointError::Transient { reason, error } => {
-                                    self.metrics.inc_retry(
-                                        cp_sequence_number,
-                                        reason,
-                                        IE::FetchError(cp_sequence_number, error),
-                                    )
-                                }
-                                CheckpointError::Permanent { reason, error } => {
-                                    error!(
-                                        cp_sequence_number,
-                                        reason, "Permanent checkpoint error: {error}"
-                                    );
-                                    self.metrics
-                                        .total_ingested_permanent_errors
-                                        .with_label_values(&[reason])
-                                        .inc();
-                                    BE::permanent(IE::FetchError(cp_sequence_number, error))
-                                }
-                            },
-                        )?;
-
-                        Ok::<Checkpoint, backoff::Error<IE>>(match checkpoint_data {
-                            CheckpointData::Raw(bytes) => {
-                                self.metrics.total_ingested_bytes.inc_by(bytes.len() as u64);
-
-                                decode::checkpoint(&bytes).map_err(|e| {
-                                    self.metrics.inc_retry(
-                                        cp_sequence_number,
-                                        e.reason(),
-                                        IE::DeserializationError(cp_sequence_number, e.into()),
-                                    )
-                                })?
+        let checkpoint_data_fut = retry_transient_with_slow_monitor(
+            "checkpoint",
+            move || {
+                let client = client.clone();
+                async move {
+                    client
+                        .checkpoint(cp_sequence_number)
+                        .await
+                        .map_err(|err| match err {
+                            // Not found errors are marked as permanent here, but retried in
+                            // `wait_for` in case the checkpoint becomes available in the future.
+                            CheckpointError::NotFound => {
+                                BE::permanent(IE::NotFound(cp_sequence_number))
                             }
-                            CheckpointData::Checkpoint(data) => data,
+                            // Retry fetch and decode errors in case the root cause is in the
+                            // upstream checkpoint data source. If the upstream checkpoint data
+                            // source is corrected, then the indexer will automatically recover
+                            // the next time the read is attempted.
+                            CheckpointError::Fetch(e) => self.metrics.inc_retry(
+                                cp_sequence_number,
+                                "fetch",
+                                IE::FetchError(cp_sequence_number, e),
+                            ),
+                            CheckpointError::Decode(e) => self.metrics.inc_retry(
+                                cp_sequence_number,
+                                e.reason(),
+                                IE::DecodeError(cp_sequence_number, e.into()),
+                            ),
                         })
-                    }
-                },
-                &self.metrics.ingested_checkpoint_latency,
-            );
+                }
+            },
+            &self.metrics.ingested_checkpoint_latency,
+        );
 
         let client = self.client.clone();
         let chain_id_fut = self.chain_id.get_or_try_init(|| {
@@ -384,7 +360,7 @@ impl IngestionClient {
                         client
                             .chain_id()
                             .await
-                            .map_err(|e| BE::transient(IE::FetchError(cp_sequence_number, e)))
+                            .map_err(|e| BE::transient(IE::ChainIdError(cp_sequence_number, e)))
                     }
                 },
                 &self.metrics.ingested_chain_id_latency,
@@ -419,10 +395,14 @@ impl IngestionClient {
             chain_id: *chain_id,
         })
     }
+
+    pub async fn latest_checkpoint_number(&self) -> anyhow::Result<u64> {
+        self.client.latest_checkpoint_number().await
+    }
 }
 
 /// Keep backing off until we are waiting for the max interval, but don't give up.
-fn transient_backoff() -> ExponentialBackoff {
+pub(crate) fn transient_backoff() -> ExponentialBackoff {
     ExponentialBackoff {
         max_interval: MAX_TRANSIENT_RETRY_INTERVAL,
         max_elapsed_time: None,
@@ -432,7 +412,7 @@ fn transient_backoff() -> ExponentialBackoff {
 
 /// Retry a fallible async operation with exponential backoff and slow-operation monitoring.
 /// Records the total time (including retries) in the provided latency histogram.
-async fn retry_transient_with_slow_monitor<F, Fut, T>(
+pub(crate) async fn retry_transient_with_slow_monitor<F, Fut, T>(
     operation: &str,
     make_future: F,
     latency: &Histogram,
@@ -478,11 +458,28 @@ mod tests {
     use dashmap::DashMap;
     use prometheus::Registry;
     use sui_types::digests::CheckpointDigest;
-    use tokio::time::timeout;
+    use sui_types::event::Event;
+    use sui_types::test_checkpoint_data_builder::TestCheckpointBuilder;
 
+    use crate::ingestion::decode;
     use crate::ingestion::test_utils::test_checkpoint_data;
 
     use super::*;
+
+    fn test_checkpoint(seq: u64) -> Checkpoint {
+        let bytes = test_checkpoint_data(seq);
+        decode::checkpoint(&bytes).unwrap()
+    }
+
+    /// Build a checkpoint with one transaction containing one event and one created object.
+    fn test_checkpoint_with_data(seq: u64) -> Checkpoint {
+        TestCheckpointBuilder::new(seq)
+            .start_transaction(0)
+            .create_owned_object(0)
+            .with_events(vec![Event::random_for_testing()])
+            .finish_transaction()
+            .build_checkpoint()
+    }
 
     #[derive(Debug, Parser)]
     struct TestArgs {
@@ -493,10 +490,10 @@ mod tests {
     /// Mock implementation of IngestionClientTrait for testing
     #[derive(Default)]
     struct MockIngestionClient {
-        checkpoints: DashMap<u64, CheckpointData>,
-        transient_failures: DashMap<u64, usize>,
+        checkpoints: DashMap<u64, Checkpoint>,
         not_found_failures: DashMap<u64, usize>,
-        permanent_failures: DashMap<u64, usize>,
+        fetch_failures: DashMap<u64, usize>,
+        decode_failures: DashMap<u64, usize>,
     }
 
     impl MockIngestionClient {
@@ -520,26 +517,22 @@ mod tests {
                 return Err(CheckpointError::NotFound);
             }
 
-            // Check for non-retryable failures
-            if let Some(mut remaining) = self.permanent_failures.get_mut(&checkpoint)
+            // Check for fetch errors
+            if let Some(mut remaining) = self.fetch_failures.get_mut(&checkpoint)
                 && *remaining > 0
             {
                 *remaining -= 1;
-                return Err(CheckpointError::Permanent {
-                    reason: "mock_permanent_error",
-                    error: anyhow::anyhow!("Mock permanent error"),
-                });
+                return Err(CheckpointError::Fetch(anyhow::anyhow!("Mock fetch error")));
             }
 
-            // Check for transient failures
-            if let Some(mut remaining) = self.transient_failures.get_mut(&checkpoint)
+            // Check for decode errors
+            if let Some(mut remaining) = self.decode_failures.get_mut(&checkpoint)
                 && *remaining > 0
             {
                 *remaining -= 1;
-                return Err(CheckpointError::Transient {
-                    reason: "mock_transient_error",
-                    error: anyhow::anyhow!("Mock transient error"),
-                });
+                return Err(CheckpointError::Decode(decode::Error::Deserialization(
+                    prost::DecodeError::new("Mock deserialization error"),
+                )));
             }
 
             // Return the checkpoint data if it exists
@@ -548,6 +541,10 @@ mod tests {
                 .as_deref()
                 .cloned()
                 .ok_or(CheckpointError::NotFound)
+        }
+
+        async fn latest_checkpoint_number(&self) -> anyhow::Result<u64> {
+            Ok(0)
         }
     }
 
@@ -609,53 +606,40 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_fetch_raw_bytes_success() {
+    async fn test_checkpoint_checkpoint_success() {
         let (client, mock) = setup_test();
 
-        // Create test data using test_checkpoint
-        let bytes = Bytes::from(test_checkpoint_data(1));
-        mock.checkpoints
-            .insert(1, CheckpointData::Raw(bytes.clone()));
+        mock.checkpoints.insert(1, test_checkpoint_with_data(1));
 
-        // Fetch and verify
         let result = client.checkpoint(1).await.unwrap();
         assert_eq!(result.checkpoint.summary.sequence_number(), &1);
         assert_eq!(result.chain_id, MockIngestionClient::mock_chain_id());
+        assert_eq!(client.metrics.total_ingested_checkpoints.get(), 1);
+        assert_eq!(client.metrics.total_ingested_transactions.get(), 1);
+        assert_eq!(client.metrics.total_ingested_events.get(), 1);
+        // 1 created object + 2 gas object versions (input + output)
+        assert_eq!(client.metrics.total_ingested_objects.get(), 3);
     }
 
     #[tokio::test]
-    async fn test_fetch_checkpoint_success() {
-        let (client, mock) = setup_test();
-
-        // Create test data - now returns zstd-compressed protobuf
-        let bytes = Bytes::from(test_checkpoint_data(1));
-        mock.checkpoints.insert(1, CheckpointData::Raw(bytes));
-
-        // Fetch and verify
-        let result = client.checkpoint(1).await.unwrap();
-        assert_eq!(result.checkpoint.summary.sequence_number(), &1);
-        assert_eq!(result.chain_id, MockIngestionClient::mock_chain_id());
-    }
-
-    #[tokio::test]
-    async fn test_fetch_not_found() {
+    async fn test_checkpoint_not_found() {
         let (client, _) = setup_test();
 
         // Try to fetch non-existent checkpoint
         let result = client.checkpoint(1).await;
         assert!(matches!(result, Err(IE::NotFound(1))));
+        assert_eq!(client.metrics.total_ingested_checkpoints.get(), 0);
+        assert_eq!(client.metrics.total_ingested_transactions.get(), 0);
+        assert_eq!(client.metrics.total_ingested_events.get(), 0);
+        assert_eq!(client.metrics.total_ingested_objects.get(), 0);
     }
 
     #[tokio::test]
-    async fn test_fetch_transient_error_with_retry() {
+    async fn test_checkpoint_fetch_error_with_retry() {
         let (client, mock) = setup_test();
 
-        // Create test data using test_checkpoint
-        let bytes = Bytes::from(test_checkpoint_data(1));
-
-        // Add checkpoint to mock with 2 transient failures
-        mock.checkpoints.insert(1, CheckpointData::Raw(bytes));
-        mock.transient_failures.insert(1, 2);
+        mock.checkpoints.insert(1, test_checkpoint(1));
+        mock.fetch_failures.insert(1, 2);
 
         // Fetch and verify it succeeds after retries
         let result = client.checkpoint(1).await.unwrap();
@@ -666,20 +650,45 @@ mod tests {
         let retries = client
             .metrics
             .total_ingested_transient_retries
-            .with_label_values(&["mock_transient_error"])
+            .with_label_values(&["fetch"])
             .get();
         assert_eq!(retries, 2);
+        assert_eq!(client.metrics.total_ingested_checkpoints.get(), 1);
+        assert_eq!(client.metrics.total_ingested_transactions.get(), 0);
+        assert_eq!(client.metrics.total_ingested_events.get(), 0);
+        assert_eq!(client.metrics.total_ingested_objects.get(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_checkpoint_decode_error_with_retry() {
+        let (client, mock) = setup_test();
+
+        mock.checkpoints.insert(1, test_checkpoint(1));
+        mock.decode_failures.insert(1, 2);
+
+        // Fetch and verify it succeeds after retries
+        let result = client.checkpoint(1).await.unwrap();
+        assert_eq!(*result.checkpoint.summary.sequence_number(), 1);
+        assert_eq!(result.chain_id, MockIngestionClient::mock_chain_id());
+
+        // Verify that exactly 2 retries were recorded
+        let retries = client
+            .metrics
+            .total_ingested_transient_retries
+            .with_label_values(&["deserialization"])
+            .get();
+        assert_eq!(retries, 2);
+        assert_eq!(client.metrics.total_ingested_checkpoints.get(), 1);
+        assert_eq!(client.metrics.total_ingested_transactions.get(), 0);
+        assert_eq!(client.metrics.total_ingested_events.get(), 0);
+        assert_eq!(client.metrics.total_ingested_objects.get(), 0);
     }
 
     #[tokio::test]
     async fn test_wait_for_checkpoint_with_retry() {
         let (client, mock) = setup_test();
 
-        // Create test data - now returns zstd-compressed protobuf
-        let bytes = Bytes::from(test_checkpoint_data(1));
-
-        // Add checkpoint to mock with 1 not_found failures
-        mock.checkpoints.insert(1, CheckpointData::Raw(bytes));
+        mock.checkpoints.insert(1, test_checkpoint(1));
         mock.not_found_failures.insert(1, 1);
 
         // Wait for checkpoint with short retry interval
@@ -690,56 +699,24 @@ mod tests {
         // Verify that exactly 1 retry was recorded
         let retries = client.metrics.total_ingested_not_found_retries.get();
         assert_eq!(retries, 1);
+        assert_eq!(client.metrics.total_ingested_checkpoints.get(), 1);
+        assert_eq!(client.metrics.total_ingested_transactions.get(), 0);
+        assert_eq!(client.metrics.total_ingested_events.get(), 0);
+        assert_eq!(client.metrics.total_ingested_objects.get(), 0);
     }
 
     #[tokio::test]
     async fn test_wait_for_checkpoint_instant() {
         let (client, mock) = setup_test();
 
-        // Create test data using test_checkpoint
-        let bytes = Bytes::from(test_checkpoint_data(1));
+        mock.checkpoints.insert(1, test_checkpoint(1));
 
-        // Add checkpoint to mock with no failures - data should be available immediately
-        mock.checkpoints.insert(1, CheckpointData::Raw(bytes));
-
-        // Wait for checkpoint with short retry interval
         let result = client.wait_for(1, Duration::from_millis(50)).await.unwrap();
         assert_eq!(result.checkpoint.summary.sequence_number(), &1);
         assert_eq!(result.chain_id, MockIngestionClient::mock_chain_id());
-    }
-
-    #[tokio::test]
-    async fn test_wait_for_permanent_deserialization_error() {
-        let (client, mock) = setup_test();
-
-        // Add invalid data that will cause a deserialization error
-        mock.checkpoints
-            .insert(1, CheckpointData::Raw(Bytes::from("invalid data")));
-
-        // wait_for should keep retrying on deserialization errors and timeout
-        timeout(
-            Duration::from_secs(1),
-            client.wait_for(1, Duration::from_millis(50)),
-        )
-        .await
-        .unwrap_err();
-    }
-
-    #[tokio::test]
-    async fn test_fetch_non_retryable_error() {
-        let (client, mock) = setup_test();
-
-        mock.permanent_failures.insert(1, 1);
-
-        let result = client.checkpoint(1).await;
-        assert!(matches!(result, Err(IE::FetchError(1, _))));
-
-        // Verify that the non-retryable error metric was incremented
-        let errors = client
-            .metrics
-            .total_ingested_permanent_errors
-            .with_label_values(&["mock_permanent_error"])
-            .get();
-        assert_eq!(errors, 1);
+        assert_eq!(client.metrics.total_ingested_checkpoints.get(), 1);
+        assert_eq!(client.metrics.total_ingested_transactions.get(), 0);
+        assert_eq!(client.metrics.total_ingested_events.get(), 0);
+        assert_eq!(client.metrics.total_ingested_objects.get(), 0);
     }
 }

--- a/crates/sui-indexer-alt-framework/src/ingestion/mod.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/mod.rs
@@ -14,6 +14,7 @@ use serde::Deserialize;
 use serde::Serialize;
 use sui_futures::service::Service;
 use tokio::sync::mpsc;
+use tracing::warn;
 
 pub use crate::config::ConcurrencyConfig as IngestConcurrencyConfig;
 use crate::ingestion::broadcaster::broadcaster;
@@ -22,11 +23,16 @@ use crate::ingestion::error::Result;
 use crate::ingestion::ingestion_client::CheckpointEnvelope;
 use crate::ingestion::ingestion_client::IngestionClient;
 use crate::ingestion::ingestion_client::IngestionClientArgs;
+use crate::ingestion::streaming_client::CheckpointStream;
+use crate::ingestion::streaming_client::CheckpointStreamingClient;
 use crate::ingestion::streaming_client::GrpcStreamingClient;
 use crate::ingestion::streaming_client::StreamingClientArgs;
 use crate::metrics::IngestionMetrics;
 
+use self::ingestion_client::retry_transient_with_slow_monitor;
+
 mod broadcaster;
+mod byte_count;
 pub(crate) mod decode;
 pub mod error;
 pub mod ingestion_client;
@@ -37,6 +43,8 @@ pub mod streaming_client;
 mod test_utils;
 
 pub(crate) const MAX_GRPC_MESSAGE_SIZE_BYTES: usize = 128 * 1024 * 1024;
+
+const OPERATION: &str = "latest_checkpoint_number";
 
 /// Combined arguments for both ingestion and streaming clients.
 /// This is a convenience wrapper that flattens both argument types.
@@ -143,6 +151,26 @@ impl IngestionService {
         &self.ingestion_client
     }
 
+    pub async fn latest_checkpoint_number(&self) -> anyhow::Result<u64> {
+        let streaming_client = self.streaming_client.clone();
+        let ingestion_client = self.ingestion_client.clone();
+        let future = move || {
+            let mut streaming_client = streaming_client.clone();
+            let ingestion_client = ingestion_client.clone();
+            async move {
+                latest_checkpoint_number(&mut streaming_client, &ingestion_client)
+                    .await
+                    .map_err(|e| backoff::Error::transient(Error::LatestCheckpointError(e)))
+            }
+        };
+        Ok(retry_transient_with_slow_monitor(
+            OPERATION,
+            future,
+            &self.metrics.ingested_latest_checkpoint_latency,
+        )
+        .await?)
+    }
+
     /// Access to the ingestion metrics.
     pub(crate) fn metrics(&self) -> &Arc<IngestionMetrics> {
         &self.metrics
@@ -241,6 +269,42 @@ impl Default for IngestionConfig {
     }
 }
 
+/// Try to get the latest checkpoint number from the streaming client first, falling back to
+/// the ingestion client if the streaming client is unavailable or fails.
+async fn latest_checkpoint_number(
+    streaming_client: &mut Option<impl CheckpointStreamingClient>,
+    ingestion_client: &IngestionClient,
+) -> anyhow::Result<u64> {
+    if let Some(streaming_client) = streaming_client.as_mut() {
+        match streaming_client.connect().await {
+            Ok(CheckpointStream { mut stream, .. }) => match stream.peek().await {
+                Some(Ok(checkpoint)) => {
+                    return Ok(checkpoint.summary.sequence_number);
+                }
+                Some(Err(e)) => {
+                    warn!(
+                        operation = OPERATION,
+                        "Failed to peek checkpoint stream: {e}"
+                    );
+                }
+                None => {
+                    warn!(
+                        operation = OPERATION,
+                        "Checkpoint stream ended unexpectedly"
+                    );
+                }
+            },
+            Err(e) => {
+                warn!(
+                    operation = OPERATION,
+                    "Failed to connect streaming client: {e}"
+                );
+            }
+        }
+    }
+    ingestion_client.latest_checkpoint_number().await
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Mutex;
@@ -251,12 +315,39 @@ mod tests {
     use wiremock::MockServer;
     use wiremock::Request;
 
+    use crate::ingestion::ingestion_client::CheckpointResult;
+    use crate::ingestion::ingestion_client::IngestionClientTrait;
     use crate::ingestion::store_client::tests::respond_with;
     use crate::ingestion::store_client::tests::respond_with_chain_id;
     use crate::ingestion::store_client::tests::status;
+    use crate::ingestion::streaming_client::test_utils::MockStreamingClient;
     use crate::ingestion::test_utils::test_checkpoint_data;
+    use crate::metrics::IngestionMetrics;
+    use crate::types::digests::ChainIdentifier;
 
     use super::*;
+
+    const FALLBACK: u64 = 99;
+
+    struct MockLatestCheckpoint(u64);
+
+    #[async_trait::async_trait]
+    impl IngestionClientTrait for MockLatestCheckpoint {
+        async fn chain_id(&self) -> anyhow::Result<ChainIdentifier> {
+            unimplemented!()
+        }
+        async fn checkpoint(&self, _: u64) -> CheckpointResult {
+            unimplemented!()
+        }
+        async fn latest_checkpoint_number(&self) -> anyhow::Result<u64> {
+            Ok(self.0)
+        }
+    }
+
+    fn mock_ingestion_client(latest_checkpoint: u64) -> IngestionClient {
+        let metrics = IngestionMetrics::new(None, &Registry::new());
+        IngestionClient::new_impl(Arc::new(MockLatestCheckpoint(latest_checkpoint)), metrics)
+    }
 
     async fn test_ingestion(
         uri: String,
@@ -455,5 +546,49 @@ mod tests {
 
         let seqs = subscriber.await.unwrap();
         assert_eq!(seqs, vec![0, 1, 2, 3, 4, 5]);
+    }
+
+    #[tokio::test]
+    async fn latest_checkpoint_number_no_streaming_client() {
+        let client = mock_ingestion_client(FALLBACK);
+        let mut streaming: Option<MockStreamingClient> = None;
+        let result = latest_checkpoint_number(&mut streaming, &client).await;
+        assert_eq!(result.unwrap(), FALLBACK);
+    }
+
+    #[tokio::test]
+    async fn latest_checkpoint_number_from_stream() {
+        let client = mock_ingestion_client(FALLBACK);
+        let mut streaming = Some(MockStreamingClient::new([42], None));
+        let result = latest_checkpoint_number(&mut streaming, &client).await;
+        assert_eq!(result.unwrap(), 42);
+    }
+
+    #[tokio::test]
+    async fn latest_checkpoint_number_stream_error_falls_back() {
+        let client = mock_ingestion_client(FALLBACK);
+        let mut mock = MockStreamingClient::new(std::iter::empty::<u64>(), None);
+        mock.insert_error();
+        let mut streaming = Some(mock);
+        let result = latest_checkpoint_number(&mut streaming, &client).await;
+        assert_eq!(result.unwrap(), FALLBACK);
+    }
+
+    #[tokio::test]
+    async fn latest_checkpoint_number_empty_stream_falls_back() {
+        let client = mock_ingestion_client(FALLBACK);
+        let mut streaming = Some(MockStreamingClient::new(std::iter::empty::<u64>(), None));
+        let result = latest_checkpoint_number(&mut streaming, &client).await;
+        assert_eq!(result.unwrap(), FALLBACK);
+    }
+
+    #[tokio::test]
+    async fn latest_checkpoint_number_connection_failure_falls_back() {
+        let client = mock_ingestion_client(FALLBACK);
+        let mut streaming = Some(
+            MockStreamingClient::new(std::iter::empty::<u64>(), None).fail_connection_times(1),
+        );
+        let result = latest_checkpoint_number(&mut streaming, &client).await;
+        assert_eq!(result.unwrap(), FALLBACK);
     }
 }

--- a/crates/sui-indexer-alt-framework/src/ingestion/mod.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/mod.rs
@@ -23,13 +23,11 @@ use crate::ingestion::error::Result;
 use crate::ingestion::ingestion_client::CheckpointEnvelope;
 use crate::ingestion::ingestion_client::IngestionClient;
 use crate::ingestion::ingestion_client::IngestionClientArgs;
-use crate::ingestion::streaming_client::CheckpointStream;
+use crate::ingestion::ingestion_client::retry_transient_with_slow_monitor;
 use crate::ingestion::streaming_client::CheckpointStreamingClient;
 use crate::ingestion::streaming_client::GrpcStreamingClient;
 use crate::ingestion::streaming_client::StreamingClientArgs;
 use crate::metrics::IngestionMetrics;
-
-use self::ingestion_client::retry_transient_with_slow_monitor;
 
 mod broadcaster;
 mod byte_count;
@@ -43,8 +41,6 @@ pub mod streaming_client;
 mod test_utils;
 
 pub(crate) const MAX_GRPC_MESSAGE_SIZE_BYTES: usize = 128 * 1024 * 1024;
-
-const OPERATION: &str = "latest_checkpoint_number";
 
 /// Combined arguments for both ingestion and streaming clients.
 /// This is a convenience wrapper that flattens both argument types.
@@ -151,6 +147,8 @@ impl IngestionService {
         &self.ingestion_client
     }
 
+    /// Return the latest checkpoint number known to the ingestion service, preferably via the
+    /// streaming client, and failing that via the ingestion client.
     pub async fn latest_checkpoint_number(&self) -> anyhow::Result<u64> {
         let streaming_client = self.streaming_client.clone();
         let ingestion_client = self.ingestion_client.clone();
@@ -163,8 +161,9 @@ impl IngestionService {
                     .map_err(|e| backoff::Error::transient(Error::LatestCheckpointError(e)))
             }
         };
+
         Ok(retry_transient_with_slow_monitor(
-            OPERATION,
+            "latest_checkpoint_number",
             future,
             &self.metrics.ingested_latest_checkpoint_latency,
         )
@@ -269,39 +268,22 @@ impl Default for IngestionConfig {
     }
 }
 
-/// Try to get the latest checkpoint number from the streaming client first, falling back to
-/// the ingestion client if the streaming client is unavailable or fails.
 async fn latest_checkpoint_number(
-    streaming_client: &mut Option<impl CheckpointStreamingClient>,
+    streaming_client: &mut Option<impl CheckpointStreamingClient + Send>,
     ingestion_client: &IngestionClient,
 ) -> anyhow::Result<u64> {
     if let Some(streaming_client) = streaming_client.as_mut() {
-        match streaming_client.connect().await {
-            Ok(CheckpointStream { mut stream, .. }) => match stream.peek().await {
-                Some(Ok(checkpoint)) => {
-                    return Ok(checkpoint.summary.sequence_number);
-                }
-                Some(Err(e)) => {
-                    warn!(
-                        operation = OPERATION,
-                        "Failed to peek checkpoint stream: {e}"
-                    );
-                }
-                None => {
-                    warn!(
-                        operation = OPERATION,
-                        "Checkpoint stream ended unexpectedly"
-                    );
-                }
-            },
+        match streaming_client.latest_checkpoint_number().await {
+            Ok(checkpoint_number) => return Ok(checkpoint_number),
             Err(e) => {
                 warn!(
-                    operation = OPERATION,
-                    "Failed to connect streaming client: {e}"
+                    operation = "latest_checkpoint_number",
+                    "Failed to get latest checkpoint number from streaming client: {e}"
                 );
             }
         }
     }
+
     ingestion_client.latest_checkpoint_number().await
 }
 

--- a/crates/sui-indexer-alt-framework/src/ingestion/rpc_client.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/rpc_client.rs
@@ -3,6 +3,7 @@
 
 use std::str::FromStr;
 
+use anyhow::Context as _;
 use anyhow::anyhow;
 use async_trait::async_trait;
 use prost_types::FieldMask;
@@ -60,11 +61,10 @@ impl IngestionClientTrait for RpcClient {
     }
 
     async fn latest_checkpoint_number(&self) -> anyhow::Result<u64> {
-        let response = get_service_info_request(self).await?;
-        let Some(latest_checkpoint_number) = response.checkpoint_height else {
-            return Err(anyhow!("Checkpoint height not found {response:?}"));
-        };
-        Ok(latest_checkpoint_number)
+        get_service_info_request(self)
+            .await?
+            .checkpoint_height
+            .context("Checkpoint height not found")
     }
 }
 

--- a/crates/sui-indexer-alt-framework/src/ingestion/rpc_client.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/rpc_client.rs
@@ -1,20 +1,22 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::str::FromStr;
+
 use anyhow::anyhow;
 use async_trait::async_trait;
 use prost_types::FieldMask;
-use std::str::FromStr;
 use sui_rpc::Client as RpcClient;
 use sui_rpc::field::FieldMaskUtil;
 use sui_rpc::proto::sui::rpc::v2::GetCheckpointRequest;
 use sui_rpc::proto::sui::rpc::v2::GetServiceInfoRequest;
+use sui_rpc::proto::sui::rpc::v2::GetServiceInfoResponse;
 use sui_types::digests::ChainIdentifier;
 use sui_types::digests::CheckpointDigest;
 use sui_types::full_checkpoint_content::Checkpoint;
 use tonic::Code;
 
-use crate::ingestion::ingestion_client::CheckpointData;
+use crate::ingestion::decode::Error::ProtoConversion;
 use crate::ingestion::ingestion_client::CheckpointError;
 use crate::ingestion::ingestion_client::CheckpointResult;
 use crate::ingestion::ingestion_client::IngestionClientTrait;
@@ -22,13 +24,7 @@ use crate::ingestion::ingestion_client::IngestionClientTrait;
 #[async_trait]
 impl IngestionClientTrait for RpcClient {
     async fn chain_id(&self) -> anyhow::Result<ChainIdentifier> {
-        let request = GetServiceInfoRequest::const_default();
-        let response = self
-            .clone()
-            .ledger_client()
-            .get_service_info(request)
-            .await?
-            .into_inner();
+        let response = get_service_info_request(self).await?;
         Ok(CheckpointDigest::from_str(response.chain_id())?.into())
     }
 
@@ -52,20 +48,34 @@ impl IngestionClientTrait for RpcClient {
             .await
             .map_err(|status| match status.code() {
                 Code::NotFound => CheckpointError::NotFound,
-                _ => CheckpointError::Transient {
-                    reason: "get_checkpoint",
-                    error: anyhow!(status),
-                },
-            })?
-            .into_inner();
+                _ => CheckpointError::Fetch(anyhow!(status)),
+            })?;
 
-        let checkpoint = Checkpoint::try_from(response.checkpoint()).map_err(|e| {
-            CheckpointError::Permanent {
-                reason: "proto_conversion",
-                error: e.into(),
-            }
-        })?;
-
-        Ok(CheckpointData::Checkpoint(checkpoint))
+        // `total_ingested_bytes` is incremented directly by the
+        // `ByteCountMakeCallbackHandler` request layer attached in
+        // `IngestionClient::with_grpc`, so it does not need to be tracked here.
+        let response = response.into_inner();
+        Checkpoint::try_from(response.checkpoint())
+            .map_err(|e| CheckpointError::Decode(ProtoConversion(e)))
     }
+
+    async fn latest_checkpoint_number(&self) -> anyhow::Result<u64> {
+        let response = get_service_info_request(self).await?;
+        let Some(latest_checkpoint_number) = response.checkpoint_height else {
+            return Err(anyhow!("Checkpoint height not found {response:?}"));
+        };
+        Ok(latest_checkpoint_number)
+    }
+}
+
+async fn get_service_info_request(
+    rpc_client: &RpcClient,
+) -> anyhow::Result<GetServiceInfoResponse> {
+    let request = GetServiceInfoRequest::const_default();
+    Ok(rpc_client
+        .clone()
+        .ledger_client()
+        .get_service_info(request)
+        .await?
+        .into_inner())
 }

--- a/crates/sui-indexer-alt-framework/src/ingestion/store_client.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/store_client.rs
@@ -20,14 +20,8 @@ use crate::ingestion::ingestion_client::CheckpointResult;
 use crate::ingestion::ingestion_client::IngestionClientTrait;
 use crate::types::full_checkpoint_content::Checkpoint;
 
-/// Disable object_store's internal retries so that transient errors (429s, 5xx) propagate
-/// immediately to the framework's own retry logic.
-pub(super) fn retry_config() -> RetryConfig {
-    RetryConfig {
-        max_retries: 0,
-        ..Default::default()
-    }
-}
+// from sui-indexer-alt-object-store
+pub(crate) const WATERMARK_PATH: &str = "_metadata/watermark/checkpoint_blob.json";
 
 pub struct StoreIngestionClient {
     store: Arc<dyn ObjectStore>,
@@ -36,9 +30,6 @@ pub struct StoreIngestionClient {
     /// metadata fetches (e.g. `end_of_epoch_checkpoints`) and don't need a metric.
     total_ingested_bytes: Option<IntCounter>,
 }
-
-// from sui-indexer-alt-object-store
-pub(crate) const WATERMARK_PATH: &str = "_metadata/watermark/checkpoint_blob.json";
 
 #[derive(serde::Deserialize, serde::Serialize)]
 pub(crate) struct ObjectStoreWatermark {
@@ -82,8 +73,10 @@ impl StoreIngestionClient {
             Err(Error::NotFound { .. }) => return Ok(None),
             Err(e) => return Err(e).context(format!("error reading {WATERMARK_PATH}")),
         };
+
         let watermark: ObjectStoreWatermark =
             serde_json::from_slice(&bytes).context(format!("error parsing {WATERMARK_PATH}"))?;
+
         Ok(Some(watermark.checkpoint_hi_inclusive))
     }
 }
@@ -123,6 +116,15 @@ impl IngestionClientTrait for StoreIngestionClient {
         self.watermark_checkpoint_hi_inclusive()
             .await
             .map(|cp| cp.unwrap_or(0))
+    }
+}
+
+/// Disable object_store's internal retries so that transient errors (429s, 5xx) propagate
+/// immediately to the framework's own retry logic.
+pub(super) fn retry_config() -> RetryConfig {
+    RetryConfig {
+        max_retries: 0,
+        ..Default::default()
     }
 }
 

--- a/crates/sui-indexer-alt-framework/src/ingestion/store_client.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/store_client.rs
@@ -3,19 +3,18 @@
 
 use std::sync::Arc;
 
+use anyhow::Context;
 use bytes::Bytes;
-use object_store::Error as ObjectStoreError;
+use object_store::Error;
 use object_store::ObjectStore;
 use object_store::ObjectStoreExt;
 use object_store::RetryConfig;
 use object_store::path::Path as ObjectPath;
+use prometheus::IntCounter;
 use serde::de::DeserializeOwned;
 use sui_types::digests::ChainIdentifier;
-use tracing::debug;
-use tracing::error;
 
 use crate::ingestion::decode;
-use crate::ingestion::ingestion_client::CheckpointData;
 use crate::ingestion::ingestion_client::CheckpointError;
 use crate::ingestion::ingestion_client::CheckpointResult;
 use crate::ingestion::ingestion_client::IngestionClientTrait;
@@ -32,11 +31,26 @@ pub(super) fn retry_config() -> RetryConfig {
 
 pub struct StoreIngestionClient {
     store: Arc<dyn ObjectStore>,
+    /// Counter incremented (in the [`IngestionClientTrait`] impl) by the size in bytes of each
+    /// fetched checkpoint payload. `None` for callers that only use this client for one-shot
+    /// metadata fetches (e.g. `end_of_epoch_checkpoints`) and don't need a metric.
+    total_ingested_bytes: Option<IntCounter>,
+}
+
+// from sui-indexer-alt-object-store
+pub(crate) const WATERMARK_PATH: &str = "_metadata/watermark/checkpoint_blob.json";
+
+#[derive(serde::Deserialize, serde::Serialize)]
+pub(crate) struct ObjectStoreWatermark {
+    pub checkpoint_hi_inclusive: u64,
 }
 
 impl StoreIngestionClient {
-    pub fn new(store: Arc<dyn ObjectStore>) -> Self {
-        Self { store }
+    pub fn new(store: Arc<dyn ObjectStore>, total_ingested_bytes: Option<IntCounter>) -> Self {
+        Self {
+            store,
+            total_ingested_bytes,
+        }
     }
 
     /// Fetch metadata mapping epoch IDs to the sequence numbers of their last checkpoints.
@@ -61,6 +75,17 @@ impl StoreIngestionClient {
         let result = self.store.get(&path).await?;
         result.bytes().await
     }
+
+    async fn watermark_checkpoint_hi_inclusive(&self) -> anyhow::Result<Option<u64>> {
+        let bytes = match self.bytes(ObjectPath::from(WATERMARK_PATH)).await {
+            Ok(bytes) => bytes,
+            Err(Error::NotFound { .. }) => return Ok(None),
+            Err(e) => return Err(e).context(format!("error reading {WATERMARK_PATH}")),
+        };
+        let watermark: ObjectStoreWatermark =
+            serde_json::from_slice(&bytes).context(format!("error parsing {WATERMARK_PATH}"))?;
+        Ok(Some(watermark.checkpoint_hi_inclusive))
+    }
 }
 
 #[async_trait::async_trait]
@@ -80,20 +105,24 @@ impl IngestionClientTrait for StoreIngestionClient {
     /// - server errors (5xx),
     /// - issues getting a full response.
     async fn checkpoint(&self, checkpoint: u64) -> CheckpointResult {
-        match self.checkpoint_bytes(checkpoint).await {
-            Ok(bytes) => Ok(CheckpointData::Raw(bytes)),
-            Err(ObjectStoreError::NotFound { .. }) => {
-                debug!(checkpoint, "Checkpoint not found");
-                Err(CheckpointError::NotFound)
-            }
-            Err(error) => {
-                error!(checkpoint, "Failed to fetch checkpoint: {error}");
-                Err(CheckpointError::Transient {
-                    reason: "object_store",
-                    error: error.into(),
-                })
-            }
+        let bytes = self
+            .checkpoint_bytes(checkpoint)
+            .await
+            .map_err(|e| match e {
+                Error::NotFound { .. } => CheckpointError::NotFound,
+                e => CheckpointError::Fetch(e.into()),
+            })?;
+
+        if let Some(counter) = &self.total_ingested_bytes {
+            counter.inc_by(bytes.len() as u64);
         }
+        decode::checkpoint(&bytes).map_err(CheckpointError::Decode)
+    }
+
+    async fn latest_checkpoint_number(&self) -> anyhow::Result<u64> {
+        self.watermark_checkpoint_hi_inclusive()
+            .await
+            .map(|cp| cp.unwrap_or(0))
     }
 }
 
@@ -144,7 +173,7 @@ pub(crate) mod tests {
     /// `respond_with_chain_id` is mounted.
     pub(crate) fn expected_chain_id() -> ChainIdentifier {
         let bytes = test_checkpoint_data(0);
-        let checkpoint = crate::ingestion::decode::checkpoint(&bytes).unwrap();
+        let checkpoint = decode::checkpoint(&bytes).unwrap();
         (*checkpoint.summary.digest()).into()
     }
 
@@ -160,6 +189,56 @@ pub(crate) mod tests {
             .map(Arc::new)
             .unwrap();
         IngestionClient::with_store(store, test_ingestion_metrics()).unwrap()
+    }
+
+    async fn test_latest_checkpoint_number(watermark: ResponseTemplate) -> anyhow::Result<u64> {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path(WATERMARK_PATH))
+            .respond_with(watermark)
+            .mount(&server)
+            .await;
+
+        let store = HttpBuilder::new()
+            .with_url(server.uri())
+            .with_client_options(ClientOptions::default().with_allow_http(true))
+            .build()
+            .map(Arc::new)
+            .unwrap();
+        let client = StoreIngestionClient::new(store, None);
+
+        IngestionClientTrait::latest_checkpoint_number(&client).await
+    }
+
+    #[tokio::test]
+    async fn test_latest_checkpoint_no_watermark() {
+        assert_eq!(
+            test_latest_checkpoint_number(status(StatusCode::NOT_FOUND))
+                .await
+                .unwrap(),
+            0
+        )
+    }
+
+    #[tokio::test]
+    async fn test_latest_checkpoint_corrupt_watermark() {
+        assert!(
+            test_latest_checkpoint_number(status(StatusCode::OK).set_body_string("<"))
+                .await
+                .is_err()
+        )
+    }
+
+    #[tokio::test]
+    async fn test_latest_checkpoint_from_watermark() {
+        let body = serde_json::json!({"checkpoint_hi_inclusive": 1}).to_string();
+        assert_eq!(
+            test_latest_checkpoint_number(status(StatusCode::OK).set_body_string(body))
+                .await
+                .unwrap(),
+            1
+        )
     }
 
     #[tokio::test]
@@ -273,7 +352,7 @@ pub(crate) mod tests {
             match times_clone.fetch_add(1, Ordering::Relaxed) {
                 0 => {
                     // Delay longer than our test timeout (2 seconds)
-                    std::thread::sleep(std::time::Duration::from_secs(4));
+                    std::thread::sleep(Duration::from_secs(4));
                     status(StatusCode::OK).set_body_bytes(test_checkpoint_data(42))
                 }
                 _ => {

--- a/crates/sui-indexer-alt-framework/src/ingestion/streaming_client.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/streaming_client.rs
@@ -43,6 +43,7 @@ pub struct StreamingClientArgs {
 }
 
 /// gRPC-based implementation of the CheckpointStreamingClient trait.
+#[derive(Clone)]
 pub struct GrpcStreamingClient {
     uri: Uri,
     connection_timeout: Duration,

--- a/crates/sui-indexer-alt-framework/src/ingestion/streaming_client.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/streaming_client.rs
@@ -63,7 +63,9 @@ impl GrpcStreamingClient {
 #[async_trait]
 impl CheckpointStreamingClient for GrpcStreamingClient {
     async fn connect(&mut self) -> Result<CheckpointStream> {
-        let endpoint = Endpoint::from(self.uri.clone()).connect_timeout(self.connection_timeout);
+        let endpoint = Endpoint::from(self.uri.clone())
+            .connect_timeout(self.connection_timeout)
+            .timeout(self.connection_timeout);
 
         let mut client = SubscriptionServiceClient::connect(endpoint)
             .await
@@ -119,6 +121,68 @@ fn wrap_stream(
         })
         .boxed();
     tokio_stream::StreamExt::peekable(stream)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::SocketAddr;
+    use std::time::Duration;
+
+    use sui_rpc::proto::sui::rpc::v2::SubscribeCheckpointsRequest;
+    use sui_rpc::proto::sui::rpc::v2::SubscribeCheckpointsResponse;
+    use sui_rpc::proto::sui::rpc::v2::subscription_service_server::SubscriptionService;
+    use sui_rpc::proto::sui::rpc::v2::subscription_service_server::SubscriptionServiceServer;
+    use tonic::transport::Server;
+
+    use super::*;
+
+    /// A gRPC server that accepts connections but never responds to
+    /// subscribe_checkpoints, simulating a stalled RPC handshake.
+    struct HangingSubscriptionService;
+
+    #[tonic::async_trait]
+    impl SubscriptionService for HangingSubscriptionService {
+        async fn subscribe_checkpoints(
+            &self,
+            _request: tonic::Request<SubscribeCheckpointsRequest>,
+        ) -> std::result::Result<
+            tonic::Response<
+                BoxStream<'static, std::result::Result<SubscribeCheckpointsResponse, Status>>,
+            >,
+            Status,
+        > {
+            futures::future::pending().await
+        }
+    }
+
+    #[tokio::test]
+    async fn subscribe_checkpoints_times_out_on_stalled_server() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr: SocketAddr = listener.local_addr().unwrap();
+
+        tokio::spawn(async move {
+            let incoming = tokio_stream::wrappers::TcpListenerStream::new(listener);
+            Server::builder()
+                .add_service(SubscriptionServiceServer::new(HangingSubscriptionService))
+                .serve_with_incoming(incoming)
+                .await
+                .unwrap();
+        });
+
+        let timeout = Duration::from_millis(200);
+        let uri: Uri = format!("http://{addr}").parse().unwrap();
+        let mut client = GrpcStreamingClient::new(uri, timeout, timeout);
+
+        let start = std::time::Instant::now();
+        let result = client.connect().await;
+        let elapsed = start.elapsed();
+
+        assert!(result.is_err(), "expected timeout error");
+        assert!(
+            elapsed < Duration::from_secs(5),
+            "connect() took {elapsed:?}, should have timed out in ~200ms"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/sui-indexer-alt-framework/src/ingestion/streaming_client.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/streaming_client.rs
@@ -33,6 +33,17 @@ pub struct CheckpointStream {
 pub trait CheckpointStreamingClient {
     /// Returns the CheckpointStream and chain id.
     async fn connect(&mut self) -> Result<CheckpointStream>;
+
+    /// Returns the latest checkpoint number available from the streaming source.
+    async fn latest_checkpoint_number(&mut self) -> Result<u64> {
+        let mut stream = self.connect().await?;
+
+        match stream.stream.next().await {
+            Some(Ok(checkpoint)) => Ok(checkpoint.summary.sequence_number),
+            Some(Err(e)) => Err(e),
+            None => Err(Error::StreamingError(anyhow!("Stream ended unexpectedly"))),
+        }
+    }
 }
 
 #[derive(clap::Args, Clone, Debug, Default)]

--- a/crates/sui-indexer-alt-framework/src/lib.rs
+++ b/crates/sui-indexer-alt-framework/src/lib.rs
@@ -127,6 +127,9 @@ pub struct Indexer<S: Store> {
     /// this checkpoint.
     last_checkpoint: Option<u64>,
 
+    /// The network's latest checkpoint, when the indexer was started.
+    latest_checkpoint: u64,
+
     /// The minimum `next_checkpoint` across all pipelines. This is the checkpoint for the indexer
     /// to start ingesting from.
     next_checkpoint: u64,
@@ -220,12 +223,17 @@ impl<S: Store> Indexer<S> {
         let ingestion_service =
             IngestionService::new(client_args, ingestion_config, metrics_prefix, registry)?;
 
+        let latest_checkpoint = ingestion_service.latest_checkpoint_number().await?;
+
+        info!(latest_checkpoint, "Ingestion store state");
+
         Ok(Self {
             store,
             metrics,
             ingestion_service,
             first_checkpoint,
             last_checkpoint,
+            latest_checkpoint,
             next_checkpoint: u64::MAX,
             next_sequential_checkpoint: None,
             task: task.into_task(),
@@ -280,7 +288,7 @@ impl<S: Store> Indexer<S> {
     /// respective watermarks.
     ///
     /// Ingestion will stop after consuming the configured `last_checkpoint` if one is provided.
-    pub async fn run(self) -> anyhow::Result<Service> {
+    pub async fn run(self) -> Result<Service> {
         if let Some(enabled_pipelines) = self.enabled_pipelines {
             ensure!(
                 enabled_pipelines.is_empty(),
@@ -323,6 +331,7 @@ impl<S: Store> Indexer<S> {
     async fn add_pipeline<P: Processor + 'static>(
         &mut self,
         pipeline_task: String,
+        retention: Option<u64>,
     ) -> Result<Option<u64>> {
         ensure!(
             self.added_pipelines.insert(P::NAME),
@@ -339,7 +348,13 @@ impl<S: Store> Indexer<S> {
 
         // Create a new record based on `proposed_next_checkpoint` if one does not exist.
         // Otherwise, use the existing record and disregard the proposed value.
-        let proposed_next_checkpoint = self.first_checkpoint.unwrap_or(0);
+        let proposed_next_checkpoint = if let Some(first_checkpoint) = self.first_checkpoint {
+            first_checkpoint
+        } else if let Some(retention) = retention {
+            self.latest_checkpoint.saturating_sub(retention)
+        } else {
+            0
+        };
         let mut conn = self.store.connect().await?;
         let init_watermark = conn
             .init_watermark(&pipeline_task, proposed_next_checkpoint.checked_sub(1))
@@ -376,7 +391,8 @@ impl<S: ConcurrentStore> Indexer<S> {
     ) -> Result<()> {
         let pipeline_task =
             pipeline_task::<S>(H::NAME, self.task.as_ref().map(|t| t.task.as_str()))?;
-        let Some(next_checkpoint) = self.add_pipeline::<H>(pipeline_task).await? else {
+        let retention = config.pruner.as_ref().map(|p| p.retention);
+        let Some(next_checkpoint) = self.add_pipeline::<H>(pipeline_task, retention).await? else {
             return Ok(());
         };
 
@@ -418,7 +434,7 @@ impl<T: SequentialStore> Indexer<T> {
             );
         }
 
-        let Some(next_checkpoint) = self.add_pipeline::<H>(H::NAME.to_owned()).await? else {
+        let Some(next_checkpoint) = self.add_pipeline::<H>(H::NAME.to_owned(), None).await? else {
             return Ok(());
         };
 
@@ -457,6 +473,8 @@ mod tests {
     use crate::FieldCount;
     use crate::config::ConcurrencyConfig;
     use crate::ingestion::ingestion_client::IngestionClientArgs;
+    use crate::ingestion::store_client::ObjectStoreWatermark;
+    use crate::ingestion::store_client::WATERMARK_PATH;
     use crate::mocks::store::MockStore;
     use crate::pipeline::CommitterConfig;
     use crate::pipeline::Processor;
@@ -492,7 +510,7 @@ mod tests {
         async fn process(
             &self,
             checkpoint: &Arc<sui_types::full_checkpoint_content::Checkpoint>,
-        ) -> anyhow::Result<Vec<Self::Value>> {
+        ) -> Result<Vec<Self::Value>> {
             let cp_num = checkpoint.summary.sequence_number;
 
             // Wait until the checkpoint is allowed to be processed
@@ -524,7 +542,7 @@ mod tests {
             &self,
             batch: &Self::Batch,
             conn: &mut <Self::Store as Store>::Connection<'a>,
-        ) -> anyhow::Result<usize> {
+        ) -> Result<usize> {
             for value in batch {
                 conn.0
                     .commit_data(Self::NAME, value.0, vec![value.0])
@@ -545,7 +563,7 @@ mod tests {
                 async fn process(
                     &self,
                     checkpoint: &Arc<sui_types::full_checkpoint_content::Checkpoint>,
-                ) -> anyhow::Result<Vec<Self::Value>> {
+                ) -> Result<Vec<Self::Value>> {
                     Ok(vec![MockValue(checkpoint.summary.sequence_number)])
                 }
             }
@@ -568,7 +586,7 @@ mod tests {
                     &self,
                     batch: &Self::Batch,
                     conn: &mut <Self::Store as Store>::Connection<'a>,
-                ) -> anyhow::Result<usize> {
+                ) -> Result<usize> {
                     for value in batch {
                         conn.0
                             .commit_data(Self::NAME, value.0, vec![value.0])
@@ -591,7 +609,7 @@ mod tests {
                     &self,
                     _batch: &Self::Batch,
                     _conn: &mut <Self::Store as Store>::Connection<'a>,
-                ) -> anyhow::Result<usize> {
+                ) -> Result<usize> {
                     Ok(1)
                 }
             }
@@ -602,6 +620,19 @@ mod tests {
     test_pipeline!(SequentialHandler, "sequential_handler");
     test_pipeline!(MockCheckpointSequenceNumberHandler, "test");
 
+    fn init_ingestion_dir(latest_checkpoint: Option<u64>) -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        if let Some(cp) = latest_checkpoint {
+            let watermark_path = dir.path().join(WATERMARK_PATH);
+            std::fs::create_dir_all(watermark_path.parent().unwrap()).unwrap();
+            let watermark = ObjectStoreWatermark {
+                checkpoint_hi_inclusive: cp,
+            };
+            std::fs::write(watermark_path, serde_json::to_string(&watermark).unwrap()).unwrap();
+        }
+        dir
+    }
+
     /// If `ingestion_data` is `Some((num_checkpoints, checkpoint_size))`, synthetic ingestion
     /// data will be generated in the temp directory before creating the indexer.
     async fn create_test_indexer(
@@ -610,7 +641,7 @@ mod tests {
         registry: &Registry,
         ingestion_data: Option<(u64, u64)>,
     ) -> (Indexer<MockStore>, tempfile::TempDir) {
-        let temp_dir = tempfile::tempdir().unwrap();
+        let temp_dir = init_ingestion_dir(None);
         if let Some((num_checkpoints, checkpoint_size)) = ingestion_data {
             synthetic_ingestion::generate_ingestion(synthetic_ingestion::Config {
                 ingestion_dir: temp_dir.path().to_owned(),
@@ -721,6 +752,76 @@ mod tests {
         )
     }
 
+    const LATEST_CHECKPOINT: u64 = 10;
+
+    /// Set up an indexer as if the network is at `latest_checkpoint` (the next checkpoint to
+    /// ingest). Runs a single concurrent pipeline with the given config. If `watermark` is
+    /// provided, the pipeline's high watermark is pre-set; `first_checkpoint` controls where
+    /// ingestion begins.
+    async fn test_next_checkpoint(
+        watermark: Option<u64>,
+        first_checkpoint: Option<u64>,
+        concurrent_config: ConcurrentConfig,
+    ) -> Indexer<MockStore> {
+        let registry = Registry::new();
+        let store = MockStore::default();
+
+        test_pipeline!(A, "concurrent_a");
+
+        if let Some(checkpoint_hi_inclusive) = watermark {
+            let mut conn = store.connect().await.unwrap();
+            conn.set_committer_watermark(
+                A::NAME,
+                CommitterWatermark {
+                    checkpoint_hi_inclusive,
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        }
+
+        let temp_dir = init_ingestion_dir(Some(LATEST_CHECKPOINT));
+        let mut indexer = Indexer::new(
+            store,
+            IndexerArgs {
+                first_checkpoint,
+                ..Default::default()
+            },
+            ClientArgs {
+                ingestion: IngestionClientArgs {
+                    local_ingestion_path: Some(temp_dir.path().to_owned()),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            IngestionConfig::default(),
+            None,
+            &registry,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(indexer.latest_checkpoint, LATEST_CHECKPOINT);
+
+        indexer
+            .concurrent_pipeline::<A>(A, concurrent_config)
+            .await
+            .unwrap();
+
+        indexer
+    }
+
+    fn pruner_config(retention: u64) -> ConcurrentConfig {
+        ConcurrentConfig {
+            pruner: Some(concurrent::PrunerConfig {
+                retention,
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
     #[test]
     fn test_arg_parsing() {
         #[derive(Parser)]
@@ -788,6 +889,7 @@ mod tests {
 
         assert_eq!(indexer.first_checkpoint, None);
         assert_eq!(indexer.last_checkpoint, None);
+        assert_eq!(indexer.latest_checkpoint, 0);
         assert_eq!(indexer.next_checkpoint, 2);
         assert_eq!(indexer.next_sequential_checkpoint, Some(2));
     }
@@ -817,6 +919,7 @@ mod tests {
 
         assert_eq!(indexer.first_checkpoint, None);
         assert_eq!(indexer.last_checkpoint, None);
+        assert_eq!(indexer.latest_checkpoint, 0);
         assert_eq!(indexer.next_checkpoint, 0);
         assert_eq!(indexer.next_sequential_checkpoint, Some(0));
     }
@@ -879,6 +982,7 @@ mod tests {
 
         assert_eq!(indexer.first_checkpoint, Some(5));
         assert_eq!(indexer.last_checkpoint, None);
+        assert_eq!(indexer.latest_checkpoint, 0);
         assert_eq!(indexer.next_checkpoint, 5);
         assert_eq!(indexer.next_sequential_checkpoint, Some(5));
     }
@@ -909,6 +1013,7 @@ mod tests {
 
         assert_eq!(indexer.first_checkpoint, Some(5));
         assert_eq!(indexer.last_checkpoint, None);
+        assert_eq!(indexer.latest_checkpoint, 0);
         assert_eq!(indexer.next_checkpoint, 11);
         assert_eq!(indexer.next_sequential_checkpoint, Some(11));
     }
@@ -942,8 +1047,76 @@ mod tests {
 
         assert_eq!(indexer.first_checkpoint, Some(24));
         assert_eq!(indexer.last_checkpoint, None);
+        assert_eq!(indexer.latest_checkpoint, 0);
         assert_eq!(indexer.next_checkpoint, 11);
         assert_eq!(indexer.next_sequential_checkpoint, Some(11));
+    }
+
+    /// latest_checkpoint is read from the watermark file.
+    #[tokio::test]
+    async fn test_latest_checkpoint_from_watermark() {
+        let registry = Registry::new();
+        let store = MockStore::default();
+        let temp_dir = init_ingestion_dir(Some(30));
+        let indexer = Indexer::new(
+            store,
+            IndexerArgs::default(),
+            ClientArgs {
+                ingestion: IngestionClientArgs {
+                    local_ingestion_path: Some(temp_dir.path().to_owned()),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            IngestionConfig::default(),
+            None,
+            &registry,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(indexer.latest_checkpoint, 30);
+    }
+
+    /// No watermark, no first_checkpoint, pruner with retention:
+    /// next_checkpoint = LATEST_CHECKPOINT - retention.
+    #[tokio::test]
+    async fn test_next_checkpoint_with_pruner_uses_retention() {
+        let retention = LATEST_CHECKPOINT - 1;
+        let indexer = test_next_checkpoint(None, None, pruner_config(retention)).await;
+        assert_eq!(indexer.next_checkpoint, LATEST_CHECKPOINT - retention);
+    }
+
+    /// No watermark, no first_checkpoint, no pruner: falls back to 0.
+    #[tokio::test]
+    async fn test_next_checkpoint_without_pruner_falls_back_to_genesis() {
+        let indexer = test_next_checkpoint(None, None, ConcurrentConfig::default()).await;
+        assert_eq!(indexer.next_checkpoint, 0);
+    }
+
+    /// Watermark at 5 takes priority over latest_checkpoint - retention.
+    #[tokio::test]
+    async fn test_next_checkpoint_watermark_takes_priority_over_pruner() {
+        let retention = LATEST_CHECKPOINT - 1;
+        let indexer = test_next_checkpoint(Some(5), None, pruner_config(retention)).await;
+        assert_eq!(indexer.next_checkpoint, 6);
+    }
+
+    /// first_checkpoint takes priority over latest_checkpoint - retention when
+    /// there's no watermark.
+    #[tokio::test]
+    async fn test_next_checkpoint_first_checkpoint_takes_priority_over_pruner() {
+        let retention = LATEST_CHECKPOINT - 1;
+        let indexer = test_next_checkpoint(None, Some(2), pruner_config(retention)).await;
+        assert_eq!(indexer.next_checkpoint, 2);
+    }
+
+    /// When retention exceeds latest_checkpoint, saturating_sub clamps to 0.
+    #[tokio::test]
+    async fn test_next_checkpoint_retention_exceeds_latest_checkpoint() {
+        let retention = LATEST_CHECKPOINT + 1;
+        let indexer = test_next_checkpoint(None, None, pruner_config(retention)).await;
+        assert_eq!(indexer.next_checkpoint, 0);
     }
 
     // test ingestion, all pipelines have watermarks, no first_checkpoint provided
@@ -985,6 +1158,47 @@ mod tests {
         assert_out_of_order!(indexer_metrics, B::NAME, 5);
         assert_out_of_order!(indexer_metrics, C::NAME, 10);
         assert_out_of_order!(indexer_metrics, D::NAME, 15);
+    }
+
+    // test ingestion, no pipelines missing watermarks, first_checkpoint provided
+    #[tokio::test]
+    async fn test_indexer_ingestion_existing_watermarks_ignore_first_checkpoint() {
+        let registry = Registry::new();
+        let store = MockStore::default();
+
+        test_pipeline!(A, "concurrent_a");
+        test_pipeline!(B, "concurrent_b");
+        test_pipeline!(C, "sequential_c");
+        test_pipeline!(D, "sequential_d");
+
+        let mut conn = store.connect().await.unwrap();
+        set_committer_watermark(&mut conn, A::NAME, 5).await;
+        set_committer_watermark(&mut conn, B::NAME, 10).await;
+        set_committer_watermark(&mut conn, C::NAME, 15).await;
+        set_committer_watermark(&mut conn, D::NAME, 20).await;
+
+        let indexer_args = IndexerArgs {
+            first_checkpoint: Some(3),
+            last_checkpoint: Some(29),
+            ..Default::default()
+        };
+        let (mut indexer, _temp_dir) =
+            create_test_indexer(store.clone(), indexer_args, &registry, Some((30, 1))).await;
+
+        add_concurrent(&mut indexer, A).await;
+        add_concurrent(&mut indexer, B).await;
+        add_sequential(&mut indexer, C).await;
+        add_sequential(&mut indexer, D).await;
+
+        let ingestion_metrics = indexer.ingestion_metrics().clone();
+        let metrics = indexer.indexer_metrics().clone();
+        indexer.run().await.unwrap().join().await.unwrap();
+
+        assert_eq!(ingestion_metrics.total_ingested_checkpoints.get(), 24);
+        assert_out_of_order!(metrics, A::NAME, 0);
+        assert_out_of_order!(metrics, B::NAME, 5);
+        assert_out_of_order!(metrics, C::NAME, 10);
+        assert_out_of_order!(metrics, D::NAME, 15);
     }
 
     // test ingestion, some pipelines missing watermarks, no first_checkpoint provided

--- a/crates/sui-indexer-alt-framework/src/lib.rs
+++ b/crates/sui-indexer-alt-framework/src/lib.rs
@@ -30,7 +30,6 @@ use crate::pipeline::sequential::SequentialConfig;
 use crate::pipeline::sequential::{self};
 use crate::service::Service;
 
-pub use anyhow::Result;
 pub use sui_field_count::FieldCount;
 pub use sui_futures::service;
 /// External users access the store trait through framework::store
@@ -210,7 +209,7 @@ impl<S: Store> Indexer<S> {
         ingestion_config: IngestionConfig,
         metrics_prefix: Option<&str>,
         registry: &Registry,
-    ) -> Result<Self> {
+    ) -> anyhow::Result<Self> {
         let IndexerArgs {
             first_checkpoint,
             last_checkpoint,
@@ -225,7 +224,7 @@ impl<S: Store> Indexer<S> {
 
         let latest_checkpoint = ingestion_service.latest_checkpoint_number().await?;
 
-        info!(latest_checkpoint, "Ingestion store state");
+        info!(latest_checkpoint);
 
         Ok(Self {
             store,
@@ -288,7 +287,7 @@ impl<S: Store> Indexer<S> {
     /// respective watermarks.
     ///
     /// Ingestion will stop after consuming the configured `last_checkpoint` if one is provided.
-    pub async fn run(self) -> Result<Service> {
+    pub async fn run(self) -> anyhow::Result<Service> {
         if let Some(enabled_pipelines) = self.enabled_pipelines {
             ensure!(
                 enabled_pipelines.is_empty(),
@@ -332,7 +331,7 @@ impl<S: Store> Indexer<S> {
         &mut self,
         pipeline_task: String,
         retention: Option<u64>,
-    ) -> Result<Option<u64>> {
+    ) -> anyhow::Result<Option<u64>> {
         ensure!(
             self.added_pipelines.insert(P::NAME),
             "Pipeline {:?} already added",
@@ -388,7 +387,7 @@ impl<S: ConcurrentStore> Indexer<S> {
         &mut self,
         handler: H,
         config: ConcurrentConfig,
-    ) -> Result<()> {
+    ) -> anyhow::Result<()> {
         let pipeline_task =
             pipeline_task::<S>(H::NAME, self.task.as_ref().map(|t| t.task.as_str()))?;
         let retention = config.pruner.as_ref().map(|p| p.retention);
@@ -425,7 +424,7 @@ impl<T: SequentialStore> Indexer<T> {
         &mut self,
         handler: H,
         config: SequentialConfig,
-    ) -> Result<()> {
+    ) -> anyhow::Result<()> {
         if self.task.is_some() {
             bail!(
                 "Sequential pipelines do not support pipeline tasks. \
@@ -510,7 +509,7 @@ mod tests {
         async fn process(
             &self,
             checkpoint: &Arc<sui_types::full_checkpoint_content::Checkpoint>,
-        ) -> Result<Vec<Self::Value>> {
+        ) -> anyhow::Result<Vec<Self::Value>> {
             let cp_num = checkpoint.summary.sequence_number;
 
             // Wait until the checkpoint is allowed to be processed
@@ -542,7 +541,7 @@ mod tests {
             &self,
             batch: &Self::Batch,
             conn: &mut <Self::Store as Store>::Connection<'a>,
-        ) -> Result<usize> {
+        ) -> anyhow::Result<usize> {
             for value in batch {
                 conn.0
                     .commit_data(Self::NAME, value.0, vec![value.0])
@@ -563,7 +562,7 @@ mod tests {
                 async fn process(
                     &self,
                     checkpoint: &Arc<sui_types::full_checkpoint_content::Checkpoint>,
-                ) -> Result<Vec<Self::Value>> {
+                ) -> anyhow::Result<Vec<Self::Value>> {
                     Ok(vec![MockValue(checkpoint.summary.sequence_number)])
                 }
             }
@@ -586,7 +585,7 @@ mod tests {
                     &self,
                     batch: &Self::Batch,
                     conn: &mut <Self::Store as Store>::Connection<'a>,
-                ) -> Result<usize> {
+                ) -> anyhow::Result<usize> {
                     for value in batch {
                         conn.0
                             .commit_data(Self::NAME, value.0, vec![value.0])
@@ -609,7 +608,7 @@ mod tests {
                     &self,
                     _batch: &Self::Batch,
                     _conn: &mut <Self::Store as Store>::Connection<'a>,
-                ) -> Result<usize> {
+                ) -> anyhow::Result<usize> {
                     Ok(1)
                 }
             }

--- a/crates/sui-indexer-alt-framework/src/metrics.rs
+++ b/crates/sui-indexer-alt-framework/src/metrics.rs
@@ -63,7 +63,6 @@ pub struct IngestionMetrics {
     pub total_ingested_bytes: IntCounter,
     pub total_ingested_transient_retries: IntCounterVec,
     pub total_ingested_not_found_retries: IntCounter,
-    pub total_ingested_permanent_errors: IntCounterVec,
     pub total_streamed_checkpoints: IntCounter,
     pub total_skipped_streamed_checkpoints: IntCounter,
     pub total_out_of_order_streamed_checkpoints: IntCounter,
@@ -79,6 +78,7 @@ pub struct IngestionMetrics {
 
     pub ingested_checkpoint_latency: Histogram,
     pub ingested_chain_id_latency: Histogram,
+    pub ingested_latest_checkpoint_latency: Histogram,
 
     pub ingestion_concurrency_limit: IntGauge,
     pub ingestion_concurrency_inflight: IntGauge,
@@ -206,8 +206,7 @@ impl IngestionMetrics {
             .unwrap(),
             total_ingested_bytes: register_int_counter_with_registry!(
                 name("total_ingested_bytes"),
-                "Total number of bytes fetched from the remote store, this metric will not \
-                be updated when data are fetched over gRPC.",
+                "Total number of bytes fetched from the remote store",
                 registry,
             )
             .unwrap(),
@@ -223,14 +222,6 @@ impl IngestionMetrics {
                 name("total_ingested_not_found_retries"),
                 "Total number of retries due to the not found errors while fetching data from the \
                  remote store",
-                registry,
-            )
-            .unwrap(),
-            total_ingested_permanent_errors: register_int_counter_vec_with_registry!(
-                name("total_ingested_permanent_errors"),
-                "Total number of permanent errors encountered while fetching data from the \
-                 remote store, which cause the ingestion service to shutdown",
-                &["reason"],
                 registry,
             )
             .unwrap(),
@@ -307,6 +298,13 @@ impl IngestionMetrics {
             ingested_chain_id_latency: register_histogram_with_registry!(
                 name("ingested_chain_id_latency"),
                 "Time taken to fetch the chain identifier, including retries",
+                INGESTION_LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            )
+            .unwrap(),
+            ingested_latest_checkpoint_latency: register_histogram_with_registry!(
+                name("ingested_latest_checkpoint_latency"),
+                "Time taken to fetch the latest checkpoint number, including retries",
                 INGESTION_LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
             )

--- a/crates/sui-indexer-alt-framework/src/pipeline/concurrent/mod.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/concurrent/mod.rs
@@ -554,22 +554,32 @@ mod tests {
             assert_eq!(data, vec![i * 10 + 1, i * 10 + 2]);
         }
 
-        // Wait for pruning to occur (5s + delay + processing time)
-        tokio::time::sleep(Duration::from_millis(5_200)).await;
+        // Wait for pruning to occur. The pruner and reader_watermark tasks both run on
+        // the same interval, so poll until the pruner has caught up rather instead of using a
+        // fixed sleep.
+        let pruning_deadline = Duration::from_secs(15);
+        let start = tokio::time::Instant::now();
+        loop {
+            let pruned = {
+                let data = setup.store.data.get(DataPipeline::NAME).unwrap();
+                !data.contains_key(&0) && !data.contains_key(&1) && !data.contains_key(&2)
+            };
+            if pruned {
+                break;
+            }
+            assert!(
+                start.elapsed() < pruning_deadline,
+                "Timed out waiting for pruning to occur"
+            );
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
 
-        // Verify pruning has occurred
+        // Verify recent checkpoints are still available
         {
             let data = setup.store.data.get(DataPipeline::NAME).unwrap();
-
-            // Verify recent checkpoints are still available
             assert!(data.contains_key(&3));
             assert!(data.contains_key(&4));
             assert!(data.contains_key(&5));
-
-            // Verify old checkpoints are pruned
-            assert!(!data.contains_key(&0));
-            assert!(!data.contains_key(&1));
-            assert!(!data.contains_key(&2));
         };
     }
 

--- a/crates/sui-rpc-api/src/grpc/v2/subscription_service.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/subscription_service.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::pin::Pin;
-
 use crate::RpcService;
 use mysten_common::ZipDebugEqIteratorExt;
 use sui_rpc::field::FieldMaskTree;
@@ -12,21 +10,14 @@ use sui_rpc::proto::sui::rpc::v2::SubscribeCheckpointsRequest;
 use sui_rpc::proto::sui::rpc::v2::SubscribeCheckpointsResponse;
 use sui_rpc::proto::sui::rpc::v2::subscription_service_server::SubscriptionService;
 use sui_types::balance_change::derive_balance_changes_2;
+use tonic::codegen::BoxStream;
 
 #[tonic::async_trait]
 impl SubscriptionService for RpcService {
-    /// Server streaming response type for the SubscribeCheckpoints method.
-    type SubscribeCheckpointsStream = Pin<
-        Box<
-            dyn tokio_stream::Stream<Item = Result<SubscribeCheckpointsResponse, tonic::Status>>
-                + Send,
-        >,
-    >;
-
     async fn subscribe_checkpoints(
         &self,
         request: tonic::Request<SubscribeCheckpointsRequest>,
-    ) -> Result<tonic::Response<Self::SubscribeCheckpointsStream>, tonic::Status> {
+    ) -> Result<tonic::Response<BoxStream<SubscribeCheckpointsResponse>>, tonic::Status> {
         let subscription_service_handle = self
             .subscription_service_handle
             .as_ref()

--- a/crates/sui-types/src/rpc_proto_conversions.rs
+++ b/crates/sui-types/src/rpc_proto_conversions.rs
@@ -3289,7 +3289,7 @@ impl From<crate::effects::AccumulatorWriteV1> for AccumulatorWrite {
             crate::effects::AccumulatorOperation::Split => AccumulatorOperation::Split,
         });
         match value.value {
-            crate::effects::AccumulatorValue::Integer(value) => message.set_value(value),
+            crate::effects::AccumulatorValue::Integer(value) => message.set_integer_value(value),
             //TODO unsupported value types
             crate::effects::AccumulatorValue::IntegerTuple(_, _)
             | crate::effects::AccumulatorValue::EventDigest(_) => {}

--- a/crates/sui-types/src/sui_sdk_types_conversions.rs
+++ b/crates/sui-types/src/sui_sdk_types_conversions.rs
@@ -659,9 +659,20 @@ impl From<crate::effects::AccumulatorWriteV1> for AccumulatorWrite {
             type_tag_core_to_sdk(value.address.ty).unwrap(),
             operation,
             match value.value {
-                crate::effects::AccumulatorValue::Integer(value) => value,
-                crate::effects::AccumulatorValue::IntegerTuple(_, _)
-                | crate::effects::AccumulatorValue::EventDigest(_) => todo!(),
+                crate::effects::AccumulatorValue::Integer(value) => {
+                    sui_sdk_types::AccumulatorValue::Integer(value)
+                }
+                crate::effects::AccumulatorValue::IntegerTuple(a, b) => {
+                    sui_sdk_types::AccumulatorValue::IntegerTuple(a, b)
+                }
+                crate::effects::AccumulatorValue::EventDigest(digests) => {
+                    sui_sdk_types::AccumulatorValue::EventDigest(
+                        digests
+                            .into_iter()
+                            .map(|(idx, digest)| (idx, digest.into()))
+                            .collect(),
+                    )
+                }
             },
         )
     }

--- a/examples/rust/walrus-attributes-indexer/src/handlers/blog_post.rs
+++ b/examples/rust/walrus-attributes-indexer/src/handlers/blog_post.rs
@@ -5,14 +5,13 @@ use std::collections::btree_map::Entry;
 use std::collections::{BTreeMap, HashSet};
 use std::sync::Arc;
 
-use anyhow::{self, Context, bail};
+use anyhow::{self, Context, Result, bail};
 use diesel::ExpressionMethods;
 use diesel::query_dsl::methods::FilterDsl;
 use diesel::upsert::excluded;
 use diesel_async::RunQueryDsl;
 use move_core_types::language_storage::StructTag;
 use sui_indexer_alt_framework::FieldCount;
-use sui_indexer_alt_framework::Result;
 use sui_indexer_alt_framework::pipeline::{Processor, sequential::Handler};
 use sui_indexer_alt_framework::postgres;
 use sui_indexer_alt_framework::types::base_types::{ObjectID, SequenceNumber, SuiAddress};


### PR DESCRIPTION
## Description 

**Commit 1:**

Adds back #26096 and #26116 which were reverted in #26188. 

**Commit 2:**

Specify `timeout` along with `connect_timeout` when creating the  gRPC client.
* `connect_timeout` only bounds the TCP/TLS handshake - the low-level socket connect. Once the TCP connection is established, `connect_timeout` has no further effect. The `subscribe_checkpoints` RPC is a separate HTTP/2 request sent over the already-established connection, so it's not covered by that setting. If a server accepts TCP, but stalls before sending response headers, the client hangs the indefinitely.
* `timeout` is the counterpart that bounds individual RPC calls on the channel.

**Commit 3:**

Include changes from #26182.


## Test plan 

Added new unit test to prove indexer does not hang during startup when streaming hangs.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
