### PR TITLE
[consensus] increase mainnet FIFO compaction coverage to 50%

### DIFF
--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -270,7 +270,7 @@ where
         let store_path = context.parameters.db_path.as_path().to_str().unwrap();
         let use_fifo_compaction = context.parameters.use_fifo_compaction
             && (context.protocol_config.chain() != ChainType::Mainnet
-                || context.own_index.value().is_multiple_of(10));
+                || context.own_index.value().is_multiple_of(2));
         let store = Arc::new(RocksDBStore::new(store_path, use_fifo_compaction));
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
 


### PR DESCRIPTION
## Description

Bump the fraction of mainnet consensus `RocksDBStore` instances that use FIFO compaction from ~10% to 50%.

`use_fifo_compaction` in [consensus/core/src/authority_node.rs](consensus/core/src/authority_node.rs) gates FIFO on `own_index.value().is_multiple_of(N)` for mainnet. Changing `N` from `10` to `2` lets every other validator (by index) run FIFO instead of roughly one in ten, while leaving non-mainnet chains and the underlying `parameters.use_fifo_compaction` toggle unchanged.

## Test plan

- `cargo check -p consensus-core`
- Existing FIFO-mode coverage at lower percentage has been running on mainnet; this is a staged rollout step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)