### PR TITLE
sui-indexer-alt-framework: unify MockIngestionClient code

### DIFF
--- a/crates/sui-indexer-alt-framework/src/ingestion/broadcaster.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/broadcaster.rs
@@ -373,46 +373,28 @@ async fn send_checkpoint(
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeSet;
+    use std::ops::Range;
     use std::sync::Arc;
     use std::time::Duration;
 
-    use async_trait::async_trait;
-    use sui_types::digests::ChainIdentifier;
-    use sui_types::messages_checkpoint::CheckpointDigest;
     use tokio::time::timeout;
 
     use crate::ingestion::IngestionConfig;
-    use crate::ingestion::decode;
-    use crate::ingestion::ingestion_client::CheckpointResult;
-    use crate::ingestion::ingestion_client::IngestionClientTrait;
+    use crate::ingestion::ingestion_client::tests::MockIngestionClient;
     use crate::ingestion::streaming_client::test_utils::MockStreamingClient;
-    use crate::ingestion::test_utils::test_checkpoint_data;
     use crate::metrics::tests::test_ingestion_metrics;
 
     use super::*;
 
-    /// Create a mock IngestionClient for tests
-    fn mock_client(metrics: Arc<IngestionMetrics>) -> IngestionClient {
-        struct MockClient;
-
-        #[async_trait]
-        impl IngestionClientTrait for MockClient {
-            async fn chain_id(&self) -> anyhow::Result<ChainIdentifier> {
-                Ok(CheckpointDigest::new([1; 32]).into())
-            }
-
-            async fn checkpoint(&self, checkpoint: u64) -> CheckpointResult {
-                // Return mock checkpoint data for any checkpoint number
-                let bytes = test_checkpoint_data(checkpoint);
-                Ok(decode::checkpoint(&bytes).unwrap())
-            }
-
-            async fn latest_checkpoint_number(&self) -> anyhow::Result<u64> {
-                Ok(0)
-            }
-        }
-
-        IngestionClient::new_impl(Arc::new(MockClient), metrics)
+    /// Create a mock `IngestionClient` that serves synthetic checkpoints for the given
+    /// sequence-number range.
+    fn mock_client_with_range(
+        checkpoints: Range<u64>,
+        metrics: Arc<IngestionMetrics>,
+    ) -> IngestionClient {
+        let mock = MockIngestionClient::default();
+        mock.insert_checkpoints(checkpoints);
+        IngestionClient::new_impl(Arc::new(mock), metrics)
     }
 
     /// Create a test config
@@ -500,7 +482,7 @@ mod tests {
             cps,
             None,
             test_config(),
-            mock_client(metrics.clone()),
+            mock_client_with_range(0..5, metrics.clone()),
             subscriber_dest,
             metrics,
         );
@@ -522,7 +504,7 @@ mod tests {
             0..,
             None,
             test_config(),
-            mock_client(metrics.clone()),
+            mock_client_with_range(0..20, metrics.clone()),
             subscriber_dest,
             metrics,
         );
@@ -545,7 +527,7 @@ mod tests {
             0..,
             None,
             test_config(),
-            mock_client(metrics.clone()),
+            mock_client_with_range(0..20, metrics.clone()),
             subscriber_dest,
             metrics,
         );
@@ -571,7 +553,7 @@ mod tests {
             0..,
             None,
             test_config(),
-            mock_client(metrics.clone()),
+            mock_client_with_range(0..20, metrics.clone()),
             subscribers,
             metrics,
         );
@@ -609,7 +591,7 @@ mod tests {
             0..5, // Bounded range
             Some(streaming_client),
             test_config(),
-            mock_client(metrics.clone()),
+            mock_client_with_range(0..5, metrics.clone()),
             subscriber_dest,
             metrics.clone(),
         );
@@ -638,7 +620,7 @@ mod tests {
             0..60,
             Some(streaming_client),
             test_config(),
-            mock_client(metrics.clone()),
+            mock_client_with_range(0..60, metrics.clone()),
             subscriber_dest,
             metrics.clone(),
         );
@@ -673,7 +655,7 @@ mod tests {
             0..30,
             Some(streaming_client),
             test_config(),
-            mock_client(metrics.clone()),
+            mock_client_with_range(0..30, metrics.clone()),
             subscriber_dest,
             metrics.clone(),
         );
@@ -704,7 +686,7 @@ mod tests {
             30..100,
             Some(streaming_client),
             test_config(),
-            mock_client(metrics.clone()),
+            mock_client_with_range(30..100, metrics.clone()),
             subscriber_dest,
             metrics.clone(),
         );
@@ -742,7 +724,7 @@ mod tests {
             0..20,
             Some(streaming_client),
             test_config(),
-            mock_client(metrics.clone()),
+            mock_client_with_range(0..20, metrics.clone()),
             subscriber_dest,
             metrics.clone(),
         );
@@ -777,7 +759,7 @@ mod tests {
             0..10,
             Some(streaming_client),
             test_config(),
-            mock_client(metrics.clone()),
+            mock_client_with_range(0..10, metrics.clone()),
             subscriber_dest,
             metrics.clone(),
         );
@@ -816,7 +798,7 @@ mod tests {
             0..15,
             Some(streaming_client),
             test_config(),
-            mock_client(metrics.clone()),
+            mock_client_with_range(0..15, metrics.clone()),
             subscriber_dest,
             metrics.clone(),
         );
@@ -856,7 +838,7 @@ mod tests {
             0..20,
             Some(streaming_client),
             test_config(),
-            mock_client(metrics.clone()),
+            mock_client_with_range(0..20, metrics.clone()),
             subscriber_dest,
             metrics.clone(),
         );
@@ -890,7 +872,7 @@ mod tests {
                 streaming_backoff_initial_batch_size: 5,
                 ..test_config()
             },
-            mock_client(metrics.clone()),
+            mock_client_with_range(0..20, metrics.clone()),
             subscriber_dest,
             metrics.clone(),
         );
@@ -930,7 +912,7 @@ mod tests {
                 streaming_backoff_initial_batch_size: 5,
                 ..test_config()
             },
-            mock_client(metrics.clone()),
+            mock_client_with_range(0..20, metrics.clone()),
             subscriber_dest,
             metrics.clone(),
         );
@@ -967,7 +949,7 @@ mod tests {
             0..50,
             Some(streaming_client),
             test_config(),
-            mock_client(metrics.clone()),
+            mock_client_with_range(0..50, metrics.clone()),
             subscriber_dest,
             metrics.clone(),
         );
@@ -1003,7 +985,7 @@ mod tests {
             0..50,
             Some(streaming_client),
             test_config(),
-            mock_client(metrics.clone()),
+            mock_client_with_range(0..50, metrics.clone()),
             subscriber_dest,
             metrics.clone(),
         );
@@ -1061,7 +1043,7 @@ mod tests {
             0..20,
             Some(streaming_service),
             config,
-            mock_client(metrics.clone()),
+            mock_client_with_range(0..20, metrics.clone()),
             subscriber_dest,
             metrics.clone(),
         );
@@ -1104,7 +1086,7 @@ mod tests {
             0..20,
             Some(streaming_client),
             config,
-            mock_client(metrics.clone()),
+            mock_client_with_range(0..20, metrics.clone()),
             subscriber_dest,
             metrics.clone(),
         );
@@ -1142,7 +1124,7 @@ mod tests {
             0..15,
             Some(streaming_client),
             test_config(),
-            mock_client(metrics.clone()),
+            mock_client_with_range(0..15, metrics.clone()),
             subscriber_dest,
             metrics.clone(),
         );

--- a/crates/sui-indexer-alt-framework/src/ingestion/ingestion_client.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/ingestion_client.rs
@@ -449,7 +449,7 @@ where
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use std::sync::Arc;
     use std::time::Duration;
 
@@ -487,18 +487,33 @@ mod tests {
         ingestion: IngestionClientArgs,
     }
 
-    /// Mock implementation of IngestionClientTrait for testing
+    /// Mock implementation of IngestionClientTrait for testing.
+    ///
+    /// - `checkpoints`: pre-inserted checkpoints returned by `checkpoint()`. Sequences not
+    ///   in the map return `CheckpointError::NotFound`.
+    /// - `not_found_failures` / `fetch_failures` / `decode_failures`: number of times to
+    ///   return the corresponding error for a given sequence number before succeeding.
+    /// - `latest_checkpoint`: value returned by `latest_checkpoint_number()`.
     #[derive(Default)]
-    struct MockIngestionClient {
-        checkpoints: DashMap<u64, Checkpoint>,
-        not_found_failures: DashMap<u64, usize>,
-        fetch_failures: DashMap<u64, usize>,
-        decode_failures: DashMap<u64, usize>,
+    pub(crate) struct MockIngestionClient {
+        pub checkpoints: DashMap<u64, Checkpoint>,
+        pub not_found_failures: DashMap<u64, usize>,
+        pub fetch_failures: DashMap<u64, usize>,
+        pub decode_failures: DashMap<u64, usize>,
+        pub latest_checkpoint: u64,
     }
 
     impl MockIngestionClient {
-        fn mock_chain_id() -> ChainIdentifier {
+        pub(crate) fn mock_chain_id() -> ChainIdentifier {
             CheckpointDigest::new([1; 32]).into()
+        }
+
+        /// Populate `checkpoints` with synthetic test checkpoints for the given sequence
+        /// numbers.
+        pub(crate) fn insert_checkpoints(&self, range: impl IntoIterator<Item = u64>) {
+            for seq in range {
+                self.checkpoints.insert(seq, test_checkpoint(seq));
+            }
         }
     }
 
@@ -509,7 +524,6 @@ mod tests {
         }
 
         async fn checkpoint(&self, checkpoint: u64) -> CheckpointResult {
-            // Check for not found failures
             if let Some(mut remaining) = self.not_found_failures.get_mut(&checkpoint)
                 && *remaining > 0
             {
@@ -517,7 +531,6 @@ mod tests {
                 return Err(CheckpointError::NotFound);
             }
 
-            // Check for fetch errors
             if let Some(mut remaining) = self.fetch_failures.get_mut(&checkpoint)
                 && *remaining > 0
             {
@@ -525,7 +538,6 @@ mod tests {
                 return Err(CheckpointError::Fetch(anyhow::anyhow!("Mock fetch error")));
             }
 
-            // Check for decode errors
             if let Some(mut remaining) = self.decode_failures.get_mut(&checkpoint)
                 && *remaining > 0
             {
@@ -535,7 +547,6 @@ mod tests {
                 )));
             }
 
-            // Return the checkpoint data if it exists
             self.checkpoints
                 .get(&checkpoint)
                 .as_deref()
@@ -544,7 +555,7 @@ mod tests {
         }
 
         async fn latest_checkpoint_number(&self) -> anyhow::Result<u64> {
-            Ok(0)
+            Ok(self.latest_checkpoint)
         }
     }
 

--- a/crates/sui-indexer-alt-framework/src/ingestion/mod.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/mod.rs
@@ -265,38 +265,25 @@ mod tests {
     use wiremock::MockServer;
     use wiremock::Request;
 
-    use crate::ingestion::ingestion_client::CheckpointResult;
-    use crate::ingestion::ingestion_client::IngestionClientTrait;
+    use crate::ingestion::ingestion_client::tests::MockIngestionClient;
     use crate::ingestion::store_client::tests::respond_with;
     use crate::ingestion::store_client::tests::respond_with_chain_id;
     use crate::ingestion::store_client::tests::status;
     use crate::ingestion::streaming_client::test_utils::MockStreamingClient;
     use crate::ingestion::test_utils::test_checkpoint_data;
     use crate::metrics::IngestionMetrics;
-    use crate::types::digests::ChainIdentifier;
 
     use super::*;
 
     const FALLBACK: u64 = 99;
 
-    struct MockLatestCheckpoint(u64);
-
-    #[async_trait::async_trait]
-    impl IngestionClientTrait for MockLatestCheckpoint {
-        async fn chain_id(&self) -> anyhow::Result<ChainIdentifier> {
-            unimplemented!()
-        }
-        async fn checkpoint(&self, _: u64) -> CheckpointResult {
-            unimplemented!()
-        }
-        async fn latest_checkpoint_number(&self) -> anyhow::Result<u64> {
-            Ok(self.0)
-        }
-    }
-
     fn mock_ingestion_client(latest_checkpoint: u64) -> IngestionClient {
         let metrics = IngestionMetrics::new(None, &Registry::new());
-        IngestionClient::new_impl(Arc::new(MockLatestCheckpoint(latest_checkpoint)), metrics)
+        let mock = MockIngestionClient {
+            latest_checkpoint,
+            ..Default::default()
+        };
+        IngestionClient::new_impl(Arc::new(mock), metrics)
     }
 
     async fn test_ingestion(uri: String, ingest_concurrency: usize) -> IngestionService {


### PR DESCRIPTION
## Description 

Changes all `sui-indexer-alt-framework` ingestion client tests to use the same `MockIngestionClient`. This prevents another copy being needed for `BackfillService` that will be added later.

## Test plan 

Only test setup, not functionality, was affected.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
