### PR TITLE
Optimize tracing overhead: global callsite filter + send_funds benchmark

### DIFF
--- a/crates/sui-node/src/main.rs
+++ b/crates/sui-node/src/main.rs
@@ -84,6 +84,7 @@ fn main() {
     let (_guard, filter_handle) = telemetry_subscribers::TelemetryConfig::new()
         .with_env()
         .with_prom_registry(&prometheus_registry)
+        .with_disable_span_latency(true)
         .init();
 
     drop(metrics_rt);

--- a/crates/sui-single-node-benchmark/src/benchmark_context.rs
+++ b/crates/sui-single-node-benchmark/src/benchmark_context.rs
@@ -15,10 +15,14 @@ use std::ops::Deref;
 use std::sync::Arc;
 use sui_config::node::RunWithRange;
 use sui_core::authority::shared_object_version_manager::{AssignedTxAndVersions, AssignedVersions};
-use sui_test_transaction_builder::PublishData;
+use sui_test_transaction_builder::{PublishData, TestTransactionBuilder};
 use sui_types::base_types::{ObjectID, ObjectRef, SequenceNumber, SuiAddress};
+use sui_types::digests::ChainIdentifier;
 use sui_types::effects::{TransactionEffects, TransactionEffectsAPI};
-use sui_types::transaction::Transaction;
+use sui_types::gas_coin::GAS;
+use sui_types::transaction::DEFAULT_VALIDATOR_GAS_PRICE;
+use sui_types::transaction::{Argument, Command, Transaction};
+use sui_types::{Identifier, SUI_FRAMEWORK_PACKAGE_ID};
 use tracing::{info, warn};
 
 pub struct BenchmarkContext {
@@ -465,6 +469,80 @@ impl BenchmarkContext {
             let results: Vec<_> = tasks.collect().await;
             results.into_iter().map(|r| r.unwrap()).collect()
         }
+    }
+
+    pub(crate) fn get_chain_identifier(&self) -> ChainIdentifier {
+        self.validator.get_validator().get_chain_identifier()
+    }
+
+    pub(crate) fn get_epoch(&self) -> u64 {
+        self.validator.get_epoch()
+    }
+
+    /// Seed each user account's address balance by splitting from their gas coin,
+    /// converting to a Balance, and calling send_funds to self.
+    pub(crate) async fn seed_address_balances(&mut self, seed_amount: u64) {
+        info!(
+            "Seeding address balances with {} MIST for {} accounts",
+            seed_amount,
+            self.user_accounts.len()
+        );
+
+        let transactions: Vec<_> = self
+            .user_accounts
+            .values()
+            .map(|account| {
+                let gas_object = account.gas_objects[0];
+                let mut tx_builder = TestTransactionBuilder::new(
+                    account.sender,
+                    gas_object,
+                    DEFAULT_VALIDATOR_GAS_PRICE,
+                );
+                {
+                    let builder = tx_builder.ptb_builder_mut();
+                    let amount_arg = builder.pure(seed_amount).unwrap();
+                    let coin =
+                        builder.command(Command::SplitCoins(Argument::GasCoin, vec![amount_arg]));
+                    let Argument::Result(coin_idx) = coin else {
+                        panic!("SplitCoins should return Result");
+                    };
+                    let coin = Argument::NestedResult(coin_idx, 0);
+                    let coin_balance = builder.programmable_move_call(
+                        SUI_FRAMEWORK_PACKAGE_ID,
+                        Identifier::new("coin").unwrap(),
+                        Identifier::new("into_balance").unwrap(),
+                        vec![GAS::type_tag()],
+                        vec![coin],
+                    );
+                    let recipient_arg = builder.pure(account.sender).unwrap();
+                    builder.programmable_move_call(
+                        SUI_FRAMEWORK_PACKAGE_ID,
+                        Identifier::new("balance").unwrap(),
+                        Identifier::new("send_funds").unwrap(),
+                        vec![GAS::type_tag()],
+                        vec![coin_balance, recipient_arg],
+                    );
+                }
+                tx_builder.build_and_sign(account.keypair.as_ref())
+            })
+            .collect();
+
+        let results = self.execute_raw_transactions(transactions).await;
+        let mut new_gas_objects = HashMap::new();
+        let cache_commit = self.validator.get_validator().get_cache_commit().clone();
+        for effects in results {
+            let batch = cache_commit
+                .build_db_batch(effects.executed_epoch(), &[*effects.transaction_digest()]);
+            cache_commit.commit_transaction_outputs(
+                effects.executed_epoch(),
+                batch,
+                &[*effects.transaction_digest()],
+            );
+            let gas_object = effects.gas_object().unwrap().0;
+            new_gas_objects.insert(gas_object.0, gas_object);
+        }
+        self.refresh_gas_objects(new_gas_objects);
+        info!("Finished seeding address balances");
     }
 
     fn refresh_gas_objects(&mut self, mut new_gas_objects: HashMap<ObjectID, ObjectRef>) {

--- a/crates/sui-single-node-benchmark/src/benchmark_context.rs
+++ b/crates/sui-single-node-benchmark/src/benchmark_context.rs
@@ -256,17 +256,21 @@ impl BenchmarkContext {
         );
 
         let is_consensus_tx = transactions.iter().any(|tx| tx.is_consensus_tx());
+        let mut durations: Vec<std::time::Duration>;
         if is_consensus_tx {
+            durations = Vec::with_capacity(tx_count);
             // With shared objects, we must execute each transaction in order.
             for transaction in transactions {
                 let key = transaction.key();
-                self.validator
+                let (_, dur) = self
+                    .validator
                     .execute_transaction(
                         transaction,
                         assigned_versions.get(&key).unwrap(),
                         self.benchmark_component,
                     )
                     .await;
+                durations.push(dur);
             }
         } else {
             let tasks: FuturesUnordered<_> = transactions
@@ -286,9 +290,7 @@ impl BenchmarkContext {
                 })
                 .collect();
             let results: Vec<_> = tasks.collect().await;
-            results.into_iter().for_each(|r| {
-                r.unwrap();
-            });
+            durations = results.into_iter().map(|r| r.unwrap().1).collect();
         }
 
         let elapsed = start_time.elapsed().as_millis() as f64 / 1000f64;
@@ -297,6 +299,8 @@ impl BenchmarkContext {
             elapsed,
             tx_count as f64 / elapsed
         );
+
+        Self::print_per_tx_timing(&mut durations);
     }
 
     pub(crate) async fn benchmark_transaction_execution_in_memory(
@@ -330,6 +334,23 @@ impl BenchmarkContext {
             elapsed,
             tx_count as f64 / elapsed,
             in_memory_store.get_num_object_reads() as f64 / tx_count as f64
+        );
+    }
+
+    fn print_per_tx_timing(durations: &mut [std::time::Duration]) {
+        durations.sort();
+        let n = durations.len();
+        let total: std::time::Duration = durations.iter().sum();
+        let avg = total / n as u32;
+        let p50 = durations[n / 2];
+        let p90 = durations[n * 90 / 100];
+        let p99 = durations[n * 99 / 100];
+        let min = durations[0];
+        let max = durations[n - 1];
+        info!(
+            "Per-tx execution timing (try_execute_immediately wall-clock):\n  \
+             avg={:?}  min={:?}  p50={:?}  p90={:?}  p99={:?}  max={:?}",
+            avg, min, p50, p90, p99, max,
         );
     }
 

--- a/crates/sui-single-node-benchmark/src/command.rs
+++ b/crates/sui-single-node-benchmark/src/command.rs
@@ -135,6 +135,23 @@ pub enum WorkloadKind {
         )]
         manifest_file: PathBuf,
     },
+    /// Benchmark send_funds transactions that withdraw from the sender's address
+    /// balance and deposit to a recipient via balance::send_funds.
+    /// Gas is paid from address balance.
+    SendFunds {
+        #[arg(
+            long,
+            default_value_t = 100_000_000_000,
+            help = "Amount of MIST to seed each sender's address balance with"
+        )]
+        seed_amount: u64,
+        #[arg(
+            long,
+            default_value_t = 1000,
+            help = "Amount of MIST to transfer per send_funds transaction"
+        )]
+        transfer_amount: u64,
+    },
 }
 
 impl WorkloadKind {
@@ -143,6 +160,8 @@ impl WorkloadKind {
             // Each transaction will always have 1 gas object, plus the number of owned objects that will be transferred.
             WorkloadKind::PTB { num_transfers, .. } => *num_transfers + 1,
             WorkloadKind::Publish { .. } => 1,
+            // 1 gas object used during the seeding phase; benchmark transactions use address balance gas.
+            WorkloadKind::SendFunds { .. } => 1,
         }
     }
 }

--- a/crates/sui-single-node-benchmark/src/single_node.rs
+++ b/crates/sui-single-node-benchmark/src/single_node.rs
@@ -81,6 +81,10 @@ impl SingleValidator {
         self.validator_service.validator_state()
     }
 
+    pub fn get_epoch(&self) -> u64 {
+        self.epoch_store.epoch()
+    }
+
     /// Publish a package, returns the package object and the updated gas object.
     pub async fn publish_package(
         &self,

--- a/crates/sui-single-node-benchmark/src/single_node.rs
+++ b/crates/sui-single-node-benchmark/src/single_node.rs
@@ -149,8 +149,9 @@ impl SingleValidator {
         transaction: Transaction,
         assigned_versions: &AssignedVersions,
         component: Component,
-    ) -> TransactionEffects {
+    ) -> (TransactionEffects, std::time::Duration) {
         let executable = self.create_executable(transaction);
+        let start = std::time::Instant::now();
         let effects = match component {
             Component::Baseline => {
                 self.get_validator()
@@ -191,8 +192,9 @@ impl SingleValidator {
                 unreachable!()
             }
         };
+        let elapsed = start.elapsed();
         assert!(effects.status().is_ok());
-        effects
+        (effects, elapsed)
     }
 
     pub(crate) async fn execute_transaction_in_memory(

--- a/crates/sui-single-node-benchmark/src/tx_generator.rs
+++ b/crates/sui-single-node-benchmark/src/tx_generator.rs
@@ -5,12 +5,14 @@ use crate::mock_account::Account;
 pub use move_tx_generator::MoveTxGenerator;
 pub use package_publish_tx_generator::PackagePublishTxGenerator;
 pub use root_object_create_tx_generator::RootObjectCreateTxGenerator;
+pub use send_funds_tx_generator::SendFundsTxGenerator;
 pub use shared_object_create_tx_generator::SharedObjectCreateTxGenerator;
 use sui_types::transaction::Transaction;
 
 mod move_tx_generator;
 mod package_publish_tx_generator;
 mod root_object_create_tx_generator;
+mod send_funds_tx_generator;
 mod shared_object_create_tx_generator;
 
 pub(crate) trait TxGenerator: Send + Sync {

--- a/crates/sui-single-node-benchmark/src/tx_generator/send_funds_tx_generator.rs
+++ b/crates/sui-single-node-benchmark/src/tx_generator/send_funds_tx_generator.rs
@@ -1,0 +1,76 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::mock_account::Account;
+use crate::tx_generator::TxGenerator;
+use move_core_types::identifier::Identifier;
+use std::sync::atomic::{AtomicU32, Ordering};
+use sui_test_transaction_builder::TestTransactionBuilder;
+use sui_types::SUI_FRAMEWORK_PACKAGE_ID;
+use sui_types::digests::ChainIdentifier;
+use sui_types::gas_coin::GAS;
+use sui_types::transaction::{DEFAULT_VALIDATOR_GAS_PRICE, FundsWithdrawalArg, Transaction};
+
+pub struct SendFundsTxGenerator {
+    chain_identifier: ChainIdentifier,
+    epoch: u64,
+    transfer_amount: u64,
+    nonce_counter: AtomicU32,
+}
+
+impl SendFundsTxGenerator {
+    pub fn new(chain_identifier: ChainIdentifier, epoch: u64, transfer_amount: u64) -> Self {
+        Self {
+            chain_identifier,
+            epoch,
+            transfer_amount,
+            nonce_counter: AtomicU32::new(0),
+        }
+    }
+}
+
+impl TxGenerator for SendFundsTxGenerator {
+    fn generate_tx(&self, account: Account) -> Transaction {
+        let nonce = self.nonce_counter.fetch_add(1, Ordering::Relaxed);
+        let (recipient, _) = sui_types::crypto::get_key_pair::<sui_types::crypto::AccountKeyPair>();
+
+        let mut tx_builder = TestTransactionBuilder::new_with_address_balance_gas(
+            account.sender,
+            DEFAULT_VALIDATOR_GAS_PRICE,
+            self.chain_identifier,
+            self.epoch,
+            nonce,
+        );
+
+        {
+            let builder = tx_builder.ptb_builder_mut();
+
+            let withdrawal =
+                FundsWithdrawalArg::balance_from_sender(self.transfer_amount, GAS::type_tag());
+            let withdrawal_result = builder.funds_withdrawal(withdrawal).unwrap();
+
+            let balance = builder.programmable_move_call(
+                SUI_FRAMEWORK_PACKAGE_ID,
+                Identifier::new("balance").unwrap(),
+                Identifier::new("redeem_funds").unwrap(),
+                vec![GAS::type_tag()],
+                vec![withdrawal_result],
+            );
+
+            let recipient_arg = builder.pure(recipient).unwrap();
+            builder.programmable_move_call(
+                SUI_FRAMEWORK_PACKAGE_ID,
+                Identifier::new("balance").unwrap(),
+                Identifier::new("send_funds").unwrap(),
+                vec![GAS::type_tag()],
+                vec![balance, recipient_arg],
+            );
+        }
+
+        tx_builder.build_and_sign(account.keypair.as_ref())
+    }
+
+    fn name(&self) -> &'static str {
+        "SendFunds Transaction Generator"
+    }
+}

--- a/crates/sui-single-node-benchmark/src/workload.rs
+++ b/crates/sui-single-node-benchmark/src/workload.rs
@@ -3,7 +3,9 @@
 
 use crate::benchmark_context::BenchmarkContext;
 use crate::command::WorkloadKind;
-use crate::tx_generator::{MoveTxGenerator, PackagePublishTxGenerator, TxGenerator};
+use crate::tx_generator::{
+    MoveTxGenerator, PackagePublishTxGenerator, SendFundsTxGenerator, TxGenerator,
+};
 use std::path::PathBuf;
 use std::sync::Arc;
 use sui_test_transaction_builder::PublishData;
@@ -69,6 +71,19 @@ impl Workload {
             WorkloadKind::Publish {
                 manifest_file: manifest_path,
             } => Arc::new(PackagePublishTxGenerator::new(ctx, manifest_path.clone()).await),
+            WorkloadKind::SendFunds {
+                seed_amount,
+                transfer_amount,
+            } => {
+                ctx.seed_address_balances(*seed_amount).await;
+                let chain_identifier = ctx.get_chain_identifier();
+                let epoch = ctx.get_epoch();
+                Arc::new(SendFundsTxGenerator::new(
+                    chain_identifier,
+                    epoch,
+                    *transfer_amount,
+                ))
+            }
         }
     }
 }

--- a/crates/sui-single-node-benchmark/tests/smoke_tests.rs
+++ b/crates/sui-single-node-benchmark/tests/smoke_tests.rs
@@ -110,6 +110,25 @@ async fn benchmark_publish_from_source() {
 }
 
 #[sim_test]
+async fn benchmark_send_funds_smoke_test() {
+    for component in Component::iter() {
+        run_benchmark(
+            Workload::new(
+                10,
+                WorkloadKind::SendFunds {
+                    seed_amount: 100_000_000_000,
+                    transfer_amount: 1000,
+                },
+            ),
+            component,
+            1000,
+            false,
+        )
+        .await;
+    }
+}
+
+#[sim_test]
 async fn benchmark_publish_from_bytecode() {
     // This test makes sure that the benchmark runs.
     let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));

--- a/crates/telemetry-subscribers/src/lib.rs
+++ b/crates/telemetry-subscribers/src/lib.rs
@@ -42,26 +42,65 @@ mod file_exporter;
 pub mod span_latency_prom;
 mod test_layer;
 
-/// Global filter layer that rejects spans above a given level at callsite registration time.
+/// Global filter layer that rejects callsites above the configured levels at registration time.
 ///
 /// Without this, per-layer filtering causes the Registry to return `Interest::always()` for
 /// every callsite. That means trace-level `#[instrument]` spans are allocated in the slab,
 /// have their per-layer filters walked, and are immediately discarded — all at significant cost.
+/// The same applies to events below the env filter threshold.
 ///
-/// By rejecting high-verbosity span callsites globally, `Span::new` short-circuits to
-/// `Span::none()` for free.
-///
-/// Events are always passed through so that per-layer log filters work as before.
-struct SpanLevelGlobalFilter {
+/// By rejecting high-verbosity callsites globally, `Span::new` short-circuits to
+/// `Span::none()` and event macros short-circuit before formatting arguments.
+struct GlobalLevelFilter {
     max_span_level: Level,
+    /// The maximum event level any layer will accept. Loaded from the EnvFilter's
+    /// max_level_hint and updated via a shared atomic when the filter is reloaded.
+    max_event_level: Arc<std::sync::atomic::AtomicU8>,
 }
 
-impl<S: tracing::Subscriber> Layer<S> for SpanLevelGlobalFilter {
+impl GlobalLevelFilter {
+    fn load_max_event_level(&self) -> LevelFilter {
+        level_filter_from_u8(self.max_event_level.load(Ordering::Relaxed))
+    }
+
+    fn exceeds_max_level(&self, metadata: &tracing::Metadata<'_>) -> bool {
+        if metadata.is_span() {
+            *metadata.level() > self.max_span_level
+        } else {
+            let max = self.load_max_event_level();
+            !max.eq(&LevelFilter::OFF) && LevelFilter::from_level(*metadata.level()) > max
+        }
+    }
+}
+
+fn level_filter_to_u8(lf: LevelFilter) -> u8 {
+    match lf {
+        LevelFilter::OFF => 0,
+        LevelFilter::ERROR => 1,
+        LevelFilter::WARN => 2,
+        LevelFilter::INFO => 3,
+        LevelFilter::DEBUG => 4,
+        LevelFilter::TRACE => 5,
+    }
+}
+
+fn level_filter_from_u8(v: u8) -> LevelFilter {
+    match v {
+        0 => LevelFilter::OFF,
+        1 => LevelFilter::ERROR,
+        2 => LevelFilter::WARN,
+        3 => LevelFilter::INFO,
+        4 => LevelFilter::DEBUG,
+        _ => LevelFilter::TRACE,
+    }
+}
+
+impl<S: tracing::Subscriber> Layer<S> for GlobalLevelFilter {
     fn register_callsite(
         &self,
         metadata: &'static tracing::Metadata<'static>,
     ) -> tracing::subscriber::Interest {
-        if metadata.is_span() && *metadata.level() > self.max_span_level {
+        if self.exceeds_max_level(metadata) {
             tracing::subscriber::Interest::never()
         } else {
             tracing::subscriber::Interest::always()
@@ -73,7 +112,13 @@ impl<S: tracing::Subscriber> Layer<S> for SpanLevelGlobalFilter {
         metadata: &tracing::Metadata<'_>,
         _ctx: tracing_subscriber::layer::Context<'_, S>,
     ) -> bool {
-        !metadata.is_span() || *metadata.level() <= self.max_span_level
+        !self.exceeds_max_level(metadata)
+    }
+
+    fn max_level_hint(&self) -> Option<LevelFilter> {
+        let span = LevelFilter::from_level(self.max_span_level);
+        let event = self.load_max_event_level();
+        Some(std::cmp::max(span, event))
     }
 }
 
@@ -154,17 +199,26 @@ impl Drop for TelemetryGuards {
 }
 
 #[derive(Clone, Debug)]
-pub struct FilterHandle(reload::Handle<EnvFilter, Registry>);
+pub struct FilterHandle {
+    reload: reload::Handle<EnvFilter, Registry>,
+    /// Shared with GlobalLevelFilter so that reloading the env filter also
+    /// updates the global event-level gate.
+    max_event_level: Option<Arc<std::sync::atomic::AtomicU8>>,
+}
 
 impl FilterHandle {
     pub fn update<S: AsRef<str>>(&self, directives: S) -> Result<(), BoxError> {
         let filter = EnvFilter::try_new(directives)?;
-        self.0.reload(filter)?;
+        if let Some(ref max_level) = self.max_event_level {
+            let hint = filter.max_level_hint().unwrap_or(LevelFilter::TRACE);
+            max_level.store(level_filter_to_u8(hint), Ordering::Relaxed);
+        }
+        self.reload.reload(filter)?;
         Ok(())
     }
 
     pub fn get(&self) -> Result<String, BoxError> {
-        self.0
+        self.reload
             .with_current(|filter| filter.to_string())
             .map_err(Into::into)
     }
@@ -452,8 +506,14 @@ impl TelemetryConfig {
         }
         let env_filter =
             EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(directives));
+        let max_event_level = Arc::new(std::sync::atomic::AtomicU8::new(level_filter_to_u8(
+            env_filter.max_level_hint().unwrap_or(LevelFilter::TRACE),
+        )));
         let (log_filter, reload_handle) = reload::Layer::new(env_filter);
-        let log_filter_handle = FilterHandle(reload_handle);
+        let log_filter_handle = FilterHandle {
+            reload: reload_handle,
+            max_event_level: Some(max_event_level.clone()),
+        };
 
         // Separate span level filter.
         // This is a dumb filter for now - allows all spans that are below a given level.
@@ -547,7 +607,10 @@ impl TelemetryConfig {
 
             let trace_env_filter = EnvFilter::try_from_env("TRACE_FILTER").unwrap();
             let (trace_env_filter, reload_handle) = reload::Layer::new(trace_env_filter);
-            trace_filter_handle = Some(FilterHandle(reload_handle));
+            trace_filter_handle = Some(FilterHandle {
+                reload: reload_handle,
+                max_event_level: None,
+            });
 
             layers.push(telemetry.with_filter(trace_env_filter).boxed());
         }
@@ -609,12 +672,14 @@ impl TelemetryConfig {
             None
         };
 
-        // Global span-level filter: rejects span callsites above span_level at
-        // registration time, preventing the Registry from allocating spans that
-        // every per-layer filter would immediately discard.
+        // Global level filter: rejects span callsites above span_level and event
+        // callsites above the env filter's max level at registration time, preventing
+        // the Registry from dispatching callsites that every per-layer filter would
+        // immediately discard.
         layers.push(
-            SpanLevelGlobalFilter {
+            GlobalLevelFilter {
                 max_span_level: span_level,
+                max_event_level,
             }
             .boxed(),
         );

--- a/crates/telemetry-subscribers/src/lib.rs
+++ b/crates/telemetry-subscribers/src/lib.rs
@@ -70,6 +70,8 @@ pub struct TelemetryConfig {
     pub crash_on_panic: bool,
     /// Optional Prometheus registry - if present, all enabled span latencies are measured
     pub prom_registry: Option<prometheus::Registry>,
+    /// Disable the PrometheusSpanLatencyLayer even when a prom_registry is set.
+    pub disable_span_latency: bool,
     pub sample_rate: f64,
     /// Add directive to include trace logs with provided target
     pub trace_target: Option<Vec<String>>,
@@ -284,6 +286,7 @@ impl TelemetryConfig {
             panic_hook: true,
             crash_on_panic: false,
             prom_registry: None,
+            disable_span_latency: false,
             sample_rate: 1.0,
             trace_target: None,
             user_info_target: Vec::new(),
@@ -315,6 +318,11 @@ impl TelemetryConfig {
 
     pub fn with_prom_registry(mut self, registry: &prometheus::Registry) -> Self {
         self.prom_registry = Some(registry.clone());
+        self
+    }
+
+    pub fn with_disable_span_latency(mut self, disable: bool) -> Self {
+        self.disable_span_latency = disable;
         self
     }
 
@@ -430,9 +438,11 @@ impl TelemetryConfig {
         }
 
         if let Some(registry) = config.prom_registry {
-            let span_lat_layer = PrometheusSpanLatencyLayer::try_new(&registry, 15)
-                .expect("Could not initialize span latency layer");
-            layers.push(span_lat_layer.with_filter(span_filter.clone()).boxed());
+            if !config.disable_span_latency {
+                let span_lat_layer = PrometheusSpanLatencyLayer::try_new(&registry, 15)
+                    .expect("Could not initialize span latency layer");
+                layers.push(span_lat_layer.with_filter(span_filter.clone()).boxed());
+            }
         }
 
         let mut trace_filter_handle = None;

--- a/crates/telemetry-subscribers/src/lib.rs
+++ b/crates/telemetry-subscribers/src/lib.rs
@@ -52,7 +52,7 @@ mod test_layer;
 /// By rejecting high-verbosity callsites globally, `Span::new` short-circuits to
 /// `Span::none()` and event macros short-circuit before formatting arguments.
 struct GlobalLevelFilter {
-    max_span_level: Level,
+    max_span_level: LevelFilter,
     /// The maximum event level any layer will accept. Loaded from the EnvFilter's
     /// max_level_hint and updated via a shared atomic when the filter is reloaded.
     max_event_level: Arc<std::sync::atomic::AtomicU8>,
@@ -65,7 +65,7 @@ impl GlobalLevelFilter {
 
     fn exceeds_max_level(&self, metadata: &tracing::Metadata<'_>) -> bool {
         if metadata.is_span() {
-            *metadata.level() > self.max_span_level
+            LevelFilter::from_level(*metadata.level()) > self.max_span_level
         } else {
             let max = self.load_max_event_level();
             !max.eq(&LevelFilter::OFF) && LevelFilter::from_level(*metadata.level()) > max
@@ -115,9 +115,8 @@ impl<S: tracing::Subscriber> Layer<S> for GlobalLevelFilter {
     }
 
     fn max_level_hint(&self) -> Option<LevelFilter> {
-        let span = LevelFilter::from_level(self.max_span_level);
         let event = self.load_max_event_level();
-        Some(std::cmp::max(span, event))
+        Some(std::cmp::max(self.max_span_level, event))
     }
 }
 
@@ -140,9 +139,9 @@ pub struct TelemetryConfig {
     pub log_file: Option<String>,
     /// Log level to set, defaults to info
     pub log_string: Option<String>,
-    /// Span level - what level of spans should be created.  Note this is not same as logging level
-    /// If set to None, then defaults to INFO
-    pub span_level: Option<Level>,
+    /// Span level - what level of spans should be created.  Note this is not same as logging level.
+    /// If set to None, then defaults to INFO. Use LevelFilter::OFF to disable all spans.
+    pub span_level: Option<LevelFilter>,
     /// Set a panic hook
     pub panic_hook: bool,
     /// Crash on panic
@@ -395,7 +394,7 @@ impl TelemetryConfig {
     }
 
     pub fn with_span_level(mut self, span_level: Level) -> Self {
-        self.span_level = Some(span_level);
+        self.span_level = Some(LevelFilter::from_level(span_level));
         self
     }
 
@@ -469,7 +468,7 @@ impl TelemetryConfig {
 
         if let Ok(span_level) = env::var("TOKIO_SPAN_LEVEL") {
             self.span_level =
-                Some(Level::from_str(&span_level).expect("Cannot parse TOKIO_SPAN_LEVEL"));
+                Some(LevelFilter::from_str(&span_level).expect("Cannot parse TOKIO_SPAN_LEVEL"));
         }
 
         if let Ok(filepath) = env::var("RUST_LOG_FILE") {
@@ -517,9 +516,11 @@ impl TelemetryConfig {
         // Separate span level filter.
         // This is a dumb filter for now - allows all spans that are below a given level.
         // TODO: implement a sampling filter
-        let span_level = config.span_level.unwrap_or(Level::INFO);
+        let span_level = config
+            .span_level
+            .unwrap_or(LevelFilter::from_level(Level::INFO));
         let span_filter = filter::filter_fn(move |metadata| {
-            metadata.is_span() && *metadata.level() <= span_level
+            metadata.is_span() && LevelFilter::from_level(*metadata.level()) <= span_level
         });
 
         let mut layers = Vec::new();

--- a/crates/telemetry-subscribers/src/lib.rs
+++ b/crates/telemetry-subscribers/src/lib.rs
@@ -103,16 +103,15 @@ impl<S: tracing::Subscriber> Layer<S> for GlobalLevelFilter {
         if self.exceeds_max_level(metadata) {
             tracing::subscriber::Interest::never()
         } else {
+            // Return always() for passing callsites. The final interest will be
+            // determined by the Registry (which returns sometimes() when per-layer
+            // filters are present). We intentionally do NOT override enabled() —
+            // doing so would add an extra check to every enabled() walk, which the
+            // per-layer filters already handle. For dynamic env filter reloads,
+            // rebuild_interest_cache() re-calls register_callsite with our updated
+            // atomic max_event_level.
             tracing::subscriber::Interest::always()
         }
-    }
-
-    fn enabled(
-        &self,
-        metadata: &tracing::Metadata<'_>,
-        _ctx: tracing_subscriber::layer::Context<'_, S>,
-    ) -> bool {
-        !self.exceeds_max_level(metadata)
     }
 
     fn max_level_hint(&self) -> Option<LevelFilter> {

--- a/crates/telemetry-subscribers/src/lib.rs
+++ b/crates/telemetry-subscribers/src/lib.rs
@@ -42,6 +42,41 @@ mod file_exporter;
 pub mod span_latency_prom;
 mod test_layer;
 
+/// Global filter layer that rejects spans above a given level at callsite registration time.
+///
+/// Without this, per-layer filtering causes the Registry to return `Interest::always()` for
+/// every callsite. That means trace-level `#[instrument]` spans are allocated in the slab,
+/// have their per-layer filters walked, and are immediately discarded — all at significant cost.
+///
+/// By rejecting high-verbosity span callsites globally, `Span::new` short-circuits to
+/// `Span::none()` for free.
+///
+/// Events are always passed through so that per-layer log filters work as before.
+struct SpanLevelGlobalFilter {
+    max_span_level: Level,
+}
+
+impl<S: tracing::Subscriber> Layer<S> for SpanLevelGlobalFilter {
+    fn register_callsite(
+        &self,
+        metadata: &'static tracing::Metadata<'static>,
+    ) -> tracing::subscriber::Interest {
+        if metadata.is_span() && *metadata.level() > self.max_span_level {
+            tracing::subscriber::Interest::never()
+        } else {
+            tracing::subscriber::Interest::always()
+        }
+    }
+
+    fn enabled(
+        &self,
+        metadata: &tracing::Metadata<'_>,
+        _ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) -> bool {
+        !metadata.is_span() || *metadata.level() <= self.max_span_level
+    }
+}
+
 /// Alias for a type-erased error type.
 pub type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
 
@@ -573,6 +608,16 @@ impl TelemetryConfig {
         } else {
             None
         };
+
+        // Global span-level filter: rejects span callsites above span_level at
+        // registration time, preventing the Registry from allocating spans that
+        // every per-layer filter would immediately discard.
+        layers.push(
+            SpanLevelGlobalFilter {
+                max_span_level: span_level,
+            }
+            .boxed(),
+        );
 
         let subscriber = tracing_subscriber::registry().with(layers);
         let subscriber_guard = if config.set_global_default {

--- a/external-crates/move/crates/move-vm-runtime/src/runtime/telemetry.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/runtime/telemetry.rs
@@ -3,11 +3,24 @@
 
 #![allow(clippy::cast_possible_truncation)]
 use std::{
-    sync::atomic::{AtomicU64, Ordering},
+    sync::atomic::{AtomicBool, AtomicU64, Ordering},
     time::Duration,
 };
 
 use crate::cache::move_cache::MoveCache;
+
+static TELEMETRY_ENABLED: AtomicBool = AtomicBool::new(true);
+static TELEMETRY_INIT: std::sync::Once = std::sync::Once::new();
+
+#[inline(always)]
+fn is_telemetry_enabled() -> bool {
+    TELEMETRY_INIT.call_once(|| {
+        if std::env::var("MOVE_VM_TELEMETRY_DISABLED").is_ok() {
+            TELEMETRY_ENABLED.store(false, Ordering::Relaxed);
+        }
+    });
+    TELEMETRY_ENABLED.load(Ordering::Relaxed)
+}
 
 // -------------------------------------------------------------------------------------------------
 // Types
@@ -217,7 +230,9 @@ impl TelemetryContext {
     {
         let mut txn_telemetry = TransactionTelemetryContext::new();
         let result = f(&mut txn_telemetry);
-        self.record_transaction(txn_telemetry);
+        if is_telemetry_enabled() {
+            self.record_transaction(txn_telemetry);
+        }
         result
     }
 


### PR DESCRIPTION
## Summary

- **Add `send_funds` workload to single-node benchmark** with per-tx `try_execute_immediately` wall-clock timing
- **Disable `PrometheusSpanLatencyLayer`** in sui-node (adds opt-in `with_disable_span_latency` config)
- **Add `GlobalLevelFilter`** to `telemetry-subscribers` — rejects trace/debug span and event callsites at `register_callsite()` time via `Interest::never()`, eliminating per-call `enabled()` walk overhead caused by per-layer filtering
- **Support `TOKIO_SPAN_LEVEL=off`** to fully disable span creation
- **Add `MOVE_VM_TELEMETRY_DISABLED` env var** to skip Move VM telemetry `record_transaction()` atomics

## Test plan

- [x] `cargo nextest run -p telemetry-subscribers` — 6/6 pass
- [x] `cargo nextest run -p sui-single-node-benchmark -- benchmark_send_funds_smoke_test` — pass
- [x] `cargo check -p sui-node`
- [ ] Verify reduced tracing overhead on production workload

🤖 Generated with [Claude Code](https://claude.com/claude-code)