### PR TITLE
Fix SuiErrorKind wire compat by moving new variant to end

### DIFF
--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -430,11 +430,6 @@ pub enum SuiErrorKind {
     TooManyTransactionsPendingConsensus,
 
     #[error(
-        "Transaction was outbid by higher-gas-price transactions in the admission queue (current minimum gas price required: {min_gas_price})"
-    )]
-    TransactionRejectedDueToOutbiddingDuringCongestion { min_gas_price: u64 },
-
-    #[error(
         "Input {object_id} already has {queue_len} transactions pending, above threshold of {threshold}"
     )]
     TooManyTransactionsPendingOnObject {
@@ -820,6 +815,11 @@ pub enum SuiErrorKind {
         claimed_object_id: ObjectID,
         found_object_ref: ObjectRef,
     },
+
+    #[error(
+        "Transaction was outbid by higher-gas-price transactions in the admission queue (current minimum gas price required: {min_gas_price})"
+    )]
+    TransactionRejectedDueToOutbiddingDuringCongestion { min_gas_price: u64 },
 }
 
 #[repr(u64)]


### PR DESCRIPTION
## Summary

PR #26114 added the `TransactionRejectedDueToOutbiddingDuringCongestion` variant in the middle of the `SuiErrorKind` enum, which shifted the BCS discriminants of every variant after `TooManyTransactionsPendingConsensus` and broke wire compatibility with nodes running prior versions.

This forward fix moves the new variant to the end of the enum, restoring the original discriminants for all pre-existing variants while preserving the new error.

## Test plan

- [x] `cargo check -p sui-types`
- [x] `SUI_SKIP_SIMTESTS=1 cargo nextest run -p sui-types` (319 passed)
- [x] `cargo xclippy -D warnings` in `crates/sui-types`
- [x] Verified the variant list is identical to the pre-#26114 state, with the new variant appended.