### PR TITLE
graphql: support optional FEATURES build arg in Dockerfile

### DIFF
--- a/docker/sui-indexer-alt-graphql/Dockerfile
+++ b/docker/sui-indexer-alt-graphql/Dockerfile
@@ -7,6 +7,7 @@ ARG PROFILE=release-unwind
 FROM rust:1.92-bullseye AS builder
 ARG PROFILE
 ARG GIT_REVISION
+ARG FEATURES=""
 ENV GIT_REVISION=$GIT_REVISION
 WORKDIR "$WORKDIR/sui"
 
@@ -21,7 +22,11 @@ COPY crates crates
 COPY sui-execution sui-execution
 COPY external-crates external-crates
 
-RUN cargo build --profile ${PROFILE} --bin sui-indexer-alt-graphql
+RUN if [ -n "$FEATURES" ]; then \
+        cargo build --profile ${PROFILE} --bin sui-indexer-alt-graphql --features "$FEATURES"; \
+    else \
+        cargo build --profile ${PROFILE} --bin sui-indexer-alt-graphql; \
+    fi
 
 # Production Image
 # debian:bullseye-slim


### PR DESCRIPTION
## Summary
- Add \`ARG FEATURES=\"\"\` to the \`sui-indexer-alt-graphql\` Dockerfile and pass it to \`cargo build --features\` only when non-empty.
- Default behavior is unchanged for callers that do not set the build arg.
- Required to enable the existing \`staging\` Cargo feature in \`crates/sui-indexer-alt-graphql/Cargo.toml:88\` on a per-environment basis.

## Why
All GraphQL envs share this single Dockerfile but build from different \`repo_ref\`s (devnet, testnet, mainnet). Hardcoding \`--features staging\` here would risk other envs inheriting it on a cherry-pick. Wiring \`FEATURES\` as a build arg lets the Pulumi config decide per env, keeping testnet and mainnet builds unchanged.

The matching sui-operations PR sets \`build_args: [\"FEATURES=staging\"]\` only in \`Pulumi.devnet.yaml\`, so non-devnet envs keep building exactly as they do today.

Context: enabling GraphQL subscriptions on devnet, which are gated behind the \`staging\` feature.

## Test plan
- CI build of \`sui-indexer-alt-graphql\` Docker image passes with the default (empty) FEATURES.
- Local build with \`docker build --build-arg FEATURES=staging\` compiles the staging code paths.
- After this lands on the \`devnet\` branch, the matching sui-operations PR is deployed and a GraphQL subscription against the devnet endpoint returns a response.