### PR TITLE
Add send_funds workload to single-node benchmark

### DIFF
--- a/crates/sui-single-node-benchmark/src/benchmark_context.rs
+++ b/crates/sui-single-node-benchmark/src/benchmark_context.rs
@@ -15,10 +15,14 @@ use std::ops::Deref;
 use std::sync::Arc;
 use sui_config::node::RunWithRange;
 use sui_core::authority::shared_object_version_manager::{AssignedTxAndVersions, AssignedVersions};
-use sui_test_transaction_builder::PublishData;
+use sui_test_transaction_builder::{PublishData, TestTransactionBuilder};
 use sui_types::base_types::{ObjectID, ObjectRef, SequenceNumber, SuiAddress};
+use sui_types::digests::ChainIdentifier;
 use sui_types::effects::{TransactionEffects, TransactionEffectsAPI};
-use sui_types::transaction::Transaction;
+use sui_types::gas_coin::GAS;
+use sui_types::transaction::DEFAULT_VALIDATOR_GAS_PRICE;
+use sui_types::transaction::{Argument, Command, Transaction};
+use sui_types::{Identifier, SUI_FRAMEWORK_PACKAGE_ID};
 use tracing::{info, warn};
 
 pub struct BenchmarkContext {
@@ -465,6 +469,80 @@ impl BenchmarkContext {
             let results: Vec<_> = tasks.collect().await;
             results.into_iter().map(|r| r.unwrap()).collect()
         }
+    }
+
+    pub(crate) fn get_chain_identifier(&self) -> ChainIdentifier {
+        self.validator.get_validator().get_chain_identifier()
+    }
+
+    pub(crate) fn get_epoch(&self) -> u64 {
+        self.validator.get_epoch()
+    }
+
+    /// Seed each user account's address balance by splitting from their gas coin,
+    /// converting to a Balance, and calling send_funds to self.
+    pub(crate) async fn seed_address_balances(&mut self, seed_amount: u64) {
+        info!(
+            "Seeding address balances with {} MIST for {} accounts",
+            seed_amount,
+            self.user_accounts.len()
+        );
+
+        let transactions: Vec<_> = self
+            .user_accounts
+            .values()
+            .map(|account| {
+                let gas_object = account.gas_objects[0];
+                let mut tx_builder = TestTransactionBuilder::new(
+                    account.sender,
+                    gas_object,
+                    DEFAULT_VALIDATOR_GAS_PRICE,
+                );
+                {
+                    let builder = tx_builder.ptb_builder_mut();
+                    let amount_arg = builder.pure(seed_amount).unwrap();
+                    let coin =
+                        builder.command(Command::SplitCoins(Argument::GasCoin, vec![amount_arg]));
+                    let Argument::Result(coin_idx) = coin else {
+                        panic!("SplitCoins should return Result");
+                    };
+                    let coin = Argument::NestedResult(coin_idx, 0);
+                    let coin_balance = builder.programmable_move_call(
+                        SUI_FRAMEWORK_PACKAGE_ID,
+                        Identifier::new("coin").unwrap(),
+                        Identifier::new("into_balance").unwrap(),
+                        vec![GAS::type_tag()],
+                        vec![coin],
+                    );
+                    let recipient_arg = builder.pure(account.sender).unwrap();
+                    builder.programmable_move_call(
+                        SUI_FRAMEWORK_PACKAGE_ID,
+                        Identifier::new("balance").unwrap(),
+                        Identifier::new("send_funds").unwrap(),
+                        vec![GAS::type_tag()],
+                        vec![coin_balance, recipient_arg],
+                    );
+                }
+                tx_builder.build_and_sign(account.keypair.as_ref())
+            })
+            .collect();
+
+        let results = self.execute_raw_transactions(transactions).await;
+        let mut new_gas_objects = HashMap::new();
+        let cache_commit = self.validator.get_validator().get_cache_commit().clone();
+        for effects in results {
+            let batch = cache_commit
+                .build_db_batch(effects.executed_epoch(), &[*effects.transaction_digest()]);
+            cache_commit.commit_transaction_outputs(
+                effects.executed_epoch(),
+                batch,
+                &[*effects.transaction_digest()],
+            );
+            let gas_object = effects.gas_object().unwrap().0;
+            new_gas_objects.insert(gas_object.0, gas_object);
+        }
+        self.refresh_gas_objects(new_gas_objects);
+        info!("Finished seeding address balances");
     }
 
     fn refresh_gas_objects(&mut self, mut new_gas_objects: HashMap<ObjectID, ObjectRef>) {

--- a/crates/sui-single-node-benchmark/src/benchmark_context.rs
+++ b/crates/sui-single-node-benchmark/src/benchmark_context.rs
@@ -348,7 +348,7 @@ impl BenchmarkContext {
         let min = durations[0];
         let max = durations[n - 1];
         info!(
-            "Per-tx execution timing (try_execute_immediately wall-clock):\n  \
+            "Per-tx execution timing (wall-clock, varies by component):\n  \
              avg={:?}  min={:?}  p50={:?}  p90={:?}  p99={:?}  max={:?}",
             avg, min, p50, p90, p99, max,
         );

--- a/crates/sui-single-node-benchmark/src/benchmark_context.rs
+++ b/crates/sui-single-node-benchmark/src/benchmark_context.rs
@@ -256,17 +256,21 @@ impl BenchmarkContext {
         );
 
         let is_consensus_tx = transactions.iter().any(|tx| tx.is_consensus_tx());
+        let mut durations: Vec<std::time::Duration>;
         if is_consensus_tx {
+            durations = Vec::with_capacity(tx_count);
             // With shared objects, we must execute each transaction in order.
             for transaction in transactions {
                 let key = transaction.key();
-                self.validator
+                let (_, dur) = self
+                    .validator
                     .execute_transaction(
                         transaction,
                         assigned_versions.get(&key).unwrap(),
                         self.benchmark_component,
                     )
                     .await;
+                durations.push(dur);
             }
         } else {
             let tasks: FuturesUnordered<_> = transactions
@@ -286,9 +290,7 @@ impl BenchmarkContext {
                 })
                 .collect();
             let results: Vec<_> = tasks.collect().await;
-            results.into_iter().for_each(|r| {
-                r.unwrap();
-            });
+            durations = results.into_iter().map(|r| r.unwrap().1).collect();
         }
 
         let elapsed = start_time.elapsed().as_millis() as f64 / 1000f64;
@@ -297,6 +299,8 @@ impl BenchmarkContext {
             elapsed,
             tx_count as f64 / elapsed
         );
+
+        Self::print_per_tx_timing(&mut durations);
     }
 
     pub(crate) async fn benchmark_transaction_execution_in_memory(
@@ -330,6 +334,23 @@ impl BenchmarkContext {
             elapsed,
             tx_count as f64 / elapsed,
             in_memory_store.get_num_object_reads() as f64 / tx_count as f64
+        );
+    }
+
+    fn print_per_tx_timing(durations: &mut [std::time::Duration]) {
+        durations.sort();
+        let n = durations.len();
+        let total: std::time::Duration = durations.iter().sum();
+        let avg = total / n as u32;
+        let p50 = durations[n / 2];
+        let p90 = durations[n * 90 / 100];
+        let p99 = durations[n * 99 / 100];
+        let min = durations[0];
+        let max = durations[n - 1];
+        info!(
+            "Per-tx execution timing (try_execute_immediately wall-clock):\n  \
+             avg={:?}  min={:?}  p50={:?}  p90={:?}  p99={:?}  max={:?}",
+            avg, min, p50, p90, p99, max,
         );
     }
 

--- a/crates/sui-single-node-benchmark/src/command.rs
+++ b/crates/sui-single-node-benchmark/src/command.rs
@@ -135,6 +135,23 @@ pub enum WorkloadKind {
         )]
         manifest_file: PathBuf,
     },
+    /// Benchmark send_funds transactions that withdraw from the sender's address
+    /// balance and deposit to a recipient via balance::send_funds.
+    /// Gas is paid from address balance.
+    SendFunds {
+        #[arg(
+            long,
+            default_value_t = 100_000_000_000,
+            help = "Amount of MIST to seed each sender's address balance with"
+        )]
+        seed_amount: u64,
+        #[arg(
+            long,
+            default_value_t = 1000,
+            help = "Amount of MIST to transfer per send_funds transaction"
+        )]
+        transfer_amount: u64,
+    },
 }
 
 impl WorkloadKind {
@@ -143,6 +160,8 @@ impl WorkloadKind {
             // Each transaction will always have 1 gas object, plus the number of owned objects that will be transferred.
             WorkloadKind::PTB { num_transfers, .. } => *num_transfers + 1,
             WorkloadKind::Publish { .. } => 1,
+            // 1 gas object used during the seeding phase; benchmark transactions use address balance gas.
+            WorkloadKind::SendFunds { .. } => 1,
         }
     }
 }

--- a/crates/sui-single-node-benchmark/src/single_node.rs
+++ b/crates/sui-single-node-benchmark/src/single_node.rs
@@ -81,6 +81,10 @@ impl SingleValidator {
         self.validator_service.validator_state()
     }
 
+    pub fn get_epoch(&self) -> u64 {
+        self.epoch_store.epoch()
+    }
+
     /// Publish a package, returns the package object and the updated gas object.
     pub async fn publish_package(
         &self,

--- a/crates/sui-single-node-benchmark/src/single_node.rs
+++ b/crates/sui-single-node-benchmark/src/single_node.rs
@@ -149,8 +149,9 @@ impl SingleValidator {
         transaction: Transaction,
         assigned_versions: &AssignedVersions,
         component: Component,
-    ) -> TransactionEffects {
+    ) -> (TransactionEffects, std::time::Duration) {
         let executable = self.create_executable(transaction);
+        let start = std::time::Instant::now();
         let effects = match component {
             Component::Baseline => {
                 self.get_validator()
@@ -191,8 +192,9 @@ impl SingleValidator {
                 unreachable!()
             }
         };
+        let elapsed = start.elapsed();
         assert!(effects.status().is_ok());
-        effects
+        (effects, elapsed)
     }
 
     pub(crate) async fn execute_transaction_in_memory(

--- a/crates/sui-single-node-benchmark/src/tx_generator.rs
+++ b/crates/sui-single-node-benchmark/src/tx_generator.rs
@@ -5,12 +5,14 @@ use crate::mock_account::Account;
 pub use move_tx_generator::MoveTxGenerator;
 pub use package_publish_tx_generator::PackagePublishTxGenerator;
 pub use root_object_create_tx_generator::RootObjectCreateTxGenerator;
+pub use send_funds_tx_generator::SendFundsTxGenerator;
 pub use shared_object_create_tx_generator::SharedObjectCreateTxGenerator;
 use sui_types::transaction::Transaction;
 
 mod move_tx_generator;
 mod package_publish_tx_generator;
 mod root_object_create_tx_generator;
+mod send_funds_tx_generator;
 mod shared_object_create_tx_generator;
 
 pub(crate) trait TxGenerator: Send + Sync {

--- a/crates/sui-single-node-benchmark/src/tx_generator/send_funds_tx_generator.rs
+++ b/crates/sui-single-node-benchmark/src/tx_generator/send_funds_tx_generator.rs
@@ -1,0 +1,76 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::mock_account::Account;
+use crate::tx_generator::TxGenerator;
+use move_core_types::identifier::Identifier;
+use std::sync::atomic::{AtomicU32, Ordering};
+use sui_test_transaction_builder::TestTransactionBuilder;
+use sui_types::SUI_FRAMEWORK_PACKAGE_ID;
+use sui_types::digests::ChainIdentifier;
+use sui_types::gas_coin::GAS;
+use sui_types::transaction::{DEFAULT_VALIDATOR_GAS_PRICE, FundsWithdrawalArg, Transaction};
+
+pub struct SendFundsTxGenerator {
+    chain_identifier: ChainIdentifier,
+    epoch: u64,
+    transfer_amount: u64,
+    nonce_counter: AtomicU32,
+}
+
+impl SendFundsTxGenerator {
+    pub fn new(chain_identifier: ChainIdentifier, epoch: u64, transfer_amount: u64) -> Self {
+        Self {
+            chain_identifier,
+            epoch,
+            transfer_amount,
+            nonce_counter: AtomicU32::new(0),
+        }
+    }
+}
+
+impl TxGenerator for SendFundsTxGenerator {
+    fn generate_tx(&self, account: Account) -> Transaction {
+        let nonce = self.nonce_counter.fetch_add(1, Ordering::Relaxed);
+        let (recipient, _) = sui_types::crypto::get_key_pair::<sui_types::crypto::AccountKeyPair>();
+
+        let mut tx_builder = TestTransactionBuilder::new_with_address_balance_gas(
+            account.sender,
+            DEFAULT_VALIDATOR_GAS_PRICE,
+            self.chain_identifier,
+            self.epoch,
+            nonce,
+        );
+
+        {
+            let builder = tx_builder.ptb_builder_mut();
+
+            let withdrawal =
+                FundsWithdrawalArg::balance_from_sender(self.transfer_amount, GAS::type_tag());
+            let withdrawal_result = builder.funds_withdrawal(withdrawal).unwrap();
+
+            let balance = builder.programmable_move_call(
+                SUI_FRAMEWORK_PACKAGE_ID,
+                Identifier::new("balance").unwrap(),
+                Identifier::new("redeem_funds").unwrap(),
+                vec![GAS::type_tag()],
+                vec![withdrawal_result],
+            );
+
+            let recipient_arg = builder.pure(recipient).unwrap();
+            builder.programmable_move_call(
+                SUI_FRAMEWORK_PACKAGE_ID,
+                Identifier::new("balance").unwrap(),
+                Identifier::new("send_funds").unwrap(),
+                vec![GAS::type_tag()],
+                vec![balance, recipient_arg],
+            );
+        }
+
+        tx_builder.build_and_sign(account.keypair.as_ref())
+    }
+
+    fn name(&self) -> &'static str {
+        "SendFunds Transaction Generator"
+    }
+}

--- a/crates/sui-single-node-benchmark/src/workload.rs
+++ b/crates/sui-single-node-benchmark/src/workload.rs
@@ -3,7 +3,9 @@
 
 use crate::benchmark_context::BenchmarkContext;
 use crate::command::WorkloadKind;
-use crate::tx_generator::{MoveTxGenerator, PackagePublishTxGenerator, TxGenerator};
+use crate::tx_generator::{
+    MoveTxGenerator, PackagePublishTxGenerator, SendFundsTxGenerator, TxGenerator,
+};
 use std::path::PathBuf;
 use std::sync::Arc;
 use sui_test_transaction_builder::PublishData;
@@ -69,6 +71,19 @@ impl Workload {
             WorkloadKind::Publish {
                 manifest_file: manifest_path,
             } => Arc::new(PackagePublishTxGenerator::new(ctx, manifest_path.clone()).await),
+            WorkloadKind::SendFunds {
+                seed_amount,
+                transfer_amount,
+            } => {
+                ctx.seed_address_balances(*seed_amount).await;
+                let chain_identifier = ctx.get_chain_identifier();
+                let epoch = ctx.get_epoch();
+                Arc::new(SendFundsTxGenerator::new(
+                    chain_identifier,
+                    epoch,
+                    *transfer_amount,
+                ))
+            }
         }
     }
 }

--- a/crates/sui-single-node-benchmark/tests/smoke_tests.rs
+++ b/crates/sui-single-node-benchmark/tests/smoke_tests.rs
@@ -110,6 +110,25 @@ async fn benchmark_publish_from_source() {
 }
 
 #[sim_test]
+async fn benchmark_send_funds_smoke_test() {
+    for component in Component::iter() {
+        run_benchmark(
+            Workload::new(
+                10,
+                WorkloadKind::SendFunds {
+                    seed_amount: 100_000_000_000,
+                    transfer_amount: 1000,
+                },
+            ),
+            component,
+            1000,
+            false,
+        )
+        .await;
+    }
+}
+
+#[sim_test]
 async fn benchmark_publish_from_bytecode() {
     // This test makes sure that the benchmark runs.
     let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));

--- a/crates/sui-single-node-benchmark/tests/smoke_tests.rs
+++ b/crates/sui-single-node-benchmark/tests/smoke_tests.rs
@@ -111,21 +111,21 @@ async fn benchmark_publish_from_source() {
 
 #[sim_test]
 async fn benchmark_send_funds_smoke_test() {
-    for component in Component::iter() {
-        run_benchmark(
-            Workload::new(
-                10,
-                WorkloadKind::SendFunds {
-                    seed_amount: 100_000_000_000,
-                    transfer_amount: 1000,
-                },
-            ),
-            component,
-            1000,
-            false,
-        )
-        .await;
-    }
+    // SendFunds uses address-balance gas which requires accumulators.
+    // Only test Baseline component — other components may not support this.
+    run_benchmark(
+        Workload::new(
+            10,
+            WorkloadKind::SendFunds {
+                seed_amount: 100_000_000_000,
+                transfer_amount: 1000,
+            },
+        ),
+        Component::Baseline,
+        1000,
+        false,
+    )
+    .await;
 }
 
 #[sim_test]

--- a/crates/sui-single-node-benchmark/tests/smoke_tests.rs
+++ b/crates/sui-single-node-benchmark/tests/smoke_tests.rs
@@ -111,6 +111,23 @@ async fn benchmark_publish_from_source() {
 
 #[sim_test]
 async fn benchmark_send_funds_smoke_test() {
+    // SendFunds requires address-balance gas payments, which are not yet enabled
+    // on every chain (e.g. mainnet). Use the chain override env var (set by the
+    // simtest CI matrix) to determine the effective chain and skip the test when
+    // the feature is disabled.
+    let chain = match std::env::var("SUI_PROTOCOL_CONFIG_CHAIN_OVERRIDE").as_deref() {
+        Ok("mainnet") => sui_protocol_config::Chain::Mainnet,
+        Ok("testnet") => sui_protocol_config::Chain::Testnet,
+        _ => sui_protocol_config::Chain::Unknown,
+    };
+    let protocol_config = sui_protocol_config::ProtocolConfig::get_for_version(
+        sui_protocol_config::ProtocolVersion::MAX,
+        chain,
+    );
+    if !protocol_config.enable_address_balance_gas_payments() {
+        return;
+    }
+
     // SendFunds uses address-balance gas which requires accumulators.
     // Only test Baseline component — other components may not support this.
     run_benchmark(


### PR DESCRIPTION
## Summary

- Add `SendFunds` workload that benchmarks address-balance send_funds transactions
- Add per-tx `try_execute_immediately` wall-clock timing (avg/min/p50/p90/p99/max)

## Test plan

- [x] `cargo nextest run -p sui-single-node-benchmark -- benchmark_send_funds_smoke_test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)