### PR TITLE
Add DeepBook Predict documentation to onchain finance

### DIFF
--- a/docs/content/onchain-finance/deepbook-predict/contract-information.mdx
+++ b/docs/content/onchain-finance/deepbook-predict/contract-information.mdx
@@ -18,7 +18,7 @@ This page contains the current public integration targets for DeepBook Predict o
 
 :::caution
 
-DeepBook Predict is documented here as a Testnet integration surface. Ignore older Predict package IDs in local configs or scripts unless a newer deployment explicitly replaces the values below.
+DeepBook Predict is documented here as a Testnet integration surface. The smart contracts are subject to change before Mainnet deployment, so treat the current package IDs, object layouts, and entry points as provisional. Ignore older Predict package IDs in local configs or scripts unless a newer deployment explicitly replaces the values below.
 
 :::
 

--- a/docs/content/onchain-finance/deepbook-predict/contract-information.mdx
+++ b/docs/content/onchain-finance/deepbook-predict/contract-information.mdx
@@ -7,7 +7,7 @@ keywords:
     predict package id,
     predict object id,
     predict server,
-    testnet,
+    Testnet,
     quote asset,
     oracle,
     plp,
@@ -18,7 +18,7 @@ This page contains the current public integration targets for DeepBook Predict o
 
 :::caution
 
-DeepBook Predict is documented here as a Testnet integration surface. The smart contracts are subject to change before Mainnet deployment, so treat the current package IDs, object layouts, and entry points as provisional. Ignore older Predict package IDs in local configs or scripts unless a newer deployment explicitly replaces the values below.
+DeepBook Predict is documented here as a Testnet integration surface. The smart contracts might change before Mainnet deployment, so treat the current package IDs, object layouts, and entry points as provisional. Ignore older Predict package IDs in local configs or scripts unless a newer deployment explicitly replaces the values below.
 
 :::
 
@@ -33,7 +33,7 @@ DeepBook Predict is documented here as a Testnet integration surface. The smart 
 | Predict object | `0xc8736204d12f0a7277c86388a68bf8a194b0a14c5538ad13f22cbd8e2a38028a` |
 | Current quote asset | `0xe95040085976bfd54a1a07225cd46c8a2b4e8e2b6732f140a0fc49850ba73e1a::dusdc::DUSDC` |
 | PLP coin type | `0xf5ea2b3749c65d6e56507cc35388719aadb28f9cab873696a2f8687f5c785138::plp::PLP` |
-| Source branch | `predict-testnet-4-16` |
+| Source branch | [`predict-testnet-4-16`](https://github.com/MystenLabs/deepbookv3/tree/predict-testnet-4-16/packages/predict) |
 
 ## Supported quote assets
 
@@ -51,7 +51,7 @@ DeepBook Predict is documented here as a Testnet integration surface. The smart 
 
 ## Public server endpoints
 
-Use the public server for render-ready market, vault, portfolio, and history data.
+The public server provides render-ready market, vault, portfolio, and history data.
 
 ### Protocol and market state
 
@@ -98,7 +98,7 @@ Use the public server for render-ready market, vault, portfolio, and history dat
 
 ## Live Sui events
 
-Use Sui checkpoint or event streaming when a UI needs lower-latency oracle state than the indexed server provides. Filter by the current Predict package ID and watch these event types:
+When a UI needs lower-latency oracle state than the indexed server provides, use Sui checkpoint or event streaming. Filter by the current Predict package ID and watch these event types:
 
 - `oracle::OraclePricesUpdated`
 - `oracle::OracleSVIUpdated`

--- a/docs/content/onchain-finance/deepbook-predict/contract-information.mdx
+++ b/docs/content/onchain-finance/deepbook-predict/contract-information.mdx
@@ -1,0 +1,122 @@
+---
+title: Contract Information
+description: DeepBook Predict Testnet package, object, quote asset, public server, data endpoints, and source branch.
+keywords:
+  [
+    deepbook predict contract information,
+    predict package id,
+    predict object id,
+    predict server,
+    testnet,
+    quote asset,
+    oracle,
+    plp,
+  ]
+---
+
+This page contains the current public integration targets for DeepBook Predict on Sui Testnet. These values come from the `predict-testnet-4-16` branch of the [DeepBookV3 Predict package](https://github.com/MystenLabs/deepbookv3/tree/predict-testnet-4-16/packages/predict).
+
+:::caution
+
+DeepBook Predict is documented here as a Testnet integration surface. Ignore older Predict package IDs in local configs or scripts unless a newer deployment explicitly replaces the values below.
+
+:::
+
+## Current deployment
+
+| Parameter | Value |
+|-----------|-------|
+| Network | Testnet |
+| Public server | `https://predict-server.testnet.mystenlabs.com` |
+| Predict package | `0xf5ea2b3749c65d6e56507cc35388719aadb28f9cab873696a2f8687f5c785138` |
+| Predict registry | `0x43af14fed5480c20ff77e2263d5f794c35b9fab7e2212903127062f4fe2a6e64` |
+| Predict object | `0xc8736204d12f0a7277c86388a68bf8a194b0a14c5538ad13f22cbd8e2a38028a` |
+| Current quote asset | `0xe95040085976bfd54a1a07225cd46c8a2b4e8e2b6732f140a0fc49850ba73e1a::dusdc::DUSDC` |
+| PLP coin type | `0xf5ea2b3749c65d6e56507cc35388719aadb28f9cab873696a2f8687f5c785138::plp::PLP` |
+| Source branch | `predict-testnet-4-16` |
+
+## Supported quote assets
+
+<details>
+<summary>DeepBook Test USDC (DUSDC)</summary>
+
+| Parameter | Value |
+|-----------|-------|
+| Type | `0xe95040085976bfd54a1a07225cd46c8a2b4e8e2b6732f140a0fc49850ba73e1a::dusdc::DUSDC` |
+| Currency ID | `0xf3000dff421833d4bb8ed58fac146d691a3aaba2785aa1989af65a7089ca3e9c` |
+| Decimals | 6 |
+| Network | Testnet |
+
+</details>
+
+## Public server endpoints
+
+Use the public server for render-ready market, vault, portfolio, and history data.
+
+### Protocol and market state
+
+| Endpoint | Use |
+|----------|-----|
+| `GET /status` | Server health and status |
+| `GET /predicts/:predict_id/state` | Predict object state and config |
+| `GET /predicts/:predict_id/oracles` | Oracle list for a Predict object |
+| `GET /oracles/:oracle_id/state` | Current oracle state |
+| `GET /predicts/:predict_id/quote-assets` | Accepted quote assets |
+| `GET /oracles/:oracle_id/ask-bounds` | Resolved oracle ask bounds |
+
+### Vault and LP data
+
+| Endpoint | Use |
+|----------|-----|
+| `GET /predicts/:predict_id/vault/summary` | Current vault summary |
+| `GET /predicts/:predict_id/vault/performance?range=ALL` | Vault performance over a selected range |
+| `GET /lp/supplies` | LP supply history |
+| `GET /lp/withdrawals` | LP withdrawal history |
+
+### Manager and portfolio data
+
+| Endpoint | Use |
+|----------|-----|
+| `GET /managers` | Predict manager list |
+| `GET /managers/:manager_id/summary` | Manager summary |
+| `GET /managers/:manager_id/positions/summary` | Manager position summary |
+| `GET /managers/:manager_id/pnl?range=ALL` | Manager PnL over a selected range |
+
+### History data
+
+| Endpoint | Use |
+|----------|-----|
+| `GET /oracles/:oracle_id/prices` | Oracle price history |
+| `GET /oracles/:oracle_id/prices/latest` | Latest indexed price update |
+| `GET /oracles/:oracle_id/svi` | Oracle SVI history |
+| `GET /oracles/:oracle_id/svi/latest` | Latest indexed SVI update |
+| `GET /positions/minted` | Position mint history |
+| `GET /positions/redeemed` | Position redeem history |
+| `GET /ranges/minted` | Range mint history |
+| `GET /ranges/redeemed` | Range redeem history |
+| `GET /trades/:oracle_id` | Trade history for an oracle |
+
+## Live Sui events
+
+Use Sui checkpoint or event streaming when a UI needs lower-latency oracle state than the indexed server provides. Filter by the current Predict package ID and watch these event types:
+
+- `oracle::OraclePricesUpdated`
+- `oracle::OracleSVIUpdated`
+- `oracle::OracleSettled`
+- `oracle::OracleActivated`
+
+Use the server for historical pagination. Use the live stream for freshness.
+
+## Source pointers
+
+| Area | Source |
+|------|--------|
+| Core shared object | [`packages/predict/sources/predict.move`](https://github.com/MystenLabs/deepbookv3/blob/predict-testnet-4-16/packages/predict/sources/predict.move) |
+| Manager account model | [`packages/predict/sources/predict_manager.move`](https://github.com/MystenLabs/deepbookv3/blob/predict-testnet-4-16/packages/predict/sources/predict_manager.move) |
+| Registry and admin entry points | [`packages/predict/sources/registry.move`](https://github.com/MystenLabs/deepbookv3/blob/predict-testnet-4-16/packages/predict/sources/registry.move) |
+| Oracle state machine | [`packages/predict/sources/oracle.move`](https://github.com/MystenLabs/deepbookv3/blob/predict-testnet-4-16/packages/predict/sources/oracle.move) |
+| Vault accounting | [`packages/predict/sources/vault/vault.move`](https://github.com/MystenLabs/deepbookv3/blob/predict-testnet-4-16/packages/predict/sources/vault/vault.move) |
+
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />

--- a/docs/content/onchain-finance/deepbook-predict/contract-information/market-keys.mdx
+++ b/docs/content/onchain-finance/deepbook-predict/contract-information/market-keys.mdx
@@ -1,0 +1,118 @@
+---
+title: Market Keys
+description: Learn how DeepBook Predict identifies binary positions and vertical ranges with MarketKey and RangeKey.
+keywords:
+  [
+    deepbook predict market key,
+    marketkey,
+    rangekey,
+    binary position,
+    vertical range,
+    strike,
+    expiry,
+  ]
+---
+
+`MarketKey` and `RangeKey` identify the internal position quantities stored in a `PredictManager`.
+
+Use `MarketKey` for binary positions keyed by oracle ID, expiry, strike, and direction. Use `RangeKey` for vertical ranges keyed by oracle ID, expiry, lower strike, and higher strike.
+
+The code examples on this page load from `packages/predict/sources/market_key` on the `predict-testnet-4-16` branch.
+
+## Binary position keys
+
+<details>
+<summary>Create `MarketKey` values</summary>
+
+Use `up()`, `down()`, or `new()` to create keys for binary positions.
+
+<ImportContent
+	source="packages/predict/sources/market_key/market_key.move"
+	mode="code"
+	org="MystenLabs"
+	repo="deepbookv3"
+	branch="predict-testnet-4-16"
+	fun="up,down,new"
+	noComments
+/>
+
+</details>
+
+<details>
+<summary>Read `MarketKey` fields</summary>
+
+<ImportContent
+	source="packages/predict/sources/market_key/market_key.move"
+	mode="code"
+	org="MystenLabs"
+	repo="deepbookv3"
+	branch="predict-testnet-4-16"
+	fun="oracle_id,expiry,strike,is_up,is_down"
+	noComments
+/>
+
+</details>
+
+## Range keys
+
+<details>
+<summary>Create `RangeKey` values</summary>
+
+Use `new()` to create a vertical range key. It aborts if `lower_strike` is not less than `higher_strike`.
+
+<ImportContent
+	source="packages/predict/sources/market_key/range_key.move"
+	mode="code"
+	org="MystenLabs"
+	repo="deepbookv3"
+	branch="predict-testnet-4-16"
+	fun="new"
+	noComments
+/>
+
+</details>
+
+<details>
+<summary>Read `RangeKey` fields</summary>
+
+<ImportContent
+	source="packages/predict/sources/market_key/range_key.move"
+	mode="code"
+	org="MystenLabs"
+	repo="deepbookv3"
+	branch="predict-testnet-4-16"
+	fun="oracle_id,expiry,lower_strike,higher_strike"
+	noComments
+/>
+
+</details>
+
+## Structs
+
+<details>
+<summary>`MarketKey`</summary>
+
+<ImportContent
+	source="packages/predict/sources/market_key/market_key.move"
+	mode="code"
+	org="MystenLabs"
+	repo="deepbookv3"
+	branch="predict-testnet-4-16"
+	struct="MarketKey"
+/>
+
+</details>
+
+<details>
+<summary>`RangeKey`</summary>
+
+<ImportContent
+	source="packages/predict/sources/market_key/range_key.move"
+	mode="code"
+	org="MystenLabs"
+	repo="deepbookv3"
+	branch="predict-testnet-4-16"
+	struct="RangeKey"
+/>
+
+</details>

--- a/docs/content/onchain-finance/deepbook-predict/contract-information/market-keys.mdx
+++ b/docs/content/onchain-finance/deepbook-predict/contract-information/market-keys.mdx
@@ -17,8 +17,6 @@ keywords:
 
 Use `MarketKey` for binary positions keyed by oracle ID, expiry, strike, and direction. Use `RangeKey` for vertical ranges keyed by oracle ID, expiry, lower strike, and higher strike.
 
-The code examples on this page load from `packages/predict/sources/market_key` on the `predict-testnet-4-16` branch.
-
 ## Binary position keys
 
 <details>

--- a/docs/content/onchain-finance/deepbook-predict/contract-information/oracle.mdx
+++ b/docs/content/onchain-finance/deepbook-predict/contract-information/oracle.mdx
@@ -16,8 +16,6 @@ keywords:
 
 `OracleSVI` is the market state for one underlying asset and one expiry. It stores spot and forward prices, SVI volatility surface parameters, activation state, the last update timestamp, and the settlement price after expiry.
 
-The code examples on this page load from `packages/predict/sources/oracle.move` on the `predict-testnet-4-16` branch.
-
 ## Lifecycle
 
 An oracle starts inactive, becomes active after `activate()`, accepts live price and SVI updates before expiry, enters pending settlement at expiry, and becomes settled when the first post-expiry price update freezes the settlement price.

--- a/docs/content/onchain-finance/deepbook-predict/contract-information/oracle.mdx
+++ b/docs/content/onchain-finance/deepbook-predict/contract-information/oracle.mdx
@@ -1,0 +1,175 @@
+---
+title: Oracle
+description: Learn about OracleSVI lifecycle, price updates, SVI updates, settlement, and oracle read functions in DeepBook Predict.
+keywords:
+  [
+    oraclesvi,
+    deepbook predict oracle,
+    oracle lifecycle,
+    svi,
+    spot price,
+    forward price,
+    settlement price,
+    oracle events,
+  ]
+---
+
+`OracleSVI` is the market state for one underlying asset and one expiry. It stores spot and forward prices, SVI volatility surface parameters, activation state, the last update timestamp, and the settlement price after expiry.
+
+The code examples on this page load from `packages/predict/sources/oracle.move` on the `predict-testnet-4-16` branch.
+
+## Lifecycle
+
+An oracle starts inactive, becomes active after `activate()`, accepts live price and SVI updates before expiry, enters pending settlement at expiry, and becomes settled when the first post-expiry price update freezes the settlement price.
+
+Mints require a live oracle. Redeems can use quoteable live or settled oracle state. After settlement, price and SVI updates are rejected.
+
+## API
+
+<details>
+<summary>Activate an oracle</summary>
+
+The `activate()` function moves an oracle into the active state before expiry.
+
+<ImportContent
+	source="packages/predict/sources/oracle.move"
+	mode="code"
+	org="MystenLabs"
+	repo="deepbookv3"
+	branch="predict-testnet-4-16"
+	fun="activate"
+	noComments
+/>
+
+</details>
+
+<details>
+<summary>Update prices</summary>
+
+The `update_prices()` function pushes high-frequency spot and forward prices. If the oracle is past expiry and not yet settled, this call freezes the settlement price instead of recording another live update.
+
+<ImportContent
+	source="packages/predict/sources/oracle.move"
+	mode="code"
+	org="MystenLabs"
+	repo="deepbookv3"
+	branch="predict-testnet-4-16"
+	fun="update_prices"
+	noComments
+/>
+
+</details>
+
+<details>
+<summary>Update SVI parameters</summary>
+
+The `update_svi()` function pushes lower-frequency SVI volatility surface parameters before expiry.
+
+<ImportContent
+	source="packages/predict/sources/oracle.move"
+	mode="code"
+	org="MystenLabs"
+	repo="deepbookv3"
+	branch="predict-testnet-4-16"
+	fun="update_svi"
+	noComments
+/>
+
+</details>
+
+<details>
+<summary>Read oracle state</summary>
+
+Use these functions to read oracle identifiers, underlying asset, prices, SVI parameters, expiry, timestamp, settlement, and lifecycle status.
+
+<ImportContent
+	source="packages/predict/sources/oracle.move"
+	mode="code"
+	org="MystenLabs"
+	repo="deepbookv3"
+	branch="predict-testnet-4-16"
+	fun="id,underlying_asset,spot_price,forward_price,prices,svi,expiry,timestamp,settlement_price,is_settled,is_active,status"
+	noComments
+/>
+
+</details>
+
+<details>
+<summary>Create price and SVI data</summary>
+
+These helper constructors build `PriceData` and `SVIParams` values for oracle updates.
+
+<ImportContent
+	source="packages/predict/sources/oracle.move"
+	mode="code"
+	org="MystenLabs"
+	repo="deepbookv3"
+	branch="predict-testnet-4-16"
+	fun="new_price_data,new_svi_params"
+	noComments
+/>
+
+</details>
+
+<details>
+<summary>Read status constants</summary>
+
+These functions return the numeric status values used by `status()`.
+
+<ImportContent
+	source="packages/predict/sources/oracle.move"
+	mode="code"
+	org="MystenLabs"
+	repo="deepbookv3"
+	branch="predict-testnet-4-16"
+	fun="status_inactive,status_active,status_pending_settlement,status_settled"
+	noComments
+/>
+
+</details>
+
+## Structs
+
+<details>
+<summary>`OracleSVI`</summary>
+
+<ImportContent
+	source="packages/predict/sources/oracle.move"
+	mode="code"
+	org="MystenLabs"
+	repo="deepbookv3"
+	branch="predict-testnet-4-16"
+	struct="OracleSVI"
+/>
+
+</details>
+
+<details>
+<summary>`PriceData` and `SVIParams`</summary>
+
+<ImportContent
+	source="packages/predict/sources/oracle.move"
+	mode="code"
+	org="MystenLabs"
+	repo="deepbookv3"
+	branch="predict-testnet-4-16"
+	struct="PriceData,SVIParams"
+/>
+
+</details>
+
+## Events
+
+<details>
+<summary>Oracle events</summary>
+
+<ImportContent
+	source="packages/predict/sources/oracle.move"
+	mode="code"
+	org="MystenLabs"
+	repo="deepbookv3"
+	branch="predict-testnet-4-16"
+	struct="OracleActivated,OraclePricesUpdated,OracleSVIUpdated,OracleSettled"
+/>
+
+</details>

--- a/docs/content/onchain-finance/deepbook-predict/contract-information/predict-manager.mdx
+++ b/docs/content/onchain-finance/deepbook-predict/contract-information/predict-manager.mdx
@@ -1,0 +1,92 @@
+---
+title: Predict Manager
+description: Learn about PredictManager accounts, deposited quote balances, binary position quantities, and range quantities.
+keywords:
+  [
+    predict manager,
+    predictmanager,
+    deepbook predict,
+    position table,
+    range position,
+    balance manager,
+    deposit,
+    withdraw,
+  ]
+---
+
+The `PredictManager` is a per-user shared account object. It wraps a DeepBook `BalanceManager`, stores quote balances, and tracks Predict positions internally.
+
+Each user should create one manager and reuse it. Binary positions and vertical ranges are not separate on-chain objects; they are quantities stored inside the manager.
+
+The code examples on this page load from `packages/predict/sources/predict_manager.move` on the `predict-testnet-4-16` branch.
+
+## API
+
+<details>
+<summary>Read owner, balances, and position quantities</summary>
+
+Use these functions to read the manager owner, deposited asset balances, binary position quantities, and range quantities.
+
+<ImportContent
+	source="packages/predict/sources/predict_manager.move"
+	mode="code"
+	org="MystenLabs"
+	repo="deepbookv3"
+	branch="predict-testnet-4-16"
+	fun="owner,balance,position,range_position"
+	noComments
+/>
+
+</details>
+
+<details>
+<summary>Deposit quote assets</summary>
+
+The manager owner deposits quote assets before minting positions or ranges.
+
+<ImportContent
+	source="packages/predict/sources/predict_manager.move"
+	mode="code"
+	org="MystenLabs"
+	repo="deepbookv3"
+	branch="predict-testnet-4-16"
+	fun="deposit"
+	noComments
+/>
+
+</details>
+
+<details>
+<summary>Withdraw quote assets</summary>
+
+The manager owner can withdraw quote assets from the manager.
+
+<ImportContent
+	source="packages/predict/sources/predict_manager.move"
+	mode="code"
+	org="MystenLabs"
+	repo="deepbookv3"
+	branch="predict-testnet-4-16"
+	fun="withdraw"
+	noComments
+/>
+
+</details>
+
+## Events
+
+<details>
+<summary>`PredictManagerCreated`</summary>
+
+Emitted when a new `PredictManager` is created.
+
+<ImportContent
+	source="packages/predict/sources/predict_manager.move"
+	mode="code"
+	org="MystenLabs"
+	repo="deepbookv3"
+	branch="predict-testnet-4-16"
+	struct="PredictManagerCreated"
+/>
+
+</details>

--- a/docs/content/onchain-finance/deepbook-predict/contract-information/predict-manager.mdx
+++ b/docs/content/onchain-finance/deepbook-predict/contract-information/predict-manager.mdx
@@ -16,9 +16,7 @@ keywords:
 
 The `PredictManager` is a per-user shared account object. It wraps a DeepBook `BalanceManager`, stores quote balances, and tracks Predict positions internally.
 
-Each user should create one manager and reuse it. Binary positions and vertical ranges are not separate on-chain objects; they are quantities stored inside the manager.
-
-The code examples on this page load from `packages/predict/sources/predict_manager.move` on the `predict-testnet-4-16` branch.
+Each user should create one manager and reuse it. Binary positions and vertical ranges are not separate onchain objects; they are quantities stored inside the manager.
 
 ## API
 

--- a/docs/content/onchain-finance/deepbook-predict/contract-information/predict.mdx
+++ b/docs/content/onchain-finance/deepbook-predict/contract-information/predict.mdx
@@ -1,0 +1,272 @@
+---
+title: Predict
+description: Learn about the Predict shared object, public trading functions, liquidity functions, configuration reads, and emitted events.
+keywords:
+  [
+    predict object,
+    deepbook predict,
+    mint,
+    redeem,
+    mint range,
+    redeem range,
+    supply,
+    withdraw,
+    plp,
+  ]
+---
+
+The `Predict` shared object is the main protocol entry point. It coordinates user actions across manager balances, oracle state, pricing config, risk config, and vault accounting.
+
+The code examples on this page load from `packages/predict/sources/predict.move` on the `predict-testnet-4-16` branch.
+
+## API
+
+Following are the public functions that applications use most often.
+
+<details>
+<summary>Create a `PredictManager`</summary>
+
+The `create_manager()` function creates a new shared `PredictManager` for the caller and returns its object ID.
+
+<ImportContent
+	source="packages/predict/sources/predict.move"
+	mode="code"
+	org="MystenLabs"
+	repo="deepbookv3"
+	branch="predict-testnet-4-16"
+	fun="create_manager"
+	noComments
+/>
+
+</details>
+
+<details>
+<summary>Preview binary position amounts</summary>
+
+The `get_trade_amounts()` function returns the mint cost and redeem payout for a binary position at the requested quantity.
+
+<ImportContent
+	source="packages/predict/sources/predict.move"
+	mode="code"
+	org="MystenLabs"
+	repo="deepbookv3"
+	branch="predict-testnet-4-16"
+	fun="get_trade_amounts"
+	noComments
+/>
+
+</details>
+
+<details>
+<summary>Mint a binary position</summary>
+
+The `mint()` function buys a binary position using an enabled quote asset deposited in the caller's `PredictManager`.
+
+<ImportContent
+	source="packages/predict/sources/predict.move"
+	mode="code"
+	org="MystenLabs"
+	repo="deepbookv3"
+	branch="predict-testnet-4-16"
+	fun="mint"
+	noComments
+/>
+
+</details>
+
+<details>
+<summary>Redeem a binary position</summary>
+
+The `redeem()` function sells a binary position and deposits the payout back into the owner's `PredictManager`.
+
+<ImportContent
+	source="packages/predict/sources/predict.move"
+	mode="code"
+	org="MystenLabs"
+	repo="deepbookv3"
+	branch="predict-testnet-4-16"
+	fun="redeem"
+	noComments
+/>
+
+</details>
+
+<details>
+<summary>Redeem a settled binary position permissionlessly</summary>
+
+The `redeem_permissionless()` function lets anyone redeem a settled position into the owner's `PredictManager`.
+
+<ImportContent
+	source="packages/predict/sources/predict.move"
+	mode="code"
+	org="MystenLabs"
+	repo="deepbookv3"
+	branch="predict-testnet-4-16"
+	fun="redeem_permissionless"
+	noComments
+/>
+
+</details>
+
+<details>
+<summary>Preview range amounts</summary>
+
+The `get_range_trade_amounts()` function returns the mint cost and redeem payout for a vertical range at the requested quantity.
+
+<ImportContent
+	source="packages/predict/sources/predict.move"
+	mode="code"
+	org="MystenLabs"
+	repo="deepbookv3"
+	branch="predict-testnet-4-16"
+	fun="get_range_trade_amounts"
+	noComments
+/>
+
+</details>
+
+<details>
+<summary>Mint a vertical range</summary>
+
+The `mint_range()` function buys a bounded range position. The range is keyed by oracle ID, expiry, lower strike, and higher strike.
+
+<ImportContent
+	source="packages/predict/sources/predict.move"
+	mode="code"
+	org="MystenLabs"
+	repo="deepbookv3"
+	branch="predict-testnet-4-16"
+	fun="mint_range"
+	noComments
+/>
+
+</details>
+
+<details>
+<summary>Redeem a vertical range</summary>
+
+The `redeem_range()` function sells a range position and deposits the payout into the owner's `PredictManager`.
+
+<ImportContent
+	source="packages/predict/sources/predict.move"
+	mode="code"
+	org="MystenLabs"
+	repo="deepbookv3"
+	branch="predict-testnet-4-16"
+	fun="redeem_range"
+	noComments
+/>
+
+</details>
+
+<details>
+<summary>Supply vault liquidity</summary>
+
+The `supply()` function deposits an accepted quote asset into the vault and returns `PLP` shares.
+
+<ImportContent
+	source="packages/predict/sources/predict.move"
+	mode="code"
+	org="MystenLabs"
+	repo="deepbookv3"
+	branch="predict-testnet-4-16"
+	fun="supply"
+	noComments
+/>
+
+</details>
+
+<details>
+<summary>Withdraw vault liquidity</summary>
+
+The `withdraw()` function burns `PLP` shares and returns the selected quote asset when the requested amount is available after max payout coverage.
+
+<ImportContent
+	source="packages/predict/sources/predict.move"
+	mode="code"
+	org="MystenLabs"
+	repo="deepbookv3"
+	branch="predict-testnet-4-16"
+	fun="withdraw"
+	noComments
+/>
+
+</details>
+
+<details>
+<summary>Compact settled oracle exposure</summary>
+
+The `compact_settled_oracle()` function lets an authorized oracle operator compact settled strike-matrix exposure into constant-size settled state.
+
+<ImportContent
+	source="packages/predict/sources/predict.move"
+	mode="code"
+	org="MystenLabs"
+	repo="deepbookv3"
+	branch="predict-testnet-4-16"
+	fun="compact_settled_oracle"
+	noComments
+/>
+
+</details>
+
+<details>
+<summary>Read protocol configuration</summary>
+
+These read functions expose trading pause state, accepted quote assets, pricing parameters, risk limits, ask bounds, and currently available withdrawal amount.
+
+<ImportContent
+	source="packages/predict/sources/predict.move"
+	mode="code"
+	org="MystenLabs"
+	repo="deepbookv3"
+	branch="predict-testnet-4-16"
+	fun="ask_bounds,trading_paused,accepted_quotes,base_spread,min_spread,utilization_multiplier,max_total_exposure_pct,available_withdrawal"
+	noComments
+/>
+
+</details>
+
+## Events
+
+<details>
+<summary>Trading events</summary>
+
+<ImportContent
+	source="packages/predict/sources/predict.move"
+	mode="code"
+	org="MystenLabs"
+	repo="deepbookv3"
+	branch="predict-testnet-4-16"
+	struct="PositionMinted,PositionRedeemed,RangeMinted,RangeRedeemed"
+/>
+
+</details>
+
+<details>
+<summary>Liquidity events</summary>
+
+<ImportContent
+	source="packages/predict/sources/predict.move"
+	mode="code"
+	org="MystenLabs"
+	repo="deepbookv3"
+	branch="predict-testnet-4-16"
+	struct="Supplied,Withdrawn"
+/>
+
+</details>
+
+<details>
+<summary>Configuration events</summary>
+
+<ImportContent
+	source="packages/predict/sources/predict.move"
+	mode="code"
+	org="MystenLabs"
+	repo="deepbookv3"
+	branch="predict-testnet-4-16"
+	struct="TradingPauseUpdated,PricingConfigUpdated,OracleAskBoundsSet,OracleAskBoundsCleared,RiskConfigUpdated,QuoteAssetEnabled,QuoteAssetDisabled"
+/>
+
+</details>

--- a/docs/content/onchain-finance/deepbook-predict/contract-information/predict.mdx
+++ b/docs/content/onchain-finance/deepbook-predict/contract-information/predict.mdx
@@ -17,8 +17,6 @@ keywords:
 
 The `Predict` shared object is the main protocol entry point. It coordinates user actions across manager balances, oracle state, pricing config, risk config, and vault accounting.
 
-The code examples on this page load from `packages/predict/sources/predict.move` on the `predict-testnet-4-16` branch.
-
 ## API
 
 Following are the public functions that applications use most often.

--- a/docs/content/onchain-finance/deepbook-predict/contract-information/registry.mdx
+++ b/docs/content/onchain-finance/deepbook-predict/contract-information/registry.mdx
@@ -19,8 +19,6 @@ The `Registry` shared object tracks the Predict object ID and the oracle IDs cre
 
 Most app integrations do not call these functions directly. They are operator and governance surfaces for deploying and maintaining the protocol.
 
-The code examples on this page load from `packages/predict/sources/registry.move` on the `predict-testnet-4-16` branch.
-
 ## API
 
 <details>

--- a/docs/content/onchain-finance/deepbook-predict/contract-information/registry.mdx
+++ b/docs/content/onchain-finance/deepbook-predict/contract-information/registry.mdx
@@ -1,0 +1,190 @@
+---
+title: Registry
+description: Learn about DeepBook Predict registry setup, oracle creation, quote asset management, and admin configuration entry points.
+keywords:
+  [
+    deepbook predict registry,
+    registry,
+    admin cap,
+    create predict,
+    create oracle,
+    quote asset,
+    oracle cap,
+    pricing config,
+    risk config,
+  ]
+---
+
+The `Registry` shared object tracks the Predict object ID and the oracle IDs created by each `OracleSVICap`. The registry module also exposes admin entry points for setup, quote asset management, oracle creation, pricing configuration, risk configuration, and the withdrawal limiter.
+
+Most app integrations do not call these functions directly. They are operator and governance surfaces for deploying and maintaining the protocol.
+
+The code examples on this page load from `packages/predict/sources/registry.move` on the `predict-testnet-4-16` branch.
+
+## API
+
+<details>
+<summary>Read registered object IDs</summary>
+
+Use these functions to read the active Predict object ID and the oracle IDs associated with an oracle cap.
+
+<ImportContent
+	source="packages/predict/sources/registry.move"
+	mode="code"
+	org="MystenLabs"
+	repo="deepbookv3"
+	branch="predict-testnet-4-16"
+	fun="predict_id,oracle_ids"
+	noComments
+/>
+
+</details>
+
+<details>
+<summary>Create the Predict object</summary>
+
+The `create_predict()` function creates the shared `Predict` object once for a quote asset and records its ID in the registry.
+
+<ImportContent
+	source="packages/predict/sources/registry.move"
+	mode="code"
+	org="MystenLabs"
+	repo="deepbookv3"
+	branch="predict-testnet-4-16"
+	fun="create_predict"
+	noComments
+/>
+
+</details>
+
+<details>
+<summary>Create and register oracle caps</summary>
+
+Oracle caps authorize oracle operators to update oracles and tighten per-oracle ask bounds.
+
+<ImportContent
+	source="packages/predict/sources/registry.move"
+	mode="code"
+	org="MystenLabs"
+	repo="deepbookv3"
+	branch="predict-testnet-4-16"
+	fun="create_oracle_cap,register_oracle_cap"
+	noComments
+/>
+
+</details>
+
+<details>
+<summary>Create an oracle</summary>
+
+The `create_oracle()` function creates an `OracleSVI`, associates it with the calling cap, and initializes the Predict vault's strike grid for that oracle.
+
+<ImportContent
+	source="packages/predict/sources/registry.move"
+	mode="code"
+	org="MystenLabs"
+	repo="deepbookv3"
+	branch="predict-testnet-4-16"
+	fun="create_oracle"
+	noComments
+/>
+
+</details>
+
+<details>
+<summary>Manage quote assets</summary>
+
+Admins can enable or disable quote assets for new supply and mint inflows.
+
+<ImportContent
+	source="packages/predict/sources/registry.move"
+	mode="code"
+	org="MystenLabs"
+	repo="deepbookv3"
+	branch="predict-testnet-4-16"
+	fun="enable_quote_asset,disable_quote_asset"
+	noComments
+/>
+
+</details>
+
+<details>
+<summary>Configure pricing</summary>
+
+These functions control global spread, minimum spread, utilization multiplier, and global ask price bounds.
+
+<ImportContent
+	source="packages/predict/sources/registry.move"
+	mode="code"
+	org="MystenLabs"
+	repo="deepbookv3"
+	branch="predict-testnet-4-16"
+	fun="set_base_spread,set_min_spread,set_utilization_multiplier,set_min_ask_price,set_max_ask_price"
+	noComments
+/>
+
+</details>
+
+<details>
+<summary>Configure oracle ask bounds</summary>
+
+Oracle ask-bound overrides are authorized by the oracle's cap and can only tighten the global bounds.
+
+<ImportContent
+	source="packages/predict/sources/registry.move"
+	mode="code"
+	org="MystenLabs"
+	repo="deepbookv3"
+	branch="predict-testnet-4-16"
+	fun="set_oracle_ask_bounds,clear_oracle_ask_bounds"
+	noComments
+/>
+
+</details>
+
+<details>
+<summary>Configure trading and risk controls</summary>
+
+These functions control the trading pause, max total exposure percentage, and LP withdrawal limiter.
+
+<ImportContent
+	source="packages/predict/sources/registry.move"
+	mode="code"
+	org="MystenLabs"
+	repo="deepbookv3"
+	branch="predict-testnet-4-16"
+	fun="set_trading_paused,set_max_total_exposure_pct,update_withdrawal_limiter,enable_withdrawal_limiter,disable_withdrawal_limiter"
+	noComments
+/>
+
+</details>
+
+## Structs and events
+
+<details>
+<summary>`Registry` and `AdminCap`</summary>
+
+<ImportContent
+	source="packages/predict/sources/registry.move"
+	mode="code"
+	org="MystenLabs"
+	repo="deepbookv3"
+	branch="predict-testnet-4-16"
+	struct="Registry,AdminCap"
+/>
+
+</details>
+
+<details>
+<summary>Registry events</summary>
+
+<ImportContent
+	source="packages/predict/sources/registry.move"
+	mode="code"
+	org="MystenLabs"
+	repo="deepbookv3"
+	branch="predict-testnet-4-16"
+	struct="PredictCreated,OracleCreated"
+/>
+
+</details>

--- a/docs/content/onchain-finance/deepbook-predict/contract-information/vault.mdx
+++ b/docs/content/onchain-finance/deepbook-predict/contract-information/vault.mdx
@@ -1,0 +1,88 @@
+---
+title: Vault
+description: Learn about the DeepBook Predict vault, PLP shares, vault value, exposure tracking, and liquidity reads.
+keywords:
+  [
+    deepbook predict vault,
+    vault,
+    plp,
+    liquidity provider,
+    vault value,
+    mark to market,
+    max payout,
+    settled oracle,
+  ]
+---
+
+The Predict vault holds accepted quote assets and takes the opposite side of every trade. `predict.move` owns pricing and trading orchestration; `vault.move` is the state machine for balances, exposure, mark-to-market liability, max payout, and settled-oracle compaction.
+
+LPs interact with the vault through `predict::supply` and `predict::withdraw`, which mint and burn `PLP` shares. See [Predict](/onchain-finance/deepbook-predict/contract-information/predict) for those public liquidity entry points.
+
+The code examples on this page load from `packages/predict/sources/vault/vault.move` and `packages/predict/sources/vault/plp.move` on the `predict-testnet-4-16` branch.
+
+## Read functions
+
+<details>
+<summary>Vault balances and value</summary>
+
+Use these functions to read total vault balance, concrete asset balances, total mark-to-market liability, vault value, and total max payout.
+
+<ImportContent
+	source="packages/predict/sources/vault/vault.move"
+	mode="code"
+	org="MystenLabs"
+	repo="deepbookv3"
+	branch="predict-testnet-4-16"
+	fun="balance,asset_balance,total_mtm,vault_value,total_max_payout"
+	noComments
+/>
+
+</details>
+
+## Structs
+
+<details>
+<summary>`Vault`</summary>
+
+<ImportContent
+	source="packages/predict/sources/vault/vault.move"
+	mode="code"
+	org="MystenLabs"
+	repo="deepbookv3"
+	branch="predict-testnet-4-16"
+	struct="Vault"
+/>
+
+</details>
+
+<details>
+<summary>`SettledOracleState`</summary>
+
+After settlement compaction, the vault stores compact per-oracle remaining quantity and liability.
+
+<ImportContent
+	source="packages/predict/sources/vault/vault.move"
+	mode="code"
+	org="MystenLabs"
+	repo="deepbookv3"
+	branch="predict-testnet-4-16"
+	struct="SettledOracleState"
+/>
+
+</details>
+
+<details>
+<summary>`PLP`</summary>
+
+`PLP` is the LP share coin minted when users supply vault liquidity.
+
+<ImportContent
+	source="packages/predict/sources/vault/plp.move"
+	mode="code"
+	org="MystenLabs"
+	repo="deepbookv3"
+	branch="predict-testnet-4-16"
+	struct="PLP"
+/>
+
+</details>

--- a/docs/content/onchain-finance/deepbook-predict/contract-information/vault.mdx
+++ b/docs/content/onchain-finance/deepbook-predict/contract-information/vault.mdx
@@ -18,8 +18,6 @@ The Predict vault holds accepted quote assets and takes the opposite side of eve
 
 LPs interact with the vault through `predict::supply` and `predict::withdraw`, which mint and burn `PLP` shares. See [Predict](/onchain-finance/deepbook-predict/contract-information/predict) for those public liquidity entry points.
 
-The code examples on this page load from `packages/predict/sources/vault/vault.move` and `packages/predict/sources/vault/plp.move` on the `predict-testnet-4-16` branch.
-
 ## Read functions
 
 <details>

--- a/docs/content/onchain-finance/deepbook-predict/deepbook-predict.mdx
+++ b/docs/content/onchain-finance/deepbook-predict/deepbook-predict.mdx
@@ -1,0 +1,57 @@
+---
+title: DeepBook Predict
+description: Prediction market protocol built alongside DeepBook, with binary positions, vertical ranges, oracle-driven pricing, and shared vault liquidity on Sui.
+keywords:
+  [
+    deepbook predict,
+    predict,
+    prediction market,
+    binary position,
+    vertical range,
+    oracle,
+    plp,
+    deepbook,
+    sui,
+  ]
+---
+
+DeepBook Predict is an expiry-based prediction market protocol on Sui. It lets applications build markets where users can mint and redeem binary positions or vertical ranges against oracle-driven prices, while liquidity providers supply quote assets to a shared vault and receive `PLP` LP shares.
+
+The protocol is currently documented from the `predict-testnet-4-16` branch of the [DeepBookV3 repository](https://github.com/MystenLabs/deepbookv3/tree/predict-testnet-4-16/packages/predict). The current public integration target is on Sui Testnet.
+
+## Key features
+
+DeepBook Predict provides the following capabilities:
+
+- **Binary positions:** Users can mint directional positions for an oracle, expiry, strike, and direction.
+- **Vertical ranges:** Users can mint bounded range positions keyed by an oracle, expiry, lower strike, and higher strike.
+- **Oracle-based pricing:** `OracleSVI` objects track spot, forward, SVI parameters, lifecycle status, and settlement prices.
+- **Shared manager accounts:** Each user reuses a `PredictManager` to hold quote balances, positions, and range quantities.
+- **Vault liquidity:** LPs supply accepted quote assets to the vault and receive `PLP` shares representing a proportional claim on vault value.
+- **Indexed data path:** Applications can use the public Predict server for render-ready market, vault, portfolio, and history data.
+
+## Integration model
+
+Most applications should combine three data sources:
+
+- Use the public Predict server for page rendering, lists, portfolio summaries, vault summaries, and historical data.
+- Use Sui checkpoint or event streaming when a page needs low-latency oracle updates.
+- Use direct on-chain object reads immediately before or after wallet flows that need confirmation-critical state.
+
+Avoid building the primary UI around raw chain scans. The server already exposes indexed surfaces for market state, portfolio state, vault state, and history.
+
+## User flow
+
+A typical user flow starts with current market data from the public server. After selecting an active oracle and strike, the user creates or finds a `PredictManager`, deposits the enabled quote asset, previews mint and redeem amounts, then submits a transaction for a binary position or vertical range. After confirmation, refresh both the affected on-chain objects and the indexed server endpoints backing the current page.
+
+## Liquidity provider flow
+
+Liquidity providers supply accepted quote assets into the shared vault using `predict::supply`. In return, the protocol mints `PLP`, which represents vault shares. LP withdrawals burn `PLP` and return a selected quote asset, subject to current vault value, max payout coverage, and the withdrawal limiter.
+
+## Testnet status
+
+DeepBook Predict is documented here as a Testnet integration surface. Do not reuse package IDs from older Predict experiments. See [Contract Information](/onchain-finance/deepbook-predict/contract-information) for the current package, object ID, quote asset, server URL, and source branch.
+
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />

--- a/docs/content/onchain-finance/deepbook-predict/deepbook-predict.mdx
+++ b/docs/content/onchain-finance/deepbook-predict/deepbook-predict.mdx
@@ -19,6 +19,12 @@ DeepBook Predict is an expiry-based prediction market protocol on Sui. It lets a
 
 The protocol is currently documented from the `predict-testnet-4-16` branch of the [DeepBookV3 repository](https://github.com/MystenLabs/deepbookv3/tree/predict-testnet-4-16/packages/predict). The current public integration target is on Sui Testnet.
 
+:::caution
+
+DeepBook Predict smart contracts are subject to change before Mainnet deployment. Treat the current package IDs, object layouts, and entry points as Testnet integration targets.
+
+:::
+
 ## Key features
 
 DeepBook Predict provides the following capabilities:

--- a/docs/content/onchain-finance/deepbook-predict/deepbook-predict.mdx
+++ b/docs/content/onchain-finance/deepbook-predict/deepbook-predict.mdx
@@ -21,7 +21,7 @@ The protocol is currently documented from the `predict-testnet-4-16` branch of t
 
 :::caution
 
-DeepBook Predict smart contracts are subject to change before Mainnet deployment. Treat the current package IDs, object layouts, and entry points as Testnet integration targets.
+DeepBook Predict smart contracts might change before Mainnet deployment. Treat the current package IDs, object layouts, and entry points as Testnet integration targets.
 
 :::
 
@@ -41,14 +41,14 @@ DeepBook Predict provides the following capabilities:
 Most applications should combine three data sources:
 
 - Use the public Predict server for page rendering, lists, portfolio summaries, vault summaries, and historical data.
-- Use Sui checkpoint or event streaming when a page needs low-latency oracle updates.
-- Use direct on-chain object reads immediately before or after wallet flows that need confirmation-critical state.
+- Sui checkpoint or event streaming supports pages that need low-latency oracle updates.
+- Use direct onchain object reads immediately before or after wallet flows that need confirmation-critical state.
 
 Avoid building the primary UI around raw chain scans. The server already exposes indexed surfaces for market state, portfolio state, vault state, and history.
 
 ## User flow
 
-A typical user flow starts with current market data from the public server. After selecting an active oracle and strike, the user creates or finds a `PredictManager`, deposits the enabled quote asset, previews mint and redeem amounts, then submits a transaction for a binary position or vertical range. After confirmation, refresh both the affected on-chain objects and the indexed server endpoints backing the current page.
+A typical user flow starts with current market data from the public server. After selecting an active oracle and strike, the user creates or finds a `PredictManager`, deposits the enabled quote asset, previews mint and redeem amounts, then submits a transaction for a binary position or vertical range. After confirmation, refresh both the affected onchain objects and the indexed server endpoints backing the current page.
 
 ## Liquidity provider flow
 

--- a/docs/content/onchain-finance/deepbook-predict/design.mdx
+++ b/docs/content/onchain-finance/deepbook-predict/design.mdx
@@ -15,7 +15,7 @@ keywords:
   ]
 ---
 
-At a high level, DeepBook Predict revolves around four main on-chain components:
+At a high level, DeepBook Predict revolves around four main onchain components:
 
 - `Predict`: The top-level shared object. It holds vault balances, pricing config, risk config, the quote-asset allowlist, oracle strike grids, withdrawal-limiter config, and the `PLP` treasury cap.
 - `PredictManager`: A per-user shared account object. It wraps a DeepBook `BalanceManager`, stores deposited quote balances, and tracks a user's binary position and vertical range quantities.
@@ -71,6 +71,6 @@ Applications should split reads by freshness and purpose:
 
 1. Render markets, portfolios, vault summaries, and history from the public Predict server.
 1. Subscribe to Sui checkpoints or events for second-level oracle updates when the UI needs a live tape.
-1. Read on-chain `Predict`, `PredictManager`, `OracleSVI`, and quote coin objects around wallet flows that require authoritative state.
+1. Read onchain `Predict`, `PredictManager`, `OracleSVI`, and quote coin objects around wallet flows that require authoritative state.
 
-This keeps page rendering fast while still letting transaction flows confirm exact on-chain state.
+This keeps page rendering fast while still letting transaction flows confirm exact onchain state.

--- a/docs/content/onchain-finance/deepbook-predict/design.mdx
+++ b/docs/content/onchain-finance/deepbook-predict/design.mdx
@@ -1,0 +1,76 @@
+---
+title: Design
+description: Learn about DeepBook Predict design, including Predict, PredictManager, OracleSVI, Vault, and PLP.
+keywords:
+  [
+    deepbook predict design,
+    predict,
+    predictmanager,
+    oraclesvi,
+    vault,
+    plp,
+    binary position,
+    vertical range,
+    prediction market,
+  ]
+---
+
+At a high level, DeepBook Predict revolves around four main on-chain components:
+
+- `Predict`: The top-level shared object. It holds vault balances, pricing config, risk config, the quote-asset allowlist, oracle strike grids, withdrawal-limiter config, and the `PLP` treasury cap.
+- `PredictManager`: A per-user shared account object. It wraps a DeepBook `BalanceManager`, stores deposited quote balances, and tracks a user's binary position and vertical range quantities.
+- `OracleSVI`: The market state for one underlying asset and one expiry. It stores spot, forward, SVI parameters, activation status, timestamps, and settlement price.
+- `Vault`: The shared liquidity and exposure state machine. It stores accepted quote assets, tracks mark-to-market liability, tracks maximum payout, and supports `PLP` supply and withdrawal flows.
+
+## `Predict` shared object {#predict}
+
+`Predict` is the main protocol object that applications pass to trading and liquidity functions. It validates quote assets, checks trading pause state, prices mints and redeems from oracle state, applies spread and utilization configuration, updates vault exposure, and emits protocol events.
+
+For a mint, `Predict` first validates that the manager owner is the signer, the quote asset is accepted, the oracle is live, and the requested market key or range key matches the oracle. It then inserts the new liability into the vault before pricing the trade, so the trader pays for the post-trade state they create. After collecting payment from the `PredictManager`, it checks total exposure and increases the user's internal position quantity.
+
+For a redeem, `Predict` decreases the user's internal position quantity, removes or compacts the vault exposure as needed, dispenses the payout from the vault, and deposits the payout back into the `PredictManager`.
+
+## `PredictManager` shared object {#predict-manager}
+
+Each user creates one `PredictManager` and reuses it across Predict flows. The manager owns an inner `BalanceManager` plus deposit and withdraw capabilities, which lets the protocol move balances during mints, redeems, and payouts without exposing the internal capabilities directly.
+
+Positions and ranges are not standalone objects. The manager stores binary position quantities in a table keyed by `MarketKey`, and vertical range quantities in a table keyed by `RangeKey`. Applications should read those quantities from the manager object or from the indexed server API rather than looking for separate position objects.
+
+## Positions and ranges {#positions-and-ranges}
+
+Binary positions are keyed by `(oracle_id, expiry, strike, is_up)`. The `is_up` direction represents whether the position pays when settlement is above the strike. A corresponding down position is created with the same oracle, expiry, and strike but the opposite direction.
+
+Vertical ranges are keyed by `(oracle_id, expiry, lower_strike, higher_strike)`. A range is priced as a single bounded instrument. At settlement, it pays out when the settlement lands in the band `(lower, higher]`.
+
+## Oracle lifecycle {#oracle-lifecycle}
+
+`OracleSVI` moves through four lifecycle states:
+
+- **Inactive:** The oracle exists but has not been activated.
+- **Active:** The oracle accepts live spot, forward, and SVI updates before expiry.
+- **Pending settlement:** The oracle has reached expiry but has not yet received the first post-expiry price push.
+- **Settled:** The first post-expiry price update freezes the settlement price and prevents further live price or SVI updates.
+
+Tradeability depends on this lifecycle. Mints require a live oracle. Redeems can quote against live or settled oracle state. After settlement, the vault can compact dense strike matrix exposure into constant-size settled state.
+
+## Vault and `PLP` {#vault-and-plp}
+
+The vault takes the opposite side of every Predict trade. It stores concrete quote asset balances, a shared quote-denominated vault balance, per-oracle strike matrices, compact settled-oracle state, total mark-to-market liability, and total maximum payout.
+
+Liquidity providers call `predict::supply` with an accepted quote asset and receive `PLP` shares. The first supplier receives shares one-to-one with the supplied amount. Later suppliers receive shares proportional to their deposit relative to current vault value. Withdrawals burn `PLP` and return quote assets only when the withdrawal amount is available after covering current max payout.
+
+## Pricing and risk {#pricing-and-risk}
+
+Predict prices binary positions and ranges from oracle fair prices plus protocol spread and utilization adjustments. The protocol can set global ask bounds and tighter per-oracle ask bounds. These bounds prevent mints with post-spread ask prices outside configured limits.
+
+Risk is enforced by the vault's total exposure check. After minting, the vault asserts that total mark-to-market liability remains within `max_total_exposure_pct` of the vault balance.
+
+## Data flow {#data-flow}
+
+Applications should split reads by freshness and purpose:
+
+1. Render markets, portfolios, vault summaries, and history from the public Predict server.
+1. Subscribe to Sui checkpoints or events for second-level oracle updates when the UI needs a live tape.
+1. Read on-chain `Predict`, `PredictManager`, `OracleSVI`, and quote coin objects around wallet flows that require authoritative state.
+
+This keeps page rendering fast while still letting transaction flows confirm exact on-chain state.

--- a/docs/content/sidebars.js
+++ b/docs/content/sidebars.js
@@ -442,6 +442,27 @@ export default {
     },
     {
       type: 'category',
+      label: 'DeepBook Predict',
+      link: { type: 'doc', id: 'onchain-finance/deepbook-predict/deepbook-predict' },
+      items: [
+        'onchain-finance/deepbook-predict/design',
+        {
+          type: 'category',
+          label: 'Contract Information',
+          link: { type: 'doc', id: 'onchain-finance/deepbook-predict/contract-information' },
+          items: [
+            'onchain-finance/deepbook-predict/contract-information/predict',
+            'onchain-finance/deepbook-predict/contract-information/predict-manager',
+            'onchain-finance/deepbook-predict/contract-information/market-keys',
+            'onchain-finance/deepbook-predict/contract-information/oracle',
+            'onchain-finance/deepbook-predict/contract-information/vault',
+            'onchain-finance/deepbook-predict/contract-information/registry',
+          ],
+        },
+      ],
+    },
+    {
+      type: 'category',
       label: 'Kiosk',
       link: { type: 'doc', id: 'onchain-finance/kiosk/index' },
       items: [


### PR DESCRIPTION
## Summary
- Added a new `DeepBook Predict` docs section under onchain finance
- Documented the protocol overview, design, contract information, oracle lifecycle, manager model, market keys, registry, and vault/PLP flows
- Wired the new section into the docs sidebar
- Based the content on the `predict-testnet-4-16` DeepBookV3 package branch and current testnet deployment targets

## Testing
- Validated the new MDX files and sidebar entries with a custom import/link check
- Verified the sidebar file parses with `node --check`
- Full Docusaurus build was not run because `docs/site/node_modules` is not present in this worktree