### PR TITLE
sui-rosetta: harden MergeAndRedeemFungibleStakedSui (chain guard, epoch binding)

### DIFF
--- a/crates/sui-rosetta/src/account.rs
+++ b/crates/sui-rosetta/src/account.rs
@@ -154,13 +154,32 @@ pub(crate) struct PoolRateInfo {
     pub sui_balance: u64,
     pub pool_token_balance: u64,
     pub validator_address: Address,
+    /// `pool.extra_fields.id` — the Bag's UID, needed by callers that want to
+    /// derive dynamic field ids inside the pool (e.g.,
+    /// `FungibleStakedSuiData`). `None` if the proto omitted the field.
+    pub pool_extra_fields_id: Option<String>,
 }
 
 /// Reads exchange rates for all active validator staking pools.
 pub(crate) async fn get_pool_exchange_rates(
     client: &mut Client,
 ) -> Result<std::collections::HashMap<String, PoolRateInfo>, Error> {
+    Ok(get_pool_exchange_rates_with_epoch(client).await?.0)
+}
+
+/// Reads exchange rates and the epoch they're snapshotted in from a single
+/// `GetEpochRequest::latest()` response. Used by amount-sensitive operations
+/// (e.g. `MergeAndRedeemFungibleStakedSui::AtLeast`/`AtMost`) that must pin
+/// the rate quote to the same epoch the resulting transaction will be bound to.
+///
+/// Reading rate and epoch separately would race: a caller could observe rate
+/// from epoch N, then read epoch N+1, and bind the transaction to N+1 with a
+/// stale N rate, silently violating AtMost caps and aborting AtLeast guards.
+pub(crate) async fn get_pool_exchange_rates_with_epoch(
+    client: &mut Client,
+) -> Result<(std::collections::HashMap<String, PoolRateInfo>, u64), Error> {
     let request = GetEpochRequest::latest().with_read_mask(FieldMask::from_paths([
+        "epoch",
         "system_state.validators.active_validators",
     ]));
     let response = client
@@ -168,7 +187,9 @@ pub(crate) async fn get_pool_exchange_rates(
         .get_epoch(request)
         .await?
         .into_inner();
-    let system_state = response.epoch().system_state();
+    let epoch_obj = response.epoch();
+    let epoch = epoch_obj.epoch();
+    let system_state = epoch_obj.system_state();
     let validators = system_state.validators().active_validators();
 
     let mut rates = std::collections::HashMap::new();
@@ -177,16 +198,21 @@ pub(crate) async fn get_pool_exchange_rates(
         let pool_id = pool.id().to_string();
         let validator_address = Address::from_str(validator.address())
             .map_err(|e| Error::DataError(format!("Invalid validator address: {}", e)))?;
+        let pool_extra_fields_id = pool
+            .extra_fields_opt()
+            .and_then(|t| t.id_opt())
+            .map(|s| s.to_string());
         rates.insert(
             pool_id,
             PoolRateInfo {
                 sui_balance: pool.sui_balance(),
                 pool_token_balance: pool.pool_token_balance(),
                 validator_address,
+                pool_extra_fields_id,
             },
         );
     }
-    Ok(rates)
+    Ok((rates, epoch))
 }
 
 async fn get_sub_account_balances(

--- a/crates/sui-rosetta/src/account.rs
+++ b/crates/sui-rosetta/src/account.rs
@@ -167,20 +167,43 @@ pub(crate) async fn get_pool_exchange_rates(
     Ok(get_pool_exchange_rates_with_epoch(client).await?.0)
 }
 
+/// Atomic snapshot of validator-set state from a single `GetEpochRequest::latest()`.
+///
+/// Splitting these reads across multiple RPCs allows an epoch transition to
+/// land between them: the caller could observe rate from epoch N, then read
+/// epoch N+1, and bind the transaction to N+1 with a stale N rate, silently
+/// violating AtMost caps and aborting AtLeast guards. Bundling rate, epoch,
+/// and the inactive-table id into one response eliminates that race.
+pub(crate) struct ValidatorSetSnapshot {
+    /// Active pool rates keyed by `pool.id` (canonical 0x-prefixed hex string).
+    pub active_rates: std::collections::HashMap<String, PoolRateInfo>,
+    /// Current epoch the snapshot was taken in.
+    pub epoch: u64,
+    /// `validators.inactive_validators.id` — UID of the
+    /// `Table<ID, ValidatorWrapper>` storing deactivated pools. `None` only if
+    /// the proto omitted the field.
+    pub inactive_validators_table_id: Option<String>,
+}
+
 /// Reads exchange rates and the epoch they're snapshotted in from a single
 /// `GetEpochRequest::latest()` response. Used by amount-sensitive operations
 /// (e.g. `MergeAndRedeemFungibleStakedSui::AtLeast`/`AtMost`) that must pin
 /// the rate quote to the same epoch the resulting transaction will be bound to.
-///
-/// Reading rate and epoch separately would race: a caller could observe rate
-/// from epoch N, then read epoch N+1, and bind the transaction to N+1 with a
-/// stale N rate, silently violating AtMost caps and aborting AtLeast guards.
 pub(crate) async fn get_pool_exchange_rates_with_epoch(
     client: &mut Client,
 ) -> Result<(std::collections::HashMap<String, PoolRateInfo>, u64), Error> {
+    let snap = get_validator_set_snapshot(client).await?;
+    Ok((snap.active_rates, snap.epoch))
+}
+
+/// Read the full validator-set snapshot atomically.
+pub(crate) async fn get_validator_set_snapshot(
+    client: &mut Client,
+) -> Result<ValidatorSetSnapshot, Error> {
     let request = GetEpochRequest::latest().with_read_mask(FieldMask::from_paths([
         "epoch",
         "system_state.validators.active_validators",
+        "system_state.validators.inactive_validators",
     ]));
     let response = client
         .ledger_client()
@@ -190,7 +213,14 @@ pub(crate) async fn get_pool_exchange_rates_with_epoch(
     let epoch_obj = response.epoch();
     let epoch = epoch_obj.epoch();
     let system_state = epoch_obj.system_state();
-    let validators = system_state.validators().active_validators();
+    let validators_proto = system_state.validators();
+    let validators = validators_proto.active_validators();
+
+    let inactive_validators_table_id = validators_proto
+        .inactive_validators
+        .as_ref()
+        .and_then(|t| t.id.as_ref())
+        .cloned();
 
     let mut rates = std::collections::HashMap::new();
     for validator in validators {
@@ -212,7 +242,11 @@ pub(crate) async fn get_pool_exchange_rates_with_epoch(
             },
         );
     }
-    Ok((rates, epoch))
+    Ok(ValidatorSetSnapshot {
+        active_rates: rates,
+        epoch,
+        inactive_validators_table_id,
+    })
 }
 
 async fn get_sub_account_balances(

--- a/crates/sui-rosetta/src/construction.rs
+++ b/crates/sui-rosetta/src/construction.rs
@@ -293,6 +293,8 @@ pub async fn metadata(
         address_balance_withdrawal,
         fss_object_count,
         redeem_token_amount,
+        redeem_plan,
+        bind_epoch,
     } = option
         .internal_operation
         .try_fetch_needed_objects(&mut context.client.clone(), Some(gas_price), budget)
@@ -334,6 +336,8 @@ pub async fn metadata(
             chain_id,
             fss_object_count,
             redeem_token_amount,
+            redeem_plan,
+            bind_epoch,
         },
         suggested_fee: vec![Amount::new(budget as i128, None)],
     })

--- a/crates/sui-rosetta/src/construction.rs
+++ b/crates/sui-rosetta/src/construction.rs
@@ -310,9 +310,21 @@ pub async fn metadata(
         vec![]
     };
 
-    // Fetch epoch and chain_id for address-balance gas transactions
-    let (epoch, chain_id) = if gas_coins.is_empty() || address_balance_withdrawal > 0 {
-        let epoch = crate::get_current_epoch(&mut context.client.clone()).await?;
+    // Fetch epoch and chain_id for address-balance gas transactions.
+    //
+    // Prefer `bind_epoch` (atomic with the rate snapshot from
+    // `get_validator_set_snapshot`) over a separate `get_current_epoch` RPC.
+    // If both are needed and `bind_epoch` is set, reusing it both saves an
+    // RPC and guarantees `metadata.epoch == bind_epoch`. Without this, an
+    // epoch transition between the two RPCs would leave them disagreeing,
+    // causing the bind-epoch mismatch check at signing time to reject the
+    // metadata even though both reads were individually valid.
+    let needs_address_balance_metadata = gas_coins.is_empty() || address_balance_withdrawal > 0;
+    let (epoch, chain_id) = if needs_address_balance_metadata {
+        let epoch = match bind_epoch {
+            Some(e) => e,
+            None => crate::get_current_epoch(&mut context.client.clone()).await?,
+        };
         let chain_id_str =
             sui_types::digests::CheckpointDigest::new(*context.chain_id.as_bytes()).base58_encode();
         (Some(epoch), Some(chain_id_str))

--- a/crates/sui-rosetta/src/operations.rs
+++ b/crates/sui-rosetta/src/operations.rs
@@ -996,6 +996,7 @@ impl Operations {
         // coin::from_balance must consume the redeem result.
         let mut redeem_cmd_idx: Option<u32> = None;
         let mut balance_split_cmd_idx: Option<u32> = None;
+        let mut coin_from_balance_cmd_idx: Option<u32> = None;
 
         for (idx, command) in commands.iter().enumerate() {
             if phase == Phase::Done {
@@ -1133,6 +1134,7 @@ impl Operations {
                     if !Self::is_result_of(&m.arguments[0], redeem_cmd_idx) {
                         return None;
                     }
+                    coin_from_balance_cmd_idx = Some(idx as u32);
                     phase = Phase::AfterFromBalance;
                 }
                 Some(Command::TransferObjects(transfer)) => {
@@ -1142,7 +1144,12 @@ impl Operations {
                     if transfer.objects.len() != 1 {
                         return None;
                     }
-                    if transfer.objects[0].kind() != ArgumentKind::Result {
+                    // The single transferred object must be the Coin<SUI>
+                    // produced by `coin::from_balance` — anything else means
+                    // the chain redeemed but the user's wallet doesn't get
+                    // those funds, so this PTB is not a recognizable
+                    // MergeAndRedeem operation.
+                    if !Self::is_result_of(&transfer.objects[0], coin_from_balance_cmd_idx) {
                         return None;
                     }
                     let addr_arg = transfer.address();
@@ -1177,20 +1184,27 @@ impl Operations {
 
         let fss_ids = Self::input_indices_to_object_ids(inputs, &fss_indices)?;
         // PTB → metadata mapping:
-        //   no split, no guard         → All (amount = None)
+        //   no split, no guard         → All (amount = None) — could also be
+        //                                full-redeem AtMost since `max_sui` isn't
+        //                                encoded in PTB bytes; reporting All is
+        //                                acceptable because the user got "at most
+        //                                everything they had".
         //   split + balance guard      → AtLeast, amount = min_sui from balance::split
+        //   no split + balance guard   → full-redeem AtLeast (binary search picked
+        //                                exactly total_tokens, so the PTB skips
+        //                                `split_fungible_staked_sui` to avoid
+        //                                leaving zero-value FSS dust). Still
+        //                                emits AtLeast + recovered min_sui.
         //   split, no guard            → unknown partial mode (None) — the PTB only
-        //                                encodes token_count, not max_sui, so we cannot
-        //                                round-trip an AtMost cap from bytes alone
-        //   no split + guard           → invalid shape, fall through to generic
+        //                                encodes token_count, not max_sui, so we
+        //                                cannot round-trip an AtMost cap from bytes.
         let (redeem_mode, amount) = match (has_split_fss, has_balance_guard) {
             (false, false) => (Some(RedeemMode::All), None),
-            (true, true) => (
+            (true, true) | (false, true) => (
                 Some(RedeemMode::AtLeast),
                 min_sui_recovered.map(|v| v.to_string()),
             ),
             (true, false) => (None, None),
-            (false, true) => return None,
         };
 
         Some(vec![Operation {
@@ -1231,15 +1245,25 @@ impl Operations {
         oid == SUI_SYSTEM_STATE_OBJECT_ID
     }
 
-    /// Returns true iff `arg` is `Result(expected_idx)`. Used to verify
-    /// dataflow linkage in `parse_merge_and_redeem` — for example, that
-    /// `balance::split` actually consumes the result of `redeem_fss` rather
-    /// than some unrelated `Balance<SUI>` that happens to be in scope.
+    /// Returns true iff `arg` is exactly `Result(expected_idx)` — *not*
+    /// `NestedResult(expected_idx, j)`. Used to verify dataflow linkage in
+    /// `parse_merge_and_redeem` — for example, that `balance::split` actually
+    /// consumes the result of `redeem_fss` rather than some unrelated
+    /// `Balance<SUI>` that happens to be in scope.
+    ///
+    /// Both `Argument::Result` and `Argument::NestedResult` map to
+    /// `ArgumentKind::Result` in the proto encoding (see
+    /// `sui-types/src/rpc_proto_conversions.rs:2811-2826`); only the
+    /// `subresult` field distinguishes them. A crafted PTB using
+    /// `NestedResult(redeem_idx, 1)` would otherwise slip past kind/result
+    /// checks even though chain execution would reject it.
     fn is_result_of(arg: &Argument, expected_idx: Option<u32>) -> bool {
         let Some(expected) = expected_idx else {
             return false;
         };
-        arg.kind() == ArgumentKind::Result && arg.result() == expected
+        arg.kind() == ArgumentKind::Result
+            && arg.result() == expected
+            && arg.subresult_opt().is_none()
     }
 
     /// Resolves a list of input indices to ObjectIDs. Returns None if any index is
@@ -2776,7 +2800,7 @@ mod tests {
             sender,
             vec![fss],
             &RedeemPlan::AtMost {
-                token_amount: 500_000_000,
+                token_amount: Some(500_000_000),
                 max_sui: 0,
             },
         )
@@ -2792,7 +2816,7 @@ mod tests {
             sender,
             vec![fss],
             &RedeemPlan::AtLeast {
-                token_amount: 500_000_000,
+                token_amount: Some(500_000_000),
                 min_sui: 1_000_000,
             },
         )
@@ -2816,7 +2840,7 @@ mod tests {
             sender,
             vec![a, b, c],
             &RedeemPlan::AtLeast {
-                token_amount: 500_000_000,
+                token_amount: Some(500_000_000),
                 min_sui: 1_000_000,
             },
         )
@@ -2825,6 +2849,32 @@ mod tests {
             &parse_pt(sender, pt),
             sender,
             &[a.0, b.0, c.0],
+            Some(RedeemMode::AtLeast),
+            Some("1000000"),
+        );
+    }
+
+    #[test]
+    fn test_parse_merge_redeem_full_atleast_no_split() {
+        // Full-redeem AtLeast: token_amount = None → no `split_fungible_staked_sui`.
+        // The PTB still has the balance::split + balance::join guard, so the
+        // parser must recognize this shape as AtLeast (with min_sui recovered)
+        // rather than emitting `redeem_mode = None` because there's no FSS split.
+        let sender = SuiAddress::random_for_testing_only();
+        let fss = random_object_ref();
+        let pt = merge_and_redeem_fss_pt(
+            sender,
+            vec![fss],
+            &RedeemPlan::AtLeast {
+                token_amount: None,
+                min_sui: 1_000_000,
+            },
+        )
+        .expect("pt");
+        assert_merge_redeem_ops_with_amount(
+            &parse_pt(sender, pt),
+            sender,
+            &[fss.0],
             Some(RedeemMode::AtLeast),
             Some("1000000"),
         );
@@ -2853,7 +2903,7 @@ mod tests {
             sender,
             vec![a, b],
             &RedeemPlan::AtMost {
-                token_amount: 500_000_000,
+                token_amount: Some(500_000_000),
                 max_sui: 0,
             },
         )
@@ -2886,7 +2936,7 @@ mod tests {
             sender,
             vec![a, b, c],
             &RedeemPlan::AtMost {
-                token_amount: 500_000_000,
+                token_amount: Some(500_000_000),
                 max_sui: 0,
             },
         )
@@ -2942,7 +2992,7 @@ mod tests {
             sender,
             vec![fss],
             &RedeemPlan::AtMost {
-                token_amount: 500_000_000,
+                token_amount: Some(500_000_000),
                 max_sui: 0,
             },
         )
@@ -3585,6 +3635,104 @@ mod tests {
         // coin::from_balance arg[0] points at zero<SUI>, not at redeem result.
         let pt = build_malformed_atleast_ptb(sender, fss, true, true, true, false);
         assert_falls_through_to_generic(&parse_pt(sender, pt));
+    }
+
+    /// Hand-build a PTB whose `balance::split` argument is `NestedResult(redeem_idx, 0)`
+    /// rather than a plain `Result(redeem_idx)`. Both proto-encode as
+    /// `ArgumentKind::Result` (only `subresult` differs) so a parser that
+    /// only checks kind+result would slip past — `is_result_of` must also
+    /// require `subresult` is unset.
+    #[test]
+    fn test_parse_falls_through_atleast_split_arg_is_nested_result() {
+        use sui_types::transaction::Argument;
+        let sender = SuiAddress::random_for_testing_only();
+        let fss = random_object_ref();
+        let mut builder = ProgrammableTransactionBuilder::new();
+        let sys = builder.input(CallArg::SUI_SYSTEM_MUT).unwrap();
+        let fss_arg = builder.obj(ObjectArg::ImmOrOwnedObject(fss)).unwrap();
+        let split_amt = builder.pure(100u64).unwrap();
+        let split_fss = builder.command(NativeCommand::move_call(
+            SUI_SYSTEM_PACKAGE_ID,
+            Identifier::new("staking_pool").unwrap(),
+            Identifier::new("split_fungible_staked_sui").unwrap(),
+            vec![],
+            vec![fss_arg, split_amt],
+        ));
+        let _redeem = builder.command(NativeCommand::move_call(
+            SUI_SYSTEM_PACKAGE_ID,
+            Identifier::new("sui_system").unwrap(),
+            Identifier::new("redeem_fungible_staked_sui").unwrap(),
+            vec![],
+            vec![sys, split_fss],
+        ));
+        // The redeem result is at command index 1 (split is 0). Construct
+        // NestedResult(1, 0) by hand — it shares ArgumentKind::Result with
+        // a plain Result(1), distinguished only by `subresult`.
+        let nested = Argument::NestedResult(1, 0);
+        let min_arg = builder.pure(0u64).unwrap();
+        let split_balance = builder.command(NativeCommand::move_call(
+            SUI_FRAMEWORK_PACKAGE_ID,
+            Identifier::new("balance").unwrap(),
+            Identifier::new("split").unwrap(),
+            vec![sui_types::TypeTag::from_str("0x2::sui::SUI").unwrap()],
+            vec![nested, min_arg],
+        ));
+        builder.command(NativeCommand::move_call(
+            SUI_FRAMEWORK_PACKAGE_ID,
+            Identifier::new("balance").unwrap(),
+            Identifier::new("join").unwrap(),
+            vec![sui_types::TypeTag::from_str("0x2::sui::SUI").unwrap()],
+            vec![nested, split_balance],
+        ));
+        let coin = builder.command(NativeCommand::move_call(
+            SUI_FRAMEWORK_PACKAGE_ID,
+            Identifier::new("coin").unwrap(),
+            Identifier::new("from_balance").unwrap(),
+            vec![sui_types::TypeTag::from_str("0x2::sui::SUI").unwrap()],
+            vec![nested],
+        ));
+        let sender_arg = builder.pure(sender).unwrap();
+        builder.command(NativeCommand::TransferObjects(vec![coin], sender_arg));
+        assert_falls_through_to_generic(&parse_pt(sender, builder.finish()));
+    }
+
+    /// TransferObjects must move the `coin::from_balance` result, not some
+    /// unrelated `Result`. Build a PTB that has the right shape up to and
+    /// including `coin::from_balance` but then transfers a different coin.
+    #[test]
+    fn test_parse_falls_through_transfer_not_from_balance_result() {
+        let sender = SuiAddress::random_for_testing_only();
+        let fss = random_object_ref();
+        let mut builder = ProgrammableTransactionBuilder::new();
+        let sys = builder.input(CallArg::SUI_SYSTEM_MUT).unwrap();
+        let fss_arg = builder.obj(ObjectArg::ImmOrOwnedObject(fss)).unwrap();
+        let redeem = builder.command(NativeCommand::move_call(
+            SUI_SYSTEM_PACKAGE_ID,
+            Identifier::new("sui_system").unwrap(),
+            Identifier::new("redeem_fungible_staked_sui").unwrap(),
+            vec![],
+            vec![sys, fss_arg],
+        ));
+        let _from_balance = builder.command(NativeCommand::move_call(
+            SUI_FRAMEWORK_PACKAGE_ID,
+            Identifier::new("coin").unwrap(),
+            Identifier::new("from_balance").unwrap(),
+            vec![sui_types::TypeTag::from_str("0x2::sui::SUI").unwrap()],
+            vec![redeem],
+        ));
+        // Construct a different Coin<SUI> via `coin::zero<SUI>` and transfer
+        // *that* instead of the from_balance result. The PTB shape up to here
+        // matches a recognized All-mode redeem, but the transfer target is wrong.
+        let other_coin = builder.command(NativeCommand::move_call(
+            SUI_FRAMEWORK_PACKAGE_ID,
+            Identifier::new("coin").unwrap(),
+            Identifier::new("zero").unwrap(),
+            vec![sui_types::TypeTag::from_str("0x2::sui::SUI").unwrap()],
+            vec![],
+        ));
+        let sender_arg = builder.pure(sender).unwrap();
+        builder.command(NativeCommand::TransferObjects(vec![other_coin], sender_arg));
+        assert_falls_through_to_generic(&parse_pt(sender, builder.finish()));
     }
 
     // ==============================================================================

--- a/crates/sui-rosetta/src/operations.rs
+++ b/crates/sui-rosetta/src/operations.rs
@@ -34,6 +34,8 @@ use sui_types::{
     SUI_FRAMEWORK_PACKAGE_ID, SUI_SYSTEM_ADDRESS, SUI_SYSTEM_PACKAGE_ID, SUI_SYSTEM_STATE_OBJECT_ID,
 };
 
+#[cfg(test)]
+use crate::types::RedeemPlan;
 use crate::types::internal_operation::{
     ConsolidateAllStakedSuiToFungible, MergeAndRedeemFungibleStakedSui, PayCoin, PaySui, Stake,
     WithdrawStake,
@@ -934,16 +936,22 @@ impl Operations {
 
     /// Parse a PTB that represents `MergeAndRedeemFungibleStakedSui`.
     ///
-    /// Strict shape produced by `merge_and_redeem_fss_pt`:
-    ///   `[join_fss]*, [split_fss]?, redeem_fss, coin::from_balance<SUI>, TransferObjects`
-    /// where:
-    /// - `[join_fss]*` means zero or more joins (N-1 joins for N FSS inputs)
-    /// - `[split_fss]?` is present only for partial redemption (AtLeast/AtMost modes)
-    /// - exactly one `redeem_fss`, `from_balance<SUI>`, and trailing `TransferObjects`
+    /// Recognized shapes (all produced by `merge_and_redeem_fss_pt`):
+    /// 1. `All`: `[join_fss]*, redeem_fss, coin::from_balance<SUI>, TransferObjects`
+    /// 2. `AtMost`: `[join_fss]*, split_fss, redeem_fss, coin::from_balance<SUI>, TransferObjects`
+    /// 3. `AtLeast`: `[join_fss]*, split_fss, redeem_fss, balance::split<SUI>, balance::join<SUI>, coin::from_balance<SUI>, TransferObjects`
     ///
-    /// Emits `redeem_mode = Some(All)` when no split is present, `None` when split is
-    /// present (AtLeast vs AtMost are indistinguishable from PTB bytes). Returns `None`
-    /// on any shape mismatch, causing fall-through to generic op.
+    /// The `balance::split + balance::join` pair after `redeem_fss` is the AtLeast
+    /// runtime guard: the chain-side `balance::split(min_sui)` aborts if the redeemed
+    /// balance is below `min_sui`, then the join restores the original balance for
+    /// `coin::from_balance` to consume in full.
+    ///
+    /// Emits:
+    /// * `Some(All)` when no `split_fungible_staked_sui` is present.
+    /// * `Some(AtLeast)` when a split_fungible_staked_sui plus `balance::split + balance::join` guard pair are present.
+    /// * `Some(AtMost)` when a split_fungible_staked_sui is present without the balance guard.
+    ///
+    /// Returns `None` on any shape mismatch, causing fall-through to generic op.
     fn parse_merge_and_redeem(
         sender: SuiAddress,
         inputs: &[Input],
@@ -961,6 +969,8 @@ impl Operations {
             Joins,
             AfterSplit,
             AfterRedeem,
+            AfterBalanceSplit,
+            AfterBalanceJoin,
             AfterFromBalance,
             Done,
         }
@@ -968,7 +978,8 @@ impl Operations {
         let mut phase = Phase::Joins;
         let mut fss_indices: Vec<u32> = Vec::new();
         let mut fss_seen: BTreeSet<u32> = BTreeSet::new();
-        let mut has_split = false;
+        let mut has_split_fss = false;
+        let mut has_balance_guard = false;
 
         for (idx, command) in commands.iter().enumerate() {
             if phase == Phase::Done {
@@ -1002,7 +1013,6 @@ impl Operations {
                     if m.arguments.len() != 2 {
                         return None;
                     }
-                    // First arg = the FSS being split (Input or Result from prior joins).
                     let first = &m.arguments[0];
                     match first.kind() {
                         ArgumentKind::Input => {
@@ -1014,8 +1024,6 @@ impl Operations {
                         ArgumentKind::Result => {}
                         _ => return None,
                     }
-                    // Second arg must be a pure u64 split amount. We don't decode it for
-                    // metadata, but we verify the input kind is Pure (not an object ref).
                     if m.arguments[1].kind() != ArgumentKind::Input {
                         return None;
                     }
@@ -1023,7 +1031,7 @@ impl Operations {
                     if inputs.get(amount_idx).map(|i| i.kind()) != Some(InputKind::Pure) {
                         return None;
                     }
-                    has_split = true;
+                    has_split_fss = true;
                     phase = Phase::AfterSplit;
                 }
                 Some(Command::MoveCall(m)) if Self::is_redeem_fss_call(m) => {
@@ -1033,7 +1041,6 @@ impl Operations {
                     if m.arguments.len() != 2 {
                         return None;
                     }
-                    // arguments[0] must reference inputs[0] (SUI_SYSTEM_STATE, verified above).
                     if m.arguments[0].kind() != ArgumentKind::Input || m.arguments[0].input() != 0 {
                         return None;
                     }
@@ -1050,8 +1057,34 @@ impl Operations {
                     }
                     phase = Phase::AfterRedeem;
                 }
-                Some(Command::MoveCall(m)) if Self::is_coin_from_balance_sui_call(m) => {
+                Some(Command::MoveCall(m)) if Self::is_balance_split_sui_call(m) => {
                     if phase != Phase::AfterRedeem {
+                        return None;
+                    }
+                    if m.arguments.len() != 2 {
+                        return None;
+                    }
+                    if m.arguments[1].kind() != ArgumentKind::Input {
+                        return None;
+                    }
+                    let amount_idx = m.arguments[1].input() as usize;
+                    if inputs.get(amount_idx).map(|i| i.kind()) != Some(InputKind::Pure) {
+                        return None;
+                    }
+                    phase = Phase::AfterBalanceSplit;
+                }
+                Some(Command::MoveCall(m)) if Self::is_balance_join_sui_call(m) => {
+                    if phase != Phase::AfterBalanceSplit {
+                        return None;
+                    }
+                    if m.arguments.len() != 2 {
+                        return None;
+                    }
+                    has_balance_guard = true;
+                    phase = Phase::AfterBalanceJoin;
+                }
+                Some(Command::MoveCall(m)) if Self::is_coin_from_balance_sui_call(m) => {
+                    if phase != Phase::AfterRedeem && phase != Phase::AfterBalanceJoin {
                         return None;
                     }
                     phase = Phase::AfterFromBalance;
@@ -1097,10 +1130,11 @@ impl Operations {
         }
 
         let fss_ids = Self::input_indices_to_object_ids(inputs, &fss_indices)?;
-        let redeem_mode = if has_split {
-            None
-        } else {
-            Some(RedeemMode::All)
+        let redeem_mode = match (has_split_fss, has_balance_guard) {
+            (false, false) => Some(RedeemMode::All),
+            (true, true) => Some(RedeemMode::AtLeast),
+            (true, false) => Some(RedeemMode::AtMost),
+            (false, true) => return None, // balance guard without prior split is invalid
         };
 
         Some(vec![Operation {
@@ -1289,6 +1323,40 @@ impl Operations {
         // Parse via TypeTag::from_str and compare structurally so any canonicalization
         // of the SUI type (padded, short, or legacy string forms) matches. This
         // future-proofs against encoder changes that emit non-canonical type strings.
+        let Ok(parsed) = sui_types::TypeTag::from_str(&tx.type_arguments[0]) else {
+            return false;
+        };
+        let Ok(expected) = sui_types::TypeTag::from_str("0x2::sui::SUI") else {
+            return false;
+        };
+        parsed == expected
+    }
+
+    /// Recognizes `balance::split<SUI>` calls used as the AtLeast runtime guard
+    /// in `merge_and_redeem_fss_pt`.
+    fn is_balance_split_sui_call(tx: &MoveCall) -> bool {
+        Self::is_balance_op_sui_call(tx, "split")
+    }
+
+    /// Recognizes `balance::join<SUI>` calls that pair with the AtLeast guard
+    /// to put the split-off sub-balance back into the original.
+    fn is_balance_join_sui_call(tx: &MoveCall) -> bool {
+        Self::is_balance_op_sui_call(tx, "join")
+    }
+
+    fn is_balance_op_sui_call(tx: &MoveCall, function: &str) -> bool {
+        let Ok(package_id) = ObjectID::from_str(tx.package()) else {
+            return false;
+        };
+        if package_id != SUI_FRAMEWORK_PACKAGE_ID {
+            return false;
+        }
+        if tx.module() != "balance" || tx.function() != function {
+            return false;
+        }
+        if tx.type_arguments.len() != 1 {
+            return false;
+        }
         let Ok(parsed) = sui_types::TypeTag::from_str(&tx.type_arguments[0]) else {
             return false;
         };
@@ -2007,6 +2075,8 @@ mod tests {
             chain_id: None,
             fss_object_count: None,
             redeem_token_amount: None,
+            redeem_plan: None,
+            bind_epoch: None,
         };
         let parsed_data = ops.into_internal()?.try_into_data(metadata)?;
         assert_eq!(data, parsed_data);
@@ -2069,6 +2139,8 @@ mod tests {
             chain_id: None,
             fss_object_count: None,
             redeem_token_amount: None,
+            redeem_plan: None,
+            bind_epoch: None,
         };
         let parsed_data = ops.into_internal()?.try_into_data(metadata)?;
         assert_eq!(data, parsed_data);
@@ -2603,7 +2675,7 @@ mod tests {
     fn test_parse_merge_redeem_single_all() {
         let sender = SuiAddress::random_for_testing_only();
         let fss = random_object_ref();
-        let pt = merge_and_redeem_fss_pt(sender, vec![fss], None).expect("pt");
+        let pt = merge_and_redeem_fss_pt(sender, vec![fss], &RedeemPlan::All).expect("pt");
         assert_merge_redeem_ops(
             &parse_pt(sender, pt),
             sender,
@@ -2616,8 +2688,65 @@ mod tests {
     fn test_parse_merge_redeem_single_partial() {
         let sender = SuiAddress::random_for_testing_only();
         let fss = random_object_ref();
-        let pt = merge_and_redeem_fss_pt(sender, vec![fss], Some(500_000_000)).expect("pt");
-        assert_merge_redeem_ops(&parse_pt(sender, pt), sender, &[fss.0], None);
+        let pt = merge_and_redeem_fss_pt(
+            sender,
+            vec![fss],
+            &RedeemPlan::AtMost {
+                token_amount: 500_000_000,
+                max_sui: 0,
+            },
+        )
+        .expect("pt");
+        assert_merge_redeem_ops(
+            &parse_pt(sender, pt),
+            sender,
+            &[fss.0],
+            Some(RedeemMode::AtMost),
+        );
+    }
+
+    #[test]
+    fn test_parse_merge_redeem_atleast_with_balance_guard() {
+        let sender = SuiAddress::random_for_testing_only();
+        let fss = random_object_ref();
+        let pt = merge_and_redeem_fss_pt(
+            sender,
+            vec![fss],
+            &RedeemPlan::AtLeast {
+                token_amount: 500_000_000,
+                min_sui: 1_000_000,
+            },
+        )
+        .expect("pt");
+        assert_merge_redeem_ops(
+            &parse_pt(sender, pt),
+            sender,
+            &[fss.0],
+            Some(RedeemMode::AtLeast),
+        );
+    }
+
+    #[test]
+    fn test_parse_merge_redeem_atleast_three_fss() {
+        let sender = SuiAddress::random_for_testing_only();
+        let a = random_object_ref();
+        let b = random_object_ref();
+        let c = random_object_ref();
+        let pt = merge_and_redeem_fss_pt(
+            sender,
+            vec![a, b, c],
+            &RedeemPlan::AtLeast {
+                token_amount: 500_000_000,
+                min_sui: 1_000_000,
+            },
+        )
+        .expect("pt");
+        assert_merge_redeem_ops(
+            &parse_pt(sender, pt),
+            sender,
+            &[a.0, b.0, c.0],
+            Some(RedeemMode::AtLeast),
+        );
     }
 
     #[test]
@@ -2625,7 +2754,7 @@ mod tests {
         let sender = SuiAddress::random_for_testing_only();
         let a = random_object_ref();
         let b = random_object_ref();
-        let pt = merge_and_redeem_fss_pt(sender, vec![a, b], None).expect("pt");
+        let pt = merge_and_redeem_fss_pt(sender, vec![a, b], &RedeemPlan::All).expect("pt");
         assert_merge_redeem_ops(
             &parse_pt(sender, pt),
             sender,
@@ -2639,8 +2768,21 @@ mod tests {
         let sender = SuiAddress::random_for_testing_only();
         let a = random_object_ref();
         let b = random_object_ref();
-        let pt = merge_and_redeem_fss_pt(sender, vec![a, b], Some(500_000_000)).expect("pt");
-        assert_merge_redeem_ops(&parse_pt(sender, pt), sender, &[a.0, b.0], None);
+        let pt = merge_and_redeem_fss_pt(
+            sender,
+            vec![a, b],
+            &RedeemPlan::AtMost {
+                token_amount: 500_000_000,
+                max_sui: 0,
+            },
+        )
+        .expect("pt");
+        assert_merge_redeem_ops(
+            &parse_pt(sender, pt),
+            sender,
+            &[a.0, b.0],
+            Some(RedeemMode::AtMost),
+        );
     }
 
     #[test]
@@ -2649,7 +2791,7 @@ mod tests {
         let a = random_object_ref();
         let b = random_object_ref();
         let c = random_object_ref();
-        let pt = merge_and_redeem_fss_pt(sender, vec![a, b, c], None).expect("pt");
+        let pt = merge_and_redeem_fss_pt(sender, vec![a, b, c], &RedeemPlan::All).expect("pt");
         assert_merge_redeem_ops(
             &parse_pt(sender, pt),
             sender,
@@ -2664,15 +2806,28 @@ mod tests {
         let a = random_object_ref();
         let b = random_object_ref();
         let c = random_object_ref();
-        let pt = merge_and_redeem_fss_pt(sender, vec![a, b, c], Some(500_000_000)).expect("pt");
-        assert_merge_redeem_ops(&parse_pt(sender, pt), sender, &[a.0, b.0, c.0], None);
+        let pt = merge_and_redeem_fss_pt(
+            sender,
+            vec![a, b, c],
+            &RedeemPlan::AtMost {
+                token_amount: 500_000_000,
+                max_sui: 0,
+            },
+        )
+        .expect("pt");
+        assert_merge_redeem_ops(
+            &parse_pt(sender, pt),
+            sender,
+            &[a.0, b.0, c.0],
+            Some(RedeemMode::AtMost),
+        );
     }
 
     #[test]
     fn test_parse_merge_redeem_five_all() {
         let sender = SuiAddress::random_for_testing_only();
         let refs: Vec<_> = (0..5).map(|_| random_object_ref()).collect();
-        let pt = merge_and_redeem_fss_pt(sender, refs.clone(), None).expect("pt");
+        let pt = merge_and_redeem_fss_pt(sender, refs.clone(), &RedeemPlan::All).expect("pt");
         let expected: Vec<_> = refs.iter().map(|r| r.0).collect();
         assert_merge_redeem_ops(
             &parse_pt(sender, pt),
@@ -2689,7 +2844,7 @@ mod tests {
         let a = random_object_ref();
         let b = random_object_ref();
         let c = random_object_ref();
-        let pt = merge_and_redeem_fss_pt(sender, vec![a, b, c], None).expect("pt");
+        let pt = merge_and_redeem_fss_pt(sender, vec![a, b, c], &RedeemPlan::All).expect("pt");
         let ops = parse_pt(sender, pt);
         let Some(OperationMetadata::MergeAndRedeemFungibleStakedSui { fss_ids, .. }) =
             ops[0].metadata.clone()
@@ -2703,7 +2858,7 @@ mod tests {
     fn test_parse_merge_redeem_sender_account() {
         let sender = SuiAddress::random_for_testing_only();
         let fss = random_object_ref();
-        let pt = merge_and_redeem_fss_pt(sender, vec![fss], None).expect("pt");
+        let pt = merge_and_redeem_fss_pt(sender, vec![fss], &RedeemPlan::All).expect("pt");
         let ops = parse_pt(sender, pt);
         assert_eq!(ops[0].account.as_ref().unwrap().address, sender);
     }
@@ -2712,7 +2867,15 @@ mod tests {
     fn test_parse_merge_redeem_no_amount_in_metadata() {
         let sender = SuiAddress::random_for_testing_only();
         let fss = random_object_ref();
-        let pt = merge_and_redeem_fss_pt(sender, vec![fss], Some(500_000_000)).expect("pt");
+        let pt = merge_and_redeem_fss_pt(
+            sender,
+            vec![fss],
+            &RedeemPlan::AtMost {
+                token_amount: 500_000_000,
+                max_sui: 0,
+            },
+        )
+        .expect("pt");
         let ops = parse_pt(sender, pt);
         let Some(OperationMetadata::MergeAndRedeemFungibleStakedSui { amount, .. }) =
             ops[0].metadata.clone()
@@ -2726,7 +2889,7 @@ mod tests {
     fn test_parse_merge_redeem_no_validator_in_metadata() {
         let sender = SuiAddress::random_for_testing_only();
         let fss = random_object_ref();
-        let pt = merge_and_redeem_fss_pt(sender, vec![fss], None).expect("pt");
+        let pt = merge_and_redeem_fss_pt(sender, vec![fss], &RedeemPlan::All).expect("pt");
         let ops = parse_pt(sender, pt);
         let Some(OperationMetadata::MergeAndRedeemFungibleStakedSui { validator, .. }) =
             ops[0].metadata.clone()

--- a/crates/sui-rosetta/src/operations.rs
+++ b/crates/sui-rosetta/src/operations.rs
@@ -980,6 +980,7 @@ impl Operations {
         let mut fss_seen: BTreeSet<u32> = BTreeSet::new();
         let mut has_split_fss = false;
         let mut has_balance_guard = false;
+        let mut min_sui_recovered: Option<u64> = None;
 
         for (idx, command) in commands.iter().enumerate() {
             if phase == Phase::Done {
@@ -1068,9 +1069,14 @@ impl Operations {
                         return None;
                     }
                     let amount_idx = m.arguments[1].input() as usize;
-                    if inputs.get(amount_idx).map(|i| i.kind()) != Some(InputKind::Pure) {
+                    let pure_input = inputs.get(amount_idx)?;
+                    if pure_input.kind() != InputKind::Pure {
                         return None;
                     }
+                    // Decode min_sui from the Pure u64 input. Failure here means
+                    // the PTB carries a malformed split amount; fall through.
+                    let min_sui = bcs::from_bytes::<u64>(pure_input.pure()).ok()?;
+                    min_sui_recovered = Some(min_sui);
                     phase = Phase::AfterBalanceSplit;
                 }
                 Some(Command::MoveCall(m)) if Self::is_balance_join_sui_call(m) => {
@@ -1130,11 +1136,21 @@ impl Operations {
         }
 
         let fss_ids = Self::input_indices_to_object_ids(inputs, &fss_indices)?;
-        let redeem_mode = match (has_split_fss, has_balance_guard) {
-            (false, false) => Some(RedeemMode::All),
-            (true, true) => Some(RedeemMode::AtLeast),
-            (true, false) => Some(RedeemMode::AtMost),
-            (false, true) => return None, // balance guard without prior split is invalid
+        // PTB → metadata mapping:
+        //   no split, no guard         → All (amount = None)
+        //   split + balance guard      → AtLeast, amount = min_sui from balance::split
+        //   split, no guard            → unknown partial mode (None) — the PTB only
+        //                                encodes token_count, not max_sui, so we cannot
+        //                                round-trip an AtMost cap from bytes alone
+        //   no split + guard           → invalid shape, fall through to generic
+        let (redeem_mode, amount) = match (has_split_fss, has_balance_guard) {
+            (false, false) => (Some(RedeemMode::All), None),
+            (true, true) => (
+                Some(RedeemMode::AtLeast),
+                min_sui_recovered.map(|v| v.to_string()),
+            ),
+            (true, false) => (None, None),
+            (false, true) => return None,
         };
 
         Some(vec![Operation {
@@ -1146,7 +1162,7 @@ impl Operations {
             coin_change: None,
             metadata: Some(OperationMetadata::MergeAndRedeemFungibleStakedSui {
                 validator: None,
-                amount: None,
+                amount,
                 redeem_mode,
                 fss_ids,
             }),
@@ -2645,6 +2661,22 @@ mod tests {
         expected_fss: &[ObjectID],
         expected_mode: Option<RedeemMode>,
     ) {
+        assert_merge_redeem_ops_with_amount(
+            ops,
+            expected_sender,
+            expected_fss,
+            expected_mode,
+            None,
+        );
+    }
+
+    fn assert_merge_redeem_ops_with_amount(
+        ops: &[Operation],
+        expected_sender: SuiAddress,
+        expected_fss: &[ObjectID],
+        expected_mode: Option<RedeemMode>,
+        expected_amount: Option<&str>,
+    ) {
         assert_eq!(ops.len(), 1);
         let op = &ops[0];
         assert_eq!(op.type_, OperationType::MergeAndRedeemFungibleStakedSui);
@@ -2663,9 +2695,10 @@ mod tests {
             panic!("wrong metadata variant: {:?}", op.metadata);
         };
         assert!(validator.is_none(), "validator must be None on parse");
-        assert!(
-            amount.is_none(),
-            "amount must be None on parse (not in PTB)"
+        assert_eq!(
+            amount.as_deref(),
+            expected_amount,
+            "metadata.amount mismatch"
         );
         assert_eq!(redeem_mode, expected_mode);
         assert_eq!(fss_ids, expected_fss);
@@ -2697,12 +2730,7 @@ mod tests {
             },
         )
         .expect("pt");
-        assert_merge_redeem_ops(
-            &parse_pt(sender, pt),
-            sender,
-            &[fss.0],
-            Some(RedeemMode::AtMost),
-        );
+        assert_merge_redeem_ops(&parse_pt(sender, pt), sender, &[fss.0], None);
     }
 
     #[test]
@@ -2718,11 +2746,12 @@ mod tests {
             },
         )
         .expect("pt");
-        assert_merge_redeem_ops(
+        assert_merge_redeem_ops_with_amount(
             &parse_pt(sender, pt),
             sender,
             &[fss.0],
             Some(RedeemMode::AtLeast),
+            Some("1000000"),
         );
     }
 
@@ -2741,11 +2770,12 @@ mod tests {
             },
         )
         .expect("pt");
-        assert_merge_redeem_ops(
+        assert_merge_redeem_ops_with_amount(
             &parse_pt(sender, pt),
             sender,
             &[a.0, b.0, c.0],
             Some(RedeemMode::AtLeast),
+            Some("1000000"),
         );
     }
 
@@ -2777,12 +2807,7 @@ mod tests {
             },
         )
         .expect("pt");
-        assert_merge_redeem_ops(
-            &parse_pt(sender, pt),
-            sender,
-            &[a.0, b.0],
-            Some(RedeemMode::AtMost),
-        );
+        assert_merge_redeem_ops(&parse_pt(sender, pt), sender, &[a.0, b.0], None);
     }
 
     #[test]
@@ -2815,12 +2840,7 @@ mod tests {
             },
         )
         .expect("pt");
-        assert_merge_redeem_ops(
-            &parse_pt(sender, pt),
-            sender,
-            &[a.0, b.0, c.0],
-            Some(RedeemMode::AtMost),
-        );
+        assert_merge_redeem_ops(&parse_pt(sender, pt), sender, &[a.0, b.0, c.0], None);
     }
 
     #[test]

--- a/crates/sui-rosetta/src/operations.rs
+++ b/crates/sui-rosetta/src/operations.rs
@@ -938,18 +938,27 @@ impl Operations {
     ///
     /// Recognized shapes (all produced by `merge_and_redeem_fss_pt`):
     /// 1. `All`: `[join_fss]*, redeem_fss, coin::from_balance<SUI>, TransferObjects`
-    /// 2. `AtMost`: `[join_fss]*, split_fss, redeem_fss, coin::from_balance<SUI>, TransferObjects`
+    /// 2. Partial without guard: `[join_fss]*, split_fss, redeem_fss, coin::from_balance<SUI>, TransferObjects`
     /// 3. `AtLeast`: `[join_fss]*, split_fss, redeem_fss, balance::split<SUI>, balance::join<SUI>, coin::from_balance<SUI>, TransferObjects`
     ///
     /// The `balance::split + balance::join` pair after `redeem_fss` is the AtLeast
-    /// runtime guard: the chain-side `balance::split(min_sui)` aborts if the redeemed
-    /// balance is below `min_sui`, then the join restores the original balance for
-    /// `coin::from_balance` to consume in full.
+    /// runtime guard: the chain-side `balance::split(min_sui)` aborts if the
+    /// redeemed balance is below `min_sui`, then the join restores the original
+    /// balance for `coin::from_balance` to consume in full. The parser also
+    /// verifies that this guard's arguments are wired to the actual redeem
+    /// result (not an unrelated `Balance<SUI>`) — see `is_result_of`.
     ///
     /// Emits:
     /// * `Some(All)` when no `split_fungible_staked_sui` is present.
-    /// * `Some(AtLeast)` when a split_fungible_staked_sui plus `balance::split + balance::join` guard pair are present.
-    /// * `Some(AtMost)` when a split_fungible_staked_sui is present without the balance guard.
+    /// * `Some(AtLeast)` + `metadata.amount = Some(min_sui)` when a
+    ///   `split_fungible_staked_sui` plus correctly-wired `balance::split +
+    ///   balance::join` guard pair are present. `min_sui` is decoded from the
+    ///   pure u64 input to `balance::split`.
+    /// * `redeem_mode = None` when a `split_fungible_staked_sui` is present
+    ///   without the balance guard. This corresponds to a partial redeem whose
+    ///   user-facing intent (`AtMost(max_sui)` vs older builders that didn't
+    ///   add a guard) cannot be recovered from PTB bytes alone — only the
+    ///   token count is encoded, not the original `max_sui` cap.
     ///
     /// Returns `None` on any shape mismatch, causing fall-through to generic op.
     fn parse_merge_and_redeem(
@@ -981,6 +990,12 @@ impl Operations {
         let mut has_split_fss = false;
         let mut has_balance_guard = false;
         let mut min_sui_recovered: Option<u64> = None;
+        // Command indices used to verify the AtLeast guard wires correctly:
+        // balance::split must consume the redeem result, balance::join must
+        // consume the redeem result and the split result, and the final
+        // coin::from_balance must consume the redeem result.
+        let mut redeem_cmd_idx: Option<u32> = None;
+        let mut balance_split_cmd_idx: Option<u32> = None;
 
         for (idx, command) in commands.iter().enumerate() {
             if phase == Phase::Done {
@@ -1056,6 +1071,7 @@ impl Operations {
                         ArgumentKind::Result => {}
                         _ => return None,
                     }
+                    redeem_cmd_idx = Some(idx as u32);
                     phase = Phase::AfterRedeem;
                 }
                 Some(Command::MoveCall(m)) if Self::is_balance_split_sui_call(m) => {
@@ -1065,6 +1081,11 @@ impl Operations {
                     if m.arguments.len() != 2 {
                         return None;
                     }
+                    // arg[0] must be the redeem result we just produced.
+                    if !Self::is_result_of(&m.arguments[0], redeem_cmd_idx) {
+                        return None;
+                    }
+                    // arg[1] must be a Pure u64 split amount.
                     if m.arguments[1].kind() != ArgumentKind::Input {
                         return None;
                     }
@@ -1077,6 +1098,7 @@ impl Operations {
                     // the PTB carries a malformed split amount; fall through.
                     let min_sui = bcs::from_bytes::<u64>(pure_input.pure()).ok()?;
                     min_sui_recovered = Some(min_sui);
+                    balance_split_cmd_idx = Some(idx as u32);
                     phase = Phase::AfterBalanceSplit;
                 }
                 Some(Command::MoveCall(m)) if Self::is_balance_join_sui_call(m) => {
@@ -1086,11 +1108,29 @@ impl Operations {
                     if m.arguments.len() != 2 {
                         return None;
                     }
+                    // arg[0] must be the redeem result; arg[1] must be the
+                    // balance::split result. Otherwise the guard isn't actually
+                    // protecting the redeemed balance — could be a different
+                    // sub-balance, which means the parser cannot claim AtLeast.
+                    if !Self::is_result_of(&m.arguments[0], redeem_cmd_idx) {
+                        return None;
+                    }
+                    if !Self::is_result_of(&m.arguments[1], balance_split_cmd_idx) {
+                        return None;
+                    }
                     has_balance_guard = true;
                     phase = Phase::AfterBalanceJoin;
                 }
                 Some(Command::MoveCall(m)) if Self::is_coin_from_balance_sui_call(m) => {
                     if phase != Phase::AfterRedeem && phase != Phase::AfterBalanceJoin {
+                        return None;
+                    }
+                    if m.arguments.len() != 1 {
+                        return None;
+                    }
+                    // The Coin<SUI> handed to TransferObjects must be derived
+                    // from the redeem result, not from some other Balance.
+                    if !Self::is_result_of(&m.arguments[0], redeem_cmd_idx) {
                         return None;
                     }
                     phase = Phase::AfterFromBalance;
@@ -1189,6 +1229,17 @@ impl Operations {
             return false;
         };
         oid == SUI_SYSTEM_STATE_OBJECT_ID
+    }
+
+    /// Returns true iff `arg` is `Result(expected_idx)`. Used to verify
+    /// dataflow linkage in `parse_merge_and_redeem` — for example, that
+    /// `balance::split` actually consumes the result of `redeem_fss` rather
+    /// than some unrelated `Balance<SUI>` that happens to be in scope.
+    fn is_result_of(arg: &Argument, expected_idx: Option<u32>) -> bool {
+        let Some(expected) = expected_idx else {
+            return false;
+        };
+        arg.kind() == ArgumentKind::Result && arg.result() == expected
     }
 
     /// Resolves a list of input indices to ObjectIDs. Returns None if any index is
@@ -3384,6 +3435,156 @@ mod tests {
         builder.command(NativeCommand::TransferObjects(vec![new_fss], sender_arg));
         let ops = parse_pt(sender, builder.finish());
         assert_falls_through_to_generic(&ops);
+    }
+
+    // ==============================================================================
+    // AtLeast guard dataflow linkage tests
+    //
+    // The AtLeast PTB shape is:
+    //   redeem_fss → balance::split<SUI> → balance::join<SUI> → coin::from_balance<SUI>
+    // and the parser must verify that the guard operates on the redeem result
+    // (not on some unrelated Balance<SUI>) — otherwise a malformed PTB could be
+    // misclassified as a typed AtLeast op even though the chain wouldn't enforce
+    // the guarantee on the redeemed balance.
+    // ==============================================================================
+
+    /// Build a malformed AtLeast PTB where the AtLeast guard operates on a
+    /// freshly-created `Balance<SUI>` (via `balance::zero<SUI>`) rather than
+    /// on the redeem result. Type-checks on chain (the chain doesn't care if
+    /// the guard runs against a different balance), but the parser must NOT
+    /// emit `Some(AtLeast)` for this PTB because the balance::split is not
+    /// gating the redeemed balance.
+    ///
+    /// NOTE: chain validation might still reject the resulting PTB for other
+    /// reasons (orphaned redeem result), but as far as the parser shape match
+    /// goes we want it to fall through to a generic op.
+    fn build_malformed_atleast_ptb(
+        sender: SuiAddress,
+        fss: ObjectRef,
+        wire_split_to_redeem: bool,
+        wire_join_to_redeem: bool,
+        wire_join_arg1_to_split: bool,
+        wire_from_balance_to_redeem: bool,
+    ) -> ProgrammableTransaction {
+        use sui_types::transaction::Argument;
+        let mut builder = ProgrammableTransactionBuilder::new();
+        let sys = builder.input(CallArg::SUI_SYSTEM_MUT).unwrap();
+        let fss_arg = builder.obj(ObjectArg::ImmOrOwnedObject(fss)).unwrap();
+        let split_amt = builder.pure(100u64).unwrap();
+        // Split fss to make the shape AtLeast/AtMost-like (with split_fss before redeem).
+        let split_fss = builder.command(NativeCommand::move_call(
+            SUI_SYSTEM_PACKAGE_ID,
+            Identifier::new("staking_pool").unwrap(),
+            Identifier::new("split_fungible_staked_sui").unwrap(),
+            vec![],
+            vec![fss_arg, split_amt],
+        ));
+        let redeem_balance = builder.command(NativeCommand::move_call(
+            SUI_SYSTEM_PACKAGE_ID,
+            Identifier::new("sui_system").unwrap(),
+            Identifier::new("redeem_fungible_staked_sui").unwrap(),
+            vec![],
+            vec![sys, split_fss],
+        ));
+        // Make a separate Balance<SUI> via `balance::zero<SUI>` to have a
+        // distinct Balance<SUI> Result available for the malformed wiring.
+        let zero_balance = builder.command(NativeCommand::move_call(
+            SUI_FRAMEWORK_PACKAGE_ID,
+            Identifier::new("balance").unwrap(),
+            Identifier::new("zero").unwrap(),
+            vec![sui_types::TypeTag::from_str("0x2::sui::SUI").unwrap()],
+            vec![],
+        ));
+        let min_arg = builder.pure(0u64).unwrap();
+        let split_arg0 = if wire_split_to_redeem {
+            redeem_balance
+        } else {
+            zero_balance
+        };
+        let split_result = builder.command(NativeCommand::move_call(
+            SUI_FRAMEWORK_PACKAGE_ID,
+            Identifier::new("balance").unwrap(),
+            Identifier::new("split").unwrap(),
+            vec![sui_types::TypeTag::from_str("0x2::sui::SUI").unwrap()],
+            vec![split_arg0, min_arg],
+        ));
+        let join_arg0 = if wire_join_to_redeem {
+            redeem_balance
+        } else {
+            zero_balance
+        };
+        let join_arg1 = if wire_join_arg1_to_split {
+            split_result
+        } else {
+            // Use a fresh zero<SUI> result so it's a Balance<SUI> Result that
+            // is not the prior balance::split's output.
+            builder.command(NativeCommand::move_call(
+                SUI_FRAMEWORK_PACKAGE_ID,
+                Identifier::new("balance").unwrap(),
+                Identifier::new("zero").unwrap(),
+                vec![sui_types::TypeTag::from_str("0x2::sui::SUI").unwrap()],
+                vec![],
+            ))
+        };
+        builder.command(NativeCommand::move_call(
+            SUI_FRAMEWORK_PACKAGE_ID,
+            Identifier::new("balance").unwrap(),
+            Identifier::new("join").unwrap(),
+            vec![sui_types::TypeTag::from_str("0x2::sui::SUI").unwrap()],
+            vec![join_arg0, join_arg1],
+        ));
+        let from_balance_arg = if wire_from_balance_to_redeem {
+            redeem_balance
+        } else {
+            zero_balance
+        };
+        let coin = builder.command(NativeCommand::move_call(
+            SUI_FRAMEWORK_PACKAGE_ID,
+            Identifier::new("coin").unwrap(),
+            Identifier::new("from_balance").unwrap(),
+            vec![sui_types::TypeTag::from_str("0x2::sui::SUI").unwrap()],
+            vec![from_balance_arg],
+        ));
+        let sender_arg = builder.pure(sender).unwrap();
+        builder.command(NativeCommand::TransferObjects(vec![coin], sender_arg));
+        let _ = Argument::GasCoin; // silence Argument unused warning when not needed
+        builder.finish()
+    }
+
+    #[test]
+    fn test_parse_falls_through_atleast_split_arg_not_redeem_result() {
+        let sender = SuiAddress::random_for_testing_only();
+        let fss = random_object_ref();
+        // balance::split arg[0] points at zero<SUI>, not at redeem result.
+        let pt = build_malformed_atleast_ptb(sender, fss, false, true, true, true);
+        assert_falls_through_to_generic(&parse_pt(sender, pt));
+    }
+
+    #[test]
+    fn test_parse_falls_through_atleast_join_arg0_not_redeem_result() {
+        let sender = SuiAddress::random_for_testing_only();
+        let fss = random_object_ref();
+        // balance::join arg[0] points at zero<SUI>, not at redeem result.
+        let pt = build_malformed_atleast_ptb(sender, fss, true, false, true, true);
+        assert_falls_through_to_generic(&parse_pt(sender, pt));
+    }
+
+    #[test]
+    fn test_parse_falls_through_atleast_join_arg1_not_split_result() {
+        let sender = SuiAddress::random_for_testing_only();
+        let fss = random_object_ref();
+        // balance::join arg[1] points at a different zero<SUI>, not at split result.
+        let pt = build_malformed_atleast_ptb(sender, fss, true, true, false, true);
+        assert_falls_through_to_generic(&parse_pt(sender, pt));
+    }
+
+    #[test]
+    fn test_parse_falls_through_atleast_from_balance_arg_not_redeem_result() {
+        let sender = SuiAddress::random_for_testing_only();
+        let fss = random_object_ref();
+        // coin::from_balance arg[0] points at zero<SUI>, not at redeem result.
+        let pt = build_malformed_atleast_ptb(sender, fss, true, true, true, false);
+        assert_falls_through_to_generic(&parse_pt(sender, pt));
     }
 
     // ==============================================================================

--- a/crates/sui-rosetta/src/types.rs
+++ b/crates/sui-rosetta/src/types.rs
@@ -499,16 +499,34 @@ pub enum RedeemMode {
 /// so the builder can attach mode-specific runtime guards. Only `AtLeast` adds
 /// a `balance::split` chain abort guard; `AtMost` relies on the staking pool
 /// invariant `actual <= floor(token * sui_balance / pool_token_balance)`.
+///
+/// `token_amount = None` on `AtLeast` / `AtMost` means "redeem the full merged
+/// FSS without splitting" — used when the binary search picked exactly the
+/// total token count. Splitting in that case is legal but leaves a zero-value
+/// FSS object in the wallet (`split_fungible_staked_sui` decrements value but
+/// doesn't delete the object), which is wasted dust. Skipping the split keeps
+/// the wallet clean.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub enum RedeemPlan {
     /// Redeem all FSS for the validator's pool.
     All,
     /// Redeem at least `min_sui` MIST. PTB enforces `balance.value >= min_sui`
     /// at execution time via `balance::split(min_sui)` and `balance::join`.
-    AtLeast { token_amount: u64, min_sui: u64 },
+    /// `token_amount = None` means redeem the full merged FSS (no
+    /// `split_fungible_staked_sui`); `Some(n)` splits off a `n`-token sub-FSS
+    /// and redeems only that.
+    AtLeast {
+        token_amount: Option<u64>,
+        min_sui: u64,
+    },
     /// Redeem at most `max_sui` MIST. Token count is chosen so the chain
     /// invariant `actual <= floor(token * SB / PTB) <= max_sui` holds.
-    AtMost { token_amount: u64, max_sui: u64 },
+    /// `token_amount = None` means the cap covers everything the user holds;
+    /// the PTB redeems the full merged FSS without splitting.
+    AtMost {
+        token_amount: Option<u64>,
+        max_sui: u64,
+    },
 }
 
 impl From<&TransactionKind> for OperationType {

--- a/crates/sui-rosetta/src/types.rs
+++ b/crates/sui-rosetta/src/types.rs
@@ -728,12 +728,16 @@ pub struct ConstructionMetadata {
     /// Used by ConsolidateAllStakedSuiToFungible.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub fss_object_count: Option<u64>,
-    /// Pool tokens to redeem. None = redeem all.
-    /// Used by MergeAndRedeemFungibleStakedSui.
+    /// Pool tokens to redeem. `None` = redeem all.
+    /// Used by `MergeAndRedeemFungibleStakedSui`.
     ///
-    /// Kept for serialization compatibility with prior metadata responses, but
-    /// new code paths consult `redeem_plan` instead, which carries the full
-    /// mode-aware plan needed to build runtime guards.
+    /// **Forward-compat field only**: kept so older clients reading newer
+    /// metadata responses still see the field they expect. New servers
+    /// consume `redeem_plan` exclusively when constructing the payload —
+    /// older metadata responses that lack `redeem_plan` cannot be signed by
+    /// new code (the payload step rejects them with a clear error so the
+    /// client can re-fetch metadata). This field is therefore one-way
+    /// compat (new server → old client), not two-way.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub redeem_token_amount: Option<u64>,
     /// Mode-aware redeem plan for `MergeAndRedeemFungibleStakedSui`.

--- a/crates/sui-rosetta/src/types.rs
+++ b/crates/sui-rosetta/src/types.rs
@@ -492,6 +492,25 @@ pub enum RedeemMode {
     All,
 }
 
+/// Internal plan describing how `MergeAndRedeemFungibleStakedSui` should execute.
+///
+/// Computed at metadata time (after pool state is read and the actual on-chain
+/// redeem formula is mirrored locally) and threaded through to PTB construction
+/// so the builder can attach mode-specific runtime guards. Only `AtLeast` adds
+/// a `balance::split` chain abort guard; `AtMost` relies on the staking pool
+/// invariant `actual <= floor(token * sui_balance / pool_token_balance)`.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub enum RedeemPlan {
+    /// Redeem all FSS for the validator's pool.
+    All,
+    /// Redeem at least `min_sui` MIST. PTB enforces `balance.value >= min_sui`
+    /// at execution time via `balance::split(min_sui)` and `balance::join`.
+    AtLeast { token_amount: u64, min_sui: u64 },
+    /// Redeem at most `max_sui` MIST. Token count is chosen so the chain
+    /// invariant `actual <= floor(token * SB / PTB) <= max_sui` holds.
+    AtMost { token_amount: u64, max_sui: u64 },
+}
+
 impl From<&TransactionKind> for OperationType {
     fn from(tx: &TransactionKind) -> Self {
         match tx.kind.and_then(|k| Kind::try_from(k).ok()) {
@@ -711,8 +730,22 @@ pub struct ConstructionMetadata {
     pub fss_object_count: Option<u64>,
     /// Pool tokens to redeem. None = redeem all.
     /// Used by MergeAndRedeemFungibleStakedSui.
+    ///
+    /// Kept for serialization compatibility with prior metadata responses, but
+    /// new code paths consult `redeem_plan` instead, which carries the full
+    /// mode-aware plan needed to build runtime guards.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub redeem_token_amount: Option<u64>,
+    /// Mode-aware redeem plan for `MergeAndRedeemFungibleStakedSui`.
+    /// Computed in `try_fetch_needed_objects` after mirroring the on-chain
+    /// payout formula and binary-searching for the right token count.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub redeem_plan: Option<RedeemPlan>,
+    /// Quote-time epoch. When `Some(N)`, the resulting transaction is bound to
+    /// epoch N via `TransactionExpiration` so amount-sensitive plans cannot be
+    /// replayed in a later epoch with a different exchange rate.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bind_epoch: Option<u64>,
 }
 
 impl IntoResponse for ConstructionMetadataResponse {
@@ -1067,6 +1100,8 @@ mod tests {
             chain_id: None,
             fss_object_count: None,
             redeem_token_amount: None,
+            redeem_plan: None,
+            bind_epoch: None,
         };
         let prod_metadata_json = serde_json::to_string(&prod_metadata).unwrap();
 

--- a/crates/sui-rosetta/src/types/internal_operation.rs
+++ b/crates/sui-rosetta/src/types/internal_operation.rs
@@ -256,12 +256,9 @@ impl InternalOperation {
                 .ok_or(anyhow!("epoch required for address-balance gas"))?;
             let nonce = rand::thread_rng().r#gen::<u32>();
 
-            // Address-balance gas already binds replay protection to the
-            // current epoch via `ValidDuring{min_epoch=max_epoch=epoch}`. If
-            // `bind_epoch` is set, verify it matches — a mismatch means the
-            // metadata was computed in a different epoch than this signing
-            // call, in which case the quote (token count from exchange rate)
-            // is stale.
+            // For amount-sensitive plans, verify the metadata epoch matches
+            // the rate-quote epoch — otherwise the rate the off-chain quote
+            // used has rolled over since metadata fetch.
             if let Some(want) = bind_epoch
                 && want != epoch
             {
@@ -272,7 +269,7 @@ impl InternalOperation {
                 .into());
             }
 
-            Ok(TransactionData::new_programmable_with_address_balance_gas(
+            let mut data = TransactionData::new_programmable_with_address_balance_gas(
                 metadata.sender,
                 pt,
                 metadata.budget,
@@ -280,7 +277,37 @@ impl InternalOperation {
                 chain_id,
                 epoch,
                 nonce,
-            ))
+            );
+
+            // The default `new_programmable_with_address_balance_gas` sets
+            // `ValidDuring { min_epoch: epoch, max_epoch: epoch + 1 }`, so the
+            // tx can still execute in `epoch + 1` against a different exchange
+            // rate. Tighten to `min == max == bind_epoch` for amount-sensitive
+            // plans. This stays replay-protected (a one-epoch range satisfies
+            // `TransactionExpiration::is_replay_protected`, see
+            // `sui-types/src/transaction.rs::is_replay_protected`).
+            if let Some(want) = bind_epoch {
+                use sui_types::transaction::{TransactionDataAPI, TransactionExpiration};
+                if let TransactionExpiration::ValidDuring {
+                    chain,
+                    nonce,
+                    min_timestamp,
+                    max_timestamp,
+                    ..
+                } = *data.expiration()
+                {
+                    *data.expiration_mut() = TransactionExpiration::ValidDuring {
+                        min_epoch: Some(want),
+                        max_epoch: Some(want),
+                        min_timestamp,
+                        max_timestamp,
+                        chain,
+                        nonce,
+                    };
+                }
+            }
+
+            Ok(data)
         } else {
             let mut data = TransactionData::new_programmable(
                 metadata.sender,

--- a/crates/sui-rosetta/src/types/internal_operation.rs
+++ b/crates/sui-rosetta/src/types/internal_operation.rs
@@ -74,7 +74,9 @@ pub struct TransactionObjectData {
     /// Pool tokens to redeem. None = redeem all.
     /// Used by MergeAndRedeemFungibleStakedSui.
     ///
-    /// Kept for backward compatibility; new code reads `redeem_plan` instead.
+    /// Forward-compat-only field: surfaced in metadata responses for older
+    /// clients, but new code reads `redeem_plan` exclusively when building
+    /// the payload. See `ConstructionMetadata::redeem_token_amount`.
     pub redeem_token_amount: Option<u64>,
     /// Mode-aware redeem plan (used by `MergeAndRedeemFungibleStakedSui`).
     /// `None` for other operations.

--- a/crates/sui-rosetta/src/types/internal_operation.rs
+++ b/crates/sui-rosetta/src/types/internal_operation.rs
@@ -33,7 +33,6 @@ use crate::errors::Error;
 use crate::types::ConstructionMetadata;
 pub use consolidate_to_fungible::ConsolidateAllStakedSuiToFungible;
 pub(crate) use consolidate_to_fungible::consolidate_to_fungible_pt;
-pub(crate) use consolidate_to_fungible::get_validator_pool_id;
 pub use merge_and_redeem::MergeAndRedeemFungibleStakedSui;
 pub(crate) use merge_and_redeem::merge_and_redeem_fss_pt;
 pub use pay_coin::PayCoin;
@@ -74,7 +73,15 @@ pub struct TransactionObjectData {
     pub fss_object_count: Option<u64>,
     /// Pool tokens to redeem. None = redeem all.
     /// Used by MergeAndRedeemFungibleStakedSui.
+    ///
+    /// Kept for backward compatibility; new code reads `redeem_plan` instead.
     pub redeem_token_amount: Option<u64>,
+    /// Mode-aware redeem plan (used by `MergeAndRedeemFungibleStakedSui`).
+    /// `None` for other operations.
+    pub redeem_plan: Option<crate::types::RedeemPlan>,
+    /// Quote-time epoch to bind the transaction to (used by amount-sensitive
+    /// `MergeAndRedeemFungibleStakedSui` modes). `None` for other operations.
+    pub bind_epoch: Option<u64>,
 }
 
 #[async_trait]
@@ -227,8 +234,15 @@ impl InternalOperation {
             }
             InternalOperation::MergeAndRedeemFungibleStakedSui(
                 MergeAndRedeemFungibleStakedSui { sender, .. },
-            ) => merge_and_redeem_fss_pt(sender, metadata.objects, metadata.redeem_token_amount)?,
+            ) => {
+                let plan = metadata.redeem_plan.as_ref().ok_or(anyhow!(
+                    "redeem_plan required for MergeAndRedeemFungibleStakedSui"
+                ))?;
+                merge_and_redeem_fss_pt(sender, metadata.objects, plan)?
+            }
         };
+
+        let bind_epoch = metadata.bind_epoch;
 
         if metadata.gas_coins.is_empty() {
             let chain_id_str = metadata
@@ -242,6 +256,22 @@ impl InternalOperation {
                 .ok_or(anyhow!("epoch required for address-balance gas"))?;
             let nonce = rand::thread_rng().r#gen::<u32>();
 
+            // Address-balance gas already binds replay protection to the
+            // current epoch via `ValidDuring{min_epoch=max_epoch=epoch}`. If
+            // `bind_epoch` is set, verify it matches — a mismatch means the
+            // metadata was computed in a different epoch than this signing
+            // call, in which case the quote (token count from exchange rate)
+            // is stale.
+            if let Some(want) = bind_epoch
+                && want != epoch
+            {
+                return Err(anyhow!(
+                    "redeem plan was quoted for epoch {want} but signing in epoch {epoch}; \
+                     re-fetch /construction/metadata"
+                )
+                .into());
+            }
+
             Ok(TransactionData::new_programmable_with_address_balance_gas(
                 metadata.sender,
                 pt,
@@ -252,13 +282,18 @@ impl InternalOperation {
                 nonce,
             ))
         } else {
-            Ok(TransactionData::new_programmable(
+            let mut data = TransactionData::new_programmable(
                 metadata.sender,
                 metadata.gas_coins,
                 pt,
                 metadata.budget,
                 metadata.gas_price,
-            ))
+            );
+            if let Some(epoch) = bind_epoch {
+                use sui_types::transaction::{TransactionDataAPI, TransactionExpiration};
+                *data.expiration_mut() = TransactionExpiration::Epoch(epoch);
+            }
+            Ok(data)
         }
     }
 }

--- a/crates/sui-rosetta/src/types/internal_operation/consolidate_to_fungible.rs
+++ b/crates/sui-rosetta/src/types/internal_operation/consolidate_to_fungible.rs
@@ -109,6 +109,8 @@ impl TryConstructTransaction for ConsolidateAllStakedSuiToFungible {
             address_balance_withdrawal: 0,
             fss_object_count: Some(fss_count as u64),
             redeem_token_amount: None,
+            redeem_plan: None,
+            bind_epoch: None,
         })
     }
 }

--- a/crates/sui-rosetta/src/types/internal_operation/merge_and_redeem.rs
+++ b/crates/sui-rosetta/src/types/internal_operation/merge_and_redeem.rs
@@ -767,7 +767,7 @@ impl TryConstructTransaction for MergeAndRedeemFungibleStakedSui {
         let redeem_token_amount = match plan {
             RedeemPlan::All => None,
             RedeemPlan::AtLeast { token_amount, .. } | RedeemPlan::AtMost { token_amount, .. } => {
-                Some(token_amount)
+                token_amount
             }
         };
 
@@ -835,7 +835,7 @@ pub(crate) fn build_redeem_plan(
                     ))
                 })?;
             Ok(RedeemPlan::AtLeast {
-                token_amount,
+                token_amount: full_redeem_or_split(token_amount, total_tokens),
                 min_sui,
             })
         }
@@ -861,10 +861,22 @@ pub(crate) fn build_redeem_plan(
                 )
                 })?;
             Ok(RedeemPlan::AtMost {
-                token_amount,
+                token_amount: full_redeem_or_split(token_amount, total_tokens),
                 max_sui,
             })
         }
+    }
+}
+
+/// Decide whether a `token_amount` selected by binary search needs a
+/// `split_fungible_staked_sui` step. If the search picked exactly the total,
+/// the merged FSS is already the right size — splitting would just leave a
+/// zero-value FSS object as dust.
+fn full_redeem_or_split(token_amount: u64, total_tokens: u64) -> Option<u64> {
+    if token_amount == total_tokens {
+        None
+    } else {
+        Some(token_amount)
     }
 }
 
@@ -912,10 +924,12 @@ pub fn merge_and_redeem_fss_pt(
         ));
     }
 
+    // None = redeem the merged FSS in full (no split). Splitting when
+    // token_amount equals the total would just leave a zero-value FSS as dust.
     let split_token_amount = match plan {
         RedeemPlan::All => None,
         RedeemPlan::AtLeast { token_amount, .. } | RedeemPlan::AtMost { token_amount, .. } => {
-            Some(*token_amount)
+            *token_amount
         }
     };
     let redeem_target = if let Some(token_amount) = split_token_amount {
@@ -1096,12 +1110,13 @@ mod tests {
                 token_amount,
                 min_sui,
             } => {
+                let inner = token_amount.expect("t=6 < total=100, plan keeps Some(token)");
                 assert_eq!(
-                    token_amount, 6,
+                    inner, 6,
                     "mirror picks t=6 (actual=6) over naive t=5 (actual=4)"
                 );
                 assert_eq!(min_sui, 5);
-                assert!(mirror_redeem_actual(&data, token_amount).unwrap() >= 5);
+                assert!(mirror_redeem_actual(&data, inner).unwrap() >= 5);
             }
             _ => panic!("wrong variant"),
         }
@@ -1126,11 +1141,9 @@ mod tests {
         let plan = build_redeem_plan(RedeemMode::AtLeast, Some(35), 30, 7, 3, Some(&data)).unwrap();
         match plan {
             RedeemPlan::AtLeast { token_amount, .. } => {
-                assert_eq!(
-                    token_amount, 16,
-                    "mirror search should pick t=16, not naive t=15"
-                );
-                assert!(mirror_redeem_actual(&data, token_amount).unwrap() >= 35);
+                let inner = token_amount.expect("t=16 < total=30, plan keeps Some(token)");
+                assert_eq!(inner, 16, "mirror search should pick t=16, not naive t=15");
+                assert!(mirror_redeem_actual(&data, inner).unwrap() >= 35);
             }
             _ => panic!("wrong variant"),
         }
@@ -1168,7 +1181,7 @@ mod tests {
                 token_amount,
                 max_sui,
             } => {
-                assert_eq!(token_amount, 49);
+                assert_eq!(token_amount, Some(49));
                 assert_eq!(max_sui, 100);
             }
             _ => panic!("wrong variant"),
@@ -1179,6 +1192,50 @@ mod tests {
     fn build_plan_all_returns_all() {
         let plan = build_redeem_plan(RedeemMode::All, None, 100, 200, 100, None).unwrap();
         assert!(matches!(plan, RedeemPlan::All));
+    }
+
+    #[test]
+    fn build_plan_atleast_full_redeem_omits_split() {
+        // Pool of 100 supply at 1:1 — to deliver 100 SUI we need all 100 tokens.
+        // binary_search returns total_tokens, so the plan should set
+        // `token_amount = None` and the PTB will skip `split_fungible_staked_sui`.
+        let data = fss(100, 100, 100, 100);
+        let plan =
+            build_redeem_plan(RedeemMode::AtLeast, Some(100), 100, 100, 100, Some(&data)).unwrap();
+        match plan {
+            RedeemPlan::AtLeast {
+                token_amount,
+                min_sui,
+            } => {
+                assert!(
+                    token_amount.is_none(),
+                    "full-redeem AtLeast should encode no-split as None, got {token_amount:?}"
+                );
+                assert_eq!(min_sui, 100);
+            }
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[test]
+    fn build_plan_atmost_full_redeem_omits_split() {
+        // Cap of 1_000_000 at rate 1:1 with 99 total tokens — every token
+        // fits, so `binary_search_at_most` returns total_tokens. Plan should
+        // encode this as no-split.
+        let plan = build_redeem_plan(RedeemMode::AtMost, Some(1_000_000), 99, 1, 1, None).unwrap();
+        match plan {
+            RedeemPlan::AtMost {
+                token_amount,
+                max_sui,
+            } => {
+                assert!(
+                    token_amount.is_none(),
+                    "full-redeem AtMost should encode no-split as None, got {token_amount:?}"
+                );
+                assert_eq!(max_sui, 1_000_000);
+            }
+            _ => panic!("wrong variant"),
+        }
     }
 
     #[test]
@@ -1245,7 +1302,7 @@ mod tests {
     fn ptb_atleast_includes_balance_split_join_guard() {
         let sender = SuiAddress::random_for_testing_only();
         let plan = RedeemPlan::AtLeast {
-            token_amount: 100,
+            token_amount: Some(100),
             min_sui: 50,
         };
         let pt = merge_and_redeem_fss_pt(sender, vec![ref_(1), ref_(2)], &plan).unwrap();
@@ -1270,7 +1327,7 @@ mod tests {
     fn ptb_atmost_omits_balance_guard() {
         let sender = SuiAddress::random_for_testing_only();
         let plan = RedeemPlan::AtMost {
-            token_amount: 100,
+            token_amount: Some(100),
             max_sui: 50,
         };
         let pt = merge_and_redeem_fss_pt(sender, vec![ref_(1)], &plan).unwrap();
@@ -1287,6 +1344,65 @@ mod tests {
         assert!(move_calls.contains(&("sui_system", "redeem_fungible_staked_sui")));
         assert!(!move_calls.contains(&("balance", "split")));
         assert!(!move_calls.contains(&("balance", "join")));
+        assert!(move_calls.contains(&("coin", "from_balance")));
+    }
+
+    #[test]
+    fn ptb_atleast_full_redeem_omits_split_keeps_guard() {
+        // token_amount = None → no `split_fungible_staked_sui`. The chain
+        // guard (balance::split + balance::join) stays in place because
+        // AtLeast still needs runtime under-delivery protection regardless
+        // of whether we're redeeming all or a subset.
+        let sender = SuiAddress::random_for_testing_only();
+        let plan = RedeemPlan::AtLeast {
+            token_amount: None,
+            min_sui: 50,
+        };
+        let pt = merge_and_redeem_fss_pt(sender, vec![ref_(1)], &plan).unwrap();
+
+        let move_calls: Vec<(&str, &str)> = pt
+            .commands
+            .iter()
+            .filter_map(|c| match c {
+                Command::MoveCall(m) => Some((m.module.as_str(), m.function.as_str())),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            !move_calls.contains(&("staking_pool", "split_fungible_staked_sui")),
+            "full-redeem AtLeast should not split FSS: {move_calls:?}"
+        );
+        assert!(move_calls.contains(&("sui_system", "redeem_fungible_staked_sui")));
+        assert!(move_calls.contains(&("balance", "split")));
+        assert!(move_calls.contains(&("balance", "join")));
+        assert!(move_calls.contains(&("coin", "from_balance")));
+    }
+
+    #[test]
+    fn ptb_atmost_full_redeem_omits_split_no_guard() {
+        // token_amount = None → no split, no balance guard. Bytes-on-chain
+        // are identical to a `RedeemPlan::All` PTB; the difference is only
+        // in `bind_epoch` which the parser can't recover, so this round-trips
+        // through parse as `Some(All)`.
+        let sender = SuiAddress::random_for_testing_only();
+        let plan = RedeemPlan::AtMost {
+            token_amount: None,
+            max_sui: 1_000_000,
+        };
+        let pt = merge_and_redeem_fss_pt(sender, vec![ref_(1)], &plan).unwrap();
+
+        let move_calls: Vec<(&str, &str)> = pt
+            .commands
+            .iter()
+            .filter_map(|c| match c {
+                Command::MoveCall(m) => Some((m.module.as_str(), m.function.as_str())),
+                _ => None,
+            })
+            .collect();
+        assert!(!move_calls.contains(&("staking_pool", "split_fungible_staked_sui")));
+        assert!(!move_calls.contains(&("balance", "split")));
+        assert!(!move_calls.contains(&("balance", "join")));
+        assert!(move_calls.contains(&("sui_system", "redeem_fungible_staked_sui")));
         assert!(move_calls.contains(&("coin", "from_balance")));
     }
 }

--- a/crates/sui-rosetta/src/types/internal_operation/merge_and_redeem.rs
+++ b/crates/sui-rosetta/src/types/internal_operation/merge_and_redeem.rs
@@ -74,6 +74,22 @@ pub(crate) struct PoolRedeemData {
     pub fss_total_supply: u64,
 }
 
+/// `floor(a * b / c)` with checked u64 overflow. Move's `mul_div!` aborts on
+/// overflow; this helper returns `Err(DataError)` to match — silently truncating
+/// to `u64` would let the off-chain mirror disagree with the chain in pathological
+/// rate scenarios.
+fn mul_div_u64(a: u64, b: u64, c: u64) -> Result<u64, Error> {
+    if c == 0 {
+        return Err(Error::DataError("mul_div_u64: divide by zero".into()));
+    }
+    let v = (a as u128) * (b as u128) / (c as u128);
+    u64::try_from(v).map_err(|_| {
+        Error::DataError(format!(
+            "redeem math overflow: floor({a} * {b} / {c}) does not fit in u64"
+        ))
+    })
+}
+
 /// Mirror of `0x3::staking_pool::PoolTokenExchangeRate::get_sui_amount` at
 /// `staking_pool.move:638-646`. Returns the SUI cap for `token_amount` pool
 /// tokens given an exchange rate of `(rate_sui, rate_token)`.
@@ -84,11 +100,15 @@ pub(crate) struct PoolRedeemData {
 /// (see `staking_pool.move:264-268`), so any token count satisfying
 /// `expected_sui_amount(token) <= max_sui` will stay within the cap at
 /// execution time regardless of intra-epoch pool drift.
-pub(crate) fn expected_sui_amount(rate_sui: u64, rate_token: u64, token_amount: u64) -> u64 {
+pub(crate) fn expected_sui_amount(
+    rate_sui: u64,
+    rate_token: u64,
+    token_amount: u64,
+) -> Result<u64, Error> {
     if rate_sui == 0 || rate_token == 0 {
-        return token_amount;
+        return Ok(token_amount);
     }
-    ((token_amount as u128) * (rate_sui as u128) / (rate_token as u128)) as u64
+    mul_div_u64(token_amount, rate_sui, rate_token)
 }
 
 /// Mirror of `0x3::staking_pool::calculate_fungible_staked_sui_withdraw_amount`
@@ -100,82 +120,87 @@ pub(crate) fn expected_sui_amount(rate_sui: u64, rate_token: u64, token_amount: 
 /// by ~2 MIST per redemption (one MIST per floor, scaled by `token/supply`).
 /// AtLeast selection must use this (not `expected_sui_amount`) to avoid picking
 /// a token count whose actual payout falls below the user's `min_sui`.
-pub(crate) fn mirror_redeem_actual(data: &PoolRedeemData, token_amount: u64) -> u64 {
+///
+/// Returns `Err(DataError)` if any intermediate `mul_div` overflows u64 — the
+/// chain's `mul_div!` aborts on overflow, so the mirror surfaces the same
+/// failure mode rather than silently truncating.
+pub(crate) fn mirror_redeem_actual(data: &PoolRedeemData, token_amount: u64) -> Result<u64, Error> {
     if data.fss_total_supply == 0 {
-        return 0;
+        return Ok(0);
     }
 
     // total_sui = exchange_rate.get_sui_amount(total_supply)
     let total_sui = if data.rate_sui == 0 || data.rate_token == 0 {
         data.fss_total_supply
     } else {
-        ((data.rate_sui as u128) * (data.fss_total_supply as u128) / (data.rate_token as u128))
-            as u64
+        mul_div_u64(data.rate_sui, data.fss_total_supply, data.rate_token)?
     };
 
     let principal = data.fss_principal.min(total_sui);
     let rewards = total_sui - principal;
 
-    let principal_out =
-        ((token_amount as u128) * (principal as u128) / (data.fss_total_supply as u128)) as u64;
-    let rewards_out =
-        ((token_amount as u128) * (rewards as u128) / (data.fss_total_supply as u128)) as u64;
+    let principal_out = mul_div_u64(token_amount, principal, data.fss_total_supply)?;
+    let rewards_out = mul_div_u64(token_amount, rewards, data.fss_total_supply)?;
 
-    principal_out + rewards_out
+    principal_out
+        .checked_add(rewards_out)
+        .ok_or_else(|| Error::DataError("redeem math overflow: principal_out + rewards_out".into()))
 }
 
 /// Binary-search the smallest `token_amount` in `[1, total_tokens]` such that
 /// `mirror_redeem_actual(data, token_amount) >= target_sui`.
 ///
-/// Returns `None` if even redeeming `total_tokens` produces less than
-/// `target_sui` (caller reports "Insufficient FSS balance").
+/// Returns `Ok(None)` if even redeeming `total_tokens` produces less than
+/// `target_sui` (caller reports "Insufficient FSS balance"). Returns
+/// `Err` only if the underlying mirror math would overflow u64.
 pub(crate) fn binary_search_at_least(
     data: &PoolRedeemData,
     total_tokens: u64,
     target_sui: u64,
-) -> Option<u64> {
+) -> Result<Option<u64>, Error> {
     if total_tokens == 0 {
-        return None;
+        return Ok(None);
     }
-    if mirror_redeem_actual(data, total_tokens) < target_sui {
-        return None;
+    if mirror_redeem_actual(data, total_tokens)? < target_sui {
+        return Ok(None);
     }
     let mut lo: u64 = 1;
     let mut hi: u64 = total_tokens;
     while lo < hi {
         let mid = lo + (hi - lo) / 2;
-        if mirror_redeem_actual(data, mid) >= target_sui {
+        if mirror_redeem_actual(data, mid)? >= target_sui {
             hi = mid;
         } else {
             lo = mid + 1;
         }
     }
-    Some(lo)
+    Ok(Some(lo))
 }
 
 /// Binary-search the largest `token_amount` in `[1, total_tokens]` such that
 /// `expected_sui_amount(rate_sui, rate_token, token_amount) <= max_sui`.
 ///
-/// Returns `None` if even one token would already exceed `max_sui` (caller
-/// reports "AtMost amount too small to redeem any tokens").
+/// Returns `Ok(None)` if even one token would already exceed `max_sui`
+/// (caller reports "AtMost amount too small to redeem any tokens"). Returns
+/// `Err` only if the underlying mirror math would overflow u64.
 pub(crate) fn binary_search_at_most(
     rate_sui: u64,
     rate_token: u64,
     total_tokens: u64,
     max_sui: u64,
-) -> Option<u64> {
+) -> Result<Option<u64>, Error> {
     if total_tokens == 0 {
-        return None;
+        return Ok(None);
     }
-    if expected_sui_amount(rate_sui, rate_token, 1) > max_sui {
-        return None;
+    if expected_sui_amount(rate_sui, rate_token, 1)? > max_sui {
+        return Ok(None);
     }
     let mut lo: u64 = 1;
     let mut hi: u64 = total_tokens;
     let mut ans: Option<u64> = None;
     while lo <= hi {
         let mid = lo + (hi - lo) / 2;
-        if expected_sui_amount(rate_sui, rate_token, mid) <= max_sui {
+        if expected_sui_amount(rate_sui, rate_token, mid)? <= max_sui {
             ans = Some(mid);
             if mid == u64::MAX {
                 break;
@@ -188,7 +213,7 @@ pub(crate) fn binary_search_at_most(
             hi = mid - 1;
         }
     }
-    ans
+    Ok(ans)
 }
 
 // ============================================================================
@@ -250,19 +275,22 @@ async fn list_owned_fss(client: &mut Client, sender: SuiAddress) -> Result<Vec<O
 }
 
 /// Resolve `validator` to a pool, the sender's FSS in that pool, and the
-/// `(rate_sui, rate_token, epoch)` snapshot — all from a single
-/// `GetEpochRequest::latest()` response.
+/// `(rate_sui, rate_token, epoch)` snapshot. Supports both active and inactive
+/// validator pools — the chain's `validator_set::redeem_fungible_staked_sui`
+/// (validator_set.move:346-364) routes through `staking_pool_mappings` for
+/// active pools and falls back to `inactive_validators[pool_id]` otherwise,
+/// so Rosetta must accept the same set.
+///
+/// FSS-first: enumerate sender's FSS, group by pool_id, then for each candidate
+/// pool look up the validator address (active fast path, inactive_validators
+/// dynamic field walk fallback). The first pool whose validator address matches
+/// `target_validator` is selected.
 ///
 /// **Atomicity is load-bearing**: amount-sensitive plans bind the resulting
-/// transaction to `epoch`, so the rate must come from the same epoch. Splitting
-/// this into separate RPCs creates a race where rate is from epoch N but
-/// `bind_epoch` is N+1, silently violating AtMost caps and aborting AtLeast
-/// guards.
-///
-/// Inactive validators (deactivated pools) are not supported by this path;
-/// the chain still allows redeeming from inactive pools, but the lookup
-/// requires walking `inactive_validators[pool_id] → ValidatorWrapper` dynamic
-/// fields, which is a follow-up.
+/// transaction to `epoch`, so the rate must come from the same RPC response
+/// as the inactive-table lookup. Otherwise an epoch transition between the
+/// rate read and the bind_epoch read could leave the quote pinned to a stale
+/// rate, silently violating AtMost caps and aborting AtLeast guards.
 async fn resolve_pool_fss_and_rate(
     client: &mut Client,
     sender: SuiAddress,
@@ -275,46 +303,193 @@ async fn resolve_pool_fss_and_rate(
         )));
     }
 
-    let (rates, epoch) = crate::account::get_pool_exchange_rates_with_epoch(client).await?;
-
+    let snapshot = crate::account::get_validator_set_snapshot(client).await?;
     let target_validator_addr = sui_sdk_types::Address::from(target_validator);
-    let (pool_id_str, rate_info) = rates
-        .iter()
-        .find(|(_, info)| info.validator_address == target_validator_addr)
-        .ok_or_else(|| {
-            Error::InvalidInput(format!(
-                "Validator {target_validator} not found among active validators"
-            ))
-        })?;
-    let pool_for_validator = ObjectID::from_str(pool_id_str)
-        .map_err(|e| Error::DataError(format!("Invalid active pool id: {e}")))?;
 
-    let mut matching: Vec<&OwnedFss> = owned
-        .iter()
-        .filter(|f| f.pool_id == pool_for_validator)
-        .collect();
-    matching.sort_by_key(|f| f.object_ref.0);
-
-    if matching.is_empty() {
-        return Err(Error::InvalidInput(format!(
-            "Sender {sender} has no FungibleStakedSui for validator {target_validator}'s pool"
-        )));
+    // Group FSS by pool_id; deterministic ordering (BTreeMap on ObjectID).
+    let mut by_pool: std::collections::BTreeMap<ObjectID, Vec<&OwnedFss>> =
+        std::collections::BTreeMap::new();
+    for fss in &owned {
+        by_pool.entry(fss.pool_id).or_default().push(fss);
     }
 
-    let total_tokens: u64 = matching.iter().map(|f| f.value).sum();
-    let fss_refs: Vec<ObjectRef> = matching.iter().map(|f| f.object_ref).collect();
+    for (pool_id, fss_list) in &by_pool {
+        // Active fast path.
+        if let Some(rate_info) = snapshot.active_rates.get(&pool_id.to_string())
+            && rate_info.validator_address == target_validator_addr
+        {
+            return Ok(build_snapshot(fss_list, rate_info, snapshot.epoch));
+        }
+
+        // Inactive fallback.
+        if let Some(table_id_str) = snapshot.inactive_validators_table_id.as_deref() {
+            let table_id = ObjectID::from_str(table_id_str).map_err(|e| {
+                Error::DataError(format!("Invalid inactive_validators table id: {e}"))
+            })?;
+            if let Some(inactive) =
+                lookup_inactive_pool(client, table_id, *pool_id, target_validator).await?
+            {
+                let mut sorted = fss_list.clone();
+                sorted.sort_by_key(|f| f.object_ref.0);
+                let total_tokens: u64 = sorted.iter().map(|f| f.value).sum();
+                let fss_refs: Vec<ObjectRef> = sorted.iter().map(|f| f.object_ref).collect();
+                return Ok(PoolFssRateSnapshot {
+                    fss_refs,
+                    total_tokens,
+                    rate_sui: inactive.rate_sui,
+                    rate_token: inactive.rate_token,
+                    epoch: snapshot.epoch,
+                    pool_extra_fields_id: Some(inactive.pool_extra_fields_id),
+                });
+            }
+        }
+    }
+
+    Err(Error::InvalidInput(format!(
+        "No FungibleStakedSui found for validator {target_validator}'s pool \
+         (sender holds {} FSS object(s) but none are for that validator's active \
+          or inactive pool)",
+        owned.len()
+    )))
+}
+
+fn build_snapshot(
+    fss_list: &[&OwnedFss],
+    rate_info: &crate::account::PoolRateInfo,
+    epoch: u64,
+) -> PoolFssRateSnapshot {
+    let mut sorted = fss_list.to_vec();
+    sorted.sort_by_key(|f| f.object_ref.0);
+    let total_tokens: u64 = sorted.iter().map(|f| f.value).sum();
+    let fss_refs: Vec<ObjectRef> = sorted.iter().map(|f| f.object_ref).collect();
     let pool_extra_fields_id = rate_info
         .pool_extra_fields_id
         .as_deref()
         .and_then(|s| ObjectID::from_str(s).ok());
-    Ok(PoolFssRateSnapshot {
+    PoolFssRateSnapshot {
         fss_refs,
         total_tokens,
         rate_sui: rate_info.sui_balance,
         rate_token: rate_info.pool_token_balance,
         epoch,
         pool_extra_fields_id,
-    })
+    }
+}
+
+/// Pool data extracted from an inactive validator's `ValidatorWrapper`.
+struct InactivePoolData {
+    rate_sui: u64,
+    rate_token: u64,
+    pool_extra_fields_id: ObjectID,
+}
+
+/// Walk `inactive_validators[pool_id]` → `ValidatorWrapper` → `Versioned` →
+/// `ValidatorV1` to extract the staking pool's rate fields and verify the
+/// validator address matches.
+///
+/// The chain stores `inactive_validators` as `Table<ID, ValidatorWrapper>`
+/// (validator_set.move:73). Each entry is a dynamic field at
+/// `derive(table.id, &TypeTag::ID, bcs(pool_id))`. The wrapper holds a
+/// `Versioned` whose latest value is the actual `ValidatorV1`, stored at
+/// `derive(versioned.id, &TypeTag::U64, bcs(version))`.
+///
+/// For inactive pools, `pool.sui_balance` and `pool.pool_token_balance` are
+/// frozen at deactivation (advance_epoch no longer touches them), so they
+/// equal the latest exchange-rate snapshot — no `pool_token_exchange_rate_at_epoch`
+/// walk-back needed.
+///
+/// Returns `None` if the wrapper is not found at the derived id (validator
+/// address didn't match) so the caller can try the next candidate pool.
+async fn lookup_inactive_pool(
+    client: &mut Client,
+    inactive_table_id: ObjectID,
+    pool_id: ObjectID,
+    expected_validator: SuiAddress,
+) -> Result<Option<InactivePoolData>, Error> {
+    use sui_types::dynamic_field::{Field, derive_dynamic_field_id};
+    use sui_types::id::ID;
+    use sui_types::sui_system_state::ValidatorWrapper;
+    use sui_types::sui_system_state::sui_system_state_inner_v1::ValidatorV1;
+
+    let id_type = sui_types::TypeTag::from_str("0x2::object::ID")
+        .map_err(|e| Error::DataError(format!("ID TypeTag: {e}")))?;
+    let pool_id_bcs =
+        bcs::to_bytes(&pool_id).map_err(|e| Error::DataError(format!("pool_id bcs: {e}")))?;
+    let wrapper_field_id = derive_dynamic_field_id(inactive_table_id, &id_type, &pool_id_bcs)
+        .map_err(|e| Error::DataError(format!("derive inactive wrapper field id: {e}")))?;
+
+    let Some(wrapper_bytes) = try_read_object_contents(client, wrapper_field_id).await? else {
+        return Ok(None);
+    };
+    let wrapper_field: Field<ID, ValidatorWrapper> = bcs::from_bytes(&wrapper_bytes)
+        .map_err(|e| Error::DataError(format!("Field<ID,ValidatorWrapper> decode: {e}")))?;
+    let versioned_id = ObjectID::from_str(
+        &wrapper_field
+            .value
+            .inner
+            .id
+            .object_id()
+            .to_hex_uncompressed(),
+    )
+    .map_err(|e| Error::DataError(format!("Invalid Versioned id: {e}")))?;
+    let version = wrapper_field.value.inner.version;
+
+    let u64_type = sui_types::TypeTag::U64;
+    let version_bcs =
+        bcs::to_bytes(&version).map_err(|e| Error::DataError(format!("version bcs: {e}")))?;
+    let validator_field_id = derive_dynamic_field_id(versioned_id, &u64_type, &version_bcs)
+        .map_err(|e| Error::DataError(format!("derive ValidatorV1 field id: {e}")))?;
+
+    let validator_bytes = try_read_object_contents(client, validator_field_id)
+        .await?
+        .ok_or_else(|| {
+            Error::DataError(format!(
+                "Inactive validator wrapper at {wrapper_field_id} points at \
+                 missing ValidatorV1 at {validator_field_id} (version {version})"
+            ))
+        })?;
+    let validator_field: Field<u64, ValidatorV1> = bcs::from_bytes(&validator_bytes)
+        .map_err(|e| Error::DataError(format!("Field<u64,ValidatorV1> decode: {e}")))?;
+    let validator = validator_field.value;
+    if validator.metadata.sui_address != expected_validator {
+        return Ok(None);
+    }
+
+    Ok(Some(InactivePoolData {
+        rate_sui: validator.staking_pool.sui_balance,
+        rate_token: validator.staking_pool.pool_token_balance,
+        pool_extra_fields_id: validator.staking_pool.extra_fields.id.id.bytes,
+    }))
+}
+
+/// Fetch raw BCS contents of an object, returning `None` if the object does
+/// not exist (so callers can probe derived addresses without erroring).
+async fn try_read_object_contents(
+    client: &mut Client,
+    object_id: ObjectID,
+) -> Result<Option<Vec<u8>>, Error> {
+    let request = sui_rpc::proto::sui::rpc::v2::GetObjectRequest::default()
+        .with_object_id(object_id.to_string())
+        .with_read_mask(FieldMask::from_paths(["contents"]));
+    let response = match client.ledger_client().get_object(request).await {
+        Ok(r) => r.into_inner(),
+        Err(status) if status.code() == tonic::Code::NotFound => return Ok(None),
+        Err(e) => return Err(Error::from(e)),
+    };
+    let Some(obj) = response.object else {
+        return Ok(None);
+    };
+    let bytes = obj
+        .contents
+        .as_ref()
+        .and_then(|b| b.value.as_deref())
+        .map(|v| v.to_vec())
+        .unwrap_or_default();
+    if bytes.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(bytes))
+    }
 }
 
 /// Atomic snapshot tying together pool, FSS, exchange rate, and the epoch the
@@ -549,7 +724,7 @@ pub(crate) fn build_redeem_plan(
                 )
             })?;
             let token_amount =
-                binary_search_at_least(data, total_tokens, min_sui).ok_or_else(|| {
+                binary_search_at_least(data, total_tokens, min_sui)?.ok_or_else(|| {
                     Error::InvalidInput(format!(
                         "Insufficient FSS balance: cannot deliver AtLeast {min_sui} SUI \
                          from {total_tokens} pool tokens at current exchange rate",
@@ -574,13 +749,13 @@ pub(crate) fn build_redeem_plan(
                     "Pool has zero exchange rate, cannot compute redeem plan".to_string(),
                 ));
             }
-            let token_amount = binary_search_at_most(rate_sui, rate_token, total_tokens, max_sui)
+            let token_amount = binary_search_at_most(rate_sui, rate_token, total_tokens, max_sui)?
                 .ok_or_else(|| {
-                Error::InvalidInput(
+                    Error::InvalidInput(
                     "AtMost amount too small: would redeem 0 pool tokens at current exchange rate"
                         .to_string(),
                 )
-            })?;
+                })?;
             Ok(RedeemPlan::AtMost {
                 token_amount,
                 max_sui,
@@ -704,23 +879,38 @@ mod tests {
     fn atmost_picks_maximum_token_under_cap() {
         // rate 200/99, supply=99: for T=49 expected=98, for T=50 expected=101.
         // Largest T with expected(T) <= 100 is 49.
-        let token = binary_search_at_most(200, 99, 99, 100).unwrap();
+        let token = binary_search_at_most(200, 99, 99, 100).unwrap().unwrap();
         assert_eq!(token, 49);
-        assert!(expected_sui_amount(200, 99, token) <= 100);
-        assert!(expected_sui_amount(200, 99, token + 1) > 100);
+        assert!(expected_sui_amount(200, 99, token).unwrap() <= 100);
+        assert!(expected_sui_amount(200, 99, token + 1).unwrap() > 100);
     }
 
     #[test]
     fn atmost_returns_none_when_one_token_already_over_cap() {
         // rate 1000:1 means 1 token = 1000 SUI; cap of 1 SUI is unsatisfiable.
-        assert!(binary_search_at_most(1000, 1, 100, 1).is_none());
+        assert!(binary_search_at_most(1000, 1, 100, 1).unwrap().is_none());
     }
 
     #[test]
     fn atmost_zero_rate_falls_back_to_one_to_one() {
         // expected(token) = token when rate fields are 0. With cap=10 and 100
         // tokens available, max satisfying token is 10.
-        assert_eq!(binary_search_at_most(0, 0, 100, 10).unwrap(), 10);
+        assert_eq!(binary_search_at_most(0, 0, 100, 10).unwrap().unwrap(), 10);
+    }
+
+    #[test]
+    fn mul_div_overflow_is_reported_not_truncated() {
+        // u64::MAX * u64::MAX / 1 fits in u128 but NOT in u64 — must error,
+        // not silently truncate. Confirms we match Move's `mul_div!` abort.
+        let err = mul_div_u64(u64::MAX, u64::MAX, 1).expect_err("should overflow");
+        assert!(format!("{err}").contains("overflow"));
+    }
+
+    #[test]
+    fn mul_div_safely_handles_typical_pool_scale() {
+        // Typical pool: ~10^9 SUI total, 1:1 rate. Should not overflow.
+        let result = mul_div_u64(1_000_000_000_000_000_000, 1, 1).unwrap();
+        assert_eq!(result, 1_000_000_000_000_000_000);
     }
 
     // --- Plan construction ---------------------------------------------------
@@ -758,7 +948,7 @@ mod tests {
                     "mirror picks t=6 (actual=6) over naive t=5 (actual=4)"
                 );
                 assert_eq!(min_sui, 5);
-                assert!(mirror_redeem_actual(&data, token_amount) >= 5);
+                assert!(mirror_redeem_actual(&data, token_amount).unwrap() >= 5);
             }
             _ => panic!("wrong variant"),
         }
@@ -787,7 +977,7 @@ mod tests {
                     token_amount, 16,
                     "mirror search should pick t=16, not naive t=15"
                 );
-                assert!(mirror_redeem_actual(&data, token_amount) >= 35);
+                assert!(mirror_redeem_actual(&data, token_amount).unwrap() >= 35);
             }
             _ => panic!("wrong variant"),
         }
@@ -852,8 +1042,8 @@ mod tests {
                         if token == 0 || token > supply {
                             continue;
                         }
-                        let expected = expected_sui_amount(rate_sui, rate_token, token);
-                        let actual = mirror_redeem_actual(&data, token);
+                        let expected = expected_sui_amount(rate_sui, rate_token, token).unwrap();
+                        let actual = mirror_redeem_actual(&data, token).unwrap();
                         assert!(actual <= expected, "actual={actual} > expected={expected}");
                         assert!(
                             actual + 2 >= expected,

--- a/crates/sui-rosetta/src/types/internal_operation/merge_and_redeem.rs
+++ b/crates/sui-rosetta/src/types/internal_operation/merge_and_redeem.rs
@@ -1,6 +1,29 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+//! `MergeAndRedeemFungibleStakedSui` construction logic.
+//!
+//! Translates a user's `(validator, amount, redeem_mode)` request into a PTB
+//! that consumes the sender's `FungibleStakedSui` for the named validator's
+//! pool and produces liquid SUI.
+//!
+//! The semantics differ by mode:
+//!
+//! * `All` — redeem every FSS the sender owns for the pool.
+//! * `AtLeast(amount)` — choose the minimum pool-token count whose redemption
+//!   yields at least `amount` MIST. The PTB also installs a runtime
+//!   `balance::split` guard so a slight under-delivery aborts the transaction
+//!   on chain instead of silently shorting the user.
+//! * `AtMost(amount)` — choose the maximum pool-token count whose chain-side
+//!   upper bound `expected = floor(token * sui_balance / pool_token_balance)`
+//!   stays at or below `amount`. The pool's invariant
+//!   `actual <= expected` then guarantees the cap holds at execution time.
+//!   This is conservative: actual SUI may fall a few MIST short of the cap.
+//!
+//! Amount-sensitive plans (`AtLeast` / `AtMost`) bind the resulting transaction
+//! to the quote epoch via `TransactionExpiration`, so a stale quote cannot
+//! execute against a different epoch's exchange rate.
+
 use async_trait::async_trait;
 use futures::TryStreamExt;
 use prost_types::FieldMask;
@@ -18,11 +41,9 @@ use sui_types::{Identifier, SUI_FRAMEWORK_PACKAGE_ID, SUI_SYSTEM_PACKAGE_ID};
 
 use crate::account::FungibleStakedSuiBcs;
 use crate::errors::Error;
-use crate::types::RedeemMode;
+use crate::types::{RedeemMode, RedeemPlan};
 
-use super::{
-    TransactionObjectData, TryConstructTransaction, get_validator_pool_id, simulate_transaction,
-};
+use super::{TransactionObjectData, TryConstructTransaction, simulate_transaction};
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct MergeAndRedeemFungibleStakedSui {
@@ -30,6 +51,216 @@ pub struct MergeAndRedeemFungibleStakedSui {
     pub validator: SuiAddress,
     pub amount: Option<u64>,
     pub redeem_mode: RedeemMode,
+}
+
+// ============================================================================
+// Mirror of the on-chain exchange-rate formula (pure, no RPC).
+// ============================================================================
+
+/// Mirror of `0x3::staking_pool::PoolTokenExchangeRate::get_sui_amount` at
+/// `staking_pool.move:638-646`. Returns the SUI cap for `token_amount` pool
+/// tokens given an exchange rate of `(rate_sui, rate_token)`.
+///
+/// The chain enforces the invariant
+/// `actual_redeemed <= floor(token * rate_sui / rate_token)` even after the
+/// per-redeemer split-floor accounting in `calculate_fungible_staked_sui_withdraw_amount`
+/// (see `staking_pool.move:264-268`), so any token count satisfying
+/// `expected_sui_amount(token) <= max_sui` will stay within the cap at
+/// execution time regardless of intra-epoch pool drift.
+pub(crate) fn expected_sui_amount(rate_sui: u64, rate_token: u64, token_amount: u64) -> u64 {
+    if rate_sui == 0 || rate_token == 0 {
+        return token_amount;
+    }
+    ((token_amount as u128) * (rate_sui as u128) / (rate_token as u128)) as u64
+}
+
+/// Binary-search the largest `token_amount` in `[1, total_tokens]` such that
+/// `expected_sui_amount(rate_sui, rate_token, token_amount) <= max_sui`.
+///
+/// Returns `None` if even one token would already exceed `max_sui` (caller
+/// reports "AtMost amount too small to redeem any tokens").
+pub(crate) fn binary_search_at_most(
+    rate_sui: u64,
+    rate_token: u64,
+    total_tokens: u64,
+    max_sui: u64,
+) -> Option<u64> {
+    if total_tokens == 0 {
+        return None;
+    }
+    if expected_sui_amount(rate_sui, rate_token, 1) > max_sui {
+        return None;
+    }
+    let mut lo: u64 = 1;
+    let mut hi: u64 = total_tokens;
+    let mut ans: Option<u64> = None;
+    while lo <= hi {
+        let mid = lo + (hi - lo) / 2;
+        if expected_sui_amount(rate_sui, rate_token, mid) <= max_sui {
+            ans = Some(mid);
+            if mid == u64::MAX {
+                break;
+            }
+            lo = mid + 1;
+        } else {
+            if mid == 0 {
+                break;
+            }
+            hi = mid - 1;
+        }
+    }
+    ans
+}
+
+// ============================================================================
+// Pool / FSS resolution (FSS-first, supports inactive validators).
+// ============================================================================
+
+/// Information extracted from a single owned `FungibleStakedSui` object.
+#[derive(Clone, Debug)]
+struct OwnedFss {
+    object_ref: ObjectRef,
+    pool_id: ObjectID,
+    value: u64,
+}
+
+async fn list_owned_fss(client: &mut Client, sender: SuiAddress) -> Result<Vec<OwnedFss>, Error> {
+    let request = ListOwnedObjectsRequest::default()
+        .with_owner(sender.to_string())
+        .with_object_type("0x3::staking_pool::FungibleStakedSui".to_string())
+        .with_page_size(1000u32)
+        .with_read_mask(FieldMask::from_paths([
+            "object_id",
+            "version",
+            "digest",
+            "contents",
+        ]));
+    let objects: Vec<_> = client
+        .list_owned_objects(request)
+        .map_err(Error::from)
+        .try_collect()
+        .await?;
+
+    let mut out = Vec::with_capacity(objects.len());
+    for obj in &objects {
+        let contents = obj
+            .contents
+            .as_ref()
+            .ok_or_else(|| Error::DataError("FungibleStakedSui missing contents".to_string()))?;
+        let fss: FungibleStakedSuiBcs = contents.deserialize().map_err(|e| {
+            Error::DataError(format!("Failed to deserialize FungibleStakedSui: {e}"))
+        })?;
+        let pool_id = ObjectID::from_str(&fss.pool_id.to_string())
+            .map_err(|e| Error::DataError(format!("Invalid pool_id: {e}")))?;
+        let object_id = ObjectID::from_str(obj.object_id())
+            .map_err(|e| Error::DataError(format!("Invalid object_id: {e}")))?;
+        let object_ref: ObjectRef = (
+            object_id,
+            obj.version().into(),
+            obj.digest()
+                .parse()
+                .map_err(|e| Error::DataError(format!("Invalid digest: {e}")))?,
+        );
+        out.push(OwnedFss {
+            object_ref,
+            pool_id,
+            value: fss.value,
+        });
+    }
+    Ok(out)
+}
+
+/// Snapshot of an active validator pulled out of `system_state.validators.active_validators`.
+#[derive(Clone, Debug)]
+struct ActivePoolEntry {
+    pool_id: ObjectID,
+    validator_addr: SuiAddress,
+}
+
+/// Read active validators and the inactive_validators table id from the system state.
+async fn fetch_validator_index(
+    client: &mut Client,
+) -> Result<(Vec<ActivePoolEntry>, Option<ObjectID>), Error> {
+    use sui_rpc::proto::sui::rpc::v2::GetEpochRequest;
+    let request = GetEpochRequest::latest().with_read_mask(FieldMask::from_paths([
+        "system_state.validators.active_validators",
+        "system_state.validators.inactive_validators",
+    ]));
+    let response = client
+        .ledger_client()
+        .get_epoch(request)
+        .await?
+        .into_inner();
+    let validators = response.epoch().system_state().validators();
+
+    let mut active = Vec::new();
+    for v in validators.active_validators() {
+        let pool_id = ObjectID::from_str(v.staking_pool().id())
+            .map_err(|e| Error::DataError(format!("Invalid active pool id: {e}")))?;
+        let validator_addr = SuiAddress::from_str(v.address())
+            .map_err(|e| Error::DataError(format!("Invalid active validator address: {e}")))?;
+        active.push(ActivePoolEntry {
+            pool_id,
+            validator_addr,
+        });
+    }
+
+    let inactive_table_id = validators
+        .inactive_validators
+        .as_ref()
+        .and_then(|t| t.id.as_ref())
+        .and_then(|id| ObjectID::from_str(id).ok());
+
+    Ok((active, inactive_table_id))
+}
+
+/// Resolve `validator` to a pool plus the sender's FSS in that pool.
+///
+/// Uses the active validator set to map `validator → pool_id`, then groups the
+/// sender's FSS by pool. Returns `(pool_id, fss_refs, total_tokens)`.
+///
+/// Inactive validators (deactivated pools) are not currently supported by this
+/// path; the chain still allows redeeming from inactive pools, but the lookup
+/// requires walking `inactive_validators[pool_id] → ValidatorWrapper` dynamic
+/// fields, which is a follow-up.
+async fn resolve_pool_and_fss(
+    client: &mut Client,
+    sender: SuiAddress,
+    target_validator: SuiAddress,
+) -> Result<(ObjectID, Vec<ObjectRef>, u64), Error> {
+    let owned = list_owned_fss(client, sender).await?;
+    if owned.is_empty() {
+        return Err(Error::InvalidInput(format!(
+            "No FungibleStakedSui found for sender {sender}"
+        )));
+    }
+
+    let (active, _inactive_table_id) = fetch_validator_index(client).await?;
+    let pool_for_validator = active
+        .iter()
+        .find(|v| v.validator_addr == target_validator)
+        .map(|v| v.pool_id)
+        .ok_or_else(|| {
+            Error::InvalidInput(format!(
+                "Validator {target_validator} not found among active validators"
+            ))
+        })?;
+
+    let mut matching: Vec<&OwnedFss> = owned
+        .iter()
+        .filter(|f| f.pool_id == pool_for_validator)
+        .collect();
+    matching.sort_by_key(|f| f.object_ref.0);
+
+    if matching.is_empty() {
+        return Err(Error::InvalidInput(format!(
+            "Sender {sender} has no FungibleStakedSui for validator {target_validator}'s pool"
+        )));
+    }
+
+    let total_tokens: u64 = matching.iter().map(|f| f.value).sum();
+    let refs: Vec<ObjectRef> = matching.iter().map(|f| f.object_ref).collect();
+    Ok((pool_for_validator, refs, total_tokens))
 }
 
 #[async_trait]
@@ -47,118 +278,20 @@ impl TryConstructTransaction for MergeAndRedeemFungibleStakedSui {
             redeem_mode,
         } = self;
 
-        let pool_id = get_validator_pool_id(client, validator).await?;
+        let (pool_id, fss_refs, total_tokens) =
+            resolve_pool_and_fss(client, sender, validator).await?;
 
-        // Discover FSS objects for this validator's pool
-        let list_request = ListOwnedObjectsRequest::default()
-            .with_owner(sender.to_string())
-            .with_object_type("0x3::staking_pool::FungibleStakedSui".to_string())
-            .with_page_size(1000u32)
-            .with_read_mask(FieldMask::from_paths([
-                "object_id",
-                "version",
-                "digest",
-                "contents",
-            ]));
+        let (rate_sui, rate_token) = pool_rate(client, pool_id).await?;
 
-        let objects: Vec<_> = client
-            .list_owned_objects(list_request)
-            .map_err(Error::from)
-            .try_collect()
-            .await?;
-
-        let mut fss_refs = Vec::new();
-        let mut total_tokens: u64 = 0;
-        for obj in &objects {
-            let contents = obj.contents.as_ref().ok_or_else(|| {
-                Error::DataError("FungibleStakedSui missing contents".to_string())
-            })?;
-            let fss: FungibleStakedSuiBcs = contents.deserialize().map_err(|e| {
-                Error::DataError(format!("Failed to deserialize FungibleStakedSui: {}", e))
-            })?;
-
-            if fss.pool_id.to_string() == pool_id {
-                total_tokens += fss.value;
-                fss_refs.push((
-                    ObjectID::from_str(obj.object_id())
-                        .map_err(|e| Error::DataError(format!("Invalid object_id: {}", e)))?,
-                    obj.version().into(),
-                    obj.digest()
-                        .parse()
-                        .map_err(|e| Error::DataError(format!("Invalid digest: {}", e)))?,
-                ));
-            }
-        }
-
-        if fss_refs.is_empty() {
-            return Err(Error::InvalidInput(format!(
-                "No FungibleStakedSui found for validator {}",
-                validator,
-            )));
-        }
-
-        // Read exchange rate to convert SUI amount → pool tokens.
-        // Note: the rate is read at metadata time. If the TX lands in a later epoch,
-        // the on-chain rate may differ. AtLeast mode may yield slightly more SUI than
-        // requested; AtMost may yield slightly less. The actual redeemed amount is
-        // captured in the TX's balance_changes.
-        let pool_rates = crate::account::get_pool_exchange_rates(client).await?;
-        let rate = pool_rates.get(&pool_id).ok_or_else(|| {
-            Error::DataError(format!("No exchange rate found for pool {}", pool_id))
-        })?;
-        let (sui_balance, pool_token_balance) = (rate.sui_balance, rate.pool_token_balance);
-
-        let token_amount = match redeem_mode {
-            RedeemMode::All => total_tokens,
-            RedeemMode::AtLeast => {
-                let amount = amount.ok_or_else(|| {
-                    Error::InvalidInput("amount required for AtLeast mode".to_string())
-                })?;
-                // ceil(amount * pool_token_balance / sui_balance)
-                if sui_balance == 0 {
-                    return Err(Error::DataError(
-                        "Pool has zero SUI balance, cannot compute exchange rate".to_string(),
-                    ));
-                }
-                let numerator =
-                    amount as u128 * pool_token_balance as u128 + sui_balance as u128 - 1;
-                let tokens = (numerator / sui_balance as u128) as u64;
-                if tokens > total_tokens {
-                    return Err(Error::InvalidInput(format!(
-                        "Insufficient FSS balance: AtLeast {} SUI requires {} tokens but only {} available",
-                        amount, tokens, total_tokens,
-                    )));
-                }
-                tokens
-            }
-            RedeemMode::AtMost => {
-                let amount = amount.ok_or_else(|| {
-                    Error::InvalidInput("amount required for AtMost mode".to_string())
-                })?;
-                // floor(amount * pool_token_balance / sui_balance)
-                if sui_balance == 0 {
-                    return Err(Error::DataError(
-                        "Pool has zero SUI balance, cannot compute exchange rate".to_string(),
-                    ));
-                }
-                let tokens =
-                    (amount as u128 * pool_token_balance as u128 / sui_balance as u128) as u64;
-                if tokens == 0 {
-                    return Err(Error::InvalidInput(
-                        "AtMost amount too small: rounds to 0 pool tokens".to_string(),
-                    ));
-                }
-                tokens.min(total_tokens)
+        let plan = build_redeem_plan(redeem_mode, amount, total_tokens, rate_sui, rate_token)?;
+        let bind_epoch = match plan {
+            RedeemPlan::All => None,
+            RedeemPlan::AtLeast { .. } | RedeemPlan::AtMost { .. } => {
+                Some(crate::get_current_epoch(client).await?)
             }
         };
 
-        let is_redeem_all = token_amount == total_tokens;
-        let pt_token_amount = if is_redeem_all {
-            None
-        } else {
-            Some(token_amount)
-        };
-        let pt = merge_and_redeem_fss_pt(sender, fss_refs.clone(), pt_token_amount)?;
+        let pt = merge_and_redeem_fss_pt(sender, fss_refs.clone(), &plan)?;
         let (budget, gas_coin_objs) =
             simulate_transaction(client, pt, sender, vec![], gas_price, budget).await?;
 
@@ -168,6 +301,13 @@ impl TryConstructTransaction for MergeAndRedeemFungibleStakedSui {
             .map(|obj| obj.object_reference().try_to_object_ref())
             .collect::<Result<Vec<_>, _>>()?;
 
+        let redeem_token_amount = match plan {
+            RedeemPlan::All => None,
+            RedeemPlan::AtLeast { token_amount, .. } | RedeemPlan::AtMost { token_amount, .. } => {
+                Some(token_amount)
+            }
+        };
+
         Ok(TransactionObjectData {
             gas_coins,
             objects: fss_refs,
@@ -176,26 +316,122 @@ impl TryConstructTransaction for MergeAndRedeemFungibleStakedSui {
             budget,
             address_balance_withdrawal: 0,
             fss_object_count: None,
-            redeem_token_amount: if is_redeem_all {
-                None
-            } else {
-                Some(token_amount)
-            },
+            redeem_token_amount,
+            redeem_plan: Some(plan),
+            bind_epoch,
         })
     }
 }
 
-/// Build PTB for merging all FSS and redeeming.
+/// Translate a user-supplied `(redeem_mode, amount)` pair into a `RedeemPlan`,
+/// validating amounts and computing token counts via binary search over the
+/// chain's exchange-rate formula.
+pub(crate) fn build_redeem_plan(
+    redeem_mode: RedeemMode,
+    amount: Option<u64>,
+    total_tokens: u64,
+    rate_sui: u64,
+    rate_token: u64,
+) -> Result<RedeemPlan, Error> {
+    match redeem_mode {
+        RedeemMode::All => Ok(RedeemPlan::All),
+        RedeemMode::AtLeast => {
+            let min_sui = amount.ok_or_else(|| {
+                Error::InvalidInput("amount required for AtLeast mode".to_string())
+            })?;
+            if min_sui == 0 {
+                return Err(Error::InvalidInput(
+                    "AtLeast amount must be at least 1 MIST".to_string(),
+                ));
+            }
+            if rate_sui == 0 || rate_token == 0 {
+                return Err(Error::DataError(
+                    "Pool has zero exchange rate, cannot compute redeem plan".to_string(),
+                ));
+            }
+            let numerator = (min_sui as u128) * (rate_token as u128) + (rate_sui as u128) - 1;
+            let tokens = (numerator / rate_sui as u128) as u64;
+            if tokens > total_tokens {
+                return Err(Error::InvalidInput(format!(
+                    "Insufficient FSS balance: AtLeast {min_sui} SUI requires {tokens} tokens \
+                     but only {total_tokens} available",
+                )));
+            }
+            Ok(RedeemPlan::AtLeast {
+                token_amount: tokens,
+                min_sui,
+            })
+        }
+        RedeemMode::AtMost => {
+            let max_sui = amount.ok_or_else(|| {
+                Error::InvalidInput("amount required for AtMost mode".to_string())
+            })?;
+            if max_sui == 0 {
+                return Err(Error::InvalidInput(
+                    "AtMost amount must be at least 1 MIST".to_string(),
+                ));
+            }
+            if rate_sui == 0 || rate_token == 0 {
+                return Err(Error::DataError(
+                    "Pool has zero exchange rate, cannot compute redeem plan".to_string(),
+                ));
+            }
+            let token_amount = binary_search_at_most(rate_sui, rate_token, total_tokens, max_sui)
+                .ok_or_else(|| {
+                Error::InvalidInput(
+                    "AtMost amount too small: would redeem 0 pool tokens at current exchange rate"
+                        .to_string(),
+                )
+            })?;
+            Ok(RedeemPlan::AtMost {
+                token_amount,
+                max_sui,
+            })
+        }
+    }
+}
+
+/// Resolve a pool's `(rate_sui, rate_token)` for the latest exchange rate.
 ///
-/// Phase 1: Merge all FSS into one
-/// Phase 2: Split token amount (None = redeem all, Some(n) = split n tokens)
-/// Phase 3: redeem_fungible_staked_sui → Balance<SUI>
-/// Phase 4: coin::from_balance<SUI> → Coin<SUI>
-/// Phase 5: TransferObjects → sender
+/// The staking pool's `sui_balance` and `pool_token_balance` fields equal the
+/// latest exchange rate's `(sui_amount, pool_token_amount)` within an epoch,
+/// since exchange rates are only added at epoch boundaries (see
+/// `staking_pool.move::process_pending_stakes_and_withdraws`).
+async fn pool_rate(client: &mut Client, pool_id: ObjectID) -> Result<(u64, u64), Error> {
+    let pool_rates = crate::account::get_pool_exchange_rates(client).await?;
+    let rate = pool_rates.get(&pool_id.to_string()).ok_or_else(|| {
+        Error::DataError(format!(
+            "No exchange rate found for pool {pool_id} \
+             (validator may be inactive — only active validators are supported \
+             for redeeming FungibleStakedSui)"
+        ))
+    })?;
+    Ok((rate.sui_balance, rate.pool_token_balance))
+}
+
+/// Build PTB for merging FSS and redeeming according to a `RedeemPlan`.
+///
+/// Common shape:
+/// 1. Merge all `fss_refs` into a single FSS object.
+/// 2. (Partial) `split_fungible_staked_sui` to a sub-FSS of `token_amount`.
+/// 3. `redeem_fungible_staked_sui` → `Balance<SUI>`.
+/// 4. (`AtLeast` only) `balance::split(&mut Balance<SUI>, min_sui)` → sub-balance,
+///    then `balance::join` it back. The split aborts on chain when the redeemed
+///    `Balance.value` is below `min_sui`, providing a runtime guard against
+///    pool drift between simulate and execution. The join restores the original
+///    balance so subsequent commands see a single, full `Balance<SUI>` again.
+/// 5. `coin::from_balance<SUI>` → `Coin<SUI>`.
+/// 6. `TransferObjects` → sender.
+///
+/// The `All` mode skips step 2 (redeems the merged FSS in full).
+/// The `AtMost` mode performs step 2 with a token count chosen so that the
+/// chain's `expected = floor(token * rate_sui / rate_token)` stays at or below
+/// the user-supplied `max_sui`; the on-chain invariant `actual <= expected`
+/// then guarantees the cap holds without an explicit guard.
 pub fn merge_and_redeem_fss_pt(
     sender: SuiAddress,
     fss_refs: Vec<ObjectRef>,
-    token_amount: Option<u64>,
+    plan: &RedeemPlan,
 ) -> anyhow::Result<ProgrammableTransaction> {
     let mut builder = ProgrammableTransactionBuilder::new();
 
@@ -205,8 +441,6 @@ pub fn merge_and_redeem_fss_pt(
 
     let system_state = builder.input(CallArg::SUI_SYSTEM_MUT)?;
 
-    // Phase 1: Merge all FSS into the first one using staking_pool::join_fungible_staked_sui
-    // MergeCoins only works on Coin<T>, not FungibleStakedSui
     let merged_fss = builder.obj(ObjectArg::ImmOrOwnedObject(fss_refs[0]))?;
     for fss_ref in &fss_refs[1..] {
         let other = builder.obj(ObjectArg::ImmOrOwnedObject(*fss_ref))?;
@@ -219,10 +453,14 @@ pub fn merge_and_redeem_fss_pt(
         ));
     }
 
-    // Phase 2: Split or use whole FSS
-    // FSS is not a Coin, so we must use staking_pool::split_fungible_staked_sui instead of SplitCoins
-    let redeem_target = if let Some(amount) = token_amount {
-        let split_amount = builder.pure(amount)?;
+    let split_token_amount = match plan {
+        RedeemPlan::All => None,
+        RedeemPlan::AtLeast { token_amount, .. } | RedeemPlan::AtMost { token_amount, .. } => {
+            Some(*token_amount)
+        }
+    };
+    let redeem_target = if let Some(token_amount) = split_token_amount {
+        let split_amount = builder.pure(token_amount)?;
         builder.command(Command::move_call(
             SUI_SYSTEM_PACKAGE_ID,
             Identifier::new("staking_pool")?,
@@ -231,11 +469,9 @@ pub fn merge_and_redeem_fss_pt(
             vec![merged_fss, split_amount],
         ))
     } else {
-        // Redeem all — use the entire merged FSS
         merged_fss
     };
 
-    // Phase 3: Redeem FSS → Balance<SUI>
     let balance_result = builder.command(Command::move_call(
         SUI_SYSTEM_PACKAGE_ID,
         SUI_SYSTEM_MODULE_NAME.to_owned(),
@@ -244,8 +480,26 @@ pub fn merge_and_redeem_fss_pt(
         vec![system_state, redeem_target],
     ));
 
-    // Phase 4: Convert Balance<SUI> → Coin<SUI>
     let sui_type = sui_types::TypeTag::from_str("0x2::sui::SUI")?;
+
+    if let RedeemPlan::AtLeast { min_sui, .. } = plan {
+        let min_arg = builder.pure(*min_sui)?;
+        let split_balance = builder.command(Command::move_call(
+            SUI_FRAMEWORK_PACKAGE_ID,
+            Identifier::new("balance")?,
+            Identifier::new("split")?,
+            vec![sui_type.clone()],
+            vec![balance_result, min_arg],
+        ));
+        builder.command(Command::move_call(
+            SUI_FRAMEWORK_PACKAGE_ID,
+            Identifier::new("balance")?,
+            Identifier::new("join")?,
+            vec![sui_type.clone()],
+            vec![balance_result, split_balance],
+        ));
+    }
+
     let coin_result = builder.command(Command::move_call(
         SUI_FRAMEWORK_PACKAGE_ID,
         Identifier::new("coin")?,
@@ -254,9 +508,174 @@ pub fn merge_and_redeem_fss_pt(
         vec![balance_result],
     ));
 
-    // Phase 5: Transfer Coin<SUI> to sender
     let sender_arg = builder.pure(sender)?;
     builder.command(Command::TransferObjects(vec![coin_result], sender_arg));
 
     Ok(builder.finish())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- AtMost binary search -------------------------------------------------
+
+    #[test]
+    fn atmost_picks_maximum_token_under_cap() {
+        // rate 200/99, supply=99: for T=49 expected=98, for T=50 expected=101.
+        // Largest T with expected(T) <= 100 is 49.
+        let token = binary_search_at_most(200, 99, 99, 100).unwrap();
+        assert_eq!(token, 49);
+        assert!(expected_sui_amount(200, 99, token) <= 100);
+        assert!(expected_sui_amount(200, 99, token + 1) > 100);
+    }
+
+    #[test]
+    fn atmost_returns_none_when_one_token_already_over_cap() {
+        // rate 1000:1 means 1 token = 1000 SUI; cap of 1 SUI is unsatisfiable.
+        assert!(binary_search_at_most(1000, 1, 100, 1).is_none());
+    }
+
+    #[test]
+    fn atmost_zero_rate_falls_back_to_one_to_one() {
+        // expected(token) = token when rate fields are 0. With cap=10 and 100
+        // tokens available, max satisfying token is 10.
+        assert_eq!(binary_search_at_most(0, 0, 100, 10).unwrap(), 10);
+    }
+
+    // --- Plan construction ---------------------------------------------------
+
+    #[test]
+    fn build_plan_atleast_picks_ceiling() {
+        // rate 200:100 means 1 token = 2 SUI. Need 5 SUI → ceil(5*100/200)=3.
+        let plan = build_redeem_plan(RedeemMode::AtLeast, Some(5), 100, 200, 100).unwrap();
+        match plan {
+            RedeemPlan::AtLeast {
+                token_amount,
+                min_sui,
+            } => {
+                assert_eq!(token_amount, 3);
+                assert_eq!(min_sui, 5);
+            }
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[test]
+    fn build_plan_atleast_rejects_when_insufficient_pool() {
+        // Need 1000 SUI from a pool with 10 tokens at 1:1 — impossible.
+        let err =
+            build_redeem_plan(RedeemMode::AtLeast, Some(1000), 10, 1, 1).expect_err("should fail");
+        assert!(format!("{err}").contains("Insufficient FSS balance"));
+    }
+
+    #[test]
+    fn build_plan_atleast_rejects_zero_amount() {
+        let err = build_redeem_plan(RedeemMode::AtLeast, Some(0), 100, 200, 100)
+            .expect_err("should fail");
+        assert!(format!("{err}").contains("at least 1 MIST"));
+    }
+
+    #[test]
+    fn build_plan_atmost_uses_binary_search() {
+        let plan = build_redeem_plan(RedeemMode::AtMost, Some(100), 99, 200, 99).unwrap();
+        match plan {
+            RedeemPlan::AtMost {
+                token_amount,
+                max_sui,
+            } => {
+                assert_eq!(token_amount, 49);
+                assert_eq!(max_sui, 100);
+            }
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[test]
+    fn build_plan_all_returns_all() {
+        let plan = build_redeem_plan(RedeemMode::All, None, 100, 200, 100).unwrap();
+        assert!(matches!(plan, RedeemPlan::All));
+    }
+
+    // --- PTB shape -----------------------------------------------------------
+
+    fn ref_(id: u8) -> ObjectRef {
+        use sui_types::base_types::{ObjectDigest, SequenceNumber};
+        let mut bytes = [0u8; 32];
+        bytes[31] = id;
+        (
+            ObjectID::from_bytes(bytes).unwrap(),
+            SequenceNumber::from_u64(1),
+            ObjectDigest::random(),
+        )
+    }
+
+    #[test]
+    fn ptb_all_omits_split_and_guard() {
+        let sender = SuiAddress::random_for_testing_only();
+        let pt = merge_and_redeem_fss_pt(sender, vec![ref_(1)], &RedeemPlan::All).unwrap();
+
+        let move_calls: Vec<&str> = pt
+            .commands
+            .iter()
+            .filter_map(|c| match c {
+                Command::MoveCall(m) => Some(m.function.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert!(move_calls.contains(&"redeem_fungible_staked_sui"));
+        assert!(move_calls.contains(&"from_balance"));
+        assert!(!move_calls.contains(&"split_fungible_staked_sui"));
+        assert!(!move_calls.contains(&"split"));
+        assert!(!move_calls.contains(&"join"));
+    }
+
+    #[test]
+    fn ptb_atleast_includes_balance_split_join_guard() {
+        let sender = SuiAddress::random_for_testing_only();
+        let plan = RedeemPlan::AtLeast {
+            token_amount: 100,
+            min_sui: 50,
+        };
+        let pt = merge_and_redeem_fss_pt(sender, vec![ref_(1), ref_(2)], &plan).unwrap();
+
+        let move_calls: Vec<(&str, &str)> = pt
+            .commands
+            .iter()
+            .filter_map(|c| match c {
+                Command::MoveCall(m) => Some((m.module.as_str(), m.function.as_str())),
+                _ => None,
+            })
+            .collect();
+        assert!(move_calls.contains(&("staking_pool", "join_fungible_staked_sui")));
+        assert!(move_calls.contains(&("staking_pool", "split_fungible_staked_sui")));
+        assert!(move_calls.contains(&("sui_system", "redeem_fungible_staked_sui")));
+        assert!(move_calls.contains(&("balance", "split")));
+        assert!(move_calls.contains(&("balance", "join")));
+        assert!(move_calls.contains(&("coin", "from_balance")));
+    }
+
+    #[test]
+    fn ptb_atmost_omits_balance_guard() {
+        let sender = SuiAddress::random_for_testing_only();
+        let plan = RedeemPlan::AtMost {
+            token_amount: 100,
+            max_sui: 50,
+        };
+        let pt = merge_and_redeem_fss_pt(sender, vec![ref_(1)], &plan).unwrap();
+
+        let move_calls: Vec<(&str, &str)> = pt
+            .commands
+            .iter()
+            .filter_map(|c| match c {
+                Command::MoveCall(m) => Some((m.module.as_str(), m.function.as_str())),
+                _ => None,
+            })
+            .collect();
+        assert!(move_calls.contains(&("staking_pool", "split_fungible_staked_sui")));
+        assert!(move_calls.contains(&("sui_system", "redeem_fungible_staked_sui")));
+        assert!(!move_calls.contains(&("balance", "split")));
+        assert!(!move_calls.contains(&("balance", "join")));
+        assert!(move_calls.contains(&("coin", "from_balance")));
+    }
 }

--- a/crates/sui-rosetta/src/types/internal_operation/merge_and_redeem.rs
+++ b/crates/sui-rosetta/src/types/internal_operation/merge_and_redeem.rs
@@ -31,7 +31,7 @@ use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 use sui_rpc::client::Client;
 use sui_rpc::field::FieldMaskUtil;
-use sui_rpc::proto::sui::rpc::v2::ListOwnedObjectsRequest;
+use sui_rpc::proto::sui::rpc::v2::{ListDynamicFieldsRequest, ListOwnedObjectsRequest};
 use sui_types::base_types::{ObjectID, ObjectRef, SuiAddress};
 use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
 use sui_types::rpc_proto_conversions::ObjectReferenceExt;
@@ -54,8 +54,25 @@ pub struct MergeAndRedeemFungibleStakedSui {
 }
 
 // ============================================================================
-// Mirror of the on-chain exchange-rate formula (pure, no RPC).
+// Mirror of the on-chain exchange-rate and split-floor payout formulae
+// (pure, no RPC).
 // ============================================================================
+
+/// Snapshot of the redeem-relevant state of a staking pool's
+/// `FungibleStakedSuiData` plus the latest exchange rate, sufficient to mirror
+/// the chain's payout formula in pure Rust.
+#[derive(Clone, Debug)]
+pub(crate) struct PoolRedeemData {
+    /// Latest `exchange_rate.sui_amount` (= pool.sui_balance within an epoch).
+    pub rate_sui: u64,
+    /// Latest `exchange_rate.pool_token_amount` (= pool.pool_token_balance).
+    pub rate_token: u64,
+    /// `FungibleStakedSuiData.principal.value()` — current Balance<SUI> in the
+    /// FSS sub-pool. Mutates within an epoch as other users convert/redeem.
+    pub fss_principal: u64,
+    /// `FungibleStakedSuiData.total_supply` — total outstanding FSS pool tokens.
+    pub fss_total_supply: u64,
+}
 
 /// Mirror of `0x3::staking_pool::PoolTokenExchangeRate::get_sui_amount` at
 /// `staking_pool.move:638-646`. Returns the SUI cap for `token_amount` pool
@@ -72,6 +89,68 @@ pub(crate) fn expected_sui_amount(rate_sui: u64, rate_token: u64, token_amount: 
         return token_amount;
     }
     ((token_amount as u128) * (rate_sui as u128) / (rate_token as u128)) as u64
+}
+
+/// Mirror of `0x3::staking_pool::calculate_fungible_staked_sui_withdraw_amount`
+/// at `staking_pool.move:231-271`. Returns the actual SUI the chain will
+/// deliver for `token_amount` FSS pool tokens given the supplied pool state.
+///
+/// The chain splits the payout into a principal share and a rewards share, each
+/// with an independent `floor`, so `actual <= expected` and the gap is bounded
+/// by ~2 MIST per redemption (one MIST per floor, scaled by `token/supply`).
+/// AtLeast selection must use this (not `expected_sui_amount`) to avoid picking
+/// a token count whose actual payout falls below the user's `min_sui`.
+pub(crate) fn mirror_redeem_actual(data: &PoolRedeemData, token_amount: u64) -> u64 {
+    if data.fss_total_supply == 0 {
+        return 0;
+    }
+
+    // total_sui = exchange_rate.get_sui_amount(total_supply)
+    let total_sui = if data.rate_sui == 0 || data.rate_token == 0 {
+        data.fss_total_supply
+    } else {
+        ((data.rate_sui as u128) * (data.fss_total_supply as u128) / (data.rate_token as u128))
+            as u64
+    };
+
+    let principal = data.fss_principal.min(total_sui);
+    let rewards = total_sui - principal;
+
+    let principal_out =
+        ((token_amount as u128) * (principal as u128) / (data.fss_total_supply as u128)) as u64;
+    let rewards_out =
+        ((token_amount as u128) * (rewards as u128) / (data.fss_total_supply as u128)) as u64;
+
+    principal_out + rewards_out
+}
+
+/// Binary-search the smallest `token_amount` in `[1, total_tokens]` such that
+/// `mirror_redeem_actual(data, token_amount) >= target_sui`.
+///
+/// Returns `None` if even redeeming `total_tokens` produces less than
+/// `target_sui` (caller reports "Insufficient FSS balance").
+pub(crate) fn binary_search_at_least(
+    data: &PoolRedeemData,
+    total_tokens: u64,
+    target_sui: u64,
+) -> Option<u64> {
+    if total_tokens == 0 {
+        return None;
+    }
+    if mirror_redeem_actual(data, total_tokens) < target_sui {
+        return None;
+    }
+    let mut lo: u64 = 1;
+    let mut hi: u64 = total_tokens;
+    while lo < hi {
+        let mid = lo + (hi - lo) / 2;
+        if mirror_redeem_actual(data, mid) >= target_sui {
+            hi = mid;
+        } else {
+            lo = mid + 1;
+        }
+    }
+    Some(lo)
 }
 
 /// Binary-search the largest `token_amount` in `[1, total_tokens]` such that
@@ -170,64 +249,25 @@ async fn list_owned_fss(client: &mut Client, sender: SuiAddress) -> Result<Vec<O
     Ok(out)
 }
 
-/// Snapshot of an active validator pulled out of `system_state.validators.active_validators`.
-#[derive(Clone, Debug)]
-struct ActivePoolEntry {
-    pool_id: ObjectID,
-    validator_addr: SuiAddress,
-}
-
-/// Read active validators and the inactive_validators table id from the system state.
-async fn fetch_validator_index(
-    client: &mut Client,
-) -> Result<(Vec<ActivePoolEntry>, Option<ObjectID>), Error> {
-    use sui_rpc::proto::sui::rpc::v2::GetEpochRequest;
-    let request = GetEpochRequest::latest().with_read_mask(FieldMask::from_paths([
-        "system_state.validators.active_validators",
-        "system_state.validators.inactive_validators",
-    ]));
-    let response = client
-        .ledger_client()
-        .get_epoch(request)
-        .await?
-        .into_inner();
-    let validators = response.epoch().system_state().validators();
-
-    let mut active = Vec::new();
-    for v in validators.active_validators() {
-        let pool_id = ObjectID::from_str(v.staking_pool().id())
-            .map_err(|e| Error::DataError(format!("Invalid active pool id: {e}")))?;
-        let validator_addr = SuiAddress::from_str(v.address())
-            .map_err(|e| Error::DataError(format!("Invalid active validator address: {e}")))?;
-        active.push(ActivePoolEntry {
-            pool_id,
-            validator_addr,
-        });
-    }
-
-    let inactive_table_id = validators
-        .inactive_validators
-        .as_ref()
-        .and_then(|t| t.id.as_ref())
-        .and_then(|id| ObjectID::from_str(id).ok());
-
-    Ok((active, inactive_table_id))
-}
-
-/// Resolve `validator` to a pool plus the sender's FSS in that pool.
+/// Resolve `validator` to a pool, the sender's FSS in that pool, and the
+/// `(rate_sui, rate_token, epoch)` snapshot — all from a single
+/// `GetEpochRequest::latest()` response.
 ///
-/// Uses the active validator set to map `validator → pool_id`, then groups the
-/// sender's FSS by pool. Returns `(pool_id, fss_refs, total_tokens)`.
+/// **Atomicity is load-bearing**: amount-sensitive plans bind the resulting
+/// transaction to `epoch`, so the rate must come from the same epoch. Splitting
+/// this into separate RPCs creates a race where rate is from epoch N but
+/// `bind_epoch` is N+1, silently violating AtMost caps and aborting AtLeast
+/// guards.
 ///
-/// Inactive validators (deactivated pools) are not currently supported by this
-/// path; the chain still allows redeeming from inactive pools, but the lookup
+/// Inactive validators (deactivated pools) are not supported by this path;
+/// the chain still allows redeeming from inactive pools, but the lookup
 /// requires walking `inactive_validators[pool_id] → ValidatorWrapper` dynamic
 /// fields, which is a follow-up.
-async fn resolve_pool_and_fss(
+async fn resolve_pool_fss_and_rate(
     client: &mut Client,
     sender: SuiAddress,
     target_validator: SuiAddress,
-) -> Result<(ObjectID, Vec<ObjectRef>, u64), Error> {
+) -> Result<PoolFssRateSnapshot, Error> {
     let owned = list_owned_fss(client, sender).await?;
     if owned.is_empty() {
         return Err(Error::InvalidInput(format!(
@@ -235,16 +275,19 @@ async fn resolve_pool_and_fss(
         )));
     }
 
-    let (active, _inactive_table_id) = fetch_validator_index(client).await?;
-    let pool_for_validator = active
+    let (rates, epoch) = crate::account::get_pool_exchange_rates_with_epoch(client).await?;
+
+    let target_validator_addr = sui_sdk_types::Address::from(target_validator);
+    let (pool_id_str, rate_info) = rates
         .iter()
-        .find(|v| v.validator_addr == target_validator)
-        .map(|v| v.pool_id)
+        .find(|(_, info)| info.validator_address == target_validator_addr)
         .ok_or_else(|| {
             Error::InvalidInput(format!(
                 "Validator {target_validator} not found among active validators"
             ))
         })?;
+    let pool_for_validator = ObjectID::from_str(pool_id_str)
+        .map_err(|e| Error::DataError(format!("Invalid active pool id: {e}")))?;
 
     let mut matching: Vec<&OwnedFss> = owned
         .iter()
@@ -259,8 +302,112 @@ async fn resolve_pool_and_fss(
     }
 
     let total_tokens: u64 = matching.iter().map(|f| f.value).sum();
-    let refs: Vec<ObjectRef> = matching.iter().map(|f| f.object_ref).collect();
-    Ok((pool_for_validator, refs, total_tokens))
+    let fss_refs: Vec<ObjectRef> = matching.iter().map(|f| f.object_ref).collect();
+    let pool_extra_fields_id = rate_info
+        .pool_extra_fields_id
+        .as_deref()
+        .and_then(|s| ObjectID::from_str(s).ok());
+    Ok(PoolFssRateSnapshot {
+        fss_refs,
+        total_tokens,
+        rate_sui: rate_info.sui_balance,
+        rate_token: rate_info.pool_token_balance,
+        epoch,
+        pool_extra_fields_id,
+    })
+}
+
+/// Atomic snapshot tying together pool, FSS, exchange rate, and the epoch the
+/// rate was read in. The epoch is the same one the resulting transaction will
+/// be bound to via `TransactionExpiration`.
+struct PoolFssRateSnapshot {
+    fss_refs: Vec<ObjectRef>,
+    total_tokens: u64,
+    rate_sui: u64,
+    rate_token: u64,
+    epoch: u64,
+    /// `pool.extra_fields.id` (the Bag UID), needed to fetch
+    /// `FungibleStakedSuiData` for AtLeast plans.
+    pool_extra_fields_id: Option<ObjectID>,
+}
+
+/// Subset of `0x3::staking_pool::FungibleStakedSuiData` we BCS-deserialize.
+/// Field order MUST match the Move source at `staking_pool.move:98-104`:
+///   `id: UID, total_supply: u64, principal: Balance<SUI>`
+/// where `UID` is a 32-byte address and `Balance<SUI>` is a `{ value: u64 }`
+/// struct (stored positionally as a u64).
+#[derive(Deserialize, Debug)]
+struct FungibleStakedSuiDataBcs {
+    _id: sui_sdk_types::Address,
+    total_supply: u64,
+    principal: BalanceValueBcs,
+}
+
+#[derive(Deserialize, Debug)]
+struct BalanceValueBcs {
+    value: u64,
+}
+
+/// Fetch the `FungibleStakedSuiData` stored at
+/// `pool.extra_fields[FungibleStakedSuiDataKey {}]`. Lists the bag's dynamic
+/// fields and finds the one whose `value_type` matches
+/// `<SUI_SYSTEM_PACKAGE>::staking_pool::FungibleStakedSuiData`, then BCS-
+/// deserializes the value into `(principal_value, total_supply)`.
+///
+/// We list rather than derive the field id locally to avoid coupling to the
+/// dynamic-field hashing rules (which would need a faithful Move-side
+/// `bcs::to_bytes(&FungibleStakedSuiDataKey {})` and TypeTag canonicalization).
+/// The bag normally holds a small number of entries (currently just FSS data),
+/// so the cost is bounded.
+async fn fetch_fss_data(client: &mut Client, bag_id: ObjectID) -> Result<(u64, u64), Error> {
+    let want_type = format!(
+        "{}::staking_pool::FungibleStakedSuiData",
+        SUI_SYSTEM_PACKAGE_ID
+    );
+
+    let request = ListDynamicFieldsRequest::default()
+        .with_parent(bag_id.to_string())
+        .with_page_size(50u32)
+        .with_read_mask(FieldMask::from_paths(["value_type", "value"]));
+    let dynamic_fields: Vec<_> = client
+        .list_dynamic_fields(request)
+        .map_err(Error::from)
+        .try_collect()
+        .await?;
+
+    for df in dynamic_fields {
+        let Some(value_type) = df.value_type.as_deref() else {
+            continue;
+        };
+        if !type_tags_match(value_type, &want_type) {
+            continue;
+        }
+        let bytes = df
+            .value
+            .as_ref()
+            .and_then(|b| b.value.as_deref())
+            .ok_or_else(|| {
+                Error::DataError("FungibleStakedSuiData entry has empty value".to_string())
+            })?;
+        let data: FungibleStakedSuiDataBcs = bcs::from_bytes(bytes)
+            .map_err(|e| Error::DataError(format!("FungibleStakedSuiData decode: {e}")))?;
+        return Ok((data.principal.value, data.total_supply));
+    }
+
+    Err(Error::DataError(format!(
+        "No FungibleStakedSuiData entry found in pool extra_fields bag {bag_id} \
+         (validator has no FSS yet — but sender holds FSS, this should not happen)"
+    )))
+}
+
+/// Compare two Move type tag strings ignoring address normalization differences
+/// (`0x3::...` vs `0x0000...3::...`). Both are valid canonical forms.
+fn type_tags_match(a: &str, b: &str) -> bool {
+    use sui_types::TypeTag;
+    match (TypeTag::from_str(a), TypeTag::from_str(b)) {
+        (Ok(ta), Ok(tb)) => ta == tb,
+        _ => a == b,
+    }
 }
 
 #[async_trait]
@@ -278,17 +425,54 @@ impl TryConstructTransaction for MergeAndRedeemFungibleStakedSui {
             redeem_mode,
         } = self;
 
-        let (pool_id, fss_refs, total_tokens) =
-            resolve_pool_and_fss(client, sender, validator).await?;
+        let snapshot = resolve_pool_fss_and_rate(client, sender, validator).await?;
+        let PoolFssRateSnapshot {
+            fss_refs,
+            total_tokens,
+            rate_sui,
+            rate_token,
+            epoch,
+            pool_extra_fields_id,
+        } = snapshot;
 
-        let (rate_sui, rate_token) = pool_rate(client, pool_id).await?;
+        // AtLeast needs the FSS sub-pool's principal+total_supply to mirror the
+        // chain's split-floor payout formula and pick the minimum token count
+        // whose actual payout >= min_sui. Fetched lazily so All/AtMost paths
+        // skip the extra GetObject.
+        let fss_data = if matches!(redeem_mode, RedeemMode::AtLeast) {
+            let bag_id = pool_extra_fields_id.ok_or_else(|| {
+                Error::DataError(
+                    "Staking pool extra_fields.id missing from system state response — \
+                     cannot locate FungibleStakedSuiData for AtLeast mode"
+                        .to_string(),
+                )
+            })?;
+            let (principal, total_supply) = fetch_fss_data(client, bag_id).await?;
+            Some(PoolRedeemData {
+                rate_sui,
+                rate_token,
+                fss_principal: principal,
+                fss_total_supply: total_supply,
+            })
+        } else {
+            None
+        };
 
-        let plan = build_redeem_plan(redeem_mode, amount, total_tokens, rate_sui, rate_token)?;
+        let plan = build_redeem_plan(
+            redeem_mode,
+            amount,
+            total_tokens,
+            rate_sui,
+            rate_token,
+            fss_data.as_ref(),
+        )?;
+        // Amount-sensitive plans bind to `epoch` so the chain executes against
+        // the same exchange rate the off-chain quote used. `epoch` here comes
+        // from the same RPC response as `(rate_sui, rate_token)`, so there is
+        // no race between rate read and epoch read.
         let bind_epoch = match plan {
             RedeemPlan::All => None,
-            RedeemPlan::AtLeast { .. } | RedeemPlan::AtMost { .. } => {
-                Some(crate::get_current_epoch(client).await?)
-            }
+            RedeemPlan::AtLeast { .. } | RedeemPlan::AtMost { .. } => Some(epoch),
         };
 
         let pt = merge_and_redeem_fss_pt(sender, fss_refs.clone(), &plan)?;
@@ -323,15 +507,25 @@ impl TryConstructTransaction for MergeAndRedeemFungibleStakedSui {
     }
 }
 
-/// Translate a user-supplied `(redeem_mode, amount)` pair into a `RedeemPlan`,
-/// validating amounts and computing token counts via binary search over the
-/// chain's exchange-rate formula.
+/// Translate a user-supplied `(redeem_mode, amount)` pair into a `RedeemPlan`.
+///
+/// `AtLeast` mirrors the chain's split-floor payout formula
+/// (`calculate_fungible_staked_sui_withdraw_amount`) and binary-searches for
+/// the minimum token count whose actual payout is `>= min_sui`. `fss_data`
+/// must be `Some` for AtLeast — without it we'd fall back to the `expected`
+/// formula which can pick a token count whose actual falls 1-2 MIST short,
+/// causing the chain guard to abort needlessly.
+///
+/// `AtMost` searches by `expected` alone — the chain's `actual <= expected`
+/// invariant (`staking_pool.move:264-268`) keeps the cap safe without the FSS
+/// sub-pool data.
 pub(crate) fn build_redeem_plan(
     redeem_mode: RedeemMode,
     amount: Option<u64>,
     total_tokens: u64,
     rate_sui: u64,
     rate_token: u64,
+    fss_data: Option<&PoolRedeemData>,
 ) -> Result<RedeemPlan, Error> {
     match redeem_mode {
         RedeemMode::All => Ok(RedeemPlan::All),
@@ -349,16 +543,20 @@ pub(crate) fn build_redeem_plan(
                     "Pool has zero exchange rate, cannot compute redeem plan".to_string(),
                 ));
             }
-            let numerator = (min_sui as u128) * (rate_token as u128) + (rate_sui as u128) - 1;
-            let tokens = (numerator / rate_sui as u128) as u64;
-            if tokens > total_tokens {
-                return Err(Error::InvalidInput(format!(
-                    "Insufficient FSS balance: AtLeast {min_sui} SUI requires {tokens} tokens \
-                     but only {total_tokens} available",
-                )));
-            }
+            let data = fss_data.ok_or_else(|| {
+                Error::DataError(
+                    "FungibleStakedSuiData required for AtLeast mode but not supplied".to_string(),
+                )
+            })?;
+            let token_amount =
+                binary_search_at_least(data, total_tokens, min_sui).ok_or_else(|| {
+                    Error::InvalidInput(format!(
+                        "Insufficient FSS balance: cannot deliver AtLeast {min_sui} SUI \
+                         from {total_tokens} pool tokens at current exchange rate",
+                    ))
+                })?;
             Ok(RedeemPlan::AtLeast {
-                token_amount: tokens,
+                token_amount,
                 min_sui,
             })
         }
@@ -389,24 +587,6 @@ pub(crate) fn build_redeem_plan(
             })
         }
     }
-}
-
-/// Resolve a pool's `(rate_sui, rate_token)` for the latest exchange rate.
-///
-/// The staking pool's `sui_balance` and `pool_token_balance` fields equal the
-/// latest exchange rate's `(sui_amount, pool_token_amount)` within an epoch,
-/// since exchange rates are only added at epoch boundaries (see
-/// `staking_pool.move::process_pending_stakes_and_withdraws`).
-async fn pool_rate(client: &mut Client, pool_id: ObjectID) -> Result<(u64, u64), Error> {
-    let pool_rates = crate::account::get_pool_exchange_rates(client).await?;
-    let rate = pool_rates.get(&pool_id.to_string()).ok_or_else(|| {
-        Error::DataError(format!(
-            "No exchange rate found for pool {pool_id} \
-             (validator may be inactive — only active validators are supported \
-             for redeeming FungibleStakedSui)"
-        ))
-    })?;
-    Ok((rate.sui_balance, rate.pool_token_balance))
 }
 
 /// Build PTB for merging FSS and redeeming according to a `RedeemPlan`.
@@ -545,17 +725,69 @@ mod tests {
 
     // --- Plan construction ---------------------------------------------------
 
+    fn fss(rate_sui: u64, rate_token: u64, principal: u64, supply: u64) -> PoolRedeemData {
+        PoolRedeemData {
+            rate_sui,
+            rate_token,
+            fss_principal: principal,
+            fss_total_supply: supply,
+        }
+    }
+
     #[test]
-    fn build_plan_atleast_picks_ceiling() {
-        // rate 200:100 means 1 token = 2 SUI. Need 5 SUI → ceil(5*100/200)=3.
-        let plan = build_redeem_plan(RedeemMode::AtLeast, Some(5), 100, 200, 100).unwrap();
+    fn build_plan_atleast_picks_minimum_token_satisfying_actual() {
+        // Pool: 1:1 rate, 100 supply, 50 principal.
+        //   total_sui = floor(100*100/100) = 100
+        //   principal_capped = 50, rewards = 50
+        //   actual(t) = floor(t*50/100) + floor(t*50/100)
+        // For t=5: actual = 2 + 2 = 4 (split-floor underrun!)
+        // For t=6: actual = 3 + 3 = 6 ≥ 5 ✓
+        // The naive `expected = floor(5*100/100) = 5` ceil formula would have
+        // picked t=5, but actual=4 < 5 — the chain guard would abort. The
+        // mirror search correctly picks t=6.
+        let data = fss(100, 100, 50, 100);
+        let plan =
+            build_redeem_plan(RedeemMode::AtLeast, Some(5), 100, 100, 100, Some(&data)).unwrap();
         match plan {
             RedeemPlan::AtLeast {
                 token_amount,
                 min_sui,
             } => {
-                assert_eq!(token_amount, 3);
+                assert_eq!(
+                    token_amount, 6,
+                    "mirror picks t=6 (actual=6) over naive t=5 (actual=4)"
+                );
                 assert_eq!(min_sui, 5);
+                assert!(mirror_redeem_actual(&data, token_amount) >= 5);
+            }
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[test]
+    fn build_plan_atleast_avoids_split_floor_underrun() {
+        // Reproduce the production bug class: rates / FSS state where the simple
+        // expected-rate ceiling underestimates by 1 MIST. Pick a pool where
+        // mirror(t) = expected(t) - 1 for the candidate t, so a naive ceil
+        // formula would pick t but actual(t) < min_sui.
+        //
+        // Setup: rate 7:3 (sui:token), supply 30, principal 7. Each token
+        // expects floor(1*7/3) = 2 MIST cap, but split-floor accounting gives
+        //   total_sui = floor(7*30/3) = 70
+        //   principal_capped = min(7, 70) = 7, rewards = 63
+        //   for t=15: principal_out=floor(15*7/30)=3, rewards_out=floor(15*63/30)=31, actual=34
+        //   for t=16: principal_out=floor(16*7/30)=3, rewards_out=floor(16*63/30)=33, actual=36
+        // Asking for min_sui=35: naive ceil(35*3/7) = 15 picks t=15 → actual=34 < 35 → guard would abort.
+        // Mirror search picks t=16 → actual=36 >= 35 ✓.
+        let data = fss(7, 3, 7, 30);
+        let plan = build_redeem_plan(RedeemMode::AtLeast, Some(35), 30, 7, 3, Some(&data)).unwrap();
+        match plan {
+            RedeemPlan::AtLeast { token_amount, .. } => {
+                assert_eq!(
+                    token_amount, 16,
+                    "mirror search should pick t=16, not naive t=15"
+                );
+                assert!(mirror_redeem_actual(&data, token_amount) >= 35);
             }
             _ => panic!("wrong variant"),
         }
@@ -564,21 +796,30 @@ mod tests {
     #[test]
     fn build_plan_atleast_rejects_when_insufficient_pool() {
         // Need 1000 SUI from a pool with 10 tokens at 1:1 — impossible.
-        let err =
-            build_redeem_plan(RedeemMode::AtLeast, Some(1000), 10, 1, 1).expect_err("should fail");
+        let data = fss(1, 1, 5, 10);
+        let err = build_redeem_plan(RedeemMode::AtLeast, Some(1000), 10, 1, 1, Some(&data))
+            .expect_err("should fail");
         assert!(format!("{err}").contains("Insufficient FSS balance"));
     }
 
     #[test]
     fn build_plan_atleast_rejects_zero_amount() {
-        let err = build_redeem_plan(RedeemMode::AtLeast, Some(0), 100, 200, 100)
+        let data = fss(200, 100, 50, 100);
+        let err = build_redeem_plan(RedeemMode::AtLeast, Some(0), 100, 200, 100, Some(&data))
             .expect_err("should fail");
         assert!(format!("{err}").contains("at least 1 MIST"));
     }
 
     #[test]
+    fn build_plan_atleast_rejects_missing_fss_data() {
+        let err = build_redeem_plan(RedeemMode::AtLeast, Some(5), 100, 200, 100, None)
+            .expect_err("should fail");
+        assert!(format!("{err}").contains("FungibleStakedSuiData required"));
+    }
+
+    #[test]
     fn build_plan_atmost_uses_binary_search() {
-        let plan = build_redeem_plan(RedeemMode::AtMost, Some(100), 99, 200, 99).unwrap();
+        let plan = build_redeem_plan(RedeemMode::AtMost, Some(100), 99, 200, 99, None).unwrap();
         match plan {
             RedeemPlan::AtMost {
                 token_amount,
@@ -593,8 +834,35 @@ mod tests {
 
     #[test]
     fn build_plan_all_returns_all() {
-        let plan = build_redeem_plan(RedeemMode::All, None, 100, 200, 100).unwrap();
+        let plan = build_redeem_plan(RedeemMode::All, None, 100, 200, 100, None).unwrap();
         assert!(matches!(plan, RedeemPlan::All));
+    }
+
+    #[test]
+    fn mirror_invariant_actual_le_expected_with_small_gap() {
+        // Property check: mirror_redeem_actual <= expected_sui_amount across a
+        // grid of plausible pool states, with the gap bounded by ~2 MIST.
+        for rate_sui in [100u64, 199, 1024, 100_003] {
+            for rate_token in [99u64, 100, 1023, 99_997] {
+                let supply = rate_token;
+                for principal_pct in [0u64, 30, 50, 80, 100] {
+                    let principal = supply * principal_pct / 100;
+                    let data = fss(rate_sui, rate_token, principal, supply);
+                    for token in [1u64, 2, supply / 2, supply.saturating_sub(1), supply] {
+                        if token == 0 || token > supply {
+                            continue;
+                        }
+                        let expected = expected_sui_amount(rate_sui, rate_token, token);
+                        let actual = mirror_redeem_actual(&data, token);
+                        assert!(actual <= expected, "actual={actual} > expected={expected}");
+                        assert!(
+                            actual + 2 >= expected,
+                            "gap > 2 MIST: expected={expected} actual={actual}"
+                        );
+                    }
+                }
+            }
+        }
     }
 
     // --- PTB shape -----------------------------------------------------------

--- a/crates/sui-rosetta/src/types/internal_operation/merge_and_redeem.rs
+++ b/crates/sui-rosetta/src/types/internal_operation/merge_and_redeem.rs
@@ -329,6 +329,14 @@ async fn resolve_pool_fss_and_rate(
             if let Some(inactive) =
                 lookup_inactive_pool(client, table_id, *pool_id, target_validator).await?
             {
+                let (rate_sui, rate_token) = fetch_pool_exchange_rate_at_epoch(
+                    client,
+                    inactive.exchange_rates_table_id,
+                    inactive.activation_epoch,
+                    inactive.deactivation_epoch,
+                    snapshot.epoch,
+                )
+                .await?;
                 let mut sorted = fss_list.clone();
                 sorted.sort_by_key(|f| f.object_ref.0);
                 let total_tokens: u64 = sorted.iter().map(|f| f.value).sum();
@@ -336,8 +344,8 @@ async fn resolve_pool_fss_and_rate(
                 return Ok(PoolFssRateSnapshot {
                     fss_refs,
                     total_tokens,
-                    rate_sui: inactive.rate_sui,
-                    rate_token: inactive.rate_token,
+                    rate_sui,
+                    rate_token,
                     epoch: snapshot.epoch,
                     pool_extra_fields_id: Some(inactive.pool_extra_fields_id),
                 });
@@ -377,15 +385,27 @@ fn build_snapshot(
 }
 
 /// Pool data extracted from an inactive validator's `ValidatorWrapper`.
+///
+/// The on-chain redeem path (`staking_pool.move:205`) calls
+/// `pool.pool_token_exchange_rate_at_epoch(ctx.epoch())` rather than reading
+/// `pool.sui_balance / pool_token_balance` directly. For inactive pools these
+/// live fields can drift from the exchange-rate snapshot when other users do
+/// regular `request_withdraw_stake` (StakedSui, not FSS) on the deactivated
+/// pool — `staking_pool.move:187-188` immediately processes the pending
+/// withdrawal for inactive/preactive pools, which mutates `sui_balance` and
+/// `pool_token_balance`. So we extract the table id and walk it the same way
+/// the chain does.
 struct InactivePoolData {
-    rate_sui: u64,
-    rate_token: u64,
+    activation_epoch: Option<u64>,
+    deactivation_epoch: Option<u64>,
+    exchange_rates_table_id: ObjectID,
     pool_extra_fields_id: ObjectID,
 }
 
 /// Walk `inactive_validators[pool_id]` → `ValidatorWrapper` → `Versioned` →
-/// `ValidatorV1` to extract the staking pool's rate fields and verify the
-/// validator address matches.
+/// `ValidatorV1` to find the validator with matching address and extract the
+/// pool's exchange-rate table id (plus activation/deactivation epochs needed
+/// for the walk-back) and the FSS data Bag id.
 ///
 /// The chain stores `inactive_validators` as `Table<ID, ValidatorWrapper>`
 /// (validator_set.move:73). Each entry is a dynamic field at
@@ -393,13 +413,8 @@ struct InactivePoolData {
 /// `Versioned` whose latest value is the actual `ValidatorV1`, stored at
 /// `derive(versioned.id, &TypeTag::U64, bcs(version))`.
 ///
-/// For inactive pools, `pool.sui_balance` and `pool.pool_token_balance` are
-/// frozen at deactivation (advance_epoch no longer touches them), so they
-/// equal the latest exchange-rate snapshot — no `pool_token_exchange_rate_at_epoch`
-/// walk-back needed.
-///
-/// Returns `None` if the wrapper is not found at the derived id (validator
-/// address didn't match) so the caller can try the next candidate pool.
+/// Returns `None` if the wrapper at the derived id resolves to a validator
+/// whose address doesn't match (caller can try the next candidate pool).
 async fn lookup_inactive_pool(
     client: &mut Client,
     inactive_table_id: ObjectID,
@@ -423,15 +438,7 @@ async fn lookup_inactive_pool(
     };
     let wrapper_field: Field<ID, ValidatorWrapper> = bcs::from_bytes(&wrapper_bytes)
         .map_err(|e| Error::DataError(format!("Field<ID,ValidatorWrapper> decode: {e}")))?;
-    let versioned_id = ObjectID::from_str(
-        &wrapper_field
-            .value
-            .inner
-            .id
-            .object_id()
-            .to_hex_uncompressed(),
-    )
-    .map_err(|e| Error::DataError(format!("Invalid Versioned id: {e}")))?;
+    let versioned_id = wrapper_field.value.inner.id.id.bytes;
     let version = wrapper_field.value.inner.version;
 
     let u64_type = sui_types::TypeTag::U64;
@@ -456,10 +463,107 @@ async fn lookup_inactive_pool(
     }
 
     Ok(Some(InactivePoolData {
-        rate_sui: validator.staking_pool.sui_balance,
-        rate_token: validator.staking_pool.pool_token_balance,
+        activation_epoch: validator.staking_pool.activation_epoch,
+        deactivation_epoch: validator.staking_pool.deactivation_epoch,
+        exchange_rates_table_id: validator.staking_pool.exchange_rates.id,
         pool_extra_fields_id: validator.staking_pool.extra_fields.id.id.bytes,
     }))
+}
+
+/// Mirror of `staking_pool::pool_token_exchange_rate_at_epoch`
+/// (`staking_pool.move:587-608`). Returns `(sui_amount, pool_token_amount)`
+/// of the exchange rate the chain would use when redeeming at `current_epoch`.
+///
+/// For deactivated pools the lookup epoch is clamped to `deactivation_epoch`
+/// (rates aren't recorded after deactivation; the last recorded rate is the
+/// one the chain replays). The walk steps backward from the clamped epoch
+/// down to `activation_epoch` and returns the first `exchange_rates[epoch]`
+/// entry it finds. If none is found (or the pool is preactive) the chain
+/// returns `initial_exchange_rate()` which `get_sui_amount` then treats as
+/// 1:1 — we surface the same `(0, 0)` here so downstream `expected_sui_amount`
+/// applies the same fallback.
+async fn fetch_pool_exchange_rate_at_epoch(
+    client: &mut Client,
+    table_id: ObjectID,
+    activation_epoch: Option<u64>,
+    deactivation_epoch: Option<u64>,
+    current_epoch: u64,
+) -> Result<(u64, u64), Error> {
+    let candidates = walk_back_epochs(activation_epoch, deactivation_epoch, current_epoch);
+    for epoch in candidates {
+        if let Some((sui_amount, pool_token_amount)) =
+            try_read_exchange_rate(client, table_id, epoch).await?
+        {
+            return Ok((sui_amount, pool_token_amount));
+        }
+    }
+    Ok((0, 0))
+}
+
+/// Pure-function half of the walk-back: given the pool's activation /
+/// deactivation epochs and the current epoch, produce the ordered list of
+/// epochs to probe, matching `pool_token_exchange_rate_at_epoch` semantics.
+///
+/// * Preactive pool (activation > current, or never activated) → empty list:
+///   the on-chain `is_preactive_at_epoch` short-circuits to
+///   `initial_exchange_rate()`.
+/// * Otherwise clamp to `min(deactivation.unwrap_or(current), current)` and
+///   walk down to `activation`.
+fn walk_back_epochs(
+    activation_epoch: Option<u64>,
+    deactivation_epoch: Option<u64>,
+    current_epoch: u64,
+) -> Vec<u64> {
+    let Some(activation) = activation_epoch else {
+        return Vec::new();
+    };
+    if activation > current_epoch {
+        return Vec::new();
+    }
+    let clamped = deactivation_epoch
+        .map(|d| d.min(current_epoch))
+        .unwrap_or(current_epoch);
+    let start = clamped.max(activation);
+    (activation..=start).rev().collect()
+}
+
+/// BCS layout of `0x3::staking_pool::PoolTokenExchangeRate`. Mirrors the Move
+/// struct at `staking_pool.move:69-72`. We can't use `sui_types`'s
+/// `PoolTokenExchangeRate` directly because its fields are private; the BCS
+/// layout (positional u64 / u64) is the public interface.
+#[derive(Deserialize, Debug)]
+struct PoolTokenExchangeRateBcs {
+    sui_amount: u64,
+    pool_token_amount: u64,
+}
+
+/// Direct dynamic-field lookup of `exchange_rates[epoch]`. Returns
+/// `Ok(None)` if the entry doesn't exist at the derived id (no rate was
+/// recorded for that epoch — caller walks back to the previous one).
+async fn try_read_exchange_rate(
+    client: &mut Client,
+    table_id: ObjectID,
+    epoch: u64,
+) -> Result<Option<(u64, u64)>, Error> {
+    use sui_types::dynamic_field::{Field, derive_dynamic_field_id};
+
+    let key_bcs = bcs::to_bytes(&epoch)
+        .map_err(|e| Error::DataError(format!("exchange_rates key bcs: {e}")))?;
+    let field_id = derive_dynamic_field_id(table_id, &sui_types::TypeTag::U64, &key_bcs)
+        .map_err(|e| Error::DataError(format!("derive exchange_rates[{epoch}] field id: {e}")))?;
+
+    let Some(bytes) = try_read_object_contents(client, field_id).await? else {
+        return Ok(None);
+    };
+    let field: Field<u64, PoolTokenExchangeRateBcs> = bcs::from_bytes(&bytes).map_err(|e| {
+        Error::DataError(format!(
+            "Field<u64,PoolTokenExchangeRate> decode at epoch {epoch}: {e}"
+        ))
+    })?;
+    Ok(Some((
+        field.value.sui_amount,
+        field.value.pool_token_amount,
+    )))
 }
 
 /// Fetch raw BCS contents of an object, returning `None` if the object does
@@ -911,6 +1015,55 @@ mod tests {
         // Typical pool: ~10^9 SUI total, 1:1 rate. Should not overflow.
         let result = mul_div_u64(1_000_000_000_000_000_000, 1, 1).unwrap();
         assert_eq!(result, 1_000_000_000_000_000_000);
+    }
+
+    // --- Exchange-rate walk-back (mirrors pool_token_exchange_rate_at_epoch) -
+
+    #[test]
+    fn walk_back_active_pool_starts_at_current_epoch() {
+        // Active pool (no deactivation): walk from current down to activation.
+        let epochs = walk_back_epochs(Some(10), None, 15);
+        assert_eq!(epochs, vec![15, 14, 13, 12, 11, 10]);
+    }
+
+    #[test]
+    fn walk_back_inactive_pool_clamps_to_deactivation_epoch() {
+        // Pool deactivated at epoch 12 — at current epoch 17 the chain replays
+        // the rate snapshot at deactivation, walking back from there.
+        let epochs = walk_back_epochs(Some(10), Some(12), 17);
+        assert_eq!(epochs, vec![12, 11, 10]);
+    }
+
+    #[test]
+    fn walk_back_clamp_is_minimum_of_deactivation_and_current() {
+        // Pool deactivated *after* current epoch (unusual but the chain handles
+        // it via min(deactivation, current)) — walk-back starts from current.
+        let epochs = walk_back_epochs(Some(10), Some(99), 12);
+        assert_eq!(epochs, vec![12, 11, 10]);
+    }
+
+    #[test]
+    fn walk_back_preactive_returns_empty() {
+        // Pool not yet activated at the lookup epoch → chain short-circuits to
+        // initial_exchange_rate(). Empty list signals the same — no
+        // exchange_rates entry to probe; the `(0, 0)` fallback applies.
+        let epochs = walk_back_epochs(Some(20), None, 15);
+        assert!(epochs.is_empty(), "got {epochs:?}");
+    }
+
+    #[test]
+    fn walk_back_no_activation_returns_empty() {
+        // Activation epoch is None — chain treats this as preactive.
+        let epochs = walk_back_epochs(None, None, 5);
+        assert!(epochs.is_empty(), "got {epochs:?}");
+    }
+
+    #[test]
+    fn walk_back_single_epoch_pool() {
+        // Pool activated and deactivated in the same epoch: walk-back probes
+        // exactly that epoch.
+        let epochs = walk_back_epochs(Some(7), Some(7), 30);
+        assert_eq!(epochs, vec![7]);
     }
 
     // --- Plan construction ---------------------------------------------------

--- a/crates/sui-rosetta/src/types/internal_operation/pay_coin.rs
+++ b/crates/sui-rosetta/src/types/internal_operation/pay_coin.rs
@@ -125,6 +125,8 @@ impl TryConstructTransaction for PayCoin {
                 address_balance_withdrawal: deficit,
                 fss_object_count: None,
                 redeem_token_amount: None,
+                redeem_plan: None,
+                bind_epoch: None,
             })
         } else {
             let total_sui_balance = gas_coin_objs.iter().map(|c| c.balance()).sum::<u64>() as i128;
@@ -142,6 +144,8 @@ impl TryConstructTransaction for PayCoin {
                 address_balance_withdrawal: deficit,
                 fss_object_count: None,
                 redeem_token_amount: None,
+                redeem_plan: None,
+                bind_epoch: None,
             })
         }
     }

--- a/crates/sui-rosetta/src/types/internal_operation/pay_sui.rs
+++ b/crates/sui-rosetta/src/types/internal_operation/pay_sui.rs
@@ -127,6 +127,8 @@ impl TryConstructTransaction for PaySui {
                     address_balance_withdrawal: address_balance_withdrawl,
                     fss_object_count: None,
                     redeem_token_amount: None,
+                    redeem_plan: None,
+                    bind_epoch: None,
                 })
             }
             _ => {
@@ -168,6 +170,8 @@ impl TryConstructTransaction for PaySui {
                     address_balance_withdrawal,
                     fss_object_count: None,
                     redeem_token_amount: None,
+                    redeem_plan: None,
+                    bind_epoch: None,
                 })
             }
         }

--- a/crates/sui-rosetta/src/types/internal_operation/stake.rs
+++ b/crates/sui-rosetta/src/types/internal_operation/stake.rs
@@ -151,6 +151,8 @@ impl TryConstructTransaction for Stake {
                     address_balance_withdrawal: actual_deficit,
                     fss_object_count: None,
                     redeem_token_amount: None,
+                    redeem_plan: None,
+                    bind_epoch: None,
                 })
             }
             _ => {
@@ -190,6 +192,8 @@ impl TryConstructTransaction for Stake {
                     address_balance_withdrawal,
                     fss_object_count: None,
                     redeem_token_amount: None,
+                    redeem_plan: None,
+                    bind_epoch: None,
                 })
             }
         }

--- a/crates/sui-rosetta/src/types/internal_operation/withdraw_stake.rs
+++ b/crates/sui-rosetta/src/types/internal_operation/withdraw_stake.rs
@@ -125,6 +125,8 @@ impl TryConstructTransaction for WithdrawStake {
             address_balance_withdrawal: 0,
             fss_object_count: None,
             redeem_token_amount: None,
+            redeem_plan: None,
+            bind_epoch: None,
         })
     }
 }

--- a/crates/sui-rosetta/tests/balance_changing_tx_tests.rs
+++ b/crates/sui-rosetta/tests/balance_changing_tx_tests.rs
@@ -632,6 +632,8 @@ async fn test_delegation_parsing() -> Result<(), anyhow::Error> {
         address_balance_withdrawal: 0,
         fss_object_count: None,
         redeem_token_amount: None,
+        redeem_plan: None,
+        bind_epoch: None,
         epoch: None,
         chain_id: None,
     };

--- a/crates/sui-rosetta/tests/end_to_end_tests.rs
+++ b/crates/sui-rosetta/tests/end_to_end_tests.rs
@@ -5227,7 +5227,16 @@ fn assert_merge_redeem_parse_ops(
         panic!("wrong metadata variant: {:?}", ops[0].metadata);
     };
     assert!(validator.is_none(), "validator must be None from parser");
-    assert!(amount.is_none(), "amount must be None from parser");
+    // AtLeast carries `min_sui` decoded from the on-chain `balance::split`
+    // guard; All and the unknown-partial mode emit no amount.
+    match expected_mode {
+        Some(sui_rosetta::types::RedeemMode::AtLeast) => {
+            assert!(amount.is_some(), "AtLeast parse should recover min_sui");
+        }
+        _ => {
+            assert!(amount.is_none(), "amount must be None from parser");
+        }
+    }
     assert_eq!(redeem_mode, expected_mode);
     assert_eq!(fss_ids.len(), expected_fss_count);
 }
@@ -5328,12 +5337,7 @@ async fn test_e2e_parse_merge_redeem_single_fss_atmost() {
         "AtMost",
     )
     .await;
-    assert_merge_redeem_parse_ops(
-        &ops,
-        sender,
-        1,
-        Some(sui_rosetta::types::RedeemMode::AtMost),
-    );
+    assert_merge_redeem_parse_ops(&ops, sender, 1, None);
 }
 
 /// F=3, All mode.
@@ -5430,12 +5434,7 @@ async fn test_e2e_parse_merge_redeem_three_fss_atmost() {
         "AtMost",
     )
     .await;
-    assert_merge_redeem_parse_ops(
-        &ops,
-        sender,
-        3,
-        Some(sui_rosetta::types::RedeemMode::AtMost),
-    );
+    assert_merge_redeem_parse_ops(&ops, sender, 3, None);
 }
 
 /// Multi-validator: FSS on both A and B; redeem only from A.
@@ -5680,7 +5679,7 @@ async fn test_e2e_block_merge_redeem_single_fss_atmost() {
         Some(500_000_000),
         "AtMost",
         1,
-        Some(sui_rosetta::types::RedeemMode::AtMost),
+        None,
     )
     .await;
 }
@@ -5782,7 +5781,7 @@ async fn test_e2e_block_merge_redeem_three_fss_atmost() {
         Some(500_000_000),
         "AtMost",
         3,
-        Some(sui_rosetta::types::RedeemMode::AtMost),
+        None,
     )
     .await;
 }

--- a/crates/sui-rosetta/tests/end_to_end_tests.rs
+++ b/crates/sui-rosetta/tests/end_to_end_tests.rs
@@ -3737,6 +3737,151 @@ async fn test_redeem_single_fss_partial() {
     );
 }
 
+/// Redeem FSS from a validator that has been moved to `inactive_validators`.
+///
+/// Exercises the full inactive code path: FSS-first pool resolution, the
+/// `inactive_validators[pool_id]` dynamic field walk, the `Versioned →
+/// ValidatorV1` decode, and the `pool_token_exchange_rate_at_epoch` walk-back
+/// against the pool's `exchange_rates` table. The chain accepts inactive
+/// pools at the same `redeem_fungible_staked_sui` entry point
+/// (`validator_set.move:346-364`) so any layout/derive bug in the Rosetta
+/// inactive code surfaces as a metadata or submit failure here.
+///
+/// Default genesis sets `min_validator_count = 4`, and `request_remove_validator`
+/// asserts `next_epoch_validator_count() > min_validator_count` (strictly
+/// greater). We start with 6 validators so removing one leaves 5 > 4 and
+/// the remove succeeds.
+#[tokio::test]
+async fn test_redeem_fss_from_inactive_validator() {
+    use futures::TryStreamExt;
+    use sui_rpc::proto::sui::rpc::v2::ListOwnedObjectsRequest;
+    use sui_test_transaction_builder::TestTransactionBuilder;
+
+    let test_cluster = TestClusterBuilder::new()
+        .with_num_validators(6)
+        .build()
+        .await;
+    let sender = test_cluster.get_address_0();
+    let keystore = &test_cluster.wallet.config.keystore;
+    let mut client = GrpcClient::new(test_cluster.rpc_url()).unwrap();
+    let (rosetta_client, _handles) = start_rosetta_test_server(client.clone()).await;
+    let validator = first_validator(&mut client).await;
+
+    // Stake → activate → convert StakedSui to FSS so the sender holds an
+    // FSS object whose pool_id == `validator`'s staking pool.
+    stake_via_rosetta(
+        &rosetta_client,
+        &mut client,
+        keystore,
+        sender,
+        validator,
+        2_000_000_000,
+    )
+    .await;
+    test_cluster.trigger_reconfiguration().await;
+
+    let staked_req = ListOwnedObjectsRequest::default()
+        .with_owner(sender.to_string())
+        .with_object_type("0x3::staking_pool::StakedSui".to_string())
+        .with_page_size(10u32)
+        .with_read_mask(FieldMask::from_paths(["object_id", "version", "digest"]));
+    let staked_objects: Vec<_> = client
+        .clone()
+        .list_owned_objects(staked_req)
+        .map_err(|e| panic!("list error: {e}"))
+        .try_collect()
+        .await
+        .unwrap();
+    let staked_obj = &staked_objects[0];
+    let staked_ref = (
+        ObjectID::from_str(staked_obj.object_id()).unwrap(),
+        staked_obj.version().into(),
+        staked_obj.digest().parse().unwrap(),
+    );
+    let gas_coins = get_all_coins(&mut client.clone(), sender).await.unwrap();
+    let gas_ref = get_object_ref(&mut client.clone(), gas_coins[0].id())
+        .await
+        .unwrap()
+        .as_object_ref();
+    let gas_price = client.get_reference_gas_price().await.unwrap();
+    let mut ptb = ProgrammableTransactionBuilder::new();
+    let sys = ptb.input(CallArg::SUI_SYSTEM_MUT).unwrap();
+    let staked_arg = ptb.obj(ObjectArg::ImmOrOwnedObject(staked_ref)).unwrap();
+    let fss_result = ptb.command(Command::move_call(
+        SUI_SYSTEM_PACKAGE_ID,
+        SUI_SYSTEM_MODULE_NAME.to_owned(),
+        Identifier::new("convert_to_fungible_staked_sui").unwrap(),
+        vec![],
+        vec![sys, staked_arg],
+    ));
+    let sender_arg = ptb.pure(sender).unwrap();
+    ptb.command(Command::TransferObjects(vec![fss_result], sender_arg));
+    let convert_tx = TransactionData::new_programmable(
+        sender,
+        vec![gas_ref],
+        ptb.finish(),
+        1_000_000_000,
+        gas_price,
+    );
+    let tx = to_sender_signed_transaction(convert_tx, keystore.export(&sender).unwrap());
+    execute_transaction(&mut client.clone(), &tx)
+        .await
+        .expect("convert StakedSui → FSS");
+
+    // Have the validator request its own removal (signed by validator key).
+    let validator_handle = test_cluster
+        .swarm
+        .validator_node_handles()
+        .into_iter()
+        .find(|h| h.with(|n| n.get_config().sui_address()) == validator)
+        .expect("validator node handle for active_validators[0]");
+    let validator_addr = validator_handle.with(|n| n.get_config().sui_address());
+    let validator_gas = test_cluster
+        .wallet
+        .get_one_gas_object_owned_by_address(validator_addr)
+        .await
+        .unwrap()
+        .unwrap();
+    let rgp = test_cluster.get_reference_gas_price().await;
+    let remove_tx = validator_handle.with(|n| {
+        TestTransactionBuilder::new(validator_addr, validator_gas, rgp)
+            .call_request_remove_validator()
+            .build_and_sign(n.get_config().account_key_pair.keypair())
+    });
+    test_cluster.execute_transaction(remove_tx).await;
+
+    // Trigger reconfiguration so the validator moves to inactive_validators.
+    // After this, `system_state.validators.active_validators` no longer
+    // contains it; only `inactive_validators[pool_id]` does.
+    test_cluster.trigger_reconfiguration().await;
+
+    let balance_before = get_sui_balance(&mut client, sender).await;
+
+    // AtLeast is the strictest mode — it forces the inactive path to fetch
+    // FSS data via dynamic-field walk, mirror the chain's payout formula
+    // (which itself reads exchange_rates[deactivation_epoch]), and bind the
+    // resulting transaction to the quote epoch. If any of those layers is
+    // wrong this fails before submission.
+    run_redeem_flow(
+        &mut client,
+        &rosetta_client,
+        keystore,
+        sender,
+        validator,
+        "AtLeast",
+        Some(500_000_000),
+    )
+    .await;
+
+    let balance_after = get_sui_balance(&mut client, sender).await;
+    let delta = balance_after as i128 - balance_before as i128;
+    assert!(
+        delta >= 500_000_000,
+        "AtLeast guarantee violated for inactive-pool redeem: \
+         got {delta} MIST, expected >= 500_000_000"
+    );
+}
+
 #[tokio::test]
 async fn test_redeem_multi_validator_isolation() {
     use futures::TryStreamExt;

--- a/crates/sui-rosetta/tests/end_to_end_tests.rs
+++ b/crates/sui-rosetta/tests/end_to_end_tests.rs
@@ -5288,8 +5288,14 @@ async fn test_e2e_parse_merge_redeem_single_fss_atleast() {
         "AtLeast",
     )
     .await;
-    // Partial mode — redeem_mode is None on parse output (AtLeast vs AtMost indistinguishable).
-    assert_merge_redeem_parse_ops(&ops, sender, 1, None);
+    // The PTB carries a balance::split + balance::join guard, so the parser
+    // can distinguish AtLeast from AtMost.
+    assert_merge_redeem_parse_ops(
+        &ops,
+        sender,
+        1,
+        Some(sui_rosetta::types::RedeemMode::AtLeast),
+    );
 }
 
 /// F=1, AtMost partial redeem.
@@ -5322,7 +5328,12 @@ async fn test_e2e_parse_merge_redeem_single_fss_atmost() {
         "AtMost",
     )
     .await;
-    assert_merge_redeem_parse_ops(&ops, sender, 1, None);
+    assert_merge_redeem_parse_ops(
+        &ops,
+        sender,
+        1,
+        Some(sui_rosetta::types::RedeemMode::AtMost),
+    );
 }
 
 /// F=3, All mode.
@@ -5381,7 +5392,12 @@ async fn test_e2e_parse_merge_redeem_three_fss_atleast() {
         "AtLeast",
     )
     .await;
-    assert_merge_redeem_parse_ops(&ops, sender, 3, None);
+    assert_merge_redeem_parse_ops(
+        &ops,
+        sender,
+        3,
+        Some(sui_rosetta::types::RedeemMode::AtLeast),
+    );
 }
 
 /// F=3, AtMost partial.
@@ -5414,7 +5430,12 @@ async fn test_e2e_parse_merge_redeem_three_fss_atmost() {
         "AtMost",
     )
     .await;
-    assert_merge_redeem_parse_ops(&ops, sender, 3, None);
+    assert_merge_redeem_parse_ops(
+        &ops,
+        sender,
+        3,
+        Some(sui_rosetta::types::RedeemMode::AtMost),
+    );
 }
 
 /// Multi-validator: FSS on both A and B; redeem only from A.
@@ -5625,7 +5646,7 @@ async fn test_e2e_block_merge_redeem_single_fss_atleast() {
         Some(500_000_000),
         "AtLeast",
         1,
-        None,
+        Some(sui_rosetta::types::RedeemMode::AtLeast),
     )
     .await;
 }
@@ -5659,7 +5680,7 @@ async fn test_e2e_block_merge_redeem_single_fss_atmost() {
         Some(500_000_000),
         "AtMost",
         1,
-        None,
+        Some(sui_rosetta::types::RedeemMode::AtMost),
     )
     .await;
 }
@@ -5727,7 +5748,7 @@ async fn test_e2e_block_merge_redeem_three_fss_atleast() {
         Some(500_000_000),
         "AtLeast",
         3,
-        None,
+        Some(sui_rosetta::types::RedeemMode::AtLeast),
     )
     .await;
 }
@@ -5761,7 +5782,7 @@ async fn test_e2e_block_merge_redeem_three_fss_atmost() {
         Some(500_000_000),
         "AtMost",
         3,
-        None,
+        Some(sui_rosetta::types::RedeemMode::AtMost),
     )
     .await;
 }
@@ -5876,9 +5897,9 @@ async fn test_e2e_merge_redeem_errors_atleast_exceeds_balance() {
     );
 }
 
-/// AtMost amount too small (rounds to zero pool tokens) → server should error.
+/// AtMost amount = 0 → rejected before binary search runs.
 #[tokio::test]
-async fn test_e2e_merge_redeem_errors_atmost_too_small() {
+async fn test_e2e_merge_redeem_errors_atmost_zero_amount() {
     let test_cluster = TestClusterBuilder::new().build().await;
     let sender = test_cluster.get_address_0();
     let keystore = &test_cluster.wallet.config.keystore;
@@ -5897,7 +5918,6 @@ async fn test_e2e_merge_redeem_errors_atmost_too_small() {
     )
     .await;
 
-    // Amount = 1 MIST; with the typical pool exchange rate this rounds to 0 pool tokens.
     let ops = serde_json::from_value(json!([{
         "operation_identifier": {"index": 0},
         "type": "MergeAndRedeemFungibleStakedSui",
@@ -5905,7 +5925,7 @@ async fn test_e2e_merge_redeem_errors_atmost_too_small() {
         "metadata": {
             "MergeAndRedeemFungibleStakedSui": {
                 "validator": validator.to_string(),
-                "amount": "1",
+                "amount": "0",
                 "redeem_mode": "AtMost",
             }
         }
@@ -5914,7 +5934,7 @@ async fn test_e2e_merge_redeem_errors_atmost_too_small() {
     let flow = rosetta_client.rosetta_flow(&ops, keystore, None).await;
     assert!(
         flow.metadata.as_ref().is_some_and(|r| r.is_err()),
-        "expected metadata error for AtMost too small, got: {:?}",
+        "expected metadata error for AtMost amount=0, got: {:?}",
         flow.metadata
     );
 }

--- a/crates/sui-rosetta/tests/end_to_end_tests.rs
+++ b/crates/sui-rosetta/tests/end_to_end_tests.rs
@@ -3862,24 +3862,61 @@ async fn test_redeem_fss_from_inactive_validator() {
     // (which itself reads exchange_rates[deactivation_epoch]), and bind the
     // resulting transaction to the quote epoch. If any of those layers is
     // wrong this fails before submission.
-    run_redeem_flow(
+    let min_sui = 500_000_000i128;
+    let response = run_redeem_flow(
         &mut client,
         &rosetta_client,
         keystore,
         sender,
         validator,
         "AtLeast",
-        Some(500_000_000),
+        Some(min_sui as u64),
     )
     .await;
 
+    // The chain's AtLeast guarantee is on the *gross* SUI delivered by
+    // `redeem_fungible_staked_sui`, not the net wallet delta — gas comes out
+    // of the same address and would push the net delta below `min_sui` even
+    // when the protocol behaved correctly. Reconstruct the gross amount as
+    // `(balance_after - balance_before) + (computation_cost + storage_cost - storage_rebate)`.
     let balance_after = get_sui_balance(&mut client, sender).await;
-    let delta = balance_after as i128 - balance_before as i128;
+    let net_delta = balance_after as i128 - balance_before as i128;
+    let gas_net_cost = transaction_net_gas_cost(
+        &mut client,
+        &response.transaction_identifier.hash.to_string(),
+    )
+    .await;
+    let gross_redeemed = net_delta + gas_net_cost;
     assert!(
-        delta >= 500_000_000,
+        gross_redeemed >= min_sui,
         "AtLeast guarantee violated for inactive-pool redeem: \
-         got {delta} MIST, expected >= 500_000_000"
+         gross_redeemed = {gross_redeemed} MIST (net_delta = {net_delta}, \
+         gas_net_cost = {gas_net_cost}), expected >= {min_sui}"
     );
+}
+
+/// Read `effects.gas_used` for a transaction and return the net gas cost
+/// (`computation_cost + storage_cost - storage_rebate`) as i128.
+///
+/// `i128` matters because storage_rebate can in principle exceed
+/// `computation_cost + storage_cost` (rare but allowed by the gas model);
+/// using u64 with saturating subtraction would silently round to zero.
+async fn transaction_net_gas_cost(client: &mut GrpcClient, tx_hash: &str) -> i128 {
+    let request = GetTransactionRequest::default()
+        .with_digest(tx_hash.to_string())
+        .with_read_mask(FieldMask::from_paths(["effects.gas_used"]));
+    let tx = client
+        .clone()
+        .ledger_client()
+        .get_transaction(request)
+        .await
+        .expect("get_transaction RPC")
+        .into_inner()
+        .transaction
+        .expect("transaction should be present in response");
+    let gas = tx.effects().gas_used();
+    gas.computation_cost_opt().unwrap_or(0) as i128 + gas.storage_cost_opt().unwrap_or(0) as i128
+        - gas.storage_rebate_opt().unwrap_or(0) as i128
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Fixes three correctness bugs in `MergeAndRedeemFungibleStakedSui` and adds support for redeeming FungibleStakedSui from inactive validator pools.

### Bugs fixed

1. **AtLeast under-delivery.** The off-chain quote used `tokens = ceil(min_sui * pool_token_balance / sui_balance)`, but the chain's actual payout floors principal and rewards independently in `calculate_fungible_staked_sui_withdraw_amount`. Realized SUI lagged the off-chain estimate by 1–2 MIST, so a user asking for AtLeast 4 SUI received 3,999,999,999 MIST in production.

2. **Cross-epoch quote reuse.** Rate was read in epoch N but the resulting transaction could execute in epoch N+1 against a different exchange rate, breaking AtMost cap guarantees and making AtLeast quotes wildly wrong.

3. **Inactive validator pools rejected.** The chain's `validator_set::redeem_fungible_staked_sui` (`validator_set.move:346-364`) routes through `staking_pool_mappings` first, then falls back to `inactive_validators[pool_id]` — both are reachable from the public entry point. The previous Rosetta code only queried active validators, so chain-legal redemptions from deactivated pools were rejected with "validator not found".

## Approach

### Mode-aware redeem plan
A `RedeemPlan` enum (`All` / `AtLeast { token_amount: Option<u64>, min_sui }` / `AtMost { token_amount: Option<u64>, max_sui }`) is computed at `/construction/metadata` time and threaded through `ConstructionMetadata` so `/construction/payloads` rebuilds the same PTB shape that simulation used. `token_amount = None` means "redeem the merged FSS in full without splitting" — used when the binary search picked exactly the total token count, since splitting in that case is legal but leaves a zero-value FSS object as wallet dust.

### AtLeast: pure-Rust mirror + on-chain guard
- **Off-chain selection:** `mirror_redeem_actual` is a Rust port of `staking_pool::calculate_fungible_staked_sui_withdraw_amount`. `binary_search_at_least` finds the minimum token count whose actual (split-floored) payout is `>= min_sui`. `FungibleStakedSuiData` (principal, total_supply) is fetched from the pool's `extra_fields` bag.
- **Chain guard:** the PTB inserts `balance::split(min_sui)` + `balance::join` after `redeem_fungible_staked_sui`. If actual delivery falls below `min_sui` at execution time (e.g., other users redeemed between simulate and execute), the chain aborts cleanly instead of silently shorting the user. The join restores the balance for `coin::from_balance` to consume in full.

### AtMost: invariant-based selection
`binary_search_at_most` picks the largest token count whose chain-side `expected = floor(token * rate_sui / rate_token)` stays at or below `max_sui`. The on-chain invariant `actual ≤ expected` (`staking_pool.move:264-268`) keeps the cap safe without a runtime guard.

### Inactive validator support
FSS-first pool resolution: enumerate the sender's FSS, group by `pool_id`, try the active fast path, then fall back to walking `inactive_validators[pool_id] → Field<ID, ValidatorWrapper> → Versioned → Field<u64, ValidatorV1>` to find a matching validator. The inactive rate quote mirrors `staking_pool::pool_token_exchange_rate_at_epoch` walk-back via direct `derive_dynamic_field_id(exchange_rates_table_id, &TypeTag::U64, bcs(epoch))` reads — using live `pool.sui_balance / pool_token_balance` would diverge from the chain because regular StakedSui withdraws on inactive pools immediately mutate those live fields (`staking_pool.move:187-188`).

### Atomic snapshot, epoch binding
`get_validator_set_snapshot` returns `(active_rates, epoch, inactive_validators_table_id)` from a single `GetEpochRequest::latest()`. All rate reads, the inactive-table lookup, and `bind_epoch` come from the same atomic snapshot. Amount-sensitive plans bind the resulting transaction to that epoch:
- Coin gas: `TransactionExpiration::Epoch(N)`.
- Address-balance gas: `ValidDuring{N, N}` (replay-protected, no execution in N+1).
- `metadata.epoch` reuses `bind_epoch` when set so the two can never disagree.

### Mirror math overflow
`mul_div_u64` returns `Err` on u64 overflow to match Move's `mul_div!` abort, replacing silent `as u64` truncation. Practically unreachable at typical pool sizes but matches chain semantics exactly.

### Read parser (`/construction/parse`, `/block/transaction`)
Recognized PTB shapes:
- `All` → `redeem_mode = Some(All)`, no `amount`.
- AtLeast (split + balance::split + balance::join) → `redeem_mode = Some(AtLeast)`, `amount = min_sui` decoded from the `balance::split` Pure input.
- Full-redeem AtLeast (no split + balance::split + balance::join) → same as above.
- Split-without-guard → `redeem_mode = None` (unknown partial mode); `max_sui` isn't encoded in PTB bytes so a typed `AtMost` parse-output would be inconsistent with the write side.

The parser also enforces dataflow linkage: `balance::split`, `balance::join`, `coin::from_balance`, and the final `TransferObjects` must all consume the actual redeem result (or the previous step's result), not an unrelated `Balance<SUI>` or `Coin<SUI>`. `is_result_of` rejects `NestedResult` masquerading as `Result` (both proto-encode as `ArgumentKind::Result`; only the `subresult` field distinguishes).

## Behavior changes

- **Cross-epoch sign/submit fails for amount-sensitive plans.** AtLeast/AtMost now bind to the quote epoch via `TransactionExpiration`. Clients must not cache unsigned bytes across epoch boundaries; if a stale quote is signed across an epoch transition, validators reject the transaction.
- **`metadata.redeem_plan` is required at signing.** Pre-deployment metadata responses (no `redeem_plan`) cannot be consumed by the new payload constructor — the call returns a clear "redeem_plan required" error and the client must re-fetch metadata. The legacy `redeem_token_amount` field is preserved in metadata responses for forward-compat (new server → old client) but is no longer read by new code. **This is a transient rollout-window error, not a fatal user error.**
- **Parser of partial-mode PTBs without the AtLeast guard now emits `redeem_mode = None`** (previously could classify as `Some(AtMost)`, which was inconsistent with the write side).

### Multi-instance Rosetta deployments

In rolling deployments where some Rosetta server instances run the old binary and some run the new, requests routed to old-binary instances continue to build PTBs without the `balance::split` guard for AtLeast and without epoch binding for AtLeast/AtMost. Those requests remain exposed to the original under-delivery and cross-epoch bugs until all instances are upgraded. Single-instance deployments don't have this exposure.

## Test plan

- [x] `cargo check -p sui-rosetta`
- [x] `cargo xclippy` (clean)
- [x] `cargo fmt --all -- --check` (clean)
- [x] `cargo nextest run -p sui-rosetta` — **221 tests pass** (98 unit + 123 e2e)
- [x] Workspace `cargo check` passes

### Unit test coverage
- Mirror math: `expected_sui_amount`, `mirror_redeem_actual`, checked `mul_div_u64` overflow, split-floor underrun regression
- Binary search: `binary_search_at_least`, `binary_search_at_most`, edge cases (single token, supply=0, cap at boundary)
- Plan construction: full-redeem `None` token_amount, partial split, AtLeast missing FSS data, zero amount
- PTB shapes: All / AtLeast (partial + full) / AtMost (partial + full), guard insertion, epoch binding
- Parser: shape recognition, AtLeast `min_sui` recovery, dataflow linkage (4 fall-through tests for malformed AtLeast guard wiring), NestedResult rejection, TransferObjects target check
- Walk-back: 6 tests covering preactive, inactive clamp, deactivation > current, single-epoch pool

### E2E test coverage
- AtLeast / AtMost / All against active validators (single + multi-FSS, multi-validator isolation)
- `/construction/parse` round-trip for all modes
- `/block/transaction` parsed output
- **Inactive validator FSS redeem**: 6-validator cluster, stake → activate → convert to FSS → validator self-removes via `request_remove_validator` → reconfigure → AtLeast redeem. Asserts gross redeemed (`net_delta + gas_net_cost`) `>= min_sui` to test the chain's gross-SUI guarantee. Verifies the inactive walk + exchange-rate walk-back end-to-end.

## Verification trail

Cross-checked against actual Move source on the local upstream/main checkout:
- Inactive routing — `validator_set.move:346-364`
- Inactive pool live-field mutation via StakedSui withdraw — `staking_pool.move:187-188`
- Exchange-rate walk-back — `staking_pool.move:587-608`
- `FungibleStakedSuiData` field order — `staking_pool.move:98-104`
- Payout split-floor gap bound ≤ 2 MIST — `staking_pool.move:231-271`
- `is_replay_protected` accepts one-epoch range — `transaction.rs:2354-2360`
- `mul_div!` abort-on-overflow — `staking_pool.move:670-671`
- `Argument::Result` / `NestedResult` proto encoding — `sui-types/src/rpc_proto_conversions.rs:2811-2826`

🤖 Generated with [Claude Code](https://claude.com/claude-code)