### PR TITLE
Cache permanent errors in CachingCoinReservationResolver

### DIFF
--- a/crates/sui-core/src/accumulators/coin_reservations.rs
+++ b/crates/sui-core/src/accumulators/coin_reservations.rs
@@ -19,7 +19,7 @@ use sui_types::{
 /// of (owner, type_tag) for each accumulator object ID.
 pub struct CachingCoinReservationResolver {
     inner: CoinReservationResolver,
-    cache: MokaCache<ObjectID, (SuiAddress, TypeTag)>,
+    cache: MokaCache<ObjectID, UserInputResult<(SuiAddress, TypeTag)>>,
 }
 
 impl CachingCoinReservationResolver {
@@ -36,22 +36,33 @@ impl CachingCoinReservationResolver {
         accumulator_version: Option<SequenceNumber>,
     ) -> UserInputResult<(SuiAddress, TypeTag)> {
         // Owner and type_tag never change once the object exists, so successful
-        // lookups are always coherent.
+        // lookups are always coherent. Errors other than "not found" (e.g. the
+        // object exists but is not a balance accumulator field) are also
+        // permanent for a given object_id and so safe to cache.
         //
-        // Don't cache errors — the only expected error is "not found", which is
-        // transient: the accumulator object may not exist on this node yet but
-        // will appear once the settlement transaction executes. Caching a
-        // transient not-found would poison the cache for all subsequent lookups.
-        if let Some(value) = self.cache.get(&object_id) {
-            return Ok(value);
+        // Don't cache "not found": the accumulator object may not exist on this
+        // node yet but will appear once the settlement transaction executes.
+        // Caching a transient not-found would poison the cache for all
+        // subsequent lookups of that id.
+        if let Some(cached) = self.cache.get(&object_id) {
+            return cached;
         }
-        let result = self
+        match self
             .inner
-            .get_owner_and_type_for_object(object_id, accumulator_version);
-        if let Ok(value) = &result {
-            self.cache.insert(object_id, value.clone());
+            .get_owner_and_type_for_object(object_id, accumulator_version)
+        {
+            Ok(Some(value)) => {
+                self.cache.insert(object_id, Ok(value.clone()));
+                Ok(value)
+            }
+            Ok(None) => Err(UserInputError::InvalidWithdrawReservation {
+                error: format!("coin reservation object id {} not found", object_id),
+            }),
+            Err(e) => {
+                self.cache.insert(object_id, Err(e.clone()));
+                Err(e)
+            }
         }
-        result
     }
 
     pub fn resolve_funds_withdrawal(

--- a/crates/sui-types/src/coin_reservation.rs
+++ b/crates/sui-types/src/coin_reservation.rs
@@ -219,19 +219,24 @@ impl CoinReservationResolver {
     }
 
     /// Looks up the type tag and owner for a given accumulator object ID.
-    /// Returns (owner, type_tag) if the object exists and is a valid balance accumulator field.
+    /// Returns `Ok(Some((owner, type_tag)))` if the object exists and is a valid balance
+    /// accumulator field, `Ok(None)` if the object does not exist (a transient condition
+    /// on this node), and `Err(_)` for any other failure (which is permanent for this
+    /// `object_id` and therefore safe to cache).
     pub fn get_owner_and_type_for_object(
         &self,
         object_id: ObjectID,
         accumulator_version: Option<SequenceNumber>,
-    ) -> UserInputResult<(SuiAddress, TypeTag)> {
-        let object = AccumulatorValue::load_object_by_id(
+    ) -> UserInputResult<Option<(SuiAddress, TypeTag)>> {
+        let Some(object) = AccumulatorValue::load_object_by_id(
             self.child_object_resolver.as_ref(),
             accumulator_version,
             object_id,
         )
         .map_err(|e| invalid_res_error!("could not load coin reservation object id {}", e))?
-        .ok_or_else(|| invalid_res_error!("coin reservation object id {} not found", object_id))?;
+        else {
+            return Ok(None);
+        };
 
         let move_object = object.data.try_as_move().unwrap();
 
@@ -249,7 +254,7 @@ impl CoinReservationResolver {
             .try_into()
             .map_err(|e| invalid_res_error!("could not load coin reservation object id {}", e))?;
 
-        Ok((key.owner, type_tag))
+        Ok(Some((key.owner, type_tag)))
     }
 
     pub fn resolve_funds_withdrawal(
@@ -258,10 +263,17 @@ impl CoinReservationResolver {
         coin_reservation: ParsedObjectRefWithdrawal,
         accumulator_version: Option<SequenceNumber>,
     ) -> UserInputResult<FundsWithdrawalArg> {
-        let (owner, type_tag) = self.get_owner_and_type_for_object(
-            coin_reservation.unmasked_object_id,
-            accumulator_version,
-        )?;
+        let (owner, type_tag) = self
+            .get_owner_and_type_for_object(
+                coin_reservation.unmasked_object_id,
+                accumulator_version,
+            )?
+            .ok_or_else(|| {
+                invalid_res_error!(
+                    "coin reservation object id {} not found",
+                    coin_reservation.unmasked_object_id
+                )
+            })?;
 
         if sender != owner {
             return Err(invalid_res_error!(


### PR DESCRIPTION
## Summary
- `CoinReservationResolver::get_owner_and_type_for_object` now returns `UserInputResult<Option<(SuiAddress, TypeTag)>>`, so \"object not found\" is `Ok(None)` rather than an error.
- `CachingCoinReservationResolver::get_owner_and_type_cached` caches both successful lookups *and* permanent errors (e.g. the object exists but is not a balance accumulator field). \"Not found\" is converted to a fresh `InvalidWithdrawReservation` error and never cached, so the cache cannot be poisoned by a transient missing-on-this-node condition.

## Test plan
- [x] `cargo check -p sui-types -p sui-core`
- [x] `cargo xclippy` in `crates/sui-types` and `crates/sui-core`
- [x] Seed search: `./scripts/simtest/seed-search.py --test simtest test::test_coin_reservation_checkpoint_replay --exact --num-seeds 200` — 200/200 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)