### PR TITLE
[move] Implement on-chain dependency pinning

### DIFF
--- a/external-crates/move/crates/move-package-alt/design/dvx-2115-address-identity.md
+++ b/external-crates/move/crates/move-package-alt/design/dvx-2115-address-identity.md
@@ -1,0 +1,129 @@
+# Address Identity in the Dependency Graph
+
+## Problem (TODO)
+
+The dependency system distinguishes between "node" concepts (where a package's source
+lives) and "edge" concepts (how a parent references a dependency). The `Pinned` enum
+represents nodes, and `DependencyContext` represents edges. However, `published_at` and
+`original_id` don't fit cleanly into either category, and the current placement leads to
+design problems. The items below are not yet resolved.
+
+## Background: What Are Addresses?
+
+Every published Move package has two addresses:
+
+- **`original_id`**: The address the package was first published at. This serves as the
+  package's identity in the Move type system — types are identified by `original_id::module::Type`.
+- **`published_at`**: The address where the current version of the package lives on-chain.
+  After an upgrade, `published_at` changes but `original_id` stays the same.
+
+These addresses can come from several sources:
+
+1. **The package's own files** — for legacy packages, this may be in `Move.toml` or
+   `Move.lock`. For modern packages, it is in `Move.published`.
+2. **`dep-replacements` in the parent's manifest** — a parent can override the addresses
+   for a dependency, e.g. when the dependency's own manifest has incorrect or missing
+   address info.
+
+## The Identity Question
+
+Consider this scenario: a git package `foo` is published twice on the same network — once
+at `0xA` and once at `0xB`. These are genuinely different on-chain packages that happen to
+share the same source code. A downstream project could depend on both (e.g., to bridge
+between them).
+
+This is an unusual corner case and something users probably shouldn't do, but it's
+important because it exposes a fundamental question about the design model. We could
+detect this situation and fail, but the fact that we're tripping on these kinds of issues
+suggests we need to think more clearly about the relationship between source identity,
+compiled identity, and address identity.
+
+In the current system:
+- Both edges point to the same fetched source (same git SHA, same local path on disk)
+- But they have different `published_at` / `original_id` via `dep-replacements`
+- The compiled bytecode differs because the self-address differs
+- The type systems are disjoint — `0xA::module::T` and `0xB::module::T` are unrelated types
+
+### Are these the same node or different nodes?
+
+**From a source perspective**: same node. The files on disk are identical.
+
+**From a compiled/on-chain perspective**: different nodes. They produce different bytecode,
+have different type identities, and are independently upgradeable.
+
+## Design Decision
+
+Addresses are part of the **compiled identity** of a package, but not part of the **source
+identity**. This means:
+
+1. **Source fetching and caching** should be based on the source location alone (git SHA +
+   path, local path, etc.). Two deps with the same source but different addresses should
+   share the same fetched files on disk. The current source cache layout does not need to
+   change.
+
+2. **Compiled identity** (for ephemeral publication, linkage, and type checking) must
+   account for addresses. The same source with different address overrides produces
+   different compilation artifacts. While we don't currently cache compiled artifacts, it
+   seems plausible that we would do so in the future, and such a cache would need to be
+   keyed by (source location + addresses).
+
+3. **For on-chain dependencies**, `published_at` is additionally the **source locator** —
+   it determines which bytecode to fetch from the network. So for on-chain deps,
+   `published_at` is unambiguously part of both the source identity and the compiled
+   identity.
+
+## Implications for `Pinned`
+
+If we treat the same source with different addresses as different nodes in the dependency
+graph, then addresses become part of the node identity for **all** `Pinned` variants, not
+just `OnChain`. This would mean `PinnedLocalDependency`, `PinnedGitDependency`, etc. would
+all carry address information.
+
+`unfetched_path` (for source fetching) would ignore addresses, since the source cache is
+keyed by source location alone. But ephemeral publication keys, linkage, and any future
+compiled artifact cache would use addresses as part of the key.
+
+### Immediate step: `Pinned::OnChain` should carry `published_at`
+
+Since `published_at` determines *what to fetch* for on-chain deps (analogous to the git
+SHA for git deps), it belongs in the `Pinned` enum regardless of the broader design:
+
+```rust
+pub(crate) enum Pinned {
+    Local(PinnedLocalDependency),
+    Git(PinnedGitDependency),
+    OnChain { published_at: PublishedID },
+    Root(PackagePath),
+}
+```
+
+This lets `unfetched_path` work naturally for all variants without panics or sentinel
+values.
+
+### Ephemeral publication keys should include addresses
+
+Currently, ephemeral publication (`Pub.<env>.toml`) entries are keyed by
+`EphemeralDependencyInfo`, which wraps `LocalDepInfo` — just the absolute local path to the
+source. The `published_at` and `original_id` are stored as data alongside the key, not as
+part of the key itself.
+
+This means two deps with the same source but different address overrides would collide on
+the same key. If we support the same source at multiple addresses (whether we treat it as
+different nodes or not), the ephemeral publication key should incorporate the address
+override.
+
+### Linkage should validate address consistency
+
+DESIGN.md (lines 609-623) describes a check for conflicting addresses: "if two
+dependencies in the graph have the same original ID but different published addresses, then
+there is a conflict." This check is not yet implemented. With the model above, this
+remains important — two edges claiming the *same* `original_id` with *different*
+`published_at` for what should be the *same* compiled package is a conflict.
+
+## Status
+
+- [x] Put `published_at` into `Pinned::OnChain` (immediate, unblocks on-chain deps)
+- [ ] Decide whether addresses belong on all `Pinned` variants or only `OnChain`
+- [ ] Update ephemeral publication keys to account for address overrides
+- [ ] Implement the address consistency check from DESIGN.md
+- [ ] Consider whether `original_id` should also be in `Pinned::OnChain` or remain in context

--- a/external-crates/move/crates/move-package-alt/src/dependency/fetch.rs
+++ b/external-crates/move/crates/move-package-alt/src/dependency/fetch.rs
@@ -13,11 +13,10 @@ use thiserror::Error;
 use crate::{
     git::GitError,
     package::paths::{PackagePath, PackagePathError},
-    schema::LocalDepInfo,
+    schema::{EnvironmentID, LocalDepInfo},
 };
 
 use super::Pinned;
-use crate::schema::EnvironmentID;
 
 #[derive(Error, Debug)]
 pub enum FetchError {
@@ -36,14 +35,15 @@ pub type FetchResult<T> = Result<T, FetchError>;
 /// Ensure that the dependency's files are present on the disk and return a path to them.
 /// Assumes that `pinned` is already normalized - paths of any local dependencies are relative
 /// to the current working directory, and local dependencies of git dependencies have been
-/// transformed into git dependencies. `chain_id` is passed through to [Pinned::unfetched_path].
+/// transformed into git dependencies. `chain_id` is used to determine the cache location for
+/// on-chain dependencies.
 pub async fn fetch(
     pinned: &Pinned,
     allow_dirty: bool,
     chain_id: &EnvironmentID,
 ) -> FetchResult<PackagePath> {
     let path = match &pinned {
-        Pinned::OnChain => return Err(FetchError::OnChainNotSupported),
+        Pinned::OnChain { .. } => return Err(FetchError::OnChainNotSupported),
         Pinned::Git(dep) => dep
             .inner
             .checkout_repo(allow_dirty)

--- a/external-crates/move/crates/move-package-alt/src/dependency/fetch.rs
+++ b/external-crates/move/crates/move-package-alt/src/dependency/fetch.rs
@@ -26,6 +26,9 @@ pub enum FetchError {
 
     #[error("Error while fetching `{1}`: {0}")]
     GitFailure(GitError, String),
+
+    #[error("On-chain dependencies are not yet supported")]
+    OnChainNotSupported,
 }
 
 pub type FetchResult<T> = Result<T, FetchError>;
@@ -40,6 +43,7 @@ pub async fn fetch(
     chain_id: &EnvironmentID,
 ) -> FetchResult<PackagePath> {
     let path = match &pinned {
+        Pinned::OnChain => return Err(FetchError::OnChainNotSupported),
         Pinned::Git(dep) => dep
             .inner
             .checkout_repo(allow_dirty)

--- a/external-crates/move/crates/move-package-alt/src/dependency/pin.rs
+++ b/external-crates/move/crates/move-package-alt/src/dependency/pin.rs
@@ -14,7 +14,7 @@ use crate::{
     git::{GitCache, GitError, GitTree},
     package::paths::PackagePath,
     schema::{
-        EnvironmentID, EnvironmentName, EphemeralDependencyInfo, LocalDepInfo,
+        ConstTrue, EnvironmentID, EnvironmentName, EphemeralDependencyInfo, LocalDepInfo,
         LockfileDependencyInfo, LockfileGitDepInfo, ManifestGitDependency, ModeName,
         OnChainDepInfo, PackageName, RenderToml, RootDepInfo,
     },
@@ -48,7 +48,7 @@ pub struct PinnedDependency {
 pub(crate) enum Pinned {
     Local(PinnedLocalDependency),
     Git(PinnedGitDependency),
-    OnChain(OnChainDepInfo),
+    OnChain,
     Root(PackagePath),
 }
 
@@ -95,7 +95,14 @@ impl PinnedDependency {
             let transformed = match dep.dep_info {
                 Resolved::Local(ref loc) => loc.clone().pin(parent, environment_id)?,
                 Resolved::Git(ref git) => git.pin().await?,
-                Resolved::OnChain(_) => todo!(),
+                Resolved::OnChain(_) => {
+                    if dep.context.addresses.is_none() {
+                        return Err(PackageError::OnChainDepMissingAddress {
+                            name: dep.context.name.to_string(),
+                        });
+                    }
+                    Pinned::OnChain
+                }
             };
 
             result.push(PinnedDependency {
@@ -193,7 +200,21 @@ impl PinnedDependency {
 
     /// Return the absolute path to the directory that this dependency would be fetched into.
     pub fn unfetched_path(&self, chain_id: &EnvironmentID) -> PathBuf {
-        self.dep_info.unfetched_path(chain_id)
+        match &self.dep_info {
+            Pinned::OnChain => {
+                let published_at = &self
+                    .context
+                    .addresses
+                    .as_ref()
+                    .expect("on-chain deps have addresses")
+                    .published_at;
+                PathBuf::from(move_command_line_common::env::MOVE_HOME.as_str())
+                    .join("on-chain")
+                    .join(chain_id)
+                    .join(published_at.to_string())
+            }
+            _ => self.dep_info.unfetched_path(chain_id),
+        }
     }
 }
 
@@ -209,7 +230,9 @@ impl Pinned {
         match &self {
             Pinned::Git(dep) => dep.inner.path_to_tree(),
             Pinned::Local(dep) => dep.absolute_path_to_package.clone(),
-            Pinned::OnChain(_dep) => todo!(),
+            Pinned::OnChain => {
+                unreachable!("on-chain deps need context; use PinnedDependency::unfetched_path")
+            }
             Pinned::Root(path) => path.path().to_path_buf(),
         }
     }
@@ -233,7 +256,7 @@ impl Pinned {
                     .clean(),
                 relative_path_from_root_package: loc.local.to_path_buf().clean(),
             })),
-            LockfileDependencyInfo::OnChain(chain) => Ok(Pinned::OnChain(chain.clone())),
+            LockfileDependencyInfo::OnChain(_) => Ok(Pinned::OnChain),
             LockfileDependencyInfo::Git(git) => Ok(Pinned::Git(git.clone().try_into()?)),
             LockfileDependencyInfo::Root(_) => Ok(Pinned::Root(PackagePath::new(
                 containing_file
@@ -257,7 +280,7 @@ impl Pinned {
                 let rev = fmt_truncated(git.inner.sha(), 6, 2);
                 format!(r#"git = "{repo}", path = "{path}", rev = "{rev}""#)
             }
-            Pinned::OnChain(_on_chain) => "on-chain = true".to_string(),
+            Pinned::OnChain => "on-chain = true".to_string(),
             Pinned::Root(_) => "local = \".\"".to_string(),
         }
     }
@@ -318,7 +341,7 @@ impl LocalDepInfo {
                 absolute_path_to_package: parent.unfetched_path(chain_id).join(&self.local).clean(),
                 relative_path_from_root_package: self.local.clean(),
             }),
-            Pinned::OnChain(_) => todo!(),
+            Pinned::OnChain => return Err(PackageError::OnChainLocalDep),
         };
 
         Ok(info)
@@ -342,7 +365,9 @@ impl From<Pinned> for LockfileDependencyInfo {
                 rev: git.inner.sha().clone(),
                 path: git.inner.path_in_repo().to_path_buf(),
             }),
-            Pinned::OnChain(on_chain) => Self::OnChain(on_chain),
+            Pinned::OnChain => Self::OnChain(OnChainDepInfo {
+                on_chain: ConstTrue,
+            }),
             Pinned::Root(_) => Self::Root(RootDepInfo { root: true }),
         }
     }

--- a/external-crates/move/crates/move-package-alt/src/dependency/pin.rs
+++ b/external-crates/move/crates/move-package-alt/src/dependency/pin.rs
@@ -16,7 +16,7 @@ use crate::{
     schema::{
         ConstTrue, EnvironmentID, EnvironmentName, EphemeralDependencyInfo, LocalDepInfo,
         LockfileDependencyInfo, LockfileGitDepInfo, ManifestGitDependency, ModeName,
-        OnChainDepInfo, PackageName, RenderToml, RootDepInfo,
+        OnChainDepInfo, PackageName, PublishAddresses, PublishedID, RenderToml, RootDepInfo,
     },
 };
 
@@ -48,12 +48,18 @@ pub struct PinnedDependency {
 pub(crate) enum Pinned {
     Local(PinnedLocalDependency),
     Git(PinnedGitDependency),
-    OnChain,
+    /// An on-chain dependency, identified by the address it is published at.
+    ///
+    /// Invariants:
+    /// - On-chain packages never have local transitive dependencies, since their manifests
+    ///   are system-generated.
+    OnChain {
+        published_at: PublishedID,
+    },
     Root(PackagePath),
 }
 
-/// Invariant: if a PinnedDependency has `dep_info` `Root`, then its `containing_file` is either a
-/// manifest or a lockfile in the directory containing the root package
+/// A git dependency pinned to a specific commit SHA.
 #[derive(Clone, Debug)]
 pub struct PinnedGitDependency {
     pub(crate) inner: GitTree,
@@ -93,15 +99,18 @@ impl PinnedDependency {
         // pinning - fix git shas and normalize local deps
         for dep in deps.into_iter() {
             let transformed = match dep.dep_info {
-                Resolved::Local(ref loc) => loc.clone().pin(parent, environment_id)?,
+                Resolved::Local(ref loc) => loc.clone().pin(parent)?,
                 Resolved::Git(ref git) => git.pin().await?,
                 Resolved::OnChain(_) => {
-                    if dep.context.addresses.is_none() {
-                        return Err(PackageError::OnChainDepMissingAddress {
+                    let addresses = dep.context.addresses.as_ref().ok_or_else(|| {
+                        PackageError::OnChainDepMissingAddress {
                             name: dep.context.name.to_string(),
-                        });
+                            env: environment_id.clone(),
+                        }
+                    })?;
+                    Pinned::OnChain {
+                        published_at: addresses.published_at.clone(),
                     }
-                    Pinned::OnChain
                 }
             };
 
@@ -152,7 +161,7 @@ impl PinnedDependency {
                 let file = dep.context.containing_file;
                 let pinned_dep = PinnedDependency {
                     context: dep.context,
-                    dep_info: Pinned::from_lockfile(file, lockfile_dep)
+                    dep_info: Pinned::from_lockfile(file, lockfile_dep, None)
                         .expect("system dependencies are valid pins"),
                 };
                 system_deps.push(pinned_dep);
@@ -199,22 +208,9 @@ impl PinnedDependency {
     }
 
     /// Return the absolute path to the directory that this dependency would be fetched into.
+    /// `chain_id` is used to determine the cache location for on-chain dependencies.
     pub fn unfetched_path(&self, chain_id: &EnvironmentID) -> PathBuf {
-        match &self.dep_info {
-            Pinned::OnChain => {
-                let published_at = &self
-                    .context
-                    .addresses
-                    .as_ref()
-                    .expect("on-chain deps have addresses")
-                    .published_at;
-                PathBuf::from(move_command_line_common::env::MOVE_HOME.as_str())
-                    .join("on-chain")
-                    .join(chain_id)
-                    .join(published_at.to_string())
-            }
-            _ => self.dep_info.unfetched_path(chain_id),
-        }
+        self.dep_info.unfetched_path(chain_id)
     }
 }
 
@@ -225,27 +221,32 @@ impl Pinned {
     }
 
     /// Return the absolute path to the directory that this package would be fetched into, without
-    /// actually fetching it. `_chain_id` is unused for now but will be needed for on-chain deps.
-    pub(crate) fn unfetched_path(&self, _chain_id: &EnvironmentID) -> PathBuf {
+    /// actually fetching it. `chain_id` is used to determine the cache location for on-chain
+    /// dependencies.
+    pub(crate) fn unfetched_path(&self, chain_id: &EnvironmentID) -> PathBuf {
         match &self {
             Pinned::Git(dep) => dep.inner.path_to_tree(),
             Pinned::Local(dep) => dep.absolute_path_to_package.clone(),
-            Pinned::OnChain => {
-                unreachable!("on-chain deps need context; use PinnedDependency::unfetched_path")
-            }
             Pinned::Root(path) => path.path().to_path_buf(),
+            Pinned::OnChain { published_at } => {
+                PathBuf::from(move_command_line_common::env::MOVE_HOME.as_str())
+                    .join("on-chain")
+                    .join(chain_id)
+                    .join(published_at.to_string())
+            }
         }
     }
 
-    /// Create a [Pinned] from a lockfile dependency info entry.
+    /// Create a [Pinned] from a lockfile dependency source and optional address override.
     ///
-    /// `containing_file` is the lockfile that the dependency comes from, used to resolve relative
-    /// paths.
+    /// `containing_file` is the lockfile path, used to resolve relative local dependency paths.
+    /// `address_override` provides the `published_at` address for on-chain dependencies.
     pub(crate) fn from_lockfile(
         containing_file: FileHandle,
-        pin: &LockfileDependencyInfo,
+        source: &LockfileDependencyInfo,
+        address_override: Option<&PublishAddresses>,
     ) -> PackageResult<Self> {
-        match &pin {
+        match source {
             LockfileDependencyInfo::Local(loc) => Ok(Pinned::Local(PinnedLocalDependency {
                 absolute_path_to_package: containing_file
                     .path()
@@ -256,7 +257,16 @@ impl Pinned {
                     .clean(),
                 relative_path_from_root_package: loc.local.to_path_buf().clean(),
             })),
-            LockfileDependencyInfo::OnChain(_) => Ok(Pinned::OnChain),
+            LockfileDependencyInfo::OnChain(_) => {
+                let published_at = address_override
+                    .ok_or_else(|| PackageError::OnChainDepMissingAddress {
+                        name: "(from lockfile)".to_string(),
+                        env: "(unknown)".to_string(),
+                    })?
+                    .published_at
+                    .clone();
+                Ok(Pinned::OnChain { published_at })
+            }
             LockfileDependencyInfo::Git(git) => Ok(Pinned::Git(git.clone().try_into()?)),
             LockfileDependencyInfo::Root(_) => Ok(Pinned::Root(PackagePath::new(
                 containing_file
@@ -280,7 +290,9 @@ impl Pinned {
                 let rev = fmt_truncated(git.inner.sha(), 6, 2);
                 format!(r#"git = "{repo}", path = "{path}", rev = "{rev}""#)
             }
-            Pinned::OnChain => "on-chain = true".to_string(),
+            Pinned::OnChain { published_at } => {
+                format!("on-chain = true, published-at = \"{published_at}\"")
+            }
             Pinned::Root(_) => "local = \".\"".to_string(),
         }
     }
@@ -321,27 +333,34 @@ impl TryFrom<LockfileGitDepInfo> for PinnedGitDependency {
 
 impl LocalDepInfo {
     /// Takes a local dependency and its `parent`, and transforms local dependencies based on their
-    /// parent. `chain_id` is passed through to [Pinned::unfetched_path].
+    /// parent.
     ///
     /// 1. If the parent is a git dependency, we convert local transitive deps to git.
     /// 2. If the parent is a local dependency, we normalize the path based on the parents.
-    fn pin(self, parent: &Pinned, chain_id: &EnvironmentID) -> PackageResult<Pinned> {
+    /// 3. The parent cannot be an on-chain dependency, because on-chain packages have
+    ///    system-generated manifests that never contain local deps.
+    fn pin(self, parent: &Pinned) -> PackageResult<Pinned> {
         let info: Pinned = match &parent {
             Pinned::Git(parent_git) => Pinned::Git(PinnedGitDependency {
                 inner: parent_git.inner.relative_tree(self.local)?,
             }),
             Pinned::Local(parent_local) => Pinned::Local(PinnedLocalDependency {
-                absolute_path_to_package: parent.unfetched_path(chain_id).join(&self.local).clean(),
+                absolute_path_to_package: parent_local
+                    .absolute_path_to_package
+                    .join(&self.local)
+                    .clean(),
                 relative_path_from_root_package: parent_local
                     .relative_path_from_root_package
                     .join(&self.local)
                     .clean(),
             }),
-            Pinned::Root(_) => Pinned::Local(PinnedLocalDependency {
-                absolute_path_to_package: parent.unfetched_path(chain_id).join(&self.local).clean(),
+            Pinned::Root(root) => Pinned::Local(PinnedLocalDependency {
+                absolute_path_to_package: root.path().join(&self.local).clean(),
                 relative_path_from_root_package: self.local.clean(),
             }),
-            Pinned::OnChain => return Err(PackageError::OnChainLocalDep),
+            Pinned::OnChain { .. } => {
+                unreachable!("on-chain packages have system-generated manifests with no local deps")
+            }
         };
 
         Ok(info)
@@ -365,7 +384,7 @@ impl From<Pinned> for LockfileDependencyInfo {
                 rev: git.inner.sha().clone(),
                 path: git.inner.path_in_repo().to_path_buf(),
             }),
-            Pinned::OnChain => Self::OnChain(OnChainDepInfo {
+            Pinned::OnChain { .. } => Self::OnChain(OnChainDepInfo {
                 on_chain: ConstTrue,
             }),
             Pinned::Root(_) => Self::Root(RootDepInfo { root: true }),
@@ -374,8 +393,12 @@ impl From<Pinned> for LockfileDependencyInfo {
 }
 
 impl Pinned {
-    /// Convert to an [EphemeralDependencyInfo]. For ephemeral dependencies, local dependencies
-    /// (including the root) are stored as absolute paths.
+    /// Convert to an [EphemeralDependencyInfo] for use as a key in ephemeral publication files.
+    /// The path is canonicalized so that ephemeral pubfiles can be reused across packages in
+    /// a single filesystem.
+    ///
+    /// Requires that the package source has already been fetched to disk (so the path can be
+    /// canonicalized).
     pub(crate) fn to_ephemeral(&self, chain_id: &EnvironmentID) -> EphemeralDependencyInfo {
         let local = self
             .unfetched_path(chain_id)
@@ -405,7 +428,6 @@ mod tests {
     use super::*;
 
     const RANDOM_SHA: &str = "1111111111111111111111111111111111111111"; // 40 characters
-    const TEST_CHAIN_ID: &str = "test-chain";
 
     // Local pinning ///////////////////////////////////////////////////////////////////////////////
 
@@ -417,10 +439,7 @@ mod tests {
         assert!(parent.is_root());
 
         let dep = new_local("../child");
-        let pinned = dep
-            .pin(&parent, &TEST_CHAIN_ID.to_string())
-            .unwrap_as_local()
-            .clone();
+        let pinned = dep.pin(&parent).unwrap_as_local().clone();
 
         assert_eq!(
             pinned.absolute_path_to_package.as_os_str(),
@@ -441,10 +460,7 @@ mod tests {
         let parent = new_pinned_local_from("/root", "parent");
 
         let dep = new_local("child");
-        let pinned = dep
-            .pin(&parent, &TEST_CHAIN_ID.to_string())
-            .unwrap_as_local()
-            .clone();
+        let pinned = dep.pin(&parent).unwrap_as_local().clone();
 
         assert_eq!(
             pinned.absolute_path_to_package.as_os_str(),
@@ -464,7 +480,7 @@ mod tests {
         let parent = new_pinned_git_from("repo.git", RANDOM_SHA, "parent");
         let dep = new_local("child");
 
-        let pinned = dep.pin(&parent, &TEST_CHAIN_ID.to_string()).unwrap_as_git();
+        let pinned = dep.pin(&parent).unwrap_as_git();
         let parent_git = parent.unwrap_as_git();
 
         assert_eq!(
@@ -494,7 +510,7 @@ mod tests {
         let parent = new_pinned_git_from("repo.git", RANDOM_SHA, "packages/foo");
         let dep = new_local("../bar");
 
-        let pinned = dep.pin(&parent, &TEST_CHAIN_ID.to_string()).unwrap_as_git();
+        let pinned = dep.pin(&parent).unwrap_as_git();
         let parent_git = parent.unwrap_as_git();
 
         assert_eq!(pinned.inner.repo_url(), parent_git.inner.repo_url());
@@ -511,7 +527,7 @@ mod tests {
         let dep = new_local("../../d");
 
         assert_snapshot!(
-            dep.pin(&parent, &TEST_CHAIN_ID.to_string()).unwrap_err().to_string(),
+            dep.pin(&parent).unwrap_err().to_string(),
             @"relative path `../d` is not contained in the repository"
         );
     }

--- a/external-crates/move/crates/move-package-alt/src/dependency/pin.rs
+++ b/external-crates/move/crates/move-package-alt/src/dependency/pin.rs
@@ -17,7 +17,8 @@ use crate::{
     schema::{
         EnvironmentID, EnvironmentName, EphemeralDependencyInfo, LocalDepInfo,
         LockfileDependencyInfo, LockfileGitDepInfo, ManifestGitDependency, ModeName,
-        OnChainDepInfo, PackageName, RenderToml, RootDepInfo,
+        OnChainDepInfo, OriginalID, PackageName, Pin, PublishAddresses, PublishedID, RenderToml,
+        RootDepInfo,
     },
 };
 
@@ -31,8 +32,31 @@ use super::{CombinedDependency, Dependency};
 pub enum Pinned {
     Local(PinnedLocalDependency),
     Git(PinnedGitDependency),
-    OnChain(OnChainDepInfo),
+    OnChain(PinnedOnChainDependency),
     Root(PackagePath),
+}
+
+/// A pinned on-chain dependency, identified by its chain ID and published address.
+/// The cache directory is `~/.move/on-chain/<chain_id>/<published_at>/`.
+#[derive(Clone, Debug)]
+pub struct PinnedOnChainDependency {
+    /// The chain identifier for the network this package is on.
+    pub chain_id: EnvironmentID,
+    /// The address the package is published at on-chain.
+    pub published_at: PublishedID,
+    /// The original publishing address (may differ from `published_at` after upgrades).
+    pub original_id: OriginalID,
+}
+
+impl PinnedOnChainDependency {
+    /// Return the cache directory path for this on-chain dependency:
+    /// `$MOVE_HOME/on-chain/<chain_id>/<published_at>/`
+    pub fn cache_path(&self) -> PathBuf {
+        PathBuf::from(move_command_line_common::env::MOVE_HOME.as_str())
+            .join("on-chain")
+            .join(&self.chain_id)
+            .join(self.published_at.to_string())
+    }
 }
 
 /// Invariant: if a PinnedDependencyInfo has `dep_info` `Root`, then its `containing_file` is either a
@@ -81,7 +105,18 @@ impl PinnedDependencyInfo {
             let transformed = match dep.0.dep_info {
                 Resolved::Local(ref loc) => loc.clone().pin(parent)?,
                 Resolved::Git(ref git) => git.pin().await?,
-                Resolved::OnChain(_) => todo!(),
+                Resolved::OnChain(_) => {
+                    let addresses = dep.0.addresses.as_ref().ok_or_else(|| {
+                        PackageError::OnChainDepMissingAddress {
+                            name: dep.0.name.to_string(),
+                        }
+                    })?;
+                    Pinned::OnChain(PinnedOnChainDependency {
+                        chain_id: environment_id.clone(),
+                        published_at: addresses.published_at.clone(),
+                        original_id: addresses.original_id.clone(),
+                    })
+                }
             };
 
             // TODO: can avoid clones above if we don't use `map` here
@@ -125,7 +160,7 @@ impl PinnedDependencyInfo {
                         })?;
                 let file = dep.0.containing_file;
                 let pinned_dep = PinnedDependencyInfo(dep.0.map(|_| {
-                    Pinned::from_lockfile(file, lockfile_dep)
+                    Pinned::from_lockfile_source(file, lockfile_dep)
                         .expect("system dependencies are valid pins")
                 }));
                 system_deps.push(pinned_dep);
@@ -183,26 +218,25 @@ impl Pinned {
         match &self {
             Pinned::Git(dep) => dep.inner.path_to_tree(),
             Pinned::Local(dep) => dep.absolute_path_to_package.clone(),
-            Pinned::OnChain(_dep) => todo!(),
+            Pinned::OnChain(dep) => dep.cache_path(),
             Pinned::Root(path) => path.path().to_path_buf(),
         }
     }
 
-    /// Create a pinned dependency from a pin in a lockfile. This involves attaching the context of
-    /// the file it is contained in (`containing_file`) and the environment it is defined in
-    /// (`env`).
+    /// Create a pinned dependency from a lockfile `pin` in environment `chain_id`.
+    /// `containing_file` is the lockfile path, used to resolve relative local dependency paths.
     ///
-    /// The returned dependency has the `override` field set, since we assume dependencies are
-    /// only pinned to the lockfile after the linkage checks have been performed.
+    /// For on-chain dependencies, uses `pin.address_override` to reconstruct the cache path.
     ///
     /// We do not set the `rename-from` field, since when we are creating the pinned dependency we
-    /// don't yet know what the rename-from field  should be. The caller is responsible for calling
+    /// don't yet know what the rename-from field should be. The caller is responsible for calling
     /// [Self::with_rename_from] if they need to establish the rename-from check invariant.
     pub fn from_lockfile(
         containing_file: FileHandle,
-        pin: &LockfileDependencyInfo,
+        pin: &Pin,
+        chain_id: &EnvironmentID,
     ) -> PackageResult<Self> {
-        match &pin {
+        match &pin.source {
             LockfileDependencyInfo::Local(loc) => Ok(Pinned::Local(PinnedLocalDependency {
                 absolute_path_to_package: containing_file
                     .path()
@@ -213,7 +247,51 @@ impl Pinned {
                     .clean(),
                 relative_path_from_root_package: loc.local.to_path_buf().clean(),
             })),
-            LockfileDependencyInfo::OnChain(chain) => Ok(Pinned::OnChain(chain.clone())),
+            LockfileDependencyInfo::OnChain(_) => {
+                let addresses =
+                    pin.address_override
+                        .as_ref()
+                        .ok_or_else(|| PackageError::OnChainDepMissingAddress {
+                            name: "unknown".to_string(),
+                        })?;
+                Ok(Pinned::OnChain(PinnedOnChainDependency {
+                    chain_id: chain_id.clone(),
+                    published_at: addresses.published_at.clone(),
+                    original_id: addresses.original_id.clone(),
+                }))
+            }
+            LockfileDependencyInfo::Git(git) => Ok(Pinned::Git(git.clone().try_into()?)),
+            LockfileDependencyInfo::Root(_) => Ok(Pinned::Root(PackagePath::new(
+                containing_file
+                    .as_ref()
+                    .parent()
+                    .expect("files have parents")
+                    .to_path_buf(),
+            )?)),
+        }
+    }
+
+    /// Create a pinned dependency from just a `LockfileDependencyInfo` source (without the full
+    /// [Pin] context). Only valid for non-on-chain dependencies (local, git, root).
+    /// Panics if called with an on-chain source.
+    fn from_lockfile_source(
+        containing_file: FileHandle,
+        source: &LockfileDependencyInfo,
+    ) -> PackageResult<Self> {
+        match source {
+            LockfileDependencyInfo::OnChain(_) => {
+                panic!("from_lockfile_source cannot be used for on-chain dependencies")
+            }
+            LockfileDependencyInfo::Local(loc) => Ok(Pinned::Local(PinnedLocalDependency {
+                absolute_path_to_package: containing_file
+                    .path()
+                    .parent()
+                    .expect("files have parents")
+                    .join(&loc.local)
+                    .to_path_buf()
+                    .clean(),
+                relative_path_from_root_package: loc.local.to_path_buf().clean(),
+            })),
             LockfileDependencyInfo::Git(git) => Ok(Pinned::Git(git.clone().try_into()?)),
             LockfileDependencyInfo::Root(_) => Ok(Pinned::Root(PackagePath::new(
                 containing_file
@@ -237,7 +315,9 @@ impl Pinned {
                 let rev = fmt_truncated(git.inner.sha(), 6, 2);
                 format!(r#"git = "{repo}", path = "{path}", rev = "{rev}""#)
             }
-            Pinned::OnChain(_on_chain) => "on-chain = true".to_string(),
+            Pinned::OnChain(dep) => {
+                format!("on-chain = true, published-at = \"{}\"", dep.published_at)
+            }
             Pinned::Root(_) => "local = \".\"".to_string(),
         }
     }
@@ -297,7 +377,7 @@ impl LocalDepInfo {
                 absolute_path_to_package: parent.unfetched_path().join(&self.local).clean(),
                 relative_path_from_root_package: self.local.clean(),
             }),
-            Pinned::OnChain(_) => todo!(),
+            Pinned::OnChain(_) => return Err(PackageError::OnChainLocalDep),
         };
 
         Ok(info)
@@ -321,7 +401,9 @@ impl From<Pinned> for LockfileDependencyInfo {
                 rev: git.inner.sha().clone(),
                 path: git.inner.path_in_repo().to_path_buf(),
             }),
-            Pinned::OnChain(on_chain) => Self::OnChain(on_chain),
+            Pinned::OnChain(_) => Self::OnChain(OnChainDepInfo {
+                on_chain: true.try_into().expect("true is ConstTrue"),
+            }),
             Pinned::Root(_) => Self::Root(RootDepInfo { root: true }),
         }
     }

--- a/external-crates/move/crates/move-package-alt/src/errors/mod.rs
+++ b/external-crates/move/crates/move-package-alt/src/errors/mod.rs
@@ -130,6 +130,15 @@ pub enum PackageError {
         "Packages with old-style Move.toml files cannot depend on new-style packages. See https://docs.sui.io/references/package-managers/package-manager-migration for instructions."
     )]
     LegacyDependsOnModern,
+
+    #[error(
+        "On-chain dependency `{name}` requires a `published-at` address. Add a \
+         `[dep-replacements.<env>.{name}]` entry with `published-at` and `original-id` fields."
+    )]
+    OnChainDepMissingAddress { name: String },
+
+    #[error("On-chain packages cannot have local transitive dependencies")]
+    OnChainLocalDep,
 }
 
 /// Truncate `s` to the first `head` characters and the last `tail` characters of `s`, separated by

--- a/external-crates/move/crates/move-package-alt/src/errors/mod.rs
+++ b/external-crates/move/crates/move-package-alt/src/errors/mod.rs
@@ -133,12 +133,9 @@ pub enum PackageError {
 
     #[error(
         "On-chain dependency `{name}` requires `published-at` and `original-id` addresses. Add a \
-         `[dep-replacements.<env>.{name}]` entry with these fields."
+         `[dep-replacements.{env}.{name}]` entry with these fields."
     )]
-    OnChainDepMissingAddress { name: String },
-
-    #[error("On-chain packages cannot have local transitive dependencies")]
-    OnChainLocalDep,
+    OnChainDepMissingAddress { name: String, env: String },
 }
 
 /// Truncate `s` to the first `head` characters and the last `tail` characters of `s`, separated by

--- a/external-crates/move/crates/move-package-alt/src/errors/mod.rs
+++ b/external-crates/move/crates/move-package-alt/src/errors/mod.rs
@@ -130,6 +130,15 @@ pub enum PackageError {
         "Packages with old-style Move.toml files cannot depend on new-style packages. See https://docs.sui.io/references/package-managers/package-manager-migration for instructions."
     )]
     LegacyDependsOnModern,
+
+    #[error(
+        "On-chain dependency `{name}` requires `published-at` and `original-id` addresses. Add a \
+         `[dep-replacements.<env>.{name}]` entry with these fields."
+    )]
+    OnChainDepMissingAddress { name: String },
+
+    #[error("On-chain packages cannot have local transitive dependencies")]
+    OnChainLocalDep,
 }
 
 /// Truncate `s` to the first `head` characters and the last `tail` characters of `s`, separated by

--- a/external-crates/move/crates/move-package-alt/src/graph/builder.rs
+++ b/external-crates/move/crates/move-package-alt/src/graph/builder.rs
@@ -116,7 +116,8 @@ impl<'a, F: MoveFlavor> PackageGraphBuilder<'a, F> {
 
         // First pass: create nodes for all packages
         for (pkg_id, pin) in pins.iter() {
-            let dep = Pinned::from_lockfile(lockfile.file(), &pin.source)?;
+            let dep =
+                Pinned::from_lockfile(lockfile.file(), &pin.source, pin.address_override.as_ref())?;
             let package = self.cache.fetch(&dep, env, mtx, self.config).await?;
             let package_manifest_digest = package.digest();
             if check_digests && package_manifest_digest != &pin.manifest_digest {

--- a/external-crates/move/crates/move-package-alt/src/graph/builder.rs
+++ b/external-crates/move/crates/move-package-alt/src/graph/builder.rs
@@ -118,7 +118,7 @@ impl<'a, F: MoveFlavor> PackageGraphBuilder<'a, F> {
 
         // First pass: create nodes for all packages
         for (pkg_id, pin) in pins.iter() {
-            let dep = Pinned::from_lockfile(lockfile.file(), &pin.source)?;
+            let dep = Pinned::from_lockfile(lockfile.file(), pin, env.id())?;
             let package = self
                 .cache
                 .fetch(&dep, env, mtx, self.config, self.flavor)

--- a/external-crates/move/crates/move-package-alt/src/graph/mod.rs
+++ b/external-crates/move/crates/move-package-alt/src/graph/mod.rs
@@ -19,10 +19,9 @@ use tracing::debug;
 
 use std::{collections::BTreeMap, sync::Arc};
 
-use crate::package::EnvironmentID;
 use crate::package::package_loader::PackageConfig;
 use crate::package::package_lock::PackageSystemLock;
-use crate::schema::{EphemeralDependencyInfo, ModeName, Publication};
+use crate::schema::{EnvironmentID, EphemeralDependencyInfo, ModeName, Publication};
 use crate::{
     dependency::PinnedDependency,
     errors::PackageResult,
@@ -215,6 +214,7 @@ mod tests {
 
     use crate::Vanilla;
     use crate::flavor::vanilla::DEFAULT_ENV_ID;
+
     use test_log::test;
 
     use crate::{

--- a/external-crates/move/crates/move-package-alt/src/graph/mod.rs
+++ b/external-crates/move/crates/move-package-alt/src/graph/mod.rs
@@ -214,6 +214,7 @@ impl<F: MoveFlavor> PackageGraph<F> {
 mod tests {
     use std::collections::BTreeMap;
 
+    use crate::Vanilla;
     use test_log::test;
 
     use crate::{
@@ -376,7 +377,7 @@ mod tests {
             PublishedID::from(4),
         )]);
 
-        graph.make_ephemeral(overrides);
+        graph.make_ephemeral(overrides, &Vanilla);
         assert_eq!(
             graph
                 .get_package(&"a".to_string())
@@ -417,7 +418,7 @@ mod tests {
             PublishedID::from(4),
         )]);
 
-        graph.make_ephemeral(overrides);
+        graph.make_ephemeral(overrides, &Vanilla);
         assert_eq!(
             graph
                 .get_package(&"a".to_string())
@@ -460,7 +461,7 @@ mod tests {
             PublishedID::from(4),
         )]);
 
-        graph.make_ephemeral(overrides);
+        graph.make_ephemeral(overrides, &Vanilla);
         assert_eq!(
             graph
                 .get_package(&"a".to_string())
@@ -498,7 +499,7 @@ mod tests {
 
         let overrides = BTreeMap::new();
 
-        graph.make_ephemeral(overrides);
+        graph.make_ephemeral(overrides, &Vanilla);
         assert!(graph.get_package(&"a".to_string()).published().is_none());
     }
 
@@ -520,7 +521,7 @@ mod tests {
 
         let overrides = BTreeMap::new();
 
-        graph.make_ephemeral(overrides);
+        graph.make_ephemeral(overrides, &Vanilla);
         assert!(graph.get_package(&"a".to_string()).published().is_none());
     }
 
@@ -544,7 +545,7 @@ mod tests {
 
         let overrides = BTreeMap::new();
 
-        graph.make_ephemeral(overrides);
+        graph.make_ephemeral(overrides, &Vanilla);
         assert_eq!(
             graph
                 .get_package(&"a".to_string())

--- a/external-crates/move/crates/move-package-alt/src/package/package_impl.rs
+++ b/external-crates/move/crates/move-package-alt/src/package/package_impl.rs
@@ -140,10 +140,7 @@ impl<F: MoveFlavor> Package<F> {
             dummy_addr,
         };
 
-        debug!(
-            "successfully loaded {:?}",
-            result.dep_for_self.unfetched_path(&config.chain_id)
-        );
+        debug!("successfully loaded {}", result.dep_for_self);
         Ok(result)
     }
 

--- a/external-crates/move/crates/move-package-alt/src/package/package_impl.rs
+++ b/external-crates/move/crates/move-package-alt/src/package/package_impl.rs
@@ -613,7 +613,7 @@ mod tests {
         let env = default_environment();
         let dep = &ManifestDependencyInfo::Local(LocalDepInfo { local: path });
 
-        let info = cache_package::<Vanilla>(&env, dep).await.unwrap();
+        let info = cache_package::<Vanilla>(&env, dep, &Vanilla).await.unwrap();
 
         let CachedPackageInfo {
             name,


### PR DESCRIPTION
## Summary

- `Pinned::OnChain` carries `published_at: PublishedID` — this is the source locator for on-chain deps, analogous to git SHA for git deps
- Fill in on-chain pinning: verify addresses present during pinning, construct `Pinned::OnChain { published_at }`
- `unfetched_path` works naturally for all `Pinned` variants including `OnChain` (cache path: `~/.move/on-chain/<chain_id>/<published_at>/`)
- `from_lockfile` takes `(&LockfileDependencyInfo, Option<&PublishAddresses>)` to extract `published_at` for on-chain deps
- Return `FetchError::OnChainNotSupported` when fetching on-chain deps (not yet implemented)
- `OnChainDepMissingAddress` error includes the environment name
- Add `design/dvx-2115-address-identity.md` documenting the relationship between source identity, compiled identity, and address identity (DVX-2115)

## Test plan

- [x] All existing tests pass
- [x] Clippy and rustfmt clean
- [ ] End-to-end test with on-chain dep (blocked on fetch implementation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## PR Stack
1. ~~#26232 — RPC endpoint for SuiFlavor (DVX-1814)~~ ✅ merged
2. ~~#26065 — Separate node/edge concepts for pinned dependencies~~ ✅ merged
3. **#26233 — On-chain dependency pinning** ← this PR
4. #26234 — Stub generation from bytecode