### PR TITLE
[graphql-stream] Lift streamed checkpoint payload onto Scope [9/n]

### DIFF
--- a/crates/sui-indexer-alt-graphql/src/api/subscription.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/subscription.rs
@@ -43,6 +43,7 @@ impl Subscription {
                         let scope = Scope::for_streamed_checkpoint(
                             package_store.clone(),
                             resolver_limits.clone(),
+                            processed.clone(),
                         );
                         yield Ok(Checkpoint {
                             sequence_number: processed.sequence_number,
@@ -84,6 +85,7 @@ impl Subscription {
                         let scope = Scope::for_streamed_checkpoint(
                             package_store.clone(),
                             resolver_limits.clone(),
+                            processed.clone(),
                         );
                         // TODO(DVX-2050): Pre-filter checkpoints using bloom filters
                         // before evaluating exact matches, to skip checkpoints with
@@ -95,9 +97,7 @@ impl Subscription {
                             yield Ok(Transaction {
                                 digest: tx.digest,
                                 contents: TransactionContents {
-                                    scope: scope.with_execution_objects(
-                                        tx.execution_objects.clone(),
-                                    ),
+                                    scope: scope.with_streamed_tx(tx.tx_sequence_number),
                                     contents: Some(Arc::new(tx.contents.clone())),
                                 },
                             });
@@ -138,6 +138,7 @@ impl Subscription {
                         let scope = Scope::for_streamed_checkpoint(
                             package_store.clone(),
                             resolver_limits.clone(),
+                            processed.clone(),
                         );
                         for tx in &processed.transactions {
                             let events = tx.contents.events().unwrap_or_default();
@@ -146,9 +147,7 @@ impl Subscription {
                                     continue;
                                 }
                                 yield Ok(Event {
-                                    scope: scope.with_execution_objects(
-                                        tx.execution_objects.clone(),
-                                    ),
+                                    scope: scope.with_streamed_tx(tx.tx_sequence_number),
                                     native,
                                     transaction_digest: tx.digest,
                                     sequence_number: idx as u64,

--- a/crates/sui-indexer-alt-graphql/src/api/subscription.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/subscription.rs
@@ -97,7 +97,7 @@ impl Subscription {
                             yield Ok(Transaction {
                                 digest: tx.digest,
                                 contents: TransactionContents {
-                                    scope: scope.with_streamed_tx(tx.tx_sequence_number),
+                                    scope: scope.with_tx_sequence_number_viewed_at(tx.tx_sequence_number),
                                     contents: Some(Arc::new(tx.contents.clone())),
                                 },
                             });
@@ -147,7 +147,7 @@ impl Subscription {
                                     continue;
                                 }
                                 yield Ok(Event {
-                                    scope: scope.with_streamed_tx(tx.tx_sequence_number),
+                                    scope: scope.with_tx_sequence_number_viewed_at(tx.tx_sequence_number),
                                     native,
                                     transaction_digest: tx.digest,
                                     sequence_number: idx as u64,

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
@@ -253,7 +253,7 @@ impl Transaction {
             filtered,
             |tx| JsonCursor::new(tx.tx_sequence_number),
             |tx| {
-                let tx_scope = scope.with_streamed_tx(tx.tx_sequence_number);
+                let tx_scope = scope.with_tx_sequence_number_viewed_at(tx.tx_sequence_number);
                 Ok(Transaction {
                     digest: tx.digest,
                     contents: TransactionContents {

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
@@ -253,7 +253,7 @@ impl Transaction {
             filtered,
             |tx| JsonCursor::new(tx.tx_sequence_number),
             |tx| {
-                let tx_scope = scope.with_execution_objects(tx.execution_objects.clone());
+                let tx_scope = scope.with_streamed_tx(tx.tx_sequence_number);
                 Ok(Transaction {
                     digest: tx.digest,
                     contents: TransactionContents {

--- a/crates/sui-indexer-alt-graphql/src/scope.rs
+++ b/crates/sui-indexer-alt-graphql/src/scope.rs
@@ -44,8 +44,8 @@ pub(crate) enum ObjectSource {
     Executed {
         execution_objects: ExecutionObjectMap,
     },
-    /// A streamed checkpoint with all per-tx contents and execution objects. The transaction
-    /// the scope is currently resolving for is identified by [`Scope::tx_sequence_number_viewed_at`].
+    /// A streamed checkpoint with all per-tx contents and execution objects. The active
+    /// transaction within this scope is identified by [`Scope::tx_sequence_number_viewed_at`].
     Streamed {
         checkpoint: Arc<ProcessedCheckpoint>,
     },

--- a/crates/sui-indexer-alt-graphql/src/scope.rs
+++ b/crates/sui-indexer-alt-graphql/src/scope.rs
@@ -32,6 +32,25 @@ use crate::task::watermark::Watermarks;
 pub(crate) type ExecutionObjectMap =
     Arc<BTreeMap<(ObjectID, SequenceNumber), Option<NativeObject>>>;
 
+/// Where object lookups in this scope draw their data from. Encodes the mutually exclusive
+/// modes a [`Scope`] can be in. Indexed mode hits the database/kv_loader (no in-memory payload).
+/// Executed mode is the mutation/simulate path, with a freshly executed transaction's outputs.
+/// Streamed mode is the subscription path, with an in-memory checkpoint payload.
+#[derive(Clone)]
+pub(crate) enum ObjectSource {
+    /// Reads go through the indexed-checkpoint path (kv_loader / DB). No in-memory payload.
+    Indexed,
+    /// A freshly executed transaction's input/output objects.
+    Executed {
+        execution_objects: ExecutionObjectMap,
+    },
+    /// A streamed checkpoint with all per-tx contents and execution objects. The transaction
+    /// the scope is currently resolving for is identified by [`Scope::tx_sequence_number_viewed_at`].
+    Streamed {
+        checkpoint: Arc<ProcessedCheckpoint>,
+    },
+}
+
 /// Root object bound for consistent dynamic field reads.
 ///
 /// This enables consistent dynamic field reads in the case of chained dynamic object fields,
@@ -64,25 +83,18 @@ pub(crate) struct Scope {
     /// None indicates execution context where we're viewing fresh transaction effects not yet indexed.
     checkpoint_viewed_at: Option<u64>,
 
+    /// The transaction we are scoped to, identified by global `tx_sequence_number`. In streaming
+    /// mode, anchors object lookups to that transaction's per-tx `execution_objects` within the
+    /// streamed checkpoint.
+    tx_sequence_number_viewed_at: Option<u64>,
+
     /// Root object bound for dynamic fields.
     ///
     /// This can be expressed either in terms of a specific object version or a checkpoint.
     root_bound: Option<RootBound>,
 
-    /// Cache of objects available in execution context (freshly executed transaction).
-    /// Maps (ObjectID, SequenceNumber) to optional object data.
-    /// None indicates the object was deleted or wrapped at that version.
-    /// This enables any Object GraphQL type to access fresh data without database queries.
-    execution_objects: ExecutionObjectMap,
-
-    /// The streamed checkpoint payload this scope is resolving against, if any. Holds the
-    /// per-tx contents and execution objects so nested resolvers can navigate the checkpoint
-    /// without re-plumbing per-yield context.
-    streamed_checkpoint: Option<Arc<ProcessedCheckpoint>>,
-
-    /// Within `streamed_checkpoint`, the `tx_sequence_number` of the transaction we are
-    /// resolving for. Object lookups use this transaction's own `execution_objects`.
-    tx_sequence_number_viewed_at: Option<u64>,
+    /// Where object lookups in this scope draw their data from. See [`ObjectSource`].
+    object_source: ObjectSource,
 
     /// Access to packages for type resolution.
     package_store: Arc<dyn PackageStore>,
@@ -101,10 +113,9 @@ impl Scope {
 
         Ok(Self {
             checkpoint_viewed_at: Some(watermark.high_watermark().checkpoint()),
-            root_bound: None,
-            execution_objects: Arc::new(BTreeMap::new()),
-            streamed_checkpoint: None,
             tx_sequence_number_viewed_at: None,
+            root_bound: None,
+            object_source: ObjectSource::Indexed,
             package_store: package_store.clone(),
             resolver_limits: limits.package_resolver(),
         })
@@ -119,24 +130,28 @@ impl Scope {
     ) -> Self {
         Self {
             checkpoint_viewed_at: None,
-            root_bound: None,
-            execution_objects: Arc::new(BTreeMap::new()),
-            streamed_checkpoint: Some(streamed_checkpoint),
             tx_sequence_number_viewed_at: None,
+            root_bound: None,
+            object_source: ObjectSource::Streamed {
+                checkpoint: streamed_checkpoint,
+            },
             package_store,
             resolver_limits,
         }
     }
 
-    /// Anchor a nested scope to a specific transaction within `streamed_checkpoint`. Object
-    /// lookups in this scope use that transaction's own `execution_objects`.
-    pub(crate) fn with_streamed_tx(&self, tx_sequence_number_viewed_at: u64) -> Self {
+    /// Pin a nested scope to a specific transaction by global `tx_sequence_number`. In streaming
+    /// mode this anchors object lookups to that transaction's per-tx `execution_objects` within
+    /// the streamed checkpoint.
+    pub(crate) fn with_tx_sequence_number_viewed_at(
+        &self,
+        tx_sequence_number_viewed_at: u64,
+    ) -> Self {
         Self {
-            checkpoint_viewed_at: None,
-            root_bound: None,
-            execution_objects: Arc::clone(&self.execution_objects),
-            streamed_checkpoint: self.streamed_checkpoint.clone(),
+            checkpoint_viewed_at: self.checkpoint_viewed_at,
             tx_sequence_number_viewed_at: Some(tx_sequence_number_viewed_at),
+            root_bound: self.root_bound,
+            object_source: self.object_source.clone(),
             package_store: self.package_store.clone(),
             resolver_limits: self.resolver_limits.clone(),
         }
@@ -160,10 +175,9 @@ impl Scope {
 
         Self {
             checkpoint_viewed_at: Some(0),
-            root_bound: None,
-            execution_objects: Arc::new(BTreeMap::new()),
-            streamed_checkpoint: None,
             tx_sequence_number_viewed_at: None,
+            root_bound: None,
+            object_source: ObjectSource::Indexed,
             package_store: Arc::new(EmptyPackageStore),
             resolver_limits: Limits::default().package_resolver(),
         }
@@ -180,10 +194,9 @@ impl Scope {
         let cp_hi_inclusive = watermark.high_watermark().checkpoint();
         (checkpoint_viewed_at <= cp_hi_inclusive).then(|| Self {
             checkpoint_viewed_at: Some(checkpoint_viewed_at),
-            root_bound: self.root_bound,
-            execution_objects: Arc::clone(&self.execution_objects),
-            streamed_checkpoint: self.streamed_checkpoint.clone(),
             tx_sequence_number_viewed_at: self.tx_sequence_number_viewed_at,
+            root_bound: self.root_bound,
+            object_source: self.object_source.clone(),
             package_store: self.package_store.clone(),
             resolver_limits: self.resolver_limits.clone(),
         })
@@ -193,10 +206,9 @@ impl Scope {
     pub(crate) fn with_root_version(&self, root_version: u64) -> Self {
         Self {
             checkpoint_viewed_at: self.checkpoint_viewed_at,
-            root_bound: Some(RootBound::Version(root_version)),
-            execution_objects: Arc::clone(&self.execution_objects),
-            streamed_checkpoint: self.streamed_checkpoint.clone(),
             tx_sequence_number_viewed_at: self.tx_sequence_number_viewed_at,
+            root_bound: Some(RootBound::Version(root_version)),
+            object_source: self.object_source.clone(),
             package_store: self.package_store.clone(),
             resolver_limits: self.resolver_limits.clone(),
         }
@@ -206,10 +218,9 @@ impl Scope {
     pub(crate) fn with_root_checkpoint(&self, root_checkpoint: u64) -> Self {
         Self {
             checkpoint_viewed_at: self.checkpoint_viewed_at,
-            root_bound: Some(RootBound::Checkpoint(root_checkpoint)),
-            execution_objects: Arc::clone(&self.execution_objects),
-            streamed_checkpoint: self.streamed_checkpoint.clone(),
             tx_sequence_number_viewed_at: self.tx_sequence_number_viewed_at,
+            root_bound: Some(RootBound::Checkpoint(root_checkpoint)),
+            object_source: self.object_source.clone(),
             package_store: self.package_store.clone(),
             resolver_limits: self.resolver_limits.clone(),
         }
@@ -219,10 +230,9 @@ impl Scope {
     pub(crate) fn without_root_bound(&self) -> Self {
         Self {
             checkpoint_viewed_at: self.checkpoint_viewed_at,
-            root_bound: None,
-            execution_objects: Arc::clone(&self.execution_objects),
-            streamed_checkpoint: self.streamed_checkpoint.clone(),
             tx_sequence_number_viewed_at: self.tx_sequence_number_viewed_at,
+            root_bound: None,
+            object_source: self.object_source.clone(),
             package_store: self.package_store.clone(),
             resolver_limits: self.resolver_limits.clone(),
         }
@@ -264,19 +274,17 @@ impl Scope {
         self.checkpoint_viewed_at.map(|cp| cp + 1)
     }
 
-    /// The execution objects map active for object lookups in this scope. When anchored to a
-    /// streamed transaction (via [`Self::with_streamed_tx`]), returns that transaction's
-    /// per-tx map from `streamed_checkpoint`. Otherwise returns the per-scope map populated
-    /// by [`Self::with_executed_transaction`] (mutation/simulate path).
-    fn execution_objects_in_view(&self) -> &ExecutionObjectMap {
-        if let (Some(seq), Some(cp)) = (
-            self.tx_sequence_number_viewed_at,
-            self.streamed_checkpoint.as_ref(),
-        ) && let Some(tx) = cp.transactions.iter().find(|t| t.tx_sequence_number == seq)
-        {
-            &tx.execution_objects
-        } else {
-            &self.execution_objects
+    /// The execution objects map active for object lookups in this scope. Resolves through the
+    /// scope's [`ObjectSource`]: in `Streamed` mode, looks up the per-tx map for the transaction
+    /// identified by `tx_sequence_number_viewed_at`; in `Executed` mode, returns the freshly
+    /// extracted map; in `Indexed` mode, returns `None` so callers fall through to the DB.
+    fn execution_objects_in_view(&self) -> Option<&ExecutionObjectMap> {
+        match &self.object_source {
+            ObjectSource::Indexed => None,
+            ObjectSource::Executed { execution_objects } => Some(execution_objects),
+            ObjectSource::Streamed { checkpoint } => checkpoint
+                .transaction(self.tx_sequence_number_viewed_at?)
+                .map(|t| &t.execution_objects),
         }
     }
 
@@ -288,7 +296,7 @@ impl Scope {
         object_id: ObjectID,
         version: SequenceNumber,
     ) -> Option<&NativeObject> {
-        self.execution_objects_in_view()
+        self.execution_objects_in_view()?
             .get(&(object_id, version))
             .and_then(|opt| opt.as_ref())
     }
@@ -299,7 +307,7 @@ impl Scope {
         &self,
         object_id: ObjectID,
     ) -> Option<&NativeObject> {
-        self.execution_objects_in_view()
+        self.execution_objects_in_view()?
             .range(..=(object_id, SequenceNumber::MAX))
             .last()
             .and_then(|(_, opt)| opt.as_ref())
@@ -314,10 +322,9 @@ impl Scope {
 
         Ok(Self {
             checkpoint_viewed_at: None,
-            root_bound: self.root_bound,
-            execution_objects,
-            streamed_checkpoint: None,
             tx_sequence_number_viewed_at: None,
+            root_bound: self.root_bound,
+            object_source: ObjectSource::Executed { execution_objects },
             package_store: self.package_store.clone(),
             resolver_limits: self.resolver_limits.clone(),
         })
@@ -402,8 +409,7 @@ impl PackageStore for Scope {
         let object_id = ObjectID::from(id);
 
         // First check execution context objects if we have any
-        let execution_objects = self.execution_objects_in_view();
-        if !execution_objects.is_empty() {
+        if let Some(execution_objects) = self.execution_objects_in_view() {
             let latest_package = execution_objects
                 .range((object_id, SequenceNumber::MIN)..=(object_id, SequenceNumber::MAX))
                 .last()

--- a/crates/sui-indexer-alt-graphql/src/scope.rs
+++ b/crates/sui-indexer-alt-graphql/src/scope.rs
@@ -23,6 +23,7 @@ use sui_types::object::Object as NativeObject;
 
 use crate::config::Limits;
 use crate::error::RpcError;
+use crate::task::streaming::ProcessedCheckpoint;
 use crate::task::streaming::StreamingPackageStore;
 use crate::task::watermark::Watermarks;
 
@@ -74,6 +75,15 @@ pub(crate) struct Scope {
     /// This enables any Object GraphQL type to access fresh data without database queries.
     execution_objects: ExecutionObjectMap,
 
+    /// The streamed checkpoint payload this scope is resolving against, if any. Holds the
+    /// per-tx contents and execution objects so nested resolvers can navigate the checkpoint
+    /// without re-plumbing per-yield context.
+    streamed_checkpoint: Option<Arc<ProcessedCheckpoint>>,
+
+    /// Within `streamed_checkpoint`, the `tx_sequence_number` of the transaction we are
+    /// resolving for. Object lookups use this transaction's own `execution_objects`.
+    tx_sequence_number_viewed_at: Option<u64>,
+
     /// Access to packages for type resolution.
     package_store: Arc<dyn PackageStore>,
 
@@ -93,6 +103,8 @@ impl Scope {
             checkpoint_viewed_at: Some(watermark.high_watermark().checkpoint()),
             root_bound: None,
             execution_objects: Arc::new(BTreeMap::new()),
+            streamed_checkpoint: None,
+            tx_sequence_number_viewed_at: None,
             package_store: package_store.clone(),
             resolver_limits: limits.package_resolver(),
         })
@@ -103,23 +115,28 @@ impl Scope {
     pub(crate) fn for_streamed_checkpoint(
         package_store: Arc<StreamingPackageStore>,
         resolver_limits: sui_package_resolver::Limits,
+        streamed_checkpoint: Arc<ProcessedCheckpoint>,
     ) -> Self {
         Self {
             checkpoint_viewed_at: None,
             root_bound: None,
             execution_objects: Arc::new(BTreeMap::new()),
+            streamed_checkpoint: Some(streamed_checkpoint),
+            tx_sequence_number_viewed_at: None,
             package_store,
             resolver_limits,
         }
     }
 
-    /// Create a nested scope with pre-built execution objects. Used by streaming to attach
-    /// per-transaction objects that were deserialized from checkpoint-level data.
-    pub(crate) fn with_execution_objects(&self, execution_objects: ExecutionObjectMap) -> Self {
+    /// Anchor a nested scope to a specific transaction within `streamed_checkpoint`. Object
+    /// lookups in this scope use that transaction's own `execution_objects`.
+    pub(crate) fn with_streamed_tx(&self, tx_sequence_number_viewed_at: u64) -> Self {
         Self {
             checkpoint_viewed_at: None,
-            root_bound: self.root_bound,
-            execution_objects,
+            root_bound: None,
+            execution_objects: Arc::clone(&self.execution_objects),
+            streamed_checkpoint: self.streamed_checkpoint.clone(),
+            tx_sequence_number_viewed_at: Some(tx_sequence_number_viewed_at),
             package_store: self.package_store.clone(),
             resolver_limits: self.resolver_limits.clone(),
         }
@@ -145,6 +162,8 @@ impl Scope {
             checkpoint_viewed_at: Some(0),
             root_bound: None,
             execution_objects: Arc::new(BTreeMap::new()),
+            streamed_checkpoint: None,
+            tx_sequence_number_viewed_at: None,
             package_store: Arc::new(EmptyPackageStore),
             resolver_limits: Limits::default().package_resolver(),
         }
@@ -163,6 +182,8 @@ impl Scope {
             checkpoint_viewed_at: Some(checkpoint_viewed_at),
             root_bound: self.root_bound,
             execution_objects: Arc::clone(&self.execution_objects),
+            streamed_checkpoint: self.streamed_checkpoint.clone(),
+            tx_sequence_number_viewed_at: self.tx_sequence_number_viewed_at,
             package_store: self.package_store.clone(),
             resolver_limits: self.resolver_limits.clone(),
         })
@@ -174,6 +195,8 @@ impl Scope {
             checkpoint_viewed_at: self.checkpoint_viewed_at,
             root_bound: Some(RootBound::Version(root_version)),
             execution_objects: Arc::clone(&self.execution_objects),
+            streamed_checkpoint: self.streamed_checkpoint.clone(),
+            tx_sequence_number_viewed_at: self.tx_sequence_number_viewed_at,
             package_store: self.package_store.clone(),
             resolver_limits: self.resolver_limits.clone(),
         }
@@ -185,6 +208,8 @@ impl Scope {
             checkpoint_viewed_at: self.checkpoint_viewed_at,
             root_bound: Some(RootBound::Checkpoint(root_checkpoint)),
             execution_objects: Arc::clone(&self.execution_objects),
+            streamed_checkpoint: self.streamed_checkpoint.clone(),
+            tx_sequence_number_viewed_at: self.tx_sequence_number_viewed_at,
             package_store: self.package_store.clone(),
             resolver_limits: self.resolver_limits.clone(),
         }
@@ -196,6 +221,8 @@ impl Scope {
             checkpoint_viewed_at: self.checkpoint_viewed_at,
             root_bound: None,
             execution_objects: Arc::clone(&self.execution_objects),
+            streamed_checkpoint: self.streamed_checkpoint.clone(),
+            tx_sequence_number_viewed_at: self.tx_sequence_number_viewed_at,
             package_store: self.package_store.clone(),
             resolver_limits: self.resolver_limits.clone(),
         }
@@ -237,6 +264,22 @@ impl Scope {
         self.checkpoint_viewed_at.map(|cp| cp + 1)
     }
 
+    /// The execution objects map active for object lookups in this scope. When anchored to a
+    /// streamed transaction (via [`Self::with_streamed_tx`]), returns that transaction's
+    /// per-tx map from `streamed_checkpoint`. Otherwise returns the per-scope map populated
+    /// by [`Self::with_executed_transaction`] (mutation/simulate path).
+    fn execution_objects_in_view(&self) -> &ExecutionObjectMap {
+        if let (Some(seq), Some(cp)) = (
+            self.tx_sequence_number_viewed_at,
+            self.streamed_checkpoint.as_ref(),
+        ) && let Some(tx) = cp.transactions.iter().find(|t| t.tx_sequence_number == seq)
+        {
+            &tx.execution_objects
+        } else {
+            &self.execution_objects
+        }
+    }
+
     /// Get an object from the execution context cache, if available.
     ///
     /// Returns None if the object doesn't exist in the cache or if it was deleted/wrapped.
@@ -245,7 +288,7 @@ impl Scope {
         object_id: ObjectID,
         version: SequenceNumber,
     ) -> Option<&NativeObject> {
-        self.execution_objects
+        self.execution_objects_in_view()
             .get(&(object_id, version))
             .and_then(|opt| opt.as_ref())
     }
@@ -256,7 +299,7 @@ impl Scope {
         &self,
         object_id: ObjectID,
     ) -> Option<&NativeObject> {
-        self.execution_objects
+        self.execution_objects_in_view()
             .range(..=(object_id, SequenceNumber::MAX))
             .last()
             .and_then(|(_, opt)| opt.as_ref())
@@ -273,6 +316,8 @@ impl Scope {
             checkpoint_viewed_at: None,
             root_bound: self.root_bound,
             execution_objects,
+            streamed_checkpoint: None,
+            tx_sequence_number_viewed_at: None,
             package_store: self.package_store.clone(),
             resolver_limits: self.resolver_limits.clone(),
         })
@@ -340,6 +385,10 @@ impl Debug for Scope {
         f.debug_struct("Scope")
             .field("checkpoint_viewed_at", &self.checkpoint_viewed_at)
             .field("root_bound", &self.root_bound)
+            .field(
+                "tx_sequence_number_viewed_at",
+                &self.tx_sequence_number_viewed_at,
+            )
             .field("resolver_limits", &self.resolver_limits)
             .finish()
     }
@@ -353,9 +402,9 @@ impl PackageStore for Scope {
         let object_id = ObjectID::from(id);
 
         // First check execution context objects if we have any
-        if !self.execution_objects.is_empty() {
-            let latest_package = self
-                .execution_objects
+        let execution_objects = self.execution_objects_in_view();
+        if !execution_objects.is_empty() {
+            let latest_package = execution_objects
                 .range((object_id, SequenceNumber::MIN)..=(object_id, SequenceNumber::MAX))
                 .last()
                 .and_then(|(_, opt_object)| opt_object.as_ref())

--- a/crates/sui-indexer-alt-graphql/src/task/streaming/checkpoint_stream_task.rs
+++ b/crates/sui-indexer-alt-graphql/src/task/streaming/checkpoint_stream_task.rs
@@ -416,13 +416,13 @@ pub(super) fn process_checkpoint(
         })
         .collect::<anyhow::Result<Vec<_>>>()?;
 
-    Ok(ProcessedCheckpoint {
+    Ok(ProcessedCheckpoint::new(
         sequence_number,
         summary,
         contents,
         signature,
         transactions,
-    })
+    ))
 }
 
 fn process_transaction(

--- a/crates/sui-indexer-alt-graphql/src/task/streaming/gap_recovery.rs
+++ b/crates/sui-indexer-alt-graphql/src/task/streaming/gap_recovery.rs
@@ -54,32 +54,33 @@ impl CheckpointFetcher for LedgerGrpcReader {
     }
 }
 
-/// Recover the gap `lo..=hi` by reading checkpoints from kv-rpc, processing them through the
-/// existing streaming pipeline, and broadcasting in order. Each chunk waits for the kv-rpc
-/// indexer to reach the chunk's upper bound before fetching, so partial progress is broadcast
-/// as the indexer catches up rather than waiting for the entire gap to be available.
+/// Recover the gap `lo..=hi_inclusive` by reading checkpoints from kv-rpc, processing them
+/// through the existing streaming pipeline, and broadcasting in order. Each chunk waits for the
+/// kv-rpc indexer to reach the chunk's upper bound before fetching, so partial progress is
+/// broadcast as the indexer catches up rather than waiting for the entire gap to be available.
 pub(crate) async fn recover_gap<F: CheckpointFetcher>(
     fetcher: &F,
     watermarks_rx: &watch::Receiver<Arc<Watermarks>>,
     sender: &broadcast::Sender<Arc<ProcessedCheckpoint>>,
     lo: u64,
-    hi: u64,
+    hi_inclusive: u64,
     chunk_size: usize,
 ) -> anyhow::Result<()> {
-    if lo > hi {
+    if lo > hi_inclusive {
         return Ok(());
     }
 
     let mask = checkpoint_field_mask();
     let chunk_size = chunk_size.max(1) as u64;
     let mut cursor = lo;
+    let mut watermarks_rx = watermarks_rx.clone();
 
-    while cursor <= hi {
-        let chunk_hi = (cursor + chunk_size - 1).min(hi);
+    while cursor <= hi_inclusive {
+        let chunk_hi_inclusive = (cursor + chunk_size - 1).min(hi_inclusive);
 
-        wait_for_pipelines_catching_up_at(chunk_hi, watermarks_rx).await?;
+        wait_for_pipelines_catching_up_at(chunk_hi_inclusive, &mut watermarks_rx).await?;
 
-        let chunk = fetch_chunk(fetcher, &mask, cursor..=chunk_hi).await?;
+        let chunk = fetch_chunk(fetcher, &mask, cursor..=chunk_hi_inclusive).await?;
 
         for proto in chunk {
             let processed = process_checkpoint(proto)?;
@@ -87,7 +88,7 @@ pub(crate) async fn recover_gap<F: CheckpointFetcher>(
             let _ = sender.send(Arc::new(processed));
         }
 
-        cursor = chunk_hi + 1;
+        cursor = chunk_hi_inclusive + 1;
     }
 
     Ok(())
@@ -100,21 +101,21 @@ pub(crate) async fn recover_gap<F: CheckpointFetcher>(
 /// to the DB and need `kv_packages` to be ready.
 async fn wait_for_pipelines_catching_up_at(
     target: u64,
-    watermarks_rx: &watch::Receiver<Arc<Watermarks>>,
+    watermarks_rx: &mut watch::Receiver<Arc<Watermarks>>,
 ) -> anyhow::Result<()> {
-    let mut rx = watermarks_rx.clone();
-    rx.wait_for(|w| {
-        let pipelines = w.per_pipeline();
-        let caught_up = |name| {
-            pipelines
-                .get(name)
-                .is_some_and(|p| p.hi().checkpoint() >= target)
-        };
-        caught_up(LEDGER_GRPC_PIPELINE) && caught_up(KV_PACKAGES_PIPELINE)
-    })
-    .await
-    .ok()
-    .context("Watermark task shut down before pipelines caught up")?;
+    watermarks_rx
+        .wait_for(|w| {
+            let pipelines = w.per_pipeline();
+            let caught_up = |name| {
+                pipelines
+                    .get(name)
+                    .is_some_and(|p| p.hi().checkpoint() >= target)
+            };
+            caught_up(LEDGER_GRPC_PIPELINE) && caught_up(KV_PACKAGES_PIPELINE)
+        })
+        .await
+        .ok()
+        .context("Watermark task shut down before pipelines caught up")?;
     Ok(())
 }
 
@@ -175,9 +176,9 @@ async fn fetch_one_with_retry<F: CheckpointFetcher>(
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
-    use std::sync::Mutex;
     use std::time::Duration;
 
+    use dashmap::DashMap;
     use sui_rpc::proto::sui::rpc::v2 as grpc;
     use sui_sdk_types::Bitmap;
     use sui_sdk_types::Bls12381Signature;
@@ -251,18 +252,18 @@ mod tests {
     }
 
     struct MockFetcher {
-        state: Mutex<HashMap<u64, (FetcherBehavior, usize)>>,
+        state: DashMap<u64, (FetcherBehavior, usize)>,
     }
 
     impl MockFetcher {
         fn new(setup: HashMap<u64, FetcherBehavior>) -> Self {
             Self {
-                state: Mutex::new(setup.into_iter().map(|(k, v)| (k, (v, 0))).collect()),
+                state: setup.into_iter().map(|(k, v)| (k, (v, 0))).collect(),
             }
         }
 
         fn calls_for(&self, seq: u64) -> usize {
-            self.state.lock().unwrap().get(&seq).map_or(0, |(_, c)| *c)
+            self.state.get(&seq).map_or(0, |g| g.1)
         }
     }
 
@@ -273,8 +274,8 @@ mod tests {
             _mask: &FieldMask,
         ) -> anyhow::Result<Option<ProtoCheckpoint>> {
             let (behavior, calls) = {
-                let mut state = self.state.lock().unwrap();
-                let entry = state
+                let mut entry = self
+                    .state
                     .get_mut(&seq)
                     .unwrap_or_else(|| panic!("MockFetcher: unconfigured key {seq}"));
                 entry.1 += 1;
@@ -306,14 +307,14 @@ mod tests {
     }
 
     fn recovery_watermarks(
-        hi: u64,
+        hi_inclusive: u64,
     ) -> (
         watch::Sender<Arc<Watermarks>>,
         watch::Receiver<Arc<Watermarks>>,
     ) {
         watch::channel(Arc::new(Watermarks::for_test(&[
-            (LEDGER_GRPC_PIPELINE, hi),
-            (KV_PACKAGES_PIPELINE, hi),
+            (LEDGER_GRPC_PIPELINE, hi_inclusive),
+            (KV_PACKAGES_PIPELINE, hi_inclusive),
         ])))
     }
 

--- a/crates/sui-indexer-alt-graphql/src/task/streaming/processed_checkpoint.rs
+++ b/crates/sui-indexer-alt-graphql/src/task/streaming/processed_checkpoint.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::HashMap;
+
 use sui_indexer_alt_reader::kv_loader::TransactionContents;
 use sui_types::crypto::AuthorityStrongQuorumSignInfo;
 use sui_types::digests::TransactionDigest;
@@ -16,6 +18,9 @@ pub(crate) struct ProcessedCheckpoint {
     pub(crate) contents: CheckpointContents,
     pub(crate) signature: AuthorityStrongQuorumSignInfo,
     pub(crate) transactions: Vec<ProcessedTransaction>,
+    /// Index of `transactions` by global `tx_sequence_number` for O(1) lookup that scales
+    /// across many subscribers. Built once at construction.
+    by_tx_sequence_number: HashMap<u64, usize>,
 }
 
 /// A transaction from a streamed checkpoint with pre-deserialized contents.
@@ -25,4 +30,34 @@ pub(crate) struct ProcessedTransaction {
     pub(crate) contents: TransactionContents,
     /// Pre-built execution objects for this transaction, extracted from checkpoint-level objects.
     pub(crate) execution_objects: ExecutionObjectMap,
+}
+
+impl ProcessedCheckpoint {
+    pub(crate) fn new(
+        sequence_number: u64,
+        summary: CheckpointSummary,
+        contents: CheckpointContents,
+        signature: AuthorityStrongQuorumSignInfo,
+        transactions: Vec<ProcessedTransaction>,
+    ) -> Self {
+        let by_tx_sequence_number = transactions
+            .iter()
+            .enumerate()
+            .map(|(i, t)| (t.tx_sequence_number, i))
+            .collect();
+        Self {
+            sequence_number,
+            summary,
+            contents,
+            signature,
+            transactions,
+            by_tx_sequence_number,
+        }
+    }
+
+    /// Lookup a transaction by its global `tx_sequence_number` within this checkpoint.
+    pub(crate) fn transaction(&self, tx_sequence_number: u64) -> Option<&ProcessedTransaction> {
+        let i = *self.by_tx_sequence_number.get(&tx_sequence_number)?;
+        self.transactions.get(i)
+    }
 }


### PR DESCRIPTION
## Description 

- Lift the streamed `ProcessedCheckpoint` onto `Scope` once per checkpoint via `Scope::for_streamed_checkpoint(..., processed)`, so yielded subscription types stop carrying per-yield transaction context.
- Replace `Scope::with_execution_objects(per_tx_map)` with `Scope::with_streamed_tx(tx_sequence_number)`. The new builder anchors a nested scope to a specific transaction within the streamed checkpoint, and object lookups (`execution_output_object`, `execution_output_object_latest`, the `PackageStore::fetch` impl) route through a small `execution_objects_in_view()` helper that returns the anchored transaction's per-tx map.
- Behavior is preserved end to end. A transaction sees exactly its own input/output objects, the same as before, so existing tests pass without snapshot churn.

## Context

This refactor lands the [discussion](https://github.com/MystenLabs/sui/pull/26170#pullrequestreview-4099866645) on PR #26170.

## Test plan 

How did you test the new or updated feature?
- unit + e2e tests

## Stack
   - #26019
   - #26094
   - #26117
   - #26170
   - #26194
   - #26202
   - #26414
   - #26453
   - #26476

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
