### PR TITLE
sui-indexer-alt-framework: separate pruner from prune watermark

### DIFF
--- a/crates/sui-checkpoint-blob-indexer/src/config.rs
+++ b/crates/sui-checkpoint-blob-indexer/src/config.rs
@@ -50,6 +50,7 @@ pub struct ConcurrentLayer {
     pub processor_channel_size: Option<usize>,
     pub collector_channel_size: Option<usize>,
     pub committer_channel_size: Option<usize>,
+    pub pruner_channel_size: Option<usize>,
 }
 
 impl ConcurrentLayer {
@@ -68,6 +69,7 @@ impl ConcurrentLayer {
             processor_channel_size: self.processor_channel_size.or(base.processor_channel_size),
             collector_channel_size: self.collector_channel_size.or(base.collector_channel_size),
             committer_channel_size: self.committer_channel_size.or(base.committer_channel_size),
+            pruner_channel_size: self.pruner_channel_size.or(base.pruner_channel_size),
         }
     }
 }

--- a/crates/sui-indexer-alt-framework/src/pipeline/concurrent/mod.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/concurrent/mod.rs
@@ -23,6 +23,7 @@ use crate::pipeline::concurrent::collector::collector;
 use crate::pipeline::concurrent::commit_watermark::commit_watermark;
 use crate::pipeline::concurrent::committer::committer;
 use crate::pipeline::concurrent::main_reader_lo::track_main_reader_lo;
+use crate::pipeline::concurrent::prune_watermark::prune_watermark;
 use crate::pipeline::concurrent::pruner::pruner;
 use crate::pipeline::concurrent::reader_watermark::reader_watermark;
 use crate::pipeline::processor::processor;
@@ -33,6 +34,7 @@ mod collector;
 mod commit_watermark;
 mod committer;
 mod main_reader_lo;
+mod prune_watermark;
 mod pruner;
 mod reader_watermark;
 
@@ -142,6 +144,9 @@ pub struct ConcurrentConfig {
 
     /// Size of the channel between the committer and the watermark updater.
     pub committer_channel_size: Option<usize>,
+
+    /// Size of the channel between the pruner and the pruner watermark updater.
+    pub pruner_channel_size: Option<usize>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -257,6 +262,7 @@ pub(crate) fn pipeline<H: Handler>(
         processor_channel_size,
         collector_channel_size,
         committer_channel_size,
+        pruner_channel_size,
     } = config;
 
     let concurrency = fanout.unwrap_or(ConcurrencyConfig::Adaptive {
@@ -278,6 +284,8 @@ pub(crate) fn pipeline<H: Handler>(
     //docs::/#buff
     let committer_channel_size = committer_channel_size.unwrap_or(num_cpus::get());
     let (committer_tx, watermark_rx) = mpsc::channel(committer_channel_size);
+    let pruner_channel_size = pruner_channel_size.unwrap_or(64);
+    let (pruner_tx, prune_watermark_rx) = mpsc::channel::<(u64, u64)>(pruner_channel_size);
     let main_reader_lo = Arc::new(SetOnce::new());
 
     let handler = Arc::new(handler);
@@ -330,7 +338,15 @@ pub(crate) fn pipeline<H: Handler>(
     let s_reader_watermark =
         reader_watermark::<H>(pruner_config.clone(), store.clone(), metrics.clone());
 
-    let s_pruner = pruner(handler, pruner_config, store, metrics);
+    let s_pruner = pruner(
+        handler,
+        pruner_config.clone(),
+        store.clone(),
+        pruner_tx,
+        metrics.clone(),
+    );
+
+    let s_prune_watermark = prune_watermark::<H>(pruner_config, prune_watermark_rx, store, metrics);
 
     s_processor
         .merge(s_collector)
@@ -339,6 +355,7 @@ pub(crate) fn pipeline<H: Handler>(
         .attach(s_track_reader_lo)
         .attach(s_reader_watermark)
         .attach(s_pruner)
+        .attach(s_prune_watermark)
 }
 
 #[cfg(test)]

--- a/crates/sui-indexer-alt-framework/src/pipeline/concurrent/prune_watermark.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/concurrent/prune_watermark.rs
@@ -1,0 +1,406 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use backoff::ExponentialBackoff;
+use sui_futures::service::Service;
+use tokio::sync::mpsc;
+use tracing::error;
+use tracing::info;
+use tracing::warn;
+
+use crate::metrics::IndexerMetrics;
+use crate::pipeline::concurrent::Handler;
+use crate::pipeline::concurrent::PrunerConfig;
+use crate::pipeline::logging::LoggerWatermark;
+use crate::pipeline::logging::WatermarkLogger;
+use crate::store::ConcurrentConnection;
+use crate::store::Store;
+
+/// If reading the initial `pruner_hi` fails, retry starting at this interval.
+const INITIAL_READ_RETRY_INTERVAL: Duration = Duration::from_millis(100);
+
+/// Cap the retry interval at this value while reading the initial `pruner_hi`.
+const MAX_READ_RETRY_INTERVAL: Duration = Duration::from_secs(1);
+
+/// The prune watermark task is responsible for advancing the pipeline's `pruner_hi` watermark in
+/// the database. It receives successfully pruned ranges `(from, to_exclusive)` from the `pruner`
+/// task over an mpsc channel, buffers out-of-order completions in a `BTreeMap`, and advances
+/// `pruner_hi` through the contiguous prefix of completed ranges.
+///
+/// Splitting watermark updates into their own task mirrors the `committer` + `commit_watermark`
+/// pattern: the pruner task focuses on distributing work, while this task focuses on persisting
+/// progress. At startup, the task reads the current DB `pruner_hi` to establish the baseline for
+/// contiguity — the first received chunk may have `from > pruner_hi` if an earlier chunk failed
+/// and is still being retried, so lazy-initialization from the first message is not safe.
+///
+/// If `config` is `None`, the task will shutdown immediately.
+pub(super) fn prune_watermark<H: Handler>(
+    config: Option<PrunerConfig>,
+    mut rx: mpsc::Receiver<(u64, u64)>,
+    store: H::Store,
+    metrics: Arc<IndexerMetrics>,
+) -> Service {
+    Service::new().spawn_aborting(async move {
+        if config.is_none() {
+            info!(pipeline = H::NAME, "Skipping prune watermark task");
+            return Ok(());
+        };
+
+        let initial_pruner_hi = read_initial_pruner_hi::<H>(&store).await;
+
+        info!(
+            pipeline = H::NAME,
+            initial_pruner_hi, "Starting prune watermark task"
+        );
+
+        // Buffer completed ranges that are not yet contiguous with `highest_pruned`.
+        let mut precommitted: BTreeMap<u64, u64> = BTreeMap::new();
+        let mut highest_pruned: u64 = initial_pruner_hi;
+        let mut highest_watermarked: u64 = initial_pruner_hi;
+
+        let mut logger = WatermarkLogger::new("pruner");
+
+        while let Some((from, to_exclusive)) = rx.recv().await {
+            precommitted.insert(from, to_exclusive);
+
+            while let Some(entry) = precommitted.first_entry() {
+                if *entry.key() != highest_pruned {
+                    break;
+                }
+                highest_pruned = entry.remove();
+            }
+
+            metrics
+                .watermark_pruner_hi
+                .with_label_values(&[H::NAME])
+                .set(highest_pruned as i64);
+
+            if highest_pruned > highest_watermarked {
+                match write_pruner_watermark::<H>(&store, highest_pruned, &metrics).await {
+                    Ok(elapsed) => {
+                        highest_watermarked = highest_pruned;
+                        logger.log::<H>(LoggerWatermark::checkpoint(highest_pruned), elapsed);
+                        metrics
+                            .watermark_pruner_hi_in_db
+                            .with_label_values(&[H::NAME])
+                            .set(highest_pruned as i64);
+                    }
+                    Err(()) => {
+                        // Failure already logged; the next received range will retry.
+                    }
+                }
+            }
+        }
+
+        info!(pipeline = H::NAME, "Stopping prune watermark task");
+        Ok(())
+    })
+}
+
+/// Read the initial `pruner_hi` from the DB, retrying with exponential backoff on connection or
+/// query failures. If the pipeline has no watermark row yet, returns 0 — in that case the pruner
+/// task will also find no watermark and produce no messages, so the value is unused until a
+/// watermark is written.
+async fn read_initial_pruner_hi<H: Handler>(store: &H::Store) -> u64 {
+    let backoff = ExponentialBackoff {
+        initial_interval: INITIAL_READ_RETRY_INTERVAL,
+        current_interval: INITIAL_READ_RETRY_INTERVAL,
+        max_interval: MAX_READ_RETRY_INTERVAL,
+        max_elapsed_time: None,
+        ..Default::default()
+    };
+
+    use backoff::Error as BE;
+    let read = || async {
+        let mut conn = store.connect().await.map_err(|e| {
+            warn!(
+                pipeline = H::NAME,
+                "Failed to connect to read initial pruner watermark, retrying: {e}"
+            );
+            BE::transient(())
+        })?;
+        // Pass `Duration::ZERO` because we only need the current `pruner_hi`; the `delay` argument
+        // exists to let the production pruner task wait until in-flight reads have completed.
+        conn.pruner_watermark(H::NAME, Duration::ZERO)
+            .await
+            .map(|w| w.map_or(0, |w| w.pruner_hi))
+            .map_err(|e| {
+                warn!(
+                    pipeline = H::NAME,
+                    "Failed to read initial pruner watermark, retrying: {e}"
+                );
+                BE::transient(())
+            })
+    };
+
+    // `max_elapsed_time: None` means the operation never terminates with a permanent error, so the
+    // `Err` arm is unreachable — `unwrap_or(0)` is a safe fallback for the type system.
+    backoff::future::retry(backoff, read).await.unwrap_or(0)
+}
+
+/// Write `pruner_hi` to the database. Returns the elapsed write time on success (so the caller can
+/// pass it to the logger) and `Err(())` on connection or DB error.
+async fn write_pruner_watermark<H: Handler>(
+    store: &H::Store,
+    pruner_hi: u64,
+    metrics: &IndexerMetrics,
+) -> Result<f64, ()> {
+    let guard = metrics
+        .watermark_pruner_write_latency
+        .with_label_values(&[H::NAME])
+        .start_timer();
+
+    let Ok(mut conn) = store.connect().await else {
+        let elapsed = guard.stop_and_record();
+        warn!(
+            pipeline = H::NAME,
+            elapsed_ms = elapsed * 1000.0,
+            "Prune watermark task failed to connect while updating watermark"
+        );
+        return Err(());
+    };
+
+    match conn.set_pruner_watermark(H::NAME, pruner_hi).await {
+        Ok(_) => Ok(guard.stop_and_record()),
+        Err(e) => {
+            let elapsed = guard.stop_and_record();
+            error!(
+                pipeline = H::NAME,
+                elapsed_ms = elapsed * 1000.0,
+                "Failed to update pruner watermark: {e}"
+            );
+            Err(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+    use std::time::SystemTime;
+    use std::time::UNIX_EPOCH;
+
+    use async_trait::async_trait;
+    use prometheus::Registry;
+    use sui_types::full_checkpoint_content::Checkpoint;
+    use tokio::sync::mpsc;
+
+    use crate::FieldCount;
+    use crate::metrics::IndexerMetrics;
+    use crate::mocks::store::*;
+    use crate::pipeline::Processor;
+    use crate::pipeline::concurrent::BatchStatus;
+    use crate::pipeline::concurrent::Handler;
+    use crate::pipeline::concurrent::PrunerConfig;
+
+    use super::*;
+
+    #[derive(Clone, FieldCount)]
+    pub struct StoredData;
+
+    pub struct DataPipeline;
+
+    #[async_trait]
+    impl Processor for DataPipeline {
+        const NAME: &'static str = "data";
+        type Value = StoredData;
+
+        async fn process(&self, _checkpoint: &Arc<Checkpoint>) -> anyhow::Result<Vec<Self::Value>> {
+            Ok(vec![])
+        }
+    }
+
+    #[async_trait]
+    impl Handler for DataPipeline {
+        type Store = MockStore;
+        type Batch = Vec<Self::Value>;
+
+        fn batch(
+            &self,
+            batch: &mut Self::Batch,
+            values: &mut std::vec::IntoIter<Self::Value>,
+        ) -> BatchStatus {
+            batch.extend(values);
+            BatchStatus::Pending
+        }
+
+        async fn commit<'a>(
+            &self,
+            _batch: &Self::Batch,
+            _conn: &mut MockConnection<'a>,
+        ) -> anyhow::Result<usize> {
+            Ok(0)
+        }
+    }
+
+    struct TestSetup {
+        store: MockStore,
+        tx: mpsc::Sender<(u64, u64)>,
+        #[allow(unused)]
+        service: Service,
+    }
+
+    fn default_watermark() -> MockWatermark {
+        let timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as u64;
+        MockWatermark {
+            epoch_hi_inclusive: 0,
+            checkpoint_hi_inclusive: Some(0),
+            tx_hi: 0,
+            timestamp_ms_hi_inclusive: timestamp,
+            reader_lo: 0,
+            pruner_timestamp: timestamp,
+            pruner_hi: 0,
+            chain_id: None,
+        }
+    }
+
+    fn setup_test(config: Option<PrunerConfig>, store: MockStore) -> TestSetup {
+        let (tx, rx) = mpsc::channel(16);
+        let registry = Registry::new_custom(Some("test".to_string()), None).unwrap();
+        let metrics = IndexerMetrics::new(None, &registry);
+        let store_clone = store.clone();
+        let service = prune_watermark::<DataPipeline>(config, rx, store_clone, metrics);
+        TestSetup { store, tx, service }
+    }
+
+    async fn wait_for_pruner_hi(store: &MockStore, expected: u64, timeout: Duration) {
+        let start = tokio::time::Instant::now();
+        loop {
+            if let Some(w) = store.watermark(DataPipeline::NAME)
+                && w.pruner_hi == expected
+            {
+                return;
+            }
+            if start.elapsed() > timeout {
+                let actual = store
+                    .watermark(DataPipeline::NAME)
+                    .map(|w| w.pruner_hi)
+                    .unwrap_or(u64::MAX);
+                panic!("Timed out waiting for pruner_hi={expected}; last observed {actual}");
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    }
+
+    #[tokio::test]
+    async fn test_basic_watermark_progression() {
+        let store = MockStore::new().with_watermark(DataPipeline::NAME, default_watermark());
+        let setup = setup_test(Some(PrunerConfig::default()), store);
+
+        for range in [(0u64, 5u64), (5, 10), (10, 15)] {
+            setup.tx.send(range).await.unwrap();
+        }
+
+        wait_for_pruner_hi(&setup.store, 15, Duration::from_secs(1)).await;
+    }
+
+    #[tokio::test]
+    async fn test_out_of_order_ranges() {
+        let store = MockStore::new().with_watermark(DataPipeline::NAME, default_watermark());
+        let setup = setup_test(Some(PrunerConfig::default()), store);
+
+        // First message establishes the baseline at `from = 0`, so (10, 15) gets buffered.
+        setup.tx.send((0, 5)).await.unwrap();
+        setup.tx.send((10, 15)).await.unwrap();
+
+        // Wait for the (0, 5) write to land before we assert the stall.
+        wait_for_pruner_hi(&setup.store, 5, Duration::from_secs(1)).await;
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert_eq!(
+            setup.store.watermark(DataPipeline::NAME).unwrap().pruner_hi,
+            5,
+            "Gap between (0, 5) and (10, 15) should stall pruner_hi at 5"
+        );
+
+        // Fill the gap. Both (5, 10) and the buffered (10, 15) should flush.
+        setup.tx.send((5, 10)).await.unwrap();
+        wait_for_pruner_hi(&setup.store, 15, Duration::from_secs(1)).await;
+    }
+
+    #[tokio::test]
+    async fn test_watermark_advances_despite_connection_flakiness() {
+        // Exercise the retry loops around DB access (initial read + per-message write). With a
+        // handful of transient connection failures, the watermark should still eventually land.
+        let store = MockStore::new()
+            .with_watermark(DataPipeline::NAME, default_watermark())
+            .with_connection_failures(3);
+        let setup = setup_test(Some(PrunerConfig::default()), store);
+
+        setup.tx.send((0, 5)).await.unwrap();
+        setup.tx.send((5, 10)).await.unwrap();
+        wait_for_pruner_hi(&setup.store, 10, Duration::from_secs(2)).await;
+    }
+
+    #[tokio::test]
+    async fn test_no_config_exits_immediately() {
+        let store = MockStore::new().with_watermark(DataPipeline::NAME, default_watermark());
+        let setup = setup_test(None, store);
+
+        // Sending into the channel succeeds (mpsc buffer), but the task has already exited so no
+        // progression happens. Give the runtime a moment and assert pruner_hi is unchanged.
+        setup.tx.send((0, 5)).await.unwrap();
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert_eq!(
+            setup.store.watermark(DataPipeline::NAME).unwrap().pruner_hi,
+            0
+        );
+    }
+
+    #[tokio::test]
+    async fn test_non_zero_initial_baseline_buffers_leading_gap() {
+        // The pruner task schedules chunks starting from DB `pruner_hi`, but a chunk at the front
+        // of the sequence may still be retrying while later chunks succeed. The watermark task
+        // must initialize its baseline from DB — not from the first received `from` — so those
+        // later completions buffer until the gap is filled.
+        let mut watermark = default_watermark();
+        watermark.pruner_hi = 2;
+        let store = MockStore::new().with_watermark(DataPipeline::NAME, watermark);
+        let setup = setup_test(Some(PrunerConfig::default()), store);
+
+        setup.tx.send((5, 10)).await.unwrap();
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert_eq!(
+            setup.store.watermark(DataPipeline::NAME).unwrap().pruner_hi,
+            2,
+            "Leading gap [2, 5) should block advancement"
+        );
+
+        setup.tx.send((2, 5)).await.unwrap();
+        wait_for_pruner_hi(&setup.store, 10, Duration::from_secs(1)).await;
+    }
+
+    #[tokio::test]
+    async fn test_missing_watermark_row_defaults_baseline_to_zero() {
+        // If the pipeline is initialized but has not yet indexed any checkpoints,
+        // `pruner_watermark` returns `Ok(None)` and the task starts from 0.
+        let mut watermark = default_watermark();
+        watermark.checkpoint_hi_inclusive = None;
+        let store = MockStore::new().with_watermark(DataPipeline::NAME, watermark);
+        let setup = setup_test(Some(PrunerConfig::default()), store);
+
+        setup.tx.send((0, 5)).await.unwrap();
+        wait_for_pruner_hi(&setup.store, 5, Duration::from_secs(1)).await;
+    }
+
+    #[tokio::test]
+    async fn test_channel_close_shutdown() {
+        let store = MockStore::new().with_watermark(DataPipeline::NAME, default_watermark());
+        let setup = setup_test(Some(PrunerConfig::default()), store);
+
+        setup.tx.send((0, 5)).await.unwrap();
+        wait_for_pruner_hi(&setup.store, 5, Duration::from_secs(1)).await;
+
+        drop(setup.tx);
+        // The task must terminate cleanly once the channel is closed.
+        setup.service.shutdown().await.unwrap();
+    }
+}

--- a/crates/sui-indexer-alt-framework/src/pipeline/concurrent/pruner.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/concurrent/pruner.rs
@@ -8,6 +8,7 @@ use futures::StreamExt;
 use futures::stream::FuturesUnordered;
 use sui_futures::service::Service;
 use tokio::sync::Semaphore;
+use tokio::sync::mpsc;
 use tokio::time::MissedTickBehavior;
 use tokio::time::interval;
 use tracing::debug;
@@ -18,8 +19,6 @@ use tracing::warn;
 use crate::metrics::IndexerMetrics;
 use crate::pipeline::concurrent::Handler;
 use crate::pipeline::concurrent::PrunerConfig;
-use crate::pipeline::logging::LoggerWatermark;
-use crate::pipeline::logging::WatermarkLogger;
 use crate::store::ConcurrentConnection;
 use crate::store::Store;
 
@@ -65,19 +64,6 @@ impl PendingRanges {
     fn remove(&mut self, from: &u64) {
         self.ranges.remove(from).unwrap();
     }
-
-    /// Returns the current pruner_hi watermark, i.e. the first checkpoint that has not yet been pruned.
-    /// This will be the first key in the pending_prune_ranges map.
-    /// If the map is empty, then it is the last checkpoint that has been scheduled for pruning.
-    fn get_pruner_hi(&self) -> u64 {
-        self.ranges.keys().next().cloned().unwrap_or(
-            self.last_scheduled_range
-                .map(|(_, t)| t)
-                // get_pruner_hi will generally not be called until we have scheduled something.
-                // But return 0 just in case we called it earlier.
-                .unwrap_or_default(),
-        )
-    }
 }
 
 /// The pruner task is responsible for deleting old data from the database. It will periodically
@@ -91,14 +77,15 @@ impl PendingRanges {
 /// The task will not prune data until at least `config.delay()` has passed since `pruner_timestamp`
 /// to give in-flight reads time to land.
 ///
-/// The task regularly traces its progress, outputting at a higher log level every
-/// [LOUD_WATERMARK_UPDATE_INTERVAL]-many checkpoints.
+/// After each chunk is successfully pruned, the range is forwarded on `tx` to the
+/// [super::prune_watermark] task, which is responsible for advancing `pruner_hi` in the database.
 ///
 /// If the `config` is `None`, the task will shutdown immediately.
 pub(super) fn pruner<H: Handler>(
     handler: Arc<H>,
     config: Option<PrunerConfig>,
     store: H::Store,
+    tx: mpsc::Sender<(u64, u64)>,
     metrics: Arc<IndexerMetrics>,
 ) -> Service {
     Service::new().spawn_aborting(async move {
@@ -117,10 +104,6 @@ pub(super) fn pruner<H: Handler>(
         // compressed to make up for missed ticks.
         let mut poll = interval(config.interval());
         poll.set_missed_tick_behavior(MissedTickBehavior::Delay);
-
-        // The pruner task will periodically output a log message at a higher log level to
-        // demonstrate that it is making progress.
-        let mut logger = WatermarkLogger::new("pruner");
 
         // Maintains the list of chunks that are ready to be pruned but not yet pruned.
         // This map can contain ranges that were attempted to be pruned in previous iterations,
@@ -171,12 +154,6 @@ pub(super) fn pruner<H: Handler>(
                 tokio::time::sleep(wait_for).await;
             }
 
-            // Tracks the current highest `pruner_hi` not yet written to db. This is updated as
-            // chunks complete.
-            let mut highest_pruned = watermark.pruner_hi;
-            // Tracks the `pruner_hi` that has been written to the db.
-            let mut highest_watermarked = watermark.pruner_hi;
-
             // (3) Collect all the new chunks that are ready to be pruned.
             // This will also advance the watermark.
             while let Some((from, to_exclusive)) = watermark.next_chunk(config.max_chunk_size) {
@@ -189,7 +166,7 @@ pub(super) fn pruner<H: Handler>(
                 pending_prune_ranges.len()
             );
 
-            // (3) Prune chunk by chunk to avoid the task waiting on a long-running database
+            // (4) Prune chunk by chunk to avoid the task waiting on a long-running database
             // transaction, between tests for cancellation.
             // Spawn all tasks in parallel, but limit the number of concurrent tasks.
             let semaphore = Arc::new(Semaphore::new(config.prune_concurrency as usize));
@@ -208,69 +185,25 @@ pub(super) fn pruner<H: Handler>(
                 }));
             }
 
-            // (4) Wait for all tasks to finish. For each task, if it succeeds, remove the range
-            // from the pending_prune_ranges. Otherwise the range will remain in the map and will be
-            // retried in the next iteration. Update the highest_pruned watermark if the task
-            // succeeds in metrics and in db, to minimize redundant pruner work if the pipeline is
-            // restarted.
+            // (5) Wait for all tasks to finish. For each task, if it succeeds, remove the range
+            // from the pending_prune_ranges and forward it to the prune_watermark task.
+            // Otherwise the range will remain in the map and will be retried in the next
+            // iteration.
             while let Some(r) = tasks.next().await {
                 let ((from, to_exclusive), result) = r.unwrap();
                 match result {
                     Ok(()) => {
                         pending_prune_ranges.remove(&from);
-                        let pruner_hi = pending_prune_ranges.get_pruner_hi();
-                        highest_pruned = highest_pruned.max(pruner_hi);
+                        if tx.send((from, to_exclusive)).await.is_err() {
+                            info!(pipeline = H::NAME, "Prune watermark channel closed");
+                            return Ok(());
+                        }
                     }
                     Err(e) => {
                         error!(
                             pipeline = H::NAME,
                             "Failed to prune data for range: {from} to {to_exclusive}: {e}"
                         );
-                    }
-                }
-
-                if highest_pruned > highest_watermarked {
-                    metrics
-                        .watermark_pruner_hi
-                        .with_label_values(&[H::NAME])
-                        .set(highest_pruned as i64);
-
-                    let guard = metrics
-                        .watermark_pruner_write_latency
-                        .with_label_values(&[H::NAME])
-                        .start_timer();
-
-                    let Ok(mut conn) = store.connect().await else {
-                        warn!(
-                            pipeline = H::NAME,
-                            "Pruner failed to connect while updating watermark"
-                        );
-                        continue;
-                    };
-
-                    match conn.set_pruner_watermark(H::NAME, highest_pruned).await {
-                        Err(e) => {
-                            let elapsed = guard.stop_and_record();
-                            error!(
-                                pipeline = H::NAME,
-                                elapsed_ms = elapsed * 1000.0,
-                                "Failed to update pruner watermark: {e}"
-                            )
-                        }
-                        Ok(true) => {
-                            highest_watermarked = highest_pruned;
-                            let elapsed = guard.stop_and_record();
-                            logger.log::<H>(
-                                LoggerWatermark::checkpoint(highest_watermarked),
-                                elapsed,
-                            );
-
-                            metrics
-                                .watermark_pruner_hi_in_db
-                                .with_label_values(&[H::NAME])
-                                .set(highest_watermarked as i64);
-                        }
-                        Ok(false) => {}
                     }
                 }
             }
@@ -334,6 +267,7 @@ mod tests {
     use async_trait::async_trait;
     use prometheus::Registry;
     use sui_types::full_checkpoint_content::Checkpoint;
+    use tokio::sync::mpsc;
     use tokio::time::Duration;
 
     use crate::FieldCount;
@@ -341,8 +275,27 @@ mod tests {
     use crate::mocks::store::*;
     use crate::pipeline::Processor;
     use crate::pipeline::concurrent::BatchStatus;
+    use crate::pipeline::concurrent::prune_watermark::prune_watermark;
 
     use super::*;
+
+    fn spawn_pruner_stack(
+        handler: Arc<DataPipeline>,
+        config: PrunerConfig,
+        store: MockStore,
+        metrics: Arc<IndexerMetrics>,
+    ) -> (Service, Service) {
+        let (tx, rx) = mpsc::channel(16);
+        let s_pruner = pruner(
+            handler,
+            Some(config.clone()),
+            store.clone(),
+            tx,
+            metrics.clone(),
+        );
+        let s_prune_watermark = prune_watermark::<DataPipeline>(Some(config), rx, store, metrics);
+        (s_pruner, s_prune_watermark)
+    }
 
     #[derive(Clone, FieldCount)]
     pub struct StoredData;
@@ -458,60 +411,6 @@ mod tests {
         assert_eq!(scheduled, vec![(1, 5), (5, 10)]);
     }
 
-    #[test]
-    fn test_pending_ranges_remove_and_watermark() {
-        let mut ranges = PendingRanges::default();
-
-        // Schedule multiple ranges
-        ranges.schedule(1, 5);
-        ranges.schedule(10, 15);
-        ranges.schedule(20, 25);
-        assert_eq!(ranges.len(), 3);
-        assert_eq!(ranges.get_pruner_hi(), 1);
-
-        // Remove first range - watermark should advance
-        ranges.remove(&1);
-        assert_eq!(ranges.len(), 2);
-        assert_eq!(ranges.get_pruner_hi(), 10); // Next range starts at 10
-
-        // Remove middle range
-        ranges.remove(&10);
-        assert_eq!(ranges.len(), 1);
-        assert_eq!(ranges.get_pruner_hi(), 20);
-
-        // Remove last range - watermark should use last_scheduled_range
-        ranges.remove(&20);
-        assert_eq!(ranges.len(), 0);
-        assert_eq!(ranges.get_pruner_hi(), 25); // End of last scheduled range
-    }
-
-    #[test]
-    fn test_pending_ranges_remove_and_watermark_out_of_order() {
-        let mut ranges = PendingRanges::default();
-
-        // Schedule multiple ranges
-        ranges.schedule(1, 5);
-        ranges.schedule(10, 15);
-        ranges.schedule(20, 25);
-        assert_eq!(ranges.len(), 3);
-        assert_eq!(ranges.get_pruner_hi(), 1);
-
-        // Remove middle range
-        ranges.remove(&10);
-        assert_eq!(ranges.len(), 2);
-        assert_eq!(ranges.get_pruner_hi(), 1);
-
-        // Remove first range
-        ranges.remove(&1);
-        assert_eq!(ranges.len(), 1);
-        assert_eq!(ranges.get_pruner_hi(), 20);
-
-        // Remove last range - watermark should use last_scheduled_range
-        ranges.remove(&20);
-        assert_eq!(ranges.len(), 0);
-        assert_eq!(ranges.get_pruner_hi(), 25); // End of last scheduled range
-    }
-
     #[tokio::test]
     async fn test_pruner() {
         let handler = Arc::new(DataPipeline);
@@ -547,9 +446,8 @@ mod tests {
             .with_watermark(DataPipeline::NAME, watermark)
             .with_data(DataPipeline::NAME, test_data);
 
-        // Start the pruner
-        let store_clone = store.clone();
-        let _pruner = pruner(handler, Some(pruner_config), store_clone, metrics);
+        // Start the pruner + prune_watermark stack
+        let _services = spawn_pruner_stack(handler, pruner_config, store.clone(), metrics);
 
         // Wait a short time within delay_ms
         tokio::time::sleep(Duration::from_millis(200)).await;
@@ -627,9 +525,8 @@ mod tests {
             .with_watermark(DataPipeline::NAME, watermark)
             .with_data(DataPipeline::NAME, test_data);
 
-        // Start the pruner
-        let store_clone = store.clone();
-        let _pruner = pruner(handler, Some(pruner_config), store_clone, metrics);
+        // Start the pruner + prune_watermark stack
+        let _services = spawn_pruner_stack(handler, pruner_config, store.clone(), metrics);
 
         // Because the `pruner_timestamp` is in the past, even with the delay_ms it should be pruned
         // close to immediately. To be safe, sleep for 1000ms before checking, which is well under
@@ -697,9 +594,8 @@ mod tests {
             .with_data(DataPipeline::NAME, test_data.clone())
             .with_prune_failures(1, 2, 1);
 
-        // Start the pruner
-        let store_clone = store.clone();
-        let _pruner = pruner(handler, Some(pruner_config), store_clone, metrics);
+        // Start the pruner + prune_watermark stack
+        let _services = spawn_pruner_stack(handler, pruner_config, store.clone(), metrics);
 
         // Wait for first pruning cycle - ranges [2,3) and [3,4) should succeed, [1,2) should fail
         tokio::time::sleep(Duration::from_millis(500)).await;

--- a/crates/sui-indexer-alt/src/config.rs
+++ b/crates/sui-indexer-alt/src/config.rs
@@ -82,6 +82,7 @@ pub struct ConcurrentLayer {
     pub processor_channel_size: Option<usize>,
     pub collector_channel_size: Option<usize>,
     pub committer_channel_size: Option<usize>,
+    pub pruner_channel_size: Option<usize>,
 }
 
 #[DefaultConfig]
@@ -237,6 +238,7 @@ impl ConcurrentLayer {
             processor_channel_size: self.processor_channel_size.or(base.processor_channel_size),
             collector_channel_size: self.collector_channel_size.or(base.collector_channel_size),
             committer_channel_size: self.committer_channel_size.or(base.committer_channel_size),
+            pruner_channel_size: self.pruner_channel_size.or(base.pruner_channel_size),
         })
     }
 }
@@ -354,6 +356,7 @@ impl Merge for ConcurrentLayer {
             processor_channel_size: other.processor_channel_size.or(self.processor_channel_size),
             collector_channel_size: other.collector_channel_size.or(self.collector_channel_size),
             committer_channel_size: other.committer_channel_size.or(self.committer_channel_size),
+            pruner_channel_size: other.pruner_channel_size.or(self.pruner_channel_size),
         })
     }
 }
@@ -465,6 +468,7 @@ impl From<ConcurrentConfig> for ConcurrentLayer {
             processor_channel_size: config.processor_channel_size,
             collector_channel_size: config.collector_channel_size,
             committer_channel_size: config.committer_channel_size,
+            pruner_channel_size: config.pruner_channel_size,
         }
     }
 }

--- a/crates/sui-kvstore/src/config.rs
+++ b/crates/sui-kvstore/src/config.rs
@@ -138,6 +138,7 @@ pub struct ConcurrentLayer {
     pub processor_channel_size: Option<usize>,
     pub collector_channel_size: Option<usize>,
     pub committer_channel_size: Option<usize>,
+    pub pruner_channel_size: Option<usize>,
 }
 
 impl ConcurrentLayer {
@@ -156,6 +157,7 @@ impl ConcurrentLayer {
             processor_channel_size: self.processor_channel_size.or(base.processor_channel_size),
             collector_channel_size: self.collector_channel_size.or(base.collector_channel_size),
             committer_channel_size: self.committer_channel_size.or(base.committer_channel_size),
+            pruner_channel_size: self.pruner_channel_size.or(base.pruner_channel_size),
         }
     }
 }


### PR DESCRIPTION
## Description 

This change splits the concurrent pruner into two tokio tasks to mirror the existing committer + commit_watermark pattern: one task distributes work, a second task owns DB watermark persistence.

## Test plan 

New unit tests.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [x] Indexing Framework: Added new `PrunerConfig::pruner_channel_size`.
