### PR TITLE
Cherry-pick: Revert "[consensus] enable fifo compaction for all networks (#26149)"

### DIFF
--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -3,10 +3,10 @@
 
 use std::{sync::Arc, time::Instant};
 
-use consensus_config::ConsensusProtocolConfig;
 use consensus_config::{
     AuthorityIndex, Committee, NetworkKeyPair, NetworkPublicKey, Parameters, ProtocolKeyPair,
 };
+use consensus_config::{ChainType, ConsensusProtocolConfig};
 use consensus_types::block::Round;
 use itertools::Itertools;
 use mysten_metrics::spawn_logged_monitored_task;
@@ -241,7 +241,8 @@ where
         let store_path = context.parameters.db_path.as_path().to_str().unwrap();
         let store = Arc::new(RocksDBStore::new(
             store_path,
-            context.parameters.use_fifo_compaction,
+            context.parameters.use_fifo_compaction
+                && context.protocol_config.chain() != ChainType::Mainnet,
         ));
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
 


### PR DESCRIPTION
## Summary
- Cherry-pick of #26211 to the v1.70 release branch
- Reverts #26149, which enabled FIFO compaction for all networks including mainnet
- Restores the mainnet guard that restricts FIFO compaction to non-mainnet chains

## Test plan
- CI passes
- Monitor metrics on validators

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>