### PR TITLE
ci: dispatch S3 release-tag flow to ensure-sui-binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -277,15 +277,16 @@ jobs:
           event-type: tag-docker-images
           client-payload: '{"sui_commit": "${{ github.sha }}", "tag": "${{ env.TAG_NAME }}"}'
 
-  # Tag all sui images with release tag, so that they can be easily found
+  # Tag sui binaries in S3 under the release alias so node operators that pull
+  # by tag name (e.g. `release: testnet-v1.70.2` in ansible) find them.
   tag-release-binaries-in-s3:
     name: Tag sui binaries in s3
     runs-on: ubuntu-latest
     steps:
-      - name: Dispatch Release binaries builds in MystenLabs/sui-operations
+      - name: Dispatch ensure-sui-binaries in MystenLabs/sui-operations
         uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # pin@v4.0.1
         with:
           repository: MystenLabs/sui-operations
           token: ${{ secrets.DOCKER_BINARY_BUILDS_DISPATCH }}
-          event-type: build-release-binaries
+          event-type: ensure-sui-binaries
           client-payload: '{"sui_commit": "${{ github.sha }}", "tag_name": "${{ env.TAG_NAME }}"}'


### PR DESCRIPTION
## Summary

Switches the cross-repo dispatch target in \`.github/workflows/release.yml\` from the legacy \`build-release-binaries\` event on \`sui-release-binaries.yml\` to the new \`ensure-sui-binaries\` event on \`ensure-sui-binaries.yml\` in sui-operations.

4-line diff: event-type, step name, and the preceding comment.

## Why

\`sui-release-binaries.yml\` is the legacy cargo-build-from-source path. \`ensure-sui-binaries.yml\` (landed in MystenLabs/sui-operations#7684 + #7686) is a thin wrapper around \`prebuild-sui-images.yml\` that:

1. HEADs S3 for the binaries this tag flow needs (\`sui-node\`, \`sui\`, \`sui-tool\`, \`stress\`) — ~15s on a cache hit.
2. On a miss, triggers \`prebuild-sui-images\` narrowed to amd64 + \`build_sui=true\` + \`stress=true\`, so mp3 builds \`sui-node\` + \`sui-tools\` + \`stress\` images and its extraction sidecar uploads \`sui-node\`, \`sui\`, \`sui-bridge\`, \`sui-tool\`, \`stress\` to S3.
3. Copies the SHA prefix to the tag prefix with \`aws s3 cp --recursive\` — one command, picks up every object (binaries + \`.sha256\` sidecars).

Client payload shape is **unchanged** — still \`{sui_commit, tag_name}\`. Target workflow's behavior is functionally equivalent to the legacy workflow for this use case, just faster (S3-skip), without the ~40m cargo build on cache miss.

## Tag contract

What ends up at \`s3://sui-releases/<release-tag>/\` after this change:

| Binary | Present in tagged prefix | Why |
|---|---|---|
| \`sui-node\` | ✅ | Node operators pull from \`{tag}/sui-node\` |
| \`sui\` | ✅ | Ansible ssfn + sui-bridge roles pull from \`{tag}/sui\` |
| \`sui-tool\` | ✅ | formal-snapshot-restore pulls from \`{tag}/sui-tool\` |
| \`sui-bridge\` | ✅ | sui-bridge ansible role pulls from \`{tag}/sui-bridge\` |
| \`stress\` | ✅ | stress-node-update pulls from \`{tag}/stress\` |
| \`sui-proxy\` | ❌ (intentional) | Only pulled by SHA (\`{sui_proxy_release}/sui-proxy\` — where \`sui_proxy_release\` is a SHA, not a tag) |
| \`sui-metric-checker\` | ❌ (intentional) | Only pulled by SHA in perf-regression-check.yml |
| \`sui-faucet\`, \`sui-bridge-cli\`, \`sui-test-validator\`, \`move-analyzer\` | ❌ (intentional) | These are released as GitHub release assets via the \`Attach Sui binaries to a release\` workflow, not consumed from S3 by tag. Grepping sui-operations shows zero consumers of these at the tag prefix. |

## After merge

The \`repository_dispatch: build-release-binaries\` entry on \`sui-release-binaries.yml\` in sui-operations becomes dead code. Follow-up sui-operations PR will remove it once this lands and a release cycle confirms the new path works end-to-end.

## Test plan

- [x] \`actionlint .github/workflows/release.yml\` — no new errors (pre-existing \`ubuntu-arm64\`/\`windows-ghcloud\` runner-label warnings and shellcheck SC2086 on unrelated lines are unchanged).
- [ ] After merge: next release tag (devnet/testnet/mainnet) fires \`ensure-sui-binaries\` in sui-operations; verify the tag prefix \`s3://sui-releases/<tag>/\` contains \`sui-node\`, \`sui\`, \`sui-bridge\`, \`sui-tool\`, \`stress\` (plus \`.sha256\` sidecars).
- [ ] Verify the older dispatch stops firing — confirm no new \`sui-release-binaries.yml\` runs appear triggered by this release flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)