### PR TITLE
Write v0 watermark temporarily during watermark format migration roll out

### DIFF
--- a/crates/sui-kvstore/src/bigtable/client/mod.rs
+++ b/crates/sui-kvstore/src/bigtable/client/mod.rs
@@ -475,14 +475,17 @@ impl BigTableClient {
         ];
         if let Some(checkpoint) = new.checkpoint_hi_inclusive {
             cells.push((col::CHECKPOINT_HI, u64_be(checkpoint)));
-            let v0 = WatermarkV0 {
-                epoch_hi_inclusive: new.epoch_hi_inclusive,
-                checkpoint_hi_inclusive: checkpoint,
-                tx_hi: new.tx_hi,
-                timestamp_ms_hi_inclusive: new.timestamp_ms_hi_inclusive,
-            };
-            cells.push((col::WATERMARK_V0, Bytes::from(bcs::to_bytes(&v0)?)));
         }
+        // Always write the v0 `w` cell so older readers (which decode the BCS `WatermarkV0`)
+        // don't see a row with only v1 cells. When the v1 row has no checkpoint observed
+        // yet, write `checkpoint_hi_inclusive: 0` as a sentinel.
+        let v0 = WatermarkV0 {
+            epoch_hi_inclusive: new.epoch_hi_inclusive,
+            checkpoint_hi_inclusive: new.checkpoint_hi_inclusive.unwrap_or(0),
+            tx_hi: new.tx_hi,
+            timestamp_ms_hi_inclusive: new.timestamp_ms_hi_inclusive,
+        };
+        cells.push((col::WATERMARK_V0, Bytes::from(bcs::to_bytes(&v0)?)));
         let mutations = build_set_cell_mutations(cells);
         let predicate = column_exists_filter(tables::watermarks::col::SCHEMA_VERSION);
         // Predicate is "row has any schema-version cell" → false_mutations write the new row.

--- a/crates/sui-kvstore/tests/watermarks.rs
+++ b/crates/sui-kvstore/tests/watermarks.rs
@@ -173,12 +173,15 @@ async fn test_init_watermark_fresh_none() -> Result<()> {
     assert_eq!(init.checkpoint_hi_inclusive, None);
     assert_eq!(init.reader_lo, Some(0));
 
-    // The row should have the v1 cells but no v0 `w` cell.
+    // The row should have the v1 cells and a sentinel v0 `w` cell (chi=0) for backward
+    // compatibility with older readers that still target the BCS `w` column.
     let cells = harness.cells(PIPELINE).await?;
     assert!(
-        cells.w.is_none(),
-        "fresh init(None) must not write the `w` cell"
+        cells.w.is_some(),
+        "fresh init(None) must still write a sentinel `w` cell for old readers"
     );
+    let v0: WatermarkV0 = bcs::from_bytes(cells.w.as_ref().unwrap())?;
+    assert_eq!(v0.checkpoint_hi_inclusive, 0);
     assert!(cells.has_v1, "fresh init(None) must write the v1 cells");
     assert_eq!(cells.schema_version, Some(1));
     assert!(


### PR DESCRIPTION
## Description

The sui-kv-rpc container (reader) is deployed after the sui-kvstore container (writer) so we need to keep writing the v0 watermark until the new reader has been deployed. This change is only being made to the 1.71 release branch so we will stop writing the legacy watermark in 1.72 (which is intentional/correct).
