### PR TITLE
typed-store: strip prefix from tidehunter iterator bounds

### DIFF
--- a/crates/typed-store/src/rocks/mod.rs
+++ b/crates/typed-store/src/rocks/mod.rs
@@ -1145,7 +1145,7 @@ impl<K, V> DBMap<K, V> {
             Storage::TideHunter(db) => match &self.column_family {
                 ColumnFamily::TideHunter((ks, prefix)) => {
                     let mut iter = db.iterator(*ks);
-                    apply_range_bounds(&mut iter, it_lower_bound, it_upper_bound);
+                    apply_range_bounds(&mut iter, it_lower_bound, it_upper_bound, prefix);
                     iter.reverse();
                     Ok(Box::new(transform_th_iterator(
                         iter,
@@ -1829,7 +1829,7 @@ where
             Storage::TideHunter(db) => match &self.column_family {
                 ColumnFamily::TideHunter((ks, prefix)) => {
                     let mut iter = db.iterator(*ks);
-                    apply_range_bounds(&mut iter, lower_bound, upper_bound);
+                    apply_range_bounds(&mut iter, lower_bound, upper_bound, prefix);
                     Box::new(transform_th_iterator(iter, prefix, self.start_iter_timer()))
                 }
                 _ => unreachable!("storage backend invariant violation"),
@@ -1862,7 +1862,7 @@ where
             Storage::TideHunter(db) => match &self.column_family {
                 ColumnFamily::TideHunter((ks, prefix)) => {
                     let mut iter = db.iterator(*ks);
-                    apply_range_bounds(&mut iter, lower_bound, upper_bound);
+                    apply_range_bounds(&mut iter, lower_bound, upper_bound, prefix);
                     Box::new(transform_th_iterator(iter, prefix, self.start_iter_timer()))
                 }
                 _ => unreachable!("storage backend invariant violation"),

--- a/crates/typed-store/src/tidehunter_util.rs
+++ b/crates/typed-store/src/tidehunter_util.rs
@@ -124,12 +124,16 @@ pub(crate) fn apply_range_bounds(
     iterator: &mut DbIterator,
     lower_bound: Option<Vec<u8>>,
     upper_bound: Option<Vec<u8>>,
+    prefix: &Option<Vec<u8>>,
 ) {
+    // Bounds come from `be_fix_int_ser(K)` which still includes the typed-store
+    // length prefix. Tidehunter stores keys with the prefix stripped, so the
+    // bounds must be stripped to match — same transform every other key path uses.
     if let Some(lower_bound) = lower_bound {
-        iterator.set_lower_bound(lower_bound);
+        iterator.set_lower_bound(transform_th_key(&lower_bound, prefix));
     }
     if let Some(upper_bound) = upper_bound {
-        iterator.set_upper_bound(upper_bound);
+        iterator.set_upper_bound(transform_th_key(&upper_bound, prefix));
     }
 }
 


### PR DESCRIPTION
## Summary
- The bounded-iterator paths in `DBMap` (`safe_iter_with_bounds`, `safe_range_iter`, `reversed_safe_iter_with_bounds`) handed `be_fix_int_ser(K)` bounds straight to tidehunter, while every other key path goes through `transform_th_key` to strip the bincode length prefix.
- For an `rm_prefix` table (e.g. `transactions`, `effects`, `events`, `checkpoint_by_digest`, …) the bound's leading bytes are the fixed length prefix. Tidehunter derives `cell_id` and `is_out_of_bound` from those bytes, so iteration gets pinned to cell 0 and stops early — empty/wrong data, while the same call on RocksDB returns the correct range.
- No production caller iterates a prefix-stripped tidehunter table with bounds today, so the bug is latent — but it would silently break the next caller that does, while passing under RocksDB.
- Fix: thread the column-family prefix into `apply_range_bounds` and run the bounds through the same `transform_th_key` every other key path uses.

## Test plan
- [ ] `USE_TIDEHUNTER=1 cargo check -p typed-store --features typed-store/tidehunter` (done locally)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)