### PR TITLE
chore: fix incorrect @param comments for recipientAddress in bridge interfaces

### DIFF
--- a/bridge/evm/contracts/SuiBridgeV2.sol
+++ b/bridge/evm/contracts/SuiBridgeV2.sol
@@ -237,7 +237,7 @@ contract SuiBridgeV2 is SuiBridge {
     /// @param tokenID The code of the token.
     /// @param suiAdjustedAmount The amount of tokens to transfer, adjusted for Sui decimals.
     /// @param senderAddress The address of the sender.
-    /// @param recipientAddress The address of the sender.
+    /// @param recipientAddress The address of the recipient.
     event TokensDepositedV2(
         uint8 indexed sourceChainID,
         uint64 indexed nonce,

--- a/bridge/evm/contracts/interfaces/ISuiBridge.sol
+++ b/bridge/evm/contracts/interfaces/ISuiBridge.sol
@@ -11,7 +11,7 @@ interface ISuiBridge {
     /// @param tokenID The code of the token.
     /// @param suiAdjustedAmount The amount of tokens to transfer, adjusted for Sui decimals.
     /// @param senderAddress The address of the sender.
-    /// @param recipientAddress The address of the sender.
+    /// @param recipientAddress The address of the recipient.
     event TokensDeposited(
         uint8 indexed sourceChainID,
         uint64 indexed nonce,
@@ -29,7 +29,7 @@ interface ISuiBridge {
     /// @param tokenID The code of the token.
     /// @param erc20AdjustedAmount The amount of tokens claimed, adjusted for ERC20 decimals.
     /// @param senderAddress The address of the sender.
-    /// @param recipientAddress The address of the sender.
+    /// @param recipientAddress The address of the recipient.
     // event BridgedTokensTransferred(
     event TokensClaimed(
         uint8 indexed sourceChainID,


### PR DESCRIPTION


## Description 

Fixed documentation errors in ISuiBridge.sol and SuiBridgeV2.sol where the @param description for recipientAddress incorrectly stated "The address of the sender" instead of "The address of the recipient" in the TokensDeposited, TokensClaimed, and TokensDepositedV2 event comments.

## Test plan 

No need

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
