### PR TITLE
[move-core-types] Convert visitors to use compressed type layouts

### DIFF
--- a/external-crates/move/crates/move-core-types/src/annotated_extractor.rs
+++ b/external-crates/move/crates/move-core-types/src/annotated_extractor.rs
@@ -67,7 +67,7 @@ where
 
     pub fn deserialize_value(
         bytes: &'b [u8],
-        layout: &'l A::MoveTypeLayout,
+        layout: crate::compressed::annotated::MoveTypeLayoutRef<'l>,
         inner: &'v mut V,
         path: Vec<Element<'p>>,
     ) -> Result<Option<V::Value>, V::Error> {
@@ -77,7 +77,7 @@ where
 
     pub fn deserialize_struct(
         bytes: &'b [u8],
-        layout: &'l A::MoveStructLayout,
+        layout: crate::compressed::annotated::MoveStructLayout<'l>,
         inner: &'v mut V,
         path: Vec<Element<'p>>,
     ) -> Result<Option<V::Value>, V::Error> {
@@ -201,7 +201,7 @@ impl<'b, 'l, V: AV::Visitor<'b, 'l>> AV::Visitor<'b, 'l> for Extractor<'_, '_, V
         // If there is a type element, check that it is a vector type with the correct element
         // type, and remove it from the path.
         let path = if let [E::Type(t), path @ ..] = self.path {
-            if !matches!(t, T::Vector(t) if driver.element_layout().is_type(t)) {
+            if !matches!(t, T::Vector(inner) if driver.element_layout().as_view().is_type(inner)) {
                 return Ok(None);
             }
             path
@@ -235,12 +235,11 @@ impl<'b, 'l, V: AV::Visitor<'b, 'l>> AV::Visitor<'b, 'l> for Extractor<'_, '_, V
         driver: &mut AV::StructDriver<'_, 'b, 'l>,
     ) -> Result<Self::Value, Self::Error> {
         use Element as E;
-        use TypeTag as T;
 
         // If there is a type element, check that it is a struct type with the correct struct tag,
         // and remove it from the path.
         let path = if let [E::Type(t), path @ ..] = self.path {
-            if !matches!(t, T::Struct(t) if driver.struct_layout().is_type(t)) {
+            if !driver.struct_layout().is_type(t) {
                 return Ok(None);
             }
             path
@@ -256,7 +255,7 @@ impl<'b, 'l, V: AV::Visitor<'b, 'l>> AV::Visitor<'b, 'l> for Extractor<'_, '_, V
         match field {
             // Skip over mismatched fields by name.
             E::Field(f) => {
-                while matches!(driver.peek_field(), Some(l) if l.name.as_str() != *f) {
+                while matches!(driver.peek_field(), Some(l) if l.0.as_str() != *f) {
                     driver.skip_field()?;
                 }
             }
@@ -281,12 +280,11 @@ impl<'b, 'l, V: AV::Visitor<'b, 'l>> AV::Visitor<'b, 'l> for Extractor<'_, '_, V
         driver: &mut AV::VariantDriver<'_, 'b, 'l>,
     ) -> Result<Self::Value, Self::Error> {
         use Element as E;
-        use TypeTag as T;
 
         // If there is a type element, check that it is a struct type with the correct struct tag,
         // and remove it from the path.
         let path = if let [E::Type(t), path @ ..] = self.path {
-            if !matches!(t, T::Struct(t) if driver.enum_layout().is_type(t)) {
+            if !driver.enum_layout().is_type(t) {
                 return Ok(None);
             }
             path
@@ -312,7 +310,7 @@ impl<'b, 'l, V: AV::Visitor<'b, 'l>> AV::Visitor<'b, 'l> for Extractor<'_, '_, V
         match field {
             // Skip over mismatched fields by name.
             E::Field(f) => {
-                while matches!(driver.peek_field(), Some(l) if l.name.as_str() != *f) {
+                while matches!(driver.peek_field(), Some(l) if l.0.as_str() != *f) {
                     driver.skip_field()?;
                 }
             }

--- a/external-crates/move/crates/move-core-types/src/annotated_value.rs
+++ b/external-crates/move/crates/move-core-types/src/annotated_value.rs
@@ -203,7 +203,7 @@ impl MoveValue {
     /// layout, unexpected bytes or trailing bytes), or a custom error expressed by the visitor.
     pub fn visit_deserialize<'b, 'l, V: Visitor<'b, 'l>>(
         blob: &'b [u8],
-        ty: &'l MoveTypeLayout,
+        ty: crate::compressed::annotated::MoveTypeLayoutRef<'l>,
         visitor: &mut V,
     ) -> Result<V::Value, V::Error>
     where
@@ -266,7 +266,7 @@ impl MoveStruct {
     /// `MoveStructLayout`).
     pub fn visit_deserialize<'b, 'l, V: Visitor<'b, 'l>>(
         blob: &'b [u8],
-        ty: &'l MoveStructLayout,
+        ty: crate::compressed::annotated::MoveStructLayout<'l>,
         visitor: &mut V,
     ) -> Result<V::Value, V::Error>
     where

--- a/external-crates/move/crates/move-core-types/src/annotated_visitor.rs
+++ b/external-crates/move/crates/move-core-types/src/annotated_visitor.rs
@@ -6,8 +6,11 @@ use std::io::{Cursor, Read};
 use crate::{
     VARIANT_TAG_MAX_VALUE,
     account_address::AccountAddress,
-    annotated_value::{MoveEnumLayout, MoveFieldLayout, MoveStructLayout, MoveTypeLayout},
-    identifier::IdentStr,
+    compressed::annotated::{
+        MoveEnumLayout, MoveFieldsLayout, MoveLayoutView, MoveStructLayout, MoveTypeLayoutRef,
+        VariantLayout,
+    },
+    identifier::{IdentStr, Identifier},
     u256::U256,
 };
 
@@ -151,6 +154,9 @@ macro_rules! visitor_default {
 pub use visitor_default;
 
 /// Visitors can be used for building values out of a serialized Move struct or value.
+///
+/// `'b` is the lifetime of the byte stream being visited; `'l` is the lifetime of the
+/// compressed annotated layout (i.e. the pool it borrows into).
 pub trait Visitor<'b, 'l> {
     type Value;
 
@@ -452,7 +458,7 @@ impl<'b, 'l, T: Traversal<'b, 'l> + ?Sized> Visitor<'b, 'l> for T {
 /// value being visited.
 pub struct ValueDriver<'c, 'b, 'l> {
     bytes: &'c mut Cursor<&'b [u8]>,
-    layout: Option<&'l MoveTypeLayout>,
+    layout: Option<MoveTypeLayoutRef<'l>>,
     start: usize,
 }
 
@@ -461,7 +467,7 @@ pub struct ValueDriver<'c, 'b, 'l> {
 /// elements).
 pub struct VecDriver<'c, 'b, 'l> {
     inner: ValueDriver<'c, 'b, 'l>,
-    layout: &'l MoveTypeLayout,
+    layout: MoveTypeLayoutRef<'l>,
     len: u64,
     off: u64,
 }
@@ -471,7 +477,7 @@ pub struct VecDriver<'c, 'b, 'l> {
 /// visiting or skipping fields).
 pub struct StructDriver<'c, 'b, 'l> {
     inner: ValueDriver<'c, 'b, 'l>,
-    layout: &'l MoveStructLayout,
+    layout: MoveStructLayout<'l>,
     off: u64,
 }
 
@@ -480,10 +486,10 @@ pub struct StructDriver<'c, 'b, 'l> {
 /// to progress the traversal (by visiting or skipping fields).
 pub struct VariantDriver<'c, 'b, 'l> {
     inner: ValueDriver<'c, 'b, 'l>,
-    layout: &'l MoveEnumLayout,
+    layout: MoveEnumLayout<'l>,
     tag: u16,
-    variant_name: &'l IdentStr,
-    variant_layout: &'l [MoveFieldLayout],
+    variant_name: &'l Identifier,
+    variant_fields: MoveFieldsLayout<'l>,
     off: u64,
 }
 
@@ -501,6 +507,9 @@ pub enum Error {
     #[error("invalid variant tag: {0}")]
     UnexpectedVariantTag(usize),
 
+    #[error("layout for variant tag {0} is unknown")]
+    UnknownVariantLayout(u16),
+
     #[error("no layout available for value")]
     NoValueLayout,
 }
@@ -515,7 +524,10 @@ impl Traversal<'_, '_> for NullTraversal {
 }
 
 impl<'c, 'b, 'l> ValueDriver<'c, 'b, 'l> {
-    pub(crate) fn new(bytes: &'c mut Cursor<&'b [u8]>, layout: Option<&'l MoveTypeLayout>) -> Self {
+    pub(crate) fn new(
+        bytes: &'c mut Cursor<&'b [u8]>,
+        layout: Option<MoveTypeLayoutRef<'l>>,
+    ) -> Self {
         let start = bytes.position() as usize;
         Self {
             bytes,
@@ -538,7 +550,7 @@ impl<'c, 'b, 'l> ValueDriver<'c, 'b, 'l> {
     pub fn bytes(&self) -> &'b [u8] {
         self.bytes.get_ref()
     }
-    ///
+
     /// The bytes that haven't been consumed by the visitor yet.
     pub fn remaining_bytes(&self) -> &'b [u8] {
         &self.bytes.get_ref()[self.position()..]
@@ -547,7 +559,7 @@ impl<'c, 'b, 'l> ValueDriver<'c, 'b, 'l> {
     /// Type layout for the value being visited. May produce an error if a layout was not supplied
     /// when the driver was created (which should only happen if the driver was created for
     /// visiting a struct specifically).
-    pub fn layout(&self) -> Result<&'l MoveTypeLayout, Error> {
+    pub fn layout(&self) -> Result<MoveTypeLayoutRef<'l>, Error> {
         self.layout.ok_or(Error::NoValueLayout)
     }
 
@@ -566,7 +578,7 @@ impl<'c, 'b, 'l> ValueDriver<'c, 'b, 'l> {
 
 #[allow(clippy::len_without_is_empty)]
 impl<'c, 'b, 'l> VecDriver<'c, 'b, 'l> {
-    fn new(inner: ValueDriver<'c, 'b, 'l>, layout: &'l MoveTypeLayout, len: u64) -> Self {
+    fn new(inner: ValueDriver<'c, 'b, 'l>, layout: MoveTypeLayoutRef<'l>, len: u64) -> Self {
         Self {
             inner,
             layout,
@@ -595,15 +607,13 @@ impl<'c, 'b, 'l> VecDriver<'c, 'b, 'l> {
         self.inner.remaining_bytes()
     }
 
-    /// Type layout for the value being visited. May produce an error if a layout was not supplied
-    /// when the driver was created (which should only happen if the driver was created for
-    /// visiting a struct specifically).
-    pub fn layout(&self) -> Result<&'l MoveTypeLayout, Error> {
+    /// Type layout for the value being visited.
+    pub fn layout(&self) -> Result<MoveTypeLayoutRef<'l>, Error> {
         self.inner.layout()
     }
 
     /// Type layout for the vector's inner type.
-    pub fn element_layout(&self) -> &'l MoveTypeLayout {
+    pub fn element_layout(&self) -> MoveTypeLayoutRef<'l> {
         self.layout
     }
 
@@ -625,10 +635,6 @@ impl<'c, 'b, 'l> VecDriver<'c, 'b, 'l> {
     /// Visit the next element in the vector. The driver accepts a visitor to use for this element,
     /// allowing the visitor to be changed on recursive calls or even between elements in the same
     /// vector.
-    ///
-    /// Returns `Ok(None)` if there are no more elements in the vector, `Ok(v)` if there was an
-    /// element and it was successfully visited (where `v` is the value returned by the visitor) or
-    /// an error if there was an underlying deserialization error, or an error during visitation.
     pub fn next_element<V: Visitor<'b, 'l> + ?Sized>(
         &mut self,
         visitor: &mut V,
@@ -650,7 +656,7 @@ impl<'c, 'b, 'l> VecDriver<'c, 'b, 'l> {
 }
 
 impl<'c, 'b, 'l> StructDriver<'c, 'b, 'l> {
-    fn new(inner: ValueDriver<'c, 'b, 'l>, layout: &'l MoveStructLayout) -> Self {
+    fn new(inner: ValueDriver<'c, 'b, 'l>, layout: MoveStructLayout<'l>) -> Self {
         Self {
             inner,
             layout,
@@ -678,15 +684,13 @@ impl<'c, 'b, 'l> StructDriver<'c, 'b, 'l> {
         self.inner.remaining_bytes()
     }
 
-    /// Type layout for the value being visited. May produce an error if a layout was not supplied
-    /// when the driver was created (which should only happen if the driver was created for
-    /// visiting a struct specifically).
-    pub fn layout(&self) -> Result<&'l MoveTypeLayout, Error> {
+    /// Type layout for the value being visited.
+    pub fn layout(&self) -> Result<MoveTypeLayoutRef<'l>, Error> {
         self.inner.layout()
     }
 
     /// The layout of the struct being visited.
-    pub fn struct_layout(&self) -> &'l MoveStructLayout {
+    pub fn struct_layout(&self) -> MoveStructLayout<'l> {
         self.layout
     }
 
@@ -695,35 +699,35 @@ impl<'c, 'b, 'l> StructDriver<'c, 'b, 'l> {
         self.off
     }
 
-    /// The layout of the next field to be visited (if there is one), or `None` otherwise.
-    pub fn peek_field(&self) -> Option<&'l MoveFieldLayout> {
-        self.layout.fields.get(self.off as usize)
+    /// The name and layout of the next field to be visited (if there is one), or `None` otherwise.
+    pub fn peek_field(&self) -> Option<(&'l Identifier, MoveTypeLayoutRef<'l>)> {
+        self.layout.field(self.off as u16)
     }
 
     /// Visit the next field in the struct. The driver accepts a visitor to use for this field,
     /// allowing the visitor to be changed on recursive calls or even between fields in the same
     /// struct.
     ///
-    /// Returns `Ok(None)` if there are no more fields in the struct, `Ok((f, v))` if there was an
-    /// field and it was successfully visited (where `v` is the value returned by the visitor, and
-    /// `f` is the layout of the field that was visited) or an error if there was an underlying
-    /// deserialization error, or an error during visitation.
+    /// Returns `Ok(None)` if there are no more fields in the struct, `Ok(((n, l), v))` if there was
+    /// a field and it was successfully visited.
     pub fn next_field<V: Visitor<'b, 'l> + ?Sized>(
         &mut self,
         visitor: &mut V,
-    ) -> Result<Option<(&'l MoveFieldLayout, V::Value)>, V::Error> {
-        let Some(field) = self.peek_field() else {
+    ) -> Result<Option<((&'l Identifier, MoveTypeLayoutRef<'l>), V::Value)>, V::Error> {
+        let Some((name, layout)) = self.peek_field() else {
             return Ok(None);
         };
 
-        let res = visit_value(self.inner.bytes, &field.layout, visitor)?;
+        let res = visit_value(self.inner.bytes, layout, visitor)?;
         self.off += 1;
-        Ok(Some((field, res)))
+        Ok(Some(((name, layout), res)))
     }
 
     /// Skip the next field. Returns the layout of the field that was visited if there was one, or
-    /// `None` if there was none. Can return an error if there was a deserialization error.
-    pub fn skip_field(&mut self) -> Result<Option<&'l MoveFieldLayout>, Error> {
+    /// `None` if there was none.
+    pub fn skip_field(
+        &mut self,
+    ) -> Result<Option<(&'l Identifier, MoveTypeLayoutRef<'l>)>, Error> {
         self.next_field(&mut NullTraversal)
             .map(|res| res.map(|(f, _)| f))
     }
@@ -732,9 +736,9 @@ impl<'c, 'b, 'l> StructDriver<'c, 'b, 'l> {
 impl<'c, 'b, 'l> VariantDriver<'c, 'b, 'l> {
     fn new(
         inner: ValueDriver<'c, 'b, 'l>,
-        layout: &'l MoveEnumLayout,
-        variant_layout: &'l [MoveFieldLayout],
-        variant_name: &'l IdentStr,
+        layout: MoveEnumLayout<'l>,
+        variant_fields: MoveFieldsLayout<'l>,
+        variant_name: &'l Identifier,
         tag: u16,
     ) -> Self {
         Self {
@@ -742,7 +746,7 @@ impl<'c, 'b, 'l> VariantDriver<'c, 'b, 'l> {
             layout,
             tag,
             variant_name,
-            variant_layout,
+            variant_fields,
             off: 0,
         }
     }
@@ -767,21 +771,19 @@ impl<'c, 'b, 'l> VariantDriver<'c, 'b, 'l> {
         self.inner.remaining_bytes()
     }
 
-    /// Type layout for the value being visited. May produce an error if a layout was not supplied
-    /// when the driver was created (which should only happen if the driver was created for
-    /// visiting a struct specifically).
-    pub fn layout(&self) -> Result<&'l MoveTypeLayout, Error> {
+    /// Type layout for the value being visited.
+    pub fn layout(&self) -> Result<MoveTypeLayoutRef<'l>, Error> {
         self.inner.layout()
     }
 
     /// The layout of the enum being visited.
-    pub fn enum_layout(&self) -> &'l MoveEnumLayout {
+    pub fn enum_layout(&self) -> MoveEnumLayout<'l> {
         self.layout
     }
 
-    /// The layout of the variant being visited.
-    pub fn variant_layout(&self) -> &'l [MoveFieldLayout] {
-        self.variant_layout
+    /// The field layout of the variant being visited.
+    pub fn variant_layout(&self) -> MoveFieldsLayout<'l> {
+        self.variant_fields
     }
 
     /// The tag of the variant being visited.
@@ -791,109 +793,100 @@ impl<'c, 'b, 'l> VariantDriver<'c, 'b, 'l> {
 
     /// The name of the enum variant being visited.
     pub fn variant_name(&self) -> &'l IdentStr {
-        self.variant_name
+        self.variant_name.as_ident_str()
     }
 
-    /// The number of elements in this vector that have been visited so far.
+    /// The number of fields in this variant that have been visited so far.
     pub fn off(&self) -> u64 {
         self.off
     }
 
-    /// The layout of the next field to be visited (if there is one), or `None` otherwise.
-    pub fn peek_field(&self) -> Option<&'l MoveFieldLayout> {
-        self.variant_layout.get(self.off as usize)
+    /// The name and layout of the next field to be visited (if there is one), or `None` otherwise.
+    pub fn peek_field(&self) -> Option<(&'l Identifier, MoveTypeLayoutRef<'l>)> {
+        self.variant_fields.field(self.off as u16)
     }
 
-    /// Visit the next field in the variant. The driver accepts a visitor to use for this field,
-    /// allowing the visitor to be changed on recursive calls or even between fields in the same
-    /// variant.
-    ///
-    /// Returns `Ok(None)` if there are no more fields in the variant, `Ok((f, v))` if there was an
-    /// field and it was successfully visited (where `v` is the value returned by the visitor, and
-    /// `f` is the layout of the field that was visited) or an error if there was an underlying
-    /// deserialization error, or an error during visitation.
+    /// Visit the next field in the variant.
     pub fn next_field<V: Visitor<'b, 'l> + ?Sized>(
         &mut self,
         visitor: &mut V,
-    ) -> Result<Option<(&'l MoveFieldLayout, V::Value)>, V::Error> {
-        let Some(field) = self.peek_field() else {
+    ) -> Result<Option<((&'l Identifier, MoveTypeLayoutRef<'l>), V::Value)>, V::Error> {
+        let Some((name, layout)) = self.peek_field() else {
             return Ok(None);
         };
 
-        let res = visit_value(self.inner.bytes, &field.layout, visitor)?;
+        let res = visit_value(self.inner.bytes, layout, visitor)?;
         self.off += 1;
-        Ok(Some((field, res)))
+        Ok(Some(((name, layout), res)))
     }
 
-    /// Skip the next field. Returns the layout of the field that was visited if there was one, or
-    /// `None` if there was none. Can return an error if there was a deserialization error.
-    pub fn skip_field(&mut self) -> Result<Option<&'l MoveFieldLayout>, Error> {
+    /// Skip the next field.
+    pub fn skip_field(
+        &mut self,
+    ) -> Result<Option<(&'l Identifier, MoveTypeLayoutRef<'l>)>, Error> {
         self.next_field(&mut NullTraversal)
             .map(|res| res.map(|(f, _)| f))
     }
 }
 
 /// Visit a serialized Move value with the provided `layout`, held in `bytes`, using the provided
-/// visitor to build a value out of it. See `annoted_value::MoveValue::visit_deserialize` for
-/// details.
+/// visitor to build a value out of it.
 pub(crate) fn visit_value<'c, 'b, 'l, V: Visitor<'b, 'l> + ?Sized>(
     bytes: &'c mut Cursor<&'b [u8]>,
-    layout: &'l MoveTypeLayout,
+    layout: MoveTypeLayoutRef<'l>,
     visitor: &mut V,
 ) -> Result<V::Value, V::Error> {
-    use MoveTypeLayout as L;
-
     let mut driver = ValueDriver::new(bytes, Some(layout));
-    match layout {
-        L::Bool => match driver.read_exact()? {
+    match layout.as_view() {
+        MoveLayoutView::Bool => match driver.read_exact()? {
             [0] => visitor.visit_bool(&driver, false),
             [1] => visitor.visit_bool(&driver, true),
             [b] => Err(Error::UnexpectedByte(b).into()),
         },
 
-        L::U8 => {
+        MoveLayoutView::U8 => {
             let v = u8::from_le_bytes(driver.read_exact()?);
             visitor.visit_u8(&driver, v)
         }
 
-        L::U16 => {
+        MoveLayoutView::U16 => {
             let v = u16::from_le_bytes(driver.read_exact()?);
             visitor.visit_u16(&driver, v)
         }
 
-        L::U32 => {
+        MoveLayoutView::U32 => {
             let v = u32::from_le_bytes(driver.read_exact()?);
             visitor.visit_u32(&driver, v)
         }
 
-        L::U64 => {
+        MoveLayoutView::U64 => {
             let v = u64::from_le_bytes(driver.read_exact()?);
             visitor.visit_u64(&driver, v)
         }
 
-        L::U128 => {
+        MoveLayoutView::U128 => {
             let v = u128::from_le_bytes(driver.read_exact()?);
             visitor.visit_u128(&driver, v)
         }
 
-        L::U256 => {
+        MoveLayoutView::U256 => {
             let v = U256::from_le_bytes(&driver.read_exact()?);
             visitor.visit_u256(&driver, v)
         }
 
-        L::Address => {
+        MoveLayoutView::Address => {
             let v = AccountAddress::new(driver.read_exact()?);
             visitor.visit_address(&driver, v)
         }
 
-        L::Signer => {
+        MoveLayoutView::Signer => {
             let v = AccountAddress::new(driver.read_exact()?);
             visitor.visit_signer(&driver, v)
         }
 
-        L::Vector(l) => visit_vector(driver, l.as_ref(), visitor),
-        L::Struct(l) => visit_struct(driver, l, visitor),
-        L::Enum(e) => visit_variant(driver, e, visitor),
+        MoveLayoutView::Vector(inner) => visit_vector(driver, inner, visitor),
+        MoveLayoutView::Struct(s) => visit_struct(driver, s, visitor),
+        MoveLayoutView::Enum(e) => visit_variant(driver, e, visitor),
     }
 }
 
@@ -901,11 +894,11 @@ pub(crate) fn visit_value<'c, 'b, 'l, V: Visitor<'b, 'l> + ?Sized>(
 /// serialized move vector), and the layout is the vector's element's layout.
 fn visit_vector<'c, 'b, 'l, V: Visitor<'b, 'l> + ?Sized>(
     mut inner: ValueDriver<'c, 'b, 'l>,
-    layout: &'l MoveTypeLayout,
+    elem_layout: MoveTypeLayoutRef<'l>,
     visitor: &mut V,
 ) -> Result<V::Value, V::Error> {
     let len = inner.read_leb128()?;
-    let mut driver = VecDriver::new(inner, layout, len);
+    let mut driver = VecDriver::new(inner, elem_layout, len);
     let res = visitor.visit_vector(&mut driver)?;
     while driver.skip_element()? {}
     Ok(res)
@@ -915,7 +908,7 @@ fn visit_vector<'c, 'b, 'l, V: Visitor<'b, 'l> + ?Sized>(
 /// serialized move struct), and the layout is a struct layout.
 pub(crate) fn visit_struct<'c, 'b, 'l, V: Visitor<'b, 'l> + ?Sized>(
     inner: ValueDriver<'c, 'b, 'l>,
-    layout: &'l MoveStructLayout,
+    layout: MoveStructLayout<'l>,
     visitor: &mut V,
 ) -> Result<V::Value, V::Error> {
     let mut driver = StructDriver::new(inner, layout);
@@ -928,7 +921,7 @@ pub(crate) fn visit_struct<'c, 'b, 'l, V: Visitor<'b, 'l> + ?Sized>(
 /// serialized move variant), and the layout is an enum layout.
 fn visit_variant<'c, 'b, 'l, V: Visitor<'b, 'l> + ?Sized>(
     mut inner: ValueDriver<'c, 'b, 'l>,
-    layout: &'l MoveEnumLayout,
+    layout: MoveEnumLayout<'l>,
     visitor: &mut V,
 ) -> Result<V::Value, V::Error> {
     // Since variants are bounded at 127, we can read the tag as a single byte.
@@ -938,19 +931,20 @@ fn visit_variant<'c, 'b, 'l, V: Visitor<'b, 'l> + ?Sized>(
     if tag > VARIANT_TAG_MAX_VALUE as u8 {
         return Err(Error::UnexpectedVariantTag(tag as usize).into());
     }
-    let variant_layout = layout
-        .variants
-        .iter()
-        .find(|((_, vtag), _)| *vtag == tag as u16)
-        .ok_or(Error::UnexpectedVariantTag(tag as usize))?;
+    let tag = tag as u16;
+    let (variant_name, variant_fields) = match layout
+        .variant(tag)
+        .ok_or(Error::UnexpectedVariantTag(tag as usize))?
+    {
+        VariantLayout::Known {
+            name,
+            tag: _,
+            fields,
+        } => (name, fields),
+        VariantLayout::Unknown { .. } => return Err(Error::UnknownVariantLayout(tag).into()),
+    };
 
-    let mut driver = VariantDriver::new(
-        inner,
-        layout,
-        variant_layout.1,
-        &variant_layout.0.0,
-        tag as u16,
-    );
+    let mut driver = VariantDriver::new(inner, layout, variant_fields, variant_name, tag);
     let res = visitor.visit_variant(&mut driver)?;
     while driver.skip_field()?.is_some() {}
     Ok(res)

--- a/external-crates/move/crates/move-core-types/src/compressed/annotated/layout.rs
+++ b/external-crates/move/crates/move-core-types/src/compressed/annotated/layout.rs
@@ -557,7 +557,7 @@ impl<T: TypeLayout> MoveLayoutView<'_, T> {
 
     /// Check whether this layout matches the given [`TypeTag`].
     #[inline]
-    pub fn is_type_tag(&self, t: &TypeTag) -> bool {
+    pub fn is_type(&self, t: &TypeTag) -> bool {
         match self {
             MoveLayoutView::Bool => *t == TypeTag::Bool,
             MoveLayoutView::U8 => *t == TypeTag::U8,
@@ -568,15 +568,15 @@ impl<T: TypeLayout> MoveLayoutView<'_, T> {
             MoveLayoutView::U256 => *t == TypeTag::U256,
             MoveLayoutView::Address => *t == TypeTag::Address,
             MoveLayoutView::Signer => *t == TypeTag::Signer,
-            MoveLayoutView::Struct(sv) => sv.is_type_tag(t),
+            MoveLayoutView::Struct(sv) => sv.is_type(t),
             MoveLayoutView::Vector(vv) => {
                 if let TypeTag::Vector(inner) = t {
-                    vv.as_view().is_type_tag(inner)
+                    vv.as_view().is_type(inner)
                 } else {
                     false
                 }
             }
-            MoveLayoutView::Enum(ev) => ev.is_type_tag(t),
+            MoveLayoutView::Enum(ev) => ev.is_type(t),
         }
     }
 
@@ -647,6 +647,8 @@ impl<T: TypeLayout> fmt::Display for MoveLayoutView<'_, T> {
             MoveLayoutView::Struct(sv) => write!(f, "{sv}"),
             MoveLayoutView::Enum(ev) if f.alternate() => write!(f, "{ev:#}"),
             MoveLayoutView::Enum(ev) => write!(f, "{ev}"),
+            // Note: Struct/Enum cases above already include the "struct"/"enum" prefix in their
+            // own Display impls (matching the tree-based annotated_value::MoveTypeLayout output).
         }
     }
 }
@@ -816,7 +818,7 @@ impl<'a, T: TypeLayout> MoveStructLayout<'a, T> {
 
     /// Check whether this struct's type tag matches the given [`TypeTag`].
     #[inline]
-    pub fn is_type_tag(self, t: &TypeTag) -> bool {
+    pub fn is_type(self, t: &TypeTag) -> bool {
         matches!(t, TypeTag::Struct(s) if &**s == self.type_)
     }
 
@@ -863,18 +865,23 @@ impl<T: TypeLayout> Eq for MoveStructLayout<'_, T> {}
 
 impl<T: TypeLayout> fmt::Display for MoveStructLayout<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{} {{ ", self.type_)?;
-        for (i, (name, layout)) in self.fields().enumerate() {
-            if i > 0 {
-                write!(f, ", ")?;
-            }
-            if f.alternate() {
-                write!(f, "{name}: {layout:#}")?;
-            } else {
-                write!(f, "{name}: {layout}")?;
-            }
+        write!(f, "struct {} ", self.type_)?;
+        let mut map = f.debug_map();
+        for (name, layout) in self.fields() {
+            map.entry(&DebugAsDisplay(&name), &DebugAsDisplay(&layout));
         }
-        write!(f, " }}")
+        map.finish()
+    }
+}
+
+struct DebugAsDisplay<'a, T>(&'a T);
+impl<T: fmt::Display> fmt::Debug for DebugAsDisplay<'_, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if f.alternate() {
+            write!(f, "{:#}", self.0)
+        } else {
+            write!(f, "{}", self.0)
+        }
     }
 }
 
@@ -920,7 +927,7 @@ impl<'a, T: TypeLayout> MoveEnumLayout<'a, T> {
 
     /// Check whether this enum's type tag matches the given [`TypeTag`].
     #[inline]
-    pub fn is_type_tag(self, t: &TypeTag) -> bool {
+    pub fn is_type(self, t: &TypeTag) -> bool {
         matches!(t, TypeTag::Struct(s) if **s == *self.type_)
     }
 
@@ -1012,29 +1019,29 @@ fn variant_view<'a, T: TypeLayout>(
 
 impl<T: TypeLayout> fmt::Display for MoveEnumLayout<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{} {{ ", self.type_)?;
-        for (i, vl) in self.variants().enumerate() {
-            if i > 0 {
-                write!(f, ", ")?;
-            }
-            write!(f, "{}(", vl.name())?;
-            match vl.fields() {
-                Some(fields) => {
-                    for (j, (name, layout)) in fields.fields().enumerate() {
-                        if j > 0 {
-                            write!(f, ", ")?;
-                        }
-                        if f.alternate() {
-                            write!(f, "{name}: {layout:#}")?;
-                        } else {
-                            write!(f, "{name}: {layout}")?;
-                        }
-                    }
-                }
-                None => write!(f, "?")?,
-            }
-            write!(f, ")")?;
+        write!(f, "enum {} ", self.type_)?;
+        let mut vmap = f.debug_set();
+        for vl in self.variants() {
+            vmap.entry(&DebugAsDisplay(&VariantDisplay(vl)));
         }
-        write!(f, " }}")
+        vmap.finish()
+    }
+}
+
+struct VariantDisplay<'a, T: TypeLayout>(VariantLayout<'a, T>);
+
+impl<T: TypeLayout> fmt::Display for VariantDisplay<'_, T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let name = self.0.name();
+        match self.0.fields() {
+            Some(fields) => {
+                let mut s = f.debug_struct(name.as_str());
+                for (n, layout) in fields.fields() {
+                    s.field(n.as_str(), &DebugAsDisplay(&layout));
+                }
+                s.finish()
+            }
+            None => write!(f, "{name}(?)"),
+        }
     }
 }

--- a/external-crates/move/crates/move-core-types/src/compressed/runtime/layout.rs
+++ b/external-crates/move/crates/move-core-types/src/compressed/runtime/layout.rs
@@ -633,7 +633,11 @@ impl<T: TypeLayout> Eq for MoveStructLayout<'_, T> {}
 
 impl<T: TypeLayout> fmt::Display for MoveStructLayout<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "struct {}", self.fields)
+        if f.alternate() {
+            write!(f, "struct {:#}", self.fields)
+        } else {
+            write!(f, "struct {}", self.fields)
+        }
     }
 }
 

--- a/external-crates/move/crates/move-core-types/src/runtime_value.rs
+++ b/external-crates/move/crates/move-core-types/src/runtime_value.rs
@@ -135,7 +135,7 @@ impl MoveValue {
     /// layout, unexpected bytes or trailing bytes), or a custom error expressed by the visitor.
     pub fn visit_deserialize<'b, 'l, V: Visitor<'b, 'l>>(
         blob: &'b [u8],
-        ty: &'l MoveTypeLayout,
+        ty: crate::compressed::runtime::MoveTypeLayoutRef<'l>,
         visitor: &mut V,
     ) -> Result<V::Value, V::Error>
     where
@@ -257,7 +257,7 @@ impl MoveStruct {
     /// `MoveStructLayout`).
     pub fn visit_deserialize<'b, 'l, V: Visitor<'b, 'l>>(
         blob: &'b [u8],
-        ty: &'l MoveStructLayout,
+        ty: crate::compressed::runtime::MoveStructLayout<'l>,
         visitor: &mut V,
     ) -> Result<V::Value, V::Error>
     where

--- a/external-crates/move/crates/move-core-types/src/runtime_visitor.rs
+++ b/external-crates/move/crates/move-core-types/src/runtime_visitor.rs
@@ -6,11 +6,17 @@ use std::io::{Cursor, Read};
 use crate::{
     VARIANT_TAG_MAX_VALUE,
     account_address::AccountAddress,
-    runtime_value::{MoveEnumLayout, MoveStructLayout, MoveTypeLayout},
+    compressed::runtime::{
+        MoveEnumLayout, MoveFieldsLayout, MoveLayoutView, MoveStructLayout, MoveTypeLayoutRef,
+        VariantLayout,
+    },
     u256::U256,
 };
 
 /// Visitors can be used for building values out of a serialized Move struct or value.
+///
+/// `'b` is the lifetime of the byte stream being visited; `'l` is the lifetime of the
+/// compressed layout (i.e. the pool it borrows into).
 pub trait Visitor<'b, 'l> {
     type Value;
 
@@ -312,7 +318,7 @@ impl<'b, 'l, T: Traversal<'b, 'l> + ?Sized> Visitor<'b, 'l> for T {
 /// value being visited.
 pub struct ValueDriver<'c, 'b, 'l> {
     bytes: &'c mut Cursor<&'b [u8]>,
-    layout: Option<&'l MoveTypeLayout>,
+    layout: Option<MoveTypeLayoutRef<'l>>,
     start: usize,
 }
 
@@ -321,7 +327,7 @@ pub struct ValueDriver<'c, 'b, 'l> {
 /// elements).
 pub struct VecDriver<'c, 'b, 'l> {
     inner: ValueDriver<'c, 'b, 'l>,
-    layout: &'l MoveTypeLayout,
+    layout: MoveTypeLayoutRef<'l>,
     len: u64,
     off: u64,
 }
@@ -331,18 +337,18 @@ pub struct VecDriver<'c, 'b, 'l> {
 /// visiting or skipping fields).
 pub struct StructDriver<'c, 'b, 'l> {
     inner: ValueDriver<'c, 'b, 'l>,
-    layout: &'l MoveStructLayout,
+    layout: MoveStructLayout<'l>,
     off: u64,
 }
 
 /// Exposes information about a variant being visited (its layout, details about the next field to
 /// be visited, and the variant's tag) to a visitor implementation, and allows that visitor
-/// to progress the traversal (by visiting or skipping fields).
+/// to progress the traversal (by skipping fields).
 pub struct VariantDriver<'c, 'b, 'l> {
     inner: ValueDriver<'c, 'b, 'l>,
-    layout: &'l MoveEnumLayout,
+    layout: MoveEnumLayout<'l>,
     tag: u16,
-    variant_layout: &'l [MoveTypeLayout],
+    variant_fields: MoveFieldsLayout<'l>,
     off: u64,
 }
 
@@ -360,6 +366,9 @@ pub enum Error {
     #[error("invalid variant tag: {0}")]
     UnexpectedVariantTag(usize),
 
+    #[error("layout for variant tag {0} is unknown")]
+    UnknownVariantLayout(u16),
+
     #[error("no layout available for value")]
     NoValueLayout,
 }
@@ -374,7 +383,10 @@ impl Traversal<'_, '_> for NullTraversal {
 }
 
 impl<'c, 'b, 'l> ValueDriver<'c, 'b, 'l> {
-    pub(crate) fn new(bytes: &'c mut Cursor<&'b [u8]>, layout: Option<&'l MoveTypeLayout>) -> Self {
+    pub(crate) fn new(
+        bytes: &'c mut Cursor<&'b [u8]>,
+        layout: Option<MoveTypeLayoutRef<'l>>,
+    ) -> Self {
         let start = bytes.position() as usize;
         Self {
             bytes,
@@ -397,7 +409,7 @@ impl<'c, 'b, 'l> ValueDriver<'c, 'b, 'l> {
     pub fn bytes(&self) -> &'b [u8] {
         self.bytes.get_ref()
     }
-    ///
+
     /// The bytes that haven't been consumed by the visitor yet.
     pub fn remaining_bytes(&self) -> &'b [u8] {
         &self.bytes.get_ref()[self.position()..]
@@ -406,7 +418,7 @@ impl<'c, 'b, 'l> ValueDriver<'c, 'b, 'l> {
     /// Type layout for the value being visited. May produce an error if a layout was not supplied
     /// when the driver was created (which should only happen if the driver was created for
     /// visiting a struct specifically).
-    pub fn layout(&self) -> Result<&'l MoveTypeLayout, Error> {
+    pub fn layout(&self) -> Result<MoveTypeLayoutRef<'l>, Error> {
         self.layout.ok_or(Error::NoValueLayout)
     }
 
@@ -425,7 +437,7 @@ impl<'c, 'b, 'l> ValueDriver<'c, 'b, 'l> {
 
 #[allow(clippy::len_without_is_empty)]
 impl<'c, 'b, 'l> VecDriver<'c, 'b, 'l> {
-    fn new(inner: ValueDriver<'c, 'b, 'l>, layout: &'l MoveTypeLayout, len: u64) -> Self {
+    fn new(inner: ValueDriver<'c, 'b, 'l>, layout: MoveTypeLayoutRef<'l>, len: u64) -> Self {
         Self {
             inner,
             layout,
@@ -454,15 +466,13 @@ impl<'c, 'b, 'l> VecDriver<'c, 'b, 'l> {
         self.inner.remaining_bytes()
     }
 
-    /// Type layout for the value being visited. May produce an error if a layout was not supplied
-    /// when the driver was created (which should only happen if the driver was created for
-    /// visiting a struct specifically).
-    pub fn layout(&self) -> Result<&'l MoveTypeLayout, Error> {
+    /// Type layout for the value being visited.
+    pub fn layout(&self) -> Result<MoveTypeLayoutRef<'l>, Error> {
         self.inner.layout()
     }
 
     /// Type layout for the vector's inner type.
-    pub fn element_layout(&self) -> &'l MoveTypeLayout {
+    pub fn element_layout(&self) -> MoveTypeLayoutRef<'l> {
         self.layout
     }
 
@@ -509,7 +519,7 @@ impl<'c, 'b, 'l> VecDriver<'c, 'b, 'l> {
 }
 
 impl<'c, 'b, 'l> StructDriver<'c, 'b, 'l> {
-    fn new(inner: ValueDriver<'c, 'b, 'l>, layout: &'l MoveStructLayout) -> Self {
+    fn new(inner: ValueDriver<'c, 'b, 'l>, layout: MoveStructLayout<'l>) -> Self {
         Self {
             inner,
             layout,
@@ -537,15 +547,13 @@ impl<'c, 'b, 'l> StructDriver<'c, 'b, 'l> {
         self.inner.remaining_bytes()
     }
 
-    /// Type layout for the value being visited. May produce an error if a layout was not supplied
-    /// when the driver was created (which should only happen if the driver was created for
-    /// visiting a struct specifically).
-    pub fn layout(&self) -> Result<&'l MoveTypeLayout, Error> {
+    /// Type layout for the value being visited.
+    pub fn layout(&self) -> Result<MoveTypeLayoutRef<'l>, Error> {
         self.inner.layout()
     }
 
     /// The layout of the struct being visited.
-    pub fn struct_layout(&self) -> &'l MoveStructLayout {
+    pub fn struct_layout(&self) -> MoveStructLayout<'l> {
         self.layout
     }
 
@@ -555,8 +563,8 @@ impl<'c, 'b, 'l> StructDriver<'c, 'b, 'l> {
     }
 
     /// The layout of the next field to be visited (if there is one), or `None` otherwise.
-    pub fn peek_field(&self) -> Option<&'l MoveTypeLayout> {
-        self.layout.fields().get(self.off as usize)
+    pub fn peek_field(&self) -> Option<MoveTypeLayoutRef<'l>> {
+        self.layout.field(self.off as u16)
     }
 
     /// Visit the next field in the struct. The driver accepts a visitor to use for this field,
@@ -570,7 +578,7 @@ impl<'c, 'b, 'l> StructDriver<'c, 'b, 'l> {
     pub fn next_field<V: Visitor<'b, 'l> + ?Sized>(
         &mut self,
         visitor: &mut V,
-    ) -> Result<Option<(&'l MoveTypeLayout, V::Value)>, V::Error> {
+    ) -> Result<Option<(MoveTypeLayoutRef<'l>, V::Value)>, V::Error> {
         let Some(field_layout) = self.peek_field() else {
             return Ok(None);
         };
@@ -582,7 +590,7 @@ impl<'c, 'b, 'l> StructDriver<'c, 'b, 'l> {
 
     /// Skip the next field. Returns the layout of the field that was visited if there was one, or
     /// `None` if there was none. Can return an error if there was a deserialization error.
-    pub fn skip_field(&mut self) -> Result<Option<&'l MoveTypeLayout>, Error> {
+    pub fn skip_field(&mut self) -> Result<Option<MoveTypeLayoutRef<'l>>, Error> {
         self.next_field(&mut NullTraversal)
             .map(|res| res.map(|(f, _)| f))
     }
@@ -591,15 +599,15 @@ impl<'c, 'b, 'l> StructDriver<'c, 'b, 'l> {
 impl<'c, 'b, 'l> VariantDriver<'c, 'b, 'l> {
     fn new(
         inner: ValueDriver<'c, 'b, 'l>,
-        layout: &'l MoveEnumLayout,
-        variant_layout: &'l [MoveTypeLayout],
+        layout: MoveEnumLayout<'l>,
+        variant_fields: MoveFieldsLayout<'l>,
         tag: u16,
     ) -> Self {
         Self {
             inner,
             layout,
             tag,
-            variant_layout,
+            variant_fields,
             off: 0,
         }
     }
@@ -624,21 +632,19 @@ impl<'c, 'b, 'l> VariantDriver<'c, 'b, 'l> {
         self.inner.remaining_bytes()
     }
 
-    /// Type layout for the value being visited. May produce an error if a layout was not supplied
-    /// when the driver was created (which should only happen if the driver was created for
-    /// visiting a struct specifically).
-    pub fn layout(&self) -> Result<&'l MoveTypeLayout, Error> {
+    /// Type layout for the value being visited.
+    pub fn layout(&self) -> Result<MoveTypeLayoutRef<'l>, Error> {
         self.inner.layout()
     }
 
     /// The layout of the enum being visited.
-    pub fn enum_layout(&self) -> &'l MoveEnumLayout {
+    pub fn enum_layout(&self) -> MoveEnumLayout<'l> {
         self.layout
     }
 
-    /// The layout of the variant being visited.
-    pub fn variant_layout(&self) -> &'l [MoveTypeLayout] {
-        self.variant_layout
+    /// The field layout of the variant being visited.
+    pub fn variant_layout(&self) -> MoveFieldsLayout<'l> {
+        self.variant_fields
     }
 
     /// The tag of the variant being visited.
@@ -646,28 +652,23 @@ impl<'c, 'b, 'l> VariantDriver<'c, 'b, 'l> {
         self.tag
     }
 
-    /// The number of elements in this vector that have been visited so far.
+    /// The number of fields in this variant that have been visited so far.
     pub fn off(&self) -> u64 {
         self.off
     }
 
     /// The layout of the next field to be visited (if there is one), or `None` otherwise.
-    pub fn peek_field(&self) -> Option<&'l MoveTypeLayout> {
-        self.variant_layout.get(self.off as usize)
+    pub fn peek_field(&self) -> Option<MoveTypeLayoutRef<'l>> {
+        self.variant_fields.field(self.off as u16)
     }
 
     /// Visit the next field in the variant. The driver accepts a visitor to use for this field,
     /// allowing the visitor to be changed on recursive calls or even between fields in the same
     /// variant.
-    ///
-    /// Returns `Ok(None)` if there are no more fields in the variant, `Ok((f, v))` if there was an
-    /// field and it was successfully visited (where `v` is the value returned by the visitor, and
-    /// `f` is the layout of the field that was visited) or an error if there was an underlying
-    /// deserialization error, or an error during visitation.
     pub fn next_field<V: Visitor<'b, 'l> + ?Sized>(
         &mut self,
         visitor: &mut V,
-    ) -> Result<Option<(&'l MoveTypeLayout, V::Value)>, V::Error> {
+    ) -> Result<Option<(MoveTypeLayoutRef<'l>, V::Value)>, V::Error> {
         let Some(field_layout) = self.peek_field() else {
             return Ok(None);
         };
@@ -679,73 +680,70 @@ impl<'c, 'b, 'l> VariantDriver<'c, 'b, 'l> {
 
     /// Skip the next field. Returns the layout of the field that was visited if there was one, or
     /// `None` if there was none. Can return an error if there was a deserialization error.
-    pub fn skip_field(&mut self) -> Result<Option<&'l MoveTypeLayout>, Error> {
+    pub fn skip_field(&mut self) -> Result<Option<MoveTypeLayoutRef<'l>>, Error> {
         self.next_field(&mut NullTraversal)
             .map(|res| res.map(|(f, _)| f))
     }
 }
 
 /// Visit a serialized Move value with the provided `layout`, held in `bytes`, using the provided
-/// visitor to build a value out of it. See `runtime_value::MoveValue::visit_deserialize` for
-/// details.
+/// visitor to build a value out of it.
 pub(crate) fn visit_value<'c, 'b, 'l, V: Visitor<'b, 'l> + ?Sized>(
     bytes: &'c mut Cursor<&'b [u8]>,
-    layout: &'l MoveTypeLayout,
+    layout: MoveTypeLayoutRef<'l>,
     visitor: &mut V,
 ) -> Result<V::Value, V::Error> {
-    use MoveTypeLayout as L;
-
     let mut driver = ValueDriver::new(bytes, Some(layout));
-    match layout {
-        L::Bool => match driver.read_exact()? {
+    match layout.as_view() {
+        MoveLayoutView::Bool => match driver.read_exact()? {
             [0] => visitor.visit_bool(&driver, false),
             [1] => visitor.visit_bool(&driver, true),
             [b] => Err(Error::UnexpectedByte(b).into()),
         },
 
-        L::U8 => {
+        MoveLayoutView::U8 => {
             let v = u8::from_le_bytes(driver.read_exact()?);
             visitor.visit_u8(&driver, v)
         }
 
-        L::U16 => {
+        MoveLayoutView::U16 => {
             let v = u16::from_le_bytes(driver.read_exact()?);
             visitor.visit_u16(&driver, v)
         }
 
-        L::U32 => {
+        MoveLayoutView::U32 => {
             let v = u32::from_le_bytes(driver.read_exact()?);
             visitor.visit_u32(&driver, v)
         }
 
-        L::U64 => {
+        MoveLayoutView::U64 => {
             let v = u64::from_le_bytes(driver.read_exact()?);
             visitor.visit_u64(&driver, v)
         }
 
-        L::U128 => {
+        MoveLayoutView::U128 => {
             let v = u128::from_le_bytes(driver.read_exact()?);
             visitor.visit_u128(&driver, v)
         }
 
-        L::U256 => {
+        MoveLayoutView::U256 => {
             let v = U256::from_le_bytes(&driver.read_exact()?);
             visitor.visit_u256(&driver, v)
         }
 
-        L::Address => {
+        MoveLayoutView::Address => {
             let v = AccountAddress::new(driver.read_exact()?);
             visitor.visit_address(&driver, v)
         }
 
-        L::Signer => {
+        MoveLayoutView::Signer => {
             let v = AccountAddress::new(driver.read_exact()?);
             visitor.visit_signer(&driver, v)
         }
 
-        L::Vector(l) => visit_vector(driver, l.as_ref(), visitor),
-        L::Struct(l) => visit_struct(driver, l, visitor),
-        L::Enum(e) => visit_variant(driver, e, visitor),
+        MoveLayoutView::Vector(inner) => visit_vector(driver, inner, visitor),
+        MoveLayoutView::Struct(s) => visit_struct(driver, s, visitor),
+        MoveLayoutView::Enum(e) => visit_variant(driver, e, visitor),
     }
 }
 
@@ -753,11 +751,11 @@ pub(crate) fn visit_value<'c, 'b, 'l, V: Visitor<'b, 'l> + ?Sized>(
 /// serialized move vector), and the layout is the vector's element's layout.
 fn visit_vector<'c, 'b, 'l, V: Visitor<'b, 'l> + ?Sized>(
     mut inner: ValueDriver<'c, 'b, 'l>,
-    layout: &'l MoveTypeLayout,
+    elem_layout: MoveTypeLayoutRef<'l>,
     visitor: &mut V,
 ) -> Result<V::Value, V::Error> {
     let len = inner.read_leb128()?;
-    let mut driver = VecDriver::new(inner, layout, len);
+    let mut driver = VecDriver::new(inner, elem_layout, len);
     let res = visitor.visit_vector(&mut driver)?;
     while driver.skip_element()? {}
     Ok(res)
@@ -767,7 +765,7 @@ fn visit_vector<'c, 'b, 'l, V: Visitor<'b, 'l> + ?Sized>(
 /// serialized move struct), and the layout is a struct layout.
 pub(crate) fn visit_struct<'c, 'b, 'l, V: Visitor<'b, 'l> + ?Sized>(
     inner: ValueDriver<'c, 'b, 'l>,
-    layout: &'l MoveStructLayout,
+    layout: MoveStructLayout<'l>,
     visitor: &mut V,
 ) -> Result<V::Value, V::Error> {
     let mut driver = StructDriver::new(inner, layout);
@@ -780,7 +778,7 @@ pub(crate) fn visit_struct<'c, 'b, 'l, V: Visitor<'b, 'l> + ?Sized>(
 /// serialized move variant), and the layout is an enum layout.
 fn visit_variant<'c, 'b, 'l, V: Visitor<'b, 'l> + ?Sized>(
     mut inner: ValueDriver<'c, 'b, 'l>,
-    layout: &'l MoveEnumLayout,
+    layout: MoveEnumLayout<'l>,
     visitor: &mut V,
 ) -> Result<V::Value, V::Error> {
     // Since variants are bounded at 127, we can read the tag as a single byte.
@@ -790,12 +788,16 @@ fn visit_variant<'c, 'b, 'l, V: Visitor<'b, 'l> + ?Sized>(
     if tag > VARIANT_TAG_MAX_VALUE as u8 {
         return Err(Error::UnexpectedVariantTag(tag as usize).into());
     }
-    let variant_layout = layout
-        .0
-        .get(tag as usize)
-        .ok_or(Error::UnexpectedVariantTag(tag as usize))?;
+    let tag = tag as u16;
+    let variant_fields = match layout
+        .variant(tag)
+        .ok_or(Error::UnexpectedVariantTag(tag as usize))?
+    {
+        VariantLayout::Known(fields) => fields,
+        VariantLayout::Unknown => return Err(Error::UnknownVariantLayout(tag).into()),
+    };
 
-    let mut driver = VariantDriver::new(inner, layout, variant_layout, tag as u16);
+    let mut driver = VariantDriver::new(inner, layout, variant_fields, tag);
     let res = visitor.visit_variant(&mut driver)?;
     while driver.skip_field()?.is_some() {}
     Ok(res)

--- a/external-crates/move/crates/move-core-types/src/unit_tests/annotated_visitor_test.rs
+++ b/external-crates/move/crates/move-core-types/src/unit_tests/annotated_visitor_test.rs
@@ -12,11 +12,46 @@ use crate::{
         self, NullTraversal, StructDriver, Traversal, ValueDriver, VariantDriver, VecDriver,
         Visitor,
     },
+    compressed::annotated as CA,
     identifier::Identifier,
     language_storage::StructTag,
     u256::U256,
 };
 use std::{fmt::Write, str::FromStr};
+
+/// Convert a tree-form `MoveTypeLayout` into a compressed layout.
+fn compress(ty: &MoveTypeLayout) -> CA::MoveTypeLayout {
+    ty.try_into().unwrap()
+}
+
+/// Test-only wrappers that take tree-form layouts (the natural shape for these tests'
+/// inputs) and forward to the compressed-layout-based visit_deserialize.
+fn tree_visit_value<'b, V: Visitor<'b, 'b>>(
+    bytes: &'b [u8],
+    ty: &MoveTypeLayout,
+    visitor: &mut V,
+) -> Result<V::Value, V::Error>
+where
+    V::Error: std::error::Error + Send + Sync + 'static,
+{
+    // Leak the compressed layout to give it a `'static` lifetime so `'l` can match `'b`.
+    let compressed: &'static CA::MoveTypeLayout = Box::leak(Box::new(compress(ty)));
+    MoveValue::visit_deserialize(bytes, compressed.as_ref(), visitor)
+}
+
+fn tree_visit_struct<'b, V: Visitor<'b, 'b>>(
+    bytes: &'b [u8],
+    ty: &MoveStructLayout,
+    visitor: &mut V,
+) -> Result<V::Value, V::Error>
+where
+    V::Error: std::error::Error + Send + Sync + 'static,
+{
+    let tree = MoveTypeLayout::Struct(Box::new(ty.clone()));
+    let compressed: &'static CA::MoveTypeLayout = Box::leak(Box::new(compress(&tree)));
+    let struct_view = compressed.as_struct().expect("struct layout");
+    MoveStruct::visit_deserialize(bytes, struct_view, visitor)
+}
 
 #[derive(Default)]
 pub(crate) struct CountingTraversal(usize);
@@ -256,11 +291,11 @@ impl<'b, 'l> Visitor<'b, 'l> for PrintVisitor {
         };
 
         while let Some((field, value)) = driver.next_field(&mut field_visitor)? {
-            fields.push((field.name.clone(), value));
+            fields.push((field.0.clone(), value));
         }
 
         self.output = field_visitor.output;
-        let type_ = driver.struct_layout().type_.clone();
+        let type_ = driver.struct_layout().type_().clone();
         Ok(MoveValue::Struct(MoveStruct { type_, fields }))
     }
 
@@ -278,11 +313,11 @@ impl<'b, 'l> Visitor<'b, 'l> for PrintVisitor {
         };
 
         while let Some((field, value)) = driver.next_field(&mut field_visitor)? {
-            fields.push((field.name.clone(), value));
+            fields.push((field.0.clone(), value));
         }
 
         self.output = field_visitor.output;
-        let type_ = driver.enum_layout().type_.clone();
+        let type_ = driver.enum_layout().type_().clone();
         Ok(MoveValue::Variant(MoveVariant {
             type_,
             variant_name: driver.variant_name().to_owned(),
@@ -346,10 +381,10 @@ fn traversal() {
     let bytes = serialize(value);
 
     let mut value_traversal = CountingTraversal::default();
-    MoveValue::visit_deserialize(&bytes, &type_layout, &mut value_traversal).unwrap();
+    tree_visit_value(&bytes, &type_layout, &mut value_traversal).unwrap();
 
     let mut struct_traversal = CountingTraversal::default();
-    MoveStruct::visit_deserialize(&bytes, struct_layout, &mut struct_traversal).unwrap();
+    tree_visit_struct(&bytes, struct_layout, &mut struct_traversal).unwrap();
 
     assert_eq!(18, value_traversal.0);
     assert_eq!(18, struct_traversal.0);
@@ -374,14 +409,14 @@ fn unexpected_eof() {
 
     assert_eq!(
         "unexpected end of input",
-        MoveValue::visit_deserialize(&bytes, &type_layout, &mut NullTraversal)
+        tree_visit_value(&bytes, &type_layout, &mut NullTraversal)
             .unwrap_err()
             .to_string(),
     );
 
     assert_eq!(
         "unexpected end of input",
-        MoveStruct::visit_deserialize(&bytes, struct_layout, &mut NullTraversal)
+        tree_visit_struct(&bytes, struct_layout, &mut NullTraversal)
             .unwrap_err()
             .to_string(),
     );
@@ -400,7 +435,7 @@ fn no_enum_tag() {
 
     assert_eq!(
         "invalid variant tag: 42",
-        MoveValue::visit_deserialize(&bytes, &layout, &mut NullTraversal)
+        tree_visit_value(&bytes, &layout, &mut NullTraversal)
             .unwrap_err()
             .to_string(),
     );
@@ -419,7 +454,7 @@ fn out_of_range_enum_tag() {
 
     assert_eq!(
         "invalid variant tag: 127",
-        MoveValue::visit_deserialize(&bytes, &layout, &mut NullTraversal)
+        tree_visit_value(&bytes, &layout, &mut NullTraversal)
             .unwrap_err()
             .to_string(),
     );
@@ -438,7 +473,7 @@ fn invalid_variant_tag() {
 
     assert_eq!(
         "invalid variant tag: 1",
-        MoveValue::visit_deserialize(&bytes, &layout, &mut NullTraversal)
+        tree_visit_value(&bytes, &layout, &mut NullTraversal)
             .unwrap_err()
             .to_string(),
     );
@@ -449,7 +484,7 @@ fn bad_bool_byte() {
     use MoveTypeLayout as T;
     assert_eq!(
         "unexpected byte: 42",
-        MoveValue::visit_deserialize(&[42], &T::Bool, &mut NullTraversal)
+        tree_visit_value(&[42], &T::Bool, &mut NullTraversal)
             .unwrap_err()
             .to_string(),
     );
@@ -470,7 +505,7 @@ fn bad_vector_length() {
 
     assert_eq!(
         "unexpected end of input",
-        MoveValue::visit_deserialize(&bytes, &layout, &mut NullTraversal)
+        tree_visit_value(&bytes, &layout, &mut NullTraversal)
             .unwrap_err()
             .to_string(),
     );
@@ -481,7 +516,7 @@ fn trailing_bytes() {
     use MoveTypeLayout as T;
     assert_eq!(
         "trailing 1 byte(s) at the end of input",
-        MoveValue::visit_deserialize(&[42, 42], &T::U8, &mut NullTraversal)
+        tree_visit_value(&[42, 42], &T::U8, &mut NullTraversal)
             .unwrap_err()
             .to_string(),
     );
@@ -537,11 +572,11 @@ fn nested_datatype_visit() {
 
     let mut value_visitor = PrintVisitor::default();
     let from_value =
-        MoveValue::visit_deserialize(&bytes, &type_layout, &mut value_visitor).unwrap();
+        tree_visit_value(&bytes, &type_layout, &mut value_visitor).unwrap();
 
     let mut struct_visitor = PrintVisitor::default();
     let from_struct =
-        MoveStruct::visit_deserialize(&bytes, struct_layout, &mut struct_visitor).unwrap();
+        tree_visit_struct(&bytes, struct_layout, &mut struct_visitor).unwrap();
 
     // This is a little strange -- even though we are deserializing a struct, we still get a value.
     // This is because the return type comes from the visitor, not the deserializer.
@@ -582,7 +617,7 @@ fn peek_field_test() {
             };
 
             while let Some(layout) = driver.peek_field() {
-                if layout.name.as_str() == *field {
+                if layout.0.as_str() == *field {
                     return driver
                         .next_field(&mut Self { fields })
                         .map(|value| value.and_then(|(_, v)| v));
@@ -603,7 +638,7 @@ fn peek_field_test() {
             };
 
             while let Some(layout) = driver.peek_field() {
-                if layout.name.as_str() == *field {
+                if layout.0.as_str() == *field {
                     return driver
                         .next_field(&mut Self { fields })
                         .map(|value| value.and_then(|(_, v)| v));
@@ -726,11 +761,11 @@ fn peek_field_test() {
     let bytes = serialize(value);
 
     let visit_value = |fields| {
-        MoveValue::visit_deserialize(&bytes, &type_layout, &mut PeekU64Visitor { fields }).unwrap()
+        tree_visit_value(&bytes, &type_layout, &mut PeekU64Visitor { fields }).unwrap()
     };
 
     let visit_struct = |fields| {
-        MoveStruct::visit_deserialize(&bytes, struct_layout, &mut PeekU64Visitor { fields })
+        tree_visit_struct(&bytes, struct_layout, &mut PeekU64Visitor { fields })
             .unwrap()
     };
 
@@ -988,10 +1023,10 @@ fn byte_offset_test() {
     ));
 
     let mut value_visitor = ByteOffsetVisitor::default();
-    MoveValue::visit_deserialize(&bytes, &type_layout, &mut value_visitor).unwrap();
+    tree_visit_value(&bytes, &type_layout, &mut value_visitor).unwrap();
 
     let mut struct_visitor = ByteOffsetVisitor::default();
-    MoveStruct::visit_deserialize(&bytes, struct_layout, &mut struct_visitor).unwrap();
+    tree_visit_struct(&bytes, struct_layout, &mut struct_visitor).unwrap();
 
     assert_eq!(value_visitor.0, struct_visitor.0);
     insta::assert_snapshot!(value_visitor.0);

--- a/external-crates/move/crates/move-core-types/src/unit_tests/extractor_test.rs
+++ b/external-crates/move/crates/move-core-types/src/unit_tests/extractor_test.rs
@@ -7,11 +7,16 @@ use crate::{
     account_address::AccountAddress,
     annotated_extractor::{Element as E, Extractor},
     annotated_value::{MoveTypeLayout, MoveValue},
+    compressed::annotated as CA,
     language_storage::TypeTag,
     unit_tests::annotated_visitor_test::{
         PrintVisitor, enum_layout_, serialize, struct_layout_, struct_value_, variant_value_,
     },
 };
+
+fn compress(ty: &MoveTypeLayout) -> &'static CA::MoveTypeLayout {
+    Box::leak(Box::new(ty.try_into().unwrap()))
+}
 
 #[test]
 fn struct_() {
@@ -736,7 +741,7 @@ fn assert_path((value, layout): (MoveValue, MoveTypeLayout), path: Vec<E<'_>>, e
     let mut printer = PrintVisitor::default();
 
     assert!(
-        Extractor::deserialize_value(&bytes, &layout, &mut printer, path.clone())
+        Extractor::deserialize_value(&bytes, compress(&layout).as_ref(), &mut printer, path.clone())
             .unwrap()
             .is_some(),
         "Failed to extract value {path:?}",
@@ -754,7 +759,7 @@ fn assert_no_path((value, layout): (MoveValue, MoveTypeLayout), path: Vec<E<'_>>
     let mut printer = PrintVisitor::default();
 
     assert!(
-        Extractor::deserialize_value(&bytes, &layout, &mut printer, path.clone())
+        Extractor::deserialize_value(&bytes, compress(&layout).as_ref(), &mut printer, path.clone())
             .unwrap()
             .is_none(),
         "Expected not to find something at {path:?}",

--- a/external-crates/move/crates/move-core-types/src/unit_tests/runtime_visitor_test.rs
+++ b/external-crates/move/crates/move-core-types/src/unit_tests/runtime_visitor_test.rs
@@ -6,6 +6,7 @@ use std::fmt::Write;
 use crate::{
     VARIANT_COUNT_MAX, VARIANT_TAG_MAX_VALUE,
     account_address::AccountAddress,
+    compressed::runtime as CR,
     runtime_value::{
         MoveEnumLayout, MoveStruct, MoveStructLayout, MoveTypeLayout, MoveValue, MoveVariant,
     },
@@ -15,6 +16,36 @@ use crate::{
     },
     u256::U256,
 };
+
+fn compress(ty: &MoveTypeLayout) -> CR::MoveTypeLayout {
+    ty.try_into().unwrap()
+}
+
+fn tree_visit_value<'b, V: Visitor<'b, 'b>>(
+    bytes: &'b [u8],
+    ty: &MoveTypeLayout,
+    visitor: &mut V,
+) -> Result<V::Value, V::Error>
+where
+    V::Error: std::error::Error + Send + Sync + 'static,
+{
+    let compressed: &'static CR::MoveTypeLayout = Box::leak(Box::new(compress(ty)));
+    MoveValue::visit_deserialize(bytes, compressed.as_ref(), visitor)
+}
+
+fn tree_visit_struct<'b, V: Visitor<'b, 'b>>(
+    bytes: &'b [u8],
+    ty: &MoveStructLayout,
+    visitor: &mut V,
+) -> Result<V::Value, V::Error>
+where
+    V::Error: std::error::Error + Send + Sync + 'static,
+{
+    let tree = MoveTypeLayout::Struct(Box::new(ty.clone()));
+    let compressed: &'static CR::MoveTypeLayout = Box::leak(Box::new(compress(&tree)));
+    let struct_view = compressed.as_struct().expect("struct layout");
+    MoveStruct::visit_deserialize(bytes, struct_view, visitor)
+}
 
 #[derive(Default)]
 pub(crate) struct CountingTraversal(usize);
@@ -328,10 +359,10 @@ fn traversal() {
     let bytes = serialize(value);
 
     let mut value_traversal = CountingTraversal::default();
-    MoveValue::visit_deserialize(&bytes, &type_layout, &mut value_traversal).unwrap();
+    tree_visit_value(&bytes, &type_layout, &mut value_traversal).unwrap();
 
     let mut struct_traversal = CountingTraversal::default();
-    MoveStruct::visit_deserialize(&bytes, struct_layout, &mut struct_traversal).unwrap();
+    tree_visit_struct(&bytes, struct_layout, &mut struct_traversal).unwrap();
 
     assert_eq!(18, value_traversal.0);
     assert_eq!(18, struct_traversal.0);
@@ -348,7 +379,7 @@ fn max_variant() {
     let bytes = serialize(value);
     let mut val_traversal = CountingTraversal::default();
     MoveValue::simple_deserialize(&bytes, &layout).unwrap();
-    MoveValue::visit_deserialize(&bytes, &layout, &mut val_traversal).unwrap();
+    tree_visit_value(&bytes, &layout, &mut val_traversal).unwrap();
 }
 
 #[test]
@@ -370,14 +401,14 @@ fn unexpected_eof() {
 
     assert_eq!(
         "unexpected end of input",
-        MoveValue::visit_deserialize(&bytes, &type_layout, &mut NullTraversal)
+        tree_visit_value(&bytes, &type_layout, &mut NullTraversal)
             .unwrap_err()
             .to_string(),
     );
 
     assert_eq!(
         "unexpected end of input",
-        MoveStruct::visit_deserialize(&bytes, struct_layout, &mut NullTraversal)
+        tree_visit_struct(&bytes, struct_layout, &mut NullTraversal)
             .unwrap_err()
             .to_string(),
     );
@@ -396,7 +427,7 @@ fn no_enum_tag() {
 
     assert_eq!(
         "invalid variant tag: 42",
-        MoveValue::visit_deserialize(&bytes, &layout, &mut NullTraversal)
+        tree_visit_value(&bytes, &layout, &mut NullTraversal)
             .unwrap_err()
             .to_string(),
     );
@@ -415,7 +446,7 @@ fn out_of_range_enum_tag() {
 
     assert_eq!(
         "invalid variant tag: 127",
-        MoveValue::visit_deserialize(&bytes, &layout, &mut NullTraversal)
+        tree_visit_value(&bytes, &layout, &mut NullTraversal)
             .unwrap_err()
             .to_string(),
     );
@@ -434,7 +465,7 @@ fn invalid_variant_tag() {
 
     assert_eq!(
         "invalid variant tag: 1",
-        MoveValue::visit_deserialize(&bytes, &layout, &mut NullTraversal)
+        tree_visit_value(&bytes, &layout, &mut NullTraversal)
             .unwrap_err()
             .to_string(),
     );
@@ -445,7 +476,7 @@ fn bad_bool_byte() {
     use MoveTypeLayout as T;
     assert_eq!(
         "unexpected byte: 42",
-        MoveValue::visit_deserialize(&[42], &T::Bool, &mut NullTraversal)
+        tree_visit_value(&[42], &T::Bool, &mut NullTraversal)
             .unwrap_err()
             .to_string(),
     );
@@ -466,7 +497,7 @@ fn bad_vector_length() {
 
     assert_eq!(
         "unexpected end of input",
-        MoveValue::visit_deserialize(&bytes, &layout, &mut NullTraversal)
+        tree_visit_value(&bytes, &layout, &mut NullTraversal)
             .unwrap_err()
             .to_string(),
     );
@@ -477,7 +508,7 @@ fn trailing_bytes() {
     use MoveTypeLayout as T;
     assert_eq!(
         "trailing 1 byte(s) at the end of input",
-        MoveValue::visit_deserialize(&[42, 42], &T::U8, &mut NullTraversal)
+        tree_visit_value(&[42, 42], &T::U8, &mut NullTraversal)
             .unwrap_err()
             .to_string(),
     );
@@ -509,11 +540,11 @@ fn nested_datatype_visit() {
 
     let mut value_visitor = PrintVisitor::default();
     let from_value =
-        MoveValue::visit_deserialize(&bytes, &type_layout, &mut value_visitor).unwrap();
+        tree_visit_value(&bytes, &type_layout, &mut value_visitor).unwrap();
 
     let mut struct_visitor = PrintVisitor::default();
     let from_struct =
-        MoveStruct::visit_deserialize(&bytes, struct_layout, &mut struct_visitor).unwrap();
+        tree_visit_struct(&bytes, struct_layout, &mut struct_visitor).unwrap();
 
     // This is a little strange -- even though we are deserializing a struct, we still get a value.
     // This is because the return type comes from the visitor, not the deserializer.
@@ -686,11 +717,11 @@ fn peek_field_test() {
     let bytes = serialize(value);
 
     let visit_value = |fields| {
-        MoveValue::visit_deserialize(&bytes, &type_layout, &mut PeekU64Visitor { fields }).unwrap()
+        tree_visit_value(&bytes, &type_layout, &mut PeekU64Visitor { fields }).unwrap()
     };
 
     let visit_struct = |fields| {
-        MoveStruct::visit_deserialize(&bytes, struct_layout, &mut PeekU64Visitor { fields })
+        tree_visit_struct(&bytes, struct_layout, &mut PeekU64Visitor { fields })
             .unwrap()
     };
 
@@ -924,10 +955,10 @@ fn byte_offset_test() {
     ]));
 
     let mut value_visitor = ByteOffsetVisitor::default();
-    MoveValue::visit_deserialize(&bytes, &type_layout, &mut value_visitor).unwrap();
+    tree_visit_value(&bytes, &type_layout, &mut value_visitor).unwrap();
 
     let mut struct_visitor = ByteOffsetVisitor::default();
-    MoveStruct::visit_deserialize(&bytes, struct_layout, &mut struct_visitor).unwrap();
+    tree_visit_struct(&bytes, struct_layout, &mut struct_visitor).unwrap();
 
     assert_eq!(value_visitor.0, struct_visitor.0);
     insta::assert_snapshot!(value_visitor.0);


### PR DESCRIPTION
## Description 

What it says on the cover.

Note that the visitors no longer hold a reference to the type layout -- this is because with how the views are now structured you do not grab inner references as you traverse (so the lifetimes no longer would work out in particular). 

It instead switches to using owned type layouts and cloning wherever needed -- this is fine however since clones are/should be exceptionally cheap (two bumps of an Arc in most cases). 


## Test plan 

Existing tests. 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
