### PR TITLE
[consensus] track block children and per-round info in dag state

### DIFF
--- a/consensus/config/src/consensus_protocol_config.rs
+++ b/consensus/config/src/consensus_protocol_config.rs
@@ -25,6 +25,7 @@ pub struct ConsensusProtocolConfig {
     transaction_voting_enabled: bool,
     num_leaders_per_round: Option<usize>,
     bad_nodes_stake_threshold: u64,
+    enable_v3: bool,
 }
 
 impl Default for ConsensusProtocolConfig {
@@ -39,6 +40,7 @@ impl Default for ConsensusProtocolConfig {
             transaction_voting_enabled: false,
             num_leaders_per_round: None,
             bad_nodes_stake_threshold: 0,
+            enable_v3: false,
         }
     }
 }
@@ -54,6 +56,7 @@ impl ConsensusProtocolConfig {
         transaction_voting_enabled: bool,
         num_leaders_per_round: Option<usize>,
         bad_nodes_stake_threshold: u64,
+        enable_v3: bool,
     ) -> Self {
         Self {
             protocol_version,
@@ -65,6 +68,7 @@ impl ConsensusProtocolConfig {
             transaction_voting_enabled,
             num_leaders_per_round,
             bad_nodes_stake_threshold,
+            enable_v3,
         }
     }
 
@@ -81,6 +85,7 @@ impl ConsensusProtocolConfig {
             transaction_voting_enabled: true,
             num_leaders_per_round: Some(1),
             bad_nodes_stake_threshold: 30,
+            enable_v3: false,
         }
     }
 
@@ -122,6 +127,10 @@ impl ConsensusProtocolConfig {
         self.bad_nodes_stake_threshold
     }
 
+    pub fn enable_v3(&self) -> bool {
+        self.enable_v3
+    }
+
     // Test setter methods
 
     pub fn set_gc_depth_for_testing(&mut self, val: u32) {
@@ -150,5 +159,9 @@ impl ConsensusProtocolConfig {
 
     pub fn set_num_leaders_per_round_for_testing(&mut self, val: Option<usize>) {
         self.num_leaders_per_round = val;
+    }
+
+    pub fn set_enable_v3_for_testing(&mut self, val: bool) {
+        self.enable_v3 = val;
     }
 }

--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -358,7 +358,7 @@ impl DagState {
         if self.context.protocol_config.enable_v3() {
             // Update votes accounting in BlockInfo.
             for ancestor in block.ancestors() {
-                // Only update children when the link is potentially a leader vote.
+                // Only update children info when the link is potentially a leader vote.
                 if ancestor.round + 1 != block_ref.round || ancestor.round <= self.gc_round() {
                     continue;
                 }
@@ -524,6 +524,9 @@ impl DagState {
 
     #[cfg(test)]
     pub(crate) fn get_block_children(&self, block_ref: &BlockRef) -> Option<Vec<BlockRef>> {
+        if block_ref.round <= self.gc_round() {
+            return None;
+        }
         self.recent_blocks
             .get(block_ref)
             .map(|block_info| block_info.children.iter().cloned().collect())
@@ -534,6 +537,9 @@ impl DagState {
         &self,
         block_ref: &BlockRef,
     ) -> Option<BTreeSet<AuthorityIndex>> {
+        if block_ref.round <= self.gc_round() {
+            return None;
+        }
         self.recent_blocks
             .get(block_ref)
             .map(|block_info| block_info.children_authorities.clone())
@@ -541,6 +547,9 @@ impl DagState {
 
     #[cfg(test)]
     pub(crate) fn get_block_total_children_stake(&self, block_ref: &BlockRef) -> Option<Stake> {
+        if block_ref.round <= self.gc_round() {
+            return None;
+        }
         self.recent_blocks
             .get(block_ref)
             .map(|block_info| block_info.total_children_stake)
@@ -930,6 +939,9 @@ impl DagState {
     /// been evicted (<= gc_round) or has not been reached yet.
     #[cfg(test)] // consumed by FlexCommitter on the v3 path (next branch)
     pub(crate) fn round_info(&self, round: Round) -> Option<&RoundInfo> {
+        if round <= self.gc_round() {
+            return None;
+        }
         let front_round = self.round_info.front()?.round;
         if round < front_round {
             return None;
@@ -948,18 +960,19 @@ impl DagState {
             return;
         }
 
-        // Check if a new RoundInfo needs to be created.
+        // DAG can only grow one round at a time. Next round is at most 1 round after
+        // the current latest round.
         let next_round = self
             .round_info
             .back()
             .map(|info| info.round + 1)
+            // round_info starts empty on fresh startup or recovery.
             .unwrap_or(gc_round + 1);
         // DAG can only grow one round at a time.
         assert!(
             block.round() <= next_round,
             "Attempted to update round info for block {block_ref} with round higher than next round {next_round}"
         );
-        
         if block.round() == next_round {
             self.round_info.push_back(RoundInfo {
                 round: block.round(),
@@ -1365,13 +1378,15 @@ impl DagState {
 
 struct BlockInfo {
     block: VerifiedBlock,
+
+    /// Used in computing commits and leader schedule in Mysticeti v3.
     /// Next-round blocks which have this block as an ancestor.
-    /// Used in computing commits and leader schedule.
     children: BTreeSet<BlockRef>,
     /// Distinct authorities that have authored one of the entries in `children`.
     children_authorities: BTreeSet<AuthorityIndex>,
     /// Sum of stake across `children_authorities`.
     total_children_stake: Stake,
+
     // Whether the block has been committed
     committed: bool,
     // Whether the block has been included in the causal history of an owned proposed block.
@@ -1397,6 +1412,8 @@ impl BlockInfo {
 }
 
 /// Aggregates information about blocks accepted at a single round.
+/// Used for commit generation and leader schedule calculation in Mysticeti v3.
+/// RoundInfo is only kept for rounds above GC round.
 pub(crate) struct RoundInfo {
     pub(crate) round: Round,
     /// Distinct authorities that have authored at least one accepted block in `round`.
@@ -1915,6 +1932,29 @@ mod test {
         );
         dag_state.set_last_commit(last_commit);
         assert_eq!(dag_state.gc_round(), 2);
+
+        // Child metadata should expose logical retention immediately when the
+        // GC round advances, even before flush physically removes stale entries.
+        for block in all_blocks.iter().filter(|block| block.round() <= 2) {
+            let block_ref = block.reference();
+            assert!(
+                dag_state.get_block_children(&block_ref).is_none(),
+                "below-gc block {block_ref:?} should hide children before flush"
+            );
+            assert!(
+                dag_state
+                    .get_block_children_authorities(&block_ref)
+                    .is_none(),
+                "below-gc block {block_ref:?} should hide child authorities before flush"
+            );
+            assert!(
+                dag_state
+                    .get_block_total_children_stake(&block_ref)
+                    .is_none(),
+                "below-gc block {block_ref:?} should hide child stake before flush"
+            );
+        }
+
         dag_state.flush();
 
         // After flush: rounds 1..=2 evicted from recent_blocks → None.
@@ -2193,6 +2233,16 @@ mod test {
         );
         dag_state.set_last_commit(last_commit);
         assert_eq!(dag_state.gc_round(), 2);
+
+        // RoundInfo should expose logical retention immediately when the GC
+        // round advances, even before flush physically removes stale entries.
+        for round in 1..=2 {
+            assert!(
+                dag_state.round_info(round).is_none(),
+                "round {round} should be hidden before flush after GC advances"
+            );
+        }
+
         dag_state.flush();
 
         // Rounds 1..=2 are evicted; rounds 3..=5 remain with their aggregates.

--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -11,7 +11,7 @@ use std::{
     vec,
 };
 
-use consensus_config::AuthorityIndex;
+use consensus_config::{AuthorityIndex, Stake};
 use consensus_types::block::{BlockDigest, BlockRef, BlockTimestampMs, Round, TransactionIndex};
 use itertools::Itertools as _;
 use mysten_common::ZipDebugEqIteratorExt;
@@ -56,6 +56,11 @@ pub struct DagState {
     // Indexes recent block refs by their authorities.
     // Vec position corresponds to the authority index.
     recent_refs_by_authority: Vec<BTreeSet<BlockRef>>,
+
+    // Per-round aggregation of accepted blocks. Front holds the oldest retained
+    // round (`gc_round + 1` after eviction); back holds `highest_accepted_round`.
+    // Rounds between front and back are always contiguous in a valid DagState.
+    round_info: VecDeque<RoundInfo>,
 
     // Keeps track of the threshold clock for proposing blocks.
     threshold_clock: ThresholdClock,
@@ -167,6 +172,7 @@ impl DagState {
             genesis,
             recent_blocks: BTreeMap::new(),
             recent_refs_by_authority: vec![BTreeSet::new(); num_authorities],
+            round_info: VecDeque::new(),
             threshold_clock,
             highest_accepted_round: 0,
             last_commit: last_commit.clone(),
@@ -183,6 +189,7 @@ impl DagState {
             evicted_rounds: vec![0; num_authorities],
         };
 
+        let mut recovered_blocks = Vec::new();
         for (authority_index, _) in context.committee.authorities() {
             let (blocks, eviction_round) = {
                 // Find the latest block for the authority to calculate the eviction round. Then we want to scan and load the blocks from the eviction round and onwards only.
@@ -206,13 +213,6 @@ impl DagState {
                 (blocks, eviction_round)
             };
 
-            state.evicted_rounds[authority_index] = eviction_round;
-
-            // Update the block metadata for the authority.
-            for block in &blocks {
-                state.update_block_metadata(block);
-            }
-
             debug!(
                 "Recovered blocks {}: {:?}",
                 authority_index,
@@ -221,6 +221,15 @@ impl DagState {
                     .map(|b| b.reference())
                     .collect::<Vec<BlockRef>>()
             );
+            recovered_blocks.extend(blocks);
+
+            state.evicted_rounds[authority_index] = eviction_round;
+        }
+
+        // Update the block metadata across all recovered blocks from lowest round to highest round.
+        recovered_blocks.sort_by_key(|b| b.reference());
+        for block in &recovered_blocks {
+            state.update_block_metadata(block);
         }
 
         if let Some(last_commit) = last_commit {
@@ -346,7 +355,28 @@ impl DagState {
         self.recent_blocks
             .insert(block_ref, BlockInfo::new(block.clone()));
         self.recent_refs_by_authority[block_ref.author].insert(block_ref);
-
+        if self.context.protocol_config.enable_v3() {
+            // Update votes accounting in BlockInfo.
+            for ancestor in block.ancestors() {
+                // Only update children when the link is potentially a leader vote.
+                if ancestor.round + 1 != block_ref.round || ancestor.round <= self.gc_round() {
+                    continue;
+                }
+                let block_info = self.recent_blocks.get_mut(ancestor).unwrap_or_else(|| {
+                    panic!(
+                        "Parent block {} of block {} does not exist",
+                        ancestor, block_ref
+                    )
+                });
+                if block_info.children.insert(block_ref)
+                    && block_info.children_authorities.insert(block_ref.author)
+                {
+                    let child_stake = self.context.committee.stake(block_ref.author);
+                    block_info.total_children_stake += child_stake;
+                }
+            }
+            self.update_round_info(block);
+        }
         if self.threshold_clock.add_block(block_ref) {
             // Do not measure quorum delay when no local block is proposed in the round.
             if let Some(last_proposed_block) = self.get_last_proposed_block()
@@ -490,6 +520,30 @@ impl DagState {
             blocks.push(block_info.block.clone())
         }
         blocks
+    }
+
+    #[cfg(test)]
+    pub(crate) fn get_block_children(&self, block_ref: &BlockRef) -> Option<Vec<BlockRef>> {
+        self.recent_blocks
+            .get(block_ref)
+            .map(|block_info| block_info.children.iter().cloned().collect())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn get_block_children_authorities(
+        &self,
+        block_ref: &BlockRef,
+    ) -> Option<BTreeSet<AuthorityIndex>> {
+        self.recent_blocks
+            .get(block_ref)
+            .map(|block_info| block_info.children_authorities.clone())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn get_block_total_children_stake(&self, block_ref: &BlockRef) -> Option<Stake> {
+        self.recent_blocks
+            .get(block_ref)
+            .map(|block_info| block_info.total_children_stake)
     }
 
     /// Gets all ancestors in the history of a block at a certain round.
@@ -872,6 +926,61 @@ impl DagState {
         self.highest_accepted_round
     }
 
+    /// Returns the `RoundInfo` for `round`, if retained. `None` if the round has
+    /// been evicted (<= gc_round) or has not been reached yet.
+    #[cfg(test)] // consumed by FlexCommitter on the v3 path (next branch)
+    pub(crate) fn round_info(&self, round: Round) -> Option<&RoundInfo> {
+        let front_round = self.round_info.front()?.round;
+        if round < front_round {
+            return None;
+        }
+        self.round_info.get((round - front_round) as usize)
+    }
+
+    /// Updates the `RoundInfo` for the round of the given block,
+    /// and creates a new `RoundInfo` if the block is in the next round.
+    fn update_round_info(&mut self, block: &VerifiedBlock) {
+        let block_ref = block.reference();
+
+        // RoundInfo is only kept for rounds above GC round.
+        let gc_round = self.gc_round();
+        if block.round() <= gc_round {
+            return;
+        }
+
+        // Check if a new RoundInfo needs to be created.
+        let next_round = self
+            .round_info
+            .back()
+            .map(|info| info.round + 1)
+            .unwrap_or(gc_round + 1);
+        // DAG can only grow one round at a time.
+        if block.round() == next_round {
+            self.round_info.push_back(RoundInfo {
+                round: block.round(),
+                authorities: BTreeSet::new(),
+                total_stake: 0,
+            });
+        } else {
+            assert!(
+                block.round() < next_round,
+                "Attempted to update round info for block {block_ref} with round higher than next round {next_round}"
+            );
+        }
+
+        // Update the RoundInfo of the block round.
+        let front_round = self
+            .round_info
+            .front()
+            .expect("round_info non-empty after extend")
+            .round;
+        let index = (block.round() - front_round) as usize;
+        let info = &mut self.round_info[index];
+        if info.authorities.insert(block_ref.author) {
+            info.total_stake += self.context.committee.stake(block_ref.author);
+        }
+    }
+
     // Buffers a new commit in memory and updates last committed rounds.
     // REQUIRED: must not skip over any commit index.
     pub(crate) fn add_commit(&mut self, commit: TrustedCommit) {
@@ -1142,6 +1251,15 @@ impl DagState {
             self.evicted_rounds[authority_index] = eviction_round;
         }
 
+        // Clean up old RoundInfo below gc_round.
+        while let Some(info) = self.round_info.front() {
+            if info.round <= self.gc_round() {
+                self.round_info.pop_front();
+            } else {
+                break;
+            }
+        }
+
         let metrics = &self.context.metrics.node_metrics;
         metrics
             .dag_state_recent_blocks
@@ -1247,6 +1365,13 @@ impl DagState {
 
 struct BlockInfo {
     block: VerifiedBlock,
+    /// Next-round blocks which have this block as an ancestor.
+    /// Used in computing commits and leader schedule.
+    children: BTreeSet<BlockRef>,
+    /// Distinct authorities that have authored one of the entries in `children`.
+    children_authorities: BTreeSet<AuthorityIndex>,
+    /// Sum of stake across `children_authorities`.
+    total_children_stake: Stake,
     // Whether the block has been committed
     committed: bool,
     // Whether the block has been included in the causal history of an owned proposed block.
@@ -1262,10 +1387,22 @@ impl BlockInfo {
     fn new(block: VerifiedBlock) -> Self {
         Self {
             block,
+            children: BTreeSet::new(),
+            children_authorities: BTreeSet::new(),
+            total_children_stake: 0,
             committed: false,
             included: false,
         }
     }
+}
+
+/// Aggregates information about blocks accepted at a single round.
+pub(crate) struct RoundInfo {
+    pub(crate) round: Round,
+    /// Distinct authorities that have authored at least one accepted block in `round`.
+    pub(crate) authorities: BTreeSet<AuthorityIndex>,
+    /// Sum of stake across `authorities`.
+    pub(crate) total_stake: Stake,
 }
 
 #[cfg(test)]
@@ -1656,6 +1793,427 @@ mod test {
                 assert!(!dag_state.has_been_included(&block.reference()));
             }
         }
+    }
+
+    #[tokio::test]
+    async fn test_block_children_basics() {
+        let (mut context, _) = Context::new_for_test(4);
+        // Small cached_rounds so a later flush actually evicts below-gc
+        // entries from recent_blocks.
+        context.parameters.dag_state_cached_rounds = 2;
+        context.protocol_config.set_gc_depth_for_testing(3);
+        context.protocol_config.set_enable_v3_for_testing(true);
+        let context = Arc::new(context);
+
+        let store = Arc::new(MemStore::new());
+        let mut dag_state = DagState::new(context.clone(), store.clone());
+
+        // Dense 4-authority DAG for rounds 1..=5 with default full links.
+        let mut dag_builder = DagBuilder::new(context.clone());
+        dag_builder.layers(1..=5).build();
+
+        let all_blocks = dag_builder.all_blocks();
+        dag_state.accept_blocks(all_blocks.clone());
+
+        // Expected children: for each block, the round+1 blocks that reference it via a
+        // parent (strong) link.
+        let mut expected_children: BTreeMap<BlockRef, BTreeSet<BlockRef>> = BTreeMap::new();
+        for block in &all_blocks {
+            expected_children
+                .entry(block.reference())
+                .or_default()
+                .extend(
+                    all_blocks
+                        .iter()
+                        .filter(|b| b.round() == block.round() + 1)
+                        .map(|b| b.reference()),
+                );
+        }
+
+        // Verify get_block_children() returns the expected set for every block.
+        for block in &all_blocks {
+            let block_ref = block.reference();
+            let actual: BTreeSet<BlockRef> = dag_state
+                .get_block_children(&block_ref)
+                .expect("accepted block should be in recent_blocks")
+                .into_iter()
+                .collect();
+            let want = expected_children.get(&block_ref).cloned().unwrap();
+            assert_eq!(actual, want, "mismatched children for {block_ref:?}");
+
+            // Derived fields: distinct authors of the child set, and summed stake.
+            let expected_authorities: BTreeSet<AuthorityIndex> =
+                want.iter().map(|r| r.author).collect();
+            let expected_stake: Stake = expected_authorities
+                .iter()
+                .map(|a| context.committee.stake(*a))
+                .sum();
+            assert_eq!(
+                dag_state
+                    .get_block_children_authorities(&block_ref)
+                    .expect("accepted block should be in recent_blocks"),
+                expected_authorities,
+                "mismatched children_authorities for {block_ref:?}"
+            );
+            assert_eq!(
+                dag_state
+                    .get_block_total_children_stake(&block_ref)
+                    .expect("accepted block should be in recent_blocks"),
+                expected_stake,
+                "mismatched total_children_stake for {block_ref:?}"
+            );
+        }
+
+        // Idempotence: re-accepting a block should be a no-op (via the
+        // contains_block early-return) and must not change any parent's
+        // children set.
+        let round_2_block = all_blocks
+            .iter()
+            .find(|b| b.round() == 2)
+            .expect("should have a round-2 block")
+            .clone();
+        let before: Vec<(BlockRef, BTreeSet<BlockRef>)> = round_2_block
+            .ancestors()
+            .iter()
+            .map(|a| {
+                (
+                    *a,
+                    dag_state
+                        .get_block_children(a)
+                        .unwrap()
+                        .into_iter()
+                        .collect(),
+                )
+            })
+            .collect();
+        dag_state.accept_block(round_2_block);
+        for (ancestor, before_set) in before {
+            let after: BTreeSet<BlockRef> = dag_state
+                .get_block_children(&ancestor)
+                .unwrap()
+                .into_iter()
+                .collect();
+            assert_eq!(
+                before_set, after,
+                "children changed for {ancestor:?} after re-accept"
+            );
+        }
+
+        // GC boundary: commit a round-5 leader so gc_round advances to 2, then
+        // flush to evict blocks with round <= eviction_round (= min(gc_round,
+        // last_round - cached_rounds) = min(2, 5-2) = 2).
+        let round_5_leader = all_blocks
+            .last()
+            .expect("last block should be round 5")
+            .reference();
+        let last_commit = TrustedCommit::new_for_test(
+            5,
+            CommitDigest::MIN,
+            context.clock.timestamp_utc_ms(),
+            round_5_leader,
+            vec![],
+        );
+        dag_state.set_last_commit(last_commit);
+        assert_eq!(dag_state.gc_round(), 2);
+        dag_state.flush();
+
+        // After flush: rounds 1..=2 evicted from recent_blocks → None.
+        // Rounds 3..=4 retain their children sets; round 5 is above GC but has
+        // no round-6 children.
+        for block in &all_blocks {
+            let block_ref = block.reference();
+            match block.round() {
+                1..=2 => assert!(
+                    dag_state.get_block_children(&block_ref).is_none(),
+                    "round {} block {block_ref:?} should be evicted after flush",
+                    block.round()
+                ),
+                3..=4 => {
+                    let actual: BTreeSet<BlockRef> = dag_state
+                        .get_block_children(&block_ref)
+                        .expect("above-gc block should remain")
+                        .into_iter()
+                        .collect();
+                    let want = expected_children
+                        .get(&block_ref)
+                        .cloned()
+                        .unwrap_or_default();
+                    assert_eq!(
+                        actual, want,
+                        "children changed for {block_ref:?} after flush"
+                    );
+                    // Derived fields survive the flush since we only evict
+                    // below-GC entries.
+                    let expected_authorities: BTreeSet<AuthorityIndex> =
+                        want.iter().map(|r| r.author).collect();
+                    let expected_stake: Stake = expected_authorities
+                        .iter()
+                        .map(|a| context.committee.stake(*a))
+                        .sum();
+                    assert_eq!(
+                        dag_state
+                            .get_block_children_authorities(&block_ref)
+                            .expect("above-gc block should remain"),
+                        expected_authorities,
+                        "children_authorities changed for {block_ref:?} after flush"
+                    );
+                    assert_eq!(
+                        dag_state
+                            .get_block_total_children_stake(&block_ref)
+                            .expect("above-gc block should remain"),
+                        expected_stake,
+                        "total_children_stake changed for {block_ref:?} after flush"
+                    );
+                }
+                5 => {
+                    let actual = dag_state
+                        .get_block_children(&block_ref)
+                        .expect("round-5 block should remain");
+                    assert!(
+                        actual.is_empty(),
+                        "round-5 block {block_ref:?} has unexpected children {actual:?}"
+                    );
+                    assert!(
+                        dag_state
+                            .get_block_children_authorities(&block_ref)
+                            .expect("round-5 block should remain")
+                            .is_empty(),
+                        "round-5 block {block_ref:?} must have no children_authorities"
+                    );
+                    assert_eq!(
+                        dag_state
+                            .get_block_total_children_stake(&block_ref)
+                            .expect("round-5 block should remain"),
+                        0,
+                        "round-5 block {block_ref:?} must have zero total_children_stake"
+                    );
+                }
+                _ => unreachable!(),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_block_children_exclusion() {
+        let (mut context, _) = Context::new_for_test(4);
+        context.parameters.dag_state_cached_rounds = 10;
+        context.protocol_config.set_gc_depth_for_testing(3);
+        context.protocol_config.set_enable_v3_for_testing(true);
+        let context = Arc::new(context);
+
+        let store = Arc::new(MemStore::new());
+        let mut dag_state = DagState::new(context.clone(), store.clone());
+
+        // Accept rounds 1..=2 with default full links.
+        let mut dag_builder = DagBuilder::new(context.clone());
+        dag_builder.layers(1..=2).build();
+        let base_blocks = dag_builder.all_blocks();
+        dag_state.accept_blocks(base_blocks.clone());
+
+        // Craft a round-3 block with mixed strong + weak ancestors:
+        //   strong: three round-2 blocks (ancestor.round + 1 == 3, authority other than 0)
+        //   weak:   one round-1 block (ancestor.round + 1 == 2, not 3, authority 0)
+        let round_2_refs: Vec<BlockRef> = base_blocks
+            .iter()
+            .filter(|b| b.round() == 2 && b.author() != AuthorityIndex::new_for_test(0))
+            .map(|b| b.reference())
+            .collect();
+        let weak_ancestor = base_blocks
+            .iter()
+            .find(|b| b.round() == 1 && b.author() == AuthorityIndex::new_for_test(0))
+            .expect("should have a round-1 authority-0 block")
+            .reference();
+
+        let mut ancestors = round_2_refs.clone();
+        ancestors.push(weak_ancestor);
+        let round_3 =
+            VerifiedBlock::new_for_test(TestBlock::new(3, 1).set_ancestors_raw(ancestors).build());
+        let round_3_ref = round_3.reference();
+        dag_state.accept_block(round_3);
+
+        // Strong ancestors (round 2): each should now list round_3_ref as a child.
+        // Derived fields: only authority 1 (round_3's author) is represented, so
+        // children_authorities == {1} and total_children_stake == stake(1).
+        let author_1 = AuthorityIndex::new_for_test(1);
+        let stake_1 = context.committee.stake(author_1);
+        for r2_ref in &round_2_refs {
+            let children = dag_state
+                .get_block_children(r2_ref)
+                .expect("round-2 block should still be present");
+            assert!(
+                children.contains(&round_3_ref),
+                "round-2 parent {r2_ref:?} should have round-3 block as child",
+            );
+            let authorities = dag_state
+                .get_block_children_authorities(r2_ref)
+                .expect("round-2 block should still be present");
+            assert_eq!(
+                authorities,
+                BTreeSet::from([author_1]),
+                "round-2 parent {r2_ref:?} should have children_authorities == {{1}}",
+            );
+            assert_eq!(
+                dag_state
+                    .get_block_total_children_stake(r2_ref)
+                    .expect("round-2 block should still be present"),
+                stake_1,
+                "round-2 parent {r2_ref:?} total_children_stake mismatch",
+            );
+        }
+
+        // Weak ancestor (round 1): must NOT have round_3_ref as a child, and
+        // its children set should only contain the natural round-2 population.
+        let weak_children = dag_state
+            .get_block_children(&weak_ancestor)
+            .expect("weak ancestor should still be present");
+        assert!(
+            !weak_children.contains(&round_3_ref),
+            "weak ancestor {weak_ancestor:?} must NOT have round-3 block as child",
+        );
+        for c in &weak_children {
+            assert_eq!(
+                c.round, 2,
+                "weak ancestor's children should all be round 2, got {c:?}"
+            );
+        }
+        // Derived fields for the weak ancestor: children are the 4 natural
+        // round-2 blocks authored by all 4 authorities, so authorities =
+        // {0,1,2,3} and stake = total_stake. round_3 does not contribute
+        // because the weak link was filtered out.
+        let weak_authorities = dag_state
+            .get_block_children_authorities(&weak_ancestor)
+            .expect("weak ancestor should still be present");
+        let expected_weak_authorities: BTreeSet<AuthorityIndex> =
+            (0..4).map(AuthorityIndex::new_for_test).collect();
+        assert_eq!(
+            weak_authorities, expected_weak_authorities,
+            "weak ancestor {weak_ancestor:?} children_authorities should cover all 4 round-2 authors",
+        );
+        assert_eq!(
+            dag_state
+                .get_block_total_children_stake(&weak_ancestor)
+                .expect("weak ancestor should still be present"),
+            context.committee.total_stake(),
+            "weak ancestor {weak_ancestor:?} total_children_stake should equal total committee stake",
+        );
+    }
+
+    #[tokio::test]
+    async fn test_round_info() {
+        let (mut context, _) = Context::new_for_test(4);
+        // Small cached_rounds so a later flush evicts below-gc round_info entries.
+        context.parameters.dag_state_cached_rounds = 2;
+        context.protocol_config.set_gc_depth_for_testing(3);
+        context.protocol_config.set_enable_v3_for_testing(true);
+        let context = Arc::new(context);
+
+        let store = Arc::new(MemStore::new());
+        let mut dag_state = DagState::new(context.clone(), store.clone());
+
+        // Before any blocks: no round_info entries exist.
+        assert!(dag_state.round_info(1).is_none());
+
+        // Accept blocks for rounds 1..=4 with full participation. Each round
+        // must aggregate every authority and stake equal to total_stake.
+        let mut dag_builder = DagBuilder::new(context.clone());
+        dag_builder.layers(1..=4).build();
+        dag_state.accept_blocks(dag_builder.all_blocks());
+
+        let all_authorities: BTreeSet<AuthorityIndex> =
+            (0..4).map(AuthorityIndex::new_for_test).collect();
+        for round in 1..=4 {
+            let info = dag_state
+                .round_info(round)
+                .unwrap_or_else(|| panic!("round_info missing for round {round}"));
+            assert_eq!(info.round, round);
+            assert_eq!(
+                info.authorities, all_authorities,
+                "round {round} authorities mismatch"
+            );
+            assert_eq!(
+                info.total_stake,
+                context.committee.total_stake(),
+                "round {round} total_stake mismatch"
+            );
+        }
+
+        // Beyond highest_accepted_round: no entry yet.
+        assert!(dag_state.round_info(5).is_none());
+
+        // Re-accepting the same blocks must not double-count stake. The
+        // contains_block early-return inside accept_block guards this.
+        dag_state.accept_blocks(dag_builder.all_blocks());
+        for round in 1..=4 {
+            let info = dag_state.round_info(round).unwrap();
+            assert_eq!(
+                info.authorities, all_authorities,
+                "round {round} authorities changed after re-accept"
+            );
+            assert_eq!(
+                info.total_stake,
+                context.committee.total_stake(),
+                "round {round} total_stake changed after re-accept"
+            );
+        }
+
+        // Partial round: extend the DAG with only authority 0 at round 5.
+        let round_5_block = VerifiedBlock::new_for_test(
+            TestBlock::new(5, 0)
+                .set_ancestors_raw(
+                    dag_builder
+                        .all_blocks()
+                        .iter()
+                        .filter(|b| b.round() == 4)
+                        .map(|b| b.reference())
+                        .collect(),
+                )
+                .build(),
+        );
+        dag_state.accept_block(round_5_block);
+        let info_5 = dag_state.round_info(5).expect("round 5 entry should exist");
+        let author_0 = AuthorityIndex::new_for_test(0);
+        assert_eq!(info_5.authorities, BTreeSet::from([author_0]));
+        assert_eq!(info_5.total_stake, context.committee.stake(author_0));
+
+        // GC boundary: commit a round-5 leader so gc_round advances to 2,
+        // then flush to evict round_info entries with round <= gc_round.
+        let round_5_leader_ref = dag_state
+            .recent_refs_by_authority
+            .iter()
+            .flat_map(|set| set.iter())
+            .find(|r| r.round == 5)
+            .copied()
+            .expect("round 5 block should be accepted");
+        let last_commit = TrustedCommit::new_for_test(
+            5,
+            CommitDigest::MIN,
+            context.clock.timestamp_utc_ms(),
+            round_5_leader_ref,
+            vec![],
+        );
+        dag_state.set_last_commit(last_commit);
+        assert_eq!(dag_state.gc_round(), 2);
+        dag_state.flush();
+
+        // Rounds 1..=2 are evicted; rounds 3..=5 remain with their aggregates.
+        for round in 1..=2 {
+            assert!(
+                dag_state.round_info(round).is_none(),
+                "round {round} should be evicted after flush"
+            );
+        }
+        for round in 3..=4 {
+            let info = dag_state
+                .round_info(round)
+                .unwrap_or_else(|| panic!("round_info missing for round {round} after flush"));
+            assert_eq!(info.authorities, all_authorities);
+            assert_eq!(info.total_stake, context.committee.total_stake());
+        }
+        let info_5 = dag_state
+            .round_info(5)
+            .expect("round 5 should still be present after flush");
+        assert_eq!(info_5.authorities, BTreeSet::from([author_0]));
+        assert_eq!(info_5.total_stake, context.committee.stake(author_0));
     }
 
     #[tokio::test]

--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -936,17 +936,20 @@ impl DagState {
     }
 
     /// Returns the `RoundInfo` for `round`, if retained. `None` if the round has
-    /// been evicted (<= gc_round) or has not been reached yet.
-    #[cfg(test)] // consumed by FlexCommitter on the v3 path (next branch)
+    /// been evicted, Gc'ed or has not been reached yet.
+    #[cfg(test)]
     pub(crate) fn round_info(&self, round: Round) -> Option<&RoundInfo> {
-        if round <= self.gc_round() {
-            return None;
-        }
         let front_round = self.round_info.front()?.round;
-        if round < front_round {
+        if round < front_round || round <= self.gc_round() {
             return None;
         }
-        self.round_info.get((round - front_round) as usize)
+        let round_info = self.round_info.get((round - front_round) as usize)?;
+        assert_eq!(
+            round_info.round, round,
+            "RoundInfo round {} does not match requested round {}. RoundInfo should be contiguous.",
+            round_info.round, round
+        );
+        Some(round_info)
     }
 
     /// Updates the `RoundInfo` for the round of the given block,

--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -955,17 +955,17 @@ impl DagState {
             .map(|info| info.round + 1)
             .unwrap_or(gc_round + 1);
         // DAG can only grow one round at a time.
+        assert!(
+            block.round() <= next_round,
+            "Attempted to update round info for block {block_ref} with round higher than next round {next_round}"
+        );
+        
         if block.round() == next_round {
             self.round_info.push_back(RoundInfo {
                 round: block.round(),
                 authorities: BTreeSet::new(),
                 total_stake: 0,
             });
-        } else {
-            assert!(
-                block.round() < next_round,
-                "Attempted to update round info for block {block_ref} with round higher than next round {next_round}"
-            );
         }
 
         // Update the RoundInfo of the block round.

--- a/crates/sui-core/src/consensus_manager/mod.rs
+++ b/crates/sui-core/src/consensus_manager/mod.rs
@@ -133,6 +133,7 @@ fn to_consensus_protocol_config(config: &ProtocolConfig, chain: Chain) -> Consen
         /* transaction_voting_enabled */ true,
         config.mysticeti_num_leaders_per_round(),
         config.consensus_bad_nodes_stake_threshold(),
+        /* enable_v3 */ false,
     )
 }
 

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/invalid_extra_args.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/invalid_extra_args.snap
@@ -5,14 +5,6 @@ info:
   edition: 2024.alpha
   lint: false
 ---
-warning[W09003]: unused assignment
-  ┌─ tests/move_2024/matching/invalid_extra_args.move:9:13
-  │
-9 │         let subject = E::A(0);
-  │             ^^^^^^^ Unused assignment for variable 'subject'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_subject')
-  │
-  = This warning can be suppressed with '#[allow(unused_assignment)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
-
 error[E03013]: positional call mismatch
   ┌─ tests/move_2024/matching/invalid_extra_args.move:9:23
   │


### PR DESCRIPTION
## Description 

Adds two pieces of per-block / per-round metadata consumed by the v3 commit rule:

- BlockInfo now tracks children, children_authorities and total_children_stake, populated in update_block_metadata() when a block is accepted.
- RoundInfo aggregates, per retained round, the set of unique authoring authorities and their total stake. It is held in a VecDeque whose front is gc_round + 1 and back is highest_accepted_round, extended on block accept and truncated on flush once entries fall to <= gc_round.

## Test plan 

CI
