### PR TITLE
sui-rpc-api: subtract mock gas coin storage cost from simulate budget

### DIFF
--- a/crates/sui-e2e-tests/tests/grpc_simulate_gas_coin_tests.rs
+++ b/crates/sui-e2e-tests/tests/grpc_simulate_gas_coin_tests.rs
@@ -1067,3 +1067,165 @@ async fn test_resolve_handles_coin_reservation_in_ptb_input() {
         result.err()
     );
 }
+
+// =============================================================================
+// Regression: when gas selection picks address balance, the estimated budget
+// must not include the storage cost of the synthetic gas coin used internally
+// by the simulator. Real execution charges gas via an accumulator event with
+// no gas-coin write, so any phantom storage cost in the budget is over-billing.
+// =============================================================================
+
+#[sim_test]
+async fn test_estimated_budget_excludes_mock_gas_coin_storage_for_address_balance() {
+    use shared_crypto::intent::Intent;
+    use sui_keys::keystore::AccountKeystore;
+    use sui_rpc::proto::sui::rpc::v2::transaction_execution_service_client::TransactionExecutionServiceClient;
+    use sui_rpc::proto::sui::rpc::v2::{
+        Argument, Command, GasPayment, Input, ProgrammableTransaction, SimulateTransactionRequest,
+        Transaction, TransactionKind, TransferObjects,
+    };
+
+    let test_env = TestEnvBuilder::new()
+        .with_proto_override_cb(Box::new(|_, mut cfg| {
+            cfg.create_root_accumulator_object_for_testing();
+            cfg.enable_coin_reservation_for_testing();
+            cfg.enable_address_balance_gas_payments_for_testing();
+            cfg
+        }))
+        .build()
+        .await;
+
+    let mut test_env = test_env;
+    let recipient = SuiAddress::random_for_testing_only();
+
+    // Sender owns a coin that the PTB transfers; the PTB never uses Argument::GasCoin so
+    // gas selection is free to use sponsor's address balance.
+    let (sender, sender_coin) = test_env.get_sender_and_gas(0);
+    let (sponsor, _) = test_env.get_sender_and_gas(1);
+
+    // Fund the sponsor's address balance so that gas selection picks address balance.
+    let sponsor_ab_amount = 5 * MIST_PER_SUI;
+    test_env
+        .fund_one_address_balance(sponsor, sponsor_ab_amount)
+        .await;
+
+    // Build an unresolved Transaction proto. Critical that the request omits both BCS and
+    // a gas budget — that's the only configuration that exercises the budget-estimation
+    // path that this fix targets.
+    let mut unresolved_transaction = Transaction::default();
+    unresolved_transaction.kind = Some(TransactionKind::from({
+        let mut ptb = ProgrammableTransaction::default();
+        ptb.inputs = vec![
+            {
+                let mut input = Input::default();
+                input.object_id = Some(sender_coin.0.to_canonical_string(true));
+                input
+            },
+            {
+                let mut input = Input::default();
+                input.literal = Some(Box::new(recipient.to_string().into()));
+                input
+            },
+        ];
+        ptb.commands = vec![Command::from({
+            let mut message = TransferObjects::default();
+            message.objects = vec![Argument::new_input(0)];
+            message.address = Some(Argument::new_input(1));
+            message
+        })];
+        ptb
+    }));
+    unresolved_transaction.sender = Some(sender.to_string());
+    unresolved_transaction.gas_payment = Some({
+        let mut message = GasPayment::default();
+        message.owner = Some(sponsor.to_string());
+        message
+    });
+
+    let mut alpha_client =
+        TransactionExecutionServiceClient::connect(test_env.cluster.rpc_url().to_owned())
+            .await
+            .unwrap();
+
+    let response = alpha_client
+        .simulate_transaction(
+            SimulateTransactionRequest::new(unresolved_transaction).with_do_gas_selection(true),
+        )
+        .await
+        .unwrap()
+        .into_inner();
+
+    let resolved_transaction: TransactionData = response
+        .transaction
+        .as_ref()
+        .unwrap()
+        .transaction
+        .as_ref()
+        .unwrap()
+        .bcs
+        .as_ref()
+        .unwrap()
+        .deserialize()
+        .unwrap();
+
+    assert!(
+        resolved_transaction.gas_data().payment.is_empty(),
+        "Expected gas selection to pick address balance, got payment: {:?}",
+        resolved_transaction.gas_data().payment
+    );
+
+    let simulated_budget = resolved_transaction.gas_data().budget;
+
+    // Sign with both sender and sponsor and execute the resolved transaction so we can
+    // measure what the gas actually costs at execution time.
+    let sender_sig = test_env
+        .cluster
+        .wallet
+        .config
+        .keystore
+        .sign_secure(&sender, &resolved_transaction, Intent::sui_transaction())
+        .await
+        .unwrap();
+    let sponsor_sig = test_env
+        .cluster
+        .wallet
+        .config
+        .keystore
+        .sign_secure(&sponsor, &resolved_transaction, Intent::sui_transaction())
+        .await
+        .unwrap();
+    let signed = sui_types::transaction::Transaction::from_data(
+        resolved_transaction,
+        vec![sender_sig, sponsor_sig],
+    );
+    let executed = test_env.cluster.execute_transaction(signed).await;
+    assert!(
+        executed.effects.status().is_ok(),
+        "Executed transaction should succeed, got: {:?}",
+        executed.effects.status()
+    );
+
+    let summary = executed.effects.gas_cost_summary();
+    let actual_net_gas = summary.net_gas_usage();
+
+    let overshoot = simulated_budget as i64 - actual_net_gas;
+    assert!(
+        overshoot >= 0,
+        "Simulated budget {simulated_budget} must cover actual net gas usage {actual_net_gas}",
+    );
+
+    // The estimator adds a `1000 * reference_gas_price` safe-overhead buffer (defined in
+    // `estimate_gas_budget_from_gas_cost`). Without this fix, the synthetic gas coin's
+    // storage write — `object_size * obj_data_cost_refundable * storage_gas_price` MIST,
+    // typically ~1M MIST under default protocol params for a Coin<SUI> object — also
+    // lands in the budget. Bound the overshoot at `1500 * RGP` so the safe-overhead
+    // alone fits comfortably while a leaked storage cost trips this assertion.
+    let max_expected_overshoot = 1_500u64.saturating_mul(test_env.rgp);
+    assert!(
+        (overshoot as u64) < max_expected_overshoot,
+        "Estimated budget overshot actual net gas usage by {overshoot} MIST \
+         (simulated={simulated_budget}, actual={actual_net_gas}); \
+         max expected overshoot is {max_expected_overshoot} MIST. \
+         The mock gas coin's storage cost is leaking into the estimate."
+    );
+}

--- a/crates/sui-rpc-api/src/grpc/v2/transaction_execution_service/simulate/mod.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/transaction_execution_service/simulate/mod.rs
@@ -132,9 +132,15 @@ pub fn simulate_transaction(
             //
             // If the request did not specify a budget, then simulate the transaction to get a budget estimate and
             // overwrite the resolved budget with the more accurate estimate.
-            if request.transaction().gas_payment().budget.is_none()
-                && request.transaction().bcs_opt().is_none()
-            {
+            // When the request didn't specify a budget, the budget computed below covers
+            // computation + storage + safe-overhead, with the synthetic gas coin's storage
+            // cost subtracted (it doesn't exist at execution time). The cost of loading
+            // any additional payment objects is added either in `estimate_gas_budget_from_gas_cost`
+            // (when payment was specified) or incrementally inside `select_gas` (when gas
+            // selection picks the coins).
+            let budget_was_estimated = request.transaction().gas_payment().budget.is_none()
+                && request.transaction().bcs_opt().is_none();
+            if budget_was_estimated {
                 let mut estimation_transaction = transaction.clone();
                 estimation_transaction.gas_data_mut().payment = Vec::new();
                 estimation_transaction.gas_data_mut().budget = protocol_config.max_tx_gas();
@@ -151,6 +157,7 @@ pub fn simulate_transaction(
                     simulation_result.effects.gas_cost_summary(),
                     reference_gas_price,
                     request.transaction().gas_payment().objects.len(),
+                    mock_gas_storage_cost(&simulation_result),
                     &protocol_config,
                 );
 
@@ -172,7 +179,15 @@ pub fn simulate_transaction(
             }
 
             if transaction.gas_data().payment.is_empty() {
-                select_gas(service, &mut transaction, &protocol_config)?;
+                select_gas(
+                    service,
+                    &mut transaction,
+                    // Only adjust the budget for actually-selected coins when we just
+                    // computed the budget from estimation. A caller-supplied budget is
+                    // taken as-is.
+                    budget_was_estimated.then_some(reference_gas_price),
+                    &protocol_config,
+                )?;
             }
         }
 
@@ -316,63 +331,75 @@ fn to_command_output(
 /// Estimate the gas budget for a transaction based on simulation results.
 ///
 /// The estimation includes:
-/// 1. Base cost from gas_cost_summary (computation + storage costs)
-/// 2. Cost of loading gas payment objects (which weren't loaded during simulation)
-/// 3. Rounding up to the protocol gas rounding step (typically 1000 MIST)
-/// 4. Adding safe overhead buffer (1000 * reference_gas_price)
-/// 5. Clamping to max_tx_gas protocol limit
+/// 1. Base cost from gas_cost_summary (computation + storage costs), with the synthetic gas
+///    coin's storage cost subtracted (it doesn't exist at execution time).
+/// 2. Cost of loading additional gas payment objects beyond the synthetic gas coin already
+///    in the simulation. When the request didn't specify gas payment objects, this is 0 —
+///    `select_gas` will pick the actual coins (or address balance) and adjust the budget
+///    incrementally for each one.
+/// 3. Rounding up to the protocol gas rounding step (typically 1000 MIST).
+/// 4. Adding safe overhead buffer (1000 * reference_gas_price).
+/// 5. Clamping to max_tx_gas protocol limit.
 fn estimate_gas_budget_from_gas_cost(
     gas_cost_summary: &sui_types::gas::GasCostSummary,
     reference_gas_price: u64,
     num_payment_objects_on_request: usize,
+    mock_gas_storage_cost: u64,
     protocol_config: &ProtocolConfig,
 ) -> u64 {
     const GAS_SAFE_OVERHEAD: u64 = 1000;
 
-    // Calculate base estimate from gas cost summary (in MIST)
-    let gas_usage = gas_cost_summary.net_gas_usage();
-    let base_estimate_mist =
-        gas_cost_summary
-            .computation_cost
-            .max(if gas_usage < 0 { 0 } else { gas_usage as u64 });
+    // The simulation always loads a synthetic gas coin so that it can produce a gas cost
+    // summary even when the caller hasn't specified a gas payment. That coin's storage
+    // write is phantom — it is not written at execution time (real address-balance gas
+    // emits an accumulator event, real coin gas writes the user-provided coin instead) —
+    // so subtract its contribution from `storage_cost` before deriving the estimate.
+    let storage_cost = gas_cost_summary
+        .storage_cost
+        .saturating_sub(mock_gas_storage_cost);
+    let gas_used = gas_cost_summary
+        .computation_cost
+        .saturating_add(storage_cost);
+    let net_gas_usage = (gas_used as i64).saturating_sub(gas_cost_summary.storage_rebate as i64);
+    let base_estimate_mist = gas_cost_summary.computation_cost.max(if net_gas_usage < 0 {
+        0
+    } else {
+        net_gas_usage as u64
+    });
 
-    // Calculate cost of loading gas payment objects.
-    // Subtract 1 because the simulation already loaded one ephemeral gas coin.
-    let num_payment_objects_for_estimation = {
-        let total = if num_payment_objects_on_request == 0 {
-            protocol_config.max_gas_payment_objects() as u64
-        } else {
-            num_payment_objects_on_request as u64
-        };
-        total.saturating_sub(1)
-    };
+    // Loading cost for additional gas coins beyond the synthetic gas coin already counted
+    // by the simulation. When the request did not specify any payment objects, the loading
+    // cost is added incrementally inside `select_gas` once the actual coins are known.
+    let extra_payment_objects = (num_payment_objects_on_request as u64).saturating_sub(1);
+    let gas_loading_cost_mist =
+        compute_gas_loading_cost_mist(extra_payment_objects, reference_gas_price, protocol_config);
 
-    // Calculate gas loading cost in gas units
-    let gas_loading_cost_units = num_payment_objects_for_estimation
-        .saturating_mul(GAS_COIN_SIZE_BYTES)
-        .saturating_mul(protocol_config.obj_access_cost_read_per_byte());
-
-    // Round up to the nearest gas rounding step (in gas units)
-    let rounded_gas_loading_cost_units =
-        if let Some(step) = protocol_config.gas_rounding_step_as_option() {
-            round_up_to_nearest(gas_loading_cost_units, step)
-        } else {
-            gas_loading_cost_units
-        };
-
-    // Convert gas loading cost to MIST
-    let gas_loading_cost_mist = rounded_gas_loading_cost_units.saturating_mul(reference_gas_price);
-
-    // Calculate safe overhead buffer in MIST
     let safe_overhead_mist = GAS_SAFE_OVERHEAD.saturating_mul(reference_gas_price);
 
-    // Add all together: base (MIST) + loading (MIST) + overhead (MIST)
-    let estimate_mist = base_estimate_mist
+    base_estimate_mist
         .saturating_add(gas_loading_cost_mist)
-        .saturating_add(safe_overhead_mist);
+        .saturating_add(safe_overhead_mist)
+        .min(protocol_config.max_tx_gas())
+}
 
-    // Clamp to max_tx_gas to ensure we don't exceed the protocol limit
-    estimate_mist.min(protocol_config.max_tx_gas())
+/// Cost in MIST of loading `extra_coins` gas-payment objects beyond the synthetic gas coin
+/// already accounted for by the estimation simulation. Mirrors the protocol's per-byte
+/// read cost, rounded up to the protocol gas rounding step in gas units before being
+/// converted to MIST.
+fn compute_gas_loading_cost_mist(
+    extra_coins: u64,
+    reference_gas_price: u64,
+    protocol_config: &ProtocolConfig,
+) -> u64 {
+    let units = extra_coins
+        .saturating_mul(GAS_COIN_SIZE_BYTES)
+        .saturating_mul(protocol_config.obj_access_cost_read_per_byte());
+    let rounded = if let Some(step) = protocol_config.gas_rounding_step_as_option() {
+        round_up_to_nearest(units, step)
+    } else {
+        units
+    };
+    rounded.saturating_mul(reference_gas_price)
 }
 
 /// Round up a value to the nearest multiple of `step` using saturating arithmetic.
@@ -385,15 +412,40 @@ fn round_up_to_nearest(value: u64, step: u64) -> u64 {
     }
 }
 
+/// Storage cost (in MIST) of the synthetic gas coin that the simulator wrote during the
+/// estimation pass. The new `storage_rebate` on the written object equals the storage cost
+/// (see `track_storage_mutation` / `collect_storage_and_rebate`) so we can read it directly
+/// from the simulation's object set instead of re-deriving it from protocol parameters.
+/// Returns 0 when the simulation didn't use a mock gas coin.
+fn mock_gas_storage_cost(
+    simulation_result: &sui_types::transaction_executor::SimulateTransactionResult,
+) -> u64 {
+    let Some(mock_gas_id) = simulation_result.mock_gas_id else {
+        return 0;
+    };
+    // Both the input version (rebate 0, since the mock coin is fresh) and the written version
+    // (rebate set to the storage cost) end up in `objects`. The written version always carries
+    // the larger value, so taking the max is correct and avoids depending on iteration order.
+    simulation_result
+        .objects
+        .iter()
+        .filter(|o| o.id() == mock_gas_id)
+        .map(|o| o.storage_rebate)
+        .max()
+        .unwrap_or(0)
+}
+
 fn select_gas(
     service: &RpcService,
     transaction: &mut sui_types::transaction::TransactionData,
+    incremental_loading_rgp: Option<u64>,
     protocol_config: &ProtocolConfig,
 ) -> Result<()> {
     use sui_types::accumulator_root::AccumulatorValue;
     use sui_types::balance::Balance;
     use sui_types::base_types::SequenceNumber;
     use sui_types::coin_reservation::CoinReservationResolver;
+    use sui_types::coin_reservation::ParsedDigest;
     use sui_types::coin_reservation::ParsedObjectRefWithdrawal;
     use sui_types::gas_coin::GAS;
     use sui_types::gas_coin::GasCoin;
@@ -544,7 +596,29 @@ fn select_gas(
         selected_gas_value
     };
 
-    if selected_gas_value >= budget {
+    // When the caller asked us to top up the budget for the loading cost of the just-picked
+    // payment objects, do so before the balance check. The simulation already counted the
+    // synthetic gas coin's load, so charge for the rest. Coin reservations don't load real
+    // gas-coin objects and are excluded.
+    let final_budget = if let Some(rgp) = incremental_loading_rgp {
+        let real_coins = transaction
+            .gas_data()
+            .payment
+            .iter()
+            .filter(|obj_ref| !ParsedDigest::is_coin_reservation_digest(&obj_ref.2))
+            .count() as u64;
+        let extra_loading_mist =
+            compute_gas_loading_cost_mist(real_coins.saturating_sub(1), rgp, protocol_config);
+        let new_budget = budget
+            .saturating_add(extra_loading_mist)
+            .min(protocol_config.max_tx_gas());
+        transaction.gas_data_mut().budget = new_budget;
+        new_budget
+    } else {
+        budget
+    };
+
+    if selected_gas_value >= final_budget {
         Ok(())
     } else {
         Err(RpcError::new(
@@ -552,7 +626,7 @@ fn select_gas(
             format!(
                 "Unable to perform gas selection due to insufficient SUI \
                 balance (in address balance or coins) for account {owner} \
-                to satisfy required budget {budget}."
+                to satisfy required budget {final_budget}."
             ),
         ))
     }


### PR DESCRIPTION
Previously, when `simulate_transaction` estimated the gas budget for a transaction whose request omitted both BCS and a budget, the synthetic gas coin that the simulator injects (so it can run when the caller hasn't provided gas payment) bled its storage write cost into the returned `gas_cost_summary.storage_cost`. That cost is phantom — at execution time, real address-balance gas payment writes no coin (the charge becomes an `AccumulatorEvent`) and real coin gas payment writes the user-provided coin instead — so it was inflating every estimate by roughly `mock_size * obj_data_cost_refundable * storage_gas_price` MIST (~1M MIST under default protocol params).

Subtract that cost from the gas cost summary inside `estimate_gas_budget_from_gas_cost`. The simulator already returns the synthetic coin's `ObjectID` and the written object carries its `storage_rebate` field set to its storage cost (see `track_storage_mutation` / `collect_storage_and_rebate`), so the helper just looks the value up in `simulation_result.objects`.

Move the per-coin loading-cost adjustment for actually-selected coins into `select_gas` itself, gated on whether the budget came from the estimator. When `select_gas` picks address balance, no real gas coin is loaded so no loading cost is added; when it picks coins (or prepends a coin reservation), the budget is topped up by the loading cost of the real coins it selected, which is tighter than the previous worst-case assumption of `max_gas_payment_objects` (256) coins.

Also add an e2e regression test (sponsored PTB, sponsor pays gas via address balance, PTB does not use the gas coin) that asserts the simulated budget overshoots the executed net gas usage by less than `1500 * RGP` MIST. Without this fix the overshoot is ~2 * RGP * 1000 MIST due to the leaked mock-gas-coin storage cost.

## Description 

Describe the changes or additions included in this PR.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
