### PR TITLE
[chore] Update tidehunter to 06520e9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8407,7 +8407,7 @@ dependencies = [
 [[package]]
 name = "minibytes"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/tidehunter.git?rev=3c0611a636a9a09a0a4ee6d5108d4f8bfeb57c2b#3c0611a636a9a09a0a4ee6d5108d4f8bfeb57c2b"
+source = "git+https://github.com/mystenlabs/tidehunter.git?rev=06520e93e8ead776eba7bf3dd1bed5ea86853c88#06520e93e8ead776eba7bf3dd1bed5ea86853c88"
 dependencies = [
  "bytes",
  "memmap2 0.7.1",
@@ -17871,7 +17871,7 @@ dependencies = [
 [[package]]
 name = "tidehunter"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/tidehunter.git?rev=3c0611a636a9a09a0a4ee6d5108d4f8bfeb57c2b#3c0611a636a9a09a0a4ee6d5108d4f8bfeb57c2b"
+source = "git+https://github.com/mystenlabs/tidehunter.git?rev=06520e93e8ead776eba7bf3dd1bed5ea86853c88#06520e93e8ead776eba7bf3dd1bed5ea86853c88"
 dependencies = [
  "arc-swap",
  "bincode 1.3.3",

--- a/crates/typed-store/Cargo.toml
+++ b/crates/typed-store/Cargo.toml
@@ -34,7 +34,7 @@ sui-macros.workspace = true
 mysten-common.workspace = true
 mysten-metrics.workspace = true
 [target.'cfg(not(windows))'.dependencies]
-tidehunter = {git = "https://github.com/mystenlabs/tidehunter.git", rev = "3c0611a636a9a09a0a4ee6d5108d4f8bfeb57c2b", version = "0.1.0", optional = true}
+tidehunter = {git = "https://github.com/mystenlabs/tidehunter.git", rev = "06520e93e8ead776eba7bf3dd1bed5ea86853c88", version = "0.1.0", optional = true}
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 rocksdb = { version = "0.22.0", default-features = false, features = ["jemalloc"] }


### PR DESCRIPTION
## Summary
- Updates tidehunter git dependency to `06520e93e8ead776eba7bf3dd1bed5ea86853c88`

## Test plan
- [ ] Deploy to private-testnet with `build_with_tidehunter=true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)