### PR TITLE
[sui-types]: change ExecutionStatus::new_failure() to accept ExecutionFaillure

### DIFF
--- a/crates/sui-core/src/accumulators/object_funds_checker/unit_tests.rs
+++ b/crates/sui-core/src/accumulators/object_funds_checker/unit_tests.rs
@@ -12,7 +12,7 @@ use sui_types::{
     crypto::get_account_key_pair,
     executable_transaction::VerifiedExecutableTransaction,
     execution_params::FundsWithdrawStatus,
-    execution_status::{ExecutionErrorKind, ExecutionStatus},
+    execution_status::{ExecutionErrorKind, ExecutionFailure, ExecutionStatus},
 };
 
 use crate::{
@@ -381,7 +381,10 @@ async fn test_should_commit_early_exits() {
     // Failed execution should always commit.
     assert!(checker.should_commit_object_funds_withdraws(
         &tx,
-        &ExecutionStatus::new_failure(ExecutionErrorKind::FunctionNotFound, None,),
+        &ExecutionStatus::new_failure(ExecutionFailure::new(
+            ExecutionErrorKind::FunctionNotFound,
+            None,
+        )),
         &withdraws,
         &ExecutionEnv::new().with_assigned_versions(AssignedVersions::new(
             vec![],

--- a/crates/sui-core/src/unit_tests/gas_tests.rs
+++ b/crates/sui-core/src/unit_tests/gas_tests.rs
@@ -13,7 +13,7 @@ use once_cell::sync::Lazy;
 use sui_protocol_config::ProtocolConfig;
 use sui_types::crypto::AccountKeyPair;
 use sui_types::effects::SignedTransactionEffects;
-use sui_types::execution_status::{ExecutionErrorKind, ExecutionStatus};
+use sui_types::execution_status::{ExecutionErrorKind, ExecutionFailure, ExecutionStatus};
 use sui_types::gas_coin::GasCoin;
 use sui_types::object::GAS_VALUE_FOR_TESTING;
 use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
@@ -582,7 +582,10 @@ async fn test_transfer_sui_insufficient_gas() {
     // We expect this to fail due to insufficient gas.
     assert_eq!(
         *effects.status(),
-        ExecutionStatus::new_failure(ExecutionErrorKind::InsufficientGas, None)
+        ExecutionStatus::new_failure(ExecutionFailure::new(
+            ExecutionErrorKind::InsufficientGas,
+            None
+        ))
     );
     // Ensure that the owner of the object did not change if the transfer failed.
     assert_eq!(

--- a/crates/sui-json-rpc/src/balance_changes.rs
+++ b/crates/sui-json-rpc/src/balance_changes.rs
@@ -250,7 +250,7 @@ mod tests {
         AccumulatorAddress, AccumulatorOperation, AccumulatorValue, AccumulatorWriteV1,
         EffectsObjectChange,
     };
-    use sui_types::execution_status::{ExecutionFailureStatus, ExecutionStatus};
+    use sui_types::execution_status::{ExecutionFailure, ExecutionFailureStatus, ExecutionStatus};
     use sui_types::gas::GasCostSummary;
     use sui_types::gas_coin::GAS;
     use sui_types::object::MoveObject;
@@ -335,7 +335,10 @@ mod tests {
         );
 
         let effects = TransactionEffects::new_from_execution_v2(
-            ExecutionStatus::new_failure(ExecutionFailureStatus::InsufficientGas, None),
+            ExecutionStatus::new_failure(ExecutionFailure::new(
+                ExecutionFailureStatus::InsufficientGas,
+                None,
+            )),
             0,
             GasCostSummary::new(gas_deduction, 0, 0, 0),
             vec![],
@@ -387,7 +390,10 @@ mod tests {
         changed_objects.insert(obj_id, change);
 
         TransactionEffects::new_from_execution_v2(
-            ExecutionStatus::new_failure(ExecutionFailureStatus::InsufficientGas, None),
+            ExecutionStatus::new_failure(ExecutionFailure::new(
+                ExecutionFailureStatus::InsufficientGas,
+                None,
+            )),
             0,
             GasCostSummary::new(amount, 0, 0, 0),
             vec![],
@@ -442,7 +448,10 @@ mod tests {
         changed_objects.insert(acc_obj_id, acc_change);
 
         let effects = TransactionEffects::new_from_execution_v2(
-            ExecutionStatus::new_failure(ExecutionFailureStatus::InsufficientGas, None),
+            ExecutionStatus::new_failure(ExecutionFailure::new(
+                ExecutionFailureStatus::InsufficientGas,
+                None,
+            )),
             0,
             GasCostSummary::new(gas_deduction, 0, 0, 0),
             vec![],
@@ -507,7 +516,10 @@ mod tests {
     #[tokio::test]
     async fn test_failed_txn_zero_gas_no_objects_returns_empty() {
         let effects = TransactionEffects::new_from_execution_v2(
-            ExecutionStatus::new_failure(ExecutionFailureStatus::InsufficientGas, None),
+            ExecutionStatus::new_failure(ExecutionFailure::new(
+                ExecutionFailureStatus::InsufficientGas,
+                None,
+            )),
             0,
             GasCostSummary::new(0, 0, 0, 0),
             vec![],

--- a/crates/sui-types/src/execution_status.rs
+++ b/crates/sui-types/src/execution_status.rs
@@ -29,6 +29,12 @@ pub struct ExecutionFailure {
     pub command: Option<CommandIndex>,
 }
 
+impl ExecutionFailure {
+    pub fn new(error: ExecutionErrorKind, command: Option<CommandIndex>) -> Self {
+        ExecutionFailure { error, command }
+    }
+}
+
 impl From<ExecutionError> for ExecutionFailure {
     fn from(value: ExecutionError) -> Self {
         Self {
@@ -451,11 +457,8 @@ impl Display for MoveLocation {
 }
 
 impl ExecutionStatus {
-    pub fn new_failure(
-        error: ExecutionErrorKind,
-        command: Option<CommandIndex>,
-    ) -> ExecutionStatus {
-        ExecutionStatus::Failure(ExecutionFailure { error, command })
+    pub fn new_failure(failure: ExecutionFailure) -> ExecutionStatus {
+        ExecutionStatus::Failure(failure)
     }
 
     pub fn is_ok(&self) -> bool {

--- a/sui-execution/latest/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/latest/sui-adapter/src/execution_engine.rs
@@ -63,7 +63,7 @@ mod checked {
     use sui_types::effects::TransactionEffects;
     use sui_types::error::{ExecutionError, ExecutionErrorTrait};
     use sui_types::execution::{ExecutionTiming, ResultWithTimings};
-    use sui_types::execution_status::{ExecutionErrorKind, ExecutionFailure, ExecutionStatus};
+    use sui_types::execution_status::{ExecutionErrorKind, ExecutionStatus};
     use sui_types::gas::GasCostSummary;
     use sui_types::gas::SuiGasStatus;
     use sui_types::id::UID;
@@ -255,8 +255,7 @@ mod checked {
                 _ => (),
             };
 
-            let ExecutionFailure { error, command } = error.to_execution_failure();
-            ExecutionStatus::new_failure(error, command)
+            ExecutionStatus::new_failure(error.to_execution_failure())
         } else {
             ExecutionStatus::Success
         };

--- a/sui-execution/v0/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/v0/sui-adapter/src/execution_engine.rs
@@ -145,8 +145,7 @@ mod checked {
                 _ => (),
             };
 
-            let (status, command) = error.to_execution_status();
-            ExecutionStatus::new_failure(status, command)
+            ExecutionStatus::new_failure(error.to_execution_failure())
         } else {
             ExecutionStatus::Success
         };

--- a/sui-execution/v1/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/v1/sui-adapter/src/execution_engine.rs
@@ -157,8 +157,7 @@ mod checked {
                 _ => (),
             };
 
-            let (status, command) = error.to_execution_status();
-            ExecutionStatus::new_failure(status, command)
+            ExecutionStatus::new_failure(error.to_execution_failure())
         } else {
             ExecutionStatus::Success
         };

--- a/sui-execution/v2/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/v2/sui-adapter/src/execution_engine.rs
@@ -169,8 +169,7 @@ mod checked {
                 _ => (),
             };
 
-            let (status, command) = error.to_execution_status();
-            ExecutionStatus::new_failure(status, command)
+            ExecutionStatus::new_failure(error.to_execution_failure())
         } else {
             ExecutionStatus::Success
         };

--- a/sui-execution/v3/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/v3/sui-adapter/src/execution_engine.rs
@@ -229,8 +229,7 @@ mod checked {
                 _ => (),
             };
 
-            let (status, command) = error.to_execution_status();
-            ExecutionStatus::new_failure(status, command)
+            ExecutionStatus::new_failure(error.to_execution_failure())
         } else {
             ExecutionStatus::Success
         };


### PR DESCRIPTION
## Description 

ExecutionFailure is the new smallest unit of error passed into ExecutionStatus. PR changes ExecutionStatus new_failure() function to be more inline with this ExecutionFailure type #25555 

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
