### PR TITLE
[1.70] Enable FIFO compaction on 10% of mainnet validators (#26217)

### DIFF
--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -3,9 +3,9 @@
 
 use std::{sync::Arc, time::Instant};
 
-use consensus_config::ConsensusProtocolConfig;
 use consensus_config::{
-    AuthorityIndex, Committee, NetworkKeyPair, NetworkPublicKey, Parameters, ProtocolKeyPair,
+    AuthorityIndex, ChainType, Committee, ConsensusProtocolConfig, NetworkKeyPair,
+    NetworkPublicKey, Parameters, ProtocolKeyPair,
 };
 use consensus_types::block::Round;
 use itertools::Itertools;
@@ -239,10 +239,10 @@ where
         ));
 
         let store_path = context.parameters.db_path.as_path().to_str().unwrap();
-        let store = Arc::new(RocksDBStore::new(
-            store_path,
-            context.parameters.use_fifo_compaction,
-        ));
+        let use_fifo_compaction = context.parameters.use_fifo_compaction
+            && (context.protocol_config.chain() != ChainType::Mainnet
+                || context.own_index.value().is_multiple_of(10));
+        let store = Arc::new(RocksDBStore::new(store_path, use_fifo_compaction));
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
 
         let block_verifier = Arc::new(SignedBlockVerifier::new(


### PR DESCRIPTION
## Summary
Cherry-pick of [#26217](https://github.com/MystenLabs/sui/pull/26217) to the 1.70 release branch.

Original commit: c84f8c5534ec8b3eb9d8ea64a7e217e6bc25c640