### PR TITLE
[indexer-alt-reader] make FullnodeClient require execution client

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/src/lib.rs
+++ b/crates/sui-indexer-alt-e2e-tests/src/lib.rs
@@ -150,7 +150,7 @@ pub struct OffchainCluster {
 pub struct OffchainClusterConfig {
     pub indexer_args: IndexerArgs,
     pub consistent_indexer_args: IndexerArgs,
-    pub fullnode_args: FullnodeArgs,
+    pub fullnode_args: Option<FullnodeArgs>,
     pub indexer_config: IndexerConfig,
     pub consistent_config: ConsistentConfig,
     pub jsonrpc_config: JsonRpcConfig,
@@ -733,7 +733,7 @@ impl Default for OffchainClusterConfig {
         Self {
             indexer_args: Default::default(),
             consistent_indexer_args: Default::default(),
-            fullnode_args: Default::default(),
+            fullnode_args: None,
             indexer_config: IndexerConfig::for_test(),
             consistent_config: ConsistentConfig::for_test(),
             jsonrpc_config: Default::default(),

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_execute_transaction_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_execute_transaction_tests.rs
@@ -124,13 +124,13 @@ impl GraphQlTestCluster {
         };
 
         let fullnode_args = FullnodeArgs {
-            fullnode_rpc_url: Some(validator_cluster.rpc_url().parse().unwrap()),
+            fullnode_rpc_url: validator_cluster.rpc_url().parse().unwrap(),
         };
 
         // Start GraphQL server that connects directly to TestCluster's RPC
         let service = start_graphql(
             None, // No database - GraphQL will use fullnode RPC for executeTransaction
-            fullnode_args,
+            Some(fullnode_args),
             DbArgs::default(),
             KvArgs::default(),
             ConsistentReaderArgs::default(),

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_simulate_transaction_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_simulate_transaction_tests.rs
@@ -161,7 +161,7 @@ impl GraphQlTestCluster {
         let database_url = database.database().url().clone();
 
         let fullnode_args = FullnodeArgs {
-            fullnode_rpc_url: Some(validator_cluster.rpc_url().parse().unwrap()),
+            fullnode_rpc_url: validator_cluster.rpc_url().parse().unwrap(),
         };
         let client_args = ClientArgs {
             ingestion: IngestionClientArgs {
@@ -190,7 +190,7 @@ impl GraphQlTestCluster {
 
         let s_graphql = start_graphql(
             Some(database_url),
-            fullnode_args,
+            Some(fullnode_args),
             DbArgs::default(),
             KvArgs::default(),
             ConsistentReaderArgs::default(),

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/testing/harness.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/testing/harness.rs
@@ -46,9 +46,9 @@ impl SubscriptionTestCluster {
 
         let service = start_graphql(
             None,
-            FullnodeArgs {
-                fullnode_rpc_url: Some(rpc_url.parse().unwrap()),
-            },
+            Some(FullnodeArgs {
+                fullnode_rpc_url: rpc_url.parse().unwrap(),
+            }),
             DbArgs::default(),
             KvArgs::default(),
             ConsistentReaderArgs::default(),

--- a/crates/sui-indexer-alt-graphql/src/api/mutation.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/mutation.rs
@@ -63,8 +63,7 @@ impl Mutation {
     ) -> Result<ExecutionResult, RpcError<TransactionInputError>> {
         // Get the gRPC client from context. If the service was started without a fullnode URL
         // there is no client to dispatch the transaction to.
-        let fullnode_client: &Option<FullnodeClient> = ctx.data()?;
-        let Some(fullnode_client) = fullnode_client.as_ref() else {
+        let Some(fullnode_client) = ctx.data_opt::<FullnodeClient>() else {
             return Err(feature_unavailable("executing transactions"));
         };
 

--- a/crates/sui-indexer-alt-graphql/src/api/mutation.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/mutation.rs
@@ -21,6 +21,7 @@ use crate::api::types::execution_result::ExecutionResult;
 use crate::api::types::transaction_effects::TransactionEffects;
 use crate::error::RpcError;
 use crate::error::bad_user_input;
+use crate::error::feature_unavailable;
 use crate::error::upcast;
 use crate::scope::Scope;
 
@@ -60,8 +61,12 @@ impl Mutation {
         transaction_data_bcs: Base64,
         signatures: Vec<Base64>,
     ) -> Result<ExecutionResult, RpcError<TransactionInputError>> {
-        // Get the gRPC client from context
-        let fullnode_client: &FullnodeClient = ctx.data()?;
+        // Get the gRPC client from context. If the service was started without a fullnode URL
+        // there is no client to dispatch the transaction to.
+        let fullnode_client: &Option<FullnodeClient> = ctx.data()?;
+        let Some(fullnode_client) = fullnode_client.as_ref() else {
+            return Err(feature_unavailable("executing transactions"));
+        };
 
         // Parse transaction data from BCS
         let tx_data: TransactionData = {

--- a/crates/sui-indexer-alt-graphql/src/api/query.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/query.rs
@@ -758,8 +758,7 @@ impl Query {
         checks_enabled: Option<bool>,
         do_gas_selection: Option<bool>,
     ) -> Result<SimulationResult, RpcError<TransactionInputError>> {
-        let fullnode_client: &Option<FullnodeClient> = ctx.data()?;
-        let Some(fullnode_client) = fullnode_client.as_ref() else {
+        let Some(fullnode_client) = ctx.data_opt::<FullnodeClient>() else {
             return Err(feature_unavailable("simulating transactions"));
         };
 

--- a/crates/sui-indexer-alt-graphql/src/api/query.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/query.rs
@@ -70,6 +70,7 @@ use crate::api::types::zklogin::ZkLoginIntentScope;
 use crate::api::types::zklogin::ZkLoginVerifyResult;
 use crate::error::RpcError;
 use crate::error::bad_user_input;
+use crate::error::feature_unavailable;
 use crate::error::upcast;
 use crate::pagination::Page;
 use crate::pagination::PaginationConfig;
@@ -757,7 +758,10 @@ impl Query {
         checks_enabled: Option<bool>,
         do_gas_selection: Option<bool>,
     ) -> Result<SimulationResult, RpcError<TransactionInputError>> {
-        let fullnode_client: &FullnodeClient = ctx.data()?;
+        let fullnode_client: &Option<FullnodeClient> = ctx.data()?;
+        let Some(fullnode_client) = fullnode_client.as_ref() else {
+            return Err(feature_unavailable("simulating transactions"));
+        };
 
         // Convert Json to serde_json::Value and parse as proto::Transaction
         let json_value: serde_json::Value = transaction

--- a/crates/sui-indexer-alt-graphql/src/args.rs
+++ b/crates/sui-indexer-alt-graphql/src/args.rs
@@ -43,7 +43,7 @@ pub enum Command {
         database_url: Url,
 
         #[command(flatten)]
-        fullnode_args: FullnodeArgs,
+        fullnode_args: Option<FullnodeArgs>,
 
         #[command(flatten)]
         db_args: DbArgs,

--- a/crates/sui-indexer-alt-graphql/src/lib.rs
+++ b/crates/sui-indexer-alt-graphql/src/lib.rs
@@ -299,7 +299,7 @@ struct SubscriptionsEnabled(bool);
 /// and will clean these up on shutdown as well.
 pub async fn start_rpc(
     database_url: Option<Url>,
-    fullnode_args: FullnodeArgs,
+    fullnode_args: Option<FullnodeArgs>,
     db_args: DbArgs,
     kv_args: KvArgs,
     consistent_reader_args: ConsistentReaderArgs,
@@ -314,11 +314,11 @@ pub async fn start_rpc(
     let rpc = RpcService::new(args, version, schema(), registry);
     let metrics = rpc.metrics();
 
-    // Create gRPC full node client wrapper. If no URL was configured, the client is stored as
-    // `None` in the schema data and resolvers that depend on it return `FeatureUnavailable`.
-    let fullnode_client = if let Some(url) = fullnode_args.fullnode_rpc_url {
+    // Create gRPC full node client wrapper. If left unconfigured, the client will not be stored in
+    // the schema data, and resolvers that depend on it return `FeatureUnavailable`.
+    let fullnode_client = if let Some(args) = fullnode_args {
         Some(
-            FullnodeClient::new(Some("graphql_fullnode"), url, registry)
+            FullnodeClient::new(Some("graphql_fullnode"), args, registry)
                 .await
                 .context("Failed to create fullnode gRPC client")?,
         )
@@ -376,7 +376,7 @@ pub async fn start_rpc(
         .checkpoint_stream_url
         .map(|uri| task::streaming::CheckpointStreamTask::new(uri, &config.subscription));
 
-    let rpc = rpc
+    let mut rpc = rpc
         .route(GRAPHQL_PATH, post(graphql).get(graphql_get))
         .route(HEALTH_PATH, get(health::check))
         .layer(watermark_task.watermarks())
@@ -396,11 +396,14 @@ pub async fn start_rpc(
         .data(consistent_reader)
         .data(pg_loader)
         .data(kv_loader)
-        .data(package_store)
-        .data(fullnode_client);
+        .data(package_store);
+
+    if let Some(fullnode_client) = fullnode_client {
+        rpc = rpc.data(fullnode_client);
+    }
 
     let subscriptions_enabled = streaming_task.is_some();
-    let mut rpc = rpc.layer(SubscriptionsEnabled(subscriptions_enabled));
+    rpc = rpc.layer(SubscriptionsEnabled(subscriptions_enabled));
 
     if let Some(ref task) = streaming_task {
         rpc = rpc.data(task.broadcaster());

--- a/crates/sui-indexer-alt-graphql/src/lib.rs
+++ b/crates/sui-indexer-alt-graphql/src/lib.rs
@@ -314,9 +314,17 @@ pub async fn start_rpc(
     let rpc = RpcService::new(args, version, schema(), registry);
     let metrics = rpc.metrics();
 
-    // Create gRPC full node client wrapper
-    let fullnode_client =
-        FullnodeClient::new(Some("graphql_fullnode"), fullnode_args, registry).await?;
+    // Create gRPC full node client wrapper. If no URL was configured, the client is stored as
+    // `None` in the schema data and resolvers that depend on it return `FeatureUnavailable`.
+    let fullnode_client = if let Some(url) = fullnode_args.fullnode_rpc_url {
+        Some(
+            FullnodeClient::new(Some("graphql_fullnode"), url, registry)
+                .await
+                .context("Failed to create fullnode gRPC client")?,
+        )
+    } else {
+        None
+    };
 
     let consistent_reader =
         ConsistentReader::new(Some("graphql_consistent"), consistent_reader_args, registry).await?;

--- a/crates/sui-indexer-alt-jsonrpc/src/api/write/mod.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/write/mod.rs
@@ -255,9 +255,6 @@ fn grpc_error_to_rpc_error(
                 status.message().to_string(),
             ))
         }
-        Error::NotConfigured => anyhow::Error::new(Error::NotConfigured)
-            .context("Fullnode client not configured for write API")
-            .into(),
         Error::Internal(err) => err.context("Write API gRPC request failed").into(),
         Error::GrpcExecutionError(status) => anyhow::Error::new(status)
             .context("Write API gRPC request failed")

--- a/crates/sui-indexer-alt-jsonrpc/src/lib.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/lib.rs
@@ -13,7 +13,6 @@ use prometheus::Registry;
 use serde_json::json;
 use sui_futures::service::Service;
 use sui_indexer_alt_reader::consistent_reader::ConsistentReaderArgs;
-use sui_indexer_alt_reader::fullnode_client::FullnodeArgs;
 use sui_indexer_alt_reader::fullnode_client::FullnodeClient;
 use sui_indexer_alt_reader::kv_loader::KvArgs;
 use sui_indexer_alt_reader::pg_reader::db::DbArgs;
@@ -312,19 +311,11 @@ pub async fn start_rpc(
         warn!("No fullnode rpc url provided, DelegationGovernance module will not be added.");
     }
 
-    if node_args.fullnode_grpc_url.is_some() {
-        let fullnode_client = FullnodeClient::new(
-            Some("jsonrpc_alt_fullnode"),
-            FullnodeArgs {
-                fullnode_rpc_url: node_args
-                    .fullnode_grpc_url
-                    .as_deref()
-                    .map(|u| Url::parse(u).expect("Invalid fullnode gRPC URL")),
-            },
-            registry,
-        )
-        .await
-        .context("Failed to create fullnode gRPC client")?;
+    if let Some(fullnode_grpc_url) = node_args.fullnode_grpc_url.as_deref() {
+        let url = Url::parse(fullnode_grpc_url).context("Invalid fullnode gRPC URL")?;
+        let fullnode_client = FullnodeClient::new(Some("jsonrpc_alt_fullnode"), url, registry)
+            .await
+            .context("Failed to create fullnode gRPC client")?;
         rpc.add_module(Write::new(fullnode_client, context.clone()))?;
     } else {
         warn!("No fullnode grpc url provided, Write module will not be added.");

--- a/crates/sui-indexer-alt-jsonrpc/src/lib.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/lib.rs
@@ -13,6 +13,7 @@ use prometheus::Registry;
 use serde_json::json;
 use sui_futures::service::Service;
 use sui_indexer_alt_reader::consistent_reader::ConsistentReaderArgs;
+use sui_indexer_alt_reader::fullnode_client::FullnodeArgs;
 use sui_indexer_alt_reader::fullnode_client::FullnodeClient;
 use sui_indexer_alt_reader::kv_loader::KvArgs;
 use sui_indexer_alt_reader::pg_reader::db::DbArgs;
@@ -312,10 +313,15 @@ pub async fn start_rpc(
     }
 
     if let Some(fullnode_grpc_url) = node_args.fullnode_grpc_url.as_deref() {
-        let url = Url::parse(fullnode_grpc_url).context("Invalid fullnode gRPC URL")?;
-        let fullnode_client = FullnodeClient::new(Some("jsonrpc_alt_fullnode"), url, registry)
-            .await
-            .context("Failed to create fullnode gRPC client")?;
+        let fullnode_rpc_url =
+            Url::parse(fullnode_grpc_url).context("Invalid fullnode gRPC URL")?;
+        let fullnode_client = FullnodeClient::new(
+            Some("jsonrpc_alt_fullnode"),
+            FullnodeArgs { fullnode_rpc_url },
+            registry,
+        )
+        .await
+        .context("Failed to create fullnode gRPC client")?;
         rpc.add_module(Write::new(fullnode_client, context.clone()))?;
     } else {
         warn!("No fullnode grpc url provided, Write module will not be added.");

--- a/crates/sui-indexer-alt-reader/src/fullnode_client.rs
+++ b/crates/sui-indexer-alt-reader/src/fullnode_client.rs
@@ -26,9 +26,13 @@ pub struct FullnodeArgs {
 }
 
 /// A client for executing and simulating transactions via the full node gRPC service.
+///
+/// This client always wraps a live gRPC connection. Callers that may be deployed without a
+/// fullnode URL should store it as `Option<FullnodeClient>` and handle the absence at the caller
+/// level, rather than asking the client to represent its own "not configured" state.
 #[derive(Clone)]
 pub struct FullnodeClient {
-    execution_client: Option<TransactionExecutionServiceClient<Channel>>,
+    execution_client: TransactionExecutionServiceClient<Channel>,
     metrics: Arc<FullnodeClientMetrics>,
 }
 
@@ -37,9 +41,6 @@ pub enum Error {
     #[error(transparent)]
     Internal(#[from] anyhow::Error),
 
-    #[error("Full node client not configured")]
-    NotConfigured,
-
     #[error(transparent)]
     GrpcExecutionError(#[from] tonic::Status),
 }
@@ -47,25 +48,20 @@ pub enum Error {
 impl FullnodeClient {
     pub async fn new(
         prefix: Option<&str>,
-        args: FullnodeArgs,
+        url: Url,
         registry: &Registry,
     ) -> Result<Self, Error> {
-        let execution_client = if let Some(url) = &args.fullnode_rpc_url {
-            let mut endpoint = Channel::from_shared(url.to_string())
-                .context("Failed to create channel for gRPC endpoint")?;
+        let mut endpoint = Channel::from_shared(url.to_string())
+            .context("Failed to create channel for gRPC endpoint")?;
 
-            if url.scheme() == "https" {
-                endpoint = endpoint
-                    .tls_config(ClientTlsConfig::new().with_native_roots())
-                    .context("Failed to configure TLS for gRPC endpoint")?;
-            }
+        if url.scheme() == "https" {
+            endpoint = endpoint
+                .tls_config(ClientTlsConfig::new().with_native_roots())
+                .context("Failed to configure TLS for gRPC endpoint")?;
+        }
 
-            let channel = endpoint.connect_lazy();
-            Some(TransactionExecutionServiceClient::new(channel))
-        } else {
-            None
-        };
-
+        let channel = endpoint.connect_lazy();
+        let execution_client = TransactionExecutionServiceClient::new(channel);
         let metrics = FullnodeClientMetrics::new(prefix, registry);
 
         Ok(Self {
@@ -106,11 +102,9 @@ impl FullnodeClient {
         .with_signatures(signatures)
         .with_read_mask(read_mask);
 
-        self.request(
-            "execute_transaction",
-            self.execution_client.clone(),
-            |mut client| async move { client.execute_transaction(request).await },
-        )
+        self.request("execute_transaction", |mut client| async move {
+            client.execute_transaction(request).await
+        })
         .await
     }
 
@@ -140,28 +134,17 @@ impl FullnodeClient {
             .with_checks(checks)
             .with_do_gas_selection(do_gas_selection);
 
-        self.request(
-            "simulate_transaction",
-            self.execution_client.clone(),
-            |mut client| async move { client.simulate_transaction(request).await },
-        )
+        self.request("simulate_transaction", |mut client| async move {
+            client.simulate_transaction(request).await
+        })
         .await
     }
 
-    async fn request<C, F, Fut, R>(
-        &self,
-        method: &str,
-        client: Option<C>,
-        response: F,
-    ) -> Result<R, Error>
+    async fn request<F, Fut, R>(&self, method: &str, response: F) -> Result<R, Error>
     where
-        F: FnOnce(C) -> Fut,
+        F: FnOnce(TransactionExecutionServiceClient<Channel>) -> Fut,
         Fut: std::future::Future<Output = Result<tonic::Response<R>, tonic::Status>>,
     {
-        let Some(client) = client else {
-            return Err(Error::NotConfigured);
-        };
-
         self.metrics
             .requests_received
             .with_label_values(&[method])
@@ -173,7 +156,7 @@ impl FullnodeClient {
             .with_label_values(&[method])
             .start_timer();
 
-        let response = response(client)
+        let response = response(self.execution_client.clone())
             .await
             .map(|r| r.into_inner())
             .map_err(Into::into);
@@ -198,39 +181,19 @@ impl FullnodeClient {
 mod tests {
     use super::*;
 
-    async fn fn_client(url: Option<&str>) -> Result<FullnodeClient, Error> {
-        let args = FullnodeArgs {
-            fullnode_rpc_url: url.map(|u| Url::parse(u).unwrap()),
-        };
+    async fn fn_client(url: &str) -> Result<FullnodeClient, Error> {
+        let url = Url::parse(url).unwrap();
         let registry = Registry::new();
-        FullnodeClient::new(None, args, &registry).await
-    }
-
-    #[tokio::test]
-    async fn no_url_means_not_configured() {
-        let client = fn_client(None).await.unwrap();
-        assert!(client.execution_client.is_none());
+        FullnodeClient::new(None, url, &registry).await
     }
 
     #[tokio::test]
     async fn http_url_creates_client() {
-        assert!(
-            fn_client(Some("http://localhost:9000"))
-                .await
-                .unwrap()
-                .execution_client
-                .is_some()
-        );
+        fn_client("http://localhost:9000").await.unwrap();
     }
 
     #[tokio::test]
     async fn https_url_creates_client() {
-        assert!(
-            fn_client(Some("https://fn.example.com"))
-                .await
-                .unwrap()
-                .execution_client
-                .is_some()
-        );
+        fn_client("https://fn.example.com").await.unwrap();
     }
 }

--- a/crates/sui-indexer-alt-reader/src/fullnode_client.rs
+++ b/crates/sui-indexer-alt-reader/src/fullnode_client.rs
@@ -18,18 +18,14 @@ use url::Url;
 
 use crate::metrics::FullnodeClientMetrics;
 
-#[derive(clap::Args, Debug, Clone, Default)]
+#[derive(clap::Args, Debug, Clone)]
 pub struct FullnodeArgs {
     /// gRPC URL for full node operations such as executeTransaction and simulateTransaction.
     #[clap(long)]
-    pub fullnode_rpc_url: Option<Url>,
+    pub fullnode_rpc_url: Url,
 }
 
 /// A client for executing and simulating transactions via the full node gRPC service.
-///
-/// This client always wraps a live gRPC connection. Callers that may be deployed without a
-/// fullnode URL should store it as `Option<FullnodeClient>` and handle the absence at the caller
-/// level, rather than asking the client to represent its own "not configured" state.
 #[derive(Clone)]
 pub struct FullnodeClient {
     execution_client: TransactionExecutionServiceClient<Channel>,
@@ -46,11 +42,15 @@ pub enum Error {
 }
 
 impl FullnodeClient {
-    pub async fn new(prefix: Option<&str>, url: Url, registry: &Registry) -> Result<Self, Error> {
-        let mut endpoint = Channel::from_shared(url.to_string())
+    pub async fn new(
+        prefix: Option<&str>,
+        args: FullnodeArgs,
+        registry: &Registry,
+    ) -> Result<Self, Error> {
+        let mut endpoint = Channel::from_shared(args.fullnode_rpc_url.to_string())
             .context("Failed to create channel for gRPC endpoint")?;
 
-        if url.scheme() == "https" {
+        if args.fullnode_rpc_url.scheme() == "https" {
             endpoint = endpoint
                 .tls_config(ClientTlsConfig::new().with_native_roots())
                 .context("Failed to configure TLS for gRPC endpoint")?;
@@ -180,7 +180,10 @@ mod tests {
     async fn fn_client(url: &str) -> Result<FullnodeClient, Error> {
         let url = Url::parse(url).unwrap();
         let registry = Registry::new();
-        FullnodeClient::new(None, url, &registry).await
+        let args = FullnodeArgs {
+            fullnode_rpc_url: url,
+        };
+        FullnodeClient::new(None, args, &registry).await
     }
 
     #[tokio::test]

--- a/crates/sui-indexer-alt-reader/src/fullnode_client.rs
+++ b/crates/sui-indexer-alt-reader/src/fullnode_client.rs
@@ -46,11 +46,7 @@ pub enum Error {
 }
 
 impl FullnodeClient {
-    pub async fn new(
-        prefix: Option<&str>,
-        url: Url,
-        registry: &Registry,
-    ) -> Result<Self, Error> {
+    pub async fn new(prefix: Option<&str>, url: Url, registry: &Registry) -> Result<Self, Error> {
         let mut endpoint = Channel::from_shared(url.to_string())
             .context("Failed to create channel for gRPC endpoint")?;
 

--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -1167,7 +1167,7 @@ async fn start(
         };
 
         let fullnode_args = FullnodeArgs {
-            fullnode_rpc_url: Some(socket_addr_to_url(fullnode_rpc_address)?),
+            fullnode_rpc_url: socket_addr_to_url(fullnode_rpc_address)?,
         };
 
         let mut graphql_config = GraphQlConfig::default();
@@ -1176,7 +1176,7 @@ async fn start(
         rpc_services = rpc_services.merge(
             start_graphql(
                 database_url.clone(),
-                fullnode_args,
+                Some(fullnode_args),
                 DbArgs::default(),
                 KvArgs::default(),
                 consistent_reader_args,


### PR DESCRIPTION
## Description 

Callers take on the responsibility of instantiating the fullnode client, rather than the client itself managing whether an execution service is configured or not, to simplify callsites using the client and reduce checks to initialization 



## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
