### PR TITLE
[autodebug] consensus: yield between rounds to prevent sim starvation

### DIFF
--- a/consensus/core/src/leader_timeout.rs
+++ b/consensus/core/src/leader_timeout.rs
@@ -110,6 +110,13 @@ impl<D: CoreThreadDispatcher> LeaderTimeoutTask<D> {
                     max_leader_timeout
                     .as_mut()
                     .reset(now + self.leader_timeout);
+
+                    // In the simulator's single-threaded cooperative runtime, the
+                    // tight leader-timeout → new-block → new-round → reset cycle can
+                    // starve other tasks (e.g. network message delivery). Yield to
+                    // allow the runtime to process them between consensus rounds.
+                    #[cfg(msim)]
+                    tokio::task::yield_now().await;
                 },
                 _ = &mut self.stop => {
                     debug!("Stop signal has been received, now shutting down");


### PR DESCRIPTION
## Summary

- Fix simtest timeout caused by consensus `LeaderTimeoutTask` starving network message delivery in the simulator
- Add `tokio::task::yield_now()` after processing new round signals in the leader timeout loop

## Root Cause

The `LeaderTimeoutTask` forms a tight cycle: timer fires → `new_block` → round advances → `new_round` signal → timers reset → timer fires again (every 200ms of sim time). In the simulator's single-threaded cooperative runtime, this cycle prevents queued network delivery timers from being processed, causing gRPC requests to never reach their destination.

This manifested as `test_transaction_expired_too_late` timing out on iteration 5 (seed `17077690485607463967`) because a gRPC `submit_transaction` request from the client was never delivered to the validator — the validator churned through ~5000 empty consensus rounds consuming the entire 1000s sim-time budget.

## Fix

`tokio::task::yield_now()` in the simulator it allows the runtime to process other events (network delivery, gRPC handling) between consensus rounds.

## Verification

- Failing CI run: https://github.com/MystenLabs/sui/actions/runs/24558071880
- Seed search: 200/200 passed after fix

## Test plan

- [x] Reproduced failure with CI seed
- [x] Verified fix passes the failing seed
- [x] Seed search 200/200 clean
- [x] `cargo xclippy` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)