### PR TITLE
Disable Move VM telemetry recording by default

### DIFF
--- a/external-crates/move/crates/move-vm-runtime/src/runtime/telemetry.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/runtime/telemetry.rs
@@ -3,11 +3,24 @@
 
 #![allow(clippy::cast_possible_truncation)]
 use std::{
-    sync::atomic::{AtomicU64, Ordering},
+    sync::atomic::{AtomicBool, AtomicU64, Ordering},
     time::Duration,
 };
 
 use crate::cache::move_cache::MoveCache;
+
+static TELEMETRY_ENABLED: AtomicBool = AtomicBool::new(false);
+static TELEMETRY_INIT: std::sync::Once = std::sync::Once::new();
+
+#[inline(always)]
+fn is_telemetry_enabled() -> bool {
+    TELEMETRY_INIT.call_once(|| {
+        if std::env::var("MOVE_VM_TELEMETRY_ENABLED").is_ok() {
+            TELEMETRY_ENABLED.store(true, Ordering::Relaxed);
+        }
+    });
+    TELEMETRY_ENABLED.load(Ordering::Relaxed)
+}
 
 // -------------------------------------------------------------------------------------------------
 // Types
@@ -217,7 +230,9 @@ impl TelemetryContext {
     {
         let mut txn_telemetry = TransactionTelemetryContext::new();
         let result = f(&mut txn_telemetry);
-        self.record_transaction(txn_telemetry);
+        if is_telemetry_enabled() {
+            self.record_transaction(txn_telemetry);
+        }
         result
     }
 


### PR DESCRIPTION
## Summary

Move VM telemetry (`record_transaction`) performs ~15 atomic fetch_add/fetch_max operations per Move VM interaction. This is now disabled by default. Set `MOVE_VM_TELEMETRY_ENABLED=1` to opt in.

The env var is read once via `std::sync::Once` and cached in a static `AtomicBool`. When disabled, `with_transaction_telemetry` skips `record_transaction` entirely — the execution closure still runs normally.

## Test plan

- [x] `cargo check -p move-vm-runtime`

🤖 Generated with [Claude Code](https://claude.com/claude-code)