### PR TITLE
[sui-indexer-alt-reader] Add gRPC metrics middleware and refactor clients to use it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15667,6 +15667,7 @@ dependencies = [
  "diesel",
  "diesel-async",
  "futures",
+ "http 1.3.1",
  "move-core-types",
  "mysten-common",
  "prometheus",
@@ -15687,6 +15688,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tonic 0.14.3",
+ "tower 0.5.3",
  "tracing",
  "url",
 ]

--- a/crates/sui-indexer-alt-reader/Cargo.toml
+++ b/crates/sui-indexer-alt-reader/Cargo.toml
@@ -18,12 +18,14 @@ clap.workspace = true
 diesel.workspace = true
 diesel-async = { workspace = true, features = ["bb8", "postgres", "async-connection-wrapper"] }
 futures.workspace = true
+http.workspace = true
 prost-types.workspace = true
 prometheus.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tonic = { workspace = true, features = ["tls-native-roots"] }
+tower.workspace = true
 tracing.workspace = true
 url.workspace = true
 

--- a/crates/sui-indexer-alt-reader/src/fullnode_client.rs
+++ b/crates/sui-indexer-alt-reader/src/fullnode_client.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
-
 use anyhow::Context;
 use prometheus::Registry;
 use prost_types::FieldMask;
@@ -13,10 +11,12 @@ use sui_types::transaction::Transaction;
 use sui_types::transaction::TransactionData;
 use tonic::transport::Channel;
 use tonic::transport::ClientTlsConfig;
+use tower::Layer;
 use tracing::instrument;
 use url::Url;
 
-use crate::metrics::FullnodeClientMetrics;
+use crate::metrics::GrpcMetricsLayer;
+use crate::metrics::GrpcMetricsService;
 
 #[derive(clap::Args, Debug, Clone)]
 pub struct FullnodeArgs {
@@ -28,8 +28,7 @@ pub struct FullnodeArgs {
 /// A client for executing and simulating transactions via the full node gRPC service.
 #[derive(Clone)]
 pub struct FullnodeClient {
-    execution_client: TransactionExecutionServiceClient<Channel>,
-    metrics: Arc<FullnodeClientMetrics>,
+    execution_client: TransactionExecutionServiceClient<GrpcMetricsService<Channel>>,
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -57,13 +56,12 @@ impl FullnodeClient {
         }
 
         let channel = endpoint.connect_lazy();
-        let execution_client = TransactionExecutionServiceClient::new(channel);
-        let metrics = FullnodeClientMetrics::new(prefix, registry);
 
-        Ok(Self {
-            execution_client,
-            metrics,
-        })
+        let layered = GrpcMetricsLayer::new(prefix.unwrap_or("fullnode"), registry).layer(channel);
+
+        let execution_client = TransactionExecutionServiceClient::new(layered);
+
+        Ok(Self { execution_client })
     }
 
     /// Execute a transaction on the Sui network via gRPC.
@@ -98,10 +96,12 @@ impl FullnodeClient {
         .with_signatures(signatures)
         .with_read_mask(read_mask);
 
-        self.request("execute_transaction", |mut client| async move {
-            client.execute_transaction(request).await
-        })
-        .await
+        self.execution_client
+            .clone()
+            .execute_transaction(request)
+            .await
+            .map(|r| r.into_inner())
+            .map_err(Into::into)
     }
 
     /// Simulate a transaction on the Sui network via gRPC.
@@ -130,46 +130,12 @@ impl FullnodeClient {
             .with_checks(checks)
             .with_do_gas_selection(do_gas_selection);
 
-        self.request("simulate_transaction", |mut client| async move {
-            client.simulate_transaction(request).await
-        })
-        .await
-    }
-
-    async fn request<F, Fut, R>(&self, method: &str, response: F) -> Result<R, Error>
-    where
-        F: FnOnce(TransactionExecutionServiceClient<Channel>) -> Fut,
-        Fut: std::future::Future<Output = Result<tonic::Response<R>, tonic::Status>>,
-    {
-        self.metrics
-            .requests_received
-            .with_label_values(&[method])
-            .inc();
-
-        let _timer = self
-            .metrics
-            .latency
-            .with_label_values(&[method])
-            .start_timer();
-
-        let response = response(self.execution_client.clone())
+        self.execution_client
+            .clone()
+            .simulate_transaction(request)
             .await
             .map(|r| r.into_inner())
-            .map_err(Into::into);
-
-        if response.is_ok() {
-            self.metrics
-                .requests_succeeded
-                .with_label_values(&[method])
-                .inc();
-        } else {
-            self.metrics
-                .requests_failed
-                .with_label_values(&[method])
-                .inc();
-        }
-
-        response
+            .map_err(Into::into)
     }
 }
 

--- a/crates/sui-indexer-alt-reader/src/ledger_grpc_reader.rs
+++ b/crates/sui-indexer-alt-reader/src/ledger_grpc_reader.rs
@@ -1,7 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Context;
@@ -17,8 +16,10 @@ use sui_types::transaction::TransactionData;
 use tonic::transport::Channel;
 use tonic::transport::ClientTlsConfig;
 use tonic::transport::Uri;
+use tower::Layer;
 
-use crate::metrics::LedgerGrpcReaderMetrics;
+use crate::metrics::GrpcMetricsLayer;
+use crate::metrics::GrpcMetricsService;
 
 const DEFAULT_MAX_DECODING_MESSAGE_SIZE: usize = 32 * 1024 * 1024;
 
@@ -50,9 +51,8 @@ pub struct CheckpointedTransaction {
 /// as fullnode, but is backed by Bigtable for serving historical data.
 #[derive(Clone)]
 pub struct LedgerGrpcReader {
-    client: LedgerServiceClient<Channel>,
+    client: LedgerServiceClient<GrpcMetricsService<Channel>>,
     timeout: Option<Duration>,
-    metrics: Arc<LedgerGrpcReaderMetrics>,
 }
 
 impl LedgerGrpcArgs {
@@ -80,20 +80,17 @@ impl LedgerGrpcReader {
         }
 
         let channel = endpoint.connect_lazy();
+        let layered =
+            GrpcMetricsLayer::new(prefix.unwrap_or("ledger_grpc"), registry).layer(channel);
 
         let timeout = args.statement_timeout();
         let max_decoding_message_size = args
             .ledger_grpc_max_decoding_message_size
             .unwrap_or(DEFAULT_MAX_DECODING_MESSAGE_SIZE);
-        let client = LedgerServiceClient::new(channel.clone())
-            .max_decoding_message_size(max_decoding_message_size);
-        let metrics = LedgerGrpcReaderMetrics::new(prefix, registry);
+        let client =
+            LedgerServiceClient::new(layered).max_decoding_message_size(max_decoding_message_size);
 
-        Ok(Self {
-            client,
-            timeout,
-            metrics,
-        })
+        Ok(Self { client, timeout })
     }
 
     pub fn as_data_loader(&self) -> DataLoader<Self> {
@@ -127,93 +124,52 @@ impl LedgerGrpcReader {
         &self,
         request: grpc::GetCheckpointRequest,
     ) -> Result<grpc::GetCheckpointResponse, tonic::Status> {
-        self.request(
-            "get_checkpoint",
-            |mut client, request| async move { client.get_checkpoint(request).await },
-            request,
-        )
-        .await
+        self.client
+            .clone()
+            .get_checkpoint(self.request(request))
+            .await
+            .map(|r| r.into_inner())
     }
 
     pub async fn batch_get_transactions(
         &self,
         request: grpc::BatchGetTransactionsRequest,
     ) -> Result<grpc::BatchGetTransactionsResponse, tonic::Status> {
-        self.request(
-            "batch_get_transactions",
-            |mut client, request| async move { client.batch_get_transactions(request).await },
-            request,
-        )
-        .await
+        self.client
+            .clone()
+            .batch_get_transactions(self.request(request))
+            .await
+            .map(|r| r.into_inner())
     }
 
     pub async fn batch_get_objects(
         &self,
         request: grpc::BatchGetObjectsRequest,
     ) -> Result<grpc::BatchGetObjectsResponse, tonic::Status> {
-        self.request(
-            "batch_get_objects",
-            |mut client, request| async move { client.batch_get_objects(request).await },
-            request,
-        )
-        .await
+        self.client
+            .clone()
+            .batch_get_objects(self.request(request))
+            .await
+            .map(|r| r.into_inner())
     }
 
     pub async fn get_transaction(
         &self,
         request: grpc::GetTransactionRequest,
     ) -> Result<grpc::GetTransactionResponse, tonic::Status> {
-        self.request(
-            "get_transaction",
-            |mut client, request| async move { client.get_transaction(request).await },
-            request,
-        )
-        .await
+        self.client
+            .clone()
+            .get_transaction(self.request(request))
+            .await
+            .map(|r| r.into_inner())
     }
 
-    // Generic request wrapper that instruments all gRPC calls with metrics
-    async fn request<F, Fut, I, R>(
-        &self,
-        method: &str,
-        response: F,
-        input: I,
-    ) -> Result<R, tonic::Status>
-    where
-        F: FnOnce(LedgerServiceClient<Channel>, tonic::Request<I>) -> Fut,
-        Fut: std::future::Future<Output = Result<tonic::Response<R>, tonic::Status>>,
-    {
-        self.metrics
-            .requests_received
-            .with_label_values(&[method])
-            .inc();
-
-        let _timer = self
-            .metrics
-            .latency
-            .with_label_values(&[method])
-            .start_timer();
-
+    /// Create a gRPC request, optionally with the grpc-timeout header if configured.
+    fn request<T>(&self, input: T) -> tonic::Request<T> {
         let mut request = tonic::Request::new(input);
         if let Some(timeout) = self.timeout {
             request.set_timeout(timeout);
         }
-
-        let response = response(self.client.clone(), request)
-            .await
-            .map(|r| r.into_inner());
-
-        if response.is_ok() {
-            self.metrics
-                .requests_succeeded
-                .with_label_values(&[method])
-                .inc();
-        } else {
-            self.metrics
-                .requests_failed
-                .with_label_values(&[method])
-                .inc();
-        }
-
-        response
+        request
     }
 }

--- a/crates/sui-indexer-alt-reader/src/metrics.rs
+++ b/crates/sui-indexer-alt-reader/src/metrics.rs
@@ -1,9 +1,14 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::Arc;
+use std::task::Context;
+use std::task::Poll;
 
 use prometheus::Histogram;
+use prometheus::HistogramTimer;
 use prometheus::HistogramVec;
 use prometheus::IntCounter;
 use prometheus::IntCounterVec;
@@ -12,6 +17,8 @@ use prometheus::register_histogram_vec_with_registry;
 use prometheus::register_histogram_with_registry;
 use prometheus::register_int_counter_vec_with_registry;
 use prometheus::register_int_counter_with_registry;
+use tower::Layer;
+use tower::Service;
 
 /// Histogram buckets for the distribution of latency (time between sending a DB request and
 /// receiving a response).
@@ -37,19 +44,42 @@ pub(crate) struct ConsistentReaderMetrics {
 }
 
 #[derive(Clone)]
-pub(crate) struct FullnodeClientMetrics {
-    pub latency: HistogramVec,
-    pub requests_received: IntCounterVec,
-    pub requests_succeeded: IntCounterVec,
-    pub requests_failed: IntCounterVec,
+pub struct GrpcMetrics {
+    latency: HistogramVec,
+    requests_received: IntCounterVec,
+    requests_succeeded: IntCounterVec,
+    requests_failed: IntCounterVec,
+    requests_cancelled: IntCounterVec,
 }
 
 #[derive(Clone)]
-pub(crate) struct LedgerGrpcReaderMetrics {
-    pub latency: HistogramVec,
-    pub requests_received: IntCounterVec,
-    pub requests_succeeded: IntCounterVec,
-    pub requests_failed: IntCounterVec,
+pub struct GrpcMetricsLayer {
+    metrics: Arc<GrpcMetrics>,
+}
+
+/// Middleware to record metrics defined in `GrpcMetrics`
+#[derive(Clone)]
+pub struct GrpcMetricsService<S> {
+    inner: S,
+    metrics: Arc<GrpcMetrics>,
+}
+
+struct MetricsGuard {
+    metrics: Arc<GrpcMetrics>,
+    method: String,
+    timer: Option<HistogramTimer>,
+}
+
+impl MetricsGuard {
+    fn record(&mut self, ok: bool) {
+        self.timer.take();
+        let counter = if ok {
+            &self.metrics.requests_succeeded
+        } else {
+            &self.metrics.requests_failed
+        };
+        counter.with_label_values(&[&self.method]).inc();
+    }
 }
 
 impl DbReaderMetrics {
@@ -132,15 +162,14 @@ impl ConsistentReaderMetrics {
     }
 }
 
-impl FullnodeClientMetrics {
-    pub(crate) fn new(prefix: Option<&str>, registry: &Registry) -> Arc<Self> {
-        let prefix = prefix.unwrap_or("fullnode_client");
+impl GrpcMetrics {
+    pub fn new(prefix: &str, registry: &Registry) -> Self {
         let name = |n| format!("{prefix}_{n}");
 
-        Arc::new(Self {
+        Self {
             latency: register_histogram_vec_with_registry!(
                 name("latency"),
-                "Time taken for full node gRPC operations",
+                "Time taken for gRPC operations",
                 &["method"],
                 LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
@@ -149,7 +178,7 @@ impl FullnodeClientMetrics {
 
             requests_received: register_int_counter_vec_with_registry!(
                 name("requests_received"),
-                "Number of full node requests received",
+                "Number of gRPC requests sent",
                 &["method"],
                 registry,
             )
@@ -157,7 +186,7 @@ impl FullnodeClientMetrics {
 
             requests_succeeded: register_int_counter_vec_with_registry!(
                 name("requests_succeeded"),
-                "Number of successful full node requests",
+                "Number of gRPC requests that completed successfully",
                 &["method"],
                 registry,
             )
@@ -165,53 +194,90 @@ impl FullnodeClientMetrics {
 
             requests_failed: register_int_counter_vec_with_registry!(
                 name("requests_failed"),
-                "Number of failed full node requests",
+                "Number of gRPC requests that completed with an error",
                 &["method"],
                 registry,
             )
             .unwrap(),
+
+            requests_cancelled: register_int_counter_vec_with_registry!(
+                name("requests_cancelled"),
+                "Number of gRPC requests dropped before completion (cancellation or panic)",
+                &["method"],
+                registry,
+            )
+            .unwrap(),
+        }
+    }
+}
+
+impl GrpcMetricsLayer {
+    pub fn new(prefix: &str, registry: &Registry) -> Self {
+        Self {
+            metrics: Arc::new(GrpcMetrics::new(prefix, registry)),
+        }
+    }
+}
+
+impl<S> Layer<S> for GrpcMetricsLayer {
+    type Service = GrpcMetricsService<S>;
+
+    fn layer(&self, service: S) -> Self::Service {
+        GrpcMetricsService {
+            inner: service,
+            metrics: self.metrics.clone(),
+        }
+    }
+}
+
+impl<S, ReqBody, ResBody> Service<http::Request<ReqBody>> for GrpcMetricsService<S>
+where
+    S: Service<http::Request<ReqBody>, Response = http::Response<ResBody>> + Send + 'static,
+    S::Future: Send + 'static,
+    S::Error: Send + 'static,
+    ReqBody: Send + 'static,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: http::Request<ReqBody>) -> Self::Future {
+        let method = req.uri().path().to_string();
+
+        let metrics = self.metrics.clone();
+        metrics
+            .requests_received
+            .with_label_values(&[&method])
+            .inc();
+        let timer = metrics.latency.with_label_values(&[&method]).start_timer();
+
+        let fut = self.inner.call(req);
+
+        let mut guard = MetricsGuard {
+            metrics,
+            method,
+            timer: Some(timer),
+        };
+
+        Box::pin(async move {
+            let result = fut.await;
+            guard.record(result.is_ok());
+            result
         })
     }
 }
 
-impl LedgerGrpcReaderMetrics {
-    pub(crate) fn new(prefix: Option<&str>, registry: &Registry) -> Arc<Self> {
-        let prefix = prefix.unwrap_or("ledger_grpc");
-        let name = |n| format!("{prefix}_{n}");
-
-        Arc::new(Self {
-            latency: register_histogram_vec_with_registry!(
-                name("latency"),
-                "Time taken for ledger service gRPC operations",
-                &["method"],
-                LATENCY_SEC_BUCKETS.to_vec(),
-                registry,
-            )
-            .unwrap(),
-
-            requests_received: register_int_counter_vec_with_registry!(
-                name("requests_received"),
-                "Number of ledger service requests sent",
-                &["method"],
-                registry,
-            )
-            .unwrap(),
-
-            requests_succeeded: register_int_counter_vec_with_registry!(
-                name("requests_succeeded"),
-                "Number of successful ledger service requests",
-                &["method"],
-                registry,
-            )
-            .unwrap(),
-
-            requests_failed: register_int_counter_vec_with_registry!(
-                name("requests_failed"),
-                "Number of failed ledger service requests",
-                &["method"],
-                registry,
-            )
-            .unwrap(),
-        })
+impl Drop for MetricsGuard {
+    fn drop(&mut self) {
+        if self.timer.is_some() {
+            self.metrics
+                .requests_cancelled
+                .with_label_values(&[&self.method])
+                .inc();
+        }
     }
 }

--- a/crates/sui-indexer-alt-reader/src/metrics.rs
+++ b/crates/sui-indexer-alt-reader/src/metrics.rs
@@ -70,18 +70,6 @@ struct MetricsGuard {
     timer: Option<HistogramTimer>,
 }
 
-impl MetricsGuard {
-    fn record(&mut self, ok: bool) {
-        self.timer.take();
-        let counter = if ok {
-            &self.metrics.requests_succeeded
-        } else {
-            &self.metrics.requests_failed
-        };
-        counter.with_label_values(&[&self.method]).inc();
-    }
-}
-
 impl DbReaderMetrics {
     pub(crate) fn new(prefix: Option<&str>, registry: &Registry) -> Arc<Self> {
         let prefix = prefix.unwrap_or("db");
@@ -216,6 +204,18 @@ impl GrpcMetricsLayer {
         Self {
             metrics: Arc::new(GrpcMetrics::new(prefix, registry)),
         }
+    }
+}
+
+impl MetricsGuard {
+    fn record(&mut self, ok: bool) {
+        self.timer.take();
+        let counter = if ok {
+            &self.metrics.requests_succeeded
+        } else {
+            &self.metrics.requests_failed
+        };
+        counter.with_label_values(&[&self.method]).inc();
     }
 }
 


### PR DESCRIPTION
## Description 

`LedgerGrpcReader` and `FullnodeClient` have the same metrics, just renamed differently, so this PR consolidates the boilerplate into a `GrpcMetricsLayer` middleware that both clients now wrap their channels with.

## Potential followups

- Refactor `FullnodeClient` to push `Option` to the caller, removing `Error::NotConfigured`. Callers hold `Option<FullnodeClient>` and decide at the boundary whether the feature is configured.    
- `requests_cancelled` counter, which we can support by replacing the `boxFuture` with a `pin_project` setup - something like                  crates/sui-indexer-alt-jsonrpc/src/metrics/middleware.rs                           
- `TimeoutLayer` 

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
