### PR TITLE
kv rpc: configure watermark pipelines

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/src/lib.rs
+++ b/crates/sui-indexer-alt-e2e-tests/src/lib.rs
@@ -48,6 +48,7 @@ use sui_indexer_alt_reader::fullnode_client::FullnodeArgs;
 use sui_indexer_alt_reader::kv_loader::KvArgs;
 use sui_indexer_alt_reader::system_package_task::SystemPackageTaskArgs;
 use sui_kv_rpc::KvRpcServer;
+use sui_kvstore::ALL_PIPELINE_NAMES;
 use sui_kvstore::BigTableClient;
 use sui_kvstore::BigTableIndexer;
 use sui_kvstore::BigTableStore;
@@ -718,12 +719,16 @@ impl OffchainCluster {
             let mut interval = interval(Duration::from_millis(200));
             loop {
                 interval.tick().await;
-                if client.get_watermark().await.is_ok_and(|wm| {
-                    wm.is_some_and(|wm| {
-                        wm.checkpoint_hi_inclusive
-                            .is_some_and(|cp| cp >= checkpoint)
+                if client
+                    .get_watermark_for_pipelines(&ALL_PIPELINE_NAMES)
+                    .await
+                    .is_ok_and(|wm| {
+                        wm.is_some_and(|wm| {
+                            wm.checkpoint_hi_inclusive
+                                .is_some_and(|cp| cp >= checkpoint)
+                        })
                     })
-                }) {
+                {
                     break;
                 }
             }

--- a/crates/sui-indexer-alt-reader/src/bigtable_reader.rs
+++ b/crates/sui-indexer-alt-reader/src/bigtable_reader.rs
@@ -10,16 +10,26 @@ use anyhow::bail;
 use async_graphql::dataloader::DataLoader;
 use prometheus::Registry;
 use sui_kvstore::BigTableClient;
+use sui_kvstore::CHECKPOINTS_PIPELINE;
 use sui_kvstore::CheckpointData;
 use sui_kvstore::KeyValueStoreReader;
+use sui_kvstore::OBJECTS_PIPELINE;
+use sui_kvstore::TRANSACTIONS_PIPELINE;
 use sui_kvstore::TransactionData;
 use sui_kvstore::TransactionEventsData;
 use sui_kvstore::WatermarkV1;
+use sui_kvstore::validate_pipeline_name;
 use sui_types::digests::TransactionDigest;
 use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 use sui_types::object::Object;
 use sui_types::storage::ObjectKey;
 use tracing::warn;
+
+const DEFAULT_BIGTABLE_WATERMARK_PIPELINES: [&str; 3] = [
+    CHECKPOINTS_PIPELINE,
+    TRANSACTIONS_PIPELINE,
+    OBJECTS_PIPELINE,
+];
 
 #[derive(clap::Args, Debug, Clone, Default)]
 pub struct BigtableArgs {
@@ -38,6 +48,16 @@ pub struct BigtableArgs {
     /// Maximum gRPC decoding message size for Bigtable responses, in bytes.
     #[arg(long)]
     pub bigtable_max_decoding_message_size: Option<usize>,
+
+    /// Pipeline watermark to include when reporting the BigTable reader watermark. Repeat to
+    /// include multiple pipelines.
+    #[arg(
+        long,
+        value_name = "PIPELINE",
+        value_delimiter = ',',
+        value_parser = validate_pipeline_name
+    )]
+    pub bigtable_watermark_pipeline: Vec<&'static str>,
 }
 
 /// A reader backed by BigTable KV store.
@@ -45,7 +65,10 @@ pub struct BigtableArgs {
 /// In order to use this reader, the environment variable `GOOGLE_APPLICATION_CREDENTIALS` must be
 /// set to the path of the credentials file.
 #[derive(Clone)]
-pub struct BigtableReader(BigTableClient);
+pub struct BigtableReader {
+    client: BigTableClient,
+    watermark_pipelines: Vec<&'static str>,
+}
 
 impl BigtableArgs {
     pub fn statement_timeout(&self) -> Option<Duration> {
@@ -72,8 +95,14 @@ impl BigtableReader {
         }
 
         let timeout = bigtable_args.statement_timeout();
-        Ok(Self(
-            BigTableClient::new_remote(
+        let watermark_pipelines = if bigtable_args.bigtable_watermark_pipeline.is_empty() {
+            DEFAULT_BIGTABLE_WATERMARK_PIPELINES.to_vec()
+        } else {
+            bigtable_args.bigtable_watermark_pipeline
+        };
+
+        Ok(Self {
+            client: BigTableClient::new_remote(
                 instance_id,
                 bigtable_args.bigtable_project,
                 true,
@@ -86,7 +115,8 @@ impl BigtableReader {
             )
             .await
             .context("Failed to create BigTable client")?,
-        ))
+            watermark_pipelines,
+        })
     }
 
     /// Create a data loader backed by this reader.
@@ -94,9 +124,9 @@ impl BigtableReader {
         DataLoader::new(self.clone(), tokio::spawn)
     }
 
-    /// Get the watermark representing the minimum across all pipeline watermarks.
+    /// Get the configured BigTable reader watermark.
     pub async fn watermark(&self) -> anyhow::Result<Option<WatermarkV1>> {
-        measure("watermark", &(), self.0.clone().get_watermark()).await
+        self.watermark_for_pipeline(&self.watermark_pipelines).await
     }
 
     /// Get the minimum watermark across the specified pipelines.
@@ -107,7 +137,7 @@ impl BigtableReader {
         measure(
             "watermark",
             &(),
-            self.0.clone().get_watermark_for_pipelines(pipelines),
+            self.client.clone().get_watermark_for_pipelines(pipelines),
         )
         .await
     }
@@ -117,7 +147,12 @@ impl BigtableReader {
         &self,
         keys: &[CheckpointSequenceNumber],
     ) -> anyhow::Result<Vec<CheckpointData>> {
-        measure("checkpoints", &keys, self.0.clone().get_checkpoints(keys)).await
+        measure(
+            "checkpoints",
+            &keys,
+            self.client.clone().get_checkpoints(keys),
+        )
+        .await
     }
 
     /// Multi-get transactions by transaction digest.
@@ -125,12 +160,17 @@ impl BigtableReader {
         &self,
         keys: &[TransactionDigest],
     ) -> anyhow::Result<Vec<TransactionData>> {
-        measure("transactions", &keys, self.0.clone().get_transactions(keys)).await
+        measure(
+            "transactions",
+            &keys,
+            self.client.clone().get_transactions(keys),
+        )
+        .await
     }
 
     /// Multi-get objects by object ID and version.
     pub(crate) async fn objects(&self, keys: &[ObjectKey]) -> anyhow::Result<Vec<Object>> {
-        measure("objects", &keys, self.0.clone().get_objects(keys)).await
+        measure("objects", &keys, self.client.clone().get_objects(keys)).await
     }
 
     // Multi-get events from transactions.
@@ -141,7 +181,7 @@ impl BigtableReader {
         measure(
             "events",
             &keys,
-            self.0.clone().get_events_for_transactions(keys),
+            self.client.clone().get_events_for_transactions(keys),
         )
         .await
     }

--- a/crates/sui-indexer-alt-reader/src/kv_loader.rs
+++ b/crates/sui-indexer-alt-reader/src/kv_loader.rs
@@ -10,6 +10,7 @@ use prometheus::Registry;
 use sui_indexer_alt_schema::transactions::StoredTransaction;
 use sui_kvstore::TransactionData as KVTransactionData;
 use sui_kvstore::TransactionEventsData as KVTransactionEventsData;
+use sui_kvstore::validate_pipeline_name;
 use sui_rpc::proto::sui::rpc::v2 as grpc;
 use sui_types::balance_change::BalanceChange as NativeBalanceChange;
 use sui_types::base_types::ObjectID;
@@ -64,6 +65,16 @@ pub struct KvArgs {
     /// Applies to both Bigtable and Ledger gRPC readers.
     #[arg(long, alias = "bigtable-max-decoding-message-size")]
     pub kv_max_decoding_message_size: Option<usize>,
+
+    /// Bigtable pipeline watermark to include when reporting the Bigtable reader watermark.
+    /// Repeat to include multiple pipelines.
+    #[arg(
+        long = "bigtable-watermark-pipeline",
+        value_name = "PIPELINE",
+        value_delimiter = ',',
+        value_parser = validate_pipeline_name
+    )]
+    pub bigtable_watermark_pipeline: Vec<&'static str>,
 
     /// gRPC endpoint URL for the ledger service (e.g., archive.mainnet.sui.io)
     #[arg(long, group = "kv_source")]
@@ -176,6 +187,7 @@ impl KvArgs {
             bigtable_project: self.bigtable_project.clone(),
             bigtable_app_profile_id: self.bigtable_app_profile_id.clone(),
             bigtable_max_decoding_message_size: self.kv_max_decoding_message_size,
+            bigtable_watermark_pipeline: self.bigtable_watermark_pipeline.clone(),
         }
     }
 

--- a/crates/sui-kv-rpc/src/lib.rs
+++ b/crates/sui-kv-rpc/src/lib.rs
@@ -4,10 +4,17 @@
 use std::net::SocketAddr;
 use std::sync::Arc;
 
+use anyhow::ensure;
 use prometheus::Registry;
 use sui_kvstore::BigTableClient;
+use sui_kvstore::CHECKPOINTS_BY_DIGEST_PIPELINE;
+use sui_kvstore::CHECKPOINTS_PIPELINE;
+use sui_kvstore::EPOCH_END_PIPELINE;
+use sui_kvstore::EPOCH_START_PIPELINE;
 use sui_kvstore::KeyValueStoreReader;
+use sui_kvstore::OBJECTS_PIPELINE;
 pub use sui_kvstore::PoolConfig;
+use sui_kvstore::TRANSACTIONS_PIPELINE;
 use sui_package_resolver::PackageStore;
 use sui_package_resolver::PackageStoreWithLruCache;
 use sui_package_resolver::Resolver;
@@ -29,6 +36,15 @@ mod v2;
 
 use package_store::BigTablePackageStore;
 
+pub const DEFAULT_SERVICE_INFO_WATERMARK_PIPELINES: [&str; 6] = [
+    CHECKPOINTS_PIPELINE,
+    CHECKPOINTS_BY_DIGEST_PIPELINE,
+    TRANSACTIONS_PIPELINE,
+    OBJECTS_PIPELINE,
+    EPOCH_START_PIPELINE,
+    EPOCH_END_PIPELINE,
+];
+
 pub type PackageResolver = Arc<Resolver<Arc<dyn PackageStore>>>;
 
 #[derive(Clone)]
@@ -37,6 +53,7 @@ pub struct KvRpcServer {
     client: BigTableClient,
     server_version: Option<ServerVersion>,
     checkpoint_bucket: Option<String>,
+    service_info_watermark_pipelines: Vec<&'static str>,
     cache: Arc<RwLock<Option<GetServiceInfoResponse>>>,
     package_resolver: PackageResolver,
 }
@@ -60,6 +77,7 @@ impl KvRpcServer {
         registry: &Registry,
         credentials_path: Option<String>,
         pool_config: PoolConfig,
+        service_info_watermark_pipelines: Vec<&'static str>,
     ) -> anyhow::Result<Self> {
         let mut client = BigTableClient::new_remote_with_credentials(
             instance_id,
@@ -81,12 +99,13 @@ impl KvRpcServer {
             .expect("failed to fetch genesis checkpoint from the KV store");
         let summary = genesis.summary.expect("genesis checkpoint missing summary");
         let chain_id = ChainIdentifier::from(summary.digest());
-        Ok(Self::init(
+        Self::init(
             client,
             chain_id,
             server_version,
             checkpoint_bucket,
-        ))
+            service_info_watermark_pipelines,
+        )
     }
 
     /// Construct a KvRpcServer backed by a local BigTable emulator.
@@ -97,12 +116,13 @@ impl KvRpcServer {
         checkpoint_bucket: Option<String>,
     ) -> anyhow::Result<Self> {
         let client = BigTableClient::new_local(host, instance_id).await?;
-        Ok(Self::init(
+        Self::init(
             client,
             ChainIdentifier::from(sui_types::digests::CheckpointDigest::default()),
             server_version,
             checkpoint_bucket,
-        ))
+            DEFAULT_SERVICE_INFO_WATERMARK_PIPELINES.to_vec(),
+        )
     }
 
     fn init(
@@ -110,7 +130,13 @@ impl KvRpcServer {
         chain_id: ChainIdentifier,
         server_version: Option<ServerVersion>,
         checkpoint_bucket: Option<String>,
-    ) -> Self {
+        service_info_watermark_pipelines: Vec<&'static str>,
+    ) -> anyhow::Result<Self> {
+        ensure!(
+            !service_info_watermark_pipelines.is_empty(),
+            "at least one service info watermark pipeline must be configured"
+        );
+
         let cache = Arc::new(RwLock::new(None));
 
         let package_store: Arc<dyn PackageStore> = Arc::new(PackageStoreWithLruCache::new(
@@ -123,6 +149,7 @@ impl KvRpcServer {
             client,
             server_version,
             checkpoint_bucket,
+            service_info_watermark_pipelines,
             cache,
             package_resolver,
         };
@@ -134,6 +161,7 @@ impl KvRpcServer {
                     server_clone.client.clone(),
                     server_clone.chain_id,
                     server_clone.server_version.clone(),
+                    &server_clone.service_info_watermark_pipelines,
                 )
                 .await
                 {
@@ -147,7 +175,7 @@ impl KvRpcServer {
             }
         });
 
-        server
+        Ok(server)
     }
 
     /// Start this server as a tonic gRPC service on the given address.

--- a/crates/sui-kv-rpc/src/main.rs
+++ b/crates/sui-kv-rpc/src/main.rs
@@ -1,14 +1,21 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::time::Duration;
+
 use anyhow::Result;
 use axum::Router;
 use axum::routing::get;
 use clap::Parser;
 use prometheus::Registry;
-use std::time::Duration;
-use sui_kv_rpc::{KvRpcServer, PoolConfig, ServerConfig};
+use sui_kv_rpc::DEFAULT_SERVICE_INFO_WATERMARK_PIPELINES;
+use sui_kv_rpc::KvRpcServer;
+use sui_kv_rpc::PoolConfig;
+use sui_kv_rpc::ServerConfig;
+use sui_kvstore::validate_pipeline_name;
 use sui_rpc_api::ServerVersion;
+use telemetry_subscribers::TelemetryConfig;
+use tonic::transport::Identity;
 
 #[derive(Parser)]
 struct PoolArgs {
@@ -33,8 +40,6 @@ impl From<PoolArgs> for PoolConfig {
         }
     }
 }
-use telemetry_subscribers::TelemetryConfig;
-use tonic::transport::Identity;
 
 bin_version::bin_version!();
 
@@ -62,6 +67,15 @@ struct App {
     app_profile_id: Option<String>,
     #[clap(long = "checkpoint-bucket")]
     checkpoint_bucket: Option<String>,
+    /// Pipeline watermark to include when reporting GetServiceInfo checkpoint height. Repeat to
+    /// include multiple pipelines.
+    #[clap(
+        long = "watermark-pipeline",
+        value_name = "PIPELINE",
+        value_delimiter = ',',
+        value_parser = validate_pipeline_name
+    )]
+    watermark_pipeline: Vec<&'static str>,
     /// Channel-level timeout in milliseconds for BigTable gRPC calls (default: 60000)
     #[clap(long = "bigtable-channel-timeout-ms")]
     bigtable_channel_timeout_ms: Option<u64>,
@@ -88,6 +102,11 @@ async fn main() -> Result<()> {
     mysten_metrics::init_metrics(&registry);
     let channel_timeout = app.bigtable_channel_timeout_ms.map(Duration::from_millis);
     let pool_config: PoolConfig = app.pool.into();
+    let service_info_watermark_pipelines = if app.watermark_pipeline.is_empty() {
+        DEFAULT_SERVICE_INFO_WATERMARK_PIPELINES.to_vec()
+    } else {
+        app.watermark_pipeline
+    };
 
     let server = KvRpcServer::new(
         app.instance_id,
@@ -99,6 +118,7 @@ async fn main() -> Result<()> {
         &registry,
         app.credentials,
         pool_config,
+        service_info_watermark_pipelines,
     )
     .await?;
 

--- a/crates/sui-kv-rpc/src/v2/mod.rs
+++ b/crates/sui-kv-rpc/src/v2/mod.rs
@@ -57,6 +57,7 @@ impl LedgerService for KvRpcServer {
             self.client.clone(),
             self.chain_id,
             self.server_version.clone(),
+            &self.service_info_watermark_pipelines,
         )
         .await
         .map(tonic::Response::new)
@@ -152,8 +153,12 @@ pub(crate) async fn get_service_info(
     mut client: BigTableClient,
     chain_id: ChainIdentifier,
     server_version: Option<ServerVersion>,
+    watermark_pipelines: &[&str],
 ) -> Result<GetServiceInfoResponse, RpcError> {
-    let Some(wm) = client.get_watermark().await? else {
+    let Some(wm) = client
+        .get_watermark_for_pipelines(watermark_pipelines)
+        .await?
+    else {
         return Err(CheckpointNotFoundError::sequence_number(0).into());
     };
     let Some(checkpoint_hi_inclusive) = wm.checkpoint_hi_inclusive else {

--- a/crates/sui-kvstore/src/bigtable/client/mod.rs
+++ b/crates/sui-kvstore/src/bigtable/client/mod.rs
@@ -12,6 +12,7 @@ use std::time::Instant;
 
 use anyhow::Context as _;
 use anyhow::Result;
+use anyhow::bail;
 use async_trait::async_trait;
 use bytes::Bytes;
 use gcp_auth::TokenProvider;
@@ -945,6 +946,10 @@ impl KeyValueStoreReader for BigTableClient {
         &mut self,
         pipelines: &[&str],
     ) -> Result<Option<WatermarkV1>> {
+        if pipelines.is_empty() {
+            bail!("at least one watermark pipeline must be provided");
+        }
+
         let keys: Vec<Vec<u8>> = pipelines
             .iter()
             .map(|name| tables::watermarks::encode_key(name))

--- a/crates/sui-kvstore/src/lib.rs
+++ b/crates/sui-kvstore/src/lib.rs
@@ -105,6 +105,19 @@ pub const ALL_PIPELINE_NAMES: [&str; 11] = [
     SYSTEM_PACKAGES_PIPELINE,
 ];
 
+pub fn validate_pipeline_name(value: &str) -> Result<&'static str, String> {
+    ALL_PIPELINE_NAMES
+        .iter()
+        .copied()
+        .find(|name| *name == value)
+        .ok_or_else(|| {
+            format!(
+                "unknown pipeline `{value}`; expected one of: {}",
+                ALL_PIPELINE_NAMES.join(", ")
+            )
+        })
+}
+
 static WRITE_LEGACY_DATA: OnceLock<bool> = OnceLock::new();
 
 /// Set whether to write legacy data (deprecated combined tx column).
@@ -254,10 +267,6 @@ pub trait KeyValueStoreReader {
         &mut self,
         pipelines: &[&str],
     ) -> Result<Option<WatermarkV1>>;
-    /// Return the minimum watermark across all pipelines.
-    async fn get_watermark(&mut self) -> Result<Option<WatermarkV1>> {
-        self.get_watermark_for_pipelines(&ALL_PIPELINE_NAMES).await
-    }
     async fn get_latest_object(&mut self, object_id: &ObjectID) -> Result<Option<Object>>;
     async fn get_epoch(&mut self, epoch_id: EpochId) -> Result<Option<EpochData>>;
     async fn get_latest_epoch(&mut self) -> Result<Option<EpochData>>;

--- a/crates/sui-kvstore/tests/e2e.rs
+++ b/crates/sui-kvstore/tests/e2e.rs
@@ -21,6 +21,7 @@ use sui_indexer_alt_framework::ingestion::ingestion_client::IngestionClientArgs;
 use sui_indexer_alt_framework::ingestion::streaming_client::StreamingClientArgs;
 use sui_indexer_alt_framework::pipeline::CommitterConfig;
 use sui_keys::keystore::AccountKeystore;
+use sui_kvstore::ALL_PIPELINE_NAMES;
 use sui_kvstore::BigTableClient;
 use sui_kvstore::BigTableIndexer;
 use sui_kvstore::BigTableStore;
@@ -229,13 +230,17 @@ impl TestHarness {
             let mut interval = interval(Duration::from_millis(100));
             loop {
                 interval.tick().await;
-                let ok = self.client.get_watermark().await.is_ok_and(|wm| {
-                    wm.is_some_and(|wm| {
-                        wm.checkpoint_hi_inclusive
-                            .is_some_and(|cp| cp >= checkpoint)
-                            && wm.epoch_hi_inclusive >= epoch
-                    })
-                });
+                let ok = self
+                    .client
+                    .get_watermark_for_pipelines(&ALL_PIPELINE_NAMES)
+                    .await
+                    .is_ok_and(|wm| {
+                        wm.is_some_and(|wm| {
+                            wm.checkpoint_hi_inclusive
+                                .is_some_and(|cp| cp >= checkpoint)
+                                && wm.epoch_hi_inclusive >= epoch
+                        })
+                    });
                 if ok {
                     break;
                 }

--- a/crates/sui-kvstore/tests/watermarks.rs
+++ b/crates/sui-kvstore/tests/watermarks.rs
@@ -458,6 +458,15 @@ async fn test_get_watermark_for_pipelines_hides_init_none() -> Result<()> {
 }
 
 #[tokio::test]
+async fn test_get_watermark_for_pipelines_rejects_empty_input() -> Result<()> {
+    let harness = WatermarkHarness::new().await?;
+    let err = harness.read_watermark(&[]).await.unwrap_err();
+
+    assert!(err.to_string().contains("at least one watermark pipeline"));
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_get_watermark_for_pipelines_hides_below_reader_lo() -> Result<()> {
     // A row with a real checkpoint becomes hidden once `reader_lo` is raised past it.
     let harness = WatermarkHarness::new().await?;


### PR DESCRIPTION
## Description

Currently the watermark reading code defaults to the minimum all pipelines when you don't pass in the pipelines you care about. This makes it hard to add new pipelines because they will be lagging while they are backfilled. With this change, the watermark reader errors if you don't explicitly define the pipelines you care about. sui-kv-rpc defaults to the pipelines it currently reads at this moment in time. Once this change lands in mainnet, I will update to pulumi to pass these pipelines as cli args, and remove the default. Then when the new bitmap pipelines are backfilled, I will add them to the watermark check when enabling those rpc APIs in the archival service. 

The BigTableReader which is used by jsonrpc-alt (and formerly by graphql) just defaults to the 3 tables it can read from. This will be deprecated soon, so I won't bother actually updating pulumi for those services.
