### PR TITLE
network: bump anemo version to 487f8bc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -877,7 +877,7 @@ dependencies = [
 [[package]]
 name = "anemo"
 version = "0.0.0"
-source = "git+https://github.com/mystenlabs/anemo.git?rev=9248f8d3951df750360308df22618e5978ad6dc0#9248f8d3951df750360308df22618e5978ad6dc0"
+source = "git+https://github.com/mystenlabs/anemo.git?rev=487f8bc739e535391a56e1aa1193084da9d64ce8#487f8bc739e535391a56e1aa1193084da9d64ce8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -925,7 +925,7 @@ dependencies = [
 [[package]]
 name = "anemo-build"
 version = "0.0.0"
-source = "git+https://github.com/mystenlabs/anemo.git?rev=9248f8d3951df750360308df22618e5978ad6dc0#9248f8d3951df750360308df22618e5978ad6dc0"
+source = "git+https://github.com/mystenlabs/anemo.git?rev=487f8bc739e535391a56e1aa1193084da9d64ce8#487f8bc739e535391a56e1aa1193084da9d64ce8"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -936,7 +936,7 @@ dependencies = [
 [[package]]
 name = "anemo-cli"
 version = "0.0.0"
-source = "git+https://github.com/mystenlabs/anemo.git?rev=9248f8d3951df750360308df22618e5978ad6dc0#9248f8d3951df750360308df22618e5978ad6dc0"
+source = "git+https://github.com/mystenlabs/anemo.git?rev=487f8bc739e535391a56e1aa1193084da9d64ce8#487f8bc739e535391a56e1aa1193084da9d64ce8"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -952,7 +952,7 @@ dependencies = [
 [[package]]
 name = "anemo-tower"
 version = "0.0.0"
-source = "git+https://github.com/mystenlabs/anemo.git?rev=9248f8d3951df750360308df22618e5978ad6dc0#9248f8d3951df750360308df22618e5978ad6dc0"
+source = "git+https://github.com/mystenlabs/anemo.git?rev=487f8bc739e535391a56e1aa1193084da9d64ce8#487f8bc739e535391a56e1aa1193084da9d64ce8"
 dependencies = [
  "anemo",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -659,10 +659,10 @@ p384 = { version = "0.13.0", default-features = false, features = [
 ciborium = "0.2"
 
 # anemo dependencies
-anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "9248f8d3951df750360308df22618e5978ad6dc0" }
-anemo-build = { git = "https://github.com/mystenlabs/anemo.git", rev = "9248f8d3951df750360308df22618e5978ad6dc0" }
-anemo-cli = { git = "https://github.com/mystenlabs/anemo.git", rev = "9248f8d3951df750360308df22618e5978ad6dc0" }
-anemo-tower = { git = "https://github.com/mystenlabs/anemo.git", rev = "9248f8d3951df750360308df22618e5978ad6dc0" }
+anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "487f8bc739e535391a56e1aa1193084da9d64ce8" }
+anemo-build = { git = "https://github.com/mystenlabs/anemo.git", rev = "487f8bc739e535391a56e1aa1193084da9d64ce8" }
+anemo-cli = { git = "https://github.com/mystenlabs/anemo.git", rev = "487f8bc739e535391a56e1aa1193084da9d64ce8" }
+anemo-tower = { git = "https://github.com/mystenlabs/anemo.git", rev = "487f8bc739e535391a56e1aa1193084da9d64ce8" }
 
 # core-types from the new sdk for use in gRPC
 sui-sdk-types = { git = "https://github.com/MystenLabs/sui-rust-sdk.git", rev = "e494a36a76a0aab8c5d66d5557995faee5c1fb09", features = [ "hash", "serde" ] }

--- a/crates/mysten-network/src/codec.rs
+++ b/crates/mysten-network/src/codec.rs
@@ -8,6 +8,25 @@ use tonic::{
     codec::{Codec, DecodeBuf, Decoder, EncodeBuf, Encoder},
 };
 
+/// Default upper bound on total decompressed payload size.
+const MAX_DECOMPRESSED_SIZE: u64 = 128 << 20;
+
+/// Decompress a snappy-framed stream, bounding output at
+/// [`MAX_DECOMPRESSED_SIZE`].
+fn decompress_snappy<R: Read>(src: R) -> std::io::Result<Vec<u8>> {
+    decompress_snappy_bounded(src, MAX_DECOMPRESSED_SIZE)
+}
+
+/// Decompress a snappy-framed stream, bounding total output at
+/// `max_allowed` bytes. Exposed separately from [`decompress_snappy`] so
+/// tests can exercise the bound directly.
+fn decompress_snappy_bounded<R: Read>(src: R, max_allowed: u64) -> std::io::Result<Vec<u8>> {
+    let mut snappy_decoder = snap::read::FrameDecoder::new(src).take(max_allowed);
+    let mut bytes = Vec::new();
+    snappy_decoder.read_to_end(&mut bytes)?;
+    Ok(bytes)
+}
+
 #[derive(Debug)]
 pub struct BcsEncoder<T>(PhantomData<T>);
 
@@ -92,13 +111,10 @@ impl<U: serde::de::DeserializeOwned> Decoder for BcsSnappyDecoder<U> {
     type Error = Status;
 
     fn decode(&mut self, buf: &mut DecodeBuf<'_>) -> Result<Option<Self::Item>, Self::Error> {
-        let compressed_size = buf.remaining();
-        if compressed_size == 0 {
+        if !buf.has_remaining() {
             return Ok(None);
         }
-        let mut snappy_decoder = snap::read::FrameDecoder::new(buf.reader());
-        let mut bytes = Vec::with_capacity(compressed_size);
-        snappy_decoder.read_to_end(&mut bytes)?;
+        let bytes = decompress_snappy(buf.reader()).map_err(|e| Status::internal(e.to_string()))?;
         let item =
             bcs::from_bytes(bytes.as_slice()).map_err(|e| Status::internal(e.to_string()))?;
         Ok(Some(item))
@@ -139,7 +155,7 @@ where
 pub mod anemo {
     use ::anemo::rpc::codec::{Codec, Decoder, Encoder};
     use bytes::Buf;
-    use std::{io::Read, marker::PhantomData};
+    use std::marker::PhantomData;
 
     #[derive(Debug)]
     pub struct BcsSnappyEncoder<T>(PhantomData<T>);
@@ -165,10 +181,7 @@ pub mod anemo {
         type Error = bcs::Error;
 
         fn decode(&mut self, buf: bytes::Bytes) -> Result<Self::Item, Self::Error> {
-            let compressed_size = buf.len();
-            let mut snappy_decoder = snap::read::FrameDecoder::new(buf.reader()).take(1 << 30);
-            let mut bytes = Vec::with_capacity(compressed_size);
-            snappy_decoder.read_to_end(&mut bytes)?;
+            let bytes = super::decompress_snappy(buf.reader())?;
             bcs::from_bytes(bytes.as_slice())
         }
     }
@@ -203,6 +216,100 @@ pub mod anemo {
 
         fn format_name(&self) -> &'static str {
             "bcs"
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ::anemo::rpc::codec::{
+        Codec as AnemoCodec, Decoder as AnemoDecoder, Encoder as AnemoEncoder,
+    };
+
+    fn snappy_compress(raw: &[u8]) -> Vec<u8> {
+        let mut out = Vec::new();
+        let mut encoder = snap::write::FrameEncoder::new(&mut out);
+        std::io::Write::write_all(&mut encoder, raw).unwrap();
+        drop(encoder);
+        out
+    }
+
+    #[test]
+    fn anemo_roundtrip() {
+        let mut codec: anemo::BcsSnappyCodec<Vec<u64>, Vec<u64>> = anemo::BcsSnappyCodec::default();
+        let value = vec![1u64, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        let encoded = codec.encoder().encode(value.clone()).unwrap();
+        let decoded = codec.decoder().decode(encoded).unwrap();
+        assert_eq!(decoded, value);
+    }
+
+    #[test]
+    fn bounded_helper_respects_output_limit() {
+        // With `max_allowed` set below the stream's decompressed size,
+        // `decompress_snappy_bounded` returns exactly `max_allowed` bytes.
+        let raw = vec![0u8; 2 * 1024 * 1024];
+        let compressed = snappy_compress(&raw);
+        let limit = 1024u64;
+        let out = decompress_snappy_bounded(&compressed[..], limit).unwrap();
+        assert_eq!(out.len() as u64, limit);
+        assert!((out.len() as u64) < raw.len() as u64);
+    }
+
+    // Tonic-variant round trip via a bespoke HttpBody. Building a real
+    // `DecodeBuf` requires tonic's internal API, so we drive the decoder
+    // through `tonic::codec::Streaming::new_request`, which is the path used
+    // by the gRPC server. This exercises the real `BcsSnappyDecoder::decode`.
+    mod tonic_via_streaming {
+        use super::super::*;
+        use super::snappy_compress;
+        use bytes::{BufMut, Bytes, BytesMut};
+        use futures::StreamExt;
+        use http_body::{Body as HttpBody, Frame};
+        use std::pin::Pin;
+        use std::task::{Context, Poll};
+
+        /// Minimal HttpBody yielding a single gRPC-framed payload. gRPC length-
+        /// prefixed frames are `[compression:u8][length:u32 BE][payload]`.
+        struct OneFrameBody(Option<Bytes>);
+
+        impl OneFrameBody {
+            fn new(payload: Bytes) -> Self {
+                let mut framed = BytesMut::with_capacity(5 + payload.len());
+                framed.put_u8(0);
+                framed.put_u32(payload.len() as u32);
+                framed.put_slice(&payload);
+                Self(Some(framed.freeze()))
+            }
+        }
+
+        impl HttpBody for OneFrameBody {
+            type Data = Bytes;
+            type Error = std::convert::Infallible;
+
+            fn poll_frame(
+                mut self: Pin<&mut Self>,
+                _cx: &mut Context<'_>,
+            ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+                Poll::Ready(self.0.take().map(|b| Ok(Frame::data(b))))
+            }
+
+            fn is_end_stream(&self) -> bool {
+                self.0.is_none()
+            }
+        }
+
+        #[tokio::test]
+        async fn tonic_roundtrip() {
+            let mut codec: BcsSnappyCodec<Vec<u64>, Vec<u64>> = BcsSnappyCodec::default();
+            let value = vec![1u64, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+            let raw = bcs::to_bytes(&value).unwrap();
+            let compressed = snappy_compress(&raw);
+            let body = OneFrameBody::new(Bytes::from(compressed));
+            let mut stream =
+                tonic::codec::Streaming::new_request(codec.decoder(), body, None, None);
+            let decoded = stream.next().await.unwrap().unwrap();
+            assert_eq!(decoded, value);
         }
     }
 }

--- a/crates/sui-network/src/randomness/builder.rs
+++ b/crates/sui-network/src/randomness/builder.rs
@@ -47,7 +47,7 @@ impl Builder {
         self
     }
 
-    pub fn build(self) -> (UnstartedRandomness, anemo::Router) {
+    pub fn build(self) -> (UnstartedRandomness, anemo::Router<anemo::ServicesSealed>) {
         let Builder {
             name,
             config,
@@ -73,8 +73,8 @@ impl Builder {
 
         let allowed_peers = AllowedPeersUpdatable::new(Arc::new(HashSet::new()));
         let router = anemo::Router::new()
-            .route_layer(RequireAuthorizationLayer::new(allowed_peers.clone()))
-            .add_rpc_service(randomness_server);
+            .add_rpc_service(randomness_server)
+            .route_layer(RequireAuthorizationLayer::new(allowed_peers.clone()));
 
         (
             UnstartedRandomness {

--- a/crates/sui-network/src/state_sync/builder.rs
+++ b/crates/sui-network/src/state_sync/builder.rs
@@ -80,7 +80,7 @@ impl<S> Builder<S>
 where
     S: WriteStore + Clone + Send + Sync + 'static,
 {
-    pub fn build(self) -> (UnstartedStateSync<S>, anemo::Router) {
+    pub fn build(self) -> (UnstartedStateSync<S>, anemo::Router<anemo::ServicesSealed>) {
         let state_sync_config = self.config.clone().unwrap_or_default();
         let (mut builder, server) = self.build_internal();
         let mut state_sync_server = StateSyncServer::new(server);
@@ -126,11 +126,13 @@ where
         }
 
         let router = anemo::Router::new()
-            // Size limit layer applied before deserialization.
+            .add_rpc_service(state_sync_server)
+            // Size limit layer applies to request messages only. This effectively
+            // bounds only checkpoint summary size, because all other state sync
+            // request messages are very small.
             .route_layer(SizeLimitLayer::new(
                 state_sync_config.max_checkpoint_summary_size(),
-            ))
-            .add_rpc_service(state_sync_server);
+            ));
 
         (builder, router)
     }

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -1159,9 +1159,12 @@ impl SuiNode {
                 .into_inner();
 
             let mut anemo_config = config.p2p_config.anemo_config.clone().unwrap_or_default();
-            // Set the max_frame_size to be 1 GB to work around the issue of there being too many
-            // staking events in the epoch change txn.
-            anemo_config.max_frame_size = Some(1 << 30);
+            // Inbound requests on this network are small (signatures, queries, summaries).
+            // Cap request frames at 1 MiB.
+            anemo_config.max_request_frame_size = Some(1 << 20);
+            // Responses can be larger (checkpoint contents).
+            // Cap response frames at 128 MiB.
+            anemo_config.max_response_frame_size = Some(128 << 20);
 
             // Set a higher default value for socket send/receive buffers if not already
             // configured.


### PR DESCRIPTION
## Description 

Set new `max_request_frame_size` config to 1 MiB on the p2p network. Lower existing max (now applies only to responses) to 128 MiB, still plenty of headroom over max observed message sizes. Factor the snappy decode path in `mysten-network::codec` into a shared helper.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
