### PR TITLE
[simulacrum] Add simulate transaction

### DIFF
--- a/crates/simulacrum/src/epoch_state.rs
+++ b/crates/simulacrum/src/epoch_state.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use anyhow::Result;
@@ -10,21 +11,49 @@ use sui_config::{
 use sui_execution::Executor;
 use sui_protocol_config::{Chain, ProtocolConfig, ProtocolVersion};
 use sui_types::{
+    base_types::ObjectID,
     committee::{Committee, EpochId},
-    digests::ChainIdentifier,
-    effects::TransactionEffects,
-    execution_params::ExecutionOrEarlyError,
+    digests::{ChainIdentifier, TransactionDigest},
+    effects::{TransactionEffects, TransactionEffectsAPI},
+    error::{SuiError, SuiErrorKind},
+    execution_params::{ExecutionOrEarlyError, FundsWithdrawStatus, get_early_execution_error},
+    full_checkpoint_content::ObjectSet,
     gas::SuiGasStatus,
     inner_temporary_store::InnerTemporaryStore,
     metrics::{BytecodeVerifierMetrics, ExecutionMetrics},
+    object::{MoveObject, OBJECT_START_VERSION, Object, Owner},
     sui_system_state::{
         SuiSystemState, SuiSystemStateTrait,
         epoch_start_sui_system_state::{EpochStartSystemState, EpochStartSystemStateTrait},
     },
-    transaction::{TransactionDataAPI, VerifiedTransaction},
+    transaction::{
+        CheckedInputObjects, ObjectReadResult, TransactionData, TransactionDataAPI,
+        VerifiedTransaction,
+    },
+    transaction_executor::{SimulateTransactionResult, TransactionChecks},
 };
 
 use crate::SimulatorStore;
+
+const DEV_INSPECT_GAS_COIN_VALUE: u64 = 1_000_000_000_000_000_000;
+
+fn early_execution_error(
+    tx_digest: &TransactionDigest,
+    checked_input_objects: &CheckedInputObjects,
+) -> ExecutionOrEarlyError {
+    // Simulacrum has no certificate deny config and doesn't track per-address withdrawal
+    // balances, so we only surface errors derivable from the checked inputs themselves
+    // (consensus-stream-ended or cancelled objects).
+    match get_early_execution_error(
+        tx_digest,
+        checked_input_objects,
+        &HashSet::new(),
+        &FundsWithdrawStatus::MaybeSufficient,
+    ) {
+        Some(error) => ExecutionOrEarlyError::Err(error),
+        None => ExecutionOrEarlyError::Ok(()),
+    }
+}
 
 pub struct EpochState {
     epoch_start_state: EpochStartSystemState,
@@ -150,6 +179,7 @@ impl EpochState {
 
         let transaction_data = transaction.data().transaction_data();
         let (kind, signer, gas_data) = transaction_data.execution_parts();
+        let execution_params = early_execution_error(&tx_digest, &checked_input_objects);
         let (inner_temp_store, gas_status, effects, _timings, result) = self
             .executor
             .execute_transaction_to_effects_and_execution_error(
@@ -157,8 +187,7 @@ impl EpochState {
                 &self.protocol_config,
                 self.execution_metrics.clone(),
                 false, // enable_expensive_checks
-                // TODO: Integrate with early execution error
-                ExecutionOrEarlyError::Ok(()),
+                execution_params,
                 &self.epoch_start_state.epoch(),
                 self.epoch_start_state.epoch_start_timestamp_ms(),
                 checked_input_objects,
@@ -171,5 +200,136 @@ impl EpochState {
                 &mut None,
             );
         Ok((inner_temp_store, gas_status, effects, result))
+    }
+
+    pub fn simulate_transaction(
+        &self,
+        store: &dyn SimulatorStore,
+        verifier_signing_config: &VerifierSigningConfig,
+        mut transaction: TransactionData,
+        checks: TransactionChecks,
+        allow_mock_gas_coin: bool,
+    ) -> Result<SimulateTransactionResult, SuiError> {
+        if transaction.kind().is_system_tx() {
+            return Err(SuiErrorKind::UnsupportedFeatureError {
+                error: "simulate does not support system transactions".to_string(),
+            }
+            .into());
+        }
+
+        let dev_inspect = checks.disabled();
+
+        transaction.validity_check_no_gas_check(&self.protocol_config)?;
+
+        let input_object_kinds = transaction.input_objects()?;
+        let receiving_object_refs = transaction.receiving_objects();
+        let is_gasless =
+            self.protocol_config.enable_gasless() && transaction.is_gasless_transaction();
+
+        let mock_gas_object = if allow_mock_gas_coin && transaction.gas().is_empty() && !is_gasless
+        {
+            let obj = Object::new_move(
+                MoveObject::new_gas_coin(
+                    OBJECT_START_VERSION,
+                    ObjectID::MAX,
+                    DEV_INSPECT_GAS_COIN_VALUE,
+                ),
+                Owner::AddressOwner(transaction.gas_data().owner),
+                TransactionDigest::genesis_marker(),
+            );
+            transaction.gas_data_mut().payment = vec![obj.compute_object_reference()];
+            Some(obj)
+        } else {
+            None
+        };
+
+        let tx_digest = transaction.digest();
+        let (mut input_objects, receiving_objects) = store.read_objects_for_synchronous_execution(
+            &tx_digest,
+            &input_object_kinds,
+            &receiving_object_refs,
+        )?;
+
+        let mock_gas_id = mock_gas_object.map(|obj| {
+            let id = obj.id();
+            input_objects.push(ObjectReadResult::new_from_gas_object(&obj));
+            id
+        });
+
+        let (gas_status, checked_input_objects) = if dev_inspect {
+            sui_transaction_checks::check_dev_inspect_input(
+                &self.protocol_config,
+                &transaction,
+                input_objects,
+                receiving_objects,
+                self.epoch_start_state.reference_gas_price(),
+            )?
+        } else {
+            sui_transaction_checks::check_transaction_input(
+                &self.protocol_config,
+                self.epoch_start_state.reference_gas_price(),
+                &transaction,
+                input_objects,
+                &receiving_objects,
+                &self.bytecode_verifier_metrics,
+                verifier_signing_config,
+            )?
+        };
+
+        let (kind, signer, gas_data) = transaction.execution_parts();
+        let execution_params = early_execution_error(&tx_digest, &checked_input_objects);
+        let (inner_temp_store, _, effects, execution_result) =
+            self.executor.dev_inspect_transaction(
+                store.backing_store(),
+                &self.protocol_config,
+                self.execution_metrics.clone(),
+                false,
+                execution_params,
+                &self.epoch_start_state.epoch(),
+                self.epoch_start_state.epoch_start_timestamp_ms(),
+                checked_input_objects,
+                gas_data,
+                gas_status,
+                kind,
+                None,
+                signer,
+                tx_digest,
+                dev_inspect,
+            );
+
+        // Simulacrum doesn't track runtime-loaded objects; `object_set` is built from the
+        // transaction's input and written objects only, and `unchanged_loaded_runtime_objects`
+        // is always empty (matching `ReadStore::get_unchanged_loaded_runtime_objects`).
+        let objects = {
+            let mut objects = ObjectSet::default();
+            for o in inner_temp_store
+                .input_objects
+                .values()
+                .chain(inner_temp_store.written.values())
+            {
+                objects.insert(o.clone());
+            }
+
+            let object_keys =
+                sui_types::storage::get_transaction_object_set(&transaction, &effects, &[]);
+
+            let mut set = ObjectSet::default();
+            for k in object_keys {
+                if let Some(o) = objects.get(&k) {
+                    set.insert(o.clone());
+                }
+            }
+            set
+        };
+
+        Ok(SimulateTransactionResult {
+            events: effects.events_digest().map(|_| inner_temp_store.events),
+            objects,
+            effects,
+            execution_result,
+            mock_gas_id,
+            unchanged_loaded_runtime_objects: vec![],
+            suggested_gas_price: None,
+        })
     }
 }

--- a/crates/simulacrum/src/epoch_state.rs
+++ b/crates/simulacrum/src/epoch_state.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::BTreeMap;
 use std::collections::HashSet;
 use std::sync::Arc;
 
@@ -22,6 +23,7 @@ use sui_types::{
     inner_temporary_store::InnerTemporaryStore,
     metrics::{BytecodeVerifierMetrics, ExecutionMetrics},
     object::{MoveObject, OBJECT_START_VERSION, Object, Owner},
+    storage::{ObjectKey, TrackingBackingStore},
     sui_system_state::{
         SuiSystemState, SuiSystemStateTrait,
         epoch_start_sui_system_state::{EpochStartSystemState, EpochStartSystemStateTrait},
@@ -278,9 +280,10 @@ impl EpochState {
 
         let (kind, signer, gas_data) = transaction.execution_parts();
         let execution_params = early_execution_error(&tx_digest, &checked_input_objects);
+        let tracking_store = TrackingBackingStore::new(store.backing_store());
         let (inner_temp_store, _, effects, execution_result) =
             self.executor.dev_inspect_transaction(
-                store.backing_store(),
+                &tracking_store,
                 &self.protocol_config,
                 self.execution_metrics.clone(),
                 false,
@@ -296,12 +299,11 @@ impl EpochState {
                 tx_digest,
                 dev_inspect,
             );
-
-        // Simulacrum doesn't track runtime-loaded objects; `object_set` is built from the
-        // transaction's input and written objects only, and `unchanged_loaded_runtime_objects`
-        // is always empty (matching `ReadStore::get_unchanged_loaded_runtime_objects`).
+        let loaded_runtime_objects = tracking_store.into_read_objects();
+        let unchanged_loaded_runtime_objects =
+            unchanged_loaded_runtime_objects(&effects, &loaded_runtime_objects);
         let objects = {
-            let mut objects = ObjectSet::default();
+            let mut objects = loaded_runtime_objects;
             for o in inner_temp_store
                 .input_objects
                 .values()
@@ -311,7 +313,11 @@ impl EpochState {
             }
 
             let object_keys =
-                sui_types::storage::get_transaction_object_set(&transaction, &effects, &[]);
+                sui_types::storage::get_transaction_object_set(
+                    &transaction,
+                    &effects,
+                    &unchanged_loaded_runtime_objects,
+                );
 
             let mut set = ObjectSet::default();
             for k in object_keys {
@@ -328,8 +334,28 @@ impl EpochState {
             effects,
             execution_result,
             mock_gas_id,
-            unchanged_loaded_runtime_objects: vec![],
+            unchanged_loaded_runtime_objects,
             suggested_gas_price: None,
         })
     }
+}
+
+fn unchanged_loaded_runtime_objects(
+    effects: &TransactionEffects,
+    loaded_runtime_objects: &ObjectSet,
+) -> Vec<ObjectKey> {
+    let mut unchanged_loaded_runtime_objects: BTreeMap<_, _> = loaded_runtime_objects
+        .iter()
+        .filter(|o| !o.is_package())
+        .map(|o| (o.id(), o.version()))
+        .collect();
+
+    for change in effects.object_changes() {
+        unchanged_loaded_runtime_objects.remove(&change.id);
+    }
+
+    unchanged_loaded_runtime_objects
+        .into_iter()
+        .map(|(id, version)| ObjectKey(id, version))
+        .collect()
 }

--- a/crates/simulacrum/src/lib.rs
+++ b/crates/simulacrum/src/lib.rs
@@ -60,6 +60,10 @@ use self::store::in_mem_store::KeyStore;
 use sui_core::mock_checkpoint_builder::{MockCheckpointBuilder, ValidatorKeypairProvider};
 use sui_types::messages_checkpoint::{CheckpointContents, CheckpointSequenceNumber};
 use sui_types::sui_system_state::SuiSystemState;
+use sui_types::transaction_driver_types::{
+    ExecuteTransactionRequestV3, ExecuteTransactionResponseV3, TransactionSubmissionError,
+};
+use sui_types::transaction_executor::SimulateTransactionResult;
 pub use sui_types::transaction_executor::TransactionChecks;
 use sui_types::{
     gas_coin::GasCoin,
@@ -868,6 +872,34 @@ impl<T, V: store::SimulatorStore> ReadStore for Simulacrum<T, V> {
     }
 }
 
+#[async_trait::async_trait]
+impl<R: Send + Sync, S: store::SimulatorStore + Send + Sync>
+    sui_types::transaction_executor::TransactionExecutor for Simulacrum<R, S>
+{
+    async fn execute_transaction(
+        &self,
+        _request: ExecuteTransactionRequestV3,
+        _client_addr: Option<std::net::SocketAddr>,
+    ) -> Result<ExecuteTransactionResponseV3, TransactionSubmissionError> {
+        todo!()
+    }
+
+    fn simulate_transaction(
+        &self,
+        transaction: TransactionData,
+        checks: TransactionChecks,
+        allow_mock_gas_coin: bool,
+    ) -> Result<SimulateTransactionResult, sui_types::error::SuiError> {
+        self.epoch_state.simulate_transaction(
+            &self.store,
+            &self.verifier_signing_config,
+            transaction,
+            checks,
+            allow_mock_gas_coin,
+        )
+    }
+}
+
 impl<T: Send + Sync, V: store::SimulatorStore + Send + Sync> RpcStateReader for Simulacrum<T, V> {
     fn get_lowest_available_checkpoint_objects(
         &self,
@@ -941,10 +973,17 @@ impl Simulacrum {
 mod tests {
     use std::time::Duration;
 
+    use move_core_types::identifier::Identifier;
     use rand::{SeedableRng, rngs::StdRng};
+    use sui_config::verifier_signing_config::VerifierSigningConfig;
     use sui_types::{
-        base_types::SuiAddress, effects::TransactionEffectsAPI, gas_coin::GasCoin,
-        transaction::TransactionDataAPI,
+        SUI_FRAMEWORK_PACKAGE_ID,
+        base_types::{ObjectID, SuiAddress},
+        effects::TransactionEffectsAPI,
+        error::SuiErrorKind,
+        gas_coin::{GAS, GasCoin},
+        transaction::{GasData, ObjectArg, TransactionDataAPI, TransactionKind},
+        transaction_executor::SimulateTransactionResult,
     };
 
     use super::*;
@@ -1052,5 +1091,264 @@ mod tests {
         } else {
             assert_eq!(checkpoint.network_total_transactions, 2); // genesis + 1 user txn
         };
+    }
+
+    #[test]
+    fn gasless_simulation_does_not_inject_mock_gas() {
+        let sim = Simulacrum::new();
+        let sender = *sim.keystore().accounts().next().unwrap().0;
+
+        // Build an EpochState over Simulacrum's store with gasless enabled on the protocol
+        // config — the only tweak we need over what `Simulacrum::new()` already provides.
+        let mut protocol_config = sim.protocol_config().clone();
+        protocol_config.enable_gasless_for_testing();
+        protocol_config.set_gasless_allowed_token_types_for_testing(vec![(
+            GAS::type_tag().to_canonical_string(true),
+            0,
+        )]);
+        let chain_identifier = (*sim
+            .store()
+            .get_checkpoint_by_sequence_number(0)
+            .unwrap()
+            .digest())
+        .into();
+        let epoch_state = EpochState::new_with_protocol_config(
+            sim.system_state(),
+            protocol_config,
+            chain_identifier,
+        );
+
+        let gas_ref = sim
+            .store()
+            .owned_objects(sender)
+            .find(|object| object.is_gas_coin())
+            .unwrap()
+            .compute_object_reference();
+        let recipient = SuiAddress::random_for_testing_only();
+
+        let kind = {
+            let mut builder = ProgrammableTransactionBuilder::new();
+            let coin = builder.obj(ObjectArg::ImmOrOwnedObject(gas_ref)).unwrap();
+            let recipient = builder.pure(recipient).unwrap();
+            builder.programmable_move_call(
+                SUI_FRAMEWORK_PACKAGE_ID,
+                Identifier::new("coin").unwrap(),
+                Identifier::new("send_funds").unwrap(),
+                vec![GAS::type_tag()],
+                vec![coin, recipient],
+            );
+            TransactionKind::ProgrammableTransaction(builder.finish())
+        };
+
+        let tx = TransactionData::new_with_gas_data(
+            kind,
+            sender,
+            GasData {
+                payment: vec![],
+                owner: sender,
+                price: 0,
+                budget: 0,
+            },
+        );
+
+        let SimulateTransactionResult {
+            effects,
+            mock_gas_id,
+            ..
+        } = epoch_state
+            .simulate_transaction(
+                sim.store(),
+                &VerifierSigningConfig::default(),
+                tx,
+                TransactionChecks::Enabled,
+                true,
+            )
+            .unwrap();
+
+        assert!(
+            mock_gas_id.is_none(),
+            "gasless simulation should not synthesize a mock gas coin",
+        );
+        assert!(effects.status().is_ok(), "{:?}", effects.status());
+    }
+
+    #[test]
+    fn simulate_rejects_system_transaction() {
+        use sui_types::transaction::GenesisTransaction;
+
+        let sim = Simulacrum::new();
+        let kind = TransactionKind::Genesis(GenesisTransaction { objects: vec![] });
+        let sender = SuiAddress::default();
+        let tx = TransactionData::new_with_gas_data(
+            kind,
+            sender,
+            GasData {
+                payment: vec![],
+                owner: sender,
+                price: 0,
+                budget: 0,
+            },
+        );
+
+        let result = sim.epoch_state.simulate_transaction(
+            sim.store(),
+            &VerifierSigningConfig::default(),
+            tx,
+            TransactionChecks::Enabled,
+            false,
+        );
+
+        let err = match result {
+            Err(e) => e,
+            Ok(_) => panic!("expected simulate_transaction to reject system transaction"),
+        };
+        assert!(
+            matches!(err.as_inner(), SuiErrorKind::UnsupportedFeatureError { .. }),
+            "expected UnsupportedFeatureError, got: {err:?}",
+        );
+    }
+
+    #[test]
+    fn simulate_with_mock_gas_coin() {
+        let sim = Simulacrum::new();
+        let sender = *sim.keystore().accounts().next().unwrap().0;
+        let recipient = SuiAddress::random_for_testing_only();
+
+        let pt = {
+            let mut builder = ProgrammableTransactionBuilder::new();
+            builder.transfer_sui(recipient, Some(1_000_000));
+            builder.finish()
+        };
+
+        let tx = TransactionData::new_with_gas_data(
+            TransactionKind::ProgrammableTransaction(pt),
+            sender,
+            GasData {
+                payment: vec![],
+                owner: sender,
+                price: sim.reference_gas_price(),
+                budget: 50_000_000,
+            },
+        );
+
+        let SimulateTransactionResult {
+            effects,
+            mock_gas_id,
+            ..
+        } = sim
+            .epoch_state
+            .simulate_transaction(
+                sim.store(),
+                &sim.verifier_signing_config,
+                tx,
+                TransactionChecks::Disabled,
+                true,
+            )
+            .unwrap();
+
+        assert_eq!(mock_gas_id, Some(ObjectID::MAX));
+        assert!(effects.status().is_ok(), "{:?}", effects.status());
+    }
+
+    #[test]
+    fn simulate_with_dev_inspect_checks_disabled() {
+        let sim = Simulacrum::new();
+        let sender = *sim.keystore().accounts().next().unwrap().0;
+
+        let gas_ref = sim
+            .store()
+            .owned_objects(sender)
+            .find(|object| object.is_gas_coin())
+            .unwrap()
+            .compute_object_reference();
+
+        let pt = {
+            let mut builder = ProgrammableTransactionBuilder::new();
+            builder.transfer_sui(sender, Some(100));
+            builder.finish()
+        };
+
+        let tx = TransactionData::new_with_gas_data(
+            TransactionKind::ProgrammableTransaction(pt),
+            sender,
+            GasData {
+                payment: vec![gas_ref],
+                owner: sender,
+                price: sim.reference_gas_price(),
+                budget: 50_000_000,
+            },
+        );
+
+        let SimulateTransactionResult {
+            effects,
+            mock_gas_id,
+            ..
+        } = sim
+            .epoch_state
+            .simulate_transaction(
+                sim.store(),
+                &sim.verifier_signing_config,
+                tx,
+                TransactionChecks::Disabled,
+                false,
+            )
+            .unwrap();
+
+        assert!(mock_gas_id.is_none());
+        assert!(effects.status().is_ok(), "{:?}", effects.status());
+    }
+
+    #[test]
+    fn simulate_with_full_checks() {
+        let sim = Simulacrum::new();
+        let sender = *sim.keystore().accounts().next().unwrap().0;
+        let recipient = SuiAddress::random_for_testing_only();
+
+        let gas_obj = sim
+            .store()
+            .owned_objects(sender)
+            .find(|object| object.is_gas_coin())
+            .unwrap();
+        let gas_ref = gas_obj.compute_object_reference();
+
+        let pt = {
+            let mut builder = ProgrammableTransactionBuilder::new();
+            builder.transfer_sui(recipient, Some(1_000));
+            builder.finish()
+        };
+
+        let tx = TransactionData::new_with_gas_data(
+            TransactionKind::ProgrammableTransaction(pt),
+            sender,
+            GasData {
+                payment: vec![gas_ref],
+                owner: sender,
+                price: sim.reference_gas_price(),
+                budget: 50_000_000,
+            },
+        );
+
+        let SimulateTransactionResult {
+            effects,
+            mock_gas_id,
+            objects,
+            ..
+        } = sim
+            .epoch_state
+            .simulate_transaction(
+                sim.store(),
+                &sim.verifier_signing_config,
+                tx,
+                TransactionChecks::Enabled,
+                false,
+            )
+            .unwrap();
+
+        assert!(mock_gas_id.is_none());
+        assert!(effects.status().is_ok(), "{:?}", effects.status());
+        assert!(
+            !objects.is_empty(),
+            "object set should contain affected objects"
+        );
     }
 }


### PR DESCRIPTION
## Description 

This PR adds a `simulate_transaction` API for simulacrum.

## Test plan 

New unit tests were added.
```
cargo nextest run
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
