### PR TITLE
Avoid allocation in bcs-to-hasher patterns using serialize_into

### DIFF
--- a/consensus/core/src/block.rs
+++ b/consensus/core/src/block.rs
@@ -384,7 +384,7 @@ struct InnerBlockDigest([u8; consensus_config::DIGEST_LENGTH]);
 /// Computes the digest of a Block, only for signing and verifications.
 fn compute_inner_block_digest(block: &Block) -> ConsensusResult<InnerBlockDigest> {
     let mut hasher = DefaultHashFunction::new();
-    hasher.update(bcs::to_bytes(block).map_err(ConsensusError::SerializationFailure)?);
+    bcs::serialize_into(&mut hasher, block).map_err(ConsensusError::SerializationFailure)?;
     Ok(InnerBlockDigest(hasher.finalize().into()))
 }
 

--- a/crates/sui-genesis-builder/src/lib.rs
+++ b/crates/sui-genesis-builder/src/lib.rs
@@ -691,11 +691,11 @@ fn create_genesis_digest(
 ) -> TransactionDigest {
     let mut hasher = DefaultHash::default();
     hasher.update(b"sui-genesis");
-    hasher.update(bcs::to_bytes(genesis_chain_parameters).unwrap());
-    hasher.update(bcs::to_bytes(genesis_validators).unwrap());
-    hasher.update(bcs::to_bytes(token_distribution_schedule).unwrap());
+    bcs::serialize_into(&mut hasher, genesis_chain_parameters).unwrap();
+    bcs::serialize_into(&mut hasher, genesis_validators).unwrap();
+    bcs::serialize_into(&mut hasher, token_distribution_schedule).unwrap();
     for system_package in system_packages {
-        hasher.update(bcs::to_bytes(&system_package.bytes).unwrap());
+        bcs::serialize_into(&mut hasher, &system_package.bytes).unwrap();
     }
 
     let hash = hasher.finalize();

--- a/crates/sui-rosetta/src/construction.rs
+++ b/crates/sui-rosetta/src/construction.rs
@@ -76,7 +76,7 @@ pub async fn payloads(
     let intent_msg_bytes = bcs::to_bytes(&intent_msg)?;
 
     let mut hasher = DefaultHash::default();
-    hasher.update(bcs::to_bytes(&intent_msg).expect("Message serialization should not fail"));
+    bcs::serialize_into(&mut hasher, &intent_msg).expect("Message serialization should not fail");
     let digest = hasher.finalize().digest;
 
     Ok(ConstructionPayloadsResponse {

--- a/crates/sui-types/src/crypto.rs
+++ b/crates/sui-types/src/crypto.rs
@@ -774,7 +774,7 @@ impl Signature {
         // itself that computes the BCS hash of the Rust type prefix and `struct TransactionData`.
         // (See `fn digest` in `impl Message for SenderSignedData`).
         let mut hasher = DefaultHash::default();
-        hasher.update(bcs::to_bytes(&value).expect("Message serialization should not fail"));
+        bcs::serialize_into(&mut hasher, &value).expect("Message serialization should not fail");
 
         Signer::sign(secret, &hasher.finalize().digest)
     }
@@ -1043,7 +1043,7 @@ impl<S: SuiSignatureInner + Sized> SuiSignature for S {
         T: Serialize,
     {
         let mut hasher = DefaultHash::default();
-        hasher.update(bcs::to_bytes(&value).expect("Message serialization should not fail"));
+        bcs::serialize_into(&mut hasher, &value).expect("Message serialization should not fail");
         let digest = hasher.finalize().digest;
 
         let (sig, pk) = &self.get_verification_inputs()?;

--- a/crates/sui-types/src/dynamic_field.rs
+++ b/crates/sui-types/src/dynamic_field.rs
@@ -275,7 +275,6 @@ where
     T: Into<SuiAddress>,
 {
     let parent: SuiAddress = parent.into();
-    let k_tag_bytes = bcs::to_bytes(key_type_tag)?;
     tracing::trace!(
         "Deriving dynamic field ID for parent={:?}, key={:?}, key_type_tag={}",
         parent,
@@ -289,7 +288,7 @@ where
     hasher.update(parent);
     hasher.update(key_bytes.len().to_le_bytes());
     hasher.update(key_bytes);
-    hasher.update(k_tag_bytes);
+    bcs::serialize_into(&mut hasher, key_type_tag)?;
     let hash = hasher.finalize();
 
     // truncate into an ObjectID and return

--- a/crates/sui-types/src/multisig.rs
+++ b/crates/sui-types/src/multisig.rs
@@ -145,9 +145,8 @@ impl AuthenticatorTrait for MultiSig {
         }
 
         let mut weight_sum: u16 = 0;
-        let message = bcs::to_bytes(&value).expect("Message serialization should not fail");
         let mut hasher = DefaultHash::default();
-        hasher.update(message);
+        bcs::serialize_into(&mut hasher, &value).expect("Message serialization should not fail");
         let digest = hasher.finalize().digest;
         // Verify each signature against its corresponding signature scheme and public key.
         // TODO: further optimization can be done because multiple Ed25519 signatures can be batch verified.

--- a/crates/sui-types/src/zk_login_authenticator.rs
+++ b/crates/sui-types/src/zk_login_authenticator.rs
@@ -64,7 +64,8 @@ impl ZkLoginAuthenticator {
     pub fn hash_inputs(&self) -> ZKLoginInputsDigest {
         use fastcrypto::hash::HashFunction;
         let mut hasher = DefaultHash::default();
-        hasher.update(bcs::to_bytes(&self.get_caching_params()).expect("serde should not fail"));
+        bcs::serialize_into(&mut hasher, &self.get_caching_params())
+            .expect("serde should not fail");
         ZKLoginInputsDigest::new(hasher.finalize().into())
     }
 

--- a/crates/sui/src/keytool.rs
+++ b/crates/sui/src/keytool.rs
@@ -864,7 +864,7 @@ impl KeyToolCommand {
                 let intent_msg = IntentMessage::new(intent, msg);
                 let raw_intent_msg: String = Base64::encode(bcs::to_bytes(&intent_msg)?);
                 let mut hasher = DefaultHash::default();
-                hasher.update(bcs::to_bytes(&intent_msg)?);
+                bcs::serialize_into(&mut hasher, &intent_msg)?;
                 let digest = hasher.finalize().digest;
                 let sui_signature = context
                     .sign_secure(&address.into(), &intent_msg.value, intent_msg.intent)
@@ -903,7 +903,7 @@ impl KeyToolCommand {
                     Base64::encode(bcs::to_bytes(&intent_msg)?)
                 );
                 let mut hasher = DefaultHash::default();
-                hasher.update(bcs::to_bytes(&intent_msg)?);
+                bcs::serialize_into(&mut hasher, &intent_msg)?;
                 let digest = hasher.finalize().digest;
                 info!("Digest to sign: {:?}", Base64::encode(digest));
 


### PR DESCRIPTION
## Summary
- Replace `bcs::to_bytes` + `hasher.update` with `bcs::serialize_into(&mut hasher, ...)` across the codebase to avoid intermediate `Vec<u8>` allocations.
- This works because `Blake2b256` (via fastcrypto's `HashFunctionWrapper`) implements `std::io::Write`.
- 12 call sites converted across 8 files:
  - `crates/sui-types/src/dynamic_field.rs` — dynamic field ID derivation
  - `crates/sui-types/src/crypto.rs` — transaction signing and verification
  - `crates/sui-types/src/zk_login_authenticator.rs` — ZK login hash inputs
  - `crates/sui-types/src/multisig.rs` — multisig digest
  - `crates/sui-genesis-builder/src/lib.rs` — genesis transaction digest (4 sites)
  - `crates/sui-rosetta/src/construction.rs` — intent message digest
  - `crates/sui/src/keytool.rs` — interactive and KMS signing
  - `consensus/core/src/block.rs` — inner block digest

## Test plan
- [x] `cargo check` passes for all affected crates
- [ ] Existing tests pass (hash output is identical since BCS produces the same byte sequence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)