### PR TITLE
Drop live_owned_object_markers table

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1682,11 +1682,6 @@ impl AuthorityState {
             .expect("must return correct number of effects")
     }
 
-    fn check_owned_locks(&self, owned_object_refs: &[ObjectRef]) -> SuiResult {
-        self.get_object_cache_reader()
-            .check_owned_objects_are_live(owned_object_refs)
-    }
-
     /// This function captures the required state to debug a forked transaction.
     /// The dump is written to a file in dir `path`, with name prefixed by the transaction digest.
     /// NOTE: Since this info escapes the validator context,
@@ -2001,10 +1996,6 @@ impl AuthorityState {
             Err(e) => return ExecutionOutput::Fatal(e),
         };
 
-        let owned_object_refs = input_objects.inner().filter_owned_objects();
-        if let Err(e) = self.check_owned_locks(&owned_object_refs) {
-            return ExecutionOutput::Fatal(e);
-        }
         let tx_digest = *certificate.digest();
         let protocol_config = epoch_store.protocol_config();
         let transaction_data = &certificate.data().intent_message().value;

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -22,7 +22,7 @@ use move_core_types::resolver::{ModuleResolver, SerializedPackage};
 use serde::{Deserialize, Serialize};
 use sui_config::node::AuthorityStorePruningConfig;
 use sui_macros::fail_point_arg;
-use sui_types::error::{SuiErrorKind, UserInputError};
+use sui_types::error::UserInputError;
 use sui_types::execution::TypeLayoutStore;
 use sui_types::global_state_hash::GlobalStateHash;
 use sui_types::message_envelope::Message;
@@ -35,14 +35,10 @@ use sui_types::{base_types::SequenceNumber, fp_bail, fp_ensure};
 use tokio::time::Instant;
 use tracing::{debug, info, trace};
 use typed_store::traits::Map;
-use typed_store::{
-    TypedStoreError,
-    rocks::{DBBatch, DBMap},
-};
+use typed_store::{TypedStoreError, rocks::DBBatch};
 
 use super::authority_store_tables::LiveObject;
 use super::{authority_store_tables::AuthorityPerpetualTables, *};
-use mysten_common::ZipDebugEqIteratorExt;
 use mysten_common::sync::notify_read::NotifyRead;
 use sui_types::effects::{TransactionEffects, TransactionEvents};
 use sui_types::gas_coin::TOTAL_SUPPLY_MIST;
@@ -588,26 +584,16 @@ impl AuthorityStore {
         self.insert_object_direct(object_ref, &object)
     }
 
-    /// Insert an object directly into the store, and also update relevant tables
-    /// NOTE: does not handle transaction lock.
-    /// This is used to insert genesis objects
+    /// Insert an object directly into the store.
+    /// This is used to insert genesis objects.
     fn insert_object_direct(&self, object_ref: ObjectRef, object: &Object) -> SuiResult {
         let mut write_batch = self.perpetual_tables.objects.batch();
 
-        // Insert object
         let store_object = get_store_object(object.clone());
         write_batch.insert_batch(
             &self.perpetual_tables.objects,
             std::iter::once((ObjectKey::from(object_ref), store_object)),
         )?;
-
-        // Update the index
-        if object.get_single_owner().is_some() {
-            // Only initialize lock for address owned objects.
-            if !object.is_child_object() {
-                self.initialize_live_object_markers_impl(&mut write_batch, &[object_ref], false)?;
-            }
-        }
 
         write_batch.write()?;
 
@@ -628,18 +614,6 @@ impl AuthorityStore {
             ref_and_objects
                 .iter()
                 .map(|(oref, o)| (ObjectKey::from(oref), get_store_object((*o).clone()))),
-        )?;
-
-        let non_child_object_refs: Vec<_> = ref_and_objects
-            .iter()
-            .filter(|(_, object)| !object.is_child_object())
-            .map(|(oref, _)| *oref)
-            .collect();
-
-        self.initialize_live_object_markers_impl(
-            &mut batch,
-            &non_child_object_refs,
-            false, // is_force_reset
         )?;
 
         batch.write()?;
@@ -702,14 +676,6 @@ impl AuthorityStore {
                             store_object_wrapper,
                         )),
                     )?;
-                    if !object.is_child_object() {
-                        Self::initialize_live_object_markers(
-                            &perpetual_db.live_owned_object_markers,
-                            &mut batch,
-                            &[object.compute_object_reference()],
-                            true, // is_force_reset
-                        )?;
-                    }
                 }
                 LiveObject::Wrapped(object_key) => {
                     batch.insert_batch(
@@ -791,8 +757,6 @@ impl AuthorityStore {
             written,
             events,
             unchanged_loaded_runtime_objects,
-            locks_to_delete,
-            new_locks_to_init,
             ..
         } = tx_outputs;
 
@@ -863,12 +827,6 @@ impl AuthorityStore {
             )?;
         }
 
-        self.initialize_live_object_markers_impl(write_batch, new_locks_to_init, false)?;
-
-        // Note: deletes locks for received objects as well (but not for objects that were in
-        // `Receiving` arguments which were not received)
-        self.delete_live_object_markers(write_batch, locks_to_delete)?;
-
         debug!(effects_digest = ?effects.digest(), "commit_certificate finished");
 
         Ok(())
@@ -887,20 +845,23 @@ impl AuthorityStore {
     }
 
     /// Gets ObjectLockInfo that represents state of lock on an object.
-    /// Returns UserInputError::ObjectNotFound if cannot find lock record for this object
+    /// Returns UserInputError::ObjectNotFound if no live version of the object exists.
     pub(crate) fn get_lock(
         &self,
         obj_ref: ObjectRef,
         epoch_store: &AuthorityPerEpochStore,
     ) -> SuiLockResult {
-        if self
-            .perpetual_tables
-            .live_owned_object_markers
-            .get(&obj_ref)?
-            .is_none()
-        {
+        let latest_alive = self.get_latest_object_ref_if_alive(obj_ref.0)?;
+        let Some(latest_ref) = latest_alive else {
+            return Err(UserInputError::ObjectNotFound {
+                object_id: obj_ref.0,
+                version: None,
+            }
+            .into());
+        };
+        if latest_ref != obj_ref {
             return Ok(ObjectLockStatus::LockedAtDifferentVersion {
-                locked_ref: self.get_latest_live_version_for_object_id(obj_ref.0)?,
+                locked_ref: latest_ref,
             });
         }
 
@@ -919,127 +880,29 @@ impl AuthorityStore {
         }
     }
 
-    /// Returns UserInputError::ObjectNotFound if no lock records found for this object.
-    pub(crate) fn get_latest_live_version_for_object_id(
-        &self,
-        object_id: ObjectID,
-    ) -> SuiResult<ObjectRef> {
-        let mut iterator = self
-            .perpetual_tables
-            .live_owned_object_markers
-            .reversed_safe_iter_with_bounds(
-                None,
-                Some((object_id, SequenceNumber::MAX, ObjectDigest::MAX)),
-            )?;
-        Ok(iterator
-            .next()
-            .transpose()?
-            .and_then(|value| {
-                if value.0.0 == object_id {
-                    Some(value)
-                } else {
-                    None
-                }
-            })
-            .ok_or_else(|| {
-                SuiError::from(UserInputError::ObjectNotFound {
-                    object_id,
-                    version: None,
-                })
-            })?
-            .0)
-    }
-
-    /// Checks multiple object locks exist.
-    /// Returns UserInputError::ObjectNotFound if cannot find lock record for at least one of the objects.
-    /// Returns UserInputError::ObjectVersionUnavailableForConsumption if at least one object lock is not initialized
-    ///     at the given version.
+    /// Checks that every requested ObjectRef matches the latest live version of that object.
+    /// Returns UserInputError::ObjectNotFound if any object has no live version (deleted/wrapped/missing).
+    /// Returns UserInputError::ObjectVersionUnavailableForConsumption if the latest live version
+    /// differs from the requested ref.
     pub fn check_owned_objects_are_live(&self, objects: &[ObjectRef]) -> SuiResult {
-        let locks = self
-            .perpetual_tables
-            .live_owned_object_markers
-            .multi_get(objects)?;
-        for (lock, obj_ref) in locks.into_iter().zip_debug_eq(objects) {
-            if lock.is_none() {
-                let latest_lock = self.get_latest_live_version_for_object_id(obj_ref.0)?;
-                fp_bail!(
-                    UserInputError::ObjectVersionUnavailableForConsumption {
-                        provided_obj_ref: *obj_ref,
-                        current_version: latest_lock.1
-                    }
-                    .into()
-                );
-            }
-        }
-        Ok(())
-    }
-
-    /// Initialize a lock to None (but exists) for a given list of ObjectRefs.
-    /// Returns SuiErrorKind::ObjectLockAlreadyInitialized if the lock already exists and is locked to a transaction
-    fn initialize_live_object_markers_impl(
-        &self,
-        write_batch: &mut DBBatch,
-        objects: &[ObjectRef],
-        is_force_reset: bool,
-    ) -> SuiResult {
-        AuthorityStore::initialize_live_object_markers(
-            &self.perpetual_tables.live_owned_object_markers,
-            write_batch,
-            objects,
-            is_force_reset,
-        )
-    }
-
-    pub fn initialize_live_object_markers(
-        live_object_marker_table: &DBMap<ObjectRef, Option<LockDetailsWrapperDeprecated>>,
-        write_batch: &mut DBBatch,
-        objects: &[ObjectRef],
-        is_force_reset: bool,
-    ) -> SuiResult {
-        trace!(?objects, "initialize_locks");
-
-        if !is_force_reset {
-            let live_object_markers = live_object_marker_table.multi_get(objects)?;
-            // If any live_object_markers exist and are not None, return errors for them
-            // Note we don't check if there is a pre-existing lock. this is because initializing the live
-            // object marker will not overwrite the lock and cause the validator to equivocate.
-            let existing_live_object_markers: Vec<ObjectRef> = live_object_markers
-                .iter()
-                .zip_debug_eq(objects)
-                .filter_map(|(lock_opt, objref)| {
-                    lock_opt.clone().flatten().map(|_tx_digest| *objref)
-                })
-                .collect();
-            if !existing_live_object_markers.is_empty() {
-                info!(
-                    ?existing_live_object_markers,
-                    "Cannot initialize live_object_markers because some exist already"
-                );
-                return Err(SuiErrorKind::ObjectLockAlreadyInitialized {
-                    refs: existing_live_object_markers,
+        for obj_ref in objects {
+            let latest_alive = self.get_latest_object_ref_if_alive(obj_ref.0)?;
+            match latest_alive {
+                None => fp_bail!(UserInputError::ObjectNotFound {
+                    object_id: obj_ref.0,
+                    version: None,
                 }
-                .into());
+                .into()),
+                Some(latest_ref) if latest_ref != *obj_ref => {
+                    fp_bail!(UserInputError::ObjectVersionUnavailableForConsumption {
+                        provided_obj_ref: *obj_ref,
+                        current_version: latest_ref.1,
+                    }
+                    .into());
+                }
+                Some(_) => {}
             }
         }
-
-        write_batch.insert_batch(
-            live_object_marker_table,
-            objects.iter().map(|obj_ref| (obj_ref, None)),
-        )?;
-        Ok(())
-    }
-
-    /// Removes locks for a given list of ObjectRefs.
-    fn delete_live_object_markers(
-        &self,
-        write_batch: &mut DBBatch,
-        objects: &[ObjectRef],
-    ) -> SuiResult {
-        trace!(?objects, "delete_locks");
-        write_batch.delete_batch(
-            &self.perpetual_tables.live_owned_object_markers,
-            objects.iter(),
-        )?;
         Ok(())
     }
 
@@ -1704,50 +1567,9 @@ pub enum ObjectLockStatus {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub enum LockDetailsWrapperDeprecated {
-    V1(LockDetailsV1Deprecated),
-}
-
-impl LockDetailsWrapperDeprecated {
-    pub fn migrate(self) -> Self {
-        // TODO: when there are multiple versions, we must iteratively migrate from version N to
-        // N+1 until we arrive at the latest version
-        self
-    }
-
-    // Always returns the most recent version. Older versions are migrated to the latest version at
-    // read time, so there is never a need to access older versions.
-    pub fn inner(&self) -> &LockDetailsDeprecated {
-        match self {
-            Self::V1(v1) => v1,
-
-            // can remove #[allow] when there are multiple versions
-            #[allow(unreachable_patterns)]
-            _ => panic!("lock details should have been migrated to latest version at read time"),
-        }
-    }
-    pub fn into_inner(self) -> LockDetailsDeprecated {
-        match self {
-            Self::V1(v1) => v1,
-
-            // can remove #[allow] when there are multiple versions
-            #[allow(unreachable_patterns)]
-            _ => panic!("lock details should have been migrated to latest version at read time"),
-        }
-    }
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LockDetailsV1Deprecated {
     pub epoch: EpochId,
     pub tx_digest: TransactionDigest,
 }
 
 pub type LockDetailsDeprecated = LockDetailsV1Deprecated;
-
-impl From<LockDetailsDeprecated> for LockDetailsWrapperDeprecated {
-    fn from(details: LockDetailsDeprecated) -> Self {
-        // always use latest version.
-        LockDetailsWrapperDeprecated::V1(details)
-    }
-}

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -31,7 +31,7 @@ use sui_types::storage::{
     get_module, get_package,
 };
 use sui_types::sui_system_state::get_sui_system_state;
-use sui_types::{base_types::SequenceNumber, fp_bail, fp_ensure};
+use sui_types::{base_types::SequenceNumber, fp_ensure};
 use tokio::time::Instant;
 use tracing::{debug, info, trace};
 use typed_store::traits::Map;
@@ -878,36 +878,6 @@ impl AuthorityStore {
         } else {
             Ok(ObjectLockStatus::Initialized)
         }
-    }
-
-    /// Checks that every requested ObjectRef matches the latest live version of that object.
-    /// Returns UserInputError::ObjectNotFound if any object has no live version (deleted/wrapped/missing).
-    /// Returns UserInputError::ObjectVersionUnavailableForConsumption if the latest live version
-    /// differs from the requested ref.
-    pub fn check_owned_objects_are_live(&self, objects: &[ObjectRef]) -> SuiResult {
-        for obj_ref in objects {
-            let latest_alive = self.get_latest_object_ref_if_alive(obj_ref.0)?;
-            match latest_alive {
-                None => fp_bail!(
-                    UserInputError::ObjectNotFound {
-                        object_id: obj_ref.0,
-                        version: None,
-                    }
-                    .into()
-                ),
-                Some(latest_ref) if latest_ref != *obj_ref => {
-                    fp_bail!(
-                        UserInputError::ObjectVersionUnavailableForConsumption {
-                            provided_obj_ref: *obj_ref,
-                            current_version: latest_ref.1,
-                        }
-                        .into()
-                    );
-                }
-                Some(_) => {}
-            }
-        }
-        Ok(())
     }
 
     /// Return the object with version less then or eq to the provided seq number.

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -888,17 +888,21 @@ impl AuthorityStore {
         for obj_ref in objects {
             let latest_alive = self.get_latest_object_ref_if_alive(obj_ref.0)?;
             match latest_alive {
-                None => fp_bail!(UserInputError::ObjectNotFound {
-                    object_id: obj_ref.0,
-                    version: None,
-                }
-                .into()),
-                Some(latest_ref) if latest_ref != *obj_ref => {
-                    fp_bail!(UserInputError::ObjectVersionUnavailableForConsumption {
-                        provided_obj_ref: *obj_ref,
-                        current_version: latest_ref.1,
+                None => fp_bail!(
+                    UserInputError::ObjectNotFound {
+                        object_id: obj_ref.0,
+                        version: None,
                     }
-                    .into());
+                    .into()
+                ),
+                Some(latest_ref) if latest_ref != *obj_ref => {
+                    fp_bail!(
+                        UserInputError::ObjectVersionUnavailableForConsumption {
+                            provided_obj_ref: *obj_ref,
+                            current_version: latest_ref.1,
+                        }
+                        .into()
+                    );
                 }
                 Some(_) => {}
             }

--- a/crates/sui-core/src/authority/authority_store_tables.rs
+++ b/crates/sui-core/src/authority/authority_store_tables.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
-use crate::authority::authority_store::LockDetailsWrapperDeprecated;
 #[cfg(tidehunter)]
 use crate::authority::epoch_marker_key::EPOCH_MARKER_KEY_SIZE;
 use crate::authority::epoch_marker_key::EpochMarkerKey;
@@ -65,13 +64,6 @@ pub struct AuthorityPerpetualTables {
     /// been written out, and which must be retried. But, they cannot be retried unless their input
     /// objects are still accessible!
     pub(crate) objects: DBMap<ObjectKey, StoreObjectWrapper>,
-
-    /// This is a map between object references of currently active objects that can be mutated.
-    ///
-    /// For old epochs, it may also contain the transaction that they are lock on for use by this
-    /// specific validator. The transaction locks themselves are now in AuthorityPerEpochStore.
-    #[rename = "owned_object_transaction_locks"]
-    pub(crate) live_owned_object_markers: DBMap<ObjectRef, Option<LockDetailsWrapperDeprecated>>,
 
     /// This is a map between the transaction digest and the corresponding transaction that's known to be
     /// executable. This means that it may have been executed locally, or it may have been synced through
@@ -163,10 +155,6 @@ impl AuthorityPerpetualTables {
                 objects_table_config(db_options.clone()),
             ),
             (
-                "owned_object_transaction_locks".to_string(),
-                owned_object_transaction_locks_table_config(db_options.clone()),
-            ),
-            (
                 "transactions".to_string(),
                 transactions_table_config(db_options.clone()),
             ),
@@ -227,10 +215,6 @@ impl AuthorityPerpetualTables {
         let epoch_tx_digest_prefix_key =
             KeyType::from_prefix_bits((8/*EpochId*/ + 8/*TransactionDigest prefix*/) * 8 + 12);
         let object_indexing = KeyIndexing::fixed(32 + 8); //  KeyIndexing::key_reduction(32 + 8, 16..(32 + 8));
-        // todo can figure way to scramble off 8 bytes in the middle
-        let obj_ref_size = 32 + 8 + 32 + 8;
-        let owned_object_transaction_locks_indexing =
-            KeyIndexing::key_reduction(obj_ref_size, 16..(obj_ref_size - 16));
 
         let mut objects_config = KeySpaceConfig::new()
             .with_max_dirty_keys(4096)
@@ -247,15 +231,6 @@ impl AuthorityPerpetualTables {
                     mutexes * 4,
                     KeyType::uniform(1),
                     objects_config,
-                ),
-            ),
-            (
-                "owned_object_transaction_locks".to_string(),
-                ThConfig::new_with_config_indexing(
-                    owned_object_transaction_locks_indexing,
-                    mutexes * 16,
-                    KeyType::uniform(default_cells_per_mutex()),
-                    bloom_config.clone().with_max_dirty_keys(16192),
                 ),
             ),
             (
@@ -879,17 +854,6 @@ impl Iterator for LiveSetIter<'_> {
 }
 
 // These functions are used to initialize the DB tables
-fn owned_object_transaction_locks_table_config(db_options: DBOptions) -> DBOptions {
-    DBOptions {
-        options: db_options
-            .clone()
-            .optimize_for_write_throughput()
-            .optimize_for_read(read_size_from_env(ENV_VAR_LOCKS_BLOCK_CACHE_SIZE).unwrap_or(1024))
-            .options,
-        rw_options: db_options.rw_options.set_ignore_range_deletions(false),
-    }
-}
-
 fn objects_table_config(db_options: DBOptions) -> DBOptions {
     db_options
         .optimize_for_write_throughput()

--- a/crates/sui-core/src/execution_cache.rs
+++ b/crates/sui-core/src/execution_cache.rs
@@ -333,10 +333,6 @@ pub trait ObjectCacheRead: Send + Sync {
     // This method is considered "private" - only used by multi_get_objects_with_more_accurate_error_return
     fn _get_live_objref(&self, object_id: ObjectID) -> SuiResult<ObjectRef>;
 
-    // Check that the given set of objects are live at the given version. This is used as a
-    // safety check before execution, and could potentially be deleted or changed to a debug_assert
-    fn check_owned_objects_are_live(&self, owned_object_refs: &[ObjectRef]) -> SuiResult;
-
     fn get_sui_system_state_object_unsafe(&self) -> SuiResult<SuiSystemState>;
 
     fn get_bridge_object_unsafe(&self) -> SuiResult<Bridge>;

--- a/crates/sui-core/src/execution_cache/writeback_cache.rs
+++ b/crates/sui-core/src/execution_cache/writeback_cache.rs
@@ -46,7 +46,7 @@ use crate::authority::authority_store::{
 use crate::authority::authority_store_tables::LiveObject;
 use crate::authority::backpressure::BackpressureManager;
 use crate::authority::epoch_start_configuration::{EpochFlag, EpochStartConfiguration};
-use crate::fallback_fetch::{do_fallback_lookup, do_fallback_lookup_fallible};
+use crate::fallback_fetch::do_fallback_lookup;
 use crate::global_state_hasher::GlobalStateHashStore;
 use crate::transaction_outputs::TransactionOutputs;
 
@@ -1920,37 +1920,6 @@ impl ObjectCacheRead for WritebackCache {
             },
         )?;
         Ok(obj.compute_object_reference())
-    }
-
-    fn check_owned_objects_are_live(&self, owned_object_refs: &[ObjectRef]) -> SuiResult {
-        do_fallback_lookup_fallible(
-            owned_object_refs,
-            |obj_ref| match self.get_object_by_id_cache_only("object_is_live", &obj_ref.0) {
-                CacheResult::Hit((version, obj)) => {
-                    if obj.compute_object_reference() != *obj_ref {
-                        Err(UserInputError::ObjectVersionUnavailableForConsumption {
-                            provided_obj_ref: *obj_ref,
-                            current_version: version,
-                        }
-                        .into())
-                    } else {
-                        Ok(CacheResult::Hit(()))
-                    }
-                }
-                CacheResult::NegativeHit => Err(UserInputError::ObjectNotFound {
-                    object_id: obj_ref.0,
-                    version: None,
-                }
-                .into()),
-                CacheResult::Miss => Ok(CacheResult::Miss),
-            },
-            |remaining| {
-                self.record_db_multi_get("object_is_live", remaining.len())
-                    .check_owned_objects_are_live(remaining)?;
-                Ok(vec![(); remaining.len()])
-            },
-        )?;
-        Ok(())
     }
 
     fn get_highest_pruned_checkpoint(&self) -> Option<CheckpointSequenceNumber> {


### PR DESCRIPTION
## Summary

Two related cleanups:

1. **Drop the `live_owned_object_markers` (column family `owned_object_transaction_locks`) table.** Its `LockDetailsWrapperDeprecated` value was already deprecated; only the key was meaningful, as a "live owned object" set. Every read it served is redundant with the `objects` table, and the cache hot path for those readers already used `objects` directly — only the disk fallback used markers.
2. **Remove the redundant `check_owned_locks` recheck inside `process_certificate`.** With post-consensus locking, the safety property this check was guarding is already established earlier in the pipeline.

## Why `check_owned_locks` is gone

The check ran inside `process_certificate` right before execution and re-verified that every owned input ObjectRef still pointed to the latest live version. With post-consensus locking the same guarantee is established earlier and held until execution:

- `try_acquire_owned_object_locks_post_consensus` (`consensus_handler.rs:2871`) runs for every `UserTransactionV2` before the certificate proceeds, and blocks any conflicting tx for the same owned `(id, version, digest)`.
- `check_certificate_input` runs at the top of `process_certificate` and re-resolves input objects against the cache; a stale input fails there with the same `ObjectVersionUnavailableForConsumption` / `ObjectNotFound` errors.

So two transactions can no longer race to consume the same owned object version, and a stale ObjectRef would have been caught upstream. The hot path was paying a `compute_object_reference` (BCS-encode + Blake2b256) per owned input per cert with no failure mode left for it to catch.

This commit removes:
- `AuthorityState::check_owned_locks` + its call in `process_certificate`
- `ObjectCacheRead::check_owned_objects_are_live` trait method
- `WritebackCache` and `AuthorityStore` impls of the same

## Why dropping `live_owned_object_markers` is safe

- `check_owned_objects_are_live` is now removed entirely (see above), so its disk fallback no longer needs the marker table.
- `get_lock` (which fed `ObjectInfoResponse.lock_for_debugging`) is rewritten to read liveness via `get_latest_object_ref_if_alive` against the `objects` table; the locking tx digest still comes from the per-epoch `owned_object_locked_transactions` table.
- The marker init/delete writes in genesis insert, bulk insert, snapshot restore, and the commit path are removed.
- The field declaration and the `owned_object_transaction_locks` entry in both RocksDB and tidehunter `open()` paths are removed.
- `LockDetailsWrapperDeprecated` enum + `owned_object_transaction_locks_table_config` helper removed.

## Notes for reviewers

- **Migration**: tidehunter does not support keyspace deletion, so existing tidehunter DBs will keep `owned_object_transaction_locks` on disk but the binary will no longer reference it. RocksDB nodes will leave the CF on disk after upgrade (typed-store's `populate_missing_cfs` opens unknown-on-disk CFs with default options); a separate cleanup task can drop it.
- **Orphan fields**: `TransactionOutputs.locks_to_delete` and `new_locks_to_init` are now computed but unused in production. Left in place to keep the diff focused — removal touches `writeback_cache_tests` mocks.
- **Background**: per-conversation analysis confirmed the marker table's only readers were `check_owned_locks` (now removed as redundant) and `lock_for_debugging` (`ObjectInfoResponse`, consumed only by `sui-tool`).

## Test plan

- [x] `cargo check -p sui-core` (RocksDB + `USE_TIDEHUNTER=1 ... --features typed-store/tidehunter`)
- [x] `cargo nextest run -p sui-core --lib` — all tests pass (one flake in `jsonrpc_index::tests::test_index_cache` from a parallel RocksDB lock race; passes in isolation, unrelated)
- [x] `cargo nextest run -p sui-core --lib authority_tests transaction_tests` — 129/129 pass
- [x] `cargo clippy -p sui-core --all-targets -- -D warnings` — clean
- [x] private-testnet deploy at 12K TPS w/ tidehunter enabled
- [ ] e2e: `cargo simtest -p sui-e2e-tests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)