### PR TITLE
[move-compiler] Don't ICE on malformed match patterns when typing already errored

### DIFF
--- a/external-crates/move/crates/move-compiler/src/hlir/match_compilation.rs
+++ b/external-crates/move/crates/move-compiler/src/hlir/match_compilation.rs
@@ -183,14 +183,26 @@ fn build_match_tree(
     if subject.ty.value.unfold_to_builtin_type_name().is_some() {
         compile_match_literal(context, subject, fringe, matrix)
     } else {
-        let tyargs = subject.ty.value.type_arguments().unwrap().clone();
+        let Some(tyargs) = subject.ty.value.type_arguments().cloned() else {
+            assert!(
+                context.env.has_errors(),
+                "ICE non-parameterized type in head constructor fringe position",
+            );
+            return MatchTree::Failure;
+        };
 
-        let (mident, datatype_name) = subject
+        let Some((mident, datatype_name)) = subject
             .ty
             .value
             .unfold_to_type_name()
             .and_then(|sp!(_, name)| name.datatype_name())
-            .expect("ICE non-datatype type in head constructor fringe position");
+        else {
+            assert!(
+                context.env.has_errors(),
+                "ICE non-datatype type in head constructor fringe position",
+            );
+            return MatchTree::Failure;
+        };
 
         if context.info.is_struct(&mident, &datatype_name) {
             compile_match_struct(
@@ -410,7 +422,10 @@ fn match_tree_to_exp(
     match result {
         MatchTree::Leaf(leaf) => make_leaf(context, init_subject, leaf),
         MatchTree::Failure => {
-            context.hlir_context.add_diag(ice!((context.arms_loc, "Generated a failure expression, which should not be allowed under match exhaustion.")));
+            // Suppress the ICE when typing already produced errors; the failure is downstream of those.
+            if !context.hlir_context.env.has_errors() {
+                context.hlir_context.add_diag(ice!((context.arms_loc, "Generated a failure expression, which should not be allowed under match exhaustion.")));
+            }
             T::exp(
                 context.output_type(),
                 sp(context.arms_loc, T::UnannotatedExp_::UnresolvedError),

--- a/external-crates/move/crates/move-compiler/src/hlir/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/hlir/translate.rs
@@ -208,15 +208,16 @@ impl<'env> Context<'env> {
 
     pub fn bind_local(&mut self, mut_: Mutability, v: N::Var, t: H::SingleType) {
         let symbol = translate_var(v);
-        // We may reuse a name if it appears on both sides of an `or` pattern
+        // A name may be reused across `or` pattern branches; mismatches imply typing already errored.
         if let Some((cur_mut, cur_t)) = self.function_locals.get(&symbol) {
-            assert!(cur_t == &t);
             assert!(
-                cur_mut == &mut_,
-                "{:?} changed mutability from {:?} to {:?}",
+                (cur_t == &t && cur_mut == &mut_) || self.env.has_errors(),
+                "{:?} rebound with mismatched (mut, type): ({:?}, {:?}) -> ({:?}, {:?})",
                 v,
                 cur_mut,
-                mut_
+                cur_t,
+                mut_,
+                t,
             );
         } else {
             self.function_locals.add(symbol, (mut_, t)).unwrap();

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/regression_25825_or_pattern_wrong_arity_with_guard.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/regression_25825_or_pattern_wrong_arity_with_guard.move
@@ -1,0 +1,20 @@
+// Regression test for https://github.com/MystenLabs/sui/issues/25825
+// HLIR match-compilation panicked with `Option::unwrap() on None` when a
+// match contained a wrong-arity unit-variant pattern in an `or` pattern with
+// a literal arm. The wrong-arity is reported by typing; later passes must
+// not crash on the resulting malformed AST.
+module 0x42::m {
+    public enum E<T> has drop {
+        A,
+        C(T, T, T),
+    }
+
+    fun t(): u64 {
+        let subject = E::A(0);
+        match (subject) {
+            E::A(x) if (true) => x,
+            E::A(x) | E::C(x, _, 0) => x,
+            _ => 1,
+        }
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/regression_25825_or_pattern_wrong_arity_with_guard.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/regression_25825_or_pattern_wrong_arity_with_guard.snap
@@ -1,0 +1,39 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+error[E03013]: positional call mismatch
+   ┌─ tests/move_2024/matching/regression_25825_or_pattern_wrong_arity_with_guard.move:13:23
+   │
+ 8 │         A,
+   │         - 'A' is declared here
+   ·
+13 │         let subject = E::A(0);
+   │                       ^^^^^^^ Invalid variant instantiation. Empty variant declarations require empty instantiations
+   │
+   = Remove '()' arguments from this instantiation
+
+error[E03013]: positional call mismatch
+   ┌─ tests/move_2024/matching/regression_25825_or_pattern_wrong_arity_with_guard.move:15:13
+   │
+ 8 │         A,
+   │         - 'A' is declared here
+   ·
+15 │             E::A(x) if (true) => x,
+   │             ^^^^^^^ Invalid variant pattern. Empty variant declarations require empty patterns
+   │
+   = Remove '()' arguments from this pattern
+
+error[E03013]: positional call mismatch
+   ┌─ tests/move_2024/matching/regression_25825_or_pattern_wrong_arity_with_guard.move:16:13
+   │
+ 8 │         A,
+   │         - 'A' is declared here
+   ·
+16 │             E::A(x) | E::C(x, _, 0) => x,
+   │             ^^^^^^^ Invalid variant pattern. Empty variant declarations require empty patterns
+   │
+   = Remove '()' arguments from this pattern

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/regression_25826_or_pattern_wrong_arity_with_literal.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/regression_25826_or_pattern_wrong_arity_with_literal.move
@@ -1,0 +1,20 @@
+// Regression test for https://github.com/MystenLabs/sui/issues/25826
+// Match compilation emitted a spurious ICE12003 ("Generated a failure
+// expression, which should not be allowed under match exhaustion") when
+// typing had already reported a wrong-arity error. The diagnostic should be
+// suppressed when typing has reported errors, leaving only the original
+// user-facing error.
+module 0x42::m {
+    public enum E has drop {
+        A(u64),
+        C(u64, u64, u64),
+    }
+
+    fun t(): u64 {
+        let subject = E::A(0);
+        match (subject) {
+            E::A(x) if (x == &0) => x,
+            E::A(x) | E::C(x, _, 0) | E::C(_, x) => x,
+        }
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/regression_25826_or_pattern_wrong_arity_with_literal.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/regression_25826_or_pattern_wrong_arity_with_literal.snap
@@ -1,0 +1,12 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+error[E04016]: too few arguments
+   ┌─ tests/move_2024/matching/regression_25826_or_pattern_wrong_arity_with_literal.move:17:39
+   │
+17 │             E::A(x) | E::C(x, _, 0) | E::C(_, x) => x,
+   │                                       ^^^^^^^^^^ Missing pattern for field '2' in '0x42::m::E::C'

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/regression_26110_or_pattern_unit_variant_field.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/regression_26110_or_pattern_unit_variant_field.move
@@ -1,0 +1,18 @@
+// Regression test for https://github.com/MystenLabs/sui/issues/26110
+// HLIR `bind_local` panicked with `assert!(cur_t == &t)` when an `or` pattern
+// rebound the same name across branches whose types disagreed because typing
+// had already reported a wrong-arity diagnostic. The compiler should report
+// the underlying error without an ICE.
+module 0x42::m {
+    public enum E<T> {
+        A(T),
+        B,
+        C(T, T),
+    }
+    fun t(): u64 {
+        match (E::A(0)) {
+            E::C(x, (0 | 1)) | E::B(x) | E::A(x) => x,
+            _ => 1,
+        }
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/regression_26110_or_pattern_unit_variant_field.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/regression_26110_or_pattern_unit_variant_field.snap
@@ -1,0 +1,45 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+error[E06001]: unused value without 'drop'
+   ┌─ tests/move_2024/matching/regression_26110_or_pattern_unit_variant_field.move:13:25
+   │    
+ 7 │         public enum E<T> {
+   │                     - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·    
+13 │             match (E::A(0)) {
+   │                    ------- The type '0x42::m::E<u64>' does not have the ability 'drop'
+   │ ╭───────────────────────────^
+   │ │ ╭─────────────────────────'
+14 │ │ │             E::C(x, (0 | 1)) | E::B(x) | E::A(x) => x,
+15 │ │ │             _ => 1,
+16 │ │ │         }
+   │ ╰─│─────────^ Invalid return
+   │   ╰─────────' The match expression takes ownership of this value but does not use it. The value does not have the 'drop' ability and must be consumed before the function returns
+
+error[E03013]: positional call mismatch
+   ┌─ tests/move_2024/matching/regression_26110_or_pattern_unit_variant_field.move:14:32
+   │
+ 9 │         B,
+   │         - 'B' is declared here
+   ·
+14 │             E::C(x, (0 | 1)) | E::B(x) | E::A(x) => x,
+   │                                ^^^^^^^ Invalid variant pattern. Empty variant declarations require empty patterns
+   │
+   = Remove '()' arguments from this pattern
+
+error[E05001]: ability constraint not satisfied
+   ┌─ tests/move_2024/matching/regression_26110_or_pattern_unit_variant_field.move:15:13
+   │
+ 7 │     public enum E<T> {
+   │                 - To satisfy the constraint, the 'drop' ability would need to be added here
+   ·
+13 │         match (E::A(0)) {
+   │                ------- The type '0x42::m::E<_>' does not have the ability 'drop'
+14 │             E::C(x, (0 | 1)) | E::B(x) | E::A(x) => x,
+15 │             _ => 1,
+   │             ^ Cannot ignore values without the 'drop' ability. '_' patterns discard their values


### PR DESCRIPTION
## Description

Fixes a cluster of compiler ICEs caused by HLIR / match-compilation asserting invariants on malformed ASTs that flowed through after typing emitted a non-blocking error.

The pipeline gates Typing → HLIR on `Severity::BlockingError` ([compiler.rs:1170](https://github.com/MystenLabs/sui/blob/main/external-crates/move/crates/move-compiler/src/command_line/compiler.rs#L1170)), but pattern arity errors (`E03013 PositionalCallMismatch`) and most other type errors are `NonblockingError`, so HLIR runs on a partially-broken AST.

Three sites now follow the convention already used in this file ([translate.rs:2919](https://github.com/MystenLabs/sui/blob/main/external-crates/move/crates/move-compiler/src/hlir/translate.rs#L2919)) — the invariant must hold OR `env.has_errors()` is true:

1. **`Context::bind_local`** ([translate.rs:209](https://github.com/MystenLabs/sui/blob/main/external-crates/move/crates/move-compiler/src/hlir/translate.rs#L209)) — an `or` pattern reusing a name across branches whose types / mutabilities disagree. Previously panicked at `assert!(cur_t == &t)`. Now keeps the first binding and lets the earlier diagnostic surface. (#26110)

2. **`build_match_tree`** ([match_compilation.rs:186](https://github.com/MystenLabs/sui/blob/main/external-crates/move/crates/move-compiler/src/hlir/match_compilation.rs#L186)) — head constructor's type is not a parameterized datatype because the malformed pattern produced a degenerate type. Previously panicked with `unwrap()` / `expect("ICE non-datatype...")`. Now returns `MatchTree::Failure` and bails. (#25825)

3. **`match_tree_to_exp` / `MatchTree::Failure`** ([match_compilation.rs:429](https://github.com/MystenLabs/sui/blob/main/external-crates/move/crates/move-compiler/src/hlir/match_compilation.rs#L429)) — suppress the spurious `ICE12003` ("Generated a failure expression") when typing already complained, leaving only the user-facing diagnostic. (#25826)

The fix is intentionally narrow: it does not change diagnostics for valid programs; it only prevents these specific ICEs when the AST is already known to be malformed.

## Test Plan

Three snapshot regression tests under `external-crates/move/crates/move-compiler/tests/move_2024/matching/` covering the MREs from the linked issues:
- `regression_26110_or_pattern_unit_variant_field.{move,snap}`
- `regression_25825_or_pattern_wrong_arity_with_guard.{move,snap}`
- `regression_25826_or_pattern_wrong_arity_with_literal.{move,snap}`

Verified locally:

```
$ cargo test --release -p move-compiler
test result: ok. 2118 passed; 0 failed   # all existing + 3 new

$ cargo move-clippy   # clean
$ cargo fmt --all -- --check   # clean
$ cargo check -p sui-framework   # clean
$ cargo check -p sui-move-build  # clean
```

Adjacent suites also pass: `bytecode-verifier-tests`, `move-stackless-bytecode`, `move-docgen-tests`, `move-bytecode-verifier`.

## Out of scope (related but different code paths)

- #25790 — panic in `cfgir/locals/state.rs:74` (constant pattern + guarded `@`-binding). Different mechanism; would need its own fix.
- #25750 — panic in `to_bytecode/translate.rs:972` (divergent expr in vector literal). Different mechanism.

## Closes

- Closes #26110
- Closes #25825
- Closes #25826