### PR TITLE
sui-protocol-config: bypass overrides in snapshot tests to prevent pollution

### DIFF
--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -5555,10 +5555,11 @@ mod test {
             };
             for i in MIN_PROTOCOL_VERSION..=MAX_PROTOCOL_VERSION {
                 let cur = ProtocolVersion::new(i);
-                assert_yaml_snapshot!(
-                    format!("{}version_{}", chain_str, cur.as_u64()),
-                    ProtocolConfig::get_for_version(cur, *chain_id)
-                );
+                // Bypass `get_for_version` so a concurrent test that installs a
+                // `CONFIG_OVERRIDE` cannot mutate the snapshotted config.
+                let mut cfg = ProtocolConfig::get_for_version_impl(cur, *chain_id);
+                cfg.version = cur;
+                assert_yaml_snapshot!(format!("{}version_{}", chain_str, cur.as_u64()), cfg);
             }
         }
     }


### PR DESCRIPTION
## Summary

`CONFIG_OVERRIDE` is a process-global `Mutex<Option<...>>` (lib.rs:5389). `test_get_for_version_if_supported_applies_test_overrides` installs an override via `enable_coin_reservation_for_testing`, which flips `enable_coin_reservation_obj_refs`, `convert_withdrawal_compatibility_ptb_arguments`, and bumps `execution_version` to 4. `snapshot_tests` runs concurrently in the same test binary and calls `get_for_version`, which always applies whatever sits in the override slot. When the two tests overlap, every snapshot computed during the override's lifetime is silently corrupted, and an unlucky `cargo insta accept` would persist that corruption to disk.

Reproduced locally by removing the fix and adding a 2s sleep inside the override test: `INSTA_UPDATE=always cargo test -p sui-protocol-config --lib test::` rewrote 136 snapshot files with the override's flags applied, including `Mainnet_version_1.snap`:

```diff
 version: 1
-feature_flags: {}
+feature_flags:
+  enable_coin_reservation_obj_refs: true
+  convert_withdrawal_compatibility_ptb_arguments: true
 max_tx_size_bytes: 131072
 ...
-
+execution_version: 4
```

The fix has `snapshot_tests` call `ProtocolConfig::get_for_version_impl` directly instead of `get_for_version`, bypassing the override hook entirely. The override mechanism is still tested by `test_get_for_version_if_supported_applies_test_overrides`. No new dependencies, no test serialization, no shared state.

## Test plan

- [x] `cargo nextest run -p sui-protocol-config` passes
- [x] `cargo xclippy` clean
- [x] After the fix, `INSTA_UPDATE=always` stress runs produce zero snapshot diffs