### PR TITLE
rpc-index: track coin and address balances separately

### DIFF
--- a/crates/sui-core/src/rpc_index.rs
+++ b/crates/sui-core/src/rpc_index.rs
@@ -51,7 +51,7 @@ use typed_store::rocks::{DBMap, DBMapTableConfigMap, MetricConf};
 use typed_store::rocksdb::{MergeOperands, WriteOptions, compaction_filter::Decision};
 use typed_store::traits::Map;
 
-const CURRENT_DB_VERSION: u64 = 3;
+const CURRENT_DB_VERSION: u64 = 4;
 // I tried increasing this to 100k and 1M and it didn't speed up indexing at all.
 const BALANCE_FLUSH_THRESHOLD: usize = 10_000;
 
@@ -168,20 +168,18 @@ pub struct CoinIndexInfo {
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Debug, Default)]
 pub struct BalanceIndexInfo {
-    pub balance_delta: i128,
-}
-
-impl From<u64> for BalanceIndexInfo {
-    fn from(coin_value: u64) -> Self {
-        Self {
-            balance_delta: coin_value as i128,
-        }
-    }
+    pub coin_balance_delta: i128,
+    pub address_balance_delta: i128,
 }
 
 impl BalanceIndexInfo {
     fn merge_delta(&mut self, other: &Self) {
-        self.balance_delta += other.balance_delta;
+        self.coin_balance_delta = self
+            .coin_balance_delta
+            .saturating_add(other.coin_balance_delta);
+        self.address_balance_delta = self
+            .address_balance_delta
+            .saturating_add(other.address_balance_delta);
     }
 }
 
@@ -193,8 +191,12 @@ impl From<BalanceIndexInfo> for sui_types::storage::BalanceInfo {
         // total balances over u64::MAX. To avoid crashing the indexer, we clamp the merged value instead
         // of panicking on overflow. This has the unfortunate consequence of making bugs in the index
         // harder to detect, but is a necessary trade-off to avoid creating a DOS attack vector.
-        let balance = index_info.balance_delta.clamp(0, u64::MAX as i128) as u64;
-        sui_types::storage::BalanceInfo { balance }
+        let coin_balance = index_info.coin_balance_delta.clamp(0, u64::MAX as i128) as u64;
+        let address_balance = index_info.address_balance_delta.clamp(0, u64::MAX as i128) as u64;
+        sui_types::storage::BalanceInfo {
+            coin_balance,
+            address_balance,
+        }
     }
 }
 
@@ -269,7 +271,7 @@ fn balance_compaction_filter(_level: u32, _key: &[u8], value: &[u8]) -> Decision
         Err(_) => return Decision::Keep,
     };
 
-    if balance_info.balance_delta == 0 {
+    if balance_info.coin_balance_delta == 0 && balance_info.address_balance_delta == 0 {
         Decision::Remove
     } else {
         Decision::Keep
@@ -801,7 +803,7 @@ impl IndexStoreTables {
 
         // iterate in reverse order, process accumulator settlements first
         for (tx_idx, tx) in checkpoint.transactions.iter().enumerate().rev() {
-            let balance_changes = sui_types::balance_change::derive_balance_changes(
+            let balance_changes = sui_types::balance_change::derive_detailed_balance_changes(
                 &tx.effects,
                 &tx.input_objects,
                 &tx.output_objects,
@@ -815,7 +817,8 @@ impl IndexStoreTables {
                             coin_type: *coin_type,
                         },
                         BalanceIndexInfo {
-                            balance_delta: change.amount,
+                            coin_balance_delta: change.coin_amount,
+                            address_balance_delta: change.address_amount,
                         },
                     ))
                 } else {
@@ -1636,7 +1639,10 @@ impl LiveObjectIndexer for RpcLiveObjectIndexer<'_> {
 
                 if let Some((coin_type, value)) = get_balance_and_type_if_coin(&object)? {
                     let balance_key = BalanceKey { owner, coin_type };
-                    let balance_info = BalanceIndexInfo::from(value);
+                    let balance_info = BalanceIndexInfo {
+                        coin_balance_delta: value.into(),
+                        address_balance_delta: 0,
+                    };
                     self.balance_changes
                         .entry(balance_key)
                         .or_default()
@@ -1665,7 +1671,8 @@ impl LiveObjectIndexer for RpcLiveObjectIndexer<'_> {
                 {
                     let balance_key = BalanceKey { owner, coin_type };
                     let balance_info = BalanceIndexInfo {
-                        balance_delta: balance,
+                        coin_balance_delta: 0,
+                        address_balance_delta: balance,
                     };
                     self.balance_changes
                         .entry(balance_key)

--- a/crates/sui-rpc-api/src/grpc/v2/state_service/get_balance.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/state_service/get_balance.rs
@@ -61,54 +61,25 @@ pub fn get_balance(service: &RpcService, request: GetBalanceRequest) -> Result<G
 }
 
 pub(super) fn render_balance(
-    service: &RpcService,
-    owner: SuiAddress,
+    _service: &RpcService,
+    _owner: SuiAddress,
     coin_type: move_core_types::language_storage::StructTag,
     balance_info: BalanceInfo,
 ) -> Balance {
     let mut balance = Balance::default()
         .with_coin_type(coin_type.to_canonical_string(true))
-        .with_balance(balance_info.balance);
+        .with_balance(
+            balance_info
+                .coin_balance
+                .saturating_add(balance_info.address_balance),
+        );
 
-    if balance_info.balance == 0 {
-        return balance;
+    if balance_info.coin_balance != 0 {
+        balance.set_coin_balance(balance_info.coin_balance);
     }
 
-    // When looking up an Address's balance for a particular coin type, there is a possibility that
-    // the value we read is "newer" (further ahead in time) than the summed balance we've read from
-    // the indexes.
-    //
-    // This inconsistency should in practice be hard to see (as its a race) but it can lead to
-    // slightly inconsistent responses:
-    //
-    // - If the Address balance is greater than it was at the checkpoint corrisponding to our index
-    // read, then we'll clamp the value returned to what was in the indexes and its possible that
-    // we under report the balance stored in `Coin<T>`s by saying that the address has no coin
-    // balance.
-    //
-    // - If the Address balance is less than it was at the checkpoint corrisponding to our index
-    // read, then we can possibly over-inflate the balance stored in `Coin<T>`s.
-    if let Some(address_balance) = service.reader.lookup_address_balance(owner, coin_type) {
-        balance.set_address_balance(address_balance);
-
-        match address_balance.cmp(&balance_info.balance) {
-            std::cmp::Ordering::Less => {
-                // If the AddressBalance is less than the total balance we read from the indexes,
-                // then the difference is attributed to coins
-                balance.set_coin_balance(balance_info.balance.saturating_sub(address_balance));
-            }
-            std::cmp::Ordering::Equal => {}
-            std::cmp::Ordering::Greater => {
-                // There is a potential race where the Address balance we read is newer than what
-                // we read from the indexes, and if its higher then lets just cap it based on what
-                // we have in the indexes.
-                balance.set_address_balance(balance_info.balance);
-            }
-        }
-    } else {
-        // If there is no AddressBalance for this coin type, then all the balance is attributed to
-        // coins
-        balance.set_coin_balance(balance_info.balance);
+    if balance_info.address_balance != 0 {
+        balance.set_address_balance(balance_info.address_balance);
     }
 
     balance

--- a/crates/sui-types/src/balance_change.rs
+++ b/crates/sui-types/src/balance_change.rs
@@ -27,6 +27,35 @@ pub struct BalanceChange {
     pub amount: i128,
 }
 
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct DetailedBalanceChange {
+    /// Owner of the balance change
+    pub address: SuiAddress,
+
+    /// Type of the Coin
+    pub coin_type: TypeTag,
+
+    /// The amount indicates the balance value changes from coins.
+    ///
+    /// A negative amount means spending coin value and positive means receiving coin value.
+    pub coin_amount: i128,
+
+    /// The amount indicates the balance value changes from address balances.
+    ///
+    /// A negative amount means spending coin value and positive means receiving coin value.
+    pub address_amount: i128,
+}
+
+impl From<DetailedBalanceChange> for BalanceChange {
+    fn from(value: DetailedBalanceChange) -> Self {
+        Self {
+            address: value.address,
+            coin_type: value.coin_type,
+            amount: value.coin_amount + value.address_amount,
+        }
+    }
+}
+
 impl std::fmt::Debug for BalanceChange {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("BalanceChange")
@@ -100,11 +129,30 @@ pub fn derive_balance_changes(
     input_objects: &[Object],
     output_objects: &[Object],
 ) -> Vec<BalanceChange> {
+    derive_detailed_balance_changes(effects, input_objects, output_objects)
+        .into_iter()
+        // Filter out when coin and address changes net to 0
+        .filter_map(|detailed_change| {
+            let change = BalanceChange::from(detailed_change);
+            if change.amount == 0 {
+                None
+            } else {
+                Some(change)
+            }
+        })
+        .collect()
+}
+
+pub fn derive_detailed_balance_changes(
+    effects: &TransactionEffects,
+    input_objects: &[Object],
+    output_objects: &[Object],
+) -> Vec<DetailedBalanceChange> {
     // 1. subtract all input coins
     let balances = coins(input_objects).fold(
-        std::collections::BTreeMap::<_, i128>::new(),
+        std::collections::BTreeMap::<_, (i128, i128)>::new(),
         |mut acc, (address, coin_type, balance)| {
-            *acc.entry((*address, coin_type)).or_default() -= balance as i128;
+            acc.entry((*address, coin_type)).or_default().0 -= balance as i128;
             acc
         },
     );
@@ -112,7 +160,7 @@ pub fn derive_balance_changes(
     // 2. add all mutated/output coins
     let balances =
         coins(output_objects).fold(balances, |mut acc, (address, coin_type, balance)| {
-            *acc.entry((*address, coin_type)).or_default() += balance as i128;
+            acc.entry((*address, coin_type)).or_default().0 += balance as i128;
             acc
         });
 
@@ -120,22 +168,23 @@ pub fn derive_balance_changes(
     let balances = address_balance_changes_from_accumulator_events(effects).fold(
         balances,
         |mut acc, (address, coin_type, signed_amount)| {
-            *acc.entry((address, coin_type)).or_default() += signed_amount;
+            acc.entry((address, coin_type)).or_default().1 += signed_amount;
             acc
         },
     );
 
     balances
         .into_iter()
-        .filter_map(|((address, coin_type), amount)| {
-            if amount == 0 {
+        .filter_map(|((address, coin_type), (coin_amount, address_amount))| {
+            if coin_amount == 0 && address_amount == 0 {
                 return None;
             }
 
-            Some(BalanceChange {
+            Some(DetailedBalanceChange {
                 address,
                 coin_type,
-                amount,
+                coin_amount,
+                address_amount,
             })
         })
         .collect()

--- a/crates/sui-types/src/storage/read_store.rs
+++ b/crates/sui-types/src/storage/read_store.rs
@@ -762,7 +762,8 @@ pub struct CoinInfo {
 
 #[derive(Default, Copy, Clone, Debug, Eq, PartialEq)]
 pub struct BalanceInfo {
-    pub balance: u64,
+    pub coin_balance: u64,
+    pub address_balance: u64,
 }
 
 #[derive(Clone, Serialize, Deserialize, Eq, PartialEq, Debug)]


### PR DESCRIPTION
This changes how balances are tracked in the rpc-indexes to separate coin and address balances in order to remove a possible inconsistency in the data returned due to a race between two reads from separate DBs.

This also bumps the CURRENT_DB_VERSION to 4 to trigger reindexing. The main reason for this is to explicitly fix some inaccurate indexes that exist on fullnodes in the wild due to a bug introduced in `baae1c4ded` and later fixed in `89deab497d`.

## Description 

Describe the changes or additions included in this PR.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [x] gRPC: rpc-index DB version has been updated to `4`. This means that on startup re-indexing will be required and can take some time depending on the amount of object history present on the node.
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
