### PR TITLE
[graphql-stream] Add Address.asTransactionObject [12/n]

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/packages/event/emit_test_event/sources/emit_test_event.move
+++ b/crates/sui-indexer-alt-e2e-tests/packages/event/emit_test_event/sources/emit_test_event.move
@@ -3,10 +3,17 @@
 
 module emit_test_event::emit_test_event;
 
+use sui::clock::Clock;
 use sui::event;
 
 public struct TestEvent has copy, drop {
 	value: u64,
+}
+
+/// Event that carries an address payload. Used by `asTransactionObject` tests so they can
+/// extract the address out of the event and resolve it via the parent transaction.
+public struct TestAddressEvent has copy, drop {
+	address_event_id: address,
 }
 
 public struct TestObject has key, store {
@@ -32,4 +39,31 @@ public fun emit_and_create(value: u64, ctx: &mut TxContext): TestObject {
 		id: object::new(ctx),
 		value,
 	}
+}
+
+/// Create a `TestObject` without emitting an event. Used as setup for tests that need a
+/// pre-existing object to mutate later.
+public fun create_object(value: u64, ctx: &mut TxContext): TestObject {
+	TestObject {
+		id: object::new(ctx),
+		value,
+	}
+}
+
+/// Mutate an existing `TestObject` and emit a `TestAddressEvent` whose `address_event_id`
+/// is the mutated object's address. Lets `asTransactionObject` tests show both the
+/// `inputState` (pre-mutation) and `outputState` (post-mutation).
+public fun mutate_and_emit(obj: &mut TestObject, new_value: u64) {
+	obj.value = new_value;
+	event::emit(TestAddressEvent {
+		address_event_id: object::id(obj).to_address(),
+	});
+}
+
+/// Emit a `TestAddressEvent` whose `address_event_id` is the (read-only) clock's address.
+/// Used by `asTransactionObject` tests for the `ConsensusObjectRead` variant.
+public fun emit_with_clock(clock: &Clock) {
+	event::emit(TestAddressEvent {
+		address_event_id: object::id(clock).to_address(),
+	});
 }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/addressable/as_transaction_object.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/addressable/as_transaction_object.move
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//# init --protocol-version 108 --accounts A --simulator
+//# init --protocol-version 108 --accounts A --simulator --addresses P=0x0
 
 //# programmable --sender A --inputs 1000 @A
 //> 0: SplitCoins(Gas, [Input(0)]);
@@ -35,6 +35,100 @@
   ) {
     asTransactionObject(transactionDigest: "@{digest_1}") {
       __typename
+    }
+  }
+}
+
+//# publish
+module P::M {
+    use sui::event;
+
+    public struct TestAddressEvent has copy, drop {
+        address_event_id: address,
+    }
+
+    public struct TestObject has key, store {
+        id: UID,
+        value: u64,
+    }
+
+    public fun create_object(value: u64, ctx: &mut TxContext): TestObject {
+        TestObject { id: object::new(ctx), value }
+    }
+
+    public fun mutate_and_emit(obj: &mut TestObject, new_value: u64) {
+        obj.value = new_value;
+        event::emit(TestAddressEvent {
+            address_event_id: object::id(obj).to_address(),
+        });
+    }
+}
+
+//# create-checkpoint
+
+//# programmable --sender A --inputs 7u64 @A
+//> 0: P::M::create_object(Input(0));
+//> 1: TransferObjects([Result(0)], Input(1));
+
+//# create-checkpoint
+
+//# programmable --sender A --inputs object(6,0) 99u64
+//> 0: P::M::mutate_and_emit(Input(0), Input(1));
+
+//# create-checkpoint
+
+//# run-graphql
+{
+  # `asTransactionObject` is called without a `transactionDigest`. Resolution defaults to
+  # the parent event's transaction because `EffectsContents::events` anchors each yielded
+  # `Event`'s scope to the parent transaction (with hydrated contents), and the resolver
+  # short-circuits the fetch via `Scope::active_transaction_contents_for`.
+  transactionEffects(digest: "@{digest_8}") {
+    events {
+      nodes {
+        contents {
+          extract(path: "address_event_id") {
+            asAddress {
+              asTransactionObject {
+                __typename
+                ... on ObjectChange {
+                  inputState { asMoveObject { contents { json } } }
+                  outputState { asMoveObject { contents { json } } }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+{
+  # Same implicit case as above, but entering via `transaction(...).effects` instead of
+  # `transactionEffects(...)`. `From<Transaction> for TransactionEffects` propagates the
+  # hydrated contents into the scope, and `EffectsContents::events` anchors them on each
+  # `Event` so descendants resolve against the parent transaction.
+  transaction(digest: "@{digest_8}") {
+    effects {
+      events {
+        nodes {
+          contents {
+            extract(path: "address_event_id") {
+              asAddress {
+                asTransactionObject {
+                  __typename
+                  ... on ObjectChange {
+                    inputState { asMoveObject { contents { json } } }
+                    outputState { asMoveObject { contents { json } } }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/addressable/as_transaction_object.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/addressable/as_transaction_object.move
@@ -1,0 +1,40 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 108 --accounts A --simulator
+
+//# programmable --sender A --inputs 1000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+
+//# create-checkpoint
+
+//# run-graphql
+{
+  # Address present in the tx as a newly created object → ObjectChange variant.
+  changed: address(address: "@{obj_1_0}") {
+    asTransactionObject(transactionDigest: "@{digest_1}") {
+      __typename
+      ... on ObjectChange {
+        idCreated
+        outputState { address }
+      }
+    }
+  }
+
+  # No `transactionDigest` argument outside subscription scope → null.
+  noArg: address(address: "@{obj_1_0}") {
+    asTransactionObject {
+      __typename
+    }
+  }
+
+  # Address not referenced by the tx → null.
+  notReferenced: address(
+    address: "0x000000000000000000000000000000000000000000000000000000000000dead"
+  ) {
+    asTransactionObject(transactionDigest: "@{digest_1}") {
+      __typename
+    }
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/addressable/as_transaction_object.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/addressable/as_transaction_object.snap
@@ -1,0 +1,41 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 4 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-8:
+//# programmable --sender A --inputs 1000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+created: object(1,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, line 10:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 3, lines 12-40:
+//# run-graphql
+Response: {
+  "data": {
+    "changed": {
+      "asTransactionObject": {
+        "__typename": "ObjectChange",
+        "idCreated": true,
+        "outputState": {
+          "address": "0xb97536b48e93de1f9c1d06619490683304fdf3423dadd0e409bd99d116a1c80c"
+        }
+      }
+    },
+    "noArg": {
+      "asTransactionObject": null
+    },
+    "notReferenced": {
+      "asTransactionObject": null
+    }
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/addressable/as_transaction_object.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/addressable/as_transaction_object.snap
@@ -1,7 +1,7 @@
 ---
 source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
 ---
-processed 4 tasks
+processed 12 tasks
 
 init:
 A: object(0,0)
@@ -36,6 +36,129 @@ Response: {
     },
     "notReferenced": {
       "asTransactionObject": null
+    }
+  }
+}
+
+task 4, lines 42-65:
+//# publish
+created: object(4,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 6680400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 5, line 67:
+//# create-checkpoint
+Checkpoint created: 2
+
+task 6, lines 69-71:
+//# programmable --sender A --inputs 7u64 @A
+//> 0: P::M::create_object(Input(0));
+//> 1: TransferObjects([Result(0)], Input(1));
+created: object(6,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2325600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 7, line 73:
+//# create-checkpoint
+Checkpoint created: 3
+
+task 8, lines 75-76:
+//# programmable --sender A --inputs object(6,0) 99u64
+//> 0: P::M::mutate_and_emit(Input(0), Input(1));
+events: Event { package_id: P, transaction_module: Identifier("M"), sender: A, type_: StructTag { address: P, module: Identifier("M"), name: Identifier("TestAddressEvent"), type_params: [] }, contents: [62, 219, 117, 132, 227, 135, 32, 1, 102, 151, 41, 1, 101, 98, 132, 247, 88, 218, 211, 19, 164, 9, 23, 115, 161, 29, 20, 131, 114, 1, 203, 163] }
+mutated: object(0,0), object(6,0)
+gas summary: computation_cost: 1000000, storage_cost: 2325600,  storage_rebate: 2302344, non_refundable_storage_fee: 23256
+
+task 9, line 78:
+//# create-checkpoint
+Checkpoint created: 4
+
+task 10, lines 80-105:
+//# run-graphql
+Response: {
+  "data": {
+    "transactionEffects": {
+      "events": {
+        "nodes": [
+          {
+            "contents": {
+              "extract": {
+                "asAddress": {
+                  "asTransactionObject": {
+                    "__typename": "ObjectChange",
+                    "inputState": {
+                      "asMoveObject": {
+                        "contents": {
+                          "json": {
+                            "id": "0x3edb7584e387200166972901656284f758dad313a4091773a11d14837201cba3",
+                            "value": "7"
+                          }
+                        }
+                      }
+                    },
+                    "outputState": {
+                      "asMoveObject": {
+                        "contents": {
+                          "json": {
+                            "id": "0x3edb7584e387200166972901656284f758dad313a4091773a11d14837201cba3",
+                            "value": "99"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 11, lines 107-134:
+//# run-graphql
+Response: {
+  "data": {
+    "transaction": {
+      "effects": {
+        "events": {
+          "nodes": [
+            {
+              "contents": {
+                "extract": {
+                  "asAddress": {
+                    "asTransactionObject": {
+                      "__typename": "ObjectChange",
+                      "inputState": {
+                        "asMoveObject": {
+                          "contents": {
+                            "json": {
+                              "id": "0x3edb7584e387200166972901656284f758dad313a4091773a11d14837201cba3",
+                              "value": "7"
+                            }
+                          }
+                        }
+                      },
+                      "outputState": {
+                        "asMoveObject": {
+                          "contents": {
+                            "json": {
+                              "id": "0x3edb7584e387200166972901656284f758dad313a4091773a11d14837201cba3",
+                              "value": "99"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
     }
   }
 }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/event_subscription.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/event_subscription.rs
@@ -115,6 +115,103 @@ async fn test_event_subscription_transaction_fields() {
     });
 }
 
+/// Verifies the `Address.asTransactionObject` resolver in streaming mode for the
+/// `ObjectChange` variant.
+#[tokio::test]
+async fn test_event_subscription_as_transaction_object_change() {
+    let mut cluster = SubscriptionTestCluster::new().await;
+    let package_id = emit_event_harness::publish(&mut cluster.validator).await;
+
+    // Pre-create the object in a separate tx, before subscribing, so the subscription
+    // only sees the mutation tx's event.
+    let (_, object_ref) =
+        emit_event_harness::create_object(&mut cluster.validator, package_id, /* value = */ 7)
+            .await;
+
+    let mut stream = cluster
+        .subscribe_with_variables(
+            r#"subscription($pkg: SuiAddress!) {
+                events(filter: { type: $pkg }) {
+                    contents {
+                        extract(path: "address_event_id") {
+                            asAddress {
+                                asTransactionObject {
+                                    __typename
+                                    ... on ObjectChange {
+                                        inputState {
+                                            asMoveObject { contents { json } }
+                                        }
+                                        outputState {
+                                            asMoveObject { contents { json } }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }"#,
+            Some(json!({ "pkg": package_id.to_string() })),
+        )
+        .await;
+
+    let _digest = emit_event_harness::mutate_and_emit(
+        &mut cluster.validator,
+        package_id,
+        object_ref,
+        /* new_value = */ 99,
+    )
+    .await;
+    let item = stream.next().await.expect("Stream ended");
+
+    graphql_redactions().bind(|| {
+        insta::assert_json_snapshot!("event_subscription_as_transaction_object_change", item);
+    });
+}
+
+/// Verifies the `Address.asTransactionObject` resolver in streaming mode for the
+/// `ConsensusObjectRead` variant. The test tx takes the (read-only) shared clock as a
+/// consensus input and emits a `TestAddressEvent` whose payload is the clock's address.
+#[tokio::test]
+async fn test_event_subscription_as_transaction_object_consensus_read() {
+    let mut cluster = SubscriptionTestCluster::new().await;
+    let package_id = emit_event_harness::publish(&mut cluster.validator).await;
+
+    let mut stream = cluster
+        .subscribe_with_variables(
+            r#"subscription($pkg: SuiAddress!) {
+                events(filter: { type: $pkg }) {
+                    contents {
+                        extract(path: "address_event_id") {
+                            asAddress {
+                                asTransactionObject {
+                                    __typename
+                                    ... on ConsensusObjectRead {
+                                        object {
+                                            asMoveObject { contents { type { repr } } }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }"#,
+            Some(json!({ "pkg": package_id.to_string() })),
+        )
+        .await;
+
+    let _digest = emit_event_harness::emit_with_clock(&mut cluster.validator, package_id).await;
+    let item = stream.next().await.expect("Stream ended");
+
+    graphql_redactions().bind(|| {
+        insta::assert_json_snapshot!(
+            "event_subscription_as_transaction_object_consensus_read",
+            item
+        );
+    });
+}
+
 /// Verifies that `event.transaction.effects.objectChanges` resolves with non-empty
 /// object data in streaming mode. Exercises `EffectsContents::fetch`'s streaming fast
 /// path plus the per-tx execution-objects anchor that `Scope::with_tx_sequence_number_viewed_at`

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/snapshots/graphql_subscription__event_subscription__event_subscription_as_transaction_object_change.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/snapshots/graphql_subscription__event_subscription__event_subscription_as_transaction_object_change.snap
@@ -1,0 +1,39 @@
+---
+source: crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/event_subscription.rs
+expression: item
+---
+{
+  "data": {
+    "events": {
+      "contents": {
+        "extract": {
+          "asAddress": {
+            "asTransactionObject": {
+              "__typename": "ObjectChange",
+              "inputState": {
+                "asMoveObject": {
+                  "contents": {
+                    "json": {
+                      "id": "[json_id]",
+                      "value": "7"
+                    }
+                  }
+                }
+              },
+              "outputState": {
+                "asMoveObject": {
+                  "contents": {
+                    "json": {
+                      "id": "[json_id]",
+                      "value": "99"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/snapshots/graphql_subscription__event_subscription__event_subscription_as_transaction_object_consensus_read.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/snapshots/graphql_subscription__event_subscription__event_subscription_as_transaction_object_consensus_read.snap
@@ -1,0 +1,28 @@
+---
+source: crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/event_subscription.rs
+expression: item
+---
+{
+  "data": {
+    "events": {
+      "contents": {
+        "extract": {
+          "asAddress": {
+            "asTransactionObject": {
+              "__typename": "ConsensusObjectRead",
+              "object": {
+                "asMoveObject": {
+                  "contents": {
+                    "type": {
+                      "repr": "[pkg]::clock::Clock"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/testing/emit_event_harness.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/testing/emit_event_harness.rs
@@ -8,8 +8,14 @@ use std::path::PathBuf;
 use move_core_types::ident_str;
 use sui_indexer_alt_e2e_tests::move_helpers::execute_ptb;
 use sui_indexer_alt_e2e_tests::move_helpers::publish_package;
+use sui_types::SUI_CLOCK_OBJECT_ID;
+use sui_types::SUI_CLOCK_OBJECT_SHARED_VERSION;
 use sui_types::base_types::ObjectID;
+use sui_types::base_types::ObjectRef;
+use sui_types::effects::TransactionEffectsAPI;
 use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
+use sui_types::transaction::ObjectArg;
+use sui_types::transaction::SharedObjectMutability;
 
 pub async fn publish(cluster: &mut test_cluster::TestCluster) -> ObjectID {
     let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
@@ -82,5 +88,81 @@ pub async fn emit_and_create(
         vec![value_arg],
     );
     ptb.transfer_arg(sender, test_object);
+    execute_ptb(cluster, ptb).await.0
+}
+
+/// Create a `TestObject` (no event emitted), transferred to the sender. Returns the
+/// transaction digest and the new object's ref so a subsequent `mutate_and_emit` call
+/// can reference it.
+pub async fn create_object(
+    cluster: &mut test_cluster::TestCluster,
+    package_id: ObjectID,
+    value: u64,
+) -> (String, ObjectRef) {
+    let sender = cluster.wallet.active_address().unwrap();
+    let mut ptb = ProgrammableTransactionBuilder::new();
+    let value_arg = ptb.pure(value).unwrap();
+    let test_object = ptb.programmable_move_call(
+        package_id,
+        ident_str!("emit_test_event").to_owned(),
+        ident_str!("create_object").to_owned(),
+        vec![],
+        vec![value_arg],
+    );
+    ptb.transfer_arg(sender, test_object);
+    let (digest, effects) = execute_ptb(cluster, ptb).await;
+    let created = effects
+        .created()
+        .into_iter()
+        .find(|(_, owner)| owner.get_address_owner_address().is_ok())
+        .expect("Should have created an owned object")
+        .0;
+    (digest, created)
+}
+
+/// Mutate an existing `TestObject` and emit a `TestAddressEvent` carrying its address.
+/// Pairs with `create_object` for tests that want to observe the object's
+/// `inputState`/`outputState` transition through `asTransactionObject`.
+pub async fn mutate_and_emit(
+    cluster: &mut test_cluster::TestCluster,
+    package_id: ObjectID,
+    object_ref: ObjectRef,
+    new_value: u64,
+) -> String {
+    let mut ptb = ProgrammableTransactionBuilder::new();
+    let object_arg = ptb.obj(ObjectArg::ImmOrOwnedObject(object_ref)).unwrap();
+    let value_arg = ptb.pure(new_value).unwrap();
+    ptb.programmable_move_call(
+        package_id,
+        ident_str!("emit_test_event").to_owned(),
+        ident_str!("mutate_and_emit").to_owned(),
+        vec![],
+        vec![object_arg, value_arg],
+    );
+    execute_ptb(cluster, ptb).await.0
+}
+
+/// Emit a `TestAddressEvent` whose payload address points at the (read-only) shared clock
+/// object (`0x6`). Used by `asTransactionObject` tests for the `ConsensusObjectRead`
+/// variant: the clock is referenced as a read-only consensus input, not a change.
+pub async fn emit_with_clock(
+    cluster: &mut test_cluster::TestCluster,
+    package_id: ObjectID,
+) -> String {
+    let mut ptb = ProgrammableTransactionBuilder::new();
+    let clock_arg = ptb
+        .obj(ObjectArg::SharedObject {
+            id: SUI_CLOCK_OBJECT_ID,
+            initial_shared_version: SUI_CLOCK_OBJECT_SHARED_VERSION,
+            mutability: SharedObjectMutability::Immutable,
+        })
+        .unwrap();
+    ptb.programmable_move_call(
+        package_id,
+        ident_str!("emit_test_event").to_owned(),
+        ident_str!("emit_with_clock").to_owned(),
+        vec![],
+        vec![clock_arg],
+    );
     execute_ptb(cluster, ptb).await.0
 }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/testing/harness.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_subscription/testing/harness.rs
@@ -383,6 +383,7 @@ pub fn graphql_redactions() -> insta::Settings {
     settings.add_redaction(".**.networkTotalTransactions", "[networkTotalTransactions]");
     settings.add_redaction(".**.cursor", "[cursor]");
     settings.add_redaction(".**.signature", "[signature]");
+    settings.add_redaction(".**.json.id", "[json_id]");
     settings.add_dynamic_redaction(".**.repr", |value, _path| {
         let s = value.as_str().unwrap();
         if let Some(idx) = s.find("::") {

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -86,7 +86,7 @@ type Address implements Node & IAddressable {
 	"""
 	How this address (interpreted as an object ID) was referenced by a specific transaction.
 	
-	Returns `null` if the address was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
+	Returns `null` if the object was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
 	
 	In an `events` subscription, the `transactionDigest` argument may be omitted; the field then resolves against the transaction that emitted the parent event.
 	
@@ -4343,8 +4343,7 @@ enum TransactionKindInput {
 }
 
 """
-An object as it appears in a specific transaction. The variant discriminates whether the
-object was changed by the transaction or read as an unchanged consensus (shared) input.
+An object as it appears in a specific transaction. The variant discriminates whether the object was changed by the transaction or read as an unchanged consensus (shared) input.
 """
 union TransactionObject = ObjectChange | ConsensusObjectRead
 

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -85,16 +85,14 @@ type Address implements Node & IAddressable {
 	asObject: Object
 	"""
 	How this address (interpreted as an object ID) was referenced by a specific transaction.
-	Returns `null` if the address was not referenced, or was present only as a non-object
-	marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
 	
-	In an `events` subscription, the `transactionDigest` argument may be omitted; the field
-	then resolves against the transaction that emitted the parent event.
+	Returns `null` if the address was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
 	
-	Passing an explicit `transactionDigest` other than the parent event's transaction in subscription
-	context is not supported; for arbitrary transaction lookups, use the indexed Query API.
+	In an `events` subscription, the `transactionDigest` argument may be omitted; the field then resolves against the transaction that emitted the parent event.
+	
+	Passing an explicit `transactionDigest` other than the parent event's transaction in subscription context is not supported; for arbitrary transaction lookups, use the indexed Query API.
 	"""
-	asTransactionObject(transactionDigest: String): TransactionObjectRef
+	asTransactionObject(transactionDigest: String): TransactionObject
 	"""
 	Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
 	
@@ -4345,11 +4343,10 @@ enum TransactionKindInput {
 }
 
 """
-Reference to an object as it appears in a specific transaction. The variant discriminates
-whether the object was changed by the transaction or read as an unchanged consensus
-(shared) input.
+An object as it appears in a specific transaction. The variant discriminates whether the
+object was changed by the transaction or read as an unchanged consensus (shared) input.
 """
-union TransactionObjectRef = ObjectChange | ConsensusObjectRead
+union TransactionObject = ObjectChange | ConsensusObjectRead
 
 """
 Transfers `inputs` to `address`. All inputs must have the `store` ability (allows public transfer) and must not be previously immutable or shared.

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -84,6 +84,18 @@ type Address implements Node & IAddressable {
 	"""
 	asObject: Object
 	"""
+	How this address (interpreted as an object ID) was referenced by a specific transaction.
+	Returns `null` if the address was not referenced, or was present only as a non-object
+	marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
+	
+	In an `events` subscription, the `transactionDigest` argument may be omitted; the field
+	then resolves against the transaction that emitted the parent event.
+	
+	Passing an explicit `transactionDigest` other than the parent event's transaction in subscription
+	context is not supported; for arbitrary transaction lookups, use the indexed Query API.
+	"""
+	asTransactionObject(transactionDigest: String): TransactionObjectRef
+	"""
 	Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
 	
 	Returns `None` when no checkpoint is set in scope (e.g. execution scope).
@@ -4331,6 +4343,13 @@ enum TransactionKindInput {
 	"""
 	PROGRAMMABLE_TX
 }
+
+"""
+Reference to an object as it appears in a specific transaction. The variant discriminates
+whether the object was changed by the transaction or read as an unchanged consensus
+(shared) input.
+"""
+union TransactionObjectRef = ObjectChange | ConsensusObjectRead
 
 """
 Transfers `inputs` to `address`. All inputs must have the `store` ability (allows public transfer) and must not be previously immutable or shared.

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -88,9 +88,9 @@ type Address implements Node & IAddressable {
 	
 	Returns `null` if the object was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
 	
-	In an `events` subscription, the `transactionDigest` argument may be omitted; the field then resolves against the transaction that emitted the parent event.
+	The `transactionDigest` argument may be omitted when the query is scoped under a transaction context (e.g. a parent `Transaction`, `TransactionEffects`, or `Event`); the field then resolves against the in-scope transaction.
 	
-	Passing an explicit `transactionDigest` other than the parent event's transaction in subscription context is not supported; for arbitrary transaction lookups, use the indexed Query API.
+	Passing an explicit `transactionDigest` other than the in-scope transaction in subscription context is not supported; for arbitrary transaction lookups, use the indexed Query API.
 	"""
 	asTransactionObject(transactionDigest: String): TransactionObject
 	"""

--- a/crates/sui-indexer-alt-graphql/src/api/subscription.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/subscription.rs
@@ -11,7 +11,6 @@ use crate::api::types::checkpoint::Checkpoint;
 use crate::api::types::event::Event;
 use crate::api::types::event::filter::EventFilter;
 use crate::api::types::transaction::Transaction;
-use crate::api::types::transaction::TransactionContents;
 use crate::api::types::transaction::filter::TransactionFilter;
 use crate::config::Limits;
 use crate::error::RpcError;
@@ -94,13 +93,7 @@ impl Subscription {
                             if !filter.matches(&tx.contents) {
                                 continue;
                             }
-                            yield Ok(Transaction {
-                                digest: tx.digest,
-                                contents: TransactionContents {
-                                    scope: scope.with_active_transaction_digest(tx.digest),
-                                    contents: Some(tx.contents.clone()),
-                                },
-                            });
+                            yield Transaction::with_contents(scope.clone(), tx.contents.clone());
                         }
                     }
                     Err(e) => {
@@ -147,7 +140,10 @@ impl Subscription {
                                     continue;
                                 }
                                 yield Ok(Event {
-                                    scope: scope.with_active_transaction_digest(tx.digest),
+                                    scope: scope.with_active_transaction_contents(
+                                        tx.digest,
+                                        tx.contents.clone(),
+                                    ),
                                     native,
                                     transaction_digest: tx.digest,
                                     sequence_number: idx as u64,

--- a/crates/sui-indexer-alt-graphql/src/api/subscription.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/subscription.rs
@@ -98,7 +98,7 @@ impl Subscription {
                                 digest: tx.digest,
                                 contents: TransactionContents {
                                     scope: scope.with_active_transaction_digest(tx.digest),
-                                    contents: Some(Arc::new(tx.contents.clone())),
+                                    contents: Some(tx.contents.clone()),
                                 },
                             });
                         }

--- a/crates/sui-indexer-alt-graphql/src/api/types/address.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/address.rs
@@ -43,7 +43,7 @@ use crate::api::types::transaction::Transaction;
 use crate::api::types::transaction::filter::TransactionFilter;
 use crate::api::types::transaction::filter::TransactionFilterValidator as TFValidator;
 use crate::api::types::transaction_effects::EffectsContents;
-use crate::api::types::transaction_object_ref::TransactionObjectRef;
+use crate::api::types::transaction_object::TransactionObject;
 use crate::api::types::unchanged_consensus_object::UnchangedConsensusObject;
 use crate::error::RpcError;
 use crate::error::bad_user_input;
@@ -221,19 +221,17 @@ impl Address {
     }
 
     /// How this address (interpreted as an object ID) was referenced by a specific transaction.
-    /// Returns `null` if the address was not referenced, or was present only as a non-object
-    /// marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
     ///
-    /// In an `events` subscription, the `transactionDigest` argument may be omitted; the field
-    /// then resolves against the transaction that emitted the parent event.
+    /// Returns `null` if the address was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
     ///
-    /// Passing an explicit `transactionDigest` other than the parent event's transaction in subscription
-    /// context is not supported; for arbitrary transaction lookups, use the indexed Query API.
+    /// In an `events` subscription, the `transactionDigest` argument may be omitted; the field then resolves against the transaction that emitted the parent event.
+    ///
+    /// Passing an explicit `transactionDigest` other than the parent event's transaction in subscription context is not supported; for arbitrary transaction lookups, use the indexed Query API.
     pub(crate) async fn as_transaction_object(
         &self,
         ctx: &Context<'_>,
         transaction_digest: Option<Digest>,
-    ) -> Option<Result<TransactionObjectRef, RpcError>> {
+    ) -> Option<Result<TransactionObject, RpcError>> {
         async {
             let Some(digest) = transaction_digest
                 .map(Into::into)
@@ -255,7 +253,7 @@ impl Address {
 
             for change in effects.object_changes() {
                 if change.id == address {
-                    return Ok(Some(TransactionObjectRef::Changed(ObjectChange {
+                    return Ok(Some(TransactionObject::Changed(ObjectChange {
                         scope: self.scope.clone(),
                         native: change,
                     })));
@@ -268,7 +266,7 @@ impl Address {
                     let cons_obj =
                         UnchangedConsensusObject::from_native(self.scope.clone(), unchanged, epoch);
                     if let UnchangedConsensusObject::Read(read) = cons_obj {
-                        return Ok(Some(TransactionObjectRef::ConsensusRead(read)));
+                        return Ok(Some(TransactionObject::ConsensusRead(read)));
                     }
                     // Address matched as a non-object marker variant; treat as not referenced.
                     return Ok(None);

--- a/crates/sui-indexer-alt-graphql/src/api/types/address.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/address.rs
@@ -222,7 +222,7 @@ impl Address {
 
     /// How this address (interpreted as an object ID) was referenced by a specific transaction.
     ///
-    /// Returns `null` if the address was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
+    /// Returns `null` if the object was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
     ///
     /// In an `events` subscription, the `transactionDigest` argument may be omitted; the field then resolves against the transaction that emitted the parent event.
     ///

--- a/crates/sui-indexer-alt-graphql/src/api/types/address.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/address.rs
@@ -224,9 +224,9 @@ impl Address {
     ///
     /// Returns `null` if the object was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
     ///
-    /// In an `events` subscription, the `transactionDigest` argument may be omitted; the field then resolves against the transaction that emitted the parent event.
+    /// The `transactionDigest` argument may be omitted when the query is scoped under a transaction context (e.g. a parent `Transaction`, `TransactionEffects`, or `Event`); the field then resolves against the in-scope transaction.
     ///
-    /// Passing an explicit `transactionDigest` other than the parent event's transaction in subscription context is not supported; for arbitrary transaction lookups, use the indexed Query API.
+    /// Passing an explicit `transactionDigest` other than the in-scope transaction in subscription context is not supported; for arbitrary transaction lookups, use the indexed Query API.
     pub(crate) async fn as_transaction_object(
         &self,
         ctx: &Context<'_>,

--- a/crates/sui-indexer-alt-graphql/src/api/types/address.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/address.rs
@@ -11,9 +11,12 @@ use async_graphql::Object;
 use async_graphql::connection::Connection;
 use async_graphql::connection::Edge;
 use futures::future::try_join_all;
+use sui_types::base_types::ObjectID;
 use sui_types::base_types::SuiAddress as NativeSuiAddress;
 use sui_types::dynamic_field::DynamicFieldType;
+use sui_types::effects::TransactionEffectsAPI;
 
+use crate::api::scalars::digest::Digest;
 use crate::api::scalars::domain::Domain;
 use crate::api::scalars::id::Id;
 use crate::api::scalars::owner_kind::OwnerKind;
@@ -32,12 +35,16 @@ use crate::api::types::name_record::NameRecord;
 use crate::api::types::object;
 use crate::api::types::object::Object;
 use crate::api::types::object::ObjectKey;
+use crate::api::types::object_change::ObjectChange;
 use crate::api::types::object_filter::ObjectFilter;
 use crate::api::types::object_filter::ObjectFilterValidator as OFValidator;
 use crate::api::types::transaction::CTransaction;
 use crate::api::types::transaction::Transaction;
 use crate::api::types::transaction::filter::TransactionFilter;
 use crate::api::types::transaction::filter::TransactionFilterValidator as TFValidator;
+use crate::api::types::transaction_effects::EffectsContents;
+use crate::api::types::transaction_object_ref::TransactionObjectRef;
+use crate::api::types::unchanged_consensus_object::UnchangedConsensusObject;
 use crate::error::RpcError;
 use crate::error::bad_user_input;
 use crate::error::convert;
@@ -208,6 +215,67 @@ impl Address {
             };
 
             Object::by_key(ctx, self.scope.clone(), key).await
+        }
+        .await
+        .transpose()
+    }
+
+    /// How this address (interpreted as an object ID) was referenced by a specific transaction.
+    /// Returns `null` if the address was not referenced, or was present only as a non-object
+    /// marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
+    ///
+    /// In an `events` subscription, the `transactionDigest` argument may be omitted; the field
+    /// then resolves against the transaction that emitted the parent event.
+    ///
+    /// Passing an explicit `transactionDigest` other than the parent event's transaction in subscription
+    /// context is not supported; for arbitrary transaction lookups, use the indexed Query API.
+    pub(crate) async fn as_transaction_object(
+        &self,
+        ctx: &Context<'_>,
+        transaction_digest: Option<Digest>,
+    ) -> Option<Result<TransactionObjectRef, RpcError>> {
+        async {
+            let Some(digest) = transaction_digest
+                .map(Into::into)
+                .or_else(|| self.scope.active_transaction_digest())
+            else {
+                return Ok(None);
+            };
+
+            let contents = EffectsContents::empty(self.scope.clone())
+                .fetch(ctx, digest)
+                .await?;
+
+            let Some(content) = contents.contents.as_ref() else {
+                return Ok(None);
+            };
+
+            let effects = content.effects()?;
+            let address: ObjectID = self.address.into();
+
+            for change in effects.object_changes() {
+                if change.id == address {
+                    return Ok(Some(TransactionObjectRef::Changed(ObjectChange {
+                        scope: self.scope.clone(),
+                        native: change,
+                    })));
+                }
+            }
+
+            let epoch = effects.executed_epoch();
+            for unchanged in effects.unchanged_consensus_objects() {
+                if unchanged.0 == address {
+                    let cons_obj =
+                        UnchangedConsensusObject::from_native(self.scope.clone(), unchanged, epoch);
+                    if let UnchangedConsensusObject::Read(read) = cons_obj {
+                        return Ok(Some(TransactionObjectRef::ConsensusRead(read)));
+                    }
+                    // Address matched as a non-object marker variant; treat as not referenced.
+                    return Ok(None);
+                }
+            }
+
+            Ok(None)
         }
         .await
         .transpose()

--- a/crates/sui-indexer-alt-graphql/src/api/types/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/mod.rs
@@ -40,6 +40,7 @@ pub(crate) mod simulation_result;
 pub(crate) mod transaction;
 pub(crate) mod transaction_effects;
 pub(crate) mod transaction_kind;
+pub(crate) mod transaction_object_ref;
 mod type_origin;
 pub(crate) mod unchanged_consensus_object;
 pub(crate) mod user_signature;

--- a/crates/sui-indexer-alt-graphql/src/api/types/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/mod.rs
@@ -40,7 +40,7 @@ pub(crate) mod simulation_result;
 pub(crate) mod transaction;
 pub(crate) mod transaction_effects;
 pub(crate) mod transaction_kind;
-pub(crate) mod transaction_object_ref;
+pub(crate) mod transaction_object;
 mod type_origin;
 pub(crate) mod unchanged_consensus_object;
 pub(crate) mod user_signature;

--- a/crates/sui-indexer-alt-graphql/src/api/types/snapshots/sui_indexer_alt_graphql__api__types__available_range__field_piplines_tests__registry_collect_pipelines_snapshot.snap
+++ b/crates/sui-indexer-alt-graphql/src/api/types/snapshots/sui_indexer_alt_graphql__api__types__available_range__field_piplines_tests__registry_collect_pipelines_snapshot.snap
@@ -38,6 +38,9 @@ Address.addressAt
 Address.asObject
   => {"obj_versions"}
 
+Address.asTransactionObject
+  => {}
+
 Address.balance
   => {"consistent"}
 

--- a/crates/sui-indexer-alt-graphql/src/api/types/snapshots/sui_indexer_alt_graphql__api__types__available_range__field_piplines_tests__registry_collect_pipelines_snapshot_staging.snap
+++ b/crates/sui-indexer-alt-graphql/src/api/types/snapshots/sui_indexer_alt_graphql__api__types__available_range__field_piplines_tests__registry_collect_pipelines_snapshot_staging.snap
@@ -38,6 +38,9 @@ Address.addressAt
 Address.asObject
   => {"obj_versions"}
 
+Address.asTransactionObject
+  => {}
+
 Address.balance
   => {"consistent"}
 

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
@@ -258,7 +258,7 @@ impl Transaction {
                     digest: tx.digest,
                     contents: TransactionContents {
                         scope: tx_scope,
-                        contents: Some(Arc::new(tx.contents.clone())),
+                        contents: Some(tx.contents.clone()),
                     },
                 })
             },
@@ -366,7 +366,7 @@ impl TransactionContents {
         if let Some(tx) = self.scope.streamed_transaction_by_digest(digest) {
             return Ok(Self {
                 scope: self.scope.clone(),
-                contents: Some(Arc::new(tx.contents.clone())),
+                contents: Some(tx.contents.clone()),
             });
         }
 

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
@@ -221,8 +221,24 @@ impl Transaction {
     pub(crate) fn with_digest(scope: Scope, digest: TransactionDigest) -> Self {
         Self {
             digest,
-            contents: TransactionContents::empty(scope),
+            contents: TransactionContents::empty(scope.with_active_transaction_digest(digest)),
         }
+    }
+
+    /// Construct a fully-inflated transaction with already-hydrated contents. The digest is
+    /// read from `contents`, which keeps it consistent with the contents anchored on the scope.
+    pub(crate) fn with_contents(
+        scope: Scope,
+        contents: Arc<NativeTransactionContents>,
+    ) -> Result<Self, RpcError> {
+        let digest = contents.digest()?;
+        Ok(Self {
+            digest,
+            contents: TransactionContents {
+                scope: scope.with_active_transaction_contents(digest, contents.clone()),
+                contents: Some(contents),
+            },
+        })
     }
 
     /// Paginate over pre-loaded transactions, applying in-memory filtering.
@@ -252,16 +268,7 @@ impl Transaction {
         page.paginate_results(
             filtered,
             |tx| JsonCursor::new(tx.tx_sequence_number),
-            |tx| {
-                let tx_scope = scope.with_active_transaction_digest(tx.digest);
-                Ok(Transaction {
-                    digest: tx.digest,
-                    contents: TransactionContents {
-                        scope: tx_scope,
-                        contents: Some(tx.contents.clone()),
-                    },
-                })
-            },
+            |tx| Transaction::with_contents(scope.clone(), tx.contents.clone()),
         )
     }
 
@@ -273,18 +280,15 @@ impl Transaction {
         scope: Scope,
         digest: Digest,
     ) -> Result<Option<Self>, RpcError> {
-        let contents = TransactionContents::empty(scope)
+        let fetched = TransactionContents::empty(scope.clone())
             .fetch(ctx, digest.into())
             .await?;
 
-        let Some(tx) = &contents.contents else {
+        let Some(contents) = fetched.contents else {
             return Ok(None);
         };
 
-        Ok(Some(Self {
-            digest: tx.digest()?,
-            contents,
-        }))
+        Ok(Some(Self::with_contents(scope, contents)?))
     }
 
     /// Cursor based pagination through transactions with filters applied.
@@ -361,12 +365,12 @@ impl TransactionContents {
             return Ok(self.clone());
         }
 
-        // Streaming fast path: if the scope is backed by a streamed checkpoint containing this
-        // transaction, hydrate from the in-memory payload instead of hitting the DB.
-        if let Some(tx) = self.scope.streamed_transaction_by_digest(digest) {
+        // Reuse contents anchored on the scope by a parent resolver (streaming and indexed
+        // alike both anchor with hydrated contents when they have them).
+        if let Some(contents) = self.scope.active_transaction_contents_for(digest) {
             return Ok(Self {
                 scope: self.scope.clone(),
-                contents: Some(tx.contents.clone()),
+                contents: Some(contents.clone()),
             });
         }
 

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
@@ -563,7 +563,7 @@ impl EffectsContents {
         if let Some(tx) = self.scope.streamed_transaction_by_digest(digest) {
             return Ok(Self {
                 scope: self.scope.clone(),
-                contents: Some(Arc::new(tx.contents.clone())),
+                contents: Some(tx.contents.clone()),
             });
         }
 

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
@@ -539,7 +539,7 @@ impl TransactionEffects {
 }
 
 impl EffectsContents {
-    fn empty(scope: Scope) -> Self {
+    pub(crate) fn empty(scope: Scope) -> Self {
         Self {
             scope,
             contents: None,

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
@@ -219,12 +219,17 @@ impl EffectsContents {
                 let page = Page::from_params(limits, first, after, last, before)?;
 
                 let events = content.events()?;
+                let transaction_digest = content.digest()?;
+                let timestamp_ms = content.timestamp_ms();
+                // Anchor the parent transaction (with hydrated contents) onto each yielded
+                // Event's scope, so descendant resolvers like `Address.asTransactionObject`
+                // default to it and `*Contents::fetch` short-circuits via the scope.
+                let event_scope = self
+                    .scope
+                    .with_active_transaction_contents(transaction_digest, content.clone());
                 page.paginate_indices(events.len(), |i| {
-                    let transaction_digest = content.digest()?;
-                    let timestamp_ms = content.timestamp_ms();
-
                     Ok(Event {
-                        scope: self.scope.clone(),
+                        scope: event_scope.clone(),
                         native: events[i].clone(),
                         transaction_digest,
                         sequence_number: i as u64,
@@ -488,6 +493,23 @@ impl EffectsContents {
 }
 
 impl TransactionEffects {
+    /// Construct a fully-inflated TransactionEffects with already-hydrated contents. The digest
+    /// is read from `contents`, which keeps it consistent with the contents anchored on the
+    /// scope.
+    pub(crate) fn with_contents(
+        scope: Scope,
+        contents: Arc<NativeTransactionContents>,
+    ) -> Result<Self, RpcError> {
+        let digest = contents.digest()?;
+        Ok(Self {
+            digest,
+            contents: EffectsContents {
+                scope: scope.with_active_transaction_contents(digest, contents.clone()),
+                contents: Some(contents),
+            },
+        })
+    }
+
     /// Create a new TransactionEffects from an ExecutedTransaction.
     pub(crate) fn from_executed_transaction(
         scope: Scope,
@@ -501,18 +523,7 @@ impl TransactionEffects {
             signatures,
         )
         .context("Failed to create TransactionContents from ExecutedTransaction")?;
-
-        let digest = contents
-            .digest()
-            .context("Failed to get digest from transaction contents")?;
-
-        Ok(Self {
-            digest,
-            contents: EffectsContents {
-                scope,
-                contents: Some(Arc::new(contents)),
-            },
-        })
+        Self::with_contents(scope, Arc::new(contents))
     }
 
     /// Load the effects from the store, and return it fully inflated (with contents already
@@ -523,18 +534,15 @@ impl TransactionEffects {
         scope: Scope,
         digest: Digest,
     ) -> Result<Option<Self>, RpcError> {
-        let contents = EffectsContents::empty(scope)
+        let fetched = EffectsContents::empty(scope.clone())
             .fetch(ctx, digest.into())
             .await?;
 
-        let Some(tx) = &contents.contents else {
+        let Some(contents) = fetched.contents else {
             return Ok(None);
         };
 
-        Ok(Some(Self {
-            digest: tx.digest()?,
-            contents,
-        }))
+        Ok(Some(Self::with_contents(scope, contents)?))
     }
 }
 
@@ -558,12 +566,12 @@ impl EffectsContents {
             return Ok(self.clone());
         }
 
-        // Streaming fast path: if the scope is backed by a streamed checkpoint containing this
-        // transaction, hydrate from the in-memory payload instead of hitting the DB.
-        if let Some(tx) = self.scope.streamed_transaction_by_digest(digest) {
+        // Reuse contents anchored on the scope by a parent resolver (streaming and indexed
+        // alike both anchor with hydrated contents when they have them).
+        if let Some(contents) = self.scope.active_transaction_contents_for(digest) {
             return Ok(Self {
                 scope: self.scope.clone(),
-                contents: Some(tx.contents.clone()),
+                contents: Some(contents.clone()),
             });
         }
 
@@ -598,7 +606,6 @@ impl EffectsContents {
 impl From<Transaction> for TransactionEffects {
     fn from(tx: Transaction) -> Self {
         let TransactionContents { scope, contents } = tx.contents;
-
         Self {
             digest: tx.digest,
             contents: EffectsContents { scope, contents },

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_object.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_object.rs
@@ -6,8 +6,7 @@ use async_graphql::Union;
 use crate::api::types::object_change::ObjectChange;
 use crate::api::types::unchanged_consensus_object::ConsensusObjectRead;
 
-/// An object as it appears in a specific transaction. The variant discriminates whether the
-/// object was changed by the transaction or read as an unchanged consensus (shared) input.
+/// An object as it appears in a specific transaction. The variant discriminates whether the object was changed by the transaction or read as an unchanged consensus (shared) input.
 #[derive(Union)]
 pub(crate) enum TransactionObject {
     Changed(ObjectChange),

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_object.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_object.rs
@@ -6,11 +6,10 @@ use async_graphql::Union;
 use crate::api::types::object_change::ObjectChange;
 use crate::api::types::unchanged_consensus_object::ConsensusObjectRead;
 
-/// Reference to an object as it appears in a specific transaction. The variant discriminates
-/// whether the object was changed by the transaction or read as an unchanged consensus
-/// (shared) input.
+/// An object as it appears in a specific transaction. The variant discriminates whether the
+/// object was changed by the transaction or read as an unchanged consensus (shared) input.
 #[derive(Union)]
-pub(crate) enum TransactionObjectRef {
+pub(crate) enum TransactionObject {
     Changed(ObjectChange),
     ConsensusRead(ConsensusObjectRead),
 }

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_object_ref.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_object_ref.rs
@@ -1,0 +1,16 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use async_graphql::Union;
+
+use crate::api::types::object_change::ObjectChange;
+use crate::api::types::unchanged_consensus_object::ConsensusObjectRead;
+
+/// Reference to an object as it appears in a specific transaction. The variant discriminates
+/// whether the object was changed by the transaction or read as an unchanged consensus
+/// (shared) input.
+#[derive(Union)]
+pub(crate) enum TransactionObjectRef {
+    Changed(ObjectChange),
+    ConsensusRead(ConsensusObjectRead),
+}

--- a/crates/sui-indexer-alt-graphql/src/scope.rs
+++ b/crates/sui-indexer-alt-graphql/src/scope.rs
@@ -293,6 +293,13 @@ impl Scope {
         }
     }
 
+    /// The digest of the transaction this scope is anchored to, if any. Returns `None` if no
+    /// specific transaction is in scope (e.g. top-level queries, indexed scopes that were not
+    /// pinned to a transaction).
+    pub(crate) fn active_transaction_digest(&self) -> Option<TransactionDigest> {
+        self.active_transaction_digest
+    }
+
     /// The execution objects map active for object lookups in this scope. Resolves through the
     /// scope's [`DataSource`]: in `Streamed` mode, returns the checkpoint-wide map (object
     /// visibility is end-of-checkpoint, matching the indexed Query path); in `Executed` mode,

--- a/crates/sui-indexer-alt-graphql/src/scope.rs
+++ b/crates/sui-indexer-alt-graphql/src/scope.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 use async_graphql::Context;
 use async_trait::async_trait;
 use move_core_types::account_address::AccountAddress;
+use sui_indexer_alt_reader::kv_loader::TransactionContents as NativeTransactionContents;
 use sui_indexer_alt_reader::package_resolver::PackageCache;
 use sui_package_resolver::Package;
 use sui_package_resolver::PackageStore;
@@ -25,7 +26,6 @@ use sui_types::object::Object as NativeObject;
 use crate::config::Limits;
 use crate::error::RpcError;
 use crate::task::streaming::ProcessedCheckpoint;
-use crate::task::streaming::ProcessedTransaction;
 use crate::task::streaming::StreamingPackageStore;
 use crate::task::watermark::Watermarks;
 
@@ -49,10 +49,33 @@ pub(crate) enum DataSource {
     },
     /// A streamed checkpoint with all per-tx contents and a checkpoint-wide execution-objects
     /// map. If the scope is anchored to a particular transaction in the checkpoint, its digest
-    /// is in [`Scope::active_transaction_digest`].
+    /// is in [`Scope::effects_viewed_at_digest`].
     Streamed {
         checkpoint: Arc<ProcessedCheckpoint>,
     },
+}
+
+/// Identifies the transaction whose effects are currently in view. Descendant resolvers default
+/// fields like `Address.asTransactionObject` to this transaction, and `*Contents::fetch` consults
+/// `contents` as a hit before falling back to streaming/kv_loader.
+///
+/// `contents` is `Some` when the anchoring caller already had them in hand (e.g. when navigating
+/// `Transaction.effects` on a hydrated `Transaction`). `None` for digest-only anchors (e.g.
+/// subscription resolvers, where contents live in the [`DataSource::Streamed`] checkpoint and are
+/// fetched on demand).
+#[derive(Clone)]
+struct ActiveTransaction {
+    digest: TransactionDigest,
+    contents: Option<Arc<NativeTransactionContents>>,
+}
+
+impl Debug for ActiveTransaction {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ActiveTransaction")
+            .field("digest", &self.digest)
+            .field("contents_loaded", &self.contents.is_some())
+            .finish()
+    }
 }
 
 /// Root object bound for consistent dynamic field reads.
@@ -87,15 +110,16 @@ pub(crate) struct Scope {
     /// None indicates execution context where we're viewing fresh transaction effects not yet indexed.
     checkpoint_viewed_at: Option<u64>,
 
-    /// The specific transaction this scope is anchored to, identified by digest. Set by
-    /// resolvers that render data for a single transaction (e.g. the streaming `transactions`
-    /// and `events` subscriptions) so downstream fields like `Address.asTransactionObject`
-    /// know which transaction's effects to scan. `None` when no specific transaction is in
-    /// scope.
+    /// The transaction whose effects descendant resolvers default to (e.g.
+    /// `Address.asTransactionObject` without an explicit `transactionDigest`). Set when a
+    /// resolver brings a single transaction into view: indexed paths that already hold the
+    /// `TransactionContents` anchor with contents (so `*Contents::fetch` can short-circuit
+    /// via `active_transaction_contents_for`); subscription resolvers anchor digest-only and
+    /// rely on the [`DataSource::Streamed`] checkpoint for content lookups.
     ///
     /// This is *not* a "view bound" up to and including a transaction; it identifies one
     /// transaction. Object visibility is end-of-checkpoint regardless of this field.
-    active_transaction_digest: Option<TransactionDigest>,
+    active_transaction: Option<ActiveTransaction>,
 
     /// Root object bound for dynamic fields.
     ///
@@ -122,7 +146,7 @@ impl Scope {
 
         Ok(Self {
             checkpoint_viewed_at: Some(watermark.high_watermark().checkpoint()),
-            active_transaction_digest: None,
+            active_transaction: None,
             root_bound: None,
             data_source: DataSource::Indexed,
             package_store: package_store.clone(),
@@ -139,7 +163,7 @@ impl Scope {
     ) -> Self {
         Self {
             checkpoint_viewed_at: None,
-            active_transaction_digest: None,
+            active_transaction: None,
             root_bound: None,
             data_source: DataSource::Streamed {
                 checkpoint: streamed_checkpoint,
@@ -149,13 +173,39 @@ impl Scope {
         }
     }
 
-    /// Anchor a nested scope to a specific transaction by digest. Used by resolvers that
-    /// render a single transaction's data so downstream fields can identify which
-    /// transaction's effects to consult. Does not change object visibility.
+    /// Anchor a nested scope to a transaction by digest only. Used when the caller does not yet
+    /// hold the transaction's contents. If the scope is already anchored to the same digest
+    /// (with or without hydrated contents), the existing anchor is preserved so descendants
+    /// keep access to any cached contents. Does not change object visibility.
     pub(crate) fn with_active_transaction_digest(&self, digest: TransactionDigest) -> Self {
+        if self.active_transaction_digest() == Some(digest) {
+            return self.clone();
+        }
+        self.with_active_transaction(ActiveTransaction {
+            digest,
+            contents: None,
+        })
+    }
+
+    /// Anchor a nested scope to a transaction whose contents the caller already holds. Lets
+    /// downstream resolvers reuse the contents instead of re-fetching via kv_loader, and lets
+    /// fields like `Address.asTransactionObject` default to this transaction. Does not change
+    /// object visibility.
+    pub(crate) fn with_active_transaction_contents(
+        &self,
+        digest: TransactionDigest,
+        contents: Arc<NativeTransactionContents>,
+    ) -> Self {
+        self.with_active_transaction(ActiveTransaction {
+            digest,
+            contents: Some(contents),
+        })
+    }
+
+    fn with_active_transaction(&self, active: ActiveTransaction) -> Self {
         Self {
             checkpoint_viewed_at: self.checkpoint_viewed_at,
-            active_transaction_digest: Some(digest),
+            active_transaction: Some(active),
             root_bound: self.root_bound,
             data_source: self.data_source.clone(),
             package_store: self.package_store.clone(),
@@ -181,7 +231,7 @@ impl Scope {
 
         Self {
             checkpoint_viewed_at: Some(0),
-            active_transaction_digest: None,
+            active_transaction: None,
             root_bound: None,
             data_source: DataSource::Indexed,
             package_store: Arc::new(EmptyPackageStore),
@@ -200,7 +250,7 @@ impl Scope {
         let cp_hi_inclusive = watermark.high_watermark().checkpoint();
         (checkpoint_viewed_at <= cp_hi_inclusive).then(|| Self {
             checkpoint_viewed_at: Some(checkpoint_viewed_at),
-            active_transaction_digest: self.active_transaction_digest,
+            active_transaction: self.active_transaction.clone(),
             root_bound: self.root_bound,
             data_source: self.data_source.clone(),
             package_store: self.package_store.clone(),
@@ -212,7 +262,7 @@ impl Scope {
     pub(crate) fn with_root_version(&self, root_version: u64) -> Self {
         Self {
             checkpoint_viewed_at: self.checkpoint_viewed_at,
-            active_transaction_digest: self.active_transaction_digest,
+            active_transaction: self.active_transaction.clone(),
             root_bound: Some(RootBound::Version(root_version)),
             data_source: self.data_source.clone(),
             package_store: self.package_store.clone(),
@@ -224,7 +274,7 @@ impl Scope {
     pub(crate) fn with_root_checkpoint(&self, root_checkpoint: u64) -> Self {
         Self {
             checkpoint_viewed_at: self.checkpoint_viewed_at,
-            active_transaction_digest: self.active_transaction_digest,
+            active_transaction: self.active_transaction.clone(),
             root_bound: Some(RootBound::Checkpoint(root_checkpoint)),
             data_source: self.data_source.clone(),
             package_store: self.package_store.clone(),
@@ -236,7 +286,7 @@ impl Scope {
     pub(crate) fn without_root_bound(&self) -> Self {
         Self {
             checkpoint_viewed_at: self.checkpoint_viewed_at,
-            active_transaction_digest: self.active_transaction_digest,
+            active_transaction: self.active_transaction.clone(),
             root_bound: None,
             data_source: self.data_source.clone(),
             package_store: self.package_store.clone(),
@@ -280,24 +330,22 @@ impl Scope {
         self.checkpoint_viewed_at.map(|cp| cp + 1)
     }
 
-    /// Lookup a transaction by digest within the streamed checkpoint backing this scope.
-    /// Returns `None` if the scope is not in [`DataSource::Streamed`] mode, or if no
-    /// transaction with that digest exists in the checkpoint.
-    pub(crate) fn streamed_transaction_by_digest(
-        &self,
-        digest: TransactionDigest,
-    ) -> Option<&ProcessedTransaction> {
-        match &self.data_source {
-            DataSource::Streamed { checkpoint } => checkpoint.transaction_by_digest(digest),
-            DataSource::Indexed | DataSource::Executed { .. } => None,
-        }
+    /// The digest of the transaction this scope is anchored to, if any.
+    pub(crate) fn active_transaction_digest(&self) -> Option<TransactionDigest> {
+        self.active_transaction.as_ref().map(|a| a.digest)
     }
 
-    /// The digest of the transaction this scope is anchored to, if any. Returns `None` if no
-    /// specific transaction is in scope (e.g. top-level queries, indexed scopes that were not
-    /// pinned to a transaction).
-    pub(crate) fn active_transaction_digest(&self) -> Option<TransactionDigest> {
-        self.active_transaction_digest
+    /// Already-fetched contents for `digest`, if the scope was anchored to that same transaction
+    /// with hydrated contents. Returns `None` for any other digest, or when the anchor is
+    /// digest-only; callers should fall through to the normal fetch path.
+    pub(crate) fn active_transaction_contents_for(
+        &self,
+        digest: TransactionDigest,
+    ) -> Option<&Arc<NativeTransactionContents>> {
+        self.active_transaction
+            .as_ref()
+            .filter(|a| a.digest == digest)
+            .and_then(|a| a.contents.as_ref())
     }
 
     /// The execution objects map active for object lookups in this scope. Resolves through the
@@ -347,7 +395,7 @@ impl Scope {
 
         Ok(Self {
             checkpoint_viewed_at: None,
-            active_transaction_digest: None,
+            active_transaction: None,
             root_bound: self.root_bound,
             data_source: DataSource::Executed { execution_objects },
             package_store: self.package_store.clone(),
@@ -417,7 +465,7 @@ impl Debug for Scope {
         f.debug_struct("Scope")
             .field("checkpoint_viewed_at", &self.checkpoint_viewed_at)
             .field("root_bound", &self.root_bound)
-            .field("active_transaction_digest", &self.active_transaction_digest)
+            .field("active_transaction", &self.active_transaction)
             .field("resolver_limits", &self.resolver_limits)
             .finish()
     }

--- a/crates/sui-indexer-alt-graphql/src/scope.rs
+++ b/crates/sui-indexer-alt-graphql/src/scope.rs
@@ -69,15 +69,6 @@ struct ActiveTransaction {
     contents: Option<Arc<NativeTransactionContents>>,
 }
 
-impl Debug for ActiveTransaction {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        f.debug_struct("ActiveTransaction")
-            .field("digest", &self.digest)
-            .field("contents_loaded", &self.contents.is_some())
-            .finish()
-    }
-}
-
 /// Root object bound for consistent dynamic field reads.
 ///
 /// This enables consistent dynamic field reads in the case of chained dynamic object fields,
@@ -458,6 +449,15 @@ fn extract_objects_from_executed_transaction(
     }
 
     Ok(Arc::new(map))
+}
+
+impl Debug for ActiveTransaction {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ActiveTransaction")
+            .field("digest", &self.digest)
+            .field("contents_loaded", &self.contents.is_some())
+            .finish()
+    }
 }
 
 impl Debug for Scope {

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -89,16 +89,14 @@ type Address implements Node & IAddressable {
 	asObject: Object
 	"""
 	How this address (interpreted as an object ID) was referenced by a specific transaction.
-	Returns `null` if the address was not referenced, or was present only as a non-object
-	marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
 	
-	In an `events` subscription, the `transactionDigest` argument may be omitted; the field
-	then resolves against the transaction that emitted the parent event.
+	Returns `null` if the address was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
 	
-	Passing an explicit `transactionDigest` other than the parent event's transaction in subscription
-	context is not supported; for arbitrary transaction lookups, use the indexed Query API.
+	In an `events` subscription, the `transactionDigest` argument may be omitted; the field then resolves against the transaction that emitted the parent event.
+	
+	Passing an explicit `transactionDigest` other than the parent event's transaction in subscription context is not supported; for arbitrary transaction lookups, use the indexed Query API.
 	"""
-	asTransactionObject(transactionDigest: String): TransactionObjectRef
+	asTransactionObject(transactionDigest: String): TransactionObject
 	"""
 	Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
 	
@@ -4349,11 +4347,10 @@ enum TransactionKindInput {
 }
 
 """
-Reference to an object as it appears in a specific transaction. The variant discriminates
-whether the object was changed by the transaction or read as an unchanged consensus
-(shared) input.
+An object as it appears in a specific transaction. The variant discriminates whether the
+object was changed by the transaction or read as an unchanged consensus (shared) input.
 """
-union TransactionObjectRef = ObjectChange | ConsensusObjectRead
+union TransactionObject = ObjectChange | ConsensusObjectRead
 
 """
 Transfers `inputs` to `address`. All inputs must have the `store` ability (allows public transfer) and must not be previously immutable or shared.

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -90,7 +90,7 @@ type Address implements Node & IAddressable {
 	"""
 	How this address (interpreted as an object ID) was referenced by a specific transaction.
 	
-	Returns `null` if the address was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
+	Returns `null` if the object was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
 	
 	In an `events` subscription, the `transactionDigest` argument may be omitted; the field then resolves against the transaction that emitted the parent event.
 	
@@ -4347,8 +4347,7 @@ enum TransactionKindInput {
 }
 
 """
-An object as it appears in a specific transaction. The variant discriminates whether the
-object was changed by the transaction or read as an unchanged consensus (shared) input.
+An object as it appears in a specific transaction. The variant discriminates whether the object was changed by the transaction or read as an unchanged consensus (shared) input.
 """
 union TransactionObject = ObjectChange | ConsensusObjectRead
 

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -88,6 +88,18 @@ type Address implements Node & IAddressable {
 	"""
 	asObject: Object
 	"""
+	How this address (interpreted as an object ID) was referenced by a specific transaction.
+	Returns `null` if the address was not referenced, or was present only as a non-object
+	marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
+	
+	In an `events` subscription, the `transactionDigest` argument may be omitted; the field
+	then resolves against the transaction that emitted the parent event.
+	
+	Passing an explicit `transactionDigest` other than the parent event's transaction in subscription
+	context is not supported; for arbitrary transaction lookups, use the indexed Query API.
+	"""
+	asTransactionObject(transactionDigest: String): TransactionObjectRef
+	"""
 	Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
 	
 	Returns `None` when no checkpoint is set in scope (e.g. execution scope).
@@ -4335,6 +4347,13 @@ enum TransactionKindInput {
 	"""
 	PROGRAMMABLE_TX
 }
+
+"""
+Reference to an object as it appears in a specific transaction. The variant discriminates
+whether the object was changed by the transaction or read as an unchanged consensus
+(shared) input.
+"""
+union TransactionObjectRef = ObjectChange | ConsensusObjectRead
 
 """
 Transfers `inputs` to `address`. All inputs must have the `store` ability (allows public transfer) and must not be previously immutable or shared.

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -92,9 +92,9 @@ type Address implements Node & IAddressable {
 	
 	Returns `null` if the object was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
 	
-	In an `events` subscription, the `transactionDigest` argument may be omitted; the field then resolves against the transaction that emitted the parent event.
+	The `transactionDigest` argument may be omitted when the query is scoped under a transaction context (e.g. a parent `Transaction`, `TransactionEffects`, or `Event`); the field then resolves against the in-scope transaction.
 	
-	Passing an explicit `transactionDigest` other than the parent event's transaction in subscription context is not supported; for arbitrary transaction lookups, use the indexed Query API.
+	Passing an explicit `transactionDigest` other than the in-scope transaction in subscription context is not supported; for arbitrary transaction lookups, use the indexed Query API.
 	"""
 	asTransactionObject(transactionDigest: String): TransactionObject
 	"""

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -89,16 +89,14 @@ type Address implements Node & IAddressable {
 	asObject: Object
 	"""
 	How this address (interpreted as an object ID) was referenced by a specific transaction.
-	Returns `null` if the address was not referenced, or was present only as a non-object
-	marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
 	
-	In an `events` subscription, the `transactionDigest` argument may be omitted; the field
-	then resolves against the transaction that emitted the parent event.
+	Returns `null` if the address was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
 	
-	Passing an explicit `transactionDigest` other than the parent event's transaction in subscription
-	context is not supported; for arbitrary transaction lookups, use the indexed Query API.
+	In an `events` subscription, the `transactionDigest` argument may be omitted; the field then resolves against the transaction that emitted the parent event.
+	
+	Passing an explicit `transactionDigest` other than the parent event's transaction in subscription context is not supported; for arbitrary transaction lookups, use the indexed Query API.
 	"""
-	asTransactionObject(transactionDigest: String): TransactionObjectRef
+	asTransactionObject(transactionDigest: String): TransactionObject
 	"""
 	Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
 	
@@ -4378,11 +4376,10 @@ enum TransactionKindInput {
 }
 
 """
-Reference to an object as it appears in a specific transaction. The variant discriminates
-whether the object was changed by the transaction or read as an unchanged consensus
-(shared) input.
+An object as it appears in a specific transaction. The variant discriminates whether the
+object was changed by the transaction or read as an unchanged consensus (shared) input.
 """
-union TransactionObjectRef = ObjectChange | ConsensusObjectRead
+union TransactionObject = ObjectChange | ConsensusObjectRead
 
 """
 Transfers `inputs` to `address`. All inputs must have the `store` ability (allows public transfer) and must not be previously immutable or shared.

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -90,7 +90,7 @@ type Address implements Node & IAddressable {
 	"""
 	How this address (interpreted as an object ID) was referenced by a specific transaction.
 	
-	Returns `null` if the address was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
+	Returns `null` if the object was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
 	
 	In an `events` subscription, the `transactionDigest` argument may be omitted; the field then resolves against the transaction that emitted the parent event.
 	
@@ -4376,8 +4376,7 @@ enum TransactionKindInput {
 }
 
 """
-An object as it appears in a specific transaction. The variant discriminates whether the
-object was changed by the transaction or read as an unchanged consensus (shared) input.
+An object as it appears in a specific transaction. The variant discriminates whether the object was changed by the transaction or read as an unchanged consensus (shared) input.
 """
 union TransactionObject = ObjectChange | ConsensusObjectRead
 

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -88,6 +88,18 @@ type Address implements Node & IAddressable {
 	"""
 	asObject: Object
 	"""
+	How this address (interpreted as an object ID) was referenced by a specific transaction.
+	Returns `null` if the address was not referenced, or was present only as a non-object
+	marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
+	
+	In an `events` subscription, the `transactionDigest` argument may be omitted; the field
+	then resolves against the transaction that emitted the parent event.
+	
+	Passing an explicit `transactionDigest` other than the parent event's transaction in subscription
+	context is not supported; for arbitrary transaction lookups, use the indexed Query API.
+	"""
+	asTransactionObject(transactionDigest: String): TransactionObjectRef
+	"""
 	Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
 	
 	Returns `None` when no checkpoint is set in scope (e.g. execution scope).
@@ -4364,6 +4376,13 @@ enum TransactionKindInput {
 	"""
 	PROGRAMMABLE_TX
 }
+
+"""
+Reference to an object as it appears in a specific transaction. The variant discriminates
+whether the object was changed by the transaction or read as an unchanged consensus
+(shared) input.
+"""
+union TransactionObjectRef = ObjectChange | ConsensusObjectRead
 
 """
 Transfers `inputs` to `address`. All inputs must have the `store` ability (allows public transfer) and must not be previously immutable or shared.

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -92,9 +92,9 @@ type Address implements Node & IAddressable {
 	
 	Returns `null` if the object was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
 	
-	In an `events` subscription, the `transactionDigest` argument may be omitted; the field then resolves against the transaction that emitted the parent event.
+	The `transactionDigest` argument may be omitted when the query is scoped under a transaction context (e.g. a parent `Transaction`, `TransactionEffects`, or `Event`); the field then resolves against the in-scope transaction.
 	
-	Passing an explicit `transactionDigest` other than the parent event's transaction in subscription context is not supported; for arbitrary transaction lookups, use the indexed Query API.
+	Passing an explicit `transactionDigest` other than the in-scope transaction in subscription context is not supported; for arbitrary transaction lookups, use the indexed Query API.
 	"""
 	asTransactionObject(transactionDigest: String): TransactionObject
 	"""

--- a/crates/sui-indexer-alt-graphql/src/task/streaming/checkpoint_stream_task.rs
+++ b/crates/sui-indexer-alt-graphql/src/task/streaming/checkpoint_stream_task.rs
@@ -500,7 +500,7 @@ fn process_transaction(
     Ok(ProcessedTransaction {
         tx_sequence_number,
         digest,
-        contents,
+        contents: Arc::new(contents),
     })
 }
 

--- a/crates/sui-indexer-alt-graphql/src/task/streaming/checkpoint_stream_task.rs
+++ b/crates/sui-indexer-alt-graphql/src/task/streaming/checkpoint_stream_task.rs
@@ -421,14 +421,14 @@ pub(super) fn process_checkpoint(
         )?);
     }
 
-    Ok(ProcessedCheckpoint::new(
+    Ok(ProcessedCheckpoint {
         sequence_number,
         summary,
         contents,
         signature,
         transactions,
-        Arc::new(execution_objects),
-    ))
+        execution_objects: Arc::new(execution_objects),
+    })
 }
 
 fn process_transaction(

--- a/crates/sui-indexer-alt-graphql/src/task/streaming/processed_checkpoint.rs
+++ b/crates/sui-indexer-alt-graphql/src/task/streaming/processed_checkpoint.rs
@@ -1,7 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashMap;
 use std::sync::Arc;
 
 use sui_indexer_alt_reader::kv_loader::TransactionContents;
@@ -23,9 +22,6 @@ pub(crate) struct ProcessedCheckpoint {
     /// checkpoint, including tombstones for deleted/wrapped objects). Object visibility in a
     /// streamed scope is end-of-checkpoint, matching what the indexed Query API exposes.
     pub(crate) execution_objects: ExecutionObjectMap,
-    /// Index of `transactions` by digest for O(1) lookup that scales across many subscribers.
-    /// Built once at construction.
-    by_digest: HashMap<TransactionDigest, usize>,
 }
 
 /// A transaction from a streamed checkpoint with pre-deserialized contents.
@@ -35,40 +31,4 @@ pub(crate) struct ProcessedTransaction {
     /// Wrapped in `Arc` so that subscribers (and resolvers within them) share a single deep
     /// copy of the per-tx contents instead of each cloning the whole `TransactionContents`.
     pub(crate) contents: Arc<TransactionContents>,
-}
-
-impl ProcessedCheckpoint {
-    /// Construct a checkpoint with the digest index pre-built from `transactions`.
-    pub(crate) fn new(
-        sequence_number: u64,
-        summary: CheckpointSummary,
-        contents: CheckpointContents,
-        signature: AuthorityStrongQuorumSignInfo,
-        transactions: Vec<ProcessedTransaction>,
-        execution_objects: ExecutionObjectMap,
-    ) -> Self {
-        let by_digest = transactions
-            .iter()
-            .enumerate()
-            .map(|(i, t)| (t.digest, i))
-            .collect();
-        Self {
-            sequence_number,
-            summary,
-            contents,
-            signature,
-            transactions,
-            execution_objects,
-            by_digest,
-        }
-    }
-
-    /// Lookup a transaction by digest within this checkpoint.
-    pub(crate) fn transaction_by_digest(
-        &self,
-        digest: TransactionDigest,
-    ) -> Option<&ProcessedTransaction> {
-        let i = *self.by_digest.get(&digest)?;
-        self.transactions.get(i)
-    }
 }

--- a/crates/sui-indexer-alt-graphql/src/task/streaming/processed_checkpoint.rs
+++ b/crates/sui-indexer-alt-graphql/src/task/streaming/processed_checkpoint.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use sui_indexer_alt_reader::kv_loader::TransactionContents;
 use sui_types::crypto::AuthorityStrongQuorumSignInfo;
@@ -31,7 +32,9 @@ pub(crate) struct ProcessedCheckpoint {
 pub(crate) struct ProcessedTransaction {
     pub(crate) tx_sequence_number: u64,
     pub(crate) digest: TransactionDigest,
-    pub(crate) contents: TransactionContents,
+    /// Wrapped in `Arc` so that subscribers (and resolvers within them) share a single deep
+    /// copy of the per-tx contents instead of each cloning the whole `TransactionContents`.
+    pub(crate) contents: Arc<TransactionContents>,
 }
 
 impl ProcessedCheckpoint {

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -84,6 +84,18 @@ type Address implements Node & IAddressable {
 	"""
 	asObject: Object
 	"""
+	How this address (interpreted as an object ID) was referenced by a specific transaction.
+	Returns `null` if the address was not referenced, or was present only as a non-object
+	marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
+	
+	In an `events` subscription, the `transactionDigest` argument may be omitted; the field
+	then resolves against the transaction that emitted the parent event.
+	
+	Passing an explicit `transactionDigest` other than the parent event's transaction in subscription
+	context is not supported; for arbitrary transaction lookups, use the indexed Query API.
+	"""
+	asTransactionObject(transactionDigest: String): TransactionObjectRef
+	"""
 	Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
 	
 	Returns `None` when no checkpoint is set in scope (e.g. execution scope).
@@ -4360,6 +4372,13 @@ enum TransactionKindInput {
 	"""
 	PROGRAMMABLE_TX
 }
+
+"""
+Reference to an object as it appears in a specific transaction. The variant discriminates
+whether the object was changed by the transaction or read as an unchanged consensus
+(shared) input.
+"""
+union TransactionObjectRef = ObjectChange | ConsensusObjectRead
 
 """
 Transfers `inputs` to `address`. All inputs must have the `store` ability (allows public transfer) and must not be previously immutable or shared.

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -85,16 +85,14 @@ type Address implements Node & IAddressable {
 	asObject: Object
 	"""
 	How this address (interpreted as an object ID) was referenced by a specific transaction.
-	Returns `null` if the address was not referenced, or was present only as a non-object
-	marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
 	
-	In an `events` subscription, the `transactionDigest` argument may be omitted; the field
-	then resolves against the transaction that emitted the parent event.
+	Returns `null` if the address was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
 	
-	Passing an explicit `transactionDigest` other than the parent event's transaction in subscription
-	context is not supported; for arbitrary transaction lookups, use the indexed Query API.
+	In an `events` subscription, the `transactionDigest` argument may be omitted; the field then resolves against the transaction that emitted the parent event.
+	
+	Passing an explicit `transactionDigest` other than the parent event's transaction in subscription context is not supported; for arbitrary transaction lookups, use the indexed Query API.
 	"""
-	asTransactionObject(transactionDigest: String): TransactionObjectRef
+	asTransactionObject(transactionDigest: String): TransactionObject
 	"""
 	Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
 	
@@ -4374,11 +4372,10 @@ enum TransactionKindInput {
 }
 
 """
-Reference to an object as it appears in a specific transaction. The variant discriminates
-whether the object was changed by the transaction or read as an unchanged consensus
-(shared) input.
+An object as it appears in a specific transaction. The variant discriminates whether the
+object was changed by the transaction or read as an unchanged consensus (shared) input.
 """
-union TransactionObjectRef = ObjectChange | ConsensusObjectRead
+union TransactionObject = ObjectChange | ConsensusObjectRead
 
 """
 Transfers `inputs` to `address`. All inputs must have the `store` ability (allows public transfer) and must not be previously immutable or shared.

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -86,7 +86,7 @@ type Address implements Node & IAddressable {
 	"""
 	How this address (interpreted as an object ID) was referenced by a specific transaction.
 	
-	Returns `null` if the address was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
+	Returns `null` if the object was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
 	
 	In an `events` subscription, the `transactionDigest` argument may be omitted; the field then resolves against the transaction that emitted the parent event.
 	
@@ -4372,8 +4372,7 @@ enum TransactionKindInput {
 }
 
 """
-An object as it appears in a specific transaction. The variant discriminates whether the
-object was changed by the transaction or read as an unchanged consensus (shared) input.
+An object as it appears in a specific transaction. The variant discriminates whether the object was changed by the transaction or read as an unchanged consensus (shared) input.
 """
 union TransactionObject = ObjectChange | ConsensusObjectRead
 

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -88,9 +88,9 @@ type Address implements Node & IAddressable {
 	
 	Returns `null` if the object was not referenced, or was present only as a non-object marker variant of unchanged consensus input (e.g. cancelled, stream-ended, per-epoch).
 	
-	In an `events` subscription, the `transactionDigest` argument may be omitted; the field then resolves against the transaction that emitted the parent event.
+	The `transactionDigest` argument may be omitted when the query is scoped under a transaction context (e.g. a parent `Transaction`, `TransactionEffects`, or `Event`); the field then resolves against the in-scope transaction.
 	
-	Passing an explicit `transactionDigest` other than the parent event's transaction in subscription context is not supported; for arbitrary transaction lookups, use the indexed Query API.
+	Passing an explicit `transactionDigest` other than the in-scope transaction in subscription context is not supported; for arbitrary transaction lookups, use the indexed Query API.
 	"""
 	asTransactionObject(transactionDigest: String): TransactionObject
 	"""


### PR DESCRIPTION
## Description 

Streaming subscribers want to take an object ID that surfaces inside an event payload and immediately ask "how was this object referenced by the transaction that emitted the event?" without round-tripping to the indexed Query API. The object is also sometimes an unchanged shared input (e.g. a clock or registry), so it never appears in `objectChanges`; the resolver therefore needs to expose both the change case and the read-only consensus input case.


This PR adds:

  ```graphql
  type Address {
    asTransactionObject(transactionDigest: String): TransactionObjectRef
  }

  union TransactionObjectRef = ObjectChange | ConsensusObjectRead
  ```

`ObjectChange` and `ConsensusObjectRead` are reused as-is from the schema; no duplication. The resolver scans `effects.object_changes` first, then `effects.unchanged_consensus_objects` filtered to the ReadOnlyRoot variant. Other unchanged-input markers (cancelled, stream-ended, per-epoch) resolve to null since they do not house an object the user can navigate to.

In an events subscription, the transactionDigest argument may be omitted; the field then resolves against the transaction that emitted the parent event, via a new Scope::tx_digest_viewed_at() helper. Passing an explicit transactionDigest other than the parent event's transaction in subscription context is intentionally not supported (the document states this); use the indexed Query API for arbitrary transaction lookups.

## Test plan 

How did you test the new or updated feature?
- unit + e2e tests

## Stack
   - #26019
   - #26094
   - #26117
   - #26170
   - #26194
   - #26202
   - #26414
   - #26453
   - #26476
   - #26487
   - #26425
   - #26495

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [x] GraphQL: add asTransactionObject  which allows user to query the status of address that is involved as an object in a particular transaction
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
