### PR TITLE
[graphql] Add scanTransactions and scanEvents skeleton behind staging

### DIFF
--- a/crates/sui-indexer-alt-graphql/src/api/query.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/query.rs
@@ -37,6 +37,8 @@ use crate::api::types::dynamic_field::DynamicField;
 use crate::api::types::epoch::CEpoch;
 use crate::api::types::epoch::Epoch;
 use crate::api::types::event::CEvent;
+#[cfg(feature = "staging")]
+use crate::api::types::event::CScanEvent;
 use crate::api::types::event::Event;
 use crate::api::types::event::filter::EventFilter;
 use crate::api::types::move_object::MoveObject;
@@ -60,6 +62,8 @@ use crate::api::types::signature_verify;
 use crate::api::types::signature_verify::IntentScope;
 use crate::api::types::signature_verify::SignatureVerifyResult;
 use crate::api::types::simulation_result::SimulationResult;
+#[cfg(feature = "staging")]
+use crate::api::types::transaction::CScanTransaction;
 use crate::api::types::transaction::CTransaction;
 use crate::api::types::transaction::Transaction;
 use crate::api::types::transaction::filter::TransactionFilter;
@@ -722,6 +726,54 @@ impl Query {
             }
             .await,
         )
+    }
+
+    /// The transactions that exist in the network, optionally filtered by multiple transaction filters.
+    ///
+    /// Supports combining filters (e.g. `affectedAddress` AND `function`). The checkpoint range being
+    /// scanned cannot exceed `ServiceConfig.maxScanLimit` — use `checkpointBound` to narrow it.
+    /// Supports a longer retention than `Query.transactions`.
+    ///
+    /// Note that this differs from `Query.transactions`, which supports a single filter with an
+    /// optional sender filter, with no checkpoint range restriction and generally a shorter retention.
+    #[cfg(feature = "staging")]
+    async fn scan_transactions(
+        &self,
+        _ctx: &Context<'_>,
+        _first: Option<u64>,
+        _after: Option<CScanTransaction>,
+        _last: Option<u64>,
+        _before: Option<CScanTransaction>,
+        _filter: TransactionFilter,
+    ) -> Result<Connection<String, Transaction>, RpcError> {
+        // TODO(phase-2): Skeleton to unblock subscription backfill integration.
+        // Real implementation pending the team's decision on bloom filter vs
+        // roaring bitmap indexing strategy.
+        Err(feature_unavailable("scanTransactions"))
+    }
+
+    /// The events that exist in the network, optionally filtered by multiple event filters.
+    ///
+    /// Supports combining filters (e.g. `sender` AND `module` AND `type`). The checkpoint range being
+    /// scanned cannot exceed `ServiceConfig.maxScanLimit` — use `afterCheckpoint`, `beforeCheckpoint`,
+    /// or `atCheckpoint` to narrow it. Supports a longer retention than `Query.events`.
+    ///
+    /// Note that this differs from `Query.events`, which supports a single filter with an optional
+    /// sender filter, with no checkpoint range restriction and generally a shorter retention.
+    #[cfg(feature = "staging")]
+    async fn scan_events(
+        &self,
+        _ctx: &Context<'_>,
+        _first: Option<u64>,
+        _after: Option<CScanEvent>,
+        _last: Option<u64>,
+        _before: Option<CScanEvent>,
+        _filter: EventFilter,
+    ) -> Result<Connection<String, Event>, RpcError> {
+        // TODO(phase-2): Skeleton to unblock subscription backfill integration.
+        // Real implementation pending the team's decision on bloom filter vs
+        // roaring bitmap indexing strategy.
+        Err(feature_unavailable("scanEvents"))
     }
 
     /// Fetch a structured representation of a concrete type, including its layout information.

--- a/crates/sui-indexer-alt-graphql/src/api/types/event/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/event/mod.rs
@@ -51,6 +51,20 @@ pub(crate) struct EventCursor {
 
 pub(crate) type CEvent = JsonCursor<EventCursor>;
 
+#[cfg(feature = "staging")]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Clone, Debug, PartialOrd, Ord, Copy)]
+pub(crate) struct ScanEventCursor {
+    #[serde(rename = "c")]
+    pub cp_sequence_number: u64,
+    #[serde(rename = "t")]
+    pub tx_sequence_number: u64,
+    #[serde(rename = "e")]
+    pub ev_sequence_number: u64,
+}
+
+#[cfg(feature = "staging")]
+pub(crate) type CScanEvent = JsonCursor<ScanEventCursor>;
+
 #[derive(Clone)]
 pub(crate) struct Event {
     pub(crate) scope: Scope,

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
@@ -67,6 +67,20 @@ pub(crate) struct TransactionContents {
 
 pub(crate) type CTransaction = JsonCursor<u64>;
 
+#[cfg(feature = "staging")]
+#[derive(
+    serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Copy, Debug, PartialOrd, Ord,
+)]
+pub(crate) struct ScanTransactionCursor {
+    #[serde(rename = "c")]
+    pub(crate) cp_sequence_number: u64,
+    #[serde(rename = "t")]
+    pub(crate) tx_sequence_number: u64,
+}
+
+#[cfg(feature = "staging")]
+pub(crate) type CScanTransaction = JsonCursor<ScanTransactionCursor>;
+
 /// Description of a transaction, the unit of activity on Sui.
 #[Object]
 impl Transaction {


### PR DESCRIPTION
## Summary

* Add skeleton `Query.scanTransactions` and `Query.scanEvents` fields, gated behind the `staging` feature, returning `feature_unavailable`.
* Introduce `CScanTransaction` and `CScanEvent` cursor types matching the signatures in #25717.
* Unblocks Phase 2 subscription backfill integration work while the team decides between bloom filter and roaring bitmap indexing strategies.

The real implementation is intentionally deferred — the skeletons exist so downstream work (subscription backfill via iterative scan extension) can target the final method signatures now.

## Test plan

- [x] `cargo check -p sui-indexer-alt-graphql --features staging` passes
- [x] `cargo check -p sui-indexer-alt-graphql` (default, no staging) passes with no new warnings
- [ ] Confirm schema SDL snapshot is unaffected in the default build (staging fields hidden)

🤖 Generated with [Claude Code](https://claude.com/claude-code)