### PR TITLE
rpc-index: gracefully handle db corruption

### DIFF
--- a/crates/sui-core/src/rpc_index.rs
+++ b/crates/sui-core/src/rpc_index.rs
@@ -247,18 +247,29 @@ fn balance_delta_merge_operator(
     existing_val: Option<&[u8]>,
     operands: &MergeOperands,
 ) -> Option<Vec<u8>> {
-    let mut result = existing_val
-        .map(|v| {
-            bcs::from_bytes::<BalanceIndexInfo>(v)
-                .expect("Failed to deserialize BalanceIndexInfo from RocksDB - data corruption.")
-        })
-        .unwrap_or_default();
+    let mut result = if let Some(existing_val) = existing_val {
+        bcs::from_bytes::<BalanceIndexInfo>(existing_val)
+            .inspect_err(|e| {
+                tracing::error!(
+                    "Failed to deserialize BalanceIndexInfo from RocksDB - data corruption: {e}"
+                )
+            })
+            .ok()?
+    } else {
+        BalanceIndexInfo::default()
+    };
 
     for operand in operands.iter() {
         let delta = bcs::from_bytes::<BalanceIndexInfo>(operand)
-            .expect("Failed to deserialize BalanceIndexInfo from RocksDB - data corruption.");
+            .inspect_err(|e| {
+                tracing::error!(
+                    "Failed to deserialize BalanceIndexInfo from RocksDB - data corruption: {e}"
+                )
+            })
+            .ok()?;
         result.merge_delta(&delta);
     }
+
     Some(
         bcs::to_bytes(&result)
             .expect("Failed to deserialize BalanceIndexInfo from RocksDB - data corruption."),


### PR DESCRIPTION
Gracefully handle db corruption, which can happen unexpectedly or explicitly upon updating the db version.

When updating the DB version, the merge operator for the balance column family tries to read the older values before we have a chance to nuke the db and reinitialize it. This makes that reading of the older value fail gracefully so that we can have a chance to properly reinitialize the db.

## Description 

Describe the changes or additions included in this PR.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
