### PR TITLE
tidehunter: replace key_reduction indexing with fixed

### DIFF
--- a/consensus/core/src/storage/rocksdb_store.rs
+++ b/consensus/core/src/storage/rocksdb_store.rs
@@ -107,9 +107,9 @@ impl RocksDBStore {
             KeyIndexing, KeySpaceConfig, KeyType, ThConfig, default_mutex_count,
         };
         let mutexes = default_mutex_count();
-        let index_digest_key = KeyIndexing::fixed(36);
-        let index_index_digest_key = KeyIndexing::fixed(40);
-        let commit_vote_key = KeyIndexing::fixed(76);
+        let index_digest_key = KeyIndexing::key_reduction(36, 0..12);
+        let index_index_digest_key = KeyIndexing::key_reduction(40, 0..24);
+        let commit_vote_key = KeyIndexing::key_reduction(76, 0..60);
         let u32_prefix = KeyType::from_prefix_bits(3 * 8);
         let u64_prefix = KeyType::from_prefix_bits(6 * 8);
         let configs = vec![

--- a/consensus/core/src/storage/rocksdb_store.rs
+++ b/consensus/core/src/storage/rocksdb_store.rs
@@ -107,9 +107,9 @@ impl RocksDBStore {
             KeyIndexing, KeySpaceConfig, KeyType, ThConfig, default_mutex_count,
         };
         let mutexes = default_mutex_count();
-        let index_digest_key = KeyIndexing::key_reduction(36, 0..12);
-        let index_index_digest_key = KeyIndexing::key_reduction(40, 0..24);
-        let commit_vote_key = KeyIndexing::key_reduction(76, 0..60);
+        let index_digest_key = KeyIndexing::fixed(36);
+        let index_index_digest_key = KeyIndexing::fixed(40);
+        let commit_vote_key = KeyIndexing::fixed(76);
         let u32_prefix = KeyType::from_prefix_bits(3 * 8);
         let u64_prefix = KeyType::from_prefix_bits(6 * 8);
         let configs = vec![

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -665,7 +665,7 @@ impl AuthorityEpochTables {
             .disable_unload()
             .with_value_cache_size(default_value_cache_size());
         let object_ref_indexing = KeyIndexing::Hash;
-        let tx_digest_indexing = KeyIndexing::key_reduction(32, 0..16);
+        let tx_digest_indexing = KeyIndexing::fixed(32);
         let uniform_key = KeyType::uniform(default_cells_per_mutex());
         let sequence_key = KeyType::from_prefix_bits(6 * 8 + 4);
         let configs = vec![

--- a/crates/sui-core/src/authority/authority_store_tables.rs
+++ b/crates/sui-core/src/authority/authority_store_tables.rs
@@ -229,8 +229,7 @@ impl AuthorityPerpetualTables {
         let object_indexing = KeyIndexing::fixed(32 + 8); //  KeyIndexing::key_reduction(32 + 8, 16..(32 + 8));
         // todo can figure way to scramble off 8 bytes in the middle
         let obj_ref_size = 32 + 8 + 32 + 8;
-        let owned_object_transaction_locks_indexing =
-            KeyIndexing::key_reduction(obj_ref_size, 16..(obj_ref_size - 16));
+        let owned_object_transaction_locks_indexing = KeyIndexing::fixed(obj_ref_size);
 
         let mut objects_config = KeySpaceConfig::new()
             .with_max_dirty_keys(4096)
@@ -261,7 +260,7 @@ impl AuthorityPerpetualTables {
             (
                 "transactions".to_string(),
                 ThConfig::new_with_rm_prefix_indexing(
-                    KeyIndexing::key_reduction(32, 0..16),
+                    KeyIndexing::fixed(32),
                     transaction_mutexes,
                     uniform_key,
                     KeySpaceConfig::new()
@@ -273,7 +272,7 @@ impl AuthorityPerpetualTables {
             (
                 "effects".to_string(),
                 ThConfig::new_with_rm_prefix_indexing(
-                    KeyIndexing::key_reduction(32, 0..16),
+                    KeyIndexing::fixed(32),
                     transaction_mutexes,
                     uniform_key,
                     apply_relocation_filter(
@@ -288,7 +287,7 @@ impl AuthorityPerpetualTables {
             (
                 "executed_effects".to_string(),
                 ThConfig::new_with_rm_prefix_indexing(
-                    KeyIndexing::key_reduction(32, 0..16),
+                    KeyIndexing::fixed(32),
                     transaction_mutexes,
                     uniform_key,
                     bloom_config


### PR DESCRIPTION
## Summary
- Switch all `KeyIndexing::key_reduction` call sites to `KeyIndexing::fixed`.
- Affects sui-core perpetual tables (`owned_object_transaction_locks`, `transactions`, `effects`, `executed_effects`), the per-epoch `tx_digest_indexing`, and the consensus rocksdb_store index/commit-vote keys.

## Test plan
- [ ] `USE_TIDEHUNTER=1 cargo check -p sui-core -p consensus-core --features typed-store/tidehunter`
- [ ] Deploy to private-testnet with `build_with_tidehunter=true` and verify stable operation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)