### PR TITLE
docker: add sui-node-th image (sui-node with tidehunter feature)

### DIFF
--- a/docker/sui-node-th/Dockerfile
+++ b/docker/sui-node-th/Dockerfile
@@ -1,0 +1,39 @@
+# Build application
+#
+# Copy in all crates, Cargo.toml and Cargo.lock unmodified,
+# and build the application.
+FROM rust:1.92-bullseye AS builder
+ARG PROFILE=release
+ARG GIT_REVISION
+ENV GIT_REVISION=$GIT_REVISION
+WORKDIR "$WORKDIR/sui"
+RUN apt-get update && apt-get install -y cmake clang
+
+COPY Cargo.toml Cargo.lock ./
+COPY consensus consensus
+COPY crates crates
+COPY sui-execution sui-execution
+COPY external-crates external-crates
+
+ENV USE_TIDEHUNTER=1
+RUN cargo build --profile ${PROFILE} --features typed-store/tidehunter --bin sui-node --target-dir target/tidehunter
+
+# Production Image
+FROM debian:bullseye-slim AS runtime
+# Use jemalloc as memory allocator
+RUN apt-get update && apt-get install -y ca-certificates curl
+ARG PROFILE=release
+WORKDIR "$WORKDIR/sui"
+# Both bench and release profiles copy from release dir
+COPY --from=builder /sui/target/tidehunter/release/sui-node /opt/sui/bin/sui-node
+# Support legacy usages of /usr/local/bin/sui-node
+COPY --from=builder /sui/target/tidehunter/release/sui-node /usr/local/bin
+# Suffixed copy lets mp3's binary_upload_config extract /opt/sui/bin/sui-node-th
+# to s3://sui-releases/{sha}/sui-node-th via {basename} substitution, matching
+# the legacy sui-release-binaries.yml S3 path so existing -th consumers keep working.
+COPY --from=builder /sui/target/tidehunter/release/sui-node /opt/sui/bin/sui-node-th
+
+ARG BUILD_DATE
+ARG GIT_REVISION
+LABEL build-date=$BUILD_DATE
+LABEL git-revision=$GIT_REVISION

--- a/docker/sui-node-th/Dockerfile
+++ b/docker/sui-node-th/Dockerfile
@@ -31,7 +31,9 @@ WORKDIR "$WORKDIR/sui"
 # as plain sui-node and corrupt unrelated databases. K8s pod entrypoints
 # must call /opt/sui/bin/sui-node-th explicitly. mp3's binary_upload_config
 # extracts this path to s3://sui-releases/{sha}/sui-node-th via {basename}
-# substitution, matching legacy sui-release-binaries.yml naming.
+# substitution; that S3 location is the contract for ansible bare-metal
+# nodes (the build_with_tidehunter selector in
+# sui-operations/ansible/playbook/sui/roles/sui-node-{internal,external}).
 COPY --from=builder /sui/target/tidehunter/release/sui-node /opt/sui/bin/sui-node-th
 
 ARG BUILD_DATE

--- a/docker/sui-node-th/Dockerfile
+++ b/docker/sui-node-th/Dockerfile
@@ -24,13 +24,14 @@ FROM debian:bullseye-slim AS runtime
 RUN apt-get update && apt-get install -y ca-certificates curl
 ARG PROFILE=release
 WORKDIR "$WORKDIR/sui"
-# Both bench and release profiles copy from release dir
-COPY --from=builder /sui/target/tidehunter/release/sui-node /opt/sui/bin/sui-node
-# Support legacy usages of /usr/local/bin/sui-node
-COPY --from=builder /sui/target/tidehunter/release/sui-node /usr/local/bin
-# Suffixed copy lets mp3's binary_upload_config extract /opt/sui/bin/sui-node-th
-# to s3://sui-releases/{sha}/sui-node-th via {basename} substitution, matching
-# the legacy sui-release-binaries.yml S3 path so existing -th consumers keep working.
+# Only ship the tidehunter binary at a suffixed path. Intentionally no
+# /opt/sui/bin/sui-node or /usr/local/bin/sui-node aliases — the binary
+# uses the tidehunter storage backend, which is incompatible with rocksdb,
+# and silently swapping at the canonical paths would let callers run it
+# as plain sui-node and corrupt unrelated databases. K8s pod entrypoints
+# must call /opt/sui/bin/sui-node-th explicitly. mp3's binary_upload_config
+# extracts this path to s3://sui-releases/{sha}/sui-node-th via {basename}
+# substitution, matching legacy sui-release-binaries.yml naming.
 COPY --from=builder /sui/target/tidehunter/release/sui-node /opt/sui/bin/sui-node-th
 
 ARG BUILD_DATE

--- a/docker/sui-node-th/build.sh
+++ b/docker/sui-node-th/build.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# fast fail.
+set -e
+
+DIR="$( cd "$( dirname "$0" )" && pwd )"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+DOCKERFILE="$DIR/Dockerfile"
+GIT_REVISION="$(git describe --always --abbrev=12 --dirty --exclude '*')"
+BUILD_DATE="$(date -u +'%Y-%m-%d')"
+
+# option to build using debug symbols
+if [ "$1" = "--debug-symbols" ]; then
+	PROFILE="bench"
+	echo "Building with full debug info enabled ... WARNING: binary size might significantly increase"
+	shift
+else
+	PROFILE="release"
+fi
+
+echo
+echo "Building sui-node-th docker image"
+echo "Dockerfile: \t$DOCKERFILE"
+echo "docker context: $REPO_ROOT"
+echo "build date: \t$BUILD_DATE"
+echo "git revision: \t$GIT_REVISION"
+echo
+
+docker build -f "$DOCKERFILE" "$REPO_ROOT" \
+	--build-arg GIT_REVISION="$GIT_REVISION" \
+	--build-arg BUILD_DATE="$BUILD_DATE" \
+	--build-arg PROFILE="$PROFILE" \
+	"$@"


### PR DESCRIPTION
## Summary

Adds \`docker/sui-node-th/Dockerfile\` and \`docker/sui-node-th/build.sh\` — sui-node built with the tidehunter storage backend.

This is **additive only** in this repo. It mirrors \`docker/sui-node\` exactly, with the cargo build replaced by:

\`\`\`
ENV USE_TIDEHUNTER=1
RUN cargo build --profile \${PROFILE} --features typed-store/tidehunter --bin sui-node --target-dir target/tidehunter
\`\`\`

## What ships in the runtime image

After @JohnMartin1's review: only one binary, at one path:

\`\`\`dockerfile
COPY --from=builder /sui/target/tidehunter/release/sui-node /opt/sui/bin/sui-node-th
\`\`\`

**No \`/opt/sui/bin/sui-node\` or \`/usr/local/bin/sui-node\` aliases** — the tidehunter binary uses a different storage backend (incompatible with rocksdb), and silently aliasing at the canonical name would let callers run it as plain sui-node and corrupt unrelated databases. The suffixed-only design forces explicit opt-in:

- K8s pod entrypoints must call \`/opt/sui/bin/sui-node-th\` explicitly.
- mp3's \`binary_upload_config\` extracts \`/opt/sui/bin/sui-node-th\` to \`s3://sui-releases/{sha}/sui-node-th\` via \`{basename}\` substitution. mp3 owns this S3 path going forward (sui-release-binaries.yml is being retired).
- ansible \`sui-node-{internal,external}\` roles already select that S3 path when \`build_with_tidehunter=true\` — no role changes needed.

## Scope

- Only \`sui-node\` gets tidehunter treatment for now. \`sui\`, \`sui-tool\`, \`stress\` are not produced by this image.
- amd64 only — sui-operations consumer is ci/devnet K8s, which is amd64.
- arm64 variant can be added later by mirroring the \`sui-node-arm64\` pattern.

## Companion sui-operations PR

[MystenLabs/sui-operations#7762](https://github.com/MystenLabs/sui-operations/pull/7762) wires this image into:
- \`scripts/workflows/prepare_sui_matrix.py\` (mp3 build matrix)
- \`pulumi/apps/mp3/Pulumi.{production,staging}.yaml\` (binary extraction rule)
- \`pulumi/gcp/sui-node/Pulumi.{ci,devnet}.yaml\` (K8s deployment swap)
- \`pulumi/gcp/sui-node/main.go\` (container command derives binary path from image_name)
- \`.github/workflows/pulumi-sui-deploy.yaml\` (auto-flips \`build_with_tidehunter\` for ci so SSH validators also pick up \`sui-node-th\`)

## Test plan

- [x] Diff against \`docker/sui-node/Dockerfile\` shows only the tidehunter-relevant changes (build flags, target-dir, single suffixed COPY).
- [x] \`build.sh\` is byte-identical to \`docker/sui-node/build.sh\` except for the image name in the echo.
- [x] No code paths in this repo reference the new files yet — purely additive.
- [ ] sui-operations companion PR: mp3 builds the new image, ci/devnet K8s pulls it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)