### PR TITLE
[move][compressed-layouts] Arc instead of Box LayoutRefs

### DIFF
--- a/external-crates/move/crates/move-core-types/src/compressed/annotated/layout.rs
+++ b/external-crates/move/crates/move-core-types/src/compressed/annotated/layout.rs
@@ -30,21 +30,21 @@ pub(crate) struct AnnotatedFieldEntry {
 pub(crate) struct AnnotatedVariantEntry {
     pub name: Identifier,
     pub tag: VariantTag,
-    pub fields: Option<Box<[AnnotatedFieldEntry]>>,
+    pub fields: Option<Arc<[AnnotatedFieldEntry]>>,
 }
 
 /// Annotated struct layout node with type tag and named fields inline.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(crate) struct MoveStructNode {
     pub(crate) type_: StructTag,
-    pub(crate) fields: Box<[AnnotatedFieldEntry]>,
+    pub(crate) fields: Arc<[AnnotatedFieldEntry]>,
 }
 
 /// Annotated enum layout node with type tag and named variants inline.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(crate) struct MoveEnumNode {
     pub(crate) type_: StructTag,
-    pub(crate) variants: Box<[AnnotatedVariantEntry]>,
+    pub(crate) variants: Arc<[AnnotatedVariantEntry]>,
 }
 
 /// A compound layout node in the annotated compressed node table.
@@ -113,7 +113,7 @@ pub struct MoveDatatypeLayout {
 #[derive(Debug, Clone)]
 pub struct MoveEnumLayout {
     type_: StructTag,
-    pub(crate) variants: Box<[VariantLayout]>,
+    pub(crate) variants: Arc<[VariantLayout]>,
 }
 
 /// The struct layout with type tag and named fields, as a view into a shared pool.
@@ -140,7 +140,7 @@ pub enum VariantLayout {
 #[derive(Debug, Clone)]
 pub struct MoveFieldsLayout {
     pool: Arc<MoveTypeLayoutPool>,
-    fields: Box<[AnnotatedFieldEntry]>,
+    fields: Arc<[AnnotatedFieldEntry]>,
 }
 
 // --- Builder type ---
@@ -679,7 +679,7 @@ impl MoveTypeLayoutBuilder {
         type_tag: &StructTag,
         fields: &[(&Identifier, LayoutHandle)],
     ) -> AResult<LayoutHandle> {
-        let fields: Box<[AnnotatedFieldEntry]> = fields
+        let fields: Arc<[AnnotatedFieldEntry]> = fields
             .iter()
             .map(|(name, h)| AnnotatedFieldEntry {
                 name: (*name).clone(),
@@ -704,7 +704,7 @@ impl MoveTypeLayoutBuilder {
             Option<&[(&Identifier, LayoutHandle)]>,
         )],
     ) -> AResult<LayoutHandle> {
-        let variant_entries: Box<[AnnotatedVariantEntry]> = variants
+        let variant_entries: Arc<[AnnotatedVariantEntry]> = variants
             .iter()
             .map(|(vn, tag, fields)| {
                 let field_entries = fields.map(|fields| {

--- a/external-crates/move/crates/move-core-types/src/compressed/runtime/layout.rs
+++ b/external-crates/move/crates/move-core-types/src/compressed/runtime/layout.rs
@@ -20,10 +20,12 @@ static EMPTY_POOL: std::sync::LazyLock<Arc<MoveTypeLayoutPool>> =
 
 // --- Node types (internal) ---
 
+type LayoutRefs = Arc<[LayoutRef]>;
+
 /// Struct layout node: field types stored as [`LayoutRef`]s.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(crate) struct MoveStructNode {
-    pub(crate) fields: Box<[LayoutRef]>,
+    pub(crate) fields: LayoutRefs,
 }
 
 /// Enum layout node: each variant is either a known list of field
@@ -31,7 +33,7 @@ pub(crate) struct MoveStructNode {
 /// field layout is not available.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(crate) struct MoveEnumNode {
-    pub(crate) variants: Box<[Option<Box<[LayoutRef]>>]>,
+    pub(crate) variants: Box<[Option<LayoutRefs>]>,
 }
 
 /// A compound layout node in the compressed node table.
@@ -90,7 +92,7 @@ pub enum MoveDatatypeLayout {
 /// The enum layout of an enum type, as a view into a shared pool.
 #[derive(Debug, Clone)]
 pub struct MoveEnumLayout {
-    pub(crate) variants: Box<[VariantLayout]>,
+    pub(crate) variants: Arc<[VariantLayout]>,
 }
 
 /// The struct layout of a struct type, as a view into a shared pool.
@@ -110,7 +112,7 @@ pub enum VariantLayout {
 #[derive(Debug, Clone)]
 pub struct MoveFieldsLayout {
     pool: Arc<MoveTypeLayoutPool>,
-    fields: Box<[LayoutRef]>,
+    fields: LayoutRefs,
 }
 
 // --- Builder type ---
@@ -423,12 +425,12 @@ impl MoveTypeLayoutBuilder {
     }
 
     pub fn struct_layout(&mut self, fields: &[LayoutHandle]) -> AResult<LayoutHandle> {
-        let field_refs: Box<[LayoutRef]> = fields.iter().map(|h| h.0).collect();
+        let field_refs: LayoutRefs = fields.iter().map(|h| h.0).collect();
         self.add_node(MoveTypeNode::Struct(MoveStructNode { fields: field_refs }))
     }
 
     pub fn enum_layout(&mut self, variants: &[Option<&[LayoutHandle]>]) -> AResult<LayoutHandle> {
-        let variant_refs: Box<[Option<Box<[LayoutRef]>>]> = variants
+        let variant_refs: Box<[Option<LayoutRefs>]> = variants
             .iter()
             .map(|v| v.map(|fields| fields.iter().map(|h| h.0).collect()))
             .collect();


### PR DESCRIPTION
## Description 

`Arc` them instead of `Box`ing to make clones bit cheaper.

## Test plan 

CI/existing tests.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
