### PR TITLE
[trace-view] Added support for reading large traces

### DIFF
--- a/external-crates/move/crates/move-analyzer/trace-adapter/package-lock.json
+++ b/external-crates/move/crates/move-analyzer/trace-adapter/package-lock.json
@@ -12,8 +12,8 @@
         "@iarna/toml": "^2.2.5",
         "@vscode/debugadapter": "^1.56.0",
         "@vscode/debugprotocol": "1.66.0",
-        "fzstd": "^0.1.1",
-        "lodash.snakecase": "^4.1.1"
+        "lodash.snakecase": "^4.1.1",
+        "zstddec": "^0.2.0"
       },
       "devDependencies": {
         "@types/lodash.snakecase": "^4.1.9",
@@ -1118,12 +1118,6 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
-    },
-    "node_modules/fzstd": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/fzstd/-/fzstd-0.1.1.tgz",
-      "integrity": "sha512-dkuVSOKKwh3eas5VkJy1AW1vFpet8TA/fGmVA5krThl8YcOVE/8ZIoEA1+U1vEn5ckxxhLirSdY837azmbaNHA==",
-      "license": "MIT"
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
@@ -2253,6 +2247,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/zstddec": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/zstddec/-/zstddec-0.2.0.tgz",
+      "integrity": "sha512-oyPnDa1X5c13+Y7mA/FDMNJrn4S8UNBe0KCqtDmor40Re7ALrPN6npFwyYVRRh+PqozZQdeg23QtbcamZnG5rA==",
+      "license": "MIT AND BSD-3-Clause"
     }
   }
 }

--- a/external-crates/move/crates/move-analyzer/trace-adapter/package.json
+++ b/external-crates/move/crates/move-analyzer/trace-adapter/package.json
@@ -40,7 +40,7 @@
     "@iarna/toml": "^2.2.5",
     "@vscode/debugadapter": "^1.56.0",
     "@vscode/debugprotocol": "1.66.0",
-    "fzstd": "^0.1.1",
+    "zstddec": "^0.2.0",
     "lodash.snakecase": "^4.1.1"
   }
 }

--- a/external-crates/move/crates/move-analyzer/trace-adapter/src/trace_utils.ts
+++ b/external-crates/move/crates/move-analyzer/trace-adapter/src/trace_utils.ts
@@ -20,7 +20,12 @@
 
 
 import * as fs from 'fs';
-import { FRAME_LIFETIME, ModuleInfo } from './utils';
+import {
+    FRAME_LIFETIME,
+    ModuleInfo,
+    streamDecompressedLines,
+    getDecoder,
+} from './utils';
 import {
     IRuntimeCompoundValue,
     RuntimeValueType,
@@ -40,7 +45,7 @@ import {
     ILoc,
     IDebugInfoFunction
 } from './debug_info_utils';
-import { decompress } from 'fzstd';
+import { logger } from "@vscode/debugadapter"
 
 
 // Data types corresponding to trace file JSON schema.
@@ -239,11 +244,6 @@ interface JSONTraceEvent {
     Effect?: JSONTraceEffect;
     CloseFrame?: JSONTraceCloseFrame;
     External?: JSONTraceExt;
-}
-
-interface JSONTraceRootObject {
-    events: JSONTraceEvent[];
-    version: number;
 }
 
 // Runtime data types.
@@ -454,36 +454,11 @@ export const EXT_EVENT_FRAME_ID = Number.MAX_SAFE_INTEGER - 4;
 
 
 /**
- * Splits decompressed trace file data into lines without creating a large intermediate string.
- * This avoids hitting JavaScript's maximum string length limit for large trace files.
- *
- * @param decompressed the decompressed buffer containing trace data
- * @returns array of strings representing lines from the trace file
- */
-function splitTraceFileLines(decompressed: Uint8Array): string[] {
-    const NEWLINE_BYTE = 0x0A;
-    const decoder = new TextDecoder();
-    const lines: string[] = [];
-
-    let lineStart = 0;
-
-    for (let i = 0; i <= decompressed.length; i++) {
-        if (i === decompressed.length || decompressed[i] === NEWLINE_BYTE) {
-            // end of the buffer or a new line
-            if (i > lineStart) {
-                const lineBytes = decompressed.slice(lineStart, i);
-                const line = decoder.decode(lineBytes).trimEnd();
-                lines.push(line);
-            }
-            lineStart = i + 1;
-        }
-    }
-
-    return lines;
-}
-
-/**
  * Reads a Move VM execution trace from a JSON file.
+ *
+ * The compressed file is read in full but decompressed and parsed one line at
+ * a time via `streamDecompressedLines`, so peak memory is proportional to the
+ * kept events (small) rather than the raw trace size (potentially multi-GB).
  *
  * @param traceFilePath path to the trace JSON file.
  * @param srcDebugInfosHashMap a map from file hash to debug info.
@@ -501,22 +476,31 @@ export async function readTrace(
     bcodeDebugInfosModMap: Map<string, IDebugInfo>,
     filesMap: Map<string, IFileInfo>,
 ): Promise<ITrace> {
-    const buf = Buffer.from(fs.readFileSync(traceFilePath));
-    const decompressed = await decompress(buf);
-    const lines = splitTraceFileLines(decompressed);
-    const [header, ...rest] = lines;
-    const jsonVersion: number = JSON.parse(header).version;
-    const jsonEvents: JSONTraceEvent[] = rest.map((line) => {
-        return JSON.parse(line);
-    });
-
-    const traceJSON: JSONTraceRootObject = {
-        events: jsonEvents,
-        version: jsonVersion,
-    };
-    if (traceJSON.events.length === 0) {
-        throw new Error('Trace contains no events');
+    const buf = fs.readFileSync(traceFilePath);
+    const u8 = new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength);
+    const decoder = await getDecoder();
+    // Push/Pop effects that don't contain references are only used by
+    // extendLifetimeIfReference, which is a no-op for non-reference values.
+    // Skipping these at the byte level avoids expensive TextDecoder +
+    // JSON.parse on potentially very large lines in big traces.
+    function skipPushPopWithoutRef(lineBytes: Buffer): boolean {
+        if (lineBytes.indexOf('{"Effect":{"Push"') === 0 ||
+            lineBytes.indexOf('{"Effect":{"Pop"') === 0) {
+            return !lineBytes.includes('Ref');
+        }
+        return false;
     }
+
+    const lineIterator = streamDecompressedLines(u8, decoder, skipPushPopWithoutRef);
+
+    // First line is the version header — skip it.
+    const headerResult = lineIterator.next();
+    if (headerResult.done) {
+        throw new Error('Empty trace file');
+    }
+
+    let eventCount = 0;
+    let lastProgressTime = Date.now();
     const events: TraceEvent[] = [];
     // We compute the end of lifetime for a local variable as follows.
     // When a given local variable is read or written in an effect, we set the end of its lifetime
@@ -542,7 +526,14 @@ export async function readTrace(
     const tracedBcodeLines = new Map<string, Set<number>>();
     // stack of frame infos OpenFrame and popped on CloseFrame
     const frameInfoStack: ITraceGenFrameInfo[] = [];
-    for (const event of traceJSON.events) {
+    for (const line of lineIterator) {
+        eventCount++;
+        const event = JSON.parse(line) as JSONTraceEvent;
+        const now = Date.now();
+        if (now - lastProgressTime >= 5000) {
+            logger.log(`Processing trace: ${eventCount} events parsed so far...`);
+            lastProgressTime = now;
+        }
         if (event.OpenFrame) {
             const localsTypes = [];
             const frame = event.OpenFrame.frame;
@@ -895,6 +886,9 @@ export async function readTrace(
                 });
             }
         }
+    }
+    if (eventCount === 0) {
+        throw new Error('Trace contains no events');
     }
     return { events, localLifetimeEnds, tracedSrcLines, tracedBcodeLines };
 }

--- a/external-crates/move/crates/move-analyzer/trace-adapter/src/utils.ts
+++ b/external-crates/move/crates/move-analyzer/trace-adapter/src/utils.ts
@@ -31,3 +31,147 @@ export const COMPRESSED_FILE_EXT = ".zst";
  */
 export const TRACE_FILE_EXT = JSON_FILE_EXT + COMPRESSED_FILE_EXT;
 
+/**
+ * Size of batches (in decompressed bytes) accumulated before line splitting.
+ * Larger batches reduce per-chunk overhead; 100 MB keeps peak memory modest
+ * even on machines with limited RAM.
+ */
+const DECOMPRESS_BATCH_SIZE = 100 * 1024 * 1024;
+
+/**
+ * Shape of the `ZSTDDecoder` class from the `zstddec/stream` package.
+ * Hand-typed here because we load the package via `await import()` (its module
+ * format is not directly compatible with the format this project compiles to)
+ * and need a local type to work with the returned object.
+ */
+interface ZstdDecoder {
+    init(): Promise<void>;
+    decode(array: Uint8Array, uncompressedSize?: number): Uint8Array;
+    decodeStreaming(arrays: Iterable<Uint8Array>): Generator<Uint8Array>;
+}
+
+let decoderPromise: Promise<ZstdDecoder> | undefined;
+
+/**
+ * Returns a lazily-initialized, cached `ZSTDDecoder` instance from
+ * the `zstddec/stream` package.
+ */
+export async function getDecoder(): Promise<ZstdDecoder> {
+    if (!decoderPromise) {
+        decoderPromise = (async () => {
+            const mod = await import('zstddec/stream');
+            const decoder = new mod.ZSTDDecoder();
+            await decoder.init();
+            return decoder as unknown as ZstdDecoder;
+        })();
+    }
+    return decoderPromise;
+}
+
+/**
+ * Decompresses a Zstandard-compressed buffer.
+ *
+ * Accepts a `Uint8Array` rather than a file path so that it can be reused
+ * unmodified by the browser-based consumer of this package.
+ *
+ * @param input the compressed Zstandard data.
+ * @returns the decompressed bytes.
+ */
+export async function decompressZstd(input: Uint8Array): Promise<Uint8Array> {
+    const decoder = await getDecoder();
+    try {
+        return decoder.decode(input);
+    } catch (err) {
+        const reason = err instanceof Error ? err.message : String(err);
+        throw new Error(
+            `Failed to decompress zstd data (${input.length} bytes): ${reason}`
+        );
+    }
+}
+
+/**
+ * Accumulates the small decompressed chunks (~128 KB each) produced by
+ * `decodeStreaming` into larger batches before yielding result to the caller.
+ * This reduces the number of JS→WASM roundtrips from tens of thousands
+ * to hundreds for large traces.
+ */
+function* batchDecompressedChunks(
+    compressed: Uint8Array,
+    decoder: ZstdDecoder,
+    batchSize: number,
+): Generator<Uint8Array> {
+    // Collect small output chunks until we have at least batchSize
+    // bytes, then concatenate and yield as one contiguous buffer.
+    const parts: Uint8Array[] = [];
+    let size = 0;
+    for (const chunk of decoder.decodeStreaming([compressed])) {
+        if (chunk.length === 0) continue;
+        parts.push(chunk);
+        size += chunk.length;
+        if (size >= batchSize) {
+            yield Buffer.concat(parts) as Uint8Array;
+            parts.length = 0;
+            size = 0;
+        }
+    }
+    // Flush remaining chunks that didn't fill a full batch.
+    if (parts.length > 0) {
+        yield Buffer.concat(parts) as Uint8Array;
+    }
+}
+
+/**
+ * Decompresses a zstd-compressed buffer and yields its content line by line.
+ * Decompressed data is accumulated into batches to amortize per-chunk
+ * overhead while keeping peak memory bounded.
+ *
+ * If `skipLine` is provided, it is called with the raw bytes of each line
+ * (as a zero-copy `Buffer` view) *before* string conversion. Lines for
+ * which it returns `true` are skipped entirely — no `TextDecoder`
+ * allocation, no yield.
+ */
+export function* streamDecompressedLines(
+    compressed: Uint8Array,
+    decoder: ZstdDecoder,
+    skipLine?: (lineBytes: Buffer) => boolean,
+): Generator<string> {
+    const NEWLINE_BYTE = 0x0A;
+    const td = new TextDecoder();
+    // A batch boundary can split a line in the middle. This holds the
+    // partial trailing bytes until the next batch completes the line.
+    let leftover: Uint8Array | undefined;
+    for (const batch of batchDecompressedChunks(compressed, decoder, DECOMPRESS_BATCH_SIZE)) {
+        // Prepend leftover from the previous batch so that a split line
+        // is reassembled before we scan for newlines.
+        const buf = leftover && leftover.length > 0
+            ? Buffer.concat([leftover, batch]) as Uint8Array
+            : batch;
+        leftover = undefined;
+        // Scan for newline-delimited lines within the batch.
+        let lineStart = 0;
+        for (let i = 0; i < buf.length; i++) {
+            if (buf[i] !== NEWLINE_BYTE) continue;
+            if (i > lineStart) {
+                // Zero-copy Buffer view of just this line's bytes.
+                const lineBytes = Buffer.from(buf.buffer, buf.byteOffset + lineStart, i - lineStart);
+                if (!skipLine || !skipLine(lineBytes)) {
+                    yield td.decode(lineBytes as Uint8Array).trimEnd();
+                }
+            }
+            lineStart = i + 1;
+        }
+        // Bytes after the last newline are a partial line — carry forward.
+        if (lineStart < buf.length) {
+            leftover = buf.subarray(lineStart);
+        }
+    }
+    // Flush final partial line (if the file doesn't end with a newline).
+    if (leftover && leftover.length > 0) {
+        const lineBytes = Buffer.from(leftover.buffer, leftover.byteOffset, leftover.length);
+        if (!skipLine || !skipLine(lineBytes)) {
+            const tail = td.decode(lineBytes as Uint8Array).trimEnd();
+            if (tail) yield tail;
+        }
+    }
+}
+

--- a/external-crates/move/crates/move-analyzer/trace-adapter/tsconfig.json
+++ b/external-crates/move/crates/move-analyzer/trace-adapter/tsconfig.json
@@ -12,6 +12,7 @@
         "rootDir": "src",
         "esModuleInterop": true,
         "resolveJsonModule": true,
+        "skipLibCheck": true,
         "strict": true /* enable all strict type-checking options */
     },
     "exclude": [

--- a/external-crates/move/crates/move-analyzer/trace-debug/package-lock.json
+++ b/external-crates/move/crates/move-analyzer/trace-debug/package-lock.json
@@ -1,20 +1,20 @@
 {
     "name": "move-trace-debug",
-    "version": "0.0.18",
+    "version": "0.0.19",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "move-trace-debug",
-            "version": "0.0.18",
+            "version": "0.0.19",
             "license": "Apache-2.0",
             "dependencies": {
                 "@iarna/toml": "^2.2.5",
                 "@vscode/debugadapter": "^1.56.0",
                 "@vscode/debugadapter-testsupport": "^1.56.0",
                 "@vscode/debugprotocol": "1.66.0",
-                "fzstd": "^0.1.1",
-                "lodash.snakecase": "^4.1.1"
+                "lodash.snakecase": "^4.1.1",
+                "zstddec": "^0.2.0"
             },
             "devDependencies": {
                 "@types/lodash.snakecase": "^4.1.9",
@@ -977,12 +977,6 @@
             "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
             "dev": true
         },
-        "node_modules/fzstd": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/fzstd/-/fzstd-0.1.1.tgz",
-            "integrity": "sha512-dkuVSOKKwh3eas5VkJy1AW1vFpet8TA/fGmVA5krThl8YcOVE/8ZIoEA1+U1vEn5ckxxhLirSdY837azmbaNHA==",
-            "license": "MIT"
-        },
         "node_modules/glob-parent": {
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
@@ -1713,6 +1707,12 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/zstddec": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/zstddec/-/zstddec-0.2.0.tgz",
+            "integrity": "sha512-oyPnDa1X5c13+Y7mA/FDMNJrn4S8UNBe0KCqtDmor40Re7ALrPN6npFwyYVRRh+PqozZQdeg23QtbcamZnG5rA==",
+            "license": "MIT AND BSD-3-Clause"
         }
     }
 }

--- a/external-crates/move/crates/move-analyzer/trace-debug/package.json
+++ b/external-crates/move/crates/move-analyzer/trace-debug/package.json
@@ -5,7 +5,7 @@
     "publisher": "mysten",
     "icon": "images/move.png",
     "license": "Apache-2.0",
-    "version": "0.0.18",
+    "version": "0.0.19",
     "preview": true,
     "repository": {
         "url": "https://github.com/MystenLabs/sui.git",
@@ -166,7 +166,7 @@
         "@vscode/debugadapter": "^1.56.0",
         "@vscode/debugadapter-testsupport": "^1.56.0",
         "@vscode/debugprotocol": "1.66.0",
-        "fzstd": "^0.1.1",
+        "zstddec": "^0.2.0",
         "lodash.snakecase": "^4.1.1"
     },
     "devDependencies": {

--- a/external-crates/move/crates/move-analyzer/trace-debug/src/extension.ts
+++ b/external-crates/move/crates/move-analyzer/trace-debug/src/extension.ts
@@ -12,7 +12,34 @@ import {
     TextDocument,
     Position
 } from 'vscode';
-import { decompress } from 'fzstd';
+/**
+ * Shape of the `ZSTDDecoder` class from the `zstddec/stream` package.
+ * Hand-typed here because we load the package via `await import()` (its module
+ * format is not directly compatible with the format this project compiles to)
+ * and need a local type to work with the returned object.
+ */
+interface ZstdDecoder {
+    init(): Promise<void>;
+    decode(array: Uint8Array, uncompressedSize?: number): Uint8Array;
+    decodeStreaming(arrays: Iterable<Uint8Array>): Generator<Uint8Array>;
+}
+
+/**
+ * Number of lines kept verbatim (effects included) for traces small enough to
+ * display in full. Traces larger than this fall back to the
+ * `PREVIEW_MAX_NON_EFFECT_LINES` cap below with `Effect`-prefixed lines
+ * dropped, to fit VSCode's editor render budget.
+ */
+const PREVIEW_MAX_LINES_WITH_EFFECTS = 1000;
+
+/**
+ * Number of non-`Effect` lines emitted for traces larger than
+ * `PREVIEW_MAX_LINES_WITH_EFFECTS`.
+ */
+const PREVIEW_MAX_NON_EFFECT_LINES = 10000;
+
+const NEWLINE_BYTE = 0x0A;
+const EFFECT_LINE_PREFIX = '{"Effect":';
 
 /**
  * Log level for the debug adapter.
@@ -200,14 +227,13 @@ export function activate(context: vscode.ExtensionContext) {
     }));
 
     // Create and register custom content provider for compressed trace files,
-    // as well as custom editor for Move trace files.
-    // TODO: for now it's OK to decompress the whole trace here because the debugger
-    // does not handle streaming traces at the moment anyway, but it will have to change
-    // once it does.
+    // as well as custom editor for Move trace files. Both providers stream the
+    // file via `decompressTraceFileForPreview` so they never materialise more
+    // than ~10K lines, which is what fits in VSCode's editor render budget.
     const trace_content_provider: vscode.TextDocumentContentProvider = {
         async provideTextDocumentContent(uri: vscode.Uri): Promise<string> {
             try {
-                return trimTraceFileContent(await decompressTraceFile(uri.path));
+                return await decompressTraceFileForPreview(uri.path);
             } catch (err) {
                 const msg = err instanceof Error ? err.message : String(err);
                 return `Failed to decode trace:\n${msg}`;
@@ -271,7 +297,7 @@ class MoveTraceViewProvider implements vscode.CustomReadonlyEditorProvider {
         webviewPanel.webview.options = { enableScripts: true };
 
         try {
-            const traceContent = trimTraceFileContent(await decompressTraceFile(document.uri.fsPath));
+            const traceContent = await decompressTraceFileForPreview(document.uri.fsPath);
             webviewPanel.webview.html = this.renderHtml(traceContent);
         } catch (err) {
             const msg = err instanceof Error ? err.message : String(err);
@@ -502,7 +528,7 @@ function findTracedFunctionsFromPath(pkgRoot: string, pkgModules: string[]): str
  * @returns traced function info containing package address, module, and function itself.
  */
 async function getTracedFunctionInfo(traceFilePath: string): Promise<TracedFunctionInfo> {
-    const traceLines = await decompressTraceFile(traceFilePath);
+    const traceLines = await readTraceFileFirstLines(traceFilePath, 2);
     if (traceLines.length <= 1) {
         throw new Error(`Empty trace file at '${traceFilePath}`);
     }
@@ -651,80 +677,6 @@ async function pickTraceFileToDebug(
 }
 
 /**
- * Splits decompressed trace file data into lines without creating a large intermediate string.
- * This avoids hitting JavaScript's maximum string length limit for large trace files.
- *
- * @param decompressed the decompressed buffer containing trace data
- * @returns array of strings representing lines from the trace file
- */
-function splitTraceFileLines(decompressed: Uint8Array): string[] {
-    const NEWLINE_BYTE = 0x0A;
-    const decoder = new TextDecoder();
-    const lines: string[] = [];
-
-    let lineStart = 0;
-
-    for (let i = 0; i <= decompressed.length; i++) {
-        if (i === decompressed.length || decompressed[i] === NEWLINE_BYTE) {
-            // end of the buffer or a new line
-            if (i > lineStart) {
-                const lineBytes = decompressed.slice(lineStart, i);
-                const line = decoder.decode(lineBytes).trimEnd();
-                lines.push(line);
-            }
-            lineStart = i + 1;
-        }
-    }
-
-    return lines;
-}
-
-/**
- * Reads and decompresses a trace file.
- * @param traceFilePath path to the trace file.
- * @returns decompressed trace file content as a string.
- */
-async function decompressTraceFile(traceFilePath: string): Promise<string[]> {
-    // Read as Buffer then view it as a Uint8Array for fzstd which expects Uint8Array
-    const buf = fs.readFileSync(traceFilePath);
-    const u8 = new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength);
-    // fzstd.decompress is synchronous, no need to await
-    const decompressed = decompress(u8);
-    return splitTraceFileLines(decompressed);
-}
-
-/**
- * Trims the trace file content to have it fit in VSCode's
- * 50M display limit.
- * @param traceFileContent content of the trace file.
- * @returns string representation of the trace file content.
- */
-function trimTraceFileContent(lines: string[]): string {
-    // Max numbers of lines to display, including effects
-    const maxLinesWithEffects = 1000;
-    if (lines.length <= maxLinesWithEffects) {
-        return lines.join('\n');
-    }
-    // Max number of lines to display without effects
-    // (if the number of lines in the trace is greater thatn
-    // maxLinesWithEffects, let's filter out the effects, but
-    // display a larger number of lines to hopefully include
-    // the whole trace sans effects).
-    let maxLines = 10000;
-    let result = "";
-    for (let i = 0; i < lines.length; i++) {
-        if (!lines[i].startsWith('{\"Effect\":')) {
-            maxLines--;
-            result += lines[i] + '\n';
-        }
-        if (maxLines === 0) {
-            break;
-        }
-    }
-    return result;
-}
-
-/**
  * Get the URI of the currently active trace view tab.
  * @returns uri of the active trace view tab or undefined if no such tab is active.
  */
@@ -744,4 +696,125 @@ function traceViewTabUri(): vscode.Uri | undefined {
         }
     }
     return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Trace file decompression and streaming helpers
+// ---------------------------------------------------------------------------
+
+let decoderPromise: Promise<ZstdDecoder> | undefined;
+
+/**
+ * Returns a lazily-initialized, cached `ZSTDDecoder` instance from
+ * the `zstddec/stream` package.
+ */
+async function getDecoder(): Promise<ZstdDecoder> {
+    if (!decoderPromise) {
+        decoderPromise = (async () => {
+            const mod = await import('zstddec/stream');
+            const decoder = new mod.ZSTDDecoder();
+            await decoder.init();
+            return decoder as unknown as ZstdDecoder;
+        })();
+    }
+    return decoderPromise;
+}
+
+/**
+ * Streams a zstd-compressed trace file and yields decompressed lines one at
+ * a time. The compressed file is read in full but decompressed data is
+ * processed in batches, so peak memory is dominated by the compressed file
+ * size, not the decompressed one.
+ */
+async function* streamTraceLines(
+    traceFilePath: string,
+): AsyncGenerator<string, void, void> {
+    const decoder = await getDecoder();
+    const buf = fs.readFileSync(traceFilePath);
+    const u8 = new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength);
+    const td = new TextDecoder();
+    let leftover: Uint8Array | undefined;
+    for (const decompressed of decoder.decodeStreaming([u8])) {
+        if (decompressed.length === 0) continue;
+        const cur = leftover && leftover.length > 0
+            // Cast needed: Buffer extends Uint8Array at runtime but TS
+            // considers them incompatible due to SharedArrayBuffer in Buffer's
+            // type signature.
+            ? Buffer.concat([leftover, decompressed]) as Uint8Array
+            : decompressed;
+        leftover = undefined;
+        let lineStart = 0;
+        for (let i = 0; i < cur.length; i++) {
+            if (cur[i] !== NEWLINE_BYTE) continue;
+            if (i > lineStart) {
+                yield td.decode(cur.subarray(lineStart, i)).trimEnd();
+            }
+            lineStart = i + 1;
+        }
+        if (lineStart < cur.length) {
+            leftover = cur.subarray(lineStart);
+        }
+    }
+    if (leftover && leftover.length > 0) {
+        const tail = td.decode(leftover).trimEnd();
+        if (tail) yield tail;
+    }
+}
+
+/**
+ * Streams a trace file and returns the editor-preview text. For small traces
+ * (≤ `PREVIEW_MAX_LINES_WITH_EFFECTS` lines) every line is emitted verbatim.
+ * For larger traces, `Effect`-prefixed lines are dropped and the first
+ * `PREVIEW_MAX_NON_EFFECT_LINES` non-effect lines are emitted, then the
+ * stream stops early without materialising the rest of the file.
+ */
+async function decompressTraceFileForPreview(traceFilePath: string): Promise<string> {
+    const buffered: string[] = [];
+    const nonEffects: string[] = [];
+    let largeMode = false;
+
+    for await (const line of streamTraceLines(traceFilePath)) {
+        if (!largeMode) {
+            buffered.push(line);
+            if (buffered.length > PREVIEW_MAX_LINES_WITH_EFFECTS) {
+                // Crossed the small-trace threshold: re-classify the buffered
+                // tail through the large-mode filter and continue streaming.
+                for (const l of buffered) {
+                    if (!l.startsWith(EFFECT_LINE_PREFIX)) {
+                        nonEffects.push(l);
+                        if (nonEffects.length >= PREVIEW_MAX_NON_EFFECT_LINES) {
+                            return nonEffects.join('\n');
+                        }
+                    }
+                }
+                buffered.length = 0;
+                largeMode = true;
+            }
+        } else {
+            if (!line.startsWith(EFFECT_LINE_PREFIX)) {
+                nonEffects.push(line);
+                if (nonEffects.length >= PREVIEW_MAX_NON_EFFECT_LINES) {
+                    return nonEffects.join('\n');
+                }
+            }
+        }
+    }
+    return largeMode ? nonEffects.join('\n') : buffered.join('\n');
+}
+
+/**
+ * Streams the first `n` lines from a trace file and stops decoding the rest.
+ * Used to extract metadata (e.g. the trace header / first event) without
+ * decompressing the entire file.
+ */
+async function readTraceFileFirstLines(
+    traceFilePath: string,
+    n: number,
+): Promise<string[]> {
+    const lines: string[] = [];
+    for await (const line of streamTraceLines(traceFilePath)) {
+        lines.push(line);
+        if (lines.length >= n) break;
+    }
+    return lines;
 }

--- a/external-crates/move/crates/move-analyzer/trace-debug/tsconfig.json
+++ b/external-crates/move/crates/move-analyzer/trace-debug/tsconfig.json
@@ -8,6 +8,7 @@
         ],
         "sourceMap": true,
         "rootDir": "src",
+        "skipLibCheck": true,
         "strict": true /* enable all strict type-checking options */
     }
 }


### PR DESCRIPTION
## Description 

This PR adds support for handling large traces. It replaces previous archiver with a more capable one and implements decoding/uncompressing of the trace in chunks so that we keep peak memory footprint low. 

We don't actually have to stream-process the trace as during parsing we filter a lot of events that would otherwise contribute to memory consumption. This allowed us to keep the changes ex to trace parsing part of the implementation.

## Test plan 

Tested on otherwise failing trace for mainnet `EfWjbxdSDotgj8ZusSuqXpU99EKhAmN92gf1bqa1SHg5` transaction. Also verified that everything works with smaller traces (e.g., with the `HKb8Ji74mNE8U6tH46M9znvgq7srztNbdAEVNatmchLM` mainnet transaction)
