### PR TITLE
[sui-package-resolver] Parametrize `Resolver` by async/sync and introduce `SyncResolver`

### DIFF
--- a/crates/sui-package-resolver/src/lib.rs
+++ b/crates/sui-package-resolver/src/lib.rs
@@ -25,6 +25,7 @@ use move_binary_format::file_format::StructDefinitionIndex;
 use move_binary_format::file_format::StructFieldInformation;
 use move_binary_format::file_format::TableIndex;
 use move_binary_format::file_format::Visibility;
+use move_binary_format::partial_vm_error;
 use move_command_line_common::display::RenderResult;
 use move_command_line_common::display::try_render_constant;
 use move_command_line_common::error_bitset::ErrorBitset;
@@ -76,8 +77,6 @@ pub struct Resolver<S> {
 #[derive(Debug)]
 pub struct SyncResolver<S> {
     package_store: S,
-    // Read by the sync resolution methods added in a later commit.
-    #[allow(dead_code)]
     limits: Option<Limits>,
 }
 
@@ -716,6 +715,241 @@ impl<S: PackageStore> Resolver<S> {
     ) -> Option<CleverError> {
         let _bitset = ErrorBitset::from_u64(abort_code)?;
         let package = self.package_store.fetch(*module_id.address()).await.ok()?;
+        package.resolve_clever_error(module_id.name().as_str(), abort_code)
+    }
+}
+
+// The methods below are line-for-line copies of the equivalent `Resolver` methods above, with
+// the `async`/`.await`/`_sync` adjustments needed for synchronous fetching. If you change one,
+// change both. The internal helpers `add_type_tag_sync` / `add_signature_sync` on
+// `ResolutionContext` are similarly paired with `add_type_tag` / `add_signature`.
+impl<S: SyncPackageStore> SyncResolver<S> {
+    pub fn canonical_type(&self, mut tag: TypeTag) -> Result<TypeTag> {
+        let mut context = ResolutionContext::new(self.limits.as_ref());
+
+        // (1). Fetch all the information from this store that is necessary to relocate package IDs
+        // in the type.
+        context.add_type_tag_sync(
+            &mut tag,
+            &self.package_store,
+            /* visit_fields */ false,
+            /* visit_phantoms */ true,
+        )?;
+
+        // (2). Use that information to relocate package IDs in the type.
+        context.canonicalize_type(&mut tag)?;
+        Ok(tag)
+    }
+
+    pub fn type_layout(&self, mut tag: TypeTag) -> Result<MoveTypeLayout> {
+        let mut context = ResolutionContext::new(self.limits.as_ref());
+
+        // (1). Fetch all the information from this store that is necessary to resolve types
+        // referenced by this tag.
+        context.add_type_tag_sync(
+            &mut tag,
+            &self.package_store,
+            /* visit_fields */ true,
+            /* visit_phantoms */ true,
+        )?;
+
+        // (2). Use that information to resolve the tag into a layout.
+        let max_depth = self
+            .limits
+            .as_ref()
+            .map_or(usize::MAX, |l| l.max_move_value_depth);
+
+        Ok(context.resolve_type_layout(&tag, max_depth)?.0)
+    }
+
+    pub fn datatype_layout(&self, struct_tag: &StructTag) -> Result<A::MoveDatatypeLayout> {
+        let type_tag = TypeTag::Struct(Box::new(struct_tag.clone()));
+        let layout = self.type_layout(type_tag)?;
+        match layout {
+            MoveTypeLayout::Struct(s) => Ok(A::MoveDatatypeLayout::Struct(s)),
+            MoveTypeLayout::Enum(e) => Ok(A::MoveDatatypeLayout::Enum(e)),
+            layout => {
+                // This error is unexpected because a `StructTag` should always resolve to either a
+                // struct or enum layout, and if it doesn't, it likely means there is a bug in the
+                // resolver logic.
+                return Err(Error::UnexpectedError(Arc::new(partial_vm_error!(
+                    UNKNOWN_INVARIANT_VIOLATION_ERROR,
+                    "StructTag {:#?} did not resolve to a struct or enum layout: {:#?}",
+                    struct_tag,
+                    layout
+                ))));
+            }
+        }
+    }
+
+    pub fn abilities(&self, mut tag: TypeTag) -> Result<AbilitySet> {
+        let mut context = ResolutionContext::new(self.limits.as_ref());
+
+        // (1). Fetch all the information from this store that is necessary to resolve types
+        // referenced by this tag.
+        context.add_type_tag_sync(
+            &mut tag,
+            &self.package_store,
+            /* visit_fields */ false,
+            /* visit_phantoms */ false,
+        )?;
+
+        // (2). Use that information to calculate the type's abilities.
+        context.resolve_abilities(&tag)
+    }
+
+    pub fn function_signature(
+        &self,
+        pkg: AccountAddress,
+        module: &str,
+        function: &str,
+    ) -> Result<FunctionDef> {
+        let mut context = ResolutionContext::new(self.limits.as_ref());
+
+        let package = self.package_store.fetch(pkg)?;
+        let Some(mut def) = package.module(module)?.function_def(function)? else {
+            return Err(Error::FunctionNotFound(
+                pkg,
+                module.to_string(),
+                function.to_string(),
+            ));
+        };
+
+        // (1). Fetch all the information from this store that is necessary to resolve types
+        // referenced by this tag.
+        for sig in def.parameters.iter().chain(def.return_.iter()) {
+            context.add_signature_sync(
+                sig.body.clone(),
+                &self.package_store,
+                package.as_ref(),
+                /* visit_fields */ false,
+            )?;
+        }
+
+        // (2). Use that information to relocate package IDs in the signature.
+        for sig in def.parameters.iter_mut().chain(def.return_.iter_mut()) {
+            context.relocate_signature(&mut sig.body)?;
+        }
+
+        Ok(def)
+    }
+
+    pub fn pure_input_layouts(
+        &self,
+        tx: &ProgrammableTransaction,
+    ) -> Result<Vec<Option<MoveTypeLayout>>> {
+        let mut tags = vec![None; tx.inputs.len()];
+        let mut register_type = |arg: &Argument, tag: &TypeTag| {
+            let &Argument::Input(ix) = arg else {
+                return;
+            };
+
+            if !matches!(tx.inputs.get(ix as usize), Some(CallArg::Pure(_))) {
+                return;
+            }
+
+            let Some(type_) = tags.get_mut(ix as usize) else {
+                return;
+            };
+
+            // Types are initially `None`, and are set to `Some(Ok(_))` as long as the input can be
+            // mapped to a unique type, and to `Some(Err(()))` if the input is used with
+            // conflicting types at some point.
+            match type_ {
+                None => *type_ = Some(Ok(tag.clone())),
+                Some(Err(())) => {}
+                Some(Ok(prev)) => {
+                    if prev != tag {
+                        *type_ = Some(Err(()));
+                    }
+                }
+            }
+        };
+
+        // (1). Infer type tags for pure inputs from their uses.
+        for cmd in &tx.commands {
+            match cmd {
+                Command::MoveCall(call) => {
+                    let params = self
+                        .function_signature(
+                            call.package.into(),
+                            call.module.as_str(),
+                            call.function.as_str(),
+                        )?
+                        .parameters;
+
+                    #[allow(clippy::disallowed_methods)]
+                    // Intentional zip: params includes implicit TxContext param not in arguments
+                    for (open_sig, arg) in params.iter().zip(call.arguments.iter()) {
+                        let sig = open_sig.instantiate(&call.type_arguments)?;
+                        register_type(arg, &sig.body);
+                    }
+                }
+
+                Command::TransferObjects(_, arg) => register_type(arg, &TypeTag::Address),
+
+                Command::SplitCoins(_, amounts) => {
+                    for amount in amounts {
+                        register_type(amount, &TypeTag::U64);
+                    }
+                }
+
+                Command::MakeMoveVec(Some(tag), elems) => {
+                    let tag = as_type_tag(tag)?;
+                    if is_primitive_type_tag(&tag) {
+                        for elem in elems {
+                            register_type(elem, &tag);
+                        }
+                    }
+                }
+
+                _ => { /* nop */ }
+            }
+        }
+
+        // (2). Gather all the unique type tags to convert into layouts. There are relatively few
+        // primitive types so this is worth doing to avoid redundant work.
+        let unique_tags: BTreeSet<_> = tags
+            .iter()
+            .flat_map(|t| t.clone())
+            .flat_map(|t| t.ok())
+            .collect();
+
+        // (3). Convert the type tags into layouts.
+        let mut layouts = BTreeMap::new();
+        for tag in unique_tags {
+            let layout = self.type_layout(tag.clone())?;
+            layouts.insert(tag, layout);
+        }
+
+        // (4) Prepare the result vector.
+        Ok(tags
+            .iter()
+            .map(|t| -> Option<_> {
+                let t = t.as_ref()?;
+                let t = t.as_ref().ok()?;
+                layouts.get(t).cloned()
+            })
+            .collect())
+    }
+
+    pub fn resolve_module_id(
+        &self,
+        module_id: ModuleId,
+        context: AccountAddress,
+    ) -> Result<ModuleId> {
+        let package = self.package_store.fetch(context)?;
+        let storage_id = package.relocate(*module_id.address())?;
+        Ok(ModuleId::new(storage_id, module_id.name().to_owned()))
+    }
+
+    pub fn resolve_clever_error(
+        &self,
+        module_id: ModuleId,
+        abort_code: u64,
+    ) -> Option<CleverError> {
+        let _bitset = ErrorBitset::from_u64(abort_code)?;
+        let package = self.package_store.fetch(*module_id.address()).ok()?;
         package.resolve_clever_error(module_id.name().as_str(), abort_code)
     }
 }
@@ -1423,6 +1657,125 @@ impl<'l> ResolutionContext<'l> {
         Ok(())
     }
 
+    /// Synchronous twin of [`Self::add_type_tag`]. Kept line-for-line parallel to the async
+    /// version — when you change one, change both.
+    fn add_type_tag_sync<S: SyncPackageStore + ?Sized>(
+        &mut self,
+        tag: &mut TypeTag,
+        store: &S,
+        visit_fields: bool,
+        visit_phantoms: bool,
+    ) -> Result<()> {
+        use TypeTag as T;
+
+        struct ToVisit<'t> {
+            tag: &'t mut TypeTag,
+            depth: usize,
+        }
+
+        let mut frontier = vec![ToVisit { tag, depth: 0 }];
+        while let Some(ToVisit { tag, depth }) = frontier.pop() {
+            macro_rules! push_ty_param {
+                ($tag:expr) => {{
+                    check_max_limit!(
+                        TypeParamNesting, self.limits;
+                        max_type_argument_depth > depth
+                    );
+
+                    frontier.push(ToVisit { tag: $tag, depth: depth + 1 })
+                }}
+            }
+
+            match tag {
+                T::Address
+                | T::Bool
+                | T::U8
+                | T::U16
+                | T::U32
+                | T::U64
+                | T::U128
+                | T::U256
+                | T::Signer => {
+                    // Nothing further to add to context
+                }
+
+                T::Vector(tag) => push_ty_param!(tag),
+
+                T::Struct(s) => {
+                    let context = store.fetch(s.address)?;
+                    let def = context
+                        .clone()
+                        .data_def(s.module.as_str(), s.name.as_str())?;
+
+                    // Normalize `address` (the ID of a package that contains the definition of this
+                    // struct) to be a runtime ID, because that's what the resolution context uses
+                    // for keys.  Take care to do this before generating the key that is used to
+                    // query and/or write into `self.structs.
+                    s.address = context.runtime_id;
+                    let key = DatatypeRef::from(s.as_ref()).as_key();
+
+                    if def.type_params.len() != s.type_params.len() {
+                        return Err(Error::TypeArityMismatch(
+                            def.type_params.len(),
+                            s.type_params.len(),
+                        ));
+                    }
+
+                    check_max_limit!(
+                        TooManyTypeParams, self.limits;
+                        max_type_argument_width >= s.type_params.len()
+                    );
+
+                    for (param, def) in s.type_params.iter_mut().zip_eq(def.type_params.iter()) {
+                        if !def.is_phantom || visit_phantoms {
+                            push_ty_param!(param);
+                        }
+                    }
+
+                    if self.datatypes.contains_key(&key) {
+                        continue;
+                    }
+
+                    if visit_fields {
+                        match &def.data {
+                            MoveData::Struct(fields) => {
+                                for (_, sig) in fields {
+                                    self.add_signature_sync(
+                                        sig.clone(),
+                                        store,
+                                        &context,
+                                        visit_fields,
+                                    )?;
+                                }
+                            }
+                            MoveData::Enum(variants) => {
+                                for variant in variants {
+                                    for (_, sig) in &variant.signatures {
+                                        self.add_signature_sync(
+                                            sig.clone(),
+                                            store,
+                                            &context,
+                                            visit_fields,
+                                        )?;
+                                    }
+                                }
+                            }
+                        };
+                    }
+
+                    check_max_limit!(
+                        TooManyTypeNodes, self.limits;
+                        max_type_nodes > self.datatypes.len()
+                    );
+
+                    self.datatypes.insert(key, def);
+                }
+            }
+        }
+
+        Ok(())
+    }
+
     // Like `add_type_tag` but for type signatures.  Needs a linkage table to translate runtime IDs
     // into storage IDs.
     async fn add_signature<T: PackageStore + ?Sized>(
@@ -1503,9 +1856,89 @@ impl<'l> ResolutionContext<'l> {
         Ok(())
     }
 
+    /// Synchronous twin of [`Self::add_signature`]. Kept line-for-line parallel to the async
+    /// version — when you change one, change both.
+    fn add_signature_sync<T: SyncPackageStore + ?Sized>(
+        &mut self,
+        sig: OpenSignatureBody,
+        store: &T,
+        context: &Package,
+        visit_fields: bool,
+    ) -> Result<()> {
+        use OpenSignatureBody as O;
+
+        let mut frontier = vec![sig];
+        while let Some(sig) = frontier.pop() {
+            match sig {
+                O::Address
+                | O::Bool
+                | O::U8
+                | O::U16
+                | O::U32
+                | O::U64
+                | O::U128
+                | O::U256
+                | O::TypeParameter(_) => {
+                    // Nothing further to add to context
+                }
+
+                O::Vector(sig) => frontier.push(*sig),
+
+                O::Datatype(key, params) => {
+                    check_max_limit!(
+                        TooManyTypeParams, self.limits;
+                        max_type_argument_width >= params.len()
+                    );
+
+                    let params_count = params.len();
+                    let data_count = self.datatypes.len();
+                    frontier.extend(params.into_iter());
+
+                    let type_params = if let Some(def) = self.datatypes.get(&key) {
+                        &def.type_params
+                    } else {
+                        check_max_limit!(
+                            TooManyTypeNodes, self.limits;
+                            max_type_nodes > data_count
+                        );
+
+                        // Need to resolve the datatype, so fetch the package that contains it.
+                        let storage_id = context.relocate(key.package)?;
+                        let package = store.fetch(storage_id)?;
+
+                        let def = package.data_def(&key.module, &key.name)?;
+                        if visit_fields {
+                            match &def.data {
+                                MoveData::Struct(fields) => {
+                                    frontier.extend(fields.iter().map(|f| &f.1).cloned());
+                                }
+                                MoveData::Enum(variants) => {
+                                    frontier.extend(
+                                        variants
+                                            .iter()
+                                            .flat_map(|v| v.signatures.iter().map(|(_, s)| s))
+                                            .cloned(),
+                                    );
+                                }
+                            };
+                        }
+
+                        &self.datatypes.entry(key).or_insert(def).type_params
+                    };
+
+                    if type_params.len() != params_count {
+                        return Err(Error::TypeArityMismatch(type_params.len(), params_count));
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
     /// Translate runtime IDs in a type `tag` into defining IDs using only the information
     /// contained in this context. Requires that the necessary information was added to the context
-    /// through calls to `add_type_tag`.
+    /// through calls to `add_type_tag` (or `add_type_tag_sync`).
     fn canonicalize_type(&self, tag: &mut TypeTag) -> Result<()> {
         use TypeTag as T;
 

--- a/crates/sui-package-resolver/src/lib.rs
+++ b/crates/sui-package-resolver/src/lib.rs
@@ -29,6 +29,7 @@ use move_command_line_common::display::RenderResult;
 use move_command_line_common::display::try_render_constant;
 use move_command_line_common::error_bitset::ErrorBitset;
 use move_core_types::account_address::AccountAddress;
+use move_core_types::annotated_value as A;
 use move_core_types::annotated_value::MoveEnumLayout;
 use move_core_types::annotated_value::MoveFieldLayout;
 use move_core_types::annotated_value::MoveStructLayout;
@@ -482,6 +483,29 @@ impl<S: PackageStore> Resolver<S> {
             .map_or(usize::MAX, |l| l.max_move_value_depth);
 
         Ok(context.resolve_type_layout(&tag, max_depth)?.0)
+    }
+
+    /// Return the datatype layout (struct or enum) corresponding to the given struct tag. This is
+    /// a convenience wrapper around [`Self::type_layout`] that mirrors the signature of the legacy
+    /// `LayoutResolver::get_annotated_layout` method for easier migration.
+    pub async fn datatype_layout(&self, struct_tag: &StructTag) -> Result<A::MoveDatatypeLayout> {
+        let type_tag = TypeTag::Struct(Box::new(struct_tag.clone()));
+        let layout = self.type_layout(type_tag).await?;
+        match layout {
+            MoveTypeLayout::Struct(s) => Ok(A::MoveDatatypeLayout::Struct(s)),
+            MoveTypeLayout::Enum(e) => Ok(A::MoveDatatypeLayout::Enum(e)),
+            layout => {
+                // This error is unexpected because a `StructTag` should always resolve to either a
+                // struct or enum layout, and if it doesn't, it likely means there is a bug in the
+                // resolver logic.
+                return Err(Error::UnexpectedError(Arc::new(partial_vm_error!(
+                    UNKNOWN_INVARIANT_VIOLATION_ERROR,
+                    "StructTag {:#?} did not resolve to a struct or enum layout: {:#?}",
+                    struct_tag,
+                    layout
+                ))));
+            }
+        }
     }
 
     /// Return the abilities of a concrete type, based on the abilities in its type definition, and

--- a/crates/sui-package-resolver/src/lib.rs
+++ b/crates/sui-package-resolver/src/lib.rs
@@ -497,12 +497,12 @@ impl<S: PackageStore> Resolver<S> {
                 // This error is unexpected because a `StructTag` should always resolve to either a
                 // struct or enum layout, and if it doesn't, it likely means there is a bug in the
                 // resolver logic.
-                return Err(Error::UnexpectedError(Arc::new(partial_vm_error!(
+                Err(Error::UnexpectedError(Arc::new(partial_vm_error!(
                     UNKNOWN_INVARIANT_VIOLATION_ERROR,
                     "StructTag {:#?} did not resolve to a struct or enum layout: {:#?}",
                     struct_tag,
                     layout
-                ))));
+                ))))
             }
         }
     }
@@ -772,12 +772,12 @@ impl<S: SyncPackageStore> SyncResolver<S> {
                 // This error is unexpected because a `StructTag` should always resolve to either a
                 // struct or enum layout, and if it doesn't, it likely means there is a bug in the
                 // resolver logic.
-                return Err(Error::UnexpectedError(Arc::new(partial_vm_error!(
+                Err(Error::UnexpectedError(Arc::new(partial_vm_error!(
                     UNKNOWN_INVARIANT_VIOLATION_ERROR,
                     "StructTag {:#?} did not resolve to a struct or enum layout: {:#?}",
                     struct_tag,
                     layout
-                ))));
+                ))))
             }
         }
     }

--- a/crates/sui-package-resolver/src/lib.rs
+++ b/crates/sui-package-resolver/src/lib.rs
@@ -37,11 +37,13 @@ use move_core_types::language_storage::ModuleId;
 use move_core_types::language_storage::StructTag;
 use move_core_types::language_storage::TypeTag;
 use sui_types::Identifier;
+use sui_types::base_types::ObjectID;
 use sui_types::base_types::SequenceNumber;
 use sui_types::base_types::is_primitive_type_tag;
 use sui_types::move_package::MovePackage;
 use sui_types::move_package::TypeOrigin;
 use sui_types::object::Object;
+use sui_types::storage::BackingPackageStore;
 use sui_types::transaction::Argument;
 use sui_types::transaction::CallArg;
 use sui_types::transaction::Command;
@@ -64,6 +66,17 @@ pub type Result<T> = std::result::Result<T, Error>;
 #[derive(Debug)]
 pub struct Resolver<S> {
     package_store: S,
+    limits: Option<Limits>,
+}
+
+/// Synchronous sibling of [`Resolver`], driven by a [`SyncPackageStore`]. Intended for hot-path
+/// callers (validator/authority execution) where the underlying storage is synchronous and
+/// async machinery would just add overhead.
+#[derive(Debug)]
+pub struct SyncResolver<S> {
+    package_store: S,
+    // Read by the sync resolution methods added in a later commit.
+    #[allow(dead_code)]
     limits: Option<Limits>,
 }
 
@@ -305,10 +318,16 @@ struct ResolutionContext<'l> {
 /// Interface to abstract over access to a store of live packages.  Used to override the default
 /// store during testing.
 #[async_trait]
-pub trait PackageStore: Send + Sync + 'static {
+pub trait PackageStore: Send + Sync {
     /// Read package contents. Fails if `id` is not an object, not a package, or is malformed in
     /// some way.
     async fn fetch(&self, id: AccountAddress) -> Result<Arc<Package>>;
+}
+
+/// Synchronous analogue of [`PackageStore`], driving [`SyncResolver`]. Has no
+/// `Send`/`Sync`/`'static` bounds so implementations can borrow freely.
+pub trait SyncPackageStore {
+    fn fetch(&self, id: AccountAddress) -> Result<Arc<Package>>;
 }
 
 macro_rules! as_ref_impl {
@@ -332,6 +351,23 @@ impl<S: PackageStore> PackageStore for Arc<S> {
     }
 }
 
+/// Every [`BackingPackageStore`] implementation is usable as a [`SyncPackageStore`]. The blanket
+/// also covers `&B`, `Arc<B>`, `Box<B>` for any `B: BackingPackageStore` via
+/// [`BackingPackageStore`]'s own forwarding impls.
+impl<S: BackingPackageStore> SyncPackageStore for S {
+    fn fetch(&self, id: AccountAddress) -> Result<Arc<Package>> {
+        let object_id = ObjectID::from(id);
+        let package_obj = self
+            .get_package_object(&object_id)
+            .map_err(|e| Error::Store {
+                store: "BackingPackageStore",
+                error: e.to_string(),
+            })?
+            .ok_or(Error::PackageNotFound(id))?;
+        Ok(Arc::new(Package::read_from_object(package_obj.object())?))
+    }
+}
+
 /// Check $value does not exceed $limit in config, if the limit config exists, returning an error
 /// containing the max value and actual value otherwise.
 macro_rules! check_max_limit {
@@ -347,6 +383,30 @@ macro_rules! check_max_limit {
 }
 
 impl<S> Resolver<S> {
+    pub fn new(package_store: S) -> Self {
+        Self {
+            package_store,
+            limits: None,
+        }
+    }
+
+    pub fn new_with_limits(package_store: S, limits: Limits) -> Self {
+        Self {
+            package_store,
+            limits: Some(limits),
+        }
+    }
+
+    pub fn package_store(&self) -> &S {
+        &self.package_store
+    }
+
+    pub fn package_store_mut(&mut self) -> &mut S {
+        &mut self.package_store
+    }
+}
+
+impl<S> SyncResolver<S> {
     pub fn new(package_store: S) -> Self {
         Self {
             package_store,


### PR DESCRIPTION
## Description

Sadly there is no easy way of parametrizing by sync/async other than through macro generation. This adds a `SyncResolver` which is basically the `Resolver` but with a sync backing store and exposes a sync interface.

This also adds a `datatype_layout` function which is just a specialization of the `type_layout` function to make it easier in PRs to come. I can remove it for now if that's preferable, but we will need to add it back later then, so figured might as well do it now.

## Test plan 

CI/existing tests.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
