### PR TITLE
[move-vm] Added additional unreachable reference tests

### DIFF
--- a/external-crates/move/crates/move-vm-transactional-tests/tests/references/store_loc_with_unreachable_ref.mvir
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/references/store_loc_with_unreachable_ref.mvir
@@ -1,0 +1,20 @@
+// StLoc with an unreachable reference to the local due to control flow.
+
+//# run
+module 0x42.m {
+
+entry foo() {
+    let x: u64;
+    let r: &u64;
+label b0:
+    x = 42;
+    jump_if_false (true) b_join;
+label b_ref:
+    r = &x;
+label b_join:
+    x = 100;
+    assert(move(x) == 100, 1);
+    return;
+}
+
+}

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/references/store_loc_with_unreachable_ref.snap
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/references/store_loc_with_unreachable_ref.snap
@@ -1,0 +1,4 @@
+---
+source: crates/move-transactional-test-runner/src/framework.rs
+---
+processed 1 task

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/references/unpack_enum_with_unreachable_ref.mvir
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/references/unpack_enum_with_unreachable_ref.mvir
@@ -1,0 +1,27 @@
+// Enum variant unpack with an unreachable field reference due to control flow.
+
+//# run
+module 0x42.m {
+
+enum Wrapper has drop {
+    Val { x: u64 },
+}
+
+entry foo() {
+    let e: Self.Wrapper;
+    let e_ref: &Self.Wrapper;
+    let x_ref: &u64;
+    let val: u64;
+label b0:
+    e = Wrapper.Val { x: 42 };
+    jump_if_false (true) b_join;
+label b_ref:
+    e_ref = &e;
+    & Wrapper.Val { x: x_ref } = copy(e_ref);
+label b_join:
+    Wrapper.Val { x: val } = move(e);
+    assert(move(val) == 42, 1);
+    return;
+}
+
+}

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/references/unpack_enum_with_unreachable_ref.snap
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/references/unpack_enum_with_unreachable_ref.snap
@@ -1,0 +1,4 @@
+---
+source: crates/move-transactional-test-runner/src/framework.rs
+---
+processed 1 task

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/references/unpack_struct_with_unreachable_ref.mvir
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/references/unpack_struct_with_unreachable_ref.mvir
@@ -1,0 +1,25 @@
+// Struct unpack with an unreachable field reference due to control flow.
+
+//# run
+module 0x42.m {
+
+struct S has drop { f: u64 }
+
+entry foo() {
+    let s: Self.S;
+    let sr: &Self.S;
+    let fr: &u64;
+    let val: u64;
+label b0:
+    s = S { f: 42 };
+    jump_if_false (true) b_join;
+label b_ref:
+    sr = &s;
+    fr = &copy(sr).S::f;
+label b_join:
+    S { f: val } = move(s);
+    assert(move(val) == 42, 1);
+    return;
+}
+
+}

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/references/unpack_struct_with_unreachable_ref.snap
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/references/unpack_struct_with_unreachable_ref.snap
@@ -1,0 +1,4 @@
+---
+source: crates/move-transactional-test-runner/src/framework.rs
+---
+processed 1 task

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/references/unpack_vec_with_unreachable_ref.mvir
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/references/unpack_vec_with_unreachable_ref.mvir
@@ -1,0 +1,25 @@
+// Vector unpack with an unreachable element reference due to control flow.
+
+//# run
+module 0x42.m {
+
+struct S has copy, drop { f: u64 }
+
+entry foo() {
+    let s: Self.S;
+    let v: vector<Self.S>;
+    let er: &Self.S;
+    let unpacked: Self.S;
+label b0:
+    s = S { f: 0 };
+    v = vec_pack_1<Self.S>(copy(s));
+    jump_if_false (true) b_join;
+label b_ref:
+    er = vec_imm_borrow<Self.S>(&v, 0);
+label b_join:
+    unpacked = vec_unpack_1<Self.S>(move(v));
+    assert(move(unpacked) == copy(s), 1);
+    return;
+}
+
+}

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/references/unpack_vec_with_unreachable_ref.snap
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/references/unpack_vec_with_unreachable_ref.snap
@@ -1,0 +1,4 @@
+---
+source: crates/move-transactional-test-runner/src/framework.rs
+---
+processed 1 task

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/references/vec_pop_back_with_unreachable_ref.mvir
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/references/vec_pop_back_with_unreachable_ref.mvir
@@ -1,0 +1,26 @@
+// Vector pop_back with an unreachable element reference due to control flow.
+
+//# run
+module 0x42.m {
+import 0x1.vector;
+
+struct S has copy, drop { f: u64 }
+
+entry foo() {
+    let s: Self.S;
+    let v: vector<Self.S>;
+    let er: &Self.S;
+    let popped: Self.S;
+label b0:
+    s = S { f: 0 };
+    v = vec_pack_1<Self.S>(copy(s));
+    jump_if_false (true) b_join;
+label b_ref:
+    er = vec_imm_borrow<Self.S>(&v, 0);
+label b_join:
+    popped = vector.pop_back<Self.S>(&mut v);
+    assert(move(popped) == copy(s), 1);
+    return;
+}
+
+}

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/references/vec_pop_back_with_unreachable_ref.snap
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/references/vec_pop_back_with_unreachable_ref.snap
@@ -1,0 +1,4 @@
+---
+source: crates/move-transactional-test-runner/src/framework.rs
+---
+processed 1 task

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/references/write_ref_with_unreachable_ref.mvir
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/references/write_ref_with_unreachable_ref.mvir
@@ -1,0 +1,22 @@
+// WriteRef with an unreachable frozen reference due to control flow.
+
+//# run
+module 0x42.m {
+
+entry foo() {
+    let x: u64;
+    let r: &u64;
+    let w: &mut u64;
+label b0:
+    x = 42;
+    w = &mut x;
+    jump_if_false (true) b_join;
+label b_ref:
+    r = freeze(copy(w));
+label b_join:
+    *move(w) = 100;
+    assert(move(x) == 100, 1);
+    return;
+}
+
+}

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/references/write_ref_with_unreachable_ref.snap
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/references/write_ref_with_unreachable_ref.snap
@@ -1,0 +1,4 @@
+---
+source: crates/move-transactional-test-runner/src/framework.rs
+---
+processed 1 task


### PR DESCRIPTION
## Description 

- Added additional tests where there are unreachable references while performing operations that require "uniqueness" of the reference/value 

## Test plan 

- Printed and verified the Rc count was > 1 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
