### PR TITLE
ci: fetch prebuilt sui binaries from S3 in release.yml on Linux

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,16 +122,23 @@ jobs:
         shell: bash
         run: |
           # Pulls binaries that mp3 (sui-operations/prebuild-sui-images.yml) extracted
-          # from prebuilt sui images to s3://sui-releases/<sui_sha>/<basename>. Fails
-          # loudly if any are missing — the prebuild matrix and mp3:binary_upload_config
-          # in sui-operations/pulumi/apps/mp3 must cover this list before tagging.
+          # from prebuilt sui images. amd64 lands at s3://sui-releases/<sui_sha>/<basename>,
+          # arm64 at s3://sui-releases/arm64/<sui_sha>/<basename> — see mp3's
+          # binary_upload_config in sui-operations/pulumi/apps/mp3 (sui-{node,tools}-arm64
+          # rules). Fails loudly if any binary in binary-build-list.json release_binaries
+          # is missing so the gap surfaces before the tag publishes.
           mkdir -p ${{ env.TMP_BUILD_DIR }} ./tmp
           [ ! -f ${{ env.BINARY_LIST_FILE }} ] && echo "${{ env.BINARY_LIST_FILE }} cannot be found" && exit 1
+
+          case "${arch}" in
+            aarch64|arm64) s3_prefix="s3://sui-releases/arm64/${sui_sha}" ;;
+            *)             s3_prefix="s3://sui-releases/${sui_sha}" ;;
+          esac
 
           missing=()
           for binary in $(jq -r '.release_binaries[]' ${{ env.BINARY_LIST_FILE }}); do
             binary=$(echo "${binary}" | tr -d $'\r')
-            src="s3://sui-releases/${sui_sha}/${binary}"
+            src="${s3_prefix}/${binary}"
             dest="${{ env.TMP_BUILD_DIR }}/${binary}"
             echo "Downloading ${src}"
             if ! aws s3 cp "${src}" "${dest}"; then
@@ -142,7 +149,7 @@ jobs:
           done
 
           if [ ${#missing[@]} -ne 0 ]; then
-            echo "::error::Missing prebuilt binaries at s3://sui-releases/${sui_sha}/ — these must be produced by sui-operations/prebuild-sui-images.yml + mp3:binary_upload_config before tagging: ${missing[*]}"
+            echo "::error::Missing prebuilt binaries at ${s3_prefix}/ — these must be produced by sui-operations/prebuild-sui-images.yml + mp3:binary_upload_config before tagging: ${missing[*]}"
             exit 1
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,6 +111,44 @@ jobs:
           aws s3 cp s3://sui-releases/${{ env.s3_existing_archive }} ./tmp/sui-${{ env.sui_tag }}-${os_type}.tgz
           tar -xf ./tmp/sui-${{ env.sui_tag }}-${os_type}.tgz -C ${{ env.TMP_BUILD_DIR }}
 
+      - name: Resolve sui_sha for prebuilt binary lookup (Linux)
+        if: ${{ startsWith(matrix.os, 'ubuntu') && env.s3_existing_archive == '' }}
+        shell: bash
+        run: |
+          echo "sui_sha=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
+
+      - name: Download prebuilt binaries from S3 (Linux)
+        if: ${{ startsWith(matrix.os, 'ubuntu') && env.s3_existing_archive == '' }}
+        shell: bash
+        run: |
+          # Pulls binaries that mp3 (sui-operations/prebuild-sui-images.yml) extracted
+          # from prebuilt sui images to s3://sui-releases/<sui_sha>/<basename>. Fails
+          # loudly if any are missing — the prebuild matrix and mp3:binary_upload_config
+          # in sui-operations/pulumi/apps/mp3 must cover this list before tagging.
+          mkdir -p ${{ env.TMP_BUILD_DIR }} ./tmp
+          [ ! -f ${{ env.BINARY_LIST_FILE }} ] && echo "${{ env.BINARY_LIST_FILE }} cannot be found" && exit 1
+
+          missing=()
+          for binary in $(jq -r '.release_binaries[]' ${{ env.BINARY_LIST_FILE }}); do
+            binary=$(echo "${binary}" | tr -d $'\r')
+            src="s3://sui-releases/${sui_sha}/${binary}"
+            dest="${{ env.TMP_BUILD_DIR }}/${binary}"
+            echo "Downloading ${src}"
+            if ! aws s3 cp "${src}" "${dest}"; then
+              missing+=("${binary}")
+              continue
+            fi
+            chmod +x "${dest}"
+          done
+
+          if [ ${#missing[@]} -ne 0 ]; then
+            echo "::error::Missing prebuilt binaries at s3://sui-releases/${sui_sha}/ — these must be produced by sui-operations/prebuild-sui-images.yml + mp3:binary_upload_config before tagging: ${missing[*]}"
+            exit 1
+          fi
+
+          tar -cvzf ./tmp/sui-${{ env.sui_tag }}-${{ env.os_type }}.tgz -C ${{ env.TMP_BUILD_DIR }} .
+          aws s3 cp ./tmp/sui-${{ env.sui_tag }}-${{ env.os_type }}.tgz s3://sui-releases/releases/sui-${{ env.sui_tag }}-${{ env.os_type }}.tgz || true
+
       - name: Install nexttest (Windows)
         if: ${{ matrix.os == 'windows-ghcloud' && env.s3_existing_archive == '' }}
         uses: taiki-e/install-action@88d897fbe3f79ed72a43e0dcbca36156ff03344e # pin@v2.67.14
@@ -139,12 +177,6 @@ jobs:
         run: |
           brew install postgresql
 
-      - name: Install postgres (Ubuntu arm64)
-        if: ${{ matrix.os == 'ubuntu-arm64' && env.s3_existing_archive == '' }}
-        shell: bash
-        run: |
-          sudo apt update && sudo apt install libpq-dev
-
       - name: Remove unused apps (MacOS arm64)
         if: ${{ matrix.os == 'macos-latest-xlarge' && env.s3_existing_archive == '' }}
         continue-on-error: true
@@ -159,23 +191,24 @@ jobs:
           df -h /
 
       - uses: ./.github/actions/setup-sccache
-        if: ${{ env.s3_existing_archive == '' }}
+        if: ${{ !startsWith(matrix.os, 'ubuntu') && env.s3_existing_archive == '' }}
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           key-prefix: ${{ matrix.os }}
 
       - name: Register cargo problem matcher
+        if: ${{ !startsWith(matrix.os, 'ubuntu') && env.s3_existing_archive == '' }}
         run: echo "::add-matcher::.github/matchers/cargo.json"
 
       - name: Cargo build for ${{ matrix.os }} platform
-        if: ${{ env.s3_existing_archive == '' }}
+        if: ${{ !startsWith(matrix.os, 'ubuntu') && env.s3_existing_archive == '' }}
         shell: bash
         run: |
           [ -f ~/.cargo/env ] && source ~/.cargo/env ; cargo build --release && cargo build --release --features tracing --bin sui && cargo build --profile=dev --bin sui --features tracing
 
       - name: Rename binaries for ${{ matrix.os }}
-        if: ${{ env.s3_existing_archive == '' }}
+        if: ${{ !startsWith(matrix.os, 'ubuntu') && env.s3_existing_archive == '' }}
         shell: bash
         run: |
           mkdir -p ${{ env.TMP_BUILD_DIR }}


### PR DESCRIPTION
## Summary

- Replaces the on-runner `cargo build` for `ubuntu-ghcloud` and `ubuntu-arm64` in `release.yml` with `aws s3 cp` from S3, where mp3 ([sui-operations/prebuild-sui-images.yml](https://github.com/MystenLabs/sui-operations/actions/workflows/prebuild-sui-images.yml) + `binary_upload_config`) already lands the binaries ahead of release tagging.
- amd64 → `s3://sui-releases/<sui_sha>/<binary>` (existing path).
- arm64 → `s3://sui-releases/arm64/<sui_sha>/<binary>` (new parallel prefix, mirrors the walrus-service-arm64 pattern).
- Windows and macOS still build from source — mp3 only produces Linux binaries today.
- Fails loudly with a `::error::` annotation if any binary in `binary-build-list.json` `release_binaries` is missing from S3, so the gap surfaces before a tag ships.

## Companion PR (must merge first)

[MystenLabs/sui-operations#7754](https://github.com/MystenLabs/sui-operations/pull/7754) adds the matching mp3 rules:
- `MystenLabs/sui:sui-tools` (amd64) gets `sui-faucet` and `sui-bridge-cli` extracted (already in the image, just not in the paths list)
- New `sui-node-arm64` and `sui-tools-arm64` rules with `linux/arm64` `build_arch`, writing to `s3://sui-releases/arm64/<sha>/`
- `prepare_sui_matrix.py` routes arm64 builds to the new image names

After 7754 ships and a release-tagged commit has flowed through `prebuild-sui-images.yml`, this PR is safe to merge.

## Known gap — `sui-test-validator` and `move-analyzer`

Tracked separately in #26412. These two `release_binaries` aren't produced by any sui Dockerfile today. With this change, they will be reported as missing and the workflow will fail until #26412 is resolved (either add to a Dockerfile + mp3 paths, or drop from `release_binaries`).

## Test plan
- [ ] sui-operations#7754 merged + `pulumi up` applied to mp3-staging and mp3-production
- [ ] #26412 resolved
- [ ] Run `prebuild-sui-images.yml` on a recent main commit and confirm:
  - [ ] `aws s3 ls s3://sui-releases/<sha>/` covers every `release_binaries` entry
  - [ ] `aws s3 ls s3://sui-releases/arm64/<sha>/` likewise
- [ ] Trigger this workflow via `workflow_dispatch` against a non-production tag; verify Linux jobs no longer cargo-build, the tarball lands, Windows/macOS still build cleanly
- [ ] Confirm the existing `s3_existing_archive` shortcut still works (re-run for an already-released version)

🤖 Generated with [Claude Code](https://claude.com/claude-code)