### PR TITLE
[ci] Run graphql_subscription e2e tests under --features staging

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -224,7 +224,7 @@ jobs:
           swap-size-gb: 256
       - name: cargo test (sui-graphql staging)
         run: |
-          cargo nextest run --profile ci --cargo-quiet --features staging -E 'package(sui-indexer-alt-graphql)'
+          cargo nextest run --profile ci --cargo-quiet --features staging -E 'package(sui-indexer-alt-graphql) or (package(sui-indexer-alt-e2e-tests) and binary(graphql_subscription))'
       - name: doctests
         run: |
           cargo test --doc


### PR DESCRIPTION
## Summary
- `crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/main.rs` is gated behind `#![cfg(feature = "staging")]`, but no CI step was building that crate with `--features staging`. The integration test binary compiled to an empty binary and contributed zero tests to the run.
- Extend the existing `cargo test (sui-graphql staging)` filter to also match `binary(graphql_subscription)` in `sui-indexer-alt-e2e-tests`. The 10 e2e graphql_subscription tests now run in CI alongside the existing 145 sui-indexer-alt-graphql tests.

## Test plan
- [x] Verified locally with `cargo nextest list --features staging -E '...'` that the new filter matches all 10 graphql_subscription tests plus the 145 existing sui-indexer-alt-graphql tests.
- [ ] CI on this PR exercises the new step end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)