### PR TITLE
pipelined batch/commit for sequential pipelines

### DIFF
--- a/crates/sui-analytics-indexer/src/config.rs
+++ b/crates/sui-analytics-indexer/src/config.rs
@@ -115,6 +115,7 @@ pub struct SequentialLayer {
     pub min_eager_rows: Option<usize>,
     pub max_batch_checkpoints: Option<usize>,
     pub processor_channel_size: Option<usize>,
+    pub pipeline_depth: Option<usize>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -183,6 +184,7 @@ impl SequentialLayer {
             min_eager_rows: self.min_eager_rows.or(base.min_eager_rows),
             max_batch_checkpoints: self.max_batch_checkpoints.or(base.max_batch_checkpoints),
             processor_channel_size: self.processor_channel_size.or(base.processor_channel_size),
+            pipeline_depth: self.pipeline_depth.or(base.pipeline_depth),
         }
     }
 }

--- a/crates/sui-indexer-alt-framework/src/pipeline/sequential/collector.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/sequential/collector.rs
@@ -4,8 +4,6 @@
 use std::cmp::Ordering;
 use std::collections::BTreeMap;
 use std::sync::Arc;
-use std::sync::atomic::AtomicUsize;
-use std::sync::atomic::Ordering as AtomicOrdering;
 
 use sui_futures::service::Service;
 use sui_indexer_alt_framework_store_traits::CommitterWatermark;
@@ -52,7 +50,6 @@ pub(super) fn collector<H: Handler>(
     min_eager_rows: usize,
     max_batch_checkpoints: usize,
     committer_tx: mpsc::Sender<BatchedRows<H>>,
-    pending_rows: Arc<AtomicUsize>,
 ) -> Service {
     Service::new().spawn_aborting(async move {
         // The `poll` interval controls the maximum time to wait between commits, regardless of the
@@ -75,6 +72,7 @@ pub(super) fn collector<H: Handler>(
         // Data for checkpoint that haven't been written yet. Note that `pending_rows` includes
         // rows in `batch`.
         let mut pending: BTreeMap<u64, IndexedCheckpoint<H>> = BTreeMap::new();
+        let mut pending_rows: usize = 0;
 
         info!(pipeline = H::NAME, "Starting collector");
 
@@ -139,7 +137,7 @@ pub(super) fn collector<H: Handler>(
                                     .inc();
 
                                 let indexed = entry.remove();
-                                pending_rows.fetch_sub(indexed.len(), AtomicOrdering::Relaxed);
+                                pending_rows -= indexed.len();
                             }
                         }
                     }
@@ -150,7 +148,7 @@ pub(super) fn collector<H: Handler>(
                         pipeline = H::NAME,
                         elapsed_ms = elapsed * 1000.0,
                         rows = batch_rows,
-                        pending = pending_rows.load(AtomicOrdering::Relaxed),
+                        pending = pending_rows,
                         "Gathered batch",
                     );
 
@@ -208,7 +206,7 @@ pub(super) fn collector<H: Handler>(
                         break;
                     }
 
-                    pending_rows.fetch_sub(batch_rows, AtomicOrdering::Relaxed);
+                    pending_rows -= batch_rows;
                     batch_checkpoints = 0;
                     batch_rows = 0;
 
@@ -228,16 +226,14 @@ pub(super) fn collector<H: Handler>(
                         .with_label_values(&[H::NAME])
                         .inc_by(indexed.len() as u64);
 
-                    let new_pending =
-                        pending_rows.fetch_add(indexed.len(), AtomicOrdering::Relaxed)
-                            + indexed.len();
+                    pending_rows += indexed.len();
                     pending.insert(indexed.checkpoint(), indexed);
 
                     // Once data has been inserted, check if we need to schedule a write before the
                     // next polling interval. This is appropriate if there are a minimum number of
                     // rows to write, and they are already in the batch, or we can process the next
                     // checkpoint to extract them.
-                    if new_pending < min_eager_rows {
+                    if pending_rows < min_eager_rows {
                         continue;
                     }
 

--- a/crates/sui-indexer-alt-framework/src/pipeline/sequential/collector.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/sequential/collector.rs
@@ -41,8 +41,8 @@ pub(super) struct BatchedRows<H: Handler> {
 /// expected checkpoint has arrived.
 ///
 /// Backpressure: when `committer_tx` is full (bounded by `pipeline_depth`), the collector
-/// blocks on send, stops draining `pending`, and `pending_rows` rises — signalling upstream
-/// ingestion to slow down.
+/// blocks on send and stops reading `rx`, so the processor→collector channel fills and the
+/// adaptive fanout / ingest controllers cut upstream concurrency.
 pub(super) fn collector<H: Handler>(
     handler: Arc<H>,
     config: SequentialConfig,
@@ -194,9 +194,10 @@ pub(super) fn collector<H: Handler>(
                         .set(watermark.timestamp_ms_hi_inclusive as i64);
 
                     // Hand the assembled batch off to the committer. When `committer_tx` is full,
-                    // this blocks — natural backpressure: the collector stops draining `pending`,
-                    // `pending_rows` rises, and the adaptive ingestion controller cuts fetch
-                    // concurrency.
+                    // this blocks — natural backpressure: the collector stops reading `rx`, the
+                    // processor→collector channel fills, the adaptive `fanout` controller cuts
+                    // processor concurrency, and the broadcaster→processor channel eventually
+                    // fills as well, signalling the ingest controller to throttle fetches.
                     let batched = BatchedRows {
                         batch: std::mem::take(&mut batch),
                         watermark,

--- a/crates/sui-indexer-alt-framework/src/pipeline/sequential/collector.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/sequential/collector.rs
@@ -1,0 +1,262 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::cmp::Ordering;
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering as AtomicOrdering;
+
+use sui_futures::service::Service;
+use sui_indexer_alt_framework_store_traits::CommitterWatermark;
+use tokio::sync::mpsc;
+use tokio::time::MissedTickBehavior;
+use tokio::time::interval;
+use tracing::debug;
+use tracing::info;
+use tracing::warn;
+
+use crate::metrics::IndexerMetrics;
+use crate::pipeline::IndexedCheckpoint;
+use crate::pipeline::WARN_PENDING_WATERMARKS;
+use crate::pipeline::sequential::Handler;
+use crate::pipeline::sequential::SequentialConfig;
+
+/// A fully-assembled batch handed off from the collector to the committer task.
+///
+/// Batches are produced strictly in checkpoint order by the collector and consumed in the
+/// same order by the committer, so watermarks advance monotonically even with pipelining.
+pub(super) struct BatchedRows<H: Handler> {
+    pub batch: H::Batch,
+    pub watermark: CommitterWatermark,
+    pub batch_rows: usize,
+}
+
+/// Collector task — drains `rx` into a reorder buffer, assembles batches in checkpoint order,
+/// and hands each ready batch off to the committer via `committer_tx`.
+///
+/// Data arrives out of order, grouped by checkpoint, on `rx`. The collector orders them and
+/// waits to dispatch them until either a configurable polling interval has passed (controlled
+/// by `config.collect_interval()`), or `H::BATCH_SIZE` rows have been accumulated and the next
+/// expected checkpoint has arrived.
+///
+/// Backpressure: when `committer_tx` is full (bounded by `pipeline_depth`), the collector
+/// blocks on send, stops draining `pending`, and `pending_rows` rises — signalling upstream
+/// ingestion to slow down.
+pub(super) fn collector<H: Handler>(
+    handler: Arc<H>,
+    config: SequentialConfig,
+    mut next_checkpoint: u64,
+    mut rx: mpsc::Receiver<IndexedCheckpoint<H>>,
+    metrics: Arc<IndexerMetrics>,
+    min_eager_rows: usize,
+    max_batch_checkpoints: usize,
+    committer_tx: mpsc::Sender<BatchedRows<H>>,
+    pending_rows: Arc<AtomicUsize>,
+) -> Service {
+    Service::new().spawn_aborting(async move {
+        // The `poll` interval controls the maximum time to wait between commits, regardless of the
+        // amount of data available.
+        let mut poll = interval(config.committer.collect_interval());
+        poll.set_missed_tick_behavior(MissedTickBehavior::Delay);
+
+        // Buffer to gather the next batch to write. A checkpoint's data is only added to the batch
+        // when it is known to come from the next checkpoint after `watermark` (the current tip of
+        // the batch), and data from previous checkpoints will be discarded to avoid double writes.
+        let mut batch = H::Batch::default();
+        let mut batch_rows = 0;
+        let mut batch_checkpoints = 0;
+
+        // The task keeps track of the highest (inclusive) checkpoint it has added to the batch
+        // through `next_checkpoint`. By extension it also knows the next checkpoint to expect and
+        // add to the batch.
+        let mut watermark: Option<CommitterWatermark> = None;
+
+        // Data for checkpoint that haven't been written yet. Note that `pending_rows` includes
+        // rows in `batch`.
+        let mut pending: BTreeMap<u64, IndexedCheckpoint<H>> = BTreeMap::new();
+
+        info!(pipeline = H::NAME, "Starting collector");
+
+        loop {
+            tokio::select! {
+                _ = poll.tick() => {
+                    if batch_checkpoints == 0
+                        && rx.is_closed()
+                        && rx.is_empty()
+                        && !has_ready_checkpoint(next_checkpoint, &pending)
+                    {
+                        info!(pipeline = H::NAME, "Process closed channel and no more data to commit");
+                        break;
+                    }
+
+                    if pending.len() > WARN_PENDING_WATERMARKS {
+                        warn!(
+                            pipeline = H::NAME,
+                            pending = pending.len(),
+                            "Pipeline has a large number of pending watermarks",
+                        );
+                    }
+
+                    let guard = metrics
+                        .collector_gather_latency
+                        .with_label_values(&[H::NAME])
+                        .start_timer();
+
+                    // Push data into the next batch as long as it's from contiguous checkpoints
+                    // and we haven't gathered information from too many checkpoints already.
+                    //
+                    // We don't worry about overall size because the handler may have optimized
+                    // writes by combining rows, but we will limit the number of checkpoints we try
+                    // and batch together as a way to impose some limit on the size of the batch
+                    // (and therefore the length of the write transaction).
+                    // docs::#batch  (see docs/content/guides/developer/advanced/custom-indexer.mdx)
+                    while batch_checkpoints < max_batch_checkpoints {
+                        let Some(entry) = pending.first_entry() else {
+                            break;
+                        };
+
+                        match next_checkpoint.cmp(entry.key()) {
+                            // Next pending checkpoint is from the future.
+                            Ordering::Less => break,
+
+                            // This is the next checkpoint -- include it.
+                            Ordering::Equal => {
+                                let indexed = entry.remove();
+                                batch_rows += indexed.len();
+                                batch_checkpoints += 1;
+                                handler.batch(&mut batch, indexed.values.into_iter());
+                                watermark = Some(indexed.watermark);
+                                next_checkpoint += 1;
+                            }
+
+                            // Next pending checkpoint is in the past, ignore it to avoid double
+                            // writes.
+                            Ordering::Greater => {
+                                metrics
+                                    .total_watermarks_out_of_order
+                                    .with_label_values(&[H::NAME])
+                                    .inc();
+
+                                let indexed = entry.remove();
+                                pending_rows.fetch_sub(indexed.len(), AtomicOrdering::Relaxed);
+                            }
+                        }
+                    }
+                    // docs::/#batch
+
+                    let elapsed = guard.stop_and_record();
+                    debug!(
+                        pipeline = H::NAME,
+                        elapsed_ms = elapsed * 1000.0,
+                        rows = batch_rows,
+                        pending = pending_rows.load(AtomicOrdering::Relaxed),
+                        "Gathered batch",
+                    );
+
+                    // If there is no new data to commit, we can skip the rest of the process. Note
+                    // that we cannot use batch_rows for the check, since it is possible that there
+                    // are empty checkpoints with no new rows added, but the watermark still needs
+                    // to be updated. Conversely, if there is no watermark to be updated, we know
+                    // there is no data to write out.
+                    if batch_checkpoints == 0 {
+                        assert_eq!(batch_rows, 0);
+                        continue;
+                    }
+
+                    let Some(watermark) = watermark else {
+                        continue;
+                    };
+
+                    metrics
+                        .collector_batch_size
+                        .with_label_values(&[H::NAME])
+                        .observe(batch_rows as f64);
+
+                    metrics
+                        .watermark_epoch
+                        .with_label_values(&[H::NAME])
+                        .set(watermark.epoch_hi_inclusive as i64);
+
+                    metrics
+                        .watermark_checkpoint
+                        .with_label_values(&[H::NAME])
+                        .set(watermark.checkpoint_hi_inclusive as i64);
+
+                    metrics
+                        .watermark_transaction
+                        .with_label_values(&[H::NAME])
+                        .set(watermark.tx_hi as i64);
+
+                    metrics
+                        .watermark_timestamp_ms
+                        .with_label_values(&[H::NAME])
+                        .set(watermark.timestamp_ms_hi_inclusive as i64);
+
+                    // Hand the assembled batch off to the committer. When `committer_tx` is full,
+                    // this blocks — natural backpressure: the collector stops draining `pending`,
+                    // `pending_rows` rises, and the adaptive ingestion controller cuts fetch
+                    // concurrency.
+                    let batched = BatchedRows {
+                        batch: std::mem::take(&mut batch),
+                        watermark,
+                        batch_rows,
+                    };
+                    if committer_tx.send(batched).await.is_err() {
+                        info!(pipeline = H::NAME, "Committer task closed; stopping collector");
+                        break;
+                    }
+
+                    pending_rows.fetch_sub(batch_rows, AtomicOrdering::Relaxed);
+                    batch_checkpoints = 0;
+                    batch_rows = 0;
+
+                    // If we could make more progress immediately, then schedule more work without
+                    // waiting.
+                    if has_ready_checkpoint(next_checkpoint, &pending) {
+                        poll.reset_immediately();
+                    }
+                }
+
+                Some(indexed) = rx.recv() => {
+                    // Although there isn't an explicit collector in the sequential pipeline,
+                    // keeping this metric consistent with concurrent pipeline is useful
+                    // to monitor the backpressure from committer to processor.
+                    metrics
+                        .total_collector_rows_received
+                        .with_label_values(&[H::NAME])
+                        .inc_by(indexed.len() as u64);
+
+                    let new_pending =
+                        pending_rows.fetch_add(indexed.len(), AtomicOrdering::Relaxed)
+                            + indexed.len();
+                    pending.insert(indexed.checkpoint(), indexed);
+
+                    // Once data has been inserted, check if we need to schedule a write before the
+                    // next polling interval. This is appropriate if there are a minimum number of
+                    // rows to write, and they are already in the batch, or we can process the next
+                    // checkpoint to extract them.
+                    if new_pending < min_eager_rows {
+                        continue;
+                    }
+
+                    if batch_checkpoints > 0 || has_ready_checkpoint(next_checkpoint, &pending) {
+                        poll.reset_immediately();
+                    }
+                }
+            }
+        }
+
+        info!(pipeline = H::NAME, "Stopping collector");
+        Ok(())
+    })
+}
+
+// Whether the first entry in `pending` is ready to be consumed by the collector — either to be
+// included in the next batch (if it matches `next_checkpoint`) or discarded as a stale duplicate
+// (if it predates `next_checkpoint`).
+fn has_ready_checkpoint<T>(next_checkpoint: u64, pending: &BTreeMap<u64, T>) -> bool {
+    pending
+        .first_key_value()
+        .is_some_and(|(&first, _)| first <= next_checkpoint)
+}

--- a/crates/sui-indexer-alt-framework/src/pipeline/sequential/committer.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/sequential/committer.rs
@@ -1,643 +1,166 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::cmp::Ordering;
-use std::collections::BTreeMap;
 use std::sync::Arc;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering as AtomicOrdering;
+use std::time::Duration;
 
+use backoff::ExponentialBackoff;
 use scoped_futures::ScopedFutureExt;
 use sui_futures::service::Service;
 use tokio::sync::mpsc;
-use tokio::time::MissedTickBehavior;
-use tokio::time::interval;
 use tracing::debug;
 use tracing::info;
 use tracing::warn;
 
 use crate::metrics::CheckpointLagMetricReporter;
 use crate::metrics::IndexerMetrics;
-use crate::pipeline::IndexedCheckpoint;
-use crate::pipeline::WARN_PENDING_WATERMARKS;
 use crate::pipeline::logging::WatermarkLogger;
 use crate::pipeline::sequential::Handler;
-use crate::pipeline::sequential::SequentialConfig;
+use crate::pipeline::sequential::collector::BatchedRows;
 use crate::store::Connection;
 use crate::store::SequentialStore;
 
-/// The committer task gathers rows into batches and writes them to the database.
-///
-/// Data arrives out of order, grouped by checkpoint, on `rx`. The task orders them and waits to
-/// write them until either a configural polling interval has passed (controlled by
-/// `config.collect_interval()`), or `H::BATCH_SIZE` rows have been accumulated and we have
-/// received the next expected checkpoint.
-///
-/// Writes are performed on checkpoint boundaries (more than one checkpoint can be present in a
-/// single write), in a single transaction that includes all row updates and an update to the
-/// watermark table.
+const INITIAL_RETRY_INTERVAL: Duration = Duration::from_millis(100);
+const MAX_RETRY_INTERVAL: Duration = Duration::from_secs(1);
+
+/// Committer task — receives fully-assembled batches from the collector and commits them in
+/// order (one at a time; watermark ordering requires strict serialisation). On commit failure
+/// it retries the same batch under exponential backoff. The collector is free to build the
+/// next batch in the meantime, bounded by `pipeline_depth`.
 pub(super) fn committer<H: Handler>(
     handler: Arc<H>,
-    config: SequentialConfig,
-    mut next_checkpoint: u64,
-    mut rx: mpsc::Receiver<IndexedCheckpoint<H>>,
     store: H::Store,
     metrics: Arc<IndexerMetrics>,
-    min_eager_rows: usize,
-    max_batch_checkpoints: usize,
+    mut rx: mpsc::Receiver<BatchedRows<H>>,
+    pending_rows: Arc<AtomicUsize>,
 ) -> Service {
     Service::new().spawn_aborting(async move {
-        // The `poll` interval controls the maximum time to wait between commits, regardless of the
-        // amount of data available.
-        let mut poll = interval(config.committer.collect_interval());
-        poll.set_missed_tick_behavior(MissedTickBehavior::Delay);
+        info!(pipeline = H::NAME, "Starting committer");
 
-        // Buffer to gather the next batch to write. A checkpoint's data is only added to the batch
-        // when it is known to come from the next checkpoint after `watermark` (the current tip of
-        // the batch), and data from previous checkpoints will be discarded to avoid double writes.
-        //
-        // The batch may be non-empty at top of a tick of the committer's loop if the previous
-        // attempt at a write failed. Attempt is incremented every time a batch write fails, and is
-        // reset when it succeeds.
-        let mut attempt = 0;
-        let mut batch = H::Batch::default();
-        let mut batch_rows = 0;
-        let mut batch_checkpoints = 0;
-
-        // The task keeps track of the highest (inclusive) checkpoint it has added to the batch
-        // through `next_checkpoint`, and whether that batch needs to be written out. By extension
-        // it also knows the next checkpoint to expect and add to the batch. In case of db txn
-        // failures, we need to know the watermark update that failed, cached to this variable. in
-        // case of db txn failures.
-        let mut watermark = None;
-
-        // The committer task will periodically output a log message at a higher log level to
-        // demonstrate that the pipeline is making progress.
         let mut logger = WatermarkLogger::new("sequential_committer");
-
         let checkpoint_lag_reporter = CheckpointLagMetricReporter::new_for_pipeline::<H>(
             &metrics.watermarked_checkpoint_timestamp_lag,
             &metrics.latest_watermarked_checkpoint_timestamp_lag_ms,
             &metrics.watermark_checkpoint_in_db,
         );
 
-        // Data for checkpoint that haven't been written yet. Note that `pending_rows` includes
-        // rows in `batch`.
-        let mut pending: BTreeMap<u64, IndexedCheckpoint<H>> = BTreeMap::new();
-        let mut pending_rows = 0;
+        while let Some(batched) = rx.recv().await {
+            let BatchedRows {
+                batch,
+                watermark,
+                batch_rows,
+            } = batched;
 
-        info!(pipeline = H::NAME, "Starting committer");
+            let backoff = ExponentialBackoff {
+                initial_interval: INITIAL_RETRY_INTERVAL,
+                current_interval: INITIAL_RETRY_INTERVAL,
+                max_interval: MAX_RETRY_INTERVAL,
+                max_elapsed_time: None,
+                ..Default::default()
+            };
 
-        loop {
-            tokio::select! {
-                _ = poll.tick() => {
-                    if batch_checkpoints == 0
-                        && rx.is_closed()
-                        && rx.is_empty()
-                        && !has_ready_checkpoint(next_checkpoint, &pending)
-                    {
-                        info!(pipeline = H::NAME, "Process closed channel and no more data to commit");
-                        break;
-                    }
+            let commit = || async {
+                metrics
+                    .total_committer_batches_attempted
+                    .with_label_values(&[H::NAME])
+                    .inc();
 
-                    if pending.len() > WARN_PENDING_WATERMARKS {
-                        warn!(
-                            pipeline = H::NAME,
-                            pending = pending.len(),
-                            "Pipeline has a large number of pending watermarks",
-                        );
-                    }
+                let guard = metrics
+                    .committer_commit_latency
+                    .with_label_values(&[H::NAME])
+                    .start_timer();
 
-                    let guard = metrics
-                        .collector_gather_latency
-                        .with_label_values(&[H::NAME])
-                        .start_timer();
-
-                    // Push data into the next batch as long as it's from contiguous checkpoints
-                    // and we haven't gathered information from too many checkpoints already.
-                    //
-                    // We don't worry about overall size because the handler may have optimized
-                    // writes by combining rows, but we will limit the number of checkpoints we try
-                    // and batch together as a way to impose some limit on the size of the batch
-                    // (and therefore the length of the write transaction).
-                    // docs::#batch  (see docs/content/guides/developer/advanced/custom-indexer.mdx)
-                    while batch_checkpoints < max_batch_checkpoints {
-                        let Some(entry) = pending.first_entry() else {
-                            break;
-                        };
-
-                        match next_checkpoint.cmp(entry.key()) {
-                            // Next pending checkpoint is from the future.
-                            Ordering::Less => break,
-
-                            // This is the next checkpoint -- include it.
-                            Ordering::Equal => {
-                                let indexed = entry.remove();
-                                batch_rows += indexed.len();
-                                batch_checkpoints += 1;
-                                handler.batch(&mut batch, indexed.values.into_iter());
-                                watermark = Some(indexed.watermark);
-                                next_checkpoint += 1;
-                            }
-
-                            // Next pending checkpoint is in the past, ignore it to avoid double
-                            // writes.
-                            Ordering::Greater => {
-                                metrics
-                                    .total_watermarks_out_of_order
-                                    .with_label_values(&[H::NAME])
-                                    .inc();
-
-                                let indexed = entry.remove();
-                                pending_rows -= indexed.len();
-                            }
-                        }
-                    }
-                    // docs::/#batch
-
-                    let elapsed = guard.stop_and_record();
-                    debug!(
-                        pipeline = H::NAME,
-                        elapsed_ms = elapsed * 1000.0,
-                        rows = batch_rows,
-                        pending = pending_rows,
-                        "Gathered batch",
-                    );
-
-                    // If there is no new data to commit, we can skip the rest of the process. Note
-                    // that we cannot use batch_rows for the check, since it is possible that there
-                    // are empty checkpoints with no new rows added, but the watermark still needs
-                    // to be updated. Conversely, if there is no watermark to be updated, we know
-                    // there is no data to write out.
-                    if batch_checkpoints == 0 {
-                        assert_eq!(batch_rows, 0);
-                        continue;
-                    }
-
-                    let Some(watermark) = watermark else {
-                        continue;
-                    };
-
-                    metrics
-                        .collector_batch_size
-                        .with_label_values(&[H::NAME])
-                        .observe(batch_rows as f64);
-
-                    metrics
-                        .total_committer_batches_attempted
-                        .with_label_values(&[H::NAME])
-                        .inc();
-
-                    metrics
-                        .watermark_epoch
-                        .with_label_values(&[H::NAME])
-                        .set(watermark.epoch_hi_inclusive as i64);
-
-                    metrics
-                        .watermark_checkpoint
-                        .with_label_values(&[H::NAME])
-                        .set(watermark.checkpoint_hi_inclusive as i64);
-
-                    metrics
-                        .watermark_transaction
-                        .with_label_values(&[H::NAME])
-                        .set(watermark.tx_hi as i64);
-
-                    metrics
-                        .watermark_timestamp_ms
-                        .with_label_values(&[H::NAME])
-                        .set(watermark.timestamp_ms_hi_inclusive as i64);
-
-                    let guard = metrics
-                        .committer_commit_latency
-                        .with_label_values(&[H::NAME])
-                        .start_timer();
-
-                    let affected = store.transaction(|conn| {
+                let result = store
+                    .transaction(|conn| {
                         async {
                             conn.set_committer_watermark(H::NAME, watermark).await?;
                             handler.commit(&batch, conn).await
-                        }.scope_boxed()
-                    }).await;
-
-
-                    let elapsed = guard.stop_and_record();
-
-                    let affected = match affected {
-                        Ok(affected) => affected,
-
-                        Err(e) => {
-                            warn!(
-                                pipeline = H::NAME,
-                                elapsed_ms = elapsed * 1000.0,
-                                attempt,
-                                committed = batch_rows,
-                                pending = pending_rows,
-                                "Error writing batch: {e}",
-                            );
-
-                            metrics
-                                .total_committer_batches_failed
-                                .with_label_values(&[H::NAME])
-                                .inc();
-
-                            attempt += 1;
-                            continue;
                         }
-                    };
+                        .scope_boxed()
+                    })
+                    .await;
 
-                    debug!(
-                        pipeline = H::NAME,
-                        attempt,
-                        affected,
-                        committed = batch_rows,
-                        pending = pending_rows,
-                        "Wrote batch",
-                    );
+                let elapsed = guard.stop_and_record();
 
-                    logger.log::<H>(&watermark, elapsed);
-
-                    checkpoint_lag_reporter.report_lag(
-                        watermark.checkpoint_hi_inclusive,
-                        watermark.timestamp_ms_hi_inclusive
-                    );
-
-                    metrics
-                        .total_committer_batches_succeeded
-                        .with_label_values(&[H::NAME])
-                        .inc();
-
-                    metrics
-                        .total_committer_rows_committed
-                        .with_label_values(&[H::NAME])
-                        .inc_by(batch_rows as u64);
-
-                    metrics
-                        .total_committer_rows_affected
-                        .with_label_values(&[H::NAME])
-                        .inc_by(affected as u64);
-
-                    metrics
-                        .committer_tx_rows
-                        .with_label_values(&[H::NAME])
-                        .observe(affected as f64);
-
-                    metrics
-                        .watermark_epoch_in_db
-                        .with_label_values(&[H::NAME])
-                        .set(watermark.epoch_hi_inclusive as i64);
-
-                    metrics
-                        .watermark_checkpoint_in_db
-                        .with_label_values(&[H::NAME])
-                        .set(watermark.checkpoint_hi_inclusive as i64);
-
-                    metrics
-                        .watermark_transaction_in_db
-                        .with_label_values(&[H::NAME])
-                        .set(watermark.tx_hi as i64);
-
-                    metrics
-                        .watermark_timestamp_in_db_ms
-                        .with_label_values(&[H::NAME])
-                        .set(watermark.timestamp_ms_hi_inclusive as i64);
-
-                    let _ = std::mem::take(&mut batch);
-                    pending_rows -= batch_rows;
-                    batch_checkpoints = 0;
-                    batch_rows = 0;
-                    attempt = 0;
-
-                    // If we could make more progress immediately, then schedule more work without
-                    // waiting.
-                    if has_ready_checkpoint(next_checkpoint, &pending) {
-                        poll.reset_immediately();
+                match result {
+                    Ok(affected) => Ok((affected, elapsed)),
+                    Err(e) => {
+                        warn!(
+                            pipeline = H::NAME,
+                            elapsed_ms = elapsed * 1000.0,
+                            committed = batch_rows,
+                            pending = pending_rows.load(AtomicOrdering::Relaxed),
+                            "Error writing batch: {e}",
+                        );
+                        metrics
+                            .total_committer_batches_failed
+                            .with_label_values(&[H::NAME])
+                            .inc();
+                        Err(backoff::Error::transient(e))
                     }
                 }
+            };
 
-                Some(indexed) = rx.recv() => {
-                    // Although there isn't an explicit collector in the sequential pipeline,
-                    // keeping this metric consistent with concurrent pipeline is useful
-                    // to monitor the backpressure from committer to processor.
-                    metrics
-                        .total_collector_rows_received
-                        .with_label_values(&[H::NAME])
-                        .inc_by(indexed.len() as u64);
+            let (affected, elapsed) = backoff::future::retry(backoff, commit).await?;
 
-                    pending_rows += indexed.len();
-                    pending.insert(indexed.checkpoint(), indexed);
+            debug!(
+                pipeline = H::NAME,
+                affected,
+                committed = batch_rows,
+                pending = pending_rows.load(AtomicOrdering::Relaxed),
+                "Wrote batch",
+            );
+            logger.log::<H>(&watermark, elapsed);
 
-                    // Once data has been inserted, check if we need to schedule a write before the
-                    // next polling interval. This is appropriate if there are a minimum number of
-                    // rows to write, and they are already in the batch, or we can process the next
-                    // checkpoint to extract them.
-                    if pending_rows < min_eager_rows {
-                        continue;
-                    }
+            checkpoint_lag_reporter.report_lag(
+                watermark.checkpoint_hi_inclusive,
+                watermark.timestamp_ms_hi_inclusive,
+            );
 
-                    if batch_checkpoints > 0 || has_ready_checkpoint(next_checkpoint, &pending) {
-                        poll.reset_immediately();
-                    }
-                }
-            }
+            metrics
+                .total_committer_batches_succeeded
+                .with_label_values(&[H::NAME])
+                .inc();
+
+            metrics
+                .total_committer_rows_committed
+                .with_label_values(&[H::NAME])
+                .inc_by(batch_rows as u64);
+
+            metrics
+                .total_committer_rows_affected
+                .with_label_values(&[H::NAME])
+                .inc_by(affected as u64);
+
+            metrics
+                .committer_tx_rows
+                .with_label_values(&[H::NAME])
+                .observe(affected as f64);
+
+            metrics
+                .watermark_epoch_in_db
+                .with_label_values(&[H::NAME])
+                .set(watermark.epoch_hi_inclusive as i64);
+
+            metrics
+                .watermark_checkpoint_in_db
+                .with_label_values(&[H::NAME])
+                .set(watermark.checkpoint_hi_inclusive as i64);
+
+            metrics
+                .watermark_transaction_in_db
+                .with_label_values(&[H::NAME])
+                .set(watermark.tx_hi as i64);
+
+            metrics
+                .watermark_timestamp_in_db_ms
+                .with_label_values(&[H::NAME])
+                .set(watermark.timestamp_ms_hi_inclusive as i64);
         }
 
         info!(pipeline = H::NAME, "Stopping committer");
         Ok(())
     })
-}
-
-// Whether the first entry in `pending` is ready to be consumed by the committer — either to be
-// included in the next batch (if it matches `next_checkpoint`) or discarded as a stale duplicate
-// (if it predates `next_checkpoint`).
-fn has_ready_checkpoint<T>(next_checkpoint: u64, pending: &BTreeMap<u64, T>) -> bool {
-    pending
-        .first_key_value()
-        .is_some_and(|(&first, _)| first <= next_checkpoint)
-}
-
-#[cfg(test)]
-mod tests {
-    use std::sync::Arc;
-    use std::time::Duration;
-
-    use async_trait::async_trait;
-    use prometheus::Registry;
-    use sui_types::full_checkpoint_content::Checkpoint;
-    use tokio::sync::mpsc;
-
-    use crate::mocks::store::MockConnection;
-    use crate::mocks::store::MockStore;
-    use crate::pipeline::CommitterConfig;
-    use crate::pipeline::Processor;
-
-    use super::*;
-
-    // Test implementation of Handler
-    #[derive(Default)]
-    struct TestHandler;
-
-    #[async_trait]
-    impl Processor for TestHandler {
-        const NAME: &'static str = "test";
-        type Value = u64;
-
-        async fn process(&self, _checkpoint: &Arc<Checkpoint>) -> anyhow::Result<Vec<Self::Value>> {
-            Ok(vec![])
-        }
-    }
-
-    #[async_trait]
-    impl super::Handler for TestHandler {
-        type Store = MockStore;
-        type Batch = Vec<u64>;
-        const MAX_BATCH_CHECKPOINTS: usize = 3; // Using small max value for testing.
-        const MIN_EAGER_ROWS: usize = 4; // Using small eager value for testing.
-
-        fn batch(&self, batch: &mut Self::Batch, values: std::vec::IntoIter<Self::Value>) {
-            batch.extend(values);
-        }
-
-        async fn commit<'a>(
-            &self,
-            batch: &Self::Batch,
-            conn: &mut MockConnection<'a>,
-        ) -> anyhow::Result<usize> {
-            if !batch.is_empty() {
-                let mut sequential_data = conn.0.sequential_checkpoint_data.lock().unwrap();
-                sequential_data.extend(batch.iter().cloned());
-            }
-            Ok(batch.len())
-        }
-    }
-
-    struct TestSetup {
-        store: MockStore,
-        checkpoint_tx: mpsc::Sender<IndexedCheckpoint<TestHandler>>,
-        #[allow(unused)]
-        committer: Service,
-    }
-
-    /// Emulates adding a sequential pipeline to the indexer. The next_checkpoint is the checkpoint
-    /// for the indexer to ingest from.
-    fn setup_test(next_checkpoint: u64, config: SequentialConfig, store: MockStore) -> TestSetup {
-        let metrics = IndexerMetrics::new(None, &Registry::default());
-
-        let min_eager_rows = config
-            .min_eager_rows
-            .unwrap_or(<TestHandler as super::Handler>::MIN_EAGER_ROWS);
-        let max_batch_checkpoints = config
-            .max_batch_checkpoints
-            .unwrap_or(<TestHandler as super::Handler>::MAX_BATCH_CHECKPOINTS);
-
-        let (checkpoint_tx, checkpoint_rx) = mpsc::channel(10);
-
-        let store_clone = store.clone();
-        let handler = Arc::new(TestHandler);
-        let committer = committer(
-            handler,
-            config,
-            next_checkpoint,
-            checkpoint_rx,
-            store_clone,
-            metrics,
-            min_eager_rows,
-            max_batch_checkpoints,
-        );
-
-        TestSetup {
-            store,
-            checkpoint_tx,
-            committer,
-        }
-    }
-
-    async fn send_checkpoint(setup: &mut TestSetup, checkpoint: u64) {
-        setup
-            .checkpoint_tx
-            .send(create_checkpoint(checkpoint))
-            .await
-            .unwrap();
-    }
-
-    fn create_checkpoint(checkpoint: u64) -> IndexedCheckpoint<TestHandler> {
-        IndexedCheckpoint::new(
-            checkpoint,        // epoch
-            checkpoint,        // checkpoint number
-            checkpoint,        // tx_hi
-            checkpoint * 1000, // timestamp
-            vec![checkpoint],  // values
-        )
-    }
-
-    #[tokio::test]
-    async fn test_committer_processes_sequential_checkpoints() {
-        let config = SequentialConfig::default();
-        let mut setup = setup_test(0, config, MockStore::default());
-
-        // Send checkpoints in order
-        for i in 0..3 {
-            send_checkpoint(&mut setup, i).await;
-        }
-
-        // Wait for processing
-        tokio::time::sleep(Duration::from_millis(200)).await;
-
-        // Verify data was written in order
-        assert_eq!(setup.store.get_sequential_data(), vec![0, 1, 2]);
-
-        // Verify watermark was updated
-        {
-            let watermark = setup.store.watermark(TestHandler::NAME).unwrap();
-            assert_eq!(watermark.checkpoint_hi_inclusive, Some(2));
-            assert_eq!(watermark.tx_hi, 2);
-        }
-
-        // Verify commit_hi was sent to ingestion
-    }
-
-    /// Configure the MockStore with no watermark, and emulate `first_checkpoint` by passing the
-    /// `initial_watermark` into the setup.
-    #[tokio::test]
-    async fn test_committer_processes_sequential_checkpoints_with_initial_watermark() {
-        let config = SequentialConfig::default();
-        let mut setup = setup_test(5, config, MockStore::default());
-
-        // Verify watermark hasn't progressed
-        let watermark = setup.store.watermark(TestHandler::NAME);
-        assert!(watermark.is_none());
-
-        // Send checkpoints in order
-        for i in 0..5 {
-            send_checkpoint(&mut setup, i).await;
-        }
-
-        // Wait for processing
-        tokio::time::sleep(Duration::from_millis(1000)).await;
-
-        // Verify watermark hasn't progressed
-        let watermark = setup.store.watermark(TestHandler::NAME);
-        assert!(watermark.is_none());
-
-        for i in 5..8 {
-            send_checkpoint(&mut setup, i).await;
-        }
-
-        // Wait for processing
-        tokio::time::sleep(Duration::from_millis(1000)).await;
-
-        // Verify data was written in order
-        assert_eq!(setup.store.get_sequential_data(), vec![5, 6, 7]);
-
-        // Verify watermark was updated
-        {
-            let watermark = setup.store.watermark(TestHandler::NAME).unwrap();
-            assert_eq!(watermark.checkpoint_hi_inclusive, Some(7));
-            assert_eq!(watermark.tx_hi, 7);
-        }
-    }
-
-    #[tokio::test]
-    async fn test_committer_processes_out_of_order_checkpoints() {
-        let config = SequentialConfig::default();
-        let mut setup = setup_test(0, config, MockStore::default());
-
-        // Send checkpoints out of order
-        for i in [1, 0, 2] {
-            send_checkpoint(&mut setup, i).await;
-        }
-
-        // Wait for processing
-        tokio::time::sleep(Duration::from_millis(200)).await;
-
-        // Verify data was written in order despite receiving out of order
-        assert_eq!(setup.store.get_sequential_data(), vec![0, 1, 2]);
-
-        // Verify watermark was updated
-        {
-            let watermark = setup.store.watermark(TestHandler::NAME).unwrap();
-            assert_eq!(watermark.checkpoint_hi_inclusive, Some(2));
-            assert_eq!(watermark.tx_hi, 2);
-        }
-
-        // Verify commit_hi was sent to ingestion
-    }
-
-    #[tokio::test]
-    async fn test_committer_commit_up_to_max_batch_checkpoints() {
-        let config = SequentialConfig::default();
-        let mut setup = setup_test(0, config, MockStore::default());
-
-        // Send checkpoints up to MAX_BATCH_CHECKPOINTS
-        for i in 0..4 {
-            send_checkpoint(&mut setup, i).await;
-        }
-
-        // Wait for processing
-        tokio::time::sleep(Duration::from_millis(200)).await;
-
-        // Verify data is written in order across batches
-        assert_eq!(setup.store.get_sequential_data(), vec![0, 1, 2, 3]);
-    }
-
-    #[tokio::test]
-    async fn test_committer_commits_eagerly() {
-        let config = SequentialConfig {
-            committer: CommitterConfig {
-                collect_interval_ms: 4_000, // Long polling to test eager commit
-                ..Default::default()
-            },
-            ..Default::default()
-        };
-        let mut setup = setup_test(0, config, MockStore::default());
-
-        // Wait for initial poll to be over
-        tokio::time::sleep(Duration::from_millis(200)).await;
-
-        // Send checkpoints 0-2
-        for i in 0..3 {
-            send_checkpoint(&mut setup, i).await;
-        }
-
-        // Verify no checkpoints are written yet (not enough rows for eager commit)
-        assert_eq!(setup.store.get_sequential_data(), Vec::<u64>::new());
-
-        // Send checkpoint 3 to trigger the eager commit (3 + 1 >= MIN_EAGER_ROWS)
-        send_checkpoint(&mut setup, 3).await;
-
-        // Wait for processing
-        tokio::time::sleep(Duration::from_millis(200)).await;
-
-        // Verify all checkpoints are written
-        assert_eq!(setup.store.get_sequential_data(), vec![0, 1, 2, 3]);
-    }
-
-    #[tokio::test]
-    async fn test_committer_retries_on_transaction_failure() {
-        let config = SequentialConfig {
-            committer: CommitterConfig {
-                collect_interval_ms: 1_000, // Long polling to test retry logic
-                ..Default::default()
-            },
-            ..Default::default()
-        };
-
-        // Create store with transaction failure configuration
-        let store = MockStore::default().with_transaction_failures(1); // Will fail once before succeeding
-
-        let mut setup = setup_test(10, config, store);
-
-        // Send a checkpoint
-        send_checkpoint(&mut setup, 10).await;
-
-        // Wait for initial poll to be over
-        tokio::time::sleep(Duration::from_millis(200)).await;
-
-        // Verify no data is written before retries complete
-        assert_eq!(setup.store.get_sequential_data(), Vec::<u64>::new());
-
-        // Wait for retries to complete
-        tokio::time::sleep(Duration::from_millis(1_200)).await;
-
-        // Verify data is written after retries complete on next polling
-        assert_eq!(setup.store.get_sequential_data(), vec![10]);
-    }
 }

--- a/crates/sui-indexer-alt-framework/src/pipeline/sequential/committer.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/sequential/committer.rs
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::sync::Arc;
-use std::sync::atomic::AtomicUsize;
-use std::sync::atomic::Ordering as AtomicOrdering;
 use std::time::Duration;
 
 use backoff::ExponentialBackoff;
@@ -34,7 +32,6 @@ pub(super) fn committer<H: Handler>(
     store: H::Store,
     metrics: Arc<IndexerMetrics>,
     mut rx: mpsc::Receiver<BatchedRows<H>>,
-    pending_rows: Arc<AtomicUsize>,
 ) -> Service {
     Service::new().spawn_aborting(async move {
         info!(pipeline = H::NAME, "Starting committer");
@@ -91,7 +88,6 @@ pub(super) fn committer<H: Handler>(
                             pipeline = H::NAME,
                             elapsed_ms = elapsed * 1000.0,
                             committed = batch_rows,
-                            pending = pending_rows.load(AtomicOrdering::Relaxed),
                             "Error writing batch: {e}",
                         );
                         metrics
@@ -109,7 +105,6 @@ pub(super) fn committer<H: Handler>(
                 pipeline = H::NAME,
                 affected,
                 committed = batch_rows,
-                pending = pending_rows.load(AtomicOrdering::Relaxed),
                 "Wrote batch",
             );
             logger.log::<H>(&watermark, elapsed);

--- a/crates/sui-indexer-alt-framework/src/pipeline/sequential/mod.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/sequential/mod.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::sync::Arc;
-use std::sync::atomic::AtomicUsize;
 
 use async_trait::async_trait;
 use serde::Deserialize;
@@ -157,10 +156,6 @@ pub(crate) fn pipeline<H: Handler>(
         .unwrap_or_else(|| (num_cpus::get() / 2).max(4));
     let (collector_tx, committer_rx) = mpsc::channel::<BatchedRows<H>>(pipeline_depth);
 
-    // Shared counter for rows in the reorder buffer (including the batch being assembled).
-    // Owned by the collector; the committer only reads it for its `pending = ...` log field.
-    let pending_rows = Arc::new(AtomicUsize::new(0));
-
     let handler = Arc::new(handler);
 
     let s_processor = processor(
@@ -181,10 +176,9 @@ pub(crate) fn pipeline<H: Handler>(
         min_eager_rows,
         max_batch_checkpoints,
         collector_tx,
-        pending_rows.clone(),
     );
 
-    let s_committer = committer::<H>(handler, store, metrics.clone(), committer_rx, pending_rows);
+    let s_committer = committer::<H>(handler, store, metrics.clone(), committer_rx);
 
     s_processor.merge(s_collector).merge(s_committer)
 }
@@ -264,7 +258,6 @@ mod tests {
         let (checkpoint_tx, checkpoint_rx) = mpsc::channel(10);
         let (collector_tx, committer_rx) =
             mpsc::channel::<BatchedRows<TestHandler>>(pipeline_depth);
-        let pending_rows = Arc::new(AtomicUsize::new(0));
 
         let store_clone = store.clone();
         let handler = Arc::new(TestHandler);
@@ -278,9 +271,8 @@ mod tests {
             min_eager_rows,
             max_batch_checkpoints,
             collector_tx,
-            pending_rows.clone(),
         );
-        let s_committer = committer(handler, store_clone, metrics, committer_rx, pending_rows);
+        let s_committer = committer(handler, store_clone, metrics, committer_rx);
 
         TestSetup {
             store,

--- a/crates/sui-indexer-alt-framework/src/pipeline/sequential/mod.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/sequential/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::sync::Arc;
+use std::sync::atomic::AtomicUsize;
 
 use async_trait::async_trait;
 use serde::Deserialize;
@@ -17,10 +18,13 @@ use crate::pipeline::CommitterConfig;
 use crate::pipeline::IngestionConfig;
 use crate::pipeline::Processor;
 use crate::pipeline::processor::processor;
+use crate::pipeline::sequential::collector::BatchedRows;
+use crate::pipeline::sequential::collector::collector;
 use crate::pipeline::sequential::committer::committer;
 use crate::store::SequentialStore;
 use crate::store::Store;
 
+mod collector;
 mod committer;
 
 /// Handlers implement the logic for a given indexing pipeline: How to process checkpoint data (by
@@ -95,6 +99,10 @@ pub struct SequentialConfig {
 
     /// Size of the channel between the processor and committer.
     pub processor_channel_size: Option<usize>,
+
+    /// Depth of the channel between the collector and committer tasks. Allows the collector
+    /// to build the next batch while the previous batch is being flushed to the DB.
+    pub pipeline_depth: Option<usize>,
 }
 
 /// Start a new sequential (in-order) indexing pipeline, served by the handler, `H`. Starting
@@ -142,7 +150,16 @@ pub(crate) fn pipeline<H: Handler>(
         .unwrap_or(H::MAX_BATCH_CHECKPOINTS);
 
     let processor_channel_size = config.processor_channel_size.unwrap_or(num_cpus::get() / 2);
-    let (processor_tx, committer_rx) = mpsc::channel(processor_channel_size);
+    let (processor_tx, collector_rx) = mpsc::channel(processor_channel_size);
+
+    let pipeline_depth = config
+        .pipeline_depth
+        .unwrap_or_else(|| (num_cpus::get() / 2).max(4));
+    let (collector_tx, committer_rx) = mpsc::channel::<BatchedRows<H>>(pipeline_depth);
+
+    // Shared counter for rows in the reorder buffer (including the batch being assembled).
+    // Owned by the collector; the committer only reads it for its `pending = ...` log field.
+    let pending_rows = Arc::new(AtomicUsize::new(0));
 
     let handler = Arc::new(handler);
 
@@ -155,16 +172,350 @@ pub(crate) fn pipeline<H: Handler>(
         store.clone(),
     );
 
-    let s_committer = committer::<H>(
-        handler,
+    let s_collector = collector::<H>(
+        handler.clone(),
         config,
         next_checkpoint,
-        committer_rx,
-        store,
+        collector_rx,
         metrics.clone(),
         min_eager_rows,
         max_batch_checkpoints,
+        collector_tx,
+        pending_rows.clone(),
     );
 
-    s_processor.merge(s_committer)
+    let s_committer = committer::<H>(handler, store, metrics.clone(), committer_rx, pending_rows);
+
+    s_processor.merge(s_collector).merge(s_committer)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use prometheus::Registry;
+    use sui_types::full_checkpoint_content::Checkpoint;
+
+    use crate::mocks::store::MockConnection;
+    use crate::mocks::store::MockStore;
+    use crate::pipeline::IndexedCheckpoint;
+
+    use super::*;
+
+    // Test implementation of Handler
+    #[derive(Default)]
+    struct TestHandler;
+
+    #[async_trait]
+    impl Processor for TestHandler {
+        const NAME: &'static str = "test";
+        type Value = u64;
+
+        async fn process(&self, _checkpoint: &Arc<Checkpoint>) -> anyhow::Result<Vec<Self::Value>> {
+            Ok(vec![])
+        }
+    }
+
+    #[async_trait]
+    impl Handler for TestHandler {
+        type Store = MockStore;
+        type Batch = Vec<u64>;
+        const MAX_BATCH_CHECKPOINTS: usize = 3; // Using small max value for testing.
+        const MIN_EAGER_ROWS: usize = 4; // Using small eager value for testing.
+
+        fn batch(&self, batch: &mut Self::Batch, values: std::vec::IntoIter<Self::Value>) {
+            batch.extend(values);
+        }
+
+        async fn commit<'a>(
+            &self,
+            batch: &Self::Batch,
+            conn: &mut MockConnection<'a>,
+        ) -> anyhow::Result<usize> {
+            if !batch.is_empty() {
+                let mut sequential_data = conn.0.sequential_checkpoint_data.lock().unwrap();
+                sequential_data.extend(batch.iter().cloned());
+            }
+            Ok(batch.len())
+        }
+    }
+
+    struct TestSetup {
+        store: MockStore,
+        checkpoint_tx: mpsc::Sender<IndexedCheckpoint<TestHandler>>,
+        #[allow(unused)]
+        service: Service,
+    }
+
+    /// Emulates adding a sequential pipeline to the indexer. Bypasses the processor stage and
+    /// feeds [IndexedCheckpoint]s directly to the collector. `next_checkpoint` is the starting
+    /// checkpoint for the indexer.
+    fn setup_test(next_checkpoint: u64, config: SequentialConfig, store: MockStore) -> TestSetup {
+        let metrics = IndexerMetrics::new(None, &Registry::default());
+
+        let min_eager_rows = config.min_eager_rows.unwrap_or(TestHandler::MIN_EAGER_ROWS);
+        let max_batch_checkpoints = config
+            .max_batch_checkpoints
+            .unwrap_or(TestHandler::MAX_BATCH_CHECKPOINTS);
+        let pipeline_depth = config
+            .pipeline_depth
+            .unwrap_or_else(|| (num_cpus::get() / 2).max(4));
+
+        let (checkpoint_tx, checkpoint_rx) = mpsc::channel(10);
+        let (collector_tx, committer_rx) =
+            mpsc::channel::<BatchedRows<TestHandler>>(pipeline_depth);
+        let pending_rows = Arc::new(AtomicUsize::new(0));
+
+        let store_clone = store.clone();
+        let handler = Arc::new(TestHandler);
+
+        let s_collector = collector(
+            handler.clone(),
+            config,
+            next_checkpoint,
+            checkpoint_rx,
+            metrics.clone(),
+            min_eager_rows,
+            max_batch_checkpoints,
+            collector_tx,
+            pending_rows.clone(),
+        );
+        let s_committer = committer(handler, store_clone, metrics, committer_rx, pending_rows);
+
+        TestSetup {
+            store,
+            checkpoint_tx,
+            service: s_collector.merge(s_committer),
+        }
+    }
+
+    async fn send_checkpoint(setup: &mut TestSetup, checkpoint: u64) {
+        setup
+            .checkpoint_tx
+            .send(create_checkpoint(checkpoint))
+            .await
+            .unwrap();
+    }
+
+    fn create_checkpoint(checkpoint: u64) -> IndexedCheckpoint<TestHandler> {
+        IndexedCheckpoint::new(
+            checkpoint,        // epoch
+            checkpoint,        // checkpoint number
+            checkpoint,        // tx_hi
+            checkpoint * 1000, // timestamp
+            vec![checkpoint],  // values
+        )
+    }
+
+    #[tokio::test]
+    async fn test_committer_processes_sequential_checkpoints() {
+        let config = SequentialConfig::default();
+        let mut setup = setup_test(0, config, MockStore::default());
+
+        // Send checkpoints in order
+        for i in 0..3 {
+            send_checkpoint(&mut setup, i).await;
+        }
+
+        // Wait for processing
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        // Verify data was written in order
+        assert_eq!(setup.store.get_sequential_data(), vec![0, 1, 2]);
+
+        // Verify watermark was updated
+        let watermark = setup.store.watermark(TestHandler::NAME).unwrap();
+        assert_eq!(watermark.checkpoint_hi_inclusive, Some(2));
+        assert_eq!(watermark.tx_hi, 2);
+    }
+
+    /// Configure the MockStore with no watermark, and emulate `first_checkpoint` by passing the
+    /// `initial_watermark` into the setup.
+    #[tokio::test]
+    async fn test_committer_processes_sequential_checkpoints_with_initial_watermark() {
+        let config = SequentialConfig::default();
+        let mut setup = setup_test(5, config, MockStore::default());
+
+        // Verify watermark hasn't progressed
+        let watermark = setup.store.watermark(TestHandler::NAME);
+        assert!(watermark.is_none());
+
+        // Send checkpoints in order
+        for i in 0..5 {
+            send_checkpoint(&mut setup, i).await;
+        }
+
+        // Wait for processing
+        tokio::time::sleep(Duration::from_millis(1000)).await;
+
+        // Verify watermark hasn't progressed
+        let watermark = setup.store.watermark(TestHandler::NAME);
+        assert!(watermark.is_none());
+
+        for i in 5..8 {
+            send_checkpoint(&mut setup, i).await;
+        }
+
+        // Wait for processing
+        tokio::time::sleep(Duration::from_millis(1000)).await;
+
+        // Verify data was written in order
+        assert_eq!(setup.store.get_sequential_data(), vec![5, 6, 7]);
+
+        // Verify watermark was updated
+        let watermark = setup.store.watermark(TestHandler::NAME).unwrap();
+        assert_eq!(watermark.checkpoint_hi_inclusive, Some(7));
+        assert_eq!(watermark.tx_hi, 7);
+    }
+
+    #[tokio::test]
+    async fn test_committer_processes_out_of_order_checkpoints() {
+        let config = SequentialConfig::default();
+        let mut setup = setup_test(0, config, MockStore::default());
+
+        // Send checkpoints out of order
+        for i in [1, 0, 2] {
+            send_checkpoint(&mut setup, i).await;
+        }
+
+        // Wait for processing
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        // Verify data was written in order despite receiving out of order
+        assert_eq!(setup.store.get_sequential_data(), vec![0, 1, 2]);
+
+        // Verify watermark was updated
+        let watermark = setup.store.watermark(TestHandler::NAME).unwrap();
+        assert_eq!(watermark.checkpoint_hi_inclusive, Some(2));
+        assert_eq!(watermark.tx_hi, 2);
+    }
+
+    #[tokio::test]
+    async fn test_committer_commit_up_to_max_batch_checkpoints() {
+        let config = SequentialConfig::default();
+        let mut setup = setup_test(0, config, MockStore::default());
+
+        // Send checkpoints up to MAX_BATCH_CHECKPOINTS
+        for i in 0..4 {
+            send_checkpoint(&mut setup, i).await;
+        }
+
+        // Wait for processing
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        // Verify data is written in order across batches
+        assert_eq!(setup.store.get_sequential_data(), vec![0, 1, 2, 3]);
+    }
+
+    #[tokio::test]
+    async fn test_committer_commits_eagerly() {
+        let config = SequentialConfig {
+            committer: CommitterConfig {
+                collect_interval_ms: 4_000, // Long polling to test eager commit
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let mut setup = setup_test(0, config, MockStore::default());
+
+        // Wait for initial poll to be over
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        // Send checkpoints 0-2
+        for i in 0..3 {
+            send_checkpoint(&mut setup, i).await;
+        }
+
+        // Verify no checkpoints are written yet (not enough rows for eager commit)
+        assert_eq!(setup.store.get_sequential_data(), Vec::<u64>::new());
+
+        // Send checkpoint 3 to trigger the eager commit (3 + 1 >= MIN_EAGER_ROWS)
+        send_checkpoint(&mut setup, 3).await;
+
+        // Wait for processing
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        // Verify all checkpoints are written
+        assert_eq!(setup.store.get_sequential_data(), vec![0, 1, 2, 3]);
+    }
+
+    #[tokio::test]
+    async fn test_committer_retries_on_transaction_failure() {
+        let config = SequentialConfig {
+            committer: CommitterConfig {
+                collect_interval_ms: 1_000, // Long polling to test retry logic
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        // Create store with transaction failure configuration
+        let store = MockStore::default().with_transaction_failures(1); // Will fail once before succeeding
+
+        let mut setup = setup_test(10, config, store);
+
+        // Send a checkpoint
+        send_checkpoint(&mut setup, 10).await;
+
+        // Wait long enough for the collector to poll-tick (collect_interval = 1s),
+        // hand the batch to the committer, and for the committer to complete one failed
+        // attempt + one successful retry under exponential backoff (100ms initial).
+        tokio::time::sleep(Duration::from_millis(1_500)).await;
+
+        assert_eq!(setup.store.get_sequential_data(), vec![10]);
+    }
+
+    /// Smoke test for pipelined operation under a slow-commit store: with
+    /// `pipeline_depth = 1` and two full batches to process, both batches must land and
+    /// the watermark must reach the last checkpoint.
+    #[tokio::test]
+    async fn pipelined_commit_runs_under_slow_commit() {
+        let config = SequentialConfig {
+            committer: CommitterConfig::default(),
+            max_batch_checkpoints: Some(3),
+            min_eager_rows: Some(1),
+            pipeline_depth: Some(1),
+            ..Default::default()
+        };
+
+        let store = MockStore::default().with_commit_delay(700);
+        let mut setup = setup_test(0, config, store);
+
+        for i in 0..6 {
+            send_checkpoint(&mut setup, i).await;
+        }
+
+        // Two batches × 700ms commit each + slack.
+        tokio::time::sleep(Duration::from_millis(2_000)).await;
+
+        assert_eq!(setup.store.get_sequential_data(), vec![0, 1, 2, 3, 4, 5]);
+        let watermark = setup.store.watermark(TestHandler::NAME).unwrap();
+        assert_eq!(watermark.checkpoint_hi_inclusive, Some(5));
+    }
+
+    /// Watermarks must advance strictly in batch order, even under pipelining.
+    #[tokio::test]
+    async fn pipelined_commit_preserves_watermark_ordering() {
+        let config = SequentialConfig {
+            committer: CommitterConfig::default(),
+            max_batch_checkpoints: Some(2),
+            min_eager_rows: Some(1),
+            pipeline_depth: Some(2),
+            ..Default::default()
+        };
+
+        let store = MockStore::default().with_commit_delay(100);
+        let mut setup = setup_test(0, config, store);
+
+        for i in 0..6 {
+            send_checkpoint(&mut setup, i).await;
+        }
+
+        tokio::time::sleep(Duration::from_millis(1_500)).await;
+
+        assert_eq!(setup.store.get_sequential_data(), vec![0, 1, 2, 3, 4, 5]);
+        let watermark = setup.store.watermark(TestHandler::NAME).unwrap();
+        assert_eq!(watermark.checkpoint_hi_inclusive, Some(5));
+        assert_eq!(watermark.tx_hi, 5);
+    }
 }

--- a/crates/sui-indexer-alt/src/config.rs
+++ b/crates/sui-indexer-alt/src/config.rs
@@ -72,6 +72,7 @@ pub struct SequentialLayer {
     pub min_eager_rows: Option<usize>,
     pub max_batch_checkpoints: Option<usize>,
     pub processor_channel_size: Option<usize>,
+    pub pipeline_depth: Option<usize>,
 }
 
 #[DefaultConfig]
@@ -234,6 +235,7 @@ impl SequentialLayer {
             min_eager_rows: self.min_eager_rows.or(base.min_eager_rows),
             max_batch_checkpoints: self.max_batch_checkpoints.or(base.max_batch_checkpoints),
             processor_channel_size: self.processor_channel_size.or(base.processor_channel_size),
+            pipeline_depth: self.pipeline_depth.or(base.pipeline_depth),
         })
     }
 }
@@ -375,6 +377,7 @@ impl Merge for SequentialLayer {
             min_eager_rows: other.min_eager_rows.or(self.min_eager_rows),
             max_batch_checkpoints: other.max_batch_checkpoints.or(self.max_batch_checkpoints),
             processor_channel_size: other.processor_channel_size.or(self.processor_channel_size),
+            pipeline_depth: other.pipeline_depth.or(self.pipeline_depth),
         })
     }
 }
@@ -497,6 +500,7 @@ impl From<SequentialConfig> for SequentialLayer {
             min_eager_rows: config.min_eager_rows,
             max_batch_checkpoints: config.max_batch_checkpoints,
             processor_channel_size: config.processor_channel_size,
+            pipeline_depth: config.pipeline_depth,
         }
     }
 }

--- a/docs/content/develop/accessing-data/custom-indexer/build.mdx
+++ b/docs/content/develop/accessing-data/custom-indexer/build.mdx
@@ -302,7 +302,7 @@ How sequential batching works:
 1. `batch()` accumulates values from multiple checkpoints.
 1. `commit()` writes the batch when framework reaches limits (`H::MAX_BATCH_CHECKPOINTS`).
 
-<ImportContent source="crates/sui-indexer-alt-framework/src/pipeline/sequential/committer.rs" mode="code" tag="batch" />
+<ImportContent source="crates/sui-indexer-alt-framework/src/pipeline/sequential/collector.rs" mode="code" tag="batch" />
 
 :::tip
 

--- a/docs/content/develop/accessing-data/custom-indexer/pipeline-architecture.mdx
+++ b/docs/content/develop/accessing-data/custom-indexer/pipeline-architecture.mdx
@@ -214,32 +214,29 @@ Sequential pipelines provide a more straightforward yet powerful architecture fo
 
 ### Architecture overview
 
-The sequential pipeline consists of only two main components, making it significantly less complex than the concurrent pipeline's six-component architecture.
+The sequential pipeline is significantly simpler than the concurrent pipeline's six-component architecture: it has a `Processor`, a `Collector`, and a `Committer`.
 
 ![Sequential pipeline diagram](../images/sequential.png)
 
 The `Broadcaster` and `Processor` components use identical backpressure mechanisms, adaptive parallel processing, and `processor()` implementations to the concurrent pipeline. The `Processor` component is described in detail in the [Common pipeline components](#processor) section.
 
-The key difference is the dramatically simplified pipeline core with just a single `Committer` component that handles ordering, batching, and database commits. Concurrent pipelines, in contrast, have five separate components in addition to the `Processor`: `Collector`, `Committer`, `CommitterWatermark`, `ReaderWatermark`, and `Pruner`.
+The `Collector` orders out-of-order checkpoints, assembles them into batches via your `batch()` logic, and hands those batches to the `Committer`, which writes them to the database in strict checkpoint order via your `commit()` logic. The two stages run as independent tasks connected by a bounded channel (`pipeline_depth`), so the `Collector` can prepare the next batch while the `Committer` flushes the current one. Concurrent pipelines share the same `Collector` + `Committer` split but additionally have `CommitterWatermark`, `ReaderWatermark`, and `Pruner` components — none of which are required in the sequential pipeline because commits and watermark updates happen in a single transaction and there is no pruning.
 
 ### Sequential pipeline components {#sequential-components}
 
-Sequential pipelines have one pipeline-specific component in addition to the shared [Processor](#processor), the [`Committer`](#seq-committer).
+Sequential pipelines have two pipeline-specific components in addition to the shared [Processor](#processor): the [`Collector`](#seq-collector) and the [`Committer`](#seq-committer).
 
-#### `Committer` {#seq-committer}
+#### `Collector` {#seq-collector}
 
-The sequential `Committer` is the main component of the pipeline and your main customization point. At a high level, the `Committer` performs the following actions:
-
-1. **Receives** out-of-order processed data from the processor.
-1. **Orders** the data by checkpoint sequence.
-1. **Batches** multiple checkpoints together using your logic.
-1. **Commits** the batch to the database atomically.
-
-To customize, your code uses two key functions that the committer calls:
+The sequential `Collector` receives out-of-order processed data from the `Processor`, orders it by checkpoint sequence, and assembles batches using your `batch()` logic. A batch is dispatched when either `collect_interval_ms` elapses or `MIN_EAGER_ROWS` have accumulated and the next expected checkpoint has arrived. The `Collector` is also responsible for bounding how many checkpoints contribute to a single batch (`MAX_BATCH_CHECKPOINTS`).
 
 `batch()`: Data merging logic.
 
 <ImportContent source="crates/sui-indexer-alt-framework/src/pipeline/sequential/mod.rs" mode="code" fun="batch" noComments />
+
+#### `Committer` {#seq-committer}
+
+The sequential `Committer` receives fully-assembled batches from the `Collector` and writes them to the database one at a time (strict ordering is required so that watermarks advance monotonically). Each commit runs inside a single transaction that includes both the row updates and the watermark update, so commits and watermark advances are atomic. On commit failure, the `Committer` retries the same batch under exponential backoff.
 
 `commit()`: Database write logic.
 
@@ -256,9 +253,10 @@ Sequential pipelines use two layers of backpressure to prevent memory overflow a
 Sequential pipelines use the same bounded-channel backpressure model as concurrent pipelines:
 
 - **Broadcaster → Processor:** bounded channel with `subscriber_channel_size` slots. Send blocks when full, and the broadcaster's adaptive controller reads the channel's `len / capacity` and cuts ingest concurrency as the subscriber falls behind.
-- **Processor → Committer:** `processor_channel_size` slots (defaults to `num_cpus / 2`). Drives the processor's adaptive `fanout` controller.
+- **Processor → Collector:** `processor_channel_size` slots (defaults to `num_cpus / 2`). Drives the processor's adaptive `fanout` controller.
+- **Collector → Committer:** `pipeline_depth` slots (defaults to `max(num_cpus / 2, 4)`). Lets the collector stage the next batch while the committer flushes the current one. When full, the collector blocks on send.
 
-Downstream pressure propagates backward: the committer slows, the processor-to-committer channel fills and collapses `fanout` to the minimum, the broadcaster-to-processor channel then fills and the broadcaster cuts `ingest_concurrency`. The committer itself holds an unbounded in-memory buffer of pending checkpoints so that out-of-order arrivals can still form a contiguous prefix to commit.
+Downstream pressure propagates backward: the committer slows, the collector-to-committer channel fills, the collector stops draining its reorder buffer, the processor-to-collector channel fills and collapses `fanout` to the minimum, and finally the broadcaster-to-processor channel fills and the broadcaster cuts `ingest_concurrency`. The collector itself holds an unbounded in-memory buffer of pending checkpoints so that out-of-order arrivals can still form a contiguous prefix to commit.
 
 ### Performance tuning
 
@@ -290,6 +288,7 @@ let config = SequentialConfig {
     min_eager_rows: None,
     max_batch_checkpoints: None,
     processor_channel_size: None, // defaults to num_cpus / 2
+    pipeline_depth: None,         // defaults to max(num_cpus / 2, 4)
 
     // Per-pipeline overrides for the ingestion layer's defaults.
     ingestion: pipeline::IngestionConfig {
@@ -301,9 +300,10 @@ let config = SequentialConfig {
 
 - `collect_interval_ms`: Higher values allow more checkpoints per batch, improving efficiency.
 - `write_concurrency`: Not applicable to sequential pipelines (always single-threaded writes).
-- `fanout`: By default, processor concurrency is adaptive: it starts at 1 and scales up to the number of CPUs based on downstream channel pressure. The controller monitors the fill fraction of the processor-to-committer channel and adjusts concurrency using a dead band between 60% and 85% fill. You can override this with fixed concurrency (`ConcurrencyConfig::Fixed`) or customize the adaptive bounds (`ConcurrencyConfig::Adaptive`). The default max of `num_cpus` assumes your processor is CPU-bound. If your processor performs IO (for example, fetching data from an external service), you might want a higher max. The adaptive controller also exposes a `dead_band` parameter to override the fill-fraction thresholds, but the defaults should work well for most workloads.
+- `fanout`: By default, processor concurrency is adaptive: it starts at 1 and scales up to the number of CPUs based on downstream channel pressure. The controller monitors the fill fraction of the processor-to-collector channel and adjusts concurrency using a dead band between 60% and 85% fill. You can override this with fixed concurrency (`ConcurrencyConfig::Fixed`) or customize the adaptive bounds (`ConcurrencyConfig::Adaptive`). The default max of `num_cpus` assumes your processor is CPU-bound. If your processor performs IO (for example, fetching data from an external service), you might want a higher max. The adaptive controller also exposes a `dead_band` parameter to override the fill-fraction thresholds, but the defaults should work well for most workloads.
 - `ingestion.subscriber_channel_size`: Capacity of the bounded broadcaster-to-processor channel. Defaults to `max(num_cpus / 2, 4)` when `None`. A pipeline that occasionally sees bursts can raise its own capacity, but note that a larger value makes this pipeline appear "less full" to the shared controller, so it triggers throttling later than its peers.
-- `processor_channel_size`: Controls the size of the channel between the processor and the committer. Defaults to `num_cpus / 2`. This channel is also the signal that drives the adaptive concurrency controller.
+- `processor_channel_size`: Controls the size of the channel between the processor and the collector. Defaults to `num_cpus / 2`. This channel is also the signal that drives the adaptive concurrency controller.
+- `pipeline_depth`: Controls the size of the channel between the collector and the committer. Defaults to `max(num_cpus / 2, 4)`. Larger values let the collector stay further ahead of a slow committer (absorbing bursts); `1` means one batch can be staged while another is committing.
 
 ## Concurrent pipeline architecture {#concurrent-pipeline-architecture}
 

--- a/docs/content/develop/accessing-data/custom-indexer/pipeline-architecture.mdx
+++ b/docs/content/develop/accessing-data/custom-indexer/pipeline-architecture.mdx
@@ -4,7 +4,7 @@ description: The `sui-indexer-alt-framework` provides two distinct pipeline arch
 keywords: [ indexer, index data, sui-indexer, custom indexer, sequential pipeline, concurrent pipeline ]
 ---
 
-The `sui-indexer-alt-framework` provides two distinct pipeline architectures. Understanding their differences is crucial for choosing the right approach.
+The `sui-indexer-alt-framework` provides two distinct pipeline architectures. Understand their differences to choose the right approach.
 
 ## Sequential versus concurrent pipelines
 
@@ -14,7 +14,7 @@ The `sui-indexer-alt-framework` provides two distinct pipeline architectures. Un
 
 ## When to use each pipeline
 
-Both pipeline types can handle updates in place, aggregations, and complex business logic. While sequential pipelines have throughput limitations compared to concurrent, the decision to use one over the other is primarily about engineering complexity rather than performance needs.
+Both pipeline types can handle updates in place, aggregations, and complex business logic. While sequential pipelines have throughput limitations compared to concurrent, base your decision primarily on engineering complexity rather than performance needs.
 
 ### Recommended: Sequential pipeline
 
@@ -37,19 +37,19 @@ Consider implementing a concurrent pipeline when:
 <li><span className="text-sui-success-dark">✓</span> Your team is willing to handle the additional implementation complexity for the performance benefits.</li>
 </ul>
 
-Supporting out-of-order commits introduces a few additional complexities to your pipeline:
+Out-of-order commits introduce a few additional complexities to your pipeline:
 
-- Watermark-aware queries: All reads must check which data the pipeline fully committed. See [the watermark system](#watermark-system) section for details.
-- Complex application logic: You must commit data in pieces rather than handle complete checkpoints.
+- Watermark-aware queries: Check which data the pipeline fully committed in all reads. See [the watermark system](#watermark-system) section for details.
+- Complex application logic: Commit data in pieces rather than handle complete checkpoints.
 
 ## Decision framework
 
-If you are unsure of which pipeline to choose for your project, start with a sequential pipeline as it is easier to implement and debug. Then, measure performance under a realistic load. If the sequential pipeline cannot meet your project's requirements, then switch to a concurrent pipeline.
+If you are unsure of which pipeline to choose for your project, start with a sequential pipeline as it is easier to implement and debug. Then, measure performance under a realistic load. If the sequential pipeline cannot meet your project's requirements, switch to a concurrent pipeline.
 
 While not an exhaustive list, some specific scenarios where a sequential pipeline might not meet requirements include:
 
-- Your pipeline produces data in each checkpoint that benefits from chunking and out-of-order commits. Individual checkpoints can produce lots of data or individual writes that might add latency.
-- You are producing a lot of data that needs pruning. In this case, you must use a concurrent pipeline.
+- Your pipeline benefits from chunking and out-of-order commits for data produced in each checkpoint. Individual checkpoints can produce lots of data or individual writes that might add latency.
+- You produce a lot of data that needs pruning. In this case, you must use a concurrent pipeline.
 
 Beyond the decision of which pipeline to use, you also need to consider scaling. If you are indexing multiple kinds of data, then consider using multiple pipelines and watermarks.
 
@@ -97,7 +97,7 @@ This watermark system is what makes concurrent pipelines both high-performance a
 
 ### Scenario 1: Basic watermark (no pruning)
 
-With pruning disabled, the indexer reports each pipeline committer `checkpoint_hi_inclusive` only. Consider the following timeline, where a number of checkpoints are being processed and some are committed out of order.
+With pruning disabled, the indexer reports only each pipeline committer `checkpoint_hi_inclusive`. Consider the following timeline, where a number of checkpoints are being processed and some are committed out of order.
 
 ```sh
 Checkpoint Processing Timeline:
@@ -111,7 +111,7 @@ Checkpoint Processing Timeline:
 ✗ = Not Committed (processing or failed)
 ```
 
-In this scenario, the `checkpoint_hi_inclusive` is at 1001, even though checkpoint 1003 is committed, because there is still a gap at 1002. The indexer must report the high watermark at 1001 to satisfy the guarantee that all data from start to `checkpoint_hi_inclusive` is available.
+In this scenario, the `checkpoint_hi_inclusive` is at 1001, even though checkpoint 1003 is committed, because there is still a gap at 1002. The indexer reports the high watermark at 1001 to satisfy the guarantee that all data from start to `checkpoint_hi_inclusive` is available.
 
 After you commit checkpoint 1002, you can safely read data up to 1003.
 
@@ -124,7 +124,7 @@ After you commit checkpoint 1002, you can safely read data up to 1003.
 
 ### Scenario 2: Pruning enabled
 
-You enable pruning for pipelines configured with a retention policy. For example, if your table is growing too large and you want to keep only the last 4 checkpoints, then `retention = 4`. This means that the indexer periodically updates `reader_lo` as the difference between `checkpoint_hi_inclusive` and the configured retention. A separate pruning task is responsible for pruning data between `[pruner_hi, reader_lo]`.
+You enable pruning for pipelines configured with a retention policy. For example, if your table is growing too large and you want to keep only the last 4 checkpoints, then `retention = 4`. This means that the indexer periodically updates `reader_lo` as the difference between `checkpoint_hi_inclusive` and the configured retention. A separate pruning task prunes data between `[pruner_hi, reader_lo]`.
 
 ```sh
 [998] [999] [1000] [1001] [1002] [1003] [1004] [1005] [1006]
@@ -199,11 +199,11 @@ A separate reader watermark update task (running periodically, configurable) adv
         pruner_hi = 1001
 ```
 
-Because `pruner_hi` (1000) < `reader_lo` (1001), the pruner detects checkpoints outside the retention window. It cleans up all elements up to `reader_lo` (deleting checkpoint 1000) and updates `pruner_hi` to `reader_lo` (1001).
+When `pruner_hi` (1000) < `reader_lo` (1001), the pruner detects checkpoints outside the retention window, cleans up all elements up to `reader_lo` (deleting checkpoint 1000), and updates `pruner_hi` to `reader_lo` (1001).
 
 
 :::info
-Checkpoints older than `reader_lo` might still temporarily exist because of:
+Checkpoints older than `reader_lo` might still temporarily exist because:
 - Intentional delay protecting in-flight queries
 - Pruner not completing cleanup yet
 :::
@@ -220,7 +220,7 @@ The sequential pipeline is significantly simpler than the concurrent pipeline's 
 
 The `Broadcaster` and `Processor` components use identical backpressure mechanisms, adaptive parallel processing, and `processor()` implementations to the concurrent pipeline. The `Processor` component is described in detail in the [Common pipeline components](#processor) section.
 
-The `Collector` orders out-of-order checkpoints, assembles them into batches via your `batch()` logic, and hands those batches to the `Committer`, which writes them to the database in strict checkpoint order via your `commit()` logic. The two stages run as independent tasks connected by a bounded channel (`pipeline_depth`), so the `Collector` can prepare the next batch while the `Committer` flushes the current one. Concurrent pipelines share the same `Collector` + `Committer` split but additionally have `CommitterWatermark`, `ReaderWatermark`, and `Pruner` components — none of which are required in the sequential pipeline because commits and watermark updates happen in a single transaction and there is no pruning.
+The `Collector` orders out-of-order checkpoints, assembles them into batches through your `batch()` logic, and hands those batches to the `Committer`, which writes them to the database in strict checkpoint order through your `commit()` logic. The two stages run as independent tasks connected by a bounded channel (`pipeline_depth`), so the `Collector` can prepare the next batch while the `Committer` flushes the current one. Concurrent pipelines share the same `Collector` + `Committer` split but additionally have `CommitterWatermark`, `ReaderWatermark`, and `Pruner` components. None of those extra components are required in the sequential pipeline because commits and watermark updates happen in a single transaction and there is no pruning.
 
 ### Sequential pipeline components {#sequential-components}
 
@@ -228,7 +228,7 @@ Sequential pipelines have two pipeline-specific components in addition to the sh
 
 #### `Collector` {#seq-collector}
 
-The sequential `Collector` receives out-of-order processed data from the `Processor`, orders it by checkpoint sequence, and assembles batches using your `batch()` logic. A batch is dispatched when either `collect_interval_ms` elapses or `MIN_EAGER_ROWS` have accumulated and the next expected checkpoint has arrived. The `Collector` is also responsible for bounding how many checkpoints contribute to a single batch (`MAX_BATCH_CHECKPOINTS`).
+The sequential `Collector` receives out-of-order processed data from the `Processor`, orders it by checkpoint sequence, and assembles batches using your `batch()` logic. The `Collector` dispatches a batch when either `collect_interval_ms` elapses or `MIN_EAGER_ROWS` have accumulated and the next expected checkpoint has arrived. The `Collector` also bounds how many checkpoints contribute to a single batch (`MAX_BATCH_CHECKPOINTS`).
 
 `batch()`: Data merging logic.
 
@@ -300,7 +300,7 @@ let config = SequentialConfig {
 
 - `collect_interval_ms`: Higher values allow more checkpoints per batch, improving efficiency.
 - `write_concurrency`: Not applicable to sequential pipelines (always single-threaded writes).
-- `fanout`: By default, processor concurrency is adaptive: it starts at 1 and scales up to the number of CPUs based on downstream channel pressure. The controller monitors the fill fraction of the processor-to-collector channel and adjusts concurrency using a dead band between 60% and 85% fill. You can override this with fixed concurrency (`ConcurrencyConfig::Fixed`) or customize the adaptive bounds (`ConcurrencyConfig::Adaptive`). The default max of `num_cpus` assumes your processor is CPU-bound. If your processor performs IO (for example, fetching data from an external service), you might want a higher max. The adaptive controller also exposes a `dead_band` parameter to override the fill-fraction thresholds, but the defaults should work well for most workloads.
+- `fanout`: By default, processor concurrency is adaptive: it starts at 1 and scales up to the number of CPUs based on downstream channel pressure. The controller monitors the fill fraction of the processor-to-collector channel and adjusts concurrency using a dead band between 60% and 85% fill. You can override this with fixed concurrency (`ConcurrencyConfig::Fixed`) or customize the adaptive bounds (`ConcurrencyConfig::Adaptive`). The default max of `num_cpus` is for CPU-bound processors. If your processor performs IO (for example, fetching data from an external service), you might want a higher max. The adaptive controller also exposes a `dead_band` parameter to override the fill-fraction thresholds, but the defaults should work well for most workloads.
 - `ingestion.subscriber_channel_size`: Capacity of the bounded broadcaster-to-processor channel. Defaults to `max(num_cpus / 2, 4)` when `None`. A pipeline that occasionally sees bursts can raise its own capacity, but note that a larger value makes this pipeline appear "less full" to the shared controller, so it triggers throttling later than its peers.
 - `processor_channel_size`: Controls the size of the channel between the processor and the collector. Defaults to `num_cpus / 2`. This channel is also the signal that drives the adaptive concurrency controller.
 - `pipeline_depth`: Controls the size of the channel between the collector and the committer. Defaults to `max(num_cpus / 2, 4)`. Larger values let the collector stay further ahead of a slow committer (absorbing bursts); `1` means one batch can be staged while another is committing.


### PR DESCRIPTION
## Description

Improve throughput potential by allowing a sequential pipeline to keep building batches while a batch is being flushed to the DB.

I tried to mimic the names/structure from the concurrent pipeline for familiarity (at the cost of a bigger review diff).

I also added backoff to retries, similar to how it works for concurrent pipelines. Previously we would have retried every tick.

## Test plan

I have been backfilling bitmaps in bigtable with this code.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [x] Indexing Framework: A new `pipeline-depth` config knob is added to sequential pipelines which allows the pipeline to continue to build batches while a batch is being flushed to the database. No need to set this config explicitly, the default value should suffice.
