### PR TITLE
sui-node-th: bundle sui-th, sui-tool-th, stress-th into the same image

### DIFF
--- a/docker/sui-node-th/Dockerfile
+++ b/docker/sui-node-th/Dockerfile
@@ -16,7 +16,9 @@ COPY sui-execution sui-execution
 COPY external-crates external-crates
 
 ENV USE_TIDEHUNTER=1
-RUN cargo build --profile ${PROFILE} --features typed-store/tidehunter --bin sui-node --target-dir target/tidehunter
+RUN cargo build --profile ${PROFILE} --features typed-store/tidehunter \
+    --bin sui-node --bin sui --bin sui-tool --bin stress \
+    --target-dir target/tidehunter
 
 # Production Image
 FROM debian:bullseye-slim AS runtime
@@ -24,17 +26,13 @@ FROM debian:bullseye-slim AS runtime
 RUN apt-get update && apt-get install -y ca-certificates curl
 ARG PROFILE=release
 WORKDIR "$WORKDIR/sui"
-# Only ship the tidehunter binary at a suffixed path. Intentionally no
-# /opt/sui/bin/sui-node or /usr/local/bin/sui-node aliases — the binary
-# uses the tidehunter storage backend, which is incompatible with rocksdb,
-# and silently swapping at the canonical paths would let callers run it
-# as plain sui-node and corrupt unrelated databases. K8s pod entrypoints
-# must call /opt/sui/bin/sui-node-th explicitly. mp3's binary_upload_config
-# extracts this path to s3://sui-releases/{sha}/sui-node-th via {basename}
-# substitution; that S3 location is the contract for ansible bare-metal
-# nodes (the build_with_tidehunter selector in
-# sui-operations/ansible/playbook/sui/roles/sui-node-{internal,external}).
+# Tidehunter-feature binaries ship at suffixed paths only — no canonical
+# aliases, since the storage backend is incompatible with rocksdb and a
+# silent swap at /opt/sui/bin/sui-node could corrupt unrelated databases.
 COPY --from=builder /sui/target/tidehunter/release/sui-node /opt/sui/bin/sui-node-th
+COPY --from=builder /sui/target/tidehunter/release/sui      /opt/sui/bin/sui-th
+COPY --from=builder /sui/target/tidehunter/release/sui-tool /opt/sui/bin/sui-tool-th
+COPY --from=builder /sui/target/tidehunter/release/stress   /opt/sui/bin/stress-th
 
 ARG BUILD_DATE
 ARG GIT_REVISION


### PR DESCRIPTION
## Summary

Extends the existing tidehunter-feature build in `docker/sui-node-th/Dockerfile` to also produce `sui`, `sui-tool`, and `stress` alongside `sui-node`. All four ship at `/opt/sui/bin/{name}-th` (suffixed paths only — no canonical aliases, same rationale as before: the tidehunter storage backend is incompatible with rocksdb).

This brings the `sui-node-th` image to parity with what `sui-release-binaries.yml` emits today (`sui-node-th`, `sui-th`, `sui-tool-th`, `stress-th`), so a follow-up sui-operations PR can teach mp3's `binary_upload_config` to extract all four from this one image — replacing the redundant ~25-min legacy cargo build.

## Why

mp3 (the new image-based binary pipeline) currently produces `sui-node-th` but not the other three. That created a cache-check false-positive in `sui-release-binaries.yml`: once mp3 uploads `sui-node-th` to S3, the legacy build short-circuits and never produces `stress-th`, leading to 403s during PTN ansible deploys (e.g. https://github.com/MystenLabs/sui-operations/actions/runs/25137399290/job/73679295113).

One cargo invocation builds all four here (vs. one per binary in `sui-release-binaries.yml` today).

## Test plan

- [ ] CI builds the modified `docker/sui-node-th` image successfully
- [ ] Image contains all four binaries at `/opt/sui/bin/{sui-node,sui,sui-tool,stress}-th`
- [ ] Follow-up sui-operations PR teaches mp3 to extract all four; verify S3 uploads land at `s3://sui-releases/{sha}/{sui-node,sui,sui-tool,stress}-th`
- [ ] PTN ansible deploy succeeds end-to-end without falling back to legacy `sui-release-binaries.yml`