### PR TITLE
[move-vm][housekeeping] Swap to quanta telemetry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6228,7 +6228,7 @@ dependencies = [
  "no-std-compat",
  "nonzero_ext",
  "parking_lot 0.12.3",
- "quanta",
+ "quanta 0.11.1",
  "rand 0.8.5",
  "smallvec",
 ]
@@ -9290,6 +9290,7 @@ dependencies = [
  "move-trace-format",
  "move-vm-config",
  "parking_lot 0.11.2",
+ "quanta 0.12.6",
  "quick_cache",
  "serde",
  "sha2 0.9.9",
@@ -11481,7 +11482,22 @@ dependencies = [
  "libc",
  "mach2",
  "once_cell",
- "raw-cpuid",
+ "raw-cpuid 10.6.0",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
+name = "quanta"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid 11.6.0",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "web-sys",
  "winapi",
@@ -11875,6 +11891,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6823ea29436221176fe662da99998ad3b4db2c7f31e7b6f5fe43adccd6320bb"
 dependencies = [
  "bitflags 1.3.2",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -18788,7 +18813,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.7.3",
+ "rand 0.8.5",
  "static_assertions",
 ]
 

--- a/external-crates/move/Cargo.lock
+++ b/external-crates/move/Cargo.lock
@@ -3249,6 +3249,7 @@ dependencies = [
  "move-vm-config",
  "parking_lot 0.11.2",
  "proptest",
+ "quanta",
  "quick_cache",
  "serde",
  "sha2 0.9.9",
@@ -4080,6 +4081,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "quanta"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4296,6 +4312,15 @@ dependencies = [
  "time",
  "unicode-segmentation",
  "unicode-width 0.2.0",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags 2.11.0",
 ]
 
 [[package]]

--- a/external-crates/move/Cargo.toml
+++ b/external-crates/move/Cargo.toml
@@ -96,6 +96,7 @@ pretty_assertions = "1.4.1"
 primitive-types = { version = "0.10.1", features = ["impl-serde"] }
 proptest = "1.6.0"
 proptest-derive = "0.5"
+quanta = "0.12"
 quick_cache = { version = "0.6.18", features = ["stats"] }
 quote = "1.0.9"
 rand = "0.8.0"

--- a/external-crates/move/crates/move-vm-runtime/Cargo.toml
+++ b/external-crates/move/crates/move-vm-runtime/Cargo.toml
@@ -23,6 +23,7 @@ indexmap.workspace = true
 lasso.workspace = true
 lru.workspace = true
 parking_lot.workspace = true
+quanta.workspace = true
 quick_cache.workspace = true
 serde.workspace = true
 sha2.workspace = true

--- a/external-crates/move/crates/move-vm-runtime/src/runtime/telemetry.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/runtime/telemetry.rs
@@ -183,7 +183,7 @@ pub(crate) struct Timer {
     kind: TimerKind,
     count: Option<u64>,
     reported: bool,
-    start_time: std::time::Instant,
+    start_time: quanta::Instant,
 }
 
 // -------------------------------------------------------------------------------------------------
@@ -378,7 +378,7 @@ impl TransactionTelemetryContext {
             kind,
             count: None,
             reported: false,
-            start_time: std::time::Instant::now(),
+            start_time: quanta::Instant::now(),
         }
     }
 
@@ -387,7 +387,7 @@ impl TransactionTelemetryContext {
             kind,
             count: Some(count),
             reported: false,
-            start_time: std::time::Instant::now(),
+            start_time: quanta::Instant::now(),
         }
     }
 


### PR DESCRIPTION
## Description 

The VM currently calls `Instant::now` which can be expensive in a system under heavy load. This swaps it for `quanta`, a library that is less precise but faster. Since we are only using milliseconds, this should be just fine for us.

## Test plan 

Everything is still green.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
