### PR TITLE
Update CLAUDE.md linting instructions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,12 +51,16 @@ SUI_SKIP_SIMTESTS=1 cargo nextest run
 # Formats & lints all Rust & Move, run before commit:
 ./scripts/lint.sh
 
-# Alternatively, run individual lints:
-cargo fmt --all -- --check
+# Alternatively, run individual lints on specific crates (much faster than linting the whole repo):
+# For crates in `crates/`: cd into the crate directory and run:
 cargo xclippy
+# For crates in `external-crates/`: cd into the crate directory and run:
+cargo move-clippy
+# For formatting:
+cargo fmt --all -- --check
 ```
 
-`cargo xclippy does not recognize -p option` - This is a known issue with some clippy command variations
+`cargo xclippy` does not recognize the `-p` option - cd into the crate directory instead.
 
 ## High-Level Architecture
 


### PR DESCRIPTION
## Summary
- Clarify that `cargo xclippy` is for crates in `crates/` and `cargo move-clippy` is for crates in `external-crates/`
- Note to cd into the crate directory for faster per-crate linting
- Fix `-p` option note

🤖 Generated with [Claude Code](https://claude.com/claude-code)