### PR TITLE
sui-indexer-alt-graphql: handle OutOfRange in watermark task

### DIFF
--- a/crates/sui-indexer-alt-graphql/src/task/watermark.rs
+++ b/crates/sui-indexer-alt-graphql/src/task/watermark.rs
@@ -519,13 +519,47 @@ async fn watermark_from_consistent(
         }
 
         Err(consistent_reader::Error::OutOfRange(status)) => {
-            let unknown = AsciiMetadataValue::from_static("<unknown>");
+            // The requested checkpoint is outside the consistent store's current
+            // range. This can happen after a deploy restarts the consistent store
+            // and its snapshot window hasn't expanded to cover the indexer DB's
+            // watermark yet. Instead of bailing (which causes the watermark task
+            // to skip the update entirely, leaving GraphQL stuck returning 500),
+            // retry with the consistent store's current max checkpoint.
+            if let Some(max_val) = status.metadata().get(CHECKPOINT_HEIGHT_METADATA)
+                && let Ok(max_cp) = max_val.to_str().unwrap_or("").parse::<u64>()
+            {
+                warn!(
+                    requested = checkpoint,
+                    consistent_max = max_cp,
+                    "Checkpoint out of consistent range, retrying with consistent store max"
+                );
+                if let Ok(AvailableRangeResponse {
+                    min_checkpoint: Some(min_checkpoint),
+                    max_checkpoint: Some(max_checkpoint),
+                    max_epoch: Some(max_epoch),
+                    total_transactions: Some(total_transactions),
+                    max_timestamp_ms: Some(max_timestamp_ms),
+                    stride: _,
+                }) = consistent_reader.available_range(max_cp).await
+                {
+                    return Ok(Some(WatermarkRow {
+                        pipeline: "consistent".to_owned(),
+                        epoch_hi_inclusive: max_epoch as i64,
+                        checkpoint_hi_inclusive: max_checkpoint as i64,
+                        tx_hi: total_transactions as i64,
+                        timestamp_ms_hi_inclusive: max_timestamp_ms as i64,
+                        epoch_lo: 0,
+                        checkpoint_lo: min_checkpoint as i64,
+                        tx_lo: 0,
+                    }));
+                }
+            }
 
+            let unknown = AsciiMetadataValue::from_static("<unknown>");
             let min = status
                 .metadata()
                 .get(LOWEST_AVAILABLE_CHECKPOINT_METADATA)
                 .unwrap_or(&unknown);
-
             let max = status
                 .metadata()
                 .get(CHECKPOINT_HEIGHT_METADATA)


### PR DESCRIPTION
## Description

Fix a bug where the GraphQL watermark task gets permanently stuck when the consistent store's snapshot window doesn't cover the indexer DB's checkpoint.

### The bug

In `watermark_from_consistent()`, when the consistent store returns `OutOfRange`, the function bails with an error. The caller (`WatermarkTask::run`) catches this error, logs a warning, and `continue`s — skipping the watermark update entirely. On the next poll (500ms later), the same thing happens. The watermark never gets updated, and the health endpoint's `checkpoint_lag_ms` grows at 1s/s until it hits the threshold and returns 500.

This requires a manual pod restart to recover — there is no self-healing.

### When it happens

After any deploy that restarts the consistent store. The snapshot window starts narrow and may not cover the indexer DB's latest checkpoint. The window eventually expands to cover it, but only after `snapshots / CPS` seconds (~2.9 hours with `snapshots=50000` on devnet).

On testnet/mainnet this is masked by snapshot restore (pre-populates the window) and 2 replicas (rolling updates keep one replica's window intact). But if both replicas ever restart simultaneously or snapshot restore fails, the same bug would hit production.

### The fix

When `OutOfRange` is returned, parse the consistent store's current `max_checkpoint` from the gRPC error metadata and retry `available_range` with that checkpoint. This gives GraphQL a valid (if slightly behind) consistent watermark instead of no watermark at all, allowing it to serve requests immediately.

The watermark will be at the consistent store's tip rather than the indexer DB's tip, so there may be a brief period where the consistent pipeline shows slightly higher lag than the other pipelines. This converges as the consistent store's window expands.

## Test plan

- [x] `cargo check -p sui-indexer-alt-graphql` passes
- [ ] CI
- [ ] Verify on devnet: after CI deploy restarts consistent-store, GraphQL should recover without manual intervention

@evan-wall-mysten @joeymeere for review — you know this code best.

🤖 Generated with [Claude Code](https://claude.com/claude-code)