### PR TITLE
[move/execution] compressed type layouts conversion

### DIFF
--- a/crates/sui-json-rpc/src/indexer_api.rs
+++ b/crates/sui-json-rpc/src/indexer_api.rs
@@ -124,7 +124,8 @@ impl<R: ReadApiServer> IndexerApi<R> {
             value,
         } = name;
         let epoch_store = self.state.load_epoch_store_one_call_per_task();
-        let layout = TypeLayoutBuilder::build_with_types(&name_type, epoch_store.module_cache())?;
+        let layout = TypeLayoutBuilder::build_with_types(&name_type, epoch_store.module_cache())
+            .and_then(|compressed| compressed.inflate())?;
         let sui_json_value = SuiJsonValue::new(value)?;
         let name_bcs_value = sui_json_value.to_bcs_bytes(&layout)?;
         Ok((name_type, name_bcs_value))

--- a/crates/sui-types/src/layout_resolver.rs
+++ b/crates/sui-types/src/layout_resolver.rs
@@ -20,11 +20,11 @@ pub fn get_layout_from_struct_tag(
     resolver: &impl GetModule,
 ) -> Result<A::MoveDatatypeLayout, SuiError> {
     let type_ = TypeTag::Struct(Box::new(struct_tag));
-    let layout = TypeLayoutBuilder::build_with_types(&type_, resolver).map_err(|e| {
-        SuiErrorKind::ObjectSerializationError {
+    let layout = TypeLayoutBuilder::build_with_types(&type_, resolver)
+        .and_then(|compressed| compressed.inflate())
+        .map_err(|e| SuiErrorKind::ObjectSerializationError {
             error: e.to_string(),
-        }
-    })?;
+        })?;
     match layout {
         A::MoveTypeLayout::Struct(l) => Ok(A::MoveDatatypeLayout::Struct(l)),
         A::MoveTypeLayout::Enum(e) => Ok(A::MoveDatatypeLayout::Enum(e)),

--- a/crates/sui-types/src/object.rs
+++ b/crates/sui-types/src/object.rs
@@ -336,11 +336,11 @@ impl MoveObject {
         resolver: &impl GetModule,
     ) -> Result<MoveStructLayout, SuiError> {
         let type_ = TypeTag::Struct(Box::new(struct_tag));
-        let layout = TypeLayoutBuilder::build_with_types(&type_, resolver).map_err(|e| {
-            SuiErrorKind::ObjectSerializationError {
+        let layout = TypeLayoutBuilder::build_with_types(&type_, resolver)
+            .and_then(|compressed| compressed.inflate())
+            .map_err(|e| SuiErrorKind::ObjectSerializationError {
                 error: e.to_string(),
-            }
-        })?;
+            })?;
         match layout {
             MoveTypeLayout::Struct(l) => Ok(*l),
             _ => unreachable!(

--- a/external-crates/move/crates/move-binary-format/src/constant.rs
+++ b/external-crates/move/crates/move-binary-format/src/constant.rs
@@ -4,47 +4,62 @@
 
 use crate::file_format::{Constant, SignatureToken};
 
-use move_core_types::runtime_value::{MoveTypeLayout, MoveValue};
+use move_core_types::{
+    compressed::runtime::{
+        BackendBuilder as _, LayoutHandle, MoveLayoutView, MoveTypeLayout, MoveTypeLayoutBuilder,
+        MoveTypeLayoutRef,
+    },
+    runtime_value::MoveValue,
+};
 
-fn sig_to_ty(sig: &SignatureToken) -> Option<MoveTypeLayout> {
-    match sig {
-        SignatureToken::Signer => Some(MoveTypeLayout::Signer),
-        SignatureToken::Address => Some(MoveTypeLayout::Address),
-        SignatureToken::Bool => Some(MoveTypeLayout::Bool),
-        SignatureToken::U8 => Some(MoveTypeLayout::U8),
-        SignatureToken::U16 => Some(MoveTypeLayout::U16),
-        SignatureToken::U32 => Some(MoveTypeLayout::U32),
-        SignatureToken::U64 => Some(MoveTypeLayout::U64),
-        SignatureToken::U128 => Some(MoveTypeLayout::U128),
-        SignatureToken::U256 => Some(MoveTypeLayout::U256),
-        SignatureToken::Vector(v) => Some(MoveTypeLayout::Vector(Box::new(sig_to_ty(v.as_ref())?))),
-        SignatureToken::Reference(_)
-        | SignatureToken::MutableReference(_)
-        | SignatureToken::Datatype(_)
-        | SignatureToken::TypeParameter(_)
-        | SignatureToken::DatatypeInstantiation(_) => None,
+pub fn constant_sig_token_to_layout(sig: &SignatureToken) -> Option<MoveTypeLayout> {
+    fn sig_to_ty_internal(
+        builder: &mut MoveTypeLayoutBuilder,
+        sig: &SignatureToken,
+    ) -> Option<LayoutHandle> {
+        Some(match sig {
+            SignatureToken::Address => builder.address(),
+            SignatureToken::Bool => builder.bool(),
+            SignatureToken::U8 => builder.u8(),
+            SignatureToken::U16 => builder.u16(),
+            SignatureToken::U32 => builder.u32(),
+            SignatureToken::U64 => builder.u64(),
+            SignatureToken::U128 => builder.u128(),
+            SignatureToken::U256 => builder.u256(),
+            SignatureToken::Vector(v) => {
+                let inner = sig_to_ty_internal(builder, v.as_ref())?;
+                builder.vector(inner).ok()?
+            }
+            SignatureToken::Signer
+            | SignatureToken::Reference(_)
+            | SignatureToken::MutableReference(_)
+            | SignatureToken::Datatype(_)
+            | SignatureToken::TypeParameter(_)
+            | SignatureToken::DatatypeInstantiation(_) => return None,
+        })
     }
+
+    let mut builder = MoveTypeLayoutBuilder::new();
+    sig_to_ty_internal(&mut builder, sig).map(|handle| builder.build(handle))
 }
 
-fn ty_to_sig(ty: &MoveTypeLayout) -> Option<SignatureToken> {
-    match ty {
-        MoveTypeLayout::Address => Some(SignatureToken::Address),
-        MoveTypeLayout::Signer => Some(SignatureToken::Signer),
-        MoveTypeLayout::U8 => Some(SignatureToken::U8),
-        MoveTypeLayout::U16 => Some(SignatureToken::U16),
-        MoveTypeLayout::U32 => Some(SignatureToken::U32),
-        MoveTypeLayout::U64 => Some(SignatureToken::U64),
-        MoveTypeLayout::U128 => Some(SignatureToken::U128),
-        MoveTypeLayout::U256 => Some(SignatureToken::U256),
-        MoveTypeLayout::Vector(v) => Some(SignatureToken::Vector(Box::new(ty_to_sig(v.as_ref())?))),
-        MoveTypeLayout::Struct(_) => None,
-        MoveTypeLayout::Enum(_) => None,
-        MoveTypeLayout::Bool => Some(SignatureToken::Bool),
+fn ty_to_sig(ty: MoveTypeLayoutRef<'_>) -> Option<SignatureToken> {
+    match ty.as_view() {
+        MoveLayoutView::Address => Some(SignatureToken::Address),
+        MoveLayoutView::U8 => Some(SignatureToken::U8),
+        MoveLayoutView::U16 => Some(SignatureToken::U16),
+        MoveLayoutView::U32 => Some(SignatureToken::U32),
+        MoveLayoutView::U64 => Some(SignatureToken::U64),
+        MoveLayoutView::U128 => Some(SignatureToken::U128),
+        MoveLayoutView::U256 => Some(SignatureToken::U256),
+        MoveLayoutView::Vector(v) => Some(SignatureToken::Vector(Box::new(ty_to_sig(v)?))),
+        MoveLayoutView::Bool => Some(SignatureToken::Bool),
+        MoveLayoutView::Signer | MoveLayoutView::Struct(_) | MoveLayoutView::Enum(_) => None,
     }
 }
 
 impl Constant {
-    pub fn serialize_constant(ty: &MoveTypeLayout, v: &MoveValue) -> Option<Self> {
+    pub fn serialize_constant(ty: MoveTypeLayoutRef<'_>, v: &MoveValue) -> Option<Self> {
         Some(Self {
             type_: ty_to_sig(ty)?,
             data: v.simple_serialize()?,
@@ -52,7 +67,7 @@ impl Constant {
     }
 
     pub fn deserialize_constant(&self) -> Option<MoveValue> {
-        let ty = sig_to_ty(&self.type_)?;
-        MoveValue::simple_deserialize(&self.data, &ty).ok()
+        let ty = constant_sig_token_to_layout(&self.type_)?;
+        MoveValue::simple_deserialize_compressed(&self.data, &ty).ok()
     }
 }

--- a/external-crates/move/crates/move-bytecode-utils/src/layout.rs
+++ b/external-crates/move/crates/move-bytecode-utils/src/layout.rs
@@ -14,7 +14,7 @@ use move_binary_format::{
 };
 use move_core_types::{
     account_address::AccountAddress,
-    annotated_value as A,
+    compressed::annotated::{self as CA, BackendBuilder as _, LayoutHandle},
     identifier::{IdentStr, Identifier},
     language_storage::{ModuleId, StructTag, TypeTag},
 };
@@ -206,8 +206,11 @@ impl<'a, T: GetModule> SerdeLayoutBuilder<'a, T> {
                     )?))
                 }
             }
-            T::TypeParameter(i) => input_type_args[*i as usize].clone(),
-            T::Reference(_, _) => unreachable!(), // structs cannot store references
+            T::TypeParameter(i) => input_type_args
+                .get(*i as usize)
+                .ok_or_else(|| anyhow::format_err!("Type parameter index {} out of bounds", i))?
+                .clone(),
+            T::Reference(_, _) => bail!("Structs cannot store references"),
         })
     }
 
@@ -227,8 +230,8 @@ impl<'a, T: GetModule> SerdeLayoutBuilder<'a, T> {
             .module_resolver
             .get_module_by_id(module_id)
             .map_err(|e| anyhow::format_err!("{:?}", e))?
-            .expect("Failed to resolve module");
-        let normalized = self.normalized_module(declaring_module.borrow());
+            .ok_or_else(|| anyhow::format_err!("Module not found: {}", module_id))?;
+        let normalized = self.normalized_module(declaring_module.borrow())?;
         let def = match (
             normalized.structs.get(name.as_ident_str()),
             normalized.enums.get(name.as_ident_str()),
@@ -264,8 +267,7 @@ impl<'a, T: GetModule> SerdeLayoutBuilder<'a, T> {
                 "{}{}",
                 module_id.address(),
                 self.config.separator.as_deref().unwrap_or("::")
-            )
-            .unwrap();
+            )?;
         }
         write!(
             type_key,
@@ -273,8 +275,7 @@ impl<'a, T: GetModule> SerdeLayoutBuilder<'a, T> {
             module_id.name(),
             self.config.separator.as_deref().unwrap_or("::"),
             name
-        )
-        .unwrap();
+        )?;
         if !generics.is_empty() {
             write!(
                 type_key,
@@ -282,8 +283,7 @@ impl<'a, T: GetModule> SerdeLayoutBuilder<'a, T> {
                 self.config.separator.as_deref().unwrap_or("<"),
                 generics.join(self.config.separator.as_deref().unwrap_or(",")),
                 self.config.separator.as_deref().unwrap_or(">")
-            )
-            .unwrap()
+            )?
         }
         if self.config.shallow {
             return Ok(Format::TypeName(type_key));
@@ -393,13 +393,15 @@ impl<'a, T: GetModule> SerdeLayoutBuilder<'a, T> {
         Ok(ContainerFormat::Enum(variants))
     }
 
-    fn normalized_module(&mut self, module: &CompiledModule) -> &Module {
+    fn normalized_module(&mut self, module: &CompiledModule) -> Result<&Module> {
         let id = module.self_id();
         if !self.modules.contains_key(&id) {
             let normalized = Module::new(&mut self.pool, module, /* include code */ false);
             self.modules.insert(id.clone(), normalized);
         }
-        self.modules.get(&id).unwrap()
+        self.modules
+            .get(&id)
+            .ok_or_else(|| anyhow::format_err!("Failed to get normalized module"))
     }
 }
 
@@ -415,7 +417,7 @@ fn print_format_type(t: &Format, depth: u64) -> Result<String> {
         Format::U128 => "u128".to_string(),
         Format::Bytes => "vector<u8>".to_string(),
         Format::Seq(inner) => format!("vector<{}>", print_format_type(inner, depth + 1)?),
-        v => unimplemented!("Printing format value {:?}", v),
+        v => bail!("Printing format value {:?} not implemented", v),
     })
 }
 
@@ -426,77 +428,104 @@ impl TypeLayoutBuilder {
     /// Construct a WithTypes `TypeLayout` with fields from `t`.
     /// Panics if `resolver` cannot resolve a module whose types are referenced directly or
     /// transitively by `t`
-    pub fn build_with_types(t: &TypeTag, resolver: &impl GetModule) -> Result<A::MoveTypeLayout> {
-        Self::build(t, resolver, 0)
+    pub fn build_with_types(t: &TypeTag, resolver: &impl GetModule) -> Result<CA::MoveTypeLayout> {
+        let mut builder = CA::MoveTypeLayoutBuilder::new();
+        let root = Self::build(&mut builder, t, resolver, 0)?;
+        Ok(builder.build(root))
     }
 
-    fn build(t: &TypeTag, resolver: &impl GetModule, depth: u64) -> Result<A::MoveTypeLayout> {
+    fn build(
+        builder: &mut CA::MoveTypeLayoutBuilder,
+        t: &TypeTag,
+        resolver: &impl GetModule,
+        depth: u64,
+    ) -> Result<LayoutHandle> {
         use TypeTag::*;
         check_depth!(depth);
         Ok(match t {
-            Bool => A::MoveTypeLayout::Bool,
-            U8 => A::MoveTypeLayout::U8,
-            U16 => A::MoveTypeLayout::U16,
-            U32 => A::MoveTypeLayout::U32,
-            U64 => A::MoveTypeLayout::U64,
-            U128 => A::MoveTypeLayout::U128,
-            U256 => A::MoveTypeLayout::U256,
-            Address => A::MoveTypeLayout::Address,
+            Bool => builder.bool(),
+            U8 => builder.u8(),
+            U16 => builder.u16(),
+            U32 => builder.u32(),
+            U64 => builder.u64(),
+            U128 => builder.u128(),
+            U256 => builder.u256(),
+            Address => builder.address(),
             Signer => bail!("Type layouts cannot contain signer"),
             Vector(elem_t) => {
-                A::MoveTypeLayout::Vector(Box::new(Self::build(elem_t, resolver, depth + 1)?))
+                let inner = Self::build(builder, elem_t, resolver, depth + 1)?;
+                builder.vector(inner)?
             }
-            Struct(s) => DatatypeLayoutBuilder::build(s, resolver, depth + 1)?.into_layout(),
+            Struct(s) => DatatypeLayoutBuilder::build(builder, s, resolver, depth + 1)?,
         })
     }
 
     fn build_from_signature_token(
+        builder: &mut CA::MoveTypeLayoutBuilder,
         m: &CompiledModule,
         s: &SignatureToken,
-        type_arguments: &[A::MoveTypeLayout],
+        type_arguments: &[LayoutHandle],
         resolver: &impl GetModule,
         depth: u64,
-    ) -> Result<A::MoveTypeLayout> {
+    ) -> Result<LayoutHandle> {
         use SignatureToken::*;
         check_depth!(depth);
         Ok(match s {
-            Vector(t) => A::MoveTypeLayout::Vector(Box::new(Self::build_from_signature_token(
+            Vector(t) => {
+                let inner = Self::build_from_signature_token(
+                    builder,
+                    m,
+                    t,
+                    type_arguments,
+                    resolver,
+                    depth + 1,
+                )?;
+                builder.vector(inner)?
+            }
+            Datatype(shi) => DatatypeLayoutBuilder::build_from_handle_idx(
+                builder,
                 m,
-                t,
-                type_arguments,
+                *shi,
+                vec![],
                 resolver,
                 depth + 1,
-            )?)),
-            Datatype(shi) => {
-                DatatypeLayoutBuilder::build_from_handle_idx(m, *shi, vec![], resolver, depth + 1)?
-                    .into_layout()
-            }
+            )?,
             DatatypeInstantiation(inst) => {
                 let (shi, type_actuals) = &**inst;
                 let actual_layouts = type_actuals
                     .iter()
                     .map(|t| {
-                        Self::build_from_signature_token(m, t, type_arguments, resolver, depth + 1)
+                        Self::build_from_signature_token(
+                            builder,
+                            m,
+                            t,
+                            type_arguments,
+                            resolver,
+                            depth + 1,
+                        )
                     })
                     .collect::<Result<Vec<_>>>()?;
                 DatatypeLayoutBuilder::build_from_handle_idx(
+                    builder,
                     m,
                     *shi,
                     actual_layouts,
                     resolver,
                     depth + 1,
                 )?
-                .into_layout()
             }
-            TypeParameter(i) => type_arguments[*i as usize].clone(),
-            Bool => A::MoveTypeLayout::Bool,
-            U8 => A::MoveTypeLayout::U8,
-            U16 => A::MoveTypeLayout::U16,
-            U32 => A::MoveTypeLayout::U32,
-            U64 => A::MoveTypeLayout::U64,
-            U128 => A::MoveTypeLayout::U128,
-            U256 => A::MoveTypeLayout::U256,
-            Address => A::MoveTypeLayout::Address,
+            TypeParameter(i) => type_arguments
+                .get(*i as usize)
+                .copied()
+                .ok_or_else(|| anyhow::format_err!("Type parameter index {} out of bounds", i))?,
+            Bool => builder.bool(),
+            U8 => builder.u8(),
+            U16 => builder.u16(),
+            U32 => builder.u32(),
+            U64 => builder.u64(),
+            U128 => builder.u128(),
+            U256 => builder.u256(),
+            Address => builder.address(),
             Signer => bail!("Type layouts cannot contain signer"),
             Reference(_) | MutableReference(_) => bail!("Type layouts cannot contain references"),
         })
@@ -508,37 +537,47 @@ impl DatatypeLayoutBuilder {
     /// Panics if `resolver` cannot resolved a module whose types are referenced directly or
     /// transitively by `s`.
     fn build(
+        builder: &mut CA::MoveTypeLayoutBuilder,
         s: &StructTag,
         resolver: &impl GetModule,
         depth: u64,
-    ) -> Result<A::MoveDatatypeLayout> {
+    ) -> Result<LayoutHandle> {
         check_depth!(depth);
         let type_arguments = s
             .type_params
             .iter()
-            .map(|t| TypeLayoutBuilder::build(t, resolver, depth))
-            .collect::<Result<Vec<A::MoveTypeLayout>>>()?;
-        Self::build_from_name(&s.module_id(), &s.name, type_arguments, resolver, depth)
+            .map(|t| TypeLayoutBuilder::build(builder, t, resolver, depth))
+            .collect::<Result<Vec<LayoutHandle>>>()?;
+        Self::build_from_name(
+            builder,
+            &s.module_id(),
+            &s.name,
+            type_arguments,
+            resolver,
+            depth,
+        )
     }
 
     fn build_from_enum_definition(
+        builder: &mut CA::MoveTypeLayoutBuilder,
         m: &CompiledModule,
         e: &EnumDefinition,
-        type_arguments: Vec<A::MoveTypeLayout>,
+        type_arguments: Vec<LayoutHandle>,
         resolver: &impl GetModule,
         depth: u64,
-    ) -> Result<A::MoveEnumLayout> {
+    ) -> Result<LayoutHandle> {
         let e_handle = m.datatype_handle_at(e.enum_handle);
         if e_handle.type_parameters.len() != type_arguments.len() {
             bail!("Wrong number of type arguments for enum")
         }
 
-        let mut variants = BTreeMap::new();
+        let mut variants = vec![];
         for (i, variant) in e.variants.iter().enumerate() {
             let name = m.identifier_at(variant.variant_name).to_owned();
             let mut fields = vec![];
             for field in &variant.fields {
                 let ty = TypeLayoutBuilder::build_from_signature_token(
+                    builder,
                     m,
                     &field.signature.0,
                     &type_arguments,
@@ -546,30 +585,57 @@ impl DatatypeLayoutBuilder {
                     depth,
                 )?;
                 let name = m.identifier_at(field.name).to_owned();
-                fields.push(A::MoveFieldLayout::new(name, ty));
+                fields.push((name, ty));
             }
-            variants.insert((name, i as u16), fields);
+            variants.push((name, i as u16, Some(fields)));
         }
 
         let mid = m.self_id();
-        let type_params: Vec<TypeTag> = type_arguments.iter().map(|t| t.into()).collect();
+        let Some(type_params) = type_arguments
+            .iter()
+            .map(|t| builder.type_tag(*t))
+            .collect()
+        else {
+            bail!("Failed to convert type argument to type tag")
+        };
         let type_ = StructTag {
             address: *mid.address(),
             module: mid.name().to_owned(),
             name: m.identifier_at(e_handle.name).to_owned(),
             type_params,
         };
-
-        Ok(A::MoveEnumLayout { type_, variants })
+        let variant_field_refs: Vec<Vec<(&Identifier, LayoutHandle)>> = variants
+            .iter()
+            .map(|(_, _, fields)| {
+                fields
+                    .as_ref()
+                    .map(|fs| fs.iter().map(|(n, h)| (n, *h)).collect())
+                    .unwrap_or_default()
+            })
+            .collect();
+        let variant_refs: Vec<(&Identifier, u16, Option<&[(&Identifier, LayoutHandle)]>)> = variants
+            .iter()
+            .zip(variant_field_refs.iter())
+            .map(|((name, tag, fields), field_refs)| {
+                let payload = if fields.is_some() {
+                    Some(field_refs.as_slice())
+                } else {
+                    None
+                };
+                (name, *tag, payload)
+            })
+            .collect();
+        builder.enum_layout(&type_, &variant_refs)
     }
 
     fn build_from_struct_definition(
+        builder: &mut CA::MoveTypeLayoutBuilder,
         m: &CompiledModule,
         s: &StructDefinition,
-        type_arguments: Vec<A::MoveTypeLayout>,
+        type_arguments: Vec<LayoutHandle>,
         resolver: &impl GetModule,
         depth: u64,
-    ) -> Result<A::MoveStructLayout> {
+    ) -> Result<LayoutHandle> {
         check_depth!(depth);
         let s_handle = m.datatype_handle_at(s.struct_handle);
         if s_handle.type_parameters.len() != type_arguments.len() {
@@ -584,6 +650,7 @@ impl DatatypeLayoutBuilder {
                     .iter()
                     .map(|f| {
                         TypeLayoutBuilder::build_from_signature_token(
+                            builder,
                             m,
                             &f.signature.0,
                             &type_arguments,
@@ -591,34 +658,44 @@ impl DatatypeLayoutBuilder {
                             depth,
                         )
                     })
-                    .collect::<Result<Vec<A::MoveTypeLayout>>>()?;
+                    .collect::<Result<Vec<LayoutHandle>>>()?;
 
                 let mid = m.self_id();
-                let type_params: Vec<TypeTag> = type_arguments.iter().map(|t| t.into()).collect();
+                let Some(type_params) = type_arguments
+                    .iter()
+                    .map(|t| builder.type_tag(*t))
+                    .collect()
+                else {
+                    bail!("Failed to convert type argument to type tag")
+                };
                 let type_ = StructTag {
                     address: *mid.address(),
                     module: mid.name().to_owned(),
                     name: m.identifier_at(s_handle.name).to_owned(),
                     type_params,
                 };
-                let fields = fields
+                let field_names: Vec<Identifier> = fields
                     .iter()
                     .map(|f| m.identifier_at(f.name).to_owned())
-                    .zip(layouts)
-                    .map(|(name, layout)| A::MoveFieldLayout::new(name, layout))
                     .collect();
-                Ok(A::MoveStructLayout { type_, fields })
+                let field_refs: Vec<(&Identifier, LayoutHandle)> = field_names
+                    .iter()
+                    .zip(layouts.iter())
+                    .map(|(n, h)| (n, *h))
+                    .collect();
+                builder.struct_layout(&type_, &field_refs)
             }
         }
     }
 
     fn build_from_name(
+        builder: &mut CA::MoveTypeLayoutBuilder,
         declaring_module: &ModuleId,
         name: &IdentStr,
-        type_arguments: Vec<A::MoveTypeLayout>,
+        type_arguments: Vec<LayoutHandle>,
         resolver: &impl GetModule,
         depth: u64,
-    ) -> Result<A::MoveDatatypeLayout> {
+    ) -> Result<LayoutHandle> {
         check_depth!(depth);
         let module = match resolver.get_module_by_id(declaring_module) {
             Err(_) | Ok(None) => bail!("Could not find module"),
@@ -628,24 +705,22 @@ impl DatatypeLayoutBuilder {
             module.borrow().find_struct_def_by_name(name.as_str()),
             module.borrow().find_enum_def_by_name(name.as_str()),
         ) {
-            (Some((_, struct_def)), None) => Ok(A::MoveDatatypeLayout::Struct(Box::new(
-                Self::build_from_struct_definition(
-                    module.borrow(),
-                    struct_def,
-                    type_arguments,
-                    resolver,
-                    depth,
-                )?,
-            ))),
-            (None, Some((_, enum_def))) => Ok(A::MoveDatatypeLayout::Enum(Box::new(
-                Self::build_from_enum_definition(
-                    module.borrow(),
-                    enum_def,
-                    type_arguments,
-                    resolver,
-                    depth,
-                )?,
-            ))),
+            (Some((_, struct_def)), None) => Self::build_from_struct_definition(
+                builder,
+                module.borrow(),
+                struct_def,
+                type_arguments,
+                resolver,
+                depth,
+            ),
+            (None, Some((_, enum_def))) => Self::build_from_enum_definition(
+                builder,
+                module.borrow(),
+                enum_def,
+                type_arguments,
+                resolver,
+                depth,
+            ),
             (Some(_), Some(_)) => bail!("Found both struct and enum with name {}", name),
             (None, None) => bail!(
                 "Could not find struct/enum named {} in module {}",
@@ -656,28 +731,32 @@ impl DatatypeLayoutBuilder {
     }
 
     fn build_from_handle_idx(
+        builder: &mut CA::MoveTypeLayoutBuilder,
         m: &CompiledModule,
         s: DatatypeHandleIndex,
-        type_arguments: Vec<A::MoveTypeLayout>,
+        type_arguments: Vec<LayoutHandle>,
         resolver: &impl GetModule,
         depth: u64,
-    ) -> Result<A::MoveDatatypeLayout> {
+    ) -> Result<LayoutHandle> {
         check_depth!(depth);
         if let Some(def) = m.find_struct_def(s) {
             // declared internally
-            Ok(A::MoveDatatypeLayout::Struct(Box::new(
-                Self::build_from_struct_definition(m, def, type_arguments, resolver, depth)?,
-            )))
+            Self::build_from_struct_definition(builder, m, def, type_arguments, resolver, depth)
         } else if let Some(def) = m.find_enum_def(s) {
-            Ok(A::MoveDatatypeLayout::Enum(Box::new(
-                Self::build_from_enum_definition(m, def, type_arguments, resolver, depth)?,
-            )))
+            Self::build_from_enum_definition(builder, m, def, type_arguments, resolver, depth)
         } else {
             let handle = m.datatype_handle_at(s);
             let name = m.identifier_at(handle.name);
             let declaring_module = m.module_id_for_handle(m.module_handle_at(handle.module));
             // declared externally
-            Self::build_from_name(&declaring_module, name, type_arguments, resolver, depth)
+            Self::build_from_name(
+                builder,
+                &declaring_module,
+                name,
+                type_arguments,
+                resolver,
+                depth,
+            )
         }
     }
 }

--- a/external-crates/move/crates/move-core-types/src/compressed/annotated/layout.rs
+++ b/external-crates/move/crates/move-core-types/src/compressed/annotated/layout.rs
@@ -18,6 +18,11 @@ use std::fmt;
 /// `AnnotatedBoxPoolBuilder`) — call sites are otherwise identical.
 pub use crate::compressed::backend::DefaultAnnotatedBuilder as MoveTypeLayoutBuilder;
 
+/// Handle returned by [`MoveTypeLayoutBuilder`] for nodes interned into the
+/// default backend. Type alias over the builder's `Root` so consumers can
+/// traffic in a single name without naming the backend's internal ref type.
+pub type LayoutHandle = <MoveTypeLayoutBuilder as BackendBuilder>::Root;
+
 // =============================================================================
 // Trait: TypeLayout
 // =============================================================================

--- a/external-crates/move/crates/move-core-types/src/compressed/annotated/layout.rs
+++ b/external-crates/move/crates/move-core-types/src/compressed/annotated/layout.rs
@@ -576,8 +576,8 @@ impl<'a, T: TypeLayout> MoveFieldsLayout<'a, T> {
 
     /// Access a field by index, returning `(name, layout)`.
     #[inline]
-    pub fn field(self, i: usize) -> Option<(&'a Identifier, MoveTypeLayoutRef<'a, T>)> {
-        self.fields.get(i).map(|entry| {
+    pub fn field(self, i: u16) -> Option<(&'a Identifier, MoveTypeLayoutRef<'a, T>)> {
+        self.fields.get(i as usize).map(|entry| {
             (
                 &entry.name,
                 MoveTypeLayoutRef {
@@ -647,7 +647,7 @@ impl<'a, T: TypeLayout> MoveStructLayout<'a, T> {
 
     /// Access a field by index, returning `(name, layout)`.
     #[inline]
-    pub fn field(self, i: usize) -> Option<(&'a Identifier, MoveTypeLayoutRef<'a, T>)> {
+    pub fn field(self, i: u16) -> Option<(&'a Identifier, MoveTypeLayoutRef<'a, T>)> {
         self.fields.field(i)
     }
 
@@ -729,15 +729,9 @@ impl<'a, T: TypeLayout> MoveEnumLayout<'a, T> {
         self.variants.len()
     }
 
-    /// Access a variant by position index.
+    /// Access a variant by its tag.
     #[inline]
-    pub fn variant(self, i: usize) -> Option<VariantLayout<'a, T>> {
-        self.variants.get(i).map(|v| variant_view(self.pool, v))
-    }
-
-    /// Find a variant by its tag value.
-    #[inline]
-    pub fn variant_by_tag(self, tag: VariantTag) -> Option<VariantLayout<'a, T>> {
+    pub fn variant(self, tag: VariantTag) -> Option<VariantLayout<'a, T>> {
         self.variants
             .iter()
             .find(|v| v.tag == tag)

--- a/external-crates/move/crates/move-core-types/src/compressed/annotated/layout.rs
+++ b/external-crates/move/crates/move-core-types/src/compressed/annotated/layout.rs
@@ -260,6 +260,18 @@ pub trait BackendBuilder: Sized {
         let pool = self.finalize(root.clone());
         MoveTypeLayout::from_parts(pool, root)
     }
+
+    /// Construct a [`MoveTypeLayout`] by running a closure that builds up a
+    /// root handle. Returns the closure's error verbatim.
+    fn with_builder<F>(f: F) -> Result<MoveTypeLayout<Self::Output>, Self::Error>
+    where
+        Self: Default,
+        F: FnOnce(&mut Self) -> Result<Self::Root, Self::Error>,
+    {
+        let mut b = Self::default();
+        let root = f(&mut b)?;
+        Ok(b.build(root))
+    }
 }
 
 // =============================================================================

--- a/external-crates/move/crates/move-core-types/src/compressed/annotated/mod.rs
+++ b/external-crates/move/crates/move-core-types/src/compressed/annotated/mod.rs
@@ -5,7 +5,7 @@ mod layout;
 mod serde_impl;
 
 pub use layout::{
-    BackendBuilder, MoveDatatypeLayout, MoveEnumLayout, MoveFieldsLayout, MoveLayoutView,
-    MoveStructLayout, MoveTypeLayout, MoveTypeLayoutBuilder, MoveTypeLayoutRef, TypeLayout,
-    VariantLayout,
+    BackendBuilder, LayoutHandle, MoveDatatypeLayout, MoveEnumLayout, MoveFieldsLayout,
+    MoveLayoutView, MoveStructLayout, MoveTypeLayout, MoveTypeLayoutBuilder, MoveTypeLayoutRef,
+    TypeLayout, VariantLayout,
 };

--- a/external-crates/move/crates/move-core-types/src/compressed/annotated/serde_impl.rs
+++ b/external-crates/move/crates/move-core-types/src/compressed/annotated/serde_impl.rs
@@ -138,7 +138,7 @@ impl<'a, 'd, T: TypeLayout> serde::de::Visitor<'d> for CompressedEnumFieldVisito
             None => return Err(A::Error::invalid_length(0, &self)),
         };
 
-        let vl = match self.0.variant_by_tag(tag) {
+        let vl = match self.0.variant(tag) {
             Some(vl) => vl,
             None => return Err(A::Error::invalid_length(tag as usize, &self)),
         };

--- a/external-crates/move/crates/move-core-types/src/compressed/backend/arc_pool.rs
+++ b/external-crates/move/crates/move-core-types/src/compressed/backend/arc_pool.rs
@@ -117,6 +117,39 @@ impl AnnotatedArcPoolBuilder {
     pub fn new() -> Self {
         Self::default()
     }
+
+    /// Resolve the type tag of a previously-interned annotated layout handle.
+    /// Returns `None` if `handle` points to an out-of-bounds table index.
+    pub fn type_tag(
+        &self,
+        handle: LayoutRef,
+    ) -> Option<crate::language_storage::TypeTag> {
+        use crate::language_storage::TypeTag;
+        Some(match handle.resolve() {
+            ResolvedRef::Leaf(leaf) => match leaf {
+                LeafType::Bool => TypeTag::Bool,
+                LeafType::U8 => TypeTag::U8,
+                LeafType::U16 => TypeTag::U16,
+                LeafType::U32 => TypeTag::U32,
+                LeafType::U64 => TypeTag::U64,
+                LeafType::U128 => TypeTag::U128,
+                LeafType::U256 => TypeTag::U256,
+                LeafType::Address => TypeTag::Address,
+                LeafType::Signer => TypeTag::Signer,
+            },
+            ResolvedRef::Index(idx) => match self.0.get(idx)? {
+                annotated_nodes::MoveTypeNode::Vector(inner) => {
+                    TypeTag::Vector(Box::new(self.type_tag(*inner)?))
+                }
+                annotated_nodes::MoveTypeNode::Struct(s) => {
+                    TypeTag::Struct(Box::new(s.type_.clone()))
+                }
+                annotated_nodes::MoveTypeNode::Enum(e) => {
+                    TypeTag::Struct(Box::new(e.type_.clone()))
+                }
+            },
+        })
+    }
 }
 
 impl runtime::BackendBuilder for RuntimeArcPoolBuilder {

--- a/external-crates/move/crates/move-core-types/src/compressed/backend/encoding.rs
+++ b/external-crates/move/crates/move-core-types/src/compressed/backend/encoding.rs
@@ -137,4 +137,9 @@ impl<Node: Eq + std::hash::Hash> PoolBuilder<Node> {
     pub fn into_vec(self) -> Vec<Node> {
         self.nodes.into_iter().collect()
     }
+
+    /// Look up a previously-interned node by its index.
+    pub(crate) fn get(&self, idx: usize) -> Option<&Node> {
+        self.nodes.get_index(idx)
+    }
 }

--- a/external-crates/move/crates/move-core-types/src/compressed/runtime/layout.rs
+++ b/external-crates/move/crates/move-core-types/src/compressed/runtime/layout.rs
@@ -225,6 +225,18 @@ pub trait BackendBuilder: Sized {
         let pool = self.finalize(root.clone());
         MoveTypeLayout::from_parts(pool, root)
     }
+
+    /// Construct a [`MoveTypeLayout`] by running a closure that builds up a
+    /// root handle. Returns the closure's error verbatim.
+    fn with_builder<F>(f: F) -> Result<MoveTypeLayout<Self::Output>, Self::Error>
+    where
+        Self: Default,
+        F: FnOnce(&mut Self) -> Result<Self::Root, Self::Error>,
+    {
+        let mut b = Self::default();
+        let root = f(&mut b)?;
+        Ok(b.build(root))
+    }
 }
 
 // =============================================================================

--- a/external-crates/move/crates/move-core-types/src/compressed/runtime/layout.rs
+++ b/external-crates/move/crates/move-core-types/src/compressed/runtime/layout.rs
@@ -14,6 +14,11 @@ use std::fmt;
 /// `RuntimeBoxPoolBuilder`) — call sites are otherwise identical.
 pub use crate::compressed::backend::DefaultRuntimeBuilder as MoveTypeLayoutBuilder;
 
+/// Handle returned by [`MoveTypeLayoutBuilder`] for nodes interned into the
+/// default backend. Type alias over the builder's `Root` so consumers can
+/// traffic in a single name without naming the backend's internal ref type.
+pub type LayoutHandle = <MoveTypeLayoutBuilder as BackendBuilder>::Root;
+
 // =============================================================================
 // Trait: TypeLayout
 // =============================================================================

--- a/external-crates/move/crates/move-core-types/src/compressed/runtime/layout.rs
+++ b/external-crates/move/crates/move-core-types/src/compressed/runtime/layout.rs
@@ -2,6 +2,7 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::compressed::VariantTag;
 use crate::compressed::backend::DefaultRuntime;
 use crate::runtime_value as RV;
 use anyhow::Result as AResult;
@@ -428,8 +429,8 @@ impl<'a, T: TypeLayout> MoveFieldsLayout<'a, T> {
 
     /// Access a field by index.
     #[inline]
-    pub fn field(self, i: usize) -> Option<MoveTypeLayoutRef<'a, T>> {
-        self.fields.get(i).map(|f| MoveTypeLayoutRef {
+    pub fn field(self, i: u16) -> Option<MoveTypeLayoutRef<'a, T>> {
+        self.fields.get(i as usize).map(|f| MoveTypeLayoutRef {
             pool: self.pool,
             root: f,
         })
@@ -462,7 +463,7 @@ impl<'a, T: TypeLayout> MoveStructLayout<'a, T> {
 
     /// Access a field by index.
     #[inline]
-    pub fn field(self, i: usize) -> Option<MoveTypeLayoutRef<'a, T>> {
+    pub fn field(self, i: u16) -> Option<MoveTypeLayoutRef<'a, T>> {
         self.fields.field(i)
     }
 
@@ -506,10 +507,12 @@ impl<'a, T: TypeLayout> MoveEnumLayout<'a, T> {
         self.variants.len()
     }
 
-    /// Access a variant by index.
+    /// Access a variant by tag.
     #[inline]
-    pub fn variant(self, i: usize) -> Option<VariantLayout<'a, T>> {
-        self.variants.get(i).map(|v| make_variant(self.pool, v))
+    pub fn variant(self, tag: VariantTag) -> Option<VariantLayout<'a, T>> {
+        self.variants
+            .get(tag as usize)
+            .map(|v| make_variant(self.pool, v))
     }
 
     /// Iterate over all variants.

--- a/external-crates/move/crates/move-core-types/src/compressed/runtime/mod.rs
+++ b/external-crates/move/crates/move-core-types/src/compressed/runtime/mod.rs
@@ -5,6 +5,7 @@ mod layout;
 mod serde_impl;
 
 pub use layout::{
-    BackendBuilder, MoveEnumLayout, MoveFieldsLayout, MoveLayoutView, MoveStructLayout,
-    MoveTypeLayout, MoveTypeLayoutBuilder, MoveTypeLayoutRef, TypeLayout, VariantLayout,
+    BackendBuilder, LayoutHandle, MoveEnumLayout, MoveFieldsLayout, MoveLayoutView,
+    MoveStructLayout, MoveTypeLayout, MoveTypeLayoutBuilder, MoveTypeLayoutRef, TypeLayout,
+    VariantLayout,
 };

--- a/external-crates/move/crates/move-core-types/src/compressed/runtime/serde_impl.rs
+++ b/external-crates/move/crates/move-core-types/src/compressed/runtime/serde_impl.rs
@@ -123,7 +123,7 @@ impl<'a, 'd, T: TypeLayout> serde::de::Visitor<'d> for CompressedEnumFieldVisito
             None => return Err(A::Error::invalid_length(0, &self)),
         };
 
-        let variant_fv = match self.0.variant(tag as usize) {
+        let variant_fv = match self.0.variant(tag) {
             Some(VariantLayout::Known(fv)) => fv,
             Some(VariantLayout::Unknown) => {
                 return Err(A::Error::custom(format!(

--- a/external-crates/move/crates/move-core-types/src/runtime_value.rs
+++ b/external-crates/move/crates/move-core-types/src/runtime_value.rs
@@ -12,7 +12,7 @@ use crate::{
 use anyhow::{Result as AResult, anyhow};
 use move_proc_macros::test_variant_order;
 use serde::{
-    Deserialize, Serialize,
+    Deserialize,
     de::Error as DeError,
     ser::{SerializeSeq, SerializeTuple},
 };
@@ -58,13 +58,13 @@ pub enum MoveValue {
     Variant(MoveVariant),
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct MoveStructLayout(pub Box<Vec<MoveTypeLayout>>);
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct MoveEnumLayout(pub Box<Vec<Vec<MoveTypeLayout>>>);
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 pub enum MoveDatatypeLayout {
     Struct(Box<MoveStructLayout>),
     Enum(Box<MoveEnumLayout>),
@@ -79,34 +79,22 @@ impl MoveDatatypeLayout {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 #[test_variant_order(src/unit_tests/staged_enum_variant_order/move_type_layout.yaml)]
 pub enum MoveTypeLayout {
-    #[serde(rename(serialize = "bool", deserialize = "bool"))]
     Bool,
-    #[serde(rename(serialize = "u8", deserialize = "u8"))]
     U8,
-    #[serde(rename(serialize = "u64", deserialize = "u64"))]
     U64,
-    #[serde(rename(serialize = "u128", deserialize = "u128"))]
     U128,
-    #[serde(rename(serialize = "address", deserialize = "address"))]
     Address,
-    #[serde(rename(serialize = "vector", deserialize = "vector"))]
     Vector(Box<MoveTypeLayout>),
-    #[serde(rename(serialize = "struct", deserialize = "struct"))]
     Struct(Box<MoveStructLayout>),
-    #[serde(rename(serialize = "signer", deserialize = "signer"))]
     Signer,
 
     // NOTE: Added in bytecode version v6, do not reorder!
-    #[serde(rename(serialize = "u16", deserialize = "u16"))]
     U16,
-    #[serde(rename(serialize = "u32", deserialize = "u32"))]
     U32,
-    #[serde(rename(serialize = "u256", deserialize = "u256"))]
     U256,
-    #[serde(rename(serialize = "enum", deserialize = "enum"))]
     Enum(Box<MoveEnumLayout>),
 }
 

--- a/external-crates/move/crates/move-core-types/src/runtime_value.rs
+++ b/external-crates/move/crates/move-core-types/src/runtime_value.rs
@@ -103,6 +103,15 @@ impl MoveValue {
         Ok(bcs::from_bytes_seed(ty, blob)?)
     }
 
+    // TODO(compressed-layouts): look at removing this and only using the visitor-based
+    // deserialization.
+    pub fn simple_deserialize_compressed(
+        blob: &[u8],
+        ty: &crate::compressed::runtime::MoveTypeLayout,
+    ) -> AResult<Self> {
+        Ok(bcs::from_bytes_seed(ty, blob)?)
+    }
+
     /// Deserialize `blob` as a Move value with the given `ty`-pe layout, and visit its
     /// sub-structure with the given `visitor`. The visitor dictates the return value that is built
     /// up during deserialization.

--- a/external-crates/move/crates/move-core-types/src/runtime_value.rs
+++ b/external-crates/move/crates/move-core-types/src/runtime_value.rs
@@ -338,7 +338,7 @@ impl MoveVariant {
             name: v_name,
             tag: _,
             fields: field_layouts,
-        }) = layout.variant(tag as usize)
+        }) = layout.variant(tag)
         else {
             panic!("Unknown variant tag {tag} in compressed layout")
         };

--- a/external-crates/move/crates/move-core-types/src/runtime_value.rs
+++ b/external-crates/move/crates/move-core-types/src/runtime_value.rs
@@ -5,7 +5,9 @@
 use crate::{
     VARIANT_TAG_MAX_VALUE,
     account_address::AccountAddress,
-    annotated_value as A, fmt_list,
+    annotated_value as A,
+    compressed::annotated as CA,
+    fmt_list,
     runtime_visitor::{Error as VError, ValueDriver, Visitor, visit_struct, visit_value},
     u256,
 };
@@ -205,6 +207,32 @@ impl MoveValue {
             _ => panic!("Invalid decoration"),
         }
     }
+
+    pub fn decorate_compressed(self, layout: CA::MoveTypeLayoutRef<'_>) -> A::MoveValue {
+        match (self, layout.as_view()) {
+            (MoveValue::Struct(s), CA::MoveLayoutView::Struct(l)) => {
+                A::MoveValue::Struct(s.decorate_compressed(&l))
+            }
+            (MoveValue::Variant(s), CA::MoveLayoutView::Enum(l)) => {
+                A::MoveValue::Variant(s.decorate_compressed(&l))
+            }
+            (MoveValue::Vector(vals), CA::MoveLayoutView::Vector(t)) => A::MoveValue::Vector(
+                vals.into_iter()
+                    .map(|v| v.decorate_compressed(t))
+                    .collect(),
+            ),
+            (MoveValue::U8(a), _) => A::MoveValue::U8(a),
+            (MoveValue::U64(u), _) => A::MoveValue::U64(u),
+            (MoveValue::U128(u), _) => A::MoveValue::U128(u),
+            (MoveValue::Bool(b), _) => A::MoveValue::Bool(b),
+            (MoveValue::Address(a), _) => A::MoveValue::Address(a),
+            (MoveValue::Signer(a), _) => A::MoveValue::Signer(a),
+            (MoveValue::U16(u), _) => A::MoveValue::U16(u),
+            (MoveValue::U32(u), _) => A::MoveValue::U32(u),
+            (MoveValue::U256(u), _) => A::MoveValue::U256(u),
+            _ => panic!("Invalid decoration"),
+        }
+    }
 }
 
 pub fn serialize_values<'a, I>(vals: I) -> Vec<Vec<u8>>
@@ -259,6 +287,18 @@ impl MoveStruct {
         }
     }
 
+    pub fn decorate_compressed(self, layout: &CA::MoveStructLayout) -> A::MoveStruct {
+        let MoveStruct(vals) = self;
+        A::MoveStruct {
+            type_: layout.type_().clone(),
+            fields: vals
+                .into_iter()
+                .zip(layout.fields())
+                .map(|(v, l)| (l.0.clone(), v.decorate_compressed(l.1)))
+                .collect(),
+        }
+    }
+
     pub fn fields(&self) -> &[MoveValue] {
         &self.0
     }
@@ -287,6 +327,28 @@ impl MoveVariant {
                 .into_iter()
                 .zip(v_layout.iter())
                 .map(|(v, l)| (l.name.clone(), v.decorate(&l.layout)))
+                .collect(),
+            variant_name: v_name.clone(),
+        }
+    }
+
+    pub fn decorate_compressed(self, layout: &CA::MoveEnumLayout) -> A::MoveVariant {
+        let MoveVariant { tag, fields } = self;
+        let Some(CA::VariantLayout::Known {
+            name: v_name,
+            tag: _,
+            fields: field_layouts,
+        }) = layout.variant(tag as usize)
+        else {
+            panic!("Unknown variant tag {tag} in compressed layout")
+        };
+        A::MoveVariant {
+            type_: layout.type_().clone(),
+            tag,
+            fields: fields
+                .into_iter()
+                .zip(field_layouts.fields())
+                .map(|(v, l)| (l.0.clone(), v.decorate_compressed(l.1)))
                 .collect(),
             variant_name: v_name.clone(),
         }

--- a/external-crates/move/crates/move-core-types/src/unit_tests/compressed_layout_test.rs
+++ b/external-crates/move/crates/move-core-types/src/unit_tests/compressed_layout_test.rs
@@ -404,7 +404,7 @@ fn annotated_view_enum_navigate() {
     };
     assert_eq!(ev.type_().name.as_str(), "MyEnum");
 
-    let vl = ev.variant_by_tag(1).unwrap();
+    let vl = ev.variant(1).unwrap();
     assert_eq!(vl.name().as_str(), "Some");
     let fv = vl.fields().expect("expected known variant");
     assert_eq!(fv.field_count(), 1);
@@ -412,7 +412,7 @@ fn annotated_view_enum_navigate() {
     assert_eq!(field_name.as_str(), "value");
     assert_eq!(field_layout.inflate().unwrap(), A::MoveTypeLayout::U64);
 
-    let vl = ev.variant_by_tag(0).unwrap();
+    let vl = ev.variant(0).unwrap();
     assert_eq!(vl.name().as_str(), "None");
     let fv = vl.fields().expect("expected known variant");
     assert_eq!(fv.field_count(), 0);

--- a/external-crates/move/crates/move-ir-to-bytecode/src/compiler.rs
+++ b/external-crates/move/crates/move-ir-to-bytecode/src/compiler.rs
@@ -5,6 +5,7 @@
 use crate::context::{CompiledDependency, Context, MaterializedPools, TABLE_MAX_SIZE};
 use anyhow::{Result, bail, format_err};
 use move_binary_format::{
+    constant::constant_sig_token_to_layout,
     file_format::{
         Ability, AbilitySet, Bytecode, CodeOffset, CodeUnit, CompiledModule, Constant,
         ConstantPoolIndex, DatatypeHandleIndex, DatatypeTyParameter, EnumDefinition,
@@ -19,7 +20,7 @@ use move_bytecode_source_map::source_map::SourceMap;
 use move_command_line_common::{
     env::get_bytecode_version_from_env, error_bitset::ErrorBitsetBuilder,
 };
-use move_core_types::runtime_value::{MoveTypeLayout, MoveValue};
+use move_core_types::runtime_value::MoveValue;
 use move_ir_types::{
     ast::{self, Bytecode as IRBytecode, Bytecode_ as IRBytecode_, *},
     sp,
@@ -350,7 +351,7 @@ fn constant_name_as_constant_value_index(
 ) -> Result<ConstantPoolIndex> {
     let name_constant = compile_constant(
         context,
-        &MoveTypeLayout::Vector(Box::new(MoveTypeLayout::U8)),
+        &Type_::Vector(Box::new(Type_::U8.make_type())).make_type(),
         MoveValue::vector_u8(const_name.to_string().into_bytes()),
     )?;
     context.constant_index(name_constant)
@@ -418,11 +419,7 @@ pub fn compile_module<'a>(
             constant_name_as_constant_value_index(&mut context, &ir_constant.name)?;
         }
 
-        let constant = compile_constant(
-            &mut context,
-            &type_to_constant_type_layout(ir_constant.signature)?,
-            ir_constant.value,
-        )?;
+        let constant = compile_constant(&mut context, &ir_constant.signature, ir_constant.value)?;
         context.declare_constant(ir_constant.name.clone(), constant.clone())?;
         let const_idx = context.constant_index(constant)?;
         record_src_loc!(const_decl: context, const_idx, ir_constant.name);
@@ -1312,7 +1309,8 @@ fn compile_expression(
         Exp_::Value(cv) => match cv.value {
             CopyableVal_::Address(address) => {
                 let address_value = MoveValue::Address(address);
-                let constant = compile_constant(context, &MoveTypeLayout::Address, address_value)?;
+                let constant =
+                    compile_constant(context, &Type_::Address.make_type(), address_value)?;
                 let idx = context.constant_index(constant)?;
                 push_instr!(exp.loc, Bytecode::LdConst(idx));
                 function_frame.push()?;
@@ -1343,7 +1341,7 @@ fn compile_expression(
             }
             CopyableVal_::ByteArray(buf) => {
                 let vec_value = MoveValue::vector_u8(buf);
-                let ty = MoveTypeLayout::Vector(Box::new(MoveTypeLayout::U8));
+                let ty = Type_::Vector(Box::new(Type_::U8.make_type())).make_type();
                 let constant = compile_constant(context, &ty, vec_value)?;
                 let idx = context.constant_index(constant)?;
                 push_instr!(exp.loc, Bytecode::LdConst(idx));
@@ -1714,38 +1712,12 @@ fn compile_call(
     Ok(())
 }
 
-fn type_to_constant_type_layout(ty: Type) -> Result<MoveTypeLayout> {
-    Ok(match ty.value {
-        Type_::Address => MoveTypeLayout::Address,
-        Type_::Signer => MoveTypeLayout::Signer,
-        Type_::U8 => MoveTypeLayout::U8,
-        Type_::U16 => MoveTypeLayout::U16,
-        Type_::U32 => MoveTypeLayout::U32,
-        Type_::U64 => MoveTypeLayout::U64,
-        Type_::U128 => MoveTypeLayout::U128,
-        Type_::U256 => MoveTypeLayout::U256,
-        Type_::Bool => MoveTypeLayout::Bool,
-        Type_::Vector(inner_type) => {
-            MoveTypeLayout::Vector(Box::new(type_to_constant_type_layout(*inner_type)?))
-        }
-        Type_::Reference(_, _) => {
-            bail!("References are not supported in constant type layouts")
-        }
-        Type_::TypeParameter(_) => {
-            bail!("Type parameters are not supported in constant type layouts")
-        }
-        Type_::Datatype(_ident, _tys) => {
-            bail!("TODO Structs are not *yet* supported in constant type layouts")
-        }
-    })
-}
-
-fn compile_constant(
-    _context: &mut Context,
-    layout: &MoveTypeLayout,
-    value: MoveValue,
-) -> Result<Constant> {
-    Constant::serialize_constant(layout, &value)
+fn compile_constant(context: &mut Context, ty: &Type, value: MoveValue) -> Result<Constant> {
+    let const_sig_token = compile_type(context, &HashMap::new(), ty)?;
+    let Some(layout) = constant_sig_token_to_layout(&const_sig_token) else {
+        bail!("Unsupported constant type: {:?}", ty);
+    };
+    Constant::serialize_constant(layout.as_ref(), &value)
         .ok_or_else(|| format_err!("Could not serialize constant"))
 }
 
@@ -1856,7 +1828,7 @@ fn compile_bytecode(
         IRBytecode_::LdTrue => Bytecode::LdTrue,
         IRBytecode_::LdFalse => Bytecode::LdFalse,
         IRBytecode_::LdConst(ty, v) => {
-            let constant = compile_constant(context, &type_to_constant_type_layout(ty)?, v)?;
+            let constant = compile_constant(context, &ty, v)?;
             Bytecode::LdConst(context.constant_index(constant)?)
         }
         IRBytecode_::LdNamedConst(c) => Bytecode::LdConst(context.named_constant_index(&c)?),

--- a/external-crates/move/crates/move-ir-to-bytecode/src/compiler.rs
+++ b/external-crates/move/crates/move-ir-to-bytecode/src/compiler.rs
@@ -350,8 +350,7 @@ fn constant_name_as_constant_value_index(
     const_name: &ConstantName,
 ) -> Result<ConstantPoolIndex> {
     let name_constant = compile_constant(
-        context,
-        &Type_::Vector(Box::new(Type_::U8.make_type())).make_type(),
+        &SignatureToken::Vector(Box::new(SignatureToken::U8)),
         MoveValue::vector_u8(const_name.to_string().into_bytes()),
     )?;
     context.constant_index(name_constant)
@@ -419,7 +418,8 @@ pub fn compile_module<'a>(
             constant_name_as_constant_value_index(&mut context, &ir_constant.name)?;
         }
 
-        let constant = compile_constant(&mut context, &ir_constant.signature, ir_constant.value)?;
+        let signature_token = compile_type(&mut context, &HashMap::new(), &ir_constant.signature)?;
+        let constant = compile_constant(&signature_token, ir_constant.value)?;
         context.declare_constant(ir_constant.name.clone(), constant.clone())?;
         let const_idx = context.constant_index(constant)?;
         record_src_loc!(const_decl: context, const_idx, ir_constant.name);
@@ -1309,8 +1309,7 @@ fn compile_expression(
         Exp_::Value(cv) => match cv.value {
             CopyableVal_::Address(address) => {
                 let address_value = MoveValue::Address(address);
-                let constant =
-                    compile_constant(context, &Type_::Address.make_type(), address_value)?;
+                let constant = compile_constant(&SignatureToken::Address, address_value)?;
                 let idx = context.constant_index(constant)?;
                 push_instr!(exp.loc, Bytecode::LdConst(idx));
                 function_frame.push()?;
@@ -1341,8 +1340,10 @@ fn compile_expression(
             }
             CopyableVal_::ByteArray(buf) => {
                 let vec_value = MoveValue::vector_u8(buf);
-                let ty = Type_::Vector(Box::new(Type_::U8.make_type())).make_type();
-                let constant = compile_constant(context, &ty, vec_value)?;
+                let constant = compile_constant(
+                    &SignatureToken::Vector(Box::new(SignatureToken::U8)),
+                    vec_value,
+                )?;
                 let idx = context.constant_index(constant)?;
                 push_instr!(exp.loc, Bytecode::LdConst(idx));
                 function_frame.push()?;
@@ -1712,10 +1713,9 @@ fn compile_call(
     Ok(())
 }
 
-fn compile_constant(context: &mut Context, ty: &Type, value: MoveValue) -> Result<Constant> {
-    let const_sig_token = compile_type(context, &HashMap::new(), ty)?;
-    let Some(layout) = constant_sig_token_to_layout(&const_sig_token) else {
-        bail!("Unsupported constant type: {:?}", ty);
+fn compile_constant(const_sig_token: &SignatureToken, value: MoveValue) -> Result<Constant> {
+    let Some(layout) = constant_sig_token_to_layout(const_sig_token) else {
+        bail!("Unsupported constant type: {:?}", const_sig_token);
     };
     Constant::serialize_constant(layout.as_ref(), &value)
         .ok_or_else(|| format_err!("Could not serialize constant"))
@@ -1828,7 +1828,8 @@ fn compile_bytecode(
         IRBytecode_::LdTrue => Bytecode::LdTrue,
         IRBytecode_::LdFalse => Bytecode::LdFalse,
         IRBytecode_::LdConst(ty, v) => {
-            let constant = compile_constant(context, &ty, v)?;
+            let signature_token = compile_type(context, &HashMap::new(), &ty)?;
+            let constant = compile_constant(&signature_token, v)?;
             Bytecode::LdConst(context.constant_index(constant)?)
         }
         IRBytecode_::LdNamedConst(c) => Bytecode::LdConst(context.named_constant_index(&c)?),

--- a/external-crates/move/crates/move-ir-types/src/ast.rs
+++ b/external-crates/move/crates/move-ir-types/src/ast.rs
@@ -862,6 +862,12 @@ impl ImportDefinition {
     }
 }
 
+impl Type_ {
+    pub fn make_type(self) -> Type {
+        Spanned::unsafe_no_loc(self)
+    }
+}
+
 impl StructDefinition_ {
     /// Creates a new StructDefinition from the abilities, the string representation of the name,
     /// and the user specified fields, a map from their names to their types

--- a/external-crates/move/crates/move-ir-types/src/ast.rs
+++ b/external-crates/move/crates/move-ir-types/src/ast.rs
@@ -862,12 +862,6 @@ impl ImportDefinition {
     }
 }
 
-impl Type_ {
-    pub fn make_type(self) -> Type {
-        Spanned::unsafe_no_loc(self)
-    }
-}
-
 impl StructDefinition_ {
     /// Creates a new StructDefinition from the abilities, the string representation of the name,
     /// and the user specified fields, a map from their names to their types

--- a/external-crates/move/crates/move-model-2/src/model.rs
+++ b/external-crates/move/crates/move-model-2/src/model.rs
@@ -1150,7 +1150,7 @@ fn make_map<I: Ord + Copy, T>(
 impl ConstantData {
     fn value(&self, compiled: &normalized::Constant) -> &runtime_value::MoveValue {
         self.value.get_or_init(|| {
-            let constant_layout = annotated_constant_layout(&compiled.type_);
+            let constant_layout = constant_layout(&compiled.type_);
             runtime_value::MoveValue::simple_deserialize_compressed(
                 &compiled.data,
                 &constant_layout,
@@ -1160,8 +1160,8 @@ impl ConstantData {
     }
 }
 
-fn annotated_constant_layout(ty: &normalized::Type) -> CR::MoveTypeLayout {
-    fn annotated_constant_layout_(
+fn constant_layout(ty: &normalized::Type) -> CR::MoveTypeLayout {
+    fn constant_layout_(
         builder: &mut CR::MoveTypeLayoutBuilder,
         ty: &normalized::Type,
     ) -> LayoutHandle {
@@ -1176,7 +1176,7 @@ fn annotated_constant_layout(ty: &normalized::Type) -> CR::MoveTypeLayout {
             T::U256 => builder.u256(),
             T::Address => builder.address(),
             T::Vector(inner) => {
-                let inner = annotated_constant_layout_(builder, inner);
+                let inner = constant_layout_(builder, inner);
                 builder
                     .vector(inner)
                     .expect("Building a vector layout for a const should never fail")
@@ -1188,7 +1188,7 @@ fn annotated_constant_layout(ty: &normalized::Type) -> CR::MoveTypeLayout {
         }
     }
     let mut builder = CR::MoveTypeLayoutBuilder::new();
-    let handle = annotated_constant_layout_(&mut builder, ty);
+    let handle = constant_layout_(&mut builder, ty);
     builder.build(handle)
 }
 

--- a/external-crates/move/crates/move-model-2/src/model.rs
+++ b/external-crates/move/crates/move-model-2/src/model.rs
@@ -25,7 +25,11 @@ use move_compiler::{
         program_info::{ModuleInfo, TypingProgramInfo},
     },
 };
-use move_core_types::{account_address::AccountAddress, runtime_value};
+use move_core_types::{
+    account_address::AccountAddress,
+    compressed::runtime::{self as CR, BackendBuilder as _, LayoutHandle},
+    runtime_value,
+};
 use move_ir_types::ast as IR;
 use move_ir_types::location::Spanned;
 use move_symbol_pool::Symbol;
@@ -1147,29 +1151,45 @@ impl ConstantData {
     fn value(&self, compiled: &normalized::Constant) -> &runtime_value::MoveValue {
         self.value.get_or_init(|| {
             let constant_layout = annotated_constant_layout(&compiled.type_);
-            runtime_value::MoveValue::simple_deserialize(&compiled.data, &constant_layout).unwrap()
+            runtime_value::MoveValue::simple_deserialize_compressed(
+                &compiled.data,
+                &constant_layout,
+            )
+            .unwrap()
         })
     }
 }
 
-fn annotated_constant_layout(ty: &normalized::Type) -> runtime_value::MoveTypeLayout {
-    use normalized::Type as T;
-    use runtime_value::MoveTypeLayout as L;
-    match ty {
-        T::Bool => L::Bool,
-        T::U8 => L::U8,
-        T::U16 => L::U16,
-        T::U32 => L::U32,
-        T::U64 => L::U64,
-        T::U128 => L::U128,
-        T::U256 => L::U256,
-        T::Address => L::Address,
-        T::Vector(inner) => L::Vector(Box::new(annotated_constant_layout(inner))),
+fn annotated_constant_layout(ty: &normalized::Type) -> CR::MoveTypeLayout {
+    fn annotated_constant_layout_(
+        builder: &mut CR::MoveTypeLayoutBuilder,
+        ty: &normalized::Type,
+    ) -> LayoutHandle {
+        use normalized::Type as T;
+        match ty {
+            T::Bool => builder.bool(),
+            T::U8 => builder.u8(),
+            T::U16 => builder.u16(),
+            T::U32 => builder.u32(),
+            T::U64 => builder.u64(),
+            T::U128 => builder.u128(),
+            T::U256 => builder.u256(),
+            T::Address => builder.address(),
+            T::Vector(inner) => {
+                let inner = annotated_constant_layout_(builder, inner);
+                builder
+                    .vector(inner)
+                    .expect("Building a vector layout for a const should never fail")
+            }
 
-        T::Datatype(_) | T::Reference(_, _) | T::TypeParameter(_) | T::Signer => {
-            unreachable!("{ty:?} is not supported in constants")
+            T::Datatype(_) | T::Reference(_, _) | T::TypeParameter(_) | T::Signer => {
+                unreachable!("{ty:?} is not supported in constants")
+            }
         }
     }
+    let mut builder = CR::MoveTypeLayoutBuilder::new();
+    let handle = annotated_constant_layout_(&mut builder, ty);
+    builder.build(handle)
 }
 
 //**************************************************************************************************

--- a/external-crates/move/crates/move-vm-runtime/src/dev_utils/vm_arguments.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/dev_utils/vm_arguments.rs
@@ -147,16 +147,7 @@ fn deserialize_value(
     ty: &Type,
     arg: impl Borrow<[u8]>,
 ) -> PartialVMResult<Value> {
-    let layout = vtables.type_to_type_layout(ty).and_then(|ty| {
-        ty.inflate().map_err(|e| {
-            partial_vm_error!(
-                UNKNOWN_INVARIANT_VIOLATION_ERROR,
-                "Failed to inflate type layout for {:?}: {}",
-                ty,
-                e
-            )
-        })
-    });
+    let layout = vtables.type_to_type_layout(ty);
     let layout = match layout {
         Ok(layout) => layout,
         Err(_err) => {
@@ -165,7 +156,7 @@ fn deserialize_value(
         }
     };
 
-    match Value::simple_deserialize(arg.borrow(), &layout) {
+    match Value::simple_deserialize(arg.borrow(), layout.as_ref()) {
         Some(val) => Ok(val),
         None => {
             warn!("[VM] failed to deserialize argument");

--- a/external-crates/move/crates/move-vm-runtime/src/dev_utils/vm_arguments.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/dev_utils/vm_arguments.rs
@@ -147,7 +147,17 @@ fn deserialize_value(
     ty: &Type,
     arg: impl Borrow<[u8]>,
 ) -> PartialVMResult<Value> {
-    let layout = match vtables.type_to_type_layout(ty) {
+    let layout = vtables.type_to_type_layout(ty).and_then(|ty| {
+        ty.inflate().map_err(|e| {
+            partial_vm_error!(
+                UNKNOWN_INVARIANT_VIOLATION_ERROR,
+                "Failed to inflate type layout for {:?}: {}",
+                ty,
+                e
+            )
+        })
+    });
+    let layout = match layout {
         Ok(layout) => layout,
         Err(_err) => {
             warn!("[VM] failed to get layout from type");

--- a/external-crates/move/crates/move-vm-runtime/src/execution/dispatch_tables.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/execution/dispatch_tables.rs
@@ -30,6 +30,10 @@ use move_binary_format::{
 };
 use move_core_types::{
     annotated_value,
+    compressed::{
+        annotated::{self as CA, BackendBuilder as _},
+        runtime::{self as CR, BackendBuilder as _},
+    },
     identifier::{IdentStr, Identifier},
     language_storage::{ModuleId, StructTag, TypeTag},
     runtime_value,
@@ -708,13 +712,14 @@ impl VMDispatchTables {
         &self,
         datatype_name: &VirtualTableKey,
         ty_args: &[Type],
+        builder: &mut CR::MoveTypeLayoutBuilder,
         type_size: &mut TypeSize,
-    ) -> PartialVMResult<runtime_value::MoveDatatypeLayout> {
+    ) -> PartialVMResult<CR::LayoutHandle> {
         type_size.check()?;
         let ty = self.resolve_type(datatype_name)?.to_ref();
         let type_layout = match ty.datatype_info.inner_ref() {
             Datatype::Enum(einfo) => {
-                let mut variant_layouts = vec![];
+                let mut variant_layouts: Vec<Vec<CR::LayoutHandle>> = vec![];
                 for variant in einfo.variants.iter() {
                     type_size.incr_node_count()?;
                     let field_tys = variant
@@ -724,13 +729,19 @@ impl VMDispatchTables {
                         .collect::<PartialVMResult<Vec<_>>>()?;
                     let field_layouts = field_tys
                         .iter()
-                        .map(|ty| self.type_to_type_layout_impl(ty, type_size))
+                        .map(|ty| self.type_to_type_layout_impl(ty, builder, type_size))
                         .collect::<PartialVMResult<Vec<_>>>()?;
                     variant_layouts.push(field_layouts);
                 }
-                runtime_value::MoveDatatypeLayout::Enum(Box::new(runtime_value::MoveEnumLayout(
-                    Box::new(variant_layouts),
-                )))
+                let variant_refs: Vec<Option<&[CR::LayoutHandle]>> =
+                    variant_layouts.iter().map(|v| Some(v.as_slice())).collect();
+                builder.enum_layout(&variant_refs).map_err(|e| {
+                    partial_vm_error!(
+                        UNKNOWN_INVARIANT_VIOLATION_ERROR,
+                        "failed to create enum layout for type {}: {e}",
+                        datatype_name.to_string(&self.interner)
+                    )
+                })?
             }
             Datatype::Struct(sinfo) => {
                 let field_tys = sinfo
@@ -740,12 +751,16 @@ impl VMDispatchTables {
                     .collect::<PartialVMResult<Vec<_>>>()?;
                 let field_layouts = field_tys
                     .iter()
-                    .map(|ty| self.type_to_type_layout_impl(ty, type_size))
+                    .map(|ty| self.type_to_type_layout_impl(ty, builder, type_size))
                     .collect::<PartialVMResult<Vec<_>>>()?;
 
-                runtime_value::MoveDatatypeLayout::Struct(Box::new(
-                    runtime_value::MoveStructLayout::new(field_layouts),
-                ))
+                builder.struct_layout(&field_layouts).map_err(|e| {
+                    partial_vm_error!(
+                        UNKNOWN_INVARIANT_VIOLATION_ERROR,
+                        "failed to create struct layout for type {}: {e}",
+                        datatype_name.to_string(&self.interner)
+                    )
+                })?
             }
         };
         type_size.check()?;
@@ -755,29 +770,35 @@ impl VMDispatchTables {
     fn type_to_type_layout_impl(
         &self,
         ty: &Type,
+        builder: &mut CR::MoveTypeLayoutBuilder,
         type_size: &mut TypeSize,
-    ) -> PartialVMResult<runtime_value::MoveTypeLayout> {
+    ) -> PartialVMResult<CR::LayoutHandle> {
         type_size.enter_type(|type_size| {
             let result = match ty {
-                Type::Bool => runtime_value::MoveTypeLayout::Bool,
-                Type::U8 => runtime_value::MoveTypeLayout::U8,
-                Type::U16 => runtime_value::MoveTypeLayout::U16,
-                Type::U32 => runtime_value::MoveTypeLayout::U32,
-                Type::U64 => runtime_value::MoveTypeLayout::U64,
-                Type::U128 => runtime_value::MoveTypeLayout::U128,
-                Type::U256 => runtime_value::MoveTypeLayout::U256,
-                Type::Address => runtime_value::MoveTypeLayout::Address,
-                Type::Signer => runtime_value::MoveTypeLayout::Signer,
-                Type::Vector(ty) => runtime_value::MoveTypeLayout::Vector(Box::new(
-                    self.type_to_type_layout_impl(ty, type_size)?,
-                )),
-                Type::Datatype(gidx) => self
-                    .datatype_to_type_layout(gidx, &[], type_size)?
-                    .into_layout(),
+                Type::Bool => builder.bool(),
+                Type::U8 => builder.u8(),
+                Type::U16 => builder.u16(),
+                Type::U32 => builder.u32(),
+                Type::U64 => builder.u64(),
+                Type::U128 => builder.u128(),
+                Type::U256 => builder.u256(),
+                Type::Address => builder.address(),
+                Type::Signer => builder.signer(),
+                Type::Vector(ty) => {
+                    let inner = self.type_to_type_layout_impl(ty, builder, type_size)?;
+                    builder.vector(inner).map_err(|e| {
+                        partial_vm_error!(
+                            UNKNOWN_INVARIANT_VIOLATION_ERROR,
+                            "failed to create vector layout for type {ty:?}: {e}",
+                        )
+                    })?
+                }
+                Type::Datatype(gidx) => {
+                    self.datatype_to_type_layout(gidx, &[], builder, type_size)?
+                }
                 Type::DatatypeInstantiation(inst) => {
                     let (gidx, ty_args) = &**inst;
-                    self.datatype_to_type_layout(gidx, ty_args, type_size)?
-                        .into_layout()
+                    self.datatype_to_type_layout(gidx, ty_args, builder, type_size)?
                 }
                 Type::Reference(_) | Type::MutableReference(_) | Type::TyParam(_) => {
                     return Err(partial_vm_error!(
@@ -795,8 +816,9 @@ impl VMDispatchTables {
         &self,
         datatype_name: &VirtualTableKey,
         ty_args: &[Type],
+        builder: &mut CA::MoveTypeLayoutBuilder,
         type_size: &mut TypeSize,
-    ) -> PartialVMResult<annotated_value::MoveDatatypeLayout> {
+    ) -> PartialVMResult<CA::LayoutHandle> {
         type_size.check()?;
         let ty = self.resolve_type(datatype_name)?.to_ref();
         let struct_tag = self.datatype_to_type_tag_impl(
@@ -808,7 +830,8 @@ impl VMDispatchTables {
 
         let type_layout = match ty.datatype_info.inner_ref() {
             Datatype::Enum(enum_type) => {
-                let mut variant_layouts = BTreeMap::new();
+                let mut variant_layouts: Vec<(Identifier, u16, Vec<(Identifier, CA::LayoutHandle)>)> =
+                    vec![];
                 for variant in enum_type.variants.iter() {
                     type_size.incr_node_count()?;
                     if variant.fields.len() != variant.field_names.len() {
@@ -824,25 +847,37 @@ impl VMDispatchTables {
                         .map(|(n, ty)| {
                             let n = self.interner.resolve_ident(n, "field name");
                             let ty = ty.subst(ty_args)?;
-                            let l = self.type_to_fully_annotated_layout_impl(&ty, type_size)?;
-                            Ok(annotated_value::MoveFieldLayout::new(n, l))
+                            let l =
+                                self.type_to_fully_annotated_layout_impl(&ty, builder, type_size)?;
+                            Ok((n, l))
                         })
                         .collect::<PartialVMResult<Vec<_>>>()?;
-                    variant_layouts.insert(
-                        (
-                            self.interner
-                                .resolve_ident(&variant.variant_name, "variant name"),
-                            variant.variant_tag,
-                        ),
+                    variant_layouts.push((
+                        self.interner
+                            .resolve_ident(&variant.variant_name, "variant name"),
+                        variant.variant_tag,
                         field_layouts,
-                    );
+                    ));
                 }
-                annotated_value::MoveDatatypeLayout::Enum(Box::new(
-                    annotated_value::MoveEnumLayout {
-                        type_: struct_tag.clone(),
-                        variants: variant_layouts,
-                    },
-                ))
+                let variant_field_refs: Vec<Vec<(&Identifier, CA::LayoutHandle)>> = variant_layouts
+                    .iter()
+                    .map(|(_, _, fields)| fields.iter().map(|(n, h)| (n, h.clone())).collect())
+                    .collect();
+                let variant_refs: Vec<(&Identifier, u16, Option<&[(&Identifier, CA::LayoutHandle)]>)> =
+                    variant_layouts
+                        .iter()
+                        .zip(variant_field_refs.iter())
+                        .map(|((name, tag, _), fields)| (name, *tag, Some(fields.as_slice())))
+                        .collect();
+                builder
+                    .enum_layout(&struct_tag, &variant_refs)
+                    .map_err(|e| {
+                        partial_vm_error!(
+                            UNKNOWN_INVARIANT_VIOLATION_ERROR,
+                            "failed to create fully annotated enum layout for type {}: {e}",
+                            datatype_name.to_string(&self.interner)
+                        )
+                    })?
             }
             Datatype::Struct(struct_type) => {
                 if struct_type.fields.len() != struct_type.field_names.len() {
@@ -851,20 +886,31 @@ impl VMDispatchTables {
                         "Field types did not match the length of field names in loaded struct"
                     ));
                 }
-                let field_layouts = struct_type
+                let field_layouts: Vec<(Identifier, CA::LayoutHandle)> = struct_type
                     .field_names
                     .iter()
                     .zip(struct_type.fields.iter())
                     .map(|(n, ty)| {
                         let n = self.interner.resolve_ident(n, "field name");
                         let ty = ty.subst(ty_args)?;
-                        let l = self.type_to_fully_annotated_layout_impl(&ty, type_size)?;
-                        Ok(annotated_value::MoveFieldLayout::new(n, l))
+                        let l =
+                            self.type_to_fully_annotated_layout_impl(&ty, builder, type_size)?;
+                        Ok((n, l))
                     })
                     .collect::<PartialVMResult<Vec<_>>>()?;
-                annotated_value::MoveDatatypeLayout::Struct(Box::new(
-                    annotated_value::MoveStructLayout::new(struct_tag, field_layouts),
-                ))
+                let field_refs: Vec<(&Identifier, CA::LayoutHandle)> = field_layouts
+                    .iter()
+                    .map(|(n, h)| (n, h.clone()))
+                    .collect();
+                builder
+                    .struct_layout(&struct_tag, &field_refs)
+                    .map_err(|e| {
+                        partial_vm_error!(
+                            UNKNOWN_INVARIANT_VIOLATION_ERROR,
+                            "failed to create fully annotated struct layout for type {}: {e}",
+                            datatype_name.to_string(&self.interner)
+                        )
+                    })?
             }
         };
         type_size.check()?;
@@ -874,29 +920,35 @@ impl VMDispatchTables {
     fn type_to_fully_annotated_layout_impl(
         &self,
         ty: &Type,
+        builder: &mut CA::MoveTypeLayoutBuilder,
         type_size: &mut TypeSize,
-    ) -> PartialVMResult<annotated_value::MoveTypeLayout> {
+    ) -> PartialVMResult<CA::LayoutHandle> {
         type_size.enter_type(|type_size| {
             let result = match ty {
-                Type::Bool => annotated_value::MoveTypeLayout::Bool,
-                Type::U8 => annotated_value::MoveTypeLayout::U8,
-                Type::U16 => annotated_value::MoveTypeLayout::U16,
-                Type::U32 => annotated_value::MoveTypeLayout::U32,
-                Type::U64 => annotated_value::MoveTypeLayout::U64,
-                Type::U128 => annotated_value::MoveTypeLayout::U128,
-                Type::U256 => annotated_value::MoveTypeLayout::U256,
-                Type::Address => annotated_value::MoveTypeLayout::Address,
-                Type::Signer => annotated_value::MoveTypeLayout::Signer,
-                Type::Vector(ty) => annotated_value::MoveTypeLayout::Vector(Box::new(
-                    self.type_to_fully_annotated_layout_impl(ty, type_size)?,
-                )),
-                Type::Datatype(gidx) => self
-                    .datatype_to_fully_annotated_layout_impl(gidx, &[], type_size)?
-                    .into_layout(),
+                Type::Bool => builder.bool(),
+                Type::U8 => builder.u8(),
+                Type::U16 => builder.u16(),
+                Type::U32 => builder.u32(),
+                Type::U64 => builder.u64(),
+                Type::U128 => builder.u128(),
+                Type::U256 => builder.u256(),
+                Type::Address => builder.address(),
+                Type::Signer => builder.signer(),
+                Type::Vector(ty) => {
+                    let inner = self.type_to_fully_annotated_layout_impl(ty, builder, type_size)?;
+                    builder.vector(inner).map_err(|e| {
+                        partial_vm_error!(
+                            UNKNOWN_INVARIANT_VIOLATION_ERROR,
+                            "failed to create vector layout for type {ty:?}: {e}",
+                        )
+                    })?
+                }
+                Type::Datatype(gidx) => {
+                    self.datatype_to_fully_annotated_layout_impl(gidx, &[], builder, type_size)?
+                }
                 Type::DatatypeInstantiation(inst) => {
                     let (gidx, ty_args) = &**inst;
-                    self.datatype_to_fully_annotated_layout_impl(gidx, ty_args, type_size)?
-                        .into_layout()
+                    self.datatype_to_fully_annotated_layout_impl(gidx, ty_args, builder, type_size)?
                 }
                 Type::Reference(_) | Type::MutableReference(_) | Type::TyParam(_) => {
                     return Err(partial_vm_error!(
@@ -930,10 +982,20 @@ impl VMDispatchTables {
         &self,
         ty: &Type,
     ) -> PartialVMResult<runtime_value::MoveTypeLayout> {
-        self.type_to_type_layout_impl(
+        let mut builder = CR::MoveTypeLayoutBuilder::new();
+        let root_handle = self.type_to_type_layout_impl(
             ty,
+            &mut builder,
             &mut TypeSize::from_vm_config_for_value_depth(&self.vm_config),
-        )
+        )?;
+        builder.build(root_handle).inflate().map_err(|e| {
+            partial_vm_error!(
+                UNKNOWN_INVARIANT_VIOLATION_ERROR,
+                "Failed to inflate type layout for {:?}: {}",
+                ty,
+                e
+            )
+        })
     }
 
     pub(crate) fn arena_type_to_fully_annotated_layout(
@@ -947,10 +1009,20 @@ impl VMDispatchTables {
         &self,
         ty: &Type,
     ) -> PartialVMResult<annotated_value::MoveTypeLayout> {
-        self.type_to_fully_annotated_layout_impl(
+        let mut builder = CA::MoveTypeLayoutBuilder::new();
+        let root_handle = self.type_to_fully_annotated_layout_impl(
             ty,
+            &mut builder,
             &mut TypeSize::from_vm_config_for_value_depth(&self.vm_config),
-        )
+        )?;
+        builder.build(root_handle).inflate().map_err(|e| {
+            partial_vm_error!(
+                UNKNOWN_INVARIANT_VIOLATION_ERROR,
+                "Failed to inflate fully annotated type layout for {:?}: {}",
+                ty,
+                e
+            )
+        })
     }
 
     // -------------------------------------------

--- a/external-crates/move/crates/move-vm-runtime/src/execution/dispatch_tables.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/execution/dispatch_tables.rs
@@ -29,14 +29,12 @@ use move_binary_format::{
     partial_vm_error,
 };
 use move_core_types::{
-    annotated_value,
     compressed::{
         annotated::{self as CA, BackendBuilder as _},
         runtime::{self as CR, BackendBuilder as _},
     },
     identifier::{IdentStr, Identifier},
     language_storage::{ModuleId, StructTag, TypeTag},
-    runtime_value,
 };
 use move_vm_config::runtime::VMConfig;
 
@@ -978,61 +976,41 @@ impl VMDispatchTables {
         )
     }
 
-    pub(crate) fn type_to_type_layout(
-        &self,
-        ty: &Type,
-    ) -> PartialVMResult<runtime_value::MoveTypeLayout> {
+    pub(crate) fn type_to_type_layout(&self, ty: &Type) -> PartialVMResult<CR::MoveTypeLayout> {
         let mut builder = CR::MoveTypeLayoutBuilder::new();
         let root_handle = self.type_to_type_layout_impl(
             ty,
             &mut builder,
             &mut TypeSize::from_vm_config_for_value_depth(&self.vm_config),
         )?;
-        builder.build(root_handle).inflate().map_err(|e| {
-            partial_vm_error!(
-                UNKNOWN_INVARIANT_VIOLATION_ERROR,
-                "Failed to inflate type layout for {:?}: {}",
-                ty,
-                e
-            )
-        })
+        Ok(builder.build(root_handle))
     }
 
     pub(crate) fn arena_type_to_fully_annotated_layout(
         &self,
         ty: &ArenaType,
-    ) -> PartialVMResult<annotated_value::MoveTypeLayout> {
+    ) -> PartialVMResult<CA::MoveTypeLayout> {
         self.type_to_fully_annotated_layout(&ty.to_type()?)
     }
 
     pub(crate) fn type_to_fully_annotated_layout(
         &self,
         ty: &Type,
-    ) -> PartialVMResult<annotated_value::MoveTypeLayout> {
+    ) -> PartialVMResult<CA::MoveTypeLayout> {
         let mut builder = CA::MoveTypeLayoutBuilder::new();
         let root_handle = self.type_to_fully_annotated_layout_impl(
             ty,
             &mut builder,
             &mut TypeSize::from_vm_config_for_value_depth(&self.vm_config),
         )?;
-        builder.build(root_handle).inflate().map_err(|e| {
-            partial_vm_error!(
-                UNKNOWN_INVARIANT_VIOLATION_ERROR,
-                "Failed to inflate fully annotated type layout for {:?}: {}",
-                ty,
-                e
-            )
-        })
+        Ok(builder.build(root_handle))
     }
 
     // -------------------------------------------
     // Public APIs for type layout retrieval.
     // -------------------------------------------
 
-    pub(crate) fn get_type_layout(
-        &self,
-        type_tag: &TypeTag,
-    ) -> VMResult<runtime_value::MoveTypeLayout> {
+    pub(crate) fn get_type_layout(&self, type_tag: &TypeTag) -> VMResult<CR::MoveTypeLayout> {
         let ty = self.load_type(type_tag)?;
         self.type_to_type_layout(&ty)
             .map_err(|e| e.finish(Location::Undefined))
@@ -1041,7 +1019,7 @@ impl VMDispatchTables {
     pub(crate) fn get_fully_annotated_type_layout(
         &self,
         type_tag: &TypeTag,
-    ) -> VMResult<annotated_value::MoveTypeLayout> {
+    ) -> VMResult<CA::MoveTypeLayout> {
         let ty = self.load_type(type_tag)?;
         self.type_to_fully_annotated_layout(&ty)
             .map_err(|e| e.finish(Location::Undefined))

--- a/external-crates/move/crates/move-vm-runtime/src/execution/dispatch_tables.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/execution/dispatch_tables.rs
@@ -859,7 +859,7 @@ impl VMDispatchTables {
                 }
                 let variant_field_refs: Vec<Vec<(&Identifier, CA::LayoutHandle)>> = variant_layouts
                     .iter()
-                    .map(|(_, _, fields)| fields.iter().map(|(n, h)| (n, h.clone())).collect())
+                    .map(|(_, _, fields)| fields.iter().map(|(n, h)| (n, *h)).collect())
                     .collect();
                 let variant_refs: Vec<(&Identifier, u16, Option<&[(&Identifier, CA::LayoutHandle)]>)> =
                     variant_layouts
@@ -898,7 +898,7 @@ impl VMDispatchTables {
                     .collect::<PartialVMResult<Vec<_>>>()?;
                 let field_refs: Vec<(&Identifier, CA::LayoutHandle)> = field_layouts
                     .iter()
-                    .map(|(n, h)| (n, h.clone()))
+                    .map(|(n, h)| (n, *h))
                     .collect();
                 builder
                     .struct_layout(&struct_tag, &field_refs)

--- a/external-crates/move/crates/move-vm-runtime/src/execution/tracing/tracer.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/execution/tracing/tracer.rs
@@ -25,7 +25,7 @@ use crate::{
 use move_binary_format::errors::{PartialVMError, PartialVMResult, VMError, VMResult};
 use move_core_types::{
     account_address::AccountAddress,
-    annotated_value::MoveTypeLayout as AnnotatedTypeLayout,
+    compressed::annotated::{self as CA, MoveTypeLayout as AnnotatedTypeLayout},
     language_storage::{ModuleId, TypeTag},
 };
 use move_trace_format::{
@@ -1146,18 +1146,16 @@ impl VMTracer<'_> {
             | B::LdTrue
             | B::LdConst(_)) => {
                 let layout = match i {
-                    B::LdU8(_) => AnnotatedTypeLayout::U8,
-                    B::LdU16(_) => AnnotatedTypeLayout::U16,
-                    B::LdU32(_) => AnnotatedTypeLayout::U32,
-                    B::LdU64(_) => AnnotatedTypeLayout::U64,
-                    B::LdU128(_) => AnnotatedTypeLayout::U128,
-                    B::LdU256(_) => AnnotatedTypeLayout::U256,
-                    B::LdTrue => AnnotatedTypeLayout::Bool,
-                    B::LdFalse => AnnotatedTypeLayout::Bool,
+                    B::LdU8(_) => AnnotatedTypeLayout::u8(),
+                    B::LdU16(_) => AnnotatedTypeLayout::u16(),
+                    B::LdU32(_) => AnnotatedTypeLayout::u32(),
+                    B::LdU64(_) => AnnotatedTypeLayout::u64(),
+                    B::LdU128(_) => AnnotatedTypeLayout::u128(),
+                    B::LdU256(_) => AnnotatedTypeLayout::u256(),
+                    B::LdTrue => AnnotatedTypeLayout::bool(),
+                    B::LdFalse => AnnotatedTypeLayout::bool(),
                     B::LdConst(const_ptr) => vtables
                         .arena_type_to_fully_annotated_layout(&const_ptr.type_)
-                        .ok()?
-                        .inflate()
                         .ok()?,
                     _ => unreachable!(),
                 };
@@ -1189,12 +1187,12 @@ impl VMTracer<'_> {
             }
             i @ (B::CastU8 | B::CastU16 | B::CastU32 | B::CastU64 | B::CastU128 | B::CastU256) => {
                 let layout = match i {
-                    B::CastU8 => AnnotatedTypeLayout::U8,
-                    B::CastU16 => AnnotatedTypeLayout::U16,
-                    B::CastU32 => AnnotatedTypeLayout::U32,
-                    B::CastU64 => AnnotatedTypeLayout::U64,
-                    B::CastU128 => AnnotatedTypeLayout::U128,
-                    B::CastU256 => AnnotatedTypeLayout::U256,
+                    B::CastU8 => AnnotatedTypeLayout::u8(),
+                    B::CastU16 => AnnotatedTypeLayout::u16(),
+                    B::CastU32 => AnnotatedTypeLayout::u32(),
+                    B::CastU64 => AnnotatedTypeLayout::u64(),
+                    B::CastU128 => AnnotatedTypeLayout::u128(),
+                    B::CastU256 => AnnotatedTypeLayout::u256(),
                     _ => unreachable!(),
                 };
                 self.type_stack.pop()?;
@@ -1244,7 +1242,7 @@ impl VMTracer<'_> {
                 self.type_stack.pop()?;
                 self.type_stack.pop()?;
                 self.type_stack.push(StackType {
-                    layout: AnnotatedTypeLayout::Bool,
+                    layout: AnnotatedTypeLayout::bool(),
                     ref_type: None,
                 });
                 let effects = emit_effects!(vec![EF::Push(
@@ -1263,11 +1261,7 @@ impl VMTracer<'_> {
                 let struct_type = struct_ptr.datatype();
                 let stack_len = self.type_stack.len();
                 let _ = self.type_stack.split_off(stack_len - field_count);
-                let ty = vtables
-                    .type_to_fully_annotated_layout(&struct_type)
-                    .ok()?
-                    .inflate()
-                    .ok()?;
+                let ty = vtables.type_to_fully_annotated_layout(&struct_type).ok()?;
                 self.type_stack.push(StackType {
                     layout: ty,
                     ref_type: None,
@@ -1287,11 +1281,7 @@ impl VMTracer<'_> {
                 .ok()?;
                 let stack_len = self.type_stack.len();
                 let _ = self.type_stack.split_off(stack_len - field_count);
-                let ty = vtables
-                    .type_to_fully_annotated_layout(&struct_type)
-                    .ok()?
-                    .inflate()
-                    .ok()?;
+                let ty = vtables.type_to_fully_annotated_layout(&struct_type).ok()?;
                 self.type_stack.push(StackType {
                     layout: ty,
                     ref_type: None,
@@ -1313,19 +1303,19 @@ impl VMTracer<'_> {
             }
             B::Unpack(_) | B::UnpackGeneric(_) => {
                 let ty = self.type_stack.pop()?;
-                let AnnotatedTypeLayout::Struct(s) = ty.layout else {
+                let CA::MoveLayoutView::Struct(s) = ty.layout.as_view() else {
                     self.report_error(&format!("Expected struct, got {:#?}", ty));
                     return None;
                 };
-                for field in &s.fields {
+                for (_, field) in s.fields() {
                     self.type_stack.push(StackType {
-                        layout: field.layout.clone(),
+                        layout: field.to_owned(),
                         ref_type: None,
                     });
                 }
                 let effects = emit_effects! {
                     let mut effects = vec![];
-                    for i in (0..s.fields.len()).rev() {
+                    for i in (0..s.field_count()).rev() {
                         let value = self.resolve_stack_value(vtables, machine, i)?;
                         effects.push(EF::Push(value));
                     }
@@ -1338,7 +1328,7 @@ impl VMTracer<'_> {
                 self.type_stack.pop()?;
                 self.type_stack.pop()?;
                 self.type_stack.push(StackType {
-                    layout: AnnotatedTypeLayout::Bool,
+                    layout: AnnotatedTypeLayout::bool(),
                     ref_type: None,
                 });
                 let effects = emit_effects!(vec![EF::Push(
@@ -1351,7 +1341,7 @@ impl VMTracer<'_> {
                 self.type_stack.pop()?;
                 self.type_stack.pop()?;
                 self.type_stack.push(StackType {
-                    layout: AnnotatedTypeLayout::Bool,
+                    layout: AnnotatedTypeLayout::bool(),
                     ref_type: None,
                 });
                 let effects = emit_effects!(vec![EF::Push(
@@ -1439,12 +1429,12 @@ impl VMTracer<'_> {
             }
             i @ (B::MutBorrowField(fh_ptr) | B::ImmBorrowField(fh_ptr)) => {
                 let value_ty = self.type_stack.pop()?;
-                let AnnotatedTypeLayout::Struct(slayout) = &value_ty.layout else {
+                let CA::MoveLayoutView::Struct(slayout) = value_ty.layout.as_view() else {
                     self.report_error(&format!("Expected struct, got {:#?}", value_ty.layout));
                     return None;
                 };
                 let field_offset = fh_ptr.offset;
-                let field_layout = slayout.fields.get(field_offset)?.layout.clone();
+                let field_layout = slayout.field(field_offset)?.1;
                 let location = value_ty.ref_type.as_ref()?.1.clone();
                 let field_location =
                     RuntimeLocation::Indexed(Box::new(location.clone()), field_offset);
@@ -1454,7 +1444,7 @@ impl VMTracer<'_> {
                     _ => unreachable!(),
                 };
                 self.type_stack.push(StackType {
-                    layout: field_layout,
+                    layout: field_layout.to_owned(),
                     ref_type: Some((ref_type, field_location)),
                 });
                 let effects = emit_effects!(vec![EF::Push(
@@ -1465,12 +1455,12 @@ impl VMTracer<'_> {
             }
             i @ (B::MutBorrowFieldGeneric(fh_ptr) | B::ImmBorrowFieldGeneric(fh_ptr)) => {
                 let value_ty = self.type_stack.pop()?;
-                let AnnotatedTypeLayout::Struct(slayout) = &value_ty.layout else {
+                let CA::MoveLayoutView::Struct(slayout) = value_ty.layout.as_view() else {
                     self.report_error(&format!("Expected struct, got {:#?}", value_ty.layout));
                     return None;
                 };
                 let field_offset = fh_ptr.offset;
-                let field_layout = slayout.fields.get(field_offset)?.layout.clone();
+                let field_layout = slayout.field(field_offset)?.1;
                 let location = value_ty.ref_type.as_ref()?.1.clone();
                 let field_location =
                     RuntimeLocation::Indexed(Box::new(location.clone()), field_offset);
@@ -1480,10 +1470,10 @@ impl VMTracer<'_> {
                     _ => unreachable!(),
                 };
                 self.type_stack.push(StackType {
-                    layout: field_layout,
+                    layout: field_layout.to_owned(),
                     ref_type: Some((ref_type, field_location)),
                 });
-                let ty_args = slayout.type_.type_params.clone();
+                let ty_args = slayout.type_().type_params.clone();
                 let effects = emit_effects!(vec![EF::Push(
                     self.resolve_stack_value(vtables, machine, 0)?
                 )]);
@@ -1491,18 +1481,15 @@ impl VMTracer<'_> {
                     .instruction(instruction, ty_args, effects, *remaining_gas, pc);
             }
             B::VecPack(ty_ptr, n) => {
-                let ty = instantiate_single_type(ty_ptr, &machine.call_stack.current_frame.ty_args)
-                    .ok()?;
-                let ty = vtables
-                    .type_to_fully_annotated_layout(&ty)
-                    .ok()?
-                    .inflate()
-                    .ok()?;
-                let ty = AnnotatedTypeLayout::Vector(Box::new(ty));
+                let inner_ty =
+                    instantiate_single_type(ty_ptr, &machine.call_stack.current_frame.ty_args)
+                        .ok()?;
+                let vec_ty = Type::Vector(Box::new(inner_ty));
+                let vec_ty = vtables.type_to_fully_annotated_layout(&vec_ty).ok()?;
                 let stack_len = self.type_stack.len();
                 let _ = self.type_stack.split_off(stack_len - *n as usize);
                 self.type_stack.push(StackType {
-                    layout: ty,
+                    layout: vec_ty,
                     ref_type: None,
                 });
                 let effects = emit_effects!(vec![EF::Push(
@@ -1519,7 +1506,7 @@ impl VMTracer<'_> {
                 };
                 self.type_stack.pop()?;
                 let ref_ty = self.type_stack.pop()?;
-                let AnnotatedTypeLayout::Vector(ty) = ref_ty.layout else {
+                let CA::MoveLayoutView::Vector(ty) = ref_ty.layout.as_view() else {
                     self.report_error(&format!("Expected vector, got {:#?}", ref_ty.layout));
                     return None;
                 };
@@ -1541,7 +1528,7 @@ impl VMTracer<'_> {
                 let location =
                     RuntimeLocation::Indexed(Box::new(ref_ty.ref_type?.1.clone()), i as usize);
                 self.type_stack.push(StackType {
-                    layout: (*ty).clone(),
+                    layout: ty.to_owned(),
                     ref_type: Some((ref_type, location)),
                 });
                 let effects = emit_effects!(vec![EF::Push(
@@ -1553,7 +1540,7 @@ impl VMTracer<'_> {
             B::VecLen(_) => {
                 self.type_stack.pop()?;
                 self.type_stack.push(StackType {
-                    layout: AnnotatedTypeLayout::U64,
+                    layout: AnnotatedTypeLayout::u64(),
                     ref_type: None,
                 });
                 let effects = emit_effects!(vec![EF::Push(
@@ -1585,12 +1572,12 @@ impl VMTracer<'_> {
             }
             B::VecPopBack(_) => {
                 let ref_ty = self.type_stack.pop()?;
-                let AnnotatedTypeLayout::Vector(ty) = ref_ty.layout else {
+                let CA::MoveLayoutView::Vector(ty) = ref_ty.layout.as_view() else {
                     self.report_error(&format!("Expected vector, got {:#?}", ref_ty.layout));
                     return None;
                 };
                 self.type_stack.push(StackType {
-                    layout: (*ty).clone(),
+                    layout: ty.to_owned(),
                     ref_type: None,
                 });
                 let effects = emit_effects!(vec![EF::Push(
@@ -1601,13 +1588,13 @@ impl VMTracer<'_> {
             }
             B::VecUnpack(_, n) => {
                 let ty = self.type_stack.pop()?;
-                let AnnotatedTypeLayout::Vector(ty) = ty.layout else {
+                let CA::MoveLayoutView::Vector(ty) = ty.layout.as_view() else {
                     self.report_error(&format!("Expected vector, got {:#?}", ty.layout));
                     return None;
                 };
                 for _ in 0..*n {
                     self.type_stack.push(StackType {
-                        layout: (*ty).clone(),
+                        layout: ty.to_owned(),
                         ref_type: None,
                     });
                 }
@@ -1643,8 +1630,6 @@ impl VMTracer<'_> {
                 let _ = self.type_stack.split_off(stack_len - field_count);
                 let ty = vtables
                     .type_to_fully_annotated_layout(&variant_inst_ptr.enum_def.datatype())
-                    .ok()?
-                    .inflate()
                     .ok()?;
                 self.type_stack.push(StackType {
                     layout: ty,
@@ -1668,8 +1653,6 @@ impl VMTracer<'_> {
                         )
                         .ok()?,
                     )
-                    .ok()?
-                    .inflate()
                     .ok()?;
                 self.type_stack.push(StackType {
                     layout: ty,
@@ -1690,14 +1673,20 @@ impl VMTracer<'_> {
                     }
                     _ => unreachable!(),
                 };
-                let AnnotatedTypeLayout::Enum(e) = ty.layout else {
+                let CA::MoveLayoutView::Enum(e) = ty.layout.as_view() else {
                     self.report_error(&format!("Expected enum, got {:#?}", ty.layout));
                     return None;
                 };
-                let variant_layout = e.variants.iter().find(|v| v.0.1 == tag)?;
-                for f_layout in variant_layout.1.iter() {
+                let CA::VariantLayout::Known { fields, .. } = e.variant(tag as usize)? else {
+                    self.report_error(&format!(
+                        "Layout not known for enum variant tag = {} enum_layout = {:#?}",
+                        tag, ty.layout
+                    ));
+                    return None;
+                };
+                for (_, f_layout) in fields.fields() {
                     self.type_stack.push(StackType {
-                        layout: f_layout.layout.clone(),
+                        layout: f_layout.to_owned(),
                         ref_type: None,
                     });
                 }
@@ -1736,16 +1725,22 @@ impl VMTracer<'_> {
                     ),
                     _ => unreachable!(),
                 };
-                let AnnotatedTypeLayout::Enum(e) = ty.layout else {
+                let CA::MoveLayoutView::Enum(e) = ty.layout.as_view() else {
                     self.report_error(&format!("Expected enum, got {:#?}", ty.layout));
                     return None;
                 };
-                let variant_layout = e.variants.iter().find(|v| v.0.1 == tag)?;
+                let CA::VariantLayout::Known { fields, .. } = e.variant(tag as usize)? else {
+                    self.report_error(&format!(
+                        "Layout not known for enum variant tag = {} enum_layout = {:#?}",
+                        tag, ty.layout
+                    ));
+                    return None;
+                };
                 let location = ty.ref_type.as_ref()?.1.clone();
-                for (i, f_layout) in variant_layout.1.iter().enumerate() {
+                for (i, (_, f_layout)) in fields.fields().enumerate() {
                     let location = RuntimeLocation::Indexed(Box::new(location.clone()), i);
                     self.type_stack.push(StackType {
-                        layout: f_layout.layout.clone(),
+                        layout: f_layout.to_owned(),
                         ref_type: Some((ref_type.clone(), location)),
                     });
                 }
@@ -1920,10 +1915,7 @@ impl FunctionTypeInfo {
             let tag = vtables.type_to_type_tag(&ty).ok()?;
             // NB: This may fail if the type represents a value greater than the max
             // value depth.
-            let type_layout = vtables
-                .type_to_fully_annotated_layout(&ty)
-                .ok()
-                .and_then(|ty| ty.inflate().ok());
+            let type_layout = vtables.type_to_fully_annotated_layout(&ty).ok();
             let layout = (type_layout, ref_type);
             Some(TagWithLayoutInfoOpt { tag, layout })
         };
@@ -1962,7 +1954,7 @@ fn into_annotated_move_value(
     value: &RuntimeValue,
     type_: &AnnotatedTypeLayout,
 ) -> Option<SerializableMoveValue> {
-    Some(value.as_annotated_move_value(type_)?.into())
+    Some(value.as_annotated_move_value(type_.as_ref())?.into())
 }
 
 fn get_version_id(

--- a/external-crates/move/crates/move-vm-runtime/src/execution/tracing/tracer.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/execution/tracing/tracer.rs
@@ -1434,7 +1434,7 @@ impl VMTracer<'_> {
                     return None;
                 };
                 let field_offset = fh_ptr.offset;
-                let field_layout = slayout.field(field_offset)?.1;
+                let field_layout = slayout.field(field_offset as u16)?.1;
                 let location = value_ty.ref_type.as_ref()?.1.clone();
                 let field_location =
                     RuntimeLocation::Indexed(Box::new(location.clone()), field_offset);
@@ -1460,7 +1460,7 @@ impl VMTracer<'_> {
                     return None;
                 };
                 let field_offset = fh_ptr.offset;
-                let field_layout = slayout.field(field_offset)?.1;
+                let field_layout = slayout.field(field_offset as u16)?.1;
                 let location = value_ty.ref_type.as_ref()?.1.clone();
                 let field_location =
                     RuntimeLocation::Indexed(Box::new(location.clone()), field_offset);
@@ -1677,7 +1677,7 @@ impl VMTracer<'_> {
                     self.report_error(&format!("Expected enum, got {:#?}", ty.layout));
                     return None;
                 };
-                let CA::VariantLayout::Known { fields, .. } = e.variant(tag as usize)? else {
+                let CA::VariantLayout::Known { fields, .. } = e.variant(tag)? else {
                     self.report_error(&format!(
                         "Layout not known for enum variant tag = {} enum_layout = {:#?}",
                         tag, ty.layout
@@ -1729,7 +1729,7 @@ impl VMTracer<'_> {
                     self.report_error(&format!("Expected enum, got {:#?}", ty.layout));
                     return None;
                 };
-                let CA::VariantLayout::Known { fields, .. } = e.variant(tag as usize)? else {
+                let CA::VariantLayout::Known { fields, .. } = e.variant(tag)? else {
                     self.report_error(&format!(
                         "Layout not known for enum variant tag = {} enum_layout = {:#?}",
                         tag, ty.layout

--- a/external-crates/move/crates/move-vm-runtime/src/execution/tracing/tracer.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/execution/tracing/tracer.rs
@@ -1156,6 +1156,8 @@ impl VMTracer<'_> {
                     B::LdFalse => AnnotatedTypeLayout::Bool,
                     B::LdConst(const_ptr) => vtables
                         .arena_type_to_fully_annotated_layout(&const_ptr.type_)
+                        .ok()?
+                        .inflate()
                         .ok()?,
                     _ => unreachable!(),
                 };
@@ -1261,7 +1263,11 @@ impl VMTracer<'_> {
                 let struct_type = struct_ptr.datatype();
                 let stack_len = self.type_stack.len();
                 let _ = self.type_stack.split_off(stack_len - field_count);
-                let ty = vtables.type_to_fully_annotated_layout(&struct_type).ok()?;
+                let ty = vtables
+                    .type_to_fully_annotated_layout(&struct_type)
+                    .ok()?
+                    .inflate()
+                    .ok()?;
                 self.type_stack.push(StackType {
                     layout: ty,
                     ref_type: None,
@@ -1281,7 +1287,11 @@ impl VMTracer<'_> {
                 .ok()?;
                 let stack_len = self.type_stack.len();
                 let _ = self.type_stack.split_off(stack_len - field_count);
-                let ty = vtables.type_to_fully_annotated_layout(&struct_type).ok()?;
+                let ty = vtables
+                    .type_to_fully_annotated_layout(&struct_type)
+                    .ok()?
+                    .inflate()
+                    .ok()?;
                 self.type_stack.push(StackType {
                     layout: ty,
                     ref_type: None,
@@ -1483,7 +1493,11 @@ impl VMTracer<'_> {
             B::VecPack(ty_ptr, n) => {
                 let ty = instantiate_single_type(ty_ptr, &machine.call_stack.current_frame.ty_args)
                     .ok()?;
-                let ty = vtables.type_to_fully_annotated_layout(&ty).ok()?;
+                let ty = vtables
+                    .type_to_fully_annotated_layout(&ty)
+                    .ok()?
+                    .inflate()
+                    .ok()?;
                 let ty = AnnotatedTypeLayout::Vector(Box::new(ty));
                 let stack_len = self.type_stack.len();
                 let _ = self.type_stack.split_off(stack_len - *n as usize);
@@ -1629,6 +1643,8 @@ impl VMTracer<'_> {
                 let _ = self.type_stack.split_off(stack_len - field_count);
                 let ty = vtables
                     .type_to_fully_annotated_layout(&variant_inst_ptr.enum_def.datatype())
+                    .ok()?
+                    .inflate()
                     .ok()?;
                 self.type_stack.push(StackType {
                     layout: ty,
@@ -1652,6 +1668,8 @@ impl VMTracer<'_> {
                         )
                         .ok()?,
                     )
+                    .ok()?
+                    .inflate()
                     .ok()?;
                 self.type_stack.push(StackType {
                     layout: ty,
@@ -1902,7 +1920,10 @@ impl FunctionTypeInfo {
             let tag = vtables.type_to_type_tag(&ty).ok()?;
             // NB: This may fail if the type represents a value greater than the max
             // value depth.
-            let type_layout = vtables.type_to_fully_annotated_layout(&ty).ok();
+            let type_layout = vtables
+                .type_to_fully_annotated_layout(&ty)
+                .ok()
+                .and_then(|ty| ty.inflate().ok());
             let layout = (type_layout, ref_type);
             Some(TagWithLayoutInfoOpt { tag, layout })
         };

--- a/external-crates/move/crates/move-vm-runtime/src/execution/values/values_impl.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/execution/values/values_impl.rs
@@ -14,12 +14,15 @@ use move_binary_format::{
     checked_as,
     errors::*,
     file_format::{Constant, SignatureToken, VariantTag},
-    partial_vm_error,
+    partial_vm_error, safe_unwrap,
 };
 use move_core_types::{
     VARIANT_TAG_MAX_VALUE,
     account_address::AccountAddress,
-    runtime_value::{MoveEnumLayout, MoveStructLayout, MoveTypeLayout},
+    compressed::runtime::{
+        BackendBuilder as _, LayoutHandle, MoveEnumLayout, MoveFieldsLayout, MoveLayoutView,
+        MoveStructLayout, MoveTypeLayout, MoveTypeLayoutBuilder, MoveTypeLayoutRef, VariantLayout,
+    },
     u256,
     vm_status::sub_status::NFE_VECTOR_ERROR_BASE,
 };
@@ -2738,12 +2741,21 @@ use serde::{
 };
 
 impl Value {
-    pub fn simple_deserialize(blob: &[u8], layout: &MoveTypeLayout) -> Option<Value> {
-        bcs::from_bytes_seed(SeedWrapper { layout }, blob).ok()
+    pub fn simple_deserialize(blob: &[u8], layout: MoveTypeLayoutRef<'_>) -> Option<Value> {
+        bcs::from_bytes_seed(
+            SeedWrapper {
+                layout: &layout,
+            },
+            blob,
+        )
+        .ok()
     }
 
-    pub fn typed_serialize(&self, layout: &MoveTypeLayout) -> Option<Vec<u8>> {
-        match bcs::to_bytes(&AnnotatedValue { layout, val: self }) {
+    pub fn typed_serialize(&self, layout: MoveTypeLayoutRef<'_>) -> Option<Vec<u8>> {
+        match bcs::to_bytes(&AnnotatedValue {
+            layout: &layout,
+            val: self,
+        }) {
             Ok(bytes) => Some(bytes),
             Err(e) => {
                 debug_assert!(
@@ -2848,67 +2860,69 @@ fn invariant_violation<S: serde::Serializer>(message: String) -> S::Error {
     S::Error::custom(partial_vm_error!(UNKNOWN_INVARIANT_VIOLATION_ERROR).with_message(message))
 }
 
-impl serde::Serialize for AnnotatedValue<'_, '_, MoveTypeLayout, Value> {
+impl serde::Serialize for AnnotatedValue<'_, '_, MoveTypeLayoutRef<'_>, Value> {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        match (self.layout, self.val) {
-            (MoveTypeLayout::U8, Value::U8(x)) => serializer.serialize_u8(*x),
-            (MoveTypeLayout::U16, Value::U16(x)) => serializer.serialize_u16(*x),
-            (MoveTypeLayout::U32, Value::U32(x)) => serializer.serialize_u32(*x),
-            (MoveTypeLayout::U64, Value::U64(x)) => serializer.serialize_u64(*x),
-            (MoveTypeLayout::U128, Value::U128(x)) => serializer.serialize_u128(**x),
-            (MoveTypeLayout::U256, Value::U256(x)) => x.serialize(serializer),
-            (MoveTypeLayout::Bool, Value::Bool(x)) => serializer.serialize_bool(*x),
-            (MoveTypeLayout::Address, Value::Address(x)) => x.serialize(serializer),
+        use MoveLayoutView as L;
+        match (self.layout.as_view(), self.val) {
+            (L::U8, Value::U8(x)) => serializer.serialize_u8(*x),
+            (L::U16, Value::U16(x)) => serializer.serialize_u16(*x),
+            (L::U32, Value::U32(x)) => serializer.serialize_u32(*x),
+            (L::U64, Value::U64(x)) => serializer.serialize_u64(*x),
+            (L::U128, Value::U128(x)) => serializer.serialize_u128(**x),
+            (L::U256, Value::U256(x)) => x.serialize(serializer),
+            (L::Bool, Value::Bool(x)) => serializer.serialize_bool(*x),
+            (L::Address, Value::Address(x)) => x.serialize(serializer),
 
-            (MoveTypeLayout::Struct(struct_layout), Value::Struct(struct_)) => (AnnotatedValue {
-                layout: struct_layout.as_ref(),
+            (L::Struct(struct_layout), Value::Struct(struct_)) => (AnnotatedValue {
+                layout: &struct_layout,
                 val: &struct_.0,
             })
             .serialize(serializer),
 
-            (MoveTypeLayout::Enum(enum_layout), Value::Variant(entry)) => (AnnotatedValue {
-                layout: enum_layout.as_ref(),
+            (L::Enum(enum_layout), Value::Variant(entry)) => (AnnotatedValue {
+                layout: &enum_layout,
                 val: entry.0.as_ref(),
             })
             .serialize(serializer),
 
-            (MoveTypeLayout::Vector(layout), Value::PrimVec(prim_vec)) => {
-                let layout = layout.as_ref();
-                match (layout, prim_vec) {
-                    (MoveTypeLayout::U8, PrimVec::VecU8(r)) => r.serialize(serializer),
-                    (MoveTypeLayout::U16, PrimVec::VecU16(r)) => r.serialize(serializer),
-                    (MoveTypeLayout::U32, PrimVec::VecU32(r)) => r.serialize(serializer),
-                    (MoveTypeLayout::U64, PrimVec::VecU64(r)) => r.serialize(serializer),
-                    (MoveTypeLayout::U128, PrimVec::VecU128(r)) => r.serialize(serializer),
-                    (MoveTypeLayout::U256, PrimVec::VecU256(r)) => r.serialize(serializer),
-                    (MoveTypeLayout::Bool, PrimVec::VecBool(r)) => r.serialize(serializer),
-                    (MoveTypeLayout::Address, PrimVec::VecAddress(r)) => r.serialize(serializer),
-                    (layout, container) => Err(invariant_violation::<S>(format!(
-                        "cannot serialize container {:?} as {:?}",
-                        container, layout
-                    ))),
-                }
-            }
-            (MoveTypeLayout::Vector(layout), Value::Vec(r)) => {
-                let layout = layout.as_ref();
+            (L::Vector(layout), Value::PrimVec(prim_vec)) => match (layout.as_view(), prim_vec) {
+                (L::U8, PrimVec::VecU8(r)) => r.serialize(serializer),
+                (L::U16, PrimVec::VecU16(r)) => r.serialize(serializer),
+                (L::U32, PrimVec::VecU32(r)) => r.serialize(serializer),
+                (L::U64, PrimVec::VecU64(r)) => r.serialize(serializer),
+                (L::U128, PrimVec::VecU128(r)) => r.serialize(serializer),
+                (L::U256, PrimVec::VecU256(r)) => r.serialize(serializer),
+                (L::Bool, PrimVec::VecBool(r)) => r.serialize(serializer),
+                (L::Address, PrimVec::VecAddress(r)) => r.serialize(serializer),
+                (layout, container) => Err(invariant_violation::<S>(format!(
+                    "cannot serialize container {:?} as {:?}",
+                    container, layout
+                ))),
+            },
+            (L::Vector(layout), Value::Vec(r)) => {
                 let v = r;
                 let mut t = serializer.serialize_seq(Some(v.len()))?;
                 for val in v.iter() {
                     let val = &*val.borrow();
-                    t.serialize_element(&AnnotatedValue { layout, val })?;
+                    t.serialize_element(&AnnotatedValue {
+                        layout: &layout,
+                        val,
+                    })?;
                 }
                 t.end()
             }
 
-            (MoveTypeLayout::Signer, Value::Struct(struct_)) => {
+            (L::Signer, Value::Struct(struct_)) => {
                 if struct_.len() != 1 {
                     return Err(invariant_violation::<S>(format!(
                         "cannot serialize container as a signer -- expected 1 field got {}",
                         struct_.len()
                     )));
                 }
+                let addr_layout = MoveTypeLayout::address();
+                let addr_ref = addr_layout.as_ref();
                 (AnnotatedValue {
-                    layout: &MoveTypeLayout::Address,
+                    layout: &addr_ref,
                     val: &*struct_
                         .safe_get(0)
                         .map_err(|e| invariant_violation::<S>(e.to_string()))?
@@ -2925,7 +2939,7 @@ impl serde::Serialize for AnnotatedValue<'_, '_, MoveTypeLayout, Value> {
     }
 }
 
-impl serde::Serialize for AnnotatedValue<'_, '_, MoveStructLayout, FixedSizeVec> {
+impl serde::Serialize for AnnotatedValue<'_, '_, MoveStructLayout<'_>, FixedSizeVec> {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let values = &self.val;
         let fields = self.layout.fields();
@@ -2936,10 +2950,10 @@ impl serde::Serialize for AnnotatedValue<'_, '_, MoveStructLayout, FixedSizeVec>
             )));
         }
         let mut t = serializer.serialize_tuple(values.len())?;
-        for (field_layout, val) in fields.iter().zip(values.iter()) {
+        for (field_layout, val) in fields.zip(values.iter()) {
             let val = &*val.borrow();
             t.serialize_element(&AnnotatedValue {
-                layout: field_layout,
+                layout: &field_layout,
                 val,
             })?;
         }
@@ -2947,7 +2961,7 @@ impl serde::Serialize for AnnotatedValue<'_, '_, MoveStructLayout, FixedSizeVec>
     }
 }
 
-impl serde::Serialize for AnnotatedValue<'_, '_, MoveEnumLayout, (VariantTag, FixedSizeVec)> {
+impl serde::Serialize for AnnotatedValue<'_, '_, MoveEnumLayout<'_>, (VariantTag, FixedSizeVec)> {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let (tag, values) = &self.val;
         let tag = if *tag as u64 > VARIANT_TAG_MAX_VALUE {
@@ -2964,12 +2978,15 @@ impl serde::Serialize for AnnotatedValue<'_, '_, MoveEnumLayout, (VariantTag, Fi
             })?
         };
 
-        let fields = &self
-            .layout
-            .0
-            .safe_get(tag as usize)
-            .map_err(|e| invariant_violation::<S>(e.to_string()))?;
-        if fields.len() != values.len() {
+        let fields = &self.layout.variant(tag as usize).ok_or_else(|| {
+            invariant_violation::<S>("Invalid variant tag for serialization".to_string())
+        })?;
+        let VariantLayout::Known(fields) = fields else {
+            return Err(invariant_violation::<S>(
+                "Cannot serialize variant with unknown layout".to_string(),
+            ));
+        };
+        if fields.field_count() != values.len() {
             return Err(invariant_violation::<S>(format!(
                 "cannot serialize variant value {:?} as {:?} -- number of fields mismatch",
                 self.val, self.layout
@@ -2988,23 +3005,23 @@ impl serde::Serialize for AnnotatedValue<'_, '_, MoveEnumLayout, (VariantTag, Fi
     }
 }
 
-struct VariantFields<'a>(&'a [MoveTypeLayout]);
+struct VariantFields<'a>(&'a MoveFieldsLayout<'a>);
 
 impl<'a> serde::Serialize for AnnotatedValue<'a, '_, VariantFields<'a>, FixedSizeVec> {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let values = self.val;
         let types = self.layout.0;
-        if types.len() != values.len() {
+        if types.field_count() != values.len() {
             return Err(invariant_violation::<S>(format!(
                 "cannot serialize variant value {:?} as {:?} -- number of fields mismatch",
                 self.val, self.layout.0
             )));
         }
         let mut t = serializer.serialize_tuple(values.len())?;
-        for (field_layout, val) in types.iter().zip(values.iter()) {
+        for (field_layout, val) in types.fields().zip(values.iter()) {
             let val = &*val.borrow();
             t.serialize_element(&AnnotatedValue {
-                layout: field_layout,
+                layout: &field_layout,
                 val,
             })?;
         }
@@ -3017,18 +3034,18 @@ struct SeedWrapper<L> {
     layout: L,
 }
 
-impl<'d> serde::de::DeserializeSeed<'d> for SeedWrapper<&MoveTypeLayout> {
+impl<'d> serde::de::DeserializeSeed<'d> for SeedWrapper<&MoveTypeLayoutRef<'_>> {
     type Value = Value;
 
     fn deserialize<D: serde::de::Deserializer<'d>>(
         self,
         deserializer: D,
     ) -> Result<Self::Value, D::Error> {
-        use MoveTypeLayout as L;
+        use MoveLayoutView as L;
         use PrimVec as PV;
         use Value as V;
 
-        match self.layout {
+        match self.layout.as_view() {
             L::Bool => bool::deserialize(deserializer).map(Value::bool),
             L::U8 => u8::deserialize(deserializer).map(Value::u8),
             L::U16 => u16::deserialize(deserializer).map(Value::u16),
@@ -3040,17 +3057,17 @@ impl<'d> serde::de::DeserializeSeed<'d> for SeedWrapper<&MoveTypeLayout> {
             L::Signer => AccountAddress::deserialize(deserializer).map(Value::signer),
 
             L::Struct(struct_layout) => Ok(SeedWrapper {
-                layout: struct_layout.as_ref(),
+                layout: &struct_layout,
             }
             .deserialize(deserializer)?),
 
             L::Enum(enum_layout) => Ok(SeedWrapper {
-                layout: enum_layout.as_ref(),
+                layout: &enum_layout,
             }
             .deserialize(deserializer)?),
 
-            L::Vector(layout) => {
-                let value = match layout.as_ref() {
+            L::Vector(inner_layout) => {
+                let value = match inner_layout.as_view() {
                     L::U8 => V::PrimVec(PV::VecU8(Vec::deserialize(deserializer)?)),
                     L::U16 => V::PrimVec(PV::VecU16(Vec::deserialize(deserializer)?)),
                     L::U32 => V::PrimVec(PV::VecU32(Vec::deserialize(deserializer)?)),
@@ -3059,10 +3076,12 @@ impl<'d> serde::de::DeserializeSeed<'d> for SeedWrapper<&MoveTypeLayout> {
                     L::U256 => V::PrimVec(PV::VecU256(Vec::deserialize(deserializer)?)),
                     L::Bool => V::PrimVec(PV::VecBool(Vec::deserialize(deserializer)?)),
                     L::Address => V::PrimVec(PV::VecAddress(Vec::deserialize(deserializer)?)),
-                    layout => {
+                    _ => {
                         // TODO: Box this as part of deserialization to avoid the second iteration?
                         let v = deserializer
-                            .deserialize_seq(VectorElementVisitor(SeedWrapper { layout }))?
+                            .deserialize_seq(VectorElementVisitor(SeedWrapper {
+                                layout: &inner_layout,
+                            }))?
                             .into_iter()
                             .map(MemBox::new)
                             .collect();
@@ -3075,32 +3094,35 @@ impl<'d> serde::de::DeserializeSeed<'d> for SeedWrapper<&MoveTypeLayout> {
     }
 }
 
-impl<'d> serde::de::DeserializeSeed<'d> for SeedWrapper<&MoveStructLayout> {
+impl<'d> serde::de::DeserializeSeed<'d> for SeedWrapper<&MoveStructLayout<'_>> {
     type Value = Value;
 
     fn deserialize<D: serde::de::Deserializer<'d>>(
         self,
         deserializer: D,
     ) -> Result<Self::Value, D::Error> {
-        let fields = deserializer
-            .deserialize_tuple(self.layout.0.len(), StructFieldVisitor(&self.layout.0))?;
+        let fields_layout = self.layout.fields_layout();
+        let fields = deserializer.deserialize_tuple(
+            fields_layout.field_count(),
+            StructFieldVisitor(&fields_layout),
+        )?;
         Ok(Value::make_struct(fields))
     }
 }
 
-impl<'d> serde::de::DeserializeSeed<'d> for SeedWrapper<&MoveEnumLayout> {
+impl<'d> serde::de::DeserializeSeed<'d> for SeedWrapper<&MoveEnumLayout<'_>> {
     type Value = Value;
 
     fn deserialize<D: serde::de::Deserializer<'d>>(
         self,
         deserializer: D,
     ) -> Result<Self::Value, D::Error> {
-        let variant = deserializer.deserialize_tuple(2, EnumFieldVisitor(&self.layout.0))?;
+        let variant = deserializer.deserialize_tuple(2, EnumFieldVisitor(self.layout))?;
         Ok(Value::Variant(variant))
     }
 }
 
-struct VectorElementVisitor<'a>(SeedWrapper<&'a MoveTypeLayout>);
+struct VectorElementVisitor<'a>(SeedWrapper<&'a MoveTypeLayoutRef<'a>>);
 
 impl<'d> serde::de::Visitor<'d> for VectorElementVisitor<'_> {
     type Value = Vec<Value>;
@@ -3121,7 +3143,7 @@ impl<'d> serde::de::Visitor<'d> for VectorElementVisitor<'_> {
     }
 }
 
-struct StructFieldVisitor<'a>(&'a [MoveTypeLayout]);
+struct StructFieldVisitor<'a>(&'a MoveFieldsLayout<'a>);
 
 impl<'d> serde::de::Visitor<'d> for StructFieldVisitor<'_> {
     type Value = Vec<Value>;
@@ -3135,9 +3157,9 @@ impl<'d> serde::de::Visitor<'d> for StructFieldVisitor<'_> {
         A: serde::de::SeqAccess<'d>,
     {
         let mut val = Vec::new();
-        for (i, field_layout) in self.0.iter().enumerate() {
+        for (i, field_layout) in self.0.fields().enumerate() {
             if let Some(elem) = seq.next_element_seed(SeedWrapper {
-                layout: field_layout,
+                layout: &field_layout,
             })? {
                 val.push(elem)
             } else {
@@ -3148,7 +3170,7 @@ impl<'d> serde::de::Visitor<'d> for StructFieldVisitor<'_> {
     }
 }
 
-struct EnumFieldVisitor<'a>(&'a Vec<Vec<MoveTypeLayout>>);
+struct EnumFieldVisitor<'a>(&'a MoveEnumLayout<'a>);
 
 impl<'d> serde::de::Visitor<'d> for EnumFieldVisitor<'_> {
     type Value = Variant;
@@ -3161,7 +3183,7 @@ impl<'d> serde::de::Visitor<'d> for EnumFieldVisitor<'_> {
     where
         A: serde::de::SeqAccess<'d>,
     {
-        let tag = match seq.next_element_seed(&MoveTypeLayout::U8)? {
+        let tag = match seq.next_element_seed(&MoveTypeLayout::u8())? {
             Some(RuntimeValue::U8(tag)) if tag as u64 <= VARIANT_TAG_MAX_VALUE => tag as u16,
             Some(RuntimeValue::U8(tag)) => {
                 return Err(A::Error::invalid_length(tag as usize, &self));
@@ -3175,11 +3197,18 @@ impl<'d> serde::de::Visitor<'d> for EnumFieldVisitor<'_> {
             None => return Err(A::Error::invalid_length(0, &self)),
         };
 
-        let Some(variant_layout) = self.0.get(tag as usize) else {
+        let Some(variant_layout) = self.0.variant(tag as usize) else {
             return Err(A::Error::invalid_length(tag as usize, &self));
         };
 
-        let Some(fields) = seq.next_element_seed(&MoveRuntimeVariantFieldLayout(variant_layout))?
+        let VariantLayout::Known(variant_layout) = variant_layout else {
+            return Err(A::Error::custom(format!(
+                "Cannot deserialize variant with unknown layout for tag {tag}"
+            )));
+        };
+
+        let Some(fields) =
+            seq.next_element_seed(&MoveRuntimeVariantFieldLayout(&variant_layout))?
         else {
             return Err(A::Error::invalid_length(1, &self));
         };
@@ -3188,7 +3217,7 @@ impl<'d> serde::de::Visitor<'d> for EnumFieldVisitor<'_> {
     }
 }
 
-struct MoveRuntimeVariantFieldLayout<'a>(&'a Vec<MoveTypeLayout>);
+struct MoveRuntimeVariantFieldLayout<'a>(&'a MoveFieldsLayout<'a>);
 
 impl<'d> serde::de::DeserializeSeed<'d> for &MoveRuntimeVariantFieldLayout<'_> {
     type Value = Vec<Value>;
@@ -3197,7 +3226,7 @@ impl<'d> serde::de::DeserializeSeed<'d> for &MoveRuntimeVariantFieldLayout<'_> {
         self,
         deserializer: D,
     ) -> Result<Self::Value, D::Error> {
-        deserializer.deserialize_tuple(self.0.len(), StructFieldVisitor(self.0))
+        deserializer.deserialize_tuple(self.0.field_count(), StructFieldVisitor(self.0))
     }
 }
 
@@ -3211,30 +3240,41 @@ impl<'d> serde::de::DeserializeSeed<'d> for &MoveRuntimeVariantFieldLayout<'_> {
 
 impl Value {
     fn constant_sig_token_to_layout(constant_signature: &SignatureToken) -> Option<MoveTypeLayout> {
-        use MoveTypeLayout as L;
         use SignatureToken as S;
 
-        Some(match constant_signature {
-            S::Bool => L::Bool,
-            S::U8 => L::U8,
-            S::U16 => L::U16,
-            S::U32 => L::U32,
-            S::U64 => L::U64,
-            S::U128 => L::U128,
-            S::U256 => L::U256,
-            S::Address => L::Address,
-            S::Signer => return None,
-            S::Vector(inner) => L::Vector(Box::new(Self::constant_sig_token_to_layout(inner)?)),
-            // Not yet supported
-            S::Datatype(_) | S::DatatypeInstantiation(_) => return None,
-            // Not allowed/Not meaningful
-            S::TypeParameter(_) | S::Reference(_) | S::MutableReference(_) => return None,
-        })
+        fn constant_sig_token_to_layout_inner(
+            builder: &mut MoveTypeLayoutBuilder,
+            constant_signature: &SignatureToken,
+        ) -> Option<LayoutHandle> {
+            Some(match constant_signature {
+                S::Bool => builder.bool(),
+                S::U8 => builder.u8(),
+                S::U16 => builder.u16(),
+                S::U32 => builder.u32(),
+                S::U64 => builder.u64(),
+                S::U128 => builder.u128(),
+                S::U256 => builder.u256(),
+                S::Address => builder.address(),
+                S::Signer => return None,
+                S::Vector(inner) => {
+                    let inner = constant_sig_token_to_layout_inner(builder, inner)?;
+                    builder.vector(inner).ok()?
+                }
+                // Not yet supported
+                S::Datatype(_) | S::DatatypeInstantiation(_) => return None,
+                // Not allowed/Not meaningful
+                S::TypeParameter(_) | S::Reference(_) | S::MutableReference(_) => return None,
+            })
+        }
+
+        let mut builder = MoveTypeLayoutBuilder::new();
+        constant_sig_token_to_layout_inner(&mut builder, constant_signature)
+            .map(|handle| builder.build(handle))
     }
 
     pub fn deserialize_constant(constant: &Constant) -> Option<Value> {
         let layout = Self::constant_sig_token_to_layout(&constant.type_)?;
-        Value::simple_deserialize(&constant.data, &layout)
+        Value::simple_deserialize(&constant.data, layout.as_ref())
     }
 }
 
@@ -3631,11 +3671,11 @@ use move_core_types::runtime_value::{
 };
 
 impl Value {
-    pub fn as_move_value(&self, layout: &MoveTypeLayout) -> PartialVMResult<RuntimeValue> {
-        use MoveTypeLayout as L;
+    pub fn as_move_value(&self, layout: MoveTypeLayoutRef<'_>) -> PartialVMResult<RuntimeValue> {
+        use MoveLayoutView as L;
         use PrimVec as PV;
 
-        Ok(match (layout, self) {
+        Ok(match (layout.as_view(), self) {
             (L::U8, Value::U8(x)) => RuntimeValue::U8(*x),
             (L::U16, Value::U16(x)) => RuntimeValue::U16(*x),
             (L::U32, Value::U32(x)) => RuntimeValue::U32(*x),
@@ -3647,12 +3687,20 @@ impl Value {
 
             // Enum variant case with dereferencing the Box.
             (L::Enum(enum_layout), Value::Variant(entry)) => {
-                let MoveEnumLayout(variants) = &**enum_layout;
                 let (tag, values) = entry.as_ref();
                 let tag = *tag; // Simply copy the u16 value, no need for dereferencing
-                let field_layouts = variants.safe_get(tag as usize)?;
+                let VariantLayout::Known(field_layouts) =
+                    safe_unwrap!(enum_layout.variant(tag as usize))
+                else {
+                    return Err(partial_vm_error!(
+                        UNREACHABLE,
+                        "Variant layout not know for tag {} for enum layout {:?}",
+                        tag,
+                        enum_layout
+                    ));
+                };
                 let mut fields = vec![];
-                for (v, field_layout) in values.iter().zip(field_layouts) {
+                for (v, field_layout) in values.iter().zip(field_layouts.fields()) {
                     fields.push(v.try_borrow()?.as_move_value(field_layout)?);
                 }
                 RuntimeValue::Variant(RuntimeVariant { tag, fields })
@@ -3661,7 +3709,7 @@ impl Value {
             // Struct case with direct access to Box
             (L::Struct(struct_layout), Value::Struct(values)) => {
                 let mut fields = vec![];
-                for (v, field_layout) in values.iter().zip(struct_layout.fields().iter()) {
+                for (v, field_layout) in values.iter().zip(struct_layout.fields()) {
                     fields.push(v.try_borrow()?.as_move_value(field_layout)?);
                 }
                 RuntimeValue::Struct(RuntimeStruct::new(fields))
@@ -3671,7 +3719,7 @@ impl Value {
             (L::Vector(inner_layout), Value::Vec(values)) => RuntimeValue::Vector(
                 values
                     .iter()
-                    .map(|v| v.try_borrow()?.as_move_value(inner_layout.as_ref()))
+                    .map(|v| v.try_borrow()?.as_move_value(inner_layout))
                     .collect::<PartialVMResult<_>>()?,
             ),
             (L::Vector(inner_layout), Value::PrimVec(values)) => {
@@ -3681,7 +3729,7 @@ impl Value {
                         MV::Vector($xs.iter().map(|x| MV::$ctor(*x)).collect())
                     };
                 }
-                match (inner_layout.as_ref(), values) {
+                match (inner_layout.as_view(), values) {
                     (L::U8, PV::VecU8(xs)) => make_vec!(xs, U8),
                     (L::U16, PV::VecU16(xs)) => make_vec!(xs, U16),
                     (L::U32, PV::VecU32(xs)) => make_vec!(xs, U32),
@@ -3712,7 +3760,7 @@ impl Value {
                         return Err(partial_vm_error!(
                             UNREACHABLE,
                             "Expected a primitive type for the primitive vector, got {:?}",
-                            inner_layout.as_ref()
+                            inner_layout
                         ));
                     }
                 }

--- a/external-crates/move/crates/move-vm-runtime/src/execution/values/values_impl.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/execution/values/values_impl.rs
@@ -12,16 +12,17 @@ use crate::{
 };
 use move_binary_format::{
     checked_as,
+    constant::constant_sig_token_to_layout,
     errors::*,
-    file_format::{Constant, SignatureToken, VariantTag},
+    file_format::{Constant, VariantTag},
     partial_vm_error, safe_unwrap,
 };
 use move_core_types::{
     VARIANT_TAG_MAX_VALUE,
     account_address::AccountAddress,
     compressed::runtime::{
-        BackendBuilder as _, LayoutHandle, MoveEnumLayout, MoveFieldsLayout, MoveLayoutView,
-        MoveStructLayout, MoveTypeLayout, MoveTypeLayoutBuilder, MoveTypeLayoutRef, VariantLayout,
+        MoveEnumLayout, MoveFieldsLayout, MoveLayoutView, MoveStructLayout, MoveTypeLayout,
+        MoveTypeLayoutRef, VariantLayout,
     },
     u256,
     vm_status::sub_status::NFE_VECTOR_ERROR_BASE,
@@ -3239,41 +3240,8 @@ impl<'d> serde::de::DeserializeSeed<'d> for &MoveRuntimeVariantFieldLayout<'_> {
 **************************************************************************************/
 
 impl Value {
-    fn constant_sig_token_to_layout(constant_signature: &SignatureToken) -> Option<MoveTypeLayout> {
-        use SignatureToken as S;
-
-        fn constant_sig_token_to_layout_inner(
-            builder: &mut MoveTypeLayoutBuilder,
-            constant_signature: &SignatureToken,
-        ) -> Option<LayoutHandle> {
-            Some(match constant_signature {
-                S::Bool => builder.bool(),
-                S::U8 => builder.u8(),
-                S::U16 => builder.u16(),
-                S::U32 => builder.u32(),
-                S::U64 => builder.u64(),
-                S::U128 => builder.u128(),
-                S::U256 => builder.u256(),
-                S::Address => builder.address(),
-                S::Signer => return None,
-                S::Vector(inner) => {
-                    let inner = constant_sig_token_to_layout_inner(builder, inner)?;
-                    builder.vector(inner).ok()?
-                }
-                // Not yet supported
-                S::Datatype(_) | S::DatatypeInstantiation(_) => return None,
-                // Not allowed/Not meaningful
-                S::TypeParameter(_) | S::Reference(_) | S::MutableReference(_) => return None,
-            })
-        }
-
-        let mut builder = MoveTypeLayoutBuilder::new();
-        constant_sig_token_to_layout_inner(&mut builder, constant_signature)
-            .map(|handle| builder.build(handle))
-    }
-
     pub fn deserialize_constant(constant: &Constant) -> Option<Value> {
-        let layout = Self::constant_sig_token_to_layout(&constant.type_)?;
+        let layout = constant_sig_token_to_layout(&constant.type_)?;
         Value::simple_deserialize(&constant.data, layout.as_ref())
     }
 }

--- a/external-crates/move/crates/move-vm-runtime/src/execution/values/values_impl.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/execution/values/values_impl.rs
@@ -2979,7 +2979,7 @@ impl serde::Serialize for AnnotatedValue<'_, '_, MoveEnumLayout<'_>, (VariantTag
             })?
         };
 
-        let fields = &self.layout.variant(tag as usize).ok_or_else(|| {
+        let fields = &self.layout.variant(tag as u16).ok_or_else(|| {
             invariant_violation::<S>("Invalid variant tag for serialization".to_string())
         })?;
         let VariantLayout::Known(fields) = fields else {
@@ -3198,7 +3198,7 @@ impl<'d> serde::de::Visitor<'d> for EnumFieldVisitor<'_> {
             None => return Err(A::Error::invalid_length(0, &self)),
         };
 
-        let Some(variant_layout) = self.0.variant(tag as usize) else {
+        let Some(variant_layout) = self.0.variant(tag as u16) else {
             return Err(A::Error::invalid_length(tag as usize, &self));
         };
 
@@ -3657,8 +3657,7 @@ impl Value {
             (L::Enum(enum_layout), Value::Variant(entry)) => {
                 let (tag, values) = entry.as_ref();
                 let tag = *tag; // Simply copy the u16 value, no need for dereferencing
-                let VariantLayout::Known(field_layouts) =
-                    safe_unwrap!(enum_layout.variant(tag as usize))
+                let VariantLayout::Known(field_layouts) = safe_unwrap!(enum_layout.variant(tag))
                 else {
                     return Err(partial_vm_error!(
                         UNREACHABLE,
@@ -3797,7 +3796,7 @@ impl Value {
                     name,
                     tag: _v_tag,
                     fields: field_layouts,
-                } = e_layout.variant(tag as usize)?
+                } = e_layout.variant(tag)?
                 else {
                     return None;
                 };

--- a/external-crates/move/crates/move-vm-runtime/src/execution/values/values_impl.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/execution/values/values_impl.rs
@@ -3198,7 +3198,7 @@ impl<'d> serde::de::Visitor<'d> for EnumFieldVisitor<'_> {
             None => return Err(A::Error::invalid_length(0, &self)),
         };
 
-        let Some(variant_layout) = self.0.variant(tag as u16) else {
+        let Some(variant_layout) = self.0.variant(tag) else {
             return Err(A::Error::invalid_length(tag as usize, &self));
         };
 

--- a/external-crates/move/crates/move-vm-runtime/src/execution/values/values_impl.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/execution/values/values_impl.rs
@@ -3767,18 +3767,21 @@ impl Value {
     }
 }
 
-use move_core_types::annotated_value::{
-    MoveEnumLayout as AnnEnumLayout, MoveStruct as AnnStruct, MoveTypeLayout as AnnTypeLayout,
-    MoveValue as AnnValue, MoveVariant as AnnVariant,
+use move_core_types::{
+    annotated_value::{MoveStruct as AnnStruct, MoveValue as AnnValue, MoveVariant as AnnVariant},
+    compressed::annotated as CA,
 };
 
 impl Value {
     /// Converts the value to an annotated move value. This is only needed for tracing and care
     /// should be taken when using this function as it can possibly inflate the size of the value.
-    pub fn as_annotated_move_value(&self, layout: &AnnTypeLayout) -> Option<AnnValue> {
-        use AnnTypeLayout as L;
+    pub fn as_annotated_move_value(
+        &self,
+        layout: CA::MoveTypeLayoutRef<'_>,
+    ) -> Option<AnnValue> {
         use AnnValue as AV;
-        match (layout, self) {
+        use CA::MoveLayoutView as L;
+        match (layout.as_view(), self) {
             (L::U8, Value::U8(x)) => Some(AnnValue::U8(*x)),
             (L::U16, Value::U16(x)) => Some(AnnValue::U16(*x)),
             (L::U32, Value::U32(x)) => Some(AnnValue::U32(*x)),
@@ -3788,34 +3791,41 @@ impl Value {
             (L::Bool, Value::Bool(x)) => Some(AnnValue::Bool(*x)),
             (L::Address, Value::Address(x)) => Some(AnnValue::Address(**x)),
             (L::Enum(e_layout), Value::Variant(var_box)) => {
-                let AnnEnumLayout { type_, variants } = e_layout.as_ref();
                 let (tag, values) = var_box.as_ref();
                 let tag = *tag;
-                let ((name, _), field_layouts) = variants.iter().find(|((_, t), _)| *t == tag)?;
+                let CA::VariantLayout::Known {
+                    name,
+                    tag: _v_tag,
+                    fields: field_layouts,
+                } = e_layout.variant(tag as usize)?
+                else {
+                    return None;
+                };
+                debug_assert_eq!(_v_tag, tag);
                 let mut fields = vec![];
-                for (v, field_layout) in values.iter().zip(field_layouts) {
+                for (v, (field_name, field_layout)) in values.iter().zip(field_layouts.fields()) {
                     fields.push((
-                        field_layout.name.clone(),
-                        v.borrow().as_annotated_move_value(&field_layout.layout)?,
+                        field_name.clone(),
+                        v.borrow().as_annotated_move_value(field_layout)?,
                     ));
                 }
                 Some(AV::Variant(AnnVariant {
                     tag,
                     fields,
-                    type_: type_.clone(),
+                    type_: e_layout.type_().clone(),
                     variant_name: name.clone(),
                 }))
             }
             (L::Struct(struct_layout), Value::Struct(values)) => {
                 let mut fields = vec![];
-                for (v, field_layout) in values.iter().zip(struct_layout.fields.iter()) {
+                for (v, (field_name, field_layout)) in values.iter().zip(struct_layout.fields()) {
                     fields.push((
-                        field_layout.name.clone(),
-                        v.borrow().as_annotated_move_value(&field_layout.layout)?,
+                        field_name.clone(),
+                        v.borrow().as_annotated_move_value(field_layout)?,
                     ));
                 }
                 Some(AV::Struct(AnnStruct::new(
-                    struct_layout.type_.clone(),
+                    struct_layout.type_().clone(),
                     fields,
                 )))
             }
@@ -3832,7 +3842,7 @@ impl Value {
                         Some(AV::Vector($xs.iter().map(|x| AV::$ctor(*x)).collect()))
                     };
                 }
-                match (inner_layout.as_ref(), values) {
+                match (inner_layout.as_view(), values) {
                     (L::U8, PrimVec::VecU8(xs)) => make_vec!(xs, U8),
                     (L::U16, PrimVec::VecU16(xs)) => make_vec!(xs, U16),
                     (L::U32, PrimVec::VecU32(xs)) => make_vec!(xs, U32),
@@ -3853,16 +3863,19 @@ impl Value {
                     _ => None,
                 }
             }
-            (layout, Value::Reference(ref_)) => ref_.as_annotated_move_value(layout),
+            (_layout_view, Value::Reference(ref_)) => ref_.as_annotated_move_value(layout),
             (_, _) => None,
         }
     }
 }
 
 impl Reference {
-    pub fn as_annotated_move_value(&self, layout: &AnnTypeLayout) -> Option<AnnValue> {
+    pub fn as_annotated_move_value(
+        &self,
+        layout: CA::MoveTypeLayoutRef<'_>,
+    ) -> Option<AnnValue> {
         use AnnValue as AV;
-        use move_core_types::annotated_value::MoveTypeLayout as L;
+        use CA::MoveLayoutView as L;
         match self {
             // If the reference is a direct reference, delegate to the inner Value.
             Reference::Value(mem_box) => mem_box.borrow().as_annotated_move_value(layout),
@@ -3880,8 +3893,8 @@ impl Reference {
                     Value::PrimVec(prim_vec) => {
                         // We require that the layout is for a vector; then we inspect
                         // the inner layout and the PrimVec variant.
-                        match layout {
-                            L::Vector(inner_layout) => match (inner_layout.as_ref(), prim_vec) {
+                        match layout.as_view() {
+                            L::Vector(inner_layout) => match (inner_layout.as_view(), prim_vec) {
                                 (L::U8, PrimVec::VecU8(xs)) => {
                                     Some(AV::Vector(xs.iter().map(|u| AV::U8(*u)).collect()))
                                 }

--- a/external-crates/move/crates/move-vm-runtime/src/execution/vm.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/execution/vm.rs
@@ -274,12 +274,25 @@ impl<'extensions> MoveVM<'extensions> {
     #[instrument(level = "trace", skip_all)]
     pub fn runtime_type_layout(&self, ty: &TypeTag) -> VMResult<runtime_value::MoveTypeLayout> {
         tracing::trace!(type_tag = %ty, "Getting runtime layout");
-        self.virtual_tables.get_type_layout(ty).map_err(|e| {
-            Self::convert_to_external_resolution_error(
-                e,
-                format!("Failed to resolve type layout for {ty}",),
-            )
-        })
+        self.virtual_tables
+            .get_type_layout(ty)
+            .and_then(|ty| {
+                ty.inflate().map_err(|e| {
+                    partial_vm_error!(
+                        UNKNOWN_INVARIANT_VIOLATION_ERROR,
+                        "Failed to inflate type layout for {:?}: {}",
+                        ty,
+                        e
+                    )
+                    .finish(Location::Undefined)
+                })
+            })
+            .map_err(|e| {
+                Self::convert_to_external_resolution_error(
+                    e,
+                    format!("Failed to resolve type layout for {ty}",),
+                )
+            })
     }
 
     /// Resolve a `TypeTag` to an annotated type layout using the VM's virtual tables.
@@ -293,6 +306,17 @@ impl<'extensions> MoveVM<'extensions> {
         tracing::trace!(type_tag = %ty, "Getting annotated layout");
         self.virtual_tables
             .get_fully_annotated_type_layout(ty)
+            .and_then(|ty| {
+                ty.inflate().map_err(|e| {
+                    partial_vm_error!(
+                        UNKNOWN_INVARIANT_VIOLATION_ERROR,
+                        "Failed to inflate type layout for {:?}: {}",
+                        ty,
+                        e
+                    )
+                    .finish(Location::Undefined)
+                })
+            })
             .map_err(|e| {
                 Self::convert_to_external_resolution_error(
                     e,

--- a/external-crates/move/crates/move-vm-runtime/src/execution/vm.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/execution/vm.rs
@@ -25,10 +25,9 @@ use move_binary_format::{
     partial_vm_error,
 };
 use move_core_types::{
-    annotated_value,
+    compressed as C,
     identifier::{IdentStr, Identifier},
     language_storage::{ModuleId, TypeTag},
-    runtime_value,
     vm_status::StatusType,
 };
 use move_trace_format::format::MoveTraceBuilder;
@@ -272,27 +271,14 @@ impl<'extensions> MoveVM<'extensions> {
     /// Additionally, the type tag _must_ use defining type IDs. Original/runtime IDs (or package
     /// IDs) are not correct here.
     #[instrument(level = "trace", skip_all)]
-    pub fn runtime_type_layout(&self, ty: &TypeTag) -> VMResult<runtime_value::MoveTypeLayout> {
+    pub fn runtime_type_layout(&self, ty: &TypeTag) -> VMResult<C::runtime::MoveTypeLayout> {
         tracing::trace!(type_tag = %ty, "Getting runtime layout");
-        self.virtual_tables
-            .get_type_layout(ty)
-            .and_then(|ty| {
-                ty.inflate().map_err(|e| {
-                    partial_vm_error!(
-                        UNKNOWN_INVARIANT_VIOLATION_ERROR,
-                        "Failed to inflate type layout for {:?}: {}",
-                        ty,
-                        e
-                    )
-                    .finish(Location::Undefined)
-                })
-            })
-            .map_err(|e| {
-                Self::convert_to_external_resolution_error(
-                    e,
-                    format!("Failed to resolve type layout for {ty}",),
-                )
-            })
+        self.virtual_tables.get_type_layout(ty).map_err(|e| {
+            Self::convert_to_external_resolution_error(
+                e,
+                format!("Failed to resolve type layout for {ty}",),
+            )
+        })
     }
 
     /// Resolve a `TypeTag` to an annotated type layout using the VM's virtual tables.
@@ -302,21 +288,10 @@ impl<'extensions> MoveVM<'extensions> {
     /// Additionally, the type tag _must_ use defining type IDs. Original/runtime IDs (or package
     /// IDs) are not correct here.
     #[instrument(level = "trace", skip_all)]
-    pub fn annotated_type_layout(&self, ty: &TypeTag) -> VMResult<annotated_value::MoveTypeLayout> {
+    pub fn annotated_type_layout(&self, ty: &TypeTag) -> VMResult<C::annotated::MoveTypeLayout> {
         tracing::trace!(type_tag = %ty, "Getting annotated layout");
         self.virtual_tables
             .get_fully_annotated_type_layout(ty)
-            .and_then(|ty| {
-                ty.inflate().map_err(|e| {
-                    partial_vm_error!(
-                        UNKNOWN_INVARIANT_VIOLATION_ERROR,
-                        "Failed to inflate type layout for {:?}: {}",
-                        ty,
-                        e
-                    )
-                    .finish(Location::Undefined)
-                })
-            })
             .map_err(|e| {
                 Self::convert_to_external_resolution_error(
                     e,

--- a/external-crates/move/crates/move-vm-runtime/src/natives/functions.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/natives/functions.rs
@@ -253,15 +253,28 @@ impl<'b> NativeContext<'_, 'b, '_> {
     }
 
     pub fn type_tag_to_type_layout(&self, ty: &TypeTag) -> Option<R::MoveTypeLayout> {
-        self.vtables.get_type_layout(ty).ok()
+        self.vtables.get_type_layout(ty).ok()?.inflate().ok()
     }
 
     pub fn type_tag_to_annotated_type_layout(&self, ty: &TypeTag) -> Option<A::MoveTypeLayout> {
-        self.vtables.get_fully_annotated_type_layout(ty).ok()
+        self.vtables
+            .get_fully_annotated_type_layout(ty)
+            .ok()
+            .and_then(|ty| ty.inflate().ok())
     }
 
     pub fn type_to_type_layout(&self, ty: &Type) -> PartialVMResult<Option<R::MoveTypeLayout>> {
-        match self.vtables.type_to_type_layout(ty) {
+        let layout = self.vtables.type_to_type_layout(ty).and_then(|ty| {
+            ty.inflate().map_err(|e| {
+                partial_vm_error!(
+                    UNKNOWN_INVARIANT_VIOLATION_ERROR,
+                    "Failed to inflate type layout for {:?}: {}",
+                    ty,
+                    e
+                )
+            })
+        });
+        match layout {
             Ok(ty_layout) => Ok(Some(ty_layout)),
             Err(e) if e.major_status().status_type() == StatusType::InvariantViolation => Err(e),
             Err(_) => Ok(None),
@@ -276,7 +289,20 @@ impl<'b> NativeContext<'_, 'b, '_> {
         &self,
         ty: &Type,
     ) -> PartialVMResult<Option<A::MoveTypeLayout>> {
-        match self.vtables.type_to_fully_annotated_layout(ty) {
+        let layout = self
+            .vtables
+            .type_to_fully_annotated_layout(ty)
+            .and_then(|ty| {
+                ty.inflate().map_err(|e| {
+                    partial_vm_error!(
+                        UNKNOWN_INVARIANT_VIOLATION_ERROR,
+                        "Failed to inflate type layout for {:?}: {}",
+                        ty,
+                        e
+                    )
+                })
+            });
+        match layout {
             Ok(ty_layout) => Ok(Some(ty_layout)),
             Err(e) if e.major_status().status_type() == StatusType::InvariantViolation => Err(e),
             Err(_) => Ok(None),

--- a/external-crates/move/crates/move-vm-runtime/src/natives/functions.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/natives/functions.rs
@@ -28,8 +28,9 @@ pub use move_binary_format::errors::PartialVMError;
 use move_binary_format::{errors::PartialVMResult, file_format::AbilitySet, partial_vm_error};
 pub use move_core_types::vm_status::StatusCode;
 use move_core_types::{
-    account_address::AccountAddress, annotated_value as A, gas_algebra::InternalGas,
-    identifier::Identifier, language_storage::TypeTag, runtime_value as R, vm_status::StatusType,
+    account_address::AccountAddress, compressed::annotated as A, compressed::runtime as R,
+    gas_algebra::InternalGas, identifier::Identifier, language_storage::TypeTag,
+    vm_status::StatusType,
 };
 use move_vm_config::runtime::VMRuntimeLimitsConfig;
 use smallvec::{SmallVec, smallvec};
@@ -253,28 +254,15 @@ impl<'b> NativeContext<'_, 'b, '_> {
     }
 
     pub fn type_tag_to_type_layout(&self, ty: &TypeTag) -> Option<R::MoveTypeLayout> {
-        self.vtables.get_type_layout(ty).ok()?.inflate().ok()
+        self.vtables.get_type_layout(ty).ok()
     }
 
     pub fn type_tag_to_annotated_type_layout(&self, ty: &TypeTag) -> Option<A::MoveTypeLayout> {
-        self.vtables
-            .get_fully_annotated_type_layout(ty)
-            .ok()
-            .and_then(|ty| ty.inflate().ok())
+        self.vtables.get_fully_annotated_type_layout(ty).ok()
     }
 
     pub fn type_to_type_layout(&self, ty: &Type) -> PartialVMResult<Option<R::MoveTypeLayout>> {
-        let layout = self.vtables.type_to_type_layout(ty).and_then(|ty| {
-            ty.inflate().map_err(|e| {
-                partial_vm_error!(
-                    UNKNOWN_INVARIANT_VIOLATION_ERROR,
-                    "Failed to inflate type layout for {:?}: {}",
-                    ty,
-                    e
-                )
-            })
-        });
-        match layout {
+        match self.vtables.type_to_type_layout(ty) {
             Ok(ty_layout) => Ok(Some(ty_layout)),
             Err(e) if e.major_status().status_type() == StatusType::InvariantViolation => Err(e),
             Err(_) => Ok(None),
@@ -289,20 +277,7 @@ impl<'b> NativeContext<'_, 'b, '_> {
         &self,
         ty: &Type,
     ) -> PartialVMResult<Option<A::MoveTypeLayout>> {
-        let layout = self
-            .vtables
-            .type_to_fully_annotated_layout(ty)
-            .and_then(|ty| {
-                ty.inflate().map_err(|e| {
-                    partial_vm_error!(
-                        UNKNOWN_INVARIANT_VIOLATION_ERROR,
-                        "Failed to inflate type layout for {:?}: {}",
-                        ty,
-                        e
-                    )
-                })
-            });
-        match layout {
+        match self.vtables.type_to_fully_annotated_layout(ty) {
             Ok(ty_layout) => Ok(Some(ty_layout)),
             Err(e) if e.major_status().status_type() == StatusType::InvariantViolation => Err(e),
             Err(_) => Ok(None),

--- a/external-crates/move/crates/move-vm-runtime/src/natives/move_stdlib/bcs.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/natives/move_stdlib/bcs.rs
@@ -14,7 +14,6 @@ use crate::{
 };
 use move_binary_format::{errors::PartialVMResult, safe_unwrap};
 use move_core_types::{
-    compressed::runtime::MoveTypeLayout,
     gas_algebra::{InternalGas, InternalGasPerByte, NumBytes},
     vm_status::sub_status::NFE_BCS_SERIALIZATION_FAILURE,
 };
@@ -68,13 +67,6 @@ fn native_to_bytes(
     };
     // serialize value
     let val = ref_to_val.read_ref()?;
-    let layout = MoveTypeLayout::try_from(&layout).map_err(|e| {
-        move_binary_format::partial_vm_error!(
-            UNKNOWN_INVARIANT_VIOLATION_ERROR,
-            "Failed to convert type layout for serialization: {:?}",
-            e
-        )
-    })?;
     let serialized_value = match val.typed_serialize(layout.as_ref()) {
         Some(serialized_value) => serialized_value,
         None => {

--- a/external-crates/move/crates/move-vm-runtime/src/natives/move_stdlib/bcs.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/natives/move_stdlib/bcs.rs
@@ -14,6 +14,7 @@ use crate::{
 };
 use move_binary_format::{errors::PartialVMResult, safe_unwrap};
 use move_core_types::{
+    compressed::runtime::MoveTypeLayout,
     gas_algebra::{InternalGas, InternalGasPerByte, NumBytes},
     vm_status::sub_status::NFE_BCS_SERIALIZATION_FAILURE,
 };
@@ -67,7 +68,14 @@ fn native_to_bytes(
     };
     // serialize value
     let val = ref_to_val.read_ref()?;
-    let serialized_value = match val.typed_serialize(&layout) {
+    let layout = MoveTypeLayout::try_from(&layout).map_err(|e| {
+        move_binary_format::partial_vm_error!(
+            UNKNOWN_INVARIANT_VIOLATION_ERROR,
+            "Failed to convert type layout for serialization: {:?}",
+            e
+        )
+    })?;
+    let serialized_value = match val.typed_serialize(layout.as_ref()) {
         Some(serialized_value) => serialized_value,
         None => {
             // If we run out of gas when charging for failure, we don't want the `OUT_OF_GAS` error

--- a/external-crates/move/crates/move-vm-runtime/src/natives/move_stdlib/debug.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/natives/move_stdlib/debug.rs
@@ -201,11 +201,11 @@ mod testing {
     };
     use move_binary_format::{
         errors::{PartialVMError, PartialVMResult},
-        partial_vm_error, safe_unwrap,
+        partial_vm_error,
     };
     use move_core_types::{
-        account_address::AccountAddress, annotated_value as A, compressed::runtime as CR,
-        language_storage::TypeTag, runtime_value as R,
+        account_address::AccountAddress, annotated_value as A, compressed::annotated as CA,
+        compressed::runtime as CR, language_storage::TypeTag, runtime_value as R,
     };
     use std::{fmt, fmt::Write};
 
@@ -233,20 +233,14 @@ mod testing {
     fn get_annotated_struct_layout(
         context: &NativeContext,
         ty: &Type,
-    ) -> PartialVMResult<A::MoveDatatypeLayout> {
+    ) -> PartialVMResult<CA::MoveDatatypeLayout> {
         let annotated_type_layout = context.type_to_fully_annotated_layout(ty)?.unwrap();
-        match annotated_type_layout {
-            A::MoveTypeLayout::Struct(annotated_struct_layout) => {
-                Ok(A::MoveDatatypeLayout::Struct(annotated_struct_layout))
-            }
-            A::MoveTypeLayout::Enum(annotated_enum_layout) => {
-                Ok(A::MoveDatatypeLayout::Enum(annotated_enum_layout))
-            }
-            _ => Err(partial_vm_error!(
+        CA::MoveDatatypeLayout::new(annotated_type_layout).ok_or_else(|| {
+            partial_vm_error!(
                 INTERNAL_TYPE_ERROR,
                 "Could not convert Type to fully-annotated MoveTypeLayout via NativeContext"
-            )),
-        }
+            )
+        })
     }
 
     fn get_vector_inner_type(ty: &Type) -> PartialVMResult<&Type> {
@@ -327,22 +321,20 @@ mod testing {
     ) -> PartialVMResult<()> {
         // get type layout in VM format
         let ty_layout = context.type_to_type_layout(&ty)?.unwrap();
-        let compressed_ty_layout = safe_unwrap!(CR::MoveTypeLayout::try_from(&ty_layout));
 
-        match &ty_layout {
-            R::MoveTypeLayout::Vector(_) => {
+        match &ty_layout.as_view() {
+            CR::MoveLayoutView::Vector(inner_tyl) => {
                 // get the inner type T of a vector<T>
                 let inner_ty = get_vector_inner_type(&ty)?;
-                let inner_tyl = context.type_to_type_layout(inner_ty)?.unwrap();
 
-                match inner_tyl {
+                match inner_tyl.as_view() {
                     // We cannot simply convert a `Value` (of type vector) to a `MoveValue` because
                     // there might be a struct in the vector that needs to be "decorated" using the
                     // logic in this function. Instead, we recursively "unpack" the vector until we
                     // get down to either (1) a primitive type, which we can forward to
                     // `print_move_value`, or (2) a struct type, which we can decorate and forward
                     // to `print_move_value`.
-                    R::MoveTypeLayout::Vector(_) | R::MoveTypeLayout::Struct(_) => {
+                    CR::MoveLayoutView::Vector(_) | CR::MoveLayoutView::Struct(_) => {
                         // `val` is either a `Vec<Vec<Value>>`, a `Vec<Struct>`,  or a `Vec<signer>`, so we cast `val` as a `Vec<Value>` and call ourselves recursively
                         let vec = VMValueCast::<Vec<Value>>::cast(val)?;
 
@@ -384,8 +376,8 @@ mod testing {
                     _ => {
                         let ann_ty_layout = context.type_to_fully_annotated_layout(&ty)?.unwrap();
                         let mv = val
-                            .as_move_value(compressed_ty_layout.as_ref())?
-                            .decorate(&ann_ty_layout);
+                            .as_move_value(ty_layout.as_ref())?
+                            .decorate_compressed(&ann_ty_layout);
                         print_move_value(
                             out,
                             mv,
@@ -399,8 +391,8 @@ mod testing {
                 };
             }
             // For a struct, we convert it to a MoveValue annotated with its field names and types and print it
-            R::MoveTypeLayout::Struct(_) => {
-                let move_struct = match val.as_move_value(compressed_ty_layout.as_ref())? {
+            CR::MoveLayoutView::Struct(_) => {
+                let move_struct = match val.as_move_value(ty_layout.as_ref())? {
                     R::MoveValue::Struct(s) => s,
                     _ => {
                         return Err(partial_vm_error!(
@@ -410,15 +402,15 @@ mod testing {
                     }
                 };
 
-                let A::MoveDatatypeLayout::Struct(annotated_struct_layout) =
-                    get_annotated_struct_layout(context, &ty)?
+                let CA::MoveLayoutView::Struct(annotated_struct_layout) =
+                    get_annotated_struct_layout(context, &ty)?.as_view()
                 else {
                     return Err(partial_vm_error!(
                         INTERNAL_TYPE_ERROR,
                         "Expected MoveDatatypeLayout::Struct"
                     ));
                 };
-                let decorated_struct = move_struct.decorate(&annotated_struct_layout);
+                let decorated_struct = move_struct.decorate_compressed(&annotated_struct_layout);
 
                 print_move_value(
                     out,
@@ -430,8 +422,8 @@ mod testing {
                     include_int_types,
                 )?;
             }
-            R::MoveTypeLayout::Enum(_) => {
-                let move_struct = match val.as_move_value(compressed_ty_layout.as_ref())? {
+            CR::MoveLayoutView::Enum(_) => {
+                let move_struct = match val.as_move_value(ty_layout.as_ref())? {
                     R::MoveValue::Variant(v) => v,
                     _ => {
                         return Err(partial_vm_error!(
@@ -441,15 +433,15 @@ mod testing {
                     }
                 };
 
-                let A::MoveDatatypeLayout::Enum(annotated_enum_layout) =
-                    get_annotated_struct_layout(context, &ty)?
+                let CA::MoveLayoutView::Enum(annotated_enum_layout) =
+                    get_annotated_struct_layout(context, &ty)?.as_view()
                 else {
                     return Err(partial_vm_error!(
                         INTERNAL_TYPE_ERROR,
                         "Expected MoveDatatypeLayout::Enum"
                     ));
                 };
-                let decorated_struct = move_struct.decorate(&annotated_enum_layout);
+                let decorated_struct = move_struct.decorate_compressed(&annotated_enum_layout);
 
                 print_move_value(
                     out,
@@ -466,8 +458,8 @@ mod testing {
                 let ann_ty_layout = context.type_to_fully_annotated_layout(&ty)?.unwrap();
                 print_move_value(
                     out,
-                    val.as_move_value(compressed_ty_layout.as_ref())?
-                        .decorate(&ann_ty_layout),
+                    val.as_move_value(ty_layout.as_ref())?
+                        .decorate_compressed(&ann_ty_layout),
                     move_std_addr,
                     depth,
                     canonicalize,

--- a/external-crates/move/crates/move-vm-runtime/src/natives/move_stdlib/debug.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/natives/move_stdlib/debug.rs
@@ -233,14 +233,8 @@ mod testing {
     fn get_annotated_struct_layout(
         context: &NativeContext,
         ty: &Type,
-    ) -> PartialVMResult<CA::MoveDatatypeLayout> {
-        let annotated_type_layout = context.type_to_fully_annotated_layout(ty)?.unwrap();
-        CA::MoveDatatypeLayout::new(annotated_type_layout).ok_or_else(|| {
-            partial_vm_error!(
-                INTERNAL_TYPE_ERROR,
-                "Could not convert Type to fully-annotated MoveTypeLayout via NativeContext"
-            )
-        })
+    ) -> PartialVMResult<CA::MoveTypeLayout> {
+        Ok(context.type_to_fully_annotated_layout(ty)?.unwrap())
     }
 
     fn get_vector_inner_type(ty: &Type) -> PartialVMResult<&Type> {
@@ -377,7 +371,7 @@ mod testing {
                         let ann_ty_layout = context.type_to_fully_annotated_layout(&ty)?.unwrap();
                         let mv = val
                             .as_move_value(ty_layout.as_ref())?
-                            .decorate_compressed(&ann_ty_layout);
+                            .decorate_compressed(ann_ty_layout.as_ref());
                         print_move_value(
                             out,
                             mv,
@@ -402,8 +396,9 @@ mod testing {
                     }
                 };
 
+                let annotated_layout = get_annotated_struct_layout(context, &ty)?;
                 let CA::MoveLayoutView::Struct(annotated_struct_layout) =
-                    get_annotated_struct_layout(context, &ty)?.as_view()
+                    annotated_layout.as_view()
                 else {
                     return Err(partial_vm_error!(
                         INTERNAL_TYPE_ERROR,
@@ -433,8 +428,8 @@ mod testing {
                     }
                 };
 
-                let CA::MoveLayoutView::Enum(annotated_enum_layout) =
-                    get_annotated_struct_layout(context, &ty)?.as_view()
+                let annotated_layout = get_annotated_struct_layout(context, &ty)?;
+                let CA::MoveLayoutView::Enum(annotated_enum_layout) = annotated_layout.as_view()
                 else {
                     return Err(partial_vm_error!(
                         INTERNAL_TYPE_ERROR,
@@ -459,7 +454,7 @@ mod testing {
                 print_move_value(
                     out,
                     val.as_move_value(ty_layout.as_ref())?
-                        .decorate_compressed(&ann_ty_layout),
+                        .decorate_compressed(ann_ty_layout.as_ref()),
                     move_std_addr,
                     depth,
                     canonicalize,

--- a/external-crates/move/crates/move-vm-runtime/src/natives/move_stdlib/debug.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/natives/move_stdlib/debug.rs
@@ -201,11 +201,11 @@ mod testing {
     };
     use move_binary_format::{
         errors::{PartialVMError, PartialVMResult},
-        partial_vm_error,
+        partial_vm_error, safe_unwrap,
     };
     use move_core_types::{
-        account_address::AccountAddress, annotated_value as A, language_storage::TypeTag,
-        runtime_value as R,
+        account_address::AccountAddress, annotated_value as A, compressed::runtime as CR,
+        language_storage::TypeTag, runtime_value as R,
     };
     use std::{fmt, fmt::Write};
 
@@ -327,6 +327,7 @@ mod testing {
     ) -> PartialVMResult<()> {
         // get type layout in VM format
         let ty_layout = context.type_to_type_layout(&ty)?.unwrap();
+        let compressed_ty_layout = safe_unwrap!(CR::MoveTypeLayout::try_from(&ty_layout));
 
         match &ty_layout {
             R::MoveTypeLayout::Vector(_) => {
@@ -382,7 +383,9 @@ mod testing {
                     // vector<T> to a MoveValue and print it.
                     _ => {
                         let ann_ty_layout = context.type_to_fully_annotated_layout(&ty)?.unwrap();
-                        let mv = val.as_move_value(&ty_layout)?.decorate(&ann_ty_layout);
+                        let mv = val
+                            .as_move_value(compressed_ty_layout.as_ref())?
+                            .decorate(&ann_ty_layout);
                         print_move_value(
                             out,
                             mv,
@@ -397,7 +400,7 @@ mod testing {
             }
             // For a struct, we convert it to a MoveValue annotated with its field names and types and print it
             R::MoveTypeLayout::Struct(_) => {
-                let move_struct = match val.as_move_value(&ty_layout)? {
+                let move_struct = match val.as_move_value(compressed_ty_layout.as_ref())? {
                     R::MoveValue::Struct(s) => s,
                     _ => {
                         return Err(partial_vm_error!(
@@ -428,7 +431,7 @@ mod testing {
                 )?;
             }
             R::MoveTypeLayout::Enum(_) => {
-                let move_struct = match val.as_move_value(&ty_layout)? {
+                let move_struct = match val.as_move_value(compressed_ty_layout.as_ref())? {
                     R::MoveValue::Variant(v) => v,
                     _ => {
                         return Err(partial_vm_error!(
@@ -463,7 +466,8 @@ mod testing {
                 let ann_ty_layout = context.type_to_fully_annotated_layout(&ty)?.unwrap();
                 print_move_value(
                     out,
-                    val.as_move_value(&ty_layout)?.decorate(&ann_ty_layout),
+                    val.as_move_value(compressed_ty_layout.as_ref())?
+                        .decorate(&ann_ty_layout),
                     move_std_addr,
                     depth,
                     canonicalize,

--- a/external-crates/move/crates/move-vm-runtime/src/unit_tests/return_value_tests.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/unit_tests/return_value_tests.rs
@@ -16,6 +16,7 @@ use crate::{
 use move_binary_format::errors::VMResult;
 use move_core_types::{
     account_address::AccountAddress,
+    compressed::runtime::MoveTypeLayout,
     identifier::Identifier,
     language_storage::{ModuleId, TypeTag},
     runtime_value::MoveValue,
@@ -140,9 +141,8 @@ fn return_signer_ref() {
         panic!("Expected reference return");
     };
     let inner_val = inner.borrow();
-    let ret_move_val = inner_val
-        .as_move_value(&move_core_types::runtime_value::MoveTypeLayout::Signer)
-        .unwrap();
+    let signer_layout = MoveTypeLayout::signer();
+    let ret_move_val = inner_val.as_move_value(signer_layout.as_ref()).unwrap();
     let expected = MoveValue::Signer(TEST_ADDR);
     assert_eq!(ret_move_val, expected);
 }

--- a/external-crates/move/crates/move-vm-runtime/src/unit_tests/value_tests.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/unit_tests/value_tests.rs
@@ -13,7 +13,11 @@ use crate::{
     shared::views::*,
 };
 use move_binary_format::{errors::*, file_format::VariantTag};
-use move_core_types::{account_address::AccountAddress, runtime_value, u256::U256};
+use move_core_types::{
+    account_address::AccountAddress,
+    compressed::runtime::{BackendBuilder as _, MoveTypeLayout, MoveTypeLayoutBuilder},
+    u256::U256,
+};
 
 #[cfg(test)]
 const SIZE_CONFIG: SizeConfig = SizeConfig {
@@ -339,16 +343,20 @@ fn signer_equivalence() -> PartialVMResult<()> {
     let addr = AccountAddress::TWO;
     let signer = Value::signer(addr);
 
+    let signer_layout = MoveTypeLayout::signer();
     assert_eq!(
         signer.serialize(),
-        signer.typed_serialize(&runtime_value::MoveTypeLayout::Signer)
+        signer.typed_serialize(signer_layout.as_ref())
     );
 
+    let struct_with_addr = MoveTypeLayoutBuilder::with_builder(|builder| {
+        let address = builder.address();
+        builder.struct_layout(&[address])
+    })
+    .unwrap();
     assert_eq!(
         signer.serialize(),
-        signer.typed_serialize(&runtime_value::MoveTypeLayout::Struct(Box::new(
-            runtime_value::MoveStructLayout(Box::new(vec![runtime_value::MoveTypeLayout::Address]))
-        )))
+        signer.typed_serialize(struct_with_addr.as_ref())
     );
 
     Ok(())

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/env.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/env.rs
@@ -20,11 +20,11 @@ use move_binary_format::{
     file_format::{Ability, AbilitySet, TypeParameterIndex},
 };
 use move_core_types::{
-    annotated_value,
+    compressed::annotated as CA,
+    compressed::runtime as CR,
     identifier::IdentStr,
     language_storage::{ModuleId, StructTag},
     resolver::IntraPackageName,
-    runtime_value::{self, MoveTypeLayout},
     vm_status::StatusCode,
 };
 use move_vm_runtime::{
@@ -148,10 +148,7 @@ where
         }
     }
 
-    pub fn fully_annotated_layout(
-        &self,
-        ty: &Type,
-    ) -> Result<annotated_value::MoveTypeLayout, Mode::Error> {
+    pub fn fully_annotated_layout(&self, ty: &Type) -> Result<CA::MoveTypeLayout, Mode::Error> {
         let tag: TypeTag = ty.clone().try_into().map_err(|s| {
             Mode::Error::new_with_source(ExecutionErrorKind::VMInvariantViolation, s)
         })?;
@@ -166,7 +163,7 @@ where
             .map_err(|e| self.convert_linked_vm_error(e, &tag_linkage))
     }
 
-    pub fn runtime_layout(&self, ty: &Type) -> Result<runtime_value::MoveTypeLayout, Mode::Error> {
+    pub fn runtime_layout(&self, ty: &Type) -> Result<CR::MoveTypeLayout, Mode::Error> {
         let tag: TypeTag = ty.clone().try_into().map_err(|s| {
             Mode::Error::new_with_source(ExecutionErrorKind::VMInvariantViolation, s)
         })?;
@@ -299,7 +296,10 @@ where
         self.adapter_type_from_vm_type(self.input_type_resolution_vm, &vm_type)
     }
 
-    pub fn type_layout_for_struct(&self, tag: &StructTag) -> Result<MoveTypeLayout, Mode::Error> {
+    pub fn type_layout_for_struct(
+        &self,
+        tag: &StructTag,
+    ) -> Result<CR::MoveTypeLayout, Mode::Error> {
         let ty: Type = self.load_type_from_struct(tag)?;
         self.runtime_layout(&ty)
     }

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/execution/context.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/execution/context.rs
@@ -29,6 +29,7 @@ use move_binary_format::{
 };
 use move_core_types::{
     account_address::AccountAddress,
+    compressed::runtime as CR,
     identifier::IdentStr,
     language_storage::{ModuleId, StructTag},
     u256::U256,
@@ -640,7 +641,7 @@ where
             )?;
             let abilities = ty.abilities();
             let has_public_transfer = abilities.has_store();
-            let Some(bytes) = value.typed_serialize(&layout) else {
+            let Some(bytes) = value.typed_serialize(layout.as_ref()) else {
                 invariant_violation!("Failed to serialize already deserialized Move value");
             };
             // safe because has_public_transfer has been determined by the abilities
@@ -715,7 +716,7 @@ where
                 let layout = vm
                     .runtime_type_layout(&type_tag)
                     .map_err(|e| self.env.convert_linked_vm_error(e, linkage))?;
-                let Some(bytes) = value.typed_serialize(&layout) else {
+                let Some(bytes) = value.typed_serialize(layout.as_ref()) else {
                     invariant_violation!("Failed to serialize Move event");
                 };
                 let TypeTag::Struct(tag) = type_tag else {
@@ -772,7 +773,7 @@ where
         vm: &MoveVM,
         linkage: &ExecutableLinkage,
         tag: StructTag,
-    ) -> Result<(Type, move_core_types::runtime_value::MoveTypeLayout), Mode::Error> {
+    ) -> Result<(Type, CR::MoveTypeLayout), Mode::Error> {
         let type_tag = TypeTag::Struct(Box::new(tag));
         let vm_type = vm
             .load_type(&type_tag)
@@ -1452,7 +1453,7 @@ where
             }
         };
         let layout = self.env.runtime_layout(&ty)?;
-        let Some(bytes) = value.typed_serialize(&layout) else {
+        let Some(bytes) = value.typed_serialize(layout.as_ref()) else {
             invariant_violation!("Failed to serialize Move value");
         };
         let arg = match location {
@@ -1517,7 +1518,7 @@ where
             _ => (result, ty),
         };
         let layout = self.env.runtime_layout(&ty)?;
-        let Some(bytes) = v.typed_serialize(&layout) else {
+        let Some(bytes) = v.typed_serialize(layout.as_ref()) else {
             invariant_violation!("Failed to serialize Move value");
         };
         let Ok(tag): Result<TypeTag, _> = ty.try_into() else {

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/execution/trace_utils.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/execution/trace_utils.rs
@@ -13,7 +13,7 @@ use crate::{
         typing::ast::{Command__, Commands, Type},
     },
 };
-use move_core_types::{annotated_value as A, language_storage::TypeTag};
+use move_core_types::{compressed::annotated as CA, language_storage::TypeTag};
 use move_trace_format::{
     format::{Effect, MoveTraceBuilder, RefType, TraceEvent, TypeTagWithRefs},
     value::{SerializableMoveValue, SimplifiedMoveStruct},
@@ -354,7 +354,7 @@ fn move_value_info_from_ctx_value<Mode: ExecutionMode>(
 fn annotated_type_layout_for_adapter_ty<Mode: ExecutionMode>(
     context: &mut Context<Mode>,
     type_: &Type,
-) -> Result<A::MoveTypeLayout, Mode::Error> {
+) -> Result<CA::MoveTypeLayout, Mode::Error> {
     Ok(context.env.fully_annotated_layout(type_).map_err(|e| {
         make_invariant_violation!(
             "Failed to get annotated type layout for adapter type: {}",
@@ -367,11 +367,11 @@ fn annotated_type_layout_for_adapter_ty<Mode: ExecutionMode>(
 /// provided annotated layout for that value.
 fn serializable_move_value_from_ctx_value(
     value: &CtxValue,
-    annotated_layout: &A::MoveTypeLayout,
+    annotated_layout: &CA::MoveTypeLayout,
 ) -> Result<SerializableMoveValue, ExecutionError> {
     VMValue::as_annotated_move_value(
         value.inner_for_tracing().inner_for_tracing(),
-        annotated_layout,
+        annotated_layout.as_ref(),
     )
     .ok_or_else(|| {
         make_invariant_violation!(

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/execution/values.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/execution/values.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use move_binary_format::errors::{PartialVMError, PartialVMResult};
 use move_core_types::account_address::AccountAddress;
-use move_core_types::runtime_value::MoveTypeLayout;
+use move_core_types::compressed::runtime as CR;
 use move_core_types::u256::U256;
 use move_vm_runtime::execution::interpreter::locals::{BaseHeap as VMBaseHeap, BaseHeapId};
 use move_vm_runtime::shared::views::ValueVisitor;
@@ -187,7 +187,7 @@ impl Value {
         ty: Type,
     ) -> Result<Value, Mode::Error> {
         let layout = env.runtime_layout(&ty)?;
-        let Some(value) = VMValue::simple_deserialize(bytes, &layout) else {
+        let Some(value) = VMValue::simple_deserialize(bytes, layout.as_ref()) else {
             // we already checked the layout of pure bytes during typing
             // and objects should already be valid
             invariant_violation!("unable to deserialize value to type {ty:?}")
@@ -195,7 +195,7 @@ impl Value {
         Ok(Value(value))
     }
 
-    pub fn typed_serialize(&self, layout: &MoveTypeLayout) -> Option<Vec<u8>> {
+    pub fn typed_serialize(&self, layout: CR::MoveTypeLayoutRef<'_>) -> Option<Vec<u8>> {
         self.0.typed_serialize(layout)
     }
 

--- a/sui-execution/latest/sui-adapter/src/type_layout_resolver.rs
+++ b/sui-execution/latest/sui-adapter/src/type_layout_resolver.rs
@@ -71,9 +71,13 @@ impl LayoutResolver for TypeLayoutResolver<'_, '_> {
         };
 
         let type_tag = TypeTag::Struct(Box::new(struct_tag.clone()));
-        match vm.annotated_type_layout(&type_tag) {
-            Ok(A::MoveTypeLayout::Struct(s)) => Ok(A::MoveDatatypeLayout::Struct(s)),
-            Ok(A::MoveTypeLayout::Enum(e)) => Ok(A::MoveDatatypeLayout::Enum(e)),
+        match vm
+            .annotated_type_layout(&type_tag)
+            .ok()
+            .and_then(|compressed| compressed.inflate().ok())
+        {
+            Some(A::MoveTypeLayout::Struct(s)) => Ok(A::MoveDatatypeLayout::Struct(s)),
+            Some(A::MoveTypeLayout::Enum(e)) => Ok(A::MoveDatatypeLayout::Enum(e)),
             _ => Err(SuiErrorKind::FailObjectLayout {
                 st: format!("{}", struct_tag),
             }

--- a/sui-execution/latest/sui-move-natives/src/config.rs
+++ b/sui-execution/latest/sui-move-natives/src/config.rs
@@ -8,8 +8,8 @@ use crate::{
 use move_binary_format::errors::{PartialVMError, PartialVMResult};
 use move_binary_format::{safe_assert_eq, safe_unwrap};
 use move_core_types::{
-    account_address::AccountAddress, gas_algebra::InternalGas, language_storage::StructTag,
-    runtime_value as R, vm_status::StatusCode,
+    account_address::AccountAddress, compressed::runtime as CR, gas_algebra::InternalGas,
+    language_storage::StructTag, vm_status::StatusCode,
 };
 use move_vm_runtime::execution::values::{Struct, Vector};
 use move_vm_runtime::native_charge_gas_early_exit;
@@ -115,7 +115,7 @@ pub fn read_setting_impl(
 fn consistent_value_before_current_epoch(
     object_runtime: &mut ObjectRuntime,
     field_setting_tag: StructTag,
-    field_setting_layout: &R::MoveTypeLayout,
+    field_setting_layout: &CR::MoveTypeLayout,
     _setting_value_ty: &Type,
     setting_data_value_ty: &Type,
     value_ty: &Type,

--- a/sui-execution/latest/sui-move-natives/src/dynamic_field.rs
+++ b/sui-execution/latest/sui-move-natives/src/dynamic_field.rs
@@ -144,7 +144,7 @@ pub fn hash_type_and_key(
         Ok(Some(layout)) => layout,
         _ => return Ok(NativeResult::err(cost, E_BCS_SERIALIZATION_FAILURE)),
     };
-    let Some(k_bytes) = k.typed_serialize(&k_layout) else {
+    let Some(k_bytes) = k.typed_serialize(k_layout.as_ref()) else {
         return Ok(NativeResult::err(cost, E_BCS_SERIALIZATION_FAILURE));
     };
     let Ok(id) = derive_dynamic_field_id(parent, &k_tag, &k_bytes) else {

--- a/sui-execution/latest/sui-move-natives/src/lib.rs
+++ b/sui-execution/latest/sui-move-natives/src/lib.rs
@@ -52,11 +52,11 @@ use crypto::vdf::{self, VDFCostParams};
 use move_binary_format::errors::{PartialVMError, PartialVMResult};
 use move_binary_format::safe_unwrap;
 use move_core_types::{
-    annotated_value as A,
+    compressed::annotated as CA,
+    compressed::runtime as CR,
     gas_algebra::{AbstractMemorySize, InternalGas},
     identifier::Identifier,
     language_storage::{StructTag, TypeTag},
-    runtime_value as R,
     vm_status::StatusCode,
 };
 use move_vm_runtime::natives::{
@@ -1378,7 +1378,7 @@ pub fn get_nth_struct_field(v: Value, n: usize) -> Result<Value, PartialVMError>
 pub(crate) fn get_tag_and_layouts(
     context: &NativeContext,
     ty: &Type,
-) -> PartialVMResult<Option<(StructTag, R::MoveTypeLayout, A::MoveTypeLayout)>> {
+) -> PartialVMResult<Option<(StructTag, CR::MoveTypeLayout, CA::MoveTypeLayout)>> {
     let tag = match context.type_to_type_tag(ty)? {
         TypeTag::Struct(s) => s,
         _ => {

--- a/sui-execution/latest/sui-move-natives/src/object_runtime/mod.rs
+++ b/sui-execution/latest/sui-move-natives/src/object_runtime/mod.rs
@@ -14,11 +14,8 @@ use indexmap::map::IndexMap;
 use indexmap::set::IndexSet;
 use move_binary_format::errors::{PartialVMError, PartialVMResult};
 use move_core_types::{
-    account_address::AccountAddress,
-    annotated_value::{MoveTypeLayout, MoveValue},
-    annotated_visitor as AV,
-    language_storage::StructTag,
-    runtime_value as R,
+    account_address::AccountAddress, annotated_value as A, annotated_visitor as AV,
+    compressed::annotated as CA, compressed::runtime as CR, language_storage::StructTag,
     vm_status::StatusCode,
 };
 use move_vm_runtime::execution::values::{GlobalValue, Value};
@@ -484,8 +481,8 @@ impl<'a> ObjectRuntime<'a> {
         parent: ObjectID,
         child: ObjectID,
         child_version: SequenceNumber,
-        child_layout: &R::MoveTypeLayout,
-        child_fully_annotated_layout: &MoveTypeLayout,
+        child_layout: &CR::MoveTypeLayout,
+        child_fully_annotated_layout: &CA::MoveTypeLayout,
         child_move_type: MoveObjectType,
     ) -> PartialVMResult<Option<ObjectResult<CacheMetadata<Value>>>> {
         let Some((value, obj_meta)) = self.child_object_store.receive_object(
@@ -530,8 +527,8 @@ impl<'a> ObjectRuntime<'a> {
         &mut self,
         parent: ObjectID,
         child: ObjectID,
-        child_layout: &R::MoveTypeLayout,
-        child_fully_annotated_layout: &MoveTypeLayout,
+        child_layout: &CR::MoveTypeLayout,
+        child_fully_annotated_layout: &CA::MoveTypeLayout,
         child_move_type: MoveObjectType,
     ) -> PartialVMResult<ObjectResult<CacheMetadata<&mut GlobalValue>>> {
         let res = self.child_object_store.get_or_fetch_object(
@@ -564,7 +561,7 @@ impl<'a> ObjectRuntime<'a> {
         &mut self,
         config_id: ObjectID,
         name_df_id: ObjectID,
-        field_setting_layout: &R::MoveTypeLayout,
+        field_setting_layout: &CR::MoveTypeLayout,
         field_setting_object_type: &MoveObjectType,
     ) -> Option<Value> {
         match self.child_object_store.config_setting_unsequenced_read(
@@ -945,7 +942,7 @@ fn check_circular_ownership(
 /// in storage.  We do not need this invariant for dev-inspect, as the programmable
 /// transaction execution will validate the bytes before we get to this point.
 pub fn get_all_uids(
-    fully_annotated_layout: &MoveTypeLayout,
+    fully_annotated_layout: &CA::MoveTypeLayout,
     bcs_bytes: &[u8],
 ) -> Result<BTreeSet<ObjectID>, /* invariant violation */ String> {
     let mut ids = BTreeSet::new();
@@ -980,9 +977,13 @@ pub fn get_all_uids(
         }
     }
 
-    MoveValue::visit_deserialize(
+    let fully_annotated_layout_inflated = fully_annotated_layout
+        .inflate()
+        .map_err(|e| format!("Failed to inflate layout. {e}"))?;
+
+    A::MoveValue::visit_deserialize(
         bcs_bytes,
-        fully_annotated_layout,
+        &fully_annotated_layout_inflated,
         &mut UIDTraversal(&mut ids),
     )
     .map_err(|e| format!("Failed to deserialize. {e}"))?;

--- a/sui-execution/latest/sui-move-natives/src/object_runtime/object_store.rs
+++ b/sui-execution/latest/sui-move-natives/src/object_runtime/object_store.rs
@@ -3,7 +3,9 @@
 
 use crate::object_runtime::{fingerprint::ObjectFingerprint, get_all_uids};
 use move_binary_format::errors::{PartialVMError, PartialVMResult};
-use move_core_types::{annotated_value as A, runtime_value as R, vm_status::StatusCode};
+use move_core_types::{
+    compressed::annotated as CA, compressed::runtime as CR, vm_status::StatusCode,
+};
 use move_vm_runtime::execution::values::{GlobalValue, StructRef, Value};
 use std::{
     collections::{BTreeMap, btree_map},
@@ -312,8 +314,8 @@ impl Inner<'_> {
         &mut self,
         parent: ObjectID,
         child: ObjectID,
-        child_ty_layout: &R::MoveTypeLayout,
-        child_ty_fully_annotated_layout: &A::MoveTypeLayout,
+        child_ty_layout: &CR::MoveTypeLayout,
+        child_ty_fully_annotated_layout: &CA::MoveTypeLayout,
         child_move_type: &MoveObjectType,
     ) -> PartialVMResult<
         ObjectResult<CacheMetadata<(MoveObjectType, GlobalValue, ObjectFingerprint)>>,
@@ -336,7 +338,7 @@ impl Inner<'_> {
         }
         // deserialize the value
         let obj_contents = obj.contents();
-        let v = match Value::simple_deserialize(obj_contents, child_ty_layout) {
+        let v = match Value::simple_deserialize(obj_contents, child_ty_layout.as_ref()) {
             Some(v) => v,
             None => return Err(
                 PartialVMError::new(StatusCode::FAILED_TO_DESERIALIZE_RESOURCE).with_message(
@@ -387,7 +389,7 @@ impl Inner<'_> {
 
 fn deserialize_move_object(
     obj: &MoveObject,
-    child_ty_layout: &R::MoveTypeLayout,
+    child_ty_layout: &CR::MoveTypeLayout,
     child_move_type: MoveObjectType,
 ) -> PartialVMResult<ObjectResult<(MoveObjectType, Value)>> {
     let child_id = obj.id();
@@ -395,7 +397,7 @@ fn deserialize_move_object(
     if obj.type_() != &child_move_type {
         return Ok(ObjectResult::MismatchedType);
     }
-    let value = match Value::simple_deserialize(obj.contents(), child_ty_layout) {
+    let value = match Value::simple_deserialize(obj.contents(), child_ty_layout.as_ref()) {
         Some(v) => v,
         None => {
             return Err(
@@ -440,8 +442,8 @@ impl<'a> ChildObjectStore<'a> {
         parent: ObjectID,
         child: ObjectID,
         child_version: SequenceNumber,
-        child_layout: &R::MoveTypeLayout,
-        child_fully_annotated_layout: &A::MoveTypeLayout,
+        child_layout: &CR::MoveTypeLayout,
+        child_fully_annotated_layout: &CA::MoveTypeLayout,
         child_move_type: MoveObjectType,
     ) -> PartialVMResult<LoadedWithMetadataResult<ObjectResult<CacheMetadata<Value>>>> {
         let (cache_info, Some((obj, obj_meta))) =
@@ -517,8 +519,8 @@ impl<'a> ChildObjectStore<'a> {
         &mut self,
         parent: ObjectID,
         child: ObjectID,
-        child_layout: &R::MoveTypeLayout,
-        child_fully_annotated_layout: &A::MoveTypeLayout,
+        child_layout: &CR::MoveTypeLayout,
+        child_fully_annotated_layout: &CA::MoveTypeLayout,
         child_move_type: MoveObjectType,
     ) -> PartialVMResult<ObjectResult<CacheMetadata<&mut ChildObject>>> {
         let store_entries_count = self.store.len() as u64;
@@ -659,7 +661,7 @@ impl<'a> ChildObjectStore<'a> {
         &mut self,
         config_id: ObjectID,
         name_df_id: ObjectID,
-        field_setting_layout: &R::MoveTypeLayout,
+        field_setting_layout: &CR::MoveTypeLayout,
         field_setting_object_type: &MoveObjectType,
     ) -> PartialVMResult<ObjectResult<Option<Value>>> {
         let parent = config_id;
@@ -676,7 +678,7 @@ impl<'a> ChildObjectStore<'a> {
                     return Ok(ObjectResult::Loaded(None));
                 };
                 let Some(value) =
-                    Value::simple_deserialize(move_obj.contents(), field_setting_layout)
+                    Value::simple_deserialize(move_obj.contents(), field_setting_layout.as_ref())
                 else {
                     return Err(
                         PartialVMError::new(StatusCode::FAILED_TO_DESERIALIZE_RESOURCE)

--- a/sui-execution/latest/sui-move-natives/src/test_scenario.rs
+++ b/sui-execution/latest/sui-move-natives/src/test_scenario.rs
@@ -668,7 +668,7 @@ pub fn allocate_receiving_ticket_for_object(
     }
 
     let obj_value = safe_unwrap!(inventories.objects.remove(&id));
-    let Some(bytes) = obj_value.typed_serialize(&layout) else {
+    let Some(bytes) = obj_value.typed_serialize(layout.as_ref()) else {
         return Ok(NativeResult::err(
             context.gas_used(),
             E_UNABLE_TO_ALLOCATE_RECEIVING_TICKET,
@@ -1019,10 +1019,11 @@ fn find_all_wrapped_objects<'a, 'i>(
             continue;
         };
 
-        let blob = safe_unwrap!(value.borrow().typed_serialize(&layout));
+        let blob = safe_unwrap!(value.borrow().typed_serialize(layout.as_ref()));
+        let annotated_layout_inflated = safe_unwrap!(annotated_layout.inflate());
         safe_unwrap!(MoveValue::visit_deserialize(
             &blob,
-            &annotated_layout,
+            &annotated_layout_inflated,
             &mut Traversal {
                 state: LookingFor::Wrapped,
                 ids,

--- a/sui-execution/latest/sui-move-natives/src/test_utils.rs
+++ b/sui-execution/latest/sui-move-natives/src/test_utils.rs
@@ -4,7 +4,7 @@
 use crate::{legacy_test_cost, types::is_otw_struct};
 use move_binary_format::errors::PartialVMResult;
 use move_binary_format::safe_unwrap;
-use move_core_types::{gas_algebra::InternalGas, runtime_value::MoveTypeLayout};
+use move_core_types::{compressed::runtime as CR, gas_algebra::InternalGas};
 use move_vm_runtime::execution::values::Struct;
 use move_vm_runtime::execution::{Type, values::Value};
 use move_vm_runtime::natives::functions::{NativeContext, NativeResult};
@@ -23,7 +23,10 @@ pub fn create_one_time_witness(
     let type_tag = context.type_to_type_tag(&ty)?;
     let type_layout = context.type_to_type_layout(&ty)?;
 
-    let Some(MoveTypeLayout::Struct(struct_layout)) = type_layout else {
+    let Some(layout) = type_layout else {
+        return Ok(NativeResult::err(InternalGas::new(1), 0));
+    };
+    let CR::MoveLayoutView::Struct(struct_layout) = layout.as_view() else {
         return Ok(NativeResult::err(InternalGas::new(1), 0));
     };
 

--- a/sui-execution/latest/sui-move-natives/src/types.rs
+++ b/sui-execution/latest/sui-move-natives/src/types.rs
@@ -4,9 +4,7 @@
 use move_binary_format::errors::PartialVMResult;
 use move_binary_format::safe_unwrap;
 use move_core_types::{
-    gas_algebra::InternalGas,
-    language_storage::TypeTag,
-    runtime_value::{MoveStructLayout, MoveTypeLayout},
+    compressed::runtime as CR, gas_algebra::InternalGas, language_storage::TypeTag,
 };
 use move_vm_runtime::{
     execution::Type, execution::values::Value, natives::functions::NativeResult,
@@ -18,11 +16,18 @@ use std::collections::VecDeque;
 use crate::{NativesCostTable, get_extension};
 
 pub(crate) fn is_otw_struct(
-    struct_layout: &MoveStructLayout,
+    struct_layout: &CR::MoveStructLayout,
     type_tag: &TypeTag,
     hardened_check: bool,
 ) -> bool {
-    let has_one_bool_field = matches!(struct_layout.0.as_slice(), [MoveTypeLayout::Bool]);
+    let has_one_bool_field = matches!(
+        struct_layout
+            .fields()
+            .map(|f| f.as_view())
+            .collect::<Vec<_>>()
+            .as_slice(),
+        [CR::MoveLayoutView::Bool]
+    );
 
     // If a struct type has the same name as the module that defines it but capitalized, and it has
     // a single field of type bool, it means that it's a one-time witness type. The remaining
@@ -87,7 +92,10 @@ pub fn is_one_time_witness(
     let type_layout = context.type_to_type_layout(&ty)?;
 
     let cost = context.gas_used();
-    let Some(MoveTypeLayout::Struct(struct_layout)) = type_layout else {
+    let Some(layout) = type_layout else {
+        return Ok(NativeResult::ok(cost, smallvec![Value::bool(false)]));
+    };
+    let CR::MoveLayoutView::Struct(struct_layout) = layout.as_view() else {
         return Ok(NativeResult::ok(cost, smallvec![Value::bool(false)]));
     };
 


### PR DESCRIPTION
## Description 

This moves Move over to using compressed type layouts almost everywhere except for the visitors (but that will be coming in a forthcoming PR).

This PR is made up of a number of commits, and I've tried to keep them fairly semantic. So reviewing this PR commit by commit would make sense (or you can review the full stack at one go, whichever works best for you).

We shouldn't have any `inflate` calls on the Move or execution side (except in one place) with this, and a couple inflation calls on the Sui side. 

## Test plan 

CI 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
