### PR TITLE
docker/sui-node: add BuildKit cache mounts for cargo target/ + registry/git

### DIFF
--- a/docker/sui-node/Dockerfile
+++ b/docker/sui-node/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1.4
+
 # Build application
 #
 # Copy in all crates, Cargo.toml and Cargo.lock unmodified,
@@ -5,6 +7,7 @@
 FROM rust:1.92-bullseye AS builder
 ARG PROFILE=release
 ARG GIT_REVISION
+ARG TARGETARCH
 ENV GIT_REVISION=$GIT_REVISION
 WORKDIR "$WORKDIR/sui"
 RUN apt-get update && apt-get install -y cmake clang
@@ -15,7 +18,21 @@ COPY crates crates
 COPY sui-execution sui-execution
 COPY external-crates external-crates
 
-RUN cargo build --profile ${PROFILE} --bin sui-node
+# BuildKit cache mounts persist target/ and the cargo registry/git caches
+# across builds on the same builder. Cache ids are split by arch so amd64
+# and arm64 builds don't stomp each other. sharing=locked serializes
+# concurrent builds for the same cache id (cargo's target/ is not safe
+# under concurrent writers).
+#
+# After the build, copy the binary out of the cache mount so the next stage
+# can COPY --from=builder. Cache mount contents do not persist into the
+# image layer.
+RUN --mount=type=cache,target=/sui/target,id=sui-node-target-${TARGETARCH},sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/registry,id=cargo-registry-${TARGETARCH},sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,id=cargo-git-${TARGETARCH},sharing=locked \
+    cargo build --profile ${PROFILE} --bin sui-node \
+    && mkdir -p /opt/sui/bin \
+    && cp /sui/target/release/sui-node /opt/sui/bin/sui-node
 
 # Production Image
 FROM debian:bullseye-slim AS runtime
@@ -24,9 +41,9 @@ RUN apt-get update && apt-get install -y ca-certificates curl
 ARG PROFILE=release
 WORKDIR "$WORKDIR/sui"
 # Both bench and release profiles copy from release dir
-COPY --from=builder /sui/target/release/sui-node /opt/sui/bin/sui-node
+COPY --from=builder /opt/sui/bin/sui-node /opt/sui/bin/sui-node
 # Support legacy usages of /usr/local/bin/sui-node
-COPY --from=builder /sui/target/release/sui-node /usr/local/bin
+COPY --from=builder /opt/sui/bin/sui-node /usr/local/bin
 
 ARG BUILD_DATE
 ARG GIT_REVISION


### PR DESCRIPTION
## Summary

- Add `--mount=type=cache` directives for `/sui/target`, `/usr/local/cargo/registry`, `/usr/local/cargo/git` on the `cargo build` step in `docker/sui-node/Dockerfile`
- Cache ids split by arch (`sui-node-target-${TARGETARCH}` etc.) so amd64 and arm64 builds don't share cargo's target layout
- `sharing=locked` serializes concurrent builds for the same cache id (cargo's target/ is not safe under concurrent writers)
- Copy the built binary out of `/sui/target` into `/opt/sui/bin` inside the same RUN, since cache mount contents don't persist into the image layer

## Why

mp3 is rolling out a transparent sccache + mold build acceleration via [MystenLabs/mp3#117](https://github.com/MystenLabs/mp3/pull/117). Cross-SHA test sweeps using sccache GCS surfaced a parallel-compile race: cargo dispatches multiple rustc invocations in parallel, sccache returns a hit and exits 0 for crate A (e.g. autocfg), and cargo schedules a dependent compile on crate B before the .rlib is on disk, producing `error: extern location for autocfg does not exist`.

The race was confirmed by setting `CARGO_BUILD_JOBS=1` on the same SHA (98a09f78) — 3/3 builds succeeded vs ~80% failure rate under default parallelism.

The proper structural fix isn't serial cargo (kills throughput); it's BuildKit cache mounts. With `target/` persisted on the builder, cargo finds existing artifacts and doesn't invoke sccache (or rustc) for them at all, eliminating the race surface. sccache then serves its intended role — cross-builder cache for cold builders or cache misses — instead of being the *primary* cache.

## Effect on existing consumers

- **GitHub Actions runs of this Dockerfile**: GHA runners are ephemeral, so cache mounts give no warm-cache benefit but no regression either. The `sharing=locked` flag is irrelevant when only one build runs per builder.
- **mp3 production builds**: same buildkit builder pool; will start benefiting from warm `target/` across rebuilds of the same arch.
- **Final image**: identical contents — only the COPY source path changed (`/opt/sui/bin/sui-node` instead of `/sui/target/release/sui-node`), and the binary is bit-for-bit the same.

## Test plan

- [ ] Build sui-node image once (cold cache) — confirm runs successfully
- [ ] Build sui-node image second time — confirm cargo reports significantly fewer Compiling lines (cache hit on most crates)
- [ ] Verify final image still has `/opt/sui/bin/sui-node` and `/usr/local/bin/sui-node` from buildkit output
- [ ] Run mp3 cross-SHA sweep on staging (post-merge) — confirm pass rate ~100% with default parallel cargo + sccache enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)