### PR TITLE
[forking 7/n] Add historical transaction query support in DataStore

### DIFF
--- a/crates/sui-forking/src/gql/client.rs
+++ b/crates/sui-forking/src/gql/client.rs
@@ -130,9 +130,9 @@ impl GraphQLClient {
 impl TransactionRead for GraphQLClient {
     fn transaction_data_and_effects(
         &self,
-        _tx_digest: &str,
+        tx_digest: &str,
     ) -> Result<Option<TransactionInfo>, Error> {
-        todo!("GraphQL transaction reads are not implemented in the skeleton")
+        block_on!(queries::txn_query::query(tx_digest.to_owned(), self))
     }
 }
 
@@ -503,5 +503,116 @@ mod tests {
             .expect("versioned object query should succeed");
 
         assert_eq!(objects, vec![None]);
+    }
+
+    fn transaction_response_body(
+        tx: &sui_types::full_checkpoint_content::ExecutedTransaction,
+        checkpoint: u64,
+    ) -> serde_json::Value {
+        let signatures: Vec<_> = tx
+            .signatures
+            .iter()
+            .map(|sig| {
+                json!({
+                    "signatureBytes": FastCryptoBase64::from_bytes(sig.as_ref()).encoded(),
+                })
+            })
+            .collect();
+        json!({
+            "data": {
+                "transaction": {
+                    "transactionBcs": FastCryptoBase64::from_bytes(
+                        &bcs::to_bytes(&tx.transaction).expect("transaction data should serialize"),
+                    )
+                    .encoded(),
+                    "signatures": signatures,
+                    "effects": {
+                        "checkpoint": { "sequenceNumber": checkpoint },
+                        "effectsBcs": FastCryptoBase64::from_bytes(
+                            &bcs::to_bytes(&tx.effects).expect("effects should serialize"),
+                        )
+                        .encoded(),
+                    },
+                }
+            }
+        })
+    }
+
+    #[tokio::test]
+    async fn test_get_transaction_data_and_effects() {
+        let server = MockServer::start().await;
+        let checkpoint = TestCheckpointBuilder::new(1)
+            .start_transaction(0)
+            .finish_transaction()
+            .build_checkpoint();
+        let executed = checkpoint
+            .transactions
+            .into_iter()
+            .next()
+            .expect("checkpoint should have one transaction");
+        let digest = sui_types::transaction::Transaction::from_generic_sig_data(
+            executed.transaction.clone(),
+            executed.signatures.clone(),
+        )
+        .digest()
+        .base58_encode();
+
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .and(header("user-agent", "sui-forking-vtest-version"))
+            .and(body_partial_json(json!({
+                "variables": {
+                    "digest": digest,
+                }
+            })))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(transaction_response_body(&executed, 42)),
+            )
+            .mount(&server)
+            .await;
+
+        let store = mock_store(&server);
+        let info = store
+            .transaction_data_and_effects(&digest)
+            .expect("transaction query should succeed")
+            .expect("transaction should be present");
+
+        assert_eq!(info.transaction.digest().base58_encode(), digest);
+        assert_eq!(info.effects, executed.effects);
+        assert_eq!(info.checkpoint, 42);
+
+        let requests = server
+            .received_requests()
+            .await
+            .expect("wiremock should record requests");
+        let request_body: serde_json::Value = requests[0]
+            .body_json()
+            .expect("request body should be json");
+        let query = request_body
+            .get("query")
+            .and_then(serde_json::Value::as_str)
+            .expect("query string should be present");
+        assert!(query.contains("transactionBcs"));
+        assert!(query.contains("signatures"));
+        assert!(query.contains("signatureBytes"));
+        assert!(query.contains("effectsBcs"));
+    }
+
+    #[tokio::test]
+    async fn test_get_transaction_returns_none() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "data": { "transaction": null }
+            })))
+            .mount(&server)
+            .await;
+
+        let store = mock_store(&server);
+        let info = store
+            .transaction_data_and_effects("missing-digest")
+            .expect("transaction query should succeed");
+        assert!(info.is_none());
     }
 }

--- a/crates/sui-forking/src/gql/queries.rs
+++ b/crates/sui-forking/src/gql/queries.rs
@@ -29,7 +29,13 @@ mod schema {
 
 pub(crate) mod txn_query {
     use super::*;
-    use sui_types::transaction::TransactionData;
+    use fastcrypto::traits::ToFromBytes;
+    use sui_types::signature::GenericSignature;
+    use sui_types::transaction::{
+        Transaction as SuiTransaction, TransactionData, VerifiedTransaction,
+    };
+
+    use crate::TransactionInfo;
 
     #[derive(cynic::Scalar, Debug, Clone)]
     #[cynic(graphql_type = "Base64")]
@@ -50,7 +56,13 @@ pub(crate) mod txn_query {
     #[derive(cynic::QueryFragment)]
     pub(crate) struct Transaction {
         transaction_bcs: Option<Base64>,
+        signatures: Vec<UserSignature>,
         effects: Option<TransactionEffects>,
+    }
+
+    #[derive(cynic::QueryFragment)]
+    pub(crate) struct UserSignature {
+        signature_bytes: Option<Base64>,
     }
 
     #[derive(cynic::QueryFragment)]
@@ -67,7 +79,7 @@ pub(crate) mod txn_query {
     pub(crate) async fn query(
         digest: String,
         client: &GraphQLClient,
-    ) -> Result<Option<(TransactionData, sui_types::effects::TransactionEffects, u64)>, Error> {
+    ) -> Result<Option<TransactionInfo>, Error> {
         let query = Query::build(TransactionDataArgs {
             digest: digest.clone(),
         });
@@ -102,6 +114,23 @@ pub(crate) mod txn_query {
             digest
         ))?;
 
+        let signatures: Vec<GenericSignature> = transaction
+            .signatures
+            .into_iter()
+            .map(|sig| {
+                let encoded = sig
+                    .signature_bytes
+                    .ok_or_else(|| anyhow!("Missing signatureBytes for transaction {}", digest))?;
+                let bytes = CryptoBase64::decode(&encoded.0).context(format!(
+                    "User signature does not decode for digest: {}",
+                    digest
+                ))?;
+                GenericSignature::from_bytes(&bytes).map_err(|e| {
+                    anyhow!("User signature parse failed for digest {}: {}", digest, e)
+                })
+            })
+            .collect::<Result<_, _>>()?;
+
         let effect_frag = transaction
             .effects
             .ok_or_else(|| anyhow!("Missing effects in transaction data response"))?;
@@ -124,10 +153,18 @@ pub(crate) mod txn_query {
 
         let checkpoint = effect_frag
             .checkpoint
-            .ok_or_else(|| anyhow!("Missing checkpoint in transaction query response"))?
+            .ok_or_else(|| anyhow!("Missing checkpoint in transaction data response"))?
             .sequence_number;
 
-        Ok(Some((txn_data, effects, checkpoint)))
+        let transaction = VerifiedTransaction::new_unchecked(
+            SuiTransaction::from_generic_sig_data(txn_data, signatures),
+        );
+
+        Ok(Some(TransactionInfo {
+            transaction,
+            effects,
+            checkpoint,
+        }))
     }
 }
 

--- a/crates/sui-forking/src/gql/queries.rs
+++ b/crates/sui-forking/src/gql/queries.rs
@@ -608,8 +608,10 @@ pub(crate) mod checkpoint_query {
 
         fn encode_bcs<T: serde::Serialize>(value: &T) -> Base64 {
             Base64(
-                FastCryptoBase64::from_bytes(&bcs::to_bytes(value).expect("value should serialize"))
-                    .encoded(),
+                FastCryptoBase64::from_bytes(
+                    &bcs::to_bytes(value).expect("value should serialize"),
+                )
+                .encoded(),
             )
         }
 
@@ -624,7 +626,8 @@ pub(crate) mod checkpoint_query {
                 content_bcs: Some(encode_bcs(&contents)),
                 validator_signatures: Some(ValidatorAggregatedSignature {
                     signature: Some(Base64(
-                        FastCryptoBase64::from_bytes(certified.auth_sig().signature.as_ref()).encoded(),
+                        FastCryptoBase64::from_bytes(certified.auth_sig().signature.as_ref())
+                            .encoded(),
                     )),
                     signers_map: certified
                         .auth_sig()
@@ -676,8 +679,10 @@ pub(crate) mod checkpoint_query {
                 content_bcs: Some(encode_bcs(&checkpoint.contents)),
                 validator_signatures: Some(ValidatorAggregatedSignature {
                     signature: Some(Base64(
-                        FastCryptoBase64::from_bytes(checkpoint.summary.auth_sig().signature.as_ref())
-                            .encoded(),
+                        FastCryptoBase64::from_bytes(
+                            checkpoint.summary.auth_sig().signature.as_ref(),
+                        )
+                        .encoded(),
                     )),
                     signers_map: vec![-1],
                 }),

--- a/crates/sui-forking/src/gql/queries.rs
+++ b/crates/sui-forking/src/gql/queries.rs
@@ -14,7 +14,7 @@
 
 use anyhow::{Context, Error, anyhow};
 use cynic::QueryBuilder;
-use fastcrypto::encoding::{Base64 as CryptoBase64, Encoding};
+use fastcrypto::encoding::{Base64 as FastCryptoBase64, Encoding};
 use itertools::Itertools;
 
 use crate::gql::client::GraphQLClient;
@@ -93,7 +93,7 @@ pub(crate) mod txn_query {
         };
 
         let txn_data: TransactionData = bcs::from_bytes(
-            &CryptoBase64::decode(
+            &FastCryptoBase64::decode(
                 &transaction
                     .transaction_bcs
                     .ok_or_else(|| {
@@ -121,7 +121,7 @@ pub(crate) mod txn_query {
                 let encoded = sig
                     .signature_bytes
                     .ok_or_else(|| anyhow!("Missing signatureBytes for transaction {}", digest))?;
-                let bytes = CryptoBase64::decode(&encoded.0).context(format!(
+                let bytes = FastCryptoBase64::decode(&encoded.0).context(format!(
                     "User signature does not decode for digest: {}",
                     digest
                 ))?;
@@ -135,7 +135,7 @@ pub(crate) mod txn_query {
             .effects
             .ok_or_else(|| anyhow!("Missing effects in transaction data response"))?;
         let effects: sui_types::effects::TransactionEffects = bcs::from_bytes(
-            &CryptoBase64::decode(
+            &FastCryptoBase64::decode(
                 &effect_frag
                     .effects_bcs
                     .ok_or_else(|| anyhow!("Missing effects bcs in transaction data response"))?
@@ -355,7 +355,7 @@ pub(crate) mod object_query {
                     .object_bcs
                     .ok_or_else(|| anyhow!("Object bcs is None for object"))?
                     .0;
-                let bytes = CryptoBase64::decode(&b64)?;
+                let bytes = FastCryptoBase64::decode(&b64)?;
                 let obj: Object = bcs::from_bytes(&bytes)?;
                 let version = frag
                     .version
@@ -545,7 +545,7 @@ pub(crate) mod checkpoint_query {
             ));
         };
 
-        let signature_bytes = CryptoBase64::decode(
+        let signature_bytes = FastCryptoBase64::decode(
             &validator_signatures
                 .signature
                 .ok_or_else(|| anyhow!("Missing aggregated checkpoint signature"))?
@@ -588,7 +588,7 @@ pub(crate) mod checkpoint_query {
     where
         T: serde::de::DeserializeOwned,
     {
-        let bytes = CryptoBase64::decode(
+        let bytes = FastCryptoBase64::decode(
             &field
                 .ok_or_else(|| anyhow!("Missing {} in checkpoint response", label))?
                 .0,
@@ -608,10 +608,8 @@ pub(crate) mod checkpoint_query {
 
         fn encode_bcs<T: serde::Serialize>(value: &T) -> Base64 {
             Base64(
-                FastCryptoBase64::from_bytes(
-                    &bcs::to_bytes(value).expect("value should serialize"),
-                )
-                .encoded(),
+                FastCryptoBase64::from_bytes(&bcs::to_bytes(value).expect("value should serialize"))
+                    .encoded(),
             )
         }
 
@@ -626,8 +624,7 @@ pub(crate) mod checkpoint_query {
                 content_bcs: Some(encode_bcs(&contents)),
                 validator_signatures: Some(ValidatorAggregatedSignature {
                     signature: Some(Base64(
-                        FastCryptoBase64::from_bytes(certified.auth_sig().signature.as_ref())
-                            .encoded(),
+                        FastCryptoBase64::from_bytes(certified.auth_sig().signature.as_ref()).encoded(),
                     )),
                     signers_map: certified
                         .auth_sig()
@@ -679,10 +676,8 @@ pub(crate) mod checkpoint_query {
                 content_bcs: Some(encode_bcs(&checkpoint.contents)),
                 validator_signatures: Some(ValidatorAggregatedSignature {
                     signature: Some(Base64(
-                        FastCryptoBase64::from_bytes(
-                            checkpoint.summary.auth_sig().signature.as_ref(),
-                        )
-                        .encoded(),
+                        FastCryptoBase64::from_bytes(checkpoint.summary.auth_sig().signature.as_ref())
+                            .encoded(),
                     )),
                     signers_map: vec![-1],
                 }),

--- a/crates/sui-forking/src/lib.rs
+++ b/crates/sui-forking/src/lib.rs
@@ -25,25 +25,27 @@ use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 use sui_types::messages_checkpoint::VerifiedCheckpoint;
 use sui_types::object::Object;
 use sui_types::supported_protocol_versions::ProtocolConfig;
-use sui_types::transaction::TransactionData;
+use sui_types::transaction::VerifiedTransaction;
 
 // ============================================================================
 // Read traits
 // ============================================================================
 
-/// Transaction data with effects and checkpoint.
+/// Signed transaction envelope paired with its execution effects and the checkpoint
+/// it was finalized in. The checkpoint is used by [`crate::store::DataStore`] as a
+/// pre-fork guard: remote results whose `checkpoint > forked_at_checkpoint` must not
+/// leak into a fork that has already diverged from the upstream chain.
 #[derive(Clone, Debug)]
 pub(crate) struct TransactionInfo {
-    pub(crate) data: TransactionData,
+    pub(crate) transaction: VerifiedTransaction,
     pub(crate) effects: TransactionEffects,
-    pub(crate) checkpoint: u64,
+    pub(crate) checkpoint: CheckpointSequenceNumber,
 }
 
 /// `TransactionRead` trait is used to retrieve transaction data for a given digest.
 pub(crate) trait TransactionRead {
-    /// Given a transaction digest, return transaction info including data, effects,
-    /// and the checkpoint that transaction was executed in.
-    /// Returns `None` if the transaction is not found.
+    /// Given a transaction digest, return the signed transaction, its effects, and the
+    /// checkpoint it was finalized in. Returns `None` if the transaction is not found.
     fn transaction_data_and_effects(
         &self,
         tx_digest: &str,

--- a/crates/sui-forking/src/store.rs
+++ b/crates/sui-forking/src/store.rs
@@ -41,6 +41,8 @@ use crate::GraphQLClient;
 use crate::Node;
 use crate::ObjectKey;
 use crate::ObjectRead;
+use crate::TransactionInfo;
+use crate::TransactionRead;
 use crate::VersionQuery;
 use crate::filesystem::FilesystemStore;
 
@@ -86,12 +88,9 @@ impl DataStore {
         self.gql.chain()
     }
 
-    /// Get a checkpoint summary by sequence number. Prefers the local cache;
-    /// on miss, any pre-fork checkpoint (`sequence <= forked_at_checkpoint`)
-    /// is fetched from the remote GraphQL endpoint and written back to disk
-    /// so subsequent reads hit the cache. Post-fork checkpoints are never
-    /// fetched remotely — they only exist if the local executor produced
-    /// them, so a miss returns `None`.
+    /// Get a checkpoint summary by sequence number. Tries the local filesystem first. If it's a
+    /// miss, then fetches it from remote if it's at or before the fork checkpoint and caches it
+    /// locally for next time.
     pub(crate) fn get_checkpoint_by_sequence_number(
         &self,
         sequence: CheckpointSequenceNumber,
@@ -169,8 +168,13 @@ impl DataStore {
         Ok(())
     }
 
-    /// Fetch a checkpoint pair from the remote GraphQL endpoint and persist
-    /// both halves to disk. Shared by the sequence-keyed cache-aware getters.
+    /// Get the highest checkpoint sequence number available on disk.
+    pub(crate) fn get_highest_checkpoint(&self) -> anyhow::Result<CheckpointSequenceNumber> {
+        self.local.get_highest_checkpoint_sequence_number()
+    }
+
+    /// Fetch checkpoint summary and contents from the remote GraphQL endpoint and persist them to
+    /// disk. Shared by the sequence-keyed cache-aware getters.
     fn fetch_and_cache_checkpoint(
         &self,
         sequence: CheckpointSequenceNumber,
@@ -265,9 +269,65 @@ impl DataStore {
             .map(|(object, _)| object))
     }
 
-    /// Get the highest checkpoint sequence number available on disk.
-    pub(crate) fn get_highest_checkpoint(&self) -> anyhow::Result<CheckpointSequenceNumber> {
-        self.local.get_highest_checkpoint_sequence_number()
+    /// Get a signed transaction by digest. First tries the local filesystem, and on miss it falls
+    /// back to the remote GraphQL endpoint. If the transaction is found remotely and is at or
+    /// before the fork checkpoint, then it is saved to disk before being returned. Transactions
+    /// produced by the local executor are always on disk.
+    ///
+    /// Note that currently historical reads do not include events, whereas local execution does
+    /// write events to disk.
+    pub(crate) fn get_transaction(
+        &self,
+        digest: &TransactionDigest,
+    ) -> anyhow::Result<Option<VerifiedTransaction>> {
+        if let Some(transaction) = self.local.get_transaction(digest)? {
+            return Ok(Some(transaction));
+        }
+        Ok(self
+            .fetch_and_cache_transaction(digest)?
+            .map(|info| info.transaction))
+    }
+
+    /// Get transaction effects by digest, with the same local-first remote-fallback
+    /// policy as [`Self::get_transaction`].
+    pub(crate) fn get_transaction_effects(
+        &self,
+        digest: &TransactionDigest,
+    ) -> anyhow::Result<Option<TransactionEffects>> {
+        if let Some(effects) = self.local.get_transaction_effects(digest)? {
+            return Ok(Some(effects));
+        }
+        Ok(self
+            .fetch_and_cache_transaction(digest)?
+            .map(|info| info.effects))
+    }
+
+    /// Fetch a transaction and its effects from the remote GraphQL endpoint and persist both halves
+    /// to disk. Shared by [`Self::get_transaction`] and [`Self::get_transaction_effects`] so a
+    /// single remote round-trip is used.
+    ///
+    /// Pre-fork guard: transaction digests aren't ordered, so we can't reject post-fork requests
+    /// up front the way [`Self::get_checkpoint_by_sequence_number`] does. Instead we check
+    /// `info.checkpoint` on the remote response and drop anything executed strictly after
+    /// `forked_at_checkpoint` so our fork doesn't silently absorb upstream activity that
+    /// happened after the fork point.
+    fn fetch_and_cache_transaction(
+        &self,
+        digest: &TransactionDigest,
+    ) -> anyhow::Result<Option<TransactionInfo>> {
+        let Some(info) = self
+            .gql
+            .transaction_data_and_effects(&digest.base58_encode())?
+        else {
+            return Ok(None);
+        };
+        if info.checkpoint > self.forked_at_checkpoint {
+            return Ok(None);
+        }
+        self.local.write_transaction(digest, &info.transaction)?;
+        self.local
+            .write_transaction_effects(digest, &info.effects)?;
+        Ok(Some(info))
     }
 
     /// Construct a `DataStore` for tests, backed by an explicit local root and a fake (unused)
@@ -280,6 +340,24 @@ impl DataStore {
         let local = FilesystemStore::new_with_root(root);
         Self {
             forked_at_checkpoint: 0,
+            gql,
+            local,
+        }
+    }
+
+    /// Test-only constructor that lets callers point the GraphQL client at an arbitrary URL
+    /// (e.g., a wiremock `MockServer`) and pin `forked_at_checkpoint` explicitly.
+    #[cfg(test)]
+    pub(crate) fn new_for_testing_with_remote(
+        root: std::path::PathBuf,
+        gql_url: String,
+        forked_at_checkpoint: CheckpointSequenceNumber,
+    ) -> Self {
+        let gql = GraphQLClient::new(Node::Custom(gql_url), "test")
+            .expect("graphql store with custom url should construct");
+        let local = FilesystemStore::new_with_root(root);
+        Self {
+            forked_at_checkpoint,
             gql,
             local,
         }
@@ -412,11 +490,13 @@ impl SimulatorStore for DataStore {
     }
 
     fn get_transaction(&self, digest: &TransactionDigest) -> Option<VerifiedTransaction> {
-        self.local.get_transaction(digest).ok().flatten()
+        DataStore::get_transaction(self, digest).ok().flatten()
     }
 
     fn get_transaction_effects(&self, digest: &TransactionDigest) -> Option<TransactionEffects> {
-        self.local.get_transaction_effects(digest).ok().flatten()
+        DataStore::get_transaction_effects(self, digest)
+            .ok()
+            .flatten()
     }
 
     fn get_transaction_events(&self, digest: &TransactionDigest) -> Option<TransactionEvents> {
@@ -555,3 +635,7 @@ mod checkpoint_persistence_tests;
 #[cfg(test)]
 #[path = "tests/store_execution.rs"]
 mod execution_tests;
+
+#[cfg(test)]
+#[path = "tests/store_transaction_fallback.rs"]
+mod transaction_fallback_tests;

--- a/crates/sui-forking/src/store.rs
+++ b/crates/sui-forking/src/store.rs
@@ -41,6 +41,8 @@ use crate::GraphQLClient;
 use crate::Node;
 use crate::ObjectKey;
 use crate::ObjectRead;
+use crate::TransactionInfo;
+use crate::TransactionRead;
 use crate::VersionQuery;
 use crate::filesystem::FilesystemStore;
 
@@ -86,12 +88,9 @@ impl DataStore {
         self.gql.chain()
     }
 
-    /// Get a checkpoint summary by sequence number. Prefers the local cache;
-    /// on miss, any pre-fork checkpoint (`sequence <= forked_at_checkpoint`)
-    /// is fetched from the remote GraphQL endpoint and written back to disk
-    /// so subsequent reads hit the cache. Post-fork checkpoints are never
-    /// fetched remotely — they only exist if the local executor produced
-    /// them, so a miss returns `None`.
+    /// Get a checkpoint summary by sequence number. Tries the local filesystem first. If it's a
+    /// miss, then fetches it from remote if it's at or before the fork checkpoint and caches it
+    /// locally for next time.
     pub(crate) fn get_checkpoint_by_sequence_number(
         &self,
         sequence: CheckpointSequenceNumber,
@@ -169,8 +168,13 @@ impl DataStore {
         Ok(())
     }
 
-    /// Fetch a checkpoint pair from the remote GraphQL endpoint and persist
-    /// both halves to disk. Shared by the sequence-keyed cache-aware getters.
+    /// Get the highest checkpoint sequence number available on disk.
+    pub(crate) fn get_highest_checkpoint(&self) -> anyhow::Result<CheckpointSequenceNumber> {
+        self.local.get_highest_checkpoint_sequence_number()
+    }
+
+    /// Fetch checkpoint summary and contents from the remote GraphQL endpoint and persist them to
+    /// disk. Shared by the sequence-keyed cache-aware getters.
     fn fetch_and_cache_checkpoint(
         &self,
         sequence: CheckpointSequenceNumber,
@@ -261,9 +265,65 @@ impl DataStore {
             .map(|(object, _)| object))
     }
 
-    /// Get the highest checkpoint sequence number available on disk.
-    pub(crate) fn get_highest_checkpoint(&self) -> anyhow::Result<CheckpointSequenceNumber> {
-        self.local.get_highest_checkpoint_sequence_number()
+    /// Get a signed transaction by digest. First tries the local filesystem, and on miss it falls
+    /// back to the remote GraphQL endpoint. If the transaction is found remotely and is at or
+    /// before the fork checkpoint, then it is saved to disk before being returned. Transactions
+    /// produced by the local executor are always on disk.
+    ///
+    /// Note that currently historical reads do not include events, whereas local execution does
+    /// write events to disk.
+    pub(crate) fn get_transaction(
+        &self,
+        digest: &TransactionDigest,
+    ) -> anyhow::Result<Option<VerifiedTransaction>> {
+        if let Some(transaction) = self.local.get_transaction(digest)? {
+            return Ok(Some(transaction));
+        }
+        Ok(self
+            .fetch_and_cache_transaction(digest)?
+            .map(|info| info.transaction))
+    }
+
+    /// Get transaction effects by digest, with the same local-first remote-fallback
+    /// policy as [`Self::get_transaction`].
+    pub(crate) fn get_transaction_effects(
+        &self,
+        digest: &TransactionDigest,
+    ) -> anyhow::Result<Option<TransactionEffects>> {
+        if let Some(effects) = self.local.get_transaction_effects(digest)? {
+            return Ok(Some(effects));
+        }
+        Ok(self
+            .fetch_and_cache_transaction(digest)?
+            .map(|info| info.effects))
+    }
+
+    /// Fetch a transaction and its effects from the remote GraphQL endpoint and persist both halves
+    /// to disk. Shared by [`Self::get_transaction`] and [`Self::get_transaction_effects`] so a
+    /// single remote round-trip is used.
+    ///
+    /// Pre-fork guard: transaction digests aren't ordered, so we can't reject post-fork requests
+    /// up front the way [`Self::get_checkpoint_by_sequence_number`] does. Instead we check
+    /// `info.checkpoint` on the remote response and drop anything executed strictly after
+    /// `forked_at_checkpoint` so our fork doesn't silently absorb upstream activity that
+    /// happened after the fork point.
+    fn fetch_and_cache_transaction(
+        &self,
+        digest: &TransactionDigest,
+    ) -> anyhow::Result<Option<TransactionInfo>> {
+        let Some(info) = self
+            .gql
+            .transaction_data_and_effects(&digest.base58_encode())?
+        else {
+            return Ok(None);
+        };
+        if info.checkpoint > self.forked_at_checkpoint {
+            return Ok(None);
+        }
+        self.local.write_transaction(digest, &info.transaction)?;
+        self.local
+            .write_transaction_effects(digest, &info.effects)?;
+        Ok(Some(info))
     }
 
     /// Construct a `DataStore` for tests, backed by an explicit local root and a fake (unused)
@@ -276,6 +336,24 @@ impl DataStore {
         let local = FilesystemStore::new_with_root(root);
         Self {
             forked_at_checkpoint: 0,
+            gql,
+            local,
+        }
+    }
+
+    /// Test-only constructor that lets callers point the GraphQL client at an arbitrary URL
+    /// (e.g., a wiremock `MockServer`) and pin `forked_at_checkpoint` explicitly.
+    #[cfg(test)]
+    pub(crate) fn new_for_testing_with_remote(
+        root: std::path::PathBuf,
+        gql_url: String,
+        forked_at_checkpoint: CheckpointSequenceNumber,
+    ) -> Self {
+        let gql = GraphQLClient::new(Node::Custom(gql_url), "test")
+            .expect("graphql store with custom url should construct");
+        let local = FilesystemStore::new_with_root(root);
+        Self {
+            forked_at_checkpoint,
             gql,
             local,
         }
@@ -408,11 +486,13 @@ impl SimulatorStore for DataStore {
     }
 
     fn get_transaction(&self, digest: &TransactionDigest) -> Option<VerifiedTransaction> {
-        self.local.get_transaction(digest).ok().flatten()
+        DataStore::get_transaction(self, digest).ok().flatten()
     }
 
     fn get_transaction_effects(&self, digest: &TransactionDigest) -> Option<TransactionEffects> {
-        self.local.get_transaction_effects(digest).ok().flatten()
+        DataStore::get_transaction_effects(self, digest)
+            .ok()
+            .flatten()
     }
 
     fn get_transaction_events(&self, digest: &TransactionDigest) -> Option<TransactionEvents> {
@@ -551,3 +631,7 @@ mod checkpoint_persistence_tests;
 #[cfg(test)]
 #[path = "tests/store_execution.rs"]
 mod execution_tests;
+
+#[cfg(test)]
+#[path = "tests/store_transaction_fallback.rs"]
+mod transaction_fallback_tests;

--- a/crates/sui-forking/src/tests/store_execution.rs
+++ b/crates/sui-forking/src/tests/store_execution.rs
@@ -93,10 +93,16 @@ fn test_advance_clock_executes_and_persists() {
 
     // The transaction was persisted to the filesystem cache.
     let tx_digest = effects.transaction_digest();
-    let persisted = sim.store().get_transaction(tx_digest);
+    let persisted = sim
+        .store()
+        .get_transaction(tx_digest)
+        .expect("transaction read should not error");
     assert!(persisted.is_some(), "transaction not persisted on disk");
 
-    let persisted_effects = sim.store().get_transaction_effects(tx_digest);
+    let persisted_effects = sim
+        .store()
+        .get_transaction_effects(tx_digest)
+        .expect("effects read should not error");
     assert_eq!(persisted_effects.unwrap(), effects);
 }
 
@@ -151,11 +157,17 @@ fn test_transfer_sui_executes_and_persists() {
     // The transaction is persisted on disk.
     let tx_digest = effects.transaction_digest();
     assert!(
-        sim.store().get_transaction(tx_digest).is_some(),
+        sim.store()
+            .get_transaction(tx_digest)
+            .expect("transaction read should not error")
+            .is_some(),
         "transaction not persisted on disk",
     );
     assert_eq!(
-        sim.store().get_transaction_effects(tx_digest).unwrap(),
+        sim.store()
+            .get_transaction_effects(tx_digest)
+            .expect("effects read should not error")
+            .unwrap(),
         effects,
     );
 

--- a/crates/sui-forking/src/tests/store_transaction_fallback.rs
+++ b/crates/sui-forking/src/tests/store_transaction_fallback.rs
@@ -1,0 +1,168 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Transaction fallback tests for [`crate::store::DataStore`]. Covers the local-hit
+//! path and the remote-fallback pre-fork guard. Wired in from `store.rs` via a
+//! `#[path]` module so it has `super::*` access to `pub(crate)` items.
+
+use fastcrypto::encoding::{Base64 as FastCryptoBase64, Encoding};
+use serde_json::json;
+use sui_types::full_checkpoint_content::ExecutedTransaction;
+use sui_types::test_checkpoint_data_builder::TestCheckpointBuilder;
+use sui_types::transaction::{Transaction as SuiTransaction, VerifiedTransaction};
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use super::*;
+
+fn executed_transaction() -> ExecutedTransaction {
+    TestCheckpointBuilder::new(1)
+        .start_transaction(0)
+        .finish_transaction()
+        .build_checkpoint()
+        .transactions
+        .into_iter()
+        .next()
+        .expect("checkpoint should have one transaction")
+}
+
+fn signed_transaction(executed: &ExecutedTransaction) -> VerifiedTransaction {
+    VerifiedTransaction::new_unchecked(SuiTransaction::from_generic_sig_data(
+        executed.transaction.clone(),
+        executed.signatures.clone(),
+    ))
+}
+
+fn transaction_response(executed: &ExecutedTransaction, checkpoint: u64) -> serde_json::Value {
+    let signatures: Vec<_> = executed
+        .signatures
+        .iter()
+        .map(|sig| {
+            json!({
+                "signatureBytes": FastCryptoBase64::from_bytes(sig.as_ref()).encoded(),
+            })
+        })
+        .collect();
+    json!({
+        "data": {
+            "transaction": {
+                "transactionBcs": FastCryptoBase64::from_bytes(
+                    &bcs::to_bytes(&executed.transaction).expect("transaction data should serialize"),
+                )
+                .encoded(),
+                "signatures": signatures,
+                "effects": {
+                    "checkpoint": { "sequenceNumber": checkpoint },
+                    "effectsBcs": FastCryptoBase64::from_bytes(
+                        &bcs::to_bytes(&executed.effects).expect("effects should serialize"),
+                    )
+                    .encoded(),
+                }
+            }
+        }
+    })
+}
+
+#[tokio::test]
+async fn local_hit_returns_transaction_without_remote() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let store = DataStore::new_for_testing(temp.path().to_path_buf());
+
+    let executed = executed_transaction();
+    let verified = signed_transaction(&executed);
+    let digest = *verified.digest();
+
+    // Pre-populate the filesystem; the fake GraphQL URL in `new_for_testing`
+    // would fail if the remote path were reached.
+    store
+        .local
+        .write_transaction(&digest, &verified)
+        .expect("write transaction");
+    store
+        .local
+        .write_transaction_effects(&digest, &executed.effects)
+        .expect("write effects");
+
+    let got = DataStore::get_transaction(&store, &digest)
+        .expect("local hit should not error")
+        .expect("transaction should be cached");
+    assert_eq!(*got.digest(), digest);
+
+    let got_effects = DataStore::get_transaction_effects(&store, &digest)
+        .expect("local hit should not error")
+        .expect("effects should be cached");
+    assert_eq!(got_effects, executed.effects);
+}
+
+#[tokio::test]
+async fn remote_fallback_caches_pre_fork_transaction() {
+    let server = MockServer::start().await;
+    let executed = executed_transaction();
+    let verified = signed_transaction(&executed);
+    let digest = *verified.digest();
+    let digest_str = digest.base58_encode();
+
+    Mock::given(method("POST"))
+        .and(path("/"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(transaction_response(&executed, 5)))
+        .mount(&server)
+        .await;
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let store = DataStore::new_for_testing_with_remote(temp.path().to_path_buf(), server.uri(), 10);
+
+    let got = DataStore::get_transaction(&store, &digest)
+        .expect("remote fetch should succeed")
+        .expect("transaction should be fetched");
+    assert_eq!(got.digest().base58_encode(), digest_str);
+
+    // Second call should hit the filesystem cache, not the remote.
+    assert!(
+        store
+            .local
+            .get_transaction(&digest)
+            .expect("local lookup after remote hit")
+            .is_some(),
+        "transaction should have been written back to local cache",
+    );
+    assert!(
+        store
+            .local
+            .get_transaction_effects(&digest)
+            .expect("local effects lookup after remote hit")
+            .is_some(),
+        "effects should have been written back to local cache",
+    );
+}
+
+#[tokio::test]
+async fn remote_fallback_rejects_post_fork_transaction() {
+    let server = MockServer::start().await;
+    let executed = executed_transaction();
+    let verified = signed_transaction(&executed);
+    let digest = *verified.digest();
+
+    // Remote reports this tx was executed at checkpoint 42, but the fork is pinned at 10.
+    Mock::given(method("POST"))
+        .and(path("/"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(transaction_response(&executed, 42)))
+        .mount(&server)
+        .await;
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let store = DataStore::new_for_testing_with_remote(temp.path().to_path_buf(), server.uri(), 10);
+
+    let got = DataStore::get_transaction(&store, &digest)
+        .expect("remote fetch should not error on post-fork digest");
+    assert!(got.is_none(), "post-fork transaction must not be returned");
+
+    // And it must not have been cached to disk.
+    assert!(
+        store
+            .local
+            .get_transaction(&digest)
+            .expect("local lookup after rejected remote")
+            .is_none(),
+        "post-fork transaction must not be written to the local cache",
+    );
+}


### PR DESCRIPTION
## Description 

This PR adds support for fetching historical transactions in addition to the ones executed locally. If a transaction is requested, local filesystem is first hit; if it does not exist, then it queries GraphQL and also requests the checkpoint in which this transaction was included. If that checkpoint is higher than the checkpoint at which this was forked at, it returns None.

## Test plan 
A few new tests.
```
cargo nextest run
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
