### PR TITLE
Report zip_debug_eq caller as system_invariant_violations label

### DIFF
--- a/crates/mysten-common/src/logging.rs
+++ b/crates/mysten-common/src/logging.rs
@@ -74,10 +74,14 @@ macro_rules! register_debug_fatal_handler {
     };
 }
 
+/// Like `debug_fatal!`, but records `$location` (a `&str`) as the
+/// `system_invariant_violations` metric label instead of the macro's own
+/// `file!():line!()`. Use this when forwarding a caller-supplied location
+/// (e.g. from `#[track_caller]` + `Location::caller()`) so the metric points
+/// at the user's call site rather than the wrapper.
 #[macro_export]
-macro_rules! debug_fatal {
-    //($msg:literal $(, $arg:expr)* $(,)?)
-    ($msg:literal $(, $arg:expr)*) => {{
+macro_rules! debug_fatal_at {
+    ($location:expr, $msg:literal $(, $arg:expr)*) => {{
         loop {
             #[cfg(msim)]
             {
@@ -98,7 +102,7 @@ macro_rules! debug_fatal {
             } else {
                 let stacktrace = std::backtrace::Backtrace::capture();
                 tracing::error!(debug_fatal = true, stacktrace = ?stacktrace, $msg $(, $arg)*);
-                let location = concat!(file!(), ':', line!());
+                let location: &str = $location;
                 if let Some(metrics) = mysten_metrics::get_metrics() {
                     metrics.system_invariant_violations.with_label_values(&[location]).inc();
                 }
@@ -112,6 +116,14 @@ macro_rules! debug_fatal {
             }
             break;
         }
+    }};
+}
+
+#[macro_export]
+macro_rules! debug_fatal {
+    //($msg:literal $(, $arg:expr)* $(,)?)
+    ($msg:literal $(, $arg:expr)*) => {{
+        $crate::debug_fatal_at!(concat!(file!(), ':', line!()), $msg $(, $arg)*);
     }};
 }
 

--- a/crates/mysten-common/src/zip_debug_eq.rs
+++ b/crates/mysten-common/src/zip_debug_eq.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::debug_fatal;
+use crate::debug_fatal_at;
 use std::panic::Location;
 
 /// Extension trait providing `zip_debug_eq` on all iterators.
@@ -40,7 +40,8 @@ impl<A: Iterator, B: Iterator> Iterator for ZipDebugEq<A, B> {
             (None, None) => None,
             (None, Some(_)) => {
                 self.finished = true;
-                debug_fatal!(
+                debug_fatal_at!(
+                    &format!("{}:{}", self.caller.file(), self.caller.line()),
                     "zip_debug_eq: first iterator shorter than second (created at {})",
                     self.caller
                 );
@@ -48,7 +49,8 @@ impl<A: Iterator, B: Iterator> Iterator for ZipDebugEq<A, B> {
             }
             (Some(_), None) => {
                 self.finished = true;
-                debug_fatal!(
+                debug_fatal_at!(
+                    &format!("{}:{}", self.caller.file(), self.caller.line()),
                     "zip_debug_eq: second iterator shorter than first (created at {})",
                     self.caller
                 );


### PR DESCRIPTION
## Summary

`debug_fatal!` records `concat!(file!(), ':', line!())` as the `name` label on the `system_invariant_violations` Prometheus counter, which Grafana uses to localize invariant violations. For `zip_debug_eq`, that label always pointed at `crates/mysten-common/src/zip_debug_eq.rs` (the macro invocation site inside the iterator impl) instead of the user's `.zip_debug_eq(...)` call site, so the metric couldn't distinguish which caller was misbehaving.

This PR:
- Adds `debug_fatal_at!($location, $msg, ...)` in `mysten-common::logging`, identical to `debug_fatal!` except the metric label is taken from `$location` instead of the macro's textual `file!()/line!()`.
- Refactors `debug_fatal!` to delegate to `debug_fatal_at!`, preserving its existing behavior and labels at all current call sites.
- Routes `zip_debug_eq`'s two diagnostic arms through `debug_fatal_at!`, passing the `Location::caller()` already captured into `ZipDebugEq.caller` via `#[track_caller]`. The metric label now matches the user call site.

## Test plan

- [x] `SUI_SKIP_SIMTESTS=1 cargo nextest run -p mysten-common` (22/22 pass, including the four `zip_debug_eq` panic tests that exercise the `crash_on_debug → fatal!` path through the new plumbing).
- [x] `cargo xclippy` clean.
- [x] `cargo fmt --all` clean.
- [x] `cargo check -p sui-core` (downstream consumer of `debug_fatal!`) builds.