### PR TITLE
[typed-store] Fix safe_range_iter including the entry at an exclusive lower bound equal to the encoded max key

### DIFF
--- a/crates/typed-store/src/rocks/tests.rs
+++ b/crates/typed-store/src/rocks/tests.rs
@@ -545,6 +545,40 @@ async fn test_reversed_safe_iter_inclusive_upper_bound_at_max() {
 }
 
 #[tokio::test]
+async fn test_safe_range_iter_exclusive_lower_bound_at_max() {
+    use std::ops::Bound;
+
+    let db: DBMap<u8, String> = open_map(temp_dir(), None);
+    db.insert(&100u8, &"100".to_string()).unwrap();
+    db.insert(&u8::MAX, &"max".to_string()).unwrap();
+
+    let results: Vec<_> =
+        get_range_iter(&db, (Bound::Excluded(u8::MAX), Bound::Unbounded)).collect();
+    assert_eq!(
+        Vec::<(u8, String)>::new(),
+        results,
+        "Range (Excluded(u8::MAX), Unbounded) must yield no entries -- there is no key strictly greater than u8::MAX",
+    );
+}
+
+#[tokio::test]
+async fn test_safe_range_iter_exclusive_lower_bound_at_max_with_inclusive_upper() {
+    use std::ops::Bound;
+
+    let db: DBMap<u8, String> = open_map(temp_dir(), None);
+    db.insert(&100u8, &"100".to_string()).unwrap();
+    db.insert(&u8::MAX, &"max".to_string()).unwrap();
+
+    let results: Vec<_> =
+        get_range_iter(&db, (Bound::Excluded(u8::MAX), Bound::Included(u8::MAX))).collect();
+    assert_eq!(
+        Vec::<(u8, String)>::new(),
+        results,
+        "Range (Excluded(u8::MAX), Included(u8::MAX)) must yield no entries -- the lower bound excludes the only candidate",
+    );
+}
+
+#[tokio::test]
 async fn test_is_empty() {
     let db: DBMap<i32, String> = open_map(temp_dir(), Some("table"));
     // Test empty map is truly empty

--- a/crates/typed-store/src/util.rs
+++ b/crates/typed-store/src/util.rs
@@ -63,10 +63,17 @@ where
         Bound::Excluded(lower_bound) => {
             let mut key_buf = be_fix_int_ser(&lower_bound);
 
-            // Since we want exclusive, we need to increment the key to exclude the previous
-            big_endian_saturating_add_one(&mut key_buf);
+            if is_max(&key_buf) {
+                // No representable key strictly greater than the maximum at this byte
+                // length. Append a zero byte so the lower bound is lexicographically
+                // greater than any same-length key, ensuring the iterator yields nothing
+                // -- matching the user's intent of excluding the max key.
+                key_buf.push(0);
+            } else {
+                // Since we want exclusive, we need to increment the key to exclude the previous
+                big_endian_saturating_add_one(&mut key_buf);
+            }
             Some(key_buf)
-            // readopts.set_iterate_lower_bound(key_buf);
         }
         Bound::Unbounded => None,
     };


### PR DESCRIPTION
## Summary

Fixes the symmetric bug to #26456 in `iterator_bounds_with_range`: the `Bound::Excluded(lower_bound)` arm silently includes the max-key entry when the user-supplied lower bound serializes to all `0xFF`. `big_endian_saturating_add_one` saturates and leaves `key_buf` unchanged, then rocksdb (whose lower bound is inclusive) yields the max key the caller asked to exclude.

The fix mirrors the `is_max` short-circuit pattern from #26456: append a `0` byte so the returned lower bound is lexicographically greater than any same-length stored key, ensuring rocksdb yields no entries for the empty range.

In practice no current Sui caller constructs `(Bound::Excluded(K), _)` for `K` that serializes to all `0xFF` (Rust's standard range syntax `a..b`, `a..=b`, `a..` produce `Bound::Included` for the lower bound), so this is a latent correctness issue rather than an active bug. `safe_range_iter` is on the public `Map` trait and accepts any `RangeBounds<K>` implementor, however, so any future caller using the explicit tuple form will hit the same divergence between intended and actual semantics.

Closes #26468

## Test plan

Added two regression tests using `DBMap<u8, String>` with `u8::MAX` as the exclusive lower bound:

- `test_safe_range_iter_exclusive_lower_bound_at_max` — `(Excluded(u8::MAX), Unbounded)` must yield no entries.
- `test_safe_range_iter_exclusive_lower_bound_at_max_with_inclusive_upper` — `(Excluded(u8::MAX), Included(u8::MAX))` must yield no entries.

Both fail against the previous code (the max entry leaks through) and pass after this change.

```
cargo test -p typed-store --lib rocks::tests
running 29 tests
...
test rocks::tests::test_safe_range_iter_exclusive_lower_bound_at_max ... ok
test rocks::tests::test_safe_range_iter_exclusive_lower_bound_at_max_with_inclusive_upper ... ok
test rocks::tests::test_safe_range_iter_inclusive_upper_bound_at_max ... ok
test rocks::tests::test_reversed_safe_iter_inclusive_upper_bound_at_max ... ok
...
test result: ok. 29 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.04s
```

`cargo xclippy` in `crates/typed-store` is clean.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework: