### PR TITLE
[jsonrpc-alt] in-house validators apy calculation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15603,7 +15603,6 @@ dependencies = [
  "sui-indexer-alt-reader",
  "sui-indexer-alt-schema",
  "sui-json",
- "sui-json-rpc-api",
  "sui-json-rpc-types",
  "sui-name-service",
  "sui-open-rpc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15581,6 +15581,7 @@ dependencies = [
  "futures",
  "http 1.3.1",
  "jsonrpsee",
+ "lru 0.10.1",
  "move-binary-format",
  "move-core-types",
  "mysten-common",

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc_fn_delegation_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc_fn_delegation_tests.rs
@@ -59,7 +59,6 @@ impl FnDelegationTestCluster {
             client_args,
             OffchainClusterConfig {
                 jsonrpc_node_args: JsonRpcNodeArgs {
-                    fullnode_rpc_url: Some(fullnode_rpc_url.clone()),
                     fullnode_grpc_url: Some(fullnode_rpc_url.to_string()),
                 },
                 ..Default::default()

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc_write_api_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc_write_api_tests.rs
@@ -100,7 +100,6 @@ impl WriteTestCluster {
                 ..Default::default()
             },
             NodeArgs {
-                fullnode_rpc_url: None,
                 fullnode_grpc_url: Some(fullnode_grpc_url),
             },
             SystemPackageTaskArgs::default(),

--- a/crates/sui-indexer-alt-e2e-tests/tests/transactional_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/transactional_tests.rs
@@ -153,7 +153,6 @@ async fn cluster(config: &OffChainConfig) -> Arc<OffchainCluster> {
                 // TODO: dummy value until simulacrum exposes grpc
                 jsonrpc_node_args: NodeArgs {
                     fullnode_grpc_url: Some("http://127.0.0.1:1".into()),
-                    fullnode_rpc_url: None,
                 },
                 ..Default::default()
             },

--- a/crates/sui-indexer-alt-jsonrpc/Cargo.toml
+++ b/crates/sui-indexer-alt-jsonrpc/Cargo.toml
@@ -28,6 +28,7 @@ fastcrypto.workspace = true
 futures.workspace = true
 http.workspace = true
 jsonrpsee = { workspace = true, features = ["macros", "server"] }
+lru.workspace = true
 pin-project-lite.workspace = true
 pin-project.workspace = true
 prometheus.workspace = true

--- a/crates/sui-indexer-alt-jsonrpc/Cargo.toml
+++ b/crates/sui-indexer-alt-jsonrpc/Cargo.toml
@@ -63,7 +63,6 @@ sui-indexer-alt-metrics.workspace = true
 sui-indexer-alt-reader.workspace = true
 sui-indexer-alt-schema.workspace = true
 sui-json.workspace = true
-sui-json-rpc-api.workspace = true
 sui-json-rpc-types.workspace = true
 sui-name-service.workspace = true
 sui-open-rpc.workspace = true

--- a/crates/sui-indexer-alt-jsonrpc/src/api/governance.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/governance.rs
@@ -2,26 +2,25 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::BTreeMap;
+use std::collections::HashMap;
 use std::convert::Infallible;
 
 use anyhow::Context as _;
 use diesel::ExpressionMethods;
 use diesel::QueryDsl;
 use futures::future;
-
 use jsonrpsee::core::RpcResult;
-use jsonrpsee::http_client::HttpClient;
 use jsonrpsee::proc_macros::rpc;
 use move_core_types::language_storage::StructTag;
-
 use sui_indexer_alt_reader::consistent_reader::proto::owner::OwnerKind;
 use sui_indexer_alt_reader::governance::RewardsKey;
 use sui_indexer_alt_reader::governance::ValidatorAddressKey;
+use sui_indexer_alt_schema::epochs::StoredEpochStart;
 use sui_indexer_alt_schema::schema::kv_epoch_starts;
-use sui_json_rpc_api::GovernanceReadApiClient;
 use sui_json_rpc_types::DelegatedStake;
 use sui_json_rpc_types::Stake;
 use sui_json_rpc_types::StakeStatus;
+use sui_json_rpc_types::ValidatorApy;
 use sui_json_rpc_types::ValidatorApys;
 use sui_open_rpc::Module;
 use sui_open_rpc_macros::open_rpc;
@@ -36,6 +35,8 @@ use sui_types::governance::STAKED_SUI_STRUCT_NAME;
 use sui_types::governance::STAKING_POOL_MODULE_NAME;
 use sui_types::governance::StakedSui;
 use sui_types::sui_serde::BigInt;
+use sui_types::sui_system_state::PoolTokenExchangeRate;
+use sui_types::sui_system_state::SuiSystemState;
 use sui_types::sui_system_state::SuiSystemStateTrait;
 use sui_types::sui_system_state::SuiSystemStateWrapper;
 use sui_types::sui_system_state::sui_system_state_inner_v1::SuiSystemStateInnerV1;
@@ -49,8 +50,11 @@ use crate::data::latest_epoch;
 use crate::data::load_live;
 use crate::data::load_live_deserialized;
 use crate::error::RpcError;
-use crate::error::client_error_to_error_object;
 use crate::error::rpc_bail;
+
+/// Number of most recent epochs to load from `kv_epoch_starts` when computing validator APYs.
+/// Matches the upper bound on adjacent-epoch samples used by `compute_apy`.
+const APY_EPOCH_WINDOW: i64 = 31;
 
 #[open_rpc(namespace = "suix", tag = "Governance API")]
 #[rpc(server, namespace = "suix")]
@@ -73,25 +77,13 @@ trait GovernanceApi {
     /// Return all [DelegatedStake].
     #[method(name = "getStakes")]
     async fn get_stakes(&self, owner: SuiAddress) -> RpcResult<Vec<DelegatedStake>>;
-}
 
-#[open_rpc(namespace = "suix", tag = "Delegation Governance API")]
-#[rpc(server, namespace = "suix")]
-trait DelegationGovernanceApi {
     /// Return the validator APY
     #[method(name = "getValidatorsApy")]
     async fn get_validators_apy(&self) -> RpcResult<ValidatorApys>;
 }
 
 pub(crate) struct Governance(pub Context);
-
-pub(crate) struct DelegationGovernance(HttpClient);
-
-impl DelegationGovernance {
-    pub(crate) fn new(client: HttpClient) -> Self {
-        Self(client)
-    }
-}
 
 #[async_trait::async_trait]
 impl GovernanceApiServer for Governance {
@@ -152,33 +144,15 @@ impl GovernanceApiServer for Governance {
 
         Ok(delegated_stakes_response(&self.0, all_stake_ids).await?)
     }
-}
 
-#[async_trait::async_trait]
-impl DelegationGovernanceApiServer for DelegationGovernance {
     async fn get_validators_apy(&self) -> RpcResult<ValidatorApys> {
-        let Self(client) = self;
-
-        client
-            .get_validators_apy()
-            .await
-            .map_err(client_error_to_error_object)
+        Ok(validators_apy_response(&self.0).await?)
     }
 }
 
 impl RpcModule for Governance {
     fn schema(&self) -> Module {
         GovernanceApiOpenRpc::module_doc()
-    }
-
-    fn into_impl(self) -> jsonrpsee::RpcModule<Self> {
-        self.into_rpc()
-    }
-}
-
-impl RpcModule for DelegationGovernance {
-    fn schema(&self) -> Module {
-        DelegationGovernanceApiOpenRpc::module_doc()
     }
 
     fn into_impl(self) -> jsonrpsee::RpcModule<Self> {
@@ -338,4 +312,103 @@ async fn delegated_stakes_response(
             },
         )
         .collect())
+}
+
+/// Load data and generate response for `getValidatorsApy`.
+///
+/// Rates are derived from `staking_pool_sui_balance` and `pool_token_balance` of each active
+/// validator in the latest `APY_EPOCH_WINDOW` rows of `kv_epoch_starts`. These are the same
+/// numbers that `advance_epoch` writes into each staking pool's `exchange_rates` table, so the
+/// adjacent-epoch APY math produces the same output as the legacy implementation, without any
+/// RocksDB dynamic-field scans.
+///
+/// Safe-mode epochs don't run `advance_epoch`, so validator balances carry over unchanged — the
+/// resulting 0-APY adjacent pair is dropped by `compute_apy`'s outlier filter, mirroring the
+/// legacy `backfill_rates` behavior.
+async fn validators_apy_response(ctx: &Context) -> Result<ValidatorApys, RpcError> {
+    use kv_epoch_starts::dsl as e;
+
+    let mut conn = ctx
+        .pg_reader()
+        .connect()
+        .await
+        .context("Failed to connect to the database")?;
+
+    let rows: Vec<StoredEpochStart> = conn
+        .results(
+            e::kv_epoch_starts
+                .order(e::epoch.desc())
+                .limit(APY_EPOCH_WINDOW),
+        )
+        .await
+        .context("Failed to fetch epoch starts for APY calculation")?;
+
+    let latest = rows
+        .first()
+        .context("No epoch start rows available for APY calculation")?;
+
+    let latest_summary = decode_summary(&latest.system_state)?;
+    let current_epoch = latest_summary.epoch;
+    let stake_subsidy_start_epoch = latest_summary.stake_subsidy_start_epoch;
+
+    let mut by_pool: HashMap<ObjectID, Vec<PoolTokenExchangeRate>> = HashMap::new();
+    for row in &rows {
+        if (row.epoch as u64) < stake_subsidy_start_epoch {
+            continue;
+        }
+        let summary = decode_summary(&row.system_state)?;
+        for v in summary.active_validators {
+            by_pool
+                .entry(v.staking_pool_id)
+                .or_default()
+                .push(PoolTokenExchangeRate::new(
+                    v.staking_pool_sui_balance,
+                    v.pool_token_balance,
+                ));
+        }
+    }
+
+    let empty_rates: Vec<PoolTokenExchangeRate> = Vec::new();
+    let apys = latest_summary
+        .active_validators
+        .into_iter()
+        .map(|v| {
+            let rates = by_pool.get(&v.staking_pool_id).unwrap_or(&empty_rates);
+            ValidatorApy {
+                address: v.sui_address,
+                apy: compute_apy(rates),
+            }
+        })
+        .collect();
+
+    Ok(ValidatorApys {
+        apys,
+        epoch: current_epoch,
+    })
+}
+
+fn decode_summary(bytes: &[u8]) -> Result<SuiSystemStateSummary, RpcError> {
+    Ok(bcs::from_bytes::<SuiSystemState>(bytes)
+        .context("Failed to deserialize SuiSystemState from kv_epoch_starts")?
+        .into_sui_system_state_summary())
+}
+
+/// Compute the average APY from a descending-epoch list of exchange rates.
+///
+/// Iterates adjacent pairs (newer, older), converts each pair into an annualized return
+/// `(older / newer) ^ 365 - 1`, discards outliers outside `(0.0, 0.1)`, and averages up to 30 of
+/// the remaining samples. This mirrors the legacy `calculate_apys` logic.
+fn compute_apy(rates: &[PoolTokenExchangeRate]) -> f64 {
+    let samples: Vec<f64> = rates
+        .windows(2)
+        .map(|w| (w[1].rate() / w[0].rate()).powf(365.0) - 1.0)
+        .filter(|apy| *apy > 0.0 && *apy < 0.1)
+        .take(30)
+        .collect();
+
+    if samples.is_empty() {
+        0.0
+    } else {
+        samples.iter().sum::<f64>() / samples.len() as f64
+    }
 }

--- a/crates/sui-indexer-alt-jsonrpc/src/api/governance.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/governance.rs
@@ -317,14 +317,13 @@ async fn delegated_stakes_response(
 /// Load data and generate response for `getValidatorsApy`.
 ///
 /// Rates are derived from `staking_pool_sui_balance` and `pool_token_balance` of each active
-/// validator in the latest `APY_EPOCH_WINDOW` rows of `kv_epoch_starts`. These are the same
-/// numbers that `advance_epoch` writes into each staking pool's `exchange_rates` table, so the
-/// adjacent-epoch APY math produces the same output as the legacy implementation, without any
-/// RocksDB dynamic-field scans.
+/// validator in the latest `APY_EPOCH_WINDOW` rows of `kv_epoch_starts`. These are the same numbers
+/// that `advance_epoch` writes into each staking pool's `exchange_rates` table. Rates from adjacent
+/// epochs are converted into annualized returns, outliers are filtered out, and the rest are
+/// averaged over the sample window to produce each validator's APY.
 ///
-/// Safe-mode epochs don't run `advance_epoch`, so validator balances carry over unchanged — the
-/// resulting 0-APY adjacent pair is dropped by `compute_apy`'s outlier filter, mirroring the
-/// legacy `backfill_rates` behavior.
+/// In safe mode, a pool's sui and token balance carry over unchanged, which produces 0% APY and
+/// gets filtered out, matching the legacy fullnode jsonrpc's `backfill_rates`.
 async fn validators_apy_response(ctx: &Context) -> Result<ValidatorApys, RpcError> {
     use kv_epoch_starts::dsl as e;
 

--- a/crates/sui-indexer-alt-jsonrpc/src/api/governance.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/governance.rs
@@ -317,12 +317,12 @@ async fn delegated_stakes_response(
 ///
 /// Rates are derived from `staking_pool_sui_balance` and `pool_token_balance` of each active
 /// validator in the latest `APY_EPOCH_WINDOW` rows of `kv_epoch_starts`. These are the same numbers
-/// that `advance_epoch` writes into each staking pool's `exchange_rates` table. Rates from adjacent
-/// epochs are converted into annualized returns, outliers are filtered out, and the rest are
-/// averaged over the sample window to produce each validator's APY.
+/// that `advance_epoch` writes into each staking pool's `exchange_rates` table. APYs are calculated
+/// from adjacent pairs of rates, and then filtered and averaged to produce each validator's APY.
+/// This mirrors the legacy fullnode jsonrpc's `backfill_rates` implementation.
 ///
 /// In safe mode, a pool's sui and token balance carry over unchanged, which produces 0% APY and
-/// gets filtered out, matching the legacy fullnode jsonrpc's `backfill_rates`.
+/// also gets filtered out.
 async fn validators_apy_response(ctx: &Context) -> Result<ValidatorApys, RpcError> {
     use kv_epoch_starts::dsl as e;
 
@@ -349,6 +349,7 @@ async fn validators_apy_response(ctx: &Context) -> Result<ValidatorApys, RpcErro
     let current_epoch = latest_summary.epoch;
     let stake_subsidy_start_epoch = latest_summary.stake_subsidy_start_epoch;
 
+    // Map pool to exchange rates history (newest to oldest)
     let mut by_pool: HashMap<ObjectID, Vec<PoolTokenExchangeRate>> = HashMap::new();
     for row in &rows {
         if (row.epoch as u64) < stake_subsidy_start_epoch {
@@ -366,16 +367,14 @@ async fn validators_apy_response(ctx: &Context) -> Result<ValidatorApys, RpcErro
         }
     }
 
-    let empty_rates: Vec<PoolTokenExchangeRate> = Vec::new();
     let apys = latest_summary
         .active_validators
         .into_iter()
-        .map(|v| {
-            let rates = by_pool.get(&v.staking_pool_id).unwrap_or(&empty_rates);
-            ValidatorApy {
-                address: v.sui_address,
-                apy: compute_apy(rates),
-            }
+        .map(|v| ValidatorApy {
+            address: v.sui_address,
+            apy: by_pool
+                .get(&v.staking_pool_id)
+                .map_or(0.0, |rates| compute_apy(rates)),
         })
         .collect();
 

--- a/crates/sui-indexer-alt-jsonrpc/src/api/governance.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/governance.rs
@@ -53,7 +53,6 @@ use crate::error::RpcError;
 use crate::error::rpc_bail;
 
 /// Number of most recent epochs to load from `kv_epoch_starts` when computing validator APYs.
-/// Matches the upper bound on adjacent-epoch samples used by `compute_apy`.
 const APY_EPOCH_WINDOW: i64 = 31;
 
 #[open_rpc(namespace = "suix", tag = "Governance API")]

--- a/crates/sui-indexer-alt-jsonrpc/src/api/governance.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/governance.rs
@@ -4,6 +4,8 @@
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::convert::Infallible;
+use std::num::NonZeroUsize;
+use std::sync::Mutex;
 
 use anyhow::Context as _;
 use diesel::ExpressionMethods;
@@ -11,6 +13,7 @@ use diesel::QueryDsl;
 use futures::future;
 use jsonrpsee::core::RpcResult;
 use jsonrpsee::proc_macros::rpc;
+use lru::LruCache;
 use move_core_types::language_storage::StructTag;
 use sui_indexer_alt_reader::consistent_reader::proto::owner::OwnerKind;
 use sui_indexer_alt_reader::governance::RewardsKey;
@@ -82,27 +85,41 @@ trait GovernanceApi {
     async fn get_validators_apy(&self) -> RpcResult<ValidatorApys>;
 }
 
-pub(crate) struct Governance(pub Context);
+pub(crate) struct Governance {
+    ctx: Context,
+    /// Caches the most recent `getValidatorsApy` response, keyed by epoch. APY inputs are fixed for
+    /// the duration of an epoch, so a capacity-1 cache evicts automatically on epoch advance.
+    apy_cache: Mutex<LruCache<u64, ValidatorApys>>,
+}
+
+impl Governance {
+    pub fn new(ctx: Context) -> Self {
+        Self {
+            ctx,
+            apy_cache: Mutex::new(LruCache::new(NonZeroUsize::new(1).unwrap())),
+        }
+    }
+}
 
 #[async_trait::async_trait]
 impl GovernanceApiServer for Governance {
     async fn get_reference_gas_price(&self) -> RpcResult<BigInt<u64>> {
-        Ok(rgp_response(&self.0).await?)
+        Ok(rgp_response(&self.ctx).await?)
     }
 
     async fn get_latest_sui_system_state(&self) -> RpcResult<SuiSystemStateSummary> {
-        Ok(latest_sui_system_state_response(&self.0).await?)
+        Ok(latest_sui_system_state_response(&self.ctx).await?)
     }
 
     async fn get_stakes_by_ids(
         &self,
         staked_sui_ids: Vec<ObjectID>,
     ) -> RpcResult<Vec<DelegatedStake>> {
-        Ok(delegated_stakes_response(&self.0, staked_sui_ids).await?)
+        Ok(delegated_stakes_response(&self.ctx, staked_sui_ids).await?)
     }
 
     async fn get_stakes(&self, owner: SuiAddress) -> RpcResult<Vec<DelegatedStake>> {
-        let Self(ctx) = self;
+        let ctx = &self.ctx;
         let config = &ctx.config().objects;
 
         let tag = StructTag {
@@ -141,11 +158,23 @@ impl GovernanceApiServer for Governance {
             }
         }
 
-        Ok(delegated_stakes_response(&self.0, all_stake_ids).await?)
+        Ok(delegated_stakes_response(ctx, all_stake_ids).await?)
     }
 
     async fn get_validators_apy(&self) -> RpcResult<ValidatorApys> {
-        Ok(validators_apy_response(&self.0).await?)
+        let ctx = &self.ctx;
+        let epoch = latest_epoch(ctx)
+            .await
+            .context("Failed to fetch latest epoch for APY cache lookup")
+            .map_err(RpcError::<Infallible>::from)?;
+
+        if let Some(hit) = self.apy_cache.lock().unwrap().get(&epoch).cloned() {
+            return Ok(hit);
+        }
+
+        let apys = validators_apy_response(ctx).await?;
+        self.apy_cache.lock().unwrap().put(epoch, apys.clone());
+        Ok(apys)
     }
 }
 

--- a/crates/sui-indexer-alt-jsonrpc/src/config.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/config.rs
@@ -1,19 +1,12 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::Context as _;
-use jsonrpsee::http_client::HeaderMap;
-use jsonrpsee::http_client::HeaderValue;
-use jsonrpsee::http_client::HttpClient;
-use jsonrpsee::http_client::HttpClientBuilder;
 use sui_default_config::DefaultConfig;
 use sui_protocol_config::ProtocolConfig;
 use sui_types::base_types::ObjectID;
 use sui_types::base_types::SuiAddress;
 
 pub use sui_name_service::NameServiceConfig;
-
-pub const CLIENT_SDK_TYPE_HEADER: &str = "client-sdk-type";
 
 #[derive(Debug)]
 pub struct RpcConfig {
@@ -308,22 +301,6 @@ impl CoinsLayer {
             default_page_size: self.default_page_size.unwrap_or(base.default_page_size),
             max_page_size: self.max_page_size.unwrap_or(base.max_page_size),
         }
-    }
-}
-
-impl NodeConfig {
-    pub fn client(&self, fullnode_rpc_url: url::Url) -> anyhow::Result<HttpClient> {
-        let mut headers = HeaderMap::new();
-        headers.insert(
-            CLIENT_SDK_TYPE_HEADER,
-            HeaderValue::from_str(&self.header_value)?,
-        );
-
-        HttpClientBuilder::default()
-            .max_request_size(self.max_request_size)
-            .set_headers(headers)
-            .build(&fullnode_rpc_url)
-            .context("Failed to initialize fullnode RPC client")
     }
 }
 

--- a/crates/sui-indexer-alt-jsonrpc/src/error.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/error.rs
@@ -141,19 +141,6 @@ pub(crate) fn invalid_params<E: std::error::Error>(err: E) -> RpcError<E> {
     RpcError::InvalidParams(err)
 }
 
-/// Helper function to convert a jsonrpc client error into an `ErrorObject`.
-pub(crate) fn client_error_to_error_object(
-    error: jsonrpsee::core::ClientError,
-) -> ErrorObject<'static> {
-    match error {
-        // `Call` is the only error type that actually conveys meaningful error
-        // from a user calling the method. Other error variants are all more or less
-        // internal errors.
-        jsonrpsee::core::ClientError::Call(e) => e,
-        _ => ErrorObject::owned(INTERNAL_ERROR_CODE, error.to_string(), None::<()>),
-    }
-}
-
 impl ResponseForPanic for PanicHandler {
     type ResponseBody = axum::body::Body;
 

--- a/crates/sui-indexer-alt-jsonrpc/src/lib.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/lib.rs
@@ -313,7 +313,7 @@ pub async fn start_rpc(
     rpc.add_module(Transactions(context.clone()))?;
 
     if let Some(_fullnode_client) = fullnode_client {
-        rpc.add_module(Governance(context.clone()))?;
+        rpc.add_module(Governance::new(context.clone()))?;
         rpc.add_module(Write::new(context.clone()))?;
     } else {
         warn!("No fullnode grpc url provided, Write and Governance modules will not be added.");

--- a/crates/sui-indexer-alt-jsonrpc/src/lib.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/lib.rs
@@ -29,7 +29,6 @@ use url::Url;
 use crate::api::checkpoints::Checkpoints;
 use crate::api::coin::Coins;
 use crate::api::dynamic_fields::DynamicFields;
-use crate::api::governance::DelegationGovernance;
 use crate::api::governance::Governance;
 use crate::api::move_utils::MoveUtils;
 use crate::api::name_service::NameService;
@@ -238,11 +237,6 @@ impl Default for RpcArgs {
 /// Configuration for the fullnode RPC that this service will connect to.
 #[derive(clap::Args, Debug, Clone, Default)]
 pub struct NodeArgs {
-    /// The URL of the fullnode JSON-RPC, used for delegation governance queries (getStakes,
-    /// getStakesByIds, getValidatorsApy).
-    #[arg(long)]
-    pub fullnode_rpc_url: Option<url::Url>,
-
     /// The URL of the fullnode gRPC service, used for transaction execution and dry-running.
     #[arg(long)]
     pub fullnode_grpc_url: Option<String>,
@@ -252,8 +246,7 @@ pub struct NodeArgs {
 /// command-line).
 ///
 /// Access to most reads is controlled by the `database_url` -- if it is `None`, reads will not
-/// work. The only exception is the `DelegationGovernance` module, which is controlled by
-/// `node_args.fullnode_rpc_url`, which can be omitted to disable reads from this RPC.
+/// work.
 ///
 /// KV queries can optionally be served by a Bigtable instance, if `bigtable_instance` is provided.
 /// Otherwise these requests are served by the database. If a `bigtable_instance` is provided, the
@@ -318,13 +311,6 @@ pub async fn start_rpc(
     rpc.add_module(QueryObjects(context.clone()))?;
     rpc.add_module(QueryTransactions(context.clone()))?;
     rpc.add_module(Transactions(context.clone()))?;
-
-    if let Some(fullnode_rpc_url) = node_args.fullnode_rpc_url {
-        let client = context.config().node.client(fullnode_rpc_url)?;
-        rpc.add_module(DelegationGovernance::new(client))?;
-    } else {
-        warn!("No fullnode rpc url provided, DelegationGovernance module will not be added.");
-    }
 
     if let Some(_fullnode_client) = fullnode_client {
         rpc.add_module(Governance(context.clone()))?;


### PR DESCRIPTION
## Description 

The implementation on fullnode jsonrpc involves getting the latest system state, and for each active validator and inactive pool, getting all historical exchange rates. APY is calculated per adjacent pair, and then a sample is selected for averaging to get the APY. This is a bit wasteful, but understandable since `getValidatorsApy` shares a cache (evicted on epoch change) with `getStakes` and `getStakesById` - and these two apis support historical estimated rewards calculation.

Now that we've split the `getStakes` APIs out, we can simplify the APY calculation. Observing that the exchange rate is calculated from the `staking_pool_sui_balance` and `pool_token_balance`, and this is indexed today on `kv_epoch_starts`, we can instead retrieve the 31 latest entries from the table, extract just the active validator data, and calculate APY accordingly. 

In practice, the calculated APY match to the last 

Without caching, a local setup speaking to mainnet postgres db, takes at most a second, and around 400ms once warm.


| validator | legacy | new |
|---|---|---|
| `0x1e1985024aafe50a8e4eafc5a89eb7ecd58ba08c39f37688bee00bd55c8b2059` | 0.01568213561669605**5** | 0.01568213561669604**8** |
| `0x61953ea72709eed72f4441dd944eec49a11b4acabfc8e04015e89c63be81b6ab` | 0.01527990128315504**8** | 0.01527990128315504**7** |
| `0xc21c40c94c712f17244d8518688dbaaa81ba232c15cb13dbba138ead55451e43` | 0.01538794574356528 | 0.01538794574356528**6** |
| `0xd939e3fe7ea4d503f84767dca0c58b7ec1c71f085638a4c0611aa64aa71b5fcf` | 0.01525615104199363**2** | 0.01525615104199363**3** |
| `0x0de5a09a0b029b0c4f1017a58dc78a2341511a7f6ba4925287aa836c1166dbbe` | 0.01552167944976588 | 0.01552167944976587**9** |
| `0xf72816357f8e5638c90ec5b0f7eecee362bac0ef7e64822ea6d686730251a7a0` | 0.01551620642763676 | 0.01551620642763675**9** |
| `0xefc45ee5de49f376b66b73f6bab9fbc0c452b18e1cfc5035c268c6786dd8bb63` | 0.01570598497104809**2** | 0.0157059849710481 |
| `0xb8068ad94d7f0448059ae3ea1d877f2af54792b2849d80e2753201adfa532411` | 0.01541293648769391**2** | 0.01541293648769391**3** |
| `0x62e0917d86c476ed6beb5594bab91fea285671df1716874cc6cbde5c695da64e` | 0.01505770851626768**8** | 0.01505770851626769**5** |
| `0x13d90417a640de83e0b83683f12028961de06195ab004156df80111a9499081b` | 0.01536802734917224**4** | 0.01536802734917224**3** |
| `0x3d9fb148e35ef4d74fcfc36995da14fc504b885d5f2bfeca37d6ea2cc044a32d` | 0.01536601659804334 | 0.01536601659804333**9** |
| `0x7ab4a4f88e3062a8af7c4c43add6e1d6d864f3511ed67c352989c81ff048fccd` | 0.0155494855880644 | 0.01554948558806440**1** |
| `0x111111dccbe54f2eab9a1374cd1763ed08e6cbb4f241f053d8153cc73283ab63` | 0.01534896886092208 | 0.01534896886092208**1** |
| `0x63c99c4c48e9a417038a5f96fa7e3a0dbaacaa56a0d766f39efc8bd6cdcb2196` | 0.01428231136856860**3** | 0.01428231136856860**5** |



## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
