### PR TITLE
Cherry-pick: Fix double-counting of gas budget in select_gas

### DIFF
--- a/crates/sui-e2e-tests/tests/grpc_simulate_gas_coin_tests.rs
+++ b/crates/sui-e2e-tests/tests/grpc_simulate_gas_coin_tests.rs
@@ -737,6 +737,122 @@ async fn test_combined_ab_and_coins_needed() {
     );
 }
 
+// =============================================================================
+// Test: AB-only gas payment succeeds when budget > half of address balance
+// Regression test for double-counting of gas budget in select_gas.
+// =============================================================================
+
+#[sim_test]
+async fn test_ab_only_budget_exceeds_half_balance() {
+    use sui_test_transaction_builder::TestTransactionBuilder;
+    use sui_types::transaction::TransactionExpiration;
+
+    let test_env = TestEnvBuilder::new()
+        .with_proto_override_cb(Box::new(|_, mut cfg| {
+            cfg.create_root_accumulator_object_for_testing();
+            cfg.enable_coin_reservation_for_testing();
+            cfg.enable_address_balance_gas_payments_for_testing();
+            cfg
+        }))
+        .build()
+        .await;
+
+    let mut test_env = test_env;
+
+    let (sender1, _) = test_env.get_sender_and_gas(0);
+    let (sender2, _) = test_env.get_sender_and_gas(1);
+
+    // Fund sender1's address balance with 1 SUI.
+    let ab_amount = MIST_PER_SUI;
+    test_env.fund_one_address_balance(sender1, ab_amount).await;
+
+    // Transfer all of sender1's coins to sender2 so sender1 only has AB.
+    let (_, all_gas) = test_env.get_sender_and_all_gas(0);
+    let mut transfer_digests = Vec::new();
+    for coin in all_gas {
+        let transfer_tx = TestTransactionBuilder::new(sender1, coin, test_env.rgp)
+            .transfer_sui(None, sender2)
+            .build();
+        let tx = test_env.cluster.wallet.sign_transaction(&transfer_tx).await;
+        let executed = test_env.cluster.execute_transaction(tx).await;
+        assert!(executed.effects.status().is_ok(), "Transfer should succeed");
+        transfer_digests.push(*executed.effects.transaction_digest());
+    }
+    test_env
+        .cluster
+        .wait_for_tx_settlement(&transfer_digests)
+        .await;
+    test_env.update_all_gas().await;
+
+    // Verify sender1 has no coins but does have AB.
+    let sender1_coins = test_env
+        .gas_objects
+        .get(&sender1)
+        .cloned()
+        .unwrap_or_default();
+    assert!(sender1_coins.is_empty(), "sender1 should have no coins");
+
+    let ab_balance = test_env.get_sui_balance_ab(sender1);
+    assert!(ab_balance > 0, "sender1 should have address balance");
+
+    // Budget is more than half the AB but less than the full AB. Before the fix,
+    // select_gas would double-count the budget when computing available balance,
+    // requiring raw_balance >= 2 * budget instead of raw_balance >= budget.
+    let gas_budget = (ab_balance * 3) / 4; // 75% of AB
+    assert!(gas_budget > ab_balance / 2);
+    assert!(gas_budget <= ab_balance);
+
+    let ptb = ProgrammableTransactionBuilder::new();
+    let pt = ptb.finish();
+    let tx = TransactionData::new_programmable(sender1, vec![], pt, gas_budget, test_env.rgp);
+
+    let client = test_env.cluster.grpc_client();
+    let result = client.simulate_transaction(&tx, true, true).await;
+
+    assert!(
+        result.is_ok(),
+        "Simulation should succeed when AB covers the budget, got: {:?}",
+        result.err()
+    );
+
+    let response = result.unwrap();
+    assert!(
+        response.transaction.effects.status().is_ok(),
+        "Expected successful execution with pure AB payment, got: {:?}",
+        response.transaction.effects.status()
+    );
+
+    // Verify pure AB payment path was taken.
+    let gas_payment = response.transaction.transaction.gas_data().payment.clone();
+    assert!(
+        gas_payment.is_empty(),
+        "Gas payment should be empty for pure AB payment, got: {:?}",
+        gas_payment
+    );
+
+    assert!(
+        matches!(
+            response.transaction.transaction.expiration(),
+            TransactionExpiration::ValidDuring { .. }
+        ),
+        "Expected ValidDuring expiration for pure AB payment, got: {:?}",
+        response.transaction.transaction.expiration()
+    );
+
+    // Execute the simulated transaction to verify it's actually valid.
+    let simulated_tx = &response.transaction.transaction;
+    let (_, effects) = test_env
+        .cluster
+        .sign_and_execute_transaction_directly(simulated_tx)
+        .await
+        .expect("Simulated transaction should execute successfully");
+    assert!(
+        effects.status().is_ok(),
+        "Executed transaction should succeed, got: {:?}",
+        effects.status()
+    );
+}
+
 /// Convert an internal ObjectRef to a proto ObjectReference with all fields set.
 fn object_ref_to_proto(
     obj_ref: &sui_types::base_types::ObjectRef,

--- a/crates/sui-rpc-api/src/grpc/v2/transaction_execution_service/simulate/mod.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/transaction_execution_service/simulate/mod.rs
@@ -385,12 +385,14 @@ fn select_gas(
     let address_balance = reader
         .lookup_address_balance(owner, GAS::type_())
         .map(|balance| {
-            // Sum up the total SUI reservations for the `owner` so that we can deduct that from the
-            // available address balance for determining if an account has sufficient funds.
+            // Sum up the explicit SUI reservations (excluding the implicit gas payment) for the
+            // `owner` so that we can deduct that from the available address balance. We use the
+            // estimation variant to avoid double-counting: the gas budget is what we're trying to
+            // satisfy, not a pre-existing reservation.
             let coin_resolver = CoinReservationResolver::new(reader.inner().clone());
 
             let reserved_sui = transaction
-                .process_funds_withdrawals_for_signing(service.chain_id, &coin_resolver)
+                .process_funds_withdrawals_for_estimation(service.chain_id, &coin_resolver)
                 .ok()
                 .and_then(|withdrawals| {
                     let sui_type = Balance::type_tag(GAS::type_tag());

--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -2884,6 +2884,15 @@ pub trait TransactionDataAPI {
         coin_resolver: &dyn CoinReservationResolverTrait,
     ) -> UserInputResult<BTreeMap<AccumulatorObjId, (u64, TypeTag)>>;
 
+    /// Like `process_funds_withdrawals_for_signing`, but excludes the implicit gas payment
+    /// withdrawal. This is used during gas selection estimation to avoid double-counting the
+    /// gas budget when determining available address balance.
+    fn process_funds_withdrawals_for_estimation(
+        &self,
+        chain_identifier: ChainIdentifier,
+        coin_resolver: &dyn CoinReservationResolverTrait,
+    ) -> UserInputResult<BTreeMap<AccumulatorObjId, (u64, TypeTag)>>;
+
     /// Like `process_funds_withdrawals_for_signing`, but must only be called on a certified
     /// transaction, i.e. one that is known to be valid.
     fn process_funds_withdrawals_for_execution(
@@ -3036,47 +3045,15 @@ impl TransactionDataAPI for TransactionDataV1 {
         chain_identifier: ChainIdentifier,
         coin_resolver: &dyn CoinReservationResolverTrait,
     ) -> UserInputResult<BTreeMap<AccumulatorObjId, (u64, TypeTag)>> {
-        let mut withdraws: Vec<_> = self.get_funds_withdrawals().collect();
+        self.accumulate_funds_withdrawals(chain_identifier, coin_resolver, true)
+    }
 
-        for withdraw in self.parsed_coin_reservations(chain_identifier) {
-            // During signing, use latest accumulator version (None).
-            let withdrawal_arg =
-                coin_resolver.resolve_funds_withdrawal(self.sender(), withdraw, None)?;
-            withdraws.push(withdrawal_arg);
-        }
-
-        withdraws.extend(self.get_funds_withdrawal_for_gas_payment());
-
-        // Accumulate all withdraws per account.
-        let mut withdraw_map: BTreeMap<AccumulatorObjId, (u64, TypeTag)> = BTreeMap::new();
-        for withdraw in withdraws {
-            let reserved_amount = match &withdraw.reservation {
-                Reservation::MaxAmountU64(amount) => {
-                    assert!(*amount > 0, "verified in validity check");
-                    *amount
-                }
-            };
-
-            let account_address = withdraw.owner_for_withdrawal(self);
-            let type_tag = withdraw.type_arg.to_type_tag();
-            let account_id =
-                AccumulatorValue::get_field_id(account_address, &type_tag).map_err(|e| {
-                    UserInputError::InvalidWithdrawReservation {
-                        error: e.to_string(),
-                    }
-                })?;
-
-            let (current_amount, _) = withdraw_map
-                .entry(account_id)
-                .or_insert_with(|| (0, type_tag));
-            *current_amount = current_amount.checked_add(reserved_amount).ok_or(
-                UserInputError::InvalidWithdrawReservation {
-                    error: "Balance withdraw reservation overflow".to_string(),
-                },
-            )?;
-        }
-
-        Ok(withdraw_map)
+    fn process_funds_withdrawals_for_estimation(
+        &self,
+        chain_identifier: ChainIdentifier,
+        coin_resolver: &dyn CoinReservationResolverTrait,
+    ) -> UserInputResult<BTreeMap<AccumulatorObjId, (u64, TypeTag)>> {
+        self.accumulate_funds_withdrawals(chain_identifier, coin_resolver, false)
     }
 
     fn process_funds_withdrawals_for_execution(
@@ -3559,6 +3536,55 @@ impl TransactionDataAPI for TransactionDataV1 {
 }
 
 impl TransactionDataV1 {
+    fn accumulate_funds_withdrawals(
+        &self,
+        chain_identifier: ChainIdentifier,
+        coin_resolver: &dyn CoinReservationResolverTrait,
+        include_gas_payment: bool,
+    ) -> UserInputResult<BTreeMap<AccumulatorObjId, (u64, TypeTag)>> {
+        let mut withdraws: Vec<_> = self.get_funds_withdrawals().collect();
+
+        for withdraw in self.parsed_coin_reservations(chain_identifier) {
+            let withdrawal_arg =
+                coin_resolver.resolve_funds_withdrawal(self.sender(), withdraw, None)?;
+            withdraws.push(withdrawal_arg);
+        }
+
+        if include_gas_payment {
+            withdraws.extend(self.get_funds_withdrawal_for_gas_payment());
+        }
+
+        let mut withdraw_map: BTreeMap<AccumulatorObjId, (u64, TypeTag)> = BTreeMap::new();
+        for withdraw in withdraws {
+            let reserved_amount = match &withdraw.reservation {
+                Reservation::MaxAmountU64(amount) => {
+                    assert!(*amount > 0, "verified in validity check");
+                    *amount
+                }
+            };
+
+            let account_address = withdraw.owner_for_withdrawal(self);
+            let type_tag = withdraw.type_arg.to_type_tag();
+            let account_id =
+                AccumulatorValue::get_field_id(account_address, &type_tag).map_err(|e| {
+                    UserInputError::InvalidWithdrawReservation {
+                        error: e.to_string(),
+                    }
+                })?;
+
+            let (current_amount, _) = withdraw_map
+                .entry(account_id)
+                .or_insert_with(|| (0, type_tag));
+            *current_amount = current_amount.checked_add(reserved_amount).ok_or(
+                UserInputError::InvalidWithdrawReservation {
+                    error: "Balance withdraw reservation overflow".to_string(),
+                },
+            )?;
+        }
+
+        Ok(withdraw_map)
+    }
+
     fn get_funds_withdrawal_for_gas_payment(&self) -> Option<FundsWithdrawalArg> {
         if self.is_gas_paid_from_address_balance() && self.gas_data().budget > 0 {
             Some(if self.sender() != self.gas_owner() {


### PR DESCRIPTION
## Summary
Cherry-pick of #26205 to the 1.70 release branch.

- Fix bug where `select_gas` double-counts the gas budget when computing available address balance, causing "insufficient balance" errors when budget > half of address balance
- Add `process_funds_withdrawals_for_estimation` which excludes the implicit gas payment withdrawal
- Regression test: `test_ab_only_budget_exceeds_half_balance`

🤖 Generated with [Claude Code](https://claude.com/claude-code)