### PR TITLE
[move-stdlib] Fix vector::take_while docstring to match implementation

### DIFF
--- a/crates/sui-framework/docs/std/vector.md
+++ b/crates/sui-framework/docs/std/vector.md
@@ -1386,9 +1386,9 @@ function <code>le</code> (les). Returns <code><b>true</b></code> if the vector i
 
 ## Macro function `take_while`
 
-Return a new vector containing the elements of <code>v</code> except the first <code>n</code> elements
-that satisfy the predicate <code>p</code>. If all elements satisfy the predicate, returns an
-empty vector.
+Return a new vector containing the longest prefix of elements of <code>v</code> that satisfy
+the predicate <code>p</code>. If the first element does not satisfy <code>p</code>, returns an empty
+vector; if every element satisfies <code>p</code>, returns all of <code>v</code>.
 
 
 <pre><code><b>public</b> <b>macro</b> <b>fun</b> <a href="../std/vector.md#std_vector_take_while">take_while</a>&lt;$T: drop&gt;($v: <a href="../std/vector.md#std_vector">vector</a>&lt;$T&gt;, $p: |&$T| -&gt; <a href="../std/bool.md#std_bool">bool</a>): <a href="../std/vector.md#std_vector">vector</a>&lt;$T&gt;

--- a/crates/sui-framework/packages/move-stdlib/sources/vector.move
+++ b/crates/sui-framework/packages/move-stdlib/sources/vector.move
@@ -507,9 +507,9 @@ public macro fun is_sorted_by<$T>($v: &vector<$T>, $le: |&$T, &$T| -> bool): boo
     }
 }
 
-/// Return a new vector containing the elements of `v` except the first `n` elements
-/// that satisfy the predicate `p`. If all elements satisfy the predicate, returns an
-/// empty vector.
+/// Return a new vector containing the longest prefix of elements of `v` that satisfy
+/// the predicate `p`. If the first element does not satisfy `p`, returns an empty
+/// vector; if every element satisfies `p`, returns all of `v`.
 public macro fun take_while<$T: drop>($v: vector<$T>, $p: |&$T| -> bool): vector<$T> {
     let v = $v;
     'take: {


### PR DESCRIPTION
## Description

The docstring for `std::vector::take_while` describes behavior **opposite** to what the macro actually does. This PR fixes the docstring (and the regenerated public reference at `docs/std/vector.md`).

### Current docstring (incorrect)

> Return a new vector containing the elements of \`v\` except the first \`n\` elements that satisfy the predicate \`p\`. If all elements satisfy the predicate, returns an empty vector.

### Implementation

```move
public macro fun take_while<\$T: drop>(\$v: vector<\$T>, \$p: |&\$T| -> bool): vector<\$T> {
    let v = \$v;
    'take: {
        let mut r = vector[];
        v.do!(|e| if (\$p(&e)) r.push_back(e) else return 'take r);
        r
    }
}
```

This is the canonical `takeWhile`: returns the longest prefix of `v` whose elements all satisfy `p`.

### Existing tests confirm the actual behavior

From `crates/sui-framework/packages/move-stdlib/tests/vector_tests.move`:

```move
assert_eq!(vector[0, 1, 2u64].take_while!(|e| *e > 0), vector[]);          // first element fails -> empty
assert_eq!(vector[0, 1, 2u64].take_while!(|e| *e < 2), vector[0, 1]);      // returns the prefix
assert_eq!(vector[0, 1, 2u64].take_while!(|e| *e == 0), vector[0]);
assert_eq!(vector[0, 1, 2].take_while!(|e| *e < 3), vector[0u64, 1, 2]);   // all satisfy -> full vector
```

### Two specific contradictions resolved

| Doc claimed | Implementation does | Test confirms |
|---|---|---|
| Returns elements *except* the first n that satisfy | Returns the prefix that *satisfies* | `take_while(\|e\| *e < 2) == [0, 1]` |
| If all satisfy, returns *empty* vector | If all satisfy, returns the *full* vector | `take_while(\|e\| *e < 3) == [0, 1, 2]` |

## Fix

```
/// Return a new vector containing the longest prefix of elements of \`v\` that satisfy
/// the predicate \`p\`. If the first element does not satisfy \`p\`, returns an empty
/// vector; if every element satisfies \`p\`, returns all of \`v\`.
```

## Test plan

```
UPDATE=1 cargo test --release -p sui-framework --test build-system-packages   # regenerates docs/std/vector.md
cargo test --release -p sui-framework-tests --test move_tests -- move-stdlib  # 457 passed, 0 failed
```

The behavior tests above (`tests/vector_tests.move`) already exercise and lock down the correct semantics; no new tests are needed.

## Closes

Closes #26439

## Release notes

Documentation-only change; no runtime / protocol impact.