### PR TITLE
[sui-rosetta] Parse ConsolidateAllStakedSuiToFungible on read path

### DIFF
--- a/crates/sui-rosetta/src/operations.rs
+++ b/crates/sui-rosetta/src/operations.rs
@@ -30,7 +30,9 @@ use sui_types::base_types::{ObjectID, SequenceNumber, SuiAddress};
 use sui_types::gas_coin::GasCoin;
 use sui_types::governance::{ADD_STAKE_FUN_NAME, WITHDRAW_STAKE_FUN_NAME};
 use sui_types::sui_system_state::SUI_SYSTEM_MODULE_NAME;
-use sui_types::{SUI_FRAMEWORK_PACKAGE_ID, SUI_SYSTEM_ADDRESS, SUI_SYSTEM_PACKAGE_ID};
+use sui_types::{
+    SUI_FRAMEWORK_PACKAGE_ID, SUI_SYSTEM_ADDRESS, SUI_SYSTEM_PACKAGE_ID, SUI_SYSTEM_STATE_OBJECT_ID,
+};
 
 use crate::types::internal_operation::{
     ConsolidateAllStakedSuiToFungible, MergeAndRedeemFungibleStakedSui, PayCoin, PaySui, Stake,
@@ -277,11 +279,15 @@ impl Operations {
         let metadata = op.metadata.ok_or_else(|| {
             Error::MissingInput("ConsolidateAllStakedSuiToFungible metadata".to_string())
         })?;
-        let OperationMetadata::ConsolidateAllStakedSuiToFungible { validator } = metadata else {
+        let OperationMetadata::ConsolidateAllStakedSuiToFungible { validator, .. } = metadata
+        else {
             return Err(Error::InvalidInput(
                 "Cannot find validator from ConsolidateAllStakedSuiToFungible metadata.".into(),
             ));
         };
+        let validator = validator.ok_or_else(|| {
+            Error::MissingInput("validator required for ConsolidateAllStakedSuiToFungible".into())
+        })?;
         Ok(InternalOperation::ConsolidateAllStakedSuiToFungible(
             ConsolidateAllStakedSuiToFungible { sender, validator },
         ))
@@ -615,6 +621,28 @@ impl Operations {
         let mut stake_ids = vec![];
         let mut currency: Option<Currency> = None;
 
+        // Detect FSS consolidation/redemption PTBs by signature MoveCalls.
+        // PR 2 will prepend a `has_redeem` check in front of this block.
+        let has_convert_fss = commands.iter().any(|c| {
+            matches!(
+                &c.command,
+                Some(Command::MoveCall(m)) if Self::is_convert_to_fss_call(m)
+            )
+        });
+        let has_join_fss = commands.iter().any(|c| {
+            matches!(
+                &c.command,
+                Some(Command::MoveCall(m)) if Self::is_join_fss_call(m)
+            )
+        });
+        if (has_convert_fss || has_join_fss)
+            && let Some(ops) = Self::parse_consolidate(sender, inputs, commands, status)
+        {
+            return Ok(ops);
+        }
+        // If has_convert_fss || has_join_fss but parse_consolidate returned None, we fall
+        // through; the unrecognized MoveCalls hit `_ => None` and emit a generic_op.
+
         for command in commands {
             let result = match &command.command {
                 Some(Command::SplitCoins(split)) => {
@@ -749,6 +777,162 @@ impl Operations {
         Ok(operations)
     }
 
+    /// Parse a PTB that represents `ConsolidateAllStakedSuiToFungible`.
+    ///
+    /// Accepts three valid shapes produced by `consolidate_to_fungible_pt`:
+    /// 1. Pure FSS merge (S=0, F>=2): only `join_fungible_staked_sui` calls, no convert, no transfer.
+    /// 2. Convert-only (S>=1, F=0): convert(s) + optional new-FSS joins + trailing `TransferObjects` to sender.
+    /// 3. Mixed (S>=1, F>=1): existing-FSS joins + convert(s) + new-FSS joins + cross-merge join, no transfer.
+    ///
+    /// Returns `None` on any shape mismatch, causing the caller to fall through to generic op emission.
+    fn parse_consolidate(
+        sender: SuiAddress,
+        inputs: &[Input],
+        commands: &[sui_rpc::proto::sui::rpc::v2::Command],
+        status: Option<OperationStatus>,
+    ) -> Option<Vec<Operation>> {
+        use std::collections::BTreeSet;
+
+        if !Self::first_input_is_sui_system_state(inputs) {
+            return None;
+        }
+
+        let mut staked_sui_indices: Vec<u32> = Vec::new();
+        let mut fss_indices: Vec<u32> = Vec::new();
+        let mut staked_seen: BTreeSet<u32> = BTreeSet::new();
+        let mut fss_seen: BTreeSet<u32> = BTreeSet::new();
+        let mut saw_transfer = false;
+
+        for (idx, command) in commands.iter().enumerate() {
+            if saw_transfer {
+                return None;
+            }
+            match &command.command {
+                Some(Command::MoveCall(m)) if Self::is_convert_to_fss_call(m) => {
+                    if m.arguments.len() != 2 {
+                        return None;
+                    }
+                    let staked_arg = &m.arguments[1];
+                    if staked_arg.kind() != ArgumentKind::Input {
+                        return None;
+                    }
+                    let i = staked_arg.input();
+                    if fss_seen.contains(&i) {
+                        return None;
+                    }
+                    if staked_seen.insert(i) {
+                        staked_sui_indices.push(i);
+                    }
+                }
+                Some(Command::MoveCall(m)) if Self::is_join_fss_call(m) => {
+                    if m.arguments.len() != 2 {
+                        return None;
+                    }
+                    for arg in &m.arguments {
+                        match arg.kind() {
+                            ArgumentKind::Input => {
+                                let i = arg.input();
+                                if staked_seen.contains(&i) {
+                                    return None;
+                                }
+                                if fss_seen.insert(i) {
+                                    fss_indices.push(i);
+                                }
+                            }
+                            ArgumentKind::Result => {}
+                            _ => return None,
+                        }
+                    }
+                }
+                Some(Command::TransferObjects(transfer)) => {
+                    if transfer.objects.len() != 1 {
+                        return None;
+                    }
+                    if transfer.objects[0].kind() != ArgumentKind::Result {
+                        return None;
+                    }
+                    let addr_arg = transfer.address();
+                    if addr_arg.kind() != ArgumentKind::Input {
+                        return None;
+                    }
+                    let recipient = inputs.get(addr_arg.input() as usize).and_then(|inp| {
+                        if inp.kind() == InputKind::Pure {
+                            bcs::from_bytes::<SuiAddress>(inp.pure()).ok()
+                        } else {
+                            None
+                        }
+                    })?;
+                    if recipient != sender {
+                        return None;
+                    }
+                    if idx + 1 != commands.len() {
+                        return None;
+                    }
+                    saw_transfer = true;
+                }
+                _ => return None,
+            }
+        }
+
+        if staked_sui_indices.is_empty() && fss_indices.is_empty() {
+            return None;
+        }
+
+        let staked_sui_ids = Self::input_indices_to_object_ids(inputs, &staked_sui_indices)?;
+        let fss_ids = Self::input_indices_to_object_ids(inputs, &fss_indices)?;
+
+        Some(vec![Operation {
+            operation_identifier: Default::default(),
+            type_: OperationType::ConsolidateAllStakedSuiToFungible,
+            status,
+            account: Some(sender.into()),
+            amount: None,
+            coin_change: None,
+            metadata: Some(OperationMetadata::ConsolidateAllStakedSuiToFungible {
+                validator: None,
+                staked_sui_ids,
+                fss_ids,
+            }),
+        }])
+    }
+
+    /// Returns true iff inputs[0] is a `SharedObject` reference to the SUI_SYSTEM_STATE (0x5).
+    ///
+    /// Note on mutability: the Move functions `convert_to_fungible_staked_sui` and
+    /// `redeem_fungible_staked_sui` take `&mut SuiSystemState`, so the chain will reject
+    /// immutable shared references at execution time. This check is therefore sufficient
+    /// without an explicit mutable-shared flag.
+    fn first_input_is_sui_system_state(inputs: &[Input]) -> bool {
+        let Some(first) = inputs.first() else {
+            return false;
+        };
+        if first.kind() != InputKind::Shared {
+            return false;
+        }
+        let Some(oid_str) = first.object_id.as_ref() else {
+            return false;
+        };
+        let Ok(oid) = ObjectID::from_str(oid_str) else {
+            return false;
+        };
+        oid == SUI_SYSTEM_STATE_OBJECT_ID
+    }
+
+    /// Resolves a list of input indices to ObjectIDs. Returns None if any index is
+    /// out-of-bounds or references an input that isn't `ImmutableOrOwned`.
+    fn input_indices_to_object_ids(inputs: &[Input], indices: &[u32]) -> Option<Vec<ObjectID>> {
+        indices
+            .iter()
+            .map(|&i| {
+                let inp = inputs.get(i as usize)?;
+                if inp.kind() != InputKind::ImmutableOrOwned {
+                    return None;
+                }
+                ObjectID::from_str(inp.object_id.as_ref()?).ok()
+            })
+            .collect()
+    }
+
     fn is_stake_call(tx: &MoveCall) -> bool {
         let package_id = match ObjectID::from_str(tx.package()) {
             Ok(id) => id,
@@ -784,6 +968,45 @@ impl Operations {
             && tx.module() == SUI_SYSTEM_MODULE_NAME.as_str()
             && (tx.function() == WITHDRAW_STAKE_FUN_NAME.as_str()
                 || tx.function() == "request_withdraw_stake_non_entry")
+    }
+
+    /// Recognizes `0x3::sui_system::convert_to_fungible_staked_sui` — the signature
+    /// MoveCall for `ConsolidateAllStakedSuiToFungible`.
+    fn is_convert_to_fss_call(tx: &MoveCall) -> bool {
+        let package_id = match ObjectID::from_str(tx.package()) {
+            Ok(id) => id,
+            Err(e) => {
+                warn!(
+                    package = tx.package(),
+                    error = %e,
+                    "Failed to parse package ID for MoveCall"
+                );
+                return false;
+            }
+        };
+        package_id == SUI_SYSTEM_PACKAGE_ID
+            && tx.module() == SUI_SYSTEM_MODULE_NAME.as_str()
+            && tx.function() == "convert_to_fungible_staked_sui"
+    }
+
+    /// Recognizes `0x3::staking_pool::join_fungible_staked_sui` — used by both
+    /// `ConsolidateAllStakedSuiToFungible` (for merging FSS) and
+    /// `MergeAndRedeemFungibleStakedSui` (PR 2).
+    fn is_join_fss_call(tx: &MoveCall) -> bool {
+        let package_id = match ObjectID::from_str(tx.package()) {
+            Ok(id) => id,
+            Err(e) => {
+                warn!(
+                    package = tx.package(),
+                    error = %e,
+                    "Failed to parse package ID for MoveCall"
+                );
+                return false;
+            }
+        };
+        package_id == SUI_SYSTEM_PACKAGE_ID
+            && tx.module() == "staking_pool"
+            && tx.function() == "join_fungible_staked_sui"
     }
 
     /// Recognizes `coin::redeem_funds<T>` calls used for address-balance withdrawals.
@@ -1267,7 +1490,12 @@ pub enum OperationMetadata {
         stake_ids: Vec<ObjectID>,
     },
     ConsolidateAllStakedSuiToFungible {
-        validator: SuiAddress,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        validator: Option<SuiAddress>,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        staked_sui_ids: Vec<ObjectID>,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        fss_ids: Vec<ObjectID>,
     },
     MergeAndRedeemFungibleStakedSui {
         validator: SuiAddress,
@@ -1399,10 +1627,40 @@ mod tests {
     use super::*;
     use crate::SUI;
     use crate::types::ConstructionMetadata;
+    use crate::types::internal_operation::consolidate_to_fungible_pt;
     use sui_rpc::proto::sui::rpc::v2::Transaction;
-    use sui_types::base_types::{ObjectDigest, ObjectID, SequenceNumber, SuiAddress};
+    use sui_types::Identifier;
+    use sui_types::base_types::{ObjectDigest, ObjectID, ObjectRef, SequenceNumber, SuiAddress};
     use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
-    use sui_types::transaction::{TEST_ONLY_GAS_UNIT_FOR_TRANSFER, TransactionData};
+    use sui_types::transaction::{
+        CallArg, Command as NativeCommand, ObjectArg, ProgrammableTransaction,
+        TEST_ONLY_GAS_UNIT_FOR_TRANSFER, TransactionData,
+    };
+
+    fn random_object_ref() -> ObjectRef {
+        (
+            ObjectID::random(),
+            SequenceNumber::from(1),
+            ObjectDigest::random(),
+        )
+    }
+
+    /// Parse a native `ProgrammableTransaction` via the proto pipeline.
+    /// Exact same conversion pattern used by `test_operation_data_parsing_pay_sui` at line 1637.
+    fn parse_pt(sender: SuiAddress, pt: ProgrammableTransaction) -> Vec<Operation> {
+        let gas = random_object_ref();
+        let gas_price = 10;
+        let data = TransactionData::new_programmable(
+            sender,
+            vec![gas],
+            pt,
+            TEST_ONLY_GAS_UNIT_FOR_TRANSFER * gas_price,
+            gas_price,
+        );
+        let proto_tx: Transaction = data.into();
+        let tx_kind = proto_tx.kind.expect("tx missing kind");
+        Operations::from_transaction(tx_kind, sender, None).expect("parse failed")
+    }
 
     #[tokio::test]
     async fn test_operation_data_parsing_pay_sui() -> Result<(), anyhow::Error> {
@@ -1609,5 +1867,406 @@ mod tests {
             }
             _ => panic!("Expected MergeAndRedeemFungibleStakedSui"),
         }
+    }
+
+    // ==============================================================================
+    // PR 1: Consolidate parser — happy-path tests (11 tests)
+    // ==============================================================================
+
+    fn assert_consolidate_ops(
+        ops: &[Operation],
+        expected_sender: SuiAddress,
+        expected_staked_sui: &[ObjectID],
+        expected_fss: &[ObjectID],
+    ) {
+        assert_eq!(ops.len(), 1);
+        let op = &ops[0];
+        assert_eq!(op.type_, OperationType::ConsolidateAllStakedSuiToFungible);
+        assert_eq!(
+            op.account.as_ref().map(|a| a.address),
+            Some(expected_sender)
+        );
+        assert!(op.amount.is_none());
+        let Some(OperationMetadata::ConsolidateAllStakedSuiToFungible {
+            validator,
+            staked_sui_ids,
+            fss_ids,
+        }) = op.metadata.clone()
+        else {
+            panic!("wrong metadata variant: {:?}", op.metadata);
+        };
+        assert!(validator.is_none(), "validator must be None on parse");
+        assert_eq!(staked_sui_ids, expected_staked_sui);
+        assert_eq!(fss_ids, expected_fss);
+    }
+
+    #[test]
+    fn test_parse_consolidate_pure_merge_2_fss() {
+        let sender = SuiAddress::random_for_testing_only();
+        let fss_a = random_object_ref();
+        let fss_b = random_object_ref();
+        let pt = consolidate_to_fungible_pt(sender, vec![fss_a, fss_b], vec![]).expect("pt");
+        let ops = parse_pt(sender, pt);
+        assert_consolidate_ops(&ops, sender, &[], &[fss_a.0, fss_b.0]);
+    }
+
+    #[test]
+    fn test_parse_consolidate_pure_merge_3_fss() {
+        let sender = SuiAddress::random_for_testing_only();
+        let a = random_object_ref();
+        let b = random_object_ref();
+        let c = random_object_ref();
+        let pt = consolidate_to_fungible_pt(sender, vec![a, b, c], vec![]).expect("pt");
+        assert_consolidate_ops(&parse_pt(sender, pt), sender, &[], &[a.0, b.0, c.0]);
+    }
+
+    #[test]
+    fn test_parse_consolidate_pure_merge_5_fss() {
+        let sender = SuiAddress::random_for_testing_only();
+        let refs: Vec<_> = (0..5).map(|_| random_object_ref()).collect();
+        let pt = consolidate_to_fungible_pt(sender, refs.clone(), vec![]).expect("pt");
+        let expected: Vec<_> = refs.iter().map(|r| r.0).collect();
+        assert_consolidate_ops(&parse_pt(sender, pt), sender, &[], &expected);
+    }
+
+    #[test]
+    fn test_parse_consolidate_single_convert_no_fss() {
+        let sender = SuiAddress::random_for_testing_only();
+        let staked = random_object_ref();
+        let pt = consolidate_to_fungible_pt(sender, vec![], vec![staked]).expect("pt");
+        assert_consolidate_ops(&parse_pt(sender, pt), sender, &[staked.0], &[]);
+    }
+
+    #[test]
+    fn test_parse_consolidate_multi_convert_no_fss() {
+        let sender = SuiAddress::random_for_testing_only();
+        let s1 = random_object_ref();
+        let s2 = random_object_ref();
+        let s3 = random_object_ref();
+        let pt = consolidate_to_fungible_pt(sender, vec![], vec![s1, s2, s3]).expect("pt");
+        assert_consolidate_ops(&parse_pt(sender, pt), sender, &[s1.0, s2.0, s3.0], &[]);
+    }
+
+    #[test]
+    fn test_parse_consolidate_single_stake_single_fss() {
+        let sender = SuiAddress::random_for_testing_only();
+        let fss = random_object_ref();
+        let staked = random_object_ref();
+        let pt = consolidate_to_fungible_pt(sender, vec![fss], vec![staked]).expect("pt");
+        assert_consolidate_ops(&parse_pt(sender, pt), sender, &[staked.0], &[fss.0]);
+    }
+
+    #[test]
+    fn test_parse_consolidate_single_stake_multi_fss() {
+        let sender = SuiAddress::random_for_testing_only();
+        let f1 = random_object_ref();
+        let f2 = random_object_ref();
+        let staked = random_object_ref();
+        let pt = consolidate_to_fungible_pt(sender, vec![f1, f2], vec![staked]).expect("pt");
+        assert_consolidate_ops(&parse_pt(sender, pt), sender, &[staked.0], &[f1.0, f2.0]);
+    }
+
+    #[test]
+    fn test_parse_consolidate_multi_stake_single_fss() {
+        let sender = SuiAddress::random_for_testing_only();
+        let fss = random_object_ref();
+        let s1 = random_object_ref();
+        let s2 = random_object_ref();
+        let pt = consolidate_to_fungible_pt(sender, vec![fss], vec![s1, s2]).expect("pt");
+        assert_consolidate_ops(&parse_pt(sender, pt), sender, &[s1.0, s2.0], &[fss.0]);
+    }
+
+    #[test]
+    fn test_parse_consolidate_multi_stake_multi_fss() {
+        let sender = SuiAddress::random_for_testing_only();
+        let f1 = random_object_ref();
+        let f2 = random_object_ref();
+        let s1 = random_object_ref();
+        let s2 = random_object_ref();
+        let pt = consolidate_to_fungible_pt(sender, vec![f1, f2], vec![s1, s2]).expect("pt");
+        assert_consolidate_ops(&parse_pt(sender, pt), sender, &[s1.0, s2.0], &[f1.0, f2.0]);
+    }
+
+    #[test]
+    fn test_parse_consolidate_large_mixed() {
+        let sender = SuiAddress::random_for_testing_only();
+        let fss: Vec<_> = (0..3).map(|_| random_object_ref()).collect();
+        let staked: Vec<_> = (0..3).map(|_| random_object_ref()).collect();
+        let pt = consolidate_to_fungible_pt(sender, fss.clone(), staked.clone()).expect("pt");
+        let expected_s: Vec<_> = staked.iter().map(|r| r.0).collect();
+        let expected_f: Vec<_> = fss.iter().map(|r| r.0).collect();
+        assert_consolidate_ops(&parse_pt(sender, pt), sender, &expected_s, &expected_f);
+    }
+
+    #[test]
+    fn test_parse_consolidate_classification_correctness() {
+        // No overlap between staked_sui_ids and fss_ids after parsing a mixed PTB.
+        let sender = SuiAddress::random_for_testing_only();
+        let f1 = random_object_ref();
+        let f2 = random_object_ref();
+        let s1 = random_object_ref();
+        let s2 = random_object_ref();
+        let pt = consolidate_to_fungible_pt(sender, vec![f1, f2], vec![s1, s2]).expect("pt");
+        let ops = parse_pt(sender, pt);
+        let Some(OperationMetadata::ConsolidateAllStakedSuiToFungible {
+            staked_sui_ids,
+            fss_ids,
+            ..
+        }) = ops[0].metadata.clone()
+        else {
+            panic!();
+        };
+        let staked_set: std::collections::HashSet<_> = staked_sui_ids.iter().collect();
+        let fss_set: std::collections::HashSet<_> = fss_ids.iter().collect();
+        assert!(
+            staked_set.is_disjoint(&fss_set),
+            "classification crossed categories"
+        );
+    }
+
+    // ==============================================================================
+    // PR 1: Fall-through tests (4 tests) — malformed PTBs must NOT be labeled Consolidate
+    // ==============================================================================
+
+    fn assert_falls_through_to_generic(ops: &[Operation]) {
+        assert_eq!(ops.len(), 1);
+        assert_eq!(
+            ops[0].type_,
+            OperationType::ProgrammableTransaction,
+            "expected fall-through to generic ProgrammableTransaction, got: {:?}",
+            ops[0].type_
+        );
+    }
+
+    #[test]
+    fn test_parse_falls_through_consolidate_with_merge_coins() {
+        let sender = SuiAddress::random_for_testing_only();
+        let fss_a = random_object_ref();
+        let fss_b = random_object_ref();
+        let coin_a = random_object_ref();
+
+        let mut builder = ProgrammableTransactionBuilder::new();
+        let _sys = builder.input(CallArg::SUI_SYSTEM_MUT).unwrap();
+        let first = builder.obj(ObjectArg::ImmOrOwnedObject(fss_a)).unwrap();
+        let other = builder.obj(ObjectArg::ImmOrOwnedObject(fss_b)).unwrap();
+        builder.command(NativeCommand::move_call(
+            SUI_SYSTEM_PACKAGE_ID,
+            Identifier::new("staking_pool").unwrap(),
+            Identifier::new("join_fungible_staked_sui").unwrap(),
+            vec![],
+            vec![first, other],
+        ));
+        // Rogue MergeCoins breaks Consolidate shape validation.
+        let coin_target = builder.obj(ObjectArg::ImmOrOwnedObject(coin_a)).unwrap();
+        builder.command(NativeCommand::MergeCoins(coin_target, vec![]));
+
+        let ops = parse_pt(sender, builder.finish());
+        assert_falls_through_to_generic(&ops);
+    }
+
+    #[test]
+    fn test_parse_falls_through_consolidate_with_unrelated_movecall() {
+        let sender = SuiAddress::random_for_testing_only();
+        let fss_a = random_object_ref();
+        let fss_b = random_object_ref();
+
+        let mut builder = ProgrammableTransactionBuilder::new();
+        let _sys = builder.input(CallArg::SUI_SYSTEM_MUT).unwrap();
+        let first = builder.obj(ObjectArg::ImmOrOwnedObject(fss_a)).unwrap();
+        let other = builder.obj(ObjectArg::ImmOrOwnedObject(fss_b)).unwrap();
+        builder.command(NativeCommand::move_call(
+            SUI_SYSTEM_PACKAGE_ID,
+            Identifier::new("staking_pool").unwrap(),
+            Identifier::new("join_fungible_staked_sui").unwrap(),
+            vec![],
+            vec![first, other],
+        ));
+        // Unrelated MoveCall (e.g., 0x2::sui::transfer doesn't exist, so use any other function).
+        builder.command(NativeCommand::move_call(
+            SUI_FRAMEWORK_PACKAGE_ID,
+            Identifier::new("coin").unwrap(),
+            Identifier::new("destroy_zero").unwrap(),
+            vec![],
+            vec![other],
+        ));
+
+        let ops = parse_pt(sender, builder.finish());
+        assert_falls_through_to_generic(&ops);
+    }
+
+    #[test]
+    fn test_parse_falls_through_convert_without_system_state() {
+        // Build a PTB where inputs[0] is an ImmOrOwned object (not SUI_SYSTEM_STATE shared).
+        let sender = SuiAddress::random_for_testing_only();
+        let staked = random_object_ref();
+        let other_obj = random_object_ref();
+
+        let mut builder = ProgrammableTransactionBuilder::new();
+        // Put a random object first — parser should reject.
+        let _not_system = builder.obj(ObjectArg::ImmOrOwnedObject(other_obj)).unwrap();
+        let staked_arg = builder.obj(ObjectArg::ImmOrOwnedObject(staked)).unwrap();
+        let sys = builder.input(CallArg::SUI_SYSTEM_MUT).unwrap();
+        let new_fss = builder.command(NativeCommand::move_call(
+            SUI_SYSTEM_PACKAGE_ID,
+            Identifier::new("sui_system").unwrap(),
+            Identifier::new("convert_to_fungible_staked_sui").unwrap(),
+            vec![],
+            vec![sys, staked_arg],
+        ));
+        let sender_arg = builder.pure(sender).unwrap();
+        builder.command(NativeCommand::TransferObjects(vec![new_fss], sender_arg));
+
+        let ops = parse_pt(sender, builder.finish());
+        assert_falls_through_to_generic(&ops);
+    }
+
+    #[test]
+    fn test_parse_falls_through_extra_command_after_transfer() {
+        // Valid Consolidate shape + an extra command after TransferObjects → reject.
+        let sender = SuiAddress::random_for_testing_only();
+        let staked = random_object_ref();
+        let other_obj = random_object_ref();
+
+        let mut builder = ProgrammableTransactionBuilder::new();
+        let sys = builder.input(CallArg::SUI_SYSTEM_MUT).unwrap();
+        let staked_arg = builder.obj(ObjectArg::ImmOrOwnedObject(staked)).unwrap();
+        let new_fss = builder.command(NativeCommand::move_call(
+            SUI_SYSTEM_PACKAGE_ID,
+            Identifier::new("sui_system").unwrap(),
+            Identifier::new("convert_to_fungible_staked_sui").unwrap(),
+            vec![],
+            vec![sys, staked_arg],
+        ));
+        let sender_arg = builder.pure(sender).unwrap();
+        builder.command(NativeCommand::TransferObjects(vec![new_fss], sender_arg));
+        // Extra command: destroy_zero on an unrelated coin.
+        let extra = builder.obj(ObjectArg::ImmOrOwnedObject(other_obj)).unwrap();
+        builder.command(NativeCommand::move_call(
+            SUI_FRAMEWORK_PACKAGE_ID,
+            Identifier::new("coin").unwrap(),
+            Identifier::new("destroy_zero").unwrap(),
+            vec![],
+            vec![extra],
+        ));
+
+        let ops = parse_pt(sender, builder.finish());
+        assert_falls_through_to_generic(&ops);
+    }
+
+    // ==============================================================================
+    // PR 1: Robustness tests (4 tests, but #38-39 belong in e2e — see plan)
+    // ==============================================================================
+
+    #[test]
+    fn test_parse_empty_ptb() {
+        let sender = SuiAddress::random_for_testing_only();
+        let pt = ProgrammableTransactionBuilder::new().finish();
+        let ops = parse_pt(sender, pt);
+        // Zero commands: parser should produce a generic op (existing behavior).
+        assert_eq!(ops.len(), 1);
+        assert_eq!(ops[0].type_, OperationType::ProgrammableTransaction);
+    }
+
+    #[test]
+    fn test_parse_only_merge_coins() {
+        // PTB with only regular MergeCoins (non-FSS) — falls through, unrelated to our dispatch.
+        let sender = SuiAddress::random_for_testing_only();
+        let coin_a = random_object_ref();
+        let coin_b = random_object_ref();
+        let mut builder = ProgrammableTransactionBuilder::new();
+        let target = builder.obj(ObjectArg::ImmOrOwnedObject(coin_a)).unwrap();
+        let source = builder.obj(ObjectArg::ImmOrOwnedObject(coin_b)).unwrap();
+        builder.command(NativeCommand::MergeCoins(target, vec![source]));
+        let ops = parse_pt(sender, builder.finish());
+        // Either ProgrammableTransaction (generic) or whatever the existing parser produces.
+        // Not our typed FSS op.
+        assert_ne!(
+            ops[0].type_,
+            OperationType::ConsolidateAllStakedSuiToFungible
+        );
+        assert_ne!(ops[0].type_, OperationType::MergeAndRedeemFungibleStakedSui);
+    }
+
+    // Tests #38 (garbage bytes) and #39 (truncated tx data) are HTTP-level and belong in
+    // end_to_end_tests.rs — see plan section D.
+
+    // ==============================================================================
+    // PR 1: Metadata serialization compat (2 tests)
+    // ==============================================================================
+
+    #[test]
+    fn test_meta_consolidate_old_input_deserializes() {
+        let validator = SuiAddress::random_for_testing_only();
+        let json = serde_json::json!({
+            "ConsolidateAllStakedSuiToFungible": { "validator": validator.to_string() }
+        });
+        let meta: OperationMetadata = serde_json::from_value(json).unwrap();
+        match meta {
+            OperationMetadata::ConsolidateAllStakedSuiToFungible {
+                validator: v,
+                staked_sui_ids,
+                fss_ids,
+            } => {
+                assert_eq!(v, Some(validator));
+                assert!(staked_sui_ids.is_empty());
+                assert!(fss_ids.is_empty());
+            }
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[test]
+    fn test_meta_consolidate_new_parse_output_serializes() {
+        let id_a = ObjectID::random();
+        let id_b = ObjectID::random();
+        let meta = OperationMetadata::ConsolidateAllStakedSuiToFungible {
+            validator: None,
+            staked_sui_ids: vec![id_a],
+            fss_ids: vec![id_b],
+        };
+        let json = serde_json::to_value(&meta).unwrap();
+        let obj = json
+            .as_object()
+            .unwrap()
+            .get("ConsolidateAllStakedSuiToFungible")
+            .unwrap()
+            .as_object()
+            .unwrap();
+        assert!(
+            !obj.contains_key("validator"),
+            "validator must be omitted when None"
+        );
+        assert_eq!(
+            obj.get("staked_sui_ids").unwrap().as_array().unwrap().len(),
+            1
+        );
+        assert_eq!(obj.get("fss_ids").unwrap().as_array().unwrap().len(), 1);
+    }
+
+    // ==============================================================================
+    // PR 1: Write-side preservation (1 test)
+    // ==============================================================================
+
+    #[test]
+    fn test_write_consolidate_requires_validator() {
+        let sender = SuiAddress::random_for_testing_only();
+        let op = Operation {
+            operation_identifier: Default::default(),
+            type_: OperationType::ConsolidateAllStakedSuiToFungible,
+            status: None,
+            account: Some(sender.into()),
+            amount: None,
+            coin_change: None,
+            metadata: Some(OperationMetadata::ConsolidateAllStakedSuiToFungible {
+                validator: None,
+                staked_sui_ids: vec![],
+                fss_ids: vec![],
+            }),
+        };
+        let err = Operations::new(vec![op])
+            .into_internal()
+            .expect_err("should fail without validator");
+        let msg = format!("{err}");
+        assert!(msg.contains("validator"), "unexpected error: {msg}");
     }
 }

--- a/crates/sui-rosetta/src/types/internal_operation.rs
+++ b/crates/sui-rosetta/src/types/internal_operation.rs
@@ -32,10 +32,10 @@ use sui_types::transaction::{
 use crate::errors::Error;
 use crate::types::ConstructionMetadata;
 pub use consolidate_to_fungible::ConsolidateAllStakedSuiToFungible;
-use consolidate_to_fungible::consolidate_to_fungible_pt;
+pub(crate) use consolidate_to_fungible::consolidate_to_fungible_pt;
 pub(crate) use consolidate_to_fungible::get_validator_pool_id;
 pub use merge_and_redeem::MergeAndRedeemFungibleStakedSui;
-use merge_and_redeem::merge_and_redeem_fss_pt;
+pub(crate) use merge_and_redeem::merge_and_redeem_fss_pt;
 pub use pay_coin::PayCoin;
 pub(crate) use pay_coin::pay_coin_pt;
 pub use pay_sui::PaySui;

--- a/crates/sui-rosetta/tests/end_to_end_tests.rs
+++ b/crates/sui-rosetta/tests/end_to_end_tests.rs
@@ -4014,3 +4014,1134 @@ async fn test_redeem_invalid_validator() {
         flow_result.metadata
     );
 }
+
+// ================================================================================
+// PR 1 e2e tests — ConsolidateAllStakedSuiToFungible parser
+// ================================================================================
+
+#[derive(serde::Deserialize)]
+struct ParseResp {
+    operations: Operations,
+    #[allow(dead_code)]
+    account_identifier_signers: Vec<AccountIdentifier>,
+}
+
+/// POST unsigned TX bytes to /construction/parse (offline endpoint).
+/// Note: SuiEnv serializes as lowercase (e.g., `localnet`), not `LocalNet`.
+async fn parse_unsigned(
+    rosetta_client: &rosetta_client::RosettaClient,
+    unsigned_tx: impl serde::Serialize,
+) -> ParseResp {
+    let request = serde_json::json!({
+        "network_identifier": {
+            "blockchain": "sui",
+            "network": serde_json::to_value(SuiEnv::LocalNet).unwrap(),
+        },
+        "signed": false,
+        "transaction": serde_json::to_value(&unsigned_tx).unwrap(),
+    });
+    rosetta_client
+        .call(rosetta_client::RosettaEndpoint::Parse, &request)
+        .await
+        .expect("parse failed")
+}
+
+async fn first_validator(client: &mut GrpcClient) -> SuiAddress {
+    let request = GetEpochRequest::latest().with_read_mask(FieldMask::from_paths(["system_state"]));
+    let response = client
+        .clone()
+        .ledger_client()
+        .get_epoch(request)
+        .await
+        .unwrap()
+        .into_inner();
+    response
+        .epoch
+        .and_then(|e| e.system_state)
+        .unwrap()
+        .validators
+        .unwrap()
+        .active_validators[0]
+        .address()
+        .parse()
+        .unwrap()
+}
+
+/// Stake `amount_mist` SUI with `validator` via the Rosetta flow.
+async fn stake_via_rosetta(
+    rosetta_client: &rosetta_client::RosettaClient,
+    client: &mut GrpcClient,
+    keystore: &sui_keys::keystore::Keystore,
+    sender: SuiAddress,
+    validator: SuiAddress,
+    amount_mist: u64,
+) {
+    let ops = serde_json::from_value(json!([{
+        "operation_identifier":{"index":0},
+        "type":"Stake",
+        "account": { "address": sender.to_string() },
+        "amount": { "value": format!("-{}", amount_mist) },
+        "metadata": { "Stake": {"validator": validator.to_string()} }
+    }]))
+    .unwrap();
+    let resp: TransactionIdentifierResponse = rosetta_client
+        .rosetta_flow(&ops, keystore, None)
+        .await
+        .submit
+        .unwrap()
+        .unwrap();
+    wait_for_transaction(client, &resp.transaction_identifier.hash.to_string())
+        .await
+        .unwrap();
+}
+
+/// Convert every owned `StakedSui` to a `FungibleStakedSui` via a direct PTB.
+/// Requires epoch to already be advanced so stakes are activated.
+async fn convert_all_staked_to_fss_directly(
+    client: &mut GrpcClient,
+    keystore: &sui_keys::keystore::Keystore,
+    sender: SuiAddress,
+) {
+    use futures::TryStreamExt;
+    use sui_rpc::proto::sui::rpc::v2::ListOwnedObjectsRequest;
+
+    let staked_req = ListOwnedObjectsRequest::default()
+        .with_owner(sender.to_string())
+        .with_object_type("0x3::staking_pool::StakedSui".to_string())
+        .with_page_size(100u32)
+        .with_read_mask(FieldMask::from_paths(["object_id", "version", "digest"]));
+    let staked_objs: Vec<_> = client
+        .clone()
+        .list_owned_objects(staked_req)
+        .try_collect()
+        .await
+        .unwrap();
+
+    for staked_obj in &staked_objs {
+        let staked_ref = (
+            ObjectID::from_str(staked_obj.object_id()).unwrap(),
+            staked_obj.version().into(),
+            staked_obj.digest().parse().unwrap(),
+        );
+        let gas_price = client.get_reference_gas_price().await.unwrap();
+        let coins = get_all_coins(&mut client.clone(), sender).await.unwrap();
+        let gas_object = get_object_ref(&mut client.clone(), coins[0].id())
+            .await
+            .unwrap()
+            .as_object_ref();
+
+        let mut ptb = ProgrammableTransactionBuilder::new();
+        let sys = ptb.input(CallArg::SUI_SYSTEM_MUT).unwrap();
+        let staked_arg = ptb.obj(ObjectArg::ImmOrOwnedObject(staked_ref)).unwrap();
+        let fss_result = ptb.command(Command::move_call(
+            SUI_SYSTEM_PACKAGE_ID,
+            SUI_SYSTEM_MODULE_NAME.to_owned(),
+            Identifier::new("convert_to_fungible_staked_sui").unwrap(),
+            vec![],
+            vec![sys, staked_arg],
+        ));
+        let sender_arg = ptb.pure(sender).unwrap();
+        ptb.command(Command::TransferObjects(vec![fss_result], sender_arg));
+
+        let tx_data = TransactionData::new_programmable(
+            sender,
+            vec![gas_object],
+            ptb.finish(),
+            1_000_000_000,
+            gas_price,
+        );
+        let tx = to_sender_signed_transaction(tx_data, keystore.export(&sender).unwrap());
+        execute_transaction(&mut client.clone(), &tx).await.unwrap();
+    }
+}
+
+/// S=1, F=0 — single StakedSui conversion, no pre-existing FSS.
+#[tokio::test]
+async fn test_e2e_parse_consolidate_1_stake_0_fss() {
+    let test_cluster = TestClusterBuilder::new().build().await;
+    let sender = test_cluster.get_address_0();
+    let keystore = &test_cluster.wallet.config.keystore;
+    let mut client = GrpcClient::new(test_cluster.rpc_url()).unwrap();
+    let (rosetta_client, _handle) = start_rosetta_test_server(client.clone()).await;
+
+    let validator = first_validator(&mut client).await;
+    stake_via_rosetta(
+        &rosetta_client,
+        &mut client,
+        keystore,
+        sender,
+        validator,
+        1_000_000_000,
+    )
+    .await;
+    test_cluster.trigger_reconfiguration().await;
+
+    let consolidate_ops = serde_json::from_value(json!([{
+        "operation_identifier": {"index": 0},
+        "type": "ConsolidateAllStakedSuiToFungible",
+        "account": {"address": sender.to_string()},
+        "metadata": {
+            "ConsolidateAllStakedSuiToFungible": {"validator": validator.to_string()}
+        }
+    }]))
+    .unwrap();
+    let flow = rosetta_client
+        .rosetta_flow(&consolidate_ops, keystore, None)
+        .await;
+    let payloads = flow.payloads.expect("payloads").expect("payloads errored");
+    let parsed = parse_unsigned(&rosetta_client, &payloads.unsigned_transaction).await;
+
+    let ops: Vec<_> = parsed.operations.into_iter().collect();
+    assert_eq!(ops.len(), 1);
+    assert_eq!(
+        ops[0].type_,
+        OperationType::ConsolidateAllStakedSuiToFungible
+    );
+    assert_eq!(ops[0].account.as_ref().unwrap().address, sender);
+    let Some(sui_rosetta::operations::OperationMetadata::ConsolidateAllStakedSuiToFungible {
+        validator: v,
+        staked_sui_ids,
+        fss_ids,
+    }) = ops[0].metadata.clone()
+    else {
+        panic!("wrong metadata variant");
+    };
+    assert!(v.is_none(), "validator must be None from parser");
+    assert_eq!(staked_sui_ids.len(), 1);
+    assert!(fss_ids.is_empty());
+}
+
+/// S=0, F=2 — pure FSS merge (no conversion).
+#[tokio::test]
+async fn test_e2e_parse_consolidate_0_stakes_2_fss() {
+    let test_cluster = TestClusterBuilder::new().build().await;
+    let sender = test_cluster.get_address_0();
+    let keystore = &test_cluster.wallet.config.keystore;
+    let mut client = GrpcClient::new(test_cluster.rpc_url()).unwrap();
+    let (rosetta_client, _handle) = start_rosetta_test_server(client.clone()).await;
+
+    let validator = first_validator(&mut client).await;
+    // Stake twice, advance epoch, convert both to FSS.
+    stake_via_rosetta(
+        &rosetta_client,
+        &mut client,
+        keystore,
+        sender,
+        validator,
+        1_000_000_000,
+    )
+    .await;
+    stake_via_rosetta(
+        &rosetta_client,
+        &mut client,
+        keystore,
+        sender,
+        validator,
+        1_000_000_000,
+    )
+    .await;
+    test_cluster.trigger_reconfiguration().await;
+    convert_all_staked_to_fss_directly(&mut client, keystore, sender).await;
+
+    let consolidate_ops = serde_json::from_value(json!([{
+        "operation_identifier": {"index": 0},
+        "type": "ConsolidateAllStakedSuiToFungible",
+        "account": {"address": sender.to_string()},
+        "metadata": {
+            "ConsolidateAllStakedSuiToFungible": {"validator": validator.to_string()}
+        }
+    }]))
+    .unwrap();
+    let flow = rosetta_client
+        .rosetta_flow(&consolidate_ops, keystore, None)
+        .await;
+    let payloads = flow.payloads.expect("payloads").expect("payloads errored");
+    let parsed = parse_unsigned(&rosetta_client, &payloads.unsigned_transaction).await;
+
+    let ops: Vec<_> = parsed.operations.into_iter().collect();
+    assert_eq!(ops.len(), 1);
+    assert_eq!(
+        ops[0].type_,
+        OperationType::ConsolidateAllStakedSuiToFungible
+    );
+    let Some(sui_rosetta::operations::OperationMetadata::ConsolidateAllStakedSuiToFungible {
+        staked_sui_ids,
+        fss_ids,
+        ..
+    }) = ops[0].metadata.clone()
+    else {
+        panic!();
+    };
+    assert!(
+        staked_sui_ids.is_empty(),
+        "pure merge should have no StakedSui IDs"
+    );
+    assert_eq!(fss_ids.len(), 2);
+}
+
+/// S=1, F=1 — mixed case: 1 stake + 1 pre-existing FSS, cross-merge path.
+#[tokio::test]
+async fn test_e2e_parse_consolidate_1_stake_1_fss() {
+    let test_cluster = TestClusterBuilder::new().build().await;
+    let sender = test_cluster.get_address_0();
+    let keystore = &test_cluster.wallet.config.keystore;
+    let mut client = GrpcClient::new(test_cluster.rpc_url()).unwrap();
+    let (rosetta_client, _handle) = start_rosetta_test_server(client.clone()).await;
+
+    let validator = first_validator(&mut client).await;
+    // Stake 1, advance, convert to FSS (= 1 FSS, 0 stakes).
+    stake_via_rosetta(
+        &rosetta_client,
+        &mut client,
+        keystore,
+        sender,
+        validator,
+        1_000_000_000,
+    )
+    .await;
+    test_cluster.trigger_reconfiguration().await;
+    convert_all_staked_to_fss_directly(&mut client, keystore, sender).await;
+    // Stake again, advance again. Now we have 1 activated stake + 1 FSS.
+    stake_via_rosetta(
+        &rosetta_client,
+        &mut client,
+        keystore,
+        sender,
+        validator,
+        1_000_000_000,
+    )
+    .await;
+    test_cluster.trigger_reconfiguration().await;
+
+    let consolidate_ops = serde_json::from_value(json!([{
+        "operation_identifier": {"index": 0},
+        "type": "ConsolidateAllStakedSuiToFungible",
+        "account": {"address": sender.to_string()},
+        "metadata": {
+            "ConsolidateAllStakedSuiToFungible": {"validator": validator.to_string()}
+        }
+    }]))
+    .unwrap();
+    let flow = rosetta_client
+        .rosetta_flow(&consolidate_ops, keystore, None)
+        .await;
+    let payloads = flow.payloads.expect("payloads").expect("payloads errored");
+    let parsed = parse_unsigned(&rosetta_client, &payloads.unsigned_transaction).await;
+
+    let ops: Vec<_> = parsed.operations.into_iter().collect();
+    let Some(sui_rosetta::operations::OperationMetadata::ConsolidateAllStakedSuiToFungible {
+        staked_sui_ids,
+        fss_ids,
+        ..
+    }) = ops[0].metadata.clone()
+    else {
+        panic!();
+    };
+    assert_eq!(staked_sui_ids.len(), 1);
+    assert_eq!(fss_ids.len(), 1);
+}
+
+/// Submit + wait, then verify the block/transaction endpoint exposes the typed op.
+#[tokio::test]
+async fn test_e2e_block_consolidate_1_stake_0_fss() {
+    let test_cluster = TestClusterBuilder::new().build().await;
+    let sender = test_cluster.get_address_0();
+    let keystore = &test_cluster.wallet.config.keystore;
+    let mut client = GrpcClient::new(test_cluster.rpc_url()).unwrap();
+    let (rosetta_client, _handle) = start_rosetta_test_server(client.clone()).await;
+
+    let validator = first_validator(&mut client).await;
+    stake_via_rosetta(
+        &rosetta_client,
+        &mut client,
+        keystore,
+        sender,
+        validator,
+        1_000_000_000,
+    )
+    .await;
+    test_cluster.trigger_reconfiguration().await;
+
+    let consolidate_ops = serde_json::from_value(json!([{
+        "operation_identifier": {"index": 0},
+        "type": "ConsolidateAllStakedSuiToFungible",
+        "account": {"address": sender.to_string()},
+        "metadata": {
+            "ConsolidateAllStakedSuiToFungible": {"validator": validator.to_string()}
+        }
+    }]))
+    .unwrap();
+    let submit_resp: TransactionIdentifierResponse = rosetta_client
+        .rosetta_flow(&consolidate_ops, keystore, None)
+        .await
+        .submit
+        .unwrap()
+        .unwrap();
+    let tx_hash = submit_resp.transaction_identifier.hash.to_string();
+    wait_for_transaction(&mut client, &tx_hash).await.unwrap();
+
+    // Read back the executed TX and reparse through the same code path.
+    let get_tx = GetTransactionRequest::default()
+        .with_digest(tx_hash.clone())
+        .with_read_mask(FieldMask::from_paths([
+            "transaction",
+            "effects",
+            "events",
+            "balance_changes",
+        ]));
+    let executed = client
+        .clone()
+        .ledger_client()
+        .get_transaction(get_tx)
+        .await
+        .unwrap()
+        .into_inner();
+    let cache = CoinMetadataCache::new(client.clone(), NonZeroUsize::new(100).unwrap());
+    let ops = Operations::try_from_executed_transaction(executed.transaction.unwrap(), &cache)
+        .await
+        .unwrap();
+    let ops_vec: Vec<_> = ops.into_iter().collect();
+    let typed = ops_vec
+        .iter()
+        .find(|o| o.type_ == OperationType::ConsolidateAllStakedSuiToFungible)
+        .expect("expected typed Consolidate op");
+    assert_eq!(typed.account.as_ref().unwrap().address, sender);
+    // Also confirm a Gas op is present.
+    assert!(ops_vec.iter().any(|o| o.type_ == OperationType::Gas));
+    // And NO SuiBalanceChange for sender (Consolidate is object-only, no net SUI delta).
+    let sender_balance_changes: Vec<_> = ops_vec
+        .iter()
+        .filter(|o| {
+            o.type_ == OperationType::SuiBalanceChange
+                && o.account.as_ref().map(|a| a.address) == Some(sender)
+        })
+        .collect();
+    assert!(
+        sender_balance_changes.is_empty(),
+        "Consolidate should have no SuiBalanceChange for sender, got {:?}",
+        sender_balance_changes
+    );
+}
+
+/// Invalid validator address (not in active set) should error at /metadata.
+#[tokio::test]
+async fn test_e2e_consolidate_errors_invalid_validator() {
+    let test_cluster = TestClusterBuilder::new().build().await;
+    let sender = test_cluster.get_address_0();
+    let keystore = &test_cluster.wallet.config.keystore;
+    let client = GrpcClient::new(test_cluster.rpc_url()).unwrap();
+    let (rosetta_client, _handle) = start_rosetta_test_server(client).await;
+
+    let fake_validator = SuiAddress::random_for_testing_only();
+    let ops = serde_json::from_value(json!([{
+        "operation_identifier": {"index": 0},
+        "type": "ConsolidateAllStakedSuiToFungible",
+        "account": {"address": sender.to_string()},
+        "metadata": {
+            "ConsolidateAllStakedSuiToFungible": {"validator": fake_validator.to_string()}
+        }
+    }]))
+    .unwrap();
+    let flow = rosetta_client.rosetta_flow(&ops, keystore, None).await;
+    assert!(
+        flow.metadata.as_ref().is_some_and(|r| r.is_err()),
+        "Expected metadata error for invalid validator, got: {:?}",
+        flow.metadata
+    );
+}
+
+/// Submitting a Consolidate op without the validator field should NOT produce a valid
+/// preprocess response. Note: the test helper's `RosettaAPIResult` untagged enum may
+/// deserialize a server error response as an empty-Ok (since `ConstructionPreprocessResponse`
+/// has all-optional fields), so we accept either an explicit `Err` OR an `Ok` with no
+/// `options` / `required_public_keys` as evidence of rejection.
+#[tokio::test]
+async fn test_e2e_consolidate_errors_missing_validator_in_metadata() {
+    let test_cluster = TestClusterBuilder::new().build().await;
+    let sender = test_cluster.get_address_0();
+    let keystore = &test_cluster.wallet.config.keystore;
+    let client = GrpcClient::new(test_cluster.rpc_url()).unwrap();
+    let (rosetta_client, _handle) = start_rosetta_test_server(client).await;
+
+    let ops = serde_json::from_value(json!([{
+        "operation_identifier": {"index": 0},
+        "type": "ConsolidateAllStakedSuiToFungible",
+        "account": {"address": sender.to_string()},
+        "metadata": {
+            "ConsolidateAllStakedSuiToFungible": {}
+        }
+    }]))
+    .unwrap();
+    let flow = rosetta_client.rosetta_flow(&ops, keystore, None).await;
+    let preprocess = flow.preprocess.as_ref().expect("preprocess attempted");
+    match preprocess {
+        Err(_) => { /* expected */ }
+        Ok(resp) => {
+            // Masked error: options must be None AND required_public_keys empty.
+            assert!(
+                resp.options.is_none() && resp.required_public_keys.is_empty(),
+                "expected rejection for missing validator, got success: {:?}",
+                resp
+            );
+        }
+    }
+}
+
+/// Garbage bytes to /construction/parse should return an error response, not panic.
+/// Note: the test helper's untagged `RosettaAPIResult` with `T = serde_json::Value` will
+/// accept ANY JSON as `Ok`. We look for Rosetta error shape (a `code` field) instead.
+#[tokio::test]
+async fn test_e2e_parse_garbage_bytes() {
+    let test_cluster = TestClusterBuilder::new().build().await;
+    let client = GrpcClient::new(test_cluster.rpc_url()).unwrap();
+    let (rosetta_client, _handle) = start_rosetta_test_server(client).await;
+
+    let request = serde_json::json!({
+        "network_identifier": {
+            "blockchain": "sui",
+            "network": serde_json::to_value(SuiEnv::LocalNet).unwrap(),
+        },
+        "signed": false,
+        "transaction": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+    });
+    let result: Result<serde_json::Value, _> = rosetta_client
+        .call(rosetta_client::RosettaEndpoint::Parse, &request)
+        .await;
+    let json = match result {
+        Ok(v) => v,
+        Err(e) => serde_json::to_value(e.code).unwrap_or_default(),
+    };
+    let has_error_shape = json.get("code").is_some() || json.get("message").is_some();
+    assert!(
+        has_error_shape,
+        "expected Rosetta error response for garbage bytes, got: {:?}",
+        json
+    );
+}
+
+/// Truncated TX bytes to /construction/parse should return an error response, not panic.
+#[tokio::test]
+async fn test_e2e_parse_truncated_tx_data() {
+    let test_cluster = TestClusterBuilder::new().build().await;
+    let client = GrpcClient::new(test_cluster.rpc_url()).unwrap();
+    let (rosetta_client, _handle) = start_rosetta_test_server(client).await;
+
+    let request = serde_json::json!({
+        "network_identifier": {
+            "blockchain": "sui",
+            "network": serde_json::to_value(SuiEnv::LocalNet).unwrap(),
+        },
+        "signed": false,
+        "transaction": "00",
+    });
+    let result: Result<serde_json::Value, _> = rosetta_client
+        .call(rosetta_client::RosettaEndpoint::Parse, &request)
+        .await;
+    let json = match result {
+        Ok(v) => v,
+        Err(e) => serde_json::to_value(e.code).unwrap_or_default(),
+    };
+    let has_error_shape = json.get("code").is_some() || json.get("message").is_some();
+    assert!(
+        has_error_shape,
+        "expected Rosetta error response for truncated bytes, got: {:?}",
+        json
+    );
+}
+
+/// S=3, F=0 — 3 stakes, no pre-existing FSS.
+#[tokio::test]
+async fn test_e2e_parse_consolidate_3_stakes_0_fss() {
+    let test_cluster = TestClusterBuilder::new().build().await;
+    let sender = test_cluster.get_address_0();
+    let keystore = &test_cluster.wallet.config.keystore;
+    let mut client = GrpcClient::new(test_cluster.rpc_url()).unwrap();
+    let (rosetta_client, _handle) = start_rosetta_test_server(client.clone()).await;
+
+    let validator = first_validator(&mut client).await;
+    for _ in 0..3 {
+        stake_via_rosetta(
+            &rosetta_client,
+            &mut client,
+            keystore,
+            sender,
+            validator,
+            1_000_000_000,
+        )
+        .await;
+    }
+    test_cluster.trigger_reconfiguration().await;
+
+    let consolidate_ops = serde_json::from_value(json!([{
+        "operation_identifier": {"index": 0},
+        "type": "ConsolidateAllStakedSuiToFungible",
+        "account": {"address": sender.to_string()},
+        "metadata": {
+            "ConsolidateAllStakedSuiToFungible": {"validator": validator.to_string()}
+        }
+    }]))
+    .unwrap();
+    let flow = rosetta_client
+        .rosetta_flow(&consolidate_ops, keystore, None)
+        .await;
+    let payloads = flow.payloads.expect("payloads").expect("payloads errored");
+    let parsed = parse_unsigned(&rosetta_client, &payloads.unsigned_transaction).await;
+
+    let ops: Vec<_> = parsed.operations.into_iter().collect();
+    assert_eq!(ops.len(), 1);
+    assert_eq!(
+        ops[0].type_,
+        OperationType::ConsolidateAllStakedSuiToFungible
+    );
+    let Some(sui_rosetta::operations::OperationMetadata::ConsolidateAllStakedSuiToFungible {
+        staked_sui_ids,
+        fss_ids,
+        ..
+    }) = ops[0].metadata.clone()
+    else {
+        panic!();
+    };
+    assert_eq!(staked_sui_ids.len(), 3);
+    assert!(fss_ids.is_empty());
+}
+
+/// S=0, F=3 — three pre-existing FSS, pure merge.
+#[tokio::test]
+async fn test_e2e_parse_consolidate_0_stakes_3_fss() {
+    let test_cluster = TestClusterBuilder::new().build().await;
+    let sender = test_cluster.get_address_0();
+    let keystore = &test_cluster.wallet.config.keystore;
+    let mut client = GrpcClient::new(test_cluster.rpc_url()).unwrap();
+    let (rosetta_client, _handle) = start_rosetta_test_server(client.clone()).await;
+
+    let validator = first_validator(&mut client).await;
+    for _ in 0..3 {
+        stake_via_rosetta(
+            &rosetta_client,
+            &mut client,
+            keystore,
+            sender,
+            validator,
+            1_000_000_000,
+        )
+        .await;
+    }
+    test_cluster.trigger_reconfiguration().await;
+    convert_all_staked_to_fss_directly(&mut client, keystore, sender).await;
+
+    let consolidate_ops = serde_json::from_value(json!([{
+        "operation_identifier": {"index": 0},
+        "type": "ConsolidateAllStakedSuiToFungible",
+        "account": {"address": sender.to_string()},
+        "metadata": {
+            "ConsolidateAllStakedSuiToFungible": {"validator": validator.to_string()}
+        }
+    }]))
+    .unwrap();
+    let flow = rosetta_client
+        .rosetta_flow(&consolidate_ops, keystore, None)
+        .await;
+    let payloads = flow.payloads.expect("payloads").expect("payloads errored");
+    let parsed = parse_unsigned(&rosetta_client, &payloads.unsigned_transaction).await;
+
+    let ops: Vec<_> = parsed.operations.into_iter().collect();
+    let Some(sui_rosetta::operations::OperationMetadata::ConsolidateAllStakedSuiToFungible {
+        staked_sui_ids,
+        fss_ids,
+        ..
+    }) = ops[0].metadata.clone()
+    else {
+        panic!();
+    };
+    assert!(staked_sui_ids.is_empty());
+    assert_eq!(fss_ids.len(), 3);
+}
+
+/// S=2, F=2 — full flow with both existing FSS and activated StakedSui.
+#[tokio::test]
+async fn test_e2e_parse_consolidate_2_stakes_2_fss() {
+    let test_cluster = TestClusterBuilder::new().build().await;
+    let sender = test_cluster.get_address_0();
+    let keystore = &test_cluster.wallet.config.keystore;
+    let mut client = GrpcClient::new(test_cluster.rpc_url()).unwrap();
+    let (rosetta_client, _handle) = start_rosetta_test_server(client.clone()).await;
+
+    let validator = first_validator(&mut client).await;
+    // First: stake twice, advance, convert to 2 FSS.
+    stake_via_rosetta(
+        &rosetta_client,
+        &mut client,
+        keystore,
+        sender,
+        validator,
+        1_000_000_000,
+    )
+    .await;
+    stake_via_rosetta(
+        &rosetta_client,
+        &mut client,
+        keystore,
+        sender,
+        validator,
+        1_000_000_000,
+    )
+    .await;
+    test_cluster.trigger_reconfiguration().await;
+    convert_all_staked_to_fss_directly(&mut client, keystore, sender).await;
+    // Then: stake twice more, advance, leaving 2 activated stakes + 2 FSS.
+    stake_via_rosetta(
+        &rosetta_client,
+        &mut client,
+        keystore,
+        sender,
+        validator,
+        1_000_000_000,
+    )
+    .await;
+    stake_via_rosetta(
+        &rosetta_client,
+        &mut client,
+        keystore,
+        sender,
+        validator,
+        1_000_000_000,
+    )
+    .await;
+    test_cluster.trigger_reconfiguration().await;
+
+    let consolidate_ops = serde_json::from_value(json!([{
+        "operation_identifier": {"index": 0},
+        "type": "ConsolidateAllStakedSuiToFungible",
+        "account": {"address": sender.to_string()},
+        "metadata": {
+            "ConsolidateAllStakedSuiToFungible": {"validator": validator.to_string()}
+        }
+    }]))
+    .unwrap();
+    let flow = rosetta_client
+        .rosetta_flow(&consolidate_ops, keystore, None)
+        .await;
+    let payloads = flow.payloads.expect("payloads").expect("payloads errored");
+    let parsed = parse_unsigned(&rosetta_client, &payloads.unsigned_transaction).await;
+
+    let ops: Vec<_> = parsed.operations.into_iter().collect();
+    let Some(sui_rosetta::operations::OperationMetadata::ConsolidateAllStakedSuiToFungible {
+        staked_sui_ids,
+        fss_ids,
+        ..
+    }) = ops[0].metadata.clone()
+    else {
+        panic!();
+    };
+    assert_eq!(staked_sui_ids.len(), 2);
+    assert_eq!(fss_ids.len(), 2);
+}
+
+/// Stake with two different validators; consolidate validator A and verify only A's
+/// objects appear in the parse output.
+#[tokio::test]
+async fn test_e2e_parse_consolidate_multi_validator_isolation() {
+    let test_cluster = TestClusterBuilder::new().build().await;
+    let sender = test_cluster.get_address_0();
+    let keystore = &test_cluster.wallet.config.keystore;
+    let mut client = GrpcClient::new(test_cluster.rpc_url()).unwrap();
+    let (rosetta_client, _handle) = start_rosetta_test_server(client.clone()).await;
+
+    let request = GetEpochRequest::latest().with_read_mask(FieldMask::from_paths(["system_state"]));
+    let response = client
+        .clone()
+        .ledger_client()
+        .get_epoch(request)
+        .await
+        .unwrap()
+        .into_inner();
+    let validators = response
+        .epoch
+        .and_then(|e| e.system_state)
+        .unwrap()
+        .validators
+        .unwrap();
+    let validator_a: SuiAddress = validators.active_validators[0].address().parse().unwrap();
+    let validator_b: SuiAddress = validators.active_validators[1].address().parse().unwrap();
+
+    stake_via_rosetta(
+        &rosetta_client,
+        &mut client,
+        keystore,
+        sender,
+        validator_a,
+        1_000_000_000,
+    )
+    .await;
+    stake_via_rosetta(
+        &rosetta_client,
+        &mut client,
+        keystore,
+        sender,
+        validator_b,
+        1_000_000_000,
+    )
+    .await;
+    test_cluster.trigger_reconfiguration().await;
+
+    // Consolidate only validator_a's stakes.
+    let consolidate_ops = serde_json::from_value(json!([{
+        "operation_identifier": {"index": 0},
+        "type": "ConsolidateAllStakedSuiToFungible",
+        "account": {"address": sender.to_string()},
+        "metadata": {
+            "ConsolidateAllStakedSuiToFungible": {"validator": validator_a.to_string()}
+        }
+    }]))
+    .unwrap();
+    let flow = rosetta_client
+        .rosetta_flow(&consolidate_ops, keystore, None)
+        .await;
+    let payloads = flow.payloads.expect("payloads").expect("payloads errored");
+    let parsed = parse_unsigned(&rosetta_client, &payloads.unsigned_transaction).await;
+
+    let ops: Vec<_> = parsed.operations.into_iter().collect();
+    let Some(sui_rosetta::operations::OperationMetadata::ConsolidateAllStakedSuiToFungible {
+        staked_sui_ids,
+        fss_ids,
+        ..
+    }) = ops[0].metadata.clone()
+    else {
+        panic!();
+    };
+    // Exactly 1 staked (from A), 0 FSS.
+    assert_eq!(staked_sui_ids.len(), 1);
+    assert!(fss_ids.is_empty());
+}
+
+/// Helper: submit a Consolidate op and verify /block/transaction exposes the typed op.
+async fn submit_and_assert_block_consolidate(
+    rosetta_client: &rosetta_client::RosettaClient,
+    client: &mut GrpcClient,
+    keystore: &sui_keys::keystore::Keystore,
+    sender: SuiAddress,
+    validator: SuiAddress,
+    expected_staked: usize,
+    expected_fss: usize,
+) {
+    let consolidate_ops = serde_json::from_value(json!([{
+        "operation_identifier": {"index": 0},
+        "type": "ConsolidateAllStakedSuiToFungible",
+        "account": {"address": sender.to_string()},
+        "metadata": {
+            "ConsolidateAllStakedSuiToFungible": {"validator": validator.to_string()}
+        }
+    }]))
+    .unwrap();
+    let submit_resp: TransactionIdentifierResponse = rosetta_client
+        .rosetta_flow(&consolidate_ops, keystore, None)
+        .await
+        .submit
+        .unwrap()
+        .unwrap();
+    let tx_hash = submit_resp.transaction_identifier.hash.to_string();
+    wait_for_transaction(client, &tx_hash).await.unwrap();
+
+    let get_tx = GetTransactionRequest::default()
+        .with_digest(tx_hash.clone())
+        .with_read_mask(FieldMask::from_paths([
+            "transaction",
+            "effects",
+            "events",
+            "balance_changes",
+        ]));
+    let executed = client
+        .clone()
+        .ledger_client()
+        .get_transaction(get_tx)
+        .await
+        .unwrap()
+        .into_inner();
+    let cache = CoinMetadataCache::new(client.clone(), NonZeroUsize::new(100).unwrap());
+    let ops = Operations::try_from_executed_transaction(executed.transaction.unwrap(), &cache)
+        .await
+        .unwrap();
+    let ops_vec: Vec<_> = ops.into_iter().collect();
+    let typed = ops_vec
+        .iter()
+        .find(|o| o.type_ == OperationType::ConsolidateAllStakedSuiToFungible)
+        .expect("expected typed Consolidate op");
+    assert_eq!(typed.account.as_ref().unwrap().address, sender);
+    let Some(sui_rosetta::operations::OperationMetadata::ConsolidateAllStakedSuiToFungible {
+        staked_sui_ids,
+        fss_ids,
+        ..
+    }) = typed.metadata.clone()
+    else {
+        panic!();
+    };
+    assert_eq!(staked_sui_ids.len(), expected_staked);
+    assert_eq!(fss_ids.len(), expected_fss);
+    // Must have a Gas op.
+    assert!(ops_vec.iter().any(|o| o.type_ == OperationType::Gas));
+    // No SuiBalanceChange for sender (Consolidate is object-only).
+    let sender_balance_changes: Vec<_> = ops_vec
+        .iter()
+        .filter(|o| {
+            o.type_ == OperationType::SuiBalanceChange
+                && o.account.as_ref().map(|a| a.address) == Some(sender)
+        })
+        .collect();
+    assert!(
+        sender_balance_changes.is_empty(),
+        "Consolidate should have no sender SuiBalanceChange, got {:?}",
+        sender_balance_changes
+    );
+}
+
+#[tokio::test]
+async fn test_e2e_block_consolidate_0_stakes_2_fss() {
+    let test_cluster = TestClusterBuilder::new().build().await;
+    let sender = test_cluster.get_address_0();
+    let keystore = &test_cluster.wallet.config.keystore;
+    let mut client = GrpcClient::new(test_cluster.rpc_url()).unwrap();
+    let (rosetta_client, _handle) = start_rosetta_test_server(client.clone()).await;
+
+    let validator = first_validator(&mut client).await;
+    for _ in 0..2 {
+        stake_via_rosetta(
+            &rosetta_client,
+            &mut client,
+            keystore,
+            sender,
+            validator,
+            1_000_000_000,
+        )
+        .await;
+    }
+    test_cluster.trigger_reconfiguration().await;
+    convert_all_staked_to_fss_directly(&mut client, keystore, sender).await;
+
+    submit_and_assert_block_consolidate(
+        &rosetta_client,
+        &mut client,
+        keystore,
+        sender,
+        validator,
+        0,
+        2,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_e2e_block_consolidate_0_stakes_3_fss() {
+    let test_cluster = TestClusterBuilder::new().build().await;
+    let sender = test_cluster.get_address_0();
+    let keystore = &test_cluster.wallet.config.keystore;
+    let mut client = GrpcClient::new(test_cluster.rpc_url()).unwrap();
+    let (rosetta_client, _handle) = start_rosetta_test_server(client.clone()).await;
+
+    let validator = first_validator(&mut client).await;
+    for _ in 0..3 {
+        stake_via_rosetta(
+            &rosetta_client,
+            &mut client,
+            keystore,
+            sender,
+            validator,
+            1_000_000_000,
+        )
+        .await;
+    }
+    test_cluster.trigger_reconfiguration().await;
+    convert_all_staked_to_fss_directly(&mut client, keystore, sender).await;
+
+    submit_and_assert_block_consolidate(
+        &rosetta_client,
+        &mut client,
+        keystore,
+        sender,
+        validator,
+        0,
+        3,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_e2e_block_consolidate_3_stakes_0_fss() {
+    let test_cluster = TestClusterBuilder::new().build().await;
+    let sender = test_cluster.get_address_0();
+    let keystore = &test_cluster.wallet.config.keystore;
+    let mut client = GrpcClient::new(test_cluster.rpc_url()).unwrap();
+    let (rosetta_client, _handle) = start_rosetta_test_server(client.clone()).await;
+
+    let validator = first_validator(&mut client).await;
+    for _ in 0..3 {
+        stake_via_rosetta(
+            &rosetta_client,
+            &mut client,
+            keystore,
+            sender,
+            validator,
+            1_000_000_000,
+        )
+        .await;
+    }
+    test_cluster.trigger_reconfiguration().await;
+
+    submit_and_assert_block_consolidate(
+        &rosetta_client,
+        &mut client,
+        keystore,
+        sender,
+        validator,
+        3,
+        0,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_e2e_block_consolidate_1_stake_1_fss() {
+    let test_cluster = TestClusterBuilder::new().build().await;
+    let sender = test_cluster.get_address_0();
+    let keystore = &test_cluster.wallet.config.keystore;
+    let mut client = GrpcClient::new(test_cluster.rpc_url()).unwrap();
+    let (rosetta_client, _handle) = start_rosetta_test_server(client.clone()).await;
+
+    let validator = first_validator(&mut client).await;
+    stake_via_rosetta(
+        &rosetta_client,
+        &mut client,
+        keystore,
+        sender,
+        validator,
+        1_000_000_000,
+    )
+    .await;
+    test_cluster.trigger_reconfiguration().await;
+    convert_all_staked_to_fss_directly(&mut client, keystore, sender).await;
+    stake_via_rosetta(
+        &rosetta_client,
+        &mut client,
+        keystore,
+        sender,
+        validator,
+        1_000_000_000,
+    )
+    .await;
+    test_cluster.trigger_reconfiguration().await;
+
+    submit_and_assert_block_consolidate(
+        &rosetta_client,
+        &mut client,
+        keystore,
+        sender,
+        validator,
+        1,
+        1,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_e2e_block_consolidate_2_stakes_2_fss() {
+    let test_cluster = TestClusterBuilder::new().build().await;
+    let sender = test_cluster.get_address_0();
+    let keystore = &test_cluster.wallet.config.keystore;
+    let mut client = GrpcClient::new(test_cluster.rpc_url()).unwrap();
+    let (rosetta_client, _handle) = start_rosetta_test_server(client.clone()).await;
+
+    let validator = first_validator(&mut client).await;
+    for _ in 0..2 {
+        stake_via_rosetta(
+            &rosetta_client,
+            &mut client,
+            keystore,
+            sender,
+            validator,
+            1_000_000_000,
+        )
+        .await;
+    }
+    test_cluster.trigger_reconfiguration().await;
+    convert_all_staked_to_fss_directly(&mut client, keystore, sender).await;
+    for _ in 0..2 {
+        stake_via_rosetta(
+            &rosetta_client,
+            &mut client,
+            keystore,
+            sender,
+            validator,
+            1_000_000_000,
+        )
+        .await;
+    }
+    test_cluster.trigger_reconfiguration().await;
+
+    submit_and_assert_block_consolidate(
+        &rosetta_client,
+        &mut client,
+        keystore,
+        sender,
+        validator,
+        2,
+        2,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_e2e_block_consolidate_multi_validator_isolation() {
+    let test_cluster = TestClusterBuilder::new().build().await;
+    let sender = test_cluster.get_address_0();
+    let keystore = &test_cluster.wallet.config.keystore;
+    let mut client = GrpcClient::new(test_cluster.rpc_url()).unwrap();
+    let (rosetta_client, _handle) = start_rosetta_test_server(client.clone()).await;
+
+    let request = GetEpochRequest::latest().with_read_mask(FieldMask::from_paths(["system_state"]));
+    let response = client
+        .clone()
+        .ledger_client()
+        .get_epoch(request)
+        .await
+        .unwrap()
+        .into_inner();
+    let validators = response
+        .epoch
+        .and_then(|e| e.system_state)
+        .unwrap()
+        .validators
+        .unwrap();
+    let validator_a: SuiAddress = validators.active_validators[0].address().parse().unwrap();
+    let validator_b: SuiAddress = validators.active_validators[1].address().parse().unwrap();
+
+    stake_via_rosetta(
+        &rosetta_client,
+        &mut client,
+        keystore,
+        sender,
+        validator_a,
+        1_000_000_000,
+    )
+    .await;
+    stake_via_rosetta(
+        &rosetta_client,
+        &mut client,
+        keystore,
+        sender,
+        validator_b,
+        1_000_000_000,
+    )
+    .await;
+    test_cluster.trigger_reconfiguration().await;
+
+    // Consolidate only validator_a's stake — expect 1 staked, 0 fss.
+    submit_and_assert_block_consolidate(
+        &rosetta_client,
+        &mut client,
+        keystore,
+        sender,
+        validator_a,
+        1,
+        0,
+    )
+    .await;
+}


### PR DESCRIPTION
## Summary

Adds typed parsing for `ConsolidateAllStakedSuiToFungible` transactions on the Rosetta read path. Previously `/construction/parse` and `/block/transaction` returned a single opaque `ProgrammableTransaction` generic op for these PTBs, leaving clients to decode the embedded PTB themselves. They now emit a typed `ConsolidateAllStakedSuiToFungible` op with `staked_sui_ids` and `fss_ids` extracted from PTB inputs.

## Changes

**Parser (`crates/sui-rosetta/src/operations.rs`):**

- New predicates `is_convert_to_fss_call` and `is_join_fss_call` recognize the signature MoveCalls `0x3::sui_system::convert_to_fungible_staked_sui` and `0x3::staking_pool::join_fungible_staked_sui`.
- Dispatch scans commands once at the top of `parse_programmable_transaction`; if either signature call is present, runs a new `parse_consolidate` sub-parser. Shape mismatch falls through to the existing generic op fallback, so third-party PTBs that happen to call the same Move functions are not mislabeled.
- `parse_consolidate` performs strict shape validation covering all three valid PTB shapes produced by the existing `consolidate_to_fungible_pt` builder:
  - pure FSS merge (`S=0, F>=2`): only `join_fungible_staked_sui` calls
  - convert-only (`S>=1, F=0`): `convert` calls + trailing `TransferObjects` to sender
  - mixed (`S>=1, F>=1`): existing FSS merges + converts + new-FSS merges + cross-merge
- Input classification walks `convert` and `join` argument refs to split PTB inputs into StakedSui vs FSS object IDs; any overlap rejects (falls through).

**Metadata — backward-compatible:**

- `OperationMetadata::ConsolidateAllStakedSuiToFungible.validator` relaxed to `Option<SuiAddress>`. Parsed ops emit `validator: None` because the Move function takes only the object ref, not the validator address — it is not recoverable from PTB bytes in the sync parse path. Write-side destructurer still returns `Error::MissingInput` if absent, preserving old behavior for write callers. Old JSON input with `{\"validator\": \"0x...\"}` continues to deserialize.
- Two new parse-populated fields: `staked_sui_ids: Vec<ObjectID>` and `fss_ids: Vec<ObjectID>`, defaulting to empty on write input (ignored by write destructurer via `..`).

**Test-visibility change (`crates/sui-rosetta/src/types/internal_operation.rs`):**

- Re-export `consolidate_to_fungible_pt` as `pub(crate)` so the unit tests in `operations.rs` can construct PTBs through the same builder used by production code, guaranteeing test-to-production shape parity.

## Behavior

`/construction/parse` response for a Consolidate PTB (S=2, F=2):
```json
{
  "operations": [{
    "type": "ConsolidateAllStakedSuiToFungible",
    "account": { "address": "<sender>" },
    "metadata": {
      "ConsolidateAllStakedSuiToFungible": {
        "staked_sui_ids": ["0x...", "0x..."],
        "fss_ids": ["0x...", "0x..."]
      }
    }
  }],
  "account_identifier_signers": [...]
}
```

`/block/transaction` layers the typed op with the usual `Gas` op and balance-change ops from effects processing (no `SuiBalanceChange` for the sender since Consolidate has no net SUI delta).

## Test plan

- [x] 22 new unit tests in `operations.rs::tests` covering:
  - 11 happy paths: every (S, F) combination accepted by the builder, including pure merge (`S=0, F={2,3,5}`), convert-only (`S={1,3}, F=0`), and mixed (`S={1,2,3}, F={1,2,3}`), plus a classification-correctness test.
  - 4 fall-through cases: rogue `MergeCoins`, unrelated MoveCall, wrong first input, extra command after `TransferObjects` — each asserts the parser falls through to the generic `ProgrammableTransaction` op.
  - 2 robustness: empty PTB, PTB with only `MergeCoins` (non-FSS).
  - 2 serialization compat: old JSON input still deserializes; new parse output serializes with proper field-skip.
  - 1 write-side preservation: missing validator on write input still yields `MissingInput`.
- [x] 19 new e2e tests in `end_to_end_tests.rs`:
  - 7 `/construction/parse` round-trip tests across the (S, F) matrix plus multi-validator isolation.
  - 7 `/block/transaction` tests submitting the TX and re-parsing through `try_from_executed_transaction`.
  - 2 new write-error tests (invalid validator, missing validator); 3 others (no-stakes, single-FSS, unactivated-only) are already covered by existing `test_consolidate_noop_*` tests.
  - 2 robustness: garbage bytes and truncated TX data to `/construction/parse` return proper Rosetta error responses.
- [x] Full `cargo nextest run -p sui-rosetta` suite: 136 tests pass, 0 skipped.
- [x] `cargo clippy -p sui-rosetta --tests` clean.