### PR TITLE
[sui-replay] Fix double-save of tx effects causing errors if `--overwrite` is not passed

### DIFF
--- a/crates/sui-replay-2/src/replay_txn.rs
+++ b/crates/sui-replay-2/src/replay_txn.rs
@@ -185,12 +185,6 @@ pub(crate) async fn replay_transaction<S: ReadDataStore>(
         .unwrap();
 
     artifact_manager
-        .member(Artifact::TransactionEffects)
-        .serialize_artifact(&context_and_effects.execution_effects)
-        .transpose()?
-        .unwrap();
-
-    artifact_manager
         .member(Artifact::TransactionGasReport)
         .serialize_artifact(&context_and_effects.gas_status.gas_usage_report())
         .transpose()?


### PR DESCRIPTION
## Description 

What the title says

## Test plan 

Ran it locally. It failed before, it passed after. 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
