### PR TITLE
ci(rust): gate simtest / benchmark / exec-cut on narrower path filters

### DIFF
--- a/.github/actions/diffs/action.yml
+++ b/.github/actions/diffs/action.yml
@@ -3,90 +3,121 @@ description: Defines variables indicating the parts of the code that changed
 outputs:
   isDoc:
     description: True when changes happened to some documentation
-    value: "${{ steps.diff.outputs.isDoc }}"
+    value: '${{ steps.diff.outputs.isDoc }}'
   isOldDoc:
     description: True when changes happened to old doc folder
-    value: "${{ steps.diff.outputs.isOldDoc }}"    
+    value: '${{ steps.diff.outputs.isOldDoc }}'
   isRust:
     description: True when changes happened to the Rust code
-    value: "${{ steps.diff.outputs.isRust }}"
+    value: '${{ steps.diff.outputs.isRust }}'
   isMove:
     description: True when changes happened to the Move code
-    value: "${{ steps.diff.outputs.isMove }}"
+    value: '${{ steps.diff.outputs.isMove }}'
   isSolidity:
     description: True when changes happened to the Solidity code
-    value: "${{ steps.diff.outputs.isSolidity }}"
+    value: '${{ steps.diff.outputs.isSolidity }}'
   isReleaseNotesEligible:
     description: True when changes happened in Release Notes eligible paths
-    value: "${{ steps.diff.outputs.isReleaseNotesEligible }}"
+    value: '${{ steps.diff.outputs.isReleaseNotesEligible }}'
   isMoveAutoFormatter:
     description: True when changes happened in MoveAutoFormatter code
-    value: "${{ steps.diff.outputs.isMoveAutoFormatter }}"
+    value: '${{ steps.diff.outputs.isMoveAutoFormatter }}'
   isMoveAnalyzerTraceAdapter:
     description: True when changes happened in Trace Adapter
-    value: "${{ steps.diff.outputs.isMoveAnalyzerTraceAdapter }}"
+    value: '${{ steps.diff.outputs.isMoveAnalyzerTraceAdapter }}'
   isExamples:
     description: True when changes happened in examples/ directory
-    value: "${{ steps.diff.outputs.isExamples }}"
+    value: '${{ steps.diff.outputs.isExamples }}'
   isReleaseNotesScript:
     description: True when changes happened to release notes scripts
-    value: "${{ steps.diff.outputs.isReleaseNotesScript }}"
+    value: '${{ steps.diff.outputs.isReleaseNotesScript }}'
+  isConsensusOrCore:
+    description: True when changes happened to consensus, protocol, or core execution crates (used to gate simtest + benchmark-smoke)
+    value: '${{ steps.diff.outputs.isConsensusOrCore }}'
+  isExecutionLayerCut:
+    description: True when changes happened to files exercised by the sui-excution-cut job (sui-execution/ or the cut script)
+    value: '${{ steps.diff.outputs.isExecutionLayerCut }}'
 
 runs:
   using: composite
   steps:
-  - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
-  - name: Detect Changes
-    uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # pin@v3.0.2
-    id: diff
-    with:
-      filters: |
-        isRust:
-          - 'consensus/**'
-          - 'crates/**'
-          - 'external-crates/**'
-          - 'sui-execution/**'
-          - '.github/workflows/cargo-llvm-cov.yml'
-          - '.github/workflows/rust.yml'
-          - '.github/workflows/external.yml'
-          - 'Cargo.lock'
-          - 'Cargo.toml'
-          - 'deny.toml'
-          - 'rust-toolchain.toml'
-          - 'rustfmt.toml'
-        isDoc:
-          - 'docs/content/**'
-          - '*.mdx'
-          - '.github/workflows/docs.yml'
-        isOldDoc:
-          - 'doc/**'
-          - '*.md'  
-        isMove:
-          - 'crates/sui-framework/**'
-          - 'crates/sui-framework-build/**'
-          - 'crates/sui-framework-tests/**'
-          - 'crates/sui_move/**'
-          - 'Cargo.toml'
-          - 'examples/**'
-          - 'sui_programmability/**'
-        isSolidity:
-          - 'bridge/evm/**'
-        isReleaseNotesEligible:
-          - 'consensus/**'
-          - 'crates/**'
-          - 'dashboards/**'
-          - 'doc/**'
-          - 'docker/**'
-          - 'external-crates/**'
-          - 'kiosk/**'
-          - 'nre/**'
-          - 'sui-execution/**'
-        isMoveAutoFormatter:
-          - 'external-crates/move/crates/move-analyzer/prettier-plugin/**'
-        isMoveAnalyzerTraceAdapter:
-          - 'external-crates/move/crates/move-analyzer/trace-adapter/**'
-        isExamples:
-          - 'examples/**'
-        isReleaseNotesScript:
-          - 'scripts/release_notes.py'
-          - 'scripts/release_notes_test.py'
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
+    - name: Detect Changes
+      uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # pin@v3.0.2
+      id: diff
+      with:
+        filters: |
+          isRust:
+            - 'consensus/**'
+            - 'crates/**'
+            - 'external-crates/**'
+            - 'sui-execution/**'
+            - '.github/workflows/cargo-llvm-cov.yml'
+            - '.github/workflows/rust.yml'
+            - '.github/workflows/external.yml'
+            - 'Cargo.lock'
+            - 'Cargo.toml'
+            - 'deny.toml'
+            - 'rust-toolchain.toml'
+            - 'rustfmt.toml'
+          isDoc:
+            - 'docs/content/**'
+            - '*.mdx'
+            - '.github/workflows/docs.yml'
+          isOldDoc:
+            - 'doc/**'
+            - '*.md'  
+          isMove:
+            - 'crates/sui-framework/**'
+            - 'crates/sui-framework-build/**'
+            - 'crates/sui-framework-tests/**'
+            - 'crates/sui_move/**'
+            - 'Cargo.toml'
+            - 'examples/**'
+            - 'sui_programmability/**'
+          isSolidity:
+            - 'bridge/evm/**'
+          isReleaseNotesEligible:
+            - 'consensus/**'
+            - 'crates/**'
+            - 'dashboards/**'
+            - 'doc/**'
+            - 'docker/**'
+            - 'external-crates/**'
+            - 'kiosk/**'
+            - 'nre/**'
+            - 'sui-execution/**'
+          isMoveAutoFormatter:
+            - 'external-crates/move/crates/move-analyzer/prettier-plugin/**'
+          isMoveAnalyzerTraceAdapter:
+            - 'external-crates/move/crates/move-analyzer/trace-adapter/**'
+          isExamples:
+            - 'examples/**'
+          isReleaseNotesScript:
+            - 'scripts/release_notes.py'
+            - 'scripts/release_notes_test.py'
+          # Consensus, protocol, and core-execution surface — changes that could
+          # plausibly affect consensus behaviour, protocol semantics, or the core
+          # execution pipeline. Used to gate the most expensive rust.yml jobs
+          # (simtest, simtest-mainnet, benchmark-smoke) so they don't run on
+          # SDK/indexer/CLI-only PRs.
+          isConsensusOrCore:
+            - 'consensus/**'
+            - 'crates/sui-core/**'
+            - 'crates/sui-types/**'
+            - 'crates/sui-protocol-config/**'
+            - 'crates/sui-config/**'
+            - 'crates/sui-network/**'
+            - 'crates/sui-benchmark/**'
+            - 'sui-execution/**'
+            - 'Cargo.lock'
+            - '.github/workflows/rust.yml'
+            - '.github/actions/diffs/action.yml'
+          # Files exercised by the `sui-excution-cut` job. The job only runs
+          # `./scripts/execution_layer.py cut for_ci_test` against sui-execution,
+          # so anything outside that scope can safely skip it.
+          isExecutionLayerCut:
+            - 'sui-execution/**'
+            - 'scripts/execution_layer.py'
+            - '.github/workflows/rust.yml'
+            - '.github/actions/diffs/action.yml'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,11 +9,11 @@ on:
       - 'mainnet'
       - 'releases/sui-*-release'
   pull_request:
-    types: [ opened, synchronize, reopened, ready_for_review ]
+    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
     inputs:
       sui_repo_ref:
-        description: "Branch / commit to test"
+        description: 'Branch / commit to test'
         type: string
         required: false
         default: ''
@@ -51,10 +51,13 @@ env:
 
 jobs:
   diff:
-    runs-on: [ ubuntu-latest ]
+    runs-on: [ubuntu-latest]
     outputs:
       isRust: ${{ steps.diff.outputs.isRust }}
       isMove: ${{ steps.diff.outputs.isMove }}
+      isSolidity: ${{ steps.diff.outputs.isSolidity }}
+      isConsensusOrCore: ${{ steps.diff.outputs.isConsensusOrCore }}
+      isExecutionLayerCut: ${{ steps.diff.outputs.isExecutionLayerCut }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
         with:
@@ -65,7 +68,7 @@ jobs:
 
   license-check:
     name: license-check
-    runs-on: [ ubuntu-latest ]
+    runs-on: [ubuntu-latest]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
         with:
@@ -88,7 +91,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - [ ubuntu-ghcloud ]
+          - [ubuntu-ghcloud]
       fail-fast: false
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
@@ -137,7 +140,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - [ ubuntu-ghcloud ]
+          - [ubuntu-ghcloud]
       fail-fast: false
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
@@ -181,7 +184,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - [ ubuntu-ghcloud ]
+          - [ubuntu-ghcloud]
       fail-fast: false
     steps:
       - run: 'echo "No build required" '
@@ -199,7 +202,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - [ ubuntu-ghcloud ]
+          - [ubuntu-ghcloud]
       fail-fast: false
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
@@ -263,9 +266,11 @@ jobs:
   benchmark-smoke:
     name: benchmark (smoke)
     needs: [diff, rustfmt, clippy]
-    if: needs.diff.outputs.isRust == 'true'
+    # Only run on changes that could affect perf-sensitive or consensus code.
+    # SDK/indexer/CLI-only PRs don't exercise sui-benchmark and can skip this.
+    if: needs.diff.outputs.isConsensusOrCore == 'true'
     timeout-minutes: 45
-    runs-on: [ ubuntu-ghcloud ]
+    runs-on: [ubuntu-ghcloud]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
         with:
@@ -323,7 +328,7 @@ jobs:
     needs: [diff, rustfmt, clippy, snapshot-check]
     if: needs.diff.outputs.isRust == 'true'
     timeout-minutes: 45
-    runs-on: [ windows-ghcloud-128 ]
+    runs-on: [windows-ghcloud-128]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
         with:
@@ -345,7 +350,7 @@ jobs:
     needs: [diff]
     if: needs.diff.outputs.isRust == 'true'
     timeout-minutes: 45
-    runs-on: [ windows-ghcloud-128 ]
+    runs-on: [windows-ghcloud-128]
     env:
       # Tests written with #[sim_test] are often flaky if run as #[tokio::test] - this var
       # causes #[sim_test] to only run under the deterministic `simtest` job, and not the
@@ -371,9 +376,12 @@ jobs:
 
   simtest:
     needs: [diff, rustfmt, clippy, snapshot-check]
-    if: needs.diff.outputs.isRust == 'true' || needs.diff.outputs.isSolidity == 'true'
+    # Simtest exercises consensus + protocol + core execution paths. SDK,
+    # indexer, CLI, and framework-only PRs don't need it. Solidity changes
+    # still trigger it because bridge logic is covered here too.
+    if: needs.diff.outputs.isConsensusOrCore == 'true' || needs.diff.outputs.isSolidity == 'true'
     timeout-minutes: 45
-    runs-on: [ ubuntu-ghcloud ]
+    runs-on: [ubuntu-ghcloud]
     env:
       MSIM_WATCHDOG_TIMEOUT_MS: 300000
     steps:
@@ -404,11 +412,24 @@ jobs:
         run: |
           scripts/simtest/stress-new-tests.sh
 
+  # Placeholder so the "simtest" required status check is satisfied on PRs that
+  # don't exercise consensus/core/solidity and correctly skip the real simtest
+  # job above. Branch protection matches on the job `name:`, which is "simtest"
+  # in both cases.
+  simtest-placeholder:
+    name: simtest
+    needs: diff
+    if: needs.diff.outputs.isConsensusOrCore == 'false' && needs.diff.outputs.isSolidity == 'false'
+    runs-on: [ubuntu-latest]
+    steps:
+      - run: echo "simtest skipped — no consensus / core / solidity changes"
+
   simtest-mainnet:
     needs: [diff, rustfmt, clippy, snapshot-check]
-    if: needs.diff.outputs.isRust == 'true' || needs.diff.outputs.isSolidity == 'true'
+    # Same scoping as simtest — see isConsensusOrCore filter definition.
+    if: needs.diff.outputs.isConsensusOrCore == 'true' || needs.diff.outputs.isSolidity == 'true'
     timeout-minutes: 45
-    runs-on: [ ubuntu-ghcloud ]
+    runs-on: [ubuntu-ghcloud]
     env:
       MSIM_WATCHDOG_TIMEOUT_MS: 300000
       SUI_PROTOCOL_CONFIG_CHAIN_OVERRIDE: mainnet
@@ -447,7 +468,7 @@ jobs:
     needs: diff
     if: needs.diff.outputs.isRust == 'false' && needs.diff.outputs.isMove == 'true'
     timeout-minutes: 10
-    runs-on: [ ubuntu-ghcloud ]
+    runs-on: [ubuntu-ghcloud]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
         with:
@@ -514,8 +535,8 @@ jobs:
     strategy:
       matrix:
         os:
-          - [ ubuntu-ghcloud ]
-          - [ windows-ghcloud ]
+          - [ubuntu-ghcloud]
+          - [windows-ghcloud]
       fail-fast: false
     steps:
       - run: 'echo "No build required" '
@@ -534,8 +555,8 @@ jobs:
     strategy:
       matrix:
         os:
-          - [ ubuntu-ghcloud ]
-          - [ windows-ghcloud ]
+          - [ubuntu-ghcloud]
+          - [windows-ghcloud]
       fail-fast: false
     steps:
       - run: 'echo "No build required" '
@@ -543,7 +564,7 @@ jobs:
   clippy:
     needs: diff
     if: needs.diff.outputs.isRust == 'true'
-    runs-on: [ ubuntu-ghcloud ]
+    runs-on: [ubuntu-ghcloud]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
         with:
@@ -568,7 +589,7 @@ jobs:
   rustfmt:
     needs: diff
     if: needs.diff.outputs.isRust == 'true'
-    runs-on: [ ubuntu-latest ]
+    runs-on: [ubuntu-latest]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
         with:
@@ -579,7 +600,7 @@ jobs:
   snapshot-check:
     needs: diff
     if: needs.diff.outputs.isRust == 'true'
-    runs-on: [ ubuntu-latest ]
+    runs-on: [ubuntu-latest]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
         with:
@@ -600,7 +621,7 @@ jobs:
     name: cargo-deny (bans, licenses, sources)
     needs: diff
     if: needs.diff.outputs.isRust == 'true'
-    runs-on: [ ubuntu-latest ]
+    runs-on: [ubuntu-latest]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
         with:
@@ -612,7 +633,7 @@ jobs:
     name: cargo-deny (advisories)
     needs: diff
     if: needs.diff.outputs.isRust == 'true'
-    runs-on: [ ubuntu-latest ]
+    runs-on: [ubuntu-latest]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
         with:
@@ -623,8 +644,10 @@ jobs:
   sui-excution-cut:
     name: cutting a new execution layer
     needs: [diff, rustfmt, clippy, snapshot-check]
-    if: needs.diff.outputs.isRust == 'true'
-    runs-on: [ ubuntu-ghcloud ]
+    # Only exercises the execution-layer cut script (./scripts/execution_layer.py)
+    # against sui-execution/. PRs outside those paths can safely skip.
+    if: needs.diff.outputs.isExecutionLayerCut == 'true'
+    runs-on: [ubuntu-ghcloud]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
         with:


### PR DESCRIPTION
## Summary

Today every Rust PR pays ~45 min of CI time on jobs that may not exercise the changed code:

- \`simtest\` (~20-25 min)
- \`simtest-mainnet\` (~20-25 min)
- \`benchmark-smoke\` (~10 min)
- \`sui-excution-cut\` (~5 min)

All four gate on the broad \`isRust\` filter, which fires on any Rust change. An SDK-only, indexer-only, or CLI-only PR still runs all of them on the critical path before merge.

This PR introduces two narrower filters in \`.github/actions/diffs/action.yml\` and wires them up in \`.github/workflows/rust.yml\`:

### Filter 1: \`isConsensusOrCore\`

Covers crates that could plausibly affect consensus behaviour, protocol semantics, or the core execution pipeline:

- \`consensus/**\`
- \`crates/sui-core/**\`
- \`crates/sui-types/**\`
- \`crates/sui-protocol-config/**\`
- \`crates/sui-config/**\`
- \`crates/sui-network/**\`
- \`crates/sui-benchmark/**\`
- \`sui-execution/**\`
- \`Cargo.lock\`
- The \`rust.yml\` workflow + the \`diffs\` composite action themselves

Applied to \`simtest\`, \`simtest-mainnet\`, and \`benchmark-smoke\`. (Simtest keeps its \`isSolidity\` branch so \`bridge/evm/**\` changes still trigger it.)

### Filter 2: \`isExecutionLayerCut\`

Covers only what the \`sui-excution-cut\` job exercises:

- \`sui-execution/**\`
- \`scripts/execution_layer.py\`
- \`rust.yml\` + \`diffs\` action

The job runs \`./scripts/execution_layer.py cut for_ci_test\` and nothing else — anything outside that scope is wasted.

## Expected impact

For PRs that don't touch consensus/core/solidity/execution-layer:
- ~45 min of CI jobs skipped on the critical path
- \`test\`, \`test-tidehunter\`, \`test-extra\`, \`clippy\`, \`rustfmt\`, \`cargo-deny\`, \`windows-*\` all keep running as before
- Reviewer experience: PR "ready to merge" signal arrives ~45 min sooner on average for non-core PRs

For PRs that DO touch consensus/core: identical to today.

## Required-check alignment

\`simtest\` is listed as a required status check in branch protection (confirmed via \`gh api repos/MystenLabs/sui/branches/main/protection --jq '.required_status_checks.contexts'\`). Gating the real \`simtest\` job more narrowly without a companion would hang PRs that correctly skip it.

I've added a \`simtest-placeholder\` job with \`name: simtest\` that runs in the complementary condition (when \`isConsensusOrCore == 'false' && isSolidity == 'false'\`) and immediately passes. This is the same pattern already used for \`test-notrust\`, \`test-tidehunter-notrust\`, and \`test-extra-notrust\`. Branch protection matches on the display name, so the required check stays satisfied either way.

\`simtest-mainnet\`, \`benchmark-smoke\`, and \`sui-excution-cut\` are NOT in the required-check list, so no placeholder is needed.

## Latent bug fix (bundled)

The \`diff\` job in \`rust.yml\` only declared \`isRust\` and \`isMove\` as outputs, but \`simtest\` already referenced \`needs.diff.outputs.isSolidity\` as part of its gate. That reference was always empty string, meaning the Solidity clause never actually fired — \`bridge/evm/**\` changes alone wouldn't trigger simtest. This PR adds \`isSolidity\`, \`isConsensusOrCore\`, and \`isExecutionLayerCut\` to the \`diff\` job's output declarations so the gates work end-to-end.

## Scope — what this does NOT change

Keeping their current broad \`isRust\` gate:
- \`test\`, \`test-extra\`, \`test-tidehunter\` — catch cross-cutting regressions
- \`clippy\`, \`rustfmt\`, \`cargo-deny\`, \`cargo-deny-advisories\`, \`snapshot-check\` — fast enough to leave
- \`windows-build\`, \`windows-cli-tests\` — need a deliberate audit of which crates compile on Windows before narrowing

These are appropriate follow-ups but have different risk profiles — each deserves its own PR with domain-owner review.

## Test plan

- [ ] CI on this PR runs all four targeted jobs (since the PR touches \`rust.yml\`, which is in \`isConsensusOrCore\`) — verifies the filter still fires for its own maintenance
- [ ] After merge: open a test PR touching only an SDK crate (e.g., \`crates/sui-sdk/**\`) and verify simtest / simtest-mainnet / benchmark-smoke / sui-excution-cut are all skipped while \`test\` / \`test-extra\` / \`test-tidehunter\` still run
- [ ] After merge: open a test PR touching only \`bridge/evm/**\` and verify simtest still runs (Solidity branch)
- [ ] After merge: confirm the \`simtest\` required status check still passes (via placeholder) on an SDK-only PR

## Owner review needed

This is a risk-tolerance call more than a technical one: *are we willing to trust that simtest will catch bugs inside the \`isConsensusOrCore\` filter scope?* Historically, has simtest caught non-consensus bugs that the filter would miss? If yes, the filter list above should expand. Happy to widen based on owner feedback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)