### PR TITLE
[sui-indexer-alt-reader] Preserve FullnodeArgs inner `Option<Url>`

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/src/lib.rs
+++ b/crates/sui-indexer-alt-e2e-tests/src/lib.rs
@@ -150,7 +150,7 @@ pub struct OffchainCluster {
 pub struct OffchainClusterConfig {
     pub indexer_args: IndexerArgs,
     pub consistent_indexer_args: IndexerArgs,
-    pub fullnode_args: Option<FullnodeArgs>,
+    pub fullnode_args: FullnodeArgs,
     pub indexer_config: IndexerConfig,
     pub consistent_config: ConsistentConfig,
     pub jsonrpc_config: JsonRpcConfig,
@@ -733,7 +733,7 @@ impl Default for OffchainClusterConfig {
         Self {
             indexer_args: Default::default(),
             consistent_indexer_args: Default::default(),
-            fullnode_args: None,
+            fullnode_args: FullnodeArgs::default(),
             indexer_config: IndexerConfig::for_test(),
             consistent_config: ConsistentConfig::for_test(),
             jsonrpc_config: Default::default(),

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_execute_transaction_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_execute_transaction_tests.rs
@@ -123,9 +123,7 @@ impl GraphQlTestCluster {
             no_ide: true,
         };
 
-        let fullnode_args = FullnodeArgs {
-            fullnode_rpc_url: Some(validator_cluster.rpc_url().parse().unwrap()),
-        };
+        let fullnode_args = FullnodeArgs::new(validator_cluster.rpc_url().parse().unwrap());
 
         // Start GraphQL server that connects directly to TestCluster's RPC
         let service = start_graphql(

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_execute_transaction_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_execute_transaction_tests.rs
@@ -124,13 +124,13 @@ impl GraphQlTestCluster {
         };
 
         let fullnode_args = FullnodeArgs {
-            fullnode_rpc_url: validator_cluster.rpc_url().parse().unwrap(),
+            fullnode_rpc_url: Some(validator_cluster.rpc_url().parse().unwrap()),
         };
 
         // Start GraphQL server that connects directly to TestCluster's RPC
         let service = start_graphql(
             None, // No database - GraphQL will use fullnode RPC for executeTransaction
-            Some(fullnode_args),
+            fullnode_args,
             DbArgs::default(),
             KvArgs::default(),
             ConsistentReaderArgs::default(),

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_simulate_transaction_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_simulate_transaction_tests.rs
@@ -161,7 +161,7 @@ impl GraphQlTestCluster {
         let database_url = database.database().url().clone();
 
         let fullnode_args = FullnodeArgs {
-            fullnode_rpc_url: validator_cluster.rpc_url().parse().unwrap(),
+            fullnode_rpc_url: Some(validator_cluster.rpc_url().parse().unwrap()),
         };
         let client_args = ClientArgs {
             ingestion: IngestionClientArgs {
@@ -190,7 +190,7 @@ impl GraphQlTestCluster {
 
         let s_graphql = start_graphql(
             Some(database_url),
-            Some(fullnode_args),
+            fullnode_args,
             DbArgs::default(),
             KvArgs::default(),
             ConsistentReaderArgs::default(),

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_simulate_transaction_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_simulate_transaction_tests.rs
@@ -160,9 +160,8 @@ impl GraphQlTestCluster {
         let database = TempDb::new().expect("Failed to create temp database");
         let database_url = database.database().url().clone();
 
-        let fullnode_args = FullnodeArgs {
-            fullnode_rpc_url: Some(validator_cluster.rpc_url().parse().unwrap()),
-        };
+        let fullnode_args = FullnodeArgs::new(validator_cluster.rpc_url().parse().unwrap());
+
         let client_args = ClientArgs {
             ingestion: IngestionClientArgs {
                 rpc_api_url: Some(

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/testing/harness.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/testing/harness.rs
@@ -46,9 +46,9 @@ impl SubscriptionTestCluster {
 
         let service = start_graphql(
             None,
-            Some(FullnodeArgs {
-                fullnode_rpc_url: rpc_url.parse().unwrap(),
-            }),
+            FullnodeArgs {
+                fullnode_rpc_url: Some(rpc_url.parse().unwrap()),
+            },
             DbArgs::default(),
             KvArgs::default(),
             ConsistentReaderArgs::default(),

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/testing/harness.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/testing/harness.rs
@@ -46,9 +46,7 @@ impl SubscriptionTestCluster {
 
         let service = start_graphql(
             None,
-            FullnodeArgs {
-                fullnode_rpc_url: Some(rpc_url.parse().unwrap()),
-            },
+            FullnodeArgs::new(rpc_url.parse().unwrap()),
             DbArgs::default(),
             KvArgs::default(),
             ConsistentReaderArgs::default(),

--- a/crates/sui-indexer-alt-graphql/src/args.rs
+++ b/crates/sui-indexer-alt-graphql/src/args.rs
@@ -43,7 +43,7 @@ pub enum Command {
         database_url: Url,
 
         #[command(flatten)]
-        fullnode_args: Option<FullnodeArgs>,
+        fullnode_args: FullnodeArgs,
 
         #[command(flatten)]
         db_args: DbArgs,

--- a/crates/sui-indexer-alt-graphql/src/lib.rs
+++ b/crates/sui-indexer-alt-graphql/src/lib.rs
@@ -299,7 +299,7 @@ struct SubscriptionsEnabled(bool);
 /// and will clean these up on shutdown as well.
 pub async fn start_rpc(
     database_url: Option<Url>,
-    fullnode_args: Option<FullnodeArgs>,
+    fullnode_args: FullnodeArgs,
     db_args: DbArgs,
     kv_args: KvArgs,
     consistent_reader_args: ConsistentReaderArgs,
@@ -316,15 +316,9 @@ pub async fn start_rpc(
 
     // Create gRPC full node client wrapper. If left unconfigured, the client will not be stored in
     // the schema data, and resolvers that depend on it return `FeatureUnavailable`.
-    let fullnode_client = if let Some(args) = fullnode_args {
-        Some(
-            FullnodeClient::new(Some("graphql_fullnode"), args, registry)
-                .await
-                .context("Failed to create fullnode gRPC client")?,
-        )
-    } else {
-        None
-    };
+    let fullnode_client = FullnodeClient::new(Some("graphql_fullnode"), fullnode_args, registry)
+        .await
+        .context("Failed to create fullnode gRPC client")?;
 
     let consistent_reader =
         ConsistentReader::new(Some("graphql_consistent"), consistent_reader_args, registry).await?;

--- a/crates/sui-indexer-alt-jsonrpc/src/lib.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/lib.rs
@@ -312,16 +312,22 @@ pub async fn start_rpc(
         warn!("No fullnode rpc url provided, DelegationGovernance module will not be added.");
     }
 
-    if let Some(fullnode_grpc_url) = node_args.fullnode_grpc_url.as_deref() {
-        let fullnode_rpc_url =
-            Url::parse(fullnode_grpc_url).context("Invalid fullnode gRPC URL")?;
-        let fullnode_client = FullnodeClient::new(
-            Some("jsonrpc_alt_fullnode"),
-            FullnodeArgs { fullnode_rpc_url },
-            registry,
-        )
-        .await
-        .context("Failed to create fullnode gRPC client")?;
+    let fullnode_grpc_url = node_args
+        .fullnode_grpc_url
+        .as_deref()
+        .map(Url::parse)
+        .transpose()
+        .context("Invalid fullnode gRPC URL")?;
+
+    let fullnode_client = FullnodeClient::new(
+        Some("jsonrpc_alt_fullnode"),
+        FullnodeArgs { fullnode_rpc_url },
+        registry,
+    )
+    .await
+    .context("Failed to create fullnode gRPC client")?;
+
+    if let Some(fullnode_client) = fullnode_client {
         rpc.add_module(Write::new(fullnode_client, context.clone()))?;
     } else {
         warn!("No fullnode grpc url provided, Write module will not be added.");

--- a/crates/sui-indexer-alt-jsonrpc/src/lib.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/lib.rs
@@ -312,20 +312,19 @@ pub async fn start_rpc(
         warn!("No fullnode rpc url provided, DelegationGovernance module will not be added.");
     }
 
-    let fullnode_grpc_url = node_args
+    let fullnode_args = node_args
         .fullnode_grpc_url
         .as_deref()
         .map(Url::parse)
         .transpose()
-        .context("Invalid fullnode gRPC URL")?;
+        .context("Invalid fullnode gRPC URL")?
+        .map(FullnodeArgs::new)
+        .unwrap_or_default();
 
-    let fullnode_client = FullnodeClient::new(
-        Some("jsonrpc_alt_fullnode"),
-        FullnodeArgs { fullnode_rpc_url },
-        registry,
-    )
-    .await
-    .context("Failed to create fullnode gRPC client")?;
+    let fullnode_client =
+        FullnodeClient::new(Some("jsonrpc_alt_fullnode"), fullnode_args, registry)
+            .await
+            .context("Failed to create fullnode gRPC client")?;
 
     if let Some(fullnode_client) = fullnode_client {
         rpc.add_module(Write::new(fullnode_client, context.clone()))?;

--- a/crates/sui-indexer-alt-reader/src/fullnode_client.rs
+++ b/crates/sui-indexer-alt-reader/src/fullnode_client.rs
@@ -23,7 +23,7 @@ pub struct FullnodeArgs {
     /// gRPC URL for full node operations such as executeTransaction and simulateTransaction.
     /// `Option` so the flag stays optional when flattened into a parent args struct.
     #[clap(long)]
-    pub fullnode_rpc_url: Option<Url>,
+    pub(crate) fullnode_rpc_url: Option<Url>,
 }
 
 /// A client for executing and simulating transactions via the full node gRPC service.
@@ -39,6 +39,14 @@ pub enum Error {
 
     #[error(transparent)]
     GrpcExecutionError(#[from] tonic::Status),
+}
+
+impl FullnodeArgs {
+    pub fn new(url: Url) -> Self {
+        Self {
+            fullnode_rpc_url: Some(url),
+        }
+    }
 }
 
 impl FullnodeClient {

--- a/crates/sui-indexer-alt-reader/src/fullnode_client.rs
+++ b/crates/sui-indexer-alt-reader/src/fullnode_client.rs
@@ -18,11 +18,12 @@ use url::Url;
 use crate::metrics::GrpcMetricsLayer;
 use crate::metrics::GrpcMetricsService;
 
-#[derive(clap::Args, Debug, Clone)]
+#[derive(clap::Args, Debug, Clone, Default)]
 pub struct FullnodeArgs {
     /// gRPC URL for full node operations such as executeTransaction and simulateTransaction.
+    /// `Option` so the flag stays optional when flattened into a parent args struct.
     #[clap(long)]
-    pub fullnode_rpc_url: Url,
+    pub fullnode_rpc_url: Option<Url>,
 }
 
 /// A client for executing and simulating transactions via the full node gRPC service.
@@ -45,11 +46,15 @@ impl FullnodeClient {
         prefix: Option<&str>,
         args: FullnodeArgs,
         registry: &Registry,
-    ) -> Result<Self, Error> {
-        let mut endpoint = Channel::from_shared(args.fullnode_rpc_url.to_string())
+    ) -> Result<Option<Self>, Error> {
+        let Some(url) = args.fullnode_rpc_url else {
+            return Ok(None);
+        };
+
+        let mut endpoint = Channel::from_shared(url.to_string())
             .context("Failed to create channel for gRPC endpoint")?;
 
-        if args.fullnode_rpc_url.scheme() == "https" {
+        if url.scheme() == "https" {
             endpoint = endpoint
                 .tls_config(ClientTlsConfig::new().with_native_roots())
                 .context("Failed to configure TLS for gRPC endpoint")?;
@@ -61,7 +66,7 @@ impl FullnodeClient {
 
         let execution_client = TransactionExecutionServiceClient::new(layered);
 
-        Ok(Self { execution_client })
+        Ok(Some(Self { execution_client }))
     }
 
     /// Execute a transaction on the Sui network via gRPC.
@@ -143,22 +148,37 @@ impl FullnodeClient {
 mod tests {
     use super::*;
 
-    async fn fn_client(url: &str) -> Result<FullnodeClient, Error> {
-        let url = Url::parse(url).unwrap();
+    async fn fn_client(url: Option<&str>) -> Result<Option<FullnodeClient>, Error> {
         let registry = Registry::new();
         let args = FullnodeArgs {
-            fullnode_rpc_url: url,
+            fullnode_rpc_url: url.map(|u| Url::parse(u).unwrap()),
         };
         FullnodeClient::new(None, args, &registry).await
     }
 
     #[tokio::test]
+    async fn no_url_means_not_configured() {
+        let client = fn_client(None).await.unwrap();
+        assert!(client.is_none());
+    }
+
+    #[tokio::test]
     async fn http_url_creates_client() {
-        fn_client("http://localhost:9000").await.unwrap();
+        assert!(
+            fn_client(Some("http://localhost:9000"))
+                .await
+                .unwrap()
+                .is_some()
+        );
     }
 
     #[tokio::test]
     async fn https_url_creates_client() {
-        fn_client("https://fn.example.com").await.unwrap();
+        assert!(
+            fn_client(Some("https://fn.example.com"))
+                .await
+                .unwrap()
+                .is_some()
+        );
     }
 }

--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -1167,7 +1167,7 @@ async fn start(
         };
 
         let fullnode_args = FullnodeArgs {
-            fullnode_rpc_url: socket_addr_to_url(fullnode_rpc_address)?,
+            fullnode_rpc_url: Some(socket_addr_to_url(fullnode_rpc_address)?),
         };
 
         let mut graphql_config = GraphQlConfig::default();
@@ -1176,7 +1176,7 @@ async fn start(
         rpc_services = rpc_services.merge(
             start_graphql(
                 database_url.clone(),
-                Some(fullnode_args),
+                fullnode_args,
                 DbArgs::default(),
                 KvArgs::default(),
                 consistent_reader_args,

--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -1166,9 +1166,7 @@ async fn start(
             ..Default::default()
         };
 
-        let fullnode_args = FullnodeArgs {
-            fullnode_rpc_url: Some(socket_addr_to_url(fullnode_rpc_address)?),
-        };
+        let fullnode_args = FullnodeArgs::new(socket_addr_to_url(fullnode_rpc_address)?);
 
         let mut graphql_config = GraphQlConfig::default();
         graphql_config.zklogin.env = sui_indexer_alt_graphql::config::ZkLoginEnv::Test;


### PR DESCRIPTION
## Description 

Because `FullnodeArgs` is flattened into graphql's start command, the inner url needs to remain `Option<T>` so that when flattened, the fullnode grpc url remains optional.

Callers construct the `FullnodeClient` by building a `FullnodeArgs` and passing it to `FullnodeClient::new`, which now returns `Result<Option<Self>, _>`. 

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
