### PR TITLE
Fix watermark init bug

### DIFF
--- a/crates/sui-analytics-indexer/src/handlers/system_package_eviction.rs
+++ b/crates/sui-analytics-indexer/src/handlers/system_package_eviction.rs
@@ -16,6 +16,8 @@ use sui_types::full_checkpoint_content::Checkpoint;
 
 use crate::store::AnalyticsStore;
 
+pub const SYSTEM_PACKAGE_EVICTION_PIPELINE: &str = "SystemPackageEviction";
+
 pub struct SystemPackageEviction {
     package_cache: Arc<PackageStoreWithLruCache<RpcPackageStore>>,
     last_epoch: AtomicU64,
@@ -32,7 +34,7 @@ impl SystemPackageEviction {
 
 #[async_trait]
 impl Processor for SystemPackageEviction {
-    const NAME: &'static str = "SystemPackageEviction";
+    const NAME: &'static str = SYSTEM_PACKAGE_EVICTION_PIPELINE;
     type Value = ();
 
     async fn process(&self, checkpoint: &Arc<Checkpoint>) -> Result<Vec<()>> {

--- a/crates/sui-analytics-indexer/src/indexer.rs
+++ b/crates/sui-analytics-indexer/src/indexer.rs
@@ -30,6 +30,7 @@ use sui_rpc_resolver::package_store::RpcPackageStore;
 
 use crate::config::IndexerConfig;
 use crate::config::OutputStoreConfig;
+use crate::handlers::system_package_eviction::SYSTEM_PACKAGE_EVICTION_PIPELINE;
 use crate::handlers::system_package_eviction::SystemPackageEviction;
 use crate::metrics::Metrics;
 use crate::progress_monitoring::spawn_snowflake_monitors;
@@ -67,7 +68,7 @@ pub async fn build_analytics_indexer(
 
     let mut pipeline_filter = indexer_args.pipeline;
     if !pipeline_filter.is_empty() {
-        pipeline_filter.push("SystemPackageEviction".to_string());
+        pipeline_filter.push(SYSTEM_PACKAGE_EVICTION_PIPELINE.to_string());
     }
 
     let adjusted_indexer_args = IndexerArgs {

--- a/crates/sui-analytics-indexer/src/store/live.rs
+++ b/crates/sui-analytics-indexer/src/store/live.rs
@@ -295,6 +295,128 @@ mod tests {
         assert!(conn.accepts_chain_id("Checkpoint", chain_id).await.unwrap());
     }
 
+    /// Build a config with two pipelines (Checkpoint at prefix `cp`, Transaction at
+    /// prefix `tx`) that the SystemPackageEviction test cases derive their watermark from.
+    fn multi_pipeline_config(object_store: Arc<dyn object_store::ObjectStore>) -> IndexerConfig {
+        let mut cfg = test_config(object_store);
+        cfg.pipeline_configs = vec![
+            PipelineConfig {
+                pipeline: Pipeline::Checkpoint,
+                file_format: crate::config::FileFormat::Parquet,
+                package_id_filter: None,
+                sf_table_id: None,
+                sf_checkpoint_col_id: None,
+                report_sf_max_table_checkpoint: false,
+                batch_size: None,
+                output_prefix: Some("cp".to_string()),
+                force_batch_cut_after_secs: 600,
+                sequential: Default::default(),
+            },
+            PipelineConfig {
+                pipeline: Pipeline::Transaction,
+                file_format: crate::config::FileFormat::Parquet,
+                package_id_filter: None,
+                sf_table_id: None,
+                sf_checkpoint_col_id: None,
+                report_sf_max_table_checkpoint: false,
+                batch_size: None,
+                output_prefix: Some("tx".to_string()),
+                force_batch_cut_after_secs: 600,
+                sequential: Default::default(),
+            },
+        ];
+        cfg
+    }
+
+    fn eviction_store() -> (Arc<dyn object_store::ObjectStore>, AnalyticsStore) {
+        let object_store: Arc<dyn object_store::ObjectStore> = Arc::new(InMemory::new());
+        let config = multi_pipeline_config(object_store.clone());
+        let store = AnalyticsStore::new(object_store.clone(), config, test_metrics());
+        (object_store, store)
+    }
+
+    /// Simulate the framework's per-pipeline `init_watermark` calls in registration
+    /// order, populating the initial_watermarks cache before the eviction pipeline fires.
+    async fn prime_pipelines(conn: &mut crate::store::AnalyticsConnection<'_>, pipelines: &[&str]) {
+        for p in pipelines {
+            let _ = conn.committer_watermark(p).await.unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn test_eviction_watermark_max_across_pipelines() {
+        let (object_store, store) = eviction_store();
+        // Checkpoint at checkpoint 399 — higher, should dominate max
+        create_test_file(&object_store, "cp", 0, 0, 400).await;
+        // Transaction at checkpoint 199
+        create_test_file(&object_store, "tx", 0, 0, 200).await;
+
+        let mut conn = store.connect().await.unwrap();
+        prime_pipelines(&mut conn, &["Checkpoint", "Transaction"]).await;
+
+        let w = conn
+            .committer_watermark(
+                crate::handlers::system_package_eviction::SYSTEM_PACKAGE_EVICTION_PIPELINE,
+            )
+            .await
+            .unwrap()
+            .expect("expected Some watermark when other pipelines have files");
+        assert_eq!(w.checkpoint_hi_inclusive, 399);
+    }
+
+    #[tokio::test]
+    async fn test_eviction_watermark_nothing_primed_returns_none() {
+        // Eviction fires before any pipeline's init_watermark — initial_watermarks empty.
+        let (_object_store, store) = eviction_store();
+        let mut conn = store.connect().await.unwrap();
+        let w = conn
+            .committer_watermark(
+                crate::handlers::system_package_eviction::SYSTEM_PACKAGE_EVICTION_PIPELINE,
+            )
+            .await
+            .unwrap();
+        assert!(w.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_eviction_watermark_fresh_pipelines_returns_none() {
+        // Pipelines registered but no files written yet — each caches `None`, max of an
+        // empty filtered iter is `None`.
+        let (_object_store, store) = eviction_store();
+        let mut conn = store.connect().await.unwrap();
+        prime_pipelines(&mut conn, &["Checkpoint", "Transaction"]).await;
+
+        let w = conn
+            .committer_watermark(
+                crate::handlers::system_package_eviction::SYSTEM_PACKAGE_EVICTION_PIPELINE,
+            )
+            .await
+            .unwrap();
+        assert!(w.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_eviction_watermark_ignores_unregistered_pipelines() {
+        // Only Checkpoint is "registered" (its init_watermark fires). Transaction has
+        // newer files on disk but never goes through registration in this process, so
+        // it doesn't show up in initial_watermarks and is correctly ignored.
+        let (object_store, store) = eviction_store();
+        create_test_file(&object_store, "cp", 0, 0, 200).await;
+        create_test_file(&object_store, "tx", 0, 0, 400).await;
+
+        let mut conn = store.connect().await.unwrap();
+        prime_pipelines(&mut conn, &["Checkpoint"]).await;
+
+        let w = conn
+            .committer_watermark(
+                crate::handlers::system_package_eviction::SYSTEM_PACKAGE_EVICTION_PIPELINE,
+            )
+            .await
+            .unwrap()
+            .expect("expected Some watermark from registered pipeline");
+        assert_eq!(w.checkpoint_hi_inclusive, 199);
+    }
+
     #[tokio::test]
     async fn test_accepts_chain_id_mismatching_rejects() {
         let (object_store, store) = in_memory_store();

--- a/crates/sui-analytics-indexer/src/store/mod.rs
+++ b/crates/sui-analytics-indexer/src/store/mod.rs
@@ -44,6 +44,7 @@ use tracing::warn;
 use crate::config::FileFormat;
 use crate::config::IndexerConfig;
 use crate::handlers::CheckpointRows;
+use crate::handlers::system_package_eviction::SYSTEM_PACKAGE_EVICTION_PIPELINE;
 use crate::metrics::Metrics;
 use crate::schema::RowSchema;
 
@@ -149,6 +150,12 @@ pub struct AnalyticsStore {
     config: IndexerConfig,
     /// Schema for each pipeline, registered during pipeline setup.
     schemas_by_pipeline: Arc<RwLock<HashMap<String, &'static [&'static str]>>>,
+    /// Committer watermarks for pipelines whose `committer_watermark` has already been
+    /// invoked during framework registration, keyed by pipeline name. Populated as a
+    /// side effect of each call. `SystemPackageEviction` (registered last in
+    /// `build_analytics_indexer`) reads from this map to derive its own watermark as the
+    /// max across other pipelines — so the cache doubles as the set of enabled pipelines.
+    initial_watermarks: Arc<tokio::sync::Mutex<HashMap<String, Option<CommitterWatermark>>>>,
 }
 
 /// Connection to the analytics store.
@@ -278,6 +285,7 @@ impl AnalyticsStore {
             worker_handles: Arc::new(tokio::sync::Mutex::new(Vec::new())),
             config,
             schemas_by_pipeline: Arc::new(RwLock::new(HashMap::new())),
+            initial_watermarks: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
         }
     }
 
@@ -664,18 +672,48 @@ impl Connection for AnalyticsConnection<'_> {
     ///
     /// In live mode: scans file names in the object store.
     /// In migration mode: reads from watermark metadata file.
+    ///
+    /// `SystemPackageEviction` is a pseudohandler that never writes files, so its
+    /// watermark cannot be derived from its own `output_prefix`. It is always registered
+    /// last in `build_analytics_indexer`, so by the time this fires for it, each other
+    /// pipeline's watermark has already been computed and cached in `initial_watermarks`.
+    /// Return the max across those pipelines. The cache only matters at tip — it starts
+    /// empty on restart and only needs invalidation to clear entries staled by a live
+    /// epoch transition. Starting at the farthest-along pipeline means eviction sits idle
+    /// while slower pipelines backfill, then wakes up at tip where invalidation matters.
     async fn committer_watermark(
         &mut self,
         pipeline: &str,
     ) -> anyhow::Result<Option<CommitterWatermark>> {
+        if pipeline == SYSTEM_PACKAGE_EVICTION_PIPELINE {
+            let watermarks = self.store.initial_watermarks.lock().await;
+            let max = watermarks
+                .values()
+                .filter_map(|w| *w)
+                .max_by_key(|w| w.checkpoint_hi_inclusive);
+            if max.is_none() {
+                warn!(
+                    pipeline = SYSTEM_PACKAGE_EVICTION_PIPELINE,
+                    "No other pipelines have durable progress; falling back to framework default start checkpoint"
+                );
+            }
+            return Ok(max);
+        }
+
         let Some(config) = self.store.config.get_pipeline_config(pipeline) else {
             return Ok(None);
         };
         let output_prefix = config.output_prefix().to_string();
-        match &self.store.mode {
-            StoreMode::Live(store) => store.committer_watermark(&output_prefix).await,
-            StoreMode::Migration(store) => store.committer_watermark(&output_prefix).await,
-        }
+        let watermark = match &self.store.mode {
+            StoreMode::Live(store) => store.committer_watermark(&output_prefix).await?,
+            StoreMode::Migration(store) => store.committer_watermark(&output_prefix).await?,
+        };
+        self.store
+            .initial_watermarks
+            .lock()
+            .await
+            .insert(pipeline.to_string(), watermark);
+        Ok(watermark)
     }
 
     /// Store the watermark for use in commit_batch.


### PR DESCRIPTION
## Description

In (#26041) I migrated the analytics indexer to use the sui-rpc-resolver rather than it's older custom package cache implementation. I used a "pseudo pipeline" to invalidate the cache on epoch boundaries. This pipeline always returned a watermark of 0 at startup, which caused the indexer to stall when it was deployed.

The fix is to just choose the max of the other pipelines as this pipelines starting watermark.

## Test plan

Manualy deploying to testnet now to verify the fix.
