### PR TITLE
ci: resolve postgres bin dir dynamically for Ubuntu 22.04/24.04 compatibility

### DIFF
--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -117,7 +117,11 @@ jobs:
         run: |
           forge soldeer update
       - name: Add postgres to PATH
-        run: echo "/usr/lib/postgresql/14/bin" >> $GITHUB_PATH
+        shell: bash
+        run: |
+          pg_bin=$(ls -d /usr/lib/postgresql/*/bin 2>/dev/null | head -1)
+          [ -n "$pg_bin" ] || { echo "ERROR: no postgres bin dir found under /usr/lib/postgresql"; exit 1; }
+          echo "$pg_bin" >> "$GITHUB_PATH"
       - name: cargo test
         run: |
           cargo nextest run --profile ci --cargo-quiet -E 'package(sui-bridge) | package(sui-bridge-indexer)'

--- a/.github/workflows/cargo-llvm-cov.yml
+++ b/.github/workflows/cargo-llvm-cov.yml
@@ -57,7 +57,11 @@ jobs:
 
       - uses: taiki-e/install-action@protoc
       - name: Add postgres to PATH
-        run: echo "/usr/lib/postgresql/14/bin" >> $GITHUB_PATH
+        shell: bash
+        run: |
+          pg_bin=$(ls -d /usr/lib/postgresql/*/bin 2>/dev/null | head -1)
+          [ -n "$pg_bin" ] || { echo "ERROR: no postgres bin dir found under /usr/lib/postgresql"; exit 1; }
+          echo "$pg_bin" >> "$GITHUB_PATH"
 
       - name: Install Rust toolchain
         run: rustup show active-toolchain || rustup toolchain install

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -102,7 +102,11 @@ jobs:
       - uses: taiki-e/install-action@nextest
       - uses: taiki-e/install-action@protoc
       - name: Add postgres to PATH
-        run: echo "/usr/lib/postgresql/14/bin" >> $GITHUB_PATH
+        shell: bash
+        run: |
+          pg_bin=$(ls -d /usr/lib/postgresql/*/bin 2>/dev/null | head -1)
+          [ -n "$pg_bin" ] || { echo "ERROR: no postgres bin dir found under /usr/lib/postgresql"; exit 1; }
+          echo "$pg_bin" >> "$GITHUB_PATH"
       - name: Install BigTable emulator
         run: |
           echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee /etc/apt/sources.list.d/google-cloud-sdk.list
@@ -147,7 +151,11 @@ jobs:
       - uses: taiki-e/install-action@nextest
       - uses: taiki-e/install-action@protoc
       - name: Add postgres to PATH
-        run: echo "/usr/lib/postgresql/14/bin" >> $GITHUB_PATH
+        shell: bash
+        run: |
+          pg_bin=$(ls -d /usr/lib/postgresql/*/bin 2>/dev/null | head -1)
+          [ -n "$pg_bin" ] || { echo "ERROR: no postgres bin dir found under /usr/lib/postgresql"; exit 1; }
+          echo "$pg_bin" >> "$GITHUB_PATH"
       - name: Set Swap Space
         uses: pierotofy/set-swap-space@fc79b3f67fa8a838184ce84a674ca12238d2c761 # pin@master
         with:
@@ -205,7 +213,11 @@ jobs:
       - uses: taiki-e/install-action@nextest
       - uses: taiki-e/install-action@protoc
       - name: Add postgres to PATH
-        run: echo "/usr/lib/postgresql/14/bin" >> $GITHUB_PATH
+        shell: bash
+        run: |
+          pg_bin=$(ls -d /usr/lib/postgresql/*/bin 2>/dev/null | head -1)
+          [ -n "$pg_bin" ] || { echo "ERROR: no postgres bin dir found under /usr/lib/postgresql"; exit 1; }
+          echo "$pg_bin" >> "$GITHUB_PATH"
       - name: Set Swap Space
         uses: pierotofy/set-swap-space@fc79b3f67fa8a838184ce84a674ca12238d2c761 # pin@master
         with:
@@ -376,7 +388,11 @@ jobs:
       - uses: taiki-e/install-action@nextest
       - uses: taiki-e/install-action@protoc
       - name: Add postgres to PATH
-        run: echo "/usr/lib/postgresql/14/bin" >> $GITHUB_PATH
+        shell: bash
+        run: |
+          pg_bin=$(ls -d /usr/lib/postgresql/*/bin 2>/dev/null | head -1)
+          [ -n "$pg_bin" ] || { echo "ERROR: no postgres bin dir found under /usr/lib/postgresql"; exit 1; }
+          echo "$pg_bin" >> "$GITHUB_PATH"
       - name: Set Swap Space
         uses: pierotofy/set-swap-space@fc79b3f67fa8a838184ce84a674ca12238d2c761 # pin@master
         with:
@@ -408,7 +424,11 @@ jobs:
       - uses: taiki-e/install-action@nextest
       - uses: taiki-e/install-action@protoc
       - name: Add postgres to PATH
-        run: echo "/usr/lib/postgresql/14/bin" >> $GITHUB_PATH
+        shell: bash
+        run: |
+          pg_bin=$(ls -d /usr/lib/postgresql/*/bin 2>/dev/null | head -1)
+          [ -n "$pg_bin" ] || { echo "ERROR: no postgres bin dir found under /usr/lib/postgresql"; exit 1; }
+          echo "$pg_bin" >> "$GITHUB_PATH"
       - name: Set Swap Space
         uses: pierotofy/set-swap-space@fc79b3f67fa8a838184ce84a674ca12238d2c761 # pin@master
         with:


### PR DESCRIPTION
## Summary
- Replace hardcoded \`/usr/lib/postgresql/14/bin\` with a glob-based version lookup in all \`Add postgres to PATH\` steps
- Works transparently on Ubuntu 22.04 (postgres 14) *and* Ubuntu 24.04 (postgres 16) — no coupling to a specific distro
- Touches \`rust.yml\`, \`cargo-llvm-cov.yml\`, \`bridge.yml\` (7 occurrences)

## Why
The \`ubuntu-ghcloud\` Larger Runner is being migrated to Ubuntu 24.04. The current hardcoded path (postgres 14) is 22.04-specific and breaks silently on 24.04 — \`echo\` succeeds but nothing is added to PATH, so downstream test steps that rely on postgres CLI tools (\`psql\`, \`pg_isready\`, etc.) find nothing. Landing this before the runner flip is safe in both directions; it works on 22.04 today and on 24.04 after the flip.

## Why not release.yml
\`release.yml\` doesn't need this fix:
- \`ubuntu-ghcloud\` build never had an \"Add postgres to PATH\" step — only uses libpq for linking, which is pre-installed in the image
- \`ubuntu-arm64\` already uses \`apt install libpq-dev\` with no PATH manipulation

## Local validation
- On Ubuntu 24.04 locally with postgres 16 installed, the new snippet resolves to \`/usr/lib/postgresql/16/bin\` and \`psql\` is executable at that path
- Script behavior on 22.04 unchanged: finds \`/usr/lib/postgresql/14/bin\`

## Test plan
- [ ] CI on this PR passes (expected: only \`diff\` + \`license-check\` trigger; none depend on the modified path)
- [ ] After merge + ubuntu-ghcloud 24.04 flip: a subsequent Rust PR's \`test\` / \`test-tidehunter\` / \`simtest\` jobs find postgres-16 on PATH and run cleanly
- [ ] Rollback plan: revert this PR if 24.04 migration is reverted; the new snippet remains safe on 22.04 either way

🤖 Generated with [Claude Code](https://claude.com/claude-code)