### PR TITLE
[chore] Update tidehunter to eab7323cafeab0873a09172b12223f1539bd6fe2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8457,7 +8457,7 @@ dependencies = [
 [[package]]
 name = "minibytes"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/tidehunter.git?rev=641675ae80ab625e1b3d72f66eae494cee0f0d2b#641675ae80ab625e1b3d72f66eae494cee0f0d2b"
+source = "git+https://github.com/mystenlabs/tidehunter.git?rev=c7c5a99ae15e70d3694efdf43e5638353ee5b522#c7c5a99ae15e70d3694efdf43e5638353ee5b522"
 dependencies = [
  "bytes",
  "memmap2 0.7.1",
@@ -18235,7 +18235,7 @@ dependencies = [
 [[package]]
 name = "tidehunter"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/tidehunter.git?rev=641675ae80ab625e1b3d72f66eae494cee0f0d2b#641675ae80ab625e1b3d72f66eae494cee0f0d2b"
+source = "git+https://github.com/mystenlabs/tidehunter.git?rev=c7c5a99ae15e70d3694efdf43e5638353ee5b522#c7c5a99ae15e70d3694efdf43e5638353ee5b522"
 dependencies = [
  "arc-swap",
  "bincode 1.3.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8457,7 +8457,7 @@ dependencies = [
 [[package]]
 name = "minibytes"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/tidehunter.git?rev=c7c5a99ae15e70d3694efdf43e5638353ee5b522#c7c5a99ae15e70d3694efdf43e5638353ee5b522"
+source = "git+https://github.com/mystenlabs/tidehunter.git?rev=eab7323cafeab0873a09172b12223f1539bd6fe2#eab7323cafeab0873a09172b12223f1539bd6fe2"
 dependencies = [
  "bytes",
  "memmap2 0.7.1",
@@ -18235,7 +18235,7 @@ dependencies = [
 [[package]]
 name = "tidehunter"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/tidehunter.git?rev=c7c5a99ae15e70d3694efdf43e5638353ee5b522#c7c5a99ae15e70d3694efdf43e5638353ee5b522"
+source = "git+https://github.com/mystenlabs/tidehunter.git?rev=eab7323cafeab0873a09172b12223f1539bd6fe2#eab7323cafeab0873a09172b12223f1539bd6fe2"
 dependencies = [
  "arc-swap",
  "bincode 1.3.3",

--- a/crates/typed-store/Cargo.toml
+++ b/crates/typed-store/Cargo.toml
@@ -39,7 +39,7 @@ itertools.workspace = true
 mysten-common.workspace = true
 mysten-metrics.workspace = true
 [target.'cfg(not(windows))'.dependencies]
-tidehunter = {git = "https://github.com/mystenlabs/tidehunter.git", rev = "c7c5a99ae15e70d3694efdf43e5638353ee5b522", version = "0.1.0", optional = true}
+tidehunter = {git = "https://github.com/mystenlabs/tidehunter.git", rev = "eab7323cafeab0873a09172b12223f1539bd6fe2", version = "0.1.0", optional = true}
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 rocksdb = { version = "0.22.0", default-features = false, features = ["jemalloc"] }

--- a/crates/typed-store/Cargo.toml
+++ b/crates/typed-store/Cargo.toml
@@ -39,7 +39,7 @@ itertools.workspace = true
 mysten-common.workspace = true
 mysten-metrics.workspace = true
 [target.'cfg(not(windows))'.dependencies]
-tidehunter = {git = "https://github.com/mystenlabs/tidehunter.git", rev = "641675ae80ab625e1b3d72f66eae494cee0f0d2b", version = "0.1.0", optional = true}
+tidehunter = {git = "https://github.com/mystenlabs/tidehunter.git", rev = "c7c5a99ae15e70d3694efdf43e5638353ee5b522", version = "0.1.0", optional = true}
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 rocksdb = { version = "0.22.0", default-features = false, features = ["jemalloc"] }


### PR DESCRIPTION
## Summary
- Updates tidehunter git dependency to [eab7323cafeab0873a09172b12223f1539bd6fe2](https://github.com/MystenLabs/sui/pull/26272/commits/f797d92450b3a9665f44ac467d43251c7d0ae17d)

## Test plan
- [ ] Deploy to private-testnet with `build_with_tidehunter=true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)