### PR TITLE
Move expensive checkpoint decoding off IO threads

### DIFF
--- a/crates/sui-indexer-alt-framework/src/ingestion/rpc_client.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/rpc_client.rs
@@ -56,8 +56,12 @@ impl IngestionClientTrait for RpcClient {
         // `ByteCountMakeCallbackHandler` request layer attached in
         // `IngestionClient::with_grpc`, so it does not need to be tracked here.
         let response = response.into_inner();
-        Checkpoint::try_from(response.checkpoint())
-            .map_err(|e| CheckpointError::Decode(ProtoConversion(e)))
+        tokio::task::spawn_blocking(move || {
+            Checkpoint::try_from(response.checkpoint())
+                .map_err(|e| CheckpointError::Decode(ProtoConversion(e)))
+        })
+        .await
+        .map_err(|e| CheckpointError::Fetch(anyhow!("decode task panicked: {e}")))?
     }
 
     async fn latest_checkpoint_number(&self) -> anyhow::Result<u64> {

--- a/crates/sui-indexer-alt-framework/src/ingestion/rpc_client.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/rpc_client.rs
@@ -56,6 +56,8 @@ impl IngestionClientTrait for RpcClient {
         // `ByteCountMakeCallbackHandler` request layer attached in
         // `IngestionClient::with_grpc`, so it does not need to be tracked here.
         let response = response.into_inner();
+        // Proto -> Checkpoint conversion is multi-ms of CPU work; offload to the
+        // blocking pool so it doesn't stall the reactor.
         tokio::task::spawn_blocking(move || {
             Checkpoint::try_from(response.checkpoint())
                 .map_err(|e| CheckpointError::Decode(ProtoConversion(e)))

--- a/crates/sui-indexer-alt-framework/src/ingestion/store_client.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/store_client.rs
@@ -54,6 +54,8 @@ impl StoreIngestionClient {
     /// Fetch and decode checkpoint data by sequence number.
     pub async fn checkpoint(&self, checkpoint: u64) -> anyhow::Result<Checkpoint> {
         let bytes = self.checkpoint_bytes(checkpoint).await?;
+        // zstd decompress + prost decode + proto -> Checkpoint is multi-ms of CPU
+        // work; offload to the blocking pool so it doesn't stall the reactor.
         let decoded = tokio::task::spawn_blocking(move || decode::checkpoint(&bytes))
             .await
             .context("decode task panicked")??;
@@ -112,6 +114,8 @@ impl IngestionClientTrait for StoreIngestionClient {
         if let Some(counter) = &self.total_ingested_bytes {
             counter.inc_by(bytes.len() as u64);
         }
+        // zstd decompress + prost decode + proto -> Checkpoint is multi-ms of CPU
+        // work; offload to the blocking pool so it doesn't stall the reactor.
         tokio::task::spawn_blocking(move || decode::checkpoint(&bytes))
             .await
             .map_err(|e| CheckpointError::Fetch(anyhow::anyhow!("decode task panicked: {e}")))?

--- a/crates/sui-indexer-alt-framework/src/ingestion/store_client.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/store_client.rs
@@ -54,7 +54,10 @@ impl StoreIngestionClient {
     /// Fetch and decode checkpoint data by sequence number.
     pub async fn checkpoint(&self, checkpoint: u64) -> anyhow::Result<Checkpoint> {
         let bytes = self.checkpoint_bytes(checkpoint).await?;
-        Ok(decode::checkpoint(&bytes)?)
+        let decoded = tokio::task::spawn_blocking(move || decode::checkpoint(&bytes))
+            .await
+            .context("decode task panicked")??;
+        Ok(decoded)
     }
 
     async fn checkpoint_bytes(&self, checkpoint: u64) -> object_store::Result<Bytes> {
@@ -109,7 +112,10 @@ impl IngestionClientTrait for StoreIngestionClient {
         if let Some(counter) = &self.total_ingested_bytes {
             counter.inc_by(bytes.len() as u64);
         }
-        decode::checkpoint(&bytes).map_err(CheckpointError::Decode)
+        tokio::task::spawn_blocking(move || decode::checkpoint(&bytes))
+            .await
+            .map_err(|e| CheckpointError::Fetch(anyhow::anyhow!("decode task panicked: {e}")))?
+            .map_err(CheckpointError::Decode)
     }
 
     async fn latest_checkpoint_number(&self) -> anyhow::Result<u64> {

--- a/crates/sui-indexer-alt-framework/src/ingestion/streaming_client.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/streaming_client.rs
@@ -101,16 +101,26 @@ impl CheckpointStreamingClient for GrpcStreamingClient {
             .map_err(|e| Error::StreamingError(anyhow!("Chain ID parse error: {e}")))?
             .into();
 
-        let stream = response.into_inner().map(|result| match result {
-            Ok(response) => response
-                .checkpoint
-                .context("Checkpoint data missing in response")
-                .and_then(|checkpoint| {
-                    Checkpoint::try_from(&checkpoint).context("Failed to parse checkpoint")
-                })
-                .map_err(Error::StreamingError),
-            Err(e) => Err(Error::RpcClientError(e)),
-        });
+        let stream = response
+            .into_inner()
+            .map(|result| async move {
+                match result {
+                    Ok(response) => {
+                        let checkpoint = response
+                            .checkpoint
+                            .context("Checkpoint data missing in response")
+                            .map_err(Error::StreamingError)?;
+                        tokio::task::spawn_blocking(move || {
+                            Checkpoint::try_from(&checkpoint).context("Failed to parse checkpoint")
+                        })
+                        .await
+                        .map_err(|e| Error::StreamingError(anyhow!("decode task panicked: {e}")))?
+                        .map_err(Error::StreamingError)
+                    }
+                    Err(e) => Err(Error::RpcClientError(e)),
+                }
+            })
+            .buffered(4);
         let stream = wrap_stream(stream, self.statement_timeout);
 
         Ok(CheckpointStream { stream, chain_id })

--- a/crates/sui-indexer-alt-framework/src/ingestion/streaming_client.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/streaming_client.rs
@@ -110,6 +110,10 @@ impl CheckpointStreamingClient for GrpcStreamingClient {
                             .checkpoint
                             .context("Checkpoint data missing in response")
                             .map_err(Error::StreamingError)?;
+                        // Proto -> Checkpoint conversion is multi-ms of CPU work;
+                        // offload to the blocking pool so it doesn't stall the reactor.
+                        // Combined with `.buffered(4)` below, up to 4 decodes can run
+                        // concurrently while new bytes keep flowing from gRPC.
                         tokio::task::spawn_blocking(move || {
                             Checkpoint::try_from(&checkpoint).context("Failed to parse checkpoint")
                         })


### PR DESCRIPTION
## Description

I was debugging throughput bottlenecks in the bigtable indexer and found that checkpoint decoding is quite expensive (about 10% of overall CPU) and the tasks are course-grained enough to warrant moving off of the tokio io threads.

```
  ┌────────────────────────────────┬─────────┬─────────┬──────────┐
  │              step              │   avg   │   p50   │   p99    │
  ├────────────────────────────────┼─────────┼─────────┼──────────┤
  │ total (zstd + prost + TryFrom) │ 3.97 ms │ 4.37 ms │ 18.82 ms │
  ├────────────────────────────────┼─────────┼─────────┼──────────┤
  │ prost decode alone             │ 0.50 ms │ 0.54 ms │ 4.71 ms  │
  ├────────────────────────────────┼─────────┼─────────┼──────────┤
  │ TryFrom (proto→native) alone   │ 2.40 ms │ 1.80 ms │ 13.72 ms │
  └────────────────────────────────┴─────────┴─────────┴──────────┘
```

This frees up the io threads to keep doing io dispatch work to keep work moving through the system.

## Test plan

I'm running it in my bigtable bitmap index backfill. This wasn't the thing that finally moved the needle, but I never tested without it after resolving the primary bottleneck. It just seems like the correct thing to do given the cost of these tasks regardless.
