### PR TITLE
[graphql-stream] SSE transport + SSE-aware GraphiQL [11/n]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15095,8 +15095,10 @@ name = "sui-indexer-alt-e2e-tests"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-stream",
  "async-trait",
  "bcs",
+ "bytes",
  "coset",
  "datatest-stable",
  "diesel",
@@ -15151,7 +15153,6 @@ dependencies = [
  "test-cluster",
  "tokio",
  "tokio-stream",
- "tokio-tungstenite 0.26.2",
  "tonic 0.14.5",
  "tracing",
  "url",

--- a/crates/sui-indexer-alt-e2e-tests/Cargo.toml
+++ b/crates/sui-indexer-alt-e2e-tests/Cargo.toml
@@ -73,8 +73,9 @@ passkey-client.workspace = true
 passkey-types.workspace = true
 jsonrpsee.workspace = true
 telemetry-subscribers.workspace = true
+async-stream.workspace = true
+bytes.workspace = true
 tokio-stream.workspace = true
-tokio-tungstenite = { workspace = true, features = ["rustls-tls-webpki-roots"] }
 tonic.workspace = true
 futures.workspace = true
 

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/testing/harness.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/testing/harness.rs
@@ -7,9 +7,10 @@ use std::net::Ipv4Addr;
 use std::net::SocketAddr;
 use std::time::Duration;
 
+use async_stream::stream;
+use bytes::BytesMut;
 use fastcrypto::encoding::Base58;
 use fastcrypto::encoding::Encoding;
-use futures::SinkExt;
 use prometheus::Registry;
 use serde_json::Value;
 use serde_json::json;
@@ -29,9 +30,6 @@ use sui_test_transaction_builder::TestTransactionBuilder;
 use test_cluster::TestCluster;
 use test_cluster::TestClusterBuilder;
 use tokio_stream::StreamExt;
-use tokio_tungstenite::connect_async;
-use tokio_tungstenite::tungstenite::Message;
-use tokio_tungstenite::tungstenite::http::Request;
 
 use super::proxy;
 use super::proxy::ProxyController;
@@ -159,7 +157,10 @@ impl SubscriptionTestCluster {
             Self {
                 validator,
                 db,
-                subscription_url: format!("ws://{}/graphql", graphql_listen_address),
+                subscription_url: format!(
+                    "http://{}/graphql/subscriptions",
+                    graphql_listen_address
+                ),
                 service,
                 indexer,
                 ingestion_dir,
@@ -194,72 +195,78 @@ impl SubscriptionTestCluster {
         query: &str,
         variables: Option<Value>,
     ) -> std::pin::Pin<Box<dyn tokio_stream::Stream<Item = Value> + Send>> {
-        let request = Request::builder()
-            .uri(&self.subscription_url)
-            .header("Sec-WebSocket-Protocol", "graphql-transport-ws")
-            .header("Connection", "Upgrade")
-            .header("Upgrade", "websocket")
-            .header("Sec-WebSocket-Version", "13")
-            .header("Host", "localhost")
-            .header(
-                "Sec-WebSocket-Key",
-                tokio_tungstenite::tungstenite::handshake::client::generate_key(),
-            )
-            .body(())
-            .unwrap();
-
-        let (ws, _) = connect_async(request)
-            .await
-            .expect("Failed to connect WebSocket");
-
-        // Use futures::StreamExt::split (tokio_stream doesn't have split).
-        let (mut sink, stream) = futures::StreamExt::split(ws);
-
-        sink.send(Message::Text(
-            json!({"type": "connection_init"}).to_string().into(),
-        ))
-        .await
-        .expect("Failed to send connection_init");
-
-        // Wrap with tokio_stream timeout, then wait for ack.
-        let mut stream = Box::pin(stream.timeout(SUBSCRIPTION_TIMEOUT));
-
-        let ack = stream
-            .next()
-            .await
-            .expect("Stream ended")
-            .expect("Timeout waiting for ack")
-            .expect("WS error");
-        let ack: Value = serde_json::from_str(ack.to_text().unwrap()).unwrap();
-        assert_eq!(ack["type"], "connection_ack");
-
         let mut payload = json!({ "query": query });
         if let Some(vars) = variables {
             payload["variables"] = vars;
         }
-        sink.send(Message::Text(
-            json!({
-                "id": "1",
-                "type": "subscribe",
-                "payload": payload
-            })
-            .to_string()
-            .into(),
-        ))
-        .await
-        .expect("Failed to send subscribe");
 
-        // Return a stream that extracts payloads from "next" messages.
-        Box::pin(stream.map(|result| {
-            let msg = result.expect("Timeout").expect("WS error");
-            let text = match msg {
-                Message::Text(t) => t,
-                other => panic!("Expected text message, got: {other:?}"),
-            };
-            let msg: Value = serde_json::from_str(&text).unwrap();
-            assert_eq!(msg["type"], "next", "Expected 'next' message, got: {msg}");
-            msg["payload"].clone()
-        }))
+        let response = reqwest::Client::new()
+            .post(&self.subscription_url)
+            .header("Accept", "text/event-stream")
+            .header("Content-Type", "application/json")
+            .json(&payload)
+            .send()
+            .await
+            .expect("Failed to POST subscription request");
+
+        assert!(
+            response.status().is_success(),
+            "Subscription request failed: {}",
+            response.status(),
+        );
+
+        Box::pin(
+            parse_sse_events(response.bytes_stream())
+                .timeout(SUBSCRIPTION_TIMEOUT)
+                .map(|result| result.expect("Timed out waiting for SSE event")),
+        )
+    }
+}
+
+/// Parse a graphql-sse byte stream into a stream of GraphQL response payloads.
+///
+/// Reads `event: next` frames, parses their `data:` field as JSON, and yields each one.
+/// Stops when the server sends `event: complete` or closes the connection.
+fn parse_sse_events(
+    body: impl futures::Stream<Item = Result<bytes::Bytes, reqwest::Error>> + Send + 'static,
+) -> impl tokio_stream::Stream<Item = Value> + Send + 'static {
+    stream! {
+        let mut body = Box::pin(body);
+        let mut buffer = BytesMut::new();
+        let mut current_event: Option<String> = None;
+        let mut current_data = String::new();
+
+        while let Some(chunk) = futures::StreamExt::next(&mut body).await {
+            let chunk = chunk.expect("SSE body error");
+            buffer.extend_from_slice(&chunk);
+
+            while let Some(pos) = buffer.iter().position(|&b| b == b'\n') {
+                let line_bytes = buffer.split_to(pos + 1);
+                let line = std::str::from_utf8(&line_bytes[..line_bytes.len() - 1])
+                    .expect("Invalid UTF-8 in SSE stream")
+                    .trim_end_matches('\r');
+
+                if line.is_empty() {
+                    if current_event.as_deref() == Some("complete") {
+                        return;
+                    }
+                    if current_event.as_deref() == Some("next") && !current_data.is_empty() {
+                        let value: Value = serde_json::from_str(&current_data)
+                            .expect("Invalid JSON in SSE data field");
+                        yield value;
+                    }
+                    current_event = None;
+                    current_data.clear();
+                } else if let Some(rest) = line.strip_prefix("event:") {
+                    current_event = Some(rest.trim().to_string());
+                } else if let Some(rest) = line.strip_prefix("data:") {
+                    if !current_data.is_empty() {
+                        current_data.push('\n');
+                    }
+                    current_data.push_str(rest.strip_prefix(' ').unwrap_or(rest));
+                }
+            }
+        }
     }
 }
 

--- a/crates/sui-indexer-alt-graphql/assets/graphiql.html
+++ b/crates/sui-indexer-alt-graphql/assets/graphiql.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>GraphiQL</title>
+  <link rel="stylesheet" href="https://unpkg.com/graphiql@3.9.0/graphiql.min.css" />
+</head>
+<body style="margin: 0;">
+  <div id="graphiql" style="height: 100vh;"></div>
+  <script crossorigin src="https://unpkg.com/react@18.3.1/umd/react.production.min.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.production.min.js"></script>
+  <script src="https://unpkg.com/graphiql@3.9.0/graphiql.min.js"></script>
+  <script src="https://unpkg.com/graphql-sse@2.6.0/umd/graphql-sse.min.js"></script>
+  <script type="module">
+    import { parse, getOperationAST } from "https://unpkg.com/graphql@16.14.0/index.mjs?module";
+
+    const GRAPHQL_ENDPOINT = "__GRAPHQL_PATH__";
+    const GRAPHQL_SUBSCRIPTIONS_ENDPOINT = "__GRAPHQL_SUBSCRIPTIONS_PATH__";
+
+    const sseClient = graphqlSse.createClient({ url: GRAPHQL_SUBSCRIPTIONS_ENDPOINT });
+
+    function isSubscription(params) {
+      try {
+        const document = parse(params.query || '');
+        const operation = getOperationAST(document, params.operationName);
+        return operation?.operation === 'subscription';
+      } catch {
+        return false;
+      }
+    }
+
+    const fetcher = async function*(params) {
+      if (isSubscription(params)) {
+        for await (const result of sseClient.iterate(params)) yield result;
+        return;
+      }
+      const response = await fetch(GRAPHQL_ENDPOINT, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Accept': 'application/json',
+        },
+        body: JSON.stringify(params),
+      });
+      yield await response.json();
+    };
+
+    ReactDOM.createRoot(document.getElementById('graphiql'))
+      .render(React.createElement(GraphiQL, { fetcher }));
+  </script>
+</body>
+</html>

--- a/crates/sui-indexer-alt-graphql/src/lib.rs
+++ b/crates/sui-indexer-alt-graphql/src/lib.rs
@@ -17,16 +17,11 @@ use async_graphql::SchemaBuilder;
 use async_graphql::SubscriptionType;
 use async_graphql::extensions::ExtensionFactory;
 use async_graphql::extensions::Tracing;
-use async_graphql::http::ALL_WEBSOCKET_PROTOCOLS;
-use async_graphql::http::GraphiQLSource;
-use async_graphql_axum::GraphQLProtocol;
 use async_graphql_axum::GraphQLRequest;
 use async_graphql_axum::GraphQLResponse;
-use async_graphql_axum::GraphQLWebSocket;
 use axum::Extension;
 use axum::Router;
 use axum::extract::ConnectInfo;
-use axum::extract::WebSocketUpgrade;
 use axum::http::Method;
 use axum::response::Html;
 use axum::response::IntoResponse;
@@ -39,6 +34,7 @@ use extensions::query_limits::QueryLimitsChecker;
 use extensions::query_limits::rich;
 use extensions::query_limits::show_usage::ShowUsage;
 use extensions::timeout::Timeout;
+use futures::StreamExt;
 use headers::ContentLength;
 use health::DbProbe;
 use prometheus::Registry;
@@ -79,6 +75,7 @@ use crate::middleware::version::Version;
 use async_graphql::EmptySubscription as Subscription;
 
 const GRAPHQL_PATH: &str = "/graphql";
+const GRAPHQL_SUBSCRIPTIONS_PATH: &str = "/graphql/subscriptions";
 const HEALTH_PATH: &str = "/graphql/health";
 
 mod api;
@@ -405,7 +402,8 @@ pub async fn start_rpc(
     };
 
     let mut rpc = rpc
-        .route(GRAPHQL_PATH, post(graphql).get(graphql_get))
+        .route(GRAPHQL_PATH, post(graphql).get(graphiql))
+        .route(GRAPHQL_SUBSCRIPTIONS_PATH, post(graphql_subscriptions))
         .route(HEALTH_PATH, get(health::check))
         .layer(watermark_task.watermarks())
         .layer(config.health)
@@ -493,56 +491,62 @@ async fn graphql(
     schema.execute(request).await.into()
 }
 
-/// Handler for GET requests on the GraphQL path. WebSocket upgrade requests are handled as
-/// subscription connections; regular GET requests serve the GraphiQL IDE (if enabled).
-async fn graphql_get(
+/// Handler for GET requests on the GraphQL path. Serves the GraphiQL IDE when enabled,
+/// otherwise responds 404. Subscriptions are served separately over SSE at
+/// `GRAPHQL_SUBSCRIPTIONS_PATH`.
+async fn graphiql(
+    Extension(IdeEnabled(ide_enabled)): Extension<IdeEnabled>,
+) -> axum::response::Response {
+    if !ide_enabled {
+        return axum::http::StatusCode::NOT_FOUND.into_response();
+    }
+
+    Html(
+        include_str!("../assets/graphiql.html")
+            .replace("__GRAPHQL_PATH__", GRAPHQL_PATH)
+            .replace("__GRAPHQL_SUBSCRIPTIONS_PATH__", GRAPHQL_SUBSCRIPTIONS_PATH),
+    )
+    .into_response()
+}
+
+async fn graphql_subscriptions(
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
     Extension(schema): Extension<Schema<Query, Mutation, Subscription>>,
     Extension(SubscriptionsEnabled(subscriptions_enabled)): Extension<SubscriptionsEnabled>,
-    Extension(IdeEnabled(ide_enabled)): Extension<IdeEnabled>,
-    ws: Option<WebSocketUpgrade>,
-    protocol: Option<GraphQLProtocol>,
-) -> impl IntoResponse {
-    match (ws, protocol) {
-        (Some(ws), Some(protocol)) => {
-            handle_ws(ws, protocol, schema, addr, subscriptions_enabled).into_response()
-        }
-        _ if ide_enabled => graphiql().into_response(),
-        _ => axum::http::StatusCode::NOT_FOUND.into_response(),
+    Extension(watermark): Extension<WatermarksLock>,
+    request: GraphQLRequest,
+) -> axum::response::Response {
+    if !subscriptions_enabled {
+        return (
+            axum::http::StatusCode::NOT_FOUND,
+            "Subscriptions are not enabled on this instance.",
+        )
+            .into_response();
     }
-}
 
-fn graphiql() -> Html<String> {
-    Html(
-        GraphiQLSource::build()
-            .endpoint(GRAPHQL_PATH)
-            .subscription_endpoint(GRAPHQL_PATH)
-            .finish(),
-    )
-}
+    let watermarks = watermark.read().await.clone();
+    let req = request
+        .into_inner()
+        .data(Session::new(addr))
+        .data(watermarks)
+        .data(rich::Meter::default());
 
-fn handle_ws(
-    ws: WebSocketUpgrade,
-    protocol: GraphQLProtocol,
-    schema: Schema<Query, Mutation, Subscription>,
-    addr: SocketAddr,
-    subscriptions_enabled: bool,
-) -> impl IntoResponse {
-    ws.protocols(ALL_WEBSOCKET_PROTOCOLS)
-        .on_upgrade(move |stream| {
-            let mut data = async_graphql::Data::default();
-            data.insert(Session::new(addr));
+    let stream = schema.execute_stream(req).map(|response| {
+        let payload = serde_json::to_string(&response).unwrap_or_else(|_| "null".into());
+        Ok::<_, std::convert::Infallible>(
+            axum::response::sse::Event::default()
+                .event("next")
+                .data(payload),
+        )
+    });
 
-            GraphQLWebSocket::new(stream, schema, protocol)
-                .with_data(data)
-                .on_connection_init(move |_| async move {
-                    if !subscriptions_enabled {
-                        return Err("Subscriptions are not enabled on this instance.".into());
-                    }
-                    Ok(async_graphql::Data::default())
-                })
-                .serve()
-        })
+    axum::response::sse::Sse::new(stream)
+        .keep_alive(
+            axum::response::sse::KeepAlive::default()
+                .interval(Duration::from_secs(15))
+                .text("keep-alive"),
+        )
+        .into_response()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Replace the WebSocket subscription transport with Server-Sent Events. SSE is the standard transport for GraphQL subscriptions over HTTP. WebSocket was added in 1/n (#26019) as a starting point and is not in production yet, so this PR removes it outright.

## Why

For one-way streaming (server pushes events, client mostly listens — exactly our subscription shape), SSE is closer to current industry best practice than WebSocket: simpler infra (no upgrade dance, plays naturally with HTTP/2/3, standard HTTP caching/proxy semantics), debuggable with curl, native browser support. The same pattern is used by OpenAI/Anthropic completion streaming, Cloudflare Workers AI, GitHub live activity, Vercel AI SDK, etc.

## GraphiQL story

Upstream GraphiQL has no SSE fetcher today. Rather than block on the in-flight upstream PR (graphql/graphiql#4218), this PR ships a small static HTML template (`assets/graphiql.html`) that loads GraphiQL via UMD plus the `graphql-sse` UMD client and wires a custom fetcher: subscriptions go through `graphqlSse.iterate()`, queries through `fetch`. CDN deps pinned; subscription detection uses `parse` + `getOperationAST` so it handles multi-operation documents with an explicit `operationName`. Once #4218 lands, this collapses to a one-line `createGraphiQLFetcher({ url, sseUrl })` call.


## Test plan 

How did you test the new or updated feature?
- unit + e2e tests
- Start local GraphQL Server

## Stack
   - #26019
   - #26094
   - #26117
   - #26170
   - #26194
   - #26202
   - #26414
   - #26453
   - #26476
   - #26487
   - #26425

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework: