### PR TITLE
feat: Enable gamma prime zklogin providers to prod

### DIFF
--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -778,6 +778,8 @@ pub fn default_zklogin_oauth_providers() -> BTreeMap<Chain, BTreeSet<String>> {
         "EveFrontier".to_string(),
         "TestEveFrontier".to_string(),
         "AwsTenant-region:ap-southeast-1-tenant_id:ap-southeast-1_2QQPyQXDz".to_string(), // Decot, external partner
+        "AwsTenant-region:eu-north-1-tenant_id:eu-north-1_Bpct2JyBg".to_string(), // test Gamma Prime, external partner
+        "AwsTenant-region:eu-north-1-tenant_id:eu-north-1_4HdQTpt3E".to_string(), // Gamma Prime, external partner
     ]);
     map.insert(Chain::Mainnet, providers.clone());
     map.insert(Chain::Testnet, providers);

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -80,6 +80,8 @@ validator_configs:
         - Apple
         - Arden
         - "AwsTenant-region:ap-southeast-1-tenant_id:ap-southeast-1_2QQPyQXDz"
+        - "AwsTenant-region:eu-north-1-tenant_id:eu-north-1_4HdQTpt3E"
+        - "AwsTenant-region:eu-north-1-tenant_id:eu-north-1_Bpct2JyBg"
         - "AwsTenant-region:eu-west-3-tenant_id:eu-west-3_gGVCx53Es"
         - Credenza3
         - EveFrontier
@@ -96,6 +98,8 @@ validator_configs:
         - Apple
         - Arden
         - "AwsTenant-region:ap-southeast-1-tenant_id:ap-southeast-1_2QQPyQXDz"
+        - "AwsTenant-region:eu-north-1-tenant_id:eu-north-1_4HdQTpt3E"
+        - "AwsTenant-region:eu-north-1-tenant_id:eu-north-1_Bpct2JyBg"
         - "AwsTenant-region:eu-west-3-tenant_id:eu-west-3_gGVCx53Es"
         - Credenza3
         - EveFrontier
@@ -250,6 +254,8 @@ validator_configs:
         - Apple
         - Arden
         - "AwsTenant-region:ap-southeast-1-tenant_id:ap-southeast-1_2QQPyQXDz"
+        - "AwsTenant-region:eu-north-1-tenant_id:eu-north-1_4HdQTpt3E"
+        - "AwsTenant-region:eu-north-1-tenant_id:eu-north-1_Bpct2JyBg"
         - "AwsTenant-region:eu-west-3-tenant_id:eu-west-3_gGVCx53Es"
         - Credenza3
         - EveFrontier
@@ -266,6 +272,8 @@ validator_configs:
         - Apple
         - Arden
         - "AwsTenant-region:ap-southeast-1-tenant_id:ap-southeast-1_2QQPyQXDz"
+        - "AwsTenant-region:eu-north-1-tenant_id:eu-north-1_4HdQTpt3E"
+        - "AwsTenant-region:eu-north-1-tenant_id:eu-north-1_Bpct2JyBg"
         - "AwsTenant-region:eu-west-3-tenant_id:eu-west-3_gGVCx53Es"
         - Credenza3
         - EveFrontier
@@ -420,6 +428,8 @@ validator_configs:
         - Apple
         - Arden
         - "AwsTenant-region:ap-southeast-1-tenant_id:ap-southeast-1_2QQPyQXDz"
+        - "AwsTenant-region:eu-north-1-tenant_id:eu-north-1_4HdQTpt3E"
+        - "AwsTenant-region:eu-north-1-tenant_id:eu-north-1_Bpct2JyBg"
         - "AwsTenant-region:eu-west-3-tenant_id:eu-west-3_gGVCx53Es"
         - Credenza3
         - EveFrontier
@@ -436,6 +446,8 @@ validator_configs:
         - Apple
         - Arden
         - "AwsTenant-region:ap-southeast-1-tenant_id:ap-southeast-1_2QQPyQXDz"
+        - "AwsTenant-region:eu-north-1-tenant_id:eu-north-1_4HdQTpt3E"
+        - "AwsTenant-region:eu-north-1-tenant_id:eu-north-1_Bpct2JyBg"
         - "AwsTenant-region:eu-west-3-tenant_id:eu-west-3_gGVCx53Es"
         - Credenza3
         - EveFrontier
@@ -590,6 +602,8 @@ validator_configs:
         - Apple
         - Arden
         - "AwsTenant-region:ap-southeast-1-tenant_id:ap-southeast-1_2QQPyQXDz"
+        - "AwsTenant-region:eu-north-1-tenant_id:eu-north-1_4HdQTpt3E"
+        - "AwsTenant-region:eu-north-1-tenant_id:eu-north-1_Bpct2JyBg"
         - "AwsTenant-region:eu-west-3-tenant_id:eu-west-3_gGVCx53Es"
         - Credenza3
         - EveFrontier
@@ -606,6 +620,8 @@ validator_configs:
         - Apple
         - Arden
         - "AwsTenant-region:ap-southeast-1-tenant_id:ap-southeast-1_2QQPyQXDz"
+        - "AwsTenant-region:eu-north-1-tenant_id:eu-north-1_4HdQTpt3E"
+        - "AwsTenant-region:eu-north-1-tenant_id:eu-north-1_Bpct2JyBg"
         - "AwsTenant-region:eu-west-3-tenant_id:eu-west-3_gGVCx53Es"
         - Credenza3
         - EveFrontier
@@ -760,6 +776,8 @@ validator_configs:
         - Apple
         - Arden
         - "AwsTenant-region:ap-southeast-1-tenant_id:ap-southeast-1_2QQPyQXDz"
+        - "AwsTenant-region:eu-north-1-tenant_id:eu-north-1_4HdQTpt3E"
+        - "AwsTenant-region:eu-north-1-tenant_id:eu-north-1_Bpct2JyBg"
         - "AwsTenant-region:eu-west-3-tenant_id:eu-west-3_gGVCx53Es"
         - Credenza3
         - EveFrontier
@@ -776,6 +794,8 @@ validator_configs:
         - Apple
         - Arden
         - "AwsTenant-region:ap-southeast-1-tenant_id:ap-southeast-1_2QQPyQXDz"
+        - "AwsTenant-region:eu-north-1-tenant_id:eu-north-1_4HdQTpt3E"
+        - "AwsTenant-region:eu-north-1-tenant_id:eu-north-1_Bpct2JyBg"
         - "AwsTenant-region:eu-west-3-tenant_id:eu-west-3_gGVCx53Es"
         - Credenza3
         - EveFrontier
@@ -930,6 +950,8 @@ validator_configs:
         - Apple
         - Arden
         - "AwsTenant-region:ap-southeast-1-tenant_id:ap-southeast-1_2QQPyQXDz"
+        - "AwsTenant-region:eu-north-1-tenant_id:eu-north-1_4HdQTpt3E"
+        - "AwsTenant-region:eu-north-1-tenant_id:eu-north-1_Bpct2JyBg"
         - "AwsTenant-region:eu-west-3-tenant_id:eu-west-3_gGVCx53Es"
         - Credenza3
         - EveFrontier
@@ -946,6 +968,8 @@ validator_configs:
         - Apple
         - Arden
         - "AwsTenant-region:ap-southeast-1-tenant_id:ap-southeast-1_2QQPyQXDz"
+        - "AwsTenant-region:eu-north-1-tenant_id:eu-north-1_4HdQTpt3E"
+        - "AwsTenant-region:eu-north-1-tenant_id:eu-north-1_Bpct2JyBg"
         - "AwsTenant-region:eu-west-3-tenant_id:eu-west-3_gGVCx53Es"
         - Credenza3
         - EveFrontier
@@ -1100,6 +1124,8 @@ validator_configs:
         - Apple
         - Arden
         - "AwsTenant-region:ap-southeast-1-tenant_id:ap-southeast-1_2QQPyQXDz"
+        - "AwsTenant-region:eu-north-1-tenant_id:eu-north-1_4HdQTpt3E"
+        - "AwsTenant-region:eu-north-1-tenant_id:eu-north-1_Bpct2JyBg"
         - "AwsTenant-region:eu-west-3-tenant_id:eu-west-3_gGVCx53Es"
         - Credenza3
         - EveFrontier
@@ -1116,6 +1142,8 @@ validator_configs:
         - Apple
         - Arden
         - "AwsTenant-region:ap-southeast-1-tenant_id:ap-southeast-1_2QQPyQXDz"
+        - "AwsTenant-region:eu-north-1-tenant_id:eu-north-1_4HdQTpt3E"
+        - "AwsTenant-region:eu-north-1-tenant_id:eu-north-1_Bpct2JyBg"
         - "AwsTenant-region:eu-west-3-tenant_id:eu-west-3_gGVCx53Es"
         - Credenza3
         - EveFrontier


### PR DESCRIPTION
## Description 

This adds Gamma prime dev and prod as providers in node config - once 2f+1 validators has this in default config for JWKs, its considered active on testnet/mainnet

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
