### PR TITLE
[Block Streaming]  return multiple blocks per response

### DIFF
--- a/consensus/core/src/authority_service.rs
+++ b/consensus/core/src/authority_service.rs
@@ -373,15 +373,23 @@ impl<C: CoreThreadDispatcher> ValidatorNetworkService for AuthorityService<C> {
             )
         };
 
+        const MAX_BLOCKS_PER_POLL: usize = 1;
         let broadcasted_blocks = BroadcastedBlockStream::new(
             PeerId::Validator(peer),
             self.rx_block_broadcast.resubscribe(),
+            MAX_BLOCKS_PER_POLL,
             self.subscription_counter.clone(),
         );
 
         // Return a stream of blocks that first yields missed blocks as requested, then new blocks.
         Ok(Box::pin(past_proposed_blocks.chain(
-            broadcasted_blocks.map(ExtendedSerializedBlock::from),
+            broadcasted_blocks.flat_map(|items| {
+                debug_assert!(
+                    items.len() <= MAX_BLOCKS_PER_POLL,
+                    "Too many blocks received from broadcast"
+                );
+                stream::iter(items.into_iter().map(ExtendedSerializedBlock::from))
+            }),
         )))
     }
 
@@ -573,6 +581,8 @@ pub(crate) struct BroadcastStream<T> {
             broadcast::Receiver<T>,
         ),
     >,
+    // Maximum number of items to return per poll.
+    max_items_per_poll: usize,
     // Counts total subscriptions / active BroadcastStreams.
     subscription_counter: Arc<SubscriptionCounter>,
 }
@@ -581,8 +591,10 @@ impl<T: 'static + Clone + Send> BroadcastStream<T> {
     pub fn new(
         peer: PeerId,
         rx: broadcast::Receiver<T>,
+        max_items_per_poll: usize,
         subscription_counter: Arc<SubscriptionCounter>,
     ) -> Self {
+        assert!(max_items_per_poll > 0, "max_items_per_poll must be > 0");
         if let Err(err) = subscription_counter.increment(&peer) {
             match err {
                 ConsensusError::Shutdown => {}
@@ -592,39 +604,61 @@ impl<T: 'static + Clone + Send> BroadcastStream<T> {
         Self {
             peer,
             inner: ReusableBoxFuture::new(make_recv_future(rx)),
+            max_items_per_poll,
             subscription_counter,
         }
     }
 }
 
 impl<T: 'static + Clone + Send> Stream for BroadcastStream<T> {
-    type Item = T;
+    type Item = Vec<T>;
 
     fn poll_next(
         mut self: Pin<&mut Self>,
         cx: &mut task::Context<'_>,
     ) -> task::Poll<Option<Self::Item>> {
-        let peer = self.peer.clone();
-        let maybe_item = loop {
-            let (result, rx) = ready!(self.inner.poll(cx));
-            self.inner.set(make_recv_future(rx));
+        loop {
+            let (result, mut rx) = ready!(self.inner.poll(cx));
 
             match result {
-                Ok(item) => break Some(item),
+                Ok(item) => {
+                    let mut items = Vec::new();
+                    items.push(item);
+
+                    // Drain any additional items that are already available, up to the cap.
+                    while items.len() < self.max_items_per_poll {
+                        match rx.try_recv() {
+                            Ok(item) => items.push(item),
+                            Err(broadcast::error::TryRecvError::Empty) => break,
+                            Err(broadcast::error::TryRecvError::Closed) => break,
+                            Err(broadcast::error::TryRecvError::Lagged(n)) => {
+                                warn!(
+                                    "Block BroadcastedBlockStream {} lagged by {} messages",
+                                    self.peer, n
+                                );
+                                break;
+                            }
+                        }
+                    }
+
+                    self.inner.set(make_recv_future(rx));
+                    return task::Poll::Ready(Some(items));
+                }
                 Err(broadcast::error::RecvError::Closed) => {
-                    info!("Block BroadcastedBlockStream {} closed", peer);
-                    break None;
+                    info!("Block BroadcastedBlockStream {} closed", self.peer);
+                    return task::Poll::Ready(None);
                 }
                 Err(broadcast::error::RecvError::Lagged(n)) => {
                     warn!(
                         "Block BroadcastedBlockStream {} lagged by {} messages",
-                        peer, n
+                        self.peer, n
                     );
+                    // Re-arm the future and loop to await the next item.
+                    self.inner.set(make_recv_future(rx));
                     continue;
                 }
             }
-        };
-        task::Poll::Ready(maybe_item)
+        }
     }
 }
 

--- a/consensus/core/src/network/mod.rs
+++ b/consensus/core/src/network/mod.rs
@@ -240,7 +240,7 @@ pub(crate) trait ValidatorNetworkService: Send + Sync + 'static {
 }
 
 /// Observer block stream type.
-pub(crate) type ObserverBlockStream = Pin<Box<dyn Stream<Item = Bytes> + Send + 'static>>;
+pub(crate) type ObserverBlockStream = Pin<Box<dyn Stream<Item = Vec<Bytes>> + Send + 'static>>;
 
 /// Observer network service for handling requests from observer nodes.
 /// Unlike ValidatorNetworkService which uses AuthorityIndex, this uses NodeId (NetworkPublicKey)

--- a/consensus/core/src/network/observer.rs
+++ b/consensus/core/src/network/observer.rs
@@ -38,8 +38,8 @@ pub(crate) struct BlockStreamRequest {
 
 #[derive(Clone, prost::Message)]
 pub(crate) struct BlockStreamResponse {
-    #[prost(bytes = "bytes", tag = "1")]
-    pub(crate) block: Bytes,
+    #[prost(bytes = "bytes", repeated, tag = "1")]
+    pub(crate) blocks: Vec<Bytes>,
 }
 
 // Observer fetch messages
@@ -267,7 +267,7 @@ impl ObserverNetworkClient for TonicObserverClient {
                 let peer_cloned = peer.clone();
                 async move {
                     match b {
-                        Ok(response) => Some(response.block),
+                        Ok(response) => Some(response.blocks),
                         Err(e) => {
                             debug!("Network error received from {:?}: {e:?}", peer_cloned);
                             None
@@ -422,7 +422,7 @@ impl<S: ObserverNetworkService> ObserverService for ObserverServiceProxy<S> {
             .await
             .map_err(|e| tonic::Status::internal(format!("{e:?}")))?;
 
-        let response_stream = block_stream.map(|block| Ok(BlockStreamResponse { block }));
+        let response_stream = block_stream.map(|blocks| Ok(BlockStreamResponse { blocks }));
 
         Ok(Response::new(Box::pin(response_stream)))
     }
@@ -512,7 +512,7 @@ mod tests {
     use bytes::Bytes;
     use consensus_config::PeerRecord;
     use consensus_types::block::Round;
-    use futures::StreamExt as _;
+    use futures::{StreamExt as _, stream};
     use parking_lot::Mutex;
 
     use crate::{
@@ -547,7 +547,7 @@ mod tests {
             .await
             .unwrap();
 
-        let blocks: Vec<_> = block_stream.collect().await;
+        let blocks: Vec<Bytes> = block_stream.flat_map(stream::iter).collect().await;
 
         assert_eq!(blocks.len(), 100);
         assert_eq!(blocks[0], Bytes::from(vec![1u8; 16]));
@@ -579,7 +579,7 @@ mod tests {
             .await
             .unwrap();
 
-        let blocks: Vec<_> = block_stream.collect().await;
+        let blocks: Vec<Bytes> = block_stream.flat_map(stream::iter).collect().await;
 
         assert_eq!(blocks.len(), 50);
         assert_eq!(blocks[0], Bytes::from(vec![51u8; 16]));
@@ -645,12 +645,17 @@ mod tests {
         // If it fails, it's likely due to authentication/allowlist configuration
         let mut stream = result.unwrap();
         let mut count = 0;
-        while let Some(block) = stream.next().await {
-            // Verify the blocks are in the expected range (rounds 11-50)
-            assert!(block.len() == 16);
-            count += 1;
+        while let Some(batch) = stream.next().await {
+            for block in batch {
+                // Verify the blocks are in the expected range (rounds 11-50)
+                assert!(block.len() == 16);
+                count += 1;
+                if count >= 40 {
+                    break; // We expect 40 blocks (rounds 11-50)
+                }
+            }
             if count >= 40 {
-                break; // We expect 40 blocks (rounds 11-50)
+                break;
             }
         }
         assert_eq!(count, 40);

--- a/consensus/core/src/network/test_network.rs
+++ b/consensus/core/src/network/test_network.rs
@@ -149,7 +149,7 @@ impl ObserverNetworkService for Mutex<TestService> {
         let block_stream = stream::iter(
             blocks_to_send
                 .into_iter()
-                .map(|extended_block| extended_block.block),
+                .map(|extended_block| vec![extended_block.block]),
         );
 
         Ok(Box::pin(block_stream))

--- a/consensus/core/src/observer_service.rs
+++ b/consensus/core/src/observer_service.rs
@@ -248,15 +248,22 @@ impl ObserverNetworkService for ObserverService {
         let past_stream = stream::iter(
             past_blocks
                 .into_iter()
-                .map(move |block| block.serialized().clone()),
+                .map(move |block| vec![block.serialized().clone()]),
         );
 
+        const MAX_BLOCKS_PER_POLL: usize = 20;
         let live_stream = BroadcastStream::<VerifiedBlock>::new(
             PeerId::Observer(Box::new(peer)),
             self.rx_accepted_block_broadcast.resubscribe(),
+            MAX_BLOCKS_PER_POLL,
             self.subscription_counter.clone(),
         )
-        .map(|block| block.serialized().clone());
+        .map(|blocks| {
+            blocks
+                .into_iter()
+                .map(|block| block.serialized().clone())
+                .collect()
+        });
 
         Ok(Box::pin(past_stream.chain(live_stream)))
     }
@@ -364,24 +371,22 @@ mod tests {
         tx_accepted_block.send(block2.clone()).unwrap();
         tx_accepted_block.send(block3.clone()).unwrap();
 
-        // Verify observer receives all three blocks in order
-        let block1 = stream.next().await.unwrap();
-        let signed1 = bcs::from_bytes(&block1).unwrap();
-        let received1 = VerifiedBlock::new_verified(signed1, block1);
-        assert_eq!(received1.round(), 5);
-        assert_eq!(received1.author().value(), 0);
-
-        let block2 = stream.next().await.unwrap();
-        let signed2 = bcs::from_bytes(&block2).unwrap();
-        let received2 = VerifiedBlock::new_verified(signed2, block2);
-        assert_eq!(received2.round(), 10);
-        assert_eq!(received2.author().value(), 1);
-
-        let block3 = stream.next().await.unwrap();
-        let signed3 = bcs::from_bytes(&block3).unwrap();
-        let received3 = VerifiedBlock::new_verified(signed3, block3);
-        assert_eq!(received3.round(), 15);
-        assert_eq!(received3.author().value(), 2);
+        // Verify observer receives all three blocks in order.
+        // Collect all blocks from the batched stream.
+        let mut received_blocks = Vec::new();
+        while received_blocks.len() < 3 {
+            let batch = stream.next().await.unwrap();
+            for block_bytes in batch {
+                let signed: SignedBlock = bcs::from_bytes(&block_bytes).unwrap();
+                received_blocks.push(VerifiedBlock::new_verified(signed, block_bytes));
+            }
+        }
+        assert_eq!(received_blocks[0].round(), 5);
+        assert_eq!(received_blocks[0].author().value(), 0);
+        assert_eq!(received_blocks[1].round(), 10);
+        assert_eq!(received_blocks[1].author().value(), 1);
+        assert_eq!(received_blocks[2].round(), 15);
+        assert_eq!(received_blocks[2].author().value(), 2);
     }
 
     #[tokio::test]

--- a/consensus/core/src/observer_subscriber.rs
+++ b/consensus/core/src/observer_subscriber.rs
@@ -153,63 +153,69 @@ impl<C: ObserverNetworkClient, S: ObserverNetworkService> ObserverSubscriber<C, 
                 let _scope = monitored_scope("ObserverSubscriberStreamConsumer");
 
                 match blocks.next().await {
-                    Some(block) => {
+                    Some(batch) => {
                         context
                             .metrics
                             .node_metrics
                             .observer_subscribed_blocks
-                            .inc();
+                            .inc_by(batch.len() as u64);
 
-                        // Backpressure: wait if we've hit max parallelism
-                        while active_tasks.load(Ordering::Acquire) >= max_parallel_tasks {
-                            // Block until a task completes instead of busy-waiting
-                            match tasks.join_next().await {
-                                Some(Ok(_)) => {
-                                    // Task completed successfully, counter already decremented
-                                }
-                                Some(Err(e)) => {
-                                    warn!("Task failed with error: {}", e);
-                                }
-                                None => {
-                                    // This shouldn't happen if our counter is accurate
-                                    warn!(
-                                        "No tasks to join but counter shows {} active tasks",
-                                        active_tasks.load(Ordering::Acquire)
-                                    );
-                                    break;
-                                }
-                            }
-                        }
-
-                        // Spawn a new task to handle this block
-                        active_tasks.fetch_add(1, Ordering::AcqRel);
-                        let counter = active_tasks.clone();
-                        let observer_service = observer_service.clone();
-                        let peer_cloned = peer.clone();
-
-                        tasks.spawn(async move {
-                            let _scope = monitored_scope("ObserverSubscriberTask::handle_block");
-
-                            let result = observer_service
-                                .handle_block(peer_cloned.clone(), block)
-                                .await;
-                            if let Err(e) = result {
-                                match e {
-                                    ConsensusError::BlockRejected { block_ref, reason } => {
-                                        debug!(
-                                            "Failed to process block from peer for block {:?}: {}",
-                                            block_ref, reason
+                        for block in batch {
+                            // Backpressure: wait if we've hit max parallelism
+                            while active_tasks.load(Ordering::Acquire) >= max_parallel_tasks {
+                                // Block until a task completes instead of busy-waiting
+                                match tasks.join_next().await {
+                                    Some(Ok(_)) => {
+                                        // Task completed successfully, counter already decremented
+                                    }
+                                    Some(Err(e)) => {
+                                        warn!("Task failed with error: {}", e);
+                                    }
+                                    None => {
+                                        // This shouldn't happen if our counter is accurate
+                                        warn!(
+                                            "No tasks to join but counter shows {} active tasks",
+                                            active_tasks.load(Ordering::Acquire)
                                         );
-                                    }
-                                    _ => {
-                                        info!("Received invalid block from peer: {}", e);
+                                        break;
                                     }
                                 }
                             }
 
-                            // Decrement counter when done
-                            counter.fetch_sub(1, Ordering::AcqRel);
-                        });
+                            // Spawn a new task to handle this block
+                            active_tasks.fetch_add(1, Ordering::AcqRel);
+                            let counter = active_tasks.clone();
+                            let observer_service = observer_service.clone();
+                            let peer_cloned = peer.clone();
+
+                            tasks.spawn(async move {
+                                let _scope =
+                                    monitored_scope("ObserverSubscriberTask::handle_block");
+
+                                let result = observer_service
+                                    .handle_block(peer_cloned.clone(), block)
+                                    .await;
+                                if let Err(e) = result {
+                                    match e {
+                                        ConsensusError::BlockRejected {
+                                            block_ref,
+                                            reason,
+                                        } => {
+                                            debug!(
+                                                "Failed to process block from peer for block {:?}: {}",
+                                                block_ref, reason
+                                            );
+                                        }
+                                        _ => {
+                                            info!("Received invalid block from peer: {}", e);
+                                        }
+                                    }
+                                }
+
+                                // Decrement counter when done
+                                counter.fetch_sub(1, Ordering::AcqRel);
+                            });
+                        }
 
                         // Reset retries when a block is received and also reset the backoff.
                         retries = 0;
@@ -288,7 +294,7 @@ mod tests {
 
             let block_stream = stream::unfold(block_value, move |val| async move {
                 sleep(Duration::from_millis(1)).await;
-                Some((Bytes::from(vec![val; 8]), val))
+                Some((vec![Bytes::from(vec![val; 8])], val))
             })
             .take(10);
             Ok(Box::pin(block_stream))


### PR DESCRIPTION
## Description 

Refactor the `BlockStreamResponse` to return a vector of blocks instead of single block. Refactored the `BroadcastStream` so it can poll the underlying channel and fetch a batch of blocks instead of a single one.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
