### PR TITLE
Add gasless transaction kill switch to TransactionDenyConfig

### DIFF
--- a/crates/sui-config/src/transaction_deny_config.rs
+++ b/crates/sui-config/src/transaction_deny_config.rs
@@ -54,6 +54,10 @@ pub struct TransactionDenyConfig {
     #[serde(default)]
     user_transaction_disabled: bool,
 
+    /// Whether gasless transactions are disabled.
+    #[serde(default)]
+    gasless_disabled: bool,
+
     /// In-memory maps for faster lookup of various lists.
     #[serde(skip)]
     object_deny_set: OnceCell<HashSet<ObjectID>>,
@@ -122,6 +126,10 @@ impl TransactionDenyConfig {
         self.user_transaction_disabled
     }
 
+    pub fn gasless_disabled(&self) -> bool {
+        self.gasless_disabled
+    }
+
     pub fn receiving_objects_disabled(&self) -> bool {
         self.receiving_objects_disabled
     }
@@ -155,6 +163,11 @@ impl TransactionDenyConfigBuilder {
 
     pub fn disable_user_transaction(mut self) -> Self {
         self.config.user_transaction_disabled = true;
+        self
+    }
+
+    pub fn disable_gasless(mut self) -> Self {
+        self.config.gasless_disabled = true;
         self
     }
 

--- a/crates/sui-core/src/unit_tests/transaction_deny_tests.rs
+++ b/crates/sui-core/src/unit_tests/transaction_deny_tests.rs
@@ -24,8 +24,9 @@ use sui_types::executable_transaction::VerifiedExecutableTransaction;
 use sui_types::execution_status::{ExecutionErrorKind, ExecutionFailure, ExecutionStatus};
 use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
 use sui_types::transaction::{
-    CallArg, TEST_ONLY_GAS_UNIT_FOR_TRANSFER, Transaction, TransactionData, TransactionDataAPI,
-    TransactionKind, VerifiedTransaction,
+    CallArg, GasData, ProgrammableTransaction, TEST_ONLY_GAS_UNIT_FOR_TRANSFER, Transaction,
+    TransactionData, TransactionDataAPI, TransactionDataV1, TransactionExpiration, TransactionKind,
+    VerifiedTransaction,
 };
 use sui_types::utils::get_zklogin_user_address;
 use sui_types::utils::{
@@ -179,6 +180,43 @@ async fn test_user_transaction_disabled() {
     .await;
     let accounts = get_accounts_and_coins(&network_config, &state);
     assert_denied(&transfer_with_account(&accounts[0], &accounts[0], &state));
+}
+
+fn submit_gasless_with_account(
+    sender_account: &Account,
+    state: &Arc<AuthorityState>,
+) -> SuiResult<()> {
+    let data = TransactionData::V1(TransactionDataV1 {
+        kind: TransactionKind::ProgrammableTransaction(ProgrammableTransaction {
+            inputs: vec![],
+            commands: vec![],
+        }),
+        sender: sender_account.0,
+        gas_data: GasData {
+            payment: vec![],
+            owner: sender_account.0,
+            price: 0,
+            budget: 0,
+        },
+        expiration: TransactionExpiration::None,
+    });
+    let tx = to_sender_signed_transaction(data, &sender_account.1);
+    let epoch_store = state.epoch_store_for_testing();
+    let verified_tx = VerifiedTransaction::new_from_verified(tx);
+    state.handle_vote_transaction(&epoch_store, verified_tx)
+}
+
+#[tokio::test]
+async fn test_gasless_transaction_disabled() {
+    let (network_config, state) = setup_test(
+        TransactionDenyConfigBuilder::new()
+            .disable_gasless()
+            .build(),
+    )
+    .await;
+    let accounts = get_accounts_and_coins(&network_config, &state);
+    assert_denied(&submit_gasless_with_account(&accounts[0], &state));
+    assert!(transfer_with_account(&accounts[0], &accounts[0], &state).is_ok());
 }
 
 #[tokio::test]

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -58,6 +58,7 @@ validator_configs:
       package-upgrade-disabled: false
       shared-object-disabled: false
       user-transaction-disabled: false
+      gasless-disabled: false
       receiving-objects-disabled: false
       zklogin-sig-disabled: false
       zklogin-disabled-providers: []
@@ -236,6 +237,7 @@ validator_configs:
       package-upgrade-disabled: false
       shared-object-disabled: false
       user-transaction-disabled: false
+      gasless-disabled: false
       receiving-objects-disabled: false
       zklogin-sig-disabled: false
       zklogin-disabled-providers: []
@@ -414,6 +416,7 @@ validator_configs:
       package-upgrade-disabled: false
       shared-object-disabled: false
       user-transaction-disabled: false
+      gasless-disabled: false
       receiving-objects-disabled: false
       zklogin-sig-disabled: false
       zklogin-disabled-providers: []
@@ -592,6 +595,7 @@ validator_configs:
       package-upgrade-disabled: false
       shared-object-disabled: false
       user-transaction-disabled: false
+      gasless-disabled: false
       receiving-objects-disabled: false
       zklogin-sig-disabled: false
       zklogin-disabled-providers: []
@@ -770,6 +774,7 @@ validator_configs:
       package-upgrade-disabled: false
       shared-object-disabled: false
       user-transaction-disabled: false
+      gasless-disabled: false
       receiving-objects-disabled: false
       zklogin-sig-disabled: false
       zklogin-disabled-providers: []
@@ -948,6 +953,7 @@ validator_configs:
       package-upgrade-disabled: false
       shared-object-disabled: false
       user-transaction-disabled: false
+      gasless-disabled: false
       receiving-objects-disabled: false
       zklogin-sig-disabled: false
       zklogin-disabled-providers: []
@@ -1126,6 +1132,7 @@ validator_configs:
       package-upgrade-disabled: false
       shared-object-disabled: false
       user-transaction-disabled: false
+      gasless-disabled: false
       receiving-objects-disabled: false
       zklogin-sig-disabled: false
       zklogin-disabled-providers: []

--- a/crates/sui-transaction-checks/src/deny.rs
+++ b/crates/sui-transaction-checks/src/deny.rs
@@ -134,6 +134,11 @@ fn check_disabled_features(
         "Transaction signing is temporarily disabled"
     );
 
+    deny_if_true!(
+        filter_config.gasless_disabled() && tx_data.is_gasless_transaction(),
+        "Gasless transactions are temporarily disabled"
+    );
+
     tx_signatures.iter().try_for_each(|s| {
         if let GenericSignature::ZkLoginAuthenticator(z) = s {
             deny_if_true!(


### PR DESCRIPTION
## Summary
- Adds a `gasless-disabled` flag to `TransactionDenyConfig` so validators can disable gasless transactions The check fires in `pre_object_load_checks` (alongside the existing `user_transaction_disabled` / `shared_object_disabled` / etc. checks) and rejects with `UserInputError::TransactionDenied`.
- Detection uses the existing `TransactionDataAPI::is_gasless_transaction()` predicate (no payment object, ProgrammableTransaction, gas price 0). The check is purely shape-based and node-local — it does not depend on protocol config, and it is opt-in per-validator, so flipping it on cannot cause consensus equivocation.
- Adds two unit tests in `transaction_deny_tests.rs`: one verifies a gasless tx is denied (and a normal gas-paying tx still goes through) when the kill switch is on, and one verifies the deny path does not fire by default.

## Test plan
- [x] `SUI_SKIP_SIMTESTS=1 cargo nextest run -p sui-core transaction_deny_tests` (all 18 pass, including the 2 new tests)
- [x] `SUI_SKIP_SIMTESTS=1 cargo nextest run -p sui-config` (9/9 pass)
- [x] `cargo clippy -p sui-config -p sui-transaction-checks -p sui-core --tests -- -D warnings` (clean)
- [x] `cargo fmt --all` (clean)