### PR TITLE
[forking 14/n] add checkpoint subscription service

### DIFF
--- a/crates/sui-forking/poc.md
+++ b/crates/sui-forking/poc.md
@@ -172,3 +172,4 @@ Shows the current checkpoint, epoch, and timestamp.
 - faucet support
 - minting any coin type
 - GraphQL RPC support
+- transfer object ownership at startup (seeding by an address and transfer all those objects to either a new address or to the active one in the wallet)

--- a/crates/sui-forking/src/cli.rs
+++ b/crates/sui-forking/src/cli.rs
@@ -166,7 +166,8 @@ async fn cmd_start(
             .with_context(|| format!("failed to get latest checkpoint for {}", network_name))?,
     };
 
-    let context = crate::startup::initialize(node, checkpoint, version, data_dir).await?;
+    let (context, subscription_handle) =
+        crate::startup::initialize(node, checkpoint, version, data_dir).await?;
 
     let output = StartOutput {
         network: network_name.clone(),
@@ -180,7 +181,12 @@ async fn cmd_start(
         network_name, checkpoint, rpc_addr,
     );
 
-    let handle = tokio::spawn(crate::startup::run(context, rpc_addr, version));
+    let handle = tokio::spawn(crate::startup::run(
+        context,
+        subscription_handle,
+        rpc_addr,
+        version,
+    ));
     handle.await??;
 
     Ok(())

--- a/crates/sui-forking/src/context.rs
+++ b/crates/sui-forking/src/context.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 
 use anyhow::{Context as _, Result, anyhow};
 use rand::rngs::OsRng;
+use tokio::sync::Mutex;
 use tokio::sync::RwLock;
 use tokio::sync::mpsc;
 
@@ -12,16 +13,37 @@ use simulacrum::Simulacrum;
 use sui_protocol_config::Chain;
 use sui_types::full_checkpoint_content::Checkpoint;
 use sui_types::messages_checkpoint::CheckpointSequenceNumber;
+use sui_types::messages_checkpoint::VerifiedCheckpoint;
 use sui_types::storage::ReadStore as _;
 
 use crate::store::DataStore;
 
+type ForkedSimulacrum = Simulacrum<OsRng, DataStore>;
+
+/// Metadata for a checkpoint created by the forked network.
+///
+/// The full checkpoint payload is an internal publication detail; callers only
+/// need these fields for RPC responses and finality metadata.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct CreatedCheckpointMetadata {
+    /// Checkpoint numbers
+    pub(crate) sequence_number: CheckpointSequenceNumber,
+    /// Checkpoint timestamp
+    pub(crate) timestamp_ms: u64,
+}
+
+struct CheckpointPublication {
+    metadata: CreatedCheckpointMetadata,
+    payload: Checkpoint,
+}
+
 /// Shared context for the forked network: the simulacrum, chain identifier,
 /// and the producer half of the checkpoint subscription channel.
 pub struct Context {
-    simulacrum: Arc<RwLock<Simulacrum<OsRng, DataStore>>>,
+    simulacrum: Arc<RwLock<ForkedSimulacrum>>,
     chain_identifier: Chain,
     checkpoint_sender: mpsc::Sender<Checkpoint>,
+    checkpoint_publication_lock: Mutex<()>,
 }
 
 impl Context {
@@ -34,10 +56,11 @@ impl Context {
             simulacrum: Arc::new(RwLock::new(simulacrum)),
             chain_identifier,
             checkpoint_sender,
+            checkpoint_publication_lock: Mutex::new(()),
         }
     }
 
-    pub(crate) fn simulacrum(&self) -> &Arc<RwLock<Simulacrum<OsRng, DataStore>>> {
+    pub(crate) fn simulacrum(&self) -> &Arc<RwLock<ForkedSimulacrum>> {
         &self.simulacrum
     }
 
@@ -45,31 +68,109 @@ impl Context {
         &self.chain_identifier
     }
 
-    /// Fetch the checkpoint at `sequence` from the store, assemble a full
-    /// `Checkpoint`, and push it to subscribers via the broker. Subscribers
-    /// must observe checkpoints in monotonically increasing sequence order —
-    /// the broker panics otherwise.
-    pub(crate) async fn publish_checkpoint(
+    /// Execute `operation`, create a checkpoint afterward, and publish that
+    /// checkpoint to subscribers.
+    ///
+    /// This is the main entry point for any execution that requires checkpoint
+    /// advancement to ensure the checkpoint is published for the subscription
+    /// service.
+    ///
+    /// # Panics
+    ///
+    /// Panics if Simulacrum creates a checkpoint but the full checkpoint
+    /// payload cannot be assembled from the same store.
+    pub(crate) async fn run_with_new_checkpoint<T, F>(
         &self,
-        sequence: CheckpointSequenceNumber,
-    ) -> Result<()> {
-        let checkpoint = {
-            let sim = self.simulacrum.read().await;
-            let store = sim.store();
+        operation: F,
+    ) -> (T, CreatedCheckpointMetadata)
+    where
+        T: Send,
+        F: FnOnce(&mut ForkedSimulacrum) -> T + Send,
+    {
+        self.try_run_with_new_checkpoint(|sim| Ok::<_, std::convert::Infallible>(operation(sim)))
+            .await
+            .unwrap_or_else(|never| match never {})
+    }
 
-            let verified = store
-                .get_checkpoint_by_sequence_number(sequence)?
-                .ok_or_else(|| anyhow!("checkpoint summary {sequence} not found"))?;
-            let contents = store
-                .get_checkpoint_contents_by_digest(&verified.content_digest)?
-                .ok_or_else(|| anyhow!("checkpoint contents for sequence {sequence} not found"))?;
-
-            sim.get_checkpoint_data(verified, contents)?
+    /// Fallible variant of [`Self::run_with_new_checkpoint`]. If `operation`
+    /// returns an error, no checkpoint is created. The publication lock is
+    /// intentionally held through enqueueing the checkpoint so the
+    /// `sui-rpc-api` subscription broker observes the same order that
+    /// Simulacrum used to create checkpoints.
+    ///
+    /// # Panics
+    ///
+    /// Panics if Simulacrum creates a checkpoint but the full checkpoint
+    /// payload cannot be assembled from the same store.
+    pub(crate) async fn try_run_with_new_checkpoint<T, E, F>(
+        &self,
+        operation: F,
+    ) -> std::result::Result<(T, CreatedCheckpointMetadata), E>
+    where
+        T: Send,
+        E: Send,
+        F: FnOnce(&mut ForkedSimulacrum) -> std::result::Result<T, E> + Send,
+    {
+        let _checkpoint_publication_guard = self.checkpoint_publication_lock.lock().await;
+        let (output, publication) = {
+            let mut sim = self.simulacrum.write().await;
+            let output = operation(&mut sim)?;
+            let publication = Self::create_checkpoint_publication(&mut sim);
+            (output, publication)
         };
 
-        self.checkpoint_sender
-            .send(checkpoint)
+        let metadata = publication.metadata;
+        self.publish_checkpoint(publication).await;
+
+        Ok((output, metadata))
+    }
+
+    fn create_checkpoint_publication(sim: &mut ForkedSimulacrum) -> CheckpointPublication {
+        let verified = sim.create_checkpoint();
+        let metadata = CreatedCheckpointMetadata {
+            sequence_number: verified.data().sequence_number,
+            timestamp_ms: verified.data().timestamp_ms,
+        };
+
+        let payload = Self::checkpoint_payload(sim, verified).unwrap_or_else(|err| {
+            panic!(
+                "failed to build checkpoint {} after Simulacrum created it: {err}",
+                metadata.sequence_number
+            )
+        });
+
+        CheckpointPublication { metadata, payload }
+    }
+
+    fn checkpoint_payload(
+        sim: &ForkedSimulacrum,
+        verified: VerifiedCheckpoint,
+    ) -> Result<Checkpoint> {
+        let contents = sim
+            .store()
+            .get_checkpoint_contents_by_digest(&verified.content_digest)?
+            .ok_or_else(|| {
+                anyhow!(
+                    "checkpoint contents for sequence {} not found",
+                    verified.data().sequence_number
+                )
+            })?;
+
+        Ok(sim.get_checkpoint_data(verified, contents)?)
+    }
+
+    async fn publish_checkpoint(&self, publication: CheckpointPublication) {
+        if let Err(err) = self
+            .checkpoint_sender
+            .send(publication.payload)
             .await
             .context("failed to enqueue checkpoint to subscription service")
+        {
+            tracing::warn!(
+                sequence_number = publication.metadata.sequence_number,
+                ?err,
+                "failed to publish checkpoint to subscribers"
+            );
+        }
     }
 }

--- a/crates/sui-forking/src/context.rs
+++ b/crates/sui-forking/src/context.rs
@@ -3,10 +3,10 @@
 
 use std::sync::Arc;
 
-use anyhow::{anyhow, Context as _, Result};
+use anyhow::{Context as _, Result, anyhow};
 use rand::rngs::OsRng;
-use tokio::sync::mpsc;
 use tokio::sync::RwLock;
+use tokio::sync::mpsc;
 
 use simulacrum::Simulacrum;
 use sui_protocol_config::Chain;

--- a/crates/sui-forking/src/context.rs
+++ b/crates/sui-forking/src/context.rs
@@ -3,25 +3,37 @@
 
 use std::sync::Arc;
 
+use anyhow::{anyhow, Context as _, Result};
 use rand::rngs::OsRng;
+use tokio::sync::mpsc;
 use tokio::sync::RwLock;
 
 use simulacrum::Simulacrum;
 use sui_protocol_config::Chain;
+use sui_types::full_checkpoint_content::Checkpoint;
+use sui_types::messages_checkpoint::CheckpointSequenceNumber;
+use sui_types::storage::ReadStore as _;
 
 use crate::store::DataStore;
 
-/// Shared context for the forked network, holding the simulacrum instance and metadata.
+/// Shared context for the forked network: the simulacrum, chain identifier,
+/// and the producer half of the checkpoint subscription channel.
 pub struct Context {
     simulacrum: Arc<RwLock<Simulacrum<OsRng, DataStore>>>,
     chain_identifier: Chain,
+    checkpoint_sender: mpsc::Sender<Checkpoint>,
 }
 
 impl Context {
-    pub(crate) fn new(simulacrum: Simulacrum<OsRng, DataStore>, chain_identifier: Chain) -> Self {
+    pub(crate) fn new(
+        simulacrum: Simulacrum<OsRng, DataStore>,
+        chain_identifier: Chain,
+        checkpoint_sender: mpsc::Sender<Checkpoint>,
+    ) -> Self {
         Self {
             simulacrum: Arc::new(RwLock::new(simulacrum)),
             chain_identifier,
+            checkpoint_sender,
         }
     }
 
@@ -31,5 +43,33 @@ impl Context {
 
     pub(crate) fn chain_identifier(&self) -> &Chain {
         &self.chain_identifier
+    }
+
+    /// Fetch the checkpoint at `sequence` from the store, assemble a full
+    /// `Checkpoint`, and push it to subscribers via the broker. Subscribers
+    /// must observe checkpoints in monotonically increasing sequence order —
+    /// the broker panics otherwise.
+    pub(crate) async fn publish_checkpoint(
+        &self,
+        sequence: CheckpointSequenceNumber,
+    ) -> Result<()> {
+        let checkpoint = {
+            let sim = self.simulacrum.read().await;
+            let store = sim.store();
+
+            let verified = store
+                .get_checkpoint_by_sequence_number(sequence)?
+                .ok_or_else(|| anyhow!("checkpoint summary {sequence} not found"))?;
+            let contents = store
+                .get_checkpoint_contents_by_digest(&verified.content_digest)?
+                .ok_or_else(|| anyhow!("checkpoint contents for sequence {sequence} not found"))?;
+
+            sim.get_checkpoint_data(verified, contents)?
+        };
+
+        self.checkpoint_sender
+            .send(checkpoint)
+            .await
+            .context("failed to enqueue checkpoint to subscription service")
     }
 }

--- a/crates/sui-forking/src/rpc/executor.rs
+++ b/crates/sui-forking/src/rpc/executor.rs
@@ -32,7 +32,8 @@ use crate::context::Context;
 /// `TransactionExecutor` implementation that runs transactions against the
 /// forked network's Simulacrum. Inbound transactions must be signed by the
 /// sender (Simulacrum verifies user signatures during execution) and each
-/// successful execution is sealed into a fresh Simulacrum checkpoint.
+/// accepted execution is sealed into a fresh Simulacrum checkpoint and
+/// published to checkpoint subscribers.
 pub(crate) struct ForkedTransactionExecutor {
     context: Arc<Context>,
 }
@@ -50,19 +51,27 @@ impl TransactionExecutor for ForkedTransactionExecutor {
         request: ExecuteTransactionRequestV3,
         _client_addr: Option<SocketAddr>,
     ) -> Result<ExecuteTransactionResponseV3, TransactionSubmissionError> {
-        // Execute under the simulacrum write lock, then seal the transaction
-        // into a fresh checkpoint so downstream reads see it as finalized.
-        // The lock is dropped before reading back events/objects so
-        // concurrent reads aren't blocked.
-        let (effects, exec_error, checkpoint_seq) = {
-            let mut sim = self.context.simulacrum().write().await;
-            let (effects, exec_error) = sim
-                .execute_transaction(request.transaction)
-                .map_err(into_submission_error)?;
-            let checkpoint = sim.create_checkpoint();
-            let checkpoint_seq = checkpoint.data().sequence_number;
-            (effects, exec_error, checkpoint_seq)
-        };
+        let ExecuteTransactionRequestV3 {
+            transaction,
+            include_events,
+            include_input_objects,
+            include_output_objects,
+            include_auxiliary_data: _,
+        } = request;
+
+        // Execute under the serialized checkpoint path, then seal the
+        // transaction into a fresh checkpoint so downstream reads see it as
+        // finalized and subscribers are notified in sequence.
+        let ((effects, exec_error), checkpoint_metadata) = self
+            .context
+            .try_run_with_new_checkpoint(|sim| {
+                let (effects, exec_error) = sim
+                    .execute_transaction(transaction)
+                    .map_err(into_submission_error)?;
+                Ok((effects, exec_error))
+            })
+            .await?;
+        let checkpoint_seq = checkpoint_metadata.sequence_number;
 
         let digest = *effects.transaction_digest();
         if let Some(err) = &exec_error {
@@ -71,7 +80,7 @@ impl TransactionExecutor for ForkedTransactionExecutor {
             info!(%digest, checkpoint_seq, "forked transaction executed");
         }
 
-        let events = if request.include_events && effects.events_digest().is_some() {
+        let events = if include_events && effects.events_digest().is_some() {
             let sim = self.context.simulacrum().read().await;
             sim.store().get_transaction_events(&digest)
         } else {
@@ -85,7 +94,7 @@ impl TransactionExecutor for ForkedTransactionExecutor {
         // versions.
         let sim = self.context.simulacrum().read().await;
         let object_store = sim.store();
-        let input_objects = if request.include_input_objects {
+        let input_objects = if include_input_objects {
             Some(
                 get_transaction_input_objects(object_store, &effects).map_err(|e| {
                     TransactionSubmissionError::TransactionDriverInternalError(SuiError::from(
@@ -96,7 +105,7 @@ impl TransactionExecutor for ForkedTransactionExecutor {
         } else {
             None
         };
-        let output_objects = if request.include_output_objects {
+        let output_objects = if include_output_objects {
             Some(
                 get_transaction_output_objects(object_store, &effects).map_err(|e| {
                     TransactionSubmissionError::TransactionDriverInternalError(SuiError::from(

--- a/crates/sui-forking/src/rpc/forking_service.rs
+++ b/crates/sui-forking/src/rpc/forking_service.rs
@@ -14,6 +14,7 @@ use tonic::Request;
 use tonic::Response;
 use tonic::Status;
 use tracing::info;
+use tracing::warn;
 
 use crate::context::Context;
 use crate::proto::forking::AdvanceCheckpointRequest;
@@ -64,15 +65,29 @@ impl ForkingService for ForkingServiceImpl {
         &self,
         _request: Request<AdvanceCheckpointRequest>,
     ) -> Result<Response<AdvanceCheckpointResponse>, Status> {
-        let mut sim = self.context.simulacrum().write().await;
-        let checkpoint = sim.create_checkpoint();
-        let checkpoint_sequence_number = checkpoint.data().sequence_number;
-        let timestamp_ms = checkpoint.data().timestamp_ms;
+        // Scope the write lock so it is released before `publish_checkpoint`
+        // acquires a read lock on the same simulacrum.
+        let (checkpoint_sequence_number, timestamp_ms) = {
+            let mut sim = self.context.simulacrum().write().await;
+            let checkpoint = sim.create_checkpoint();
+            (
+                checkpoint.data().sequence_number,
+                checkpoint.data().timestamp_ms,
+            )
+        };
 
         info!(
             checkpoint_sequence_number,
             timestamp_ms, "checkpoint created"
         );
+
+        if let Err(err) = self
+            .context
+            .publish_checkpoint(checkpoint_sequence_number)
+            .await
+        {
+            warn!(?err, "failed to publish checkpoint to subscribers");
+        }
 
         Ok(Response::new(AdvanceCheckpointResponse {
             checkpoint_sequence_number,

--- a/crates/sui-forking/src/rpc/forking_service.rs
+++ b/crates/sui-forking/src/rpc/forking_service.rs
@@ -14,7 +14,6 @@ use tonic::Request;
 use tonic::Response;
 use tonic::Status;
 use tracing::info;
-use tracing::warn;
 
 use crate::context::Context;
 use crate::proto::forking::AdvanceCheckpointRequest;
@@ -48,12 +47,23 @@ impl ForkingService for ForkingServiceImpl {
             .duration_ms
             .unwrap_or(DEFAULT_ADVANCE_CLOCK_MS);
 
-        let mut sim = self.context.simulacrum().write().await;
-        let effects = sim.advance_clock(Duration::from_millis(duration_ms));
-        let tx_digest = *effects.transaction_digest();
-        let timestamp_ms = sim.store().get_clock().timestamp_ms;
+        let ((tx_digest, timestamp_ms), checkpoint_metadata) = self
+            .context
+            .run_with_new_checkpoint(|sim| {
+                let effects = sim.advance_clock(Duration::from_millis(duration_ms));
+                let tx_digest = *effects.transaction_digest();
+                let timestamp_ms = sim.store().get_clock().timestamp_ms;
+                (tx_digest, timestamp_ms)
+            })
+            .await;
 
-        info!(%tx_digest, duration_ms, timestamp_ms, "clock advanced");
+        info!(
+            %tx_digest,
+            duration_ms,
+            timestamp_ms,
+            checkpoint_sequence_number = checkpoint_metadata.sequence_number,
+            "clock advanced"
+        );
 
         Ok(Response::new(AdvanceClockResponse {
             timestamp_ms,
@@ -65,33 +75,17 @@ impl ForkingService for ForkingServiceImpl {
         &self,
         _request: Request<AdvanceCheckpointRequest>,
     ) -> Result<Response<AdvanceCheckpointResponse>, Status> {
-        // Scope the write lock so it is released before `publish_checkpoint`
-        // acquires a read lock on the same simulacrum.
-        let (checkpoint_sequence_number, timestamp_ms) = {
-            let mut sim = self.context.simulacrum().write().await;
-            let checkpoint = sim.create_checkpoint();
-            (
-                checkpoint.data().sequence_number,
-                checkpoint.data().timestamp_ms,
-            )
-        };
+        let (_, checkpoint_metadata) = self.context.run_with_new_checkpoint(|_| ()).await;
 
         info!(
-            checkpoint_sequence_number,
-            timestamp_ms, "checkpoint created"
+            checkpoint_sequence_number = checkpoint_metadata.sequence_number,
+            timestamp_ms = checkpoint_metadata.timestamp_ms,
+            "checkpoint created"
         );
 
-        if let Err(err) = self
-            .context
-            .publish_checkpoint(checkpoint_sequence_number)
-            .await
-        {
-            warn!(?err, "failed to publish checkpoint to subscribers");
-        }
-
         Ok(Response::new(AdvanceCheckpointResponse {
-            checkpoint_sequence_number,
-            timestamp_ms,
+            checkpoint_sequence_number: checkpoint_metadata.sequence_number,
+            timestamp_ms: checkpoint_metadata.timestamp_ms,
         }))
     }
 

--- a/crates/sui-forking/src/rpc/mod.rs
+++ b/crates/sui-forking/src/rpc/mod.rs
@@ -10,3 +10,7 @@ pub(crate) mod forking_service;
 #[cfg(test)]
 #[path = "../tests/rpc_executor.rs"]
 mod executor_tests;
+
+#[cfg(test)]
+#[path = "../tests/subscription_e2e.rs"]
+mod subscription_tests;

--- a/crates/sui-forking/src/startup.rs
+++ b/crates/sui-forking/src/startup.rs
@@ -6,7 +6,9 @@ use std::num::NonZeroUsize;
 use std::sync::Arc;
 
 use anyhow::{Result, anyhow};
+use prometheus::Registry;
 use rand::rngs::OsRng;
+use sui_rpc_api::subscription::{SubscriptionService, SubscriptionServiceHandle};
 use sui_rpc_api::{RpcService, ServerVersion};
 use sui_types::storage::RpcStateReader;
 use tracing::info;
@@ -27,13 +29,15 @@ use crate::rpc::forking_service::ForkingServiceImpl;
 use crate::store::DataStore;
 
 /// Initialize a forked network by fetching state from the remote endpoint at
-/// `forked_at_checkpoint` and starting a local Simulacrum instance.
+/// `forked_at_checkpoint` and starting a local Simulacrum instance. Also
+/// builds the checkpoint subscription broker; the returned handle must be
+/// passed to [`run`] so the gRPC server exposes the streaming RPC.
 pub async fn initialize(
     node: Node,
     forked_at_checkpoint: CheckpointSequenceNumber,
     version: &str,
     data_dir: Option<std::path::PathBuf>,
-) -> Result<Context> {
+) -> Result<(Context, SubscriptionServiceHandle)> {
     // 1. Create DataStore — empty local cache, GraphQL wired up.
     let data_store = DataStore::new(node.clone(), forked_at_checkpoint, version, data_dir).await?;
     let chain_identifier = data_store.chain();
@@ -83,18 +87,33 @@ pub async fn initialize(
         rng,
     );
 
-    Ok(Context::new(simulacrum, chain_identifier))
+    // 8. Build the checkpoint subscription broker. The sender is owned by
+    //    `Context` (producers push here on `advance_checkpoint`); the handle
+    //    is wired into `RpcService` in `run` so subscribers can register.
+    let registry = Registry::new();
+    let (checkpoint_sender, subscription_handle) = SubscriptionService::build(&registry);
+
+    Ok((
+        Context::new(simulacrum, chain_identifier, checkpoint_sender),
+        subscription_handle,
+    ))
 }
 
 /// Run the forked network. Spawns a `sui-rpc-api` gRPC server bound to
 /// `rpc_addr` on top of the context's `DataStore`, then blocks on Ctrl+C.
-pub async fn run(context: Context, rpc_addr: SocketAddr, version: &'static str) -> Result<()> {
+pub async fn run(
+    context: Context,
+    subscription_handle: SubscriptionServiceHandle,
+    rpc_addr: SocketAddr,
+    version: &'static str,
+) -> Result<()> {
     let reader: Arc<dyn RpcStateReader> = {
         let sim = context.simulacrum().read().await;
         Arc::new(sim.store().clone())
     };
     let mut service = RpcService::new(reader);
     service.with_server_version(ServerVersion::new("sui-forking", version));
+    service.with_subscription_service(subscription_handle);
     let context = Arc::new(context);
     service.with_executor(Arc::new(ForkedTransactionExecutor::new(context.clone())));
     service.with_custom_service(ForkingServiceServer::new(ForkingServiceImpl::new(

--- a/crates/sui-forking/src/tests/rpc_executor.rs
+++ b/crates/sui-forking/src/tests/rpc_executor.rs
@@ -90,7 +90,11 @@ impl TestHarness {
 
         let gas_object = Self::find_gas_coin(&config, sender);
 
-        let context = Arc::new(Context::new(sim, Chain::Unknown));
+        // The executor tests do not exercise the checkpoint subscription path,
+        // so the receiver is dropped immediately — `Context::publish_checkpoint`
+        // is never invoked in this harness.
+        let (checkpoint_sender, _) = tokio::sync::mpsc::channel(1);
+        let context = Arc::new(Context::new(sim, Chain::Unknown, checkpoint_sender));
         let executor = ForkedTransactionExecutor::new(context);
 
         Self {

--- a/crates/sui-forking/src/tests/rpc_executor.rs
+++ b/crates/sui-forking/src/tests/rpc_executor.rs
@@ -10,6 +10,7 @@
 use std::collections::BTreeMap;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
+use std::time::Duration;
 
 use rand::rngs::OsRng;
 
@@ -24,12 +25,13 @@ use sui_types::crypto::{AccountKeyPair, KeypairTraits, get_key_pair};
 use sui_types::effects::TransactionEffectsAPI;
 use sui_types::error::SuiErrorKind;
 use sui_types::execution_status::ExecutionErrorKind;
+use sui_types::full_checkpoint_content::Checkpoint;
 use sui_types::gas_coin::GasCoin;
 use sui_types::object::{Object, Owner};
 use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
 use sui_types::transaction::{GasData, Transaction, TransactionData, TransactionKind};
 use sui_types::transaction_driver_types::{
-    ExecuteTransactionRequestV3, TransactionSubmissionError,
+    EffectsFinalityInfo, ExecuteTransactionRequestV3, TransactionSubmissionError,
 };
 use sui_types::transaction_executor::{TransactionChecks, TransactionExecutor};
 
@@ -45,6 +47,7 @@ struct TestHarness {
     sender_key: AccountKeyPair,
     gas_object: Object,
     reference_gas_price: u64,
+    checkpoint_receiver: tokio::sync::mpsc::Receiver<Checkpoint>,
     temp: tempfile::TempDir,
 }
 
@@ -90,10 +93,7 @@ impl TestHarness {
 
         let gas_object = Self::find_gas_coin(&config, sender);
 
-        // The executor tests do not exercise the checkpoint subscription path,
-        // so the receiver is dropped immediately — `Context::publish_checkpoint`
-        // is never invoked in this harness.
-        let (checkpoint_sender, _) = tokio::sync::mpsc::channel(1);
+        let (checkpoint_sender, checkpoint_receiver) = tokio::sync::mpsc::channel(4);
         let context = Arc::new(Context::new(sim, Chain::Unknown, checkpoint_sender));
         let executor = ForkedTransactionExecutor::new(context);
 
@@ -103,6 +103,7 @@ impl TestHarness {
             sender_key,
             gas_object,
             reference_gas_price,
+            checkpoint_receiver,
             temp,
         }
     }
@@ -136,6 +137,32 @@ impl TestHarness {
         );
         Transaction::from_data_and_signer(tx_data, vec![&self.sender_key])
     }
+}
+
+#[tokio::test]
+async fn test_tx_execution_publishes_checkpoint() {
+    let mut harness = TestHarness::new();
+    let signed_tx = harness.build_transfer_tx(1_000);
+
+    let request = ExecuteTransactionRequestV3::new_v2(signed_tx);
+    let response = harness
+        .executor
+        .execute_transaction(request, None)
+        .await
+        .expect("execute_transaction should succeed");
+
+    let EffectsFinalityInfo::Checkpointed(_epoch, checkpoint_seq) = response.effects.finality_info
+    else {
+        panic!("forked execution should report checkpointed finality");
+    };
+
+    let checkpoint =
+        tokio::time::timeout(Duration::from_secs(5), harness.checkpoint_receiver.recv())
+            .await
+            .expect("timed out waiting for published checkpoint")
+            .expect("checkpoint channel closed");
+
+    assert_eq!(*checkpoint.summary.sequence_number(), checkpoint_seq);
 }
 
 #[tokio::test]
@@ -190,7 +217,7 @@ async fn test_insufficient_coin_balance() {
 
 #[tokio::test]
 async fn test_bad_signature_returns_submission_error() {
-    let harness = TestHarness::new();
+    let mut harness = TestHarness::new();
 
     let pt = {
         let mut builder = ProgrammableTransactionBuilder::new();
@@ -221,6 +248,10 @@ async fn test_bad_signature_returns_submission_error() {
     assert!(
         matches!(err, TransactionSubmissionError::InvalidUserSignature(_)),
         "expected InvalidUserSignature, got {err:?}",
+    );
+    assert!(
+        harness.checkpoint_receiver.try_recv().is_err(),
+        "rejected transactions must not publish checkpoints",
     );
 }
 

--- a/crates/sui-forking/src/tests/subscription_e2e.rs
+++ b/crates/sui-forking/src/tests/subscription_e2e.rs
@@ -62,6 +62,8 @@ impl ServerHarness {
             .map(|o| (o.id(), o.clone()))
             .collect();
         data_store.update_objects(written, vec![]);
+        data_store.insert_checkpoint(config.genesis.checkpoint());
+        data_store.insert_checkpoint_contents(config.genesis.checkpoint_contents().clone());
 
         let keystore = KeyStore::from_network_config(&config);
         let sim = Simulacrum::new_from_custom_state(

--- a/crates/sui-forking/src/tests/subscription_e2e.rs
+++ b/crates/sui-forking/src/tests/subscription_e2e.rs
@@ -3,8 +3,8 @@
 
 //! End-to-end tests for the checkpoint subscription gRPC. Spins up the full
 //! tonic stack (forking admin RPCs + the canonical sui-rpc-api streaming
-//! RPC), drives `advance_checkpoint`, and asserts subscribers see each
-//! checkpoint on the stream.
+//! RPC), drives checkpoint-producing admin calls, and asserts subscribers
+//! see each checkpoint on the stream.
 
 use std::collections::BTreeMap;
 use std::num::NonZeroUsize;
@@ -32,7 +32,9 @@ use crate::proto::forking::forking_service_server::ForkingServiceServer;
 use crate::rpc::executor::ForkedTransactionExecutor;
 use crate::rpc::forking_service::ForkingServiceImpl;
 use crate::store::DataStore;
-use crate::{AdvanceCheckpointRequest, ForkingServiceClient};
+use crate::{
+    AdvanceCheckpointRequest, AdvanceClockRequest, ForkingServiceClient, GetStatusRequest,
+};
 
 /// In-process gRPC harness: builds a fresh Simulacrum from a genesis
 /// `NetworkConfig`, wires up the subscription broker, and starts a tonic
@@ -163,6 +165,45 @@ async fn subscription_streams_checkpoints_after_advance() -> Result<()> {
             "subscription message missing checkpoint payload"
         );
     }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn subscription_streams_checkpoint_after_advance_clock() -> Result<()> {
+    let harness = ServerHarness::start().await?;
+
+    let mut subscriptions =
+        SubscriptionServiceClient::connect(harness.grpc_endpoint.clone()).await?;
+    let mut stream = subscriptions
+        .subscribe_checkpoints(SubscribeCheckpointsRequest::default())
+        .await?
+        .into_inner();
+
+    let mut forking = ForkingServiceClient::connect(harness.grpc_endpoint.clone()).await?;
+    let clock = forking
+        .advance_clock(AdvanceClockRequest {
+            duration_ms: Some(1_000),
+        })
+        .await?
+        .into_inner();
+    assert!(
+        !clock.tx_digest.is_empty(),
+        "advance_clock should return the clock transaction digest",
+    );
+
+    let status = forking.get_status(GetStatusRequest {}).await?.into_inner();
+
+    let msg = tokio::time::timeout(STREAM_RECV_TIMEOUT, stream.message())
+        .await?
+        .map_err(|e| anyhow!("stream error: {e}"))?
+        .ok_or_else(|| anyhow!("subscription stream closed before advance_clock"))?;
+
+    assert_eq!(msg.cursor, Some(status.checkpoint_sequence_number));
+    assert!(
+        msg.checkpoint.is_some(),
+        "subscription message missing checkpoint payload"
+    );
 
     Ok(())
 }

--- a/crates/sui-forking/src/tests/subscription_e2e.rs
+++ b/crates/sui-forking/src/tests/subscription_e2e.rs
@@ -1,0 +1,198 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! End-to-end tests for the checkpoint subscription gRPC. Spins up the full
+//! tonic stack (forking admin RPCs + the canonical sui-rpc-api streaming
+//! RPC), drives `advance_checkpoint`, and asserts subscribers see each
+//! checkpoint on the stream.
+
+use std::collections::BTreeMap;
+use std::num::NonZeroUsize;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Result, anyhow};
+use prometheus::Registry;
+use rand::rngs::OsRng;
+use simulacrum::Simulacrum;
+use simulacrum::store::in_mem_store::KeyStore;
+use sui_protocol_config::Chain;
+use sui_rpc_api::proto::sui::rpc::v2::SubscribeCheckpointsRequest;
+use sui_rpc_api::proto::sui::rpc::v2::subscription_service_client::SubscriptionServiceClient;
+use sui_rpc_api::subscription::SubscriptionService;
+use sui_rpc_api::{RpcService, ServerVersion};
+use sui_swarm_config::network_config_builder::ConfigBuilder;
+use sui_types::base_types::ObjectID;
+use sui_types::object::Object;
+use sui_types::storage::RpcStateReader;
+
+use crate::context::Context;
+use crate::proto::forking::forking_service_server::ForkingServiceServer;
+use crate::rpc::executor::ForkedTransactionExecutor;
+use crate::rpc::forking_service::ForkingServiceImpl;
+use crate::store::DataStore;
+use crate::{AdvanceCheckpointRequest, ForkingServiceClient};
+
+/// In-process gRPC harness: builds a fresh Simulacrum from a genesis
+/// `NetworkConfig`, wires up the subscription broker, and starts a tonic
+/// server on an ephemeral port. The server task is aborted when the
+/// harness is dropped.
+struct ServerHarness {
+    server_task: tokio::task::JoinHandle<()>,
+    grpc_endpoint: String,
+    // Held to keep the on-disk store alive for the lifetime of the server.
+    _temp: tempfile::TempDir,
+}
+
+impl ServerHarness {
+    async fn start() -> Result<Self> {
+        let temp = tempfile::tempdir()?;
+        let mut rng = OsRng;
+        let config = ConfigBuilder::new_with_temp_dir()
+            .rng(&mut rng)
+            .deterministic_committee_size(NonZeroUsize::MIN)
+            .build();
+
+        let mut data_store = DataStore::new_for_testing(temp.path().to_path_buf());
+        let written: BTreeMap<ObjectID, Object> = config
+            .genesis
+            .objects()
+            .iter()
+            .map(|o| (o.id(), o.clone()))
+            .collect();
+        data_store.update_objects(written, vec![]);
+
+        let keystore = KeyStore::from_network_config(&config);
+        let sim = Simulacrum::new_from_custom_state(
+            keystore,
+            config.genesis.checkpoint(),
+            config.genesis.sui_system_object(),
+            &config,
+            data_store.clone(),
+            rng,
+        );
+
+        let registry = Registry::new();
+        let (checkpoint_sender, subscription_handle) = SubscriptionService::build(&registry);
+
+        let context = Arc::new(Context::new(sim, Chain::Unknown, checkpoint_sender));
+
+        let reader: Arc<dyn RpcStateReader> = Arc::new(data_store);
+        let mut service = RpcService::new(reader);
+        service.with_server_version(ServerVersion::new("sui-forking", "test"));
+        service.with_subscription_service(subscription_handle);
+        service.with_executor(Arc::new(ForkedTransactionExecutor::new(context.clone())));
+        service.with_custom_service(ForkingServiceServer::new(ForkingServiceImpl::new(
+            context.clone(),
+        )));
+        service.with_file_descriptor_set(crate::proto::FILE_DESCRIPTOR_SET);
+
+        // Bind to ephemeral port via a probe listener, then drop and let
+        // `start_service` rebind. The window between is short enough not to
+        // matter for in-process tests.
+        let probe = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+        let addr = probe.local_addr()?;
+        drop(probe);
+
+        let server_task = tokio::spawn(async move { service.start_service(addr).await });
+
+        let grpc_endpoint = format!("http://{addr}");
+
+        // Wait for the server to come up by polling a connect.
+        for _ in 0..50 {
+            if ForkingServiceClient::connect(grpc_endpoint.clone()).await.is_ok() {
+                return Ok(Self {
+                    server_task,
+                    grpc_endpoint,
+                    _temp: temp,
+                });
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        Err(anyhow!("timed out waiting for gRPC server to bind"))
+    }
+}
+
+impl Drop for ServerHarness {
+    fn drop(&mut self) {
+        self.server_task.abort();
+    }
+}
+
+const STREAM_RECV_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[tokio::test]
+async fn subscription_streams_checkpoints_after_advance() -> Result<()> {
+    let harness = ServerHarness::start().await?;
+
+    let mut subscriptions =
+        SubscriptionServiceClient::connect(harness.grpc_endpoint.clone()).await?;
+    let mut stream = subscriptions
+        .subscribe_checkpoints(SubscribeCheckpointsRequest::default())
+        .await?
+        .into_inner();
+
+    let mut forking = ForkingServiceClient::connect(harness.grpc_endpoint.clone()).await?;
+
+    let mut expected = Vec::with_capacity(3);
+    for _ in 0..3 {
+        let resp = forking
+            .advance_checkpoint(AdvanceCheckpointRequest {})
+            .await?
+            .into_inner();
+        expected.push(resp.checkpoint_sequence_number);
+    }
+
+    for expected_seq in expected {
+        let msg = tokio::time::timeout(STREAM_RECV_TIMEOUT, stream.message())
+            .await?
+            .map_err(|e| anyhow!("stream error: {e}"))?
+            .ok_or_else(|| anyhow!("subscription stream closed before advance"))?;
+        let cursor = msg.cursor.ok_or_else(|| anyhow!("missing cursor on subscription message"))?;
+        assert_eq!(cursor, expected_seq);
+        assert!(
+            msg.checkpoint.is_some(),
+            "subscription message missing checkpoint payload"
+        );
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn subscription_fans_out_to_multiple_subscribers() -> Result<()> {
+    let harness = ServerHarness::start().await?;
+
+    let mut sub_a = SubscriptionServiceClient::connect(harness.grpc_endpoint.clone()).await?;
+    let mut stream_a = sub_a
+        .subscribe_checkpoints(SubscribeCheckpointsRequest::default())
+        .await?
+        .into_inner();
+
+    let mut sub_b = SubscriptionServiceClient::connect(harness.grpc_endpoint.clone()).await?;
+    let mut stream_b = sub_b
+        .subscribe_checkpoints(SubscribeCheckpointsRequest::default())
+        .await?
+        .into_inner();
+
+    let mut forking = ForkingServiceClient::connect(harness.grpc_endpoint.clone()).await?;
+    let resp = forking
+        .advance_checkpoint(AdvanceCheckpointRequest {})
+        .await?
+        .into_inner();
+    let expected_seq = resp.checkpoint_sequence_number;
+
+    let msg_a = tokio::time::timeout(STREAM_RECV_TIMEOUT, stream_a.message())
+        .await?
+        .map_err(|e| anyhow!("stream A error: {e}"))?
+        .ok_or_else(|| anyhow!("stream A closed before advance"))?;
+    let msg_b = tokio::time::timeout(STREAM_RECV_TIMEOUT, stream_b.message())
+        .await?
+        .map_err(|e| anyhow!("stream B error: {e}"))?
+        .ok_or_else(|| anyhow!("stream B closed before advance"))?;
+
+    assert_eq!(msg_a.cursor, Some(expected_seq));
+    assert_eq!(msg_b.cursor, Some(expected_seq));
+
+    Ok(())
+}

--- a/crates/sui-forking/src/tests/subscription_e2e.rs
+++ b/crates/sui-forking/src/tests/subscription_e2e.rs
@@ -15,6 +15,7 @@ use anyhow::{Result, anyhow};
 use prometheus::Registry;
 use rand::rngs::OsRng;
 use simulacrum::Simulacrum;
+use simulacrum::SimulatorStore;
 use simulacrum::store::in_mem_store::KeyStore;
 use sui_protocol_config::Chain;
 use sui_rpc_api::proto::sui::rpc::v2::SubscribeCheckpointsRequest;
@@ -100,7 +101,10 @@ impl ServerHarness {
 
         // Wait for the server to come up by polling a connect.
         for _ in 0..50 {
-            if ForkingServiceClient::connect(grpc_endpoint.clone()).await.is_ok() {
+            if ForkingServiceClient::connect(grpc_endpoint.clone())
+                .await
+                .is_ok()
+            {
                 return Ok(Self {
                     server_task,
                     grpc_endpoint,
@@ -148,7 +152,9 @@ async fn subscription_streams_checkpoints_after_advance() -> Result<()> {
             .await?
             .map_err(|e| anyhow!("stream error: {e}"))?
             .ok_or_else(|| anyhow!("subscription stream closed before advance"))?;
-        let cursor = msg.cursor.ok_or_else(|| anyhow!("missing cursor on subscription message"))?;
+        let cursor = msg
+            .cursor
+            .ok_or_else(|| anyhow!("missing cursor on subscription message"))?;
         assert_eq!(cursor, expected_seq);
         assert!(
             msg.checkpoint.is_some(),


### PR DESCRIPTION
## Description 

This PR adds the checkpoint subscription service for the rpc by reusing the current implementation in `sui-rpc-api`, and providing a handle. It adds a producer for pushing newly created checkpoints to subscribers.
## Test plan 

New tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
