### PR TITLE
kvstore: add tx seq digest pipeline

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/src/lib.rs
+++ b/crates/sui-indexer-alt-e2e-tests/src/lib.rs
@@ -848,6 +848,7 @@ async fn start_archival(
         BtIndexerConfig::default(),
         PipelineLayer::default(),
         Chain::Unknown,
+        &[],
         registry,
     )
     .await

--- a/crates/sui-indexer-alt-e2e-tests/src/lib.rs
+++ b/crates/sui-indexer-alt-e2e-tests/src/lib.rs
@@ -49,6 +49,7 @@ use sui_indexer_alt_reader::kv_loader::KvArgs;
 use sui_indexer_alt_reader::system_package_task::SystemPackageTaskArgs;
 use sui_kv_rpc::KvRpcServer;
 use sui_kvstore::ALL_PIPELINE_NAMES;
+use sui_kvstore::ALPHA_PIPELINE_NAMES;
 use sui_kvstore::BigTableClient;
 use sui_kvstore::BigTableIndexer;
 use sui_kvstore::BigTableStore;
@@ -848,7 +849,7 @@ async fn start_archival(
         BtIndexerConfig::default(),
         PipelineLayer::default(),
         Chain::Unknown,
-        &[],
+        &ALPHA_PIPELINE_NAMES,
         registry,
     )
     .await

--- a/crates/sui-kvstore/src/bigtable/client/mod.rs
+++ b/crates/sui-kvstore/src/bigtable/client/mod.rs
@@ -4,6 +4,7 @@
 mod auth_channel;
 mod channel_pool;
 
+use std::collections::HashMap;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -40,6 +41,7 @@ use crate::PackageData;
 use crate::ProtocolConfigData;
 use crate::TransactionData;
 use crate::TransactionEventsData;
+use crate::TxSeqDigestData;
 use crate::WatermarkV0;
 use crate::WatermarkV1;
 use crate::bigtable::metrics::KvMetrics;
@@ -65,6 +67,7 @@ use crate::bigtable::proto::bigtable::v2::row_range::EndKey;
 use crate::bigtable::proto::bigtable::v2::row_range::StartKey;
 use crate::bigtable::proto::bigtable::v2::value_range;
 use crate::tables;
+use crate::tables::tx_seq_digest;
 
 const DEFAULT_MAX_DECODING_MESSAGE_SIZE: usize = 32 * 1024 * 1024;
 // TODO: Add per-method timeouts (e.g. separate write vs read) via tonic::Request::set_timeout().
@@ -891,6 +894,46 @@ impl BigTableClient {
             ..ReadRowsRequest::default()
         };
         self.read_rows(request, table_name).await
+    }
+
+    /// Resolve tx_sequence_numbers to tx digest mapping rows
+    /// via a single `multi_get` on the `tx_seq_digest` table.
+    ///
+    /// Returns a vector parallel to the input: `None` for any tx_seq that has
+    /// no row (e.g. not yet indexed).
+    pub async fn resolve_tx_digests(
+        &mut self,
+        tx_sequence_numbers: &[u64],
+    ) -> Result<Vec<Option<TxSeqDigestData>>> {
+        if tx_sequence_numbers.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let keys: Vec<Vec<u8>> = tx_sequence_numbers
+            .iter()
+            .map(|s| tx_seq_digest::encode_key(*s))
+            .collect();
+
+        let rows = self.multi_get(tx_seq_digest::NAME, keys, None).await?;
+
+        let mut by_seq: HashMap<u64, TxSeqDigestData> = HashMap::with_capacity(rows.len());
+        for (row_key, cells) in &rows {
+            let tx_seq = tx_seq_digest::decode_key(row_key.as_ref())?;
+            let (digest, event_count) = tx_seq_digest::decode(cells)?;
+            by_seq.insert(
+                tx_seq,
+                TxSeqDigestData {
+                    tx_sequence_number: tx_seq,
+                    digest,
+                    event_count,
+                },
+            );
+        }
+
+        Ok(tx_sequence_numbers
+            .iter()
+            .map(|s| by_seq.get(s).copied())
+            .collect())
     }
 }
 

--- a/crates/sui-kvstore/src/bigtable/init.sh
+++ b/crates/sui-kvstore/src/bigtable/init.sh
@@ -12,7 +12,7 @@ fi
 
 for table in checkpoints checkpoints_by_digest transactions objects epochs \
     watermark_alt protocol_configs packages packages_by_id \
-    packages_by_checkpoint system_packages; do
+    packages_by_checkpoint system_packages tx_seq_digest; do
   (
     set -x
     "${command[@]}" createtable $table

--- a/crates/sui-kvstore/src/bin/sui-kvstore-alt.rs
+++ b/crates/sui-kvstore/src/bin/sui-kvstore-alt.rs
@@ -15,6 +15,7 @@ use sui_kvstore::BigTableClient;
 use sui_kvstore::BigTableIndexer;
 use sui_kvstore::BigTableStore;
 use sui_kvstore::IndexerConfig;
+use sui_kvstore::parse_alpha_pipeline_name;
 use sui_kvstore::set_write_legacy_data;
 use sui_protocol_config::Chain;
 use telemetry_subscribers::TelemetryConfig;
@@ -51,6 +52,10 @@ struct Args {
     #[arg(long)]
     write_legacy_data: bool,
 
+    /// Enable an alpha pipeline by framework pipeline name. Repeat to enable multiple pipelines.
+    #[arg(long = "enable-alpha-pipeline", value_name = "PIPELINE_NAME", value_parser = parse_alpha_pipeline_name)]
+    enable_alpha_pipelines: Vec<&'static str>,
+
     #[command(flatten)]
     metrics_args: MetricsArgs,
 
@@ -83,10 +88,12 @@ async fn main() -> Result<()> {
 
     let is_bounded = args.indexer_args.last_checkpoint.is_some();
     set_write_legacy_data(args.write_legacy_data);
+    let alpha_pipelines = args.enable_alpha_pipelines;
 
     info!("Starting sui-kvstore-alt indexer");
     info!(instance_id = %args.instance_id);
     info!("Config: {:#?}", config);
+    info!(?alpha_pipelines, "Enabled alpha pipelines");
 
     let channel_timeout = config
         .bigtable_channel_timeout_ms
@@ -127,6 +134,7 @@ async fn main() -> Result<()> {
         indexer_config,
         config.pipeline,
         args.chain,
+        &alpha_pipelines,
         &registry,
     )
     .await?;

--- a/crates/sui-kvstore/src/config.rs
+++ b/crates/sui-kvstore/src/config.rs
@@ -197,6 +197,7 @@ pub struct PipelineLayer {
     pub packages_by_id: ConcurrentLayer,
     pub packages_by_checkpoint: ConcurrentLayer,
     pub system_packages: ConcurrentLayer,
+    pub tx_seq_digest: ConcurrentLayer,
 }
 
 /// This type is identical to [`framework::ingestion::IngestionConfig`], but is set-up to be

--- a/crates/sui-kvstore/src/handlers/mod.rs
+++ b/crates/sui-kvstore/src/handlers/mod.rs
@@ -13,6 +13,7 @@ pub use packages_by_id::PackagesByIdPipeline;
 pub use protocol_configs::ProtocolConfigsPipeline;
 pub use system_packages::SystemPackagesPipeline;
 pub use transactions::TransactionsPipeline;
+pub use tx_seq_digest::TxSeqDigestPipeline;
 
 mod checkpoints;
 mod checkpoints_by_digest;
@@ -26,3 +27,4 @@ mod packages_by_id;
 mod protocol_configs;
 mod system_packages;
 mod transactions;
+mod tx_seq_digest;

--- a/crates/sui-kvstore/src/handlers/tx_seq_digest.rs
+++ b/crates/sui-kvstore/src/handlers/tx_seq_digest.rs
@@ -1,0 +1,52 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use sui_indexer_alt_framework::pipeline::Processor;
+use sui_types::full_checkpoint_content::Checkpoint;
+
+use crate::bigtable::proto::bigtable::v2::mutate_rows_request::Entry;
+use crate::tables;
+
+use super::handler::BigTableProcessor;
+
+/// Pipeline that writes one row per transaction keyed by tx_sequence_number,
+/// mapping each tx_seq to its `(TransactionDigest, event_count)`.
+pub struct TxSeqDigestPipeline;
+
+#[async_trait::async_trait]
+impl Processor for TxSeqDigestPipeline {
+    const NAME: &'static str = "kvstore_tx_seq_digest";
+    type Value = Entry;
+
+    async fn process(&self, checkpoint: &Arc<Checkpoint>) -> anyhow::Result<Vec<Self::Value>> {
+        let cp = checkpoint.summary.data();
+        // network_total_transactions is cumulative *including* this checkpoint,
+        // so tx_lo is the first tx_seq in this checkpoint.
+        let tx_lo = cp.network_total_transactions - checkpoint.transactions.len() as u64;
+        let timestamp_ms = cp.timestamp_ms;
+
+        let entries = checkpoint
+            .transactions
+            .iter()
+            .enumerate()
+            .map(|(i, tx)| {
+                let tx_seq = tx_lo + i as u64;
+                let digest = tx.transaction.digest();
+                let event_count = tx.events.as_ref().map(|e| e.data.len() as u32).unwrap_or(0);
+                tables::make_entry(
+                    tables::tx_seq_digest::encode_key(tx_seq),
+                    tables::tx_seq_digest::encode(&digest, event_count),
+                    Some(timestamp_ms),
+                )
+            })
+            .collect();
+
+        Ok(entries)
+    }
+}
+
+impl BigTableProcessor for TxSeqDigestPipeline {
+    const TABLE: &'static str = tables::tx_seq_digest::NAME;
+}

--- a/crates/sui-kvstore/src/lib.rs
+++ b/crates/sui-kvstore/src/lib.rs
@@ -58,6 +58,7 @@ pub use crate::handlers::PackagesPipeline;
 pub use crate::handlers::ProtocolConfigsPipeline;
 pub use crate::handlers::SystemPackagesPipeline;
 pub use crate::handlers::TransactionsPipeline;
+pub use crate::handlers::TxSeqDigestPipeline;
 pub use crate::store::BigTableConnection;
 pub use crate::store::BigTableStore;
 pub use config::BigtablePoolLayer;
@@ -89,9 +90,13 @@ pub const PACKAGES_BY_CHECKPOINT_PIPELINE: &str =
     <BigTableHandler<PackagesByCheckpointPipeline> as sui_indexer_alt_framework::pipeline::Processor>::NAME;
 pub const SYSTEM_PACKAGES_PIPELINE: &str =
     <BigTableHandler<SystemPackagesPipeline> as sui_indexer_alt_framework::pipeline::Processor>::NAME;
+pub const TX_SEQ_DIGEST_PIPELINE: &str =
+    <BigTableHandler<TxSeqDigestPipeline> as sui_indexer_alt_framework::pipeline::Processor>::NAME;
 
-/// All pipeline names registered by the indexer.
-pub const ALL_PIPELINE_NAMES: [&str; 11] = [
+pub const ALPHA_PIPELINE_NAMES: [&str; 1] = [TX_SEQ_DIGEST_PIPELINE];
+
+/// All pipeline names known to the indexer.
+pub const ALL_PIPELINE_NAMES: [&str; 12] = [
     CHECKPOINTS_PIPELINE,
     CHECKPOINTS_BY_DIGEST_PIPELINE,
     TRANSACTIONS_PIPELINE,
@@ -103,6 +108,7 @@ pub const ALL_PIPELINE_NAMES: [&str; 11] = [
     PACKAGES_BY_ID_PIPELINE,
     PACKAGES_BY_CHECKPOINT_PIPELINE,
     SYSTEM_PACKAGES_PIPELINE,
+    TX_SEQ_DIGEST_PIPELINE,
 ];
 
 pub fn validate_pipeline_name(value: &str) -> Result<&'static str, String> {
@@ -114,6 +120,19 @@ pub fn validate_pipeline_name(value: &str) -> Result<&'static str, String> {
             format!(
                 "unknown pipeline `{value}`; expected one of: {}",
                 ALL_PIPELINE_NAMES.join(", ")
+            )
+        })
+}
+
+pub fn parse_alpha_pipeline_name(value: &str) -> Result<&'static str, String> {
+    ALPHA_PIPELINE_NAMES
+        .iter()
+        .copied()
+        .find(|name| *name == value)
+        .ok_or_else(|| {
+            format!(
+                "unknown alpha pipeline `{value}`; expected one of: {}",
+                ALPHA_PIPELINE_NAMES.join(", ")
             )
         })
 }
@@ -170,6 +189,13 @@ impl TransactionData {
 pub struct TransactionEventsData {
     pub events: Vec<Event>,
     pub timestamp_ms: u64,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct TxSeqDigestData {
+    pub tx_sequence_number: u64,
+    pub digest: TransactionDigest,
+    pub event_count: u32,
 }
 
 /// Epoch data returned by reader methods.
@@ -337,6 +363,7 @@ impl BigTableIndexer {
         config: IndexerConfig,
         pipeline: PipelineLayer,
         chain: Chain,
+        alpha_pipelines: &[&str],
         registry: &Registry,
     ) -> Result<Self> {
         let mut indexer = Indexer::new(
@@ -483,6 +510,18 @@ impl BigTableIndexer {
                 pipeline.system_packages.finish(base.clone()),
             )
             .await?;
+        if alpha_pipelines.contains(&TX_SEQ_DIGEST_PIPELINE) {
+            indexer
+                .concurrent_pipeline(
+                    BigTableHandler::new(
+                        TxSeqDigestPipeline,
+                        &pipeline.tx_seq_digest,
+                        build_rate_limiter(&pipeline.tx_seq_digest, base_rps, &global),
+                    ),
+                    pipeline.tx_seq_digest.finish(base.clone()),
+                )
+                .await?;
+        }
 
         Ok(Self { indexer })
     }

--- a/crates/sui-kvstore/src/tables/mod.rs
+++ b/crates/sui-kvstore/src/tables/mod.rs
@@ -26,6 +26,7 @@ pub mod packages_by_id;
 pub mod protocol_configs;
 pub mod system_packages;
 pub mod transactions;
+pub mod tx_seq_digest;
 pub mod watermarks;
 
 /// Column family name used by all tables.

--- a/crates/sui-kvstore/src/tables/tx_seq_digest.rs
+++ b/crates/sui-kvstore/src/tables/tx_seq_digest.rs
@@ -1,0 +1,157 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Direct mapping from `tx_sequence_number → (TransactionDigest, event_count)`.
+//!
+//! Row key layout: `[salt_u8][tx_seq_be_u64]` — 9 bytes, where
+//! `salt_u8 = (tx_seq % SALT_COUNT) as u8`. The salt prefix spreads writes
+//! across `SALT_COUNT` tablet prefixes so an append-only, monotonic
+//! `tx_sequence_number` doesn't funnel every write into a single trailing
+//! tablet. Within a salt bucket rows are still sorted by tx_seq, so point
+//! lookups via `multi_get` and per-shard range scans still work; a full
+//! ascending scan has to fan out across all `SALT_COUNT` buckets and
+//! merge client-side (see `scan_tx_seq_digest_stream`).
+//!
+//! `event_count` lets readers enumerate a transaction's event_seqs without
+//! reading the tx row itself — used by unfiltered event listing to bound
+//! the walk to exactly the events contributing to a page.
+
+use anyhow::{Context, Result};
+use bytes::Bytes;
+use sui_types::digests::TransactionDigest;
+
+pub const NAME: &str = "tx_seq_digest";
+
+/// Number of salt prefix buckets. Power of 2 so `tx_seq % SALT_COUNT` stays cheap.
+/// Writes spread across this many tablet prefixes to avoid the sequential-PK
+/// hotspot from monotonic `tx_sequence_number`. Readers that need strictly
+/// ascending iteration fan out across all `SALT_COUNT` shards and k-way merge.
+/// 64 keeps the page-fill fan-out modest while leaving enough write headroom
+/// to scale without a table rewrite.
+pub const SALT_COUNT: u64 = 64;
+
+pub mod col {
+    /// Raw 32-byte TransactionDigest.
+    pub const DIGEST: &str = "d";
+    /// Big-endian u32 count of events emitted by this transaction.
+    pub const EVENT_COUNT: &str = "e";
+}
+
+/// Row key: `[salt_u8][tx_seq_be_u64]`, where `salt_u8 = (tx_seq % SALT_COUNT) as u8`.
+pub fn encode_key(tx_seq: u64) -> Vec<u8> {
+    let mut k = Vec::with_capacity(9);
+    k.push((tx_seq % SALT_COUNT) as u8);
+    k.extend_from_slice(&tx_seq.to_be_bytes());
+    k
+}
+
+/// Decode a salted row key, validating length and salt-byte consistency.
+pub fn decode_key(key: &[u8]) -> Result<u64> {
+    if key.len() != 9 {
+        anyhow::bail!("tx_seq_digest key not 9 bytes (got {})", key.len());
+    }
+    let tx_seq = u64::from_be_bytes(key[1..].try_into().unwrap());
+    let expected_salt = (tx_seq % SALT_COUNT) as u8;
+    if key[0] != expected_salt {
+        anyhow::bail!(
+            "tx_seq_digest salt byte mismatch: key[0]={} expected={}",
+            key[0],
+            expected_salt
+        );
+    }
+    Ok(tx_seq)
+}
+
+pub fn encode(digest: &TransactionDigest, event_count: u32) -> [(&'static str, Bytes); 2] {
+    [
+        (col::DIGEST, Bytes::from(digest.inner().to_vec())),
+        (
+            col::EVENT_COUNT,
+            Bytes::copy_from_slice(&event_count.to_be_bytes()),
+        ),
+    ]
+}
+
+pub fn decode(cells: &[(Bytes, Bytes)]) -> Result<(TransactionDigest, u32)> {
+    let mut digest: Option<TransactionDigest> = None;
+    let mut event_count: u32 = 0;
+    for (column, value) in cells {
+        if column.as_ref() == col::DIGEST.as_bytes() {
+            let bytes: [u8; 32] = value
+                .as_ref()
+                .try_into()
+                .context("tx_seq_digest digest not 32 bytes")?;
+            digest = Some(TransactionDigest::from(bytes));
+        } else if column.as_ref() == col::EVENT_COUNT.as_bytes() {
+            let bytes: [u8; 4] = value
+                .as_ref()
+                .try_into()
+                .context("tx_seq_digest event_count not 4 bytes")?;
+            event_count = u32::from_be_bytes(bytes);
+        }
+    }
+    Ok((
+        digest.context("tx_seq_digest missing digest column")?,
+        event_count,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encode_key_layout() {
+        for tx_seq in [0u64, 1, 63, 64, 65, 1_000_000, u64::MAX] {
+            let k = encode_key(tx_seq);
+            assert_eq!(k.len(), 9, "key must be 9 bytes for tx_seq={tx_seq}");
+            assert_eq!(
+                k[0],
+                (tx_seq % SALT_COUNT) as u8,
+                "salt byte for tx_seq={tx_seq}"
+            );
+            assert_eq!(&k[1..], &tx_seq.to_be_bytes());
+        }
+    }
+
+    #[test]
+    fn encode_decode_round_trip() {
+        for tx_seq in [0u64, 1, 63, 64, 65, 1_000_000, u64::MAX] {
+            let k = encode_key(tx_seq);
+            let got = decode_key(&k).expect("decode must accept freshly encoded key");
+            assert_eq!(got, tx_seq);
+        }
+    }
+
+    #[test]
+    fn encode_decode_row_round_trip() {
+        let digest = TransactionDigest::new([7; 32]);
+        let event_count = 123_456;
+        let cells = encode(&digest, event_count);
+
+        assert_eq!(cells[1].1.as_ref(), &event_count.to_be_bytes());
+
+        let cells = cells
+            .into_iter()
+            .map(|(column, value)| (Bytes::from_static(column.as_bytes()), value))
+            .collect::<Vec<_>>();
+        let (decoded_digest, decoded_event_count) = decode(&cells).unwrap();
+        assert_eq!(decoded_digest, digest);
+        assert_eq!(decoded_event_count, event_count);
+    }
+
+    #[test]
+    fn decode_key_rejects_wrong_length() {
+        assert!(decode_key(&[0u8; 8]).is_err());
+        assert!(decode_key(&[0u8; 10]).is_err());
+        assert!(decode_key(&[]).is_err());
+    }
+
+    #[test]
+    fn decode_key_rejects_inconsistent_salt() {
+        let tx_seq: u64 = 1_000;
+        let mut k = encode_key(tx_seq);
+        k[0] = k[0].wrapping_add(1);
+        assert!(decode_key(&k).is_err());
+    }
+}

--- a/crates/sui-kvstore/src/testing.rs
+++ b/crates/sui-kvstore/src/testing.rs
@@ -35,6 +35,7 @@ pub const TABLES: &[&str] = &[
     crate::tables::packages_by_id::NAME,
     crate::tables::packages_by_checkpoint::NAME,
     crate::tables::system_packages::NAME,
+    crate::tables::tx_seq_digest::NAME,
 ];
 
 /// A self-contained BigTable emulator process.

--- a/crates/sui-kvstore/tests/e2e.rs
+++ b/crates/sui-kvstore/tests/e2e.rs
@@ -7,6 +7,7 @@
 //! creates the required tables, and tears everything down when done.
 //! Tests require `gcloud`, `cbt`, and the BigTable emulator on PATH.
 
+use std::collections::HashSet;
 use std::time::Duration;
 
 use anyhow::Context;
@@ -28,6 +29,7 @@ use sui_kvstore::BigTableStore;
 use sui_kvstore::IndexerConfig;
 use sui_kvstore::KeyValueStoreReader;
 use sui_kvstore::PipelineLayer;
+use sui_kvstore::TX_SEQ_DIGEST_PIPELINE;
 use sui_kvstore::tables::{checkpoints, epochs, transactions};
 use sui_kvstore::testing::BigTableEmulator;
 use sui_kvstore::testing::INSTANCE_ID;
@@ -174,6 +176,7 @@ impl TestHarness {
             IndexerConfig::default(),
             PipelineLayer::default(),
             Chain::Unknown,
+            &[TX_SEQ_DIGEST_PIPELINE],
             &registry,
         )
         .await
@@ -688,6 +691,40 @@ async fn test_indexer_e2e() -> Result<()> {
     assert!(partial.summary.is_some(), "summary should be present");
     assert!(partial.signatures.is_none(), "signatures should be absent");
     assert!(partial.contents.is_none(), "contents should be absent");
+
+    // -- tx_seq_digest pipeline: verify tx_sequence_number resolution --
+    let mut all_tx_seqs: Vec<u64> = Vec::new();
+    for cp in &checkpoints {
+        let summary = cp.summary.as_ref().unwrap();
+        let contents = cp.contents.as_ref().unwrap();
+        let tx_lo = summary.network_total_transactions - contents.size() as u64;
+        for i in 0..contents.size() {
+            all_tx_seqs.push(tx_lo + i as u64);
+        }
+    }
+    let resolved_digests = harness
+        .bigtable_client()
+        .resolve_tx_digests(&all_tx_seqs)
+        .await?;
+    assert_eq!(
+        resolved_digests.len(),
+        all_tx_seqs.len(),
+        "all tx_sequence_numbers should resolve to digests"
+    );
+    assert!(
+        resolved_digests.iter().all(|r| r.is_some()),
+        "every tx_seq should resolve to Some(TxSeqDigestData)"
+    );
+    let resolved_digest_set: HashSet<_> = resolved_digests
+        .iter()
+        .filter_map(|r| r.map(|data| data.digest))
+        .collect();
+    for d in &tx_digests {
+        assert!(
+            resolved_digest_set.contains(d),
+            "tx_seq_digest pipeline should contain digest {d}"
+        );
+    }
 
     // -- Column-filtered epoch partial reads --
     // Fetch epoch with only small scalar columns — no system_state.


### PR DESCRIPTION
## Description

This adds a pipeline for a new `tx_seq_digest` table that maps a transaction sequence number to it's digest, and event count.

This mapping table is required because the bitmap that is stored in the reverse-index stores transaction sequence numbers, but the transaction contents are keyed by digest in big table.

The event count column is used to avoid over-fetching transaction rows for unfiltered event queries (i.e, if I need to fill a page of size 100 events, I know exactly which transactions to load to get those 100 events). This is just a small optimization to simplify the read path with very little cost/complexity to the write path.

The pipeline is gated behind a new --enable-alpha-pipeline arg so it won't start backfilling until we explicitly enable it in pulumi.

The transaction sequence number key is sequential which was causing hot partition issues when I was backfilling. I was also worried this could surface under heavy chain load, so I "salted" the key across 64 buckets (`seq % 64`) which allows bigtable to rebalance those buckets across nodes. This salting technique enables us to do range queries by performing multiple concurrent reads of each sequential key. We only use this capability for paginated ListEvents/ListTransactions requests with no filters set. I expect that to be a pretty uncommon request pattern, but we have flexibility with the concurrency limits we set on the client side to control big table load for those APIs. 