### PR TITLE
ci: add setup-mold composite action for faster Linux linking

### DIFF
--- a/.github/actions/setup-mold/action.yml
+++ b/.github/actions/setup-mold/action.yml
@@ -1,0 +1,26 @@
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Setup mold linker
+description: Install mold and configure RUSTFLAGS on Linux for faster linking. No-op on non-Linux.
+
+runs:
+  using: composite
+  steps:
+    - name: Install mold linker (Linux)
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y mold
+        mold --version
+
+    - name: Configure RUSTFLAGS for mold (Linux)
+      if: runner.os == 'Linux'
+      shell: bash
+      # RUSTFLAGS env fully replaces [build].rustflags from .cargo/config.toml, so the
+      # baseline flags are replicated here alongside -C link-arg=-fuse-ld=mold. All Linux
+      # consumers of the mystenlabs-sccache bucket must share identical RUSTFLAGS for cache
+      # keys to match — route every such workflow through this action rather than duplicating.
+      run: |
+        echo "RUSTFLAGS=-C force-frame-pointers=yes -C force-unwind-tables=yes -A unknown_lints -A mismatched_lifetime_syntaxes -C link-arg=-fuse-ld=mold" >> "$GITHUB_ENV"

--- a/.github/actions/setup-sccache/action.yml
+++ b/.github/actions/setup-sccache/action.yml
@@ -18,21 +18,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Install mold linker (Linux)
-      if: runner.os == 'Linux'
-      shell: bash
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y mold
-        mold --version
-
-    - name: Configure RUSTFLAGS for mold (Linux)
-      if: runner.os == 'Linux'
-      shell: bash
-      # RUSTFLAGS env replaces (not appends to) [build].rustflags from .cargo/config.toml,
-      # so the baseline flags are replicated here. Keep in sync with .cargo/config.toml.
-      run: |
-        echo "RUSTFLAGS=-C force-frame-pointers=yes -C force-unwind-tables=yes -A unknown_lints -A mismatched_lifetime_syntaxes -C link-arg=-fuse-ld=mold" >> "$GITHUB_ENV"
+    - uses: ./.github/actions/setup-mold
 
     - name: Configure AWS credentials
       if: inputs.aws-access-key-id != ''

--- a/.github/actions/setup-sccache/action.yml
+++ b/.github/actions/setup-sccache/action.yml
@@ -18,6 +18,22 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Install mold linker (Linux)
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y mold
+        mold --version
+
+    - name: Configure RUSTFLAGS for mold (Linux)
+      if: runner.os == 'Linux'
+      shell: bash
+      # RUSTFLAGS env replaces (not appends to) [build].rustflags from .cargo/config.toml,
+      # so the baseline flags are replicated here. Keep in sync with .cargo/config.toml.
+      run: |
+        echo "RUSTFLAGS=-C force-frame-pointers=yes -C force-unwind-tables=yes -A unknown_lints -A mismatched_lifetime_syntaxes -C link-arg=-fuse-ld=mold" >> "$GITHUB_ENV"
+
     - name: Configure AWS credentials
       if: inputs.aws-access-key-id != ''
       uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # pin@v5.1.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,6 +162,23 @@ jobs:
           sudo rm -rf ~/Library/Developer/Xcode/iOS\ DeviceSupport/*
           df -h /
 
+      - name: Install mold linker (Linux)
+        if: ${{ runner.os == 'Linux' && env.s3_existing_archive == '' }}
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y mold
+          mold --version
+
+      - name: Configure RUSTFLAGS for mold (Linux)
+        if: ${{ runner.os == 'Linux' && env.s3_existing_archive == '' }}
+        shell: bash
+        # Must match sccache-warmup.yml and .github/actions/setup-sccache: RUSTFLAGS is
+        # part of the sccache cache key, so all consumers of the mystenlabs-sccache bucket
+        # on Linux need the same flag set to share cache entries.
+        run: |
+          echo "RUSTFLAGS=-C force-frame-pointers=yes -C force-unwind-tables=yes -A unknown_lints -A mismatched_lifetime_syntaxes -C link-arg=-fuse-ld=mold" >> "$GITHUB_ENV"
+
       - name: Setup sccache
         if: ${{ env.s3_existing_archive == '' }}
         id: sccache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,22 +162,8 @@ jobs:
           sudo rm -rf ~/Library/Developer/Xcode/iOS\ DeviceSupport/*
           df -h /
 
-      - name: Install mold linker (Linux)
-        if: ${{ runner.os == 'Linux' && env.s3_existing_archive == '' }}
-        shell: bash
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y mold
-          mold --version
-
-      - name: Configure RUSTFLAGS for mold (Linux)
-        if: ${{ runner.os == 'Linux' && env.s3_existing_archive == '' }}
-        shell: bash
-        # Must match sccache-warmup.yml and .github/actions/setup-sccache: RUSTFLAGS is
-        # part of the sccache cache key, so all consumers of the mystenlabs-sccache bucket
-        # on Linux need the same flag set to share cache entries.
-        run: |
-          echo "RUSTFLAGS=-C force-frame-pointers=yes -C force-unwind-tables=yes -A unknown_lints -A mismatched_lifetime_syntaxes -C link-arg=-fuse-ld=mold" >> "$GITHUB_ENV"
+      - uses: ./.github/actions/setup-mold
+        if: ${{ env.s3_existing_archive == '' }}
 
       - name: Setup sccache
         if: ${{ env.s3_existing_archive == '' }}

--- a/.github/workflows/sccache-warmup.yml
+++ b/.github/workflows/sccache-warmup.yml
@@ -91,6 +91,22 @@ jobs:
           sudo rm -rf ~/Library/Developer/Xcode/iOS\ DeviceSupport/*
           df -h /
 
+      - name: Install mold linker (Linux)
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y mold
+          mold --version
+
+      - name: Configure RUSTFLAGS for mold (Linux)
+        if: runner.os == 'Linux'
+        shell: bash
+        # Keep in sync with .cargo/config.toml [build].rustflags — RUSTFLAGS env replaces
+        # (not appends to) the config file's rustflags.
+        run: |
+          echo "RUSTFLAGS=-C force-frame-pointers=yes -C force-unwind-tables=yes -A unknown_lints -A mismatched_lifetime_syntaxes -C link-arg=-fuse-ld=mold" >> "$GITHUB_ENV"
+
       - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # pin@v0.0.9
 
       - name: Register cargo problem matcher

--- a/.github/workflows/sccache-warmup.yml
+++ b/.github/workflows/sccache-warmup.yml
@@ -91,21 +91,7 @@ jobs:
           sudo rm -rf ~/Library/Developer/Xcode/iOS\ DeviceSupport/*
           df -h /
 
-      - name: Install mold linker (Linux)
-        if: runner.os == 'Linux'
-        shell: bash
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y mold
-          mold --version
-
-      - name: Configure RUSTFLAGS for mold (Linux)
-        if: runner.os == 'Linux'
-        shell: bash
-        # Keep in sync with .cargo/config.toml [build].rustflags — RUSTFLAGS env replaces
-        # (not appends to) the config file's rustflags.
-        run: |
-          echo "RUSTFLAGS=-C force-frame-pointers=yes -C force-unwind-tables=yes -A unknown_lints -A mismatched_lifetime_syntaxes -C link-arg=-fuse-ld=mold" >> "$GITHUB_ENV"
+      - uses: ./.github/actions/setup-mold
 
       - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # pin@v0.0.9
 


### PR DESCRIPTION
## Summary
- Add `.github/actions/setup-mold` composite action that installs `mold` and configures `RUSTFLAGS` to use it via `-fuse-ld=mold` (Linux only; no-op elsewhere)
- Route every Linux cache consumer in this repo through it:
  - `setup-sccache` composite → covers `rust.yml` (PR CI), `nightly.yml`, `external.yml`
  - `sccache-warmup.yml` → direct reference
  - `release.yml` → direct reference (gated on archive-not-exists)
- Windows / macOS runners unchanged; local developer environments unchanged (CI-only `RUSTFLAGS` override)

**Why**: PR CI Linux builds currently link with the default `ld.bfd`/`ld.gold`. At this workspace's scale, linking is a meaningful fraction of wall-clock even with sccache hit rate at ~96% on Linux — sccache cannot cache link steps. `mold` is typically 5–10× faster than the default linker on Rust workspaces of this size.

**Expected impact**: 10–20% wall-clock reduction on Linux PR CI jobs (`test`, `test-tidehunter`, `test-extra`, `simtest`, `simtest-mainnet`, `clippy`, `benchmark-smoke`, `sui-excution-cut`, `move-test`) plus Linux release binary builds.

## Architecture
`.github/actions/setup-mold/action.yml` is the single source of truth for the `RUSTFLAGS` string. Any future workflow that builds Rust on Linux and consumes the `mystenlabs-sccache` bucket should either:
- Use the `setup-sccache` composite (which already pulls in `setup-mold`), or
- Reference `- uses: ./.github/actions/setup-mold` directly

This guarantees all Linux consumers produce matching sccache cache keys.

## Why release.yml is included
`RUSTFLAGS` is part of sccache's cache key. If the warmup job starts building with mold but `release.yml` doesn't, the warmup populates mold-keyed entries that release cannot consume — regressing release builds to cold cache. All three direct sccache consumers in this repo (composite, warmup, release) must stay consistent. (Credit: surfaced in review by codex.)

## Follow-up required in sui-operations
`MystenLabs/sui-operations` has its own release-binary build workflow that also writes to `mystenlabs-sccache` on Linux. It needs the same `setup-mold`-equivalent steps to stay cache-compatible. Until that follow-up lands, sui-operations release builds will experience a cold-cache regression after this PR merges.

## Design notes

**Why env, not `.cargo/config.toml`**: `RUSTFLAGS` is set via env rather than `.cargo/config.toml` so local developer setups don't suddenly require `mold`. Tradeoff: `RUSTFLAGS` env fully replaces `[build].rustflags` from `.cargo/config.toml`, so the baseline flags (`force-frame-pointers=yes`, `force-unwind-tables=yes`, lint allows) are replicated inside `setup-mold`. If `.cargo/config.toml`'s `[build].rustflags` ever changes, `setup-mold/action.yml` must be updated to match. A comment at the duplication site calls this out.

**First post-merge run will be slow**: adding the mold flag shifts the sccache cache key. The first PR CI / release run after merge will see a much lower hit rate while the cache repopulates. The daily `sccache-warmup` job rebuilds it within 24h; manual dispatch immediately after merge is recommended to minimize the window.

## Testing note
End-to-end testing on the PR branch is limited: `sccache-warmup.yml` hardcodes `ref: main` in its checkout step (line 45), so dispatching the warmup against this branch checks out main — which lacks the `setup-mold` action — and fails. Options for pre-merge validation:
1. Land a small follow-up that un-pins the warmup checkout (`github.ref` instead of `ref: main`) to enable branch-level testing
2. Merge, then dispatch `sccache-warmup.yml` and compare against baseline

## Test plan
- [ ] PR CI on this branch: `Install mold linker (Linux)` and `Configure RUSTFLAGS for mold (Linux)` steps succeed on every Linux job (delivered via the `setup-mold` composite)
- [ ] Windows jobs (`windows-build`, `windows-cli-tests`) skip the mold steps — verified via `if: runner.os == 'Linux'` inside `setup-mold`
- [ ] PR CI `Post Set up sccache` output: expect Rust hit rate to drop sharply on this first run (new cache key) and recover after the next warmup — this is the expected invalidation behavior, not a regression
- [ ] After merge: manually dispatch `sccache-warmup.yml` on main to repopulate mold-keyed cache within ~90 min (slowest leg is `macos-latest-large`)
- [ ] After warmup completes: trigger a representative PR CI run and compare wall-clock vs. a pre-merge baseline (baseline reference: ubuntu-ghcloud warmup at ~34m14s / 96% hit on main prior to this PR)
- [ ] Next release tag build (or manual `release.yml` dispatch) picks up warmed mold-keyed cache cleanly — full coverage of this check requires the sui-operations follow-up PR to also land

🤖 Generated with [Claude Code](https://claude.com/claude-code)