### PR TITLE
[move][move-compiler] Diagnostic prefixes turned into families, interned

### DIFF
--- a/external-crates/move/crates/move-compiler/src/command_line/compiler.rs
+++ b/external-crates/move/crates/move-compiler/src/command_line/compiler.rs
@@ -594,7 +594,7 @@ macro_rules! ast_stepped_compilers {
 
                 pub fn check_and_report(self, files: &MappedFiles)  {
                     let errors_result = self.check().map_err(|(_, diags)| diags);
-                    unwrap_or_report_diagnostics(&files, errors_result);
+                    unwrap_or_report_diagnostics(files, errors_result);
                 }
 
                 pub fn build_and_report(
@@ -602,8 +602,8 @@ macro_rules! ast_stepped_compilers {
                     files: &MappedFiles,
                 ) -> Vec<AnnotatedCompiledUnit> {
                     let units_result = self.build().map_err(|(_, diags)| diags);
-                    let (units, warnings) = unwrap_or_report_diagnostics(&files, units_result);
-                    report_warnings(&files, warnings);
+                    let (units, warnings) = unwrap_or_report_diagnostics(files, units_result);
+                    report_warnings(files, warnings);
                     units
                 }
             }

--- a/external-crates/move/crates/move-compiler/src/diagnostics/codes.rs
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/codes.rs
@@ -2,6 +2,8 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::BTreeMap;
+
 //**************************************************************************************************
 // Main types
 //**************************************************************************************************
@@ -15,18 +17,84 @@ pub enum Severity {
     Bug = 4,
 }
 
-/// An optional prefix to distinguish between different types of warnings (internal vs. possibly
-/// multiple externally provided ones).
-pub type ExternalPrefix = Option<&'static str>;
-/// The ID for a diagnostic, consisting of an optional prefix, a category, and a code.
-pub type DiagnosticsID = (ExternalPrefix, u8, u8);
+/// A compact identifier for a diagnostic family. Compiler-internal diagnostics use
+/// `COMPILER_FAMILY`; external tools (linters, sui-specific checks, etc.) register their
+/// family at startup and receive a unique `Family`.
+#[derive(PartialEq, Eq, Clone, Copy, Debug, Hash, PartialOrd, Ord)]
+pub struct Family(u8);
+
+pub const COMPILER_FAMILY: Family = Family(0);
+pub const LINT_WARNING_FAMILY: Family = Family(1);
+pub const SUI_LINT_FAMILY: Family = Family(2);
+
+impl Family {
+    pub fn as_u8(self) -> u8 {
+        self.0
+    }
+}
+
+/// Registry mapping `Family` values to their display prefixes. Built once during compiler
+/// setup and shared (read-only) thereafter. The display prefix is used when rendering diagnostic
+/// codes (e.g., `"Lint W04001"`).
+#[derive(PartialEq, Eq, Hash, Clone, Debug)]
+pub struct FamilyRegistry {
+    /// Index = Family.0. The compiler family (index 0) has no display prefix.
+    prefixes: Vec<Option<&'static str>>,
+    /// Reverse map from display prefix string to Family for lookup during filter resolution.
+    by_prefix: BTreeMap<&'static str, Family>,
+}
+
+impl FamilyRegistry {
+    pub fn new() -> Self {
+        let mut registry = Self {
+            prefixes: vec![None], // 0 = COMPILER, no display prefix
+            by_prefix: BTreeMap::new(),
+        };
+        assert!(registry.register("Lint ") == LINT_WARNING_FAMILY);
+        assert!(registry.register("Sui ") == SUI_LINT_FAMILY);
+        registry
+    }
+
+    /// Register an external family with the given display prefix (e.g., `"Lint "`, `"Sui "`).
+    /// Returns the assigned `Family`. Panics if more than 255 families are registered.
+    pub fn register(&mut self, display_prefix: &'static str) -> Family {
+        if let Some(&existing) = self.by_prefix.get(display_prefix) {
+            return existing;
+        }
+        let id = self.prefixes.len();
+        assert!(id <= u8::MAX as usize, "too many diagnostic families");
+        let ns = Family(id as u8);
+        self.prefixes.push(Some(display_prefix));
+        self.by_prefix.insert(display_prefix, ns);
+        ns
+    }
+
+    /// Look up the display prefix for a family. Returns `None` for the compiler family.
+    pub fn display_prefix(&self, ns: Family) -> Option<&'static str> {
+        self.prefixes.get(ns.0 as usize).copied().unwrap_or(None)
+    }
+
+    /// Look up a `Family` by its display prefix string.
+    pub fn family_for_prefix(&self, prefix: &str) -> Option<Family> {
+        self.by_prefix.get(prefix).copied()
+    }
+}
+
+impl Default for FamilyRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// The ID for a diagnostic, consisting of a family, category, and code.
+pub type DiagnosticsID = (Family, u8, u8);
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Hash)]
 pub struct DiagnosticInfo {
     severity: Severity,
     category: u8,
     code: u8,
-    external_prefix: ExternalPrefix,
+    family: Family,
     message: &'static str,
 }
 
@@ -45,7 +113,7 @@ pub(crate) trait DiagnosticCode: Copy {
             severity,
             category,
             code,
-            external_prefix: None,
+            family: COMPILER_FAMILY,
             message,
         }
     }
@@ -55,12 +123,13 @@ pub(crate) trait DiagnosticCode: Copy {
 // Categories and Codes
 //**************************************************************************************************
 
-/// A custom DiagnosticInfo.
+/// A custom DiagnosticInfo for external diagnostics (lints, sui-specific checks, etc.).
 /// The diagnostic will get rendered as
-/// `"[{external_prefix}{severity}{category}{code}] {message}"`.
+/// `"[{display_prefix}{severity}{category}{code}] {message}"`,
+/// where the display prefix is looked up from the `FamilyRegistry` at render time.
 /// Note, this will panic if `category > 99`
 pub const fn custom(
-    external_prefix: &'static str,
+    family: Family,
     severity: Severity,
     category: u8,
     code: u8,
@@ -71,7 +140,7 @@ pub const fn custom(
         severity,
         category,
         code,
-        external_prefix: Some(external_prefix),
+        family,
         message,
     }
 }
@@ -374,12 +443,15 @@ codes!(
 //**************************************************************************************************
 
 impl DiagnosticInfo {
-    pub fn render(self) -> (/* code */ String, /* message */ &'static str) {
+    pub fn render(
+        self,
+        registry: &FamilyRegistry,
+    ) -> (/* code */ String, /* message */ &'static str) {
         let Self {
             severity,
             category,
             code,
-            external_prefix,
+            family,
             message,
         } = self;
         let sev_prefix = match severity {
@@ -389,7 +461,7 @@ impl DiagnosticInfo {
             Severity::Bug => "ICE",
         };
         debug_assert!(category <= 99);
-        let string_code = if let Some(ext) = external_prefix {
+        let string_code = if let Some(ext) = registry.display_prefix(family) {
             format!("{ext}{sev_prefix}{category:02}{code:03}")
         } else {
             format!("{sev_prefix}{category:02}{code:03}")
@@ -415,7 +487,7 @@ impl DiagnosticInfo {
     }
 
     pub fn id(&self) -> DiagnosticsID {
-        (self.external_prefix, self.category, self.code)
+        (self.family, self.category, self.code)
     }
 
     pub fn message(&self) -> &'static str {
@@ -423,11 +495,11 @@ impl DiagnosticInfo {
     }
 
     pub fn is_external(&self) -> bool {
-        self.external_prefix.is_some()
+        self.family != COMPILER_FAMILY
     }
 
-    pub fn external_prefix(&self) -> Option<&'static str> {
-        self.external_prefix
+    pub fn family(&self) -> Family {
+        self.family
     }
 }
 

--- a/external-crates/move/crates/move-compiler/src/diagnostics/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/mod.rs
@@ -9,7 +9,10 @@ use crate::{
     Flags,
     command_line::COLOR_MODE_ENV_VAR,
     diagnostics::{
-        codes::{Category, DiagnosticCode, DiagnosticInfo, DiagnosticsID, Severity},
+        codes::{
+            Category, DiagnosticCode, DiagnosticInfo, DiagnosticsID, Family, FamilyRegistry,
+            Severity,
+        },
         warning_filters::{FilterName, FilterPrefix, WarningFilters, WarningFiltersScope},
     },
     shared::{
@@ -52,10 +55,17 @@ pub struct DiagnosticReporter<'env> {
     warning_filters_scope: WarningFiltersScope,
 }
 
-#[derive(PartialEq, Eq, Hash, Clone, Debug, Default)]
+#[derive(PartialEq, Eq, Hash, Clone, Debug)]
 pub struct Diagnostics {
     diags: Option<Diagnostics_>,
     format: DiagnosticsFormat,
+    family_registry: Box<FamilyRegistry>,
+}
+
+impl Default for Diagnostics {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 #[derive(PartialEq, Eq, Hash, Clone, Debug, Default)]
@@ -213,6 +223,7 @@ fn render_diagnostics(writer: &mut dyn WriteColor, mapping: &MappedFiles, diags:
     let Diagnostics {
         diags: Some(mut diags),
         format,
+        family_registry,
     } = diags
     else {
         return;
@@ -227,7 +238,7 @@ fn render_diagnostics(writer: &mut dyn WriteColor, mapping: &MappedFiles, diags:
         loc1.cmp(loc2).then_with(|| e1.cmp(e2))
     });
     match format {
-        DiagnosticsFormat::Text => emit_diagnostics_text(writer, mapping, diags),
+        DiagnosticsFormat::Text => emit_diagnostics_text(&family_registry, writer, mapping, diags),
         DiagnosticsFormat::JSON => emit_diagnostics_json(writer, mapping, diags),
     }
 }
@@ -240,6 +251,7 @@ fn convert_loc(mapped_files: &MappedFiles, loc: Loc) -> Option<(FileId, Range<us
 }
 
 fn emit_diagnostics_text(
+    registry: &FamilyRegistry,
     writer: &mut dyn WriteColor,
     mapped_files: &MappedFiles,
     diags: Diagnostics_,
@@ -250,12 +262,13 @@ fn emit_diagnostics_text(
             continue;
         }
         seen.insert(diag.clone());
-        let rendered = render_diagnostic_text(mapped_files, diag);
+        let rendered = render_diagnostic_text(registry, mapped_files, diag);
         emit(writer, &Config::default(), mapped_files.files(), &rendered).unwrap()
     }
 }
 
 fn render_diagnostic_text(
+    registry: &FamilyRegistry,
     mapped_files: &MappedFiles,
     diag: Diagnostic,
 ) -> csr::diagnostic::Diagnostic<FileId> {
@@ -279,7 +292,7 @@ fn render_diagnostic_text(
         mut notes,
     } = diag;
     let mut diag = csr::diagnostic::Diagnostic::new(info.severity().into_codespan_severity());
-    let (code, message) = info.render();
+    let (code, message) = info.render(registry);
     diag = diag.with_code(code);
     diag = diag.with_message(message.to_string());
     let labels = vec![mk_lbl(LabelStyle::Primary, primary_label, &mut notes)]
@@ -331,6 +344,7 @@ pub fn generate_migration_diff(
         Diagnostics {
             diags: Some(inner),
             format,
+            ..
         } => {
             assert!(
                 matches!(format, DiagnosticsFormat::Text),
@@ -487,7 +501,12 @@ impl Diagnostics {
         Self {
             diags: None,
             format: DiagnosticsFormat::default(),
+            family_registry: Box::new(FamilyRegistry::new()),
         }
+    }
+
+    pub fn family_registry(&self) -> &FamilyRegistry {
+        &self.family_registry
     }
 
     pub fn set_format(&mut self, format: DiagnosticsFormat) {
@@ -515,6 +534,7 @@ impl Diagnostics {
         let Self {
             diags: Some(inner),
             format: _,
+            ..
         } = self
         else {
             return None;
@@ -532,6 +552,7 @@ impl Diagnostics {
         let Self {
             diags: Some(inner),
             format: _,
+            ..
         } = self
         else {
             return 0;
@@ -550,6 +571,7 @@ impl Diagnostics {
         let Self {
             diags: Some(inner),
             format: _,
+            ..
         } = self
         else {
             return true;
@@ -561,6 +583,7 @@ impl Diagnostics {
         let Self {
             diags: Some(inner),
             format: _,
+            ..
         } = self
         else {
             return 0;
@@ -603,6 +626,7 @@ impl Diagnostics {
                     severity_count,
                 }),
             format: _format,
+            ..
         } = other
         else {
             return;
@@ -660,10 +684,11 @@ impl Diagnostics {
         inner.diagnostics.retain(f);
     }
 
-    pub fn any_with_prefix(&self, prefix: &str) -> bool {
+    pub fn any_with_family(&self, namespace: Family) -> bool {
         let Self {
             diags: Some(inner),
             format: _,
+            ..
         } = self
         else {
             return false;
@@ -671,7 +696,7 @@ impl Diagnostics {
         inner
             .diagnostics
             .iter()
-            .any(|d| d.info.external_prefix() == Some(prefix))
+            .any(|d| d.info.family() == namespace)
     }
 
     /// Returns true if any diagnostic in the Syntax category have already been recorded.
@@ -679,6 +704,7 @@ impl Diagnostics {
         let Self {
             diags: Some(inner),
             format: _,
+            ..
         } = self
         else {
             return false;
@@ -691,10 +717,11 @@ impl Diagnostics {
 
     /// Returns the number of diags filtered in source (user) code (not in the dependencies) that
     /// have a given prefix and how many different unique lints were filtered.
-    pub fn filtered_source_diags_with_prefix(&self, prefix: &str) -> (usize, usize) {
+    pub fn filtered_source_diags_with_family(&self, namespace: Family) -> (usize, usize) {
         let Self {
             diags: Some(inner),
             format: _,
+            ..
         } = self
         else {
             return (0, 0);
@@ -702,7 +729,7 @@ impl Diagnostics {
         let mut filtered_diags_num = 0;
         let mut unique = HashSet::new();
         inner.filtered_source_diagnostics.iter().for_each(|d| {
-            if d.info.external_prefix() == Some(prefix) {
+            if d.info.family() == namespace {
                 filtered_diags_num += 1;
                 unique.insert((d.info.category(), d.info.code()));
             }
@@ -1103,24 +1130,20 @@ impl FromIterator<Diagnostic> for Diagnostics {
 impl From<Vec<Diagnostic>> for Diagnostics {
     fn from(diagnostics: Vec<Diagnostic>) -> Self {
         if diagnostics.is_empty() {
-            return Self {
-                diags: None,
-                format: DiagnosticsFormat::default(),
-            };
+            return Self::new();
         }
 
         let mut severity_count = BTreeMap::new();
         for diag in &diagnostics {
             *severity_count.entry(diag.info.severity()).or_insert(0) += 1;
         }
-        Self {
-            diags: Some(Diagnostics_ {
-                diagnostics,
-                filtered_source_diagnostics: vec![],
-                severity_count,
-            }),
-            format: DiagnosticsFormat::default(),
-        }
+        let mut s = Self::new();
+        s.diags = Some(Diagnostics_ {
+            diagnostics,
+            filtered_source_diagnostics: vec![],
+            severity_count,
+        });
+        s
     }
 }
 

--- a/external-crates/move/crates/move-compiler/src/diagnostics/warning_filters.rs
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/warning_filters.rs
@@ -4,7 +4,7 @@
 use crate::{
     diagnostics::{
         Diagnostic, DiagnosticCode,
-        codes::{Category, DiagnosticInfo, ExternalPrefix, Severity, UnusedItem},
+        codes::{COMPILER_FAMILY, Category, DiagnosticInfo, Family, Severity, UnusedItem},
     },
     shared::{AstDebug, CompilationEnv, known_attributes},
 };
@@ -45,7 +45,7 @@ macro_rules! known_code_filter {
             move_symbol_pool::Symbol::from($name),
             std::collections::BTreeSet::from([
                 crate::diagnostics::warning_filters::WarningFilter::Code {
-                    prefix: None,
+                    namespace: COMPILER_FAMILY,
                     category: Category::$category as u8,
                     code: $category::$code as u8,
                     name: Some($name),
@@ -59,8 +59,8 @@ macro_rules! known_code_filter {
 // Types
 //**************************************************************************************************
 
-/// None for the default 'allow'.
-/// Some(prefix) for a custom set of warnings, e.g. 'allow(lint(_))'.
+/// The namespace prefix for a filter. `None` for the default attribute namespace (e.g., `allow`).
+/// `Some(symbol)` for a custom namespace, e.g., `lint` in `allow(lint(_))`.
 pub type FilterPrefix = Option<Symbol>;
 pub type FilterName = Symbol;
 
@@ -102,7 +102,7 @@ unsafe impl Sync for WarningFilters {}
 #[derive(PartialEq, Eq, Clone, Debug, PartialOrd, Ord, Hash)]
 /// Used to filter out diagnostics, specifically used for warning suppression
 pub struct WarningFiltersBuilder {
-    filters: BTreeMap<ExternalPrefix, UnprefixedWarningFilters>,
+    filters: BTreeMap<Family, UnprefixedWarningFilters>,
     for_dependency: bool, // if false, the filters are used for source code
 }
 
@@ -125,16 +125,16 @@ enum UnprefixedWarningFilters {
 /// Represents a single annotation for a diagnostic filter
 pub enum WarningFilter {
     /// Filters all warnings
-    All(ExternalPrefix),
+    All(Family),
     /// Filters all warnings of a specific category. Only known filters have names.
     Category {
-        prefix: ExternalPrefix,
+        namespace: Family,
         category: u8,
         name: Option<WellKnownFilterName>,
     },
     /// Filters a single warning, as defined by codes below. Only known filters have names.
     Code {
-        prefix: ExternalPrefix,
+        namespace: Family,
         category: u8,
         code: u8,
         name: Option<WellKnownFilterName>,
@@ -273,8 +273,8 @@ impl WarningFiltersBuilder {
 
     pub fn new_all_filter_alls(env: &CompilationEnv) -> Self {
         let mut all_filter_alls = WarningFiltersBuilder::new_for_dependency();
-        for prefix in env.known_filter_names() {
-            for f in env.filter_from_str(prefix, FILTER_ALL) {
+        for filter_prefix in env.known_filter_prefixes() {
+            for f in env.filter_from_str(filter_prefix, FILTER_ALL) {
                 all_filter_alls.add(f);
             }
         }
@@ -286,16 +286,16 @@ impl WarningFiltersBuilder {
     }
 
     fn is_filtered_by_info(&self, info: &DiagnosticInfo) -> bool {
-        let prefix = info.external_prefix();
+        let namespace = info.family();
         self.filters
-            .get(&prefix)
+            .get(&namespace)
             .is_some_and(|filters| filters.is_filtered_by_info(info))
     }
 
     pub fn union(&mut self, other: &Self) {
-        for (prefix, filters) in &other.filters {
+        for (namespace, filters) in &other.filters {
             self.filters
-                .entry(*prefix)
+                .entry(*namespace)
                 .or_insert_with(UnprefixedWarningFilters::new)
                 .union(filters);
         }
@@ -312,25 +312,26 @@ impl WarningFiltersBuilder {
     }
 
     pub fn add(&mut self, filter: WarningFilter) {
-        let (prefix, category, code, name) = match filter {
-            WarningFilter::All(prefix) => {
-                self.filters.insert(prefix, UnprefixedWarningFilters::All);
+        let (namespace, category, code, name) = match filter {
+            WarningFilter::All(namespace) => {
+                self.filters
+                    .insert(namespace, UnprefixedWarningFilters::All);
                 return;
             }
             WarningFilter::Category {
-                prefix,
+                namespace,
                 category,
                 name,
-            } => (prefix, category, None, name),
+            } => (namespace, category, None, name),
             WarningFilter::Code {
-                prefix,
+                namespace,
                 category,
                 code,
                 name,
-            } => (prefix, category, Some(code), name),
+            } => (namespace, category, Some(code), name),
         };
         self.filters
-            .entry(prefix)
+            .entry(namespace)
             .or_insert(UnprefixedWarningFilters::Empty)
             .add(category, code, name)
     }
@@ -338,7 +339,7 @@ impl WarningFiltersBuilder {
     pub fn unused_warnings_filter_for_test() -> Self {
         Self {
             filters: BTreeMap::from([(
-                None,
+                COMPILER_FAMILY,
                 UnprefixedWarningFilters::unused_warnings_filter_for_test(),
             )]),
             for_dependency: false,
@@ -455,26 +456,22 @@ impl WarningFilter {
     }
 
     pub fn code(
-        prefix: ExternalPrefix,
+        namespace: Family,
         category: u8,
         code: u8,
         name: Option<WellKnownFilterName>,
     ) -> Self {
         Self::Code {
-            prefix,
+            namespace,
             category,
             code,
             name,
         }
     }
 
-    pub fn category(
-        prefix: ExternalPrefix,
-        category: u8,
-        name: Option<WellKnownFilterName>,
-    ) -> Self {
+    pub fn category(namespace: Family, category: u8, name: Option<WellKnownFilterName>) -> Self {
         Self::Category {
-            prefix,
+            namespace,
             category,
             name,
         }
@@ -484,12 +481,12 @@ impl WarningFilter {
         BTreeMap::from([
             (
                 FILTER_ALL.into(),
-                BTreeSet::from([WarningFilter::All(None)]),
+                BTreeSet::from([WarningFilter::All(COMPILER_FAMILY)]),
             ),
             (
                 FILTER_UNUSED.into(),
                 BTreeSet::from([WarningFilter::Category {
-                    prefix: None,
+                    namespace: COMPILER_FAMILY,
                     category: Category::UnusedItem as u8,
                     name: Some(FILTER_UNUSED),
                 }]),
@@ -506,13 +503,13 @@ impl WarningFilter {
                 FILTER_UNUSED_TYPE_PARAMETER.into(),
                 BTreeSet::from([
                     WarningFilter::Code {
-                        prefix: None,
+                        namespace: COMPILER_FAMILY,
                         category: Category::UnusedItem as u8,
                         code: UnusedItem::StructTypeParam as u8,
                         name: Some(FILTER_UNUSED_TYPE_PARAMETER),
                     },
                     WarningFilter::Code {
-                        prefix: None,
+                        namespace: COMPILER_FAMILY,
                         category: Category::UnusedItem as u8,
                         code: UnusedItem::FunTypeParam as u8,
                         name: Some(FILTER_UNUSED_TYPE_PARAMETER),
@@ -547,25 +544,30 @@ impl AstDebug for WarningFilters {
 
 impl AstDebug for WarningFiltersBuilder {
     fn ast_debug(&self, w: &mut crate::shared::ast_debug::AstWriter) {
-        for (prefix, filters) in &self.filters {
-            let prefix_str = prefix.unwrap_or(known_attributes::DiagnosticAttribute::ALLOW);
+        for (namespace, filters) in &self.filters {
+            let ns_str = if *namespace == COMPILER_FAMILY {
+                known_attributes::DiagnosticAttribute::ALLOW
+            } else {
+                // For external namespaces, use the allow attribute as a fallback label
+                known_attributes::DiagnosticAttribute::ALLOW
+            };
             match filters {
                 UnprefixedWarningFilters::All => w.write(format!(
                     "#[{}({})]",
-                    prefix_str,
-                    WarningFilter::All(*prefix).to_str().unwrap(),
+                    ns_str,
+                    WarningFilter::All(*namespace).to_str().unwrap(),
                 )),
                 UnprefixedWarningFilters::Specified { categories, codes } => {
-                    w.write(format!("#[{}(", prefix_str));
+                    w.write(format!("#[{}(", ns_str));
                     let items = categories
                         .iter()
                         .map(|(cat, n)| WarningFilter::Category {
-                            prefix: *prefix,
+                            namespace: *namespace,
                             category: *cat,
                             name: *n,
                         })
                         .chain(codes.iter().map(|((cat, code), n)| WarningFilter::Code {
-                            prefix: *prefix,
+                            namespace: *namespace,
                             category: *cat,
                             code: *code,
                             name: *n,

--- a/external-crates/move/crates/move-compiler/src/linters/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/linters/mod.rs
@@ -7,7 +7,7 @@ use crate::{
     cfgir::visitor::CFGIRVisitor,
     command_line::compiler::Visitor,
     diagnostics::{
-        codes::{DiagnosticInfo, Severity, custom},
+        codes::{DiagnosticInfo, LINT_WARNING_FAMILY, Severity, custom},
         warning_filters::WarningFilter,
     },
     typing::visitor::TypingVisitor,
@@ -86,7 +86,7 @@ macro_rules! lints {
             const fn diag_info(&self) -> DiagnosticInfo {
                 let (category, code, msg) = self.category_code_and_message();
                 custom(
-                    LINT_WARNING_PREFIX,
+                    LINT_WARNING_FAMILY,
                     Severity::Warning,
                     category,
                     code,
@@ -187,12 +187,7 @@ pub fn known_filters() -> (Option<Symbol>, Vec<WarningFilter>) {
         STYLE_WARNING_FILTERS
             .iter()
             .map(|(category, code, filter_name)| {
-                WarningFilter::code(
-                    Some(LINT_WARNING_PREFIX),
-                    *category,
-                    *code,
-                    Some(filter_name),
-                )
+                WarningFilter::code(LINT_WARNING_FAMILY, *category, *code, Some(filter_name))
             })
             .collect(),
     )

--- a/external-crates/move/crates/move-compiler/src/shared/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/shared/mod.rs
@@ -10,7 +10,7 @@ use crate::{
     command_line as cli, diag,
     diagnostics::{
         Diagnostic, DiagnosticReporter, Diagnostics, DiagnosticsFormat,
-        codes::{DiagnosticsID, Severity},
+        codes::{COMPILER_FAMILY, DiagnosticsID, FamilyRegistry, Severity},
         warning_filters::{
             FILTER_ALL, FilterName, FilterPrefix, WarningFilter, WarningFiltersBuilder,
             WarningFiltersScope, WarningFiltersTable,
@@ -248,6 +248,8 @@ pub struct CompilationEnv {
     known_filters: BTreeMap<FilterPrefix, BTreeMap<FilterName, BTreeSet<WarningFilter>>>,
     /// Maps a diagnostics ID to a known filter name.
     known_filter_names: BTreeMap<DiagnosticsID, (FilterPrefix, FilterName)>,
+    /// Registry mapping `Family` values to their display prefix strings.
+    family_registry: FamilyRegistry,
     prim_definers: OnceLock<BTreeMap<N::BuiltinTypeName_, E::ModuleIdent>>,
     // TODO(tzakian): Remove the global counter and use this counter instead
     // pub counter: u64,
@@ -286,13 +288,13 @@ impl CompilationEnv {
                 all_filters.iter().flat_map(|(name, filters)| {
                     filters.iter().filter_map(|v| {
                         if let WarningFilter::Code {
-                            prefix,
+                            namespace,
                             category,
                             code,
                             ..
                         } = v
                         {
-                            Some(((*prefix, *category, *code), (*attr, *name)))
+                            Some(((*namespace, *category, *code), (*attr, *name)))
                         } else {
                             None
                         }
@@ -303,7 +305,7 @@ impl CompilationEnv {
 
         let top_level_warning_filter_opt = if flags.silence_warnings() {
             let mut f = WarningFiltersBuilder::new_for_source();
-            f.add(WarningFilter::All(None));
+            f.add(WarningFilter::All(COMPILER_FAMILY));
             Some(f)
         } else {
             warning_filters
@@ -330,6 +332,7 @@ impl CompilationEnv {
             default_config: default_config.unwrap_or_default(),
             known_filters,
             known_filter_names,
+            family_registry: FamilyRegistry::new(),
             prim_definers: OnceLock::new(),
             mapped_files: MappedFiles::empty(),
             save_hooks,
@@ -436,7 +439,7 @@ impl CompilationEnv {
         final_diags
     }
 
-    pub fn known_filter_names(&self) -> impl IntoIterator<Item = FilterPrefix> + '_ {
+    pub fn known_filter_prefixes(&self) -> impl IntoIterator<Item = FilterPrefix> + '_ {
         self.known_filters.keys().copied()
     }
 
@@ -458,16 +461,18 @@ impl CompilationEnv {
     ) -> anyhow::Result<()> {
         let filter_attr = self.known_filters.entry(attr_name).or_default();
         for filter in filters {
-            let (prefix, n) = match filter {
-                WarningFilter::All(prefix) => (prefix, Symbol::from(FILTER_ALL)),
-                WarningFilter::Category { name, prefix, .. } => {
+            let (namespace, n) = match filter {
+                WarningFilter::All(namespace) => (namespace, Symbol::from(FILTER_ALL)),
+                WarningFilter::Category {
+                    name, namespace, ..
+                } => {
                     let Some(n) = name else {
                         anyhow::bail!("A known Category warning filter must have a name specified");
                     };
-                    (prefix, Symbol::from(n))
+                    (namespace, Symbol::from(n))
                 }
                 WarningFilter::Code {
-                    prefix,
+                    namespace,
                     category,
                     code,
                     name,
@@ -477,18 +482,26 @@ impl CompilationEnv {
                     };
                     let n = Symbol::from(n);
                     self.known_filter_names
-                        .insert((prefix, category, code), (attr_name, n));
-                    (prefix, n)
+                        .insert((namespace, category, code), (attr_name, n));
+                    (namespace, n)
                 }
             };
             anyhow::ensure!(
-                attr_name.is_some() == prefix.is_some(),
-                "If the attribute name is specified, e.g. Some(_), the external prefix must also \
-                be specified. attribute name: {attr_name:?}, external prefix: {prefix:?}",
+                attr_name.is_some() == (namespace != COMPILER_FAMILY),
+                "If the attribute name is specified, e.g. Some(_), the namespace must be \
+                external (not COMPILER). attribute name: {attr_name:?}, namespace: {namespace:?}",
             );
             filter_attr.entry(n).or_default().insert(filter);
         }
         Ok(())
+    }
+
+    pub fn family_registry(&self) -> &FamilyRegistry {
+        &self.family_registry
+    }
+
+    pub fn family_registry_mut(&mut self) -> &mut FamilyRegistry {
+        &mut self.family_registry
     }
 
     pub fn visitors(&self) -> &Visitors {

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/coin_field.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/coin_field.rs
@@ -6,7 +6,7 @@
 
 use crate::{
     diag,
-    diagnostics::codes::{DiagnosticInfo, Severity, custom},
+    diagnostics::codes::{DiagnosticInfo, LINT_WARNING_FAMILY, Severity, custom},
     expansion::ast::ModuleIdent,
     naming::ast as N,
     parser::ast::DatatypeName,
@@ -14,13 +14,10 @@ use crate::{
     typing::{ast as T, visitor::simple_visitor},
 };
 
-use super::{
-    COIN_MOD_NAME, COIN_STRUCT_NAME, LINT_WARNING_PREFIX, LinterDiagnosticCategory,
-    LinterDiagnosticCode,
-};
+use super::{COIN_MOD_NAME, COIN_STRUCT_NAME, LinterDiagnosticCategory, LinterDiagnosticCode};
 
 const COIN_FIELD_DIAG: DiagnosticInfo = custom(
-    LINT_WARNING_PREFIX,
+    LINT_WARNING_FAMILY,
     Severity::Warning,
     LinterDiagnosticCategory::Sui as u8,
     LinterDiagnosticCode::CoinField as u8,

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/collection_equality.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/collection_equality.rs
@@ -10,7 +10,7 @@ use move_symbol_pool::Symbol;
 
 use crate::{
     diag,
-    diagnostics::codes::{DiagnosticInfo, Severity, custom},
+    diagnostics::codes::{DiagnosticInfo, LINT_WARNING_FAMILY, Severity, custom},
     parser::ast as P,
     sui_mode::{SUI_ADDR_NAME, SUI_ADDR_VALUE},
     typing::{ast as T, visitor::simple_visitor},
@@ -18,14 +18,14 @@ use crate::{
 
 use super::{
     BAG_MOD_NAME, BAG_STRUCT_NAME, LINKED_TABLE_MOD_NAME, LINKED_TABLE_STRUCT_NAME,
-    LINT_WARNING_PREFIX, LinterDiagnosticCategory, LinterDiagnosticCode, OBJECT_BAG_MOD_NAME,
-    OBJECT_BAG_STRUCT_NAME, OBJECT_TABLE_MOD_NAME, OBJECT_TABLE_STRUCT_NAME, TABLE_MOD_NAME,
-    TABLE_STRUCT_NAME, TABLE_VEC_MOD_NAME, TABLE_VEC_STRUCT_NAME, VEC_MAP_MOD_NAME,
-    VEC_MAP_STRUCT_NAME, VEC_SET_MOD_NAME, VEC_SET_STRUCT_NAME,
+    LinterDiagnosticCategory, LinterDiagnosticCode, OBJECT_BAG_MOD_NAME, OBJECT_BAG_STRUCT_NAME,
+    OBJECT_TABLE_MOD_NAME, OBJECT_TABLE_STRUCT_NAME, TABLE_MOD_NAME, TABLE_STRUCT_NAME,
+    TABLE_VEC_MOD_NAME, TABLE_VEC_STRUCT_NAME, VEC_MAP_MOD_NAME, VEC_MAP_STRUCT_NAME,
+    VEC_SET_MOD_NAME, VEC_SET_STRUCT_NAME,
 };
 
 const COLLECTIONS_EQUALITY_DIAG: DiagnosticInfo = custom(
-    LINT_WARNING_PREFIX,
+    LINT_WARNING_FAMILY,
     Severity::Warning,
     LinterDiagnosticCategory::Sui as u8,
     LinterDiagnosticCode::CollectionEquality as u8,

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/custom_state_change.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/custom_state_change.rs
@@ -24,7 +24,7 @@ use crate::{
     diag,
     diagnostics::{
         Diagnostic, Diagnostics,
-        codes::{DiagnosticInfo, Severity, custom},
+        codes::{DiagnosticInfo, LINT_WARNING_FAMILY, Severity, custom},
     },
     hlir::ast::{
         BaseType_, Label, ModuleCall, SingleType, SingleType_, Type, Type_, TypeName_, Var,
@@ -36,8 +36,8 @@ use crate::{
 use std::collections::BTreeMap;
 
 use super::{
-    FREEZE_FUN, INVALID_LOC, LINT_WARNING_PREFIX, LinterDiagnosticCategory, LinterDiagnosticCode,
-    RECEIVE_FUN, SHARE_FUN, TRANSFER_FUN, TRANSFER_MOD_NAME,
+    FREEZE_FUN, INVALID_LOC, LinterDiagnosticCategory, LinterDiagnosticCode, RECEIVE_FUN,
+    SHARE_FUN, TRANSFER_FUN, TRANSFER_MOD_NAME,
 };
 
 const PRIVATE_OBJ_FUNCTIONS: &[(AccountAddress, &str, &str)] = &[
@@ -48,7 +48,7 @@ const PRIVATE_OBJ_FUNCTIONS: &[(AccountAddress, &str, &str)] = &[
 ];
 
 const CUSTOM_STATE_CHANGE_DIAG: DiagnosticInfo = custom(
-    LINT_WARNING_PREFIX,
+    LINT_WARNING_FAMILY,
     Severity::Warning,
     LinterDiagnosticCategory::Sui as u8,
     LinterDiagnosticCode::CustomStateChange as u8,

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/freeze_wrapped.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/freeze_wrapped.rs
@@ -9,7 +9,7 @@ use crate::{
     diag,
     diagnostics::{
         Diagnostic, DiagnosticReporter, Diagnostics,
-        codes::{DiagnosticInfo, Severity, custom},
+        codes::{DiagnosticInfo, LINT_WARNING_FAMILY, Severity, custom},
         warning_filters::WarningFilters,
     },
     expansion::ast as E,
@@ -19,8 +19,8 @@ use crate::{
     sui_mode::{
         SUI_ADDR_VALUE,
         linters::{
-            FREEZE_FUN, LINT_WARNING_PREFIX, LinterDiagnosticCategory, LinterDiagnosticCode,
-            PUBLIC_FREEZE_FUN, TRANSFER_MOD_NAME,
+            FREEZE_FUN, LinterDiagnosticCategory, LinterDiagnosticCode, PUBLIC_FREEZE_FUN,
+            TRANSFER_MOD_NAME,
         },
     },
     typing::{
@@ -34,7 +34,7 @@ use move_symbol_pool::Symbol;
 use std::{collections::BTreeMap, sync::Arc};
 
 const FREEZE_WRAPPING_DIAG: DiagnosticInfo = custom(
-    LINT_WARNING_PREFIX,
+    LINT_WARNING_FAMILY,
     Severity::Warning,
     LinterDiagnosticCategory::Sui as u8,
     LinterDiagnosticCode::FreezeWrapped as u8,

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/freezing_capability.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/freezing_capability.rs
@@ -6,14 +6,14 @@
 
 use crate::{
     diag,
-    diagnostics::codes::{DiagnosticInfo, Severity, custom},
+    diagnostics::codes::{DiagnosticInfo, LINT_WARNING_FAMILY, Severity, custom},
     naming::ast::TypeName_,
     shared::Identifier,
     sui_mode::{
         SUI_ADDR_VALUE,
         linters::{
-            FREEZE_FUN, LINT_WARNING_PREFIX, LinterDiagnosticCategory, LinterDiagnosticCode,
-            PUBLIC_FREEZE_FUN, TRANSFER_MOD_NAME,
+            FREEZE_FUN, LinterDiagnosticCategory, LinterDiagnosticCode, PUBLIC_FREEZE_FUN,
+            TRANSFER_MOD_NAME,
         },
     },
     typing::{ast as T, core, visitor::simple_visitor},
@@ -26,7 +26,7 @@ use regex::Regex;
 use std::sync::LazyLock;
 
 const FREEZE_CAPABILITY_DIAG: DiagnosticInfo = custom(
-    LINT_WARNING_PREFIX,
+    LINT_WARNING_FAMILY,
     Severity::Warning,
     LinterDiagnosticCategory::Sui as u8,
     LinterDiagnosticCode::FreezingCapability as u8,

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/missing_key.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/missing_key.rs
@@ -3,12 +3,12 @@
 
 //! This linter rule checks for structs with an `id` field of type `UID` without the `key` ability.
 
-use super::{LINT_WARNING_PREFIX, LinterDiagnosticCategory, LinterDiagnosticCode};
+use super::{LinterDiagnosticCategory, LinterDiagnosticCode};
 use crate::expansion::ast::ModuleIdent;
 use crate::parser::ast::DatatypeName;
 use crate::{
     diag,
-    diagnostics::codes::{DiagnosticInfo, Severity, custom},
+    diagnostics::codes::{DiagnosticInfo, LINT_WARNING_FAMILY, Severity, custom},
     naming::ast::{StructDefinition, StructFields},
     parser::ast::Ability_,
     sui_mode::{ID_FIELD_NAME, OBJECT_MODULE_NAME, SUI_ADDR_VALUE, UID_TYPE_NAME},
@@ -16,7 +16,7 @@ use crate::{
 };
 
 const MISSING_KEY_ABILITY_DIAG: DiagnosticInfo = custom(
-    LINT_WARNING_PREFIX,
+    LINT_WARNING_FAMILY,
     Severity::Warning,
     LinterDiagnosticCategory::Sui as u8,
     LinterDiagnosticCode::MissingKey as u8,

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/mod.rs
@@ -4,10 +4,10 @@
 use crate::{
     cfgir::visitor::AbstractInterpreterVisitor,
     command_line::compiler::Visitor,
-    diagnostics::warning_filters::WarningFilter,
+    diagnostics::{codes::LINT_WARNING_FAMILY, warning_filters::WarningFilter},
     expansion::ast as E,
     hlir::ast::{BaseType_, SingleType, SingleType_},
-    linters::{ALLOW_ATTR_CATEGORY, LINT_WARNING_PREFIX, LintLevel, LinterDiagnosticCategory},
+    linters::{ALLOW_ATTR_CATEGORY, LintLevel, LinterDiagnosticCategory},
     typing::visitor::TypingVisitor,
 };
 use move_ir_types::location::Loc;
@@ -100,75 +100,75 @@ pub enum LinterDiagnosticCode {
 
 pub fn known_filters() -> (Option<Symbol>, Vec<WarningFilter>) {
     let filters = vec![
-        WarningFilter::All(Some(LINT_WARNING_PREFIX)),
+        WarningFilter::All(LINT_WARNING_FAMILY),
         WarningFilter::code(
-            Some(LINT_WARNING_PREFIX),
+            LINT_WARNING_FAMILY,
             LinterDiagnosticCategory::Sui as u8,
             LinterDiagnosticCode::ShareOwned as u8,
             Some(SHARE_OWNED_FILTER_NAME),
         ),
         WarningFilter::code(
-            Some(LINT_WARNING_PREFIX),
+            LINT_WARNING_FAMILY,
             LinterDiagnosticCategory::Sui as u8,
             LinterDiagnosticCode::SelfTransfer as u8,
             Some(SELF_TRANSFER_FILTER_NAME),
         ),
         WarningFilter::code(
-            Some(LINT_WARNING_PREFIX),
+            LINT_WARNING_FAMILY,
             LinterDiagnosticCategory::Sui as u8,
             LinterDiagnosticCode::CustomStateChange as u8,
             Some(CUSTOM_STATE_CHANGE_FILTER_NAME),
         ),
         WarningFilter::code(
-            Some(LINT_WARNING_PREFIX),
+            LINT_WARNING_FAMILY,
             LinterDiagnosticCategory::Sui as u8,
             LinterDiagnosticCode::CoinField as u8,
             Some(COIN_FIELD_FILTER_NAME),
         ),
         WarningFilter::code(
-            Some(LINT_WARNING_PREFIX),
+            LINT_WARNING_FAMILY,
             LinterDiagnosticCategory::Sui as u8,
             LinterDiagnosticCode::FreezeWrapped as u8,
             Some(FREEZE_WRAPPED_FILTER_NAME),
         ),
         WarningFilter::code(
-            Some(LINT_WARNING_PREFIX),
+            LINT_WARNING_FAMILY,
             LinterDiagnosticCategory::Sui as u8,
             LinterDiagnosticCode::CollectionEquality as u8,
             Some(COLLECTION_EQUALITY_FILTER_NAME),
         ),
         WarningFilter::code(
-            Some(LINT_WARNING_PREFIX),
+            LINT_WARNING_FAMILY,
             LinterDiagnosticCategory::Sui as u8,
             LinterDiagnosticCode::PublicRandom as u8,
             Some(PUBLIC_RANDOM_FILTER_NAME),
         ),
         WarningFilter::code(
-            Some(LINT_WARNING_PREFIX),
+            LINT_WARNING_FAMILY,
             LinterDiagnosticCategory::Sui as u8,
             LinterDiagnosticCode::MissingKey as u8,
             Some(MISSING_KEY_FILTER_NAME),
         ),
         WarningFilter::code(
-            Some(LINT_WARNING_PREFIX),
+            LINT_WARNING_FAMILY,
             LinterDiagnosticCategory::Sui as u8,
             LinterDiagnosticCode::FreezingCapability as u8,
             Some(FREEZING_CAPABILITY_FILTER_NAME),
         ),
         WarningFilter::code(
-            Some(LINT_WARNING_PREFIX),
+            LINT_WARNING_FAMILY,
             LinterDiagnosticCategory::Sui as u8,
             LinterDiagnosticCode::PreferMutableTxContext as u8,
             Some(PREFER_MUTABLE_TX_CONTEXT_FILTER_NAME),
         ),
         WarningFilter::code(
-            Some(LINT_WARNING_PREFIX),
+            LINT_WARNING_FAMILY,
             LinterDiagnosticCategory::Sui as u8,
             LinterDiagnosticCode::UnnecessaryPublicEntry as u8,
             Some(UNNECESSARY_PUBLIC_ENTRY_FILTER_NAME),
         ),
         WarningFilter::code(
-            Some(LINT_WARNING_PREFIX),
+            LINT_WARNING_FAMILY,
             LinterDiagnosticCategory::Sui as u8,
             LinterDiagnosticCode::UncallableFunction as u8,
             Some(UNCALLABLE_FUNCTION_FILTER_NAME),

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/public_mut_tx_context.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/public_mut_tx_context.rs
@@ -5,10 +5,10 @@
 //! Detects and reports instances where a non-mutable reference to `TxContext` is used in public function signatures.
 //! Promotes best practices for future-proofing smart contract code by allowing mutation of the transaction context.
 
-use super::{LINT_WARNING_PREFIX, LinterDiagnosticCategory, LinterDiagnosticCode};
+use super::{LinterDiagnosticCategory, LinterDiagnosticCode};
 use crate::{
     diag,
-    diagnostics::codes::{DiagnosticInfo, Severity, custom},
+    diagnostics::codes::{DiagnosticInfo, LINT_WARNING_FAMILY, Severity, custom},
     expansion::ast::{ModuleIdent, Visibility},
     naming::ast::TypeInner,
     parser::ast::FunctionName,
@@ -18,7 +18,7 @@ use crate::{
 use move_ir_types::location::Loc;
 
 const REQUIRE_MUTABLE_TX_CONTEXT_DIAG: DiagnosticInfo = custom(
-    LINT_WARNING_PREFIX,
+    LINT_WARNING_FAMILY,
     Severity::Warning,
     LinterDiagnosticCategory::Sui as u8,
     LinterDiagnosticCode::PreferMutableTxContext as u8,

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/public_random.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/public_random.rs
@@ -9,19 +9,19 @@ use crate::sui_mode::{SUI_ADDR_NAME, SUI_ADDR_VALUE};
 use crate::typing::visitor::simple_visitor;
 use crate::{
     diag,
-    diagnostics::codes::{DiagnosticInfo, Severity, custom},
+    diagnostics::codes::{DiagnosticInfo, LINT_WARNING_FAMILY, Severity, custom},
     expansion::ast::Visibility,
     naming::ast as N,
     typing::ast as T,
 };
 
 use super::{
-    LINT_WARNING_PREFIX, LinterDiagnosticCategory, LinterDiagnosticCode,
-    RANDOM_GENERATOR_STRUCT_NAME, RANDOM_MOD_NAME, RANDOM_STRUCT_NAME,
+    LinterDiagnosticCategory, LinterDiagnosticCode, RANDOM_GENERATOR_STRUCT_NAME, RANDOM_MOD_NAME,
+    RANDOM_STRUCT_NAME,
 };
 
 const PUBLIC_RANDOM_DIAG: DiagnosticInfo = custom(
-    LINT_WARNING_PREFIX,
+    LINT_WARNING_FAMILY,
     Severity::Warning,
     LinterDiagnosticCategory::Sui as u8,
     LinterDiagnosticCode::PublicRandom as u8,

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/self_transfer.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/self_transfer.rs
@@ -20,7 +20,7 @@ use crate::{
     diag,
     diagnostics::{
         Diagnostic, Diagnostics,
-        codes::{DiagnosticInfo, Severity, custom},
+        codes::{DiagnosticInfo, LINT_WARNING_FAMILY, Severity, custom},
     },
     hlir::ast::{Label, ModuleCall, Type, Type_, Var},
     parser::ast::Ability_,
@@ -29,8 +29,8 @@ use crate::{
 use std::collections::BTreeMap;
 
 use super::{
-    INVALID_LOC, LINT_WARNING_PREFIX, LinterDiagnosticCategory, LinterDiagnosticCode,
-    PUBLIC_TRANSFER_FUN, TRANSFER_FUN, TRANSFER_MOD_NAME, type_abilities,
+    INVALID_LOC, LinterDiagnosticCategory, LinterDiagnosticCode, PUBLIC_TRANSFER_FUN, TRANSFER_FUN,
+    TRANSFER_MOD_NAME, type_abilities,
 };
 
 const TRANSFER_FUNCTIONS: &[(AccountAddress, &str, &str)] = &[
@@ -39,7 +39,7 @@ const TRANSFER_FUNCTIONS: &[(AccountAddress, &str, &str)] = &[
 ];
 
 const SELF_TRANSFER_DIAG: DiagnosticInfo = custom(
-    LINT_WARNING_PREFIX,
+    LINT_WARNING_FAMILY,
     Severity::Warning,
     LinterDiagnosticCategory::Sui as u8,
     LinterDiagnosticCode::SelfTransfer as u8,

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/share_owned.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/share_owned.rs
@@ -19,7 +19,7 @@ use crate::{
     diag,
     diagnostics::{
         Diagnostic, Diagnostics,
-        codes::{DiagnosticInfo, Severity, custom},
+        codes::{DiagnosticInfo, LINT_WARNING_FAMILY, Severity, custom},
     },
     expansion::ast::ModuleIdent,
     hlir::ast::{
@@ -36,8 +36,8 @@ use crate::{
         SUI_ADDR_VALUE, TX_CONTEXT_MODULE_NAME, TX_CONTEXT_TYPE_NAME,
         info::TransferKind,
         linters::{
-            LINT_WARNING_PREFIX, LinterDiagnosticCategory, LinterDiagnosticCode, PUBLIC_SHARE_FUN,
-            SHARE_FUN, TRANSFER_MOD_NAME, type_abilities,
+            LinterDiagnosticCategory, LinterDiagnosticCode, PUBLIC_SHARE_FUN, SHARE_FUN,
+            TRANSFER_MOD_NAME, type_abilities,
         },
     },
 };
@@ -52,7 +52,7 @@ const SHARE_FUNCTIONS: &[(AccountAddress, &str, &str)] = &[
 ];
 
 const SHARE_OWNED_DIAG: DiagnosticInfo = custom(
-    LINT_WARNING_PREFIX,
+    LINT_WARNING_FAMILY,
     Severity::Warning,
     LinterDiagnosticCategory::Sui as u8,
     LinterDiagnosticCode::ShareOwned as u8,

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/uncallable_function.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/uncallable_function.rs
@@ -1,10 +1,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use super::{LINT_WARNING_PREFIX, LinterDiagnosticCategory, LinterDiagnosticCode};
+use super::{LinterDiagnosticCategory, LinterDiagnosticCode};
 use crate::{
     diag,
-    diagnostics::codes::{DiagnosticInfo, Severity, custom},
+    diagnostics::codes::{DiagnosticInfo, LINT_WARNING_FAMILY, Severity, custom},
     expansion::ast::ModuleIdent,
     parser::ast::FunctionName,
     sui_mode::{
@@ -17,7 +17,7 @@ use crate::{
 use move_ir_types::location::Loc;
 
 const UNCALLABLE_FUNCTION_SIGNATURE: DiagnosticInfo = custom(
-    LINT_WARNING_PREFIX,
+    LINT_WARNING_FAMILY,
     Severity::Warning,
     LinterDiagnosticCategory::Sui as u8,
     LinterDiagnosticCode::UncallableFunction as u8,

--- a/external-crates/move/crates/move-compiler/src/sui_mode/linters/unnecessary_public_entry.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/linters/unnecessary_public_entry.rs
@@ -4,10 +4,10 @@
 // Implements lint rule for Move code to detect unnecessary `public entry` functions.
 // It identifies and reports functions that contain both `public` and `entry` modifiers.
 
-use super::{LINT_WARNING_PREFIX, LinterDiagnosticCategory, LinterDiagnosticCode};
+use super::{LinterDiagnosticCategory, LinterDiagnosticCode};
 use crate::{
     diag,
-    diagnostics::codes::{DiagnosticInfo, Severity, custom},
+    diagnostics::codes::{DiagnosticInfo, LINT_WARNING_FAMILY, Severity, custom},
     expansion::ast::{ModuleIdent, Visibility},
     parser::ast::FunctionName,
     typing::{
@@ -17,7 +17,7 @@ use crate::{
 };
 
 const PUBLIC_ENTRY_DIAG: DiagnosticInfo = custom(
-    LINT_WARNING_PREFIX,
+    LINT_WARNING_FAMILY,
     Severity::Warning,
     LinterDiagnosticCategory::Sui as u8,
     LinterDiagnosticCode::UnnecessaryPublicEntry as u8,

--- a/external-crates/move/crates/move-compiler/src/sui_mode/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/sui_mode/mod.rs
@@ -5,7 +5,7 @@ use move_core_types::account_address::AccountAddress;
 use move_symbol_pool::Symbol;
 
 use crate::{
-    diagnostics::codes::{DiagnosticInfo, Severity, custom},
+    diagnostics::codes::{DiagnosticInfo, SUI_LINT_FAMILY, Severity, custom},
     shared::stdlib_definitions,
 };
 
@@ -111,7 +111,7 @@ pub const ID_LEAK_CATEGORY: u8 = 1;
 pub const TYPING: u8 = 2;
 
 pub const ID_LEAK_DIAG: DiagnosticInfo = custom(
-    SUI_DIAG_PREFIX,
+    SUI_LINT_FAMILY,
     Severity::NonblockingError,
     /* category */ ID_LEAK_CATEGORY,
     /* code */ 1,
@@ -119,63 +119,63 @@ pub const ID_LEAK_DIAG: DiagnosticInfo = custom(
 );
 
 pub const INIT_FUN_DIAG: DiagnosticInfo = custom(
-    SUI_DIAG_PREFIX,
+    SUI_LINT_FAMILY,
     Severity::NonblockingError,
     /* category */ TYPING,
     /* code */ 3,
     "invalid 'init' function",
 );
 pub const OTW_DECL_DIAG: DiagnosticInfo = custom(
-    SUI_DIAG_PREFIX,
+    SUI_LINT_FAMILY,
     Severity::NonblockingError,
     /* category */ TYPING,
     /* code */ 4,
     "invalid one-time witness declaration",
 );
 pub const OTW_USAGE_DIAG: DiagnosticInfo = custom(
-    SUI_DIAG_PREFIX,
+    SUI_LINT_FAMILY,
     Severity::NonblockingError,
     /* category */ TYPING,
     /* code */ 5,
     "invalid one-time witness usage",
 );
 pub const INIT_CALL_DIAG: DiagnosticInfo = custom(
-    SUI_DIAG_PREFIX,
+    SUI_LINT_FAMILY,
     Severity::NonblockingError,
     /* category */ TYPING,
     /* code */ 6,
     "invalid 'init' call",
 );
 pub const OBJECT_DECL_DIAG: DiagnosticInfo = custom(
-    SUI_DIAG_PREFIX,
+    SUI_LINT_FAMILY,
     Severity::NonblockingError,
     /* category */ TYPING,
     /* code */ 7,
     "invalid object declaration",
 );
 pub const EVENT_EMIT_CALL_DIAG: DiagnosticInfo = custom(
-    SUI_DIAG_PREFIX,
+    SUI_LINT_FAMILY,
     Severity::NonblockingError,
     /* category */ TYPING,
     /* code */ 8,
     "invalid event",
 );
 pub const PRIVATE_TRANSFER_CALL_DIAG: DiagnosticInfo = custom(
-    SUI_DIAG_PREFIX,
+    SUI_LINT_FAMILY,
     Severity::NonblockingError,
     /* category */ TYPING,
     /* code */ 9,
     "invalid private transfer call",
 );
 pub const DYNAMIC_COIN_CREATION_CALL_DIAG: DiagnosticInfo = custom(
-    SUI_DIAG_PREFIX,
+    SUI_LINT_FAMILY,
     Severity::NonblockingError,
     /* category */ TYPING,
     /* code */ 10,
     "invalid coin creation call",
 );
 pub const INTERNAL_PERMIT_CALL_DIAG: DiagnosticInfo = custom(
-    SUI_DIAG_PREFIX,
+    SUI_LINT_FAMILY,
     Severity::NonblockingError,
     /* category */ TYPING,
     /* code */ 11,


### PR DESCRIPTION
## Description 

Toward reworking allow lists, intern prefixes as u8s (also, rename the families to help my brain a bit). This is a small change, but should allow us to do some fun optimizations in the next PR.

## Test plan 

Everything still works.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
