### PR TITLE
Optimize tracing overhead: global callsite filter, disable span latency layer

### DIFF
--- a/crates/sui-node/src/main.rs
+++ b/crates/sui-node/src/main.rs
@@ -84,6 +84,7 @@ fn main() {
     let (_guard, filter_handle) = telemetry_subscribers::TelemetryConfig::new()
         .with_env()
         .with_prom_registry(&prometheus_registry)
+        .with_disable_span_latency(true)
         .init();
 
     drop(metrics_rt);

--- a/crates/telemetry-subscribers/src/lib.rs
+++ b/crates/telemetry-subscribers/src/lib.rs
@@ -42,26 +42,65 @@ mod file_exporter;
 pub mod span_latency_prom;
 mod test_layer;
 
-/// Global filter layer that rejects spans above a given level at callsite registration time.
+/// Global filter layer that rejects callsites above the configured levels at registration time.
 ///
 /// Without this, per-layer filtering causes the Registry to return `Interest::always()` for
 /// every callsite. That means trace-level `#[instrument]` spans are allocated in the slab,
 /// have their per-layer filters walked, and are immediately discarded — all at significant cost.
+/// The same applies to events below the env filter threshold.
 ///
-/// By rejecting high-verbosity span callsites globally, `Span::new` short-circuits to
-/// `Span::none()` for free.
-///
-/// Events are always passed through so that per-layer log filters work as before.
-struct SpanLevelGlobalFilter {
+/// By rejecting high-verbosity callsites globally, `Span::new` short-circuits to
+/// `Span::none()` and event macros short-circuit before formatting arguments.
+struct GlobalLevelFilter {
     max_span_level: Level,
+    /// The maximum event level any layer will accept. Loaded from the EnvFilter's
+    /// max_level_hint and updated via a shared atomic when the filter is reloaded.
+    max_event_level: Arc<std::sync::atomic::AtomicU8>,
 }
 
-impl<S: tracing::Subscriber> Layer<S> for SpanLevelGlobalFilter {
+impl GlobalLevelFilter {
+    fn load_max_event_level(&self) -> LevelFilter {
+        level_filter_from_u8(self.max_event_level.load(Ordering::Relaxed))
+    }
+
+    fn exceeds_max_level(&self, metadata: &tracing::Metadata<'_>) -> bool {
+        if metadata.is_span() {
+            *metadata.level() > self.max_span_level
+        } else {
+            let max = self.load_max_event_level();
+            !max.eq(&LevelFilter::OFF) && LevelFilter::from_level(*metadata.level()) > max
+        }
+    }
+}
+
+fn level_filter_to_u8(lf: LevelFilter) -> u8 {
+    match lf {
+        LevelFilter::OFF => 0,
+        LevelFilter::ERROR => 1,
+        LevelFilter::WARN => 2,
+        LevelFilter::INFO => 3,
+        LevelFilter::DEBUG => 4,
+        LevelFilter::TRACE => 5,
+    }
+}
+
+fn level_filter_from_u8(v: u8) -> LevelFilter {
+    match v {
+        0 => LevelFilter::OFF,
+        1 => LevelFilter::ERROR,
+        2 => LevelFilter::WARN,
+        3 => LevelFilter::INFO,
+        4 => LevelFilter::DEBUG,
+        _ => LevelFilter::TRACE,
+    }
+}
+
+impl<S: tracing::Subscriber> Layer<S> for GlobalLevelFilter {
     fn register_callsite(
         &self,
         metadata: &'static tracing::Metadata<'static>,
     ) -> tracing::subscriber::Interest {
-        if metadata.is_span() && *metadata.level() > self.max_span_level {
+        if self.exceeds_max_level(metadata) {
             tracing::subscriber::Interest::never()
         } else {
             tracing::subscriber::Interest::always()
@@ -73,7 +112,13 @@ impl<S: tracing::Subscriber> Layer<S> for SpanLevelGlobalFilter {
         metadata: &tracing::Metadata<'_>,
         _ctx: tracing_subscriber::layer::Context<'_, S>,
     ) -> bool {
-        !metadata.is_span() || *metadata.level() <= self.max_span_level
+        !self.exceeds_max_level(metadata)
+    }
+
+    fn max_level_hint(&self) -> Option<LevelFilter> {
+        let span = LevelFilter::from_level(self.max_span_level);
+        let event = self.load_max_event_level();
+        Some(std::cmp::max(span, event))
     }
 }
 
@@ -154,17 +199,26 @@ impl Drop for TelemetryGuards {
 }
 
 #[derive(Clone, Debug)]
-pub struct FilterHandle(reload::Handle<EnvFilter, Registry>);
+pub struct FilterHandle {
+    reload: reload::Handle<EnvFilter, Registry>,
+    /// Shared with GlobalLevelFilter so that reloading the env filter also
+    /// updates the global event-level gate.
+    max_event_level: Option<Arc<std::sync::atomic::AtomicU8>>,
+}
 
 impl FilterHandle {
     pub fn update<S: AsRef<str>>(&self, directives: S) -> Result<(), BoxError> {
         let filter = EnvFilter::try_new(directives)?;
-        self.0.reload(filter)?;
+        if let Some(ref max_level) = self.max_event_level {
+            let hint = filter.max_level_hint().unwrap_or(LevelFilter::TRACE);
+            max_level.store(level_filter_to_u8(hint), Ordering::Relaxed);
+        }
+        self.reload.reload(filter)?;
         Ok(())
     }
 
     pub fn get(&self) -> Result<String, BoxError> {
-        self.0
+        self.reload
             .with_current(|filter| filter.to_string())
             .map_err(Into::into)
     }
@@ -452,8 +506,14 @@ impl TelemetryConfig {
         }
         let env_filter =
             EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(directives));
+        let max_event_level = Arc::new(std::sync::atomic::AtomicU8::new(level_filter_to_u8(
+            env_filter.max_level_hint().unwrap_or(LevelFilter::TRACE),
+        )));
         let (log_filter, reload_handle) = reload::Layer::new(env_filter);
-        let log_filter_handle = FilterHandle(reload_handle);
+        let log_filter_handle = FilterHandle {
+            reload: reload_handle,
+            max_event_level: Some(max_event_level.clone()),
+        };
 
         // Separate span level filter.
         // This is a dumb filter for now - allows all spans that are below a given level.
@@ -547,7 +607,10 @@ impl TelemetryConfig {
 
             let trace_env_filter = EnvFilter::try_from_env("TRACE_FILTER").unwrap();
             let (trace_env_filter, reload_handle) = reload::Layer::new(trace_env_filter);
-            trace_filter_handle = Some(FilterHandle(reload_handle));
+            trace_filter_handle = Some(FilterHandle {
+                reload: reload_handle,
+                max_event_level: None,
+            });
 
             layers.push(telemetry.with_filter(trace_env_filter).boxed());
         }
@@ -609,12 +672,14 @@ impl TelemetryConfig {
             None
         };
 
-        // Global span-level filter: rejects span callsites above span_level at
-        // registration time, preventing the Registry from allocating spans that
-        // every per-layer filter would immediately discard.
+        // Global level filter: rejects span callsites above span_level and event
+        // callsites above the env filter's max level at registration time, preventing
+        // the Registry from dispatching callsites that every per-layer filter would
+        // immediately discard.
         layers.push(
-            SpanLevelGlobalFilter {
+            GlobalLevelFilter {
                 max_span_level: span_level,
+                max_event_level,
             }
             .boxed(),
         );

--- a/crates/telemetry-subscribers/src/lib.rs
+++ b/crates/telemetry-subscribers/src/lib.rs
@@ -70,6 +70,8 @@ pub struct TelemetryConfig {
     pub crash_on_panic: bool,
     /// Optional Prometheus registry - if present, all enabled span latencies are measured
     pub prom_registry: Option<prometheus::Registry>,
+    /// Disable the PrometheusSpanLatencyLayer even when a prom_registry is set.
+    pub disable_span_latency: bool,
     pub sample_rate: f64,
     /// Add directive to include trace logs with provided target
     pub trace_target: Option<Vec<String>>,
@@ -284,6 +286,7 @@ impl TelemetryConfig {
             panic_hook: true,
             crash_on_panic: false,
             prom_registry: None,
+            disable_span_latency: false,
             sample_rate: 1.0,
             trace_target: None,
             user_info_target: Vec::new(),
@@ -315,6 +318,11 @@ impl TelemetryConfig {
 
     pub fn with_prom_registry(mut self, registry: &prometheus::Registry) -> Self {
         self.prom_registry = Some(registry.clone());
+        self
+    }
+
+    pub fn with_disable_span_latency(mut self, disable: bool) -> Self {
+        self.disable_span_latency = disable;
         self
     }
 
@@ -430,9 +438,11 @@ impl TelemetryConfig {
         }
 
         if let Some(registry) = config.prom_registry {
-            let span_lat_layer = PrometheusSpanLatencyLayer::try_new(&registry, 15)
-                .expect("Could not initialize span latency layer");
-            layers.push(span_lat_layer.with_filter(span_filter.clone()).boxed());
+            if !config.disable_span_latency {
+                let span_lat_layer = PrometheusSpanLatencyLayer::try_new(&registry, 15)
+                    .expect("Could not initialize span latency layer");
+                layers.push(span_lat_layer.with_filter(span_filter.clone()).boxed());
+            }
         }
 
         let mut trace_filter_handle = None;

--- a/crates/telemetry-subscribers/src/lib.rs
+++ b/crates/telemetry-subscribers/src/lib.rs
@@ -532,12 +532,12 @@ impl TelemetryConfig {
             layers.push(console_subscriber::spawn().boxed());
         }
 
-        if let Some(registry) = config.prom_registry {
-            if !config.disable_span_latency {
-                let span_lat_layer = PrometheusSpanLatencyLayer::try_new(&registry, 15)
-                    .expect("Could not initialize span latency layer");
-                layers.push(span_lat_layer.with_filter(span_filter.clone()).boxed());
-            }
+        if let Some(registry) = config.prom_registry
+            && !config.disable_span_latency
+        {
+            let span_lat_layer = PrometheusSpanLatencyLayer::try_new(&registry, 15)
+                .expect("Could not initialize span latency layer");
+            layers.push(span_lat_layer.with_filter(span_filter.clone()).boxed());
         }
 
         let mut trace_filter_handle = None;

--- a/crates/telemetry-subscribers/src/lib.rs
+++ b/crates/telemetry-subscribers/src/lib.rs
@@ -52,7 +52,7 @@ mod test_layer;
 /// By rejecting high-verbosity callsites globally, `Span::new` short-circuits to
 /// `Span::none()` and event macros short-circuit before formatting arguments.
 struct GlobalLevelFilter {
-    max_span_level: Level,
+    max_span_level: LevelFilter,
     /// The maximum event level any layer will accept. Loaded from the EnvFilter's
     /// max_level_hint and updated via a shared atomic when the filter is reloaded.
     max_event_level: Arc<std::sync::atomic::AtomicU8>,
@@ -65,7 +65,7 @@ impl GlobalLevelFilter {
 
     fn exceeds_max_level(&self, metadata: &tracing::Metadata<'_>) -> bool {
         if metadata.is_span() {
-            *metadata.level() > self.max_span_level
+            LevelFilter::from_level(*metadata.level()) > self.max_span_level
         } else {
             let max = self.load_max_event_level();
             !max.eq(&LevelFilter::OFF) && LevelFilter::from_level(*metadata.level()) > max
@@ -115,9 +115,8 @@ impl<S: tracing::Subscriber> Layer<S> for GlobalLevelFilter {
     }
 
     fn max_level_hint(&self) -> Option<LevelFilter> {
-        let span = LevelFilter::from_level(self.max_span_level);
         let event = self.load_max_event_level();
-        Some(std::cmp::max(span, event))
+        Some(std::cmp::max(self.max_span_level, event))
     }
 }
 
@@ -140,9 +139,9 @@ pub struct TelemetryConfig {
     pub log_file: Option<String>,
     /// Log level to set, defaults to info
     pub log_string: Option<String>,
-    /// Span level - what level of spans should be created.  Note this is not same as logging level
-    /// If set to None, then defaults to INFO
-    pub span_level: Option<Level>,
+    /// Span level - what level of spans should be created.  Note this is not same as logging level.
+    /// If set to None, then defaults to INFO. Use LevelFilter::OFF to disable all spans.
+    pub span_level: Option<LevelFilter>,
     /// Set a panic hook
     pub panic_hook: bool,
     /// Crash on panic
@@ -395,7 +394,7 @@ impl TelemetryConfig {
     }
 
     pub fn with_span_level(mut self, span_level: Level) -> Self {
-        self.span_level = Some(span_level);
+        self.span_level = Some(LevelFilter::from_level(span_level));
         self
     }
 
@@ -469,7 +468,7 @@ impl TelemetryConfig {
 
         if let Ok(span_level) = env::var("TOKIO_SPAN_LEVEL") {
             self.span_level =
-                Some(Level::from_str(&span_level).expect("Cannot parse TOKIO_SPAN_LEVEL"));
+                Some(LevelFilter::from_str(&span_level).expect("Cannot parse TOKIO_SPAN_LEVEL"));
         }
 
         if let Ok(filepath) = env::var("RUST_LOG_FILE") {
@@ -517,9 +516,11 @@ impl TelemetryConfig {
         // Separate span level filter.
         // This is a dumb filter for now - allows all spans that are below a given level.
         // TODO: implement a sampling filter
-        let span_level = config.span_level.unwrap_or(Level::INFO);
+        let span_level = config
+            .span_level
+            .unwrap_or(LevelFilter::from_level(Level::INFO));
         let span_filter = filter::filter_fn(move |metadata| {
-            metadata.is_span() && *metadata.level() <= span_level
+            metadata.is_span() && LevelFilter::from_level(*metadata.level()) <= span_level
         });
 
         let mut layers = Vec::new();

--- a/crates/telemetry-subscribers/src/lib.rs
+++ b/crates/telemetry-subscribers/src/lib.rs
@@ -103,16 +103,15 @@ impl<S: tracing::Subscriber> Layer<S> for GlobalLevelFilter {
         if self.exceeds_max_level(metadata) {
             tracing::subscriber::Interest::never()
         } else {
+            // Return always() for passing callsites. The final interest will be
+            // determined by the Registry (which returns sometimes() when per-layer
+            // filters are present). We intentionally do NOT override enabled() —
+            // doing so would add an extra check to every enabled() walk, which the
+            // per-layer filters already handle. For dynamic env filter reloads,
+            // rebuild_interest_cache() re-calls register_callsite with our updated
+            // atomic max_event_level.
             tracing::subscriber::Interest::always()
         }
-    }
-
-    fn enabled(
-        &self,
-        metadata: &tracing::Metadata<'_>,
-        _ctx: tracing_subscriber::layer::Context<'_, S>,
-    ) -> bool {
-        !self.exceeds_max_level(metadata)
     }
 
     fn max_level_hint(&self) -> Option<LevelFilter> {

--- a/crates/telemetry-subscribers/src/lib.rs
+++ b/crates/telemetry-subscribers/src/lib.rs
@@ -676,15 +676,20 @@ impl TelemetryConfig {
         // callsites above the env filter's max level at registration time, preventing
         // the Registry from dispatching callsites that every per-layer filter would
         // immediately discard.
-        layers.push(
-            GlobalLevelFilter {
-                max_span_level: span_level,
-                max_event_level,
-            }
-            .boxed(),
-        );
-
-        let subscriber = tracing_subscriber::registry().with(layers);
+        //
+        // Must be stacked on top of `layers` via `.with()` rather than pushed into the
+        // Vec. `Vec<Layer>::register_callsite` returns the most permissive Interest
+        // across its layers, so a `never()` from this filter would be overridden by
+        // any layer (e.g. fmt+EnvFilter) returning `sometimes()`. As an outer
+        // `Layered`, `pick_interest` short-circuits to `never()` and the inner stack
+        // is never consulted.
+        let global_filter = GlobalLevelFilter {
+            max_span_level: span_level,
+            max_event_level,
+        };
+        let subscriber = tracing_subscriber::registry()
+            .with(layers)
+            .with(global_filter);
         let subscriber_guard = if config.set_global_default {
             tracing::subscriber::set_global_default(subscriber)
                 .expect("unable to initialize tracing subscriber");

--- a/crates/telemetry-subscribers/src/lib.rs
+++ b/crates/telemetry-subscribers/src/lib.rs
@@ -42,6 +42,41 @@ mod file_exporter;
 pub mod span_latency_prom;
 mod test_layer;
 
+/// Global filter layer that rejects spans above a given level at callsite registration time.
+///
+/// Without this, per-layer filtering causes the Registry to return `Interest::always()` for
+/// every callsite. That means trace-level `#[instrument]` spans are allocated in the slab,
+/// have their per-layer filters walked, and are immediately discarded — all at significant cost.
+///
+/// By rejecting high-verbosity span callsites globally, `Span::new` short-circuits to
+/// `Span::none()` for free.
+///
+/// Events are always passed through so that per-layer log filters work as before.
+struct SpanLevelGlobalFilter {
+    max_span_level: Level,
+}
+
+impl<S: tracing::Subscriber> Layer<S> for SpanLevelGlobalFilter {
+    fn register_callsite(
+        &self,
+        metadata: &'static tracing::Metadata<'static>,
+    ) -> tracing::subscriber::Interest {
+        if metadata.is_span() && *metadata.level() > self.max_span_level {
+            tracing::subscriber::Interest::never()
+        } else {
+            tracing::subscriber::Interest::always()
+        }
+    }
+
+    fn enabled(
+        &self,
+        metadata: &tracing::Metadata<'_>,
+        _ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) -> bool {
+        !metadata.is_span() || *metadata.level() <= self.max_span_level
+    }
+}
+
 /// Alias for a type-erased error type.
 pub type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
 
@@ -573,6 +608,16 @@ impl TelemetryConfig {
         } else {
             None
         };
+
+        // Global span-level filter: rejects span callsites above span_level at
+        // registration time, preventing the Registry from allocating spans that
+        // every per-layer filter would immediately discard.
+        layers.push(
+            SpanLevelGlobalFilter {
+                max_span_level: span_level,
+            }
+            .boxed(),
+        );
 
         let subscriber = tracing_subscriber::registry().with(layers);
         let subscriber_guard = if config.set_global_default {

--- a/crates/telemetry-subscribers/src/lib.rs
+++ b/crates/telemetry-subscribers/src/lib.rs
@@ -504,13 +504,26 @@ impl TelemetryConfig {
         }
         let env_filter =
             EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(directives));
+        // When the test layer is enabled, it accepts events at any level without a
+        // per-layer filter, so global event-level filtering would hide events the
+        // test wants to capture. Disable it by pinning max_event_level to TRACE
+        // (and skip propagating env filter reloads into it).
+        let max_event_level_seed = if config.enable_test_layer {
+            LevelFilter::TRACE
+        } else {
+            env_filter.max_level_hint().unwrap_or(LevelFilter::TRACE)
+        };
         let max_event_level = Arc::new(std::sync::atomic::AtomicU8::new(level_filter_to_u8(
-            env_filter.max_level_hint().unwrap_or(LevelFilter::TRACE),
+            max_event_level_seed,
         )));
         let (log_filter, reload_handle) = reload::Layer::new(env_filter);
         let log_filter_handle = FilterHandle {
             reload: reload_handle,
-            max_event_level: Some(max_event_level.clone()),
+            max_event_level: if config.enable_test_layer {
+                None
+            } else {
+                Some(max_event_level.clone())
+            },
         };
 
         // Separate span level filter.


### PR DESCRIPTION
## Summary

- **Disable `PrometheusSpanLatencyLayer`** in sui-node via `with_disable_span_latency` config
- **Add `GlobalLevelFilter`** — rejects trace/debug callsites at `register_callsite()` time via `Interest::never()`, eliminating per-call `enabled()` walk overhead from per-layer filtering
- **Extend global filter to events** — also rejects event callsites above the EnvFilter's max level
- **Remove `enabled()` override** — avoid adding to the filter walk for passing callsites
- **Support `TOKIO_SPAN_LEVEL=off`** — change span_level to `LevelFilter` so `off` is valid

## Test plan

- [x] `cargo nextest run -p telemetry-subscribers` — 6/6 pass
- [x] `cargo check -p sui-node`

🤖 Generated with [Claude Code](https://claude.com/claude-code)