### PR TITLE
docker/sui-services: build sui-metric-checker

### DIFF
--- a/docker/sui-services/Dockerfile
+++ b/docker/sui-services/Dockerfile
@@ -13,7 +13,8 @@ COPY crates crates
 COPY sui-execution sui-execution
 COPY external-crates external-crates
 RUN cargo build --release \
-    --bin sui-oracle
+    --bin sui-oracle \
+    --bin sui-metric-checker
 RUN mkdir /sui/bin/
 RUN find /sui/target/release/ -maxdepth 1 -type f -executable -print 
 RUN find /sui/target/release/ -maxdepth 1 -type f -executable -print | xargs cp -t /sui/bin/


### PR DESCRIPTION
## Summary

Adds `--bin sui-metric-checker` to `docker/sui-services/Dockerfile` so the binary ends up at `/usr/local/bin/sui-metric-checker` in the final image.

## Why

`sui-metric-checker` is consumed by [`MystenLabs/sui-operations/.github/workflows/private-testnet-perf-regression-check.yml`](https://github.com/MystenLabs/sui-operations/blob/main/.github/workflows/private-testnet-perf-regression-check.yml) via `s3://sui-releases/<sui_commit>/sui-metric-checker`. Today that artifact is only produced by the legacy `sui-release-binaries.yml` workflow in sui-operations (which runs an unscoped `cargo build --release` on a GHA runner and happens to leave `sui-metric-checker` in `target/release/`).

On the sui-operations side we've rolled out an mp3 binary-extraction pipeline that pulls binaries out of the sui Docker images we already build and publishes them to the same S3 URLs. This change unblocks adding `sui-metric-checker` to that extraction config, moving us one step closer to retiring the classic `sui-release-binaries.yml` workflow.

## How it flows

- `cargo build --release --bin sui-oracle --bin sui-metric-checker` produces both binaries in `target/release/`
- Existing `find /sui/target/release/ -maxdepth 1 -type f -executable | xargs cp -t /sui/bin/` pattern already bulk-copies everything executable to `/sui/bin/`, then to `/usr/local/bin/` in the runtime stage — no further Dockerfile change needed
- mp3's `BINARY_UPLOAD_CONFIG` in sui-operations will add a rule keyed `"MystenLabs/sui:sui-services"` with path `/usr/local/bin/sui-metric-checker` in a follow-up PR

## Test plan

- [x] `crates/sui-metric-checker/src/main.rs` exists → binary target is valid
- [x] Crate is listed in workspace `members`
- [ ] CI build of `sui-services` image succeeds
- [ ] Follow-up sui-operations PR adds the mp3 extraction rule and verifies upload to `s3://sui-releases/<sha>/sui-metric-checker`

🤖 Generated with [Claude Code](https://claude.com/claude-code)