### PR TITLE
[move-ir] Require public on structs/enums

### DIFF
--- a/crates/sui-adapter-transactional-tests/tests/enums/enum_with_key_only.mvir
+++ b/crates/sui-adapter-transactional-tests/tests/enums/enum_with_key_only.mvir
@@ -7,7 +7,7 @@
 mvir 0x0::f {
     import 0x2::transfer;
 
-    enum X has key {
+    public enum X has key {
         A { } 
     }
 

--- a/crates/sui-adapter-transactional-tests/tests/enums/enum_with_key_only_uid_field.mvir
+++ b/crates/sui-adapter-transactional-tests/tests/enums/enum_with_key_only_uid_field.mvir
@@ -9,7 +9,7 @@ mvir 0x0::f {
     import 0x2::object;
     import 0x2::tx_context;
 
-    enum X has key {
+    public enum X has key {
         A { id: object::UID }
     }
 

--- a/crates/sui-adapter-transactional-tests/tests/enums/enum_with_key_store.mvir
+++ b/crates/sui-adapter-transactional-tests/tests/enums/enum_with_key_store.mvir
@@ -11,7 +11,7 @@ mvir 0x0::f {
     import 0x2::dynamic_object_field;
     import 0x2::tx_context;
 
-    enum X has store, key {
+    public enum X has store, key {
         A { } 
     }
 

--- a/crates/sui-adapter-transactional-tests/tests/enums/enum_with_key_store_uid_field.mvir
+++ b/crates/sui-adapter-transactional-tests/tests/enums/enum_with_key_store_uid_field.mvir
@@ -11,7 +11,7 @@ mvir 0x0::f {
     import 0x2::dynamic_object_field;
     import 0x2::tx_context;
 
-    enum X has store, key {
+    public enum X has store, key {
         A { id: object::UID } 
     }
 

--- a/crates/sui-adapter-transactional-tests/tests/publish/init_param.mvir
+++ b/crates/sui-adapter-transactional-tests/tests/publish/init_param.mvir
@@ -11,7 +11,7 @@ mvir 0x0::M1 {
     import 0x2::object;
     import 0x2::transfer;
 
-    struct Object has key, store {
+    public struct Object has key, store {
         id: object::UID,
         value: u64,
     }

--- a/crates/sui-adapter-transactional-tests/tests/publish/init_public.mvir
+++ b/crates/sui-adapter-transactional-tests/tests/publish/init_public.mvir
@@ -11,7 +11,7 @@ mvir 0x0::M1 {
     import 0x2::object;
     import 0x2::transfer;
 
-    struct Object has key, store {
+    public struct Object has key, store {
         id: object::UID,
         value: u64,
     }

--- a/crates/sui-adapter-transactional-tests/tests/publish/init_ret.mvir
+++ b/crates/sui-adapter-transactional-tests/tests/publish/init_ret.mvir
@@ -11,7 +11,7 @@ mvir 0x0::M1 {
     import 0x2::object;
     import 0x2::transfer;
 
-    struct Object has key, store {
+    public struct Object has key, store {
         id: object::UID,
         value: u64,
     }

--- a/crates/sui-verifier-transactional-tests/tests/entry_points/generic_and_generic_object_params.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/entry_points/generic_and_generic_object_params.mvir
@@ -5,7 +5,7 @@
 mvir 0x0::m {
     import 0x2::object;
     import 0x2::tx_context;
-    struct Obj<T> has key {
+    public struct Obj<T> has key {
         id: object::UID,
     }
     public entry fun foo<T0: key, T1: store>(l0: T0, l1: Self::Obj<T1>, c: &mut tx_context::TxContext) {

--- a/crates/sui-verifier-transactional-tests/tests/entry_points/generic_param_after_primitive.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/entry_points/generic_param_after_primitive.mvir
@@ -5,7 +5,7 @@
 mvir 0x0::m {
     import 0x2::object;
     import 0x2::tx_context;
-    struct Obj has key {
+    public struct Obj has key {
         id: object::UID,
     }
     public entry fun foo<T>(l0: Self::Obj, l1: u64, l2: T, ctx: &mut tx_context::TxContext) {

--- a/crates/sui-verifier-transactional-tests/tests/entry_points/non_key_struct.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/entry_points/non_key_struct.mvir
@@ -7,7 +7,7 @@
 mvir 0x0::m {
     import 0x2::tx_context;
 
-    struct S has copy, drop, store { value: u64 }
+    public struct S has copy, drop, store { value: u64 }
 
     public entry fun no(s: Self::S, ctx: &mut tx_context::TxContext) {
         label l0:

--- a/crates/sui-verifier-transactional-tests/tests/entry_points/non_key_struct_generic.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/entry_points/non_key_struct_generic.mvir
@@ -8,8 +8,8 @@ mvir 0x0::m {
     import 0x2::tx_context;
     import 0x2::object;
 
-    struct Obj<T> has key { id: object::UID }
-    struct NoStore has copy, drop { value: u64 }
+    public struct Obj<T> has key { id: object::UID }
+    public struct NoStore has copy, drop { value: u64 }
 
     public entry fun no(s: Self::Obj<Self::NoStore>, ctx: &mut tx_context::TxContext) {
         label l0:
@@ -25,7 +25,7 @@ mvir 0x0::m {
     import 0x2::tx_context;
     import 0x2::object;
 
-    struct Obj<T> has key { id: object::UID }
+    public struct Obj<T> has key { id: object::UID }
 
     public entry fun no<T>(s: Self::Obj<T>, ctx: &mut tx_context::TxContext) {
         label l0:

--- a/crates/sui-verifier-transactional-tests/tests/entry_points/non_key_struct_generic_v106.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/entry_points/non_key_struct_generic_v106.mvir
@@ -10,8 +10,8 @@ mvir 0x0::m {
     import 0x2::tx_context;
     import 0x2::object;
 
-    struct Obj<T> has key { id: object::UID }
-    struct NoStore has copy, drop { value: u64 }
+    public struct Obj<T> has key { id: object::UID }
+    public struct NoStore has copy, drop { value: u64 }
 
     public entry fun no(s: Self::Obj<Self::NoStore>, ctx: &mut tx_context::TxContext) {
         label l0:
@@ -27,7 +27,7 @@ mvir 0x0::m {
     import 0x2::tx_context;
     import 0x2::object;
 
-    struct Obj<T> has key { id: object::UID }
+    public struct Obj<T> has key { id: object::UID }
 
     public entry fun no<T>(s: Self::Obj<T>, ctx: &mut tx_context::TxContext) {
         label l0:

--- a/crates/sui-verifier-transactional-tests/tests/entry_points/non_key_struct_generic_valid.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/entry_points/non_key_struct_generic_valid.mvir
@@ -8,7 +8,7 @@ mvir 0x0::m {
     import 0x2::tx_context;
     import 0x2::object;
 
-    struct Obj<T> has key { id: object::UID }
+    public struct Obj<T> has key { id: object::UID }
 
     public entry fun no<T: store>(s: Self::Obj<T>, ctx: &mut tx_context::TxContext) {
         label l0:

--- a/crates/sui-verifier-transactional-tests/tests/entry_points/non_key_struct_v106.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/entry_points/non_key_struct_v106.mvir
@@ -9,7 +9,7 @@
 mvir 0x0::m {
     import 0x2::tx_context;
 
-    struct S has copy, drop, store { value: u64 }
+    public struct S has copy, drop, store { value: u64 }
 
     public entry fun no(s: Self::S, ctx: &mut tx_context::TxContext) {
         label l0:

--- a/crates/sui-verifier-transactional-tests/tests/entry_points/non_key_struct_vector.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/entry_points/non_key_struct_vector.mvir
@@ -7,7 +7,7 @@
 mvir 0x0::m {
     import 0x2::tx_context;
 
-    struct S has copy, drop, store { value: u64 }
+    public struct S has copy, drop, store { value: u64 }
 
     public entry fun no(s: vector<Self::S>, ctx: &mut tx_context::TxContext) {
         label l0:

--- a/crates/sui-verifier-transactional-tests/tests/entry_points/non_key_struct_vector_v106.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/entry_points/non_key_struct_vector_v106.mvir
@@ -9,7 +9,7 @@
 mvir 0x0::m {
     import 0x2::tx_context;
 
-    struct S has copy, drop, store { value: u64 }
+    public struct S has copy, drop, store { value: u64 }
 
     public entry fun no(s: vector<Self::S>, ctx: &mut tx_context::TxContext) {
         label l0:

--- a/crates/sui-verifier-transactional-tests/tests/entry_points/obj_mut_ref_vector.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/entry_points/obj_mut_ref_vector.mvir
@@ -8,7 +8,7 @@ mvir 0x0::m {
     import 0x2::object;
     import 0x2::tx_context;
 
-    struct S has key { id: object::UID }
+    public struct S has key { id: object::UID }
 
     public entry fun no(s: &mut vector<Self::S>, ctx: &mut tx_context::TxContext) {
         label l0:

--- a/crates/sui-verifier-transactional-tests/tests/entry_points/obj_mut_ref_vector_v106.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/entry_points/obj_mut_ref_vector_v106.mvir
@@ -10,7 +10,7 @@ mvir 0x0::m {
     import 0x2::object;
     import 0x2::tx_context;
 
-    struct S has key { id: object::UID }
+    public struct S has key { id: object::UID }
 
     public entry fun no(s: &mut vector<Self::S>, ctx: &mut tx_context::TxContext) {
         label l0:

--- a/crates/sui-verifier-transactional-tests/tests/entry_points/obj_ref_vector.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/entry_points/obj_ref_vector.mvir
@@ -8,7 +8,7 @@ mvir 0x0::m {
     import 0x2::object;
     import 0x2::tx_context;
 
-    struct S has key { id: object::UID }
+    public struct S has key { id: object::UID }
 
     public entry fun no(s: &vector<Self::S>, ctx: &mut tx_context::TxContext) {
         label l0:

--- a/crates/sui-verifier-transactional-tests/tests/entry_points/obj_ref_vector_v106.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/entry_points/obj_ref_vector_v106.mvir
@@ -10,7 +10,7 @@ mvir 0x0::m {
     import 0x2::object;
     import 0x2::tx_context;
 
-    struct S has key { id: object::UID }
+    public struct S has key { id: object::UID }
 
     public entry fun no(s: &vector<Self::S>, ctx: &mut tx_context::TxContext) {
         label l0:

--- a/crates/sui-verifier-transactional-tests/tests/entry_points/optional_txn_context.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/entry_points/optional_txn_context.mvir
@@ -15,7 +15,7 @@ mvir 0x0::m {
 mvir 0x0::m {
     import 0x2::tx_context;
     import 0x2::object;
-    struct Obj has key { id: object::UID }
+    public struct Obj has key { id: object::UID }
     public entry fun t(flag: bool, arg: &mut Self::Obj) {
         label l0:
         abort 0;

--- a/crates/sui-verifier-transactional-tests/tests/entry_points/return_values.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/entry_points/return_values.mvir
@@ -33,7 +33,7 @@ mvir 0x0::m {
 //# publish
 mvir 0x0::m {
     import 0x2::tx_context;
-    struct Droppable has drop { flag: bool }
+    public struct Droppable has drop { flag: bool }
     public entry fun foo(ctx: &mut tx_context::TxContext): Self::Droppable {
         label l0:
         abort 0;
@@ -43,7 +43,7 @@ mvir 0x0::m {
 //# publish
 mvir 0x0::m {
     import 0x2::tx_context;
-    struct Droppable has drop { flag: bool }
+    public struct Droppable has drop { flag: bool }
     public entry fun foo(ctx: &mut tx_context::TxContext): vector<Self::Droppable> * u64 {
         label l0:
         abort 0;

--- a/crates/sui-verifier-transactional-tests/tests/entry_points/return_values_invalid.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/entry_points/return_values_invalid.mvir
@@ -33,7 +33,7 @@ mvir 0x0::m {
 //# publish
 mvir 0x0::m {
     import 0x2::tx_context;
-    struct Copyable has copy { flag: bool }
+    public struct Copyable has copy { flag: bool }
     public entry fun foo(ctx: &mut tx_context::TxContext): Self::Copyable {
         label l0:
         abort 0;
@@ -44,7 +44,7 @@ mvir 0x0::m {
 mvir 0x0::m {
     import 0x2::tx_context;
     import 0x2::object;
-    struct Obj has key, store { id: object::UID }
+    public struct Obj has key, store { id: object::UID }
     public entry fun foo(ctx: &mut tx_context::TxContext): Self::Obj {
         label l0:
         abort 0;
@@ -55,7 +55,7 @@ mvir 0x0::m {
 mvir 0x0::m {
     import 0x2::tx_context;
     import 0x2::object;
-    struct Obj has key, store { id: object::UID }
+    public struct Obj has key, store { id: object::UID }
     public entry fun foo(ctx: &mut tx_context::TxContext): vector<Self::Obj> {
         label l0:
         abort 0;

--- a/crates/sui-verifier-transactional-tests/tests/entry_points/return_values_invalid_v106.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/entry_points/return_values_invalid_v106.mvir
@@ -35,7 +35,7 @@ mvir 0x0::m {
 //# publish
 mvir 0x0::m {
     import 0x2::tx_context;
-    struct Copyable has copy { flag: bool }
+    public struct Copyable has copy { flag: bool }
     public entry fun foo(ctx: &mut tx_context::TxContext): Self::Copyable {
         label l0:
         abort 0;
@@ -46,7 +46,7 @@ mvir 0x0::m {
 mvir 0x0::m {
     import 0x2::tx_context;
     import 0x2::object;
-    struct Obj has key, store { id: object::UID }
+    public struct Obj has key, store { id: object::UID }
     public entry fun foo(ctx: &mut tx_context::TxContext): Self::Obj {
         label l0:
         abort 0;
@@ -57,7 +57,7 @@ mvir 0x0::m {
 mvir 0x0::m {
     import 0x2::tx_context;
     import 0x2::object;
-    struct Obj has key, store { id: object::UID }
+    public struct Obj has key, store { id: object::UID }
     public entry fun foo(ctx: &mut tx_context::TxContext): vector<Self::Obj> {
         label l0:
         abort 0;

--- a/crates/sui-verifier-transactional-tests/tests/entry_points/single_type_param_generic_object.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/entry_points/single_type_param_generic_object.mvir
@@ -5,7 +5,7 @@
 mvir 0x0::m {
     import 0x2::object;
     import 0x2::tx_context;
-    struct Obj<T> has key {
+    public struct Obj<T> has key {
         id: object::UID,
     }
     public entry fun foo<T: store>(l: Self::Obj<T>, ctx: &mut tx_context::TxContext) {

--- a/crates/sui-verifier-transactional-tests/tests/enums/enum_with_key_only.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/enums/enum_with_key_only.mvir
@@ -5,7 +5,7 @@
 
 //# publish 
 mvir 0x0::f {
-    enum X has key {
+    public enum X has key {
         A { } 
     }
 }

--- a/crates/sui-verifier-transactional-tests/tests/enums/enum_with_key_only_uid_field.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/enums/enum_with_key_only_uid_field.mvir
@@ -7,7 +7,7 @@
 mvir 0x0::f {
     import 0x2::object;
 
-    enum X has key {
+    public enum X has key {
         A { id: object::UID } 
     }
 }

--- a/crates/sui-verifier-transactional-tests/tests/enums/enum_with_key_only_uid_field_version_48.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/enums/enum_with_key_only_uid_field_version_48.mvir
@@ -7,7 +7,7 @@
 mvir 0x0::f {
     import 0x2::object;
 
-    enum X has key {
+    public enum X has key {
         A { id: object::UID } 
     }
 }

--- a/crates/sui-verifier-transactional-tests/tests/enums/enum_with_key_only_version_48.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/enums/enum_with_key_only_version_48.mvir
@@ -5,7 +5,7 @@
 
 //# publish 
 mvir 0x0::f {
-    enum X has key {
+    public enum X has key {
         A { } 
     }
 }

--- a/crates/sui-verifier-transactional-tests/tests/enums/enum_with_key_store.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/enums/enum_with_key_store.mvir
@@ -5,7 +5,7 @@
 
 //# publish
 mvir 0x0::f {
-    enum X has store, key {
+    public enum X has store, key {
         A { } 
     }
 }

--- a/crates/sui-verifier-transactional-tests/tests/enums/enum_with_key_store_uid_field.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/enums/enum_with_key_store_uid_field.mvir
@@ -7,7 +7,7 @@
 mvir 0x0::f {
     import 0x2::object;
 
-    enum X has store, key {
+    public enum X has store, key {
         A { id: object::UID } 
     }
 }

--- a/crates/sui-verifier-transactional-tests/tests/enums/enum_with_key_store_uid_field_version_48.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/enums/enum_with_key_store_uid_field_version_48.mvir
@@ -7,7 +7,7 @@
 mvir 0x0::f {
     import 0x2::object;
 
-    enum X has store, key {
+    public enum X has store, key {
         A { id: object::UID } 
     }
 }

--- a/crates/sui-verifier-transactional-tests/tests/enums/enum_with_key_store_version_48.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/enums/enum_with_key_store_version_48.mvir
@@ -5,7 +5,7 @@
 
 //# publish
 mvir 0x0::f {
-    enum X has store, key {
+    public enum X has store, key {
         A { } 
     }
 }

--- a/crates/sui-verifier-transactional-tests/tests/id_immutable/mut_borrow_generic_key_struct_id_field.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/id_immutable/mut_borrow_generic_key_struct_id_field.mvir
@@ -5,7 +5,7 @@
 mvir 0x0::m {
     import 0x2::object;
 
-    struct Foo<T> has key {
+    public struct Foo<T> has key {
         id: object::UID,
     }
 

--- a/crates/sui-verifier-transactional-tests/tests/id_immutable/mut_borrow_key_struct_id_field.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/id_immutable/mut_borrow_key_struct_id_field.mvir
@@ -5,7 +5,7 @@
 mvir 0x0::m {
     import 0x2::object;
 
-    struct Foo has key {
+    public struct Foo has key {
         id: object::UID,
     }
 

--- a/crates/sui-verifier-transactional-tests/tests/id_immutable/mut_borrow_key_struct_non_id_field.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/id_immutable/mut_borrow_key_struct_non_id_field.mvir
@@ -5,7 +5,7 @@
 mvir 0x0::m {
     import 0x2::object;
 
-    struct Foo has key {
+    public struct Foo has key {
         id: object::UID,
         other: object::UID,
     }

--- a/crates/sui-verifier-transactional-tests/tests/id_immutable/mut_borrow_non_key_struct_id_field.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/id_immutable/mut_borrow_non_key_struct_id_field.mvir
@@ -5,7 +5,7 @@
 mvir 0x0::m {
     import 0x2::object;
 
-    struct Foo {
+    public struct Foo {
         id: object::UID,
     }
 

--- a/crates/sui-verifier-transactional-tests/tests/id_immutable/write_id_field.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/id_immutable/write_id_field.mvir
@@ -5,7 +5,7 @@
 mvir 0x0::m {
     import 0x2::object;
 
-    struct Foo has key {
+    public struct Foo has key {
         id: object::UID,
     }
 

--- a/crates/sui-verifier-transactional-tests/tests/id_leak/derived_object_no_leak.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/id_leak/derived_object_no_leak.mvir
@@ -9,7 +9,7 @@ mvir 0x0::m {
     import 0x2::derived_object;
     import 0x2::tx_context;
 
-    struct A has key {
+    public struct A has key {
         id: object::UID
     }
 

--- a/crates/sui-verifier-transactional-tests/tests/id_leak/direct_leak_through_call.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/id_leak/direct_leak_through_call.mvir
@@ -6,7 +6,7 @@
 mvir 0x0::m {
     import 0x2::object;
 
-    struct Foo has key {
+    public struct Foo has key {
         id: object::UID,
     }
 

--- a/crates/sui-verifier-transactional-tests/tests/id_leak/indirect_leak_through_call.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/id_leak/indirect_leak_through_call.mvir
@@ -6,7 +6,7 @@
 mvir 0x0::m {
     import 0x2::object;
 
-    struct Foo has key {
+    public struct Foo has key {
         id: object::UID,
     }
 
@@ -30,7 +30,7 @@ mvir 0x0::m {
 mvir 0x0::m {
     import 0x2::object;
 
-    struct Foo has key {
+    public struct Foo has key {
         id: object::UID,
     }
 

--- a/crates/sui-verifier-transactional-tests/tests/id_leak/infinite_loop.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/id_leak/infinite_loop.mvir
@@ -8,7 +8,7 @@ mvir 0x0::m {
     import 0x2::object;
     import 0x2::tx_context;
 
-    struct Obj has key {
+    public struct Obj has key {
         id: object::UID,
     }
 
@@ -32,7 +32,7 @@ mvir 0x0::m {
     import 0x2::object;
     import 0x2::tx_context;
 
-    struct Obj has key {
+    public struct Obj has key {
         id: object::UID,
     }
 

--- a/crates/sui-verifier-transactional-tests/tests/id_leak/loop.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/id_leak/loop.mvir
@@ -8,7 +8,7 @@ mvir 0x0::m {
     import 0x2::tx_context;
     import 0x2::transfer;
 
-    struct Obj has key {
+    public struct Obj has key {
         id: object::UID,
     }
 

--- a/crates/sui-verifier-transactional-tests/tests/id_leak/through_call_with_borrow_field.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/id_leak/through_call_with_borrow_field.mvir
@@ -7,9 +7,9 @@ mvir 0x0::m {
     import 0x2::object;
     import 0x2::transfer;
 
-    struct S has copy, drop { f: u64 }
+    public struct S has copy, drop { f: u64 }
 
-    struct Object has key { id: object::UID }
+    public struct Object has key { id: object::UID }
 
     fun new(id: object::UID): Self::Object {
         label l0:

--- a/crates/sui-verifier-transactional-tests/tests/id_leak/through_direct_return.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/id_leak/through_direct_return.mvir
@@ -6,7 +6,7 @@
 mvir 0x0::m {
     import 0x2::object;
 
-    struct Foo has key {
+    public struct Foo has key {
         id: object::UID,
     }
 

--- a/crates/sui-verifier-transactional-tests/tests/id_leak/through_indirect_return.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/id_leak/through_indirect_return.mvir
@@ -6,7 +6,7 @@
 mvir 0x0::m {
     import 0x2::object;
 
-    struct Foo has key {
+    public struct Foo has key {
         id: object::UID,
     }
 

--- a/crates/sui-verifier-transactional-tests/tests/id_leak/through_pack.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/id_leak/through_pack.mvir
@@ -8,15 +8,15 @@ mvir 0x0::test {
     import 0x2::transfer;
     import 0x2::tx_context;
 
-    struct A has key {
+    public struct A has key {
         id: object::UID
     }
 
-    struct C has key {
+    public struct C has key {
         id: object::UID
     }
 
-    struct B {
+    public struct B {
         id: object::UID
     }
 
@@ -41,11 +41,11 @@ mvir 0x0::test {
 mvir 0x0::m {
     import 0x2::object;
 
-    struct Foo has key {
+    public struct Foo has key {
         id: object::UID,
     }
 
-    struct Bar {
+    public struct Bar {
         id: object::UID,
         v: u64,
     }

--- a/crates/sui-verifier-transactional-tests/tests/id_leak/through_reference.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/id_leak/through_reference.mvir
@@ -5,7 +5,7 @@
 mvir 0x0::m {
     import 0x2::object;
 
-    struct Foo has key {
+    public struct Foo has key {
         id: object::UID,
     }
 

--- a/crates/sui-verifier-transactional-tests/tests/id_leak/through_vector.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/id_leak/through_vector.mvir
@@ -6,7 +6,7 @@
 mvir 0x0::m {
     import 0x2::object;
 
-    struct Foo has key {
+    public struct Foo has key {
         id: object::UID,
     }
 

--- a/crates/sui-verifier-transactional-tests/tests/id_leak/transmute.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/id_leak/transmute.mvir
@@ -7,11 +7,11 @@ mvir 0x0::m {
     import 0x2::tx_context;
     import 0x2::transfer;
 
-    struct Cat has key {
+    public struct Cat has key {
         id: object::UID,
     }
 
-    struct Dog has key {
+    public struct Dog has key {
         id: object::UID,
     }
 

--- a/crates/sui-verifier-transactional-tests/tests/init/not_txn_context.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/init/not_txn_context.mvir
@@ -12,7 +12,7 @@ mvir 0x0::m {
 
 //# publish
 mvir 0x0::tx_context {
-    struct TxContext { value: u64 }
+    public struct TxContext { value: u64 }
     fun init(ctx: Self::TxContext) {
         label l0:
         abort 0;

--- a/crates/sui-verifier-transactional-tests/tests/one_time_witness/bool_field.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/one_time_witness/bool_field.mvir
@@ -7,7 +7,7 @@
 mvir 0x0::m {
     import 0x2::tx_context;
 
-    struct M has drop { some_field: bool }
+    public struct M has drop { some_field: bool }
 
     fun init(_otw: Self::M, _ctx: &mut tx_context::TxContext) {
         label l0:

--- a/crates/sui-verifier-transactional-tests/tests/one_time_witness/enum_no_drop.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/one_time_witness/enum_no_drop.mvir
@@ -7,7 +7,7 @@
 mvir 0x0::m {
     import 0x2::tx_context;
 
-    enum M { 
+    public enum M { 
         V { }
     }
 

--- a/crates/sui-verifier-transactional-tests/tests/one_time_witness/enum_single_variant_bool_field.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/one_time_witness/enum_single_variant_bool_field.mvir
@@ -7,7 +7,7 @@
 mvir 0x0::m {
     import 0x2::tx_context;
 
-    enum M has drop { 
+    public enum M has drop { 
         V { field: bool }
     }
 

--- a/crates/sui-verifier-transactional-tests/tests/one_time_witness/enum_single_variant_no_field.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/one_time_witness/enum_single_variant_no_field.mvir
@@ -7,7 +7,7 @@
 mvir 0x0::m {
     import 0x2::tx_context;
 
-    enum M has drop { 
+    public enum M has drop { 
         V  { }
     }
 

--- a/crates/sui-verifier-transactional-tests/tests/one_time_witness/enum_wrong_name.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/one_time_witness/enum_wrong_name.mvir
@@ -7,7 +7,7 @@
 mvir 0x0::m {
     import 0x2::tx_context;
 
-    enum OTHER has drop { 
+    public enum OTHER has drop { 
         V { }
     }
 

--- a/crates/sui-verifier-transactional-tests/tests/one_time_witness/instantiate.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/one_time_witness/instantiate.mvir
@@ -7,7 +7,7 @@
 mvir 0x0::m {
     import 0x2::tx_context;
 
-    struct M has drop { dummy: bool }
+    public struct M has drop { dummy: bool }
 
     fun init(_otw: Self::M, _ctx: &mut tx_context::TxContext) {
         label l0:

--- a/crates/sui-verifier-transactional-tests/tests/one_time_witness/many_fields_invalid.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/one_time_witness/many_fields_invalid.mvir
@@ -7,7 +7,7 @@
 mvir 0x0::m {
     import 0x2::tx_context;
 
-    struct M has drop { some_field: bool, some_field2: bool  }
+    public struct M has drop { some_field: bool, some_field2: bool  }
 
     fun init(_otw: Self::M, _ctx: &mut tx_context::TxContext) {
         label l0:

--- a/crates/sui-verifier-transactional-tests/tests/one_time_witness/many_fields_valid.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/one_time_witness/many_fields_valid.mvir
@@ -5,7 +5,7 @@
 
 //# publish
 mvir 0x0::m {
-    struct M has drop { some_field: bool, some_field2: bool  }
+    public struct M has drop { some_field: bool, some_field2: bool  }
 
     public fun new(): Self::M {
         label l0:

--- a/crates/sui-verifier-transactional-tests/tests/one_time_witness/more_abilities.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/one_time_witness/more_abilities.mvir
@@ -9,7 +9,7 @@
 mvir 0x0::m {
     import 0x2::tx_context;
 
-    struct M has drop, copy { dummy: bool }
+    public struct M has drop, copy { dummy: bool }
 
     fun init(_otw: Self::M, _ctx: &mut tx_context::TxContext) {
         label l0:
@@ -22,7 +22,7 @@ mvir 0x0::m {
 mvir 0x0::m {
     import 0x2::tx_context;
 
-    struct M has drop, store { dummy: bool }
+    public struct M has drop, store { dummy: bool }
 
     fun init(_otw: Self::M, _ctx: &mut tx_context::TxContext) {
         label l0:
@@ -35,7 +35,7 @@ mvir 0x0::m {
 mvir 0x0::m {
     import 0x2::tx_context;
 
-    struct M has drop, copy, store { dummy: bool }
+    public struct M has drop, copy, store { dummy: bool }
 
     fun init(_otw: Self::M, _ctx: &mut tx_context::TxContext) {
         label l0:

--- a/crates/sui-verifier-transactional-tests/tests/one_time_witness/no_drop.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/one_time_witness/no_drop.mvir
@@ -7,7 +7,7 @@
 mvir 0x0::m {
     import 0x2::tx_context;
 
-    struct M { dummy: bool }
+    public struct M { dummy: bool }
 
     fun init(otw: Self::M, _ctx: &mut tx_context::TxContext) {
         label l0:

--- a/crates/sui-verifier-transactional-tests/tests/one_time_witness/no_field.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/one_time_witness/no_field.mvir
@@ -7,7 +7,7 @@
 mvir 0x0::m {
     import 0x2::tx_context;
 
-    struct M has drop {}
+    public struct M has drop {}
 
     fun init(_otw: Self::M, _ctx: &mut tx_context::TxContext) {
         label l0:

--- a/crates/sui-verifier-transactional-tests/tests/one_time_witness/no_init_arg.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/one_time_witness/no_init_arg.mvir
@@ -7,7 +7,7 @@
 mvir 0x0::m {
     import 0x2::tx_context;
 
-    struct M has drop { dummy: bool }
+    public struct M has drop { dummy: bool }
 
     fun init(_ctx: &mut tx_context::TxContext) {
         label l0:

--- a/crates/sui-verifier-transactional-tests/tests/one_time_witness/type_param.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/one_time_witness/type_param.mvir
@@ -7,7 +7,7 @@
 mvir 0x0::m {
     import 0x2::tx_context;
 
-    struct M<phantom T> has drop { dummy: bool }
+    public struct M<phantom T> has drop { dummy: bool }
 
     fun init<T>(_otw: Self::M<T>, _ctx: &mut tx_context::TxContext) {
         label l0:

--- a/crates/sui-verifier-transactional-tests/tests/one_time_witness/wrong_field_type.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/one_time_witness/wrong_field_type.mvir
@@ -7,7 +7,7 @@
 mvir 0x0::m {
     import 0x2::tx_context;
 
-    struct M has store, drop { value: u64 }
+    public struct M has store, drop { value: u64 }
 
     fun init(_ctx: &mut tx_context::TxContext) {
         label l0:
@@ -26,8 +26,8 @@ mvir 0x0::m {
 mvir 0x0::m {
     import 0x2::tx_context;
 
-    struct Other has drop { value: bool }
-    struct M has drop { value: Self::Other }
+    public struct Other has drop { value: bool }
+    public struct M has drop { value: Self::Other }
 
     fun init(_ctx: &mut tx_context::TxContext) {
         label l0:

--- a/crates/sui-verifier-transactional-tests/tests/one_time_witness/wrong_field_type_with_init.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/one_time_witness/wrong_field_type_with_init.mvir
@@ -7,7 +7,7 @@
 mvir 0x0::m {
     import 0x2::tx_context;
 
-    struct M has drop { value: u64 }
+    public struct M has drop { value: u64 }
 
     fun init(_otw: Self::M, _ctx: &mut tx_context::TxContext) {
         label l0:

--- a/crates/sui-verifier-transactional-tests/tests/one_time_witness/wrong_init_type.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/one_time_witness/wrong_init_type.mvir
@@ -7,8 +7,8 @@
 mvir 0x0::m {
     import 0x2::tx_context;
 
-    struct M has drop { dummy: bool }
-    struct N has drop { dummy: bool }
+    public struct M has drop { dummy: bool }
+    public struct N has drop { dummy: bool }
 
     fun init(_otw: Self::N, _ctx: &mut tx_context::TxContext) {
         label l0:

--- a/crates/sui-verifier-transactional-tests/tests/one_time_witness/wrong_name.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/one_time_witness/wrong_name.mvir
@@ -7,7 +7,7 @@
 mvir 0x0::m {
     import 0x2::tx_context;
 
-    struct OneTimeWitness has drop { dummy: bool }
+    public struct OneTimeWitness has drop { dummy: bool }
 
     fun init(_otw: Self::OneTimeWitness, _ctx: &mut tx_context::TxContext) {
         label l0:

--- a/crates/sui-verifier-transactional-tests/tests/one_time_witness/wrong_name_format.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/one_time_witness/wrong_name_format.mvir
@@ -7,7 +7,7 @@
 mvir 0x0::mod {
     import 0x2::tx_context;
 
-    struct Mod has drop { dummy: bool }
+    public struct Mod has drop { dummy: bool }
 
     fun init(_mod: Self::Mod, ctx: &mut tx_context::TxContext) {
         label l0:

--- a/crates/sui-verifier-transactional-tests/tests/private_generics/internal_permit.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/private_generics/internal_permit.mvir
@@ -7,7 +7,7 @@
 mvir 0x0::t {
     import 0x1::internal;
 
-    struct Internal { dummy_field: bool }
+    public struct Internal { dummy_field: bool }
 
     fun test_success() {
         let permit: internal::Permit<Self::Internal>;
@@ -34,7 +34,7 @@ mvir 0x0::t {
 mvir 0x0::t {
     import 0x1::internal;
 
-    struct Internal { dummy_field: bool }
+    public struct Internal { dummy_field: bool }
 
     fun test_fail_permit_type() {
         let permit: internal::Permit<internal::Permit<Self::Internal>>;
@@ -48,7 +48,7 @@ mvir 0x0::t {
 mvir 0x0::t {
     import 0x1::internal;
 
-    struct Internal { dummy_field: bool }
+    public struct Internal { dummy_field: bool }
 
     fun test_fail_permit_type() {
         let permit: internal::Permit<vector<Self::Internal>>;

--- a/crates/sui-verifier-transactional-tests/tests/private_generics/new_currency.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/private_generics/new_currency.mvir
@@ -41,7 +41,7 @@ mvir 0x0::t {
     import 0x2::tx_context;
 
     // Uses `LP` with an external generic parameter, to prove that we can do that.
-    struct LP<phantom A> has key {
+    public struct LP<phantom A> has key {
         id: object::UID
     }
 
@@ -73,7 +73,7 @@ mvir 0x0::t {
     import 0x2::coin_registry;
     import 0x2::tx_context;
 
-    struct Foo has key {
+    public struct Foo has key {
         id: object::UID
     }
 

--- a/crates/sui-verifier-transactional-tests/tests/private_generics/no_public_transfer_explicit.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/private_generics/no_public_transfer_explicit.mvir
@@ -9,16 +9,16 @@
 mvir test::m {
     import 0x2::object;
 
-    struct KeyStruct has key {
+    public struct KeyStruct has key {
         id: object::UID,
     }
 
-    struct KeyStoreStruct has key, store {
+    public struct KeyStoreStruct has key, store {
         id: object::UID,
     }
 
     // Enums cannot have key see failure below
-    enum StoreEnum has store {
+    public enum StoreEnum has store {
         V { id: object::UID },
     }
 }
@@ -31,7 +31,7 @@ mvir test::m {
 mvir 0x0::m {
     import 0x2::object;
     // Enums cannot have key
-    enum StoreEnum has key {
+    public enum StoreEnum has key {
         V { id: object::UID },
     }
 }

--- a/crates/sui-verifier-transactional-tests/tests/private_generics/private_event_emit.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/private_generics/private_event_emit.mvir
@@ -43,7 +43,7 @@ mvir 0x0::m {
 mvir 0x0::m {
     import 0x2::event;
 
-    struct X has copy, drop {
+    public struct X has copy, drop {
         dummy: bool,
     }
 
@@ -58,7 +58,7 @@ mvir 0x0::m {
 mvir 0x0::m {
     import 0x2::event;
 
-    enum X has copy, drop {
+    public enum X has copy, drop {
         V { }
     }
 
@@ -71,11 +71,11 @@ mvir 0x0::m {
 
 //# publish
 mvir test::m {
-    struct Y has copy, drop {
+    public struct Y has copy, drop {
         dummy: bool,
     }
 
-    enum X has copy, drop {
+    public enum X has copy, drop {
         V { }
     }
 }
@@ -144,7 +144,7 @@ mvir 0x0::m {
 mvir 0x0::m {
     import 0x2::event;
 
-    struct X has copy, drop {
+    public struct X has copy, drop {
         dummy: bool,
     }
 
@@ -159,7 +159,7 @@ mvir 0x0::m {
 mvir 0x0::m {
     import 0x2::event;
 
-    enum X has copy, drop {
+    public enum X has copy, drop {
         V { }
     }
 

--- a/crates/sui-verifier-transactional-tests/tests/private_generics/receive_with_and_without_store.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/private_generics/receive_with_and_without_store.mvir
@@ -29,7 +29,7 @@ mvir 0x0::m {
     import 0x2::transfer;
     import 0x2::object;
 
-    struct A has key { id: object::UID }
+    public struct A has key { id: object::UID }
 
     // Valid since `A` defined in this module
     fun receive_good(m: &mut object::UID, r: transfer::Receiving<Self::A>): Self::A {

--- a/crates/sui-verifier-transactional-tests/tests/struct_with_key/key_struct_first_field_not_id.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/struct_with_key/key_struct_first_field_not_id.mvir
@@ -4,7 +4,7 @@
 //# publish
 mvir 0x0::m {
     import 0x2::object;
-    struct S has key {
+    public struct S has key {
         flag: bool
     }
 }

--- a/crates/sui-verifier-transactional-tests/tests/struct_with_key/key_struct_id_field_incorrect_struct_address.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/struct_with_key/key_struct_id_field_incorrect_struct_address.mvir
@@ -4,8 +4,8 @@
 //# publish
 mvir 0x0::object {
     import 0x2::object;
-    struct UID has store { flag: bool }
-    struct S has key {
+    public struct UID has store { flag: bool }
+    public struct S has key {
         id: Self::UID
     }
 }

--- a/crates/sui-verifier-transactional-tests/tests/struct_with_key/key_struct_id_field_incorrect_struct_name.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/struct_with_key/key_struct_id_field_incorrect_struct_name.mvir
@@ -4,7 +4,7 @@
 //# publish
 mvir 0x0::m {
     import 0x2::object;
-    struct S has key {
+    public struct S has key {
         id: object::ID
     }
 }

--- a/crates/sui-verifier-transactional-tests/tests/struct_with_key/key_struct_id_field_incorrect_type.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/struct_with_key/key_struct_id_field_incorrect_type.mvir
@@ -4,7 +4,7 @@
 //# publish
 mvir 0x0::m {
     import 0x2::object;
-    struct S has key {
+    public struct S has key {
         id: bool
     }
 }

--- a/crates/sui-verifier-transactional-tests/tests/struct_with_key/key_struct_id_field_valid.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/struct_with_key/key_struct_id_field_valid.mvir
@@ -4,7 +4,7 @@
 //# publish
 mvir 0x0::m {
     import 0x2::object;
-    struct S has key {
+    public struct S has key {
         id: object::UID
     }
 }

--- a/crates/sui-verifier-transactional-tests/tests/struct_with_key/key_struct_second_field_id.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/struct_with_key/key_struct_second_field_id.mvir
@@ -4,7 +4,7 @@
 //# publish
 mvir 0x0::m {
     import 0x2::object;
-    struct S has key {
+    public struct S has key {
         flag: bool,
         id: object::UID,
     }

--- a/crates/sui-verifier-transactional-tests/tests/struct_with_key/key_struct_with_drop.mvir
+++ b/crates/sui-verifier-transactional-tests/tests/struct_with_key/key_struct_with_drop.mvir
@@ -4,7 +4,7 @@
 //# publish
 mvir 0x0::m {
     import 0x2::object;
-    struct S has key, drop {
+    public struct S has key, drop {
         id: object::UID,
         flag: bool
     }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/ability_field_requirements/resource_enum_has_resource_field.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/ability_field_requirements/resource_enum_has_resource_field.mvir
@@ -1,5 +1,5 @@
 //# publish
 mvir 0x42::Test {
-    struct All has key, store, copy, drop { b: bool }
-    enum T { V { f: Self::All } } // can drop abilities
+    public struct All has key, store, copy, drop { b: bool }
+    public enum T { V { f: Self::All } } // can drop abilities
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/ability_field_requirements/resource_has_resource_field.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/ability_field_requirements/resource_has_resource_field.mvir
@@ -1,5 +1,5 @@
 //# publish
 mvir 0x42::Test {
-    struct All has key, store, copy, drop { b: bool }
-    struct T { f: Self::All } // can drop abilities
+    public struct All has key, store, copy, drop { b: bool }
+    public struct T { f: Self::All } // can drop abilities
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/ability_field_requirements/unrestricted_enum_has_resource_field.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/ability_field_requirements/unrestricted_enum_has_resource_field.mvir
@@ -1,8 +1,8 @@
 //# publish
 mvir 0x42::Test {
 import 0x1::XUS;
-    struct Coin has store { value: u64 }
-    enum T has copy, drop {
+    public struct Coin has store { value: u64 }
+    public enum T has copy, drop {
         V0 { },
         V1 { 
             // does not have copy or drop
@@ -15,7 +15,7 @@ import 0x1::XUS;
 //# publish
 mvir 0x42::Test {
 import 0x1::XUS;
-    enum T has copy, drop {
+    public enum T has copy, drop {
         V0 { },
         V1 { 
             // does not have copy or drop
@@ -23,17 +23,17 @@ import 0x1::XUS;
             fint: u64,
         },
     }
-    enum Coin has store { V { value: u64 } }
+    public enum Coin has store { V { value: u64 } }
 }
 
 //# publish
 mvir 0x42::Test {
 import 0x1::XUS;
-    struct T has copy, drop {
+    public struct T has copy, drop {
         // does not have copy or drop
         fc: Self::Coin,
         fint: u64,
     }
 
-    enum Coin has store { V { value: u64 } }
+    public enum Coin has store { V { value: u64 } }
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/ability_field_requirements/unrestricted_has_resource_field.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/ability_field_requirements/unrestricted_has_resource_field.mvir
@@ -1,8 +1,8 @@
 //# publish
 mvir 0x42::Test {
 import 0x1::XUS;
-    struct Coin has store { value: u64 }
-    struct T has copy, drop {
+    public struct Coin has store { value: u64 }
+    public struct T has copy, drop {
         // does not have copy or drop
         fc: Self::Coin,
         fint: u64,

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_bounds/too_few_type_actuals.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_bounds/too_few_type_actuals.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x1::M {
-    struct S<T> { b: bool }
+    public struct S<T> { b: bool }
 
     fun foo() {
         // missing type arg

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_bounds/too_few_type_actuals_enum.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_bounds/too_few_type_actuals_enum.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x1::M {
-    enum S<T> { V{ b: bool } }
+    public enum S<T> { V{ b: bool } }
 
     fun foo() {
         // missing type arg

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_bounds/too_many_type_actuals.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_bounds/too_many_type_actuals.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x6::M {
-    struct S { b: bool }
+    public struct S { b: bool }
 
     fun foo() {
         // type arg mismatch

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_bounds/too_many_type_actuals_enum.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_bounds/too_many_type_actuals_enum.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x1::M {
-    enum S { V { b: bool } }
+    public enum S { V { b: bool } }
 
     fun foo() {
         // type arg mismatch

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_duplication/duplicate_enum_and_struct_names.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_duplication/duplicate_enum_and_struct_names.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x42::M {
     // duplicate structs and enums
-    struct T{b: bool}
-    enum T{ V{ x: u64 } }
+    public struct T{b: bool}
+    public enum T{ V{ x: u64 } }
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_duplication/duplicate_enum_name.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_duplication/duplicate_enum_name.mvir
@@ -1,7 +1,7 @@
 //# publish
 mvir 0x42::M {
     // duplicate enums 
-    enum T{ V{ b: bool} }
-    enum T{ V{ x: u64} }
+    public enum T{ V{ b: bool} }
+    public enum T{ V{ x: u64} }
 }
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_duplication/duplicate_field_name.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_duplication/duplicate_field_name.mvir
@@ -1,7 +1,7 @@
 //# publish
 mvir 0x1::M {
     // duplicate field of the same name
-    struct T{f: u64, f: u64}
+    public struct T{f: u64, f: u64}
 }
 
 // check: DUPLICATE_ELEMENT

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_duplication/duplicate_field_name_enum.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_duplication/duplicate_field_name_enum.mvir
@@ -1,7 +1,7 @@
 //# publish
 mvir 0x1::M {
     // duplicate field of the same name
-    enum T{ V { f: u64, f: u64 }  }
+    public enum T{ V { f: u64, f: u64 }  }
 }
 
 // check: DUPLICATE_ELEMENT

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_duplication/duplicate_struct_name.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_duplication/duplicate_struct_name.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x42::M {
     // duplicate structs
-    struct T{b: bool}
-    struct T{x: u64}
+    public struct T{b: bool}
+    public struct T{x: u64}
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_duplication/duplicate_variant_name.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_duplication/duplicate_variant_name.mvir
@@ -1,7 +1,7 @@
 //# publish
 mvir 0x1::M {
     // duplicate variant of the same name
-    enum T { 
+    public enum T { 
         V { },
         V { f: u64, f: u64 }
     }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_duplication/empty_enums.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_duplication/empty_enums.mvir
@@ -1,7 +1,7 @@
 //# publish
 mvir 0x1::EmptyStruct {
   // no empty enums allowed
-  enum Empty { }
+  public enum Empty { }
 
 }
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_duplication/empty_structs.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_duplication/empty_structs.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x1::EmptyStruct {
   // no empty structs allowed
-  struct Empty { }
+  public struct Empty { }
 
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/control_flow/last_jump_unconditional_drop.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/control_flow/last_jump_unconditional_drop.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x1::test {
-    struct HotPotato { value: u64 }
+    public struct HotPotato { value: u64 }
     public fun get_hot_potato(): Self::HotPotato {
         label l0:
         return HotPotato { value: 42 };

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/control_flow/variant_switch.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/control_flow/variant_switch.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x1::PolymorphicEnums {
-    enum EnumWithTwoVariants<T> {
+    public enum EnumWithTwoVariants<T> {
         One { },
         Two { x: T }
     }
@@ -26,7 +26,7 @@ mvir 0x1::PolymorphicEnums {
 
 //# publish
 mvir 0x2::MonomorphicEnums {
-    enum EnumWithTwoVariants {
+    public enum EnumWithTwoVariants {
         One { },
         Two { x: u64 }
     }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/control_flow/variant_switch_successor.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/control_flow/variant_switch_successor.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x42::m {
-    enum X  { A { }, B { } }
+    public enum X  { A { }, B { } }
 
     fun foo(x: Self::X) {
         label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/control_flow/variant_switch_unconditional_branch.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/control_flow/variant_switch_unconditional_branch.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x42::m { 
-    enum X { V1 { x: u64 }, V2 { } }
+    public enum X { V1 { x: u64 }, V2 { } }
 
     entry fun foo(x: Self::X) {
         let y: u64;

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/dependencies/all_fields_accessible.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/dependencies/all_fields_accessible.mvir
@@ -1,7 +1,7 @@
 //# publish
 mvir 0x42::M {
-    struct A{x: u64}
-    struct B has drop {y: u64}
+    public struct A{x: u64}
+    public struct B has drop {y: u64}
 
     public fun a(x: u64): Self::A {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/dependencies/internal_function_invalid_call.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/dependencies/internal_function_invalid_call.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x42::Test {
-    struct T has drop {value: u64}
+    public struct T has drop {value: u64}
 
     fun initial_value(): u64 {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/dependencies/non_internal_function_valid_call.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/dependencies/non_internal_function_valid_call.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x42::Test {
-    struct T has drop {value: u64}
+    public struct T has drop {value: u64}
 
     fun initial_value(): u64 {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/enum_defs/enum_match.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/enum_defs/enum_match.mvir
@@ -1,7 +1,7 @@
 //# publish
 mvir 0x42::m {
 
-    enum Threes<T> has {
+    public enum Threes<T> has {
         One { pos0: T } ,
         Two{},
         Three { pos0: T }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/enum_defs/enum_match_out_of_bounds.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/enum_defs/enum_match_out_of_bounds.mvir
@@ -1,7 +1,7 @@
 //# publish
 mvir 0x42::m {
 
-    enum Threes<T> has {
+    public enum Threes<T> has {
         One { pos0: T } ,
         Two{},
         Three { pos0: T }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/enum_defs/module_enum_shared_name.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/enum_defs/module_enum_shared_name.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x42::M {
-    enum M has drop { V { } }
+    public enum M has drop { V { } }
     public fun new(): Self::M {
     label b0:
         return M::V { };

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/enum_defs/module_enum_struct_shared_name.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/enum_defs/module_enum_struct_shared_name.mvir
@@ -1,5 +1,5 @@
 //# publish
 mvir 0x42::m {
-    struct X { x: bool }
-    enum X { V { x: bool } }
+    public struct X { x: bool }
+    public enum X { V { x: bool } }
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/enum_defs/mutual_recursive_enum.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/enum_defs/mutual_recursive_enum.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x42::M {
     // cannot have mutually recursive enums
-    enum A{ V { b: Self::B } }
-    enum B{ V { a: Self::A } }
+    public enum A{ V { b: Self::B } }
+    public enum B{ V { a: Self::A } }
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/enum_defs/recursive_enum.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/enum_defs/recursive_enum.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x1::Cup {
-    enum Cup<T> { V { f: T } }
+    public enum Cup<T> { V { f: T } }
     public fun cup<T>(f: T): Self::Cup<T> {
     label b0:
         return Cup::V<T> { f: move(f) };
@@ -10,14 +10,14 @@ mvir 0x1::Cup {
 //# publish
 mvir 0x1::M0 {
     // recursive enum
-    enum Foo { V { f: Self::Foo } }
+    public enum Foo { V { f: Self::Foo } }
 }
 
 //# publish
 mvir 0x1::M1 {
     import 0x1::Cup;
     // recursive enum
-    enum Foo { V { f: Cup::Cup<Self::Foo> } }
+    public enum Foo { V { f: Cup::Cup<Self::Foo> } }
 
     // would blow up the stack
     public fun foo(): Self::Foo {
@@ -31,8 +31,8 @@ mvir 0x1::M1 {
 mvir 0x1::M2 {
     import 0x1::signer;
 
-    enum X { V { y: vector<Self::Y> } }
-    enum Y { V { x: vector<Self::X> } }
+    public enum X { V { y: vector<Self::Y> } }
+    public enum Y { V { x: vector<Self::X> } }
 }
 
 //# publish
@@ -40,7 +40,7 @@ mvir 0x1::M3 {
     import 0x1::Cup;
 
     // recursive enum
-    enum Foo { V { f: Cup::Cup<Self::Foo> } }
+    public enum Foo { V { f: Cup::Cup<Self::Foo> } }
 
 }
 
@@ -49,8 +49,8 @@ mvir 0x1::M3 {
     import 0x1::Cup;
 
     // indirect recursive enum
-    enum A { V { b: Self::B } }
-    enum B { V { c: Self::C } }
-    enum C { V { d: vector<Self::D> } }
-    enum D { V { x: Cup::Cup<Cup::Cup<Cup::Cup<Self::A>>> } }
+    public enum A { V { b: Self::B } }
+    public enum B { V { c: Self::C } }
+    public enum C { V { d: vector<Self::D> } }
+    public enum D { V { x: Cup::Cup<Cup::Cup<Cup::Cup<Self::A>>> } }
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/enum_defs/ref_in_enum.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/enum_defs/ref_in_enum.mvir
@@ -1,19 +1,19 @@
 //# publish
 mvir 0x42::M1 {
-    enum S { V { x: &u64 } }
+    public enum S { V { x: &u64 } }
 }
 
 //# publish
 mvir 0x42::M2 {
-    enum S { V { x: &mut u64 } }
+    public enum S { V { x: &mut u64 } }
 }
 
 //# publish
 mvir 0x42::M3 {
-    enum S<T> { V { t: &T } }
+    public enum S<T> { V { t: &T } }
 }
 
 //# publish
 mvir 0x42::M4 {
-    enum S<T> { V { t: &mut T } }
+    public enum S<T> { V { t: &mut T } }
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/complex_1.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/complex_1.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x6::M {
-    struct S<T> { b: bool }
+    public struct S<T> { b: bool }
 
     fun a<T>() {
     label b0:
@@ -52,7 +52,7 @@ mvir 0x6::M {
 
 //# publish
 mvir 0x7::M2 {
-    struct S<T> { b: bool }
+    public struct S<T> { b: bool }
 
     fun f<T>() {
     label b0:
@@ -72,7 +72,7 @@ mvir 0x7::M2 {
 //# publish
 
 mvir 0x8::M3 {
-    struct S<T> { b: bool }
+    public struct S<T> { b: bool }
 
     fun a<T>() {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/complex_1_enum.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/complex_1_enum.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x6::M {
-    enum S<T> { V{ b: bool } }
+    public enum S<T> { V{ b: bool } }
 
     fun a<T>() {
     label b0:
@@ -52,7 +52,7 @@ mvir 0x6::M {
 
 //# publish
 mvir 0x7::M2 {
-    enum S<T> { V { b: bool } }
+    public enum S<T> { V { b: bool } }
 
     fun f<T>() {
     label b0:
@@ -72,7 +72,7 @@ mvir 0x7::M2 {
 //# publish
 
 mvir 0x8::M3 {
-    enum S<T> { V{ b: bool } }
+    public enum S<T> { V{ b: bool } }
 
     fun a<T>() {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_non_generic_type_ok.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_non_generic_type_ok.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x6::M {
-    struct S<T> { b: bool }
+    public struct S<T> { b: bool }
 
     fun f<T>() {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_non_generic_type_ok_enum.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_non_generic_type_ok_enum.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x6::M {
-    enum S<T> { V{ b: bool } }
+    public enum S<T> { V{ b: bool } }
 
     fun f<T>() {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_three_args_type_con_non_generic_types_ok.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_three_args_type_con_non_generic_types_ok.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x6::M {
-    struct S<T> { b: bool }
+    public struct S<T> { b: bool }
 
     fun f<T1, T2, T3>() {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_three_args_type_con_non_generic_types_ok_enum.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_three_args_type_con_non_generic_types_ok_enum.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x1::M {
-    enum S<T> { V { b: bool } }
+    public enum S<T> { V { b: bool } }
 
     fun f<T1, T2, T3>() {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_three_args_type_con_shifting.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_three_args_type_con_shifting.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x6::M {
-    struct S<T> { b: bool }
+    public struct S<T> { b: bool }
 
     fun f<T1, T2, T3>() {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_three_args_type_con_shifting_enum.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_three_args_type_con_shifting_enum.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x6::M {
-    enum S<T> { V{ b: bool } }
+    public enum S<T> { V{ b: bool } }
 
     fun f<T1, T2, T3>() {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_two_args_swapping_type_con.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_two_args_swapping_type_con.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x6::M {
-    struct S<T> { b: bool }
+    public struct S<T> { b: bool }
 
     fun f<T1, T2>() {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_two_args_swapping_type_con_enum.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_two_args_swapping_type_con_enum.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x6::M {
-    enum S<T> { V { b: bool } }
+    public enum S<T> { V { b: bool } }
 
     fun f<T1, T2>() {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_type_con.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_type_con.mvir
@@ -4,7 +4,7 @@
 //           f<T>, g<S<T>>, f<S<T>>, g<S<S<T>>>, ...
 
 mvir 0x6::M {
-    struct S<T> { b: bool }
+    public struct S<T> { b: bool }
 
     fun f<T>() {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_type_con_enum.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_type_con_enum.mvir
@@ -4,7 +4,7 @@
 //           f<T>, g<S<T>>, f<S<T>>, g<S<S<T>>>, ...
 
 mvir 0x6::M {
-    enum S<T> { V { b: bool } }
+    public enum S<T> { V { b: bool } }
 
     fun f<T>() {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/nested_types_1.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/nested_types_1.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x1::M {
-    struct S<T> { b: bool }
+    public struct S<T> { b: bool }
 
     fun foo<T>() {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/nested_types_1_enum.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/nested_types_1_enum.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x6::M {
-    enum S<T> { V { b: bool }, R { } }
+    public enum S<T> { V { b: bool }, R { } }
 
     fun foo<T>() {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/nested_types_2.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/nested_types_2.mvir
@@ -1,8 +1,8 @@
 //# publish
 
 mvir 0x6::M {
-    struct S<T> { b: bool }
-    struct R<T1, T2> { b: bool }
+    public struct S<T> { b: bool }
+    public struct R<T1, T2> { b: bool }
 
     fun foo<T>() {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/nested_types_2_enum.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/nested_types_2_enum.mvir
@@ -1,8 +1,8 @@
 //# publish
 
 mvir 0x1::M {
-    enum S<T> { V{ b: bool } }
-    enum R<T1, T2> { V{ b: bool } }
+    public enum S<T> { V{ b: bool } }
+    public enum R<T1, T2> { V{ b: bool } }
 
     fun foo<T>() {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/nested_types_2_enum_struct.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/nested_types_2_enum_struct.mvir
@@ -1,8 +1,8 @@
 //# publish
 
 mvir 0x6::M {
-    struct S<T> { b: bool }
-    enum R<T1, T2> { V{ b: bool } }
+    public struct S<T> { b: bool }
+    public enum R<T1, T2> { V{ b: bool } }
 
     fun foo<T>() {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/recursive_infinite_type_terminates.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/recursive_infinite_type_terminates.mvir
@@ -1,7 +1,7 @@
 //# publish
 
 mvir 0x6::M {
-    struct Box<T> { x: T }
+    public struct Box<T> { x: T }
 
     fun unbox<T>(b: Self::Box<T>): T {
         let x: T;

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/recursive_one_arg_type_con.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/recursive_one_arg_type_con.mvir
@@ -3,7 +3,7 @@
 // Bad! Can have infinitely many instances: f<T>, f<S<T>>, f<S<S<T>>>, ...
 
 mvir 0x6::M {
-    struct S<T> { b: bool }
+    public struct S<T> { b: bool }
 
     fun f<T>(x: T) {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/recursive_one_arg_type_con_enum.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/recursive_one_arg_type_con_enum.mvir
@@ -3,7 +3,7 @@
 // Bad! Can have infinitely many instances: f<T>, f<S<T>>, f<S<S<T>>>, ...
 
 mvir 0x6::M {
-    enum S<T> { V{ b: bool } }
+    public enum S<T> { V{ b: bool } }
 
     fun f<T>(x: T) {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/recursive_two_args_swapping_type_con.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/recursive_two_args_swapping_type_con.mvir
@@ -4,7 +4,7 @@
 // f<T1, T2> => f<S<T2>, T1> => f<S<T1>, S<T2>> => f<S<S<T2>>, S<T1>> => ...
 
 mvir 0x1::M {
-    struct S<T> { x: T }
+    public struct S<T> { x: T }
 
     fun f<T1, T2>(a: T1, b: T2) {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/recursive_two_args_swapping_type_con_enum.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/recursive_two_args_swapping_type_con_enum.mvir
@@ -4,7 +4,7 @@
 // f<T1, T2> => f<S<T2>, T1> => f<S<T1>, S<T2>> => f<S<S<T2>>, S<T1>> => ...
 
 mvir 0x6::M {
-    enum S<T> { V{ x: T } }
+    public enum S<T> { V{ x: T } }
 
     fun f<T1, T2>(a: T1, b: T2) {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/two_loops.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/two_loops.mvir
@@ -4,7 +4,7 @@
 // One error for the loop.
 
 mvir 0x6::M {
-    struct S<T> { b: bool }
+    public struct S<T> { b: bool }
 
     fun f<T>() {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/two_loops_enum.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/two_loops_enum.mvir
@@ -4,7 +4,7 @@
 // One error for the loop.
 
 mvir 0x6::M {
-    enum S<T> { V { b: bool } }
+    public enum S<T> { V { b: bool } }
 
     fun f<T>() {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/abort_unused_resource.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/abort_unused_resource.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x1::M {
-    struct Coin { value: u64 }
+    public struct Coin { value: u64 }
     fun zero(): Self::Coin {
     label b0:
         return Coin { value: 0 };

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/assign_enum_resource.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/assign_enum_resource.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x1::M {
-    enum EnumValue {
+    public enum EnumValue {
         Nothing { },
         Coin { value: u64 }
     }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/assign_resource.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/assign_resource.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x1::M {
-    struct Coin { value: u64 }
+    public struct Coin { value: u64 }
     fun zero(): Self::Coin {
     label b0:
         return Coin { value: 0 };

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/enum_non_drop_assignment.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/enum_non_drop_assignment.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x1::Enums {
-    enum PolyEnumWithTwoVariants<T> {
+    public enum PolyEnumWithTwoVariants<T> {
         One { },
         Two { x: T }
     }
@@ -23,9 +23,9 @@ mvir 0x1::Enums {
 
 //# publish
 mvir 0x1::Enums {
-    struct X { b: bool }
+    public struct X { b: bool }
 
-    enum MonoEnumWithTwoVariants {
+    public enum MonoEnumWithTwoVariants {
         One { },
         Two { x: Self::X }
     }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/join_failure.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/join_failure.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x1::M {
-    struct R { f:bool }
+    public struct R { f:bool }
     fun t0() {
         let r: Self::R;
         let f: bool;
@@ -21,7 +21,7 @@ mvir 0x1::M {
 
 //# publish
 mvir 0x1::M {
-    struct R { f:bool }
+    public struct R { f:bool }
     fun t0() {
         let r: Self::R;
         let f: bool;
@@ -41,7 +41,7 @@ mvir 0x1::M {
 
 //# publish
 mvir 0x1::M {
-    struct R { f:bool }
+    public struct R { f:bool }
     fun t0() {
         let r: Self::R;
         let f: bool;
@@ -62,7 +62,7 @@ mvir 0x1::M {
 
 //# publish
 mvir 0x1::M {
-    struct R has copy, drop { f:bool }
+    public struct R has copy, drop { f:bool }
     fun t0() {
         let r: Self::R;
         let f: bool;
@@ -83,7 +83,7 @@ mvir 0x1::M {
 
 //# publish
 mvir 0x1::M {
-    struct R { f:bool }
+    public struct R { f:bool }
     fun t0() {
         let r: Self::R;
         let ref: &Self::R;

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/vector_ops_non_droppable_resource_not_destroyed.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/vector_ops_non_droppable_resource_not_destroyed.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x1::M {
-    struct R has store { b: bool }
+    public struct R has store { b: bool }
     fun f() {
         let v: vector<Self::R>;
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/abstract_state/borrow_field_if_else.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/abstract_state/borrow_field_if_else.mvir
@@ -4,7 +4,7 @@
 
 mvir 0x2::borrow_field_if_else {
 
-struct S has copy, drop {
+public struct S has copy, drop {
     f: u64,
     g: u64,
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/abstract_state/impossible_loop.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/abstract_state/impossible_loop.mvir
@@ -5,11 +5,11 @@
 
 mvir 0x2::loopy {
 
-struct List has copy, drop {
+public struct List has copy, drop {
     dummy: bool,
 }
 
-struct Node has copy, drop {
+public struct Node has copy, drop {
     val: u8,
     next: Self::List,
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/assign_field_after_local.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/assign_field_after_local.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x42::Tester {
-    struct T has drop {v: u64}
+    public struct T has drop {v: u64}
 
     public fun new(v: u64): Self::T  {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/assign_local_struct.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/assign_local_struct.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x42::Tester {
-    struct T has drop {v: u64}
+    public struct T has drop {v: u64}
 
     public fun new(v: u64): Self::T  {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/assign_local_struct_invalidated.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/assign_local_struct_invalidated.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x42::Tester {
-    struct T has drop {v: u64}
+    public struct T has drop {v: u64}
 
     public fun new(v: u64): Self::T  {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/borrow_copy_ok.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/borrow_copy_ok.mvir
@@ -1,7 +1,7 @@
 //# publish
 
 mvir 0x1::B {
-    struct T has drop {g: u64}
+    public struct T has drop {g: u64}
 
     public fun new(g: u64): Self::T {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/borrow_enum_field_mutable_invalid.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/borrow_enum_field_mutable_invalid.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x1::M {
-    enum E has drop {
+    public enum E has drop {
         V { f0: u64 }
     }
 
@@ -27,7 +27,7 @@ mvir 0x1::M {
 
 //# publish
 mvir 0x1::M1 {
-    enum E has drop {
+    public enum E has drop {
         V { f0: u64 }
     }
 
@@ -58,7 +58,7 @@ mvir 0x1::M1 {
 
 //# publish
 mvir 0x1::M2 {
-    enum E has drop {
+    public enum E has drop {
         V { f0: u64 }
     }
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/borrow_field_ok.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/borrow_field_ok.mvir
@@ -1,8 +1,8 @@
 //# publish
 mvir 0x1::A {
 
-    struct T has drop {v: u64}
-    struct K has drop {f: Self::T}
+    public struct T has drop {v: u64}
+    public struct K has drop {f: Self::T}
 
     public fun new_T(v: u64) : Self::T {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/borrow_owned_enum.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/borrow_owned_enum.mvir
@@ -2,7 +2,7 @@
 
 mvir 0x2::borrow_owned_enum {
 
-enum E has drop {
+public enum E has drop {
     A { a: u64, b: u64, c: u64, d: u64, e: u64, f: u64, g: u64, h: u64,
         i: u64, j: u64, k: u64, l: u64, m: u64, n: u64, o: u64, p: u64 },
     B {}

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/borrow_return_mutable_borrow_bad.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/borrow_return_mutable_borrow_bad.mvir
@@ -1,7 +1,7 @@
 //# publish
 mvir 0x1::M {
-    struct X { f: Self::Y }
-    struct Y { g: u64, h: u64 }
+    public struct X { f: Self::Y }
+    public struct Y { g: u64, h: u64 }
 
     fun t1(ref_x: &mut Self::X): &mut Self::Y * &u64  {
         let ref_x_f: &mut Self::Y;

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/call_with_mut_and_imm.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/call_with_mut_and_imm.mvir
@@ -3,7 +3,7 @@
 //# publish
 
 mvir 0x1::Tester {
-    struct T has copy { f: u64, g: u64, h: u64 }
+    public struct T has copy { f: u64, g: u64, h: u64 }
 
     fun borrow(s1: &mut Self::T): &mut u64 * &mut u64 * &u64 * &u64 {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/copy_loc_borrowed_field.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/copy_loc_borrowed_field.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x1::Tester {
-    struct T has copy { f: u64 }
+    public struct T has copy { f: u64 }
 
     fun t() {
         let x: Self::T;

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/copy_loc_borrowed_field_invalid.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/copy_loc_borrowed_field_invalid.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x1::Tester {
-    struct T has copy { f: u64 }
+    public struct T has copy { f: u64 }
 
     fun t() {
         let x: Self::T;

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/deref_borrow_field_ok.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/deref_borrow_field_ok.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x1::M {
-    struct T has drop {f: u64}
+    public struct T has drop {f: u64}
 
     public fun new(g: u64): Self::T {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/deref_eq_bad.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/deref_eq_bad.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x1::M {
-    struct T {v : u64}
+    public struct T {v : u64}
 
     public fun new(v: u64): Self::T {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/deref_eq_good.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/deref_eq_good.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x1::M {
-    struct T {v : u64}
+    public struct T {v : u64}
 
     public fun new(v: u64): Self::T {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/double_enum_unpack.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/double_enum_unpack.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x1::o {
-    enum X has drop { 
+    public enum X has drop { 
         One { x: u64, y: u64 },
         Two { x: u64, y: u64},
     }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/enum_variant_factor.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/enum_variant_factor.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x1::o1 {
-    enum X has drop {
+    public enum X has drop {
         Empty { },
         One { x: u64, y: u64 },
     }
@@ -18,7 +18,7 @@ mvir 0x1::o1 {
 
 //# publish
 mvir 0x1::o2 {
-    enum X has drop {
+    public enum X has drop {
         One { x: u64, y: u64 },
         Two { x: u64, y: u64},
     }
@@ -37,7 +37,7 @@ mvir 0x1::o2 {
 
 //# publish
 mvir 0x1::o3 {
-    enum X has drop {
+    public enum X has drop {
         One { x: u64, y: u64 },
         Two { x: u64, y: u64},
     }
@@ -55,7 +55,7 @@ mvir 0x1::o3 {
 
 //# publish
 mvir 0x1::o4 {
-    enum X has drop {
+    public enum X has drop {
         One { x: u64, y: u64 },
         Two { x: u64, y: u64},
     }
@@ -75,7 +75,7 @@ mvir 0x1::o4 {
 
 //# publish
 mvir 0x1::o5 {
-    enum X has drop {
+    public enum X has drop {
         One { x: u64, y: u64 },
         Two { x: u64, y: u64},
     }
@@ -95,7 +95,7 @@ mvir 0x1::o5 {
 
 //# publish
 mvir 0x1::invalid {
-    enum X has drop {
+    public enum X has drop {
         One { x: u64 },
         Two { x: u64, y: u64},
     }
@@ -119,7 +119,7 @@ mvir 0x1::invalid {
 
 //# publish
 mvir 0x1::invalid2 {
-    enum X has drop {
+    public enum X has drop {
         One { x: u64 },
         Two { x: u64, y: u64},
     }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/expressivity/extension_after_call.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/expressivity/extension_after_call.mvir
@@ -4,8 +4,8 @@
 
 mvir 0x2::Tester {
 
-struct Point has copy, drop, store { x: u64, y: u64 }
-struct Box has copy, drop, store { tl: Self::Point, br: Self::Point }
+public struct Point has copy, drop, store { x: u64, y: u64 }
+public struct Box has copy, drop, store { tl: Self::Point, br: Self::Point }
 
 fun borrow(p: &mut Self::Box): &mut Self::Point {
 label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/expressivity/extension_writes_after_join.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/expressivity/extension_writes_after_join.mvir
@@ -4,7 +4,7 @@
 
 mvir 0x2::extension_after_join {
 
-struct S has copy, drop, store { f: u64 }
+public struct S has copy, drop, store { f: u64 }
 
 fun t(cond: bool, a: &mut Self::S, b: &mut Self::S): &mut Self::S {
     let x: &mut Self::S;

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/expressivity/imm_borrow_after_mut_fields.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/expressivity/imm_borrow_after_mut_fields.mvir
@@ -3,7 +3,7 @@
 //# publish
 mvir 0x2::field {
 
-    struct S has copy, drop { f: u64 }
+    public struct S has copy, drop { f: u64 }
 
     fun t(s: Self::S) {
         let s_imm: &Self::S;
@@ -20,7 +20,7 @@ mvir 0x2::field {
 //# publish
 mvir 0x3::field {
 
-    struct S has copy, drop { f: u64 }
+    public struct S has copy, drop { f: u64 }
 
     fun t(s: Self::S) {
         let s_imm: &Self::S;
@@ -38,7 +38,7 @@ mvir 0x3::field {
 //# publish
 mvir 0x4::invalid_write {
 
-    struct S has copy, drop { f: u64 }
+    public struct S has copy, drop { f: u64 }
 
     fun t(s: Self::S) {
         let s_imm: &Self::S;

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/expressivity/multible_mutable_return_values.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/expressivity/multible_mutable_return_values.mvir
@@ -4,7 +4,7 @@
 
 mvir 0x2::Tester {
 
-struct Point has copy, drop, store { x: u64, y: u64 }
+public struct Point has copy, drop, store { x: u64, y: u64 }
 
 fun borrow(p: &mut Self::Point): &mut u64 * &mut u64 {
 label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/expressivity/mutable_borrows_are_not_unique.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/expressivity/mutable_borrows_are_not_unique.mvir
@@ -3,8 +3,8 @@
 //# publish
 mvir 0x2::fields {
 
-    struct S has copy, drop { f: u64 }
-    struct Pair has copy, drop { s1: Self::S, s2: Self::S }
+    public struct S has copy, drop { f: u64 }
+    public struct Pair has copy, drop { s1: Self::S, s2: Self::S }
 
     fun create(p: &mut Self::Pair) {
         // mutable variables are not unique. Nor do they take ownership over their memory
@@ -37,8 +37,8 @@ mvir 0x2::fields {
 //# publish
 mvir 0x3::fields_write {
 
-    struct S has copy, drop { f: u64 }
-    struct Pair has copy, drop { s1: Self::S, s2: Self::S }
+    public struct S has copy, drop { f: u64 }
+    public struct Pair has copy, drop { s1: Self::S, s2: Self::S }
 
     fun write(p: &mut Self::Pair) {
         // We can do the same thing, and write to them

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/expressivity/mutable_borrows_are_not_unique_calls.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/expressivity/mutable_borrows_are_not_unique_calls.mvir
@@ -3,7 +3,7 @@
 //# publish
 mvir 0x4::call {
 
-    struct S has copy, drop { f: u64 }
+    public struct S has copy, drop { f: u64 }
 
     fun borrow_f(s: &mut Self::S): &mut u64 {
     label b0:
@@ -29,7 +29,7 @@ mvir 0x4::call {
 //# publish
 mvir 0x5::call_and_write_invalid {
 
-    struct S has copy, drop { f: u64 }
+    public struct S has copy, drop { f: u64 }
 
     fun borrow_f(s: &mut Self::S): &mut u64 {
     label b0:
@@ -57,7 +57,7 @@ mvir 0x5::call_and_write_invalid {
 //# publish
 mvir 0x6::call_and_write_valid {
 
-    struct S has copy, drop { f: u64 }
+    public struct S has copy, drop { f: u64 }
 
     fun borrow_f(s: &mut Self::S): &mut u64 {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/expressivity/simple_dangling.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/expressivity/simple_dangling.mvir
@@ -2,7 +2,7 @@
 
 //# publish
 mvir 0x2::field {
-    struct S has copy, drop { f: u64 }
+    public struct S has copy, drop { f: u64 }
     fun t(s: &mut Self::S) {
         let f: &u64;
     label b0:
@@ -14,8 +14,8 @@ mvir 0x2::field {
 
 //# publish
 mvir 0x3::nested_field {
-    struct S has copy, drop { f: u64 }
-    struct P has copy, drop { s: Self::S }
+    public struct S has copy, drop { f: u64 }
+    public struct P has copy, drop { s: Self::S }
     fun t(p: &mut Self::P) {
         let s: &mut Self::S;
         let f: &u64;
@@ -62,7 +62,7 @@ mvir 0x5::simple_call {
 
 //# publish
 mvir 0x5::field_call {
-    struct S has copy, drop { f: u64 }
+    public struct S has copy, drop { f: u64 }
 
     fun f(r: &mut Self::S): &u64 {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/expressivity/subtree_writes_release.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/expressivity/subtree_writes_release.mvir
@@ -4,9 +4,9 @@
 
 mvir 0x2::extension_after_join {
 
-struct Tree has copy, drop, store { l: Self::Sub1, r: Self::Sub1 }
-struct Sub1 has copy, drop, store { l: Self::Sub2, r: Self::Sub2 }
-struct Sub2 has copy, drop, store { l: u64, r: u64 }
+public struct Tree has copy, drop, store { l: Self::Sub1, r: Self::Sub1 }
+public struct Sub1 has copy, drop, store { l: Self::Sub2, r: Self::Sub2 }
+public struct Sub2 has copy, drop, store { l: u64, r: u64 }
 
 fun t(cond: bool, root: &mut Self::Tree) {
     let x: &mut Self::Sub1;

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/factor_invalid_1.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/factor_invalid_1.mvir
@@ -1,7 +1,7 @@
 //# publish
 mvir 0x1::M {
-    struct X has drop { f: Self::Y }
-    struct Y has drop { g: u64, h: u64 }
+    public struct X has drop { f: Self::Y }
+    public struct Y has drop { g: u64, h: u64 }
 
     fun t1() {
         let x: Self::X;
@@ -29,8 +29,8 @@ mvir 0x1::M {
 
 //# publish
 mvir 0x1::M2 {
-    struct X has drop { f: Self::Y }
-    struct Y has drop { g: u64, h: u64 }
+    public struct X has drop { f: Self::Y }
+    public struct Y has drop { g: u64, h: u64 }
     fun t2() {
         let x: Self::X;
         let ref_x: &mut Self::X;

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/factor_invalid_2.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/factor_invalid_2.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x1::M {
-    struct S { g: u64 }
+    public struct S { g: u64 }
 
     fun t1(root: &mut Self::S, cond: bool) {
         let x1: u64;

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/factor_invalid_2_enum.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/factor_invalid_2_enum.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x1::M {
-    enum S { V { g: u64 } }
+    public enum S { V { g: u64 } }
 
     fun t1(root: &mut Self::S, cond: bool) {
         let x1: u64;

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/factor_valid_1.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/factor_valid_1.mvir
@@ -1,7 +1,7 @@
 //# publish
 mvir 0x1::M {
-    struct X has drop { f: Self::Y }
-    struct Y has drop { g: u64, h: u64 }
+    public struct X has drop { f: Self::Y }
+    public struct Y has drop { g: u64, h: u64 }
 
     // tests deep borrows + releases
     fun t1() {

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/factor_valid_2.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/factor_valid_2.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x1::M {
-    struct S { g: u64 }
+    public struct S { g: u64 }
 
     fun t1(root: &mut Self::S, cond: bool) {
         let x1: u64;

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/imm_borrow_loc.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/imm_borrow_loc.mvir
@@ -1,8 +1,8 @@
 //# publish
 mvir 0x1::Tester {
 
-    struct Data has key { v1: u64, v2: u64 }
-    struct Box has key { f: u64 }
+    public struct Data has key { v1: u64, v2: u64 }
+    public struct Box has key { f: u64 }
 
     // the key struct is here to just give a feeling why the computation might not be reorderable
     fun bump_and_pick(data: &mut Self::Data, b1: &mut Self::Box, b2: &mut Self::Box): &u64 {

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/imm_borrow_loc_trivial.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/imm_borrow_loc_trivial.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x1::Tester {
-    struct X has key { f: u64 }
+    public struct X has key { f: u64 }
 
     fun bump_and_give(x_ref: &mut Self::X, other: &u64): &u64 {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/imm_borrow_loc_trivial_valid.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/imm_borrow_loc_trivial_valid.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x1::Tester {
-    struct X has key { f: u64 }
+    public struct X has key { f: u64 }
 
     fun bump_and_give(x_ref: &mut Self::X, other: &u64): &u64 {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/imm_borrow_loc_valid.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/imm_borrow_loc_valid.mvir
@@ -1,8 +1,8 @@
 //# publish
 mvir 0x1::Tester {
 
-    struct Data has key { v1: u64, v2: u64 }
-    struct Box has key { f: u64 }
+    public struct Data has key { v1: u64, v2: u64 }
+    public struct Box has key { f: u64 }
 
     // the key struct is here to just give a feeling why the computation might not be reorderable
     fun bump_and_pick(data: &mut Self::Data, b1: &mut Self::Box, b2: &mut Self::Box): &u64  {

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/imm_borrow_on_mut.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/imm_borrow_on_mut.mvir
@@ -1,8 +1,8 @@
 //# publish
 mvir 0x1::Tester {
 
-    struct Initializer has key { x: u64, y: u64 }
-    struct Point { x: u64, y: u64 }
+    public struct Initializer has key { x: u64, y: u64 }
+    public struct Point { x: u64, y: u64 }
 
     // the key struct is here to just give a feeling why the computation might not be reorderable
     fun set_and_pick(init: &mut Self::Initializer, p: &mut Self::Point): &mut u64 {

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/imm_borrow_on_mut_invalid.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/imm_borrow_on_mut_invalid.mvir
@@ -1,8 +1,8 @@
 //# publish
 mvir 0x1::Tester {
 
-    struct Initializer has key { x: u64, y: u64 }
-    struct Point { x: u64, y: u64 }
+    public struct Initializer has key { x: u64, y: u64 }
+    public struct Point { x: u64, y: u64 }
 
     // the key struct is here to just give a feeling why the computation might not be reorderable
     fun set_and_pick(init: &mut Self::Initializer, p: &mut Self::Point): &mut u64 {
@@ -48,8 +48,8 @@ mvir 0x1::Tester {
 //# publish
 mvir 0x1::Tester2 {
 
-    struct Initializer has key { x: u64, y: u64 }
-    struct Point { x: u64, y: u64 }
+    public struct Initializer has key { x: u64, y: u64 }
+    public struct Point { x: u64, y: u64 }
 
     // the key struct is here to just give a feeling why the computation might not be reorderable
     fun set_and_pick(init: &mut Self::Initializer, p: &mut Self::Point): &mut u64 {

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/imm_borrow_on_mut_invalid_enum.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/imm_borrow_on_mut_invalid_enum.mvir
@@ -1,8 +1,8 @@
 //# publish
 mvir 0x42::Tester {
 
-    enum Initializer { V { x: u64, y: u64 } }
-    enum Point { V { x: u64, y: u64 } }
+    public enum Initializer { V { x: u64, y: u64 } }
+    public enum Point { V { x: u64, y: u64 } }
 
     // the key struct is here to just give a feeling why the computation might not be reorderable
     fun set_and_pick(init: &mut Self::Initializer, p: &mut Self::Point): &mut u64 {
@@ -48,8 +48,8 @@ mvir 0x42::Tester {
 //# publish
 mvir 0x43::Tester {
 
-    enum Initializer { V { x: u64, y: u64 } }
-    enum Point { V { x: u64, y: u64 } }
+    public enum Initializer { V { x: u64, y: u64 } }
+    public enum Point { V { x: u64, y: u64 } }
 
     // the key struct is here to just give a feeling why the computation might not be reorderable
     fun set_and_pick(init: &mut Self::Initializer, p: &mut Self::Point): &mut u64 {

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/imm_borrow_on_mut_trivial.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/imm_borrow_on_mut_trivial.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x1::Tester {
-    struct X { f: u64 }
+    public struct X { f: u64 }
 
     fun bump_and_give(x_ref: &mut Self::X): &u64 {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/imm_borrow_on_mut_trivial_invalid.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/imm_borrow_on_mut_trivial_invalid.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x1::Tester {
-    struct X { f: u64 }
+    public struct X { f: u64 }
 
     fun bump_and_give(x_ref: &mut Self::X): &u64 {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/imm_borrow_on_mut_trivial_invalid_enum.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/imm_borrow_on_mut_trivial_invalid_enum.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x1::Tester {
-    enum X { V { f: u64 } }
+    public enum X { V { f: u64 } }
 
     fun bump_and_give(x_ref: &mut Self::X): &u64 {
         let f_ref: &mut u64;

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/imm_extends_mut_arg.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/imm_extends_mut_arg.mvir
@@ -3,7 +3,7 @@
 //# publish
 
 mvir 0x2::eps1_freeze {
-    struct T has copy { f: u64 }
+    public struct T has copy { f: u64 }
 
     fun eps1(s: &Self::T, s2: &mut Self::T) {
     label b0:
@@ -23,7 +23,7 @@ mvir 0x2::eps1_freeze {
 //# publish
 
 mvir 0x3::eps2_freeze {
-    struct T has copy { f: u64 }
+    public struct T has copy { f: u64 }
 
     fun eps2(s2: &mut Self::T, s: &Self::T) {
     label b0:
@@ -43,7 +43,7 @@ mvir 0x3::eps2_freeze {
 //# publish
 
 mvir 0x4::eps1_reborrow {
-    struct T has copy, drop { f: u64 }
+    public struct T has copy, drop { f: u64 }
 
     fun eps1(s: &Self::T, s2: &mut Self::T) {
     label b0:
@@ -65,7 +65,7 @@ mvir 0x4::eps1_reborrow {
 //# publish
 
 mvir 0x5::eps2_reborrow {
-    struct T has copy, drop { f: u64 }
+    public struct T has copy, drop { f: u64 }
 
     fun eps2(s2: &mut Self::T, s: &Self::T) {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/imm_extends_mut_arg_field.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/imm_extends_mut_arg_field.mvir
@@ -3,7 +3,7 @@
 //# publish
 
 mvir 0x1::Tester {
-    struct T has copy { f: u64 }
+    public struct T has copy { f: u64 }
 
     fun f1(s: &Self::T, f: &mut u64) {
     label b0:
@@ -26,7 +26,7 @@ mvir 0x1::Tester {
 //# publish
 
 mvir 0x1::Tester {
-    struct T has copy { f: u64 }
+    public struct T has copy { f: u64 }
 
     fun f2(f: &mut u64, s: &Self::T) {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/invalid_enum_ref_unpack.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/invalid_enum_ref_unpack.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x1::o {
-    enum X has drop { 
+    public enum X has drop { 
         One { x: u64 },
         Two { x: u64, y: u64},
     }
@@ -21,7 +21,7 @@ mvir 0x1::o {
 
 //# publish
 mvir 0x1::o {
-    enum X has drop { 
+    public enum X has drop { 
         One { x: u64 },
         Two { x: u64, y: u64},
     }
@@ -48,7 +48,7 @@ mvir 0x1::o {
 
 //# publish
 mvir 0x1::o {
-    enum X has drop { 
+    public enum X has drop { 
         One { x: u64 },
         Two { x: u64, y: u64},
     }
@@ -69,7 +69,7 @@ mvir 0x1::o {
 
 //# publish
 mvir 0x1::o {
-    enum X has drop { 
+    public enum X has drop { 
         One { x: u64 },
         Two { x: u64, y: u64},
     }
@@ -96,7 +96,7 @@ mvir 0x1::o {
 
 //# publish
 mvir 0x1::o {
-    enum X has drop { 
+    public enum X has drop { 
         One { x: u64 },
         Two { x: u64, y: u64},
     }
@@ -115,7 +115,7 @@ mvir 0x1::o {
 
 //# publish
 mvir 0x1::o {
-    enum X has drop { 
+    public enum X has drop { 
         One { x: u64 },
         Two { x: u64, y: u64},
     }
@@ -135,7 +135,7 @@ mvir 0x1::o {
 
 //# publish
 mvir 0x1::o {
-    enum X has drop { 
+    public enum X has drop { 
         One { x: u64 },
         Two { x: u64, y: u64},
     }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/invalid_enum_ref_unpack_loop.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/invalid_enum_ref_unpack_loop.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x1::o {
-    enum X has drop { 
+    public enum X has drop { 
         One { x: u64 },
         Two { x: u64, y: u64},
     }
@@ -38,7 +38,7 @@ mvir 0x1::o {
 
 //# publish
 mvir 0x1::o {
-    enum X has drop { 
+    public enum X has drop { 
         One { x: u64 },
         Two { x: u64, y: u64},
     }
@@ -77,7 +77,7 @@ mvir 0x1::o {
 
 //# publish
 mvir 0x1::o {
-    enum X has drop { 
+    public enum X has drop { 
         One { x: u64 },
         Two { x: u64, y: u64},
     }
@@ -115,7 +115,7 @@ mvir 0x1::o {
 
 //# publish
 mvir 0x1::o {
-    enum X has drop { 
+    public enum X has drop { 
         One { x: u64 },
         Two { x: u64, y: u64},
     }
@@ -156,7 +156,7 @@ mvir 0x1::o {
 
 //# publish
 mvir 0x1::o {
-    enum X has drop { 
+    public enum X has drop { 
         One { x: u64 },
         Two { x: u64, y: u64},
     }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/join_borrow_unavailable_valid.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/join_borrow_unavailable_valid.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x1::M {
-    struct S { f: u64 }
+    public struct S { f: u64 }
 
     fun t1(root: &mut Self::S, cond: bool) {
         let u: u64;

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/mutable_borrow_invalid.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/mutable_borrow_invalid.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x1::M {
-    struct S { f: u64, g: u64, h: u64 }
+    public struct S { f: u64, g: u64, h: u64 }
 
 
     fun t1(root: &mut Self::S, cond: bool) {
@@ -21,7 +21,7 @@ mvir 0x1::M {
 //# publish
 mvir 0x1::M2 {
 
-    struct S { f: u64, g: u64, h: u64 }
+    public struct S { f: u64, g: u64, h: u64 }
 
     fun t2(root: &mut Self::S, cond: bool) {
         let x: &mut u64;

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/mutate_borrow_field_ok.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/mutate_borrow_field_ok.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x42::Test {
-    struct T has drop {v: u64}
+    public struct T has drop {v: u64}
 
     public fun new(g: u64): Self::T {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/mutate_resource_holder.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/mutate_resource_holder.mvir
@@ -1,7 +1,7 @@
 //# publish
 mvir 0x42::A {
-    struct Coin has store { value: u64 }
-    struct T { f: Self::Coin }
+    public struct Coin has store { value: u64 }
+    public struct T { f: Self::Coin }
 
     public fun t(this: &mut Self::T, y: Self::T) {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/mutate_resource_holder_2.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/mutate_resource_holder_2.mvir
@@ -1,7 +1,7 @@
 //# publish
 mvir 0x42::A {
-    struct Coin { balance: u64 }
-    struct A { c: Self::Coin }
+    public struct Coin { balance: u64 }
+    public struct A { c: Self::Coin }
 
     public fun zero(): Self::Coin {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/mutate_with_borrowed_loc_struct_invalid.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/mutate_with_borrowed_loc_struct_invalid.mvir
@@ -1,7 +1,7 @@
 //# publish
 mvir 0x1::M {
-    struct X { b: bool }
-    struct S { z: u64 }
+    public struct X { b: bool }
+    public struct S { z: u64 }
     fun t1() {
         let x: Self::X;
         let y: &Self::X;
@@ -18,8 +18,8 @@ mvir 0x1::M {
 
 //# publish
 mvir 0x1::N {
-    struct X { b: bool }
-    struct S { z: u64 }
+    public struct X { b: bool }
+    public struct S { z: u64 }
     fun t2() {
         let s: Self::S;
         let y: &Self::S;

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/nested_mutate.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/nested_mutate.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x42::B {
-    struct T has drop {g: u64}
+    public struct T has drop {g: u64}
 
     public fun new(g: u64): Self::T {
     label b0:
@@ -21,7 +21,7 @@ mvir 0x42::B {
 //# publish
 mvir 0x43::A {
     import 0x42::B;
-    struct T has drop {f: B::T}
+    public struct T has drop {f: B::T}
 
     public fun new(f: B::T): Self::T {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/read_field_after_assign_local.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/read_field_after_assign_local.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x42::Tester {
-    struct T has drop {v: u64}
+    public struct T has drop {v: u64}
 
     public fun new(v: u64): Self::T  {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/ref_moved_one_branch.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/ref_moved_one_branch.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x1::A {
-    struct S {value: u64}
+    public struct S {value: u64}
 
     public fun t(changed: bool, s: &mut Self::S) {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/return_with_borrowed_loc.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/return_with_borrowed_loc.mvir
@@ -1,7 +1,7 @@
 //# publish
 mvir 0x1::M {
-    struct X has drop { y: Self::Y }
-    struct Y has drop { u: u64 }
+    public struct X has drop { y: Self::Y }
+    public struct Y has drop { u: u64 }
 
     fun t1() {
         let x: u64;

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/return_with_borrowed_loc_invalid.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/return_with_borrowed_loc_invalid.mvir
@@ -1,7 +1,7 @@
 //# publish
 mvir 0x1::M {
-    struct X has drop { y: Self::Y }
-    struct Y has drop { u: u64 }
+    public struct X has drop { y: Self::Y }
+    public struct Y has drop { u: u64 }
 
     fun t1(): &u64 {
         let x: u64;
@@ -16,8 +16,8 @@ mvir 0x1::M {
 
 //# publish
 mvir 0x1::M2 {
-    struct X has drop { y: Self::Y }
-    struct Y has drop { u: u64 }
+    public struct X has drop { y: Self::Y }
+    public struct Y has drop { u: u64 }
     fun t2(): &u64 {
         let x: u64;
         let y: &u64;
@@ -31,8 +31,8 @@ mvir 0x1::M2 {
 
 //# publish
 mvir 0x1::M3 {
-    struct X has drop { y: Self::Y }
-    struct Y has drop { u: u64 }
+    public struct X has drop { y: Self::Y }
+    public struct Y has drop { u: u64 }
     fun t3(): &u64 {
         let s: Self::X;
         let x: &Self::X;
@@ -50,8 +50,8 @@ mvir 0x1::M3 {
 
 //# publish
 mvir 0x1::M4 {
-    struct X has drop { y: Self::Y }
-    struct Y has drop { u: u64 }
+    public struct X has drop { y: Self::Y }
+    public struct Y has drop { u: u64 }
     fun t4(): &u64 {
         let s: Self::X;
         let x: &Self::X;

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/return_with_borrowed_loc_resource_invalid.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/return_with_borrowed_loc_resource_invalid.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x1::M {
-    struct X { u: u64 }
+    public struct X { u: u64 }
 
     fun t() {
         let s: Self::X;

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/simple_mutate.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/simple_mutate.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x42::A {
-    struct T has drop {f: u64}
+    public struct T has drop {f: u64}
 
     public fun new(f: u64): Self::T {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/two_mutable_enum_unpacks.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/two_mutable_enum_unpacks.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x42::M {
-    enum Foo {
+    public enum Foo {
         V { 
             a: u64,
             b: u64,

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/two_mutable_ref.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/two_mutable_ref.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x42::M {
-    struct Foo {
+    public struct Foo {
         a: u64,
         b: u64,
     }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/use_after_move.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/use_after_move.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x42::B {
-    struct T has copy, drop {g: u64}
+    public struct T has copy, drop {g: u64}
 
     public fun new(g: u64): Self::T {
     label b0:
@@ -12,7 +12,7 @@ mvir 0x42::B {
 //# publish
 mvir 0x43::A {
     import 0x42::B;
-    struct T{value: B::T}
+    public struct T{value: B::T}
     public fun new(m: B::T): Self::T {
     label b0:
         return T{value: move(m)};

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/use_prefix_after_move.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/use_prefix_after_move.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x42::B {
-    struct T has copy, drop {g: u64}
+    public struct T has copy, drop {g: u64}
 
     public fun new(g: u64): Self::T {
     label b0:
@@ -19,7 +19,7 @@ mvir 0x42::B {
 //# publish
 mvir 0x43::A {
     import 0x42::B;
-    struct T has drop {f: B::T}
+    public struct T has drop {f: B::T}
 
     public fun new(f: B::T): Self::T {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/use_suffix_after_move.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/use_suffix_after_move.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x42::B {
-    struct T has drop {g: u64}
+    public struct T has drop {g: u64}
 
     public fun new(g: u64): Self::T {
     label b0:
@@ -19,7 +19,7 @@ mvir 0x42::B {
 //# publish
 mvir 0x42::A {
     import 0x42::B;
-    struct T{f: B::T}
+    public struct T{f: B::T}
 
     public fun new(f: B::T): Self::T {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/valid_enum_ref_unpack.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/valid_enum_ref_unpack.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x1::o {
-    enum X has drop { 
+    public enum X has drop { 
         One { x: u64 },
         Two { x: u64, y: u64},
     }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/valid_enum_unpack_loop.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/valid_enum_unpack_loop.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x1::woo {
-    enum X has drop { 
+    public enum X has drop { 
         One { x: u64 },
         Two { x: u64, y: u64},
     }
@@ -40,7 +40,7 @@ mvir 0x1::woo {
 
 //# publish
 mvir 0x1::o {
-    enum X has drop { 
+    public enum X has drop { 
         One { x: u64 },
         Two { x: u64, y: u64},
     }
@@ -79,7 +79,7 @@ mvir 0x1::o {
 
 //# publish
 mvir 0x1::k {
-    enum X has drop { 
+    public enum X has drop { 
         One { x: u64 },
         Two { x: u64, y: u64},
     }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/writeref_borrow_invalid.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/writeref_borrow_invalid.mvir
@@ -1,7 +1,7 @@
 //# publish
 mvir 0x1::M {
-    struct G has drop { v: u64 }
-    struct S has drop { g: Self::G }
+    public struct G has drop { v: u64 }
+    public struct S has drop { g: Self::G }
 
     fun t1(root: &mut Self::S, cond: bool) {
         let v_mut: &mut u64;

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/writeref_borrow_valid1.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/writeref_borrow_valid1.mvir
@@ -1,7 +1,7 @@
 //# publish
 mvir 0x1::M {
-    struct G has drop { v1: u64, v2: u64 }
-    struct S { g1: Self::G, g2: Self::G }
+    public struct G has drop { v1: u64, v2: u64 }
+    public struct S { g1: Self::G, g2: Self::G }
 
     fun t1(root: &mut Self::S, cond: bool) {
         let v1_mut: &mut u64;

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/writeref_borrow_valid2.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/writeref_borrow_valid2.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x1::M {
-    struct S { f: u64, g: u64, h: u64 }
+    public struct S { f: u64, g: u64, h: u64 }
 
     fun t1(root: &mut Self::S, cond: bool) {
         let x: &mut u64;

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/script_signature/script_type_parameters_in_args.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/script_signature/script_type_parameters_in_args.mvir
@@ -30,7 +30,7 @@ label b0:
 
 //# publish
 mvir 0x42::M {
-    struct Box<T> has drop { x: T }
+    public struct Box<T> has drop { x: T }
 }
 
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/script_signature/script_with_generic_type_arg.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/script_signature/script_with_generic_type_arg.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x1::M {
-    struct Cup<T> { flag: u64 }
+    public struct Cup<T> { flag: u64 }
 }
 
 //# run --type-args 0x1::M::Cup<0x1::M::Cup<bool>>

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/script_signature/script_with_type_parameters.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/script_signature/script_with_type_parameters.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x1::Coin {
-    struct Coin { value: u64 }
+    public struct Coin { value: u64 }
     public fun value(c: &Self::Coin): u64 {
     label b0:
         return *&move(c).Coin::value;

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/script_signature/struct_arguments.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/script_signature/struct_arguments.mvir
@@ -4,7 +4,7 @@
 // should abort indicating no verification errors occurred
 
 mvir 0x42::M {
-    struct S { f: u64 }
+    public struct S { f: u64 }
 
     public entry fun foo(s: Self::S, i: &Self::S, m: &mut Self::S) {
         label l0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/all_as_all_ok.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/all_as_all_ok.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x1::M {
-    struct S<T> { b: bool }
+    public struct S<T> { b: bool }
 
     fun foo<T>() {
         let x: Self::S<T>;

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/all_as_resource.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/all_as_resource.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x1::M {
-    struct S<T: key> { b: bool }
+    public struct S<T: key> { b: bool }
 
     fun foo<T>() {
         // T does not have key

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/all_as_unrestricted.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/all_as_unrestricted.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x1::M {
-    struct S<T: copy + drop> { b: bool }
+    public struct S<T: copy + drop> { b: bool }
 
     fun foo<T>() {
         // T does not have copy or drop

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/check_constraints_script.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/check_constraints_script.mvir
@@ -1,16 +1,16 @@
 //# publish
 mvir 0x1::M {
-    struct K has key { dummy: bool }
+    public struct K has key { dummy: bool }
 
-    struct BoxCopy<T> has copy { f: T }
-    struct BoxDrop<T> has drop { f: T }
-    struct BoxStore<T> has store { f: T }
-    struct BoxKey<T> has key { f: T }
+    public struct BoxCopy<T> has copy { f: T }
+    public struct BoxDrop<T> has drop { f: T }
+    public struct BoxStore<T> has store { f: T }
+    public struct BoxKey<T> has key { f: T }
 
-    struct NeedsCopy<T: copy> { dummy: bool }
-    struct NeedsDrop<T: drop> { dummy: bool }
-    struct NeedsStore<T: store> { dummy: bool }
-    struct NeedsKey<T: key> { dummy: bool }
+    public struct NeedsCopy<T: copy> { dummy: bool }
+    public struct NeedsDrop<T: drop> { dummy: bool }
+    public struct NeedsStore<T: store> { dummy: bool }
+    public struct NeedsKey<T: key> { dummy: bool }
 }
 
 // tests various valid constraints in script arguments

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/check_constraints_script_invalid.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/check_constraints_script_invalid.mvir
@@ -1,14 +1,14 @@
 //# publish
 mvir 0x1::M {
-    struct BoxCopy<T> has copy { f: T }
-    struct BoxDrop<T> has drop { f: T }
-    struct BoxStore<T> has store { f: T }
-    struct BoxKey<T> has key { f: T }
+    public struct BoxCopy<T> has copy { f: T }
+    public struct BoxDrop<T> has drop { f: T }
+    public struct BoxStore<T> has store { f: T }
+    public struct BoxKey<T> has key { f: T }
 
-    struct NeedsCopy<T: copy> { dummy: bool }
-    struct NeedsDrop<T: drop> { dummy: bool }
-    struct NeedsStore<T: store> { dummy: bool }
-    struct NeedsKey<T: key> { dummy: bool }
+    public struct NeedsCopy<T: copy> { dummy: bool }
+    public struct NeedsDrop<T: drop> { dummy: bool }
+    public struct NeedsStore<T: store> { dummy: bool }
+    public struct NeedsKey<T: key> { dummy: bool }
 }
 
 // tests various invalid constraints in script arguments

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/reference_as_type_actual_for_struct.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/reference_as_type_actual_for_struct.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x1::M {
-    struct S<T> { b: bool }
+    public struct S<T> { b: bool }
 
     fun foo() {
         // cannot use refs in generics

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/reference_as_type_actual_in_struct_inst_for_bytecode_instruction.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/reference_as_type_actual_in_struct_inst_for_bytecode_instruction.mvir
@@ -2,7 +2,7 @@
 mvir 0x1::M {
     import 0x1::signer;
 
-    struct Some<T> has key { item: T }
+    public struct Some<T> has key { item: T }
 
     fun id<T>(x: T): T { label b0: abort(0); }
     fun foo() {
@@ -14,7 +14,7 @@ mvir 0x1::M {
 
 //# publish
 mvir 0x1::M {
-    struct Some<T> { item: T }
+    public struct Some<T> { item: T }
 
     fun foo() {
         let x: u64;
@@ -30,7 +30,7 @@ mvir 0x1::M {
 
 //# publish
 mvir 0x1::M {
-    struct Some<T> { item: T }
+    public struct Some<T> { item: T }
 
     fun foo() {
         let x: &u64;
@@ -44,7 +44,7 @@ mvir 0x1::M {
 
 //# publish
 mvir 0x1::M {
-    struct S<T> { v: T }
+    public struct S<T> { v: T }
 
     // cannot use refs in generics
     fun foo(s: Self::S<&u64>): u64 {
@@ -55,7 +55,7 @@ mvir 0x1::M {
 
 //# publish
 mvir 0x1::M {
-    struct S<T> { v: T }
+    public struct S<T> { v: T }
 
     // cannot use refs in generics
     fun foo(s: Self::S<&u64>): u64 {

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/reference_in_fields.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/reference_in_fields.mvir
@@ -1,5 +1,5 @@
 //# publish
 mvir 0x42::M {
     // no refs in fields
-    struct Foo { x: &u64 }
+    public struct Foo { x: &u64 }
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/resource_as_all_ok.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/resource_as_all_ok.mvir
@@ -1,7 +1,7 @@
 //# publish
 mvir 0x1::M {
-    struct S<T> { b: bool }
-    struct R { b: bool }
+    public struct S<T> { b: bool }
+    public struct R { b: bool }
 
     fun foo() {
         // constraints satisfied

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/resource_as_unrestricted.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/resource_as_unrestricted.mvir
@@ -1,7 +1,7 @@
 //# publish
 mvir 0x1::M {
-    struct S<T: copy + drop> { b: bool }
-    struct R { b: bool }
+    public struct S<T: copy + drop> { b: bool }
+    public struct R { b: bool }
 
     fun foo() {
         // R does not have copy or drop

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/two_type_actuals_ok.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/two_type_actuals_ok.mvir
@@ -1,7 +1,7 @@
 //# publish
 mvir 0x1::M {
-    struct R has key { b: bool}
-    struct S<T1: key, T2: copy + drop> { b: bool }
+    public struct R has key { b: bool}
+    public struct S<T1: key, T2: copy + drop> { b: bool }
 
     fun foo() {
         // satisfy constraints

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/two_type_actuals_reverse_order.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/two_type_actuals_reverse_order.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x1::M {
-    struct S<T1: key, T2: copy + drop> { b: bool }
+    public struct S<T1: key, T2: copy + drop> { b: bool }
 
     fun foo() {
         // bool does not have key
@@ -12,8 +12,8 @@ mvir 0x1::M {
 
 //# publish
 mvir 0x1::M2 {
-    struct R has key { b: bool }
-    struct S<T1: key, T2: copy + drop> { b: bool }
+    public struct R has key { b: bool }
+    public struct S<T1: key, T2: copy + drop> { b: bool }
 
     fun foo() {
         // bool does not have key, R does not have copy+drop

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/unrestricted_as_all_ok.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/unrestricted_as_all_ok.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x1::M {
-    struct S<T> { b: bool }
+    public struct S<T> { b: bool }
 
     fun foo() {
         // no constraint

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/unrestricted_as_resource.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/unrestricted_as_resource.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x1::M {
-    struct S<T: key> { b: bool }
+    public struct S<T: key> { b: bool }
 
     fun foo() {
         // bool does not have key

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/consume_stack.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/consume_stack.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x6::M {
-    struct R has key { data: vector<u8> }
+    public struct R has key { data: vector<u8> }
 
     fun is_ok_(addr: &address, data: &vector<u8>): bool {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/multiple_return_values.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/multiple_return_values.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x6::Test {
-    struct T { b: bool }
+    public struct T { b: bool }
 
     public fun new(): Self::T {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/multiple_return_values_extra_binding.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/multiple_return_values_extra_binding.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x6::Test {
-    struct T { b: bool }
+    public struct T { b: bool }
 
     public fun new(): Self::T {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/multiple_return_values_extra_value.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/multiple_return_values_extra_value.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x6::Test {
-    struct T { b: bool }
+    public struct T { b: bool }
 
     public fun new(): Self::T {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/multiple_return_values_missing_binding.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/multiple_return_values_missing_binding.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x6::Test {
-    struct T { b: bool }
+    public struct T { b: bool }
 
     public fun new(): Self::T {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/multiple_return_values_missing_value.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/multiple_return_values_missing_value.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x6::Test {
-    struct T { b: bool }
+    public struct T { b: bool }
 
     public fun new(): Self::T {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/pack_invalid_number_arguments_enum.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/pack_invalid_number_arguments_enum.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x6::MonoTooMany {
-    enum Foo{ V { x: u64 } }
+    public enum Foo{ V { x: u64 } }
 
     fun bar(x: u64, y: u64): Self::Foo {
         let t: Self::Foo;
@@ -12,7 +12,7 @@ mvir 0x6::MonoTooMany {
 
 //# publish
 mvir 0x7::MonoTooFew {
-    enum Foo{ V { x: u64 } }
+    public enum Foo{ V { x: u64 } }
 
     fun bar(x: u64, y: u64): Self::Foo {
         let t: Self::Foo;
@@ -24,7 +24,7 @@ mvir 0x7::MonoTooFew {
 
 //# publish
 mvir 0x8::PolyTooMany {
-    enum Foo<T>{ V { x: T } }
+    public enum Foo<T>{ V { x: T } }
 
     fun bar(x: u64, y: u64): Self::Foo<u64> {
         let t: Self::Foo<u64>;
@@ -36,7 +36,7 @@ mvir 0x8::PolyTooMany {
 
 //# publish
 mvir 0x9::PolyTooFew {
-    enum Foo<T>{ V { x: T } }
+    public enum Foo<T>{ V { x: T } }
 
     fun bar(x: u64, y: u64): Self::Foo<u64> {
         let t: Self::Foo<u64>;

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/unpack_extra_binding.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/unpack_extra_binding.mvir
@@ -1,7 +1,7 @@
 //# publish
 mvir 0x6::Test {
-    struct X { b: bool }
-    struct T { i: u64, x: Self::X }
+    public struct X { b: bool }
+    public struct T { i: u64, x: Self::X }
 
     public fun new_t(): Self::T {
         let x: Self::X;

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/unpack_extra_binding_enum.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/unpack_extra_binding_enum.mvir
@@ -1,7 +1,7 @@
 //# publish
 mvir 0x6::Test {
-    struct X { b: bool }
-    enum T { V{ i: u64, x: Self::X } }
+    public struct X { b: bool }
+    public enum T { V{ i: u64, x: Self::X } }
 
     public fun new_t(): Self::T {
         let x: Self::X;
@@ -24,8 +24,8 @@ mvir 0x6::Test {
 
 //# publish
 mvir 0x7::Test {
-    struct X { b: bool }
-    enum T<H> { V{ i: H, x: Self::X } }
+    public struct X { b: bool }
+    public enum T<H> { V{ i: H, x: Self::X } }
 
     public fun new_t(): Self::T<u64> {
         let x: Self::X;
@@ -47,8 +47,8 @@ mvir 0x7::Test {
 
 //# publish
 mvir 0x8::Test {
-    struct X { b: bool }
-    enum T<H> { V{ i: H, x: Self::X } }
+    public struct X { b: bool }
+    public enum T<H> { V{ i: H, x: Self::X } }
 
     public fun new_t(): Self::T<u64> {
         let x: Self::X;
@@ -70,8 +70,8 @@ mvir 0x8::Test {
 
 //# publish
 mvir 0x9::Test {
-    struct X { b: bool }
-    enum T<H> { V{ i: H, x: Self::X } }
+    public struct X { b: bool }
+    public enum T<H> { V{ i: H, x: Self::X } }
 
     public fun new_t(): Self::T<u64> {
         let x: Self::X;

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/unpack_missing_binding.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/unpack_missing_binding.mvir
@@ -1,7 +1,7 @@
 //# publish
 mvir 0x6::Test {
-    struct X { b: bool }
-    struct T { i: u64, x: Self::X, b: bool, y: u64 }
+    public struct X { b: bool }
+    public struct T { i: u64, x: Self::X, b: bool, y: u64 }
 
     public fun new_t(): Self::T {
         let x: Self::X;

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/unpack_missing_binding_enum.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/unpack_missing_binding_enum.mvir
@@ -1,7 +1,7 @@
 //# publish
 mvir 0x6::Test {
-    struct X { b: bool }
-    enum T { V { i: u64, x: Self::X, b: bool, y: u64 } }
+    public struct X { b: bool }
+    public enum T { V { i: u64, x: Self::X, b: bool, y: u64 } }
 
     public fun new_t(): Self::T {
         let x: Self::X;
@@ -23,8 +23,8 @@ mvir 0x6::Test {
 
 //# publish
 mvir 0x7::Test {
-    struct X { b: bool }
-    enum T<H> { V{ i: H, x: Self::X, b: bool, y: u64 } }
+    public struct X { b: bool }
+    public enum T<H> { V{ i: H, x: Self::X, b: bool, y: u64 } }
 
     public fun new_t(): Self::T<u64> {
         let x: Self::X;
@@ -46,8 +46,8 @@ mvir 0x7::Test {
 
 //# publish
 mvir 0x8::Test {
-    struct X { b: bool }
-    enum T<H> { V{ i: H, x: Self::X, b: bool, y: u64 } }
+    public struct X { b: bool }
+    public enum T<H> { V{ i: H, x: Self::X, b: bool, y: u64 } }
 
     public fun new_t(): Self::T<u64> {
         let x: Self::X;
@@ -69,8 +69,8 @@ mvir 0x8::Test {
 
 //# publish
 mvir 0x9::Test {
-    struct X { b: bool }
-    enum T<H> { V{ i: H, x: Self::X, b: bool, y: u64 } }
+    public struct X { b: bool }
+    public enum T<H> { V{ i: H, x: Self::X, b: bool, y: u64 } }
 
     public fun new_t(): Self::T<u64> {
         let x: Self::X;

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/struct_defs/module_struct_shared_name.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/struct_defs/module_struct_shared_name.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x42::M {
-    struct M has drop { b: bool }
+    public struct M has drop { b: bool }
     public fun new(): Self::M {
     label b0:
         return M{ b: true };

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/struct_defs/mutual_recursive_struct.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/struct_defs/mutual_recursive_struct.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x42::M {
     // cannot have mutually recursive structs
-    struct A{b: Self::B}
-    struct B{a: Self::A}
+    public struct A{b: Self::B}
+    public struct B{a: Self::A}
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/struct_defs/recursive_struct.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/struct_defs/recursive_struct.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x1::Cup {
-    struct Cup<T> { f: T }
+    public struct Cup<T> { f: T }
     public fun cup<T>(f: T): Self::Cup<T> {
     label b0:
         return Cup<T> { f: move(f) };
@@ -10,14 +10,14 @@ mvir 0x1::Cup {
 //# publish
 mvir 0x1::M0 {
     // recursive struct
-    struct Foo { f: Self::Foo }
+    public struct Foo { f: Self::Foo }
 }
 
 //# publish
 mvir 0x1::M1 {
     import 0x1::Cup;
     // recursive struct
-    struct Foo { f: Cup::Cup<Self::Foo> }
+    public struct Foo { f: Cup::Cup<Self::Foo> }
 
     // would blow up the stack
     public fun foo(): Self::Foo {
@@ -31,8 +31,8 @@ mvir 0x1::M1 {
 mvir 0x1::M2 {
     import 0x1::signer;
 
-    struct X { y: vector<Self::Y> }
-    struct Y { x: vector<Self::X> }
+    public struct X { y: vector<Self::Y> }
+    public struct Y { x: vector<Self::X> }
 
 }
 
@@ -41,7 +41,7 @@ mvir 0x1::M3 {
     import 0x1::Cup;
 
     // recursive struct
-    struct Foo { f: Cup::Cup<Self::Foo> }
+    public struct Foo { f: Cup::Cup<Self::Foo> }
 
 }
 
@@ -50,9 +50,9 @@ mvir 0x1::M3 {
     import 0x1::Cup;
 
     // indirect recursive struct
-    struct A { b: Self::B }
-    struct B { c: Self::C }
-    struct C { d: vector<Self::D> }
-    struct D { x: Cup::Cup<Cup::Cup<Cup::Cup<Self::A>>> }
+    public struct A { b: Self::B }
+    public struct B { c: Self::C }
+    public struct C { d: vector<Self::D> }
+    public struct D { x: Cup::Cup<Cup::Cup<Cup::Cup<Self::A>>> }
 
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/struct_defs/ref_in_struct.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/struct_defs/ref_in_struct.mvir
@@ -1,19 +1,19 @@
 //# publish
 mvir 0x42::M1 {
-    struct S { x: &u64 }
+    public struct S { x: &u64 }
 }
 
 //# publish
 mvir 0x42::M2 {
-    struct S { x: &mut u64 }
+    public struct S { x: &mut u64 }
 }
 
 //# publish
 mvir 0x42::M3 {
-    struct S<T> { t: &T }
+    public struct S<T> { t: &T }
 }
 
 //# publish
 mvir 0x42::M4 {
-    struct S<T> { t: &mut T }
+    public struct S<T> { t: &mut T }
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/assign_local_resource.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/assign_local_resource.mvir
@@ -1,7 +1,7 @@
 //# publish
 mvir 0x42::A {
-    struct Coin has store { value: u64 }
-    struct T { f: Self::Coin }
+    public struct Coin has store { value: u64 }
+    public struct T { f: Self::Coin }
 
     public fun t(resource1: Self::Coin, resource2: Self::Coin) {
     label b0:
@@ -12,7 +12,7 @@ mvir 0x42::A {
 
 //# publish
 mvir 0x42::A {
-    enum Coin has store { V { value: u64 } }
+    public enum Coin has store { V { value: u64 } }
 
     public fun t(resource1: Self::Coin, resource2: Self::Coin) {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/assign_local_resource_twice.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/assign_local_resource_twice.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x42::A {
-    struct Coin has store { value: u64 }
+    public struct Coin has store { value: u64 }
 
     public fun t(resource_ref: &mut Self::Coin, resource1: Self::Coin, resource2: Self::Coin) {
     label b0:
@@ -13,7 +13,7 @@ mvir 0x42::A {
 
 //# publish
 mvir 0x43::A {
-    enum Coin has store { V { value: u64 } }
+    public enum Coin has store { V { value: u64 } }
 
     public fun t(resource_ref: &mut Self::Coin, resource1: Self::Coin, resource2: Self::Coin) {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/assign_resource_type.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/assign_resource_type.mvir
@@ -1,7 +1,7 @@
 //# publish
 mvir 0x42::A {
-    struct Coin has store { value: u64 }
-    struct T { f: Self::Coin }
+    public struct Coin has store { value: u64 }
+    public struct T { f: Self::Coin }
 
     public fun t(this: &mut Self::T, y: Self::Coin) {
         let x: &mut Self::Coin;

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/assign_resource_type_enum.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/assign_resource_type_enum.mvir
@@ -1,7 +1,7 @@
 //# publish
 mvir 0x42::A {
-    struct Coin has store { value: u64 }
-    enum T { V { f: Self::Coin } }
+    public struct Coin has store { value: u64 }
+    public enum T { V { f: Self::Coin } }
 
     public fun t(this: &mut Self::T, y: Self::Coin) {
         let x: &mut Self::Coin;

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/cant_deref_resource.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/cant_deref_resource.mvir
@@ -1,7 +1,7 @@
 //# publish
 mvir 0x1::Token {
 
-    struct T has key {v: u64}
+    public struct T has key {v: u64}
 
     public fun new(v: u64): Self::T {
     label b0:
@@ -41,7 +41,7 @@ mvir 0x1::Token {
 //# publish
 mvir 0x2::Token {
 
-    enum T has key { V{v: u64}}
+    public enum T has key { V{v: u64}}
 
     public fun new(v: u64): Self::T {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/casting_operators_types_mismatch.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/casting_operators_types_mismatch.mvir
@@ -122,7 +122,7 @@ label b0:
 
 //# publish
 mvir 0x42::M {
-    struct S { x: bool }
+    public struct S { x: bool }
     fun f() {
     label b0:
         _ = to_u8(S { x: true });
@@ -132,7 +132,7 @@ mvir 0x42::M {
 
 //# publish
 mvir 0x42::M {
-    struct S { x: bool }
+    public struct S { x: bool }
     fun g() {
     label b0:
         _ = to_u64(S { x: true });
@@ -142,7 +142,7 @@ mvir 0x42::M {
 
 //# publish
 mvir 0x42::M {
-    struct S { x: bool }
+    public struct S { x: bool }
     fun h() {
     label b0:
         _ = to_u128(S { x: true });
@@ -152,7 +152,7 @@ mvir 0x42::M {
 
 //# publish
 mvir 0x42::M {
-    struct S { x: bool }
+    public struct S { x: bool }
     fun f() {
     label b0:
         _ = to_u16(S { x: true });
@@ -162,7 +162,7 @@ mvir 0x42::M {
 
 //# publish
 mvir 0x42::M {
-    struct S { x: bool }
+    public struct S { x: bool }
     fun g() {
     label b0:
         _ = to_u32(S { x: true });
@@ -172,7 +172,7 @@ mvir 0x42::M {
 
 //# publish
 mvir 0x42::M {
-    struct S { x: bool }
+    public struct S { x: bool }
     fun h() {
     label b0:
         _ = to_u256(S { x: true });

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/destroy_resource_holder.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/destroy_resource_holder.mvir
@@ -1,8 +1,8 @@
 //# publish
 mvir 0x42::A {
 
-    struct Coin has store { value: u64 }
-    struct A { c: Self::Coin }
+    public struct Coin has store { value: u64 }
+    public struct A { c: Self::Coin }
 
     public fun destroy_zero(c: Self::Coin) {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/equality_resource_refs.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/equality_resource_refs.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x1::Token {
-    struct T has key { b: bool }
+    public struct T has key { b: bool }
 
     public fun test() {
         let t: Self::T;
@@ -28,7 +28,7 @@ label b0:
 
 //# publish
 mvir 0x2::Token {
-    enum T has key { V { b: bool } }
+    public enum T has key { V { b: bool } }
 
     public fun test() {
         let t: Self::T;

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/equality_resource_values.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/equality_resource_values.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x1::Token {
-    struct T has key { b: bool }
+    public struct T has key { b: bool }
 
     public fun test() {
         let no: bool;
@@ -12,7 +12,7 @@ mvir 0x1::Token {
 
 //# publish
 mvir 0x2::Token {
-    enum T has key { V { b: bool } }
+    public enum T has key { V { b: bool } }
 
     public fun test() {
         let no: bool;

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_abilities_borrow_field.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_abilities_borrow_field.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x1::M {
-    struct Foo<T>{ x: T }
+    public struct Foo<T>{ x: T }
 
     fun baz(x: u64) {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_abilities_imm_borrow_field.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_abilities_imm_borrow_field.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x1::M {
-    struct Foo<T>{ x: T }
+    public struct Foo<T>{ x: T }
 
     fun baz(x: u64) {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_abilities_imm_unpack_enum.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_abilities_imm_unpack_enum.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x1::M {
-    enum Foo<T> { V{ x: T }}
+    public enum Foo<T> { V{ x: T }}
 
     fun baz(x: u64) {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_abilities_pack.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_abilities_pack.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x1::M {
-    struct Foo<T1, T2> { x: T1, y: T2 }
+    public struct Foo<T1, T2> { x: T1, y: T2 }
 
     fun foo<T>(x: T): Self::Foo<u64, T> {
         let f: Self::Foo<u64, T>;
@@ -12,7 +12,7 @@ mvir 0x1::M {
 
 //# publish
 mvir 0x2::M {
-    enum Foo<T1, T2> { V { x: T1, y: T2 } }
+    public enum Foo<T1, T2> { V { x: T1, y: T2 } }
 
     fun foo<T>(x: T): Self::Foo<u64, T> {
         let f: Self::Foo<u64, T>;

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_abilities_struct_non_nominal_resource.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_abilities_struct_non_nominal_resource.mvir
@@ -1,7 +1,7 @@
 //# publish
 mvir 0x1::M {
-    struct R { b: bool }
-    struct Box<T> { x: T }
+    public struct R { b: bool }
+    public struct Box<T> { x: T }
 
     fun foo(x: Self::Box<Self::R>): Self::Box<Self::R> {
         let y: Self::Box<Self::R>;
@@ -13,8 +13,8 @@ mvir 0x1::M {
 
 //# publish
 mvir 0x2::M {
-    enum R { V{ b: bool } }
-    enum Box<T> { V{ x: T } }
+    public enum R { V{ b: bool } }
+    public enum Box<T> { V{ x: T } }
 
     fun foo(x: Self::Box<Self::R>): Self::Box<Self::R> {
         let y: Self::Box<Self::R>;

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_abilities_unpack.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_abilities_unpack.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x1::M {
-    struct Foo<T> { x: T }
+    public struct Foo<T> { x: T }
 
     fun baz<T>(x: Self::Foo<T>) {
         let y: T;
@@ -12,7 +12,7 @@ mvir 0x1::M {
 
 //# publish
 mvir 0x2::M {
-    enum Foo<T> { V{ x: T } }
+    public enum Foo<T> { V{ x: T } }
 
     fun baz<T>(x: Self::Foo<T>) {
         let y: T;

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_abilities_unpack_mut_enum.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_abilities_unpack_mut_enum.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x1::M {
-    enum Foo<T>{ V { x: T } }
+    public enum Foo<T>{ V { x: T } }
 
     fun baz(x: u64) {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_call.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_call.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x1::M {
-    struct Foo { f: bool }
+    public struct Foo { f: bool }
 
     public fun id<T>(x: T): T {
     label b0:
@@ -24,7 +24,7 @@ mvir 0x1::M {
 
 //# publish
 mvir 0x2::M {
-    enum Foo { V{ f: bool } }
+    public enum Foo { V{ f: bool } }
 
     public fun id<T>(x: T): T {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_field_borrow.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_field_borrow.mvir
@@ -1,7 +1,7 @@
 //# publish
 mvir 0x1::M {
-    struct X has drop { v: u64 }
-    struct S<T> has drop { f: T }
+    public struct X has drop { v: u64 }
+    public struct S<T> has drop { f: T }
     fun t(s: Self::S<Self::X>): u64 {
     label b0:
         return *(&(&(&s).S<Self::X>::f).X::v);
@@ -10,8 +10,8 @@ mvir 0x1::M {
 
 //# publish
 mvir 0x2::M {
-    enum X has drop { V { v: u64 } }
-    enum S<T> has drop { V { f: T } }
+    public enum X has drop { V { v: u64 } }
+    public enum S<T> has drop { V { f: T } }
     fun t(s: Self::S<Self::X>): u64 {
     let v: &u64;
     let f: &Self::X;

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_field_borrow_after_call.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_field_borrow_after_call.mvir
@@ -1,7 +1,7 @@
 //# publish
 
 mvir 0x1::M {
-    struct X has drop { v: u64 }
+    public struct X has drop { v: u64 }
     fun id<T>(x: &T): &T {
     label b0:
         return move(x);

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_field_unpack_borrow_after_call_enum.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_field_unpack_borrow_after_call_enum.mvir
@@ -1,7 +1,7 @@
 //# publish
 
 mvir 0x1::M {
-    enum X has drop { V{ v: u64 }}
+    public enum X has drop { V{ v: u64 }}
     fun id<T>(x: &T): &T {
     label b0:
         return move(x);

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_import_function.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_import_function.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x1::M {
-    struct R has key { f: bool }
+    public struct R has key { f: bool }
 
     public fun foo<T>(x: T) {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_import_struct.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_import_struct.mvir
@@ -1,8 +1,8 @@
 //# publish
 mvir 0x1::M {
-    struct Foo<T> has key { x: T }
+    public struct Foo<T> has key { x: T }
 
-    struct Bar<T1, T2: key, T3: copy + drop> { x: T3, y: T2, z: T1 }
+    public struct Bar<T1, T2: key, T3: copy + drop> { x: T3, y: T2, z: T1 }
 }
 
 //# run
@@ -29,9 +29,9 @@ label b0:
 
 //# publish
 mvir 0x4::M {
-    enum Foo<T> has key { V { x: T } }
+    public enum Foo<T> has key { V { x: T } }
 
-    enum Bar<T1, T2: key, T3: copy + drop> { V { x: T3, y: T2, z: T1 } }
+    public enum Bar<T1, T2: key, T3: copy + drop> { V { x: T3, y: T2, z: T1 } }
 }
 
 //# run

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_option.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_option.mvir
@@ -4,7 +4,7 @@
 mvir 0x42::Option {
     import 0x1::vector;
 
-    struct T<E> has copy, drop, store {
+    public struct T<E> has copy, drop, store {
         v: vector<E>
     }
 
@@ -42,7 +42,7 @@ mvir 0x42::Option {
 
 // example using generics in a few common/interesting/non-trivial ways -- with actual enums!
 mvir 0x43::Option {
-    enum T<E> has copy, drop, store {
+    public enum T<E> has copy, drop, store {
         None { },
         Some { v: E }
     }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_pack.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_pack.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x1::M {
-    struct Foo<T> { x: T }
+    public struct Foo<T> { x: T }
 
     fun foo() {
         let x: Self::Foo<u64>;
@@ -12,8 +12,8 @@ mvir 0x1::M {
 
 //# publish
 mvir 0x1::N {
-    struct Foo<T1, T2: key> { x: T1, y: T2 }
-    struct Bar has key { f: bool }
+    public struct Foo<T1, T2: key> { x: T1, y: T2 }
+    public struct Bar has key { f: bool }
 
     fun foo() {
         let x: Self::Foo<u64, Self::Bar>;
@@ -25,7 +25,7 @@ mvir 0x1::N {
 
 //# publish
 mvir 0x2::M {
-    enum Foo<T> { V { x: T } }
+    public enum Foo<T> { V { x: T } }
 
     fun foo() {
         let x: Self::Foo<u64>;
@@ -37,8 +37,8 @@ mvir 0x2::M {
 
 //# publish
 mvir 0x2::N {
-    enum Foo<T1, T2: key> { V { x: T1, y: T2 } }
-    enum Bar has key { V { f: bool } }
+    public enum Foo<T1, T2: key> { V { x: T1, y: T2 } }
+    public enum Bar has key { V { f: bool } }
 
     fun foo() {
         let x: Self::Foo<u64, Self::Bar>;

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_pack_type_mismatch.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_pack_type_mismatch.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x1::M {
-    struct Foo<T> { x: T }
+    public struct Foo<T> { x: T }
 
     fun foo() {
         let x: Self::Foo<u64>;
@@ -12,8 +12,8 @@ mvir 0x1::M {
 
 //# publish
 mvir 0x1::N {
-    struct Foo<T1, T2: key> { x: T1, y: T2 }
-    struct Bar has key { f: bool }
+    public struct Foo<T1, T2: key> { x: T1, y: T2 }
+    public struct Bar has key { f: bool }
 
     fun foo() {
         let x: Self::Foo<u64, Self::Bar>;
@@ -25,8 +25,8 @@ mvir 0x1::N {
 
 //# publish
 mvir 0x1::O {
-    struct Foo<T1, T2: key> { x: T1, y: T2 }
-    struct Bar<T> has key { f: T }
+    public struct Foo<T1, T2: key> { x: T1, y: T2 }
+    public struct Bar<T> has key { f: T }
 
     fun foo() {
         let x: Self::Foo<u64, Self::Bar<bool>>;
@@ -38,8 +38,8 @@ mvir 0x1::O {
 
 //# publish
 mvir 0x1::P {
-    struct Foo<T1, T2: key> { x: T1, y: T2 }
-    struct Bar<T> has key { f: T }
+    public struct Foo<T1, T2: key> { x: T1, y: T2 }
+    public struct Bar<T> has key { f: T }
 
     fun foo() {
         let x: Self::Foo<u64, Self::Bar<bool>>;
@@ -52,7 +52,7 @@ mvir 0x1::P {
 
 //# publish
 mvir 0x2::M {
-    enum Foo<T> { V { x: T } }
+    public enum Foo<T> { V { x: T } }
 
     fun foo() {
         let x: Self::Foo<u64>;
@@ -64,8 +64,8 @@ mvir 0x2::M {
 
 //# publish
 mvir 0x2::N {
-    enum Foo<T1, T2: key> { V { x: T1, y: T2 } }
-    enum Bar has key { V { f: bool } }
+    public enum Foo<T1, T2: key> { V { x: T1, y: T2 } }
+    public enum Bar has key { V { f: bool } }
 
     fun foo() {
         let x: Self::Foo<u64, Self::Bar>;
@@ -77,8 +77,8 @@ mvir 0x2::N {
 
 //# publish
 mvir 0x2::O {
-    enum Foo<T1, T2: key> { V { x: T1, y: T2 } }
-    enum Bar<T> has key { V { f: T } }
+    public enum Foo<T1, T2: key> { V { x: T1, y: T2 } }
+    public enum Bar<T> has key { V { f: T } }
 
     fun foo() {
         let x: Self::Foo<u64, Self::Bar<bool>>;
@@ -90,8 +90,8 @@ mvir 0x2::O {
 
 //# publish
 mvir 0x2::P {
-    enum Foo<T1, T2: key> { V { x: T1, y: T2 } }
-    enum Bar<T> has key { V { f: T } }
+    public enum Foo<T1, T2: key> { V { x: T1, y: T2 } }
+    public enum Bar<T> has key { V { f: T } }
 
     fun foo() {
         let x: Self::Foo<u64, Self::Bar<bool>>;

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_struct_def.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_struct_def.mvir
@@ -5,8 +5,8 @@
 //   2) fields have correct types
 
 mvir 0x1::M {
-    struct Foo<T> { x: T }
-    struct Bar<T1, T2, T3: key, T4: copy + drop> { x1: T2, x2: T3, x3: T4, x4: T1 }
+    public struct Foo<T> { x: T }
+    public struct Bar<T1, T2, T3: key, T4: copy + drop> { x1: T2, x2: T3, x3: T4, x4: T1 }
 }
 
 //# publish
@@ -16,6 +16,6 @@ mvir 0x1::M {
 //   2) fields have correct types
 
 mvir 0x2::M {
-    enum Foo<T> { V { x: T } }
-    enum Bar<T1, T2, T3: key, T4: copy + drop> { V { x1: T2, x2: T3, x3: T4, x4: T1 } }
+    public enum Foo<T> { V { x: T } }
+    public enum Bar<T1, T2, T3: key, T4: copy + drop> { V { x1: T2, x2: T3, x3: T4, x4: T1 } }
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_unpack.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_unpack.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x1::M {
-    struct Foo<T> { x: T }
+    public struct Foo<T> { x: T }
 
     fun foo() {
         let x: u64;
@@ -12,7 +12,7 @@ mvir 0x1::M {
 
 //# publish
 mvir 0x1::N {
-    struct Foo<T1: copy + drop, T2> { x: T1, y: T2 }
+    public struct Foo<T1: copy + drop, T2> { x: T1, y: T2 }
 
     fun foo() {
         let x: u64;
@@ -26,7 +26,7 @@ mvir 0x1::N {
 
 //# publish
 mvir 0x2::M {
-    enum Foo<T> { V { x: T } }
+    public enum Foo<T> { V { x: T } }
 
     fun foo() {
         let x: u64;
@@ -38,7 +38,7 @@ mvir 0x2::M {
 
 //# publish
 mvir 0x2::N {
-    enum Foo<T1: copy + drop, T2> { V { x: T1, y: T2 } }
+    public enum Foo<T1: copy + drop, T2> { V { x: T1, y: T2 } }
 
     fun foo() {
         let x: u64;

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_unpack_type_mismatch.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_unpack_type_mismatch.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x1::O {
-    struct Foo<T1: copy + drop, T2> { x: T1, y: T2 }
+    public struct Foo<T1: copy + drop, T2> { x: T1, y: T2 }
 
     fun foo() {
         let x: u64;
@@ -14,7 +14,7 @@ mvir 0x1::O {
 
 //# publish
 mvir 0x2::O {
-    enum Foo<T1: copy + drop, T2> { V { x: T1, y: T2 } }
+    public enum Foo<T1: copy + drop, T2> { V { x: T1, y: T2 } }
 
     fun foo() {
         let x: u64;

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/integer_binary_operators_types_mismatch.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/integer_binary_operators_types_mismatch.mvir
@@ -135,7 +135,7 @@ label b0:
 
 //# publish
 mvir 0x42::M {
-    struct R { x: bool }
+    public struct R { x: bool }
     fun f() {
     label b0:
         _ = 0 + (R { x: true });
@@ -145,7 +145,7 @@ mvir 0x42::M {
 
 //# publish
 mvir 0x42::M {
-    struct R { x: bool }
+    public struct R { x: bool }
     fun g() {
     label b0:
         _ = (R { x: true }) + 0;
@@ -155,7 +155,7 @@ mvir 0x42::M {
 
 //# publish
 mvir 0x42::M {
-    struct R { x: bool }
+    public struct R { x: bool }
     fun h() {
     label b0:
         _ = (R { x: true }) + (R { x: true });
@@ -300,7 +300,7 @@ label b0:
 
 //# publish
 mvir 0x42::M {
-    struct R { x: bool }
+    public struct R { x: bool }
     fun f() {
     label b0:
         _ = 0 - (R { x: true });
@@ -310,7 +310,7 @@ mvir 0x42::M {
 
 //# publish
 mvir 0x42::M {
-    struct R { x: bool }
+    public struct R { x: bool }
     fun g() {
     label b0:
         _ = (R { x: true }) - 0;
@@ -320,7 +320,7 @@ mvir 0x42::M {
 
 //# publish
 mvir 0x42::M {
-    struct R { x: bool }
+    public struct R { x: bool }
     fun h() {
     label b0:
         _ = (R { x: true }) - (R { x: true });
@@ -465,7 +465,7 @@ label b0:
 
 //# publish
 mvir 0x42::M {
-    struct R { x: bool }
+    public struct R { x: bool }
     fun f() {
     label b0:
         _ = 0 * (R { x: true });
@@ -475,7 +475,7 @@ mvir 0x42::M {
 
 //# publish
 mvir 0x42::M {
-    struct R { x: bool }
+    public struct R { x: bool }
     fun g() {
     label b0:
         _ = (R { x: true }) * 0;
@@ -485,7 +485,7 @@ mvir 0x42::M {
 
 //# publish
 mvir 0x42::M {
-    struct R { x: bool }
+    public struct R { x: bool }
     fun h() {
     label b0:
         _ = (R { x: true }) * (R { x: true });
@@ -630,7 +630,7 @@ label b0:
 
 //# publish
 mvir 0x42::M {
-    struct R { x: bool }
+    public struct R { x: bool }
     fun f() {
     label b0:
         _ = 0 / (R { x: true });
@@ -640,7 +640,7 @@ mvir 0x42::M {
 
 //# publish
 mvir 0x42::M {
-    struct R { x: bool }
+    public struct R { x: bool }
     fun g() {
     label b0:
         _ = (R { x: true }) / 0;
@@ -650,7 +650,7 @@ mvir 0x42::M {
 
 //# publish
 mvir 0x42::M {
-    struct R { x: bool }
+    public struct R { x: bool }
     fun h() {
     label b0:
         _ = (R { x: true }) / (R { x: true });
@@ -795,7 +795,7 @@ label b0:
 
 //# publish
 mvir 0x42::M {
-    struct R { x: bool }
+    public struct R { x: bool }
     fun f() {
     label b0:
         _ = 0 & (R { x: true });
@@ -805,7 +805,7 @@ mvir 0x42::M {
 
 //# publish
 mvir 0x42::M {
-    struct R { x: bool }
+    public struct R { x: bool }
     fun g() {
     label b0:
         _ = (R { x: true }) & 0;
@@ -815,7 +815,7 @@ mvir 0x42::M {
 
 //# publish
 mvir 0x42::M {
-    struct R { x: bool }
+    public struct R { x: bool }
     fun h() {
     label b0:
         _ = (R { x: true }) & (R { x: true });
@@ -960,7 +960,7 @@ label b0:
 
 //# publish
 mvir 0x42::M {
-    struct R { x: bool }
+    public struct R { x: bool }
     fun f() {
     label b0:
         _ = 0 | (R { x: true });
@@ -970,7 +970,7 @@ mvir 0x42::M {
 
 //# publish
 mvir 0x42::M {
-    struct R { x: bool }
+    public struct R { x: bool }
     fun g() {
     label b0:
         _ = (R { x: true }) | 0;
@@ -980,7 +980,7 @@ mvir 0x42::M {
 
 //# publish
 mvir 0x42::M {
-    struct R { x: bool }
+    public struct R { x: bool }
     fun h() {
     label b0:
         _ = (R { x: true }) | (R { x: true });
@@ -1125,7 +1125,7 @@ label b0:
 
 //# publish
 mvir 0x42::M {
-    struct R { x: bool }
+    public struct R { x: bool }
     fun f() {
     label b0:
         _ = 0 ^ (R { x: true });
@@ -1135,7 +1135,7 @@ mvir 0x42::M {
 
 //# publish
 mvir 0x42::M {
-    struct R { x: bool }
+    public struct R { x: bool }
     fun g() {
     label b0:
         _ = (R { x: true }) ^ 0;
@@ -1145,7 +1145,7 @@ mvir 0x42::M {
 
 //# publish
 mvir 0x42::M {
-    struct R { x: bool }
+    public struct R { x: bool }
     fun h() {
     label b0:
         _ = (R { x: true }) ^ (R { x: true });
@@ -1268,7 +1268,7 @@ label b0:
 
 //# publish
 mvir 0x42::M {
-    struct R { x: bool }
+    public struct R { x: bool }
     fun f() {
     label b0:
         _ = 0 == (R { x: true });
@@ -1278,7 +1278,7 @@ mvir 0x42::M {
 
 //# publish
 mvir 0x42::M {
-    struct R { x: bool }
+    public struct R { x: bool }
     fun g() {
     label b0:
         _ = (R { x: true }) == 0;
@@ -1400,7 +1400,7 @@ label b0:
 
 //# publish
 mvir 0x42::M {
-    struct R { x: bool }
+    public struct R { x: bool }
     fun f() {
     label b0:
         _ = 0 != (R { x: true });
@@ -1410,7 +1410,7 @@ mvir 0x42::M {
 
 //# publish
 mvir 0x42::M {
-    struct R { x: bool }
+    public struct R { x: bool }
     fun g() {
     label b0:
         _ = (R { x: true }) != 0;
@@ -1955,7 +1955,7 @@ label b0:
 
 //# publish
 mvir 0x42::M {
-    struct R { x: bool }
+    public struct R { x: bool }
     fun f() {
     label b0:
         _ = 0 << (R { x: true });
@@ -1965,7 +1965,7 @@ mvir 0x42::M {
 
 //# publish
 mvir 0x42::M {
-    struct R { x: bool }
+    public struct R { x: bool }
     fun g() {
     label b0:
         _ = (R { x: true }) << 0;
@@ -1975,7 +1975,7 @@ mvir 0x42::M {
 
 //# publish
 mvir 0x42::M {
-    struct R { x: bool }
+    public struct R { x: bool }
     fun h() {
     label b0:
         _ = (R { x: true }) << (R { x: true });
@@ -2076,7 +2076,7 @@ label b0:
 
 //# publish
 mvir 0x42::M {
-    struct R { x: bool }
+    public struct R { x: bool }
     fun f() {
     label b0:
         _ = 0 >> (R { x: true });
@@ -2086,7 +2086,7 @@ mvir 0x42::M {
 
 //# publish
 mvir 0x42::M {
-    struct R { x: bool }
+    public struct R { x: bool }
     fun g() {
     label b0:
         _ = (R { x: true }) >> 0;
@@ -2096,7 +2096,7 @@ mvir 0x42::M {
 
 //# publish
 mvir 0x42::M {
-    struct R { x: bool }
+    public struct R { x: bool }
     fun h() {
     label b0:
         _ = (R { x: true }) >> (R { x: true });

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/invalid_field_write.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/invalid_field_write.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x42::Test {
-    struct T{fr: bool}
+    public struct T{fr: bool}
 
     public fun new(): Self::T {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/invalid_field_write_mut_unpack_enum.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/invalid_field_write_mut_unpack_enum.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x42::Test {
-    enum T{V { fr: bool} }
+    public enum T{V { fr: bool} }
 
     public fun new(): Self::T {
     label b0:
@@ -19,7 +19,7 @@ mvir 0x42::Test {
 
 //# publish
 mvir 0x42::Test {
-    enum T<B> {V { fr: B } }
+    public enum T<B> {V { fr: B } }
 
     public fun new(): Self::T<bool> {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/invalid_resouce_write_unpack_mut_enum.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/invalid_resouce_write_unpack_mut_enum.mvir
@@ -1,7 +1,7 @@
 //# publish
 mvir 0x43::RTest {
-    enum Coin has store { V{ value: u64 } }
-    enum T { V{ f: Self::Coin } }
+    public enum Coin has store { V{ value: u64 } }
+    public enum T { V{ f: Self::Coin } }
 
       public fun update(t: &mut Self::T, i: Self::Coin) {
         let x: &mut Self::Coin;

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/invalid_resource_write.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/invalid_resource_write.mvir
@@ -1,7 +1,7 @@
 //# publish
 mvir 0x42::RTest {
-    struct Coin has store { value: u64 }
-    struct T { f: Self::Coin }
+    public struct Coin has store { value: u64 }
+    public struct T { f: Self::Coin }
 
       public fun update(t: &mut Self::T, i: Self::Coin) {
         let x: &mut Self::Coin;

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/mut_borrow_from_imm_ref.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/mut_borrow_from_imm_ref.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x42::Token {
-    struct T{value: u64}
+    public struct T{value: u64}
     public fun new(m: u64): Self::T {
     label b0:
         return T{value: copy(m)};

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/mut_borrow_from_imm_ref_enum.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/mut_borrow_from_imm_ref_enum.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x42::Token {
-    enum  T { V{value: u64}}
+    public enum  T { V{value: u64}}
     public fun new(m: u64): Self::T {
     label b0:
         return T::V{value: copy(m)};
@@ -26,7 +26,7 @@ mvir 0x42::Token {
 
 //# publish
 mvir 0x42::Token {
-    enum  T<B> { V{value: B }}
+    public enum  T<B> { V{value: B }}
 
     public fun bump_value<B>(this: &Self::T<B>, new: B) {
         let val: &mut B;

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/mut_call_from_get_resource.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/mut_call_from_get_resource.mvir
@@ -1,7 +1,7 @@
 //# publish
 mvir 0x42::Token {
 
-    struct T has key {balance: u64}
+    public struct T has key {balance: u64}
 
     public fun new(balance: u64): Self::T  {
     label b0:
@@ -64,7 +64,7 @@ mvir 0x42::Token {
 //# publish
 mvir 0x43::Token {
 
-    enum T has key {V { balance: u64} }
+    public enum T has key {V { balance: u64} }
 
     public fun new(balance: u64): Self::T  {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/mut_call_with_imm_ref.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/mut_call_with_imm_ref.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x42::Token {
-    struct T{value: u64}
+    public struct T{value: u64}
     public fun new(m: u64): Self::T {
     label b0:
         return T{value: copy(m)};

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/mut_call_with_imm_ref_enum.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/mut_call_with_imm_ref_enum.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x42::Token {
-    enum T{ V { value: u64 } }
+    public enum T{ V { value: u64 } }
     public fun new(m: u64): Self::T {
     label b0:
         return T::V{value: copy(m)};

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/pack_enum_with_refs.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/pack_enum_with_refs.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x2::O {
-    enum Foo<T> { V { x: T } }
+    public enum Foo<T> { V { x: T } }
 
     fun foo(x: &u64): Self::Foo<u64> {
         let y: Self::Foo<u64>;
@@ -12,7 +12,7 @@ mvir 0x2::O {
 
 //# publish
 mvir 0x2::O {
-    enum Foo<T> { V { x: T } }
+    public enum Foo<T> { V { x: T } }
 
     fun foo(x: &u64): Self::Foo<&u64> {
         let y: Self::Foo<&u64>;
@@ -24,12 +24,12 @@ mvir 0x2::O {
 
 //# publish
 mvir 0x2::O {
-    enum Foo<T> { V { x: &T } }
+    public enum Foo<T> { V { x: &T } }
 }
 
 //# publish
 mvir 0x2::O {
-    enum Foo<T> { V { x: T } }
+    public enum Foo<T> { V { x: T } }
 
     fun foo(x: &mut u64): Self::Foo<u64> {
         let y: Self::Foo<u64>;
@@ -41,7 +41,7 @@ mvir 0x2::O {
 
 //# publish
 mvir 0x2::O {
-    enum Foo<T> { V { x: T } }
+    public enum Foo<T> { V { x: T } }
 
     fun foo(x: &mut u64): Self::Foo<&mut u64> {
         let y: Self::Foo<&mut u64>;
@@ -53,7 +53,7 @@ mvir 0x2::O {
 
 //# publish
 mvir 0x2::O {
-    enum Foo<T> { V { x: &mut T } }
+    public enum Foo<T> { V { x: &mut T } }
 }
 
 
@@ -61,7 +61,7 @@ mvir 0x2::O {
 
 //# publish
 mvir 0x2::O {
-    enum Foo { V { x: u64 } }
+    public enum Foo { V { x: u64 } }
 
     fun foo(x: &mut u64): Self::Foo {
         let y: Self::Foo;
@@ -73,7 +73,7 @@ mvir 0x2::O {
 
 //# publish
 mvir 0x2::O {
-    enum Foo { V { x: &mut u64 } }
+    public enum Foo { V { x: &mut u64 } }
 
     fun foo(x: &mut u64): Self::Foo {
         let y: Self::Foo;
@@ -85,5 +85,5 @@ mvir 0x2::O {
 
 //# publish
 mvir 0x2::O {
-    enum Foo { V { x: &mut u64 } }
+    public enum Foo { V { x: &mut u64 } }
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/pack_generic_enum_invalid_type_arguments.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/pack_generic_enum_invalid_type_arguments.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x2::O {
-    enum Foo<T> { V { x: T } }
+    public enum Foo<T> { V { x: T } }
 
     fun foo(x: u64): Self::Foo<u64> {
         let y: Self::Foo<u64>;
@@ -12,7 +12,7 @@ mvir 0x2::O {
 
 //# publish
 mvir 0x2::O {
-    enum Foo<T> { V { x: T } }
+    public enum Foo<T> { V { x: T } }
 
     fun foo(x: u64): Self::Foo<bool> {
         let y: Self::Foo<u64>;
@@ -24,7 +24,7 @@ mvir 0x2::O {
 
 //# publish
 mvir 0x2::O {
-    enum Foo<T> { V { x: T } }
+    public enum Foo<T> { V { x: T } }
 
     fun foo(x: u64): Self::Foo<u64> {
         let y: Self::Foo<bool>;
@@ -36,7 +36,7 @@ mvir 0x2::O {
 
 //# publish
 mvir 0x2::O {
-    enum Foo<T> { V { x: T } }
+    public enum Foo<T> { V { x: T } }
 
     fun foo(x: u64): Self::Foo<u64> {
         let y: Self::Foo<u64>;
@@ -48,7 +48,7 @@ mvir 0x2::O {
 
 //# publish
 mvir 0x2::O {
-    enum Foo<T> { V { x: T } }
+    public enum Foo<T> { V { x: T } }
 
     fun foo(x: u64): Self::Foo<u64> {
         let y: Self::Foo<u64, bool>;
@@ -60,7 +60,7 @@ mvir 0x2::O {
 
 //# publish
 mvir 0x2::O {
-    enum Foo<T> { V { x: T } }
+    public enum Foo<T> { V { x: T } }
 
     fun foo(x: u64): Self::Foo<u64, bool> {
         let y: Self::Foo<u64>;
@@ -73,13 +73,13 @@ mvir 0x2::O {
 
 //# publish
 mvir 0x1::O {
-    enum Foo<T> { V { x: T } }
+    public enum Foo<T> { V { x: T } }
 }
 
 //# publish
 mvir 0x2::O {
     import 0x1::O;
-    enum Foo<T> { V { x: T } }
+    public enum Foo<T> { V { x: T } }
 
     fun foo(x: u64): O::Foo<u64> {
         let y: Self::Foo<u64>;
@@ -92,7 +92,7 @@ mvir 0x2::O {
 //# publish
 mvir 0x2::O {
     import 0x1::O;
-    enum Foo<T> { V { x: T } }
+    public enum Foo<T> { V { x: T } }
 
     fun foo(x: u64): O::Foo<u64> {
         let y: O::Foo<u64>;

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/pack_generic_enum_non_generically.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/pack_generic_enum_non_generically.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x2::O {
-    enum Foo<T> { V { x: T } }
+    public enum Foo<T> { V { x: T } }
 
     fun foo(x: u64): Self::Foo<u64> {
         let y: Self::Foo<u64>;

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/pack_non_generic_enum_generically.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/pack_non_generic_enum_generically.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x2::O {
-    enum Foo { V { x: u64 } }
+    public enum Foo { V { x: u64 } }
 
     fun foo(x: u64): Self::Foo {
         let y: Self::Foo;

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/phantom_params/bytecode_ops_abilities_bad.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/phantom_params/bytecode_ops_abilities_bad.mvir
@@ -4,14 +4,14 @@
 // (phantom arguments) are not considered when deriving the abilities for a struct or enum.
 
 mvir 0x1::M1 {
-    struct NoAbilities { a: bool }
+    public struct NoAbilities { a: bool }
 }
 
 //# publish
 mvir 0x1::M2 {
     import 0x1::M1;
 
-    struct HasDrop<phantom T1, T2> has drop { a: bool }
+    public struct HasDrop<phantom T1, T2> has drop { a: bool }
 
     // `WriteRef` requires drop
     fun f(ref: &mut Self::HasDrop<M1::NoAbilities, M1::NoAbilities>) {
@@ -25,7 +25,7 @@ mvir 0x1::M2 {
 mvir 0x1::M3 {
     import 0x1::M1;
 
-    struct HasDrop<phantom T1, T2> has drop { a: bool }
+    public struct HasDrop<phantom T1, T2> has drop { a: bool }
 
     // `Pop` requires drop
     fun f() {
@@ -39,7 +39,7 @@ mvir 0x1::M3 {
  mvir 0x1::M4 {
     import 0x1::M1;
 
-    struct HasDrop<phantom T1, T2> has drop { a: bool }
+    public struct HasDrop<phantom T1, T2> has drop { a: bool }
 
     // Leaving value in local requires drop
     fun f(x: Self::HasDrop<M1::NoAbilities, M1::NoAbilities>) {
@@ -51,7 +51,7 @@ mvir 0x1::M3 {
 //# publish
  mvir 0x1::M5 {
     import 0x1::M1;
-    struct HasCopy<phantom T1, T2> has copy { a : bool }
+    public struct HasCopy<phantom T1, T2> has copy { a : bool }
 
     // `CopyLoc` requires copy
     fun f(x: Self::HasCopy<M1::NoAbilities, M1::NoAbilities>): Self::HasCopy<M1::NoAbilities, M1::NoAbilities> * Self::HasCopy<M1::NoAbilities, M1::NoAbilities> {
@@ -64,8 +64,8 @@ mvir 0x1::M3 {
 mvir 0x1::M9 {
     import 0x1::M1;
 
-    struct HasStore<phantom T1, T2> has store { a: bool }
-    struct RequireStore<T: store> { a: bool }
+    public struct HasStore<phantom T1, T2> has store { a: bool }
+    public struct RequireStore<T: store> { a: bool }
 
     fun f(): Self::RequireStore<Self::HasStore<M1::NoAbilities, M1::NoAbilities>> {
     label b0:
@@ -76,14 +76,14 @@ mvir 0x1::M9 {
 //# publish
 
 mvir 0x2::M1 {
-    enum NoAbilities { V { a: bool } }
+    public enum NoAbilities { V { a: bool } }
 }
 
 //# publish
 mvir 0x2::M2 {
     import 0x2::M1;
 
-    enum HasDrop<phantom T1, T2> has drop { V { a: bool } }
+    public enum HasDrop<phantom T1, T2> has drop { V { a: bool } }
 
     // `WriteRef` requires drop
     fun f(ref: &mut Self::HasDrop<M1::NoAbilities, M1::NoAbilities>) {
@@ -97,7 +97,7 @@ mvir 0x2::M2 {
 mvir 0x2::M3 {
     import 0x2::M1;
 
-    enum HasDrop<phantom T1, T2> has drop { V { a: bool } }
+    public enum HasDrop<phantom T1, T2> has drop { V { a: bool } }
 
     // `Pop` requires drop
     fun f() {
@@ -111,7 +111,7 @@ mvir 0x2::M3 {
  mvir 0x2::M4 {
     import 0x2::M1;
 
-    enum HasDrop<phantom T1, T2> has drop { V { a: bool } }
+    public enum HasDrop<phantom T1, T2> has drop { V { a: bool } }
 
     // Leaving value in local requires drop
     fun f(x: Self::HasDrop<M1::NoAbilities, M1::NoAbilities>) {
@@ -123,7 +123,7 @@ mvir 0x2::M3 {
 //# publish
  mvir 0x2::M5 {
     import 0x2::M1;
-    enum HasCopy<phantom T1, T2> has copy { V { a : bool } }
+    public enum HasCopy<phantom T1, T2> has copy { V { a : bool } }
 
     // `CopyLoc` requires copy
     fun f(x: Self::HasCopy<M1::NoAbilities, M1::NoAbilities>): Self::HasCopy<M1::NoAbilities, M1::NoAbilities> * Self::HasCopy<M1::NoAbilities, M1::NoAbilities> {
@@ -136,8 +136,8 @@ mvir 0x2::M3 {
 mvir 0x2::M9 {
     import 0x2::M1;
 
-    enum HasStore<phantom T1, T2> has store { V { a: bool } }
-    enum RequireStore<T: store> { V { a: bool } }
+    public enum HasStore<phantom T1, T2> has store { V { a: bool } }
+    public enum RequireStore<T: store> { V { a: bool } }
 
     fun f(): Self::RequireStore<Self::HasStore<M1::NoAbilities, M1::NoAbilities>> {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/phantom_params/bytecode_ops_abilities_ok.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/phantom_params/bytecode_ops_abilities_ok.mvir
@@ -5,12 +5,12 @@
 // abilities required for specific bytecode operatiosn.
 
 mvir 0x1::M {
-    struct NoAbilities { a: bool }
-    struct HasDrop<phantom T1, T2> has drop { a: bool }
-    struct HasCopy<phantom T1, T2> has copy { a : bool }
-    struct HasStore<phantom T1, T2> has store { a: bool }
-    struct HasKey<phantom T1, T2> has key { a : bool }
-    struct RequireStore<T: store> { a: bool }
+    public struct NoAbilities { a: bool }
+    public struct HasDrop<phantom T1, T2> has drop { a: bool }
+    public struct HasCopy<phantom T1, T2> has copy { a : bool }
+    public struct HasStore<phantom T1, T2> has store { a: bool }
+    public struct HasKey<phantom T1, T2> has key { a : bool }
+    public struct RequireStore<T: store> { a: bool }
 
     // `WriteRef` requires drop
     fun f1(ref: &mut Self::HasDrop<Self::NoAbilities, u64>) {
@@ -46,12 +46,12 @@ mvir 0x1::M {
 
 //# publish
 mvir 0x2::M {
-    enum NoAbilities { V{ a: bool } }
-    enum HasDrop<phantom T1, T2> has drop { V{ a: bool }}
-    enum HasCopy<phantom T1, T2> has copy { V{ a : bool }}
-    enum HasStore<phantom T1, T2> has store { V{ a: bool }}
-    enum HasKey<phantom T1, T2> has key { V{ a : bool } }
-    enum RequireStore<T: store> { V{ a: bool }}
+    public enum NoAbilities { V{ a: bool } }
+    public enum HasDrop<phantom T1, T2> has drop { V{ a: bool }}
+    public enum HasCopy<phantom T1, T2> has copy { V{ a : bool }}
+    public enum HasStore<phantom T1, T2> has store { V{ a: bool }}
+    public enum HasKey<phantom T1, T2> has key { V{ a : bool } }
+    public enum RequireStore<T: store> { V{ a: bool }}
 
     // `WriteRef` requires drop
     fun f1(ref: &mut Self::HasDrop<Self::NoAbilities, u64>) {

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/phantom_params/constraints_abilities_bad.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/phantom_params/constraints_abilities_bad.mvir
@@ -1,15 +1,15 @@
 //# publish
 mvir 0x1::M1 {
-    struct NoAbilities { a: bool }
-    struct HasAbilities<phantom T1, T2> has drop, copy, store, key { a: bool }
+    public struct NoAbilities { a: bool }
+    public struct HasAbilities<phantom T1, T2> has drop, copy, store, key { a: bool }
 }
 
 //# publish
 mvir 0x2::M2 {
     import 0x1::M1;
 
-    struct S1<T: drop + copy + store + key> { a: bool }
-    struct S2 {
+    public struct S1<T: drop + copy + store + key> { a: bool }
+    public struct S2 {
         a: Self::S1<M1::HasAbilities<M1::NoAbilities, M1::NoAbilities>>,
     }
 }
@@ -18,13 +18,13 @@ mvir 0x2::M2 {
 mvir 0x3::M3 {
     import 0x1::M1;
 
-    struct HasDrop<phantom T1, T2> has drop { a: bool }
-    struct HasCopy<phantom T1, T2> has copy { a: bool }
-    struct HasStore<phantom T1, T2> has store { a: bool }
-    struct HasKey<phantom T1, T2> has key { a: bool }
+    public struct HasDrop<phantom T1, T2> has drop { a: bool }
+    public struct HasCopy<phantom T1, T2> has copy { a: bool }
+    public struct HasStore<phantom T1, T2> has store { a: bool }
+    public struct HasKey<phantom T1, T2> has key { a: bool }
 
-    struct S1<T1: drop, T2: copy, T3: store, T4: key> { a: bool }
-    struct S2 {
+    public struct S1<T1: drop, T2: copy, T3: store, T4: key> { a: bool }
+    public struct S2 {
         a: Self::S1< Self::HasDrop<M1::NoAbilities, M1::NoAbilities>,
                     Self::HasCopy<M1::NoAbilities, M1::NoAbilities>,
                     Self::HasStore<M1::NoAbilities, M1::NoAbilities>,
@@ -50,10 +50,10 @@ mvir 0x4::M4 {
 mvir 0x5::M3Valid {
     import 0x1::M1;
 
-    struct HasDrop<phantom T1, T2> has drop { a: bool }
-    struct HasCopy<phantom T1, T2> has copy { a: bool }
-    struct HasStore<phantom T1, T2> has store { a: bool }
-    struct HasKey<phantom T1, T2> has key { a: bool }
+    public struct HasDrop<phantom T1, T2> has drop { a: bool }
+    public struct HasCopy<phantom T1, T2> has copy { a: bool }
+    public struct HasStore<phantom T1, T2> has store { a: bool }
+    public struct HasKey<phantom T1, T2> has key { a: bool }
 
 }
 
@@ -76,16 +76,16 @@ mvir 0x6::M5 {
 
 //# publish
 mvir 0x7::M1 {
-    enum NoAbilities { V{ a: bool } }
-    enum HasAbilities<phantom T1, T2> has drop, copy, store, key { V{ a: bool } }
+    public enum NoAbilities { V{ a: bool } }
+    public enum HasAbilities<phantom T1, T2> has drop, copy, store, key { V{ a: bool } }
 }
 
 //# publish
 mvir 0x8::M2 {
     import 0x7::M1;
 
-    enum S1<T: drop + copy + store + key> { V{ a: bool }}
-    enum S2 {
+    public enum S1<T: drop + copy + store + key> { V{ a: bool }}
+    public enum S2 {
         V { a: Self::S1<M1::HasAbilities<M1::NoAbilities, M1::NoAbilities>> } 
     }
 }
@@ -94,13 +94,13 @@ mvir 0x8::M2 {
 mvir 0x9::M3 {
     import 0x7::M1;
 
-    enum HasDrop<phantom T1, T2> has drop { V{ a: bool }}
-    enum HasCopy<phantom T1, T2> has copy { V{ a: bool }}
-    enum HasStore<phantom T1, T2> has store { V{ a: bool }}
-    enum HasKey<phantom T1, T2> has key { V{ a: bool }}
+    public enum HasDrop<phantom T1, T2> has drop { V{ a: bool }}
+    public enum HasCopy<phantom T1, T2> has copy { V{ a: bool }}
+    public enum HasStore<phantom T1, T2> has store { V{ a: bool }}
+    public enum HasKey<phantom T1, T2> has key { V{ a: bool }}
 
-    enum S1<T1: drop, T2: copy, T3: store, T4: key> { V{ a: bool }}
-    enum S2 {
+    public enum S1<T1: drop, T2: copy, T3: store, T4: key> { V{ a: bool }}
+    public enum S2 {
         V { 
             a: Self::S1< Self::HasDrop<M1::NoAbilities, M1::NoAbilities>,
                     Self::HasCopy<M1::NoAbilities, M1::NoAbilities>,
@@ -128,10 +128,10 @@ mvir 0x10::M4 {
 mvir 0x11::M3Valid {
     import 0x7::M1;
 
-    enum HasDrop<phantom T1, T2> has drop { V{ a: bool }}
-    enum HasCopy<phantom T1, T2> has copy { V{ a: bool }}
-    enum HasStore<phantom T1, T2> has store { V{ a: bool }}
-    enum HasKey<phantom T1, T2> has key { V{ a: bool }}
+    public enum HasDrop<phantom T1, T2> has drop { V{ a: bool }}
+    public enum HasCopy<phantom T1, T2> has copy { V{ a: bool }}
+    public enum HasStore<phantom T1, T2> has store { V{ a: bool }}
+    public enum HasKey<phantom T1, T2> has key { V{ a: bool }}
 
 }
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/phantom_params/constraints_abilities_ok.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/phantom_params/constraints_abilities_ok.mvir
@@ -1,19 +1,19 @@
 //# publish
 mvir 0x1::M {
-    struct NoAbilities { a: bool }
-    struct HasDrop<phantom T1, T2> has drop { a: bool }
-    struct HasCopy<phantom T1, T2> has copy { a: bool }
-    struct HasStore<phantom T1, T2> has store { a: bool }
-    struct HasKey<phantom T1, T2> has key { a: bool }
-    struct HasAbilities<phantom T1, T2> has drop, copy, store, key { a: bool }
+    public struct NoAbilities { a: bool }
+    public struct HasDrop<phantom T1, T2> has drop { a: bool }
+    public struct HasCopy<phantom T1, T2> has copy { a: bool }
+    public struct HasStore<phantom T1, T2> has store { a: bool }
+    public struct HasKey<phantom T1, T2> has key { a: bool }
+    public struct HasAbilities<phantom T1, T2> has drop, copy, store, key { a: bool }
 
-    struct S1<T: drop + copy + store + key> { a: bool }
-    struct S2 {
+    public struct S1<T: drop + copy + store + key> { a: bool }
+    public struct S2 {
         a: Self::S1<Self::HasAbilities<Self::NoAbilities, u64>>,
     }
 
-    struct S3<T1: drop, T2: copy, T3: store, T4: key> { a: bool }
-    struct S4 {
+    public struct S3<T1: drop, T2: copy, T3: store, T4: key> { a: bool }
+    public struct S4 {
         a: Self::S3< Self::HasDrop<Self::NoAbilities, u64>,
                     Self::HasCopy<Self::NoAbilities, u64>,
                     Self::HasStore<Self::NoAbilities, u64>,
@@ -42,20 +42,20 @@ mvir 0x1::M {
 
 //# publish
 mvir 0x2::M {
-    enum NoAbilities { V{ a: bool } }
-    enum HasDrop<phantom T1, T2> has drop { V{ a: bool }}
-    enum HasCopy<phantom T1, T2> has copy { V{ a: bool }}
-    enum HasStore<phantom T1, T2> has store { V{ a: bool }}
-    enum HasKey<phantom T1, T2> has key { V{ a: bool }}
-    enum HasAbilities<phantom T1, T2> has drop, copy, store, key { V{ a: bool } }
+    public enum NoAbilities { V{ a: bool } }
+    public enum HasDrop<phantom T1, T2> has drop { V{ a: bool }}
+    public enum HasCopy<phantom T1, T2> has copy { V{ a: bool }}
+    public enum HasStore<phantom T1, T2> has store { V{ a: bool }}
+    public enum HasKey<phantom T1, T2> has key { V{ a: bool }}
+    public enum HasAbilities<phantom T1, T2> has drop, copy, store, key { V{ a: bool } }
 
-    enum S1<T: drop + copy + store + key> { V{ a: bool }}
-    enum S2 {
+    public enum S1<T: drop + copy + store + key> { V{ a: bool }}
+    public enum S2 {
         V { a: Self::S1<Self::HasAbilities<Self::NoAbilities, u64>>, }
     }
 
-    enum S3<T1: drop, T2: copy, T3: store, T4: key> { V{ a: bool }}
-    enum S4 {
+    public enum S3<T1: drop, T2: copy, T3: store, T4: key> { V{ a: bool }}
+    public enum S4 {
         V { 
             a: Self::S3< Self::HasDrop<Self::NoAbilities, u64>,
                     Self::HasCopy<Self::NoAbilities, u64>,

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/phantom_params/fields_abilities_bad.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/phantom_params/fields_abilities_bad.mvir
@@ -4,12 +4,12 @@
 // parameter with a type without the required abilities.
 
 mvir 0x1::M1 {
-    struct NoAbilities { a: bool }
+    public struct NoAbilities { a: bool }
 
-    struct HasDrop<phantom T1, T2> has drop { a: bool }
-    struct HasCopy<phantom T1, T2> has copy { a : bool }
-    struct HasStore<phantom T1, T2> has store { a : bool }
-    struct HasKey<phantom T1, T2> has key { a : bool }
+    public struct HasDrop<phantom T1, T2> has drop { a: bool }
+    public struct HasCopy<phantom T1, T2> has copy { a : bool }
+    public struct HasStore<phantom T1, T2> has store { a : bool }
+    public struct HasKey<phantom T1, T2> has key { a : bool }
 
 }
 
@@ -17,39 +17,39 @@ mvir 0x1::M1 {
 mvir 0x1::M2 {
     import 0x1::M1;
 
-    struct S has drop { a: M1::HasDrop<M1::NoAbilities, M1::NoAbilities> }
+    public struct S has drop { a: M1::HasDrop<M1::NoAbilities, M1::NoAbilities> }
 }
 
 //# publish
 mvir 0x1::M3 {
     import 0x1::M1;
 
-    struct S has copy { a: M1::HasCopy<M1::NoAbilities, M1::NoAbilities> }
+    public struct S has copy { a: M1::HasCopy<M1::NoAbilities, M1::NoAbilities> }
 }
 
 //# publish
 mvir 0x1::M4 {
     import 0x1::M1;
 
-    struct S has store { a: M1::HasStore<M1::NoAbilities, M1::NoAbilities> }
+    public struct S has store { a: M1::HasStore<M1::NoAbilities, M1::NoAbilities> }
 }
 
 //# publish
 mvir 0x1::M5 {
     import 0x1::M1;
 
-    struct S has key { a: M1::HasStore<M1::NoAbilities, M1::NoAbilities> }
+    public struct S has key { a: M1::HasStore<M1::NoAbilities, M1::NoAbilities> }
 }
 
 //# publish
 
 mvir 0x2::M1 {
-    enum NoAbilities { V{ a: bool } }
+    public enum NoAbilities { V{ a: bool } }
 
-    enum HasDrop<phantom T1, T2> has drop { V{ a: bool }}
-    enum HasCopy<phantom T1, T2> has copy { V{ a : bool }}
-    enum HasStore<phantom T1, T2> has store { V{ a : bool } }
-    enum HasKey<phantom T1, T2> has key { V{ a : bool } }
+    public enum HasDrop<phantom T1, T2> has drop { V{ a: bool }}
+    public enum HasCopy<phantom T1, T2> has copy { V{ a : bool }}
+    public enum HasStore<phantom T1, T2> has store { V{ a : bool } }
+    public enum HasKey<phantom T1, T2> has key { V{ a : bool } }
 
 }
 
@@ -57,26 +57,26 @@ mvir 0x2::M1 {
 mvir 0x2::M2 {
     import 0x2::M1;
 
-    enum S has drop { V{ a: M1::HasDrop<M1::NoAbilities, M1::NoAbilities> }}
+    public enum S has drop { V{ a: M1::HasDrop<M1::NoAbilities, M1::NoAbilities> }}
 }
 
 //# publish
 mvir 0x2::M3 {
     import 0x2::M1;
 
-    enum S has copy { V{ a: M1::HasCopy<M1::NoAbilities, M1::NoAbilities> }}
+    public enum S has copy { V{ a: M1::HasCopy<M1::NoAbilities, M1::NoAbilities> }}
 }
 
 //# publish
 mvir 0x2::M4 {
     import 0x2::M1;
 
-    enum S has store { V{ a: M1::HasStore<M1::NoAbilities, M1::NoAbilities> }}
+    public enum S has store { V{ a: M1::HasStore<M1::NoAbilities, M1::NoAbilities> }}
 }
 
 //# publish
 mvir 0x2::M5 {
     import 0x2::M1;
 
-    enum S has key { V{ a: M1::HasStore<M1::NoAbilities, M1::NoAbilities> }}
+    public enum S has key { V{ a: M1::HasStore<M1::NoAbilities, M1::NoAbilities> }}
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/phantom_params/fields_abilities_ok.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/phantom_params/fields_abilities_ok.mvir
@@ -4,31 +4,31 @@
 // the abilities required for the fields of a struct/enum.
 
 mvir 0x1::M {
-    struct NoAbilities { a: bool }
+    public struct NoAbilities { a: bool }
 
-    struct HasDrop<phantom T1, T2> has drop { a: bool }
-    struct HasCopy<phantom T1, T2> has copy { a : bool }
-    struct HasStore<phantom T1, T2> has store { a : bool }
-    struct HasKey<phantom T1, T2> has key { a : bool }
+    public struct HasDrop<phantom T1, T2> has drop { a: bool }
+    public struct HasCopy<phantom T1, T2> has copy { a : bool }
+    public struct HasStore<phantom T1, T2> has store { a : bool }
+    public struct HasKey<phantom T1, T2> has key { a : bool }
 
-    struct S1 has drop { a: Self::HasDrop<Self::NoAbilities, u64> }
-    struct S2 has copy { a: Self::HasCopy<Self::NoAbilities, u64> }
-    struct S3 has store { a: Self::HasStore<Self::NoAbilities, u64> }
-    struct S4 has key { a: Self::HasStore<Self::NoAbilities, u64> }
+    public struct S1 has drop { a: Self::HasDrop<Self::NoAbilities, u64> }
+    public struct S2 has copy { a: Self::HasCopy<Self::NoAbilities, u64> }
+    public struct S3 has store { a: Self::HasStore<Self::NoAbilities, u64> }
+    public struct S4 has key { a: Self::HasStore<Self::NoAbilities, u64> }
 }
 
 //# publish
 
 mvir 0x2::M {
-    enum NoAbilities { V{ a: bool } }
+    public enum NoAbilities { V{ a: bool } }
 
-    enum HasDrop<phantom T1, T2> has drop { V{ a: bool }}
-    enum HasCopy<phantom T1, T2> has copy { V{ a : bool }}
-    enum HasStore<phantom T1, T2> has store { V{ a : bool } }
-    enum HasKey<phantom T1, T2> has key { V{ a : bool } }
+    public enum HasDrop<phantom T1, T2> has drop { V{ a: bool }}
+    public enum HasCopy<phantom T1, T2> has copy { V{ a : bool }}
+    public enum HasStore<phantom T1, T2> has store { V{ a : bool } }
+    public enum HasKey<phantom T1, T2> has key { V{ a : bool } }
 
-    enum S1 has drop { V{ a: Self::HasDrop<Self::NoAbilities, u64> }}
-    enum S2 has copy { V{ a: Self::HasCopy<Self::NoAbilities, u64> }}
-    enum S3 has store { V{ a: Self::HasStore<Self::NoAbilities, u64> }}
-    enum S4 has key { V{ a: Self::HasStore<Self::NoAbilities, u64> }}
+    public enum S1 has drop { V{ a: Self::HasDrop<Self::NoAbilities, u64> }}
+    public enum S2 has copy { V{ a: Self::HasCopy<Self::NoAbilities, u64> }}
+    public enum S3 has store { V{ a: Self::HasStore<Self::NoAbilities, u64> }}
+    public enum S4 has key { V{ a: Self::HasStore<Self::NoAbilities, u64> }}
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/phantom_params/struct_definition_bad.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/phantom_params/struct_definition_bad.mvir
@@ -5,7 +5,7 @@
 
 mvir 0x1::M1 {
     // A phantom parameter cannot be used as the type of a field
-    struct S1<phantom T> {
+    public struct S1<phantom T> {
         a: T
     }
 }
@@ -13,7 +13,7 @@ mvir 0x1::M1 {
 //# publish
 mvir 0x1::M2 {
     // The parameter of vector is non-phantom and a phantom parameter shouldn't be allowed in that position
-    struct S2<phantom T> {
+    public struct S2<phantom T> {
         a: vector<T>
     }
 }
@@ -21,8 +21,8 @@ mvir 0x1::M2 {
 //# publish
 mvir 0x1::M3 {
     // A phantom parameter cannot be used as the argument to a non-phantom parameter
-    struct S1<T> { f: bool }
-    struct S2<phantom T> {
+    public struct S1<T> { f: bool }
+    public struct S2<phantom T> {
         a: Self::S1<T>
     }
 }
@@ -31,9 +31,9 @@ mvir 0x1::M3 {
 mvir 0x1::M4 {
     // More complicated test where the phantom position violation is inside another
     // type argument.
-    struct S1<T> { a: T}
-    struct S2<T> { a : T }
-    struct S3<phantom T> {
+    public struct S1<T> { a: T}
+    public struct S2<T> { a : T }
+    public struct S3<phantom T> {
         a: Self::S1<Self::S2<T>>
     }
 }
@@ -41,7 +41,7 @@ mvir 0x1::M4 {
 //# publish
 mvir 0x1::M5 {
     // Mixing phantom and non-phantom parameters
-    struct S<T1, phantom T2, T3> {
+    public struct S<T1, phantom T2, T3> {
         a: T2
     }
 }
@@ -49,8 +49,8 @@ mvir 0x1::M5 {
 //# publish
 mvir 0x1::M6 {
     // Phantom parameters should satisfy constraints
-    struct S1<phantom T: copy> { a: bool }
-    struct S2<phantom T> {
+    public struct S1<phantom T: copy> { a: bool }
+    public struct S2<phantom T> {
         a: Self::S1<T>
     }
 }
@@ -62,7 +62,7 @@ mvir 0x1::M6 {
 
 mvir 0x2::M1 {
     // A phantom parameter cannot be used as the type of a field
-    enum S1<phantom T> {
+    public enum S1<phantom T> {
         V { a: T }
     }
 }
@@ -70,7 +70,7 @@ mvir 0x2::M1 {
 //# publish
 mvir 0x2::M2 {
     // The parameter of vector is non-phantom and a phantom parameter shouldn't be allowed in that position
-    enum S2<phantom T> {
+    public enum S2<phantom T> {
         V { a: vector<T> }
     }
 }
@@ -78,8 +78,8 @@ mvir 0x2::M2 {
 //# publish
 mvir 0x2::M3 {
     // A phantom parameter cannot be used as the argument to a non-phantom parameter
-    enum S1<T> { V{ f: bool }}
-    enum S2<phantom T> {
+    public enum S1<T> { V{ f: bool }}
+    public enum S2<phantom T> {
         V { a: Self::S1<T> }
     }
 }
@@ -88,9 +88,9 @@ mvir 0x2::M3 {
 mvir 0x2::M4 {
     // More complicated test where the phantom position violation is inside another
     // type argument.
-    enum S1<T> { V{ a: T}}
-    enum S2<T> { V{ a : T } }
-    enum S3<phantom T> {
+    public enum S1<T> { V{ a: T}}
+    public enum S2<T> { V{ a : T } }
+    public enum S3<phantom T> {
         V { a: Self::S1<Self::S2<T>> }
     }
 }
@@ -98,7 +98,7 @@ mvir 0x2::M4 {
 //# publish
 mvir 0x2::M5 {
     // Mixing phantom and non-phantom parameters
-    enum S<T1, phantom T2, T3> {
+    public enum S<T1, phantom T2, T3> {
         V { a: T2 }
     }
 }
@@ -106,8 +106,8 @@ mvir 0x2::M5 {
 //# publish
 mvir 0x2::M6 {
     // Phantom parameters should satisfy constraints
-    enum S1<phantom T: copy> { V{ a: bool } }
-    enum S2<phantom T> {
+    public enum S1<phantom T: copy> { V{ a: bool } }
+    public enum S2<phantom T> {
         V { a: Self::S1<T> }
     }
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/phantom_params/struct_definition_ok.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/phantom_params/struct_definition_ok.mvir
@@ -1,23 +1,23 @@
 //# publish
 mvir 0x1::M1 {
     // Not using a phantom parameter at all is ok.
-    struct S1<phantom T> {
+    public struct S1<phantom T> {
         a: u64
     }
 
     // Phantom parameters can be used in phantom position.
-    struct S2<phantom T> {
+    public struct S2<phantom T> {
         a: Self::S1<T>,
         b: vector<Self::S1<T>>
     }
 
     // It's ok to not use a non-phantom parameter (backward-compatibility).
-    struct S3<T> {
+    public struct S3<T> {
         a: u64
     }
 
     // Mixing phantom and non-phantom parameters
-    struct S4<phantom T1, T2, phantom T3, T4> {
+    public struct S4<phantom T1, T2, phantom T3, T4> {
         a: T2,
         b: T4
     }
@@ -28,7 +28,7 @@ mvir 0x2::M2 {
     import 0x1::M1;
 
     // Phantom position across modules
-    struct S<phantom T> {
+    public struct S<phantom T> {
         a: M1::S2<M1::S1<T>>
     }
 }
@@ -37,11 +37,11 @@ mvir 0x2::M2 {
 mvir 0x3::M3 {
     // Phantom parameters should be allowed to be declared with constraints.
 
-    struct S1<phantom T: copy> {
+    public struct S1<phantom T: copy> {
         a: u64
     }
 
-    struct S2<phantom T: copy + drop + store> {
+    public struct S2<phantom T: copy + drop + store> {
         a: Self::S1<T>
     }
 }
@@ -49,12 +49,12 @@ mvir 0x3::M3 {
 //# publish
 mvir 0x4::M1 {
     // Not using a phantom parameter at all is ok.
-    enum S1<phantom T> {
+    public enum S1<phantom T> {
         V { a: u64 }
     }
 
     // Phantom parameters can be used in phantom position.
-    enum S2<phantom T> {
+    public enum S2<phantom T> {
         V {
             a: Self::S1<T>,
             b: vector<Self::S1<T>>
@@ -62,12 +62,12 @@ mvir 0x4::M1 {
     }
 
     // It's ok to not use a non-phantom parameter (backward-compatibility).
-    enum S3<T> {
+    public enum S3<T> {
         V { a: u64 }
     }
 
     // Mixing phantom and non-phantom parameters
-    enum S4<phantom T1, T2, phantom T3, T4> {
+    public enum S4<phantom T1, T2, phantom T3, T4> {
         V {
             a: T2,
             b: T4
@@ -80,7 +80,7 @@ mvir 0x5::M2 {
     import 0x4::M1;
 
     // Phantom position across modules
-    enum S<phantom T> {
+    public enum S<phantom T> {
         V { a: M1::S2<M1::S1<T>> }
     }
 }
@@ -89,11 +89,11 @@ mvir 0x5::M2 {
 mvir 0x5::M3 {
     // Phantom parameters should be allowed to be declared with constraints.
 
-    enum S1<phantom T: copy> {
+    public enum S1<phantom T: copy> {
         V { a: u64 }
     }
 
-    enum S2<phantom T: copy + drop + store> {
+    public enum S2<phantom T: copy + drop + store> {
         V { a: Self::S1<T> }
     }
 }
@@ -103,7 +103,7 @@ mvir 0x6::M4 {
     import 0x1::M1;
 
     // Phantom position across modules
-    enum S<phantom T> {
+    public enum S<phantom T> {
         V { a: M1::S2<M1::S1<T>> }
     }
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/ref_type_param.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/ref_type_param.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x42::M1 {
-    struct S<T: copy> { t: T }
+    public struct S<T: copy> { t: T }
 
     // should get flagged w/ constraint not satisfied--T does not have copy
     public fun bad_sig<T>(s: &Self::S<T>) {
@@ -11,7 +11,7 @@ mvir 0x42::M1 {
 
 //# publish
 mvir 0x42::M2 {
-    struct S<T: copy> { t: T }
+    public struct S<T: copy> { t: T }
 
     // should get flagged w/ constraint not satisfied--T does not have copy
     public fun bad_sig<T>(s: &mut Self::S<T>) {
@@ -22,7 +22,7 @@ mvir 0x42::M2 {
 
 //# publish
 mvir 0x42::M3 {
-    struct S<T: copy> { t: T }
+    public struct S<T: copy> { t: T }
 
     // should get flagged--missing type argument
     public fun bad_sig<T>(s: &Self::S) {
@@ -33,8 +33,8 @@ mvir 0x42::M3 {
 
 //# publish
 mvir 0x42::M4 {
-    struct Box<T> { t: T }
-    struct S<T: copy> { t: T }
+    public struct Box<T> { t: T }
+    public struct S<T: copy> { t: T }
 
     // should be rejected
     public fun bad_sig<T>(v: Self::Box<Self::S<T>>): Self::Box<Self::S<T>> {
@@ -45,7 +45,7 @@ mvir 0x42::M4 {
 
 //# publish
 mvir 0x43::M1 {
-    enum S<T: copy> { V{ t: T } }
+    public enum S<T: copy> { V{ t: T } }
 
     // should get flagged w/ constraint not satisfied--T does not have copy
     public fun bad_sig<T>(s: &Self::S<T>) {
@@ -56,7 +56,7 @@ mvir 0x43::M1 {
 
 //# publish
 mvir 0x43::M2 {
-    struct S<T: copy> { t: T }
+    public struct S<T: copy> { t: T }
 
     // should get flagged w/ constraint not satisfied--T does not have copy
     public fun bad_sig<T>(s: &mut Self::S<T>) {
@@ -67,7 +67,7 @@ mvir 0x43::M2 {
 
 //# publish
 mvir 0x43::M3 {
-    enum S<T: copy> { V{ t: T } }
+    public enum S<T: copy> { V{ t: T } }
 
     // should get flagged--missing type argument
     public fun bad_sig<T>(s: &Self::S) {
@@ -78,8 +78,8 @@ mvir 0x43::M3 {
 
 //# publish
 mvir 0x43::M4 {
-    enum Box<T> { V{ t: T } }
-    enum S<T: copy> { V{ t: T } }
+    public enum Box<T> { V{ t: T } }
+    public enum S<T: copy> { V{ t: T } }
 
     // should be rejected
     public fun bad_sig<T>(v: Self::Box<Self::S<T>>): Self::Box<Self::S<T>> {

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/ref_type_param_exploits.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/ref_type_param_exploits.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x42::M1 {
-    struct S<T: copy> { t: T }
+    public struct S<T: copy> { t: T }
 
     // note: T does not have copy
     // if this worked, it would be very bad because `T` can be (e.g.) a Coin
@@ -12,7 +12,7 @@ mvir 0x42::M1 {
 
 //# publish
 mvir 0x42::M2 {
-    struct S<T: copy> has copy { t: T }
+    public struct S<T: copy> has copy { t: T }
 
     // note: T does not have copy
     // if this worked, it would be very bad because `T` can be (e.g.) a Coin
@@ -24,7 +24,7 @@ mvir 0x42::M2 {
 
 //# publish
 mvir 0x42::M3 {
-    struct S<T: store> has store { t: T }
+    public struct S<T: store> has store { t: T }
 
     // note: T does not have store
     // if this worked, it would be very bad because `T` can be (e.g.) a hot potato
@@ -37,7 +37,7 @@ mvir 0x42::M3 {
 
 //# publish
 mvir 0x42::M4 {
-    struct S<T: copy> { t: T }
+    public struct S<T: copy> { t: T }
 
     public fun bad_sig<T>(s: &Self::S<T>) { // should get flagged w/ constraint not satisfied
     label b0:
@@ -55,7 +55,7 @@ mvir 0x42::M4 {
 
 //# publish
 mvir 0x42::M5 {
-    struct S<T: copy> { t: T }
+    public struct S<T: copy> { t: T }
 
     public fun bad_sig<T>(s: &Self::S<T>) { // should get flagged w/ constraint not satisfied
     label b0:
@@ -73,7 +73,7 @@ mvir 0x42::M5 {
 
 //# publish
 mvir 0x43::M1 {
-    enum S<T: copy> { V{ t: T } }
+    public enum S<T: copy> { V{ t: T } }
 
     // note: T does not have copy
     // if this worked, it would be very bad because `T` can be (e.g.) a Coin
@@ -87,7 +87,7 @@ mvir 0x43::M1 {
 
 //# publish
 mvir 0x43::M2 {
-    enum S<T: copy> has copy { V{ t: T } }
+    public enum S<T: copy> has copy { V{ t: T } }
 
     // note: T does not have copy
     // if this worked, it would be very bad because `T` can be (e.g.) a Coin
@@ -99,7 +99,7 @@ mvir 0x43::M2 {
 
 //# publish
 mvir 0x43::M3 {
-    enum S<T: store> has store { V{ t: T } }
+    public enum S<T: store> has store { V{ t: T } }
 
     // note: T does not have store
     // if this worked, it would be very bad because `T` can be (e.g.) a hot potato
@@ -113,7 +113,7 @@ mvir 0x43::M3 {
 
 //# publish
 mvir 0x43::M4 {
-    enum S<T: copy> { V{ t: T } }
+    public enum S<T: copy> { V{ t: T } }
 
     public fun bad_sig<T>(s: &Self::S<T>) { // should get flagged w/ constraint not satisfied
     label b0:
@@ -131,7 +131,7 @@ mvir 0x43::M4 {
 
 //# publish
 mvir 0x43::M5 {
-    enum S<T: copy> { V{ t: T } }
+    public enum S<T: copy> { V{ t: T } }
 
     public fun bad_sig<T>(s: &Self::S<T>) { // should get flagged w/ constraint not satisfied
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/release.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/release.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x1::M {
-    struct Coin { value: u64 }
+    public struct Coin { value: u64 }
     fun t(): Self::Coin {
     label b0:
         // cannot pop without the drop ability
@@ -11,7 +11,7 @@ mvir 0x1::M {
 
 //# publish
 mvir 0x2::M {
-    enum Coin { V { value: u64 } }
+    public enum Coin { V { value: u64 } }
     fun t(): Self::Coin {
     label b0:
         // cannot pop without the drop ability

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/resource_instantiate_bad_type.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/resource_instantiate_bad_type.mvir
@@ -1,9 +1,9 @@
 //# publish
 
 mvir 0x42::Test {
-    struct A { b: bool }
-    struct B { b: bool }
-    struct T { ft: Self::B }
+    public struct A { b: bool }
+    public struct B { b: bool }
+    public struct T { ft: Self::B }
 
     public fun t1(x: Self::A): Self::T {
     label b0:
@@ -16,9 +16,9 @@ mvir 0x42::Test {
 //# publish
 
 mvir 0x43::Test {
-    struct B { b: bool }
-    enum A { V { b: bool } }
-    enum T { V { ft: Self::B } }
+    public struct B { b: bool }
+    public enum A { V { b: bool } }
+    public enum T { V { ft: Self::B } }
 
     public fun t1(x: Self::A): Self::T {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/return_type_mismatch_and_unused_resource.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/return_type_mismatch_and_unused_resource.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x1::M {
-    struct R { flag: bool }
+    public struct R { flag: bool }
 
     // Type checking is done before memory safety checks
     // wrong return type
@@ -28,7 +28,7 @@ mvir 0x1::M2 {
 
 //# publish
 mvir 0x1::M {
-    struct R { flag: bool }
+    public struct R { flag: bool }
 
     fun t1(): u64 {
         let c: Self::R;
@@ -54,7 +54,7 @@ mvir 0x1::M2 {
 
 //# publish
 mvir 0x2::M {
-    enum R { V { flag: bool } }
+    public enum R { V { flag: bool } }
 
     // Type checking is done before memory safety checks
     // wrong return type
@@ -68,7 +68,7 @@ mvir 0x2::M {
 
 //# publish
 mvir 0x2::M {
-    enum R { V { flag: bool } }
+    public enum R { V { flag: bool } }
 
     fun t1(): u64 {
         let c: Self::R;

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/signer_copy_loc_transitive.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/signer_copy_loc_transitive.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x42::M {
-    struct S<T> has copy { s: T }
+    public struct S<T> has copy { s: T }
     fun t(s: signer): Self::S<signer> {
         let x: Self::S<signer>;
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/signer_does_not_have_store.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/signer_does_not_have_store.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x42::M {
-    struct S<T> {
+    public struct S<T> {
         f: T,
     }
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/signer_read_ref_transitive.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/signer_read_ref_transitive.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x42::M {
-    struct S<T> { s: T }
+    public struct S<T> { s: T }
     fun t(s: signer): Self::S<signer> {
         let x: Self::S<signer>;
     label b0:
@@ -12,7 +12,7 @@ mvir 0x42::M {
 
 //# publish
 mvir 0x42::M {
-    struct S<T> { s: T }
+    public struct S<T> { s: T }
     fun t(s: signer): signer {
         let x: Self::S<signer>;
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/signer_transitive.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/signer_transitive.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x42::M {
-    struct S<T> has drop {
+    public struct S<T> has drop {
         f: T,
     }
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/struct_kind_inference.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/struct_kind_inference.mvir
@@ -1,8 +1,8 @@
 //# publish
 // ensure that generic structs instantiated with struct types behave like resources
 mvir 0x1::M1 {
-    struct MyResource { b: bool }
-    struct S<T> { t: T }
+    public struct MyResource { b: bool }
+    public struct S<T> { t: T }
 
     // verifer should reject; didn't move resource;
     public fun p(s: Self::S<Self::MyResource>) {
@@ -13,8 +13,8 @@ mvir 0x1::M1 {
 
 //# publish
 mvir 0x1::M2 {
-    struct MyResource { b: bool }
-    struct S<T> { t: T }
+    public struct MyResource { b: bool }
+    public struct S<T> { t: T }
 
     // verifier should reject; drops s2 on the floor
     public fun p(s1: Self::S<Self::MyResource>, s2: Self::S<Self::MyResource>): Self::S<Self::MyResource> {
@@ -26,8 +26,8 @@ mvir 0x1::M2 {
 
 //# publish
 mvir 0x1::M3 {
-    struct MyResource { b: bool }
-    struct S<T> { t: T }
+    public struct MyResource { b: bool }
+    public struct S<T> { t: T }
 
     // verifier should reject; copies s
     public fun p(s: &Self::S<Self::MyResource>): Self::S<Self::MyResource> {
@@ -38,8 +38,8 @@ mvir 0x1::M3 {
 
 //# publish
 mvir 0x1::M4 {
-    struct MyResource { b: bool }
-    struct S<T> { t: T }
+    public struct MyResource { b: bool }
+    public struct S<T> { t: T }
 
     // verifier should reject; drops s1 on the floor
     public fun p(s1: &mut Self::S<Self::MyResource>, s2: Self::S<Self::MyResource>) {
@@ -51,8 +51,8 @@ mvir 0x1::M4 {
 
 //# publish
 mvir 0x1::M5 {
-    struct MyResource { b: bool }
-    struct S<T> { t: T }
+    public struct MyResource { b: bool }
+    public struct S<T> { t: T }
 
     // verifier should reject; copies s
     public fun p(s: Self::S<Self::MyResource>): Self::S<Self::MyResource> * Self::S<Self::MyResource> {
@@ -64,8 +64,8 @@ mvir 0x1::M5 {
 //# publish
 // ensure that generic enums instantiated with enum types behave like resources
 mvir 0x2::M1 {
-    enum MyResource { V{ b: bool } }
-    enum S<T> { V{ t: T } }
+    public enum MyResource { V{ b: bool } }
+    public enum S<T> { V{ t: T } }
 
     // verifer should reject; didn't move resource;
     public fun p(s: Self::S<Self::MyResource>) {
@@ -76,8 +76,8 @@ mvir 0x2::M1 {
 
 //# publish
 mvir 0x2::M2 {
-    enum MyResource { V{ b: bool } }
-    enum S<T> { V{ t: T } }
+    public enum MyResource { V{ b: bool } }
+    public enum S<T> { V{ t: T } }
 
     // verifier should reject; drops s2 on the floor
     public fun p(s1: Self::S<Self::MyResource>, s2: Self::S<Self::MyResource>): Self::S<Self::MyResource> {
@@ -89,8 +89,8 @@ mvir 0x2::M2 {
 
 //# publish
 mvir 0x2::M3 {
-    enum MyResource { V{ b: bool } }
-    enum S<T> { V{ t: T } }
+    public enum MyResource { V{ b: bool } }
+    public enum S<T> { V{ t: T } }
 
     // verifier should reject; copies s
     public fun p(s: &Self::S<Self::MyResource>): Self::S<Self::MyResource> {
@@ -101,8 +101,8 @@ mvir 0x2::M3 {
 
 //# publish
 mvir 0x2::M4 {
-    enum MyResource { V{ b: bool } }
-    enum S<T> { V{ t: T } }
+    public enum MyResource { V{ b: bool } }
+    public enum S<T> { V{ t: T } }
 
     // verifier should reject; drops s1 on the floor
     public fun p(s1: &mut Self::S<Self::MyResource>, s2: Self::S<Self::MyResource>) {
@@ -114,8 +114,8 @@ mvir 0x2::M4 {
 
 //# publish
 mvir 0x2::M5 {
-    enum MyResource { V{ b: bool } }
-    enum S<T> { V{ t: T } }
+    public enum MyResource { V{ b: bool } }
+    public enum S<T> { V{ t: T } }
 
     // verifier should reject; copies s
     public fun p(s: Self::S<Self::MyResource>): Self::S<Self::MyResource> * Self::S<Self::MyResource> {

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/unpack_generic_enum_non_generically.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/unpack_generic_enum_non_generically.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x2::ByValue {
-    enum Foo<T> { V { x: T } }
+    public enum Foo<T> { V { x: T } }
 
     fun foo(y: Self::Foo<u64>) {
         let x: u64;
@@ -13,7 +13,7 @@ mvir 0x2::ByValue {
 
 //# publish
 mvir 0x2::ByImmRef {
-    enum Foo<T> { V { x: T } }
+    public enum Foo<T> { V { x: T } }
 
     fun foo(y: Self::Foo<u64>) {
         let x: u64;
@@ -26,7 +26,7 @@ mvir 0x2::ByImmRef {
 
 //# publish
 mvir 0x2::ByMutRef {
-    enum Foo<T> { V { x: T } }
+    public enum Foo<T> { V { x: T } }
 
     fun foo(y: Self::Foo<u64>) {
         let x: u64;
@@ -39,7 +39,7 @@ mvir 0x2::ByMutRef {
 
 //# publish
 mvir 0x2::ByValue {
-    enum Foo<T> { V { x: T } }
+    public enum Foo<T> { V { x: T } }
 
     fun foo(y: &Self::Foo<u64>) {
         let x: u64;
@@ -52,7 +52,7 @@ mvir 0x2::ByValue {
 
 //# publish
 mvir 0x2::ByImmRef {
-    enum Foo<T> { V { x: T } }
+    public enum Foo<T> { V { x: T } }
 
     fun foo(y: &Self::Foo<u64>) {
         let x: u64;
@@ -65,7 +65,7 @@ mvir 0x2::ByImmRef {
 
 //# publish
 mvir 0x2::ByMutRef {
-    enum Foo<T> { V { x: T } }
+    public enum Foo<T> { V { x: T } }
 
     fun foo(y: &Self::Foo<u64>) {
         let x: u64;
@@ -78,7 +78,7 @@ mvir 0x2::ByMutRef {
 
 //# publish
 mvir 0x2::ByValue {
-    enum Foo<T> { V { x: T } }
+    public enum Foo<T> { V { x: T } }
 
     fun foo(y: &mut Self::Foo<u64>) {
         let x: u64;
@@ -91,7 +91,7 @@ mvir 0x2::ByValue {
 
 //# publish
 mvir 0x2::ByImmRef {
-    enum Foo<T> { V { x: T } }
+    public enum Foo<T> { V { x: T } }
 
     fun foo(y: &mut Self::Foo<u64>) {
         let x: u64;
@@ -104,7 +104,7 @@ mvir 0x2::ByImmRef {
 
 //# publish
 mvir 0x2::ByMutRef {
-    enum Foo<T> { V { x: T } }
+    public enum Foo<T> { V { x: T } }
 
     fun foo(y: &mut Self::Foo<u64>) {
         let x: u64;

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/unpack_generic_enum_wrong_type_arg.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/unpack_generic_enum_wrong_type_arg.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x2::ByValue {
-    enum Foo<T> { V { x: T } }
+    public enum Foo<T> { V { x: T } }
 
     fun foo(y: Self::Foo<u64>) {
         let x: u64;
@@ -13,7 +13,7 @@ mvir 0x2::ByValue {
 
 //# publish
 mvir 0x2::ByImmRef {
-    enum Foo<T> { V { x: T } }
+    public enum Foo<T> { V { x: T } }
 
     fun foo(y: Self::Foo<u64>) {
         let x: u64;
@@ -26,7 +26,7 @@ mvir 0x2::ByImmRef {
 
 //# publish
 mvir 0x2::ByMutRef {
-    enum Foo<T> { V { x: T } }
+    public enum Foo<T> { V { x: T } }
 
     fun foo(y: Self::Foo<u64>) {
         let x: u64;
@@ -39,7 +39,7 @@ mvir 0x2::ByMutRef {
 
 //# publish
 mvir 0x2::ByValue {
-    enum Foo<T> { V { x: T } }
+    public enum Foo<T> { V { x: T } }
 
     fun foo(y: &Self::Foo<u64>) {
         let x: u64;
@@ -52,7 +52,7 @@ mvir 0x2::ByValue {
 
 //# publish
 mvir 0x2::ByImmRef {
-    enum Foo<T> { V { x: T } }
+    public enum Foo<T> { V { x: T } }
 
     fun foo(y: &Self::Foo<u64>) {
         let x: u64;
@@ -65,7 +65,7 @@ mvir 0x2::ByImmRef {
 
 //# publish
 mvir 0x2::ByMutRef {
-    enum Foo<T> { V { x: T } }
+    public enum Foo<T> { V { x: T } }
 
     fun foo(y: &Self::Foo<u64>) {
         let x: u64;
@@ -78,7 +78,7 @@ mvir 0x2::ByMutRef {
 
 //# publish
 mvir 0x2::ByValue {
-    enum Foo<T> { V { x: T } }
+    public enum Foo<T> { V { x: T } }
 
     fun foo(y: &mut Self::Foo<u64>) {
         let x: u64;
@@ -91,7 +91,7 @@ mvir 0x2::ByValue {
 
 //# publish
 mvir 0x2::ByImmRef {
-    enum Foo<T> { V { x: T } }
+    public enum Foo<T> { V { x: T } }
 
     fun foo(y: &mut Self::Foo<u64>) {
         let x: u64;
@@ -104,7 +104,7 @@ mvir 0x2::ByImmRef {
 
 //# publish
 mvir 0x2::ByMutRef {
-    enum Foo<T> { V { x: T } }
+    public enum Foo<T> { V { x: T } }
 
     fun foo(y: &mut Self::Foo<u64>) {
         let x: u64;

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/unpack_non_generic_enum_generically.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/unpack_non_generic_enum_generically.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x2::ByValue {
-    enum Foo { V { x: u64 } }
+    public enum Foo { V { x: u64 } }
 
     fun foo(y: Self::Foo) {
         let x: u64;
@@ -13,7 +13,7 @@ mvir 0x2::ByValue {
 
 //# publish
 mvir 0x2::ByImmRef {
-    enum Foo { V { x: u64 } }
+    public enum Foo { V { x: u64 } }
 
     fun foo(y: Self::Foo) {
         let x: u64;
@@ -26,7 +26,7 @@ mvir 0x2::ByImmRef {
 
 //# publish
 mvir 0x2::ByMutRef {
-    enum Foo { V { x: u64 } }
+    public enum Foo { V { x: u64 } }
 
     fun foo(y: Self::Foo) {
         let x: u64;
@@ -39,7 +39,7 @@ mvir 0x2::ByMutRef {
 
 //# publish
 mvir 0x2::ByValue {
-    enum Foo { V { x: u64 } }
+    public enum Foo { V { x: u64 } }
 
     fun foo(y: &Self::Foo) {
         let x: u64;
@@ -52,7 +52,7 @@ mvir 0x2::ByValue {
 
 //# publish
 mvir 0x2::ByImmRef {
-    enum Foo { V { x: u64 } }
+    public enum Foo { V { x: u64 } }
 
     fun foo(y: &Self::Foo) {
         let x: u64;
@@ -65,7 +65,7 @@ mvir 0x2::ByImmRef {
 
 //# publish
 mvir 0x2::ByMutRef {
-    enum Foo { V { x: u64 } }
+    public enum Foo { V { x: u64 } }
 
     fun foo(y: &Self::Foo) {
         let x: u64;
@@ -78,7 +78,7 @@ mvir 0x2::ByMutRef {
 
 //# publish
 mvir 0x2::ByValue {
-    enum Foo { V { x: u64 } }
+    public enum Foo { V { x: u64 } }
 
     fun foo(y: &mut Self::Foo) {
         let x: u64;
@@ -91,7 +91,7 @@ mvir 0x2::ByValue {
 
 //# publish
 mvir 0x2::ByImmRef {
-    enum Foo { V { x: u64 } }
+    public enum Foo { V { x: u64 } }
 
     fun foo(y: &mut Self::Foo) {
         let x: u64;
@@ -104,7 +104,7 @@ mvir 0x2::ByImmRef {
 
 //# publish
 mvir 0x2::ByMutRef {
-    enum Foo { V { x: u64 } }
+    public enum Foo { V { x: u64 } }
 
     fun foo(y: &mut Self::Foo) {
         let x: u64;

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/unpack_resource.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/unpack_resource.mvir
@@ -1,7 +1,7 @@
 //# publish
 mvir 0x1::Test {
-    struct X { b: bool }
-    struct T { i: u64, x: Self::X, b: bool }
+    public struct X { b: bool }
+    public struct T { i: u64, x: Self::X, b: bool }
 
     public fun new_x(): Self::X {
     label b0:
@@ -52,8 +52,8 @@ label b0:
 
 //# publish
 mvir 0x3::Test {
-    enum X { V{ b: bool } }
-    enum T { V{ i: u64, x: Self::X, b: bool } }
+    public enum X { V{ b: bool } }
+    public enum T { V{ i: u64, x: Self::X, b: bool } }
 
     public fun new_x(): Self::X {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/unpack_wrong_type.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/unpack_wrong_type.mvir
@@ -1,7 +1,7 @@
 //# publish
 mvir 0x1::Test {
-    struct X { b: bool }
-    struct T { b: bool }
+    public struct X { b: bool }
+    public struct T { b: bool }
 
     public fun new_t(): Self::T {
     label b0:
@@ -20,8 +20,8 @@ mvir 0x1::Test {
 
 //# publish
 mvir 0x2::Test {
-    enum X { V { b: bool } }
-    enum T { V { b: bool } }
+    public enum X { V { b: bool } }
+    public enum T { V { b: bool } }
 
     public fun new_t(): Self::T {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/unrestricted_instantiate.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/unrestricted_instantiate.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x42::Test {
-    struct T has drop {fint: u64, fv: bool}
+    public struct T has drop {fint: u64, fv: bool}
 
     public fun t1(fint: u64, fv: bool): Self::T {
     label b0:
@@ -30,7 +30,7 @@ label b0:
 
 //# publish
 mvir 0x44::Test {
-    enum T has drop {V {fint: u64, fv: bool} }
+    public enum T has drop {V {fint: u64, fv: bool} }
 
     public fun t1(fint: u64, fv: bool): Self::T {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/unrestricted_instantiate_bad_type.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/unrestricted_instantiate_bad_type.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x42::Test {
-    struct T{fint: u64}
+    public struct T{fint: u64}
 
     public fun t1(): Self::T {
     label b0:
@@ -11,7 +11,7 @@ mvir 0x42::Test {
 
 //# publish
 mvir 0x43::Test {
-    enum T{V {fint: u64} }
+    public enum T{V {fint: u64} }
 
     public fun t1(): Self::T {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/unused_resource_holder.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/unused_resource_holder.mvir
@@ -1,8 +1,8 @@
 //# publish
 
 mvir 0x42::A {
-    struct Coin has store { value: u64 }
-    struct T { g: Self::Coin }
+    public struct Coin has store { value: u64 }
+    public struct T { g: Self::Coin }
 
     public fun zero(): Self::Coin {
     label b0:
@@ -34,8 +34,8 @@ label b0:
 
 //# publish
 mvir 0x43::A {
-    enum Coin has store { V{ value: u64 } }
-    enum T { V{ g: Self::Coin } }
+    public enum Coin has store { V{ value: u64 } }
+    public enum T { V{ g: Self::Coin } }
 
     public fun zero(): Self::Coin {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/variant_switch_invalid_head_type.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/variant_switch_invalid_head_type.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x2::O {
-    enum Foo<T> { V { x: T } }
+    public enum Foo<T> { V { x: T } }
 
     fun foo(x: &mut Self::Foo<u64>) {
     label b0:
@@ -15,7 +15,7 @@ mvir 0x2::O {
 
 //# publish
 mvir 0x2::O {
-    enum Foo<T> { V { x: T } }
+    public enum Foo<T> { V { x: T } }
 
     fun foo(x: Self::Foo<u64>) {
     label b0:
@@ -30,7 +30,7 @@ mvir 0x2::O {
 
 //# publish
 mvir 0x2::O {
-    enum Foo<T> { V { x: T } }
+    public enum Foo<T> { V { x: T } }
 
     fun foo(x: u64) {
     label b0:
@@ -45,7 +45,7 @@ mvir 0x2::O {
 
 //# publish
 mvir 0x2::O {
-    enum Foo<T> { V { x: T } }
+    public enum Foo<T> { V { x: T } }
 
     fun foo(x: &u64) {
     label b0:
@@ -60,7 +60,7 @@ mvir 0x2::O {
 
 //# publish
 mvir 0x2::O {
-    enum Foo<T> { V { x: T } }
+    public enum Foo<T> { V { x: T } }
 
     fun foo(x: &mut u64) {
     label b0:
@@ -76,9 +76,9 @@ mvir 0x2::O {
 
 //# publish
 mvir 0x2::O {
-    struct Bar { x: bool }
+    public struct Bar { x: bool }
 
-    enum Foo<T> { V { x: T } }
+    public enum Foo<T> { V { x: T } }
 
     fun foo(x: &Self::Bar) {
     label b0:
@@ -93,9 +93,9 @@ mvir 0x2::O {
 
 //# publish
 mvir 0x2::O {
-    struct Bar { x: bool }
+    public struct Bar { x: bool }
 
-    enum Foo<T> { V { x: T } }
+    public enum Foo<T> { V { x: T } }
 
     fun foo(x: &mut Self::Bar) {
     label b0:
@@ -110,8 +110,8 @@ mvir 0x2::O {
 
 //# publish
 mvir 0x2::P {
-    enum Foo<T> { V { x: T } }
-    enum Bar<T> { V { x: T } }
+    public enum Foo<T> { V { x: T } }
+    public enum Bar<T> { V { x: T } }
 
     fun foo(x: &Self::Bar<u64>) {
     label b0:
@@ -126,8 +126,8 @@ mvir 0x2::P {
 
 //# publish
 mvir 0x2::P {
-    enum Foo<T> { V { x: T } }
-    enum Bar<T> { V { x: T } }
+    public enum Foo<T> { V { x: T } }
+    public enum Bar<T> { V { x: T } }
 
     fun foo(x: &Self::Foo<u64>) {
     label b0:
@@ -142,8 +142,8 @@ mvir 0x2::P {
 
 //# publish
 mvir 0x2::P {
-    enum Foo<T> { V { x: T } }
-    enum Bar { V { x: u64 } }
+    public enum Foo<T> { V { x: T } }
+    public enum Bar { V { x: u64 } }
 
     fun foo(x: &Self::Foo<u64>) {
     label b0:
@@ -158,8 +158,8 @@ mvir 0x2::P {
 
 //# publish
 mvir 0x2::P {
-    enum Foo<T> { V { x: T } }
-    enum Bar { V { x: u64 } }
+    public enum Foo<T> { V { x: T } }
+    public enum Bar { V { x: u64 } }
 
     fun foo(x: &Self::Bar) {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/variant_switch_partial_enum_switch.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/variant_switch_partial_enum_switch.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x2::O {
-    enum Foo<T> { V { x: T } }
+    public enum Foo<T> { V { x: T } }
 
     fun foo(x: &Self::Foo<u64>) {
     label b0:
@@ -15,7 +15,7 @@ mvir 0x2::O {
 
 //# publish
 mvir 0x2::O {
-    enum Foo<T> { V { x: T } }
+    public enum Foo<T> { V { x: T } }
 
     fun foo(x: &Self::Foo<u64>) {
     label b0:
@@ -29,7 +29,7 @@ mvir 0x2::O {
 
 //# publish
 mvir 0x2::O {
-    enum Foo<T> { V { x: T }, X { } }
+    public enum Foo<T> { V { x: T }, X { } }
 
     fun foo(x: &Self::Foo<u64>) {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/variant_switch_valid_head_type.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/variant_switch_valid_head_type.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x2::A {
-    enum Foo<T: drop> has drop { V { x: T } }
+    public enum Foo<T: drop> has drop { V { x: T } }
 
     fun foo(x: Self::Foo<u64>) {
     label b0:
@@ -15,7 +15,7 @@ mvir 0x2::A {
 
 //# publish
 mvir 0x2::B {
-    enum Foo<T> { V { x: T } }
+    public enum Foo<T> { V { x: T } }
 
     fun foo(x: &Self::Foo<u64>) {
     label b0:
@@ -30,7 +30,7 @@ mvir 0x2::B {
 
 //# publish
 mvir 0x2::C {
-    enum Foo<T> { V { x: T } }
+    public enum Foo<T> { V { x: T } }
 
     fun foo(x: &mut Self::Foo<u64>) {
     label b0:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/vector_type_param.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/vector_type_param.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x42::M1 {
-    struct S<T: copy> { t: T }
+    public struct S<T: copy> { t: T }
 
     // should get flagged w/ constraint not satisfied--T does not have copy
     public fun bad_sig<T>(v: vector<Self::S<T>>): vector<Self::S<T>> {
@@ -11,7 +11,7 @@ mvir 0x42::M1 {
 
 //# publish
 mvir 0x42::M2 {
-    struct S<T: copy> { t: T }
+    public struct S<T: copy> { t: T }
 
     // should get flagged w/ constraint not satisfied--T does not have copy
     public fun bad_sig<T>(v: &vector<Self::S<T>>) {
@@ -22,7 +22,7 @@ mvir 0x42::M2 {
 
 //# publish
 mvir 0x42::M3 {
-    struct S<T: copy> { t: T }
+    public struct S<T: copy> { t: T }
 
     // should get flagged w/ constraint not satisfied--T does not have copy
     public fun bad_sig<T>(v: &mut vector<Self::S<T>>) {
@@ -33,7 +33,7 @@ mvir 0x42::M3 {
 
 //# publish
 mvir 0x43::M1 {
-    enum S<T: copy> { V { t: T } }
+    public enum S<T: copy> { V { t: T } }
 
     // should get flagged w/ constraint not satisfied--T does not have copy
     public fun bad_sig<T>(v: vector<Self::S<T>>): vector<Self::S<T>> {
@@ -44,7 +44,7 @@ mvir 0x43::M1 {
 
 //# publish
 mvir 0x43::M2 {
-    enum S<T: copy> { V { t: T } }
+    public enum S<T: copy> { V { t: T } }
 
     // should get flagged w/ constraint not satisfied--T does not have copy
     public fun bad_sig<T>(v: &vector<Self::S<T>>) {
@@ -55,7 +55,7 @@ mvir 0x43::M2 {
 
 //# publish
 mvir 0x43::M3 {
-    enum S<T: copy> { V { t: T } }
+    public enum S<T: copy> { V { t: T } }
 
     // should get flagged w/ constraint not satisfied--T does not have copy
     public fun bad_sig<T>(v: &mut vector<Self::S<T>>) {

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/vector_type_param_exploits.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/vector_type_param_exploits.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x42::M1 {
-    struct S<T: copy + drop> has copy, drop { t: T }
+    public struct S<T: copy + drop> has copy, drop { t: T }
 
     // it would be bad if this worked because T could be (e.g.) a coin
     // should get flagged w/ constraint not satisfied--T does not have copy
@@ -12,7 +12,7 @@ mvir 0x42::M1 {
 
 //# publish
 mvir 0x42::M2 {
-    struct S<T: drop> has drop { t: T }
+    public struct S<T: drop> has drop { t: T }
 
     // it would be bad if this worked because T could be (e.g.) a hot potato
     public fun bad_sig<T>(v: vector<Self::S<T>>) {
@@ -23,7 +23,7 @@ mvir 0x42::M2 {
 
 //# publish
 mvir 0x42::M3 {
-    struct S<T: copy> { t: T }
+    public struct S<T: copy> { t: T }
 
     public fun bad_sig<T>(s: vector<Self::S<T>>) { // should get flagged w/ constraint not satisfied
     label b0:
@@ -41,7 +41,7 @@ mvir 0x42::M3 {
 
 //# publish
 mvir 0x42::M4 {
-    struct S<T: copy> { t: T }
+    public struct S<T: copy> { t: T }
 
     public fun bad_sig<T>(s: vector<Self::S<T>>) { // should get flagged w/ constraint not satisfied
     label b0:

--- a/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/bytecode-generation/declarations/function.mvir
+++ b/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/bytecode-generation/declarations/function.mvir
@@ -2,7 +2,7 @@
 // This module defines several public functions with complex bodies.
 // This can be thought of as a smoke test that tests many different aspects of bytecode generation.
 mvir 0x3d10::Example {
-    struct Coin { value: u64 }
+    public struct Coin { value: u64 }
 
     public fun value(this: &Self::Coin): u64 {
         let value_ref: &u64;

--- a/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/bytecode-generation/expressions/borrow.mvir
+++ b/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/bytecode-generation/expressions/borrow.mvir
@@ -29,7 +29,7 @@ label b0:
 
 //# print-bytecode
 mvir 0x1d4::M {
-    struct T { u: u64 }
+    public struct T { u: u64 }
 
     // An immutable borrow, of a field on an immutable reference to a struct,
     // produces an immutable reference type.
@@ -64,7 +64,7 @@ mvir 0x1d4::M {
 
 //# print-bytecode
 mvir 0x2d4::M {
-    struct T<U> { u: U }
+    public struct T<U> { u: U }
 
     fun f(t: &Self::T<u64>) {
         let r: &u64;
@@ -85,7 +85,7 @@ mvir 0x2d4::M {
 
 //# publish
 mvir 0x3d4::M {
-    struct T has key { b: bool }
+    public struct T has key { b: bool }
 
     public fun new(): Self::T {
     label b0:

--- a/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/bytecode-generation/expressions/borrow_mut.mvir
+++ b/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/bytecode-generation/expressions/borrow_mut.mvir
@@ -13,7 +13,7 @@ label b0:
 
 //# print-bytecode
 mvir 0x3d::Foobar {
-    struct FooCoin { value: u64 }
+    public struct FooCoin { value: u64 }
 
     public fun borrow_mut_field(arg: &mut Self::FooCoin) {
         let field_ref: &mut u64;
@@ -26,7 +26,7 @@ mvir 0x3d::Foobar {
 
 //# print-bytecode
 mvir 0x4d::Foobar {
-    struct FooCoin<T> { value: u64 }
+    public struct FooCoin<T> { value: u64 }
 
     public fun borrow_mut_field(arg: &mut Self::FooCoin<address>) {
         let field_ref: &mut u64;

--- a/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/bytecode-generation/expressions/pack.mvir
+++ b/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/bytecode-generation/expressions/pack.mvir
@@ -1,6 +1,6 @@
 //# print-bytecode
 mvir 0x2d20::M {
-    struct T { u: u64 }
+    public struct T { u: u64 }
 
     fun f(): Self::T {
     label b0:
@@ -10,7 +10,7 @@ mvir 0x2d20::M {
 
 //# print-bytecode
 mvir 0x3d20::M {
-    struct T { u: u64, v: u128 }
+    public struct T { u: u64, v: u128 }
 
     // A pack expression must use the correct field names.
     fun f(): Self::T {
@@ -21,7 +21,7 @@ mvir 0x3d20::M {
 
 //# print-bytecode
 mvir 0x4d20::M {
-    struct T { x: u64, y: u64 }
+    public struct T { x: u64, y: u64 }
 
     // A pack expression must refer to the fields in the correct order.
     fun f(): Self::T {

--- a/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/bytecode-generation/expressions/unpack.mvir
+++ b/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/bytecode-generation/expressions/unpack.mvir
@@ -1,6 +1,6 @@
 //# print-bytecode
 mvir 0x1d12::M {
-    struct T { b: bool }
+    public struct T { b: bool }
 
     fun new(): Self::T {
     label b0:
@@ -19,7 +19,7 @@ mvir 0x1d12::M {
 
 //# publish
 mvir 0x2d12::M {
-    struct T { b: bool }
+    public struct T { b: bool }
 
     public fun new(): Self::T {
     label b0:

--- a/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/bytecode-generation/statements/enums.mvir
+++ b/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/bytecode-generation/statements/enums.mvir
@@ -1,6 +1,6 @@
 //# print-bytecode
 mvir 0x3d8::M {
-    enum T has drop {
+    public enum T has drop {
         X { },
         Y { f: u64 },
     }

--- a/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/parsing/duplicate_entry.mvir
+++ b/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/parsing/duplicate_entry.mvir
@@ -1,0 +1,8 @@
+//# print-bytecode
+// Each module-member modifier may appear at most once.
+mvir 0x42::M {
+    public entry entry fun foo() {
+    label b0:
+        return;
+    }
+}

--- a/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/parsing/duplicate_entry.snap
+++ b/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/parsing/duplicate_entry.snap
@@ -1,0 +1,8 @@
+---
+source: crates/move-transactional-test-runner/src/framework.rs
+---
+processed 1 task
+
+task 0, lines 1-8:
+//# print-bytecode
+Error: ParserError: Invalid Token: Duplicate 'entry' modifier

--- a/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/parsing/duplicate_native.mvir
+++ b/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/parsing/duplicate_native.mvir
@@ -1,0 +1,5 @@
+//# print-bytecode
+// Each module-member modifier may appear at most once.
+mvir 0x42::M {
+    native native public fun foo(): u64;
+}

--- a/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/parsing/duplicate_native.snap
+++ b/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/parsing/duplicate_native.snap
@@ -1,0 +1,8 @@
+---
+source: crates/move-transactional-test-runner/src/framework.rs
+---
+processed 1 task
+
+task 0, lines 1-5:
+//# print-bytecode
+Error: ParserError: Invalid Token: Duplicate 'native' modifier

--- a/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/parsing/duplicate_public.mvir
+++ b/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/parsing/duplicate_public.mvir
@@ -1,0 +1,8 @@
+//# print-bytecode
+// Each module-member modifier may appear at most once.
+mvir 0x42::M {
+    public public fun foo() {
+    label b0:
+        return;
+    }
+}

--- a/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/parsing/duplicate_public.snap
+++ b/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/parsing/duplicate_public.snap
@@ -1,0 +1,8 @@
+---
+source: crates/move-transactional-test-runner/src/framework.rs
+---
+processed 1 task
+
+task 0, lines 1-8:
+//# print-bytecode
+Error: ParserError: Invalid Token: Duplicate visibility modifier

--- a/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/parsing/enum_invalid_visibility.mvir
+++ b/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/parsing/enum_invalid_visibility.mvir
@@ -1,0 +1,6 @@
+//# print-bytecode
+// Only bare `public` is supported on enum declarations today;
+// `public(friend)` and other variants are reserved for future use.
+mvir 0x42::M {
+    public(friend) enum E { V { } }
+}

--- a/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/parsing/enum_invalid_visibility.snap
+++ b/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/parsing/enum_invalid_visibility.snap
@@ -1,0 +1,8 @@
+---
+source: crates/move-transactional-test-runner/src/framework.rs
+---
+processed 1 task
+
+task 0, lines 1-6:
+//# print-bytecode
+Error: ParserError: Invalid Token: only 'public' visibility is supported on enum declarations

--- a/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/parsing/enum_missing_visibility.mvir
+++ b/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/parsing/enum_missing_visibility.mvir
@@ -1,0 +1,5 @@
+//# print-bytecode
+// Enum declarations require an explicit `public` visibility.
+mvir 0x42::M {
+    enum E { V { } }
+}

--- a/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/parsing/enum_missing_visibility.snap
+++ b/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/parsing/enum_missing_visibility.snap
@@ -1,0 +1,8 @@
+---
+source: crates/move-transactional-test-runner/src/framework.rs
+---
+processed 1 task
+
+task 0, lines 1-5:
+//# print-bytecode
+Error: ParserError: Invalid Token: enum declarations require an explicit 'public' visibility

--- a/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/parsing/enums.mvir
+++ b/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/parsing/enums.mvir
@@ -1,6 +1,6 @@
 //# print-bytecode
 mvir 0x3d8::M {
-    enum T { V { } }
-    // Struct declarations need to be before enum declarations.
-    struct T { x: u64, }
+    // Struct and enum declarations may appear in any order.
+    public enum T { V { } }
+    public struct T { x: u64, }
 }

--- a/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/parsing/enums.snap
+++ b/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/parsing/enums.snap
@@ -5,4 +5,15 @@ processed 1 task
 
 task 0, lines 1-6:
 //# print-bytecode
-Error: ParserError: Invalid Token: expected 'fun' before function name
+// Move bytecode v7
+module 3d8.M {
+
+struct T {
+	x: u64
+}
+
+enum T {
+	V {  }
+}
+
+}

--- a/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/parsing/function_missing_fun.mvir
+++ b/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/parsing/function_missing_fun.mvir
@@ -1,0 +1,10 @@
+//# print-bytecode
+// Function declarations require the `fun` keyword between the modifiers
+// and the function name. This also covers the broader
+// "expected 'struct', 'enum', or 'fun' declaration" dispatch error.
+mvir 0x42::M {
+    public foo() {
+    label b0:
+        return;
+    }
+}

--- a/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/parsing/function_missing_fun.snap
+++ b/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/parsing/function_missing_fun.snap
@@ -1,0 +1,8 @@
+---
+source: crates/move-transactional-test-runner/src/framework.rs
+---
+processed 1 task
+
+task 0, lines 1-10:
+//# print-bytecode
+Error: ParserError: Invalid Token: expected 'struct', 'enum', or 'fun' declaration

--- a/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/parsing/struct_invalid_visibility.mvir
+++ b/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/parsing/struct_invalid_visibility.mvir
@@ -1,0 +1,6 @@
+//# print-bytecode
+// Only bare `public` is supported on struct declarations today;
+// `public(friend)` and other variants are reserved for future use.
+mvir 0x42::M {
+    public(friend) struct T { v: u64 }
+}

--- a/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/parsing/struct_invalid_visibility.snap
+++ b/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/parsing/struct_invalid_visibility.snap
@@ -1,0 +1,8 @@
+---
+source: crates/move-transactional-test-runner/src/framework.rs
+---
+processed 1 task
+
+task 0, lines 1-6:
+//# print-bytecode
+Error: ParserError: Invalid Token: only 'public' visibility is supported on struct declarations

--- a/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/parsing/struct_missing_visibility.mvir
+++ b/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/parsing/struct_missing_visibility.mvir
@@ -1,0 +1,5 @@
+//# print-bytecode
+// Struct declarations require an explicit `public` visibility.
+mvir 0x42::M {
+    struct T { v: u64 }
+}

--- a/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/parsing/struct_missing_visibility.snap
+++ b/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/parsing/struct_missing_visibility.snap
@@ -1,0 +1,8 @@
+---
+source: crates/move-transactional-test-runner/src/framework.rs
+---
+processed 1 task
+
+task 0, lines 1-5:
+//# print-bytecode
+Error: ParserError: Invalid Token: struct declarations require an explicit 'public' visibility

--- a/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/parsing/structs.mvir
+++ b/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/parsing/structs.mvir
@@ -2,7 +2,7 @@
 // A struct declaration cannot contain function declarations (like the syntax for declaring
 // "methods" in other languages).
 mvir 0x3d8::M {
-    struct T {
+    public struct T {
         x: u64,
 
         f() {

--- a/external-crates/move/crates/move-ir-compiler/src/unit_tests/cfg_tests.rs
+++ b/external-crates/move/crates/move-ir-compiler/src/unit_tests/cfg_tests.rs
@@ -277,7 +277,7 @@ fn cfg_compile_if_else_with_two_aborts() {
 fn cfg_compile_variant_switch_simple() {
     let text = "
         mvir 0x42::m {
-            enum X has drop { V1 { x: u64 }, V2 { } }
+            public enum X has drop { V1 { x: u64 }, V2 { } }
 
             entry fun foo(x: Self::X) {
                 let y: u64;
@@ -304,7 +304,7 @@ fn cfg_compile_variant_switch_simple() {
 fn cfg_compile_variant_switch_simple_unconditional_jump() {
     let text = "
         mvir 0x42::m {
-            enum X has drop { V1 { x: u64 }, V2 { } }
+            public enum X has drop { V1 { x: u64 }, V2 { } }
 
             entry fun foo(x: Self::X) {
                 let y: u64;
@@ -334,7 +334,7 @@ fn cfg_compile_variant_switch_simple_unconditional_jump() {
 fn cfg_compile_variant_switch() {
     let text = "
         mvir 0x42::m {
-            enum X { V1 { x: u64 }, V2 { } }
+            public enum X { V1 { x: u64 }, V2 { } }
 
             entry fun foo(x: Self::X) {
                 let y: u64;
@@ -370,7 +370,7 @@ fn cfg_compile_variant_switch() {
 fn cfg_compile_variant_switch_with_two_aborts() {
     let text = "
         mvir 0x42::m {
-            enum X { V1 { x: u64 }, V2 { } }
+            public enum X { V1 { x: u64 }, V2 { } }
 
             entry fun foo(x: Self::X) {
                 let y: u64;
@@ -406,7 +406,7 @@ fn cfg_compile_variant_switch_with_two_aborts() {
 fn cfg_compile_variant_switch_with_return() {
     let text = "
         mvir 0x42::m {
-            enum X { V1 { x: u64 }, V2 { } }
+            public enum X { V1 { x: u64 }, V2 { } }
 
             entry fun foo(x: Self::X) {
                 let y: u64;

--- a/external-crates/move/crates/move-ir-compiler/src/unit_tests/function_tests.rs
+++ b/external-crates/move/crates/move-ir-compiler/src/unit_tests/function_tests.rs
@@ -39,7 +39,7 @@ fn compile_module_with_large_frame() {
     let mut code = String::from(
         "
         mvir 0x16::Foobar {
-            struct FooCoin { value: u64 }
+            public struct FooCoin { value: u64 }
         ",
     );
 

--- a/external-crates/move/crates/move-ir-to-bytecode-syntax/src/lib.rs
+++ b/external-crates/move/crates/move-ir-to-bytecode-syntax/src/lib.rs
@@ -158,9 +158,8 @@
 //! ## Modules
 //! ```text
 //! sdecl ∈ StructDecl ::=
-//!   | resource n { f_1: t_1, ..., f_j: t_j } // declaration of a resource struct
-//!   | struct n { f_1: t_1, ..., f_j: t_j }   // declaration of a non-resource (value) struct
-//!                                            // s.t. any 't_i' is not of resource kind
+//!   | public struct n { f_1: t_1, ..., f_j: t_j } // declaration of a struct;
+//!                                                 // currently `public` is the only supported visibility
 //!
 //! body ∈ ProcedureBody ::=
 //!  | let x_1; ... let x_j; s // The locals declared in this procedure, and the code for that procedure

--- a/external-crates/move/crates/move-ir-to-bytecode-syntax/src/syntax.rs
+++ b/external-crates/move/crates/move-ir-to-bytecode-syntax/src/syntax.rs
@@ -1554,34 +1554,127 @@ fn parse_return_type(tokens: &mut Lexer) -> Result<Vec<Type>, ParseError<Loc, an
     Ok(v)
 }
 
-// FunctionVisibility : FunctionVisibility = {
-//   (Public("("<v: Script | Friend>")")?)?
+//**************************************************************************************************
+// Modifiers
+//**************************************************************************************************
+
+/// Module-member modifiers (visibility, native, entry) parsed up front before
+/// dispatching to the appropriate decl parser. Modeled on the source-language
+/// `Modifiers` struct in `move-compiler/src/parser/syntax.rs`.
+struct Modifiers {
+    visibility: Option<(FunctionVisibility, Loc)>,
+    native: Option<Loc>,
+    entry: Option<Loc>,
+}
+
+impl Modifiers {
+    fn empty() -> Self {
+        Self {
+            visibility: None,
+            native: None,
+            entry: None,
+        }
+    }
+}
+
+// ModuleMemberModifiers = <ModuleMemberModifier>*
+// ModuleMemberModifier  = <Visibility> | "native" | "entry"
+// Each modifier may appear at most once; any order is accepted.
+fn parse_module_member_modifiers(
+    tokens: &mut Lexer,
+) -> Result<Modifiers, ParseError<Loc, anyhow::Error>> {
+    let mut mods = Modifiers::empty();
+    loop {
+        match tokens.peek() {
+            Tok::Public => {
+                let vis_loc = current_token_loc(tokens);
+                let vis = parse_visibility(tokens)?;
+                if mods.visibility.is_some() {
+                    return Err(duplicate_modifier_error(vis_loc, "visibility"));
+                }
+                mods.visibility = Some((vis, vis_loc));
+            }
+            Tok::Native => {
+                let loc = current_token_loc(tokens);
+                tokens.advance()?;
+                if mods.native.is_some() {
+                    return Err(duplicate_modifier_error(loc, "'native'"));
+                }
+                mods.native = Some(loc);
+            }
+            Tok::NameValue if tokens.content() == "entry" => {
+                let loc = current_token_loc(tokens);
+                tokens.advance()?;
+                if mods.entry.is_some() {
+                    return Err(duplicate_modifier_error(loc, "'entry'"));
+                }
+                mods.entry = Some(loc);
+            }
+            _ => break,
+        }
+    }
+    Ok(mods)
+}
+
+fn duplicate_modifier_error(loc: Loc, modifier: &str) -> ParseError<Loc, anyhow::Error> {
+    ParseError::InvalidToken {
+        location: loc,
+        message: format!("Duplicate {modifier} modifier"),
+    }
+}
+
+fn check_no_modifier(
+    modifier_loc: Option<Loc>,
+    modifier_name: &str,
+    decl: &str,
+) -> Result<(), ParseError<Loc, anyhow::Error>> {
+    if let Some(loc) = modifier_loc {
+        return Err(ParseError::InvalidToken {
+            location: loc,
+            message: format!("'{modifier_name}' is not a valid modifier on {decl} declarations"),
+        });
+    }
+    Ok(())
+}
+
+fn require_public_visibility(
+    visibility: Option<(FunctionVisibility, Loc)>,
+    decl_keyword_loc: Loc,
+    decl: &str,
+) -> Result<(), ParseError<Loc, anyhow::Error>> {
+    match visibility {
+        Some((FunctionVisibility::Public, _)) => Ok(()),
+        Some((_, loc)) => Err(ParseError::InvalidToken {
+            location: loc,
+            message: format!("only 'public' visibility is supported on {decl} declarations"),
+        }),
+        None => Err(ParseError::InvalidToken {
+            location: decl_keyword_loc,
+            message: format!("{decl} declarations require an explicit 'public' visibility"),
+        }),
+    }
+}
+
+// Visibility : FunctionVisibility = {
+//   (Public("(" "friend" ")")?)?
 // }
-fn parse_function_visibility(
+fn parse_visibility(
     tokens: &mut Lexer,
 ) -> Result<FunctionVisibility, ParseError<Loc, anyhow::Error>> {
     let visibility = if match_token(tokens, Tok::Public)? {
-        let sub_public_vis = if match_token(tokens, Tok::LParen)? {
+        if match_token(tokens, Tok::LParen)? {
             let sub_token = tokens.peek();
-            match &sub_token {
-                Tok::Script | Tok::Friend => (),
-                t => {
-                    return Err(ParseError::InvalidToken {
-                        location: current_token_loc(tokens),
-                        message: format!("expected Tok::Script or Tok::Friend, not {:?}", t),
-                    });
-                }
+            if sub_token != Tok::Friend {
+                return Err(ParseError::InvalidToken {
+                    location: current_token_loc(tokens),
+                    message: format!("expected Tok::Friend, not {:?}", sub_token),
+                });
             }
             tokens.advance()?;
             consume_token(tokens, Tok::RParen)?;
-            Some(sub_token)
+            FunctionVisibility::Friend
         } else {
-            None
-        };
-        match sub_public_vis {
-            None => FunctionVisibility::Public,
-            Some(Tok::Friend) => FunctionVisibility::Friend,
-            _ => panic!("Unexpected token that is not a visibility modifier"),
+            FunctionVisibility::Public
         }
     } else {
         FunctionVisibility::Internal
@@ -1612,30 +1705,23 @@ fn parse_function_visibility(
 
 fn parse_function_decl(
     tokens: &mut Lexer,
+    start_loc: usize,
+    modifiers: Modifiers,
 ) -> Result<(FunctionName, Function), ParseError<Loc, anyhow::Error>> {
-    let start_loc = tokens.start_loc();
+    let Modifiers {
+        visibility,
+        native,
+        entry,
+    } = modifiers;
+    let visibility = visibility
+        .map(|(v, _)| v)
+        .unwrap_or(FunctionVisibility::Internal);
+    let is_native = native.is_some();
+    let is_entry = entry.is_some();
 
-    let is_native = if tokens.peek() == Tok::Native {
-        tokens.advance()?;
-        true
-    } else {
-        false
-    };
-
-    let visibility = parse_function_visibility(tokens)?;
-    let is_entry = if tokens.peek() == Tok::NameValue && tokens.content() == "entry" {
-        tokens.advance()?;
-        true
-    } else {
-        false
-    };
-
-    if tokens.peek() != Tok::NameValue || tokens.content() != "fun" {
-        return Err(ParseError::InvalidToken {
-            location: current_token_loc(tokens),
-            message: "expected 'fun' before function name".to_string(),
-        });
-    }
+    // The dispatcher in `parse_module` has already verified the upcoming
+    // token is the `fun` keyword.
+    debug_assert!(tokens.peek() == Tok::NameValue && tokens.content() == "fun");
     tokens.advance()?;
 
     let (name, type_parameters) = parse_name_and_type_parameters(tokens, parse_type_parameter)?;
@@ -1687,23 +1773,24 @@ fn parse_field_decl(tokens: &mut Lexer) -> Result<(Field, Type), ParseError<Loc,
 }
 
 // StructDecl: StructDefinition_ = {
-//     "struct" <name_and_type_parameters:
-//     NameAndTypeFormals> ("has" <Ability> ("," <Ability)*)? "{" <data: Comma<FieldDecl>> "}"
-//     =>? { ... }
-//     <native: NativeTag> <name_and_type_parameters: NameAndTypeFormals>
-//     ("has" <Ability> ("," <Ability)*)?";" =>? { ... }
+//     "public" "native"? "struct" <name_and_type_parameters: NameAndTypeFormals>
+//         ("has" <Ability> ("," <Ability>)*)?
+//         ( "{" <data: Comma<FieldDecl>> "}" | ";" )
 // }
 fn parse_struct_decl(
     tokens: &mut Lexer,
+    start_loc: usize,
+    modifiers: Modifiers,
 ) -> Result<StructDefinition, ParseError<Loc, anyhow::Error>> {
-    let start_loc = tokens.start_loc();
-
-    let is_native = if tokens.peek() == Tok::Native {
-        tokens.advance()?;
-        true
-    } else {
-        false
-    };
+    let Modifiers {
+        visibility,
+        native,
+        entry,
+    } = modifiers;
+    let struct_keyword_loc = current_token_loc(tokens);
+    require_public_visibility(visibility, struct_keyword_loc, "struct")?;
+    check_no_modifier(entry, "entry", "struct")?;
+    let is_native = native.is_some();
 
     consume_token(tokens, Tok::Struct)?;
     let (name, type_parameters) =
@@ -1749,12 +1836,24 @@ fn parse_struct_decl(
 }
 
 // EnumDecl: EnumDefinition = {
-//     "enum" <name_and_type_parameters:
-//     NameAndTypeFormals> ("has" <Ability> ("," <Ability)*)? "{" <data: Comma<VariantDecl>> "}"
-//     => { ... }
+//     "public" "enum" <name_and_type_parameters: NameAndTypeFormals>
+//         ("has" <Ability> ("," <Ability>)*)?
+//         "{" <data: Comma<VariantDecl>> "}"
 // }
-fn parse_enum_decl(tokens: &mut Lexer) -> Result<EnumDefinition, ParseError<Loc, anyhow::Error>> {
-    let start_loc = tokens.start_loc();
+fn parse_enum_decl(
+    tokens: &mut Lexer,
+    start_loc: usize,
+    modifiers: Modifiers,
+) -> Result<EnumDefinition, ParseError<Loc, anyhow::Error>> {
+    let Modifiers {
+        visibility,
+        native,
+        entry,
+    } = modifiers;
+    let enum_keyword_loc = current_token_loc(tokens);
+    require_public_visibility(visibility, enum_keyword_loc, "enum")?;
+    check_no_modifier(native, "native", "enum")?;
+    check_no_modifier(entry, "entry", "enum")?;
 
     consume_token(tokens, Tok::Enum)?;
 
@@ -1882,15 +1981,6 @@ fn parse_import_decl(
 //     "}" =>? ModuleDefinition::new(n, imports, structs, functions),
 // }
 
-fn is_struct_decl(tokens: &mut Lexer) -> Result<bool, ParseError<Loc, anyhow::Error>> {
-    let t = tokens.peek();
-    Ok(t == Tok::Struct || (t == Tok::Native && tokens.lookahead()? == Tok::Struct))
-}
-
-fn is_enum_decl(tokens: &mut Lexer) -> bool {
-    tokens.peek() == Tok::Enum
-}
-
 fn parse_module(tokens: &mut Lexer) -> Result<ModuleDefinition, ParseError<Loc, anyhow::Error>> {
     let publishable =
         if matches!(tokens.peek(), Tok::NameValue) && tokens.content() == "unpublishable" {
@@ -1915,18 +2005,31 @@ fn parse_module(tokens: &mut Lexer) -> Result<ModuleDefinition, ParseError<Loc, 
     }
 
     let mut structs: Vec<StructDefinition> = vec![];
-    while is_struct_decl(tokens)? {
-        structs.push(parse_struct_decl(tokens)?);
-    }
-
     let mut enums: Vec<EnumDefinition> = vec![];
-    while is_enum_decl(tokens) {
-        enums.push(parse_enum_decl(tokens)?);
-    }
-
     let mut functions: Vec<(FunctionName, Function)> = vec![];
     while tokens.peek() != Tok::RBrace {
-        functions.push(parse_function_decl(tokens)?);
+        let decl_start_loc = tokens.start_loc();
+        let modifiers = parse_module_member_modifiers(tokens)?;
+
+        match tokens.peek() {
+            Tok::Struct => {
+                structs.push(parse_struct_decl(tokens, decl_start_loc, modifiers)?);
+            }
+            Tok::Enum => {
+                enums.push(parse_enum_decl(tokens, decl_start_loc, modifiers)?);
+            }
+            // `fun` is detected by content (matching the existing `entry`
+            // pattern); only function decls start with that keyword.
+            Tok::NameValue if tokens.content() == "fun" => {
+                functions.push(parse_function_decl(tokens, decl_start_loc, modifiers)?);
+            }
+            _ => {
+                return Err(ParseError::InvalidToken {
+                    location: current_token_loc(tokens),
+                    message: "expected 'struct', 'enum', or 'fun' declaration".to_string(),
+                });
+            }
+        }
     }
     tokens.advance()?; // consume the RBrace
     let end_loc = tokens.previous_end_loc();

--- a/external-crates/move/crates/move-transactional-test-runner/tests/vm_test_harness/cross_package_generic_call.mvir
+++ b/external-crates/move/crates/move-transactional-test-runner/tests/vm_test_harness/cross_package_generic_call.mvir
@@ -1,7 +1,7 @@
 //# publish
 
 mvir 0x42::M {
-    struct S has drop { f: u64 }
+    public struct S has drop { f: u64 }
 }
 
 //# run --type-args 0x42::M::S --args 0 0 0

--- a/external-crates/move/crates/move-vm-runtime/src/unit_tests/compatibility_tests.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/unit_tests/compatibility_tests.rs
@@ -37,7 +37,7 @@ fn test_enum_upgrade_variant_removal() {
     let old = compile(
         "
         mvir 0x1::M {
-            enum E { V { }, L { } }
+            public enum E { V { }, L { } }
         }
         ",
     );
@@ -45,7 +45,7 @@ fn test_enum_upgrade_variant_removal() {
     let new = compile(
         "
         mvir 0x1::M {
-            enum E { V { } }
+            public enum E { V { } }
         }
         ",
     );
@@ -59,7 +59,7 @@ fn test_enum_upgrade_variant_rename() {
     let old = compile(
         "
         mvir 0x1::M {
-            enum E { V { } }
+            public enum E { V { } }
         }
         ",
     );
@@ -67,7 +67,7 @@ fn test_enum_upgrade_variant_rename() {
     let new = compile(
         "
         mvir 0x1::M {
-            enum E { L { } }
+            public enum E { L { } }
         }
         ",
     );
@@ -81,7 +81,7 @@ fn test_enum_upgrade_variant_reorder() {
     let old = compile(
         "
         mvir 0x1::M {
-            enum E { V { }, L { } }
+            public enum E { V { }, L { } }
         }
         ",
     );
@@ -89,7 +89,7 @@ fn test_enum_upgrade_variant_reorder() {
     let new = compile(
         "
         mvir 0x1::M {
-            enum E { L { }, V { } }
+            public enum E { L { }, V { } }
         }
         ",
     );
@@ -103,7 +103,7 @@ fn test_enum_upgrade_variant_add_field() {
     let old = compile(
         "
         mvir 0x1::M {
-            enum E { V { } }
+            public enum E { V { } }
         }
         ",
     );
@@ -111,7 +111,7 @@ fn test_enum_upgrade_variant_add_field() {
     let new = compile(
         "
         mvir 0x1::M {
-            enum E { V { x: u64 } }
+            public enum E { V { x: u64 } }
         }
         ",
     );
@@ -125,7 +125,7 @@ fn test_enum_upgrade_variant_remove_field() {
     let old = compile(
         "
         mvir 0x1::M {
-            enum E { V { x: u64 } }
+            public enum E { V { x: u64 } }
         }
         ",
     );
@@ -133,7 +133,7 @@ fn test_enum_upgrade_variant_remove_field() {
     let new = compile(
         "
         mvir 0x1::M {
-            enum E { V { } }
+            public enum E { V { } }
         }
         ",
     );
@@ -147,7 +147,7 @@ fn test_enum_upgrade_variant_rename_field() {
     let old = compile(
         "
         mvir 0x1::M {
-            enum E { V { x: u64 } }
+            public enum E { V { x: u64 } }
         }
         ",
     );
@@ -155,7 +155,7 @@ fn test_enum_upgrade_variant_rename_field() {
     let new = compile(
         "
         mvir 0x1::M {
-            enum E { V { y: u64 } }
+            public enum E { V { y: u64 } }
         }
         ",
     );
@@ -169,7 +169,7 @@ fn test_enum_upgrade_variant_change_field_type() {
     let old = compile(
         "
         mvir 0x1::M {
-            enum E { V { x: u64 } }
+            public enum E { V { x: u64 } }
         }
         ",
     );
@@ -177,7 +177,7 @@ fn test_enum_upgrade_variant_change_field_type() {
     let new = compile(
         "
         mvir 0x1::M {
-            enum E { V { x: bool } }
+            public enum E { V { x: bool } }
         }
         ",
     );
@@ -191,7 +191,7 @@ fn test_enum_upgrade_add_variant_at_front() {
     let old = compile(
         "
         mvir 0x1::M {
-            enum E { V { x: u64 } }
+            public enum E { V { x: u64 } }
         }
         ",
     );
@@ -199,7 +199,7 @@ fn test_enum_upgrade_add_variant_at_front() {
     let new = compile(
         "
         mvir 0x1::M {
-            enum E { L { x: u64 }, V { x: u64 } }
+            public enum E { L { x: u64 }, V { x: u64 } }
         }
         ",
     );
@@ -214,7 +214,7 @@ fn test_enum_upgrade_add_variant_at_end() {
     let old = compile(
         "
         mvir 0x1::M {
-            enum E { V { x: u64 } }
+            public enum E { V { x: u64 } }
         }
         ",
     );
@@ -223,7 +223,7 @@ fn test_enum_upgrade_add_variant_at_end() {
     let new = compile(
         "
         mvir 0x1::M {
-            enum E { V { x: u64 }, L { x: u64 }}
+            public enum E { V { x: u64 }, L { x: u64 }}
         }
         ",
     );
@@ -242,7 +242,7 @@ fn test_enum_upgrade_add_store_ability() {
     let old = compile(
         "
         mvir 0x1::M {
-            enum E { V { x: u64 } }
+            public enum E { V { x: u64 } }
         }
         ",
     );
@@ -250,7 +250,7 @@ fn test_enum_upgrade_add_store_ability() {
     let new = compile(
         "
         mvir 0x1::M {
-            enum E has store { V { x: u64 } }
+            public enum E has store { V { x: u64 } }
         }
         ",
     );

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/control_flow/fields_packed_in_order.mvir
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/control_flow/fields_packed_in_order.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x6::M {
-    struct T has drop {
+    public struct T has drop {
         b: u64,
         a: u64
     }

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/entry_points/modify_mutable_ref_inputs.mvir
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/entry_points/modify_mutable_ref_inputs.mvir
@@ -4,7 +4,7 @@
 // modifications should be observable
 
 mvir 0x42::M {
-    struct S { f: u64 }
+    public struct S { f: u64 }
 
     public fun set_f(s: &mut Self::S, f: u64) {
         label l0:

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/entry_points/ref_inputs.mvir
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/entry_points/ref_inputs.mvir
@@ -3,7 +3,7 @@
 // ref arguments are now allowed
 
 mvir 0x42::M {
-    struct S has drop { f: u64 }
+    public struct S has drop { f: u64 }
 
     public fun t1(r1: &u64) {
         label l0:

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/entry_points/return_values.mvir
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/entry_points/return_values.mvir
@@ -3,7 +3,7 @@
 // entry points can now return values
 
 mvir 0x42::M {
-    struct S { f: u64 }
+    public struct S { f: u64 }
 
     public fun t(
         x: u64,

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/entry_points/script_too_few_type_args_inner.mvir
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/entry_points/script_too_few_type_args_inner.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x5::M {
-    struct Ex<T> { flag: bool }
+    public struct Ex<T> { flag: bool }
 }
 
 //# run --type-args 0x5::M::Ex

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/entry_points/script_too_many_type_args_inner.mvir
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/entry_points/script_too_many_type_args_inner.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x5::M {
-    struct Ex<T> { flag: bool }
+    public struct Ex<T> { flag: bool }
 }
 
 //# run --type-args 0x5::M::Ex<bool,u64>

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/entry_points/script_type_arg_kind_mismatch_1.mvir
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/entry_points/script_type_arg_kind_mismatch_1.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x5::Coin {
-    struct Coin { value: u64 }
+    public struct Coin { value: u64 }
     public fun value(c: &Self::Coin): u64 {
     label b0:
         return *&move(c).Coin::value;

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/entry_points/struct_arguments.mvir
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/entry_points/struct_arguments.mvir
@@ -3,7 +3,7 @@
 // struct and struct ref arguments are now allowed
 
 mvir 0x42::M {
-    struct S has drop { f: u64 }
+    public struct S has drop { f: u64 }
 
     public entry fun foo(s: Self::S, i: &Self::S, m: &mut Self::S) {
         label l0:

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/enums/basic_poly_enum_type_mismatch.mvir
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/enums/basic_poly_enum_type_mismatch.mvir
@@ -1,6 +1,6 @@
 //# print-bytecode
 mvir 0x6::MonomorphicEnums {
-    enum EnumWithTwoVariants<T> {
+    public enum EnumWithTwoVariants<T> {
         One { },
         Two { x: u64 }
     }
@@ -25,7 +25,7 @@ mvir 0x6::MonomorphicEnums {
 
 //# publish
 mvir 0x6::MonomorphicEnums {
-    enum EnumWithTwoVariants<T> {
+    public enum EnumWithTwoVariants<T> {
         One { },
         Two { x: u64 }
     }

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/enums/enum_variant_jump_same_label.mvir
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/enums/enum_variant_jump_same_label.mvir
@@ -1,6 +1,6 @@
 //# print-bytecode
 mvir 0x6::Enums {
-    enum EnumWithThreeVariants<T> {
+    public enum EnumWithThreeVariants<T> {
         One { },
         Two { x: T },
         Three { } 
@@ -44,7 +44,7 @@ mvir 0x6::Enums {
 
 //# publish
 mvir 0x6::Enums {
-    enum EnumWithThreeVariants<T> {
+    public enum EnumWithThreeVariants<T> {
         One { },
         Two { x: T },
         Three { } 

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/enums/enum_variant_mismatch.mvir
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/enums/enum_variant_mismatch.mvir
@@ -1,6 +1,6 @@
 //# print-bytecode
 mvir 0x6::MonomorphicEnums {
-    enum EnumWithTwoVariants<T> {
+    public enum EnumWithTwoVariants<T> {
         One { },
         Two { x: T }
     }
@@ -25,7 +25,7 @@ mvir 0x6::MonomorphicEnums {
 
 //# publish
 mvir 0x6::MonomorphicEnums {
-    enum EnumWithTwoVariants<T> {
+    public enum EnumWithTwoVariants<T> {
         One { },
         Two { x: T }
     }

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/enums/enum_variant_tag_unpack_invalid.mvir
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/enums/enum_variant_tag_unpack_invalid.mvir
@@ -1,11 +1,11 @@
 //# publish
 mvir 0x6::Enums {
-    enum PolyEnum<T> {
+    public enum PolyEnum<T> {
         One { },
         Two { x: T },
     }
 
-    enum MonoEnum {
+    public enum MonoEnum {
         One { },
         Two { x: u8 },
     }

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/enums/mono/enum_decl_monomorphic.mvir
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/enums/mono/enum_decl_monomorphic.mvir
@@ -1,15 +1,15 @@
 //# print-bytecode
 mvir 0x6::MonomorphicEnums {
-    enum EnumWithOneVariant {
+    public enum EnumWithOneVariant {
         One { }
     }
 
-    enum EnumWithTwoVariants {
+    public enum EnumWithTwoVariants {
         One { },
         Two { x: u64 }
     }
 
-    enum EnumWithTwoVariantsPlusAbilities has drop, copy, store, key {
+    public enum EnumWithTwoVariantsPlusAbilities has drop, copy, store, key {
         One { },
         Two { x: u64 }
     }
@@ -34,16 +34,16 @@ mvir 0x6::MonomorphicEnums {
 
 //# publish
 mvir 0x6::MonomorphicEnums {
-    enum EnumWithOneVariant {
+    public enum EnumWithOneVariant {
         One { }
     }
 
-    enum EnumWithTwoVariants {
+    public enum EnumWithTwoVariants {
         One { },
         Two { x: u64 }
     }
 
-    enum EnumWithTwoVariantsPlusAbilities has drop, copy, store, key {
+    public enum EnumWithTwoVariantsPlusAbilities has drop, copy, store, key {
         One { },
         Two { x: u64 }
     }

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/enums/mono/enum_decl_monomorphic_fail_unpack.mvir
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/enums/mono/enum_decl_monomorphic_fail_unpack.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x6::MonomorphicEnums {
-    enum EnumWithTwoVariants {
+    public enum EnumWithTwoVariants {
         One { },
         Two { x: u64 }
     }

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/enums/mono/enum_decl_monomorphic_mismatched_variants.mvir
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/enums/mono/enum_decl_monomorphic_mismatched_variants.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x6::MonomorphicEnums {
-    enum EnumWithTwoVariants {
+    public enum EnumWithTwoVariants {
         One { },
         Two { x: u64 }
     }

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/enums/mono/mut_ref_update.mvir
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/enums/mono/mut_ref_update.mvir
@@ -2,7 +2,7 @@
 
 //# print-bytecode
 mvir 0x6::MonomorphicEnums {
-    enum EnumWithTwoVariants has drop {
+    public enum EnumWithTwoVariants has drop {
         One { x: u64 },
         Two { x: u64, y: u64 }
     }
@@ -51,7 +51,7 @@ mvir 0x6::MonomorphicEnums {
 
 //# publish
 mvir 0x6::MonomorphicEnums {
-    enum EnumWithTwoVariants has drop {
+    public enum EnumWithTwoVariants has drop {
         One { x: u64 },
         Two { x: u64, y: u64 }
     }

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/enums/mono/mut_ref_update_variant.mvir
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/enums/mono/mut_ref_update_variant.mvir
@@ -2,7 +2,7 @@
 
 //# print-bytecode
 mvir 0x6::MonomorphicEnums {
-    enum EnumWithTwoVariants has drop {
+    public enum EnumWithTwoVariants has drop {
         One { x: u64 },
         Two { x: u64, y: u64 }
     }
@@ -35,7 +35,7 @@ mvir 0x6::MonomorphicEnums {
 
 //# publish
 mvir 0x6::MonomorphicEnums {
-    enum EnumWithTwoVariants has drop {
+    public enum EnumWithTwoVariants has drop {
         One { x: u64 },
         Two { x: u64, y: u64 }
     }

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/enums/poly/basic_poly_enum.mvir
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/enums/poly/basic_poly_enum.mvir
@@ -1,6 +1,6 @@
 //# print-bytecode
 mvir 0x6::MonomorphicEnums {
-    enum EnumWithTwoVariants<T> {
+    public enum EnumWithTwoVariants<T> {
         One { },
         Two { x: T }
     }
@@ -25,7 +25,7 @@ mvir 0x6::MonomorphicEnums {
 
 //# publish
 mvir 0x6::MonomorphicEnums {
-    enum EnumWithTwoVariants<T> {
+    public enum EnumWithTwoVariants<T> {
         One { },
         Two { x: T }
     }

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/enums/poly/enum_decl_poly_mismatched_variants.mvir
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/enums/poly/enum_decl_poly_mismatched_variants.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x6::PolymorphicEnums {
-    enum EnumWithTwoVariants<T> {
+    public enum EnumWithTwoVariants<T> {
         One { },
         Two { x: T }
     }

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/enums/poly/poly_mut_ref_update.mvir
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/enums/poly/poly_mut_ref_update.mvir
@@ -2,7 +2,7 @@
 
 //# print-bytecode
 mvir 0x6::PolymorphicEnums {
-    enum EnumWithTwoVariants<T: drop> has drop {
+    public enum EnumWithTwoVariants<T: drop> has drop {
         One { x: T },
         Two { x: T, y: u64 }
     }
@@ -51,7 +51,7 @@ mvir 0x6::PolymorphicEnums {
 
 //# publish
 mvir 0x6::PolymorphicEnums {
-    enum EnumWithTwoVariants<T: drop> has drop {
+    public enum EnumWithTwoVariants<T: drop> has drop {
         One { x: T },
         Two { x: T, y: u64 }
     }

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/enums/poly/poly_mut_ref_update_variant.mvir
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/enums/poly/poly_mut_ref_update_variant.mvir
@@ -2,7 +2,7 @@
 
 //# print-bytecode
 mvir 0x6::PolymorphicEnums {
-    enum EnumWithTwoVariants<T> has drop {
+    public enum EnumWithTwoVariants<T> has drop {
         One { x: T },
         Two { x: T, y: T }
     }
@@ -35,7 +35,7 @@ mvir 0x6::PolymorphicEnums {
 
 //# publish
 mvir 0x6::PolymorphicEnums {
-    enum EnumWithTwoVariants<T> has drop {
+    public enum EnumWithTwoVariants<T> has drop {
         One { x: T },
         Two { x: T, y: T }
     }

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/enums/unpack_mut_ref_alias.mvir
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/enums/unpack_mut_ref_alias.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x6::o {
-    enum X has drop { 
+    public enum X has drop { 
         One { x: u64, y: u64 },
         Two { x: u64, y: u64},
     }

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/enums/variant_switch_loop.mvir
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/enums/variant_switch_loop.mvir
@@ -1,6 +1,6 @@
 //# print-bytecode
 mvir 0x6::InfiniteSwith {
-    enum EnumWithOneVariant {
+    public enum EnumWithOneVariant {
         One { }
     }
 
@@ -23,7 +23,7 @@ mvir 0x6::InfiniteSwith {
 
 //# publish
 mvir 0x6::InfiniteSwith {
-    enum EnumWithOneVariant {
+    public enum EnumWithOneVariant {
         One { }
     }
 

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/instructions/assign_struct_field.mvir
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/instructions/assign_struct_field.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x42::Tester {
-    struct T has drop {v: u64}
+    public struct T has drop {v: u64}
 
     public fun new(v: u64): Self::T  {
     label b0:

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/instructions/deref_value.mvir
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/instructions/deref_value.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x6::A {
-    struct T has drop {f: u64}
+    public struct T has drop {f: u64}
 
     public fun new(f: u64): Self::T {
     label b0:

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/instructions/deref_value_nested.mvir
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/instructions/deref_value_nested.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x6::B {
-    struct T has drop {g: u64}
+    public struct T has drop {g: u64}
 
     public fun new(g: u64): Self::T {
     label b0:
@@ -22,7 +22,7 @@ mvir 0x6::B {
 mvir 0x7::A {
     import 0x6::B;
 
-    struct T has drop {f: B::T}
+    public struct T has drop {f: B::T}
 
     public fun new(f: B::T): Self::T {
     label b0:

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/instructions/field_reads.mvir
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/instructions/field_reads.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x42::VTest {
-    struct T has drop {fint: u64, fv: bool}
+    public struct T has drop {fint: u64, fv: bool}
 
     public fun new(x: u64, y: bool): Self::T {
     label b0:
@@ -35,7 +35,7 @@ mvir 0x42::VTest {
 //# publish
 
 mvir 0x43::RTest {
-    struct T{fint: u64, fv: bool}
+    public struct T{fint: u64, fv: bool}
 
     public fun new(x: u64, y: bool): Self::T {
     label b0:

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/instructions/field_writes.mvir
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/instructions/field_writes.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x42::VTest {
-    struct T has drop {fint: u64, fv: bool}
+    public struct T has drop {fint: u64, fv: bool}
 
     public fun new(x: u64, y: bool): Self::T {
     label b0:
@@ -43,7 +43,7 @@ mvir 0x42::VTest {
 //# publish
 
 mvir 0x43::RTest {
-    struct T{fint: u64, fr: bool}
+    public struct T{fint: u64, fr: bool}
 
     public fun new(x: u64, y: bool): Self::T {
     label b0:

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/instructions/pack_unpack.mvir
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/instructions/pack_unpack.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x42::Test {
-    struct T { i: u64, b: bool }
+    public struct T { i: u64, b: bool }
 
     public fun new_t(): Self::T {
     label b0:

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/instructions/vec_copy_nested.mvir
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/instructions/vec_copy_nested.mvir
@@ -2,8 +2,8 @@
 mvir 0x42::DeepCopy {
     import 0x1::vector;
 
-    struct Config has copy, drop, store { i: u64 }
-    struct Nested has copy, drop, store { c: Self::Config }
+    public struct Config has copy, drop, store { i: u64 }
+    public struct Nested has copy, drop, store { c: Self::Config }
 
     public fun test_struct_shallow() {
         let c1: Self::Config;

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/module_publishing/publish_module_and_use.mvir
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/module_publishing/publish_module_and_use.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x5::Coin {
-    struct Coin { value: u64 }
+    public struct Coin { value: u64 }
     public fun value(c: &Self::Coin): u64 {
     label b0:
         return *&move(c).Coin::value;
@@ -21,7 +21,7 @@ mvir 0x5::Coin {
 mvir 0x43::MoneyHolder {
     import 0x5::Coin;
 
-    struct T { money: Coin::Coin }
+    public struct T { money: Coin::Coin }
 
     public fun new(m: Coin::Coin): Self::T {
     label b0:

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/module_publishing/publish_two_modules.mvir
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/module_publishing/publish_two_modules.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x5::Coin {
-    struct Coin { value: u64 }
+    public struct Coin { value: u64 }
     public fun value(c: &Self::Coin): u64 {
     label b0:
         return *&move(c).Coin::value;
@@ -21,7 +21,7 @@ mvir 0x5::Coin {
 mvir 0x42::MoneyHolder {
     import 0x5::Coin;
 
-    struct T { money: Coin::Coin }
+    public struct T { money: Coin::Coin }
 
     public fun new(m: Coin::Coin): Self::T {
     label b0:
@@ -49,7 +49,7 @@ mvir 0x42::MoneyHolder {
 
 //# publish
 mvir 0x43::Bar {
-        struct T has drop {baz: u64}
+        public struct T has drop {baz: u64}
         public fun new(m: u64): Self::T {
         label b0:
             return T{baz: move(m)};

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/native_functions/vector_module.mvir
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/native_functions/vector_module.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x5::Coin {
-    struct Coin has store { value: u64 }
+    public struct Coin has store { value: u64 }
     public fun value(c: &Self::Coin): u64 {
     label b0:
         return *&move(c).Coin::value;
@@ -22,7 +22,7 @@ mvir 0x42::M {
     import 0x5::Coin;
     import 0x1::vector;
 
-    struct Coins has key { f: vector<Coin::Coin> }
+    public struct Coins has key { f: vector<Coin::Coin> }
 
     public fun new(): Self::Coins {
         let coin_vec: vector<Coin::Coin>;

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/native_functions/vector_resource_not_destroyed_at_return.mvir
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/native_functions/vector_resource_not_destroyed_at_return.mvir
@@ -2,7 +2,7 @@
 mvir 0x42::M {
     import 0x1::vector;
 
-    struct R has store { b: bool}
+    public struct R has store { b: bool}
 
     fun f() {
         let v: vector<Self::R>;

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/native_structs/non_existant_native_struct.mvir
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/native_structs/non_existant_native_struct.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x42::M {
     // error, missing dep
-    native struct T;
-    native struct T2;
+    public native struct T;
+    public native struct T2;
 }

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/recursion/runtime_layout_deeply_nested.mvir
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/recursion/runtime_layout_deeply_nested.mvir
@@ -1,14 +1,14 @@
 //# publish
 mvir 0x42::M {
-    struct Box<T> has key, store { x: T }
-    struct Box3<T> has store { x: Self::Box<Self::Box<T>> }
-    struct Box7<T> has store { x: Self::Box3<Self::Box3<T>> }
-    struct Box15<T> has store { x: Self::Box7<Self::Box7<T>> }
-    struct Box31<T> has store { x: Self::Box15<Self::Box15<T>> }
-    struct Box63<T> has store { x: Self::Box31<Self::Box31<T>> }
-    struct Box127<T> has key, store { x: Self::Box63<Self::Box63<T>> }
-    struct Box128<T> has key, store { x: Self::Box127<T> }
-    struct Box255<T> has key, store { x: Self::Box127<Self::Box127<T>> }
+    public struct Box<T> has key, store { x: T }
+    public struct Box3<T> has store { x: Self::Box<Self::Box<T>> }
+    public struct Box7<T> has store { x: Self::Box3<Self::Box3<T>> }
+    public struct Box15<T> has store { x: Self::Box7<Self::Box7<T>> }
+    public struct Box31<T> has store { x: Self::Box15<Self::Box15<T>> }
+    public struct Box63<T> has store { x: Self::Box31<Self::Box31<T>> }
+    public struct Box127<T> has key, store { x: Self::Box63<Self::Box63<T>> }
+    public struct Box128<T> has key, store { x: Self::Box127<T> }
+    public struct Box255<T> has key, store { x: Self::Box127<Self::Box127<T>> }
 
     public fun box3<T>(x: T): Self::Box3<T> {
     label b0:

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/recursion/runtime_type_deeply_nested.mvir
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/recursion/runtime_type_deeply_nested.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x42::M {
-    struct Foo<T> { x: bool }
+    public struct Foo<T> { x: bool }
     public fun f0<T>() { label b0: return; }
     public fun f3<T>() { label b0: Self::f0<Self::Foo<Self::Foo<Self::Foo<T>>>>(); return; }
     public fun f7<T>() { label b0: Self::f3<Self::Foo<Self::Foo<Self::Foo<Self::Foo<T>>>>>(); return; }

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/references/borrow_in_loop.mvir
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/references/borrow_in_loop.mvir
@@ -1,7 +1,7 @@
 //# publish
 mvir 0x42::m {
 
-struct S has copy, drop { f: u64 }
+public struct S has copy, drop { f: u64 }
 public fun foo() {
     let x: Self::S;
     let y: Self::S;

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/references/deref_move_module_ok.mvir
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/references/deref_move_module_ok.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x6::M {
-    struct T has drop {v : u64}
+    public struct T has drop {v : u64}
 
     public fun new(v: u64): Self::T {
     label b0:

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/references/mixed_lvalue.mvir
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/references/mixed_lvalue.mvir
@@ -1,7 +1,7 @@
 //# publish
 mvir 0x6::A {
 
-    struct S { f: u64 }
+    public struct S { f: u64 }
 
     fun four(): u64 * u64 * u64 * u64 {
     label b0:

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/references/mutate_move_ok.mvir
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/references/mutate_move_ok.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x6::B {
-    struct T has drop {g: u64}
+    public struct T has drop {g: u64}
 
     public fun new(v: u64): Self::T {
     label b0:

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/references/unpack_enum_with_unreachable_ref.mvir
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/references/unpack_enum_with_unreachable_ref.mvir
@@ -3,7 +3,7 @@
 //# run
 mvir 0x42::m {
 
-enum Wrapper has drop {
+public enum Wrapper has drop {
     Val { x: u64 },
 }
 

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/references/unpack_struct_with_unreachable_ref.mvir
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/references/unpack_struct_with_unreachable_ref.mvir
@@ -3,7 +3,7 @@
 //# run
 mvir 0x42::m {
 
-struct S has drop { f: u64 }
+public struct S has drop { f: u64 }
 
 entry fun foo() {
     let s: Self::S;

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/references/unpack_vec_with_unreachable_ref.mvir
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/references/unpack_vec_with_unreachable_ref.mvir
@@ -3,7 +3,7 @@
 //# run
 mvir 0x42::m {
 
-struct S has copy, drop { f: u64 }
+public struct S has copy, drop { f: u64 }
 
 entry fun foo() {
     let s: Self::S;

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/references/vec_pop_back_with_unreachable_ref.mvir
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/references/vec_pop_back_with_unreachable_ref.mvir
@@ -4,7 +4,7 @@
 mvir 0x42::m {
 import 0x1::vector;
 
-struct S has copy, drop { f: u64 }
+public struct S has copy, drop { f: u64 }
 
 entry fun foo() {
     let s: Self::S;

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/stack_and_function_calls/many_function_calls_as_args.mvir
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/stack_and_function_calls/many_function_calls_as_args.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x5::A {
-    struct T has drop {value: u64, even: bool}
+    public struct T has drop {value: u64, even: bool}
 
     public fun new(): Self::T {
     label b0:

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/stack_and_function_calls/multiple_composite_functions.mvir
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/stack_and_function_calls/multiple_composite_functions.mvir
@@ -1,6 +1,6 @@
 //# publish
 mvir 0x5::A {
-    struct T has drop {value: u64}
+    public struct T has drop {value: u64}
 
     public fun new(v: u64): Self::T {
     label b0:


### PR DESCRIPTION
## Description 

- 🤖 
- We are breaking everything so why not this too
- Requiring public on datatype declarations was a bit more involved than other changes due to changing the grammar a bit (`public` no longer implies a function)

## Test plan 

- More tests
- Added some missing tests from previous PRs too 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
