### PR TITLE
Fix race condition in admission queue simtest

### DIFF
--- a/crates/sui-e2e-tests/tests/admission_queue_tests.rs
+++ b/crates/sui-e2e-tests/tests/admission_queue_tests.rs
@@ -153,6 +153,12 @@ async fn test_admission_queue_eviction_and_rejection() {
         }
     });
 
+    // Wait for the high-gas tx to reach the queue and evict a fill
+    // before re-enabling drain. Without this, the scheduler may drain
+    // both fills (now that drain_disabled is false) before the high-gas
+    // InsertCommand arrives, so no eviction occurs.
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
     // Re-enable draining so all accepted transactions complete.
     drain_disabled.store(false, Ordering::SeqCst);
 


### PR DESCRIPTION
## Description 

Before re-enabling the drain, give some time to ensure that the high gas tx has made it to the (full) queue. This will prevent the premature draining of the queue and correctly perform the eviction.

## Test plan 

```
MSIM_TEST_NUM=50 cargo simtest -p sui-e2e-tests -- test_admission_queue_eviction_and_rejection
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
