### PR TITLE
[move-package] Relax bounds in json-rpc to handle system packages.

### DIFF
--- a/crates/sui-json-rpc-types/src/sui_object.rs
+++ b/crates/sui-json-rpc-types/src/sui_object.rs
@@ -27,8 +27,7 @@ use sui_types::base_types::{
     TransactionDigest,
 };
 use sui_types::error::{
-    ExecutionError, SuiErrorKind, SuiObjectResponseError, SuiResult, UserInputError,
-    UserInputResult,
+    SuiErrorKind, SuiObjectResponseError, SuiResult, UserInputError, UserInputResult,
 };
 use sui_types::gas_coin::GasCoin;
 use sui_types::messages_checkpoint::CheckpointSequenceNumber;
@@ -253,7 +252,9 @@ impl SuiObjectData {
                 p.id,
                 self.version,
                 p.module_map,
-                protocol_config.max_move_package_size(),
+                // Package is published, so no need to bound (and it may be a system package so may
+                // exceed normal publish limits)
+                u64::MAX,
                 p.type_origin_table,
                 p.linkage_table,
             )?),
@@ -1045,22 +1046,6 @@ impl From<MovePackage> for SuiRawMovePackage {
             type_origin_table: p.type_origin_table().clone(),
             linkage_table: p.linkage_table().clone(),
         }
-    }
-}
-
-impl SuiRawMovePackage {
-    pub fn to_move_package(
-        &self,
-        max_move_package_size: u64,
-    ) -> Result<MovePackage, ExecutionError> {
-        MovePackage::new(
-            self.id,
-            self.version,
-            self.module_map.clone(),
-            max_move_package_size,
-            self.type_origin_table.clone(),
-            self.linkage_table.clone(),
-        )
     }
 }
 

--- a/crates/sui-replay-2/src/package_tools.rs
+++ b/crates/sui-replay-2/src/package_tools.rs
@@ -25,7 +25,6 @@ use sui_types::{
     digests::TransactionDigest,
     move_package::{MovePackage, TypeOrigin, UpgradeInfo},
     object::{Data, Object},
-    supported_protocol_versions::ProtocolConfig,
 };
 
 /// Information about a package in the cache
@@ -561,16 +560,14 @@ impl PackageRebuilder {
             .build_new_linkage_table(&compiled_modules, &original_package)
             .context("Failed to build linkage table")?;
 
-        // Get protocol config for max package size
-        let protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
-        let max_package_size = protocol_config.max_move_package_size();
-
         // Create a new MovePackage with updated modules and properly generated tables
         let rebuilt_package = MovePackage::new(
             self.package_info.package_id, // Use the package ID directly
             version,
             module_map,
-            max_package_size,
+            // We're trying to rebuild the package (locally!) and this package may be a system
+            // package, so be permissive and allow rebuilding a package of any size.
+            u64::MAX,
             type_origin_table,
             linkage_table,
         )


### PR DESCRIPTION
## Description 

System packages may now exceed the max move package size (for non-system packages). However the json-rpc pathway for serving these back still called `MovePackage::new` with the max move package size for normal packages. Relax this.

This also fixes this same kind of pattern in replay, and removes an unused `to_move_package` function on `SuiRawMovePackage`.

## Test plan 

CI + under the PR that increases the size of system package.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
