### PR TITLE
[consensus] add LeaderScheduleV3 sliding-window scorer

### DIFF
--- a/consensus/config/src/consensus_protocol_config.rs
+++ b/consensus/config/src/consensus_protocol_config.rs
@@ -27,8 +27,8 @@ pub struct ConsensusProtocolConfig {
     bad_nodes_stake_threshold: u64,
     /// Whether to enable V3 logic.
     enable_v3: bool,
-    /// Number of recent commits retained by `LeaderScheduleV3` for its sliding-window scoring.
-    leader_schedule_running_length: u32,
+    /// Number of recent commits retained for leader schedule sliding-window scoring.
+    leader_schedule_window_size: u32,
 }
 
 impl Default for ConsensusProtocolConfig {
@@ -44,7 +44,7 @@ impl Default for ConsensusProtocolConfig {
             num_leaders_per_round: None,
             bad_nodes_stake_threshold: 0,
             enable_v3: false,
-            leader_schedule_running_length: 300,
+            leader_schedule_window_size: 300,
         }
     }
 }
@@ -61,7 +61,7 @@ impl ConsensusProtocolConfig {
         num_leaders_per_round: Option<usize>,
         bad_nodes_stake_threshold: u64,
         enable_v3: bool,
-        leader_schedule_running_length: u32,
+        leader_schedule_window_size: u32,
     ) -> Self {
         Self {
             protocol_version,
@@ -74,7 +74,7 @@ impl ConsensusProtocolConfig {
             num_leaders_per_round,
             bad_nodes_stake_threshold,
             enable_v3,
-            leader_schedule_running_length,
+            leader_schedule_window_size,
         }
     }
 
@@ -92,7 +92,7 @@ impl ConsensusProtocolConfig {
             num_leaders_per_round: Some(1),
             bad_nodes_stake_threshold: 30,
             enable_v3: false,
-            leader_schedule_running_length: 300,
+            leader_schedule_window_size: 300,
         }
     }
 
@@ -138,8 +138,8 @@ impl ConsensusProtocolConfig {
         self.enable_v3
     }
 
-    pub fn leader_schedule_running_length(&self) -> u32 {
-        self.leader_schedule_running_length
+    pub fn leader_schedule_window_size(&self) -> u32 {
+        self.leader_schedule_window_size
     }
 
     // Test setter methods
@@ -176,7 +176,7 @@ impl ConsensusProtocolConfig {
         self.enable_v3 = val;
     }
 
-    pub fn set_leader_schedule_running_length_for_testing(&mut self, val: u32) {
-        self.leader_schedule_running_length = val;
+    pub fn set_leader_schedule_window_size_for_testing(&mut self, val: u32) {
+        self.leader_schedule_window_size = val;
     }
 }

--- a/consensus/config/src/consensus_protocol_config.rs
+++ b/consensus/config/src/consensus_protocol_config.rs
@@ -25,7 +25,10 @@ pub struct ConsensusProtocolConfig {
     transaction_voting_enabled: bool,
     num_leaders_per_round: Option<usize>,
     bad_nodes_stake_threshold: u64,
+    /// Whether to enable V3 logic.
     enable_v3: bool,
+    /// Number of recent commits retained by `LeaderScheduleV3` for its sliding-window scoring.
+    leader_schedule_running_length: u32,
 }
 
 impl Default for ConsensusProtocolConfig {
@@ -41,6 +44,7 @@ impl Default for ConsensusProtocolConfig {
             num_leaders_per_round: None,
             bad_nodes_stake_threshold: 0,
             enable_v3: false,
+            leader_schedule_running_length: 300,
         }
     }
 }
@@ -57,6 +61,7 @@ impl ConsensusProtocolConfig {
         num_leaders_per_round: Option<usize>,
         bad_nodes_stake_threshold: u64,
         enable_v3: bool,
+        leader_schedule_running_length: u32,
     ) -> Self {
         Self {
             protocol_version,
@@ -69,6 +74,7 @@ impl ConsensusProtocolConfig {
             num_leaders_per_round,
             bad_nodes_stake_threshold,
             enable_v3,
+            leader_schedule_running_length,
         }
     }
 
@@ -86,6 +92,7 @@ impl ConsensusProtocolConfig {
             num_leaders_per_round: Some(1),
             bad_nodes_stake_threshold: 30,
             enable_v3: false,
+            leader_schedule_running_length: 300,
         }
     }
 
@@ -131,6 +138,10 @@ impl ConsensusProtocolConfig {
         self.enable_v3
     }
 
+    pub fn leader_schedule_running_length(&self) -> u32 {
+        self.leader_schedule_running_length
+    }
+
     // Test setter methods
 
     pub fn set_gc_depth_for_testing(&mut self, val: u32) {
@@ -163,5 +174,9 @@ impl ConsensusProtocolConfig {
 
     pub fn set_enable_v3_for_testing(&mut self, val: bool) {
         self.enable_v3 = val;
+    }
+
+    pub fn set_leader_schedule_running_length_for_testing(&mut self, val: u32) {
+        self.leader_schedule_running_length = val;
     }
 }

--- a/consensus/config/src/consensus_protocol_config.rs
+++ b/consensus/config/src/consensus_protocol_config.rs
@@ -46,8 +46,8 @@ impl Default for ConsensusProtocolConfig {
             num_leaders_per_round: None,
             bad_nodes_stake_threshold: 0,
             enable_v3: false,
-            leader_schedule_window_size: 300,
-            leader_schedule_update_interval: 12,
+            leader_schedule_window_size: 600,
+            leader_schedule_update_interval: 60,
         }
     }
 }
@@ -97,8 +97,8 @@ impl ConsensusProtocolConfig {
             num_leaders_per_round: Some(1),
             bad_nodes_stake_threshold: 30,
             enable_v3: false,
-            leader_schedule_window_size: 300,
-            leader_schedule_update_interval: 12,
+            leader_schedule_window_size: 600,
+            leader_schedule_update_interval: 60,
         }
     }
 
@@ -144,12 +144,15 @@ impl ConsensusProtocolConfig {
         self.enable_v3
     }
 
+    // Clamped to ≥ 1: downstream code (LeaderScheduleV3) uses these as window
+    // sizes and modulus operands, so a 0 config would divide by zero or be
+    // an empty window. Treat 0 as "effectively 1" instead of panicking.
     pub fn leader_schedule_window_size(&self) -> u32 {
-        self.leader_schedule_window_size
+        self.leader_schedule_window_size.max(1)
     }
 
     pub fn leader_schedule_update_interval(&self) -> u32 {
-        self.leader_schedule_update_interval
+        self.leader_schedule_update_interval.max(1)
     }
 
     // Test setter methods

--- a/consensus/config/src/consensus_protocol_config.rs
+++ b/consensus/config/src/consensus_protocol_config.rs
@@ -29,6 +29,8 @@ pub struct ConsensusProtocolConfig {
     enable_v3: bool,
     /// Number of recent commits retained for leader schedule sliding-window scoring.
     leader_schedule_window_size: u32,
+    /// Number of commit indices that use the same Mysticeti v3 leader schedule.
+    leader_schedule_update_interval: u32,
 }
 
 impl Default for ConsensusProtocolConfig {
@@ -45,6 +47,7 @@ impl Default for ConsensusProtocolConfig {
             bad_nodes_stake_threshold: 0,
             enable_v3: false,
             leader_schedule_window_size: 300,
+            leader_schedule_update_interval: 12,
         }
     }
 }
@@ -62,6 +65,7 @@ impl ConsensusProtocolConfig {
         bad_nodes_stake_threshold: u64,
         enable_v3: bool,
         leader_schedule_window_size: u32,
+        leader_schedule_update_interval: u32,
     ) -> Self {
         Self {
             protocol_version,
@@ -75,6 +79,7 @@ impl ConsensusProtocolConfig {
             bad_nodes_stake_threshold,
             enable_v3,
             leader_schedule_window_size,
+            leader_schedule_update_interval,
         }
     }
 
@@ -93,6 +98,7 @@ impl ConsensusProtocolConfig {
             bad_nodes_stake_threshold: 30,
             enable_v3: false,
             leader_schedule_window_size: 300,
+            leader_schedule_update_interval: 12,
         }
     }
 
@@ -142,6 +148,10 @@ impl ConsensusProtocolConfig {
         self.leader_schedule_window_size
     }
 
+    pub fn leader_schedule_update_interval(&self) -> u32 {
+        self.leader_schedule_update_interval
+    }
+
     // Test setter methods
 
     pub fn set_gc_depth_for_testing(&mut self, val: u32) {
@@ -178,5 +188,9 @@ impl ConsensusProtocolConfig {
 
     pub fn set_leader_schedule_window_size_for_testing(&mut self, val: u32) {
         self.leader_schedule_window_size = val;
+    }
+
+    pub fn set_leader_schedule_update_interval_for_testing(&mut self, val: u32) {
+        self.leader_schedule_update_interval = val;
     }
 }

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -39,7 +39,8 @@ use crate::{
     error::{ConsensusError, ConsensusResult},
     leader_schedule::LeaderSchedule,
     leader_schedule_v3::LeaderScheduleV3,
-    proposer::{Proposer, ValidatorProposer},
+    leader_scoring::ReputationScores,
+    proposer::{ProposalLeaderWaiter, Proposer, ValidatorProposer},
     round_tracker::RoundTracker,
     transaction::TransactionConsumer,
     transaction_vote_tracker::TransactionVoteTracker,
@@ -143,14 +144,13 @@ impl Core {
             Some(0)
         };
 
-        let propagation_scores = leader_schedule
-            .leader_swap_table
-            .read()
-            .reputation_scores
-            .clone();
-        let mut ancestor_state_manager =
-            AncestorStateManager::new(context.clone(), dag_state.clone());
-        ancestor_state_manager.set_propagation_scores(propagation_scores);
+        // Propagation scores are pushed later once `Core` exists.
+        let ancestor_state_manager = AncestorStateManager::new(context.clone(), dag_state.clone());
+        let leader_waiter = if let Some(schedule) = leader_schedule_v3.as_ref() {
+            ProposalLeaderWaiter::V3(schedule.next_commit_leader_schedule())
+        } else {
+            ProposalLeaderWaiter::V2(committer.clone())
+        };
 
         // Create the ValidatorProposer
         let proposer = Some(Box::new(ValidatorProposer::new(
@@ -162,10 +162,10 @@ impl Core {
             last_known_proposed_round,
             ancestor_state_manager,
             round_tracker.clone(),
-            committer.clone(),
+            leader_waiter,
         )) as Box<dyn Proposer>);
 
-        Self {
+        let mut core = Self {
             context,
             last_signaled_round,
             last_decided_leader,
@@ -177,8 +177,14 @@ impl Core {
             signals,
             dag_state,
             proposer,
+        };
+
+        let propagation_scores = core.current_reputation_scores();
+        if let Some(proposer) = core.proposer.as_mut() {
+            proposer.set_propagation_scores(propagation_scores);
         }
-        .recover_validator()
+
+        core.recover_validator()
     }
 
     /// Creates a new Core instance for an observer node that only processes blocks.
@@ -609,12 +615,7 @@ impl Core {
                 self.leader_schedule
                     .update_leader_schedule_v2(&self.dag_state);
 
-                let propagation_scores = self
-                    .leader_schedule
-                    .leader_swap_table
-                    .read()
-                    .reputation_scores
-                    .clone();
+                let propagation_scores = self.current_reputation_scores();
                 if let Some(proposer) = &mut self.proposer {
                     proposer.set_propagation_scores(propagation_scores);
                 }
@@ -734,11 +735,22 @@ impl Core {
         }
 
         // Only enabled in v3: use v3 leader schedule to score validators.
+        // This is for metrics only.
         if let Some(schedule) = self.leader_schedule_v3.as_mut() {
             for sub_dag in &committed_sub_dags {
                 schedule.add_commit(sub_dag.clone());
             }
-            schedule.next_commit_leader_schedule();
+            let next_commit_leader_schedule = schedule.next_commit_leader_schedule();
+            debug!(
+                "Next v3 commit leaders: index={} min_round={} num={} allowed={:?}",
+                next_commit_leader_schedule.next_commit_index,
+                next_commit_leader_schedule.min_next_leader_round,
+                next_commit_leader_schedule.num_leaders,
+                next_commit_leader_schedule.allowed_leaders,
+            );
+            if let Some(proposer) = self.proposer.as_mut() {
+                proposer.set_next_commit_leader_schedule(next_commit_leader_schedule);
+            }
         }
 
         Ok(committed_sub_dags)
@@ -784,6 +796,19 @@ impl Core {
     /// Returns the last proposed round, or None if this is an observer node.
     pub(crate) fn last_proposed_round(&self) -> Option<Round> {
         self.proposer.as_ref().map(|p| p.last_proposed_round())
+    }
+
+    /// Returns the current `ReputationScores` from the leader schedule.
+    fn current_reputation_scores(&self) -> ReputationScores {
+        if let Some(schedule) = self.leader_schedule_v3.as_ref() {
+            schedule.current_reputation_scores()
+        } else {
+            self.leader_schedule
+                .leader_swap_table
+                .read()
+                .reputation_scores
+                .clone()
+        }
     }
 
     // Tries to select a prefix of certified commits to be committed next respecting the `limit`.

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -38,6 +38,7 @@ use crate::{
     dag_state::DagState,
     error::{ConsensusError, ConsensusResult},
     leader_schedule::LeaderSchedule,
+    leader_schedule_v3::LeaderScheduleV3,
     proposer::{Proposer, ValidatorProposer},
     round_tracker::RoundTracker,
     transaction::TransactionConsumer,
@@ -64,6 +65,8 @@ pub(crate) struct Core {
     /// The consensus leader schedule to be used to resolve the leader for a
     /// given round.
     leader_schedule: Arc<LeaderSchedule>,
+    /// Scores validators using the DAG and schedules leader for next commit, in a sliding-window.
+    leader_schedule_v3: Option<LeaderScheduleV3>,
     /// The commit observer is responsible for observing the commits and collecting
     /// + sending subdags over the consensus output channel.
     commit_observer: CommitObserver,
@@ -93,6 +96,16 @@ impl Core {
     ) -> Self {
         let last_decided_leader = dag_state.read().last_commit_leader();
         let number_of_leaders = context.protocol_config.num_leaders_per_round().unwrap_or(1);
+
+        let leader_schedule_v3 = if context.protocol_config.enable_v3() {
+            Some(LeaderScheduleV3::from_store(
+                context.clone(),
+                dag_state.clone(),
+            ))
+        } else {
+            None
+        };
+
         let committer = Arc::new(
             UniversalCommitterBuilder::new(
                 context.clone(),
@@ -157,6 +170,7 @@ impl Core {
             last_signaled_round,
             last_decided_leader,
             leader_schedule,
+            leader_schedule_v3,
             block_manager,
             committer,
             commit_observer,
@@ -178,6 +192,16 @@ impl Core {
     ) -> Self {
         let last_decided_leader = dag_state.read().last_commit_leader();
         let number_of_leaders = context.protocol_config.num_leaders_per_round().unwrap_or(1);
+
+        let leader_schedule_v3 = if context.protocol_config.enable_v3() {
+            Some(LeaderScheduleV3::from_store(
+                context.clone(),
+                dag_state.clone(),
+            ))
+        } else {
+            None
+        };
+
         let committer = Arc::new(
             UniversalCommitterBuilder::new(
                 context.clone(),
@@ -197,6 +221,7 @@ impl Core {
             last_signaled_round,
             last_decided_leader,
             leader_schedule,
+            leader_schedule_v3,
             block_manager,
             committer,
             commit_observer,
@@ -706,6 +731,14 @@ impl Core {
                 committed_block_refs,
                 self.dag_state.read().gc_round(),
             );
+        }
+
+        // Only enabled in v3: use v3 leader schedule to score validators.
+        if let Some(schedule) = self.leader_schedule_v3.as_mut() {
+            for sub_dag in &committed_sub_dags {
+                schedule.add_commit(sub_dag.clone());
+            }
+            schedule.next_commit_leader_schedule();
         }
 
         Ok(committed_sub_dags)

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -144,15 +144,14 @@ impl Core {
             Some(0)
         };
 
-        // Propagation scores are pushed later once `Core` exists.
         let ancestor_state_manager = AncestorStateManager::new(context.clone(), dag_state.clone());
+
+        // Create the ValidatorProposer.
         let leader_waiter = if let Some(schedule) = leader_schedule_v3.as_ref() {
             ProposalLeaderWaiter::V3(schedule.next_commit_leader_schedule())
         } else {
             ProposalLeaderWaiter::V2(committer.clone())
         };
-
-        // Create the ValidatorProposer
         let proposer = Some(Box::new(ValidatorProposer::new(
             dag_state.clone(),
             context.clone(),
@@ -179,10 +178,12 @@ impl Core {
             proposer,
         };
 
+        // Initialize propagation scores for the proposer before recovery.
         let propagation_scores = core.current_reputation_scores();
-        if let Some(proposer) = core.proposer.as_mut() {
-            proposer.set_propagation_scores(propagation_scores);
-        }
+        core.proposer
+            .as_mut()
+            .unwrap()
+            .set_propagation_scores(propagation_scores);
 
         core.recover_validator()
     }

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -148,7 +148,15 @@ impl Core {
 
         // Create the ValidatorProposer.
         let leader_waiter = if let Some(schedule) = leader_schedule_v3.as_ref() {
-            ProposalLeaderWaiter::V3(schedule.next_commit_leader_schedule())
+            let next_commit_leader_schedule = schedule.next_commit_leader_schedule();
+            debug!(
+                "Initial v3 commit leaders: index={} min_round={} num={} allowed={:?}",
+                next_commit_leader_schedule.next_commit_index,
+                next_commit_leader_schedule.min_next_leader_round,
+                next_commit_leader_schedule.num_leaders,
+                next_commit_leader_schedule.allowed_leaders,
+            );
+            ProposalLeaderWaiter::V3(next_commit_leader_schedule)
         } else {
             ProposalLeaderWaiter::V2(committer.clone())
         };
@@ -733,25 +741,6 @@ impl Core {
                 committed_block_refs,
                 self.dag_state.read().gc_round(),
             );
-        }
-
-        // Only enabled in v3: use v3 leader schedule to score validators.
-        // This is for metrics only.
-        if let Some(schedule) = self.leader_schedule_v3.as_mut() {
-            for sub_dag in &committed_sub_dags {
-                schedule.add_commit(sub_dag.clone());
-            }
-            let next_commit_leader_schedule = schedule.next_commit_leader_schedule();
-            debug!(
-                "Next v3 commit leaders: index={} min_round={} num={} allowed={:?}",
-                next_commit_leader_schedule.next_commit_index,
-                next_commit_leader_schedule.min_next_leader_round,
-                next_commit_leader_schedule.num_leaders,
-                next_commit_leader_schedule.allowed_leaders,
-            );
-            if let Some(proposer) = self.proposer.as_mut() {
-                proposer.set_next_commit_leader_schedule(next_commit_leader_schedule);
-            }
         }
 
         Ok(committed_sub_dags)

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -149,8 +149,8 @@ impl Core {
         // Create the ValidatorProposer.
         let leader_waiter = if let Some(schedule) = leader_schedule_v3.as_ref() {
             let next_commit_leader_schedule = schedule.next_commit_leader_schedule();
-            debug!(
-                "Initial v3 commit leaders: index={} min_round={} num={} allowed={:?}",
+            info!(
+                "Recovered next commit leaders: index={} min_round={} num={} allowed={:?}",
                 next_commit_leader_schedule.next_commit_index,
                 next_commit_leader_schedule.min_next_leader_round,
                 next_commit_leader_schedule.num_leaders,

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -153,7 +153,7 @@ impl Core {
                 "Recovered next commit leaders: index={} min_round={} num={} allowed={:?}",
                 next_commit_leader_schedule.next_commit_index,
                 next_commit_leader_schedule.min_next_leader_round,
-                next_commit_leader_schedule.num_leaders,
+                next_commit_leader_schedule.num_leaders(),
                 next_commit_leader_schedule.allowed_leaders,
             );
             ProposalLeaderWaiter::V3(next_commit_leader_schedule)

--- a/consensus/core/src/leader_schedule_v3.rs
+++ b/consensus/core/src/leader_schedule_v3.rs
@@ -35,19 +35,21 @@ use crate::{
 pub(crate) struct LeaderScheduleV3 {
     context: Arc<Context>,
     next_commit_index: CommitIndex,
+    // Total scores per authority in the running window, indexed by AuthorityIndex.
     total_scores_per_authority: Vec<u64>,
-    // Sum of `num_leaders` across all entries in `scores_entry`.
+    // Total number of leaders across the running window.
+    // Used for metrics.
     total_num_leaders: usize,
-    // Sum of `leader_stakes` across all entries in `scores_entry`.
+    // Total stake of leaders across the running window
+    // Used for metrics.
     total_leader_stakes: u64,
 
-    // Holds at most the last two committed subdags, used as C-2 and C-1 when
-    // scoring the next commit. Populated from CommittedSubDag directly so no
-    // DagState lookup is needed.
+    // Holds at most the last two committed subdags, used as C-2 and C-1
+    // when computing scores with leaders from C-3.
     pending_commits: VecDeque<CommittedSubDag>,
     // One entry per scored commit still in the running window. Used to
     // subtract a commit's contributions from `total_scores_per_authority` on
-    // eviction. Bounded by `leader_schedule_running_length`.
+    // eviction. Bounded by `leader_schedule_window_size`.
     scores_entry: VecDeque<ScoresEntry>,
 }
 
@@ -115,7 +117,7 @@ impl LeaderScheduleV3 {
         total_scores_per_authority: Vec<u64>,
     ) -> Self {
         assert_eq!(total_scores_per_authority.len(), context.committee.size());
-        let running_length = context.protocol_config.leader_schedule_running_length() as usize;
+        let running_length = context.protocol_config.leader_schedule_window_size() as usize;
         Self {
             context,
             next_commit_index,
@@ -128,11 +130,11 @@ impl LeaderScheduleV3 {
     }
 
     /// Number of recent committed sub-dags that must be replayed on startup
-    /// to reconstruct the full state: `leader_schedule_running_length`
+    /// to reconstruct the full state: `leader_schedule_window_size`
     /// for the scoring window plus 2 for the pending commits held before
     /// scoring begins.
     fn replay_length(context: &Context) -> u32 {
-        context.protocol_config.leader_schedule_running_length() + 2
+        context.protocol_config.leader_schedule_window_size() + 2
     }
 
     /// Returns the leader schedule for the next commit.
@@ -380,7 +382,7 @@ impl LeaderScheduleV3 {
     fn running_length(&self) -> usize {
         self.context
             .protocol_config
-            .leader_schedule_running_length() as usize
+            .leader_schedule_window_size() as usize
     }
 
     /// Average number of leader-round blocks per scored commit in the current
@@ -447,7 +449,7 @@ mod tests {
         if let Some(len) = running_length {
             context
                 .protocol_config
-                .set_leader_schedule_running_length_for_testing(len);
+                .set_leader_schedule_window_size_for_testing(len);
         }
         Arc::new(context)
     }
@@ -734,7 +736,7 @@ mod tests {
     async fn test_replay_length() {
         let (mut ctx, _) = Context::new_for_test(4);
         ctx.protocol_config
-            .set_leader_schedule_running_length_for_testing(5);
+            .set_leader_schedule_window_size_for_testing(5);
         let context = Arc::new(ctx);
         assert_eq!(LeaderScheduleV3::replay_length(&context), 7);
     }
@@ -749,7 +751,7 @@ mod tests {
 
         let (mut ctx, _) = Context::new_for_test(4);
         ctx.protocol_config
-            .set_leader_schedule_running_length_for_testing(5);
+            .set_leader_schedule_window_size_for_testing(5);
         let context = Arc::new(ctx);
 
         // Uniform chain: rounds 1..=10, authorities 0 and 1 produce blocks

--- a/consensus/core/src/leader_schedule_v3.rs
+++ b/consensus/core/src/leader_schedule_v3.rs
@@ -14,8 +14,9 @@ use rand::{SeedableRng, prelude::SliceRandom, rngs::StdRng};
 use crate::{
     CommitIndex, CommitRef, CommittedSubDag, DagState,
     block::{BlockAPI, GENESIS_ROUND},
-    commit::load_committed_subdag_from_store,
+    commit::{CommitRange, load_committed_subdag_from_store},
     context::Context,
+    leader_scoring::ReputationScores,
 };
 
 /// Incremental, sliding-window leader scorer over recent commits.
@@ -51,7 +52,7 @@ pub(crate) struct LeaderScheduleV3 {
 }
 
 /// This is used by the commit rule to figure out the next commit leaders.
-#[allow(unused)]
+#[derive(Clone, Debug, Default)]
 pub(crate) struct NextCommitLeaderSchedule {
     // Index of the next commit.
     pub(crate) next_commit_index: CommitIndex,
@@ -330,6 +331,17 @@ impl LeaderScheduleV3 {
         self.pending_commits.push_back(c);
 
         self.report_metrics();
+    }
+
+    /// Snapshot of the running per-authority scores.
+    pub(crate) fn current_reputation_scores(&self) -> ReputationScores {
+        let commit_range = match (self.scores_entry.front(), self.scores_entry.back()) {
+            (Some(front), Some(back)) => {
+                CommitRange::new(front.commit_ref.index..=back.commit_ref.index)
+            }
+            _ => CommitRange::default(),
+        };
+        ReputationScores::new(commit_range, self.total_scores_per_authority.clone())
     }
 
     fn report_metrics(&self) {

--- a/consensus/core/src/leader_schedule_v3.rs
+++ b/consensus/core/src/leader_schedule_v3.rs
@@ -1,0 +1,846 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{
+    collections::{BTreeMap, BTreeSet, VecDeque},
+    sync::Arc,
+};
+
+use consensus_config::AuthorityIndex;
+use consensus_types::block::Round;
+use parking_lot::RwLock;
+use rand::{SeedableRng, prelude::SliceRandom, rngs::StdRng};
+
+use crate::{
+    CommitIndex, CommitRef, CommittedSubDag, DagState,
+    block::{BlockAPI, GENESIS_ROUND},
+    commit::load_committed_subdag_from_store,
+    context::Context,
+};
+
+/// Incremental, sliding-window leader scorer over recent commits.
+///
+/// On each new commit C, score contributions are computed and added to the
+/// running totals. When the running window is full, the oldest commit is evicted
+/// and its contributions are subtracted from the running totals.
+///
+/// Scoring rule for commit C (requires `C >= 3` so that C-1 and C-2 are present):
+/// Let `r` be the leader round of commit C-2.
+/// For each authority A: consider A's blocks at round `r+1` ("voting block") across commits
+/// C and C-1.
+/// Collect the set of distinct authorities B, such that at least one of A's voting blocks
+/// vote to (has an ancestor that is) a B's round `r` ("leader block") block in commit C-2.
+/// Then `score[A] += sum_{B in distinct set} stake(B)`.
+pub(crate) struct LeaderScheduleV3 {
+    context: Arc<Context>,
+    next_commit_index: CommitIndex,
+    total_scores_per_authority: Vec<u64>,
+    // Sum of `num_leaders` across all entries in `scores_entry`.
+    total_num_leaders: usize,
+    // Sum of `leader_stakes` across all entries in `scores_entry`.
+    total_leader_stakes: u64,
+
+    // Holds at most the last two committed subdags, used as C-2 and C-1 when
+    // scoring the next commit. Populated from CommittedSubDag directly so no
+    // DagState lookup is needed.
+    pending_commits: VecDeque<CommittedSubDag>,
+    // One entry per scored commit still in the running window. Used to
+    // subtract a commit's contributions from `total_scores_per_authority` on
+    // eviction. Bounded by `leader_schedule_running_length`.
+    scores_entry: VecDeque<ScoresEntry>,
+}
+
+/// This is used by the commit rule to figure out the next commit leaders.
+#[allow(unused)]
+pub(crate) struct NextCommitLeaderSchedule {
+    // Index of the next commit.
+    pub(crate) next_commit_index: CommitIndex,
+    // Minimum round of the next commit leader.
+    pub(crate) min_next_leader_round: Round,
+    // Number of leaders to select.
+    pub(crate) num_leaders: usize,
+    // Allowed leaders to be selected from.
+    pub(crate) allowed_leaders: Vec<AuthorityIndex>,
+}
+
+struct ScoresEntry {
+    commit_ref: CommitRef,
+    // Per-authority incremental score contributed by processing this commit,
+    // indexed by AuthorityIndex. Retained so eviction can subtract it.
+    score_contributions: Vec<u64>,
+    // Number of round `r` (leader) blocks in the scored commit (C-2).
+    // Retained so eviction can subtract it from `total_num_leaders`.
+    num_leaders: usize,
+    // Sum of stake(author) across all leader blocks in the scored commit.
+    // Retained so eviction can subtract it from `total_leader_stakes`.
+    leader_stakes: u64,
+}
+
+impl LeaderScheduleV3 {
+    /// Constructs a `LeaderScheduleV3`.
+    /// Replays persisted commits from storage if available, to ensure
+    /// the running window and current scores are recovered exactly.
+    pub(crate) fn from_store(
+        context: Arc<Context>,
+        dag_state: Arc<RwLock<DagState>>,
+    ) -> LeaderScheduleV3 {
+        let committee_size = context.committee.size();
+        let last_commit_index = dag_state.read().last_commit_index();
+        if last_commit_index == 0 {
+            return LeaderScheduleV3::new(context, 1, vec![0; committee_size]);
+        }
+
+        let replay_count = LeaderScheduleV3::replay_length(&context);
+        // Replay maximum replay_count commits, and starting from commit 1 at minimum.
+        let replay_start = last_commit_index.saturating_sub(replay_count) + 1;
+        // The first replayed commit's index will be replay_start, so initializing next_commit_index
+        // to replay_start.
+        let mut leader_schedule =
+            LeaderScheduleV3::new(context.clone(), replay_start, vec![0; committee_size]);
+        let store = dag_state.read().store();
+        let commits = store
+            .scan_commits((replay_start..=last_commit_index).into())
+            .expect("Failed to scan commits from storage");
+        for commit in commits {
+            let subdag = load_committed_subdag_from_store(store.as_ref(), commit);
+            leader_schedule.add_commit(subdag);
+        }
+        leader_schedule
+    }
+
+    pub(crate) fn new(
+        context: Arc<Context>,
+        next_commit_index: CommitIndex,
+        total_scores_per_authority: Vec<u64>,
+    ) -> Self {
+        assert_eq!(total_scores_per_authority.len(), context.committee.size());
+        let running_length = context.protocol_config.leader_schedule_running_length() as usize;
+        Self {
+            context,
+            next_commit_index,
+            total_scores_per_authority,
+            total_num_leaders: 0,
+            total_leader_stakes: 0,
+            pending_commits: VecDeque::with_capacity(2),
+            scores_entry: VecDeque::with_capacity(running_length),
+        }
+    }
+
+    /// Number of recent committed sub-dags that must be replayed on startup
+    /// to reconstruct the full state: `leader_schedule_running_length`
+    /// for the scoring window plus 2 for the pending commits held before
+    /// scoring begins.
+    fn replay_length(context: &Context) -> u32 {
+        context.protocol_config.leader_schedule_running_length() + 2
+    }
+
+    /// Returns the leader schedule for the next commit.
+    ///
+    /// next_commit_index and min_next_leader_round are determined from the current commit.
+    /// num_leaders in next commit is a constant right now, but can become dynamic in future.
+    /// Selects authorities with good enough performance and satisfying other constraints,
+    /// which can become the next commit leaders.
+    pub(crate) fn next_commit_leader_schedule(&self) -> NextCommitLeaderSchedule {
+        let min_next_leader_round = self
+            .pending_commits
+            .back()
+            .map(|c| c.leader.round)
+            .unwrap_or(GENESIS_ROUND)
+            + 1;
+        let num_leaders = self
+            .context
+            .protocol_config
+            .num_leaders_per_round()
+            .unwrap_or(1);
+        NextCommitLeaderSchedule {
+            next_commit_index: self.next_commit_index,
+            min_next_leader_round,
+            num_leaders,
+            allowed_leaders: self.select_allowed_leaders_with_fixed_config(),
+        }
+    }
+
+    /// Returns the set of authorities allowed to be leaders, based on current
+    /// running scores and threshold in config.
+    ///
+    /// Authorities are ranked by score descending. Lowest-score authorities are
+    /// excluded while their cumulative stake remains within `stake_threshold`%
+    /// of total stake.
+    pub(crate) fn select_allowed_leaders_with_fixed_config(&self) -> Vec<AuthorityIndex> {
+        // Create a vector of authorities and their scores.
+        let mut by_score: Vec<(AuthorityIndex, u64)> = self
+            .total_scores_per_authority
+            .iter()
+            .enumerate()
+            .map(|(i, score)| {
+                let authority_index = self
+                    .context
+                    .committee
+                    .to_authority_index(i)
+                    .expect("Should be a valid AuthorityIndex");
+                (authority_index, *score)
+            })
+            .collect();
+
+        // Shuffle deterministically.
+        let seed_bytes = self
+            .pending_commits
+            .back()
+            .map(|c| c.commit_ref.digest.into_inner())
+            .unwrap_or_else(|| {
+                // No pending commits yet — derive a per-epoch seed so the
+                // initialization shuffle differs across epochs instead of
+                // always defaulting to all-zeros.
+                let mut seed = [0u8; 32];
+                seed[..8].copy_from_slice(&self.context.epoch_start_timestamp_ms.to_le_bytes());
+                seed[8..16].copy_from_slice(&self.context.committee.epoch().to_le_bytes());
+                seed
+            });
+        let mut rng = StdRng::from_seed(seed_bytes);
+        by_score.shuffle(&mut rng);
+
+        // Use stable sort to produce deterministic order of authorities with the same score.
+        by_score.sort_by(|a, b| b.1.cmp(&a.1));
+
+        // A bad threshold of 0 will select all authorities.
+        let mut accumulated_bad_stake = 0u64;
+        let cutoff = (self.context.protocol_config.bad_nodes_stake_threshold()
+            * self.context.committee.total_stake())
+            / 100;
+        while let Some((idx, _)) = by_score.last() {
+            let stake = self.context.committee.stake(*idx);
+            if accumulated_bad_stake + stake > cutoff {
+                break;
+            }
+            accumulated_bad_stake += stake;
+            by_score.pop();
+        }
+
+        by_score.into_iter().map(|(idx, _)| idx).collect()
+    }
+
+    /// Scores a commit and adds it into the running window.
+    /// Evicts the oldest scored commit and drops its scores, if the window is full.
+    pub(crate) fn add_commit(&mut self, c: CommittedSubDag) {
+        // Ensure commits are added in order.
+        assert_eq!(c.commit_ref.index, self.next_commit_index);
+        self.next_commit_index += 1;
+
+        // There must be exactly 2 pending commits to compute the next scores.
+        // Otherwise, this is a new consensus instance (new epoch or recovery).
+        if self.pending_commits.len() < 2 {
+            self.pending_commits.push_back(c);
+            self.report_metrics();
+            return;
+        }
+
+        // Keep at most `running_length - 1` commit scores so there is room to
+        // push one more below.
+        while self.scores_entry.len() >= self.running_length() {
+            let evicted = self.scores_entry.pop_front().expect("non empty");
+            tracing::trace!(
+                "LeaderScheduleV3 evicting scored commit {} from running window",
+                evicted.commit_ref
+            );
+            for (i, contribution) in evicted.score_contributions.iter().enumerate() {
+                self.total_scores_per_authority[i] = self.total_scores_per_authority[i]
+                    .checked_sub(*contribution)
+                    .unwrap();
+            }
+            self.total_num_leaders = self
+                .total_num_leaders
+                .checked_sub(evicted.num_leaders)
+                .unwrap();
+            self.total_leader_stakes = self
+                .total_leader_stakes
+                .checked_sub(evicted.leader_stakes)
+                .unwrap();
+        }
+
+        // Compute score contributions for the new commit.
+        let c_minus_2 = &self.pending_commits[0];
+        let c_minus_1 = &self.pending_commits[1];
+
+        let leader_round = c_minus_2.leader.round;
+        let vote_round = leader_round + 1;
+
+        let leader_refs: BTreeSet<_> = c_minus_2
+            .blocks
+            .iter()
+            .filter(|b| b.round() == leader_round)
+            .map(|b| b.reference())
+            .collect();
+
+        let voting_blocks: Vec<_> = c_minus_1
+            .blocks
+            .iter()
+            .chain(c.blocks.iter())
+            .filter(|b| b.round() == vote_round)
+            .collect();
+
+        let mut score_contributions = vec![0u64; self.context.committee.size()];
+
+        if !voting_blocks.is_empty() && !leader_refs.is_empty() {
+            // Collect a map from authorities voting on leader blocks, to leader authorities they voted on.
+            // This consolidates votes and scores per authority.
+            let mut per_authority_votes: BTreeMap<AuthorityIndex, BTreeSet<AuthorityIndex>> =
+                BTreeMap::new();
+            for voting_block in voting_blocks {
+                let authority_votes = per_authority_votes
+                    .entry(voting_block.author())
+                    .or_default();
+                for voted_block in voting_block.ancestors() {
+                    if leader_refs.contains(voted_block) {
+                        authority_votes.insert(voted_block.author);
+                    }
+                }
+            }
+
+            for (voting_authority, leader_authorities) in per_authority_votes {
+                let total_leader_stake = leader_authorities
+                    .into_iter()
+                    .map(|i| self.context.committee.stake(i))
+                    .sum();
+                score_contributions[voting_authority.value()] = total_leader_stake;
+            }
+        }
+
+        // Add the contributions to the running totals.
+        for (i, delta) in score_contributions.iter().enumerate() {
+            self.total_scores_per_authority[i] += *delta;
+        }
+
+        // Record this commit's scores for future eviction.
+        let num_leaders = leader_refs.len();
+        let leader_stakes: u64 = leader_refs
+            .iter()
+            .map(|r| self.context.committee.stake(r.author))
+            .sum();
+        self.total_num_leaders += num_leaders;
+        self.total_leader_stakes += leader_stakes;
+        self.scores_entry.push_back(ScoresEntry {
+            commit_ref: c_minus_2.commit_ref,
+            score_contributions,
+            num_leaders,
+            leader_stakes,
+        });
+
+        // Rotate the pending commits: drop C-2, keep C-1, add C.
+        self.pending_commits.pop_front();
+        self.pending_commits.push_back(c);
+
+        self.report_metrics();
+    }
+
+    fn report_metrics(&self) {
+        let metrics = &self.context.metrics.node_metrics;
+        for (i, score) in self.total_scores_per_authority.iter().enumerate() {
+            let authority_index = self
+                .context
+                .committee
+                .to_authority_index(i)
+                .expect("Should be a valid AuthorityIndex");
+            let hostname = &self.context.committee.authority(authority_index).hostname;
+            if hostname.is_empty() {
+                continue;
+            }
+            metrics
+                .leader_schedule_total_scores
+                .with_label_values(&[hostname])
+                .set(*score as i64);
+            let normalized = if self.total_leader_stakes == 0 {
+                0.0
+            } else {
+                *score as f64 / self.total_leader_stakes as f64
+            };
+            metrics
+                .leader_schedule_normalized_scores
+                .with_label_values(&[hostname])
+                .set(normalized);
+        }
+        if let Some(last) = self.scores_entry.back() {
+            metrics
+                .leader_schedule_last_num_leaders
+                .set(last.num_leaders as i64);
+        }
+    }
+
+    fn running_length(&self) -> usize {
+        self.context
+            .protocol_config
+            .leader_schedule_running_length() as usize
+    }
+
+    /// Average number of leader-round blocks per scored commit in the current
+    /// running window. Returns 0.0 when no commits have been scored yet.
+    #[cfg(test)]
+    fn average_num_leaders(&self) -> f64 {
+        if self.scores_entry.is_empty() {
+            0.0
+        } else {
+            self.total_num_leaders as f64 / self.scores_entry.len() as f64
+        }
+    }
+
+    /// Average total leader stake per scored commit in the current running
+    /// window. Returns 0.0 when no commits have been scored yet.
+    #[cfg(test)]
+    fn average_leader_stakes(&self) -> f64 {
+        if self.scores_entry.is_empty() {
+            0.0
+        } else {
+            self.total_leader_stakes as f64 / self.scores_entry.len() as f64
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn total_scores_per_authority(&self) -> &[u64] {
+        &self.total_scores_per_authority
+    }
+
+    #[cfg(test)]
+    pub(crate) fn scores_entry_len(&self) -> usize {
+        self.scores_entry.len()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn pending_commits_len(&self) -> usize {
+        self.pending_commits.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use consensus_config::{AuthorityIndex, local_committee_and_keys};
+    use consensus_types::block::{BlockRef, Round};
+
+    use super::*;
+    use crate::{
+        block::{TestBlock, VerifiedBlock},
+        commit::CommitDigest,
+        context::Context,
+    };
+
+    fn setup(committee_size: usize) -> Arc<Context> {
+        setup_with_running_length(committee_size, None)
+    }
+
+    fn setup_with_running_length(
+        committee_size: usize,
+        running_length: Option<u32>,
+    ) -> Arc<Context> {
+        let (mut context, _) = Context::new_for_test(committee_size);
+        if let Some(len) = running_length {
+            context
+                .protocol_config
+                .set_leader_schedule_running_length_for_testing(len);
+        }
+        Arc::new(context)
+    }
+
+    /// Builds a VerifiedBlock at (round, author) with the given ancestor refs.
+    fn make_block(round: Round, author: u32, ancestors: Vec<BlockRef>) -> VerifiedBlock {
+        VerifiedBlock::new_for_test(
+            TestBlock::new(round, author)
+                .set_ancestors(ancestors)
+                .build(),
+        )
+    }
+
+    fn make_commit(
+        index: CommitIndex,
+        leader: BlockRef,
+        blocks: Vec<VerifiedBlock>,
+    ) -> CommittedSubDag {
+        CommittedSubDag::new(
+            leader,
+            blocks,
+            /* timestamp_ms */ 0,
+            CommitRef {
+                index,
+                digest: CommitDigest::MIN,
+            },
+        )
+    }
+
+    #[tokio::test]
+    async fn test_new_state_is_zero() {
+        let context = setup(4);
+        let schedule = LeaderScheduleV3::new(context, 1, vec![0; 4]);
+        assert_eq!(schedule.total_scores_per_authority(), &[0u64; 4]);
+        assert_eq!(schedule.scores_entry_len(), 0);
+        assert_eq!(schedule.pending_commits_len(), 0);
+        assert_eq!(schedule.average_num_leaders(), 0.0);
+        assert_eq!(schedule.average_leader_stakes(), 0.0);
+    }
+
+    #[tokio::test]
+    async fn test_first_two_commits_score_zero() {
+        let context = setup(4);
+        let mut schedule = LeaderScheduleV3::new(context, 1, vec![0; 4]);
+
+        let leader1 = make_block(1, 0, vec![]);
+        schedule.add_commit(make_commit(1, leader1.reference(), vec![leader1.clone()]));
+        assert_eq!(schedule.total_scores_per_authority(), &[0u64; 4]);
+        assert_eq!(schedule.scores_entry_len(), 0);
+        assert_eq!(schedule.pending_commits_len(), 1);
+
+        let leader2 = make_block(2, 1, vec![leader1.reference()]);
+        schedule.add_commit(make_commit(2, leader2.reference(), vec![leader2.clone()]));
+        assert_eq!(schedule.total_scores_per_authority(), &[0u64; 4]);
+        assert_eq!(schedule.scores_entry_len(), 0);
+        assert_eq!(schedule.pending_commits_len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_third_commit_scores_from_c_minus_2() {
+        let context = setup(4);
+        let mut schedule = LeaderScheduleV3::new(context.clone(), 1, vec![0; 4]);
+
+        // Commit 1 (C-2): leader at round 1, authority 0. Blocks at round 1 from
+        // all four authorities (these are B-candidates at C-2 leader round).
+        let b0 = make_block(1, 0, vec![]);
+        let b1 = make_block(1, 1, vec![]);
+        let b2 = make_block(1, 2, vec![]);
+        let b3 = make_block(1, 3, vec![]);
+        schedule.add_commit(make_commit(
+            1,
+            b0.reference(),
+            vec![b0.clone(), b1.clone(), b2.clone(), b3.clone()],
+        ));
+
+        // Commit 2 (C-1): two vote blocks at round 2 linking to commit 1 blocks.
+        // Authority 0's round-2 block links to B0 and B1 at round 1.
+        // Authority 1's round-2 block links to B2 only.
+        let v0_c1 = make_block(2, 0, vec![b0.reference(), b1.reference()]);
+        let v1_c1 = make_block(2, 1, vec![b2.reference()]);
+        schedule.add_commit(make_commit(
+            2,
+            v0_c1.reference(),
+            vec![v0_c1.clone(), v1_c1.clone()],
+        ));
+        // No scoring yet — we need C-2 to apply.
+        assert_eq!(schedule.total_scores_per_authority(), &[0u64; 4]);
+
+        // Commit 3 (C): one vote block at round 2 (C-2's leader round was 1, so
+        // vote round = 2). Authority 2's round-2 block links to B1 and B3.
+        let v2_c = make_block(2, 2, vec![b1.reference(), b3.reference()]);
+        schedule.add_commit(make_commit(3, v2_c.reference(), vec![v2_c.clone()]));
+
+        // Expected contributions (equal stake per authority in new_for_test):
+        //   A=0: distinct Bs = {0, 1} → stake(0)+stake(1)
+        //   A=1: distinct Bs = {2}    → stake(2)
+        //   A=2: distinct Bs = {1, 3} → stake(1)+stake(3)
+        //   A=3: no vote blocks at round 2 → 0
+        let s0 = context.committee.stake(AuthorityIndex::new_for_test(0));
+        let s1 = context.committee.stake(AuthorityIndex::new_for_test(1));
+        let s2 = context.committee.stake(AuthorityIndex::new_for_test(2));
+        let s3 = context.committee.stake(AuthorityIndex::new_for_test(3));
+        assert_eq!(
+            schedule.total_scores_per_authority(),
+            &[s0 + s1, s2, s1 + s3, 0]
+        );
+        assert_eq!(schedule.scores_entry_len(), 1);
+        assert_eq!(schedule.pending_commits_len(), 2);
+        // C-2 (commit 1) has 4 leader-round blocks, so with one scored entry
+        // the average is 4.0 and the average leader stake equals the sum of
+        // all four authority stakes.
+        assert_eq!(schedule.average_num_leaders(), 4.0);
+        assert_eq!(schedule.average_leader_stakes(), (s0 + s1 + s2 + s3) as f64);
+    }
+
+    #[tokio::test]
+    async fn test_eviction_subtracts_contributions() {
+        // Uniform chain: rounds 1..=6, two authorities (0 and 1) at each round,
+        // each round's blocks link to both blocks of the previous round.
+        // With `running_length=3`, scores_entry tops out at 3 entries; the
+        // 4th scored commit evicts the earliest. Because every scored commit
+        // contributes the same delta, post-eviction totals equal pre-eviction
+        // totals — which proves eviction is subtracting.
+        let context = setup_with_running_length(4, Some(3));
+        let mut schedule = LeaderScheduleV3::new(context.clone(), 1, vec![0; 4]);
+
+        let mut blocks_by_round: Vec<Vec<VerifiedBlock>> = Vec::new();
+        blocks_by_round.push(vec![make_block(1, 0, vec![]), make_block(1, 1, vec![])]);
+        for round in 2..=6u32 {
+            let prev = &blocks_by_round[(round - 2) as usize];
+            let ancestors: Vec<_> = prev.iter().map(|b| b.reference()).collect();
+            blocks_by_round.push(vec![
+                make_block(round, 0, ancestors.clone()),
+                make_block(round, 1, ancestors),
+            ]);
+        }
+
+        let commit = |i: CommitIndex, brs: &[Vec<VerifiedBlock>]| -> CommittedSubDag {
+            let blocks = brs[(i - 1) as usize].clone();
+            let leader = blocks[0].reference();
+            make_commit(i, leader, blocks)
+        };
+
+        for i in 1..=5 {
+            schedule.add_commit(commit(i, &blocks_by_round));
+        }
+        let after_5 = schedule.total_scores_per_authority().to_vec();
+        assert_eq!(schedule.scores_entry_len(), 3);
+
+        // 3 scored commits in a uniform chain, each contributing
+        // `stake(0) + stake(1)` to authorities 0 and 1.
+        let s0 = context.committee.stake(AuthorityIndex::new_for_test(0));
+        let s1 = context.committee.stake(AuthorityIndex::new_for_test(1));
+        let per_commit = s0 + s1;
+        assert_eq!(after_5, vec![3 * per_commit, 3 * per_commit, 0, 0]);
+
+        schedule.add_commit(commit(6, &blocks_by_round));
+        assert_eq!(schedule.scores_entry_len(), 3);
+        // cs3 was evicted and cs6 added; both deltas are identical, so totals
+        // are unchanged. Had eviction not subtracted, totals would be 4 * per_commit.
+        assert_eq!(schedule.total_scores_per_authority().to_vec(), after_5);
+        // Every scored C-2 in this uniform chain has exactly 2 leader-round
+        // blocks from authorities 0 and 1; both averages are unaffected by
+        // eviction because each evicted entry's contributions are replaced
+        // by identical ones.
+        assert_eq!(schedule.average_num_leaders(), 2.0);
+        assert_eq!(schedule.average_leader_stakes(), (s0 + s1) as f64);
+    }
+
+    #[tokio::test]
+    async fn test_select_returns_next_commit_index_and_requested_count() {
+        // With the default threshold disabled, no authority is "bad", so the
+        // full randomized order is available and selection returns exactly
+        // `num_leaders` authorities. The returned CommitIndex echoes the one
+        // supplied to `new`.
+        let (mut ctx, _) = Context::new_for_test(4);
+        ctx.protocol_config
+            .set_num_leaders_per_round_for_testing(Some(3));
+        ctx.protocol_config
+            .set_bad_nodes_stake_threshold_for_testing(0);
+        let context = Arc::new(ctx);
+        let schedule = LeaderScheduleV3::new(context, 7, vec![5, 10, 0, 2]);
+        let next = schedule.next_commit_leader_schedule();
+        assert_eq!(next.next_commit_index, 7);
+        // No pending commits -> min_next_leader_round is GENESIS_ROUND + 1.
+        assert_eq!(next.min_next_leader_round, 1);
+        assert_eq!(next.num_leaders, 3);
+        // Threshold is 0, so every authority is allowed.
+        assert_eq!(next.allowed_leaders.len(), 4);
+        // The allowed-leaders list is a permutation of distinct authorities.
+        let mut sorted = next.allowed_leaders.clone();
+        sorted.sort();
+        sorted.dedup();
+        assert_eq!(sorted.len(), next.allowed_leaders.len());
+    }
+
+    #[tokio::test]
+    async fn test_select_skips_bad_nodes() {
+        // 4 equal-stake authorities. Threshold 30% with total_stake=4 gives a
+        // cutoff of 1; the single lowest-score authority (a1, score 0) is
+        // filtered out of the allowed-leaders list. The remaining 3 must not
+        // include it, regardless of the randomized order.
+        let (mut ctx, _) = Context::new_for_test(4);
+        ctx.protocol_config
+            .set_bad_nodes_stake_threshold_for_testing(30);
+        let context = Arc::new(ctx);
+        let schedule = LeaderScheduleV3::new(context.clone(), 1, vec![100, 0, 100, 100]);
+
+        let allowed = schedule.select_allowed_leaders_with_fixed_config();
+        assert_eq!(allowed.len(), 3);
+        assert!(!allowed.contains(&AuthorityIndex::new_for_test(1)));
+    }
+
+    #[tokio::test]
+    async fn test_select_bad_nodes_does_not_exceed_stake_threshold() {
+        // 4 equal-stake authorities with total stake 10,000. A 30% threshold
+        // permits excluding one 2,500-stake authority, but excluding the next
+        // one would cross the 3,000-stake cutoff.
+        let (mut ctx, _) = Context::new_for_test(4);
+        let (committee, _) = local_committee_and_keys(0, vec![2500; 4]);
+        ctx = ctx.with_committee(committee);
+        ctx.protocol_config
+            .set_bad_nodes_stake_threshold_for_testing(30);
+        let context = Arc::new(ctx);
+        let schedule = LeaderScheduleV3::new(context, 1, vec![10, 0, 1, 2]);
+
+        let allowed = schedule.select_allowed_leaders_with_fixed_config();
+        assert_eq!(allowed.len(), 3);
+        assert!(!allowed.contains(&AuthorityIndex::new_for_test(1)));
+        assert!(allowed.contains(&AuthorityIndex::new_for_test(2)));
+    }
+
+    #[tokio::test]
+    async fn test_select_allowed_leaders_returns_only_good_stake() {
+        // Threshold 80% with total_stake=4 gives a cutoff of 3; the three
+        // lowest-score authorities accumulate exactly 3 stake and are filtered
+        // from the allowed list. Only the single highest-score authority
+        // remains.
+        let (mut ctx, _) = Context::new_for_test(4);
+        ctx.protocol_config
+            .set_bad_nodes_stake_threshold_for_testing(80);
+        let context = Arc::new(ctx);
+        let schedule = LeaderScheduleV3::new(context, 1, vec![10, 0, 1, 2]);
+
+        let allowed = schedule.select_allowed_leaders_with_fixed_config();
+        assert_eq!(allowed, vec![AuthorityIndex::new_for_test(0)]);
+    }
+
+    #[tokio::test]
+    async fn test_select_allowed_leaders_seed_varies_per_epoch_at_init() {
+        use std::collections::HashSet;
+
+        // At epoch start every authority's score is zero. The bad-nodes 30% cutoff
+        // with equal stakes filters exactly one of the tied authorities; which one
+        // depends on the shuffle seed. The same authority shouldn't be permanently filtered.
+        let zero_scores = vec![0u64; 4];
+        let mut allowed_sets: HashSet<Vec<AuthorityIndex>> = HashSet::new();
+        for &(epoch, ts) in &[(0u64, 0u64), (1, 1_000), (2, 2_000), (5, 5_000)] {
+            let (committee, _) = local_committee_and_keys(epoch, vec![1, 1, 1, 1]);
+            let (mut ctx, _) = Context::new_for_test(4);
+            ctx = ctx
+                .with_committee(committee)
+                .with_epoch_start_timestamp_ms(ts);
+            ctx.protocol_config
+                .set_bad_nodes_stake_threshold_for_testing(30);
+            let context = Arc::new(ctx);
+            let schedule = LeaderScheduleV3::new(context, 1, zero_scores.clone());
+            let allowed = schedule.select_allowed_leaders_with_fixed_config();
+            // Sanity: 30% cutoff filters exactly one of four equal-stake authorities.
+            assert_eq!(allowed.len(), 3);
+            allowed_sets.insert(allowed);
+        }
+        assert!(
+            allowed_sets.len() >= 2,
+            "expected per-epoch seed variance to produce at least 2 distinct \
+             allowed-leader outputs across (epoch, timestamp) pairs, \
+             got {}: {:?}",
+            allowed_sets.len(),
+            allowed_sets
+        );
+    }
+
+    #[tokio::test]
+    async fn test_replay_length() {
+        let (mut ctx, _) = Context::new_for_test(4);
+        ctx.protocol_config
+            .set_leader_schedule_running_length_for_testing(5);
+        let context = Arc::new(ctx);
+        assert_eq!(LeaderScheduleV3::replay_length(&context), 7);
+    }
+
+    #[tokio::test]
+    async fn test_recovery_replay_produces_same_state_as_live() {
+        // Invariant behind the `+2` recovery rule: replaying only the last
+        // `running_length + 2` commits produces the same v3 state as feeding
+        // the full history live, because earlier commits would have been
+        // evicted anyway. We simulate it without going through storage by
+        // stepping two schedules through identical `add_commit` sequences.
+
+        let (mut ctx, _) = Context::new_for_test(4);
+        ctx.protocol_config
+            .set_leader_schedule_running_length_for_testing(5);
+        let context = Arc::new(ctx);
+
+        // Uniform chain: rounds 1..=10, authorities 0 and 1 produce blocks
+        // at each round linking back to both of the previous round's blocks.
+        let mut blocks_by_round: Vec<Vec<VerifiedBlock>> = Vec::new();
+        blocks_by_round.push(vec![make_block(1, 0, vec![]), make_block(1, 1, vec![])]);
+        for round in 2..=10u32 {
+            let prev = &blocks_by_round[(round - 2) as usize];
+            let ancestors: Vec<_> = prev.iter().map(|b| b.reference()).collect();
+            blocks_by_round.push(vec![
+                make_block(round, 0, ancestors.clone()),
+                make_block(round, 1, ancestors),
+            ]);
+        }
+        let commit_at = |i: CommitIndex, brs: &[Vec<VerifiedBlock>]| -> CommittedSubDag {
+            let blocks = brs[(i - 1) as usize].clone();
+            let leader = blocks[0].reference();
+            make_commit(i, leader, blocks)
+        };
+
+        // Live path: feed commits 1..=10 into a fresh schedule starting at index 1.
+        let mut live = LeaderScheduleV3::new(context.clone(), 1, vec![0; 4]);
+        for i in 1..=10 {
+            live.add_commit(commit_at(i, &blocks_by_round));
+        }
+        assert_eq!(live.scores_entry_len(), 5);
+        assert_eq!(live.pending_commits_len(), 2);
+
+        // Recovery path: replay only the last `running_length + 2 = 7`
+        // commits (indices 4..=10) into a fresh schedule starting at index 4.
+        let replay_count = LeaderScheduleV3::replay_length(&context);
+        assert_eq!(replay_count, 7);
+        let mut replayed = LeaderScheduleV3::new(context.clone(), 4, vec![0; 4]);
+        for i in 4..=10 {
+            replayed.add_commit(commit_at(i, &blocks_by_round));
+        }
+
+        // The two schedules must be indistinguishable from the outside.
+        assert_eq!(
+            live.total_scores_per_authority(),
+            replayed.total_scores_per_authority()
+        );
+        assert_eq!(live.scores_entry_len(), replayed.scores_entry_len());
+        assert_eq!(live.pending_commits_len(), replayed.pending_commits_len());
+        assert_eq!(live.average_num_leaders(), replayed.average_num_leaders());
+        assert_eq!(
+            live.average_leader_stakes(),
+            replayed.average_leader_stakes()
+        );
+        // Selection is also seeded off the same pending commit, so the
+        // authority ordering must match.
+        let live_next = live.next_commit_leader_schedule();
+        let replay_next = replayed.next_commit_leader_schedule();
+        assert_eq!(live_next.next_commit_index, replay_next.next_commit_index);
+        assert_eq!(
+            live_next.min_next_leader_round,
+            replay_next.min_next_leader_round
+        );
+        assert_eq!(live_next.num_leaders, replay_next.num_leaders);
+        assert_eq!(live_next.allowed_leaders, replay_next.allowed_leaders);
+    }
+
+    #[tokio::test]
+    async fn test_select_is_deterministic_for_same_commit_index() {
+        // Same state + same next_commit_index produces the same ordering on
+        // every call.
+        let (mut ctx, _) = Context::new_for_test(4);
+        ctx.protocol_config
+            .set_num_leaders_per_round_for_testing(Some(4));
+        ctx.protocol_config
+            .set_bad_nodes_stake_threshold_for_testing(0);
+        let context = Arc::new(ctx);
+        let schedule = LeaderScheduleV3::new(context, 42, vec![1, 2, 3, 4]);
+        let first = schedule.next_commit_leader_schedule();
+        let second = schedule.next_commit_leader_schedule();
+        assert_eq!(first.allowed_leaders, second.allowed_leaders);
+    }
+
+    #[tokio::test]
+    async fn test_authority_with_no_votes_scores_zero() {
+        let context = setup(4);
+        let mut schedule = LeaderScheduleV3::new(context.clone(), 1, vec![0; 4]);
+
+        let b0 = make_block(1, 0, vec![]);
+        let b1 = make_block(1, 1, vec![]);
+        schedule.add_commit(make_commit(1, b0.reference(), vec![b0.clone(), b1.clone()]));
+
+        // Commit 2 has only authority 0's vote block at round 2 (linking to B0).
+        let v0_c1 = make_block(2, 0, vec![b0.reference()]);
+        schedule.add_commit(make_commit(2, v0_c1.reference(), vec![v0_c1.clone()]));
+
+        // Commit 3 has no round-2 vote blocks — just a round-3 leader.
+        let leader3 = make_block(3, 1, vec![v0_c1.reference()]);
+        schedule.add_commit(make_commit(3, leader3.reference(), vec![leader3.clone()]));
+
+        // When processing commit 3: r = 1 (C-2's leader round), vote round = 2.
+        // Vote blocks at round 2 in {C, C-1} = {v0_c1}. Authority 0 links to B0,
+        // so score[0] = stake(0). Authorities 1, 2, 3 have no round-2 vote
+        // blocks, so they score 0.
+        let s0 = context.committee.stake(AuthorityIndex::new_for_test(0));
+        assert_eq!(schedule.total_scores_per_authority()[0], s0);
+        assert_eq!(schedule.total_scores_per_authority()[1], 0);
+        assert_eq!(schedule.total_scores_per_authority()[2], 0);
+        assert_eq!(schedule.total_scores_per_authority()[3], 0);
+    }
+}

--- a/consensus/core/src/leader_schedule_v3.rs
+++ b/consensus/core/src/leader_schedule_v3.rs
@@ -13,11 +13,14 @@ use rand::{SeedableRng, prelude::SliceRandom, rngs::StdRng};
 
 use crate::{
     CommitIndex, CommitRef, CommittedSubDag, DagState,
-    block::{BlockAPI, GENESIS_ROUND, VerifiedBlock},
+    block::{BlockAPI, VerifiedBlock},
     commit::{CommitRange, load_committed_subdag_from_store},
     context::Context,
     leader_scoring::ReputationScores,
 };
+
+// Max pending commits kept for scoring.
+const MAX_PENDING_COMMITS: usize = 3;
 
 /// Incremental, sliding-window leader scorer over recent commits.
 ///
@@ -46,7 +49,6 @@ use crate::{
 /// The overall score for A is `score[A] = voted_for_stake[A] * certified_by_stake[A]`.
 pub(crate) struct LeaderScheduleV3 {
     context: Arc<Context>,
-    next_commit_index: CommitIndex,
     // Total scores per authority in the running window, indexed by AuthorityIndex.
     // Each scored commit contributes `voted_for_stake[A] * certified_by_stake[A]`
     // (stake² units) per authority A, summed across the running window.
@@ -64,46 +66,15 @@ pub(crate) struct LeaderScheduleV3 {
     // Score entries are produced once 3 commits have accumulated; on each
     // subsequent `add_commit`, the oldest is evicted and a new commit appended.
     pending_commits: VecDeque<CommittedSubDag>,
-    // One entry per scored commit still in the running window. Used to
-    // subtract a commit's contributions from `total_scores_per_authority` on
-    // eviction. Bounded by `leader_schedule_window_size`.
+    // One entry per scored commit in the running window.
+    // Used to subtract a commit's contributions from `total_scores_per_authority`
+    // on eviction. Bounded by `leader_schedule_window_size`.
     scores_entries: VecDeque<ScoresEntry>,
-    // Most recent schedule to return to the proposer. The commit index and
+    // Leader schedule for the current commit interval. The commit index and
     // minimum round move every commit; leader selection changes only at
-    // configured rotation boundaries.
-    cached_schedule: NextCommitLeaderSchedule,
+    // configured interval boundaries.
+    current_schedule: NextCommitLeaderSchedule,
 }
-
-/// This is used by the commit rule to figure out the next commit leaders.
-#[derive(Clone, Debug, Default)]
-pub(crate) struct NextCommitLeaderSchedule {
-    // Index of the next commit.
-    pub(crate) next_commit_index: CommitIndex,
-    // Minimum round of the next commit leader.
-    pub(crate) min_next_leader_round: Round,
-    // Number of leaders to select per round.
-    pub(crate) num_leaders: usize,
-    // Authorities allowed to be leaders.
-    pub(crate) allowed_leaders: Vec<AuthorityIndex>,
-}
-
-struct ScoresEntry {
-    // CommitRef of the scored commit (the C-3-equivalent: oldest pending commit
-    // at the time the entry was produced).
-    commit_ref: CommitRef,
-    // Per-authority incremental score contributed by the scored commit, indexed
-    // by AuthorityIndex. Retained so eviction can subtract from
-    // `total_scores_per_authority`.
-    score_contributions: Vec<u64>,
-    // Number of leader blocks in the scored commit. Retained so
-    // eviction can subtract from `total_num_leaders`.
-    num_leaders: usize,
-    // `Σ stake(leader_authors)` for the scored commit. Retained so eviction
-    // can subtract from `total_leader_stakes`.
-    leader_stakes: u64,
-}
-
-const MAX_PENDING_COMMITS: usize = 3;
 
 impl LeaderScheduleV3 {
     /// Constructs a `LeaderScheduleV3`.
@@ -114,18 +85,17 @@ impl LeaderScheduleV3 {
         dag_state: Arc<RwLock<DagState>>,
     ) -> LeaderScheduleV3 {
         let committee_size = context.committee.size();
-        let last_commit_index = dag_state.read().last_commit_index();
-        if last_commit_index == 0 {
-            return LeaderScheduleV3::new(context, 1, vec![0; committee_size]);
-        }
+        let mut leader_schedule = LeaderScheduleV3::new(context.clone(), vec![0; committee_size]);
 
+        let last_commit_index = dag_state.read().last_commit_index();
         let replay_count = LeaderScheduleV3::replay_length(&context);
         // Replay maximum replay_count commits, and starting from commit 1 at minimum.
         let replay_start = last_commit_index.saturating_sub(replay_count) + 1;
-        // The first replayed commit's index will be replay_start, so initializing next_commit_index
-        // to replay_start.
-        let mut leader_schedule =
-            LeaderScheduleV3::new(context.clone(), replay_start, vec![0; committee_size]);
+        if replay_start > last_commit_index {
+            // No commits to replay, return the new schedule with empty state.
+            return leader_schedule;
+        }
+
         let store = dag_state.read().store();
         let commits = store
             .scan_commits((replay_start..=last_commit_index).into())
@@ -137,63 +107,69 @@ impl LeaderScheduleV3 {
         leader_schedule
     }
 
-    pub(crate) fn new(
-        context: Arc<Context>,
-        next_commit_index: CommitIndex,
-        total_scores_per_authority: Vec<u64>,
-    ) -> Self {
+    pub(crate) fn new(context: Arc<Context>, total_scores_per_authority: Vec<u64>) -> Self {
         assert_eq!(total_scores_per_authority.len(), context.committee.size());
-        let running_length = context.protocol_config.leader_schedule_window_size() as usize;
+        let window_size = context.protocol_config.leader_schedule_window_size() as usize;
         let mut schedule = Self {
             context,
-            next_commit_index,
             total_scores_per_authority,
             total_num_leaders: 0,
             total_leader_stakes: 0,
             pending_commits: VecDeque::with_capacity(MAX_PENDING_COMMITS),
-            scores_entries: VecDeque::with_capacity(running_length),
-            cached_schedule: NextCommitLeaderSchedule::default(),
+            scores_entries: VecDeque::with_capacity(window_size),
+            current_schedule: NextCommitLeaderSchedule::default(),
         };
-        schedule.cached_schedule = schedule.compute_next_commit_leader_schedule();
+        schedule.current_schedule = schedule.compute_next_commit_leader_schedule();
         schedule
+    }
+
+    /// Index of the next commit to be added — one past the last commit in
+    /// `pending_commits`, or 1 if none have been added yet.
+    pub(crate) fn next_commit_index(&self) -> CommitIndex {
+        self.pending_commits
+            .back()
+            .map(|c| c.commit_ref.index)
+            .unwrap_or(0)
+            + 1
+    }
+
+    /// Minimum round the next commit's leader can be at — one past the leader
+    /// round of the last commit in `pending_commits`, or 1 if none have been
+    /// added yet.
+    pub(crate) fn min_next_leader_round(&self) -> Round {
+        self.pending_commits
+            .back()
+            .map(|c| c.leader.round)
+            .unwrap_or(0)
+            + 1
     }
 
     /// Number of recent committed sub-dags that must be replayed on startup
     /// to reconstruct the full state: `leader_schedule_window_size` for the
     /// scoring window, the pending commits held before scoring begins, and
-    /// enough additional commits to reconstruct the cached schedule boundary.
+    /// `interval - 1` more so the replay spans back to the most recent rotation
+    /// boundary with the full scoring window already populated.
     fn replay_length(context: &Context) -> u32 {
         context.protocol_config.leader_schedule_window_size()
             + MAX_PENDING_COMMITS as u32
-            + context
-                .protocol_config
-                .leader_schedule_update_interval()
-                .saturating_sub(1)
+            + context.protocol_config.leader_schedule_update_interval()
+            - 1
     }
 
-    /// Returns the cached leader schedule. See `cached_schedule` for what
+    /// Returns the current leader schedule. See `current_schedule` for what
     /// is refreshed every commit vs. only on rotation boundaries.
     pub(crate) fn next_commit_leader_schedule(&self) -> NextCommitLeaderSchedule {
-        self.cached_schedule.clone()
+        self.current_schedule.clone()
     }
 
     pub(crate) fn compute_next_commit_leader_schedule(&self) -> NextCommitLeaderSchedule {
-        let min_next_leader_round = self
-            .pending_commits
-            .back()
-            .map(|c| c.leader.round)
-            .unwrap_or(GENESIS_ROUND)
-            + 1;
-        let num_leaders = self
-            .context
-            .protocol_config
-            .num_leaders_per_round()
-            .unwrap_or(1);
+        let allowed_leaders = self.select_allowed_leaders_with_fixed_config();
+        let num_leaders = allowed_leaders.len();
         NextCommitLeaderSchedule {
-            next_commit_index: self.next_commit_index,
-            min_next_leader_round,
+            next_commit_index: self.next_commit_index(),
+            min_next_leader_round: self.min_next_leader_round(),
             num_leaders,
-            allowed_leaders: self.select_allowed_leaders_with_fixed_config(),
+            allowed_leaders,
         }
     }
 
@@ -239,7 +215,6 @@ impl LeaderScheduleV3 {
         // Use stable sort to produce deterministic order of authorities with the same score.
         by_score.sort_by(|a, b| b.1.cmp(&a.1));
 
-        // A bad threshold of 0 will select all authorities.
         let mut accumulated_bad_stake = 0u64;
         let cutoff = (self.context.protocol_config.bad_nodes_stake_threshold()
             * self.context.committee.total_stake())
@@ -266,15 +241,18 @@ impl LeaderScheduleV3 {
     /// to satisfy both the r+1 voting-block scan and the r+2 certifying-block
     /// scan (some commit in [C-2, C-1, c] satisfies each `>` bound).
     pub(crate) fn add_commit(&mut self, c: CommittedSubDag) {
-        // Ensure commits are added in order.
-        assert_eq!(c.commit_ref.index, self.next_commit_index);
-        self.next_commit_index += 1;
+        // Ensure commits are added in order. On the very first call there is
+        // no prior commit to check against; once we have one, every subsequent
+        // commit must be consecutive.
+        if let Some(last) = self.pending_commits.back() {
+            assert_eq!(c.commit_ref.index, last.commit_ref.index + 1);
+        }
 
         // Need C-3, C-2, C-1 in pending before producing a score entry.
         // Until then, this is warmup (new instance, new epoch, or recovery).
         if self.pending_commits.len() < MAX_PENDING_COMMITS {
             self.pending_commits.push_back(c);
-            self.refresh_cached_schedule();
+            self.refresh_current_schedule();
             self.report_metrics();
             return;
         }
@@ -286,9 +264,7 @@ impl LeaderScheduleV3 {
         let vote_round = leader_round + 1;
         let certify_round = leader_round + 2;
 
-        // Architectural invariant check. Depth 3 is only enough to bracket
-        // both scan ranges if consecutive commits have strictly increasing
-        // leader rounds; trip loudly if upstream stops upholding this.
+        // Scoring logic assumes strictly increasing leader rounds across consecutive commits.
         assert!(
             c_minus_3.leader.round < c_minus_2.leader.round
                 && c_minus_2.leader.round < c_minus_1.leader.round
@@ -301,8 +277,8 @@ impl LeaderScheduleV3 {
             c.leader.round,
         );
 
-        // leader_refs: every round-r block in C-3. A commit may legitimately
-        // contain multiple round-r leader blocks; all of them count.
+        // Every block in leader round is a leader block. A commit may
+        // contain one or multiple leader blocks.
         let leader_refs: BTreeSet<BlockRef> = c_minus_3
             .blocks
             .iter()
@@ -310,9 +286,7 @@ impl LeaderScheduleV3 {
             .map(|b| b.reference())
             .collect();
 
-        // C-3's leader is by construction in C-3.blocks at round r, so it
-        // must show up in leader_refs. A failure here points at an
-        // malformed CommittedSubDag.
+        // A failure here points at an malformed CommittedSubDag.
         assert!(!leader_refs.is_empty());
         assert!(
             leader_refs.contains(&c_minus_3.leader),
@@ -322,13 +296,14 @@ impl LeaderScheduleV3 {
         );
 
         // Walk [C-2, C-1, C] up to and including the first commit whose
-        // leader round exceeds each bound.
+        // leader round exceeds each bound. The cut off is chosen to exclude
+        // blocks that are produced late relative to the current highest round.
         let voting_commits =
             Self::scan_commits_until_leader_round_above(&self.pending_commits, &c, vote_round);
         let certifying_commits =
             Self::scan_commits_until_leader_round_above(&self.pending_commits, &c, certify_round);
 
-        // Group r+1 voting blocks by author; len() != 1 detects equivocation.
+        // Group round r+1 voting blocks by author.
         let mut voting_blocks_by_author: BTreeMap<AuthorityIndex, Vec<&VerifiedBlock>> =
             BTreeMap::new();
         for cmt in &voting_commits {
@@ -358,15 +333,15 @@ impl LeaderScheduleV3 {
             }
             let voting_block = voting_blocks[0];
 
-            // voted_for_stake[A]: distinct P authorities whose round-r block
-            // in C-3 is an ancestor of A's voting block.
-            let mut ps = BTreeSet::<AuthorityIndex>::new();
+            // voted_for_stake[A]: distinct authorities whose leader block
+            // in C-3 is voted by A's voting block.
+            let mut leader_authorities = BTreeSet::<AuthorityIndex>::new();
             for anc in voting_block.ancestors() {
                 if leader_refs.contains(anc) {
-                    ps.insert(anc.author);
+                    leader_authorities.insert(anc.author);
                 }
             }
-            let voted_for_stake: u64 = ps
+            let voted_for_stake: u64 = leader_authorities
                 .into_iter()
                 .map(|i| self.context.committee.stake(i))
                 .sum();
@@ -375,16 +350,16 @@ impl LeaderScheduleV3 {
                 continue;
             }
 
-            // certified_by_stake[A]: distinct Q authorities whose r+2 block
+            // certified_by_stake[A]: distinct authorities whose round r+2 block
             // certifies A's voting block (has it as an ancestor).
             let voting_block_ref = voting_block.reference();
-            let mut qs = BTreeSet::<AuthorityIndex>::new();
-            for q_block in &certifying_blocks {
-                if q_block.ancestors().contains(&voting_block_ref) {
-                    qs.insert(q_block.author());
+            let mut certifying_authorities = BTreeSet::<AuthorityIndex>::new();
+            for certifying_block in &certifying_blocks {
+                if certifying_block.ancestors().contains(&voting_block_ref) {
+                    certifying_authorities.insert(certifying_block.author());
                 }
             }
-            let certified_by_stake: u64 = qs
+            let certified_by_stake: u64 = certifying_authorities
                 .into_iter()
                 .map(|i| self.context.committee.stake(i))
                 .sum();
@@ -399,9 +374,7 @@ impl LeaderScheduleV3 {
             .map(|block_ref| self.context.committee.stake(block_ref.author))
             .sum();
 
-        // All inputs validated and computed; eviction can now happen
-        // immediately before pushing the new entry.
-        while self.scores_entries.len() >= self.running_length() {
+        while self.scores_entries.len() >= self.window_size() {
             let evicted = self.scores_entries.pop_front().expect("non empty");
             tracing::trace!(
                 "LeaderScheduleV3 evicting scored commit {} from running window",
@@ -436,37 +409,31 @@ impl LeaderScheduleV3 {
             leader_stakes,
         });
 
-        // Rotate pending: drop C-3, keep C-2 and C-1, append c.
+        // Rotate pending commits: drop C-3, keep C-2 and C-1, append c.
         self.pending_commits.pop_front();
         self.pending_commits.push_back(c);
 
-        self.refresh_cached_schedule();
+        self.refresh_current_schedule();
         self.report_metrics();
     }
 
-    fn refresh_cached_schedule(&mut self) {
+    fn refresh_current_schedule(&mut self) {
         let interval = self
             .context
             .protocol_config
             .leader_schedule_update_interval() as CommitIndex;
-        let on_boundary = interval == 0
-            || self
-                .next_commit_index
-                .saturating_sub(1)
-                .is_multiple_of(interval);
+        let on_boundary = self
+            .next_commit_index()
+            .saturating_sub(1)
+            .is_multiple_of(interval);
         if on_boundary {
             // Boundary: full recompute, including allowed_leaders.
-            self.cached_schedule = self.compute_next_commit_leader_schedule();
+            self.current_schedule = self.compute_next_commit_leader_schedule();
         } else {
             // Off-boundary: only the per-commit fields move; skip the
             // expensive allowed-leaders selection.
-            self.cached_schedule.next_commit_index = self.next_commit_index;
-            self.cached_schedule.min_next_leader_round = self
-                .pending_commits
-                .back()
-                .map(|c| c.leader.round)
-                .unwrap_or(GENESIS_ROUND)
-                + 1;
+            self.current_schedule.next_commit_index = self.next_commit_index();
+            self.current_schedule.min_next_leader_round = self.min_next_leader_round();
         }
     }
 
@@ -497,12 +464,14 @@ impl LeaderScheduleV3 {
 
     /// Snapshot of the running per-authority scores.
     pub(crate) fn current_reputation_scores(&self) -> ReputationScores {
-        let commit_range = match (self.scores_entries.front(), self.scores_entries.back()) {
-            (Some(front), Some(back)) => {
-                CommitRange::new(front.commit_ref.index..=back.commit_ref.index)
-            }
-            _ => CommitRange::default(),
-        };
+        let interval_size = self
+            .context
+            .protocol_config
+            .leader_schedule_update_interval();
+        let interval_num = (self.current_schedule.next_commit_index - 1) / interval_size;
+        let commit_range = CommitRange::new(
+            (interval_num * interval_size + 1)..=(interval_num + 1) * interval_size,
+        );
         ReputationScores::new(commit_range, self.total_scores_per_authority.clone())
     }
 
@@ -549,7 +518,7 @@ impl LeaderScheduleV3 {
         }
     }
 
-    fn running_length(&self) -> usize {
+    fn window_size(&self) -> usize {
         self.context.protocol_config.leader_schedule_window_size() as usize
     }
 
@@ -586,6 +555,33 @@ impl LeaderScheduleV3 {
     }
 }
 
+/// This is used by the commit rule to figure out the next commit leaders.
+#[derive(Clone, Debug, Default)]
+pub(crate) struct NextCommitLeaderSchedule {
+    // Index of the next commit.
+    pub(crate) next_commit_index: CommitIndex,
+    // Informs the committer about the minimum round of the next commit leader.
+    pub(crate) min_next_leader_round: Round,
+    // Number of leaders to select per round.
+    pub(crate) num_leaders: usize,
+    // Authorities allowed to be leaders.
+    pub(crate) allowed_leaders: Vec<AuthorityIndex>,
+}
+
+struct ScoresEntry {
+    // CommitRef of the oldest pending commit at the time the entry was produced.
+    commit_ref: CommitRef,
+    // Per-authority incremental score indexed by AuthorityIndex.
+    // Retained so eviction can subtract from `total_scores_per_authority`.
+    score_contributions: Vec<u64>,
+    // Number of leader blocks in the commit.
+    // Retained so eviction can subtract from `total_num_leaders`.
+    num_leaders: usize,
+    // `Σ stake(leader_authors)` from this commit's leaders.
+    // Retained so eviction can subtract from `total_leader_stakes`.
+    leader_stakes: u64,
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
@@ -601,15 +597,12 @@ mod tests {
     };
 
     fn setup(committee_size: usize) -> Arc<Context> {
-        setup_with_running_length(committee_size, None)
+        setup_with_window_size(committee_size, None)
     }
 
-    fn setup_with_running_length(
-        committee_size: usize,
-        running_length: Option<u32>,
-    ) -> Arc<Context> {
+    fn setup_with_window_size(committee_size: usize, window_size: Option<u32>) -> Arc<Context> {
         let (mut context, _) = Context::new_for_test(committee_size);
-        if let Some(len) = running_length {
+        if let Some(len) = window_size {
             context
                 .protocol_config
                 .set_leader_schedule_window_size_for_testing(len);
@@ -664,10 +657,35 @@ mod tests {
             .collect()
     }
 
+    fn assert_current_schedule_matches_computed(schedule: &LeaderScheduleV3) {
+        let current = schedule.next_commit_leader_schedule();
+        let computed = schedule.compute_next_commit_leader_schedule();
+        assert_eq!(current.next_commit_index, computed.next_commit_index);
+        assert_eq!(
+            current.min_next_leader_round,
+            computed.min_next_leader_round
+        );
+        assert_eq!(current.num_leaders, computed.num_leaders);
+        assert_eq!(current.allowed_leaders, computed.allowed_leaders);
+    }
+
+    fn assert_current_reputation_range(
+        schedule: &LeaderScheduleV3,
+        start: CommitIndex,
+        end: CommitIndex,
+    ) {
+        let scores = schedule.current_reputation_scores();
+        assert_eq!(scores.commit_range, CommitRange::new(start..=end));
+        assert_eq!(
+            scores.scores_per_authority.as_slice(),
+            schedule.total_scores_per_authority()
+        );
+    }
+
     #[tokio::test]
     async fn test_new_state_is_zero() {
         let context = setup(4);
-        let schedule = LeaderScheduleV3::new(context, 1, vec![0; 4]);
+        let schedule = LeaderScheduleV3::new(context, vec![0; 4]);
         assert_eq!(schedule.total_scores_per_authority(), &[0u64; 4]);
         assert_eq!(schedule.scores_entries_len(), 0);
         assert_eq!(schedule.pending_commits_len(), 0);
@@ -677,10 +695,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_first_three_commits_score_zero() {
-        // The new rule needs C-3, C-2, C-1 in pending before producing the
+        // Scoring logic needs C-3, C-2, C-1 in pending before producing the
         // first score entry, so the first three commits are warmup.
         let context = setup(4);
-        let mut schedule = LeaderScheduleV3::new(context, 1, vec![0; 4]);
+        let mut schedule = LeaderScheduleV3::new(context, vec![0; 4]);
 
         let leader1 = make_block(1, 0, vec![]);
         schedule.add_commit(make_commit(1, leader1.reference(), vec![leader1.clone()]));
@@ -709,7 +727,7 @@ mod tests {
         // Voting blocks live at round 2 in C2, certifying blocks at round 3 in
         // C3, and C4 acts as the > r+2 sentinel.
         let context = setup(4);
-        let mut schedule = LeaderScheduleV3::new(context.clone(), 1, vec![0; 4]);
+        let mut schedule = LeaderScheduleV3::new(context.clone(), vec![0; 4]);
 
         // C1: leader = L0_1 (auth 0); blocks include L1_1 too, so leader_refs
         // for C-3 = {L0_1, L1_1}.
@@ -771,13 +789,13 @@ mod tests {
     async fn test_eviction_subtracts_contributions() {
         // Uniform chain: rounds 1..=8, two authorities (0 and 1) producing
         // blocks at each round and linking to both of the previous round's
-        // blocks. With `running_length=3` and the new rule, the first score
+        // blocks. With `window_size=3` and the new rule, the first score
         // entry lands when commit 4 is added, the window fills at commit 6,
         // and commit 7 evicts the earliest entry. Because every scored commit
         // contributes an identical delta, post-eviction totals equal
         // pre-eviction totals — proving eviction is subtracting correctly.
-        let context = setup_with_running_length(4, Some(3));
-        let mut schedule = LeaderScheduleV3::new(context.clone(), 1, vec![0; 4]);
+        let context = setup_with_window_size(4, Some(3));
+        let mut schedule = LeaderScheduleV3::new(context.clone(), vec![0; 4]);
 
         let mut blocks_by_round: Vec<Vec<VerifiedBlock>> = Vec::new();
         blocks_by_round.push(vec![make_block(1, 0, vec![]), make_block(1, 1, vec![])]);
@@ -829,23 +847,21 @@ mod tests {
     #[tokio::test]
     async fn test_select_returns_next_commit_index_and_requested_count() {
         // With the default threshold disabled, no authority is "bad", so the
-        // full randomized order is available and selection returns exactly
-        // `num_leaders` authorities. The returned CommitIndex echoes the one
-        // supplied to `new`.
+        // full randomized order is available and `num_leaders` equals the
+        // committee size. With no pending commits, the returned CommitIndex
+        // is the default 1.
         let (mut ctx, _) = Context::new_for_test(4);
-        ctx.protocol_config
-            .set_num_leaders_per_round_for_testing(Some(3));
         ctx.protocol_config
             .set_bad_nodes_stake_threshold_for_testing(0);
         let context = Arc::new(ctx);
-        let schedule = LeaderScheduleV3::new(context, 7, vec![5, 10, 0, 2]);
+        let schedule = LeaderScheduleV3::new(context, vec![5, 10, 0, 2]);
         let next = schedule.compute_next_commit_leader_schedule();
-        assert_eq!(next.next_commit_index, 7);
-        // No pending commits -> min_next_leader_round is GENESIS_ROUND + 1.
+        assert_eq!(next.next_commit_index, 1);
+        // No pending commits -> min_next_leader_round defaults to 1.
         assert_eq!(next.min_next_leader_round, 1);
-        assert_eq!(next.num_leaders, 3);
         // Threshold is 0, so every authority is allowed.
         assert_eq!(next.allowed_leaders.len(), 4);
+        assert_eq!(next.num_leaders, next.allowed_leaders.len());
         // The allowed-leaders list is a permutation of distinct authorities.
         let mut sorted = next.allowed_leaders.clone();
         sorted.sort();
@@ -854,55 +870,73 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_select_skips_bad_nodes() {
-        // 4 equal-stake authorities. Threshold 30% with total_stake=4 gives a
-        // cutoff of 1; the single lowest-score authority (a1, score 0) is
-        // filtered out of the allowed-leaders list. The remaining 3 must not
-        // include it, regardless of the randomized order.
-        let (mut ctx, _) = Context::new_for_test(4);
-        ctx.protocol_config
-            .set_bad_nodes_stake_threshold_for_testing(30);
-        let context = Arc::new(ctx);
-        let schedule = LeaderScheduleV3::new(context.clone(), 1, vec![100, 0, 100, 100]);
+    async fn test_select_allowed_leaders_threshold_cases() {
+        struct Case {
+            name: &'static str,
+            stakes: Vec<u64>,
+            scores: Vec<u64>,
+            threshold: u64,
+            expected_len: usize,
+            excluded: Vec<u32>,
+            exact_allowed: Option<Vec<u32>>,
+        }
 
-        let allowed = schedule.select_allowed_leaders_with_fixed_config();
-        assert_eq!(allowed.len(), 3);
-        assert!(!allowed.contains(&AuthorityIndex::new_for_test(1)));
-    }
+        let cases = [
+            Case {
+                name: "filters single lowest equal-stake authority",
+                stakes: vec![1; 4],
+                scores: vec![100, 0, 100, 100],
+                threshold: 30,
+                expected_len: 3,
+                excluded: vec![1],
+                exact_allowed: None,
+            },
+            Case {
+                name: "does not exceed stake threshold",
+                stakes: vec![2500; 4],
+                scores: vec![10, 0, 1, 2],
+                threshold: 30,
+                expected_len: 3,
+                excluded: vec![1],
+                exact_allowed: None,
+            },
+            Case {
+                name: "only highest score remains",
+                stakes: vec![1; 4],
+                scores: vec![10, 0, 1, 2],
+                threshold: 80,
+                expected_len: 1,
+                excluded: vec![1, 2, 3],
+                exact_allowed: Some(vec![0]),
+            },
+        ];
 
-    #[tokio::test]
-    async fn test_select_bad_nodes_does_not_exceed_stake_threshold() {
-        // 4 equal-stake authorities with total stake 10,000. A 30% threshold
-        // permits excluding one 2,500-stake authority, but excluding the next
-        // one would cross the 3,000-stake cutoff.
-        let (mut ctx, _) = Context::new_for_test(4);
-        let (committee, _) = local_committee_and_keys(0, vec![2500; 4]);
-        ctx = ctx.with_committee(committee);
-        ctx.protocol_config
-            .set_bad_nodes_stake_threshold_for_testing(30);
-        let context = Arc::new(ctx);
-        let schedule = LeaderScheduleV3::new(context, 1, vec![10, 0, 1, 2]);
+        for case in cases {
+            let (mut ctx, _) = Context::new_for_test(case.stakes.len());
+            let (committee, _) = local_committee_and_keys(0, case.stakes);
+            ctx = ctx.with_committee(committee);
+            ctx.protocol_config
+                .set_bad_nodes_stake_threshold_for_testing(case.threshold);
+            let context = Arc::new(ctx);
+            let schedule = LeaderScheduleV3::new(context, case.scores);
 
-        let allowed = schedule.select_allowed_leaders_with_fixed_config();
-        assert_eq!(allowed.len(), 3);
-        assert!(!allowed.contains(&AuthorityIndex::new_for_test(1)));
-        assert!(allowed.contains(&AuthorityIndex::new_for_test(2)));
-    }
-
-    #[tokio::test]
-    async fn test_select_allowed_leaders_returns_only_good_stake() {
-        // Threshold 80% with total_stake=4 gives a cutoff of 3; the three
-        // lowest-score authorities accumulate exactly 3 stake and are filtered
-        // from the allowed list. Only the single highest-score authority
-        // remains.
-        let (mut ctx, _) = Context::new_for_test(4);
-        ctx.protocol_config
-            .set_bad_nodes_stake_threshold_for_testing(80);
-        let context = Arc::new(ctx);
-        let schedule = LeaderScheduleV3::new(context, 1, vec![10, 0, 1, 2]);
-
-        let allowed = schedule.select_allowed_leaders_with_fixed_config();
-        assert_eq!(allowed, vec![AuthorityIndex::new_for_test(0)]);
+            let allowed = schedule.select_allowed_leaders_with_fixed_config();
+            assert_eq!(allowed.len(), case.expected_len, "{}", case.name);
+            for excluded in case.excluded {
+                assert!(
+                    !allowed.contains(&AuthorityIndex::new_for_test(excluded)),
+                    "{}: unexpectedly allowed authority {excluded}",
+                    case.name
+                );
+            }
+            if let Some(exact_allowed) = case.exact_allowed {
+                let expected = exact_allowed
+                    .into_iter()
+                    .map(AuthorityIndex::new_for_test)
+                    .collect::<Vec<_>>();
+                assert_eq!(allowed, expected, "{}", case.name);
+            }
+        }
     }
 
     #[tokio::test]
@@ -923,7 +957,7 @@ mod tests {
             ctx.protocol_config
                 .set_bad_nodes_stake_threshold_for_testing(30);
             let context = Arc::new(ctx);
-            let schedule = LeaderScheduleV3::new(context, 1, zero_scores.clone());
+            let schedule = LeaderScheduleV3::new(context, zero_scores.clone());
             let allowed = schedule.select_allowed_leaders_with_fixed_config();
             // Sanity: 30% cutoff filters exactly one of four equal-stake authorities.
             assert_eq!(allowed.len(), 3);
@@ -942,7 +976,7 @@ mod tests {
     #[tokio::test]
     async fn test_replay_length() {
         // Replay covers scored entries, pending commits, and enough additional
-        // history to reconstruct the cached schedule at the last rotation.
+        // history to reconstruct the current schedule at the last rotation.
         let (mut ctx, _) = Context::new_for_test(4);
         ctx.protocol_config
             .set_leader_schedule_window_size_for_testing(5);
@@ -961,6 +995,45 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_current_reputation_scores_uses_effective_interval_one_for_zero() {
+        let (mut ctx, _) = Context::new_for_test(4);
+        ctx.protocol_config
+            .set_leader_schedule_update_interval_for_testing(0);
+        let context = Arc::new(ctx);
+        let mut schedule = LeaderScheduleV3::new(context, vec![1, 2, 3, 4]);
+        let commits = make_uniform_chain_commits(2);
+
+        assert_current_reputation_range(&schedule, 1, 1);
+        schedule.add_commit(commits[0].clone());
+        assert_current_reputation_range(&schedule, 2, 2);
+        schedule.add_commit(commits[1].clone());
+        assert_current_reputation_range(&schedule, 3, 3);
+    }
+
+    #[tokio::test]
+    async fn test_current_reputation_scores_interval_boundaries() {
+        let (mut ctx, _) = Context::new_for_test(4);
+        ctx.protocol_config
+            .set_leader_schedule_update_interval_for_testing(12);
+        let context = Arc::new(ctx);
+        let mut schedule = LeaderScheduleV3::new(context, vec![1, 2, 3, 4]);
+        let commits = make_uniform_chain_commits(12);
+
+        assert_eq!(schedule.next_commit_leader_schedule().next_commit_index, 1);
+        assert_current_reputation_range(&schedule, 1, 12);
+
+        for commit in commits.iter().take(11) {
+            schedule.add_commit(commit.clone());
+        }
+        assert_eq!(schedule.next_commit_leader_schedule().next_commit_index, 12);
+        assert_current_reputation_range(&schedule, 1, 12);
+
+        schedule.add_commit(commits[11].clone());
+        assert_eq!(schedule.next_commit_leader_schedule().next_commit_index, 13);
+        assert_current_reputation_range(&schedule, 13, 24);
+    }
+
+    #[tokio::test]
     async fn test_recovery_replay_produces_same_state_as_live() {
         let (mut ctx, _) = Context::new_for_test(4);
         ctx.protocol_config
@@ -972,7 +1045,7 @@ mod tests {
         let commits = make_uniform_chain_commits(23);
 
         // Live path: feed all commits into a fresh schedule starting at index 1.
-        let mut live = LeaderScheduleV3::new(context.clone(), 1, vec![0; 4]);
+        let mut live = LeaderScheduleV3::new(context.clone(), vec![0; 4]);
         for commit in &commits {
             live.add_commit(commit.clone());
         }
@@ -984,7 +1057,7 @@ mod tests {
         let last_commit_index = commits.last().unwrap().commit_ref.index;
         let replay_start = last_commit_index.saturating_sub(replay_count) + 1;
         assert_eq!(replay_start, 5);
-        let mut replayed = LeaderScheduleV3::new(context.clone(), replay_start, vec![0; 4]);
+        let mut replayed = LeaderScheduleV3::new(context.clone(), vec![0; 4]);
         for commit in commits.iter().skip((replay_start - 1) as usize).cloned() {
             replayed.add_commit(commit);
         }
@@ -1022,7 +1095,7 @@ mod tests {
         ctx.protocol_config
             .set_bad_nodes_stake_threshold_for_testing(0);
         let context = Arc::new(ctx);
-        let schedule = LeaderScheduleV3::new(context, 42, vec![1, 2, 3, 4]);
+        let schedule = LeaderScheduleV3::new(context, vec![1, 2, 3, 4]);
         let first = schedule.compute_next_commit_leader_schedule();
         let second = schedule.compute_next_commit_leader_schedule();
         assert_eq!(first.allowed_leaders, second.allowed_leaders);
@@ -1034,7 +1107,7 @@ mod tests {
         ctx.protocol_config
             .set_leader_schedule_update_interval_for_testing(12);
         let context = Arc::new(ctx);
-        let mut schedule = LeaderScheduleV3::new(context, 1, vec![0; 4]);
+        let mut schedule = LeaderScheduleV3::new(context, vec![0; 4]);
         let commits = make_uniform_chain_commits(12);
 
         let initial = schedule.next_commit_leader_schedule();
@@ -1053,59 +1126,38 @@ mod tests {
         assert_eq!(before_boundary.allowed_leaders, initial.allowed_leaders);
 
         schedule.add_commit(commits[11].clone());
-        let on_boundary = schedule.next_commit_leader_schedule();
-        let computed_on_boundary = schedule.compute_next_commit_leader_schedule();
-        assert_eq!(on_boundary.next_commit_index, 13);
-        assert_eq!(
-            on_boundary.min_next_leader_round,
-            computed_on_boundary.min_next_leader_round
-        );
-        assert_eq!(on_boundary.num_leaders, computed_on_boundary.num_leaders);
-        assert_eq!(
-            on_boundary.allowed_leaders,
-            computed_on_boundary.allowed_leaders
-        );
+        assert_eq!(schedule.next_commit_leader_schedule().next_commit_index, 13);
+        // On boundary: cached schedule was just fully recomputed.
+        assert_current_schedule_matches_computed(&schedule);
     }
 
     #[tokio::test]
-    async fn test_interval_zero_refreshes_every_commit() {
-        let (mut ctx, _) = Context::new_for_test(4);
-        ctx.protocol_config
-            .set_leader_schedule_update_interval_for_testing(0);
-        let context = Arc::new(ctx);
-        let mut schedule = LeaderScheduleV3::new(context, 1, vec![0; 4]);
-        let commits = make_uniform_chain_commits(2);
+    async fn test_effective_interval_one_refreshes_full_schedule_every_commit() {
+        for interval in [0, 1] {
+            let (mut ctx, _) = Context::new_for_test(4);
+            ctx.protocol_config
+                .set_leader_schedule_update_interval_for_testing(interval);
+            let context = Arc::new(ctx);
+            let mut schedule = LeaderScheduleV3::new(context, vec![0; 4]);
+            let commits = make_uniform_chain_commits(4);
 
-        schedule.add_commit(commits[0].clone());
-        assert_eq!(schedule.next_commit_leader_schedule().next_commit_index, 2);
-        schedule.add_commit(commits[1].clone());
-        assert_eq!(schedule.next_commit_leader_schedule().next_commit_index, 3);
+            assert_current_schedule_matches_computed(&schedule);
+            for commit in commits {
+                schedule.add_commit(commit);
+                assert_current_schedule_matches_computed(&schedule);
+            }
+        }
     }
 
     #[tokio::test]
-    async fn test_interval_one_refreshes_every_commit() {
-        let (mut ctx, _) = Context::new_for_test(4);
-        ctx.protocol_config
-            .set_leader_schedule_update_interval_for_testing(1);
-        let context = Arc::new(ctx);
-        let mut schedule = LeaderScheduleV3::new(context, 1, vec![0; 4]);
-        let commits = make_uniform_chain_commits(2);
-
-        schedule.add_commit(commits[0].clone());
-        assert_eq!(schedule.next_commit_leader_schedule().next_commit_index, 2);
-        schedule.add_commit(commits[1].clone());
-        assert_eq!(schedule.next_commit_leader_schedule().next_commit_index, 3);
-    }
-
-    #[tokio::test]
-    async fn test_recovery_cache_matches_live_before_first_rotation_boundary() {
+    async fn test_recovery_matches_live_before_first_rotation_boundary() {
         let (mut ctx, _) = Context::new_for_test(4);
         ctx.protocol_config
             .set_leader_schedule_update_interval_for_testing(12);
         let context = Arc::new(ctx);
         let commits = make_uniform_chain_commits(5);
 
-        let mut live = LeaderScheduleV3::new(context.clone(), 1, vec![0; 4]);
+        let mut live = LeaderScheduleV3::new(context.clone(), vec![0; 4]);
         for commit in &commits {
             live.add_commit(commit.clone());
         }
@@ -1114,7 +1166,7 @@ mod tests {
         let last_commit_index = commits.last().unwrap().commit_ref.index;
         let replay_start = last_commit_index.saturating_sub(replay_count) + 1;
         assert_eq!(replay_start, 1);
-        let mut replayed = LeaderScheduleV3::new(context, replay_start, vec![0; 4]);
+        let mut replayed = LeaderScheduleV3::new(context, vec![0; 4]);
         for commit in commits {
             replayed.add_commit(commit);
         }
@@ -1133,7 +1185,7 @@ mod tests {
         //   (b) A has a voting block but no r+2 block certifies it →
         //       certified_by_stake = 0, multiplicative score = 0.
         let context = setup(4);
-        let mut schedule = LeaderScheduleV3::new(context.clone(), 1, vec![0; 4]);
+        let mut schedule = LeaderScheduleV3::new(context.clone(), vec![0; 4]);
 
         // C1: round-1 leader blocks for authorities 0 and 1.
         let l0_1 = make_block(1, 0, vec![]);
@@ -1187,7 +1239,7 @@ mod tests {
         // by equivocation. Correct behavior: C4 isn't in the voting range, so
         // auth 1 has exactly one voting block (in C3) and score is nonzero.
         let context = setup(4);
-        let mut schedule = LeaderScheduleV3::new(context.clone(), 1, vec![0; 4]);
+        let mut schedule = LeaderScheduleV3::new(context.clone(), vec![0; 4]);
 
         let l0_1 = make_block(1, 0, vec![]);
         schedule.add_commit(make_commit(1, l0_1.reference(), vec![l0_1.clone()]));
@@ -1236,7 +1288,7 @@ mod tests {
         // sentinel. Place a round-3 block in C4 (as ancestor of C4's round-4
         // leader) and verify it contributes to certified_by_stake.
         let context = setup(4);
-        let mut schedule = LeaderScheduleV3::new(context.clone(), 1, vec![0; 4]);
+        let mut schedule = LeaderScheduleV3::new(context.clone(), vec![0; 4]);
 
         let l0_1 = make_block(1, 0, vec![]);
         schedule.add_commit(make_commit(1, l0_1.reference(), vec![l0_1.clone()]));
@@ -1280,7 +1332,7 @@ mod tests {
         // were broken and the block were scanned for r+1, auth 2 would
         // accrue a nonzero score.
         let context = setup(4);
-        let mut schedule = LeaderScheduleV3::new(context.clone(), 1, vec![0; 4]);
+        let mut schedule = LeaderScheduleV3::new(context.clone(), vec![0; 4]);
 
         let l0_1 = make_block(1, 0, vec![]);
         schedule.add_commit(make_commit(1, l0_1.reference(), vec![l0_1.clone()]));
@@ -1332,7 +1384,7 @@ mod tests {
         // leader_refs is a multi-element set. A=3's voting block links all
         // three; voted_for_stake[3] must include all three stakes.
         let context = setup(4);
-        let mut schedule = LeaderScheduleV3::new(context.clone(), 1, vec![0; 4]);
+        let mut schedule = LeaderScheduleV3::new(context.clone(), vec![0; 4]);
 
         let l0_1 = make_block(1, 0, vec![]);
         let l1_1 = make_block(1, 1, vec![]);
@@ -1373,7 +1425,7 @@ mod tests {
         // Authority 0 produces two distinct round-2 voting blocks → score=0.
         // Authority 1 produces exactly one → score follows the formula.
         let context = setup(4);
-        let mut schedule = LeaderScheduleV3::new(context.clone(), 1, vec![0; 4]);
+        let mut schedule = LeaderScheduleV3::new(context.clone(), vec![0; 4]);
 
         let l0_1 = make_block(1, 0, vec![]);
         schedule.add_commit(make_commit(1, l0_1.reference(), vec![l0_1.clone()]));
@@ -1410,7 +1462,7 @@ mod tests {
         // from auths 1 and 3 certify A=0's voting block
         // (certified_by_stake = s1 + s3). Assert the exact product.
         let context = setup(4);
-        let mut schedule = LeaderScheduleV3::new(context.clone(), 1, vec![0; 4]);
+        let mut schedule = LeaderScheduleV3::new(context.clone(), vec![0; 4]);
 
         let l1_1 = make_block(1, 1, vec![]);
         let l2_1 = make_block(1, 2, vec![]);
@@ -1451,7 +1503,7 @@ mod tests {
         //   (b) A=0's voting block links a leader, but no r+2 block certifies
         //       it → certified_by_stake=0 → multiplicative zero.
         let context = setup(4);
-        let mut schedule = LeaderScheduleV3::new(context.clone(), 1, vec![0; 4]);
+        let mut schedule = LeaderScheduleV3::new(context.clone(), vec![0; 4]);
 
         let l0_1 = make_block(1, 0, vec![]);
         schedule.add_commit(make_commit(1, l0_1.reference(), vec![l0_1.clone()]));
@@ -1475,12 +1527,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_repeated_q_authority_counts_once() {
+    async fn test_repeated_certifying_authority_counts_once() {
         // Authority 1 produces two distinct round-3 certifying blocks (in C3
         // and C4) that both certify A=0's voting block. certified_by_stake[0]
         // must include stake(1) exactly once.
         let context = setup(4);
-        let mut schedule = LeaderScheduleV3::new(context.clone(), 1, vec![0; 4]);
+        let mut schedule = LeaderScheduleV3::new(context.clone(), vec![0; 4]);
 
         let l0_1 = make_block(1, 0, vec![]);
         schedule.add_commit(make_commit(1, l0_1.reference(), vec![l0_1.clone()]));

--- a/consensus/core/src/leader_schedule_v3.rs
+++ b/consensus/core/src/leader_schedule_v3.rs
@@ -7,13 +7,13 @@ use std::{
 };
 
 use consensus_config::AuthorityIndex;
-use consensus_types::block::Round;
+use consensus_types::block::{BlockRef, Round};
 use parking_lot::RwLock;
 use rand::{SeedableRng, prelude::SliceRandom, rngs::StdRng};
 
 use crate::{
     CommitIndex, CommitRef, CommittedSubDag, DagState,
-    block::{BlockAPI, GENESIS_ROUND},
+    block::{BlockAPI, GENESIS_ROUND, VerifiedBlock},
     commit::{CommitRange, load_committed_subdag_from_store},
     context::Context,
     leader_scoring::ReputationScores,
@@ -25,32 +25,49 @@ use crate::{
 /// running totals. When the running window is full, the oldest commit is evicted
 /// and its contributions are subtracted from the running totals.
 ///
-/// Scoring rule for commit C (requires `C >= 3` so that C-1 and C-2 are present):
-/// Let `r` be the leader round of commit C-2.
-/// For each authority A: consider A's blocks at round `r+1` ("voting block") across commits
-/// C and C-1.
-/// Collect the set of distinct authorities B, such that at least one of A's voting blocks
-/// vote to (has an ancestor that is) a B's round `r` ("leader block") block in commit C-2.
-/// Then `score[A] += sum_{B in distinct set} stake(B)`.
+/// Scoring rule for commit C:
+///
+/// When `C >= 4`, C-1, C-2 and C-3 exist as pending commits.
+/// Let `r` be the leader round of commit C-3.
+///
+/// For each authority A: consider A's block at round `r+1` (voting round) across commits
+/// from commit C-2 to commit with leader round > `r+1`.
+/// If there are multiple A blocks in this slot, `score[A] = 0`.
+///
+/// Collect the set of distinct authorities P, such that A's voting block votes to
+/// (has an ancestor link to) P's round `r` block (leader block) in commit C-3.
+/// Then `voted_for_stake[A] = sum_{P in distinct set} stake(P)`.
+///
+/// Collect the set of distinct authorities Q, such that a Q's round `r+2`
+/// block certifies (has an ancestor link to) A's voting block in round `r+1`,
+/// across commits from C-2 to commit with leader round > `r+2`.
+/// Then `certified_by_stake[A] = sum_{Q in distinct set} stake(Q)`.
+///
+/// The overall score for A is `score[A] = voted_for_stake[A] * certified_by_stake[A]`.
 pub(crate) struct LeaderScheduleV3 {
     context: Arc<Context>,
     next_commit_index: CommitIndex,
     // Total scores per authority in the running window, indexed by AuthorityIndex.
+    // Each scored commit contributes `voted_for_stake[A] * certified_by_stake[A]`
+    // (stake² units) per authority A, summed across the running window.
     total_scores_per_authority: Vec<u64>,
-    // Total number of leaders across the running window.
+    // Total number of leader-round blocks across the running window.
     // Used for metrics.
     total_num_leaders: usize,
-    // Total stake of leaders across the running window
-    // Used for metrics.
+    // Running sum of `Σ stake(leader_authors)` across the scored commits in
+    // the window. The normalized-score metric multiplies this by
+    // `committee.total_stake()` at report time to match the stake² units of
+    // `total_scores_per_authority`.
     total_leader_stakes: u64,
 
-    // Holds at most the last two committed subdags, used as C-2 and C-1
-    // when computing scores with leaders from C-3.
+    // Holds at most the last three committed subdags, for computing leader scores.
+    // Score entries are produced once 3 commits have accumulated; on each
+    // subsequent `add_commit`, the oldest is evicted and a new commit appended.
     pending_commits: VecDeque<CommittedSubDag>,
     // One entry per scored commit still in the running window. Used to
     // subtract a commit's contributions from `total_scores_per_authority` on
     // eviction. Bounded by `leader_schedule_window_size`.
-    scores_entry: VecDeque<ScoresEntry>,
+    scores_entries: VecDeque<ScoresEntry>,
 }
 
 /// This is used by the commit rule to figure out the next commit leaders.
@@ -60,24 +77,29 @@ pub(crate) struct NextCommitLeaderSchedule {
     pub(crate) next_commit_index: CommitIndex,
     // Minimum round of the next commit leader.
     pub(crate) min_next_leader_round: Round,
-    // Number of leaders to select.
+    // Number of leaders to select per round.
     pub(crate) num_leaders: usize,
-    // Allowed leaders to be selected from.
+    // Authorities allowed to be leaders.
     pub(crate) allowed_leaders: Vec<AuthorityIndex>,
 }
 
 struct ScoresEntry {
+    // CommitRef of the scored commit (the C-3-equivalent: oldest pending commit
+    // at the time the entry was produced).
     commit_ref: CommitRef,
-    // Per-authority incremental score contributed by processing this commit,
-    // indexed by AuthorityIndex. Retained so eviction can subtract it.
+    // Per-authority incremental score contributed by the scored commit, indexed
+    // by AuthorityIndex. Retained so eviction can subtract from
+    // `total_scores_per_authority`.
     score_contributions: Vec<u64>,
-    // Number of round `r` (leader) blocks in the scored commit (C-2).
-    // Retained so eviction can subtract it from `total_num_leaders`.
+    // Number of leader blocks in the scored commit. Retained so
+    // eviction can subtract from `total_num_leaders`.
     num_leaders: usize,
-    // Sum of stake(author) across all leader blocks in the scored commit.
-    // Retained so eviction can subtract it from `total_leader_stakes`.
+    // `Σ stake(leader_authors)` for the scored commit. Retained so eviction
+    // can subtract from `total_leader_stakes`.
     leader_stakes: u64,
 }
+
+const MAX_PENDING_COMMITS: usize = 3;
 
 impl LeaderScheduleV3 {
     /// Constructs a `LeaderScheduleV3`.
@@ -124,17 +146,17 @@ impl LeaderScheduleV3 {
             total_scores_per_authority,
             total_num_leaders: 0,
             total_leader_stakes: 0,
-            pending_commits: VecDeque::with_capacity(2),
-            scores_entry: VecDeque::with_capacity(running_length),
+            pending_commits: VecDeque::with_capacity(3),
+            scores_entries: VecDeque::with_capacity(running_length),
         }
     }
 
     /// Number of recent committed sub-dags that must be replayed on startup
-    /// to reconstruct the full state: `leader_schedule_window_size`
-    /// for the scoring window plus 2 for the pending commits held before
-    /// scoring begins.
+    /// to reconstruct the full state: `leader_schedule_window_size` for the
+    /// scoring window plus 3 for the pending commits held before scoring
+    /// begins.
     fn replay_length(context: &Context) -> u32 {
-        context.protocol_config.leader_schedule_window_size() + 2
+        context.protocol_config.leader_schedule_window_size() + MAX_PENDING_COMMITS as u32
     }
 
     /// Returns the leader schedule for the next commit.
@@ -222,25 +244,152 @@ impl LeaderScheduleV3 {
         by_score.into_iter().map(|(idx, _)| idx).collect()
     }
 
-    /// Scores a commit and adds it into the running window.
-    /// Evicts the oldest scored commit and drops its scores, if the window is full.
+    /// On each `add_commit(c)`, once 3 commits have accumulated, a score entry
+    /// corresponding to the front of `pending_commits` (the C-3-equivalent)
+    /// is produced; then C is appended to `pending_commits` and the front is
+    /// evicted. Evicts the oldest entry from the running window if full.
+    ///
+    /// Architectural contract: consecutive commits must have strictly
+    /// increasing leader rounds. Under the invariant, 3 commits are sufficient
+    /// to satisfy both the r+1 voting-block scan and the r+2 certifying-block
+    /// scan (some commit in [C-2, C-1, c] satisfies each `>` bound).
     pub(crate) fn add_commit(&mut self, c: CommittedSubDag) {
         // Ensure commits are added in order.
         assert_eq!(c.commit_ref.index, self.next_commit_index);
         self.next_commit_index += 1;
 
-        // There must be exactly 2 pending commits to compute the next scores.
-        // Otherwise, this is a new consensus instance (new epoch or recovery).
-        if self.pending_commits.len() < 2 {
+        // Need C-3, C-2, C-1 in pending before producing a score entry.
+        // Until then, this is warmup (new instance, new epoch, or recovery).
+        if self.pending_commits.len() < MAX_PENDING_COMMITS {
             self.pending_commits.push_back(c);
             self.report_metrics();
             return;
         }
 
-        // Keep at most `running_length - 1` commit scores so there is room to
-        // push one more below.
-        while self.scores_entry.len() >= self.running_length() {
-            let evicted = self.scores_entry.pop_front().expect("non empty");
+        let c_minus_3 = &self.pending_commits[0];
+        let c_minus_2 = &self.pending_commits[1];
+        let c_minus_1 = &self.pending_commits[2];
+        let leader_round = c_minus_3.leader.round;
+        let vote_round = leader_round + 1;
+        let certify_round = leader_round + 2;
+
+        // Architectural invariant check. Depth 3 is only enough to bracket
+        // both scan ranges if consecutive commits have strictly increasing
+        // leader rounds; trip loudly if upstream stops upholding this.
+        assert!(
+            c_minus_3.leader.round < c_minus_2.leader.round
+                && c_minus_2.leader.round < c_minus_1.leader.round
+                && c_minus_1.leader.round < c.leader.round,
+            "consecutive commits must have strictly increasing leader rounds; \
+             got {}, {}, {}, {}",
+            c_minus_3.leader.round,
+            c_minus_2.leader.round,
+            c_minus_1.leader.round,
+            c.leader.round,
+        );
+
+        // leader_refs: every round-r block in C-3. A commit may legitimately
+        // contain multiple round-r leader blocks; all of them count.
+        let leader_refs: BTreeSet<BlockRef> = c_minus_3
+            .blocks
+            .iter()
+            .filter(|b| b.round() == leader_round)
+            .map(|b| b.reference())
+            .collect();
+
+        // C-3's leader is by construction in C-3.blocks at round r, so it
+        // must show up in leader_refs. A failure here points at an
+        // malformed CommittedSubDag.
+        assert!(!leader_refs.is_empty());
+        assert!(
+            leader_refs.contains(&c_minus_3.leader),
+            "C-3's leader {} missing from its own leader blocks {:?}",
+            c_minus_3.leader,
+            leader_refs,
+        );
+
+        // Walk [C-2, C-1, C] up to and including the first commit whose
+        // leader round exceeds each bound.
+        let voting_commits =
+            Self::scan_commits_until_leader_round_above(&self.pending_commits, &c, vote_round);
+        let certifying_commits =
+            Self::scan_commits_until_leader_round_above(&self.pending_commits, &c, certify_round);
+
+        // Group r+1 voting blocks by author; len() != 1 detects equivocation.
+        let mut voting_blocks_by_author: BTreeMap<AuthorityIndex, Vec<&VerifiedBlock>> =
+            BTreeMap::new();
+        for cmt in &voting_commits {
+            for b in &cmt.blocks {
+                if b.round() == vote_round {
+                    voting_blocks_by_author
+                        .entry(b.author())
+                        .or_default()
+                        .push(b);
+                }
+            }
+        }
+        let mut certifying_blocks: Vec<&VerifiedBlock> = Vec::new();
+        for cmt in &certifying_commits {
+            for b in &cmt.blocks {
+                if b.round() == certify_round {
+                    certifying_blocks.push(b);
+                }
+            }
+        }
+
+        let mut score_contributions = vec![0u64; self.context.committee.size()];
+        for (a, voting_blocks) in &voting_blocks_by_author {
+            // Equivocation: more than one r+1 block from A → score[A] = 0.
+            if voting_blocks.len() != 1 {
+                continue;
+            }
+            let voting_block = voting_blocks[0];
+
+            // voted_for_stake[A]: distinct P authorities whose round-r block
+            // in C-3 is an ancestor of A's voting block.
+            let mut ps = BTreeSet::<AuthorityIndex>::new();
+            for anc in voting_block.ancestors() {
+                if leader_refs.contains(anc) {
+                    ps.insert(anc.author);
+                }
+            }
+            let voted_for_stake: u64 = ps
+                .into_iter()
+                .map(|i| self.context.committee.stake(i))
+                .sum();
+            // Product would be 0 anyway; skip the certifying-block scan.
+            if voted_for_stake == 0 {
+                continue;
+            }
+
+            // certified_by_stake[A]: distinct Q authorities whose r+2 block
+            // certifies A's voting block (has it as an ancestor).
+            let voting_block_ref = voting_block.reference();
+            let mut qs = BTreeSet::<AuthorityIndex>::new();
+            for q_block in &certifying_blocks {
+                if q_block.ancestors().contains(&voting_block_ref) {
+                    qs.insert(q_block.author());
+                }
+            }
+            let certified_by_stake: u64 = qs
+                .into_iter()
+                .map(|i| self.context.committee.stake(i))
+                .sum();
+
+            score_contributions[a.value()] =
+                voted_for_stake.checked_mul(certified_by_stake).unwrap();
+        }
+
+        let num_leaders = leader_refs.len();
+        let leader_stakes: u64 = leader_refs
+            .iter()
+            .map(|block_ref| self.context.committee.stake(block_ref.author))
+            .sum();
+
+        // All inputs validated and computed; eviction can now happen
+        // immediately before pushing the new entry.
+        while self.scores_entries.len() >= self.running_length() {
+            let evicted = self.scores_entries.pop_front().expect("non empty");
             tracing::trace!(
                 "LeaderScheduleV3 evicting scored commit {} from running window",
                 evicted.commit_ref
@@ -260,84 +409,55 @@ impl LeaderScheduleV3 {
                 .unwrap();
         }
 
-        // Compute score contributions for the new commit.
-        let c_minus_2 = &self.pending_commits[0];
-        let c_minus_1 = &self.pending_commits[1];
-
-        let leader_round = c_minus_2.leader.round;
-        let vote_round = leader_round + 1;
-
-        let leader_refs: BTreeSet<_> = c_minus_2
-            .blocks
-            .iter()
-            .filter(|b| b.round() == leader_round)
-            .map(|b| b.reference())
-            .collect();
-
-        let voting_blocks: Vec<_> = c_minus_1
-            .blocks
-            .iter()
-            .chain(c.blocks.iter())
-            .filter(|b| b.round() == vote_round)
-            .collect();
-
-        let mut score_contributions = vec![0u64; self.context.committee.size()];
-
-        if !voting_blocks.is_empty() && !leader_refs.is_empty() {
-            // Collect a map from authorities voting on leader blocks, to leader authorities they voted on.
-            // This consolidates votes and scores per authority.
-            let mut per_authority_votes: BTreeMap<AuthorityIndex, BTreeSet<AuthorityIndex>> =
-                BTreeMap::new();
-            for voting_block in voting_blocks {
-                let authority_votes = per_authority_votes
-                    .entry(voting_block.author())
-                    .or_default();
-                for voted_block in voting_block.ancestors() {
-                    if leader_refs.contains(voted_block) {
-                        authority_votes.insert(voted_block.author);
-                    }
-                }
-            }
-
-            for (voting_authority, leader_authorities) in per_authority_votes {
-                let total_leader_stake = leader_authorities
-                    .into_iter()
-                    .map(|i| self.context.committee.stake(i))
-                    .sum();
-                score_contributions[voting_authority.value()] = total_leader_stake;
-            }
-        }
-
-        // Add the contributions to the running totals.
         for (i, delta) in score_contributions.iter().enumerate() {
-            self.total_scores_per_authority[i] += *delta;
+            self.total_scores_per_authority[i] = self.total_scores_per_authority[i]
+                .checked_add(*delta)
+                .unwrap();
         }
-
-        // Record this commit's scores for future eviction.
-        let num_leaders = leader_refs.len();
-        let leader_stakes: u64 = leader_refs
-            .iter()
-            .map(|r| self.context.committee.stake(r.author))
-            .sum();
-        self.total_num_leaders += num_leaders;
-        self.total_leader_stakes += leader_stakes;
-        self.scores_entry.push_back(ScoresEntry {
-            commit_ref: c_minus_2.commit_ref,
+        self.total_num_leaders = self.total_num_leaders.checked_add(num_leaders).unwrap();
+        self.total_leader_stakes = self.total_leader_stakes.checked_add(leader_stakes).unwrap();
+        self.scores_entries.push_back(ScoresEntry {
+            commit_ref: c_minus_3.commit_ref,
             score_contributions,
             num_leaders,
             leader_stakes,
         });
 
-        // Rotate the pending commits: drop C-2, keep C-1, add C.
+        // Rotate pending: drop C-3, keep C-2 and C-1, append c.
         self.pending_commits.pop_front();
         self.pending_commits.push_back(c);
 
         self.report_metrics();
     }
 
+    /// Walks commits [C-2, C-1, C] in order.
+    /// Returning every commit up to and **including** the first one whose
+    /// leader round is strictly greater than `upper`.
+    fn scan_commits_until_leader_round_above<'a>(
+        pending: &'a VecDeque<CommittedSubDag>,
+        c: &'a CommittedSubDag,
+        upper: Round,
+    ) -> Vec<&'a CommittedSubDag> {
+        let mut out = Vec::new();
+        for cmt in pending.iter().skip(1).chain(std::iter::once(c)) {
+            out.push(cmt);
+            if cmt.leader.round > upper {
+                break;
+            }
+        }
+        assert!(
+            out.last()
+                .map(|cmt| cmt.leader.round > upper)
+                .unwrap_or(false),
+            "scan must end on a commit with leader.round > {upper}; \
+             strictly-increasing-leader-rounds invariant violated upstream",
+        );
+        out
+    }
+
     /// Snapshot of the running per-authority scores.
     pub(crate) fn current_reputation_scores(&self) -> ReputationScores {
-        let commit_range = match (self.scores_entry.front(), self.scores_entry.back()) {
+        let commit_range = match (self.scores_entries.front(), self.scores_entries.back()) {
             (Some(front), Some(back)) => {
                 CommitRange::new(front.commit_ref.index..=back.commit_ref.index)
             }
@@ -362,49 +482,52 @@ impl LeaderScheduleV3 {
                 .leader_schedule_total_scores
                 .with_label_values(&[hostname])
                 .set(*score as i64);
-            let normalized = if self.total_leader_stakes == 0 {
+            // Multiply at report time so the field stays raw `Σ stake(leaders)`
+            // and the metric formula divides stake² (numerator) by stake²
+            // (denominator) — i.e. a fraction with no stake dimension.
+            let denominator = self
+                .total_leader_stakes
+                .checked_mul(self.context.committee.total_stake())
+                .unwrap();
+            let normalized = if denominator == 0 {
                 0.0
             } else {
-                *score as f64 / self.total_leader_stakes as f64
+                *score as f64 / denominator as f64
             };
             metrics
                 .leader_schedule_normalized_scores
                 .with_label_values(&[hostname])
                 .set(normalized);
         }
-        if let Some(last) = self.scores_entry.back() {
+        if let Some(last) = self.scores_entries.back() {
             metrics
                 .leader_schedule_last_num_leaders
                 .set(last.num_leaders as i64);
+            metrics
+                .leader_schedule_average_num_leaders
+                .set(self.average_num_leaders());
         }
     }
 
     fn running_length(&self) -> usize {
-        self.context
-            .protocol_config
-            .leader_schedule_window_size() as usize
+        self.context.protocol_config.leader_schedule_window_size() as usize
     }
 
     /// Average number of leader-round blocks per scored commit in the current
     /// running window. Returns 0.0 when no commits have been scored yet.
-    #[cfg(test)]
     fn average_num_leaders(&self) -> f64 {
-        if self.scores_entry.is_empty() {
+        if self.scores_entries.is_empty() {
             0.0
         } else {
-            self.total_num_leaders as f64 / self.scores_entry.len() as f64
+            self.total_num_leaders as f64 / self.scores_entries.len() as f64
         }
     }
 
-    /// Average total leader stake per scored commit in the current running
-    /// window. Returns 0.0 when no commits have been scored yet.
+    /// Running sum of `Σ stake(leader_authors)` across the scored commits in
+    /// the current window.
     #[cfg(test)]
-    fn average_leader_stakes(&self) -> f64 {
-        if self.scores_entry.is_empty() {
-            0.0
-        } else {
-            self.total_leader_stakes as f64 / self.scores_entry.len() as f64
-        }
+    pub(crate) fn total_leader_stakes(&self) -> u64 {
+        self.total_leader_stakes
     }
 
     #[cfg(test)]
@@ -413,8 +536,8 @@ impl LeaderScheduleV3 {
     }
 
     #[cfg(test)]
-    pub(crate) fn scores_entry_len(&self) -> usize {
-        self.scores_entry.len()
+    pub(crate) fn scores_entries_len(&self) -> usize {
+        self.scores_entries.len()
     }
 
     #[cfg(test)]
@@ -484,101 +607,119 @@ mod tests {
         let context = setup(4);
         let schedule = LeaderScheduleV3::new(context, 1, vec![0; 4]);
         assert_eq!(schedule.total_scores_per_authority(), &[0u64; 4]);
-        assert_eq!(schedule.scores_entry_len(), 0);
+        assert_eq!(schedule.scores_entries_len(), 0);
         assert_eq!(schedule.pending_commits_len(), 0);
         assert_eq!(schedule.average_num_leaders(), 0.0);
-        assert_eq!(schedule.average_leader_stakes(), 0.0);
+        assert_eq!(schedule.total_leader_stakes(), 0);
     }
 
     #[tokio::test]
-    async fn test_first_two_commits_score_zero() {
+    async fn test_first_three_commits_score_zero() {
+        // The new rule needs C-3, C-2, C-1 in pending before producing the
+        // first score entry, so the first three commits are warmup.
         let context = setup(4);
         let mut schedule = LeaderScheduleV3::new(context, 1, vec![0; 4]);
 
         let leader1 = make_block(1, 0, vec![]);
         schedule.add_commit(make_commit(1, leader1.reference(), vec![leader1.clone()]));
         assert_eq!(schedule.total_scores_per_authority(), &[0u64; 4]);
-        assert_eq!(schedule.scores_entry_len(), 0);
+        assert_eq!(schedule.scores_entries_len(), 0);
         assert_eq!(schedule.pending_commits_len(), 1);
 
         let leader2 = make_block(2, 1, vec![leader1.reference()]);
         schedule.add_commit(make_commit(2, leader2.reference(), vec![leader2.clone()]));
         assert_eq!(schedule.total_scores_per_authority(), &[0u64; 4]);
-        assert_eq!(schedule.scores_entry_len(), 0);
+        assert_eq!(schedule.scores_entries_len(), 0);
         assert_eq!(schedule.pending_commits_len(), 2);
+
+        let leader3 = make_block(3, 2, vec![leader2.reference()]);
+        schedule.add_commit(make_commit(3, leader3.reference(), vec![leader3.clone()]));
+        assert_eq!(schedule.total_scores_per_authority(), &[0u64; 4]);
+        assert_eq!(schedule.scores_entries_len(), 0);
+        assert_eq!(schedule.pending_commits_len(), 3);
     }
 
     #[tokio::test]
-    async fn test_third_commit_scores_from_c_minus_2() {
+    async fn test_fourth_commit_scores_from_c_minus_3() {
+        // 4 commits with strictly increasing leader rounds (1, 2, 3, 4).
+        // C1 (the C-3-equivalent when scoring on C4) carries multiple round-1
+        // leader blocks, exercising "leader_refs = all round-r blocks in C-3".
+        // Voting blocks live at round 2 in C2, certifying blocks at round 3 in
+        // C3, and C4 acts as the > r+2 sentinel.
         let context = setup(4);
         let mut schedule = LeaderScheduleV3::new(context.clone(), 1, vec![0; 4]);
 
-        // Commit 1 (C-2): leader at round 1, authority 0. Blocks at round 1 from
-        // all four authorities (these are B-candidates at C-2 leader round).
-        let b0 = make_block(1, 0, vec![]);
-        let b1 = make_block(1, 1, vec![]);
-        let b2 = make_block(1, 2, vec![]);
-        let b3 = make_block(1, 3, vec![]);
+        // C1: leader = L0_1 (auth 0); blocks include L1_1 too, so leader_refs
+        // for C-3 = {L0_1, L1_1}.
+        let l0_1 = make_block(1, 0, vec![]);
+        let l1_1 = make_block(1, 1, vec![]);
         schedule.add_commit(make_commit(
             1,
-            b0.reference(),
-            vec![b0.clone(), b1.clone(), b2.clone(), b3.clone()],
+            l0_1.reference(),
+            vec![l0_1.clone(), l1_1.clone()],
         ));
 
-        // Commit 2 (C-1): two vote blocks at round 2 linking to commit 1 blocks.
-        // Authority 0's round-2 block links to B0 and B1 at round 1.
-        // Authority 1's round-2 block links to B2 only.
-        let v0_c1 = make_block(2, 0, vec![b0.reference(), b1.reference()]);
-        let v1_c1 = make_block(2, 1, vec![b2.reference()]);
-        schedule.add_commit(make_commit(
-            2,
-            v0_c1.reference(),
-            vec![v0_c1.clone(), v1_c1.clone()],
-        ));
-        // No scoring yet — we need C-2 to apply.
+        // C2: round-2 voting blocks for authorities 0 and 2.
+        //   v0 (auth 0) links L0_1 only.
+        //   v2 (auth 2) links L0_1 and L1_1.
+        let v0 = make_block(2, 0, vec![l0_1.reference()]);
+        let v2 = make_block(2, 2, vec![l0_1.reference(), l1_1.reference()]);
+        schedule.add_commit(make_commit(2, v0.reference(), vec![v0.clone(), v2.clone()]));
         assert_eq!(schedule.total_scores_per_authority(), &[0u64; 4]);
 
-        // Commit 3 (C): one vote block at round 2 (C-2's leader round was 1, so
-        // vote round = 2). Authority 2's round-2 block links to B1 and B3.
-        let v2_c = make_block(2, 2, vec![b1.reference(), b3.reference()]);
-        schedule.add_commit(make_commit(3, v2_c.reference(), vec![v2_c.clone()]));
+        // C3: round-3 certifying block q1 (auth 1) certifies v0 and v2.
+        let q1 = make_block(3, 1, vec![v0.reference(), v2.reference()]);
+        schedule.add_commit(make_commit(3, q1.reference(), vec![q1.clone()]));
 
-        // Expected contributions (equal stake per authority in new_for_test):
-        //   A=0: distinct Bs = {0, 1} → stake(0)+stake(1)
-        //   A=1: distinct Bs = {2}    → stake(2)
-        //   A=2: distinct Bs = {1, 3} → stake(1)+stake(3)
-        //   A=3: no vote blocks at round 2 → 0
+        // C4: leader at round 4. Add a round-3 block q3 (auth 3) certifying v0
+        // only — exercises "C4 (the inclusive r+2 sentinel) is searched too".
+        let q3 = make_block(3, 3, vec![v0.reference()]);
+        let lead4 = make_block(4, 0, vec![q1.reference()]);
+        schedule.add_commit(make_commit(
+            4,
+            lead4.reference(),
+            vec![lead4.clone(), q3.clone()],
+        ));
+
+        // Expected:
+        //   A=0: voting={v0}, voted_for_stake = s0 (links L0_1).
+        //        certifiers: q1 has v0 ancestor → qs={1}; q3 has v0 ancestor → qs={1,3}.
+        //        certified_by_stake = s1 + s3.   score[0] = s0 * (s1 + s3).
+        //   A=2: voting={v2}, voted_for_stake = s0 + s1 (links L0_1, L1_1).
+        //        certifiers: q1 has v2 → qs={1}; q3 doesn't → qs stays {1}.
+        //        certified_by_stake = s1.        score[2] = (s0 + s1) * s1.
+        //   A=1, A=3: no round-2 voting block → 0.
         let s0 = context.committee.stake(AuthorityIndex::new_for_test(0));
         let s1 = context.committee.stake(AuthorityIndex::new_for_test(1));
-        let s2 = context.committee.stake(AuthorityIndex::new_for_test(2));
         let s3 = context.committee.stake(AuthorityIndex::new_for_test(3));
         assert_eq!(
             schedule.total_scores_per_authority(),
-            &[s0 + s1, s2, s1 + s3, 0]
+            &[s0 * (s1 + s3), 0, (s0 + s1) * s1, 0]
         );
-        assert_eq!(schedule.scores_entry_len(), 1);
-        assert_eq!(schedule.pending_commits_len(), 2);
-        // C-2 (commit 1) has 4 leader-round blocks, so with one scored entry
-        // the average is 4.0 and the average leader stake equals the sum of
-        // all four authority stakes.
-        assert_eq!(schedule.average_num_leaders(), 4.0);
-        assert_eq!(schedule.average_leader_stakes(), (s0 + s1 + s2 + s3) as f64);
+        assert_eq!(schedule.scores_entries_len(), 1);
+        assert_eq!(schedule.pending_commits_len(), 3);
+        // C-3 (commit 1) has 2 leader-round blocks (auths 0 and 1) → average
+        // num_leaders=2, single scored entry contributes (s0 + s1) to the
+        // running total leader-stake.
+        assert_eq!(schedule.average_num_leaders(), 2.0);
+        assert_eq!(schedule.total_leader_stakes(), s0 + s1);
     }
 
     #[tokio::test]
     async fn test_eviction_subtracts_contributions() {
-        // Uniform chain: rounds 1..=6, two authorities (0 and 1) at each round,
-        // each round's blocks link to both blocks of the previous round.
-        // With `running_length=3`, scores_entry tops out at 3 entries; the
-        // 4th scored commit evicts the earliest. Because every scored commit
-        // contributes the same delta, post-eviction totals equal pre-eviction
-        // totals — which proves eviction is subtracting.
+        // Uniform chain: rounds 1..=8, two authorities (0 and 1) producing
+        // blocks at each round and linking to both of the previous round's
+        // blocks. With `running_length=3` and the new rule, the first score
+        // entry lands when commit 4 is added, the window fills at commit 6,
+        // and commit 7 evicts the earliest entry. Because every scored commit
+        // contributes an identical delta, post-eviction totals equal
+        // pre-eviction totals — proving eviction is subtracting correctly.
         let context = setup_with_running_length(4, Some(3));
         let mut schedule = LeaderScheduleV3::new(context.clone(), 1, vec![0; 4]);
 
         let mut blocks_by_round: Vec<Vec<VerifiedBlock>> = Vec::new();
         blocks_by_round.push(vec![make_block(1, 0, vec![]), make_block(1, 1, vec![])]);
-        for round in 2..=6u32 {
+        for round in 2..=7u32 {
             let prev = &blocks_by_round[(round - 2) as usize];
             let ancestors: Vec<_> = prev.iter().map(|b| b.reference()).collect();
             blocks_by_round.push(vec![
@@ -593,30 +734,34 @@ mod tests {
             make_commit(i, leader, blocks)
         };
 
-        for i in 1..=5 {
+        for i in 1..=6 {
             schedule.add_commit(commit(i, &blocks_by_round));
         }
-        let after_5 = schedule.total_scores_per_authority().to_vec();
-        assert_eq!(schedule.scores_entry_len(), 3);
+        let after_6 = schedule.total_scores_per_authority().to_vec();
+        // Window full: scored entries for C1, C2, C3.
+        assert_eq!(schedule.scores_entries_len(), 3);
 
-        // 3 scored commits in a uniform chain, each contributing
-        // `stake(0) + stake(1)` to authorities 0 and 1.
+        // Per-commit contribution to authority A in this uniform chain:
+        //   voted_for_stake[A]    = s0 + s1 (A's r+1 voting block links both leaders),
+        //   certified_by_stake[A] = s0 + s1 (both r+2 blocks certify A's voting block).
+        // → per_commit = (s0 + s1)^2 for authorities 0 and 1; 0 for 2 and 3.
         let s0 = context.committee.stake(AuthorityIndex::new_for_test(0));
         let s1 = context.committee.stake(AuthorityIndex::new_for_test(1));
-        let per_commit = s0 + s1;
-        assert_eq!(after_5, vec![3 * per_commit, 3 * per_commit, 0, 0]);
+        let per_commit = (s0 + s1) * (s0 + s1);
+        assert_eq!(after_6, vec![3 * per_commit, 3 * per_commit, 0, 0]);
 
-        schedule.add_commit(commit(6, &blocks_by_round));
-        assert_eq!(schedule.scores_entry_len(), 3);
-        // cs3 was evicted and cs6 added; both deltas are identical, so totals
-        // are unchanged. Had eviction not subtracted, totals would be 4 * per_commit.
-        assert_eq!(schedule.total_scores_per_authority().to_vec(), after_5);
-        // Every scored C-2 in this uniform chain has exactly 2 leader-round
-        // blocks from authorities 0 and 1; both averages are unaffected by
-        // eviction because each evicted entry's contributions are replaced
-        // by identical ones.
+        schedule.add_commit(commit(7, &blocks_by_round));
+        assert_eq!(schedule.scores_entries_len(), 3);
+        // C1's entry was evicted and C4's entry added; identical deltas leave
+        // totals unchanged. Had eviction not subtracted, totals would be
+        // 4 * per_commit.
+        assert_eq!(schedule.total_scores_per_authority().to_vec(), after_6);
+
+        // Each scored C-3 has exactly 2 leader-round blocks from auths 0/1;
+        // average_num_leaders=2.0 and the running leader-stake total is
+        // 3 entries × (s0 + s1) per commit.
         assert_eq!(schedule.average_num_leaders(), 2.0);
-        assert_eq!(schedule.average_leader_stakes(), (s0 + s1) as f64);
+        assert_eq!(schedule.total_leader_stakes(), 3 * (s0 + s1));
     }
 
     #[tokio::test]
@@ -734,17 +879,19 @@ mod tests {
 
     #[tokio::test]
     async fn test_replay_length() {
+        // Replay covers `leader_schedule_window_size` scored entries plus the
+        // 3 pending commits held before scoring kicks in.
         let (mut ctx, _) = Context::new_for_test(4);
         ctx.protocol_config
             .set_leader_schedule_window_size_for_testing(5);
         let context = Arc::new(ctx);
-        assert_eq!(LeaderScheduleV3::replay_length(&context), 7);
+        assert_eq!(LeaderScheduleV3::replay_length(&context), 8);
     }
 
     #[tokio::test]
     async fn test_recovery_replay_produces_same_state_as_live() {
-        // Invariant behind the `+2` recovery rule: replaying only the last
-        // `running_length + 2` commits produces the same v3 state as feeding
+        // Invariant behind the `+3` recovery rule: replaying only the last
+        // `running_length + 3` commits produces the same v3 state as feeding
         // the full history live, because earlier commits would have been
         // evicted anyway. We simulate it without going through storage by
         // stepping two schedules through identical `add_commit` sequences.
@@ -777,15 +924,17 @@ mod tests {
         for i in 1..=10 {
             live.add_commit(commit_at(i, &blocks_by_round));
         }
-        assert_eq!(live.scores_entry_len(), 5);
-        assert_eq!(live.pending_commits_len(), 2);
+        // 10 commits → score entries for C1..C7 (7 entries), capped at
+        // running_length=5 (entries for C3..C7); pending = [C8, C9, C10].
+        assert_eq!(live.scores_entries_len(), 5);
+        assert_eq!(live.pending_commits_len(), 3);
 
-        // Recovery path: replay only the last `running_length + 2 = 7`
-        // commits (indices 4..=10) into a fresh schedule starting at index 4.
+        // Recovery path: replay only the last `running_length + 3 = 8`
+        // commits (indices 3..=10) into a fresh schedule starting at index 3.
         let replay_count = LeaderScheduleV3::replay_length(&context);
-        assert_eq!(replay_count, 7);
-        let mut replayed = LeaderScheduleV3::new(context.clone(), 4, vec![0; 4]);
-        for i in 4..=10 {
+        assert_eq!(replay_count, 8);
+        let mut replayed = LeaderScheduleV3::new(context.clone(), 3, vec![0; 4]);
+        for i in 3..=10 {
             replayed.add_commit(commit_at(i, &blocks_by_round));
         }
 
@@ -794,13 +943,10 @@ mod tests {
             live.total_scores_per_authority(),
             replayed.total_scores_per_authority()
         );
-        assert_eq!(live.scores_entry_len(), replayed.scores_entry_len());
+        assert_eq!(live.scores_entries_len(), replayed.scores_entries_len());
         assert_eq!(live.pending_commits_len(), replayed.pending_commits_len());
         assert_eq!(live.average_num_leaders(), replayed.average_num_leaders());
-        assert_eq!(
-            live.average_leader_stakes(),
-            replayed.average_leader_stakes()
-        );
+        assert_eq!(live.total_leader_stakes(), replayed.total_leader_stakes());
         // Selection is also seeded off the same pending commit, so the
         // authority ordering must match.
         let live_next = live.next_commit_leader_schedule();
@@ -832,29 +978,383 @@ mod tests {
 
     #[tokio::test]
     async fn test_authority_with_no_votes_scores_zero() {
+        // Score-zero comes from two distinct paths under the new rule:
+        //   (a) no r+1 voting block from A → A skipped entirely.
+        //   (b) A has a voting block but no r+2 block certifies it →
+        //       certified_by_stake = 0, multiplicative score = 0.
         let context = setup(4);
         let mut schedule = LeaderScheduleV3::new(context.clone(), 1, vec![0; 4]);
 
-        let b0 = make_block(1, 0, vec![]);
-        let b1 = make_block(1, 1, vec![]);
-        schedule.add_commit(make_commit(1, b0.reference(), vec![b0.clone(), b1.clone()]));
+        // C1: round-1 leader blocks for authorities 0 and 1.
+        let l0_1 = make_block(1, 0, vec![]);
+        let l1_1 = make_block(1, 1, vec![]);
+        schedule.add_commit(make_commit(
+            1,
+            l0_1.reference(),
+            vec![l0_1.clone(), l1_1.clone()],
+        ));
 
-        // Commit 2 has only authority 0's vote block at round 2 (linking to B0).
-        let v0_c1 = make_block(2, 0, vec![b0.reference()]);
-        schedule.add_commit(make_commit(2, v0_c1.reference(), vec![v0_c1.clone()]));
+        // C2: round-2 voting blocks from authorities 0 and 1.
+        //   v0 links L0_1, v1 links L1_1.
+        let v0 = make_block(2, 0, vec![l0_1.reference()]);
+        let v1 = make_block(2, 1, vec![l1_1.reference()]);
+        schedule.add_commit(make_commit(2, v0.reference(), vec![v0.clone(), v1.clone()]));
 
-        // Commit 3 has no round-2 vote blocks — just a round-3 leader.
-        let leader3 = make_block(3, 1, vec![v0_c1.reference()]);
-        schedule.add_commit(make_commit(3, leader3.reference(), vec![leader3.clone()]));
+        // C3: round-3 certifying block q_to_v0 certifies v0 only — leaves v1
+        // uncertified.
+        let q_to_v0 = make_block(3, 1, vec![v0.reference()]);
+        schedule.add_commit(make_commit(3, q_to_v0.reference(), vec![q_to_v0.clone()]));
 
-        // When processing commit 3: r = 1 (C-2's leader round), vote round = 2.
-        // Vote blocks at round 2 in {C, C-1} = {v0_c1}. Authority 0 links to B0,
-        // so score[0] = stake(0). Authorities 1, 2, 3 have no round-2 vote
-        // blocks, so they score 0.
+        // C4: round-4 leader (the > r+2 sentinel for scoring C1).
+        let l0_4 = make_block(4, 0, vec![q_to_v0.reference()]);
+        schedule.add_commit(make_commit(4, l0_4.reference(), vec![l0_4.clone()]));
+
+        // Expected:
+        //   A=0: voting={v0}, voted_for_stake=s0; certifiers from q_to_v0 → qs={1},
+        //        certified_by_stake=s1.   score[0] = s0 * s1.
+        //   A=1: voting={v1}, voted_for_stake=s1; nothing certifies v1 →
+        //        certified_by_stake=0. score[1] = 0 (multiplicative-zero arm).
+        //   A=2, A=3: no voting block → 0 (skipped arm).
         let s0 = context.committee.stake(AuthorityIndex::new_for_test(0));
-        assert_eq!(schedule.total_scores_per_authority()[0], s0);
+        let s1 = context.committee.stake(AuthorityIndex::new_for_test(1));
+        assert_eq!(schedule.total_scores_per_authority()[0], s0 * s1);
         assert_eq!(schedule.total_scores_per_authority()[1], 0);
         assert_eq!(schedule.total_scores_per_authority()[2], 0);
         assert_eq!(schedule.total_scores_per_authority()[3], 0);
+    }
+
+    #[tokio::test]
+    async fn test_voting_scan_excludes_blocks_past_sentinel() {
+        // 4 commits with strictly increasing leader rounds (1, 2, 3, 4).
+        // When scoring C1: vote_round=2, certify_round=3.
+        //   voting_commits    scan stops at C3 (leader.round=3 > 2): [C2, C3].
+        //   certifying_commits scan stops at C4 (leader.round=4 > 3): [C2, C3, C4].
+        //
+        // Plant a round-2 voting block in C3 (inside the voting range) AND a
+        // sibling round-2 block from the same author L1_2_in_C4 in C4
+        // (outside the voting range). If the bound were broken and C4 were
+        // scanned for r+1, auth 1 would have two voting blocks and score 0
+        // by equivocation. Correct behavior: C4 isn't in the voting range, so
+        // auth 1 has exactly one voting block (in C3) and score is nonzero.
+        let context = setup(4);
+        let mut schedule = LeaderScheduleV3::new(context.clone(), 1, vec![0; 4]);
+
+        let l0_1 = make_block(1, 0, vec![]);
+        schedule.add_commit(make_commit(1, l0_1.reference(), vec![l0_1.clone()]));
+
+        let l0_2 = make_block(2, 0, vec![l0_1.reference()]);
+        schedule.add_commit(make_commit(2, l0_2.reference(), vec![l0_2.clone()]));
+
+        // C3 leader at round 3; pack a forged round-2 voting block from auth 1.
+        let l1_2_in_c3 = make_block(2, 1, vec![l0_1.reference()]);
+        let l0_3 = make_block(3, 0, vec![l0_2.reference(), l1_2_in_c3.reference()]);
+        schedule.add_commit(make_commit(
+            3,
+            l0_3.reference(),
+            vec![l0_3.clone(), l1_2_in_c3.clone()],
+        ));
+
+        // C4 leader at round 4. Pack ANOTHER round-2 block from auth 1 here —
+        // this one must NOT be scanned for r+1.
+        let l1_2_in_c4 = make_block(2, 1, vec![]);
+        let l0_4 = make_block(4, 0, vec![l0_3.reference()]);
+        schedule.add_commit(make_commit(
+            4,
+            l0_4.reference(),
+            vec![l0_4.clone(), l1_2_in_c4.clone()],
+        ));
+
+        // Expected (correct bound):
+        //   voting_blocks_by_author = {0: [l0_2], 1: [l1_2_in_c3]}.
+        //   A=0: voted_for_stake=s0, certifiers: l0_3 has l0_2 ancestor → qs={0},
+        //        certified_by_stake=s0. score[0] = s0*s0.
+        //   A=1: voted_for_stake=s0 (l1_2_in_c3 → l0_1), certifiers: l0_3 has
+        //        l1_2_in_c3 ancestor → qs={0}. certified_by_stake=s0.
+        //        score[1] = s0*s0.
+        // If C4 were scanned for r+1, auth 1 would have two voting blocks → 0.
+        let s0 = context.committee.stake(AuthorityIndex::new_for_test(0));
+        assert_eq!(schedule.total_scores_per_authority()[0], s0 * s0);
+        assert_eq!(schedule.total_scores_per_authority()[1], s0 * s0);
+        assert_eq!(schedule.total_scores_per_authority()[2], 0);
+        assert_eq!(schedule.total_scores_per_authority()[3], 0);
+    }
+
+    #[tokio::test]
+    async fn test_certifying_scan_includes_sentinel_block() {
+        // 4 commits with leader rounds 1, 2, 3, 4. When scoring C1, the
+        // certifying scan range is [C2, C3, C4] — C4 is the >r+2=3 inclusive
+        // sentinel. Place a round-3 block in C4 (as ancestor of C4's round-4
+        // leader) and verify it contributes to certified_by_stake.
+        let context = setup(4);
+        let mut schedule = LeaderScheduleV3::new(context.clone(), 1, vec![0; 4]);
+
+        let l0_1 = make_block(1, 0, vec![]);
+        schedule.add_commit(make_commit(1, l0_1.reference(), vec![l0_1.clone()]));
+
+        let l0_2 = make_block(2, 0, vec![l0_1.reference()]);
+        schedule.add_commit(make_commit(2, l0_2.reference(), vec![l0_2.clone()]));
+
+        let l0_3 = make_block(3, 0, vec![l0_2.reference()]);
+        schedule.add_commit(make_commit(3, l0_3.reference(), vec![l0_3.clone()]));
+
+        // C4: leader at round 4, plus a round-3 block from auth 2 carried as
+        // an ancestor. The round-3 block certifies l0_2, so it must show up
+        // in certified_by_stake[0] alongside l0_3.
+        let late_3 = make_block(3, 2, vec![l0_2.reference()]);
+        let l0_4 = make_block(4, 0, vec![l0_3.reference(), late_3.reference()]);
+        schedule.add_commit(make_commit(
+            4,
+            l0_4.reference(),
+            vec![l0_4.clone(), late_3.clone()],
+        ));
+
+        // Expected:
+        //   A=0: voting={l0_2}, voted_for_stake=s0.
+        //        certifying blocks at round 3 in [C2, C3, C4] = {l0_3, late_3};
+        //        both certify l0_2 → qs={0, 2}, certified_by_stake = s0 + s2.
+        //        score[0] = s0 * (s0 + s2).
+        let s0 = context.committee.stake(AuthorityIndex::new_for_test(0));
+        let s2 = context.committee.stake(AuthorityIndex::new_for_test(2));
+        assert_eq!(schedule.total_scores_per_authority()[0], s0 * (s0 + s2));
+    }
+
+    #[tokio::test]
+    async fn test_round_skip_collapses_voting_range() {
+        // 4 commits with leader rounds 1, 3, 4, 5 (round 2 skipped). When
+        // scoring C1: r=1, vote_round=2, certify_round=3.
+        //   voting_commits:    starts at C2 (leader.round=3 > 2) → range=[C2].
+        //   certifying_commits: C2 (3) ≤ 3 ok; C3 (4) > 3 stop → range=[C2, C3].
+        //
+        // Plant a round-2 block in C3 (auth 2) — outside the voting range,
+        // must NOT contribute. l0_3 (in C2) links to it so that, IF the bound
+        // were broken and the block were scanned for r+1, auth 2 would
+        // accrue a nonzero score.
+        let context = setup(4);
+        let mut schedule = LeaderScheduleV3::new(context.clone(), 1, vec![0; 4]);
+
+        let l0_1 = make_block(1, 0, vec![]);
+        schedule.add_commit(make_commit(1, l0_1.reference(), vec![l0_1.clone()]));
+
+        // C2: leader at round 3 (skipping round 2). Pack a round-2 voting
+        // block from auth 1 (inside the voting range).
+        let l1_2 = make_block(2, 1, vec![l0_1.reference()]);
+        let l2_2_in_c3 = make_block(2, 2, vec![l0_1.reference()]);
+        let l0_3 = make_block(
+            3,
+            0,
+            vec![l1_2.reference(), l2_2_in_c3.reference(), l0_1.reference()],
+        );
+        schedule.add_commit(make_commit(
+            2,
+            l0_3.reference(),
+            vec![l0_3.clone(), l1_2.clone()],
+        ));
+
+        // C3: leader at round 4. Pack the round-2 block from auth 2 here —
+        // outside the voting range; must be ignored.
+        let l0_4 = make_block(4, 0, vec![l0_3.reference()]);
+        schedule.add_commit(make_commit(
+            3,
+            l0_4.reference(),
+            vec![l0_4.clone(), l2_2_in_c3.clone()],
+        ));
+
+        // C4: leader at round 5.
+        let l0_5 = make_block(5, 0, vec![l0_4.reference()]);
+        schedule.add_commit(make_commit(4, l0_5.reference(), vec![l0_5.clone()]));
+
+        // Expected:
+        //   A=1: voted_for_stake=s0 (l1_2 → l0_1). certifiers: l0_3 has l1_2
+        //        ancestor → qs={0}. certified_by_stake=s0. score[1] = s0*s0.
+        //   A=2: NOT scanned (l2_2_in_c3 is in C3, which is not in voting range).
+        //        score[2] = 0. If the bound were broken, score[2] would be
+        //        s0*s0 (l2_2_in_c3 → l0_1, and l0_3 has l2_2_in_c3 ancestor).
+        let s0 = context.committee.stake(AuthorityIndex::new_for_test(0));
+        assert_eq!(schedule.total_scores_per_authority()[0], 0);
+        assert_eq!(schedule.total_scores_per_authority()[1], s0 * s0);
+        assert_eq!(schedule.total_scores_per_authority()[2], 0);
+        assert_eq!(schedule.total_scores_per_authority()[3], 0);
+    }
+
+    #[tokio::test]
+    async fn test_c_minus_3_with_multiple_round_r_leaders() {
+        // C-3 (= C1) packs three round-1 leader blocks (auths 0, 1, 2), so
+        // leader_refs is a multi-element set. A=3's voting block links all
+        // three; voted_for_stake[3] must include all three stakes.
+        let context = setup(4);
+        let mut schedule = LeaderScheduleV3::new(context.clone(), 1, vec![0; 4]);
+
+        let l0_1 = make_block(1, 0, vec![]);
+        let l1_1 = make_block(1, 1, vec![]);
+        let l2_1 = make_block(1, 2, vec![]);
+        schedule.add_commit(make_commit(
+            1,
+            l0_1.reference(),
+            vec![l0_1.clone(), l1_1.clone(), l2_1.clone()],
+        ));
+
+        // A=3 produces the round-2 voting block, linking all three leaders.
+        let v3 = make_block(
+            2,
+            3,
+            vec![l0_1.reference(), l1_1.reference(), l2_1.reference()],
+        );
+        schedule.add_commit(make_commit(2, v3.reference(), vec![v3.clone()]));
+
+        // A=0 produces a round-3 certifying block (q0) certifying v3.
+        let q0 = make_block(3, 0, vec![v3.reference()]);
+        schedule.add_commit(make_commit(3, q0.reference(), vec![q0.clone()]));
+
+        let l0_4 = make_block(4, 0, vec![q0.reference()]);
+        schedule.add_commit(make_commit(4, l0_4.reference(), vec![l0_4.clone()]));
+
+        let s0 = context.committee.stake(AuthorityIndex::new_for_test(0));
+        let s1 = context.committee.stake(AuthorityIndex::new_for_test(1));
+        let s2 = context.committee.stake(AuthorityIndex::new_for_test(2));
+        // voted_for_stake[3] = s0 + s1 + s2; certified_by_stake[3] = s0.
+        assert_eq!(
+            schedule.total_scores_per_authority()[3],
+            (s0 + s1 + s2) * s0
+        );
+    }
+
+    #[tokio::test]
+    async fn test_equivocation_zeros_voting_score() {
+        // Authority 0 produces two distinct round-2 voting blocks → score=0.
+        // Authority 1 produces exactly one → score follows the formula.
+        let context = setup(4);
+        let mut schedule = LeaderScheduleV3::new(context.clone(), 1, vec![0; 4]);
+
+        let l0_1 = make_block(1, 0, vec![]);
+        schedule.add_commit(make_commit(1, l0_1.reference(), vec![l0_1.clone()]));
+
+        // C2: pack two round-2 blocks from auth 0 (distinct ancestors → distinct
+        // refs) plus one from auth 1.
+        let v0_a = make_block(2, 0, vec![l0_1.reference()]);
+        let v0_b = make_block(2, 0, vec![]);
+        let v1 = make_block(2, 1, vec![l0_1.reference()]);
+        schedule.add_commit(make_commit(
+            2,
+            v0_a.reference(),
+            vec![v0_a.clone(), v0_b.clone(), v1.clone()],
+        ));
+
+        // C3: round-3 block from auth 0 certifying v1 (so certified_by_stake[1] > 0).
+        let q = make_block(3, 0, vec![v1.reference()]);
+        schedule.add_commit(make_commit(3, q.reference(), vec![q.clone()]));
+
+        let l0_4 = make_block(4, 0, vec![q.reference()]);
+        schedule.add_commit(make_commit(4, l0_4.reference(), vec![l0_4.clone()]));
+
+        // A=0 has two round-2 blocks → equivocation → score=0.
+        // A=1: voted_for_stake=s0, certified_by_stake=s0 → score=s0*s0.
+        let s0 = context.committee.stake(AuthorityIndex::new_for_test(0));
+        assert_eq!(schedule.total_scores_per_authority()[0], 0);
+        assert_eq!(schedule.total_scores_per_authority()[1], s0 * s0);
+    }
+
+    #[tokio::test]
+    async fn test_score_is_product_of_voted_for_and_certified_by_stake() {
+        // 4 authorities. A=0's voting block links {auth 1, auth 2} round-1
+        // leader blocks (voted_for_stake = s1 + s2); two distinct r+2 blocks
+        // from auths 1 and 3 certify A=0's voting block
+        // (certified_by_stake = s1 + s3). Assert the exact product.
+        let context = setup(4);
+        let mut schedule = LeaderScheduleV3::new(context.clone(), 1, vec![0; 4]);
+
+        let l1_1 = make_block(1, 1, vec![]);
+        let l2_1 = make_block(1, 2, vec![]);
+        schedule.add_commit(make_commit(
+            1,
+            l1_1.reference(),
+            vec![l1_1.clone(), l2_1.clone()],
+        ));
+
+        let v0 = make_block(2, 0, vec![l1_1.reference(), l2_1.reference()]);
+        schedule.add_commit(make_commit(2, v0.reference(), vec![v0.clone()]));
+
+        let q1 = make_block(3, 1, vec![v0.reference()]);
+        schedule.add_commit(make_commit(3, q1.reference(), vec![q1.clone()]));
+
+        let q3 = make_block(3, 3, vec![v0.reference()]);
+        let l_4 = make_block(4, 0, vec![q1.reference(), q3.reference()]);
+        schedule.add_commit(make_commit(
+            4,
+            l_4.reference(),
+            vec![l_4.clone(), q3.clone()],
+        ));
+
+        let s1 = context.committee.stake(AuthorityIndex::new_for_test(1));
+        let s2 = context.committee.stake(AuthorityIndex::new_for_test(2));
+        let s3 = context.committee.stake(AuthorityIndex::new_for_test(3));
+        assert_eq!(
+            schedule.total_scores_per_authority()[0],
+            (s1 + s2) * (s1 + s3)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_zero_voted_for_or_certified_by_stake_yields_zero() {
+        // Two zero-product paths under one fixture:
+        //   (a) A=1's voting block links no leader → voted_for_stake=0,
+        //       short-circuit skip.
+        //   (b) A=0's voting block links a leader, but no r+2 block certifies
+        //       it → certified_by_stake=0 → multiplicative zero.
+        let context = setup(4);
+        let mut schedule = LeaderScheduleV3::new(context.clone(), 1, vec![0; 4]);
+
+        let l0_1 = make_block(1, 0, vec![]);
+        schedule.add_commit(make_commit(1, l0_1.reference(), vec![l0_1.clone()]));
+
+        let v0 = make_block(2, 0, vec![l0_1.reference()]);
+        let v1_no_leader = make_block(2, 1, vec![]);
+        schedule.add_commit(make_commit(
+            2,
+            v0.reference(),
+            vec![v0.clone(), v1_no_leader.clone()],
+        ));
+
+        // C3: round-3 leader doesn't certify v0 (so certified_by_stake[0] = 0).
+        let l0_3 = make_block(3, 0, vec![]);
+        schedule.add_commit(make_commit(3, l0_3.reference(), vec![l0_3.clone()]));
+
+        let l0_4 = make_block(4, 0, vec![l0_3.reference()]);
+        schedule.add_commit(make_commit(4, l0_4.reference(), vec![l0_4.clone()]));
+
+        assert_eq!(schedule.total_scores_per_authority(), &[0u64; 4]);
+    }
+
+    #[tokio::test]
+    async fn test_repeated_q_authority_counts_once() {
+        // Authority 1 produces two distinct round-3 certifying blocks (in C3
+        // and C4) that both certify A=0's voting block. certified_by_stake[0]
+        // must include stake(1) exactly once.
+        let context = setup(4);
+        let mut schedule = LeaderScheduleV3::new(context.clone(), 1, vec![0; 4]);
+
+        let l0_1 = make_block(1, 0, vec![]);
+        schedule.add_commit(make_commit(1, l0_1.reference(), vec![l0_1.clone()]));
+
+        let v0 = make_block(2, 0, vec![l0_1.reference()]);
+        schedule.add_commit(make_commit(2, v0.reference(), vec![v0.clone()]));
+
+        let q1_a = make_block(3, 1, vec![v0.reference()]);
+        schedule.add_commit(make_commit(3, q1_a.reference(), vec![q1_a.clone()]));
+
+        // Distinct second round-3 block from auth 1 — both certify v0,
+        // distinct refs because of the extra l0_1 ancestor.
+        let q1_b = make_block(3, 1, vec![v0.reference(), l0_1.reference()]);
+        let l_4 = make_block(4, 0, vec![q1_a.reference(), q1_b.reference()]);
+        schedule.add_commit(make_commit(
+            4,
+            l_4.reference(),
+            vec![l_4.clone(), q1_b.clone()],
+        ));
+
+        // Both q1_a and q1_b certify v0; auth-1 hits qs twice, but the
+        // BTreeSet dedups → certified_by_stake = s1 (not 2*s1).
+        let s0 = context.committee.stake(AuthorityIndex::new_for_test(0));
+        let s1 = context.committee.stake(AuthorityIndex::new_for_test(1));
+        assert_eq!(schedule.total_scores_per_authority()[0], s0 * s1);
     }
 }

--- a/consensus/core/src/leader_schedule_v3.rs
+++ b/consensus/core/src/leader_schedule_v3.rs
@@ -68,6 +68,10 @@ pub(crate) struct LeaderScheduleV3 {
     // subtract a commit's contributions from `total_scores_per_authority` on
     // eviction. Bounded by `leader_schedule_window_size`.
     scores_entries: VecDeque<ScoresEntry>,
+    // Most recent schedule to return to the proposer. The commit index and
+    // minimum round move every commit; leader selection changes only at
+    // configured rotation boundaries.
+    cached_schedule: NextCommitLeaderSchedule,
 }
 
 /// This is used by the commit rule to figure out the next commit leaders.
@@ -140,32 +144,40 @@ impl LeaderScheduleV3 {
     ) -> Self {
         assert_eq!(total_scores_per_authority.len(), context.committee.size());
         let running_length = context.protocol_config.leader_schedule_window_size() as usize;
-        Self {
+        let mut schedule = Self {
             context,
             next_commit_index,
             total_scores_per_authority,
             total_num_leaders: 0,
             total_leader_stakes: 0,
-            pending_commits: VecDeque::with_capacity(3),
+            pending_commits: VecDeque::with_capacity(MAX_PENDING_COMMITS),
             scores_entries: VecDeque::with_capacity(running_length),
-        }
+            cached_schedule: NextCommitLeaderSchedule::default(),
+        };
+        schedule.cached_schedule = schedule.compute_next_commit_leader_schedule();
+        schedule
     }
 
     /// Number of recent committed sub-dags that must be replayed on startup
     /// to reconstruct the full state: `leader_schedule_window_size` for the
-    /// scoring window plus 3 for the pending commits held before scoring
-    /// begins.
+    /// scoring window, the pending commits held before scoring begins, and
+    /// enough additional commits to reconstruct the cached schedule boundary.
     fn replay_length(context: &Context) -> u32 {
-        context.protocol_config.leader_schedule_window_size() + MAX_PENDING_COMMITS as u32
+        context.protocol_config.leader_schedule_window_size()
+            + MAX_PENDING_COMMITS as u32
+            + context
+                .protocol_config
+                .leader_schedule_update_interval()
+                .saturating_sub(1)
     }
 
-    /// Returns the leader schedule for the next commit.
-    ///
-    /// next_commit_index and min_next_leader_round are determined from the current commit.
-    /// num_leaders in next commit is a constant right now, but can become dynamic in future.
-    /// Selects authorities with good enough performance and satisfying other constraints,
-    /// which can become the next commit leaders.
+    /// Returns the cached leader schedule. See `cached_schedule` for what
+    /// is refreshed every commit vs. only on rotation boundaries.
     pub(crate) fn next_commit_leader_schedule(&self) -> NextCommitLeaderSchedule {
+        self.cached_schedule.clone()
+    }
+
+    pub(crate) fn compute_next_commit_leader_schedule(&self) -> NextCommitLeaderSchedule {
         let min_next_leader_round = self
             .pending_commits
             .back()
@@ -262,6 +274,7 @@ impl LeaderScheduleV3 {
         // Until then, this is warmup (new instance, new epoch, or recovery).
         if self.pending_commits.len() < MAX_PENDING_COMMITS {
             self.pending_commits.push_back(c);
+            self.refresh_cached_schedule();
             self.report_metrics();
             return;
         }
@@ -427,7 +440,34 @@ impl LeaderScheduleV3 {
         self.pending_commits.pop_front();
         self.pending_commits.push_back(c);
 
+        self.refresh_cached_schedule();
         self.report_metrics();
+    }
+
+    fn refresh_cached_schedule(&mut self) {
+        let interval = self
+            .context
+            .protocol_config
+            .leader_schedule_update_interval() as CommitIndex;
+        let on_boundary = interval == 0
+            || self
+                .next_commit_index
+                .saturating_sub(1)
+                .is_multiple_of(interval);
+        if on_boundary {
+            // Boundary: full recompute, including allowed_leaders.
+            self.cached_schedule = self.compute_next_commit_leader_schedule();
+        } else {
+            // Off-boundary: only the per-commit fields move; skip the
+            // expensive allowed-leaders selection.
+            self.cached_schedule.next_commit_index = self.next_commit_index;
+            self.cached_schedule.min_next_leader_round = self
+                .pending_commits
+                .back()
+                .map(|c| c.leader.round)
+                .unwrap_or(GENESIS_ROUND)
+                + 1;
+        }
     }
 
     /// Walks commits [C-2, C-1, C] in order.
@@ -600,6 +640,28 @@ mod tests {
                 digest: CommitDigest::MIN,
             },
         )
+    }
+
+    fn make_uniform_chain_commits(last_index: CommitIndex) -> Vec<CommittedSubDag> {
+        assert!(last_index > 0);
+        let mut blocks_by_round: Vec<Vec<VerifiedBlock>> = Vec::new();
+        blocks_by_round.push(vec![make_block(1, 0, vec![]), make_block(1, 1, vec![])]);
+        for round in 2..=last_index {
+            let prev = &blocks_by_round[(round - 2) as usize];
+            let ancestors: Vec<_> = prev.iter().map(|b| b.reference()).collect();
+            blocks_by_round.push(vec![
+                make_block(round, 0, ancestors.clone()),
+                make_block(round, 1, ancestors),
+            ]);
+        }
+
+        (1..=last_index)
+            .map(|i| {
+                let blocks = blocks_by_round[(i - 1) as usize].clone();
+                let leader = blocks[0].reference();
+                make_commit(i, leader, blocks)
+            })
+            .collect()
     }
 
     #[tokio::test]
@@ -777,7 +839,7 @@ mod tests {
             .set_bad_nodes_stake_threshold_for_testing(0);
         let context = Arc::new(ctx);
         let schedule = LeaderScheduleV3::new(context, 7, vec![5, 10, 0, 2]);
-        let next = schedule.next_commit_leader_schedule();
+        let next = schedule.compute_next_commit_leader_schedule();
         assert_eq!(next.next_commit_index, 7);
         // No pending commits -> min_next_leader_round is GENESIS_ROUND + 1.
         assert_eq!(next.min_next_leader_round, 1);
@@ -879,63 +941,52 @@ mod tests {
 
     #[tokio::test]
     async fn test_replay_length() {
-        // Replay covers `leader_schedule_window_size` scored entries plus the
-        // 3 pending commits held before scoring kicks in.
+        // Replay covers scored entries, pending commits, and enough additional
+        // history to reconstruct the cached schedule at the last rotation.
         let (mut ctx, _) = Context::new_for_test(4);
         ctx.protocol_config
             .set_leader_schedule_window_size_for_testing(5);
+        ctx.protocol_config
+            .set_leader_schedule_update_interval_for_testing(12);
+        let context = Arc::new(ctx);
+        assert_eq!(LeaderScheduleV3::replay_length(&context), 19);
+
+        let (mut ctx, _) = Context::new_for_test(4);
+        ctx.protocol_config
+            .set_leader_schedule_window_size_for_testing(5);
+        ctx.protocol_config
+            .set_leader_schedule_update_interval_for_testing(0);
         let context = Arc::new(ctx);
         assert_eq!(LeaderScheduleV3::replay_length(&context), 8);
     }
 
     #[tokio::test]
     async fn test_recovery_replay_produces_same_state_as_live() {
-        // Invariant behind the `+3` recovery rule: replaying only the last
-        // `running_length + 3` commits produces the same v3 state as feeding
-        // the full history live, because earlier commits would have been
-        // evicted anyway. We simulate it without going through storage by
-        // stepping two schedules through identical `add_commit` sequences.
-
         let (mut ctx, _) = Context::new_for_test(4);
         ctx.protocol_config
             .set_leader_schedule_window_size_for_testing(5);
+        ctx.protocol_config
+            .set_leader_schedule_update_interval_for_testing(12);
         let context = Arc::new(ctx);
 
-        // Uniform chain: rounds 1..=10, authorities 0 and 1 produce blocks
-        // at each round linking back to both of the previous round's blocks.
-        let mut blocks_by_round: Vec<Vec<VerifiedBlock>> = Vec::new();
-        blocks_by_round.push(vec![make_block(1, 0, vec![]), make_block(1, 1, vec![])]);
-        for round in 2..=10u32 {
-            let prev = &blocks_by_round[(round - 2) as usize];
-            let ancestors: Vec<_> = prev.iter().map(|b| b.reference()).collect();
-            blocks_by_round.push(vec![
-                make_block(round, 0, ancestors.clone()),
-                make_block(round, 1, ancestors),
-            ]);
-        }
-        let commit_at = |i: CommitIndex, brs: &[Vec<VerifiedBlock>]| -> CommittedSubDag {
-            let blocks = brs[(i - 1) as usize].clone();
-            let leader = blocks[0].reference();
-            make_commit(i, leader, blocks)
-        };
+        let commits = make_uniform_chain_commits(23);
 
-        // Live path: feed commits 1..=10 into a fresh schedule starting at index 1.
+        // Live path: feed all commits into a fresh schedule starting at index 1.
         let mut live = LeaderScheduleV3::new(context.clone(), 1, vec![0; 4]);
-        for i in 1..=10 {
-            live.add_commit(commit_at(i, &blocks_by_round));
+        for commit in &commits {
+            live.add_commit(commit.clone());
         }
-        // 10 commits → score entries for C1..C7 (7 entries), capped at
-        // running_length=5 (entries for C3..C7); pending = [C8, C9, C10].
         assert_eq!(live.scores_entries_len(), 5);
         assert_eq!(live.pending_commits_len(), 3);
 
-        // Recovery path: replay only the last `running_length + 3 = 8`
-        // commits (indices 3..=10) into a fresh schedule starting at index 3.
         let replay_count = LeaderScheduleV3::replay_length(&context);
-        assert_eq!(replay_count, 8);
-        let mut replayed = LeaderScheduleV3::new(context.clone(), 3, vec![0; 4]);
-        for i in 3..=10 {
-            replayed.add_commit(commit_at(i, &blocks_by_round));
+        assert_eq!(replay_count, 19);
+        let last_commit_index = commits.last().unwrap().commit_ref.index;
+        let replay_start = last_commit_index.saturating_sub(replay_count) + 1;
+        assert_eq!(replay_start, 5);
+        let mut replayed = LeaderScheduleV3::new(context.clone(), replay_start, vec![0; 4]);
+        for commit in commits.iter().skip((replay_start - 1) as usize).cloned() {
+            replayed.add_commit(commit);
         }
 
         // The two schedules must be indistinguishable from the outside.
@@ -958,6 +1009,7 @@ mod tests {
         );
         assert_eq!(live_next.num_leaders, replay_next.num_leaders);
         assert_eq!(live_next.allowed_leaders, replay_next.allowed_leaders);
+        assert_eq!(live_next.next_commit_index, 24);
     }
 
     #[tokio::test]
@@ -971,9 +1023,107 @@ mod tests {
             .set_bad_nodes_stake_threshold_for_testing(0);
         let context = Arc::new(ctx);
         let schedule = LeaderScheduleV3::new(context, 42, vec![1, 2, 3, 4]);
-        let first = schedule.next_commit_leader_schedule();
-        let second = schedule.next_commit_leader_schedule();
+        let first = schedule.compute_next_commit_leader_schedule();
+        let second = schedule.compute_next_commit_leader_schedule();
         assert_eq!(first.allowed_leaders, second.allowed_leaders);
+    }
+
+    #[tokio::test]
+    async fn test_schedule_rotates_on_interval_boundary() {
+        let (mut ctx, _) = Context::new_for_test(4);
+        ctx.protocol_config
+            .set_leader_schedule_update_interval_for_testing(12);
+        let context = Arc::new(ctx);
+        let mut schedule = LeaderScheduleV3::new(context, 1, vec![0; 4]);
+        let commits = make_uniform_chain_commits(12);
+
+        let initial = schedule.next_commit_leader_schedule();
+        assert_eq!(initial.next_commit_index, 1);
+        for commit in commits.iter().take(11) {
+            schedule.add_commit(commit.clone());
+        }
+        let before_boundary = schedule.next_commit_leader_schedule();
+        let computed_before_boundary = schedule.compute_next_commit_leader_schedule();
+        assert_eq!(before_boundary.next_commit_index, 12);
+        assert_eq!(
+            before_boundary.min_next_leader_round,
+            computed_before_boundary.min_next_leader_round
+        );
+        assert_eq!(before_boundary.num_leaders, initial.num_leaders);
+        assert_eq!(before_boundary.allowed_leaders, initial.allowed_leaders);
+
+        schedule.add_commit(commits[11].clone());
+        let on_boundary = schedule.next_commit_leader_schedule();
+        let computed_on_boundary = schedule.compute_next_commit_leader_schedule();
+        assert_eq!(on_boundary.next_commit_index, 13);
+        assert_eq!(
+            on_boundary.min_next_leader_round,
+            computed_on_boundary.min_next_leader_round
+        );
+        assert_eq!(on_boundary.num_leaders, computed_on_boundary.num_leaders);
+        assert_eq!(
+            on_boundary.allowed_leaders,
+            computed_on_boundary.allowed_leaders
+        );
+    }
+
+    #[tokio::test]
+    async fn test_interval_zero_refreshes_every_commit() {
+        let (mut ctx, _) = Context::new_for_test(4);
+        ctx.protocol_config
+            .set_leader_schedule_update_interval_for_testing(0);
+        let context = Arc::new(ctx);
+        let mut schedule = LeaderScheduleV3::new(context, 1, vec![0; 4]);
+        let commits = make_uniform_chain_commits(2);
+
+        schedule.add_commit(commits[0].clone());
+        assert_eq!(schedule.next_commit_leader_schedule().next_commit_index, 2);
+        schedule.add_commit(commits[1].clone());
+        assert_eq!(schedule.next_commit_leader_schedule().next_commit_index, 3);
+    }
+
+    #[tokio::test]
+    async fn test_interval_one_refreshes_every_commit() {
+        let (mut ctx, _) = Context::new_for_test(4);
+        ctx.protocol_config
+            .set_leader_schedule_update_interval_for_testing(1);
+        let context = Arc::new(ctx);
+        let mut schedule = LeaderScheduleV3::new(context, 1, vec![0; 4]);
+        let commits = make_uniform_chain_commits(2);
+
+        schedule.add_commit(commits[0].clone());
+        assert_eq!(schedule.next_commit_leader_schedule().next_commit_index, 2);
+        schedule.add_commit(commits[1].clone());
+        assert_eq!(schedule.next_commit_leader_schedule().next_commit_index, 3);
+    }
+
+    #[tokio::test]
+    async fn test_recovery_cache_matches_live_before_first_rotation_boundary() {
+        let (mut ctx, _) = Context::new_for_test(4);
+        ctx.protocol_config
+            .set_leader_schedule_update_interval_for_testing(12);
+        let context = Arc::new(ctx);
+        let commits = make_uniform_chain_commits(5);
+
+        let mut live = LeaderScheduleV3::new(context.clone(), 1, vec![0; 4]);
+        for commit in &commits {
+            live.add_commit(commit.clone());
+        }
+
+        let replay_count = LeaderScheduleV3::replay_length(&context);
+        let last_commit_index = commits.last().unwrap().commit_ref.index;
+        let replay_start = last_commit_index.saturating_sub(replay_count) + 1;
+        assert_eq!(replay_start, 1);
+        let mut replayed = LeaderScheduleV3::new(context, replay_start, vec![0; 4]);
+        for commit in commits {
+            replayed.add_commit(commit);
+        }
+
+        assert_eq!(live.next_commit_leader_schedule().next_commit_index, 6);
+        assert_eq!(
+            live.next_commit_leader_schedule().next_commit_index,
+            replayed.next_commit_leader_schedule().next_commit_index
+        );
     }
 
     #[tokio::test]

--- a/consensus/core/src/leader_schedule_v3.rs
+++ b/consensus/core/src/leader_schedule_v3.rs
@@ -88,13 +88,11 @@ impl LeaderScheduleV3 {
         let mut leader_schedule = LeaderScheduleV3::new(context.clone(), vec![0; committee_size]);
 
         let last_commit_index = dag_state.read().last_commit_index();
-        let replay_count = LeaderScheduleV3::replay_length(&context);
-        // Replay maximum replay_count commits, and starting from commit 1 at minimum.
-        let replay_start = last_commit_index.saturating_sub(replay_count) + 1;
-        if replay_start > last_commit_index {
+        if last_commit_index == 0 {
             // No commits to replay, return the new schedule with empty state.
             return leader_schedule;
         }
+        let replay_start = LeaderScheduleV3::replay_start(&context, last_commit_index);
 
         let store = dag_state.read().store();
         let commits = store
@@ -144,16 +142,25 @@ impl LeaderScheduleV3 {
             + 1
     }
 
-    /// Number of recent committed sub-dags that must be replayed on startup
-    /// to reconstruct the full state: `leader_schedule_window_size` for the
-    /// scoring window, the pending commits held before scoring begins, and
-    /// `interval - 1` more so the replay spans back to the most recent rotation
-    /// boundary with the full scoring window already populated.
-    fn replay_length(context: &Context) -> u32 {
-        context.protocol_config.leader_schedule_window_size()
-            + MAX_PENDING_COMMITS as u32
-            + context.protocol_config.leader_schedule_update_interval()
-            - 1
+    /// Replays commits from the start commit index to the `last_commit_index`,
+    /// so afterwards the leader schedule matches what live processing would have
+    /// built.
+    ///
+    /// This means the most recent schedule must be correctly recovered, by processing
+    /// enough (window_size + MAX_PENDING_COMMITS) commit before computing the current schedule.
+    /// Each leader schedule applies to commits within leader_schedule_update_interval.
+    /// A new schedule is computed when next commit index % update interval == 1.
+    fn replay_start(context: &Context, last_commit_index: CommitIndex) -> CommitIndex {
+        let window_size = context.protocol_config.leader_schedule_window_size();
+        let update_interval = context.protocol_config.leader_schedule_update_interval();
+        // The next commit index which requires a new leader schedule to be computed.
+        let last_schedule_update_index =
+            (last_commit_index / update_interval) * update_interval + 1;
+        // Replay must at least window_size + MAX_PENDING_COMMITS commits
+        // when computing the schedule for last update, or replay from commit 1.
+        last_schedule_update_index
+            .saturating_sub(window_size + MAX_PENDING_COMMITS as u32)
+            .max(1)
     }
 
     /// Returns the current leader schedule. See `current_schedule` for what
@@ -164,11 +171,9 @@ impl LeaderScheduleV3 {
 
     pub(crate) fn compute_next_commit_leader_schedule(&self) -> NextCommitLeaderSchedule {
         let allowed_leaders = self.select_allowed_leaders_with_fixed_config();
-        let num_leaders = allowed_leaders.len();
         NextCommitLeaderSchedule {
             next_commit_index: self.next_commit_index(),
             min_next_leader_round: self.min_next_leader_round(),
-            num_leaders,
             allowed_leaders,
         }
     }
@@ -231,10 +236,10 @@ impl LeaderScheduleV3 {
         by_score.into_iter().map(|(idx, _)| idx).collect()
     }
 
-    /// On each `add_commit(c)`, once 3 commits have accumulated, a score entry
-    /// corresponding to the front of `pending_commits` (the C-3-equivalent)
-    /// is produced; then C is appended to `pending_commits` and the front is
-    /// evicted. Evicts the oldest entry from the running window if full.
+    /// On each `add_commit(C)`, if there are already 3 commits buffered in pending_commits,
+    /// a score entry is produced and added to the back of scores_entries.
+    /// C is always appended to `pending_commits`. The oldest entry is
+    /// evicted from `pending_commits` if full (more than 3 entries).
     ///
     /// Architectural contract: consecutive commits must have strictly
     /// increasing leader rounds. Under the invariant, 3 commits are sufficient
@@ -329,6 +334,11 @@ impl LeaderScheduleV3 {
         for (a, voting_blocks) in &voting_blocks_by_author {
             // Equivocation: more than one r+1 block from A → score[A] = 0.
             if voting_blocks.len() != 1 {
+                tracing::debug!(
+                    "Equivocation detected on authority {}: {:?}",
+                    a,
+                    voting_blocks,
+                );
                 continue;
             }
             let voting_block = voting_blocks[0];
@@ -562,10 +572,15 @@ pub(crate) struct NextCommitLeaderSchedule {
     pub(crate) next_commit_index: CommitIndex,
     // Informs the committer about the minimum round of the next commit leader.
     pub(crate) min_next_leader_round: Round,
-    // Number of leaders to select per round.
-    pub(crate) num_leaders: usize,
     // Authorities allowed to be leaders.
     pub(crate) allowed_leaders: Vec<AuthorityIndex>,
+}
+
+impl NextCommitLeaderSchedule {
+    // Number of authorities allowed to be leaders in the next commit.
+    pub(crate) fn num_leaders(&self) -> usize {
+        self.allowed_leaders.len()
+    }
 }
 
 struct ScoresEntry {
@@ -665,7 +680,7 @@ mod tests {
             current.min_next_leader_round,
             computed.min_next_leader_round
         );
-        assert_eq!(current.num_leaders, computed.num_leaders);
+        assert_eq!(current.num_leaders(), computed.num_leaders());
         assert_eq!(current.allowed_leaders, computed.allowed_leaders);
     }
 
@@ -694,34 +709,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_first_three_commits_score_zero() {
+    async fn test_add_commit_basics() {
+        // 4 commits with strictly increasing leader rounds (1, 2, 3, 4).
         // Scoring logic needs C-3, C-2, C-1 in pending before producing the
         // first score entry, so the first three commits are warmup.
-        let context = setup(4);
-        let mut schedule = LeaderScheduleV3::new(context, vec![0; 4]);
-
-        let leader1 = make_block(1, 0, vec![]);
-        schedule.add_commit(make_commit(1, leader1.reference(), vec![leader1.clone()]));
-        assert_eq!(schedule.total_scores_per_authority(), &[0u64; 4]);
-        assert_eq!(schedule.scores_entries_len(), 0);
-        assert_eq!(schedule.pending_commits_len(), 1);
-
-        let leader2 = make_block(2, 1, vec![leader1.reference()]);
-        schedule.add_commit(make_commit(2, leader2.reference(), vec![leader2.clone()]));
-        assert_eq!(schedule.total_scores_per_authority(), &[0u64; 4]);
-        assert_eq!(schedule.scores_entries_len(), 0);
-        assert_eq!(schedule.pending_commits_len(), 2);
-
-        let leader3 = make_block(3, 2, vec![leader2.reference()]);
-        schedule.add_commit(make_commit(3, leader3.reference(), vec![leader3.clone()]));
-        assert_eq!(schedule.total_scores_per_authority(), &[0u64; 4]);
-        assert_eq!(schedule.scores_entries_len(), 0);
-        assert_eq!(schedule.pending_commits_len(), 3);
-    }
-
-    #[tokio::test]
-    async fn test_fourth_commit_scores_from_c_minus_3() {
-        // 4 commits with strictly increasing leader rounds (1, 2, 3, 4).
         // C1 (the C-3-equivalent when scoring on C4) carries multiple round-1
         // leader blocks, exercising "leader_refs = all round-r blocks in C-3".
         // Voting blocks live at round 2 in C2, certifying blocks at round 3 in
@@ -738,6 +729,9 @@ mod tests {
             l0_1.reference(),
             vec![l0_1.clone(), l1_1.clone()],
         ));
+        assert_eq!(schedule.total_scores_per_authority(), &[0u64; 4]);
+        assert_eq!(schedule.scores_entries_len(), 0);
+        assert_eq!(schedule.pending_commits_len(), 1);
 
         // C2: round-2 voting blocks for authorities 0 and 2.
         //   v0 (auth 0) links L0_1 only.
@@ -746,10 +740,15 @@ mod tests {
         let v2 = make_block(2, 2, vec![l0_1.reference(), l1_1.reference()]);
         schedule.add_commit(make_commit(2, v0.reference(), vec![v0.clone(), v2.clone()]));
         assert_eq!(schedule.total_scores_per_authority(), &[0u64; 4]);
+        assert_eq!(schedule.scores_entries_len(), 0);
+        assert_eq!(schedule.pending_commits_len(), 2);
 
         // C3: round-3 certifying block q1 (auth 1) certifies v0 and v2.
         let q1 = make_block(3, 1, vec![v0.reference(), v2.reference()]);
         schedule.add_commit(make_commit(3, q1.reference(), vec![q1.clone()]));
+        assert_eq!(schedule.total_scores_per_authority(), &[0u64; 4]);
+        assert_eq!(schedule.scores_entries_len(), 0);
+        assert_eq!(schedule.pending_commits_len(), 3);
 
         // C4: leader at round 4. Add a round-3 block q3 (auth 3) certifying v0
         // only — exercises "C4 (the inclusive r+2 sentinel) is searched too".
@@ -861,7 +860,7 @@ mod tests {
         assert_eq!(next.min_next_leader_round, 1);
         // Threshold is 0, so every authority is allowed.
         assert_eq!(next.allowed_leaders.len(), 4);
-        assert_eq!(next.num_leaders, next.allowed_leaders.len());
+        assert_eq!(next.num_leaders(), next.allowed_leaders.len());
         // The allowed-leaders list is a permutation of distinct authorities.
         let mut sorted = next.allowed_leaders.clone();
         sorted.sort();
@@ -974,24 +973,76 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_replay_length() {
-        // Replay covers scored entries, pending commits, and enough additional
-        // history to reconstruct the current schedule at the last rotation.
-        let (mut ctx, _) = Context::new_for_test(4);
-        ctx.protocol_config
-            .set_leader_schedule_window_size_for_testing(5);
-        ctx.protocol_config
-            .set_leader_schedule_update_interval_for_testing(12);
-        let context = Arc::new(ctx);
-        assert_eq!(LeaderScheduleV3::replay_length(&context), 19);
+    async fn test_replay_start() {
+        // Cases pick W=5, MAX_PENDING=3, so W + MAX_PENDING = 8.
+        // Expected start = max(1, sync_point - 8) where sync_point is the
+        // next_commit_index immediately after the schedule state that replay
+        // needs to reconstruct.
+        struct Case {
+            name: &'static str,
+            interval: u32,
+            last_commit_index: CommitIndex,
+            expected_start: CommitIndex,
+        }
+        let cases = [
+            Case {
+                name: "no commits → 1 (no-op signal)",
+                interval: 12,
+                last_commit_index: 0,
+                expected_start: 1,
+            },
+            Case {
+                name: "before first boundary, short history → 1",
+                interval: 12,
+                last_commit_index: 5,
+                expected_start: 1,
+            },
+            Case {
+                name: "before first boundary, longer history → 1",
+                interval: 12,
+                last_commit_index: 11,
+                expected_start: 1,
+            },
+            Case {
+                name: "exactly on first boundary → B - 7",
+                interval: 12,
+                last_commit_index: 12,
+                expected_start: 5,
+            },
+            Case {
+                name: "between boundaries → last_boundary - 7",
+                interval: 12,
+                last_commit_index: 23,
+                expected_start: 5,
+            },
+            Case {
+                name: "exactly on second boundary → B - 7",
+                interval: 12,
+                last_commit_index: 24,
+                expected_start: 17,
+            },
+            Case {
+                name: "interval=0 clamped to 1, every commit is a boundary → N - 7",
+                interval: 0,
+                last_commit_index: 11,
+                expected_start: 4,
+            },
+        ];
 
-        let (mut ctx, _) = Context::new_for_test(4);
-        ctx.protocol_config
-            .set_leader_schedule_window_size_for_testing(5);
-        ctx.protocol_config
-            .set_leader_schedule_update_interval_for_testing(0);
-        let context = Arc::new(ctx);
-        assert_eq!(LeaderScheduleV3::replay_length(&context), 8);
+        for case in cases {
+            let (mut ctx, _) = Context::new_for_test(4);
+            ctx.protocol_config
+                .set_leader_schedule_window_size_for_testing(5);
+            ctx.protocol_config
+                .set_leader_schedule_update_interval_for_testing(case.interval);
+            let context = Arc::new(ctx);
+            assert_eq!(
+                LeaderScheduleV3::replay_start(&context, case.last_commit_index),
+                case.expected_start,
+                "{}",
+                case.name
+            );
+        }
     }
 
     #[tokio::test]
@@ -1052,10 +1103,8 @@ mod tests {
         assert_eq!(live.scores_entries_len(), 5);
         assert_eq!(live.pending_commits_len(), 3);
 
-        let replay_count = LeaderScheduleV3::replay_length(&context);
-        assert_eq!(replay_count, 19);
         let last_commit_index = commits.last().unwrap().commit_ref.index;
-        let replay_start = last_commit_index.saturating_sub(replay_count) + 1;
+        let replay_start = LeaderScheduleV3::replay_start(&context, last_commit_index);
         assert_eq!(replay_start, 5);
         let mut replayed = LeaderScheduleV3::new(context.clone(), vec![0; 4]);
         for commit in commits.iter().skip((replay_start - 1) as usize).cloned() {
@@ -1080,7 +1129,6 @@ mod tests {
             live_next.min_next_leader_round,
             replay_next.min_next_leader_round
         );
-        assert_eq!(live_next.num_leaders, replay_next.num_leaders);
         assert_eq!(live_next.allowed_leaders, replay_next.allowed_leaders);
         assert_eq!(live_next.next_commit_index, 24);
     }
@@ -1122,7 +1170,6 @@ mod tests {
             before_boundary.min_next_leader_round,
             computed_before_boundary.min_next_leader_round
         );
-        assert_eq!(before_boundary.num_leaders, initial.num_leaders);
         assert_eq!(before_boundary.allowed_leaders, initial.allowed_leaders);
 
         schedule.add_commit(commits[11].clone());
@@ -1162,9 +1209,8 @@ mod tests {
             live.add_commit(commit.clone());
         }
 
-        let replay_count = LeaderScheduleV3::replay_length(&context);
         let last_commit_index = commits.last().unwrap().commit_ref.index;
-        let replay_start = last_commit_index.saturating_sub(replay_count) + 1;
+        let replay_start = LeaderScheduleV3::replay_start(&context, last_commit_index);
         assert_eq!(replay_start, 1);
         let mut replayed = LeaderScheduleV3::new(context, vec![0; 4]);
         for commit in commits {
@@ -1456,7 +1502,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_score_is_product_of_voted_for_and_certified_by_stake() {
+    async fn test_score_computation() {
         // 4 authorities. A=0's voting block links {auth 1, auth 2} round-1
         // leader blocks (voted_for_stake = s1 + s2); two distinct r+2 blocks
         // from auths 1 and 3 certify A=0's voting block

--- a/consensus/core/src/lib.rs
+++ b/consensus/core/src/lib.rs
@@ -22,6 +22,7 @@ mod core_thread;
 mod dag_state;
 mod error;
 mod leader_schedule;
+mod leader_schedule_v3;
 mod leader_scoring;
 mod leader_timeout;
 mod linearizer;

--- a/consensus/core/src/metrics.rs
+++ b/consensus/core/src/metrics.rs
@@ -4,10 +4,11 @@
 use std::sync::Arc;
 
 use prometheus::{
-    Histogram, HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec, Registry,
-    exponential_buckets, register_histogram_vec_with_registry, register_histogram_with_registry,
-    register_int_counter_vec_with_registry, register_int_counter_with_registry,
-    register_int_gauge_vec_with_registry, register_int_gauge_with_registry,
+    GaugeVec, Histogram, HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec, Registry,
+    exponential_buckets, register_gauge_vec_with_registry, register_histogram_vec_with_registry,
+    register_histogram_with_registry, register_int_counter_vec_with_registry,
+    register_int_counter_with_registry, register_int_gauge_vec_with_registry,
+    register_int_gauge_with_registry,
 };
 
 use crate::network::metrics::NetworkMetrics;
@@ -168,6 +169,9 @@ pub(crate) struct NodeMetrics {
     pub(crate) quorum_receive_latency: Histogram,
     pub(crate) block_receive_delay: IntCounterVec,
     pub(crate) reputation_scores: IntGaugeVec,
+    pub(crate) leader_schedule_total_scores: IntGaugeVec,
+    pub(crate) leader_schedule_normalized_scores: GaugeVec,
+    pub(crate) leader_schedule_last_num_leaders: IntGauge,
     pub(crate) scope_processing_time: HistogramVec,
     pub(crate) sub_dags_per_commit_count: Histogram,
     pub(crate) block_suspensions: IntCounterVec,
@@ -617,6 +621,23 @@ impl NodeMetrics {
                 "reputation_scores",
                 "Reputation scores for each authority",
                 &["authority"],
+                registry,
+            ).unwrap(),
+            leader_schedule_total_scores: register_int_gauge_vec_with_registry!(
+                "leader_schedule_total_scores",
+                "LeaderScheduleV3 running total score per authority over the scoring window",
+                &["authority"],
+                registry,
+            ).unwrap(),
+            leader_schedule_normalized_scores: register_gauge_vec_with_registry!(
+                "leader_schedule_normalized_scores",
+                "LeaderScheduleV3 per-authority total score divided by total leader stake in the scoring window",
+                &["authority"],
+                registry,
+            ).unwrap(),
+            leader_schedule_last_num_leaders: register_int_gauge_with_registry!(
+                "leader_schedule_last_num_leaders",
+                "LeaderScheduleV3 number of leader-round blocks in the most recently scored commit",
                 registry,
             ).unwrap(),
             scope_processing_time: register_histogram_vec_with_registry!(

--- a/consensus/core/src/metrics.rs
+++ b/consensus/core/src/metrics.rs
@@ -4,11 +4,11 @@
 use std::sync::Arc;
 
 use prometheus::{
-    GaugeVec, Histogram, HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec, Registry,
-    exponential_buckets, register_gauge_vec_with_registry, register_histogram_vec_with_registry,
-    register_histogram_with_registry, register_int_counter_vec_with_registry,
-    register_int_counter_with_registry, register_int_gauge_vec_with_registry,
-    register_int_gauge_with_registry,
+    Gauge, GaugeVec, Histogram, HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec,
+    Registry, exponential_buckets, register_gauge_vec_with_registry, register_gauge_with_registry,
+    register_histogram_vec_with_registry, register_histogram_with_registry,
+    register_int_counter_vec_with_registry, register_int_counter_with_registry,
+    register_int_gauge_vec_with_registry, register_int_gauge_with_registry,
 };
 
 use crate::network::metrics::NetworkMetrics;
@@ -172,6 +172,7 @@ pub(crate) struct NodeMetrics {
     pub(crate) leader_schedule_total_scores: IntGaugeVec,
     pub(crate) leader_schedule_normalized_scores: GaugeVec,
     pub(crate) leader_schedule_last_num_leaders: IntGauge,
+    pub(crate) leader_schedule_average_num_leaders: Gauge,
     pub(crate) scope_processing_time: HistogramVec,
     pub(crate) sub_dags_per_commit_count: Histogram,
     pub(crate) block_suspensions: IntCounterVec,
@@ -625,19 +626,24 @@ impl NodeMetrics {
             ).unwrap(),
             leader_schedule_total_scores: register_int_gauge_vec_with_registry!(
                 "leader_schedule_total_scores",
-                "LeaderScheduleV3 running total score per authority over the scoring window",
+                "LeaderScheduleV3 running per-authority score over the scoring window. Each commit contributes voted_for_stake * certified_by_stake (stake^2 units)",
                 &["authority"],
                 registry,
             ).unwrap(),
             leader_schedule_normalized_scores: register_gauge_vec_with_registry!(
                 "leader_schedule_normalized_scores",
-                "LeaderScheduleV3 per-authority total score divided by total leader stake in the scoring window",
+                "LeaderScheduleV3 per-authority total score divided by (running sum of per-commit leader stake) * committee total stake. Stake^2 over stake^2; a fraction with no stake dimension",
                 &["authority"],
                 registry,
             ).unwrap(),
             leader_schedule_last_num_leaders: register_int_gauge_with_registry!(
                 "leader_schedule_last_num_leaders",
                 "LeaderScheduleV3 number of leader-round blocks in the most recently scored commit",
+                registry,
+            ).unwrap(),
+            leader_schedule_average_num_leaders: register_gauge_with_registry!(
+                "leader_schedule_average_num_leaders",
+                "LeaderScheduleV3 moving average of the number of leaders per commit across the scoring window",
                 registry,
             ).unwrap(),
             scope_processing_time: register_histogram_vec_with_registry!(

--- a/consensus/core/src/network/observer.rs
+++ b/consensus/core/src/network/observer.rs
@@ -659,7 +659,7 @@ mod tests {
             }
             if count >= 40 {
                 break;
-Yes, Y            }
+            }
         }
         assert_eq!(count, 40);
 

--- a/consensus/core/src/network/observer.rs
+++ b/consensus/core/src/network/observer.rs
@@ -659,7 +659,7 @@ mod tests {
             }
             if count >= 40 {
                 break;
-            }
+Yes, Y            }
         }
         assert_eq!(count, 40);
 

--- a/consensus/core/src/proposer.rs
+++ b/consensus/core/src/proposer.rs
@@ -451,7 +451,8 @@ impl Proposer for ValidatorProposer {
         }
 
         // TODO(v3): support these metrics under v3 multi leader logic:
-        // - Leader slots can be empty when the quorum round is no greater than already committed leader round.
+        // - Leader slots are empty when the quorum round is no greater than last committed leader round,
+        //   because of async process or recovery.
         // - Record accepted time for each block, to decide the last leader and the amount of time waiting for it.
         if !self.context.protocol_config.enable_v3() {
             let leader_slot = leader_slots.first().unwrap();

--- a/consensus/core/src/proposer.rs
+++ b/consensus/core/src/proposer.rs
@@ -17,10 +17,12 @@ use crate::{
     },
     context::Context,
     dag_state::DagState,
+    leader_schedule_v3::NextCommitLeaderSchedule,
     round_tracker::RoundTracker,
     stake_aggregator::{QuorumThreshold, StakeAggregator},
     transaction::TransactionConsumer,
     transaction_vote_tracker::TransactionVoteTracker,
+    universal_committer::UniversalCommitter,
 };
 
 const MAX_COMMIT_VOTES_PER_BLOCK: usize = 100;
@@ -53,6 +55,9 @@ pub(crate) trait Proposer: Send + Sync {
     /// Sets propagation scores on the ancestor state manager (validators only)
     fn set_propagation_scores(&mut self, scores: crate::leader_scoring::ReputationScores);
 
+    /// Sets the next v3 commit leader schedule used to wait before proposing.
+    fn set_next_commit_leader_schedule(&mut self, schedule: NextCommitLeaderSchedule);
+
     /// Notifies transaction consumer about committed own blocks (validators only)
     fn notify_own_blocks_committed(&self, block_refs: Vec<BlockRef>, gc_round: Round);
 
@@ -73,7 +78,7 @@ pub(crate) struct ValidatorProposer {
     ancestor_state_manager: AncestorStateManager,
     round_tracker: Arc<RwLock<RoundTracker>>,
     dag_state: Arc<RwLock<DagState>>,
-    committer: Arc<crate::universal_committer::UniversalCommitter>,
+    leader_waiter: ProposalLeaderWaiter,
 }
 
 impl ValidatorProposer {
@@ -86,7 +91,7 @@ impl ValidatorProposer {
         last_known_proposed_round: Option<Round>,
         ancestor_state_manager: AncestorStateManager,
         round_tracker: Arc<RwLock<RoundTracker>>,
-        committer: Arc<crate::universal_committer::UniversalCommitter>,
+        leader_waiter: ProposalLeaderWaiter,
     ) -> Self {
         let last_included_ancestors = vec![None; context.committee.size()];
         Self {
@@ -100,7 +105,7 @@ impl ValidatorProposer {
             ancestor_state_manager,
             round_tracker,
             dag_state,
-            committer,
+            leader_waiter,
         }
     }
 
@@ -117,31 +122,6 @@ impl ValidatorProposer {
             .get_last_proposed_block()
             .expect("A block should have been returned")
             .timestamp_ms()
-    }
-
-    fn leaders(&self, round: Round) -> Vec<Slot> {
-        self.committer
-            .get_leaders(round)
-            .into_iter()
-            .map(|authority_index| Slot::new(round, authority_index))
-            .collect()
-    }
-
-    fn first_leader(&self, round: Round) -> consensus_config::AuthorityIndex {
-        self.leaders(round).first().unwrap().authority
-    }
-
-    fn leaders_exist(&self, round: Round) -> bool {
-        let dag_state = self.dag_state.read();
-        for leader in self.leaders(round) {
-            // Search for all the leaders. If at least one is not found, then return false.
-            // A linear search should be fine here as the set of elements is not expected to be small enough and more sophisticated
-            // data structures might not give us much here.
-            if !dag_state.contains_cached_block_at_slot(leader) {
-                return false;
-            }
-        }
-        true
     }
 
     /// Retrieves the next ancestors to propose to form a block at `clock_round` round.
@@ -403,12 +383,19 @@ impl Proposer for ValidatorProposer {
 
         // There must be a quorum of blocks from the previous round.
         let quorum_round = clock_round.saturating_sub(1);
+        let leader_slots = self.leader_waiter.leader_slots_to_wait_for(quorum_round);
 
         // Create a new block either because we want to "forcefully" propose a block due to a leader timeout,
         // or because we are actually ready to produce the block (leader exists and min delay has passed).
         if !force {
-            if !self.leaders_exist(quorum_round) {
-                return None;
+            {
+                let dag_state = self.dag_state.read();
+                if !leader_slots
+                    .iter()
+                    .all(|slot| dag_state.contains_cached_block_at_slot(*slot))
+                {
+                    return None;
+                }
             }
 
             if Duration::from_millis(
@@ -462,27 +449,31 @@ impl Proposer for ValidatorProposer {
             self.last_included_ancestors[ancestor.author()] = Some(ancestor.reference());
         }
 
-        let leader_authority = &self
-            .context
-            .committee
-            .authority(self.first_leader(quorum_round))
-            .hostname;
-        self.context
-            .metrics
-            .node_metrics
-            .block_proposal_leader_wait_ms
-            .with_label_values(&[leader_authority])
-            .inc_by(
-                Instant::now()
-                    .saturating_duration_since(self.dag_state.read().threshold_clock_quorum_ts())
-                    .as_millis() as u64,
-            );
-        self.context
-            .metrics
-            .node_metrics
-            .block_proposal_leader_wait_count
-            .with_label_values(&[leader_authority])
-            .inc();
+        if let Some(leader_slot) = leader_slots.first() {
+            let leader_authority = &self
+                .context
+                .committee
+                .authority(leader_slot.authority)
+                .hostname;
+            self.context
+                .metrics
+                .node_metrics
+                .block_proposal_leader_wait_ms
+                .with_label_values(&[leader_authority])
+                .inc_by(
+                    Instant::now()
+                        .saturating_duration_since(
+                            self.dag_state.read().threshold_clock_quorum_ts(),
+                        )
+                        .as_millis() as u64,
+                );
+            self.context
+                .metrics
+                .node_metrics
+                .block_proposal_leader_wait_count
+                .with_label_values(&[leader_authority])
+                .inc();
+        }
 
         self.context
             .metrics
@@ -714,6 +705,10 @@ impl Proposer for ValidatorProposer {
         self.ancestor_state_manager.set_propagation_scores(scores);
     }
 
+    fn set_next_commit_leader_schedule(&mut self, schedule: NextCommitLeaderSchedule) {
+        self.leader_waiter.update_v3_schedule(schedule);
+    }
+
     fn notify_own_blocks_committed(&self, block_refs: Vec<BlockRef>, gc_round: Round) {
         self.transaction_consumer
             .notify_own_blocks_status(block_refs, gc_round);
@@ -722,5 +717,87 @@ impl Proposer for ValidatorProposer {
     #[cfg(test)]
     fn round_tracker_for_tests(&self) -> Arc<RwLock<RoundTracker>> {
         self.round_tracker.clone()
+    }
+}
+
+/// Determines the identity and set of leaders to wait for from leader schedule,
+/// when proposing a block.
+pub(crate) enum ProposalLeaderWaiter {
+    V2(Arc<UniversalCommitter>),
+    V3(NextCommitLeaderSchedule),
+}
+
+impl ProposalLeaderWaiter {
+    fn leader_slots_to_wait_for(&self, round: Round) -> Vec<Slot> {
+        match self {
+            Self::V2(committer) => committer
+                .get_leaders(round)
+                .into_iter()
+                .map(|authority_index| Slot::new(round, authority_index))
+                .collect(),
+            Self::V3(schedule) => {
+                if round < schedule.min_next_leader_round {
+                    return vec![];
+                }
+                schedule
+                    .allowed_leaders
+                    .iter()
+                    .map(|leader| Slot::new(round, *leader))
+                    .collect()
+            }
+        }
+    }
+
+    fn update_v3_schedule(&mut self, schedule: NextCommitLeaderSchedule) {
+        if let Self::V3(current) = self {
+            *current = schedule;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use consensus_config::AuthorityIndex;
+
+    use super::*;
+
+    #[test]
+    fn proposal_leader_waiter_v3_uses_and_updates_schedule() {
+        let mut waiter = ProposalLeaderWaiter::V3(NextCommitLeaderSchedule {
+            next_commit_index: 1,
+            min_next_leader_round: 4,
+            num_leaders: 1,
+            allowed_leaders: vec![
+                AuthorityIndex::new_for_test(0),
+                AuthorityIndex::new_for_test(2),
+            ],
+        });
+
+        assert!(waiter.leader_slots_to_wait_for(3).is_empty());
+        assert_eq!(
+            waiter.leader_slots_to_wait_for(4),
+            vec![
+                Slot::new(4, AuthorityIndex::new_for_test(0)),
+                Slot::new(4, AuthorityIndex::new_for_test(2)),
+            ]
+        );
+
+        waiter.update_v3_schedule(NextCommitLeaderSchedule {
+            next_commit_index: 2,
+            min_next_leader_round: 4,
+            num_leaders: 1,
+            allowed_leaders: vec![
+                AuthorityIndex::new_for_test(1),
+                AuthorityIndex::new_for_test(3),
+            ],
+        });
+
+        assert_eq!(
+            waiter.leader_slots_to_wait_for(4),
+            vec![
+                Slot::new(4, AuthorityIndex::new_for_test(1)),
+                Slot::new(4, AuthorityIndex::new_for_test(3)),
+            ]
+        );
     }
 }

--- a/consensus/core/src/proposer.rs
+++ b/consensus/core/src/proposer.rs
@@ -449,7 +449,11 @@ impl Proposer for ValidatorProposer {
             self.last_included_ancestors[ancestor.author()] = Some(ancestor.reference());
         }
 
-        if let Some(leader_slot) = leader_slots.first() {
+        // TODO(v3): support these metrics under v3 multi leader logic:
+        // - Leader slots can be empty when the quorum round is no greater than already committed leader round.
+        // - Record accepted time for each block, to decide the last leader and the amount of time waiting for it.
+        if !self.context.protocol_config.enable_v3() {
+            let leader_slot = leader_slots.first().unwrap();
             let leader_authority = &self
                 .context
                 .committee

--- a/consensus/core/src/proposer.rs
+++ b/consensus/core/src/proposer.rs
@@ -56,6 +56,7 @@ pub(crate) trait Proposer: Send + Sync {
     fn set_propagation_scores(&mut self, scores: crate::leader_scoring::ReputationScores);
 
     /// Sets the next v3 commit leader schedule used to wait before proposing.
+    #[allow(dead_code)]
     fn set_next_commit_leader_schedule(&mut self, schedule: NextCommitLeaderSchedule);
 
     /// Notifies transaction consumer about committed own blocks (validators only)
@@ -752,6 +753,7 @@ impl ProposalLeaderWaiter {
         }
     }
 
+    #[allow(dead_code)]
     fn update_v3_schedule(&mut self, schedule: NextCommitLeaderSchedule) {
         if let Self::V3(current) = self {
             *current = schedule;

--- a/consensus/core/src/proposer.rs
+++ b/consensus/core/src/proposer.rs
@@ -773,7 +773,6 @@ mod tests {
         let mut waiter = ProposalLeaderWaiter::V3(NextCommitLeaderSchedule {
             next_commit_index: 1,
             min_next_leader_round: 4,
-            num_leaders: 1,
             allowed_leaders: vec![
                 AuthorityIndex::new_for_test(0),
                 AuthorityIndex::new_for_test(2),
@@ -792,7 +791,6 @@ mod tests {
         waiter.update_v3_schedule(NextCommitLeaderSchedule {
             next_commit_index: 2,
             min_next_leader_round: 4,
-            num_leaders: 1,
             allowed_leaders: vec![
                 AuthorityIndex::new_for_test(1),
                 AuthorityIndex::new_for_test(3),

--- a/crates/sui-core/src/consensus_manager/mod.rs
+++ b/crates/sui-core/src/consensus_manager/mod.rs
@@ -135,6 +135,7 @@ fn to_consensus_protocol_config(config: &ProtocolConfig, chain: Chain) -> Consen
         config.consensus_bad_nodes_stake_threshold(),
         /* enable_v3 */ false,
         /* leader_schedule_window_size */ 300,
+        /* leader_schedule_update_interval */ 12,
     )
 }
 

--- a/crates/sui-core/src/consensus_manager/mod.rs
+++ b/crates/sui-core/src/consensus_manager/mod.rs
@@ -134,6 +134,7 @@ fn to_consensus_protocol_config(config: &ProtocolConfig, chain: Chain) -> Consen
         config.mysticeti_num_leaders_per_round(),
         config.consensus_bad_nodes_stake_threshold(),
         /* enable_v3 */ false,
+        /* leader_schedule_running_length */ 300,
     )
 }
 

--- a/crates/sui-core/src/consensus_manager/mod.rs
+++ b/crates/sui-core/src/consensus_manager/mod.rs
@@ -134,7 +134,7 @@ fn to_consensus_protocol_config(config: &ProtocolConfig, chain: Chain) -> Consen
         config.mysticeti_num_leaders_per_round(),
         config.consensus_bad_nodes_stake_threshold(),
         /* enable_v3 */ false,
-        /* leader_schedule_running_length */ 300,
+        /* leader_schedule_window_size */ 300,
     )
 }
 


### PR DESCRIPTION
## Description 

Support multiple anchor blocks / leaders per round in leader schedule, and allow adjusting the number of leaders dynamically.

Computation for leader scores (comment above `LeaderScheduleV3`):

When `C >= 4`, C-1, C-2 and C-3 exist as pending commits.
Let `r` be the leader round of commit C-3.

For each authority A: consider A's block at round `r+1` (voting round) across commits
from commit C-2 to commit with leader round > `r+1`.
If there are multiple A blocks in this slot, `score[A] = 0`.

Collect the set of distinct authorities P, such that A's voting block votes to
(has an ancestor link to) P's round `r` block (leader block) in commit C-3.
Then `voted_for_stake[A] = sum_{P in distinct set} stake(P)`.

Collect the set of distinct authorities Q, such that a Q's round `r+2`
block certifies (has an ancestor link to) A's voting block in round `r+1`,
across commits from C-2 to commit with leader round > `r+2`.
Then `certified_by_stake[A] = sum_{Q in distinct set} stake(Q)`.

The overall score for A is `score[A] = voted_for_stake[A] * certified_by_stake[A]`.

## Test plan 

CI
