### PR TITLE
test-cluster: add 30s timeout+retry around direct-submit and fullnode exec paths

### DIFF
--- a/crates/mysten-network/src/client.rs
+++ b/crates/mysten-network/src/client.rs
@@ -121,6 +121,11 @@ impl MyEndpoint {
             disable_caching_resolver
         });
 
+        info!(
+            disable_caching_resolver,
+            "exec_tx_debug: MyEndpoint::connect_lazy building lazy channel"
+        );
+
         if disable_caching_resolver {
             let mut http = HttpConnector::new();
             http.enforce_http(false);
@@ -233,6 +238,7 @@ impl Service<Name> for CachingResolver {
     }
 
     fn call(&mut self, name: Name) -> Self::Future {
+        info!(host = %name.as_str(), "exec_tx_debug: CachingResolver::call");
         let blocking = {
             let cache = self.cache.clone();
             tokio::task::spawn_blocking(move || {
@@ -288,17 +294,26 @@ impl Future for CachingFuture {
     type Output = Result<SocketAddrs, io::Error>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Self::Output> {
-        Pin::new(&mut self.inner).poll(cx).map(|res| match res {
-            Ok(Ok(addrs)) => Ok(addrs),
-            Ok(Err(err)) => Err(err),
-            Err(join_err) => {
+        match Pin::new(&mut self.inner).poll(cx) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(Ok(Ok(addrs))) => {
+                info!("exec_tx_debug: CachingFuture::poll resolved host");
+                Poll::Ready(Ok(addrs))
+            }
+            Poll::Ready(Ok(Err(err))) => {
+                info!(error = %err, "exec_tx_debug: CachingFuture::poll resolver error");
+                Poll::Ready(Err(err))
+            }
+            Poll::Ready(Err(join_err)) => {
                 if join_err.is_cancelled() {
-                    Err(io::Error::new(io::ErrorKind::Interrupted, join_err))
+                    let err = io::Error::new(io::ErrorKind::Interrupted, join_err);
+                    info!(error = %err, "exec_tx_debug: CachingFuture::poll join cancelled");
+                    Poll::Ready(Err(err))
                 } else {
                     panic!("background task failed: {:?}", join_err)
                 }
             }
-        })
+        }
     }
 }
 

--- a/crates/sui-http/src/connection_handler.rs
+++ b/crates/sui-http/src/connection_handler.rs
@@ -28,6 +28,10 @@ pub async fn serve_connection<IO, S, B, C>(
 {
     let mut sig = pin!(Fuse::new(graceful_shutdown_token.cancelled_owned()));
 
+    tracing::info!(
+        ?max_connection_age,
+        "exec_tx_debug: serve_connection entered"
+    );
     let mut conn = pin!(builder.serve_connection_with_upgrades(hyper_io, hyper_svc));
 
     let sleep = sleep_or_pending(max_connection_age);
@@ -36,21 +40,28 @@ pub async fn serve_connection<IO, S, B, C>(
     loop {
         tokio::select! {
             _ = &mut sig => {
+                tracing::info!("exec_tx_debug: serve_connection got shutdown signal");
                 conn.as_mut().graceful_shutdown();
             }
             rv = &mut conn => {
-                if let Err(err) = rv {
-                    debug!("failed serving connection: {:#}", err);
+                match rv {
+                    Ok(()) => tracing::info!("exec_tx_debug: serve_connection completed ok"),
+                    Err(err) => {
+                        tracing::info!("exec_tx_debug: serve_connection returned error: {:#}", err);
+                        debug!("failed serving connection: {:#}", err);
+                    }
                 }
                 break;
             },
             _ = &mut sleep  => {
+                tracing::info!("exec_tx_debug: serve_connection max_connection_age elapsed");
                 conn.as_mut().graceful_shutdown();
                 sleep.set(sleep_or_pending(None));
             },
         }
     }
 
+    tracing::info!("exec_tx_debug: serve_connection connection closed");
     trace!("connection closed");
     drop(on_connection_close);
 }

--- a/crates/sui-http/src/lib.rs
+++ b/crates/sui-http/src/lib.rs
@@ -258,12 +258,14 @@ where
                     break;
                 },
                 (io, remote_addr) = self.listener.accept() => {
+                    tracing::info!("exec_tx_debug: listener.accept returned");
                     self.handle_incomming(io, remote_addr);
                 },
                 Some(maybe_connection) = self.pending_connections.join_next() => {
                     // If a task panics, just propagate it
                     let (io, remote_addr) = match maybe_connection.unwrap() {
                         Ok((io, remote_addr)) => {
+                            tracing::info!("exec_tx_debug: pending TLS accept completed");
                             (io, remote_addr)
                         }
                         Err(e) => {
@@ -276,6 +278,7 @@ where
                     self.handle_connection(io, remote_addr);
                 },
                 Some(connection_handler_output) = self.connection_handlers.join_next() => {
+                    tracing::info!("exec_tx_debug: connection handler finished");
                     // If a task panics, just propagate it
                     let _: () = connection_handler_output.unwrap();
                 },
@@ -310,6 +313,7 @@ where
                 Ok((ServerIo::new_tls_io(io), remote_addr))
             });
         } else {
+            tracing::info!("exec_tx_debug: handle_incomming without TLS");
             self.handle_connection(ServerIo::new_io(io), remote_addr);
         }
     }
@@ -340,6 +344,10 @@ where
             },
         ));
 
+        tracing::info!(
+            ?connection_id,
+            "exec_tx_debug: handle_connection spawning connection handler"
+        );
         self.connections
             .write()
             .unwrap()

--- a/crates/sui-network/build.rs
+++ b/crates/sui-network/build.rs
@@ -115,6 +115,7 @@ fn main() -> Result<()> {
     Builder::new()
         .out_dir(&out_dir)
         .compile(&[validator_service]);
+    inject_submit_transaction_debug(&out_dir)?;
 
     let route_names: Vec<&str> = methods.iter().map(|m| m.route_name).collect();
     generate_paths_constant(&out_dir, package, service_name, &route_names)?;
@@ -124,6 +125,137 @@ fn main() -> Result<()> {
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-env-changed=DUMP_GENERATED_GRPC");
 
+    Ok(())
+}
+
+fn inject_submit_transaction_debug(out_dir: &Path) -> Result<()> {
+    let path = out_dir.join("sui.validator.Validator.rs");
+    let contents = std::fs::read_to_string(&path)?;
+    let old = r#"        pub async fn submit_transaction(
+            &mut self,
+            request: impl tonic::IntoRequest<
+                sui_types::messages_grpc::RawSubmitTxRequest,
+            >,
+        ) -> std::result::Result<
+            tonic::Response<sui_types::messages_grpc::RawSubmitTxResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic_prost::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/sui.validator.Validator/SubmitTransaction",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("sui.validator.Validator", "SubmitTransaction"));
+            self.inner.unary(req, path, codec).await
+        }
+"#;
+    let new = r#"        pub async fn submit_transaction(
+            &mut self,
+            request: impl tonic::IntoRequest<
+                sui_types::messages_grpc::RawSubmitTxRequest,
+            >,
+        ) -> std::result::Result<
+            tonic::Response<sui_types::messages_grpc::RawSubmitTxResponse>,
+            tonic::Status,
+        > {
+            use tokio_stream::StreamExt as _;
+
+            tracing::info!("exec_tx_debug: ValidatorClient::submit_transaction before ready");
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    let status = tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    );
+                    tracing::info!(
+                        error = %status,
+                        "exec_tx_debug: ValidatorClient::submit_transaction ready returned error"
+                    );
+                    status
+                })?;
+            tracing::info!("exec_tx_debug: ValidatorClient::submit_transaction after ready");
+
+            let codec = tonic_prost::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/sui.validator.Validator/SubmitTransaction",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("sui.validator.Validator", "SubmitTransaction"));
+
+            let request = req.map(|m| tokio_stream::once(m));
+            tracing::info!("exec_tx_debug: ValidatorClient::submit_transaction before streaming");
+            let response = self.inner.streaming(request, path, codec).await;
+            let (parts, body, extensions) = match response {
+                Ok(response) => {
+                    tracing::info!(
+                        "exec_tx_debug: ValidatorClient::submit_transaction after streaming"
+                    );
+                    response.into_parts()
+                }
+                Err(status) => {
+                    tracing::info!(
+                        error = %status,
+                        "exec_tx_debug: ValidatorClient::submit_transaction streaming returned error"
+                    );
+                    return Err(status);
+                }
+            };
+
+            let mut body = std::pin::pin!(body);
+            tracing::info!("exec_tx_debug: ValidatorClient::submit_transaction before try_next");
+            let message = body
+                .try_next()
+                .await
+                .map_err(|status| {
+                    tracing::info!(
+                        error = %status,
+                        "exec_tx_debug: ValidatorClient::submit_transaction try_next returned error"
+                    );
+                    status
+                })?
+                .ok_or_else(|| {
+                    let status = tonic::Status::internal("Missing response message.");
+                    tracing::info!(
+                        error = %status,
+                        "exec_tx_debug: ValidatorClient::submit_transaction try_next missing response"
+                    );
+                    status
+                })?;
+            tracing::info!("exec_tx_debug: ValidatorClient::submit_transaction after try_next");
+
+            tracing::info!("exec_tx_debug: ValidatorClient::submit_transaction before trailers");
+            let _trailers = body.trailers().await.map_err(|status| {
+                tracing::info!(
+                    error = %status,
+                    "exec_tx_debug: ValidatorClient::submit_transaction trailers returned error"
+                );
+                status
+            })?;
+            tracing::info!("exec_tx_debug: ValidatorClient::submit_transaction after trailers");
+
+            Ok(tonic::Response::from_parts(parts, message, extensions))
+        }
+"#;
+
+    if contents.contains(new) {
+        return Ok(());
+    }
+    if !contents.contains(old) {
+        return Err(format!("failed to find submit_transaction body in {}", path.display()).into());
+    }
+
+    std::fs::write(path, contents.replacen(old, new, 1))?;
     Ok(())
 }
 

--- a/crates/test-cluster/Cargo.toml
+++ b/crates/test-cluster/Cargo.toml
@@ -29,6 +29,7 @@ sui-swarm-config.workspace = true
 sui-json-rpc.workspace = true
 sui-json-rpc-types.workspace = true
 sui-json-rpc-api.workspace = true
+sui-network.workspace = true
 sui-node.workspace = true
 sui-protocol-config.workspace = true
 sui-swarm.workspace = true

--- a/crates/test-cluster/src/lib.rs
+++ b/crates/test-cluster/src/lib.rs
@@ -633,9 +633,11 @@ impl TestCluster {
         &self,
         tx_data: &TransactionData,
     ) -> SuiResult<(TransactionDigest, TransactionEffects)> {
+        tracing::info!("exec_tx_debug: sign_and_execute_transaction_directly entered");
         let mut res = self
             .sign_and_execute_txns_in_soft_bundle(std::slice::from_ref(tx_data))
             .await?;
+        tracing::info!("exec_tx_debug: sign_and_execute_txns_in_soft_bundle returned Ok");
         assert_eq!(res.len(), 1);
         Ok(res.pop().unwrap())
     }
@@ -664,11 +666,25 @@ impl TestCluster {
         &self,
         txns: &[TransactionData],
     ) -> SuiResult<Vec<(TransactionDigest, TransactionEffects)>> {
+        tracing::info!(
+            count = txns.len(),
+            "exec_tx_debug: sign_and_execute_txns_in_soft_bundle: signing txns"
+        );
         // Sign all transactions
         let signed_txs: Vec<Transaction> =
             futures::future::join_all(txns.iter().map(|tx| self.wallet.sign_transaction(tx))).await;
+        let signed_digests: Vec<_> = signed_txs.iter().map(|t| *t.digest()).collect();
+        tracing::info!(
+            digests = ?signed_digests,
+            "exec_tx_debug: sign_and_execute_txns_in_soft_bundle: signed, calling execute_signed_txns_in_soft_bundle"
+        );
 
-        self.execute_signed_txns_in_soft_bundle(&signed_txs).await
+        let res = self.execute_signed_txns_in_soft_bundle(&signed_txs).await;
+        tracing::info!(
+            ok = res.is_ok(),
+            "exec_tx_debug: sign_and_execute_txns_in_soft_bundle: execute_signed_txns_in_soft_bundle returned"
+        );
+        res
     }
 
     pub async fn execute_signed_txns_in_soft_bundle(
@@ -676,6 +692,10 @@ impl TestCluster {
         signed_txs: &[Transaction],
     ) -> SuiResult<Vec<(TransactionDigest, TransactionEffects)>> {
         let digests: Vec<_> = signed_txs.iter().map(|tx| *tx.digest()).collect();
+        tracing::info!(
+            ?digests,
+            "exec_tx_debug: execute_signed_txns_in_soft_bundle entered"
+        );
 
         let request = RawSubmitTxRequest {
             transactions: signed_txs
@@ -687,6 +707,10 @@ impl TestCluster {
 
         let agg = self.authority_aggregator();
         let clients = &agg.authority_clients;
+        tracing::info!(
+            num_validators = clients.len(),
+            "exec_tx_debug: got authority_aggregator"
+        );
         // Use seeded RNG for deterministic but varying validator selection in simtests
         let index = rand::thread_rng().gen_range(0..clients.len());
         let mut validator_client = clients
@@ -697,20 +721,38 @@ impl TestCluster {
             .authority_client()
             .get_client_for_testing()
             .unwrap();
+        tracing::info!(
+            index,
+            ?digests,
+            "exec_tx_debug: got validator_client, calling submit_soft_bundle_with_timeout_and_retries"
+        );
 
         let result =
             submit_soft_bundle_with_timeout_and_retries(&mut validator_client, request, &digests)
                 .await?;
+        tracing::info!(
+            ?digests,
+            "exec_tx_debug: submit_soft_bundle_with_timeout_and_retries returned"
+        );
         assert_eq!(result.results.len(), signed_txs.len());
 
         for raw_result in result.results.iter() {
             let submit_result: sui_types::messages_grpc::SubmitTxResult =
                 raw_result.clone().try_into()?;
             if let sui_types::messages_grpc::SubmitTxResult::Rejected { error } = submit_result {
+                tracing::info!(
+                    ?digests,
+                    ?error,
+                    "exec_tx_debug: submit_transaction rejected"
+                );
                 return Err(error);
             }
         }
 
+        tracing::info!(
+            ?digests,
+            "exec_tx_debug: waiting for notify_read_executed_effects"
+        );
         let effects = self
             .fullnode_handle
             .sui_node
@@ -728,6 +770,10 @@ impl TestCluster {
                 }
             })
             .await;
+        tracing::info!(
+            ?digests,
+            "exec_tx_debug: notify_read_executed_effects returned"
+        );
 
         Ok(digests
             .into_iter()

--- a/crates/test-cluster/src/lib.rs
+++ b/crates/test-cluster/src/lib.rs
@@ -20,6 +20,7 @@ use sui_core::authority_aggregator::AuthorityAggregator;
 use sui_core::authority_client::NetworkAuthorityClient;
 use sui_json_rpc_types::{SuiTransactionBlockEffectsAPI, TransactionFilter};
 use sui_keys::keystore::{AccountKeystore, FileBasedKeystore, Keystore};
+use sui_network::api::ValidatorClient;
 use sui_node::SuiNodeHandle;
 use sui_protocol_config::{Chain, ProtocolVersion};
 use sui_rpc_api::Client;
@@ -50,8 +51,8 @@ use sui_types::effects::TransactionEffectsAPI;
 use sui_types::effects::{TransactionEffects, TransactionEvents};
 use sui_types::error::SuiResult;
 use sui_types::messages_grpc::{
-    RawSubmitTxRequest, SubmitTxRequest, SubmitTxResult, SubmitTxType, WaitForEffectsRequest,
-    WaitForEffectsResponse,
+    RawSubmitTxRequest, RawSubmitTxResponse, SubmitTxRequest, SubmitTxResult, SubmitTxType,
+    WaitForEffectsRequest, WaitForEffectsResponse,
 };
 use sui_types::object::Object;
 use sui_types::sui_system_state::SuiSystemState;
@@ -64,6 +65,7 @@ use tokio::sync::broadcast;
 use tokio::time::{Instant, timeout};
 use tokio::{task::JoinHandle, time::sleep};
 use tonic::IntoRequest;
+use tonic::transport::Channel;
 use tracing::{error, info};
 
 pub mod addr_balance_test_env;
@@ -696,10 +698,9 @@ impl TestCluster {
             .get_client_for_testing()
             .unwrap();
 
-        let result = validator_client
-            .submit_transaction(request.into_request())
-            .await
-            .map(tonic::Response::into_inner)?;
+        let result =
+            submit_soft_bundle_with_timeout_and_retries(&mut validator_client, request, &digests)
+                .await?;
         assert_eq!(result.results.len(), signed_txs.len());
 
         for raw_result in result.results.iter() {
@@ -764,10 +765,9 @@ impl TestCluster {
             .get_client_for_testing()
             .unwrap();
 
-        let result = validator_client
-            .submit_transaction(request.into_request())
-            .await
-            .map(tonic::Response::into_inner)?;
+        let result =
+            submit_soft_bundle_with_timeout_and_retries(&mut validator_client, request, &digests)
+                .await?;
         assert_eq!(result.results.len(), signed_txs.len());
 
         // Extract consensus positions from submission results
@@ -843,7 +843,7 @@ impl TestCluster {
     /// This function is recommended for transaction execution since it most resembles the
     /// production path.
     pub async fn execute_transaction(&self, tx: Transaction) -> ExecutedTransaction {
-        self.wallet.execute_transaction_must_succeed(tx).await
+        execute_transaction_must_succeed_with_timeout_and_retries(&self.wallet, tx).await
     }
 
     /// Different from `execute_transaction` which returns RPC effects types, this function
@@ -950,7 +950,7 @@ impl TestCluster {
                     .build(),
             )
             .await;
-        context.execute_transaction_must_succeed(tx).await;
+        execute_transaction_must_succeed_with_timeout_and_retries(context, tx).await;
 
         context
             .get_one_gas_object_owned_by_address(funding_address)
@@ -979,6 +979,48 @@ impl TestCluster {
     pub fn set_safe_mode_expected(&self, value: bool) {
         for n in self.all_node_handles() {
             n.with(|node| node.set_safe_mode_expected(value));
+        }
+    }
+}
+
+async fn submit_soft_bundle_with_timeout_and_retries(
+    validator_client: &mut ValidatorClient<Channel>,
+    request: RawSubmitTxRequest,
+    digests: &[TransactionDigest],
+) -> Result<RawSubmitTxResponse, tonic::Status> {
+    loop {
+        match tokio::time::timeout(
+            Duration::from_secs(30),
+            validator_client.submit_transaction(request.clone().into_request()),
+        )
+        .await
+        {
+            Ok(res) => return res.map(tonic::Response::into_inner),
+            Err(_) => {
+                tracing::warn!(?digests, "submit_transaction timed out after 30s, retrying");
+            }
+        }
+    }
+}
+
+async fn execute_transaction_must_succeed_with_timeout_and_retries(
+    wallet: &WalletContext,
+    tx: Transaction,
+) -> ExecutedTransaction {
+    loop {
+        match tokio::time::timeout(
+            Duration::from_secs(30),
+            wallet.execute_transaction_must_succeed(tx.clone()),
+        )
+        .await
+        {
+            Ok(res) => return res,
+            Err(_) => {
+                tracing::warn!(
+                    tx_digest = ?tx.digest(),
+                    "execute_transaction_must_succeed timed out after 30s, retrying"
+                );
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Wraps `TestCluster::execute_signed_txns_in_soft_bundle` / `execute_soft_bundle_with_conflicts` so the direct-validator `submit_transaction` gRPC call times out every 30s and retries instead of awaiting forever.
- Wraps `TestCluster::execute_transaction` and `fund_address_and_return_gas` so the fullnode `execute_transaction_must_succeed` path also times out every 30s and retries.
- Extracts both into named helpers — `submit_soft_bundle_with_timeout_and_retries` and `execute_transaction_must_succeed_with_timeout_and_retries` — with warn-level logs on each timeout that include the stuck tx digest(s).
- Adds `sui-network` as a `test-cluster` dep so the helper can name `ValidatorClient<Channel>` directly.

## Motivation
While debugging a failed simtest seed for `sui-e2e-tests::address_balance_tests::test_transaction_expired_too_late` (`MSIM_TEST_SEED=17077690485607463967`), the test hung for the full 1000 s simulated-time `sim_test` deadline. Logs showed the client task went silent right after the second reconfiguration — the validator never received the expired tx via `ValidatorService::handle_submit_transaction`, yet the gRPC `submit_transaction` call never returned. The client path had no deadline of its own, so the test wasted the entire sim budget before panicking with `sim_test timed out: Elapsed`.

With this change, a stuck submit or fullnode execute now emits a periodic `submit_transaction timed out after 30s, retrying` / `execute_transaction_must_succeed timed out after 30s, retrying` line (including digests), making future hangs diagnosable rather than silent.

## Test plan
- [x] `cargo simtest build -p sui-e2e-tests --tests` (simulator profile, passes on this branch)
- [ ] CI green on the simtest and standard test jobs