### PR TITLE
Fix native call double-pop in gas meter stack height tracking

### DIFF
--- a/crates/sui-core/src/unit_tests/move_package_upgrade_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_package_upgrade_tests.rs
@@ -1155,6 +1155,7 @@ async fn test_upgrade_package_add_new_module_in_dep_only_mode_pre_v68() {
     // Allow new modules in deps-only mode for this test.
     let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
         config.set_execution_version_for_testing(3);
+        // set up config values that would otherwise be incompatible with the execution version
         config.set_gas_model_version_for_testing(11);
         config.set_disallow_new_modules_in_deps_only_packages_for_testing(false);
         config

--- a/crates/sui-core/src/unit_tests/move_package_upgrade_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_package_upgrade_tests.rs
@@ -1155,6 +1155,7 @@ async fn test_upgrade_package_add_new_module_in_dep_only_mode_pre_v68() {
     // Allow new modules in deps-only mode for this test.
     let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
         config.set_execution_version_for_testing(3);
+        config.set_gas_model_version_for_testing(11);
         config.set_disallow_new_modules_in_deps_only_packages_for_testing(false);
         config
     });

--- a/crates/sui-e2e-tests/tests/address_balance_tests.rs
+++ b/crates/sui-e2e-tests/tests/address_balance_tests.rs
@@ -653,6 +653,7 @@ async fn test_address_balance_gas_v3_accumulator_sign() {
         .with_proto_override_cb(Box::new(|_, mut cfg| {
             cfg.enable_address_balance_gas_payments_for_testing();
             cfg.set_execution_version_for_testing(3);
+            cfg.set_gas_model_version_for_testing(11);
             cfg
         }))
         .build()

--- a/crates/sui-e2e-tests/tests/address_balance_tests.rs
+++ b/crates/sui-e2e-tests/tests/address_balance_tests.rs
@@ -653,6 +653,7 @@ async fn test_address_balance_gas_v3_accumulator_sign() {
         .with_proto_override_cb(Box::new(|_, mut cfg| {
             cfg.enable_address_balance_gas_payments_for_testing();
             cfg.set_execution_version_for_testing(3);
+            // set up config values that would otherwise be incompatible with the execution version
             cfg.set_gas_model_version_for_testing(11);
             cfg
         }))

--- a/crates/sui-e2e-tests/tests/coin_registry_tests.rs
+++ b/crates/sui-e2e-tests/tests/coin_registry_tests.rs
@@ -12,6 +12,7 @@ async fn test_create_coin_registry_object() {
     let _guard =
         sui_protocol_config::ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
             config.set_execution_version_for_testing(3);
+            config.set_gas_model_version_for_testing(11);
             // The new consensus handler requires these flags, and they are irrelevant to the test
             config.set_ignore_execution_time_observations_after_certs_closed_for_testing(true);
             config.set_record_time_estimate_processed_for_testing(true);

--- a/crates/sui-e2e-tests/tests/coin_registry_tests.rs
+++ b/crates/sui-e2e-tests/tests/coin_registry_tests.rs
@@ -12,6 +12,7 @@ async fn test_create_coin_registry_object() {
     let _guard =
         sui_protocol_config::ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
             config.set_execution_version_for_testing(3);
+            // set up config values that would otherwise be incompatible with the execution version
             config.set_gas_model_version_for_testing(11);
             // The new consensus handler requires these flags, and they are irrelevant to the test
             config.set_ignore_execution_time_observations_after_certs_closed_for_testing(true);

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -324,6 +324,7 @@ const TESTNET_USDC: &str =
 //              Enable bulletproofs verification on devnet.
 //              Enable defer_unpaid_amplification on mainnet.
 // Version 123: Add timestamp_based_epoch_close feature flag and enable in tests.
+//              Fix native call double-pop in gas meter stack height tracking (gas_model v12).
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
@@ -4880,6 +4881,7 @@ impl ProtocolConfig {
                     if chain != Chain::Mainnet && chain != Chain::Testnet {
                         cfg.feature_flags.timestamp_based_epoch_close = true;
                     }
+                    cfg.gas_model_version = Some(12);
                 }
                 // Use this template when making changes:
                 //

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -28,7 +28,7 @@ use tracing::{info, warn};
 
 /// The minimum and maximum protocol versions supported by this build.
 const MIN_PROTOCOL_VERSION: u64 = 1;
-const MAX_PROTOCOL_VERSION: u64 = 122;
+const MAX_PROTOCOL_VERSION: u64 = 123;
 
 const TESTNET_USDC: &str =
     "0xa1ec7fc00a6f40db9693ad1415d0c193ad3906494428cf252621037bd7117e29::usdc::USDC";
@@ -317,6 +317,7 @@ const TESTNET_USDC: &str =
 // Version 120: Disallow unused jump tables
 // Version 121: Re-enable defer_unpaid_amplification (devnet + testnet).
 // Version 122: Framework update: vector::empty is deprecated.
+// Version 123: Fix native call double-pop in gas meter stack height tracking (gas_model v12).
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
@@ -4800,6 +4801,13 @@ impl ProtocolConfig {
                         .early_return_receive_object_mismatched_type = true;
                 }
                 122 => {}
+                123 => {
+                    // Fix native call double-pop in gas meter stack height tracking.
+                    // charge_native_function_before_execution was popping args that
+                    // charge_call already popped. The resulting negative heights were
+                    // masked by saturating_sub in pop_stack. Version 12 fixes this.
+                    cfg.gas_model_version = Some(12);
+                }
                 // Use this template when making changes:
                 //
                 //     // modify an existing constant.

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_123.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_123.snap
@@ -238,7 +238,7 @@ obj_access_cost_delete_per_byte: 40
 obj_access_cost_verify_per_byte: 200
 max_type_to_layout_nodes: 512
 max_ptb_value_size: 1048576
-gas_model_version: 11
+gas_model_version: 12
 obj_data_cost_refundable: 100
 obj_metadata_cost_non_refundable: 50
 storage_rebate_rate: 9900

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_123.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_123.snap
@@ -1,0 +1,677 @@
+---
+source: crates/sui-protocol-config/src/lib.rs
+expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
+---
+version: 123
+feature_flags:
+  package_upgrades: true
+  commit_root_state_digest: true
+  advance_epoch_start_time_in_safe_mode: true
+  loaded_child_objects_fixed: true
+  missing_type_is_compatibility_error: true
+  scoring_decision_with_validity_cutoff: true
+  consensus_order_end_of_epoch_last: true
+  disallow_adding_abilities_on_upgrade: true
+  disable_invariant_violation_check_in_swap_loc: true
+  advance_to_highest_supported_protocol_version: true
+  ban_entry_init: true
+  package_digest_hash_module: true
+  disallow_change_struct_type_params_on_upgrade: true
+  no_extraneous_module_bytes: true
+  narwhal_versioned_metadata: true
+  zklogin_auth: true
+  consensus_transaction_ordering: ByGasPrice
+  simplified_unwrap_then_delete: true
+  upgraded_multisig_supported: true
+  txn_base_cost_as_multiplier: true
+  shared_object_deletion: true
+  narwhal_new_leader_election_schedule: true
+  loaded_child_object_format: true
+  enable_jwk_consensus_updates: true
+  end_of_epoch_transaction_supported: true
+  simple_conservation_checks: true
+  loaded_child_object_format_type: true
+  receive_objects: true
+  consensus_checkpoint_signature_key_includes_digest: true
+  random_beacon: true
+  bridge: true
+  enable_effects_v2: true
+  narwhal_certificate_v2: true
+  verify_legacy_zklogin_address: true
+  recompute_has_public_transfer_in_execution: true
+  accept_zklogin_in_multisig: true
+  accept_passkey_in_multisig: true
+  validate_zklogin_public_identifier: true
+  include_consensus_digest_in_prologue: true
+  hardened_otw_check: true
+  allow_receiving_object_id: true
+  enable_poseidon: true
+  enable_coin_deny_list: true
+  enable_group_ops_native_functions: true
+  enable_nitro_attestation: true
+  enable_nitro_attestation_upgraded_parsing: true
+  enable_nitro_attestation_all_nonzero_pcrs_parsing: true
+  enable_nitro_attestation_always_include_required_pcrs_parsing: true
+  reject_mutable_random_on_entry_functions: true
+  per_object_congestion_control_mode:
+    ExecutionTimeEstimate:
+      target_utilization: 50
+      allowed_txn_cost_overage_burst_limit_us: 500000
+      randomness_scalar: 20
+      max_estimate_us: 1500000
+      stored_observations_num_included_checkpoints: 10
+      stored_observations_limit: 180
+      stake_weighted_median_threshold: 3334
+      default_none_duration_for_new_keys: true
+      observations_chunk_size: 18
+  consensus_choice: Mysticeti
+  consensus_network: Tonic
+  correct_gas_payment_limit_check: true
+  zklogin_max_epoch_upper_bound_delta: 30
+  mysticeti_leader_scoring_and_schedule: true
+  reshare_at_same_initial_version: true
+  resolve_abort_locations_to_package_id: true
+  mysticeti_use_committed_subdag_digest: true
+  record_consensus_determined_version_assignments_in_prologue: true
+  record_consensus_determined_version_assignments_in_prologue_v2: true
+  fresh_vm_on_framework_upgrade: true
+  prepend_prologue_tx_in_consensus_commit_in_checkpoints: true
+  mysticeti_num_leaders_per_round: 1
+  soft_bundle: true
+  enable_coin_deny_list_v2: true
+  passkey_auth: true
+  authority_capabilities_v2: true
+  rethrow_serialization_type_layout_errors: true
+  consensus_distributed_vote_scoring_strategy: true
+  consensus_round_prober: true
+  validate_identifier_inputs: true
+  disallow_self_identifier: true
+  mysticeti_fastpath: true
+  disable_preconsensus_locking: true
+  relocate_event_module: true
+  uncompressed_g1_group_elements: true
+  disallow_new_modules_in_deps_only_packages: true
+  consensus_smart_ancestor_selection: true
+  consensus_round_prober_probe_accepted_rounds: true
+  native_charging_v2: true
+  consensus_linearize_subdag_v2: true
+  convert_type_argument_error: true
+  variant_nodes: true
+  consensus_zstd_compression: true
+  minimize_child_object_mutations: true
+  record_additional_state_digest_in_prologue: true
+  move_native_context: true
+  consensus_median_based_commit_timestamp: true
+  normalize_ptb_arguments: true
+  consensus_batched_block_sync: true
+  enforce_checkpoint_timestamp_monotonicity: true
+  max_ptb_value_size_v2: true
+  resolve_type_input_ids_to_defining_id: true
+  enable_party_transfer: true
+  allow_unbounded_system_objects: true
+  type_tags_in_object_runtime: true
+  create_root_accumulator_object: true
+  address_balance_gas_check_rgp_at_signing: true
+  enable_multi_epoch_transaction_expiration: true
+  relax_valid_during_for_owned_inputs: true
+  enable_ptb_execution_v2: true
+  better_adapter_type_resolution_errors: true
+  record_time_estimate_processed: true
+  dependency_linkage_error: true
+  additional_multisig_checks: true
+  ignore_execution_time_observations_after_certs_closed: true
+  debug_fatal_on_move_invariant_violation: true
+  additional_consensus_digest_indirect_state: true
+  check_for_init_during_upgrade: true
+  use_mfp_txns_in_load_initial_object_debts: true
+  cancel_for_failed_dkg_early: true
+  enable_coin_registry: true
+  abstract_size_in_object_runtime: true
+  object_runtime_charge_cache_load_gas: true
+  additional_borrow_checks: true
+  use_new_commit_handler: true
+  better_loader_errors: true
+  generate_df_type_layouts: true
+  enable_display_registry: true
+  private_generics_verifier_v2: true
+  deprecate_global_storage_ops: true
+  normalize_depth_formula: true
+  consensus_skip_gced_accept_votes: true
+  include_cancelled_randomness_txns_in_prologue: true
+  address_aliases: true
+  fix_checkpoint_signature_mapping: true
+  consensus_skip_gced_blocks_in_direct_finalization: true
+  gas_rounding_halve_digits: true
+  flexible_tx_context_positions: true
+  disable_entry_point_signature_check: true
+  restrict_hot_or_not_entry_functions: true
+  consensus_always_accept_system_transactions: true
+  validator_metadata_verify_v2: true
+  randomize_checkpoint_tx_limit_in_tests: true
+  gasless_transaction_drop_safety: true
+  merge_randomness_into_checkpoint: true
+  use_coin_party_owner: true
+  disallow_jump_orphans: true
+  early_return_receive_object_mismatched_type: true
+max_tx_size_bytes: 131072
+max_input_objects: 2048
+max_size_written_objects: 5000000
+max_size_written_objects_system_tx: 50000000
+max_serialized_tx_effects_size_bytes: 524288
+max_serialized_tx_effects_size_bytes_system_tx: 8388608
+max_gas_payment_objects: 256
+max_modules_in_publish: 64
+max_package_dependencies: 32
+max_arguments: 512
+max_type_arguments: 16
+max_type_argument_depth: 16
+max_pure_argument_size: 16384
+max_programmable_tx_commands: 1024
+move_binary_format_version: 7
+min_move_binary_format_version: 6
+binary_module_handles: 100
+binary_struct_handles: 300
+binary_function_handles: 1500
+binary_function_instantiations: 750
+binary_signatures: 1000
+binary_constant_pool: 4000
+binary_identifiers: 10000
+binary_address_identifiers: 100
+binary_struct_defs: 200
+binary_struct_def_instantiations: 100
+binary_function_defs: 1000
+binary_field_handles: 500
+binary_field_instantiations: 250
+binary_friend_decls: 100
+binary_variant_handles: 1024
+binary_variant_instantiation_handles: 1024
+max_move_object_size: 256000
+max_move_package_size: 102400
+max_publish_or_upgrade_per_ptb: 5
+max_tx_gas: 50000000000000
+max_gas_price: 50000000000
+max_gas_price_rgp_factor_for_aborted_transactions: 100
+max_gas_computation_bucket: 5000000
+gas_rounding_step: 1000
+max_loop_depth: 5
+max_generic_instantiation_length: 32
+max_function_parameters: 128
+max_basic_blocks: 1024
+max_value_stack_size: 1024
+max_type_nodes: 256
+max_push_size: 10000
+max_struct_definitions: 200
+max_function_definitions: 1000
+max_fields_in_struct: 32
+max_dependency_depth: 100
+max_num_event_emit: 1024
+max_num_new_move_object_ids: 2048
+max_num_new_move_object_ids_system_tx: 32768
+max_num_deleted_move_object_ids: 2048
+max_num_deleted_move_object_ids_system_tx: 32768
+max_num_transferred_move_object_ids: 2048
+max_num_transferred_move_object_ids_system_tx: 32768
+max_event_emit_size: 256000
+max_event_emit_size_total: 65536000
+max_move_vector_len: 262144
+max_move_identifier_len: 128
+max_move_value_depth: 128
+max_move_enum_variants: 127
+max_back_edges_per_function: 10000
+max_back_edges_per_module: 10000
+max_verifier_meter_ticks_per_function: 16000000
+max_meter_ticks_per_module: 16000000
+max_meter_ticks_per_package: 16000000
+object_runtime_max_num_cached_objects: 1000
+object_runtime_max_num_cached_objects_system_tx: 16000
+object_runtime_max_num_store_entries: 1000
+object_runtime_max_num_store_entries_system_tx: 16000
+base_tx_cost_fixed: 1000
+package_publish_cost_fixed: 1000
+base_tx_cost_per_byte: 0
+package_publish_cost_per_byte: 80
+obj_access_cost_read_per_byte: 15
+obj_access_cost_mutate_per_byte: 40
+obj_access_cost_delete_per_byte: 40
+obj_access_cost_verify_per_byte: 200
+max_type_to_layout_nodes: 512
+max_ptb_value_size: 1048576
+gas_model_version: 12
+obj_data_cost_refundable: 100
+obj_metadata_cost_non_refundable: 50
+storage_rebate_rate: 9900
+storage_fund_reinvest_rate: 500
+reward_slashing_rate: 10000
+storage_gas_price: 76
+accumulator_object_storage_cost: 7600
+max_transactions_per_checkpoint: 20000
+max_checkpoint_size_bytes: 31457280
+buffer_stake_for_protocol_upgrade_bps: 5000
+address_from_bytes_cost_base: 52
+address_to_u256_cost_base: 52
+address_from_u256_cost_base: 52
+config_read_setting_impl_cost_base: 100
+config_read_setting_impl_cost_per_byte: 40
+dynamic_field_hash_type_and_key_cost_base: 52
+dynamic_field_hash_type_and_key_type_cost_per_byte: 2
+dynamic_field_hash_type_and_key_value_cost_per_byte: 2
+dynamic_field_hash_type_and_key_type_tag_cost_per_byte: 2
+dynamic_field_add_child_object_cost_base: 52
+dynamic_field_add_child_object_type_cost_per_byte: 10
+dynamic_field_add_child_object_value_cost_per_byte: 1
+dynamic_field_add_child_object_struct_tag_cost_per_byte: 10
+dynamic_field_borrow_child_object_cost_base: 52
+dynamic_field_borrow_child_object_child_ref_cost_per_byte: 1
+dynamic_field_borrow_child_object_type_cost_per_byte: 10
+dynamic_field_remove_child_object_cost_base: 52
+dynamic_field_remove_child_object_child_cost_per_byte: 1
+dynamic_field_remove_child_object_type_cost_per_byte: 2
+dynamic_field_has_child_object_cost_base: 52
+dynamic_field_has_child_object_with_ty_cost_base: 52
+dynamic_field_has_child_object_with_ty_type_cost_per_byte: 2
+dynamic_field_has_child_object_with_ty_type_tag_cost_per_byte: 2
+event_emit_cost_base: 52
+event_emit_value_size_derivation_cost_per_byte: 2
+event_emit_tag_size_derivation_cost_per_byte: 5
+event_emit_output_cost_per_byte: 10
+event_emit_auth_stream_cost: 52
+object_borrow_uid_cost_base: 52
+object_delete_impl_cost_base: 52
+object_record_new_uid_cost_base: 52
+transfer_transfer_internal_cost_base: 52
+transfer_party_transfer_internal_cost_base: 52
+transfer_freeze_object_cost_base: 52
+transfer_share_object_cost_base: 52
+transfer_receive_object_cost_base: 52
+transfer_receive_object_cost_per_byte: 1
+transfer_receive_object_type_cost_per_byte: 2
+tx_context_derive_id_cost_base: 52
+tx_context_fresh_id_cost_base: 52
+tx_context_sender_cost_base: 30
+tx_context_epoch_cost_base: 30
+tx_context_epoch_timestamp_ms_cost_base: 30
+tx_context_sponsor_cost_base: 30
+tx_context_rgp_cost_base: 30
+tx_context_gas_price_cost_base: 30
+tx_context_gas_budget_cost_base: 30
+tx_context_ids_created_cost_base: 30
+tx_context_replace_cost_base: 30
+types_is_one_time_witness_cost_base: 52
+types_is_one_time_witness_type_tag_cost_per_byte: 2
+types_is_one_time_witness_type_cost_per_byte: 2
+validator_validate_metadata_cost_base: 20000
+validator_validate_metadata_data_cost_per_byte: 2
+crypto_invalid_arguments_cost: 100
+bls12381_bls12381_min_sig_verify_cost_base: 44064
+bls12381_bls12381_min_sig_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_sig_verify_msg_cost_per_block: 2
+bls12381_bls12381_min_pk_verify_cost_base: 49282
+bls12381_bls12381_min_pk_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_pk_verify_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_keccak256_cost_base: 500
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_sha256_cost_base: 500
+ecdsa_k1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_k1_decompress_pubkey_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_cost_base: 1470
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_k1_secp256k1_verify_sha256_cost_base: 1470
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_keccak256_cost_base: 1173
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_sha256_cost_base: 1173
+ecdsa_r1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_keccak256_cost_base: 4225
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_sha256_cost_base: 4225
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_block: 2
+ecvrf_ecvrf_verify_cost_base: 4848
+ecvrf_ecvrf_verify_alpha_string_cost_per_byte: 2
+ecvrf_ecvrf_verify_alpha_string_cost_per_block: 2
+ed25519_ed25519_verify_cost_base: 1802
+ed25519_ed25519_verify_msg_cost_per_byte: 2
+ed25519_ed25519_verify_msg_cost_per_block: 2
+groth16_prepare_verifying_key_bls12381_cost_base: 53838
+groth16_prepare_verifying_key_bn254_cost_base: 82010
+groth16_verify_groth16_proof_internal_bls12381_cost_base: 72090
+groth16_verify_groth16_proof_internal_bls12381_cost_per_public_input: 8213
+groth16_verify_groth16_proof_internal_bn254_cost_base: 115502
+groth16_verify_groth16_proof_internal_bn254_cost_per_public_input: 9484
+groth16_verify_groth16_proof_internal_public_input_cost_per_byte: 2
+hash_blake2b256_cost_base: 10
+hash_blake2b256_data_cost_per_byte: 2
+hash_blake2b256_data_cost_per_block: 2
+hash_keccak256_cost_base: 10
+hash_keccak256_data_cost_per_byte: 2
+hash_keccak256_data_cost_per_block: 2
+poseidon_bn254_cost_base: 260
+poseidon_bn254_cost_per_block: 388
+group_ops_bls12381_decode_scalar_cost: 7
+group_ops_bls12381_decode_g1_cost: 2848
+group_ops_bls12381_decode_g2_cost: 3770
+group_ops_bls12381_decode_gt_cost: 3068
+group_ops_bls12381_scalar_add_cost: 10
+group_ops_bls12381_g1_add_cost: 1556
+group_ops_bls12381_g2_add_cost: 3048
+group_ops_bls12381_gt_add_cost: 188
+group_ops_bls12381_scalar_sub_cost: 10
+group_ops_bls12381_g1_sub_cost: 1550
+group_ops_bls12381_g2_sub_cost: 3019
+group_ops_bls12381_gt_sub_cost: 497
+group_ops_bls12381_scalar_mul_cost: 11
+group_ops_bls12381_g1_mul_cost: 4842
+group_ops_bls12381_g2_mul_cost: 9108
+group_ops_bls12381_gt_mul_cost: 27490
+group_ops_bls12381_scalar_div_cost: 91
+group_ops_bls12381_g1_div_cost: 5091
+group_ops_bls12381_g2_div_cost: 9206
+group_ops_bls12381_gt_div_cost: 27804
+group_ops_bls12381_g1_hash_to_base_cost: 2962
+group_ops_bls12381_g2_hash_to_base_cost: 8688
+group_ops_bls12381_g1_hash_to_cost_per_byte: 2
+group_ops_bls12381_g2_hash_to_cost_per_byte: 2
+group_ops_bls12381_g1_msm_base_cost: 62648
+group_ops_bls12381_g2_msm_base_cost: 131192
+group_ops_bls12381_g1_msm_base_cost_per_input: 1333
+group_ops_bls12381_g2_msm_base_cost_per_input: 3216
+group_ops_bls12381_msm_max_len: 32
+group_ops_bls12381_pairing_cost: 26897
+group_ops_bls12381_g1_to_uncompressed_g1_cost: 2099
+group_ops_bls12381_uncompressed_g1_to_g1_cost: 677
+group_ops_bls12381_uncompressed_g1_sum_base_cost: 77
+group_ops_bls12381_uncompressed_g1_sum_cost_per_term: 26
+group_ops_bls12381_uncompressed_g1_sum_max_terms: 1200
+group_ops_ristretto_decode_scalar_cost: 7
+group_ops_ristretto_decode_point_cost: 200
+group_ops_ristretto_scalar_add_cost: 10
+group_ops_ristretto_point_add_cost: 500
+group_ops_ristretto_scalar_sub_cost: 10
+group_ops_ristretto_point_sub_cost: 500
+group_ops_ristretto_scalar_mul_cost: 11
+group_ops_ristretto_point_mul_cost: 1200
+group_ops_ristretto_scalar_div_cost: 151
+group_ops_ristretto_point_div_cost: 2500
+hmac_hmac_sha3_256_cost_base: 52
+hmac_hmac_sha3_256_input_cost_per_byte: 2
+hmac_hmac_sha3_256_input_cost_per_block: 2
+check_zklogin_id_cost_base: 200
+check_zklogin_issuer_cost_base: 200
+nitro_attestation_parse_base_cost: 2650
+nitro_attestation_parse_cost_per_byte: 50
+nitro_attestation_verify_base_cost: 2481600
+nitro_attestation_verify_cost_per_cert: 2618450
+bcs_per_byte_serialized_cost: 2
+bcs_legacy_min_output_size_cost: 1
+bcs_failure_cost: 52
+hash_sha2_256_base_cost: 52
+hash_sha2_256_per_byte_cost: 2
+hash_sha2_256_legacy_min_input_len_cost: 1
+hash_sha3_256_base_cost: 52
+hash_sha3_256_per_byte_cost: 2
+hash_sha3_256_legacy_min_input_len_cost: 1
+type_name_get_base_cost: 52
+type_name_get_per_byte_cost: 2
+type_name_id_base_cost: 52
+string_check_utf8_base_cost: 52
+string_check_utf8_per_byte_cost: 2
+string_is_char_boundary_base_cost: 52
+string_sub_string_base_cost: 52
+string_sub_string_per_byte_cost: 2
+string_index_of_base_cost: 52
+string_index_of_per_byte_pattern_cost: 2
+string_index_of_per_byte_searched_cost: 2
+vector_empty_base_cost: 52
+vector_length_base_cost: 52
+vector_push_back_base_cost: 52
+vector_push_back_legacy_per_abstract_memory_unit_cost: 2
+vector_borrow_base_cost: 52
+vector_pop_back_base_cost: 52
+vector_destroy_empty_base_cost: 52
+vector_swap_base_cost: 52
+debug_print_base_cost: 52
+debug_print_stack_trace_base_cost: 52
+execution_version: 4
+consensus_bad_nodes_stake_threshold: 30
+max_jwk_votes_per_validator_per_epoch: 240
+max_age_of_jwk_in_epochs: 1
+random_beacon_reduction_allowed_delta: 800
+random_beacon_reduction_lower_bound: 500
+random_beacon_dkg_timeout_round: 3000
+random_beacon_min_round_interval_ms: 500
+random_beacon_dkg_version: 1
+consensus_max_transaction_size_bytes: 262144
+consensus_max_transactions_in_block_bytes: 524288
+consensus_max_num_transactions_in_block: 512
+consensus_voting_rounds: 40
+max_accumulated_txn_cost_per_object_in_narwhal_commit: 40
+max_deferral_rounds_for_congestion_control: 10
+max_txn_cost_overage_per_object_in_commit: 18446744073709551615
+allowed_txn_cost_overage_burst_per_object_in_commit: 370000000
+min_checkpoint_interval_ms: 200
+checkpoint_summary_version_specific_data: 1
+max_soft_bundle_size: 5
+bridge_should_try_to_finalize_committee: true
+max_accumulated_txn_cost_per_object_in_mysticeti_commit: 37000000
+max_accumulated_randomness_txn_cost_per_object_in_mysticeti_commit: 7400000
+consensus_gc_depth: 60
+gas_budget_based_txn_cost_cap_factor: 400000
+gas_budget_based_txn_cost_absolute_cap_commit_count: 50
+sip_45_consensus_amplification_threshold: 5
+use_object_per_epoch_marker_table_v2: true
+consensus_commit_rate_estimation_window_size: 10
+aliased_addresses:
+  - original:
+      - 205
+      - 137
+      - 98
+      - 218
+      - 210
+      - 120
+      - 216
+      - 181
+      - 15
+      - 160
+      - 249
+      - 235
+      - 1
+      - 134
+      - 191
+      - 164
+      - 203
+      - 222
+      - 204
+      - 109
+      - 89
+      - 55
+      - 114
+      - 20
+      - 200
+      - 141
+      - 2
+      - 134
+      - 160
+      - 172
+      - 149
+      - 98
+    aliased:
+      - 11
+      - 45
+      - 163
+      - 39
+      - 186
+      - 106
+      - 76
+      - 172
+      - 190
+      - 117
+      - 221
+      - 221
+      - 80
+      - 230
+      - 232
+      - 187
+      - 248
+      - 29
+      - 100
+      - 150
+      - 233
+      - 45
+      - 102
+      - 175
+      - 145
+      - 84
+      - 198
+      - 28
+      - 119
+      - 247
+      - 51
+      - 47
+    allowed_tx_digests:
+      - - 2
+        - 145
+        - 170
+        - 78
+        - 99
+        - 246
+        - 130
+        - 221
+        - 11
+        - 53
+        - 228
+        - 241
+        - 202
+        - 113
+        - 56
+        - 105
+        - 120
+        - 236
+        - 143
+        - 114
+        - 165
+        - 106
+        - 212
+        - 165
+        - 196
+        - 178
+        - 239
+        - 253
+        - 97
+        - 66
+        - 98
+        - 197
+  - original:
+      - 226
+      - 139
+      - 80
+      - 206
+      - 241
+      - 214
+      - 51
+      - 234
+      - 67
+      - 211
+      - 41
+      - 106
+      - 63
+      - 107
+      - 103
+      - 255
+      - 3
+      - 18
+      - 165
+      - 241
+      - 169
+      - 159
+      - 10
+      - 247
+      - 83
+      - 200
+      - 91
+      - 139
+      - 93
+      - 232
+      - 255
+      - 6
+    aliased:
+      - 11
+      - 45
+      - 163
+      - 39
+      - 186
+      - 106
+      - 76
+      - 172
+      - 190
+      - 117
+      - 221
+      - 221
+      - 80
+      - 230
+      - 232
+      - 187
+      - 248
+      - 29
+      - 100
+      - 150
+      - 233
+      - 45
+      - 102
+      - 175
+      - 145
+      - 84
+      - 198
+      - 28
+      - 119
+      - 247
+      - 51
+      - 47
+    allowed_tx_digests:
+      - - 253
+        - 118
+        - 94
+        - 221
+        - 205
+        - 105
+        - 164
+        - 185
+        - 146
+        - 65
+        - 207
+        - 179
+        - 194
+        - 136
+        - 51
+        - 126
+        - 222
+        - 28
+        - 78
+        - 230
+        - 151
+        - 0
+        - 147
+        - 120
+        - 44
+        - 55
+        - 155
+        - 111
+        - 243
+        - 35
+        - 173
+        - 119
+translation_per_command_base_charge: 1
+translation_per_input_base_charge: 1
+translation_pure_input_per_byte_charge: 1
+translation_per_type_node_charge: 1
+translation_per_reference_node_charge: 1
+translation_per_linkage_entry_charge: 10
+max_updates_per_settlement_txn: 100
+gasless_max_unused_inputs: 1
+gasless_max_pure_input_bytes: 32

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_123.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_123.snap
@@ -247,7 +247,7 @@ obj_access_cost_delete_per_byte: 40
 obj_access_cost_verify_per_byte: 200
 max_type_to_layout_nodes: 512
 max_ptb_value_size: 1048576
-gas_model_version: 11
+gas_model_version: 12
 obj_data_cost_refundable: 100
 obj_metadata_cost_non_refundable: 50
 storage_rebate_rate: 9900

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_123.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_123.snap
@@ -1,0 +1,493 @@
+---
+source: crates/sui-protocol-config/src/lib.rs
+expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
+---
+version: 123
+feature_flags:
+  package_upgrades: true
+  commit_root_state_digest: true
+  advance_epoch_start_time_in_safe_mode: true
+  loaded_child_objects_fixed: true
+  missing_type_is_compatibility_error: true
+  scoring_decision_with_validity_cutoff: true
+  consensus_order_end_of_epoch_last: true
+  disallow_adding_abilities_on_upgrade: true
+  disable_invariant_violation_check_in_swap_loc: true
+  advance_to_highest_supported_protocol_version: true
+  ban_entry_init: true
+  package_digest_hash_module: true
+  disallow_change_struct_type_params_on_upgrade: true
+  no_extraneous_module_bytes: true
+  narwhal_versioned_metadata: true
+  zklogin_auth: true
+  consensus_transaction_ordering: ByGasPrice
+  simplified_unwrap_then_delete: true
+  upgraded_multisig_supported: true
+  txn_base_cost_as_multiplier: true
+  shared_object_deletion: true
+  narwhal_new_leader_election_schedule: true
+  loaded_child_object_format: true
+  enable_jwk_consensus_updates: true
+  end_of_epoch_transaction_supported: true
+  simple_conservation_checks: true
+  loaded_child_object_format_type: true
+  receive_objects: true
+  consensus_checkpoint_signature_key_includes_digest: true
+  random_beacon: true
+  bridge: true
+  enable_effects_v2: true
+  narwhal_certificate_v2: true
+  verify_legacy_zklogin_address: true
+  recompute_has_public_transfer_in_execution: true
+  accept_zklogin_in_multisig: true
+  accept_passkey_in_multisig: true
+  validate_zklogin_public_identifier: true
+  include_consensus_digest_in_prologue: true
+  hardened_otw_check: true
+  allow_receiving_object_id: true
+  enable_poseidon: true
+  enable_coin_deny_list: true
+  enable_group_ops_native_functions: true
+  enable_nitro_attestation: true
+  enable_nitro_attestation_upgraded_parsing: true
+  enable_nitro_attestation_all_nonzero_pcrs_parsing: true
+  enable_nitro_attestation_always_include_required_pcrs_parsing: true
+  reject_mutable_random_on_entry_functions: true
+  per_object_congestion_control_mode:
+    ExecutionTimeEstimate:
+      target_utilization: 50
+      allowed_txn_cost_overage_burst_limit_us: 500000
+      randomness_scalar: 20
+      max_estimate_us: 1500000
+      stored_observations_num_included_checkpoints: 10
+      stored_observations_limit: 180
+      stake_weighted_median_threshold: 3334
+      default_none_duration_for_new_keys: true
+      observations_chunk_size: 18
+  consensus_choice: Mysticeti
+  consensus_network: Tonic
+  correct_gas_payment_limit_check: true
+  zklogin_max_epoch_upper_bound_delta: 30
+  mysticeti_leader_scoring_and_schedule: true
+  reshare_at_same_initial_version: true
+  resolve_abort_locations_to_package_id: true
+  mysticeti_use_committed_subdag_digest: true
+  record_consensus_determined_version_assignments_in_prologue: true
+  record_consensus_determined_version_assignments_in_prologue_v2: true
+  fresh_vm_on_framework_upgrade: true
+  prepend_prologue_tx_in_consensus_commit_in_checkpoints: true
+  mysticeti_num_leaders_per_round: 1
+  soft_bundle: true
+  enable_coin_deny_list_v2: true
+  passkey_auth: true
+  authority_capabilities_v2: true
+  rethrow_serialization_type_layout_errors: true
+  consensus_distributed_vote_scoring_strategy: true
+  consensus_round_prober: true
+  validate_identifier_inputs: true
+  disallow_self_identifier: true
+  mysticeti_fastpath: true
+  disable_preconsensus_locking: true
+  relocate_event_module: true
+  uncompressed_g1_group_elements: true
+  disallow_new_modules_in_deps_only_packages: true
+  consensus_smart_ancestor_selection: true
+  consensus_round_prober_probe_accepted_rounds: true
+  native_charging_v2: true
+  consensus_linearize_subdag_v2: true
+  convert_type_argument_error: true
+  variant_nodes: true
+  consensus_zstd_compression: true
+  minimize_child_object_mutations: true
+  record_additional_state_digest_in_prologue: true
+  move_native_context: true
+  consensus_median_based_commit_timestamp: true
+  normalize_ptb_arguments: true
+  consensus_batched_block_sync: true
+  enforce_checkpoint_timestamp_monotonicity: true
+  max_ptb_value_size_v2: true
+  resolve_type_input_ids_to_defining_id: true
+  enable_party_transfer: true
+  allow_unbounded_system_objects: true
+  type_tags_in_object_runtime: true
+  enable_accumulators: true
+  enable_coin_reservation_obj_refs: true
+  create_root_accumulator_object: true
+  enable_authenticated_event_streams: true
+  enable_address_balance_gas_payments: true
+  address_balance_gas_check_rgp_at_signing: true
+  enable_multi_epoch_transaction_expiration: true
+  relax_valid_during_for_owned_inputs: true
+  enable_ptb_execution_v2: true
+  better_adapter_type_resolution_errors: true
+  record_time_estimate_processed: true
+  dependency_linkage_error: true
+  additional_multisig_checks: true
+  ignore_execution_time_observations_after_certs_closed: true
+  debug_fatal_on_move_invariant_violation: true
+  additional_consensus_digest_indirect_state: true
+  check_for_init_during_upgrade: true
+  include_checkpoint_artifacts_digest_in_summary: true
+  use_mfp_txns_in_load_initial_object_debts: true
+  cancel_for_failed_dkg_early: true
+  enable_coin_registry: true
+  abstract_size_in_object_runtime: true
+  object_runtime_charge_cache_load_gas: true
+  additional_borrow_checks: true
+  use_new_commit_handler: true
+  better_loader_errors: true
+  generate_df_type_layouts: true
+  enable_display_registry: true
+  private_generics_verifier_v2: true
+  deprecate_global_storage_ops: true
+  normalize_depth_formula: true
+  consensus_skip_gced_accept_votes: true
+  include_cancelled_randomness_txns_in_prologue: true
+  address_aliases: true
+  fix_checkpoint_signature_mapping: true
+  enable_object_funds_withdraw: true
+  consensus_skip_gced_blocks_in_direct_finalization: true
+  gas_rounding_halve_digits: true
+  flexible_tx_context_positions: true
+  disable_entry_point_signature_check: true
+  convert_withdrawal_compatibility_ptb_arguments: true
+  restrict_hot_or_not_entry_functions: true
+  split_checkpoints_in_consensus_handler: true
+  consensus_always_accept_system_transactions: true
+  validator_metadata_verify_v2: true
+  defer_unpaid_amplification: true
+  randomize_checkpoint_tx_limit_in_tests: true
+  gasless_transaction_drop_safety: true
+  merge_randomness_into_checkpoint: true
+  use_coin_party_owner: true
+  enable_gasless: true
+  disallow_jump_orphans: true
+  early_return_receive_object_mismatched_type: true
+max_tx_size_bytes: 131072
+max_input_objects: 2048
+max_size_written_objects: 5000000
+max_size_written_objects_system_tx: 50000000
+max_serialized_tx_effects_size_bytes: 524288
+max_serialized_tx_effects_size_bytes_system_tx: 8388608
+max_gas_payment_objects: 256
+max_modules_in_publish: 64
+max_package_dependencies: 32
+max_arguments: 512
+max_type_arguments: 16
+max_type_argument_depth: 16
+max_pure_argument_size: 16384
+max_programmable_tx_commands: 1024
+move_binary_format_version: 7
+min_move_binary_format_version: 6
+binary_module_handles: 100
+binary_struct_handles: 300
+binary_function_handles: 1500
+binary_function_instantiations: 750
+binary_signatures: 1000
+binary_constant_pool: 4000
+binary_identifiers: 10000
+binary_address_identifiers: 100
+binary_struct_defs: 200
+binary_struct_def_instantiations: 100
+binary_function_defs: 1000
+binary_field_handles: 500
+binary_field_instantiations: 250
+binary_friend_decls: 100
+binary_variant_handles: 1024
+binary_variant_instantiation_handles: 1024
+max_move_object_size: 256000
+max_move_package_size: 102400
+max_publish_or_upgrade_per_ptb: 5
+max_tx_gas: 50000000000000
+max_gas_price: 50000000000
+max_gas_price_rgp_factor_for_aborted_transactions: 100
+max_gas_computation_bucket: 5000000
+gas_rounding_step: 1000
+max_loop_depth: 5
+max_generic_instantiation_length: 32
+max_function_parameters: 128
+max_basic_blocks: 1024
+max_value_stack_size: 1024
+max_type_nodes: 256
+max_push_size: 10000
+max_struct_definitions: 200
+max_function_definitions: 1000
+max_fields_in_struct: 32
+max_dependency_depth: 100
+max_num_event_emit: 1024
+max_num_new_move_object_ids: 2048
+max_num_new_move_object_ids_system_tx: 32768
+max_num_deleted_move_object_ids: 2048
+max_num_deleted_move_object_ids_system_tx: 32768
+max_num_transferred_move_object_ids: 2048
+max_num_transferred_move_object_ids_system_tx: 32768
+max_event_emit_size: 256000
+max_event_emit_size_total: 65536000
+max_move_vector_len: 262144
+max_move_identifier_len: 128
+max_move_value_depth: 128
+max_move_enum_variants: 127
+max_back_edges_per_function: 10000
+max_back_edges_per_module: 10000
+max_verifier_meter_ticks_per_function: 16000000
+max_meter_ticks_per_module: 16000000
+max_meter_ticks_per_package: 16000000
+object_runtime_max_num_cached_objects: 1000
+object_runtime_max_num_cached_objects_system_tx: 16000
+object_runtime_max_num_store_entries: 1000
+object_runtime_max_num_store_entries_system_tx: 16000
+base_tx_cost_fixed: 1000
+package_publish_cost_fixed: 1000
+base_tx_cost_per_byte: 0
+package_publish_cost_per_byte: 80
+obj_access_cost_read_per_byte: 15
+obj_access_cost_mutate_per_byte: 40
+obj_access_cost_delete_per_byte: 40
+obj_access_cost_verify_per_byte: 200
+max_type_to_layout_nodes: 512
+max_ptb_value_size: 1048576
+gas_model_version: 12
+obj_data_cost_refundable: 100
+obj_metadata_cost_non_refundable: 50
+storage_rebate_rate: 9900
+storage_fund_reinvest_rate: 500
+reward_slashing_rate: 10000
+storage_gas_price: 76
+accumulator_object_storage_cost: 7600
+max_transactions_per_checkpoint: 20000
+max_checkpoint_size_bytes: 31457280
+buffer_stake_for_protocol_upgrade_bps: 5000
+address_from_bytes_cost_base: 52
+address_to_u256_cost_base: 52
+address_from_u256_cost_base: 52
+config_read_setting_impl_cost_base: 100
+config_read_setting_impl_cost_per_byte: 40
+dynamic_field_hash_type_and_key_cost_base: 52
+dynamic_field_hash_type_and_key_type_cost_per_byte: 2
+dynamic_field_hash_type_and_key_value_cost_per_byte: 2
+dynamic_field_hash_type_and_key_type_tag_cost_per_byte: 2
+dynamic_field_add_child_object_cost_base: 52
+dynamic_field_add_child_object_type_cost_per_byte: 10
+dynamic_field_add_child_object_value_cost_per_byte: 1
+dynamic_field_add_child_object_struct_tag_cost_per_byte: 10
+dynamic_field_borrow_child_object_cost_base: 52
+dynamic_field_borrow_child_object_child_ref_cost_per_byte: 1
+dynamic_field_borrow_child_object_type_cost_per_byte: 10
+dynamic_field_remove_child_object_cost_base: 52
+dynamic_field_remove_child_object_child_cost_per_byte: 1
+dynamic_field_remove_child_object_type_cost_per_byte: 2
+dynamic_field_has_child_object_cost_base: 52
+dynamic_field_has_child_object_with_ty_cost_base: 52
+dynamic_field_has_child_object_with_ty_type_cost_per_byte: 2
+dynamic_field_has_child_object_with_ty_type_tag_cost_per_byte: 2
+event_emit_cost_base: 52
+event_emit_value_size_derivation_cost_per_byte: 2
+event_emit_tag_size_derivation_cost_per_byte: 5
+event_emit_output_cost_per_byte: 10
+event_emit_auth_stream_cost: 52
+object_borrow_uid_cost_base: 52
+object_delete_impl_cost_base: 52
+object_record_new_uid_cost_base: 52
+transfer_transfer_internal_cost_base: 52
+transfer_party_transfer_internal_cost_base: 52
+transfer_freeze_object_cost_base: 52
+transfer_share_object_cost_base: 52
+transfer_receive_object_cost_base: 52
+transfer_receive_object_cost_per_byte: 1
+transfer_receive_object_type_cost_per_byte: 2
+tx_context_derive_id_cost_base: 52
+tx_context_fresh_id_cost_base: 52
+tx_context_sender_cost_base: 30
+tx_context_epoch_cost_base: 30
+tx_context_epoch_timestamp_ms_cost_base: 30
+tx_context_sponsor_cost_base: 30
+tx_context_rgp_cost_base: 30
+tx_context_gas_price_cost_base: 30
+tx_context_gas_budget_cost_base: 30
+tx_context_ids_created_cost_base: 30
+tx_context_replace_cost_base: 30
+types_is_one_time_witness_cost_base: 52
+types_is_one_time_witness_type_tag_cost_per_byte: 2
+types_is_one_time_witness_type_cost_per_byte: 2
+validator_validate_metadata_cost_base: 20000
+validator_validate_metadata_data_cost_per_byte: 2
+crypto_invalid_arguments_cost: 100
+bls12381_bls12381_min_sig_verify_cost_base: 44064
+bls12381_bls12381_min_sig_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_sig_verify_msg_cost_per_block: 2
+bls12381_bls12381_min_pk_verify_cost_base: 49282
+bls12381_bls12381_min_pk_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_pk_verify_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_keccak256_cost_base: 500
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_sha256_cost_base: 500
+ecdsa_k1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_k1_decompress_pubkey_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_cost_base: 1470
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_k1_secp256k1_verify_sha256_cost_base: 1470
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_keccak256_cost_base: 1173
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_sha256_cost_base: 1173
+ecdsa_r1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_keccak256_cost_base: 4225
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_sha256_cost_base: 4225
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_block: 2
+ecvrf_ecvrf_verify_cost_base: 4848
+ecvrf_ecvrf_verify_alpha_string_cost_per_byte: 2
+ecvrf_ecvrf_verify_alpha_string_cost_per_block: 2
+ed25519_ed25519_verify_cost_base: 1802
+ed25519_ed25519_verify_msg_cost_per_byte: 2
+ed25519_ed25519_verify_msg_cost_per_block: 2
+groth16_prepare_verifying_key_bls12381_cost_base: 53838
+groth16_prepare_verifying_key_bn254_cost_base: 82010
+groth16_verify_groth16_proof_internal_bls12381_cost_base: 72090
+groth16_verify_groth16_proof_internal_bls12381_cost_per_public_input: 8213
+groth16_verify_groth16_proof_internal_bn254_cost_base: 115502
+groth16_verify_groth16_proof_internal_bn254_cost_per_public_input: 9484
+groth16_verify_groth16_proof_internal_public_input_cost_per_byte: 2
+hash_blake2b256_cost_base: 10
+hash_blake2b256_data_cost_per_byte: 2
+hash_blake2b256_data_cost_per_block: 2
+hash_keccak256_cost_base: 10
+hash_keccak256_data_cost_per_byte: 2
+hash_keccak256_data_cost_per_block: 2
+poseidon_bn254_cost_base: 260
+poseidon_bn254_cost_per_block: 388
+group_ops_bls12381_decode_scalar_cost: 7
+group_ops_bls12381_decode_g1_cost: 2848
+group_ops_bls12381_decode_g2_cost: 3770
+group_ops_bls12381_decode_gt_cost: 3068
+group_ops_bls12381_scalar_add_cost: 10
+group_ops_bls12381_g1_add_cost: 1556
+group_ops_bls12381_g2_add_cost: 3048
+group_ops_bls12381_gt_add_cost: 188
+group_ops_bls12381_scalar_sub_cost: 10
+group_ops_bls12381_g1_sub_cost: 1550
+group_ops_bls12381_g2_sub_cost: 3019
+group_ops_bls12381_gt_sub_cost: 497
+group_ops_bls12381_scalar_mul_cost: 11
+group_ops_bls12381_g1_mul_cost: 4842
+group_ops_bls12381_g2_mul_cost: 9108
+group_ops_bls12381_gt_mul_cost: 27490
+group_ops_bls12381_scalar_div_cost: 91
+group_ops_bls12381_g1_div_cost: 5091
+group_ops_bls12381_g2_div_cost: 9206
+group_ops_bls12381_gt_div_cost: 27804
+group_ops_bls12381_g1_hash_to_base_cost: 2962
+group_ops_bls12381_g2_hash_to_base_cost: 8688
+group_ops_bls12381_g1_hash_to_cost_per_byte: 2
+group_ops_bls12381_g2_hash_to_cost_per_byte: 2
+group_ops_bls12381_g1_msm_base_cost: 62648
+group_ops_bls12381_g2_msm_base_cost: 131192
+group_ops_bls12381_g1_msm_base_cost_per_input: 1333
+group_ops_bls12381_g2_msm_base_cost_per_input: 3216
+group_ops_bls12381_msm_max_len: 32
+group_ops_bls12381_pairing_cost: 26897
+group_ops_bls12381_g1_to_uncompressed_g1_cost: 2099
+group_ops_bls12381_uncompressed_g1_to_g1_cost: 677
+group_ops_bls12381_uncompressed_g1_sum_base_cost: 77
+group_ops_bls12381_uncompressed_g1_sum_cost_per_term: 26
+group_ops_bls12381_uncompressed_g1_sum_max_terms: 1200
+group_ops_ristretto_decode_scalar_cost: 7
+group_ops_ristretto_decode_point_cost: 200
+group_ops_ristretto_scalar_add_cost: 10
+group_ops_ristretto_point_add_cost: 500
+group_ops_ristretto_scalar_sub_cost: 10
+group_ops_ristretto_point_sub_cost: 500
+group_ops_ristretto_scalar_mul_cost: 11
+group_ops_ristretto_point_mul_cost: 1200
+group_ops_ristretto_scalar_div_cost: 151
+group_ops_ristretto_point_div_cost: 2500
+hmac_hmac_sha3_256_cost_base: 52
+hmac_hmac_sha3_256_input_cost_per_byte: 2
+hmac_hmac_sha3_256_input_cost_per_block: 2
+check_zklogin_id_cost_base: 200
+check_zklogin_issuer_cost_base: 200
+nitro_attestation_parse_base_cost: 2650
+nitro_attestation_parse_cost_per_byte: 50
+nitro_attestation_verify_base_cost: 2481600
+nitro_attestation_verify_cost_per_cert: 2618450
+bcs_per_byte_serialized_cost: 2
+bcs_legacy_min_output_size_cost: 1
+bcs_failure_cost: 52
+hash_sha2_256_base_cost: 52
+hash_sha2_256_per_byte_cost: 2
+hash_sha2_256_legacy_min_input_len_cost: 1
+hash_sha3_256_base_cost: 52
+hash_sha3_256_per_byte_cost: 2
+hash_sha3_256_legacy_min_input_len_cost: 1
+type_name_get_base_cost: 52
+type_name_get_per_byte_cost: 2
+type_name_id_base_cost: 52
+string_check_utf8_base_cost: 52
+string_check_utf8_per_byte_cost: 2
+string_is_char_boundary_base_cost: 52
+string_sub_string_base_cost: 52
+string_sub_string_per_byte_cost: 2
+string_index_of_base_cost: 52
+string_index_of_per_byte_pattern_cost: 2
+string_index_of_per_byte_searched_cost: 2
+vector_empty_base_cost: 52
+vector_length_base_cost: 52
+vector_push_back_base_cost: 52
+vector_push_back_legacy_per_abstract_memory_unit_cost: 2
+vector_borrow_base_cost: 52
+vector_pop_back_base_cost: 52
+vector_destroy_empty_base_cost: 52
+vector_swap_base_cost: 52
+debug_print_base_cost: 52
+debug_print_stack_trace_base_cost: 52
+execution_version: 4
+consensus_bad_nodes_stake_threshold: 30
+max_jwk_votes_per_validator_per_epoch: 240
+max_age_of_jwk_in_epochs: 1
+random_beacon_reduction_allowed_delta: 800
+random_beacon_reduction_lower_bound: 500
+random_beacon_dkg_timeout_round: 3000
+random_beacon_min_round_interval_ms: 500
+random_beacon_dkg_version: 1
+consensus_max_transaction_size_bytes: 262144
+consensus_max_transactions_in_block_bytes: 524288
+consensus_max_num_transactions_in_block: 512
+consensus_voting_rounds: 40
+max_accumulated_txn_cost_per_object_in_narwhal_commit: 40
+max_deferral_rounds_for_congestion_control: 10
+max_txn_cost_overage_per_object_in_commit: 18446744073709551615
+allowed_txn_cost_overage_burst_per_object_in_commit: 370000000
+min_checkpoint_interval_ms: 200
+checkpoint_summary_version_specific_data: 1
+max_soft_bundle_size: 5
+bridge_should_try_to_finalize_committee: true
+max_accumulated_txn_cost_per_object_in_mysticeti_commit: 37000000
+max_accumulated_randomness_txn_cost_per_object_in_mysticeti_commit: 7400000
+consensus_gc_depth: 60
+gas_budget_based_txn_cost_cap_factor: 400000
+gas_budget_based_txn_cost_absolute_cap_commit_count: 50
+sip_45_consensus_amplification_threshold: 5
+use_object_per_epoch_marker_table_v2: true
+consensus_commit_rate_estimation_window_size: 10
+translation_per_command_base_charge: 1
+translation_per_input_base_charge: 1
+translation_pure_input_per_byte_charge: 1
+translation_per_type_node_charge: 1
+translation_per_reference_node_charge: 1
+translation_per_linkage_entry_charge: 10
+max_updates_per_settlement_txn: 100
+gasless_max_computation_units: 50000
+gasless_allowed_token_types:
+  - - "0xa1ec7fc00a6f40db9693ad1415d0c193ad3906494428cf252621037bd7117e29::usdc::USDC"
+    - 0
+gasless_max_unused_inputs: 1
+gasless_max_pure_input_bytes: 32
+gasless_max_tps: 50

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_123.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_123.snap
@@ -252,7 +252,7 @@ obj_access_cost_delete_per_byte: 40
 obj_access_cost_verify_per_byte: 200
 max_type_to_layout_nodes: 512
 max_ptb_value_size: 1048576
-gas_model_version: 11
+gas_model_version: 12
 obj_data_cost_refundable: 100
 obj_metadata_cost_non_refundable: 50
 storage_rebate_rate: 9900

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_123.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_123.snap
@@ -1,0 +1,496 @@
+---
+source: crates/sui-protocol-config/src/lib.rs
+expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
+---
+version: 123
+feature_flags:
+  package_upgrades: true
+  commit_root_state_digest: true
+  advance_epoch_start_time_in_safe_mode: true
+  loaded_child_objects_fixed: true
+  missing_type_is_compatibility_error: true
+  scoring_decision_with_validity_cutoff: true
+  consensus_order_end_of_epoch_last: true
+  disallow_adding_abilities_on_upgrade: true
+  disable_invariant_violation_check_in_swap_loc: true
+  advance_to_highest_supported_protocol_version: true
+  ban_entry_init: true
+  package_digest_hash_module: true
+  disallow_change_struct_type_params_on_upgrade: true
+  no_extraneous_module_bytes: true
+  narwhal_versioned_metadata: true
+  zklogin_auth: true
+  consensus_transaction_ordering: ByGasPrice
+  simplified_unwrap_then_delete: true
+  upgraded_multisig_supported: true
+  txn_base_cost_as_multiplier: true
+  shared_object_deletion: true
+  narwhal_new_leader_election_schedule: true
+  loaded_child_object_format: true
+  enable_jwk_consensus_updates: true
+  end_of_epoch_transaction_supported: true
+  simple_conservation_checks: true
+  loaded_child_object_format_type: true
+  receive_objects: true
+  consensus_checkpoint_signature_key_includes_digest: true
+  random_beacon: true
+  bridge: true
+  enable_effects_v2: true
+  narwhal_certificate_v2: true
+  verify_legacy_zklogin_address: true
+  recompute_has_public_transfer_in_execution: true
+  accept_zklogin_in_multisig: true
+  accept_passkey_in_multisig: true
+  validate_zklogin_public_identifier: true
+  include_consensus_digest_in_prologue: true
+  hardened_otw_check: true
+  allow_receiving_object_id: true
+  enable_poseidon: true
+  enable_coin_deny_list: true
+  enable_group_ops_native_functions: true
+  enable_group_ops_native_function_msm: true
+  enable_ristretto255_group_ops: true
+  enable_nitro_attestation: true
+  enable_nitro_attestation_upgraded_parsing: true
+  enable_nitro_attestation_all_nonzero_pcrs_parsing: true
+  enable_nitro_attestation_always_include_required_pcrs_parsing: true
+  reject_mutable_random_on_entry_functions: true
+  per_object_congestion_control_mode:
+    ExecutionTimeEstimate:
+      target_utilization: 50
+      allowed_txn_cost_overage_burst_limit_us: 500000
+      randomness_scalar: 20
+      max_estimate_us: 1500000
+      stored_observations_num_included_checkpoints: 10
+      stored_observations_limit: 180
+      stake_weighted_median_threshold: 3334
+      default_none_duration_for_new_keys: true
+      observations_chunk_size: 18
+  consensus_choice: Mysticeti
+  consensus_network: Tonic
+  correct_gas_payment_limit_check: true
+  zklogin_max_epoch_upper_bound_delta: 30
+  mysticeti_leader_scoring_and_schedule: true
+  reshare_at_same_initial_version: true
+  resolve_abort_locations_to_package_id: true
+  mysticeti_use_committed_subdag_digest: true
+  enable_vdf: true
+  record_consensus_determined_version_assignments_in_prologue: true
+  record_consensus_determined_version_assignments_in_prologue_v2: true
+  fresh_vm_on_framework_upgrade: true
+  prepend_prologue_tx_in_consensus_commit_in_checkpoints: true
+  mysticeti_num_leaders_per_round: 1
+  soft_bundle: true
+  enable_coin_deny_list_v2: true
+  passkey_auth: true
+  authority_capabilities_v2: true
+  rethrow_serialization_type_layout_errors: true
+  consensus_distributed_vote_scoring_strategy: true
+  consensus_round_prober: true
+  validate_identifier_inputs: true
+  disallow_self_identifier: true
+  mysticeti_fastpath: true
+  disable_preconsensus_locking: true
+  relocate_event_module: true
+  uncompressed_g1_group_elements: true
+  disallow_new_modules_in_deps_only_packages: true
+  consensus_smart_ancestor_selection: true
+  consensus_round_prober_probe_accepted_rounds: true
+  native_charging_v2: true
+  consensus_linearize_subdag_v2: true
+  convert_type_argument_error: true
+  variant_nodes: true
+  consensus_zstd_compression: true
+  minimize_child_object_mutations: true
+  record_additional_state_digest_in_prologue: true
+  move_native_context: true
+  consensus_median_based_commit_timestamp: true
+  normalize_ptb_arguments: true
+  consensus_batched_block_sync: true
+  enforce_checkpoint_timestamp_monotonicity: true
+  max_ptb_value_size_v2: true
+  resolve_type_input_ids_to_defining_id: true
+  enable_party_transfer: true
+  allow_unbounded_system_objects: true
+  type_tags_in_object_runtime: true
+  enable_accumulators: true
+  enable_coin_reservation_obj_refs: true
+  create_root_accumulator_object: true
+  enable_authenticated_event_streams: true
+  enable_address_balance_gas_payments: true
+  address_balance_gas_check_rgp_at_signing: true
+  enable_multi_epoch_transaction_expiration: true
+  relax_valid_during_for_owned_inputs: true
+  enable_ptb_execution_v2: true
+  better_adapter_type_resolution_errors: true
+  record_time_estimate_processed: true
+  dependency_linkage_error: true
+  additional_multisig_checks: true
+  ignore_execution_time_observations_after_certs_closed: true
+  debug_fatal_on_move_invariant_violation: true
+  additional_consensus_digest_indirect_state: true
+  check_for_init_during_upgrade: true
+  include_checkpoint_artifacts_digest_in_summary: true
+  use_mfp_txns_in_load_initial_object_debts: true
+  cancel_for_failed_dkg_early: true
+  enable_coin_registry: true
+  abstract_size_in_object_runtime: true
+  object_runtime_charge_cache_load_gas: true
+  additional_borrow_checks: true
+  use_new_commit_handler: true
+  better_loader_errors: true
+  generate_df_type_layouts: true
+  enable_display_registry: true
+  private_generics_verifier_v2: true
+  deprecate_global_storage_ops: true
+  normalize_depth_formula: true
+  consensus_skip_gced_accept_votes: true
+  include_cancelled_randomness_txns_in_prologue: true
+  address_aliases: true
+  fix_checkpoint_signature_mapping: true
+  enable_object_funds_withdraw: true
+  consensus_skip_gced_blocks_in_direct_finalization: true
+  gas_rounding_halve_digits: true
+  flexible_tx_context_positions: true
+  disable_entry_point_signature_check: true
+  convert_withdrawal_compatibility_ptb_arguments: true
+  restrict_hot_or_not_entry_functions: true
+  split_checkpoints_in_consensus_handler: true
+  consensus_always_accept_system_transactions: true
+  validator_metadata_verify_v2: true
+  defer_unpaid_amplification: true
+  randomize_checkpoint_tx_limit_in_tests: true
+  gasless_transaction_drop_safety: true
+  merge_randomness_into_checkpoint: true
+  use_coin_party_owner: true
+  enable_gasless: true
+  disallow_jump_orphans: true
+  early_return_receive_object_mismatched_type: true
+max_tx_size_bytes: 131072
+max_input_objects: 2048
+max_size_written_objects: 5000000
+max_size_written_objects_system_tx: 50000000
+max_serialized_tx_effects_size_bytes: 524288
+max_serialized_tx_effects_size_bytes_system_tx: 8388608
+max_gas_payment_objects: 256
+max_modules_in_publish: 64
+max_package_dependencies: 32
+max_arguments: 512
+max_type_arguments: 16
+max_type_argument_depth: 16
+max_pure_argument_size: 16384
+max_programmable_tx_commands: 1024
+move_binary_format_version: 7
+min_move_binary_format_version: 6
+binary_module_handles: 100
+binary_struct_handles: 300
+binary_function_handles: 1500
+binary_function_instantiations: 750
+binary_signatures: 1000
+binary_constant_pool: 4000
+binary_identifiers: 10000
+binary_address_identifiers: 100
+binary_struct_defs: 200
+binary_struct_def_instantiations: 100
+binary_function_defs: 1000
+binary_field_handles: 500
+binary_field_instantiations: 250
+binary_friend_decls: 100
+binary_variant_handles: 1024
+binary_variant_instantiation_handles: 1024
+max_move_object_size: 256000
+max_move_package_size: 102400
+max_publish_or_upgrade_per_ptb: 5
+max_tx_gas: 50000000000000
+max_gas_price: 50000000000
+max_gas_price_rgp_factor_for_aborted_transactions: 100
+max_gas_computation_bucket: 5000000
+gas_rounding_step: 1000
+max_loop_depth: 5
+max_generic_instantiation_length: 32
+max_function_parameters: 128
+max_basic_blocks: 1024
+max_value_stack_size: 1024
+max_type_nodes: 256
+max_push_size: 10000
+max_struct_definitions: 200
+max_function_definitions: 1000
+max_fields_in_struct: 32
+max_dependency_depth: 100
+max_num_event_emit: 1024
+max_num_new_move_object_ids: 2048
+max_num_new_move_object_ids_system_tx: 32768
+max_num_deleted_move_object_ids: 2048
+max_num_deleted_move_object_ids_system_tx: 32768
+max_num_transferred_move_object_ids: 2048
+max_num_transferred_move_object_ids_system_tx: 32768
+max_event_emit_size: 256000
+max_event_emit_size_total: 65536000
+max_move_vector_len: 262144
+max_move_identifier_len: 128
+max_move_value_depth: 128
+max_move_enum_variants: 127
+max_back_edges_per_function: 10000
+max_back_edges_per_module: 10000
+max_verifier_meter_ticks_per_function: 16000000
+max_meter_ticks_per_module: 16000000
+max_meter_ticks_per_package: 16000000
+object_runtime_max_num_cached_objects: 1000
+object_runtime_max_num_cached_objects_system_tx: 16000
+object_runtime_max_num_store_entries: 1000
+object_runtime_max_num_store_entries_system_tx: 16000
+base_tx_cost_fixed: 1000
+package_publish_cost_fixed: 1000
+base_tx_cost_per_byte: 0
+package_publish_cost_per_byte: 80
+obj_access_cost_read_per_byte: 15
+obj_access_cost_mutate_per_byte: 40
+obj_access_cost_delete_per_byte: 40
+obj_access_cost_verify_per_byte: 200
+max_type_to_layout_nodes: 512
+max_ptb_value_size: 1048576
+gas_model_version: 12
+obj_data_cost_refundable: 100
+obj_metadata_cost_non_refundable: 50
+storage_rebate_rate: 9900
+storage_fund_reinvest_rate: 500
+reward_slashing_rate: 10000
+storage_gas_price: 76
+accumulator_object_storage_cost: 7600
+max_transactions_per_checkpoint: 20000
+max_checkpoint_size_bytes: 31457280
+buffer_stake_for_protocol_upgrade_bps: 5000
+address_from_bytes_cost_base: 52
+address_to_u256_cost_base: 52
+address_from_u256_cost_base: 52
+config_read_setting_impl_cost_base: 100
+config_read_setting_impl_cost_per_byte: 40
+dynamic_field_hash_type_and_key_cost_base: 52
+dynamic_field_hash_type_and_key_type_cost_per_byte: 2
+dynamic_field_hash_type_and_key_value_cost_per_byte: 2
+dynamic_field_hash_type_and_key_type_tag_cost_per_byte: 2
+dynamic_field_add_child_object_cost_base: 52
+dynamic_field_add_child_object_type_cost_per_byte: 10
+dynamic_field_add_child_object_value_cost_per_byte: 1
+dynamic_field_add_child_object_struct_tag_cost_per_byte: 10
+dynamic_field_borrow_child_object_cost_base: 52
+dynamic_field_borrow_child_object_child_ref_cost_per_byte: 1
+dynamic_field_borrow_child_object_type_cost_per_byte: 10
+dynamic_field_remove_child_object_cost_base: 52
+dynamic_field_remove_child_object_child_cost_per_byte: 1
+dynamic_field_remove_child_object_type_cost_per_byte: 2
+dynamic_field_has_child_object_cost_base: 52
+dynamic_field_has_child_object_with_ty_cost_base: 52
+dynamic_field_has_child_object_with_ty_type_cost_per_byte: 2
+dynamic_field_has_child_object_with_ty_type_tag_cost_per_byte: 2
+event_emit_cost_base: 52
+event_emit_value_size_derivation_cost_per_byte: 2
+event_emit_tag_size_derivation_cost_per_byte: 5
+event_emit_output_cost_per_byte: 10
+event_emit_auth_stream_cost: 52
+object_borrow_uid_cost_base: 52
+object_delete_impl_cost_base: 52
+object_record_new_uid_cost_base: 52
+transfer_transfer_internal_cost_base: 52
+transfer_party_transfer_internal_cost_base: 52
+transfer_freeze_object_cost_base: 52
+transfer_share_object_cost_base: 52
+transfer_receive_object_cost_base: 52
+transfer_receive_object_cost_per_byte: 1
+transfer_receive_object_type_cost_per_byte: 2
+tx_context_derive_id_cost_base: 52
+tx_context_fresh_id_cost_base: 52
+tx_context_sender_cost_base: 30
+tx_context_epoch_cost_base: 30
+tx_context_epoch_timestamp_ms_cost_base: 30
+tx_context_sponsor_cost_base: 30
+tx_context_rgp_cost_base: 30
+tx_context_gas_price_cost_base: 30
+tx_context_gas_budget_cost_base: 30
+tx_context_ids_created_cost_base: 30
+tx_context_replace_cost_base: 30
+types_is_one_time_witness_cost_base: 52
+types_is_one_time_witness_type_tag_cost_per_byte: 2
+types_is_one_time_witness_type_cost_per_byte: 2
+validator_validate_metadata_cost_base: 20000
+validator_validate_metadata_data_cost_per_byte: 2
+crypto_invalid_arguments_cost: 100
+bls12381_bls12381_min_sig_verify_cost_base: 44064
+bls12381_bls12381_min_sig_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_sig_verify_msg_cost_per_block: 2
+bls12381_bls12381_min_pk_verify_cost_base: 49282
+bls12381_bls12381_min_pk_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_pk_verify_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_keccak256_cost_base: 500
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_sha256_cost_base: 500
+ecdsa_k1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_k1_decompress_pubkey_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_cost_base: 1470
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_k1_secp256k1_verify_sha256_cost_base: 1470
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_keccak256_cost_base: 1173
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_sha256_cost_base: 1173
+ecdsa_r1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_keccak256_cost_base: 4225
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_sha256_cost_base: 4225
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_block: 2
+ecvrf_ecvrf_verify_cost_base: 4848
+ecvrf_ecvrf_verify_alpha_string_cost_per_byte: 2
+ecvrf_ecvrf_verify_alpha_string_cost_per_block: 2
+ed25519_ed25519_verify_cost_base: 1802
+ed25519_ed25519_verify_msg_cost_per_byte: 2
+ed25519_ed25519_verify_msg_cost_per_block: 2
+groth16_prepare_verifying_key_bls12381_cost_base: 53838
+groth16_prepare_verifying_key_bn254_cost_base: 82010
+groth16_verify_groth16_proof_internal_bls12381_cost_base: 72090
+groth16_verify_groth16_proof_internal_bls12381_cost_per_public_input: 8213
+groth16_verify_groth16_proof_internal_bn254_cost_base: 115502
+groth16_verify_groth16_proof_internal_bn254_cost_per_public_input: 9484
+groth16_verify_groth16_proof_internal_public_input_cost_per_byte: 2
+hash_blake2b256_cost_base: 10
+hash_blake2b256_data_cost_per_byte: 2
+hash_blake2b256_data_cost_per_block: 2
+hash_keccak256_cost_base: 10
+hash_keccak256_data_cost_per_byte: 2
+hash_keccak256_data_cost_per_block: 2
+poseidon_bn254_cost_base: 260
+poseidon_bn254_cost_per_block: 388
+group_ops_bls12381_decode_scalar_cost: 7
+group_ops_bls12381_decode_g1_cost: 2848
+group_ops_bls12381_decode_g2_cost: 3770
+group_ops_bls12381_decode_gt_cost: 3068
+group_ops_bls12381_scalar_add_cost: 10
+group_ops_bls12381_g1_add_cost: 1556
+group_ops_bls12381_g2_add_cost: 3048
+group_ops_bls12381_gt_add_cost: 188
+group_ops_bls12381_scalar_sub_cost: 10
+group_ops_bls12381_g1_sub_cost: 1550
+group_ops_bls12381_g2_sub_cost: 3019
+group_ops_bls12381_gt_sub_cost: 497
+group_ops_bls12381_scalar_mul_cost: 11
+group_ops_bls12381_g1_mul_cost: 4842
+group_ops_bls12381_g2_mul_cost: 9108
+group_ops_bls12381_gt_mul_cost: 27490
+group_ops_bls12381_scalar_div_cost: 91
+group_ops_bls12381_g1_div_cost: 5091
+group_ops_bls12381_g2_div_cost: 9206
+group_ops_bls12381_gt_div_cost: 27804
+group_ops_bls12381_g1_hash_to_base_cost: 2962
+group_ops_bls12381_g2_hash_to_base_cost: 8688
+group_ops_bls12381_g1_hash_to_cost_per_byte: 2
+group_ops_bls12381_g2_hash_to_cost_per_byte: 2
+group_ops_bls12381_g1_msm_base_cost: 62648
+group_ops_bls12381_g2_msm_base_cost: 131192
+group_ops_bls12381_g1_msm_base_cost_per_input: 1333
+group_ops_bls12381_g2_msm_base_cost_per_input: 3216
+group_ops_bls12381_msm_max_len: 32
+group_ops_bls12381_pairing_cost: 26897
+group_ops_bls12381_g1_to_uncompressed_g1_cost: 2099
+group_ops_bls12381_uncompressed_g1_to_g1_cost: 677
+group_ops_bls12381_uncompressed_g1_sum_base_cost: 77
+group_ops_bls12381_uncompressed_g1_sum_cost_per_term: 26
+group_ops_bls12381_uncompressed_g1_sum_max_terms: 1200
+group_ops_ristretto_decode_scalar_cost: 7
+group_ops_ristretto_decode_point_cost: 200
+group_ops_ristretto_scalar_add_cost: 10
+group_ops_ristretto_point_add_cost: 500
+group_ops_ristretto_scalar_sub_cost: 10
+group_ops_ristretto_point_sub_cost: 500
+group_ops_ristretto_scalar_mul_cost: 11
+group_ops_ristretto_point_mul_cost: 1200
+group_ops_ristretto_scalar_div_cost: 151
+group_ops_ristretto_point_div_cost: 2500
+hmac_hmac_sha3_256_cost_base: 52
+hmac_hmac_sha3_256_input_cost_per_byte: 2
+hmac_hmac_sha3_256_input_cost_per_block: 2
+check_zklogin_id_cost_base: 200
+check_zklogin_issuer_cost_base: 200
+vdf_verify_vdf_cost: 1500
+vdf_hash_to_input_cost: 100
+nitro_attestation_parse_base_cost: 2650
+nitro_attestation_parse_cost_per_byte: 50
+nitro_attestation_verify_base_cost: 2481600
+nitro_attestation_verify_cost_per_cert: 2618450
+bcs_per_byte_serialized_cost: 2
+bcs_legacy_min_output_size_cost: 1
+bcs_failure_cost: 52
+hash_sha2_256_base_cost: 52
+hash_sha2_256_per_byte_cost: 2
+hash_sha2_256_legacy_min_input_len_cost: 1
+hash_sha3_256_base_cost: 52
+hash_sha3_256_per_byte_cost: 2
+hash_sha3_256_legacy_min_input_len_cost: 1
+type_name_get_base_cost: 52
+type_name_get_per_byte_cost: 2
+type_name_id_base_cost: 52
+string_check_utf8_base_cost: 52
+string_check_utf8_per_byte_cost: 2
+string_is_char_boundary_base_cost: 52
+string_sub_string_base_cost: 52
+string_sub_string_per_byte_cost: 2
+string_index_of_base_cost: 52
+string_index_of_per_byte_pattern_cost: 2
+string_index_of_per_byte_searched_cost: 2
+vector_empty_base_cost: 52
+vector_length_base_cost: 52
+vector_push_back_base_cost: 52
+vector_push_back_legacy_per_abstract_memory_unit_cost: 2
+vector_borrow_base_cost: 52
+vector_pop_back_base_cost: 52
+vector_destroy_empty_base_cost: 52
+vector_swap_base_cost: 52
+debug_print_base_cost: 52
+debug_print_stack_trace_base_cost: 52
+execution_version: 4
+consensus_bad_nodes_stake_threshold: 30
+max_jwk_votes_per_validator_per_epoch: 240
+max_age_of_jwk_in_epochs: 1
+random_beacon_reduction_allowed_delta: 800
+random_beacon_reduction_lower_bound: 500
+random_beacon_dkg_timeout_round: 3000
+random_beacon_min_round_interval_ms: 500
+random_beacon_dkg_version: 1
+consensus_max_transaction_size_bytes: 262144
+consensus_max_transactions_in_block_bytes: 524288
+consensus_max_num_transactions_in_block: 512
+consensus_voting_rounds: 40
+max_accumulated_txn_cost_per_object_in_narwhal_commit: 40
+max_deferral_rounds_for_congestion_control: 10
+max_txn_cost_overage_per_object_in_commit: 18446744073709551615
+allowed_txn_cost_overage_burst_per_object_in_commit: 370000000
+min_checkpoint_interval_ms: 200
+checkpoint_summary_version_specific_data: 1
+max_soft_bundle_size: 5
+bridge_should_try_to_finalize_committee: true
+max_accumulated_txn_cost_per_object_in_mysticeti_commit: 37000000
+max_accumulated_randomness_txn_cost_per_object_in_mysticeti_commit: 7400000
+consensus_gc_depth: 60
+gas_budget_based_txn_cost_cap_factor: 400000
+gas_budget_based_txn_cost_absolute_cap_commit_count: 50
+sip_45_consensus_amplification_threshold: 5
+use_object_per_epoch_marker_table_v2: true
+consensus_commit_rate_estimation_window_size: 10
+translation_per_command_base_charge: 1
+translation_per_input_base_charge: 1
+translation_pure_input_per_byte_charge: 1
+translation_per_type_node_charge: 1
+translation_per_reference_node_charge: 1
+translation_per_linkage_entry_charge: 10
+max_updates_per_settlement_txn: 100
+gasless_max_computation_units: 50000
+gasless_allowed_token_types: []
+gasless_max_unused_inputs: 1
+gasless_max_pure_input_bytes: 32
+gasless_max_tps: 50

--- a/crates/sui-types/src/gas_model/gas_predicates.rs
+++ b/crates/sui-types/src/gas_model/gas_predicates.rs
@@ -63,6 +63,15 @@ pub fn cost_table_for_version(gas_model: u64) -> CostTable {
     }
 }
 
+// In gas model versions <= 11, charge_native_function_before_execution pops
+// args that were already popped by charge_call — a double-pop. The resulting
+// negative stack heights were masked by saturating_sub in pop_stack.
+// Version 12+ fixes the double-pop so charge_native_function_before_execution
+// no longer pops args.
+pub fn legacy_charge_native_pops_args(gas_model_version: u64) -> bool {
+    gas_model_version <= 11
+}
+
 // Return if the native function call threshold is exceeded
 pub fn native_function_threshold_exceeded(gas_model_version: u64, num_native_calls: u64) -> bool {
     if gas_model_version > 8 {

--- a/crates/sui-types/src/gas_model/gas_predicates.rs
+++ b/crates/sui-types/src/gas_model/gas_predicates.rs
@@ -63,6 +63,15 @@ pub fn cost_table_for_version(gas_model: u64) -> CostTable {
     }
 }
 
+// In gas model versions <= 11, charge_native_function_before_execution pops
+// args that were already popped by charge_call — a double-pop. The resulting
+// negative stack heights were masked by saturating_sub in pop_stack.
+// Version 12+ fixes the double-pop so charge_native_function_before_execution
+// no longer pops args.
+pub fn fix_native_double_pop(gas_model_version: u64) -> bool {
+    gas_model_version > 11
+}
+
 // Return if the native function call threshold is exceeded
 pub fn native_function_threshold_exceeded(gas_model_version: u64, num_native_calls: u64) -> bool {
     if gas_model_version > 8 {

--- a/crates/sui-types/src/gas_model/tables.rs
+++ b/crates/sui-types/src/gas_model/tables.rs
@@ -1,9 +1,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use super::gas_predicates::charge_input_as_memory;
+use super::gas_predicates::{charge_input_as_memory, legacy_charge_native_pops_args};
 use crate::gas_model::units_types::{CostTable, Gas, GasCost};
 use move_binary_format::errors::{PartialVMError, PartialVMResult};
+use mysten_common::debug_fatal;
 
 use move_core_types::gas_algebra::{AbstractMemorySize, InternalGas};
 
@@ -168,7 +169,24 @@ impl GasStatus {
     }
 
     pub fn pop_stack(&mut self, pops: u64) {
-        self.stack_height_current = self.stack_height_current.saturating_sub(pops);
+        // Underflow is expected when charge_native still pops args (legacy
+        // double-pop). Otherwise — i.e., gas_model_version > 11 where the
+        // native-call double-pop fix is in effect — it indicates a real bug.
+        // debug_fatal! panics in debug and logs an error + bumps the
+        // system_invariant_violations metric in release.
+        self.stack_height_current = match self.stack_height_current.checked_sub(pops) {
+            Some(stack_height) => stack_height,
+            None if legacy_charge_native_pops_args(self.gas_model_version) => 0,
+            None => {
+                debug_fatal!(
+                    "stack height underflow: current={}, pops={}. \
+                     This indicates a double-pop or missing push in the gas meter.",
+                    self.stack_height_current,
+                    pops
+                );
+                0
+            }
+        };
     }
 
     pub fn increase_instruction_count(&mut self, amount: u64) -> PartialVMResult<()> {

--- a/crates/sui-types/src/gas_model/tables.rs
+++ b/crates/sui-types/src/gas_model/tables.rs
@@ -231,14 +231,6 @@ impl GasStatus {
         Ok(())
     }
 
-    pub fn decrease_stack_size(&mut self, size_amount: u64) {
-        let new_size = self.stack_size_current.saturating_sub(size_amount);
-        if new_size > self.stack_size_high_water_mark {
-            self.stack_size_high_water_mark = new_size;
-        }
-        self.stack_size_current = new_size;
-    }
-
     /// Given: pushes + pops + increase + decrease in size for an instruction charge for the
     /// execution of the instruction.
     pub fn charge(
@@ -268,7 +260,6 @@ impl GasStatus {
             .total_internal(),
         )?;
 
-        // self.decrease_stack_size(decr_size);
         self.pop_stack(pops);
         Ok(())
     }

--- a/crates/sui-types/src/gas_model/tables.rs
+++ b/crates/sui-types/src/gas_model/tables.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use super::gas_predicates::charge_input_as_memory;
+use super::gas_predicates::{charge_input_as_memory, fix_native_double_pop};
 use crate::gas_model::units_types::{CostTable, Gas, GasCost};
 use move_binary_format::errors::{PartialVMError, PartialVMResult};
 
@@ -168,6 +168,13 @@ impl GasStatus {
     }
 
     pub fn pop_stack(&mut self, pops: u64) {
+        debug_assert!(
+            !fix_native_double_pop(self.gas_model_version) || self.stack_height_current >= pops,
+            "stack height underflow: current={}, pops={}. \
+             This indicates a double-pop or missing push in the gas meter.",
+            self.stack_height_current,
+            pops,
+        );
         self.stack_height_current = self.stack_height_current.saturating_sub(pops);
     }
 
@@ -568,5 +575,76 @@ pub fn initial_cost_schedule_v5() -> CostTable {
         instruction_tiers,
         stack_size_tiers,
         stack_height_tiers,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn unmetered_with_version(version: u64) -> GasStatus {
+        let mut s = GasStatus::new_unmetered();
+        s.gas_model_version = version;
+        s
+    }
+
+    /// Simulates the charge sequence for a native function call as it happens
+    /// in the interpreter (call_function → call_native_impl → call_native_with_args):
+    ///
+    ///   1. charge_call: pops args from the stack
+    ///   2. charge_native_function_before_execution: pops args AGAIN (the double-pop bug)
+    ///   3. charge_native_function: pushes return values
+    fn simulate_native_call(s: &mut GasStatus, num_args: u64, num_returns: u64) {
+        // Caller pushes args
+        for _ in 0..num_args {
+            s.push_stack(1).unwrap();
+        }
+        // charge_call pops args
+        s.pop_stack(num_args);
+        // charge_native_function_before_execution: double-pop in v11, no-op in v12
+        if !fix_native_double_pop(s.gas_model_version) {
+            s.pop_stack(num_args); // the bug
+        }
+        // charge_native_function pushes returns
+        s.push_stack(num_returns).unwrap();
+    }
+
+    #[test]
+    fn test_v12_native_call_stack_height_is_exact() {
+        // In v12, after 10 native calls each returning 1 value,
+        // the stack height should be exactly 10.
+        let mut s = unmetered_with_version(12);
+        for _ in 0..10 {
+            simulate_native_call(&mut s, 1, 1);
+        }
+        assert_eq!(s.stack_height_current(), 10);
+    }
+
+    #[test]
+    fn test_v11_native_call_stack_height_is_wrong() {
+        // In v11, the double-pop saturates the height to 0 after each call.
+        // After 10 native calls each returning 1 value, the height should be
+        // 10 but is stuck at 1 because saturation prevents accumulation.
+        let mut s = unmetered_with_version(11);
+        for _ in 0..10 {
+            simulate_native_call(&mut s, 1, 1);
+        }
+        assert_eq!(
+            s.stack_height_current(),
+            1,
+            "v11: saturation prevents correct accumulation (should be 10, got 1)"
+        );
+    }
+
+    #[test]
+    #[cfg_attr(not(debug_assertions), ignore)]
+    #[should_panic(expected = "stack height underflow")]
+    fn test_v12_debug_assert_catches_double_pop() {
+        // Verify that the debug_assert in pop_stack fires if we attempt a
+        // double-pop in v12. This is the safety net that prevents regressions.
+        let mut s = unmetered_with_version(12);
+        s.push_stack(2).unwrap(); // sh=2
+        s.pop_stack(2); // sh=0  (charge_call)
+        s.pop_stack(2); // sh=-2 → debug_assert fires
     }
 }

--- a/sui-execution/latest/sui-adapter/src/gas_meter.rs
+++ b/sui-execution/latest/sui-adapter/src/gas_meter.rs
@@ -16,7 +16,10 @@ use move_vm_runtime::{
     },
 };
 use sui_types::gas_model::{
-    gas_predicates::{native_function_threshold_exceeded, use_legacy_abstract_size},
+    gas_predicates::{
+        legacy_charge_native_pops_args, native_function_threshold_exceeded,
+        use_legacy_abstract_size,
+    },
     tables::{GasStatus, REFERENCE_SIZE, STRUCT_SIZE, VEC_SIZE},
 };
 
@@ -148,18 +151,21 @@ impl<G: DerefMut<Target = GasStatus>> GasMeter for SuiGasMeter<G> {
         &mut self,
         mut args: impl ExactSizeIterator<Item = impl ValueView>,
     ) -> PartialVMResult<()> {
-        // Determine the number of pops that are going to be needed for this function call, and
-        // charge for them.
-        let pops = args.len() as u64;
-        // Calculate the size decrease of the stack from the above pops.
-        let stack_reduction_size = args.try_fold(
-            AbstractMemorySize::new(pops),
-            |acc, elem| -> PartialVMResult<_> { Ok(acc + abstract_memory_size(&self.0, elem)?) },
-        )?;
-        // Track that this is going to be popping from the operand stack. We also increment the
-        // instruction count as we need to account for the `Call` bytecode that initiated this
-        // native call.
-        self.0.charge(1, 0, pops, 0, stack_reduction_size.into())
+        if legacy_charge_native_pops_args(self.0.gas_model_version) {
+            // Legacy: pop args again (double-pop, masked by saturating_sub).
+            let pops = args.len() as u64;
+            let stack_reduction_size = args.try_fold(
+                AbstractMemorySize::new(pops),
+                |acc, elem| -> PartialVMResult<_> {
+                    Ok(acc + abstract_memory_size(&self.0, elem)?)
+                },
+            )?;
+            self.0.charge(1, 0, pops, 0, stack_reduction_size.into())
+        } else {
+            // The args were already popped by charge_call/charge_call_generic.
+            // Only charge the instruction cost, not the pops.
+            self.0.charge(1, 0, 0, 0, 0)
+        }
     }
 
     fn charge_call(

--- a/sui-execution/latest/sui-adapter/src/gas_meter.rs
+++ b/sui-execution/latest/sui-adapter/src/gas_meter.rs
@@ -16,7 +16,9 @@ use move_vm_runtime::{
     },
 };
 use sui_types::gas_model::{
-    gas_predicates::{native_function_threshold_exceeded, use_legacy_abstract_size},
+    gas_predicates::{
+        fix_native_double_pop, native_function_threshold_exceeded, use_legacy_abstract_size,
+    },
     tables::{GasStatus, REFERENCE_SIZE, STRUCT_SIZE, VEC_SIZE},
 };
 
@@ -148,18 +150,21 @@ impl<G: DerefMut<Target = GasStatus>> GasMeter for SuiGasMeter<G> {
         &mut self,
         mut args: impl ExactSizeIterator<Item = impl ValueView>,
     ) -> PartialVMResult<()> {
-        // Determine the number of pops that are going to be needed for this function call, and
-        // charge for them.
-        let pops = args.len() as u64;
-        // Calculate the size decrease of the stack from the above pops.
-        let stack_reduction_size = args.try_fold(
-            AbstractMemorySize::new(pops),
-            |acc, elem| -> PartialVMResult<_> { Ok(acc + abstract_memory_size(&self.0, elem)?) },
-        )?;
-        // Track that this is going to be popping from the operand stack. We also increment the
-        // instruction count as we need to account for the `Call` bytecode that initiated this
-        // native call.
-        self.0.charge(1, 0, pops, 0, stack_reduction_size.into())
+        if fix_native_double_pop(self.0.gas_model_version) {
+            // The args were already popped by charge_call/charge_call_generic.
+            // Only charge the instruction cost, not the pops.
+            self.0.charge(1, 0, 0, 0, 0)
+        } else {
+            // Legacy: pop args again (double-pop, masked by saturating_sub).
+            let pops = args.len() as u64;
+            let stack_reduction_size = args.try_fold(
+                AbstractMemorySize::new(pops),
+                |acc, elem| -> PartialVMResult<_> {
+                    Ok(acc + abstract_memory_size(&self.0, elem)?)
+                },
+            )?;
+            self.0.charge(1, 0, pops, 0, stack_reduction_size.into())
+        }
     }
 
     fn charge_call(


### PR DESCRIPTION
## Description

`charge_native_function_before_execution` was popping args from the gas meter's `stack_height_current` that `charge_call` had already popped. The resulting negative intermediate heights were masked by `saturating_sub` in `pop_stack`.

`pop_stack` has now a single `checked_sub` which branches on the result: `Some(stack_height)` uses it; `None` with `gas_model_version <= 11` saturates to `0` (legacy double-pop is intentional); `None` with `gas_model_version > 11` panics in debug, saturates to `0` in release and reports an invariant violation.

## Test plan

Existing tests.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [x] Protocol: Adds protocol version 123 (`gas_model_version` 12). Fixes a stack-height double-decrement in the gas meter for native calls. Internal accounting correctness only; no user-visible change to successful transactions.
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework: