### PR TITLE
[indexer-alt-reader] Extract kv args to be shared by graphql and other readers

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/src/lib.rs
+++ b/crates/sui-indexer-alt-e2e-tests/src/lib.rs
@@ -431,6 +431,7 @@ impl OffchainCluster {
             kv_args.clone(),
             consistent_reader_args.clone(),
             jsonrpc_args,
+            JsonRpcNodeArgs::default(),
             SystemPackageTaskArgs::default(),
             jsonrpc_config,
             registry,

--- a/crates/sui-indexer-alt-e2e-tests/src/lib.rs
+++ b/crates/sui-indexer-alt-e2e-tests/src/lib.rs
@@ -36,7 +36,6 @@ use sui_indexer_alt_framework::ingestion::ingestion_client::IngestionClientArgs;
 use sui_indexer_alt_framework::pipeline::CommitterConfig;
 use sui_indexer_alt_framework::postgres::schema::watermarks;
 use sui_indexer_alt_graphql::RpcArgs as GraphQlArgs;
-use sui_indexer_alt_graphql::args::KvArgs as GraphQlKvArgs;
 use sui_indexer_alt_graphql::args::SubscriptionArgs;
 use sui_indexer_alt_graphql::config::RpcConfig as GraphQlConfig;
 use sui_indexer_alt_graphql::start_rpc as start_graphql;
@@ -44,9 +43,9 @@ use sui_indexer_alt_jsonrpc::NodeArgs as JsonRpcNodeArgs;
 use sui_indexer_alt_jsonrpc::RpcArgs as JsonRpcArgs;
 use sui_indexer_alt_jsonrpc::config::RpcConfig as JsonRpcConfig;
 use sui_indexer_alt_jsonrpc::start_rpc as start_jsonrpc;
-use sui_indexer_alt_reader::bigtable_reader::BigtableArgs;
 use sui_indexer_alt_reader::consistent_reader::ConsistentReaderArgs;
 use sui_indexer_alt_reader::fullnode_client::FullnodeArgs;
+use sui_indexer_alt_reader::kv_loader::KvArgs;
 use sui_indexer_alt_reader::system_package_task::SystemPackageTaskArgs;
 use sui_kv_rpc::KvRpcServer;
 use sui_kvstore::BigTableClient;
@@ -417,7 +416,7 @@ impl OffchainCluster {
         let (bigtable_client, bigtable_emulator, archival_service) =
             start_archival(client_args.clone(), kv_rpc_address, registry).await?;
 
-        let graphql_kv_args = GraphQlKvArgs {
+        let kv_args = KvArgs {
             ledger_grpc_url: Some(
                 format!("http://{kv_rpc_address}")
                     .parse()
@@ -428,12 +427,10 @@ impl OffchainCluster {
 
         let jsonrpc = start_jsonrpc(
             Some(database_url.clone()),
-            None,
             DbArgs::default(),
-            BigtableArgs::default(),
+            kv_args.clone(),
             consistent_reader_args.clone(),
             jsonrpc_args,
-            JsonRpcNodeArgs::default(),
             SystemPackageTaskArgs::default(),
             jsonrpc_config,
             registry,
@@ -445,7 +442,7 @@ impl OffchainCluster {
             Some(database_url.clone()),
             fullnode_args,
             DbArgs::default(),
-            graphql_kv_args,
+            kv_args,
             consistent_reader_args,
             graphql_args,
             SystemPackageTaskArgs::default(),

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_execute_transaction_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_execute_transaction_tests.rs
@@ -14,12 +14,12 @@ use serde_json::Value;
 use serde_json::json;
 use sui_futures::service::Service;
 use sui_indexer_alt_graphql::RpcArgs as GraphQlArgs;
-use sui_indexer_alt_graphql::args::KvArgs as GraphQlKvArgs;
 use sui_indexer_alt_graphql::args::SubscriptionArgs;
 use sui_indexer_alt_graphql::config::RpcConfig as GraphQlConfig;
 use sui_indexer_alt_graphql::start_rpc as start_graphql;
 use sui_indexer_alt_reader::consistent_reader::ConsistentReaderArgs;
 use sui_indexer_alt_reader::fullnode_client::FullnodeArgs;
+use sui_indexer_alt_reader::kv_loader::KvArgs;
 use sui_indexer_alt_reader::system_package_task::SystemPackageTaskArgs;
 use sui_macros::sim_test;
 use sui_pg_db::DbArgs;
@@ -132,7 +132,7 @@ impl GraphQlTestCluster {
             None, // No database - GraphQL will use fullnode RPC for executeTransaction
             fullnode_args,
             DbArgs::default(),
-            GraphQlKvArgs::default(),
+            KvArgs::default(),
             ConsistentReaderArgs::default(),
             graphql_args,
             SystemPackageTaskArgs::default(),

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_simulate_transaction_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_simulate_transaction_tests.rs
@@ -21,12 +21,12 @@ use sui_indexer_alt_framework::IndexerArgs;
 use sui_indexer_alt_framework::ingestion::ClientArgs;
 use sui_indexer_alt_framework::ingestion::ingestion_client::IngestionClientArgs;
 use sui_indexer_alt_graphql::RpcArgs as GraphQlArgs;
-use sui_indexer_alt_graphql::args::KvArgs as GraphQlKvArgs;
 use sui_indexer_alt_graphql::args::SubscriptionArgs;
 use sui_indexer_alt_graphql::config::RpcConfig as GraphQlConfig;
 use sui_indexer_alt_graphql::start_rpc as start_graphql;
 use sui_indexer_alt_reader::consistent_reader::ConsistentReaderArgs;
 use sui_indexer_alt_reader::fullnode_client::FullnodeArgs;
+use sui_indexer_alt_reader::kv_loader::KvArgs;
 use sui_indexer_alt_reader::system_package_task::SystemPackageTaskArgs;
 use sui_pg_db::DbArgs;
 use sui_pg_db::temp::TempDb;
@@ -192,7 +192,7 @@ impl GraphQlTestCluster {
             Some(database_url),
             fullnode_args,
             DbArgs::default(),
-            GraphQlKvArgs::default(),
+            KvArgs::default(),
             ConsistentReaderArgs::default(),
             GraphQlArgs {
                 rpc_listen_address: graphql_listen_address,

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/testing/harness.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/testing/harness.rs
@@ -15,12 +15,12 @@ use serde_json::Value;
 use serde_json::json;
 use sui_futures::service::Service;
 use sui_indexer_alt_graphql::RpcArgs as GraphQlArgs;
-use sui_indexer_alt_graphql::args::KvArgs as GraphQlKvArgs;
 use sui_indexer_alt_graphql::args::SubscriptionArgs;
 use sui_indexer_alt_graphql::config::RpcConfig as GraphQlConfig;
 use sui_indexer_alt_graphql::start_rpc as start_graphql;
 use sui_indexer_alt_reader::consistent_reader::ConsistentReaderArgs;
 use sui_indexer_alt_reader::fullnode_client::FullnodeArgs;
+use sui_indexer_alt_reader::kv_loader::KvArgs;
 use sui_indexer_alt_reader::system_package_task::SystemPackageTaskArgs;
 use sui_pg_db::DbArgs;
 use sui_pg_db::temp::get_available_port;
@@ -50,7 +50,7 @@ impl SubscriptionTestCluster {
                 fullnode_rpc_url: Some(rpc_url.parse().unwrap()),
             },
             DbArgs::default(),
-            GraphQlKvArgs::default(),
+            KvArgs::default(),
             ConsistentReaderArgs::default(),
             GraphQlArgs {
                 rpc_listen_address: graphql_listen_address,

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc_fn_delegation_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc_fn_delegation_tests.rs
@@ -16,8 +16,8 @@ use sui_indexer_alt_jsonrpc::RpcArgs;
 use sui_indexer_alt_jsonrpc::args::SystemPackageTaskArgs;
 use sui_indexer_alt_jsonrpc::config::RpcConfig;
 use sui_indexer_alt_jsonrpc::start_rpc;
-use sui_indexer_alt_reader::bigtable_reader::BigtableArgs;
 use sui_indexer_alt_reader::consistent_reader::ConsistentReaderArgs;
+use sui_indexer_alt_reader::kv_loader::KvArgs;
 use sui_macros::sim_test;
 use sui_pg_db::DbArgs;
 use sui_pg_db::temp::get_available_port;
@@ -72,9 +72,8 @@ impl FnDelegationTestCluster {
 
         let service = start_rpc(
             None,
-            None,
             DbArgs::default(),
-            BigtableArgs::default(),
+            KvArgs::default(),
             ConsistentReaderArgs::default(),
             rpc_args,
             NodeArgs {

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc_write_api_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc_write_api_tests.rs
@@ -21,7 +21,6 @@ use sui_indexer_alt_jsonrpc::RpcArgs;
 use sui_indexer_alt_jsonrpc::args::SystemPackageTaskArgs;
 use sui_indexer_alt_jsonrpc::config::RpcConfig;
 use sui_indexer_alt_jsonrpc::start_rpc;
-use sui_indexer_alt_reader::bigtable_reader::BigtableArgs;
 use sui_indexer_alt_reader::consistent_reader::ConsistentReaderArgs;
 use sui_indexer_alt_reader::kv_loader::KvArgs;
 use sui_pg_db::DbArgs;

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc_write_api_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc_write_api_tests.rs
@@ -23,6 +23,7 @@ use sui_indexer_alt_jsonrpc::config::RpcConfig;
 use sui_indexer_alt_jsonrpc::start_rpc;
 use sui_indexer_alt_reader::bigtable_reader::BigtableArgs;
 use sui_indexer_alt_reader::consistent_reader::ConsistentReaderArgs;
+use sui_indexer_alt_reader::kv_loader::KvArgs;
 use sui_pg_db::DbArgs;
 use sui_pg_db::temp::TempDb;
 use sui_pg_db::temp::get_available_port;
@@ -92,9 +93,8 @@ impl WriteTestCluster {
 
         let rpc_service = start_rpc(
             Some(database_url),
-            None,
             DbArgs::default(),
-            BigtableArgs::default(),
+            KvArgs::default(),
             ConsistentReaderArgs::default(),
             RpcArgs {
                 rpc_listen_address,

--- a/crates/sui-indexer-alt-graphql/src/args.rs
+++ b/crates/sui-indexer-alt-graphql/src/args.rs
@@ -4,69 +4,15 @@
 use std::path::PathBuf;
 
 use sui_indexer_alt_metrics::MetricsArgs;
-use sui_indexer_alt_reader::bigtable_reader::BigtableArgs;
 use sui_indexer_alt_reader::consistent_reader::ConsistentReaderArgs;
 use sui_indexer_alt_reader::fullnode_client::FullnodeArgs;
-use sui_indexer_alt_reader::ledger_grpc_reader::LedgerGrpcArgs;
+use sui_indexer_alt_reader::kv_loader::KvArgs;
 use sui_indexer_alt_reader::pg_reader::db::DbArgs;
 use sui_indexer_alt_reader::system_package_task::SystemPackageTaskArgs;
 use tonic::transport::Uri;
 use url::Url;
 
 use crate::RpcArgs;
-
-/// Arguments for configuring KV store access (either Bigtable or Ledger gRPC).
-///
-/// These options are mutually exclusive - only one KV store source can be configured at a time.
-#[derive(clap::Args, Debug, Clone, Default)]
-#[group(required = false)]
-pub struct KvArgs {
-    /// Bigtable instance ID to make KV store requests to.
-    #[arg(long, group = "kv_source")]
-    pub bigtable_instance: Option<String>,
-
-    /// GCP project ID for the BigTable instance (defaults to the token provider's project).
-    #[arg(long)]
-    pub bigtable_project: Option<String>,
-
-    /// App profile ID to use for Bigtable client. If not provided, the default profile will be used.
-    #[arg(long)]
-    pub bigtable_app_profile_id: Option<String>,
-
-    /// Maximum gRPC decoding message size for KV responses, in bytes.
-    ///
-    /// Applies to both Bigtable and Ledger gRPC readers.
-    #[arg(long)]
-    pub kv_max_decoding_message_size: Option<usize>,
-
-    /// gRPC endpoint URL for the ledger service (e.g., archive.mainnet.sui.io)
-    #[arg(long, group = "kv_source")]
-    pub ledger_grpc_url: Option<Uri>,
-
-    /// Time spent waiting for a request to the kv store to complete, in milliseconds.
-    #[arg(long)]
-    pub kv_statement_timeout_ms: Option<u64>,
-}
-
-impl KvArgs {
-    /// Extract BigtableArgs from KvArgs
-    pub fn bigtable_args(&self) -> BigtableArgs {
-        BigtableArgs {
-            bigtable_statement_timeout_ms: self.kv_statement_timeout_ms,
-            bigtable_project: self.bigtable_project.clone(),
-            bigtable_app_profile_id: self.bigtable_app_profile_id.clone(),
-            bigtable_max_decoding_message_size: self.kv_max_decoding_message_size,
-        }
-    }
-
-    /// Extract LedgerGrpcArgs from KvArgs
-    pub fn ledger_grpc_args(&self) -> LedgerGrpcArgs {
-        LedgerGrpcArgs {
-            ledger_grpc_statement_timeout_ms: self.kv_statement_timeout_ms,
-            ledger_grpc_max_decoding_message_size: self.kv_max_decoding_message_size,
-        }
-    }
-}
 
 /// Arguments for configuring GraphQL streaming subscriptions.
 #[derive(clap::Args, Debug, Clone, Default)]

--- a/crates/sui-indexer-alt-graphql/src/lib.rs
+++ b/crates/sui-indexer-alt-graphql/src/lib.rs
@@ -47,6 +47,7 @@ use sui_indexer_alt_reader::consistent_reader::ConsistentReader;
 use sui_indexer_alt_reader::consistent_reader::ConsistentReaderArgs;
 use sui_indexer_alt_reader::fullnode_client::FullnodeArgs;
 use sui_indexer_alt_reader::fullnode_client::FullnodeClient;
+use sui_indexer_alt_reader::kv_loader::KvArgs;
 use sui_indexer_alt_reader::kv_loader::KvLoader;
 use sui_indexer_alt_reader::ledger_grpc_reader::LedgerGrpcReader;
 use sui_indexer_alt_reader::package_resolver::DbPackageStore;
@@ -302,7 +303,7 @@ pub async fn start_rpc(
     database_url: Option<Url>,
     fullnode_args: FullnodeArgs,
     db_args: DbArgs,
-    kv_args: args::KvArgs,
+    kv_args: KvArgs,
     consistent_reader_args: ConsistentReaderArgs,
     args: RpcArgs,
     system_package_task_args: SystemPackageTaskArgs,

--- a/crates/sui-indexer-alt-graphql/src/lib.rs
+++ b/crates/sui-indexer-alt-graphql/src/lib.rs
@@ -42,14 +42,12 @@ use headers::ContentLength;
 use health::DbProbe;
 use prometheus::Registry;
 use sui_futures::service::Service;
-use sui_indexer_alt_reader::bigtable_reader::BigtableReader;
 use sui_indexer_alt_reader::consistent_reader::ConsistentReader;
 use sui_indexer_alt_reader::consistent_reader::ConsistentReaderArgs;
 use sui_indexer_alt_reader::fullnode_client::FullnodeArgs;
 use sui_indexer_alt_reader::fullnode_client::FullnodeClient;
 use sui_indexer_alt_reader::kv_loader::KvArgs;
 use sui_indexer_alt_reader::kv_loader::KvLoader;
-use sui_indexer_alt_reader::ledger_grpc_reader::LedgerGrpcReader;
 use sui_indexer_alt_reader::package_resolver::DbPackageStore;
 use sui_indexer_alt_reader::package_resolver::PackageCache;
 use sui_indexer_alt_reader::pg_reader::PgReader;
@@ -320,48 +318,27 @@ pub async fn start_rpc(
     let fullnode_client =
         FullnodeClient::new(Some("graphql_fullnode"), fullnode_args, registry).await?;
 
-    let pg_reader =
-        PgReader::new(Some("graphql_db"), database_url.clone(), db_args, registry).await?;
-
-    let bigtable_reader = if let Some(instance_id) = kv_args.bigtable_instance.as_ref() {
-        let reader = BigtableReader::new(
-            instance_id.clone(),
-            "indexer-alt-graphql".to_owned(),
-            kv_args.bigtable_args(),
-            registry,
-        )
-        .await?;
-
-        Some(reader)
-    } else {
-        None
-    };
-
-    let ledger_grpc_reader = if let Some(ledger_grpc_url) = kv_args.ledger_grpc_url.as_ref() {
-        let reader = LedgerGrpcReader::new(
-            ledger_grpc_url.clone(),
-            kv_args.ledger_grpc_args(),
-            Some("graphql_ledger_grpc"),
-            registry,
-        )
-        .await
-        .context("Failed to create Ledger gRPC reader")?;
-        Some(reader)
-    } else {
-        None
-    };
-
     let consistent_reader =
         ConsistentReader::new(Some("graphql_consistent"), consistent_reader_args, registry).await?;
 
+    let bigtable_reader = kv_args
+        .bigtable_reader("indexer-alt-graphql".to_owned(), registry)
+        .await?;
+
+    let ledger_grpc_reader = kv_args
+        .ledger_grpc_reader(Some("graphql_ledger_grpc"), registry)
+        .await?;
+
+    let pg_reader =
+        PgReader::new(Some("graphql_db"), database_url.clone(), db_args, registry).await?;
+
     let pg_loader = Arc::new(pg_reader.as_data_loader());
-    let kv_loader = if let Some(reader) = bigtable_reader.as_ref() {
-        KvLoader::new_with_bigtable(Arc::new(reader.as_data_loader()))
-    } else if let Some(reader) = ledger_grpc_reader.as_ref() {
-        KvLoader::new_with_ledger_grpc(Arc::new(reader.as_data_loader()))
-    } else {
-        KvLoader::new_with_pg(pg_loader.clone())
-    };
+
+    let kv_loader = KvLoader::from_kv_sources(
+        bigtable_reader.clone(),
+        ledger_grpc_reader.clone(),
+        pg_loader.clone(),
+    );
 
     let package_store = Arc::new(PackageCache::new(DbPackageStore::new(pg_loader.clone())));
 

--- a/crates/sui-indexer-alt-jsonrpc/src/args.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/args.rs
@@ -4,8 +4,8 @@
 use std::path::PathBuf;
 
 use sui_indexer_alt_metrics::MetricsArgs;
-use sui_indexer_alt_reader::bigtable_reader::BigtableArgs;
 use sui_indexer_alt_reader::consistent_reader::ConsistentReaderArgs;
+use sui_indexer_alt_reader::kv_loader::KvArgs;
 use sui_indexer_alt_reader::pg_reader::db::DbArgs;
 use url::Url;
 
@@ -32,16 +32,11 @@ pub enum Command {
         )]
         database_url: Url,
 
-        /// Bigtable instance ID to make KV store requests to. If this is not provided, KV store
-        /// requests will be made to the database.
-        #[clap(long)]
-        bigtable_instance: Option<String>,
-
         #[command(flatten)]
         db_args: DbArgs,
 
         #[command(flatten)]
-        bigtable_args: BigtableArgs,
+        kv_args: KvArgs,
 
         #[command(flatten)]
         consistent_reader_args: ConsistentReaderArgs,

--- a/crates/sui-indexer-alt-jsonrpc/src/context.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/context.rs
@@ -7,12 +7,10 @@ use anyhow::Context as _;
 use async_graphql::dataloader::DataLoader;
 use diesel::QueryDsl;
 use prometheus::Registry;
-use sui_indexer_alt_reader::bigtable_reader::BigtableReader;
 use sui_indexer_alt_reader::consistent_reader::ConsistentReader;
 use sui_indexer_alt_reader::consistent_reader::ConsistentReaderArgs;
 use sui_indexer_alt_reader::kv_loader::KvArgs;
 use sui_indexer_alt_reader::kv_loader::KvLoader;
-use sui_indexer_alt_reader::ledger_grpc_reader::LedgerGrpcReader;
 use sui_indexer_alt_reader::package_resolver::DbPackageStore;
 use sui_indexer_alt_reader::package_resolver::PackageCache;
 use sui_indexer_alt_reader::pg_reader::PgReader;
@@ -81,30 +79,15 @@ impl Context {
         let pg_reader = PgReader::new(None, database_url, db_args, registry).await?;
         let pg_loader = Arc::new(pg_reader.as_data_loader());
 
-        let kv_loader = if let Some(instance_id) = kv_args.bigtable_instance.as_ref() {
-            let bigtable_reader = BigtableReader::new(
-                instance_id.clone(),
-                "indexer-alt-jsonrpc".to_owned(),
-                kv_args.bigtable_args(),
-                registry,
-            )
-            .await?;
-
-            KvLoader::new_with_bigtable(Arc::new(bigtable_reader.as_data_loader()))
-        } else if let Some(ledger_grpc_url) = kv_args.ledger_grpc_url.as_ref() {
-            let reader = LedgerGrpcReader::new(
-                ledger_grpc_url.clone(),
-                kv_args.ledger_grpc_args(),
-                Some("jsonrpc_ledger_grpc"),
-                registry,
-            )
-            .await
-            .context("Failed to create Ledger gRPC reader")?;
-
-            KvLoader::new_with_ledger_grpc(Arc::new(reader.as_data_loader()))
-        } else {
-            KvLoader::new_with_pg(pg_loader.clone())
-        };
+        let kv_loader = KvLoader::from_kv_sources(
+            kv_args
+                .bigtable_reader("indexer-alt-jsonrpc".to_owned(), registry)
+                .await?,
+            kv_args
+                .ledger_grpc_reader(Some("jsonrpc_ledger_grpc"), registry)
+                .await?,
+            pg_loader.clone(),
+        );
 
         let store = Arc::new(PackageCache::new(DbPackageStore::new(pg_loader.clone())));
         let package_resolver = Arc::new(Resolver::new_with_limits(

--- a/crates/sui-indexer-alt-jsonrpc/src/context.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/context.rs
@@ -7,11 +7,12 @@ use anyhow::Context as _;
 use async_graphql::dataloader::DataLoader;
 use diesel::QueryDsl;
 use prometheus::Registry;
-use sui_indexer_alt_reader::bigtable_reader::BigtableArgs;
 use sui_indexer_alt_reader::bigtable_reader::BigtableReader;
 use sui_indexer_alt_reader::consistent_reader::ConsistentReader;
 use sui_indexer_alt_reader::consistent_reader::ConsistentReaderArgs;
+use sui_indexer_alt_reader::kv_loader::KvArgs;
 use sui_indexer_alt_reader::kv_loader::KvLoader;
+use sui_indexer_alt_reader::ledger_grpc_reader::LedgerGrpcReader;
 use sui_indexer_alt_reader::package_resolver::DbPackageStore;
 use sui_indexer_alt_reader::package_resolver::PackageCache;
 use sui_indexer_alt_reader::pg_reader::PgReader;
@@ -59,15 +60,18 @@ pub(crate) struct Context {
 }
 
 impl Context {
-    /// Set-up access to the stores through all the interfaces available in the context. If
-    /// `bigtable_instance` is set, KV lookups will be sent to it, otherwise they will be sent to
-    /// the `database. If `database_url` is `None`, the interfaces will be set-up but will fail to
+    /// Set-up access to the stores through all the interfaces available in the context.
+    ///
+    /// KV lookups are routed based on `kv_args`: if a Bigtable instance is configured, lookups go
+    /// directly to Bigtable; if a Ledger gRPC URL is configured, lookups go through kv-rpc;
+    /// otherwise they fall back to Postgres.
+    ///
+    /// If `database_url` is `None`, the Postgres-backed interfaces will be set-up but will fail to
     /// accept any connections.
     pub(crate) async fn new(
         database_url: Option<Url>,
-        bigtable_instance: Option<String>,
         db_args: DbArgs,
-        bigtable_args: BigtableArgs,
+        kv_args: KvArgs,
         consistent_reader_args: ConsistentReaderArgs,
         config: RpcConfig,
         metrics: Arc<RpcMetrics>,
@@ -77,16 +81,27 @@ impl Context {
         let pg_reader = PgReader::new(None, database_url, db_args, registry).await?;
         let pg_loader = Arc::new(pg_reader.as_data_loader());
 
-        let kv_loader = if let Some(instance_id) = bigtable_instance {
+        let kv_loader = if let Some(instance_id) = kv_args.bigtable_instance.as_ref() {
             let bigtable_reader = BigtableReader::new(
-                instance_id,
+                instance_id.clone(),
                 "indexer-alt-jsonrpc".to_owned(),
-                bigtable_args,
+                kv_args.bigtable_args(),
                 registry,
             )
             .await?;
 
             KvLoader::new_with_bigtable(Arc::new(bigtable_reader.as_data_loader()))
+        } else if let Some(ledger_grpc_url) = kv_args.ledger_grpc_url.as_ref() {
+            let reader = LedgerGrpcReader::new(
+                ledger_grpc_url.clone(),
+                kv_args.ledger_grpc_args(),
+                Some("jsonrpc_ledger_grpc"),
+                registry,
+            )
+            .await
+            .context("Failed to create Ledger gRPC reader")?;
+
+            KvLoader::new_with_ledger_grpc(Arc::new(reader.as_data_loader()))
         } else {
             KvLoader::new_with_pg(pg_loader.clone())
         };

--- a/crates/sui-indexer-alt-jsonrpc/src/lib.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/lib.rs
@@ -6,16 +6,17 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Context as _;
+use async_graphql::dataloader::DataLoader;
 use jsonrpsee::server::BatchRequestConfig;
 use jsonrpsee::server::RpcServiceBuilder;
 use jsonrpsee::server::ServerBuilder;
 use prometheus::Registry;
 use serde_json::json;
 use sui_futures::service::Service;
-use sui_indexer_alt_reader::bigtable_reader::BigtableArgs;
 use sui_indexer_alt_reader::consistent_reader::ConsistentReaderArgs;
 use sui_indexer_alt_reader::fullnode_client::FullnodeArgs;
 use sui_indexer_alt_reader::fullnode_client::FullnodeClient;
+use sui_indexer_alt_reader::kv_loader::KvArgs;
 use sui_indexer_alt_reader::pg_reader::db::DbArgs;
 use sui_indexer_alt_reader::system_package_task::SystemPackageTask;
 use sui_indexer_alt_reader::system_package_task::SystemPackageTaskArgs;
@@ -235,6 +236,7 @@ impl Default for RpcArgs {
     }
 }
 
+/// Configuration for the fullnode RPC that this service will connect to.
 #[derive(clap::Args, Debug, Clone, Default)]
 pub struct NodeArgs {
     /// The URL of the fullnode JSON-RPC, used for delegation governance queries (getStakes,
@@ -265,9 +267,8 @@ pub struct NodeArgs {
 /// and will clean these up on shutdown as well.
 pub async fn start_rpc(
     database_url: Option<Url>,
-    bigtable_instance: Option<String>,
     db_args: DbArgs,
-    bigtable_args: BigtableArgs,
+    kv_args: KvArgs,
     consistent_reader_args: ConsistentReaderArgs,
     rpc_args: RpcArgs,
     node_args: NodeArgs,
@@ -279,9 +280,8 @@ pub async fn start_rpc(
 
     let context = Context::new(
         database_url,
-        bigtable_instance,
         db_args,
-        bigtable_args,
+        kv_args,
         consistent_reader_args,
         rpc_config,
         rpc.metrics(),

--- a/crates/sui-indexer-alt-jsonrpc/src/lib.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/lib.rs
@@ -6,7 +6,6 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Context as _;
-use async_graphql::dataloader::DataLoader;
 use jsonrpsee::server::BatchRequestConfig;
 use jsonrpsee::server::RpcServiceBuilder;
 use jsonrpsee::server::ServerBuilder;

--- a/crates/sui-indexer-alt-jsonrpc/src/main.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/main.rs
@@ -42,9 +42,8 @@ async fn main() -> anyhow::Result<()> {
     match args.command {
         Command::Rpc {
             database_url,
-            bigtable_instance,
             db_args,
-            bigtable_args,
+            kv_args,
             consistent_reader_args,
             rpc_args,
             system_package_task_args,
@@ -75,9 +74,8 @@ async fn main() -> anyhow::Result<()> {
 
             let s_rpc = start_rpc(
                 Some(database_url),
-                bigtable_instance,
                 db_args,
-                bigtable_args,
+                kv_args,
                 consistent_reader_args,
                 rpc_args,
                 node_args,

--- a/crates/sui-indexer-alt-reader/src/kv_loader.rs
+++ b/crates/sui-indexer-alt-reader/src/kv_loader.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 
 use anyhow::Context;
 use async_graphql::dataloader::DataLoader;
+use prometheus::Registry;
 use sui_indexer_alt_schema::transactions::StoredTransaction;
 use sui_kvstore::TransactionData as KVTransactionData;
 use sui_kvstore::TransactionEventsData as KVTransactionEventsData;
@@ -129,7 +130,47 @@ pub enum BalanceChangeContents {
 }
 
 impl KvArgs {
-    pub fn bigtable_args(&self) -> BigtableArgs {
+    pub async fn bigtable_reader(
+        &self,
+        client_name: String,
+        registry: &Registry,
+    ) -> anyhow::Result<Option<BigtableReader>> {
+        let Some(instance_id) = self.bigtable_instance.as_ref() else {
+            return Ok(None);
+        };
+
+        Ok(Some(
+            BigtableReader::new(
+                instance_id.clone(),
+                client_name,
+                self.bigtable_args(),
+                registry,
+            )
+            .await?,
+        ))
+    }
+
+    pub async fn ledger_grpc_reader(
+        &self,
+        prefix: Option<&str>,
+        registry: &Registry,
+    ) -> anyhow::Result<Option<LedgerGrpcReader>> {
+        let Some(ledger_grpc_url) = self.ledger_grpc_url.as_ref() else {
+            return Ok(None);
+        };
+
+        Ok(Some(
+            LedgerGrpcReader::new(
+                ledger_grpc_url.clone(),
+                self.ledger_grpc_args(),
+                prefix,
+                registry,
+            )
+            .await?,
+        ))
+    }
+
+    fn bigtable_args(&self) -> BigtableArgs {
         BigtableArgs {
             bigtable_statement_timeout_ms: self.kv_statement_timeout_ms,
             bigtable_project: self.bigtable_project.clone(),
@@ -138,7 +179,7 @@ impl KvArgs {
         }
     }
 
-    pub fn ledger_grpc_args(&self) -> LedgerGrpcArgs {
+    fn ledger_grpc_args(&self) -> LedgerGrpcArgs {
         LedgerGrpcArgs {
             ledger_grpc_statement_timeout_ms: self.kv_statement_timeout_ms,
             ledger_grpc_max_decoding_message_size: self.kv_max_decoding_message_size,
@@ -147,16 +188,20 @@ impl KvArgs {
 }
 
 impl KvLoader {
-    pub fn new_with_bigtable(bigtable_loader: Arc<DataLoader<BigtableReader>>) -> Self {
-        Self::Bigtable(bigtable_loader)
-    }
-
-    pub fn new_with_pg(pg_loader: Arc<DataLoader<PgReader>>) -> Self {
-        Self::Pg(pg_loader)
-    }
-
-    pub fn new_with_ledger_grpc(ledger_grpc_loader: Arc<DataLoader<LedgerGrpcReader>>) -> Self {
-        Self::LedgerGrpc(ledger_grpc_loader)
+    /// Create a KvLoader from the available KV sources, preferring Bigtable, then Ledger gRPC, with
+    /// a fallback to the shared Postgres `DataLoader`.
+    pub fn from_kv_sources(
+        bigtable: Option<BigtableReader>,
+        ledger_grpc: Option<LedgerGrpcReader>,
+        pg_loader: Arc<DataLoader<PgReader>>,
+    ) -> Self {
+        if let Some(reader) = bigtable {
+            Self::Bigtable(Arc::new(reader.as_data_loader()))
+        } else if let Some(reader) = ledger_grpc {
+            Self::LedgerGrpc(Arc::new(reader.as_data_loader()))
+        } else {
+            Self::Pg(pg_loader)
+        }
     }
 
     pub async fn load_one_object(

--- a/crates/sui-indexer-alt-reader/src/kv_loader.rs
+++ b/crates/sui-indexer-alt-reader/src/kv_loader.rs
@@ -25,17 +25,53 @@ use sui_types::messages_checkpoint::CheckpointSummary;
 use sui_types::object::Object;
 use sui_types::signature::GenericSignature;
 use sui_types::transaction::TransactionData;
+use tonic::transport::Uri;
 
+use crate::bigtable_reader::BigtableArgs;
 use crate::bigtable_reader::BigtableReader;
 use crate::checkpoints::CheckpointKey;
 use crate::error::Error;
 use crate::events::StoredTransactionEvents;
 use crate::events::TransactionEventsKey;
 use crate::ledger_grpc_reader::CheckpointedTransaction;
+use crate::ledger_grpc_reader::LedgerGrpcArgs;
 use crate::ledger_grpc_reader::LedgerGrpcReader;
 use crate::objects::VersionedObjectKey;
 use crate::pg_reader::PgReader;
 use crate::transactions::TransactionKey;
+
+/// Arguments for configuring KV store access (either Bigtable or Ledger gRPC).
+///
+/// These options are mutually exclusive - only one KV store source can be configured at a time.
+#[derive(clap::Args, Debug, Clone, Default)]
+#[group(required = false)]
+pub struct KvArgs {
+    /// Bigtable instance ID to make KV store requests to.
+    #[arg(long, group = "kv_source")]
+    pub bigtable_instance: Option<String>,
+
+    /// GCP project ID for the BigTable instance (defaults to the token provider's project).
+    #[arg(long)]
+    pub bigtable_project: Option<String>,
+
+    /// App profile ID to use for Bigtable client. If not provided, the default profile will be used.
+    #[arg(long)]
+    pub bigtable_app_profile_id: Option<String>,
+
+    /// Maximum gRPC decoding message size for KV responses, in bytes.
+    ///
+    /// Applies to both Bigtable and Ledger gRPC readers.
+    #[arg(long, alias = "bigtable-max-decoding-message-size")]
+    pub kv_max_decoding_message_size: Option<usize>,
+
+    /// gRPC endpoint URL for the ledger service (e.g., archive.mainnet.sui.io)
+    #[arg(long, group = "kv_source")]
+    pub ledger_grpc_url: Option<Uri>,
+
+    /// Time spent waiting for a request to the kv store to complete, in milliseconds.
+    #[arg(long, alias = "bigtable-statement-timeout-ms")]
+    pub kv_statement_timeout_ms: Option<u64>,
+}
 
 /// A loader for point lookups in kv stores backed by either Bigtable, Postgres, or KV gRPC.
 /// Supported lookups:
@@ -90,6 +126,24 @@ pub enum TransactionEventsContents {
 pub enum BalanceChangeContents {
     Grpc(grpc::BalanceChange),
     Native(NativeBalanceChange),
+}
+
+impl KvArgs {
+    pub fn bigtable_args(&self) -> BigtableArgs {
+        BigtableArgs {
+            bigtable_statement_timeout_ms: self.kv_statement_timeout_ms,
+            bigtable_project: self.bigtable_project.clone(),
+            bigtable_app_profile_id: self.bigtable_app_profile_id.clone(),
+            bigtable_max_decoding_message_size: self.kv_max_decoding_message_size,
+        }
+    }
+
+    pub fn ledger_grpc_args(&self) -> LedgerGrpcArgs {
+        LedgerGrpcArgs {
+            ledger_grpc_statement_timeout_ms: self.kv_statement_timeout_ms,
+            ledger_grpc_max_decoding_message_size: self.kv_max_decoding_message_size,
+        }
+    }
 }
 
 impl KvLoader {

--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -50,11 +50,12 @@ use sui_indexer_alt_framework::{
     ingestion::{ClientArgs, ingestion_client::IngestionClientArgs},
 };
 use sui_indexer_alt_graphql::{
-    RpcArgs as GraphQlArgs, args::KvArgs as GraphQlKvArgs, args::SubscriptionArgs,
-    config::RpcConfig as GraphQlConfig, start_rpc as start_graphql,
+    RpcArgs as GraphQlArgs, RpcArgs as GraphQlArgs, args::SubscriptionArgs,
+    config::RpcConfig as GraphQlConfig, config::RpcConfig as GraphQlConfig,
+    start_rpc as start_graphql, start_rpc as start_graphql,
 };
 use sui_indexer_alt_reader::{
-    consistent_reader::ConsistentReaderArgs, fullnode_client::FullnodeArgs,
+    consistent_reader::ConsistentReaderArgs, fullnode_client::FullnodeArgs, kv_loader::KvArgs,
     system_package_task::SystemPackageTaskArgs,
 };
 use sui_keys::key_derive::generate_new_key;
@@ -1178,7 +1179,7 @@ async fn start(
                 database_url.clone(),
                 fullnode_args,
                 DbArgs::default(),
-                GraphQlKvArgs::default(),
+                KvArgs::default(),
                 consistent_reader_args,
                 graphql_args,
                 SystemPackageTaskArgs::default(),

--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -50,9 +50,8 @@ use sui_indexer_alt_framework::{
     ingestion::{ClientArgs, ingestion_client::IngestionClientArgs},
 };
 use sui_indexer_alt_graphql::{
-    RpcArgs as GraphQlArgs, RpcArgs as GraphQlArgs, args::SubscriptionArgs,
-    config::RpcConfig as GraphQlConfig, config::RpcConfig as GraphQlConfig,
-    start_rpc as start_graphql, start_rpc as start_graphql,
+    RpcArgs as GraphQlArgs, args::SubscriptionArgs, config::RpcConfig as GraphQlConfig,
+    start_rpc as start_graphql,
 };
 use sui_indexer_alt_reader::{
     consistent_reader::ConsistentReaderArgs, fullnode_client::FullnodeArgs, kv_loader::KvArgs,


### PR DESCRIPTION
## Description 

Lift the `KvArgs` and kv loader setup logic out of graphql into `sui-indexer-alt-reader`, so both graphql and jsonrpc-alt have the ability to create a kv from either bigtable or ledger grpc. This enables jsonrpc-alt local dev and testing (by connecting jsonrpc-alt to a ledger grpc instance - which could be on top of a bigtable emulator)

This came up as part of the jsonrpc-alt migration off fullnode-jsonrpc (instead using fullnode grpc for governance api)

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
