### PR TITLE
sui-kvstore: implement accepts_chain_id

### DIFF
--- a/crates/sui-kvstore/src/bigtable/client/mod.rs
+++ b/crates/sui-kvstore/src/bigtable/client/mod.rs
@@ -417,6 +417,44 @@ impl BigTableClient {
         Ok(!predicate_matched)
     }
 
+    /// Returns `true` iff the supplied `chain_id` matches the chain_id stored for `pipeline`.
+    /// On the first call (no chain_id cell yet) writes `chain_id` and returns `true`. The
+    /// chain_id cell is independent of the v1 watermark cells, so this can be invoked before
+    /// `init_watermark`.
+    pub async fn accepts_chain_id(&mut self, pipeline: &str, chain_id: [u8; 32]) -> Result<bool> {
+        use tables::watermarks::col;
+        let mutations =
+            build_set_cell_mutations([(col::CHAIN_ID, Bytes::copy_from_slice(&chain_id))]);
+        let predicate = column_exists_filter(col::CHAIN_ID);
+        // Predicate is "row already has a chain_id" → false_mutations write the new chain_id
+        // when nothing is stored yet.
+        let predicate_matched = self
+            .check_and_mutate_row(
+                tables::watermarks::NAME,
+                tables::watermarks::encode_key(pipeline),
+                Some(predicate),
+                Vec::new(),
+                mutations,
+            )
+            .await?;
+        if !predicate_matched {
+            return Ok(true);
+        }
+        let row = self.get_pipeline_watermark_rows(pipeline).await?;
+        let cell = row
+            .iter()
+            .find_map(|(c, v)| (c.as_ref() == col::CHAIN_ID.as_bytes()).then_some(v))
+            .context("chain_id missing after CAS reported it present")?;
+        let stored: [u8; 32] = cell.as_ref().try_into().map_err(|_| {
+            anyhow::anyhow!(
+                "`{}` column has unexpected length {} (expected 32)",
+                col::CHAIN_ID,
+                cell.len()
+            )
+        })?;
+        Ok(stored == chain_id)
+    }
+
     /// Create the row for a pipeline iff no schema-version cell exists yet. Used by
     /// `init_watermark` for fresh rows and the v0 → v1 bootstrap. Returns `true` iff the
     /// write happened.
@@ -446,7 +484,7 @@ impl BigTableClient {
             cells.push((col::WATERMARK_V0, Bytes::from(bcs::to_bytes(&v0)?)));
         }
         let mutations = build_set_cell_mutations(cells);
-        let predicate = schema_version_column_exists_filter();
+        let predicate = column_exists_filter(tables::watermarks::col::SCHEMA_VERSION);
         // Predicate is "row has any schema-version cell" → false_mutations write the new row.
         let predicate_matched = self
             .check_and_mutate_row(
@@ -1272,10 +1310,9 @@ fn column_value_at_least_filter(column: &str, value: Bytes) -> RowFilter {
     }
 }
 
-/// Build a `RowFilter` matching any cell in the `sui:v` (schema-version) column. Used as the
-/// predicate for the "create-if-absent" path: if the predicate matches, the row already exists
-/// in the new schema.
-fn schema_version_column_exists_filter() -> RowFilter {
+/// Build a `RowFilter` matching any cell in the `sui:<column>` column. Used as a CAS predicate
+/// for "create-if-absent" paths: if the predicate matches, the cell already exists.
+fn column_exists_filter(column: &str) -> RowFilter {
     RowFilter {
         filter: Some(Filter::Chain(Chain {
             filters: vec![
@@ -1285,7 +1322,7 @@ fn schema_version_column_exists_filter() -> RowFilter {
                 RowFilter {
                     filter: Some(Filter::ColumnQualifierRegexFilter(Bytes::from(format!(
                         "^{}$",
-                        tables::watermarks::col::SCHEMA_VERSION
+                        column
                     )))),
                 },
             ],

--- a/crates/sui-kvstore/src/bigtable/store.rs
+++ b/crates/sui-kvstore/src/bigtable/store.rs
@@ -177,13 +177,8 @@ impl Connection for BigTableConnection<'_> {
         }))
     }
 
-    async fn accepts_chain_id(
-        &mut self,
-        _pipeline_task: &str,
-        _chain_id: [u8; 32],
-    ) -> Result<bool> {
-        // TODO: Implement storing chain_id
-        Ok(true)
+    async fn accepts_chain_id(&mut self, pipeline_task: &str, chain_id: [u8; 32]) -> Result<bool> {
+        self.client.accepts_chain_id(pipeline_task, chain_id).await
     }
 
     async fn committer_watermark(
@@ -327,6 +322,36 @@ mod tests {
             .await
             .unwrap();
         (emulator, BigTableStore::new(client))
+    }
+
+    #[tokio::test]
+    async fn test_accepts_chain_id_first_call_writes_and_accepts() {
+        let (_emulator, store) = store_conn().await;
+        let mut conn = store.connect().await.unwrap();
+
+        let chain_id = [1u8; 32];
+        assert!(conn.accepts_chain_id(PIPELINE, chain_id).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_accepts_chain_id_matching_accepts() {
+        let (_emulator, store) = store_conn().await;
+        let mut conn = store.connect().await.unwrap();
+
+        let chain_id = [1u8; 32];
+        assert!(conn.accepts_chain_id(PIPELINE, chain_id).await.unwrap());
+        assert!(conn.accepts_chain_id(PIPELINE, chain_id).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_accepts_chain_id_mismatching_rejects() {
+        let (_emulator, store) = store_conn().await;
+        let mut conn = store.connect().await.unwrap();
+
+        let chain_id_a = [1u8; 32];
+        let chain_id_b = [2u8; 32];
+        assert!(conn.accepts_chain_id(PIPELINE, chain_id_a).await.unwrap());
+        assert!(!conn.accepts_chain_id(PIPELINE, chain_id_b).await.unwrap());
     }
 
     #[tokio::test]

--- a/crates/sui-kvstore/src/tables/watermarks.rs
+++ b/crates/sui-kvstore/src/tables/watermarks.rs
@@ -35,6 +35,9 @@ pub mod col {
     pub const READER_LO: &str = "rl";
     pub const PRUNER_HI: &str = "ph";
     pub const PRUNER_TIMESTAMP_MS: &str = "ptm";
+    /// Per-pipeline chain id (raw 32 bytes). Independent of the `v1` schema cells —
+    /// written by `accepts_chain_id` and ignored by watermark decoding.
+    pub const CHAIN_ID: &str = "cid";
 }
 
 /// Current schema version written into the `v` cell.


### PR DESCRIPTION
## Description
    
Stores the `chain_id` in a new `cid` cell on the pipeline's watermark row via a `CheckAndMutateRow` that writes only when the cell is absent; on conflict, reads the stored id back and compares.                   

## Test plan
    
Added new unit tests.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
