### PR TITLE
[sui-tool] Fix validator connections in fetch-transaction

### DIFF
--- a/crates/sui-tool/src/lib.rs
+++ b/crates/sui-tool/src/lib.rs
@@ -103,7 +103,9 @@ async fn make_clients(
         .active_validators;
 
     for validator in active_validators {
-        let net_addr = Multiaddr::try_from(validator.net_address).unwrap();
+        let net_addr = Multiaddr::try_from(validator.net_address)
+            .unwrap()
+            .rewrite_http_to_https();
         let tls_config = sui_tls::create_rustls_client_config(
             sui_types::crypto::NetworkPublicKey::from_bytes(&validator.network_pubkey_bytes)?,
             sui_tls::SUI_VALIDATOR_SERVER_NAME.to_string(),


### PR DESCRIPTION
## Summary
- `sui-tool fetch-transaction` was unable to connect to any validators, failing instantly with "transport error: Unknown error"
- The `make_clients` function was not calling `.rewrite_http_to_https()` on validator network addresses before creating TLS channels. Since the hyper-rustls connector is configured with `https_only()`, the `http://` URIs derived from `/http` multiaddrs were rejected immediately.
- Added the missing `.rewrite_http_to_https()` call, matching what `make_network_authority_clients_with_network_config` in `sui-core/authority_client.rs` already does.

## Test plan
- [x] Ran `cargo run --bin sui-tool -- fetch-transaction --fullnode-rpc-url https://fullnode.mainnet.sui.io:443 --digest <digest>` against mainnet
- [x] Before fix: all ~120 validators fail in ~0.022s with "transport error: Unknown error"
- [x] After fix: ~120 validators connect successfully (0.3-1.0s response times), returning expected `TransactionNotFound` for pruned transactions

🤖 Generated with [Claude Code](https://claude.com/claude-code)