### PR TITLE
fix: sui client send-funds always reported zero balance

### DIFF
--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -1391,12 +1391,8 @@ impl SuiClientCommands {
                     TypeTag::from_str(SUI_COIN_TYPE).expect("SUI_COIN_TYPE should be valid");
                 let coin_type_tag = coin_type.unwrap_or_else(|| sui_type_tag.clone());
 
-                // Compare TypeTags directly — `to_canonical_string(true)` expands the
-                // address, which never equals the short-form `SUI_COIN_TYPE` literal.
                 let is_sui = coin_type_tag == sui_type_tag;
 
-                // `get_balance` keys on the inner coin type T (e.g. `0x2::sui::SUI`),
-                // not the `Coin<T>` wrapper — that's how the rpc index stores balances.
                 let TypeTag::Struct(coin_struct_tag) = &coin_type_tag else {
                     bail!("coin type must be a struct type, got {coin_type_tag}");
                 };

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -1387,19 +1387,20 @@ impl SuiClientCommands {
                 let _ = context.cache_chain_id().await?;
                 let client = context.grpc_client()?;
 
-                let coin_type_tag = coin_type.unwrap_or_else(|| {
-                    TypeTag::from_str(SUI_COIN_TYPE).expect("SUI_COIN_TYPE should be valid")
-                });
+                let sui_type_tag =
+                    TypeTag::from_str(SUI_COIN_TYPE).expect("SUI_COIN_TYPE should be valid");
+                let coin_type_tag = coin_type.unwrap_or_else(|| sui_type_tag.clone());
 
-                let is_sui = coin_type_tag.to_canonical_string(true) == SUI_COIN_TYPE;
+                // Compare TypeTags directly — `to_canonical_string(true)` expands the
+                // address, which never equals the short-form `SUI_COIN_TYPE` literal.
+                let is_sui = coin_type_tag == sui_type_tag;
 
-                let coin_struct_tag: StructTag = format!(
-                    "0x2::coin::Coin<{}>",
-                    coin_type_tag.to_canonical_string(true)
-                )
-                .parse()
-                .expect("valid struct tag");
-                let balance_info = client.get_balance(signer, &coin_struct_tag).await?;
+                // `get_balance` keys on the inner coin type T (e.g. `0x2::sui::SUI`),
+                // not the `Coin<T>` wrapper — that's how the rpc index stores balances.
+                let TypeTag::Struct(coin_struct_tag) = &coin_type_tag else {
+                    bail!("coin type must be a struct type, got {coin_type_tag}");
+                };
+                let balance_info = client.get_balance(signer, coin_struct_tag).await?;
                 let coin_balance = balance_info.coin_balance();
                 let address_balance = balance_info.address_balance();
 

--- a/crates/sui/tests/cli_tests.rs
+++ b/crates/sui/tests/cli_tests.rs
@@ -3493,6 +3493,43 @@ async fn test_pay_all_sui() -> Result<(), anyhow::Error> {
 }
 
 #[sim_test]
+async fn test_send_funds_sui() -> Result<(), anyhow::Error> {
+    let (mut test_cluster, client, rgp, _objects, recipients, addresses) =
+        test_cluster_helper().await;
+    let recipient1 = &recipients[0];
+    let address2 = addresses[0];
+    let context = &mut test_cluster.wallet;
+    let amount = 1_000_000_000u64;
+
+    let send_funds = SuiClientCommands::SendFunds {
+        to: recipient1.clone(),
+        amount: Some(amount),
+        all_coins: false,
+        coin_type: None,
+        stateless: false,
+        gas_data: GasDataArgs {
+            gas_budget: Some(rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER),
+            ..Default::default()
+        },
+        processing: TxProcessingArgs::default(),
+    }
+    .execute(context)
+    .await?;
+
+    let SuiClientCommandResult::TransactionBlock(response) = send_funds else {
+        panic!("SendFunds test failed");
+    };
+    assert!(response.effects.status().is_ok());
+
+    // `send-funds` deposits into the recipient's address balance, not a Coin<T>.
+    let balance = client.get_balance(address2, &GAS::type_()).await?;
+    assert_eq!(balance.address_balance(), amount);
+    assert_eq!(balance.coin_balance(), 0);
+
+    Ok(())
+}
+
+#[sim_test]
 async fn test_transfer() -> Result<(), anyhow::Error> {
     let (mut test_cluster, client, rgp, objects, recipients, addresses) =
         test_cluster_helper().await;

--- a/crates/sui/tests/cli_tests.rs
+++ b/crates/sui/tests/cli_tests.rs
@@ -21,7 +21,7 @@ use sui::client_commands::{
 use sui::client_ptb::ptb::PTB;
 use sui::sui_commands::RpcArgs;
 use sui_keys::key_identity::KeyIdentity;
-use sui_protocol_config::ProtocolConfig;
+use sui_protocol_config::{ProtocolConfig, ProtocolVersion};
 use sui_rpc_api::Client;
 use sui_test_transaction_builder::batch_make_transfer_transactions;
 use sui_types::effects::TransactionEffectsAPI;
@@ -3496,6 +3496,13 @@ async fn test_pay_all_sui() -> Result<(), anyhow::Error> {
 async fn test_send_funds_sui() -> Result<(), anyhow::Error> {
     let (mut test_cluster, client, rgp, _objects, recipients, addresses) =
         test_cluster_helper().await;
+    let protocol_config = ProtocolConfig::get_for_version(
+        ProtocolVersion::max(),
+        test_cluster.get_chain_identifier().chain(),
+    );
+    if !protocol_config.enable_address_balance_gas_payments() {
+        return Ok(());
+    }
     let recipient1 = &recipients[0];
     let address2 = addresses[0];
     let context = &mut test_cluster.wallet;


### PR DESCRIPTION
## Description

`sui client send-funds` has been broken for coin-funded transfers. Two bugs in `client_commands.rs::SendFunds`:

1. `get_balance` was called with `Coin<T>` but the endpoint keys on the inner coin type `T` (like every other in-tree caller). Lookup always missed → `Coin balance: 0` → every `send-funds` failed with "Insufficient balance".
2. `is_sui` compared `coin_type_tag.to_canonical_string(true)` (full-length address) to `SUI_COIN_TYPE = "0x2::sui::SUI"` (short form). Always false, so once bug 1 was fixed the default SUI case bailed out with "Non-SUI coin transfers using coins require explicit coin selection".

Fix: destructure the `TypeTag` and pass the inner `StructTag` to `get_balance`; compare `TypeTag`s directly.

## Test plan

Tested against a local `sui genesis && sui start --with-faucet --force-regenesis` network with faucet funds:

- [x] `send-funds --to <addr> --amount 1000000000` succeeds; recipient sees 1 SUI in their address balance (verified via `suix_getBalance`).
- [x] `send-funds --amount 50000000000` succeeds.
- [x] `--dry-run` reports `Status: Success`.
- [ ] CI green.

---

## Release notes

- [x] CLI: Fix `sui client send-funds` which was always failing with `Insufficient balance … Coin balance: 0` regardless of the sender's actual coin balance.