### PR TITLE
deps: bump rustls-webpki to 0.103.12 (fix RUSTSEC-2026-0099)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7887,7 +7887,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -12694,9 +12694,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring 0.17.8",


### PR DESCRIPTION
## Summary
\`cargo update -p rustls-webpki\`, bumping 0.103.10 → 0.103.12 to clear **RUSTSEC-2026-0099** — a wildcard-certificate name-constraint bypass in rustls-webpki that has been failing the \`cargo-deny (advisories)\` CI job repo-wide.

## Background
The advisory was published recently (identifiers GHSA-965h-392x-2mh5 and GHSA-xgp8-3hg3-c2mh). Since then, every PR's cargo-deny check has been failing, with output:

\`\`\`
error[vulnerability]: Name constraints were accepted for certificates asserting a wildcard name
   rustls-webpki 0.103.10 ... security vulnerability detected
   ID: RUSTSEC-2026-0099
   Solution: Upgrade to >=0.103.12, <0.104.0-alpha.1 OR >=0.104.0-alpha.6
\`\`\`

## Changes
- \`Cargo.lock\` only — a 6-line patch (3 lines for rustls-webpki version/checksum + 3 lines for libloading collateral)
- No \`Cargo.toml\` edits needed; rustls-webpki is a transitive dep and 0.103.12 satisfies the existing constraint

### Note on libloading / windows-targets collateral
Cargo's resolver re-unified libloading 0.8.6's \`windows-targets\` choice from 0.52.6 to 0.48.0. Both versions were already present in the lockfile via other crates; this is just a different selection among already-locked-in candidates. **Windows-only; Linux/macOS builds unaffected.**

## Not addressed here
The \`core2 0.4.0\` **yanked** warning (also surfaced by cargo-deny) isn't fixed here — it's a transitive via \`sui-proxy → multiaddr 0.17 → multihash 0.17 → core2 ^0.4.0\`, and 0.4.0 is the only yanked 0.4.x. Clearing it requires updating the multihash/multiaddr chain, which is a larger change. The yanked status is a warning (not a failure) in cargo-deny v2, so it doesn't block CI.

## Test plan
- [ ] CI: \`cargo-deny (advisories)\` transitions from FAILURE to SUCCESS on this PR
- [ ] Other CI jobs unaffected (this is lockfile-only; no runtime behavior change on Linux)

🤖 Generated with [Claude Code](https://claude.com/claude-code)