### PR TITLE
Provision mode for external keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15906,6 +15906,7 @@ dependencies = [
  "slip10_ed25519",
  "sui-types",
  "tempfile",
+ "thiserror 1.0.69",
  "tiny-bip39",
  "tokio",
 ]

--- a/crates/sui-keys/Cargo.toml
+++ b/crates/sui-keys/Cargo.toml
@@ -27,6 +27,7 @@ base64.workspace = true
 jsonrpc.workspace = true
 tokio = { workspace = true, features = ["process"] }
 async-trait.workspace = true
+thiserror.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/sui-keys/src/external.rs
+++ b/crates/sui-keys/src/external.rs
@@ -13,7 +13,8 @@ use base64;
 use base64::{Engine as _, engine::general_purpose};
 use bcs;
 use fastcrypto::traits::{EncodeDecodeBase64, VerifyingKey};
-use jsonrpc::client::Endpoint;
+use jsonrpc::client::{Endpoint, JsonRpcError};
+use jsonrpc::types::RemoteError;
 use mockall::{automock, predicate::*};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::{Value as JsonValue, json};
@@ -25,6 +26,26 @@ use std::process::Stdio;
 use sui_types::base_types::SuiAddress;
 use sui_types::crypto::{PublicKey, Signature, SuiKeyPair, SuiSignature, SuiSignatureInner};
 use tokio::process::Command;
+
+const PROVISION_MODE_NOT_SUPPORTED_ERROR_CODE: i32 = -32012;
+
+#[derive(Debug, thiserror::Error)]
+pub enum ExternalExecError {
+    #[error(transparent)]
+    JsonRpc(#[from] JsonRpcError),
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error("Command failed with status: {0}")]
+    CommandFailed(std::process::ExitStatus),
+    #[error("Command returned null result")]
+    NullResult,
+}
+
+impl From<RemoteError> for ExternalExecError {
+    fn from(error: RemoteError) -> Self {
+        JsonRpcError::from(error).into()
+    }
+}
 
 #[derive(Debug)]
 /// External keystore for managing keys and aliases with an external signer.
@@ -53,6 +74,23 @@ pub struct ExternalKey {
     pub key_id: String,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, Default, PartialEq, Eq)]
+/// Provision mode requested when creating a key on an external signer.
+pub enum ProvisionMode {
+    /// Creates a recoverable key without surfacing recovery material in this flow.
+    #[default]
+    RecoverableAssumed,
+    /// Creates a recoverable key and returns recovery material immediately.
+    MnemonicBacked,
+    /// Creates a device-bound key with no recovery path.
+    NonRecoverable,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct CreateKeyParams {
+    pub mode: ProvisionMode,
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct KeysResponse {
     pub keys: Vec<ExternalKey>,
@@ -78,7 +116,7 @@ pub struct SignResponse {
 #[async_trait]
 pub trait CommandRunner: Send + Sync + Debug {
     async fn run(&self, command: &str, method: &str, params: JsonValue)
-    -> Result<JsonValue, Error>;
+    -> Result<JsonValue, ExternalExecError>;
 }
 
 #[derive(Debug)]
@@ -90,7 +128,7 @@ impl CommandRunner for StdCommandRunner {
         command: &str,
         method: &str,
         params: JsonValue,
-    ) -> Result<JsonValue, Error> {
+    ) -> Result<JsonValue, ExternalExecError> {
         let mut cmd = Command::new(command)
             .arg("call")
             .stdin(Stdio::piped())
@@ -104,23 +142,13 @@ impl CommandRunner for StdCommandRunner {
 
         let res: JsonValue = endpoint.call(method, params).await?;
         if res.is_null() {
-            return Err(anyhow!("Command returned null result"));
+            return Err(ExternalExecError::NullResult);
         }
 
-        let output = cmd
-            .wait_with_output()
-            .await
-            .map_err(|e| anyhow!("Failed to wait for command to finish: {}", e))?;
+        let output = cmd.wait_with_output().await?;
 
         if !output.status.success() {
-            return Err(Error::msg(format!(
-                "Command failed with status: {}",
-                output.status
-            )));
-        }
-
-        if !res["error"].is_null() {
-            return Err(anyhow!("Command failed with error: {:?}", res["error"]));
+            return Err(ExternalExecError::CommandFailed(output.status));
         }
 
         Ok(res)
@@ -203,7 +231,7 @@ impl External {
         command: &str,
         method: &str,
         params: JsonValue,
-    ) -> Result<JsonValue, Error> {
+    ) -> Result<JsonValue, ExternalExecError> {
         self.command_runner.run(command, method, params).await
     }
 
@@ -384,22 +412,56 @@ impl AccountKeystore for External {
         alias: Option<String>,
         opts: GenerateOptions,
     ) -> Result<GeneratedKey, Error> {
-        let GenerateOptions::ExternalSigner(ext_signer) = opts else {
+        let GenerateOptions::ExternalSigner {
+            signer: ext_signer,
+            provision_mode,
+        } = opts
+        else {
             return Err(anyhow!("Signer must be provided for external keys."));
         };
+        let create_key_params = provision_mode
+            .map(|mode| {
+                serde_json::to_value(CreateKeyParams { mode })
+                    .map_err(|e| anyhow!("Failed to serialize create key params: {}", e))
+            })
+            .transpose()?
+            .unwrap_or(JsonValue::Null);
 
-        // Attempt to generate, fallback to adding an existing key.
-        let stored_key = match self.exec(&ext_signer, "create_key", json![null]).await {
+        // Attempt to generate, fallback to indexing the first unindexed key.
+        let stored_key = match self.exec(&ext_signer, "create_key", create_key_params).await {
             Ok(res) => serde_json::from_value(res)
                 .map(|k: ExternalKey| StoredKey {
                     public_key: k.public_key,
                     ext_signer: ext_signer.clone(),
                     key_id: k.key_id,
                 })
-                .map_err(|e| anyhow!("Failed to parse key response from external signer: {}", e)),
-            Err(_) => self.add_first_unindexed_key(ext_signer).await,
-        }
-        .map_err(|e| anyhow!("Failed to generate or add a key: {}", e))?;
+                .map_err(|e| anyhow!("Failed to parse key response from external signer: {}", e))?,
+            Err(create_error) => {
+                let provision_mode_error = match &create_error {
+                    ExternalExecError::JsonRpc(JsonRpcError::RemoteError(error))
+                        if error.code == PROVISION_MODE_NOT_SUPPORTED_ERROR_CODE =>
+                    {
+                        Some(error.message.as_str())
+                    }
+                    _ => None,
+                };
+
+                match self.add_first_unindexed_key(ext_signer.clone()).await {
+                    Ok(stored_key) => stored_key,
+                    Err(add_error) => {
+                        let error = match provision_mode_error {
+                            Some(message) => anyhow!(
+                                "{message}. Also failed to add the first unindexed key: {add_error}"
+                            ),
+                            None => anyhow!(
+                                "Failed to create a new key on the external signer: {create_error}. Also failed to add the first unindexed key: {add_error}"
+                            ),
+                        };
+                        return Err(error);
+                    }
+                }
+            }
+        };
 
         let address: SuiAddress = (&stored_key.public_key).into();
         let public_key = stored_key.public_key.clone();
@@ -677,13 +739,17 @@ impl AccountKeystore for External {
 
 #[cfg(test)]
 mod tests {
-    use super::{External, MockCommandRunner, StdCommandRunner, StoredKey};
+    use super::{External, ExternalExecError, MockCommandRunner, StdCommandRunner, StoredKey};
+    use crate::external::{
+        PROVISION_MODE_NOT_SUPPORTED_ERROR_CODE, ProvisionMode,
+    };
     use crate::key_identity::KeyIdentity;
     use crate::keystore::{ALIASES_FILE_EXTENSION, AccountKeystore, GenerateOptions, GeneratedKey};
-    use anyhow::anyhow;
     use fastcrypto::ed25519::Ed25519KeyPair;
     use fastcrypto::secp256k1::Secp256k1KeyPair;
     use fastcrypto::traits::{EncodeDecodeBase64, KeyPair, ToFromBytes};
+    use jsonrpc::client::JsonRpcError;
+    use jsonrpc::types::RemoteError;
     use mockall::predicate::eq;
     use rand::prelude::StdRng;
     use rand::{SeedableRng, thread_rng};
@@ -701,6 +767,17 @@ mod tests {
     const PUBLIC_KEY: &str = "ALJ0GaLcBTTwTTh5dvyc6xaxwrjkG1spQzlL+W4CGLqG";
     const UNTAGGED_PUBLIC_KEY: &str = "snQZotwFNPBNOHl2/JzrFrHCuOQbWylDOUv5bgIYuoY=";
     const ADDRESS: &str = "0x9219616732544c54259b3f5aeef5ec078535e322ee63f7de2ca8a197fd2a4f6f";
+    const PROVISION_MODE_NOT_SUPPORTED_MESSAGE: &str =
+        "Provision mode is not supported by yubikey-signer";
+
+    fn unsupported_action_error(method: &str) -> ExternalExecError {
+        RemoteError {
+            code: -32601,
+            message: format!("Unsupported action {method}"),
+            data: None,
+        }
+        .into()
+    }
 
     fn load_external_keystore() -> External {
         let cargo_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap())
@@ -838,7 +915,7 @@ mod tests {
         let mut mock = MockCommandRunner::new();
         let key_id = "key-123";
         mock.expect_run()
-            .with(eq("signer"), eq("create_key"), eq(json![null]))
+            .with(eq("signer"), eq("create_key"), eq(JsonValue::Null))
             .returning(move |_, _, _| {
                 Ok(json!({
                     "key_id": key_id,
@@ -849,7 +926,13 @@ mod tests {
             });
         let mut external = External::new_for_test(Box::new(mock), None);
         let result = external
-            .generate(None, GenerateOptions::ExternalSigner("signer".to_string()))
+            .generate(
+                None,
+                GenerateOptions::ExternalSigner {
+                    signer: "signer".to_string(),
+                    provision_mode: None,
+                },
+            )
             .await;
         assert!(result.is_ok());
         let GeneratedKey {
@@ -869,7 +952,7 @@ mod tests {
 
         let mut mock = MockCommandRunner::new();
         mock.expect_run()
-            .with(eq("signer"), eq("create_key"), eq(json![null]))
+            .with(eq("signer"), eq("create_key"), eq(JsonValue::Null))
             .returning(move |_, _, _| {
                 Ok(json!({
                     "key_id": key_id,
@@ -879,10 +962,49 @@ mod tests {
 
         let mut external = External::new_for_test(Box::new(mock), None);
         let result = external
-            .generate(None, GenerateOptions::ExternalSigner("signer".to_string()))
+            .generate(
+                None,
+                GenerateOptions::ExternalSigner {
+                    signer: "signer".to_string(),
+                    provision_mode: None,
+                },
+            )
             .await;
         let GeneratedKey { scheme, .. } = result.unwrap();
         assert_eq!(scheme, Secp256k1);
+    }
+
+    #[tokio::test]
+    async fn test_generate_with_provision_mode() {
+        let mut mock = MockCommandRunner::new();
+        let key_id = "key-123";
+        mock.expect_run()
+            .with(
+                eq("signer"),
+                eq("create_key"),
+                eq(json!({ "mode": "MnemonicBacked" })),
+            )
+            .returning(move |_, _, _| {
+                Ok(json!({
+                    "key_id": key_id,
+                    "public_key": {
+                        "Ed25519": UNTAGGED_PUBLIC_KEY
+                    }
+                }))
+            });
+
+        let mut external = External::new_for_test(Box::new(mock), None);
+        let result = external
+            .generate(
+                None,
+                GenerateOptions::ExternalSigner {
+                    signer: "signer".to_string(),
+                    provision_mode: Some(ProvisionMode::MnemonicBacked),
+                },
+            )
+            .await;
+
+        assert!(result.is_ok());
     }
 
     #[tokio::test]
@@ -917,10 +1039,8 @@ mod tests {
         let mut mock = MockCommandRunner::new();
         let key_id = "key-123";
         mock.expect_run().returning(move |_, method, params| {
-            if method == "create_key" && params == json![null] {
-                return Err(anyhow!(
-                    "Command failed with error: Unsupported action create_key"
-                ));
+            if method == "create_key" && params == JsonValue::Null {
+                return Err(unsupported_action_error("create_key"));
             }
             if method == "keys" && params == json![null] {
                 return Ok(json!({
@@ -942,7 +1062,13 @@ mod tests {
         let mut external = External::new_for_test(Box::new(mock), Some(tmp_keystore));
         external.save().await.unwrap();
         let result = external
-            .generate(None, GenerateOptions::ExternalSigner("signer".to_string()))
+            .generate(
+                None,
+                GenerateOptions::ExternalSigner {
+                    signer: "signer".to_string(),
+                    provision_mode: None,
+                },
+            )
             .await;
         assert!(result.is_ok());
         let GeneratedKey {
@@ -953,6 +1079,45 @@ mod tests {
         assert_eq!(scheme, ED25519);
         assert_eq!(address, SuiAddress::from_str(ADDRESS).unwrap());
         assert_eq!(public_key.encode_base64(), PUBLIC_KEY);
+    }
+
+    #[tokio::test]
+    async fn test_generate_fallback_preserves_provision_mode_error() {
+        let mut mock = MockCommandRunner::new();
+        mock.expect_run().returning(move |_, method, params| {
+            if method == "create_key" && params == JsonValue::Null {
+                return Err(RemoteError {
+                    code: PROVISION_MODE_NOT_SUPPORTED_ERROR_CODE,
+                    message: PROVISION_MODE_NOT_SUPPORTED_MESSAGE.to_string(),
+                    data: None,
+                }
+                .into());
+            }
+            if method == "keys" && params == json![null] {
+                return Err(ExternalExecError::Io(std::io::Error::other(
+                    "No available key found for external signer signer",
+                )));
+            }
+            panic!("Unexpected method called: {}", method);
+        });
+
+        let tmp_dir = TempDir::new().unwrap();
+        let tmp_keystore = tmp_dir.path().join("external.keystore");
+        let mut external = External::new_for_test(Box::new(mock), Some(tmp_keystore));
+        external.save().await.unwrap();
+        let result = external
+            .generate(
+                None,
+                GenerateOptions::ExternalSigner {
+                    signer: "signer".to_string(),
+                    provision_mode: None,
+                },
+            )
+            .await;
+
+        let error = result.unwrap_err().to_string();
+        assert!(error.contains(PROVISION_MODE_NOT_SUPPORTED_MESSAGE));
+        assert!(error.contains("Also failed to add the first unindexed key"));
     }
 
     #[tokio::test]
@@ -996,9 +1161,7 @@ mod tests {
         mock.expect_run().returning(move |_, method, _| {
             // Simulate lack of "public_key" method support
             if method == "public_key" {
-                return Err(anyhow!(
-                    "Command failed with error: Unsupported action public_key"
-                ));
+                return Err(unsupported_action_error("public_key"));
             }
             if method == "keys" {
                 return Ok(json!({
@@ -1055,10 +1218,23 @@ mod tests {
     #[tokio::test]
     async fn test_exec_error_propagation() {
         let mut mock = MockCommandRunner::new();
-        mock.expect_run().returning(|_, _, _| Err(anyhow!("fail")));
+        mock.expect_run().returning(|_, _, _| {
+            Err(RemoteError {
+                code: -32601,
+                message: "Unsupported action method".to_string(),
+                data: None,
+            }
+            .into())
+        });
         let external = External::new_for_test(Box::new(mock), None);
         let result = external.exec("cmd", "method", json!([1, 2, 3])).await;
-        assert!(result.is_err());
+        match result {
+            Err(ExternalExecError::JsonRpc(JsonRpcError::RemoteError(error))) => {
+                assert_eq!(error.code, -32601);
+                assert_eq!(error.message, "Unsupported action method");
+            }
+            other => panic!("expected remote JSON-RPC error, got {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/crates/sui-keys/src/external.rs
+++ b/crates/sui-keys/src/external.rs
@@ -74,6 +74,13 @@ pub struct ExternalKey {
     pub key_id: String,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct CreateKeyResponse {
+    pub public_key: PublicKey,
+    pub key_id: String,
+    pub mnemonic: Option<String>,
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, Default, PartialEq, Eq)]
 /// Provision mode requested when creating a key on an external signer.
 pub enum ProvisionMode {
@@ -428,12 +435,17 @@ impl AccountKeystore for External {
             .unwrap_or(JsonValue::Null);
 
         // Attempt to generate, fallback to indexing the first unindexed key.
-        let stored_key = match self.exec(&ext_signer, "create_key", create_key_params).await {
+        let (stored_key, mnemonic) = match self.exec(&ext_signer, "create_key", create_key_params).await {
             Ok(res) => serde_json::from_value(res)
-                .map(|k: ExternalKey| StoredKey {
-                    public_key: k.public_key,
-                    ext_signer: ext_signer.clone(),
-                    key_id: k.key_id,
+                .map(|k: CreateKeyResponse| {
+                    (
+                        StoredKey {
+                            public_key: k.public_key,
+                            ext_signer: ext_signer.clone(),
+                            key_id: k.key_id,
+                        },
+                        k.mnemonic,
+                    )
                 })
                 .map_err(|e| anyhow!("Failed to parse key response from external signer: {}", e))?,
             Err(create_error) => {
@@ -447,7 +459,7 @@ impl AccountKeystore for External {
                 };
 
                 match self.add_first_unindexed_key(ext_signer.clone()).await {
-                    Ok(stored_key) => stored_key,
+                    Ok(stored_key) => (stored_key, None),
                     Err(add_error) => {
                         let error = match provision_mode_error {
                             Some(message) => anyhow!(
@@ -480,6 +492,7 @@ impl AccountKeystore for External {
             address,
             scheme: public_key.scheme(),
             public_key,
+            mnemonic,
         })
     }
 
@@ -939,10 +952,12 @@ mod tests {
             address,
             public_key,
             scheme,
+            mnemonic,
         } = result.unwrap();
         assert_eq!(scheme, ED25519);
         assert_eq!(address, SuiAddress::from_str(ADDRESS).unwrap());
         assert_eq!(public_key.encode_base64(), PUBLIC_KEY);
+        assert_eq!(mnemonic, None);
         assert!(external.keys.contains_key(&address));
 
         // With a different signature scheme
@@ -978,6 +993,7 @@ mod tests {
     async fn test_generate_with_provision_mode() {
         let mut mock = MockCommandRunner::new();
         let key_id = "key-123";
+        let mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
         mock.expect_run()
             .with(
                 eq("signer"),
@@ -989,7 +1005,8 @@ mod tests {
                     "key_id": key_id,
                     "public_key": {
                         "Ed25519": UNTAGGED_PUBLIC_KEY
-                    }
+                    },
+                    "mnemonic": mnemonic
                 }))
             });
 
@@ -1005,6 +1022,7 @@ mod tests {
             .await;
 
         assert!(result.is_ok());
+        assert_eq!(result.unwrap().mnemonic, Some(mnemonic.to_string()));
     }
 
     #[tokio::test]
@@ -1075,10 +1093,12 @@ mod tests {
             address,
             public_key,
             scheme,
+            mnemonic,
         } = result.unwrap();
         assert_eq!(scheme, ED25519);
         assert_eq!(address, SuiAddress::from_str(ADDRESS).unwrap());
         assert_eq!(public_key.encode_base64(), PUBLIC_KEY);
+        assert_eq!(mnemonic, None);
     }
 
     #[tokio::test]

--- a/crates/sui-keys/src/external.rs
+++ b/crates/sui-keys/src/external.rs
@@ -76,20 +76,21 @@ pub struct ExternalKey {
     pub key_id: String,
 }
 
+// No debug display for CreateKeyResponse as it may contain sensitive mnemonic.
 #[derive(Serialize, Deserialize, Clone)]
 pub struct CreateKeyResponse {
     pub public_key: PublicKey,
     pub key_id: String,
+    /// Only used for display, do not persist to file
     #[serde(skip_serializing)]
     pub mnemonic: Option<String>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 /// Provision mode requested when creating a key on an external signer.
 pub enum ProvisionMode {
     /// Creates a recoverable key without surfacing recovery material in this flow.
-    #[default]
     RecoverableAssumed,
     /// Creates a recoverable key and returns recovery material immediately.
     MnemonicBacked,
@@ -148,6 +149,7 @@ impl CommandRunner for StdCommandRunner {
             .arg("call")
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
+            .kill_on_drop(true)
             .spawn()?;
 
         let mut endpoint = Endpoint::new(
@@ -292,27 +294,16 @@ impl External {
         Ok(key)
     }
 
-    pub async fn add_first_unindexed_key(
+    pub async fn get_first_unindexed_key(
         &mut self,
         ext_signer: String,
     ) -> Result<StoredKey, Error> {
         let keys = self.signer_available_keys(ext_signer.clone()).await?;
 
-        let key: StoredKey = keys
+        Ok(keys
             .into_iter()
             .find(|k| !self.is_indexed(k))
-            .ok_or_else(|| anyhow!("No available key found for external signer {}", ext_signer))?;
-
-        self.keys.insert((&key.public_key).into(), key.clone());
-        self.aliases.insert(
-            (&key.public_key).into(),
-            Alias {
-                alias: self.create_alias(None)?,
-                public_key_base64: key.public_key.encode_base64(),
-            },
-        );
-        self.save().await?;
-        Ok(key)
+            .ok_or_else(|| anyhow!("No available key found for external signer {}", ext_signer))?)
     }
 
     /// Get the public key for a given key ID from an external signer.
@@ -473,7 +464,7 @@ impl AccountKeystore for External {
                     ));
                 }
 
-                match self.add_first_unindexed_key(ext_signer.clone()).await {
+                match self.get_first_unindexed_key(ext_signer.clone()).await {
                     Ok(stored_key) => (stored_key, None),
                     Err(add_error) => {
                         return Err(anyhow!(
@@ -1053,7 +1044,7 @@ mod tests {
         let tmp_keystore = tmp_dir.path().join("external.keystore");
         let mut external = External::new_for_test(Box::new(mock), Some(tmp_keystore));
         external.save().await.unwrap();
-        let stored_key = external.add_first_unindexed_key("signer".to_string()).await;
+        let stored_key = external.get_first_unindexed_key("signer".to_string()).await;
         assert!(stored_key.is_ok());
         let stored_key = stored_key.unwrap();
         assert_eq!(stored_key.key_id, key_id);
@@ -1109,8 +1100,11 @@ mod tests {
         assert_eq!(mnemonic, None);
     }
 
+    // Yubikey returns `PROVISIONMODE_NOT_SUPPORTED_ERROR_CODE` if the create_key method is called with RecoverableAssumed (default),
+    // this test ensures the CLI does not attempt to add keys it lists from the yubikey
+    // Only ledger should use get_first_unindexed_key() since it cannot generate individual keys.
     #[tokio::test]
-    async fn test_generate_does_not_fallback_on_provision_mode_error() {
+    async fn test_generate_does_not_fallback_on_provision_mode_not_error() {
         let mut mock = MockCommandRunner::new();
         mock.expect_run().returning(move |_, method, params| {
             if method == "create_key" && params == JsonValue::Null {

--- a/crates/sui-keys/src/external.rs
+++ b/crates/sui-keys/src/external.rs
@@ -300,10 +300,9 @@ impl External {
     ) -> Result<StoredKey, Error> {
         let keys = self.signer_available_keys(ext_signer.clone()).await?;
 
-        Ok(keys
-            .into_iter()
+        keys.into_iter()
             .find(|k| !self.is_indexed(k))
-            .ok_or_else(|| anyhow!("No available key found for external signer {}", ext_signer))?)
+            .ok_or_else(|| anyhow!("No available key found for external signer {}", ext_signer))
     }
 
     /// Get the public key for a given key ID from an external signer.

--- a/crates/sui-keys/src/external.rs
+++ b/crates/sui-keys/src/external.rs
@@ -27,7 +27,9 @@ use sui_types::base_types::SuiAddress;
 use sui_types::crypto::{PublicKey, Signature, SuiKeyPair, SuiSignature, SuiSignatureInner};
 use tokio::process::Command;
 
-const PROVISION_MODE_NOT_SUPPORTED_ERROR_CODE: i32 = -32012;
+// TODO create specific error code or some metadata method to improve on this.
+/// Ledgers do not support key generation, so we use the JSON RPC method not found error code to identify when create is not supported by the signer.
+const JSON_RPC_METHOD_NOT_FOUND_ERROR_CODE: i32 = -32601;
 
 #[derive(Debug, thiserror::Error)]
 pub enum ExternalExecError {
@@ -74,14 +76,16 @@ pub struct ExternalKey {
     pub key_id: String,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct CreateKeyResponse {
     pub public_key: PublicKey,
     pub key_id: String,
+    #[serde(skip_serializing)]
     pub mnemonic: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
 /// Provision mode requested when creating a key on an external signer.
 pub enum ProvisionMode {
     /// Creates a recoverable key without surfacing recovery material in this flow.
@@ -122,8 +126,12 @@ pub struct SignResponse {
 #[automock]
 #[async_trait]
 pub trait CommandRunner: Send + Sync + Debug {
-    async fn run(&self, command: &str, method: &str, params: JsonValue)
-    -> Result<JsonValue, ExternalExecError>;
+    async fn run(
+        &self,
+        command: &str,
+        method: &str,
+        params: JsonValue,
+    ) -> Result<JsonValue, ExternalExecError>;
 }
 
 #[derive(Debug)]
@@ -435,7 +443,10 @@ impl AccountKeystore for External {
             .unwrap_or(JsonValue::Null);
 
         // Attempt to generate, fallback to indexing the first unindexed key.
-        let (stored_key, mnemonic) = match self.exec(&ext_signer, "create_key", create_key_params).await {
+        let (stored_key, mnemonic) = match self
+            .exec(&ext_signer, "create_key", create_key_params)
+            .await
+        {
             Ok(res) => serde_json::from_value(res)
                 .map(|k: CreateKeyResponse| {
                     (
@@ -449,27 +460,25 @@ impl AccountKeystore for External {
                 })
                 .map_err(|e| anyhow!("Failed to parse key response from external signer: {}", e))?,
             Err(create_error) => {
-                let provision_mode_error = match &create_error {
+                let create_not_supported = matches!(
+                    &create_error,
                     ExternalExecError::JsonRpc(JsonRpcError::RemoteError(error))
-                        if error.code == PROVISION_MODE_NOT_SUPPORTED_ERROR_CODE =>
-                    {
-                        Some(error.message.as_str())
-                    }
-                    _ => None,
-                };
+                        if error.code == JSON_RPC_METHOD_NOT_FOUND_ERROR_CODE
+                );
+
+                // return here if we failed to create a key for a reason other than the method not being found, otherwise attempt to fallback to adding an existing key.
+                if !create_not_supported {
+                    return Err(anyhow!(
+                        "Failed to create a new key on the external signer: {create_error}"
+                    ));
+                }
 
                 match self.add_first_unindexed_key(ext_signer.clone()).await {
                     Ok(stored_key) => (stored_key, None),
                     Err(add_error) => {
-                        let error = match provision_mode_error {
-                            Some(message) => anyhow!(
-                                "{message}. Also failed to add the first unindexed key: {add_error}"
-                            ),
-                            None => anyhow!(
-                                "Failed to create a new key on the external signer: {create_error}. Also failed to add the first unindexed key: {add_error}"
-                            ),
-                        };
-                        return Err(error);
+                        return Err(anyhow!(
+                            "Failed to create a new key on the external signer: {create_error}. Also failed to add the first unindexed key: {add_error}"
+                        ));
                     }
                 }
             }
@@ -753,9 +762,7 @@ impl AccountKeystore for External {
 #[cfg(test)]
 mod tests {
     use super::{External, ExternalExecError, MockCommandRunner, StdCommandRunner, StoredKey};
-    use crate::external::{
-        PROVISION_MODE_NOT_SUPPORTED_ERROR_CODE, ProvisionMode,
-    };
+    use crate::external::ProvisionMode;
     use crate::key_identity::KeyIdentity;
     use crate::keystore::{ALIASES_FILE_EXTENSION, AccountKeystore, GenerateOptions, GeneratedKey};
     use fastcrypto::ed25519::Ed25519KeyPair;
@@ -780,6 +787,7 @@ mod tests {
     const PUBLIC_KEY: &str = "ALJ0GaLcBTTwTTh5dvyc6xaxwrjkG1spQzlL+W4CGLqG";
     const UNTAGGED_PUBLIC_KEY: &str = "snQZotwFNPBNOHl2/JzrFrHCuOQbWylDOUv5bgIYuoY=";
     const ADDRESS: &str = "0x9219616732544c54259b3f5aeef5ec078535e322ee63f7de2ca8a197fd2a4f6f";
+    const PROVISION_MODE_NOT_SUPPORTED_ERROR_CODE: i32 = -32012;
     const PROVISION_MODE_NOT_SUPPORTED_MESSAGE: &str =
         "Provision mode is not supported by yubikey-signer";
 
@@ -998,7 +1006,7 @@ mod tests {
             .with(
                 eq("signer"),
                 eq("create_key"),
-                eq(json!({ "mode": "MnemonicBacked" })),
+                eq(json!({ "mode": "mnemonic-backed" })),
             )
             .returning(move |_, _, _| {
                 Ok(json!({
@@ -1102,7 +1110,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_generate_fallback_preserves_provision_mode_error() {
+    async fn test_generate_does_not_fallback_on_provision_mode_error() {
         let mut mock = MockCommandRunner::new();
         mock.expect_run().returning(move |_, method, params| {
             if method == "create_key" && params == JsonValue::Null {
@@ -1114,9 +1122,7 @@ mod tests {
                 .into());
             }
             if method == "keys" && params == json![null] {
-                return Err(ExternalExecError::Io(std::io::Error::other(
-                    "No available key found for external signer signer",
-                )));
+                panic!("keys should not be queried after a provision mode error");
             }
             panic!("Unexpected method called: {}", method);
         });
@@ -1137,7 +1143,7 @@ mod tests {
 
         let error = result.unwrap_err().to_string();
         assert!(error.contains(PROVISION_MODE_NOT_SUPPORTED_MESSAGE));
-        assert!(error.contains("Also failed to add the first unindexed key"));
+        assert!(!error.contains("Also failed to add the first unindexed key"));
     }
 
     #[tokio::test]

--- a/crates/sui-keys/src/keystore.rs
+++ b/crates/sui-keys/src/keystore.rs
@@ -67,6 +67,7 @@ pub struct GeneratedKey {
     pub address: SuiAddress,
     pub public_key: PublicKey,
     pub scheme: SignatureScheme,
+    pub mnemonic: Option<String>,
 }
 
 #[async_trait]
@@ -98,6 +99,7 @@ pub trait AccountKeystore: Send + Sync {
             address,
             public_key,
             scheme,
+            mnemonic: None,
         })
     }
 

--- a/crates/sui-keys/src/keystore.rs
+++ b/crates/sui-keys/src/keystore.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub use crate::external::External;
+use crate::external::ProvisionMode;
 use crate::key_derive::{derive_key_pair_from_path, generate_new_key};
 use crate::key_identity::KeyIdentity;
 use crate::random_names::{random_name, random_names};
@@ -55,9 +56,13 @@ pub enum GenerateOptions {
     /// File or InMem keystore
     Local(LocalGenerate),
     /// Signer
-    ExternalSigner(String),
+    ExternalSigner {
+        signer: String,
+        provision_mode: Option<ProvisionMode>,
+    },
 }
 
+#[derive(Debug)]
 pub struct GeneratedKey {
     pub address: SuiAddress,
     pub public_key: PublicKey,
@@ -78,7 +83,7 @@ pub trait AccountKeystore: Send + Sync {
             GenerateOptions::Local(opts) => {
                 (opts.key_scheme, opts.derivation_path, opts.word_length)
             }
-            GenerateOptions::ExternalSigner(_) => {
+            GenerateOptions::ExternalSigner { .. } => {
                 return Err(anyhow!(
                     "Generating new keypair is not supported for this keystore type"
                 ));

--- a/crates/sui/src/external_signer.rs
+++ b/crates/sui/src/external_signer.rs
@@ -178,7 +178,7 @@ mod tests {
     use async_trait::async_trait;
     use clap::Parser;
     use serde_json::{Value, json};
-    use sui_keys::external::{CommandRunner, ExternalExecError};
+    use sui_keys::external::{CommandRunner, ExternalExecError, ProvisionMode};
     use sui_keys::keystore::Keystore;
     use tempfile::TempDir;
 

--- a/crates/sui/src/external_signer.rs
+++ b/crates/sui/src/external_signer.rs
@@ -1,4 +1,3 @@
-use std::fmt::{Debug, Display, Formatter};
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use crate::keytool::Key;
@@ -7,16 +6,40 @@ use clap::*;
 use json_to_table::{Orientation, json_to_table};
 use serde::Serialize;
 use serde_json::json;
-use sui_keys::external::External;
+use std::fmt::{Debug, Display, Formatter};
+use sui_keys::external::{External, ProvisionMode};
 use sui_keys::keystore::{AccountKeystore, GenerateOptions, GeneratedKey, Keystore};
 use tracing::info;
+
+#[derive(ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
+#[clap(rename_all = "kebab-case")]
+pub enum ProvisionModeArg {
+    RecoverableAssumed,
+    MnemonicBacked,
+    NonRecoverable,
+}
+
+impl From<ProvisionModeArg> for ProvisionMode {
+    fn from(value: ProvisionModeArg) -> Self {
+        match value {
+            ProvisionModeArg::RecoverableAssumed => ProvisionMode::RecoverableAssumed,
+            ProvisionModeArg::MnemonicBacked => ProvisionMode::MnemonicBacked,
+            ProvisionModeArg::NonRecoverable => ProvisionMode::NonRecoverable,
+        }
+    }
+}
 
 #[allow(clippy::large_enum_variant)]
 #[derive(Subcommand)]
 #[clap(rename_all = "kebab-case")]
 pub enum ExternalKeysCommand {
     /// Generate a new key for an external signer
-    Generate { signer: String },
+    Generate {
+        signer: String,
+        /// Provisioning mode to request when creating a new signer key.
+        #[clap(long, value_enum)]
+        provision_mode: Option<ProvisionModeArg>,
+    },
     /// List all keys available for an external signer
     ListKeys { signer: String },
     /// Add an existing key to the sui cli for an existing external signer key
@@ -46,7 +69,10 @@ impl ExternalKeysCommand {
         external_keys: Option<&mut Keystore>,
     ) -> Result<CommandOutput, anyhow::Error> {
         match self {
-            ExternalKeysCommand::Generate { signer } => {
+            ExternalKeysCommand::Generate {
+                signer,
+                provision_mode,
+            } => {
                 let Some(external_keys) = external_keys else {
                     return Err(anyhow!("Keystore is not configured for external signer"));
                 };
@@ -54,7 +80,13 @@ impl ExternalKeysCommand {
                     return Err(anyhow!("Keystore is not configured for external signer"));
                 };
                 let GeneratedKey { public_key, .. } = external_keys
-                    .generate(None, GenerateOptions::ExternalSigner(signer))
+                    .generate(
+                        None,
+                        GenerateOptions::ExternalSigner {
+                            signer,
+                            provision_mode: provision_mode.map(Into::into),
+                        },
+                    )
                     .await?;
                 let key = Key::from(public_key);
                 external_keys.save().await?;
@@ -132,4 +164,39 @@ fn get_external_keystore(keystore: Option<&mut Keystore>) -> Result<&mut Externa
         return Err(anyhow!("Keystore is not configured for external signer"));
     };
     Ok(external_keystore)
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+
+    use super::{ExternalKeysCommand, ProvisionModeArg};
+    use crate::sui_commands::SuiCommand;
+
+    #[test]
+    fn test_external_keys_generate_parses_provision_mode() {
+        let command = SuiCommand::try_parse_from([
+            "sui",
+            "external-keys",
+            "generate",
+            "yubikey",
+            "--provision-mode",
+            "mnemonic-backed",
+        ])
+        .unwrap();
+
+        let SuiCommand::ExternalKeys { cmd, .. } = command else {
+            panic!("expected external-keys command");
+        };
+        let ExternalKeysCommand::Generate {
+            signer,
+            provision_mode,
+        } = cmd
+        else {
+            panic!("expected external-keys generate command");
+        };
+
+        assert_eq!(signer, "yubikey");
+        assert_eq!(provision_mode, Some(ProvisionModeArg::MnemonicBacked));
+    }
 }

--- a/crates/sui/src/external_signer.rs
+++ b/crates/sui/src/external_signer.rs
@@ -178,7 +178,7 @@ mod tests {
     use async_trait::async_trait;
     use clap::Parser;
     use serde_json::{Value, json};
-    use sui_keys::external::{CommandRunner, ExternalExecError, ProvisionMode};
+    use sui_keys::external::{CommandRunner, ExternalExecError};
     use sui_keys::keystore::Keystore;
     use tempfile::TempDir;
 

--- a/crates/sui/src/external_signer.rs
+++ b/crates/sui/src/external_signer.rs
@@ -195,10 +195,13 @@ mod tests {
     impl CommandRunner for StubCommandRunner {
         async fn run(
             &self,
-            _command: &str,
-            _method: &str,
-            _params: Value,
+            command: &str,
+            method: &str,
+            params: Value,
         ) -> Result<Value, ExternalExecError> {
+            assert_eq!(command, "yubikey");
+            assert_eq!(method, "create_key");
+            assert_eq!(params, json!({ "mode": "mnemonic-backed" }));
             Ok(self.response.clone())
         }
     }

--- a/crates/sui/src/external_signer.rs
+++ b/crates/sui/src/external_signer.rs
@@ -79,7 +79,11 @@ impl ExternalKeysCommand {
                 let Keystore::External(external_keys) = external_keys else {
                     return Err(anyhow!("Keystore is not configured for external signer"));
                 };
-                let GeneratedKey { public_key, .. } = external_keys
+                let GeneratedKey {
+                    public_key,
+                    mnemonic,
+                    ..
+                } = external_keys
                     .generate(
                         None,
                         GenerateOptions::ExternalSigner {
@@ -88,7 +92,7 @@ impl ExternalKeysCommand {
                         },
                     )
                     .await?;
-                let key = Key::from(public_key);
+                let key = Key::from(public_key).with_mnemonic(mnemonic);
                 external_keys.save().await?;
                 Ok(CommandOutput::ExternalGenerate(key))
             }
@@ -168,10 +172,36 @@ fn get_external_keystore(keystore: Option<&mut Keystore>) -> Result<&mut Externa
 
 #[cfg(test)]
 mod tests {
-    use clap::Parser;
+    use std::path::PathBuf;
 
-    use super::{ExternalKeysCommand, ProvisionModeArg};
+    use anyhow::Error;
+    use async_trait::async_trait;
+    use clap::Parser;
+    use serde_json::{Value, json};
+    use sui_keys::external::{CommandRunner, ExternalExecError};
+    use sui_keys::keystore::Keystore;
+    use tempfile::TempDir;
+
+    use super::{CommandOutput, ExternalKeysCommand, ProvisionModeArg};
     use crate::sui_commands::SuiCommand;
+    use sui_keys::external::External;
+
+    #[derive(Debug)]
+    struct StubCommandRunner {
+        response: Value,
+    }
+
+    #[async_trait]
+    impl CommandRunner for StubCommandRunner {
+        async fn run(
+            &self,
+            _command: &str,
+            _method: &str,
+            _params: Value,
+        ) -> Result<Value, ExternalExecError> {
+            Ok(self.response.clone())
+        }
+    }
 
     #[test]
     fn test_external_keys_generate_parses_provision_mode() {
@@ -198,5 +228,40 @@ mod tests {
 
         assert_eq!(signer, "yubikey");
         assert_eq!(provision_mode, Some(ProvisionModeArg::MnemonicBacked));
+    }
+
+    #[tokio::test]
+    async fn test_external_keys_generate_surfaces_signer_mnemonic() -> Result<(), Error> {
+        let tmp_dir = TempDir::new()?;
+        let tmp_keystore = PathBuf::from(tmp_dir.path()).join("external.keystore");
+        let mut keystore = Keystore::External(External::new_for_test(
+            Box::new(StubCommandRunner {
+                response: json!({
+                    "key_id": "key-123",
+                    "public_key": {
+                        "Ed25519": "snQZotwFNPBNOHl2/JzrFrHCuOQbWylDOUv5bgIYuoY="
+                    },
+                    "mnemonic": "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+                }),
+            }),
+            Some(tmp_keystore),
+        ));
+
+        let output = ExternalKeysCommand::Generate {
+            signer: "yubikey".to_string(),
+            provision_mode: Some(ProvisionModeArg::MnemonicBacked),
+        }
+        .execute(Some(&mut keystore))
+        .await?;
+
+        let CommandOutput::ExternalGenerate(key) = output else {
+            panic!("expected generated key output");
+        };
+        let json = serde_json::to_value(key)?;
+        assert_eq!(
+            json["mnemonic"],
+            "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+        );
+        Ok(())
     }
 }

--- a/crates/sui/src/keytool.rs
+++ b/crates/sui/src/keytool.rs
@@ -1394,6 +1394,13 @@ impl From<PublicKey> for Key {
     }
 }
 
+impl Key {
+    pub(crate) fn with_mnemonic(mut self, mnemonic: Option<String>) -> Self {
+        self.mnemonic = mnemonic;
+        self
+    }
+}
+
 impl Display for CommandOutput {
     fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
         match self {


### PR DESCRIPTION
## Description 

Adds a "provision mode" argument to the CLI which adds 3 options to how keys can be generated:
- RecoverableAssumed: default mode which is only supported by ledger signer where a backup flow is an expected part of the signer, ledgers walk you through this.
- MnemonicBacked: generate a key outside of the signer, import it and return the mnemonic to the user
- NonRecoverable: generate on device, skip backups.

Ledgers support RecoverableAssumed since they walk users through a backup flow, however yubikeys are not backed up by default on generation and do not support recoverable assumed. Yubikeys require users to provision with either mnemonicbacked or nonrecoverable to explicitly approve of the risk of on device generation.

## Test plan 

unit tests and QA

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [x] CLI: external-keys subcommand receives --provision-mode [recoverable-assumed|mnemonic-backed|non-recoverable] 
- [ ] Rust SDK:
- [ ] Indexing Framework:
