### PR TITLE
sui-benchmark: retry soft bundles on retriable wait_for_effects responses

### DIFF
--- a/crates/sui-benchmark/src/lib.rs
+++ b/crates/sui-benchmark/src/lib.rs
@@ -600,6 +600,23 @@ impl ValidatorProxy for LocalValidatorAggregatorProxy {
     }
 }
 
+async fn warn_and_backoff_for_retry(
+    digests: &[TransactionDigest],
+    retry_cnt: &mut u32,
+    reason: impl std::fmt::Display,
+) {
+    let delay = Duration::from_millis(rand::thread_rng().gen_range(100..1000));
+    warn!(
+        ?digests,
+        retry_cnt = *retry_cnt,
+        "Soft bundle retry: {}. Sleeping for {:?} ...",
+        reason,
+        delay,
+    );
+    *retry_cnt += 1;
+    sleep(delay).await;
+}
+
 #[instrument(level = "debug", skip_all, fields(digests = ?txs.iter().map(|tx| *tx.digest()).collect::<Vec<_>>()))]
 async fn execute_soft_bundle_with_retries(
     td: &TransactionDriver<NetworkAuthorityClient>,
@@ -639,16 +656,12 @@ async fn execute_soft_bundle_with_retries(
                 if err.is_retryable().0
                     && (retry_cnt < max_retries || start.elapsed() < min_retry_duration)
                 {
-                    let delay = Duration::from_millis(rand::thread_rng().gen_range(100..1000));
-                    warn!(
-                        ?digests,
-                        retry_cnt,
-                        "Failed to get validator client with retriable error: {:?}. Sleeping for {:?} ...",
-                        err,
-                        delay,
-                    );
-                    retry_cnt += 1;
-                    sleep(delay).await;
+                    warn_and_backoff_for_retry(
+                        &digests,
+                        &mut retry_cnt,
+                        format!("get validator client failed: {err:?}"),
+                    )
+                    .await;
                     continue;
                 }
                 return Err(err.into());
@@ -670,16 +683,12 @@ async fn execute_soft_bundle_with_retries(
                 if sui_error.is_retryable().0
                     && (retry_cnt < max_retries || start.elapsed() < min_retry_duration)
                 {
-                    let delay = Duration::from_millis(rand::thread_rng().gen_range(100..1000));
-                    warn!(
-                        ?digests,
-                        retry_cnt,
-                        "Soft bundle submission failed with retriable error: {:?}. Sleeping for {:?} ...",
-                        sui_error,
-                        delay,
-                    );
-                    retry_cnt += 1;
-                    sleep(delay).await;
+                    warn_and_backoff_for_retry(
+                        &digests,
+                        &mut retry_cnt,
+                        format!("submission failed: {sui_error:?}"),
+                    )
+                    .await;
                     continue;
                 }
                 return Err(sui_error.into());
@@ -742,16 +751,12 @@ async fn execute_soft_bundle_with_retries(
         }
 
         if should_retry {
-            let delay = Duration::from_millis(rand::thread_rng().gen_range(100..1000));
-            warn!(
-                ?digests,
-                retry_cnt,
-                "Soft bundle rejected with retriable error: {:?}. Sleeping for {:?} ...",
-                last_error,
-                delay,
-            );
-            retry_cnt += 1;
-            sleep(delay).await;
+            warn_and_backoff_for_retry(
+                &digests,
+                &mut retry_cnt,
+                format!("submission rejected: {last_error:?}"),
+            )
+            .await;
             continue;
         }
 
@@ -783,6 +788,34 @@ async fn execute_soft_bundle_with_retries(
             .collect();
 
         let wait_responses = futures::future::join_all(wait_futures).await;
+
+        // If any tx's wait_for_effects came back with a retriable signal (epoch-change
+        // rejection or an Expired consensus position), the tx was never ordered, so
+        // re-submit the bundle in the new epoch / with a fresh consensus position.
+        // Rejected{error: None} is intentionally not treated as retriable: it occurs
+        // when our chosen validator voted to accept while a quorum of others voted to
+        // reject, leaving no local rejection reason to act on. The caller surfaces it
+        // as UnknownRejection.
+        let retriable_wait_failure = wait_responses.iter().find_map(|r| match r {
+            Ok(WaitForEffectsResponse::Rejected { error: Some(e) }) if e.is_retryable().0 => {
+                Some(format!("rejected: {e:?}"))
+            }
+            Ok(WaitForEffectsResponse::Expired { epoch, round }) => {
+                Some(format!("expired (epoch {epoch}, round {round:?})"))
+            }
+            _ => None,
+        });
+        if let Some(reason) = retriable_wait_failure
+            && (retry_cnt < max_retries || start.elapsed() < min_retry_duration)
+        {
+            warn_and_backoff_for_retry(
+                &digests,
+                &mut retry_cnt,
+                format!("wait_for_effects retriable failure: {reason}"),
+            )
+            .await;
+            continue;
+        }
 
         // Build final results by combining immediate responses with waited responses
         let mut wait_response_iter = wait_responses.into_iter();

--- a/crates/sui-benchmark/src/workloads/composite/mod.rs
+++ b/crates/sui-benchmark/src/workloads/composite/mod.rs
@@ -467,6 +467,37 @@ struct AliasState {
     cycle_state: AliasRevokeCycleState,
 }
 
+impl AliasState {
+    /// Apply the result of polling `is_transaction_checkpointed` for the currently
+    /// pending Add or Remove alias tx. If checkpoint-confirmed, transitions to the
+    /// next cycle state.
+    fn confirm_pending_alias_checkpoint(&mut self, checkpointed: bool) {
+        if !checkpointed {
+            return;
+        }
+        let next_state = match &self.cycle_state {
+            AliasRevokeCycleState::AddPending {
+                tx_digest: Some(digest),
+            } => {
+                info!("Add alias tx {digest} checkpoint confirmed");
+                Some(AliasRevokeCycleState::Active {
+                    successful_alias_txs: 0,
+                })
+            }
+            AliasRevokeCycleState::RemovePending {
+                tx_digest: Some(digest),
+            } => {
+                info!("Remove alias tx {digest} checkpoint confirmed");
+                Some(AliasRevokeCycleState::Revoked)
+            }
+            _ => None,
+        };
+        if let Some(s) = next_state {
+            self.cycle_state = s;
+        }
+    }
+}
+
 #[derive(Clone, Copy)]
 enum BatchTxKind {
     /// Standard composite PTB.
@@ -744,47 +775,30 @@ impl CompositePayload {
     /// Polls for pending alias checkpoint confirmations and returns true if
     /// an alias tx should be generated this batch.
     async fn advance_alias_state(&mut self) -> bool {
-        let Some(ref mut alias_state) = self.alias_state else {
-            return false;
-        };
-
-        match &alias_state.cycle_state {
-            AliasRevokeCycleState::AddPending {
-                tx_digest: Some(digest),
-            } => {
-                let checkpointed = self.fullnode_proxies[0]
-                    .is_transaction_checkpointed(digest)
-                    .await
-                    .unwrap_or(false);
-                if checkpointed {
-                    info!("Add alias tx {digest} checkpoint confirmed");
-                    alias_state.cycle_state = AliasRevokeCycleState::Active {
-                        successful_alias_txs: 0,
-                    };
-                }
+        let pending_alias_digest = self.alias_state.as_ref().and_then(|s| match s.cycle_state {
+            AliasRevokeCycleState::AddPending { tx_digest: Some(d) }
+            | AliasRevokeCycleState::RemovePending { tx_digest: Some(d) } => Some(d),
+            _ => None,
+        });
+        if let Some(digest) = pending_alias_digest {
+            let checkpointed = self.fullnode_proxies[0]
+                .is_transaction_checkpointed(&digest)
+                .await
+                .unwrap_or(false);
+            if let Some(alias_state) = self.alias_state.as_mut() {
+                alias_state.confirm_pending_alias_checkpoint(checkpointed);
             }
-            AliasRevokeCycleState::RemovePending {
-                tx_digest: Some(digest),
-            } => {
-                let checkpointed = self.fullnode_proxies[0]
-                    .is_transaction_checkpointed(digest)
-                    .await
-                    .unwrap_or(false);
-                if checkpointed {
-                    info!("Remove alias tx {digest} checkpoint confirmed");
-                    alias_state.cycle_state = AliasRevokeCycleState::Revoked;
-                }
-            }
-            _ => {}
         }
 
-        let mut rng = get_rng();
+        let Some(alias_state) = self.alias_state.as_ref() else {
+            return false;
+        };
         match &alias_state.cycle_state {
             AliasRevokeCycleState::Active {
                 successful_alias_txs,
             } if *successful_alias_txs >= self.config.alias_txs_before_revoke => true,
             AliasRevokeCycleState::Active { .. } => {
-                rng.gen_bool(self.config.alias_tx_probability as f64)
+                get_rng().gen_bool(self.config.alias_tx_probability as f64)
             }
             AliasRevokeCycleState::Revoked | AliasRevokeCycleState::NeedAdd => true,
             _ => false,
@@ -1927,5 +1941,87 @@ impl Workload<dyn Payload> for CompositeWorkload {
 
     fn name(&self) -> &str {
         "Composite"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn alias_state_for_test(cycle_state: AliasRevokeCycleState) -> AliasState {
+        let (sender, keypair): (_, AccountKeyPair) = get_key_pair();
+        AliasState {
+            alias_address: sender,
+            alias_keypair: Arc::new(keypair),
+            address_aliases_id: ObjectID::random(),
+            address_aliases_initial_shared_version: SequenceNumber::from_u64(1),
+            cycle_state,
+        }
+    }
+
+    /// Verifies `Revoked` is reachable: a checkpoint-confirmed `RemovePending`
+    /// transitions the state machine into `Revoked`, the gating state for the
+    /// post-revoke probe.
+    #[test]
+    fn alias_state_remove_pending_to_revoked() {
+        let mut state = alias_state_for_test(AliasRevokeCycleState::RemovePending {
+            tx_digest: Some(TransactionDigest::random()),
+        });
+
+        state.confirm_pending_alias_checkpoint(false);
+        assert!(matches!(
+            state.cycle_state,
+            AliasRevokeCycleState::RemovePending { tx_digest: Some(_) }
+        ));
+
+        state.confirm_pending_alias_checkpoint(true);
+        assert!(matches!(state.cycle_state, AliasRevokeCycleState::Revoked));
+    }
+
+    #[test]
+    fn alias_state_add_pending_to_active() {
+        let mut state = alias_state_for_test(AliasRevokeCycleState::AddPending {
+            tx_digest: Some(TransactionDigest::random()),
+        });
+        state.confirm_pending_alias_checkpoint(true);
+        assert!(matches!(
+            state.cycle_state,
+            AliasRevokeCycleState::Active {
+                successful_alias_txs: 0
+            }
+        ));
+    }
+
+    /// Pending states with no observed digest yet (Phase 1) must not advance.
+    #[test]
+    fn alias_state_pending_without_digest_does_not_advance() {
+        let mut state =
+            alias_state_for_test(AliasRevokeCycleState::RemovePending { tx_digest: None });
+        state.confirm_pending_alias_checkpoint(true);
+        assert!(matches!(
+            state.cycle_state,
+            AliasRevokeCycleState::RemovePending { tx_digest: None }
+        ));
+    }
+
+    /// Verifies the cycle exits `Revoked`: a permanent failure for the
+    /// post-revoke probe transitions back to `NeedAdd`, restarting the cycle.
+    #[test]
+    fn alias_state_revoked_exits_to_need_add_on_probe_failure() {
+        let mut state = alias_state_for_test(AliasRevokeCycleState::Revoked);
+        let counted = CompositePayload::handle_alias_tx_result(
+            &mut state,
+            BatchTxKind::InvalidPostRevocation,
+            &BatchedTransactionStatus::PermanentFailure {
+                error: "test".into(),
+            },
+            10,
+            TransactionDigest::random(),
+        );
+        assert!(
+            counted,
+            "expected probe rejection to be counted as expected"
+        );
+        assert!(matches!(state.cycle_state, AliasRevokeCycleState::NeedAdd));
     }
 }


### PR DESCRIPTION
## Summary

The bench soft-bundle proxy already retries on submit-time retriable rejections. Extend the same retry (10 attempts / 60s) to cover retriable `wait_for_effects` responses — `Rejected` with a retriable reason and `Expired` — which similarly mean the tx was never ordered.

This removes spurious epoch-boundary failures the composite alias-revoke workload was working around, and lets that workaround (per-batch checkpoint polls + digest tracking set) be deleted.

## Behavior change

Workloads that count `RetriableFailure` events will see fewer; most now resolve to `Success` or `PermanentFailure` via proxy-level retry. `Rejected{error: None}` still surfaces as `UnknownRejection`.

---

## Release notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework: