### PR TITLE
[move-compiler] Fix for hexstring newline parsing

### DIFF
--- a/external-crates/move/crates/move-compiler/src/parser/syntax.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/syntax.rs
@@ -1839,8 +1839,10 @@ fn parse_term(context: &mut Context) -> Result<Exp, Box<Diagnostic>> {
         }
 
         Tok::NumValue => {
-            // Check if this is a ModuleIdent (in a ModuleAccess).
-            if context.tokens.lookahead()? == Tok::ColonColon {
+            // Check if this is a ModuleIdent (in a ModuleAccess). If lookahead encounters a
+            // lexing error further ahead, fall back to parsing the current number literal so that
+            // we still make progress and surface the lexer diagnostic during `parse_value`.
+            if let Ok(Tok::ColonColon) = context.tokens.lookahead() {
                 parse_name_exp(context)?
             } else {
                 Exp_::Value(parse_value(context)?)

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/hexstring_newline.move
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/hexstring_newline.move
@@ -1,0 +1,7 @@
+module 0x42::M {
+  public fun f(): vector<u8> {
+    let sig = x"0
+0";
+    sig
+  }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/hexstring_newline.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/hexstring_newline.snap
@@ -1,0 +1,26 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: legacy
+  lint: false
+---
+error[E01008]: invalid hex string
+  ┌─ tests/move_check/parser/hexstring_newline.move:3:15
+  │
+3 │     let sig = x"0
+  │               ^^^ Missing closing quote (") after hex string
+
+error[E13001]: feature is not supported in specified edition
+  ┌─ tests/move_check/parser/hexstring_newline.move:4:2
+  │
+4 │ 0";
+  │  ^ string literals (without a leading 'b' or 'x') are not supported by current edition 'legacy'; the '2024' edition supports this feature
+  │
+  = You can update the edition in the 'Move.toml', or via command line flag if invoking the compiler directly.
+
+error[E03009]: unbound variable
+  ┌─ tests/move_check/parser/hexstring_newline.move:5:5
+  │
+5 │     sig
+  │     ^^^ Unbound variable 'sig'


### PR DESCRIPTION
## Description 

Fix issue where we could loop when parsing hex strings with newlines in them. 

## Test plan 

Repro: looped before, fails now.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
