### PR TITLE
[move][move-compiler] Fix an issue with the use of subtype in match pattern type inference

### DIFF
--- a/external-crates/move/crates/move-compiler/src/hlir/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/hlir/translate.rs
@@ -210,7 +210,13 @@ impl<'env> Context<'env> {
         let symbol = translate_var(v);
         // We may reuse a name if it appears on both sides of an `or` pattern
         if let Some((cur_mut, cur_t)) = self.function_locals.get(&symbol) {
-            assert!(cur_t == &t);
+            assert!(
+                cur_t == &t,
+                "{:?} changed type from {:?} to {:?}",
+                v,
+                cur_t,
+                t
+            );
             assert!(
                 cur_mut == &mut_,
                 "{:?} changed mutability from {:?} to {:?}",

--- a/external-crates/move/crates/move-compiler/src/hlir/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/hlir/translate.rs
@@ -210,15 +210,19 @@ impl<'env> Context<'env> {
         let symbol = translate_var(v);
         // We may reuse a name if it appears on both sides of an `or` pattern
         if let Some((cur_mut, cur_t)) = self.function_locals.get(&symbol) {
-            assert!(
+            ice_assert!(
+                self,
                 cur_t == &t,
+                v.loc,
                 "{:?} changed type from {:?} to {:?}",
                 v,
                 cur_t,
                 t
             );
-            assert!(
+            ice_assert!(
+                self,
                 cur_mut == &mut_,
+                v.loc,
                 "{:?} changed mutability from {:?} to {:?}",
                 v,
                 cur_mut,

--- a/external-crates/move/crates/move-compiler/src/typing/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/translate.rs
@@ -2378,15 +2378,15 @@ fn match_arm(
     let ploc = pattern.loc;
     let mut pattern = match_pattern(context, pattern, ref_mut, &rhs_binders);
 
-    if subtype_opt(
+    if let Some(pat_ty) = subtype_opt(
         context,
         ploc,
         || "Invalid pattern",
         &pattern.ty,
         subject_type,
-    )
-    .is_none()
-    {
+    ) {
+        pattern.ty = pat_ty;
+    } else {
         pattern.ty = context.error_type(ploc);
         pattern.pat.value = T::UnannotatedPat_::ErrorPat;
     }
@@ -2452,6 +2452,29 @@ fn match_pattern(
     )
 }
 
+// Wraps `subtype_opt` for use during pattern typing. Returns `None` (without
+// emitting a diagnostic) when either side is a top-level `UnresolvedError`, so
+// no unification is attempted. `UnresolvedError` is absorbing in the type
+// substitution: once a metavariable is bound to it, no further unification can
+// re-bind it. Or-pattern branches share binder metavariables via
+// `make_expr_list_tvars` in `match_arm`, so letting one malformed branch bind
+// `tvar_x := UnresolvedError` would silently corrupt typing in the other
+// branches.
+fn pattern_subtype_opt<T: ToString, F: FnOnce() -> T>(
+    context: &mut Context,
+    loc: Loc,
+    msg: F,
+    lhs: &Type,
+    rhs: &Type,
+) -> Option<Type> {
+    if matches!(lhs.value.inner(), TI::UnresolvedError)
+        || matches!(rhs.value.inner(), TI::UnresolvedError)
+    {
+        return None;
+    }
+    subtype_opt(context, loc, msg, lhs, rhs)
+}
+
 fn match_pattern_(
     context: &mut Context,
     sp!(loc, pat_): N::MatchPattern,
@@ -2503,7 +2526,7 @@ fn match_pattern_(
                     match_pattern_(context, tpat, mut_ref, rhs_binders, wildcard_needs_drop);
                 // This double-clone should not be necessary, but the borrow checker is unhappy.
                 let fty_ref = rtype!(tpat.pat.loc, fty.clone());
-                if let Some(pat_ty) = subtype_opt(
+                if let Some(pat_ty) = pattern_subtype_opt(
                     context,
                     f.loc(),
                     || "Invalid pattern field type",
@@ -2559,7 +2582,7 @@ fn match_pattern_(
                     match_pattern_(context, tpat, mut_ref, rhs_binders, wildcard_needs_drop);
                 // This double-clone should not be necessary, but the borrow checker is unhappy.
                 let fty_ref = rtype!(tpat.pat.loc, fty.clone());
-                if let Some(pat_ty) = subtype_opt(
+                if let Some(pat_ty) = pattern_subtype_opt(
                     context,
                     f.loc(),
                     || "Invalid pattern field type",
@@ -2736,13 +2759,17 @@ fn match_pattern_(
                 inner_wildcards_need_drop,
             );
             let x_ty = context.get_local_type(&x);
-            let ty = subtype(
+            // If unification is skipped (one side is `UnresolvedError`), keep the at-pattern
+            // structure with `x_ty` as the type so binders downstream remain typed via `x_ty`'s
+            // metavariable rather than being lost to a top-level `ErrorPat` rewrite.
+            let ty = pattern_subtype_opt(
                 context,
                 inner.pat.loc,
                 || "Invalid inner pattern type".to_string(),
                 &inner.ty,
                 &x_ty,
-            );
+            )
+            .unwrap_or(x_ty);
             if type_needs_copy && mut_ref.is_none() {
                 context.add_ability_constraint(
                     loc,
@@ -2766,7 +2793,7 @@ fn match_pattern_(
             );
             let x_ty = context.get_local_type(&x);
             // ensure subtype for posterity
-            subtype(
+            pattern_subtype_opt(
                 context,
                 inner.pat.loc,
                 || "Invalid inner pattern type".to_string(),

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/invalid_extra_args_3.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/invalid_extra_args_3.move
@@ -1,0 +1,13 @@
+module 0x42::m {
+    public enum E<T> has drop {
+        A(T),
+        B,
+        C(T, T),
+    }
+    fun t(): u64 {
+        match (E::A(0)) {
+            E::C(x, (0 | 1)) | E::B(x) | E::A(x) => x,
+            _ => 1,
+        }
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/invalid_extra_args_3.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/invalid_extra_args_3.snap
@@ -1,0 +1,17 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+error[E03013]: positional call mismatch
+  ┌─ tests/move_2024/matching/invalid_extra_args_3.move:9:32
+  │
+4 │         B,
+  │         - 'B' is declared here
+  ·
+9 │             E::C(x, (0 | 1)) | E::B(x) | E::A(x) => x,
+  │                                ^^^^^^^ Invalid variant pattern. Empty variant declarations require empty patterns
+  │
+  = Remove '()' arguments from this pattern

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/invalid_extra_args_4.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/invalid_extra_args_4.move
@@ -1,0 +1,13 @@
+module 0x42::m {
+    public enum E<T> has drop {
+        A(T),
+        B,
+        C(T, T),
+    }
+    fun t(): u64 {
+        match (E::A(0u64)) {
+            E::C(x, (0 | 1)) | E::B(x) | E::A(x) => x + 1u64,
+            _ => 1,
+        }
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/invalid_extra_args_4.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/invalid_extra_args_4.snap
@@ -1,0 +1,17 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+error[E03013]: positional call mismatch
+  ┌─ tests/move_2024/matching/invalid_extra_args_4.move:9:32
+  │
+4 │         B,
+  │         - 'B' is declared here
+  ·
+9 │             E::C(x, (0 | 1)) | E::B(x) | E::A(x) => x + 1u64,
+  │                                ^^^^^^^ Invalid variant pattern. Empty variant declarations require empty patterns
+  │
+  = Remove '()' arguments from this pattern

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/invalid_native_struct_field_binder.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/invalid_native_struct_field_binder.move
@@ -1,0 +1,9 @@
+module 0x42::m {
+    public native struct N;
+
+    fun t(n: &N): u64 {
+        match (n) {
+            N { x } => x,
+        }
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/invalid_native_struct_field_binder.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/invalid_native_struct_field_binder.snap
@@ -1,0 +1,26 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+error[E04007]: incompatible types
+  ┌─ tests/move_2024/matching/invalid_native_struct_field_binder.move:5:9
+  │  
+4 │       fun t(n: &N): u64 {
+  │                     --- Expected: 'u64'
+5 │ ╭         match (n) {
+6 │ │             N { x } => x,
+  │ │                 - Given: '&_'
+7 │ │         }
+  │ ╰─────────^ Invalid return expression
+
+error[E04015]: invalid use of native item
+  ┌─ tests/move_2024/matching/invalid_native_struct_field_binder.move:6:13
+  │
+2 │     public native struct N;
+  │            ------ Struct declared 'native' here
+  ·
+6 │             N { x } => x,
+  │             ^^^^^^^ Invalid pattern usage for native struct '0x42::m::N'. Native structs cannot be directly constructed/deconstructed, and their fields cannot be dirctly accessed

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/invalid_nested_native_struct.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/invalid_nested_native_struct.move
@@ -4,7 +4,7 @@
 // Tests: native struct nested inside a regular struct, destructured in match.
 // Targets: struct_fields().unwrap() in deeper specialization paths.
 module 0x0::M {
-    public native struct N;
+    public native struct N has drop;
 
     public struct Wrapper has drop {
         inner: N,

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/invalid_nested_native_struct.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/invalid_nested_native_struct.snap
@@ -5,22 +5,10 @@ info:
   edition: 2024.alpha
   lint: false
 ---
-error[E05001]: ability constraint not satisfied
-   ┌─ tests/move_2024/matching/invalid_nested_native_struct.move:10:16
-   │
- 7 │     public native struct N;
-   │                          - To satisfy the constraint, the 'drop' ability would need to be added here
-   ·
-10 │         inner: N,
-   │                ^
-   │                │
-   │                Invalid field type. The struct was declared with the ability 'drop' so all fields require the ability 'drop'
-   │                The type '0x0::M::N' does not have the ability 'drop'
-
 error[E04015]: invalid use of native item
    ┌─ tests/move_2024/matching/invalid_nested_native_struct.move:15:30
    │
- 7 │     public native struct N;
+ 7 │     public native struct N has drop;
    │            ------ Struct declared 'native' here
    ·
 15 │             Wrapper { inner: N {} } => 1,

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/invalid_or_binding_at_pattern.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/invalid_or_binding_at_pattern.move
@@ -1,0 +1,12 @@
+module 0x42::m {
+    public enum E has drop { A(u64), B }
+
+    fun t(e: E): u64 {
+        match (e) {
+            x @ (E::B(0) | E::A(_)) => match (x) {
+                _ => 0,
+            },
+            _ => 1,
+        }
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/invalid_or_binding_at_pattern.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/invalid_or_binding_at_pattern.snap
@@ -1,0 +1,26 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+error[E03013]: positional call mismatch
+  ┌─ tests/move_2024/matching/invalid_or_binding_at_pattern.move:6:18
+  │
+2 │     public enum E has drop { A(u64), B }
+  │                                      - 'B' is declared here
+  ·
+6 │             x @ (E::B(0) | E::A(_)) => match (x) {
+  │                  ^^^^^^^ Invalid variant pattern. Empty variant declarations require empty patterns
+  │
+  = Remove '()' arguments from this pattern
+
+warning[W04039]: unable to determine principal type for literal
+  ┌─ tests/move_2024/matching/invalid_or_binding_at_pattern.move:6:23
+  │
+6 │             x @ (E::B(0) | E::A(_)) => match (x) {
+  │                       ^ Could not determine a concrete type for this numeric literal, so defaulting to 'u64'
+  │
+  = To avoid this warning, add an explicit type annotation, e.g., '<num>u64'
+  = This warning can be suppressed with '#[allow(untyped_literal)]' applied to the 'module' or module member ('const', 'fun', or 'struct')

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/invalid_or_binding_struct.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/invalid_or_binding_struct.move
@@ -1,0 +1,9 @@
+module 0x42::m {
+    public struct S { x: u64 }
+
+    fun t(s: S): u64 {
+        match (s) {
+            S { x } | S { bogus: x } => x,
+        }
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/invalid_or_binding_struct.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/invalid_or_binding_struct.snap
@@ -1,0 +1,18 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+error[E03010]: unbound field
+  ┌─ tests/move_2024/matching/invalid_or_binding_struct.move:6:23
+  │
+6 │             S { x } | S { bogus: x } => x,
+  │                       ^^^^^^^^^^^^^^ Unbound field 'bogus' in '0x42::m::S'
+
+error[E04016]: too few arguments
+  ┌─ tests/move_2024/matching/invalid_or_binding_struct.move:6:23
+  │
+6 │             S { x } | S { bogus: x } => x,
+  │                       ^^^^^^^^^^^^^^ Missing pattern for field 'x' in '0x42::m::S'

--- a/external-crates/move/crates/move-compiler/tests/move_2024/naming/pattern_ellipsis_invalid.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/naming/pattern_ellipsis_invalid.snap
@@ -46,6 +46,12 @@ warning[W09002]: unused variable
    │
    = This warning can be suppressed with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
+error[E04010]: cannot infer type
+   ┌─ tests/move_2024/naming/pattern_ellipsis_invalid.move:18:18
+   │
+18 │             Y::D(x, ..) => 0,
+   │                  ^ Could not infer this type. Try adding an annotation
+
 error[E03013]: positional call mismatch
    ┌─ tests/move_2024/naming/pattern_ellipsis_invalid.move:19:13
    │
@@ -64,6 +70,12 @@ warning[W09002]: unused variable
    │                  ^ Unused local variable 'x'. Consider removing or prefixing with an underscore: '_x'
    │
    = This warning can be suppressed with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+error[E04010]: cannot infer type
+   ┌─ tests/move_2024/naming/pattern_ellipsis_invalid.move:19:18
+   │
+19 │             Y::D{x, ..} => 0,
+   │                  ^ Could not infer this type. Try adding an annotation
 
 error[E03013]: positional call mismatch
    ┌─ tests/move_2024/naming/pattern_ellipsis_invalid.move:25:13
@@ -112,6 +124,12 @@ warning[W09002]: unused variable
    │
    = This warning can be suppressed with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
+error[E04010]: cannot infer type
+   ┌─ tests/move_2024/naming/pattern_ellipsis_invalid.move:27:18
+   │
+27 │             X::D{x, ..} => 0,
+   │                  ^ Could not infer this type. Try adding an annotation
+
 error[E03013]: positional call mismatch
    ┌─ tests/move_2024/naming/pattern_ellipsis_invalid.move:33:13
    │
@@ -158,3 +176,9 @@ warning[W09002]: unused variable
    │                  ^ Unused local variable 'x'. Consider removing or prefixing with an underscore: '_x'
    │
    = This warning can be suppressed with '#[allow(unused_variable)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+error[E04010]: cannot infer type
+   ┌─ tests/move_2024/naming/pattern_ellipsis_invalid.move:35:18
+   │
+35 │             Z::D(x, ..) => 0,
+   │                  ^ Could not infer this type. Try adding an annotation


### PR DESCRIPTION
## Description 

Fixes #26110 which was caused due to type inference substitution information leakage. Added code paths to avoid unification in error cases, which avoids the issue.

## Test plan 

Tests added

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
