### PR TITLE
[test] Drop redundant enable_coin_reservation_for_testing in simulate tests

### DIFF
--- a/crates/sui-e2e-tests/tests/grpc_simulate_gas_coin_tests.rs
+++ b/crates/sui-e2e-tests/tests/grpc_simulate_gas_coin_tests.rs
@@ -77,7 +77,6 @@ async fn test_has_ab_has_coins_uses_gas_coin() {
     let test_env = TestEnvBuilder::new()
         .with_proto_override_cb(Box::new(|_, mut cfg| {
             cfg.create_root_accumulator_object_for_testing();
-            cfg.enable_coin_reservation_for_testing();
             cfg.enable_address_balance_gas_payments_for_testing();
             cfg
         }))
@@ -617,7 +616,6 @@ async fn test_combined_ab_and_coins_needed() {
     let test_env = TestEnvBuilder::new()
         .with_proto_override_cb(Box::new(|_, mut cfg| {
             cfg.create_root_accumulator_object_for_testing();
-            cfg.enable_coin_reservation_for_testing();
             cfg.enable_address_balance_gas_payments_for_testing();
             cfg
         }))


### PR DESCRIPTION
## Summary
- Removes the `cfg.enable_coin_reservation_for_testing()` call from `test_has_ab_has_coins_uses_gas_coin` and `test_combined_ab_and_coins_needed` in `grpc_simulate_gas_coin_tests.rs`.
- `enable_coin_reservation_obj_refs` is already enabled by the base protocol config at the test cluster's protocol version for `chain != Chain::Mainnet`, so the test override is a no-op on normal simtest runs. Under `SUI_PROTOCOL_CONFIG_CHAIN_OVERRIDE=mainnet` it was actively harmful: it flipped the flag on top of the mainnet base, and because msim's `thread_local!` is shared across simnodes the override leaked into the fullnode's RPC and defeated the mainnet gate added in #26082. That is why the assertion introduced in #26084 ("Mainnet override should disable coin reservation, got digest: …") started firing for Dario and others.
- With this change, non-mainnet runs behave identically (base config already enables the feature), and mainnet runs honor the RPC's gating — the existing mid-test `has_mainnet_protocol_config_override` branches now work as originally intended.

## Test plan
- [x] `cargo simtest --no-capture -p sui-e2e-tests --test grpc_simulate_gas_coin_tests test_combined_ab_and_coins_needed test_has_ab_has_coins_uses_gas_coin` — passes.
- [x] `SUI_PROTOCOL_CONFIG_CHAIN_OVERRIDE=mainnet MSIM_TEST_SEED=18256063960127244791 cargo simtest --no-capture -p sui-e2e-tests --test grpc_simulate_gas_coin_tests test_combined_ab_and_coins_needed test_has_ab_has_coins_uses_gas_coin` (Dario's repro) — passes.
- [x] `cargo clippy -p sui-e2e-tests --tests -- -D warnings`.
- [x] `cargo fmt --all -- --check`.