### PR TITLE
display: differentiate between scoped and latest object loads

### DIFF
--- a/crates/sui-display/src/v2/interpreter.rs
+++ b/crates/sui-display/src/v2/interpreter.rs
@@ -27,7 +27,10 @@ pub struct Interpreter<S: V::Store> {
 
     /// Cache of the objects that have been fetched so far. This cache is never evicted -- it is
     /// used to keep objects alive for the lifetime of the interpreter.
-    cache: DashMap<AccountAddress, Option<Arc<V::OwnedSlice>>>,
+    ///
+    /// The cache is keyed by the object ID and whether the object is being accessed as a child of
+    /// another object (bounded by its version -- `true`), or at its latest version (`false`).
+    cache: DashMap<(AccountAddress, bool), Option<Arc<V::OwnedSlice>>>,
 
     root: V::OwnedSlice,
 }
@@ -136,8 +139,8 @@ impl<S: V::Store> Interpreter<S> {
         while let Some(accessor) = accessors.last() {
             match (root, accessor) {
                 (VV::Address(a), A::DFIndex(i)) => {
-                    let df_id = i.derive_dynamic_field_id(a)?.into();
-                    let Some(slice) = self.object(df_id).await? else {
+                    let df_id = i.derive_dynamic_field_id(a.bytes)?.into();
+                    let Some(slice) = self.fetch(df_id, a.scoped).await? else {
                         return Ok(None);
                     };
 
@@ -155,12 +158,13 @@ impl<S: V::Store> Interpreter<S> {
                     root = VV::Slice(V::Slice {
                         bytes: field.value_bytes,
                         layout: field.value_layout,
+                        scoped: slice.scoped,
                     });
                 }
 
                 (VV::Address(a), A::DOFIndex(i)) => {
-                    let df_id = i.derive_dynamic_object_field_id(a)?.into();
-                    let Some(slice) = self.object(df_id).await? else {
+                    let df_id = i.derive_dynamic_object_field_id(a.bytes)?.into();
+                    let Some(slice) = self.fetch(df_id, a.scoped).await? else {
                         return Ok(None);
                     };
 
@@ -178,7 +182,7 @@ impl<S: V::Store> Interpreter<S> {
                         return Ok(None);
                     };
 
-                    let Some(value_slice) = self.object(id).await? else {
+                    let Some(value_slice) = self.fetch(id, a.scoped).await? else {
                         return Ok(None);
                     };
 
@@ -187,8 +191,8 @@ impl<S: V::Store> Interpreter<S> {
                 }
 
                 (VV::Address(a), A::Derived(i)) => {
-                    let id = i.derive_object_id(a)?.into();
-                    let Some(slice) = self.object(id).await? else {
+                    let id = i.derive_object_id(a.bytes)?.into();
+                    let Some(slice) = self.fetch(id, a.scoped).await? else {
                         return Ok(None);
                     };
 
@@ -244,10 +248,13 @@ impl<S: V::Store> Interpreter<S> {
                 // value. This can consume multiple accessors, but will pause if it encounters a
                 // dynamic (object) field access.
                 (VV::Slice(slice), _) => {
-                    let Some(value) = Extractor::deserialize_slice(slice, &mut accessors)? else {
+                    let Some(mut value) = Extractor::deserialize_slice(slice, &mut accessors)?
+                    else {
                         return Ok(None);
                     };
 
+                    // The extractor does not track scoping -- attach that information on the side.
+                    value.set_scope(slice.scoped);
                     root = value;
                 }
 
@@ -304,7 +311,7 @@ impl<S: V::Store> Interpreter<S> {
 
         Ok(match lit {
             L::Self_ => Some(VV::Slice(self.root.as_slice())),
-            L::Address(a) => Some(VV::Address(*a)),
+            L::Address(a) => Some(VV::Address(V::Address::latest(*a))),
             L::Bool(b) => Some(VV::Bool(*b)),
             L::U8(n) => Some(VV::U8(*n)),
             L::U16(n) => Some(VV::U16(*n)),
@@ -400,21 +407,36 @@ impl<S: V::Store> Interpreter<S> {
 
     /// Fetch an object from the store, caching the result.
     ///
+    /// Accepts the object's ID and whether the fetch should be scoped by the store's parent object
+    /// (if the store supports this concept).
+    ///
     /// Returns a `Slice<'s>` that borrows from the cached data. The returned slice is guaranteed
     /// to remain valid for the lifetime 's because the cache (and the Arc it contains) lives for
     /// the entire lifetime of the Interpreter.
-    async fn object<'s>(&'s self, id: AccountAddress) -> Result<Option<V::Slice<'s>>, FormatError> {
-        let owned = if let Some(cached) = self.cache.get(&id) {
+    async fn fetch<'s>(
+        &'s self,
+        id: AccountAddress,
+        scoped: bool,
+    ) -> Result<Option<V::Slice<'s>>, FormatError> {
+        let key = (id, scoped);
+        let owned = if let Some(cached) = self.cache.get(&key) {
             cached.clone()
         } else {
-            let loaded = self
-                .store
-                .object(id)
-                .await
-                .map_err(|e| FormatError::Store(Arc::new(e)))?
-                .map(Arc::new);
+            let loaded = if scoped {
+                self.store.scoped(id).await
+            } else {
+                self.store.latest(id).await
+            }
+            .map_err(|e| FormatError::Store(Arc::new(e)))?
+            .map(|(layout, bytes)| {
+                Arc::new(V::OwnedSlice {
+                    layout,
+                    bytes,
+                    scoped,
+                })
+            });
 
-            self.cache.entry(id).or_insert(loaded).clone()
+            self.cache.entry(key).or_insert(loaded).clone()
         };
 
         let Some(owned) = owned.as_ref() else {

--- a/crates/sui-display/src/v2/mod.rs
+++ b/crates/sui-display/src/v2/mod.rs
@@ -317,7 +317,7 @@ mod tests {
         layout: MoveTypeLayout,
         path: &str,
     ) -> Result<Option<serde_json::Value>, FormatError> {
-        let interpreter = Interpreter::new(OwnedSlice { bytes, layout }, store);
+        let interpreter = Interpreter::new(OwnedSlice::new(layout, bytes), store);
         let used = AtomicUsize::new(0);
 
         let chain = Extract::parse(Limits::default(), path)?;
@@ -329,6 +329,21 @@ mod tests {
         Ok(Some(value.format_json(meter)?))
     }
 
+    async fn extract_owned(
+        store: impl Store,
+        bytes: Vec<u8>,
+        layout: MoveTypeLayout,
+        path: &str,
+    ) -> Result<Option<OwnedSlice>, FormatError> {
+        let interpreter = Interpreter::new(OwnedSlice::new(layout, bytes), store);
+        let chain = Extract::parse(Limits::default(), path)?;
+        let Some(value) = chain.extract(&interpreter).await? else {
+            return Ok(None);
+        };
+
+        Ok(value.into_owned_slice())
+    }
+
     async fn dynamic_field_id(
         store: MockStore,
         bytes: Vec<u8>,
@@ -336,8 +351,7 @@ mod tests {
         parent: AccountAddress,
         literal: &str,
     ) -> Result<Option<AccountAddress>, FormatError> {
-        let interpreter = Interpreter::new(OwnedSlice { bytes, layout }, store);
-
+        let interpreter = Interpreter::new(OwnedSlice::new(layout, bytes), store);
         let name = Name::parse(Limits::default(), literal)?;
         let Some(value) = name.eval(&interpreter).await? else {
             return Ok(None);
@@ -353,8 +367,7 @@ mod tests {
         parent: AccountAddress,
         literal: &str,
     ) -> Result<Option<AccountAddress>, FormatError> {
-        let interpreter = Interpreter::new(OwnedSlice { bytes, layout }, store);
-
+        let interpreter = Interpreter::new(OwnedSlice::new(layout, bytes), store);
         let name = Name::parse(Limits::default(), literal)?;
         let Some(value) = name.eval(&interpreter).await? else {
             return Ok(None);
@@ -370,8 +383,7 @@ mod tests {
         parent: AccountAddress,
         literal: &str,
     ) -> Result<Option<AccountAddress>, FormatError> {
-        let interpreter = Interpreter::new(OwnedSlice { bytes, layout }, store);
-
+        let interpreter = Interpreter::new(OwnedSlice::new(layout, bytes), store);
         let name = Name::parse(Limits::default(), literal)?;
         let Some(value) = name.eval(&interpreter).await? else {
             return Ok(None);
@@ -390,7 +402,7 @@ mod tests {
         max_output_size: usize,
         fields: impl IntoIterator<Item = (&'s str, &'s str)>,
     ) -> Result<IndexMap<String, Result<serde_json::Value, FormatError>>, Error> {
-        let interpreter = Interpreter::new(OwnedSlice { bytes, layout }, store);
+        let interpreter = Interpreter::new(OwnedSlice::new(layout, bytes), store);
         Display::parse(limits, fields)?
             .display(max_depth, max_output_size, &interpreter)
             .await
@@ -821,10 +833,7 @@ mod tests {
         ];
 
         let store = MockStore::default();
-        let root = OwnedSlice {
-            layout: struct_("0x1::m::S", fields),
-            bytes,
-        };
+        let root = OwnedSlice::new(struct_("0x1::m::S", fields), bytes);
 
         let mut output: Vec<serde_json::Value> = Vec::with_capacity(formats.len());
         let interpreter = Interpreter::new(root, store);
@@ -1570,9 +1579,12 @@ mod tests {
 
         #[async_trait]
         impl Store for BlockingStore {
-            async fn object(&self, id: AccountAddress) -> anyhow::Result<Option<OwnedSlice>> {
+            async fn latest(
+                &self,
+                id: AccountAddress,
+            ) -> anyhow::Result<Option<(MoveTypeLayout, Vec<u8>)>> {
                 self.barrier.wait().await;
-                self.inner.object(id).await
+                self.inner.latest(id).await
             }
         }
 
@@ -1755,6 +1767,156 @@ mod tests {
             ),
         }
         "###);
+    }
+
+    #[tokio::test]
+    async fn test_extract_root_value_remains_scoped() {
+        let parent = AccountAddress::from_str("0x4000").unwrap();
+        let bytes = bcs::to_bytes(&parent).unwrap();
+        let layout = struct_(
+            "0x1::m::Root",
+            vec![(
+                "parent",
+                struct_(
+                    "0x1::m::Parent",
+                    vec![("id", L::Struct(Box::new(UID::layout())))],
+                ),
+            )],
+        );
+
+        let store = MockStore::default().with_dynamic_field(
+            parent,
+            "key",
+            L::Struct(Box::new(move_utf8_str_layout())),
+            (20u64, 21u64),
+            struct_("0x1::m::Inner", vec![("x", L::U64), ("y", L::U64)]),
+        );
+
+        let slice = extract_owned(store, bytes, layout, "parent.id->['key']")
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert!(slice.scoped);
+        assert_eq!(slice.bytes, bcs::to_bytes(&(20u64, 21u64)).unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_extract_literal_lookup_is_latest() {
+        let parent = AccountAddress::from_str("0x4100").unwrap();
+        let bytes = bcs::to_bytes(&false).unwrap();
+        let layout = L::Bool;
+
+        let store = MockStore::default().with_dynamic_field(
+            parent,
+            "key",
+            L::Struct(Box::new(move_utf8_str_layout())),
+            (20u64, 21u64),
+            struct_("0x1::m::Inner", vec![("x", L::U64), ("y", L::U64)]),
+        );
+
+        let slice = extract_owned(store, bytes, layout, "@0x4100->['key']")
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert!(!slice.scoped);
+        assert_eq!(slice.bytes, bcs::to_bytes(&(20u64, 21u64)).unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_extract_root_value_via_literal_field_remains_scoped() {
+        let parent = AccountAddress::from_str("0x4200").unwrap();
+        let bytes = bcs::to_bytes(&parent).unwrap();
+        let layout = struct_(
+            "0x1::m::Root",
+            vec![(
+                "parent",
+                struct_(
+                    "0x1::m::Parent",
+                    vec![("id", L::Struct(Box::new(UID::layout())))],
+                ),
+            )],
+        );
+
+        let store = MockStore::default().with_dynamic_field(
+            parent,
+            "key",
+            L::Struct(Box::new(move_utf8_str_layout())),
+            (20u64, 21u64),
+            struct_("0x1::m::Inner", vec![("x", L::U64), ("y", L::U64)]),
+        );
+
+        let slice = extract_owned(
+            store,
+            bytes,
+            layout,
+            "0x1::m::Wrapper{p: parent.id.id}.p->['key']",
+        )
+        .await
+        .unwrap()
+        .unwrap();
+
+        assert!(slice.scoped);
+        assert_eq!(slice.bytes, bcs::to_bytes(&(20u64, 21u64)).unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_extract_derived_object_with_literal_parent_is_latest() {
+        let literal_parent = AccountAddress::from_str("0x4300").unwrap();
+        let bytes = bcs::to_bytes(&("derived_key",)).unwrap();
+        let layout = struct_(
+            "0x1::m::Root",
+            vec![("key", L::Struct(Box::new(move_utf8_str_layout())))],
+        );
+
+        let store = MockStore::default().with_derived_object(
+            literal_parent,
+            "derived_key",
+            L::Struct(Box::new(move_utf8_str_layout())),
+            (20u64, 21u64),
+            struct_("0x1::m::Inner", vec![("x", L::U64), ("y", L::U64)]),
+        );
+
+        let slice = extract_owned(store, bytes, layout, "@0x4300~>[key]")
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert!(!slice.scoped);
+        assert_eq!(slice.bytes, bcs::to_bytes(&(20u64, 21u64)).unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_extract_derived_object_with_root_parent_remains_scoped() {
+        let parent = AccountAddress::from_str("0x4400").unwrap();
+        let bytes = bcs::to_bytes(&parent).unwrap();
+        let layout = struct_(
+            "0x1::m::Root",
+            vec![(
+                "parent",
+                struct_(
+                    "0x1::m::Parent",
+                    vec![("id", L::Struct(Box::new(UID::layout())))],
+                ),
+            )],
+        );
+
+        let store = MockStore::default().with_derived_object(
+            parent,
+            "derived_key",
+            L::Struct(Box::new(move_utf8_str_layout())),
+            (20u64, 21u64),
+            struct_("0x1::m::Inner", vec![("x", L::U64), ("y", L::U64)]),
+        );
+
+        let slice = extract_owned(store, bytes, layout, "parent~>['derived_key']")
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert!(slice.scoped);
+        assert_eq!(slice.bytes, bcs::to_bytes(&(20u64, 21u64)).unwrap());
     }
 
     #[tokio::test]
@@ -2568,7 +2730,7 @@ mod tests {
         );
 
         let store = MockStore::default();
-        let root = OwnedSlice { bytes, layout };
+        let root = OwnedSlice::new(layout, bytes);
         let interpreter = Interpreter::new(root, store);
 
         let formats = ["{st}", "{en}", "{vs}"];

--- a/crates/sui-display/src/v2/value.rs
+++ b/crates/sui-display/src/v2/value.rs
@@ -45,8 +45,16 @@ use crate::v2::writer;
 /// requests for the same object, and it is the store's responsibility to handle this correctly
 /// (e.g. by deduplicating in-flight requests).
 #[async_trait]
-pub trait Store {
-    async fn object(&self, id: AccountAddress) -> anyhow::Result<Option<OwnedSlice>>;
+pub trait Store: Sync {
+    async fn latest(&self, id: AccountAddress)
+    -> anyhow::Result<Option<(MoveTypeLayout, Vec<u8>)>>;
+
+    async fn scoped(
+        &self,
+        id: AccountAddress,
+    ) -> anyhow::Result<Option<(MoveTypeLayout, Vec<u8>)>> {
+        self.latest(id).await
+    }
 }
 
 /// Result of evaluating a single strand of a Display v2 format string.
@@ -63,7 +71,7 @@ pub enum Strand<'s> {
 /// Value representation used during evaluation by the Display v2 interpreter.
 #[derive(Clone)]
 pub enum Value<'s> {
-    Address(AccountAddress),
+    Address(Address),
     Bool(bool),
     Bytes(Cow<'s, [u8]>),
     Enum(Enum<'s>),
@@ -77,6 +85,15 @@ pub enum Value<'s> {
     U128(u128),
     U256(U256),
     Vector(Vector<'s>),
+}
+
+#[derive(Clone, Copy)]
+pub struct Address {
+    pub(crate) bytes: AccountAddress,
+
+    /// Indicates whether this value came from the parent object being formatted (in which case
+    /// child object reads should be scoped by the parent object's version).
+    pub(crate) scoped: bool,
 }
 
 /// Non-aggregate values that can be formatted during string interpolation.
@@ -108,6 +125,10 @@ pub enum Accessor<'s> {
 pub struct Slice<'s> {
     pub(crate) layout: &'s MoveTypeLayout,
     pub(crate) bytes: &'s [u8],
+
+    /// Indicates whether this value came from the parent object being formatted (in which case
+    /// child object reads should be scoped by the parent object's version).
+    pub(crate) scoped: bool,
 }
 
 /// An owned version of `Slice`.
@@ -115,6 +136,10 @@ pub struct Slice<'s> {
 pub struct OwnedSlice {
     pub layout: MoveTypeLayout,
     pub bytes: Vec<u8>,
+
+    /// Indicates whether this value came from the parent object being formatted (in which case
+    /// child object reads should be scoped by the parent object's version).
+    pub scoped: bool,
 }
 
 /// An evaluated vector literal.
@@ -145,6 +170,22 @@ pub struct Enum<'s> {
 pub enum Fields<'s> {
     Positional(Vec<Value<'s>>),
     Named(Vec<(&'s str, Value<'s>)>),
+}
+
+impl Address {
+    pub(crate) fn scoped(bytes: AccountAddress) -> Self {
+        Self {
+            bytes,
+            scoped: true,
+        }
+    }
+
+    pub(crate) fn latest(bytes: AccountAddress) -> Self {
+        Self {
+            bytes,
+            scoped: false,
+        }
+    }
 }
 
 impl Value<'_> {
@@ -215,7 +256,7 @@ impl Value<'_> {
         mut meter: writer::Meter<'_>,
     ) -> Result<F, FormatError> {
         match self {
-            Value::Address(a) => Ok(F::string(&mut meter, a.to_canonical_string(true))?),
+            Value::Address(a) => Ok(F::string(&mut meter, a.bytes.to_canonical_string(true))?),
             Value::Bool(b) => Ok(F::bool(&mut meter, b)?),
             Value::U8(n) => Ok(F::number(&mut meter, n as u32)?),
             Value::U16(n) => Ok(F::number(&mut meter, n as u32)?),
@@ -293,6 +334,7 @@ impl Value<'_> {
             V::Slice(Slice {
                 layout,
                 bytes: data,
+                ..
             }) => match layout {
                 L::U8 => Some(bcs::from_bytes::<u8>(data).ok()?.into()),
                 L::U16 => Some(bcs::from_bytes::<u16>(data).ok()?.into()),
@@ -311,6 +353,18 @@ impl Value<'_> {
             | V::String(_)
             | V::Struct(_)
             | V::Vector(_) => None,
+        }
+    }
+
+    /// Annotate the value with a scope status.
+    pub(crate) fn set_scope(&mut self, scope: bool) {
+        match self {
+            Value::Address(a) => a.scoped = scope,
+            Value::Slice(s) => s.scoped = scope,
+
+            // Other value types can't be parents for child object reads, so scope status can be
+            // ignored.
+            _ => (),
         }
     }
 }
@@ -470,10 +524,19 @@ impl<'s> Accessor<'s> {
 }
 
 impl OwnedSlice {
+    pub fn new(layout: MoveTypeLayout, bytes: Vec<u8>) -> Self {
+        Self {
+            layout,
+            bytes,
+            scoped: true,
+        }
+    }
+
     pub(crate) fn as_slice(&self) -> Slice<'_> {
         Slice {
             layout: &self.layout,
             bytes: &self.bytes,
+            scoped: self.scoped,
         }
     }
 }
@@ -494,9 +557,19 @@ impl Value<'_> {
     /// This operation returns `None` if the value contains compound literals (struct, enum, vector
     /// literals), since their layouts are not guaranteed to be valid.
     pub fn into_owned_slice(self) -> Option<OwnedSlice> {
+        let scoped = match &self {
+            Value::Slice(s) => s.scoped,
+            Value::Address(a) => a.scoped,
+            _ => false,
+        };
+
         let layout = self.layout()?;
         let bytes = bcs::to_bytes(&self).ok()?;
-        Some(OwnedSlice { layout, bytes })
+        Some(OwnedSlice {
+            layout,
+            bytes,
+            scoped,
+        })
     }
 
     /// Compute the type layout for this value, if possible.
@@ -633,7 +706,7 @@ impl Serialize for Value<'_> {
         S: serde::Serializer,
     {
         match self {
-            Value::Address(a) => a.serialize(serializer),
+            Value::Address(a) => a.bytes.serialize(serializer),
             Value::Bool(b) => b.serialize(serializer),
             Value::Bytes(b) => b.serialize(serializer),
             Value::Enum(e) => e.serialize(serializer),
@@ -758,7 +831,7 @@ impl<'s> TryFrom<Value<'s>> for Atom<'s> {
         use Value as V;
 
         Ok(match value {
-            V::Address(a) => A::Address(a),
+            V::Address(a) => A::Address(a.bytes),
             V::Bool(b) => A::Bool(b),
             V::U8(n) => A::U8(n),
             V::U16(n) => A::U16(n),
@@ -783,7 +856,7 @@ impl<'s> TryFrom<Value<'s>> for Atom<'s> {
                     .into_iter()
                     .map(|e| match e {
                         V::U8(b) => Ok(b),
-                        V::Slice(Slice { layout, bytes }) if layout == &L::U8 => {
+                        V::Slice(Slice { layout, bytes, .. }) if layout == &L::U8 => {
                             Ok(bcs::from_bytes(bytes)?)
                         }
                         _ => Err(FormatError::TransformInvalid("unexpected vector")),
@@ -793,7 +866,7 @@ impl<'s> TryFrom<Value<'s>> for Atom<'s> {
                 A::Bytes(Cow::Owned(bytes?))
             }
 
-            V::Slice(Slice { layout, bytes }) => match layout {
+            V::Slice(Slice { layout, bytes, .. }) => match layout {
                 L::Address => A::Address(bcs::from_bytes(bytes)?),
                 L::Bool => A::Bool(bcs::from_bytes(bytes)?),
                 L::U8 => A::U8(bcs::from_bytes(bytes)?),
@@ -861,7 +934,7 @@ pub(crate) mod tests {
     /// Mock Store implementation for testing.
     #[derive(Default, Clone)]
     pub struct MockStore {
-        data: BTreeMap<AccountAddress, OwnedSlice>,
+        data: BTreeMap<AccountAddress, (MoveTypeLayout, Vec<u8>)>,
     }
 
     impl MockStore {
@@ -902,7 +975,7 @@ pub(crate) mod tests {
                 ],
             }));
 
-            self.data.insert(df_id.into(), OwnedSlice { layout, bytes });
+            self.data.insert(df_id.into(), (layout, bytes));
             self
         }
 
@@ -953,18 +1026,8 @@ pub(crate) mod tests {
                 ],
             }));
 
-            let field = OwnedSlice {
-                layout: field_layout,
-                bytes: field_bytes,
-            };
-
-            let value = OwnedSlice {
-                layout: value_layout,
-                bytes: value_bytes,
-            };
-
-            self.data.insert(dof_id.into(), field);
-            self.data.insert(val_id, value);
+            self.data.insert(dof_id.into(), (field_layout, field_bytes));
+            self.data.insert(val_id, (value_layout, value_bytes));
             self
         }
 
@@ -978,23 +1041,21 @@ pub(crate) mod tests {
             value_layout: MoveTypeLayout,
         ) -> Self {
             let name_bytes = bcs::to_bytes(&name).unwrap();
+            let value_bytes = bcs::to_bytes(&value).unwrap();
             let name_type = TypeTag::from(&name_layout);
             let id = derive_object_id(parent, &name_type, &name_bytes).unwrap();
 
-            self.data.insert(
-                id.into(),
-                OwnedSlice {
-                    layout: value_layout,
-                    bytes: bcs::to_bytes(&value).unwrap(),
-                },
-            );
+            self.data.insert(id.into(), (value_layout, value_bytes));
             self
         }
     }
 
     #[async_trait]
     impl Store for MockStore {
-        async fn object(&self, id: AccountAddress) -> anyhow::Result<Option<OwnedSlice>> {
+        async fn latest(
+            &self,
+            id: AccountAddress,
+        ) -> anyhow::Result<Option<(MoveTypeLayout, Vec<u8>)>> {
             Ok(self.data.get(&id).cloned())
         }
     }
@@ -1066,6 +1127,7 @@ pub(crate) mod tests {
         let slice = Slice {
             layout: &L::U64,
             bytes,
+            scoped: false,
         };
 
         let serialized = bcs::to_bytes(&slice).unwrap();
@@ -1137,7 +1199,7 @@ pub(crate) mod tests {
     fn test_serialize_address() {
         let addr: AccountAddress = "0x1".parse().unwrap();
         assert_eq!(
-            bcs::to_bytes(&Value::Address(addr)).unwrap(),
+            bcs::to_bytes(&Value::Address(Address::latest(addr))).unwrap(),
             bcs::to_bytes(&addr).unwrap()
         );
     }
@@ -1186,7 +1248,7 @@ pub(crate) mod tests {
             fields: Fields::Named(vec![
                 ("x", Value::U32(100)),
                 ("y", Value::U32(200)),
-                ("z", Value::Address(addr)),
+                ("z", Value::Address(Address::latest(addr))),
             ]),
         });
 
@@ -1320,7 +1382,7 @@ pub(crate) mod tests {
             Value::U64(12345678),
             Value::U128(123456),
             Value::U256(U256::from(42u64)),
-            Value::Address("0x42".parse().unwrap()),
+            Value::Address(Address::latest("0x42".parse().unwrap())),
             Value::String(Cow::Borrowed("hello".as_bytes())),
             Value::Bytes(Cow::Borrowed(&[1, 2, 3])),
             Value::Vector(Vector {
@@ -1331,6 +1393,7 @@ pub(crate) mod tests {
                     Value::Slice(Slice {
                         layout: &L::U8,
                         bytes: &[6],
+                        scoped: false,
                     }),
                 ],
             }),
@@ -1378,46 +1441,57 @@ pub(crate) mod tests {
             Value::Slice(Slice {
                 layout: &L::Bool,
                 bytes: &bool_bytes,
+                scoped: false,
             }),
             Value::Slice(Slice {
                 layout: &L::U8,
                 bytes: &u8_bytes,
+                scoped: false,
             }),
             Value::Slice(Slice {
                 layout: &L::U16,
                 bytes: &u16_bytes,
+                scoped: false,
             }),
             Value::Slice(Slice {
                 layout: &L::U32,
                 bytes: &u32_bytes,
+                scoped: false,
             }),
             Value::Slice(Slice {
                 layout: &L::U64,
                 bytes: &u64_bytes,
+                scoped: false,
             }),
             Value::Slice(Slice {
                 layout: &L::U128,
                 bytes: &u128_bytes,
+                scoped: false,
             }),
             Value::Slice(Slice {
                 layout: &L::U256,
                 bytes: &u256_bytes,
+                scoped: false,
             }),
             Value::Slice(Slice {
                 layout: &L::Address,
                 bytes: &addr_bytes,
+                scoped: false,
             }),
             Value::Slice(Slice {
                 layout: &str_layout,
                 bytes: &str_bytes,
+                scoped: false,
             }),
             Value::Slice(Slice {
                 layout: &type_name_layout,
                 bytes: &type_name_bytes,
+                scoped: false,
             }),
             Value::Slice(Slice {
                 layout: &vec_layout,
                 bytes: &vec_bytes,
+                scoped: false,
             }),
         ];
 
@@ -1451,7 +1525,7 @@ pub(crate) mod tests {
             Value::U64(45),
             Value::U128(46),
             Value::U256(U256::from(47u64)),
-            Value::Address("0x48".parse().unwrap()),
+            Value::Address(Address::latest("0x48".parse().unwrap())),
             Value::String(Cow::Borrowed("hello".as_bytes())),
             Value::Bytes(Cow::Borrowed(&[1, 2, 3])),
         ];
@@ -1484,7 +1558,10 @@ pub(crate) mod tests {
             fields: Fields::Named(vec![
                 ("x", Value::U32(100)),
                 ("y", Value::U32(200)),
-                ("z", Value::Address("0x300".parse().unwrap())),
+                (
+                    "z",
+                    Value::Address(Address::latest("0x300".parse().unwrap())),
+                ),
             ]),
         });
 
@@ -1495,6 +1572,7 @@ pub(crate) mod tests {
             ),
             bytes: &bcs::to_bytes(&(100u32, 200u32, "0x300".parse::<AccountAddress>().unwrap()))
                 .unwrap(),
+            scoped: false,
         });
 
         let expect = json!({
@@ -1524,6 +1602,7 @@ pub(crate) mod tests {
                 vec![("A", vec![("b", L::U64), ("c", L::Bool)])],
             ),
             bytes: &bcs::to_bytes(&(0u8, 42u64, true)).unwrap(),
+            scoped: false,
         });
 
         let expect = json!({

--- a/crates/sui-display/src/v2/visitor/extractor.rs
+++ b/crates/sui-display/src/v2/visitor/extractor.rs
@@ -10,6 +10,7 @@ use sui_types::object::option_visitor::OptionVisitor;
 
 use crate::v2::error::FormatError;
 use crate::v2::value::Accessor;
+use crate::v2::value::Address;
 use crate::v2::value::Slice;
 use crate::v2::value::Value;
 use crate::v2::visitor::address::AddressExtractor;
@@ -105,9 +106,12 @@ impl<'v> AV::Visitor<'v, 'v> for Extractor<'v, '_> {
         a: AccountAddress,
     ) -> Result<Self::Value, Self::Error> {
         match self.path.last() {
-            Some(Accessor::DFIndex(_) | Accessor::DOFIndex(_)) => Ok(Some(Value::Address(a))),
+            Some(Accessor::DFIndex(_) | Accessor::DOFIndex(_) | Accessor::Derived(_)) => {
+                Ok(Some(Value::Address(Address::latest(a))))
+            }
+
             Some(_) => Ok(None),
-            None => Ok(Some(Value::Address(a))),
+            None => Ok(Some(Value::Address(Address::scoped(a)))),
         }
     }
 
@@ -129,6 +133,7 @@ impl<'v> AV::Visitor<'v, 'v> for Extractor<'v, '_> {
             return Ok(Some(Value::Slice(Slice {
                 layout: driver.layout()?,
                 bytes: &driver.bytes()[driver.start()..driver.position()],
+                scoped: false,
             })));
         };
 
@@ -154,6 +159,7 @@ impl<'v> AV::Visitor<'v, 'v> for Extractor<'v, '_> {
             return Ok(Some(Value::Slice(Slice {
                 layout: driver.layout()?,
                 bytes: &driver.bytes()[driver.start()..driver.position()],
+                scoped: false,
             })));
         };
 
@@ -166,7 +172,7 @@ impl<'v> AV::Visitor<'v, 'v> for Extractor<'v, '_> {
         ) {
             return AddressExtractor
                 .visit_struct(driver)
-                .map(|a| a.map(Value::Address));
+                .map(|a| a.map(|a| Value::Address(Address::latest(a))));
         }
 
         // If the next accessor is an index, then try and treat this struct as a VecMap, and
@@ -218,6 +224,7 @@ impl<'v> AV::Visitor<'v, 'v> for Extractor<'v, '_> {
             return Ok(Some(Value::Slice(Slice {
                 layout: driver.layout()?,
                 bytes: &driver.bytes()[driver.start()..driver.position()],
+                scoped: false,
             })));
         };
 

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/move_value/format_scope.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/move_value/format_scope.move
@@ -1,0 +1,97 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 118 --accounts A --addresses test=0x0 --simulator
+
+//# publish --sender A
+module test::mod {
+  use sui::derived_object;
+  use sui::dynamic_field as df;
+
+  public struct Root has key, store {
+    id: UID,
+    key: u64,
+  }
+
+  public struct Parent has key, store {
+    id: UID,
+  }
+
+  public struct Child has key, store {
+    id: UID,
+    count: u64,
+  }
+
+  public fun root(key: u64, ctx: &mut TxContext): Root {
+    Root {
+      id: object::new(ctx),
+      key,
+    }
+  }
+
+  public fun parent(ctx: &mut TxContext): Parent {
+    Parent { id: object::new(ctx) }
+  }
+
+  public fun dynamic_field(parent: &mut Parent, key: u64, count: u64, ctx: &mut TxContext) {
+    let value = Child {
+      id: object::new(ctx),
+      count,
+    };
+
+    df::add(&mut parent.id, key, value);
+  }
+
+  public fun derived(parent: &mut Parent, key: u64, count: u64): Child {
+    Child {
+      id: derived_object::claim(&mut parent.id, key),
+      count,
+    }
+  }
+
+  public fun inc_field(parent: &mut Parent, key: u64) {
+    let child: &mut Child = df::borrow_mut(&mut parent.id, key);
+    child.inc_child();
+  }
+
+  public fun inc_child(child: &mut Child) {
+    child.count = child.count + 1;
+  }
+}
+
+//# programmable --sender A --inputs @A 7u64
+//> 0: test::mod::root(Input(1));
+//> 1: TransferObjects([Result(0)], Input(0))
+
+//# programmable --sender A --inputs @A
+//> 0: test::mod::parent();
+//> 1: TransferObjects([Result(0)], Input(0))
+
+//# create-checkpoint
+
+//# programmable --sender A --inputs object(3,0) 7u64 111u64
+//> 0: test::mod::dynamic_field(Input(0), Input(1), Input(2))
+
+//# programmable --sender A --inputs object(3,0) 7u64
+//> 0: test::mod::inc_field(Input(0), Input(1))
+
+//# programmable --sender A --inputs object(3,0) 7u64 333u64 @A
+//> 0: test::mod::derived(Input(0), Input(1), Input(2));
+//> 1: TransferObjects([Result(0)], Input(3))
+
+//# programmable --sender A --inputs object(7,1)
+//> 0: test::mod::inc_child(Input(0))
+
+//# create-checkpoint
+
+//# run-graphql
+{
+  object(address: "@{obj_2_0}", rootVersion: 3) {
+    asMoveObject {
+      contents {
+        dynamicField: format(format: "{@@{obj_3_0}->[key].count}")
+        derivedObject: format(format: "{@@{obj_3_0}~>[key].count}")
+      }
+    }
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/move_value/format_scope.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/move_value/format_scope.snap
@@ -1,0 +1,79 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 11 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-60:
+//# publish --sender A
+created: object(1,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 8109200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 62-64:
+//# programmable --sender A --inputs @A 7u64
+//> 0: test::mod::root(Input(1));
+//> 1: TransferObjects([Result(0)], Input(0))
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2295200,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 3, lines 66-68:
+//# programmable --sender A --inputs @A
+//> 0: test::mod::parent();
+//> 1: TransferObjects([Result(0)], Input(0))
+created: object(3,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2249600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 4, line 70:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 5, lines 72-73:
+//# programmable --sender A --inputs object(3,0) 7u64 111u64
+//> 0: test::mod::dynamic_field(Input(0), Input(1), Input(2))
+created: object(5,0)
+mutated: object(0,0), object(3,0)
+gas summary: computation_cost: 1000000, storage_cost: 4286400,  storage_rebate: 2227104, non_refundable_storage_fee: 22496
+
+task 6, lines 75-76:
+//# programmable --sender A --inputs object(3,0) 7u64
+//> 0: test::mod::inc_field(Input(0), Input(1))
+mutated: object(0,0), object(3,0), object(5,0)
+gas summary: computation_cost: 1000000, storage_cost: 4286400,  storage_rebate: 4243536, non_refundable_storage_fee: 42864
+
+task 7, lines 78-80:
+//# programmable --sender A --inputs object(3,0) 7u64 333u64 @A
+//> 0: test::mod::derived(Input(0), Input(1), Input(2));
+//> 1: TransferObjects([Result(0)], Input(3))
+created: object(7,0), object(7,1)
+mutated: object(0,0), object(3,0)
+gas summary: computation_cost: 1000000, storage_cost: 6057200,  storage_rebate: 2227104, non_refundable_storage_fee: 22496
+
+task 8, lines 82-83:
+//# programmable --sender A --inputs object(7,1)
+//> 0: test::mod::inc_child(Input(0))
+mutated: object(0,0), object(7,1)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 2279772, non_refundable_storage_fee: 23028
+
+task 9, line 85:
+//# create-checkpoint
+Checkpoint created: 2
+
+task 10, lines 87-97:
+//# run-graphql
+Response: {
+  "data": {
+    "object": {
+      "asMoveObject": {
+        "contents": {
+          "dynamicField": "112",
+          "derivedObject": "334"
+        }
+      }
+    }
+  }
+}

--- a/crates/sui-indexer-alt-graphql/src/api/types/dynamic_field.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/dynamic_field.rs
@@ -565,10 +565,10 @@ impl DynamicField {
 
         #[async_trait]
         impl sui_display::v2::Store for NopStore {
-            async fn object(
+            async fn latest(
                 &self,
                 _: AccountAddress,
-            ) -> anyhow::Result<Option<sui_display::v2::OwnedSlice>> {
+            ) -> anyhow::Result<Option<(MoveTypeLayout, Vec<u8>)>> {
                 bail!("Dynamic loads not supported")
             }
         }
@@ -576,10 +576,8 @@ impl DynamicField {
         let limits: &Limits = ctx.data()?;
         let limits = limits.display();
 
-        let root = sui_display::v2::OwnedSlice {
-            layout: MoveTypeLayout::Bool,
-            bytes: bcs::to_bytes(&false).unwrap(),
-        };
+        let root =
+            sui_display::v2::OwnedSlice::new(MoveTypeLayout::Bool, bcs::to_bytes(&false).unwrap());
 
         let parsed =
             sui_display::v2::Name::parse(limits, &literal).map_err(|e| bad_user_input(e.into()))?;

--- a/crates/sui-indexer-alt-graphql/src/api/types/move_value.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/move_value.rs
@@ -230,11 +230,7 @@ impl MoveValue {
             if let Some(display_v2) = display_v2.map_err(upcast)? {
                 let store = DisplayStore::new(ctx, &self.type_.scope);
 
-                let root = sui_display::v2::OwnedSlice {
-                    bytes: self.native.clone(),
-                    layout,
-                };
-
+                let root = sui_display::v2::OwnedSlice::new(layout, self.native.clone());
                 let interpreter = sui_display::v2::Interpreter::new(root, store);
 
                 for (field, value) in
@@ -316,13 +312,10 @@ impl MoveValue {
             let store = DisplayStore::new(ctx, &self.type_.scope);
 
             // Create an interpreter that combines the root value with the store
-            let root = sui_display::v2::OwnedSlice {
-                bytes: self.native.clone(),
-                layout,
-            };
+            let root = sui_display::v2::OwnedSlice::new(layout, self.native.clone());
+            let interpreter = sui_display::v2::Interpreter::new(root, store);
 
             // Evaluate the extraction and convert to an owned slice
-            let interpreter = sui_display::v2::Interpreter::new(root, store);
             let Some(value) = extract
                 .extract(&interpreter)
                 .await
@@ -334,12 +327,19 @@ impl MoveValue {
             let Some(sui_display::v2::OwnedSlice {
                 layout,
                 bytes: native,
+                scoped,
             }) = value.into_owned_slice()
             else {
                 return Err(bad_user_input(Error::NotASlice));
             };
 
-            let type_ = MoveType::from_layout(layout, self.type_.scope.clone());
+            let scope = if scoped {
+                self.type_.scope.clone()
+            } else {
+                self.type_.scope.without_root_bound()
+            };
+
+            let type_ = MoveType::from_layout(layout, scope);
             Ok(Some(MoveValue { type_, native }))
         }
         .await
@@ -364,11 +364,7 @@ impl MoveValue {
             };
 
             let store = DisplayStore::new(ctx, &self.type_.scope);
-            let root = sui_display::v2::OwnedSlice {
-                bytes: self.native.clone(),
-                layout,
-            };
-
+            let root = sui_display::v2::OwnedSlice::new(layout, self.native.clone());
             let interpreter = sui_display::v2::Interpreter::new(root, store);
             let value = parsed
                 .format::<serde_json::Value>(
@@ -435,41 +431,15 @@ impl<'f, 'r> DisplayStore<'f, 'r> {
     fn new(ctx: &'f Context<'r>, scope: &'f Scope) -> Self {
         Self { ctx, scope }
     }
-}
 
-impl JsonVisitor {
-    fn new(limits: &Limits) -> Self {
-        Self {
-            size_budget: limits.max_move_value_bound,
-            depth_budget: limits.max_move_value_depth,
-        }
-    }
-
-    fn deserialize_value(
-        &mut self,
-        bytes: &[u8],
-        layout: &A::MoveTypeLayout,
-    ) -> Result<serde_json::Value, RV::Error> {
-        A::MoveValue::visit_deserialize(
-            bytes,
-            layout,
-            &mut RV::RpcVisitor::new(RV::LocalMeter::new(
-                &mut self.size_budget,
-                self.depth_budget,
-            )),
-        )
-    }
-}
-
-#[async_trait]
-impl<'f, 'r> sui_display::v2::Store for DisplayStore<'f, 'r> {
-    async fn object(
+    async fn fetch(
         &self,
+        scope: Scope,
         id: AccountAddress,
-    ) -> anyhow::Result<Option<sui_display::v2::OwnedSlice>> {
+    ) -> anyhow::Result<Option<(A::MoveTypeLayout, Vec<u8>)>> {
         // NOTE: We can't use `anyhow::Context` here because `RpcError` doesn't implement
         // `std::error::Error`.
-        let object = Object::latest(self.ctx, self.scope.clone(), id.into())
+        let object = Object::latest(self.ctx, scope, id.into())
             .await
             .map_err(|e| anyhow!("Failed to fetch object: {e:?}"))?;
 
@@ -503,7 +473,48 @@ impl<'f, 'r> sui_display::v2::Store for DisplayStore<'f, 'r> {
         };
 
         let bytes = move_object.contents().to_owned();
-        Ok(Some(sui_display::v2::OwnedSlice { layout, bytes }))
+        Ok(Some((layout, bytes)))
+    }
+}
+
+impl JsonVisitor {
+    fn new(limits: &Limits) -> Self {
+        Self {
+            size_budget: limits.max_move_value_bound,
+            depth_budget: limits.max_move_value_depth,
+        }
+    }
+
+    fn deserialize_value(
+        &mut self,
+        bytes: &[u8],
+        layout: &A::MoveTypeLayout,
+    ) -> Result<serde_json::Value, RV::Error> {
+        A::MoveValue::visit_deserialize(
+            bytes,
+            layout,
+            &mut RV::RpcVisitor::new(RV::LocalMeter::new(
+                &mut self.size_budget,
+                self.depth_budget,
+            )),
+        )
+    }
+}
+
+#[async_trait]
+impl<'f, 'r> sui_display::v2::Store for DisplayStore<'f, 'r> {
+    async fn latest(
+        &self,
+        id: AccountAddress,
+    ) -> anyhow::Result<Option<(A::MoveTypeLayout, Vec<u8>)>> {
+        self.fetch(self.scope.without_root_bound(), id).await
+    }
+
+    async fn scoped(
+        &self,
+        id: AccountAddress,
+    ) -> anyhow::Result<Option<(A::MoveTypeLayout, Vec<u8>)>> {
+        self.fetch(self.scope.clone(), id).await
     }
 }
 

--- a/crates/sui-indexer-alt-jsonrpc/src/api/objects/response.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/objects/response.rs
@@ -244,11 +244,7 @@ async fn display_fields(
 
     if let Some(display_v2) = display_v2? {
         let store = DisplayStore::new(ctx);
-        let root = sui_display::v2::OwnedSlice {
-            bytes: object.contents().to_owned(),
-            layout,
-        };
-
+        let root = sui_display::v2::OwnedSlice::new(layout, object.contents().to_owned());
         let interpreter = sui_display::v2::Interpreter::new(root, store);
         let fields = sui_display::v2::Display::parse(config.display(), display_v2.fields())?
             .display(
@@ -329,10 +325,10 @@ impl<'c> DisplayStore<'c> {
 
 #[async_trait]
 impl sui_display::v2::Store for DisplayStore<'_> {
-    async fn object(
+    async fn latest(
         &self,
         id: move_core_types::account_address::AccountAddress,
-    ) -> anyhow::Result<Option<sui_display::v2::OwnedSlice>> {
+    ) -> anyhow::Result<Option<(move_core_types::annotated_value::MoveTypeLayout, Vec<u8>)>> {
         let Some(object) = load_live(self.ctx, id.into())
             .await
             .context("Failed to fetch object")?
@@ -352,9 +348,6 @@ impl sui_display::v2::Store for DisplayStore<'_> {
             .await
             .context("Failed to resolve type layout")?;
 
-        Ok(Some(sui_display::v2::OwnedSlice {
-            layout,
-            bytes: move_object.contents().to_owned(),
-        }))
+        Ok(Some((layout, move_object.contents().to_owned())))
     }
 }

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -163,10 +163,10 @@ impl<'s> DisplayStore<'s> {
 
 #[async_trait]
 impl sui_display::v2::Store for DisplayStore<'_> {
-    async fn object(
+    async fn latest(
         &self,
         id: AccountAddress,
-    ) -> anyhow::Result<Option<sui_display::v2::OwnedSlice>> {
+    ) -> anyhow::Result<Option<(MoveTypeLayout, Vec<u8>)>> {
         let read = self.state.get_object_read(&id.into())?;
         let ObjectRead::Exists(_, object, Some(layout)) = read else {
             return Ok(None);
@@ -176,10 +176,10 @@ impl sui_display::v2::Store for DisplayStore<'_> {
             return Ok(None);
         };
 
-        Ok(Some(sui_display::v2::OwnedSlice {
-            bytes: move_object.contents().to_vec(),
-            layout: MoveTypeLayout::Struct(Box::new(layout)),
-        }))
+        Ok(Some((
+            MoveTypeLayout::Struct(Box::new(layout)),
+            move_object.contents().to_vec(),
+        )))
     }
 }
 
@@ -1354,11 +1354,7 @@ async fn get_display_fields(
 
     let display: Vec<(String, Result<Json, anyhow::Error>)> =
         if let Some(display_object) = get_display_object_v2_by_type(fullnode_api, type_)? {
-            let root = sui_display::v2::OwnedSlice {
-                bytes: move_object.contents().to_owned(),
-                layout,
-            };
-
+            let root = sui_display::v2::OwnedSlice::new(layout, move_object.contents().to_owned());
             let store = DisplayStore::new(fullnode_api.state.as_ref());
             let interpreter = sui_display::v2::Interpreter::new(root, store);
             let limits = sui_display::v2::Limits {

--- a/crates/sui-rpc-api/src/grpc/v2/render.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/render.rs
@@ -81,10 +81,7 @@ impl RpcService {
             .ok()
             .flatten()?;
 
-        let root = sui_display::v2::OwnedSlice {
-            bytes: contents.to_owned(),
-            layout,
-        };
+        let root = sui_display::v2::OwnedSlice::new(layout, contents.to_owned());
         let interpreter = sui_display::v2::Interpreter::new(root, DisplayStore::new(&self.reader));
 
         let mut display = Display::default();

--- a/crates/sui-rpc-api/src/reader.rs
+++ b/crates/sui-rpc-api/src/reader.rs
@@ -223,10 +223,10 @@ impl<'s> DisplayStore<'s> {
 
 #[async_trait::async_trait]
 impl sui_display::v2::Store for DisplayStore<'_> {
-    async fn object(
+    async fn latest(
         &self,
         id: move_core_types::account_address::AccountAddress,
-    ) -> anyhow::Result<Option<sui_display::v2::OwnedSlice>> {
+    ) -> anyhow::Result<Option<(move_core_types::annotated_value::MoveTypeLayout, Vec<u8>)>> {
         let Some(object) = self.state.inner().get_object(&id.into()) else {
             return Ok(None);
         };
@@ -241,9 +241,6 @@ impl sui_display::v2::Store for DisplayStore<'_> {
             return Ok(None);
         };
 
-        Ok(Some(sui_display::v2::OwnedSlice {
-            bytes: move_object.contents().to_vec(),
-            layout,
-        }))
+        Ok(Some((layout, move_object.contents().to_vec())))
     }
 }


### PR DESCRIPTION
## Description

Previously Display's `Store` trait only supported one kind of object load. For most implementors, this was fine, but for GraphQL, we need to be able to differentiate between an object load that is scoped within the confines of a parent object, and an object load that is targeting the latest version of an object.

This changes introduces that distinction, so that it's possible to use some part of the parent object as the key for a dynamic field on some other object or derived object rooted on some other object.

## Test plan

New unit tests for `sui-display`:

```
$ cargo nextest run -p sui-display
```

New E2E tests for versioning behavior:

```
$ cargo nextest run -p sui-indexer-alt-e2e-tests
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [x] GraphQL: Fixes an issue where a derived object or dynamic field load could be incorrectly bounded by the version of the object containing the derived object key, instead of the parent.
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
