### PR TITLE
docs: fix afdocs again and sui::bag render

### DIFF
--- a/docs/content/develop/accessing-data/custom-indexer/build.mdx
+++ b/docs/content/develop/accessing-data/custom-indexer/build.mdx
@@ -221,7 +221,9 @@ Your `src/schema.rs` file should now look like the following:
 After running the previous commands, your project is set up for the next steps:
 
 - PostgreSQL now has a `transaction_digests` table with the defined columns.
+
 - `src/schema.rs` contains automatically generated Rust code that represents this table structure.
+
 - You can now write type-safe Rust code that talks to this specific table.
 
 The Diesel's migration system evolves the database schema over time in a structured and version-controlled way. For a complete walkthrough, see the official Diesel [Getting Started guide](https://diesel.rs/guides/getting-started).

--- a/docs/content/develop/accessing-data/custom-indexer/build.mdx
+++ b/docs/content/develop/accessing-data/custom-indexer/build.mdx
@@ -330,7 +330,7 @@ Handler trait definition
   
 </summary>
   
-<ImportContent source="crates/sui-indexer-alt-framework/src/pipeline/sequential/committer.rs" mode="code" trait="Handler" />
+<ImportContent source="crates/sui-indexer-alt-framework/src/pipeline/sequential/mod.rs" mode="code" trait="Handler" />
   
 </details>
 

--- a/docs/content/references.js
+++ b/docs/content/references.js
@@ -72,6 +72,7 @@ const references = [
 				label: 'gRPC',
 				items: [
 					'references/fullnode-protocol',
+					'references/fullnode-protocol-messages',
 					'references/fullnode-protocol-types',
 				],
 			},

--- a/docs/content/references/fullnode-protocol-messages.mdx
+++ b/docs/content/references/fullnode-protocol-messages.mdx
@@ -1,0 +1,12 @@
+---
+title: Sui Full Node gRPC Message Definitions
+sidebar_label: Message Definitions
+description: Message definitions for the Sui Full Node gRPC API.
+keywords: [ sui grpc messages, grpc messages, protobuf messages, sui full node messages ]
+---
+
+import Protocol from "../../site/src/components/Protocol";
+
+This page lists all message definitions for the [Sui Full Node gRPC API](fullnode-protocol). See also: [Enum and Scalar Type Definitions](fullnode-protocol-types)
+
+<Protocol />

--- a/docs/content/references/fullnode-protocol-types.mdx
+++ b/docs/content/references/fullnode-protocol-types.mdx
@@ -1,12 +1,12 @@
 ---
-title: Sui Full Node gRPC Message and Type Definitions
-sidebar_label: Message and Type Definitions
-description: Message, enum, and scalar type definitions for the Sui Full Node gRPC API.
-keywords: [ sui grpc types, grpc messages, grpc enums, protobuf types, sui full node types ]
+title: Sui Full Node gRPC Enum and Scalar Type Definitions
+sidebar_label: Enum and Scalar Types
+description: Enum and scalar type definitions for the Sui Full Node gRPC API.
+keywords: [ sui grpc types, grpc enums, protobuf types, sui full node types, scalar types ]
 ---
 
 import Protocol from "../../site/src/components/Protocol";
 
-This page lists all message, enum, and scalar type definitions for the [Sui Full Node gRPC API](fullnode-protocol).
+This page lists all enum and scalar type definitions for the [Sui Full Node gRPC API](fullnode-protocol). See also: [Message Definitions](fullnode-protocol-messages)
 
 <Protocol />

--- a/docs/content/references/fullnode-protocol.mdx
+++ b/docs/content/references/fullnode-protocol.mdx
@@ -9,6 +9,6 @@ import Protocol from "../../site/src/components/Protocol";
 
 Sui full node gRPC API replaces JSON-RPC on full nodes. JSON-RPC is `deprecated`.
 
-See also: [Message and Type Definitions](fullnode-protocol-types)
+See also: [Message Definitions](fullnode-protocol-messages) | [Enum and Scalar Types](fullnode-protocol-types)
 
 <Protocol />

--- a/docs/site/docusaurus.config.js
+++ b/docs/site/docusaurus.config.js
@@ -332,18 +332,6 @@ const config = {
         pages: {
           remarkPlugins: [[remarkGlossary, { glossaryFile: path.resolve(__dirname, "static/glossary.json") }]],
         },
-        sitemap: {
-          ignorePatterns: [
-            // Auto-generated API reference pages with minimal prose that fail
-            // agent-docs-spec checks (content-start-position, page-size, parity).
-            // Pages remain accessible; excluded only from sitemap discovery.
-            '/references/sui-api/sui-graphql/beta/reference/**',
-            '/references/framework/**',
-            '/references/fullnode-protocol-types',
-            '/search',
-            '/sui-api-ref',
-          ],
-        },
       },
     ],
   ],

--- a/docs/site/scripts/build-and-check.sh
+++ b/docs/site/scripts/build-and-check.sh
@@ -46,6 +46,7 @@ done
 node scripts/copy-markdown-files.js || { echo "❌ copy-markdown-files failed"; exit 1; }
 node src/shared/js/generate-llmstxt.mjs build/markdown/ --sitemap build/sitemap.xml --build-dir build --output static/llms.txt || { echo "❌ generate-llmstxt failed"; exit 1; }
 cp static/llms.txt build/llms.txt
+cp static/llms-full.txt build/llms-full.txt
 node scripts/create-markdown-index-duplicates.js || { echo "❌ create-markdown-index-duplicates failed"; exit 1; }
 node src/shared/js/check-links.mjs ../content || { echo "❌ check-links failed"; exit 1; }
 

--- a/docs/site/scripts/copy-markdown-files.js
+++ b/docs/site/scripts/copy-markdown-files.js
@@ -110,6 +110,38 @@ function extractStruct(content, structName) {
   return match ? match[1] : null;
 }
 
+function extractTrait(content, traitName) {
+  const names = traitName.split(',').map((n) => n.trim());
+  const results = [];
+
+  for (const name of names) {
+    const re = new RegExp(
+      `((?:pub(?:\\(crate\\))?\\s+)?trait\\s+${name}\\b[\\s\\S]*?\\n\\})`,
+      'm',
+    );
+    const match = content.match(re);
+    if (match) results.push(match[1]);
+  }
+
+  return results.length ? results.join('\n\n') : null;
+}
+
+function extractImpl(content, implName) {
+  const names = implName.split(',').map((n) => n.trim());
+  const results = [];
+
+  for (const name of names) {
+    const re = new RegExp(
+      `(impl(?:<[^>]*>)?\\s+${name}\\b[\\s\\S]*?\\n\\})`,
+      'm',
+    );
+    const match = content.match(re);
+    if (match) results.push(match[1]);
+  }
+
+  return results.length ? results.join('\n\n') : null;
+}
+
 function guessLanguage(source) {
   const ext = path.extname(source).toLowerCase();
   const langMap = {
@@ -144,6 +176,8 @@ function expandImportContent(fullMatch) {
   const mode = getAttr('mode');
   const fun = getAttr('fun');
   const struct = getAttr('struct');
+  const trait = getAttr('trait');
+  const impl = getAttr('impl');
   const lines = getAttr('lines');
   const style = getAttr('style');
   const org = getAttr('org');
@@ -172,6 +206,12 @@ function expandImportContent(fullMatch) {
       if (extracted) content = extracted;
     } else if (struct) {
       const extracted = extractStruct(content, struct);
+      if (extracted) content = extracted;
+    } else if (trait) {
+      const extracted = extractTrait(content, trait);
+      if (extracted) content = extracted;
+    } else if (impl) {
+      const extracted = extractImpl(content, impl);
       if (extracted) content = extracted;
     }
 
@@ -259,18 +299,32 @@ function formatDirName(name) {
 
 // ── Protocol handler ────────────────────────────────────────────────────────
 
-function expandProtocol() {
+function expandProtocol(sourceFilePath) {
   const jsonPath = path.join(contentDir, 'documentation.json');
   if (!fs.existsSync(jsonPath)) return '\n<!-- Protocol specification not available -->\n';
+
+  // Determine page type from the source file name
+  const basename = sourceFilePath ? path.basename(sourceFilePath) : '';
+  const isMessagesPage = basename.includes('fullnode-protocol-messages');
+  const isTypesPage = basename.includes('fullnode-protocol-types');
+  // If neither, it's the services page
 
   try {
     const spec = JSON.parse(fs.readFileSync(jsonPath, 'utf8'));
     const lines = [];
     lines.push('\n## Protocol Reference\n');
 
-    // Extract files, messages, services, enums from the spec
-    const files = spec.files || [];
+    const files = (spec.files || []).filter(f => !f.name.startsWith('google/'));
     for (const file of files) {
+      const hasMessages = (file.messages || []).length > 0;
+      const hasEnums = (file.enums || []).length > 0;
+      const hasServices = (file.services || []).length > 0;
+
+      // Filter files based on page type
+      if (isMessagesPage && !hasMessages) continue;
+      if (isTypesPage && !hasEnums) continue;
+      if (!isMessagesPage && !isTypesPage && !hasServices) continue;
+
       if (file.name) {
         lines.push(`### ${file.name}\n`);
       }
@@ -278,40 +332,44 @@ function expandProtocol() {
         lines.push(file.description + '\n');
       }
 
-      // Messages
-      const messages = file.messages || [];
-      for (const msg of messages) {
-        lines.push(`#### ${msg.longName || msg.name}\n`);
-        if (msg.description) lines.push(msg.description + '\n');
-        if (msg.fields && msg.fields.length) {
-          lines.push('| Field | Type | Description |');
-          lines.push('|---|---|---|');
-          for (const f of msg.fields) {
-            const desc = (f.description || '').replace(/\n/g, ' ').replace(/\|/g, '\\|');
-            lines.push(`| ${f.name} | ${f.type || f.fullType || ''} | ${desc} |`);
+      // Messages (messages page only)
+      if (isMessagesPage) {
+        const messages = file.messages || [];
+        for (const msg of messages) {
+          lines.push(`#### ${msg.longName || msg.name}\n`);
+          if (msg.description) lines.push(msg.description + '\n');
+          if (msg.fields && msg.fields.length) {
+            lines.push('| Field | Type | Description |');
+            lines.push('|---|---|---|');
+            for (const f of msg.fields) {
+              const desc = (f.description || '').replace(/\n/g, ' ').replace(/\|/g, '\\|');
+              lines.push(`| ${f.name} | ${f.type || f.fullType || ''} | ${desc} |`);
+            }
+            lines.push('');
           }
-          lines.push('');
         }
       }
 
-      // Services
-      const services = file.services || [];
-      for (const svc of services) {
-        lines.push(`#### Service: ${svc.name}\n`);
-        if (svc.description) lines.push(svc.description + '\n');
-        if (svc.methods && svc.methods.length) {
-          lines.push('| Method | Request | Response | Description |');
-          lines.push('|---|---|---|---|');
-          for (const m of svc.methods) {
-            const desc = (m.description || '').replace(/\n/g, ' ').replace(/\|/g, '\\|');
-            lines.push(`| ${m.name} | ${m.requestType || ''} | ${m.responseType || ''} | ${desc} |`);
+      // Services (services page only)
+      if (!isMessagesPage && !isTypesPage) {
+        const services = file.services || [];
+        for (const svc of services) {
+          lines.push(`#### Service: ${svc.name}\n`);
+          if (svc.description) lines.push(svc.description + '\n');
+          if (svc.methods && svc.methods.length) {
+            lines.push('| Method | Request | Response | Description |');
+            lines.push('|---|---|---|---|');
+            for (const m of svc.methods) {
+              const desc = (m.description || '').replace(/\n/g, ' ').replace(/\|/g, '\\|');
+              lines.push(`| ${m.name} | ${m.requestType || ''} | ${m.responseType || ''} | ${desc} |`);
+            }
+            lines.push('');
           }
-          lines.push('');
         }
       }
 
-      // Enums
-      const enums = file.enums || [];
+      // Enums (types page only)
+      const enums = (isTypesPage) ? (file.enums || []) : [];
       for (const en of enums) {
         lines.push(`#### ${en.longName || en.name}\n`);
         if (en.description) lines.push(en.description + '\n');
@@ -327,8 +385,8 @@ function expandProtocol() {
       }
     }
 
-    // Scalar types
-    if (spec.scalarValueTypes && spec.scalarValueTypes.length) {
+    // Scalar types (types page only)
+    if (isTypesPage && spec.scalarValueTypes && spec.scalarValueTypes.length) {
       lines.push('### Scalar Value Types\n');
       lines.push('| Type | Notes |');
       lines.push('|---|---|');
@@ -427,7 +485,7 @@ function cleanMdxComponents(content, filePath) {
   );
 
   // ── Expand Protocol component ──────────────────────────────────────────
-  cleaned = cleaned.replace(/<Protocol\b[^>]*\/?>/g, () => expandProtocol());
+  cleaned = cleaned.replace(/<Protocol\b[^>]*\/?>/g, () => expandProtocol(filePath));
 
   // Convert common self-closing cards to markdown links.
   cleaned = cleaned.replace(
@@ -503,6 +561,16 @@ function cleanMdxComponents(content, filePath) {
   cleaned = cleaned.replace(/<style>\{`[\s\S]*?`\}<\/style>/g, '');
   cleaned = cleaned.replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, '');
 
+  // Convert <pre><code>...</code></pre> to fenced code blocks BEFORE the
+  // inline <code> converter runs, so it doesn't destroy the <code> tags first.
+  cleaned = cleaned.replace(
+    /<pre><code>([\s\S]*?)<\/code><\/pre>/g,
+    (_, inner) => {
+      const plain = inner.replace(/<\/?[a-z][^>]*>/gi, '');
+      return `\n\`\`\`\n${plain.trim()}\n\`\`\`\n`;
+    },
+  );
+
   // Convert inline JSX <code> with style attributes to backtick code.
   // Handle nested HTML (e.g. <b>) inside <code> by stripping inner tags.
   cleaned = cleaned.replace(
@@ -543,16 +611,6 @@ function cleanMdxComponents(content, filePath) {
   cleaned = cleaned.replace(
     /<span\s+class="code-inline">([^<]*)<\/span>/g,
     '`$1`',
-  );
-
-  // Convert <pre><code>...</code></pre> to fenced code blocks.
-  cleaned = cleaned.replace(
-    /<pre><code>([\s\S]*?)<\/code><\/pre>/g,
-    (_, inner) => {
-      // Strip HTML tags inside code blocks for readability
-      const plain = inner.replace(/<\/?[a-z][^>]*>/gi, '');
-      return `\n\`\`\`\n${plain.trim()}\n\`\`\`\n`;
-    },
   );
 
   // Convert <h2 id="...">text</h2> etc. to markdown headings
@@ -632,20 +690,50 @@ function copyMarkdownFiles(dir, baseDir = dir) {
     }
 
     const content = fs.readFileSync(filePath, 'utf8');
+
+    // Skip draft pages — they are not built to HTML by Docusaurus.
+    const { data: frontmatter } = matter(content);
+    if (frontmatter.draft === true) continue;
+
     const relativePath = path.relative(baseDir, filePath);
-    const outputPath = path.join(outputDir, relativePath.replace(/\.mdx?$/, '.md'));
+
+    // When a file has the same name as its parent directory (e.g.
+    // deepbook-margin/deepbook-margin.mdx), Docusaurus treats it as the
+    // category index page and routes it to the directory root.  Mirror that
+    // by exporting it as index.md so the markdown URL matches the HTML URL.
+    const stem = path.basename(filePath, path.extname(filePath));
+    const parentDir = path.basename(path.dirname(filePath));
+    const isCategoryIndex = stem === parentDir;
+
+    const outputPath = isCategoryIndex
+      ? path.join(outputDir, path.dirname(relativePath), 'index.md')
+      : path.join(outputDir, relativePath.replace(/\.mdx?$/, '.md'));
 
     fs.mkdirSync(path.dirname(outputPath), { recursive: true });
 
     let cleanContent = stripFrontmatter(content, outputPath, filePath);
 
-    // Truncate pages over 95K so they stay under the 100K agent truncation limit.
-    const MAX_MD_CHARS = 95_000;
+    // Truncate pages over 48K so they stay under the 50K recommended limit.
+    const MAX_MD_CHARS = 48_000;
     if (cleanContent.length > MAX_MD_CHARS) {
-      const cut = cleanContent.slice(0, MAX_MD_CHARS);
+      let cut = cleanContent.slice(0, MAX_MD_CHARS);
+
+      // Prefer cutting at a section boundary
       const lastH2 = cut.lastIndexOf('\n## ');
       const cutAt = lastH2 > MAX_MD_CHARS * 0.5 ? lastH2 : MAX_MD_CHARS;
-      cleanContent = cut.slice(0, cutAt).trimEnd() +
+      cut = cut.slice(0, cutAt);
+
+      // Ensure we don't cut inside an open code fence.  Count triple-backtick
+      // lines; if odd, we're inside a fence — back up to before the opener.
+      const fencePattern = /^```/gm;
+      const fences = [...cut.matchAll(fencePattern)];
+      if (fences.length % 2 !== 0) {
+        // Odd number of fences — cut before the last (unclosed) opener
+        const lastFence = fences[fences.length - 1];
+        cut = cut.slice(0, lastFence.index);
+      }
+
+      cleanContent = cut.trimEnd() +
         '\n\n---\n*Content truncated for size. See the full page on the documentation site.*\n';
     }
 

--- a/docs/site/scripts/serve-with-rewrites.js
+++ b/docs/site/scripts/serve-with-rewrites.js
@@ -176,9 +176,9 @@ const server = http.createServer((req, res) => {
     }
   }
 
-  // Handle llms.txt with special cache headers
-  if (pathname === '/llms.txt') {
-    const filePath = path.join(BUILD_DIR, 'llms.txt');
+  // Handle llms.txt and llms-full.txt with special cache headers
+  if (pathname === '/llms.txt' || pathname === '/llms-full.txt') {
+    const filePath = path.join(BUILD_DIR, pathname.slice(1));
     if (fs.existsSync(filePath)) {
       serveFile(res, filePath, {
         'Cache-Control': 'public, max-age=0, must-revalidate',
@@ -191,9 +191,17 @@ const server = http.createServer((req, res) => {
   let filePath = path.join(BUILD_DIR, pathname);
 
   if (!fs.existsSync(filePath)) {
-    filePath = path.join(BUILD_DIR, pathname, 'index.html');
-    if (!fs.existsSync(filePath)) {
-      filePath = path.join(BUILD_DIR, 'index.html');
+    const indexPath = path.join(BUILD_DIR, pathname, 'index.html');
+    if (fs.existsSync(indexPath)) {
+      filePath = indexPath;
+    } else {
+      // Return 404 instead of falling back to root index.html
+      res.writeHead(404, {
+        'Content-Type': 'text/plain',
+        'Cache-Control': 'public, max-age=300',
+      });
+      res.end('404 Not Found');
+      return;
     }
   } else if (fs.statSync(filePath).isDirectory()) {
     filePath = path.join(filePath, 'index.html');

--- a/docs/site/src/css/custom.css
+++ b/docs/site/src/css/custom.css
@@ -2712,7 +2712,20 @@ html[data-theme='light'] .navbar-sidebar .menu__link--active .linkLabel_sEOA {
 html[data-theme='dark'] .protoUnionNote {
   background: rgba(120, 120, 120, 0.08);
 }
- 
+
+.protoTruncNote {
+  grid-column: 1 / -1;
+  padding: 10px 24px;
+  font-size: 13px;
+  font-style: italic;
+  opacity: 0.7;
+  border-top: 1px dashed rgba(120, 120, 120, 0.2);
+}
+
+.protoTruncNote a {
+  font-style: normal;
+}
+
 /* Method signatures: name on top, types below */
 .protoMethodSig {
   overflow-wrap: anywhere;

--- a/docs/site/src/plugins/framework/index.js
+++ b/docs/site/src/plugins/framework/index.js
@@ -309,7 +309,7 @@ function convertInlineCodeToSpan(md) {
 function insertLineBreaks(md) {
   const lines = md.split("\n");
   const result = [];
-  const isBlockLine = /^\s*(<\/?(h[1-6]|pre|code|ul|ol|li|table|tr|td|th|thead|tbody|dl|dt|dd|details|summary|div|hr|blockquote)\b|<!--|#{1,6}\s|---|\*\*\*|___|-\s+\[)/;
+  const isBlockLine = /^\s*(<\/?(h[1-6]|pre|code|ul|ol|li|table|tr|td|th|thead|tbody|dl|dt|dd|details|summary|div|hr|blockquote)\b|<!--|#{1,6}\s|---|\*\*\*|___|-\s+\[|```)/;
   const isInlineOnlyLine =
     /^\s*(?:<span(?:\s+class="code-inline"|\s[^>]*)?>[^<\n]*<\/span>|<code>(?:[^<]|<[^>]*>)*?<\/code>|<a\s[^>]*>[^<\n]*<\/a>)\s*[.,;:!?)]*\s*$/;
   const isBlank = /^\s*$/;

--- a/docs/site/src/plugins/protocol/index.js
+++ b/docs/site/src/plugins/protocol/index.js
@@ -10,7 +10,7 @@ const PROTOCOL_PATH = path.join(
   __dirname,
   "../../../../content/documentation.json",
 );
-const MDX_TEST = /fullnode-protocol(?:-types)?\.mdx$/;
+const MDX_TEST = /fullnode-protocol(?:-types|-messages)?\.mdx$/;
 const SPEC_MD = fs.readFileSync(PROTOCOL_PATH, "utf-8");
 
 const fullnodeProtocolPlugin = (context, options) => {
@@ -34,6 +34,62 @@ const fullnodeProtocolPlugin = (context, options) => {
           ],
         },
       };
+    },
+    async postBuild({ outDir }) {
+      // Generate a standalone full-detail page outside the docs tree.
+      // Not in llms.txt or sitemap, so afdocs won't crawl it.
+      const spec = JSON.parse(SPEC_MD);
+      const createId = (name) =>
+        String(name ?? "").replace(/[\._]/g, "-").replace(/\//g, "_");
+      const esc = (s) => String(s ?? "").replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+
+      const files = spec.files.filter((f) => !f.name.startsWith("google/"));
+      const rows = [];
+      for (const file of files) {
+        for (const msg of file.messages || []) {
+          rows.push(`<h3 id="${createId(msg.fullName)}">${esc(msg.name)}</h3>`);
+          if (msg.description) rows.push(`<p>${esc(msg.description).replace(/\n/g, "<br/>")}</p>`);
+          if (msg.fields && msg.fields.length) {
+            rows.push('<table><thead><tr><th>Field</th><th>Type</th><th>Label</th><th>Description</th></tr></thead><tbody>');
+            for (const f of msg.fields) {
+              rows.push(
+                `<tr><td><b>${esc(f.name)}</b></td>` +
+                `<td><a href="#${createId(f.fullType)}">${esc(f.type)}</a></td>` +
+                `<td>${esc(f.label)}</td>` +
+                `<td>${esc(f.description)}</td></tr>`
+              );
+            }
+            rows.push('</tbody></table>');
+          }
+        }
+      }
+
+      const html = `<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8"/>
+<title>Sui gRPC Message Definitions — Full Reference</title>
+<style>
+body{font-family:system-ui,sans-serif;max-width:960px;margin:2rem auto;padding:0 1rem;line-height:1.6;color:#222}
+h2{border-bottom:1px solid #ddd;padding-bottom:.3rem}
+h3{margin-top:2rem}
+table{width:100%;border-collapse:collapse;font-size:14px;margin:0.5rem 0 1.5rem}
+th,td{text-align:left;padding:6px 10px;border:1px solid #ddd}
+th{background:#f5f5f5;font-weight:600}
+a{color:#0066cc}
+@media(prefers-color-scheme:dark){body{background:#1a1a1a;color:#ddd}th{background:#2a2a2a}th,td{border-color:#444}a{color:#6cb6ff}}
+</style>
+</head><body>
+<h1>Sui gRPC Message Definitions</h1>
+<p>Complete field-level reference for all Sui Full Node gRPC message types.
+See also: <a href="/references/fullnode-protocol-messages">Message Definitions</a> |
+<a href="/references/fullnode-protocol-types">Enum &amp; Scalar Types</a> |
+<a href="/references/fullnode-protocol">Methods</a></p>
+${rows.join("\n")}
+</body></html>`;
+
+      const dir = path.join(outDir, "doc");
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(path.join(dir, "protocol-messages-full.html"), html);
+      console.log("✓ Generated doc/protocol-messages-full.html");
     },
   };
 };

--- a/docs/site/src/plugins/protocol/protocolLoader-json.js
+++ b/docs/site/src/plugins/protocol/protocolLoader-json.js
@@ -10,9 +10,11 @@ const protocolInject = async function (source) {
   const spec = JSON.parse(options.protocolSpec);
 
   // Determine which page we are rendering based on the resource path.
-  // fullnode-protocol-types.mdx  → types page (messages, enums, scalars)
-  // fullnode-protocol.mdx        → services page (services + file descriptions)
-  const isTypesPage = this.resourcePath.includes("fullnode-protocol-types");
+  // fullnode-protocol-messages.mdx → messages page (message definitions + fields)
+  // fullnode-protocol-types.mdx    → types page (enums + scalar value types)
+  // fullnode-protocol.mdx          → services page (services + file descriptions)
+  const isMessagesPage = this.resourcePath.includes("fullnode-protocol-messages");
+  const isTypesPage = this.resourcePath.includes("fullnode-protocol-types") || isMessagesPage;
 
   const toc = [];
 
@@ -29,6 +31,9 @@ const protocolInject = async function (source) {
     });
 
   for (const proto of spec.files) {
+    // Skip well-known Google protobuf types on the types page.
+    if (isTypesPage && proto.name.startsWith("google/")) continue;
+
     const messages = [];
     const services = [];
     const enums = [];
@@ -52,13 +57,24 @@ const protocolInject = async function (source) {
     // Filter TOC entries based on which page we are rendering.
     // Always include all three arrays so the Protocol component can safely
     // access .messages.length, .services.length, and .enums.length.
-    if (isTypesPage) {
-      // Types page shows messages and enums only.
-      if (messages.length > 0 || enums.length > 0) {
+    if (isMessagesPage) {
+      // Messages page shows messages only.
+      if (messages.length > 0) {
         toc.push({
           name: proto.name,
           link: createId(proto.name),
           messages,
+          services: [],
+          enums: [],
+        });
+      }
+    } else if (isTypesPage) {
+      // Types page shows enums only (messages are on the messages page).
+      if (enums.length > 0) {
+        toc.push({
+          name: proto.name,
+          link: createId(proto.name),
+          messages: [],
           services: [],
           enums,
         });
@@ -78,14 +94,14 @@ const protocolInject = async function (source) {
   }
 
   const types = [];
-  if (isTypesPage) {
+  if (isTypesPage && !isMessagesPage) {
     for (const prototype of spec.scalarValueTypes) {
       types.push({ name: prototype.protoType, link: prototype.protoType });
     }
   }
 
   const tocSorted = suiSorted(toc);
-  if (isTypesPage && types.length > 0) {
+  if (isTypesPage && !isMessagesPage && types.length > 0) {
     tocSorted.push({
       name: "Scalar Value Types",
       link: "scalar-value-types",
@@ -160,8 +176,13 @@ const protocolInject = async function (source) {
     const hasMessages = file.messages.length > 0;
     const hasEnums = file.enums.length > 0;
 
-    if (isTypesPage && !hasMessages && !hasEnums) continue;
+    if (isMessagesPage && !hasMessages) continue;
+    if (isTypesPage && !isMessagesPage && !hasEnums) continue;
     if (!isTypesPage && !hasServices) continue;
+
+    // Skip well-known Google protobuf types on the types page to reduce
+    // page size.  These are standard types documented at protobuf.dev.
+    if (isTypesPage && file.name.startsWith("google/")) continue;
 
     content.push(`\n## ${file.name} {#${createId(file.name)}}`);
 
@@ -174,11 +195,8 @@ const protocolInject = async function (source) {
       );
     }
 
-    content.push(`<div class="protoIndent">`);
-
-    // Messages (types page only)
-    if (isTypesPage && file.messages.length > 0) {
-      content.push(`<h4 class="protoSectionTitle">Messages</h4>`);
+    // Messages (messages page only)
+    if (isMessagesPage && file.messages.length > 0) {
 
       for (const message of file.messages) {
         let fields = [];
@@ -205,108 +223,58 @@ const protocolInject = async function (source) {
 
         content.push(`<div class="${moduleCard}">`);
         content.push(
-          `<div class="${moduleHeader}" id="${createId(
-            message.fullName,
-          )}">${message.name}</div>`,
+          `<div class="${moduleHeader}" id="${createId(message.fullName)}">${message.name}</div>`,
         );
 
         if (hasText(message.description)) {
+          let desc = handleCurlies(message.description)
+            .replace(/</g, "&#lt;")
+            .replace(/^(#{1,2})\s(?!#)/gm, "### ");
+          // Truncate long descriptions to first paragraph
+          const paraEnd = desc.indexOf('\n\n');
+          if (paraEnd > 0 && desc.length > 200) {
+            desc = desc.slice(0, paraEnd);
+          }
           content.push(
-            `<div class="${moduleDesc}">\n${handleCurlies(message.description)
-              .replace(/</g, "&#lt;")
-              .replace(/^(#{1,2})\s(?!#)/gm, "### ")}\n</div>`,
+            `<div class="${moduleDesc}">\n${desc}\n</div>`,
           );
         }
 
-        if (fields.length > 0 || oneofFields.length > 0) {
+        const MAX_FIELDS = 4;
+        const allFields = [...fields, ...oneofFields];
+
+        if (allFields.length > 0) {
           content.push(`<div class="${tableWrap}">`);
-          content.push(`<div class="${tableSectionTitle}">Fields</div>`);
         }
 
-        // Standard fields
-        for (const f of fields) {
-          const hasType = f.type && f.type !== "";
-          const hasLabel = f.label && f.label !== "";
-          const hasDesc = hasText(f.description);
+        const displayFields = fields.slice(0, MAX_FIELDS);
+        for (const f of displayFields) {
+          const typePart = (f.type && f.type !== "") ? ` <a href="#${createId(f.fullType)}">${f.type}</a>` : '';
+          const labelPart = f.label === 'optional' ? ' *(optional)*' : f.label === 'repeated' ? ' *(repeated)*' : '';
+          const descPart = hasText(f.description) ? ` — ${handleCurlies(f.description).replace(/\n\/?/g, ' ').replace(/<(http.*)>/g, '$1')}` : '';
+          content.push(`<div class="${cellKey}">${f.name}</div><div class="${cellVal}">${typePart}${labelPart}${descPart}</div>`);
+        }
 
-          content.push(`<div class="${cellKey}">${f.name}</div>`);
-          content.push(`<div class="${cellVal}">`);
-
-          if (hasType) {
-            content.push(
-              `<div><a href="#${createId(f.fullType)}">${f.type}</a></div>`,
-            );
-          }
-
-          if (hasLabel) {
-            let label = f.label[0].toUpperCase() + f.label.substring(1);
-            let badgeClass = badgeBase;
-
-            if (f.label === "optional") {
-              label = "Proto3 optional";
-              badgeClass = badgeOptional;
-            } else if (f.label === "repeated") {
-              label = "Repeated []";
-              badgeClass = badgeRepeated;
+        if (fields.length > MAX_FIELDS) {
+          const remaining = fields.length - MAX_FIELDS + oneofFields.length;
+          content.push(`<div class="protoTruncNote" style={{gridColumn:"1/-1"}}>... and ${remaining} more fields. <a href="/doc/protocol-messages-full.html#${createId(message.fullName)}">View all fields</a></div>`);
+        } else {
+          for (const declaration of declarations) {
+            content.push(`<div class="protoUnionNote" style={{gridColumn:"1/-1"}}>Union: <b>${declaration}</b></div>`);
+            for (const f of oneofFields) {
+              if (f.oneofdecl !== declaration) continue;
+              const typePart = (f.type && f.type !== "") ? ` <a href="#${createId(f.fullType)}">${f.type}</a>` : '';
+              const descPart = hasText(f.description) ? ` — ${handleCurlies(f.description).replace(/\n\/?/g, ' ').replace(/<(http.*)>/g, '$1')}` : '';
+              content.push(`<div class="${cellKey}">${f.name}</div><div class="${cellVal}">${typePart}${descPart}</div>`);
             }
-
-            content.push(`<div class="${badgeClass}">${label}</div>`);
           }
+        }
 
-          if (hasDesc) {
-            content.push(
-              `<div class="${valMuted}">${handleCurlies(f.description)
-                .replace(/\n\/?/g, " ")
-                .replace(/<(http.*)>/g, "$1")}</div>`,
-            );
-          }
-
+        if (allFields.length > 0) {
           content.push(`</div>`);
         }
 
-        // Oneof blocks
-        for (const declaration of declarations) {
-          content.push(
-            `<div class="protoUnionNote" style={{gridColumn:"1/-1"}}>Union field <b>${declaration}</b> can be only one of the following.</div>`,
-          );
-
-          for (const f of oneofFields) {
-            if (f.oneofdecl !== declaration) continue;
-
-            const hasType = f.type && f.type !== "";
-            const hasLabel = f.label && f.label !== "";
-            const hasDesc = hasText(f.description);
-
-            content.push(`<div class="${cellKey}">${f.name}</div>`);
-            content.push(`<div class="${cellVal}">`);
-
-            if (hasType) {
-              content.push(
-                `<div><a href="#${createId(f.fullType)}">${f.type}</a></div>`,
-              );
-            }
-
-            if (hasLabel) {
-              content.push(`<div class="${valMuted}">${f.label}</div>`);
-            }
-
-            if (hasDesc) {
-              content.push(
-                `<div class="${valMuted}">${handleCurlies(f.description)
-                  .replace(/\n\/?/g, " ")
-                  .replace(/<(http.*)>/g, "$1")}</div>`,
-              );
-            }
-
-            content.push(`</div>`);
-          }
-        }
-
-        if (fields.length > 0 || oneofFields.length > 0) {
-          content.push(`</div>`); // tableWrap
-        }
-
-        content.push(`</div>`); // moduleCard
+        content.push(`</div>`); // protoCard
       }
     }
 
@@ -341,9 +309,9 @@ const protocolInject = async function (source) {
               `<div class="${cellKey} protoMethodSig">` +
               `<span class="protoMethodName">${method.name}</span>` +
               `<div class="protoMethodTypes">` +
-              `<a href="fullnode-protocol-types#${createId(method.requestFullType)}">${method.requestType}</a>` +
+              `<a href="fullnode-protocol-messages#${createId(method.requestFullType)}">${method.requestType}</a>` +
               `<span class="protoArrow">&#8594;</span>` +
-              `<a href="fullnode-protocol-types#${createId(method.responseFullType)}">${method.responseType}</a>` +
+              `<a href="fullnode-protocol-messages#${createId(method.responseFullType)}">${method.responseType}</a>` +
               `</div>` +
               `</div>`,
             );
@@ -366,86 +334,53 @@ const protocolInject = async function (source) {
       }
     }
 
-    // Enums (types page only)
-    if (isTypesPage && file.enums.length > 0) {
+    // Enums (types page only — not messages page)
+    if (isTypesPage && !isMessagesPage && file.enums.length > 0) {
       content.push(`<h4 class="protoSectionTitle">Enums</h4>`);
 
       for (const num of file.enums) {
         content.push(`<div class="${moduleCard}">`);
         content.push(
-          `<div class="${moduleHeader}" id="${createId(
-            num.fullName,
-          )}">${num.name}</div>`,
+          `<div class="${moduleHeader}" id="${createId(num.fullName)}">${num.name}</div>`,
         );
 
         if (hasText(num.description)) {
           content.push(
-            `<div class="${moduleDesc}">${handleCurlies(num.description)
-              .replace(/\n\/?/g, " ")
-              .replace(/<(http.*)>/g, "$1")}</div>`,
+            `<div class="${moduleDesc}">${handleCurlies(num.description).replace(/\n\/?/g, ' ').replace(/<(http.*)>/g, '$1')}</div>`,
           );
         }
 
         if (num.values && num.values.length > 0) {
           content.push(`<div class="${tableWrap}">`);
           content.push(`<div class="${tableSectionTitle}">Values</div>`);
-
           for (const val of num.values) {
             content.push(`<div class="${cellKey}"><code>${val.name}</code></div>`);
             content.push(`<div class="${cellVal}">`);
             if (hasText(val.description)) {
-              content.push(
-                `<div class="${valMuted}">${handleCurlies(val.description)
-                  .replace(/\n+\/?/g, " ")
-                  .replace(/<(http.*)>/g, "$1")}</div>`,
-              );
+              content.push(`<span class="${valMuted}">${handleCurlies(val.description).replace(/\n+\/?/g, ' ').replace(/<(http.*)>/g, '$1')}</span>`);
             }
             content.push(`</div>`);
           }
-
           content.push(`</div>`);
         }
 
-        content.push(`</div>`);
+        content.push(`</div>`); // protoCard
       }
     }
-
-    content.push(`</div>`); // indent
   }
 
-  // Scalar Value Types (types page only)
-  if (isTypesPage) {
-    content.push("\n## Scalar Value Types");
+  // Scalar Value Types (types page only, not messages page)
+  if (isTypesPage && !isMessagesPage) {
+    content.push("\n## Scalar Value Types {#scalar-value-types}");
+    content.push("");
+    content.push("| Proto Type | C++ | Go | Java | Python | Notes |");
+    content.push("|---|---|---|---|---|---|");
 
     for (const scalar of spec.scalarValueTypes) {
-      content.push(`\n### ${scalar.protoType}`);
-      if (hasText(scalar.notes)) {
-        content.push(`<div class="${prose}">\n${handleCurlies(scalar.notes)}\n</div>`);
-      }
-
-      content.push(`<div class="protoScalarRow">`);
+      const notes = hasText(scalar.notes) ? handleCurlies(scalar.notes).replace(/\n/g, ' ').replace(/\|/g, '\\|') : '';
       content.push(
-        `<div class="protoScalarCard"><div class="protoScalarTitle">C++</div><div class="protoScalarVal">${scalar.cppType}</div></div>`,
+        `| **${scalar.protoType}** | ${scalar.cppType} | ${scalar.goType} | ${scalar.javaType} | ${scalar.pythonType} | ${notes} |`,
       );
-      content.push(
-        `<div class="protoScalarCard"><div class="protoScalarTitle">C#</div><div class="protoScalarVal">${scalar.csType}</div></div>`,
-      );
-      content.push(
-        `<div class="protoScalarCard"><div class="protoScalarTitle">Go</div><div class="protoScalarVal">${scalar.goType}</div></div>`,
-      );
-      content.push(
-        `<div class="protoScalarCard"><div class="protoScalarTitle">Java</div><div class="protoScalarVal">${scalar.javaType}</div></div>`,
-      );
-      content.push(
-        `<div class="protoScalarCard"><div class="protoScalarTitle">PHP</div><div class="protoScalarVal">${scalar.phpType}</div></div>`,
-      );
-      content.push(
-        `<div class="protoScalarCard"><div class="protoScalarTitle">Python</div><div class="protoScalarVal">${scalar.pythonType}</div></div>`,
-      );
-      content.push(
-        `<div class="protoScalarCard"><div class="protoScalarTitle">Ruby</div><div class="protoScalarVal">${scalar.rubyType}</div></div>`,
-      );
-      content.push(`</div>`);
     }
   }
 

--- a/docs/site/src/shared/js/generate-llmstxt.mjs
+++ b/docs/site/src/shared/js/generate-llmstxt.mjs
@@ -24,7 +24,7 @@ const outputFile = flags["output"] ?? path.join(scriptDir, "../../../static/llms
 const baseUrl = flags["base-url"] ?? "https://docs.sui.io";
 
 // ── Constants ────────────────────────────────────────────────────────────────
-const TARGET_CHARS = 80_000;
+const TARGET_CHARS = 45_000;
 const PINNED_SECTIONS = ["Move", "Top Level Navigation", "Sui Developer Skills"];
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -304,7 +304,7 @@ function sortPages(pages) {
 
 // ── Build output ─────────────────────────────────────────────────────────────
 
-function build(ratio = 1) {
+function build(ratio = 1, { includeFull = false } = {}) {
   const lines = [];
 
   // Static header (LLM optimized)
@@ -315,6 +315,13 @@ function build(ratio = 1) {
     "Designed for efficient retrieval and grounding by large language models.",
     ""
   );
+
+  if (includeFull) {
+    lines.push(
+      `> For the complete, unabridged page index see [llms-full.txt](${baseUrl}/llms-full.txt).`,
+      ""
+    );
+  }
 
   const sections = sortSections(Object.keys(grouped));
 
@@ -354,22 +361,29 @@ function build(ratio = 1) {
   return lines.join("\n");
 }
 
-// ── Trim passes ──────────────────────────────────────────────────────────────
+// ── Build full listing ───────────────────────────────────────────────────────
 
-let output = build(1);
+const fullOutput = build(1);
+
+// ── Build trimmed listing for llms.txt (under TARGET_CHARS) ─────────────────
+
+let output = build(1, { includeFull: true });
 
 if (output.length > TARGET_CHARS) {
   const ratio = TARGET_CHARS / output.length;
-  output = build(ratio);
+  output = build(ratio, { includeFull: true });
 }
 
 if (output.length > TARGET_CHARS) {
   output = output.slice(0, TARGET_CHARS);
 }
 
-// ── Write file ───────────────────────────────────────────────────────────────
+// ── Write files ──────────────────────────────────────────────────────────────
 
 fs.mkdirSync(path.dirname(outputFile), { recursive: true });
 fs.writeFileSync(outputFile, output, "utf8");
-
 console.log(`✓ Generated ${outputFile} (${output.length.toLocaleString()} chars)`);
+
+const fullOutputFile = outputFile.replace(/llms\.txt$/, "llms-full.txt");
+fs.writeFileSync(fullOutputFile, fullOutput, "utf8");
+console.log(`✓ Generated ${fullOutputFile} (${fullOutput.length.toLocaleString()} chars)`);

--- a/docs/site/src/theme/Layout/index.js
+++ b/docs/site/src/theme/Layout/index.js
@@ -1,0 +1,64 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Swizzled from @docusaurus/theme-classic to place <Navbar /> after main
+// content in DOM order.  CSS `order: -1` + `position: sticky` keeps the
+// navbar visually pinned at the top.  This improves content-start-position
+// for automated doc-quality scanners that convert HTML to text sequentially.
+
+import React from 'react';
+import clsx from 'clsx';
+import ErrorBoundary from '@docusaurus/ErrorBoundary';
+import {
+  PageMetadata,
+  SkipToContentFallbackId,
+  ThemeClassNames,
+} from '@docusaurus/theme-common';
+import {useKeyboardNavigation} from '@docusaurus/theme-common/internal';
+import SkipToContent from '@theme/SkipToContent';
+import AnnouncementBar from '@theme/AnnouncementBar';
+import Navbar from '@theme/Navbar';
+import Footer from '@theme/Footer';
+import LayoutProvider from '@theme/Layout/Provider';
+import ErrorPageContent from '@theme/ErrorPageContent';
+import styles from './styles.module.css';
+
+export default function Layout(props) {
+  const {
+    children,
+    noFooter,
+    wrapperClassName,
+    title,
+    description,
+  } = props;
+  useKeyboardNavigation();
+  return (
+    <LayoutProvider>
+      <PageMetadata title={title} description={description} />
+
+      <SkipToContent />
+
+      <div className={styles.layoutWrapper}>
+        {/* Main content first in DOM for content-start-position */}
+        <div
+          id={SkipToContentFallbackId}
+          className={clsx(
+            ThemeClassNames.layout.main.container,
+            ThemeClassNames.wrapper.main,
+            styles.mainWrapper,
+            wrapperClassName,
+          )}>
+          <ErrorBoundary fallback={(params) => <ErrorPageContent {...params} />}>
+            {children}
+          </ErrorBoundary>
+        </div>
+
+        {/* Navbar after main in DOM, visually repositioned via CSS order */}
+        <AnnouncementBar />
+        <Navbar />
+      </div>
+
+      {!noFooter && <Footer />}
+    </LayoutProvider>
+  );
+}

--- a/docs/site/src/theme/Layout/styles.module.css
+++ b/docs/site/src/theme/Layout/styles.module.css
@@ -1,0 +1,36 @@
+/* Copyright (c) Mysten Labs, Inc.
+   SPDX-License-Identifier: Apache-2.0 */
+
+html,
+body {
+  height: 100%;
+}
+
+/* Flex container that lets us reorder navbar vs main via CSS order */
+.layoutWrapper {
+  display: flex;
+  flex-direction: column;
+  flex: 1 0 auto;
+}
+
+/* Navbar appears first visually (order: -1) even though it's after main in DOM */
+.layoutWrapper > :global(.navbar),
+.layoutWrapper > :global([class*="announcementBar"]) {
+  order: -1;
+}
+
+.mainWrapper {
+  flex: 1 0 auto;
+  display: flex;
+  flex-direction: column;
+}
+
+:global(.docusaurus-mt-lg) {
+  margin-top: 3rem;
+}
+
+:global(#__docusaurus) {
+  min-height: 100%;
+  display: flex;
+  flex-direction: column;
+}

--- a/docs/site/static/llms-full.txt
+++ b/docs/site/static/llms-full.txt
@@ -2,8 +2,6 @@
 
 > Comprehensive reference for Sui blockchain development, including Move smart contract programming, Sui framework concepts, frontend integration, and fullstack application architecture. Designed for efficient retrieval and grounding by large language models.
 
-> For the complete, unabridged page index see [llms-full.txt](https://docs.sui.io/llms-full.txt).
-
 ## Move
 
 - [Move Language Reference](https://move-book.com/llms.txt)
@@ -108,6 +106,47 @@
 - [Epochs](https://docs.sui.io/develop/sui-architecture/epochs.md)
 - [Sui Architecture Index](https://docs.sui.io/develop/sui-architecture/index.md)
 - [Networks](https://docs.sui.io/develop/sui-architecture/networks.md)
+- [Object Model](https://docs.sui.io/develop/sui-architecture/object-model.md)
+- [Protocol Upgrades](https://docs.sui.io/develop/sui-architecture/protocol-upgrades.md)
+- [Sui Security](https://docs.sui.io/develop/sui-architecture/sui-security.md)
+- [Sui Storage](https://docs.sui.io/develop/sui-architecture/sui-storage.md)
+- [Tokenomics Overview](https://docs.sui.io/develop/sui-architecture/tokenomics-overview.md)
+
+### Develop/Testing Debugging
+- [Common Errors](https://docs.sui.io/develop/testing-debugging/common-errors.md)
+- [Testing Debugging Index](https://docs.sui.io/develop/testing-debugging/index.md)
+
+### Develop/Transaction Payment
+- [Gas In Sui](https://docs.sui.io/develop/transaction-payment/gas-in-sui.md)
+- [Gas Smashing](https://docs.sui.io/develop/transaction-payment/gas-smashing.md)
+- [Transaction Payment Index](https://docs.sui.io/develop/transaction-payment/index.md)
+- [Local Fee Markets](https://docs.sui.io/develop/transaction-payment/local-fee-markets.md)
+- [Sponsor Txn](https://docs.sui.io/develop/transaction-payment/sponsor-txn.md)
+
+### Develop/Transactions
+- [Transactions Index](https://docs.sui.io/develop/transactions/index.md)
+- [Transaction Lifecycle](https://docs.sui.io/develop/transactions/transaction-lifecycle.md)
+- [Txn Overview](https://docs.sui.io/develop/transactions/txn-overview.md)
+
+### Develop/Transactions/Ptbs
+- [Building Ptb](https://docs.sui.io/develop/transactions/ptbs/building-ptb.md)
+- [Ptbs Index](https://docs.sui.io/develop/transactions/ptbs/index.md)
+- [Inputs And Results](https://docs.sui.io/develop/transactions/ptbs/inputs-and-results.md)
+- [Prog Txn Blocks](https://docs.sui.io/develop/transactions/ptbs/prog-txn-blocks.md)
+
+### Develop/Transactions/Transaction Auth
+- [Address Aliases](https://docs.sui.io/develop/transactions/transaction-auth/address-aliases.md)
+- [Auth Overview](https://docs.sui.io/develop/transactions/transaction-auth/auth-overview.md)
+- [Transaction Auth Index](https://docs.sui.io/develop/transactions/transaction-auth/index.md)
+- [Intent Signing](https://docs.sui.io/develop/transactions/transaction-auth/intent-signing.md)
+- [Multisig](https://docs.sui.io/develop/transactions/transaction-auth/multisig.md)
+- [Offline Signing](https://docs.sui.io/develop/transactions/transaction-auth/offline-signing.md)
+
+### Develop/Write Move
+- [Write Move Index](https://docs.sui.io/develop/write-move/index.md)
+- [Move Best Practices](https://docs.sui.io/develop/write-move/move-best-practices.md)
+- [Package Overview](https://docs.sui.io/develop/write-move/package-overview.md)
+- [Sui Move Concepts](https://docs.sui.io/develop/write-move/sui-move-concepts.md)
 
 ## Getting Started
 
@@ -123,6 +162,12 @@
 - [Onboarding Index](https://docs.sui.io/getting-started/onboarding/index.md)
 - [Install Binaries](https://docs.sui.io/getting-started/onboarding/install-binaries.md)
 - [Install Source](https://docs.sui.io/getting-started/onboarding/install-source.md)
+- [Local Network](https://docs.sui.io/getting-started/onboarding/local-network.md)
+- [Next Steps](https://docs.sui.io/getting-started/onboarding/next-steps.md)
+- [Sui Install](https://docs.sui.io/getting-started/onboarding/sui-install.md)
+- [Sui For Ethereum](https://docs.sui.io/getting-started/sui-for-ethereum.md)
+- [Sui For Solana](https://docs.sui.io/getting-started/sui-for-solana.md)
+- [Tooling](https://docs.sui.io/getting-started/tooling.md)
 
 ## Onchain Finance
 
@@ -215,6 +260,46 @@
 ### Onchain Finance/Examples Patterns
 - [Fixed Supply](https://docs.sui.io/onchain-finance/examples-patterns/fixed-supply.md)
 - [In Game Currency](https://docs.sui.io/onchain-finance/examples-patterns/in-game-currency.md)
+- [Examples Patterns Index](https://docs.sui.io/onchain-finance/examples-patterns/index.md)
+- [Kiosk](https://docs.sui.io/onchain-finance/examples-patterns/kiosk.md)
+- [Loyalty Tokens](https://docs.sui.io/onchain-finance/examples-patterns/loyalty-tokens.md)
+- [Nft Rental](https://docs.sui.io/onchain-finance/examples-patterns/nft-rental.md)
+- [Soulbound Tokens](https://docs.sui.io/onchain-finance/examples-patterns/soulbound-tokens.md)
+- [Wasm Template](https://docs.sui.io/onchain-finance/examples-patterns/wasm-template.md)
+
+### Onchain Finance/Fungible Tokens
+- [Coin](https://docs.sui.io/onchain-finance/fungible-tokens/coin.md)
+- [Create A Fungible Token
+    Coin](https://docs.sui.io/onchain-finance/fungible-tokens/create-a-fungible-token-coin.md)
+- [Create A Fungible
+    Token](https://docs.sui.io/onchain-finance/fungible-tokens/create-a-fungible-token.md)
+- [Currency](https://docs.sui.io/onchain-finance/fungible-tokens/currency.md)
+- [Fungible Tokens Index](https://docs.sui.io/onchain-finance/fungible-tokens/index.md)
+- [Regulated Tokens](https://docs.sui.io/onchain-finance/fungible-tokens/regulated-tokens.md)
+- [Sui Bridging](https://docs.sui.io/onchain-finance/fungible-tokens/sui-bridging.md)
+- [Token Vesting
+    Strategies](https://docs.sui.io/onchain-finance/fungible-tokens/token-vesting-strategies.md)
+
+### Onchain Finance/Kiosk
+- [Kiosk Index](https://docs.sui.io/onchain-finance/kiosk/index.md)
+- [Kiosk Apps](https://docs.sui.io/onchain-finance/kiosk/kiosk-apps.md)
+- [Kiosk Example](https://docs.sui.io/onchain-finance/kiosk/kiosk-example.md)
+
+### Onchain Finance/Pas
+- [Pas Index](https://docs.sui.io/onchain-finance/pas/index.md)
+- [Integrating Pas](https://docs.sui.io/onchain-finance/pas/integrating-pas.md)
+- [Pas Architecture](https://docs.sui.io/onchain-finance/pas/pas-architecture.md)
+- [Pas Workflows](https://docs.sui.io/onchain-finance/pas/pas-workflows.md)
+- [Querying Assets](https://docs.sui.io/onchain-finance/pas/querying-assets.md)
+- [Payment Kit](https://docs.sui.io/onchain-finance/payment-kit.md)
+
+### Onchain Finance/Tokenized Assets
+- [Asset Tokenization](https://docs.sui.io/onchain-finance/tokenized-assets/asset-tokenization.md)
+- [Create Nft](https://docs.sui.io/onchain-finance/tokenized-assets/create-nft.md)
+- [Deploy Tokenized
+    Asset](https://docs.sui.io/onchain-finance/tokenized-assets/deploy-tokenized-asset.md)
+- [Tokenized Assets Index](https://docs.sui.io/onchain-finance/tokenized-assets/index.md)
+- [Types Of Assets](https://docs.sui.io/onchain-finance/types-of-assets.md)
 
 ## Operators
 
@@ -236,6 +321,16 @@
 - [Sui Full Node](https://docs.sui.io/operators/full-node/sui-full-node.md)
 - [Updates](https://docs.sui.io/operators/full-node/updates.md)
 - [Genesis](https://docs.sui.io/operators/genesis.md)
+- [Operators Index](https://docs.sui.io/operators/index.md)
+- [Snapshots](https://docs.sui.io/operators/snapshots.md)
+
+### Operators/Validator
+- [Alerts](https://docs.sui.io/operators/validator/alerts.md)
+- [Validator Index](https://docs.sui.io/operators/validator/index.md)
+- [Node Tools](https://docs.sui.io/operators/validator/node-tools.md)
+- [Validator Config](https://docs.sui.io/operators/validator/validator-config.md)
+- [Validator Rewards](https://docs.sui.io/operators/validator/validator-rewards.md)
+- [Validator Tasks](https://docs.sui.io/operators/validator/validator-tasks.md)
 
 ## References
 
@@ -667,6 +762,260 @@
     Input](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/gas-input.md)
 - [Genesis
     Transaction](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/genesis-transaction.md)
+-
+    [Immutable](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/immutable.md)
+- [Input](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/input.md)
+-
+    [Linkage](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/linkage.md)
+- [Make Move Vec
+    Command](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/make-move-vec-command.md)
+- [Merge Coins
+    Command](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/merge-coins-command.md)
+- [Move Call
+    Command](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/move-call-command.md)
+- [Move Datatype
+    Connection](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/move-datatype-connection.md)
+- [Move Datatype
+    Edge](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/move-datatype-edge.md)
+- [Move Datatype Type
+    Parameter](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/move-datatype-type-parameter.md)
+- [Move
+    Datatype](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/move-datatype.md)
+- [Move Enum
+    Connection](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/move-enum-connection.md)
+- [Move Enum
+    Edge](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/move-enum-edge.md)
+- [Move Enum
+    Variant](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/move-enum-variant.md)
+- [Move
+    Enum](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/move-enum.md)
+- [Move
+    Field](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/move-field.md)
+- [Move Function
+    Connection](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/move-function-connection.md)
+- [Move Function
+    Edge](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/move-function-edge.md)
+- [Move Function Type
+    Parameter](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/move-function-type-parameter.md)
+- [Move
+    Function](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/move-function.md)
+- [Move Module
+    Connection](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/move-module-connection.md)
+- [Move Module
+    Edge](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/move-module-edge.md)
+- [Move
+    Module](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/move-module.md)
+- [Move Object
+    Connection](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/move-object-connection.md)
+- [Move Object
+    Edge](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/move-object-edge.md)
+- [Move
+    Object](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/move-object.md)
+- [Move Package
+    Connection](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/move-package-connection.md)
+- [Move Package
+    Edge](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/move-package-edge.md)
+- [Move
+    Package](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/move-package.md)
+- [Move Struct
+    Connection](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/move-struct-connection.md)
+- [Move Struct
+    Edge](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/move-struct-edge.md)
+- [Move
+    Struct](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/move-struct.md)
+- [Move
+    Type](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/move-type.md)
+- [Move Value
+    Connection](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/move-value-connection.md)
+- [Move Value
+    Edge](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/move-value-edge.md)
+- [Move
+    Value](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/move-value.md)
+- [Multisig
+    Committee](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/multisig-committee.md)
+- [Multisig
+    Member](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/multisig-member.md)
+- [Multisig
+    Signature](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/multisig-signature.md)
+- [Mutate Consensus Stream
+    Ended](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/mutate-consensus-stream-ended.md)
+- [Name
+    Record](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/name-record.md)
+- [Object Change
+    Connection](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/object-change-connection.md)
+- [Object Change
+    Edge](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/object-change-edge.md)
+- [Object
+    Change](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/object-change.md)
+- [Object
+    Connection](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/object-connection.md)
+- [Object
+    Edge](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/object-edge.md)
+- [Object
+    Owner](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/object-owner.md)
+-
+    [Object](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/object.md)
+- [Open Move
+    Type](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/open-move-type.md)
+- [Other
+    Command](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/other-command.md)
+- [Owned Or
+    Immutable](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/owned-or-immutable.md)
+- [Page
+    Info](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/page-info.md)
+- [Passkey Public
+    Key](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/passkey-public-key.md)
+- [Passkey
+    Signature](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/passkey-signature.md)
+- [Per Epoch
+    Config](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/per-epoch-config.md)
+- [Programmable System
+    Transaction](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/programmable-system-transaction.md)
+- [Programmable
+    Transaction](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/programmable-transaction.md)
+- [Protocol
+    Config](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/protocol-config.md)
+- [Protocol
+    Configs](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/protocol-configs.md)
+- [Publish
+    Command](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/publish-command.md)
+- [Pure](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/pure.md)
+- [Randomness State Create
+    Transaction](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/randomness-state-create-transaction.md)
+- [Randomness State Update
+    Transaction](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/randomness-state-update-transaction.md)
+- [Read Consensus Stream
+    Ended](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/read-consensus-stream-ended.md)
+-
+    [Receiving](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/receiving.md)
+- [Secp 256 K1 Public
+    Key](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/secp-256-k1-public-key.md)
+- [Secp 256 K1
+    Signature](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/secp-256-k1-signature.md)
+- [Secp 256 R1 Public
+    Key](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/secp-256-r1-public-key.md)
+- [Secp 256 R1
+    Signature](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/secp-256-r1-signature.md)
+- [Service
+    Config](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/service-config.md)
+- [Shared
+    Input](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/shared-input.md)
+-
+    [Shared](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/shared.md)
+- [Signature Verify
+    Result](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/signature-verify-result.md)
+- [Simulation
+    Result](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/simulation-result.md)
+- [Split Coins
+    Command](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/split-coins-command.md)
+- [Store Execution Time Observations
+    Transaction](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/store-execution-time-observations-transaction.md)
+- [Transaction
+    Connection](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/transaction-connection.md)
+- [Transaction
+    Edge](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/transaction-edge.md)
+- [Transaction
+    Effects](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/transaction-effects.md)
+- [Transaction Input
+    Connection](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/transaction-input-connection.md)
+- [Transaction Input
+    Edge](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/transaction-input-edge.md)
+-
+    [Transaction](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/transaction.md)
+- [Transfer Objects
+    Command](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/transfer-objects-command.md)
+- [Tx
+    Result](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/tx-result.md)
+- [Type
+    Origin](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/type-origin.md)
+- [Unchanged Consensus Object
+    Connection](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/unchanged-consensus-object-connection.md)
+- [Unchanged Consensus Object
+    Edge](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/unchanged-consensus-object-edge.md)
+- [Upgrade
+    Command](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/upgrade-command.md)
+- [User
+    Signature](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/user-signature.md)
+- [Validator Aggregated
+    Signature](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/validator-aggregated-signature.md)
+- [Validator
+    Connection](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/validator-connection.md)
+- [Validator
+    Edge](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/validator-edge.md)
+- [Validator
+    Set](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/validator-set.md)
+-
+    [Validator](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/validator.md)
+- [Withdraw Max Amount
+    U64](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/withdraw-max-amount-u64.md)
+- [Write Accumulator Storage Cost
+    Transaction](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/write-accumulator-storage-cost-transaction.md)
+- [Zk Login
+    Claim](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/zk-login-claim.md)
+- [Zk Login
+    Inputs](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/zk-login-inputs.md)
+- [Zk Login Jwk
+    Id](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/zk-login-jwk-id.md)
+- [Zk Login
+    Proof](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/zk-login-proof.md)
+- [Zk Login Public
+    Identifier](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/zk-login-public-identifier.md)
+- [Zk Login
+    Signature](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/zk-login-signature.md)
+- [Zk Login Verify
+    Result](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/objects/zk-login-verify-result.md)
+
+### References/Sui Api/Sui Graphql/Beta/Reference/Types/Scalars
+- [Base
+    64](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/scalars/base-64.md)
+- [Big
+    Int](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/scalars/big-int.md)
+-
+    [Boolean](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/scalars/boolean.md)
+- [Date
+    Time](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/scalars/date-time.md)
+- [Id](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/scalars/id.md)
+- [Int](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/scalars/int.md)
+- [Json](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/scalars/json.md)
+- [Move Type
+    Layout](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/scalars/move-type-layout.md)
+- [Move Type
+    Signature](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/scalars/move-type-signature.md)
+- [Open Move Type
+    Signature](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/scalars/open-move-type-signature.md)
+-
+    [String](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/scalars/string.md)
+- [Sui
+    Address](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/scalars/sui-address.md)
+- [Uint
+    53](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/scalars/uint-53.md)
+
+### References/Sui Api/Sui Graphql/Beta/Reference/Types/Unions
+-
+    [Command](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/unions/command.md)
+- [Dynamic Field
+    Value](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/unions/dynamic-field-value.md)
+- [End Of Epoch Transaction
+    Kind](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/unions/end-of-epoch-transaction-kind.md)
+- [Multisig Member Public
+    Key](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/unions/multisig-member-public-key.md)
+- [Owner](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/unions/owner.md)
+- [Signature
+    Scheme](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/unions/signature-scheme.md)
+- [Transaction
+    Argument](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/unions/transaction-argument.md)
+- [Transaction
+    Input](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/unions/transaction-input.md)
+- [Transaction
+    Kind](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/unions/transaction-kind.md)
+- [Unchanged Consensus
+    Object](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/unions/unchanged-consensus-object.md)
+- [Withdrawal
+    Reservation](https://docs.sui.io/references/sui-api/sui-graphql/beta/reference/types/unions/withdrawal-reservation.md)
+- [Sui Glossary](https://docs.sui.io/references/sui-glossary.md)
+- [Sui Graphql](https://docs.sui.io/references/sui-graphql.md)
+- [Sui Move](https://docs.sui.io/references/sui-move.md)
+- [Sui Sdks](https://docs.sui.io/references/sui-sdks.md)
 
 ## Sui Stack
 
@@ -690,3 +1039,13 @@
 
 ### Sui Stack/Suiplay0x1
 - [Best Practices](https://docs.sui.io/sui-stack/suiplay0x1/best-practices.md)
+- [Suiplay0x1 Index](https://docs.sui.io/sui-stack/suiplay0x1/index.md)
+- [Integration](https://docs.sui.io/sui-stack/suiplay0x1/integration.md)
+- [Migration Strategies](https://docs.sui.io/sui-stack/suiplay0x1/migration-strategies.md)
+- [Wallet Integration](https://docs.sui.io/sui-stack/suiplay0x1/wallet-integration.md)
+
+### Sui Stack/Zklogin Integration
+- [Developer Account](https://docs.sui.io/sui-stack/zklogin-integration/developer-account.md)
+- [Zklogin Integration Index](https://docs.sui.io/sui-stack/zklogin-integration/index.md)
+- [Zklogin Example](https://docs.sui.io/sui-stack/zklogin-integration/zklogin-example.md)
+- [Zklogin](https://docs.sui.io/sui-stack/zklogin-integration/zklogin.md)

--- a/docs/site/vercel.json
+++ b/docs/site/vercel.json
@@ -2593,7 +2593,7 @@
   ],
   "rewrites": [
     {
-      "source": "/:path((?!markdown|_next|api|static|img|fonts|doc|paper|display-preview|llms\\.txt|robots\\.txt|sitemap\\.xml|\\.well-known).*)",
+      "source": "/:path((?!markdown|_next|api|static|img|fonts|doc|paper|display-preview|llms\\.txt|llms-full\\.txt|robots\\.txt|sitemap\\.xml|\\.well-known).*)",
       "has": [
         {
           "type": "header",
@@ -2604,7 +2604,7 @@
       "destination": "/markdown/:path.md"
     },
     {
-      "source": "/:path((?!markdown|_next|api|static|img|fonts|doc|paper|display-preview|llms\\.txt|robots\\.txt|sitemap\\.xml|\\.well-known).*)",
+      "source": "/:path((?!markdown|_next|api|static|img|fonts|doc|paper|display-preview|llms\\.txt|llms-full\\.txt|robots\\.txt|sitemap\\.xml|\\.well-known).*)",
       "has": [
         {
           "type": "header",
@@ -2643,6 +2643,15 @@
     },
     {
       "source": "/llms.txt",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=0, must-revalidate"
+        }
+      ]
+    },
+    {
+      "source": "/llms-full.txt",
       "headers": [
         {
           "key": "Cache-Control",


### PR DESCRIPTION
## Description 

Fixes more of the af docs specs + CI job, and also fixes the sui::bag page's rendering:

```
jessiemongeon@Mongeon-MacBook-Pro-GHV6J4N726-M docs % npx afdocs@latest check https://sui-docs-git-fork-jessiemongeon1-fix-suibag-sui-foundation.vercel.app/ --max-links=700  --canonical-origin=https://docs.sui.io
Running checks on sui-docs-git-fork-jessiemongeon1-fix-suibag-sui-foundation.vercel.app...

Agent-Friendly Docs Check: https://sui-docs-git-fork-jessiemongeon1-fix-suibag-sui-foundation.vercel.app/
Timestamp: 4/24/2026, 1:43:14 PM

content-discoverability
  ✓ llms-txt-exists: llms.txt found at 1 location(s)
  ✓ llms-txt-valid: llms.txt follows the proposed structure (H1, blockquote, heading-delimited link sections)
  ⚠ llms-txt-size: llms.txt is 67,642 characters (between 50,000 and 100,000; consider splitting)
      Learn more: https://agentdocsspec.com/spec/#llms-txt-size
  ✓ llms-txt-links-resolve: All 424 same-origin links resolve (425 total links)
  ✓ llms-txt-links-markdown: 424/424 same-origin links point to markdown content (100%) (1 external link excluded)
  ✓ llms-txt-directive: llms.txt directive found in all 638 pages, near the top of content

markdown-availability
  ✓ markdown-url-support: 637/638 pages support .md URLs (100%)
  ✓ content-negotiation: 637/638 pages support content negotiation (100%)

page-size
  ✓ rendering-strategy: All 638 pages contain server-rendered content
  ✓ page-size-markdown: All 637 pages under 50K chars (median 3K, max 48K)
  ⚠ page-size-html: 9 of 638 pages convert to 50K–100K chars (max 84K, 79% boilerplate)
      Learn more: https://agentdocsspec.com/spec/#page-size-html
  ✗ content-start-position: 3 of 638 pages have content starting past 50% (worst 95%)
      Learn more: https://agentdocsspec.com/spec/#content-start-position

content-structure
  ✓ tabbed-content-serialization: 68 tab group(s) across 37 of 638 pages; all serialize under 50K chars
  ✓ section-header-quality: 1 of 3 page(s) with tab headers don't distinguish between variants
  ✓ markdown-code-fence-validity: All 4123 code fences properly closed across 638 pages

url-stability
  ✓ http-status-codes: All 638 pages return proper error codes for bad URLs
  ✓ redirect-behavior: All 3 redirect(s) across 638 pages are same-host HTTP redirects

observability
  ✓ llms-txt-freshness: llms.txt covers 98% of 278 sitemap doc pages; 592 llms.txt links not in sitemap (may indicate stale links or incomplete sitemap)
  ✗ markdown-content-parity: 147 of 637 pages have substantive content differences between markdown and HTML (avg 12% missing)
      Learn more: https://agentdocsspec.com/spec/#markdown-content-parity
  ✓ cache-header-hygiene: All 639 endpoints have appropriate cache headers

authentication
  ✓ auth-gate-detection: All 638 pages are publicly accessible
  ○ auth-alternative-access: All docs pages are publicly accessible; no alternative access paths needed

Summary
  17 passed, 2 warnings, 2 failed, 1 skipped (22 total)

Full spec: https://agentdocsspec.com/spec/
```

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
