### PR TITLE
[graphql-stream] Recover from upstream gRPC gaps via kv-rpc [7/n]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15224,6 +15224,7 @@ dependencies = [
  "async-trait",
  "axum 0.7.5",
  "axum-extra 0.9.3",
+ "backoff",
  "bcs",
  "bin-version",
  "chrono",

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/checkpoint_subscription.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/checkpoint_subscription.rs
@@ -10,7 +10,9 @@ use serde_json::json;
 use tokio_stream::StreamExt;
 
 use crate::testing::SubscriptionTestCluster;
+use crate::testing::checkpoint_seq;
 use crate::testing::checkpoint_tx_digests;
+use crate::testing::drain_checkpoints_until_stalled;
 use crate::testing::graphql_redactions;
 use crate::testing::object_wrapping_harness;
 use crate::testing::transfer_coins;
@@ -27,10 +29,7 @@ async fn test_subscription_sequential() {
         .collect()
         .await;
 
-    let seqs: Vec<u64> = items
-        .iter()
-        .map(|i| i["data"]["checkpoints"]["sequenceNumber"].as_u64().unwrap())
-        .collect();
+    let seqs: Vec<u64> = items.iter().map(checkpoint_seq).collect();
     assert!(seqs.windows(2).all(|w| w[1] == w[0] + 1), "{seqs:?}");
 }
 
@@ -379,4 +378,61 @@ async fn test_subscription_object_json() {
     settings.bind(|| {
         insta::assert_json_snapshot!("subscription_object_json", [cp1, cp2, cp3, cp4]);
     });
+}
+
+// --- Gap recovery tests ---
+
+/// Forces a reconnect blackout via the proxy and asserts the subscriber sees a
+/// contiguous sequence of checkpoints across it (gap recovery filled the
+/// missing range from kv-rpc). `ledger_grpc_url` bypasses the proxy, so
+/// recovery reads aren't blocked.
+#[tokio::test]
+async fn test_subscription_recovers_from_upstream_disconnect() {
+    let (cluster, proxy) = SubscriptionTestCluster::new_with_disruption_proxy().await;
+
+    let mut stream = cluster
+        .subscribe("subscription { checkpoints { sequenceNumber } }")
+        .await;
+
+    // Healthy streaming.
+    let first = checkpoint_seq(&stream.next().await.unwrap());
+    let second = checkpoint_seq(&stream.next().await.unwrap());
+    assert_eq!(second, first + 1);
+
+    // Blackout: graphql can't reconnect.
+    proxy.block_connections();
+    proxy.disconnect_all();
+
+    // Let the validator advance so a real gap forms, then drain whatever
+    // graphql had pushed before the disconnect took effect.
+    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+    let last_seen = drain_checkpoints_until_stalled(&mut stream, second).await;
+    let validator_tip = cluster.validator_checkpoint_tip();
+    assert!(
+        validator_tip > last_seen + 1,
+        "validator did not advance during blackout: tip={validator_tip}, last_seen={last_seen}",
+    );
+
+    // Resume.
+    proxy.allow_connections();
+
+    // First item signals reconnect + recovery have started. The validator's
+    // tip at this moment bounds the reconnect tip from above, so reading
+    // past it crosses from recovery into post-recovery live items.
+    let mut received = vec![checkpoint_seq(&stream.next().await.unwrap())];
+    let resume_tip = cluster.validator_checkpoint_tip();
+    while *received.last().unwrap() < resume_tip + 20 {
+        received.push(checkpoint_seq(&stream.next().await.unwrap()));
+    }
+
+    assert_eq!(
+        received[0],
+        last_seen + 1,
+        "non-contiguous resume: last_seen={last_seen}, first received={}",
+        received[0],
+    );
+    assert!(
+        received.windows(2).all(|w| w[1] == w[0] + 1),
+        "post-resume not contiguous: {received:?}",
+    );
 }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/testing/harness.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/testing/harness.rs
@@ -33,6 +33,9 @@ use tokio_tungstenite::connect_async;
 use tokio_tungstenite::tungstenite::Message;
 use tokio_tungstenite::tungstenite::http::Request;
 
+use super::proxy;
+use super::proxy::ProxyController;
+
 const SUBSCRIPTION_TIMEOUT: Duration = Duration::from_secs(30);
 
 pub struct SubscriptionTestCluster {
@@ -53,6 +56,24 @@ impl SubscriptionTestCluster {
     /// validator + postgres DB + kv_packages indexer + GraphQL service.
     /// Waits for kv_packages to index the genesis checkpoint so subscriptions are ready.
     pub async fn new() -> Self {
+        let (cluster, _controller) = Self::new_inner(false).await;
+        cluster
+    }
+
+    /// Same as `new()`, but inserts a TCP proxy between graphql's streaming
+    /// connection and the validator's gRPC. Returns a controller that tests
+    /// can use to forcibly disconnect the streaming connection mid-test,
+    /// exercising graphql's reconnect + gap-recovery code path.
+    ///
+    /// Only the streaming connection runs through the proxy. `ledger_grpc_url`
+    /// (used by gap recovery) still points at the validator directly, so
+    /// `disconnect_all()` only severs the stream and leaves recovery reads
+    /// untouched.
+    pub async fn new_with_disruption_proxy() -> (Self, ProxyController) {
+        Self::new_inner(true).await
+    }
+
+    async fn new_inner(use_proxy: bool) -> (Self, ProxyController) {
         let ingestion_dir = tempfile::tempdir().expect("Failed to create ingestion dir");
         let validator = TestClusterBuilder::new()
             .with_num_validators(1)
@@ -96,11 +117,27 @@ impl SubscriptionTestCluster {
         let graphql_listen_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), graphql_port);
         let rpc_url = validator.rpc_url();
 
+        let (stream_url, controller): (String, ProxyController) = if use_proxy {
+            proxy::start(rpc_url).await
+        } else {
+            (rpc_url.to_string(), ProxyController::default())
+        };
+
+        // The validator's gRPC v2 endpoint serves both `SubscriptionService` and
+        // `LedgerService`, so we point `ledger_grpc_url` at the same URL graphql streams
+        // from. Required because gap recovery makes `ledger_grpc_reader` mandatory when
+        // streaming is enabled. Note: `ledger_grpc_url` always targets the validator
+        // directly so `disconnect_all()` cannot interfere with gap-recovery reads.
+        let kv_args = KvArgs {
+            ledger_grpc_url: Some(rpc_url.parse().unwrap()),
+            ..Default::default()
+        };
+
         let service = start_graphql(
             Some(database_url),
             FullnodeArgs::new(rpc_url.parse().unwrap()),
             DbArgs::default(),
-            KvArgs::default(),
+            kv_args,
             ConsistentReaderArgs::default(),
             GraphQlArgs {
                 rpc_listen_address: graphql_listen_address,
@@ -108,7 +145,7 @@ impl SubscriptionTestCluster {
             },
             SystemPackageTaskArgs::default(),
             SubscriptionArgs {
-                checkpoint_stream_url: Some(rpc_url.parse().unwrap()),
+                checkpoint_stream_url: Some(stream_url.parse().unwrap()),
             },
             "0.0.0",
             GraphQlConfig::default(),
@@ -118,14 +155,28 @@ impl SubscriptionTestCluster {
         .await
         .expect("Failed to start GraphQL server");
 
-        Self {
-            validator,
-            db,
-            subscription_url: format!("ws://{}/graphql", graphql_listen_address),
-            service,
-            indexer,
-            ingestion_dir,
-        }
+        (
+            Self {
+                validator,
+                db,
+                subscription_url: format!("ws://{}/graphql", graphql_listen_address),
+                service,
+                indexer,
+                ingestion_dir,
+            },
+            controller,
+        )
+    }
+
+    /// Latest checkpoint sequence number produced by the validator (the
+    /// on-chain tip, not whatever graphql has currently streamed).
+    pub fn validator_checkpoint_tip(&self) -> u64 {
+        self.validator
+            .fullnode_handle
+            .sui_node
+            .state()
+            .get_latest_checkpoint_sequence_number()
+            .expect("Failed to read validator checkpoint tip")
     }
 
     /// Subscribe and return a stream of GraphQL payloads.
@@ -276,6 +327,32 @@ pub fn checkpoint_tx_digests(item: &Value) -> Vec<&str> {
         .as_array()
         .map(|nodes| nodes.iter().filter_map(|n| n["digest"].as_str()).collect())
         .unwrap_or_default()
+}
+
+/// Extract `sequenceNumber` from a top-level checkpoint subscription response.
+/// Path: data.checkpoints.sequenceNumber
+pub fn checkpoint_seq(item: &Value) -> u64 {
+    item["data"]["checkpoints"]["sequenceNumber"]
+        .as_u64()
+        .expect("checkpoint payload missing sequenceNumber")
+}
+
+/// Read checkpoint items from `stream` until it goes quiet for one second,
+/// returning the last sequence number observed. `start` is returned unchanged
+/// if the stream stalls before delivering anything. Used to assert that the
+/// streaming subscription has paused (e.g. during a forced reconnect blackout).
+pub async fn drain_checkpoints_until_stalled(
+    stream: &mut (impl tokio_stream::Stream<Item = Value> + Unpin),
+    start: u64,
+) -> u64 {
+    let mut last = start;
+    loop {
+        match tokio::time::timeout(Duration::from_secs(1), stream.next()).await {
+            Ok(Some(item)) => last = checkpoint_seq(&item),
+            Ok(None) => panic!("stream ended unexpectedly"),
+            Err(_) => return last,
+        }
+    }
 }
 
 /// Common snapshot redactions for GraphQL subscription tests.

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/testing/mod.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/testing/mod.rs
@@ -3,5 +3,6 @@
 
 mod harness;
 pub mod object_wrapping_harness;
+pub mod proxy;
 
 pub use harness::*;

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/testing/proxy.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/testing/proxy.rs
@@ -1,0 +1,146 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! TCP proxy for testing graphql streaming subscription's gap-recovery behavior.
+//!
+//! # Why this exists
+//!
+//! Graphql streaming subscriptions reconnect on upstream gRPC stream errors and
+//! recover any gap from kv-rpc (see
+//! `sui-indexer-alt-graphql/src/task/streaming/checkpoint_stream_task.rs`). To
+//! e2e test that recovery, we need a way to trigger an upstream disconnect
+//! mid-test, but the validator's gRPC just keeps running and graphql's
+//! connection stays healthy on its own.
+//!
+//! # What it does
+//!
+//! The proxy sits between graphql and the upstream:
+//!
+//! ```text
+//!   graphql ──TCP──▶ proxy ──TCP──▶ upstream (validator gRPC)
+//!                      │
+//!                      ▼ disconnect_all()
+//! ```
+//!
+//! Tests call `disconnect_all()` to abort every active forwarding task,
+//! closing both ends of each connection. graphql sees a TCP close, tonic
+//! surfaces a stream error, and the streaming task's reconnect + gap-recovery
+//! code path runs.
+//!
+//! To force a *deterministic* gap (rather than relying on timing luck for the
+//! validator to advance during the reconnect window), tests can additionally
+//! call `block_connections()` before `disconnect_all()` and `allow_connections()`
+//! after a known sleep. While blocked, the proxy accepts each inbound TCP
+//! connection and immediately drops it, so graphql's reconnect attempts fail
+//! for the full blackout window. The validator keeps producing checkpoints
+//! during that window, so when reconnect finally succeeds, gap recovery has a
+//! known-non-empty range to fill.
+
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+
+use tokio::io::AsyncWriteExt;
+use tokio::net::TcpListener;
+use tokio::net::TcpStream;
+use tokio::task::AbortHandle;
+
+/// Controls the proxy's active connections. Cheap to clone.
+#[derive(Clone, Default)]
+pub struct ProxyController {
+    active: Arc<Mutex<Vec<AbortHandle>>>,
+    blocked: Arc<AtomicBool>,
+}
+
+impl ProxyController {
+    /// Abort every active forwarding task. Connections made after this call
+    /// still work normally unless `block_connections()` was called first.
+    pub fn disconnect_all(&self) {
+        for handle in self.active.lock().unwrap().drain(..) {
+            handle.abort();
+        }
+    }
+
+    /// Reject new inbound connections until `allow_connections()` is called.
+    /// Combined with `disconnect_all()`, this lets a test guarantee a reconnect
+    /// blackout of a known minimum duration, forcing the validator to advance
+    /// past the disconnect point so a real gap forms.
+    pub fn block_connections(&self) {
+        self.blocked.store(true, Ordering::Release);
+    }
+
+    /// Resume accepting inbound connections.
+    pub fn allow_connections(&self) {
+        self.blocked.store(false, Ordering::Release);
+    }
+}
+
+/// Start a TCP proxy forwarding to `upstream_url`. Returns the proxy's URL
+/// (which graphql should connect to instead of the upstream) and a controller
+/// for triggering disconnects.
+pub async fn start(upstream_url: &str) -> (String, ProxyController) {
+    let upstream_addr = upstream_url
+        .trim_start_matches("http://")
+        .trim_start_matches("https://")
+        .to_string();
+
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("Failed to bind proxy");
+    let local_port = listener
+        .local_addr()
+        .expect("Failed to get local addr")
+        .port();
+
+    let controller = ProxyController::default();
+    let active = controller.active.clone();
+    let blocked = controller.blocked.clone();
+
+    tokio::spawn(async move {
+        loop {
+            let (inbound, _) = match listener.accept().await {
+                Ok(io) => io,
+                Err(_) => return,
+            };
+            if blocked.load(Ordering::Acquire) {
+                // Drop the socket immediately; the client sees its reconnect
+                // attempt fail and will back off and retry.
+                drop(inbound);
+                continue;
+            }
+            let upstream = upstream_addr.clone();
+            let task = tokio::spawn(forward(inbound, upstream));
+            active.lock().unwrap().push(task.abort_handle());
+        }
+    });
+
+    (format!("http://127.0.0.1:{local_port}"), controller)
+}
+
+/// Pump bytes between `inbound` and a fresh outbound connection to
+/// `upstream_addr`. Returns when either direction closes or the task is
+/// aborted via `ProxyController::disconnect_all`.
+async fn forward(inbound: TcpStream, upstream_addr: String) {
+    let outbound = match TcpStream::connect(&upstream_addr).await {
+        Ok(s) => s,
+        Err(_) => return,
+    };
+
+    let (mut ri, mut wi) = inbound.into_split();
+    let (mut ro, mut wo) = outbound.into_split();
+
+    let inbound_to_outbound = async {
+        let _ = tokio::io::copy(&mut ri, &mut wo).await;
+        let _ = wo.shutdown().await;
+    };
+    let outbound_to_inbound = async {
+        let _ = tokio::io::copy(&mut ro, &mut wi).await;
+        let _ = wi.shutdown().await;
+    };
+
+    tokio::select! {
+        _ = inbound_to_outbound => {}
+        _ = outbound_to_inbound => {}
+    }
+}

--- a/crates/sui-indexer-alt-graphql/Cargo.toml
+++ b/crates/sui-indexer-alt-graphql/Cargo.toml
@@ -20,6 +20,7 @@ async-stream.workspace = true
 async-graphql-axum.workspace = true
 async-graphql-value.workspace = true
 async-trait.workspace = true
+backoff.workspace = true
 # axum.workspace = true
 # axum-extra.workspace = true
 axum = { version = "0.7", default-features = false, features = [ "macros", "tokio", "http1", "http2", "json", "matched-path", "original-uri", "form", "query", "ws", ] }

--- a/crates/sui-indexer-alt-graphql/src/config.rs
+++ b/crates/sui-indexer-alt-graphql/src/config.rs
@@ -238,6 +238,9 @@ pub struct SubscriptionConfig {
     /// How often (in milliseconds) the eviction task checks the `kv_packages` watermark
     /// and evicts indexed packages from the streaming index.
     pub package_eviction_interval_ms: u64,
+
+    /// Number of checkpoints fetched concurrently per chunk during upstream gap recovery.
+    pub gap_recovery_chunk_size: usize,
 }
 
 impl Default for SubscriptionConfig {
@@ -245,6 +248,7 @@ impl Default for SubscriptionConfig {
         Self {
             broadcast_buffer: 256,
             package_eviction_interval_ms: 300_000,
+            gap_recovery_chunk_size: 50,
         }
     }
 }
@@ -255,6 +259,7 @@ impl Default for SubscriptionConfig {
 pub struct SubscriptionLayer {
     pub broadcast_buffer: Option<usize>,
     pub package_eviction_interval_ms: Option<u64>,
+    pub gap_recovery_chunk_size: Option<usize>,
 }
 
 impl SubscriptionLayer {
@@ -264,6 +269,9 @@ impl SubscriptionLayer {
             package_eviction_interval_ms: self
                 .package_eviction_interval_ms
                 .unwrap_or(base.package_eviction_interval_ms),
+            gap_recovery_chunk_size: self
+                .gap_recovery_chunk_size
+                .unwrap_or(base.gap_recovery_chunk_size),
         }
     }
 }
@@ -537,6 +545,7 @@ impl From<SubscriptionConfig> for SubscriptionLayer {
         Self {
             broadcast_buffer: Some(value.broadcast_buffer),
             package_eviction_interval_ms: Some(value.package_eviction_interval_ms),
+            gap_recovery_chunk_size: Some(value.gap_recovery_chunk_size),
         }
     }
 }

--- a/crates/sui-indexer-alt-graphql/src/lib.rs
+++ b/crates/sui-indexer-alt-graphql/src/lib.rs
@@ -362,36 +362,46 @@ pub async fn start_rpc(
         pg_pipelines,
         pg_reader.clone(),
         bigtable_reader,
-        ledger_grpc_reader,
+        ledger_grpc_reader.clone(),
         consistent_reader.clone(),
         metrics.clone(),
     );
 
-    let streaming_setup = subscription_args.checkpoint_stream_url.map(|uri| {
-        let streaming_packages = Arc::new(task::streaming::StreamingPackageStore::new(
-            package_store.clone(),
-        ));
-        // Unbounded is intentional: if `kv_packages` lags long enough for this queue to
-        // grow without bound, the indexer infrastructure itself has a bigger problem and
-        // OOM on this service is one failure mode among many. Monitor via metrics.
-        #[allow(clippy::disallowed_methods)]
-        let (package_eviction_tx, package_eviction_rx) = tokio::sync::mpsc::unbounded_channel();
-        let readiness = task::streaming::SubscriptionReadiness::new(watermark_task.watermarks_rx());
-        let stream_task = task::streaming::CheckpointStreamTask::new(
-            uri,
-            &config.subscription,
-            streaming_packages.clone(),
-            package_eviction_tx,
-            readiness.clone(),
-        );
-        let eviction_task = task::streaming::PackageEvictionTask::new(
-            streaming_packages.clone(),
-            package_eviction_rx,
-            watermark_task.watermarks(),
-            Duration::from_millis(config.subscription.package_eviction_interval_ms),
-        );
-        (stream_task, eviction_task, streaming_packages, readiness)
-    });
+    let streaming_setup = match subscription_args.checkpoint_stream_url {
+        Some(uri) => {
+            let ledger_grpc = ledger_grpc_reader
+                .clone()
+                .context("Ledger gRPC reader is required when streaming is enabled")?;
+
+            let streaming_packages = Arc::new(task::streaming::StreamingPackageStore::new(
+                package_store.clone(),
+            ));
+            // Unbounded is intentional: if `kv_packages` lags long enough for this queue to
+            // grow without bound, the indexer infrastructure itself has a bigger problem and
+            // OOM on this service is one failure mode among many. Monitor via metrics.
+            #[allow(clippy::disallowed_methods)]
+            let (package_eviction_tx, package_eviction_rx) = tokio::sync::mpsc::unbounded_channel();
+            let readiness =
+                task::streaming::SubscriptionReadiness::new(watermark_task.watermarks_rx());
+            let stream_task = task::streaming::CheckpointStreamTask::new(
+                uri,
+                &config.subscription,
+                streaming_packages.clone(),
+                package_eviction_tx,
+                readiness.clone(),
+                ledger_grpc,
+                watermark_task.watermarks_rx(),
+            );
+            let eviction_task = task::streaming::PackageEvictionTask::new(
+                streaming_packages.clone(),
+                package_eviction_rx,
+                watermark_task.watermarks(),
+                Duration::from_millis(config.subscription.package_eviction_interval_ms),
+            );
+            Some((stream_task, eviction_task, streaming_packages, readiness))
+        }
+        None => None,
+    };
 
     let mut rpc = rpc
         .route(GRAPHQL_PATH, post(graphql).get(graphql_get))

--- a/crates/sui-indexer-alt-graphql/src/task/streaming/checkpoint_stream_task.rs
+++ b/crates/sui-indexer-alt-graphql/src/task/streaming/checkpoint_stream_task.rs
@@ -310,10 +310,11 @@ impl CheckpointStreamTask {
         Ok(())
     }
 
-    /// Index packages from the checkpoint into the streaming store, signal eviction, then
-    /// process and broadcast. Indexing is needed because `kv_packages` may not yet have
-    /// these packages at stream time; recovered checkpoints from `recover_gap` skip this
-    /// step because the watermark gate guarantees they're already in the DB.
+    /// Index packages from the checkpoint into the streaming store, signal eviction,
+    /// then process and broadcast. Indexing exposes the checkpoint's packages to
+    /// subscribers immediately, ahead of `kv_packages`. Recovered checkpoints from
+    /// `recover_gap` skip this step because the gate already waits for both
+    /// `ledger_grpc` and `kv_packages` to catch up.
     fn index_and_broadcast(&self, checkpoint: ProtoCheckpoint, seq: u64) -> anyhow::Result<()> {
         let packages = extract_packages(&checkpoint);
         if !packages.is_empty() {

--- a/crates/sui-indexer-alt-graphql/src/task/streaming/checkpoint_stream_task.rs
+++ b/crates/sui-indexer-alt-graphql/src/task/streaming/checkpoint_stream_task.rs
@@ -1,15 +1,72 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+//! Checkpoint stream task.
+//!
+//! Maintains the connection to the fullnode's `SubscribeCheckpoints` gRPC
+//! stream and broadcasts every checkpoint, in order, to GraphQL subscribers.
+//!
+//! ```text
+//!   loop forever:
+//!     connect (retry on transient errors, fail on auth/config)
+//!     for each incoming checkpoint:
+//!       if seq > last_broadcast + 1:
+//!         recover_gap(last_broadcast + 1 ..= seq - 1)
+//!       broadcast(checkpoint)
+//!     on stream end: reconnect
+//! ```
+//!
+//! # Reconnect
+//!
+//! gRPC connections drop for many reasons: rolling deploys, network blips,
+//! server restarts. When the stream errors or closes, the task reconnects
+//! with bounded exponential backoff. Transient errors retry indefinitely;
+//! permanent gRPC errors (auth, config) terminate the task.
+//!
+//! # Gap recovery
+//!
+//! `SubscribeCheckpoints` resumes at the current tip on reconnect, not where
+//! we left off. So after a drop, the first new message typically has a
+//! sequence number well past the last we broadcast — checkpoints produced
+//! during the drop are now invisible on the live stream.
+//!
+//! Detection happens on every incoming message: if `seq > last_broadcast + 1`,
+//! the task fetches the missing checkpoints from kv-rpc (a `LedgerService`
+//! endpoint serving historical checkpoints) and broadcasts them in order
+//! before broadcasting the live message.
+//!
+//! ```text
+//!   stream:    ... 10, 11   ╳ drop ╳   16, 17, 18 ...
+//!                                       ↑ first after reconnect
+//!
+//!   on receive 16 (last_broadcast = 11):
+//!     fetch 12..=15 from kv-rpc, broadcast 12..=15
+//!     then broadcast 16
+//! ```
+//!
+//! Recovery is chunked, with each chunk waiting for the kv-rpc indexer to
+//! catch up. See `gap_recovery` for chunk size and retry semantics.
+//!
+//! # Subscriber view
+//!
+//! From a subscriber's perspective, the broadcast is strictly contiguous,
+//! in-order, and contains no duplicates — there's no visible boundary
+//! between recovered and live messages. Long disconnects converge naturally:
+//! if recovery itself takes long enough that the validator advances past
+//! the recovery target, the next live message is itself a gap, and detection
+//! fires again.
+
 use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Context as _;
+use backoff::ExponentialBackoff;
 use futures::StreamExt;
 use move_core_types::account_address::AccountAddress;
 use sui_futures::service::Service;
 use sui_indexer_alt_reader::kv_loader::TransactionContents as NativeTransactionContents;
+use sui_indexer_alt_reader::ledger_grpc_reader::LedgerGrpcReader;
 use sui_package_resolver::Package;
 use sui_rpc::field::FieldMask;
 use sui_rpc::field::FieldMaskUtil;
@@ -34,16 +91,20 @@ use sui_types::signature::GenericSignature;
 use sui_types::transaction::TransactionData;
 use tokio::sync::broadcast;
 use tokio::sync::mpsc::UnboundedSender;
+use tokio::sync::watch;
 use tonic::Streaming;
 use tonic::transport::Endpoint;
 use tonic::transport::Uri;
 use tracing::info;
+use tracing::warn;
 
 use crate::config::SubscriptionConfig;
 use crate::scope::ExecutionObjectMap;
+use crate::task::watermark::Watermarks;
 
 use super::StreamingPackageStore;
 use super::SubscriptionReadiness;
+use super::gap_recovery::recover_gap;
 use super::processed_checkpoint::ProcessedCheckpoint;
 use super::processed_checkpoint::ProcessedTransaction;
 
@@ -58,7 +119,7 @@ const CONNECTION_TIMEOUT: Duration = Duration::from_secs(30);
 pub(crate) type CheckpointBroadcaster = broadcast::Receiver<Arc<ProcessedCheckpoint>>;
 
 /// Field mask requesting checkpoint-level and transaction-level fields needed by GraphQL resolvers.
-fn checkpoint_field_mask() -> FieldMask {
+pub(super) fn checkpoint_field_mask() -> FieldMask {
     FieldMask::from_paths([
         ProtoCheckpoint::path_builder().sequence_number(),
         ProtoCheckpoint::path_builder().summary().bcs().value(),
@@ -105,6 +166,14 @@ pub(crate) struct CheckpointStreamTask {
     streaming_packages: Arc<StreamingPackageStore>,
     package_eviction_tx: UnboundedSender<(u64, Vec<AccountAddress>)>,
     readiness: Arc<SubscriptionReadiness>,
+    /// kv-rpc reader used to fill upstream gaps. Required: streaming subscriptions need a
+    /// fallback source to recover from disconnects. lib.rs ensures this is configured when
+    /// streaming is enabled.
+    ledger_grpc_reader: LedgerGrpcReader,
+    /// Watermarks receiver used by gap recovery to wait for kv-rpc to be at or past a target
+    /// before fetching.
+    watermarks_rx: watch::Receiver<Arc<Watermarks>>,
+    gap_recovery_chunk_size: usize,
 }
 
 impl CheckpointStreamTask {
@@ -114,6 +183,8 @@ impl CheckpointStreamTask {
         streaming_packages: Arc<StreamingPackageStore>,
         package_eviction_tx: UnboundedSender<(u64, Vec<AccountAddress>)>,
         readiness: Arc<SubscriptionReadiness>,
+        ledger_grpc_reader: LedgerGrpcReader,
+        watermarks_rx: watch::Receiver<Arc<Watermarks>>,
     ) -> Self {
         let (sender, broadcaster) = broadcast::channel(config.broadcast_buffer);
         Self {
@@ -123,6 +194,9 @@ impl CheckpointStreamTask {
             streaming_packages,
             package_eviction_tx,
             readiness,
+            ledger_grpc_reader,
+            watermarks_rx,
+            gap_recovery_chunk_size: config.gap_recovery_chunk_size,
         }
     }
 
@@ -151,47 +225,149 @@ impl CheckpointStreamTask {
         Ok(stream)
     }
 
-    // TODO(Phase 2): Connection and stream errors currently terminate the task.
-    // Proper error handling will be addressed alongside backfilling.
+    /// Drive the upstream checkpoint stream. Reconnects on any failure with bounded backoff,
+    /// detects gaps on each incoming checkpoint, and fills them via kv-rpc before broadcasting
+    /// the live message. Permanent connect errors (auth / config) terminate the task; transient
+    /// errors retry indefinitely.
     pub(crate) fn run(self) -> Service {
         Service::new().spawn_aborting(async move {
-            info!("Connecting to checkpoint stream at {}...", self.uri);
-            let mut stream = self.connect().await?;
-            info!("Connected to checkpoint stream at {}", self.uri);
+            let mut last_broadcast: Option<u64> = None;
+            let mut first_recorded = false;
 
-            let mut first_checkpoint_recorded = false;
-            while let Some(result) = stream.next().await {
-                let response = result.context("Checkpoint stream error")?;
-                if let Some(checkpoint) = response.checkpoint {
-                    let sequence_number = checkpoint
-                        .sequence_number
-                        .context("Checkpoint without sequence_number")?;
-                    if !first_checkpoint_recorded {
-                        self.readiness.record_first_checkpoint(sequence_number);
-                        first_checkpoint_recorded = true;
-                    }
-                    let packages = extract_packages(&checkpoint);
-                    if !packages.is_empty() {
-                        self.streaming_packages
-                            .index_packages(sequence_number, &packages);
-                        let ids = packages.iter().map(|p| p.storage_id()).collect();
-                        // Send errors only if the eviction task has exited — at that
-                        // point nothing will drain the store, but we keep serving.
-                        let _ = self.package_eviction_tx.send((sequence_number, ids));
-                    }
-                    let processed = process_checkpoint(checkpoint)?;
-                    // Ignore send errors — no active subscribers is a normal state
-                    // (e.g., no clients have connected yet). The checkpoint is simply dropped.
-                    let _ = self.sender.send(Arc::new(processed));
+            loop {
+                info!("Connecting to checkpoint stream at {}...", self.uri);
+                let stream = backoff::future::retry(reconnect_backoff(), || async {
+                    self.connect().await.map_err(classify_connect_error)
+                })
+                .await?;
+                info!("Connected to checkpoint stream at {}", self.uri);
+
+                self.consume_stream(stream, &mut last_broadcast, &mut first_recorded)
+                    .await?;
+                warn!("Checkpoint stream ended, reconnecting");
+            }
+        })
+    }
+
+    /// Consume one connected stream until it ends or errors. On stream-level errors, logs
+    /// and returns `Ok(())` so the caller reconnects. Per-message errors (malformed proto,
+    /// gap recovery failure) propagate as `Err` and terminate the task.
+    ///
+    /// Generic over the stream type so tests can feed synthetic messages without standing
+    /// up a real gRPC server. Tonic's `Streaming<T>` already implements `Stream`, so the
+    /// production call site is unchanged.
+    async fn consume_stream<S>(
+        &self,
+        mut stream: S,
+        last_broadcast: &mut Option<u64>,
+        first_recorded: &mut bool,
+    ) -> anyhow::Result<()>
+    where
+        S: futures::Stream<Item = Result<SubscribeCheckpointsResponse, tonic::Status>> + Unpin,
+    {
+        while let Some(result) = stream.next().await {
+            let response = match result {
+                Ok(r) => r,
+                Err(e) => {
+                    warn!("Stream error: {e:#}");
+                    return Ok(());
                 }
+            };
+
+            let Some(checkpoint) = response.checkpoint else {
+                continue;
+            };
+            let seq = checkpoint
+                .sequence_number
+                .context("Checkpoint without sequence_number")?;
+
+            if !*first_recorded {
+                self.readiness.record_first_checkpoint(seq);
+                *first_recorded = true;
             }
 
-            Ok(())
-        })
+            // Gap detection: synchronously fill any hole between last_broadcast and this
+            // message before broadcasting the live cp.
+            if let Some(last) = *last_broadcast
+                && seq > last + 1
+            {
+                info!(from = last + 1, to = seq - 1, "Recovering gap");
+                recover_gap(
+                    &self.ledger_grpc_reader,
+                    &self.watermarks_rx,
+                    &self.sender,
+                    last + 1,
+                    seq - 1,
+                    self.gap_recovery_chunk_size,
+                )
+                .await?;
+            }
+
+            self.index_and_broadcast(checkpoint, seq)?;
+            *last_broadcast = Some(seq);
+        }
+
+        Ok(())
+    }
+
+    /// Index packages from the checkpoint into the streaming store, signal eviction, then
+    /// process and broadcast. Indexing is needed because `kv_packages` may not yet have
+    /// these packages at stream time; recovered checkpoints from `recover_gap` skip this
+    /// step because the watermark gate guarantees they're already in the DB.
+    fn index_and_broadcast(&self, checkpoint: ProtoCheckpoint, seq: u64) -> anyhow::Result<()> {
+        let packages = extract_packages(&checkpoint);
+        if !packages.is_empty() {
+            self.streaming_packages.index_packages(seq, &packages);
+            let ids = packages.iter().map(|p| p.storage_id()).collect();
+            // Send errors only if the eviction task has exited; nothing will drain the
+            // store, but we keep serving.
+            let _ = self.package_eviction_tx.send((seq, ids));
+        }
+        let processed = process_checkpoint(checkpoint)?;
+        // Ignore send errors: no active subscribers is a normal state.
+        let _ = self.sender.send(Arc::new(processed));
+        Ok(())
     }
 }
 
-fn process_checkpoint(checkpoint: ProtoCheckpoint) -> anyhow::Result<ProcessedCheckpoint> {
+/// Backoff between reconnect attempts: 1s growing to 5s max, no overall deadline.
+/// Tight cap so we recover quickly from rolling deploys; infinite retry so the streaming
+/// server stays alive through extended outages.
+fn reconnect_backoff() -> ExponentialBackoff {
+    ExponentialBackoff {
+        initial_interval: Duration::from_secs(1),
+        max_interval: Duration::from_secs(5),
+        max_elapsed_time: None,
+        ..Default::default()
+    }
+}
+
+/// Classify connect errors as transient or permanent. gRPC codes that signal config problems
+/// (auth, missing endpoint, malformed request) terminate the task; everything else retries.
+fn classify_connect_error(e: anyhow::Error) -> backoff::Error<anyhow::Error> {
+    use tonic::Code;
+    let permanent = e.downcast_ref::<tonic::Status>().is_some_and(|s| {
+        matches!(
+            s.code(),
+            Code::Unauthenticated
+                | Code::PermissionDenied
+                | Code::InvalidArgument
+                | Code::Unimplemented
+        )
+    });
+
+    if permanent {
+        warn!("Permanent connect failure (config / auth issue): {e:#}");
+        backoff::Error::permanent(e)
+    } else {
+        warn!("Connect failed, will retry: {e:#}");
+        backoff::Error::transient(e)
+    }
+}
+
+pub(super) fn process_checkpoint(
+    checkpoint: ProtoCheckpoint,
+) -> anyhow::Result<ProcessedCheckpoint> {
     let sequence_number = checkpoint
         .sequence_number
         .context("Checkpoint without sequence_number")?;

--- a/crates/sui-indexer-alt-graphql/src/task/streaming/gap_recovery.rs
+++ b/crates/sui-indexer-alt-graphql/src/task/streaming/gap_recovery.rs
@@ -1,0 +1,447 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::ops::RangeInclusive;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Context as _;
+use anyhow::anyhow;
+use backoff::ExponentialBackoff;
+use futures::future::try_join_all;
+use prost_types::FieldMask;
+use sui_indexer_alt_reader::ledger_grpc_reader::LedgerGrpcReader;
+use sui_rpc::proto::sui::rpc::v2::Checkpoint as ProtoCheckpoint;
+use sui_rpc::proto::sui::rpc::v2::GetCheckpointRequest;
+use tokio::sync::broadcast;
+use tokio::sync::watch;
+use tracing::warn;
+
+use super::ProcessedCheckpoint;
+use super::checkpoint_stream_task::checkpoint_field_mask;
+use super::checkpoint_stream_task::process_checkpoint;
+use crate::task::watermark::Watermarks;
+
+/// Pipeline name under which `WatermarkTask` tracks the kv-rpc / LedgerService source.
+const LEDGER_GRPC_PIPELINE: &str = "ledger_grpc";
+
+/// Abstraction over the source that gap recovery fetches checkpoints from. The production
+/// implementation talks to kv-rpc via `LedgerGrpcReader`; tests use an in-memory mock.
+///
+/// `Ok(None)` covers both `NotFound` and empty-payload responses (treated equivalently as
+/// "not available, retry"). `Err` covers transport-level failures.
+pub(crate) trait CheckpointFetcher {
+    async fn fetch_checkpoint(
+        &self,
+        seq: u64,
+        mask: &FieldMask,
+    ) -> anyhow::Result<Option<ProtoCheckpoint>>;
+}
+
+impl CheckpointFetcher for LedgerGrpcReader {
+    async fn fetch_checkpoint(
+        &self,
+        seq: u64,
+        mask: &FieldMask,
+    ) -> anyhow::Result<Option<ProtoCheckpoint>> {
+        let request = GetCheckpointRequest::by_sequence_number(seq).with_read_mask(mask.clone());
+        match self.get_checkpoint(request).await {
+            Ok(response) => Ok(response.checkpoint),
+            Err(status) if status.code() == tonic::Code::NotFound => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+}
+
+/// Recover the gap `lo..=hi` by reading checkpoints from kv-rpc, processing them through the
+/// existing streaming pipeline, and broadcasting in order. Each chunk waits for the kv-rpc
+/// indexer to reach the chunk's upper bound before fetching, so partial progress is broadcast
+/// as the indexer catches up rather than waiting for the entire gap to be available.
+pub(crate) async fn recover_gap<F: CheckpointFetcher>(
+    fetcher: &F,
+    watermarks_rx: &watch::Receiver<Arc<Watermarks>>,
+    sender: &broadcast::Sender<Arc<ProcessedCheckpoint>>,
+    lo: u64,
+    hi: u64,
+    chunk_size: usize,
+) -> anyhow::Result<()> {
+    if lo > hi {
+        return Ok(());
+    }
+
+    let mask = checkpoint_field_mask();
+    let chunk_size = chunk_size.max(1) as u64;
+    let mut cursor = lo;
+
+    while cursor <= hi {
+        let chunk_hi = (cursor + chunk_size - 1).min(hi);
+
+        wait_for_ledger_grpc_high(watermarks_rx, chunk_hi).await?;
+
+        let chunk = fetch_chunk(fetcher, &mask, cursor..=chunk_hi).await?;
+
+        for proto in chunk {
+            let processed = process_checkpoint(proto)?;
+            // Ignore send errors: no active subscribers is a normal state during recovery.
+            let _ = sender.send(Arc::new(processed));
+        }
+
+        cursor = chunk_hi + 1;
+    }
+
+    Ok(())
+}
+
+/// Block until the kv-rpc indexer's high watermark reaches `target`. Hardcoded against the
+/// `ledger_grpc` pipeline name because gap recovery is currently only supported for that
+/// backend.
+async fn wait_for_ledger_grpc_high(
+    watermarks_rx: &watch::Receiver<Arc<Watermarks>>,
+    target: u64,
+) -> anyhow::Result<()> {
+    let mut rx = watermarks_rx.clone();
+    rx.wait_for(|w| {
+        w.per_pipeline()
+            .get(LEDGER_GRPC_PIPELINE)
+            .is_some_and(|p| p.hi().checkpoint() >= target)
+    })
+    .await
+    .ok()
+    .context("Watermark task shut down before ledger_grpc caught up")?;
+    Ok(())
+}
+
+/// Fetch every checkpoint in `range` concurrently. Each call retries independently and
+/// indefinitely on any error; successful results are held locally until the full chunk
+/// resolves.
+async fn fetch_chunk<F: CheckpointFetcher>(
+    fetcher: &F,
+    mask: &FieldMask,
+    range: RangeInclusive<u64>,
+) -> anyhow::Result<Vec<ProtoCheckpoint>> {
+    let futures = range.map(|seq| fetch_one_with_retry(fetcher, mask, seq));
+    try_join_all(futures).await
+}
+
+/// Fetch one checkpoint via `GetCheckpoint`, retrying every error as transient with exponential
+/// backoff and no overall deadline.
+///
+/// All gRPC errors are treated as transient on purpose, including `NotFound` and empty payloads.
+/// After the per-chunk watermark gate, `NotFound` would mean either below-retention or a
+/// watermark-data inconsistency on kv-rpc. Neither case is fixed by retrying, but neither is
+/// fixed by crashing the streaming server either: the server is long-lived with many
+/// subscribers, and tearing it down on a single bad fetch is worse than staying up and
+/// surfacing the issue through observability so an operator can intervene (manual restart,
+/// retention bump, etc.).
+///
+/// TODO: Emit metrics so ops can alert on stuck recovery.
+async fn fetch_one_with_retry<F: CheckpointFetcher>(
+    fetcher: &F,
+    mask: &FieldMask,
+    seq: u64,
+) -> anyhow::Result<ProtoCheckpoint> {
+    let backoff = ExponentialBackoff {
+        initial_interval: Duration::from_millis(100),
+        max_interval: Duration::from_secs(5),
+        max_elapsed_time: None,
+        ..Default::default()
+    };
+
+    backoff::future::retry(backoff, || async {
+        match fetcher.fetch_checkpoint(seq, mask).await {
+            Ok(Some(cp)) => Ok(cp),
+            Ok(None) => {
+                warn!(seq, "Retrying: checkpoint not yet available from kv-rpc");
+                Err(backoff::Error::transient(anyhow!(
+                    "checkpoint {seq} not available"
+                )))
+            }
+            Err(e) => {
+                warn!(seq, "Retrying gap fetch after error: {e}");
+                Err(backoff::Error::transient(e))
+            }
+        }
+    })
+    .await
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+    use std::time::Duration;
+
+    use sui_rpc::proto::sui::rpc::v2 as grpc;
+    use sui_sdk_types::Bitmap;
+    use sui_sdk_types::Bls12381Signature;
+    use sui_sdk_types::ValidatorAggregatedSignature as SdkValidatorAggregatedSignature;
+    use sui_types::crypto::AggregateAuthoritySignature;
+    use sui_types::gas::GasCostSummary;
+    use sui_types::messages_checkpoint::CheckpointContents as NativeCheckpointContents;
+    use sui_types::messages_checkpoint::CheckpointSummary as NativeCheckpointSummary;
+    use tokio::time::timeout;
+
+    use super::*;
+
+    /// Build a fully deserializable test `ProtoCheckpoint` with empty contents and a zero
+    /// signature. `process_checkpoint` parses (but does not verify) the signature, so the
+    /// all-zero bytes are accepted.
+    fn make_test_proto_checkpoint(seq: u64) -> ProtoCheckpoint {
+        let contents = NativeCheckpointContents::new_with_digests_only_for_tests(vec![]);
+        let summary = NativeCheckpointSummary {
+            epoch: 0,
+            sequence_number: seq,
+            network_total_transactions: 0,
+            content_digest: *contents.digest(),
+            previous_digest: None,
+            epoch_rolling_gas_cost_summary: GasCostSummary::default(),
+            timestamp_ms: 0,
+            checkpoint_commitments: vec![],
+            end_of_epoch_data: None,
+            version_specific_data: vec![],
+        };
+        // Use the default `AggregateAuthoritySignature` bytes rather than all-zeros: the
+        // proto → sui_types conversion in `process_checkpoint` calls
+        // `AggregateAuthoritySignature::from_bytes` and expects the BLS encoding to round-trip,
+        // which all-zero bytes do not satisfy.
+        let default_bls_bytes: [u8; 48] = AggregateAuthoritySignature::default()
+            .as_ref()
+            .try_into()
+            .expect("BLS aggregate signature is 48 bytes");
+        let sdk_sig = SdkValidatorAggregatedSignature {
+            epoch: 0,
+            signature: Bls12381Signature::new(default_bls_bytes),
+            bitmap: Bitmap::default(),
+        };
+
+        let mut summary_bcs = grpc::Bcs::default();
+        summary_bcs.value = Some(bcs::to_bytes(&summary).unwrap().into());
+        let mut summary_proto = grpc::CheckpointSummary::default();
+        summary_proto.bcs = Some(summary_bcs);
+
+        let mut contents_bcs = grpc::Bcs::default();
+        contents_bcs.value = Some(bcs::to_bytes(&contents).unwrap().into());
+        let mut contents_proto = grpc::CheckpointContents::default();
+        contents_proto.bcs = Some(contents_bcs);
+
+        let mut cp = ProtoCheckpoint::default();
+        cp.sequence_number = Some(seq);
+        cp.summary = Some(summary_proto);
+        cp.contents = Some(contents_proto);
+        cp.signature = Some(sdk_sig.into());
+        cp
+    }
+
+    /// Per-key behavior of the mock fetcher.
+    #[derive(Debug, Clone)]
+    enum FetcherBehavior {
+        /// Always return `Ok(Some(make_test_proto_checkpoint(seq)))`.
+        Success,
+        /// Return `Err` for the first N calls, then `Ok(Some(...))` afterward.
+        ErrorThenSuccess(usize),
+        /// Return `Ok(None)` for the first N calls, then `Ok(Some(...))` afterward.
+        NoneThenSuccess(usize),
+    }
+
+    struct MockFetcher {
+        state: Mutex<HashMap<u64, (FetcherBehavior, usize)>>,
+    }
+
+    impl MockFetcher {
+        fn new(setup: HashMap<u64, FetcherBehavior>) -> Self {
+            Self {
+                state: Mutex::new(setup.into_iter().map(|(k, v)| (k, (v, 0))).collect()),
+            }
+        }
+
+        fn calls_for(&self, seq: u64) -> usize {
+            self.state.lock().unwrap().get(&seq).map_or(0, |(_, c)| *c)
+        }
+    }
+
+    impl CheckpointFetcher for MockFetcher {
+        async fn fetch_checkpoint(
+            &self,
+            seq: u64,
+            _mask: &FieldMask,
+        ) -> anyhow::Result<Option<ProtoCheckpoint>> {
+            let (behavior, calls) = {
+                let mut state = self.state.lock().unwrap();
+                let entry = state
+                    .get_mut(&seq)
+                    .unwrap_or_else(|| panic!("MockFetcher: unconfigured key {seq}"));
+                entry.1 += 1;
+                (entry.0.clone(), entry.1)
+            };
+
+            match behavior {
+                FetcherBehavior::Success => Ok(Some(make_test_proto_checkpoint(seq))),
+                FetcherBehavior::ErrorThenSuccess(n) => {
+                    if calls <= n {
+                        Err(anyhow!("simulated transient error for cp {seq}"))
+                    } else {
+                        Ok(Some(make_test_proto_checkpoint(seq)))
+                    }
+                }
+                FetcherBehavior::NoneThenSuccess(n) => {
+                    if calls <= n {
+                        Ok(None)
+                    } else {
+                        Ok(Some(make_test_proto_checkpoint(seq)))
+                    }
+                }
+            }
+        }
+    }
+
+    fn fetcher(setup: &[(u64, FetcherBehavior)]) -> MockFetcher {
+        MockFetcher::new(setup.iter().cloned().collect::<HashMap<_, _>>())
+    }
+
+    fn ledger_grpc_watermarks(
+        hi: u64,
+    ) -> (
+        watch::Sender<Arc<Watermarks>>,
+        watch::Receiver<Arc<Watermarks>>,
+    ) {
+        watch::channel(Arc::new(Watermarks::for_test(&[(
+            LEDGER_GRPC_PIPELINE,
+            hi,
+        )])))
+    }
+
+    fn empty_mask() -> FieldMask {
+        FieldMask::default()
+    }
+
+    fn drain_broadcast(receiver: &mut broadcast::Receiver<Arc<ProcessedCheckpoint>>) -> Vec<u64> {
+        let mut received = Vec::new();
+        while let Ok(cp) = receiver.try_recv() {
+            received.push(cp.sequence_number);
+        }
+        received
+    }
+
+    // --- fetch_one_with_retry ---
+
+    #[tokio::test]
+    async fn fetch_one_with_retry_succeeds_first_try() {
+        let mock = fetcher(&[(42, FetcherBehavior::Success)]);
+        let cp = fetch_one_with_retry(&mock, &empty_mask(), 42)
+            .await
+            .unwrap();
+        assert_eq!(cp.sequence_number, Some(42));
+        assert_eq!(mock.calls_for(42), 1);
+    }
+
+    #[tokio::test]
+    async fn fetch_one_with_retry_recovers_from_transient_errors() {
+        let mock = fetcher(&[(42, FetcherBehavior::ErrorThenSuccess(3))]);
+        let cp = fetch_one_with_retry(&mock, &empty_mask(), 42)
+            .await
+            .unwrap();
+        assert_eq!(cp.sequence_number, Some(42));
+        assert_eq!(mock.calls_for(42), 4);
+    }
+
+    #[tokio::test]
+    async fn fetch_one_with_retry_recovers_from_not_available() {
+        let mock = fetcher(&[(42, FetcherBehavior::NoneThenSuccess(2))]);
+        let cp = fetch_one_with_retry(&mock, &empty_mask(), 42)
+            .await
+            .unwrap();
+        assert_eq!(cp.sequence_number, Some(42));
+        assert_eq!(mock.calls_for(42), 3);
+    }
+
+    // --- fetch_chunk ---
+
+    #[tokio::test]
+    async fn fetch_chunk_all_succeed() {
+        let mock = fetcher(&[
+            (1, FetcherBehavior::Success),
+            (2, FetcherBehavior::Success),
+            (3, FetcherBehavior::Success),
+        ]);
+        let chunk = fetch_chunk(&mock, &empty_mask(), 1..=3).await.unwrap();
+        assert_eq!(
+            chunk.iter().map(|c| c.sequence_number).collect::<Vec<_>>(),
+            vec![Some(1), Some(2), Some(3)],
+        );
+        for seq in 1..=3 {
+            assert_eq!(mock.calls_for(seq), 1);
+        }
+    }
+
+    #[tokio::test]
+    async fn fetch_chunk_failing_call_does_not_refetch_successful_ones() {
+        let mock = fetcher(&[
+            (1, FetcherBehavior::Success),
+            (2, FetcherBehavior::ErrorThenSuccess(2)),
+            (3, FetcherBehavior::Success),
+        ]);
+        let chunk = fetch_chunk(&mock, &empty_mask(), 1..=3).await.unwrap();
+        assert_eq!(chunk.len(), 3);
+        assert_eq!(mock.calls_for(1), 1);
+        assert_eq!(mock.calls_for(3), 1);
+        assert_eq!(mock.calls_for(2), 3);
+    }
+
+    // --- recover_gap with watermark progression ---
+
+    #[tokio::test]
+    async fn recover_gap_lo_greater_than_hi_returns_immediately() {
+        let mock = fetcher(&[]);
+        let (_tx, rx) = ledger_grpc_watermarks(0);
+        let (sender, _rx) = broadcast::channel(16);
+        recover_gap(&mock, &rx, &sender, 5, 4, 10).await.unwrap();
+        // No keys configured; if anything was fetched, MockFetcher would panic.
+    }
+
+    #[tokio::test]
+    async fn recover_gap_progresses_chunk_by_chunk_with_watermark() {
+        let mock = fetcher(&[
+            (1, FetcherBehavior::Success),
+            (2, FetcherBehavior::Success),
+            (3, FetcherBehavior::Success),
+            (4, FetcherBehavior::Success),
+            (5, FetcherBehavior::Success),
+            (6, FetcherBehavior::Success),
+        ]);
+        // Initial watermark below the first chunk's hi (3), so recover_gap must wait.
+        let (tx, rx) = ledger_grpc_watermarks(0);
+        let (sender, mut receiver) = broadcast::channel(16);
+
+        let mock_arc = Arc::new(mock);
+        let mock_for_task = mock_arc.clone();
+        let task =
+            tokio::spawn(async move { recover_gap(&*mock_for_task, &rx, &sender, 1, 6, 3).await });
+
+        // Should not progress while watermark is at 0. 200ms is comfortably more than the
+        // task scheduling overhead so the spawned `recover_gap` reaches its watermark wait.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        assert_eq!(drain_broadcast(&mut receiver), Vec::<u64>::new());
+        assert_eq!(mock_arc.calls_for(1), 0, "first chunk not yet fetched");
+
+        // Advance to 3: first chunk completes (1, 2, 3).
+        tx.send(Arc::new(Watermarks::for_test(&[(LEDGER_GRPC_PIPELINE, 3)])))
+            .unwrap();
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        assert_eq!(drain_broadcast(&mut receiver), vec![1, 2, 3]);
+        assert_eq!(
+            mock_arc.calls_for(4),
+            0,
+            "second chunk waiting on watermark"
+        );
+
+        // Advance to 6: second chunk completes (4, 5, 6) and recover_gap returns.
+        tx.send(Arc::new(Watermarks::for_test(&[(LEDGER_GRPC_PIPELINE, 6)])))
+            .unwrap();
+        timeout(Duration::from_secs(1), task)
+            .await
+            .expect("recover_gap did not finish")
+            .unwrap()
+            .unwrap();
+        assert_eq!(drain_broadcast(&mut receiver), vec![4, 5, 6]);
+    }
+}

--- a/crates/sui-indexer-alt-graphql/src/task/streaming/gap_recovery.rs
+++ b/crates/sui-indexer-alt-graphql/src/task/streaming/gap_recovery.rs
@@ -20,6 +20,7 @@ use tracing::warn;
 use super::ProcessedCheckpoint;
 use super::checkpoint_stream_task::checkpoint_field_mask;
 use super::checkpoint_stream_task::process_checkpoint;
+use crate::task::watermark::KV_PACKAGES_PIPELINE;
 use crate::task::watermark::Watermarks;
 
 /// Pipeline name under which `WatermarkTask` tracks the kv-rpc / LedgerService source.
@@ -76,7 +77,7 @@ pub(crate) async fn recover_gap<F: CheckpointFetcher>(
     while cursor <= hi {
         let chunk_hi = (cursor + chunk_size - 1).min(hi);
 
-        wait_for_ledger_grpc_high(watermarks_rx, chunk_hi).await?;
+        wait_for_pipelines_catching_up_at(chunk_hi, watermarks_rx).await?;
 
         let chunk = fetch_chunk(fetcher, &mask, cursor..=chunk_hi).await?;
 
@@ -92,22 +93,28 @@ pub(crate) async fn recover_gap<F: CheckpointFetcher>(
     Ok(())
 }
 
-/// Block until the kv-rpc indexer's high watermark reaches `target`. Hardcoded against the
-/// `ledger_grpc` pipeline name because gap recovery is currently only supported for that
-/// backend.
-async fn wait_for_ledger_grpc_high(
-    watermarks_rx: &watch::Receiver<Arc<Watermarks>>,
+/// Block until both indexer pipelines that gap recovery depends on have caught up to
+/// `target`: `ledger_grpc` (kv-rpc, serves checkpoint contents) and `kv_packages`
+/// (Postgres, serves package resolution from the DB). Recovered checkpoints don't go
+/// through `index_and_broadcast`, so subscribers resolving their packages fall through
+/// to the DB and need `kv_packages` to be ready.
+async fn wait_for_pipelines_catching_up_at(
     target: u64,
+    watermarks_rx: &watch::Receiver<Arc<Watermarks>>,
 ) -> anyhow::Result<()> {
     let mut rx = watermarks_rx.clone();
     rx.wait_for(|w| {
-        w.per_pipeline()
-            .get(LEDGER_GRPC_PIPELINE)
-            .is_some_and(|p| p.hi().checkpoint() >= target)
+        let pipelines = w.per_pipeline();
+        let caught_up = |name| {
+            pipelines
+                .get(name)
+                .is_some_and(|p| p.hi().checkpoint() >= target)
+        };
+        caught_up(LEDGER_GRPC_PIPELINE) && caught_up(KV_PACKAGES_PIPELINE)
     })
     .await
     .ok()
-    .context("Watermark task shut down before ledger_grpc caught up")?;
+    .context("Watermark task shut down before pipelines caught up")?;
     Ok(())
 }
 
@@ -298,16 +305,16 @@ mod tests {
         MockFetcher::new(setup.iter().cloned().collect::<HashMap<_, _>>())
     }
 
-    fn ledger_grpc_watermarks(
+    fn recovery_watermarks(
         hi: u64,
     ) -> (
         watch::Sender<Arc<Watermarks>>,
         watch::Receiver<Arc<Watermarks>>,
     ) {
-        watch::channel(Arc::new(Watermarks::for_test(&[(
-            LEDGER_GRPC_PIPELINE,
-            hi,
-        )])))
+        watch::channel(Arc::new(Watermarks::for_test(&[
+            (LEDGER_GRPC_PIPELINE, hi),
+            (KV_PACKAGES_PIPELINE, hi),
+        ])))
     }
 
     fn empty_mask() -> FieldMask {
@@ -392,7 +399,7 @@ mod tests {
     #[tokio::test]
     async fn recover_gap_lo_greater_than_hi_returns_immediately() {
         let mock = fetcher(&[]);
-        let (_tx, rx) = ledger_grpc_watermarks(0);
+        let (_tx, rx) = recovery_watermarks(0);
         let (sender, _rx) = broadcast::channel(16);
         recover_gap(&mock, &rx, &sender, 5, 4, 10).await.unwrap();
         // No keys configured; if anything was fetched, MockFetcher would panic.
@@ -409,7 +416,7 @@ mod tests {
             (6, FetcherBehavior::Success),
         ]);
         // Initial watermark below the first chunk's hi (3), so recover_gap must wait.
-        let (tx, rx) = ledger_grpc_watermarks(0);
+        let (tx, rx) = recovery_watermarks(0);
         let (sender, mut receiver) = broadcast::channel(16);
 
         let mock_arc = Arc::new(mock);
@@ -424,8 +431,11 @@ mod tests {
         assert_eq!(mock_arc.calls_for(1), 0, "first chunk not yet fetched");
 
         // Advance to 3: first chunk completes (1, 2, 3).
-        tx.send(Arc::new(Watermarks::for_test(&[(LEDGER_GRPC_PIPELINE, 3)])))
-            .unwrap();
+        tx.send(Arc::new(Watermarks::for_test(&[
+            (LEDGER_GRPC_PIPELINE, 3),
+            (KV_PACKAGES_PIPELINE, 3),
+        ])))
+        .unwrap();
         tokio::time::sleep(Duration::from_millis(200)).await;
         assert_eq!(drain_broadcast(&mut receiver), vec![1, 2, 3]);
         assert_eq!(
@@ -435,13 +445,57 @@ mod tests {
         );
 
         // Advance to 6: second chunk completes (4, 5, 6) and recover_gap returns.
-        tx.send(Arc::new(Watermarks::for_test(&[(LEDGER_GRPC_PIPELINE, 6)])))
-            .unwrap();
+        tx.send(Arc::new(Watermarks::for_test(&[
+            (LEDGER_GRPC_PIPELINE, 6),
+            (KV_PACKAGES_PIPELINE, 6),
+        ])))
+        .unwrap();
         timeout(Duration::from_secs(1), task)
             .await
             .expect("recover_gap did not finish")
             .unwrap()
             .unwrap();
         assert_eq!(drain_broadcast(&mut receiver), vec![4, 5, 6]);
+    }
+
+    #[tokio::test]
+    async fn recover_gap_waits_for_both_pipelines() {
+        let mock = fetcher(&[
+            (1, FetcherBehavior::Success),
+            (2, FetcherBehavior::Success),
+            (3, FetcherBehavior::Success),
+        ]);
+        let (tx, rx) = recovery_watermarks(0);
+        let (sender, mut receiver) = broadcast::channel(16);
+
+        let mock_arc = Arc::new(mock);
+        let mock_for_task = mock_arc.clone();
+        let task =
+            tokio::spawn(async move { recover_gap(&*mock_for_task, &rx, &sender, 1, 3, 3).await });
+
+        // ledger_grpc has caught up but kv_packages is still at 0. Recovery must
+        // not progress because subscribers would resolve packages from a DB that
+        // hasn't indexed them yet.
+        tx.send(Arc::new(Watermarks::for_test(&[
+            (LEDGER_GRPC_PIPELINE, 3),
+            (KV_PACKAGES_PIPELINE, 0),
+        ])))
+        .unwrap();
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        assert_eq!(drain_broadcast(&mut receiver), Vec::<u64>::new());
+        assert_eq!(mock_arc.calls_for(1), 0, "fetch waiting on kv_packages");
+
+        // Advance kv_packages: both pipelines caught up, recovery completes.
+        tx.send(Arc::new(Watermarks::for_test(&[
+            (LEDGER_GRPC_PIPELINE, 3),
+            (KV_PACKAGES_PIPELINE, 3),
+        ])))
+        .unwrap();
+        timeout(Duration::from_secs(1), task)
+            .await
+            .expect("recover_gap did not finish")
+            .unwrap()
+            .unwrap();
+        assert_eq!(drain_broadcast(&mut receiver), vec![1, 2, 3]);
     }
 }

--- a/crates/sui-indexer-alt-graphql/src/task/streaming/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/task/streaming/mod.rs
@@ -40,6 +40,7 @@
 //! ```
 
 mod checkpoint_stream_task;
+mod gap_recovery;
 mod package_eviction_task;
 mod processed_checkpoint;
 mod streamed_package_store;


### PR DESCRIPTION
## Description 

* `CheckpointStreamTask` now reconnects on upstream stream errors and detects gaps when the first message after reconnect has a sequence number past the last broadcast. Missing checkpoints are fetched from kv-rpc (`LedgerService`) and broadcast in order before the live message, so subscribers see strictly contiguous, in-order checkpoints across disconnects.
* New `gap_recovery` module with a `CheckpointFetcher` trait, `recover_gap` driver (chunked, watermark-gated per chunk, infinite transient retry), and unit tests covering retry, chunk semantics, and watermark progression.
* Reconnect uses bounded exponential backoff. Permanent gRPC errors (`Unauthenticated`, `PermissionDenied`, `InvalidArgument`, `Unimplemented`) terminate the task; everything else retries indefinitely so the streaming server stays alive through upstream outages.

See the module-level doc at the top of `checkpoint_stream_task.rs` for the algorithm and design rationale.

**Out of scope (follow-ups)**:

 * Metrics for gap recovery (counter of attempts, failures, stuck-seconds gauge). TODO marker in the code.

## Test plan 

How did you test the new or updated feature?

 - Unit tests in `gap_recovery::tests` — 7 tests covering `fetch_one_with_retry`, `fetch_chunk`, and `recover_gap` (including a watermark-progression scenario).
 - `cargo xclippy` clean.
 - `cargo fmt` applied.

## Stack
- #26019
- #26094
- #26117
- #26170
- #26194
- #26202
- #26414

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
