### PR TITLE
Remove pre-chunking execution time observation code path

### DIFF
--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -569,7 +569,7 @@ mod test {
                     stored_observations_limit: rng.gen_range(1..=20),
                     stake_weighted_median_threshold: 0,
                     default_none_duration_for_new_keys: true,
-                    observations_chunk_size: None,
+                    observations_chunk_size: Some(18),
                 },
             );
             max_deferral_rounds = if rng.gen_bool(0.5) {

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -100,9 +100,7 @@ use super::transaction_deferral::{DeferralKey, DeferralReason};
 use super::transaction_reject_reason_cache::TransactionRejectReasonCache;
 use crate::authority::ResolverWrapper;
 use crate::authority::epoch_start_configuration::EpochStartConfiguration;
-use crate::authority::execution_time_estimator::{
-    EXTRA_FIELD_EXECUTION_TIME_ESTIMATES_CHUNK_COUNT_KEY, EXTRA_FIELD_EXECUTION_TIME_ESTIMATES_KEY,
-};
+use crate::authority::execution_time_estimator::EXTRA_FIELD_EXECUTION_TIME_ESTIMATES_CHUNK_COUNT_KEY;
 use crate::authority::shared_object_version_manager::{
     AsTx, AssignedTxAndVersions, ConsensusSharedObjVerAssignment, Schedulable, SharedObjVerManager,
 };
@@ -1518,12 +1516,15 @@ impl AuthorityPerEpochStore {
             Duration,
         ),
     > {
-        if !matches!(
-            protocol_config.per_object_congestion_control_mode(),
-            PerObjectCongestionControlMode::ExecutionTimeEstimate(_)
-        ) {
+        let PerObjectCongestionControlMode::ExecutionTimeEstimate(params) =
+            protocol_config.per_object_congestion_control_mode()
+        else {
             return itertools::Either::Left(std::iter::empty());
-        }
+        };
+        assert!(
+            params.observations_chunk_size.is_some(),
+            "observation chunking must be enabled"
+        );
 
         // Load stored execution time observations from the SuiSystemState object.
         let system_state =
@@ -1545,60 +1546,39 @@ impl AuthorityPerEpochStore {
                 return itertools::Either::Left(std::iter::empty());
             }
         };
-        let stored_observations = if protocol_config.enable_observation_chunking() {
-            if let Ok::<u64, _>(chunk_count) = get_dynamic_field_from_store(
+        let Ok::<u64, _>(chunk_count) = get_dynamic_field_from_store(
+            object_store,
+            system_state.extra_fields.id.id.bytes,
+            &EXTRA_FIELD_EXECUTION_TIME_ESTIMATES_CHUNK_COUNT_KEY,
+        ) else {
+            debug_fatal!("could not read stored execution time chunk count");
+            return itertools::Either::Left(std::iter::empty());
+        };
+
+        let mut chunks = Vec::new();
+        for chunk_index in 0..chunk_count {
+            let chunk_key = ExecutionTimeObservationChunkKey { chunk_index };
+            let Ok::<Vec<u8>, _>(chunk_bytes) = get_dynamic_field_from_store(
                 object_store,
                 system_state.extra_fields.id.id.bytes,
-                &EXTRA_FIELD_EXECUTION_TIME_ESTIMATES_CHUNK_COUNT_KEY,
-            ) {
-                let mut chunks = Vec::new();
-                for chunk_index in 0..chunk_count {
-                    let chunk_key = ExecutionTimeObservationChunkKey { chunk_index };
-                    let Ok::<Vec<u8>, _>(chunk_bytes) = get_dynamic_field_from_store(
-                        object_store,
-                        system_state.extra_fields.id.id.bytes,
-                        &chunk_key,
-                    ) else {
-                        debug_fatal!(
-                            "Could not find stored execution time observation chunk {}",
-                            chunk_index
-                        );
-                        return itertools::Either::Left(std::iter::empty());
-                    };
-
-                    // This is stored as a vector<u8> in Move, so we double-deserialize to get back
-                    // the observation chunk.
-                    let chunk: StoredExecutionTimeObservations = bcs::from_bytes(&chunk_bytes)
-                        .expect("failed to deserialize stored execution time estimates chunk");
-                    chunks.push(chunk);
-                }
-
-                StoredExecutionTimeObservations::merge_sorted_chunks(chunks).unwrap_v1()
-            } else {
-                warn!(
-                    "Could not read stored execution time chunk count. This should only happen in the first epoch where chunking is enabled."
-                );
-                return itertools::Either::Left(std::iter::empty());
-            }
-        } else {
-            // TODO: Remove this once we've enabled chunking on mainnet.
-            let Ok::<Vec<u8>, _>(stored_observations_bytes) = get_dynamic_field_from_store(
-                object_store,
-                system_state.extra_fields.id.id.bytes,
-                &EXTRA_FIELD_EXECUTION_TIME_ESTIMATES_KEY,
+                &chunk_key,
             ) else {
-                warn!(
-                    "Could not find stored execution time observations. This should only happen in the first epoch where ExecutionTimeEstimate mode is enabled."
+                debug_fatal!(
+                    "Could not find stored execution time observation chunk {}",
+                    chunk_index
                 );
                 return itertools::Either::Left(std::iter::empty());
             };
+
             // This is stored as a vector<u8> in Move, so we double-deserialize to get back
-            //`StoredExecutionTimeObservations`.
-            let stored_observations: StoredExecutionTimeObservations =
-                bcs::from_bytes(&stored_observations_bytes)
-                    .expect("failed to deserialize stored execution time estimates");
-            stored_observations.unwrap_v1()
-        };
+            // the observation chunk.
+            let chunk: StoredExecutionTimeObservations = bcs::from_bytes(&chunk_bytes)
+                .expect("failed to deserialize stored execution time estimates chunk");
+            chunks.push(chunk);
+        }
+
+        let stored_observations =
+            StoredExecutionTimeObservations::merge_sorted_chunks(chunks).unwrap_v1();
 
         info!(
             "loaded stored execution time observations for {} keys",

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -1521,10 +1521,9 @@ impl AuthorityPerEpochStore {
         else {
             return itertools::Either::Left(std::iter::empty());
         };
-        assert!(
-            params.observations_chunk_size.is_some(),
-            "observation chunking must be enabled"
-        );
+        if params.observations_chunk_size.is_none() {
+            return itertools::Either::Left(std::iter::empty());
+        }
 
         // Load stored execution time observations from the SuiSystemState object.
         let system_state =
@@ -1551,7 +1550,15 @@ impl AuthorityPerEpochStore {
             system_state.extra_fields.id.id.bytes,
             &EXTRA_FIELD_EXECUTION_TIME_ESTIMATES_CHUNK_COUNT_KEY,
         ) else {
-            debug_fatal!("could not read stored execution time chunk count");
+            error!(
+                "Could not read stored execution time chunk count. This should only happen in the first epoch where chunking is enabled."
+            );
+            if let Some(metrics) = mysten_metrics::get_metrics() {
+                metrics
+                    .system_invariant_violations
+                    .with_label_values(&["execution_time_chunk_count_missing"])
+                    .inc();
+            }
             return itertools::Either::Left(std::iter::empty());
         };
 

--- a/crates/sui-core/src/authority/execution_time_estimator.rs
+++ b/crates/sui-core/src/authority/execution_time_estimator.rs
@@ -925,7 +925,7 @@ mod tests {
                         stored_observations_limit: u64::MAX,
                         stake_weighted_median_threshold: 0,
                         default_none_duration_for_new_keys: true,
-                        observations_chunk_size: None,
+                        observations_chunk_size: Some(18),
                     },
                 ),
             );
@@ -1060,7 +1060,7 @@ mod tests {
                         stored_observations_limit: u64::MAX,
                         stake_weighted_median_threshold: 0,
                         default_none_duration_for_new_keys: true,
-                        observations_chunk_size: None,
+                        observations_chunk_size: Some(18),
                     },
                 ),
             );
@@ -1153,7 +1153,7 @@ mod tests {
                         stored_observations_limit: u64::MAX,
                         stake_weighted_median_threshold: 0,
                         default_none_duration_for_new_keys: true,
-                        observations_chunk_size: None,
+                        observations_chunk_size: Some(18),
                     },
                 ),
             );
@@ -1250,7 +1250,7 @@ mod tests {
                         stored_observations_limit: u64::MAX,
                         stake_weighted_median_threshold: 0,
                         default_none_duration_for_new_keys: true,
-                        observations_chunk_size: None,
+                        observations_chunk_size: Some(18),
                     },
                 ),
             );
@@ -1393,7 +1393,7 @@ mod tests {
                         stored_observations_limit: u64::MAX,
                         stake_weighted_median_threshold: 0,
                         default_none_duration_for_new_keys: true,
-                        observations_chunk_size: None,
+                        observations_chunk_size: Some(18),
                     },
                 ),
             );
@@ -1672,7 +1672,7 @@ mod tests {
                 stored_observations_limit: u64::MAX,
                 stake_weighted_median_threshold: 0,
                 default_none_duration_for_new_keys: true,
-                observations_chunk_size: None,
+                observations_chunk_size: Some(18),
             },
             std::iter::empty(),
         );

--- a/crates/sui-core/src/authority/shared_object_congestion_tracker.rs
+++ b/crates/sui-core/src/authority/shared_object_congestion_tracker.rs
@@ -328,7 +328,7 @@ mod object_cost_tests {
             stored_observations_limit: u64::MAX,
             stake_weighted_median_threshold: 0,
             default_none_duration_for_new_keys: false,
-            observations_chunk_size: None,
+            observations_chunk_size: Some(18),
         }
     }
 
@@ -689,7 +689,7 @@ mod object_cost_tests {
                 stored_observations_limit: u64::MAX,
                 stake_weighted_median_threshold: 0,
                 default_none_duration_for_new_keys: false,
-                observations_chunk_size: None,
+                observations_chunk_size: Some(18),
             },
             false,
             false,
@@ -785,7 +785,7 @@ mod object_cost_tests {
                 stored_observations_limit: u64::MAX,
                 stake_weighted_median_threshold: 0,
                 default_none_duration_for_new_keys: false,
-                observations_chunk_size: None,
+                observations_chunk_size: Some(18),
             },
             false,
             false,
@@ -1039,7 +1039,7 @@ mod object_cost_tests {
             stored_observations_limit: u64::MAX,
             stake_weighted_median_threshold: 0,
             default_none_duration_for_new_keys: false,
-            observations_chunk_size: None,
+            observations_chunk_size: Some(18),
         };
         let mut tracker = SharedObjectCongestionTracker::new(
             [(shared_obj_0, 500), (shared_obj_1, 500)],
@@ -1085,7 +1085,7 @@ mod object_cost_tests {
             stored_observations_limit: u64::MAX,
             stake_weighted_median_threshold: 0,
             default_none_duration_for_new_keys: false,
-            observations_chunk_size: None,
+            observations_chunk_size: Some(18),
         };
         let mut tracker = SharedObjectCongestionTracker::new(
             [(shared_obj_0, 0), (shared_obj_1, 0)],

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -5893,7 +5893,7 @@ async fn test_consensus_handler_per_object_congestion_control() {
         stored_observations_limit: u64::MAX,
         stake_weighted_median_threshold: 0,
         default_none_duration_for_new_keys: false,
-        observations_chunk_size: None,
+        observations_chunk_size: Some(18),
     };
 
     let mut protocol_config =
@@ -6165,7 +6165,7 @@ async fn test_consensus_handler_congestion_control_transaction_cancellation() {
         stored_observations_limit: u64::MAX,
         stake_weighted_median_threshold: 0,
         default_none_duration_for_new_keys: false,
-        observations_chunk_size: None,
+        observations_chunk_size: Some(18),
     };
 
     let mut protocol_config =

--- a/crates/sui-core/src/unit_tests/congestion_control_tests.rs
+++ b/crates/sui-core/src/unit_tests/congestion_control_tests.rs
@@ -67,7 +67,7 @@ impl TestSetup {
                 stored_observations_limit: u64::MAX,
                 stake_weighted_median_threshold: 0,
                 default_none_duration_for_new_keys: false,
-                observations_chunk_size: None,
+                observations_chunk_size: Some(18),
             }),
         );
 
@@ -247,7 +247,7 @@ async fn test_congestion_control_execution_cancellation() {
                 stored_observations_limit: u64::MAX,
                 stake_weighted_median_threshold: 0,
                 default_none_duration_for_new_keys: false,
-                observations_chunk_size: None,
+                observations_chunk_size: Some(18),
             },
             false,
             false,

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -2322,13 +2322,6 @@ impl ProtocolConfig {
         window_size
     }
 
-    pub fn enable_observation_chunking(&self) -> bool {
-        matches!(self.feature_flags.per_object_congestion_control_mode,
-            PerObjectCongestionControlMode::ExecutionTimeEstimate(ref params)
-                if params.observations_chunk_size.is_some()
-        )
-    }
-
     pub fn address_aliases(&self) -> bool {
         let address_aliases = self.feature_flags.address_aliases;
         assert!(

--- a/sui-execution/latest/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/latest/sui-adapter/src/execution_engine.rs
@@ -1126,16 +1126,14 @@ pub(crate) mod checked {
                             if let PerObjectCongestionControlMode::ExecutionTimeEstimate(params) =
                                 protocol_config.per_object_congestion_control_mode()
                             {
-                                if let Some(chunk_size) = params.observations_chunk_size {
-                                    builder = setup_store_execution_time_estimates_v2(
-                                        builder,
-                                        estimates,
-                                        chunk_size as usize,
-                                    );
-                                } else {
-                                    builder =
-                                        setup_store_execution_time_estimates(builder, estimates);
-                                }
+                                let chunk_size = params
+                                    .observations_chunk_size
+                                    .expect("observation chunking is enabled at all protocol versions handled by this execution layer");
+                                builder = setup_store_execution_time_estimates(
+                                    builder,
+                                    estimates,
+                                    chunk_size as usize,
+                                );
                             }
                         }
                         EndOfEpochTransactionKind::AccumulatorRootCreate => {
@@ -1769,25 +1767,6 @@ pub(crate) mod checked {
     }
 
     fn setup_store_execution_time_estimates(
-        mut builder: ProgrammableTransactionBuilder,
-        estimates: StoredExecutionTimeObservations,
-    ) -> ProgrammableTransactionBuilder {
-        let system_state = builder.obj(ObjectArg::SUI_SYSTEM_MUT).unwrap();
-        // This is stored as a vector<u8> in Move, so we first convert to bytes before again
-        // serializing inside the call to `pure`.
-        let estimates_bytes = bcs::to_bytes(&estimates).unwrap();
-        let estimates_arg = builder.pure(estimates_bytes).unwrap();
-        builder.programmable_move_call(
-            SUI_SYSTEM_PACKAGE_ID,
-            SUI_SYSTEM_MODULE_NAME.to_owned(),
-            ident_str!("store_execution_time_estimates").to_owned(),
-            vec![],
-            vec![system_state, estimates_arg],
-        );
-        builder
-    }
-
-    fn setup_store_execution_time_estimates_v2(
         mut builder: ProgrammableTransactionBuilder,
         estimates: StoredExecutionTimeObservations,
         chunk_size: usize,


### PR DESCRIPTION
## Description

Observation chunking has been enabled since protocol version 102, and the `latest` execution layer only runs at protocol version 119+, so the pre-chunking observation storage path is unreachable there.

`sui-execution/v3` still serves the older versions and keeps both paths. `sui-core` is not version-gated, so when chunking is off it now starts the epoch with no stored observations instead of reading the legacy single-key dynamic field.

## Test plan

Covered by existing execution-time-estimator and congestion-control tests; their fixtures move to `observations_chunk_size: Some(18)` to match mainnet.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework:
