### PR TITLE
[easy][move-vm-runtime] Remove call name and module id from gas charger trait

### DIFF
--- a/external-crates/move/crates/move-vm-runtime/src/dev_utils/gas_schedule.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/dev_utils/gas_schedule.rs
@@ -28,7 +28,6 @@ use move_core_types::{
         AbstractMemorySize, GasQuantity, InternalGas, InternalGasPerAbstractMemoryUnit,
         InternalGasUnit, NumArgs, NumBytes, ToUnit, ToUnitFractional,
     },
-    language_storage::ModuleId,
     u256,
 };
 use serde::{Deserialize, Serialize};
@@ -292,8 +291,6 @@ impl GasMeter for GasStatus<'_> {
 
     fn charge_call(
         &mut self,
-        _module_id: &ModuleId,
-        _func_name: &str,
         args: impl ExactSizeIterator<Item = impl ValueView>,
         _num_locals: NumArgs,
     ) -> PartialVMResult<()> {
@@ -302,8 +299,6 @@ impl GasMeter for GasStatus<'_> {
 
     fn charge_call_generic(
         &mut self,
-        _module_id: &ModuleId,
-        _func_name: &str,
         args: impl ExactSizeIterator<Item = impl ValueView>,
         _num_locals: NumArgs,
     ) -> PartialVMResult<()> {

--- a/external-crates/move/crates/move-vm-runtime/src/dev_utils/tiered_gas_schedule.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/dev_utils/tiered_gas_schedule.rs
@@ -11,12 +11,9 @@ use move_binary_format::{
     errors::{PartialVMError, PartialVMResult},
     partial_vm_error,
 };
-use move_core_types::{
-    gas_algebra::{
-        AbstractMemorySize, GasQuantity, InternalGas, InternalGasUnit, NumArgs, NumBytes, ToUnit,
-        ToUnitFractional,
-    },
-    language_storage::ModuleId,
+use move_core_types::gas_algebra::{
+    AbstractMemorySize, GasQuantity, InternalGas, InternalGasUnit, NumArgs, NumBytes, ToUnit,
+    ToUnitFractional,
 };
 
 use crate::{
@@ -522,8 +519,6 @@ impl<'b> GasMeter for GasStatus<'b> {
 
     fn charge_call(
         &mut self,
-        _module_id: &ModuleId,
-        _func_name: &str,
         mut args: impl ExactSizeIterator<Item = impl ValueView>,
         _num_locals: NumArgs,
     ) -> PartialVMResult<()> {
@@ -539,8 +534,6 @@ impl<'b> GasMeter for GasStatus<'b> {
 
     fn charge_call_generic(
         &mut self,
-        _module_id: &ModuleId,
-        _func_name: &str,
         mut args: impl ExactSizeIterator<Item = impl ValueView>,
         _num_locals: NumArgs,
     ) -> PartialVMResult<()> {

--- a/external-crates/move/crates/move-vm-runtime/src/execution/interpreter/eval.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/execution/interpreter/eval.rs
@@ -905,7 +905,6 @@ fn call_function(
     });
 
     // Charge gas
-    let module_id = function.module_id(&run_context.vtables.interner);
     let last_n_operands = state
         .last_n_operands(function.arg_count())
         .map_err(|e| set_err_info!(run_context.interner(), state.call_stack.current_frame, e))?;
@@ -913,24 +912,14 @@ fn call_function(
     if ty_args.is_empty() {
         // Charge for a non-generic call
         gas_meter
-            .charge_call(
-                &module_id,
-                &function.name_str(&run_context.vtables.interner),
-                last_n_operands,
-                (function.local_count() as u64).into(),
-            )
+            .charge_call(last_n_operands, (function.local_count() as u64).into())
             .map_err(|e| {
                 set_err_info!(run_context.interner(), state.call_stack.current_frame, e)
             })?;
     } else {
         // Charge for a generic call
         gas_meter
-            .charge_call_generic(
-                &module_id,
-                &function.name_str(&run_context.vtables.interner),
-                last_n_operands,
-                (function.local_count() as u64).into(),
-            )
+            .charge_call_generic(last_n_operands, (function.local_count() as u64).into())
             .map_err(|e| {
                 set_err_info!(run_context.interner(), state.call_stack.current_frame, e)
             })?;

--- a/external-crates/move/crates/move-vm-runtime/src/jit/execution/ast.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/jit/execution/ast.rs
@@ -885,6 +885,7 @@ impl Function {
         self.return_.len()
     }
 
+    #[allow(dead_code)]
     pub fn name_str(&self, interner: &IdentifierInterner) -> String {
         self.name(interner).to_string()
     }

--- a/external-crates/move/crates/move-vm-runtime/src/shared/gas.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/shared/gas.rs
@@ -3,10 +3,7 @@
 
 use crate::shared::views::ValueView;
 use move_binary_format::errors::PartialVMResult;
-use move_core_types::{
-    gas_algebra::{InternalGas, NumArgs, NumBytes},
-    language_storage::ModuleId,
-};
+use move_core_types::gas_algebra::{InternalGas, NumArgs, NumBytes};
 
 /// Enum of instructions that do not need extra information for gas metering.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -77,16 +74,12 @@ pub trait GasMeter {
 
     fn charge_call(
         &mut self,
-        module_id: &ModuleId,
-        func_name: &str,
         args: impl ExactSizeIterator<Item = impl ValueView>,
         num_locals: NumArgs,
     ) -> PartialVMResult<()>;
 
     fn charge_call_generic(
         &mut self,
-        module_id: &ModuleId,
-        func_name: &str,
         args: impl ExactSizeIterator<Item = impl ValueView>,
         num_locals: NumArgs,
     ) -> PartialVMResult<()>;
@@ -186,8 +179,6 @@ impl GasMeter for UnmeteredGasMeter {
 
     fn charge_call(
         &mut self,
-        _module_id: &ModuleId,
-        _func_name: &str,
         _args: impl IntoIterator<Item = impl ValueView>,
         _num_locals: NumArgs,
     ) -> PartialVMResult<()> {
@@ -196,8 +187,6 @@ impl GasMeter for UnmeteredGasMeter {
 
     fn charge_call_generic(
         &mut self,
-        _module_id: &ModuleId,
-        _func_name: &str,
         _args: impl ExactSizeIterator<Item = impl ValueView>,
         _num_locals: NumArgs,
     ) -> PartialVMResult<()> {

--- a/sui-execution/latest/sui-adapter/src/gas_meter.rs
+++ b/sui-execution/latest/sui-adapter/src/gas_meter.rs
@@ -4,10 +4,7 @@
 use std::ops::DerefMut;
 
 use move_binary_format::errors::PartialVMResult;
-use move_core_types::{
-    gas_algebra::{AbstractMemorySize, InternalGas, NumArgs, NumBytes},
-    language_storage::ModuleId,
-};
+use move_core_types::gas_algebra::{AbstractMemorySize, InternalGas, NumArgs, NumBytes};
 use move_vm_runtime::{
     execution::Type,
     shared::{
@@ -170,8 +167,6 @@ impl<G: DerefMut<Target = GasStatus>> GasMeter for SuiGasMeter<G> {
 
     fn charge_call(
         &mut self,
-        _module_id: &ModuleId,
-        _func_name: &str,
         mut args: impl ExactSizeIterator<Item = impl ValueView>,
         _num_locals: NumArgs,
     ) -> PartialVMResult<()> {
@@ -188,8 +183,6 @@ impl<G: DerefMut<Target = GasStatus>> GasMeter for SuiGasMeter<G> {
 
     fn charge_call_generic(
         &mut self,
-        _module_id: &ModuleId,
-        _func_name: &str,
         mut args: impl ExactSizeIterator<Item = impl ValueView>,
         _num_locals: NumArgs,
     ) -> PartialVMResult<()> {


### PR DESCRIPTION
## Description 

Weren't being used anywhere and it was creating additional (needless) allocations in the VM to realize the string.

## Test plan 

CI 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
