### PR TITLE
[sui-framework] Switch df/dof `get_*` macros to use `exists` instead of `exists_with_type` 

### DIFF
--- a/crates/sui-framework/docs/sui/dynamic_field.md
+++ b/crates/sui-framework/docs/sui/dynamic_field.md
@@ -319,6 +319,8 @@ Returns true if and only if the <code><a href="../sui/object.md#sui_object">obje
 ## Function `remove_opt`
 
 Removes the dynamic field if it exists. Returns <code>some(Value)</code> if it exists or <code>none</code> otherwise.
+Aborts with <code><a href="../sui/dynamic_field.md#sui_dynamic_field_EFieldTypeMismatch">EFieldTypeMismatch</a></code> if the field exists, but the value does not have the specified
+type.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/dynamic_field.md#sui_dynamic_field_remove_opt">remove_opt</a>&lt;Name: <b>copy</b>, drop, store, Value: store&gt;(<a href="../sui/object.md#sui_object">object</a>: &<b>mut</b> <a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, name: Name): <a href="../std/option.md#std_option_Option">std::option::Option</a>&lt;Value&gt;
@@ -353,6 +355,8 @@ Removes the dynamic field if it exists. Returns <code>some(Value)</code> if it e
 Removes the existing value at <code>name</code> (if any) and adds <code>value</code> in its place.
 Returns the old value if it existed, or <code>none</code> otherwise.
 Note: the old and new value types may differ.
+Aborts with <code><a href="../sui/dynamic_field.md#sui_dynamic_field_EFieldTypeMismatch">EFieldTypeMismatch</a></code> if the field exists, but the value does not have the specified
+<code>ValueOld</code> type.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/dynamic_field.md#sui_dynamic_field_replace">replace</a>&lt;Name: <b>copy</b>, drop, store, ValueNew: store, ValueOld: store&gt;(<a href="../sui/object.md#sui_object">object</a>: &<b>mut</b> <a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, name: Name, value: ValueNew): <a href="../std/option.md#std_option_Option">std::option::Option</a>&lt;ValueOld&gt;
@@ -416,6 +420,8 @@ Returns true if and only if the <code><a href="../sui/object.md#sui_object">obje
 
 Immutably borrows the field value, adding it with <code>$default</code> if it doesn't exist.
 Note that <code>$default</code> is evaluated only if the field does not already exist.
+Aborts with <code><a href="../sui/dynamic_field.md#sui_dynamic_field_EFieldTypeMismatch">EFieldTypeMismatch</a></code> if the field exists, but the value does not have the specified
+type.
 
 
 <pre><code><b>public</b> <b>macro</b> <b>fun</b> <a href="../sui/dynamic_field.md#sui_dynamic_field_borrow_or_add">borrow_or_add</a>&lt;$Name: <b>copy</b>, drop, store, $Value: store&gt;($<a href="../sui/object.md#sui_object">object</a>: &<b>mut</b> <a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, $name: $Name, $default: $Value): &$Value
@@ -449,6 +455,8 @@ Note that <code>$default</code> is evaluated only if the field does not already 
 
 Mutably borrows the field value, adding it with <code>$default</code> if it doesn't exist.
 Note that <code>$default</code> is evaluated only if the field does not already exist.
+Aborts with <code><a href="../sui/dynamic_field.md#sui_dynamic_field_EFieldTypeMismatch">EFieldTypeMismatch</a></code> if the field exists, but the value does not have the specified
+type.
 
 
 <pre><code><b>public</b> <b>macro</b> <b>fun</b> <a href="../sui/dynamic_field.md#sui_dynamic_field_borrow_mut_or_add">borrow_mut_or_add</a>&lt;$Name: <b>copy</b>, drop, store, $Value: store&gt;($<a href="../sui/object.md#sui_object">object</a>: &<b>mut</b> <a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, $name: $Name, $default: $Value): &<b>mut</b> $Value
@@ -482,6 +490,8 @@ Note that <code>$default</code> is evaluated only if the field does not already 
 
 If the field exists, calls <code>$f</code> on an immutable reference to the value; otherwise, does nothing.
 This is like getting an <code>Option&lt;&Value&gt;</code> then calling <code><a href="../std/option.md#std_option_do">std::option::do</a></code>.
+Aborts with <code><a href="../sui/dynamic_field.md#sui_dynamic_field_EFieldTypeMismatch">EFieldTypeMismatch</a></code> if the field exists, but the value does not have the specified
+type.
 
 
 <pre><code><b>public</b> <b>macro</b> <b>fun</b> <a href="../sui/dynamic_field.md#sui_dynamic_field_get_do">get_do</a>&lt;$Name: <b>copy</b>, drop, store, $Value: store, $R: drop&gt;($<a href="../sui/object.md#sui_object">object</a>: &<a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, $name: $Name, $f: |&$Value| -&gt; $R)
@@ -500,7 +510,7 @@ This is like getting an <code>Option&lt;&Value&gt;</code> then calling <code><a 
 ) {
     <b>let</b> o = $<a href="../sui/object.md#sui_object">object</a>;
     <b>let</b> name = $name;
-    <b>if</b> (<a href="../sui/dynamic_field.md#sui_dynamic_field_exists">exists</a>&lt;$Name&gt;(o, name)) { $f(<a href="../sui/borrow.md#sui_borrow">borrow</a>(o, name)) }
+    <b>if</b> (<a href="../sui/dynamic_field.md#sui_dynamic_field_exists">exists</a>&lt;$Name&gt;(o, name)) { $f(<a href="../sui/borrow.md#sui_borrow">borrow</a>(o, name)); }
 }
 </code></pre>
 
@@ -514,6 +524,8 @@ This is like getting an <code>Option&lt;&Value&gt;</code> then calling <code><a 
 
 If the field exists, calls <code>$f</code> on a mutable reference to the value; otherwise, does nothing.
 This is like getting an <code>Option&lt;&<b>mut</b> Value&gt;</code> then calling <code><a href="../std/option.md#std_option_do">std::option::do</a></code>.
+Aborts with <code><a href="../sui/dynamic_field.md#sui_dynamic_field_EFieldTypeMismatch">EFieldTypeMismatch</a></code> if the field exists, but the value does not have the specified
+type.
 
 
 <pre><code><b>public</b> <b>macro</b> <b>fun</b> <a href="../sui/dynamic_field.md#sui_dynamic_field_get_mut_do">get_mut_do</a>&lt;$Name: <b>copy</b>, drop, store, $Value: store, $R: drop&gt;($<a href="../sui/object.md#sui_object">object</a>: &<b>mut</b> <a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, $name: $Name, $f: |&<b>mut</b> $Value| -&gt; $R)
@@ -532,7 +544,7 @@ This is like getting an <code>Option&lt;&<b>mut</b> Value&gt;</code> then callin
 ) {
     <b>let</b> o = $<a href="../sui/object.md#sui_object">object</a>;
     <b>let</b> name = $name;
-    <b>if</b> (<a href="../sui/dynamic_field.md#sui_dynamic_field_exists">exists</a>&lt;$Name&gt;(o, name)) { $f(<a href="../sui/dynamic_field.md#sui_dynamic_field_borrow_mut">borrow_mut</a>(o, name)) }
+    <b>if</b> (<a href="../sui/dynamic_field.md#sui_dynamic_field_exists">exists</a>&lt;$Name&gt;(o, name)) { $f(<a href="../sui/dynamic_field.md#sui_dynamic_field_borrow_mut">borrow_mut</a>(o, name)); }
 }
 </code></pre>
 
@@ -547,6 +559,8 @@ This is like getting an <code>Option&lt;&<b>mut</b> Value&gt;</code> then callin
 If the field exists, applies <code>$some</code> to an immutable reference to the value; otherwise, returns
 <code>$none</code>.
 This is like getting an <code>Option&lt;&Value&gt;</code> then calling <code><a href="../std/option.md#std_option_fold">std::option::fold</a></code>.
+Aborts with <code><a href="../sui/dynamic_field.md#sui_dynamic_field_EFieldTypeMismatch">EFieldTypeMismatch</a></code> if the field exists, but the value does not have the specified
+type.
 
 
 <pre><code><b>public</b> <b>macro</b> <b>fun</b> <a href="../sui/dynamic_field.md#sui_dynamic_field_get_fold">get_fold</a>&lt;$Name: <b>copy</b>, drop, store, $Value: store, $R&gt;($<a href="../sui/object.md#sui_object">object</a>: &<a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, $name: $Name, $none: $R, $some: |&$Value| -&gt; $R): $R
@@ -581,6 +595,8 @@ This is like getting an <code>Option&lt;&Value&gt;</code> then calling <code><a 
 If the field exists, applies <code>$some</code> to a mutable reference to the value; otherwise, returns
 <code>$none</code>.
 This is like getting an <code>Option&lt;&<b>mut</b> Value&gt;</code> then calling <code><a href="../std/option.md#std_option_fold">std::option::fold</a></code>.
+Aborts with <code><a href="../sui/dynamic_field.md#sui_dynamic_field_EFieldTypeMismatch">EFieldTypeMismatch</a></code> if the field exists, but the value does not have the specified
+type.
 
 
 <pre><code><b>public</b> <b>macro</b> <b>fun</b> <a href="../sui/dynamic_field.md#sui_dynamic_field_get_mut_fold">get_mut_fold</a>&lt;$Name: <b>copy</b>, drop, store, $Value: store, $R&gt;($<a href="../sui/object.md#sui_object">object</a>: &<b>mut</b> <a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, $name: $Name, $none: $R, $some: |&<b>mut</b> $Value| -&gt; $R): $R

--- a/crates/sui-framework/docs/sui/dynamic_field.md
+++ b/crates/sui-framework/docs/sui/dynamic_field.md
@@ -500,7 +500,7 @@ This is like getting an <code>Option&lt;&Value&gt;</code> then calling <code><a 
 ) {
     <b>let</b> o = $<a href="../sui/object.md#sui_object">object</a>;
     <b>let</b> name = $name;
-    <b>if</b> (<a href="../sui/dynamic_field.md#sui_dynamic_field_exists_with_type">exists_with_type</a>&lt;$Name, $Value&gt;(o, name)) { $f(<a href="../sui/borrow.md#sui_borrow">borrow</a>(o, name)); }
+    <b>if</b> (<a href="../sui/dynamic_field.md#sui_dynamic_field_exists">exists</a>&lt;$Name&gt;(o, name)) { $f(<a href="../sui/borrow.md#sui_borrow">borrow</a>(o, name)) }
 }
 </code></pre>
 
@@ -532,7 +532,7 @@ This is like getting an <code>Option&lt;&<b>mut</b> Value&gt;</code> then callin
 ) {
     <b>let</b> o = $<a href="../sui/object.md#sui_object">object</a>;
     <b>let</b> name = $name;
-    <b>if</b> (<a href="../sui/dynamic_field.md#sui_dynamic_field_exists_with_type">exists_with_type</a>&lt;$Name, $Value&gt;(o, name)) { $f(<a href="../sui/dynamic_field.md#sui_dynamic_field_borrow_mut">borrow_mut</a>(o, name)); }
+    <b>if</b> (<a href="../sui/dynamic_field.md#sui_dynamic_field_exists">exists</a>&lt;$Name&gt;(o, name)) { $f(<a href="../sui/dynamic_field.md#sui_dynamic_field_borrow_mut">borrow_mut</a>(o, name)) }
 }
 </code></pre>
 
@@ -566,7 +566,7 @@ This is like getting an <code>Option&lt;&Value&gt;</code> then calling <code><a 
 ): $R {
     <b>let</b> o = $<a href="../sui/object.md#sui_object">object</a>;
     <b>let</b> name = $name;
-    <b>if</b> (<a href="../sui/dynamic_field.md#sui_dynamic_field_exists_with_type">exists_with_type</a>&lt;$Name, $Value&gt;(o, name)) $some(<a href="../sui/borrow.md#sui_borrow">borrow</a>(o, name)) <b>else</b> $none
+    <b>if</b> (<a href="../sui/dynamic_field.md#sui_dynamic_field_exists">exists</a>&lt;$Name&gt;(o, name)) $some(<a href="../sui/borrow.md#sui_borrow">borrow</a>(o, name)) <b>else</b> $none
 }
 </code></pre>
 
@@ -600,7 +600,7 @@ This is like getting an <code>Option&lt;&<b>mut</b> Value&gt;</code> then callin
 ): $R {
     <b>let</b> o = $<a href="../sui/object.md#sui_object">object</a>;
     <b>let</b> name = $name;
-    <b>if</b> (<a href="../sui/dynamic_field.md#sui_dynamic_field_exists_with_type">exists_with_type</a>&lt;$Name, $Value&gt;(o, name)) $some(<a href="../sui/dynamic_field.md#sui_dynamic_field_borrow_mut">borrow_mut</a>(o, name)) <b>else</b> $none
+    <b>if</b> (<a href="../sui/dynamic_field.md#sui_dynamic_field_exists">exists</a>&lt;$Name&gt;(o, name)) $some(<a href="../sui/dynamic_field.md#sui_dynamic_field_borrow_mut">borrow_mut</a>(o, name)) <b>else</b> $none
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/sui/dynamic_object_field.md
+++ b/crates/sui-framework/docs/sui/dynamic_object_field.md
@@ -440,7 +440,7 @@ This is like getting an <code>Option&lt;&Value&gt;</code> then calling <code><a 
 ) {
     <b>let</b> o = $<a href="../sui/object.md#sui_object">object</a>;
     <b>let</b> name = $name;
-    <b>if</b> (<a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_exists_with_type">exists_with_type</a>&lt;$Name, $Value&gt;(o, name)) { $f(<a href="../sui/borrow.md#sui_borrow">borrow</a>(o, name)); }
+    <b>if</b> (<a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_exists">exists</a>&lt;$Name&gt;(o, name)) { $f(<a href="../sui/borrow.md#sui_borrow">borrow</a>(o, name)) }
 }
 </code></pre>
 
@@ -472,7 +472,7 @@ This is like getting an <code>Option&lt;&<b>mut</b> Value&gt;</code> then callin
 ) {
     <b>let</b> o = $<a href="../sui/object.md#sui_object">object</a>;
     <b>let</b> name = $name;
-    <b>if</b> (<a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_exists_with_type">exists_with_type</a>&lt;$Name, $Value&gt;(o, name)) { $f(<a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_borrow_mut">borrow_mut</a>(o, name)); }
+    <b>if</b> (<a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_exists">exists</a>&lt;$Name&gt;(o, name)) { $f(<a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_borrow_mut">borrow_mut</a>(o, name)) }
 }
 </code></pre>
 
@@ -506,7 +506,7 @@ This is like getting an <code>Option&lt;&Value&gt;</code> then calling <code><a 
 ): $R {
     <b>let</b> o = $<a href="../sui/object.md#sui_object">object</a>;
     <b>let</b> name = $name;
-    <b>if</b> (<a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_exists_with_type">exists_with_type</a>&lt;$Name, $Value&gt;(o, name)) $some(<a href="../sui/borrow.md#sui_borrow">borrow</a>(o, name)) <b>else</b> $none
+    <b>if</b> (<a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_exists">exists</a>&lt;$Name&gt;(o, name)) $some(<a href="../sui/borrow.md#sui_borrow">borrow</a>(o, name)) <b>else</b> $none
 }
 </code></pre>
 
@@ -540,7 +540,7 @@ This is like getting an <code>Option&lt;&<b>mut</b> Value&gt;</code> then callin
 ): $R {
     <b>let</b> o = $<a href="../sui/object.md#sui_object">object</a>;
     <b>let</b> name = $name;
-    <b>if</b> (<a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_exists_with_type">exists_with_type</a>&lt;$Name, $Value&gt;(o, name)) $some(<a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_borrow_mut">borrow_mut</a>(o, name)) <b>else</b> $none
+    <b>if</b> (<a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_exists">exists</a>&lt;$Name&gt;(o, name)) $some(<a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_borrow_mut">borrow_mut</a>(o, name)) <b>else</b> $none
 }
 </code></pre>
 

--- a/crates/sui-framework/docs/sui/dynamic_object_field.md
+++ b/crates/sui-framework/docs/sui/dynamic_object_field.md
@@ -290,6 +290,8 @@ Returns none otherwise
 
 Removes the dynamic object field if it exists. Returns <code>some(Value)</code> if it exists or <code>none</code>
 otherwise.
+Aborts with <code>EFieldTypeMismatch</code> if the field exists, but the value object does not have the
+specified type.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_remove_opt">remove_opt</a>&lt;Name: <b>copy</b>, drop, store, Value: key, store&gt;(<a href="../sui/object.md#sui_object">object</a>: &<b>mut</b> <a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, name: Name): <a href="../std/option.md#std_option_Option">std::option::Option</a>&lt;Value&gt;
@@ -324,6 +326,8 @@ otherwise.
 Removes the existing value at <code>name</code> (if any) and adds <code>value</code> in its place.
 Returns the old value if it existed, or <code>none</code> otherwise.
 Note: the old and new value types may differ.
+Aborts with <code>EFieldTypeMismatch</code> if the field exists, but the value object does not have the
+specified <code>ValueOld</code> type.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_replace">replace</a>&lt;Name: <b>copy</b>, drop, store, ValueNew: key, store, ValueOld: key, store&gt;(<a href="../sui/object.md#sui_object">object</a>: &<b>mut</b> <a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, name: Name, value: ValueNew): <a href="../std/option.md#std_option_Option">std::option::Option</a>&lt;ValueOld&gt;
@@ -356,6 +360,8 @@ Note: the old and new value types may differ.
 
 Immutably borrows the field value, adding it with <code>$default</code> if it doesn't exist.
 Note that <code>$default</code> is evaluated only if the field does not already exist.
+Aborts with <code>EFieldTypeMismatch</code> if the field exists, but the value object does not have the
+specified type.
 
 
 <pre><code><b>public</b> <b>macro</b> <b>fun</b> <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_borrow_or_add">borrow_or_add</a>&lt;$Name: <b>copy</b>, drop, store, $Value: key, store&gt;($<a href="../sui/object.md#sui_object">object</a>: &<b>mut</b> <a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, $name: $Name, $default: $Value): &$Value
@@ -389,6 +395,8 @@ Note that <code>$default</code> is evaluated only if the field does not already 
 
 Mutably borrows the field value, adding it with <code>$default</code> if it doesn't exist.
 Note that <code>$default</code> is evaluated only if the field does not already exist.
+Aborts with <code>EFieldTypeMismatch</code> if the field exists, but the value object does not have the
+specified type.
 
 
 <pre><code><b>public</b> <b>macro</b> <b>fun</b> <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_borrow_mut_or_add">borrow_mut_or_add</a>&lt;$Name: <b>copy</b>, drop, store, $Value: key, store&gt;($<a href="../sui/object.md#sui_object">object</a>: &<b>mut</b> <a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, $name: $Name, $default: $Value): &<b>mut</b> $Value
@@ -422,6 +430,8 @@ Note that <code>$default</code> is evaluated only if the field does not already 
 
 If the field exists, calls <code>$f</code> on an immutable reference to the value; otherwise, does nothing.
 This is like getting an <code>Option&lt;&Value&gt;</code> then calling <code><a href="../std/option.md#std_option_do">std::option::do</a></code>.
+Aborts with <code>EFieldTypeMismatch</code> if the field exists, but the value object does not have the
+specified type.
 
 
 <pre><code><b>public</b> <b>macro</b> <b>fun</b> <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_get_do">get_do</a>&lt;$Name: <b>copy</b>, drop, store, $Value: key, store, $R: drop&gt;($<a href="../sui/object.md#sui_object">object</a>: &<a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, $name: $Name, $f: |&$Value| -&gt; $R)
@@ -440,7 +450,7 @@ This is like getting an <code>Option&lt;&Value&gt;</code> then calling <code><a 
 ) {
     <b>let</b> o = $<a href="../sui/object.md#sui_object">object</a>;
     <b>let</b> name = $name;
-    <b>if</b> (<a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_exists">exists</a>&lt;$Name&gt;(o, name)) { $f(<a href="../sui/borrow.md#sui_borrow">borrow</a>(o, name)) }
+    <b>if</b> (<a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_exists">exists</a>&lt;$Name&gt;(o, name)) { $f(<a href="../sui/borrow.md#sui_borrow">borrow</a>(o, name)); }
 }
 </code></pre>
 
@@ -454,6 +464,8 @@ This is like getting an <code>Option&lt;&Value&gt;</code> then calling <code><a 
 
 If the field exists, calls <code>$f</code> on a mutable reference to the value; otherwise, does nothing.
 This is like getting an <code>Option&lt;&<b>mut</b> Value&gt;</code> then calling <code><a href="../std/option.md#std_option_do">std::option::do</a></code>.
+Aborts with <code>EFieldTypeMismatch</code> if the field exists, but the value object does not have the
+specified type.
 
 
 <pre><code><b>public</b> <b>macro</b> <b>fun</b> <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_get_mut_do">get_mut_do</a>&lt;$Name: <b>copy</b>, drop, store, $Value: key, store, $R: drop&gt;($<a href="../sui/object.md#sui_object">object</a>: &<b>mut</b> <a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, $name: $Name, $f: |&<b>mut</b> $Value| -&gt; $R)
@@ -472,7 +484,7 @@ This is like getting an <code>Option&lt;&<b>mut</b> Value&gt;</code> then callin
 ) {
     <b>let</b> o = $<a href="../sui/object.md#sui_object">object</a>;
     <b>let</b> name = $name;
-    <b>if</b> (<a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_exists">exists</a>&lt;$Name&gt;(o, name)) { $f(<a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_borrow_mut">borrow_mut</a>(o, name)) }
+    <b>if</b> (<a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_exists">exists</a>&lt;$Name&gt;(o, name)) { $f(<a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_borrow_mut">borrow_mut</a>(o, name)); }
 }
 </code></pre>
 
@@ -487,6 +499,8 @@ This is like getting an <code>Option&lt;&<b>mut</b> Value&gt;</code> then callin
 If the field exists, applies <code>$some</code> to an immutable reference to the value; otherwise, returns
 <code>$none</code>.
 This is like getting an <code>Option&lt;&Value&gt;</code> then calling <code><a href="../std/option.md#std_option_fold">std::option::fold</a></code>.
+Aborts with <code>EFieldTypeMismatch</code> if the field exists, but the value object does not have the
+specified type.
 
 
 <pre><code><b>public</b> <b>macro</b> <b>fun</b> <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_get_fold">get_fold</a>&lt;$Name: <b>copy</b>, drop, store, $Value: key, store, $R&gt;($<a href="../sui/object.md#sui_object">object</a>: &<a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, $name: $Name, $none: $R, $some: |&$Value| -&gt; $R): $R
@@ -521,6 +535,8 @@ This is like getting an <code>Option&lt;&Value&gt;</code> then calling <code><a 
 If the field exists, applies <code>$some</code> to a mutable reference to the value; otherwise, returns
 <code>$none</code>.
 This is like getting an <code>Option&lt;&<b>mut</b> Value&gt;</code> then calling <code><a href="../std/option.md#std_option_fold">std::option::fold</a></code>.
+Aborts with <code>EFieldTypeMismatch</code> if the field exists, but the value object does not have the
+specified type.
 
 
 <pre><code><b>public</b> <b>macro</b> <b>fun</b> <a href="../sui/dynamic_object_field.md#sui_dynamic_object_field_get_mut_fold">get_mut_fold</a>&lt;$Name: <b>copy</b>, drop, store, $Value: key, store, $R&gt;($<a href="../sui/object.md#sui_object">object</a>: &<b>mut</b> <a href="../sui/object.md#sui_object_UID">sui::object::UID</a>, $name: $Name, $none: $R, $some: |&<b>mut</b> $Value| -&gt; $R): $R

--- a/crates/sui-framework/packages/sui-framework/sources/dynamic_field.move
+++ b/crates/sui-framework/packages/sui-framework/sources/dynamic_field.move
@@ -99,6 +99,8 @@ public fun exists<Name: copy + drop + store>(object: &UID, name: Name): bool {
 }
 
 /// Removes the dynamic field if it exists. Returns `some(Value)` if it exists or `none` otherwise.
+/// Aborts with `EFieldTypeMismatch` if the field exists, but the value does not have the specified
+/// type.
 public fun remove_opt<Name: copy + drop + store, Value: store>(
     object: &mut UID,
     name: Name,
@@ -113,6 +115,8 @@ public fun remove_opt<Name: copy + drop + store, Value: store>(
 /// Removes the existing value at `name` (if any) and adds `value` in its place.
 /// Returns the old value if it existed, or `none` otherwise.
 /// Note: the old and new value types may differ.
+/// Aborts with `EFieldTypeMismatch` if the field exists, but the value does not have the specified
+/// `ValueOld` type.
 public fun replace<Name: copy + drop + store, ValueNew: store, ValueOld: store>(
     object: &mut UID,
     name: Name,
@@ -138,6 +142,8 @@ public fun exists_with_type<Name: copy + drop + store, Value: store>(
 
 /// Immutably borrows the field value, adding it with `$default` if it doesn't exist.
 /// Note that `$default` is evaluated only if the field does not already exist.
+/// Aborts with `EFieldTypeMismatch` if the field exists, but the value does not have the specified
+/// type.
 public macro fun borrow_or_add<$Name: copy + drop + store, $Value: store>(
     $object: &mut UID,
     $name: $Name,
@@ -151,6 +157,8 @@ public macro fun borrow_or_add<$Name: copy + drop + store, $Value: store>(
 
 /// Mutably borrows the field value, adding it with `$default` if it doesn't exist.
 /// Note that `$default` is evaluated only if the field does not already exist.
+/// Aborts with `EFieldTypeMismatch` if the field exists, but the value does not have the specified
+/// type.
 public macro fun borrow_mut_or_add<$Name: copy + drop + store, $Value: store>(
     $object: &mut UID,
     $name: $Name,
@@ -164,6 +172,8 @@ public macro fun borrow_mut_or_add<$Name: copy + drop + store, $Value: store>(
 
 /// If the field exists, calls `$f` on an immutable reference to the value; otherwise, does nothing.
 /// This is like getting an `Option<&Value>` then calling `std::option::do`.
+/// Aborts with `EFieldTypeMismatch` if the field exists, but the value does not have the specified
+/// type.
 public macro fun get_do<$Name: copy + drop + store, $Value: store, $R: drop>(
     $object: &UID,
     $name: $Name,
@@ -176,6 +186,8 @@ public macro fun get_do<$Name: copy + drop + store, $Value: store, $R: drop>(
 
 /// If the field exists, calls `$f` on a mutable reference to the value; otherwise, does nothing.
 /// This is like getting an `Option<&mut Value>` then calling `std::option::do`.
+/// Aborts with `EFieldTypeMismatch` if the field exists, but the value does not have the specified
+/// type.
 public macro fun get_mut_do<$Name: copy + drop + store, $Value: store, $R: drop>(
     $object: &mut UID,
     $name: $Name,
@@ -189,6 +201,8 @@ public macro fun get_mut_do<$Name: copy + drop + store, $Value: store, $R: drop>
 /// If the field exists, applies `$some` to an immutable reference to the value; otherwise, returns
 /// `$none`.
 /// This is like getting an `Option<&Value>` then calling `std::option::fold`.
+/// Aborts with `EFieldTypeMismatch` if the field exists, but the value does not have the specified
+/// type.
 public macro fun get_fold<$Name: copy + drop + store, $Value: store, $R>(
     $object: &UID,
     $name: $Name,
@@ -203,6 +217,8 @@ public macro fun get_fold<$Name: copy + drop + store, $Value: store, $R>(
 /// If the field exists, applies `$some` to a mutable reference to the value; otherwise, returns
 /// `$none`.
 /// This is like getting an `Option<&mut Value>` then calling `std::option::fold`.
+/// Aborts with `EFieldTypeMismatch` if the field exists, but the value does not have the specified
+/// type.
 public macro fun get_mut_fold<$Name: copy + drop + store, $Value: store, $R>(
     $object: &mut UID,
     $name: $Name,

--- a/crates/sui-framework/packages/sui-framework/sources/dynamic_field.move
+++ b/crates/sui-framework/packages/sui-framework/sources/dynamic_field.move
@@ -171,7 +171,7 @@ public macro fun get_do<$Name: copy + drop + store, $Value: store, $R: drop>(
 ) {
     let o = $object;
     let name = $name;
-    if (exists_with_type<$Name, $Value>(o, name)) { $f(borrow(o, name)); }
+    if (exists<$Name>(o, name)) { $f(borrow(o, name)); }
 }
 
 /// If the field exists, calls `$f` on a mutable reference to the value; otherwise, does nothing.
@@ -183,7 +183,7 @@ public macro fun get_mut_do<$Name: copy + drop + store, $Value: store, $R: drop>
 ) {
     let o = $object;
     let name = $name;
-    if (exists_with_type<$Name, $Value>(o, name)) { $f(borrow_mut(o, name)); }
+    if (exists<$Name>(o, name)) { $f(borrow_mut(o, name)); }
 }
 
 /// If the field exists, applies `$some` to an immutable reference to the value; otherwise, returns
@@ -197,7 +197,7 @@ public macro fun get_fold<$Name: copy + drop + store, $Value: store, $R>(
 ): $R {
     let o = $object;
     let name = $name;
-    if (exists_with_type<$Name, $Value>(o, name)) $some(borrow(o, name)) else $none
+    if (exists<$Name>(o, name)) $some(borrow(o, name)) else $none
 }
 
 /// If the field exists, applies `$some` to a mutable reference to the value; otherwise, returns
@@ -211,7 +211,7 @@ public macro fun get_mut_fold<$Name: copy + drop + store, $Value: store, $R>(
 ): $R {
     let o = $object;
     let name = $name;
-    if (exists_with_type<$Name, $Value>(o, name)) $some(borrow_mut(o, name)) else $none
+    if (exists<$Name>(o, name)) $some(borrow_mut(o, name)) else $none
 }
 
 // === Deprecated ===

--- a/crates/sui-framework/packages/sui-framework/sources/dynamic_object_field.move
+++ b/crates/sui-framework/packages/sui-framework/sources/dynamic_object_field.move
@@ -90,6 +90,8 @@ public fun id<Name: copy + drop + store>(object: &UID, name: Name): Option<ID> {
 
 /// Removes the dynamic object field if it exists. Returns `some(Value)` if it exists or `none`
 /// otherwise.
+/// Aborts with `EFieldTypeMismatch` if the field exists, but the value object does not have the
+/// specified type.
 public fun remove_opt<Name: copy + drop + store, Value: key + store>(
     object: &mut UID,
     name: Name,
@@ -104,6 +106,8 @@ public fun remove_opt<Name: copy + drop + store, Value: key + store>(
 /// Removes the existing value at `name` (if any) and adds `value` in its place.
 /// Returns the old value if it existed, or `none` otherwise.
 /// Note: the old and new value types may differ.
+/// Aborts with `EFieldTypeMismatch` if the field exists, but the value object does not have the
+/// specified `ValueOld` type.
 public fun replace<Name: copy + drop + store, ValueNew: key + store, ValueOld: key + store>(
     object: &mut UID,
     name: Name,
@@ -118,6 +122,8 @@ public fun replace<Name: copy + drop + store, ValueNew: key + store, ValueOld: k
 
 /// Immutably borrows the field value, adding it with `$default` if it doesn't exist.
 /// Note that `$default` is evaluated only if the field does not already exist.
+/// Aborts with `EFieldTypeMismatch` if the field exists, but the value object does not have the
+/// specified type.
 public macro fun borrow_or_add<$Name: copy + drop + store, $Value: key + store>(
     $object: &mut UID,
     $name: $Name,
@@ -131,6 +137,8 @@ public macro fun borrow_or_add<$Name: copy + drop + store, $Value: key + store>(
 
 /// Mutably borrows the field value, adding it with `$default` if it doesn't exist.
 /// Note that `$default` is evaluated only if the field does not already exist.
+/// Aborts with `EFieldTypeMismatch` if the field exists, but the value object does not have the
+/// specified type.
 public macro fun borrow_mut_or_add<$Name: copy + drop + store, $Value: key + store>(
     $object: &mut UID,
     $name: $Name,
@@ -144,6 +152,8 @@ public macro fun borrow_mut_or_add<$Name: copy + drop + store, $Value: key + sto
 
 /// If the field exists, calls `$f` on an immutable reference to the value; otherwise, does nothing.
 /// This is like getting an `Option<&Value>` then calling `std::option::do`.
+/// Aborts with `EFieldTypeMismatch` if the field exists, but the value object does not have the
+/// specified type.
 public macro fun get_do<$Name: copy + drop + store, $Value: key + store, $R: drop>(
     $object: &UID,
     $name: $Name,
@@ -156,6 +166,8 @@ public macro fun get_do<$Name: copy + drop + store, $Value: key + store, $R: dro
 
 /// If the field exists, calls `$f` on a mutable reference to the value; otherwise, does nothing.
 /// This is like getting an `Option<&mut Value>` then calling `std::option::do`.
+/// Aborts with `EFieldTypeMismatch` if the field exists, but the value object does not have the
+/// specified type.
 public macro fun get_mut_do<$Name: copy + drop + store, $Value: key + store, $R: drop>(
     $object: &mut UID,
     $name: $Name,
@@ -169,6 +181,8 @@ public macro fun get_mut_do<$Name: copy + drop + store, $Value: key + store, $R:
 /// If the field exists, applies `$some` to an immutable reference to the value; otherwise, returns
 /// `$none`.
 /// This is like getting an `Option<&Value>` then calling `std::option::fold`.
+/// Aborts with `EFieldTypeMismatch` if the field exists, but the value object does not have the
+/// specified type.
 public macro fun get_fold<$Name: copy + drop + store, $Value: key + store, $R>(
     $object: &UID,
     $name: $Name,
@@ -183,6 +197,8 @@ public macro fun get_fold<$Name: copy + drop + store, $Value: key + store, $R>(
 /// If the field exists, applies `$some` to a mutable reference to the value; otherwise, returns
 /// `$none`.
 /// This is like getting an `Option<&mut Value>` then calling `std::option::fold`.
+/// Aborts with `EFieldTypeMismatch` if the field exists, but the value object does not have the
+/// specified type.
 public macro fun get_mut_fold<$Name: copy + drop + store, $Value: key + store, $R>(
     $object: &mut UID,
     $name: $Name,

--- a/crates/sui-framework/packages/sui-framework/sources/dynamic_object_field.move
+++ b/crates/sui-framework/packages/sui-framework/sources/dynamic_object_field.move
@@ -151,7 +151,7 @@ public macro fun get_do<$Name: copy + drop + store, $Value: key + store, $R: dro
 ) {
     let o = $object;
     let name = $name;
-    if (exists_with_type<$Name, $Value>(o, name)) { $f(borrow(o, name)); }
+    if (exists<$Name>(o, name)) { $f(borrow(o, name)); }
 }
 
 /// If the field exists, calls `$f` on a mutable reference to the value; otherwise, does nothing.
@@ -163,7 +163,7 @@ public macro fun get_mut_do<$Name: copy + drop + store, $Value: key + store, $R:
 ) {
     let o = $object;
     let name = $name;
-    if (exists_with_type<$Name, $Value>(o, name)) { $f(borrow_mut(o, name)); }
+    if (exists<$Name>(o, name)) { $f(borrow_mut(o, name)); }
 }
 
 /// If the field exists, applies `$some` to an immutable reference to the value; otherwise, returns
@@ -177,7 +177,7 @@ public macro fun get_fold<$Name: copy + drop + store, $Value: key + store, $R>(
 ): $R {
     let o = $object;
     let name = $name;
-    if (exists_with_type<$Name, $Value>(o, name)) $some(borrow(o, name)) else $none
+    if (exists<$Name>(o, name)) $some(borrow(o, name)) else $none
 }
 
 /// If the field exists, applies `$some` to a mutable reference to the value; otherwise, returns
@@ -191,7 +191,7 @@ public macro fun get_mut_fold<$Name: copy + drop + store, $Value: key + store, $
 ): $R {
     let o = $object;
     let name = $name;
-    if (exists_with_type<$Name, $Value>(o, name)) $some(borrow_mut(o, name)) else $none
+    if (exists<$Name>(o, name)) $some(borrow_mut(o, name)) else $none
 }
 
 // === Deprecated ===

--- a/crates/sui-framework/packages/sui-framework/tests/dynamic_field_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/dynamic_field_tests.move
@@ -334,24 +334,19 @@ fun get_do_missing() {
     let sender = @0x0;
     let mut scenario = test_scenario::begin(sender);
     let id = scenario.new_object();
-    let mut called = false;
-    dynamic_field::get_do!(&id, 0u64, |_v: &u64| { called = true; assert!(false) });
-    assert!(!called);
+    dynamic_field::get_do!(&id, 0u64, |_v: &u64| assert!(false));
     scenario.end();
     id.delete();
 }
 
-#[test]
+#[test, expected_failure(abort_code = sui::dynamic_field::EFieldTypeMismatch)]
 fun get_do_wrong_type() {
     let sender = @0x0;
     let mut scenario = test_scenario::begin(sender);
     let mut id = scenario.new_object();
     add(&mut id, 0u64, 42u64);
-    let mut called = false;
-    dynamic_field::get_do!(&id, 0u64, |_v: &u8| { called = true; assert!(false) });
-    assert!(!called);
-    scenario.end();
-    id.delete();
+    dynamic_field::get_do!(&id, 0u64, |_v: &u8| assert!(false));
+    abort
 }
 
 #[test]
@@ -371,24 +366,19 @@ fun get_mut_do_missing() {
     let sender = @0x0;
     let mut scenario = test_scenario::begin(sender);
     let mut id = scenario.new_object();
-    let mut called = false;
-    dynamic_field::get_mut_do!(&mut id, 0u64, |_v: &mut u64| { called = true; assert!(false) });
-    assert!(!called);
+    dynamic_field::get_mut_do!(&mut id, 0u64, |_v: &mut u64| assert!(false));
     scenario.end();
     id.delete();
 }
 
-#[test]
+#[test, expected_failure(abort_code = sui::dynamic_field::EFieldTypeMismatch)]
 fun get_mut_do_wrong_type() {
     let sender = @0x0;
     let mut scenario = test_scenario::begin(sender);
     let mut id = scenario.new_object();
     add(&mut id, 0u64, 42u64);
-    let mut called = false;
-    dynamic_field::get_mut_do!(&mut id, 0u64, |_v: &mut u8| { called = true; assert!(false) });
-    assert!(!called);
-    scenario.end();
-    id.delete();
+    dynamic_field::get_mut_do!(&mut id, 0u64, |_v: &mut u8| assert!(false));
+    abort
 }
 
 #[test]
@@ -414,16 +404,14 @@ fun get_fold_missing() {
     id.delete();
 }
 
-#[test]
+#[test, expected_failure(abort_code = sui::dynamic_field::EFieldTypeMismatch)]
 fun get_fold_wrong_type() {
     let sender = @0x0;
     let mut scenario = test_scenario::begin(sender);
     let mut id = scenario.new_object();
     add(&mut id, 0u64, 42u64);
-    let result: u8 = dynamic_field::get_fold!(&id, 0u64, 0u8, |_: &u8| abort 0);
-    assert_eq!(result, 0);
-    scenario.end();
-    id.delete();
+    let _result: u8 = dynamic_field::get_fold!(&id, 0u64, 0u8, |_: &u8| abort 0);
+    abort
 }
 
 #[test]
@@ -453,16 +441,14 @@ fun get_mut_fold_missing() {
     id.delete();
 }
 
-#[test]
+#[test, expected_failure(abort_code = sui::dynamic_field::EFieldTypeMismatch)]
 fun get_mut_fold_wrong_type() {
     let sender = @0x0;
     let mut scenario = test_scenario::begin(sender);
     let mut id = scenario.new_object();
     add(&mut id, 0u64, 42u64);
-    let result: u8 = dynamic_field::get_mut_fold!(&mut id, 0u64, 0u8, |_: &mut u8| abort 0);
-    assert_eq!(result, 0);
-    scenario.end();
-    id.delete();
+    let _restult: u8 = dynamic_field::get_mut_fold!(&mut id, 0u64, 0u8, |_: &mut u8| abort 0);
+    abort
 }
 
 // === Deprecated Tests ===

--- a/crates/sui-framework/packages/sui-framework/tests/dynamic_object_field_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/dynamic_object_field_tests.move
@@ -433,24 +433,19 @@ fun get_do_missing() {
     let sender = @0x0;
     let mut scenario = test_scenario::begin(sender);
     let id = scenario.new_object();
-    let mut called = false;
-    dynamic_object_field::get_do!(&id, 0u64, |_v: &Counter| { called = true; assert!(false) });
-    assert!(!called);
+    dynamic_object_field::get_do!(&id, 0u64, |_v: &Counter| assert!(false));
     scenario.end();
     id.delete();
 }
 
-#[test]
+#[test, expected_failure(abort_code = sui::dynamic_field::EFieldTypeMismatch)]
 fun get_do_wrong_type() {
     let sender = @0x0;
     let mut scenario = test_scenario::begin(sender);
     let mut id = scenario.new_object();
     add(&mut id, 0u64, new(&mut scenario));
-    let mut called = false;
-    dynamic_object_field::get_do!(&id, 0u64, |_v: &Fake| { called = true; assert!(false) });
-    assert!(!called);
-    scenario.end();
-    id.delete();
+    dynamic_object_field::get_do!(&id, 0u64, |_v: &Fake| assert!(false));
+    abort
 }
 
 #[test]
@@ -471,30 +466,19 @@ fun get_mut_do_missing() {
     let sender = @0x0;
     let mut scenario = test_scenario::begin(sender);
     let mut id = scenario.new_object();
-    let mut called = false;
-    dynamic_object_field::get_mut_do!(&mut id, 0u64, |_v: &mut Counter| {
-        called = true;
-        assert!(false)
-    });
-    assert!(!called);
+    dynamic_object_field::get_mut_do!(&mut id, 0u64, |_v: &mut Counter| assert!(false));
     scenario.end();
     id.delete();
 }
 
-#[test]
+#[test, expected_failure(abort_code = sui::dynamic_field::EFieldTypeMismatch)]
 fun get_mut_do_wrong_type() {
     let sender = @0x0;
     let mut scenario = test_scenario::begin(sender);
     let mut id = scenario.new_object();
     add(&mut id, 0u64, new(&mut scenario));
-    let mut called = false;
-    dynamic_object_field::get_mut_do!(&mut id, 0u64, |_v: &mut Fake| {
-        called = true;
-        assert!(false)
-    });
-    assert!(!called);
-    scenario.end();
-    id.delete();
+    dynamic_object_field::get_mut_do!(&mut id, 0u64, |_v: &mut Fake| assert!(false));
+    abort
 }
 
 #[test]
@@ -521,16 +505,14 @@ fun get_fold_missing() {
     id.delete();
 }
 
-#[test]
+#[test, expected_failure(abort_code = sui::dynamic_field::EFieldTypeMismatch)]
 fun get_fold_wrong_type() {
     let sender = @0x0;
     let mut scenario = test_scenario::begin(sender);
     let mut id = scenario.new_object();
     add(&mut id, 0u64, new(&mut scenario));
-    let result: u64 = dynamic_object_field::get_fold!(&id, 0u64, 99u64, |_: &Fake| abort 0);
-    assert_eq!(result, 99);
-    scenario.end();
-    id.delete();
+    let _result: u64 = dynamic_object_field::get_fold!(&id, 0u64, 99u64, |_: &Fake| abort 0);
+    abort
 }
 
 #[test]
@@ -565,21 +547,14 @@ fun get_mut_fold_missing() {
     id.delete();
 }
 
-#[test]
+#[test, expected_failure(abort_code = sui::dynamic_field::EFieldTypeMismatch)]
 fun get_mut_fold_wrong_type() {
     let sender = @0x0;
     let mut scenario = test_scenario::begin(sender);
     let mut id = scenario.new_object();
     add(&mut id, 0u64, new(&mut scenario));
-    let result: u64 = dynamic_object_field::get_mut_fold!(
-        &mut id,
-        0u64,
-        99u64,
-        |_: &mut Fake| abort 0,
-    );
-    assert_eq!(result, 99);
-    scenario.end();
-    id.delete();
+    dynamic_object_field::get_mut_fold!(&mut id, 0u64, 99u64, |_: &mut Fake| abort 0);
+    abort
 }
 
 // === Deprecated Tests ===


### PR DESCRIPTION
## Description 

- Switching the get macros so they abort instead of returning `none` on type mismatch 
  - This amounts to switching from `exists_with_type` to `exists`
- Added some additional abort related comments 
- Stacked on #26248  

## Test plan 

- 👀 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
