### PR TITLE
sui-indexer-alt-object-store: implement accepts_chain_id

### DIFF
--- a/crates/sui-analytics-indexer/src/store/live.rs
+++ b/crates/sui-analytics-indexer/src/store/live.rs
@@ -252,7 +252,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_committer_watermark_multiple_epochs() {
-        let object_store: Arc<dyn object_store::ObjectStore> = Arc::new(InMemory::new());
+        let (object_store, store) = in_memory_store();
         // Epoch 0 - files written to output_prefix "test_pipeline"
         create_test_file(&object_store, "test_pipeline", 0, 0, 100).await;
         create_test_file(&object_store, "test_pipeline", 0, 100, 200).await;
@@ -260,8 +260,6 @@ mod tests {
         create_test_file(&object_store, "test_pipeline", 1, 200, 300).await;
         create_test_file(&object_store, "test_pipeline", 1, 300, 400).await;
 
-        let config = test_config(object_store.clone());
-        let store = AnalyticsStore::new(object_store, config, test_metrics());
         let mut conn = store.connect().await.unwrap();
 
         // Use pipeline name "Checkpoint" which maps to output_prefix "test_pipeline"

--- a/crates/sui-analytics-indexer/src/store/mod.rs
+++ b/crates/sui-analytics-indexer/src/store/mod.rs
@@ -23,13 +23,8 @@ use std::sync::RwLock;
 use std::time::Duration;
 use std::time::Instant;
 
-use anyhow::Context;
 use async_trait::async_trait;
-use object_store::Error as ObjectStoreError;
 use object_store::ObjectStore;
-use object_store::ObjectStoreExt as _;
-use object_store::PutMode;
-use object_store::PutOptions;
 use object_store::PutPayload;
 use object_store::path::Path as ObjectPath;
 use scoped_futures::ScopedBoxFuture;
@@ -657,36 +652,12 @@ impl Connection for AnalyticsConnection<'_> {
         pipeline_task: &str,
         chain_id: [u8; 32],
     ) -> anyhow::Result<bool> {
-        let object_store = self.store.mode.object_store();
-        let path = chain_id_path(pipeline_task);
-
-        // Try to claim the path with a conditional create first. If it doesn't exist,
-        // we win the race and accept. If it already exists, fall back to read + compare.
-        match object_store
-            .put_opts(
-                &path,
-                chain_id.to_vec().into(),
-                PutOptions {
-                    mode: PutMode::Create,
-                    ..Default::default()
-                },
-            )
-            .await
-        {
-            Ok(_) => Ok(true),
-            Err(ObjectStoreError::AlreadyExists { .. }) => {
-                let bytes = object_store.get(&path).await?.bytes().await?;
-                let stored: [u8; 32] = bytes.as_ref().try_into().ok().with_context(|| {
-                    format!(
-                        "stored chain_id at {} has wrong length: {}",
-                        path,
-                        bytes.len()
-                    )
-                })?;
-                Ok(stored == chain_id)
-            }
-            Err(e) => Err(e.into()),
-        }
+        sui_indexer_alt_object_store::accepts_chain_id(
+            self.store.mode.object_store().as_ref(),
+            pipeline_task,
+            chain_id,
+        )
+        .await
     }
 
     /// Determine the watermark.
@@ -724,12 +695,6 @@ impl Connection for AnalyticsConnection<'_> {
 
 #[async_trait]
 impl SequentialConnection for AnalyticsConnection<'_> {}
-
-/// Construct the object store path for a chain_id file.
-/// Path format: `_metadata/chain_id/{pipeline_task}`
-pub(crate) fn chain_id_path(pipeline_task: &str) -> ObjectPath {
-    ObjectPath::from(format!("_metadata/chain_id/{}", pipeline_task))
-}
 
 /// Construct the object store path for an analytics file.
 /// Path format: {pipeline}/epoch_{epoch}/{start}_{end}.{ext}

--- a/crates/sui-indexer-alt-object-store/src/lib.rs
+++ b/crates/sui-indexer-alt-object-store/src/lib.rs
@@ -229,11 +229,10 @@ impl Connection for ObjectStoreConnection {
 
     async fn accepts_chain_id(
         &mut self,
-        _pipeline_task: &str,
-        _chain_id: [u8; 32],
+        pipeline_task: &str,
+        chain_id: [u8; 32],
     ) -> anyhow::Result<bool> {
-        // TODO: Implement storing chain_id
-        Ok(true)
+        crate::accepts_chain_id(self.object_store.as_ref(), pipeline_task, chain_id).await
     }
 
     async fn committer_watermark(
@@ -353,6 +352,46 @@ fn watermark_path(pipeline: &str) -> ObjectPath {
     ObjectPath::from(format!("_metadata/watermarks/{}.json", pipeline))
 }
 
+fn chain_id_path(pipeline_task: &str) -> ObjectPath {
+    ObjectPath::from(format!("_metadata/chain_id/{pipeline_task}"))
+}
+
+/// Reusable implementation of [`Connection::accepts_chain_id`] for object-store-backed
+/// connections. Stores `chain_id` at `_metadata/chain_id/{pipeline_task}` on first call
+/// via a conditional create; on subsequent calls reads and compares.
+pub async fn accepts_chain_id(
+    object_store: &dyn object_store::ObjectStore,
+    pipeline_task: &str,
+    chain_id: [u8; 32],
+) -> anyhow::Result<bool> {
+    let path = chain_id_path(pipeline_task);
+    match object_store
+        .put_opts(
+            &path,
+            chain_id.to_vec().into(),
+            object_store::PutOptions {
+                mode: PutMode::Create,
+                ..Default::default()
+            },
+        )
+        .await
+    {
+        Ok(_) => Ok(true),
+        Err(ObjectStoreError::AlreadyExists { .. }) => {
+            let bytes = object_store.get(&path).await?.bytes().await?;
+            let stored: [u8; 32] = bytes.as_ref().try_into().ok().with_context(|| {
+                format!(
+                    "stored chain_id at {} has wrong length: {}",
+                    path,
+                    bytes.len()
+                )
+            })?;
+            Ok(stored == chain_id)
+        }
+        Err(e) => Err(e.into()),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use object_store::memory::InMemory;
@@ -378,6 +417,17 @@ mod tests {
     async fn store_conn() -> ObjectStoreConnection {
         let store = ObjectStore::new(Arc::new(InMemory::new()));
         store.connect().await.unwrap()
+    }
+
+    async fn read_stored_chain_id(conn: &ObjectStoreConnection, pipeline_task: &str) -> Vec<u8> {
+        conn.object_store
+            .get(&chain_id_path(pipeline_task))
+            .await
+            .unwrap()
+            .bytes()
+            .await
+            .unwrap()
+            .to_vec()
     }
 
     #[tokio::test]
@@ -788,5 +838,37 @@ mod tests {
         let mut conn = conn;
         let result = conn.pruner_watermark(PIPELINE, Duration::ZERO).await;
         assert!(result.is_err(), "expected overflow error, got {result:?}");
+    }
+
+    #[tokio::test]
+    async fn test_accepts_chain_id_first_call_writes_and_accepts() {
+        let mut conn = store_conn().await;
+
+        let chain_id = [1u8; 32];
+        assert!(conn.accepts_chain_id(PIPELINE, chain_id).await.unwrap());
+        assert_eq!(read_stored_chain_id(&conn, PIPELINE).await, chain_id);
+    }
+
+    #[tokio::test]
+    async fn test_accepts_chain_id_matching_accepts() {
+        let mut conn = store_conn().await;
+
+        let chain_id = [1u8; 32];
+        assert!(conn.accepts_chain_id(PIPELINE, chain_id).await.unwrap());
+        // Second call with the same chain_id should also accept
+        assert!(conn.accepts_chain_id(PIPELINE, chain_id).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_accepts_chain_id_mismatching_rejects() {
+        let mut conn = store_conn().await;
+
+        let chain_id_a = [1u8; 32];
+        let chain_id_b = [2u8; 32];
+        assert!(conn.accepts_chain_id(PIPELINE, chain_id_a).await.unwrap());
+        assert!(!conn.accepts_chain_id(PIPELINE, chain_id_b).await.unwrap());
+
+        // Stored bytes are unchanged (still chain_id_a)
+        assert_eq!(read_stored_chain_id(&conn, PIPELINE).await, chain_id_a);
     }
 }


### PR DESCRIPTION
## Description 

Moves the `sui-analytics-indexer`'s `accepts_chain_id` impl (added in #26171) into `sui-indexer-alt-object-store` so it can be used in both locations.

## Test plan 

Added new unit tests.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [x] Indexing Framework: Implement `accepts_chain_id` in object store
