### PR TITLE
[1.71] Fix coin reservation panic during checkpoint replay

### DIFF
--- a/crates/sui-benchmark/src/workloads/composite/mod.rs
+++ b/crates/sui-benchmark/src/workloads/composite/mod.rs
@@ -302,6 +302,7 @@ impl CompositeWorkloadConfig {
         probabilities.insert(ObjectBalanceOverdraw::NAME, 0.1);
         probabilities.insert(AuthenticatedEventEmit::NAME, 0.1);
         probabilities.insert(ImmutableObjectRead::NAME, 0.2);
+        probabilities.insert(CoinReservationWithdraw::NAME, 0.1);
         Self {
             probabilities,
             alias_tx_probability: 0.3,

--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -1550,6 +1550,7 @@ mod test {
     #[sim_test(config = "test_config()")]
     async fn test_composite_workload() {
         sui_protocol_config::ProtocolConfig::poison_get_for_min_version();
+
         let test_cluster = build_test_cluster(4, 10000, 1).await;
 
         let protocol_config = sui_protocol_config::ProtocolConfig::get_for_version(
@@ -1673,6 +1674,49 @@ mod test {
                 "expected at least one authenticated event emit"
             );
         }
+    }
+
+    /// Regression test for a panic at transaction_rewriting.rs where a coin-reservation
+    /// transaction executes before the settlement transaction that creates the accumulator
+    /// object it depends on. Uses execution delays to create adversarial scheduling.
+    #[sim_test(config = "test_config()")]
+    async fn test_coin_reservation_checkpoint_replay() {
+        sui_protocol_config::ProtocolConfig::poison_get_for_min_version();
+
+        register_fail_point_async("transaction_execution_delay", move || async move {
+            if thread_rng().gen_range(0..10u64) == 0 {
+                let delay = thread_rng().gen_range(0..1000u64);
+                tokio::time::sleep(Duration::from_millis(delay)).await;
+            }
+        });
+
+        let test_cluster = build_test_cluster(4, 10000, 1).await;
+
+        use sui_benchmark::workloads::composite::*;
+        let composite_config = CompositeWorkloadConfig {
+            num_shared_counters: 2,
+            shared_counter_hotness: 0.95,
+            address_balance_amount: 1000,
+            address_balance_gas_probability: 0.5,
+            conflicting_transaction_probability: 0.1,
+            ..Default::default()
+        }
+        .with_probability(SharedCounterIncrement::NAME, 0.1)
+        .with_probability(AddressBalanceDeposit::NAME, 0.1)
+        .with_probability(AddressBalanceWithdraw::NAME, 0.1)
+        .with_probability(AddressBalanceOverdraw::NAME, 0.3)
+        .with_probability(CoinReservationWithdraw::NAME, 0.3);
+
+        test_simulated_load_with_test_config(
+            test_cluster,
+            60,
+            SimulatedLoadConfig::composite_only(composite_config),
+            None,
+            None,
+            None::<fn(Arc<TestCluster>) -> std::future::Ready<()>>,
+            false,
+        )
+        .await;
     }
 
     #[sim_test(config = "test_config()")]

--- a/crates/sui-core/src/accumulators/coin_reservations.rs
+++ b/crates/sui-core/src/accumulators/coin_reservations.rs
@@ -19,7 +19,7 @@ use sui_types::{
 /// of (owner, type_tag) for each accumulator object ID.
 pub struct CachingCoinReservationResolver {
     inner: CoinReservationResolver,
-    cache: MokaCache<ObjectID, Result<(SuiAddress, TypeTag), UserInputError>>,
+    cache: MokaCache<ObjectID, (SuiAddress, TypeTag)>,
 }
 
 impl CachingCoinReservationResolver {
@@ -35,12 +35,23 @@ impl CachingCoinReservationResolver {
         object_id: ObjectID,
         accumulator_version: Option<SequenceNumber>,
     ) -> UserInputResult<(SuiAddress, TypeTag)> {
-        // Owner and type_tag never change, so the cache is always coherent.
-        // On cache miss, use MVCC to read at the specified version.
-        self.cache.get_with(object_id, || {
-            self.inner
-                .get_owner_and_type_for_object(object_id, accumulator_version)
-        })
+        // Owner and type_tag never change once the object exists, so successful
+        // lookups are always coherent.
+        //
+        // Don't cache errors — the only expected error is "not found", which is
+        // transient: the accumulator object may not exist on this node yet but
+        // will appear once the settlement transaction executes. Caching a
+        // transient not-found would poison the cache for all subsequent lookups.
+        if let Some(value) = self.cache.get(&object_id) {
+            return Ok(value);
+        }
+        let result = self
+            .inner
+            .get_owner_and_type_for_object(object_id, accumulator_version);
+        if let Ok(value) = &result {
+            self.cache.insert(object_id, value.clone());
+        }
+        result
     }
 
     pub fn resolve_funds_withdrawal(

--- a/crates/sui-core/src/accumulators/transaction_rewriting.rs
+++ b/crates/sui-core/src/accumulators/transaction_rewriting.rs
@@ -12,6 +12,10 @@ use sui_types::transaction::{CallArg, ObjectArg, ProgrammableTransaction, Transa
 /// Returns `Some(rewritten_inputs)` if any inputs were rewritten, where each bool indicates whether
 /// the corresponding input was converted from a coin reservation. Returns `None` if nothing
 /// was rewritten.
+///
+/// `accumulator_version` is the version of the accumulator root object to use for MVCC lookup.
+/// This is required during checkpoint replay to read the accumulator state at the correct version,
+/// before any settlement transactions have modified it.
 pub fn rewrite_transaction_for_coin_reservations(
     chain_identifier: ChainIdentifier,
     coin_reservation_resolver: &dyn CoinReservationResolverTrait,
@@ -57,6 +61,8 @@ fn rewrite_programmable_transaction_for_coin_reservations(
             // 2. The scheduler reserves funds before allowing the transaction to execute. If the
             //    accumulator were deleted (balance dropped to 0), the reservation would fail and
             //    the transaction would not enter execution.
+            // 3. During checkpoint replay with MVCC, we read the accumulator at the version before
+            //    any settlement transactions have modified it.
             let withdraw = coin_reservation_resolver
                 .resolve_funds_withdrawal(sender, parsed, accumulator_version)
                 .unwrap();

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1916,13 +1916,19 @@ impl AuthorityState {
         Vec<ExecutionTiming>,
         Result<(), ExecutionError>,
     ) {
-        let rewritten_inputs = rewrite_transaction_for_coin_reservations(
-            self.chain_identifier,
-            &*self.coin_reservation_resolver,
-            sender,
-            &mut kind,
-            accumulator_version,
-        );
+        // Skip rewriting if execution_params already indicates an error - the transaction will fail
+        // anyway, and trying to rewrite could fail if the accumulator was deleted.
+        let rewritten_inputs = if execution_params.is_ok() {
+            rewrite_transaction_for_coin_reservations(
+                self.chain_identifier,
+                &*self.coin_reservation_resolver,
+                sender,
+                &mut kind,
+                accumulator_version,
+            )
+        } else {
+            None
+        };
 
         let (inner_temp_store, gas_status, effects, timings, execution_error) = executor
             // TODO only run this function on FullNodes, use `execute_transaction_to_effects` on validators.

--- a/crates/sui-core/src/execution_scheduler/execution_scheduler_impl.rs
+++ b/crates/sui-core/src/execution_scheduler/execution_scheduler_impl.rs
@@ -5,6 +5,7 @@ use crate::{
     accumulators::funds_read::AccountFundsRead,
     authority::{
         AuthorityMetrics, ExecutionEnv, authority_per_epoch_store::AuthorityPerEpochStore,
+        epoch_start_configuration::EpochStartConfigTrait,
         shared_object_version_manager::Schedulable,
     },
     execution_cache::{ObjectCacheRead, TransactionCacheRead},
@@ -207,7 +208,7 @@ impl ExecutionScheduler {
         let input_object_kinds = tx_data
             .input_objects()
             .expect("input_objects() cannot fail");
-        let input_object_keys: Vec<_> = epoch_store
+        let mut input_object_keys: Vec<_> = epoch_store
             .get_input_object_keys(
                 &cert.key(),
                 &input_object_kinds,
@@ -215,6 +216,21 @@ impl ExecutionScheduler {
             )
             .into_iter()
             .collect();
+
+        // Coin reservation transactions need to wait for the accumulator root object
+        // to reach the assigned accumulator version. This ensures settlement transactions
+        // (which create/update accumulator account objects) execute before coin reservation
+        // transactions that depend on those objects.
+        if tx_data.kind().has_coin_reservations()
+            && let Some(accumulator_version) = execution_env.assigned_versions.accumulator_version
+            && let Some(initial_shared_version) =
+                (**epoch_store.epoch_start_config()).accumulator_root_obj_initial_shared_version()
+        {
+            input_object_keys.push(InputKey::VersionedObject {
+                id: FullObjectID::new(SUI_ACCUMULATOR_ROOT_OBJECT_ID, Some(initial_shared_version)),
+                version: accumulator_version,
+            });
+        }
 
         let receiving_object_keys: HashSet<_> = tx_data
             .receiving_objects()

--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -2101,6 +2101,10 @@ impl TransactionKind {
         Either::Right(pt.coin_reservation_obj_refs())
     }
 
+    pub fn has_coin_reservations(&self) -> bool {
+        self.get_coin_reservation_obj_refs().next().is_some()
+    }
+
     pub fn validity_check(&self, config: &ProtocolConfig) -> UserInputResult {
         match self {
             TransactionKind::ProgrammableTransaction(p) => p.validity_check(config)?,


### PR DESCRIPTION
## Summary
Cherry-pick of https://github.com/MystenLabs/sui/pull/26337 to the 1.71 release branch.

Original commit: 6914bde36b

Fixes panics in coin reservation transactions during checkpoint replay by:
1. Not caching not-found errors in CachingCoinReservationResolver
2. Skipping transaction rewriting on early execution error
3. Adding accumulator root as input dependency for coin reservation transactions so the scheduler waits for settlements to complete first

🤖 Generated with [Claude Code](https://claude.com/claude-code)