### PR TITLE
[sui-framework][std] Tighten test_pow_overflow to use per-type MAX boundary

### DIFF
--- a/crates/sui-framework/packages/move-stdlib/tests/u128_tests.move
+++ b/crates/sui-framework/packages/move-stdlib/tests/u128_tests.move
@@ -97,7 +97,7 @@ fun test_pow() {
 
 #[test, expected_failure(arithmetic_error, location = std::u128)]
 fun test_pow_overflow() {
-    255u128.pow(255);
+    MAX.pow(2);
 }
 
 #[test]

--- a/crates/sui-framework/packages/move-stdlib/tests/u16_tests.move
+++ b/crates/sui-framework/packages/move-stdlib/tests/u16_tests.move
@@ -97,7 +97,7 @@ fun test_pow() {
 
 #[test, expected_failure(arithmetic_error, location = std::u16)]
 fun test_pow_overflow() {
-    255u16.pow(255);
+    MAX.pow(2);
 }
 
 #[test]

--- a/crates/sui-framework/packages/move-stdlib/tests/u256_tests.move
+++ b/crates/sui-framework/packages/move-stdlib/tests/u256_tests.move
@@ -67,7 +67,7 @@ fun test_pow() {
 
 #[test, expected_failure(arithmetic_error, location = std::u256)]
 fun test_pow_overflow() {
-    255u256.pow(255);
+    MAX.pow(2);
 }
 
 #[test]

--- a/crates/sui-framework/packages/move-stdlib/tests/u32_tests.move
+++ b/crates/sui-framework/packages/move-stdlib/tests/u32_tests.move
@@ -97,7 +97,7 @@ fun test_pow() {
 
 #[test, expected_failure(arithmetic_error, location = std::u32)]
 fun test_pow_overflow() {
-    255u32.pow(255);
+    MAX.pow(2);
 }
 
 #[test]

--- a/crates/sui-framework/packages/move-stdlib/tests/u64_tests.move
+++ b/crates/sui-framework/packages/move-stdlib/tests/u64_tests.move
@@ -97,7 +97,7 @@ fun test_pow() {
 
 #[test, expected_failure(arithmetic_error, location = std::u64)]
 fun test_pow_overflow() {
-    255u64.pow(255);
+    MAX.pow(2);
 }
 
 #[test]


### PR DESCRIPTION
## Description

Each `test_pow_overflow` in `u16_tests`, `u32_tests`, `u64_tests`, `u128_tests`, and `u256_tests` was a copy-paste of u8's `255u8.pow(255)`, just with the literal type suffix changed. The `arithmetic_error` fired because `255^k` overflows every integer width eventually, but the test was not exercising the type's own overflow boundary — it was running the same u8-sized growth curve in every file.

This changes each body to `MAX.pow(2)`, so each test fails on the first multiplication at the type's actual boundary. Same `expected_failure(arithmetic_error)`, stronger per-type negative coverage.

Mirrors the spirit of #26204 (skinnypete65) which fixed similar mislabeled / cross-type test artifacts in the integer test files.

## Test plan

```sh
cargo test --release -p sui-framework-tests --test move_tests -- move-stdlib
```

Result: 457 passed, 0 failed. All `test_pow_overflow` cases (u8, u16, u32, u64, u128, u256) still PASS — the `expected_failure` annotation still fires because `MAX.pow(2)` overflows the type for every `MAX > 1`.

## Files changed

- `crates/sui-framework/packages/move-stdlib/tests/u16_tests.move`
- `crates/sui-framework/packages/move-stdlib/tests/u32_tests.move`
- `crates/sui-framework/packages/move-stdlib/tests/u64_tests.move`
- `crates/sui-framework/packages/move-stdlib/tests/u128_tests.move`
- `crates/sui-framework/packages/move-stdlib/tests/u256_tests.move`

5 files changed, 5 insertions(+), 5 deletions(-).

## Release notes

Tests-only change; no runtime impact.