### PR TITLE
Fix integer test type mismatches

### DIFF
--- a/crates/sui-framework/packages/move-stdlib/tests/u128_tests.move
+++ b/crates/sui-framework/packages/move-stdlib/tests/u128_tests.move
@@ -83,9 +83,9 @@ fun test_div_ceil() {
     integer_tests::test_div_ceil!(MAX, CASES);
 }
 
-#[test, expected_failure(arithmetic_error, location = std::u8)]
+#[test, expected_failure(arithmetic_error, location = std::u128)]
 fun test_div_ceil_error() {
-    1u8.div_ceil(0);
+    1u128.div_ceil(0);
 }
 
 #[test]
@@ -95,9 +95,9 @@ fun test_pow() {
     assert_eq!(3u128.pow(27), integer_tests::slow_pow!(3u128, 27));
 }
 
-#[test, expected_failure(arithmetic_error, location = std::u16)]
+#[test, expected_failure(arithmetic_error, location = std::u128)]
 fun test_pow_overflow() {
-    255u16.pow(255);
+    255u128.pow(255);
 }
 
 #[test]

--- a/crates/sui-framework/packages/move-stdlib/tests/u16_tests.move
+++ b/crates/sui-framework/packages/move-stdlib/tests/u16_tests.move
@@ -83,9 +83,9 @@ fun test_div_ceil() {
     integer_tests::test_div_ceil!(MAX, CASES);
 }
 
-#[test, expected_failure(arithmetic_error, location = std::u8)]
+#[test, expected_failure(arithmetic_error, location = std::u16)]
 fun test_div_ceil_error() {
-    1u8.div_ceil(0);
+    1u16.div_ceil(0);
 }
 
 #[test]

--- a/crates/sui-framework/packages/move-stdlib/tests/u256_tests.move
+++ b/crates/sui-framework/packages/move-stdlib/tests/u256_tests.move
@@ -53,9 +53,9 @@ fun test_div_ceil() {
     integer_tests::test_div_ceil!(MAX, CASES);
 }
 
-#[test, expected_failure(arithmetic_error, location = std::u8)]
+#[test, expected_failure(arithmetic_error, location = std::u256)]
 fun test_div_ceil_error() {
-    1u8.div_ceil(0);
+    1u256.div_ceil(0);
 }
 
 #[test]

--- a/crates/sui-framework/packages/move-stdlib/tests/u32_tests.move
+++ b/crates/sui-framework/packages/move-stdlib/tests/u32_tests.move
@@ -83,9 +83,9 @@ fun test_div_ceil() {
     integer_tests::test_div_ceil!(MAX, CASES);
 }
 
-#[test, expected_failure(arithmetic_error, location = std::u8)]
+#[test, expected_failure(arithmetic_error, location = std::u32)]
 fun test_div_ceil_error() {
-    1u8.div_ceil(0);
+    1u32.div_ceil(0);
 }
 
 #[test]

--- a/crates/sui-framework/packages/move-stdlib/tests/u64_tests.move
+++ b/crates/sui-framework/packages/move-stdlib/tests/u64_tests.move
@@ -83,9 +83,9 @@ fun test_div_ceil() {
     integer_tests::test_div_ceil!(MAX, CASES);
 }
 
-#[test, expected_failure(arithmetic_error, location = std::u8)]
+#[test, expected_failure(arithmetic_error, location = std::u64)]
 fun test_div_ceil_error() {
-    1u8.div_ceil(0);
+    1u64.div_ceil(0);
 }
 
 #[test]


### PR DESCRIPTION
## Description

- Fix the negative `div_ceil` tests in the `u16`, `u32`, `u64`, `u128`, and `u256` stdlib test modules so each test exercises the matching integer type.
- Fix `u128_tests::test_pow_overflow` to invoke `u128::pow` instead of `u16::pow`.
- This restores the intended per-type negative coverage and removes false confidence from mislabeled tests.

## Test plan

```sh
SUI_SKIP_SIMTESTS=1 cargo nextest run --profile ci --cargo-quiet -p sui-framework-tests --test move_tests -- move-stdlib
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework: