### PR TITLE
typed-store: fix safe_drop_db lock race in tidehunter builds

### DIFF
--- a/crates/typed-store/src/rocks/mod.rs
+++ b/crates/typed-store/src/rocks/mod.rs
@@ -2047,8 +2047,19 @@ pub fn open_cf_opts_secondary<P: AsRef<Path>>(
 }
 
 // Drops a database if there is no other handle to it, with retries and timeout.
-#[cfg(not(tidehunter))]
-pub async fn safe_drop_db(path: PathBuf, timeout: Duration) -> Result<(), rocksdb::Error> {
+// Detects the storage variant (RocksDB vs. tidehunter) from the directory
+// contents and dispatches to the matching cleanup. Both variants coexist in
+// tidehunter builds — some stores (e.g. rpc-index) are pure RocksDB even when
+// the tidehunter feature is enabled elsewhere in the binary.
+pub async fn safe_drop_db(path: PathBuf, timeout: Duration) -> Result<(), std::io::Error> {
+    #[cfg(tidehunter)]
+    if is_tidehunter_db(&path) {
+        return safe_drop_tidehunter_db(path, timeout).await;
+    }
+    safe_drop_rocksdb(path, timeout).await
+}
+
+async fn safe_drop_rocksdb(path: PathBuf, timeout: Duration) -> Result<(), std::io::Error> {
     let mut backoff = backoff::ExponentialBackoff {
         max_elapsed_time: Some(timeout),
         ..Default::default()
@@ -2058,14 +2069,21 @@ pub async fn safe_drop_db(path: PathBuf, timeout: Duration) -> Result<(), rocksd
             Ok(()) => return Ok(()),
             Err(err) => match backoff.next_backoff() {
                 Some(duration) => tokio::time::sleep(duration).await,
-                None => return Err(err),
+                None => return Err(std::io::Error::other(err)),
             },
         }
     }
 }
 
 #[cfg(tidehunter)]
-pub async fn safe_drop_db(path: PathBuf, timeout: Duration) -> Result<(), std::io::Error> {
+fn is_tidehunter_db(path: &Path) -> bool {
+    // `shape.yaml` is written by TideHunterDb::open and is the canonical marker
+    // for a tidehunter DB directory; RocksDB never creates it.
+    path.join("shape.yaml").exists()
+}
+
+#[cfg(tidehunter)]
+async fn safe_drop_tidehunter_db(path: PathBuf, timeout: Duration) -> Result<(), std::io::Error> {
     let mut backoff = backoff::ExponentialBackoff {
         max_elapsed_time: Some(timeout),
         ..Default::default()


### PR DESCRIPTION
## Summary
- In tidehunter builds, `safe_drop_db` was a cfg-gated override that only invoked `TideHunterDb::drop_db`. Pure-RocksDB stores (e.g. `rpc-index`) re-initialize by dropping the handle, calling `safe_drop_db`, then reopening — the non-TH variant's `rocksdb::DB::destroy` retry loop was what papered over the async `Drop` of the previous handle. Without it, re-open panics with `"lock hold by current process"` because the path is still in RocksDB's in-process `locked_files_` set when the pending `UnlockFile` hasn't fired yet.
- Replace the two cfg-gated variants with a single runtime-dispatched function: detect tidehunter paths by the presence of `shape.yaml` and route to the matching cleanup; everything else (including pure-RocksDB stores in a tidehunter-enabled binary) uses `rocksdb::DB::destroy` with the retry loop.
- Unified return type to `std::io::Error`. All callers (`rpc_index.rs`, `db_tool`, `authority_per_epoch_store_pruner`, `consensus_store_pruner`, tests) either use `?` into `anyhow::Result`, `.expect(...)`, or match on `Display`, so no caller-side changes needed.

## Test plan
- [x] `cargo check -p typed-store -p sui-core -p sui-tool`
- [x] `USE_TIDEHUNTER=1 cargo check -p typed-store -p sui-core -p sui-tool --features typed-store/tidehunter`
- [x] `cargo clippy -p typed-store --lib --no-deps` (both feature configs)
- [x] `cargo nextest run -p typed-store --lib test_safe_drop_db` (both feature configs)
- [ ] Weekly Antithesis run with this branch to confirm the rpc-index panic is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)