### PR TITLE
Fix warnings in release mode

### DIFF
--- a/external-crates/move/crates/move-regex-borrow-graph/src/collections.rs
+++ b/external-crates/move/crates/move-regex-borrow-graph/src/collections.rs
@@ -129,6 +129,7 @@ impl<Loc: Copy, Lbl: Ord + Clone + fmt::Display> Graph<Loc, Lbl> {
     }
 
     /// Returns the direct successors of the specified reference by NodeIndex
+    #[cfg(debug_assertions)]
     fn successors_idx(
         &self,
         r: NodeIndex,

--- a/external-crates/move/crates/move-regex-borrow-graph/src/graph_map.rs
+++ b/external-crates/move/crates/move-regex-borrow-graph/src/graph_map.rs
@@ -138,6 +138,7 @@ impl<N, E> GraphMap<N, E> {
     }
 
     /// Returns the weight of the edge from `from` to `to`, or None if the edge does not exist.
+    #[allow(unused)]
     pub fn edge_weight(&self, from: NodeIndex, to: NodeIndex) -> Option<&E> {
         self.edge_weights.get(&(from, to))
     }
@@ -235,6 +236,7 @@ impl<N, E> GraphMap<N, E> {
     }
 
     /// Returns an iterator over all edges in the graph, as (from, weight, to) triples.
+    #[allow(unused)]
     pub fn all_edges_idx(&self) -> impl Iterator<Item = (NodeIndex, &E, NodeIndex)> + '_ {
         self.edge_weights.iter().map(|((p, s), e)| (*p, e, *s))
     }
@@ -262,6 +264,7 @@ impl<N, E> GraphMap<N, E> {
         }))
     }
 
+    #[allow(unused)]
     pub(crate) fn check_invariants(&self) {
         #[cfg(debug_assertions)]
         {


### PR DESCRIPTION
## Description 

Added `#[allow(unused)]` to the function in `graph_map.rs` as in other test only function that already existed in the file.
Added `#[cfg(debug_assertions)]` in `fn successors_idx(..)` given that function is only called from `debug_assertion` code

## Test plan 

Built and verified no warnings

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
