### PR TITLE
Allow for custom replay graphql url

### DIFF
--- a/crates/sui-data-store/src/node.rs
+++ b/crates/sui-data-store/src/node.rs
@@ -56,7 +56,8 @@ impl Node {
         match self {
             Node::Mainnet => MAINNET_GQL_URL,
             Node::Testnet => TESTNET_GQL_URL,
-            Node::Custom(_url) => todo!("custom gql url not implemented"),
+            // For custom, assume it's already a GraphQL URL
+            Node::Custom(url) => url.as_str(),
         }
     }
 
@@ -79,6 +80,27 @@ impl FromStr for Node {
             "mainnet" => Ok(Node::Mainnet),
             "testnet" => Ok(Node::Testnet),
             _ => Ok(Node::Custom(s.to_string())),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn custom_gql_url_returns_provided_url() {
+        let url = "https://graphql.devnet.example.com/graphql";
+        let node = Node::Custom(url.to_string());
+        assert_eq!(node.gql_url(), url);
+    }
+
+    #[test]
+    fn from_str_unknown_becomes_custom() {
+        let url = "https://graphql.devnet.example.com/graphql";
+        match Node::from_str(url).unwrap() {
+            Node::Custom(s) => assert_eq!(s, url),
+            other => panic!("expected Custom, got {other:?}"),
         }
     }
 }

--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -6,6 +6,7 @@ use std::net::{AddrParseError, IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::num::NonZeroUsize;
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
+use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
 use std::{fs, io};
@@ -420,6 +421,12 @@ pub enum SuiCommand {
 
         #[command(flatten)]
         replay_config: SR2::ReplayConfigStable,
+
+        /// Network or GraphQL URL to replay against. Accepts `mainnet`, `testnet`,
+        /// or a full GraphQL URL (e.g. for devnet or a self-hosted endpoint).
+        /// When omitted, the network is derived from the active wallet env.
+        #[arg(long = "node", short = 'n')]
+        node: Option<String>,
     },
 
     /// Generate shell completion scripts for CLI
@@ -797,13 +804,18 @@ impl SuiCommand {
             SuiCommand::ReplayTransaction {
                 config,
                 replay_config,
+                node,
             } => {
                 let mut context = get_wallet_context(&config).await?;
                 if let Some(env_override) = config.env {
                     context = context.with_env_override(env_override);
                 }
 
-                let node = get_replay_node(&context).await?;
+                let node = match node {
+                    Some(s) => sui_data_store::Node::from_str(&s)
+                        .map_err(|e| anyhow!("invalid --node value: {e}"))?,
+                    None => get_replay_node(&context).await?,
+                };
                 let file_config = SR2::load_config_file()?;
                 let stable_config = SR2::merge_configs(replay_config, file_config);
                 let experimental_config = SR2::ReplayConfigExperimental {


### PR DESCRIPTION
## Description 

This PR adds support for passing a custom graphql url to replay a transaction. This will enable to replay transactions on devnet:
```
sui replay --node https://graphql.devnet.sui.io/graphql --digest 5R1qDi4qtPrS7ChHtpt8EgagGEWFZcbh9uostzzJksLu
```

## Test plan 

Existing tests.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [x] CLI: `sui replay` now allows to pass a custom `node` url to a `GraphQL` server: `sui replay --node https://graphql.devnet.sui.io/graphql`.
- [ ] Rust SDK:
- [ ] Indexing Framework:
