### PR TITLE
Avoid direct disk write of RejectUserCerts in consensus handler

### DIFF
--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -3117,21 +3117,6 @@ impl AuthorityPerEpochStore {
         }
     }
 
-    /// Record epoch close for the timestamp-based epoch transition path.
-    /// Sets epoch_close_time for metrics and fires user_certs_closed_notify
-    /// (needed by consensus adapter for submit delay cancellation).
-    /// Does NOT modify reconfig_state — that is handled by the consensus handler directly.
-    pub fn record_epoch_close_for_timestamp_based_transition(&self) {
-        let mut epoch_close_time = self.epoch_close_time.write();
-        if epoch_close_time.is_none() {
-            *epoch_close_time = Some(Instant::now());
-
-            self.user_certs_closed_notify
-                .notify()
-                .expect("user_certs_closed_notify called twice on same epoch store");
-        }
-    }
-
     pub async fn user_certs_closed_notify(&self) {
         self.user_certs_closed_notify.wait().await
     }

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -3100,21 +3100,31 @@ impl AuthorityPerEpochStore {
         self.reconfig_state_mem.write()
     }
 
-    pub fn close_user_certs(&self, mut lock_guard: RwLockWriteGuard<'_, ReconfigState>) {
-        lock_guard.close_user_certs();
-        self.store_reconfig_state(&lock_guard)
-            .expect("Updating reconfig state cannot fail");
-
-        // Set epoch_close_time for metric purpose.
+    fn record_epoch_close_time(&self) {
         let mut epoch_close_time = self.epoch_close_time.write();
         if epoch_close_time.is_none() {
-            // Only update it the first time epoch is closed.
             *epoch_close_time = Some(Instant::now());
-
             self.user_certs_closed_notify
                 .notify()
                 .expect("user_certs_closed_notify called twice on same epoch store");
         }
+    }
+
+    /// Transition to RejectUserCerts with immediate disk persistence.
+    /// Used by consensus_adapter::close_epoch() where there is no commit batch.
+    pub fn close_user_certs(&self, mut lock_guard: RwLockWriteGuard<'_, ReconfigState>) {
+        lock_guard.close_user_certs();
+        self.store_reconfig_state(&lock_guard)
+            .expect("Updating reconfig state cannot fail");
+        self.record_epoch_close_time();
+    }
+
+    /// Transition to RejectUserCerts WITHOUT persisting to disk.
+    /// Used by the consensus handler where persistence happens through the commit batch
+    /// (via advance_eop_state_machine -> state.output.store_reconfig_state).
+    pub fn close_user_certs_for_commit(&self, mut lock_guard: RwLockWriteGuard<'_, ReconfigState>) {
+        lock_guard.close_user_certs();
+        self.record_epoch_close_time();
     }
 
     pub async fn user_certs_closed_notify(&self) {

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -1404,6 +1404,14 @@ impl AuthorityPerEpochStore {
         self.epoch_start_configuration.epoch_start_state()
     }
 
+    pub fn next_reconfiguration_timestamp_ms(&self) -> u64 {
+        let epoch_start_state = self.epoch_start_state();
+        epoch_start_state
+            .epoch_start_timestamp_ms()
+            .checked_add(epoch_start_state.epoch_duration_ms())
+            .expect("Overflow calculating next_reconfiguration_timestamp_ms")
+    }
+
     pub fn previous_epoch_last_checkpoint(&self) -> CheckpointSequenceNumber {
         self.previous_epoch_last_checkpoint
     }
@@ -3101,6 +3109,21 @@ impl AuthorityPerEpochStore {
         let mut epoch_close_time = self.epoch_close_time.write();
         if epoch_close_time.is_none() {
             // Only update it the first time epoch is closed.
+            *epoch_close_time = Some(Instant::now());
+
+            self.user_certs_closed_notify
+                .notify()
+                .expect("user_certs_closed_notify called twice on same epoch store");
+        }
+    }
+
+    /// Record epoch close for the timestamp-based epoch transition path.
+    /// Sets epoch_close_time for metrics and fires user_certs_closed_notify
+    /// (needed by consensus adapter for submit delay cancellation).
+    /// Does NOT modify reconfig_state — that is handled by the consensus handler directly.
+    pub fn record_epoch_close_for_timestamp_based_transition(&self) {
+        let mut epoch_close_time = self.epoch_close_time.write();
+        if epoch_close_time.is_none() {
             *epoch_close_time = Some(Instant::now());
 
             self.user_certs_closed_notify

--- a/crates/sui-core/src/checkpoints/checkpoint_output.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_output.rs
@@ -128,7 +128,9 @@ impl<T: SubmitToConsensus + ReconfigurationInitiator> CheckpointOutput
                 .set(checkpoint_seq as i64);
         }
 
-        if checkpoint_timestamp >= self.next_reconfiguration_timestamp_ms {
+        if checkpoint_timestamp >= self.next_reconfiguration_timestamp_ms
+            && !epoch_store.protocol_config().timestamp_based_epoch_close()
+        {
             // close_epoch is ok if called multiple times
             info!(
                 "Closing epoch at sequence {checkpoint_seq} at timestamp {checkpoint_timestamp}. next_reconfiguration_timestamp_ms {}",

--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -343,14 +343,10 @@ impl ConsensusAdapter {
         self.num_inflight_transactions.load(Ordering::Relaxed)
     }
 
-    pub fn submit_recovered(self: &Arc<Self>, epoch_store: &Arc<AuthorityPerEpochStore>) {
-        // Send EndOfPublish if needed.
+    pub fn recover_end_of_publish(self: &Arc<Self>, epoch_store: &Arc<AuthorityPerEpochStore>) {
         // This handles the case where the node crashed after setting reconfig lock state
         // but before the EndOfPublish message was sent to consensus.
-        // Skip when timestamp_based_epoch_close is enabled (epoch close is timestamp-driven).
-        if epoch_store.should_send_end_of_publish()
-            && !epoch_store.protocol_config().timestamp_based_epoch_close()
-        {
+        if epoch_store.should_send_end_of_publish() {
             let transaction = ConsensusTransaction::new_end_of_publish(self.authority);
             info!(epoch=?epoch_store.epoch(), "Submitting EndOfPublish message to consensus");
             self.submit_unchecked(&[transaction], epoch_store, None, None);

--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -348,8 +348,8 @@ impl ConsensusAdapter {
         // This handles the case where the node crashed after setting reconfig lock state
         // but before the EndOfPublish message was sent to consensus.
         // Skip when timestamp_based_epoch_close is enabled (epoch close is timestamp-driven).
-        if !epoch_store.protocol_config().timestamp_based_epoch_close()
-            && epoch_store.should_send_end_of_publish()
+        if epoch_store.should_send_end_of_publish()
+            && !epoch_store.protocol_config().timestamp_based_epoch_close()
         {
             let transaction = ConsensusTransaction::new_end_of_publish(self.authority);
             info!(epoch=?epoch_store.epoch(), "Submitting EndOfPublish message to consensus");
@@ -981,8 +981,8 @@ impl ConsensusAdapter {
                     | ConsensusTransactionKind::UserTransactionV2(_)
             );
         if is_user_tx
-            && !epoch_store.protocol_config().timestamp_based_epoch_close()
             && epoch_store.should_send_end_of_publish()
+            && !epoch_store.protocol_config().timestamp_based_epoch_close()
         {
             // sending message outside of any locks scope
             if let Err(err) = self.submit(
@@ -1218,11 +1218,6 @@ impl ReconfigurationInitiator for Arc<ConsensusAdapter> {
     /// It sets reconfig state to reject new certificates from user.
     /// ConsensusAdapter will send EndOfPublish message once pending certificate queue is drained.
     fn close_epoch(&self, epoch_store: &Arc<AuthorityPerEpochStore>) {
-        if epoch_store.protocol_config().timestamp_based_epoch_close() {
-            // With timestamp-based epoch close, the consensus handler handles the
-            // transition directly. No need to send EndOfPublish automatically.
-            return;
-        }
         {
             let reconfig_guard = epoch_store.get_reconfig_state_write_lock_guard();
             if !reconfig_guard.should_accept_user_certs() {

--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -347,7 +347,10 @@ impl ConsensusAdapter {
         // Send EndOfPublish if needed.
         // This handles the case where the node crashed after setting reconfig lock state
         // but before the EndOfPublish message was sent to consensus.
-        if epoch_store.should_send_end_of_publish() {
+        // Skip when timestamp_based_epoch_close is enabled (epoch close is timestamp-driven).
+        if !epoch_store.protocol_config().timestamp_based_epoch_close()
+            && epoch_store.should_send_end_of_publish()
+        {
             let transaction = ConsensusTransaction::new_end_of_publish(self.authority);
             info!(epoch=?epoch_store.epoch(), "Submitting EndOfPublish message to consensus");
             self.submit_unchecked(&[transaction], epoch_store, None, None);
@@ -977,7 +980,10 @@ impl ConsensusAdapter {
                     | ConsensusTransactionKind::UserTransaction(_)
                     | ConsensusTransactionKind::UserTransactionV2(_)
             );
-        if is_user_tx && epoch_store.should_send_end_of_publish() {
+        if is_user_tx
+            && !epoch_store.protocol_config().timestamp_based_epoch_close()
+            && epoch_store.should_send_end_of_publish()
+        {
             // sending message outside of any locks scope
             if let Err(err) = self.submit(
                 ConsensusTransaction::new_end_of_publish(self.authority),
@@ -1212,6 +1218,11 @@ impl ReconfigurationInitiator for Arc<ConsensusAdapter> {
     /// It sets reconfig state to reject new certificates from user.
     /// ConsensusAdapter will send EndOfPublish message once pending certificate queue is drained.
     fn close_epoch(&self, epoch_store: &Arc<AuthorityPerEpochStore>) {
+        if epoch_store.protocol_config().timestamp_based_epoch_close() {
+            // With timestamp-based epoch close, the consensus handler handles the
+            // transition directly. No need to send EndOfPublish automatically.
+            return;
+        }
         {
             let reconfig_guard = epoch_store.get_reconfig_state_write_lock_guard();
             if !reconfig_guard.should_accept_user_certs() {

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -1447,7 +1447,7 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
             // close_user_certs() is only needed here when timestamp_based_epoch_close is enabled.
             let reconfig_guard = self.epoch_store.get_reconfig_state_write_lock_guard();
             if reconfig_guard.should_accept_user_certs() {
-                self.epoch_store.close_user_certs(reconfig_guard);
+                self.epoch_store.close_user_certs_for_commit(reconfig_guard);
             }
         }
         let collected_eop_quorum =

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -1256,8 +1256,15 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
                     user_transactions,
                 );
 
-            let (should_accept_tx, lock, final_round) =
-                self.handle_eop(&mut state, end_of_publish_transactions);
+            let (should_accept_tx, lock, final_round) = if self
+                .epoch_store
+                .protocol_config()
+                .timestamp_based_epoch_close()
+            {
+                self.handle_epoch_close(&mut state, &commit_info, end_of_publish_transactions)
+            } else {
+                self.handle_eop(&mut state, end_of_publish_transactions)
+            };
 
             let make_checkpoint = should_accept_tx || final_round;
             if !make_checkpoint {
@@ -1310,8 +1317,15 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
                 user_transactions,
             );
 
-            let (should_accept_tx, lock, final_round) =
-                self.handle_eop(&mut state, end_of_publish_transactions);
+            let (should_accept_tx, lock, final_round) = if self
+                .epoch_store
+                .protocol_config()
+                .timestamp_based_epoch_close()
+            {
+                self.handle_epoch_close(&mut state, &commit_info, end_of_publish_transactions)
+            } else {
+                self.handle_eop(&mut state, end_of_publish_transactions)
+            };
 
             let make_checkpoint = should_accept_tx || final_round;
             if !make_checkpoint {
@@ -1435,6 +1449,75 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
         } else {
             (true, None, false)
         }
+    }
+
+    /// Timestamp-based epoch close: transitions to RejectAllCerts when consensus commit
+    /// timestamp exceeds reconfiguration timestamp. Also supports manual epoch close via
+    /// EndOfPublish quorum as a fallback.
+    fn handle_epoch_close(
+        &self,
+        state: &mut CommitHandlerState,
+        commit_info: &ConsensusCommitInfo,
+        end_of_publish_transactions: Vec<AuthorityName>,
+    ) -> (bool, Option<RwLockWriteGuard<'_, ReconfigState>>, bool) {
+        // Still process EndOfPublish transactions for manual epoch close support.
+        let collected_eop =
+            self.process_end_of_publish_transactions(state, end_of_publish_transactions);
+
+        let timestamp_triggered =
+            commit_info.timestamp >= self.epoch_store.next_reconfiguration_timestamp_ms();
+
+        let should_close = timestamp_triggered || collected_eop;
+
+        if !should_close {
+            return (true, None, false);
+        }
+
+        let mut reconfig_state = self.epoch_store.get_reconfig_state_write_lock_guard();
+        let start_state_is_reject_all_tx = reconfig_state.is_reject_all_tx();
+
+        if reconfig_state.should_accept_user_certs() {
+            // First time closing: transition directly to RejectAllCerts.
+            if timestamp_triggered {
+                info!(
+                    "Timestamp-based epoch close: commit timestamp {} >= reconfiguration timestamp {}",
+                    commit_info.timestamp,
+                    self.epoch_store.next_reconfiguration_timestamp_ms(),
+                );
+            }
+            if collected_eop {
+                info!("EndOfPublish quorum reached for manual epoch close");
+            }
+            self.epoch_store
+                .record_epoch_close_for_timestamp_based_transition();
+        }
+
+        reconfig_state.close_all_certs();
+
+        let commit_has_deferred_txns = state.output.has_deferred_transactions();
+        let previous_commits_have_deferred_txns = !self.epoch_store.deferred_transactions_empty();
+
+        if !commit_has_deferred_txns && !previous_commits_have_deferred_txns {
+            if !start_state_is_reject_all_tx {
+                info!("Transitioning to RejectAllTx");
+            }
+            reconfig_state.close_all_tx();
+        } else {
+            debug!(
+                "Blocking end of epoch on deferred transactions, from previous commits?={}, from this commit?={}",
+                previous_commits_have_deferred_txns, commit_has_deferred_txns,
+            );
+        }
+
+        state.output.store_reconfig_state(reconfig_state.clone());
+
+        let final_round = !start_state_is_reject_all_tx && reconfig_state.is_reject_all_tx();
+
+        (
+            reconfig_state.should_accept_tx(),
+            Some(reconfig_state),
+            final_round,
+        )
     }
 
     fn record_end_of_epoch_execution_time_observations(
@@ -2843,12 +2926,19 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
                     _ => {}
                 }
 
-                if matches!(
-                    &parsed.transaction.kind,
-                    ConsensusTransactionKind::UserTransaction(_)
-                        | ConsensusTransactionKind::UserTransactionV2(_)
-                        | ConsensusTransactionKind::CertifiedTransaction(_)
-                ) {
+                // When timestamp_based_epoch_close is enabled, validators don't
+                // automatically send EndOfPublish, so skip this filter.
+                if !self
+                    .epoch_store
+                    .protocol_config()
+                    .timestamp_based_epoch_close()
+                    && matches!(
+                        &parsed.transaction.kind,
+                        ConsensusTransactionKind::UserTransaction(_)
+                            | ConsensusTransactionKind::UserTransactionV2(_)
+                            | ConsensusTransactionKind::CertifiedTransaction(_)
+                    )
+                {
                     let author_name = self
                         .epoch_store
                         .committee()
@@ -3212,6 +3302,13 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
     }
 
     async fn send_end_of_publish_if_needed(&self) {
+        if self
+            .epoch_store
+            .protocol_config()
+            .timestamp_based_epoch_close()
+        {
+            return;
+        }
         if !self.epoch_store.should_send_end_of_publish() {
             return;
         }

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -1461,13 +1461,13 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
         end_of_publish_transactions: Vec<AuthorityName>,
     ) -> (bool, Option<RwLockWriteGuard<'_, ReconfigState>>, bool) {
         // Still process EndOfPublish transactions for manual epoch close support.
-        let collected_eop =
+        let collected_eop_quorum =
             self.process_end_of_publish_transactions(state, end_of_publish_transactions);
 
         let timestamp_triggered =
             commit_info.timestamp >= self.epoch_store.next_reconfiguration_timestamp_ms();
 
-        let should_close = timestamp_triggered || collected_eop;
+        let should_close = timestamp_triggered || collected_eop_quorum;
 
         if !should_close {
             return (true, None, false);
@@ -1484,7 +1484,7 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
                     self.epoch_store.next_reconfiguration_timestamp_ms(),
                 );
             }
-            if collected_eop {
+            if collected_eop_quorum {
                 info!("EndOfPublish quorum reached for manual epoch close");
             }
             reconfig_state.close_all_certs();

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -1477,7 +1477,6 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
         let start_state_is_reject_all_tx = reconfig_state.is_reject_all_tx();
 
         if reconfig_state.should_accept_user_certs() {
-            // First time closing: transition directly to RejectAllCerts.
             if timestamp_triggered {
                 info!(
                     "Timestamp-based epoch close: commit timestamp {} >= reconfiguration timestamp {}",
@@ -1488,11 +1487,10 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
             if collected_eop {
                 info!("EndOfPublish quorum reached for manual epoch close");
             }
+            reconfig_state.close_all_certs();
             self.epoch_store
                 .record_epoch_close_for_timestamp_based_transition();
         }
-
-        reconfig_state.close_all_certs();
 
         let commit_has_deferred_txns = state.output.has_deferred_transactions();
         let previous_commits_have_deferred_txns = !self.epoch_store.deferred_transactions_empty();

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -1178,15 +1178,28 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
             .with_label_values(&[&leader_author.to_string()])
             .inc();
 
+        let mut initial_reconfig_state = self
+            .epoch_store
+            .get_reconfig_state_read_lock_guard()
+            .clone();
+
+        // When timestamp-based epoch close is enabled, reject user transactions
+        // starting from the first commit whose timestamp crosses the threshold.
+        if self
+            .epoch_store
+            .protocol_config()
+            .timestamp_based_epoch_close()
+            && commit_info.timestamp >= self.epoch_store.next_reconfiguration_timestamp_ms()
+        {
+            initial_reconfig_state.close_all_certs();
+        }
+
         let mut state = CommitHandlerState {
             output: ConsensusCommitOutput::new(commit_info.round),
             dkg_failed: false,
             randomness_round: None,
             indirect_state_observer: Some(IndirectStateObserver::new()),
-            initial_reconfig_state: self
-                .epoch_store
-                .get_reconfig_state_read_lock_guard()
-                .clone(),
+            initial_reconfig_state,
             occurrence_counts: HashMap::new(),
         };
 

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -1256,7 +1256,7 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
                     user_transactions,
                 );
 
-            let (should_accept_tx, lock, final_round) = self.handle_eop(
+            let (should_accept_tx, lock, final_round) = self.handle_close_epoch(
                 &mut state,
                 self.epoch_store
                     .protocol_config()
@@ -1316,7 +1316,7 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
                 user_transactions,
             );
 
-            let (should_accept_tx, lock, final_round) = self.handle_eop(
+            let (should_accept_tx, lock, final_round) = self.handle_close_epoch(
                 &mut state,
                 self.epoch_store
                     .protocol_config()
@@ -1434,7 +1434,7 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
         self.send_end_of_publish_if_needed().await;
     }
 
-    fn handle_eop(
+    fn handle_close_epoch(
         &self,
         state: &mut CommitHandlerState,
         timestamp_based_epoch_close: bool,

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -1178,28 +1178,15 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
             .with_label_values(&[&leader_author.to_string()])
             .inc();
 
-        let mut initial_reconfig_state = self
-            .epoch_store
-            .get_reconfig_state_read_lock_guard()
-            .clone();
-
-        // When timestamp-based epoch close is enabled, reject user transactions
-        // starting from the first commit whose timestamp crosses the threshold.
-        if self
-            .epoch_store
-            .protocol_config()
-            .timestamp_based_epoch_close()
-            && commit_info.timestamp >= self.epoch_store.next_reconfiguration_timestamp_ms()
-        {
-            initial_reconfig_state.close_all_certs();
-        }
-
         let mut state = CommitHandlerState {
             output: ConsensusCommitOutput::new(commit_info.round),
             dkg_failed: false,
             randomness_round: None,
             indirect_state_observer: Some(IndirectStateObserver::new()),
-            initial_reconfig_state,
+            initial_reconfig_state: self
+                .epoch_store
+                .get_reconfig_state_read_lock_guard()
+                .clone(),
             occurrence_counts: HashMap::new(),
         };
 
@@ -1269,15 +1256,14 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
                     user_transactions,
                 );
 
-            let (should_accept_tx, lock, final_round) = if self
-                .epoch_store
-                .protocol_config()
-                .timestamp_based_epoch_close()
-            {
-                self.handle_epoch_close(&mut state, &commit_info, end_of_publish_transactions)
-            } else {
-                self.handle_eop(&mut state, end_of_publish_transactions)
-            };
+            let (should_accept_tx, lock, final_round) = self.handle_eop(
+                &mut state,
+                self.epoch_store
+                    .protocol_config()
+                    .timestamp_based_epoch_close(),
+                &commit_info,
+                end_of_publish_transactions,
+            );
 
             let make_checkpoint = should_accept_tx || final_round;
             if !make_checkpoint {
@@ -1330,15 +1316,14 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
                 user_transactions,
             );
 
-            let (should_accept_tx, lock, final_round) = if self
-                .epoch_store
-                .protocol_config()
-                .timestamp_based_epoch_close()
-            {
-                self.handle_epoch_close(&mut state, &commit_info, end_of_publish_transactions)
-            } else {
-                self.handle_eop(&mut state, end_of_publish_transactions)
-            };
+            let (should_accept_tx, lock, final_round) = self.handle_eop(
+                &mut state,
+                self.epoch_store
+                    .protocol_config()
+                    .timestamp_based_epoch_close(),
+                &commit_info,
+                end_of_publish_transactions,
+            );
 
             let make_checkpoint = should_accept_tx || final_round;
             if !make_checkpoint {
@@ -1452,83 +1437,27 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
     fn handle_eop(
         &self,
         state: &mut CommitHandlerState,
+        timestamp_based_epoch_close: bool,
+        commit_info: &ConsensusCommitInfo,
         end_of_publish_transactions: Vec<AuthorityName>,
     ) -> (bool, Option<RwLockWriteGuard<'_, ReconfigState>>, bool) {
-        let collected_eop =
+        let timestamp_triggered = timestamp_based_epoch_close
+            && commit_info.timestamp >= self.epoch_store.next_reconfiguration_timestamp_ms();
+        if timestamp_triggered {
+            // close_user_certs() is only needed here when timestamp_based_epoch_close is enabled.
+            let reconfig_guard = self.epoch_store.get_reconfig_state_write_lock_guard();
+            if reconfig_guard.should_accept_user_certs() {
+                self.epoch_store.close_user_certs(reconfig_guard);
+            }
+        }
+        let collected_eop_quorum =
             self.process_end_of_publish_transactions(state, end_of_publish_transactions);
-        if collected_eop {
+        if timestamp_triggered || collected_eop_quorum {
             let (lock, final_round) = self.advance_eop_state_machine(state);
             (lock.should_accept_tx(), Some(lock), final_round)
         } else {
             (true, None, false)
         }
-    }
-
-    /// Timestamp-based epoch close: transitions to RejectAllCerts when consensus commit
-    /// timestamp exceeds reconfiguration timestamp. Also supports manual epoch close via
-    /// EndOfPublish quorum as a fallback.
-    fn handle_epoch_close(
-        &self,
-        state: &mut CommitHandlerState,
-        commit_info: &ConsensusCommitInfo,
-        end_of_publish_transactions: Vec<AuthorityName>,
-    ) -> (bool, Option<RwLockWriteGuard<'_, ReconfigState>>, bool) {
-        // Still process EndOfPublish transactions for manual epoch close support.
-        let collected_eop_quorum =
-            self.process_end_of_publish_transactions(state, end_of_publish_transactions);
-
-        let timestamp_triggered =
-            commit_info.timestamp >= self.epoch_store.next_reconfiguration_timestamp_ms();
-
-        let should_close = timestamp_triggered || collected_eop_quorum;
-
-        if !should_close {
-            return (true, None, false);
-        }
-
-        let mut reconfig_state = self.epoch_store.get_reconfig_state_write_lock_guard();
-        let start_state_is_reject_all_tx = reconfig_state.is_reject_all_tx();
-
-        if reconfig_state.should_accept_user_certs() {
-            if timestamp_triggered {
-                info!(
-                    "Timestamp-based epoch close: commit timestamp {} >= reconfiguration timestamp {}",
-                    commit_info.timestamp,
-                    self.epoch_store.next_reconfiguration_timestamp_ms(),
-                );
-            }
-            if collected_eop_quorum {
-                info!("EndOfPublish quorum reached for manual epoch close");
-            }
-            reconfig_state.close_all_certs();
-            self.epoch_store
-                .record_epoch_close_for_timestamp_based_transition();
-        }
-
-        let commit_has_deferred_txns = state.output.has_deferred_transactions();
-        let previous_commits_have_deferred_txns = !self.epoch_store.deferred_transactions_empty();
-
-        if !commit_has_deferred_txns && !previous_commits_have_deferred_txns {
-            if !start_state_is_reject_all_tx {
-                info!("Transitioning to RejectAllTx");
-            }
-            reconfig_state.close_all_tx();
-        } else {
-            debug!(
-                "Blocking end of epoch on deferred transactions, from previous commits?={}, from this commit?={}",
-                previous_commits_have_deferred_txns, commit_has_deferred_txns,
-            );
-        }
-
-        state.output.store_reconfig_state(reconfig_state.clone());
-
-        let final_round = !start_state_is_reject_all_tx && reconfig_state.is_reject_all_tx();
-
-        (
-            reconfig_state.should_accept_tx(),
-            Some(reconfig_state),
-            final_round,
-        )
     }
 
     fn record_end_of_epoch_execution_time_observations(
@@ -2937,19 +2866,12 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
                     _ => {}
                 }
 
-                // When timestamp_based_epoch_close is enabled, validators don't
-                // automatically send EndOfPublish, so skip this filter.
-                if !self
-                    .epoch_store
-                    .protocol_config()
-                    .timestamp_based_epoch_close()
-                    && matches!(
-                        &parsed.transaction.kind,
-                        ConsensusTransactionKind::UserTransaction(_)
-                            | ConsensusTransactionKind::UserTransactionV2(_)
-                            | ConsensusTransactionKind::CertifiedTransaction(_)
-                    )
-                {
+                if matches!(
+                    &parsed.transaction.kind,
+                    ConsensusTransactionKind::UserTransaction(_)
+                        | ConsensusTransactionKind::UserTransactionV2(_)
+                        | ConsensusTransactionKind::CertifiedTransaction(_)
+                ) {
                     let author_name = self
                         .epoch_store
                         .committee()

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -886,7 +886,9 @@ impl SuiNode {
             )
             .await?;
 
-            components.consensus_adapter.submit_recovered(&epoch_store);
+            components
+                .consensus_adapter
+                .recover_end_of_publish(&epoch_store);
 
             // Start the gRPC server
             components.validator_server_handle = components.validator_server_handle.start().await;

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -1515,9 +1515,7 @@ impl SuiNode {
             sender: consensus_adapter,
             signer: state.secret.clone(),
             authority: config.protocol_public_key(),
-            next_reconfiguration_timestamp_ms: epoch_start_timestamp_ms
-                .checked_add(epoch_duration_ms)
-                .expect("Overflow calculating next_reconfiguration_timestamp_ms"),
+            next_reconfiguration_timestamp_ms: epoch_store.next_reconfiguration_timestamp_ms(),
             metrics: checkpoint_metrics.clone(),
         });
 

--- a/crates/sui-open-rpc/tests/snapshots/generate_spec__openrpc.snap.json
+++ b/crates/sui-open-rpc/tests/snapshots/generate_spec__openrpc.snap.json
@@ -1437,6 +1437,7 @@
                 "soft_bundle": false,
                 "split_checkpoints_in_consensus_handler": false,
                 "throughput_aware_consensus_submission": false,
+                "timestamp_based_epoch_close": false,
                 "txn_base_cost_as_multiplier": false,
                 "type_tags_in_object_runtime": false,
                 "uncompressed_g1_group_elements": false,

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -316,6 +316,7 @@ const TESTNET_USDC: &str =
 // Version 119: Enable the new VM.
 // Version 120: Disallow unused jump tables
 // Version 121: Re-enable defer_unpaid_amplification (devnet + testnet).
+// Version 121: Add timestamp_based_epoch_close feature flag.
 // Version 122: Framework update: vector::empty is deprecated.
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
@@ -1054,6 +1055,13 @@ struct FeatureFlags {
     // If true, return early on type mismatch in receive_object.
     #[serde(skip_serializing_if = "is_false")]
     early_return_receive_object_mismatched_type: bool,
+
+    // If true, use consensus commit timestamps to determine epoch close instead of EndOfPublish voting.
+    // Each validator transitions from AcceptAllCerts to RejectAllCerts when the consensus commit
+    // timestamp exceeds the reconfiguration timestamp. EndOfPublish quorum still works as a
+    // fallback for manual epoch close.
+    #[serde(skip_serializing_if = "is_false")]
+    timestamp_based_epoch_close: bool,
 }
 
 fn is_false(b: &bool) -> bool {
@@ -2749,6 +2757,10 @@ impl ProtocolConfig {
     pub fn early_return_receive_object_mismatched_type(&self) -> bool {
         self.feature_flags
             .early_return_receive_object_mismatched_type
+    }
+
+    pub fn timestamp_based_epoch_close(&self) -> bool {
+        self.feature_flags.timestamp_based_epoch_close
     }
 }
 
@@ -4799,6 +4811,9 @@ impl ProtocolConfig {
                     }
                     cfg.feature_flags
                         .early_return_receive_object_mismatched_type = true;
+                    if chain != Chain::Mainnet && chain != Chain::Testnet {
+                        cfg.feature_flags.timestamp_based_epoch_close = true;
+                    }
                 }
                 122 => {}
                 // Use this template when making changes:

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -316,7 +316,7 @@ const TESTNET_USDC: &str =
 // Version 119: Enable the new VM.
 // Version 120: Disallow unused jump tables
 // Version 121: Re-enable defer_unpaid_amplification (devnet + testnet).
-// Version 121: Add timestamp_based_epoch_close feature flag.
+//              Add timestamp_based_epoch_close feature flag.
 // Version 122: Framework update: vector::empty is deprecated.
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_1.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_1.snap
@@ -3,7 +3,9 @@ source: crates/sui-protocol-config/src/lib.rs
 expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
 ---
 version: 1
-feature_flags: {}
+feature_flags:
+  enable_coin_reservation_obj_refs: true
+  convert_withdrawal_compatibility_ptb_arguments: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_serialized_tx_effects_size_bytes: 524288
@@ -158,4 +160,4 @@ hash_keccak256_data_cost_per_block: 2
 hmac_hmac_sha3_256_cost_base: 52
 hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
-
+execution_version: 4

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_121.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_121.snap
@@ -166,6 +166,7 @@ feature_flags:
   enable_gasless: true
   disallow_jump_orphans: true
   early_return_receive_object_mismatched_type: true
+  timestamp_based_epoch_close: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_122.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_122.snap
@@ -166,6 +166,7 @@ feature_flags:
   enable_gasless: true
   disallow_jump_orphans: true
   early_return_receive_object_mismatched_type: true
+  timestamp_based_epoch_close: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000


### PR DESCRIPTION
## Summary

- Refactors `close_user_certs` so the consensus handler path (`handle_close_epoch`) transitions reconfig state in-memory only, without a direct disk write. Disk persistence happens through the commit batch via `advance_eop_state_machine` → `state.output.store_reconfig_state`.
- The consensus adapter's `close_epoch()` path retains its direct disk write (needed for `recover_end_of_publish` crash recovery).
- Extracts `record_epoch_close_time()` helper to avoid duplication.

## Motivation

In the timestamp-based epoch close path, `close_user_certs` writes `RejectUserCerts` directly to the `reconfig_state` DB column **outside** the atomic commit batch. If the validator crashes between this write and the batch flush, on restart the consensus handler loads `RejectUserCerts` into `initial_reconfig_state`. Today this is safe only because `should_accept_consensus_certs()` returns `true` for `RejectUserCerts`, so `filter_consensus_txns` still includes user txns — matching the first-run behavior. But this is a fragile invariant: any future change that gates filtering on `should_accept_user_certs` instead would silently introduce a fork-after-crash-recovery bug.

This PR eliminates the hazard by ensuring the consensus handler never writes reconfig state outside the commit batch.

## Test plan

- [x] `cargo check -p sui-core` passes
- [ ] Existing simtests covering epoch close (timestamp-based and EOP-quorum) should pass unchanged — no behavioral change, only persistence path change

🤖 Generated with [Claude Code](https://claude.com/claude-code)