### PR TITLE
[move-core-types] Adds a bunch more functionality

### DIFF
--- a/external-crates/move/crates/move-core-types/src/compressed/annotated/layout.rs
+++ b/external-crates/move/crates/move-core-types/src/compressed/annotated/layout.rs
@@ -258,7 +258,7 @@ pub trait BackendBuilder: Sized {
     /// Recursively absorb an existing compressed annotated layout (from any
     /// backend) into this builder, deduplicating shared subtrees against the
     /// builder's pool.
-    fn from_layout<U: TypeLayout>(
+    fn intern_layout<U: TypeLayout>(
         &mut self,
         layout: &MoveTypeLayout<U>,
     ) -> Result<Self::Root, Self::Error> {
@@ -389,6 +389,27 @@ impl<T: TypeLayout> MoveTypeLayout<T> {
     /// Inflate back into a tree-based [`AV::MoveTypeLayout`].
     pub fn inflate(&self) -> AResult<AV::MoveTypeLayout> {
         self.as_ref().inflate()
+    }
+
+    /// If this layout is a struct, return a borrowed view onto it.
+    pub fn as_struct(&self) -> Option<MoveStructLayout<'_, T>> {
+        match self.as_view() {
+            MoveLayoutView::Struct(s) => Some(s),
+            _ => None,
+        }
+    }
+
+    /// If this layout is an enum, return a borrowed view onto it.
+    pub fn as_enum(&self) -> Option<MoveEnumLayout<'_, T>> {
+        match self.as_view() {
+            MoveLayoutView::Enum(e) => Some(e),
+            _ => None,
+        }
+    }
+
+    /// If this layout is a struct or enum, return a borrowed datatype view.
+    pub fn as_datatype(&self) -> Option<MoveDatatypeLayout<'_, T>> {
+        MoveDatatypeLayout::new(self.as_ref())
     }
 
     /// Returns `true` iff `self` and `other` describe the same Move type,

--- a/external-crates/move/crates/move-core-types/src/compressed/annotated/layout.rs
+++ b/external-crates/move/crates/move-core-types/src/compressed/annotated/layout.rs
@@ -311,7 +311,21 @@ impl<T: TypeLayout> MoveTypeLayout<T> {
     pub fn inflate(&self) -> AResult<AV::MoveTypeLayout> {
         self.as_ref().inflate()
     }
+
+    /// Returns `true` iff `self` and `other` describe the same Move type,
+    /// regardless of pool ordering or how subtrees are shared.
+    pub fn equivalent<U: TypeLayout>(&self, other: &MoveTypeLayout<U>) -> bool {
+        self.as_ref().equivalent(&other.as_ref())
+    }
 }
+
+impl<T: TypeLayout> PartialEq for MoveTypeLayout<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.equivalent(other)
+    }
+}
+
+impl<T: TypeLayout> Eq for MoveTypeLayout<T> {}
 
 impl<T: TypeLayout> fmt::Display for MoveTypeLayout<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -358,6 +372,12 @@ impl<'a, T: TypeLayout> MoveTypeLayoutRef<'a, T> {
     /// Inflate back into a tree-based [`AV::MoveTypeLayout`].
     pub fn inflate(self) -> AResult<AV::MoveTypeLayout> {
         self.as_view().inflate()
+    }
+
+    /// Returns `true` iff the two layouts describe the same Move type,
+    /// regardless of pool ordering or how subtrees are shared.
+    pub fn equivalent<U: TypeLayout>(&self, other: &MoveTypeLayoutRef<'_, U>) -> bool {
+        (*self).as_view().equivalent(&(*other).as_view())
     }
 }
 
@@ -459,7 +479,36 @@ impl<T: TypeLayout> MoveLayoutView<'_, T> {
             MoveLayoutView::Enum(ev) => ev.is_type_tag(t),
         }
     }
+
+    /// Returns `true` iff `self` and `other` describe the same Move type,
+    /// regardless of pool ordering or how subtrees are shared.
+    pub fn equivalent<U: TypeLayout>(&self, other: &MoveLayoutView<'_, U>) -> bool {
+        use MoveLayoutView::*;
+        match (self, other) {
+            (Bool, Bool)
+            | (U8, U8)
+            | (U16, U16)
+            | (U32, U32)
+            | (U64, U64)
+            | (U128, U128)
+            | (U256, U256)
+            | (Address, Address)
+            | (Signer, Signer) => true,
+            (Vector(a), Vector(b)) => a.equivalent(b),
+            (Struct(a), Struct(b)) => a.equivalent(b),
+            (Enum(a), Enum(b)) => a.equivalent(b),
+            _ => false,
+        }
+    }
 }
+
+impl<T: TypeLayout> PartialEq for MoveLayoutView<'_, T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.equivalent(other)
+    }
+}
+
+impl<T: TypeLayout> Eq for MoveLayoutView<'_, T> {}
 
 impl<T: TypeLayout> From<MoveLayoutView<'_, T>> for TypeTag {
     fn from(view: MoveLayoutView<'_, T>) -> TypeTag {
@@ -563,7 +612,25 @@ impl<'a, T: TypeLayout> MoveDatatypeLayout<'a, T> {
             }
         }
     }
+
+    /// Returns `true` iff `self` and `other` describe the same datatype,
+    /// regardless of pool ordering.
+    pub fn equivalent<U: TypeLayout>(&self, other: &MoveDatatypeLayout<'_, U>) -> bool {
+        match (self, other) {
+            (MoveDatatypeLayout::Struct(a), MoveDatatypeLayout::Struct(b)) => a.equivalent(b),
+            (MoveDatatypeLayout::Enum(a), MoveDatatypeLayout::Enum(b)) => a.equivalent(b),
+            _ => false,
+        }
+    }
 }
+
+impl<T: TypeLayout> PartialEq for MoveDatatypeLayout<'_, T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.equivalent(other)
+    }
+}
+
+impl<T: TypeLayout> Eq for MoveDatatypeLayout<'_, T> {}
 
 // --- MoveFieldsLayout ---
 
@@ -616,7 +683,27 @@ impl<'a, T: TypeLayout> MoveFieldsLayout<'a, T> {
             )
         })
     }
+
+    /// Returns `true` iff the two field-lists describe the same fields
+    /// (same arity, pairwise-equivalent layouts, identical names),
+    /// regardless of pool ordering.
+    pub fn equivalent<U: TypeLayout>(&self, other: &MoveFieldsLayout<'_, U>) -> bool {
+        if self.field_count() != other.field_count() {
+            return false;
+        }
+        self.fields()
+            .zip(other.fields())
+            .all(|((na, la), (nb, lb))| na == nb && la.equivalent(&lb))
+    }
 }
+
+impl<T: TypeLayout> PartialEq for MoveFieldsLayout<'_, T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.equivalent(other)
+    }
+}
+
+impl<T: TypeLayout> Eq for MoveFieldsLayout<'_, T> {}
 
 // --- MoveStructLayout ---
 
@@ -658,7 +745,21 @@ impl<'a, T: TypeLayout> MoveStructLayout<'a, T> {
     ) -> impl ExactSizeIterator<Item = (&'a Identifier, MoveTypeLayoutRef<'a, T>)> {
         self.fields.fields()
     }
+
+    /// Returns `true` iff `self` and `other` describe the same struct type
+    /// (same type tag, same fields), regardless of pool ordering.
+    pub fn equivalent<U: TypeLayout>(&self, other: &MoveStructLayout<'_, U>) -> bool {
+        self.type_ == other.type_ && self.fields.equivalent(&other.fields)
+    }
 }
+
+impl<T: TypeLayout> PartialEq for MoveStructLayout<'_, T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.equivalent(other)
+    }
+}
+
+impl<T: TypeLayout> Eq for MoveStructLayout<'_, T> {}
 
 impl<T: TypeLayout> fmt::Display for MoveStructLayout<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -744,7 +845,52 @@ impl<'a, T: TypeLayout> MoveEnumLayout<'a, T> {
         let pool = self.pool;
         self.variants.iter().map(move |v| variant_view(pool, v))
     }
+
+    /// Returns `true` iff `self` and `other` describe the same enum type
+    /// (same type tag, same variants with matching names/tags/fields),
+    /// regardless of pool ordering.
+    pub fn equivalent<U: TypeLayout>(&self, other: &MoveEnumLayout<'_, U>) -> bool {
+        if self.type_ != other.type_ {
+            return false;
+        }
+        if self.variant_count() != other.variant_count() {
+            return false;
+        }
+        self.variants().zip(other.variants()).all(|pair| match pair {
+            (
+                VariantLayout::Unknown {
+                    name: na,
+                    tag: ta,
+                },
+                VariantLayout::Unknown {
+                    name: nb,
+                    tag: tb,
+                },
+            ) => na == nb && ta == tb,
+            (
+                VariantLayout::Known {
+                    name: na,
+                    tag: ta,
+                    fields: fa,
+                },
+                VariantLayout::Known {
+                    name: nb,
+                    tag: tb,
+                    fields: fb,
+                },
+            ) => na == nb && ta == tb && fa.equivalent(&fb),
+            _ => false,
+        })
+    }
 }
+
+impl<T: TypeLayout> PartialEq for MoveEnumLayout<'_, T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.equivalent(other)
+    }
+}
+
+impl<T: TypeLayout> Eq for MoveEnumLayout<'_, T> {}
 
 #[inline]
 fn variant_view<'a, T: TypeLayout>(

--- a/external-crates/move/crates/move-core-types/src/compressed/annotated/layout.rs
+++ b/external-crates/move/crates/move-core-types/src/compressed/annotated/layout.rs
@@ -255,6 +255,85 @@ pub trait BackendBuilder: Sized {
         })
     }
 
+    /// Recursively absorb an existing compressed annotated layout (from any
+    /// backend) into this builder, deduplicating shared subtrees against the
+    /// builder's pool.
+    fn from_layout<U: TypeLayout>(
+        &mut self,
+        layout: &MoveTypeLayout<U>,
+    ) -> Result<Self::Root, Self::Error> {
+        self.intern_view(layout.as_view())
+    }
+
+    /// Recursively intern a [`MoveLayoutView`] (a borrowed resolved layout)
+    /// into this builder.
+    fn intern_view<U: TypeLayout>(
+        &mut self,
+        view: MoveLayoutView<'_, U>,
+    ) -> Result<Self::Root, Self::Error> {
+        Ok(match view {
+            MoveLayoutView::Bool => self.bool(),
+            MoveLayoutView::U8 => self.u8(),
+            MoveLayoutView::U16 => self.u16(),
+            MoveLayoutView::U32 => self.u32(),
+            MoveLayoutView::U64 => self.u64(),
+            MoveLayoutView::U128 => self.u128(),
+            MoveLayoutView::U256 => self.u256(),
+            MoveLayoutView::Address => self.address(),
+            MoveLayoutView::Signer => self.signer(),
+            MoveLayoutView::Vector(inner) => {
+                let inner_h = self.intern_view(inner.as_view())?;
+                self.vector(inner_h)?
+            }
+            MoveLayoutView::Struct(s) => {
+                let type_tag = s.type_().clone();
+                let fields: Vec<(Identifier, Self::Root)> = s
+                    .fields()
+                    .map(|(name, layout)| Ok((name.clone(), self.intern_view(layout.as_view())?)))
+                    .collect::<Result<_, Self::Error>>()?;
+                let field_refs: Vec<(&Identifier, Self::Root)> =
+                    fields.iter().map(|(n, h)| (n, h.clone())).collect();
+                self.struct_layout(&type_tag, &field_refs)?
+            }
+            MoveLayoutView::Enum(e) => {
+                let type_tag = e.type_().clone();
+                // First collect (name, tag, optional field handles) so we
+                // can build the borrowed slices in a second pass.
+                let variants: Vec<(Identifier, VariantTag, Option<Vec<(Identifier, Self::Root)>>)> =
+                    e.variants()
+                        .map(|v| match v {
+                            VariantLayout::Known { name, tag, fields } => {
+                                let fs: Vec<(Identifier, Self::Root)> = fields
+                                    .fields()
+                                    .map(|(n, l)| {
+                                        Ok((n.clone(), self.intern_view(l.as_view())?))
+                                    })
+                                    .collect::<Result<_, Self::Error>>()?;
+                                Ok((name.clone(), tag, Some(fs)))
+                            }
+                            VariantLayout::Unknown { name, tag } => {
+                                Ok((name.clone(), tag, None))
+                            }
+                        })
+                        .collect::<Result<_, Self::Error>>()?;
+                let variant_field_refs: Vec<Option<Vec<(&Identifier, Self::Root)>>> = variants
+                    .iter()
+                    .map(|(_, _, fs)| {
+                        fs.as_ref()
+                            .map(|fs| fs.iter().map(|(n, h)| (n, h.clone())).collect())
+                    })
+                    .collect();
+                let variant_refs: Vec<(&Identifier, VariantTag, Option<&[(&Identifier, Self::Root)]>)> =
+                    variants
+                        .iter()
+                        .zip(variant_field_refs.iter())
+                        .map(|((name, tag, _), fs)| (name, *tag, fs.as_deref()))
+                        .collect();
+                self.enum_layout(&type_tag, &variant_refs)?
+            }
+        })
+    }
+
     /// Finalize the builder and wrap the result in a [`MoveTypeLayout`].
     fn build(self, root: Self::Root) -> MoveTypeLayout<Self::Output> {
         let pool = self.finalize(root.clone());

--- a/external-crates/move/crates/move-core-types/src/compressed/backend/annotated_nodes.rs
+++ b/external-crates/move/crates/move-core-types/src/compressed/backend/annotated_nodes.rs
@@ -14,6 +14,7 @@ use crate::compressed::annotated::{
 };
 use crate::identifier::Identifier;
 use crate::language_storage::StructTag;
+use std::sync::Arc;
 
 // =============================================================================
 // Node types
@@ -32,21 +33,21 @@ pub struct AnnotatedFieldEntry<R> {
 pub struct AnnotatedVariantEntry<R> {
     pub name: Identifier,
     pub tag: VariantTag,
-    pub fields: Option<Box<[AnnotatedFieldEntry<R>]>>,
+    pub fields: Option<Arc<[AnnotatedFieldEntry<R>]>>,
 }
 
 /// Annotated struct layout node with type tag and named fields inline.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct MoveStructNode<R> {
     pub(crate) type_: StructTag,
-    pub(crate) fields: Box<[AnnotatedFieldEntry<R>]>,
+    pub(crate) fields: Arc<[AnnotatedFieldEntry<R>]>,
 }
 
 /// Annotated enum layout node with type tag and named variants inline.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct MoveEnumNode<R> {
     pub(crate) type_: StructTag,
-    pub(crate) variants: Box<[AnnotatedVariantEntry<R>]>,
+    pub(crate) variants: Arc<[AnnotatedVariantEntry<R>]>,
 }
 
 /// A compound layout node generic over the reference type.
@@ -65,7 +66,7 @@ impl MoveTypeNode<LayoutRef> {
     /// Build a struct node from a type tag and a slice of `(name, layout-ref)`
     /// pairs.
     pub(crate) fn struct_node(type_tag: &StructTag, fields: &[(&Identifier, LayoutRef)]) -> Self {
-        let field_entries: Box<[AnnotatedFieldEntry<LayoutRef>]> = fields
+        let field_entries: Arc<[AnnotatedFieldEntry<LayoutRef>]> = fields
             .iter()
             .map(|(name, h)| AnnotatedFieldEntry {
                 name: (*name).clone(),
@@ -83,7 +84,7 @@ impl MoveTypeNode<LayoutRef> {
         type_tag: &StructTag,
         variants: &[(&Identifier, VariantTag, Option<&[(&Identifier, LayoutRef)]>)],
     ) -> Self {
-        let variant_entries: Box<[AnnotatedVariantEntry<LayoutRef>]> = variants
+        let variant_entries: Arc<[AnnotatedVariantEntry<LayoutRef>]> = variants
             .iter()
             .map(|(vn, tag, fields)| {
                 let field_entries = fields.map(|fields| {

--- a/external-crates/move/crates/move-core-types/src/compressed/backend/runtime_nodes.rs
+++ b/external-crates/move/crates/move-core-types/src/compressed/backend/runtime_nodes.rs
@@ -11,6 +11,7 @@ use crate::compressed::runtime::{
     MoveEnumLayout, MoveFieldsLayout, MoveLayoutView, MoveStructLayout, MoveTypeLayoutRef,
     TypeLayout,
 };
+use std::sync::Arc;
 
 // =============================================================================
 // Node types
@@ -19,7 +20,7 @@ use crate::compressed::runtime::{
 /// Struct layout node: field types stored as references of type `R`.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct MoveStructNode<R> {
-    pub(crate) fields: Box<[R]>,
+    pub(crate) fields: Arc<[R]>,
 }
 
 /// Enum layout node: each variant is either a known list of field
@@ -27,7 +28,7 @@ pub struct MoveStructNode<R> {
 /// not available.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct MoveEnumNode<R> {
-    pub(crate) variants: Box<[Option<Box<[R]>>]>,
+    pub(crate) variants: Arc<[Option<Arc<[R]>>]>,
 }
 
 /// A compound layout node generic over the reference type.

--- a/external-crates/move/crates/move-core-types/src/compressed/runtime/layout.rs
+++ b/external-crates/move/crates/move-core-types/src/compressed/runtime/layout.rs
@@ -222,6 +222,64 @@ pub trait BackendBuilder: Sized {
         })
     }
 
+    /// Recursively absorb an existing compressed layout (from any backend)
+    /// into this builder, deduplicating shared subtrees against the builder's
+    /// pool.
+    fn from_layout<U: TypeLayout>(
+        &mut self,
+        layout: &MoveTypeLayout<U>,
+    ) -> Result<Self::Root, Self::Error> {
+        self.intern_view(layout.as_view())
+    }
+
+    /// Recursively intern a [`MoveLayoutView`] (a borrowed resolved layout)
+    /// into this builder.
+    fn intern_view<U: TypeLayout>(
+        &mut self,
+        view: MoveLayoutView<'_, U>,
+    ) -> Result<Self::Root, Self::Error> {
+        Ok(match view {
+            MoveLayoutView::Bool => self.bool(),
+            MoveLayoutView::U8 => self.u8(),
+            MoveLayoutView::U16 => self.u16(),
+            MoveLayoutView::U32 => self.u32(),
+            MoveLayoutView::U64 => self.u64(),
+            MoveLayoutView::U128 => self.u128(),
+            MoveLayoutView::U256 => self.u256(),
+            MoveLayoutView::Address => self.address(),
+            MoveLayoutView::Signer => self.signer(),
+            MoveLayoutView::Vector(inner) => {
+                let inner_h = self.intern_view(inner.as_view())?;
+                self.vector(inner_h)?
+            }
+            MoveLayoutView::Struct(s) => {
+                let fields = s
+                    .fields()
+                    .map(|f| self.intern_view(f.as_view()))
+                    .collect::<Result<Vec<_>, _>>()?;
+                self.struct_layout(&fields)?
+            }
+            MoveLayoutView::Enum(e) => {
+                let variant_handles: Vec<Option<Vec<Self::Root>>> = e
+                    .variants()
+                    .map(|v| match v {
+                        VariantLayout::Known(fs) => fs
+                            .fields()
+                            .map(|f| self.intern_view(f.as_view()))
+                            .collect::<Result<Vec<_>, _>>()
+                            .map(Some),
+                        VariantLayout::Unknown => Ok(None),
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+                let variant_refs: Vec<Option<&[Self::Root]>> = variant_handles
+                    .iter()
+                    .map(|v| v.as_deref())
+                    .collect();
+                self.enum_layout(&variant_refs)?
+            }
+        })
+    }
+
     /// Finalize the builder and wrap the result in a [`MoveTypeLayout`].
     fn build(self, root: Self::Root) -> MoveTypeLayout<Self::Output> {
         let pool = self.finalize(root.clone());

--- a/external-crates/move/crates/move-core-types/src/compressed/runtime/layout.rs
+++ b/external-crates/move/crates/move-core-types/src/compressed/runtime/layout.rs
@@ -286,7 +286,21 @@ impl<T: TypeLayout> MoveTypeLayout<T> {
     pub fn inflate(&self) -> AResult<RV::MoveTypeLayout> {
         self.as_ref().inflate()
     }
+
+    /// Returns `true` iff `self` and `other` describe the same Move type,
+    /// regardless of pool ordering or how subtrees are shared.
+    pub fn equivalent<U: TypeLayout>(&self, other: &MoveTypeLayout<U>) -> bool {
+        self.as_ref().equivalent(&other.as_ref())
+    }
 }
+
+impl<T: TypeLayout> PartialEq for MoveTypeLayout<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.equivalent(other)
+    }
+}
+
+impl<T: TypeLayout> Eq for MoveTypeLayout<T> {}
 
 impl<T: TypeLayout> fmt::Display for MoveTypeLayout<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -334,6 +348,12 @@ impl<'a, T: TypeLayout> MoveTypeLayoutRef<'a, T> {
     /// if any enum variant has an unknown layout.
     pub fn inflate(self) -> AResult<RV::MoveTypeLayout> {
         self.as_view().inflate()
+    }
+
+    /// Returns `true` iff the two layouts describe the same Move type,
+    /// regardless of pool ordering or how subtrees are shared.
+    pub fn equivalent<U: TypeLayout>(&self, other: &MoveTypeLayoutRef<'_, U>) -> bool {
+        (*self).as_view().equivalent(&(*other).as_view())
     }
 }
 
@@ -394,7 +414,36 @@ impl<T: TypeLayout> MoveLayoutView<'_, T> {
             }
         })
     }
+
+    /// Returns `true` iff `self` and `other` describe the same Move type,
+    /// regardless of pool ordering or how subtrees are shared.
+    pub fn equivalent<U: TypeLayout>(&self, other: &MoveLayoutView<'_, U>) -> bool {
+        use MoveLayoutView::*;
+        match (self, other) {
+            (Bool, Bool)
+            | (U8, U8)
+            | (U16, U16)
+            | (U32, U32)
+            | (U64, U64)
+            | (U128, U128)
+            | (U256, U256)
+            | (Address, Address)
+            | (Signer, Signer) => true,
+            (Vector(a), Vector(b)) => a.equivalent(b),
+            (Struct(a), Struct(b)) => a.equivalent(b),
+            (Enum(a), Enum(b)) => a.equivalent(b),
+            _ => false,
+        }
+    }
 }
+
+impl<T: TypeLayout> PartialEq for MoveLayoutView<'_, T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.equivalent(other)
+    }
+}
+
+impl<T: TypeLayout> Eq for MoveLayoutView<'_, T> {}
 
 impl<T: TypeLayout> fmt::Display for MoveLayoutView<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -444,7 +493,26 @@ impl<'a, T: TypeLayout> MoveFieldsLayout<'a, T> {
             root: f,
         })
     }
+
+    /// Returns `true` iff the two field-lists describe the same fields
+    /// (same arity, pairwise-equivalent layouts), regardless of pool ordering.
+    pub fn equivalent<U: TypeLayout>(&self, other: &MoveFieldsLayout<'_, U>) -> bool {
+        if self.field_count() != other.field_count() {
+            return false;
+        }
+        self.fields()
+            .zip(other.fields())
+            .all(|(a, b)| a.equivalent(&b))
+    }
 }
+
+impl<T: TypeLayout> PartialEq for MoveFieldsLayout<'_, T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.equivalent(other)
+    }
+}
+
+impl<T: TypeLayout> Eq for MoveFieldsLayout<'_, T> {}
 
 // --- MoveStructLayout ---
 
@@ -472,7 +540,21 @@ impl<'a, T: TypeLayout> MoveStructLayout<'a, T> {
     pub fn fields(self) -> impl ExactSizeIterator<Item = MoveTypeLayoutRef<'a, T>> {
         self.fields.fields()
     }
+
+    /// Returns `true` iff `self` and `other` describe the same struct type,
+    /// regardless of pool ordering.
+    pub fn equivalent<U: TypeLayout>(&self, other: &MoveStructLayout<'_, U>) -> bool {
+        self.fields.equivalent(&other.fields)
+    }
 }
+
+impl<T: TypeLayout> PartialEq for MoveStructLayout<'_, T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.equivalent(other)
+    }
+}
+
+impl<T: TypeLayout> Eq for MoveStructLayout<'_, T> {}
 
 impl<T: TypeLayout> fmt::Display for MoveStructLayout<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -521,7 +603,29 @@ impl<'a, T: TypeLayout> MoveEnumLayout<'a, T> {
         let pool = self.pool;
         self.variants.iter().map(move |v| make_variant(pool, v))
     }
+
+    /// Returns `true` iff `self` and `other` describe the same enum type,
+    /// regardless of pool ordering. Variants must match positionally
+    /// (same Known/Unknown disposition, equivalent fields when Known).
+    pub fn equivalent<U: TypeLayout>(&self, other: &MoveEnumLayout<'_, U>) -> bool {
+        if self.variant_count() != other.variant_count() {
+            return false;
+        }
+        self.variants().zip(other.variants()).all(|pair| match pair {
+            (VariantLayout::Unknown, VariantLayout::Unknown) => true,
+            (VariantLayout::Known(a), VariantLayout::Known(b)) => a.equivalent(&b),
+            _ => false,
+        })
+    }
 }
+
+impl<T: TypeLayout> PartialEq for MoveEnumLayout<'_, T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.equivalent(other)
+    }
+}
+
+impl<T: TypeLayout> Eq for MoveEnumLayout<'_, T> {}
 
 #[inline]
 fn make_variant<'a, T: TypeLayout>(

--- a/external-crates/move/crates/move-core-types/src/compressed/runtime/layout.rs
+++ b/external-crates/move/crates/move-core-types/src/compressed/runtime/layout.rs
@@ -7,6 +7,7 @@ use crate::compressed::backend::DefaultRuntime;
 use crate::runtime_value as RV;
 use anyhow::Result as AResult;
 use std::fmt;
+use std::sync::Arc;
 
 /// The default compressed-runtime layout builder. Alias so most users can just write
 /// `MoveTypeLayoutBuilder::new()`.
@@ -97,7 +98,7 @@ pub enum MoveLayoutView<'a, T: TypeLayout = DefaultRuntime> {
 #[derive(Debug)]
 pub struct MoveEnumLayout<'a, T: TypeLayout = DefaultRuntime> {
     pub(crate) pool: &'a T,
-    pub(crate) variants: &'a [Option<Box<[T::Root]>>],
+    pub(crate) variants: &'a [Option<Arc<[T::Root]>>],
 }
 
 /// The struct layout of a struct type, as a view into a shared pool.
@@ -630,7 +631,7 @@ impl<T: TypeLayout> Eq for MoveEnumLayout<'_, T> {}
 #[inline]
 fn make_variant<'a, T: TypeLayout>(
     pool: &'a T,
-    v: &'a Option<Box<[T::Root]>>,
+    v: &'a Option<Arc<[T::Root]>>,
 ) -> VariantLayout<'a, T> {
     match v {
         Some(fields) => VariantLayout::Known(MoveFieldsLayout { pool, fields }),

--- a/external-crates/move/crates/move-core-types/src/compressed/runtime/layout.rs
+++ b/external-crates/move/crates/move-core-types/src/compressed/runtime/layout.rs
@@ -225,7 +225,7 @@ pub trait BackendBuilder: Sized {
     /// Recursively absorb an existing compressed layout (from any backend)
     /// into this builder, deduplicating shared subtrees against the builder's
     /// pool.
-    fn from_layout<U: TypeLayout>(
+    fn intern_layout<U: TypeLayout>(
         &mut self,
         layout: &MoveTypeLayout<U>,
     ) -> Result<Self::Root, Self::Error> {
@@ -344,6 +344,22 @@ impl<T: TypeLayout> MoveTypeLayout<T> {
     /// if any enum variant has an unknown layout.
     pub fn inflate(&self) -> AResult<RV::MoveTypeLayout> {
         self.as_ref().inflate()
+    }
+
+    /// If this layout is a struct, return a borrowed view onto it.
+    pub fn as_struct(&self) -> Option<MoveStructLayout<'_, T>> {
+        match self.as_view() {
+            MoveLayoutView::Struct(s) => Some(s),
+            _ => None,
+        }
+    }
+
+    /// If this layout is an enum, return a borrowed view onto it.
+    pub fn as_enum(&self) -> Option<MoveEnumLayout<'_, T>> {
+        match self.as_view() {
+            MoveLayoutView::Enum(e) => Some(e),
+            _ => None,
+        }
     }
 
     /// Returns `true` iff `self` and `other` describe the same Move type,

--- a/external-crates/move/crates/move-core-types/src/proptest_types.rs
+++ b/external-crates/move/crates/move-core-types/src/proptest_types.rs
@@ -4,10 +4,13 @@
 
 use crate::{
     account_address::AccountAddress,
+    annotated_value as A,
     identifier::Identifier,
     language_storage::{StructTag, TypeTag},
+    runtime_value as R,
 };
 use proptest::{collection::vec, prelude::*};
+use std::collections::BTreeMap;
 
 impl Arbitrary for TypeTag {
     type Parameters = ();
@@ -49,4 +52,113 @@ impl Arbitrary for TypeTag {
         )
         .boxed()
     }
+}
+
+// =============================================================================
+// Layout strategies
+// =============================================================================
+
+/// Strategy producing arbitrary runtime tree-form `MoveTypeLayout`s. Bounded
+/// in depth and breadth so generated layouts stay reasonable for property tests.
+pub fn arb_runtime_layout() -> BoxedStrategy<R::MoveTypeLayout> {
+    use R::MoveTypeLayout as T;
+
+    let leaf = prop_oneof![
+        Just(T::Bool),
+        Just(T::U8),
+        Just(T::U16),
+        Just(T::U32),
+        Just(T::U64),
+        Just(T::U128),
+        Just(T::U256),
+        Just(T::Address),
+        Just(T::Signer),
+    ];
+
+    leaf.prop_recursive(
+        4,  // depth
+        24, // max nodes
+        4,  // branching
+        |inner| {
+            prop_oneof![
+                inner.clone().prop_map(|t| T::Vector(Box::new(t))),
+                vec(inner.clone(), 0..=4)
+                    .prop_map(|fields| T::Struct(Box::new(R::MoveStructLayout(Box::new(fields))))),
+                vec(vec(inner, 0..=3), 1..=3)
+                    .prop_map(|variants| T::Enum(Box::new(R::MoveEnumLayout(Box::new(variants))))),
+            ]
+        },
+    )
+    .boxed()
+}
+
+/// Strategy producing arbitrary annotated tree-form `MoveTypeLayout`s, including
+/// type tags and field/variant names. Bounded in depth and breadth.
+pub fn arb_annotated_layout() -> BoxedStrategy<A::MoveTypeLayout> {
+    use A::MoveTypeLayout as T;
+
+    let leaf = prop_oneof![
+        Just(T::Bool),
+        Just(T::U8),
+        Just(T::U16),
+        Just(T::U32),
+        Just(T::U64),
+        Just(T::U128),
+        Just(T::U256),
+        Just(T::Address),
+        Just(T::Signer),
+    ];
+
+    leaf.prop_recursive(
+        4,  // depth
+        24, // max nodes
+        4,  // branching
+        |inner| {
+            let struct_tag = (
+                any::<AccountAddress>(),
+                any::<Identifier>(),
+                any::<Identifier>(),
+            )
+                .prop_map(|(address, module, name)| StructTag {
+                    address,
+                    module,
+                    name,
+                    type_params: vec![],
+                });
+
+            let field = (any::<Identifier>(), inner.clone())
+                .prop_map(|(name, layout)| A::MoveFieldLayout { name, layout });
+
+            let variant_fields = vec(field.clone(), 0..=3);
+
+            // Build distinct (variant_name, tag) keys for the map.
+            let variants = vec((any::<Identifier>(), variant_fields.clone()), 1..=3).prop_map(
+                |entries| -> BTreeMap<(Identifier, u16), Vec<A::MoveFieldLayout>> {
+                    let mut map = BTreeMap::new();
+                    let mut seen: std::collections::HashSet<Identifier> =
+                        std::collections::HashSet::new();
+                    for (tag, (mut name, fields)) in entries.into_iter().enumerate() {
+                        let tag = tag as u16;
+                        // Ensure unique variant name within the enum.
+                        while !seen.insert(name.clone()) {
+                            name = Identifier::new(format!("{}_{}", name.as_str(), tag)).unwrap();
+                        }
+                        map.insert((name, tag), fields);
+                    }
+                    map
+                },
+            );
+
+            prop_oneof![
+                inner.clone().prop_map(|t| T::Vector(Box::new(t))),
+                (struct_tag.clone(), vec(field, 0..=4)).prop_map(|(type_, fields)| T::Struct(
+                    Box::new(A::MoveStructLayout { type_, fields })
+                )),
+                (struct_tag, variants).prop_map(|(type_, variants)| T::Enum(Box::new(
+                    A::MoveEnumLayout { type_, variants }
+                ))),
+            ]
+        },
+    )
+    .boxed()
 }

--- a/external-crates/move/crates/move-core-types/src/unit_tests/compressed_equivalence_test.rs
+++ b/external-crates/move/crates/move-core-types/src/unit_tests/compressed_equivalence_test.rs
@@ -1,0 +1,764 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Tests for `equivalent` on compressed type layouts (runtime + annotated).
+//!
+//! Equivalence is **structural**: two layouts compare equal iff they describe
+//! the same Move type, regardless of pool ordering or how subtrees are shared.
+
+use crate::{
+    annotated_value as A,
+    compressed::{
+        annotated::{self as CA, BackendBuilder as _},
+        runtime::{self as CR, BackendBuilder as _},
+    },
+    identifier::Identifier,
+    language_storage::StructTag,
+    runtime_value as R,
+};
+use rand::{Rng, SeedableRng, rngs::StdRng, seq::SliceRandom};
+use std::collections::BTreeMap;
+use std::str::FromStr;
+
+// =============================================================================
+// Helpers: build compressed layouts by interning a tree in a shuffled visit
+// order. This produces the same logical layout but with different pool indices.
+// =============================================================================
+
+fn compress_runtime(t: &R::MoveTypeLayout) -> CR::MoveTypeLayout {
+    t.try_into().unwrap()
+}
+
+fn compress_annotated(t: &A::MoveTypeLayout) -> CA::MoveTypeLayout {
+    t.try_into().unwrap()
+}
+
+/// Build a compressed runtime layout from a tree, interning children in a
+/// permuted order driven by `seed`. The resulting layout is logically the same
+/// as `compress_runtime(t)` but the pool indices typically differ.
+fn compress_with_shuffle_runtime(t: &R::MoveTypeLayout, seed: u64) -> CR::MoveTypeLayout {
+    let mut b = CR::MoveTypeLayoutBuilder::new();
+    let mut rng = StdRng::seed_from_u64(seed);
+    let root = intern_shuffled_runtime(&mut b, t, &mut rng);
+    b.build(root)
+}
+
+fn intern_shuffled_runtime(
+    b: &mut CR::MoveTypeLayoutBuilder,
+    t: &R::MoveTypeLayout,
+    rng: &mut StdRng,
+) -> CR::LayoutHandle {
+    use R::MoveTypeLayout as T;
+    match t {
+        T::Bool => b.bool(),
+        T::U8 => b.u8(),
+        T::U16 => b.u16(),
+        T::U32 => b.u32(),
+        T::U64 => b.u64(),
+        T::U128 => b.u128(),
+        T::U256 => b.u256(),
+        T::Address => b.address(),
+        T::Signer => b.signer(),
+        T::Vector(inner) => {
+            let h = intern_shuffled_runtime(b, inner, rng);
+            b.vector(h).unwrap()
+        }
+        T::Struct(s) => {
+            let mut order: Vec<usize> = (0..s.0.len()).collect();
+            order.shuffle(rng);
+            let mut handles: Vec<Option<CR::LayoutHandle>> = (0..s.0.len()).map(|_| None).collect();
+            for i in order {
+                handles[i] = Some(intern_shuffled_runtime(b, &s.0[i], rng));
+            }
+            let handles: Vec<CR::LayoutHandle> = handles.into_iter().map(Option::unwrap).collect();
+            b.struct_layout(&handles).unwrap()
+        }
+        T::Enum(e) => {
+            let mut handles: Vec<Option<Vec<CR::LayoutHandle>>> =
+                (0..e.0.len()).map(|_| None).collect();
+            let mut order: Vec<usize> = (0..e.0.len()).collect();
+            order.shuffle(rng);
+            for i in order {
+                let variant = &e.0[i];
+                let mut field_order: Vec<usize> = (0..variant.len()).collect();
+                field_order.shuffle(rng);
+                let mut field_handles: Vec<Option<CR::LayoutHandle>> =
+                    (0..variant.len()).map(|_| None).collect();
+                for j in field_order {
+                    field_handles[j] = Some(intern_shuffled_runtime(b, &variant[j], rng));
+                }
+                handles[i] = Some(field_handles.into_iter().map(Option::unwrap).collect());
+            }
+            let variants: Vec<Vec<CR::LayoutHandle>> =
+                handles.into_iter().map(Option::unwrap).collect();
+            let variant_refs: Vec<Option<&[CR::LayoutHandle]>> =
+                variants.iter().map(|v| Some(v.as_slice())).collect();
+            b.enum_layout(&variant_refs).unwrap()
+        }
+    }
+}
+
+/// Build a compressed annotated layout from a tree, interning children in a
+/// permuted order driven by `seed`.
+fn compress_with_shuffle_annotated(t: &A::MoveTypeLayout, seed: u64) -> CA::MoveTypeLayout {
+    let mut b = CA::MoveTypeLayoutBuilder::new();
+    let mut rng = StdRng::seed_from_u64(seed);
+    let root = intern_shuffled_annotated(&mut b, t, &mut rng);
+    b.build(root)
+}
+
+fn intern_shuffled_annotated(
+    b: &mut CA::MoveTypeLayoutBuilder,
+    t: &A::MoveTypeLayout,
+    rng: &mut StdRng,
+) -> CA::LayoutHandle {
+    use A::MoveTypeLayout as T;
+    match t {
+        T::Bool => b.bool(),
+        T::U8 => b.u8(),
+        T::U16 => b.u16(),
+        T::U32 => b.u32(),
+        T::U64 => b.u64(),
+        T::U128 => b.u128(),
+        T::U256 => b.u256(),
+        T::Address => b.address(),
+        T::Signer => b.signer(),
+        T::Vector(inner) => {
+            let h = intern_shuffled_annotated(b, inner, rng);
+            b.vector(h).unwrap()
+        }
+        T::Struct(s) => {
+            let n = s.fields.len();
+            let mut order: Vec<usize> = (0..n).collect();
+            order.shuffle(rng);
+            let mut handles: Vec<Option<(Identifier, CA::LayoutHandle)>> =
+                (0..n).map(|_| None).collect();
+            for i in order {
+                let f = &s.fields[i];
+                let h = intern_shuffled_annotated(b, &f.layout, rng);
+                handles[i] = Some((f.name.clone(), h));
+            }
+            let handles: Vec<(Identifier, CA::LayoutHandle)> =
+                handles.into_iter().map(Option::unwrap).collect();
+            let handle_refs: Vec<(&Identifier, CA::LayoutHandle)> =
+                handles.iter().map(|(n, h)| (n, *h)).collect();
+            b.struct_layout(&s.type_, &handle_refs).unwrap()
+        }
+        T::Enum(e) => {
+            let entries: Vec<(&(Identifier, u16), &Vec<A::MoveFieldLayout>)> =
+                e.variants.iter().collect();
+            let mut order: Vec<usize> = (0..entries.len()).collect();
+            order.shuffle(rng);
+            let mut variants: Vec<
+                Option<(Identifier, u16, Option<Vec<(Identifier, CA::LayoutHandle)>>)>,
+            > = (0..entries.len()).map(|_| None).collect();
+            for i in order {
+                let ((vname, vtag), fields) = entries[i];
+                let m = fields.len();
+                let mut field_order: Vec<usize> = (0..m).collect();
+                field_order.shuffle(rng);
+                let mut field_handles: Vec<Option<(Identifier, CA::LayoutHandle)>> =
+                    (0..m).map(|_| None).collect();
+                for j in field_order {
+                    let f = &fields[j];
+                    let h = intern_shuffled_annotated(b, &f.layout, rng);
+                    field_handles[j] = Some((f.name.clone(), h));
+                }
+                let field_handles: Vec<(Identifier, CA::LayoutHandle)> =
+                    field_handles.into_iter().map(Option::unwrap).collect();
+                variants[i] = Some((vname.clone(), *vtag, Some(field_handles)));
+            }
+            let variants: Vec<(Identifier, u16, Vec<(Identifier, CA::LayoutHandle)>)> = variants
+                .into_iter()
+                .map(|v| {
+                    let (n, t, fs) = v.unwrap();
+                    (n, t, fs.unwrap())
+                })
+                .collect();
+            let variant_field_refs: Vec<Vec<(&Identifier, CA::LayoutHandle)>> = variants
+                .iter()
+                .map(|(_, _, fs)| fs.iter().map(|(n, h)| (n, *h)).collect())
+                .collect();
+            let variant_refs: Vec<(&Identifier, u16, Option<&[(&Identifier, CA::LayoutHandle)]>)> =
+                variants
+                    .iter()
+                    .zip(variant_field_refs.iter())
+                    .map(|((name, tag, _), fs)| (name, *tag, Some(fs.as_slice())))
+                    .collect();
+            b.enum_layout(&e.type_, &variant_refs).unwrap()
+        }
+    }
+}
+
+// =============================================================================
+// Helpers: small layout constructors for unit tests.
+// =============================================================================
+
+fn struct_tag(rep: &str) -> StructTag {
+    StructTag::from_str(rep).unwrap()
+}
+
+fn ident(s: &str) -> Identifier {
+    Identifier::new(s).unwrap()
+}
+
+// =============================================================================
+// Runtime: unit tests
+// =============================================================================
+
+#[test]
+fn runtime_reflexive() {
+    let t = R::MoveTypeLayout::Struct(Box::new(R::MoveStructLayout(Box::new(vec![
+        R::MoveTypeLayout::U8,
+        R::MoveTypeLayout::Vector(Box::new(R::MoveTypeLayout::U64)),
+    ]))));
+    let c = compress_runtime(&t);
+    assert!(c.equivalent(&c));
+}
+
+#[test]
+fn runtime_clone_fast_path() {
+    let t = R::MoveTypeLayout::Vector(Box::new(R::MoveTypeLayout::U8));
+    let a = compress_runtime(&t);
+    let b = a.clone();
+    // Clone shares the Arc; the fast path should fire.
+    assert!(a.equivalent(&b));
+}
+
+#[test]
+fn runtime_pool_permutation_invariant() {
+    let t = R::MoveTypeLayout::Struct(Box::new(R::MoveStructLayout(Box::new(vec![
+        R::MoveTypeLayout::Vector(Box::new(R::MoveTypeLayout::U8)),
+        R::MoveTypeLayout::Vector(Box::new(R::MoveTypeLayout::U16)),
+        R::MoveTypeLayout::Struct(Box::new(R::MoveStructLayout(Box::new(vec![
+            R::MoveTypeLayout::U64,
+        ])))),
+    ]))));
+    let a = compress_runtime(&t);
+    // Try several seeds to cover different shuffle outcomes.
+    for seed in 0..8u64 {
+        let b = compress_with_shuffle_runtime(&t, seed);
+        assert!(
+            a.equivalent(&b),
+            "seed {seed}: layouts should be equivalent under pool permutation"
+        );
+    }
+}
+
+#[test]
+fn runtime_different_arity_not_equivalent() {
+    let t1 = R::MoveTypeLayout::Struct(Box::new(R::MoveStructLayout(Box::new(vec![
+        R::MoveTypeLayout::U8,
+    ]))));
+    let t2 = R::MoveTypeLayout::Struct(Box::new(R::MoveStructLayout(Box::new(vec![
+        R::MoveTypeLayout::U8,
+        R::MoveTypeLayout::U8,
+    ]))));
+    assert!(!compress_runtime(&t1).equivalent(&compress_runtime(&t2)));
+}
+
+#[test]
+fn runtime_different_leaf_not_equivalent() {
+    let t1 = R::MoveTypeLayout::Vector(Box::new(R::MoveTypeLayout::U8));
+    let t2 = R::MoveTypeLayout::Vector(Box::new(R::MoveTypeLayout::U16));
+    assert!(!compress_runtime(&t1).equivalent(&compress_runtime(&t2)));
+}
+
+#[test]
+fn runtime_subtype_struct_equivalent() {
+    let t = R::MoveTypeLayout::Struct(Box::new(R::MoveStructLayout(Box::new(vec![
+        R::MoveTypeLayout::U64,
+    ]))));
+    let a = compress_runtime(&t);
+    let b = compress_with_shuffle_runtime(&t, 7);
+
+    let CR::MoveLayoutView::Struct(sa) = a.as_view() else {
+        panic!()
+    };
+    let CR::MoveLayoutView::Struct(sb) = b.as_view() else {
+        panic!()
+    };
+    assert!(sa.equivalent(&sb));
+}
+
+#[test]
+fn runtime_subtype_view_equivalent() {
+    let t = R::MoveTypeLayout::Vector(Box::new(R::MoveTypeLayout::U8));
+    let a = compress_runtime(&t);
+    let b = compress_with_shuffle_runtime(&t, 1);
+    assert!(a.as_view().equivalent(&b.as_view()));
+}
+
+#[test]
+fn runtime_view_mismatched_kinds_not_equivalent() {
+    let l1 = compress_runtime(&R::MoveTypeLayout::U8);
+    let l2 = compress_runtime(&R::MoveTypeLayout::U16);
+    let v1 = l1.as_view();
+    let v2 = l2.as_view();
+    assert!(!v1.equivalent(&v2));
+
+    let s = compress_runtime(&R::MoveTypeLayout::Struct(Box::new(R::MoveStructLayout(
+        Box::new(vec![R::MoveTypeLayout::U8]),
+    ))));
+    let lu = compress_runtime(&R::MoveTypeLayout::U8);
+    let v_struct = s.as_view();
+    let v_u8 = lu.as_view();
+    assert!(!v_struct.equivalent(&v_u8));
+}
+
+#[test]
+fn runtime_unknown_variant_equivalence() {
+    let mut b1 = CR::MoveTypeLayoutBuilder::new();
+    let u8_h1 = b1.u8();
+    let v1_fields = [u8_h1];
+    let h1 = b1.enum_layout(&[None, Some(&v1_fields)]).unwrap();
+    let l1 = b1.build(h1);
+
+    let mut b2 = CR::MoveTypeLayoutBuilder::new();
+    let u8_h2 = b2.u8();
+    let v2_fields = [u8_h2];
+    let h2 = b2.enum_layout(&[None, Some(&v2_fields)]).unwrap();
+    let l2 = b2.build(h2);
+
+    assert!(l1.equivalent(&l2));
+
+    // Known with empty fields vs Unknown — not equivalent.
+    let mut b3 = CR::MoveTypeLayoutBuilder::new();
+    let u8_h3 = b3.u8();
+    let v3_b: [CR::LayoutHandle; 1] = [u8_h3];
+    let h3 = b3
+        .enum_layout(&[Some(&[]), Some(&v3_b)])
+        .unwrap();
+    let l3 = b3.build(h3);
+    assert!(!l1.equivalent(&l3));
+}
+
+#[test]
+fn runtime_dag_with_shared_subtree() {
+    // struct { a: vector<u8>, b: vector<u8> } — the inner vector<u8> is shared
+    // when the builder dedups. Build twice with two different shuffle seeds and
+    // confirm both compare equivalent.
+    let inner = R::MoveTypeLayout::Vector(Box::new(R::MoveTypeLayout::U8));
+    let t = R::MoveTypeLayout::Struct(Box::new(R::MoveStructLayout(Box::new(vec![
+        inner.clone(),
+        inner,
+    ]))));
+    let a = compress_with_shuffle_runtime(&t, 0);
+    let b = compress_with_shuffle_runtime(&t, 100);
+    assert!(a.equivalent(&b));
+}
+
+// =============================================================================
+// Annotated: unit tests
+// =============================================================================
+
+#[test]
+fn annotated_reflexive() {
+    let t = A::MoveTypeLayout::Struct(Box::new(A::MoveStructLayout {
+        type_: struct_tag("0x0::foo::Bar"),
+        fields: vec![A::MoveFieldLayout::new(ident("a"), A::MoveTypeLayout::U8)],
+    }));
+    let c = compress_annotated(&t);
+    assert!(c.equivalent(&c));
+}
+
+#[test]
+fn annotated_clone_fast_path() {
+    let t = A::MoveTypeLayout::Vector(Box::new(A::MoveTypeLayout::U8));
+    let a = compress_annotated(&t);
+    let b = a.clone();
+    assert!(a.equivalent(&b));
+}
+
+#[test]
+fn annotated_pool_permutation_invariant() {
+    let inner = A::MoveTypeLayout::Vector(Box::new(A::MoveTypeLayout::U8));
+    let t = A::MoveTypeLayout::Struct(Box::new(A::MoveStructLayout {
+        type_: struct_tag("0x0::foo::Bar"),
+        fields: vec![
+            A::MoveFieldLayout::new(ident("a"), inner.clone()),
+            A::MoveFieldLayout::new(ident("b"), inner),
+        ],
+    }));
+    let a = compress_annotated(&t);
+    for seed in 0..8u64 {
+        let b = compress_with_shuffle_annotated(&t, seed);
+        assert!(a.equivalent(&b), "seed {seed}");
+    }
+}
+
+#[test]
+fn annotated_different_struct_tag_not_equivalent() {
+    let mk = |tag: &str| {
+        compress_annotated(&A::MoveTypeLayout::Struct(Box::new(A::MoveStructLayout {
+            type_: struct_tag(tag),
+            fields: vec![A::MoveFieldLayout::new(ident("a"), A::MoveTypeLayout::U8)],
+        })))
+    };
+    assert!(!mk("0x0::foo::A").equivalent(&mk("0x0::foo::B")));
+}
+
+#[test]
+fn annotated_different_field_name_not_equivalent() {
+    let mk = |name: &str| {
+        compress_annotated(&A::MoveTypeLayout::Struct(Box::new(A::MoveStructLayout {
+            type_: struct_tag("0x0::foo::Bar"),
+            fields: vec![A::MoveFieldLayout::new(ident(name), A::MoveTypeLayout::U8)],
+        })))
+    };
+    assert!(!mk("a").equivalent(&mk("b")));
+}
+
+#[test]
+fn annotated_different_variant_tag_not_equivalent() {
+    let mk = |tag: u16| {
+        let mut variants = BTreeMap::new();
+        variants.insert(
+            (ident("V"), tag),
+            vec![A::MoveFieldLayout::new(ident("x"), A::MoveTypeLayout::U8)],
+        );
+        compress_annotated(&A::MoveTypeLayout::Enum(Box::new(A::MoveEnumLayout {
+            type_: struct_tag("0x0::foo::E"),
+            variants,
+        })))
+    };
+    assert!(!mk(0).equivalent(&mk(1)));
+}
+
+#[test]
+fn annotated_different_variant_name_not_equivalent() {
+    let mk = |name: &str| {
+        let mut variants = BTreeMap::new();
+        variants.insert(
+            (ident(name), 0),
+            vec![A::MoveFieldLayout::new(ident("x"), A::MoveTypeLayout::U8)],
+        );
+        compress_annotated(&A::MoveTypeLayout::Enum(Box::new(A::MoveEnumLayout {
+            type_: struct_tag("0x0::foo::E"),
+            variants,
+        })))
+    };
+    assert!(!mk("V1").equivalent(&mk("V2")));
+}
+
+#[test]
+fn annotated_unknown_variant_equivalence() {
+    let tag = struct_tag("0x0::foo::E");
+    let n_v = ident("V");
+    let n_w = ident("W");
+    let n_x = ident("x");
+
+    let mut b1 = CA::MoveTypeLayoutBuilder::new();
+    let u8_h1 = b1.u8();
+    let v1_w_fields = [(&n_x, u8_h1)];
+    let h1 = b1
+        .enum_layout(
+            &tag,
+            &[(&n_v, 0u16, None), (&n_w, 1u16, Some(&v1_w_fields))],
+        )
+        .unwrap();
+    let l1 = b1.build(h1);
+
+    let mut b2 = CA::MoveTypeLayoutBuilder::new();
+    let u8_h2 = b2.u8();
+    let v2_w_fields = [(&n_x, u8_h2)];
+    let h2 = b2
+        .enum_layout(
+            &tag,
+            &[(&n_v, 0u16, None), (&n_w, 1u16, Some(&v2_w_fields))],
+        )
+        .unwrap();
+    let l2 = b2.build(h2);
+    assert!(l1.equivalent(&l2));
+
+    // Known with empty fields vs Unknown — not equivalent.
+    let mut b3 = CA::MoveTypeLayoutBuilder::new();
+    let u8_h3 = b3.u8();
+    let v3_w_fields = [(&n_x, u8_h3)];
+    let h3 = b3
+        .enum_layout(
+            &tag,
+            &[
+                (&n_v, 0u16, Some(&[])),
+                (&n_w, 1u16, Some(&v3_w_fields)),
+            ],
+        )
+        .unwrap();
+    let l3 = b3.build(h3);
+    assert!(!l1.equivalent(&l3));
+}
+
+#[test]
+fn annotated_subtype_struct_equivalent() {
+    let t = A::MoveTypeLayout::Struct(Box::new(A::MoveStructLayout {
+        type_: struct_tag("0x0::foo::Bar"),
+        fields: vec![A::MoveFieldLayout::new(ident("a"), A::MoveTypeLayout::U8)],
+    }));
+    let a = compress_annotated(&t);
+    let b = compress_with_shuffle_annotated(&t, 3);
+
+    let CA::MoveLayoutView::Struct(sa) = a.as_view() else {
+        panic!()
+    };
+    let CA::MoveLayoutView::Struct(sb) = b.as_view() else {
+        panic!()
+    };
+    assert!(sa.equivalent(&sb));
+}
+
+// =============================================================================
+// Mutation helpers (for proptests).
+// =============================================================================
+
+/// Mutate a runtime tree at one node so the result is structurally different.
+/// Returns `None` if no mutation could be applied (only happens for trivial
+/// degenerate inputs we don't generate).
+fn mutate_runtime(t: &R::MoveTypeLayout, seed: u64) -> Option<R::MoveTypeLayout> {
+    let mut rng = StdRng::seed_from_u64(seed);
+    Some(mutate_runtime_inner(t, &mut rng))
+}
+
+fn mutate_runtime_inner(t: &R::MoveTypeLayout, rng: &mut StdRng) -> R::MoveTypeLayout {
+    use R::MoveTypeLayout as T;
+    // Always alter the leaf type at the deepest reachable level — guarantees
+    // the resulting tree differs in at least one observable spot.
+    match t {
+        T::Bool => T::U8,
+        T::U8 => T::U16,
+        T::U16 => T::U32,
+        T::U32 => T::U64,
+        T::U64 => T::U128,
+        T::U128 => T::U256,
+        T::U256 => T::Address,
+        T::Address => T::Signer,
+        T::Signer => T::Bool,
+        T::Vector(inner) => T::Vector(Box::new(mutate_runtime_inner(inner, rng))),
+        T::Struct(s) => {
+            if s.0.is_empty() {
+                // Add a field so the arity differs.
+                T::Struct(Box::new(R::MoveStructLayout(Box::new(vec![T::Bool]))))
+            } else {
+                let i = rng.gen_range(0..s.0.len());
+                let mut new_fields = (*s.0).clone();
+                new_fields[i] = mutate_runtime_inner(&new_fields[i], rng);
+                T::Struct(Box::new(R::MoveStructLayout(Box::new(new_fields))))
+            }
+        }
+        T::Enum(e) => {
+            if e.0.is_empty() {
+                T::Enum(Box::new(R::MoveEnumLayout(Box::new(vec![vec![T::Bool]]))))
+            } else {
+                let vi = rng.gen_range(0..e.0.len());
+                let mut new_variants = (*e.0).clone();
+                if new_variants[vi].is_empty() {
+                    new_variants[vi].push(T::Bool);
+                } else {
+                    let fi = rng.gen_range(0..new_variants[vi].len());
+                    new_variants[vi][fi] = mutate_runtime_inner(&new_variants[vi][fi], rng);
+                }
+                T::Enum(Box::new(R::MoveEnumLayout(Box::new(new_variants))))
+            }
+        }
+    }
+}
+
+/// Mutate an annotated tree so the result is structurally different.
+fn mutate_annotated(t: &A::MoveTypeLayout, seed: u64) -> Option<A::MoveTypeLayout> {
+    let mut rng = StdRng::seed_from_u64(seed);
+    Some(mutate_annotated_inner(t, &mut rng))
+}
+
+fn mutate_annotated_inner(t: &A::MoveTypeLayout, rng: &mut StdRng) -> A::MoveTypeLayout {
+    use A::MoveTypeLayout as T;
+    match t {
+        T::Bool => T::U8,
+        T::U8 => T::U16,
+        T::U16 => T::U32,
+        T::U32 => T::U64,
+        T::U64 => T::U128,
+        T::U128 => T::U256,
+        T::U256 => T::Address,
+        T::Address => T::Signer,
+        T::Signer => T::Bool,
+        T::Vector(inner) => T::Vector(Box::new(mutate_annotated_inner(inner, rng))),
+        T::Struct(s) => {
+            let mut new_fields = s.fields.clone();
+            if new_fields.is_empty() {
+                new_fields.push(A::MoveFieldLayout::new(ident("__added"), T::Bool));
+            } else {
+                let i = rng.gen_range(0..new_fields.len());
+                new_fields[i].layout = mutate_annotated_inner(&new_fields[i].layout, rng);
+            }
+            T::Struct(Box::new(A::MoveStructLayout {
+                type_: s.type_.clone(),
+                fields: new_fields,
+            }))
+        }
+        T::Enum(e) => {
+            if e.variants.is_empty() {
+                let mut variants = BTreeMap::new();
+                variants.insert((ident("__added"), 0), vec![]);
+                T::Enum(Box::new(A::MoveEnumLayout {
+                    type_: e.type_.clone(),
+                    variants,
+                }))
+            } else {
+                let mut entries: Vec<((Identifier, u16), Vec<A::MoveFieldLayout>)> = e
+                    .variants
+                    .iter()
+                    .map(|(k, v)| (k.clone(), v.clone()))
+                    .collect();
+                let vi = rng.gen_range(0..entries.len());
+                if entries[vi].1.is_empty() {
+                    entries[vi]
+                        .1
+                        .push(A::MoveFieldLayout::new(ident("__added"), T::Bool));
+                } else {
+                    let fi = rng.gen_range(0..entries[vi].1.len());
+                    entries[vi].1[fi].layout =
+                        mutate_annotated_inner(&entries[vi].1[fi].layout, rng);
+                }
+                let variants: BTreeMap<(Identifier, u16), Vec<A::MoveFieldLayout>> =
+                    entries.into_iter().collect();
+                T::Enum(Box::new(A::MoveEnumLayout {
+                    type_: e.type_.clone(),
+                    variants,
+                }))
+            }
+        }
+    }
+}
+
+// =============================================================================
+// Proptests
+// =============================================================================
+
+use crate::proptest_types::{arb_annotated_layout, arb_runtime_layout};
+use proptest::prelude::*;
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 256, ..ProptestConfig::default() })]
+
+    // --- Runtime ---
+
+    #[test]
+    fn pt_runtime_reflexive(t in arb_runtime_layout()) {
+        let c = compress_runtime(&t);
+        prop_assert!(c.equivalent(&c));
+    }
+
+    #[test]
+    fn pt_runtime_clone(t in arb_runtime_layout()) {
+        let c = compress_runtime(&t);
+        prop_assert!(c.equivalent(&c.clone()));
+    }
+
+    #[test]
+    fn pt_runtime_pool_permutation_invariant(t in arb_runtime_layout(), seed in any::<u64>()) {
+        let a = compress_runtime(&t);
+        let b = compress_with_shuffle_runtime(&t, seed);
+        prop_assert!(a.equivalent(&b));
+    }
+
+    #[test]
+    fn pt_runtime_symmetric(t1 in arb_runtime_layout(), t2 in arb_runtime_layout()) {
+        let a = compress_runtime(&t1);
+        let b = compress_runtime(&t2);
+        prop_assert_eq!(a.equivalent(&b), b.equivalent(&a));
+    }
+
+    #[test]
+    fn pt_runtime_transitive(t in arb_runtime_layout(), s1 in any::<u64>(), s2 in any::<u64>()) {
+        let a = compress_runtime(&t);
+        let b = compress_with_shuffle_runtime(&t, s1);
+        let c = compress_with_shuffle_runtime(&t, s2);
+        // a~b and b~c by pool-permutation invariance, so a~c must hold.
+        prop_assert!(a.equivalent(&b));
+        prop_assert!(b.equivalent(&c));
+        prop_assert!(a.equivalent(&c));
+    }
+
+    #[test]
+    fn pt_runtime_mutation_not_equivalent(t in arb_runtime_layout(), seed in any::<u64>()) {
+        let mutated = mutate_runtime(&t, seed).unwrap();
+        let a = compress_runtime(&t);
+        let b = compress_runtime(&mutated);
+        prop_assert!(!a.equivalent(&b));
+    }
+
+    #[test]
+    fn pt_runtime_view_consistency(t in arb_runtime_layout(), seed in any::<u64>()) {
+        let a = compress_runtime(&t);
+        let b = compress_with_shuffle_runtime(&t, seed);
+        prop_assert!(a.as_view().equivalent(&b.as_view()));
+    }
+
+    // --- Annotated ---
+
+    #[test]
+    fn pt_annotated_reflexive(t in arb_annotated_layout()) {
+        let c = compress_annotated(&t);
+        prop_assert!(c.equivalent(&c));
+    }
+
+    #[test]
+    fn pt_annotated_clone(t in arb_annotated_layout()) {
+        let c = compress_annotated(&t);
+        prop_assert!(c.equivalent(&c.clone()));
+    }
+
+    #[test]
+    fn pt_annotated_pool_permutation_invariant(
+        t in arb_annotated_layout(),
+        seed in any::<u64>(),
+    ) {
+        let a = compress_annotated(&t);
+        let b = compress_with_shuffle_annotated(&t, seed);
+        prop_assert!(a.equivalent(&b));
+    }
+
+    #[test]
+    fn pt_annotated_symmetric(
+        t1 in arb_annotated_layout(),
+        t2 in arb_annotated_layout(),
+    ) {
+        let a = compress_annotated(&t1);
+        let b = compress_annotated(&t2);
+        prop_assert_eq!(a.equivalent(&b), b.equivalent(&a));
+    }
+
+    #[test]
+    fn pt_annotated_transitive(
+        t in arb_annotated_layout(),
+        s1 in any::<u64>(),
+        s2 in any::<u64>(),
+    ) {
+        let a = compress_annotated(&t);
+        let b = compress_with_shuffle_annotated(&t, s1);
+        let c = compress_with_shuffle_annotated(&t, s2);
+        prop_assert!(a.equivalent(&b));
+        prop_assert!(b.equivalent(&c));
+        prop_assert!(a.equivalent(&c));
+    }
+
+    #[test]
+    fn pt_annotated_mutation_not_equivalent(
+        t in arb_annotated_layout(),
+        seed in any::<u64>(),
+    ) {
+        let mutated = mutate_annotated(&t, seed).unwrap();
+        let a = compress_annotated(&t);
+        let b = compress_annotated(&mutated);
+        prop_assert!(!a.equivalent(&b));
+    }
+
+    #[test]
+    fn pt_annotated_view_consistency(
+        t in arb_annotated_layout(),
+        seed in any::<u64>(),
+    ) {
+        let a = compress_annotated(&t);
+        let b = compress_with_shuffle_annotated(&t, seed);
+        prop_assert!(a.as_view().equivalent(&b.as_view()));
+    }
+}

--- a/external-crates/move/crates/move-core-types/src/unit_tests/mod.rs
+++ b/external-crates/move/crates/move-core-types/src/unit_tests/mod.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod annotated_visitor_test;
+mod compressed_equivalence_test;
 mod compressed_layout_test;
 mod extractor_test;
 mod identifier_test;


### PR DESCRIPTION
## Description 

See the commits for details but:
1. Adds an `equivalent` function to check structural equivalence of compressed type layouts (and then implements `Eq`/`PartialEq` using this).
2. Switch to `Arc<[...]>`s instead of `Box<[...]>` to lower clone overhead.
3/4. Adds some helper functionality that is needed on the Sui-side conversion.

## Test plan 

CI + additional tests for `equivalent` 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
