### PR TITLE
[typed-store] Fix safe_range_iter dropping the entry at an inclusive upper bound equal to the encoded max key

### DIFF
--- a/crates/typed-store/src/rocks/tests.rs
+++ b/crates/typed-store/src/rocks/tests.rs
@@ -515,6 +515,36 @@ async fn test_range_iter() {
 }
 
 #[tokio::test]
+async fn test_safe_range_iter_inclusive_upper_bound_at_max() {
+    let db: DBMap<u8, String> = open_map(temp_dir(), None);
+    db.insert(&100u8, &"100".to_string()).unwrap();
+    db.insert(&u8::MAX, &"max".to_string()).unwrap();
+
+    let results: Vec<_> = get_range_iter(&db, 100u8..=u8::MAX).collect();
+    assert_eq!(
+        vec![(100u8, "100".to_string()), (u8::MAX, "max".to_string())],
+        results,
+        "Range ..=u8::MAX must include the entry at u8::MAX",
+    );
+}
+
+#[tokio::test]
+async fn test_reversed_safe_iter_inclusive_upper_bound_at_max() {
+    let db: DBMap<u8, String> = open_map(temp_dir(), None);
+    db.insert(&100u8, &"100".to_string()).unwrap();
+    db.insert(&u8::MAX, &"max".to_string()).unwrap();
+
+    let results: Vec<_> = get_reverse_iter(&db, None, Some(u8::MAX))
+        .map(|item| item.unwrap())
+        .collect();
+    assert_eq!(
+        vec![(u8::MAX, "max".to_string()), (100u8, "100".to_string())],
+        results,
+        "reversed_safe_iter_with_bounds upper=u8::MAX must include the entry at u8::MAX",
+    );
+}
+
+#[tokio::test]
 async fn test_is_empty() {
     let db: DBMap<i32, String> = open_map(temp_dir(), Some("table"));
     // Test empty map is truly empty

--- a/crates/typed-store/src/util.rs
+++ b/crates/typed-store/src/util.rs
@@ -74,13 +74,17 @@ where
         Bound::Included(upper_bound) => {
             let mut key_buf = be_fix_int_ser(&upper_bound);
 
-            // If the key is already at the limit, there's nowhere else to go, so no upper bound
-            if !is_max(&key_buf) {
-                // Since we want exclusive, we need to increment the key to get the upper bound
+            if is_max(&key_buf) {
+                // The key is already at the limit, so the inclusive upper bound covers
+                // everything; leaving the rocksdb upper bound unset is the only way to
+                // include the max key (rocksdb upper bound is exclusive).
+                None
+            } else {
+                // Since rocksdb upper bound is exclusive, increment the key by one so the
+                // user-supplied inclusive bound is included.
                 big_endian_saturating_add_one(&mut key_buf);
-                // readopts.set_iterate_upper_bound(key_buf);
+                Some(key_buf)
             }
-            Some(key_buf)
         }
         Bound::Excluded(upper_bound) => {
             // Rocksdb upper bound is inclusive by default so nothing to do


### PR DESCRIPTION
## Description

`typed_store::util::iterator_bounds_with_range` has an off-by-one in its `Bound::Included(upper_bound)` arm. When the user-supplied upper bound serializes to a key that is all `0xFF` (e.g. `u8::MAX`, `u64::MAX`, `ObjectID(0xFF…)`), the function returns `Some(key_buf)`, which is then handed to rocksdb as its iterator upper bound. Because rocksdb's iterator upper bound is *exclusive*, the entry at that key is excluded — even though the caller asked for an inclusive bound.

The inline comment already described the intended semantic — *“If the key is already at the limit, there's nowhere else to go, so no upper bound”* — but the code still returned the bound. This patch makes the code match the comment by returning `None` in that case so rocksdb is given no upper bound and the max-key entry is iterated.

Affects:
- `DBMap::safe_range_iter(..=K)` when `K` serializes to all `0xFF`.
- `DBMap::reversed_safe_iter_with_bounds(_, Some(K))` for the same `K`.

`DBMap::safe_iter_with_bounds` is unaffected because it uses `iterator_bounds`, which is exclusive on the upper bound by design.

## The bug as a failing test

```rust
let db: DBMap<u8, String> = open_map(temp_dir(), None);
db.insert(&100u8, &\"100\".to_string()).unwrap();
db.insert(&u8::MAX, &\"max\".to_string()).unwrap();

let results: Vec<_> = get_range_iter(&db, 100u8..=u8::MAX).collect();
// Expected: [(100, \"100\"), (255, \"max\")]
// Actual on main: [(100, \"100\")]   <-- the entry at u8::MAX is silently dropped
```

## The fix

```rust
Bound::Included(upper_bound) => {
    let mut key_buf = be_fix_int_ser(&upper_bound);
    if is_max(&key_buf) {
        None
    } else {
        big_endian_saturating_add_one(&mut key_buf);
        Some(key_buf)
    }
}
```

## Test plan

Two regression tests in `crates/typed-store/src/rocks/tests.rs`:
- `test_safe_range_iter_inclusive_upper_bound_at_max`
- `test_reversed_safe_iter_inclusive_upper_bound_at_max`

Both insert `(100u8, _)` and `(u8::MAX, _)`, then iterate with `..=u8::MAX` and assert that both entries are returned. Both fail on `main` (the entry at `u8::MAX` is dropped) and pass after this change.

```sh
cargo test --release -p typed-store
# all 36 tests pass (28 existing rocks tests + 5 unit + 3 doctests + the 2 new regression tests)

cargo check -p sui-core -p sui-storage  # downstream consumers compile cleanly
```

## Closes

Closes #26455

## Release notes

- [x] Nodes (Validators and Full nodes): callers of `DBMap::safe_range_iter(..=K)` or `DBMap::reversed_safe_iter_with_bounds(_, Some(K))` where `K` serializes to all `0xFF` will now correctly include the entry at `K`. Previously that entry was silently skipped.