### PR TITLE
Remove dead code gated on mysticeti_fastpath / disable_preconsensus_locking

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1423,36 +1423,15 @@ impl AuthorityState {
         })
     }
 
-    /// Wait for a transaction to be executed.
-    /// For consensus transactions, it needs to be sequenced by the consensus.
-    /// For owned object transactions, this function will enqueue the transaction for execution.
+    /// Wait for a transaction to be executed. Transactions need to be sequenced by consensus
+    /// before being enqueued for execution.
     ///
     /// Only use this in tests.
     #[instrument(level = "trace", skip_all)]
     pub async fn wait_for_transaction_execution_for_testing(
         &self,
         transaction: &VerifiedExecutableTransaction,
-        epoch_store: &Arc<AuthorityPerEpochStore>,
     ) -> TransactionEffects {
-        if !transaction.is_consensus_tx()
-            && !epoch_store.protocol_config().disable_preconsensus_locking()
-        {
-            // Shared object transactions need to be sequenced by the consensus before enqueueing
-            // for execution, done in AuthorityPerEpochStore::handle_consensus_transaction().
-            //
-            // For owned object transactions, they can be enqueued for execution immediately
-            // ONLY when disable_preconsensus_locking is false (QD/original fastpath mode).
-            // When disable_preconsensus_locking is true (MFP mode), all transactions including
-            // owned object transactions must go through consensus before enqueuing for execution.
-            self.execution_scheduler.enqueue(
-                vec![(
-                    Schedulable::Transaction(transaction.clone()),
-                    ExecutionEnv::new(),
-                )],
-                epoch_store,
-            );
-        }
-
         self.notify_read_effects_for_testing(
             "AuthorityState::wait_for_transaction_execution_for_testing",
             *transaction.digest(),

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -447,10 +447,10 @@ pub struct AuthorityPerEpochStore {
     // Saved at end of epoch for propagating observations to the next.
     pub(crate) end_of_epoch_execution_time_observations: OnceCell<StoredExecutionTimeObservations>,
 
-    pub(crate) consensus_tx_status_cache: Option<ConsensusTxStatusCache>,
+    pub(crate) consensus_tx_status_cache: ConsensusTxStatusCache,
 
     /// A cache that maintains the reject vote reason for a transaction.
-    pub(crate) tx_reject_reason_cache: Option<TransactionRejectReasonCache>,
+    pub(crate) tx_reject_reason_cache: TransactionRejectReasonCache,
 
     /// A cache that tracks submitted transactions to prevent DoS through excessive resubmissions.
     pub(crate) submitted_transaction_cache: SubmittedTransactionCache,
@@ -1208,10 +1208,9 @@ impl AuthorityPerEpochStore {
             )),
         );
 
-        let consensus_tx_status_cache =
-            Some(ConsensusTxStatusCache::new(protocol_config.gc_depth()));
+        let consensus_tx_status_cache = ConsensusTxStatusCache::new(protocol_config.gc_depth());
 
-        let tx_reject_reason_cache = Some(TransactionRejectReasonCache::new(None, epoch_id));
+        let tx_reject_reason_cache = TransactionRejectReasonCache::new(None, epoch_id);
 
         let submitted_transaction_cache =
             SubmittedTransactionCache::new(None, submitted_transaction_cache_metrics);
@@ -3765,26 +3764,21 @@ impl AuthorityPerEpochStore {
         position: ConsensusPosition,
         status: ConsensusTxStatus,
     ) {
-        if let Some(cache) = self.consensus_tx_status_cache.as_ref() {
-            cache.set_transaction_status(position, status);
-        }
+        self.consensus_tx_status_cache
+            .set_transaction_status(position, status);
     }
 
     pub(crate) fn set_rejection_vote_reason(&self, position: ConsensusPosition, reason: &SuiError) {
-        if let Some(tx_reject_reason_cache) = self.tx_reject_reason_cache.as_ref() {
-            tx_reject_reason_cache.set_rejection_vote_reason(position, reason);
-        }
+        self.tx_reject_reason_cache
+            .set_rejection_vote_reason(position, reason);
     }
 
     pub(crate) fn get_rejection_vote_reason(
         &self,
         position: ConsensusPosition,
     ) -> Option<SuiError> {
-        if let Some(tx_reject_reason_cache) = self.tx_reject_reason_cache.as_ref() {
-            tx_reject_reason_cache.get_rejection_vote_reason(position)
-        } else {
-            None
-        }
+        self.tx_reject_reason_cache
+            .get_rejection_vote_reason(position)
     }
 
     /// Caches recent finalized transactions, to avoid revoting them.

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -1208,17 +1208,10 @@ impl AuthorityPerEpochStore {
             )),
         );
 
-        let consensus_tx_status_cache = if protocol_config.mysticeti_fastpath() {
-            Some(ConsensusTxStatusCache::new(protocol_config.gc_depth()))
-        } else {
-            None
-        };
+        let consensus_tx_status_cache =
+            Some(ConsensusTxStatusCache::new(protocol_config.gc_depth()));
 
-        let tx_reject_reason_cache = if protocol_config.mysticeti_fastpath() {
-            Some(TransactionRejectReasonCache::new(None, epoch_id))
-        } else {
-            None
-        };
+        let tx_reject_reason_cache = Some(TransactionRejectReasonCache::new(None, epoch_id));
 
         let submitted_transaction_cache =
             SubmittedTransactionCache::new(None, submitted_transaction_cache_metrics);

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -2085,7 +2085,6 @@ impl AuthorityPerEpochStore {
     }
 
     /// Gets owned object locks, checking quarantine first then falling back to DB.
-    /// Used for post-consensus conflict detection when preconsensus locking is disabled.
     /// After crash recovery, quarantine is empty so we naturally fall back to DB.
     pub fn get_owned_object_locks(
         &self,
@@ -2098,7 +2097,6 @@ impl AuthorityPerEpochStore {
     }
 
     /// Attempts to acquire owned object locks for a transaction post-consensus.
-    /// This is used when preconsensus locking is disabled.
     ///
     /// Checks whether the object versions are already locked by searching:
     /// 1. The current commit

--- a/crates/sui-core/src/authority/consensus_quarantine.rs
+++ b/crates/sui-core/src/authority/consensus_quarantine.rs
@@ -893,7 +893,6 @@ impl ConsensusOutputQuarantine {
     }
 
     /// Gets owned object locks, checking quarantine first then falling back to DB.
-    /// Used for post-consensus conflict detection when preconsensus locking is disabled.
     /// After crash recovery, quarantine is empty so we naturally fall back to DB.
     pub(super) fn get_owned_object_locks(
         &self,

--- a/crates/sui-core/src/authority/consensus_quarantine.rs
+++ b/crates/sui-core/src/authority/consensus_quarantine.rs
@@ -93,7 +93,7 @@ pub(crate) struct ConsensusCommitOutput {
         Vec<(ExecutionTimeObservationKey, Duration)>,
     )>,
 
-    // Owned object locks acquired post-consensus (when disable_preconsensus_locking=true)
+    // Owned object locks acquired post-consensus.
     owned_object_locks: HashMap<ObjectRef, LockDetails>,
 
     // True when the checkpoint queue had no pending roots after this commit's flush.

--- a/crates/sui-core/src/authority/consensus_tx_status_cache.rs
+++ b/crates/sui-core/src/authority/consensus_tx_status_cache.rs
@@ -135,10 +135,7 @@ impl ConsensusTxStatusCache {
         }
     }
 
-    pub(crate) async fn update_last_committed_leader_round(
-        &self,
-        last_committed_leader_round: u32,
-    ) {
+    pub(crate) fn update_last_committed_leader_round(&self, last_committed_leader_round: u32) {
         debug!(
             "Updating last committed leader round: {}",
             last_committed_leader_round
@@ -259,15 +256,11 @@ mod tests {
         cache.set_transaction_status(tx_pos, ConsensusTxStatus::Finalized);
 
         // Set initial leader round which doesn't GC anything.
-        cache
-            .update_last_committed_leader_round(CONSENSUS_STATUS_RETENTION_ROUNDS + 1)
-            .await;
+        cache.update_last_committed_leader_round(CONSENSUS_STATUS_RETENTION_ROUNDS + 1);
 
         // Update with round that will trigger GC using previous round (CONSENSUS_STATUS_RETENTION_ROUNDS + 1)
         // This will expire transactions up to and including round 1
-        cache
-            .update_last_committed_leader_round(CONSENSUS_STATUS_RETENTION_ROUNDS + 2)
-            .await;
+        cache.update_last_committed_leader_round(CONSENSUS_STATUS_RETENTION_ROUNDS + 2);
 
         // Try to read status - should be expired
         let result = cache.notify_read_transaction_status(tx_pos).await;
@@ -288,9 +281,7 @@ mod tests {
         }
 
         // Set initial leader round which doesn't GC anything.
-        cache
-            .update_last_committed_leader_round(CONSENSUS_STATUS_RETENTION_ROUNDS + 2)
-            .await;
+        cache.update_last_committed_leader_round(CONSENSUS_STATUS_RETENTION_ROUNDS + 2);
 
         // No rounds should be cleaned up yet since this was the initial update
         {
@@ -305,9 +296,7 @@ mod tests {
 
         // Update that triggers GC using previous round (CONSENSUS_STATUS_RETENTION_ROUNDS + 2)
         // This will expire transactions up to and including round 2
-        cache
-            .update_last_committed_leader_round(CONSENSUS_STATUS_RETENTION_ROUNDS + 3)
-            .await;
+        cache.update_last_committed_leader_round(CONSENSUS_STATUS_RETENTION_ROUNDS + 3);
 
         // Verify rounds 1-2 are cleaned up, 3-5 remain
         {
@@ -322,9 +311,7 @@ mod tests {
 
         // Another update using previous round (CONSENSUS_STATUS_RETENTION_ROUNDS + 3) for GC
         // This will expire transactions up to and including round 3
-        cache
-            .update_last_committed_leader_round(CONSENSUS_STATUS_RETENTION_ROUNDS + 4)
-            .await;
+        cache.update_last_committed_leader_round(CONSENSUS_STATUS_RETENTION_ROUNDS + 4);
 
         // Verify rounds 1-3 are cleaned up, 4-5 remain
         {

--- a/crates/sui-core/src/authority/test_authority_builder.rs
+++ b/crates/sui-core/src/authority/test_authority_builder.rs
@@ -212,9 +212,6 @@ impl<'a> TestAuthorityBuilder<'a> {
         // `AuthorityPerEpochStore::new` is called
         //
         // Only create a guard if an explicit protocol_config was provided.
-        // If no protocol_config is provided, the caller is responsible for setting up
-        // any necessary protocol config overrides (e.g., disable_preconsensus_locking=false
-        // for tests that use the Quorum Driver flow with extract_cert).
         let _guard = self
             .protocol_config
             .clone()

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -646,13 +646,6 @@ impl ValidatorService {
         submitter_client_addr: Option<IpAddr>,
     ) -> SuiResult<(RawSubmitTxResponse, Weight)> {
         let epoch_store = state.load_epoch_store_one_call_per_task();
-        if !epoch_store.protocol_config().mysticeti_fastpath() {
-            return Err(SuiErrorKind::UnsupportedFeatureError {
-                error: "Mysticeti fastpath".to_string(),
-            }
-            .into());
-        }
-
         let submit_type = SubmitTxType::try_from(request.submit_type).map_err(|e| {
             SuiErrorKind::GrpcMessageDeserializeError {
                 type_info: "RawSubmitTxRequest.submit_type".to_string(),

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -1201,11 +1201,7 @@ impl ValidatorService {
                 Some(pos) => pos,
                 None => return futures::future::pending().await,
             };
-            let consensus_tx_status_cache = epoch_store.consensus_tx_status_cache.as_ref().ok_or(
-                SuiErrorKind::UnsupportedFeatureError {
-                    error: "Consensus tx status cache".to_string(),
-                },
-            )?;
+            let consensus_tx_status_cache = &epoch_store.consensus_tx_status_cache;
             consensus_tx_status_cache.check_position_too_ahead(&consensus_position)?;
             match consensus_tx_status_cache
                 .notify_read_transaction_status(consensus_position)
@@ -1260,12 +1256,7 @@ impl ValidatorService {
         request: WaitForEffectsRequest,
         epoch_store: &Arc<AuthorityPerEpochStore>,
     ) -> SuiResult<WaitForEffectsResponse> {
-        let Some(consensus_tx_status_cache) = epoch_store.consensus_tx_status_cache.as_ref() else {
-            return Err(SuiErrorKind::UnsupportedFeatureError {
-                error: "Mysticeti fastpath".to_string(),
-            }
-            .into());
-        };
+        let consensus_tx_status_cache = &epoch_store.consensus_tx_status_cache;
 
         let Some(consensus_position) = request.consensus_position else {
             return Err(SuiErrorKind::InvalidRequest(
@@ -1405,8 +1396,7 @@ impl ValidatorService {
         // Get last committed leader round from epoch store
         let last_committed_leader_round = epoch_store
             .consensus_tx_status_cache
-            .as_ref()
-            .and_then(|cache| cache.get_last_committed_leader_round())
+            .get_last_committed_leader_round()
             .unwrap_or(0);
 
         // Get last locally built checkpoint sequence

--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -762,18 +762,16 @@ impl ConsensusAdapter {
         }
 
         // Record submitted transactions early for DoS protection
-        if epoch_store.protocol_config().mysticeti_fastpath() {
-            for transaction in &transactions {
-                if let Some(tx) = transaction.kind.as_user_transaction() {
-                    let amplification_factor = (tx.data().transaction_data().gas_price()
-                        / epoch_store.reference_gas_price().max(1))
-                    .max(1);
-                    epoch_store.submitted_transaction_cache.record_submitted_tx(
-                        tx.digest(),
-                        amplification_factor as u32,
-                        submitter_client_addr,
-                    );
-                }
+        for transaction in &transactions {
+            if let Some(tx) = transaction.kind.as_user_transaction() {
+                let amplification_factor = (tx.data().transaction_data().gas_price()
+                    / epoch_store.reference_gas_price().max(1))
+                .max(1);
+                epoch_store.submitted_transaction_cache.record_submitted_tx(
+                    tx.digest(),
+                    amplification_factor as u32,
+                    submitter_client_addr,
+                );
             }
         }
 

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -1198,7 +1198,7 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
             &commit_info,
             &consensus_commit,
         );
-        // Buffer owned object locks for batch write when preconsensus locking is disabled
+        // Buffer owned object locks for batch write.
         if !owned_object_locks.is_empty() {
             state.output.set_owned_object_locks(owned_object_locks);
         }
@@ -2679,8 +2679,7 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
     }
 
     // Filters out rejected or deprecated transactions.
-    // Returns FilteredConsensusOutput containing transactions and owned_object_locks
-    // (collected when preconsensus locking is disabled).
+    // Returns FilteredConsensusOutput containing transactions and owned_object_locks.
     #[instrument(level = "trace", skip_all)]
     fn filter_consensus_txns(
         &mut self,
@@ -2768,7 +2767,6 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
                     .consensus_handler_transaction_sizes
                     .with_label_values(&[kind])
                     .observe(parsed.serialized_len as f64);
-                // UserTransaction exists only when mysticeti_fastpath is enabled in protocol config.
                 if matches!(
                     &parsed.transaction.kind,
                     ConsensusTransactionKind::CertifiedTransaction(_)
@@ -2872,9 +2870,8 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
                     }
                 }
 
-                // When preconsensus locking is disabled, perform post-consensus owned object
-                // conflict detection. If lock acquisition fails, the transaction has
-                // invalid/conflicting owned inputs and should be dropped.
+                // Perform post-consensus owned object conflict detection. If lock acquisition
+                // fails, the transaction has invalid/conflicting owned inputs and should be dropped.
                 // This must happen AFTER all filtering checks above to avoid acquiring locks
                 // for transactions that will be dropped (e.g., during epoch change).
                 // Only applies to UserTransactionV2 - other transaction types don't need lock acquisition.

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -1130,15 +1130,13 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
 
         let last_committed_round = self.last_consensus_stats.index.last_committed_round;
 
-        if let Some(consensus_tx_status_cache) = self.epoch_store.consensus_tx_status_cache.as_ref()
-        {
-            consensus_tx_status_cache
-                .update_last_committed_leader_round(last_committed_round as u32)
-                .await;
-        }
-        if let Some(tx_reject_reason_cache) = self.epoch_store.tx_reject_reason_cache.as_ref() {
-            tx_reject_reason_cache.set_last_committed_leader_round(last_committed_round as u32);
-        }
+        self.epoch_store
+            .consensus_tx_status_cache
+            .update_last_committed_leader_round(last_committed_round as u32)
+            .await;
+        self.epoch_store
+            .tx_reject_reason_cache
+            .set_last_committed_leader_round(last_committed_round as u32);
 
         let commit_info = self.additional_consensus_state.observe_commit(
             self.epoch_store.protocol_config(),

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -2716,9 +2716,7 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
 
                 // Transaction has appeared in consensus output, we can increment the submission count
                 // for this tx for DoS protection.
-                if self.epoch_store.protocol_config().mysticeti_fastpath()
-                    && let Some(tx) = parsed.transaction.kind.as_user_transaction()
-                {
+                if let Some(tx) = parsed.transaction.kind.as_user_transaction() {
                     let digest = tx.digest();
                     if let Some((spam_weight, submitter_client_addrs)) = self
                         .epoch_store
@@ -2821,16 +2819,6 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
                         | ConsensusTransactionKind::RandomnessDkgMessage(_, _) => continue,
                         _ => {}
                     }
-                }
-
-                if parsed.transaction.is_user_transaction()
-                    && !self.epoch_store.protocol_config().mysticeti_fastpath()
-                {
-                    debug!(
-                        "Ignoring MFP transaction {:?} because MFP is disabled",
-                        parsed.transaction.key()
-                    );
-                    continue;
                 }
 
                 if let ConsensusTransactionKind::CertifiedTransaction(certificate) =

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -1132,8 +1132,7 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
 
         self.epoch_store
             .consensus_tx_status_cache
-            .update_last_committed_leader_round(last_committed_round as u32)
-            .await;
+            .update_last_committed_leader_round(last_committed_round as u32);
         self.epoch_store
             .tx_reject_reason_cache
             .set_last_committed_leader_round(last_committed_round as u32);

--- a/crates/sui-core/src/consensus_manager/mod.rs
+++ b/crates/sui-core/src/consensus_manager/mod.rs
@@ -130,7 +130,7 @@ fn to_consensus_protocol_config(config: &ProtocolConfig, chain: Chain) -> Consen
         config.max_transactions_in_block_bytes(),
         config.max_num_transactions_in_block(),
         config.gc_depth(),
-        config.mysticeti_fastpath(),
+        true,
         config.mysticeti_num_leaders_per_round(),
         config.consensus_bad_nodes_stake_threshold(),
     )

--- a/crates/sui-core/src/consensus_manager/mod.rs
+++ b/crates/sui-core/src/consensus_manager/mod.rs
@@ -130,7 +130,7 @@ fn to_consensus_protocol_config(config: &ProtocolConfig, chain: Chain) -> Consen
         config.max_transactions_in_block_bytes(),
         config.max_num_transactions_in_block(),
         config.gc_depth(),
-        true,
+        /* transaction_voting_enabled */ true,
         config.mysticeti_num_leaders_per_round(),
         config.consensus_bad_nodes_stake_threshold(),
     )

--- a/crates/sui-core/src/consensus_validator.rs
+++ b/crates/sui-core/src/consensus_validator.rs
@@ -216,10 +216,6 @@ impl SuiTxValidator {
         txs: Vec<ConsensusTransactionKind>,
     ) -> Vec<TransactionIndex> {
         let epoch_store = &self.epoch_store;
-        if !epoch_store.protocol_config().mysticeti_fastpath() {
-            return vec![];
-        }
-
         let mut reject_txn_votes = Vec::new();
         for (i, tx) in txs.into_iter().enumerate() {
             let tx: PlainTransactionWithClaims = match tx {

--- a/crates/sui-core/src/unit_tests/transfer_to_object_tests.rs
+++ b/crates/sui-core/src/unit_tests/transfer_to_object_tests.rs
@@ -227,11 +227,10 @@ impl TestRunner {
         &mut self,
         executable: VerifiedExecutableTransaction,
     ) -> TransactionEffects {
-        let epoch_store = self.authority_state.load_epoch_store_one_call_per_task();
         assign_versions_and_schedule(&self.authority_state, &executable).await;
         let effects = self
             .authority_state
-            .wait_for_transaction_execution_for_testing(&executable, &epoch_store)
+            .wait_for_transaction_execution_for_testing(&executable)
             .await;
 
         if self.aggressive_pruning_enabled {

--- a/crates/sui-core/src/unit_tests/wait_for_effects_tests.rs
+++ b/crates/sui-core/src/unit_tests/wait_for_effects_tests.rs
@@ -399,7 +399,7 @@ async fn test_wait_for_effects_expired() {
     tokio::spawn(async move {
         tokio::time::sleep(Duration::from_millis(100)).await;
         let epoch_store = state_clone.epoch_store_for_testing();
-        let cache = epoch_store.consensus_tx_status_cache.as_ref().unwrap();
+        let cache = &epoch_store.consensus_tx_status_cache;
 
         // Initialize the last committed leader round.
         cache
@@ -537,7 +537,7 @@ async fn test_wait_for_effects_ping() {
             let epoch_store = state_clone.epoch_store_for_testing();
 
             tokio::time::sleep(Duration::from_millis(100)).await;
-            let consensus_tx_status_cache = epoch_store.consensus_tx_status_cache.as_ref().unwrap();
+            let consensus_tx_status_cache = &epoch_store.consensus_tx_status_cache;
             consensus_tx_status_cache
                 .update_last_committed_leader_round(CONSENSUS_STATUS_RETENTION_ROUNDS + 10)
                 .await;

--- a/crates/sui-core/src/unit_tests/wait_for_effects_tests.rs
+++ b/crates/sui-core/src/unit_tests/wait_for_effects_tests.rs
@@ -402,14 +402,12 @@ async fn test_wait_for_effects_expired() {
         let cache = &epoch_store.consensus_tx_status_cache;
 
         // Initialize the last committed leader round.
-        cache
-            .update_last_committed_leader_round(CONSENSUS_STATUS_RETENTION_ROUNDS + block_round)
-            .await;
+        cache.update_last_committed_leader_round(CONSENSUS_STATUS_RETENTION_ROUNDS + block_round);
 
         // Update that will actually trigger expiration using the leader round.
-        cache
-            .update_last_committed_leader_round(CONSENSUS_STATUS_RETENTION_ROUNDS + block_round + 1)
-            .await;
+        cache.update_last_committed_leader_round(
+            CONSENSUS_STATUS_RETENTION_ROUNDS + block_round + 1,
+        );
     });
 
     let response = test_context
@@ -539,11 +537,9 @@ async fn test_wait_for_effects_ping() {
             tokio::time::sleep(Duration::from_millis(100)).await;
             let consensus_tx_status_cache = &epoch_store.consensus_tx_status_cache;
             consensus_tx_status_cache
-                .update_last_committed_leader_round(CONSENSUS_STATUS_RETENTION_ROUNDS + 10)
-                .await;
+                .update_last_committed_leader_round(CONSENSUS_STATUS_RETENTION_ROUNDS + 10);
             consensus_tx_status_cache
-                .update_last_committed_leader_round(CONSENSUS_STATUS_RETENTION_ROUNDS + 11)
-                .await;
+                .update_last_committed_leader_round(CONSENSUS_STATUS_RETENTION_ROUNDS + 11);
         });
 
         let response = test_context

--- a/crates/sui-single-node-benchmark/src/single_node.rs
+++ b/crates/sui-single-node-benchmark/src/single_node.rs
@@ -174,7 +174,7 @@ impl SingleValidator {
                     &self.epoch_store,
                 );
                 self.get_validator()
-                    .wait_for_transaction_execution_for_testing(&executable, &self.epoch_store)
+                    .wait_for_transaction_execution_for_testing(&executable)
                     .await
             }
             Component::ValidatorWithoutConsensus | Component::ValidatorWithFakeConsensus => {


### PR DESCRIPTION
## Summary

- `mysticeti_fastpath` is enabled on all chains since Mainnet v96; `disable_preconsensus_locking` since v105. Both accessors always return `true` now.
- Delete the call-site conditionals in `sui-core` and `sui-single-node-benchmark`: unwrap the live (always-taken) branches, drop the dead (never-taken) branches.

### Notable changes
- `AuthorityState::wait_for_transaction_execution_for_testing` loses its dead `!disable_preconsensus_locking()` enqueue path and its now-unused `epoch_store` parameter; updated two callers.
- `vote_transactions` early-return, `handle_submit_transaction_inner` `UnsupportedFeatureError`, and the "Ignoring MFP transaction" skip block are all deleted as unreachable.
- `to_consensus_protocol_config` passes `true` literally for the `mysticeti_fastpath` argument that still flows into `consensus-core`.

## Test plan

- [x] `cargo check -p sui-core -p sui-single-node-benchmark`
- [x] `cargo clippy -p sui-core -p sui-single-node-benchmark -p sui-protocol-config -- -D warnings`
- [x] `cargo fmt`
- [x] `cargo nextest run -p sui-protocol-config` — snapshot tests pass with zero diff (lib.rs untouched)
- [x] `cargo nextest run -p sui-core --lib --no-fail-fast` — 650/650 pass
- [x] CI simtests / e2e

🤖 Generated with [Claude Code](https://claude.com/claude-code)