### PR TITLE
[Graphql-alt] Graphql client sdk metric

### DIFF
--- a/crates/sui-indexer-alt-graphql/src/extensions/logging.rs
+++ b/crates/sui-indexer-alt-graphql/src/extensions/logging.rs
@@ -47,21 +47,28 @@ use crate::metrics::RpcMetrics;
 /// This custom response header contains a unique request-id used for debugging and appears in the logs.
 pub const REQUEST_ID_HEADER: HeaderName = HeaderName::from_static("x-sui-rpc-request-id");
 
-/// Headers identifying the SDK that issued the request. To capture an additional client header
-/// in the future, define another constant here, read it in `ClientInfo::from_headers`, and expose
-/// it via the appropriate metric label or log field.
+/// Header identifying the SDK that issued the request. The value flows into the
+/// `client_sdk_type` Prometheus label, matched against `SDK_TYPE_WHITELIST`. Add a new entry to
+/// the whitelist when a new first-party SDK adopts this header, otherwise its requests will be
+/// bucketed into `CLIENT_LABEL_OTHER`.
 const CLIENT_SDK_TYPE_HEADER: HeaderName = HeaderName::from_static("client-sdk-type");
+
+/// Header identifying the SDK version that issued the request. The value flows into the
+/// `client_sdk_version` Prometheus label, sanitized by `sanitize_sdk_version`. Values longer
+/// than `MAX_SDK_VERSION_LEN` or containing characters outside `[A-Za-z0-9._-]` are bucketed
+/// into `CLIENT_LABEL_OTHER`.
 const CLIENT_SDK_VERSION_HEADER: HeaderName = HeaderName::from_static("client-sdk-version");
 
-/// Maximum length of a client SDK header value we accept as a Prometheus label. Anything longer
-/// is bucketed to `CLIENT_LABEL_INVALID` so a misbehaving client cannot grow the per-series memory
-/// cost without bound.
-const MAX_CLIENT_SDK_LABEL_LEN: usize = 64;
+/// SDKs we accept verbatim as the `client_sdk_type` Prometheus label.
+const SDK_TYPE_WHITELIST: &[&str] = &["rust", "typescript", "python"];
 
-/// Sentinel label value substituted when a client SDK header exceeds `MAX_CLIENT_SDK_LABEL_LEN`.
-/// Distinct from the empty string we use when the header is absent, so dashboards can tell the
-/// two apart.
-const CLIENT_LABEL_INVALID: &str = "INVALID";
+/// Maximum length of a `client-sdk-version` value we accept verbatim.
+const MAX_SDK_VERSION_LEN: usize = 32;
+
+/// Sentinel label value substituted when a client SDK header is present but does not match an
+/// allowed value. Distinct from the empty string we use when the header is absent, so dashboards
+/// can tell the two apart.
+const CLIENT_LABEL_OTHER: &str = "other";
 
 /// Context data that tracks the session UUID and the client's address, to associate logs with a
 /// particular request.
@@ -125,11 +132,11 @@ impl ClientInfo {
             sdk_type: headers
                 .get(&CLIENT_SDK_TYPE_HEADER)
                 .and_then(|v| v.to_str().ok())
-                .map(sanitize_client_label),
+                .map(sanitize_sdk_type),
             sdk_version: headers
                 .get(&CLIENT_SDK_VERSION_HEADER)
                 .and_then(|v| v.to_str().ok())
-                .map(sanitize_client_label),
+                .map(sanitize_sdk_version),
         }
     }
 }
@@ -165,18 +172,13 @@ impl ExtensionFactory for Logging {
 #[async_trait::async_trait]
 impl Extension for LoggingExt {
     async fn request(&self, ctx: &ExtensionContext<'_>, next: NextRequest<'_>) -> Response {
-        let session: &Session = ctx.data_unchecked();
-        let client_sdk_type = session.client.sdk_type.as_deref().unwrap_or("");
-        let client_sdk_version = session.client.sdk_version.as_deref().unwrap_or("");
-        self.metrics
-            .queries_received
-            .with_label_values(&[client_sdk_type, client_sdk_version])
-            .inc();
         MetricsFuture::request(self, next.run(ctx)).await
     }
 
     /// Capture Session information from the Context so that the `request` handler can use it for
-    /// logging, once it has finished executing.
+    /// logging, once it has finished executing. The labeled `queries_received` counter is also
+    /// incremented here because `request` is called before request-level data is merged into the
+    /// context, so `Session` is not yet readable at that point.
     async fn prepare_request(
         &self,
         ctx: &ExtensionContext<'_>,
@@ -184,6 +186,12 @@ impl Extension for LoggingExt {
         next: NextPrepareRequest<'_>,
     ) -> ServerResult<Request> {
         let session: &Session = ctx.data_unchecked();
+        let client_sdk_type = session.client.sdk_type.as_deref().unwrap_or("");
+        let client_sdk_version = session.client.sdk_version.as_deref().unwrap_or("");
+        self.metrics
+            .queries_received
+            .with_label_values(&[client_sdk_type, client_sdk_version])
+            .inc();
         let _ = self.session.set(session.clone());
         next.run(ctx, request).await
     }
@@ -328,14 +336,32 @@ fn is_loud_query(codes: &[&str]) -> bool {
             .any(|c| matches!(*c, code::REQUEST_TIMEOUT | code::INTERNAL_SERVER_ERROR))
 }
 
-/// Sanitize a client SDK header value before it is used as a Prometheus label. Values longer than
-/// `MAX_CLIENT_SDK_LABEL_LEN` bytes are bucketed to `CLIENT_LABEL_INVALID`, which caps the
-/// per-series memory cost in the metric registry.
-fn sanitize_client_label(value: &str) -> String {
-    if value.len() <= MAX_CLIENT_SDK_LABEL_LEN {
+/// Sanitize a `client-sdk-type` header value before it is used as a Prometheus label. Values
+/// outside `SDK_TYPE_WHITELIST` are bucketed to `CLIENT_LABEL_OTHER` so the metric's cardinality
+/// is bounded by the size of the whitelist.
+fn sanitize_sdk_type(value: &str) -> String {
+    if SDK_TYPE_WHITELIST.contains(&value) {
         value.to_string()
     } else {
-        CLIENT_LABEL_INVALID.to_string()
+        CLIENT_LABEL_OTHER.to_string()
+    }
+}
+
+/// Sanitize a `client-sdk-version` header value before it is used as a Prometheus label. Values
+/// longer than `MAX_SDK_VERSION_LEN` or containing characters outside `[A-Za-z0-9._-]` are
+/// bucketed to `CLIENT_LABEL_OTHER`. Build metadata (`+...`) is rejected on purpose, because
+/// per-build suffixes are exactly the cardinality vector we are trying to avoid.
+fn sanitize_sdk_version(value: &str) -> String {
+    let valid = !value.is_empty()
+        && value.len() <= MAX_SDK_VERSION_LEN
+        && value
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'-' | b'_'));
+
+    if valid {
+        value.to_string()
+    } else {
+        CLIENT_LABEL_OTHER.to_string()
     }
 }
 
@@ -383,17 +409,45 @@ mod tests {
     }
 
     #[test]
-    fn client_info_oversized_value_bucketed_invalid() {
+    fn client_info_unknown_sdk_type_bucketed_other() {
         let mut headers = HeaderMap::new();
-        let too_long = "a".repeat(MAX_CLIENT_SDK_LABEL_LEN + 1);
+        headers.insert(CLIENT_SDK_TYPE_HEADER, HeaderValue::from_static("haskell"));
+        headers.insert(CLIENT_SDK_VERSION_HEADER, HeaderValue::from_static("0.1.0"));
+
+        let info = ClientInfo::from_headers(&headers);
+
+        assert_eq!(info.sdk_type.as_deref(), Some(CLIENT_LABEL_OTHER));
+        assert_eq!(info.sdk_version.as_deref(), Some("0.1.0"));
+    }
+
+    #[test]
+    fn client_info_oversized_version_bucketed_other() {
+        let mut headers = HeaderMap::new();
+        let too_long = "1.".to_string() + &"0".repeat(MAX_SDK_VERSION_LEN);
+        headers.insert(CLIENT_SDK_TYPE_HEADER, HeaderValue::from_static("rust"));
         headers.insert(
-            CLIENT_SDK_TYPE_HEADER,
+            CLIENT_SDK_VERSION_HEADER,
             HeaderValue::from_str(&too_long).unwrap(),
         );
 
         let info = ClientInfo::from_headers(&headers);
 
-        assert_eq!(info.sdk_type.as_deref(), Some(CLIENT_LABEL_INVALID));
+        assert_eq!(info.sdk_type.as_deref(), Some("rust"));
+        assert_eq!(info.sdk_version.as_deref(), Some(CLIENT_LABEL_OTHER));
+    }
+
+    #[test]
+    fn client_info_version_with_build_metadata_bucketed_other() {
+        let mut headers = HeaderMap::new();
+        headers.insert(CLIENT_SDK_TYPE_HEADER, HeaderValue::from_static("rust"));
+        headers.insert(
+            CLIENT_SDK_VERSION_HEADER,
+            HeaderValue::from_static("1.0.0+abc123"),
+        );
+
+        let info = ClientInfo::from_headers(&headers);
+
+        assert_eq!(info.sdk_version.as_deref(), Some(CLIENT_LABEL_OTHER));
     }
 
     #[tokio::test]

--- a/crates/sui-indexer-alt-graphql/src/extensions/logging.rs
+++ b/crates/sui-indexer-alt-graphql/src/extensions/logging.rs
@@ -250,11 +250,7 @@ where
         ext.metrics.queries_in_flight.dec();
 
         // SAFETY: This is set by `prepare_request`.
-        let Session {
-            uuid,
-            addr,
-            client,
-        } = ext.session.get().unwrap();
+        let Session { uuid, addr, client } = ext.session.get().unwrap();
         let client_sdk_type = client.sdk_type.as_deref().unwrap_or("");
         let client_sdk_version = client.sdk_version.as_deref().unwrap_or("");
         let request_id = uuid.to_string().try_into().unwrap();
@@ -301,11 +297,7 @@ where
 impl<F> PinnedDrop for MetricsFuture<F> {
     fn drop(self: Pin<&mut Self>) {
         if let Some(RequestMetrics { timer, ext }) = self.project().metrics.take() {
-            let Session {
-                uuid,
-                addr,
-                client,
-            } = ext.session.get().unwrap();
+            let Session { uuid, addr, client } = ext.session.get().unwrap();
             let client_sdk_type = client.sdk_type.as_deref().unwrap_or("");
             let client_sdk_version = client.sdk_version.as_deref().unwrap_or("");
             let elapsed_ms = timer.stop_and_record() * 1000.0;
@@ -382,10 +374,7 @@ mod tests {
         assert!(response.is_err());
         assert_eq!(error_codes(&response), vec![code::GRAPHQL_PARSE_FAILED]);
         assert_eq!(
-            metrics
-                .queries_received
-                .with_label_values(&["", ""])
-                .get(),
+            metrics.queries_received.with_label_values(&["", ""]).get(),
             1
         );
         assert_eq!(
@@ -417,10 +406,7 @@ mod tests {
             vec![code::GRAPHQL_VALIDATION_FAILED]
         );
         assert_eq!(
-            metrics
-                .queries_received
-                .with_label_values(&["", ""])
-                .get(),
+            metrics.queries_received.with_label_values(&["", ""]).get(),
             1
         );
         assert_eq!(
@@ -453,10 +439,7 @@ mod tests {
         assert_eq!(codes.len(), 3);
 
         assert_eq!(
-            metrics
-                .queries_received
-                .with_label_values(&["", ""])
-                .get(),
+            metrics.queries_received.with_label_values(&["", ""]).get(),
             1
         );
         assert_eq!(metrics.queries_failed.get(), 1);

--- a/crates/sui-indexer-alt-graphql/src/extensions/logging.rs
+++ b/crates/sui-indexer-alt-graphql/src/extensions/logging.rs
@@ -53,6 +53,16 @@ pub const REQUEST_ID_HEADER: HeaderName = HeaderName::from_static("x-sui-rpc-req
 const CLIENT_SDK_TYPE_HEADER: HeaderName = HeaderName::from_static("client-sdk-type");
 const CLIENT_SDK_VERSION_HEADER: HeaderName = HeaderName::from_static("client-sdk-version");
 
+/// Maximum length of a client SDK header value we accept as a Prometheus label. Anything longer
+/// is bucketed to `CLIENT_LABEL_INVALID` so a misbehaving client cannot grow the per-series memory
+/// cost without bound.
+const MAX_CLIENT_SDK_LABEL_LEN: usize = 64;
+
+/// Sentinel label value substituted when a client SDK header exceeds `MAX_CLIENT_SDK_LABEL_LEN`.
+/// Distinct from the empty string we use when the header is absent, so dashboards can tell the
+/// two apart.
+const CLIENT_LABEL_INVALID: &str = "INVALID";
+
 /// Context data that tracks the session UUID and the client's address, to associate logs with a
 /// particular request.
 #[derive(Clone)]
@@ -114,10 +124,12 @@ impl ClientInfo {
         Self {
             sdk_type: headers
                 .get(&CLIENT_SDK_TYPE_HEADER)
-                .and_then(|v| v.to_str().ok().map(String::from)),
+                .and_then(|v| v.to_str().ok())
+                .map(sanitize_client_label),
             sdk_version: headers
                 .get(&CLIENT_SDK_VERSION_HEADER)
-                .and_then(|v| v.to_str().ok().map(String::from)),
+                .and_then(|v| v.to_str().ok())
+                .map(sanitize_client_label),
         }
     }
 }
@@ -316,6 +328,17 @@ fn is_loud_query(codes: &[&str]) -> bool {
             .any(|c| matches!(*c, code::REQUEST_TIMEOUT | code::INTERNAL_SERVER_ERROR))
 }
 
+/// Sanitize a client SDK header value before it is used as a Prometheus label. Values longer than
+/// `MAX_CLIENT_SDK_LABEL_LEN` bytes are bucketed to `CLIENT_LABEL_INVALID`, which caps the
+/// per-series memory cost in the metric registry.
+fn sanitize_client_label(value: &str) -> String {
+    if value.len() <= MAX_CLIENT_SDK_LABEL_LEN {
+        value.to_string()
+    } else {
+        CLIENT_LABEL_INVALID.to_string()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use async_graphql::EmptyMutation;
@@ -357,6 +380,20 @@ mod tests {
 
         assert!(info.sdk_type.is_none());
         assert!(info.sdk_version.is_none());
+    }
+
+    #[test]
+    fn client_info_oversized_value_bucketed_invalid() {
+        let mut headers = HeaderMap::new();
+        let too_long = "a".repeat(MAX_CLIENT_SDK_LABEL_LEN + 1);
+        headers.insert(
+            CLIENT_SDK_TYPE_HEADER,
+            HeaderValue::from_str(&too_long).unwrap(),
+        );
+
+        let info = ClientInfo::from_headers(&headers);
+
+        assert_eq!(info.sdk_type.as_deref(), Some(CLIENT_LABEL_INVALID));
     }
 
     #[tokio::test]

--- a/crates/sui-indexer-alt-graphql/src/extensions/logging.rs
+++ b/crates/sui-indexer-alt-graphql/src/extensions/logging.rs
@@ -26,6 +26,7 @@ use async_graphql::extensions::NextResolve;
 use async_graphql::extensions::NextValidation;
 use async_graphql::extensions::ResolveInfo;
 use async_graphql::parser::types::ExecutableDocument;
+use axum::http::HeaderMap;
 use axum::http::HeaderName;
 use pin_project::pin_project;
 use pin_project::pinned_drop;
@@ -46,12 +47,27 @@ use crate::metrics::RpcMetrics;
 /// This custom response header contains a unique request-id used for debugging and appears in the logs.
 pub const REQUEST_ID_HEADER: HeaderName = HeaderName::from_static("x-sui-rpc-request-id");
 
+/// Headers identifying the SDK that issued the request. To capture an additional client header
+/// in the future, define another constant here, read it in `ClientInfo::from_headers`, and expose
+/// it via the appropriate metric label or log field.
+const CLIENT_SDK_TYPE_HEADER: HeaderName = HeaderName::from_static("client-sdk-type");
+const CLIENT_SDK_VERSION_HEADER: HeaderName = HeaderName::from_static("client-sdk-version");
+
 /// Context data that tracks the session UUID and the client's address, to associate logs with a
 /// particular request.
-#[derive(Copy, Clone)]
+#[derive(Clone)]
 pub(crate) struct Session {
     pub uuid: Uuid,
     pub addr: SocketAddr,
+    pub client: ClientInfo,
+}
+
+/// Information about the SDK that issued the request, extracted from request headers. Lives on
+/// `Session` so it travels with the request through extensions, metrics, and logs.
+#[derive(Clone, Default)]
+pub(crate) struct ClientInfo {
+    pub sdk_type: Option<String>,
+    pub sdk_version: Option<String>,
 }
 
 /// This extension is responsible for tracing and recording metrics for various GraphQL queries.
@@ -81,6 +97,27 @@ impl Session {
         Self {
             uuid: Uuid::new_v4(),
             addr,
+            client: ClientInfo::default(),
+        }
+    }
+
+    /// Builder used at the HTTP entry point to attach client identifiers extracted from request
+    /// headers. All other code paths keep the default (empty) `ClientInfo`.
+    pub(crate) fn with_client_info(mut self, client: ClientInfo) -> Self {
+        self.client = client;
+        self
+    }
+}
+
+impl ClientInfo {
+    pub(crate) fn from_headers(headers: &HeaderMap) -> Self {
+        Self {
+            sdk_type: headers
+                .get(&CLIENT_SDK_TYPE_HEADER)
+                .and_then(|v| v.to_str().ok().map(String::from)),
+            sdk_version: headers
+                .get(&CLIENT_SDK_VERSION_HEADER)
+                .and_then(|v| v.to_str().ok().map(String::from)),
         }
     }
 }
@@ -90,7 +127,6 @@ impl<F> MetricsFuture<F> {
     where
         F: Future<Output = Response>,
     {
-        ext.metrics.queries_received.inc();
         ext.metrics.queries_in_flight.inc();
         let guard = ext.metrics.query_latency.start_timer();
 
@@ -117,6 +153,13 @@ impl ExtensionFactory for Logging {
 #[async_trait::async_trait]
 impl Extension for LoggingExt {
     async fn request(&self, ctx: &ExtensionContext<'_>, next: NextRequest<'_>) -> Response {
+        let session: &Session = ctx.data_unchecked();
+        let client_sdk_type = session.client.sdk_type.as_deref().unwrap_or("");
+        let client_sdk_version = session.client.sdk_version.as_deref().unwrap_or("");
+        self.metrics
+            .queries_received
+            .with_label_values(&[client_sdk_type, client_sdk_version])
+            .inc();
         MetricsFuture::request(self, next.run(ctx)).await
     }
 
@@ -128,8 +171,8 @@ impl Extension for LoggingExt {
         request: Request,
         next: NextPrepareRequest<'_>,
     ) -> ServerResult<Request> {
-        let session = ctx.data_unchecked();
-        let _ = self.session.set(*session);
+        let session: &Session = ctx.data_unchecked();
+        let _ = self.session.set(session.clone());
         next.run(ctx, request).await
     }
 
@@ -207,15 +250,21 @@ where
         ext.metrics.queries_in_flight.dec();
 
         // SAFETY: This is set by `prepare_request`.
-        let Session { uuid, addr } = ext.session.get().unwrap();
+        let Session {
+            uuid,
+            addr,
+            client,
+        } = ext.session.get().unwrap();
+        let client_sdk_type = client.sdk_type.as_deref().unwrap_or("");
+        let client_sdk_version = client.sdk_version.as_deref().unwrap_or("");
         let request_id = uuid.to_string().try_into().unwrap();
         resp.http_headers.insert(REQUEST_ID_HEADER, request_id);
 
         if resp.is_ok() {
             if log_enabled!(Level::Debug) {
-                debug!(request_id = %uuid, %addr, elapsed_ms, query = ext.query.get().unwrap(), response = %json!(resp), "Request succeeded");
+                debug!(request_id = %uuid, %addr, elapsed_ms, client_sdk_type, client_sdk_version, query = ext.query.get().unwrap(), response = %json!(resp), "Request succeeded");
             } else {
-                info!(request_id = %uuid, %addr, elapsed_ms, "Request succeeded");
+                info!(request_id = %uuid, %addr, elapsed_ms, client_sdk_type, client_sdk_version, "Request succeeded");
             }
             ext.metrics.queries_succeeded.inc();
         } else {
@@ -225,11 +274,11 @@ where
 
             // Log internal errors, timeouts, and unknown errors at a higher log level than other errors.
             if is_loud_query(&codes) {
-                warn!(request_id = %uuid, %addr, elapsed_ms, query = ext.query.get().unwrap(), response = %json!(resp), "Request failed");
+                warn!(request_id = %uuid, %addr, elapsed_ms, client_sdk_type, client_sdk_version, query = ext.query.get().unwrap(), response = %json!(resp), "Request failed");
             } else if log_enabled!(Level::Debug) {
-                debug!(request_id = %uuid, %addr, elapsed_ms, query = ext.query.get().unwrap(), response = %json!(resp), "Request failed");
+                debug!(request_id = %uuid, %addr, elapsed_ms, client_sdk_type, client_sdk_version, query = ext.query.get().unwrap(), response = %json!(resp), "Request failed");
             } else {
-                info!(request_id = %uuid, %addr, elapsed_ms, ?codes, "Request failed");
+                info!(request_id = %uuid, %addr, elapsed_ms, client_sdk_type, client_sdk_version, ?codes, "Request failed");
             }
 
             if codes.is_empty() {
@@ -252,10 +301,16 @@ where
 impl<F> PinnedDrop for MetricsFuture<F> {
     fn drop(self: Pin<&mut Self>) {
         if let Some(RequestMetrics { timer, ext }) = self.project().metrics.take() {
-            let Session { uuid, addr } = ext.session.get().unwrap();
+            let Session {
+                uuid,
+                addr,
+                client,
+            } = ext.session.get().unwrap();
+            let client_sdk_type = client.sdk_type.as_deref().unwrap_or("");
+            let client_sdk_version = client.sdk_version.as_deref().unwrap_or("");
             let elapsed_ms = timer.stop_and_record() * 1000.0;
             ext.metrics.queries_cancelled.inc();
-            info!(%uuid, %addr, elapsed_ms, "Request cancelled");
+            info!(%uuid, %addr, elapsed_ms, client_sdk_type, client_sdk_version, "Request cancelled");
         }
     }
 }
@@ -275,6 +330,7 @@ mod tests {
     use async_graphql::EmptySubscription;
     use async_graphql::Object;
     use async_graphql::Schema;
+    use axum::http::HeaderValue;
     use prometheus::Registry;
 
     use super::*;
@@ -286,6 +342,29 @@ mod tests {
         async fn op(&self) -> bool {
             true
         }
+    }
+
+    #[test]
+    fn client_info_extracts_sdk_headers() {
+        let mut headers = HeaderMap::new();
+        headers.insert(CLIENT_SDK_TYPE_HEADER, HeaderValue::from_static("rust"));
+        headers.insert(
+            CLIENT_SDK_VERSION_HEADER,
+            HeaderValue::from_static("1.69.0"),
+        );
+
+        let info = ClientInfo::from_headers(&headers);
+
+        assert_eq!(info.sdk_type.as_deref(), Some("rust"));
+        assert_eq!(info.sdk_version.as_deref(), Some("1.69.0"));
+    }
+
+    #[test]
+    fn client_info_missing_headers_yield_none() {
+        let info = ClientInfo::from_headers(&HeaderMap::new());
+
+        assert!(info.sdk_type.is_none());
+        assert!(info.sdk_version.is_none());
     }
 
     #[tokio::test]
@@ -302,7 +381,13 @@ mod tests {
 
         assert!(response.is_err());
         assert_eq!(error_codes(&response), vec![code::GRAPHQL_PARSE_FAILED]);
-        assert_eq!(metrics.queries_received.get(), 1);
+        assert_eq!(
+            metrics
+                .queries_received
+                .with_label_values(&["", ""])
+                .get(),
+            1
+        );
         assert_eq!(
             metrics
                 .query_errors
@@ -331,7 +416,13 @@ mod tests {
             error_codes(&response),
             vec![code::GRAPHQL_VALIDATION_FAILED]
         );
-        assert_eq!(metrics.queries_received.get(), 1);
+        assert_eq!(
+            metrics
+                .queries_received
+                .with_label_values(&["", ""])
+                .get(),
+            1
+        );
         assert_eq!(
             metrics
                 .query_errors
@@ -361,7 +452,13 @@ mod tests {
         let codes = error_codes(&response);
         assert_eq!(codes.len(), 3);
 
-        assert_eq!(metrics.queries_received.get(), 1);
+        assert_eq!(
+            metrics
+                .queries_received
+                .with_label_values(&["", ""])
+                .get(),
+            1
+        );
         assert_eq!(metrics.queries_failed.get(), 1);
         assert_eq!(
             metrics

--- a/crates/sui-indexer-alt-graphql/src/extensions/timeout.rs
+++ b/crates/sui-indexer-alt-graphql/src/extensions/timeout.rs
@@ -22,7 +22,6 @@ use timeout_tracing::timeout;
 use tracing::warn;
 
 use crate::error::request_timeout;
-use crate::extensions::logging::ClientInfo;
 use crate::extensions::logging::Session;
 
 /// How long to wait for each kind of operation before timing out.
@@ -130,6 +129,8 @@ mod tests {
     use itertools::Itertools;
     use regex::Regex;
     use telemetry_subscribers::TelemetryConfig;
+
+    use crate::extensions::logging::ClientInfo;
     use uuid::Uuid;
 
     use crate::error::code;

--- a/crates/sui-indexer-alt-graphql/src/extensions/timeout.rs
+++ b/crates/sui-indexer-alt-graphql/src/extensions/timeout.rs
@@ -22,6 +22,7 @@ use timeout_tracing::timeout;
 use tracing::warn;
 
 use crate::error::request_timeout;
+use crate::extensions::logging::ClientInfo;
 use crate::extensions::logging::Session;
 
 /// How long to wait for each kind of operation before timing out.
@@ -275,6 +276,7 @@ mod tests {
                 // ffffffff-ffff-ffff-ffff-ffffffffffff
                 uuid: Uuid::from_bytes([255; 16]),
                 addr: SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), 0),
+                client: ClientInfo::default(),
             })
             .extension(Timeout::new(TimeoutConfig {
                 query: query_timeout,

--- a/crates/sui-indexer-alt-graphql/src/lib.rs
+++ b/crates/sui-indexer-alt-graphql/src/lib.rs
@@ -70,6 +70,7 @@ use crate::api::query::Query;
 #[cfg(feature = "staging")]
 use crate::api::subscription::Subscription;
 use crate::error::PanicHandler;
+use crate::extensions::logging::ClientInfo;
 use crate::extensions::logging::Logging;
 use crate::extensions::logging::Session;
 use crate::metrics::RpcMetrics;
@@ -465,12 +466,13 @@ async fn graphql(
     Extension(watermark): Extension<WatermarksLock>,
     TypedHeader(content_length): TypedHeader<ContentLength>,
     show_usage: Option<TypedHeader<ShowUsage>>,
+    headers: axum::http::HeaderMap,
     request: GraphQLRequest,
 ) -> GraphQLResponse {
     let mut request = request
         .into_inner()
         .data(content_length)
-        .data(Session::new(addr))
+        .data(Session::new(addr).with_client_info(ClientInfo::from_headers(&headers)))
         .data(watermark.read().await.clone())
         .data(rich::Meter::default());
 

--- a/crates/sui-indexer-alt-graphql/src/metrics.rs
+++ b/crates/sui-indexer-alt-graphql/src/metrics.rs
@@ -47,7 +47,7 @@ pub struct RpcMetrics {
 
     // Top-level metrics for all read requests (queries).
     pub query_latency: Histogram,
-    pub queries_received: IntCounter,
+    pub queries_received: IntCounterVec,
     pub queries_succeeded: IntCounter,
     pub queries_failed: IntCounter,
     pub query_errors: IntCounterVec,
@@ -139,9 +139,10 @@ impl RpcMetrics {
             )
             .unwrap(),
 
-            queries_received: register_int_counter_with_registry!(
+            queries_received: register_int_counter_vec_with_registry!(
                 "graphql_queries_received",
-                "Number of read requests the service has received",
+                "Number of read requests the service has received, labelled by the SDK identifiers carried in `client-sdk-type` and `client-sdk-version` request headers (empty when absent)",
+                &["client_sdk_type", "client_sdk_version"],
                 registry,
             )
             .unwrap(),


### PR DESCRIPTION
## Description 

- Add `client_sdk_type` and `client_sdk_version` labels to the `graphql_queries_received` Prometheus counter, sourced from the `client-sdk-type` and `client-sdk-version` HTTP request headers.
- Surface the same identifiers as structured fields on every request log line (succeeded, failed, cancelled).
- Empty string fallback when headers are absent, so non-SDK callers still aggregate cleanly.

Metrics that get the new labels:
  - `graphql_queries_received`

## Test plan 

How did you test the new or updated feature?

- Unit tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
