### PR TITLE
[jsonrpc-alt] graceful fallback when the package resolver cannot resolve an input based on MoveCall signature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15783,6 +15783,7 @@ name = "sui-json-rpc-types"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "bcs",
  "colored",
  "enum_dispatch",
@@ -15810,6 +15811,7 @@ dependencies = [
  "sui-protocol-config",
  "sui-types",
  "tabled",
+ "tokio",
  "tracing",
 ]
 

--- a/crates/sui-json-rpc-types/Cargo.toml
+++ b/crates/sui-json-rpc-types/Cargo.toml
@@ -39,4 +39,6 @@ sui-json.workspace = true
 sui-package-resolver.workspace = true
 
 [dev-dependencies]
+async-trait.workspace = true
 insta.workspace = true
+tokio = { workspace = true, features = ["macros", "rt"] }

--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -1933,6 +1933,7 @@ impl SuiProgrammableTransactionBlock {
             Ok(layouts) => layouts,
             Err(_) => vec![None; value.inputs.len()],
         };
+
         let ProgrammableTransaction { inputs, commands } = value;
         Ok(SuiProgrammableTransactionBlock {
             inputs: inputs

--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -1925,7 +1925,14 @@ impl SuiProgrammableTransactionBlock {
         value: ProgrammableTransaction,
         package_resolver: &Resolver<impl PackageStore>,
     ) -> Result<Self, anyhow::Error> {
-        let input_types = package_resolver.pure_input_layouts(&value).await?;
+        // If the resolver can't infer layouts (e.g. a MoveCall references a function the resolver
+        // can't find), fall back to rendering every pure input as untyped bytes rather than
+        // failing the whole conversion. Matches the legacy `sui-json-rpc` behavior and the
+        // `sui-indexer-alt-graphql` behavior at `programmable/mod.rs`.
+        let input_types = match package_resolver.pure_input_layouts(&value).await {
+            Ok(layouts) => layouts,
+            Err(_) => vec![None; value.inputs.len()],
+        };
         let ProgrammableTransaction { inputs, commands } = value;
         Ok(SuiProgrammableTransactionBlock {
             inputs: inputs
@@ -2628,5 +2635,64 @@ impl Filter<EffectsWithInput> for TransactionFilter {
             TransactionFilter::Checkpoint(_) => false,
             TransactionFilter::FromOrToAddress { addr: _ } => false,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use async_trait::async_trait;
+    use move_core_types::account_address::AccountAddress;
+    use move_core_types::ident_str;
+    use sui_package_resolver::Package;
+    use sui_package_resolver::error::Error as PackageResolverError;
+    use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
+
+    use super::*;
+
+    struct EmptyPackageStore;
+
+    #[async_trait]
+    impl PackageStore for EmptyPackageStore {
+        async fn fetch(&self, id: AccountAddress) -> sui_package_resolver::Result<Arc<Package>> {
+            Err(PackageResolverError::PackageNotFound(id))
+        }
+    }
+
+    #[tokio::test]
+    async fn programmable_transaction_falls_back_when_layout_resolution_fails() {
+        let mut builder = ProgrammableTransactionBuilder::new();
+        let recipient = builder.pure(SuiAddress::ZERO).unwrap();
+        builder.programmable_move_call(
+            ObjectID::ZERO,
+            ident_str!("pay").to_owned(),
+            ident_str!("pay_all_sui").to_owned(),
+            vec![],
+            vec![recipient],
+        );
+
+        let resolver = Resolver::new(EmptyPackageStore);
+        let transaction = SuiProgrammableTransactionBlock::try_from_with_package_resolver(
+            builder.finish(),
+            &resolver,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(transaction.commands.len(), 1);
+        assert_eq!(transaction.inputs.len(), 1);
+
+        let SuiCallArg::Pure(input) = &transaction.inputs[0] else {
+            panic!("expected pure input");
+        };
+        assert_eq!(input.value_type(), None);
+
+        // SuiAddress::ZERO BCS-encodes to 32 zero bytes. With no layout, those bytes should come
+        // through unchanged as a JSON array of numbers.
+        assert_eq!(
+            input.value().to_json_value(),
+            serde_json::json!(vec![0u8; 32]),
+        );
     }
 }


### PR DESCRIPTION
## Description 


`sui_getTransactionBlock` in `sui-indexer-alt-jsonrpc` currently returns `-32603 Internal Error: Failed to resolve types in transaction data: Function not found: ...` whenever the package resolver can't find a function referenced by a PTB. The whole response does not need to fail though, because raw input bytes are still available, and can be returned.

Graphql and legacy `sui-json-rpc` end up serving some version of the `PureValue { value_type: None, value: bytes }`, so we make a similar change for `jsonrpc-alt` for parity. 

## Test plan 

unit test, and locally checked that now we return results instead of -32603

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
