### PR TITLE
[package-alt] Cache-package chain-id consistency tests (DVX-1805)

### DIFF
--- a/crates/sui/tests/shell_tests/cache_package/a/Move.toml
+++ b/crates/sui/tests/shell_tests/cache_package/a/Move.toml
@@ -1,2 +1,7 @@
 [package]
 name = "a"
+implicit-dependencies = false
+
+[environments]
+custom_env = "c057011d"
+unpublished_env = "unpublished"

--- a/crates/sui/tests/shell_tests/cache_package/a/Published.toml
+++ b/crates/sui/tests/shell_tests/cache_package/a/Published.toml
@@ -3,3 +3,9 @@ chain-id = "4c78adac"
 published-at = "0xcafe"
 original-id = "0xdeadbeef"
 version = 2
+
+[published.custom_env]
+chain-id = "c057011d"
+published-at = "0xbeef"
+original-id = "0xfeed"
+version = 1

--- a/crates/sui/tests/shell_tests/cache_package/custom_env.sh
+++ b/crates/sui/tests/shell_tests/cache_package/custom_env.sh
@@ -1,0 +1,7 @@
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Run `cache-package` against an env that is declared in the dep's manifest but
+# is not one of the flavor's default envs; should return the publication for
+# that env (NOT testnet's).
+sui move --client.config $CONFIG cache-package custom_env c057011d "{ local="\"$(pwd -W 2>/dev/null || pwd)/a\"" }"

--- a/crates/sui/tests/shell_tests/cache_package/custom_env.snap
+++ b/crates/sui/tests/shell_tests/cache_package/custom_env.snap
@@ -1,0 +1,19 @@
+---
+source: crates/sui/tests/shell_tests.rs
+---
+----- script -----
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Run `cache-package` against an env that is declared in the dep's manifest but
+# is not one of the flavor's default envs; should return the publication for
+# that env (NOT testnet's).
+sui move --client.config $CONFIG cache-package custom_env c057011d "{ local="\"$(pwd -W 2>/dev/null || pwd)/a\"" }"
+
+----- results -----
+success: true
+exit_code: 0
+----- stdout -----
+{"name":"a","published-at":"0x000000000000000000000000000000000000000000000000000000000000beef","original-id":"0x000000000000000000000000000000000000000000000000000000000000feed","chain_id":"c057011d"}
+
+----- stderr -----

--- a/crates/sui/tests/shell_tests/cache_package/mismatched_id.sh
+++ b/crates/sui/tests/shell_tests/cache_package/mismatched_id.sh
@@ -1,0 +1,7 @@
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Run `cache-package` with a valid env name but the WRONG chain id; should fail
+# (the env name and id passed by the caller must agree with each other and with
+# the publication recorded for that env).
+sui move --client.config $CONFIG cache-package custom_env wrongid12 "{ local="\"$(pwd -W 2>/dev/null || pwd)/a\"" }"

--- a/crates/sui/tests/shell_tests/cache_package/unknown_env.sh
+++ b/crates/sui/tests/shell_tests/cache_package/unknown_env.sh
@@ -1,0 +1,6 @@
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Run `cache-package` against an env that is neither declared in the dep's
+# manifest nor among the flavor's default envs; should fail.
+sui move --client.config $CONFIG cache-package unknown_env abcd1234 "{ local="\"$(pwd -W 2>/dev/null || pwd)/a\"" }"

--- a/crates/sui/tests/shell_tests/cache_package/unknown_env.snap
+++ b/crates/sui/tests/shell_tests/cache_package/unknown_env.snap
@@ -1,0 +1,18 @@
+---
+source: crates/sui/tests/shell_tests.rs
+---
+----- script -----
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Run `cache-package` against an env that is neither declared in the dep's
+# manifest nor among the flavor's default envs; should fail.
+sui move --client.config $CONFIG cache-package unknown_env abcd1234 "{ local="\"$(pwd -W 2>/dev/null || pwd)/a\"" }"
+
+----- results -----
+success: false
+exit_code: 1
+----- stdout -----
+Package `a` does not declare a `unknown_env` environment. The available environments are ["testnet", "mainnet", "custom_env", "unpublished_env"]. Consider running with `--build-env testnet`
+
+----- stderr -----

--- a/crates/sui/tests/shell_tests/cache_package/unpublished_env.sh
+++ b/crates/sui/tests/shell_tests/cache_package/unpublished_env.sh
@@ -1,0 +1,7 @@
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Run `cache-package` against an env that the dep's manifest declares but for
+# which no publication is recorded in Published.toml; should succeed and return
+# the package info with no address fields.
+sui move --client.config $CONFIG cache-package unpublished_env unpublished "{ local="\"$(pwd -W 2>/dev/null || pwd)/a\"" }"

--- a/crates/sui/tests/shell_tests/cache_package/unpublished_env.snap
+++ b/crates/sui/tests/shell_tests/cache_package/unpublished_env.snap
@@ -1,0 +1,19 @@
+---
+source: crates/sui/tests/shell_tests.rs
+---
+----- script -----
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Run `cache-package` against an env that the dep's manifest declares but for
+# which no publication is recorded in Published.toml; should succeed and return
+# the package info with no address fields.
+sui move --client.config $CONFIG cache-package unpublished_env unpublished "{ local="\"$(pwd -W 2>/dev/null || pwd)/a\"" }"
+
+----- results -----
+success: true
+exit_code: 0
+----- stdout -----
+{"name":"a","chain_id":"unpublished"}
+
+----- stderr -----


### PR DESCRIPTION
## Summary

Adds shell tests that exercise `sui move cache-package` against a dep with publications in multiple environments, including a case (`mismatched_id.sh`) where the env name and chain id passed by the caller disagree. That last case currently passes silently with the wrong data — that's the bug DVX-1805 is about.

This branch is a draft for the test set; the fix will land on the same branch.

- Refs DVX-1805
- DVX-2098 is a duplicate of DVX-1805 (same underlying bug, narrower framing)

## Test plan

- [ ] `cargo nextest run -p sui --test shell_tests cache_package` — 4 of 5 tests pass; `mismatched_id.sh` fails (expected, no snapshot yet)
- [ ] After the fix lands on this branch, `mismatched_id.sh` becomes a clean failure (i.e. cache-package returns a non-zero exit) and we accept the new snapshot
- [ ] Verify the existing `cache_package.sh` snapshot is unchanged (fixture additions are purely additive for testnet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)