### PR TITLE
[Block Streaming] Introduce the NodeRole and the capabilities

### DIFF
--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -85,10 +85,9 @@ pub struct NodeConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub consensus_config: Option<ConsensusConfig>,
 
-    /// The sync mode for full nodes. `None` means the node is configured as a
-    /// validator. `Some(mode)` means it is a full node using the given sync
-    /// strategy. This drives the `intended_node_role()` used for startup
-    /// infrastructure decisions.
+    /// The sync mode for full nodes.
+    /// When `None` is provided and this is a full node then the default is used which is `StateSyncOnly`.
+    /// For validator nodes this is expected to be `None`
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub fullnode_sync_mode: Option<FullNodeSyncMode>,
 
@@ -916,30 +915,24 @@ impl NodeConfig {
     /// create RPC servers or index stores). The authoritative per-epoch role
     /// lives on `AuthorityPerEpochStore::node_role()`.
     pub fn intended_node_role(&self) -> NodeRole {
-        match self.fullnode_sync_mode {
-            Some(mode) => {
-                // Validate that consensus config has been set correctly when the the chosen sync mode has been set to consensus observer
-                if mode == FullNodeSyncMode::ConsensusObserver {
-                    assert!(
-                        self.has_observer_config_peers(),
-                        "Peers list should be set when full node is configured to sync as consensus observer."
-                    );
-                }
-                NodeRole::FullNode(mode)
+        let has_consensus_config = self.consensus_config.is_some();
+
+        match (self.fullnode_sync_mode, has_consensus_config) {
+            (Some(FullNodeSyncMode::ConsensusObserver), _) => {
+                assert!(
+                    self.has_observer_config_peers(),
+                    "Observer peers must be configured when sync mode is ConsensusObserver"
+                );
+                NodeRole::FullNode(FullNodeSyncMode::ConsensusObserver)
             }
-            None => {
-                // If the full node sync mode has not been set, then we need to check whether the node has a consensus config set. If yes, then this is a validator.
-                if self.consensus_config.is_some() {
-                    assert!(
-                        !self.has_observer_config_peers(),
-                        "Peers list should be empty when the node is configured as validator"
-                    );
-                    NodeRole::Validator
-                } else {
-                    // If there is no fullnode sync mode set, and not consensus config set, then this is a full node with state sync only
-                    NodeRole::FullNode(FullNodeSyncMode::StateSyncOnly)
-                }
+            (Some(FullNodeSyncMode::StateSyncOnly), true) => {
+                panic!("Consensus config should not be set for a StateSyncOnly full node");
             }
+            (Some(FullNodeSyncMode::StateSyncOnly), false) => {
+                NodeRole::FullNode(FullNodeSyncMode::StateSyncOnly)
+            }
+            (None, false) => NodeRole::FullNode(FullNodeSyncMode::StateSyncOnly),
+            (None, true) => NodeRole::Validator,
         }
     }
 

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -31,6 +31,7 @@ use sui_types::crypto::NetworkKeyPair;
 use sui_types::crypto::SuiKeyPair;
 use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 use sui_types::supported_protocol_versions::{Chain, SupportedProtocolVersions};
+use sui_types::node_role::NodeRole;
 use sui_types::traffic_control::{PolicyConfig, RemoteFirewallConfig};
 
 use sui_types::crypto::{AccountKeyPair, AuthorityKeyPair, get_key_pair_from_rng};
@@ -897,6 +898,34 @@ impl NodeConfig {
 
     pub fn consensus_config(&self) -> Option<&ConsensusConfig> {
         self.consensus_config.as_ref()
+    }
+
+    /// Determines the node role from static configuration.
+    /// This is a preliminary role based on config alone — the authoritative
+    /// role that also accounts for committee membership lives on
+    /// `AuthorityPerEpochStore::node_role()`.
+    pub fn node_role(&self) -> NodeRole {
+        let has_consensus_config = self.consensus_config.is_some();
+        let has_observer_peers = self
+            .consensus_config
+            .as_ref()
+            .and_then(|c| c.parameters.as_ref())
+            .map(|p| !p.observer.peers.is_empty())
+            .unwrap_or(false);
+        match (has_consensus_config, has_observer_peers) {
+            (true, false) => NodeRole::validator(),
+            (true, true) => NodeRole::observer(),
+            _ => NodeRole::fullnode(),
+        }
+    }
+
+    /// Whether this node has observer peers configured in its consensus config.
+    pub fn has_observer_config(&self) -> bool {
+        self.consensus_config
+            .as_ref()
+            .and_then(|c| c.parameters.as_ref())
+            .map(|p| !p.observer.peers.is_empty())
+            .unwrap_or(false)
     }
 
     pub fn genesis(&self) -> Result<&genesis::Genesis> {

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -1970,6 +1970,111 @@ remote-store-options:
         std::fs::remove_file(&service_account_file).ok();
         std::fs::remove_file(&aws_key_file).ok();
     }
+
+    mod intended_node_role_tests {
+        use super::*;
+        use crate::ConsensusConfig;
+        use consensus_config::Parameters as ConsensusParameters;
+        use fastcrypto::ed25519::Ed25519KeyPair;
+        use sui_types::node_role::{FullNodeSyncMode, NodeRole};
+
+        fn fullnode_template_config() -> NodeConfig {
+            const TEMPLATE: &str = include_str!("../data/fullnode-template.yaml");
+            serde_yaml::from_str(TEMPLATE).unwrap()
+        }
+
+        fn minimal_consensus_config() -> ConsensusConfig {
+            ConsensusConfig {
+                db_path: PathBuf::from("/tmp/consensus"),
+                db_retention_epochs: None,
+                db_pruner_period_secs: None,
+                max_pending_transactions: None,
+                parameters: Default::default(),
+                listen_address: None,
+                external_address: None,
+            }
+        }
+
+        fn consensus_config_with_observer_peers() -> ConsensusConfig {
+            let mut config = minimal_consensus_config();
+            let kp = Ed25519KeyPair::generate(&mut StdRng::from_seed([0; 32]));
+            let peer = consensus_config::PeerRecord {
+                public_key: consensus_config::NetworkPublicKey::new(kp.public().clone()),
+                address: "/ip4/127.0.0.1/udp/8080".parse().unwrap(),
+            };
+            let mut params = ConsensusParameters::default();
+            params.observer.peers = vec![peer];
+            config.parameters = Some(params);
+            config
+        }
+
+        #[test]
+        fn validator_with_consensus_config() {
+            let mut config = fullnode_template_config();
+            config.consensus_config = Some(minimal_consensus_config());
+            config.fullnode_sync_mode = None;
+
+            assert_eq!(config.intended_node_role(), NodeRole::Validator);
+        }
+
+        #[test]
+        fn fullnode_explicit_state_sync() {
+            let mut config = fullnode_template_config();
+            config.consensus_config = None;
+            config.fullnode_sync_mode = Some(FullNodeSyncMode::StateSyncOnly);
+
+            assert_eq!(
+                config.intended_node_role(),
+                NodeRole::FullNode(FullNodeSyncMode::StateSyncOnly)
+            );
+        }
+
+        #[test]
+        fn fullnode_implicit_state_sync() {
+            let mut config = fullnode_template_config();
+            config.consensus_config = None;
+            config.fullnode_sync_mode = None;
+
+            assert_eq!(
+                config.intended_node_role(),
+                NodeRole::FullNode(FullNodeSyncMode::StateSyncOnly)
+            );
+        }
+
+        #[test]
+        fn fullnode_consensus_observer() {
+            let mut config = fullnode_template_config();
+            config.consensus_config = Some(consensus_config_with_observer_peers());
+            config.fullnode_sync_mode = Some(FullNodeSyncMode::ConsensusObserver);
+
+            assert_eq!(
+                config.intended_node_role(),
+                NodeRole::FullNode(FullNodeSyncMode::ConsensusObserver)
+            );
+        }
+
+        #[test]
+        #[should_panic(
+            expected = "Consensus config should not be set for a StateSyncOnly full node"
+        )]
+        fn state_sync_with_consensus_config_panics() {
+            let mut config = fullnode_template_config();
+            config.consensus_config = Some(minimal_consensus_config());
+            config.fullnode_sync_mode = Some(FullNodeSyncMode::StateSyncOnly);
+
+            config.intended_node_role();
+        }
+
+        #[test]
+        #[should_panic(expected = "Observer peers must be configured")]
+        fn observer_without_peers_panics() {
+            let mut config = fullnode_template_config();
+            config.consensus_config = Some(minimal_consensus_config());
+            config.fullnode_sync_mode = Some(FullNodeSyncMode::ConsensusObserver);
+
+            config.intended_node_role();
+        }
+    }
 }
 
 // RunWithRange is used to specify the ending epoch/checkpoint to process.

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -30,6 +30,7 @@ use sui_types::crypto::KeypairTraits;
 use sui_types::crypto::NetworkKeyPair;
 use sui_types::crypto::SuiKeyPair;
 use sui_types::messages_checkpoint::CheckpointSequenceNumber;
+use sui_types::node_role::{FullNodeSyncMode, NodeRole};
 use sui_types::supported_protocol_versions::{Chain, SupportedProtocolVersions};
 use sui_types::traffic_control::{PolicyConfig, RemoteFirewallConfig};
 
@@ -83,6 +84,13 @@ pub struct NodeConfig {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub consensus_config: Option<ConsensusConfig>,
+
+    /// The sync mode for full nodes. `None` means the node is configured as a
+    /// validator. `Some(mode)` means it is a full node using the given sync
+    /// strategy. This drives the `intended_node_role()` used for startup
+    /// infrastructure decisions.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fullnode_sync_mode: Option<FullNodeSyncMode>,
 
     #[serde(default = "default_enable_index_processing")]
     pub enable_index_processing: bool,
@@ -883,7 +891,7 @@ impl NodeConfig {
         self.db_path.join("db_checkpoints")
     }
 
-    pub fn store_db_path(&self) -> PathBuf {
+    pub fn db_store_path(&self) -> PathBuf {
         self.db_path().join("store")
     }
 
@@ -903,8 +911,39 @@ impl NodeConfig {
         self.consensus_config.as_ref()
     }
 
-    /// Whether this node has observer peers configured in its consensus config.
-    pub fn has_observer_config(&self) -> bool {
+    /// Returns the node role as declared by configuration. This is the
+    /// *intended* role used for one-time startup decisions (e.g. whether to
+    /// create RPC servers or index stores). The authoritative per-epoch role
+    /// lives on `AuthorityPerEpochStore::node_role()`.
+    pub fn intended_node_role(&self) -> NodeRole {
+        match self.fullnode_sync_mode {
+            Some(mode) => {
+                // Validate that consensus config has been set correctly when the the chosen sync mode has been set to consensus observer
+                if mode == FullNodeSyncMode::ConsensusObserver {
+                    assert!(
+                        self.has_observer_config_peers(),
+                        "Peers list should be set when full node is configured to sync as consensus observer."
+                    );
+                }
+                NodeRole::FullNode(mode)
+            }
+            None => {
+                // If the full node sync mode has not been set, then we need to check whether the node has a consensus config set. If yes, then this is a validator.
+                if self.consensus_config.is_some() {
+                    assert!(
+                        !self.has_observer_config_peers(),
+                        "Peers list should be empty when the node is configured as validator"
+                    );
+                    NodeRole::Validator
+                } else {
+                    // If there is no fullnode sync mode set, and not consensus config set, then this is a full node with state sync only
+                    NodeRole::FullNode(FullNodeSyncMode::StateSyncOnly)
+                }
+            }
+        }
+    }
+
+    pub fn has_observer_config_peers(&self) -> bool {
         self.consensus_config
             .as_ref()
             .and_then(|c| c.parameters.as_ref())

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -30,7 +30,6 @@ use sui_types::crypto::KeypairTraits;
 use sui_types::crypto::NetworkKeyPair;
 use sui_types::crypto::SuiKeyPair;
 use sui_types::messages_checkpoint::CheckpointSequenceNumber;
-use sui_types::node_role::{FullNodeSyncMode, NodeRole};
 use sui_types::supported_protocol_versions::{Chain, SupportedProtocolVersions};
 use sui_types::traffic_control::{PolicyConfig, RemoteFirewallConfig};
 
@@ -884,6 +883,10 @@ impl NodeConfig {
         self.db_path.join("db_checkpoints")
     }
 
+    pub fn store_db_path(&self) -> PathBuf {
+        self.db_path().join("store")
+    }
+
     pub fn archive_path(&self) -> PathBuf {
         self.db_path.join("archive")
     }
@@ -898,25 +901,6 @@ impl NodeConfig {
 
     pub fn consensus_config(&self) -> Option<&ConsensusConfig> {
         self.consensus_config.as_ref()
-    }
-
-    /// Determines the node role from static configuration.
-    /// This is a preliminary role based on config alone — the authoritative
-    /// role that also accounts for committee membership lives on
-    /// `AuthorityPerEpochStore::node_role()`.
-    pub fn node_role(&self) -> NodeRole {
-        let has_consensus_config = self.consensus_config.is_some();
-        let has_observer_peers = self
-            .consensus_config
-            .as_ref()
-            .and_then(|c| c.parameters.as_ref())
-            .map(|p| !p.observer.peers.is_empty())
-            .unwrap_or(false);
-        match (has_consensus_config, has_observer_peers) {
-            (true, false) => NodeRole::Validator,
-            (true, true) => NodeRole::FullNode(FullNodeSyncMode::ConsensusObserver),
-            _ => NodeRole::FullNode(FullNodeSyncMode::StateSyncOnly),
-        }
     }
 
     /// Whether this node has observer peers configured in its consensus config.

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -30,8 +30,8 @@ use sui_types::crypto::KeypairTraits;
 use sui_types::crypto::NetworkKeyPair;
 use sui_types::crypto::SuiKeyPair;
 use sui_types::messages_checkpoint::CheckpointSequenceNumber;
-use sui_types::supported_protocol_versions::{Chain, SupportedProtocolVersions};
 use sui_types::node_role::NodeRole;
+use sui_types::supported_protocol_versions::{Chain, SupportedProtocolVersions};
 use sui_types::traffic_control::{PolicyConfig, RemoteFirewallConfig};
 
 use sui_types::crypto::{AccountKeyPair, AuthorityKeyPair, get_key_pair_from_rng};

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -30,7 +30,7 @@ use sui_types::crypto::KeypairTraits;
 use sui_types::crypto::NetworkKeyPair;
 use sui_types::crypto::SuiKeyPair;
 use sui_types::messages_checkpoint::CheckpointSequenceNumber;
-use sui_types::node_role::NodeRole;
+use sui_types::node_role::{FullNodeSyncMode, NodeRole};
 use sui_types::supported_protocol_versions::{Chain, SupportedProtocolVersions};
 use sui_types::traffic_control::{PolicyConfig, RemoteFirewallConfig};
 
@@ -913,9 +913,9 @@ impl NodeConfig {
             .map(|p| !p.observer.peers.is_empty())
             .unwrap_or(false);
         match (has_consensus_config, has_observer_peers) {
-            (true, false) => NodeRole::validator(),
-            (true, true) => NodeRole::observer(),
-            _ => NodeRole::fullnode(),
+            (true, false) => NodeRole::Validator,
+            (true, true) => NodeRole::FullNode(FullNodeSyncMode::ConsensusObserver),
+            _ => NodeRole::FullNode(FullNodeSyncMode::StateSyncOnly),
         }
     }
 

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -977,11 +977,11 @@ impl AuthorityState {
     }
 
     pub fn is_validator(&self, epoch_store: &AuthorityPerEpochStore) -> bool {
-        epoch_store.node_role().is_validator()
+        epoch_store.node_role() == NodeRole::Validator
     }
 
     pub fn is_fullnode(&self, epoch_store: &AuthorityPerEpochStore) -> bool {
-        epoch_store.node_role().is_fullnode()
+        matches!(epoch_store.node_role(), NodeRole::FullNode(_))
     }
 
     pub fn committee_store(&self) -> &Arc<CommitteeStore> {

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -6592,6 +6592,7 @@ impl AuthorityState {
             self.get_object_store().clone(),
             expensive_safety_check_config,
             epoch_last_checkpoint,
+            self.config.fullnode_sync_mode,
         )?;
         self.epoch_store.store(new_epoch_store.clone());
         Ok(new_epoch_store)

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -84,6 +84,7 @@ use sui_types::inner_temporary_store::PackageStoreWithFallback;
 use sui_types::layout_resolver::LayoutResolver;
 use sui_types::layout_resolver::into_struct_layout;
 use sui_types::messages_consensus::AuthorityCapabilitiesV2;
+use sui_types::node_role::NodeRole;
 use sui_types::object::bounded_visitor::BoundedVisitor;
 use sui_types::storage::ChildObjectResolver;
 use sui_types::storage::InputKey;
@@ -971,12 +972,16 @@ pub struct AuthorityState {
 ///
 /// Repeating valid commands should produce no changes and return no error.
 impl AuthorityState {
+    pub fn node_role(&self, epoch_store: &AuthorityPerEpochStore) -> NodeRole {
+        epoch_store.node_role()
+    }
+
     pub fn is_validator(&self, epoch_store: &AuthorityPerEpochStore) -> bool {
-        epoch_store.committee().authority_exists(&self.name)
+        epoch_store.node_role().is_validator()
     }
 
     pub fn is_fullnode(&self, epoch_store: &AuthorityPerEpochStore) -> bool {
-        !self.is_validator(epoch_store)
+        epoch_store.node_role().is_fullnode()
     }
 
     pub fn committee_store(&self) -> &Arc<CommitteeStore> {

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -977,11 +977,11 @@ impl AuthorityState {
     }
 
     pub fn is_validator(&self, epoch_store: &AuthorityPerEpochStore) -> bool {
-        epoch_store.node_role() == NodeRole::Validator
+        epoch_store.node_role().is_validator()
     }
 
     pub fn is_fullnode(&self, epoch_store: &AuthorityPerEpochStore) -> bool {
-        matches!(epoch_store.node_role(), NodeRole::FullNode(_))
+        epoch_store.node_role().is_fullnode()
     }
 
     pub fn committee_store(&self) -> &Arc<CommitteeStore> {

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -64,7 +64,7 @@ use sui_types::messages_consensus::{
     ConsensusTransaction, ConsensusTransactionKey, ConsensusTransactionKind, TimestampMs,
     VersionedDkgConfirmation, check_total_jwk_size,
 };
-use sui_types::node_role::NodeRole;
+use sui_types::node_role::{FullNodeSyncMode, NodeRole};
 use sui_types::signature::GenericSignature;
 use sui_types::storage::{BackingPackageStore, InputKey, ObjectStore};
 use sui_types::sui_system_state::epoch_start_sui_system_state::{
@@ -3854,17 +3854,17 @@ impl AuthorityPerEpochStore {
     /// committee membership and observer configuration.
     pub fn node_role(&self) -> NodeRole {
         if self.committee.authority_exists(&self.name) {
-            NodeRole::validator()
+            NodeRole::Validator
         } else if self.has_observer_config {
-            NodeRole::observer()
+            NodeRole::FullNode(FullNodeSyncMode::ConsensusObserver)
         } else {
-            NodeRole::fullnode()
+            NodeRole::FullNode(FullNodeSyncMode::StateSyncOnly)
         }
     }
 
     /// Whether this node is a validator in this epoch.
     pub fn is_validator(&self) -> bool {
-        self.node_role().is_validator()
+        self.node_role() == NodeRole::Validator
     }
 }
 

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -64,7 +64,7 @@ use sui_types::messages_consensus::{
     ConsensusTransaction, ConsensusTransactionKey, ConsensusTransactionKind, TimestampMs,
     VersionedDkgConfirmation, check_total_jwk_size,
 };
-use sui_types::node_role::NodeRole;
+use sui_types::node_role::{FullNodeSyncMode, NodeRole};
 use sui_types::signature::GenericSignature;
 use sui_types::storage::{BackingPackageStore, InputKey, ObjectStore};
 use sui_types::sui_system_state::epoch_start_sui_system_state::{
@@ -474,9 +474,9 @@ pub struct AuthorityPerEpochStore {
     /// barrier transaction (keyed by the same AccumulatorSettlement key as settlements).
     barrier_registrations: Arc<Mutex<HashMap<TransactionKey, BarrierRegistration>>>,
 
-    /// Whether the node is configured with observer peers (static from NodeConfig).
-    /// Used together with committee membership to compute NodeRole per epoch.
-    has_observer_config: bool,
+    /// The node's role for this epoch, derived from committee membership and
+    /// the configured sync mode. Computed once at construction.
+    node_role: NodeRole,
 }
 enum SettlementRegistration {
     Ready(Vec<VerifiedExecutableTransaction>),
@@ -1077,7 +1077,7 @@ impl AuthorityPerEpochStore {
         highest_executed_checkpoint: CheckpointSequenceNumber,
         previous_epoch_last_checkpoint: CheckpointSequenceNumber,
         submitted_transaction_cache_metrics: Arc<SubmittedTransactionCacheMetrics>,
-        has_observer_config: bool,
+        fullnode_sync_mode: Option<FullNodeSyncMode>,
     ) -> SuiResult<Arc<Self>> {
         let current_time = Instant::now();
         let epoch_id = committee.epoch;
@@ -1284,7 +1284,7 @@ impl AuthorityPerEpochStore {
             finalized_transactions_cache,
             settlement_registrations: Default::default(),
             barrier_registrations: Default::default(),
-            has_observer_config,
+            node_role: NodeRole::from_committee(&committee, &name, fullnode_sync_mode),
         });
 
         s.update_buffer_stake_metric();
@@ -1453,6 +1453,7 @@ impl AuthorityPerEpochStore {
         object_store: Arc<dyn ObjectStore + Send + Sync>,
         expensive_safety_check_config: &ExpensiveSafetyCheckConfig,
         epoch_last_checkpoint: CheckpointSequenceNumber,
+        fullnode_sync_mode: Option<FullNodeSyncMode>,
     ) -> SuiResult<Arc<Self>> {
         assert_eq!(self.epoch() + 1, new_committee.epoch);
         self.record_reconfig_halt_duration_metric();
@@ -1475,7 +1476,7 @@ impl AuthorityPerEpochStore {
             epoch_last_checkpoint,
             epoch_last_checkpoint,
             self.submitted_transaction_cache.metrics(),
-            self.has_observer_config,
+            fullnode_sync_mode,
         )
     }
 
@@ -1500,6 +1501,7 @@ impl AuthorityPerEpochStore {
             object_store,
             expensive_safety_check_config,
             epoch_last_checkpoint,
+            None,
         )
         .expect("failed to create new authority per epoch store")
     }
@@ -3850,10 +3852,9 @@ impl AuthorityPerEpochStore {
             .get_observations()
     }
 
-    /// Returns the role of this node for the current epoch, computed from
-    /// committee membership and observer configuration.
+    /// Returns the role of this node for the current epoch.
     pub fn node_role(&self) -> NodeRole {
-        NodeRole::from_committee(&self.committee, &self.name, self.has_observer_config)
+        self.node_role
     }
 
     /// Whether this node is a validator in this epoch.

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -3864,7 +3864,7 @@ impl AuthorityPerEpochStore {
 
     /// Whether this node is a validator in this epoch.
     pub fn is_validator(&self) -> bool {
-        self.node_role() == NodeRole::Validator
+        self.node_role().is_validator()
     }
 }
 

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -64,6 +64,7 @@ use sui_types::messages_consensus::{
     ConsensusTransaction, ConsensusTransactionKey, ConsensusTransactionKind, TimestampMs,
     VersionedDkgConfirmation, check_total_jwk_size,
 };
+use sui_types::node_role::NodeRole;
 use sui_types::signature::GenericSignature;
 use sui_types::storage::{BackingPackageStore, InputKey, ObjectStore};
 use sui_types::sui_system_state::epoch_start_sui_system_state::{
@@ -472,6 +473,10 @@ pub struct AuthorityPerEpochStore {
     /// Waiters for barrier transactions. Used by execution scheduler to wait for
     /// barrier transaction (keyed by the same AccumulatorSettlement key as settlements).
     barrier_registrations: Arc<Mutex<HashMap<TransactionKey, BarrierRegistration>>>,
+
+    /// Whether the node is configured with observer peers (static from NodeConfig).
+    /// Used together with committee membership to compute NodeRole per epoch.
+    has_observer_config: bool,
 }
 enum SettlementRegistration {
     Ready(Vec<VerifiedExecutableTransaction>),
@@ -1072,6 +1077,7 @@ impl AuthorityPerEpochStore {
         highest_executed_checkpoint: CheckpointSequenceNumber,
         previous_epoch_last_checkpoint: CheckpointSequenceNumber,
         submitted_transaction_cache_metrics: Arc<SubmittedTransactionCacheMetrics>,
+        has_observer_config: bool,
     ) -> SuiResult<Arc<Self>> {
         let current_time = Instant::now();
         let epoch_id = committee.epoch;
@@ -1278,6 +1284,7 @@ impl AuthorityPerEpochStore {
             finalized_transactions_cache,
             settlement_registrations: Default::default(),
             barrier_registrations: Default::default(),
+            has_observer_config,
         });
 
         s.update_buffer_stake_metric();
@@ -1468,6 +1475,7 @@ impl AuthorityPerEpochStore {
             epoch_last_checkpoint,
             epoch_last_checkpoint,
             self.submitted_transaction_cache.metrics(),
+            self.has_observer_config,
         )
     }
 
@@ -3842,9 +3850,21 @@ impl AuthorityPerEpochStore {
             .get_observations()
     }
 
+    /// Returns the role of this node for the current epoch, computed from
+    /// committee membership and observer configuration.
+    pub fn node_role(&self) -> NodeRole {
+        if self.committee.authority_exists(&self.name) {
+            NodeRole::validator()
+        } else if self.has_observer_config {
+            NodeRole::observer()
+        } else {
+            NodeRole::fullnode()
+        }
+    }
+
     /// Whether this node is a validator in this epoch.
     pub fn is_validator(&self) -> bool {
-        self.committee.authority_exists(&self.name)
+        self.node_role().is_validator()
     }
 }
 

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -64,7 +64,7 @@ use sui_types::messages_consensus::{
     ConsensusTransaction, ConsensusTransactionKey, ConsensusTransactionKind, TimestampMs,
     VersionedDkgConfirmation, check_total_jwk_size,
 };
-use sui_types::node_role::{FullNodeSyncMode, NodeRole};
+use sui_types::node_role::NodeRole;
 use sui_types::signature::GenericSignature;
 use sui_types::storage::{BackingPackageStore, InputKey, ObjectStore};
 use sui_types::sui_system_state::epoch_start_sui_system_state::{
@@ -3853,13 +3853,7 @@ impl AuthorityPerEpochStore {
     /// Returns the role of this node for the current epoch, computed from
     /// committee membership and observer configuration.
     pub fn node_role(&self) -> NodeRole {
-        if self.committee.authority_exists(&self.name) {
-            NodeRole::Validator
-        } else if self.has_observer_config {
-            NodeRole::FullNode(FullNodeSyncMode::ConsensusObserver)
-        } else {
-            NodeRole::FullNode(FullNodeSyncMode::StateSyncOnly)
-        }
+        NodeRole::from_committee(&self.committee, &self.name, self.has_observer_config)
     }
 
     /// Whether this node is a validator in this epoch.

--- a/crates/sui-core/src/authority/test_authority_builder.rs
+++ b/crates/sui-core/src/authority/test_authority_builder.rs
@@ -327,6 +327,7 @@ impl<'a> TestAuthorityBuilder<'a> {
                 .unwrap_or(0),
             0,
             Arc::new(SubmittedTransactionCacheMetrics::new(&registry)),
+            false,
         )
         .expect("failed to create authority per epoch store");
 

--- a/crates/sui-core/src/authority/test_authority_builder.rs
+++ b/crates/sui-core/src/authority/test_authority_builder.rs
@@ -327,7 +327,7 @@ impl<'a> TestAuthorityBuilder<'a> {
                 .unwrap_or(0),
             0,
             Arc::new(SubmittedTransactionCacheMetrics::new(&registry)),
-            false,
+            None,
         )
         .expect("failed to create authority per epoch store");
 

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -11,9 +11,9 @@ use crate::authority::AuthorityState;
 use crate::authority::epoch_start_configuration::EpochStartConfigTrait;
 use crate::authority_client::{AuthorityAPI, make_network_authority_clients_with_network_config};
 use crate::checkpoints::causal_order::CausalOrder;
-use crate::checkpoints::checkpoint_output::{CertifiedCheckpointOutput, CheckpointOutput};
+use crate::checkpoints::checkpoint_output::CertifiedCheckpointOutput;
 pub use crate::checkpoints::checkpoint_output::{
-    LogCheckpointOutput, SendCheckpointToStateSync, SubmitCheckpointToConsensus,
+    CheckpointOutput, LogCheckpointOutput, SendCheckpointToStateSync, SubmitCheckpointToConsensus,
 };
 pub use crate::checkpoints::metrics::CheckpointMetrics;
 use crate::consensus_manager::ReplayWaiter;

--- a/crates/sui-core/src/consensus_manager/mod.rs
+++ b/crates/sui-core/src/consensus_manager/mod.rs
@@ -137,10 +137,11 @@ fn to_consensus_protocol_config(config: &ProtocolConfig, chain: Chain) -> Consen
     )
 }
 
-/// Used by Sui validator to start consensus protocol for each epoch.
+/// Used by Sui to start consensus protocol for each epoch.
+/// Supports both validator mode (with protocol keypair) and observer mode (without).
 pub struct ConsensusManager {
     consensus_config: ConsensusConfig,
-    protocol_keypair: ProtocolKeyPair,
+    protocol_keypair: Option<ProtocolKeyPair>,
     network_keypair: NetworkKeyPair,
     storage_base_path: PathBuf,
     metrics: Arc<ConsensusManagerMetrics>,
@@ -178,15 +179,21 @@ impl ConsensusManager {
         consensus_config: &ConsensusConfig,
         registry_service: &RegistryService,
         consensus_client: Arc<UpdatableConsensusClient>,
+        is_validator: bool,
     ) -> Self {
         let metrics = Arc::new(ConsensusManagerMetrics::new(
             &registry_service.default_registry(),
         ));
         let client = Arc::new(LazyMysticetiClient::new());
         let (consumer_monitor_sender, _) = broadcast::channel(1);
+        let protocol_keypair = if is_validator {
+            Some(ProtocolKeyPair::new(node_config.worker_key_pair().copy()))
+        } else {
+            None
+        };
         Self {
             consensus_config: consensus_config.clone(),
-            protocol_keypair: ProtocolKeyPair::new(node_config.worker_key_pair().copy()),
+            protocol_keypair,
             network_keypair: NetworkKeyPair::new(node_config.network_key_pair().copy()),
             storage_base_path: consensus_config.db_path().to_path_buf(),
             metrics,
@@ -297,7 +304,7 @@ impl ConsensusManager {
             committee.clone(),
             parameters.clone(),
             to_consensus_protocol_config(protocol_config, epoch_store.get_chain()),
-            Some(self.protocol_keypair.clone()),
+            self.protocol_keypair.clone(),
             self.network_keypair.clone(),
             Arc::new(Clock::default()),
             Arc::new(tx_validator.clone()),

--- a/crates/sui-core/src/consensus_manager/mod.rs
+++ b/crates/sui-core/src/consensus_manager/mod.rs
@@ -29,6 +29,7 @@ use sui_protocol_config::{Chain, ProtocolConfig, ProtocolVersion};
 use sui_types::crypto::NetworkPublicKey;
 use sui_types::error::{SuiErrorKind, SuiResult};
 use sui_types::messages_consensus::{ConsensusPosition, ConsensusTransaction};
+use sui_types::node_role::NodeRole;
 use sui_types::{
     committee::EpochId, sui_system_state::epoch_start_sui_system_state::EpochStartSystemStateTrait,
 };
@@ -179,14 +180,14 @@ impl ConsensusManager {
         consensus_config: &ConsensusConfig,
         registry_service: &RegistryService,
         consensus_client: Arc<UpdatableConsensusClient>,
-        is_validator: bool,
+        node_role: NodeRole,
     ) -> Self {
         let metrics = Arc::new(ConsensusManagerMetrics::new(
             &registry_service.default_registry(),
         ));
         let client = Arc::new(LazyMysticetiClient::new());
         let (consumer_monitor_sender, _) = broadcast::channel(1);
-        let protocol_keypair = if is_validator {
+        let protocol_keypair = if node_role.is_validator() {
             Some(ProtocolKeyPair::new(node_config.worker_key_pair().copy()))
         } else {
             None

--- a/crates/sui-core/src/consensus_manager/mod.rs
+++ b/crates/sui-core/src/consensus_manager/mod.rs
@@ -187,7 +187,7 @@ impl ConsensusManager {
         ));
         let client = Arc::new(LazyMysticetiClient::new());
         let (consumer_monitor_sender, _) = broadcast::channel(1);
-        let protocol_keypair = if node_role == NodeRole::Validator {
+        let protocol_keypair = if node_role.is_validator() {
             Some(ProtocolKeyPair::new(node_config.worker_key_pair().copy()))
         } else {
             None

--- a/crates/sui-core/src/consensus_manager/mod.rs
+++ b/crates/sui-core/src/consensus_manager/mod.rs
@@ -187,7 +187,7 @@ impl ConsensusManager {
         ));
         let client = Arc::new(LazyMysticetiClient::new());
         let (consumer_monitor_sender, _) = broadcast::channel(1);
-        let protocol_keypair = if node_role.is_validator() {
+        let protocol_keypair = if node_role == NodeRole::Validator {
             Some(ProtocolKeyPair::new(node_config.worker_key_pair().copy()))
         } else {
             None

--- a/crates/sui-core/src/unit_tests/consensus_manager_tests.rs
+++ b/crates/sui-core/src/unit_tests/consensus_manager_tests.rs
@@ -8,8 +8,9 @@ use futures::FutureExt;
 use mysten_metrics::RegistryService;
 use prometheus::Registry;
 use sui_swarm_config::network_config_builder::ConfigBuilder;
-use sui_types::messages_checkpoint::{
-    CertifiedCheckpointSummary, CheckpointContents, CheckpointSummary,
+use sui_types::{
+    messages_checkpoint::{CertifiedCheckpointSummary, CheckpointContents, CheckpointSummary},
+    node_role::NodeRole,
 };
 use tokio::{sync::mpsc, time::sleep};
 
@@ -79,7 +80,7 @@ async fn test_consensus_manager() {
         consensus_config,
         &registry_service,
         consensus_client,
-        true,
+        sui_types::node_role::NodeRole::validator(),
     );
 
     let boot_counter = *manager.boot_counter.lock().await;
@@ -163,7 +164,7 @@ async fn test_consensus_manager_address_update() {
         consensus_config,
         &registry_service,
         consensus_client,
-        true,
+        NodeRole::validator(),
     ));
 
     // Start consensus

--- a/crates/sui-core/src/unit_tests/consensus_manager_tests.rs
+++ b/crates/sui-core/src/unit_tests/consensus_manager_tests.rs
@@ -80,7 +80,7 @@ async fn test_consensus_manager() {
         consensus_config,
         &registry_service,
         consensus_client,
-        sui_types::node_role::NodeRole::validator(),
+        sui_types::node_role::NodeRole::Validator,
     );
 
     let boot_counter = *manager.boot_counter.lock().await;
@@ -164,7 +164,7 @@ async fn test_consensus_manager_address_update() {
         consensus_config,
         &registry_service,
         consensus_client,
-        NodeRole::validator(),
+        NodeRole::Validator,
     ));
 
     // Start consensus

--- a/crates/sui-core/src/unit_tests/consensus_manager_tests.rs
+++ b/crates/sui-core/src/unit_tests/consensus_manager_tests.rs
@@ -79,6 +79,7 @@ async fn test_consensus_manager() {
         consensus_config,
         &registry_service,
         consensus_client,
+        true,
     );
 
     let boot_counter = *manager.boot_counter.lock().await;
@@ -162,6 +163,7 @@ async fn test_consensus_manager_address_update() {
         consensus_config,
         &registry_service,
         consensus_client,
+        true,
     ));
 
     // Start consensus

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -41,6 +41,7 @@ use sui_core::execution_cache::build_execution_cache;
 use sui_network::endpoint_manager::{AddressSource, EndpointId};
 use sui_network::validator::server::SUI_TLS_SERVER_NAME;
 use sui_types::full_checkpoint_content::Checkpoint;
+use sui_types::node_role::NodeRole;
 
 use sui_core::global_state_hasher::GlobalStateHashMetrics;
 use sui_core::storage::RestReadStore;
@@ -96,8 +97,8 @@ use sui_core::authority_server::{ValidatorService, ValidatorServiceMetrics};
 use sui_core::checkpoints::checkpoint_executor::metrics::CheckpointExecutorMetrics;
 use sui_core::checkpoints::checkpoint_executor::{CheckpointExecutor, StopReason};
 use sui_core::checkpoints::{
-    CheckpointMetrics, CheckpointService, CheckpointStore, SendCheckpointToStateSync,
-    SubmitCheckpointToConsensus,
+    CheckpointMetrics, CheckpointOutput, CheckpointService, CheckpointStore, LogCheckpointOutput,
+    SendCheckpointToStateSync, SubmitCheckpointToConsensus,
 };
 use sui_core::consensus_adapter::{ConsensusAdapter, ConsensusAdapterMetrics};
 use sui_core::consensus_manager::ConsensusManager;
@@ -161,7 +162,7 @@ mod handle;
 pub mod metrics;
 
 pub struct ValidatorComponents {
-    validator_server_handle: SpawnOnce,
+    validator_server_handle: Option<SpawnOnce>,
     validator_overload_monitor_handle: Option<JoinHandle<()>>,
     consensus_manager: Arc<ConsensusManager>,
     consensus_store_pruner: ConsensusStorePruner,
@@ -465,8 +466,9 @@ impl SuiNode {
         }
 
         let run_with_range = config.run_with_range;
-        let is_validator = config.consensus_config().is_some();
-        let is_full_node = !is_validator;
+        // Preliminary role from config — used for infrastructure decisions before
+        // the epoch store exists. The authoritative role is on AuthorityPerEpochStore.
+        let preliminary_role = config.node_role();
         let prometheus_registry = registry_service.default_registry();
 
         info!(node =? config.protocol_public_key(),
@@ -505,16 +507,18 @@ impl SuiNode {
         Self::check_and_recover_forks(
             &checkpoint_store,
             &checkpoint_metrics,
-            is_validator,
+            preliminary_role.should_check_forks(),
             config.fork_recovery.as_ref(),
         )
         .await?;
 
-        // By default, only enable write stall on validators for perpetual db.
-        let enable_write_stall = config.enable_db_write_stall.unwrap_or(is_validator);
+        // By default, only enable write stall on nodes that run consensus.
+        let enable_write_stall = config
+            .enable_db_write_stall
+            .unwrap_or(preliminary_role.runs_consensus());
         let perpetual_tables_options = AuthorityPerpetualTablesOptions {
             enable_write_stall,
-            is_validator,
+            is_validator: preliminary_role.is_validator(),
         };
         let perpetual_tables = Arc::new(AuthorityPerpetualTables::open(
             &config.db_path().join("store"),
@@ -598,6 +602,7 @@ impl SuiNode {
             Arc::new(SubmittedTransactionCacheMetrics::new(
                 &registry_service.default_registry(),
             )),
+            config.has_observer_config(),
         )?;
 
         info!("created epoch store");
@@ -646,7 +651,9 @@ impl SuiNode {
             checkpoint_store.clone(),
         );
 
-        let index_store = if is_full_node && config.enable_index_processing {
+        let index_store = if preliminary_role.should_enable_index_processing()
+            && config.enable_index_processing
+        {
             info!("creating jsonrpc index store");
             Some(Arc::new(IndexStore::new(
                 config.db_path().join("indexes"),
@@ -660,7 +667,9 @@ impl SuiNode {
             None
         };
 
-        let rpc_index = if is_full_node && config.rpc().is_some_and(|rpc| rpc.enable_indexing()) {
+        let rpc_index = if preliminary_role.should_enable_index_processing()
+            && config.rpc().is_some_and(|rpc| rpc.enable_indexing())
+        {
             info!("creating rpc index store");
             Some(Arc::new(
                 RpcIndexStore::new(
@@ -806,18 +815,19 @@ impl SuiNode {
         let (end_of_epoch_channel, end_of_epoch_receiver) =
             broadcast::channel(config.end_of_epoch_broadcast_channel_capacity);
 
-        let transaction_orchestrator = if is_full_node && run_with_range.is_none() {
-            Some(Arc::new(TransactionOrchestrator::new_with_auth_aggregator(
-                auth_agg.load_full(),
-                state.clone(),
-                end_of_epoch_receiver,
-                &config.db_path(),
-                &prometheus_registry,
-                &config,
-            )))
-        } else {
-            None
-        };
+        let transaction_orchestrator =
+            if preliminary_role.should_enable_index_processing() && run_with_range.is_none() {
+                Some(Arc::new(TransactionOrchestrator::new_with_auth_aggregator(
+                    auth_agg.load_full(),
+                    state.clone(),
+                    end_of_epoch_receiver,
+                    &config.db_path(),
+                    &prometheus_registry,
+                    &config,
+                )))
+            } else {
+                None
+            };
 
         let (http_servers, subscription_service_checkpoint_sender) = build_http_servers(
             state.clone(),
@@ -826,6 +836,7 @@ impl SuiNode {
             &config,
             &prometheus_registry,
             server_version,
+            preliminary_role,
         )
         .await?;
 
@@ -855,7 +866,8 @@ impl SuiNode {
             .configured_max_protocol_version
             .set(config.supported_protocol_versions.unwrap().max.as_u64() as i64);
 
-        let validator_components = if state.is_validator(&epoch_store) {
+        let node_role = epoch_store.node_role();
+        let validator_components = if node_role.runs_consensus() {
             let mut components = Self::construct_validator_components(
                 config.clone(),
                 state.clone(),
@@ -869,18 +881,31 @@ impl SuiNode {
                 &registry_service,
                 sui_node_metrics.clone(),
                 checkpoint_metrics.clone(),
+                node_role,
             )
             .await?;
 
-            components
-                .consensus_adapter
-                .recover_end_of_publish(&epoch_store);
+            if node_role.can_submit_to_consensus() {
+                components.consensus_adapter.submit_recovered(&epoch_store);
+            }
 
-            // Start the gRPC server
-            components.validator_server_handle = components.validator_server_handle.start().await;
+            if node_role.should_run_validator_service() {
+                // Start the gRPC server
+                components.validator_server_handle = Some(
+                    components
+                        .validator_server_handle
+                        .take()
+                        .unwrap()
+                        .start()
+                        .await,
+                );
 
-            // Set the consensus address updater so that we can update the consensus peer addresses when requested.
-            endpoint_manager.set_consensus_address_updater(components.consensus_manager.clone());
+                // Set the consensus address updater so that we can update the consensus peer addresses when requested.
+                endpoint_manager
+                    .set_consensus_address_updater(components.consensus_manager.clone());
+            } else {
+                info!("Starting node as Observer — connecting to configured peers");
+            }
 
             Some(components)
         } else {
@@ -1255,12 +1280,13 @@ impl SuiNode {
         registry_service: &RegistryService,
         sui_node_metrics: Arc<SuiNodeMetrics>,
         checkpoint_metrics: Arc<CheckpointMetrics>,
+        node_role: NodeRole,
     ) -> Result<ValidatorComponents> {
         let mut config_clone = config.clone();
         let consensus_config = config_clone
             .consensus_config
             .as_mut()
-            .ok_or_else(|| anyhow!("Validator is missing consensus config"))?;
+            .ok_or_else(|| anyhow!("Node is missing consensus config"))?;
 
         let client = Arc::new(UpdatableConsensusClient::new());
         let inflight_slot_freed_notify = Arc::new(tokio::sync::Notify::new());
@@ -1273,11 +1299,13 @@ impl SuiNode {
             checkpoint_store.clone(),
             inflight_slot_freed_notify.clone(),
         ));
+
         let consensus_manager = Arc::new(ConsensusManager::new(
             &config,
             consensus_config,
             registry_service,
             client,
+            node_role.can_submit_to_consensus(),
         ));
 
         // This only gets started up once, not on every epoch. (Make call to remove every epoch.)
@@ -1291,22 +1319,27 @@ impl SuiNode {
         let sui_tx_validator_metrics =
             SuiTxValidatorMetrics::new(&registry_service.default_registry());
 
-        let (validator_server_handle, admission_queue) = Self::start_grpc_validator_service(
-            &config,
-            state.clone(),
-            consensus_adapter.clone(),
-            epoch_store.clone(),
-            &registry_service.default_registry(),
-            inflight_slot_freed_notify,
-        )
-        .await?;
+        let validator_server_handle = if node_role.should_run_validator_service() {
+            Some(
+                Self::start_grpc_validator_service(
+                    &config,
+                    state.clone(),
+                    consensus_adapter.clone(),
+                    &registry_service.default_registry(),
+                )
+                .await?,
+            )
+        } else {
+            None
+        };
 
         // Starts an overload monitor that monitors the execution of the authority.
         // Don't start the overload monitor when max_load_shedding_percentage is 0.
-        let validator_overload_monitor_handle = if config
-            .authority_overload_config
-            .max_load_shedding_percentage
-            > 0
+        let validator_overload_monitor_handle = if node_role.should_run_overload_monitor()
+            && config
+                .authority_overload_config
+                .max_load_shedding_percentage
+                > 0
         {
             let authority_state = Arc::downgrade(&state);
             let overload_config = config.authority_overload_config.clone();
@@ -1337,6 +1370,7 @@ impl SuiNode {
             sui_node_metrics,
             sui_tx_validator_metrics,
             admission_queue,
+            node_role,
         )
         .await
     }
@@ -1353,12 +1387,13 @@ impl SuiNode {
         consensus_store_pruner: ConsensusStorePruner,
         state_hasher: Weak<GlobalStateHasher>,
         backpressure_manager: Arc<BackpressureManager>,
-        validator_server_handle: SpawnOnce,
+        validator_server_handle: Option<SpawnOnce>,
         validator_overload_monitor_handle: Option<JoinHandle<()>>,
         checkpoint_metrics: Arc<CheckpointMetrics>,
         sui_node_metrics: Arc<SuiNodeMetrics>,
         sui_tx_validator_metrics: Arc<SuiTxValidatorMetrics>,
         admission_queue: Option<AdmissionQueueContext>,
+        node_role: NodeRole,
     ) -> Result<ValidatorComponents> {
         let checkpoint_service = Self::build_checkpoint_service(
             config,
@@ -1369,9 +1404,10 @@ impl SuiNode {
             state_sync_handle,
             state_hasher,
             checkpoint_metrics.clone(),
+            node_role,
         );
 
-        if epoch_store.randomness_state_enabled() {
+        if node_role.should_run_randomness() && epoch_store.randomness_state_enabled() {
             let randomness_manager = RandomnessManager::try_new(
                 Arc::downgrade(&epoch_store),
                 Box::new(consensus_adapter.clone()),
@@ -1386,14 +1422,16 @@ impl SuiNode {
             }
         }
 
-        ExecutionTimeObserver::spawn(
-            epoch_store.clone(),
-            Box::new(consensus_adapter.clone()),
-            config
-                .execution_time_observer_config
-                .clone()
-                .unwrap_or_default(),
-        );
+        if node_role.should_run_execution_time_observer() {
+            ExecutionTimeObserver::spawn(
+                epoch_store.clone(),
+                Box::new(consensus_adapter.clone()),
+                config
+                    .execution_time_observer_config
+                    .clone()
+                    .unwrap_or_default(),
+            );
+        }
 
         let throughput_calculator = Arc::new(ConsensusThroughputCalculator::new(
             None,
@@ -1446,7 +1484,7 @@ impl SuiNode {
             .spawn(epoch_store.clone(), replay_waiter)
             .await;
 
-        if epoch_store.authenticator_state_enabled() {
+        if node_role.should_run_jwk_updater() && epoch_store.authenticator_state_enabled() {
             Self::start_jwk_updater(
                 config,
                 sui_node_metrics,
@@ -1481,6 +1519,7 @@ impl SuiNode {
         state_sync_handle: state_sync::Handle,
         state_hasher: Weak<GlobalStateHasher>,
         checkpoint_metrics: Arc<CheckpointMetrics>,
+        node_role: NodeRole,
     ) -> Arc<CheckpointService> {
         let epoch_start_timestamp_ms = epoch_store.epoch_start_state().epoch_start_timestamp_ms();
         let epoch_duration_ms = epoch_store.epoch_start_state().epoch_duration_ms();
@@ -1491,13 +1530,19 @@ impl SuiNode {
             epoch_start_timestamp_ms, epoch_duration_ms
         );
 
-        let checkpoint_output = Box::new(SubmitCheckpointToConsensus {
-            sender: consensus_adapter,
-            signer: state.secret.clone(),
-            authority: config.protocol_public_key(),
-            next_reconfiguration_timestamp_ms: epoch_store.next_reconfiguration_timestamp_ms(),
-            metrics: checkpoint_metrics.clone(),
-        });
+        let checkpoint_output: Box<dyn CheckpointOutput> = if node_role.can_submit_to_consensus() {
+            Box::new(SubmitCheckpointToConsensus {
+                sender: consensus_adapter,
+                signer: state.secret.clone(),
+                authority: config.protocol_public_key(),
+                next_reconfiguration_timestamp_ms: epoch_start_timestamp_ms
+                    .checked_add(epoch_duration_ms)
+                    .expect("Overflow calculating next_reconfiguration_timestamp_ms"),
+                metrics: checkpoint_metrics.clone(),
+            })
+        } else {
+            LogCheckpointOutput::boxed()
+        };
 
         let certified_checkpoint_output = SendCheckpointToStateSync::new(state_sync_handle);
         let max_tx_per_checkpoint = max_tx_per_checkpoint(epoch_store.protocol_config());
@@ -1808,6 +1853,8 @@ impl SuiNode {
                 )
                 .await;
 
+            let new_role = new_epoch_store.node_role();
+
             let new_validator_components = if let Some(ValidatorComponents {
                 validator_server_handle,
                 validator_overload_monitor_handle,
@@ -1819,12 +1866,10 @@ impl SuiNode {
                 admission_queue,
             }) = validator_components_lock_guard.take()
             {
-                info!("Reconfiguring the validator.");
+                info!("Reconfiguring node (was running consensus).");
 
                 consensus_manager.shutdown().await;
                 info!("Consensus has shut down.");
-
-                info!("Epoch store finished reconfiguration.");
 
                 // No other components should be holding a strong reference to state hasher
                 // at this point. Confirm here before we swap in the new hasher.
@@ -1840,8 +1885,8 @@ impl SuiNode {
 
                 consensus_store_pruner.prune(next_epoch).await;
 
-                if self.state.is_validator(&new_epoch_store) {
-                    // Only restart consensus if this node is still a validator in the new epoch.
+                if new_role.runs_consensus() {
+                    info!("Restarting consensus as {new_role}");
                     Some(
                         Self::start_epoch_specific_validator_components(
                             &self.config,
@@ -1861,11 +1906,12 @@ impl SuiNode {
                             self.metrics.clone(),
                             sui_tx_validator_metrics,
                             admission_queue,
+                            new_role,
                         )
                         .await?,
                     )
                 } else {
-                    info!("This node is no longer a validator after reconfiguration");
+                    info!("This node no longer runs consensus after reconfiguration");
                     None
                 }
             } else {
@@ -1881,8 +1927,8 @@ impl SuiNode {
                 let weak_hasher = Arc::downgrade(&new_hasher);
                 *hasher_guard = Some(new_hasher);
 
-                if self.state.is_validator(&new_epoch_store) {
-                    info!("Promoting the node from fullnode to validator, starting grpc server");
+                if new_role.runs_consensus() {
+                    info!("Promoting node to {new_role}, starting consensus components");
 
                     let mut components = Self::construct_validator_components(
                         self.config.clone(),
@@ -1897,15 +1943,23 @@ impl SuiNode {
                         &self.registry_service,
                         self.metrics.clone(),
                         self.checkpoint_metrics.clone(),
+                        new_role,
                     )
                     .await?;
 
-                    components.validator_server_handle =
-                        components.validator_server_handle.start().await;
+                    if new_role.should_run_validator_service() {
+                        components.validator_server_handle = Some(
+                            components
+                                .validator_server_handle
+                                .take()
+                                .unwrap()
+                                .start()
+                                .await,
+                        );
 
-                    // Set the consensus address updater as the full node got promoted now to a validator.
-                    self.endpoint_manager
-                        .set_consensus_address_updater(components.consensus_manager.clone());
+                        self.endpoint_manager
+                            .set_consensus_address_updater(components.consensus_manager.clone());
+                    }
 
                     Some(components)
                 } else {
@@ -2033,12 +2087,10 @@ impl SuiNode {
     async fn check_and_recover_forks(
         checkpoint_store: &CheckpointStore,
         checkpoint_metrics: &CheckpointMetrics,
-        is_validator: bool,
+        should_check_forks: bool,
         fork_recovery: Option<&ForkRecoveryConfig>,
     ) -> Result<()> {
-        // Fork detection and recovery is only relevant for validators
-        // Fullnodes should sync from validators and don't need fork checking
-        if !is_validator {
+        if !should_check_forks {
             return Ok(());
         }
 
@@ -2393,9 +2445,9 @@ async fn build_http_servers(
     config: &NodeConfig,
     prometheus_registry: &Registry,
     server_version: ServerVersion,
+    node_role: NodeRole,
 ) -> Result<(HttpServers, Option<tokio::sync::mpsc::Sender<Checkpoint>>)> {
-    // Validators do not expose these APIs
-    if config.consensus_config().is_some() {
+    if !node_role.should_run_rpc_servers() {
         return Ok((HttpServers::default(), None));
     }
 

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -518,7 +518,7 @@ impl SuiNode {
             .unwrap_or(preliminary_role.runs_consensus());
         let perpetual_tables_options = AuthorityPerpetualTablesOptions {
             enable_write_stall,
-            is_validator: preliminary_role == NodeRole::Validator,
+            is_validator: preliminary_role.is_validator(),
         };
         let perpetual_tables = Arc::new(AuthorityPerpetualTables::open(
             &config.db_path().join("store"),
@@ -815,19 +815,19 @@ impl SuiNode {
         let (end_of_epoch_channel, end_of_epoch_receiver) =
             broadcast::channel(config.end_of_epoch_broadcast_channel_capacity);
 
-        let transaction_orchestrator =
-            if preliminary_role.should_enable_index_processing() && run_with_range.is_none() {
-                Some(Arc::new(TransactionOrchestrator::new_with_auth_aggregator(
-                    auth_agg.load_full(),
-                    state.clone(),
-                    end_of_epoch_receiver,
-                    &config.db_path(),
-                    &prometheus_registry,
-                    &config,
-                )))
-            } else {
-                None
-            };
+        let transaction_orchestrator = if preliminary_role.is_fullnode() && run_with_range.is_none()
+        {
+            Some(Arc::new(TransactionOrchestrator::new_with_auth_aggregator(
+                auth_agg.load_full(),
+                state.clone(),
+                end_of_epoch_receiver,
+                &config.db_path(),
+                &prometheus_registry,
+                &config,
+            )))
+        } else {
+            None
+        };
 
         let (http_servers, subscription_service_checkpoint_sender) = build_http_servers(
             state.clone(),

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -1305,7 +1305,7 @@ impl SuiNode {
             consensus_config,
             registry_service,
             client,
-            node_role.can_submit_to_consensus(),
+            node_role,
         ));
 
         // This only gets started up once, not on every epoch. (Make call to remove every epoch.)

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -1915,7 +1915,9 @@ impl SuiNode {
                         .await?,
                     )
                 } else {
-                    info!("This node no longer runs consensus after reconfiguration");
+                    info!(
+                        "This node has new role {new_role} and no longer runs consensus after reconfiguration"
+                    );
                     None
                 }
             } else {
@@ -2451,6 +2453,7 @@ async fn build_http_servers(
     server_version: ServerVersion,
     node_role: NodeRole,
 ) -> Result<(HttpServers, Option<tokio::sync::mpsc::Sender<Checkpoint>>)> {
+    // Validators do not expose these APIs
     if !node_role.should_run_rpc_servers() {
         return Ok((HttpServers::default(), None));
     }

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -1737,7 +1737,10 @@ impl SuiNode {
                 .set(cur_epoch_store.protocol_config().version.as_u64() as i64);
 
             // Advertise capabilities to committee, if we are a validator.
-            if let Some(components) = &*self.validator_components.lock().await {
+            // FullNodes that state sync via consensus will also have validator components, by they are not supposed to submit any capabilities.
+            if let Some(components) = &*self.validator_components.lock().await
+                && cur_epoch_store.is_validator()
+            {
                 // TODO: without this sleep, the consensus message is not delivered reliably.
                 tokio::time::sleep(Duration::from_millis(1)).await;
 

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -494,7 +494,7 @@ impl SuiNode {
             None,
         ));
 
-        let node_role = Self::resolve_node_role(&config, &committee_store)?;
+        let node_role = config.intended_node_role();
 
         let pruner_watermarks = Arc::new(PrunerWatermarks::default());
         let checkpoint_store = CheckpointStore::new(
@@ -520,7 +520,7 @@ impl SuiNode {
             is_validator: node_role.is_validator(),
         };
         let perpetual_tables = Arc::new(AuthorityPerpetualTables::open(
-            &config.store_db_path(),
+            &config.db_store_path(),
             Some(perpetual_tables_options),
             Some(pruner_watermarks.epoch_id.clone()),
         ));
@@ -586,7 +586,7 @@ impl SuiNode {
         let epoch_store = AuthorityPerEpochStore::new(
             config.protocol_public_key(),
             committee.clone(),
-            &config.store_db_path(),
+            &config.db_store_path(),
             Some(epoch_options.options),
             EpochMetrics::new(&registry_service.default_registry()),
             epoch_start_configuration,
@@ -601,7 +601,7 @@ impl SuiNode {
             Arc::new(SubmittedTransactionCacheMetrics::new(
                 &registry_service.default_registry(),
             )),
-            config.has_observer_config(),
+            config.fullnode_sync_mode,
         )?;
 
         info!("created epoch store");
@@ -1707,15 +1707,6 @@ impl SuiNode {
                 "Creating checkpoint executor for epoch {}",
                 epoch_store.epoch()
             );
-            // Validators use the `verify_locally_built_checkpoint` path which
-            // skips checkpoint data processing for non-end-of-epoch checkpoints,
-            // creating gaps that cause the subscription service to panic.
-            let subscription_sender = if epoch_store.node_role().is_fullnode() {
-                self.subscription_service_checkpoint_sender.clone()
-            } else {
-                None
-            };
-
             let checkpoint_executor = CheckpointExecutor::new(
                 epoch_store.clone(),
                 self.checkpoint_store.clone(),
@@ -1724,7 +1715,7 @@ impl SuiNode {
                 self.backpressure_manager.clone(),
                 self.config.checkpoint_executor_config.clone(),
                 checkpoint_executor_metrics.clone(),
-                subscription_sender,
+                self.subscription_service_checkpoint_sender.clone(),
             );
 
             let run_with_range = self.config.run_with_range;
@@ -2097,36 +2088,6 @@ impl SuiNode {
         } else {
             digest_str
         }
-    }
-
-    /// Resolves the node role by temporarily opening the perpetual tables to
-    /// read the recovery epoch, then looking up the committee. On a fresh
-    /// genesis node the DB is empty, so we fall back to the latest committee
-    /// in the store (which is the genesis committee).
-    fn resolve_node_role(
-        config: &NodeConfig,
-        committee_store: &CommitteeStore,
-    ) -> SuiResult<NodeRole> {
-        let perpetual_tables = AuthorityPerpetualTables::open(&config.store_db_path(), None, None);
-
-        let committee = if perpetual_tables.database_is_empty()? {
-            committee_store.get_latest_committee()?
-        } else {
-            let cur_epoch = perpetual_tables.get_recovery_epoch_at_restart()?;
-            committee_store
-                .get_committee(&cur_epoch)?
-                .expect("Committee of the current epoch must exist")
-                .as_ref()
-                .clone()
-        };
-
-        drop(perpetual_tables);
-
-        Ok(NodeRole::from_committee(
-            &committee,
-            &config.protocol_public_key(),
-            config.has_observer_config(),
-        ))
     }
 
     /// Check for previously detected forks and handle them appropriately.

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -518,7 +518,7 @@ impl SuiNode {
             .unwrap_or(preliminary_role.runs_consensus());
         let perpetual_tables_options = AuthorityPerpetualTablesOptions {
             enable_write_stall,
-            is_validator: preliminary_role.is_validator(),
+            is_validator: preliminary_role == NodeRole::Validator,
         };
         let perpetual_tables = Arc::new(AuthorityPerpetualTables::open(
             &config.db_path().join("store"),
@@ -885,7 +885,7 @@ impl SuiNode {
             )
             .await?;
 
-            if node_role.can_submit_to_consensus() {
+            if node_role.can_propose_transactions() {
                 components.consensus_adapter.submit_recovered(&epoch_store);
             }
 
@@ -1530,7 +1530,7 @@ impl SuiNode {
             epoch_start_timestamp_ms, epoch_duration_ms
         );
 
-        let checkpoint_output: Box<dyn CheckpointOutput> = if node_role.can_submit_to_consensus() {
+        let checkpoint_output: Box<dyn CheckpointOutput> = if node_role.can_propose_transactions() {
             Box::new(SubmitCheckpointToConsensus {
                 sender: consensus_adapter,
                 signer: state.secret.clone(),

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -503,13 +503,14 @@ impl SuiNode {
         );
         let checkpoint_metrics = CheckpointMetrics::new(&registry_service.default_registry());
 
-        Self::check_and_recover_forks(
-            &checkpoint_store,
-            &checkpoint_metrics,
-            node_role.runs_consensus(),
-            config.fork_recovery.as_ref(),
-        )
-        .await?;
+        if node_role.runs_consensus() {
+            Self::check_and_recover_forks(
+                &checkpoint_store,
+                &checkpoint_metrics,
+                config.fork_recovery.as_ref(),
+            )
+            .await?;
+        }
 
         // By default, only enable write stall on nodes that run consensus.
         let enable_write_stall = config
@@ -886,9 +887,7 @@ impl SuiNode {
                 components
                     .consensus_adapter
                     .recover_end_of_publish(&epoch_store);
-            }
 
-            if node_role.is_validator() {
                 // Start the gRPC server
                 components.validator_server_handle = Some(
                     components
@@ -1878,6 +1877,8 @@ impl SuiNode {
                 consensus_manager.shutdown().await;
                 info!("Consensus has shut down.");
 
+                info!("Epoch store finished reconfiguration.");
+
                 // No other components should be holding a strong reference to state hasher
                 // at this point. Confirm here before we swap in the new hasher.
                 let global_state_hasher_metrics = Arc::into_inner(hasher)
@@ -2096,13 +2097,8 @@ impl SuiNode {
     async fn check_and_recover_forks(
         checkpoint_store: &CheckpointStore,
         checkpoint_metrics: &CheckpointMetrics,
-        should_check_forks: bool,
         fork_recovery: Option<&ForkRecoveryConfig>,
     ) -> Result<()> {
-        if !should_check_forks {
-            return Ok(());
-        }
-
         // Try to recover from forks if recovery config is provided
         if let Some(recovery) = fork_recovery {
             Self::try_recover_checkpoint_fork(checkpoint_store, recovery)?;
@@ -2668,7 +2664,6 @@ mod tests {
         let r = SuiNode::check_and_recover_forks(
             &checkpoint_store,
             &checkpoint_metrics,
-            true,
             Some(&fork_recovery),
         )
         .await;
@@ -2689,7 +2684,6 @@ mod tests {
         let r = SuiNode::check_and_recover_forks(
             &checkpoint_store,
             &checkpoint_metrics,
-            true,
             Some(&fork_recovery_with_override),
         )
         .await;
@@ -2717,7 +2711,6 @@ mod tests {
         let r = SuiNode::check_and_recover_forks(
             &checkpoint_store,
             &checkpoint_metrics,
-            true,
             Some(&fork_recovery),
         )
         .await;
@@ -2738,7 +2731,6 @@ mod tests {
         let r = SuiNode::check_and_recover_forks(
             &checkpoint_store,
             &checkpoint_metrics,
-            true,
             Some(&fork_recovery_with_override),
         )
         .await;

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -888,7 +888,7 @@ impl SuiNode {
                     .recover_end_of_publish(&epoch_store);
             }
 
-            if node_role.should_run_validator_service() {
+            if node_role.is_validator() {
                 // Start the gRPC server
                 components.validator_server_handle = Some(
                     components
@@ -1318,8 +1318,7 @@ impl SuiNode {
         let sui_tx_validator_metrics =
             SuiTxValidatorMetrics::new(&registry_service.default_registry());
 
-        let (validator_server_handle, admission_queue) = if node_role.should_run_validator_service()
-        {
+        let (validator_server_handle, admission_queue) = if node_role.is_validator() {
             let (handle, queue) = Self::start_grpc_validator_service(
                 &config,
                 state.clone(),
@@ -1336,7 +1335,7 @@ impl SuiNode {
 
         // Starts an overload monitor that monitors the execution of the authority.
         // Don't start the overload monitor when max_load_shedding_percentage is 0.
-        let validator_overload_monitor_handle = if node_role.should_run_overload_monitor()
+        let validator_overload_monitor_handle = if node_role.is_validator()
             && config
                 .authority_overload_config
                 .max_load_shedding_percentage
@@ -1423,7 +1422,7 @@ impl SuiNode {
             }
         }
 
-        if node_role.should_run_execution_time_observer() {
+        if node_role.is_validator() {
             ExecutionTimeObserver::spawn(
                 epoch_store.clone(),
                 Box::new(consensus_adapter.clone()),
@@ -1485,7 +1484,7 @@ impl SuiNode {
             .spawn(epoch_store.clone(), replay_waiter)
             .await;
 
-        if node_role.should_run_jwk_updater() && epoch_store.authenticator_state_enabled() {
+        if node_role.is_validator() && epoch_store.authenticator_state_enabled() {
             Self::start_jwk_updater(
                 config,
                 sui_node_metrics,
@@ -1708,6 +1707,15 @@ impl SuiNode {
                 "Creating checkpoint executor for epoch {}",
                 epoch_store.epoch()
             );
+            // Validators use the `verify_locally_built_checkpoint` path which
+            // skips checkpoint data processing for non-end-of-epoch checkpoints,
+            // creating gaps that cause the subscription service to panic.
+            let subscription_sender = if epoch_store.node_role().is_fullnode() {
+                self.subscription_service_checkpoint_sender.clone()
+            } else {
+                None
+            };
+
             let checkpoint_executor = CheckpointExecutor::new(
                 epoch_store.clone(),
                 self.checkpoint_store.clone(),
@@ -1716,7 +1724,7 @@ impl SuiNode {
                 self.backpressure_manager.clone(),
                 self.config.checkpoint_executor_config.clone(),
                 checkpoint_executor_metrics.clone(),
-                self.subscription_service_checkpoint_sender.clone(),
+                subscription_sender,
             );
 
             let run_with_range = self.config.run_with_range;
@@ -1954,7 +1962,7 @@ impl SuiNode {
                     )
                     .await?;
 
-                    if new_role.should_run_validator_service() {
+                    if new_role.is_validator() {
                         components.validator_server_handle = Some(
                             components
                                 .validator_server_handle

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -886,7 +886,9 @@ impl SuiNode {
             .await?;
 
             if node_role.can_propose_transactions() {
-                components.consensus_adapter.submit_recovered(&epoch_store);
+                components
+                    .consensus_adapter
+                    .recover_end_of_publish(&epoch_store);
             }
 
             if node_role.should_run_validator_service() {
@@ -1319,18 +1321,20 @@ impl SuiNode {
         let sui_tx_validator_metrics =
             SuiTxValidatorMetrics::new(&registry_service.default_registry());
 
-        let validator_server_handle = if node_role.should_run_validator_service() {
-            Some(
-                Self::start_grpc_validator_service(
-                    &config,
-                    state.clone(),
-                    consensus_adapter.clone(),
-                    &registry_service.default_registry(),
-                )
-                .await?,
+        let (validator_server_handle, admission_queue) = if node_role.should_run_validator_service()
+        {
+            let (handle, queue) = Self::start_grpc_validator_service(
+                &config,
+                state.clone(),
+                consensus_adapter.clone(),
+                epoch_store.clone(),
+                &registry_service.default_registry(),
+                inflight_slot_freed_notify,
             )
+            .await?;
+            (Some(handle), queue)
         } else {
-            None
+            (None, None)
         };
 
         // Starts an overload monitor that monitors the execution of the authority.

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -466,9 +466,6 @@ impl SuiNode {
         }
 
         let run_with_range = config.run_with_range;
-        // Preliminary role from config — used for infrastructure decisions before
-        // the epoch store exists. The authoritative role is on AuthorityPerEpochStore.
-        let preliminary_role = config.node_role();
         let prometheus_registry = registry_service.default_registry();
 
         info!(node =? config.protocol_public_key(),
@@ -497,6 +494,8 @@ impl SuiNode {
             None,
         ));
 
+        let node_role = Self::resolve_node_role(&config, &committee_store)?;
+
         let pruner_watermarks = Arc::new(PrunerWatermarks::default());
         let checkpoint_store = CheckpointStore::new(
             &config.db_path().join("checkpoints"),
@@ -507,7 +506,7 @@ impl SuiNode {
         Self::check_and_recover_forks(
             &checkpoint_store,
             &checkpoint_metrics,
-            preliminary_role.should_check_forks(),
+            node_role.runs_consensus(),
             config.fork_recovery.as_ref(),
         )
         .await?;
@@ -515,13 +514,13 @@ impl SuiNode {
         // By default, only enable write stall on nodes that run consensus.
         let enable_write_stall = config
             .enable_db_write_stall
-            .unwrap_or(preliminary_role.runs_consensus());
+            .unwrap_or(node_role.runs_consensus());
         let perpetual_tables_options = AuthorityPerpetualTablesOptions {
             enable_write_stall,
-            is_validator: preliminary_role.is_validator(),
+            is_validator: node_role.is_validator(),
         };
         let perpetual_tables = Arc::new(AuthorityPerpetualTables::open(
-            &config.db_path().join("store"),
+            &config.store_db_path(),
             Some(perpetual_tables_options),
             Some(pruner_watermarks.epoch_id.clone()),
         ));
@@ -587,7 +586,7 @@ impl SuiNode {
         let epoch_store = AuthorityPerEpochStore::new(
             config.protocol_public_key(),
             committee.clone(),
-            &config.db_path().join("store"),
+            &config.store_db_path(),
             Some(epoch_options.options),
             EpochMetrics::new(&registry_service.default_registry()),
             epoch_start_configuration,
@@ -651,23 +650,22 @@ impl SuiNode {
             checkpoint_store.clone(),
         );
 
-        let index_store = if preliminary_role.should_enable_index_processing()
-            && config.enable_index_processing
-        {
-            info!("creating jsonrpc index store");
-            Some(Arc::new(IndexStore::new(
-                config.db_path().join("indexes"),
-                &prometheus_registry,
-                epoch_store
-                    .protocol_config()
-                    .max_move_identifier_len_as_option(),
-                config.remove_deprecated_tables,
-            )))
-        } else {
-            None
-        };
+        let index_store =
+            if node_role.should_enable_index_processing() && config.enable_index_processing {
+                info!("creating jsonrpc index store");
+                Some(Arc::new(IndexStore::new(
+                    config.db_path().join("indexes"),
+                    &prometheus_registry,
+                    epoch_store
+                        .protocol_config()
+                        .max_move_identifier_len_as_option(),
+                    config.remove_deprecated_tables,
+                )))
+            } else {
+                None
+            };
 
-        let rpc_index = if preliminary_role.should_enable_index_processing()
+        let rpc_index = if node_role.should_enable_index_processing()
             && config.rpc().is_some_and(|rpc| rpc.enable_indexing())
         {
             info!("creating rpc index store");
@@ -815,8 +813,7 @@ impl SuiNode {
         let (end_of_epoch_channel, end_of_epoch_receiver) =
             broadcast::channel(config.end_of_epoch_broadcast_channel_capacity);
 
-        let transaction_orchestrator = if preliminary_role.is_fullnode() && run_with_range.is_none()
-        {
+        let transaction_orchestrator = if node_role.is_fullnode() && run_with_range.is_none() {
             Some(Arc::new(TransactionOrchestrator::new_with_auth_aggregator(
                 auth_agg.load_full(),
                 state.clone(),
@@ -836,7 +833,7 @@ impl SuiNode {
             &config,
             &prometheus_registry,
             server_version,
-            preliminary_role,
+            node_role,
         )
         .await?;
 
@@ -1411,7 +1408,7 @@ impl SuiNode {
             node_role,
         );
 
-        if node_role.should_run_randomness() && epoch_store.randomness_state_enabled() {
+        if node_role.runs_consensus() && epoch_store.randomness_state_enabled() {
             let randomness_manager = RandomnessManager::try_new(
                 Arc::downgrade(&epoch_store),
                 Box::new(consensus_adapter.clone()),
@@ -1656,6 +1653,10 @@ impl SuiNode {
 
     pub fn state(&self) -> Arc<AuthorityState> {
         self.state.clone()
+    }
+
+    pub fn node_role(&self) -> NodeRole {
+        self.state.load_epoch_store_one_call_per_task().node_role()
     }
 
     // Only used for testing because of how epoch store is loaded.
@@ -2085,6 +2086,36 @@ impl SuiNode {
         } else {
             digest_str
         }
+    }
+
+    /// Resolves the node role by temporarily opening the perpetual tables to
+    /// read the recovery epoch, then looking up the committee. On a fresh
+    /// genesis node the DB is empty, so we fall back to the latest committee
+    /// in the store (which is the genesis committee).
+    fn resolve_node_role(
+        config: &NodeConfig,
+        committee_store: &CommitteeStore,
+    ) -> SuiResult<NodeRole> {
+        let perpetual_tables = AuthorityPerpetualTables::open(&config.store_db_path(), None, None);
+
+        let committee = if perpetual_tables.database_is_empty()? {
+            committee_store.get_latest_committee()?
+        } else {
+            let cur_epoch = perpetual_tables.get_recovery_epoch_at_restart()?;
+            committee_store
+                .get_committee(&cur_epoch)?
+                .expect("Committee of the current epoch must exist")
+                .as_ref()
+                .clone()
+        };
+
+        drop(perpetual_tables);
+
+        Ok(NodeRole::from_committee(
+            &committee,
+            &config.protocol_public_key(),
+            config.has_observer_config(),
+        ))
     }
 
     /// Check for previously detected forks and handle them appropriately.

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -882,7 +882,7 @@ impl SuiNode {
             )
             .await?;
 
-            if node_role.can_propose_transactions() {
+            if node_role.is_validator() {
                 components
                     .consensus_adapter
                     .recover_end_of_publish(&epoch_store);
@@ -1530,7 +1530,7 @@ impl SuiNode {
             epoch_start_timestamp_ms, epoch_duration_ms
         );
 
-        let checkpoint_output: Box<dyn CheckpointOutput> = if node_role.can_propose_transactions() {
+        let checkpoint_output: Box<dyn CheckpointOutput> = if node_role.is_validator() {
             Box::new(SubmitCheckpointToConsensus {
                 sender: consensus_adapter,
                 signer: state.secret.clone(),

--- a/crates/sui-node/src/main.rs
+++ b/crates/sui-node/src/main.rs
@@ -118,8 +118,6 @@ fn main() {
         config.network_address = listen_address;
     }
 
-    let is_validator = config.node_role().is_validator();
-
     let admin_interface_port = config.admin_interface_port;
 
     // Run node in a separate runtime so that admin/monitoring functions continue to work
@@ -164,6 +162,7 @@ fn main() {
     runtimes.metrics.spawn(async move {
         let node = node_once_cell_clone.get().await;
         let chain_identifier = node.state().get_chain_identifier().to_string();
+        let is_validator = node.node_role().is_validator();
         info!("Sui chain identifier: {chain_identifier}");
         prometheus_registry
             .register(mysten_metrics::uptime_metric(
@@ -183,6 +182,7 @@ fn main() {
     runtimes.metrics.spawn(async move {
         let node = node_once_cell.get().await;
         let state = node.state();
+        let is_validator = node.node_role().is_validator();
         loop {
             send_telemetry_event(state.clone(), is_validator).await;
             sleep(Duration::from_secs(3600)).await;

--- a/crates/sui-node/src/main.rs
+++ b/crates/sui-node/src/main.rs
@@ -118,7 +118,7 @@ fn main() {
         config.network_address = listen_address;
     }
 
-    let is_validator = config.consensus_config().is_some();
+    let is_validator = config.node_role().is_validator();
 
     let admin_interface_port = config.admin_interface_port;
 

--- a/crates/sui-node/src/main.rs
+++ b/crates/sui-node/src/main.rs
@@ -118,7 +118,7 @@ fn main() {
         config.network_address = listen_address;
     }
 
-    let is_validator = config.node_role() == sui_types::node_role::NodeRole::Validator;
+    let is_validator = config.node_role().is_validator();
 
     let admin_interface_port = config.admin_interface_port;
 

--- a/crates/sui-node/src/main.rs
+++ b/crates/sui-node/src/main.rs
@@ -118,7 +118,7 @@ fn main() {
         config.network_address = listen_address;
     }
 
-    let is_validator = config.node_role().is_validator();
+    let is_validator = config.node_role() == sui_types::node_role::NodeRole::Validator;
 
     let admin_interface_port = config.admin_interface_port;
 

--- a/crates/sui-node/src/main.rs
+++ b/crates/sui-node/src/main.rs
@@ -118,6 +118,8 @@ fn main() {
         config.network_address = listen_address;
     }
 
+    let is_validator = config.intended_node_role().is_validator();
+
     let admin_interface_port = config.admin_interface_port;
 
     // Run node in a separate runtime so that admin/monitoring functions continue to work
@@ -162,7 +164,6 @@ fn main() {
     runtimes.metrics.spawn(async move {
         let node = node_once_cell_clone.get().await;
         let chain_identifier = node.state().get_chain_identifier().to_string();
-        let is_validator = node.node_role().is_validator();
         info!("Sui chain identifier: {chain_identifier}");
         prometheus_registry
             .register(mysten_metrics::uptime_metric(
@@ -182,7 +183,6 @@ fn main() {
     runtimes.metrics.spawn(async move {
         let node = node_once_cell.get().await;
         let state = node.state();
-        let is_validator = node.node_role().is_validator();
         loop {
             send_telemetry_event(state.clone(), is_validator).await;
             sleep(Duration::from_secs(3600)).await;

--- a/crates/sui-swarm-config/src/node_config_builder.rs
+++ b/crates/sui-swarm-config/src/node_config_builder.rs
@@ -24,6 +24,7 @@ use sui_config::{
 use sui_protocol_config::Chain;
 use sui_types::crypto::{AuthorityKeyPair, AuthorityPublicKeyBytes, NetworkKeyPair, SuiKeyPair};
 use sui_types::multiaddr::Multiaddr;
+use sui_types::node_role::FullNodeSyncMode;
 use sui_types::supported_protocol_versions::SupportedProtocolVersions;
 use sui_types::traffic_control::{PolicyConfig, RemoteFirewallConfig};
 
@@ -213,6 +214,7 @@ impl ValidatorConfigBuilder {
                 .to_socket_addr()
                 .unwrap(),
             consensus_config: Some(consensus_config),
+            fullnode_sync_mode: None,
             remove_deprecated_tables: false,
             enable_index_processing: default_enable_index_processing(),
             sync_post_process_one_tx: false,
@@ -558,6 +560,7 @@ impl FullnodeConfigBuilder {
                 .unwrap_or(local_ip_utils::get_available_port(&localhost)),
             json_rpc_address: self.json_rpc_address.unwrap_or(json_rpc_address),
             consensus_config: None,
+            fullnode_sync_mode: Some(FullNodeSyncMode::StateSyncOnly),
             remove_deprecated_tables: false,
             enable_index_processing: default_enable_index_processing(),
             sync_post_process_one_tx: self.sync_post_process_one_tx,

--- a/crates/sui-types/src/lib.rs
+++ b/crates/sui-types/src/lib.rs
@@ -77,6 +77,7 @@ pub mod move_package;
 pub mod multisig;
 pub mod multisig_legacy;
 pub mod nitro_attestation;
+pub mod node_role;
 pub mod object;
 pub mod passkey_authenticator;
 pub mod programmable_transaction_builder;

--- a/crates/sui-types/src/node_role.rs
+++ b/crates/sui-types/src/node_role.rs
@@ -20,11 +20,10 @@ pub enum FullNodeSyncMode {
 /// the committee). FullNodes carry a sync mode that determines whether
 /// they also participate in consensus as an observer.
 ///
-/// Behavior should be gated through capability methods (e.g. `runs_consensus()`,
-/// `can_propose_transactions()`) rather than matching on variants directly.
+/// Behavior should be gated through capability methods (e.g. `runs_consensus()`) rather than matching on variants directly.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum NodeRole {
-    /// A validator that participates in consensus and signs checkpoints.
+    /// A validator that participates in consensus, proposes blocks and signs checkpoints.
     Validator,
     /// A full node that serves RPC/indexing and syncs via the configured mode.
     FullNode(FullNodeSyncMode),
@@ -64,11 +63,6 @@ impl NodeRole {
         )
     }
 
-    /// Whether this node can propose transactions and checkpoint signatures to consensus.
-    pub fn can_propose_transactions(&self) -> bool {
-        matches!(self, Self::Validator)
-    }
-
     /// Whether this node should create index stores for JSON-RPC and REST API.
     pub fn should_enable_index_processing(&self) -> bool {
         matches!(self, Self::FullNode(_))
@@ -100,7 +94,6 @@ mod tests {
     fn test_validator_role() {
         let role = NodeRole::Validator;
         assert!(role.runs_consensus());
-        assert!(role.can_propose_transactions());
         assert!(!role.should_enable_index_processing());
         assert!(!role.should_run_rpc_servers());
     }
@@ -109,7 +102,6 @@ mod tests {
     fn test_consensus_observer_role() {
         let role = NodeRole::FullNode(FullNodeSyncMode::ConsensusObserver);
         assert!(role.runs_consensus());
-        assert!(!role.can_propose_transactions());
         assert!(role.should_enable_index_processing());
         assert!(role.should_run_rpc_servers());
     }
@@ -118,7 +110,6 @@ mod tests {
     fn test_fullnode_state_sync_role() {
         let role = NodeRole::FullNode(FullNodeSyncMode::StateSyncOnly);
         assert!(!role.runs_consensus());
-        assert!(!role.can_propose_transactions());
         assert!(role.should_enable_index_processing());
         assert!(role.should_run_rpc_servers());
     }

--- a/crates/sui-types/src/node_role.rs
+++ b/crates/sui-types/src/node_role.rs
@@ -3,9 +3,11 @@
 
 use crate::base_types::AuthorityName;
 use crate::committee::Committee;
+use serde::{Deserialize, Serialize};
 
 /// How a full node syncs data from the network.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
 pub enum FullNodeSyncMode {
     /// Syncs exclusively via the state-sync protocol.
     StateSyncOnly = 0,
@@ -29,18 +31,17 @@ pub enum NodeRole {
 }
 
 impl NodeRole {
-    /// Determines the node role from committee membership and observer configuration.
-    /// This is the single source of truth for role derivation — used both at startup
-    /// (with the latest committee from CommitteeStore) and per-epoch (in AuthorityPerEpochStore).
+    /// Determines the node role from committee membership and the configured sync mode.
+    /// Used per-epoch in AuthorityPerEpochStore to derive the authoritative role.
     pub fn from_committee(
         committee: &Committee,
         name: &AuthorityName,
-        has_observer_config: bool,
+        fullnode_sync_mode: Option<FullNodeSyncMode>,
     ) -> Self {
         if committee.authority_exists(name) {
             NodeRole::Validator
-        } else if has_observer_config {
-            NodeRole::FullNode(FullNodeSyncMode::ConsensusObserver)
+        } else if let Some(mode) = fullnode_sync_mode {
+            NodeRole::FullNode(mode)
         } else {
             NodeRole::FullNode(FullNodeSyncMode::StateSyncOnly)
         }

--- a/crates/sui-types/src/node_role.rs
+++ b/crates/sui-types/src/node_role.rs
@@ -26,6 +26,13 @@ pub enum NodeRole {
 }
 
 impl NodeRole {
+    pub fn is_fullnode(&self) -> bool {
+        matches!(self, Self::FullNode(_))
+    }
+
+    pub fn is_validator(&self) -> bool {
+        matches!(self, Self::Validator)
+    }
     // --- Capability methods ---
 
     /// Whether this node participates in the consensus protocol.

--- a/crates/sui-types/src/node_role.rs
+++ b/crates/sui-types/src/node_role.rs
@@ -73,26 +73,6 @@ impl NodeRole {
         matches!(self, Self::FullNode(_))
     }
 
-    /// Whether this node should expose the gRPC validator service.
-    pub fn should_run_validator_service(&self) -> bool {
-        matches!(self, Self::Validator)
-    }
-
-    /// Whether this node should run the authority overload monitor.
-    pub fn should_run_overload_monitor(&self) -> bool {
-        matches!(self, Self::Validator)
-    }
-
-    /// Whether this node should submit JWK updates to consensus.
-    pub fn should_run_jwk_updater(&self) -> bool {
-        matches!(self, Self::Validator)
-    }
-
-    /// Whether this node should run the execution time observer.
-    pub fn should_run_execution_time_observer(&self) -> bool {
-        matches!(self, Self::Validator)
-    }
-
     /// Whether this node should expose HTTP/RPC servers (JSON-RPC, REST).
     pub fn should_run_rpc_servers(&self) -> bool {
         matches!(self, Self::FullNode(_))

--- a/crates/sui-types/src/node_role.rs
+++ b/crates/sui-types/src/node_role.rs
@@ -1,123 +1,101 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-/// Represents the roles a node plays in the network for a given epoch.
-/// A node can have multiple active roles — for example, an observer-mode
-/// full node is both a FullNode and an Observer.
+/// How a full node syncs data from the network.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FullNodeSyncMode {
+    /// Syncs exclusively via the state-sync protocol.
+    StateSyncOnly = 0,
+    /// Streams consensus blocks for faster ingestion, in addition to state sync.
+    ConsensusObserver = 1,
+}
+
+/// Represents the role a node plays in the network for a given epoch.
+/// A node is either a Validator (in the committee) or a FullNode (not in
+/// the committee). FullNodes carry a sync mode that determines whether
+/// they also participate in consensus as an observer.
 ///
 /// Behavior should be gated through capability methods (e.g. `runs_consensus()`,
-/// `can_submit_to_consensus()`) rather than checking individual role booleans.
+/// `can_propose_transactions()`) rather than matching on variants directly.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct NodeRole {
-    is_validator: bool,
-    is_observer: bool,
-    is_fullnode: bool,
+pub enum NodeRole {
+    /// A validator that participates in consensus and signs checkpoints.
+    Validator,
+    /// A full node that serves RPC/indexing and syncs via the configured mode.
+    FullNode(FullNodeSyncMode),
 }
 
 impl NodeRole {
-    /// A validator that participates in consensus and signs checkpoints.
-    pub fn validator() -> Self {
-        Self {
-            is_validator: true,
-            is_observer: false,
-            is_fullnode: false,
-        }
-    }
-
-    /// An observer-mode full node: streams consensus blocks for faster ingestion
-    /// while providing full-node services (JSON-RPC, indexing).
-    pub fn observer() -> Self {
-        Self {
-            is_validator: false,
-            is_observer: true,
-            is_fullnode: true,
-        }
-    }
-
-    /// A pure full node: syncs via state sync only.
-    pub fn fullnode() -> Self {
-        Self {
-            is_validator: false,
-            is_observer: false,
-            is_fullnode: true,
-        }
-    }
-
-    // --- Role checks ---
-
-    pub fn is_validator(&self) -> bool {
-        self.is_validator
-    }
-
-    pub fn is_observer(&self) -> bool {
-        self.is_observer
-    }
-
-    pub fn is_fullnode(&self) -> bool {
-        self.is_fullnode
-    }
-
     // --- Capability methods ---
 
-    /// Whether this node participates in the consensus protocol (validator or observer).
+    /// Whether this node participates in the consensus protocol.
     pub fn runs_consensus(&self) -> bool {
-        self.is_validator || self.is_observer
+        matches!(
+            self,
+            Self::Validator | Self::FullNode(FullNodeSyncMode::ConsensusObserver)
+        )
     }
 
-    /// Whether this node can submit transactions and checkpoint signatures to consensus.
-    pub fn can_submit_to_consensus(&self) -> bool {
-        self.is_validator
+    /// Whether this node can propose transactions and checkpoint signatures to consensus.
+    pub fn can_propose_transactions(&self) -> bool {
+        matches!(self, Self::Validator)
     }
 
     /// Whether this node should run fork detection and recovery at startup.
     pub fn should_check_forks(&self) -> bool {
-        self.is_validator || self.is_observer
+        matches!(
+            self,
+            Self::Validator | Self::FullNode(FullNodeSyncMode::ConsensusObserver)
+        )
     }
 
     /// Whether this node should create index stores for JSON-RPC and REST API.
     pub fn should_enable_index_processing(&self) -> bool {
-        self.is_fullnode
+        matches!(self, Self::FullNode(_))
     }
 
     /// Whether this node should expose the gRPC validator service.
     pub fn should_run_validator_service(&self) -> bool {
-        self.is_validator
+        matches!(self, Self::Validator)
     }
 
     /// Whether this node should run the authority overload monitor.
     pub fn should_run_overload_monitor(&self) -> bool {
-        self.is_validator
+        matches!(self, Self::Validator)
     }
 
     /// Whether this node should run the randomness manager (DKG).
     pub fn should_run_randomness(&self) -> bool {
-        self.is_validator || self.is_observer
+        matches!(
+            self,
+            Self::Validator | Self::FullNode(FullNodeSyncMode::ConsensusObserver)
+        )
     }
-
+    
     /// Whether this node should submit JWK updates to consensus.
     pub fn should_run_jwk_updater(&self) -> bool {
-        self.is_validator
+        matches!(self, Self::Validator)
     }
 
     /// Whether this node should run the execution time observer.
     pub fn should_run_execution_time_observer(&self) -> bool {
-        self.is_validator
+        matches!(self, Self::Validator)
     }
 
     /// Whether this node should expose HTTP/RPC servers (JSON-RPC, REST).
     pub fn should_run_rpc_servers(&self) -> bool {
-        self.is_fullnode
+        matches!(self, Self::FullNode(_))
     }
 }
 
 impl std::fmt::Display for NodeRole {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if self.is_validator {
-            write!(f, "Validator")
-        } else if self.is_observer {
-            write!(f, "Observer")
-        } else {
-            write!(f, "FullNode")
+        match self {
+            Self::Validator => write!(f, "Validator"),
+            Self::FullNode(FullNodeSyncMode::StateSyncOnly) => write!(f, "FullNode"),
+            Self::FullNode(FullNodeSyncMode::ConsensusObserver) => {
+                write!(f, "FullNode(ConsensusObserver)")
+            }
         }
     }
 }
@@ -128,38 +106,32 @@ mod tests {
 
     #[test]
     fn test_validator_role() {
-        let role = NodeRole::validator();
-        assert!(role.is_validator());
-        assert!(!role.is_observer());
-        assert!(!role.is_fullnode());
+        let role = NodeRole::Validator;
         assert!(role.runs_consensus());
-        assert!(role.can_submit_to_consensus());
+        assert!(role.can_propose_transactions());
         assert!(role.should_check_forks());
         assert!(!role.should_enable_index_processing());
+        assert!(!role.should_run_rpc_servers());
     }
 
     #[test]
-    fn test_observer_role() {
-        let role = NodeRole::observer();
-        assert!(!role.is_validator());
-        assert!(role.is_observer());
-        assert!(role.is_fullnode());
+    fn test_consensus_observer_role() {
+        let role = NodeRole::FullNode(FullNodeSyncMode::ConsensusObserver);
         assert!(role.runs_consensus());
-        assert!(!role.can_submit_to_consensus());
+        assert!(!role.can_propose_transactions());
         assert!(role.should_check_forks());
         assert!(role.should_enable_index_processing());
         assert!(role.should_run_randomness());
+        assert!(role.should_run_rpc_servers());
     }
 
     #[test]
-    fn test_fullnode_role() {
-        let role = NodeRole::fullnode();
-        assert!(!role.is_validator());
-        assert!(!role.is_observer());
-        assert!(role.is_fullnode());
+    fn test_fullnode_state_sync_role() {
+        let role = NodeRole::FullNode(FullNodeSyncMode::StateSyncOnly);
         assert!(!role.runs_consensus());
-        assert!(!role.can_submit_to_consensus());
+        assert!(!role.can_propose_transactions());
         assert!(!role.should_check_forks());
         assert!(role.should_enable_index_processing());
+        assert!(role.should_run_rpc_servers());
     }
 }

--- a/crates/sui-types/src/node_role.rs
+++ b/crates/sui-types/src/node_role.rs
@@ -49,6 +49,8 @@ impl NodeRole {
     }
 
     /// Whether this node should run fork detection and recovery at startup.
+    // Fork detection and recovery is only relevant for validators and full nodes that run in observer mode.
+    // Fullnodes that run in checkpoint state sync mode only don't need fork checking
     pub fn should_check_forks(&self) -> bool {
         matches!(
             self,

--- a/crates/sui-types/src/node_role.rs
+++ b/crates/sui-types/src/node_role.rs
@@ -1,6 +1,9 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::base_types::AuthorityName;
+use crate::committee::Committee;
+
 /// How a full node syncs data from the network.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum FullNodeSyncMode {
@@ -26,6 +29,23 @@ pub enum NodeRole {
 }
 
 impl NodeRole {
+    /// Determines the node role from committee membership and observer configuration.
+    /// This is the single source of truth for role derivation — used both at startup
+    /// (with the latest committee from CommitteeStore) and per-epoch (in AuthorityPerEpochStore).
+    pub fn from_committee(
+        committee: &Committee,
+        name: &AuthorityName,
+        has_observer_config: bool,
+    ) -> Self {
+        if committee.authority_exists(name) {
+            NodeRole::Validator
+        } else if has_observer_config {
+            NodeRole::FullNode(FullNodeSyncMode::ConsensusObserver)
+        } else {
+            NodeRole::FullNode(FullNodeSyncMode::StateSyncOnly)
+        }
+    }
+
     pub fn is_fullnode(&self) -> bool {
         matches!(self, Self::FullNode(_))
     }
@@ -48,16 +68,6 @@ impl NodeRole {
         matches!(self, Self::Validator)
     }
 
-    /// Whether this node should run fork detection and recovery at startup.
-    // Fork detection and recovery is only relevant for validators and full nodes that run in observer mode.
-    // Fullnodes that run in checkpoint state sync mode only don't need fork checking
-    pub fn should_check_forks(&self) -> bool {
-        matches!(
-            self,
-            Self::Validator | Self::FullNode(FullNodeSyncMode::ConsensusObserver)
-        )
-    }
-
     /// Whether this node should create index stores for JSON-RPC and REST API.
     pub fn should_enable_index_processing(&self) -> bool {
         matches!(self, Self::FullNode(_))
@@ -71,14 +81,6 @@ impl NodeRole {
     /// Whether this node should run the authority overload monitor.
     pub fn should_run_overload_monitor(&self) -> bool {
         matches!(self, Self::Validator)
-    }
-
-    /// Whether this node should run the randomness manager (DKG).
-    pub fn should_run_randomness(&self) -> bool {
-        matches!(
-            self,
-            Self::Validator | Self::FullNode(FullNodeSyncMode::ConsensusObserver)
-        )
     }
 
     /// Whether this node should submit JWK updates to consensus.
@@ -118,7 +120,6 @@ mod tests {
         let role = NodeRole::Validator;
         assert!(role.runs_consensus());
         assert!(role.can_propose_transactions());
-        assert!(role.should_check_forks());
         assert!(!role.should_enable_index_processing());
         assert!(!role.should_run_rpc_servers());
     }
@@ -128,9 +129,7 @@ mod tests {
         let role = NodeRole::FullNode(FullNodeSyncMode::ConsensusObserver);
         assert!(role.runs_consensus());
         assert!(!role.can_propose_transactions());
-        assert!(role.should_check_forks());
         assert!(role.should_enable_index_processing());
-        assert!(role.should_run_randomness());
         assert!(role.should_run_rpc_servers());
     }
 
@@ -139,7 +138,6 @@ mod tests {
         let role = NodeRole::FullNode(FullNodeSyncMode::StateSyncOnly);
         assert!(!role.runs_consensus());
         assert!(!role.can_propose_transactions());
-        assert!(!role.should_check_forks());
         assert!(role.should_enable_index_processing());
         assert!(role.should_run_rpc_servers());
     }

--- a/crates/sui-types/src/node_role.rs
+++ b/crates/sui-types/src/node_role.rs
@@ -1,0 +1,165 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Represents the roles a node plays in the network for a given epoch.
+/// A node can have multiple active roles — for example, an observer-mode
+/// full node is both a FullNode and an Observer.
+///
+/// Behavior should be gated through capability methods (e.g. `runs_consensus()`,
+/// `can_submit_to_consensus()`) rather than checking individual role booleans.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct NodeRole {
+    is_validator: bool,
+    is_observer: bool,
+    is_fullnode: bool,
+}
+
+impl NodeRole {
+    /// A validator that participates in consensus and signs checkpoints.
+    pub fn validator() -> Self {
+        Self {
+            is_validator: true,
+            is_observer: false,
+            is_fullnode: false,
+        }
+    }
+
+    /// An observer-mode full node: streams consensus blocks for faster ingestion
+    /// while providing full-node services (JSON-RPC, indexing).
+    pub fn observer() -> Self {
+        Self {
+            is_validator: false,
+            is_observer: true,
+            is_fullnode: true,
+        }
+    }
+
+    /// A pure full node: syncs via state sync only.
+    pub fn fullnode() -> Self {
+        Self {
+            is_validator: false,
+            is_observer: false,
+            is_fullnode: true,
+        }
+    }
+
+    // --- Role checks ---
+
+    pub fn is_validator(&self) -> bool {
+        self.is_validator
+    }
+
+    pub fn is_observer(&self) -> bool {
+        self.is_observer
+    }
+
+    pub fn is_fullnode(&self) -> bool {
+        self.is_fullnode
+    }
+
+    // --- Capability methods ---
+
+    /// Whether this node participates in the consensus protocol (validator or observer).
+    pub fn runs_consensus(&self) -> bool {
+        self.is_validator || self.is_observer
+    }
+
+    /// Whether this node can submit transactions and checkpoint signatures to consensus.
+    pub fn can_submit_to_consensus(&self) -> bool {
+        self.is_validator
+    }
+
+    /// Whether this node should run fork detection and recovery at startup.
+    pub fn should_check_forks(&self) -> bool {
+        self.is_validator || self.is_observer
+    }
+
+    /// Whether this node should create index stores for JSON-RPC and REST API.
+    pub fn should_enable_index_processing(&self) -> bool {
+        self.is_fullnode
+    }
+
+    /// Whether this node should expose the gRPC validator service.
+    pub fn should_run_validator_service(&self) -> bool {
+        self.is_validator
+    }
+
+    /// Whether this node should run the authority overload monitor.
+    pub fn should_run_overload_monitor(&self) -> bool {
+        self.is_validator
+    }
+
+    /// Whether this node should run the randomness manager (DKG).
+    pub fn should_run_randomness(&self) -> bool {
+        self.is_validator || self.is_observer
+    }
+
+    /// Whether this node should submit JWK updates to consensus.
+    pub fn should_run_jwk_updater(&self) -> bool {
+        self.is_validator
+    }
+
+    /// Whether this node should run the execution time observer.
+    pub fn should_run_execution_time_observer(&self) -> bool {
+        self.is_validator
+    }
+
+    /// Whether this node should expose HTTP/RPC servers (JSON-RPC, REST).
+    pub fn should_run_rpc_servers(&self) -> bool {
+        self.is_fullnode
+    }
+}
+
+impl std::fmt::Display for NodeRole {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.is_validator {
+            write!(f, "Validator")
+        } else if self.is_observer {
+            write!(f, "Observer")
+        } else {
+            write!(f, "FullNode")
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validator_role() {
+        let role = NodeRole::validator();
+        assert!(role.is_validator());
+        assert!(!role.is_observer());
+        assert!(!role.is_fullnode());
+        assert!(role.runs_consensus());
+        assert!(role.can_submit_to_consensus());
+        assert!(role.should_check_forks());
+        assert!(!role.should_enable_index_processing());
+    }
+
+    #[test]
+    fn test_observer_role() {
+        let role = NodeRole::observer();
+        assert!(!role.is_validator());
+        assert!(role.is_observer());
+        assert!(role.is_fullnode());
+        assert!(role.runs_consensus());
+        assert!(!role.can_submit_to_consensus());
+        assert!(role.should_check_forks());
+        assert!(role.should_enable_index_processing());
+        assert!(role.should_run_randomness());
+    }
+
+    #[test]
+    fn test_fullnode_role() {
+        let role = NodeRole::fullnode();
+        assert!(!role.is_validator());
+        assert!(!role.is_observer());
+        assert!(role.is_fullnode());
+        assert!(!role.runs_consensus());
+        assert!(!role.can_submit_to_consensus());
+        assert!(!role.should_check_forks());
+        assert!(role.should_enable_index_processing());
+    }
+}

--- a/crates/sui-types/src/node_role.rs
+++ b/crates/sui-types/src/node_role.rs
@@ -71,7 +71,7 @@ impl NodeRole {
             Self::Validator | Self::FullNode(FullNodeSyncMode::ConsensusObserver)
         )
     }
-    
+
     /// Whether this node should submit JWK updates to consensus.
     pub fn should_run_jwk_updater(&self) -> bool {
         matches!(self, Self::Validator)


### PR DESCRIPTION
## Description 

# Refactor: NodeRole for Observer-Mode Full Nodes

## Problem

With the introduction of block streaming, a new node type arises which we call Observer. This can be perceived as a full node that also spins up the relative consensus components to stream blocks from a peer, process them, build up the DAG and execute the commit rule. Eventually, this node will be able to execute transactions out of the commit path as a validator does. Sui nodes currently have a binary identity: validator (`consensus_config` present) or full node (no `consensus_config`). The consensus layer already supports observer mode, but the sui-node layer has no way to start consensus in observer mode. We need a third mode - **observer-mode full node** - that streams consensus blocks for faster ingestion while retaining full-node capabilities (JSON-RPC, indexing).

## Design: NodeRole with FullNodeSyncMode

`NodeRole` is an **enum with two top-level variants**: `Validator` and `FullNode`. A `FullNode` carries a `FullNodeSyncMode` that determines how it syncs data from the network. This models the real domain relationship: the observer distinction is about *how a fullnode syncs*, not a separate role.

```rust
pub enum FullNodeSyncMode {
    /// Syncs exclusively via the state-sync protocol.
    StateSyncOnly = 0,
    /// Streams consensus blocks for faster ingestion, in addition to state sync.
    ConsensusObserver = 1,
}

pub enum NodeRole {
    /// In the committee — participates in consensus and signs checkpoints.
    Validator,
    /// Not in the committee — serves RPC/indexing and syncs via the configured mode.
    FullNode(FullNodeSyncMode),
}

impl NodeRole {
    // --- Capability methods (primary API for gating behavior) ---
    pub fn runs_consensus(&self) -> bool {
        matches!(self, Validator | FullNode(ConsensusObserver))
    }
    pub fn can_propose_transactions(&self) -> bool { matches!(self, Validator) }
    pub fn should_enable_index_processing(&self) -> bool { matches!(self, FullNode(_)) }
    pub fn should_run_rpc_servers(&self) -> bool { matches!(self, FullNode(_)) }
    ...
}
```

Behavior is gated through **capability methods** on `NodeRole` — code should prefer capability methods over direct variant matching. This means if requirements change (e.g., consensus observers should also run the overload monitor), we flip one method in `NodeRole` instead of hunting through call sites.

| Method                                | Validator | FullNode (StateSyncOnly) | FullNode (ConsensusObserver) |
|:-------------------------------------:|:---------:|:------------------------:|:----------------------------:|
| `runs_consensus()`                    | yes       | no                       | yes                          |
| `can_propose_transactions()`           | yes       | no                       | no                           |
| `should_check_forks()`                | yes       | no                       | yes                          |
| `should_enable_index_processing()`    | no        | yes                      | yes                          |
| `should_run_validator_service()`      | yes       | no                       | no                           |
| `should_run_overload_monitor()`       | yes       | no                       | no                           |
| `should_run_randomness()`             | yes       | no                       | yes                          |
| `should_run_jwk_updater()`            | yes       | no                       | no                           |
| `should_run_execution_time_observer()`| yes       | no                       | no                           |
| `should_run_rpc_servers()`            | no        | yes                      | yes                          |

## Role Determination

`NodeRole` is a computed property on `AuthorityPerEpochStore` — the single source of truth. It's derived per-epoch from:
1. **Committee membership** (dynamic — changes each epoch)
2. **Observer config** (static — whether observer peers are configured in `ConsensusConfig`)

A node with observer peers **promotes to Validator** when added to the committee and **falls back to FullNode(ConsensusObserver)** when removed. All 4 epoch transitions (2×2) are handled.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
