### PR TITLE
[sui-adapter] Add type linkage caching as well as type conversion and loaded function caches

### DIFF
--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -1082,6 +1082,10 @@ struct FeatureFlags {
     // MAX_PUBLIC_INPUTS public inputs.
     #[serde(skip_serializing_if = "is_false")]
     limit_groth16_pvk_inputs: bool,
+
+    // If true, enable caching in ptb execution.
+    #[serde(skip_serializing_if = "is_false")]
+    enable_ptb_tx_cache: bool,
 }
 
 fn is_false(b: &bool) -> bool {
@@ -2812,6 +2816,10 @@ impl ProtocolConfig {
 
     pub fn limit_groth16_pvk_inputs(&self) -> bool {
         self.feature_flags.limit_groth16_pvk_inputs
+    }
+
+    pub fn enable_ptb_tx_cache(&self) -> bool {
+        self.feature_flags.enable_ptb_tx_cache
     }
 }
 
@@ -4893,6 +4901,7 @@ impl ProtocolConfig {
                     }
                     cfg.gas_model_version = Some(12);
                     cfg.feature_flags.limit_groth16_pvk_inputs = true;
+                    cfg.feature_flags.enable_ptb_tx_cache = true;
                 }
                 // Use this template when making changes:
                 //

--- a/external-crates/move/crates/move-vm-runtime/src/dev_utils/gas_schedule.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/dev_utils/gas_schedule.rs
@@ -28,7 +28,6 @@ use move_core_types::{
         AbstractMemorySize, GasQuantity, InternalGas, InternalGasPerAbstractMemoryUnit,
         InternalGasUnit, NumArgs, NumBytes, ToUnit, ToUnitFractional,
     },
-    language_storage::ModuleId,
     u256,
 };
 use serde::{Deserialize, Serialize};
@@ -292,8 +291,6 @@ impl GasMeter for GasStatus<'_> {
 
     fn charge_call(
         &mut self,
-        _module_id: &ModuleId,
-        _func_name: &str,
         args: impl ExactSizeIterator<Item = impl ValueView>,
         _num_locals: NumArgs,
     ) -> PartialVMResult<()> {
@@ -302,8 +299,6 @@ impl GasMeter for GasStatus<'_> {
 
     fn charge_call_generic(
         &mut self,
-        _module_id: &ModuleId,
-        _func_name: &str,
         args: impl ExactSizeIterator<Item = impl ValueView>,
         _num_locals: NumArgs,
     ) -> PartialVMResult<()> {

--- a/external-crates/move/crates/move-vm-runtime/src/dev_utils/tiered_gas_schedule.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/dev_utils/tiered_gas_schedule.rs
@@ -11,12 +11,9 @@ use move_binary_format::{
     errors::{PartialVMError, PartialVMResult},
     partial_vm_error,
 };
-use move_core_types::{
-    gas_algebra::{
-        AbstractMemorySize, GasQuantity, InternalGas, InternalGasUnit, NumArgs, NumBytes, ToUnit,
-        ToUnitFractional,
-    },
-    language_storage::ModuleId,
+use move_core_types::gas_algebra::{
+    AbstractMemorySize, GasQuantity, InternalGas, InternalGasUnit, NumArgs, NumBytes, ToUnit,
+    ToUnitFractional,
 };
 
 use crate::{
@@ -522,8 +519,6 @@ impl<'b> GasMeter for GasStatus<'b> {
 
     fn charge_call(
         &mut self,
-        _module_id: &ModuleId,
-        _func_name: &str,
         mut args: impl ExactSizeIterator<Item = impl ValueView>,
         _num_locals: NumArgs,
     ) -> PartialVMResult<()> {
@@ -539,8 +534,6 @@ impl<'b> GasMeter for GasStatus<'b> {
 
     fn charge_call_generic(
         &mut self,
-        _module_id: &ModuleId,
-        _func_name: &str,
         mut args: impl ExactSizeIterator<Item = impl ValueView>,
         _num_locals: NumArgs,
     ) -> PartialVMResult<()> {

--- a/external-crates/move/crates/move-vm-runtime/src/execution/interpreter/eval.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/execution/interpreter/eval.rs
@@ -905,7 +905,6 @@ fn call_function(
     });
 
     // Charge gas
-    let module_id = function.module_id(&run_context.vtables.interner);
     let last_n_operands = state
         .last_n_operands(function.arg_count())
         .map_err(|e| set_err_info!(run_context.interner(), state.call_stack.current_frame, e))?;
@@ -913,24 +912,14 @@ fn call_function(
     if ty_args.is_empty() {
         // Charge for a non-generic call
         gas_meter
-            .charge_call(
-                &module_id,
-                &function.name_str(&run_context.vtables.interner),
-                last_n_operands,
-                (function.local_count() as u64).into(),
-            )
+            .charge_call(last_n_operands, (function.local_count() as u64).into())
             .map_err(|e| {
                 set_err_info!(run_context.interner(), state.call_stack.current_frame, e)
             })?;
     } else {
         // Charge for a generic call
         gas_meter
-            .charge_call_generic(
-                &module_id,
-                &function.name_str(&run_context.vtables.interner),
-                last_n_operands,
-                (function.local_count() as u64).into(),
-            )
+            .charge_call_generic(last_n_operands, (function.local_count() as u64).into())
             .map_err(|e| {
                 set_err_info!(run_context.interner(), state.call_stack.current_frame, e)
             })?;

--- a/external-crates/move/crates/move-vm-runtime/src/jit/execution/ast.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/jit/execution/ast.rs
@@ -885,6 +885,7 @@ impl Function {
         self.return_.len()
     }
 
+    #[allow(dead_code)]
     pub fn name_str(&self, interner: &IdentifierInterner) -> String {
         self.name(interner).to_string()
     }

--- a/external-crates/move/crates/move-vm-runtime/src/shared/gas.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/shared/gas.rs
@@ -3,10 +3,7 @@
 
 use crate::shared::views::ValueView;
 use move_binary_format::errors::PartialVMResult;
-use move_core_types::{
-    gas_algebra::{InternalGas, NumArgs, NumBytes},
-    language_storage::ModuleId,
-};
+use move_core_types::gas_algebra::{InternalGas, NumArgs, NumBytes};
 
 /// Enum of instructions that do not need extra information for gas metering.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -77,16 +74,12 @@ pub trait GasMeter {
 
     fn charge_call(
         &mut self,
-        module_id: &ModuleId,
-        func_name: &str,
         args: impl ExactSizeIterator<Item = impl ValueView>,
         num_locals: NumArgs,
     ) -> PartialVMResult<()>;
 
     fn charge_call_generic(
         &mut self,
-        module_id: &ModuleId,
-        func_name: &str,
         args: impl ExactSizeIterator<Item = impl ValueView>,
         num_locals: NumArgs,
     ) -> PartialVMResult<()>;
@@ -186,8 +179,6 @@ impl GasMeter for UnmeteredGasMeter {
 
     fn charge_call(
         &mut self,
-        _module_id: &ModuleId,
-        _func_name: &str,
         _args: impl IntoIterator<Item = impl ValueView>,
         _num_locals: NumArgs,
     ) -> PartialVMResult<()> {
@@ -196,8 +187,6 @@ impl GasMeter for UnmeteredGasMeter {
 
     fn charge_call_generic(
         &mut self,
-        _module_id: &ModuleId,
-        _func_name: &str,
         _args: impl ExactSizeIterator<Item = impl ValueView>,
         _num_locals: NumArgs,
     ) -> PartialVMResult<()> {

--- a/sui-execution/latest/sui-adapter/src/gas_meter.rs
+++ b/sui-execution/latest/sui-adapter/src/gas_meter.rs
@@ -4,10 +4,7 @@
 use std::ops::DerefMut;
 
 use move_binary_format::errors::PartialVMResult;
-use move_core_types::{
-    gas_algebra::{AbstractMemorySize, InternalGas, NumArgs, NumBytes},
-    language_storage::ModuleId,
-};
+use move_core_types::gas_algebra::{AbstractMemorySize, InternalGas, NumArgs, NumBytes};
 use move_vm_runtime::{
     execution::Type,
     shared::{
@@ -170,8 +167,6 @@ impl<G: DerefMut<Target = GasStatus>> GasMeter for SuiGasMeter<G> {
 
     fn charge_call(
         &mut self,
-        _module_id: &ModuleId,
-        _func_name: &str,
         mut args: impl ExactSizeIterator<Item = impl ValueView>,
         _num_locals: NumArgs,
     ) -> PartialVMResult<()> {
@@ -188,8 +183,6 @@ impl<G: DerefMut<Target = GasStatus>> GasMeter for SuiGasMeter<G> {
 
     fn charge_call_generic(
         &mut self,
-        _module_id: &ModuleId,
-        _func_name: &str,
         mut args: impl ExactSizeIterator<Item = impl ValueView>,
         _num_locals: NumArgs,
     ) -> PartialVMResult<()> {

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/env/cache.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/env/cache.rs
@@ -6,7 +6,9 @@ use crate::static_programmable_transactions::{
     loading::ast::{LoadedFunction, Type},
 };
 use indexmap::IndexSet;
-use move_core_types::{account_address::AccountAddress, language_storage::TypeTag};
+use move_core_types::{
+    account_address::AccountAddress, identifier::IdentStr, language_storage::TypeTag,
+};
 use move_vm_runtime::execution as vm_runtime;
 use std::{
     cell::RefCell,
@@ -86,6 +88,8 @@ struct PerTxCache_ {
     /// the version-specific package ID because private/entry functions can disappear across
     /// package versions, so different versions resolve differently.
     function_cache: HashMap<LoadedFunctionKey, Rc<LoadedFunction>>,
+
+    defining_id_map: HashMap<(ObjectID, Identifier, Identifier), ObjectID>,
 }
 
 /// Early-returns `Ok($empty)` from the enclosing method when PTB caching is disabled. The second
@@ -112,6 +116,7 @@ impl<'pc> PerTxCache<'pc> {
                 vm_to_type: HashMap::new(),
                 type_to_vm: HashMap::new(),
                 function_cache: HashMap::new(),
+                defining_id_map: HashMap::new(),
             }),
         }
     }
@@ -278,6 +283,42 @@ impl<'pc> PerTxCache<'pc> {
             "duplicate insert into function_cache"
         );
         Ok(())
+    }
+
+    pub(super) fn insert_type_to_defining_id(
+        &self,
+        package: ObjectID,
+        module: &IdentStr,
+        name: &IdentStr,
+        defining_id: ObjectID,
+    ) -> Result<(), ExecutionError> {
+        gated!(self.protocol_config, ());
+        let previous = self
+            .borrow_mut()?
+            .defining_id_map
+            .insert((package, module.to_owned(), name.to_owned()), defining_id);
+        assert_invariant!(
+            previous.is_none(),
+            "duplicate insert into defining_id_map: ({}::{}::{})",
+            package,
+            module,
+            name
+        );
+        Ok(())
+    }
+
+    pub(super) fn lookup_type_to_defining_id(
+        &self,
+        package: ObjectID,
+        module: &IdentStr,
+        name: &IdentStr,
+    ) -> Result<Option<ObjectID>, ExecutionError> {
+        gated!(self.protocol_config, None);
+        Ok(self
+            .borrow()?
+            .defining_id_map
+            .get(&(package, module.to_owned(), name.to_owned()))
+            .cloned())
     }
 }
 

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/env/cache.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/env/cache.rs
@@ -150,7 +150,7 @@ impl<'pc> PerTxCache<'pc> {
         Ok(())
     }
 
-    pub(super) fn lookup_type_by_input(
+    pub(super) fn lookup_type_input(
         &self,
         input: &TypeInput,
     ) -> Result<Option<Type>, ExecutionError> {
@@ -169,16 +169,13 @@ impl<'pc> PerTxCache<'pc> {
             "TypeInput cannot represent a reference type: {:?}",
             ty
         );
-        let mut c = self.borrow_mut()?;
-        if let Some(existing) = c.type_input_to_type.get(&input) {
-            assert_invariant!(
-                existing == &ty,
-                "cache inconsistency on type_input_to_type: existing {:?} vs new {:?}",
-                existing,
-                ty
-            );
-        }
-        c.type_input_to_type.insert(input, ty);
+
+        let previous = self.borrow_mut()?.type_input_to_type.insert(input, ty);
+        assert_invariant!(
+            previous.is_none(),
+            "duplicate insert into type_input_to_type"
+        );
+
         Ok(())
     }
 
@@ -201,31 +198,22 @@ impl<'pc> PerTxCache<'pc> {
         ty: Type,
     ) -> Result<(Rc<TypeTag>, Type), ExecutionError> {
         let tag = Rc::new(tag);
+
         gated!(self.protocol_config, (tag, ty));
         assert_invariant!(
             !matches!(ty, Type::Reference(_, _)),
             "TypeTag cannot represent a reference type: {:?}",
             ty
         );
+
         let mut c = self.borrow_mut()?;
-        if let Some(existing) = c.tag_to_type.get(&tag) {
-            assert_invariant!(
-                existing == &ty,
-                "cache inconsistency on tag_to_type: existing {:?} vs new {:?}",
-                existing,
-                ty
-            );
-        }
-        if let Some(existing) = c.type_to_tag.get(&ty) {
-            assert_invariant!(
-                existing == &tag,
-                "cache inconsistency on type_to_tag: existing {:?} vs new {:?}",
-                existing,
-                tag
-            );
-        }
-        c.tag_to_type.insert(tag.clone(), ty.clone());
-        c.type_to_tag.insert(ty.clone(), tag.clone());
+
+        let previous_tag = c.tag_to_type.insert(tag.clone(), ty.clone());
+        assert_invariant!(previous_tag.is_none(), "duplicate insert into tag_to_type");
+
+        let previous_type = c.type_to_tag.insert(ty.clone(), tag.clone());
+        assert_invariant!(previous_type.is_none(), "duplicate insert into type_to_tag");
+
         Ok((tag, ty))
     }
 
@@ -251,31 +239,25 @@ impl<'pc> PerTxCache<'pc> {
         ty: Type,
     ) -> Result<(Rc<vm_runtime::Type>, Type), ExecutionError> {
         let vm_type = Rc::new(vm_type);
+
         gated!(self.protocol_config, (vm_type, ty));
         assert_invariant!(
             !matches!(vm_type.as_ref(), vm_runtime::Type::TyParam(_)),
             "cannot cache unresolved TyParam: {:?}",
             vm_type
         );
+
         let mut c = self.borrow_mut()?;
-        if let Some(existing) = c.vm_to_type.get(&vm_type) {
-            assert_invariant!(
-                existing == &ty,
-                "cache inconsistency on vm_to_type: existing {:?} vs new {:?}",
-                existing,
-                ty
-            );
-        }
-        if let Some(existing) = c.type_to_vm.get(&ty) {
-            assert_invariant!(
-                existing == &vm_type,
-                "cache inconsistency on type_to_vm: existing {:?} vs new {:?}",
-                existing,
-                vm_type
-            );
-        }
-        c.vm_to_type.insert(vm_type.clone(), ty.clone());
-        c.type_to_vm.insert(ty.clone(), vm_type.clone());
+
+        let previous_vm_type = c.vm_to_type.insert(vm_type.clone(), ty.clone());
+        assert_invariant!(
+            previous_vm_type.is_none(),
+            "duplicate insert into vm_to_type"
+        );
+
+        let previous_type = c.type_to_vm.insert(ty.clone(), vm_type.clone());
+        assert_invariant!(previous_type.is_none(), "duplicate insert into type_to_vm");
+
         Ok((vm_type, ty))
     }
 
@@ -293,21 +275,11 @@ impl<'pc> PerTxCache<'pc> {
         function: Rc<LoadedFunction>,
     ) -> Result<(), ExecutionError> {
         gated!(self.protocol_config, ());
-        let mut c = self.borrow_mut()?;
-        if let Some(existing) = c.function_cache.get(&key) {
-            // Structural drift check: the fields that the key pins down should match. Anything
-            // derived (visibility / is_entry / instruction_length / definition_index / signature)
-            // is a pure function of those inputs, so if the key agrees the result must too.
-            assert_invariant!(
-                existing.version_mid == function.version_mid
-                    && existing.original_mid == function.original_mid
-                    && existing.is_entry == function.is_entry
-                    && existing.visibility == function.visibility,
-                "function_cache drift for key {:?}",
-                key
-            );
-        }
-        c.function_cache.insert(key, function);
+        let previous_function = self.borrow_mut()?.function_cache.insert(key, function);
+        assert_invariant!(
+            previous_function.is_none(),
+            "duplicate insert into function_cache"
+        );
         Ok(())
     }
 }

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/env/cache.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/env/cache.rs
@@ -184,10 +184,7 @@ impl<'pc> PerTxCache<'pc> {
         Ok(self.borrow()?.tag_to_type.get(tag).cloned())
     }
 
-    pub(super) fn lookup_tag_by_type(
-        &self,
-        ty: &Type,
-    ) -> Result<Option<Rc<TypeTag>>, ExecutionError> {
+    pub(super) fn lookup_tag(&self, ty: &Type) -> Result<Option<Rc<TypeTag>>, ExecutionError> {
         gated!(self.protocol_config, None);
         Ok(self.borrow()?.type_to_tag.get(ty).cloned())
     }
@@ -225,7 +222,7 @@ impl<'pc> PerTxCache<'pc> {
         Ok(self.borrow()?.vm_to_type.get(vm_type).cloned())
     }
 
-    pub(super) fn lookup_vm_type_by_type(
+    pub(super) fn lookup_vm_type(
         &self,
         ty: &Type,
     ) -> Result<Option<Rc<vm_runtime::Type>>, ExecutionError> {

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/env/cache.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/env/cache.rs
@@ -1,13 +1,19 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::static_programmable_transactions::{
-    linkage::resolved_linkage::ExecutableLinkage,
-    loading::ast::{LoadedFunction, Type},
+use crate::{
+    data_store::PackageStore,
+    static_programmable_transactions::{
+        linkage::{resolution::ResolutionTable, resolved_linkage::ExecutableLinkage},
+        loading::ast::{LoadedFunction, Type},
+    },
 };
 use indexmap::IndexSet;
 use move_core_types::{
-    account_address::AccountAddress, identifier::IdentStr, language_storage::TypeTag,
+    account_address::AccountAddress,
+    identifier::IdentStr,
+    language_storage::{StructTag, TypeTag},
+    resolver::IntraPackageName,
 };
 use move_vm_runtime::execution as vm_runtime;
 use std::{
@@ -16,10 +22,16 @@ use std::{
     rc::Rc,
 };
 use sui_protocol_config::ProtocolConfig;
-use sui_types::{Identifier, base_types::ObjectID, error::ExecutionError, type_input::TypeInput};
+use sui_types::{
+    Identifier,
+    base_types::ObjectID,
+    error::ExecutionError,
+    execution_status::{ExecutionErrorKind, TypeArgumentError},
+    type_input::{StructInput, TypeInput},
+};
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub(super) struct TypeLinkageCacheKey {
+pub(crate) struct TypeLinkageCacheKey {
     // NB: We use a BTreeSet here to ensure that the order of the root IDs does not affect the
     // cache key.
     root_ids: BTreeSet<AccountAddress>,
@@ -33,7 +45,7 @@ pub(super) struct LoadedFunctionKey {
     type_arguments: Vec<Type>,
 }
 
-pub(super) struct PerTxCache<'pc> {
+pub(crate) struct PerTxCache<'pc> {
     protocol_config: &'pc ProtocolConfig,
     inner: RefCell<PerTxCache_>,
 }
@@ -42,10 +54,14 @@ pub(super) struct PerTxCache<'pc> {
 ///
 /// The tables fall into four groups:
 ///
-/// 1. **Linkage resolution** (`type_linkage_cache`): computing an `ExecutableLinkage` for a set of
-///    defining-ID addresses touches every transitive dependency of those packages; the same set
-///    of roots may be queried many times within a single PTB (once per type input, once per type
-///    argument on a call, etc.). This caches that lookup.
+/// 1. **Linkage resolution** (`type_resolution_cache`): computing the transitive-dependency
+///    `ResolutionTable` for a set of root addresses touches every transitive dependency of
+///    those packages; the same set of roots may be queried many times within a single PTB
+///    (once per object input, once per type argument on a call, once per `get_type_linkage`,
+///    etc.). Caching the `ResolutionTable` (rather than the derived `ExecutableLinkage`) lets
+///    input-resolution analysis fold cached smaller resolution tables into the PTB-wide table
+///    without re-walking, and lets `Env::get_type_linkage` derive its `ExecutableLinkage` from the
+///    same source.
 ///
 /// 2. **TypeInput resolution** (`type_input_to_type`): user-supplied `TypeInput`s are resolved to
 ///    adapter `Type`s via a tag lookup + VM load. Kept one-way because multiple `TypeInput`s can
@@ -67,13 +83,26 @@ pub(super) struct PerTxCache<'pc> {
 /// tuples, so hashing dominates over ordered iteration, and `vm_runtime::Type` in particular
 /// only implements `Hash + Eq` (not `Ord`).
 struct PerTxCache_ {
-    /// Linkage resolutions keyed by `<defining-ID root set>`.
-    ///
-    /// NB: this can only be used for determining type linkages.
-    type_linkage_cache: HashMap<TypeLinkageCacheKey, ExecutableLinkage>,
+    /// Per-tag small `ResolutionTable`s keyed by the root-address set walked. Used both to
+    /// fold into the PTB-wide table during input-resolution analysis and to derive the
+    /// `ExecutableLinkage` that `Env::get_type_linkage` returns on the error path.
+    type_resolution_cache: HashMap<TypeLinkageCacheKey, Rc<ResolutionTable>>,
+
+    /// Cached `ExecutableLinkage` derived from the `ResolutionTable` of the same key. Avoids
+    /// re-cloning the table and re-running `ResolvedLinkage::from_resolution_table` on every
+    /// `Env::get_type_linkage` call (which fires once per VM error decoration).
+    /// `ExecutableLinkage` is itself a thin `Rc` wrapper, so cloning it out of the map is cheap.
+    type_executable_linkage_cache: HashMap<TypeLinkageCacheKey, ExecutableLinkage>,
 
     /// TypeInput -> adapter Type. One-way only.
     type_input_to_type: HashMap<TypeInput, Type>,
+
+    /// TypeInput -> defining-ID `TypeTag`. The rewrite walks each `TypeInput::Struct`,
+    /// resolves its `address` through the package's `type_origin_table` to the defining ID
+    /// for the named type, and recurses into type params. This is keyed on the raw
+    /// user-supplied `TypeInput` because the same input is queried both during input
+    /// resolution analysis (for linkage pre-warming) and during loading.
+    type_input_to_tag: HashMap<TypeInput, Rc<TypeTag>>,
 
     /// Bijective Type <-> TypeTag. Populated atomically via `insert_tag_type_pair`.
     tag_to_type: HashMap<Rc<TypeTag>, Type>,
@@ -105,12 +134,14 @@ macro_rules! gated {
 }
 
 impl<'pc> PerTxCache<'pc> {
-    pub(super) fn new(protocol_config: &'pc ProtocolConfig) -> Self {
+    pub(crate) fn new(protocol_config: &'pc ProtocolConfig) -> Self {
         Self {
             protocol_config,
             inner: RefCell::new(PerTxCache_ {
-                type_linkage_cache: HashMap::new(),
+                type_resolution_cache: HashMap::new(),
+                type_executable_linkage_cache: HashMap::new(),
                 type_input_to_type: HashMap::new(),
+                type_input_to_tag: HashMap::new(),
                 tag_to_type: HashMap::new(),
                 type_to_tag: HashMap::new(),
                 vm_to_type: HashMap::new(),
@@ -119,6 +150,10 @@ impl<'pc> PerTxCache<'pc> {
                 defining_id_map: HashMap::new(),
             }),
         }
+    }
+
+    pub(crate) fn is_enabled(&self) -> bool {
+        self.protocol_config.enable_ptb_tx_cache()
     }
 
     fn borrow(&self) -> Result<std::cell::Ref<'_, PerTxCache_>, ExecutionError> {
@@ -137,22 +172,160 @@ impl<'pc> PerTxCache<'pc> {
         })
     }
 
-    pub(super) fn lookup_type_linkage(
+    /// Look up the derived `ExecutableLinkage` for `key`, returning a clone of the cached
+    /// entry if present. Returns `None` on miss (the caller is expected to build it from the
+    /// `ResolutionTable` and store it via [`cache_resolved_type_linkage`]).
+    pub(super) fn lookup_resolved_type_linkage(
         &self,
         key: &TypeLinkageCacheKey,
     ) -> Result<Option<ExecutableLinkage>, ExecutionError> {
         gated!(self.protocol_config, None);
-        Ok(self.borrow()?.type_linkage_cache.get(key).cloned())
+        Ok(self
+            .borrow()?
+            .type_executable_linkage_cache
+            .get(key)
+            .cloned())
     }
 
-    pub(super) fn insert_type_linkage(
+    /// Store `linkage` under `key`. Returns the linkage back so the caller can use it without
+    /// re-cloning. When caching is disabled, the insert is skipped and the linkage is returned
+    /// as-is.
+    pub(super) fn cache_resolved_type_linkage(
         &self,
         key: TypeLinkageCacheKey,
         linkage: ExecutableLinkage,
-    ) -> Result<(), ExecutionError> {
-        gated!(self.protocol_config, ());
-        self.borrow_mut()?.type_linkage_cache.insert(key, linkage);
-        Ok(())
+    ) -> Result<ExecutableLinkage, ExecutionError> {
+        gated!(self.protocol_config, linkage);
+        self.borrow_mut()?
+            .type_executable_linkage_cache
+            .insert(key, linkage.clone());
+        Ok(linkage)
+    }
+
+    /// Look up the cached small `ResolutionTable` for `key`, or compute and cache it via
+    /// `compute` on miss. When caching is disabled, always invokes `compute` and returns its
+    /// result wrapped in a fresh `Rc` without touching the table.
+    pub(crate) fn get_or_compute_type_resolution(
+        &self,
+        key: TypeLinkageCacheKey,
+        compute: impl FnOnce() -> Result<ResolutionTable, ExecutionError>,
+    ) -> Result<Rc<ResolutionTable>, ExecutionError> {
+        if !self.protocol_config.enable_ptb_tx_cache() {
+            return Ok(Rc::new(compute()?));
+        }
+        if let Some(cached) = self.borrow()?.type_resolution_cache.get(&key).cloned() {
+            return Ok(cached);
+        }
+        let table = Rc::new(compute()?);
+        self.borrow_mut()?
+            .type_resolution_cache
+            .insert(key, table.clone());
+        Ok(table)
+    }
+
+    /// Resolve a `TypeInput` into a `TypeTag` whose addresses are defining IDs (not the raw
+    /// user-supplied addresses), consulting (and populating) the per-tx cache. The recursion
+    /// also memoizes nested type-input fragments.
+    pub(crate) fn type_input_to_defining_tag(
+        &self,
+        ty: &TypeInput,
+        type_arg_idx: usize,
+        package_store: &dyn PackageStore,
+    ) -> Result<Rc<TypeTag>, ExecutionError> {
+        if self.protocol_config.enable_ptb_tx_cache()
+            && let Some(cached) = self.borrow()?.type_input_to_tag.get(ty).cloned()
+        {
+            return Ok(cached);
+        }
+
+        let tag = match ty {
+            TypeInput::Bool => TypeTag::Bool,
+            TypeInput::U8 => TypeTag::U8,
+            TypeInput::U16 => TypeTag::U16,
+            TypeInput::U32 => TypeTag::U32,
+            TypeInput::U64 => TypeTag::U64,
+            TypeInput::U128 => TypeTag::U128,
+            TypeInput::U256 => TypeTag::U256,
+            TypeInput::Address => TypeTag::Address,
+            TypeInput::Signer => TypeTag::Signer,
+            TypeInput::Vector(inner) => {
+                let inner_tag =
+                    self.type_input_to_defining_tag(inner, type_arg_idx, package_store)?;
+                TypeTag::Vector(Box::new((*inner_tag).clone()))
+            }
+            TypeInput::Struct(struct_input) => {
+                let StructInput {
+                    address,
+                    module,
+                    name,
+                    type_params,
+                } = &**struct_input;
+
+                let pkg_id = ObjectID::from(*address);
+                let module = super::to_identifier(module.clone())?;
+                let name = super::to_identifier(name.clone())?;
+
+                // Consult the per-(pkg, module, name) defining-ID map first; only walk the
+                // package's type-origin table on miss. Every miss-path resolution gets stored
+                // back, so a later `Env::resolve_type_to_defining_id` for the same key is a hit.
+                let resolved_id = if let Some(cached) =
+                    self.lookup_type_to_defining_id(pkg_id, &module, &name)?
+                {
+                    cached
+                } else {
+                    let pkg = package_store
+                        .get_package(&pkg_id)
+                        .ok()
+                        .flatten()
+                        .ok_or_else(|| {
+                            let argument_idx = match checked_as!(type_arg_idx, u16) {
+                                Err(e) => return e,
+                                Ok(v) => v,
+                            };
+                            ExecutionError::from_kind(ExecutionErrorKind::TypeArgumentError {
+                                argument_idx,
+                                kind: TypeArgumentError::TypeNotFound,
+                            })
+                        })?;
+                    let tid = IntraPackageName {
+                        module_name: module.clone(),
+                        type_name: name.clone(),
+                    };
+                    let Some(resolved_address) = pkg.type_origin_table().get(&tid).cloned() else {
+                        return Err(ExecutionError::from_kind(
+                            ExecutionErrorKind::TypeArgumentError {
+                                argument_idx: checked_as!(type_arg_idx, u16)?,
+                                kind: TypeArgumentError::TypeNotFound,
+                            },
+                        ));
+                    };
+                    let resolved_id = ObjectID::from(resolved_address);
+                    self.insert_type_to_defining_id(pkg_id, &module, &name, resolved_id)?;
+                    resolved_id
+                };
+
+                let type_params = type_params
+                    .iter()
+                    .map(|tp| {
+                        self.type_input_to_defining_tag(tp, type_arg_idx, package_store)
+                            .map(|rc| (*rc).clone())
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+                TypeTag::Struct(Box::new(StructTag {
+                    address: resolved_id.into(),
+                    module,
+                    name,
+                    type_params,
+                }))
+            }
+        };
+
+        let tag = Rc::new(tag);
+        gated!(self.protocol_config, tag);
+        self.borrow_mut()?
+            .type_input_to_tag
+            .insert(ty.clone(), tag.clone());
+        Ok(tag)
     }
 
     pub(super) fn lookup_type_input(
@@ -323,7 +496,7 @@ impl<'pc> PerTxCache<'pc> {
 }
 
 impl TypeLinkageCacheKey {
-    pub(super) fn new(root_ids: &IndexSet<AccountAddress>) -> Self {
+    pub(crate) fn new(root_ids: &IndexSet<AccountAddress>) -> Self {
         Self {
             root_ids: root_ids.iter().copied().collect(),
         }

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/env/cache.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/env/cache.rs
@@ -1,0 +1,337 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::static_programmable_transactions::{
+    linkage::resolved_linkage::ExecutableLinkage,
+    loading::ast::{LoadedFunction, Type},
+};
+use indexmap::IndexSet;
+use move_core_types::{account_address::AccountAddress, language_storage::TypeTag};
+use move_vm_runtime::execution as vm_runtime;
+use std::{
+    cell::RefCell,
+    collections::{BTreeSet, HashMap},
+    rc::Rc,
+};
+use sui_protocol_config::ProtocolConfig;
+use sui_types::{Identifier, base_types::ObjectID, error::ExecutionError, type_input::TypeInput};
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub(super) struct TypeLinkageCacheKey {
+    // NB: We use a BTreeSet here to ensure that the order of the root IDs does not affect the
+    // cache key.
+    root_ids: BTreeSet<AccountAddress>,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub(super) struct LoadedFunctionKey {
+    package: ObjectID,
+    module: Identifier,
+    function: Identifier,
+    type_arguments: Vec<Type>,
+}
+
+pub(super) struct PerTxCache<'pc> {
+    protocol_config: &'pc ProtocolConfig,
+    inner: RefCell<PerTxCache_>,
+}
+
+/// Per-transaction memoization tables shared across the PTB pipeline.
+///
+/// The tables fall into four groups:
+///
+/// 1. **Linkage resolution** (`type_linkage_cache`): computing an `ExecutableLinkage` for a set of
+///    defining-ID addresses touches every transitive dependency of those packages; the same set
+///    of roots may be queried many times within a single PTB (once per type input, once per type
+///    argument on a call, etc.). This caches that lookup.
+///
+/// 2. **TypeInput resolution** (`type_input_to_type`): user-supplied `TypeInput`s are resolved to
+///    adapter `Type`s via a tag lookup + VM load. Kept one-way because multiple `TypeInput`s can
+///    resolve to the same `Type` so a reverse map would be ambiguous.
+///
+/// 3. **Bijective type conversions** (`tag_to_type` / `type_to_tag`, `vm_to_type` / `type_to_vm`):
+///    adapter `Type`, `TypeTag`, and `vm_runtime::Type` all carry defining IDs, so the mappings
+///    between them are one-to-one for fully-resolved types. Each bijection is kept as two maps
+///    sharing `Rc`-owned value sides, and populated atomically through a single helper
+///    (`insert_tag_type_pair`, `insert_vm_type_pair`) so the two directions cannot drift.
+///
+/// 4. **Loaded function resolution** (`function_cache`): resolving a Move call to a
+///    `LoadedFunction` involves call-linkage computation, VM instantiation against that linkage,
+///    function-def lookup, and type-parameter substitution. The full result is a pure function
+///    of `(version-specific package, module, function, type arguments)`, so we cache the
+///    `Rc<LoadedFunction>` keyed on that tuple.
+///
+/// All fields are `HashMap`-backed: the keys are either structural type trees or defining-ID
+/// tuples, so hashing dominates over ordered iteration, and `vm_runtime::Type` in particular
+/// only implements `Hash + Eq` (not `Ord`).
+struct PerTxCache_ {
+    /// Linkage resolutions keyed by `<defining-ID root set>`.
+    ///
+    /// NB: this can only be used for determining type linkages.
+    type_linkage_cache: HashMap<TypeLinkageCacheKey, ExecutableLinkage>,
+
+    /// TypeInput -> adapter Type. One-way only.
+    type_input_to_type: HashMap<TypeInput, Type>,
+
+    /// Bijective Type <-> TypeTag. Populated atomically via `insert_tag_type_pair`.
+    tag_to_type: HashMap<Rc<TypeTag>, Type>,
+    type_to_tag: HashMap<Type, Rc<TypeTag>>,
+
+    /// Bijective Type <-> vm_runtime::Type. Only fully-resolved types (no `TyParam`). Populated
+    /// atomically via `insert_vm_type_pair`.
+    vm_to_type: HashMap<Rc<vm_runtime::Type>, Type>,
+    type_to_vm: HashMap<Type, Rc<vm_runtime::Type>>,
+
+    /// `(package version-id, module, function, type arguments)` -> `Rc<LoadedFunction>`. Keyed on
+    /// the version-specific package ID because private/entry functions can disappear across
+    /// package versions, so different versions resolve differently.
+    function_cache: HashMap<LoadedFunctionKey, Rc<LoadedFunction>>,
+}
+
+/// Early-returns `Ok($empty)` from the enclosing method when PTB caching is disabled. The second
+/// argument is the stand-in result for that short-circuit: `None` for lookups, `()` for inserts,
+/// or a freshly-allocated `(Rc, value)` pair for the paired inserts that must still hand a valid
+/// return back to the caller.
+macro_rules! gated {
+    ($config:expr, $empty:expr) => {
+        if !$config.enable_ptb_tx_cache() {
+            return Ok($empty);
+        }
+    };
+}
+
+impl<'pc> PerTxCache<'pc> {
+    pub(super) fn new(protocol_config: &'pc ProtocolConfig) -> Self {
+        Self {
+            protocol_config,
+            inner: RefCell::new(PerTxCache_ {
+                type_linkage_cache: HashMap::new(),
+                type_input_to_type: HashMap::new(),
+                tag_to_type: HashMap::new(),
+                type_to_tag: HashMap::new(),
+                vm_to_type: HashMap::new(),
+                type_to_vm: HashMap::new(),
+                function_cache: HashMap::new(),
+            }),
+        }
+    }
+
+    fn borrow(&self) -> Result<std::cell::Ref<'_, PerTxCache_>, ExecutionError> {
+        self.inner.try_borrow().map_err(|_| {
+            make_invariant_violation!(
+                "Should be able to borrow PerTxCache for access here as we are only accessing it"
+            )
+        })
+    }
+
+    fn borrow_mut(&self) -> Result<std::cell::RefMut<'_, PerTxCache_>, ExecutionError> {
+        self.inner.try_borrow_mut().map_err(|_| {
+            make_invariant_violation!(
+                "Should be able to borrow PerTxCache for mutation here as we are only mutating it"
+            )
+        })
+    }
+
+    pub(super) fn lookup_type_linkage(
+        &self,
+        key: &TypeLinkageCacheKey,
+    ) -> Result<Option<ExecutableLinkage>, ExecutionError> {
+        gated!(self.protocol_config, None);
+        Ok(self.borrow()?.type_linkage_cache.get(key).cloned())
+    }
+
+    pub(super) fn insert_type_linkage(
+        &self,
+        key: TypeLinkageCacheKey,
+        linkage: ExecutableLinkage,
+    ) -> Result<(), ExecutionError> {
+        gated!(self.protocol_config, ());
+        self.borrow_mut()?.type_linkage_cache.insert(key, linkage);
+        Ok(())
+    }
+
+    pub(super) fn lookup_type_by_input(
+        &self,
+        input: &TypeInput,
+    ) -> Result<Option<Type>, ExecutionError> {
+        gated!(self.protocol_config, None);
+        Ok(self.borrow()?.type_input_to_type.get(input).cloned())
+    }
+
+    pub(super) fn insert_type_input(
+        &self,
+        input: TypeInput,
+        ty: Type,
+    ) -> Result<(), ExecutionError> {
+        gated!(self.protocol_config, ());
+        assert_invariant!(
+            !matches!(ty, Type::Reference(_, _)),
+            "TypeInput cannot represent a reference type: {:?}",
+            ty
+        );
+        let mut c = self.borrow_mut()?;
+        if let Some(existing) = c.type_input_to_type.get(&input) {
+            assert_invariant!(
+                existing == &ty,
+                "cache inconsistency on type_input_to_type: existing {:?} vs new {:?}",
+                existing,
+                ty
+            );
+        }
+        c.type_input_to_type.insert(input, ty);
+        Ok(())
+    }
+
+    pub(super) fn lookup_type_by_tag(&self, tag: &TypeTag) -> Result<Option<Type>, ExecutionError> {
+        gated!(self.protocol_config, None);
+        Ok(self.borrow()?.tag_to_type.get(tag).cloned())
+    }
+
+    pub(super) fn lookup_tag_by_type(
+        &self,
+        ty: &Type,
+    ) -> Result<Option<Rc<TypeTag>>, ExecutionError> {
+        gated!(self.protocol_config, None);
+        Ok(self.borrow()?.type_to_tag.get(ty).cloned())
+    }
+
+    pub(super) fn insert_tag_type_pair(
+        &self,
+        tag: TypeTag,
+        ty: Type,
+    ) -> Result<(Rc<TypeTag>, Type), ExecutionError> {
+        let tag = Rc::new(tag);
+        gated!(self.protocol_config, (tag, ty));
+        assert_invariant!(
+            !matches!(ty, Type::Reference(_, _)),
+            "TypeTag cannot represent a reference type: {:?}",
+            ty
+        );
+        let mut c = self.borrow_mut()?;
+        if let Some(existing) = c.tag_to_type.get(&tag) {
+            assert_invariant!(
+                existing == &ty,
+                "cache inconsistency on tag_to_type: existing {:?} vs new {:?}",
+                existing,
+                ty
+            );
+        }
+        if let Some(existing) = c.type_to_tag.get(&ty) {
+            assert_invariant!(
+                existing == &tag,
+                "cache inconsistency on type_to_tag: existing {:?} vs new {:?}",
+                existing,
+                tag
+            );
+        }
+        c.tag_to_type.insert(tag.clone(), ty.clone());
+        c.type_to_tag.insert(ty.clone(), tag.clone());
+        Ok((tag, ty))
+    }
+
+    pub(super) fn lookup_type_by_vm_type(
+        &self,
+        vm_type: &vm_runtime::Type,
+    ) -> Result<Option<Type>, ExecutionError> {
+        gated!(self.protocol_config, None);
+        Ok(self.borrow()?.vm_to_type.get(vm_type).cloned())
+    }
+
+    pub(super) fn lookup_vm_type_by_type(
+        &self,
+        ty: &Type,
+    ) -> Result<Option<Rc<vm_runtime::Type>>, ExecutionError> {
+        gated!(self.protocol_config, None);
+        Ok(self.borrow()?.type_to_vm.get(ty).cloned())
+    }
+
+    pub(super) fn insert_vm_type_pair(
+        &self,
+        vm_type: vm_runtime::Type,
+        ty: Type,
+    ) -> Result<(Rc<vm_runtime::Type>, Type), ExecutionError> {
+        let vm_type = Rc::new(vm_type);
+        gated!(self.protocol_config, (vm_type, ty));
+        assert_invariant!(
+            !matches!(vm_type.as_ref(), vm_runtime::Type::TyParam(_)),
+            "cannot cache unresolved TyParam: {:?}",
+            vm_type
+        );
+        let mut c = self.borrow_mut()?;
+        if let Some(existing) = c.vm_to_type.get(&vm_type) {
+            assert_invariant!(
+                existing == &ty,
+                "cache inconsistency on vm_to_type: existing {:?} vs new {:?}",
+                existing,
+                ty
+            );
+        }
+        if let Some(existing) = c.type_to_vm.get(&ty) {
+            assert_invariant!(
+                existing == &vm_type,
+                "cache inconsistency on type_to_vm: existing {:?} vs new {:?}",
+                existing,
+                vm_type
+            );
+        }
+        c.vm_to_type.insert(vm_type.clone(), ty.clone());
+        c.type_to_vm.insert(ty.clone(), vm_type.clone());
+        Ok((vm_type, ty))
+    }
+
+    pub(super) fn lookup_function(
+        &self,
+        key: &LoadedFunctionKey,
+    ) -> Result<Option<Rc<LoadedFunction>>, ExecutionError> {
+        gated!(self.protocol_config, None);
+        Ok(self.borrow()?.function_cache.get(key).cloned())
+    }
+
+    pub(super) fn insert_function(
+        &self,
+        key: LoadedFunctionKey,
+        function: Rc<LoadedFunction>,
+    ) -> Result<(), ExecutionError> {
+        gated!(self.protocol_config, ());
+        let mut c = self.borrow_mut()?;
+        if let Some(existing) = c.function_cache.get(&key) {
+            // Structural drift check: the fields that the key pins down should match. Anything
+            // derived (visibility / is_entry / instruction_length / definition_index / signature)
+            // is a pure function of those inputs, so if the key agrees the result must too.
+            assert_invariant!(
+                existing.version_mid == function.version_mid
+                    && existing.original_mid == function.original_mid
+                    && existing.is_entry == function.is_entry
+                    && existing.visibility == function.visibility,
+                "function_cache drift for key {:?}",
+                key
+            );
+        }
+        c.function_cache.insert(key, function);
+        Ok(())
+    }
+}
+
+impl TypeLinkageCacheKey {
+    pub(super) fn new(root_ids: &IndexSet<AccountAddress>) -> Self {
+        Self {
+            root_ids: root_ids.iter().copied().collect(),
+        }
+    }
+}
+
+impl LoadedFunctionKey {
+    pub(super) fn new(
+        package: ObjectID,
+        module: Identifier,
+        function: Identifier,
+        type_arguments: Vec<Type>,
+    ) -> Self {
+        Self {
+            package,
+            module,
+            function,
+            type_arguments,
+        }
+    }
+}

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/env/mod.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/env/mod.rs
@@ -280,7 +280,7 @@ impl<'pc, 'vm, 'state, 'linkage, 'extensions> Env<'pc, 'vm, 'state, 'linkage, 'e
     }
 
     pub fn load_type_input(&self, idx: usize, ty: TypeInput) -> Result<Type, ExecutionError> {
-        if let Some(cached) = self.per_tx_cache.lookup_type_by_input(&ty)? {
+        if let Some(cached) = self.per_tx_cache.lookup_type_input(&ty)? {
             return Ok(cached);
         }
         let vm_type = self.load_vm_type_from_type_input(idx, ty.clone())?;

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/env/mod.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/env/mod.rs
@@ -133,7 +133,7 @@ impl<'pc, 'vm, 'state, 'linkage, 'extensions> Env<'pc, 'vm, 'state, 'linkage, 'e
 
     /// Resolve an adapter `Type` to its `TypeTag`, consulting (and populating) the per-tx cache.
     fn tag_from_type(&self, ty: &Type) -> Result<Rc<TypeTag>, ExecutionError> {
-        if let Some(rc) = self.per_tx_cache.lookup_tag_by_type(ty)? {
+        if let Some(rc) = self.per_tx_cache.lookup_tag(ty)? {
             return Ok(rc);
         }
         let tag: TypeTag = ty.clone().try_into().map_err(|s| {
@@ -415,7 +415,7 @@ impl<'pc, 'vm, 'state, 'linkage, 'extensions> Env<'pc, 'vm, 'state, 'linkage, 'e
         type_arg_idx: Option<usize>,
         ty: &Type,
     ) -> Result<vm_runtime::Type, ExecutionError> {
-        if let Some(cached) = self.per_tx_cache.lookup_vm_type_by_type(ty)? {
+        if let Some(cached) = self.per_tx_cache.lookup_vm_type(ty)? {
             return Ok((*cached).clone());
         }
         let tag = self.tag_from_type(ty)?;

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/env/mod.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/env/mod.rs
@@ -23,7 +23,6 @@ use move_core_types::{
     annotated_value,
     identifier::IdentStr,
     language_storage::{ModuleId, StructTag},
-    resolver::IntraPackageName,
     runtime_value::{self, MoveTypeLayout},
     vm_status::StatusCode,
 };
@@ -44,10 +43,10 @@ use sui_types::{
     gas_coin::GasCoin,
     move_package::{UpgradeCap, UpgradeReceipt, UpgradeTicket},
     object::Object,
-    type_input::{StructInput, TypeInput},
+    type_input::TypeInput,
 };
 
-mod cache;
+pub(crate) mod cache;
 
 static GAS_COIN_TYPE: LazyLock<StructTag> = LazyLock::new(GasCoin::type_);
 static UPGRADE_TICKET_TYPE: LazyLock<StructTag> = LazyLock::new(UpgradeTicket::type_);
@@ -65,17 +64,18 @@ pub struct Env<'pc, 'vm, 'state, 'linkage, 'extensions> {
     // only. This VM should only be used for resolution of input types, but should not be used for
     // resolution around function calls, execution, or final serialization of execution values.
     input_type_resolution_vm: &'linkage MoveVM<'extensions>,
-    per_tx_cache: PerTxCache<'pc>,
+    per_tx_cache: &'linkage PerTxCache<'pc>,
 }
 
 impl<'pc, 'vm, 'state, 'linkage, 'extensions> Env<'pc, 'vm, 'state, 'linkage, 'extensions> {
-    pub fn new(
+    pub(crate) fn new(
         protocol_config: &'pc ProtocolConfig,
         vm: &'vm MoveRuntime,
         state_view: &'state mut dyn ExecutionState,
         linkable_store: &'linkage CachedPackageStore<'state, 'vm>,
         linkage_analysis: &'linkage LinkageAnalyzer,
         input_type_resolution_vm: &'linkage MoveVM<'extensions>,
+        per_tx_cache: &'linkage PerTxCache<'pc>,
     ) -> Self {
         Self {
             protocol_config,
@@ -84,7 +84,7 @@ impl<'pc, 'vm, 'state, 'linkage, 'extensions> Env<'pc, 'vm, 'state, 'linkage, 'e
             linkable_store,
             linkage_analysis,
             input_type_resolution_vm,
-            per_tx_cache: PerTxCache::new(protocol_config),
+            per_tx_cache,
         }
     }
 
@@ -148,10 +148,12 @@ impl<'pc, 'vm, 'state, 'linkage, 'extensions> Env<'pc, 'vm, 'state, 'linkage, 'e
         ty: &Type,
     ) -> Result<annotated_value::MoveTypeLayout, ExecutionError> {
         let tag = self.tag_from_type(ty)?;
-        let tag_linkage = self.get_type_linkage(&tag)?;
         self.input_type_resolution_vm
             .annotated_type_layout(&tag)
-            .map_err(|e| self.convert_linked_vm_error(e, &tag_linkage))
+            .map_err(|e| match self.get_type_linkage(&tag) {
+                Ok(linkage) => self.convert_linked_vm_error(e, &linkage),
+                Err(linkage_err) => linkage_err,
+            })
     }
 
     pub fn runtime_layout(
@@ -159,10 +161,12 @@ impl<'pc, 'vm, 'state, 'linkage, 'extensions> Env<'pc, 'vm, 'state, 'linkage, 'e
         ty: &Type,
     ) -> Result<runtime_value::MoveTypeLayout, ExecutionError> {
         let tag = self.tag_from_type(ty)?;
-        let tag_linkage = self.get_type_linkage(&tag)?;
         self.input_type_resolution_vm
             .runtime_type_layout(&tag)
-            .map_err(|e| self.convert_linked_vm_error(e, &tag_linkage))
+            .map_err(|e| match self.get_type_linkage(&tag) {
+                Ok(linkage) => self.convert_linked_vm_error(e, &linkage),
+                Err(linkage_err) => linkage_err,
+            })
     }
 
     pub fn load_framework_function(
@@ -438,17 +442,24 @@ impl<'pc, 'vm, 'state, 'linkage, 'extensions> Env<'pc, 'vm, 'state, 'linkage, 'e
             return Ok(Some(cached));
         }
 
-        let Ok(Some(resolved)) = self
+        let resolved = match self
             .linkable_store
             .resolve_type_to_defining_id(package, module, name)
-        else {
-            invariant_violation!(
-                "Expected to resolve defining ID for type {}::{}::{} but it was not found in the package store. This should not happen.",
-                package,
-                module,
-                name
-            );
+        {
+            Ok(Some(resolved)) => resolved,
+            Ok(None) => return Ok(None),
+            Err(e) => {
+                invariant_violation!(
+                    "Error while resolving defining ID for type {}::{}::{}: {}. \
+                     This should not happen as we should have been able to load the package that defines this type.",
+                    package,
+                    module,
+                    name,
+                    e
+                );
+            }
         };
+
         self.per_tx_cache
             .insert_type_to_defining_id(package, module, name, resolved)?;
         Ok(Some(resolved))
@@ -473,28 +484,41 @@ impl<'pc, 'vm, 'state, 'linkage, 'extensions> Env<'pc, 'vm, 'state, 'linkage, 'e
             }
         }
 
-        let tag_linkage = self.get_type_linkage(tag)?;
-        let ty = self
-            .input_type_resolution_vm
+        self.input_type_resolution_vm
             .load_type(tag)
-            .map_err(|e| execution_error(self, type_arg_idx, e, &tag_linkage))?;
-        Ok(ty)
+            .map_err(|e| match self.get_type_linkage(tag) {
+                Ok(linkage) => execution_error(self, type_arg_idx, e, &linkage),
+                Err(linkage_err) => linkage_err,
+            })
     }
 
     fn get_type_linkage(&self, tag: &TypeTag) -> Result<ExecutableLinkage, ExecutionError> {
+        use crate::static_programmable_transactions::linkage::{
+            resolution::ResolutionTable, resolved_linkage::ResolvedLinkage,
+        };
         let root_ids = tag.all_addresses();
         let key = TypeLinkageCacheKey::new(&root_ids);
-        if let Some(cached) = self.per_tx_cache.lookup_type_linkage(&key)? {
+
+        // Fast path: a previous call already built the `ExecutableLinkage` for this key.
+        // `ExecutableLinkage` is a cheap `Rc` clone.
+        if let Some(cached) = self.per_tx_cache.lookup_resolved_type_linkage(&key)? {
             return Ok(cached);
         }
-        let linkage = ExecutableLinkage::type_linkage(
-            self.linkage_analysis.config().clone(),
-            root_ids.into_iter().map(ObjectID::from),
-            self.linkable_store,
-        )?;
-        self.per_tx_cache
-            .insert_type_linkage(key, linkage.clone())?;
-        Ok(linkage)
+
+        // Slow path: fetch (or compute) the underlying `ResolutionTable`, build the linkage,
+        // and store it for subsequent calls.
+        let table = self
+            .per_tx_cache
+            .get_or_compute_type_resolution(key.clone(), || {
+                ResolutionTable::for_type_addresses(
+                    self.linkage_analysis.config().clone(),
+                    root_ids.iter().copied().map(ObjectID::from),
+                    self.linkable_store,
+                )
+            })?;
+        let linkage =
+            ExecutableLinkage::new(ResolvedLinkage::from_resolution_table((*table).clone()));
+        self.per_tx_cache.cache_resolved_type_linkage(key, linkage)
     }
 
     /// Converts a VM runtime Type to an adapter Type.
@@ -594,82 +618,14 @@ impl<'pc, 'vm, 'state, 'linkage, 'extensions> Env<'pc, 'vm, 'state, 'linkage, 'e
         type_arg_idx: usize,
         ty: TypeInput,
     ) -> Result<vm_runtime::Type, ExecutionError> {
-        fn to_type_tag_internal(
-            env: &Env,
-            type_arg_idx: usize,
-            ty: &TypeInput,
-        ) -> Result<TypeTag, ExecutionError> {
-            Ok(match ty {
-                TypeInput::Bool => TypeTag::Bool,
-                TypeInput::U8 => TypeTag::U8,
-                TypeInput::U16 => TypeTag::U16,
-                TypeInput::U32 => TypeTag::U32,
-                TypeInput::U64 => TypeTag::U64,
-                TypeInput::U128 => TypeTag::U128,
-                TypeInput::U256 => TypeTag::U256,
-                TypeInput::Address => TypeTag::Address,
-                TypeInput::Signer => TypeTag::Signer,
-                TypeInput::Vector(type_input) => {
-                    let inner = to_type_tag_internal(env, type_arg_idx, type_input)?;
-                    TypeTag::Vector(Box::new(inner))
-                }
-                TypeInput::Struct(struct_input) => {
-                    let StructInput {
-                        address,
-                        module,
-                        name,
-                        type_params,
-                    } = &**struct_input;
-
-                    let pkg = env
-                        .linkable_store
-                        .get_package(&ObjectID::from(*address))
-                        .ok()
-                        .flatten()
-                        .ok_or_else(|| {
-                            let argument_idx = match checked_as!(type_arg_idx, u16) {
-                                Err(e) => return e,
-                                Ok(v) => v,
-                            };
-                            ExecutionError::from_kind(ExecutionErrorKind::TypeArgumentError {
-                                argument_idx,
-                                kind: TypeArgumentError::TypeNotFound,
-                            })
-                        })?;
-                    let module = to_identifier(module.clone())?;
-                    let name = to_identifier(name.clone())?;
-                    let tid = IntraPackageName {
-                        module_name: module,
-                        type_name: name,
-                    };
-                    let Some(resolved_address) = pkg.type_origin_table().get(&tid).cloned() else {
-                        return Err(ExecutionError::from_kind(
-                            ExecutionErrorKind::TypeArgumentError {
-                                argument_idx: checked_as!(type_arg_idx, u16)?,
-                                kind: TypeArgumentError::TypeNotFound,
-                            },
-                        ));
-                    };
-
-                    let tys = type_params
-                        .iter()
-                        .map(|tp| to_type_tag_internal(env, type_arg_idx, tp))
-                        .collect::<Result<Vec<_>, _>>()?;
-                    TypeTag::Struct(Box::new(StructTag {
-                        address: resolved_address,
-                        module: tid.module_name,
-                        name: tid.type_name,
-                        type_params: tys,
-                    }))
-                }
-            })
-        }
-        let tag = to_type_tag_internal(self, type_arg_idx, &ty)?;
+        let tag =
+            self.per_tx_cache
+                .type_input_to_defining_tag(&ty, type_arg_idx, self.linkable_store)?;
         self.load_vm_type_from_type_tag(Some(type_arg_idx), &tag)
     }
 }
 
-fn to_identifier(name: String) -> Result<Identifier, ExecutionError> {
+pub(super) fn to_identifier(name: String) -> Result<Identifier, ExecutionError> {
     Identifier::new(name).map_err(|e| {
         ExecutionError::new_with_source(ExecutionErrorKind::VMInvariantViolation, e.to_string())
     })

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/env/mod.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/env/mod.rs
@@ -9,6 +9,7 @@ use crate::{
     data_store::{PackageStore, cached_package_store::CachedPackageStore},
     execution_value::ExecutionState,
     static_programmable_transactions::{
+        env::cache::{LoadedFunctionKey, PerTxCache, TypeLinkageCacheKey},
         execution::context::subst_signature,
         linkage::{analysis::LinkageAnalyzer, resolved_linkage::ExecutableLinkage},
         loading::ast::{self as L, Datatype, LoadedFunction, LoadedFunctionInstantiation, Type},
@@ -30,7 +31,7 @@ use move_vm_runtime::{
     execution::{self as vm_runtime, vm::MoveVM},
     runtime::MoveRuntime,
 };
-use std::{cell::OnceCell, rc::Rc};
+use std::{rc::Rc, sync::LazyLock};
 use sui_protocol_config::ProtocolConfig;
 use sui_types::{
     Identifier, SUI_FRAMEWORK_PACKAGE_ID, TypeTag,
@@ -46,33 +47,25 @@ use sui_types::{
     type_input::{StructInput, TypeInput},
 };
 
+mod cache;
+
+static GAS_COIN_TYPE: LazyLock<StructTag> = LazyLock::new(GasCoin::type_);
+static UPGRADE_TICKET_TYPE: LazyLock<StructTag> = LazyLock::new(UpgradeTicket::type_);
+static UPGRADE_RECEIPT_TYPE: LazyLock<StructTag> = LazyLock::new(UpgradeReceipt::type_);
+static UPGRADE_CAP_TYPE: LazyLock<StructTag> = LazyLock::new(UpgradeCap::type_);
+static TX_CONTEXT_TYPE: LazyLock<StructTag> = LazyLock::new(TxContext::type_);
+
 pub struct Env<'pc, 'vm, 'state, 'linkage, 'extensions> {
     pub protocol_config: &'pc ProtocolConfig,
     pub vm: &'vm MoveRuntime,
     pub state_view: &'state mut dyn ExecutionState,
     pub linkable_store: &'linkage CachedPackageStore<'state, 'vm>,
     pub linkage_analysis: &'linkage LinkageAnalyzer,
-    gas_coin_type: OnceCell<Type>,
-    upgrade_ticket_type: OnceCell<Type>,
-    upgrade_receipt_type: OnceCell<Type>,
-    upgrade_cap_type: OnceCell<Type>,
-    tx_context_type: OnceCell<Type>,
     // The VM used for type resolution of input types (and types statically present in the PTB)
     // only. This VM should only be used for resolution of input types, but should not be used for
     // resolution around function calls, execution, or final serialization of execution values.
     input_type_resolution_vm: &'linkage MoveVM<'extensions>,
-}
-
-macro_rules! get_or_init_ty {
-    ($env:expr, $ident:ident, $tag:expr) => {{
-        let env = $env;
-        if env.$ident.get().is_none() {
-            let tag = $tag;
-            let ty = env.load_type_from_struct(&tag)?;
-            env.$ident.set(ty.clone()).unwrap();
-        }
-        Ok(env.$ident.get().unwrap().clone())
-    }};
+    per_tx_cache: PerTxCache<'pc>,
 }
 
 impl<'pc, 'vm, 'state, 'linkage, 'extensions> Env<'pc, 'vm, 'state, 'linkage, 'extensions> {
@@ -90,12 +83,8 @@ impl<'pc, 'vm, 'state, 'linkage, 'extensions> Env<'pc, 'vm, 'state, 'linkage, 'e
             state_view,
             linkable_store,
             linkage_analysis,
-            gas_coin_type: OnceCell::new(),
-            upgrade_ticket_type: OnceCell::new(),
-            upgrade_receipt_type: OnceCell::new(),
-            upgrade_cap_type: OnceCell::new(),
-            tx_context_type: OnceCell::new(),
             input_type_resolution_vm,
+            per_tx_cache: PerTxCache::new(protocol_config),
         }
     }
 
@@ -142,19 +131,24 @@ impl<'pc, 'vm, 'state, 'linkage, 'extensions> Env<'pc, 'vm, 'state, 'linkage, 'e
         }
     }
 
+    /// Resolve an adapter `Type` to its `TypeTag`, consulting (and populating) the per-tx cache.
+    fn tag_from_type(&self, ty: &Type) -> Result<Rc<TypeTag>, ExecutionError> {
+        if let Some(rc) = self.per_tx_cache.lookup_tag_by_type(ty)? {
+            return Ok(rc);
+        }
+        let tag: TypeTag = ty.clone().try_into().map_err(|s| {
+            ExecutionError::new_with_source(ExecutionErrorKind::VMInvariantViolation, s)
+        })?;
+        let (rc, _) = self.per_tx_cache.insert_tag_type_pair(tag, ty.clone())?;
+        Ok(rc)
+    }
+
     pub fn fully_annotated_layout(
         &self,
         ty: &Type,
     ) -> Result<annotated_value::MoveTypeLayout, ExecutionError> {
-        let tag: TypeTag = ty.clone().try_into().map_err(|s| {
-            ExecutionError::new_with_source(ExecutionErrorKind::VMInvariantViolation, s)
-        })?;
-        let objects = tag.all_addresses();
-        let tag_linkage = ExecutableLinkage::type_linkage(
-            self.linkage_analysis.config().clone(),
-            objects.into_iter().map(ObjectID::from),
-            self.linkable_store,
-        )?;
+        let tag = self.tag_from_type(ty)?;
+        let tag_linkage = self.get_type_linkage(&tag)?;
         self.input_type_resolution_vm
             .annotated_type_layout(&tag)
             .map_err(|e| self.convert_linked_vm_error(e, &tag_linkage))
@@ -164,15 +158,8 @@ impl<'pc, 'vm, 'state, 'linkage, 'extensions> Env<'pc, 'vm, 'state, 'linkage, 'e
         &self,
         ty: &Type,
     ) -> Result<runtime_value::MoveTypeLayout, ExecutionError> {
-        let tag: TypeTag = ty.clone().try_into().map_err(|s| {
-            ExecutionError::new_with_source(ExecutionErrorKind::VMInvariantViolation, s)
-        })?;
-        let objects = tag.all_addresses();
-        let tag_linkage = ExecutableLinkage::type_linkage(
-            self.linkage_analysis.config().clone(),
-            objects.into_iter().map(ObjectID::from),
-            self.linkable_store,
-        )?;
+        let tag = self.tag_from_type(ty)?;
+        let tag_linkage = self.get_type_linkage(&tag)?;
         self.input_type_resolution_vm
             .runtime_type_layout(&tag)
             .map_err(|e| self.convert_linked_vm_error(e, &tag_linkage))
@@ -183,7 +170,7 @@ impl<'pc, 'vm, 'state, 'linkage, 'extensions> Env<'pc, 'vm, 'state, 'linkage, 'e
         module: &IdentStr,
         function: &IdentStr,
         type_arguments: Vec<Type>,
-    ) -> Result<LoadedFunction, ExecutionError> {
+    ) -> Result<Rc<LoadedFunction>, ExecutionError> {
         self.load_function(
             SUI_FRAMEWORK_PACKAGE_ID,
             module.to_string(),
@@ -198,9 +185,19 @@ impl<'pc, 'vm, 'state, 'linkage, 'extensions> Env<'pc, 'vm, 'state, 'linkage, 'e
         module: String,
         function: String,
         type_arguments: Vec<Type>,
-    ) -> Result<LoadedFunction, ExecutionError> {
+    ) -> Result<Rc<LoadedFunction>, ExecutionError> {
         let module = to_identifier(module)?;
         let name = to_identifier(function)?;
+
+        let cache_key = LoadedFunctionKey::new(
+            package,
+            module.clone(),
+            name.clone(),
+            type_arguments.clone(),
+        );
+        if let Some(cached) = self.per_tx_cache.lookup_function(&cache_key)? {
+            return Ok(cached);
+        }
 
         let linkage = self.linkage_analysis.compute_call_linkage(
             &package,
@@ -264,7 +261,7 @@ impl<'pc, 'vm, 'state, 'linkage, 'extensions> Env<'pc, 'vm, 'state, 'linkage, 'e
             parameters,
             return_,
         };
-        Ok(LoadedFunction {
+        let loaded = Rc::new(LoadedFunction {
             version_mid,
             original_mid,
             name,
@@ -276,24 +273,44 @@ impl<'pc, 'vm, 'state, 'linkage, 'extensions> Env<'pc, 'vm, 'state, 'linkage, 'e
             visibility: runtime_signature.visibility,
             is_entry: runtime_signature.is_entry,
             is_native: runtime_signature.is_native,
-        })
+        });
+        self.per_tx_cache
+            .insert_function(cache_key, loaded.clone())?;
+        Ok(loaded)
     }
 
     pub fn load_type_input(&self, idx: usize, ty: TypeInput) -> Result<Type, ExecutionError> {
-        let vm_type = self.load_vm_type_from_type_input(idx, ty)?;
-        self.adapter_type_from_vm_type(self.input_type_resolution_vm, &vm_type)
+        if let Some(cached) = self.per_tx_cache.lookup_type_by_input(&ty)? {
+            return Ok(cached);
+        }
+        let vm_type = self.load_vm_type_from_type_input(idx, ty.clone())?;
+        let adapter = self.adapter_type_from_vm_type(self.input_type_resolution_vm, &vm_type)?;
+        self.per_tx_cache.insert_type_input(ty, adapter.clone())?;
+        Ok(adapter)
     }
 
     pub fn load_type_tag(&self, idx: usize, ty: &TypeTag) -> Result<Type, ExecutionError> {
+        if let Some(cached) = self.per_tx_cache.lookup_type_by_tag(ty)? {
+            return Ok(cached);
+        }
         let vm_type = self.load_vm_type_from_type_tag(Some(idx), ty)?;
-        self.adapter_type_from_vm_type(self.input_type_resolution_vm, &vm_type)
+        let adapter = self.adapter_type_from_vm_type(self.input_type_resolution_vm, &vm_type)?;
+        self.per_tx_cache
+            .insert_tag_type_pair(ty.clone(), adapter.clone())?;
+        Ok(adapter)
     }
 
     /// We verify that all types in the `StructTag` are defining ID-based types.
     pub fn load_type_from_struct(&self, tag: &StructTag) -> Result<Type, ExecutionError> {
-        let vm_type =
-            self.load_vm_type_from_type_tag(None, &TypeTag::Struct(Box::new(tag.clone())))?;
-        self.adapter_type_from_vm_type(self.input_type_resolution_vm, &vm_type)
+        let tag = TypeTag::Struct(Box::new(tag.clone()));
+        if let Some(cached) = self.per_tx_cache.lookup_type_by_tag(&tag)? {
+            return Ok(cached);
+        }
+        let vm_type = self.load_vm_type_from_type_tag(None, &tag)?;
+        let adapter = self.adapter_type_from_vm_type(self.input_type_resolution_vm, &vm_type)?;
+        self.per_tx_cache
+            .insert_tag_type_pair(tag, adapter.clone())?;
+        Ok(adapter)
     }
 
     pub fn type_layout_for_struct(
@@ -305,23 +322,23 @@ impl<'pc, 'vm, 'state, 'linkage, 'extensions> Env<'pc, 'vm, 'state, 'linkage, 'e
     }
 
     pub fn gas_coin_type(&self) -> Result<Type, ExecutionError> {
-        get_or_init_ty!(self, gas_coin_type, GasCoin::type_())
+        self.load_type_from_struct(&GAS_COIN_TYPE)
     }
 
     pub fn upgrade_ticket_type(&self) -> Result<Type, ExecutionError> {
-        get_or_init_ty!(self, upgrade_ticket_type, UpgradeTicket::type_())
+        self.load_type_from_struct(&UPGRADE_TICKET_TYPE)
     }
 
     pub fn upgrade_receipt_type(&self) -> Result<Type, ExecutionError> {
-        get_or_init_ty!(self, upgrade_receipt_type, UpgradeReceipt::type_())
+        self.load_type_from_struct(&UPGRADE_RECEIPT_TYPE)
     }
 
     pub fn upgrade_cap_type(&self) -> Result<Type, ExecutionError> {
-        get_or_init_ty!(self, upgrade_cap_type, UpgradeCap::type_())
+        self.load_type_from_struct(&UPGRADE_CAP_TYPE)
     }
 
     pub fn tx_context_type(&self) -> Result<Type, ExecutionError> {
-        get_or_init_ty!(self, tx_context_type, TxContext::type_())
+        self.load_type_from_struct(&TX_CONTEXT_TYPE)
     }
 
     pub fn coin_type(&self, inner_type: Type) -> Result<Type, ExecutionError> {
@@ -398,10 +415,14 @@ impl<'pc, 'vm, 'state, 'linkage, 'extensions> Env<'pc, 'vm, 'state, 'linkage, 'e
         type_arg_idx: Option<usize>,
         ty: &Type,
     ) -> Result<vm_runtime::Type, ExecutionError> {
-        let tag: TypeTag = ty.clone().try_into().map_err(|s| {
-            ExecutionError::new_with_source(ExecutionErrorKind::VMInvariantViolation, s)
-        })?;
-        self.load_vm_type_from_type_tag(type_arg_idx, &tag)
+        if let Some(cached) = self.per_tx_cache.lookup_vm_type_by_type(ty)? {
+            return Ok((*cached).clone());
+        }
+        let tag = self.tag_from_type(ty)?;
+        let vm_type = self.load_vm_type_from_type_tag(type_arg_idx, &tag)?;
+        self.per_tx_cache
+            .insert_vm_type_pair(vm_type.clone(), ty.clone())?;
+        Ok(vm_type)
     }
 
     /// Take a type tag and returns a VM runtime Type and the linkage for it.
@@ -423,18 +444,28 @@ impl<'pc, 'vm, 'state, 'linkage, 'extensions> Env<'pc, 'vm, 'state, 'linkage, 'e
             }
         }
 
-        let objects = tag.all_addresses();
-
-        let tag_linkage = ExecutableLinkage::type_linkage(
-            self.linkage_analysis.config().clone(),
-            objects.iter().map(|a| ObjectID::from(*a)),
-            self.linkable_store,
-        )?;
+        let tag_linkage = self.get_type_linkage(tag)?;
         let ty = self
             .input_type_resolution_vm
             .load_type(tag)
             .map_err(|e| execution_error(self, type_arg_idx, e, &tag_linkage))?;
         Ok(ty)
+    }
+
+    fn get_type_linkage(&self, tag: &TypeTag) -> Result<ExecutableLinkage, ExecutionError> {
+        let root_ids = tag.all_addresses();
+        let key = TypeLinkageCacheKey::new(&root_ids);
+        if let Some(cached) = self.per_tx_cache.lookup_type_linkage(&key)? {
+            return Ok(cached);
+        }
+        let linkage = ExecutableLinkage::type_linkage(
+            self.linkage_analysis.config().clone(),
+            root_ids.into_iter().map(ObjectID::from),
+            self.linkable_store,
+        )?;
+        self.per_tx_cache
+            .insert_type_linkage(key, linkage.clone())?;
+        Ok(linkage)
     }
 
     /// Converts a VM runtime Type to an adapter Type.
@@ -445,7 +476,11 @@ impl<'pc, 'vm, 'state, 'linkage, 'extensions> Env<'pc, 'vm, 'state, 'linkage, 'e
     ) -> Result<Type, ExecutionError> {
         use vm_runtime as VRT;
 
-        Ok(match vm_type {
+        if let Some(cached) = self.per_tx_cache.lookup_type_by_vm_type(vm_type)? {
+            return Ok(cached);
+        }
+
+        let ty = match vm_type {
             VRT::Type::Bool => Type::Bool,
             VRT::Type::U8 => Type::U8,
             VRT::Type::U16 => Type::U16,
@@ -516,7 +551,10 @@ impl<'pc, 'vm, 'state, 'linkage, 'extensions> Env<'pc, 'vm, 'state, 'linkage, 'e
                     vm_type
                 );
             }
-        })
+        };
+        self.per_tx_cache
+            .insert_vm_type_pair(vm_type.clone(), ty.clone())?;
+        Ok(ty)
     }
 
     /// Load a `TypeInput` into a VM runtime `Type` and its `Linkage`. Loading into the VM ensures
@@ -530,7 +568,7 @@ impl<'pc, 'vm, 'state, 'linkage, 'extensions> Env<'pc, 'vm, 'state, 'linkage, 'e
         fn to_type_tag_internal(
             env: &Env,
             type_arg_idx: usize,
-            ty: TypeInput,
+            ty: &TypeInput,
         ) -> Result<TypeTag, ExecutionError> {
             Ok(match ty {
                 TypeInput::Bool => TypeTag::Bool,
@@ -543,7 +581,7 @@ impl<'pc, 'vm, 'state, 'linkage, 'extensions> Env<'pc, 'vm, 'state, 'linkage, 'e
                 TypeInput::Address => TypeTag::Address,
                 TypeInput::Signer => TypeTag::Signer,
                 TypeInput::Vector(type_input) => {
-                    let inner = to_type_tag_internal(env, type_arg_idx, *type_input)?;
+                    let inner = to_type_tag_internal(env, type_arg_idx, type_input)?;
                     TypeTag::Vector(Box::new(inner))
                 }
                 TypeInput::Struct(struct_input) => {
@@ -552,11 +590,11 @@ impl<'pc, 'vm, 'state, 'linkage, 'extensions> Env<'pc, 'vm, 'state, 'linkage, 'e
                         module,
                         name,
                         type_params,
-                    } = *struct_input;
+                    } = &**struct_input;
 
                     let pkg = env
                         .linkable_store
-                        .get_package(&address.into())
+                        .get_package(&ObjectID::from(*address))
                         .ok()
                         .flatten()
                         .ok_or_else(|| {
@@ -569,8 +607,8 @@ impl<'pc, 'vm, 'state, 'linkage, 'extensions> Env<'pc, 'vm, 'state, 'linkage, 'e
                                 kind: TypeArgumentError::TypeNotFound,
                             })
                         })?;
-                    let module = to_identifier(module)?;
-                    let name = to_identifier(name)?;
+                    let module = to_identifier(module.clone())?;
+                    let name = to_identifier(name.clone())?;
                     let tid = IntraPackageName {
                         module_name: module,
                         type_name: name,
@@ -585,7 +623,7 @@ impl<'pc, 'vm, 'state, 'linkage, 'extensions> Env<'pc, 'vm, 'state, 'linkage, 'e
                     };
 
                     let tys = type_params
-                        .into_iter()
+                        .iter()
                         .map(|tp| to_type_tag_internal(env, type_arg_idx, tp))
                         .collect::<Result<Vec<_>, _>>()?;
                     TypeTag::Struct(Box::new(StructTag {
@@ -597,7 +635,7 @@ impl<'pc, 'vm, 'state, 'linkage, 'extensions> Env<'pc, 'vm, 'state, 'linkage, 'e
                 }
             })
         }
-        let tag = to_type_tag_internal(self, type_arg_idx, ty)?;
+        let tag = to_type_tag_internal(self, type_arg_idx, &ty)?;
         self.load_vm_type_from_type_tag(Some(type_arg_idx), &tag)
     }
 }

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/env/mod.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/env/mod.rs
@@ -425,6 +425,35 @@ impl<'pc, 'vm, 'state, 'linkage, 'extensions> Env<'pc, 'vm, 'state, 'linkage, 'e
         Ok(vm_type)
     }
 
+    pub fn resolve_type_to_defining_id(
+        &self,
+        package: ObjectID,
+        module: &IdentStr,
+        name: &IdentStr,
+    ) -> Result<Option<ObjectID>, ExecutionError> {
+        if let Some(cached) = self
+            .per_tx_cache
+            .lookup_type_to_defining_id(package, module, name)?
+        {
+            return Ok(Some(cached));
+        }
+
+        let Ok(Some(resolved)) = self
+            .linkable_store
+            .resolve_type_to_defining_id(package, module, name)
+        else {
+            invariant_violation!(
+                "Expected to resolve defining ID for type {}::{}::{} but it was not found in the package store. This should not happen.",
+                package,
+                module,
+                name
+            );
+        };
+        self.per_tx_cache
+            .insert_type_to_defining_id(package, module, name, resolved)?;
+        Ok(Some(resolved))
+    }
+
     /// Take a type tag and returns a VM runtime Type and the linkage for it.
     fn load_vm_type_from_type_tag(
         &self,

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/execution/context.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/execution/context.rs
@@ -956,7 +956,7 @@ impl<'env, 'pc, 'vm, 'state, 'linkage, 'gas, 'extension>
 
     pub fn vm_move_call(
         &mut self,
-        function: T::LoadedFunction,
+        function: Rc<T::LoadedFunction>,
         args: Vec<CtxValue>,
         trace_builder_opt: &mut Option<MoveTraceBuilder>,
     ) -> Result<Vec<CtxValue>, ExecutionError> {
@@ -983,7 +983,7 @@ impl<'env, 'pc, 'vm, 'state, 'linkage, 'gas, 'extension>
             )?;
             self.take_user_events(
                 vm,
-                function.version_mid,
+                function.version_mid.clone(),
                 function.definition_index,
                 function.instruction_length,
                 &function.linkage,

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/linkage/analysis.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/linkage/analysis.rs
@@ -6,6 +6,7 @@ use crate::{
     execution_mode::ExecutionMode,
     execution_value::ExecutionState,
     static_programmable_transactions::{
+        env::cache::PerTxCache,
         linkage::{
             config::{LinkageConfig, ResolutionConfig},
             resolution::{ResolutionTable, VersionConstraint, add_and_unify, get_package},
@@ -78,17 +79,19 @@ impl LinkageAnalyzer {
         &self.internal
     }
 
-    pub fn compute_input_type_resolution_linkage(
+    pub(crate) fn compute_input_type_resolution_linkage(
         &self,
         tx: &ProgrammableTransaction,
         package_store: &dyn PackageStore,
         object_store: &dyn ExecutionState,
+        cache: &PerTxCache,
     ) -> Result<ExecutableLinkage, ExecutionError> {
         input_type_resolution_analysis::compute_resolution_linkage(
             self,
             tx,
             package_store,
             object_store,
+            cache,
         )
     }
 
@@ -187,13 +190,17 @@ mod input_type_resolution_analysis {
     use crate::{
         data_store::PackageStore,
         execution_value::ExecutionState,
-        static_programmable_transactions::linkage::{
-            analysis::LinkageAnalyzer,
-            resolution::ResolutionTable,
-            resolved_linkage::{ExecutableLinkage, ResolvedLinkage},
+        static_programmable_transactions::{
+            env::cache::{PerTxCache, TypeLinkageCacheKey},
+            linkage::{
+                analysis::LinkageAnalyzer,
+                resolution::ResolutionTable,
+                resolved_linkage::{ExecutableLinkage, ResolvedLinkage},
+            },
         },
     };
-    use move_core_types::language_storage::StructTag;
+    use indexmap::IndexSet;
+    use move_core_types::{account_address::AccountAddress, language_storage::StructTag};
     use sui_types::{
         base_types::ObjectID,
         error::ExecutionError,
@@ -210,6 +217,7 @@ mod input_type_resolution_analysis {
         tx: &ProgrammableTransaction,
         package_store: &dyn PackageStore,
         object_store: &dyn ExecutionState,
+        cache: &PerTxCache,
     ) -> Result<ExecutableLinkage, ExecutionError> {
         let ProgrammableTransaction { inputs, commands } = tx;
 
@@ -217,11 +225,18 @@ mod input_type_resolution_analysis {
             .internal
             .resolution_table_with_native_packages(package_store)?;
         for arg in inputs.iter() {
-            input(&mut resolution_table, arg, package_store, object_store)?;
+            input(
+                analyzer,
+                &mut resolution_table,
+                arg,
+                package_store,
+                object_store,
+                cache,
+            )?;
         }
 
         for cmd in commands.iter() {
-            command(&mut resolution_table, cmd, package_store)?;
+            command(analyzer, &mut resolution_table, cmd, package_store, cache)?;
         }
 
         Ok(ExecutableLinkage::new(
@@ -229,11 +244,34 @@ mod input_type_resolution_analysis {
         ))
     }
 
+    /// Get-or-compute the small `ResolutionTable` for `addrs` via the per-tx cache, then fold
+    /// it into `big`. When the cache has the entry from a prior call (or a previous tag in the
+    /// same PTB), no re-walking happens — the cached transitive-dependency closure is reused.
+    fn merge_type_addresses(
+        analyzer: &LinkageAnalyzer,
+        big: &mut ResolutionTable,
+        addrs: IndexSet<AccountAddress>,
+        package_store: &dyn PackageStore,
+        cache: &PerTxCache,
+    ) -> Result<(), ExecutionError> {
+        let key = TypeLinkageCacheKey::new(&addrs);
+        let small = cache.get_or_compute_type_resolution(key, || {
+            ResolutionTable::for_type_addresses(
+                analyzer.config().clone(),
+                addrs.iter().copied().map(ObjectID::from),
+                package_store,
+            )
+        })?;
+        big.fold_in(&small)
+    }
+
     fn input(
+        analyzer: &LinkageAnalyzer,
         resolution_table: &mut ResolutionTable,
         arg: &CallArg,
         package_store: &dyn PackageStore,
         object_store: &dyn ExecutionState,
+        cache: &PerTxCache,
     ) -> Result<(), ExecutionError> {
         match arg {
             CallArg::Pure(_) | CallArg::Object(ObjectArg::Receiving(_)) => (),
@@ -250,15 +288,25 @@ mod input_type_resolution_analysis {
                 // invariant: the addresses in the type are defining addresses for the types since
                 // these are the types of the objects as stored on-chain.
                 let tag: StructTag = ty.clone().into();
-                let ids = tag.all_addresses().into_iter().map(ObjectID::from);
-                resolution_table.add_type_linkages_to_table(ids, package_store)?;
+                merge_type_addresses(
+                    analyzer,
+                    resolution_table,
+                    tag.all_addresses(),
+                    package_store,
+                    cache,
+                )?;
             }
             CallArg::FundsWithdrawal(f) => {
                 let FundsWithdrawalArg { type_arg, .. } = f;
                 match type_arg {
                     WithdrawalTypeArg::Balance(tag) => {
-                        let ids = tag.all_addresses().into_iter().map(ObjectID::from);
-                        resolution_table.add_type_linkages_to_table(ids, package_store)?;
+                        merge_type_addresses(
+                            analyzer,
+                            resolution_table,
+                            tag.all_addresses(),
+                            package_store,
+                            cache,
+                        )?;
                     }
                 }
             }
@@ -268,19 +316,48 @@ mod input_type_resolution_analysis {
     }
 
     fn command(
+        analyzer: &LinkageAnalyzer,
         resolution_table: &mut ResolutionTable,
         command: &Command,
         package_store: &dyn PackageStore,
+        cache: &PerTxCache,
     ) -> Result<(), ExecutionError> {
-        let mut add_ty_input = |ty: &TypeInput| {
-            let tag = ty.to_type_tag().map_err(|e| {
+        let mut add_ty_input = |(idx, ty): (usize, &TypeInput)| -> Result<(), ExecutionError> {
+            // Merge for the raw user-supplied addresses — preserves the pre-existing behavior of
+            // contributing the user's specific package versions to the PTB-wide constraints
+            // (e.g. an "at least v2" constraint from a v2 package ID stays in the big table even
+            // if the type's defining ID is v1).
+            let raw_tag = ty.to_type_tag().map_err(|e| {
                 ExecutionError::new_with_source(
                     ExecutionErrorKind::InvalidLinkage,
                     format!("Invalid type tag in move call argument: {:?}", e),
                 )
             })?;
-            let ids = tag.all_addresses().into_iter().map(ObjectID::from);
-            resolution_table.add_type_linkages_to_table(ids, package_store)
+            merge_type_addresses(
+                analyzer,
+                resolution_table,
+                raw_tag.all_addresses(),
+                package_store,
+                cache,
+            )?;
+
+            // Also pre-warm a small resolution table under the defining-ID key so future
+            // `Env::get_type_linkage` calls (which see defining-ID tags after type-origin rewrite)
+            // hit the cache. In the common case where raw == defining IDs, this is the same key as
+            // above and is a cheap cache hit; otherwise it walks once and caches.
+            if cache.is_enabled() {
+                let defining_tag = cache.type_input_to_defining_tag(ty, idx, package_store)?;
+                let defining_addrs = defining_tag.all_addresses();
+                let key = TypeLinkageCacheKey::new(&defining_addrs);
+                cache.get_or_compute_type_resolution(key, || {
+                    ResolutionTable::for_type_addresses(
+                        analyzer.config().clone(),
+                        defining_addrs.iter().copied().map(ObjectID::from),
+                        package_store,
+                    )
+                })?;
+            }
+            Ok(())
         };
         match command {
             Command::MoveCall(pmc) => {
@@ -289,11 +366,14 @@ mod input_type_resolution_analysis {
                     type_arguments,
                     ..
                 } = &**pmc;
-                type_arguments.iter().try_for_each(add_ty_input)?;
+                type_arguments
+                    .iter()
+                    .enumerate()
+                    .try_for_each(&mut add_ty_input)?;
                 resolution_table.add_type_linkages_to_table([*package], package_store)?;
             }
             Command::MakeMoveVec(Some(ty), _) => {
-                add_ty_input(ty)?;
+                add_ty_input((0, ty))?;
             }
             Command::MakeMoveVec(None, _)
             | Command::TransferObjects(_, _)

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/linkage/analysis.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/linkage/analysis.rs
@@ -345,17 +345,22 @@ mod input_type_resolution_analysis {
             // `Env::get_type_linkage` calls (which see defining-ID tags after type-origin rewrite)
             // hit the cache. In the common case where raw == defining IDs, this is the same key as
             // above and is a cheap cache hit; otherwise it walks once and caches.
-            if cache.is_enabled() {
-                let defining_tag = cache.type_input_to_defining_tag(ty, idx, package_store)?;
+            //
+            // Pre-warming is purely an optimization — any failure (e.g. a missing type, an
+            // invalid package address) is swallowed here and surfaces later through the normal
+            // loading path, where it can be reported with the correct command/argument context.
+            if cache.is_enabled()
+                && let Ok(defining_tag) = cache.type_input_to_defining_tag(ty, idx, package_store)
+            {
                 let defining_addrs = defining_tag.all_addresses();
                 let key = TypeLinkageCacheKey::new(&defining_addrs);
-                cache.get_or_compute_type_resolution(key, || {
+                let _ = cache.get_or_compute_type_resolution(key, || {
                     ResolutionTable::for_type_addresses(
                         analyzer.config().clone(),
                         defining_addrs.iter().copied().map(ObjectID::from),
                         package_store,
                     )
-                })?;
+                });
             }
             Ok(())
         };

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/linkage/resolution.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/linkage/resolution.rs
@@ -45,6 +45,47 @@ impl ResolutionTable {
         }
     }
 
+    /// Build a fresh `ResolutionTable` containing only the transitive-dependency closure of
+    /// `ids`, used for the type-resolution path. Equivalent to `empty(config)` followed by
+    /// `add_type_linkages_to_table(ids, store)`.
+    pub fn for_type_addresses<I>(
+        config: ResolutionConfig,
+        ids: I,
+        store: &dyn PackageStore,
+    ) -> Result<Self, ExecutionError>
+    where
+        I: IntoIterator,
+        I::Item: Borrow<ObjectID>,
+    {
+        let mut table = Self::empty(config);
+        table.add_type_linkages_to_table(ids, store)?;
+        Ok(table)
+    }
+
+    /// Fold the entries from `other` into `self`, unifying constraints for any package that
+    /// already exists in `self`. Used to merge a per-tag small `ResolutionTable` (typically
+    /// pulled from the per-tx cache) into the PTB-wide table without re-walking transitive
+    /// dependencies.
+    pub fn fold_in(&mut self, other: &ResolutionTable) -> Result<(), ExecutionError> {
+        for (original_pkg_id, constraint) in &other.resolution_table {
+            match self.resolution_table.entry(*original_pkg_id) {
+                Entry::Vacant(e) => {
+                    e.insert(constraint.clone());
+                }
+                Entry::Occupied(mut e) => {
+                    let unified = e.get().unify(constraint)?;
+                    e.insert(unified);
+                }
+            }
+        }
+        for (version_id, original_id) in &other.all_versions_resolution_table {
+            self.all_versions_resolution_table
+                .entry(*version_id)
+                .or_insert(*original_id);
+        }
+        Ok(())
+    }
+
     /// Given a list of object IDs, generate a `ResolvedLinkage` for them.
     /// Since this linkage analysis should only be used for types, all packages are resolved
     /// "upwards" (i.e., later versions of the package are preferred).

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/loading/ast.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/loading/ast.rs
@@ -164,7 +164,7 @@ pub struct LoadedFunction {
 
 #[derive(Debug)]
 pub struct MoveCall {
-    pub function: LoadedFunction,
+    pub function: Rc<LoadedFunction>,
     pub arguments: Vec<Argument>,
 }
 

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/mod.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/mod.rs
@@ -14,7 +14,9 @@ use crate::{
     execution_value::ExecutionState,
     gas_charger::GasCharger,
     static_programmable_transactions::{
-        env::Env, linkage::analysis::LinkageAnalyzer, metering::translation_meter,
+        env::{Env, cache::PerTxCache},
+        linkage::analysis::LinkageAnalyzer,
+        metering::translation_meter,
     },
 };
 use move_trace_format::format::MoveTraceBuilder;
@@ -52,8 +54,9 @@ pub fn execute<Mode: ExecutionMode>(
     let package_store = CachedPackageStore::new(vm, TransactionPackageStore::new(package_store));
     let linkage_analysis =
         LinkageAnalyzer::new::<Mode>(protocol_config).map_err(|e| (e, vec![]))?;
+    let per_tx_cache = PerTxCache::new(protocol_config);
     let ptb_type_linkage = linkage_analysis
-        .compute_input_type_resolution_linkage(&txn, &package_store, state_view)
+        .compute_input_type_resolution_linkage(&txn, &package_store, state_view, &per_tx_cache)
         .and_then(|linkage| linkage.linkage_context())
         .map_err(|e| (e, vec![]))?;
     let resolution_vm = vm
@@ -72,6 +75,7 @@ pub fn execute<Mode: ExecutionMode>(
         &package_store,
         &linkage_analysis,
         &resolution_vm,
+        &per_tx_cache,
     );
     let mut translation_meter =
         translation_meter::TranslationMeter::new(protocol_config, gas_charger);

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/ast.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/ast.rs
@@ -10,7 +10,7 @@ use crate::{
 use indexmap::{IndexMap, IndexSet};
 use move_core_types::{account_address::AccountAddress, u256::U256};
 use move_vm_runtime::execution::values::VectorSpecialization;
-use std::cell::OnceCell;
+use std::{cell::OnceCell, rc::Rc};
 use sui_types::base_types::{ObjectID, ObjectRef};
 
 //**************************************************************************************************
@@ -147,7 +147,7 @@ pub type LoadedFunction = L::LoadedFunction;
 
 #[derive(Debug)]
 pub struct MoveCall {
-    pub function: LoadedFunction,
+    pub function: Rc<LoadedFunction>,
     pub arguments: Vec<Argument>,
 }
 

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/invariant_checks/defining_ids_in_types.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/invariant_checks/defining_ids_in_types.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    data_store::PackageStore,
     sp,
     static_programmable_transactions::{env, spanned::Spanned, typing::ast as T},
 };
@@ -82,7 +81,7 @@ fn ensure_type_defining_id_based(env: &env::Env, ty: &T::Type) -> Result<(), Exe
             // If we fail to resolve the type that's an invariant violation as we should be able to
             // load the package that defined this type otherwise we should have failed at
             // load/typing time.
-            let Ok(Some(resolved_id)) = env.linkable_store.resolve_type_to_defining_id(
+            let Ok(Some(resolved_id)) = env.resolve_type_to_defining_id(
                 (*datatype.module.address()).into(),
                 datatype.module.name(),
                 &datatype.name,

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/invariant_checks/type_check.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/invariant_checks/type_check.rs
@@ -150,7 +150,7 @@ fn command<Mode: ExecutionMode>(
                 function,
                 arguments,
             } = &**move_call;
-            let L::LoadedFunction { signature, .. } = function;
+            let L::LoadedFunction { signature, .. } = &**function;
             let L::LoadedFunctionInstantiation {
                 parameters,
                 return_,


### PR DESCRIPTION
## Description 

This adds per-transaction caches to the PTB layer that cache type conversions that are done, as well as type linkage caches and loaded functions.

## Test plan 

Make sure existing tests + local benchmarking 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
