### PR TITLE
test: refine Sui transactional runner and dynamic field coverage

### DIFF
--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/dynamic_object_field_id_and_type.move
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/dynamic_object_field_id_and_type.move
@@ -1,0 +1,80 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses test=0x0 --accounts A
+
+//# publish
+module test::m {
+    use sui::dynamic_object_field as ofield;
+
+    public struct Parent has key, store {
+        id: UID,
+    }
+
+    public struct Child has key, store {
+        id: UID,
+        value: u64,
+    }
+
+    public struct OtherChild has key, store {
+        id: UID,
+        value: u64,
+    }
+
+    public entry fun parent(ctx: &mut TxContext) {
+        transfer::public_transfer(
+            Parent { id: object::new(ctx) },
+            tx_context::sender(ctx),
+        )
+    }
+
+    public entry fun add_child(parent: &mut Parent, ctx: &mut TxContext) {
+        let child = Child { id: object::new(ctx), value: 10 };
+        let child_id = object::id(&child);
+
+        ofield::add(&mut parent.id, 0u64, child);
+        let stored_id = ofield::id(&parent.id, 0u64);
+
+        assert!(stored_id.is_some(), 0);
+        assert!(stored_id.destroy_some() == child_id, 1);
+        assert!(ofield::exists_with_type<u64, Child>(&parent.id, 0u64), 2);
+        assert!(!ofield::exists_with_type<u64, OtherChild>(&parent.id, 0u64), 3);
+    }
+
+    public entry fun replace_child(parent: &mut Parent, ctx: &mut TxContext) {
+        let replacement = OtherChild { id: object::new(ctx), value: 20 };
+        let replacement_id = object::id(&replacement);
+        let old = ofield::replace<u64, OtherChild, Child>(&mut parent.id, 0u64, replacement);
+
+        assert!(old.is_some(), 4);
+
+        let Child { id, value } = old.destroy_some();
+        assert!(value == 10, 5);
+        object::delete(id);
+
+        let stored_id = ofield::id(&parent.id, 0u64);
+        assert!(stored_id.is_some(), 6);
+        assert!(stored_id.destroy_some() == replacement_id, 7);
+        assert!(!ofield::exists_with_type<u64, Child>(&parent.id, 0u64), 8);
+        assert!(ofield::exists_with_type<u64, OtherChild>(&parent.id, 0u64), 9);
+    }
+
+    public entry fun remove_child(parent: &mut Parent) {
+        let OtherChild { id, value } = ofield::remove<u64, OtherChild>(&mut parent.id, 0u64);
+
+        assert!(value == 20, 10);
+        object::delete(id);
+
+        let stored_id = ofield::id(&parent.id, 0u64);
+        assert!(stored_id.is_none(), 11);
+        assert!(!ofield::exists<u64>(&parent.id, 0u64), 12);
+    }
+}
+
+//# run test::m::parent --sender A
+
+//# run test::m::add_child --sender A --args object(2,0)
+
+//# run test::m::replace_child --sender A --args object(2,0)
+
+//# run test::m::remove_child --sender A --args object(2,0)

--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/dynamic_object_field_id_and_type.snap
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/dynamic_object_field_id_and_type.snap
@@ -1,0 +1,39 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+assertion_line: 920
+---
+processed 6 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-72:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 13733200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, line 74:
+//# run test::m::parent --sender A
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2234400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, line 76:
+//# run test::m::add_child --sender A --args object(2,0)
+created: object(3,0), object(3,1)
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 5988800,  storage_rebate: 2212056, non_refundable_storage_fee: 22344
+
+task 4, line 78:
+//# run test::m::replace_child --sender A --args object(2,0)
+created: object(4,0)
+mutated: object(0,0), object(2,0), object(3,1)
+deleted: object(3,0)
+gas summary: computation_cost: 1000000, storage_cost: 6026800,  storage_rebate: 5928912, non_refundable_storage_fee: 59888
+
+task 5, line 80:
+//# run test::m::remove_child --sender A --args object(2,0)
+mutated: object(0,0), object(2,0)
+deleted: object(3,1), object(4,0)
+gas summary: computation_cost: 1000000, storage_cost: 2234400,  storage_rebate: 5966532, non_refundable_storage_fee: 60268

--- a/crates/sui-transactional-test-runner/src/lib.rs
+++ b/crates/sui-transactional-test-runner/src/lib.rs
@@ -68,12 +68,20 @@ mod testing_imports {
 use testing_imports::*;
 
 #[cfg(feature = "testing")]
+static TELEMETRY: std::sync::OnceLock<(
+    telemetry_subscribers::TelemetryGuards,
+    telemetry_subscribers::TracingHandle,
+)> = std::sync::OnceLock::new();
+
+#[cfg(feature = "testing")]
 #[cfg_attr(not(msim), tokio::main)]
 #[cfg_attr(msim, msim::main)]
 pub async fn run_test(path: &Path) -> Result<(), Box<dyn std::error::Error>> {
-    let (_guard, _filter_handle) = telemetry_subscribers::TelemetryConfig::new()
-        .with_env()
-        .init();
+    TELEMETRY.get_or_init(|| {
+        telemetry_subscribers::TelemetryConfig::new()
+            .with_env()
+            .init()
+    });
     run_test_impl::<SuiTestAdapter>(path, Some(std::sync::Arc::new(PRE_COMPILED.clone())), None)
         .await?;
     Ok(())


### PR DESCRIPTION
## Summary

- Initialize Sui transactional test runner telemetry once per process and retain the guard/filter handle for the process lifetime.
- Add a dynamic object field transactional regression for `id`, wrong-type `exists_with_type`, `replace`, and removal cleanup.

## Why

The baseline broad verifier transactional cargo-test route failed after the first datatest case with `SetGlobalDefaultError("a global default trace dispatcher has already been set")`. The new fixture also fills a static coverage gap for `sui::dynamic_object_field::id` and wrong-type object-field type checks.

## Test Coverage And Oracle Delta

- Adapter transactional `.move` fixtures: 411 before, 412 after.
- Adapter transactional `.snap` files: 422 before, 423 after.
- Verifier serial broad route: baseline `1 passed; 117 failed`; after patch `118 passed; 0 failed`.
- New oracle checks object child ID lookup, wrong object type predicate false, replacement old-child return, type predicate flip, and no ID/existence after removal.

Measured lcov/profdata coverage is unavailable locally because `cargo-llvm-cov` is missing.

## Validation Commands

```bash
SUI_SKIP_SIMTESTS=1 cargo check -p sui-transactional-test-runner -p sui-adapter-transactional-tests -p sui-verifier-transactional-tests
SUI_SKIP_SIMTESTS=1 cargo test -p sui-adapter-transactional-tests --test tests dynamic_fields/dynamic_object_field_id_and_type.move
SUI_SKIP_SIMTESTS=1 cargo test -p sui-verifier-transactional-tests --test tests entry_points/id.mvir
SUI_SKIP_SIMTESTS=1 cargo test -p sui-verifier-transactional-tests --test tests -- --test-threads=1
cargo fmt --check
git diff --check
cd crates/sui-transactional-test-runner && SUI_SKIP_SIMTESTS=1 cargo xclippy -D warnings
cd ../../crates/sui-adapter-transactional-tests && SUI_SKIP_SIMTESTS=1 cargo xclippy -D warnings
find crates/sui-adapter-transactional-tests/tests -name '*.snap.new' -print
```

`cargo-nextest` and `cargo-llvm-cov` probes are blocked locally because those cargo subcommands are unavailable.

## Risk

Low to medium. The Rust change is confined to the testing feature path and keeps `run_test_impl::<SuiTestAdapter>` unchanged. The Move fixture is snapshot-backed and deterministic in the transactional runner.

## Files Changed

- `crates/sui-transactional-test-runner/src/lib.rs`
- `crates/sui-adapter-transactional-tests/tests/dynamic_fields/dynamic_object_field_id_and_type.move`
- `crates/sui-adapter-transactional-tests/tests/dynamic_fields/dynamic_object_field_id_and_type.snap`

## Branch And Commit

Branch: `test-refine/sui-tr-dof`

Commit: `d85cf1c148727460bdbd35401f6a6472597fcb1a`

## Reproduction

```bash
git checkout test-refine/sui-tr-dof
SUI_SKIP_SIMTESTS=1 cargo test -p sui-verifier-transactional-tests --test tests -- --test-threads=1
SUI_SKIP_SIMTESTS=1 cargo test -p sui-adapter-transactional-tests --test tests dynamic_fields/dynamic_object_field_id_and_type.move
```
