### PR TITLE
[sui-light-client] Avoid allocation in MMR hash via serialize_into

### DIFF
--- a/crates/sui-light-client/src/authenticated_events/mmr.rs
+++ b/crates/sui-light-client/src/authenticated_events/mmr.rs
@@ -8,9 +8,10 @@ use sui_types::accumulator_root::{EventCommitment, EventStreamHead, build_event_
 const U256_ZERO: U256 = U256::zero();
 
 fn hash_two_to_one_u256(left: U256, right: U256) -> U256 {
-    let mut concatenated = bcs::to_bytes(&left).expect("Failed to serialize left U256");
-    concatenated.extend_from_slice(&bcs::to_bytes(&right).expect("Failed to serialize right U256"));
-    let hash = Blake2b256::digest(&concatenated);
+    let mut hasher = Blake2b256::new();
+    bcs::serialize_into(&mut hasher, &left).expect("Failed to serialize left U256");
+    bcs::serialize_into(&mut hasher, &right).expect("Failed to serialize right U256");
+    let hash = hasher.finalize();
     U256::from_le_bytes(&hash.digest)
 }
 


### PR DESCRIPTION
## Summary

Sister fix to #26415 ([Avoid allocation in bcs-to-hasher patterns using serialize_into](https://github.com/MystenLabs/sui/pull/26415)) for `crates/sui-light-client/src/authenticated_events/mmr.rs`, which was missed in that sweep.

`hash_two_to_one_u256` was building an intermediate `Vec<u8>` by allocating two `bcs::to_bytes` results and concatenating them, then hashing the combined buffer. Replace with `bcs::serialize_into(&mut hasher, ...)` so the hasher consumes BCS bytes directly without an intermediate `Vec<u8>`.

```diff
 fn hash_two_to_one_u256(left: U256, right: U256) -> U256 {
-    let mut concatenated = bcs::to_bytes(&left).expect("Failed to serialize left U256");
-    concatenated.extend_from_slice(&bcs::to_bytes(&right).expect("Failed to serialize right U256"));
-    let hash = Blake2b256::digest(&concatenated);
+    let mut hasher = Blake2b256::new();
+    bcs::serialize_into(&mut hasher, &left).expect("Failed to serialize left U256");
+    bcs::serialize_into(&mut hasher, &right).expect("Failed to serialize right U256");
+    let hash = hasher.finalize();
     U256::from_le_bytes(&hash.digest)
 }
```

Saves two `Vec<u8>` allocations and one `extend_from_slice` (memcpy) per call. The function is called O(log n) times per event added to the MMR via `add_to_stream`, so light clients building the MMR for a checkpoint with N events incur ~N * log(N) calls -- savings scale with traffic.

Hash output is unchanged because `bcs::serialize_into` produces the same byte sequence as `bcs::to_bytes` followed by concatenation, just streamed into the hasher instead of going through a buffer.

## Test plan

- [x] `cargo test -p sui-light-client --lib authenticated_events::mmr` -- 3/3 tests pass, including `test_compat_with_framework` which pins the hash output to the value produced by the Move framework's `test_mmr_digest_compat_with_rust` snapshot test. If this fix changed hash semantics, that test would fail.
- [x] `cargo xclippy` in `crates/sui-light-client` is clean.

```
running 3 tests
test authenticated_events::mmr::tests::test_basic ... ok
test authenticated_events::mmr::tests::test_compat_with_framework ... ok
test authenticated_events::mmr::tests::test_verify_stream_head_update ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 10 filtered out
```

---

## Release notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework: