### PR TITLE
gRPC typescript examples

### DIFF
--- a/docs/content/develop/accessing-data/grpc/grpc-examples.mdx
+++ b/docs/content/develop/accessing-data/grpc/grpc-examples.mdx
@@ -1,0 +1,393 @@
+---
+title: TypeScript SDK Examples
+description: Practical examples using SuiGrpcClient from the @mysten/sui SDK to query and interact with the Sui network.
+keywords: [ grpc, typescript, sui sdk, SuiGrpcClient, examples, tutorial, bcs decoding, streaming ]
+---
+
+The `@mysten/sui` TypeScript SDK provides `SuiGrpcClient`, a high-level, type-safe client for the Sui Full Node gRPC API. This page shows practical examples with real request and response shapes.
+
+For the low-level gRPC protocol details, see [Querying Data with gRPC](/develop/accessing-data/grpc/using-grpc). For the full method reference, see [Sui Full Node gRPC Methods](/references/fullnode-protocol).
+
+## Setup
+
+Install the SDK:
+
+```shell
+npm install @mysten/sui @mysten/bcs
+```
+
+Create the client:
+
+```ts
+import { SuiGrpcClient } from "@mysten/sui/grpc";
+
+const client = new SuiGrpcClient({
+  network: "testnet",
+  baseUrl: "https://fullnode.testnet.sui.io",
+});
+```
+
+### Network URLs
+
+| Network | `network` | `baseUrl` |
+| ------- | --------- | --------- |
+| Mainnet | `"mainnet"` | `https://fullnode.mainnet.sui.io` |
+| Testnet | `"testnet"` | `https://fullnode.testnet.sui.io` |
+| Devnet | `"devnet"` | `https://fullnode.devnet.sui.io` |
+| Localnet | `"localnet"` | `http://127.0.0.1:9000` |
+
+:::info
+
+Both `network` and `baseUrl` are required. The `baseUrl` should not include a port suffix for public networks (no `:443`).
+
+:::
+
+### Transport options
+
+By default, `SuiGrpcClient` uses `GrpcWebFetchTransport` (gRPC-web over HTTP/1.1 or HTTP/2), which works in both browsers and Node.js.
+
+For server-side applications that need native HTTP/2 gRPC, you can provide a custom transport:
+
+```ts
+import { SuiGrpcClient } from "@mysten/sui/grpc";
+import { GrpcTransport } from "@protobuf-ts/grpc-transport";
+import { ChannelCredentials } from "@grpc/grpc-js";
+
+const client = new SuiGrpcClient({
+  network: "mainnet",
+  transport: new GrpcTransport({
+    host: "https://fullnode.mainnet.sui.io:443",
+    channelCredentials: ChannelCredentials.createSsl(),
+  }),
+});
+```
+
+This requires installing `@protobuf-ts/grpc-transport` and `@grpc/grpc-js`.
+
+## Querying objects
+
+Use `getObject` to fetch a single object. The `include` parameter controls which fields are returned.
+
+```ts
+const result = await client.getObject({
+  objectId: "0x0000000000000000000000000000000000000000000000000000000000000006",
+  include: { json: true },
+});
+
+console.log(result);
+```
+
+Response:
+
+```json
+{
+  "object": {
+    "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
+    "version": "849547913",
+    "digest": "Bd6aRkqj5Va43F8QT3gymCBoVLcdvD77b9jS3GmLYsR",
+    "owner": {
+      "$kind": "Shared",
+      "Shared": { "initialSharedVersion": "1" }
+    },
+    "type": "0x0000000000000000000000000000000000000000000000000000000000000002::clock::Clock",
+    "json": {
+      "id": "0x0000000000000000000000000000000000000000000000000000000000000006",
+      "timestamp_ms": "1777798905234"
+    }
+  }
+}
+```
+
+### Include options for objects
+
+| Option | Type | What it adds to the response |
+| ------ | ---- | ---------------------------- |
+| `json` | `boolean` | JSON-decoded Move fields |
+| `content` | `boolean` | Raw BCS content bytes |
+| `objectBcs` | `boolean` | Full object BCS encoding |
+| `display` | `boolean` | Display metadata (if configured) |
+| `previousTransaction` | `boolean` | Digest of the last transaction that modified this object |
+
+### Batch fetching
+
+Use `getObjects` to fetch multiple objects in a single call:
+
+```ts
+const result = await client.getObjects({
+  objectIds: [
+    "0x0000000000000000000000000000000000000000000000000000000000000005",
+    "0x0000000000000000000000000000000000000000000000000000000000000006",
+  ],
+  include: { json: true },
+});
+
+for (const obj of result.objects) {
+  console.log(obj.type, obj.json);
+}
+```
+
+## Listing owned objects
+
+Use `listOwnedObjects` with pagination:
+
+```ts
+let cursor: string | null = null;
+let hasNextPage = true;
+
+while (hasNextPage) {
+  const page = await client.listOwnedObjects({
+    owner: "0x94096a6a54129234237759c66e6ef1037224fb3102a0ae29d33b490281c8e4d5",
+    limit: 50,
+    cursor,
+  });
+
+  for (const obj of page.objects) {
+    console.log(obj.objectId, obj.type);
+  }
+
+  cursor = page.cursor;
+  hasNextPage = page.hasNextPage;
+}
+```
+
+## Balances and coins
+
+### Get balance for a coin type
+
+```ts
+const balance = await client.getBalance({
+  owner: "0x94096a6a54129234237759c66e6ef1037224fb3102a0ae29d33b490281c8e4d5",
+});
+
+console.log(balance);
+```
+
+Response:
+
+```json
+{
+  "balance": {
+    "balance": "1500000000",
+    "coinType": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+    "coinBalance": "1500000000",
+    "addressBalance": "1500000000"
+  }
+}
+```
+
+The default `coinType` is `0x2::sui::SUI`. To query a different coin:
+
+```ts
+const balance = await client.getBalance({
+  owner: "0x...",
+  coinType: "0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7::usdc::USDC",
+});
+```
+
+### List all balances
+
+```ts
+const allBalances = await client.listBalances({
+  owner: "0x94096a6a54129234237759c66e6ef1037224fb3102a0ae29d33b490281c8e4d5",
+});
+
+for (const bal of allBalances.balances) {
+  console.log(bal.coinType, bal.coinBalance);
+}
+```
+
+### Get coin metadata
+
+```ts
+const meta = await client.getCoinMetadata({ coinType: "0x2::sui::SUI" });
+console.log(meta);
+```
+
+Response:
+
+```json
+{
+  "coinMetadata": {
+    "id": "0xf256d3fb6a50eaa748d94335b34f2982fbc3b63ceec78cafaa29ebc9ebaf2bbc",
+    "decimals": 9,
+    "name": "Sui",
+    "symbol": "SUI",
+    "description": "",
+    "iconUrl": ""
+  }
+}
+```
+
+## Transactions
+
+### Fetch a transaction
+
+```ts
+const tx = await client.getTransaction({
+  digest: "ASYhXWNufSk8ujeeAYS2Sjw8Z8o4kB9s2Pz2HLCqmGCq",
+  include: { effects: true, events: true },
+});
+
+console.log(tx.Transaction.digest);
+console.log(tx.Transaction.status); // { success: true, error: null }
+```
+
+### Execute a transaction
+
+Build, sign, and execute a transaction end-to-end:
+
+```ts
+import { Ed25519Keypair } from "@mysten/sui/keypairs/ed25519";
+import { Transaction } from "@mysten/sui/transactions";
+
+const keypair = Ed25519Keypair.fromSecretKey("suiprivkey1...");
+
+const tx = new Transaction();
+tx.transferObjects(
+  [tx.splitCoins(tx.gas, [1_000_000_000])],
+  "0xRECIPIENT_ADDRESS"
+);
+
+const result = await client.signAndExecuteTransaction({
+  transaction: tx,
+  signer: keypair,
+  include: { effects: true },
+});
+
+console.log("Digest:", result.Transaction.digest);
+console.log("Success:", result.Transaction.status.success);
+```
+
+### Include options for transactions
+
+| Option | Type | What it adds |
+| ------ | ---- | ------------ |
+| `effects` | `boolean` | Transaction effects (created/mutated/deleted objects, gas used) |
+| `events` | `boolean` | Events emitted by the transaction |
+| `objectTypes` | `boolean` | A `Record<objectId, typeString>` for affected objects |
+| `commandResults` | `boolean` | Return values from Move calls (for `simulateTransaction`) |
+
+## Simulating transactions and BCS decoding
+
+Use `simulateTransaction` to dry-run a transaction and decode return values using `@mysten/bcs`.
+
+```ts
+import { bcs } from "@mysten/bcs";
+import { Transaction } from "@mysten/sui/transactions";
+
+const tx = new Transaction();
+// Call a Move function that returns a u64
+tx.moveCall({
+  target: "0xPACKAGE::module::my_view_function",
+  arguments: [tx.object("0xOBJECT_ID")],
+});
+
+const simResult = await client.simulateTransaction({
+  transaction: tx,
+  include: { commandResults: true },
+});
+
+// Decode the return value from BCS bytes
+const returnBytes = simResult.commandResults?.[0]?.returnValues?.[0]?.bcs;
+if (returnBytes) {
+  const value = bcs.u64().parse(new Uint8Array(returnBytes));
+  console.log("Return value:", value);
+}
+```
+
+### Common BCS decoders
+
+```ts
+import { bcs } from "@mysten/bcs";
+
+// Single values
+bcs.u64().parse(bytes);          // bigint
+bcs.u128().parse(bytes);         // bigint
+bcs.bool().parse(bytes);         // boolean
+bcs.string().parse(bytes);       // string
+
+// Vectors
+bcs.vector(bcs.u64()).parse(bytes);    // bigint[]
+bcs.vector(bcs.string()).parse(bytes); // string[]
+```
+
+## Dynamic fields
+
+### List dynamic fields on an object
+
+```ts
+const fields = await client.listDynamicFields({
+  parentId: "0xb57fba584a700a5bcb40991e1b2e6bf68b0f3896d767a0da92e69de73de226ac",
+});
+
+for (const field of fields.dynamicFields) {
+  console.log(field.name, field.objectId);
+}
+```
+
+### Get a specific dynamic field
+
+```ts
+const field = await client.getDynamicField({
+  parentId: "0xPARENT_OBJECT_ID",
+  name: {
+    type: "u64",
+    value: "42",
+  },
+});
+```
+
+## Streaming checkpoints
+
+Use the raw `subscriptionService` to stream live checkpoint updates:
+
+```ts
+const stream = client.subscriptionService.subscribeCheckpoints({
+  readMask: {
+    paths: ["sequenceNumber", "digest", "summary"],
+  },
+});
+
+for await (const response of stream.responses) {
+  console.log(
+    "Checkpoint:",
+    response.checkpoint?.sequenceNumber,
+    response.checkpoint?.digest
+  );
+}
+```
+
+:::info
+
+Streaming uses gRPC server-side streaming. The stream starts from the latest checkpoint and delivers updates in order without gaps. If the connection drops, reconnect and use other APIs to backfill any missed checkpoints.
+
+:::
+
+## Using raw service clients
+
+`SuiGrpcClient` exposes the underlying protobuf-ts service clients for when you need full proto-level control:
+
+| Property | Proto service | Use case |
+| -------- | ------------- | -------- |
+| `client.transactionExecutionService` | `TransactionExecutionService` | Submit transactions, simulate |
+| `client.ledgerService` | `LedgerService` | Fetch checkpoints, transactions, objects |
+| `client.stateService` | `StateService` | Query balances, coins, dynamic fields |
+| `client.subscriptionService` | `SubscriptionService` | Stream checkpoints |
+| `client.movePackageService` | `MovePackageService` | Inspect Move packages |
+| `client.signatureVerificationService` | `SignatureVerificationService` | Verify signatures |
+| `client.nameService` | `NameService` | Resolve SuiNS names |
+
+Example using the raw ledger service:
+
+```ts
+const { response } = await client.ledgerService.getTransaction({
+  digest: "ASYhXWNufSk8ujeeAYS2Sjw8Z8o4kB9s2Pz2HLCqmGCq",
+  readMask: {
+    paths: ["events", "effects"],
+  },
+});
+
+console.log(response);
+```
+
+The raw service clients use proto field names (`read_mask`, `sequence_number`) rather than the camelCase Core API names. Refer to the [Message Definitions](/references/fullnode-protocol-messages) for the full proto schema.

--- a/docs/content/develop/accessing-data/grpc/using-grpc.mdx
+++ b/docs/content/develop/accessing-data/grpc/using-grpc.mdx
@@ -4,12 +4,18 @@ description: Learn how to use gRPC clients for the Sui network with grpcurl, Buf
 keywords: [ grpc, grpc client, grpcurl, typescript grpc, golang grpc, python grpc, sui grpc tutorial ]
 ---
 
-This guide provides practical examples for querying the Sui network using gRPC. For core concepts, see the [corresponding concepts page](/develop/accessing-data/grpc/what-is-grpc).
+This guide covers low-level gRPC concepts and shows how to build clients using `grpcurl`, Buf CLI, and language-specific proto tooling. For core concepts, see the [corresponding concepts page](/develop/accessing-data/grpc/what-is-grpc).
+
+:::tip TypeScript developers
+
+If you are using TypeScript, the `@mysten/sui` SDK provides `SuiGrpcClient` — a high-level, type-safe client that wraps the gRPC API. See [TypeScript SDK Examples](/develop/accessing-data/grpc/grpc-examples) for practical examples with real request and response shapes. The raw gRPC examples below are for languages without an SDK or for advanced use cases.
+
+:::
 
 <Tabs className="tabsHeadingCentered--small">
 <TabItem value="prereq" label="Prerequisites">
 
-Before you begin, ensure you have access to a [gRPC](/develop/accessing-data/grpc)-enabled Sui full node. Check the [list of RPC and data providers](https://www.notion.so/mystenlabs/RPC-providers-offering-future-Sui-data-primitives-2466d9dcb4e980a99a36e9aafd8c17e0?source=copy_link) that support gRPC on their full nodes, and contact a provider directly to request access.
+Before you begin, ensure you have access to a [gRPC](/develop/accessing-data/grpc)-enabled Sui full node. Sui Foundation operates public full nodes for each network (for example, `fullnode.mainnet.sui.io`, `fullnode.testnet.sui.io`). You can also contact an RPC provider directly to request access — check the [Sui Discord](https://discord.gg/sui) for an up-to-date list of providers that support gRPC.
 
 If your provider doesn't yet support gRPC, you can:
 
@@ -245,7 +251,7 @@ client.GetTransaction(request, (err: any, response: any) => {
 #### Step 3: Run the sample client
 
 ```shell
-npx tsx c
+npx tsx client.ts
 ```
 
 - `proto-loader` handles any nested `.proto` files. Just make sure paths and imports are correct.

--- a/docs/content/develop/accessing-data/grpc/what-is-grpc.mdx
+++ b/docs/content/develop/accessing-data/grpc/what-is-grpc.mdx
@@ -46,15 +46,15 @@ In addition to request-response calls, gRPC supports server-side streaming, enab
 
 The following gRPC services are available on Sui. Protocol buffers define the gRPC interface. You can find the relevant `.proto` files at [`sui-apis` on GitHub](https://github.com/MystenLabs/sui-apis/tree/main/proto), which apart from the gRPC messages (request and response payloads), include the following services:
 
-| Service | `.proto` file | Purpose |
-| --- | --- | --- |
-| `TransactionExecutionService` | `sui/rpc/v2/transaction_execution_service.proto` | Submit and execute signed transactions on the Sui network. Wallets and apps use this service to send user actions to the network. |
-| `LedgerService` | `sui/rpc/v2/ledger_service.proto` | Look up specific checkpoints, transactions, objects, and more from the current state and recent history of the Sui network. History refers to the recent past, limited to what a full node retains. |
-| `StateService` | `sui/rpc/v2/state_service.proto` | Query up-to-date onchain data like balances, coin metadata, dynamic fields, or owned objects. It also supports dry-run simulations for transactions. |
-| `SubscriptionService` | `sui/rpc/v2/subscription_service.proto` | Stream live updates for checkpoints. Ideal for building reactive systems such as indexers, bots, and dashboards. See Subscriptions for streaming data. |
-| `MovePackageService` | `sui/rpc/v2/move_package_service.proto` | Access metadata and the content of Move packages deployed on the Sui network. Useful for tooling, analysis, and smart contract introspection. |
-| `SignatureVerificationService` | `sui/rpc/v2/signature_verification_service.proto` | Validate signatures outside transaction execution. Helps pre-verify payloads that might include [zkLogin](/sui-stack/zklogin-integration) or other signatures, simulate authentication, or build custom signing workflows. |
-| `NameService` | `sui/rpc/v2/name_service.proto` | Resolve human-readable SuiNS names to their underlying name records, and perform reverse lookups from Sui addresses back to linked names. |
+| Service | `.proto` file | SDK property | Purpose |
+| --- | --- | --- | --- |
+| `TransactionExecutionService` | `sui/rpc/v2/transaction_execution_service.proto` | `client.transactionExecutionService` | Submit and execute signed transactions on the Sui network. Wallets and apps use this service to send user actions to the network. |
+| `LedgerService` | `sui/rpc/v2/ledger_service.proto` | `client.ledgerService` | Look up specific checkpoints, transactions, objects, and more from the current state and recent history of the Sui network. History refers to the recent past, limited to what a full node retains. |
+| `StateService` | `sui/rpc/v2/state_service.proto` | `client.stateService` | Query up-to-date onchain data like balances, coin metadata, dynamic fields, or owned objects. It also supports dry-run simulations for transactions. |
+| `SubscriptionService` | `sui/rpc/v2/subscription_service.proto` | `client.subscriptionService` | Stream live updates for checkpoints. Ideal for building reactive systems such as indexers, bots, and dashboards. See Subscriptions for streaming data. |
+| `MovePackageService` | `sui/rpc/v2/move_package_service.proto` | `client.movePackageService` | Access metadata and the content of Move packages deployed on the Sui network. Useful for tooling, analysis, and smart contract introspection. |
+| `SignatureVerificationService` | `sui/rpc/v2/signature_verification_service.proto` | `client.signatureVerificationService` | Validate signatures outside transaction execution. Helps pre-verify payloads that might include [zkLogin](/sui-stack/zklogin-integration) or other signatures, simulate authentication, or build custom signing workflows. |
+| `NameService` | `sui/rpc/v2/name_service.proto` | `client.nameService` | Resolve human-readable SuiNS names to their underlying name records, and perform reverse lookups from Sui addresses back to linked names. |
 
 Use these definitions to generate client libraries in various programming languages.
 

--- a/docs/content/references/fullnode-protocol.mdx
+++ b/docs/content/references/fullnode-protocol.mdx
@@ -9,6 +9,12 @@ import Protocol from "../../site/src/components/Protocol";
 
 Sui full node gRPC API replaces JSON-RPC on full nodes. JSON-RPC is `deprecated`.
 
+:::tip
+
+For TypeScript developers, the `@mysten/sui` SDK provides [`SuiGrpcClient`](/develop/accessing-data/grpc/grpc-examples) which wraps this API with a type-safe, high-level client. See the [TypeScript SDK Examples](/develop/accessing-data/grpc/grpc-examples) for practical usage.
+
+:::
+
 See also: [Message Definitions](fullnode-protocol-messages) | [Enum and Scalar Types](fullnode-protocol-types)
 
 <Protocol />

--- a/docs/content/sidebars.js
+++ b/docs/content/sidebars.js
@@ -168,6 +168,7 @@ export default {
           items: [
             'develop/accessing-data/grpc/what-is-grpc',
             'develop/accessing-data/grpc/using-grpc',
+            'develop/accessing-data/grpc/grpc-examples',
           ],
         },
         {


### PR DESCRIPTION
      ## Summary

   - **New page: `grpc-examples.mdx`** — Cookbook-style TypeScript SDK examples using `SuiGrpcClient` with real
   request/response shapes. Covers: setup with network URL table, querying objects, balances & coins, transactions,
   simulating + BCS decoding, dynamic fields, streaming checkpoints, and raw service client usage.
   - **`using-grpc.mdx`** — Added SDK tip callout directing TypeScript devs to the new page, fixed truncated `npx tsx c`
   → `npx tsx client.ts`, replaced broken Notion provider link with public info.
   - **`what-is-grpc.mdx`** — Added "SDK property" column to the services table mapping proto services to `SuiGrpcClient`
    properties.
   - **`fullnode-protocol.mdx`** — Added tip callout linking to SDK examples.
   - **`sidebars.js`** — Registered the new page in the gRPC nav category.

   ## Motivation

   The current gRPC docs show only low-level proto-loader / grpcurl usage for TypeScript and never mention
   `SuiGrpcClient` from `@mysten/sui/grpc` — the recommended SDK path. Developers have to piece together information
   across docs.sui.io and sdk.mystenlabs.com with no cross-linking. This PR bridges that gap.

   ## Test plan

   - [x] Verify new page renders correctly at `/develop/accessing-data/grpc/grpc-examples`
   - [x] Verify sidebar shows the new "TypeScript SDK Examples" entry under gRPC
   - [x] Verify tip callouts render on `using-grpc` and `fullnode-protocol` pages
   - [x] Verify services table in `what-is-grpc` renders with the new SDK property column
   - [x] Verify all internal links resolve