### PR TITLE
[forking 16/n] Add object seeding

### DIFF
--- a/crates/sui-forking/README.md
+++ b/crates/sui-forking/README.md
@@ -36,6 +36,29 @@ The table below summarizes when to use each option:
 | Startup cost | Higher (state bootstrap + potential object downloads) | Lower (local genesis and startup) |
 | Determinism/reproducibility | Deterministic from selected checkpoint + seeded objects | Deterministic from local genesis/configuration |
 
+## Seeding Owned Objects
+
+Owned-object enumeration can be seeded when starting the fork:
+
+```bash
+sui-forking start --checkpoint 12345678 --address 0x... --object 0x...
+```
+
+- `--address` is repeatable and seeds metadata for every object owned by that
+  address at the fork checkpoint. Address seeding requires a checkpoint in the
+  GraphQL object enumeration range.
+- `--object` is repeatable and fetches that object at the fork checkpoint. If
+  the object is address-owned, it is added to the initial owned-object index.
+- Seed metadata is written once to `seed_manifest.json` under the fork
+  directory. The manifest is immutable.
+
+When restarting with the same `--data-dir`, `--network`, and `--checkpoint`,
+omit seed flags. If a seed manifest already exists and any seed flags are
+provided, startup fails instead of overwriting or reinterpreting the local
+state. Resume starts from the highest locally persisted checkpoint and keeps
+the durable owned-object index and deleted-object markers authoritative over
+the original seed manifest.
+
 ## Limitations
 - Staking and related operations are not supported.
 - Single validator, single authority network.

--- a/crates/sui-forking/seeding_design.md
+++ b/crates/sui-forking/seeding_design.md
@@ -39,6 +39,8 @@ the checkpoint must be within the last 1h.
 When restarting a fork with the same `--data-dir` and `--checkpoint`, the existing
 seeding information that is stored on disk will be reused. If `--address` or `--object` is
 provided, the tool will error with a message indicating that a seed manifest already exists.
+The durable owned-object index and local deleted markers remain authoritative over the manifest
+after the fork has executed local transactions.
 
 ## Generated files
 
@@ -56,7 +58,8 @@ One file is written to `{data_dir}/{network}/forked_at_{checkpoint}/`:
             "version": 42,
             "digest": "...",
             "owner": "0x...",
-            "object_type": "0x2::coin::Coin<0x2::sui::SUI>"
+            "object_type": "0x2::coin::Coin<0x2::sui::SUI>",
+            "balance": 1000000
         }
     ]
 }
@@ -106,7 +109,8 @@ query($sequenceNumber: UInt53, $address: SuiAddress!, $first: Int, $after: Strin
 
 - Page size: 50
 - Paginate with cursor loop (same pattern as `events_query`)
-- Only collect `AddressOwner` and `ConsensusAddressOwner` entries -- not really sure about ConsensusAddressOwner, probably we don't need it.
+- Only collect `AddressOwner` entries. `ConsensusAddressOwner`, shared, immutable, and object-owned
+  objects are not usable as address-owned gas/input objects for the initial index.
 
 ### Individual objects (reuse existing)
 
@@ -123,10 +127,11 @@ digest) from the deserialized `Object` for the `SeedEntry`.
 #[derive(Serialize, Deserialize)]
 struct SeedEntry {
     object_id: ObjectID,
-    version: u64,
-    digest: String,
+    version: SequenceNumber,
+    digest: ObjectDigest,
     owner: SuiAddress,
-    object_type: String,
+    object_type: StructTag,
+    balance: Option<u64>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -159,24 +164,31 @@ async fn resolve_seeds(
 4. Merge, dedup by `object_id`
 5. Return `SeedManifest`
 
-## Composition with owned_objects_design.md (Option B)
+## Composition with owned_objects_design.md
 
-The seed manifest is the "virtual live set" for pre-fork objects.
-Post-fork mutations are tracked via `live` markers + BCS files.
+The seed manifest is the immutable pre-fork baseline. The durable
+`indices/owned_objects` file and object tombstones are the current local state
+once the fork has started executing.
 
 **Index rebuild on startup** (two sources):
-1. `seed_manifest.json` entries → baseline owner index entries
-2. `objects/*/live` markers → post-fork mutations that override/extend seed state
+1. If `indices/owned_objects` exists, use it as-is and do not rewrite it from the manifest.
+2. If the index is missing and the fork has not advanced past the fork checkpoint, initialize it
+   from `seed_manifest.json`.
+3. If the index is missing but local checkpoints are newer than the fork checkpoint, fail closed
+   instead of rebuilding stale seed state over local mutations.
 
 **When a seeded object is first accessed** (e.g., as tx input):
 - `get_object_from_remote()` fetches full BCS, writes to disk
-- `update_objects()` creates `live` marker + updates index in-place
+- the owned index entry can already satisfy default owned-object listing, while object-loading
+  read masks fetch BCS lazily
 
 **When a seeded object is deleted/mutated post-fork**:
-- `update_objects()` removes old index entry (from seed), adds new one or removes `live` marker
+- `update_objects()` removes the old index entry, adds the new address-owned entry, or removes the
+  entry for wrapped/shared/immutable/object-owned transitions
+- local deleted markers prevent current-object reads from falling back to the remote endpoint
 
-**Key invariant**: Seed manifest is immutable after creation. Post-fork state
-tracked entirely through `live` markers.
+**Key invariant**: Seed manifest is immutable after creation. Post-fork state is tracked entirely
+through the durable owned-object index, object BCS files, and deleted markers.
 
 ## Edge cases
 

--- a/crates/sui-forking/seeding_design.md
+++ b/crates/sui-forking/seeding_design.md
@@ -79,7 +79,11 @@ Seed resolution:
 
 ## GraphQL queries
 
-### Address-owned objects query (new)
+### Address-owned objects query
+
+`src/gql/queries.rs` owns the checkpoint-scoped address query. The seed module
+calls `GraphQLClient::get_address_owned_objects_at_checkpoint()` and does not
+construct raw GraphQL requests.
 
 Uses `Checkpoint.query` scoping (same pattern as `VersionAtCheckpointQuery`):
 
@@ -95,9 +99,11 @@ query($sequenceNumber: UInt53, $address: SuiAddress!, $first: Int, $after: Strin
             digest
             owner {
               ... on AddressOwner { address { address } }
-              ... on ConsensusAddressOwner { address { address } }
             }
-            contents { type { repr } }
+            contents {
+              type { repr }
+              json
+            }
           }
           pageInfo { hasNextPage endCursor }
         }
@@ -109,8 +115,9 @@ query($sequenceNumber: UInt53, $address: SuiAddress!, $first: Int, $after: Strin
 
 - Page size: 50
 - Paginate with cursor loop (same pattern as `events_query`)
-- Only collect `AddressOwner` entries. `ConsensusAddressOwner`, shared, immutable, and object-owned
-  objects are not usable as address-owned gas/input objects for the initial index.
+- Only collect `AddressOwner` entries. Other owner variants are handled by the
+  query fallback and skipped; they are not usable as address-owned gas/input
+  objects for the initial index.
 
 ### Individual objects (reuse existing)
 
@@ -203,8 +210,8 @@ through the durable owned-object index, object BCS files, and deleted markers.
 
 | File | Action |
 |------|--------|
-| `src/seed.rs` | New — types, resolution logic, file I/O |
-| `src/gql/queries.rs` | Modify — new `address_objects_query` module |
+| `src/seed.rs` | New — types, seed policy, manifest/index initialization |
+| `src/gql/queries.rs` | Modify — new `address_owned_objects_query` module |
 | `src/cli.rs` | Modify — three new CLI args on Start |
 | `src/startup.rs` | Modify — wire seeding into initialize() |
 | `src/filesystem.rs` | Modify — seed manifest read/write |

--- a/crates/sui-forking/src/cli.rs
+++ b/crates/sui-forking/src/cli.rs
@@ -14,13 +14,13 @@ use sui_types::base_types::ObjectID;
 use sui_types::base_types::SuiAddress;
 use tracing::info;
 
-use crate::seed::SeedInput;
 use crate::AdvanceCheckpointRequest;
 use crate::AdvanceClockRequest;
 use crate::ForkingServiceClient;
 use crate::GetStatusRequest;
 use crate::GraphQLClient;
 use crate::Node;
+use crate::seed::SeedInput;
 
 /// Default bind address for the RPC server.
 pub const DEFAULT_RPC_ADDR: &str = "127.0.0.1:9000";

--- a/crates/sui-forking/src/cli.rs
+++ b/crates/sui-forking/src/cli.rs
@@ -10,8 +10,11 @@ use clap::Parser;
 use clap::Subcommand;
 use reqwest::Url;
 use serde::Serialize;
+use sui_types::base_types::ObjectID;
+use sui_types::base_types::SuiAddress;
 use tracing::info;
 
+use crate::seed::SeedInput;
 use crate::AdvanceCheckpointRequest;
 use crate::AdvanceClockRequest;
 use crate::ForkingServiceClient;
@@ -49,6 +52,14 @@ enum Command {
         #[arg(long, env = "FORKING_DATA_STORE")]
         data_dir: Option<PathBuf>,
 
+        /// Address whose owned objects should seed the initial owned-object index
+        #[arg(long = "address")]
+        addresses: Vec<SuiAddress>,
+
+        /// Object ID to fetch and seed if it is address-owned
+        #[arg(long = "object")]
+        object_ids: Vec<ObjectID>,
+
         /// Address to bind the RPC server to
         #[arg(long, default_value = DEFAULT_RPC_ADDR)]
         rpc_addr: SocketAddr,
@@ -57,7 +68,7 @@ enum Command {
     /// Advance the network clock by a given duration
     AdvanceClock {
         /// RPC server address to connect to
-        #[arg(long, default_value = DEFAULT_RPC_ADDR)]
+        #[arg(long, default_value = DEFAULT_RPC_ADDR, value_parser = parse_rpc_addr)]
         rpc_addr: Url,
 
         /// Duration in milliseconds to advance the clock (defaults to 1)
@@ -68,14 +79,14 @@ enum Command {
     /// Seal pending transactions into a new checkpoint
     AdvanceCheckpoint {
         /// RPC server address to connect to
-        #[arg(long, default_value = DEFAULT_RPC_ADDR)]
+        #[arg(long, default_value = DEFAULT_RPC_ADDR, value_parser = parse_rpc_addr)]
         rpc_addr: Url,
     },
 
     /// Get the current status of the forked network
     Status {
         /// RPC server address to connect to
-        #[arg(long, default_value = DEFAULT_RPC_ADDR)]
+        #[arg(long, default_value = DEFAULT_RPC_ADDR, value_parser = parse_rpc_addr)]
         rpc_addr: Url,
     },
 }
@@ -117,12 +128,18 @@ impl Cli {
                 network,
                 checkpoint,
                 data_dir,
+                addresses,
+                object_ids,
                 rpc_addr,
             } => {
                 cmd_start(
                     network,
                     checkpoint,
                     data_dir,
+                    SeedInput {
+                        addresses,
+                        object_ids,
+                    },
                     rpc_addr,
                     self.json_output,
                     version,
@@ -156,6 +173,7 @@ async fn cmd_start(
     node: Node,
     checkpoint: Option<u64>,
     data_dir: Option<PathBuf>,
+    seed_input: SeedInput,
     rpc_addr: SocketAddr,
     json_output: bool,
     version: &'static str,
@@ -171,7 +189,7 @@ async fn cmd_start(
     };
 
     let (context, subscription_handle) =
-        crate::startup::initialize(node, checkpoint, version, data_dir).await?;
+        crate::startup::initialize(node, checkpoint, version, data_dir, seed_input).await?;
 
     let output = StartOutput {
         network: network_name.clone(),
@@ -201,7 +219,7 @@ async fn cmd_advance_clock(
     duration_ms: Option<u64>,
     json_output: bool,
 ) -> Result<()> {
-    let mut client = ForkingServiceClient::connect(format!("http://{rpc_addr}")).await?;
+    let mut client = ForkingServiceClient::connect(rpc_endpoint(&rpc_addr)).await?;
     let resp = client
         .advance_clock(AdvanceClockRequest { duration_ms })
         .await?
@@ -217,7 +235,7 @@ async fn cmd_advance_clock(
 }
 
 async fn cmd_advance_checkpoint(rpc_addr: Url, json_output: bool) -> Result<()> {
-    let mut client = ForkingServiceClient::connect(format!("http://{rpc_addr}")).await?;
+    let mut client = ForkingServiceClient::connect(rpc_endpoint(&rpc_addr)).await?;
     let resp = client
         .advance_checkpoint(AdvanceCheckpointRequest {})
         .await?
@@ -233,7 +251,7 @@ async fn cmd_advance_checkpoint(rpc_addr: Url, json_output: bool) -> Result<()> 
 }
 
 async fn cmd_status(rpc_addr: Url, json_output: bool) -> Result<()> {
-    let mut client = ForkingServiceClient::connect(format!("http://{rpc_addr}")).await?;
+    let mut client = ForkingServiceClient::connect(rpc_endpoint(&rpc_addr)).await?;
     let resp = client.get_status(GetStatusRequest {}).await?.into_inner();
 
     let output = StatusOutput {
@@ -245,6 +263,27 @@ async fn cmd_status(rpc_addr: Url, json_output: bool) -> Result<()> {
     };
     print_output(&output, json_output);
     Ok(())
+}
+
+fn parse_rpc_addr(rpc_addr: &str) -> std::result::Result<Url, String> {
+    let endpoint = if rpc_addr.contains("://") {
+        rpc_addr.to_owned()
+    } else {
+        format!("http://{rpc_addr}")
+    };
+    let url =
+        Url::parse(&endpoint).map_err(|err| format!("invalid --rpc-addr `{rpc_addr}`: {err}"))?;
+    if !matches!(url.scheme(), "http" | "https") {
+        return Err(format!(
+            "--rpc-addr must use http or https, got `{}`",
+            url.scheme(),
+        ));
+    }
+    Ok(url)
+}
+
+fn rpc_endpoint(rpc_addr: &Url) -> String {
+    rpc_addr.as_str().to_owned()
 }
 
 fn format_timestamp(ms: u64) -> String {
@@ -302,5 +341,45 @@ impl std::fmt::Display for StatusOutput {
             self.timestamp_ms, self.timestamp,
         )?;
         write!(f, "  forked at checkpoint: {}", self.forked_at_checkpoint)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn client_commands_accept_default_rpc_addr() {
+        for command in ["advance-clock", "advance-checkpoint", "status"] {
+            let cli = Cli::try_parse_from(["sui-forking", command]).unwrap();
+            let rpc_addr = match cli.command {
+                Command::AdvanceClock { rpc_addr, .. }
+                | Command::AdvanceCheckpoint { rpc_addr }
+                | Command::Status { rpc_addr } => rpc_addr,
+                Command::Start { .. } => panic!("expected client command"),
+            };
+
+            assert_eq!(rpc_addr, Url::parse("http://127.0.0.1:9000").unwrap());
+            assert_eq!(rpc_endpoint(&rpc_addr), "http://127.0.0.1:9000/");
+        }
+    }
+
+    #[test]
+    fn rpc_endpoint_accepts_bare_address_or_full_url() {
+        assert_eq!(
+            parse_rpc_addr("127.0.0.1:9001").unwrap(),
+            Url::parse("http://127.0.0.1:9001").unwrap(),
+        );
+        assert_eq!(
+            parse_rpc_addr("http://127.0.0.1:9001").unwrap(),
+            Url::parse("http://127.0.0.1:9001").unwrap(),
+        );
+    }
+
+    #[test]
+    fn rpc_endpoint_rejects_non_http_schemes() {
+        let err = parse_rpc_addr("ftp://127.0.0.1:9000").unwrap_err();
+
+        assert!(err.contains("must use http or https"));
     }
 }

--- a/crates/sui-forking/src/filesystem.rs
+++ b/crates/sui-forking/src/filesystem.rs
@@ -22,6 +22,7 @@
 //!             - data                   (BCS-encoded Transaction envelope)
 //!             - effects                (BCS-encoded TransactionEffects)
 //!             - events                 (BCS-encoded TransactionEvents)
+//!     - seed_manifest.json             (JSON seed metadata for initial owned-object index)
 
 use std::fs;
 use std::io::ErrorKind;
@@ -55,6 +56,7 @@ use sui_types::transaction::Transaction;
 use sui_types::transaction::VerifiedTransaction;
 
 use crate::Node;
+use crate::seed::SeedManifest;
 
 /// Directory name appended to the configured filesystem store root.
 const DATA_STORE_DIR: &str = ".forking_data_store";
@@ -86,6 +88,8 @@ const CHECKPOINT_CONTENTS_DIR: &str = "contents";
 const CHECKPOINT_DIGEST_INDEX_FILE: &str = "digest_index";
 /// Marker file for the latest checkpoint sequence known to the store.
 const LATEST_FILE: &str = "latest";
+/// JSON file containing immutable pre-fork seed metadata.
+const SEED_MANIFEST_FILE: &str = "seed_manifest.json";
 
 /// Current-state removal kind for an object affected by local execution.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -208,6 +212,11 @@ impl FilesystemStore {
     /// Return the file path for the owned-object index.
     fn owned_objects_index_path(&self) -> PathBuf {
         self.indices_dir().join(OWNED_OBJECTS_INDEX_FILE)
+    }
+
+    /// Return the path to the seed manifest for this fork directory.
+    pub(crate) fn seed_manifest_path(&self) -> PathBuf {
+        self.root.join(SEED_MANIFEST_FILE)
     }
 
     /// Persist a verified transaction to disk under `transactions/{digest}/data`. The underlying
@@ -564,6 +573,49 @@ impl FilesystemStore {
             .with_context(|| format!("Failed to write index file: {}", tmp_path.display()))?;
         fs::rename(&tmp_path, &path)
             .with_context(|| format!("Failed to replace owned-object index: {}", path.display()))
+    }
+
+    /// Return whether the immutable seed manifest exists for this fork directory.
+    pub(crate) fn seed_manifest_exists(&self) -> bool {
+        self.seed_manifest_path().exists()
+    }
+
+    /// Read the immutable seed manifest from disk.
+    pub(crate) fn read_seed_manifest(&self) -> anyhow::Result<SeedManifest> {
+        let path = self.seed_manifest_path();
+        let bytes =
+            fs::read(&path).with_context(|| format!("Failed to read file: {}", path.display()))?;
+        serde_json::from_slice(&bytes)
+            .with_context(|| format!("Failed to deserialize seed manifest: {}", path.display()))
+    }
+
+    /// Write the immutable seed manifest, failing if one already exists.
+    pub(crate) fn write_seed_manifest(&self, manifest: &SeedManifest) -> anyhow::Result<()> {
+        let path = self.seed_manifest_path();
+        if path.exists() {
+            bail!("Seed manifest already exists: {}", path.display());
+        }
+        if let Some(parent) = path.parent().filter(|p| !p.as_os_str().is_empty()) {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("Failed to create directory: {}", parent.display()))?;
+        }
+
+        let tmp_path = path.with_extension("json.tmp");
+        let bytes = serde_json::to_vec_pretty(manifest)
+            .with_context(|| format!("Failed to serialize seed manifest: {}", path.display()))?;
+        fs::write(&tmp_path, bytes)
+            .with_context(|| format!("Failed to write seed manifest: {}", tmp_path.display()))?;
+        if path.exists() {
+            fs::remove_file(&tmp_path).with_context(|| {
+                format!(
+                    "Failed to remove temporary seed manifest: {}",
+                    tmp_path.display()
+                )
+            })?;
+            bail!("Seed manifest already exists: {}", path.display());
+        }
+        fs::rename(&tmp_path, &path)
+            .with_context(|| format!("Failed to replace seed manifest: {}", path.display()))
     }
 
     /// Get the highest checkpoint sequence number available on disk.

--- a/crates/sui-forking/src/filesystem.rs
+++ b/crates/sui-forking/src/filesystem.rs
@@ -555,7 +555,10 @@ impl FilesystemStore {
     /// Persist the owned-object index to disk. The entire index is rewritten on each update, but
     /// this is expected to be small and updated infrequently enough that this should not be a
     /// bottleneck.
-    fn write_owned_object_entries(&self, entries: &[OwnedObjectEntry]) -> anyhow::Result<()> {
+    pub(crate) fn write_owned_object_entries(
+        &self,
+        entries: &[OwnedObjectEntry],
+    ) -> anyhow::Result<()> {
         let path = self.owned_objects_index_path();
         if let Some(parent) = path.parent().filter(|p| !p.as_os_str().is_empty()) {
             fs::create_dir_all(parent)
@@ -573,6 +576,11 @@ impl FilesystemStore {
             .with_context(|| format!("Failed to write index file: {}", tmp_path.display()))?;
         fs::rename(&tmp_path, &path)
             .with_context(|| format!("Failed to replace owned-object index: {}", path.display()))
+    }
+
+    /// Return whether the durable owned-object index has already been initialized.
+    pub(crate) fn owned_object_index_exists(&self) -> bool {
+        self.owned_objects_index_path().exists()
     }
 
     /// Return whether the immutable seed manifest exists for this fork directory.

--- a/crates/sui-forking/src/gql/client.rs
+++ b/crates/sui-forking/src/gql/client.rs
@@ -22,6 +22,7 @@ use crate::ObjectKey;
 use crate::ObjectRead;
 use crate::TransactionInfo;
 use crate::TransactionRead;
+use crate::gql::AddressOwnedObject;
 use crate::gql::queries;
 
 macro_rules! block_on {
@@ -85,29 +86,6 @@ impl GraphQLClient {
         Self::run_query_internal(&self.client, &self.rpc, &self.version, operation).await
     }
 
-    pub(crate) async fn run_raw_query<T>(
-        &self,
-        query: &str,
-        variables: serde_json::Value,
-    ) -> Result<GraphQlResponse<T>, Error>
-    where
-        T: serde::de::DeserializeOwned,
-    {
-        self.client
-            .post(self.rpc.clone())
-            .header(USER_AGENT, format!("sui-forking-v{}", self.version))
-            .json(&serde_json::json!({
-                "query": query,
-                "variables": variables,
-            }))
-            .send()
-            .await
-            .context("Failed to send raw GQL query")?
-            .json::<GraphQlResponse<T>>()
-            .await
-            .context("Failed to read response in raw GQL query")
-    }
-
     async fn run_query_internal<T, V>(
         client: &reqwest::Client,
         rpc: &reqwest::Url,
@@ -150,6 +128,16 @@ impl TransactionRead for GraphQLClient {
 }
 
 impl GraphQLClient {
+    /// Fetch address-owned object metadata at a checkpoint, paginating through
+    /// the checkpoint-scoped ownership connection.
+    pub(crate) async fn get_address_owned_objects_at_checkpoint(
+        &self,
+        address: SuiAddress,
+        checkpoint: CheckpointSequenceNumber,
+    ) -> Result<Vec<AddressOwnedObject>, Error> {
+        queries::address_owned_objects_query::query(address, checkpoint, self).await
+    }
+
     /// Get the latest checkpoint sequence number from GraphQL RPC.
     pub async fn get_latest_checkpoint_sequence_number(
         &self,

--- a/crates/sui-forking/src/gql/client.rs
+++ b/crates/sui-forking/src/gql/client.rs
@@ -85,6 +85,29 @@ impl GraphQLClient {
         Self::run_query_internal(&self.client, &self.rpc, &self.version, operation).await
     }
 
+    pub(crate) async fn run_raw_query<T>(
+        &self,
+        query: &str,
+        variables: serde_json::Value,
+    ) -> Result<GraphQlResponse<T>, Error>
+    where
+        T: serde::de::DeserializeOwned,
+    {
+        self.client
+            .post(self.rpc.clone())
+            .header(USER_AGENT, format!("sui-forking-v{}", self.version))
+            .json(&serde_json::json!({
+                "query": query,
+                "variables": variables,
+            }))
+            .send()
+            .await
+            .context("Failed to send raw GQL query")?
+            .json::<GraphQlResponse<T>>()
+            .await
+            .context("Failed to read response in raw GQL query")
+    }
+
     async fn run_query_internal<T, V>(
         client: &reqwest::Client,
         rpc: &reqwest::Url,

--- a/crates/sui-forking/src/gql/client.rs
+++ b/crates/sui-forking/src/gql/client.rs
@@ -24,6 +24,7 @@ use crate::TransactionInfo;
 use crate::TransactionRead;
 use crate::gql::AddressOwnedObject;
 use crate::gql::queries;
+use sui_types::base_types::SuiAddress;
 
 macro_rules! block_on {
     ($expr:expr) => {{

--- a/crates/sui-forking/src/gql/mod.rs
+++ b/crates/sui-forking/src/gql/mod.rs
@@ -5,3 +5,4 @@ mod client;
 mod queries;
 
 pub use client::GraphQLClient;
+pub(crate) use queries::address_owned_objects_query::AddressOwnedObject;

--- a/crates/sui-forking/src/gql/queries.rs
+++ b/crates/sui-forking/src/gql/queries.rs
@@ -221,6 +221,496 @@ pub(crate) mod available_range_query {
     }
 }
 
+pub(crate) mod address_owned_objects_query {
+    use anyhow::Context;
+    use anyhow::Error;
+    use anyhow::anyhow;
+    use cynic::QueryBuilder as _;
+    use move_core_types::language_storage::StructTag;
+    use sui_types::SUI_FRAMEWORK_ADDRESS;
+    use sui_types::base_types::ObjectID;
+    use sui_types::base_types::SequenceNumber;
+    use sui_types::base_types::SuiAddress as SuiAddressType;
+    use sui_types::digests::ObjectDigest;
+    use sui_types::messages_checkpoint::CheckpointSequenceNumber;
+
+    use crate::gql::GraphQLClient;
+    use crate::gql::queries::schema;
+
+    const PAGE_SIZE: i32 = 50;
+
+    /// Lightweight metadata for an address-owned object at a checkpoint.
+    #[derive(Clone, Debug, Eq, PartialEq)]
+    pub(crate) struct AddressOwnedObject {
+        pub(crate) object_id: ObjectID,
+        pub(crate) version: SequenceNumber,
+        pub(crate) digest: ObjectDigest,
+        pub(crate) owner: SuiAddressType,
+        pub(crate) object_type: StructTag,
+        pub(crate) balance: Option<u64>,
+    }
+
+    #[derive(cynic::QueryVariables)]
+    pub(crate) struct AddressObjectsArgs {
+        pub sequence_number: Option<u64>,
+        pub address: SuiAddress,
+        pub first: Option<i32>,
+        pub after: Option<String>,
+    }
+
+    #[derive(cynic::QueryFragment)]
+    #[cynic(
+        variables = "AddressObjectsArgs",
+        graphql_type = "Query",
+        schema_module = "crate::gql::queries::schema"
+    )]
+    pub(crate) struct Query {
+        #[arguments(sequenceNumber: $sequence_number)]
+        checkpoint: Option<Checkpoint>,
+    }
+
+    #[derive(cynic::QueryFragment)]
+    #[cynic(
+        variables = "AddressObjectsArgs",
+        schema_module = "crate::gql::queries::schema"
+    )]
+    pub(crate) struct Checkpoint {
+        query: Option<ScopedQuery>,
+    }
+
+    #[derive(cynic::QueryFragment)]
+    #[cynic(
+        variables = "AddressObjectsArgs",
+        graphql_type = "Query",
+        schema_module = "crate::gql::queries::schema"
+    )]
+    pub(crate) struct ScopedQuery {
+        #[arguments(address: $address)]
+        address: Option<Address>,
+    }
+
+    #[derive(cynic::QueryFragment)]
+    #[cynic(
+        variables = "AddressObjectsArgs",
+        graphql_type = "Address",
+        schema_module = "crate::gql::queries::schema"
+    )]
+    pub(crate) struct Address {
+        #[arguments(first: $first, after: $after)]
+        objects: Option<MoveObjectConnection>,
+    }
+
+    #[derive(cynic::QueryFragment)]
+    #[cynic(
+        variables = "AddressObjectsArgs",
+        schema_module = "crate::gql::queries::schema"
+    )]
+    pub(crate) struct MoveObjectConnection {
+        nodes: Vec<MoveObject>,
+        page_info: PageInfo,
+    }
+
+    #[derive(cynic::QueryFragment)]
+    #[cynic(schema_module = "crate::gql::queries::schema")]
+    pub(crate) struct PageInfo {
+        has_next_page: bool,
+        end_cursor: Option<String>,
+    }
+
+    #[derive(cynic::QueryFragment)]
+    #[cynic(schema_module = "crate::gql::queries::schema")]
+    pub(crate) struct MoveObject {
+        address: SuiAddress,
+        version: Option<u64>,
+        digest: Option<String>,
+        owner: Option<Owner>,
+        contents: Option<MoveValue>,
+    }
+
+    #[derive(cynic::InlineFragments)]
+    #[cynic(schema_module = "crate::gql::queries::schema")]
+    pub(crate) enum Owner {
+        AddressOwner(AddressOwner),
+        #[cynic(fallback)]
+        Other,
+    }
+
+    #[derive(cynic::QueryFragment)]
+    #[cynic(schema_module = "crate::gql::queries::schema")]
+    pub(crate) struct AddressOwner {
+        address: Option<OwnerAddress>,
+    }
+
+    #[derive(cynic::QueryFragment)]
+    #[cynic(
+        graphql_type = "Address",
+        schema_module = "crate::gql::queries::schema"
+    )]
+    pub(crate) struct OwnerAddress {
+        address: SuiAddress,
+    }
+
+    #[derive(cynic::QueryFragment)]
+    #[cynic(schema_module = "crate::gql::queries::schema")]
+    pub(crate) struct MoveValue {
+        #[cynic(rename = "type")]
+        object_type: Option<MoveType>,
+        json: Option<Json>,
+    }
+
+    #[derive(cynic::QueryFragment)]
+    #[cynic(schema_module = "crate::gql::queries::schema")]
+    pub(crate) struct MoveType {
+        repr: String,
+    }
+
+    #[derive(cynic::Scalar, Debug, Clone)]
+    #[cynic(graphql_type = "JSON")]
+    pub(crate) struct Json(pub serde_json::Value);
+
+    #[derive(cynic::Scalar, Debug, Clone)]
+    #[cynic(graphql_type = "SuiAddress")]
+    pub(crate) struct SuiAddress(pub String);
+
+    pub(crate) async fn query(
+        address: SuiAddressType,
+        checkpoint: CheckpointSequenceNumber,
+        client: &GraphQLClient,
+    ) -> Result<Vec<AddressOwnedObject>, Error> {
+        let mut entries = Vec::new();
+        let mut cursor = None;
+
+        loop {
+            let operation = Query::build(AddressObjectsArgs {
+                sequence_number: Some(checkpoint),
+                address: SuiAddress(address.to_string()),
+                first: Some(PAGE_SIZE),
+                after: cursor,
+            });
+            let response = client
+                .run_query(&operation)
+                .await
+                .with_context(|| format!("failed to query owned objects for {address}"))?;
+
+            let data = response.data.ok_or_else(|| {
+                anyhow!(
+                    "missing data in address objects query response for {address}: {:?}",
+                    response.errors,
+                )
+            })?;
+            let checkpoint_data = data
+                .checkpoint
+                .ok_or_else(|| anyhow!("checkpoint {checkpoint} not found for address seeding"))?;
+            let scoped_query = checkpoint_data
+                .query
+                .ok_or_else(|| anyhow!("missing checkpoint-scoped query for address seeding"))?;
+            let Some(address_data) = scoped_query.address else {
+                return Ok(entries);
+            };
+            let Some(objects) = address_data.objects else {
+                return Ok(entries);
+            };
+
+            for node in objects.nodes {
+                if let Some(entry) = decode_move_object(node)? {
+                    entries.push(entry);
+                }
+            }
+
+            if !objects.page_info.has_next_page {
+                break;
+            }
+            cursor = objects.page_info.end_cursor;
+        }
+
+        Ok(entries)
+    }
+
+    fn coin_balance_from_json(
+        object_type: &StructTag,
+        json: Option<&serde_json::Value>,
+    ) -> Option<u64> {
+        if object_type.address != SUI_FRAMEWORK_ADDRESS
+            || object_type.module.as_ident_str().as_str() != "coin"
+            || object_type.name.as_ident_str().as_str() != "Coin"
+        {
+            return None;
+        }
+
+        let balance = json?.get("balance")?;
+        balance
+            .as_u64()
+            .or_else(|| balance.as_str().and_then(|value| value.parse().ok()))
+    }
+
+    fn decode_move_object(node: MoveObject) -> Result<Option<AddressOwnedObject>, Error> {
+        let owner = match node.owner {
+            Some(Owner::AddressOwner(owner)) => owner
+                .address
+                .ok_or_else(|| anyhow!("address-owned seed entry is missing owner address"))?
+                .address
+                .0
+                .parse::<SuiAddressType>()
+                .with_context(|| format!("invalid seed owner for object {}", node.address.0))?,
+            _ => return Ok(None),
+        };
+        let contents = node
+            .contents
+            .ok_or_else(|| anyhow!("seed object {} is missing contents", node.address.0))?;
+        let object_type = contents
+            .object_type
+            .ok_or_else(|| anyhow!("seed object {} is missing type", node.address.0))?
+            .repr
+            .parse::<StructTag>()
+            .with_context(|| format!("invalid seed object type for {}", node.address.0))?;
+        let object_id = node
+            .address
+            .0
+            .parse::<ObjectID>()
+            .with_context(|| format!("invalid seed object id {}", node.address.0))?;
+        let digest = node
+            .digest
+            .ok_or_else(|| anyhow!("seed object {object_id} is missing digest"))?
+            .parse::<ObjectDigest>()
+            .with_context(|| format!("invalid seed object digest for {object_id}"))?;
+        let version = node
+            .version
+            .ok_or_else(|| anyhow!("seed object {object_id} is missing version"))?;
+        let balance =
+            coin_balance_from_json(&object_type, contents.json.as_ref().map(|json| &json.0));
+
+        Ok(Some(AddressOwnedObject {
+            object_id,
+            version: SequenceNumber::from_u64(version),
+            digest,
+            owner,
+            object_type,
+            balance,
+        }))
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use sui_types::base_types::ObjectID;
+        use sui_types::gas_coin::GasCoin;
+        use sui_types::object::Object;
+        use sui_types::object::Owner as SuiOwner;
+        use wiremock::Mock;
+        use wiremock::MockServer;
+        use wiremock::ResponseTemplate;
+        use wiremock::matchers::body_partial_json;
+        use wiremock::matchers::method;
+        use wiremock::matchers::path;
+
+        use super::*;
+        use crate::Node;
+
+        fn address_objects_response(
+            nodes: Vec<serde_json::Value>,
+            has_next_page: bool,
+            end_cursor: Option<&str>,
+        ) -> serde_json::Value {
+            serde_json::json!({
+                "data": {
+                    "checkpoint": {
+                        "query": {
+                            "address": {
+                                "objects": {
+                                    "nodes": nodes,
+                                    "pageInfo": {
+                                        "hasNextPage": has_next_page,
+                                        "endCursor": end_cursor,
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            })
+        }
+
+        fn missing_address_response() -> serde_json::Value {
+            serde_json::json!({
+                "data": {
+                    "checkpoint": {
+                        "query": {
+                            "address": null
+                        }
+                    }
+                }
+            })
+        }
+
+        fn missing_objects_response() -> serde_json::Value {
+            serde_json::json!({
+                "data": {
+                    "checkpoint": {
+                        "query": {
+                            "address": {
+                                "objects": null
+                            }
+                        }
+                    }
+                }
+            })
+        }
+
+        fn address_owned_node(object: &Object, owner: SuiAddressType) -> serde_json::Value {
+            serde_json::json!({
+                "address": object.id().to_string(),
+                "version": object.version().value(),
+                "digest": object.digest().to_string(),
+                "owner": {
+                    "__typename": "AddressOwner",
+                    "address": { "address": owner.to_string() },
+                },
+                "contents": {
+                    "type": { "repr": object.struct_tag().unwrap().to_canonical_string(true) },
+                    "json": { "balance": "123" },
+                }
+            })
+        }
+
+        fn consensus_owned_node(object: &Object, owner: SuiAddressType) -> serde_json::Value {
+            serde_json::json!({
+                "address": object.id().to_string(),
+                "version": object.version().value(),
+                "digest": object.digest().to_string(),
+                "owner": {
+                    "__typename": "ConsensusAddressOwner",
+                    "address": { "address": owner.to_string() },
+                },
+                "contents": {
+                    "type": { "repr": object.struct_tag().unwrap().to_canonical_string(true) },
+                    "json": { "balance": "456" },
+                }
+            })
+        }
+
+        #[test]
+        fn coin_balance_from_json_reads_string_balance() {
+            let ty = GasCoin::type_();
+            let json = serde_json::json!({
+                "id": "0x1",
+                "balance": "42",
+            });
+
+            assert_eq!(coin_balance_from_json(&ty, Some(&json)), Some(42));
+        }
+
+        #[tokio::test]
+        async fn query_paginates_and_skips_non_address_owned_objects() {
+            let server = MockServer::start().await;
+            let owner = SuiAddressType::random_for_testing_only();
+            let first = Object::with_id_owner_version_for_testing(
+                ObjectID::random(),
+                SequenceNumber::from_u64(7),
+                SuiOwner::AddressOwner(owner),
+            );
+            let second = Object::with_id_owner_version_for_testing(
+                ObjectID::random(),
+                SequenceNumber::from_u64(8),
+                SuiOwner::ConsensusAddressOwner {
+                    start_version: SequenceNumber::from_u64(8),
+                    owner,
+                },
+            );
+
+            Mock::given(method("POST"))
+                .and(path("/"))
+                .and(body_partial_json(serde_json::json!({
+                    "variables": { "after": null }
+                })))
+                .respond_with(
+                    ResponseTemplate::new(200).set_body_json(address_objects_response(
+                        vec![address_owned_node(&first, owner)],
+                        true,
+                        Some("cursor-1"),
+                    )),
+                )
+                .mount(&server)
+                .await;
+            Mock::given(method("POST"))
+                .and(path("/"))
+                .and(body_partial_json(serde_json::json!({
+                    "variables": { "after": "cursor-1" }
+                })))
+                .respond_with(
+                    ResponseTemplate::new(200).set_body_json(address_objects_response(
+                        vec![consensus_owned_node(&second, owner)],
+                        false,
+                        None,
+                    )),
+                )
+                .mount(&server)
+                .await;
+
+            let gql = GraphQLClient::new(Node::Custom(server.uri()), "test")
+                .expect("graphql client should build");
+            let entries = query(owner, 10, &gql)
+                .await
+                .expect("address seed should resolve");
+
+            assert_eq!(entries.len(), 1);
+            assert_eq!(entries[0].object_id, first.id());
+            assert_eq!(entries[0].version, first.version());
+            assert_eq!(entries[0].balance, Some(123));
+
+            let requests = server
+                .received_requests()
+                .await
+                .expect("wiremock should record requests");
+            let request_body: serde_json::Value = requests[0]
+                .body_json()
+                .expect("request body should be json");
+            let query = request_body
+                .get("query")
+                .and_then(serde_json::Value::as_str)
+                .expect("query string should be present");
+            assert!(query.contains("address(address: $address)"));
+            assert!(query.contains("... on AddressOwner"));
+            assert!(!query.contains("ConsensusAddressOwner"));
+        }
+
+        #[tokio::test]
+        async fn query_returns_empty_for_missing_address_or_objects() {
+            let owner = SuiAddressType::random_for_testing_only();
+
+            let server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .and(path("/"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(missing_address_response()))
+                .mount(&server)
+                .await;
+            let gql = GraphQLClient::new(Node::Custom(server.uri()), "test")
+                .expect("graphql client should build");
+
+            assert!(
+                query(owner, 10, &gql)
+                    .await
+                    .expect("missing address should resolve")
+                    .is_empty()
+            );
+
+            let server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .and(path("/"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(missing_objects_response()))
+                .mount(&server)
+                .await;
+            let gql = GraphQLClient::new(Node::Custom(server.uri()), "test")
+                .expect("graphql client should build");
+
+            assert!(
+                query(owner, 10, &gql)
+                    .await
+                    .expect("missing objects should resolve")
+                    .is_empty()
+            );
+        }
+    }
+}
+
 pub(crate) mod events_query {
     use super::*;
     use sui_types::effects::TransactionEvents;

--- a/crates/sui-forking/src/lib.rs
+++ b/crates/sui-forking/src/lib.rs
@@ -12,6 +12,7 @@ mod gql;
 mod node;
 mod proto;
 mod rpc;
+pub(crate) mod seed;
 pub mod startup;
 pub mod store;
 
@@ -19,6 +20,7 @@ pub use gql::GraphQLClient;
 pub use node::Node;
 pub use proto::forking::forking_service_client::ForkingServiceClient;
 pub use proto::forking::{AdvanceCheckpointRequest, AdvanceClockRequest, GetStatusRequest};
+pub use seed::SeedInput;
 pub use store::DataStore;
 
 use anyhow::{Error, Result};

--- a/crates/sui-forking/src/seed.rs
+++ b/crates/sui-forking/src/seed.rs
@@ -12,9 +12,11 @@ use std::collections::BTreeSet;
 use anyhow::Error;
 use anyhow::bail;
 use itertools::Itertools as _;
-use move_core_types::language_storage::StructTag;
 use serde::Deserialize;
 use serde::Serialize;
+use tracing::warn;
+
+use move_core_types::language_storage::StructTag;
 use sui_types::base_types::ObjectID;
 use sui_types::base_types::SequenceNumber;
 use sui_types::base_types::SuiAddress;
@@ -22,7 +24,6 @@ use sui_types::digests::ObjectDigest;
 use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 use sui_types::object::Object;
 use sui_types::object::Owner;
-use tracing::warn;
 
 use crate::DataStore;
 use crate::ObjectKey;

--- a/crates/sui-forking/src/seed.rs
+++ b/crates/sui-forking/src/seed.rs
@@ -1,0 +1,721 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Seed resolution for the initial owned-object index.
+//!
+//! Address seeds resolve lightweight object metadata at the fork checkpoint, while
+//! explicit object seeds also cache the full object BCS through the existing object query path.
+
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+
+use anyhow::Context as _;
+use anyhow::Error;
+use anyhow::anyhow;
+use anyhow::bail;
+use itertools::Itertools as _;
+use serde::Deserialize;
+use serde::Serialize;
+use serde_json::Value;
+use serde_json::json;
+use tracing::warn;
+
+use move_core_types::language_storage::StructTag;
+use sui_types::SUI_FRAMEWORK_ADDRESS;
+use sui_types::base_types::ObjectID;
+use sui_types::base_types::SequenceNumber;
+use sui_types::base_types::SuiAddress;
+use sui_types::digests::ObjectDigest;
+use sui_types::messages_checkpoint::CheckpointSequenceNumber;
+use sui_types::object::Object;
+use sui_types::object::Owner;
+
+use crate::DataStore;
+use crate::ObjectKey;
+use crate::ObjectRead as _;
+use crate::VersionQuery;
+use crate::filesystem::OwnedObjectEntry;
+use crate::gql::GraphQLClient;
+
+const ADDRESS_OBJECTS_PAGE_SIZE: i32 = 50;
+const ADDRESS_OBJECTS_QUERY: &str = r#"
+query($sequenceNumber: UInt53, $address: SuiAddress!, $first: Int, $after: String) {
+  checkpoint(sequenceNumber: $sequenceNumber) {
+    query {
+      address(address: $address) {
+        objects(first: $first, after: $after) {
+          nodes {
+            address
+            version
+            digest
+            owner {
+              __typename
+              ... on AddressOwner { address { address } }
+            }
+            contents {
+              type { repr }
+              json
+            }
+          }
+          pageInfo { hasNextPage endCursor }
+        }
+      }
+    }
+  }
+}
+"#;
+
+/// CLI seed input before it has been resolved against the upstream chain.
+#[derive(Clone, Debug, Default)]
+pub struct SeedInput {
+    /// Addresses whose owned objects should seed the initial owned-object index.
+    pub addresses: Vec<SuiAddress>,
+    /// Object IDs to fetch and seed when they are address-owned.
+    pub object_ids: Vec<ObjectID>,
+}
+
+/// Object metadata used to seed the initial owned-object index.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub(crate) struct SeedEntry {
+    pub(crate) object_id: ObjectID,
+    pub(crate) version: SequenceNumber,
+    pub(crate) digest: ObjectDigest,
+    pub(crate) owner: SuiAddress,
+    pub(crate) object_type: StructTag,
+    pub(crate) balance: Option<u64>,
+}
+
+/// Durable manifest for pre-fork seed metadata.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub(crate) struct SeedManifest {
+    pub(crate) network: String,
+    pub(crate) checkpoint: CheckpointSequenceNumber,
+    pub(crate) entries: Vec<SeedEntry>,
+}
+
+#[derive(Deserialize)]
+struct AddressNode {
+    address: String,
+}
+
+#[derive(Deserialize)]
+struct AddressObjectsAddress {
+    objects: MoveObjectConnection,
+}
+
+#[derive(Deserialize)]
+struct AddressObjectsCheckpoint {
+    query: Option<AddressObjectsScopedQuery>,
+}
+
+#[derive(Deserialize)]
+struct AddressObjectsQuery {
+    checkpoint: Option<AddressObjectsCheckpoint>,
+}
+
+#[derive(Deserialize)]
+struct AddressObjectsScopedQuery {
+    address: Option<AddressObjectsAddress>,
+}
+
+#[derive(Deserialize)]
+struct MoveObjectConnection {
+    nodes: Vec<MoveObjectNode>,
+    #[serde(rename = "pageInfo")]
+    page_info: PageInfo,
+}
+
+#[derive(Deserialize)]
+struct MoveObjectContents {
+    #[serde(rename = "type")]
+    object_type: Option<MoveTypeNode>,
+    json: Option<Value>,
+}
+
+#[derive(Deserialize)]
+struct MoveObjectNode {
+    address: String,
+    version: Option<u64>,
+    digest: Option<String>,
+    owner: Option<OwnerNode>,
+    contents: Option<MoveObjectContents>,
+}
+
+#[derive(Deserialize)]
+struct MoveTypeNode {
+    repr: String,
+}
+
+#[derive(Deserialize)]
+struct OwnerNode {
+    #[serde(rename = "__typename")]
+    typename: String,
+    address: Option<AddressNode>,
+}
+
+#[derive(Deserialize)]
+struct PageInfo {
+    #[serde(rename = "hasNextPage")]
+    has_next_page: bool,
+    #[serde(rename = "endCursor")]
+    end_cursor: Option<String>,
+}
+
+impl MoveObjectNode {
+    fn try_into_seed_entry(self) -> Result<Option<SeedEntry>, Error> {
+        let Some(owner) = self.owner else {
+            return Ok(None);
+        };
+        if owner.typename != "AddressOwner" {
+            return Ok(None);
+        }
+        let owner = owner
+            .address
+            .ok_or_else(|| anyhow!("address-owned seed entry is missing owner address"))?
+            .address
+            .parse::<SuiAddress>()
+            .with_context(|| format!("invalid seed owner for object {}", self.address))?;
+        let contents = self
+            .contents
+            .ok_or_else(|| anyhow!("seed object {} is missing contents", self.address))?;
+        let object_type = contents
+            .object_type
+            .ok_or_else(|| anyhow!("seed object {} is missing type", self.address))?
+            .repr
+            .parse::<StructTag>()
+            .with_context(|| format!("invalid seed object type for {}", self.address))?;
+        let object_id = self
+            .address
+            .parse::<ObjectID>()
+            .with_context(|| format!("invalid seed object id {}", self.address))?;
+        let digest = self
+            .digest
+            .ok_or_else(|| anyhow!("seed object {object_id} is missing digest"))?
+            .parse::<ObjectDigest>()
+            .with_context(|| format!("invalid seed object digest for {object_id}"))?;
+        let version = self
+            .version
+            .ok_or_else(|| anyhow!("seed object {object_id} is missing version"))?;
+        let balance = coin_balance_from_json(&object_type, contents.json.as_ref());
+
+        Ok(Some(SeedEntry {
+            object_id,
+            version: SequenceNumber::from_u64(version),
+            digest,
+            owner,
+            object_type,
+            balance,
+        }))
+    }
+}
+
+impl SeedEntry {
+    fn from_object(object: &Object) -> Option<Self> {
+        let Owner::AddressOwner(owner) = &object.owner else {
+            return None;
+        };
+
+        Some(Self {
+            object_id: object.id(),
+            version: object.version(),
+            digest: object.digest(),
+            owner: *owner,
+            object_type: object.struct_tag()?,
+            balance: object.as_coin_maybe().map(|coin| coin.value()),
+        })
+    }
+}
+
+impl SeedInput {
+    /// Return true when no addresses or objects were requested for seeding.
+    pub fn is_empty(&self) -> bool {
+        self.addresses.is_empty() && self.object_ids.is_empty()
+    }
+}
+
+impl From<&SeedEntry> for OwnedObjectEntry {
+    fn from(entry: &SeedEntry) -> Self {
+        Self {
+            owner: entry.owner,
+            object_id: entry.object_id,
+            version: entry.version,
+            object_type: entry.object_type.clone(),
+            balance: entry.balance,
+        }
+    }
+}
+
+/// Reject seed inputs that would overwrite or reinterpret an existing manifest.
+pub(crate) fn ensure_seed_policy(data_store: &DataStore, input: &SeedInput) -> Result<(), Error> {
+    if data_store.local().seed_manifest_exists() && !input.is_empty() {
+        bail!(
+            "A seed manifest already exists at {}. To fork the same checkpoint with different seeds, use a different --data-dir.",
+            data_store.local().seed_manifest_path().display(),
+        );
+    }
+    Ok(())
+}
+
+/// Initialize the durable owned-object index from the seed manifest when it is safe to do so.
+pub(crate) fn initialize_owned_index_from_seed(
+    data_store: &DataStore,
+    manifest: &SeedManifest,
+) -> Result<(), Error> {
+    if data_store.local().owned_object_index_exists() {
+        return Ok(());
+    }
+
+    if let Some(checkpoint) = data_store.get_highest_verified_checkpoint()?
+        && checkpoint.data().sequence_number > data_store.forked_at_checkpoint()
+    {
+        bail!(
+            "seed manifest exists but the owned-object index is missing while local checkpoints have advanced past the fork checkpoint; refusing to rebuild stale seed state",
+        );
+    }
+
+    let entries: Vec<_> = manifest
+        .entries
+        .iter()
+        .map(OwnedObjectEntry::from)
+        .collect();
+    data_store.local().write_owned_object_entries(&entries)
+}
+
+/// Load or create the seed manifest for the current fork directory.
+pub(crate) async fn prepare_seed_manifest(
+    data_store: &DataStore,
+    network: String,
+    input: &SeedInput,
+) -> Result<Option<SeedManifest>, Error> {
+    if data_store.local().seed_manifest_exists() {
+        if !input.is_empty() {
+            bail!(
+                "A seed manifest already exists at {}. To fork the same checkpoint with different seeds, use a different --data-dir.",
+                data_store.local().seed_manifest_path().display(),
+            );
+        }
+        return data_store.local().read_seed_manifest().map(Some);
+    }
+
+    if input.is_empty() {
+        return Ok(None);
+    }
+
+    let manifest = resolve_seeds(input, network, data_store).await?;
+    data_store.local().write_seed_manifest(&manifest)?;
+    Ok(Some(manifest))
+}
+
+fn coin_balance_from_json(object_type: &StructTag, json: Option<&Value>) -> Option<u64> {
+    if object_type.address != SUI_FRAMEWORK_ADDRESS
+        || object_type.module.as_ident_str().as_str() != "coin"
+        || object_type.name.as_ident_str().as_str() != "Coin"
+    {
+        return None;
+    }
+
+    let balance = json?.get("balance")?;
+    balance
+        .as_u64()
+        .or_else(|| balance.as_str().and_then(|value| value.parse().ok()))
+}
+
+fn dedupe_addresses(addresses: &[SuiAddress]) -> Vec<SuiAddress> {
+    addresses
+        .iter()
+        .copied()
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
+fn dedupe_object_ids(object_ids: &[ObjectID]) -> Vec<ObjectID> {
+    object_ids
+        .iter()
+        .copied()
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
+fn ensure_address_seeding_available(
+    gql: &GraphQLClient,
+    checkpoint: CheckpointSequenceNumber,
+) -> Result<(), Error> {
+    let lowest_available = gql.get_lowest_available_checkpoint_objects()?;
+    if checkpoint < lowest_available {
+        bail!(
+            "address seeding is unavailable at checkpoint {checkpoint}; object ownership enumeration is available starting at checkpoint {lowest_available}. Use --object for older checkpoints.",
+        );
+    }
+    Ok(())
+}
+
+async fn resolve_address_seed(
+    gql: &GraphQLClient,
+    address: SuiAddress,
+    checkpoint: CheckpointSequenceNumber,
+) -> Result<Vec<SeedEntry>, Error> {
+    let mut entries = Vec::new();
+    let mut cursor = None;
+
+    loop {
+        let response = gql
+            .run_raw_query::<AddressObjectsQuery>(
+                ADDRESS_OBJECTS_QUERY,
+                json!({
+                    "sequenceNumber": checkpoint,
+                    "address": address.to_string(),
+                    "first": ADDRESS_OBJECTS_PAGE_SIZE,
+                    "after": cursor,
+                }),
+            )
+            .await
+            .with_context(|| format!("failed to query owned objects for {address}"))?;
+
+        let data = response.data.ok_or_else(|| {
+            anyhow!(
+                "missing data in address objects query response for {address}: {:?}",
+                response.errors,
+            )
+        })?;
+        let checkpoint_data = data
+            .checkpoint
+            .ok_or_else(|| anyhow!("checkpoint {checkpoint} not found for address seeding"))?;
+        let scoped_query = checkpoint_data
+            .query
+            .ok_or_else(|| anyhow!("missing checkpoint-scoped query for address seeding"))?;
+        let Some(address_data) = scoped_query.address else {
+            return Ok(entries);
+        };
+
+        for node in address_data.objects.nodes {
+            if let Some(entry) = node.try_into_seed_entry()? {
+                entries.push(entry);
+            }
+        }
+
+        if !address_data.objects.page_info.has_next_page {
+            break;
+        }
+        cursor = address_data.objects.page_info.end_cursor;
+    }
+
+    Ok(entries)
+}
+
+fn resolve_object_seeds(
+    data_store: &DataStore,
+    checkpoint: CheckpointSequenceNumber,
+    object_ids: &[ObjectID],
+) -> Result<Vec<SeedEntry>, Error> {
+    if object_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let keys: Vec<_> = object_ids
+        .iter()
+        .map(|object_id| ObjectKey {
+            object_id: *object_id,
+            version_query: VersionQuery::AtCheckpoint(checkpoint),
+        })
+        .collect();
+    let objects = data_store.gql().get_objects(&keys)?;
+    let mut entries = Vec::new();
+
+    for (object_id, object) in object_ids.iter().zip_eq(objects) {
+        let Some((object, _)) = object else {
+            warn!(%object_id, checkpoint, "object seed not found at fork checkpoint");
+            continue;
+        };
+        data_store.local().write_object(&object)?;
+        if let Some(entry) = SeedEntry::from_object(&object) {
+            entries.push(entry);
+        } else {
+            warn!(
+                %object_id,
+                checkpoint,
+                "object seed is not address-owned and will not be added to the owned-object index",
+            );
+        }
+    }
+
+    Ok(entries)
+}
+
+async fn resolve_seeds(
+    input: &SeedInput,
+    network: String,
+    data_store: &DataStore,
+) -> Result<SeedManifest, Error> {
+    let checkpoint = data_store.forked_at_checkpoint();
+    let mut entries = BTreeMap::new();
+
+    if !input.addresses.is_empty() {
+        ensure_address_seeding_available(data_store.gql(), checkpoint)?;
+    }
+
+    for address in dedupe_addresses(&input.addresses) {
+        let address_entries = resolve_address_seed(data_store.gql(), address, checkpoint).await?;
+        if address_entries.is_empty() {
+            warn!(%address, checkpoint, "address seed resolved no owned objects");
+        }
+        for entry in address_entries {
+            entries.insert(entry.object_id, entry);
+        }
+    }
+
+    let remaining_object_ids: Vec<_> = dedupe_object_ids(&input.object_ids)
+        .into_iter()
+        .filter(|object_id| !entries.contains_key(object_id))
+        .collect();
+    for entry in resolve_object_seeds(data_store, checkpoint, &remaining_object_ids)? {
+        entries.insert(entry.object_id, entry);
+    }
+
+    Ok(SeedManifest {
+        network,
+        checkpoint,
+        entries: entries.into_values().collect(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use fastcrypto::encoding::Base64 as FastCryptoBase64;
+    use fastcrypto::encoding::Encoding as _;
+    use sui_types::gas_coin::GasCoin;
+    use wiremock::Mock;
+    use wiremock::MockServer;
+    use wiremock::ResponseTemplate;
+    use wiremock::matchers::body_partial_json;
+    use wiremock::matchers::method;
+    use wiremock::matchers::path;
+
+    use super::*;
+    use crate::Node;
+
+    fn address_objects_response(
+        nodes: Vec<serde_json::Value>,
+        has_next_page: bool,
+        end_cursor: Option<&str>,
+    ) -> serde_json::Value {
+        json!({
+            "data": {
+                "checkpoint": {
+                    "query": {
+                        "address": {
+                            "objects": {
+                                "nodes": nodes,
+                                "pageInfo": {
+                                    "hasNextPage": has_next_page,
+                                    "endCursor": end_cursor,
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        })
+    }
+
+    fn address_owned_node(object: &Object, owner: SuiAddress) -> serde_json::Value {
+        json!({
+            "address": object.id().to_string(),
+            "version": object.version().value(),
+            "digest": object.digest().to_string(),
+            "owner": {
+                "__typename": "AddressOwner",
+                "address": { "address": owner.to_string() },
+            },
+            "contents": {
+                "type": { "repr": object.struct_tag().unwrap().to_canonical_string(true) },
+                "json": { "balance": "123" },
+            }
+        })
+    }
+
+    fn consensus_owned_node(object: &Object, owner: SuiAddress) -> serde_json::Value {
+        json!({
+            "address": object.id().to_string(),
+            "version": object.version().value(),
+            "digest": object.digest().to_string(),
+            "owner": {
+                "__typename": "ConsensusAddressOwner",
+                "address": { "address": owner.to_string() },
+            },
+            "contents": {
+                "type": { "repr": object.struct_tag().unwrap().to_canonical_string(true) },
+                "json": { "balance": "456" },
+            }
+        })
+    }
+
+    fn object_response_body(object: &Object) -> serde_json::Value {
+        json!({
+            "data": {
+                "multiGetObjects": [{
+                    "address": object.id().to_string(),
+                    "version": object.version().value(),
+                    "objectBcs": FastCryptoBase64::from_bytes(
+                        &bcs::to_bytes(object).expect("object should serialize"),
+                    )
+                    .encoded(),
+                }]
+            }
+        })
+    }
+
+    #[test]
+    fn coin_balance_from_json_reads_string_balance() {
+        let ty = GasCoin::type_();
+        let json = json!({
+            "id": "0x1",
+            "balance": "42",
+        });
+
+        assert_eq!(coin_balance_from_json(&ty, Some(&json)), Some(42));
+    }
+
+    #[test]
+    fn dedupe_object_ids_sorts_and_removes_duplicates() {
+        let first = ObjectID::random();
+        let second = ObjectID::random();
+        let deduped = dedupe_object_ids(&[second, first, second]);
+
+        assert_eq!(deduped.len(), 2);
+        assert!(deduped[0] < deduped[1]);
+    }
+
+    #[tokio::test]
+    async fn prepare_seed_manifest_does_not_write_manifest_when_resolution_fails() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let store =
+            DataStore::new_for_testing_with_remote(temp.path().to_path_buf(), server.uri(), 11);
+        let err = prepare_seed_manifest(
+            &store,
+            "custom".to_owned(),
+            &SeedInput {
+                addresses: vec![],
+                object_ids: vec![ObjectID::random()],
+            },
+        )
+        .await
+        .expect_err("seed resolution should fail");
+
+        assert!(
+            err.to_string().contains("Failed to read response")
+                || err.to_string().contains("Object bcs is None")
+                || err.to_string().contains("Missing data")
+        );
+        assert!(!store.local().seed_manifest_exists());
+    }
+
+    #[tokio::test]
+    async fn prepare_seed_manifest_fetches_explicit_object_and_caches_bcs() {
+        let server = MockServer::start().await;
+        let owner = SuiAddress::random_for_testing_only();
+        let object = Object::with_id_owner_version_for_testing(
+            ObjectID::random(),
+            SequenceNumber::from_u64(3),
+            Owner::AddressOwner(owner),
+        );
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(object_response_body(&object)))
+            .mount(&server)
+            .await;
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let store =
+            DataStore::new_for_testing_with_remote(temp.path().to_path_buf(), server.uri(), 11);
+        let manifest = prepare_seed_manifest(
+            &store,
+            "custom".to_owned(),
+            &SeedInput {
+                addresses: vec![],
+                object_ids: vec![object.id()],
+            },
+        )
+        .await
+        .expect("seed manifest should resolve")
+        .expect("manifest should exist");
+
+        assert_eq!(manifest.entries.len(), 1);
+        assert_eq!(manifest.entries[0].object_id, object.id());
+        assert_eq!(
+            store
+                .local()
+                .get_object_at_version(&object.id(), object.version().value())
+                .expect("local object lookup should not fail")
+                .unwrap(),
+            object,
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_address_seed_paginates_and_skips_consensus_owned_objects() {
+        let server = MockServer::start().await;
+        let owner = SuiAddress::random_for_testing_only();
+        let first = Object::with_id_owner_version_for_testing(
+            ObjectID::random(),
+            SequenceNumber::from_u64(7),
+            Owner::AddressOwner(owner),
+        );
+        let second = Object::with_id_owner_version_for_testing(
+            ObjectID::random(),
+            SequenceNumber::from_u64(8),
+            Owner::ConsensusAddressOwner {
+                start_version: SequenceNumber::from_u64(8),
+                owner,
+            },
+        );
+
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .and(body_partial_json(json!({
+                "variables": { "after": null }
+            })))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(address_objects_response(
+                    vec![address_owned_node(&first, owner)],
+                    true,
+                    Some("cursor-1"),
+                )),
+            )
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .and(body_partial_json(json!({
+                "variables": { "after": "cursor-1" }
+            })))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(address_objects_response(
+                    vec![consensus_owned_node(&second, owner)],
+                    false,
+                    None,
+                )),
+            )
+            .mount(&server)
+            .await;
+
+        let gql = GraphQLClient::new(Node::Custom(server.uri()), "test")
+            .expect("graphql client should build");
+        let entries = resolve_address_seed(&gql, owner, 10)
+            .await
+            .expect("address seed should resolve");
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].object_id, first.id());
+        assert_eq!(entries[0].version, first.version());
+        assert_eq!(entries[0].balance, Some(123));
+    }
+}

--- a/crates/sui-forking/src/seed.rs
+++ b/crates/sui-forking/src/seed.rs
@@ -9,19 +9,12 @@
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 
-use anyhow::Context as _;
 use anyhow::Error;
-use anyhow::anyhow;
 use anyhow::bail;
 use itertools::Itertools as _;
+use move_core_types::language_storage::StructTag;
 use serde::Deserialize;
 use serde::Serialize;
-use serde_json::Value;
-use serde_json::json;
-use tracing::warn;
-
-use move_core_types::language_storage::StructTag;
-use sui_types::SUI_FRAMEWORK_ADDRESS;
 use sui_types::base_types::ObjectID;
 use sui_types::base_types::SequenceNumber;
 use sui_types::base_types::SuiAddress;
@@ -29,41 +22,15 @@ use sui_types::digests::ObjectDigest;
 use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 use sui_types::object::Object;
 use sui_types::object::Owner;
+use tracing::warn;
 
 use crate::DataStore;
 use crate::ObjectKey;
 use crate::ObjectRead as _;
 use crate::VersionQuery;
 use crate::filesystem::OwnedObjectEntry;
+use crate::gql::AddressOwnedObject;
 use crate::gql::GraphQLClient;
-
-const ADDRESS_OBJECTS_PAGE_SIZE: i32 = 50;
-const ADDRESS_OBJECTS_QUERY: &str = r#"
-query($sequenceNumber: UInt53, $address: SuiAddress!, $first: Int, $after: String) {
-  checkpoint(sequenceNumber: $sequenceNumber) {
-    query {
-      address(address: $address) {
-        objects(first: $first, after: $after) {
-          nodes {
-            address
-            version
-            digest
-            owner {
-              __typename
-              ... on AddressOwner { address { address } }
-            }
-            contents {
-              type { repr }
-              json
-            }
-          }
-          pageInfo { hasNextPage endCursor }
-        }
-      }
-    }
-  }
-}
-"#;
 
 /// CLI seed input before it has been resolved against the upstream chain.
 #[derive(Clone, Debug, Default)]
@@ -93,122 +60,6 @@ pub(crate) struct SeedManifest {
     pub(crate) entries: Vec<SeedEntry>,
 }
 
-#[derive(Deserialize)]
-struct AddressNode {
-    address: String,
-}
-
-#[derive(Deserialize)]
-struct AddressObjectsAddress {
-    objects: MoveObjectConnection,
-}
-
-#[derive(Deserialize)]
-struct AddressObjectsCheckpoint {
-    query: Option<AddressObjectsScopedQuery>,
-}
-
-#[derive(Deserialize)]
-struct AddressObjectsQuery {
-    checkpoint: Option<AddressObjectsCheckpoint>,
-}
-
-#[derive(Deserialize)]
-struct AddressObjectsScopedQuery {
-    address: Option<AddressObjectsAddress>,
-}
-
-#[derive(Deserialize)]
-struct MoveObjectConnection {
-    nodes: Vec<MoveObjectNode>,
-    #[serde(rename = "pageInfo")]
-    page_info: PageInfo,
-}
-
-#[derive(Deserialize)]
-struct MoveObjectContents {
-    #[serde(rename = "type")]
-    object_type: Option<MoveTypeNode>,
-    json: Option<Value>,
-}
-
-#[derive(Deserialize)]
-struct MoveObjectNode {
-    address: String,
-    version: Option<u64>,
-    digest: Option<String>,
-    owner: Option<OwnerNode>,
-    contents: Option<MoveObjectContents>,
-}
-
-#[derive(Deserialize)]
-struct MoveTypeNode {
-    repr: String,
-}
-
-#[derive(Deserialize)]
-struct OwnerNode {
-    #[serde(rename = "__typename")]
-    typename: String,
-    address: Option<AddressNode>,
-}
-
-#[derive(Deserialize)]
-struct PageInfo {
-    #[serde(rename = "hasNextPage")]
-    has_next_page: bool,
-    #[serde(rename = "endCursor")]
-    end_cursor: Option<String>,
-}
-
-impl MoveObjectNode {
-    fn try_into_seed_entry(self) -> Result<Option<SeedEntry>, Error> {
-        let Some(owner) = self.owner else {
-            return Ok(None);
-        };
-        if owner.typename != "AddressOwner" {
-            return Ok(None);
-        }
-        let owner = owner
-            .address
-            .ok_or_else(|| anyhow!("address-owned seed entry is missing owner address"))?
-            .address
-            .parse::<SuiAddress>()
-            .with_context(|| format!("invalid seed owner for object {}", self.address))?;
-        let contents = self
-            .contents
-            .ok_or_else(|| anyhow!("seed object {} is missing contents", self.address))?;
-        let object_type = contents
-            .object_type
-            .ok_or_else(|| anyhow!("seed object {} is missing type", self.address))?
-            .repr
-            .parse::<StructTag>()
-            .with_context(|| format!("invalid seed object type for {}", self.address))?;
-        let object_id = self
-            .address
-            .parse::<ObjectID>()
-            .with_context(|| format!("invalid seed object id {}", self.address))?;
-        let digest = self
-            .digest
-            .ok_or_else(|| anyhow!("seed object {object_id} is missing digest"))?
-            .parse::<ObjectDigest>()
-            .with_context(|| format!("invalid seed object digest for {object_id}"))?;
-        let version = self
-            .version
-            .ok_or_else(|| anyhow!("seed object {object_id} is missing version"))?;
-        let balance = coin_balance_from_json(&object_type, contents.json.as_ref());
-
-        Ok(Some(SeedEntry {
-            object_id,
-            version: SequenceNumber::from_u64(version),
-            digest,
-            owner,
-            object_type,
-            balance,
-        }))
-    }
-}
-
 impl SeedEntry {
     fn from_object(object: &Object) -> Option<Self> {
         let Owner::AddressOwner(owner) = &object.owner else {
@@ -230,6 +81,19 @@ impl SeedInput {
     /// Return true when no addresses or objects were requested for seeding.
     pub fn is_empty(&self) -> bool {
         self.addresses.is_empty() && self.object_ids.is_empty()
+    }
+}
+
+impl From<AddressOwnedObject> for SeedEntry {
+    fn from(object: AddressOwnedObject) -> Self {
+        Self {
+            object_id: object.object_id,
+            version: object.version,
+            digest: object.digest,
+            owner: object.owner,
+            object_type: object.object_type,
+            balance: object.balance,
+        }
     }
 }
 
@@ -306,20 +170,6 @@ pub(crate) async fn prepare_seed_manifest(
     Ok(Some(manifest))
 }
 
-fn coin_balance_from_json(object_type: &StructTag, json: Option<&Value>) -> Option<u64> {
-    if object_type.address != SUI_FRAMEWORK_ADDRESS
-        || object_type.module.as_ident_str().as_str() != "coin"
-        || object_type.name.as_ident_str().as_str() != "Coin"
-    {
-        return None;
-    }
-
-    let balance = json?.get("balance")?;
-    balance
-        .as_u64()
-        .or_else(|| balance.as_str().and_then(|value| value.parse().ok()))
-}
-
 fn dedupe_addresses(addresses: &[SuiAddress]) -> Vec<SuiAddress> {
     addresses
         .iter()
@@ -356,52 +206,12 @@ async fn resolve_address_seed(
     address: SuiAddress,
     checkpoint: CheckpointSequenceNumber,
 ) -> Result<Vec<SeedEntry>, Error> {
-    let mut entries = Vec::new();
-    let mut cursor = None;
-
-    loop {
-        let response = gql
-            .run_raw_query::<AddressObjectsQuery>(
-                ADDRESS_OBJECTS_QUERY,
-                json!({
-                    "sequenceNumber": checkpoint,
-                    "address": address.to_string(),
-                    "first": ADDRESS_OBJECTS_PAGE_SIZE,
-                    "after": cursor,
-                }),
-            )
-            .await
-            .with_context(|| format!("failed to query owned objects for {address}"))?;
-
-        let data = response.data.ok_or_else(|| {
-            anyhow!(
-                "missing data in address objects query response for {address}: {:?}",
-                response.errors,
-            )
-        })?;
-        let checkpoint_data = data
-            .checkpoint
-            .ok_or_else(|| anyhow!("checkpoint {checkpoint} not found for address seeding"))?;
-        let scoped_query = checkpoint_data
-            .query
-            .ok_or_else(|| anyhow!("missing checkpoint-scoped query for address seeding"))?;
-        let Some(address_data) = scoped_query.address else {
-            return Ok(entries);
-        };
-
-        for node in address_data.objects.nodes {
-            if let Some(entry) = node.try_into_seed_entry()? {
-                entries.push(entry);
-            }
-        }
-
-        if !address_data.objects.page_info.has_next_page {
-            break;
-        }
-        cursor = address_data.objects.page_info.end_cursor;
-    }
-
-    Ok(entries)
+    Ok(gql
+        .get_address_owned_objects_at_checkpoint(address, checkpoint)
+        .await?
+        .into_iter()
+        .map(SeedEntry::from)
+        .collect())
 }
 
 fn resolve_object_seeds(
@@ -484,72 +294,14 @@ async fn resolve_seeds(
 mod tests {
     use fastcrypto::encoding::Base64 as FastCryptoBase64;
     use fastcrypto::encoding::Encoding as _;
-    use sui_types::gas_coin::GasCoin;
+    use serde_json::json;
     use wiremock::Mock;
     use wiremock::MockServer;
     use wiremock::ResponseTemplate;
-    use wiremock::matchers::body_partial_json;
     use wiremock::matchers::method;
     use wiremock::matchers::path;
 
     use super::*;
-    use crate::Node;
-
-    fn address_objects_response(
-        nodes: Vec<serde_json::Value>,
-        has_next_page: bool,
-        end_cursor: Option<&str>,
-    ) -> serde_json::Value {
-        json!({
-            "data": {
-                "checkpoint": {
-                    "query": {
-                        "address": {
-                            "objects": {
-                                "nodes": nodes,
-                                "pageInfo": {
-                                    "hasNextPage": has_next_page,
-                                    "endCursor": end_cursor,
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        })
-    }
-
-    fn address_owned_node(object: &Object, owner: SuiAddress) -> serde_json::Value {
-        json!({
-            "address": object.id().to_string(),
-            "version": object.version().value(),
-            "digest": object.digest().to_string(),
-            "owner": {
-                "__typename": "AddressOwner",
-                "address": { "address": owner.to_string() },
-            },
-            "contents": {
-                "type": { "repr": object.struct_tag().unwrap().to_canonical_string(true) },
-                "json": { "balance": "123" },
-            }
-        })
-    }
-
-    fn consensus_owned_node(object: &Object, owner: SuiAddress) -> serde_json::Value {
-        json!({
-            "address": object.id().to_string(),
-            "version": object.version().value(),
-            "digest": object.digest().to_string(),
-            "owner": {
-                "__typename": "ConsensusAddressOwner",
-                "address": { "address": owner.to_string() },
-            },
-            "contents": {
-                "type": { "repr": object.struct_tag().unwrap().to_canonical_string(true) },
-                "json": { "balance": "456" },
-            }
-        })
-    }
 
     fn object_response_body(object: &Object) -> serde_json::Value {
         json!({
@@ -566,15 +318,20 @@ mod tests {
         })
     }
 
-    #[test]
-    fn coin_balance_from_json_reads_string_balance() {
-        let ty = GasCoin::type_();
-        let json = json!({
-            "id": "0x1",
-            "balance": "42",
-        });
-
-        assert_eq!(coin_balance_from_json(&ty, Some(&json)), Some(42));
+    fn available_range_response(
+        first_sequence_number: CheckpointSequenceNumber,
+    ) -> serde_json::Value {
+        json!({
+            "data": {
+                "serviceConfig": {
+                    "availableRange": {
+                        "first": {
+                            "sequenceNumber": first_sequence_number,
+                        }
+                    }
+                }
+            }
+        })
     }
 
     #[test]
@@ -661,61 +418,37 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn resolve_address_seed_paginates_and_skips_consensus_owned_objects() {
+    async fn prepare_seed_manifest_rejects_address_seed_before_object_available_range() {
         let server = MockServer::start().await;
-        let owner = SuiAddress::random_for_testing_only();
-        let first = Object::with_id_owner_version_for_testing(
-            ObjectID::random(),
-            SequenceNumber::from_u64(7),
-            Owner::AddressOwner(owner),
-        );
-        let second = Object::with_id_owner_version_for_testing(
-            ObjectID::random(),
-            SequenceNumber::from_u64(8),
-            Owner::ConsensusAddressOwner {
-                start_version: SequenceNumber::from_u64(8),
-                owner,
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(available_range_response(12)))
+            .mount(&server)
+            .await;
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let store =
+            DataStore::new_for_testing_with_remote(temp.path().to_path_buf(), server.uri(), 11);
+        let err = prepare_seed_manifest(
+            &store,
+            "custom".to_owned(),
+            &SeedInput {
+                addresses: vec![SuiAddress::random_for_testing_only()],
+                object_ids: vec![],
             },
+        )
+        .await
+        .expect_err("address seed should fail before object available range");
+
+        assert!(err.to_string().contains("address seeding is unavailable"));
+        assert!(!store.local().seed_manifest_exists());
+        assert_eq!(
+            server
+                .received_requests()
+                .await
+                .expect("wiremock should record requests")
+                .len(),
+            1,
         );
-
-        Mock::given(method("POST"))
-            .and(path("/"))
-            .and(body_partial_json(json!({
-                "variables": { "after": null }
-            })))
-            .respond_with(
-                ResponseTemplate::new(200).set_body_json(address_objects_response(
-                    vec![address_owned_node(&first, owner)],
-                    true,
-                    Some("cursor-1"),
-                )),
-            )
-            .mount(&server)
-            .await;
-        Mock::given(method("POST"))
-            .and(path("/"))
-            .and(body_partial_json(json!({
-                "variables": { "after": "cursor-1" }
-            })))
-            .respond_with(
-                ResponseTemplate::new(200).set_body_json(address_objects_response(
-                    vec![consensus_owned_node(&second, owner)],
-                    false,
-                    None,
-                )),
-            )
-            .mount(&server)
-            .await;
-
-        let gql = GraphQLClient::new(Node::Custom(server.uri()), "test")
-            .expect("graphql client should build");
-        let entries = resolve_address_seed(&gql, owner, 10)
-            .await
-            .expect("address seed should resolve");
-
-        assert_eq!(entries.len(), 1);
-        assert_eq!(entries[0].object_id, first.id());
-        assert_eq!(entries[0].version, first.version());
-        assert_eq!(entries[0].balance, Some(123));
     }
 }

--- a/crates/sui-forking/src/startup.rs
+++ b/crates/sui-forking/src/startup.rs
@@ -26,27 +26,36 @@ use crate::context::Context;
 use crate::proto::forking::forking_service_server::ForkingServiceServer;
 use crate::rpc::executor::ForkedTransactionExecutor;
 use crate::rpc::forking_service::ForkingServiceImpl;
+use crate::seed::SeedInput;
 use crate::store::DataStore;
 
-/// Initialize a forked network by fetching state from the remote endpoint at
-/// `forked_at_checkpoint` and starting a local Simulacrum instance. Also
-/// builds the checkpoint subscription broker; the returned handle must be
-/// passed to [`run`] so the gRPC server exposes the streaming RPC.
+/// Initialize a forked network by fetching the fork checkpoint from the remote
+/// endpoint when needed, applying seed metadata, and starting a local Simulacrum
+/// instance from the highest checkpoint already persisted locally. Also builds
+/// the checkpoint subscription broker; the returned handle must be passed to
+/// [`run`] so the gRPC server exposes the streaming RPC.
 pub async fn initialize(
     node: Node,
     forked_at_checkpoint: CheckpointSequenceNumber,
     version: &str,
     data_dir: Option<std::path::PathBuf>,
+    seed_input: SeedInput,
 ) -> Result<(Context, SubscriptionServiceHandle)> {
     // 1. Create DataStore — empty local cache, GraphQL wired up.
     let data_store = DataStore::new(node.clone(), forked_at_checkpoint, version, data_dir).await?;
     let chain_identifier = data_store.chain();
+    crate::seed::ensure_seed_policy(&data_store, &seed_input)?;
 
     // 2. Download and persist the startup checkpoint (summary + contents),
     //    then read the summary back through the cache-aware getter.
     data_store.download_and_persist_startup_checkpoint()?;
+    let manifest =
+        crate::seed::prepare_seed_manifest(&data_store, node.network_name(), &seed_input).await?;
+    if let Some(manifest) = &manifest {
+        crate::seed::initialize_owned_index_from_seed(&data_store, manifest)?;
+    }
     let checkpoint = data_store
-        .get_checkpoint_by_sequence_number(forked_at_checkpoint)?
+        .get_highest_verified_checkpoint()?
         .ok_or_else(|| anyhow!("checkpoint {} not found", forked_at_checkpoint))?;
 
     // 3. Read system state — fetches object 0x5 + dynamic fields from remote via ObjectStore.

--- a/crates/sui-forking/src/store.rs
+++ b/crates/sui-forking/src/store.rs
@@ -143,11 +143,6 @@ impl DataStore {
         self.inner.gql.chain()
     }
 
-    #[cfg(test)]
-    pub(crate) fn local(&self) -> &FilesystemStore {
-        &self.inner.local
-    }
-
     fn read_local_snapshot(&self) -> StorageResult<RwLockReadGuard<'_, ()>> {
         self.inner
             .local_snapshot_lock
@@ -163,11 +158,11 @@ impl DataStore {
     }
 
     pub(crate) fn gql(&self) -> &GraphQLClient {
-        &self.gql
+        &self.inner.gql
     }
 
     pub(crate) fn local(&self) -> &FilesystemStore {
-        &self.local
+        &self.inner.local
     }
 
     /// Get a checkpoint summary by sequence number. Tries the local filesystem first. If it's a
@@ -645,7 +640,7 @@ impl DataStore {
             return None;
         }
 
-        if let Some(object) = self.local.get_latest_object(&entry.object_id).ok()? {
+        if let Some(object) = self.local().get_latest_object(&entry.object_id).ok()? {
             if object.version() != entry.version {
                 return None;
             }

--- a/crates/sui-forking/src/store.rs
+++ b/crates/sui-forking/src/store.rs
@@ -162,6 +162,14 @@ impl DataStore {
             .map_err(|_| anyhow!("local snapshot lock poisoned"))
     }
 
+    pub(crate) fn gql(&self) -> &GraphQLClient {
+        &self.gql
+    }
+
+    pub(crate) fn local(&self) -> &FilesystemStore {
+        &self.local
+    }
+
     /// Get a checkpoint summary by sequence number. Tries the local filesystem first. If it's a
     /// miss, then fetches it from remote if it's at or before the fork checkpoint and caches it
     /// locally for next time.
@@ -636,18 +644,24 @@ impl DataStore {
         if object.version() != entry.version {
             return None;
         }
-        if object.owner != sui_types::object::Owner::AddressOwner(entry.owner) {
-            return None;
-        }
-        let object_type = object.struct_tag()?;
-        if object_type != entry.object_type {
-            return None;
+
+        if let Some(object) = self.local.get_latest_object(&entry.object_id).ok()? {
+            if object.version() != entry.version {
+                return None;
+            }
+            if object.owner != sui_types::object::Owner::AddressOwner(entry.owner) {
+                return None;
+            }
+            let object_type = object.struct_tag()?;
+            if object_type != entry.object_type {
+                return None;
+            }
         }
 
         Some(OwnedObjectInfo {
             owner: entry.owner,
-            object_type,
-            balance: object.as_coin_maybe().map(|coin| coin.value()),
+            object_type: entry.object_type,
+            balance: entry.balance,
             object_id: entry.object_id,
             version: entry.version,
         })

--- a/crates/sui-forking/src/store.rs
+++ b/crates/sui-forking/src/store.rs
@@ -1173,7 +1173,8 @@ impl RpcStateReader for DataStore {
 
 impl RpcIndexes for DataStore {
     fn get_epoch_info(&self, _epoch: EpochId) -> StorageResult<Option<EpochInfo>> {
-        todo!("not supported yet")
+        // TODO: For now, we don't really need it. To be added later
+        StorageResult::Ok(None)
     }
 
     fn owned_objects_iter(

--- a/crates/sui-forking/src/store.rs
+++ b/crates/sui-forking/src/store.rs
@@ -631,15 +631,6 @@ impl DataStore {
     /// local store, and if so convert it to `OwnedObjectInfo`. This guards against stale index
     /// entries that point to objects that have been deleted or wrapped by later transactions.
     fn valid_owned_object_info(&self, entry: OwnedObjectEntry) -> Option<OwnedObjectInfo> {
-        let object = self
-            .inner
-            .local
-            .get_latest_object(&entry.object_id)
-            .ok()??;
-        if object.version() != entry.version {
-            return None;
-        }
-
         if let Some(object) = self.local().get_latest_object(&entry.object_id).ok()? {
             if object.version() != entry.version {
                 return None;

--- a/crates/sui-forking/src/tests/filesystem.rs
+++ b/crates/sui-forking/src/tests/filesystem.rs
@@ -20,6 +20,9 @@ use sui_types::object::Object;
 use sui_types::object::ObjectInner;
 use sui_types::object::Owner;
 
+use crate::seed::SeedEntry;
+use crate::seed::SeedManifest;
+
 use super::*;
 
 fn test_store() -> (tempfile::TempDir, FilesystemStore) {
@@ -252,6 +255,31 @@ fn test_owned_object_index_upserts_removes_and_stays_sorted() {
     let entries = store.get_owned_object_entries().unwrap();
     assert_eq!(entries.len(), 1);
     assert_eq!(entries[0].object_id, first_id);
+}
+
+#[test]
+fn test_seed_manifest_round_trips_and_is_immutable() {
+    let (_dir, store) = test_store();
+    let owner = SuiAddress::random_for_testing_only();
+    let object = make_object_with_owner(ObjectID::random(), 1, Owner::AddressOwner(owner));
+    let manifest = SeedManifest {
+        network: "testnet".to_owned(),
+        checkpoint: 42,
+        entries: vec![SeedEntry {
+            object_id: object.id(),
+            version: object.version(),
+            digest: object.digest(),
+            owner,
+            object_type: object.struct_tag().unwrap(),
+            balance: object.as_coin_maybe().map(|coin| coin.value()),
+        }],
+    };
+
+    store.write_seed_manifest(&manifest).unwrap();
+
+    assert!(store.seed_manifest_exists());
+    assert_eq!(store.read_seed_manifest().unwrap(), manifest);
+    assert!(store.write_seed_manifest(&manifest).is_err());
 }
 
 #[test]

--- a/crates/sui-forking/src/tests/store_checkpoint_persistence.rs
+++ b/crates/sui-forking/src/tests/store_checkpoint_persistence.rs
@@ -5,8 +5,16 @@
 //! `src/tests/` but is a child of the `store` module via a `#[path]` wiring
 //! in `store.rs`, so it retains `super::*` access to `pub(crate)` items.
 
+use std::num::NonZeroUsize;
+
+use rand::rngs::OsRng;
+use simulacrum::Simulacrum;
 use simulacrum::store::SimulatorStore;
+use simulacrum::store::in_mem_store::KeyStore;
+use sui_swarm_config::network_config_builder::ConfigBuilder;
+use sui_types::base_types::ObjectID;
 use sui_types::messages_checkpoint::{CheckpointContents, VerifiedCheckpoint};
+use sui_types::object::Object;
 use sui_types::test_checkpoint_data_builder::TestCheckpointBuilder;
 
 use super::*;
@@ -76,5 +84,46 @@ fn insert_checkpoint_and_contents_are_independent() {
     assert_eq!(
         highest.data().sequence_number,
         checkpoint.data().sequence_number,
+    );
+}
+
+#[test]
+fn resumed_simulacrum_builds_next_checkpoint_after_highest_local_checkpoint() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let mut rng = OsRng;
+    let config = ConfigBuilder::new_with_temp_dir()
+        .rng(&mut rng)
+        .deterministic_committee_size(NonZeroUsize::MIN)
+        .build();
+    let mut store = DataStore::new_for_testing(temp.path().to_path_buf());
+    let written: BTreeMap<ObjectID, Object> = config
+        .genesis
+        .objects()
+        .iter()
+        .map(|object| (object.id(), object.clone()))
+        .collect();
+    store.update_objects(written, vec![]);
+
+    let (checkpoint, contents) = build_checkpoint(5);
+    store.insert_checkpoint(checkpoint.clone());
+    store.insert_checkpoint_contents(contents);
+
+    let keystore = KeyStore::from_network_config(&config);
+    let mut sim = Simulacrum::new_from_custom_state(
+        keystore,
+        store
+            .get_highest_verified_checkpoint()
+            .expect("highest checkpoint lookup should not fail")
+            .expect("highest checkpoint should exist"),
+        config.genesis.sui_system_object(),
+        &config,
+        store,
+        rng,
+    );
+
+    let next = sim.create_checkpoint();
+    assert_eq!(
+        next.data().sequence_number,
+        checkpoint.data().sequence_number + 1,
     );
 }

--- a/crates/sui-forking/src/tests/store_checkpoint_persistence.rs
+++ b/crates/sui-forking/src/tests/store_checkpoint_persistence.rs
@@ -87,8 +87,8 @@ fn insert_checkpoint_and_contents_are_independent() {
     );
 }
 
-#[test]
-fn resumed_simulacrum_builds_next_checkpoint_after_highest_local_checkpoint() {
+#[tokio::test]
+async fn resumed_simulacrum_builds_next_checkpoint_after_highest_local_checkpoint() {
     let temp = tempfile::tempdir().expect("tempdir");
     let mut rng = OsRng;
     let config = ConfigBuilder::new_with_temp_dir()

--- a/crates/sui-forking/src/tests/store_execution.rs
+++ b/crates/sui-forking/src/tests/store_execution.rs
@@ -272,7 +272,7 @@ fn test_seeded_owned_object_metadata_lists_without_bcs_until_deleted() {
     let object_id = ObjectID::random();
 
     store
-        .local
+        .local()
         .write_owned_object_entries(&[OwnedObjectEntry {
             owner,
             object_id,
@@ -292,7 +292,7 @@ fn test_seeded_owned_object_metadata_lists_without_bcs_until_deleted() {
     assert_eq!(infos[0].balance, Some(123));
     assert!(
         store
-            .local
+            .local()
             .get_latest_object(&object_id)
             .expect("local lookup should not fail")
             .is_none(),

--- a/crates/sui-forking/src/tests/store_execution.rs
+++ b/crates/sui-forking/src/tests/store_execution.rs
@@ -266,6 +266,57 @@ fn test_owned_objects_removes_non_address_owned_transitions() {
 }
 
 #[test]
+fn test_seeded_owned_object_metadata_lists_without_bcs_until_deleted() {
+    let (_temp, mut store) = test_data_store();
+    let owner = SuiAddress::random_for_testing_only();
+    let object_id = ObjectID::random();
+
+    store
+        .local
+        .write_owned_object_entries(&[OwnedObjectEntry {
+            owner,
+            object_id,
+            version: SequenceNumber::from_u64(7),
+            object_type: GasCoin::type_(),
+            balance: Some(123),
+        }])
+        .unwrap();
+
+    let infos: Vec<_> = RpcIndexes::owned_objects_iter(&store, owner, Some(GasCoin::type_()), None)
+        .expect("seeded owned-object iterator should build")
+        .map(|result| result.expect("seeded entry should decode"))
+        .collect();
+    assert_eq!(infos.len(), 1);
+    assert_eq!(infos[0].object_id, object_id);
+    assert_eq!(infos[0].version, SequenceNumber::from_u64(7));
+    assert_eq!(infos[0].balance, Some(123));
+    assert!(
+        store
+            .local
+            .get_latest_object(&object_id)
+            .expect("local lookup should not fail")
+            .is_none(),
+        "seed metadata should not require local BCS",
+    );
+
+    store.update_objects(
+        BTreeMap::new(),
+        vec![(
+            object_id,
+            SequenceNumber::from_u64(8),
+            ObjectDigest::OBJECT_DIGEST_DELETED,
+        )],
+    );
+
+    assert_eq!(
+        RpcIndexes::owned_objects_iter(&store, owner, Some(GasCoin::type_()), None)
+            .expect("owned-object iterator should build")
+            .count(),
+        0,
+    );
+}
+
+#[test]
 fn test_local_deletion_removes_owned_object_and_blocks_remote_resurrection() {
     let (_temp, mut store) = test_data_store();
     let owner = SuiAddress::random_for_testing_only();

--- a/crates/sui-forking/src/tests/subscription_e2e.rs
+++ b/crates/sui-forking/src/tests/subscription_e2e.rs
@@ -245,3 +245,40 @@ async fn subscription_fans_out_to_multiple_subscribers() -> Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn advance_clock_creates_and_streams_checkpoint() -> Result<()> {
+    let harness = ServerHarness::start().await?;
+
+    let mut subscriptions =
+        SubscriptionServiceClient::connect(harness.grpc_endpoint.clone()).await?;
+    let mut stream = subscriptions
+        .subscribe_checkpoints(SubscribeCheckpointsRequest::default())
+        .await?
+        .into_inner();
+
+    let mut forking = ForkingServiceClient::connect(harness.grpc_endpoint.clone()).await?;
+    let clock = forking
+        .advance_clock(AdvanceClockRequest {
+            duration_ms: Some(10),
+        })
+        .await?
+        .into_inner();
+
+    let msg = tokio::time::timeout(STREAM_RECV_TIMEOUT, stream.message())
+        .await?
+        .map_err(|e| anyhow!("stream error: {e}"))?
+        .ok_or_else(|| anyhow!("subscription stream closed before clock advance"))?;
+    let checkpoint_sequence_number = msg
+        .cursor
+        .ok_or_else(|| anyhow!("missing cursor on subscription message"))?;
+    let status = forking.get_status(GetStatusRequest {}).await?.into_inner();
+
+    assert_eq!(
+        status.checkpoint_sequence_number,
+        checkpoint_sequence_number
+    );
+    assert_eq!(status.timestamp_ms, clock.timestamp_ms);
+
+    Ok(())
+}


### PR DESCRIPTION
## Description 

This PR adds object seeding for startup. In a nutshell, the user can seed the forked network with a list of object ids, or with an address. The tool will fetch the object references for owned objects for an address and feed it into the owned objects index.

The user can only pass in addresses for checkpoints that are not older than 1h. For older checkpoints, the user must know the objects for which to reconstruct ownership.

The tool creates a seed file in the default or specified data directory, which will be used for correctly resuming the network and taking into consideration if any of those objects were deleted in a later checkpoint.

Finally, `advance-clock` now produces a checkpoint as well to avoid dealing with intermediary state.

## Test plan 

New tests.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
