### PR TITLE
[sui-framework] Fix bag::remove and object_bag::remove docstrings

### DIFF
--- a/crates/sui-framework/docs/sui/bag.md
+++ b/crates/sui-framework/docs/sui/bag.md
@@ -217,7 +217,7 @@ the value does not have the specified type.
 
 ## Function `remove`
 
-Mutably borrows the key-value pair in the bag <code><a href="../sui/bag.md#sui_bag">bag</a>: &<b>mut</b> <a href="../sui/bag.md#sui_bag_Bag">Bag</a></code> and returns the value.
+Removes the key-value pair in the bag <code><a href="../sui/bag.md#sui_bag">bag</a>: &<b>mut</b> <a href="../sui/bag.md#sui_bag_Bag">Bag</a></code> and returns the value.
 Aborts with <code><a href="../sui/dynamic_field.md#sui_dynamic_field_EFieldDoesNotExist">sui::dynamic_field::EFieldDoesNotExist</a></code> if the bag does not have an entry with
 that key <code>k: K</code>.
 Aborts with <code><a href="../sui/dynamic_field.md#sui_dynamic_field_EFieldTypeMismatch">sui::dynamic_field::EFieldTypeMismatch</a></code> if the bag has an entry for the key, but

--- a/crates/sui-framework/docs/sui/object_bag.md
+++ b/crates/sui-framework/docs/sui/object_bag.md
@@ -203,7 +203,7 @@ the value does not have the specified type.
 
 ## Function `remove`
 
-Mutably borrows the key-value pair in the bag <code><a href="../sui/bag.md#sui_bag">bag</a>: &<b>mut</b> <a href="../sui/object_bag.md#sui_object_bag_ObjectBag">ObjectBag</a></code> and returns the value.
+Removes the key-value pair in the bag <code><a href="../sui/bag.md#sui_bag">bag</a>: &<b>mut</b> <a href="../sui/object_bag.md#sui_object_bag_ObjectBag">ObjectBag</a></code> and returns the value.
 Aborts with <code><a href="../sui/dynamic_field.md#sui_dynamic_field_EFieldDoesNotExist">sui::dynamic_field::EFieldDoesNotExist</a></code> if the bag does not have an entry with
 that key <code>k: K</code>.
 Aborts with <code><a href="../sui/dynamic_field.md#sui_dynamic_field_EFieldTypeMismatch">sui::dynamic_field::EFieldTypeMismatch</a></code> if the bag has an entry for the key, but

--- a/crates/sui-framework/packages/sui-framework/sources/bag.move
+++ b/crates/sui-framework/packages/sui-framework/sources/bag.move
@@ -71,7 +71,7 @@ public fun borrow_mut<K: copy + drop + store, V: store>(bag: &mut Bag, k: K): &m
     field::borrow_mut(&mut bag.id, k)
 }
 
-/// Mutably borrows the key-value pair in the bag `bag: &mut Bag` and returns the value.
+/// Removes the key-value pair in the bag `bag: &mut Bag` and returns the value.
 /// Aborts with `sui::dynamic_field::EFieldDoesNotExist` if the bag does not have an entry with
 /// that key `k: K`.
 /// Aborts with `sui::dynamic_field::EFieldTypeMismatch` if the bag has an entry for the key, but

--- a/crates/sui-framework/packages/sui-framework/sources/object_bag.move
+++ b/crates/sui-framework/packages/sui-framework/sources/object_bag.move
@@ -55,7 +55,7 @@ public fun borrow_mut<K: copy + drop + store, V: key + store>(bag: &mut ObjectBa
     ofield::borrow_mut(&mut bag.id, k)
 }
 
-/// Mutably borrows the key-value pair in the bag `bag: &mut ObjectBag` and returns the value.
+/// Removes the key-value pair in the bag `bag: &mut ObjectBag` and returns the value.
 /// Aborts with `sui::dynamic_field::EFieldDoesNotExist` if the bag does not have an entry with
 /// that key `k: K`.
 /// Aborts with `sui::dynamic_field::EFieldTypeMismatch` if the bag has an entry for the key, but


### PR DESCRIPTION
## Description

Two `remove` functions in the framework had docstrings that described the *opposite* of what the code does:

- `sui::bag::remove` and `sui::object_bag::remove` both said *"Mutably borrows the key-value pair... and returns the value"*, but the functions actually **remove** the entry (call `field::remove` / `ofield::remove`, decrement `bag.size`, return the value).
- The wrong text is also shipped in the public framework references: `crates/sui-framework/docs/sui/bag.md` and `crates/sui-framework/docs/sui/object_bag.md`.

This is a copy-paste error from the immediately preceding `borrow_mut` doc block in both files.

## Comparison with sibling APIs

`sui::table::remove` and `sui::object_table::remove` are documented correctly:
```
/// Removes the key-value pair in the table `table: &mut Table<K, V>` and returns the value.
```

This PR brings `bag::remove` and `object_bag::remove` in line with that wording.

## Implementation evidence

`bag::remove`:
```move
public fun remove<K: copy + drop + store, V: store>(bag: &mut Bag, k: K): V {
    let v = field::remove(&mut bag.id, k);
    bag.size = bag.size - 1;
    v
}
```

`object_bag::remove`:
```move
public fun remove<K: copy + drop + store, V: key + store>(bag: &mut ObjectBag, k: K): V {
    let v = ofield::remove(&mut bag.id, k);
    bag.size = bag.size - 1;
    v
}
```

Both clearly remove the entry, not borrow it.

## Test plan

```sh
UPDATE=1 cargo test --release -p sui-framework --test build-system-packages   # regenerates docs
cargo test --release -p sui-framework-tests --test move_tests -- sui-framework  # 639 passed, 0 failed
```

## Closes

Closes #26441

## Release notes

Documentation-only change; no runtime / protocol impact.