### PR TITLE
Add gasless and accumulator account monitoring

### DIFF
--- a/crates/sui-core/src/accumulators/mod.rs
+++ b/crates/sui-core/src/accumulators/mod.rs
@@ -458,16 +458,7 @@ pub fn build_accumulator_barrier_tx(
 ) -> TransactionKind {
     let num_settlements = settlement_effects.len() as u64;
 
-    let (objects_created, objects_destroyed) = settlement_effects
-        .iter()
-        .flat_map(|effects| effects.object_changes())
-        .fold((0u64, 0u64), |(created, destroyed), change| {
-            match change.id_operation {
-                IDOperation::Created => (created + 1, destroyed),
-                IDOperation::Deleted => (created, destroyed + 1),
-                IDOperation::None => (created, destroyed),
-            }
-        });
+    let (objects_created, objects_destroyed) = count_accumulator_object_changes(settlement_effects);
 
     let mut builder = ProgrammableTransactionBuilder::new();
     let root = builder
@@ -499,6 +490,21 @@ pub fn build_accumulator_barrier_tx(
     );
 
     TransactionKind::ProgrammableSystemTransaction(builder.finish())
+}
+
+pub(crate) fn count_accumulator_object_changes(
+    settlement_effects: &[TransactionEffects],
+) -> (u64, u64) {
+    settlement_effects
+        .iter()
+        .flat_map(|effects| effects.object_changes())
+        .fold((0u64, 0u64), |(created, destroyed), change| {
+            match change.id_operation {
+                IDOperation::Created => (created + 1, destroyed),
+                IDOperation::Deleted => (created, destroyed + 1),
+                IDOperation::None => (created, destroyed),
+            }
+        })
 }
 
 #[cfg(test)]

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -217,6 +217,7 @@ pub struct ValidatorServiceMetrics {
     client_id_source_config_mismatch: IntCounter,
     x_forwarded_for_num_hops: Gauge,
     pub gasless_rate_limited_count: IntCounter,
+    pub gasless_submission_outcomes: IntCounterVec,
 }
 
 impl ValidatorServiceMetrics {
@@ -404,6 +405,13 @@ impl ValidatorServiceMetrics {
             gasless_rate_limited_count: register_int_counter_with_registry!(
                 "validator_service_gasless_rate_limited_count",
                 "Number of gasless transactions rejected by rate limiter",
+                registry,
+            )
+            .unwrap(),
+            gasless_submission_outcomes: register_int_counter_vec_with_registry!(
+                "validator_service_gasless_submission_outcomes",
+                "Number of valid gasless transaction submissions by outcome",
+                &["outcome"],
                 registry,
             )
             .unwrap(),
@@ -749,14 +757,18 @@ impl ValidatorService {
 
             // Ok to fail the request when any transaction is invalid.
             let tx_size = transaction.validity_check(&epoch_store.tx_validity_check_context())?;
-
-            if transaction
+            let is_gasless = transaction
                 .data()
                 .transaction_data()
-                .is_gasless_transaction()
-            {
+                .is_gasless_transaction();
+
+            if is_gasless {
                 // Gasless transactions count for traffic control, since they have no economic cost.
                 spam_weight = Weight::one();
+                metrics
+                    .gasless_submission_outcomes
+                    .with_label_values(&["attempted"])
+                    .inc();
             }
 
             let overload_check_res = state.check_system_overload(
@@ -769,19 +781,26 @@ impl ValidatorService {
                     .num_rejected_tx_during_overload
                     .with_label_values(&[error.as_ref()])
                     .inc();
+                if is_gasless {
+                    metrics
+                        .gasless_submission_outcomes
+                        .with_label_values(&["rejected_overload"])
+                        .inc();
+                }
                 results[idx] = Some(SubmitTxResult::Rejected { error });
                 continue;
             }
 
-            if transaction
-                .data()
-                .transaction_data()
-                .is_gasless_transaction()
+            if is_gasless
                 && !self
                     .gasless_limiter
                     .try_acquire(epoch_store.protocol_config())
             {
                 metrics.gasless_rate_limited_count.inc();
+                metrics
+                    .gasless_submission_outcomes
+                    .with_label_values(&["rejected_rate_limited"])
+                    .inc();
                 results[idx] = Some(SubmitTxResult::Rejected {
                     error: SuiErrorKind::ValidatorOverloadedRetryAfter {
                         retry_after_secs: 1,
@@ -942,6 +961,12 @@ impl ValidatorService {
                 &state.name,
                 tx_with_claims,
             ));
+            if is_gasless {
+                metrics
+                    .gasless_submission_outcomes
+                    .with_label_values(&["submitted"])
+                    .inc();
+            }
 
             transaction_indexes.push(idx);
             tx_digests.push(tx_digest);

--- a/crates/sui-core/src/checkpoints/metrics.rs
+++ b/crates/sui-core/src/checkpoints/metrics.rs
@@ -8,6 +8,7 @@ use prometheus::{
     register_int_counter_with_registry, register_int_gauge_vec_with_registry,
     register_int_gauge_with_registry,
 };
+use std::convert::TryFrom;
 use std::sync::Arc;
 
 pub struct CheckpointMetrics {
@@ -35,6 +36,9 @@ pub struct CheckpointMetrics {
     pub last_certified_checkpoint_age: Histogram,
     // TODO: delete once users are migrated to non-Mysten histogram.
     pub last_certified_checkpoint_age_ms: MystenHistogram,
+    pub accumulator_accounts_created: IntCounter,
+    pub accumulator_accounts_deleted: IntCounter,
+    pub accumulator_accounts_live: IntGauge,
 }
 
 impl CheckpointMetrics {
@@ -167,11 +171,43 @@ impl CheckpointMetrics {
                 registry
             )
             .unwrap(),
+            accumulator_accounts_created: register_int_counter_with_registry!(
+                "accumulator_accounts_created",
+                "Total number of accumulator account objects created by settlement transactions",
+                registry
+            )
+            .unwrap(),
+            accumulator_accounts_deleted: register_int_counter_with_registry!(
+                "accumulator_accounts_deleted",
+                "Total number of accumulator account objects deleted by settlement transactions",
+                registry
+            )
+            .unwrap(),
+            accumulator_accounts_live: register_int_gauge_with_registry!(
+                "accumulator_accounts_live",
+                "Current number of live accumulator account objects after settlement processing",
+                registry
+            )
+            .unwrap(),
         };
         Arc::new(this)
     }
 
     pub fn new_for_tests() -> Arc<Self> {
         Self::new(&Registry::new())
+    }
+
+    pub fn initialize_accumulator_accounts_live(&self, live_accounts: u64) {
+        self.accumulator_accounts_live
+            .set(i64::try_from(live_accounts).expect("accumulator account count exceeds i64"));
+    }
+
+    pub fn report_accumulator_account_changes(&self, created: u64, deleted: u64) {
+        self.accumulator_accounts_created.inc_by(created);
+        self.accumulator_accounts_deleted.inc_by(deleted);
+
+        let created = i64::try_from(created).expect("created accumulator accounts exceeds i64");
+        let deleted = i64::try_from(deleted).expect("deleted accumulator accounts exceeds i64");
+        self.accumulator_accounts_live.add(created - deleted);
     }
 }

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -36,7 +36,6 @@ use pin_project_lite::pin_project;
 use serde::{Deserialize, Serialize};
 use sui_macros::fail_point_arg;
 use sui_network::default_mysten_network_config;
-use sui_types::SUI_ACCUMULATOR_ROOT_OBJECT_ID;
 use sui_types::base_types::{ConciseableName, SequenceNumber};
 use sui_types::executable_transaction::VerifiedExecutableTransaction;
 use sui_types::execution::ExecutionTimeObservationKey;
@@ -44,6 +43,7 @@ use sui_types::messages_checkpoint::{
     CheckpointArtifacts, CheckpointCommitment, VersionedFullCheckpointContents,
 };
 use sui_types::sui_system_state::epoch_start_sui_system_state::EpochStartSystemStateTrait;
+use sui_types::{SUI_ACCUMULATOR_ROOT_OBJECT_ID, accumulator_metadata};
 use tokio::sync::{mpsc, watch};
 use typed_store::rocks::{DBOptions, ReadWriteOptions, default_db_options};
 
@@ -1664,6 +1664,10 @@ impl CheckpointBuilder {
             tx_key,
         )
         .await;
+        let (accounts_created, accounts_deleted) =
+            accumulators::count_accumulator_object_changes(&settlement_effects);
+        self.metrics
+            .report_accumulator_account_changes(accounts_created, accounts_deleted);
 
         let barrier_tx = accumulators::build_accumulator_barrier_tx(
             epoch,
@@ -1689,13 +1693,13 @@ impl CheckpointBuilder {
         )
         .await;
 
-        let settlement_effects: Vec<_> = settlement_effects
+        let settlement_and_barrier_effects: Vec<_> = settlement_effects
             .into_iter()
             .chain(barrier_effects)
             .collect();
 
         let mut next_accumulator_version = None;
-        for fx in settlement_effects.iter() {
+        for fx in settlement_and_barrier_effects.iter() {
             assert!(
                 fx.status().is_ok(),
                 "settlement transaction cannot fail (digest: {:?}) {:#?}",
@@ -1724,7 +1728,7 @@ impl CheckpointBuilder {
             .execution_scheduler()
             .settle_address_funds(settlements);
 
-        (tx_key, settlement_effects)
+        (tx_key, settlement_and_barrier_effects)
     }
 
     // Given the root transactions of a pending checkpoint, resolve the transactions should be included in
@@ -3400,6 +3404,7 @@ impl CheckpointService {
         info!(
             "Starting checkpoint service with {max_transactions_per_checkpoint} max_transactions_per_checkpoint and {max_checkpoint_size_bytes} max_checkpoint_size_bytes"
         );
+        Self::initialize_accumulator_account_metrics(&state, &epoch_store, &metrics);
         let notify_builder = Arc::new(Notify::new());
         let notify_aggregator = Arc::new(Notify::new());
 
@@ -3467,6 +3472,23 @@ impl CheckpointService {
                 ckpt_state_hasher,
             ))),
         })
+    }
+
+    fn initialize_accumulator_account_metrics(
+        state: &AuthorityState,
+        epoch_store: &AuthorityPerEpochStore,
+        metrics: &CheckpointMetrics,
+    ) {
+        if !epoch_store.protocol_config().enable_accumulators() {
+            return;
+        }
+
+        let object_store = state.get_object_store();
+        match accumulator_metadata::get_accumulator_object_count(object_store.as_ref()) {
+            Ok(Some(count)) => metrics.initialize_accumulator_accounts_live(count),
+            Ok(None) => {}
+            Err(e) => fatal!("failed to initialize accumulator account metrics: {e}"),
+        }
     }
 
     /// Starts the CheckpointService.


### PR DESCRIPTION
## Description 
Adds basic monitoring for gasless/free-tier traffic and realized account seeding activity.

  New metrics:

  - `validator_service_gasless_submission_outcomes{outcome=attempted|rejected_overload|rejected_rate_limited|submitted}`
  - `validator_service_gasless_rate_limited_count`
  - `accumulator_accounts_created`
  - `accumulator_accounts_deleted`
  - `accumulator_accounts_live`


## Test plan 



---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
