### PR TITLE
Fix Full node hanging on shutdown

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -54,7 +54,7 @@ use std::collections::BTreeSet;
 use std::fs::File;
 use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::Ordering;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 use std::time::Instant;
 use std::time::SystemTime;
@@ -964,6 +964,9 @@ pub struct AuthorityState {
     /// Limits the number of concurrent post-processing tasks to avoid overwhelming
     /// the blocking thread pool. Defaults to the number of available CPUs.
     post_processing_semaphore: Arc<tokio::sync::Semaphore>,
+
+    // Allows gracefully handling long-running operation while the node is shutting down
+    shutting_down: AtomicBool,
 }
 
 /// The authority state encapsulates all state, drives execution, and ensures safety.
@@ -3895,6 +3898,7 @@ impl AuthorityState {
             object_funds_checker_metrics,
             pending_post_processing: Arc::new(DashMap::new()),
             post_processing_semaphore: Arc::new(tokio::sync::Semaphore::new(num_cpus::get())),
+            shutting_down: AtomicBool::new(false),
         });
         state.init_object_funds_checker().await;
 
@@ -6619,6 +6623,15 @@ impl AuthorityState {
         self.get_reconfig_api()
             .clear_state_end_of_epoch(&self.execution_lock_for_reconfiguration().await);
         Ok(())
+    }
+
+    pub fn signal_shutdown(&self) {
+        self.shutting_down
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+    }
+
+    pub fn is_shutting_down(&self) -> bool {
+        self.shutting_down.load(std::sync::atomic::Ordering::SeqCst)
     }
 }
 

--- a/crates/sui-core/src/verify_indexes.rs
+++ b/crates/sui-core/src/verify_indexes.rs
@@ -125,6 +125,11 @@ pub async fn fix_indexes(authority_state: Weak<AuthorityState>) -> Result<()> {
                             tracing::info!("Authority is shutting down, stopped fixing coin index");
                             return Ok(vec![]);
                         }
+                        // Avoid spamming the logs, while keeping a frequent step size to keep operators informed
+                        // of this ongoing background task
+                        if i % 50000 == 0 {
+                            tracing::info!("Evaluating coin index {}", i);
+                        }
                     }
                     let (coin_index_key, _) = entry?;
                     if is_violation(&coin_index_key, &authority) {

--- a/crates/sui-core/src/verify_indexes.rs
+++ b/crates/sui-core/src/verify_indexes.rs
@@ -119,7 +119,13 @@ pub async fn fix_indexes(authority_state: Weak<AuthorityState>) -> Result<()> {
         if let Some(authority) = authority_state_clone.upgrade() {
             let mut batch = vec![];
             if let Some(indexes) = &authority.indexes {
-                for entry in indexes.tables().coin_index().safe_iter() {
+                for (i, entry) in indexes.tables().coin_index().safe_iter().enumerate() {
+                    if i % 1000 == 0 {
+                        if authority.is_shutting_down() {
+                            tracing::info!("Authority is shutting down, stopped fixing coin index");
+                            return Ok(vec![]);
+                        }
+                    }
                     let (coin_index_key, _) = entry?;
                     if is_violation(&coin_index_key, &authority) {
                         batch.push(coin_index_key);

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -2273,6 +2273,10 @@ impl SuiNode {
             }
         }
     }
+
+    pub fn signal_shutdown(&self) {
+        self.state.signal_shutdown();
+    }
 }
 
 #[cfg(not(msim))]

--- a/crates/sui-node/src/main.rs
+++ b/crates/sui-node/src/main.rs
@@ -125,6 +125,7 @@ fn main() {
     // if it deadlocks.
     let node_once_cell = Arc::new(AsyncOnceCell::<Arc<sui_node::SuiNode>>::new());
     let node_once_cell_clone = node_once_cell.clone();
+    let node_once_cell_for_shutdown = node_once_cell.clone();
 
     // let sui-node signal main to shutdown runtimes
     let (runtime_shutdown_tx, runtime_shutdown_rx) = broadcast::channel::<()>(1);
@@ -194,6 +195,13 @@ fn main() {
         .build()
         .unwrap()
         .block_on(wait_termination(runtime_shutdown_rx));
+
+    // we pass any main thread SIGINT down to the node
+    // this should be used to signal any long running batched operation to stop
+    runtimes.sui_node.block_on(async {
+        let node = node_once_cell_for_shutdown.get().await;
+        node.signal_shutdown();
+    });
 
     // Drop and wait all runtimes on main thread
     drop(runtimes);


### PR DESCRIPTION
## Description 

During maintenance operations, we noticed that sometimes our Sui nodes are hanging indefinitely on SIGTERM, resulting in a partial shutdown state unable to respond to RPC queries while the process is still running. This behavior is exclusively present on Full nodes, and not on validators.

We traced this to the blocking background task in `sui_core::verify_indexes::fix_indexes()`, unable to be dropped by tokio until finished. This runs at every startup and requires over 4 hours from node startup from on our mainnet machine (NVME SSD, 256GB RAM), during which time issuing a SIGTERM results in the aformentioned zombie state.

I am not familiar enough with the Sui codebase to determine whether this repair function introduced in https://github.com/MystenLabs/sui/pull/21559 should be removed. I opted to instead add a small shutdown signaling system from the node to the tokio Runtimes to gracefully handle terminating such long-running tasks.

## Test plan

Ran these changes rebased on top of the most recent mainnet release. Restarting the node multiple times in a row was reliable.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [X] Nodes (Validators and Full nodes): Full nodes do not hang on shutdown after being recently restarted
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
