### PR TITLE
soft-deprecate checkpoint-buffer-size

### DIFF
--- a/crates/sui-analytics-indexer/src/config.rs
+++ b/crates/sui-analytics-indexer/src/config.rs
@@ -13,6 +13,7 @@ use sui_indexer_alt_framework::ingestion::{IngestConcurrencyConfig, IngestionCon
 use sui_indexer_alt_framework::pipeline;
 use sui_indexer_alt_framework::pipeline::CommitterConfig;
 use sui_indexer_alt_framework::pipeline::sequential::SequentialConfig;
+use tracing::warn;
 
 use crate::pipeline::Pipeline;
 
@@ -129,10 +130,23 @@ pub struct IngestionLayer {
     pub streaming_backoff_max_batch_size: Option<usize>,
     pub streaming_connection_timeout_ms: Option<u64>,
     pub streaming_statement_timeout_ms: Option<u64>,
+
+    /// Deprecated: accepted (and ignored) so old configs don't fail to parse. Replaced by
+    /// per-pipeline `ingestion.subscriber_channel_size`.
+    #[serde(default)]
+    pub checkpoint_buffer_size: Option<usize>,
 }
 
 impl IngestionLayer {
     pub fn finish(self, base: IngestionConfig) -> IngestionConfig {
+        if self.checkpoint_buffer_size.is_some() {
+            warn!(
+                "Config field `checkpoint_buffer_size` is deprecated and ignored. Remove it from \
+                 your config; set `subscriber_channel_size` under each pipeline's `ingestion` \
+                 section if you need to override the default."
+            );
+        }
+
         IngestionConfig {
             ingest_concurrency: self.ingest_concurrency.unwrap_or(base.ingest_concurrency),
             retry_interval_ms: self.retry_interval_ms.unwrap_or(base.retry_interval_ms),

--- a/crates/sui-checkpoint-blob-indexer/src/config.rs
+++ b/crates/sui-checkpoint-blob-indexer/src/config.rs
@@ -7,6 +7,7 @@ use sui_indexer_alt_framework::config::ConcurrencyConfig;
 use sui_indexer_alt_framework::pipeline;
 use sui_indexer_alt_framework::pipeline::CommitterConfig;
 use sui_indexer_alt_framework::pipeline::concurrent::ConcurrentConfig;
+use tracing::warn;
 
 #[DefaultConfig]
 #[derive(Clone, Default, Debug)]
@@ -115,6 +116,10 @@ pub struct IngestionConfig {
     pub streaming_backoff_max_batch_size: usize,
     pub streaming_connection_timeout_ms: u64,
     pub streaming_statement_timeout_ms: u64,
+
+    /// Deprecated: accepted (and ignored) so old configs don't fail to parse. Replaced by
+    /// per-pipeline `ingestion.subscriber-channel-size`.
+    pub checkpoint_buffer_size: Option<usize>,
 }
 
 impl Default for IngestionConfig {
@@ -132,12 +137,21 @@ impl From<framework::ingestion::IngestionConfig> for IngestionConfig {
             streaming_backoff_max_batch_size: config.streaming_backoff_max_batch_size,
             streaming_connection_timeout_ms: config.streaming_connection_timeout_ms,
             streaming_statement_timeout_ms: config.streaming_statement_timeout_ms,
+            checkpoint_buffer_size: None,
         }
     }
 }
 
 impl From<IngestionConfig> for framework::ingestion::IngestionConfig {
     fn from(config: IngestionConfig) -> Self {
+        if config.checkpoint_buffer_size.is_some() {
+            warn!(
+                "Config field `checkpoint-buffer-size` is deprecated and ignored. Remove it from \
+                 your config; set `subscriber-channel-size` under each pipeline's `ingestion` \
+                 section if you need to override the default."
+            );
+        }
+
         framework::ingestion::IngestionConfig {
             ingest_concurrency: config.ingest_concurrency,
             retry_interval_ms: config.retry_interval_ms,

--- a/crates/sui-indexer-alt-consistent-store/src/config.rs
+++ b/crates/sui-indexer-alt-consistent-store/src/config.rs
@@ -4,6 +4,7 @@
 use sui_default_config::DefaultConfig;
 use sui_indexer_alt_framework as framework;
 use sui_indexer_alt_framework::pipeline::CommitterConfig;
+use tracing::warn;
 
 use crate::DbConfig;
 use crate::rpc::pagination::PaginationConfig;
@@ -43,6 +44,10 @@ pub struct IngestionConfig {
     pub streaming_backoff_max_batch_size: usize,
     pub streaming_connection_timeout_ms: u64,
     pub streaming_statement_timeout_ms: u64,
+
+    /// Deprecated: accepted (and ignored) so old configs don't fail to parse. Replaced by
+    /// per-pipeline `ingestion.subscriber-channel-size`.
+    pub checkpoint_buffer_size: Option<usize>,
 }
 
 #[DefaultConfig]
@@ -150,12 +155,21 @@ impl From<framework::ingestion::IngestionConfig> for IngestionConfig {
             streaming_backoff_max_batch_size: config.streaming_backoff_max_batch_size,
             streaming_connection_timeout_ms: config.streaming_connection_timeout_ms,
             streaming_statement_timeout_ms: config.streaming_statement_timeout_ms,
+            checkpoint_buffer_size: None,
         }
     }
 }
 
 impl From<IngestionConfig> for framework::ingestion::IngestionConfig {
     fn from(config: IngestionConfig) -> Self {
+        if config.checkpoint_buffer_size.is_some() {
+            warn!(
+                "Config field `checkpoint-buffer-size` is deprecated and ignored. Remove it from \
+                 your config; set `subscriber-channel-size` under each pipeline's `ingestion` \
+                 section if you need to override the default."
+            );
+        }
+
         framework::ingestion::IngestionConfig {
             ingest_concurrency: config.ingest_concurrency,
             retry_interval_ms: config.retry_interval_ms,

--- a/crates/sui-indexer-alt/src/config.rs
+++ b/crates/sui-indexer-alt/src/config.rs
@@ -9,6 +9,7 @@ use sui_indexer_alt_framework::pipeline::CommitterConfig;
 use sui_indexer_alt_framework::pipeline::concurrent::ConcurrentConfig;
 use sui_indexer_alt_framework::pipeline::concurrent::PrunerConfig;
 use sui_indexer_alt_framework::pipeline::sequential::SequentialConfig;
+use tracing::warn;
 
 /// Trait for merging configuration structs together.
 pub trait Merge: Sized {
@@ -55,6 +56,10 @@ pub struct IngestionLayer {
     pub streaming_backoff_max_batch_size: Option<usize>,
     pub streaming_connection_timeout_ms: Option<u64>,
     pub streaming_statement_timeout_ms: Option<u64>,
+
+    /// Deprecated: accepted (and ignored) so old configs don't fail to parse. Replaced by
+    /// per-pipeline `ingestion.subscriber-channel-size`.
+    pub checkpoint_buffer_size: Option<usize>,
 }
 
 #[DefaultConfig]
@@ -185,6 +190,14 @@ impl IndexerConfig {
 
 impl IngestionLayer {
     pub fn finish(self, base: IngestionConfig) -> anyhow::Result<IngestionConfig> {
+        if self.checkpoint_buffer_size.is_some() {
+            warn!(
+                "Config field `checkpoint-buffer-size` is deprecated and ignored. Remove it from \
+                 your config; set `subscriber-channel-size` under each pipeline's `ingestion` \
+                 section if you need to override the default."
+            );
+        }
+
         Ok(IngestionConfig {
             ingest_concurrency: self.ingest_concurrency.unwrap_or(base.ingest_concurrency),
             retry_interval_ms: self.retry_interval_ms.unwrap_or(base.retry_interval_ms),
@@ -348,6 +361,7 @@ impl Merge for IngestionLayer {
             streaming_statement_timeout_ms: other
                 .streaming_statement_timeout_ms
                 .or(self.streaming_statement_timeout_ms),
+            checkpoint_buffer_size: other.checkpoint_buffer_size.or(self.checkpoint_buffer_size),
         })
     }
 }
@@ -469,6 +483,7 @@ impl From<IngestionConfig> for IngestionLayer {
             streaming_backoff_max_batch_size: Some(config.streaming_backoff_max_batch_size),
             streaming_connection_timeout_ms: Some(config.streaming_connection_timeout_ms),
             streaming_statement_timeout_ms: Some(config.streaming_statement_timeout_ms),
+            checkpoint_buffer_size: None,
         }
     }
 }
@@ -817,5 +832,18 @@ mod tests {
             err.to_string().contains("i_dont_exist"),
             "Unexpected error: {err}"
         );
+    }
+
+    #[test]
+    fn deprecated_checkpoint_buffer_size_parses() {
+        let config: IndexerConfig = toml::from_str(
+            r#"
+            [ingestion]
+            checkpoint-buffer-size = 5000
+            "#,
+        )
+        .expect("deprecated `checkpoint-buffer-size` must deserialize without error");
+
+        assert_eq!(config.ingestion.checkpoint_buffer_size, Some(5000));
     }
 }

--- a/crates/sui-kvstore/src/config.rs
+++ b/crates/sui-kvstore/src/config.rs
@@ -211,6 +211,10 @@ pub struct IngestionConfig {
     pub streaming_backoff_max_batch_size: usize,
     pub streaming_connection_timeout_ms: u64,
     pub streaming_statement_timeout_ms: u64,
+
+    /// Deprecated: accepted (and ignored) so old configs don't fail to parse. Replaced by
+    /// per-pipeline `ingestion.subscriber-channel-size`.
+    pub checkpoint_buffer_size: Option<usize>,
 }
 
 impl Default for IngestionConfig {
@@ -228,12 +232,21 @@ impl From<framework::ingestion::IngestionConfig> for IngestionConfig {
             streaming_backoff_max_batch_size: config.streaming_backoff_max_batch_size,
             streaming_connection_timeout_ms: config.streaming_connection_timeout_ms,
             streaming_statement_timeout_ms: config.streaming_statement_timeout_ms,
+            checkpoint_buffer_size: None,
         }
     }
 }
 
 impl From<IngestionConfig> for framework::ingestion::IngestionConfig {
     fn from(config: IngestionConfig) -> Self {
+        if config.checkpoint_buffer_size.is_some() {
+            warn!(
+                "Config field `checkpoint-buffer-size` is deprecated and ignored. Remove it from \
+                 your config; set `subscriber-channel-size` under each pipeline's `ingestion` \
+                 section if you need to override the default."
+            );
+        }
+
         framework::ingestion::IngestionConfig {
             ingest_concurrency: config.ingest_concurrency,
             retry_interval_ms: config.retry_interval_ms,


### PR DESCRIPTION
## Description

In <https://github.com/MystenLabs/sui/pull/26302> I deprecated checkpoint-buffer-size, but I meant to "soft deprecate" it, not hard-fail with deserialization errors. This PR adds a warning that the field is now ignored. We can fully rip it out later.
