### PR TITLE
[graphql-stream] Add top-level events subscription [8/n]

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/Cargo.toml
+++ b/crates/sui-indexer-alt-e2e-tests/Cargo.toml
@@ -50,9 +50,11 @@ sui-indexer-alt-schema.workspace = true
 sui-pg-db.workspace = true
 sui-protocol-config.workspace = true
 sui-rpc.workspace = true
+sui-test-transaction-builder.workspace = true
 sui-types.workspace = true
 move-core-types.workspace = true
 sui-move-build.workspace = true
+test-cluster.workspace = true
 
 [target.'cfg(msim)'.dependencies]
 msim.workspace = true
@@ -82,7 +84,5 @@ sui-json-rpc-types.workspace = true
 sui-macros.workspace = true
 sui-sdk.workspace = true
 sui-swarm-config.workspace = true
-sui-test-transaction-builder.workspace = true
 sui-transactional-test-runner = { workspace = true, features = ["testing"] }
-test-cluster.workspace = true
 tracing.workspace = true

--- a/crates/sui-indexer-alt-e2e-tests/packages/event/emit_test_event/sources/emit_test_event.move
+++ b/crates/sui-indexer-alt-e2e-tests/packages/event/emit_test_event/sources/emit_test_event.move
@@ -13,4 +13,8 @@ module emit_test_event::emit_test_event {
             value: 1,
         });
     }
+
+    public fun emit_with_value(value: u64) {
+        event::emit(TestEvent { value })
+    }
 }

--- a/crates/sui-indexer-alt-e2e-tests/src/lib.rs
+++ b/crates/sui-indexer-alt-e2e-tests/src/lib.rs
@@ -83,6 +83,7 @@ use url::Url;
 
 pub mod coin_registry;
 pub mod find;
+pub mod move_helpers;
 
 /// A simulation of the network, accompanied by off-chain services (database, indexer, RPC),
 /// connected by local data ingestion.

--- a/crates/sui-indexer-alt-e2e-tests/src/move_helpers.rs
+++ b/crates/sui-indexer-alt-e2e-tests/src/move_helpers.rs
@@ -1,0 +1,70 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Generic helpers for publishing Move packages and executing programmable transactions
+//! against a `TestCluster`. Used by integration test harnesses to avoid duplicating gas,
+//! signing, and execute boilerplate.
+
+use std::collections::BTreeSet;
+use std::path::Path;
+
+use fastcrypto::encoding::Base58;
+use fastcrypto::encoding::Encoding;
+use sui_test_transaction_builder::TestTransactionBuilder;
+use sui_types::base_types::ObjectID;
+use sui_types::base_types::ObjectRef;
+use sui_types::effects::TransactionEffects;
+use sui_types::effects::TransactionEffectsAPI;
+use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
+use sui_types::transaction::TransactionData;
+
+const DEFAULT_GAS_BUDGET: u64 = 5_000_000_000;
+
+/// Publish a Move package at `path` and return the new package ID.
+pub async fn publish_package(cluster: &mut test_cluster::TestCluster, path: &Path) -> ObjectID {
+    let sender = cluster.wallet.active_address().unwrap();
+    let gas = gas_for(cluster).await;
+    let rgp = cluster.wallet.get_reference_gas_price().await.unwrap();
+    let tx = cluster
+        .wallet
+        .sign_transaction(
+            &TestTransactionBuilder::new(sender, gas, rgp)
+                .publish_async(path.to_path_buf())
+                .await
+                .build(),
+        )
+        .await;
+    let resp = cluster.wallet.execute_transaction_must_succeed(tx).await;
+    resp.get_new_package_obj().unwrap().0
+}
+
+/// Sign and execute a programmable transaction. Returns the Base58-encoded transaction
+/// digest and the resulting effects.
+pub async fn execute_ptb(
+    cluster: &mut test_cluster::TestCluster,
+    ptb: ProgrammableTransactionBuilder,
+) -> (String, TransactionEffects) {
+    let sender = cluster.wallet.active_address().unwrap();
+    let gas = gas_for(cluster).await;
+    let rgp = cluster.wallet.get_reference_gas_price().await.unwrap();
+    let tx_data =
+        TransactionData::new_programmable(sender, vec![gas], ptb.finish(), DEFAULT_GAS_BUDGET, rgp);
+    let tx = cluster.wallet.sign_transaction(&tx_data).await;
+    let resp = cluster.wallet.execute_transaction_must_succeed(tx).await;
+    (
+        Base58::encode(*resp.effects.transaction_digest()),
+        resp.effects,
+    )
+}
+
+/// Get an unused gas object reference owned by the active address.
+pub async fn gas_for(cluster: &mut test_cluster::TestCluster) -> ObjectRef {
+    let sender = cluster.wallet.active_address().unwrap();
+    cluster
+        .wallet
+        .gas_for_owner_budget(sender, DEFAULT_GAS_BUDGET, BTreeSet::new())
+        .await
+        .unwrap()
+        .1
+        .compute_object_reference()
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/checkpoint_subscription.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/checkpoint_subscription.rs
@@ -12,7 +12,7 @@ use tokio_stream::StreamExt;
 use crate::testing::SubscriptionTestCluster;
 use crate::testing::checkpoint_seq;
 use crate::testing::checkpoint_tx_digests;
-use crate::testing::drain_checkpoints_until_stalled;
+use crate::testing::drain_until_stalled;
 use crate::testing::graphql_redactions;
 use crate::testing::object_wrapping_harness;
 use crate::testing::transfer_coins;
@@ -406,7 +406,8 @@ async fn test_subscription_recovers_from_upstream_disconnect() {
     // Let the validator advance so a real gap forms, then drain whatever
     // graphql had pushed before the disconnect took effect.
     tokio::time::sleep(std::time::Duration::from_secs(2)).await;
-    let last_seen = drain_checkpoints_until_stalled(&mut stream, second).await;
+    let drained = drain_until_stalled(&mut stream).await;
+    let last_seen = drained.last().map(checkpoint_seq).unwrap_or(second);
     let validator_tip = cluster.validator_checkpoint_tip();
     assert!(
         validator_tip > last_seen + 1,

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/event_subscription.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/event_subscription.rs
@@ -1,0 +1,171 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! These tests use `#[tokio::test]` rather than the workspace-standard simulator test
+//! attribute because the harness needs a real Postgres `TempDb` and a real
+//! `TestClusterBuilder` validator, neither of which works inside the simulator's
+//! deterministic runtime.
+
+use std::collections::HashSet;
+use std::time::Duration;
+
+use serde_json::Value;
+use serde_json::json;
+use tokio_stream::StreamExt;
+
+use crate::testing::SubscriptionTestCluster;
+use crate::testing::emit_event_harness;
+use crate::testing::graphql_redactions;
+
+fn event_value(item: &Value) -> Option<&str> {
+    item["data"]["events"]["contents"]["json"]["value"].as_str()
+}
+
+fn event_bcs(item: &Value) -> Option<&str> {
+    item["data"]["events"]["eventBcs"].as_str()
+}
+
+#[tokio::test]
+async fn test_event_subscription() {
+    let mut cluster = SubscriptionTestCluster::new().await;
+    let package_id = emit_event_harness::publish(&mut cluster.validator).await;
+
+    let mut stream = cluster
+        .subscribe_with_variables(
+            r#"subscription($pkg: SuiAddress!) {
+                events(filter: { type: $pkg }) {
+                    sender { address }
+                    transaction { digest }
+                    contents {
+                        type { repr }
+                        json
+                    }
+                    sequenceNumber
+                    timestamp
+                }
+            }"#,
+            Some(json!({ "pkg": package_id.to_string() })),
+        )
+        .await;
+
+    let _digest = emit_event_harness::emit(&mut cluster.validator, package_id).await;
+    let item = stream.next().await.expect("Stream ended");
+
+    graphql_redactions().bind(|| {
+        insta::assert_json_snapshot!("event_subscription", item);
+    });
+}
+
+#[tokio::test]
+async fn test_event_subscription_sender_filter() {
+    let mut cluster = SubscriptionTestCluster::new().await;
+    let sender = cluster.validator.wallet.active_address().unwrap();
+    let package_id = emit_event_harness::publish(&mut cluster.validator).await;
+
+    let mut stream = cluster
+        .subscribe_with_variables(
+            r#"subscription($sender: SuiAddress!) {
+                events(filter: { sender: $sender }) {
+                    sender { address }
+                    contents { type { repr } }
+                }
+            }"#,
+            Some(json!({ "sender": sender.to_string() })),
+        )
+        .await;
+
+    let _digest = emit_event_harness::emit(&mut cluster.validator, package_id).await;
+    let item = stream.next().await.expect("Stream ended");
+
+    graphql_redactions().bind(|| {
+        insta::assert_json_snapshot!("event_subscription_sender_filter", item);
+    });
+}
+
+#[tokio::test]
+async fn test_event_subscription_module_filter() {
+    let mut cluster = SubscriptionTestCluster::new().await;
+    let package_id = emit_event_harness::publish(&mut cluster.validator).await;
+
+    let mut stream = cluster
+        .subscribe_with_variables(
+            r#"subscription($mod: String!) {
+                events(filter: { module: $mod }) {
+                    contents { type { repr } }
+                }
+            }"#,
+            Some(json!({ "mod": format!("{}::emit_test_event", package_id) })),
+        )
+        .await;
+
+    let _digest = emit_event_harness::emit(&mut cluster.validator, package_id).await;
+    let item = stream.next().await.expect("Stream ended");
+
+    graphql_redactions().bind(|| {
+        insta::assert_json_snapshot!("event_subscription_module_filter", item);
+    });
+}
+
+/// Forces a reconnect blackout via the proxy and asserts the subscriber receives every
+/// event emitted during the gap once the connection is restored. Mirrors
+/// `test_subscription_recovers_from_upstream_disconnect` but for the events subscription.
+///
+/// Each emit uses a distinct `value` so the resulting events have unique `eventBcs`
+/// bytes, letting us verify both ordering (via the parsed `contents.json.value`) and
+/// individual identity (via `eventBcs` distinctness).
+#[tokio::test]
+async fn test_event_subscription_recovers_from_upstream_disconnect() {
+    let (mut cluster, proxy) = SubscriptionTestCluster::new_with_disruption_proxy().await;
+    let package_id = emit_event_harness::publish(&mut cluster.validator).await;
+
+    let mut stream = cluster
+        .subscribe_with_variables(
+            r#"subscription($pkg: SuiAddress!) {
+                events(filter: { type: $pkg }) {
+                    eventBcs
+                    contents { json }
+                }
+            }"#,
+            Some(json!({ "pkg": package_id.to_string() })),
+        )
+        .await;
+
+    // Healthy: emit value=1, verify it streams live.
+    emit_event_harness::emit_with_value(&mut cluster.validator, package_id, 1).await;
+    let live = stream.next().await.expect("Stream ended");
+    assert_eq!(event_value(&live), Some("1"));
+
+    // Blackout: drop the upstream gRPC connection.
+    proxy.block_connections();
+    proxy.disconnect_all();
+
+    // Let the disconnect take effect on the streaming server before asserting silence.
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    // No events should arrive while the upstream is blacked out.
+    let silence = tokio::time::timeout(Duration::from_secs(1), stream.next()).await;
+    assert!(
+        silence.is_err(),
+        "stream yielded an event during blackout: {silence:?}",
+    );
+
+    // Emit eight events during the blackout (values 2..10). The validator advances and
+    // produces checkpoints that the streaming server can't see live.
+    for v in 2..10u64 {
+        emit_event_harness::emit_with_value(&mut cluster.validator, package_id, v).await;
+    }
+
+    // Resume: gap recovery via kv-rpc fills in the missing checkpoints in order.
+    proxy.allow_connections();
+
+    let received: Vec<Value> = (&mut stream).take(8).collect().await;
+    let values: Vec<&str> = received.iter().filter_map(event_value).collect();
+    let bcs_set: HashSet<&str> = received.iter().filter_map(event_bcs).collect();
+
+    assert_eq!(
+        values,
+        vec!["2", "3", "4", "5", "6", "7", "8", "9"],
+        "events out of order",
+    );
+    assert_eq!(bcs_set.len(), 8, "eventBcs should be distinct across emits");
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/main.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/main.rs
@@ -6,4 +6,5 @@
 mod testing;
 
 mod checkpoint_subscription;
+mod event_subscription;
 mod transaction_subscription;

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/snapshots/graphql_subscription__event_subscription__event_subscription.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/snapshots/graphql_subscription__event_subscription__event_subscription.snap
@@ -1,0 +1,26 @@
+---
+source: crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/event_subscription.rs
+expression: item
+---
+{
+  "data": {
+    "events": {
+      "sender": {
+        "address": "[address]"
+      },
+      "transaction": {
+        "digest": "[digest]"
+      },
+      "contents": {
+        "type": {
+          "repr": "[pkg]::emit_test_event::TestEvent"
+        },
+        "json": {
+          "value": "1"
+        }
+      },
+      "sequenceNumber": "[seq]",
+      "timestamp": "[timestamp]"
+    }
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/snapshots/graphql_subscription__event_subscription__event_subscription_module_filter.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/snapshots/graphql_subscription__event_subscription__event_subscription_module_filter.snap
@@ -1,0 +1,15 @@
+---
+source: crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/event_subscription.rs
+expression: item
+---
+{
+  "data": {
+    "events": {
+      "contents": {
+        "type": {
+          "repr": "[pkg]::emit_test_event::TestEvent"
+        }
+      }
+    }
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/snapshots/graphql_subscription__event_subscription__event_subscription_sender_filter.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/snapshots/graphql_subscription__event_subscription__event_subscription_sender_filter.snap
@@ -1,0 +1,18 @@
+---
+source: crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/event_subscription.rs
+expression: item
+---
+{
+  "data": {
+    "events": {
+      "sender": {
+        "address": "[address]"
+      },
+      "contents": {
+        "type": {
+          "repr": "[pkg]::emit_test_event::TestEvent"
+        }
+      }
+    }
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/testing/emit_event_harness.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/testing/emit_event_harness.rs
@@ -1,0 +1,64 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Helpers for interacting with the `emit_test_event` Move package in tests.
+
+use std::path::PathBuf;
+
+use move_core_types::ident_str;
+use sui_indexer_alt_e2e_tests::move_helpers::execute_ptb;
+use sui_indexer_alt_e2e_tests::move_helpers::publish_package;
+use sui_types::base_types::ObjectID;
+use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
+
+pub async fn publish(cluster: &mut test_cluster::TestCluster) -> ObjectID {
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.extend(["packages", "event", "emit_test_event"]);
+    publish_package(cluster, &path).await
+}
+
+/// Append a call to `emit_test_event::emit_test_event()` onto an existing PTB. Use this
+/// to compose with other move calls in the same transaction.
+pub fn add_emit_call(ptb: &mut ProgrammableTransactionBuilder, package_id: ObjectID) {
+    ptb.programmable_move_call(
+        package_id,
+        ident_str!("emit_test_event").to_owned(),
+        ident_str!("emit_test_event").to_owned(),
+        vec![],
+        vec![],
+    );
+}
+
+/// Append a call to `emit_test_event::emit_with_value(value)` onto an existing PTB.
+/// Each call with a distinct `value` produces a distinct `TestEvent`, useful for tests
+/// that need to identify events individually.
+pub fn add_emit_with_value_call(
+    ptb: &mut ProgrammableTransactionBuilder,
+    package_id: ObjectID,
+    value: u64,
+) {
+    let value_arg = ptb.pure(value).unwrap();
+    ptb.programmable_move_call(
+        package_id,
+        ident_str!("emit_test_event").to_owned(),
+        ident_str!("emit_with_value").to_owned(),
+        vec![],
+        vec![value_arg],
+    );
+}
+
+pub async fn emit(cluster: &mut test_cluster::TestCluster, package_id: ObjectID) -> String {
+    let mut ptb = ProgrammableTransactionBuilder::new();
+    add_emit_call(&mut ptb, package_id);
+    execute_ptb(cluster, ptb).await.0
+}
+
+pub async fn emit_with_value(
+    cluster: &mut test_cluster::TestCluster,
+    package_id: ObjectID,
+    value: u64,
+) -> String {
+    let mut ptb = ProgrammableTransactionBuilder::new();
+    add_emit_with_value_call(&mut ptb, package_id, value);
+    execute_ptb(cluster, ptb).await.0
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/testing/harness.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/testing/harness.rs
@@ -337,20 +337,19 @@ pub fn checkpoint_seq(item: &Value) -> u64 {
         .expect("checkpoint payload missing sequenceNumber")
 }
 
-/// Read checkpoint items from `stream` until it goes quiet for one second,
-/// returning the last sequence number observed. `start` is returned unchanged
-/// if the stream stalls before delivering anything. Used to assert that the
-/// streaming subscription has paused (e.g. during a forced reconnect blackout).
-pub async fn drain_checkpoints_until_stalled(
+/// Read items from `stream` until it goes quiet for one second, returning every item
+/// observed in order. Returns an empty `Vec` when the stream stalls before delivering
+/// anything. Used to assert silence (`drained.is_empty()`) or to recover the last
+/// observed value via a domain-specific extractor (`drained.last().map(...)`).
+pub async fn drain_until_stalled(
     stream: &mut (impl tokio_stream::Stream<Item = Value> + Unpin),
-    start: u64,
-) -> u64 {
-    let mut last = start;
+) -> Vec<Value> {
+    let mut drained = Vec::new();
     loop {
         match tokio::time::timeout(Duration::from_secs(1), stream.next()).await {
-            Ok(Some(item)) => last = checkpoint_seq(&item),
+            Ok(Some(item)) => drained.push(item),
             Ok(None) => panic!("stream ended unexpectedly"),
-            Err(_) => return last,
+            Err(_) => return drained,
         }
     }
 }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/testing/mod.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/testing/mod.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod emit_event_harness;
 mod harness;
 pub mod object_wrapping_harness;
 pub mod proxy;

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/testing/object_wrapping_harness.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/testing/object_wrapping_harness.rs
@@ -3,37 +3,39 @@
 
 //! Helpers for interacting with the `object_wrapping` Move package in tests.
 
-use std::collections::BTreeSet;
 use std::path::PathBuf;
 
-use fastcrypto::encoding::Base58;
-use fastcrypto::encoding::Encoding;
 use move_core_types::ident_str;
-use sui_test_transaction_builder::TestTransactionBuilder;
+use sui_indexer_alt_e2e_tests::move_helpers::execute_ptb;
+use sui_indexer_alt_e2e_tests::move_helpers::publish_package;
 use sui_types::base_types::ObjectID;
 use sui_types::base_types::ObjectRef;
 use sui_types::effects::TransactionEffectsAPI;
 use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
+use sui_types::transaction::Argument;
 use sui_types::transaction::ObjectArg;
-use sui_types::transaction::TransactionData;
 
 pub async fn publish(cluster: &mut test_cluster::TestCluster) -> ObjectID {
-    let sender = cluster.wallet.active_address().unwrap();
     let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     path.extend(["packages", "object_wrapping"]);
-    let gas = gas_for(cluster).await;
-    let rgp = cluster.wallet.get_reference_gas_price().await.unwrap();
-    let tx = cluster
-        .wallet
-        .sign_transaction(
-            &TestTransactionBuilder::new(sender, gas, rgp)
-                .publish_async(path)
-                .await
-                .build(),
-        )
-        .await;
-    let resp = cluster.wallet.execute_transaction_must_succeed(tx).await;
-    resp.get_new_package_obj().unwrap().0
+    publish_package(cluster, &path).await
+}
+
+/// Append a call to `wrapping::create(value)` onto an existing PTB and return the
+/// `Item` argument so the caller can transfer it or feed it into a subsequent call.
+pub fn add_create_call(
+    ptb: &mut ProgrammableTransactionBuilder,
+    package_id: ObjectID,
+    value: u64,
+) -> Argument {
+    let value_arg = ptb.pure(value).unwrap();
+    ptb.programmable_move_call(
+        package_id,
+        ident_str!("wrapping").to_owned(),
+        ident_str!("create").to_owned(),
+        vec![],
+        vec![value_arg],
+    )
 }
 
 pub async fn create_item(
@@ -43,16 +45,9 @@ pub async fn create_item(
 ) -> (String, ObjectRef) {
     let sender = cluster.wallet.active_address().unwrap();
     let mut ptb = ProgrammableTransactionBuilder::new();
-    let value_arg = ptb.pure(value).unwrap();
-    let item = ptb.programmable_move_call(
-        package_id,
-        ident_str!("wrapping").to_owned(),
-        ident_str!("create").to_owned(),
-        vec![],
-        vec![value_arg],
-    );
+    let item = add_create_call(&mut ptb, package_id, value);
     ptb.transfer_arg(sender, item);
-    let (digest, effects) = execute(cluster, ptb).await;
+    let (digest, effects) = execute_ptb(cluster, ptb).await;
     let created = effects
         .created()
         .into_iter()
@@ -78,7 +73,7 @@ pub async fn update_item(
         vec![],
         vec![item_arg, value_arg],
     );
-    let (digest, effects) = execute(cluster, ptb).await;
+    let (digest, effects) = execute_ptb(cluster, ptb).await;
     let mutated = effects
         .mutated()
         .into_iter()
@@ -104,7 +99,7 @@ pub async fn wrap_item(
         vec![item_arg],
     );
     ptb.transfer_arg(sender, wrapper);
-    let (digest, effects) = execute(cluster, ptb).await;
+    let (digest, effects) = execute_ptb(cluster, ptb).await;
     let created = effects
         .created()
         .into_iter()
@@ -130,7 +125,7 @@ pub async fn unwrap_wrapper(
         vec![wrapper_arg],
     );
     ptb.transfer_arg(sender, item);
-    let (digest, effects) = execute(cluster, ptb).await;
+    let (digest, effects) = execute_ptb(cluster, ptb).await;
     let unwrapped = effects
         .unwrapped()
         .into_iter()
@@ -138,32 +133,4 @@ pub async fn unwrap_wrapper(
         .expect("Should have unwrapped an Item")
         .0;
     (digest, unwrapped)
-}
-
-async fn execute(
-    cluster: &mut test_cluster::TestCluster,
-    ptb: ProgrammableTransactionBuilder,
-) -> (String, sui_types::effects::TransactionEffects) {
-    let sender = cluster.wallet.active_address().unwrap();
-    let gas = gas_for(cluster).await;
-    let rgp = cluster.wallet.get_reference_gas_price().await.unwrap();
-    let tx_data =
-        TransactionData::new_programmable(sender, vec![gas], ptb.finish(), 5_000_000_000, rgp);
-    let tx = cluster.wallet.sign_transaction(&tx_data).await;
-    let resp = cluster.wallet.execute_transaction_must_succeed(tx).await;
-    (
-        Base58::encode(*resp.effects.transaction_digest()),
-        resp.effects,
-    )
-}
-
-async fn gas_for(cluster: &mut test_cluster::TestCluster) -> ObjectRef {
-    let sender = cluster.wallet.active_address().unwrap();
-    cluster
-        .wallet
-        .gas_for_owner_budget(sender, 5_000_000_000, BTreeSet::new())
-        .await
-        .unwrap()
-        .1
-        .compute_object_reference()
 }

--- a/crates/sui-indexer-alt-graphql/src/api/subscription.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/subscription.rs
@@ -8,6 +8,8 @@ use tokio::sync::broadcast;
 use tracing::warn;
 
 use crate::api::types::checkpoint::Checkpoint;
+use crate::api::types::event::Event;
+use crate::api::types::event::filter::EventFilter;
 use crate::api::types::transaction::Transaction;
 use crate::api::types::transaction::TransactionContents;
 use crate::api::types::transaction::filter::TransactionFilter;
@@ -99,6 +101,60 @@ impl Subscription {
                                     contents: Some(Arc::new(tx.contents.clone())),
                                 },
                             });
+                        }
+                    }
+                    Err(e) => {
+                        yield Err(broadcast_error(e));
+                        break;
+                    }
+                }
+            }
+        })
+    }
+
+    /// Subscribe to events as they are emitted, with optional filtering.
+    ///
+    /// Each matching event is yielded individually as it appears in finalized
+    /// checkpoints. Events are ordered by checkpoint, then by transaction
+    /// position within the checkpoint, then by position within the transaction.
+    ///
+    /// This subscription is not yet available for use.
+    async fn events(
+        &self,
+        ctx: &Context<'_>,
+        filter: Option<EventFilter>,
+    ) -> Result<impl futures::Stream<Item = Result<Event, RpcError>>, RpcError> {
+        let package_store = ctx.data::<Arc<StreamingPackageStore>>()?.clone();
+        let limits: &Limits = ctx.data()?;
+        let resolver_limits = limits.package_resolver();
+        let mut receiver = ctx.data::<CheckpointBroadcaster>()?.resubscribe();
+        let filter = filter.unwrap_or_default();
+
+        Ok(async_stream::stream! {
+            loop {
+                match receiver.recv().await {
+                    Ok(processed) => {
+                        let timestamp_ms = Some(processed.summary.timestamp_ms);
+                        let scope = Scope::for_streamed_checkpoint(
+                            package_store.clone(),
+                            resolver_limits.clone(),
+                        );
+                        for tx in &processed.transactions {
+                            let events = tx.contents.events().unwrap_or_default();
+                            for (idx, native) in events.into_iter().enumerate() {
+                                if !filter.matches(&native) {
+                                    continue;
+                                }
+                                yield Ok(Event {
+                                    scope: scope.with_execution_objects(
+                                        tx.execution_objects.clone(),
+                                    ),
+                                    native,
+                                    transaction_digest: tx.digest,
+                                    sequence_number: idx as u64,
+                                    timestamp_ms,
+                                });
+                            }
                         }
                     }
                     Err(e) => {

--- a/crates/sui-indexer-alt-graphql/src/api/types/event/lookups.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/event/lookups.rs
@@ -3,6 +3,7 @@
 
 use std::iter::Rev;
 use std::ops::Range;
+use std::sync::Arc;
 
 use anyhow::Context as _;
 use async_graphql::Context;
@@ -90,7 +91,7 @@ fn tx_events_paginated<'e>(
 
             let event = Event {
                 scope: scope.clone(),
-                native: native.clone(),
+                native: Arc::new(native.clone()),
                 transaction_digest,
                 sequence_number: ev_sequence_number as u64,
                 timestamp_ms: contents.timestamp_ms(),

--- a/crates/sui-indexer-alt-graphql/src/api/types/event/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/event/mod.rs
@@ -54,7 +54,10 @@ pub(crate) type CEvent = JsonCursor<EventCursor>;
 #[derive(Clone)]
 pub(crate) struct Event {
     pub(crate) scope: Scope,
-    pub(crate) native: NativeEvent,
+    /// Shared `Arc` so that multiple subscribers receiving events from the same
+    /// streamed checkpoint avoid a deep clone per yield. Cloning an `Event` is then
+    /// just an atomic refcount bump on the `native` field.
+    pub(crate) native: Arc<NativeEvent>,
     /// Digest of the transaction that emitted this event
     pub(crate) transaction_digest: TransactionDigest,
     /// Position of this event within the transaction's events list (0-indexed)

--- a/crates/sui-indexer-alt-graphql/src/api/types/snapshots/sui_indexer_alt_graphql__api__types__available_range__field_piplines_tests__registry_collect_pipelines_snapshot_staging.snap
+++ b/crates/sui-indexer-alt-graphql/src/api/types/snapshots/sui_indexer_alt_graphql__api__types__available_range__field_piplines_tests__registry_collect_pipelines_snapshot_staging.snap
@@ -1646,6 +1646,9 @@ Subscription.checkpoints
 Subscription.transactions
   => {}
 
+Subscription.events
+  => {}
+
 Transaction.id
   => {}
 

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -4067,6 +4067,16 @@ type Subscription {
 	"""
 	checkpoints: Checkpoint!
 	"""
+	Subscribe to events as they are emitted, with optional filtering.
+	
+	Each matching event is yielded individually as it appears in finalized
+	checkpoints. Events are ordered by checkpoint, then by transaction
+	position within the checkpoint, then by position within the transaction.
+	
+	This subscription is not yet available for use.
+	"""
+	events(filter: EventFilter): Event!
+	"""
 	Subscribe to transactions as they are finalized, with optional filtering.
 	
 	Each matching transaction is yielded individually as it appears in finalized

--- a/crates/sui-indexer-alt-graphql/src/task/streaming/checkpoint_stream_task.rs
+++ b/crates/sui-indexer-alt-graphql/src/task/streaming/checkpoint_stream_task.rs
@@ -448,7 +448,7 @@ fn process_transaction(
         .deserialize()
         .context("Failed to deserialize transaction effects")?;
 
-    let events: Vec<_> = proto
+    let events: Vec<Arc<_>> = proto
         .events
         .as_ref()
         .and_then(|e| e.bcs.as_ref())
@@ -457,7 +457,7 @@ fn process_transaction(
                 .context("Failed to deserialize transaction events")
         })
         .transpose()?
-        .map(|e: TransactionEvents| e.data)
+        .map(|e: TransactionEvents| e.data.into_iter().map(Arc::new).collect())
         .unwrap_or_default();
 
     let signatures: Vec<GenericSignature> = proto

--- a/crates/sui-indexer-alt-graphql/src/task/streaming/checkpoint_stream_task.rs
+++ b/crates/sui-indexer-alt-graphql/src/task/streaming/checkpoint_stream_task.rs
@@ -448,7 +448,7 @@ fn process_transaction(
         .deserialize()
         .context("Failed to deserialize transaction effects")?;
 
-    let events = proto
+    let events: Vec<_> = proto
         .events
         .as_ref()
         .and_then(|e| e.bcs.as_ref())
@@ -457,7 +457,8 @@ fn process_transaction(
                 .context("Failed to deserialize transaction events")
         })
         .transpose()?
-        .map(|e: TransactionEvents| e.data);
+        .map(|e: TransactionEvents| e.data)
+        .unwrap_or_default();
 
     let signatures: Vec<GenericSignature> = proto
         .signatures

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -4063,6 +4063,16 @@ type Subscription {
 	"""
 	checkpoints: Checkpoint!
 	"""
+	Subscribe to events as they are emitted, with optional filtering.
+	
+	Each matching event is yielded individually as it appears in finalized
+	checkpoints. Events are ordered by checkpoint, then by transaction
+	position within the checkpoint, then by position within the transaction.
+	
+	This subscription is not yet available for use.
+	"""
+	events(filter: EventFilter): Event!
+	"""
 	Subscribe to transactions as they are finalized, with optional filtering.
 	
 	Each matching transaction is yielded individually as it appears in finalized

--- a/crates/sui-indexer-alt-jsonrpc/src/api/transactions/response.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/transactions/response.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::str::FromStr;
+use std::sync::Arc;
 
 use anyhow::Context as _;
 use futures::future::OptionFuture;
@@ -29,7 +30,6 @@ use sui_types::digests::TransactionDigest;
 use sui_types::effects::ObjectChange;
 use sui_types::effects::TransactionEffects;
 use sui_types::effects::TransactionEffectsAPI;
-use sui_types::event::Event;
 use sui_types::object::Object;
 use sui_types::signature::GenericSignature;
 use sui_types::transaction::TransactionData;
@@ -141,7 +141,7 @@ async fn events(
     digest: TransactionDigest,
     tx: &TransactionContents,
 ) -> Result<SuiTransactionBlockEvents, RpcError<Error>> {
-    let events: Vec<Event> = tx.events()?;
+    let events = tx.events()?;
     let mut sui_events = Vec::with_capacity(events.len());
 
     for (ix, event) in events.into_iter().enumerate() {
@@ -163,8 +163,14 @@ async fn events(
             ),
         };
 
-        let sui_event = SuiEvent::try_from(event, digest, ix as u64, tx.timestamp_ms(), layout)
-            .with_context(|| format!("Failed to convert Event {ix} into response"))?;
+        let sui_event = SuiEvent::try_from(
+            Arc::unwrap_or_clone(event),
+            digest,
+            ix as u64,
+            tx.timestamp_ms(),
+            layout,
+        )
+        .with_context(|| format!("Failed to convert Event {ix} into response"))?;
 
         sui_events.push(sui_event)
     }

--- a/crates/sui-indexer-alt-reader/src/kv_loader.rs
+++ b/crates/sui-indexer-alt-reader/src/kv_loader.rs
@@ -100,7 +100,7 @@ pub enum TransactionContents {
 #[derive(Clone)]
 pub struct ExecutedTransactionData {
     pub effects: Box<TransactionEffects>,
-    pub events: Vec<Event>,
+    pub events: Vec<Arc<Event>>,
     pub transaction_data: Box<TransactionData>,
     pub signatures: Vec<GenericSignature>,
     pub balance_changes: Vec<grpc::BalanceChange>,
@@ -382,13 +382,13 @@ impl TransactionContents {
             .context("Effects BCS should be valid")?;
 
         // Parse events from BCS if present, defaulting to empty when absent.
-        let events: Vec<Event> = executed_transaction
+        let events: Vec<Arc<Event>> = executed_transaction
             .events
             .as_ref()
             .and_then(|events| events.bcs.as_ref())
             .map(|bcs| bcs.deserialize().context("Events BCS should be valid"))
             .transpose()?
-            .map(|events: TransactionEvents| events.data)
+            .map(|events: TransactionEvents| events.data.into_iter().map(Arc::new).collect())
             .unwrap_or_default();
 
         let balance_changes = executed_transaction.balance_changes.clone();
@@ -479,13 +479,20 @@ impl TransactionContents {
         }
     }
 
-    pub fn events(&self) -> anyhow::Result<Vec<Event>> {
+    /// Returns the events for this transaction. Each `Event` is wrapped in an `Arc` so
+    /// callers fanning the same transaction out to multiple consumers (e.g., subscription
+    /// resolvers serving different subscribers) share the underlying event allocation
+    /// rather than each performing a deep clone.
+    pub fn events(&self) -> anyhow::Result<Vec<Arc<Event>>> {
+        fn wrap(events: Vec<Event>) -> Vec<Arc<Event>> {
+            events.into_iter().map(Arc::new).collect()
+        }
         match self {
-            Self::Pg(stored) => {
-                bcs::from_bytes(&stored.events).context("Failed to deserialize events")
-            }
-            Self::Bigtable(kv) => Ok(kv.events.clone().unwrap_or_default().data),
-            Self::LedgerGrpc(txn) => Ok(txn.events.clone().unwrap_or_default()),
+            Self::Pg(stored) => bcs::from_bytes(&stored.events)
+                .context("Failed to deserialize events")
+                .map(wrap),
+            Self::Bigtable(kv) => Ok(wrap(kv.events.clone().unwrap_or_default().data)),
+            Self::LedgerGrpc(txn) => Ok(wrap(txn.events.clone().unwrap_or_default())),
             Self::ExecutedTransaction(tx) => Ok(tx.events.clone()),
         }
     }

--- a/crates/sui-indexer-alt-reader/src/kv_loader.rs
+++ b/crates/sui-indexer-alt-reader/src/kv_loader.rs
@@ -100,7 +100,7 @@ pub enum TransactionContents {
 #[derive(Clone)]
 pub struct ExecutedTransactionData {
     pub effects: Box<TransactionEffects>,
-    pub events: Option<Vec<Event>>,
+    pub events: Vec<Event>,
     pub transaction_data: Box<TransactionData>,
     pub signatures: Vec<GenericSignature>,
     pub balance_changes: Vec<grpc::BalanceChange>,
@@ -381,14 +381,15 @@ impl TransactionContents {
             .deserialize()
             .context("Effects BCS should be valid")?;
 
-        // Parse events from BCS if present
-        let events = executed_transaction
+        // Parse events from BCS if present, defaulting to empty when absent.
+        let events: Vec<Event> = executed_transaction
             .events
             .as_ref()
             .and_then(|events| events.bcs.as_ref())
             .map(|bcs| bcs.deserialize().context("Events BCS should be valid"))
             .transpose()?
-            .map(|events: TransactionEvents| events.data);
+            .map(|events: TransactionEvents| events.data)
+            .unwrap_or_default();
 
         let balance_changes = executed_transaction.balance_changes.clone();
 
@@ -485,7 +486,7 @@ impl TransactionContents {
             }
             Self::Bigtable(kv) => Ok(kv.events.clone().unwrap_or_default().data),
             Self::LedgerGrpc(txn) => Ok(txn.events.clone().unwrap_or_default()),
-            Self::ExecutedTransaction(tx) => Ok(tx.events.clone().unwrap_or_default()),
+            Self::ExecutedTransaction(tx) => Ok(tx.events.clone()),
         }
     }
 


### PR DESCRIPTION
## Description 

Add `subscription { events(filter: { sender, module, type }) { ... } }` that yields each matching event individually as it appears in finalized checkpoints. Each yield carries the streamed checkpoint scope plus tx execution objects, so Move type and value resolution flows through the streaming package store

*Features that are not supported in this PR (and will be added in follow-up PR):*
- Resume from a historical event cursor
- Plumbing transaction contents into `Event` so chained resolution like `event.transaction.effects.objectChanges` works for streamed events
- Metrics


## Test plan 

How did you test the new or updated feature?

- Unit + e2e tests
- Start a local GraphQL server


## Stack
   - #26019
   - #26094
   - #26117
   - #26170
   - #26194
   - #26202
   - #26414
   - #26453

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
