### PR TITLE
[graphql-stream] Resolve Event.transaction in streaming mode [10/n]

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/packages/event/emit_test_event/sources/emit_test_event.move
+++ b/crates/sui-indexer-alt-e2e-tests/packages/event/emit_test_event/sources/emit_test_event.move
@@ -1,35 +1,35 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-module emit_test_event::emit_test_event {
-    use sui::event;
+module emit_test_event::emit_test_event;
 
-    public struct TestEvent has copy, drop {
-        value: u64,
-    }
+use sui::event;
 
-    public struct TestObject has key, store {
-        id: UID,
-        value: u64,
-    }
+public struct TestEvent has copy, drop {
+	value: u64,
+}
 
-    public fun emit_test_event() {
-        event::emit(TestEvent {
-            value: 1,
-        });
-    }
+public struct TestObject has key, store {
+	id: UID,
+	value: u64,
+}
 
-    public fun emit_with_value(value: u64) {
-        event::emit(TestEvent { value })
-    }
+public fun emit_test_event() {
+	event::emit(TestEvent {
+		value: 1,
+	});
+}
 
-    /// Emit a `TestEvent` and create a `TestObject` in the same transaction. Used to
-    /// verify chained `event { transaction { effects { objectChanges } } }` queries.
-    public fun emit_and_create(value: u64, ctx: &mut TxContext): TestObject {
-        event::emit(TestEvent { value });
-        TestObject {
-            id: object::new(ctx),
-            value,
-        }
-    }
+public fun emit_with_value(value: u64) {
+	event::emit(TestEvent { value })
+}
+
+/// Emit a `TestEvent` and create a `TestObject` in the same transaction. Used to
+/// verify chained `event { transaction { effects { objectChanges } } }` queries.
+public fun emit_and_create(value: u64, ctx: &mut TxContext): TestObject {
+	event::emit(TestEvent { value });
+	TestObject {
+		id: object::new(ctx),
+		value,
+	}
 }

--- a/crates/sui-indexer-alt-e2e-tests/packages/event/emit_test_event/sources/emit_test_event.move
+++ b/crates/sui-indexer-alt-e2e-tests/packages/event/emit_test_event/sources/emit_test_event.move
@@ -8,6 +8,11 @@ module emit_test_event::emit_test_event {
         value: u64,
     }
 
+    public struct TestObject has key, store {
+        id: UID,
+        value: u64,
+    }
+
     public fun emit_test_event() {
         event::emit(TestEvent {
             value: 1,
@@ -16,5 +21,15 @@ module emit_test_event::emit_test_event {
 
     public fun emit_with_value(value: u64) {
         event::emit(TestEvent { value })
+    }
+
+    /// Emit a `TestEvent` and create a `TestObject` in the same transaction. Used to
+    /// verify chained `event { transaction { effects { objectChanges } } }` queries.
+    public fun emit_and_create(value: u64, ctx: &mut TxContext): TestObject {
+        event::emit(TestEvent { value });
+        TestObject {
+            id: object::new(ctx),
+            value,
+        }
     }
 }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/event_subscription.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/event_subscription.rs
@@ -82,6 +82,83 @@ async fn test_event_subscription_sender_filter() {
     });
 }
 
+/// Verifies that `event.transaction.<field>` resolves fully in streaming mode rather
+/// than returning a digest-only stub. Exercises `TransactionContents::fetch`'s streaming
+/// fast path.
+#[tokio::test]
+async fn test_event_subscription_transaction_fields() {
+    let mut cluster = SubscriptionTestCluster::new().await;
+    let package_id = emit_event_harness::publish(&mut cluster.validator).await;
+
+    let mut stream = cluster
+        .subscribe_with_variables(
+            r#"subscription($pkg: SuiAddress!) {
+                events(filter: { type: $pkg }) {
+                    transaction {
+                        digest
+                        sender { address }
+                        kind { __typename }
+                        gasInput { gasBudget gasPrice }
+                    }
+                    contents { type { repr } }
+                }
+            }"#,
+            Some(json!({ "pkg": package_id.to_string() })),
+        )
+        .await;
+
+    let _digest = emit_event_harness::emit(&mut cluster.validator, package_id).await;
+    let item = stream.next().await.expect("Stream ended");
+
+    graphql_redactions().bind(|| {
+        insta::assert_json_snapshot!("event_subscription_transaction_fields", item);
+    });
+}
+
+/// Verifies that `event.transaction.effects.objectChanges` resolves with non-empty
+/// object data in streaming mode. Exercises `EffectsContents::fetch`'s streaming fast
+/// path plus the per-tx execution-objects anchor that `Scope::with_tx_sequence_number_viewed_at`
+/// sets up.
+#[tokio::test]
+async fn test_event_subscription_object_changes() {
+    let mut cluster = SubscriptionTestCluster::new().await;
+    let package_id = emit_event_harness::publish(&mut cluster.validator).await;
+
+    let mut stream = cluster
+        .subscribe_with_variables(
+            r#"subscription($pkg: SuiAddress!) {
+                events(filter: { type: $pkg }) {
+                    transaction {
+                        effects {
+                            status
+                            objectChanges {
+                                nodes {
+                                    outputState {
+                                        address
+                                        version
+                                        digest
+                                        asMoveObject {
+                                            contents { type { repr } }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }"#,
+            Some(json!({ "pkg": package_id.to_string() })),
+        )
+        .await;
+
+    let _digest = emit_event_harness::emit_and_create(&mut cluster.validator, package_id, 7).await;
+    let item = stream.next().await.expect("Stream ended");
+
+    graphql_redactions().bind(|| {
+        insta::assert_json_snapshot!("event_subscription_object_changes", item);
+    });
+}
+
 #[tokio::test]
 async fn test_event_subscription_module_filter() {
     let mut cluster = SubscriptionTestCluster::new().await;

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/snapshots/graphql_subscription__event_subscription__event_subscription_object_changes.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/snapshots/graphql_subscription__event_subscription__event_subscription_object_changes.snap
@@ -1,0 +1,47 @@
+---
+source: crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/event_subscription.rs
+expression: item
+---
+{
+  "data": {
+    "events": {
+      "transaction": {
+        "effects": {
+          "status": "SUCCESS",
+          "objectChanges": {
+            "nodes": [
+              {
+                "outputState": {
+                  "address": "[address]",
+                  "version": "[version]",
+                  "digest": "[digest]",
+                  "asMoveObject": {
+                    "contents": {
+                      "type": {
+                        "repr": "[pkg]::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "outputState": {
+                  "address": "[address]",
+                  "version": "[version]",
+                  "digest": "[digest]",
+                  "asMoveObject": {
+                    "contents": {
+                      "type": {
+                        "repr": "[pkg]::emit_test_event::TestObject"
+                      }
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/snapshots/graphql_subscription__event_subscription__event_subscription_transaction_fields.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/snapshots/graphql_subscription__event_subscription__event_subscription_transaction_fields.snap
@@ -1,0 +1,28 @@
+---
+source: crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/event_subscription.rs
+expression: item
+---
+{
+  "data": {
+    "events": {
+      "transaction": {
+        "digest": "[digest]",
+        "sender": {
+          "address": "[address]"
+        },
+        "kind": {
+          "__typename": "ProgrammableTransaction"
+        },
+        "gasInput": {
+          "gasBudget": "5000000000",
+          "gasPrice": "1000"
+        }
+      },
+      "contents": {
+        "type": {
+          "repr": "[pkg]::emit_test_event::TestEvent"
+        }
+      }
+    }
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/testing/emit_event_harness.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/testing/emit_event_harness.rs
@@ -62,3 +62,25 @@ pub async fn emit_with_value(
     add_emit_with_value_call(&mut ptb, package_id, value);
     execute_ptb(cluster, ptb).await.0
 }
+
+/// Emit a `TestEvent` and create a `TestObject` in the same transaction. Used by tests
+/// that need an event subscription yield to also reference object changes via
+/// `event { transaction { effects { objectChanges } } }`.
+pub async fn emit_and_create(
+    cluster: &mut test_cluster::TestCluster,
+    package_id: ObjectID,
+    value: u64,
+) -> String {
+    let sender = cluster.wallet.active_address().unwrap();
+    let mut ptb = ProgrammableTransactionBuilder::new();
+    let value_arg = ptb.pure(value).unwrap();
+    let test_object = ptb.programmable_move_call(
+        package_id,
+        ident_str!("emit_test_event").to_owned(),
+        ident_str!("emit_and_create").to_owned(),
+        vec![],
+        vec![value_arg],
+    );
+    ptb.transfer_arg(sender, test_object);
+    execute_ptb(cluster, ptb).await.0
+}

--- a/crates/sui-indexer-alt-graphql/src/api/subscription.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/subscription.rs
@@ -97,7 +97,7 @@ impl Subscription {
                             yield Ok(Transaction {
                                 digest: tx.digest,
                                 contents: TransactionContents {
-                                    scope: scope.with_tx_sequence_number_viewed_at(tx.tx_sequence_number),
+                                    scope: scope.with_active_transaction_digest(tx.digest),
                                     contents: Some(Arc::new(tx.contents.clone())),
                                 },
                             });
@@ -147,7 +147,7 @@ impl Subscription {
                                     continue;
                                 }
                                 yield Ok(Event {
-                                    scope: scope.with_tx_sequence_number_viewed_at(tx.tx_sequence_number),
+                                    scope: scope.with_active_transaction_digest(tx.digest),
                                     native,
                                     transaction_digest: tx.digest,
                                     sequence_number: idx as u64,

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
@@ -360,6 +360,16 @@ impl TransactionContents {
         if self.contents.is_some() {
             return Ok(self.clone());
         }
+
+        // Streaming fast path: if the scope is backed by a streamed checkpoint containing this
+        // transaction, hydrate from the in-memory payload instead of hitting the DB.
+        if let Some(tx) = self.scope.streamed_transaction_by_digest(digest) {
+            return Ok(Self {
+                scope: self.scope.clone(),
+                contents: Some(Arc::new(tx.contents.clone())),
+            });
+        }
+
         let Some(checkpoint_viewed_at) = self.scope.checkpoint_viewed_at() else {
             return Ok(self.clone());
         };

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
@@ -253,7 +253,7 @@ impl Transaction {
             filtered,
             |tx| JsonCursor::new(tx.tx_sequence_number),
             |tx| {
-                let tx_scope = scope.with_tx_sequence_number_viewed_at(tx.tx_sequence_number);
+                let tx_scope = scope.with_active_transaction_digest(tx.digest);
                 Ok(Transaction {
                     digest: tx.digest,
                     contents: TransactionContents {

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
@@ -557,6 +557,16 @@ impl EffectsContents {
         if self.contents.is_some() {
             return Ok(self.clone());
         }
+
+        // Streaming fast path: if the scope is backed by a streamed checkpoint containing this
+        // transaction, hydrate from the in-memory payload instead of hitting the DB.
+        if let Some(tx) = self.scope.streamed_transaction_by_digest(digest) {
+            return Ok(Self {
+                scope: self.scope.clone(),
+                contents: Some(Arc::new(tx.contents.clone())),
+            });
+        }
+
         let Some(checkpoint_viewed_at) = self.scope.checkpoint_viewed_at() else {
             return Ok(self.clone());
         };

--- a/crates/sui-indexer-alt-graphql/src/scope.rs
+++ b/crates/sui-indexer-alt-graphql/src/scope.rs
@@ -34,12 +34,13 @@ use crate::task::watermark::Watermarks;
 pub(crate) type ExecutionObjectMap =
     Arc<BTreeMap<(ObjectID, SequenceNumber), Option<NativeObject>>>;
 
-/// Where object lookups in this scope draw their data from. Encodes the mutually exclusive
-/// modes a [`Scope`] can be in. Indexed mode hits the database/kv_loader (no in-memory payload).
-/// Executed mode is the mutation/simulate path, with a freshly executed transaction's outputs.
-/// Streamed mode is the subscription path, with an in-memory checkpoint payload.
+/// Where in-memory lookups (objects, transaction contents, etc.) in this scope draw their data
+/// from. Encodes the mutually exclusive modes a [`Scope`] can be in. Indexed mode hits the
+/// database/kv_loader (no in-memory payload). Executed mode is the mutation/simulate path, with a
+/// freshly executed transaction's outputs. Streamed mode is the subscription path, with an
+/// in-memory checkpoint payload.
 #[derive(Clone)]
-pub(crate) enum ObjectSource {
+pub(crate) enum DataSource {
     /// Reads go through the indexed-checkpoint path (kv_loader / DB). No in-memory payload.
     Indexed,
     /// A freshly executed transaction's input/output objects.
@@ -95,8 +96,8 @@ pub(crate) struct Scope {
     /// This can be expressed either in terms of a specific object version or a checkpoint.
     root_bound: Option<RootBound>,
 
-    /// Where object lookups in this scope draw their data from. See [`ObjectSource`].
-    object_source: ObjectSource,
+    /// Where in-memory lookups in this scope draw their data from. See [`DataSource`].
+    data_source: DataSource,
 
     /// Access to packages for type resolution.
     package_store: Arc<dyn PackageStore>,
@@ -117,7 +118,7 @@ impl Scope {
             checkpoint_viewed_at: Some(watermark.high_watermark().checkpoint()),
             tx_sequence_number_viewed_at: None,
             root_bound: None,
-            object_source: ObjectSource::Indexed,
+            data_source: DataSource::Indexed,
             package_store: package_store.clone(),
             resolver_limits: limits.package_resolver(),
         })
@@ -134,7 +135,7 @@ impl Scope {
             checkpoint_viewed_at: None,
             tx_sequence_number_viewed_at: None,
             root_bound: None,
-            object_source: ObjectSource::Streamed {
+            data_source: DataSource::Streamed {
                 checkpoint: streamed_checkpoint,
             },
             package_store,
@@ -153,7 +154,7 @@ impl Scope {
             checkpoint_viewed_at: self.checkpoint_viewed_at,
             tx_sequence_number_viewed_at: Some(tx_sequence_number_viewed_at),
             root_bound: self.root_bound,
-            object_source: self.object_source.clone(),
+            data_source: self.data_source.clone(),
             package_store: self.package_store.clone(),
             resolver_limits: self.resolver_limits.clone(),
         }
@@ -179,7 +180,7 @@ impl Scope {
             checkpoint_viewed_at: Some(0),
             tx_sequence_number_viewed_at: None,
             root_bound: None,
-            object_source: ObjectSource::Indexed,
+            data_source: DataSource::Indexed,
             package_store: Arc::new(EmptyPackageStore),
             resolver_limits: Limits::default().package_resolver(),
         }
@@ -198,7 +199,7 @@ impl Scope {
             checkpoint_viewed_at: Some(checkpoint_viewed_at),
             tx_sequence_number_viewed_at: self.tx_sequence_number_viewed_at,
             root_bound: self.root_bound,
-            object_source: self.object_source.clone(),
+            data_source: self.data_source.clone(),
             package_store: self.package_store.clone(),
             resolver_limits: self.resolver_limits.clone(),
         })
@@ -210,7 +211,7 @@ impl Scope {
             checkpoint_viewed_at: self.checkpoint_viewed_at,
             tx_sequence_number_viewed_at: self.tx_sequence_number_viewed_at,
             root_bound: Some(RootBound::Version(root_version)),
-            object_source: self.object_source.clone(),
+            data_source: self.data_source.clone(),
             package_store: self.package_store.clone(),
             resolver_limits: self.resolver_limits.clone(),
         }
@@ -222,7 +223,7 @@ impl Scope {
             checkpoint_viewed_at: self.checkpoint_viewed_at,
             tx_sequence_number_viewed_at: self.tx_sequence_number_viewed_at,
             root_bound: Some(RootBound::Checkpoint(root_checkpoint)),
-            object_source: self.object_source.clone(),
+            data_source: self.data_source.clone(),
             package_store: self.package_store.clone(),
             resolver_limits: self.resolver_limits.clone(),
         }
@@ -234,7 +235,7 @@ impl Scope {
             checkpoint_viewed_at: self.checkpoint_viewed_at,
             tx_sequence_number_viewed_at: self.tx_sequence_number_viewed_at,
             root_bound: None,
-            object_source: self.object_source.clone(),
+            data_source: self.data_source.clone(),
             package_store: self.package_store.clone(),
             resolver_limits: self.resolver_limits.clone(),
         }
@@ -277,27 +278,27 @@ impl Scope {
     }
 
     /// Lookup a transaction by digest within the streamed checkpoint backing this scope.
-    /// Returns `None` if the scope is not in [`ObjectSource::Streamed`] mode, or if no
+    /// Returns `None` if the scope is not in [`DataSource::Streamed`] mode, or if no
     /// transaction with that digest exists in the checkpoint.
     pub(crate) fn streamed_transaction_by_digest(
         &self,
         digest: TransactionDigest,
     ) -> Option<&ProcessedTransaction> {
-        match &self.object_source {
-            ObjectSource::Streamed { checkpoint } => checkpoint.transaction_by_digest(digest),
-            ObjectSource::Indexed | ObjectSource::Executed { .. } => None,
+        match &self.data_source {
+            DataSource::Streamed { checkpoint } => checkpoint.transaction_by_digest(digest),
+            DataSource::Indexed | DataSource::Executed { .. } => None,
         }
     }
 
     /// The execution objects map active for object lookups in this scope. Resolves through the
-    /// scope's [`ObjectSource`]: in `Streamed` mode, looks up the per-tx map for the transaction
+    /// scope's [`DataSource`]: in `Streamed` mode, looks up the per-tx map for the transaction
     /// identified by `tx_sequence_number_viewed_at`; in `Executed` mode, returns the freshly
     /// extracted map; in `Indexed` mode, returns `None` so callers fall through to the DB.
     fn execution_objects_in_view(&self) -> Option<&ExecutionObjectMap> {
-        match &self.object_source {
-            ObjectSource::Indexed => None,
-            ObjectSource::Executed { execution_objects } => Some(execution_objects),
-            ObjectSource::Streamed { checkpoint } => checkpoint
+        match &self.data_source {
+            DataSource::Indexed => None,
+            DataSource::Executed { execution_objects } => Some(execution_objects),
+            DataSource::Streamed { checkpoint } => checkpoint
                 .transaction(self.tx_sequence_number_viewed_at?)
                 .map(|t| &t.execution_objects),
         }
@@ -339,7 +340,7 @@ impl Scope {
             checkpoint_viewed_at: None,
             tx_sequence_number_viewed_at: None,
             root_bound: self.root_bound,
-            object_source: ObjectSource::Executed { execution_objects },
+            data_source: DataSource::Executed { execution_objects },
             package_store: self.package_store.clone(),
             resolver_limits: self.resolver_limits.clone(),
         })

--- a/crates/sui-indexer-alt-graphql/src/scope.rs
+++ b/crates/sui-indexer-alt-graphql/src/scope.rs
@@ -19,11 +19,13 @@ use sui_rpc::proto::sui::rpc::v2 as grpc;
 use sui_rpc::proto::sui::rpc::v2::changed_object::OutputObjectState;
 use sui_types::base_types::ObjectID;
 use sui_types::base_types::SequenceNumber;
+use sui_types::digests::TransactionDigest;
 use sui_types::object::Object as NativeObject;
 
 use crate::config::Limits;
 use crate::error::RpcError;
 use crate::task::streaming::ProcessedCheckpoint;
+use crate::task::streaming::ProcessedTransaction;
 use crate::task::streaming::StreamingPackageStore;
 use crate::task::watermark::Watermarks;
 
@@ -272,6 +274,19 @@ impl Scope {
     /// Returns `None` in execution context (freshly executed transaction).
     pub(crate) fn checkpoint_viewed_at_exclusive_bound(&self) -> Option<u64> {
         self.checkpoint_viewed_at.map(|cp| cp + 1)
+    }
+
+    /// Lookup a transaction by digest within the streamed checkpoint backing this scope.
+    /// Returns `None` if the scope is not in [`ObjectSource::Streamed`] mode, or if no
+    /// transaction with that digest exists in the checkpoint.
+    pub(crate) fn streamed_transaction_by_digest(
+        &self,
+        digest: TransactionDigest,
+    ) -> Option<&ProcessedTransaction> {
+        match &self.object_source {
+            ObjectSource::Streamed { checkpoint } => checkpoint.transaction_by_digest(digest),
+            ObjectSource::Indexed | ObjectSource::Executed { .. } => None,
+        }
     }
 
     /// The execution objects map active for object lookups in this scope. Resolves through the

--- a/crates/sui-indexer-alt-graphql/src/scope.rs
+++ b/crates/sui-indexer-alt-graphql/src/scope.rs
@@ -47,8 +47,9 @@ pub(crate) enum DataSource {
     Executed {
         execution_objects: ExecutionObjectMap,
     },
-    /// A streamed checkpoint with all per-tx contents and execution objects. The active
-    /// transaction within this scope is identified by [`Scope::tx_sequence_number_viewed_at`].
+    /// A streamed checkpoint with all per-tx contents and a checkpoint-wide execution-objects
+    /// map. If the scope is anchored to a particular transaction in the checkpoint, its digest
+    /// is in [`Scope::active_transaction_digest`].
     Streamed {
         checkpoint: Arc<ProcessedCheckpoint>,
     },
@@ -86,10 +87,15 @@ pub(crate) struct Scope {
     /// None indicates execution context where we're viewing fresh transaction effects not yet indexed.
     checkpoint_viewed_at: Option<u64>,
 
-    /// The transaction we are scoped to, identified by global `tx_sequence_number`. In streaming
-    /// mode, anchors object lookups to that transaction's per-tx `execution_objects` within the
-    /// streamed checkpoint.
-    tx_sequence_number_viewed_at: Option<u64>,
+    /// The specific transaction this scope is anchored to, identified by digest. Set by
+    /// resolvers that render data for a single transaction (e.g. the streaming `transactions`
+    /// and `events` subscriptions) so downstream fields like `Address.asTransactionObject`
+    /// know which transaction's effects to scan. `None` when no specific transaction is in
+    /// scope.
+    ///
+    /// This is *not* a "view bound" up to and including a transaction; it identifies one
+    /// transaction. Object visibility is end-of-checkpoint regardless of this field.
+    active_transaction_digest: Option<TransactionDigest>,
 
     /// Root object bound for dynamic fields.
     ///
@@ -116,7 +122,7 @@ impl Scope {
 
         Ok(Self {
             checkpoint_viewed_at: Some(watermark.high_watermark().checkpoint()),
-            tx_sequence_number_viewed_at: None,
+            active_transaction_digest: None,
             root_bound: None,
             data_source: DataSource::Indexed,
             package_store: package_store.clone(),
@@ -133,7 +139,7 @@ impl Scope {
     ) -> Self {
         Self {
             checkpoint_viewed_at: None,
-            tx_sequence_number_viewed_at: None,
+            active_transaction_digest: None,
             root_bound: None,
             data_source: DataSource::Streamed {
                 checkpoint: streamed_checkpoint,
@@ -143,16 +149,13 @@ impl Scope {
         }
     }
 
-    /// Pin a nested scope to a specific transaction by global `tx_sequence_number`. In streaming
-    /// mode this anchors object lookups to that transaction's per-tx `execution_objects` within
-    /// the streamed checkpoint.
-    pub(crate) fn with_tx_sequence_number_viewed_at(
-        &self,
-        tx_sequence_number_viewed_at: u64,
-    ) -> Self {
+    /// Anchor a nested scope to a specific transaction by digest. Used by resolvers that
+    /// render a single transaction's data so downstream fields can identify which
+    /// transaction's effects to consult. Does not change object visibility.
+    pub(crate) fn with_active_transaction_digest(&self, digest: TransactionDigest) -> Self {
         Self {
             checkpoint_viewed_at: self.checkpoint_viewed_at,
-            tx_sequence_number_viewed_at: Some(tx_sequence_number_viewed_at),
+            active_transaction_digest: Some(digest),
             root_bound: self.root_bound,
             data_source: self.data_source.clone(),
             package_store: self.package_store.clone(),
@@ -178,7 +181,7 @@ impl Scope {
 
         Self {
             checkpoint_viewed_at: Some(0),
-            tx_sequence_number_viewed_at: None,
+            active_transaction_digest: None,
             root_bound: None,
             data_source: DataSource::Indexed,
             package_store: Arc::new(EmptyPackageStore),
@@ -197,7 +200,7 @@ impl Scope {
         let cp_hi_inclusive = watermark.high_watermark().checkpoint();
         (checkpoint_viewed_at <= cp_hi_inclusive).then(|| Self {
             checkpoint_viewed_at: Some(checkpoint_viewed_at),
-            tx_sequence_number_viewed_at: self.tx_sequence_number_viewed_at,
+            active_transaction_digest: self.active_transaction_digest,
             root_bound: self.root_bound,
             data_source: self.data_source.clone(),
             package_store: self.package_store.clone(),
@@ -209,7 +212,7 @@ impl Scope {
     pub(crate) fn with_root_version(&self, root_version: u64) -> Self {
         Self {
             checkpoint_viewed_at: self.checkpoint_viewed_at,
-            tx_sequence_number_viewed_at: self.tx_sequence_number_viewed_at,
+            active_transaction_digest: self.active_transaction_digest,
             root_bound: Some(RootBound::Version(root_version)),
             data_source: self.data_source.clone(),
             package_store: self.package_store.clone(),
@@ -221,7 +224,7 @@ impl Scope {
     pub(crate) fn with_root_checkpoint(&self, root_checkpoint: u64) -> Self {
         Self {
             checkpoint_viewed_at: self.checkpoint_viewed_at,
-            tx_sequence_number_viewed_at: self.tx_sequence_number_viewed_at,
+            active_transaction_digest: self.active_transaction_digest,
             root_bound: Some(RootBound::Checkpoint(root_checkpoint)),
             data_source: self.data_source.clone(),
             package_store: self.package_store.clone(),
@@ -233,7 +236,7 @@ impl Scope {
     pub(crate) fn without_root_bound(&self) -> Self {
         Self {
             checkpoint_viewed_at: self.checkpoint_viewed_at,
-            tx_sequence_number_viewed_at: self.tx_sequence_number_viewed_at,
+            active_transaction_digest: self.active_transaction_digest,
             root_bound: None,
             data_source: self.data_source.clone(),
             package_store: self.package_store.clone(),
@@ -291,16 +294,15 @@ impl Scope {
     }
 
     /// The execution objects map active for object lookups in this scope. Resolves through the
-    /// scope's [`DataSource`]: in `Streamed` mode, looks up the per-tx map for the transaction
-    /// identified by `tx_sequence_number_viewed_at`; in `Executed` mode, returns the freshly
-    /// extracted map; in `Indexed` mode, returns `None` so callers fall through to the DB.
+    /// scope's [`DataSource`]: in `Streamed` mode, returns the checkpoint-wide map (object
+    /// visibility is end-of-checkpoint, matching the indexed Query path); in `Executed` mode,
+    /// returns the freshly extracted map; in `Indexed` mode, returns `None` so callers fall
+    /// through to the DB.
     fn execution_objects_in_view(&self) -> Option<&ExecutionObjectMap> {
         match &self.data_source {
             DataSource::Indexed => None,
             DataSource::Executed { execution_objects } => Some(execution_objects),
-            DataSource::Streamed { checkpoint } => checkpoint
-                .transaction(self.tx_sequence_number_viewed_at?)
-                .map(|t| &t.execution_objects),
+            DataSource::Streamed { checkpoint } => Some(&checkpoint.execution_objects),
         }
     }
 
@@ -338,7 +340,7 @@ impl Scope {
 
         Ok(Self {
             checkpoint_viewed_at: None,
-            tx_sequence_number_viewed_at: None,
+            active_transaction_digest: None,
             root_bound: self.root_bound,
             data_source: DataSource::Executed { execution_objects },
             package_store: self.package_store.clone(),
@@ -408,10 +410,7 @@ impl Debug for Scope {
         f.debug_struct("Scope")
             .field("checkpoint_viewed_at", &self.checkpoint_viewed_at)
             .field("root_bound", &self.root_bound)
-            .field(
-                "tx_sequence_number_viewed_at",
-                &self.tx_sequence_number_viewed_at,
-            )
+            .field("active_transaction_digest", &self.active_transaction_digest)
             .field("resolver_limits", &self.resolver_limits)
             .finish()
     }

--- a/crates/sui-indexer-alt-graphql/src/task/streaming/checkpoint_stream_task.rs
+++ b/crates/sui-indexer-alt-graphql/src/task/streaming/checkpoint_stream_task.rs
@@ -99,7 +99,6 @@ use tracing::info;
 use tracing::warn;
 
 use crate::config::SubscriptionConfig;
-use crate::scope::ExecutionObjectMap;
 use crate::task::watermark::Watermarks;
 
 use super::StreamingPackageStore;
@@ -401,20 +400,26 @@ pub(super) fn process_checkpoint(
     let cp_sequence_number = sequence_number;
     let tx_lo = summary.network_total_transactions - checkpoint.transactions.len() as u64;
     let checkpoint_objects = deserialize_checkpoint_objects(&checkpoint)?;
-    let transactions = checkpoint
-        .transactions
-        .iter()
-        .enumerate()
-        .map(|(i, proto)| {
-            process_transaction(
-                proto,
-                &checkpoint_objects,
-                timestamp_ms,
-                cp_sequence_number,
-                tx_lo + i as u64,
-            )
-        })
-        .collect::<anyhow::Result<Vec<_>>>()?;
+
+    // Seed the checkpoint-wide execution-objects map with every existing object version
+    // carried by the proto. Tombstones for deleted/wrapped outputs are added below from each
+    // transaction's effects because the proto doesn't carry deleted-object payloads.
+    let mut execution_objects: BTreeMap<(ObjectID, SequenceNumber), Option<NativeObject>> =
+        checkpoint_objects
+            .iter()
+            .map(|(k, v)| (*k, Some(v.clone())))
+            .collect();
+
+    let mut transactions = Vec::with_capacity(checkpoint.transactions.len());
+    for (i, proto) in checkpoint.transactions.iter().enumerate() {
+        add_tombstones(&mut execution_objects, proto)?;
+        transactions.push(process_transaction(
+            proto,
+            timestamp_ms,
+            cp_sequence_number,
+            tx_lo + i as u64,
+        )?);
+    }
 
     Ok(ProcessedCheckpoint::new(
         sequence_number,
@@ -422,12 +427,12 @@ pub(super) fn process_checkpoint(
         contents,
         signature,
         transactions,
+        Arc::new(execution_objects),
     ))
 }
 
 fn process_transaction(
     proto: &ProtoExecutedTransaction,
-    checkpoint_objects: &BTreeMap<(ObjectID, SequenceNumber), NativeObject>,
     timestamp_ms: u64,
     cp_sequence_number: u64,
     tx_sequence_number: u64,
@@ -478,8 +483,6 @@ fn process_transaction(
 
     let digest = *effects.transaction_digest();
 
-    let execution_objects = build_execution_objects(checkpoint_objects, proto)?;
-
     let contents = NativeTransactionContents::ExecutedTransaction(
         sui_indexer_alt_reader::kv_loader::ExecutedTransactionData {
             effects: Box::new(effects),
@@ -498,7 +501,6 @@ fn process_transaction(
         tx_sequence_number,
         digest,
         contents,
-        execution_objects,
     })
 }
 
@@ -543,48 +545,36 @@ fn deserialize_checkpoint_objects(
     Ok(map)
 }
 
-/// Build an ExecutionObjectMap for a single transaction by filtering checkpoint-level objects
-/// using the transaction's `changed_objects` from effects.
-///
-/// Includes both input objects (previous version) and output objects (new version) so that
-/// both `inputState` and `outputState` can resolve from streaming.
-/// Objects with `DoesNotExist` output state become tombstones (None).
-fn build_execution_objects(
-    checkpoint_objects: &BTreeMap<(ObjectID, SequenceNumber), NativeObject>,
+/// Add tombstones (`None` entries) to a checkpoint-wide execution-objects map for any
+/// `DoesNotExist` outputs in this transaction's effects. The proto's `objects` field doesn't
+/// carry payloads for deleted/wrapped objects, so tombstones must come from effects; without
+/// them, `execution_output_object_latest` would return the pre-deletion version of an object
+/// that no longer exists at end-of-checkpoint.
+fn add_tombstones(
+    map: &mut BTreeMap<(ObjectID, SequenceNumber), Option<NativeObject>>,
     proto_tx: &ProtoExecutedTransaction,
-) -> anyhow::Result<ExecutionObjectMap> {
-    let mut map = BTreeMap::new();
+) -> anyhow::Result<()> {
+    let Some(effects) = &proto_tx.effects else {
+        return Ok(());
+    };
 
-    if let Some(effects) = &proto_tx.effects {
-        let lamport_version = SequenceNumber::from_u64(
-            effects
-                .lamport_version
-                .context("Effects should have lamport_version")?,
-        );
+    let lamport_version = SequenceNumber::from_u64(
+        effects
+            .lamport_version
+            .context("Effects should have lamport_version")?,
+    );
 
-        for changed_obj in &effects.changed_objects {
-            let object_id: ObjectID = changed_obj
-                .object_id
-                .as_ref()
-                .and_then(|id| id.parse().ok())
-                .context("ChangedObject should have valid object_id")?;
-
-            // Input object (previous version, before the transaction).
-            if let Some(input_version) = changed_obj.input_version {
-                let input_version = SequenceNumber::from_u64(input_version);
-                if let Some(obj) = checkpoint_objects.get(&(object_id, input_version)) {
-                    map.insert((object_id, input_version), Some(obj.clone()));
-                }
-            }
-
-            // Output object (new version, after the transaction).
-            if changed_obj.output_state() == OutputObjectState::DoesNotExist {
-                map.insert((object_id, lamport_version), None);
-            } else if let Some(obj) = checkpoint_objects.get(&(object_id, lamport_version)) {
-                map.insert((object_id, lamport_version), Some(obj.clone()));
-            }
+    for changed_obj in &effects.changed_objects {
+        if changed_obj.output_state() != OutputObjectState::DoesNotExist {
+            continue;
         }
+        let object_id: ObjectID = changed_obj
+            .object_id
+            .as_ref()
+            .and_then(|id| id.parse().ok())
+            .context("ChangedObject should have valid object_id")?;
+        map.insert((object_id, lamport_version), None);
     }
 
-    Ok(Arc::new(map))
+    Ok(())
 }

--- a/crates/sui-indexer-alt-graphql/src/task/streaming/processed_checkpoint.rs
+++ b/crates/sui-indexer-alt-graphql/src/task/streaming/processed_checkpoint.rs
@@ -21,6 +21,8 @@ pub(crate) struct ProcessedCheckpoint {
     /// Index of `transactions` by global `tx_sequence_number` for O(1) lookup that scales
     /// across many subscribers. Built once at construction.
     by_tx_sequence_number: HashMap<u64, usize>,
+    /// Index of `transactions` by digest. Same rationale as `by_tx_sequence_number`.
+    by_digest: HashMap<TransactionDigest, usize>,
 }
 
 /// A transaction from a streamed checkpoint with pre-deserialized contents.
@@ -33,6 +35,7 @@ pub(crate) struct ProcessedTransaction {
 }
 
 impl ProcessedCheckpoint {
+    /// Construct a checkpoint with both lookup indexes pre-built from `transactions`.
     pub(crate) fn new(
         sequence_number: u64,
         summary: CheckpointSummary,
@@ -45,6 +48,11 @@ impl ProcessedCheckpoint {
             .enumerate()
             .map(|(i, t)| (t.tx_sequence_number, i))
             .collect();
+        let by_digest = transactions
+            .iter()
+            .enumerate()
+            .map(|(i, t)| (t.digest, i))
+            .collect();
         Self {
             sequence_number,
             summary,
@@ -52,12 +60,22 @@ impl ProcessedCheckpoint {
             signature,
             transactions,
             by_tx_sequence_number,
+            by_digest,
         }
     }
 
     /// Lookup a transaction by its global `tx_sequence_number` within this checkpoint.
     pub(crate) fn transaction(&self, tx_sequence_number: u64) -> Option<&ProcessedTransaction> {
         let i = *self.by_tx_sequence_number.get(&tx_sequence_number)?;
+        self.transactions.get(i)
+    }
+
+    /// Lookup a transaction by digest within this checkpoint.
+    pub(crate) fn transaction_by_digest(
+        &self,
+        digest: TransactionDigest,
+    ) -> Option<&ProcessedTransaction> {
+        let i = *self.by_digest.get(&digest)?;
         self.transactions.get(i)
     }
 }

--- a/crates/sui-indexer-alt-graphql/src/task/streaming/processed_checkpoint.rs
+++ b/crates/sui-indexer-alt-graphql/src/task/streaming/processed_checkpoint.rs
@@ -18,10 +18,12 @@ pub(crate) struct ProcessedCheckpoint {
     pub(crate) contents: CheckpointContents,
     pub(crate) signature: AuthorityStrongQuorumSignInfo,
     pub(crate) transactions: Vec<ProcessedTransaction>,
-    /// Index of `transactions` by global `tx_sequence_number` for O(1) lookup that scales
-    /// across many subscribers. Built once at construction.
-    by_tx_sequence_number: HashMap<u64, usize>,
-    /// Index of `transactions` by digest. Same rationale as `by_tx_sequence_number`.
+    /// Checkpoint-wide execution objects (inputs and outputs across all transactions in the
+    /// checkpoint, including tombstones for deleted/wrapped objects). Object visibility in a
+    /// streamed scope is end-of-checkpoint, matching what the indexed Query API exposes.
+    pub(crate) execution_objects: ExecutionObjectMap,
+    /// Index of `transactions` by digest for O(1) lookup that scales across many subscribers.
+    /// Built once at construction.
     by_digest: HashMap<TransactionDigest, usize>,
 }
 
@@ -30,24 +32,18 @@ pub(crate) struct ProcessedTransaction {
     pub(crate) tx_sequence_number: u64,
     pub(crate) digest: TransactionDigest,
     pub(crate) contents: TransactionContents,
-    /// Pre-built execution objects for this transaction, extracted from checkpoint-level objects.
-    pub(crate) execution_objects: ExecutionObjectMap,
 }
 
 impl ProcessedCheckpoint {
-    /// Construct a checkpoint with both lookup indexes pre-built from `transactions`.
+    /// Construct a checkpoint with the digest index pre-built from `transactions`.
     pub(crate) fn new(
         sequence_number: u64,
         summary: CheckpointSummary,
         contents: CheckpointContents,
         signature: AuthorityStrongQuorumSignInfo,
         transactions: Vec<ProcessedTransaction>,
+        execution_objects: ExecutionObjectMap,
     ) -> Self {
-        let by_tx_sequence_number = transactions
-            .iter()
-            .enumerate()
-            .map(|(i, t)| (t.tx_sequence_number, i))
-            .collect();
         let by_digest = transactions
             .iter()
             .enumerate()
@@ -59,15 +55,9 @@ impl ProcessedCheckpoint {
             contents,
             signature,
             transactions,
-            by_tx_sequence_number,
+            execution_objects,
             by_digest,
         }
-    }
-
-    /// Lookup a transaction by its global `tx_sequence_number` within this checkpoint.
-    pub(crate) fn transaction(&self, tx_sequence_number: u64) -> Option<&ProcessedTransaction> {
-        let i = *self.by_tx_sequence_number.get(&tx_sequence_number)?;
-        self.transactions.get(i)
     }
 
     /// Lookup a transaction by digest within this checkpoint.


### PR DESCRIPTION
## Description 

Streaming subscribers expect `subscription { events { transaction { effects { objectChanges } } } }` to resolve fully in one round trip. Today it does not: `event.transaction` returns a digest-only stub, and chained fields under it (`effects`, `kind`, `gasInput`, `objectChanges`, etc.) come back null. Clients either issue a follow-up query against the indexed API to fill in the data, defeating the point of streaming, or live with incomplete payloads.

Also incorporates review feedback from #26476: 
- renames `ObjectSource` → `DataSource` (the enum now backs in-memory lookups for both objects and transaction contents, not just objects);
-  drops the intra-checkpoint object-visibility narrowing in `Streamed` mode so subscribers see end-of-checkpoint state, matching what the indexed Query path returns;
-  renames `tx_sequence_number_viewed_at` → `active_transaction_digest: Option<TransactionDigest>` to make clear the field identifies a specific transaction in scope, not a "viewed-at" bound.


## Test plan 

How did you test the new or updated feature?
- unit tests + e2e tests

## Stack
   - #26019
   - #26094
   - #26117
   - #26170
   - #26194
   - #26202
   - #26414
   - #26453
   - #26476
   - #26487

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
