### PR TITLE
Update alert settings recommended for operators

### DIFF
--- a/docs/content/operators/validator/alerts.mdx
+++ b/docs/content/operators/validator/alerts.mdx
@@ -4,137 +4,94 @@ sidebar_label: Alert Reference
 description: A collection of the Prometheus Alertmanager rules that trigger alerts and warnings on Validator and Full nodes.
 ---
 
-When running a Sui Validator node or Full node, you might want to configure alerting based on some or all of the following metrics.
+When running a Sui Validator or full node, it is recommended to monitor the health of the nodes and set up alerts on problems.
+Besides alerting on crashes and other common issues, you might also want to configure alerting based on the following example rules.
 
-## Alert reference 
+The following sections cover the alert queries, but the details are meant to be customized to suit your infrastructure.
 
-The following sections cover the alert settings, but their details are meant to be customized in the following ways:
-
-- Replace `$network` with your actual network label (for example, `mainnet`, `testnet`, and so on).
-- Thresholds assume about 10,000 stake units — adjust for your own validator set size.
-- Labels like `host` and `container` are stripped to be agnostic on infrastructure.
-
-## High-priority chain health alerts (validator-specific)
+## High-priority health alerts
 
 These alerts should receive the most immediate attention from you or your team.
 
-### Safe mode during reconfiguration
+### Crash loop
 
-| Key          | Value                                            |
-| ------------ | ------------------------------------------------ |
-| **Name**     | `Safe Mode during Reconfiguration`               |
-| **Summary**  | Epoch failed to advance; chain entered safe mode |
-| **Duration** | `5m`                                             |
+| Key          | Value                                       |
+| ------------ | ------------------------------------------- |
+| **Name**     | `Crash loop`                                |
+| **Summary**  | Node is crash looping                       |
+| **Duration** | Recommended to trigger after `15m`          |
 
-```sh
-is_safe_mode{network="$network"} > 0.5 or absent(is_safe_mode{network="$network"})
+```promql
+max without(version) (uptime) < 60 or absent(uptime)
 ```
+
+Node is not staying up longer than 60s. Possible reasons:
+- Binary version too old.
+- Incorrect configuration.
+- Software bug.
+
+Please notify Sui community on Discord if this cannot be resolved on your own.
 
 ### Consensus proposals failure
 
 | Key          | Value                                       |
 | ------------ | ------------------------------------------- |
-| **Name**     | `Consensus Proposals Failure`               |
-| **Summary**  | Less than 80% of stake is proposing consensus blocks |
-| **Duration** | `5m`                                        |
+| **Name**     | `Consensus proposals failure`               |
+| **Summary**  | Consensus block proposal rate is low        |
+| **Duration** | Recommended to trigger after `1h`           |
 
-```sh
-sum(
-  sum by (host) (current_voting_right{network="$network"})
-  and
-  sum by (host) (rate(consensus_proposed_blocks{network="$network"}[5m])) > 0
-) < 8000
+```promql
+sum without(force) (rate(consensus_proposed_blocks[5m])) < 1.0
 ```
+
+Validators with a slow consensus proposal rate can hurt network latency and throughput.
+It is usually due to network, disk or CPU performance issues.
 
 ### Checkpoint execution rate is low
 
 | Key          | Value                                                 |
 | ------------ | ----------------------------------------------------- |
-| **Name**     | `Checkpoint Execution Rate Is Low`                    |
-| **Summary**  | Less than 80% of stake is executing checkpoints quickly enough |
-| **Duration** | `5m`                                                  |
+| **Name**     | `Checkpoint execution rate is low`                    |
+| **Summary**  | Validator is not executing checkpoints quickly enough |
+| **Duration** | Recommended to trigger after `1h`                     |
 
-```sh
-sum(
-  sum by (host) (current_voting_right{network="$network"})
-  and
-  sum by (host) (rate(last_executed_checkpoint{network="$network"}[5m])) > 2
-) < 8000
+```promql
+rate(last_executed_checkpoint[5m]) < 1.0
 ```
 
-### Certificate execution latencies are high
+Validators and full nodes with slow checkpoint execution will not have up-to-date information from the network.
+It is usually due to network, disk or CPU performance issues.
+
+### Safe mode during reconfiguration
 
 | Key          | Value                                                                    |
 | ------------ | ------------------------------------------------------------------------ |
-| **Name**     | `Certificate execution latencies are high`                               |
-| **Summary**  | Less than 80% of stake is handling shared-object tx certs with low enough latency |
-| **Duration** | `5m`                                                                     |
+| **Name**     | `Safe mode during reconfiguration`                                       |
+| **Summary**  | Validator or full node failed to advance the epoch and entered safe mode |
+| **Duration** | Recommended to trigger after `15m`                                       |
 
-```sh
-sum(
-  sum by (host) (current_voting_right{network="$network"})
-  and
-  histogram_quantile(0.95, sum by (le, host) (
-    rate(validator_service_handle_certificate_consensus_latency_bucket{network="$network"}[5m])
-  )) < 3
-) < 8000
+```promql
+is_safe_mode > 0.5
 ```
 
-### Randomness DKG failure
-
-| Key          | Value                                             |
-| ------------ | ------------------------------------------------- |
-| **Name**     | `RandomnessDkgFailure`                            |
-| **Summary**  | Random beacon DKG has failed on one or more hosts |
-| **Duration** | `5m`                                              |
-
-```sh
-epoch_random_beacon_dkg_failed{network="$network"} > 0 or absent(is_safe_mode{network="$network"})
-```
-
-### Validators not upgraded
-
-| Key          | Value                                     |
-| ------------ | ----------------------------------------- |
-| **Name**     | `Mysten validators are not upgraded`      |
-| **Summary**  | Validators are behind on protocol version |
-| **Duration** | `1h`                                      |
-
-```sh
-min(sui_configured_max_protocol_version{network="$network", host=~"Mysten-.*"})
-  < quantile(0.34, sui_configured_max_protocol_version{network="$network"})
-```
+Usually this issue is outside the control of validator or full node operators.
+Please notify Sui community on Discord when this is observed.
 
 ## Non-urgent and warning alerts
 
-All alerts are important, but the following alerts and warnings can be addressed within a normal node maintenance workflow.
-
-### Consensus sequencing p99 latency high
-
-| Key          | Value                                                        |
-| ------------ | ------------------------------------------------------------ |
-| **Name**     | `Consensus sequencing p99 latencies are high`                |
-| **Summary**  | Less than 80% of stake is sequencing tx certs with acceptable latency |
-| **Duration** | `1m`                                                         |
-
-```sh
-sum(
-  sum by (host) (current_voting_right{network="$network"})
-  and
-  histogram_quantile(0.95, sum by (le, host) (
-    rate(sequencing_certificate_latency_bucket{network="$network", position="0", tx_type=~"shared_certificate|owned_certificate|soft_bundle"}[2m])
-  )) < 2
-) < 5000
-```
+All alerts are important, but the following alerts and warnings can be addressed within the normal node maintenance workflow.
 
 ### System invariant violations
 
 | Key          | Value                                     |
 | ------------ | ----------------------------------------- |
-| **Name**     | `System Invariant Violations`             |
-| **Summary**  | The system reported an invariant violation |
-| **Duration** | `1m`                                      |
+| **Name**     | `System invariant violations`             |
+| **Summary**  | The node reports an invariant violation   |
+| **Duration** | Recommended to trigger after `15m`        |
 
-```sh
-max(system_invariant_violations{network="$network"}) > 0
+```promql
+system_invariant_violations > 0
 ```
+
+Usually this issue is outside the control of validator or full node operators.
+Please notify Sui community on Discord when this is observed.


### PR DESCRIPTION
## Description 

- Operators generally only see their own metrics. Update queries accordingly.
- Update queries from recent changes.
- Remove non-actionable alert rules.

## Test plan 

claude review
