### PR TITLE
[indexers-rpc] VM error visibility jsonrpc only

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14810,7 +14810,6 @@ dependencies = [
 [[package]]
 name = "sui-crypto"
 version = "0.3.0"
-source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=e494a36a76a0aab8c5d66d5557995faee5c1fb09#e494a36a76a0aab8c5d66d5557995faee5c1fb09"
 dependencies = [
  "ark-bn254",
  "ark-ff 0.4.2",
@@ -16796,7 +16795,6 @@ dependencies = [
 [[package]]
 name = "sui-rpc"
 version = "0.3.0"
-source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=e494a36a76a0aab8c5d66d5557995faee5c1fb09#e494a36a76a0aab8c5d66d5557995faee5c1fb09"
 dependencies = [
  "base64 0.22.1",
  "bcs",
@@ -16993,7 +16991,6 @@ dependencies = [
 [[package]]
 name = "sui-sdk-types"
 version = "0.3.0"
-source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=e494a36a76a0aab8c5d66d5557995faee5c1fb09#e494a36a76a0aab8c5d66d5557995faee5c1fb09"
 dependencies = [
  "base64ct",
  "bcs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15018,6 +15018,8 @@ dependencies = [
  "move-vm-types-v1",
  "move-vm-types-v2",
  "move-vm-types-v3",
+ "mysten-common",
+ "mysten-metrics",
  "petgraph 0.5.1",
  "sui-adapter-latest",
  "sui-adapter-v0",
@@ -15036,6 +15038,7 @@ dependencies = [
  "sui-verifier-v1",
  "sui-verifier-v2",
  "sui-verifier-v3",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/simulacrum/src/epoch_state.rs
+++ b/crates/simulacrum/src/epoch_state.rs
@@ -170,6 +170,11 @@ impl EpochState {
                 tx_digest,
                 &mut None,
             );
-        Ok((inner_temp_store, gas_status, effects, result))
+        Ok((
+            inner_temp_store,
+            gas_status,
+            effects,
+            result.map_err(sui_types::error::ExecutionError::from),
+        ))
     }
 }

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -139,7 +139,7 @@ use sui_types::effects::{
     InputConsensusObject, SignedTransactionEffects, TransactionEffects, TransactionEffectsAPI,
     TransactionEvents, VerifiedSignedTransactionEffects,
 };
-use sui_types::error::{ExecutionError, ExecutionErrorTrait, SuiErrorKind, UserInputError};
+use sui_types::error::{ExecutionError, SuiErrorKind, UserInputError};
 use sui_types::event::EventID;
 use sui_types::executable_transaction::VerifiedExecutableTransaction;
 use sui_types::execution_status::ExecutionErrorKind;

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -139,7 +139,7 @@ use sui_types::effects::{
     InputConsensusObject, SignedTransactionEffects, TransactionEffects, TransactionEffectsAPI,
     TransactionEvents, VerifiedSignedTransactionEffects,
 };
-use sui_types::error::{ExecutionError, SuiErrorKind, UserInputError};
+use sui_types::error::{ExecutionError, ExecutionErrorTrait, SuiErrorKind, UserInputError};
 use sui_types::event::EventID;
 use sui_types::executable_transaction::VerifiedExecutableTransaction;
 use sui_types::execution_status::ExecutionErrorKind;

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -139,7 +139,7 @@ use sui_types::effects::{
     InputConsensusObject, SignedTransactionEffects, TransactionEffects, TransactionEffectsAPI,
     TransactionEvents, VerifiedSignedTransactionEffects,
 };
-use sui_types::error::{ExecutionError, ExecutionErrorTrait, SuiErrorKind, UserInputError};
+use sui_types::error::{ExecutionError, SuiErrorKind, UserInputError};
 use sui_types::event::EventID;
 use sui_types::executable_transaction::VerifiedExecutableTransaction;
 use sui_types::execution_status::ExecutionErrorKind;
@@ -2437,7 +2437,7 @@ impl AuthorityState {
         let execution_error_source = execution_error
             .as_ref()
             .err()
-            .and_then(|e| e.source_ref().as_ref().map(|e| e.to_string()));
+            .and_then(|e| e.source().as_ref().map(|e| e.to_string()));
 
         Ok((
             DryRunTransactionBlockResponse {

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -139,7 +139,9 @@ use sui_types::effects::{
     InputConsensusObject, SignedTransactionEffects, TransactionEffects, TransactionEffectsAPI,
     TransactionEvents, VerifiedSignedTransactionEffects,
 };
-use sui_types::error::{ExecutionError, SuiErrorKind, UserInputError};
+use sui_types::error::{
+    ExecutionError, ExecutionErrorContext, ExecutionErrorMetadata, SuiErrorKind, UserInputError,
+};
 use sui_types::event::EventID;
 use sui_types::executable_transaction::VerifiedExecutableTransaction;
 use sui_types::execution_status::ExecutionErrorKind;
@@ -1455,7 +1457,7 @@ impl AuthorityState {
         certificate: &VerifiedExecutableTransaction,
         mut execution_env: ExecutionEnv,
         epoch_store: &Arc<AuthorityPerEpochStore>,
-    ) -> ExecutionOutput<(TransactionEffects, Option<ExecutionError>)> {
+    ) -> ExecutionOutput<(TransactionEffects, Option<ExecutionErrorContext>)> {
         let _scope = monitored_scope("Execution::try_execute_immediately");
         let _metrics_guard = self.metrics.internal_execution_latency.start_timer();
 
@@ -1637,7 +1639,10 @@ impl AuthorityState {
         &self,
         certificate: &VerifiedCertificate,
         execution_env: ExecutionEnv,
-    ) -> (VerifiedSignedTransactionEffects, Option<ExecutionError>) {
+    ) -> (
+        VerifiedSignedTransactionEffects,
+        Option<ExecutionErrorContext>,
+    ) {
         let epoch_store = self.epoch_store_for_testing();
         let (effects, execution_error_opt) = self
             .try_execute_immediately(
@@ -1655,7 +1660,10 @@ impl AuthorityState {
         &self,
         executable: &VerifiedExecutableTransaction,
         execution_env: ExecutionEnv,
-    ) -> (VerifiedSignedTransactionEffects, Option<ExecutionError>) {
+    ) -> (
+        VerifiedSignedTransactionEffects,
+        Option<ExecutionErrorContext>,
+    ) {
         let epoch_store = self.epoch_store_for_testing();
         let (effects, execution_error_opt) = self
             .try_execute_immediately(executable, execution_env, &epoch_store)
@@ -1731,7 +1739,7 @@ impl AuthorityState {
     ) -> ExecutionOutput<(
         TransactionOutputs,
         Vec<ExecutionTiming>,
-        Option<ExecutionError>,
+        Option<ExecutionErrorContext>,
     )> {
         let _scope = monitored_scope("Execution::process_certificate");
         let tx_digest = *certificate.digest();
@@ -1905,12 +1913,13 @@ impl AuthorityState {
         signer: SuiAddress,
         tx_digest: TransactionDigest,
         accumulator_version: Option<SequenceNumber>,
+        is_fullnode: bool,
     ) -> (
         InnerTemporaryStore,
         SuiGasStatus,
         TransactionEffects,
         Vec<ExecutionTiming>,
-        Result<(), ExecutionError>,
+        Result<(), ExecutionErrorContext>,
     ) {
         let rewritten_inputs = rewrite_transaction_for_coin_reservations(
             self.chain_identifier,
@@ -1920,33 +1929,56 @@ impl AuthorityState {
             accumulator_version,
         );
 
-        let (inner_temp_store, gas_status, effects, timings, execution_error) = executor
-            // TODO only run this function on FullNodes, use `execute_transaction_to_effects` on validators.
-            .execute_transaction_to_effects_and_execution_error(
-                store,
-                protocol_config,
-                self.metrics.execution_metrics.clone(),
-                enable_expensive_checks,
-                execution_params,
-                epoch_id,
-                epoch_timestamp_ms,
-                input_objects,
-                gas_data,
-                gas_status,
-                kind,
-                rewritten_inputs,
-                signer,
-                tx_digest,
-                &mut None,
-            );
+        if is_fullnode {
+            let (inner_temp_store, gas_status, effects, timings, execution_error) = executor
+                .execute_transaction_to_effects_and_execution_error(
+                    store,
+                    protocol_config,
+                    self.metrics.execution_metrics.clone(),
+                    enable_expensive_checks,
+                    execution_params,
+                    epoch_id,
+                    epoch_timestamp_ms,
+                    input_objects,
+                    gas_data,
+                    gas_status,
+                    kind,
+                    rewritten_inputs,
+                    signer,
+                    tx_digest,
+                    &mut None,
+                );
 
-        (
-            inner_temp_store,
-            gas_status,
-            effects,
-            timings,
-            execution_error,
-        )
+            (
+                inner_temp_store,
+                gas_status,
+                effects,
+                timings,
+                execution_error,
+            )
+        } else {
+            // TODO: _execution_failure is unused..
+            let (inner_temp_store, gas_status, effects, timings, _execution_failure) = executor
+                .execute_transaction_to_effects(
+                    store,
+                    protocol_config,
+                    self.metrics.execution_metrics.clone(),
+                    enable_expensive_checks,
+                    execution_params,
+                    epoch_id,
+                    epoch_timestamp_ms,
+                    input_objects,
+                    gas_data,
+                    gas_status,
+                    kind,
+                    rewritten_inputs,
+                    signer,
+                    tx_digest,
+                    &mut None,
+                );
+
+            (inner_temp_store, gas_status, effects, timings, Ok(()))
+        }
     }
 
     /// execute_certificate validates the transaction input, and executes the certificate,
@@ -1969,7 +2001,7 @@ impl AuthorityState {
     ) -> ExecutionOutput<(
         TransactionOutputs,
         Vec<ExecutionTiming>,
-        Option<ExecutionError>,
+        Option<ExecutionErrorContext>,
     )> {
         let _scope = monitored_scope("Execution::prepare_certificate");
         let _metrics_guard = self.metrics.prepare_certificate_latency.start_timer();
@@ -2018,7 +2050,7 @@ impl AuthorityState {
         let tracking_store = TrackingBackingStore::new(self.get_backing_store().as_ref());
 
         #[allow(unused_mut)]
-        let (inner_temp_store, _, mut effects, timings, execution_error_opt) = self
+        let (inner_temp_store, _, mut effects, timings, execution_error_result) = self
             .execute_transaction_to_effects(
                 &**epoch_store.executor(),
                 &tracking_store,
@@ -2042,7 +2074,10 @@ impl AuthorityState {
                 signer,
                 tx_digest,
                 execution_env.assigned_versions.accumulator_version,
+                self.is_fullnode(epoch_store),
             );
+
+        let execution_error_opt = execution_error_result.err();
 
         let object_funds_checker = self.object_funds_checker.load();
         if let Some(object_funds_checker) = object_funds_checker.as_ref()
@@ -2153,9 +2188,19 @@ impl AuthorityState {
                 &tracking_store.into_read_objects(),
             );
 
+        let execution_error_metadata = execution_error_opt
+            .as_ref()
+            .and_then(ExecutionErrorContext::metadata_with_source);
+
         // index certificate
         let _ = self
-            .post_process_one_tx(certificate, &effects, &inner_temp_store, epoch_store)
+            .post_process_one_tx(
+                certificate,
+                &effects,
+                &inner_temp_store,
+                epoch_store,
+                execution_error_metadata,
+            )
             .tap_err(|e| {
                 self.metrics.post_processing_total_failures.inc();
                 error!(?tx_digest, "tx post processing failed: {e}");
@@ -2181,7 +2226,7 @@ impl AuthorityState {
             );
         }
 
-        ExecutionOutput::Success((transaction_outputs, timings, execution_error_opt.err()))
+        ExecutionOutput::Success((transaction_outputs, timings, execution_error_opt))
     }
 
     pub fn prepare_certificate_for_benchmark(
@@ -2203,7 +2248,10 @@ impl AuthorityState {
                 epoch_store,
             )
             .unwrap();
-        Ok((transaction_outputs, execution_error_opt))
+        Ok((
+            transaction_outputs,
+            execution_error_opt.map(ExecutionError::from),
+        ))
     }
 
     #[instrument(skip_all)]
@@ -2391,6 +2439,7 @@ impl AuthorityState {
                 transaction_digest,
                 // Use latest accumulator version for dry run/dev inspect
                 None,
+                self.is_fullnode(epoch_store),
             );
 
         let tx_digest = *effects.transaction_digest();
@@ -2437,7 +2486,18 @@ impl AuthorityState {
         let execution_error_source = execution_error
             .as_ref()
             .err()
-            .and_then(|e| e.source().as_ref().map(|e| e.to_string()));
+            .and_then(|e| std::error::Error::source(e).map(|e| e.to_string()));
+        let error_metadata = execution_error
+            .as_ref()
+            .err()
+            .and_then(ExecutionErrorContext::metadata_with_source);
+        if let Some(error) = execution_error.as_ref().err() {
+            debug!(
+                tx_digest = ?tx_digest,
+                execution_error_kind = ?error.kind(),
+                "dry run transaction execution failed"
+            );
+        }
 
         Ok((
             DryRunTransactionBlockResponse {
@@ -2464,6 +2524,7 @@ impl AuthorityState {
                 object_changes,
                 balance_changes,
                 execution_error_source,
+                error_metadata,
             },
             written_with_kind,
             effects,
@@ -2731,7 +2792,7 @@ impl AuthorityState {
             objects: object_set,
             events: effects.events_digest().map(|_| inner_temp_store.events),
             effects,
-            execution_result,
+            execution_result: execution_result.map_err(ExecutionError::from),
             mock_gas_id,
             unchanged_loaded_runtime_objects,
             suggested_gas_price: self
@@ -2959,10 +3020,16 @@ impl AuthorityState {
                     self.get_backing_package_store(),
                 )));
 
+        let error_metadata = execution_result
+            .as_ref()
+            .err()
+            .and_then(ExecutionErrorContext::metadata_with_source);
+
         DevInspectResults::new(
             effects,
             inner_temp_store.events.clone(),
-            execution_result,
+            execution_result.map_err(ExecutionError::from),
+            error_metadata,
             raw_txn_data,
             raw_effects,
             layout_resolver.as_mut(),
@@ -2997,6 +3064,7 @@ impl AuthorityState {
         inner_temporary_store: &InnerTemporaryStore,
         epoch_store: &Arc<AuthorityPerEpochStore>,
         acquire_locks: bool,
+        execution_error_metadata: Option<ExecutionErrorMetadata>,
     ) -> SuiResult<(StagedBatch, IndexStoreCacheUpdatesWithLocks)> {
         let changes = Self::process_object_index(backing_package_store, object_store, effects, written, inner_temporary_store, epoch_store)
             .tap_err(|e| warn!(tx_digest=?digest, "Failed to process object index, index_tx is skipped: {e}"))?;
@@ -3029,6 +3097,7 @@ impl AuthorityState {
             tx_coins,
             effects.accumulator_events(),
             acquire_locks,
+            execution_error_metadata,
         )
     }
 
@@ -3373,6 +3442,7 @@ impl AuthorityState {
         effects: &TransactionEffects,
         inner_temporary_store: &InnerTemporaryStore,
         epoch_store: &Arc<AuthorityPerEpochStore>,
+        execution_error_metadata: Option<ExecutionErrorMetadata>,
     ) -> SuiResult {
         let Some(indexes) = &self.indexes else {
             return Ok(());
@@ -3401,6 +3471,7 @@ impl AuthorityState {
                 inner_temporary_store,
                 epoch_store,
                 true, // acquire_locks
+                execution_error_metadata.clone(),
             );
 
             match result {
@@ -3468,6 +3539,7 @@ impl AuthorityState {
                     &inner_temporary_store,
                     &epoch_store,
                     false, // acquire_locks
+                    execution_error_metadata,
                 );
 
                 match result {
@@ -3501,6 +3573,7 @@ impl AuthorityState {
         inner_temporary_store: &InnerTemporaryStore,
         epoch_store: &Arc<AuthorityPerEpochStore>,
         acquire_locks: bool,
+        execution_error_metadata: Option<ExecutionErrorMetadata>,
     ) -> SuiResult<(StagedBatch, IndexStoreCacheUpdatesWithLocks)> {
         let _scope = monitored_scope("Execution::post_process_one_tx");
 
@@ -3531,6 +3604,7 @@ impl AuthorityState {
             inner_temporary_store,
             epoch_store,
             acquire_locks,
+            execution_error_metadata,
         )
         .tap_ok(|_| metrics.post_processing_total_tx_indexed.inc())
         .tap_err(|e| error!(?tx_digest, "Post processing - Couldn't index tx: {e}"))

--- a/crates/sui-core/src/authority/authority_test_utils.rs
+++ b/crates/sui-core/src/authority/authority_test_utils.rs
@@ -120,7 +120,7 @@ pub async fn execute_from_consensus(
         .try_execute_executable_for_test(&executable, env)
         .await;
     let effects = result.inner().data().clone();
-    (effects, execution_error_opt)
+    (effects, execution_error_opt.map(ExecutionError::from))
 }
 
 /// This is the primary test helper for executing transactions end-to-end.
@@ -221,7 +221,11 @@ pub async fn submit_and_execute_with_error(
         execution_error_opt = fullnode_execution_error_opt;
     }
 
-    Ok((executable, result.into_inner(), execution_error_opt))
+    Ok((
+        executable,
+        result.into_inner(),
+        execution_error_opt.map(ExecutionError::from),
+    ))
 }
 
 /// Enqueues multiple transactions for execution after they've been through consensus.

--- a/crates/sui-core/src/jsonrpc_index.rs
+++ b/crates/sui-core/src/jsonrpc_index.rs
@@ -34,7 +34,7 @@ use sui_types::base_types::{ObjectInfo, ObjectRef};
 use sui_types::digests::TransactionEventsDigest;
 use sui_types::dynamic_field::{self, DynamicFieldInfo};
 use sui_types::effects::TransactionEvents;
-use sui_types::error::{SuiError, SuiErrorKind, SuiResult, UserInputError};
+use sui_types::error::{ExecutionErrorMetadata, SuiError, SuiErrorKind, SuiResult, UserInputError};
 use sui_types::inner_temporary_store::TxCoins;
 use sui_types::object::{Object, Owner};
 use sui_types::parse_sui_struct_tag;
@@ -52,6 +52,7 @@ type DynamicFieldKey = (ObjectID, ObjectID);
 type EventId = (TxSequenceNumber, usize);
 type EventIndex = (TransactionEventsDigest, TransactionDigest, u64);
 type AllBalance = HashMap<TypeTag, TotalBalance>;
+type ExecutionErrorMetadataIndexValue = (TxSequenceNumber, ExecutionErrorMetadata);
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Debug)]
 pub struct CoinIndexKey2 {
@@ -275,6 +276,9 @@ pub struct IndexStoreTables {
     event_by_time: DBMap<(u64, EventId), EventIndex>,
 
     pruner_watermark: DBMap<(), TxSequenceNumber>,
+
+    /// Index from transaction digest to execution error context metadata.
+    execution_error_metadata: DBMap<TransactionDigest, ExecutionErrorMetadataIndexValue>,
 }
 
 impl IndexStoreTables {
@@ -583,6 +587,7 @@ impl IndexStoreTables {
         // Skipped tables:
         // - transaction_order / transactions_seq: sequence numbers differ by design
         // - transactions_by_input_object_id / transactions_by_mutated_object_id: deprecated
+        // - execution_error_metadata: local execution context, not reconstructed during restore
         // - meta: metadata singleton, not meaningful to compare
         // - pruner_watermark: operational state
     }
@@ -838,6 +843,17 @@ impl IndexStore {
                     |(_, event_id): (u64, EventId)| event_id.0,
                 ),
             ),
+            (
+                "execution_error_metadata".to_string(),
+                compaction_filter_config(
+                    "execution_error_metadata",
+                    compaction_metrics.clone(),
+                    db_options.clone(),
+                    pruner_watermark.clone(),
+                    |(sequence_number, _): ExecutionErrorMetadataIndexValue| sequence_number,
+                    false,
+                ),
+            ),
         ]));
         let tables = IndexStoreTables::open_tables_read_write_with_deprecation_option(
             path,
@@ -1074,8 +1090,18 @@ impl IndexStore {
         tx_coins: Option<TxCoins>,
         accumulator_events: Vec<AccumulatorEvent>,
         acquire_locks: bool,
+        execution_error_metadata: Option<ExecutionErrorMetadata>,
     ) -> SuiResult<(StagedBatch, IndexStoreCacheUpdatesWithLocks)> {
         let mut batch = StagedBatch::new();
+
+        if let Some(metadata) = execution_error_metadata {
+            if !metadata.is_empty() {
+                batch.insert_batch(
+                    &self.tables.execution_error_metadata,
+                    std::iter::once((*digest, (sequence, metadata))),
+                )?;
+            }
+        }
 
         batch.insert_batch(
             &self.tables.transaction_order,
@@ -1232,6 +1258,33 @@ impl IndexStore {
         )?;
 
         Ok((batch, cache_updates))
+    }
+
+    pub fn get_execution_error_metadata(
+        &self,
+        digest: TransactionDigest,
+    ) -> SuiResult<Option<ExecutionErrorMetadata>> {
+        self.tables
+            .execution_error_metadata
+            .get(&digest)
+            .map(|value| value.map(|(_, metadata)| metadata))
+            .map_err(SuiError::from)
+    }
+
+    pub fn multi_get_execution_error_metadata(
+        &self,
+        digests: &[TransactionDigest],
+    ) -> SuiResult<Vec<Option<ExecutionErrorMetadata>>> {
+        self.tables
+            .execution_error_metadata
+            .multi_get(digests)
+            .map(|values| {
+                values
+                    .into_iter()
+                    .map(|value| value.map(|(_, metadata)| metadata))
+                    .collect()
+            })
+            .map_err(SuiError::from)
     }
 
     /// Write a combined index batch and apply cache updates.
@@ -2293,6 +2346,58 @@ mod tests {
     use sui_types::object::Owner;
 
     #[tokio::test]
+    async fn test_execution_error_metadata_index_round_trip() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let index_store = IndexStore::new_without_init(
+            temp_dir.path().to_path_buf(),
+            &Registry::default(),
+            Some(128),
+            false,
+        );
+        let address: SuiAddress = AccountAddress::random().into();
+        let digest = TransactionDigest::random();
+        let missing_digest = TransactionDigest::random();
+        let seq = index_store.allocate_sequence_number();
+        let mut metadata = BTreeMap::new();
+        metadata.insert("source".to_string(), "VMError".to_string());
+
+        let (raw_batch, cache_updates) = index_store.index_tx(
+            seq,
+            address,
+            vec![].into_iter(),
+            vec![].into_iter(),
+            vec![].into_iter(),
+            &TransactionEvents { data: vec![] },
+            ObjectIndexChanges {
+                deleted_owners: vec![],
+                deleted_dynamic_fields: vec![],
+                new_owners: vec![],
+                new_dynamic_fields: vec![],
+            },
+            &digest,
+            1234,
+            None,
+            vec![],
+            false,
+            Some(metadata.clone()),
+        )?;
+        let mut db_batch = index_store.new_db_batch();
+        db_batch.concat(vec![raw_batch]).unwrap();
+        index_store.commit_index_batch(db_batch, vec![cache_updates.into_inner()])?;
+
+        assert_eq!(
+            index_store.get_execution_error_metadata(digest)?,
+            Some(metadata.clone())
+        );
+        assert_eq!(
+            index_store.multi_get_execution_error_metadata(&[digest, missing_digest])?,
+            vec![Some(metadata), None]
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_index_cache() -> anyhow::Result<()> {
         // This test is going to invoke `index_tx()`where 10 coins each with balance 100
         // are going to be added to an address. The balance is then going to be read from the db
@@ -2347,6 +2452,7 @@ mod tests {
             Some(tx_coins),
             vec![],
             false,
+            None,
         )?;
         // Commit the batch so subsequent reads see the data
         let mut db_batch = index_store.new_db_batch();
@@ -2399,6 +2505,7 @@ mod tests {
             Some(tx_coins),
             vec![],
             false,
+            None,
         )?;
         let mut db_batch = index_store.new_db_batch();
         db_batch.concat(vec![raw_batch]).unwrap();

--- a/crates/sui-indexer-alt-jsonrpc/src/api/write/response.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/write/response.rs
@@ -97,6 +97,13 @@ pub(super) async fn dry_run(
 ) -> Result<DryRunTransactionBlockResponse, RpcError<Error>> {
     let effects = deserialize_effects(executed_tx)?;
     let tx_digest = tx_data.digest();
+    let error_metadata = executed_tx
+        .effects
+        .as_ref()
+        .and_then(|effects| effects.status.as_ref())
+        .and_then(|status| status.error.as_ref())
+        .map(|error| error.metadata.clone())
+        .filter(|metadata| !metadata.is_empty());
 
     Ok(DryRunTransactionBlockResponse {
         effects: effects_response(&effects)?,
@@ -105,6 +112,7 @@ pub(super) async fn dry_run(
         balance_changes: balance_changes(executed_tx)?,
         input: input(ctx, tx_data, vec![]).await?.data,
         execution_error_source: None,
+        error_metadata,
         suggested_gas_price,
     })
 }

--- a/crates/sui-json-rpc-tests/tests/transaction_tests.rs
+++ b/crates/sui-json-rpc-tests/tests/transaction_tests.rs
@@ -9,13 +9,13 @@ use std::str::FromStr;
 use move_core_types::identifier::Identifier;
 use sui_json::{call_args, type_args};
 use sui_json_rpc_api::ReadApiClient;
-use sui_json_rpc_types::SuiTransactionBlockDataAPI;
 use sui_json_rpc_types::SuiTransactionBlockResponseQuery;
 use sui_json_rpc_types::TransactionFilter;
 use sui_json_rpc_types::{
     SuiObjectDataOptions, SuiObjectResponseQuery, SuiTransactionBlockResponse,
     SuiTransactionBlockResponseOptions, TransactionBlockBytes,
 };
+use sui_json_rpc_types::{SuiTransactionBlockDataAPI, SuiTransactionBlockEffectsAPI};
 use sui_macros::sim_test;
 use sui_types::SUI_FRAMEWORK_ADDRESS;
 use sui_types::base_types::ObjectID;
@@ -528,4 +528,133 @@ async fn test_display_transaction_block_with_empty_balance_changes() {
     assert!(tx_block.balance_changes.as_ref().unwrap().is_empty());
 
     let _ = tx_block.to_string();
+}
+
+#[sim_test]
+async fn test_execution_error_metadata_in_response() -> Result<(), anyhow::Error> {
+    let mut cluster = TestClusterBuilder::new().build().await;
+    let client = cluster.sui_client().clone();
+    let address = cluster.get_address_0();
+
+    let objects = client
+        .read_api()
+        .get_owned_objects(
+            address,
+            Some(SuiObjectResponseQuery::new_with_options(
+                SuiObjectDataOptions::new()
+                    .with_type()
+                    .with_owner()
+                    .with_previous_transaction(),
+            )),
+            None,
+            None,
+        )
+        .await?
+        .data;
+
+    let coin = objects.first().unwrap();
+    let gas = objects.last().unwrap().object().unwrap().object_ref();
+    let signer = cluster.wallet.active_address().unwrap();
+
+    let package_id = ObjectID::new(SUI_FRAMEWORK_ADDRESS.into_bytes());
+    let module = Identifier::from_str("pay")?;
+    let function = Identifier::from_str("divide_and_keep")?;
+
+    let sui_type_args = type_args![GAS::type_tag()]?;
+    let type_args = sui_type_args
+        .into_iter()
+        .map(|ty| ty.try_into())
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let sui_call_args = call_args!(coin.data.clone().unwrap().object_id, 0u64)?;
+
+    let mut pt_builder = ProgrammableTransactionBuilder::new();
+    let call_args = client
+        .transaction_builder()
+        .resolve_and_checks_json_args(
+            &mut pt_builder,
+            package_id,
+            &module,
+            &function,
+            &type_args,
+            sui_call_args,
+        )
+        .await?;
+
+    let cmd = Command::move_call(package_id, module, function, type_args, call_args);
+    pt_builder.command(cmd);
+    let pt = pt_builder.finish();
+
+    let tx_data = TransactionData::new_programmable(signer, vec![gas], pt, 10_000_000, 1000);
+    let dry_run_response = client
+        .read_api()
+        .dry_run_transaction_block(tx_data.clone())
+        .await?;
+    let dry_run_error_metadata = dry_run_response
+        .error_metadata
+        .as_ref()
+        .expect("Dry run execution error metadata should be present for failing transactions");
+    assert!(
+        !dry_run_error_metadata.is_empty(),
+        "Dry run metadata shouldn't be empty"
+    );
+    if let Some(source) = &dry_run_response.execution_error_source {
+        assert_eq!(dry_run_error_metadata.get("source"), Some(source));
+    }
+
+    let signed_data = cluster.wallet.sign_transaction(&tx_data).await;
+
+    let execution_response = client
+        .quorum_driver_api()
+        .execute_transaction_block(
+            signed_data,
+            SuiTransactionBlockResponseOptions::new().with_effects(),
+            Some(ExecuteTransactionRequestType::WaitForLocalExecution),
+        )
+        .await
+        .unwrap();
+
+    let response = client
+        .read_api()
+        .get_transaction_with_options(
+            execution_response.digest,
+            SuiTransactionBlockResponseOptions::new().with_effects(),
+        )
+        .await?;
+
+    let error_metadata = response.error_metadata;
+    let effects = response.effects.unwrap();
+    let status = effects.into_status();
+    match status {
+        sui_json_rpc_types::SuiExecutionStatus::Failure { error } => {
+            assert!(
+                error.contains("MoveAbort")
+                    || error.contains("DivideByZero")
+                    || error.contains("E_DIVIDE_BY_ZERO")
+                    || error.contains("divide by zero")
+                    || error.contains("ArithmeticError"),
+                "Error was: {}",
+                error
+            );
+            assert!(
+                error_metadata.is_some(),
+                "Execution error metadata should be present for failing transactions"
+            );
+            let metadata = error_metadata.as_ref().unwrap();
+            assert!(!metadata.is_empty(), "Metadata shouldn't be empty");
+        }
+        _ => panic!("Expected execution failure, got {:?}", status),
+    }
+
+    let responses = client
+        .read_api()
+        .multi_get_transactions_with_options(
+            vec![execution_response.digest],
+            SuiTransactionBlockResponseOptions::new().with_effects(),
+        )
+        .await?;
+    assert_eq!(1, responses.len());
+    assert_eq!(error_metadata, responses[0].error_metadata);
+
+    Ok(())
 }

--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -38,7 +38,7 @@ use sui_types::effects::{
     AccumulatorOperation, AccumulatorValue, TransactionEffects, TransactionEffectsAPI,
     TransactionEvents,
 };
-use sui_types::error::{ExecutionError, SuiError, SuiResult};
+use sui_types::error::{ExecutionError, ExecutionErrorMetadata, SuiError, SuiResult};
 use sui_types::execution_status::{ExecutionFailure, ExecutionStatus};
 use sui_types::gas::GasCostSummary;
 use sui_types::layout_resolver::{LayoutResolver, get_layout_from_struct_tag};
@@ -251,6 +251,8 @@ pub struct SuiTransactionBlockResponse {
     pub errors: Vec<String>,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub raw_effects: Vec<u8>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error_metadata: Option<ExecutionErrorMetadata>,
 }
 
 impl SuiTransactionBlockResponse {
@@ -1220,6 +1222,8 @@ pub struct DryRunTransactionBlockResponse {
     pub balance_changes: Vec<BalanceChange>,
     pub input: SuiTransactionBlockData,
     pub execution_error_source: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error_metadata: Option<ExecutionErrorMetadata>,
     // If an input object is congested, suggest a gas price to use.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schemars(with = "Option<BigInt<u64>>")]
@@ -1331,6 +1335,9 @@ pub struct DevInspectResults {
     /// Execution error from executing the transactions
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
+    /// Execution error metadata from executing the transactions
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error_metadata: Option<ExecutionErrorMetadata>,
     /// The raw transaction data that was dev inspected.
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub raw_txn_data: Vec<u8>,
@@ -1361,6 +1368,7 @@ impl DevInspectResults {
         effects: TransactionEffects,
         events: TransactionEvents,
         return_values: Result<Vec<ExecutionResult>, ExecutionError>,
+        error_metadata: Option<ExecutionErrorMetadata>,
         raw_txn_data: Vec<u8>,
         raw_effects: Vec<u8>,
         resolver: &mut dyn LayoutResolver,
@@ -1397,6 +1405,7 @@ impl DevInspectResults {
             events: SuiTransactionBlockEvents::try_from(events, tx_digest, None, resolver)?,
             results,
             error,
+            error_metadata,
             raw_txn_data,
             raw_effects,
         })

--- a/crates/sui-json-rpc/src/authority_state.rs
+++ b/crates/sui-json-rpc/src/authority_state.rs
@@ -30,7 +30,7 @@ use sui_types::committee::{Committee, EpochId};
 use sui_types::digests::{ChainIdentifier, TransactionDigest};
 use sui_types::dynamic_field::DynamicFieldInfo;
 use sui_types::effects::TransactionEffects;
-use sui_types::error::{SuiError, SuiErrorKind, SuiResult, UserInputError};
+use sui_types::error::{ExecutionErrorMetadata, SuiError, SuiErrorKind, SuiResult, UserInputError};
 use sui_types::event::EventID;
 use sui_types::governance::StakedSui;
 use sui_types::messages_checkpoint::{
@@ -61,6 +61,11 @@ pub trait StateRead: Send + Sync {
         transactions: &[TransactionDigest],
         effects: &[TransactionDigest],
     ) -> StateReadResult<KVStoreTransactionData>;
+
+    fn multi_get_execution_error_metadata(
+        &self,
+        digests: &[TransactionDigest],
+    ) -> StateReadResult<Vec<Option<ExecutionErrorMetadata>>>;
 
     fn get_object_read(&self, object_id: &ObjectID) -> StateReadResult<ObjectRead>;
 
@@ -246,6 +251,17 @@ impl StateRead for AuthorityState {
             )
             .await?,
         )
+    }
+
+    fn multi_get_execution_error_metadata(
+        &self,
+        digests: &[TransactionDigest],
+    ) -> StateReadResult<Vec<Option<ExecutionErrorMetadata>>> {
+        let Some(indexes) = &self.indexes else {
+            return Ok(vec![None; digests.len()]);
+        };
+
+        Ok(indexes.multi_get_execution_error_metadata(digests)?)
     }
 
     fn get_object_read(&self, object_id: &ObjectID) -> StateReadResult<ObjectRead> {

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -54,7 +54,7 @@ use sui_types::crypto::AggregateAuthoritySignature;
 use sui_types::display::DisplayVersionUpdatedEvent;
 use sui_types::display_registry;
 use sui_types::effects::{TransactionEffects, TransactionEffectsAPI, TransactionEvents};
-use sui_types::error::{SuiError, SuiObjectResponseError};
+use sui_types::error::{ExecutionErrorMetadata, SuiError, SuiObjectResponseError};
 use sui_types::messages_checkpoint::{
     CheckpointContents, CheckpointSequenceNumber, CheckpointSummary, CheckpointTimestamp,
 };
@@ -200,6 +200,7 @@ struct IntermediateTransactionResponse {
     digest: TransactionDigest,
     transaction: Option<Transaction>,
     effects: Option<TransactionEffects>,
+    error_metadata: Option<ExecutionErrorMetadata>,
     events: Option<SuiTransactionBlockEvents>,
     checkpoint_seq: Option<CheckpointSequenceNumber>,
     balance_changes: Option<Vec<BalanceChange>>,
@@ -371,10 +372,47 @@ impl ReadApi {
                 .tap_err(
                     |err| debug!(digests=?digests_clone, "Failed to multi get effects for transactions: {:?}", err),
                 )?;
-            for ((_digest, cache_entry), e) in temp_response
+
+            let mut failed_digests = vec![];
+            for (digest, e) in digests.iter().zip(effects_list.iter()) {
+                if let Some(effects) = e {
+                    if effects.status().is_err() {
+                        failed_digests.push(*digest);
+                    }
+                }
+            }
+
+            let mut error_metadata_map = HashMap::new();
+            if !failed_digests.is_empty() {
+                match self
+                    .state
+                    .multi_get_execution_error_metadata(&failed_digests)
+                {
+                    Ok(metadata_list) => {
+                        for (digest, metadata) in failed_digests
+                            .iter()
+                            .copied()
+                            .zip(metadata_list.into_iter())
+                        {
+                            if let Some(metadata) = metadata {
+                                error_metadata_map.insert(digest, metadata);
+                            }
+                        }
+                    }
+                    Err(err) => {
+                        debug!(
+                            ?failed_digests,
+                            "Failed to get execution error metadata: {err:?}"
+                        );
+                    }
+                }
+            }
+
+            for ((digest, cache_entry), e) in temp_response
                 .iter_mut()
                 .zip_debug_eq(effects_list.into_iter())
             {
+                cache_entry.error_metadata = error_metadata_map.remove(*digest);
                 cache_entry.effects = e;
             }
         }
@@ -897,18 +935,30 @@ impl ReadApiServer for ReadApi {
                 temp_response.transaction = Some(transaction);
             }
 
-            // Fetch effects when `show_events` is true because events relies on effects
             if opts.require_effects() {
                 let transaction_kv_store = self.transaction_kv_store.clone();
-                temp_response.effects = Some(
-                    transaction_kv_store
-                        .get_fx_by_tx_digest(digest)
-                        .await
-                        .map_err(|err| {
-                            debug!(tx_digest=?digest, "Failed to get effects: {:?}", err);
-                            Error::from(err)
-                        })?,
-                );
+                let effects = transaction_kv_store
+                    .get_fx_by_tx_digest(digest)
+                    .await
+                    .map_err(|err| {
+                        debug!(tx_digest=?digest, "Failed to get effects: {:?}", err);
+                        Error::from(err)
+                    })?;
+
+                if effects.status().is_err() {
+                    match self.state.multi_get_execution_error_metadata(&[digest]) {
+                        Ok(mut metadata) => {
+                            temp_response.error_metadata = metadata.pop().flatten();
+                        }
+                        Err(err) => {
+                            debug!(
+                                tx_digest = ?digest,
+                                "Failed to get execution error metadata: {err:?}"
+                            );
+                        }
+                    }
+                }
+                temp_response.effects = Some(effects);
             }
 
             temp_response.checkpoint_seq = self
@@ -1522,6 +1572,8 @@ fn convert_to_response(
     }
 
     if let Some(effects) = cache.effects {
+        let is_failure = effects.status().is_err();
+
         if opts.show_raw_effects {
             response.raw_effects = bcs::to_bytes(&effects).map_err(|e| {
                 // TODO: is this a client or server error?
@@ -1534,6 +1586,10 @@ fn convert_to_response(
                 // TODO: is this a client or server error?
                 anyhow!("Failed to convert transaction block effects with error: {e}")
             })?);
+        }
+
+        if is_failure && (opts.show_effects || opts.show_raw_effects) {
+            response.error_metadata = cache.error_metadata;
         }
     }
 

--- a/crates/sui-json-rpc/src/transaction_execution_api.rs
+++ b/crates/sui-json-rpc/src/transaction_execution_api.rs
@@ -262,6 +262,7 @@ impl TransactionExecutionApi {
             checkpoint: None,
             errors: vec![],
             raw_effects,
+            error_metadata: None,
         })
     }
 
@@ -319,6 +320,7 @@ impl TransactionExecutionApi {
             balance_changes,
             input: resp.input,
             execution_error_source: resp.execution_error_source,
+            error_metadata: resp.error_metadata,
             suggested_gas_price: resp.suggested_gas_price,
         })
     }

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -6194,6 +6194,16 @@
               "null"
             ]
           },
+          "errorMetadata": {
+            "description": "Execution error metadata from executing the transactions",
+            "type": [
+              "object",
+              "null"
+            ],
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
           "events": {
             "description": "Events that likely would be generated if the transaction is actually run.",
             "type": "array",
@@ -6281,6 +6291,15 @@
           },
           "effects": {
             "$ref": "#/components/schemas/TransactionBlockEffects"
+          },
+          "errorMetadata": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "additionalProperties": {
+              "type": "string"
+            }
           },
           "events": {
             "type": "array",
@@ -11301,6 +11320,15 @@
                 "type": "null"
               }
             ]
+          },
+          "errorMetadata": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "additionalProperties": {
+              "type": "string"
+            }
           },
           "errors": {
             "type": "array",

--- a/crates/sui-open-rpc/tests/examples.rs
+++ b/crates/sui-open-rpc/tests/examples.rs
@@ -282,6 +282,7 @@ impl RpcExampleProvider {
             events: SuiTransactionBlockEvents { data: vec![] },
             results: None,
             error: None,
+            error_metadata: None,
             raw_txn_data: vec![],
             raw_effects: vec![],
         };
@@ -784,6 +785,7 @@ impl RpcExampleProvider {
             checkpoint: None,
             errors: vec![],
             raw_effects: vec![],
+            error_metadata: None,
         };
 
         (data2, signatures, recipient, obj_id, result)

--- a/crates/sui-open-rpc/tests/snapshots/generate_spec__openrpc.snap.json
+++ b/crates/sui-open-rpc/tests/snapshots/generate_spec__openrpc.snap.json
@@ -6215,6 +6215,16 @@
               "null"
             ]
           },
+          "errorMetadata": {
+            "description": "Execution error metadata from executing the transactions",
+            "type": [
+              "object",
+              "null"
+            ],
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
           "events": {
             "description": "Events that likely would be generated if the transaction is actually run.",
             "type": "array",
@@ -6300,6 +6310,15 @@
           },
           "effects": {
             "$ref": "#/components/schemas/TransactionBlockEffects"
+          },
+          "errorMetadata": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "additionalProperties": {
+              "type": "string"
+            }
           },
           "events": {
             "type": "array",
@@ -11320,6 +11339,15 @@
                 "type": "null"
               }
             ]
+          },
+          "errorMetadata": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "additionalProperties": {
+              "type": "string"
+            }
           },
           "errors": {
             "type": "array",

--- a/crates/sui-replay-2/src/execution.rs
+++ b/crates/sui-replay-2/src/execution.rs
@@ -148,6 +148,7 @@ pub fn execute_transaction_to_effects(
             digest,
             trace_builder_opt,
         );
+    let result = result.map_err(ExecutionError::from);
     let ReplayStore {
         object_cache,
         checkpoint: _,

--- a/crates/sui-replay/src/replay.rs
+++ b/crates/sui-replay/src/replay.rs
@@ -810,6 +810,7 @@ impl LocalExec {
                 *tx_digest,
                 &mut None,
             );
+        let result = result.map_err(ExecutionError::from);
 
         if let Err(err) = self.pretty_print_for_tracing(
             &gas_status,
@@ -1005,6 +1006,7 @@ impl LocalExec {
                 *executable.digest(),
                 &mut None,
             );
+        let exec_res = exec_res.map_err(ExecutionError::from);
 
         let effects =
             SuiTransactionBlockEffects::try_from(effects).map_err(ReplayEngineError::from)?;

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -1166,8 +1166,6 @@ pub trait ExecutionErrorTrait:
     fn with_command_index(self, command: CommandIndex) -> Self;
     fn kind(&self) -> &ExecutionErrorKind;
     fn command(&self) -> Option<CommandIndex>;
-    // TODO remove, source ref should be used before instantiating this trait or after making it concrete
-    fn source_ref(&self) -> Option<&(dyn std::error::Error + 'static)>;
 
     fn to_execution_failure(&self) -> ExecutionFailure {
         ExecutionFailure {
@@ -1245,10 +1243,6 @@ impl ExecutionErrorTrait for ExecutionError {
 
     fn command(&self) -> Option<CommandIndex> {
         self.command()
-    }
-
-    fn source_ref(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        self.inner.source.as_deref().map(|e| e as _)
     }
 }
 

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -1158,20 +1158,43 @@ impl std::fmt::Debug for SuiError {
 }
 
 pub(crate) type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
+pub type ExecutionErrorMetadata = BTreeMap<String, String>;
 
 /// A trait for execution errors that provides common methods for accessing error information and creating new errors.
 pub trait ExecutionErrorTrait:
-    From<ExecutionError> + Debug + std::error::Error + Send + Sync + Sized
+    From<ExecutionError> + Debug + std::error::Error + Send + Sync + Sized + 'static
 {
+    fn new(
+        failure: ExecutionFailure,
+        source: Option<BoxError>,
+        metadata: ExecutionErrorMetadata,
+    ) -> Self;
+
+    fn from_execution_failure(failure: ExecutionFailure) -> Self {
+        Self::new(failure, None, ExecutionErrorMetadata::default())
+    }
+
+    fn from_kind(kind: ExecutionErrorKind) -> Self {
+        Self::from_execution_failure(ExecutionFailure::new(kind, None))
+    }
+
+    fn new_with_source<E>(kind: ExecutionErrorKind, source: E) -> Self
+    where
+        E: Into<BoxError>,
+    {
+        Self::new(
+            ExecutionFailure::new(kind, None),
+            Some(source.into()),
+            ExecutionErrorMetadata::default(),
+        )
+    }
+
     fn with_command_index(self, command: CommandIndex) -> Self;
     fn kind(&self) -> &ExecutionErrorKind;
     fn command(&self) -> Option<CommandIndex>;
 
     fn to_execution_failure(&self) -> ExecutionFailure {
-        ExecutionFailure {
-            error: self.kind().clone(),
-            command: self.command(),
-        }
+        ExecutionFailure::new(self.kind().clone(), self.command())
     }
 }
 
@@ -1233,6 +1256,20 @@ impl ExecutionError {
 }
 
 impl ExecutionErrorTrait for ExecutionError {
+    fn new(
+        failure: ExecutionFailure,
+        source: Option<BoxError>,
+        _metadata: ExecutionErrorMetadata,
+    ) -> Self {
+        let ExecutionFailure { error, command } = failure;
+        let err = ExecutionError::new(error, source);
+        if let Some(command) = command {
+            err.with_command_index(command)
+        } else {
+            err
+        }
+    }
+
     fn with_command_index(self, command: CommandIndex) -> Self {
         self.with_command_index(command)
     }
@@ -1243,6 +1280,126 @@ impl ExecutionErrorTrait for ExecutionError {
 
     fn command(&self) -> Option<CommandIndex> {
         self.command()
+    }
+}
+
+#[derive(Debug)]
+pub struct ExecutionErrorContext {
+    kind: ExecutionErrorKind,
+    metadata: ExecutionErrorMetadata,
+    source: Option<BoxError>,
+    command: Option<CommandIndex>,
+}
+
+impl ExecutionErrorContext {
+    pub fn kind(&self) -> &ExecutionErrorKind {
+        &self.kind
+    }
+
+    pub fn command(&self) -> Option<CommandIndex> {
+        self.command
+    }
+
+    pub fn metadata_with_source(&self) -> Option<ExecutionErrorMetadata> {
+        let mut metadata = self.metadata.clone();
+        if let Some(source) = self.source.as_ref() {
+            metadata.insert("source".to_string(), source.to_string());
+        }
+
+        (!metadata.is_empty()).then_some(metadata)
+    }
+
+    pub fn to_execution_status(&self) -> (ExecutionErrorKind, Option<CommandIndex>) {
+        (self.kind().clone(), self.command())
+    }
+}
+
+impl ExecutionErrorTrait for ExecutionErrorContext {
+    fn new(
+        failure: ExecutionFailure,
+        source: Option<BoxError>,
+        metadata: ExecutionErrorMetadata,
+    ) -> Self {
+        let ExecutionFailure { error, command } = failure;
+        Self {
+            kind: error,
+            metadata,
+            source,
+            command,
+        }
+    }
+
+    fn with_command_index(self, command: CommandIndex) -> Self {
+        Self {
+            command: Some(command),
+            ..self
+        }
+    }
+
+    fn kind(&self) -> &ExecutionErrorKind {
+        self.kind()
+    }
+
+    fn command(&self) -> Option<CommandIndex> {
+        self.command()
+    }
+}
+
+impl std::fmt::Display for ExecutionErrorContext {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "ExecutionErrorContext: {:?}", self)
+    }
+}
+
+impl std::error::Error for ExecutionErrorContext {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.source.as_deref().map(|e| e as _)
+    }
+}
+
+impl From<ExecutionErrorKind> for ExecutionErrorContext {
+    fn from(kind: ExecutionErrorKind) -> Self {
+        <Self as ExecutionErrorTrait>::from_kind(kind)
+    }
+}
+
+impl From<ExecutionFailure> for ExecutionErrorContext {
+    fn from(value: ExecutionFailure) -> Self {
+        <Self as ExecutionErrorTrait>::from_execution_failure(value)
+    }
+}
+
+impl From<ExecutionError> for ExecutionErrorContext {
+    fn from(value: ExecutionError) -> Self {
+        let ExecutionError { inner } = value;
+        let ExecutionErrorInner {
+            kind,
+            source,
+            command,
+        } = *inner;
+        Self {
+            kind,
+            metadata: BTreeMap::new(),
+            source,
+            command,
+        }
+    }
+}
+
+impl From<ExecutionErrorContext> for ExecutionError {
+    fn from(value: ExecutionErrorContext) -> Self {
+        let ExecutionErrorContext {
+            kind,
+            metadata: _,
+            source,
+            command,
+        } = value;
+        let err = ExecutionError::new(kind, source);
+        if let Some(command) = command {
+            err.with_command_index(command)
+        } else {
+            err
+        }
     }
 }
 
@@ -1266,13 +1423,7 @@ impl From<ExecutionErrorKind> for ExecutionError {
 
 impl From<ExecutionFailure> for ExecutionError {
     fn from(value: ExecutionFailure) -> Self {
-        let ExecutionFailure { error, command } = value;
-        let err = ExecutionError::from_kind(error);
-        if let Some(command) = command {
-            err.with_command_index(command)
-        } else {
-            err
-        }
+        <Self as ExecutionErrorTrait>::from_execution_failure(value)
     }
 }
 

--- a/crates/sui-types/src/execution_status.rs
+++ b/crates/sui-types/src/execution_status.rs
@@ -3,7 +3,7 @@
 
 use crate::ObjectID;
 use crate::base_types::SuiAddress;
-use crate::error::{ExecutionError, ExecutionErrorTrait};
+use crate::error::{BoxError, ExecutionError, ExecutionErrorMetadata, ExecutionErrorTrait};
 use move_binary_format::file_format::{CodeOffset, TypeParameterIndex};
 use move_core_types::language_storage::ModuleId;
 use serde::{Deserialize, Serialize};
@@ -53,6 +53,14 @@ impl Display for ExecutionFailure {
 }
 
 impl ExecutionErrorTrait for ExecutionFailure {
+    fn new(
+        failure: ExecutionFailure,
+        _source: Option<BoxError>,
+        _metadata: ExecutionErrorMetadata,
+    ) -> Self {
+        failure
+    }
+
     fn with_command_index(self, command: CommandIndex) -> Self {
         Self {
             command: Some(command),

--- a/crates/sui-types/src/execution_status.rs
+++ b/crates/sui-types/src/execution_status.rs
@@ -65,9 +65,6 @@ impl ExecutionErrorTrait for ExecutionFailure {
     fn command(&self) -> Option<CommandIndex> {
         self.command
     }
-    fn source_ref(&self) -> Option<&(dyn Error + 'static)> {
-        None
-    }
 }
 
 #[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize)]

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -2725,6 +2725,7 @@ fn to_legacy_dry_run_transaction_block_response(
         balance_changes: to_legacy_balance_changes(&response.transaction),
         input,
         execution_error_source,
+        error_metadata: None,
         suggested_gas_price: response.suggested_gas_price,
     })
 }

--- a/external-crates/move/Cargo.lock
+++ b/external-crates/move/Cargo.lock
@@ -6356,3 +6356,15 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
+
+[[patch.unused]]
+name = "sui-crypto"
+version = "0.3.0"
+
+[[patch.unused]]
+name = "sui-rpc"
+version = "0.3.0"
+
+[[patch.unused]]
+name = "sui-sdk-types"
+version = "0.3.0"

--- a/sui-execution/Cargo.toml
+++ b/sui-execution/Cargo.toml
@@ -8,8 +8,11 @@ publish = false
 edition = "2024"
 
 [dependencies]
+mysten-common.workspace = true
+mysten-metrics.workspace = true
 sui-protocol-config.workspace = true
 sui-types.workspace = true
+tracing.workspace = true
 
 move-binary-format.workspace = true
 move-bytecode-verifier-meter.workspace = true

--- a/sui-execution/Cargo.toml
+++ b/sui-execution/Cargo.toml
@@ -7,6 +7,9 @@ license = "Apache-2.0"
 publish = false
 edition = "2024"
 
+[lints]
+workspace = true
+
 [dependencies]
 mysten-common.workspace = true
 mysten-metrics.workspace = true

--- a/sui-execution/latest/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/latest/sui-adapter/src/execution_engine.rs
@@ -769,9 +769,7 @@ mod checked {
                 rewritten_inputs,
                 pt,
                 trace_builder_opt,
-            )
-            // TODO push Mode::Error lower into the call stack and remove into()
-            .map_err(|(e, timings)| (e.into(), timings)),
+            ),
             TransactionKind::ProgrammableSystemTransaction(pt) => {
                 SPT::execute::<execution_mode::System<Mode::Error>>(
                     protocol_config,
@@ -785,8 +783,7 @@ mod checked {
                     pt,
                     trace_builder_opt,
                 )
-                // TODO push Mode::Error lower into the call stack and remove into()
-                .map_err(|(e, _)| (e.into(), vec![]))?;
+                .map_err(|(e, _)| (e, vec![]))?;
                 Ok((Mode::empty_results(), vec![]))
             }
             TransactionKind::EndOfEpochTransaction(txns) => {
@@ -916,9 +913,8 @@ mod checked {
             }
         }?;
         temporary_store
-            .check_execution_results_consistency()
-            // TODO push Mode::Error lower into the call stack and remove into()
-            .map_err(|e| (e.into(), vec![]))?;
+            .check_execution_results_consistency::<Mode::Error>()
+            .map_err(|e| (e, vec![]))?;
         Ok(result)
     }
 
@@ -956,10 +952,10 @@ mod checked {
         (storage_rewards, computation_rewards)
     }
 
-    pub fn construct_advance_epoch_pt(
+    pub fn construct_advance_epoch_pt<E: ExecutionErrorTrait>(
         mut builder: ProgrammableTransactionBuilder,
         params: &AdvanceEpochParams,
-    ) -> Result<ProgrammableTransaction, ExecutionError> {
+    ) -> Result<ProgrammableTransaction, E> {
         // Step 1: Create storage and computation rewards.
         let (storage_rewards, computation_rewards) = mint_epoch_rewards_in_pt(&mut builder, params);
 
@@ -1077,9 +1073,8 @@ mod checked {
             reward_slashing_rate: protocol_config.reward_slashing_rate(),
             epoch_start_timestamp_ms: change_epoch.epoch_start_timestamp_ms,
         };
-        // TODO push Mode::Error lower into the call stack and remove (implicit) into()
-        let advance_epoch_pt = construct_advance_epoch_pt(builder, &params)?;
-        let result = SPT::execute::<execution_mode::System>(
+        let advance_epoch_pt = construct_advance_epoch_pt::<Mode::Error>(builder, &params)?;
+        let result = SPT::execute::<execution_mode::System<Mode::Error>>(
             protocol_config,
             metrics.clone(),
             move_vm,
@@ -1231,7 +1226,7 @@ mod checked {
             );
             builder.finish()
         };
-        SPT::execute::<execution_mode::System>(
+        SPT::execute::<execution_mode::System<Mode::Error>>(
             protocol_config,
             metrics,
             move_vm,
@@ -1243,7 +1238,6 @@ mod checked {
             pt,
             trace_builder_opt,
         )
-        // TODO push Mode::Error lower into the call stack and remove (implicit) into()
         .map_err(|(e, _)| e)?;
         Ok(())
     }
@@ -1380,7 +1374,7 @@ mod checked {
             );
             builder.finish()
         };
-        SPT::execute::<execution_mode::System>(
+        SPT::execute::<execution_mode::System<Mode::Error>>(
             protocol_config,
             metrics,
             move_vm,
@@ -1453,7 +1447,7 @@ mod checked {
             );
             builder.finish()
         };
-        SPT::execute::<execution_mode::System>(
+        SPT::execute::<execution_mode::System<Mode::Error>>(
             protocol_config,
             metrics,
             move_vm,

--- a/sui-execution/latest/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/latest/sui-adapter/src/execution_engine.rs
@@ -405,10 +405,9 @@ mod checked {
                         Mode::ExecutionResults,
                         Mode::Error,
                     > = match execution_params {
-                        ExecutionOrEarlyError::Err(early_execution_error) => Err((
-                            ExecutionError::new(early_execution_error, None).into(),
-                            vec![],
-                        )),
+                        ExecutionOrEarlyError::Err(early_execution_error) => {
+                            Err((Mode::Error::from_kind(early_execution_error), vec![]))
+                        }
                         ExecutionOrEarlyError::Ok(()) => execution_loop::<Mode>(
                             store,
                             temporary_store,
@@ -457,9 +456,10 @@ mod checked {
             && result.is_ok()
             && let Err(msg) = temporary_store.check_gasless_execution_requirements()
         {
-            result = Err(
-                ExecutionError::new_with_source(ExecutionErrorKind::InsufficientGas, msg).into(),
-            );
+            result = Err(Mode::Error::new_with_source(
+                ExecutionErrorKind::InsufficientGas,
+                msg,
+            ));
         }
 
         let cost_summary = gas_charger.charge_gas(temporary_store, &mut result);
@@ -592,14 +592,13 @@ mod checked {
                 );
                 Ok(())
             }
-            LimitThresholdCrossed::Hard(_, lim) => Err(ExecutionError::new_with_source(
+            LimitThresholdCrossed::Hard(_, lim) => Err(Mode::Error::new_with_source(
                 ExecutionErrorKind::EffectsTooLarge {
                     current_size: effects_estimated_size as u64,
                     max_size: lim as u64,
                 },
                 "Transaction effects are too large",
-            )
-            .into()),
+            )),
         }
     }
 
@@ -632,14 +631,13 @@ mod checked {
                     )
                 }
                 LimitThresholdCrossed::Hard(_, lim) => {
-                    return Err(ExecutionError::new_with_source(
+                    return Err(Mode::Error::new_with_source(
                         ExecutionErrorKind::WrittenObjectsTooLarge {
                             current_size: written_objects_size as u64,
                             max_size: lim as u64,
                         },
                         "Written objects size crossed hard limit",
-                    )
-                    .into());
+                    ));
                 }
             };
         }

--- a/sui-execution/latest/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/latest/sui-adapter/src/execution_engine.rs
@@ -13,7 +13,6 @@ mod checked {
     use move_binary_format::CompiledModule;
     use move_trace_format::format::MoveTraceBuilder;
     use move_vm_runtime::runtime::MoveRuntime;
-    use mysten_common::debug_fatal;
     use std::collections::BTreeMap;
     use std::{cell::RefCell, collections::HashSet, rc::Rc, sync::Arc};
     use sui_types::accumulator_root::{ACCUMULATOR_ROOT_CREATE_FUNC, ACCUMULATOR_ROOT_MODULE};
@@ -221,40 +220,6 @@ mod checked {
         );
 
         let status = if let Err(error) = &execution_result {
-            // Elaborate errors in logs if they are unexpected or their status is terse.
-            use ExecutionErrorKind as K;
-            match error.kind() {
-                K::InvariantViolation | K::VMInvariantViolation => {
-                    debug_fatal!(
-                        "INVARIANT VIOLATION! Txn Digest: {}, Source: {:?}",
-                        transaction_digest,
-                        error.source_ref(),
-                    );
-                }
-
-                K::SuiMoveVerificationError | K::VMVerificationOrDeserializationError => {
-                    #[skip_checked_arithmetic]
-                    tracing::debug!(
-                        kind = ?error.kind(),
-                        tx_digest = ?transaction_digest,
-                        "Verification Error. Source: {:?}",
-                        error.source_ref(),
-                    );
-                }
-
-                K::PublishUpgradeMissingDependency | K::PublishUpgradeDependencyDowngrade => {
-                    #[skip_checked_arithmetic]
-                    tracing::debug!(
-                        kind = ?error.kind(),
-                        tx_digest = ?transaction_digest,
-                        "Publish/Upgrade Error. Source: {:?}",
-                        error.source_ref(),
-                    )
-                }
-
-                _ => (),
-            };
-
             ExecutionStatus::new_failure(error.to_execution_failure())
         } else {
             ExecutionStatus::Success

--- a/sui-execution/latest/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/latest/sui-adapter/src/execution_engine.rs
@@ -913,7 +913,7 @@ mod checked {
             }
         }?;
         temporary_store
-            .check_execution_results_consistency::<Mode::Error>()
+            .check_execution_results_consistency::<Mode>()
             .map_err(|e| (e, vec![]))?;
         Ok(result)
     }
@@ -952,10 +952,10 @@ mod checked {
         (storage_rewards, computation_rewards)
     }
 
-    pub fn construct_advance_epoch_pt<E: ExecutionErrorTrait>(
+    pub fn construct_advance_epoch_pt<Mode: ExecutionMode>(
         mut builder: ProgrammableTransactionBuilder,
         params: &AdvanceEpochParams,
-    ) -> Result<ProgrammableTransaction, E> {
+    ) -> Result<ProgrammableTransaction, Mode::Error> {
         // Step 1: Create storage and computation rewards.
         let (storage_rewards, computation_rewards) = mint_epoch_rewards_in_pt(&mut builder, params);
 
@@ -1073,7 +1073,7 @@ mod checked {
             reward_slashing_rate: protocol_config.reward_slashing_rate(),
             epoch_start_timestamp_ms: change_epoch.epoch_start_timestamp_ms,
         };
-        let advance_epoch_pt = construct_advance_epoch_pt::<Mode::Error>(builder, &params)?;
+        let advance_epoch_pt = construct_advance_epoch_pt::<Mode>(builder, &params)?;
         let result = SPT::execute::<execution_mode::System<Mode::Error>>(
             protocol_config,
             metrics.clone(),

--- a/sui-execution/latest/sui-adapter/src/execution_mode.rs
+++ b/sui-execution/latest/sui-adapter/src/execution_mode.rs
@@ -273,12 +273,15 @@ where
 /// WARNING! Using this mode will bypass all normal checks around Move entry functions! This
 /// includes the various rules for function arguments, meaning any object can be created just from
 /// BCS bytes!
-pub struct DevInspect<const SKIP_ALL_CHECKS: bool>;
+pub struct DevInspect<const SKIP_ALL_CHECKS: bool, E = ExecutionError>(PhantomData<fn() -> E>);
 
-impl<const SKIP_ALL_CHECKS: bool> ExecutionMode for DevInspect<SKIP_ALL_CHECKS> {
+impl<const SKIP_ALL_CHECKS: bool, E> ExecutionMode for DevInspect<SKIP_ALL_CHECKS, E>
+where
+    E: ExecutionErrorTrait,
+{
     type ArgumentUpdates = Vec<(Argument, Vec<u8>, TypeTag)>;
     type ExecutionResults = Vec<ExecutionResult>;
-    type Error = ExecutionError;
+    type Error = E;
 
     fn allow_arbitrary_function_calls() -> bool {
         SKIP_ALL_CHECKS

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/env.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/env.rs
@@ -7,6 +7,7 @@
 
 use crate::{
     data_store::{PackageStore, cached_package_store::CachedPackageStore},
+    execution_mode::ExecutionMode,
     execution_value::ExecutionState,
     static_programmable_transactions::{
         execution::context::subst_signature,
@@ -37,7 +38,7 @@ use sui_types::{
     balance::RESOLVED_BALANCE_STRUCT,
     base_types::{ObjectID, TxContext},
     coin::RESOLVED_COIN_STRUCT,
-    error::{ExecutionError, ExecutionErrorTrait},
+    error::ExecutionErrorTrait,
     execution_status::{ExecutionErrorKind, TypeArgumentError},
     funds_accumulator::RESOLVED_WITHDRAWAL_STRUCT,
     gas_coin::GasCoin,
@@ -46,9 +47,9 @@ use sui_types::{
     type_input::{StructInput, TypeInput},
 };
 
-pub struct Env<'pc, 'vm, 'state, 'linkage, 'extensions, E = ExecutionError>
+pub struct Env<'pc, 'vm, 'state, 'linkage, 'extensions, Mode>
 where
-    E: ExecutionErrorTrait,
+    Mode: ExecutionMode,
 {
     pub protocol_config: &'pc ProtocolConfig,
     pub vm: &'vm MoveRuntime,
@@ -64,7 +65,7 @@ where
     // only. This VM should only be used for resolution of input types, but should not be used for
     // resolution around function calls, execution, or final serialization of execution values.
     input_type_resolution_vm: &'linkage MoveVM<'extensions>,
-    _error: PhantomData<fn() -> E>,
+    _mode: PhantomData<fn() -> Mode>,
 }
 
 macro_rules! get_or_init_ty {
@@ -79,9 +80,10 @@ macro_rules! get_or_init_ty {
     }};
 }
 
-impl<'pc, 'vm, 'state, 'linkage, 'extensions, E> Env<'pc, 'vm, 'state, 'linkage, 'extensions, E>
+impl<'pc, 'vm, 'state, 'linkage, 'extensions, Mode>
+    Env<'pc, 'vm, 'state, 'linkage, 'extensions, Mode>
 where
-    E: ExecutionErrorTrait,
+    Mode: ExecutionMode,
 {
     pub fn new(
         protocol_config: &'pc ProtocolConfig,
@@ -103,15 +105,15 @@ where
             upgrade_cap_type: OnceCell::new(),
             tx_context_type: OnceCell::new(),
             input_type_resolution_vm,
-            _error: PhantomData,
+            _mode: PhantomData,
         }
     }
 
-    pub fn convert_linked_vm_error(&self, e: VMError, linkage: &ExecutableLinkage) -> E {
+    pub fn convert_linked_vm_error(&self, e: VMError, linkage: &ExecutableLinkage) -> Mode::Error {
         convert_vm_error(e, self.linkable_store, Some(linkage), self.protocol_config)
     }
 
-    pub fn convert_vm_error(&self, e: VMError) -> E {
+    pub fn convert_vm_error(&self, e: VMError) -> Mode::Error {
         convert_vm_error(e, self.linkable_store, None, self.protocol_config)
     }
 
@@ -120,7 +122,7 @@ where
         idx: usize,
         e: VMError,
         linkage: &ExecutableLinkage,
-    ) -> E {
+    ) -> Mode::Error {
         use move_core_types::vm_status::StatusCode;
         let argument_idx = match checked_as!(idx, TypeParameterIndex) {
             Err(e) => return e.into(),
@@ -128,16 +130,16 @@ where
         };
         match e.major_status() {
             StatusCode::NUMBER_OF_TYPE_ARGUMENTS_MISMATCH => {
-                E::from_kind(ExecutionErrorKind::TypeArityMismatch)
+                Mode::Error::from_kind(ExecutionErrorKind::TypeArityMismatch)
             }
             StatusCode::EXTERNAL_RESOLUTION_REQUEST_ERROR => {
-                E::from_kind(ExecutionErrorKind::TypeArgumentError {
+                Mode::Error::from_kind(ExecutionErrorKind::TypeArgumentError {
                     argument_idx,
                     kind: TypeArgumentError::TypeNotFound,
                 })
             }
             StatusCode::CONSTRAINT_NOT_SATISFIED => {
-                E::from_kind(ExecutionErrorKind::TypeArgumentError {
+                Mode::Error::from_kind(ExecutionErrorKind::TypeArgumentError {
                     argument_idx,
                     kind: TypeArgumentError::ConstraintNotSatisfied,
                 })
@@ -146,13 +148,15 @@ where
         }
     }
 
-    pub fn fully_annotated_layout(&self, ty: &Type) -> Result<annotated_value::MoveTypeLayout, E> {
-        let tag: TypeTag = ty
-            .clone()
-            .try_into()
-            .map_err(|s| E::new_with_source(ExecutionErrorKind::VMInvariantViolation, s))?;
+    pub fn fully_annotated_layout(
+        &self,
+        ty: &Type,
+    ) -> Result<annotated_value::MoveTypeLayout, Mode::Error> {
+        let tag: TypeTag = ty.clone().try_into().map_err(|s| {
+            Mode::Error::new_with_source(ExecutionErrorKind::VMInvariantViolation, s)
+        })?;
         let objects = tag.all_addresses();
-        let tag_linkage = ExecutableLinkage::type_linkage::<_, E>(
+        let tag_linkage = ExecutableLinkage::type_linkage::<_, Mode::Error>(
             objects.into_iter().map(ObjectID::from),
             self.linkable_store,
         )?;
@@ -161,13 +165,12 @@ where
             .map_err(|e| self.convert_linked_vm_error(e, &tag_linkage))
     }
 
-    pub fn runtime_layout(&self, ty: &Type) -> Result<runtime_value::MoveTypeLayout, E> {
-        let tag: TypeTag = ty
-            .clone()
-            .try_into()
-            .map_err(|s| E::new_with_source(ExecutionErrorKind::VMInvariantViolation, s))?;
+    pub fn runtime_layout(&self, ty: &Type) -> Result<runtime_value::MoveTypeLayout, Mode::Error> {
+        let tag: TypeTag = ty.clone().try_into().map_err(|s| {
+            Mode::Error::new_with_source(ExecutionErrorKind::VMInvariantViolation, s)
+        })?;
         let objects = tag.all_addresses();
-        let tag_linkage = ExecutableLinkage::type_linkage::<_, E>(
+        let tag_linkage = ExecutableLinkage::type_linkage::<_, Mode::Error>(
             objects.into_iter().map(ObjectID::from),
             self.linkable_store,
         )?;
@@ -181,7 +184,7 @@ where
         module: &IdentStr,
         function: &IdentStr,
         type_arguments: Vec<Type>,
-    ) -> Result<LoadedFunction, E> {
+    ) -> Result<LoadedFunction, Mode::Error> {
         self.load_function(
             SUI_FRAMEWORK_PACKAGE_ID,
             module.to_string(),
@@ -196,11 +199,11 @@ where
         module: String,
         function: String,
         type_arguments: Vec<Type>,
-    ) -> Result<LoadedFunction, E> {
+    ) -> Result<LoadedFunction, Mode::Error> {
         let module = to_identifier(module)?;
         let name = to_identifier(function)?;
 
-        let linkage = self.linkage_analysis.compute_call_linkage::<E>(
+        let linkage = self.linkage_analysis.compute_call_linkage::<Mode::Error>(
             &package,
             module.as_ident_str(),
             name.as_ident_str(),
@@ -228,14 +231,14 @@ where
             .vm
             .make_vm(
                 &self.linkable_store.package_store,
-                linkage.linkage_context::<E>()?,
+                linkage.linkage_context::<Mode::Error>()?,
             )
             .map_err(|e| self.convert_linked_vm_error(e, &linkage))?;
         let runtime_signature = vm
             .function_information(&original_mid, name.as_ident_str(), &loaded_type_arguments)
             .map_err(|e| {
                 if e.major_status() == StatusCode::EXTERNAL_RESOLUTION_REQUEST_ERROR {
-                    E::new_with_source(
+                    Mode::Error::new_with_source(
                         ExecutionErrorKind::FunctionNotFound,
                         format!(
                             "Could not resolve function '{}' in module '{}'",
@@ -277,49 +280,49 @@ where
         })
     }
 
-    pub fn load_type_input(&self, idx: usize, ty: TypeInput) -> Result<Type, E> {
+    pub fn load_type_input(&self, idx: usize, ty: TypeInput) -> Result<Type, Mode::Error> {
         let vm_type = self.load_vm_type_from_type_input(idx, ty)?;
         self.adapter_type_from_vm_type(self.input_type_resolution_vm, &vm_type)
     }
 
-    pub fn load_type_tag(&self, idx: usize, ty: &TypeTag) -> Result<Type, E> {
+    pub fn load_type_tag(&self, idx: usize, ty: &TypeTag) -> Result<Type, Mode::Error> {
         let vm_type = self.load_vm_type_from_type_tag(Some(idx), ty)?;
         self.adapter_type_from_vm_type(self.input_type_resolution_vm, &vm_type)
     }
 
     /// We verify that all types in the `StructTag` are defining ID-based types.
-    pub fn load_type_from_struct(&self, tag: &StructTag) -> Result<Type, E> {
+    pub fn load_type_from_struct(&self, tag: &StructTag) -> Result<Type, Mode::Error> {
         let vm_type =
             self.load_vm_type_from_type_tag(None, &TypeTag::Struct(Box::new(tag.clone())))?;
         self.adapter_type_from_vm_type(self.input_type_resolution_vm, &vm_type)
     }
 
-    pub fn type_layout_for_struct(&self, tag: &StructTag) -> Result<MoveTypeLayout, E> {
+    pub fn type_layout_for_struct(&self, tag: &StructTag) -> Result<MoveTypeLayout, Mode::Error> {
         let ty: Type = self.load_type_from_struct(tag)?;
         self.runtime_layout(&ty)
     }
 
-    pub fn gas_coin_type(&self) -> Result<Type, E> {
+    pub fn gas_coin_type(&self) -> Result<Type, Mode::Error> {
         get_or_init_ty!(self, gas_coin_type, GasCoin::type_())
     }
 
-    pub fn upgrade_ticket_type(&self) -> Result<Type, E> {
+    pub fn upgrade_ticket_type(&self) -> Result<Type, Mode::Error> {
         get_or_init_ty!(self, upgrade_ticket_type, UpgradeTicket::type_())
     }
 
-    pub fn upgrade_receipt_type(&self) -> Result<Type, E> {
+    pub fn upgrade_receipt_type(&self) -> Result<Type, Mode::Error> {
         get_or_init_ty!(self, upgrade_receipt_type, UpgradeReceipt::type_())
     }
 
-    pub fn upgrade_cap_type(&self) -> Result<Type, E> {
+    pub fn upgrade_cap_type(&self) -> Result<Type, Mode::Error> {
         get_or_init_ty!(self, upgrade_cap_type, UpgradeCap::type_())
     }
 
-    pub fn tx_context_type(&self) -> Result<Type, E> {
+    pub fn tx_context_type(&self) -> Result<Type, Mode::Error> {
         get_or_init_ty!(self, tx_context_type, TxContext::type_())
     }
 
-    pub fn coin_type(&self, inner_type: Type) -> Result<Type, E> {
+    pub fn coin_type(&self, inner_type: Type) -> Result<Type, Mode::Error> {
         const COIN_ABILITIES: AbilitySet =
             AbilitySet::singleton(Ability::Key).union(AbilitySet::singleton(Ability::Store));
         let (a, m, n) = RESOLVED_COIN_STRUCT;
@@ -332,7 +335,7 @@ where
         })))
     }
 
-    pub fn balance_type(&self, inner_type: Type) -> Result<Type, E> {
+    pub fn balance_type(&self, inner_type: Type) -> Result<Type, Mode::Error> {
         const BALANCE_ABILITIES: AbilitySet = AbilitySet::singleton(Ability::Store);
         let (a, m, n) = RESOLVED_BALANCE_STRUCT;
         let module = ModuleId::new(*a, m.to_owned());
@@ -344,7 +347,7 @@ where
         })))
     }
 
-    pub fn withdrawal_type(&self, inner_type: Type) -> Result<Type, E> {
+    pub fn withdrawal_type(&self, inner_type: Type) -> Result<Type, Mode::Error> {
         const WITHDRAWAL_ABILITIES: AbilitySet = AbilitySet::singleton(Ability::Drop);
         let (a, m, n) = RESOLVED_WITHDRAWAL_STRUCT;
         let module = ModuleId::new(*a, m.to_owned());
@@ -356,20 +359,22 @@ where
         })))
     }
 
-    pub fn vector_type(&self, element_type: Type) -> Result<Type, E> {
+    pub fn vector_type(&self, element_type: Type) -> Result<Type, Mode::Error> {
         let abilities = AbilitySet::polymorphic_abilities(
             AbilitySet::VECTOR,
             [false],
             [element_type.abilities()],
         )
-        .map_err(|e| E::new_with_source(ExecutionErrorKind::VMInvariantViolation, e.to_string()))?;
+        .map_err(|e| {
+            Mode::Error::new_with_source(ExecutionErrorKind::VMInvariantViolation, e.to_string())
+        })?;
         Ok(Type::Vector(Rc::new(L::Vector {
             abilities,
             element_type,
         })))
     }
 
-    pub fn read_object(&self, id: &ObjectID) -> Result<&Object, E> {
+    pub fn read_object(&self, id: &ObjectID) -> Result<&Object, Mode::Error> {
         let Some(obj) = self.state_view.read_object(id) else {
             // protected by transaction input checker
             invariant_violation!("Object {:?} does not exist", id);
@@ -382,7 +387,7 @@ where
         &self,
         idx: usize,
         ty: &Type,
-    ) -> Result<vm_runtime::Type, E> {
+    ) -> Result<vm_runtime::Type, Mode::Error> {
         self.load_vm_type_from_adapter_type(Some(idx), ty)
     }
 
@@ -390,11 +395,10 @@ where
         &self,
         type_arg_idx: Option<usize>,
         ty: &Type,
-    ) -> Result<vm_runtime::Type, E> {
-        let tag: TypeTag = ty
-            .clone()
-            .try_into()
-            .map_err(|s| E::new_with_source(ExecutionErrorKind::VMInvariantViolation, s))?;
+    ) -> Result<vm_runtime::Type, Mode::Error> {
+        let tag: TypeTag = ty.clone().try_into().map_err(|s| {
+            Mode::Error::new_with_source(ExecutionErrorKind::VMInvariantViolation, s)
+        })?;
         self.load_vm_type_from_type_tag(type_arg_idx, &tag)
     }
 
@@ -403,13 +407,13 @@ where
         &self,
         type_arg_idx: Option<usize>,
         tag: &TypeTag,
-    ) -> Result<vm_runtime::Type, E> {
-        fn execution_error<E: ExecutionErrorTrait>(
-            env: &Env<'_, '_, '_, '_, '_, E>,
+    ) -> Result<vm_runtime::Type, Mode::Error> {
+        fn execution_error<Mode: ExecutionMode>(
+            env: &Env<'_, '_, '_, '_, '_, Mode>,
             type_arg_idx: Option<usize>,
             e: VMError,
             linkage: &ExecutableLinkage,
-        ) -> E {
+        ) -> Mode::Error {
             if let Some(idx) = type_arg_idx {
                 env.convert_type_argument_error(idx, e, linkage)
             } else {
@@ -419,7 +423,7 @@ where
 
         let objects = tag.all_addresses();
 
-        let tag_linkage = ExecutableLinkage::type_linkage::<_, E>(
+        let tag_linkage = ExecutableLinkage::type_linkage::<_, Mode::Error>(
             objects.iter().map(|a| ObjectID::from(*a)),
             self.linkable_store,
         )?;
@@ -435,7 +439,7 @@ where
         &self,
         vm: &MoveVM,
         vm_type: &vm_runtime::Type,
-    ) -> Result<Type, E> {
+    ) -> Result<Type, Mode::Error> {
         use vm_runtime as VRT;
 
         Ok(match vm_type {
@@ -519,12 +523,12 @@ where
         &self,
         type_arg_idx: usize,
         ty: TypeInput,
-    ) -> Result<vm_runtime::Type, E> {
-        fn to_type_tag_internal<E: ExecutionErrorTrait>(
-            env: &Env<'_, '_, '_, '_, '_, E>,
+    ) -> Result<vm_runtime::Type, Mode::Error> {
+        fn to_type_tag_internal<Mode: ExecutionMode>(
+            env: &Env<'_, '_, '_, '_, '_, Mode>,
             type_arg_idx: usize,
             ty: TypeInput,
-        ) -> Result<TypeTag, E> {
+        ) -> Result<TypeTag, Mode::Error> {
             Ok(match ty {
                 TypeInput::Bool => TypeTag::Bool,
                 TypeInput::U8 => TypeTag::U8,
@@ -557,7 +561,7 @@ where
                                 Err(e) => return e.into(),
                                 Ok(v) => v,
                             };
-                            E::from_kind(ExecutionErrorKind::TypeArgumentError {
+                            Mode::Error::from_kind(ExecutionErrorKind::TypeArgumentError {
                                 argument_idx,
                                 kind: TypeArgumentError::TypeNotFound,
                             })
@@ -569,10 +573,12 @@ where
                         type_name: name,
                     };
                     let Some(resolved_address) = pkg.type_origin_table().get(&tid).cloned() else {
-                        return Err(E::from_kind(ExecutionErrorKind::TypeArgumentError {
-                            argument_idx: checked_as!(type_arg_idx, u16)?,
-                            kind: TypeArgumentError::TypeNotFound,
-                        }));
+                        return Err(Mode::Error::from_kind(
+                            ExecutionErrorKind::TypeArgumentError {
+                                argument_idx: checked_as!(type_arg_idx, u16)?,
+                                kind: TypeArgumentError::TypeNotFound,
+                            },
+                        ));
                     };
 
                     let tys = type_params

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/env.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/env.rs
@@ -30,14 +30,14 @@ use move_vm_runtime::{
     execution::{self as vm_runtime, vm::MoveVM},
     runtime::MoveRuntime,
 };
-use std::{cell::OnceCell, rc::Rc};
+use std::{cell::OnceCell, marker::PhantomData, rc::Rc};
 use sui_protocol_config::ProtocolConfig;
 use sui_types::{
     Identifier, SUI_FRAMEWORK_PACKAGE_ID, TypeTag,
     balance::RESOLVED_BALANCE_STRUCT,
     base_types::{ObjectID, TxContext},
     coin::RESOLVED_COIN_STRUCT,
-    error::ExecutionError,
+    error::{ExecutionError, ExecutionErrorTrait},
     execution_status::{ExecutionErrorKind, TypeArgumentError},
     funds_accumulator::RESOLVED_WITHDRAWAL_STRUCT,
     gas_coin::GasCoin,
@@ -46,7 +46,10 @@ use sui_types::{
     type_input::{StructInput, TypeInput},
 };
 
-pub struct Env<'pc, 'vm, 'state, 'linkage, 'extensions> {
+pub struct Env<'pc, 'vm, 'state, 'linkage, 'extensions, E = ExecutionError>
+where
+    E: ExecutionErrorTrait,
+{
     pub protocol_config: &'pc ProtocolConfig,
     pub vm: &'vm MoveRuntime,
     pub state_view: &'state mut dyn ExecutionState,
@@ -61,6 +64,7 @@ pub struct Env<'pc, 'vm, 'state, 'linkage, 'extensions> {
     // only. This VM should only be used for resolution of input types, but should not be used for
     // resolution around function calls, execution, or final serialization of execution values.
     input_type_resolution_vm: &'linkage MoveVM<'extensions>,
+    _error: PhantomData<fn() -> E>,
 }
 
 macro_rules! get_or_init_ty {
@@ -75,7 +79,10 @@ macro_rules! get_or_init_ty {
     }};
 }
 
-impl<'pc, 'vm, 'state, 'linkage, 'extensions> Env<'pc, 'vm, 'state, 'linkage, 'extensions> {
+impl<'pc, 'vm, 'state, 'linkage, 'extensions, E> Env<'pc, 'vm, 'state, 'linkage, 'extensions, E>
+where
+    E: ExecutionErrorTrait,
+{
     pub fn new(
         protocol_config: &'pc ProtocolConfig,
         vm: &'vm MoveRuntime,
@@ -96,18 +103,15 @@ impl<'pc, 'vm, 'state, 'linkage, 'extensions> Env<'pc, 'vm, 'state, 'linkage, 'e
             upgrade_cap_type: OnceCell::new(),
             tx_context_type: OnceCell::new(),
             input_type_resolution_vm,
+            _error: PhantomData,
         }
     }
 
-    pub fn convert_linked_vm_error(
-        &self,
-        e: VMError,
-        linkage: &ExecutableLinkage,
-    ) -> ExecutionError {
+    pub fn convert_linked_vm_error(&self, e: VMError, linkage: &ExecutableLinkage) -> E {
         convert_vm_error(e, self.linkable_store, Some(linkage), self.protocol_config)
     }
 
-    pub fn convert_vm_error(&self, e: VMError) -> ExecutionError {
+    pub fn convert_vm_error(&self, e: VMError) -> E {
         convert_vm_error(e, self.linkable_store, None, self.protocol_config)
     }
 
@@ -116,41 +120,39 @@ impl<'pc, 'vm, 'state, 'linkage, 'extensions> Env<'pc, 'vm, 'state, 'linkage, 'e
         idx: usize,
         e: VMError,
         linkage: &ExecutableLinkage,
-    ) -> ExecutionError {
+    ) -> E {
         use move_core_types::vm_status::StatusCode;
         let argument_idx = match checked_as!(idx, TypeParameterIndex) {
-            Err(e) => return e,
+            Err(e) => return e.into(),
             Ok(v) => v,
         };
         match e.major_status() {
             StatusCode::NUMBER_OF_TYPE_ARGUMENTS_MISMATCH => {
-                ExecutionErrorKind::TypeArityMismatch.into()
+                E::from_kind(ExecutionErrorKind::TypeArityMismatch)
             }
             StatusCode::EXTERNAL_RESOLUTION_REQUEST_ERROR => {
-                ExecutionErrorKind::TypeArgumentError {
+                E::from_kind(ExecutionErrorKind::TypeArgumentError {
                     argument_idx,
                     kind: TypeArgumentError::TypeNotFound,
-                }
-                .into()
+                })
             }
-            StatusCode::CONSTRAINT_NOT_SATISFIED => ExecutionErrorKind::TypeArgumentError {
-                argument_idx,
-                kind: TypeArgumentError::ConstraintNotSatisfied,
+            StatusCode::CONSTRAINT_NOT_SATISFIED => {
+                E::from_kind(ExecutionErrorKind::TypeArgumentError {
+                    argument_idx,
+                    kind: TypeArgumentError::ConstraintNotSatisfied,
+                })
             }
-            .into(),
             _ => self.convert_linked_vm_error(e, linkage),
         }
     }
 
-    pub fn fully_annotated_layout(
-        &self,
-        ty: &Type,
-    ) -> Result<annotated_value::MoveTypeLayout, ExecutionError> {
-        let tag: TypeTag = ty.clone().try_into().map_err(|s| {
-            ExecutionError::new_with_source(ExecutionErrorKind::VMInvariantViolation, s)
-        })?;
+    pub fn fully_annotated_layout(&self, ty: &Type) -> Result<annotated_value::MoveTypeLayout, E> {
+        let tag: TypeTag = ty
+            .clone()
+            .try_into()
+            .map_err(|s| E::new_with_source(ExecutionErrorKind::VMInvariantViolation, s))?;
         let objects = tag.all_addresses();
-        let tag_linkage = ExecutableLinkage::type_linkage(
+        let tag_linkage = ExecutableLinkage::type_linkage::<_, E>(
             objects.into_iter().map(ObjectID::from),
             self.linkable_store,
         )?;
@@ -159,15 +161,13 @@ impl<'pc, 'vm, 'state, 'linkage, 'extensions> Env<'pc, 'vm, 'state, 'linkage, 'e
             .map_err(|e| self.convert_linked_vm_error(e, &tag_linkage))
     }
 
-    pub fn runtime_layout(
-        &self,
-        ty: &Type,
-    ) -> Result<runtime_value::MoveTypeLayout, ExecutionError> {
-        let tag: TypeTag = ty.clone().try_into().map_err(|s| {
-            ExecutionError::new_with_source(ExecutionErrorKind::VMInvariantViolation, s)
-        })?;
+    pub fn runtime_layout(&self, ty: &Type) -> Result<runtime_value::MoveTypeLayout, E> {
+        let tag: TypeTag = ty
+            .clone()
+            .try_into()
+            .map_err(|s| E::new_with_source(ExecutionErrorKind::VMInvariantViolation, s))?;
         let objects = tag.all_addresses();
-        let tag_linkage = ExecutableLinkage::type_linkage(
+        let tag_linkage = ExecutableLinkage::type_linkage::<_, E>(
             objects.into_iter().map(ObjectID::from),
             self.linkable_store,
         )?;
@@ -181,7 +181,7 @@ impl<'pc, 'vm, 'state, 'linkage, 'extensions> Env<'pc, 'vm, 'state, 'linkage, 'e
         module: &IdentStr,
         function: &IdentStr,
         type_arguments: Vec<Type>,
-    ) -> Result<LoadedFunction, ExecutionError> {
+    ) -> Result<LoadedFunction, E> {
         self.load_function(
             SUI_FRAMEWORK_PACKAGE_ID,
             module.to_string(),
@@ -196,11 +196,11 @@ impl<'pc, 'vm, 'state, 'linkage, 'extensions> Env<'pc, 'vm, 'state, 'linkage, 'e
         module: String,
         function: String,
         type_arguments: Vec<Type>,
-    ) -> Result<LoadedFunction, ExecutionError> {
+    ) -> Result<LoadedFunction, E> {
         let module = to_identifier(module)?;
         let name = to_identifier(function)?;
 
-        let linkage = self.linkage_analysis.compute_call_linkage(
+        let linkage = self.linkage_analysis.compute_call_linkage::<E>(
             &package,
             module.as_ident_str(),
             name.as_ident_str(),
@@ -228,14 +228,14 @@ impl<'pc, 'vm, 'state, 'linkage, 'extensions> Env<'pc, 'vm, 'state, 'linkage, 'e
             .vm
             .make_vm(
                 &self.linkable_store.package_store,
-                linkage.linkage_context()?,
+                linkage.linkage_context::<E>()?,
             )
             .map_err(|e| self.convert_linked_vm_error(e, &linkage))?;
         let runtime_signature = vm
             .function_information(&original_mid, name.as_ident_str(), &loaded_type_arguments)
             .map_err(|e| {
                 if e.major_status() == StatusCode::EXTERNAL_RESOLUTION_REQUEST_ERROR {
-                    ExecutionError::new_with_source(
+                    E::new_with_source(
                         ExecutionErrorKind::FunctionNotFound,
                         format!(
                             "Could not resolve function '{}' in module '{}'",
@@ -277,52 +277,49 @@ impl<'pc, 'vm, 'state, 'linkage, 'extensions> Env<'pc, 'vm, 'state, 'linkage, 'e
         })
     }
 
-    pub fn load_type_input(&self, idx: usize, ty: TypeInput) -> Result<Type, ExecutionError> {
+    pub fn load_type_input(&self, idx: usize, ty: TypeInput) -> Result<Type, E> {
         let vm_type = self.load_vm_type_from_type_input(idx, ty)?;
         self.adapter_type_from_vm_type(self.input_type_resolution_vm, &vm_type)
     }
 
-    pub fn load_type_tag(&self, idx: usize, ty: &TypeTag) -> Result<Type, ExecutionError> {
+    pub fn load_type_tag(&self, idx: usize, ty: &TypeTag) -> Result<Type, E> {
         let vm_type = self.load_vm_type_from_type_tag(Some(idx), ty)?;
         self.adapter_type_from_vm_type(self.input_type_resolution_vm, &vm_type)
     }
 
     /// We verify that all types in the `StructTag` are defining ID-based types.
-    pub fn load_type_from_struct(&self, tag: &StructTag) -> Result<Type, ExecutionError> {
+    pub fn load_type_from_struct(&self, tag: &StructTag) -> Result<Type, E> {
         let vm_type =
             self.load_vm_type_from_type_tag(None, &TypeTag::Struct(Box::new(tag.clone())))?;
         self.adapter_type_from_vm_type(self.input_type_resolution_vm, &vm_type)
     }
 
-    pub fn type_layout_for_struct(
-        &self,
-        tag: &StructTag,
-    ) -> Result<MoveTypeLayout, ExecutionError> {
+    pub fn type_layout_for_struct(&self, tag: &StructTag) -> Result<MoveTypeLayout, E> {
         let ty: Type = self.load_type_from_struct(tag)?;
         self.runtime_layout(&ty)
     }
 
-    pub fn gas_coin_type(&self) -> Result<Type, ExecutionError> {
+    pub fn gas_coin_type(&self) -> Result<Type, E> {
         get_or_init_ty!(self, gas_coin_type, GasCoin::type_())
     }
 
-    pub fn upgrade_ticket_type(&self) -> Result<Type, ExecutionError> {
+    pub fn upgrade_ticket_type(&self) -> Result<Type, E> {
         get_or_init_ty!(self, upgrade_ticket_type, UpgradeTicket::type_())
     }
 
-    pub fn upgrade_receipt_type(&self) -> Result<Type, ExecutionError> {
+    pub fn upgrade_receipt_type(&self) -> Result<Type, E> {
         get_or_init_ty!(self, upgrade_receipt_type, UpgradeReceipt::type_())
     }
 
-    pub fn upgrade_cap_type(&self) -> Result<Type, ExecutionError> {
+    pub fn upgrade_cap_type(&self) -> Result<Type, E> {
         get_or_init_ty!(self, upgrade_cap_type, UpgradeCap::type_())
     }
 
-    pub fn tx_context_type(&self) -> Result<Type, ExecutionError> {
+    pub fn tx_context_type(&self) -> Result<Type, E> {
         get_or_init_ty!(self, tx_context_type, TxContext::type_())
     }
 
-    pub fn coin_type(&self, inner_type: Type) -> Result<Type, ExecutionError> {
+    pub fn coin_type(&self, inner_type: Type) -> Result<Type, E> {
         const COIN_ABILITIES: AbilitySet =
             AbilitySet::singleton(Ability::Key).union(AbilitySet::singleton(Ability::Store));
         let (a, m, n) = RESOLVED_COIN_STRUCT;
@@ -335,7 +332,7 @@ impl<'pc, 'vm, 'state, 'linkage, 'extensions> Env<'pc, 'vm, 'state, 'linkage, 'e
         })))
     }
 
-    pub fn balance_type(&self, inner_type: Type) -> Result<Type, ExecutionError> {
+    pub fn balance_type(&self, inner_type: Type) -> Result<Type, E> {
         const BALANCE_ABILITIES: AbilitySet = AbilitySet::singleton(Ability::Store);
         let (a, m, n) = RESOLVED_BALANCE_STRUCT;
         let module = ModuleId::new(*a, m.to_owned());
@@ -347,7 +344,7 @@ impl<'pc, 'vm, 'state, 'linkage, 'extensions> Env<'pc, 'vm, 'state, 'linkage, 'e
         })))
     }
 
-    pub fn withdrawal_type(&self, inner_type: Type) -> Result<Type, ExecutionError> {
+    pub fn withdrawal_type(&self, inner_type: Type) -> Result<Type, E> {
         const WITHDRAWAL_ABILITIES: AbilitySet = AbilitySet::singleton(Ability::Drop);
         let (a, m, n) = RESOLVED_WITHDRAWAL_STRUCT;
         let module = ModuleId::new(*a, m.to_owned());
@@ -359,22 +356,20 @@ impl<'pc, 'vm, 'state, 'linkage, 'extensions> Env<'pc, 'vm, 'state, 'linkage, 'e
         })))
     }
 
-    pub fn vector_type(&self, element_type: Type) -> Result<Type, ExecutionError> {
+    pub fn vector_type(&self, element_type: Type) -> Result<Type, E> {
         let abilities = AbilitySet::polymorphic_abilities(
             AbilitySet::VECTOR,
             [false],
             [element_type.abilities()],
         )
-        .map_err(|e| {
-            ExecutionError::new_with_source(ExecutionErrorKind::VMInvariantViolation, e.to_string())
-        })?;
+        .map_err(|e| E::new_with_source(ExecutionErrorKind::VMInvariantViolation, e.to_string()))?;
         Ok(Type::Vector(Rc::new(L::Vector {
             abilities,
             element_type,
         })))
     }
 
-    pub fn read_object(&self, id: &ObjectID) -> Result<&Object, ExecutionError> {
+    pub fn read_object(&self, id: &ObjectID) -> Result<&Object, E> {
         let Some(obj) = self.state_view.read_object(id) else {
             // protected by transaction input checker
             invariant_violation!("Object {:?} does not exist", id);
@@ -387,7 +382,7 @@ impl<'pc, 'vm, 'state, 'linkage, 'extensions> Env<'pc, 'vm, 'state, 'linkage, 'e
         &self,
         idx: usize,
         ty: &Type,
-    ) -> Result<vm_runtime::Type, ExecutionError> {
+    ) -> Result<vm_runtime::Type, E> {
         self.load_vm_type_from_adapter_type(Some(idx), ty)
     }
 
@@ -395,10 +390,11 @@ impl<'pc, 'vm, 'state, 'linkage, 'extensions> Env<'pc, 'vm, 'state, 'linkage, 'e
         &self,
         type_arg_idx: Option<usize>,
         ty: &Type,
-    ) -> Result<vm_runtime::Type, ExecutionError> {
-        let tag: TypeTag = ty.clone().try_into().map_err(|s| {
-            ExecutionError::new_with_source(ExecutionErrorKind::VMInvariantViolation, s)
-        })?;
+    ) -> Result<vm_runtime::Type, E> {
+        let tag: TypeTag = ty
+            .clone()
+            .try_into()
+            .map_err(|s| E::new_with_source(ExecutionErrorKind::VMInvariantViolation, s))?;
         self.load_vm_type_from_type_tag(type_arg_idx, &tag)
     }
 
@@ -407,13 +403,13 @@ impl<'pc, 'vm, 'state, 'linkage, 'extensions> Env<'pc, 'vm, 'state, 'linkage, 'e
         &self,
         type_arg_idx: Option<usize>,
         tag: &TypeTag,
-    ) -> Result<vm_runtime::Type, ExecutionError> {
-        fn execution_error(
-            env: &Env,
+    ) -> Result<vm_runtime::Type, E> {
+        fn execution_error<E: ExecutionErrorTrait>(
+            env: &Env<'_, '_, '_, '_, '_, E>,
             type_arg_idx: Option<usize>,
             e: VMError,
             linkage: &ExecutableLinkage,
-        ) -> ExecutionError {
+        ) -> E {
             if let Some(idx) = type_arg_idx {
                 env.convert_type_argument_error(idx, e, linkage)
             } else {
@@ -423,7 +419,7 @@ impl<'pc, 'vm, 'state, 'linkage, 'extensions> Env<'pc, 'vm, 'state, 'linkage, 'e
 
         let objects = tag.all_addresses();
 
-        let tag_linkage = ExecutableLinkage::type_linkage(
+        let tag_linkage = ExecutableLinkage::type_linkage::<_, E>(
             objects.iter().map(|a| ObjectID::from(*a)),
             self.linkable_store,
         )?;
@@ -439,7 +435,7 @@ impl<'pc, 'vm, 'state, 'linkage, 'extensions> Env<'pc, 'vm, 'state, 'linkage, 'e
         &self,
         vm: &MoveVM,
         vm_type: &vm_runtime::Type,
-    ) -> Result<Type, ExecutionError> {
+    ) -> Result<Type, E> {
         use vm_runtime as VRT;
 
         Ok(match vm_type {
@@ -523,12 +519,12 @@ impl<'pc, 'vm, 'state, 'linkage, 'extensions> Env<'pc, 'vm, 'state, 'linkage, 'e
         &self,
         type_arg_idx: usize,
         ty: TypeInput,
-    ) -> Result<vm_runtime::Type, ExecutionError> {
-        fn to_type_tag_internal(
-            env: &Env,
+    ) -> Result<vm_runtime::Type, E> {
+        fn to_type_tag_internal<E: ExecutionErrorTrait>(
+            env: &Env<'_, '_, '_, '_, '_, E>,
             type_arg_idx: usize,
             ty: TypeInput,
-        ) -> Result<TypeTag, ExecutionError> {
+        ) -> Result<TypeTag, E> {
             Ok(match ty {
                 TypeInput::Bool => TypeTag::Bool,
                 TypeInput::U8 => TypeTag::U8,
@@ -558,10 +554,10 @@ impl<'pc, 'vm, 'state, 'linkage, 'extensions> Env<'pc, 'vm, 'state, 'linkage, 'e
                         .flatten()
                         .ok_or_else(|| {
                             let argument_idx = match checked_as!(type_arg_idx, u16) {
-                                Err(e) => return e,
+                                Err(e) => return e.into(),
                                 Ok(v) => v,
                             };
-                            ExecutionError::from_kind(ExecutionErrorKind::TypeArgumentError {
+                            E::from_kind(ExecutionErrorKind::TypeArgumentError {
                                 argument_idx,
                                 kind: TypeArgumentError::TypeNotFound,
                             })
@@ -573,12 +569,10 @@ impl<'pc, 'vm, 'state, 'linkage, 'extensions> Env<'pc, 'vm, 'state, 'linkage, 'e
                         type_name: name,
                     };
                     let Some(resolved_address) = pkg.type_origin_table().get(&tid).cloned() else {
-                        return Err(ExecutionError::from_kind(
-                            ExecutionErrorKind::TypeArgumentError {
-                                argument_idx: checked_as!(type_arg_idx, u16)?,
-                                kind: TypeArgumentError::TypeNotFound,
-                            },
-                        ));
+                        return Err(E::from_kind(ExecutionErrorKind::TypeArgumentError {
+                            argument_idx: checked_as!(type_arg_idx, u16)?,
+                            kind: TypeArgumentError::TypeNotFound,
+                        }));
                     };
 
                     let tys = type_params
@@ -599,18 +593,17 @@ impl<'pc, 'vm, 'state, 'linkage, 'extensions> Env<'pc, 'vm, 'state, 'linkage, 'e
     }
 }
 
-fn to_identifier(name: String) -> Result<Identifier, ExecutionError> {
-    Identifier::new(name).map_err(|e| {
-        ExecutionError::new_with_source(ExecutionErrorKind::VMInvariantViolation, e.to_string())
-    })
+fn to_identifier<E: ExecutionErrorTrait>(name: String) -> Result<Identifier, E> {
+    Identifier::new(name)
+        .map_err(|e| E::new_with_source(ExecutionErrorKind::VMInvariantViolation, e.to_string()))
 }
 
-fn convert_vm_error(
+fn convert_vm_error<E: ExecutionErrorTrait>(
     error: VMError,
     store: &dyn PackageStore,
     linkage: Option<&ExecutableLinkage>,
     _protocol_config: &ProtocolConfig,
-) -> ExecutionError {
+) -> E {
     use crate::error::convert_vm_error_impl;
     convert_vm_error_impl(
         error,
@@ -653,4 +646,5 @@ fn convert_vm_error(
             })
         },
     )
+    .into()
 }

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/execution/context.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/execution/context.rs
@@ -74,7 +74,7 @@ use sui_types::{
         SuiAddress, TxContext,
     },
     effects::{AccumulatorAddress, AccumulatorValue, AccumulatorWriteV1},
-    error::{ExecutionError, SafeIndex, command_argument_error},
+    error::{ExecutionError, ExecutionErrorTrait, SafeIndex, command_argument_error},
     event::Event,
     execution::{ExecutionResults, ExecutionResultsV2},
     execution_status::{CommandArgumentError, ExecutionErrorKind, PackageUpgradeError},
@@ -155,7 +155,7 @@ macro_rules! charge_gas {
 // found the VM is reused, otherwise a new VM is created and inserted into the cache.
 macro_rules! with_vm {
     ($self:ident, $linkage:expr, $body:expr) => {{
-        let link_context = $linkage.linkage_context()?;
+        let link_context = $linkage.linkage_context::<ExecutionError>()?;
         let linkage_hash = link_context.to_linkage_hash();
         let mut vm = if let Some((_, vm)) = $self.executable_vm_cache.remove(&linkage_hash) {
             vm
@@ -248,8 +248,11 @@ enum ResolvedLocation<'a> {
 }
 
 /// Maintains all runtime state specific to programmable transactions
-pub struct Context<'env, 'pc, 'vm, 'state, 'linkage, 'gas, 'extension> {
-    pub env: &'env Env<'pc, 'vm, 'state, 'linkage, 'extension>,
+pub struct Context<'env, 'pc, 'vm, 'state, 'linkage, 'gas, 'extension, E = ExecutionError>
+where
+    E: ExecutionErrorTrait,
+{
+    pub env: &'env Env<'pc, 'vm, 'state, 'linkage, 'extension, E>,
     /// Metrics for reporting exceeded limits
     pub metrics: Arc<ExecutionMetrics>,
     pub native_extensions: NativeExtensions<'env>,
@@ -313,12 +316,14 @@ impl Locations {
     }
 }
 
-impl<'env, 'pc, 'vm, 'state, 'linkage, 'gas, 'extension>
-    Context<'env, 'pc, 'vm, 'state, 'linkage, 'gas, 'extension>
+impl<'env, 'pc, 'vm, 'state, 'linkage, 'gas, 'extension, E>
+    Context<'env, 'pc, 'vm, 'state, 'linkage, 'gas, 'extension, E>
+where
+    E: ExecutionErrorTrait,
 {
     #[instrument(name = "Context::new", level = "trace", skip_all)]
     pub fn new(
-        env: &'env Env<'pc, 'vm, 'state, 'linkage, 'extension>,
+        env: &'env Env<'pc, 'vm, 'state, 'linkage, 'extension, E>,
         metrics: Arc<ExecutionMetrics>,
         tx_context: Rc<RefCell<TxContext>>,
         gas_charger: &'gas mut GasCharger,
@@ -328,7 +333,7 @@ impl<'env, 'pc, 'vm, 'state, 'linkage, 'gas, 'extension>
         input_withdrawal_metadata: Vec<T::WithdrawalInput>,
         pure_input_metadata: Vec<T::PureInput>,
         receiving_input_metadata: Vec<T::ReceivingInput>,
-    ) -> Result<Self, ExecutionError>
+    ) -> Result<Self, E>
     where
         'pc: 'state,
     {
@@ -457,10 +462,7 @@ impl<'env, 'pc, 'vm, 'state, 'linkage, 'gas, 'extension>
         })
     }
 
-    pub(crate) fn record_gas_coin_transfer(
-        &mut self,
-        transfer: GasCoinTransfer,
-    ) -> Result<(), ExecutionError> {
+    pub(crate) fn record_gas_coin_transfer(&mut self, transfer: GasCoinTransfer) -> Result<(), E> {
         // send funds transfer ==> accumulators/address balances are enabled
         assert_invariant!(
             !matches!(transfer, GasCoinTransfer::SendFunds { .. })
@@ -474,7 +476,7 @@ impl<'env, 'pc, 'vm, 'state, 'linkage, 'gas, 'extension>
         Ok(())
     }
 
-    pub fn finish<Mode: ExecutionMode>(mut self) -> Result<ExecutionResults, ExecutionError> {
+    pub fn finish<Mode: ExecutionMode>(mut self) -> Result<ExecutionResults, E> {
         assert_invariant!(
             !self.locations.tx_context_value.local(0)?.is_invalid()?,
             "tx context value should be present"
@@ -566,9 +568,12 @@ impl<'env, 'pc, 'vm, 'state, 'linkage, 'gas, 'extension>
         let tx_digest = ref_context.borrow().digest();
 
         let object_runtime: ObjectRuntime = native_extensions
-            .try_borrow_mut().map_err(|_| make_invariant_violation!(
+            .try_borrow_mut()
+            .map_err(|_| {
+                make_invariant_violation!(
                 "Should be able to borrow object runtime native extension at the end of execution"
-            ))?
+            )
+            })?
             .remove()
             .map_err(|e| env.convert_vm_error(e.finish(Location::Undefined)))?;
 
@@ -640,7 +645,7 @@ impl<'env, 'pc, 'vm, 'state, 'linkage, 'gas, 'extension>
             };
             // safe because has_public_transfer has been determined by the abilities
             let move_object = unsafe {
-                create_written_object::<Mode>(
+                create_written_object::<Mode, E>(
                     env,
                     &loaded_runtime_objects,
                     id,
@@ -666,7 +671,7 @@ impl<'env, 'pc, 'vm, 'state, 'linkage, 'gas, 'extension>
             written_objects.insert(id, package_obj);
         }
 
-        execution::context::finish(
+        Ok(execution::context::finish(
             env.protocol_config,
             env.state_view,
             gas_charger,
@@ -681,7 +686,7 @@ impl<'env, 'pc, 'vm, 'state, 'linkage, 'gas, 'extension>
             accumulator_events,
             settlement_input_sui,
             settlement_output_sui,
-        )
+        )?)
     }
 
     pub fn take_user_events(
@@ -691,7 +696,7 @@ impl<'env, 'pc, 'vm, 'state, 'linkage, 'gas, 'extension>
         function_def_idx: FunctionDefinitionIndex,
         instr_length: u16,
         linkage: &ExecutableLinkage,
-    ) -> Result<(), ExecutionError> {
+    ) -> Result<(), E> {
         let events = object_runtime_mut!(self)?.take_user_events();
         let Some(num_events) = self.user_events.len().checked_add(events.len()) else {
             invariant_violation!("usize overflow, too many events emitted")
@@ -718,7 +723,7 @@ impl<'env, 'pc, 'vm, 'state, 'linkage, 'gas, 'extension>
                 };
                 Ok((version_mid.clone(), *tag, bytes))
             })
-            .collect::<Result<Vec<_>, ExecutionError>>()?;
+            .collect::<Result<Vec<_>, E>>()?;
         self.user_events.extend(new_events);
         Ok(())
     }
@@ -732,9 +737,9 @@ impl<'env, 'pc, 'vm, 'state, 'linkage, 'gas, 'extension>
     /// it needs to be able to create a VM over any newly published packages as the `init`
     /// functions in those packages may have created objects of types defined in those packages.
     fn make_writeout_vm<I>(
-        env: &Env,
+        env: &Env<'pc, 'vm, 'state, 'linkage, 'extension, E>,
         writes: I,
-    ) -> Result<(MoveVM<'extension>, ExecutableLinkage), ExecutionError>
+    ) -> Result<(MoveVM<'extension>, ExecutableLinkage), E>
     where
         I: IntoIterator<Item = MoveObjectType>,
     {
@@ -744,11 +749,11 @@ impl<'env, 'pc, 'vm, 'state, 'linkage, 'gas, 'extension>
             .map(ObjectID::from)
             .collect::<BTreeSet<_>>();
 
-        let ty_linkage = ExecutableLinkage::type_linkage(&tys_addrs, env.linkable_store)?;
+        let ty_linkage = ExecutableLinkage::type_linkage::<_, E>(&tys_addrs, env.linkable_store)?;
         env.vm
             .make_vm(
                 &env.linkable_store.package_store,
-                ty_linkage.linkage_context()?,
+                ty_linkage.linkage_context::<E>()?,
             )
             .map_err(|e| env.convert_linked_vm_error(e, &ty_linkage))
             .map(|vm| (vm, ty_linkage))
@@ -759,11 +764,11 @@ impl<'env, 'pc, 'vm, 'state, 'linkage, 'gas, 'extension>
     /// the types requested may have only been created during the execution of the transaction and
     /// therefore will not be present in the `resolution_vm`.
     fn load_type_and_layout_from_struct_for_writeout(
-        env: &Env,
+        env: &Env<'pc, 'vm, 'state, 'linkage, 'extension, E>,
         vm: &MoveVM,
         linkage: &ExecutableLinkage,
         tag: StructTag,
-    ) -> Result<(Type, move_core_types::runtime_value::MoveTypeLayout), ExecutionError> {
+    ) -> Result<(Type, move_core_types::runtime_value::MoveTypeLayout), E> {
         let type_tag = TypeTag::Struct(Box::new(tag));
         let vm_type = vm
             .load_type(&type_tag)
@@ -779,11 +784,7 @@ impl<'env, 'pc, 'vm, 'state, 'linkage, 'gas, 'extension>
     // Arguments and Values
     //
 
-    fn location(
-        &mut self,
-        usage: UsageKind,
-        location: T::Location,
-    ) -> Result<Value, ExecutionError> {
+    fn location(&mut self, usage: UsageKind, location: T::Location) -> Result<Value, E> {
         let resolved = self.locations.resolve(location)?;
         let mut local = match resolved {
             ResolvedLocation::Local(l) => l,
@@ -831,14 +832,14 @@ impl<'env, 'pc, 'vm, 'state, 'linkage, 'gas, 'extension>
         })
     }
 
-    fn location_usage(&mut self, usage: T::Usage) -> Result<Value, ExecutionError> {
+    fn location_usage(&mut self, usage: T::Usage) -> Result<Value, E> {
         match usage {
             T::Usage::Move(location) => self.location(UsageKind::Move, location),
             T::Usage::Copy { location, .. } => self.location(UsageKind::Copy, location),
         }
     }
 
-    fn argument_value(&mut self, sp!(_, (arg_, _)): T::Argument) -> Result<Value, ExecutionError> {
+    fn argument_value(&mut self, sp!(_, (arg_, _)): T::Argument) -> Result<Value, E> {
         match arg_ {
             T::Argument__::Use(usage) => self.location_usage(usage),
             // freeze is a no-op for references since the value does not track mutability
@@ -847,12 +848,12 @@ impl<'env, 'pc, 'vm, 'state, 'linkage, 'gas, 'extension>
             T::Argument__::Read(usage) => {
                 let reference = self.location_usage(usage)?;
                 charge_gas!(self, charge_read_ref, &reference)?;
-                reference.read_ref()
+                Ok(reference.read_ref()?)
             }
         }
     }
 
-    pub fn argument<V>(&mut self, arg: T::Argument) -> Result<V, ExecutionError>
+    pub fn argument<V>(&mut self, arg: T::Argument) -> Result<V, E>
     where
         VMValue: VMValueCast<V>,
     {
@@ -864,14 +865,14 @@ impl<'env, 'pc, 'vm, 'state, 'linkage, 'gas, 'extension>
         Ok(value)
     }
 
-    pub fn arguments<V>(&mut self, args: Vec<T::Argument>) -> Result<Vec<V>, ExecutionError>
+    pub fn arguments<V>(&mut self, args: Vec<T::Argument>) -> Result<Vec<V>, E>
     where
         VMValue: VMValueCast<V>,
     {
         args.into_iter().map(|arg| self.argument(arg)).collect()
     }
 
-    pub fn result(&mut self, result: Vec<Option<CtxValue>>) -> Result<(), ExecutionError> {
+    pub fn result(&mut self, result: Vec<Option<CtxValue>>) -> Result<(), E> {
         self.locations
             .results
             .push(Locals::new(result.into_iter().map(|v| v.map(|v| v.0)))?);
@@ -883,7 +884,7 @@ impl<'env, 'pc, 'vm, 'state, 'linkage, 'gas, 'extension>
         is_move_call: bool,
         num_args: usize,
         num_return: usize,
-    ) -> Result<(), ExecutionError> {
+    ) -> Result<(), E> {
         let move_gas_status = self.gas_charger.move_gas_status_mut();
         let before_size = move_gas_status.stack_size_current();
         // Pop all of the arguments
@@ -908,11 +909,11 @@ impl<'env, 'pc, 'vm, 'state, 'linkage, 'gas, 'extension>
         Ok(())
     }
 
-    pub fn copy_value(&mut self, value: &CtxValue) -> Result<CtxValue, ExecutionError> {
+    pub fn copy_value(&mut self, value: &CtxValue) -> Result<CtxValue, E> {
         Ok(CtxValue(copy_value(self.gas_charger, self.env, &value.0)?))
     }
 
-    pub fn new_coin(&mut self, amount: u64) -> Result<CtxValue, ExecutionError> {
+    pub fn new_coin(&mut self, amount: u64) -> Result<CtxValue, E> {
         let id = self.tx_context.borrow_mut().fresh_id();
         object_runtime_mut!(self)?
             .new_id(id)
@@ -920,7 +921,7 @@ impl<'env, 'pc, 'vm, 'state, 'linkage, 'gas, 'extension>
         Ok(CtxValue(Value::coin(id, amount)))
     }
 
-    pub fn destroy_coin(&mut self, coin: CtxValue) -> Result<u64, ExecutionError> {
+    pub fn destroy_coin(&mut self, coin: CtxValue) -> Result<u64, E> {
         let (id, amount) = coin.0.unpack_coin()?;
         object_runtime_mut!(self)?
             .delete_id(id)
@@ -928,7 +929,7 @@ impl<'env, 'pc, 'vm, 'state, 'linkage, 'gas, 'extension>
         Ok(amount)
     }
 
-    pub fn new_upgrade_cap(&mut self, version_id: ObjectID) -> Result<CtxValue, ExecutionError> {
+    pub fn new_upgrade_cap(&mut self, version_id: ObjectID) -> Result<CtxValue, E> {
         let id = self.tx_context.borrow_mut().fresh_id();
         object_runtime_mut!(self)?
             .new_id(id)
@@ -955,7 +956,7 @@ impl<'env, 'pc, 'vm, 'state, 'linkage, 'gas, 'extension>
         function: T::LoadedFunction,
         args: Vec<CtxValue>,
         trace_builder_opt: &mut Option<MoveTraceBuilder>,
-    ) -> Result<Vec<CtxValue>, ExecutionError> {
+    ) -> Result<Vec<CtxValue>, E> {
         with_vm!(self, &function.linkage, |vm: &mut MoveVM<'env>| {
             let ty_args = function
                 .type_arguments
@@ -967,7 +968,7 @@ impl<'env, 'pc, 'vm, 'state, 'linkage, 'gas, 'extension>
                     vm.load_type(&tag)
                         .map_err(|e| self.env.convert_linked_vm_error(e, &function.linkage))
                 })
-                .collect::<Result<Vec<_>, _>>()?;
+                .collect::<Result<Vec<_>, E>>()?;
             let result = self.execute_function_bypass_visibility_with_vm(
                 vm,
                 &function.original_mid,
@@ -984,7 +985,7 @@ impl<'env, 'pc, 'vm, 'state, 'linkage, 'gas, 'extension>
                 function.instruction_length,
                 &function.linkage,
             )?;
-            Ok::<Vec<CtxValue>, ExecutionError>(result)
+            Ok::<Vec<CtxValue>, E>(result)
         })
     }
 
@@ -997,7 +998,7 @@ impl<'env, 'pc, 'vm, 'state, 'linkage, 'gas, 'extension>
         args: Vec<CtxValue>,
         linkage: &ExecutableLinkage,
         tracer: &mut Option<MoveTraceBuilder>,
-    ) -> Result<Vec<CtxValue>, ExecutionError> {
+    ) -> Result<Vec<CtxValue>, E> {
         let gas_status = self.gas_charger.move_gas_status_mut();
         let values = vm
             .execute_function_bypass_visibility(
@@ -1021,7 +1022,7 @@ impl<'env, 'pc, 'vm, 'state, 'linkage, 'gas, 'extension>
         &mut self,
         module_bytes: &[Vec<u8>],
         is_upgrade: bool,
-    ) -> Result<Vec<CompiledModule>, ExecutionError> {
+    ) -> Result<Vec<CompiledModule>, E> {
         assert_invariant!(
             !module_bytes.is_empty(),
             "empty package is checked in transaction input checker"
@@ -1045,10 +1046,7 @@ impl<'env, 'pc, 'vm, 'state, 'linkage, 'gas, 'extension>
         Ok(modules)
     }
 
-    fn fetch_package(
-        &mut self,
-        dependency_id: &ObjectID,
-    ) -> Result<Rc<MovePackage>, ExecutionError> {
+    fn fetch_package(&mut self, dependency_id: &ObjectID) -> Result<Rc<MovePackage>, E> {
         let [fetched_package] = self.fetch_packages(&[*dependency_id])?.try_into().map_err(
             |_| {
                 make_invariant_violation!(
@@ -1059,10 +1057,7 @@ impl<'env, 'pc, 'vm, 'state, 'linkage, 'gas, 'extension>
         Ok(fetched_package)
     }
 
-    fn fetch_packages(
-        &mut self,
-        dependency_ids: &[ObjectID],
-    ) -> Result<Vec<Rc<MovePackage>>, ExecutionError> {
+    fn fetch_packages(&mut self, dependency_ids: &[ObjectID]) -> Result<Vec<Rc<MovePackage>>, E> {
         let mut fetched = vec![];
         let mut missing = vec![];
 
@@ -1075,7 +1070,8 @@ impl<'env, 'pc, 'vm, 'state, 'linkage, 'gas, 'extension>
                     return Err(ExecutionError::new_with_source(
                         ExecutionErrorKind::PublishUpgradeMissingDependency,
                         e,
-                    ));
+                    )
+                    .into());
                 }
                 Ok(Some(inner)) => {
                     fetched.push(inner);
@@ -1104,7 +1100,8 @@ impl<'env, 'pc, 'vm, 'state, 'linkage, 'gas, 'extension>
             Err(ExecutionError::new_with_source(
                 ExecutionErrorKind::PublishUpgradeMissingDependency,
                 msg,
-            ))
+            )
+            .into())
         }
     }
 
@@ -1114,7 +1111,7 @@ impl<'env, 'pc, 'vm, 'state, 'linkage, 'gas, 'extension>
         pkg: &MovePackage,
         modules: &[CompiledModule],
         linkage: &ExecutableLinkage,
-    ) -> Result<(VerifiedPackage, MoveVM<'env>), ExecutionError> {
+    ) -> Result<(VerifiedPackage, MoveVM<'env>), E> {
         let serialized_pkg = pkg.into_serialized_move_package().map_err(|e| {
             make_invariant_violation!("Failed to serialize package for verification: {}", e)
         })?;
@@ -1155,7 +1152,7 @@ impl<'env, 'pc, 'vm, 'state, 'linkage, 'gas, 'extension>
         modules: &[CompiledModule],
         linkage: &ExecutableLinkage,
         trace_builder_opt: &mut Option<MoveTraceBuilder>,
-    ) -> Result<(), ExecutionError> {
+    ) -> Result<(), E> {
         for module in modules {
             let Some((fdef_idx, fdef)) = module.find_function_def_by_name(INIT_FN_NAME.as_str())
             else {
@@ -1222,7 +1219,7 @@ impl<'env, 'pc, 'vm, 'state, 'linkage, 'gas, 'extension>
         dep_ids: &[ObjectID],
         linkage: ResolvedLinkage,
         trace_builder_opt: &mut Option<MoveTraceBuilder>,
-    ) -> Result<ObjectID, ExecutionError> {
+    ) -> Result<ObjectID, E> {
         let original_id = if <Mode>::packages_are_predefined() {
             // do not calculate or substitute id for predefined packages
             (*modules.safe_get(0)?.self_id().address()).into()
@@ -1276,7 +1273,7 @@ impl<'env, 'pc, 'vm, 'state, 'linkage, 'gas, 'extension>
         current_package_id: ObjectID,
         upgrade_ticket_policy: u8,
         linkage: ResolvedLinkage,
-    ) -> Result<ObjectID, ExecutionError> {
+    ) -> Result<ObjectID, E> {
         // Check that this package ID points to a package and get the package we're upgrading.
         let current_move_package = self.fetch_package(&current_package_id)?;
 
@@ -1343,7 +1340,8 @@ impl<'env, 'pc, 'vm, 'state, 'linkage, 'gas, 'extension>
             return Err(ExecutionError::new_with_source(
                 ExecutionErrorKind::FeatureNotYetSupported,
                 "`init` in new modules on upgrade is not yet supported",
-            ));
+            )
+            .into());
         }
 
         self.env.linkable_store.package_store.push_package(
@@ -1363,7 +1361,7 @@ impl<'env, 'pc, 'vm, 'state, 'linkage, 'gas, 'extension>
         recipient: Owner,
         ty: Type,
         object: CtxValue,
-    ) -> Result<(), ExecutionError> {
+    ) -> Result<(), E> {
         self.transfer_object_(recipient, ty, object, /* end of transaction */ false)
     }
 
@@ -1373,7 +1371,7 @@ impl<'env, 'pc, 'vm, 'state, 'linkage, 'gas, 'extension>
         ty: Type,
         object: CtxValue,
         end_of_transaction: bool,
-    ) -> Result<(), ExecutionError> {
+    ) -> Result<(), E> {
         let tag = TypeTag::try_from(ty)
             .map_err(|_| make_invariant_violation!("Unable to convert Type to TypeTag"))?;
         let TypeTag::Struct(tag) = tag else {
@@ -1393,7 +1391,7 @@ impl<'env, 'pc, 'vm, 'state, 'linkage, 'gas, 'extension>
     pub fn argument_updates(
         &mut self,
         args: Vec<T::Argument>,
-    ) -> Result<Vec<(sui_types::transaction::Argument, Vec<u8>, TypeTag)>, ExecutionError> {
+    ) -> Result<Vec<(sui_types::transaction::Argument, Vec<u8>, TypeTag)>, E> {
         args.into_iter()
             .filter_map(|arg| self.argument_update(arg).transpose())
             .collect()
@@ -1402,7 +1400,7 @@ impl<'env, 'pc, 'vm, 'state, 'linkage, 'gas, 'extension>
     fn argument_update(
         &mut self,
         sp!(_, (arg, ty)): T::Argument,
-    ) -> Result<Option<(sui_types::transaction::Argument, Vec<u8>, TypeTag)>, ExecutionError> {
+    ) -> Result<Option<(sui_types::transaction::Argument, Vec<u8>, TypeTag)>, E> {
         use sui_types::transaction::Argument as TxArgument;
         let ty = match ty {
             Type::Reference(true, inner) => (*inner).clone(),
@@ -1489,7 +1487,7 @@ impl<'env, 'pc, 'vm, 'state, 'linkage, 'gas, 'extension>
         &self,
         results: &[CtxValue],
         result_tys: &T::ResultType,
-    ) -> Result<Vec<(Vec<u8>, TypeTag)>, ExecutionError> {
+    ) -> Result<Vec<(Vec<u8>, TypeTag)>, E> {
         assert_invariant!(
             results.len() == result_tys.len(),
             "results and result types should match"
@@ -1501,11 +1499,7 @@ impl<'env, 'pc, 'vm, 'state, 'linkage, 'gas, 'extension>
             .collect()
     }
 
-    fn tracked_result(
-        &self,
-        result: &Value,
-        ty: Type,
-    ) -> Result<(Vec<u8>, TypeTag), ExecutionError> {
+    fn tracked_result(&self, result: &Value, ty: Type) -> Result<(Vec<u8>, TypeTag), E> {
         let inner_value;
         let (v, ty) = match ty {
             Type::Reference(_, inner) => {
@@ -1565,12 +1559,12 @@ impl CtxValue {
     }
 }
 
-fn load_object_arg(
+fn load_object_arg<E: ExecutionErrorTrait>(
     meter: &mut GasCharger,
-    env: &Env,
+    env: &Env<'_, '_, '_, '_, '_, E>,
     input_object_map: &mut BTreeMap<ObjectID, object_runtime::InputObject>,
     input: T::ObjectInput,
-) -> Result<(T::InputIndex, InputObjectMetadata, Value), ExecutionError> {
+) -> Result<(T::InputIndex, InputObjectMetadata, Value), E> {
     let id = input.arg.id();
     let mutability = input.arg.mutability();
     let (metadata, value) =
@@ -1578,14 +1572,14 @@ fn load_object_arg(
     Ok((input.original_input_index, metadata, value))
 }
 
-fn load_object_arg_impl(
+fn load_object_arg_impl<E: ExecutionErrorTrait>(
     meter: &mut GasCharger,
-    env: &Env,
+    env: &Env<'_, '_, '_, '_, '_, E>,
     input_object_map: &mut BTreeMap<ObjectID, object_runtime::InputObject>,
     id: ObjectID,
     mutability: ObjectMutability,
     ty: T::Type,
-) -> Result<(InputObjectMetadata, Value), ExecutionError> {
+) -> Result<(InputObjectMetadata, Value), E> {
     let obj = env.read_object(&id)?;
     let owner = obj.owner.clone();
     let version = obj.version();
@@ -1626,11 +1620,11 @@ fn load_object_arg_impl(
     Ok((object_metadata, v))
 }
 
-fn load_withdrawal_arg(
+fn load_withdrawal_arg<E: ExecutionErrorTrait>(
     meter: &mut GasCharger,
-    env: &Env,
+    env: &Env<'_, '_, '_, '_, '_, E>,
     withdrawal: &T::WithdrawalInput,
-) -> Result<Value, ExecutionError> {
+) -> Result<Value, E> {
     let T::WithdrawalInput {
         original_input_index: _,
         ty: _,
@@ -1643,12 +1637,12 @@ fn load_withdrawal_arg(
     Ok(loaded)
 }
 
-fn load_pure_value(
+fn load_pure_value<E: ExecutionErrorTrait>(
     meter: &mut GasCharger,
-    env: &Env,
+    env: &Env<'_, '_, '_, '_, '_, E>,
     bytes: &[u8],
     metadata: &T::PureInput,
-) -> Result<Value, ExecutionError> {
+) -> Result<Value, E> {
     let loaded = Value::deserialize(env, bytes, metadata.ty.clone())?;
     // ByteValue::Receiving { id, version } => Value::receiving(*id, *version),
     charge_gas_!(meter, env, charge_copy_loc, &loaded)?;
@@ -1656,11 +1650,11 @@ fn load_pure_value(
     Ok(loaded)
 }
 
-fn load_receiving_value(
+fn load_receiving_value<E: ExecutionErrorTrait>(
     meter: &mut GasCharger,
-    env: &Env,
+    env: &Env<'_, '_, '_, '_, '_, E>,
     metadata: &T::ReceivingInput,
-) -> Result<Value, ExecutionError> {
+) -> Result<Value, E> {
     let (id, version, _) = metadata.object_ref;
     let loaded = Value::receiving(id, version);
     charge_gas_!(meter, env, charge_copy_loc, &loaded)?;
@@ -1668,10 +1662,14 @@ fn load_receiving_value(
     Ok(loaded)
 }
 
-fn copy_value(meter: &mut GasCharger, env: &Env, value: &Value) -> Result<Value, ExecutionError> {
+fn copy_value<E: ExecutionErrorTrait>(
+    meter: &mut GasCharger,
+    env: &Env<'_, '_, '_, '_, '_, E>,
+    value: &Value,
+) -> Result<Value, E> {
     charge_gas_!(meter, env, charge_copy_loc, value)?;
     charge_gas_!(meter, env, charge_pop, value)?;
-    value.copy()
+    Ok(value.copy()?)
 }
 
 /// The max budget was deducted from the gas coin at the beginning of the transaction,
@@ -1888,8 +1886,8 @@ fn balance_change_accumulator_event(
 ///
 /// This function assumes proper generation of has_public_transfer, either from the abilities of
 /// the StructTag, or from the runtime correctly propagating from the inputs
-unsafe fn create_written_object<Mode: ExecutionMode>(
-    env: &Env,
+unsafe fn create_written_object<Mode: ExecutionMode, E: ExecutionErrorTrait>(
+    env: &Env<'_, '_, '_, '_, '_, E>,
     objects_modified_at: &BTreeMap<ObjectID, LoadedRuntimeObject>,
     id: ObjectID,
     type_: Type,
@@ -1959,27 +1957,30 @@ pub fn subst_signature(
     })
 }
 
-pub enum EitherError {
+pub enum EitherError<E = ExecutionError>
+where
+    E: ExecutionErrorTrait,
+{
     CommandArgument(CommandArgumentError),
-    Execution(ExecutionError),
+    Execution(E),
 }
 
-impl From<ExecutionError> for EitherError {
+impl<E: ExecutionErrorTrait> From<ExecutionError> for EitherError<E> {
     fn from(e: ExecutionError) -> Self {
-        EitherError::Execution(e)
+        EitherError::Execution(e.into())
     }
 }
 
-impl From<CommandArgumentError> for EitherError {
+impl<E: ExecutionErrorTrait> From<CommandArgumentError> for EitherError<E> {
     fn from(e: CommandArgumentError) -> Self {
         EitherError::CommandArgument(e)
     }
 }
 
-impl EitherError {
-    pub fn into_execution_error(self, command_index: usize) -> ExecutionError {
+impl<E: ExecutionErrorTrait> EitherError<E> {
+    pub fn into_execution_error(self, command_index: usize) -> E {
         match self {
-            EitherError::CommandArgument(e) => command_argument_error(e, command_index),
+            EitherError::CommandArgument(e) => command_argument_error(e, command_index).into(),
             EitherError::Execution(e) => e,
         }
     }

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/execution/context.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/execution/context.rs
@@ -248,11 +248,11 @@ enum ResolvedLocation<'a> {
 }
 
 /// Maintains all runtime state specific to programmable transactions
-pub struct Context<'env, 'pc, 'vm, 'state, 'linkage, 'gas, 'extension, E = ExecutionError>
+pub struct Context<'env, 'pc, 'vm, 'state, 'linkage, 'gas, 'extension, Mode>
 where
-    E: ExecutionErrorTrait,
+    Mode: ExecutionMode,
 {
-    pub env: &'env Env<'pc, 'vm, 'state, 'linkage, 'extension, E>,
+    pub env: &'env Env<'pc, 'vm, 'state, 'linkage, 'extension, Mode>,
     /// Metrics for reporting exceeded limits
     pub metrics: Arc<ExecutionMetrics>,
     pub native_extensions: NativeExtensions<'env>,
@@ -316,14 +316,14 @@ impl Locations {
     }
 }
 
-impl<'env, 'pc, 'vm, 'state, 'linkage, 'gas, 'extension, E>
-    Context<'env, 'pc, 'vm, 'state, 'linkage, 'gas, 'extension, E>
+impl<'env, 'pc, 'vm, 'state, 'linkage, 'gas, 'extension, Mode>
+    Context<'env, 'pc, 'vm, 'state, 'linkage, 'gas, 'extension, Mode>
 where
-    E: ExecutionErrorTrait,
+    Mode: ExecutionMode,
 {
     #[instrument(name = "Context::new", level = "trace", skip_all)]
     pub fn new(
-        env: &'env Env<'pc, 'vm, 'state, 'linkage, 'extension, E>,
+        env: &'env Env<'pc, 'vm, 'state, 'linkage, 'extension, Mode>,
         metrics: Arc<ExecutionMetrics>,
         tx_context: Rc<RefCell<TxContext>>,
         gas_charger: &'gas mut GasCharger,
@@ -333,7 +333,7 @@ where
         input_withdrawal_metadata: Vec<T::WithdrawalInput>,
         pure_input_metadata: Vec<T::PureInput>,
         receiving_input_metadata: Vec<T::ReceivingInput>,
-    ) -> Result<Self, E>
+    ) -> Result<Self, Mode::Error>
     where
         'pc: 'state,
     {
@@ -462,7 +462,10 @@ where
         })
     }
 
-    pub(crate) fn record_gas_coin_transfer(&mut self, transfer: GasCoinTransfer) -> Result<(), E> {
+    pub(crate) fn record_gas_coin_transfer(
+        &mut self,
+        transfer: GasCoinTransfer,
+    ) -> Result<(), Mode::Error> {
         // send funds transfer ==> accumulators/address balances are enabled
         assert_invariant!(
             !matches!(transfer, GasCoinTransfer::SendFunds { .. })
@@ -476,7 +479,7 @@ where
         Ok(())
     }
 
-    pub fn finish<Mode: ExecutionMode>(mut self) -> Result<ExecutionResults, E> {
+    pub fn finish(mut self) -> Result<ExecutionResults, Mode::Error> {
         assert_invariant!(
             !self.locations.tx_context_value.local(0)?.is_invalid()?,
             "tx context value should be present"
@@ -645,7 +648,7 @@ where
             };
             // safe because has_public_transfer has been determined by the abilities
             let move_object = unsafe {
-                create_written_object::<Mode, E>(
+                create_written_object::<Mode>(
                     env,
                     &loaded_runtime_objects,
                     id,
@@ -696,7 +699,7 @@ where
         function_def_idx: FunctionDefinitionIndex,
         instr_length: u16,
         linkage: &ExecutableLinkage,
-    ) -> Result<(), E> {
+    ) -> Result<(), Mode::Error> {
         let events = object_runtime_mut!(self)?.take_user_events();
         let Some(num_events) = self.user_events.len().checked_add(events.len()) else {
             invariant_violation!("usize overflow, too many events emitted")
@@ -723,7 +726,7 @@ where
                 };
                 Ok((version_mid.clone(), *tag, bytes))
             })
-            .collect::<Result<Vec<_>, E>>()?;
+            .collect::<Result<Vec<_>, Mode::Error>>()?;
         self.user_events.extend(new_events);
         Ok(())
     }
@@ -737,9 +740,9 @@ where
     /// it needs to be able to create a VM over any newly published packages as the `init`
     /// functions in those packages may have created objects of types defined in those packages.
     fn make_writeout_vm<I>(
-        env: &Env<'pc, 'vm, 'state, 'linkage, 'extension, E>,
+        env: &Env<'pc, 'vm, 'state, 'linkage, 'extension, Mode>,
         writes: I,
-    ) -> Result<(MoveVM<'extension>, ExecutableLinkage), E>
+    ) -> Result<(MoveVM<'extension>, ExecutableLinkage), Mode::Error>
     where
         I: IntoIterator<Item = MoveObjectType>,
     {
@@ -749,11 +752,12 @@ where
             .map(ObjectID::from)
             .collect::<BTreeSet<_>>();
 
-        let ty_linkage = ExecutableLinkage::type_linkage::<_, E>(&tys_addrs, env.linkable_store)?;
+        let ty_linkage =
+            ExecutableLinkage::type_linkage::<_, Mode::Error>(&tys_addrs, env.linkable_store)?;
         env.vm
             .make_vm(
                 &env.linkable_store.package_store,
-                ty_linkage.linkage_context::<E>()?,
+                ty_linkage.linkage_context::<Mode::Error>()?,
             )
             .map_err(|e| env.convert_linked_vm_error(e, &ty_linkage))
             .map(|vm| (vm, ty_linkage))
@@ -764,11 +768,11 @@ where
     /// the types requested may have only been created during the execution of the transaction and
     /// therefore will not be present in the `resolution_vm`.
     fn load_type_and_layout_from_struct_for_writeout(
-        env: &Env<'pc, 'vm, 'state, 'linkage, 'extension, E>,
+        env: &Env<'pc, 'vm, 'state, 'linkage, 'extension, Mode>,
         vm: &MoveVM,
         linkage: &ExecutableLinkage,
         tag: StructTag,
-    ) -> Result<(Type, move_core_types::runtime_value::MoveTypeLayout), E> {
+    ) -> Result<(Type, move_core_types::runtime_value::MoveTypeLayout), Mode::Error> {
         let type_tag = TypeTag::Struct(Box::new(tag));
         let vm_type = vm
             .load_type(&type_tag)
@@ -784,7 +788,7 @@ where
     // Arguments and Values
     //
 
-    fn location(&mut self, usage: UsageKind, location: T::Location) -> Result<Value, E> {
+    fn location(&mut self, usage: UsageKind, location: T::Location) -> Result<Value, Mode::Error> {
         let resolved = self.locations.resolve(location)?;
         let mut local = match resolved {
             ResolvedLocation::Local(l) => l,
@@ -832,14 +836,14 @@ where
         })
     }
 
-    fn location_usage(&mut self, usage: T::Usage) -> Result<Value, E> {
+    fn location_usage(&mut self, usage: T::Usage) -> Result<Value, Mode::Error> {
         match usage {
             T::Usage::Move(location) => self.location(UsageKind::Move, location),
             T::Usage::Copy { location, .. } => self.location(UsageKind::Copy, location),
         }
     }
 
-    fn argument_value(&mut self, sp!(_, (arg_, _)): T::Argument) -> Result<Value, E> {
+    fn argument_value(&mut self, sp!(_, (arg_, _)): T::Argument) -> Result<Value, Mode::Error> {
         match arg_ {
             T::Argument__::Use(usage) => self.location_usage(usage),
             // freeze is a no-op for references since the value does not track mutability
@@ -853,7 +857,7 @@ where
         }
     }
 
-    pub fn argument<V>(&mut self, arg: T::Argument) -> Result<V, E>
+    pub fn argument<V>(&mut self, arg: T::Argument) -> Result<V, Mode::Error>
     where
         VMValue: VMValueCast<V>,
     {
@@ -865,14 +869,14 @@ where
         Ok(value)
     }
 
-    pub fn arguments<V>(&mut self, args: Vec<T::Argument>) -> Result<Vec<V>, E>
+    pub fn arguments<V>(&mut self, args: Vec<T::Argument>) -> Result<Vec<V>, Mode::Error>
     where
         VMValue: VMValueCast<V>,
     {
         args.into_iter().map(|arg| self.argument(arg)).collect()
     }
 
-    pub fn result(&mut self, result: Vec<Option<CtxValue>>) -> Result<(), E> {
+    pub fn result(&mut self, result: Vec<Option<CtxValue>>) -> Result<(), Mode::Error> {
         self.locations
             .results
             .push(Locals::new(result.into_iter().map(|v| v.map(|v| v.0)))?);
@@ -884,7 +888,7 @@ where
         is_move_call: bool,
         num_args: usize,
         num_return: usize,
-    ) -> Result<(), E> {
+    ) -> Result<(), Mode::Error> {
         let move_gas_status = self.gas_charger.move_gas_status_mut();
         let before_size = move_gas_status.stack_size_current();
         // Pop all of the arguments
@@ -909,11 +913,11 @@ where
         Ok(())
     }
 
-    pub fn copy_value(&mut self, value: &CtxValue) -> Result<CtxValue, E> {
+    pub fn copy_value(&mut self, value: &CtxValue) -> Result<CtxValue, Mode::Error> {
         Ok(CtxValue(copy_value(self.gas_charger, self.env, &value.0)?))
     }
 
-    pub fn new_coin(&mut self, amount: u64) -> Result<CtxValue, E> {
+    pub fn new_coin(&mut self, amount: u64) -> Result<CtxValue, Mode::Error> {
         let id = self.tx_context.borrow_mut().fresh_id();
         object_runtime_mut!(self)?
             .new_id(id)
@@ -921,7 +925,7 @@ where
         Ok(CtxValue(Value::coin(id, amount)))
     }
 
-    pub fn destroy_coin(&mut self, coin: CtxValue) -> Result<u64, E> {
+    pub fn destroy_coin(&mut self, coin: CtxValue) -> Result<u64, Mode::Error> {
         let (id, amount) = coin.0.unpack_coin()?;
         object_runtime_mut!(self)?
             .delete_id(id)
@@ -929,7 +933,7 @@ where
         Ok(amount)
     }
 
-    pub fn new_upgrade_cap(&mut self, version_id: ObjectID) -> Result<CtxValue, E> {
+    pub fn new_upgrade_cap(&mut self, version_id: ObjectID) -> Result<CtxValue, Mode::Error> {
         let id = self.tx_context.borrow_mut().fresh_id();
         object_runtime_mut!(self)?
             .new_id(id)
@@ -956,7 +960,7 @@ where
         function: T::LoadedFunction,
         args: Vec<CtxValue>,
         trace_builder_opt: &mut Option<MoveTraceBuilder>,
-    ) -> Result<Vec<CtxValue>, E> {
+    ) -> Result<Vec<CtxValue>, Mode::Error> {
         with_vm!(self, &function.linkage, |vm: &mut MoveVM<'env>| {
             let ty_args = function
                 .type_arguments
@@ -968,7 +972,7 @@ where
                     vm.load_type(&tag)
                         .map_err(|e| self.env.convert_linked_vm_error(e, &function.linkage))
                 })
-                .collect::<Result<Vec<_>, E>>()?;
+                .collect::<Result<Vec<_>, Mode::Error>>()?;
             let result = self.execute_function_bypass_visibility_with_vm(
                 vm,
                 &function.original_mid,
@@ -985,7 +989,7 @@ where
                 function.instruction_length,
                 &function.linkage,
             )?;
-            Ok::<Vec<CtxValue>, E>(result)
+            Ok::<Vec<CtxValue>, Mode::Error>(result)
         })
     }
 
@@ -998,7 +1002,7 @@ where
         args: Vec<CtxValue>,
         linkage: &ExecutableLinkage,
         tracer: &mut Option<MoveTraceBuilder>,
-    ) -> Result<Vec<CtxValue>, E> {
+    ) -> Result<Vec<CtxValue>, Mode::Error> {
         let gas_status = self.gas_charger.move_gas_status_mut();
         let values = vm
             .execute_function_bypass_visibility(
@@ -1022,7 +1026,7 @@ where
         &mut self,
         module_bytes: &[Vec<u8>],
         is_upgrade: bool,
-    ) -> Result<Vec<CompiledModule>, E> {
+    ) -> Result<Vec<CompiledModule>, Mode::Error> {
         assert_invariant!(
             !module_bytes.is_empty(),
             "empty package is checked in transaction input checker"
@@ -1046,7 +1050,7 @@ where
         Ok(modules)
     }
 
-    fn fetch_package(&mut self, dependency_id: &ObjectID) -> Result<Rc<MovePackage>, E> {
+    fn fetch_package(&mut self, dependency_id: &ObjectID) -> Result<Rc<MovePackage>, Mode::Error> {
         let [fetched_package] = self.fetch_packages(&[*dependency_id])?.try_into().map_err(
             |_| {
                 make_invariant_violation!(
@@ -1057,7 +1061,10 @@ where
         Ok(fetched_package)
     }
 
-    fn fetch_packages(&mut self, dependency_ids: &[ObjectID]) -> Result<Vec<Rc<MovePackage>>, E> {
+    fn fetch_packages(
+        &mut self,
+        dependency_ids: &[ObjectID],
+    ) -> Result<Vec<Rc<MovePackage>>, Mode::Error> {
         let mut fetched = vec![];
         let mut missing = vec![];
 
@@ -1111,7 +1118,7 @@ where
         pkg: &MovePackage,
         modules: &[CompiledModule],
         linkage: &ExecutableLinkage,
-    ) -> Result<(VerifiedPackage, MoveVM<'env>), E> {
+    ) -> Result<(VerifiedPackage, MoveVM<'env>), Mode::Error> {
         let serialized_pkg = pkg.into_serialized_move_package().map_err(|e| {
             make_invariant_violation!("Failed to serialize package for verification: {}", e)
         })?;
@@ -1152,7 +1159,7 @@ where
         modules: &[CompiledModule],
         linkage: &ExecutableLinkage,
         trace_builder_opt: &mut Option<MoveTraceBuilder>,
-    ) -> Result<(), E> {
+    ) -> Result<(), Mode::Error> {
         for module in modules {
             let Some((fdef_idx, fdef)) = module.find_function_def_by_name(INIT_FN_NAME.as_str())
             else {
@@ -1213,14 +1220,14 @@ where
         Ok(())
     }
 
-    pub fn publish_and_init_package<Mode: ExecutionMode>(
+    pub fn publish_and_init_package(
         &mut self,
         mut modules: Vec<CompiledModule>,
         dep_ids: &[ObjectID],
         linkage: ResolvedLinkage,
         trace_builder_opt: &mut Option<MoveTraceBuilder>,
-    ) -> Result<ObjectID, E> {
-        let original_id = if <Mode>::packages_are_predefined() {
+    ) -> Result<ObjectID, Mode::Error> {
+        let original_id = if Mode::packages_are_predefined() {
             // do not calculate or substitute id for predefined packages
             (*modules.safe_get(0)?.self_id().address()).into()
         } else {
@@ -1273,7 +1280,7 @@ where
         current_package_id: ObjectID,
         upgrade_ticket_policy: u8,
         linkage: ResolvedLinkage,
-    ) -> Result<ObjectID, E> {
+    ) -> Result<ObjectID, Mode::Error> {
         // Check that this package ID points to a package and get the package we're upgrading.
         let current_move_package = self.fetch_package(&current_package_id)?;
 
@@ -1361,7 +1368,7 @@ where
         recipient: Owner,
         ty: Type,
         object: CtxValue,
-    ) -> Result<(), E> {
+    ) -> Result<(), Mode::Error> {
         self.transfer_object_(recipient, ty, object, /* end of transaction */ false)
     }
 
@@ -1371,7 +1378,7 @@ where
         ty: Type,
         object: CtxValue,
         end_of_transaction: bool,
-    ) -> Result<(), E> {
+    ) -> Result<(), Mode::Error> {
         let tag = TypeTag::try_from(ty)
             .map_err(|_| make_invariant_violation!("Unable to convert Type to TypeTag"))?;
         let TypeTag::Struct(tag) = tag else {
@@ -1391,7 +1398,7 @@ where
     pub fn argument_updates(
         &mut self,
         args: Vec<T::Argument>,
-    ) -> Result<Vec<(sui_types::transaction::Argument, Vec<u8>, TypeTag)>, E> {
+    ) -> Result<Vec<(sui_types::transaction::Argument, Vec<u8>, TypeTag)>, Mode::Error> {
         args.into_iter()
             .filter_map(|arg| self.argument_update(arg).transpose())
             .collect()
@@ -1400,7 +1407,7 @@ where
     fn argument_update(
         &mut self,
         sp!(_, (arg, ty)): T::Argument,
-    ) -> Result<Option<(sui_types::transaction::Argument, Vec<u8>, TypeTag)>, E> {
+    ) -> Result<Option<(sui_types::transaction::Argument, Vec<u8>, TypeTag)>, Mode::Error> {
         use sui_types::transaction::Argument as TxArgument;
         let ty = match ty {
             Type::Reference(true, inner) => (*inner).clone(),
@@ -1487,7 +1494,7 @@ where
         &self,
         results: &[CtxValue],
         result_tys: &T::ResultType,
-    ) -> Result<Vec<(Vec<u8>, TypeTag)>, E> {
+    ) -> Result<Vec<(Vec<u8>, TypeTag)>, Mode::Error> {
         assert_invariant!(
             results.len() == result_tys.len(),
             "results and result types should match"
@@ -1499,7 +1506,7 @@ where
             .collect()
     }
 
-    fn tracked_result(&self, result: &Value, ty: Type) -> Result<(Vec<u8>, TypeTag), E> {
+    fn tracked_result(&self, result: &Value, ty: Type) -> Result<(Vec<u8>, TypeTag), Mode::Error> {
         let inner_value;
         let (v, ty) = match ty {
             Type::Reference(_, inner) => {
@@ -1559,12 +1566,12 @@ impl CtxValue {
     }
 }
 
-fn load_object_arg<E: ExecutionErrorTrait>(
+fn load_object_arg<Mode: ExecutionMode>(
     meter: &mut GasCharger,
-    env: &Env<'_, '_, '_, '_, '_, E>,
+    env: &Env<'_, '_, '_, '_, '_, Mode>,
     input_object_map: &mut BTreeMap<ObjectID, object_runtime::InputObject>,
     input: T::ObjectInput,
-) -> Result<(T::InputIndex, InputObjectMetadata, Value), E> {
+) -> Result<(T::InputIndex, InputObjectMetadata, Value), Mode::Error> {
     let id = input.arg.id();
     let mutability = input.arg.mutability();
     let (metadata, value) =
@@ -1572,14 +1579,14 @@ fn load_object_arg<E: ExecutionErrorTrait>(
     Ok((input.original_input_index, metadata, value))
 }
 
-fn load_object_arg_impl<E: ExecutionErrorTrait>(
+fn load_object_arg_impl<Mode: ExecutionMode>(
     meter: &mut GasCharger,
-    env: &Env<'_, '_, '_, '_, '_, E>,
+    env: &Env<'_, '_, '_, '_, '_, Mode>,
     input_object_map: &mut BTreeMap<ObjectID, object_runtime::InputObject>,
     id: ObjectID,
     mutability: ObjectMutability,
     ty: T::Type,
-) -> Result<(InputObjectMetadata, Value), E> {
+) -> Result<(InputObjectMetadata, Value), Mode::Error> {
     let obj = env.read_object(&id)?;
     let owner = obj.owner.clone();
     let version = obj.version();
@@ -1620,11 +1627,11 @@ fn load_object_arg_impl<E: ExecutionErrorTrait>(
     Ok((object_metadata, v))
 }
 
-fn load_withdrawal_arg<E: ExecutionErrorTrait>(
+fn load_withdrawal_arg<Mode: ExecutionMode>(
     meter: &mut GasCharger,
-    env: &Env<'_, '_, '_, '_, '_, E>,
+    env: &Env<'_, '_, '_, '_, '_, Mode>,
     withdrawal: &T::WithdrawalInput,
-) -> Result<Value, E> {
+) -> Result<Value, Mode::Error> {
     let T::WithdrawalInput {
         original_input_index: _,
         ty: _,
@@ -1637,12 +1644,12 @@ fn load_withdrawal_arg<E: ExecutionErrorTrait>(
     Ok(loaded)
 }
 
-fn load_pure_value<E: ExecutionErrorTrait>(
+fn load_pure_value<Mode: ExecutionMode>(
     meter: &mut GasCharger,
-    env: &Env<'_, '_, '_, '_, '_, E>,
+    env: &Env<'_, '_, '_, '_, '_, Mode>,
     bytes: &[u8],
     metadata: &T::PureInput,
-) -> Result<Value, E> {
+) -> Result<Value, Mode::Error> {
     let loaded = Value::deserialize(env, bytes, metadata.ty.clone())?;
     // ByteValue::Receiving { id, version } => Value::receiving(*id, *version),
     charge_gas_!(meter, env, charge_copy_loc, &loaded)?;
@@ -1650,11 +1657,11 @@ fn load_pure_value<E: ExecutionErrorTrait>(
     Ok(loaded)
 }
 
-fn load_receiving_value<E: ExecutionErrorTrait>(
+fn load_receiving_value<Mode: ExecutionMode>(
     meter: &mut GasCharger,
-    env: &Env<'_, '_, '_, '_, '_, E>,
+    env: &Env<'_, '_, '_, '_, '_, Mode>,
     metadata: &T::ReceivingInput,
-) -> Result<Value, E> {
+) -> Result<Value, Mode::Error> {
     let (id, version, _) = metadata.object_ref;
     let loaded = Value::receiving(id, version);
     charge_gas_!(meter, env, charge_copy_loc, &loaded)?;
@@ -1662,11 +1669,11 @@ fn load_receiving_value<E: ExecutionErrorTrait>(
     Ok(loaded)
 }
 
-fn copy_value<E: ExecutionErrorTrait>(
+fn copy_value<Mode: ExecutionMode>(
     meter: &mut GasCharger,
-    env: &Env<'_, '_, '_, '_, '_, E>,
+    env: &Env<'_, '_, '_, '_, '_, Mode>,
     value: &Value,
-) -> Result<Value, E> {
+) -> Result<Value, Mode::Error> {
     charge_gas_!(meter, env, charge_copy_loc, value)?;
     charge_gas_!(meter, env, charge_pop, value)?;
     Ok(value.copy()?)
@@ -1886,8 +1893,8 @@ fn balance_change_accumulator_event(
 ///
 /// This function assumes proper generation of has_public_transfer, either from the abilities of
 /// the StructTag, or from the runtime correctly propagating from the inputs
-unsafe fn create_written_object<Mode: ExecutionMode, E: ExecutionErrorTrait>(
-    env: &Env<'_, '_, '_, '_, '_, E>,
+unsafe fn create_written_object<Mode: ExecutionMode>(
+    env: &Env<'_, '_, '_, '_, '_, Mode>,
     objects_modified_at: &BTreeMap<ObjectID, LoadedRuntimeObject>,
     id: ObjectID,
     type_: Type,

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/execution/context.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/execution/context.rs
@@ -967,7 +967,7 @@ where
                 .iter()
                 .map(|ty| {
                     let tag: TypeTag = ty.clone().try_into().map_err(|e| {
-                        ExecutionError::new_with_source(ExecutionErrorKind::VMInvariantViolation, e)
+                        Mode::Error::new_with_source(ExecutionErrorKind::VMInvariantViolation, e)
                     })?;
                     vm.load_type(&tag)
                         .map_err(|e| self.env.convert_linked_vm_error(e, &function.linkage))
@@ -1074,11 +1074,10 @@ where
         for id in &dependency_ids {
             match self.env.linkable_store.get_move_package(id) {
                 Err(e) => {
-                    return Err(ExecutionError::new_with_source(
+                    return Err(Mode::Error::new_with_source(
                         ExecutionErrorKind::PublishUpgradeMissingDependency,
                         e,
-                    )
-                    .into());
+                    ));
                 }
                 Ok(Some(inner)) => {
                     fetched.push(inner);
@@ -1104,11 +1103,10 @@ where
                     .collect::<Vec<_>>()
                     .join(", ")
             );
-            Err(ExecutionError::new_with_source(
+            Err(Mode::Error::new_with_source(
                 ExecutionErrorKind::PublishUpgradeMissingDependency,
                 msg,
-            )
-            .into())
+            ))
         }
     }
 
@@ -1344,11 +1342,10 @@ where
         });
         if new_module_has_init {
             // TODO we cannot run 'init' on upgrade yet due to global type cache limitations
-            return Err(ExecutionError::new_with_source(
+            return Err(Mode::Error::new_with_source(
                 ExecutionErrorKind::FeatureNotYetSupported,
                 "`init` in new modules on upgrade is not yet supported",
-            )
-            .into());
+            ));
         }
 
         self.env.linkable_store.package_store.push_package(
@@ -1395,6 +1392,7 @@ where
     // Dev Inspect tracking
     //
 
+    #[allow(clippy::type_complexity)]
     pub fn argument_updates(
         &mut self,
         args: Vec<T::Argument>,
@@ -1404,6 +1402,7 @@ where
             .collect()
     }
 
+    #[allow(clippy::type_complexity)]
     fn argument_update(
         &mut self,
         sp!(_, (arg, ty)): T::Argument,

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/execution/interpreter.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/execution/interpreter.rs
@@ -36,7 +36,7 @@ use sui_types::{
 use tracing::instrument;
 
 pub fn execute<'env, 'pc, 'vm, 'state, 'linkage, 'extension, Mode: ExecutionMode>(
-    env: &'env mut Env<'pc, 'vm, 'state, 'linkage, 'extension, Mode::Error>,
+    env: &'env mut Env<'pc, 'vm, 'state, 'linkage, 'extension, Mode>,
     metrics: Arc<ExecutionMetrics>,
     tx_context: Rc<RefCell<TxContext>>,
     gas_charger: &mut GasCharger,
@@ -77,7 +77,7 @@ where
 
 fn execute_inner<'env, 'pc, 'vm, 'state, 'linkage, 'extension, Mode: ExecutionMode>(
     timings: &mut IndexedExecutionTimings,
-    env: &'env mut Env<'pc, 'vm, 'state, 'linkage, 'extension, Mode::Error>,
+    env: &'env mut Env<'pc, 'vm, 'state, 'linkage, 'extension, Mode>,
     metrics: Arc<ExecutionMetrics>,
     tx_context: Rc<RefCell<TxContext>>,
     gas_charger: &mut GasCharger,
@@ -147,7 +147,7 @@ where
     let generated_object_ids = object_runtime!(context)?.generated_object_ids();
 
     // apply changes
-    let finished = context.finish::<Mode>();
+    let finished = context.finish();
     // Save loaded objects for debug. We dont want to lose the info
     env.state_view
         .save_loaded_runtime_objects(loaded_runtime_objects);
@@ -162,7 +162,7 @@ where
 /// Execute a single command
 #[instrument(level = "trace", skip_all)]
 fn execute_command<Mode: ExecutionMode>(
-    context: &mut Context<'_, '_, '_, '_, '_, '_, '_, Mode::Error>,
+    context: &mut Context<'_, '_, '_, '_, '_, '_, '_, Mode>,
     mode_results: &mut Mode::ExecutionResults,
     c: T::Command_,
     trace_builder_opt: &mut Option<MoveTraceBuilder>,
@@ -353,12 +353,8 @@ fn execute_command<Mode: ExecutionMode>(
             let modules =
                 context.deserialize_modules(&module_bytes, /* is upgrade */ false)?;
 
-            let original_id = context.publish_and_init_package::<Mode>(
-                modules,
-                &dep_ids,
-                linkage,
-                trace_builder_opt,
-            )?;
+            let original_id =
+                context.publish_and_init_package(modules, &dep_ids, linkage, trace_builder_opt)?;
 
             if <Mode>::packages_are_predefined() {
                 // no upgrade cap for genesis modules

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/execution/interpreter.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/execution/interpreter.rs
@@ -26,7 +26,7 @@ use std::{
 };
 use sui_types::{
     base_types::TxContext,
-    error::ExecutionError,
+    error::{ExecutionError, ExecutionErrorTrait},
     execution::{ExecutionTiming, ResultWithTimings},
     execution_status::{ExecutionErrorKind, PackageUpgradeError},
     metrics::ExecutionMetrics,
@@ -36,13 +36,13 @@ use sui_types::{
 use tracing::instrument;
 
 pub fn execute<'env, 'pc, 'vm, 'state, 'linkage, 'extension, Mode: ExecutionMode>(
-    env: &'env mut Env<'pc, 'vm, 'state, 'linkage, 'extension>,
+    env: &'env mut Env<'pc, 'vm, 'state, 'linkage, 'extension, Mode::Error>,
     metrics: Arc<ExecutionMetrics>,
     tx_context: Rc<RefCell<TxContext>>,
     gas_charger: &mut GasCharger,
     ast: T::Transaction,
     trace_builder_opt: &mut Option<MoveTraceBuilder>,
-) -> ResultWithTimings<Mode::ExecutionResults, ExecutionError>
+) -> ResultWithTimings<Mode::ExecutionResults, Mode::Error>
 where
     'pc: 'state,
     'env: 'state,
@@ -77,13 +77,13 @@ where
 
 fn execute_inner<'env, 'pc, 'vm, 'state, 'linkage, 'extension, Mode: ExecutionMode>(
     timings: &mut IndexedExecutionTimings,
-    env: &'env mut Env<'pc, 'vm, 'state, 'linkage, 'extension>,
+    env: &'env mut Env<'pc, 'vm, 'state, 'linkage, 'extension, Mode::Error>,
     metrics: Arc<ExecutionMetrics>,
     tx_context: Rc<RefCell<TxContext>>,
     gas_charger: &mut GasCharger,
     ast: T::Transaction,
     trace_builder_opt: &mut Option<MoveTraceBuilder>,
-) -> Result<Mode::ExecutionResults, ExecutionError>
+) -> Result<Mode::ExecutionResults, Mode::Error>
 where
     'pc: 'state,
 {
@@ -162,11 +162,11 @@ where
 /// Execute a single command
 #[instrument(level = "trace", skip_all)]
 fn execute_command<Mode: ExecutionMode>(
-    context: &mut Context,
+    context: &mut Context<'_, '_, '_, '_, '_, '_, '_, Mode::Error>,
     mode_results: &mut Mode::ExecutionResults,
     c: T::Command_,
     trace_builder_opt: &mut Option<MoveTraceBuilder>,
-) -> Result<(), ExecutionError> {
+) -> Result<(), Mode::Error> {
     let T::Command_ {
         command,
         result_type,
@@ -253,9 +253,9 @@ fn execute_command<Mode: ExecutionMode>(
             let mut total: u64 = 0;
             for amount in &amount_values {
                 let Some(new_total) = total.checked_add(*amount) else {
-                    return Err(ExecutionError::from_kind(
-                        ExecutionErrorKind::CoinBalanceOverflow,
-                    ));
+                    return Err(
+                        ExecutionError::from_kind(ExecutionErrorKind::CoinBalanceOverflow).into(),
+                    );
                 };
                 total = new_total;
             }
@@ -273,6 +273,7 @@ fn execute_command<Mode: ExecutionMode>(
                     ExecutionErrorKind::InsufficientCoinBalance,
                     format!("balance: {coin_value} required: {total}")
                 )
+                .into()
             );
             coin_ref.coin_ref_subtract_balance(total)?;
             let amounts = amount_values
@@ -321,16 +322,16 @@ fn execute_command<Mode: ExecutionMode>(
             let mut additional: u64 = 0;
             for amount in amounts {
                 let Some(new_additional) = additional.checked_add(amount) else {
-                    return Err(ExecutionError::from_kind(
-                        ExecutionErrorKind::CoinBalanceOverflow,
-                    ));
+                    return Err(
+                        ExecutionError::from_kind(ExecutionErrorKind::CoinBalanceOverflow).into(),
+                    );
                 };
                 additional = new_additional;
             }
             let target_value = context.copy_value(&target_ref)?.coin_ref_value()?;
             fp_ensure!(
                 target_value.checked_add(additional).is_some(),
-                ExecutionError::from_kind(ExecutionErrorKind::CoinBalanceOverflow,)
+                ExecutionError::from_kind(ExecutionErrorKind::CoinBalanceOverflow,).into()
             );
             target_ref.coin_ref_add_balance(additional)?;
             trace_utils::trace_merge_coins(
@@ -379,14 +380,15 @@ fn execute_command<Mode: ExecutionMode>(
                 .into_upgrade_ticket()?;
             // Make sure the passed-in package ID matches the package ID in the `upgrade_ticket`.
             if current_package_id != upgrade_ticket.package.bytes {
-                return Err(ExecutionError::from_kind(
-                    ExecutionErrorKind::PackageUpgradeError {
+                return Err(
+                    ExecutionError::from_kind(ExecutionErrorKind::PackageUpgradeError {
                         upgrade_error: PackageUpgradeError::PackageIDDoesNotMatch {
                             package_id: current_package_id,
                             ticket_id: upgrade_ticket.package.bytes,
                         },
-                    },
-                ));
+                    })
+                    .into(),
+                );
             }
             // deserialize modules and charge gas
             let modules = context.deserialize_modules(&module_bytes, /* is upgrade */ true)?;
@@ -398,13 +400,14 @@ fn execute_command<Mode: ExecutionMode>(
             )
             .to_vec();
             if computed_digest != upgrade_ticket.digest {
-                return Err(ExecutionError::from_kind(
-                    ExecutionErrorKind::PackageUpgradeError {
+                return Err(
+                    ExecutionError::from_kind(ExecutionErrorKind::PackageUpgradeError {
                         upgrade_error: PackageUpgradeError::DigestDoesNotMatch {
                             digest: computed_digest,
                         },
-                    },
-                ));
+                    })
+                    .into(),
+                );
             }
 
             let upgraded_package_id = context.upgrade(

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/execution/interpreter.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/execution/interpreter.rs
@@ -26,7 +26,7 @@ use std::{
 };
 use sui_types::{
     base_types::TxContext,
-    error::{ExecutionError, ExecutionErrorTrait},
+    error::ExecutionErrorTrait,
     execution::{ExecutionTiming, ResultWithTimings},
     execution_status::{ExecutionErrorKind, PackageUpgradeError},
     metrics::ExecutionMetrics,
@@ -253,9 +253,9 @@ fn execute_command<Mode: ExecutionMode>(
             let mut total: u64 = 0;
             for amount in &amount_values {
                 let Some(new_total) = total.checked_add(*amount) else {
-                    return Err(
-                        ExecutionError::from_kind(ExecutionErrorKind::CoinBalanceOverflow).into(),
-                    );
+                    return Err(Mode::Error::from_kind(
+                        ExecutionErrorKind::CoinBalanceOverflow,
+                    ));
                 };
                 total = new_total;
             }
@@ -269,11 +269,10 @@ fn execute_command<Mode: ExecutionMode>(
             let coin_value = context.copy_value(&coin_ref)?.coin_ref_value()?;
             fp_ensure!(
                 coin_value >= total,
-                ExecutionError::new_with_source(
+                Mode::Error::new_with_source(
                     ExecutionErrorKind::InsufficientCoinBalance,
                     format!("balance: {coin_value} required: {total}")
                 )
-                .into()
             );
             coin_ref.coin_ref_subtract_balance(total)?;
             let amounts = amount_values
@@ -322,16 +321,16 @@ fn execute_command<Mode: ExecutionMode>(
             let mut additional: u64 = 0;
             for amount in amounts {
                 let Some(new_additional) = additional.checked_add(amount) else {
-                    return Err(
-                        ExecutionError::from_kind(ExecutionErrorKind::CoinBalanceOverflow).into(),
-                    );
+                    return Err(Mode::Error::from_kind(
+                        ExecutionErrorKind::CoinBalanceOverflow,
+                    ));
                 };
                 additional = new_additional;
             }
             let target_value = context.copy_value(&target_ref)?.coin_ref_value()?;
             fp_ensure!(
                 target_value.checked_add(additional).is_some(),
-                ExecutionError::from_kind(ExecutionErrorKind::CoinBalanceOverflow,).into()
+                Mode::Error::from_kind(ExecutionErrorKind::CoinBalanceOverflow,)
             );
             target_ref.coin_ref_add_balance(additional)?;
             trace_utils::trace_merge_coins(
@@ -376,15 +375,14 @@ fn execute_command<Mode: ExecutionMode>(
                 .into_upgrade_ticket()?;
             // Make sure the passed-in package ID matches the package ID in the `upgrade_ticket`.
             if current_package_id != upgrade_ticket.package.bytes {
-                return Err(
-                    ExecutionError::from_kind(ExecutionErrorKind::PackageUpgradeError {
+                return Err(Mode::Error::from_kind(
+                    ExecutionErrorKind::PackageUpgradeError {
                         upgrade_error: PackageUpgradeError::PackageIDDoesNotMatch {
                             package_id: current_package_id,
                             ticket_id: upgrade_ticket.package.bytes,
                         },
-                    })
-                    .into(),
-                );
+                    },
+                ));
             }
             // deserialize modules and charge gas
             let modules = context.deserialize_modules(&module_bytes, /* is upgrade */ true)?;
@@ -396,14 +394,13 @@ fn execute_command<Mode: ExecutionMode>(
             )
             .to_vec();
             if computed_digest != upgrade_ticket.digest {
-                return Err(
-                    ExecutionError::from_kind(ExecutionErrorKind::PackageUpgradeError {
+                return Err(Mode::Error::from_kind(
+                    ExecutionErrorKind::PackageUpgradeError {
                         upgrade_error: PackageUpgradeError::DigestDoesNotMatch {
                             digest: computed_digest,
                         },
-                    })
-                    .into(),
-                );
+                    },
+                ));
             }
 
             let upgraded_package_id = context.upgrade(

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/execution/trace_utils.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/execution/trace_utils.rs
@@ -6,9 +6,12 @@
 //! tracing is enabled or not to make sure that any errors coming from these functions only manifest itself
 //! when tracing is enabled.
 
-use crate::static_programmable_transactions::{
-    execution::context::{Context, CtxValue},
-    typing::ast::{Command__, Commands, Type},
+use crate::{
+    execution_mode::ExecutionMode,
+    static_programmable_transactions::{
+        execution::context::{Context, CtxValue},
+        typing::ast::{Command__, Commands, Type},
+    },
 };
 use move_core_types::{annotated_value as A, language_storage::TypeTag};
 use move_trace_format::{
@@ -18,7 +21,7 @@ use move_trace_format::{
 use move_vm_runtime::execution::values::Value as VMValue;
 use mysten_common::ZipDebugEqIteratorExt;
 use sui_types::{
-    error::{ExecutionError, ExecutionErrorTrait},
+    error::ExecutionError,
     ptb_trace::{
         ExtMoveValue, ExtMoveValueInfo, ExternalEvent, PTBCommandInfo, PTBEvent, SummaryEvent,
     },
@@ -47,12 +50,12 @@ pub fn trace_move_call_end(trace_builder_opt: &mut Option<MoveTraceBuilder>) {
 
 /// Inserts transfer event into the trace. As is the case for all other public functions in this module,
 /// its body is (and must be) enclosed in an if statement checking if tracing is enabled.
-pub fn trace_transfer<E: ExecutionErrorTrait>(
-    context: &mut Context<'_, '_, '_, '_, '_, '_, '_, E>,
+pub fn trace_transfer<Mode: ExecutionMode>(
+    context: &mut Context<'_, '_, '_, '_, '_, '_, '_, Mode>,
     trace_builder_opt: &mut Option<MoveTraceBuilder>,
     values: &[CtxValue],
     tys: &[Type],
-) -> Result<(), E> {
+) -> Result<(), Mode::Error> {
     if let Some(trace_builder) = trace_builder_opt {
         let mut to_transfer = vec![];
         for (idx, (v, ty)) in values.iter().zip_debug_eq(tys).enumerate() {
@@ -77,11 +80,11 @@ pub fn trace_transfer<E: ExecutionErrorTrait>(
 
 /// Inserts PTB summary event into the trace. As is the case for all other public functions in this module,
 /// its body is (and must be) enclosed in an if statement checking if tracing is enabled.
-pub fn trace_ptb_summary<E: ExecutionErrorTrait>(
-    context: &mut Context<'_, '_, '_, '_, '_, '_, '_, E>,
+pub fn trace_ptb_summary<Mode: ExecutionMode>(
+    context: &mut Context<'_, '_, '_, '_, '_, '_, '_, Mode>,
     trace_builder_opt: &mut Option<MoveTraceBuilder>,
     commands: &Commands,
-) -> Result<(), E> {
+) -> Result<(), Mode::Error> {
     if let Some(trace_builder) = trace_builder_opt {
         let events = commands
             .iter()
@@ -138,7 +141,7 @@ pub fn trace_ptb_summary<E: ExecutionErrorTrait>(
                     Ok(vec![PTBCommandInfo::ExternalEvent("Upgrade".to_string())])
                 }
             })
-            .collect::<Result<Vec<Vec<PTBCommandInfo>>, E>>()?
+            .collect::<Result<Vec<Vec<PTBCommandInfo>>, Mode::Error>>()?
             .into_iter()
             .flatten()
             .collect();
@@ -155,14 +158,14 @@ pub fn trace_ptb_summary<E: ExecutionErrorTrait>(
 
 /// Inserts split coins event into the trace. As is the case for all other public functions in this module,
 /// its body is (and must be) enclosed in an if statement checking if tracing is enabled.
-pub fn trace_split_coins<E: ExecutionErrorTrait>(
-    context: &mut Context<'_, '_, '_, '_, '_, '_, '_, E>,
+pub fn trace_split_coins<Mode: ExecutionMode>(
+    context: &mut Context<'_, '_, '_, '_, '_, '_, '_, Mode>,
     trace_builder_opt: &mut Option<MoveTraceBuilder>,
     coin_type: &Type,
     input_coin: Vec<ExtMoveValueInfo>,
     split_coin_values: &[CtxValue],
     total_split_value: u64,
-) -> Result<(), E> {
+) -> Result<(), Mode::Error> {
     if let Some(trace_builder) = trace_builder_opt {
         let type_tag_with_refs = adapter_type_to_type_tag_with_refs(coin_type)?;
         let layout = annotated_type_layout_for_adapter_ty(context, coin_type)?;
@@ -203,13 +206,13 @@ pub fn trace_split_coins<E: ExecutionErrorTrait>(
 
 /// Inserts merge coins event into the trace. As is the case for all other public functions in this module,
 /// its body is (and must be) enclosed in an if statement checking if tracing is enabled.
-pub fn trace_merge_coins<E: ExecutionErrorTrait>(
-    _context: &mut Context<'_, '_, '_, '_, '_, '_, '_, E>,
+pub fn trace_merge_coins<Mode: ExecutionMode>(
+    _context: &mut Context<'_, '_, '_, '_, '_, '_, '_, Mode>,
     trace_builder_opt: &mut Option<MoveTraceBuilder>,
     _coin_type: &Type,
     mut trace_values: Vec<ExtMoveValueInfo>,
     total_merged_value: u64,
-) -> Result<(), E> {
+) -> Result<(), Mode::Error> {
     if let Some(trace_builder) = trace_builder_opt {
         if trace_values.is_empty() {
             invariant_violation!("Missing destination coin for tracing `MergeCoins`");
@@ -248,12 +251,12 @@ pub fn trace_merge_coins<E: ExecutionErrorTrait>(
 
 /// Inserts make move vec event into the trace. As is the case for all other public functions in this module,
 /// its body is (and must be) enclosed in an if statement checking if tracing is enabled.
-pub fn trace_make_move_vec<E: ExecutionErrorTrait>(
-    context: &mut Context<'_, '_, '_, '_, '_, '_, '_, E>,
+pub fn trace_make_move_vec<Mode: ExecutionMode>(
+    context: &mut Context<'_, '_, '_, '_, '_, '_, '_, Mode>,
     trace_builder_opt: &mut Option<MoveTraceBuilder>,
     values: &[CtxValue],
     type_: &Type,
-) -> Result<(), E> {
+) -> Result<(), Mode::Error> {
     if let Some(trace_builder) = trace_builder_opt {
         let type_tag_with_refs = adapter_type_to_type_tag_with_refs(type_)?;
         let layout = annotated_type_layout_for_adapter_ty(context, type_)?;
@@ -321,13 +324,13 @@ pub fn trace_execution_error(trace_builder_opt: &mut Option<MoveTraceBuilder>, m
 /// Adds `ExtMoveValueInfo` to the mutable vector passed as an argument.
 /// As is the case for all other public functions in this module,
 /// its body is (and must be) enclosed in an if statement checking if tracing is enabled.
-pub fn add_move_value_info_from_ctx_value<E: ExecutionErrorTrait>(
-    context: &mut Context<'_, '_, '_, '_, '_, '_, '_, E>,
+pub fn add_move_value_info_from_ctx_value<Mode: ExecutionMode>(
+    context: &mut Context<'_, '_, '_, '_, '_, '_, '_, Mode>,
     trace_builder_opt: &mut Option<MoveTraceBuilder>,
     move_values: &mut Vec<ExtMoveValueInfo>,
     type_: &Type,
     value: &CtxValue,
-) -> Result<(), E> {
+) -> Result<(), Mode::Error> {
     if trace_builder_opt.is_some()
         && let Some(move_value_info) = move_value_info_from_ctx_value(context, type_, value)?
     {
@@ -337,21 +340,21 @@ pub fn add_move_value_info_from_ctx_value<E: ExecutionErrorTrait>(
 }
 
 /// Creates `ExtMoveValueInfo` from `Value`.
-fn move_value_info_from_ctx_value<E: ExecutionErrorTrait>(
-    context: &mut Context<'_, '_, '_, '_, '_, '_, '_, E>,
+fn move_value_info_from_ctx_value<Mode: ExecutionMode>(
+    context: &mut Context<'_, '_, '_, '_, '_, '_, '_, Mode>,
     type_: &Type,
     value: &CtxValue,
-) -> Result<Option<ExtMoveValueInfo>, E> {
+) -> Result<Option<ExtMoveValueInfo>, Mode::Error> {
     let layout = annotated_type_layout_for_adapter_ty(context, type_)?;
     let value = serializable_move_value_from_ctx_value(value, &layout)?;
     let type_ = adapter_type_to_type_tag_with_refs(type_)?;
     Ok(Some(ExtMoveValueInfo { type_, value }))
 }
 
-fn annotated_type_layout_for_adapter_ty<E: ExecutionErrorTrait>(
-    context: &mut Context<'_, '_, '_, '_, '_, '_, '_, E>,
+fn annotated_type_layout_for_adapter_ty<Mode: ExecutionMode>(
+    context: &mut Context<'_, '_, '_, '_, '_, '_, '_, Mode>,
     type_: &Type,
-) -> Result<A::MoveTypeLayout, E> {
+) -> Result<A::MoveTypeLayout, Mode::Error> {
     Ok(context.env.fully_annotated_layout(type_).map_err(|e| {
         make_invariant_violation!(
             "Failed to get annotated type layout for adapter type: {}",

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/execution/trace_utils.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/execution/trace_utils.rs
@@ -18,7 +18,7 @@ use move_trace_format::{
 use move_vm_runtime::execution::values::Value as VMValue;
 use mysten_common::ZipDebugEqIteratorExt;
 use sui_types::{
-    error::ExecutionError,
+    error::{ExecutionError, ExecutionErrorTrait},
     ptb_trace::{
         ExtMoveValue, ExtMoveValueInfo, ExternalEvent, PTBCommandInfo, PTBEvent, SummaryEvent,
     },
@@ -47,12 +47,12 @@ pub fn trace_move_call_end(trace_builder_opt: &mut Option<MoveTraceBuilder>) {
 
 /// Inserts transfer event into the trace. As is the case for all other public functions in this module,
 /// its body is (and must be) enclosed in an if statement checking if tracing is enabled.
-pub fn trace_transfer(
-    context: &mut Context,
+pub fn trace_transfer<E: ExecutionErrorTrait>(
+    context: &mut Context<'_, '_, '_, '_, '_, '_, '_, E>,
     trace_builder_opt: &mut Option<MoveTraceBuilder>,
     values: &[CtxValue],
     tys: &[Type],
-) -> Result<(), ExecutionError> {
+) -> Result<(), E> {
     if let Some(trace_builder) = trace_builder_opt {
         let mut to_transfer = vec![];
         for (idx, (v, ty)) in values.iter().zip_debug_eq(tys).enumerate() {
@@ -77,11 +77,11 @@ pub fn trace_transfer(
 
 /// Inserts PTB summary event into the trace. As is the case for all other public functions in this module,
 /// its body is (and must be) enclosed in an if statement checking if tracing is enabled.
-pub fn trace_ptb_summary(
-    context: &mut Context,
+pub fn trace_ptb_summary<E: ExecutionErrorTrait>(
+    context: &mut Context<'_, '_, '_, '_, '_, '_, '_, E>,
     trace_builder_opt: &mut Option<MoveTraceBuilder>,
     commands: &Commands,
-) -> Result<(), ExecutionError> {
+) -> Result<(), E> {
     if let Some(trace_builder) = trace_builder_opt {
         let events = commands
             .iter()
@@ -138,7 +138,7 @@ pub fn trace_ptb_summary(
                     Ok(vec![PTBCommandInfo::ExternalEvent("Upgrade".to_string())])
                 }
             })
-            .collect::<Result<Vec<Vec<PTBCommandInfo>>, ExecutionError>>()?
+            .collect::<Result<Vec<Vec<PTBCommandInfo>>, E>>()?
             .into_iter()
             .flatten()
             .collect();
@@ -155,14 +155,14 @@ pub fn trace_ptb_summary(
 
 /// Inserts split coins event into the trace. As is the case for all other public functions in this module,
 /// its body is (and must be) enclosed in an if statement checking if tracing is enabled.
-pub fn trace_split_coins(
-    context: &mut Context,
+pub fn trace_split_coins<E: ExecutionErrorTrait>(
+    context: &mut Context<'_, '_, '_, '_, '_, '_, '_, E>,
     trace_builder_opt: &mut Option<MoveTraceBuilder>,
     coin_type: &Type,
     input_coin: Vec<ExtMoveValueInfo>,
     split_coin_values: &[CtxValue],
     total_split_value: u64,
-) -> Result<(), ExecutionError> {
+) -> Result<(), E> {
     if let Some(trace_builder) = trace_builder_opt {
         let type_tag_with_refs = adapter_type_to_type_tag_with_refs(coin_type)?;
         let layout = annotated_type_layout_for_adapter_ty(context, coin_type)?;
@@ -203,13 +203,13 @@ pub fn trace_split_coins(
 
 /// Inserts merge coins event into the trace. As is the case for all other public functions in this module,
 /// its body is (and must be) enclosed in an if statement checking if tracing is enabled.
-pub fn trace_merge_coins(
-    _context: &mut Context,
+pub fn trace_merge_coins<E: ExecutionErrorTrait>(
+    _context: &mut Context<'_, '_, '_, '_, '_, '_, '_, E>,
     trace_builder_opt: &mut Option<MoveTraceBuilder>,
     _coin_type: &Type,
     mut trace_values: Vec<ExtMoveValueInfo>,
     total_merged_value: u64,
-) -> Result<(), ExecutionError> {
+) -> Result<(), E> {
     if let Some(trace_builder) = trace_builder_opt {
         if trace_values.is_empty() {
             invariant_violation!("Missing destination coin for tracing `MergeCoins`");
@@ -248,12 +248,12 @@ pub fn trace_merge_coins(
 
 /// Inserts make move vec event into the trace. As is the case for all other public functions in this module,
 /// its body is (and must be) enclosed in an if statement checking if tracing is enabled.
-pub fn trace_make_move_vec(
-    context: &mut Context,
+pub fn trace_make_move_vec<E: ExecutionErrorTrait>(
+    context: &mut Context<'_, '_, '_, '_, '_, '_, '_, E>,
     trace_builder_opt: &mut Option<MoveTraceBuilder>,
     values: &[CtxValue],
     type_: &Type,
-) -> Result<(), ExecutionError> {
+) -> Result<(), E> {
     if let Some(trace_builder) = trace_builder_opt {
         let type_tag_with_refs = adapter_type_to_type_tag_with_refs(type_)?;
         let layout = annotated_type_layout_for_adapter_ty(context, type_)?;
@@ -321,13 +321,13 @@ pub fn trace_execution_error(trace_builder_opt: &mut Option<MoveTraceBuilder>, m
 /// Adds `ExtMoveValueInfo` to the mutable vector passed as an argument.
 /// As is the case for all other public functions in this module,
 /// its body is (and must be) enclosed in an if statement checking if tracing is enabled.
-pub fn add_move_value_info_from_ctx_value(
-    context: &mut Context,
+pub fn add_move_value_info_from_ctx_value<E: ExecutionErrorTrait>(
+    context: &mut Context<'_, '_, '_, '_, '_, '_, '_, E>,
     trace_builder_opt: &mut Option<MoveTraceBuilder>,
     move_values: &mut Vec<ExtMoveValueInfo>,
     type_: &Type,
     value: &CtxValue,
-) -> Result<(), ExecutionError> {
+) -> Result<(), E> {
     if trace_builder_opt.is_some()
         && let Some(move_value_info) = move_value_info_from_ctx_value(context, type_, value)?
     {
@@ -337,27 +337,27 @@ pub fn add_move_value_info_from_ctx_value(
 }
 
 /// Creates `ExtMoveValueInfo` from `Value`.
-fn move_value_info_from_ctx_value(
-    context: &mut Context,
+fn move_value_info_from_ctx_value<E: ExecutionErrorTrait>(
+    context: &mut Context<'_, '_, '_, '_, '_, '_, '_, E>,
     type_: &Type,
     value: &CtxValue,
-) -> Result<Option<ExtMoveValueInfo>, ExecutionError> {
+) -> Result<Option<ExtMoveValueInfo>, E> {
     let layout = annotated_type_layout_for_adapter_ty(context, type_)?;
     let value = serializable_move_value_from_ctx_value(value, &layout)?;
     let type_ = adapter_type_to_type_tag_with_refs(type_)?;
     Ok(Some(ExtMoveValueInfo { type_, value }))
 }
 
-fn annotated_type_layout_for_adapter_ty(
-    context: &mut Context,
+fn annotated_type_layout_for_adapter_ty<E: ExecutionErrorTrait>(
+    context: &mut Context<'_, '_, '_, '_, '_, '_, '_, E>,
     type_: &Type,
-) -> Result<A::MoveTypeLayout, ExecutionError> {
-    context.env.fully_annotated_layout(type_).map_err(|e| {
+) -> Result<A::MoveTypeLayout, E> {
+    Ok(context.env.fully_annotated_layout(type_).map_err(|e| {
         make_invariant_violation!(
             "Failed to get annotated type layout for adapter type: {}",
             e
         )
-    })
+    })?)
 }
 
 /// Creates a `SerializableMoveValue` (a Move value for the trace format) from a `CtxValue` and a

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/execution/values.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/execution/values.rs
@@ -17,7 +17,7 @@ use move_vm_runtime::{
 use sui_types::{
     base_types::{ObjectID, SequenceNumber},
     digests::TransactionDigest,
-    error::ExecutionError,
+    error::{ExecutionError, ExecutionErrorTrait},
     move_package::{UpgradeCap, UpgradeReceipt, UpgradeTicket},
 };
 pub enum InputValue<'a> {
@@ -178,7 +178,11 @@ impl Value {
         self.0.cast().map_err(iv("cast"))
     }
 
-    pub fn deserialize(env: &Env, bytes: &[u8], ty: Type) -> Result<Value, ExecutionError> {
+    pub fn deserialize<E: ExecutionErrorTrait>(
+        env: &Env<'_, '_, '_, '_, '_, E>,
+        bytes: &[u8],
+        ty: Type,
+    ) -> Result<Value, E> {
         let layout = env.runtime_layout(&ty)?;
         let Some(value) = VMValue::simple_deserialize(bytes, &layout) else {
             // we already checked the layout of pure bytes during typing

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/execution/values.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/execution/values.rs
@@ -3,7 +3,10 @@
 
 use std::collections::BTreeMap;
 
-use crate::static_programmable_transactions::{env::Env, typing::ast::Type};
+use crate::{
+    execution_mode::ExecutionMode,
+    static_programmable_transactions::{env::Env, typing::ast::Type},
+};
 use move_binary_format::errors::{PartialVMError, PartialVMResult};
 use move_core_types::account_address::AccountAddress;
 use move_core_types::runtime_value::MoveTypeLayout;
@@ -17,7 +20,7 @@ use move_vm_runtime::{
 use sui_types::{
     base_types::{ObjectID, SequenceNumber},
     digests::TransactionDigest,
-    error::{ExecutionError, ExecutionErrorTrait},
+    error::ExecutionError,
     move_package::{UpgradeCap, UpgradeReceipt, UpgradeTicket},
 };
 pub enum InputValue<'a> {
@@ -178,11 +181,11 @@ impl Value {
         self.0.cast().map_err(iv("cast"))
     }
 
-    pub fn deserialize<E: ExecutionErrorTrait>(
-        env: &Env<'_, '_, '_, '_, '_, E>,
+    pub fn deserialize<Mode: ExecutionMode>(
+        env: &Env<'_, '_, '_, '_, '_, Mode>,
         bytes: &[u8],
         ty: Type,
-    ) -> Result<Value, E> {
+    ) -> Result<Value, Mode::Error> {
         let layout = env.runtime_layout(&ty)?;
         let Some(value) = VMValue::simple_deserialize(bytes, &layout) else {
             // we already checked the layout of pure bytes during typing

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/linkage/analysis.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/linkage/analysis.rs
@@ -19,9 +19,7 @@ use move_core_types::identifier::IdentStr;
 use move_vm_runtime::validation::verification::ast::Package as VerifiedPackage;
 use sui_protocol_config::ProtocolConfig;
 use sui_types::{
-    base_types::ObjectID,
-    error::{ExecutionError, ExecutionErrorTrait},
-    execution_status::ExecutionErrorKind,
+    base_types::ObjectID, error::ExecutionErrorTrait, execution_status::ExecutionErrorKind,
     transaction::ProgrammableTransaction,
 };
 
@@ -31,9 +29,7 @@ pub struct LinkageAnalyzer {
 }
 
 impl LinkageAnalyzer {
-    pub fn new<Mode: ExecutionMode>(
-        protocol_config: &ProtocolConfig,
-    ) -> Result<Self, ExecutionError> {
+    pub fn new<Mode: ExecutionMode>(protocol_config: &ProtocolConfig) -> Result<Self, Mode::Error> {
         let always_include_system_packages = !Mode::packages_are_predefined();
         let linkage_config = LinkageConfig::legacy_linkage_settings(always_include_system_packages);
         let binary_config = protocol_config.binary_config(None);

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/linkage/analysis.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/linkage/analysis.rs
@@ -19,7 +19,9 @@ use move_core_types::identifier::IdentStr;
 use move_vm_runtime::validation::verification::ast::Package as VerifiedPackage;
 use sui_protocol_config::ProtocolConfig;
 use sui_types::{
-    base_types::ObjectID, error::ExecutionError, execution_status::ExecutionErrorKind,
+    base_types::ObjectID,
+    error::{ExecutionError, ExecutionErrorTrait},
+    execution_status::ExecutionErrorKind,
     transaction::ProgrammableTransaction,
 };
 
@@ -43,14 +45,14 @@ impl LinkageAnalyzer {
         })
     }
 
-    pub fn compute_call_linkage(
+    pub fn compute_call_linkage<E: ExecutionErrorTrait>(
         &self,
         package: &ObjectID,
         module_name: &IdentStr,
         function_name: &IdentStr,
         type_args: &[Type],
         store: &dyn PackageStore,
-    ) -> Result<ExecutableLinkage, ExecutionError> {
+    ) -> Result<ExecutableLinkage, E> {
         Ok(ExecutableLinkage::new(
             ResolvedLinkage::from_resolution_table(self.compute_call_linkage_(
                 package,
@@ -62,11 +64,11 @@ impl LinkageAnalyzer {
         ))
     }
 
-    pub fn compute_publication_linkage(
+    pub fn compute_publication_linkage<E: ExecutionErrorTrait>(
         &self,
         deps: &[ObjectID],
         store: &dyn PackageStore,
-    ) -> Result<ResolvedLinkage, ExecutionError> {
+    ) -> Result<ResolvedLinkage, E> {
         Ok(ResolvedLinkage::from_resolution_table(
             self.compute_publication_linkage_(deps, store)?,
         ))
@@ -76,12 +78,12 @@ impl LinkageAnalyzer {
         &self.internal
     }
 
-    pub fn compute_input_type_resolution_linkage(
+    pub fn compute_input_type_resolution_linkage<E: ExecutionErrorTrait>(
         &self,
         tx: &ProgrammableTransaction,
         package_store: &dyn PackageStore,
         object_store: &dyn ExecutionState,
-    ) -> Result<ExecutableLinkage, ExecutionError> {
+    ) -> Result<ExecutableLinkage, E> {
         input_type_resolution_analysis::compute_resolution_linkage(
             self,
             tx,
@@ -90,26 +92,26 @@ impl LinkageAnalyzer {
         )
     }
 
-    fn compute_call_linkage_(
+    fn compute_call_linkage_<E: ExecutionErrorTrait>(
         &self,
         package: &ObjectID,
         module_name: &IdentStr,
         function_name: &IdentStr,
         type_args: &[Type],
         store: &dyn PackageStore,
-    ) -> Result<ResolutionTable, ExecutionError> {
+    ) -> Result<ResolutionTable, E> {
         let mut resolution_table = self
             .internal
             .linkage_config
             .resolution_table_with_native_packages(store)?;
 
-        fn add_package(
+        fn add_package<E: ExecutionErrorTrait>(
             object_id: &ObjectID,
             store: &dyn PackageStore,
             resolution_table: &mut ResolutionTable,
             self_resolution_fn: fn(&VerifiedPackage) -> Option<VersionConstraint>,
             dep_resolution_fn: fn(&VerifiedPackage) -> Option<VersionConstraint>,
-        ) -> Result<(), ExecutionError> {
+        ) -> Result<(), E> {
             let pkg = get_package(object_id, store)?;
             let transitive_deps = pkg.linkage_table().values().copied().map(ObjectID::from);
             for object_id in transitive_deps {
@@ -120,8 +122,8 @@ impl LinkageAnalyzer {
         }
 
         let pkg = get_package(package, store)?;
-        let fn_not_found_err = || {
-            ExecutionError::new_with_source(
+        let fn_not_found_err = || -> E {
+            E::new_with_source(
                 ExecutionErrorKind::FunctionNotFound,
                 format!(
                     "Could not resolve function '{}' in module '{}::{}'",
@@ -167,11 +169,11 @@ impl LinkageAnalyzer {
     }
 
     /// Compute the linkage for a publish or upgrade command. This is a special case because
-    fn compute_publication_linkage_(
+    fn compute_publication_linkage_<E: ExecutionErrorTrait>(
         &self,
         deps: &[ObjectID],
         store: &dyn PackageStore,
-    ) -> Result<ResolutionTable, ExecutionError> {
+    ) -> Result<ResolutionTable, E> {
         let mut resolution_table = self
             .internal
             .linkage_config
@@ -196,7 +198,7 @@ mod input_type_resolution_analysis {
     use move_core_types::language_storage::StructTag;
     use sui_types::{
         base_types::ObjectID,
-        error::ExecutionError,
+        error::ExecutionErrorTrait,
         execution_status::ExecutionErrorKind,
         transaction::{
             CallArg, Command, FundsWithdrawalArg, ObjectArg, ProgrammableMoveCall,
@@ -205,12 +207,12 @@ mod input_type_resolution_analysis {
         type_input::TypeInput,
     };
 
-    pub(super) fn compute_resolution_linkage(
+    pub(super) fn compute_resolution_linkage<E: ExecutionErrorTrait>(
         analyzer: &LinkageAnalyzer,
         tx: &ProgrammableTransaction,
         package_store: &dyn PackageStore,
         object_store: &dyn ExecutionState,
-    ) -> Result<ExecutableLinkage, ExecutionError> {
+    ) -> Result<ExecutableLinkage, E> {
         let ProgrammableTransaction { inputs, commands } = tx;
 
         let mut resolution_table = analyzer
@@ -230,12 +232,12 @@ mod input_type_resolution_analysis {
         ))
     }
 
-    fn input(
+    fn input<E: ExecutionErrorTrait>(
         resolution_table: &mut ResolutionTable,
         arg: &CallArg,
         package_store: &dyn PackageStore,
         object_store: &dyn ExecutionState,
-    ) -> Result<(), ExecutionError> {
+    ) -> Result<(), E> {
         match arg {
             CallArg::Pure(_) | CallArg::Object(ObjectArg::Receiving(_)) => (),
             CallArg::Object(
@@ -268,14 +270,14 @@ mod input_type_resolution_analysis {
         Ok(())
     }
 
-    fn command(
+    fn command<E: ExecutionErrorTrait>(
         resolution_table: &mut ResolutionTable,
         command: &Command,
         package_store: &dyn PackageStore,
-    ) -> Result<(), ExecutionError> {
-        let mut add_ty_input = |ty: &TypeInput| {
+    ) -> Result<(), E> {
+        let mut add_ty_input = |ty: &TypeInput| -> Result<(), E> {
             let tag = ty.to_type_tag().map_err(|e| {
-                ExecutionError::new_with_source(
+                E::new_with_source(
                     ExecutionErrorKind::InvalidLinkage,
                     format!("Invalid type tag in move call argument: {:?}", e),
                 )

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/linkage/config.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/linkage/config.rs
@@ -10,7 +10,7 @@ use crate::{
 use move_binary_format::binary_config::BinaryConfig;
 use sui_types::{
     MOVE_STDLIB_PACKAGE_ID, SUI_FRAMEWORK_PACKAGE_ID, SUI_SYSTEM_PACKAGE_ID, base_types::ObjectID,
-    error::ExecutionError,
+    error::ExecutionErrorTrait,
 };
 
 /// These are the set of native packages in Sui -- importantly they can be used implicitly by
@@ -57,10 +57,13 @@ impl LinkageConfig {
         }
     }
 
-    pub(crate) fn resolution_table_with_native_packages(
+    pub(crate) fn resolution_table_with_native_packages<E>(
         &self,
         store: &dyn PackageStore,
-    ) -> Result<ResolutionTable, ExecutionError> {
+    ) -> Result<ResolutionTable, E>
+    where
+        E: ExecutionErrorTrait,
+    {
         let mut resolution_table = ResolutionTable::empty();
         if self.always_include_system_packages {
             for id in NATIVE_PACKAGE_IDS {

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/linkage/resolution.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/linkage/resolution.rs
@@ -9,7 +9,7 @@ use std::{
     sync::Arc,
 };
 use sui_types::{
-    base_types::ObjectID, error::ExecutionError, execution_status::ExecutionErrorKind,
+    base_types::ObjectID, error::ExecutionErrorTrait, execution_status::ExecutionErrorKind,
 };
 
 /// Unifiers. These are used to determine how to unify two packages.
@@ -44,12 +44,13 @@ impl ResolutionTable {
     /// Given a list of object IDs, generate a `ResolvedLinkage` for them.
     /// Since this linkage analysis should only be used for types, all packages are resolved
     /// "upwards" (i.e., later versions of the package are preferred).
-    pub fn add_type_linkages_to_table<I>(
+    pub fn add_type_linkages_to_table<I, E>(
         &mut self,
         ids: I,
         store: &dyn PackageStore,
-    ) -> Result<(), ExecutionError>
+    ) -> Result<(), E>
     where
+        E: ExecutionErrorTrait,
         I: IntoIterator,
         I::Item: Borrow<ObjectID>,
     {
@@ -81,12 +82,15 @@ impl VersionConstraint {
         ))
     }
 
-    pub fn unify(&self, other: &VersionConstraint) -> Result<VersionConstraint, ExecutionError> {
+    pub fn unify<E: ExecutionErrorTrait>(
+        &self,
+        other: &VersionConstraint,
+    ) -> Result<VersionConstraint, E> {
         match (&self, other) {
             // If we have two exact resolutions, they must be the same.
             (VersionConstraint::Exact(sv, self_id), VersionConstraint::Exact(ov, other_id)) => {
                 if self_id != other_id || sv != ov {
-                    Err(ExecutionError::new_with_source(
+                    Err(E::new_with_source(
                         ExecutionErrorKind::InvalidLinkage,
                         format!(
                             "exact/exact conflicting resolutions for package: linkage requires the same package \
@@ -125,7 +129,7 @@ impl VersionConstraint {
                 VersionConstraint::Exact(exact_version, exact_id),
             ) => {
                 if exact_version < at_least_version {
-                    return Err(ExecutionError::new_with_source(
+                    return Err(E::new_with_source(
                         ExecutionErrorKind::InvalidLinkage,
                         format!(
                             "Exact/AtLeast conflicting resolutions for package: linkage requires exactly this \
@@ -144,26 +148,27 @@ impl VersionConstraint {
 
 /// Load a package from the store, and update the type origin map with the types in that
 /// package.
-pub(crate) fn get_package(
+pub(crate) fn get_package<E: ExecutionErrorTrait>(
     object_id: &ObjectID,
     store: &dyn PackageStore,
-) -> Result<Arc<VerifiedPackage>, ExecutionError> {
+) -> Result<Arc<VerifiedPackage>, E> {
     store
         .get_package(object_id)
-        .map_err(|e| {
-            ExecutionError::new_with_source(ExecutionErrorKind::PublishUpgradeMissingDependency, e)
-        })?
-        .ok_or_else(|| ExecutionError::from_kind(ExecutionErrorKind::InvalidLinkage))
+        .map_err(|e| E::new_with_source(ExecutionErrorKind::PublishUpgradeMissingDependency, e))?
+        .ok_or_else(|| E::from_kind(ExecutionErrorKind::InvalidLinkage))
 }
 
 // Add a package to the unification table, unifying it with any existing package in the table.
 // Errors if the packages cannot be unified (e.g., if one is exact and the other is not).
-pub(crate) fn add_and_unify(
+pub(crate) fn add_and_unify<E>(
     object_id: &ObjectID,
     store: &dyn PackageStore,
     resolution_table: &mut ResolutionTable,
     resolution_fn: fn(&VerifiedPackage) -> Option<VersionConstraint>,
-) -> Result<(), ExecutionError> {
+) -> Result<(), E>
+where
+    E: ExecutionErrorTrait,
+{
     let package = get_package(object_id, store)?;
 
     let Some(resolution) = resolution_fn(&package) else {

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/linkage/resolved_linkage.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/linkage/resolved_linkage.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use move_vm_runtime::shared::linkage_context::LinkageContext;
 use std::{borrow::Borrow, collections::BTreeMap, rc::Rc};
-use sui_types::{base_types::ObjectID, error::ExecutionError};
+use sui_types::{base_types::ObjectID, error::ExecutionErrorTrait};
 
 #[derive(Clone, Debug)]
 pub struct ExecutableLinkage(pub Rc<ResolvedLinkage>);
@@ -20,8 +20,9 @@ impl ExecutableLinkage {
     /// Given a list of object IDs, generate a `ResolvedLinkage` for them.
     /// Since this linkage analysis should only be used for types, all packages are resolved
     /// "upwards" (i.e., later versions of the package are preferred).
-    pub fn type_linkage<I>(ids: I, store: &dyn PackageStore) -> Result<Self, ExecutionError>
+    pub fn type_linkage<I, E>(ids: I, store: &dyn PackageStore) -> Result<Self, E>
     where
+        E: ExecutionErrorTrait,
         I: IntoIterator,
         I::Item: Borrow<ObjectID>,
     {
@@ -32,12 +33,13 @@ impl ExecutableLinkage {
         )))
     }
 
-    pub fn linkage_context(&self) -> Result<LinkageContext, ExecutionError> {
+    pub fn linkage_context<E: ExecutionErrorTrait>(&self) -> Result<LinkageContext, E> {
         LinkageContext::new(self.0.linkage.iter().map(|(k, v)| (**k, **v)).collect()).map_err(|e| {
             make_invariant_violation!(
                 "Failed to create linkage context from resolved linkage: {:?}",
                 e
             )
+            .into()
         })
     }
 }

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/loading/translate.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/loading/translate.rs
@@ -21,7 +21,7 @@ use sui_types::{
 
 pub fn transaction<Mode: ExecutionMode>(
     meter: &mut TranslationMeter<'_, '_>,
-    env: &Env<'_, '_, '_, '_, '_, Mode::Error>,
+    env: &Env<'_, '_, '_, '_, '_, Mode>,
     tx_context: &TxContext,
     // which inputs are withdrawals that need to be converted to coins, must
     // be the same length as the inputs
@@ -69,7 +69,7 @@ pub fn transaction<Mode: ExecutionMode>(
 }
 
 fn input<Mode: ExecutionMode>(
-    env: &Env<'_, '_, '_, '_, '_, Mode::Error>,
+    env: &Env<'_, '_, '_, '_, '_, Mode>,
     tx_context: &TxContext,
     // True iff this is a withdrawal that needs to be converted to a coin
     is_withdrawal_compatibility_input: bool,
@@ -198,7 +198,7 @@ fn object_mutability(mutability: SharedObjectMutability) -> L::ObjectMutability 
 }
 
 fn command<Mode: ExecutionMode>(
-    env: &Env<'_, '_, '_, '_, '_, Mode::Error>,
+    env: &Env<'_, '_, '_, '_, '_, Mode>,
     command: P::Command,
 ) -> Result<L::Command, Mode::Error> {
     Ok(match command {

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/loading/translate.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/loading/translate.rs
@@ -14,22 +14,22 @@ use move_core_types::{account_address::AccountAddress, language_storage::StructT
 use mysten_common::ZipDebugEqIteratorExt;
 use sui_types::{
     base_types::TxContext,
-    error::ExecutionError,
+    error::ExecutionErrorTrait,
     object::Owner,
     transaction::{self as P, CallArg, FundsWithdrawalArg, ObjectArg, SharedObjectMutability},
 };
 
 pub fn transaction<Mode: ExecutionMode>(
     meter: &mut TranslationMeter<'_, '_>,
-    env: &Env,
+    env: &Env<'_, '_, '_, '_, '_, Mode::Error>,
     tx_context: &TxContext,
     // which inputs are withdrawals that need to be converted to coins, must
     // be the same length as the inputs
     withdrawal_compatibility_inputs: Option<Vec<bool>>,
     gas_payment: Option<GasPayment>,
     pt: P::ProgrammableTransaction,
-) -> Result<L::Transaction, ExecutionError> {
-    metering::pre_translation::meter(meter, &pt)?;
+) -> Result<L::Transaction, Mode::Error> {
+    metering::pre_translation::meter::<Mode::Error>(meter, &pt)?;
     let P::ProgrammableTransaction { inputs, commands } = pt;
     // withdrawal_compatibility_inputs specified ==> the protocol config flag is set
     assert_invariant!(
@@ -56,7 +56,7 @@ pub fn transaction<Mode: ExecutionMode>(
     let commands = commands
         .into_iter()
         .enumerate()
-        .map(|(idx, cmd)| command(env, cmd).map_err(|e| e.with_command_index(idx)))
+        .map(|(idx, cmd)| command::<Mode>(env, cmd).map_err(|e| e.with_command_index(idx)))
         .collect::<Result<Vec<_>, _>>()?;
     let loaded_tx = L::Transaction {
         gas_payment,
@@ -64,17 +64,17 @@ pub fn transaction<Mode: ExecutionMode>(
         original_command_len,
         commands,
     };
-    metering::loading::meter(meter, &loaded_tx)?;
+    metering::loading::meter::<Mode::Error>(meter, &loaded_tx)?;
     Ok(loaded_tx)
 }
 
 fn input<Mode: ExecutionMode>(
-    env: &Env,
+    env: &Env<'_, '_, '_, '_, '_, Mode::Error>,
     tx_context: &TxContext,
     // True iff this is a withdrawal that needs to be converted to a coin
     is_withdrawal_compatibility_input: bool,
     arg: CallArg,
-) -> Result<(L::InputArg, L::InputType), ExecutionError> {
+) -> Result<(L::InputArg, L::InputType), Mode::Error> {
     // is_withdrawal_compatibility_input ==> FundsWithdrawal
     assert_invariant!(
         !is_withdrawal_compatibility_input || matches!(arg, CallArg::FundsWithdrawal(_)),
@@ -197,7 +197,10 @@ fn object_mutability(mutability: SharedObjectMutability) -> L::ObjectMutability 
     }
 }
 
-fn command(env: &Env, command: P::Command) -> Result<L::Command, ExecutionError> {
+fn command<Mode: ExecutionMode>(
+    env: &Env<'_, '_, '_, '_, '_, Mode::Error>,
+    command: P::Command,
+) -> Result<L::Command, Mode::Error> {
     Ok(match command {
         P::Command::MoveCall(pmc) => {
             let P::ProgrammableMoveCall {
@@ -232,13 +235,13 @@ fn command(env: &Env, command: P::Command) -> Result<L::Command, ExecutionError>
         P::Command::Publish(items, object_ids) => {
             let resolved_linkage = env
                 .linkage_analysis
-                .compute_publication_linkage(&object_ids, env.linkable_store)?;
+                .compute_publication_linkage::<Mode::Error>(&object_ids, env.linkable_store)?;
             L::Command::Publish(items, object_ids, resolved_linkage)
         }
         P::Command::Upgrade(items, object_ids, object_id, argument) => {
             let resolved_linkage = env
                 .linkage_analysis
-                .compute_publication_linkage(&object_ids, env.linkable_store)?;
+                .compute_publication_linkage::<Mode::Error>(&object_ids, env.linkable_store)?;
             L::Command::Upgrade(items, object_ids, object_id, argument, resolved_linkage)
         }
     })

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/metering/loading.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/metering/loading.rs
@@ -5,15 +5,15 @@ use crate::static_programmable_transactions::{
     linkage::resolved_linkage::ResolvedLinkage, loading::ast as L,
     metering::translation_meter::TranslationMeter,
 };
-use sui_types::error::ExecutionError;
+use sui_types::error::ExecutionErrorTrait;
 
 /// After loading and before type checking we do a pass over the loaded transaction to charge for
 /// types that occured in the transaction and were loaded. We simply charge for the number of type
 /// nodes that were loaded.
-pub fn meter(
+pub fn meter<E: ExecutionErrorTrait>(
     meter: &mut TranslationMeter,
     transaction: &L::Transaction,
-) -> Result<(), ExecutionError> {
+) -> Result<(), E> {
     let inputs = transaction.inputs.iter().filter_map(|i| match &i.1 {
         L::InputType::Bytes => None,
         L::InputType::Fixed(ty) => Some(ty),

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/metering/pre_translation.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/metering/pre_translation.rs
@@ -3,7 +3,7 @@
 
 use crate::static_programmable_transactions::metering::translation_meter::TranslationMeter;
 use sui_types::{
-    error::ExecutionError,
+    error::ExecutionErrorTrait,
     transaction::{CallArg, Command, ProgrammableTransaction},
 };
 
@@ -13,10 +13,10 @@ use sui_types::{
 /// - number of commands and their arguments
 /// - for Move calls, count arguments to the function (both value and type arguments) as the
 ///   "arguments" to charge for for the command.
-pub fn meter(
+pub fn meter<E: ExecutionErrorTrait>(
     meter: &mut TranslationMeter,
     transaction: &ProgrammableTransaction,
-) -> Result<(), ExecutionError> {
+) -> Result<(), E> {
     meter.charge_base_inputs(transaction.inputs.len())?;
 
     for input in &transaction.inputs {

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/metering/translation_meter.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/metering/translation_meter.rs
@@ -3,7 +3,7 @@
 
 use crate::gas_charger::GasCharger;
 use sui_protocol_config::ProtocolConfig;
-use sui_types::error::ExecutionError;
+use sui_types::error::ExecutionErrorTrait;
 use sui_types::execution_status::ExecutionErrorKind;
 
 /// The [`TranslationMeter`] is responsible for metering gas usage for various operations
@@ -28,14 +28,20 @@ impl<'pc, 'gas> TranslationMeter<'pc, 'gas> {
         }
     }
 
-    pub fn charge_base_inputs(&mut self, num_inputs: usize) -> Result<(), ExecutionError> {
+    pub fn charge_base_inputs<E: ExecutionErrorTrait>(
+        &mut self,
+        num_inputs: usize,
+    ) -> Result<(), E> {
         let amount = (num_inputs as u64)
             .max(1)
             .saturating_mul(self.protocol_config.translation_per_input_base_charge());
         self.charge(amount)
     }
 
-    pub fn charge_pure_input_bytes(&mut self, num_bytes: usize) -> Result<(), ExecutionError> {
+    pub fn charge_pure_input_bytes<E: ExecutionErrorTrait>(
+        &mut self,
+        num_bytes: usize,
+    ) -> Result<(), E> {
         let amount = (num_bytes as u64).max(1).saturating_mul(
             self.protocol_config
                 .translation_pure_input_per_byte_charge(),
@@ -43,7 +49,10 @@ impl<'pc, 'gas> TranslationMeter<'pc, 'gas> {
         self.charge(amount)
     }
 
-    pub fn charge_base_command(&mut self, num_args: usize) -> Result<(), ExecutionError> {
+    pub fn charge_base_command<E: ExecutionErrorTrait>(
+        &mut self,
+        num_args: usize,
+    ) -> Result<(), E> {
         let amount = (num_args as u64)
             .max(1)
             .saturating_mul(self.protocol_config.translation_per_command_base_charge());
@@ -53,27 +62,30 @@ impl<'pc, 'gas> TranslationMeter<'pc, 'gas> {
     /// Charge gas for loading types based on the number of type nodes loaded.
     /// The cost is calculated as `num_type_nodes * TYPE_LOAD_PER_NODE_MULTIPLIER`.
     /// This function assumes that `num_type_nodes` is non-zero.
-    pub fn charge_num_type_nodes(&mut self, num_type_nodes: u64) -> Result<(), ExecutionError> {
+    pub fn charge_num_type_nodes<E: ExecutionErrorTrait>(
+        &mut self,
+        num_type_nodes: u64,
+    ) -> Result<(), E> {
         let amount = num_type_nodes
             .max(1)
             .saturating_mul(self.protocol_config.translation_per_type_node_charge());
         self.charge(amount)
     }
 
-    pub fn charge_num_type_references(
+    pub fn charge_num_type_references<E: ExecutionErrorTrait>(
         &mut self,
         num_type_references: u64,
-    ) -> Result<(), ExecutionError> {
+    ) -> Result<(), E> {
         let amount = self.reference_cost_formula(num_type_references.max(1))?;
         let amount =
             amount.saturating_mul(self.protocol_config.translation_per_reference_node_charge());
         self.charge(amount)
     }
 
-    pub fn charge_num_linkage_entries(
+    pub fn charge_num_linkage_entries<E: ExecutionErrorTrait>(
         &mut self,
         num_linkage_entries: usize,
-    ) -> Result<(), ExecutionError> {
+    ) -> Result<(), E> {
         let amount = (num_linkage_entries as u64)
             .saturating_mul(self.protocol_config.translation_per_linkage_entry_charge())
             .max(1);
@@ -85,7 +97,7 @@ impl<'pc, 'gas> TranslationMeter<'pc, 'gas> {
     // cost = (num_type_references * (num_type_references + 1)) / 2
     //
     // Take &self to access protocol config if needed in the future.
-    fn reference_cost_formula(&self, n: u64) -> Result<u64, ExecutionError> {
+    fn reference_cost_formula<E: ExecutionErrorTrait>(&self, n: u64) -> Result<u64, E> {
         let Some(n_succ) = n.checked_add(1) else {
             invariant_violation!("u64 overflow when calculating type reference cost")
         };
@@ -94,7 +106,7 @@ impl<'pc, 'gas> TranslationMeter<'pc, 'gas> {
 
     // Charge gas using a point charge mechanism based on the cumulative number of units charged so
     // far.
-    fn charge(&mut self, amount: u64) -> Result<(), ExecutionError> {
+    fn charge<E: ExecutionErrorTrait>(&mut self, amount: u64) -> Result<(), E> {
         debug_assert!(amount > 0);
         self.charger
             .move_gas_status_mut()
@@ -102,10 +114,11 @@ impl<'pc, 'gas> TranslationMeter<'pc, 'gas> {
             .map_err(Self::gas_error)
     }
 
-    fn gas_error<E>(e: E) -> ExecutionError
+    fn gas_error<T, E>(e: T) -> E
     where
-        E: Into<Box<dyn std::error::Error + Send + Sync + 'static>>,
+        T: Into<Box<dyn std::error::Error + Send + Sync + 'static>>,
+        E: ExecutionErrorTrait,
     {
-        ExecutionError::new_with_source(ExecutionErrorKind::InsufficientGas, e)
+        E::new_with_source(ExecutionErrorKind::InsufficientGas, e)
     }
 }

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/metering/typing.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/metering/typing.rs
@@ -4,16 +4,16 @@
 use crate::static_programmable_transactions::{
     metering::translation_meter::TranslationMeter, typing::ast as T,
 };
-use sui_types::{base_types::TxContextKind, error::ExecutionError};
+use sui_types::{base_types::TxContextKind, error::ExecutionErrorTrait};
 
 /// After loading and type checking, we do a second pass over the typed transaction to charge for
 /// type-related properties (before further analysis is done):
 /// - number of type nodes (including nested)
 /// - number of type references. These are charged non-linearly
-pub fn meter(
+pub fn meter<E: ExecutionErrorTrait>(
     meter: &mut TranslationMeter,
     transaction: &T::Transaction,
-) -> Result<(), ExecutionError> {
+) -> Result<(), E> {
     let mut num_refs: u64 = 0;
     let mut num_nodes: u64 = 0;
 

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/mod.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/mod.rs
@@ -47,25 +47,25 @@ pub fn execute<Mode: ExecutionMode>(
     withdrawal_compatibility_inputs: Option<Vec<bool>>,
     txn: ProgrammableTransaction,
     trace_builder_opt: &mut Option<MoveTraceBuilder>,
-) -> ResultWithTimings<Mode::ExecutionResults, ExecutionError> {
+) -> ResultWithTimings<Mode::ExecutionResults, Mode::Error> {
     let gas_payment = gas_charger.gas_payment_amount();
     let package_store = CachedPackageStore::new(vm, TransactionPackageStore::new(package_store));
     let linkage_analysis =
-        LinkageAnalyzer::new::<Mode>(protocol_config).map_err(|e| (e, vec![]))?;
+        LinkageAnalyzer::new::<Mode>(protocol_config).map_err(|e| (e.into(), vec![]))?;
     let ptb_type_linkage = linkage_analysis
-        .compute_input_type_resolution_linkage(&txn, &package_store, state_view)
-        .and_then(|linkage| linkage.linkage_context())
+        .compute_input_type_resolution_linkage::<Mode::Error>(&txn, &package_store, state_view)
+        .and_then(|linkage| linkage.linkage_context::<Mode::Error>())
         .map_err(|e| (e, vec![]))?;
     let resolution_vm = vm
         .make_vm(&package_store.package_store, ptb_type_linkage)
         .map_err(|e| {
             (
-                ExecutionError::new_with_source(ExecutionErrorKind::InvalidLinkage, e),
+                ExecutionError::new_with_source(ExecutionErrorKind::InvalidLinkage, e).into(),
                 vec![],
             )
         })?;
 
-    let mut env = Env::new(
+    let mut env: Env<'_, '_, '_, '_, '_, Mode::Error> = Env::new(
         protocol_config,
         vm,
         state_view,
@@ -86,10 +86,10 @@ pub fn execute<Mode: ExecutionMode>(
             gas_payment,
             txn,
         )
-        .map_err(|e| (e, vec![]))?
+        .map_err(|e| (e.into(), vec![]))?
     };
     let txn = typing::translate_and_verify::<Mode>(&mut translation_meter, &env, txn)
-        .map_err(|e| (e, vec![]))?;
+        .map_err(|e| (e.into(), vec![]))?;
     execution::interpreter::execute::<Mode>(
         &mut env,
         metrics,
@@ -98,4 +98,5 @@ pub fn execute<Mode: ExecutionMode>(
         txn,
         trace_builder_opt,
     )
+    .map_err(|(e, timings)| (e.into(), timings))
 }

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/mod.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/mod.rs
@@ -22,7 +22,7 @@ use move_vm_runtime::runtime::MoveRuntime;
 use std::{cell::RefCell, rc::Rc, sync::Arc};
 use sui_protocol_config::ProtocolConfig;
 use sui_types::{
-    base_types::TxContext, error::ExecutionError, execution::ResultWithTimings,
+    base_types::TxContext, error::ExecutionErrorTrait, execution::ResultWithTimings,
     execution_status::ExecutionErrorKind, metrics::ExecutionMetrics, storage::BackingPackageStore,
     transaction::ProgrammableTransaction,
 };
@@ -51,7 +51,7 @@ pub fn execute<Mode: ExecutionMode>(
     let gas_payment = gas_charger.gas_payment_amount();
     let package_store = CachedPackageStore::new(vm, TransactionPackageStore::new(package_store));
     let linkage_analysis =
-        LinkageAnalyzer::new::<Mode>(protocol_config).map_err(|e| (e.into(), vec![]))?;
+        LinkageAnalyzer::new::<Mode>(protocol_config).map_err(|e| (e, vec![]))?;
     let ptb_type_linkage = linkage_analysis
         .compute_input_type_resolution_linkage::<Mode::Error>(&txn, &package_store, state_view)
         .and_then(|linkage| linkage.linkage_context::<Mode::Error>())
@@ -60,12 +60,12 @@ pub fn execute<Mode: ExecutionMode>(
         .make_vm(&package_store.package_store, ptb_type_linkage)
         .map_err(|e| {
             (
-                ExecutionError::new_with_source(ExecutionErrorKind::InvalidLinkage, e).into(),
+                Mode::Error::new_with_source(ExecutionErrorKind::InvalidLinkage, e),
                 vec![],
             )
         })?;
 
-    let mut env: Env<'_, '_, '_, '_, '_, Mode::Error> = Env::new(
+    let mut env: Env<'_, '_, '_, '_, '_, Mode> = Env::new(
         protocol_config,
         vm,
         state_view,
@@ -86,10 +86,10 @@ pub fn execute<Mode: ExecutionMode>(
             gas_payment,
             txn,
         )
-        .map_err(|e| (e.into(), vec![]))?
+        .map_err(|e| (e, vec![]))?
     };
     let txn = typing::translate_and_verify::<Mode>(&mut translation_meter, &env, txn)
-        .map_err(|e| (e.into(), vec![]))?;
+        .map_err(|e| (e, vec![]))?;
     execution::interpreter::execute::<Mode>(
         &mut env,
         metrics,
@@ -98,5 +98,5 @@ pub fn execute<Mode: ExecutionMode>(
         txn,
         trace_builder_opt,
     )
-    .map_err(|(e, timings)| (e.into(), timings))
+    .map_err(|(e, timings)| (e, timings))
 }

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/mod.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/mod.rs
@@ -98,5 +98,4 @@ pub fn execute<Mode: ExecutionMode>(
         txn,
         trace_builder_opt,
     )
-    .map_err(|(e, timings)| (e, timings))
 }

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/invariant_checks/defining_ids_in_types.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/invariant_checks/defining_ids_in_types.rs
@@ -6,9 +6,12 @@ use crate::{
     sp,
     static_programmable_transactions::{env, spanned::Spanned, typing::ast as T},
 };
-use sui_types::error::ExecutionError;
+use sui_types::error::ExecutionErrorTrait;
 
-pub fn verify(env: &env::Env, tt: &T::Transaction) -> Result<(), ExecutionError> {
+pub fn verify<E: ExecutionErrorTrait>(
+    env: &env::Env<'_, '_, '_, '_, '_, E>,
+    tt: &T::Transaction,
+) -> Result<(), E> {
     let check_type = |ty| ensure_type_defining_id_based(env, ty);
     let check_arg = |sp!(_, (_, ty)): &Spanned<_>| ensure_type_defining_id_based(env, ty);
 
@@ -62,7 +65,10 @@ pub fn verify(env: &env::Env, tt: &T::Transaction) -> Result<(), ExecutionError>
     })
 }
 
-fn ensure_type_defining_id_based(env: &env::Env, ty: &T::Type) -> Result<(), ExecutionError> {
+fn ensure_type_defining_id_based<E: ExecutionErrorTrait>(
+    env: &env::Env<'_, '_, '_, '_, '_, E>,
+    ty: &T::Type,
+) -> Result<(), E> {
     match ty {
         T::Type::Bool
         | T::Type::U8

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/invariant_checks/defining_ids_in_types.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/invariant_checks/defining_ids_in_types.rs
@@ -3,15 +3,15 @@
 
 use crate::{
     data_store::PackageStore,
+    execution_mode::ExecutionMode,
     sp,
     static_programmable_transactions::{env, spanned::Spanned, typing::ast as T},
 };
-use sui_types::error::ExecutionErrorTrait;
 
-pub fn verify<E: ExecutionErrorTrait>(
-    env: &env::Env<'_, '_, '_, '_, '_, E>,
+pub fn verify<Mode: ExecutionMode>(
+    env: &env::Env<'_, '_, '_, '_, '_, Mode>,
     tt: &T::Transaction,
-) -> Result<(), E> {
+) -> Result<(), Mode::Error> {
     let check_type = |ty| ensure_type_defining_id_based(env, ty);
     let check_arg = |sp!(_, (_, ty)): &Spanned<_>| ensure_type_defining_id_based(env, ty);
 
@@ -65,10 +65,10 @@ pub fn verify<E: ExecutionErrorTrait>(
     })
 }
 
-fn ensure_type_defining_id_based<E: ExecutionErrorTrait>(
-    env: &env::Env<'_, '_, '_, '_, '_, E>,
+fn ensure_type_defining_id_based<Mode: ExecutionMode>(
+    env: &env::Env<'_, '_, '_, '_, '_, Mode>,
     ty: &T::Type,
-) -> Result<(), E> {
+) -> Result<(), Mode::Error> {
     match ty {
         T::Type::Bool
         | T::Type::U8

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/invariant_checks/memory_safety.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/invariant_checks/memory_safety.rs
@@ -2,13 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
+    execution_mode::ExecutionMode,
     sp,
     static_programmable_transactions::{env::Env, typing::ast as T},
 };
 use indexmap::IndexSet;
 use mysten_common::ZipDebugEqIteratorExt;
 use std::rc::Rc;
-use sui_types::error::{ExecutionError, ExecutionErrorTrait};
+use sui_types::error::ExecutionError;
 
 /// A dot-star like extension, but with a unique identifier. Deltas can be compared between
 /// different Deltas of the same command, otherwise they behave like .* in the regex based
@@ -291,8 +292,8 @@ impl Location {
 }
 
 impl Context {
-    fn new<E: ExecutionErrorTrait>(
-        _env: &Env<'_, '_, '_, '_, '_, E>,
+    fn new<Mode: ExecutionMode>(
+        _env: &Env<'_, '_, '_, '_, '_, Mode>,
         txn: &T::Transaction,
     ) -> anyhow::Result<Self> {
         let T::Transaction {
@@ -318,28 +319,28 @@ impl Context {
                     i, u16
                 )?)))
             })
-            .collect::<Result<_, E>>()?;
+            .collect::<Result<_, ExecutionError>>()?;
         let withdrawal_inputs = (0..withdrawals.len())
             .map(|i| {
                 Ok(Location::non_ref(T::Location::WithdrawalInput(
                     checked_as!(i, u16)?,
                 )))
             })
-            .collect::<Result<_, E>>()?;
+            .collect::<Result<_, ExecutionError>>()?;
         let pure_inputs = (0..pure.len())
             .map(|i| {
                 Ok(Location::non_ref(T::Location::PureInput(checked_as!(
                     i, u16
                 )?)))
             })
-            .collect::<Result<_, E>>()?;
+            .collect::<Result<_, ExecutionError>>()?;
         let receiving_inputs = (0..receiving.len())
             .map(|i| {
                 Ok(Location::non_ref(T::Location::ReceivingInput(checked_as!(
                     i, u16
                 )?)))
             })
-            .collect::<Result<_, E>>()?;
+            .collect::<Result<_, ExecutionError>>()?;
         Ok(Self {
             tx_context,
             gas,
@@ -549,15 +550,15 @@ impl Context {
 /// Checks the following
 /// - Values are not used after being moved
 /// - Reference safety is upheld (no dangling references)
-pub fn verify<E: ExecutionErrorTrait>(
-    env: &Env<'_, '_, '_, '_, '_, E>,
+pub fn verify<Mode: ExecutionMode>(
+    env: &Env<'_, '_, '_, '_, '_, Mode>,
     txn: &T::Transaction,
-) -> Result<(), E> {
+) -> Result<(), Mode::Error> {
     Ok(verify_(env, txn).map_err(|e| make_invariant_violation!("{}. Transaction {:?}", e, txn))?)
 }
 
-fn verify_<E: ExecutionErrorTrait>(
-    env: &Env<'_, '_, '_, '_, '_, E>,
+fn verify_<Mode: ExecutionMode>(
+    env: &Env<'_, '_, '_, '_, '_, Mode>,
     txn: &T::Transaction,
 ) -> anyhow::Result<()> {
     let mut context = Context::new(env, txn)?;

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/invariant_checks/memory_safety.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/invariant_checks/memory_safety.rs
@@ -8,7 +8,7 @@ use crate::{
 use indexmap::IndexSet;
 use mysten_common::ZipDebugEqIteratorExt;
 use std::rc::Rc;
-use sui_types::error::ExecutionError;
+use sui_types::error::{ExecutionError, ExecutionErrorTrait};
 
 /// A dot-star like extension, but with a unique identifier. Deltas can be compared between
 /// different Deltas of the same command, otherwise they behave like .* in the regex based
@@ -291,7 +291,10 @@ impl Location {
 }
 
 impl Context {
-    fn new(_env: &Env, txn: &T::Transaction) -> anyhow::Result<Self> {
+    fn new<E: ExecutionErrorTrait>(
+        _env: &Env<'_, '_, '_, '_, '_, E>,
+        txn: &T::Transaction,
+    ) -> anyhow::Result<Self> {
         let T::Transaction {
             gas_payment,
             bytes: _,
@@ -315,28 +318,28 @@ impl Context {
                     i, u16
                 )?)))
             })
-            .collect::<Result<_, ExecutionError>>()?;
+            .collect::<Result<_, E>>()?;
         let withdrawal_inputs = (0..withdrawals.len())
             .map(|i| {
                 Ok(Location::non_ref(T::Location::WithdrawalInput(
                     checked_as!(i, u16)?,
                 )))
             })
-            .collect::<Result<_, ExecutionError>>()?;
+            .collect::<Result<_, E>>()?;
         let pure_inputs = (0..pure.len())
             .map(|i| {
                 Ok(Location::non_ref(T::Location::PureInput(checked_as!(
                     i, u16
                 )?)))
             })
-            .collect::<Result<_, ExecutionError>>()?;
+            .collect::<Result<_, E>>()?;
         let receiving_inputs = (0..receiving.len())
             .map(|i| {
                 Ok(Location::non_ref(T::Location::ReceivingInput(checked_as!(
                     i, u16
                 )?)))
             })
-            .collect::<Result<_, ExecutionError>>()?;
+            .collect::<Result<_, E>>()?;
         Ok(Self {
             tx_context,
             gas,
@@ -546,11 +549,17 @@ impl Context {
 /// Checks the following
 /// - Values are not used after being moved
 /// - Reference safety is upheld (no dangling references)
-pub fn verify(env: &Env, txn: &T::Transaction) -> Result<(), ExecutionError> {
-    verify_(env, txn).map_err(|e| make_invariant_violation!("{}. Transaction {:?}", e, txn))
+pub fn verify<E: ExecutionErrorTrait>(
+    env: &Env<'_, '_, '_, '_, '_, E>,
+    txn: &T::Transaction,
+) -> Result<(), E> {
+    Ok(verify_(env, txn).map_err(|e| make_invariant_violation!("{}. Transaction {:?}", e, txn))?)
 }
 
-fn verify_(env: &Env, txn: &T::Transaction) -> anyhow::Result<()> {
+fn verify_<E: ExecutionErrorTrait>(
+    env: &Env<'_, '_, '_, '_, '_, E>,
+    txn: &T::Transaction,
+) -> anyhow::Result<()> {
     let mut context = Context::new(env, txn)?;
     let T::Transaction {
         gas_payment: _,

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/invariant_checks/mod.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/invariant_checks/mod.rs
@@ -10,7 +10,7 @@ pub mod memory_safety;
 pub mod type_check;
 
 pub fn transaction<Mode: ExecutionMode>(
-    env: &env::Env<'_, '_, '_, '_, '_, Mode::Error>,
+    env: &env::Env<'_, '_, '_, '_, '_, Mode>,
     tt: &T::Transaction,
 ) -> Result<(), Mode::Error> {
     defining_ids_in_types::verify(env, tt)?;

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/invariant_checks/mod.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/invariant_checks/mod.rs
@@ -5,16 +5,14 @@ use crate::{
     execution_mode::ExecutionMode,
     static_programmable_transactions::{env, typing::ast as T},
 };
-use sui_types::error::ExecutionError;
-
 pub mod defining_ids_in_types;
 pub mod memory_safety;
 pub mod type_check;
 
 pub fn transaction<Mode: ExecutionMode>(
-    env: &env::Env,
+    env: &env::Env<'_, '_, '_, '_, '_, Mode::Error>,
     tt: &T::Transaction,
-) -> Result<(), ExecutionError> {
+) -> Result<(), Mode::Error> {
     defining_ids_in_types::verify(env, tt)?;
     type_check::verify::<Mode>(env, tt)?;
     memory_safety::verify(env, tt)?;

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/invariant_checks/type_check.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/invariant_checks/type_check.rs
@@ -19,7 +19,7 @@ use crate::{
     },
 };
 use sui_types::{
-    coin::RESOLVED_COIN_STRUCT, error::ExecutionError,
+    coin::RESOLVED_COIN_STRUCT, error::ExecutionErrorTrait,
     funds_accumulator::RESOLVED_WITHDRAWAL_STRUCT,
 };
 
@@ -47,17 +47,18 @@ impl<'txn> Context<'txn> {
     }
 }
 
-/// Verifies the correctness of the typing on the AST
-/// - All object inputs have key
-/// - All pure inputs are valid types
-/// - All receiving inputs types have key
-/// - All commands are well formed with correct argument/result types
-/// - All dropped result values have the `drop` ability
-pub fn verify<Mode: ExecutionMode>(env: &Env, txn: &T::Transaction) -> Result<(), ExecutionError> {
-    verify_::<Mode>(env, txn).map_err(|e| make_invariant_violation!("{}. Transaction {:?}", e, txn))
+pub fn verify<Mode: ExecutionMode>(
+    env: &Env<'_, '_, '_, '_, '_, Mode::Error>,
+    txn: &T::Transaction,
+) -> Result<(), Mode::Error> {
+    Ok(verify_::<Mode>(env, txn)
+        .map_err(|e| make_invariant_violation!("{}. Transaction {:?}", e, txn))?)
 }
 
-fn verify_<Mode: ExecutionMode>(env: &Env, txn: &T::Transaction) -> anyhow::Result<()> {
+fn verify_<Mode: ExecutionMode>(
+    env: &Env<'_, '_, '_, '_, '_, Mode::Error>,
+    txn: &T::Transaction,
+) -> anyhow::Result<()> {
     let context = Context::new(txn);
     let T::Transaction {
         gas_payment: _,
@@ -123,7 +124,7 @@ fn withdrawal_input(ty: &T::Type) -> anyhow::Result<()> {
 fn pure_input<Mode: ExecutionMode>(p: &T::PureInput) -> anyhow::Result<()> {
     if !Mode::allow_arbitrary_values() {
         anyhow::ensure!(
-            input_arguments::is_valid_pure_type(&p.ty)?,
+            input_arguments::is_valid_pure_type::<Mode::Error>(&p.ty)?,
             "pure type must be valid"
         );
     }
@@ -139,7 +140,7 @@ fn receiving_input(r: &T::ReceivingInput) -> anyhow::Result<()> {
 }
 
 fn command<Mode: ExecutionMode>(
-    env: &Env,
+    env: &Env<'_, '_, '_, '_, '_, Mode::Error>,
     context: &Context,
     sp!(_, c): &T::Command,
 ) -> anyhow::Result<()> {
@@ -307,8 +308,8 @@ fn command<Mode: ExecutionMode>(
     Ok(())
 }
 
-fn argument(
-    env: &Env,
+fn argument<E: ExecutionErrorTrait>(
+    env: &Env<'_, '_, '_, '_, '_, E>,
     context: &Context,
     sp!(_, (arg__, ty)): &T::Argument,
     param: &T::Type,
@@ -372,7 +373,11 @@ fn argument(
     Ok(())
 }
 
-fn usage(env: &Env, context: &Context, u: &T::Usage) -> anyhow::Result<T::Type> {
+fn usage<E: ExecutionErrorTrait>(
+    env: &Env<'_, '_, '_, '_, '_, E>,
+    context: &Context,
+    u: &T::Usage,
+) -> anyhow::Result<T::Type> {
     match u {
         T::Usage::Move(l)
         | T::Usage::Copy {
@@ -382,7 +387,11 @@ fn usage(env: &Env, context: &Context, u: &T::Usage) -> anyhow::Result<T::Type> 
     }
 }
 
-fn location(env: &Env, context: &Context, l: T::Location) -> anyhow::Result<T::Type> {
+fn location<E: ExecutionErrorTrait>(
+    env: &Env<'_, '_, '_, '_, '_, E>,
+    context: &Context,
+    l: T::Location,
+) -> anyhow::Result<T::Type> {
     Ok(match l {
         T::Location::TxContext => env.tx_context_type()?,
         T::Location::GasCoin => env.gas_coin_type()?,
@@ -419,8 +428,8 @@ fn location(env: &Env, context: &Context, l: T::Location) -> anyhow::Result<T::T
     })
 }
 
-fn withdrawal_compatibility_conversion(
-    env: &Env,
+fn withdrawal_compatibility_conversion<E: ExecutionErrorTrait>(
+    env: &Env<'_, '_, '_, '_, '_, E>,
     context: &Context,
     withdrawal_location: T::Location,
     conv: &T::WithdrawalCompatibilityConversion,

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/invariant_checks/type_check.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/invariant_checks/type_check.rs
@@ -18,10 +18,7 @@ use crate::{
         },
     },
 };
-use sui_types::{
-    coin::RESOLVED_COIN_STRUCT, error::ExecutionErrorTrait,
-    funds_accumulator::RESOLVED_WITHDRAWAL_STRUCT,
-};
+use sui_types::{coin::RESOLVED_COIN_STRUCT, funds_accumulator::RESOLVED_WITHDRAWAL_STRUCT};
 
 struct Context<'txn> {
     objects: Vec<&'txn T::Type>,
@@ -48,7 +45,7 @@ impl<'txn> Context<'txn> {
 }
 
 pub fn verify<Mode: ExecutionMode>(
-    env: &Env<'_, '_, '_, '_, '_, Mode::Error>,
+    env: &Env<'_, '_, '_, '_, '_, Mode>,
     txn: &T::Transaction,
 ) -> Result<(), Mode::Error> {
     Ok(verify_::<Mode>(env, txn)
@@ -56,7 +53,7 @@ pub fn verify<Mode: ExecutionMode>(
 }
 
 fn verify_<Mode: ExecutionMode>(
-    env: &Env<'_, '_, '_, '_, '_, Mode::Error>,
+    env: &Env<'_, '_, '_, '_, '_, Mode>,
     txn: &T::Transaction,
 ) -> anyhow::Result<()> {
     let context = Context::new(txn);
@@ -140,7 +137,7 @@ fn receiving_input(r: &T::ReceivingInput) -> anyhow::Result<()> {
 }
 
 fn command<Mode: ExecutionMode>(
-    env: &Env<'_, '_, '_, '_, '_, Mode::Error>,
+    env: &Env<'_, '_, '_, '_, '_, Mode>,
     context: &Context,
     sp!(_, c): &T::Command,
 ) -> anyhow::Result<()> {
@@ -308,8 +305,8 @@ fn command<Mode: ExecutionMode>(
     Ok(())
 }
 
-fn argument<E: ExecutionErrorTrait>(
-    env: &Env<'_, '_, '_, '_, '_, E>,
+fn argument<Mode: ExecutionMode>(
+    env: &Env<'_, '_, '_, '_, '_, Mode>,
     context: &Context,
     sp!(_, (arg__, ty)): &T::Argument,
     param: &T::Type,
@@ -373,8 +370,8 @@ fn argument<E: ExecutionErrorTrait>(
     Ok(())
 }
 
-fn usage<E: ExecutionErrorTrait>(
-    env: &Env<'_, '_, '_, '_, '_, E>,
+fn usage<Mode: ExecutionMode>(
+    env: &Env<'_, '_, '_, '_, '_, Mode>,
     context: &Context,
     u: &T::Usage,
 ) -> anyhow::Result<T::Type> {
@@ -387,8 +384,8 @@ fn usage<E: ExecutionErrorTrait>(
     }
 }
 
-fn location<E: ExecutionErrorTrait>(
-    env: &Env<'_, '_, '_, '_, '_, E>,
+fn location<Mode: ExecutionMode>(
+    env: &Env<'_, '_, '_, '_, '_, Mode>,
     context: &Context,
     l: T::Location,
 ) -> anyhow::Result<T::Type> {
@@ -428,8 +425,8 @@ fn location<E: ExecutionErrorTrait>(
     })
 }
 
-fn withdrawal_compatibility_conversion<E: ExecutionErrorTrait>(
-    env: &Env<'_, '_, '_, '_, '_, E>,
+fn withdrawal_compatibility_conversion<Mode: ExecutionMode>(
+    env: &Env<'_, '_, '_, '_, '_, Mode>,
     context: &Context,
     withdrawal_location: T::Location,
     conv: &T::WithdrawalCompatibilityConversion,

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/mod.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/mod.rs
@@ -9,8 +9,6 @@ use crate::{
         metering::{self, translation_meter::TranslationMeter},
     },
 };
-use sui_types::error::ExecutionError;
-
 pub mod ast;
 pub mod invariant_checks;
 pub mod translate;
@@ -18,11 +16,11 @@ pub mod verify;
 
 pub fn translate_and_verify<Mode: ExecutionMode>(
     meter: &mut TranslationMeter<'_, '_>,
-    env: &env::Env,
+    env: &env::Env<'_, '_, '_, '_, '_, Mode::Error>,
     lt: L::Transaction,
-) -> Result<ast::Transaction, ExecutionError> {
+) -> Result<ast::Transaction, Mode::Error> {
     let mut ast = translate::transaction::<Mode>(env, lt)?;
-    metering::typing::meter(meter, &ast)?;
+    metering::typing::meter::<Mode::Error>(meter, &ast)?;
     verify::transaction::<Mode>(env, &mut ast)?;
     invariant_checks::transaction::<Mode>(env, &ast)?;
     Ok(ast)

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/mod.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/mod.rs
@@ -16,7 +16,7 @@ pub mod verify;
 
 pub fn translate_and_verify<Mode: ExecutionMode>(
     meter: &mut TranslationMeter<'_, '_>,
-    env: &env::Env<'_, '_, '_, '_, '_, Mode::Error>,
+    env: &env::Env<'_, '_, '_, '_, '_, Mode>,
     lt: L::Transaction,
 ) -> Result<ast::Transaction, Mode::Error> {
     let mut ast = translate::transaction::<Mode>(env, lt)?;

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/translate.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/translate.rs
@@ -195,11 +195,11 @@ impl Context {
         self.commands.get(i as usize).map(|c| &c.value.result_type)
     }
 
-    fn fixed_location_type<E: ExecutionErrorTrait>(
+    fn fixed_location_type<Mode: ExecutionMode>(
         &mut self,
-        env: &Env<'_, '_, '_, '_, '_, E>,
+        env: &Env<'_, '_, '_, '_, '_, Mode>,
         location: T::Location,
-    ) -> Result<Option<Type>, E> {
+    ) -> Result<Option<Type>, Mode::Error> {
         Ok(Some(match location {
             T::Location::TxContext => env.tx_context_type()?,
             T::Location::GasCoin => env.gas_coin_type()?,
@@ -226,11 +226,11 @@ impl Context {
     }
 
     // Get the fixed type of a location. Returns `None` for Pure and Receiving inputs,
-    fn fixed_type<E: ExecutionErrorTrait>(
+    fn fixed_type<Mode: ExecutionMode>(
         &mut self,
-        env: &Env<'_, '_, '_, '_, '_, E>,
+        env: &Env<'_, '_, '_, '_, '_, Mode>,
         splat_location: SplatLocation,
-    ) -> Result<Option<(T::Location, Type)>, E> {
+    ) -> Result<Option<(T::Location, Type)>, Mode::Error> {
         let location = match splat_location {
             SplatLocation::GasCoin => T::Location::GasCoin,
             SplatLocation::Result(i, j) => T::Location::Result(i, j),
@@ -256,13 +256,13 @@ impl Context {
         Ok(Some((location, ty)))
     }
 
-    fn resolve_location<E: ExecutionErrorTrait>(
+    fn resolve_location<Mode: ExecutionMode>(
         &mut self,
-        env: &Env<'_, '_, '_, '_, '_, E>,
+        env: &Env<'_, '_, '_, '_, '_, Mode>,
         splat_location: SplatLocation,
         expected_ty: &Type,
         bytes_constraint: BytesConstraint,
-    ) -> Result<(T::Location, Type), E> {
+    ) -> Result<(T::Location, Type), Mode::Error> {
         let location = match splat_location {
             SplatLocation::GasCoin => T::Location::GasCoin,
             SplatLocation::Result(i, j) => T::Location::Result(i, j),
@@ -334,7 +334,7 @@ impl Context {
 }
 
 pub fn transaction<Mode: ExecutionMode>(
-    env: &Env<'_, '_, '_, '_, '_, Mode::Error>,
+    env: &Env<'_, '_, '_, '_, '_, Mode>,
     lt: L::Transaction,
 ) -> Result<T::Transaction, Mode::Error> {
     let L::Transaction {
@@ -378,7 +378,7 @@ pub fn transaction<Mode: ExecutionMode>(
 }
 
 fn command<Mode: ExecutionMode>(
-    env: &Env<'_, '_, '_, '_, '_, Mode::Error>,
+    env: &Env<'_, '_, '_, '_, '_, Mode>,
     context: &mut Context,
     command: L::Command,
 ) -> Result<(T::Command__, T::ResultType), Mode::Error> {
@@ -519,8 +519,8 @@ fn command<Mode: ExecutionMode>(
     })
 }
 
-fn move_call_parameters<'a, E: ExecutionErrorTrait>(
-    _env: &Env<'_, '_, '_, '_, '_, E>,
+fn move_call_parameters<'a, Mode: ExecutionMode>(
+    _env: &Env<'_, '_, '_, '_, '_, Mode>,
     function: &'a L::LoadedFunction,
 ) -> Vec<(&'a Type, TxContextKind)> {
     function
@@ -531,12 +531,12 @@ fn move_call_parameters<'a, E: ExecutionErrorTrait>(
         .collect()
 }
 
-fn move_call_arguments<E: ExecutionErrorTrait>(
-    env: &Env<'_, '_, '_, '_, '_, E>,
+fn move_call_arguments<Mode: ExecutionMode>(
+    env: &Env<'_, '_, '_, '_, '_, Mode>,
     context: &mut Context,
     function: &L::LoadedFunction,
     args: Vec<SplatLocation>,
-) -> Result<Vec<T::Argument>, E> {
+) -> Result<Vec<T::Argument>, Mode::Error> {
     let params = move_call_parameters(env, function);
     assert_invariant!(
         params.len() == function.signature.parameters.len(),
@@ -594,7 +594,7 @@ fn move_call_arguments<E: ExecutionErrorTrait>(
                 }
             })
         })
-        .collect::<Result<Vec<_>, E>>()?;
+        .collect::<Result<Vec<_>, Mode::Error>>()?;
 
     assert_invariant!(
         args.next().is_none(),
@@ -686,13 +686,13 @@ where
     Ok(res)
 }
 
-fn arguments<E: ExecutionErrorTrait>(
-    env: &Env<'_, '_, '_, '_, '_, E>,
+fn arguments<Mode: ExecutionMode>(
+    env: &Env<'_, '_, '_, '_, '_, Mode>,
     context: &mut Context,
     start_idx: usize,
     locations: Vec<SplatLocation>,
     expected_tys: impl IntoIterator<Item = Type>,
-) -> Result<Vec<T::Argument>, E> {
+) -> Result<Vec<T::Argument>, Mode::Error> {
     #[allow(clippy::disallowed_methods)]
     locations
         .into_iter()
@@ -709,26 +709,26 @@ fn arguments<E: ExecutionErrorTrait>(
         .collect()
 }
 
-fn argument<E: ExecutionErrorTrait>(
-    env: &Env<'_, '_, '_, '_, '_, E>,
+fn argument<Mode: ExecutionMode>(
+    env: &Env<'_, '_, '_, '_, '_, Mode>,
     context: &mut Context,
     command_arg_idx: usize,
     location: SplatLocation,
     expected_ty: Type,
-) -> Result<T::Argument, E> {
+) -> Result<T::Argument, Mode::Error> {
     let arg__ = argument_(env, context, command_arg_idx, location, &expected_ty)
         .map_err(|e| e.into_execution_error(command_arg_idx))?;
     let arg_ = (arg__, expected_ty);
     Ok(sp(checked_as!(command_arg_idx, u16)?, arg_))
 }
 
-fn argument_<E: ExecutionErrorTrait>(
-    env: &Env<'_, '_, '_, '_, '_, E>,
+fn argument_<Mode: ExecutionMode>(
+    env: &Env<'_, '_, '_, '_, '_, Mode>,
     context: &mut Context,
     command_arg_idx: usize,
     location: SplatLocation,
     expected_ty: &Type,
-) -> Result<T::Argument__, EitherError<E>> {
+) -> Result<T::Argument__, EitherError<Mode::Error>> {
     let current_command = context.current_command;
     let bytes_constraint = BytesConstraint {
         command: current_command,
@@ -790,14 +790,14 @@ fn check_type(actual_ty: &Type, expected_ty: &Type) -> Result<(), CommandArgumen
     }
 }
 
-fn constrained_arguments<E: ExecutionErrorTrait>(
-    env: &Env<'_, '_, '_, '_, '_, E>,
+fn constrained_arguments<Mode: ExecutionMode>(
+    env: &Env<'_, '_, '_, '_, '_, Mode>,
     context: &mut Context,
     start_idx: usize,
     locations: Vec<SplatLocation>,
     constraint: AbilitySet,
     err_case: CommandArgumentError,
-) -> Result<Vec<T::Argument>, E> {
+) -> Result<Vec<T::Argument>, Mode::Error> {
     locations
         .into_iter()
         .enumerate()
@@ -810,14 +810,14 @@ fn constrained_arguments<E: ExecutionErrorTrait>(
         .collect()
 }
 
-fn constrained_argument<E: ExecutionErrorTrait>(
-    env: &Env<'_, '_, '_, '_, '_, E>,
+fn constrained_argument<Mode: ExecutionMode>(
+    env: &Env<'_, '_, '_, '_, '_, Mode>,
     context: &mut Context,
     command_arg_idx: usize,
     location: SplatLocation,
     constraint: AbilitySet,
     err_case: CommandArgumentError,
-) -> Result<T::Argument, E> {
+) -> Result<T::Argument, Mode::Error> {
     let arg_ = constrained_argument_(
         env,
         context,
@@ -830,14 +830,14 @@ fn constrained_argument<E: ExecutionErrorTrait>(
     Ok(sp(checked_as!(command_arg_idx, u16)?, arg_))
 }
 
-fn constrained_argument_<E: ExecutionErrorTrait>(
-    env: &Env<'_, '_, '_, '_, '_, E>,
+fn constrained_argument_<Mode: ExecutionMode>(
+    env: &Env<'_, '_, '_, '_, '_, Mode>,
     context: &mut Context,
     command_arg_idx: usize,
     location: SplatLocation,
     constraint: AbilitySet,
     err_case: CommandArgumentError,
-) -> Result<T::Argument_, EitherError<E>> {
+) -> Result<T::Argument_, EitherError<Mode::Error>> {
     if let Some((location, ty)) =
         constrained_type(env, context, command_arg_idx, location, constraint)
             .map_err(EitherError::Execution)?
@@ -852,13 +852,13 @@ fn constrained_argument_<E: ExecutionErrorTrait>(
     }
 }
 
-fn constrained_type<'a, E: ExecutionErrorTrait>(
-    env: &'a Env<'_, '_, '_, '_, '_, E>,
+fn constrained_type<'a, Mode: ExecutionMode>(
+    env: &'a Env<'_, '_, '_, '_, '_, Mode>,
     context: &'a mut Context,
     _command_arg_idx: usize,
     location: SplatLocation,
     constraint: AbilitySet,
-) -> Result<Option<(T::Location, Type)>, E> {
+) -> Result<Option<(T::Location, Type)>, Mode::Error> {
     let Some((location, ty)) = context.fixed_type(env, location)? else {
         return Ok(None);
     };
@@ -869,23 +869,23 @@ fn constrained_type<'a, E: ExecutionErrorTrait>(
     })
 }
 
-fn coin_mut_ref_argument<E: ExecutionErrorTrait>(
-    env: &Env<'_, '_, '_, '_, '_, E>,
+fn coin_mut_ref_argument<Mode: ExecutionMode>(
+    env: &Env<'_, '_, '_, '_, '_, Mode>,
     context: &mut Context,
     command_arg_idx: usize,
     location: SplatLocation,
-) -> Result<T::Argument, E> {
+) -> Result<T::Argument, Mode::Error> {
     let arg_ = coin_mut_ref_argument_(env, context, command_arg_idx, location)
         .map_err(|e| e.into_execution_error(command_arg_idx))?;
     Ok(sp(checked_as!(command_arg_idx, u16)?, arg_))
 }
 
-fn coin_mut_ref_argument_<E: ExecutionErrorTrait>(
-    env: &Env<'_, '_, '_, '_, '_, E>,
+fn coin_mut_ref_argument_<Mode: ExecutionMode>(
+    env: &Env<'_, '_, '_, '_, '_, Mode>,
     context: &mut Context,
     _command_arg_idx: usize,
     location: SplatLocation,
-) -> Result<T::Argument_, EitherError<E>> {
+) -> Result<T::Argument_, EitherError<Mode::Error>> {
     let Some((location, actual_ty)) = context
         .fixed_type(env, location)
         .map_err(EitherError::Execution)?
@@ -926,10 +926,10 @@ fn check_coin_type<E: ExecutionErrorTrait>(ty: &Type) -> Result<(), EitherError<
 
 /// Determines which withdrawal inputs need to be converted for compatibility, and appends the
 /// owner address of each such withdrawal as a new pure input.
-fn determine_withdrawal_compatibility_inputs<E: ExecutionErrorTrait>(
-    _env: &Env<'_, '_, '_, '_, '_, E>,
+fn determine_withdrawal_compatibility_inputs<Mode: ExecutionMode>(
+    _env: &Env<'_, '_, '_, '_, '_, Mode>,
     inputs: &mut L::Inputs,
-) -> Result<IndexMap</* input withdrawal */ u16, /* owner address input */ u16>, E> {
+) -> Result<IndexMap</* input withdrawal */ u16, /* owner address input */ u16>, Mode::Error> {
     let withdrawal_compatibility_owners: IndexMap<u16, AccountAddress> = inputs
         .iter()
         .enumerate()
@@ -943,7 +943,7 @@ fn determine_withdrawal_compatibility_inputs<E: ExecutionErrorTrait>(
             }
         })
         .map(|(i, owner)| Ok((checked_as!(i, u16)?, owner)))
-        .collect::<Result<_, E>>()?;
+        .collect::<Result<_, Mode::Error>>()?;
     withdrawal_compatibility_owners
         .into_iter()
         .map(|(i, owner)| {
@@ -969,15 +969,15 @@ struct WithdrawalCompatibilityRemap {
 /// For each withdrawal input that needs conversion, insert a conversion command to a
 /// `sui::coin::Coin<T>` and swaps references to that input to the conversion result.
 /// Adjusts result indices in subsequent commands accordingly.
-fn withdrawal_compatibility_conversion<E: ExecutionErrorTrait>(
-    env: &Env<'_, '_, '_, '_, '_, E>,
+fn withdrawal_compatibility_conversion<Mode: ExecutionMode>(
+    env: &Env<'_, '_, '_, '_, '_, Mode>,
     context: &mut Context,
     withdrawal_compatability_inputs: IndexMap<
         /* input withdrawal */ u16,
         /* owner address input */ u16,
     >,
     commands: &mut [L::Command],
-) -> Result<(), E> {
+) -> Result<(), Mode::Error> {
     let mut compatibility_remap = WithdrawalCompatibilityRemap {
         remap: IndexMap::new(),
         lift: 0,
@@ -991,12 +991,12 @@ fn withdrawal_compatibility_conversion<E: ExecutionErrorTrait>(
     Ok(())
 }
 
-fn convert_withdrawal_to_coin<E: ExecutionErrorTrait>(
-    env: &Env<'_, '_, '_, '_, '_, E>,
+fn convert_withdrawal_to_coin<Mode: ExecutionMode>(
+    env: &Env<'_, '_, '_, '_, '_, Mode>,
     context: &mut Context,
     withdrawal_input: u16,
     owner_input: u16,
-) -> Result</* Result index */ u16, E> {
+) -> Result</* Result index */ u16, Mode::Error> {
     assert_invariant!(
         env.protocol_config
             .convert_withdrawal_compatibility_ptb_arguments(),

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/translate.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/translate.rs
@@ -20,7 +20,7 @@ use sui_types::{
     balance::RESOLVED_BALANCE_STRUCT,
     base_types::{ObjectRef, TxContextKind},
     coin::{COIN_MODULE_NAME, REDEEM_FUNDS_FUNC_NAME, RESOLVED_COIN_STRUCT},
-    error::{ExecutionError, SafeIndex, command_argument_error},
+    error::{ExecutionError, ExecutionErrorTrait, SafeIndex, command_argument_error},
     execution_status::{CommandArgumentError, ExecutionErrorKind},
     funds_accumulator::RESOLVED_WITHDRAWAL_STRUCT,
 };
@@ -195,11 +195,11 @@ impl Context {
         self.commands.get(i as usize).map(|c| &c.value.result_type)
     }
 
-    fn fixed_location_type(
+    fn fixed_location_type<E: ExecutionErrorTrait>(
         &mut self,
-        env: &Env,
+        env: &Env<'_, '_, '_, '_, '_, E>,
         location: T::Location,
-    ) -> Result<Option<Type>, ExecutionError> {
+    ) -> Result<Option<Type>, E> {
         Ok(Some(match location {
             T::Location::TxContext => env.tx_context_type()?,
             T::Location::GasCoin => env.gas_coin_type()?,
@@ -226,11 +226,11 @@ impl Context {
     }
 
     // Get the fixed type of a location. Returns `None` for Pure and Receiving inputs,
-    fn fixed_type(
+    fn fixed_type<E: ExecutionErrorTrait>(
         &mut self,
-        env: &Env,
+        env: &Env<'_, '_, '_, '_, '_, E>,
         splat_location: SplatLocation,
-    ) -> Result<Option<(T::Location, Type)>, ExecutionError> {
+    ) -> Result<Option<(T::Location, Type)>, E> {
         let location = match splat_location {
             SplatLocation::GasCoin => T::Location::GasCoin,
             SplatLocation::Result(i, j) => T::Location::Result(i, j),
@@ -256,13 +256,13 @@ impl Context {
         Ok(Some((location, ty)))
     }
 
-    fn resolve_location(
+    fn resolve_location<E: ExecutionErrorTrait>(
         &mut self,
-        env: &Env,
+        env: &Env<'_, '_, '_, '_, '_, E>,
         splat_location: SplatLocation,
         expected_ty: &Type,
         bytes_constraint: BytesConstraint,
-    ) -> Result<(T::Location, Type), ExecutionError> {
+    ) -> Result<(T::Location, Type), E> {
         let location = match splat_location {
             SplatLocation::GasCoin => T::Location::GasCoin,
             SplatLocation::Result(i, j) => T::Location::Result(i, j),
@@ -334,9 +334,9 @@ impl Context {
 }
 
 pub fn transaction<Mode: ExecutionMode>(
-    env: &Env,
+    env: &Env<'_, '_, '_, '_, '_, Mode::Error>,
     lt: L::Transaction,
-) -> Result<T::Transaction, ExecutionError> {
+) -> Result<T::Transaction, Mode::Error> {
     let L::Transaction {
         gas_payment,
         mut inputs,
@@ -378,10 +378,10 @@ pub fn transaction<Mode: ExecutionMode>(
 }
 
 fn command<Mode: ExecutionMode>(
-    env: &Env,
+    env: &Env<'_, '_, '_, '_, '_, Mode::Error>,
     context: &mut Context,
     command: L::Command,
-) -> Result<(T::Command__, T::ResultType), ExecutionError> {
+) -> Result<(T::Command__, T::ResultType), Mode::Error> {
     Ok(match command {
         L::Command::MoveCall(lmc) => {
             let L::MoveCall {
@@ -519,8 +519,8 @@ fn command<Mode: ExecutionMode>(
     })
 }
 
-fn move_call_parameters<'a>(
-    _env: &Env,
+fn move_call_parameters<'a, E: ExecutionErrorTrait>(
+    _env: &Env<'_, '_, '_, '_, '_, E>,
     function: &'a L::LoadedFunction,
 ) -> Vec<(&'a Type, TxContextKind)> {
     function
@@ -531,12 +531,12 @@ fn move_call_parameters<'a>(
         .collect()
 }
 
-fn move_call_arguments(
-    env: &Env,
+fn move_call_arguments<E: ExecutionErrorTrait>(
+    env: &Env<'_, '_, '_, '_, '_, E>,
     context: &mut Context,
     function: &L::LoadedFunction,
     args: Vec<SplatLocation>,
-) -> Result<Vec<T::Argument>, ExecutionError> {
+) -> Result<Vec<T::Argument>, E> {
     let params = move_call_parameters(env, function);
     assert_invariant!(
         params.len() == function.signature.parameters.len(),
@@ -563,7 +563,8 @@ fn move_call_arguments(
                 function.name,
                 num_args,
             ),
-        ));
+        )
+        .into());
     }
     // construct arguments, injecting tx context args as needed
     let mut args = args.into_iter().enumerate();
@@ -593,7 +594,7 @@ fn move_call_arguments(
                 }
             })
         })
-        .collect::<Result<Vec<_>, ExecutionError>>()?;
+        .collect::<Result<Vec<_>, E>>()?;
 
     assert_invariant!(
         args.next().is_none(),
@@ -602,34 +603,35 @@ fn move_call_arguments(
     Ok(res)
 }
 
-fn one_location(
+fn one_location<E: ExecutionErrorTrait>(
     context: &mut Context,
     command_arg_idx: usize,
     arg: L::Argument,
-) -> Result<SplatLocation, ExecutionError> {
+) -> Result<SplatLocation, E> {
     let locs = locations(context, command_arg_idx, vec![arg])?;
     let Ok([loc]): Result<[SplatLocation; 1], _> = locs.try_into() else {
         return Err(command_argument_error(
             CommandArgumentError::InvalidArgumentArity,
             command_arg_idx,
-        ));
+        )
+        .into());
     };
     Ok(loc)
 }
 
-fn locations<Items: IntoIterator<Item = L::Argument>>(
+fn locations<E: ExecutionErrorTrait, Items: IntoIterator<Item = L::Argument>>(
     context: &mut Context,
     start_idx: usize,
     args: Items,
-) -> Result<Vec<SplatLocation>, ExecutionError>
+) -> Result<Vec<SplatLocation>, E>
 where
     Items::IntoIter: ExactSizeIterator,
 {
-    fn splat_arg(
+    fn splat_arg<E: ExecutionErrorTrait>(
         context: &mut Context,
         res: &mut Vec<SplatLocation>,
         arg: L::Argument,
-    ) -> Result<(), EitherError> {
+    ) -> Result<(), EitherError<E>> {
         match arg {
             L::Argument::GasCoin => res.push(SplatLocation::GasCoin),
             L::Argument::Input(i) => {
@@ -672,9 +674,10 @@ where
     let _args_len = args.len();
     let mut res = vec![];
     for (arg_idx, arg) in args.enumerate() {
-        splat_arg(context, &mut res, arg).map_err(|e| {
+        splat_arg::<E>(context, &mut res, arg).map_err(|e| {
             let Some(idx) = start_idx.checked_add(arg_idx) else {
-                return make_invariant_violation!("usize overflow when calculating argument index");
+                return make_invariant_violation!("usize overflow when calculating argument index")
+                    .into();
             };
             e.into_execution_error(idx)
         })?
@@ -683,13 +686,13 @@ where
     Ok(res)
 }
 
-fn arguments(
-    env: &Env,
+fn arguments<E: ExecutionErrorTrait>(
+    env: &Env<'_, '_, '_, '_, '_, E>,
     context: &mut Context,
     start_idx: usize,
     locations: Vec<SplatLocation>,
     expected_tys: impl IntoIterator<Item = Type>,
-) -> Result<Vec<T::Argument>, ExecutionError> {
+) -> Result<Vec<T::Argument>, E> {
     #[allow(clippy::disallowed_methods)]
     locations
         .into_iter()
@@ -706,33 +709,34 @@ fn arguments(
         .collect()
 }
 
-fn argument(
-    env: &Env,
+fn argument<E: ExecutionErrorTrait>(
+    env: &Env<'_, '_, '_, '_, '_, E>,
     context: &mut Context,
     command_arg_idx: usize,
     location: SplatLocation,
     expected_ty: Type,
-) -> Result<T::Argument, ExecutionError> {
+) -> Result<T::Argument, E> {
     let arg__ = argument_(env, context, command_arg_idx, location, &expected_ty)
         .map_err(|e| e.into_execution_error(command_arg_idx))?;
     let arg_ = (arg__, expected_ty);
     Ok(sp(checked_as!(command_arg_idx, u16)?, arg_))
 }
 
-fn argument_(
-    env: &Env,
+fn argument_<E: ExecutionErrorTrait>(
+    env: &Env<'_, '_, '_, '_, '_, E>,
     context: &mut Context,
     command_arg_idx: usize,
     location: SplatLocation,
     expected_ty: &Type,
-) -> Result<T::Argument__, EitherError> {
+) -> Result<T::Argument__, EitherError<E>> {
     let current_command = context.current_command;
     let bytes_constraint = BytesConstraint {
         command: current_command,
         argument: checked_as!(command_arg_idx, u16)?,
     };
-    let (location, actual_ty) =
-        context.resolve_location(env, location, expected_ty, bytes_constraint)?;
+    let (location, actual_ty) = context
+        .resolve_location(env, location, expected_ty, bytes_constraint)
+        .map_err(EitherError::Execution)?;
     Ok(match (actual_ty, expected_ty) {
         // Reference location types
         (Type::Reference(a_is_mut, a), Type::Reference(b_is_mut, b)) => {
@@ -786,14 +790,14 @@ fn check_type(actual_ty: &Type, expected_ty: &Type) -> Result<(), CommandArgumen
     }
 }
 
-fn constrained_arguments(
-    env: &Env,
+fn constrained_arguments<E: ExecutionErrorTrait>(
+    env: &Env<'_, '_, '_, '_, '_, E>,
     context: &mut Context,
     start_idx: usize,
     locations: Vec<SplatLocation>,
     constraint: AbilitySet,
     err_case: CommandArgumentError,
-) -> Result<Vec<T::Argument>, ExecutionError> {
+) -> Result<Vec<T::Argument>, E> {
     locations
         .into_iter()
         .enumerate()
@@ -806,14 +810,14 @@ fn constrained_arguments(
         .collect()
 }
 
-fn constrained_argument(
-    env: &Env,
+fn constrained_argument<E: ExecutionErrorTrait>(
+    env: &Env<'_, '_, '_, '_, '_, E>,
     context: &mut Context,
     command_arg_idx: usize,
     location: SplatLocation,
     constraint: AbilitySet,
     err_case: CommandArgumentError,
-) -> Result<T::Argument, ExecutionError> {
+) -> Result<T::Argument, E> {
     let arg_ = constrained_argument_(
         env,
         context,
@@ -826,16 +830,17 @@ fn constrained_argument(
     Ok(sp(checked_as!(command_arg_idx, u16)?, arg_))
 }
 
-fn constrained_argument_(
-    env: &Env,
+fn constrained_argument_<E: ExecutionErrorTrait>(
+    env: &Env<'_, '_, '_, '_, '_, E>,
     context: &mut Context,
     command_arg_idx: usize,
     location: SplatLocation,
     constraint: AbilitySet,
     err_case: CommandArgumentError,
-) -> Result<T::Argument_, EitherError> {
+) -> Result<T::Argument_, EitherError<E>> {
     if let Some((location, ty)) =
-        constrained_type(env, context, command_arg_idx, location, constraint)?
+        constrained_type(env, context, command_arg_idx, location, constraint)
+            .map_err(EitherError::Execution)?
     {
         if ty.abilities().has_copy() {
             Ok((T::Argument__::new_copy(location), ty))
@@ -847,13 +852,13 @@ fn constrained_argument_(
     }
 }
 
-fn constrained_type<'a>(
-    env: &'a Env,
+fn constrained_type<'a, E: ExecutionErrorTrait>(
+    env: &'a Env<'_, '_, '_, '_, '_, E>,
     context: &'a mut Context,
     _command_arg_idx: usize,
     location: SplatLocation,
     constraint: AbilitySet,
-) -> Result<Option<(T::Location, Type)>, ExecutionError> {
+) -> Result<Option<(T::Location, Type)>, E> {
     let Some((location, ty)) = context.fixed_type(env, location)? else {
         return Ok(None);
     };
@@ -864,24 +869,27 @@ fn constrained_type<'a>(
     })
 }
 
-fn coin_mut_ref_argument(
-    env: &Env,
+fn coin_mut_ref_argument<E: ExecutionErrorTrait>(
+    env: &Env<'_, '_, '_, '_, '_, E>,
     context: &mut Context,
     command_arg_idx: usize,
     location: SplatLocation,
-) -> Result<T::Argument, ExecutionError> {
+) -> Result<T::Argument, E> {
     let arg_ = coin_mut_ref_argument_(env, context, command_arg_idx, location)
         .map_err(|e| e.into_execution_error(command_arg_idx))?;
     Ok(sp(checked_as!(command_arg_idx, u16)?, arg_))
 }
 
-fn coin_mut_ref_argument_(
-    env: &Env,
+fn coin_mut_ref_argument_<E: ExecutionErrorTrait>(
+    env: &Env<'_, '_, '_, '_, '_, E>,
     context: &mut Context,
     _command_arg_idx: usize,
     location: SplatLocation,
-) -> Result<T::Argument_, EitherError> {
-    let Some((location, actual_ty)) = context.fixed_type(env, location)? else {
+) -> Result<T::Argument_, EitherError<E>> {
+    let Some((location, actual_ty)) = context
+        .fixed_type(env, location)
+        .map_err(EitherError::Execution)?
+    else {
         // TODO we do not currently bytes in any mode as that would require additional type
         // inference not currently supported
         return Err(CommandArgumentError::TypeMismatch.into());
@@ -904,7 +912,7 @@ fn coin_mut_ref_argument_(
     })
 }
 
-fn check_coin_type(ty: &Type) -> Result<(), EitherError> {
+fn check_coin_type<E: ExecutionErrorTrait>(ty: &Type) -> Result<(), EitherError<E>> {
     if coin_inner_type(ty).is_some() {
         Ok(())
     } else {
@@ -918,10 +926,10 @@ fn check_coin_type(ty: &Type) -> Result<(), EitherError> {
 
 /// Determines which withdrawal inputs need to be converted for compatibility, and appends the
 /// owner address of each such withdrawal as a new pure input.
-fn determine_withdrawal_compatibility_inputs(
-    _env: &Env,
+fn determine_withdrawal_compatibility_inputs<E: ExecutionErrorTrait>(
+    _env: &Env<'_, '_, '_, '_, '_, E>,
     inputs: &mut L::Inputs,
-) -> Result<IndexMap</* input withdrawal */ u16, /* owner address input */ u16>, ExecutionError> {
+) -> Result<IndexMap</* input withdrawal */ u16, /* owner address input */ u16>, E> {
     let withdrawal_compatibility_owners: IndexMap<u16, AccountAddress> = inputs
         .iter()
         .enumerate()
@@ -935,7 +943,7 @@ fn determine_withdrawal_compatibility_inputs(
             }
         })
         .map(|(i, owner)| Ok((checked_as!(i, u16)?, owner)))
-        .collect::<Result<_, ExecutionError>>()?;
+        .collect::<Result<_, E>>()?;
     withdrawal_compatibility_owners
         .into_iter()
         .map(|(i, owner)| {
@@ -961,15 +969,15 @@ struct WithdrawalCompatibilityRemap {
 /// For each withdrawal input that needs conversion, insert a conversion command to a
 /// `sui::coin::Coin<T>` and swaps references to that input to the conversion result.
 /// Adjusts result indices in subsequent commands accordingly.
-fn withdrawal_compatibility_conversion(
-    env: &Env,
+fn withdrawal_compatibility_conversion<E: ExecutionErrorTrait>(
+    env: &Env<'_, '_, '_, '_, '_, E>,
     context: &mut Context,
     withdrawal_compatability_inputs: IndexMap<
         /* input withdrawal */ u16,
         /* owner address input */ u16,
     >,
     commands: &mut [L::Command],
-) -> Result<(), ExecutionError> {
+) -> Result<(), E> {
     let mut compatibility_remap = WithdrawalCompatibilityRemap {
         remap: IndexMap::new(),
         lift: 0,
@@ -979,15 +987,16 @@ fn withdrawal_compatibility_conversion(
         compatibility_remap.remap.insert(input, result_idx);
     }
     compatibility_remap.lift = checked_as!(context.commands.len(), u16)?;
-    lift_result_indices(&compatibility_remap, commands)
+    lift_result_indices(&compatibility_remap, commands)?;
+    Ok(())
 }
 
-fn convert_withdrawal_to_coin(
-    env: &Env,
+fn convert_withdrawal_to_coin<E: ExecutionErrorTrait>(
+    env: &Env<'_, '_, '_, '_, '_, E>,
     context: &mut Context,
     withdrawal_input: u16,
     owner_input: u16,
-) -> Result</* Result index */ u16, ExecutionError> {
+) -> Result</* Result index */ u16, E> {
     assert_invariant!(
         env.protocol_config
             .convert_withdrawal_compatibility_ptb_arguments(),

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/translate.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/translate.rs
@@ -553,7 +553,7 @@ fn move_call_arguments<Mode: ExecutionMode>(
     };
     let num_parameters = params.len();
     if num_args != num_parameters {
-        return Err(ExecutionError::new_with_source(
+        return Err(Mode::Error::new_with_source(
             ExecutionErrorKind::ArityMismatch,
             format!(
                 "Expected {} argument{} calling function '{}::{}', but found {}",
@@ -563,8 +563,7 @@ fn move_call_arguments<Mode: ExecutionMode>(
                 function.name,
                 num_args,
             ),
-        )
-        .into());
+        ));
     }
     // construct arguments, injecting tx context args as needed
     let mut args = args.into_iter().enumerate();

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/verify/drop_safety.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/verify/drop_safety.rs
@@ -10,7 +10,7 @@ use crate::{
 /// After, it verifies the following
 /// - No results without `drop` are unused (all unused non-input values have `drop`)
 pub fn refine_and_verify<Mode: ExecutionMode>(
-    env: &Env<'_, '_, '_, '_, '_, Mode::Error>,
+    env: &Env<'_, '_, '_, '_, '_, Mode>,
     ast: &mut T::Transaction,
 ) -> Result<(), Mode::Error> {
     refine::transaction(env, ast)?;
@@ -19,10 +19,8 @@ pub fn refine_and_verify<Mode: ExecutionMode>(
 }
 
 mod refine {
-    use sui_types::{
-        coin::{COIN_MODULE_NAME, SEND_FUNDS_FUNC_NAME},
-        error::ExecutionErrorTrait,
-    };
+    use crate::execution_mode::ExecutionMode;
+    use sui_types::coin::{COIN_MODULE_NAME, SEND_FUNDS_FUNC_NAME};
 
     use crate::{
         sp,
@@ -57,10 +55,10 @@ mod refine {
 
     /// After memory safety, we can switch the last usage of a `Copy` to a `Move` if it is not
     /// borrowed at the time of the last usage.
-    pub fn transaction<E: ExecutionErrorTrait>(
-        env: &Env<'_, '_, '_, '_, '_, E>,
+    pub fn transaction<Mode: ExecutionMode>(
+        env: &Env<'_, '_, '_, '_, '_, Mode>,
         ast: &mut T::Transaction,
-    ) -> Result<(), E> {
+    ) -> Result<(), Mode::Error> {
         let mut context = Context::new();
         for c in ast.commands.iter_mut().rev() {
             command(&mut context, c);
@@ -125,11 +123,11 @@ mod refine {
 
     /// For any withdrawal conversion where the value was not moved, send it back to the original
     /// owner
-    fn return_unused_withdrawal_conversions<E: ExecutionErrorTrait>(
-        env: &Env<'_, '_, '_, '_, '_, E>,
+    fn return_unused_withdrawal_conversions<Mode: ExecutionMode>(
+        env: &Env<'_, '_, '_, '_, '_, Mode>,
         ast: &mut T::Transaction,
         moved_locations: &BTreeSet<T::Location>,
-    ) -> Result<(), E> {
+    ) -> Result<(), Mode::Error> {
         // withdrawal conversions not empty ==> accumulators enabled
         assert_invariant!(
             ast.withdrawal_compatibility_conversions.is_empty()
@@ -233,8 +231,8 @@ mod verify {
     }
 
     impl Context {
-        fn new<E: ExecutionErrorTrait>(
-            _env: &Env<'_, '_, '_, '_, '_, E>,
+        fn new<Mode: ExecutionMode>(
+            _env: &Env<'_, '_, '_, '_, '_, Mode>,
             ast: &T::Transaction,
         ) -> Self {
             let objects = ast.objects.iter().map(|_| Some(Value)).collect::<Vec<_>>();
@@ -287,7 +285,7 @@ mod verify {
     /// Checks the following
     /// - All unused result values have `drop`
     pub fn transaction<Mode: ExecutionMode>(
-        env: &Env<'_, '_, '_, '_, '_, Mode::Error>,
+        env: &Env<'_, '_, '_, '_, '_, Mode>,
         ast: &T::Transaction,
     ) -> Result<(), Mode::Error> {
         let mut context = Context::new(env, ast);

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/verify/drop_safety.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/verify/drop_safety.rs
@@ -5,15 +5,14 @@ use crate::{
     execution_mode::ExecutionMode,
     static_programmable_transactions::{env::Env, typing::ast as T},
 };
-use sui_types::error::ExecutionError;
 
 /// Refines usage of values so that the last `Copy` of a value is a `Move` if it is not borrowed
 /// After, it verifies the following
 /// - No results without `drop` are unused (all unused non-input values have `drop`)
 pub fn refine_and_verify<Mode: ExecutionMode>(
-    env: &Env,
+    env: &Env<'_, '_, '_, '_, '_, Mode::Error>,
     ast: &mut T::Transaction,
-) -> Result<(), ExecutionError> {
+) -> Result<(), Mode::Error> {
     refine::transaction(env, ast)?;
     verify::transaction::<Mode>(env, ast)?;
     Ok(())
@@ -22,7 +21,7 @@ pub fn refine_and_verify<Mode: ExecutionMode>(
 mod refine {
     use sui_types::{
         coin::{COIN_MODULE_NAME, SEND_FUNDS_FUNC_NAME},
-        error::ExecutionError,
+        error::ExecutionErrorTrait,
     };
 
     use crate::{
@@ -58,7 +57,10 @@ mod refine {
 
     /// After memory safety, we can switch the last usage of a `Copy` to a `Move` if it is not
     /// borrowed at the time of the last usage.
-    pub fn transaction(env: &Env, ast: &mut T::Transaction) -> Result<(), ExecutionError> {
+    pub fn transaction<E: ExecutionErrorTrait>(
+        env: &Env<'_, '_, '_, '_, '_, E>,
+        ast: &mut T::Transaction,
+    ) -> Result<(), E> {
         let mut context = Context::new();
         for c in ast.commands.iter_mut().rev() {
             command(&mut context, c);
@@ -123,11 +125,11 @@ mod refine {
 
     /// For any withdrawal conversion where the value was not moved, send it back to the original
     /// owner
-    fn return_unused_withdrawal_conversions(
-        env: &Env,
+    fn return_unused_withdrawal_conversions<E: ExecutionErrorTrait>(
+        env: &Env<'_, '_, '_, '_, '_, E>,
         ast: &mut T::Transaction,
         moved_locations: &BTreeSet<T::Location>,
-    ) -> Result<(), ExecutionError> {
+    ) -> Result<(), E> {
         // withdrawal conversions not empty ==> accumulators enabled
         assert_invariant!(
             ast.withdrawal_compatibility_conversions.is_empty()
@@ -214,7 +216,7 @@ mod verify {
         },
     };
     use mysten_common::ZipDebugEqIteratorExt;
-    use sui_types::error::{ExecutionError, SafeIndex};
+    use sui_types::error::{ExecutionErrorTrait, SafeIndex};
     use sui_types::execution_status::ExecutionErrorKind;
 
     #[must_use]
@@ -231,7 +233,10 @@ mod verify {
     }
 
     impl Context {
-        fn new(_env: &Env, ast: &T::Transaction) -> Result<Self, ExecutionError> {
+        fn new<E: ExecutionErrorTrait>(
+            _env: &Env<'_, '_, '_, '_, '_, E>,
+            ast: &T::Transaction,
+        ) -> Self {
             let objects = ast.objects.iter().map(|_| Some(Value)).collect::<Vec<_>>();
             let withdrawals = ast
                 .withdrawals
@@ -249,7 +254,7 @@ mod verify {
             } else {
                 Some(Value)
             };
-            Ok(Self {
+            Self {
                 tx_context: Some(Value),
                 gas_coin,
                 objects,
@@ -257,10 +262,13 @@ mod verify {
                 pure,
                 receiving,
                 results: Vec::with_capacity(ast.commands.len()),
-            })
+            }
         }
 
-        fn location(&mut self, l: T::Location) -> Result<&mut Option<Value>, ExecutionError> {
+        fn location<E: ExecutionErrorTrait>(
+            &mut self,
+            l: T::Location,
+        ) -> Result<&mut Option<Value>, E> {
             Ok(match l {
                 T::Location::TxContext => &mut self.tx_context,
                 T::Location::GasCoin => &mut self.gas_coin,
@@ -279,14 +287,14 @@ mod verify {
     /// Checks the following
     /// - All unused result values have `drop`
     pub fn transaction<Mode: ExecutionMode>(
-        env: &Env,
+        env: &Env<'_, '_, '_, '_, '_, Mode::Error>,
         ast: &T::Transaction,
-    ) -> Result<(), ExecutionError> {
-        let mut context = Context::new(env, ast)?;
+    ) -> Result<(), Mode::Error> {
+        let mut context = Context::new(env, ast);
         let commands = &ast.commands;
         for c in commands {
-            let result =
-                command(&mut context, c).map_err(|e| e.with_command_index(c.idx as usize))?;
+            let result = command::<Mode::Error>(&mut context, c)
+                .map_err(|e| e.with_command_index(c.idx as usize))?;
             assert_invariant!(
                 result.len() == c.value.result_type.len(),
                 "result length mismatch"
@@ -338,10 +346,10 @@ mod verify {
         Ok(())
     }
 
-    fn command(
+    fn command<E: ExecutionErrorTrait>(
         context: &mut Context,
         sp!(_, c): &T::Command,
-    ) -> Result<Vec<Value>, ExecutionError> {
+    ) -> Result<Vec<Value>, E> {
         let result_tys = &c.result_type;
         Ok(match &c.command {
             T::Command__::MoveCall(mc) => {
@@ -401,7 +409,7 @@ mod verify {
         idx: (usize, usize),
         value: Option<Value>,
         ty: &Type,
-    ) -> Result<(), ExecutionError> {
+    ) -> Result<(), Mode::Error> {
         match value {
             Some(v) => drop_value::<Mode>(idx, v, ty),
             None => Ok(()),
@@ -412,7 +420,7 @@ mod verify {
         (i, j): (usize, usize),
         value: Value,
         ty: &Type,
-    ) -> Result<(), ExecutionError> {
+    ) -> Result<(), Mode::Error> {
         let abilities = ty.abilities();
         if !abilities.has_drop() && !Mode::allow_arbitrary_values() {
             let msg = if abilities.has_copy() {
@@ -421,7 +429,7 @@ mod verify {
             } else {
                 "Unused value without drop"
             };
-            return Err(ExecutionError::new_with_source(
+            return Err(Mode::Error::new_with_source(
                 ExecutionErrorKind::UnusedValueWithoutDrop {
                     result_idx: checked_as!(i, u16)?,
                     secondary_idx: checked_as!(j, u16)?,
@@ -433,11 +441,17 @@ mod verify {
         Ok(())
     }
 
-    fn arguments(context: &mut Context, xs: &[T::Argument]) -> Result<Vec<Value>, ExecutionError> {
+    fn arguments<E: ExecutionErrorTrait>(
+        context: &mut Context,
+        xs: &[T::Argument],
+    ) -> Result<Vec<Value>, E> {
         xs.iter().map(|x| argument(context, x)).collect()
     }
 
-    fn argument(context: &mut Context, sp!(_, x): &T::Argument) -> Result<Value, ExecutionError> {
+    fn argument<E: ExecutionErrorTrait>(
+        context: &mut Context,
+        sp!(_, x): &T::Argument,
+    ) -> Result<Value, E> {
         match &x.0 {
             T::Argument__::Use(T::Usage::Move(location)) => move_value(context, *location),
             T::Argument__::Use(T::Usage::Copy { location, .. }) => copy_value(context, *location),
@@ -447,42 +461,51 @@ mod verify {
         }
     }
 
-    fn move_value(context: &mut Context, l: T::Location) -> Result<Value, ExecutionError> {
-        let Some(value) = context.location(l)?.take() else {
+    fn move_value<E: ExecutionErrorTrait>(
+        context: &mut Context,
+        l: T::Location,
+    ) -> Result<Value, E> {
+        let Some(value) = context.location::<E>(l)?.take() else {
             invariant_violation!("memory safety should have failed")
         };
         Ok(value)
     }
 
-    fn copy_value(context: &mut Context, l: T::Location) -> Result<Value, ExecutionError> {
+    fn copy_value<E: ExecutionErrorTrait>(
+        context: &mut Context,
+        l: T::Location,
+    ) -> Result<Value, E> {
         assert_invariant!(
-            context.location(l)?.is_some(),
+            context.location::<E>(l)?.is_some(),
             "memory safety should have failed"
         );
         Ok(Value)
     }
 
-    fn borrow_location(context: &mut Context, l: T::Location) -> Result<Value, ExecutionError> {
+    fn borrow_location<E: ExecutionErrorTrait>(
+        context: &mut Context,
+        l: T::Location,
+    ) -> Result<Value, E> {
         assert_invariant!(
-            context.location(l)?.is_some(),
+            context.location::<E>(l)?.is_some(),
             "memory safety should have failed"
         );
         Ok(Value)
     }
 
-    fn read_ref(context: &mut Context, u: &T::Usage) -> Result<Value, ExecutionError> {
+    fn read_ref<E: ExecutionErrorTrait>(context: &mut Context, u: &T::Usage) -> Result<Value, E> {
         let value = match u {
-            T::Usage::Move(l) => move_value(context, *l)?,
-            T::Usage::Copy { location, .. } => copy_value(context, *location)?,
+            T::Usage::Move(l) => move_value::<E>(context, *l)?,
+            T::Usage::Copy { location, .. } => copy_value::<E>(context, *location)?,
         };
         consume_value(value);
         Ok(Value)
     }
 
-    fn freeze_ref(context: &mut Context, u: &T::Usage) -> Result<Value, ExecutionError> {
+    fn freeze_ref<E: ExecutionErrorTrait>(context: &mut Context, u: &T::Usage) -> Result<Value, E> {
         let value = match u {
-            T::Usage::Move(l) => move_value(context, *l)?,
-            T::Usage::Copy { location, .. } => copy_value(context, *location)?,
+            T::Usage::Move(l) => move_value::<E>(context, *l)?,
+            T::Usage::Copy { location, .. } => copy_value::<E>(context, *location)?,
         };
         consume_value(value);
         Ok(Value)

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/verify/input_arguments.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/verify/input_arguments.rs
@@ -18,7 +18,7 @@ use sui_types::{
     SUI_FRAMEWORK_ADDRESS,
     base_types::{RESOLVED_ASCII_STR, RESOLVED_STD_OPTION, RESOLVED_UTF8_STR},
     coin::{COIN_MODULE_NAME, SEND_FUNDS_FUNC_NAME},
-    error::{ExecutionError, SafeIndex, command_argument_error},
+    error::{ExecutionError, ExecutionErrorTrait, SafeIndex, command_argument_error},
     execution_status::{CommandArgumentError, ExecutionErrorKind},
     id::RESOLVED_SUI_ID,
     transfer::RESOLVED_RECEIVING_STRUCT,
@@ -74,7 +74,10 @@ impl Context {
 /// 2. That any `Object` arguments are used validly. This means mutable references are taken only
 ///    on mutable objects. And that the gas coin is only taken by value in transfer objects or with
 ///    `sui::coin::send_funds`.
-pub fn verify<Mode: ExecutionMode>(env: &Env, txn: &T::Transaction) -> Result<(), ExecutionError> {
+pub fn verify<Mode: ExecutionMode>(
+    env: &Env<'_, '_, '_, '_, '_, Mode::Error>,
+    txn: &T::Transaction,
+) -> Result<(), Mode::Error> {
     let T::Transaction {
         gas_payment: _,
         bytes,
@@ -106,7 +109,7 @@ pub fn verify<Mode: ExecutionMode>(env: &Env, txn: &T::Transaction) -> Result<()
 fn check_pure_input<Mode: ExecutionMode>(
     bytes: &IndexSet<Vec<u8>>,
     pure: &T::PureInput,
-) -> Result<(), ExecutionError> {
+) -> Result<(), Mode::Error> {
     let T::PureInput {
         original_input_index,
         byte_index,
@@ -129,7 +132,7 @@ fn check_pure_bytes<Mode: ExecutionMode>(
     command_arg_idx: u16,
     bytes: &[u8],
     constraint: &Type,
-) -> Result<(), ExecutionError> {
+) -> Result<(), Mode::Error> {
     assert_invariant!(
         !matches!(constraint, Type::Reference(_, _)),
         "references should not be added as a constraint"
@@ -137,7 +140,7 @@ fn check_pure_bytes<Mode: ExecutionMode>(
     if Mode::allow_arbitrary_values() {
         return Ok(());
     }
-    let Some(layout) = primitive_serialization_layout(constraint)? else {
+    let Some(layout) = primitive_serialization_layout::<Mode::Error>(constraint)? else {
         let msg = format!(
             "Invalid usage of `Pure` argument for a non-primitive argument type at index {command_arg_idx}.",
         );
@@ -147,15 +150,16 @@ fn check_pure_bytes<Mode: ExecutionMode>(
                 command_arg_idx,
             ),
             msg,
-        ));
+        )
+        .into());
     };
     bcs_argument_validate(bytes, command_arg_idx, layout)?;
     Ok(())
 }
 
-fn primitive_serialization_layout(
+fn primitive_serialization_layout<E: ExecutionErrorTrait>(
     param_ty: &Type,
-) -> Result<Option<PrimitiveArgumentLayout>, ExecutionError> {
+) -> Result<Option<PrimitiveArgumentLayout>, E> {
     Ok(match param_ty {
         Type::Signer => return Ok(None),
         Type::Reference(_, _) => {
@@ -171,14 +175,15 @@ fn primitive_serialization_layout(
         Type::Address => Some(PrimitiveArgumentLayout::Address),
 
         Type::Vector(v) => {
-            let info_opt = primitive_serialization_layout(&v.element_type)?;
+            let info_opt = primitive_serialization_layout::<E>(&v.element_type)?;
             info_opt.map(|layout| PrimitiveArgumentLayout::Vector(Box::new(layout)))
         }
         Type::Datatype(dt) => {
             let resolved = dt.qualified_ident();
             // is option of a string
             if resolved == RESOLVED_STD_OPTION && dt.type_arguments.len() == 1 {
-                let info_opt = primitive_serialization_layout(dt.type_arguments.first().unwrap())?;
+                let info_opt =
+                    primitive_serialization_layout::<E>(dt.type_arguments.first().unwrap())?;
                 info_opt.map(|layout| PrimitiveArgumentLayout::Option(Box::new(layout)))
             } else if dt.type_arguments.is_empty() {
                 if resolved == RESOLVED_SUI_ID {
@@ -197,7 +202,7 @@ fn primitive_serialization_layout(
     })
 }
 
-fn check_receiving_input(receiving: &T::ReceivingInput) -> Result<(), ExecutionError> {
+fn check_receiving_input<E: ExecutionErrorTrait>(receiving: &T::ReceivingInput) -> Result<(), E> {
     let T::ReceivingInput {
         original_input_index: _,
         object_ref: _,
@@ -205,22 +210,25 @@ fn check_receiving_input(receiving: &T::ReceivingInput) -> Result<(), ExecutionE
         constraint,
     } = receiving;
     let BytesConstraint { command, argument } = constraint;
-    check_receiving(*argument, ty).map_err(|e| e.with_command_index(*command as usize))
+    check_receiving::<E>(*argument, ty).map_err(|e| e.with_command_index(*command as usize))
 }
 
-fn check_receiving(command_arg_idx: u16, constraint: &Type) -> Result<(), ExecutionError> {
+fn check_receiving<E: ExecutionErrorTrait>(
+    command_arg_idx: u16,
+    constraint: &Type,
+) -> Result<(), E> {
     if is_valid_receiving(constraint) {
         Ok(())
     } else {
-        Err(command_argument_error(
-            CommandArgumentError::TypeMismatch,
-            command_arg_idx as usize,
-        ))
+        Err(
+            command_argument_error(CommandArgumentError::TypeMismatch, command_arg_idx as usize)
+                .into(),
+        )
     }
 }
 
-pub fn is_valid_pure_type(constraint: &Type) -> Result<bool, ExecutionError> {
-    Ok(primitive_serialization_layout(constraint)?.is_some())
+pub fn is_valid_pure_type<E: ExecutionErrorTrait>(constraint: &Type) -> Result<bool, E> {
+    Ok(primitive_serialization_layout::<E>(constraint)?.is_some())
 }
 
 /// Returns true if a type is a `Receiving<t>` where `t` has `key`
@@ -237,7 +245,11 @@ pub fn is_valid_receiving(constraint: &Type) -> bool {
 // Object usage
 //**************************************************************************************************
 
-fn command(env: &Env, context: &mut Context, sp!(_, c): &T::Command) -> Result<(), ExecutionError> {
+fn command<E: ExecutionErrorTrait>(
+    env: &Env<'_, '_, '_, '_, '_, E>,
+    context: &mut Context,
+    sp!(_, c): &T::Command,
+) -> Result<(), E> {
     match &c.command {
         T::Command__::MoveCall(mc) => {
             check_obj_usages(context, &mc.arguments)?;
@@ -277,17 +289,20 @@ fn command(env: &Env, context: &mut Context, sp!(_, c): &T::Command) -> Result<(
 }
 
 // Checks for valid by-mut-ref and by-value usage of input objects
-fn check_obj_usages(
+fn check_obj_usages<E: ExecutionErrorTrait>(
     context: &mut Context,
     arguments: &[T::Argument],
-) -> Result<(), ExecutionError> {
+) -> Result<(), E> {
     for arg in arguments {
         check_obj_usage(context, arg)?;
     }
     Ok(())
 }
 
-fn check_obj_usage(context: &mut Context, arg: &T::Argument) -> Result<(), ExecutionError> {
+fn check_obj_usage<E: ExecutionErrorTrait>(
+    context: &mut Context,
+    arg: &T::Argument,
+) -> Result<(), E> {
     match &arg.value.0 {
         T::Argument__::Borrow(true, l) => check_obj_by_mut_ref(context, arg.idx, l),
         T::Argument__::Use(T::Usage::Move(l)) => check_by_value(context, arg.idx, l),
@@ -303,11 +318,11 @@ fn check_obj_usage(context: &mut Context, arg: &T::Argument) -> Result<(), Execu
 }
 
 // Checks for valid by-mut-ref usage of input objects
-fn check_obj_by_mut_ref(
+fn check_obj_by_mut_ref<E: ExecutionErrorTrait>(
     context: &mut Context,
     arg_idx: u16,
     location: &T::Location,
-) -> Result<(), ExecutionError> {
+) -> Result<(), E> {
     match location {
         T::Location::WithdrawalInput(_)
         | T::Location::PureInput(_)
@@ -320,7 +335,8 @@ fn check_obj_by_mut_ref(
                 Err(command_argument_error(
                     CommandArgumentError::InvalidObjectByMutRef,
                     arg_idx as usize,
-                ))
+                )
+                .into())
             } else {
                 Ok(())
             }
@@ -329,11 +345,11 @@ fn check_obj_by_mut_ref(
 }
 
 // Checks for valid by-value usage of input objects
-fn check_by_value(
+fn check_by_value<E: ExecutionErrorTrait>(
     context: &mut Context,
     arg_idx: u16,
     location: &T::Location,
-) -> Result<(), ExecutionError> {
+) -> Result<(), E> {
     match location {
         T::Location::GasCoin
         | T::Location::Result(_, _)
@@ -346,7 +362,8 @@ fn check_by_value(
                 Err(command_argument_error(
                     CommandArgumentError::InvalidObjectByValue,
                     arg_idx as usize,
-                ))
+                )
+                .into())
             } else {
                 Ok(())
             }
@@ -355,14 +372,14 @@ fn check_by_value(
 }
 
 // Checks for no by value usage of gas
-fn check_gas_by_values(arguments: &[T::Argument]) -> Result<(), ExecutionError> {
+fn check_gas_by_values<E: ExecutionErrorTrait>(arguments: &[T::Argument]) -> Result<(), E> {
     for arg in arguments {
         check_gas_by_value(arg)?;
     }
     Ok(())
 }
 
-fn check_gas_by_value(arg: &T::Argument) -> Result<(), ExecutionError> {
+fn check_gas_by_value<E: ExecutionErrorTrait>(arg: &T::Argument) -> Result<(), E> {
     match &arg.value.0 {
         T::Argument__::Use(T::Usage::Move(l)) => check_gas_by_value_loc(arg.idx, l),
         // We do not care about the read/freeze case since they cannot move an object input
@@ -373,12 +390,16 @@ fn check_gas_by_value(arg: &T::Argument) -> Result<(), ExecutionError> {
     }
 }
 
-fn check_gas_by_value_loc(idx: u16, location: &T::Location) -> Result<(), ExecutionError> {
+fn check_gas_by_value_loc<E: ExecutionErrorTrait>(
+    idx: u16,
+    location: &T::Location,
+) -> Result<(), E> {
     match location {
         T::Location::GasCoin => Err(command_argument_error(
             CommandArgumentError::InvalidGasCoinUsage,
             idx as usize,
-        )),
+        )
+        .into()),
         T::Location::TxContext
         | T::Location::ObjectInput(_)
         | T::Location::WithdrawalInput(_)

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/verify/input_arguments.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/verify/input_arguments.rs
@@ -75,7 +75,7 @@ impl Context {
 ///    on mutable objects. And that the gas coin is only taken by value in transfer objects or with
 ///    `sui::coin::send_funds`.
 pub fn verify<Mode: ExecutionMode>(
-    env: &Env<'_, '_, '_, '_, '_, Mode::Error>,
+    env: &Env<'_, '_, '_, '_, '_, Mode>,
     txn: &T::Transaction,
 ) -> Result<(), Mode::Error> {
     let T::Transaction {
@@ -245,11 +245,11 @@ pub fn is_valid_receiving(constraint: &Type) -> bool {
 // Object usage
 //**************************************************************************************************
 
-fn command<E: ExecutionErrorTrait>(
-    env: &Env<'_, '_, '_, '_, '_, E>,
+fn command<Mode: ExecutionMode>(
+    env: &Env<'_, '_, '_, '_, '_, Mode>,
     context: &mut Context,
     sp!(_, c): &T::Command,
-) -> Result<(), E> {
+) -> Result<(), Mode::Error> {
     match &c.command {
         T::Command__::MoveCall(mc) => {
             check_obj_usages(context, &mc.arguments)?;

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/verify/input_arguments.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/verify/input_arguments.rs
@@ -18,7 +18,7 @@ use sui_types::{
     SUI_FRAMEWORK_ADDRESS,
     base_types::{RESOLVED_ASCII_STR, RESOLVED_STD_OPTION, RESOLVED_UTF8_STR},
     coin::{COIN_MODULE_NAME, SEND_FUNDS_FUNC_NAME},
-    error::{ExecutionError, ExecutionErrorTrait, SafeIndex, command_argument_error},
+    error::{ExecutionErrorTrait, SafeIndex, command_argument_error},
     execution_status::{CommandArgumentError, ExecutionErrorKind},
     id::RESOLVED_SUI_ID,
     transfer::RESOLVED_RECEIVING_STRUCT,
@@ -144,14 +144,13 @@ fn check_pure_bytes<Mode: ExecutionMode>(
         let msg = format!(
             "Invalid usage of `Pure` argument for a non-primitive argument type at index {command_arg_idx}.",
         );
-        return Err(ExecutionError::new_with_source(
+        return Err(Mode::Error::new_with_source(
             ExecutionErrorKind::command_argument_error(
                 CommandArgumentError::InvalidUsageOfPureArg,
                 command_arg_idx,
             ),
             msg,
-        )
-        .into());
+        ));
     };
     bcs_argument_validate(bytes, command_arg_idx, layout)?;
     Ok(())

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/verify/memory_safety.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/verify/memory_safety.rs
@@ -8,6 +8,7 @@ use std::{
 };
 
 use crate::{
+    execution_mode::ExecutionMode,
     sp,
     static_programmable_transactions::{
         env::Env,
@@ -69,10 +70,10 @@ impl Value {
 }
 
 impl Context {
-    fn new<E: ExecutionErrorTrait>(
-        _env: &Env<'_, '_, '_, '_, '_, E>,
+    fn new<Mode: ExecutionMode>(
+        _env: &Env<'_, '_, '_, '_, '_, Mode>,
         ast: &T::Transaction,
-    ) -> Result<Self, E> {
+    ) -> Result<Self, Mode::Error> {
         let gas_coin = if ast.gas_payment.is_none() {
             None
         } else {
@@ -101,7 +102,7 @@ impl Context {
             .filter(|ty| matches!(&ty, Type::Reference(_, _)))
             .count();
         let (mut graph, _locals) =
-            Graph::new::<()>(canonical_reference_capacity, []).map_err(graph_err::<E>)?;
+            Graph::new::<()>(canonical_reference_capacity, []).map_err(graph_err::<Mode::Error>)?;
         let local_root = graph
             .extend_by_epsilon(
                 (),
@@ -109,7 +110,7 @@ impl Context {
                 /* is_mut */ true,
                 &mut DummyMeter,
             )
-            .map_err(graph_meter_err::<E>)?;
+            .map_err(graph_meter_err::<Mode::Error>)?;
         Ok(Self {
             graph,
             local_root,
@@ -267,15 +268,15 @@ impl Context {
 /// Checks the following
 /// - Values are not used after being moved
 /// - Reference safety is upheld (no dangling references)
-pub fn verify<E: ExecutionErrorTrait>(
-    env: &Env<'_, '_, '_, '_, '_, E>,
+pub fn verify<Mode: ExecutionMode>(
+    env: &Env<'_, '_, '_, '_, '_, Mode>,
     ast: &T::Transaction,
-) -> Result<(), E> {
+) -> Result<(), Mode::Error> {
     let mut context = Context::new(env, ast)?;
     let commands = &ast.commands;
     for c in commands {
-        let result =
-            command::<E>(&mut context, c).map_err(|e| e.with_command_index(c.idx as usize))?;
+        let result = command::<Mode::Error>(&mut context, c)
+            .map_err(|e| e.with_command_index(c.idx as usize))?;
         assert_invariant!(
             result.len() == c.value.result_type.len(),
             "result length mismatch for command. {c:?}"
@@ -292,11 +293,11 @@ pub fn verify<E: ExecutionErrorTrait>(
                 Ok(if !drop {
                     Some(v)
                 } else {
-                    consume_value::<E>(&mut context, v)?;
+                    consume_value::<Mode::Error>(&mut context, v)?;
                     None
                 })
             })
-            .collect::<Result<Vec<_>, E>>()?;
+            .collect::<Result<Vec<_>, Mode::Error>>()?;
         context.results.push(result_values);
     }
 
@@ -313,21 +314,23 @@ pub fn verify<E: ExecutionErrorTrait>(
     let pure = std::mem::take(pure);
     let receiving = std::mem::take(receiving);
     let results = std::mem::take(results);
-    consume_value_opt::<E>(&mut context, gas_coin)?;
+    consume_value_opt::<Mode::Error>(&mut context, gas_coin)?;
     for vopt in objects.into_iter().chain(pure).chain(receiving) {
-        consume_value_opt::<E>(&mut context, vopt)?;
+        consume_value_opt::<Mode::Error>(&mut context, vopt)?;
     }
     for result in results {
         for vopt in result {
-            consume_value_opt::<E>(&mut context, vopt)?;
+            consume_value_opt::<Mode::Error>(&mut context, vopt)?;
         }
     }
 
     assert_invariant!(
-        context.borrowed_by::<E>(context.local_root)?.is_empty(),
+        context
+            .borrowed_by::<Mode::Error>(context.local_root)?
+            .is_empty(),
         "reference to local root not released"
     );
-    context.release::<E>(context.local_root)?;
+    context.release::<Mode::Error>(context.local_root)?;
     assert_invariant!(context.graph.is_empty(), "reference not released");
     assert_invariant!(
         context.tx_context.is_some(),

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/verify/memory_safety.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/verify/memory_safety.rs
@@ -17,8 +17,8 @@ use crate::{
 use move_regex_borrow_graph::{MeterError, meter::DummyMeter, references::Ref};
 use mysten_common::ZipDebugEqIteratorExt;
 use sui_types::{
-    error::{ExecutionError, SafeIndex, command_argument_error},
-    execution_status::CommandArgumentError,
+    error::{ExecutionErrorTrait, SafeIndex},
+    execution_status::{CommandArgumentError, ExecutionErrorKind},
 };
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
@@ -69,7 +69,10 @@ impl Value {
 }
 
 impl Context {
-    fn new(_env: &Env, ast: &T::Transaction) -> Result<Self, ExecutionError> {
+    fn new<E: ExecutionErrorTrait>(
+        _env: &Env<'_, '_, '_, '_, '_, E>,
+        ast: &T::Transaction,
+    ) -> Result<Self, E> {
         let gas_coin = if ast.gas_payment.is_none() {
             None
         } else {
@@ -98,7 +101,7 @@ impl Context {
             .filter(|ty| matches!(&ty, Type::Reference(_, _)))
             .count();
         let (mut graph, _locals) =
-            Graph::new::<()>(canonical_reference_capacity, []).map_err(graph_err)?;
+            Graph::new::<()>(canonical_reference_capacity, []).map_err(graph_err::<E>)?;
         let local_root = graph
             .extend_by_epsilon(
                 (),
@@ -106,7 +109,7 @@ impl Context {
                 /* is_mut */ true,
                 &mut DummyMeter,
             )
-            .map_err(graph_meter_err)?;
+            .map_err(graph_meter_err::<E>)?;
         Ok(Self {
             graph,
             local_root,
@@ -120,7 +123,10 @@ impl Context {
         })
     }
 
-    fn location(&mut self, l: T::Location) -> Result<&mut Option<Value>, ExecutionError> {
+    fn location<E: ExecutionErrorTrait>(
+        &mut self,
+        l: T::Location,
+    ) -> Result<&mut Option<Value>, E> {
         Ok(match l {
             T::Location::TxContext => &mut self.tx_context,
             T::Location::GasCoin => &mut self.gas_coin,
@@ -135,45 +141,49 @@ impl Context {
         })
     }
 
-    fn is_mutable(&self, r: Ref) -> Result<bool, ExecutionError> {
-        self.graph.is_mutable(r).map_err(graph_err)
+    fn is_mutable<E: ExecutionErrorTrait>(&self, r: Ref) -> Result<bool, E> {
+        self.graph.is_mutable(r).map_err(graph_err::<E>)
     }
 
-    fn borrowed_by(&self, r: Ref) -> Result<BTreeMap<Ref, Paths>, ExecutionError> {
+    fn borrowed_by<E: ExecutionErrorTrait>(&self, r: Ref) -> Result<BTreeMap<Ref, Paths>, E> {
         self.graph
             .borrowed_by(r, &mut DummyMeter)
-            .map_err(graph_meter_err)
+            .map_err(graph_meter_err::<E>)
     }
 
     /// Used for checking if a location is borrowed
     /// Used for updating the borrowed marker in Copy, and for correctness of Move
-    fn is_location_borrowed(&self, l: T::Location) -> Result<bool, ExecutionError> {
-        let borrowed_by = self.borrowed_by(self.local_root)?;
+    fn is_location_borrowed<E: ExecutionErrorTrait>(&self, l: T::Location) -> Result<bool, E> {
+        let borrowed_by = self.borrowed_by::<E>(self.local_root)?;
         Ok(borrowed_by
             .iter()
             .any(|(_, paths)| paths.iter().any(|path| path.starts_with(&Location(l)))))
     }
 
-    fn release(&mut self, r: Ref) -> Result<(), ExecutionError> {
+    fn release<E: ExecutionErrorTrait>(&mut self, r: Ref) -> Result<(), E> {
         self.graph
             .release(r, &mut DummyMeter)
-            .map_err(graph_meter_err)
+            .map_err(graph_meter_err::<E>)
     }
 
-    fn extend_by_epsilon(&mut self, r: Ref, is_mut: bool) -> Result<Ref, ExecutionError> {
+    fn extend_by_epsilon<E: ExecutionErrorTrait>(
+        &mut self,
+        r: Ref,
+        is_mut: bool,
+    ) -> Result<Ref, E> {
         let new_r = self
             .graph
             .extend_by_epsilon((), std::iter::once(r), is_mut, &mut DummyMeter)
-            .map_err(graph_meter_err)?;
+            .map_err(graph_meter_err::<E>)?;
         Ok(new_r)
     }
 
-    fn extend_by_label(
+    fn extend_by_label<E: ExecutionErrorTrait>(
         &mut self,
         r: Ref,
         is_mut: bool,
         extension: T::Location,
-    ) -> Result<Ref, ExecutionError> {
+    ) -> Result<Ref, E> {
         let new_r = self
             .graph
             .extend_by_label(
@@ -183,49 +193,52 @@ impl Context {
                 Location(extension),
                 &mut DummyMeter,
             )
-            .map_err(graph_meter_err)?;
+            .map_err(graph_meter_err::<E>)?;
         Ok(new_r)
     }
 
-    fn extend_by_dot_star_for_call(
+    fn extend_by_dot_star_for_call<E: ExecutionErrorTrait>(
         &mut self,
         sources: &BTreeSet<Ref>,
         mutabilities: Vec<bool>,
-    ) -> Result<Vec<Ref>, ExecutionError> {
+    ) -> Result<Vec<Ref>, E> {
         let new_refs = self
             .graph
             .extend_by_dot_star_for_call((), sources, mutabilities, &mut DummyMeter)
-            .map_err(graph_meter_err)?;
+            .map_err(graph_meter_err::<E>)?;
         Ok(new_refs)
     }
 
     // Writable if
     // No imm equal
     // No extensions
-    fn is_writable(&self, r: Ref) -> Result<bool, ExecutionError> {
-        debug_assert!(self.is_mutable(r)?);
+    fn is_writable<E: ExecutionErrorTrait>(&self, r: Ref) -> Result<bool, E> {
+        debug_assert!(self.is_mutable::<E>(r)?);
         Ok(self
-            .borrowed_by(r)?
+            .borrowed_by::<E>(r)?
             .values()
             .all(|paths| paths.iter().all(|path| path.is_epsilon())))
     }
 
     // is in reference not able to be used in a call or return
-    fn find_non_transferrable(&self, refs: &BTreeSet<Ref>) -> Result<Option<Ref>, ExecutionError> {
+    fn find_non_transferrable<E: ExecutionErrorTrait>(
+        &self,
+        refs: &BTreeSet<Ref>,
+    ) -> Result<Option<Ref>, E> {
         let borrows = refs
             .iter()
             .copied()
-            .map(|r| Ok((r, self.borrowed_by(r)?)))
-            .collect::<Result<BTreeMap<_, _>, ExecutionError>>()?;
+            .map(|r| Ok((r, self.borrowed_by::<E>(r)?)))
+            .collect::<Result<BTreeMap<_, _>, E>>()?;
         let mut_refs = refs
             .iter()
             .copied()
-            .filter_map(|r| match self.is_mutable(r) {
+            .filter_map(|r| match self.is_mutable::<E>(r) {
                 Ok(true) => Some(Ok(r)),
                 Ok(false) => None,
                 Err(e) => Some(Err(e)),
             })
-            .collect::<Result<BTreeSet<_>, ExecutionError>>()?;
+            .collect::<Result<BTreeSet<_>, E>>()?;
         for (r, borrowed_by) in borrows {
             let is_mut = mut_refs.contains(&r);
             for (borrower, paths) in borrowed_by {
@@ -254,11 +267,15 @@ impl Context {
 /// Checks the following
 /// - Values are not used after being moved
 /// - Reference safety is upheld (no dangling references)
-pub fn verify(env: &Env, ast: &T::Transaction) -> Result<(), ExecutionError> {
+pub fn verify<E: ExecutionErrorTrait>(
+    env: &Env<'_, '_, '_, '_, '_, E>,
+    ast: &T::Transaction,
+) -> Result<(), E> {
     let mut context = Context::new(env, ast)?;
     let commands = &ast.commands;
     for c in commands {
-        let result = command(&mut context, c).map_err(|e| e.with_command_index(c.idx as usize))?;
+        let result =
+            command::<E>(&mut context, c).map_err(|e| e.with_command_index(c.idx as usize))?;
         assert_invariant!(
             result.len() == c.value.result_type.len(),
             "result length mismatch for command. {c:?}"
@@ -275,11 +292,11 @@ pub fn verify(env: &Env, ast: &T::Transaction) -> Result<(), ExecutionError> {
                 Ok(if !drop {
                     Some(v)
                 } else {
-                    consume_value(&mut context, v)?;
+                    consume_value::<E>(&mut context, v)?;
                     None
                 })
             })
-            .collect::<Result<Vec<_>, ExecutionError>>()?;
+            .collect::<Result<Vec<_>, E>>()?;
         context.results.push(result_values);
     }
 
@@ -296,21 +313,21 @@ pub fn verify(env: &Env, ast: &T::Transaction) -> Result<(), ExecutionError> {
     let pure = std::mem::take(pure);
     let receiving = std::mem::take(receiving);
     let results = std::mem::take(results);
-    consume_value_opt(&mut context, gas_coin)?;
+    consume_value_opt::<E>(&mut context, gas_coin)?;
     for vopt in objects.into_iter().chain(pure).chain(receiving) {
-        consume_value_opt(&mut context, vopt)?;
+        consume_value_opt::<E>(&mut context, vopt)?;
     }
     for result in results {
         for vopt in result {
-            consume_value_opt(&mut context, vopt)?;
+            consume_value_opt::<E>(&mut context, vopt)?;
         }
     }
 
     assert_invariant!(
-        context.borrowed_by(context.local_root)?.is_empty(),
+        context.borrowed_by::<E>(context.local_root)?.is_empty(),
         "reference to local root not released"
     );
-    context.release(context.local_root)?;
+    context.release::<E>(context.local_root)?;
     assert_invariant!(context.graph.is_empty(), "reference not released");
     assert_invariant!(
         context.tx_context.is_some(),
@@ -320,7 +337,10 @@ pub fn verify(env: &Env, ast: &T::Transaction) -> Result<(), ExecutionError> {
     Ok(())
 }
 
-fn command(context: &mut Context, sp!(_, c): &T::Command) -> Result<Vec<Value>, ExecutionError> {
+fn command<E: ExecutionErrorTrait>(
+    context: &mut Context,
+    sp!(_, c): &T::Command,
+) -> Result<Vec<Value>, E> {
     let result_tys = &c.result_type;
     Ok(match &c.command {
         T::Command__::MoveCall(mc) => {
@@ -328,39 +348,39 @@ fn command(context: &mut Context, sp!(_, c): &T::Command) -> Result<Vec<Value>, 
                 function,
                 arguments: args,
             } = &**mc;
-            let arg_values = arguments(context, args)?;
-            call(context, arg_values, &function.signature)?
+            let arg_values = arguments::<E>(context, args)?;
+            call::<E>(context, arg_values, &function.signature)?
         }
         T::Command__::TransferObjects(objects, recipient) => {
-            let object_values = arguments(context, objects)?;
-            let recipient_value = argument(context, recipient)?;
-            consume_values(context, object_values)?;
-            consume_value(context, recipient_value)?;
+            let object_values = arguments::<E>(context, objects)?;
+            let recipient_value = argument::<E>(context, recipient)?;
+            consume_values::<E>(context, object_values)?;
+            consume_value::<E>(context, recipient_value)?;
             vec![]
         }
         T::Command__::SplitCoins(_, coin, amounts) => {
-            let coin_value = argument(context, coin)?;
-            let amount_values = arguments(context, amounts)?;
-            consume_values(context, amount_values)?;
-            write_ref(context, 0, coin_value)?;
+            let coin_value = argument::<E>(context, coin)?;
+            let amount_values = arguments::<E>(context, amounts)?;
+            consume_values::<E>(context, amount_values)?;
+            write_ref::<E>(context, 0, coin_value)?;
             (0..amounts.len()).map(|_| Value::NonRef).collect()
         }
         T::Command__::MergeCoins(_, target, coins) => {
-            let target_value = argument(context, target)?;
-            let coin_values = arguments(context, coins)?;
-            consume_values(context, coin_values)?;
-            write_ref(context, 0, target_value)?;
+            let target_value = argument::<E>(context, target)?;
+            let coin_values = arguments::<E>(context, coins)?;
+            consume_values::<E>(context, coin_values)?;
+            write_ref::<E>(context, 0, target_value)?;
             vec![]
         }
         T::Command__::MakeMoveVec(_, xs) => {
-            let vs = arguments(context, xs)?;
-            consume_values(context, vs)?;
+            let vs = arguments::<E>(context, xs)?;
+            consume_values::<E>(context, vs)?;
             vec![Value::NonRef]
         }
         T::Command__::Publish(_, _, _) => result_tys.iter().map(|_| Value::NonRef).collect(),
         T::Command__::Upgrade(_, _, _, x, _) => {
-            let v = argument(context, x)?;
-            consume_value(context, v)?;
+            let v = argument::<E>(context, x)?;
+            consume_value::<E>(context, v)?;
             vec![Value::NonRef]
         }
     })
@@ -370,173 +390,198 @@ fn command(context: &mut Context, sp!(_, c): &T::Command) -> Result<Vec<Value>, 
 // Abstract State
 //**************************************************************************************************
 
-fn consume_values(context: &mut Context, values: Vec<Value>) -> Result<(), ExecutionError> {
+fn consume_values<E: ExecutionErrorTrait>(
+    context: &mut Context,
+    values: Vec<Value>,
+) -> Result<(), E> {
     for v in values {
-        consume_value(context, v)?;
+        consume_value::<E>(context, v)?;
     }
     Ok(())
 }
 
-fn consume_value_opt(context: &mut Context, value: Option<Value>) -> Result<(), ExecutionError> {
+fn consume_value_opt<E: ExecutionErrorTrait>(
+    context: &mut Context,
+    value: Option<Value>,
+) -> Result<(), E> {
     match value {
-        Some(v) => consume_value(context, v),
+        Some(v) => consume_value::<E>(context, v),
         None => Ok(()),
     }
 }
 
-fn consume_value(context: &mut Context, value: Value) -> Result<(), ExecutionError> {
+fn consume_value<E: ExecutionErrorTrait>(context: &mut Context, value: Value) -> Result<(), E> {
     match value {
         Value::NonRef => Ok(()),
         Value::Ref(r) => {
-            context.release(r)?;
+            context.release::<E>(r)?;
             Ok(())
         }
     }
 }
 
-fn arguments(context: &mut Context, xs: &[T::Argument]) -> Result<Vec<Value>, ExecutionError> {
-    xs.iter().map(|x| argument(context, x)).collect()
+fn arguments<E: ExecutionErrorTrait>(
+    context: &mut Context,
+    xs: &[T::Argument],
+) -> Result<Vec<Value>, E> {
+    xs.iter().map(|x| argument::<E>(context, x)).collect()
 }
 
-fn argument(context: &mut Context, x: &T::Argument) -> Result<Value, ExecutionError> {
+fn argument<E: ExecutionErrorTrait>(context: &mut Context, x: &T::Argument) -> Result<Value, E> {
     match &x.value.0 {
-        T::Argument__::Use(T::Usage::Move(location)) => move_value(context, x.idx, *location),
+        T::Argument__::Use(T::Usage::Move(location)) => move_value::<E>(context, x.idx, *location),
         T::Argument__::Use(T::Usage::Copy { location, borrowed }) => {
-            copy_value(context, x.idx, *location, borrowed)
+            copy_value::<E>(context, x.idx, *location, borrowed)
         }
         T::Argument__::Borrow(is_mut, location) => {
-            borrow_location(context, x.idx, *is_mut, *location)
+            borrow_location::<E>(context, x.idx, *is_mut, *location)
         }
-        T::Argument__::Read(usage) => read_ref(context, x.idx, usage),
-        T::Argument__::Freeze(usage) => freeze_ref(context, x.idx, usage),
+        T::Argument__::Read(usage) => read_ref::<E>(context, x.idx, usage),
+        T::Argument__::Freeze(usage) => freeze_ref::<E>(context, x.idx, usage),
     }
 }
 
-fn move_value(
+fn move_value<E: ExecutionErrorTrait>(
     context: &mut Context,
     arg_idx: u16,
     l: T::Location,
-) -> Result<Value, ExecutionError> {
-    if context.is_location_borrowed(l)? {
+) -> Result<Value, E> {
+    if context.is_location_borrowed::<E>(l)? {
         // TODO more specific error
-        return Err(command_argument_error(
+        return Err(E::from_kind(ExecutionErrorKind::command_argument_error(
             CommandArgumentError::CannotMoveBorrowedValue,
-            arg_idx as usize,
-        ));
+            arg_idx,
+        )));
     }
-    let Some(value) = context.location(l)?.take() else {
-        return Err(command_argument_error(
+    let Some(value) = context.location::<E>(l)?.take() else {
+        return Err(E::from_kind(ExecutionErrorKind::command_argument_error(
             CommandArgumentError::ArgumentWithoutValue,
-            arg_idx as usize,
-        ));
+            arg_idx,
+        )));
     };
     Ok(value)
 }
 
-fn copy_value(
+fn copy_value<E: ExecutionErrorTrait>(
     context: &mut Context,
     arg_idx: u16,
     l: T::Location,
     borrowed: &OnceCell<bool>,
-) -> Result<Value, ExecutionError> {
-    let is_borrowed = context.is_location_borrowed(l)?;
+) -> Result<Value, E> {
+    let is_borrowed = context.is_location_borrowed::<E>(l)?;
     borrowed
         .set(is_borrowed)
         .map_err(|_| make_invariant_violation!("Copy's borrowed marker should not yet be set"))?;
 
-    let Some(value) = context.location(l)? else {
+    let Some(value) = context.location::<E>(l)? else {
         // TODO more specific error
-        return Err(command_argument_error(
+        return Err(E::from_kind(ExecutionErrorKind::command_argument_error(
             CommandArgumentError::ArgumentWithoutValue,
-            arg_idx as usize,
-        ));
+            arg_idx,
+        )));
     };
     Ok(match value {
         Value::Ref(r) => {
             let r = *r;
-            let is_mut = context.is_mutable(r)?;
-            let new_r = context.extend_by_epsilon(r, is_mut)?;
+            let is_mut = context.is_mutable::<E>(r)?;
+            let new_r = context.extend_by_epsilon::<E>(r, is_mut)?;
             Value::Ref(new_r)
         }
         Value::NonRef => Value::NonRef,
     })
 }
 
-fn borrow_location(
+fn borrow_location<E: ExecutionErrorTrait>(
     context: &mut Context,
     arg_idx: u16,
     is_mut: bool,
     l: T::Location,
-) -> Result<Value, ExecutionError> {
+) -> Result<Value, E> {
     // check that the location has a value
-    let Some(value) = context.location(l)? else {
+    let Some(value) = context.location::<E>(l)? else {
         // TODO more specific error
-        return Err(command_argument_error(
+        return Err(E::from_kind(ExecutionErrorKind::command_argument_error(
             CommandArgumentError::ArgumentWithoutValue,
-            arg_idx as usize,
-        ));
+            arg_idx,
+        )));
     };
     assert_invariant!(
         value.is_non_ref(),
         "type checking should guarantee no borrowing of references"
     );
-    let new_r = context.extend_by_label(context.local_root, is_mut, l)?;
+    let new_r = context.extend_by_label::<E>(context.local_root, is_mut, l)?;
     Ok(Value::Ref(new_r))
 }
 
 /// Creates an alias to the reference, but one that is immutable
-fn freeze_ref(context: &mut Context, arg_idx: u16, u: &T::Usage) -> Result<Value, ExecutionError> {
+fn freeze_ref<E: ExecutionErrorTrait>(
+    context: &mut Context,
+    arg_idx: u16,
+    u: &T::Usage,
+) -> Result<Value, E> {
     let value = match u {
-        T::Usage::Move(l) => move_value(context, arg_idx, *l)?,
-        T::Usage::Copy { location, borrowed } => copy_value(context, arg_idx, *location, borrowed)?,
+        T::Usage::Move(l) => move_value::<E>(context, arg_idx, *l)?,
+        T::Usage::Copy { location, borrowed } => {
+            copy_value::<E>(context, arg_idx, *location, borrowed)?
+        }
     };
     let Some(r) = value.to_ref() else {
         invariant_violation!("type checking should guarantee FreezeRef is used on only references")
     };
-    let new_r = context.extend_by_epsilon(r, /* is_mut */ false)?;
-    consume_value(context, value)?;
+    let new_r = context.extend_by_epsilon::<E>(r, /* is_mut */ false)?;
+    consume_value::<E>(context, value)?;
     Ok(Value::Ref(new_r))
 }
 
-fn read_ref(context: &mut Context, arg_idx: u16, u: &T::Usage) -> Result<Value, ExecutionError> {
+fn read_ref<E: ExecutionErrorTrait>(
+    context: &mut Context,
+    arg_idx: u16,
+    u: &T::Usage,
+) -> Result<Value, E> {
     let value = match u {
-        T::Usage::Move(l) => move_value(context, arg_idx, *l)?,
-        T::Usage::Copy { location, borrowed } => copy_value(context, arg_idx, *location, borrowed)?,
+        T::Usage::Move(l) => move_value::<E>(context, arg_idx, *l)?,
+        T::Usage::Copy { location, borrowed } => {
+            copy_value::<E>(context, arg_idx, *location, borrowed)?
+        }
     };
     assert_invariant!(
         value.is_ref(),
         "type checking should guarantee ReadRef is used on only references"
     );
-    consume_value(context, value)?;
+    consume_value::<E>(context, value)?;
     Ok(Value::NonRef)
 }
 
-fn write_ref(context: &mut Context, arg_idx: usize, value: Value) -> Result<(), ExecutionError> {
+fn write_ref<E: ExecutionErrorTrait>(
+    context: &mut Context,
+    arg_idx: usize,
+    value: Value,
+) -> Result<(), E> {
     let Value::Ref(r) = value else {
         invariant_violation!("type checking should guarantee WriteRef is used on only references");
     };
 
-    if !context.is_writable(r)? {
+    if !context.is_writable::<E>(r)? {
         // TODO more specific error
-        return Err(command_argument_error(
+        return Err(E::from_kind(ExecutionErrorKind::command_argument_error(
             CommandArgumentError::CannotWriteToExtendedReference,
-            arg_idx,
-        ));
+            checked_as!(arg_idx, u16)?,
+        )));
     }
-    consume_value(context, value)?;
+    consume_value::<E>(context, value)?;
     Ok(())
 }
 
-fn call(
+fn call<E: ExecutionErrorTrait>(
     context: &mut Context,
     arg_values: Vec<Value>,
     signature: &T::LoadedFunctionInstantiation,
-) -> Result<Vec<Value>, ExecutionError> {
+) -> Result<Vec<Value>, E> {
     let sources = arg_values
         .iter()
         .filter_map(|v| v.to_ref())
         .collect::<BTreeSet<_>>();
-    if let Some(v) = context.find_non_transferrable(&sources)? {
+    if let Some(v) = context.find_non_transferrable::<E>(&sources)? {
         let mut_idx = arg_values
             .iter()
             .zip_debug_eq(&signature.parameters)
@@ -546,10 +591,10 @@ fn call(
         let Some((idx, _)) = mut_idx else {
             invariant_violation!("non transferrable value was not found in arguments");
         };
-        return Err(command_argument_error(
+        return Err(E::from_kind(ExecutionErrorKind::command_argument_error(
             CommandArgumentError::InvalidReferenceArgument,
-            idx,
-        ));
+            checked_as!(idx, u16)?,
+        )));
     }
     let mutabilities = signature
         .return_
@@ -560,7 +605,7 @@ fn call(
         })
         .collect::<Vec<_>>();
     let mutabilities_len = mutabilities.len();
-    let mut return_references = context.extend_by_dot_star_for_call(&sources, mutabilities)?;
+    let mut return_references = context.extend_by_dot_star_for_call::<E>(&sources, mutabilities)?;
     assert_invariant!(
         return_references.len() == mutabilities_len,
         "return_references should have the same length as mutabilities"
@@ -576,33 +621,33 @@ fn call(
                     let Some(new_ref) = return_references.pop() else {
                         invariant_violation!("return_references has less references than return_");
                     };
-                    debug_assert_eq!(context.is_mutable(new_ref)?, *_is_mut);
+                    debug_assert_eq!(context.is_mutable::<E>(new_ref)?, *_is_mut);
                     Value::Ref(new_ref)
                 }
                 _ => Value::NonRef,
             })
         })
-        .collect::<Result<Vec<_>, ExecutionError>>()?;
+        .collect::<Result<Vec<_>, E>>()?;
     return_values.reverse();
     assert_invariant!(
         return_references.is_empty(),
         "return_references has more references than return_"
     );
-    consume_values(context, arg_values)?;
+    consume_values::<E>(context, arg_values)?;
     Ok(return_values)
 }
 
-fn graph_meter_err(e: MeterError<()>) -> ExecutionError {
+fn graph_meter_err<E: ExecutionErrorTrait>(e: MeterError<()>) -> E {
     match e {
         MeterError::Meter(()) => {
-            make_invariant_violation!("DummyMeter should never produce a Meter error")
+            make_invariant_violation!("DummyMeter should never produce a Meter error").into()
         }
-        MeterError::InvariantViolation(iv) => graph_err(iv),
+        MeterError::InvariantViolation(iv) => graph_err::<E>(iv),
     }
 }
 
-fn graph_err(e: move_regex_borrow_graph::InvariantViolation) -> ExecutionError {
-    make_invariant_violation!("Borrow graph invariant violation: {}", e.0)
+fn graph_err<E: ExecutionErrorTrait>(e: move_regex_borrow_graph::InvariantViolation) -> E {
+    make_invariant_violation!("Borrow graph invariant violation: {}", e.0).into()
 }
 
 impl fmt::Display for Location {

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/verify/mod.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/verify/mod.rs
@@ -13,7 +13,7 @@ pub mod move_functions;
 pub mod private_entry_arguments;
 
 pub fn transaction<Mode: ExecutionMode>(
-    env: &env::Env<'_, '_, '_, '_, '_, Mode::Error>,
+    env: &env::Env<'_, '_, '_, '_, '_, Mode>,
     ast: &mut T::Transaction,
 ) -> Result<(), Mode::Error> {
     input_arguments::verify::<Mode>(env, &*ast)?;

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/verify/mod.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/verify/mod.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use sui_types::error::ExecutionError;
-
 use crate::{
     execution_mode::ExecutionMode,
     static_programmable_transactions::{env, typing::ast as T},
@@ -15,9 +13,9 @@ pub mod move_functions;
 pub mod private_entry_arguments;
 
 pub fn transaction<Mode: ExecutionMode>(
-    env: &env::Env,
+    env: &env::Env<'_, '_, '_, '_, '_, Mode::Error>,
     ast: &mut T::Transaction,
-) -> Result<(), ExecutionError> {
+) -> Result<(), Mode::Error> {
     input_arguments::verify::<Mode>(env, &*ast)?;
     move_functions::verify::<Mode>(env, &*ast)?;
     memory_safety::verify(env, &*ast)?;

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/verify/move_functions.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/verify/move_functions.rs
@@ -19,7 +19,7 @@ use sui_verifier::private_generics_verifier_v2;
 ///    - Can be disabled under certain execution modes
 ///    - Can be disabled via a feature flag
 pub fn verify<Mode: ExecutionMode>(
-    env: &Env<'_, '_, '_, '_, '_, Mode::Error>,
+    env: &Env<'_, '_, '_, '_, '_, Mode>,
     txn: &T::Transaction,
 ) -> Result<(), Mode::Error> {
     for c in &txn.commands {
@@ -29,7 +29,7 @@ pub fn verify<Mode: ExecutionMode>(
 }
 
 fn command<Mode: ExecutionMode>(
-    env: &Env<'_, '_, '_, '_, '_, Mode::Error>,
+    env: &Env<'_, '_, '_, '_, '_, Mode>,
     sp!(_, c): &T::Command,
 ) -> Result<(), Mode::Error> {
     let T::Command_ {
@@ -55,7 +55,7 @@ fn command<Mode: ExecutionMode>(
 /// - valid visibility
 /// - private generics rules
 fn move_call<Mode: ExecutionMode>(
-    env: &Env<'_, '_, '_, '_, '_, Mode::Error>,
+    env: &Env<'_, '_, '_, '_, '_, Mode>,
     call: &T::MoveCall,
 ) -> Result<(), Mode::Error> {
     let T::MoveCall {
@@ -69,7 +69,7 @@ fn move_call<Mode: ExecutionMode>(
 }
 
 fn check_signature<Mode: ExecutionMode>(
-    env: &Env<'_, '_, '_, '_, '_, Mode::Error>,
+    env: &Env<'_, '_, '_, '_, '_, Mode>,
     function: &T::LoadedFunction,
 ) -> Result<(), Mode::Error> {
     fn check_return_type<Mode: ExecutionMode, E: ExecutionErrorTrait>(
@@ -100,7 +100,7 @@ fn check_signature<Mode: ExecutionMode>(
 }
 
 fn check_visibility<Mode: ExecutionMode>(
-    _env: &Env<'_, '_, '_, '_, '_, Mode::Error>,
+    _env: &Env<'_, '_, '_, '_, '_, Mode>,
     function: &T::LoadedFunction,
 ) -> Result<(), Mode::Error> {
     let visibility = function.visibility;

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/verify/move_functions.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/verify/move_functions.rs
@@ -7,7 +7,7 @@ use crate::static_programmable_transactions::{env::Env, loading::ast::Type, typi
 use move_binary_format::file_format::Visibility;
 use move_core_types::identifier::IdentStr;
 use move_core_types::language_storage::ModuleId;
-use sui_types::error::{ExecutionError, ExecutionErrorTrait};
+use sui_types::error::ExecutionErrorTrait;
 use sui_types::execution_status::ExecutionErrorKind;
 use sui_verifier::private_generics_verifier_v2;
 
@@ -79,12 +79,11 @@ fn check_signature<Mode: ExecutionMode>(
         if let Type::Reference(_, _) = return_type
             && !Mode::allow_arbitrary_values()
         {
-            return Err(ExecutionError::from_kind(
+            return Err(E::from_kind(
                 ExecutionErrorKind::InvalidPublicFunctionReturnType {
                     idx: checked_as!(idx, u16)?,
                 },
-            )
-            .into());
+            ));
         }
         Ok(())
     }
@@ -115,11 +114,10 @@ fn check_visibility<Mode: ExecutionMode>(
         // cannot call private or friend if not entry
         (Visibility::Private | Visibility::Friend, false) => {
             if !Mode::allow_arbitrary_function_calls() {
-                return Err(ExecutionError::new_with_source(
+                return Err(Mode::Error::new_with_source(
                     ExecutionErrorKind::NonEntryFunctionInvoked,
                     "Can only call `entry` or `public` functions",
-                )
-                .into());
+                ));
             }
         }
     };
@@ -157,5 +155,8 @@ fn check_private_generics_v2<E: ExecutionErrorTrait>(
                  only be instantiated with types defined within the caller's module.{}",
         callee_package_name, callee_module, callee_function, internal_idx, help,
     );
-    Err(ExecutionError::new_with_source(ExecutionErrorKind::NonEntryFunctionInvoked, msg).into())
+    Err(E::new_with_source(
+        ExecutionErrorKind::NonEntryFunctionInvoked,
+        msg,
+    ))
 }

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/verify/move_functions.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/verify/move_functions.rs
@@ -7,7 +7,7 @@ use crate::static_programmable_transactions::{env::Env, loading::ast::Type, typi
 use move_binary_format::file_format::Visibility;
 use move_core_types::identifier::IdentStr;
 use move_core_types::language_storage::ModuleId;
-use sui_types::error::ExecutionError;
+use sui_types::error::{ExecutionError, ExecutionErrorTrait};
 use sui_types::execution_status::ExecutionErrorKind;
 use sui_verifier::private_generics_verifier_v2;
 
@@ -18,14 +18,20 @@ use sui_verifier::private_generics_verifier_v2;
 /// - no references returned from move calls
 ///    - Can be disabled under certain execution modes
 ///    - Can be disabled via a feature flag
-pub fn verify<Mode: ExecutionMode>(env: &Env, txn: &T::Transaction) -> Result<(), ExecutionError> {
+pub fn verify<Mode: ExecutionMode>(
+    env: &Env<'_, '_, '_, '_, '_, Mode::Error>,
+    txn: &T::Transaction,
+) -> Result<(), Mode::Error> {
     for c in &txn.commands {
         command::<Mode>(env, c).map_err(|e| e.with_command_index(c.idx as usize))?;
     }
     Ok(())
 }
 
-fn command<Mode: ExecutionMode>(env: &Env, sp!(_, c): &T::Command) -> Result<(), ExecutionError> {
+fn command<Mode: ExecutionMode>(
+    env: &Env<'_, '_, '_, '_, '_, Mode::Error>,
+    sp!(_, c): &T::Command,
+) -> Result<(), Mode::Error> {
     let T::Command_ {
         command,
         result_type: _,
@@ -48,7 +54,10 @@ fn command<Mode: ExecutionMode>(env: &Env, sp!(_, c): &T::Command) -> Result<(),
 /// - valid signature (no references in return type)
 /// - valid visibility
 /// - private generics rules
-fn move_call<Mode: ExecutionMode>(env: &Env, call: &T::MoveCall) -> Result<(), ExecutionError> {
+fn move_call<Mode: ExecutionMode>(
+    env: &Env<'_, '_, '_, '_, '_, Mode::Error>,
+    call: &T::MoveCall,
+) -> Result<(), Mode::Error> {
     let T::MoveCall {
         function,
         arguments: _,
@@ -60,13 +69,13 @@ fn move_call<Mode: ExecutionMode>(env: &Env, call: &T::MoveCall) -> Result<(), E
 }
 
 fn check_signature<Mode: ExecutionMode>(
-    env: &Env,
+    env: &Env<'_, '_, '_, '_, '_, Mode::Error>,
     function: &T::LoadedFunction,
-) -> Result<(), ExecutionError> {
-    fn check_return_type<Mode: ExecutionMode>(
+) -> Result<(), Mode::Error> {
+    fn check_return_type<Mode: ExecutionMode, E: ExecutionErrorTrait>(
         idx: usize,
         return_type: &T::Type,
-    ) -> Result<(), ExecutionError> {
+    ) -> Result<(), E> {
         if let Type::Reference(_, _) = return_type
             && !Mode::allow_arbitrary_values()
         {
@@ -74,7 +83,8 @@ fn check_signature<Mode: ExecutionMode>(
                 ExecutionErrorKind::InvalidPublicFunctionReturnType {
                     idx: checked_as!(idx, u16)?,
                 },
-            ));
+            )
+            .into());
         }
         Ok(())
     }
@@ -84,15 +94,15 @@ fn check_signature<Mode: ExecutionMode>(
     }
 
     for (idx, ty) in function.signature.return_.iter().enumerate() {
-        check_return_type::<Mode>(idx, ty)?;
+        check_return_type::<Mode, Mode::Error>(idx, ty)?;
     }
     Ok(())
 }
 
 fn check_visibility<Mode: ExecutionMode>(
-    _env: &Env,
+    _env: &Env<'_, '_, '_, '_, '_, Mode::Error>,
     function: &T::LoadedFunction,
-) -> Result<(), ExecutionError> {
+) -> Result<(), Mode::Error> {
     let visibility = function.visibility;
     let is_entry = function.is_entry;
     match (visibility, is_entry) {
@@ -108,17 +118,18 @@ fn check_visibility<Mode: ExecutionMode>(
                 return Err(ExecutionError::new_with_source(
                     ExecutionErrorKind::NonEntryFunctionInvoked,
                     "Can only call `entry` or `public` functions",
-                ));
+                )
+                .into());
             }
         }
     };
     Ok(())
 }
 
-fn check_private_generics_v2(
+fn check_private_generics_v2<E: ExecutionErrorTrait>(
     callee_package: &ModuleId,
     callee_function: &IdentStr,
-) -> Result<(), ExecutionError> {
+) -> Result<(), E> {
     let callee_address = *callee_package.address();
     let callee_module = callee_package.name();
     let callee = (callee_address, callee_module, callee_function);
@@ -146,8 +157,5 @@ fn check_private_generics_v2(
                  only be instantiated with types defined within the caller's module.{}",
         callee_package_name, callee_module, callee_function, internal_idx, help,
     );
-    Err(ExecutionError::new_with_source(
-        ExecutionErrorKind::NonEntryFunctionInvoked,
-        msg,
-    ))
+    Err(ExecutionError::new_with_source(ExecutionErrorKind::NonEntryFunctionInvoked, msg).into())
 }

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/verify/private_entry_arguments.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/verify/private_entry_arguments.rs
@@ -393,7 +393,7 @@ impl Context {
 /// - Note that command inputs are released before checking the rules, so an `entry` function can
 ///   consume a hot potato value if it is the last "heating" value in its clique.
 pub fn verify<Mode: ExecutionMode>(
-    env: &Env<'_, '_, '_, '_, '_, Mode::Error>,
+    env: &Env<'_, '_, '_, '_, '_, Mode>,
     txn: &T::Transaction,
 ) -> Result<(), Mode::Error> {
     let mut context = Context::new(txn);
@@ -411,7 +411,7 @@ pub fn verify<Mode: ExecutionMode>(
 }
 
 fn command<Mode: ExecutionMode>(
-    env: &Env<'_, '_, '_, '_, '_, Mode::Error>,
+    env: &Env<'_, '_, '_, '_, '_, Mode>,
     context: &mut Context,
     sp!(_, c): &T::Command,
 ) -> Result<Vec<Option<Value>>, Mode::Error> {
@@ -459,27 +459,27 @@ fn command<Mode: ExecutionMode>(
 }
 
 /// Returns the index of the first hot argument, if any
-fn arguments<'a, E: ExecutionErrorTrait>(
-    env: &Env<'_, '_, '_, '_, '_, E>,
+fn arguments<'a, Mode: ExecutionMode>(
+    env: &Env<'_, '_, '_, '_, '_, Mode>,
     context: &mut Context,
     args: impl IntoIterator<Item = &'a T::Argument>,
-) -> Result<Vec<(u16, CliqueID)>, E> {
+) -> Result<Vec<(u16, CliqueID)>, Mode::Error> {
     let mut arguments = vec![];
     for arg in args {
-        if let Some(clique) = argument::<E>(env, context, arg)? {
+        if let Some(clique) = argument::<Mode>(env, context, arg)? {
             arguments.push((arg.idx, clique));
         }
     }
     Ok(arguments)
 }
 
-fn argument<E: ExecutionErrorTrait>(
-    _env: &Env<'_, '_, '_, '_, '_, E>,
+fn argument<Mode: ExecutionMode>(
+    _env: &Env<'_, '_, '_, '_, '_, Mode>,
     context: &mut Context,
     arg: &T::Argument,
-) -> Result<Option<CliqueID>, E> {
-    let value = context.argument::<E>(arg)?;
-    context.cliques.release_value::<E>(value)
+) -> Result<Option<CliqueID>, Mode::Error> {
+    let value = context.argument::<Mode::Error>(arg)?;
+    context.cliques.release_value::<Mode::Error>(value)
 }
 
 /// Checks a move call for
@@ -490,7 +490,7 @@ fn argument<E: ExecutionErrorTrait>(
 ///
 /// Returns true iff any return type is a hot potato
 fn move_call<Mode: ExecutionMode>(
-    _env: &Env<'_, '_, '_, '_, '_, Mode::Error>,
+    _env: &Env<'_, '_, '_, '_, '_, Mode>,
     context: &mut Context,
     call: &T::MoveCall,
     argument_cliques: &[(u16, CliqueID)],

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/verify/private_entry_arguments.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/verify/private_entry_arguments.rs
@@ -10,11 +10,8 @@ use crate::sp;
 use crate::static_programmable_transactions::{env::Env, typing::ast as T};
 use move_binary_format::file_format::Visibility;
 use mysten_common::ZipDebugEqIteratorExt;
-use sui_types::error::SafeIndex;
-use sui_types::{
-    error::{ExecutionError, command_argument_error},
-    execution_status::CommandArgumentError,
-};
+use sui_types::error::{ExecutionErrorTrait, SafeIndex};
+use sui_types::execution_status::{CommandArgumentError, ExecutionErrorKind};
 
 /// Marks if a clique is hot or not
 #[derive(Clone, Copy, Debug)]
@@ -61,7 +58,7 @@ struct Context {
 }
 
 impl Temperature {
-    fn add(self, other: Temperature) -> Result<Temperature, ExecutionError> {
+    fn add<E: ExecutionErrorTrait>(self, other: Temperature) -> Result<Temperature, E> {
         Ok(match (self, other) {
             (Temperature::AlwaysHot, _) | (_, Temperature::AlwaysHot) => Temperature::AlwaysHot,
             (Temperature::Count(a), Temperature::Count(b)) => Temperature::Count(
@@ -71,7 +68,7 @@ impl Temperature {
         })
     }
 
-    fn sub(self, b: usize) -> Result<Temperature, ExecutionError> {
+    fn sub<E: ExecutionErrorTrait>(self, b: usize) -> Result<Temperature, E> {
         Ok(match self {
             Temperature::AlwaysHot => Temperature::AlwaysHot,
             Temperature::Count(a) => Temperature::Count(
@@ -104,7 +101,7 @@ impl Cliques {
     }
 
     /// Returns the root of the clique (resolving any merges/forwards)
-    fn root(&self, id: CliqueID) -> Result<CliqueID, ExecutionError> {
+    fn root<E: ExecutionErrorTrait>(&self, id: CliqueID) -> Result<CliqueID, E> {
         let mut visited = BTreeSet::from([id]);
         let mut cur = id;
         loop {
@@ -122,8 +119,8 @@ impl Cliques {
     }
 
     /// Returns the temperature of the clique (at the root)
-    fn temp(&self, id: CliqueID) -> Result<Temperature, ExecutionError> {
-        let root = self.root(id)?;
+    fn temp<E: ExecutionErrorTrait>(&self, id: CliqueID) -> Result<Temperature, E> {
+        let root = self.root::<E>(id)?;
         let Clique::Root(temp) = *self.0.safe_get(root)? else {
             invariant_violation!("Clique {root} should be a root");
         };
@@ -131,8 +128,8 @@ impl Cliques {
     }
 
     /// Returns a mutable reference to the temperature of the clique (at the root)
-    fn temp_mut(&mut self, id: CliqueID) -> Result<&mut Temperature, ExecutionError> {
-        let root = self.root(id)?;
+    fn temp_mut<E: ExecutionErrorTrait>(&mut self, id: CliqueID) -> Result<&mut Temperature, E> {
+        let root = self.root::<E>(id)?;
         let Clique::Root(temp) = self.0.safe_get_mut(root)? else {
             invariant_violation!("Clique {root} should be a root");
         };
@@ -141,21 +138,24 @@ impl Cliques {
 
     /// Modifies the temperature of this clique (at the root) via `f`, whose first parameter is the
     /// current temperature
-    fn modify_temp(
+    fn modify_temp<E: ExecutionErrorTrait>(
         &mut self,
         id: CliqueID,
-        f: impl FnOnce(Temperature) -> Result<Temperature, ExecutionError>,
-    ) -> Result<(), ExecutionError> {
-        let temp = self.temp_mut(id)?;
+        f: impl FnOnce(Temperature) -> Result<Temperature, E>,
+    ) -> Result<(), E> {
+        let temp = self.temp_mut::<E>(id)?;
         *temp = f(*temp)?;
         Ok(())
     }
 
     /// Merges the given cliques into one clique
-    fn merge(&mut self, clique_ids: BTreeSet<CliqueID>) -> Result<CliqueID, ExecutionError> {
+    fn merge<E: ExecutionErrorTrait>(
+        &mut self,
+        clique_ids: BTreeSet<CliqueID>,
+    ) -> Result<CliqueID, E> {
         let roots: BTreeSet<CliqueID> = clique_ids
             .iter()
-            .map(|&id| self.root(id))
+            .map(|&id| self.root::<E>(id))
             .collect::<Result<_, _>>()?;
         Ok(match roots.len() {
             0 => self.next(),
@@ -164,9 +164,9 @@ impl Cliques {
                 let merged = self.next();
                 let mut merged_temp = Temperature::Count(0);
                 for &root in &roots {
-                    let temp = self.temp(root)?;
+                    let temp = self.temp::<E>(root)?;
                     *self.0.safe_get_mut(root)? = Clique::Merged(merged);
-                    merged_temp = merged_temp.add(temp)?;
+                    merged_temp = merged_temp.add::<E>(temp)?;
                 }
                 *self.0.safe_get_mut(merged)? = Clique::Root(merged_temp);
                 // For efficiency, forward all the non-roots to the merged root
@@ -189,33 +189,40 @@ impl Cliques {
     }
 
     /// Creates a new value in the given `clique` and bumps the hot count if `heats` is true
-    fn new_value(&mut self, clique: CliqueID, heats: bool) -> Result<Value, ExecutionError> {
+    fn new_value<E: ExecutionErrorTrait>(
+        &mut self,
+        clique: CliqueID,
+        heats: bool,
+    ) -> Result<Value, E> {
         if heats {
-            self.modify_temp(clique, |t| t.add(Temperature::Count(1)))?;
+            self.modify_temp::<E>(clique, |t| t.add::<E>(Temperature::Count(1)))?;
         }
         Ok(Value::Normal { clique, heats })
     }
 
     /// Releases a value, decrementing the hot count of its clique if it `heats`.
-    fn release_value(&mut self, value: Value) -> Result<Option<CliqueID>, ExecutionError> {
+    fn release_value<E: ExecutionErrorTrait>(
+        &mut self,
+        value: Value,
+    ) -> Result<Option<CliqueID>, E> {
         let (clique, heats) = match value {
             Value::TxContext => return Ok(None),
             Value::Normal { clique, heats } => (clique, heats),
         };
         if heats {
-            self.modify_temp(clique, |t| t.sub(1))?;
+            self.modify_temp::<E>(clique, |t| t.sub::<E>(1))?;
         }
         Ok(Some(clique))
     }
 
     /// Returns true if the clique is hot, always hot or a positive hot count
-    fn is_hot(&self, clique: CliqueID) -> Result<bool, ExecutionError> {
-        Ok(self.temp(clique)?.is_hot())
+    fn is_hot<E: ExecutionErrorTrait>(&self, clique: CliqueID) -> Result<bool, E> {
+        Ok(self.temp::<E>(clique)?.is_hot())
     }
 
     /// Marks the given clique as always hot
-    fn mark_always_hot(&mut self, clique: CliqueID) -> Result<(), ExecutionError> {
-        self.modify_temp(clique, |_| Ok(Temperature::AlwaysHot))
+    fn mark_always_hot<E: ExecutionErrorTrait>(&mut self, clique: CliqueID) -> Result<(), E> {
+        self.modify_temp::<E>(clique, |_| Ok(Temperature::AlwaysHot))
     }
 }
 
@@ -249,7 +256,7 @@ impl Context {
     }
 
     // Checks if all values are released and that all hot counts are zero
-    fn finish(self) -> Result<(), ExecutionError> {
+    fn finish<E: ExecutionErrorTrait>(self) -> Result<(), E> {
         let Context {
             mut cliques,
             tx_context,
@@ -277,10 +284,10 @@ impl Context {
                 Value::Normal { clique, .. } => clique,
             };
             clique_ids.insert(*clique);
-            cliques.release_value(value)?;
+            cliques.release_value::<E>(value)?;
         }
         for id in clique_ids {
-            match cliques.temp(id)? {
+            match cliques.temp::<E>(id)? {
                 Temperature::AlwaysHot => (),
                 Temperature::Count(c) => {
                     assert_invariant!(c == 0, "All hot counts should be zero at end")
@@ -290,7 +297,10 @@ impl Context {
         Ok(())
     }
 
-    fn location(&mut self, location: &T::Location) -> Result<&mut Option<Value>, ExecutionError> {
+    fn location<E: ExecutionErrorTrait>(
+        &mut self,
+        location: &T::Location,
+    ) -> Result<&mut Option<Value>, E> {
         Ok(match location {
             T::Location::GasCoin => &mut self.gas_coin,
             T::Location::ObjectInput(i) => self.objects.safe_get_mut(*i as usize)?,
@@ -305,16 +315,16 @@ impl Context {
         })
     }
 
-    fn usage(&mut self, usage: &T::Usage) -> Result<Value, ExecutionError> {
+    fn usage<E: ExecutionErrorTrait>(&mut self, usage: &T::Usage) -> Result<Value, E> {
         match usage {
             T::Usage::Move(location) => {
-                let Some(value) = self.location(location)?.take() else {
+                let Some(value) = self.location::<E>(location)?.take() else {
                     invariant_violation!("Move of moved value");
                 };
                 Ok(value)
             }
             T::Usage::Copy { location, .. } => {
-                let Some(location) = self.location(location)?.as_ref() else {
+                let Some(location) = self.location::<E>(location)?.as_ref() else {
                     invariant_violation!("Copy of moved value");
                 };
                 let (clique, heats) = match location {
@@ -323,30 +333,33 @@ impl Context {
                     }
                     Value::Normal { clique, heats } => (*clique, *heats),
                 };
-                self.cliques.new_value(clique, heats)
+                self.cliques.new_value::<E>(clique, heats)
             }
         }
     }
 
-    fn argument(&mut self, sp!(_, (arg, _ty)): &T::Argument) -> Result<Value, ExecutionError> {
+    fn argument<E: ExecutionErrorTrait>(
+        &mut self,
+        sp!(_, (arg, _ty)): &T::Argument,
+    ) -> Result<Value, E> {
         Ok(match arg {
-            T::Argument__::Use(usage) => self.usage(usage)?,
+            T::Argument__::Use(usage) => self.usage::<E>(usage)?,
             T::Argument__::Read(usage) | T::Argument__::Freeze(usage) => {
                 // This is equivalent to just the `usage` but we go through the steps of
                 // creating a new value and releasing the old one for "correctness" and clarity
-                let value = self.usage(usage)?;
+                let value = self.usage::<E>(usage)?;
                 let (clique, heats) = match &value {
                     Value::TxContext => {
                         invariant_violation!("Cannot read or freeze TxContext");
                     }
                     Value::Normal { clique, heats } => (*clique, *heats),
                 };
-                let new_value = self.cliques.new_value(clique, heats)?;
-                self.cliques.release_value(value)?;
+                let new_value = self.cliques.new_value::<E>(clique, heats)?;
+                self.cliques.release_value::<E>(value)?;
                 new_value
             }
             T::Argument__::Borrow(_, location) => {
-                let Some(location) = self.location(location)?.as_ref() else {
+                let Some(location) = self.location::<E>(location)?.as_ref() else {
                     invariant_violation!("Borrow of moved value");
                 };
                 let (clique, heats) = match location {
@@ -358,7 +371,7 @@ impl Context {
                 };
                 // Create a new value (representing the reference to this value)
                 // that is in the same clique and has the same heat
-                self.cliques.new_value(clique, heats)?
+                self.cliques.new_value::<E>(clique, heats)?
             }
         })
     }
@@ -379,7 +392,10 @@ impl Context {
 /// - A non-public `entry` function cannot have any inputs that are in a `hot` clique.
 /// - Note that command inputs are released before checking the rules, so an `entry` function can
 ///   consume a hot potato value if it is the last "heating" value in its clique.
-pub fn verify<Mode: ExecutionMode>(env: &Env, txn: &T::Transaction) -> Result<(), ExecutionError> {
+pub fn verify<Mode: ExecutionMode>(
+    env: &Env<'_, '_, '_, '_, '_, Mode::Error>,
+    txn: &T::Transaction,
+) -> Result<(), Mode::Error> {
     let mut context = Context::new(txn);
     for c in &txn.commands {
         let result_values = command::<Mode>(env, &mut context, c)
@@ -390,15 +406,15 @@ pub fn verify<Mode: ExecutionMode>(env: &Env, txn: &T::Transaction) -> Result<()
         );
         context.results.push(result_values);
     }
-    context.finish()?;
+    context.finish::<Mode::Error>()?;
     Ok(())
 }
 
 fn command<Mode: ExecutionMode>(
-    env: &Env,
+    env: &Env<'_, '_, '_, '_, '_, Mode::Error>,
     context: &mut Context,
     sp!(_, c): &T::Command,
-) -> Result<Vec<Option<Value>>, ExecutionError> {
+) -> Result<Vec<Option<Value>>, Mode::Error> {
     let T::Command_ {
         command,
         result_type,
@@ -417,10 +433,12 @@ fn command<Mode: ExecutionMode>(
     }
     let merged_clique = context
         .cliques
-        .merge(argument_cliques.into_iter().map(|(_, c)| c).collect())?;
+        .merge::<Mode::Error>(argument_cliques.into_iter().map(|(_, c)| c).collect())?;
     let consumes_shared_objects = !consumed_shared_objects.is_empty();
     if consumes_shared_objects {
-        context.cliques.mark_always_hot(merged_clique)?;
+        context
+            .cliques
+            .mark_always_hot::<Mode::Error>(merged_clique)?;
     }
     assert_invariant!(
         drop_values.len() == result_type.len(),
@@ -441,27 +459,27 @@ fn command<Mode: ExecutionMode>(
 }
 
 /// Returns the index of the first hot argument, if any
-fn arguments<'a>(
-    env: &Env,
+fn arguments<'a, E: ExecutionErrorTrait>(
+    env: &Env<'_, '_, '_, '_, '_, E>,
     context: &mut Context,
     args: impl IntoIterator<Item = &'a T::Argument>,
-) -> Result<Vec<(u16, CliqueID)>, ExecutionError> {
+) -> Result<Vec<(u16, CliqueID)>, E> {
     let mut arguments = vec![];
     for arg in args {
-        if let Some(clique) = argument(env, context, arg)? {
+        if let Some(clique) = argument::<E>(env, context, arg)? {
             arguments.push((arg.idx, clique));
         }
     }
     Ok(arguments)
 }
 
-fn argument(
-    _env: &Env,
+fn argument<E: ExecutionErrorTrait>(
+    _env: &Env<'_, '_, '_, '_, '_, E>,
     context: &mut Context,
     arg: &T::Argument,
-) -> Result<Option<CliqueID>, ExecutionError> {
-    let value = context.argument(arg)?;
-    context.cliques.release_value(value)
+) -> Result<Option<CliqueID>, E> {
+    let value = context.argument::<E>(arg)?;
+    context.cliques.release_value::<E>(value)
 }
 
 /// Checks a move call for
@@ -472,11 +490,11 @@ fn argument(
 ///
 /// Returns true iff any return type is a hot potato
 fn move_call<Mode: ExecutionMode>(
-    _env: &Env,
+    _env: &Env<'_, '_, '_, '_, '_, Mode::Error>,
     context: &mut Context,
     call: &T::MoveCall,
     argument_cliques: &[(u16, CliqueID)],
-) -> Result<(), ExecutionError> {
+) -> Result<(), Mode::Error> {
     let T::MoveCall {
         function,
         arguments: _,
@@ -487,15 +505,17 @@ fn move_call<Mode: ExecutionMode>(
     if is_entry && is_non_public && !Mode::allow_arbitrary_values() {
         let mut hot_argument: Option<u16> = None;
         for (idx, clique) in argument_cliques {
-            if context.cliques.is_hot(*clique)? {
+            if context.cliques.is_hot::<Mode::Error>(*clique)? {
                 hot_argument = Some(*idx);
                 break;
             }
         }
         if let Some(idx) = hot_argument {
-            return Err(command_argument_error(
-                CommandArgumentError::InvalidArgumentToPrivateEntryFunction,
-                idx as usize,
+            return Err(Mode::Error::from_kind(
+                ExecutionErrorKind::command_argument_error(
+                    CommandArgumentError::InvalidArgumentToPrivateEntryFunction,
+                    idx,
+                ),
             ));
         }
     }

--- a/sui-execution/latest/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/latest/sui-adapter/src/temporary_store.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::execution_mode::ExecutionMode;
 use crate::gas_charger::{GasCharger, PaymentLocation};
 use mysten_common::ZipDebugEqIteratorExt;
 use mysten_metrics::monitored_scope;
@@ -29,7 +30,7 @@ use sui_types::{
     SUI_DENY_LIST_OBJECT_ID,
     base_types::{ObjectID, ObjectRef, SequenceNumber, SuiAddress, TransactionDigest},
     effects::EffectsObjectChange,
-    error::{ExecutionError, ExecutionErrorTrait, SuiResult},
+    error::{ExecutionError, SuiResult},
     gas::GasCostSummary,
     object::Object,
     object::Owner,
@@ -904,7 +905,9 @@ impl TemporaryStore<'_> {
         }
     }
 
-    pub fn check_execution_results_consistency<E: ExecutionErrorTrait>(&self) -> Result<(), E> {
+    pub fn check_execution_results_consistency<Mode: ExecutionMode>(
+        &self,
+    ) -> Result<(), Mode::Error> {
         assert_invariant!(
             self.execution_results
                 .created_object_ids

--- a/sui-execution/latest/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/latest/sui-adapter/src/temporary_store.rs
@@ -29,7 +29,7 @@ use sui_types::{
     SUI_DENY_LIST_OBJECT_ID,
     base_types::{ObjectID, ObjectRef, SequenceNumber, SuiAddress, TransactionDigest},
     effects::EffectsObjectChange,
-    error::{ExecutionError, SuiResult},
+    error::{ExecutionError, ExecutionErrorTrait, SuiResult},
     gas::GasCostSummary,
     object::Object,
     object::Owner,
@@ -904,7 +904,7 @@ impl TemporaryStore<'_> {
         }
     }
 
-    pub fn check_execution_results_consistency(&self) -> Result<(), ExecutionError> {
+    pub fn check_execution_results_consistency<E: ExecutionErrorTrait>(&self) -> Result<(), E> {
         assert_invariant!(
             self.execution_results
                 .created_object_ids

--- a/sui-execution/latest/sui-adapter/src/type_layout_resolver.rs
+++ b/sui-execution/latest/sui-adapter/src/type_layout_resolver.rs
@@ -9,7 +9,7 @@ use move_core_types::language_storage::StructTag;
 use move_vm_runtime::runtime::MoveRuntime;
 use sui_types::TypeTag;
 use sui_types::base_types::ObjectID;
-use sui_types::error::{SuiErrorKind, SuiResult};
+use sui_types::error::{ExecutionError, SuiErrorKind, SuiResult};
 use sui_types::execution::TypeLayoutStore;
 use sui_types::storage::{BackingPackageStore, PackageObject};
 use sui_types::{error::SuiError, layout_resolver::LayoutResolver};
@@ -39,8 +39,8 @@ impl LayoutResolver for TypeLayoutResolver<'_, '_> {
         let null_resolver = NullSuiResolver(&self.state_view);
         let resolver =
             CachedPackageStore::new(self.vm, TransactionPackageStore::new(&null_resolver));
-        let tag_linkage = ExecutableLinkage::type_linkage(ids, &resolver)?;
-        let link_context = tag_linkage.linkage_context()?;
+        let tag_linkage = ExecutableLinkage::type_linkage::<_, ExecutionError>(ids, &resolver)?;
+        let link_context = tag_linkage.linkage_context::<ExecutionError>()?;
         let data_store = TransactionPackageStore::new(&null_resolver);
         let Ok(vm) = self.vm.make_vm(data_store, link_context) else {
             return Err(SuiErrorKind::FailObjectLayout {

--- a/sui-execution/src/executor.rs
+++ b/sui-execution/src/executor.rs
@@ -13,7 +13,7 @@ use sui_types::{
     committee::EpochId,
     digests::TransactionDigest,
     effects::TransactionEffects,
-    error::{ExecutionError, ExecutionErrorContext},
+    error::ExecutionError,
     execution::{ExecutionResult, TypeLayoutStore},
     execution_status::ExecutionFailure,
     gas::SuiGasStatus,

--- a/sui-execution/src/executor.rs
+++ b/sui-execution/src/executor.rs
@@ -13,7 +13,7 @@ use sui_types::{
     committee::EpochId,
     digests::TransactionDigest,
     effects::TransactionEffects,
-    error::ExecutionError,
+    error::{ExecutionError, ExecutionErrorContext},
     execution::{ExecutionResult, TypeLayoutStore},
     execution_status::ExecutionFailure,
     gas::SuiGasStatus,

--- a/sui-execution/src/executor.rs
+++ b/sui-execution/src/executor.rs
@@ -13,7 +13,7 @@ use sui_types::{
     committee::EpochId,
     digests::TransactionDigest,
     effects::TransactionEffects,
-    error::ExecutionError,
+    error::{ExecutionError, ExecutionErrorContext},
     execution::{ExecutionResult, TypeLayoutStore},
     execution_status::ExecutionFailure,
     gas::SuiGasStatus,
@@ -79,7 +79,7 @@ pub trait Executor {
         SuiGasStatus,
         TransactionEffects,
         Vec<ExecutionTiming>,
-        Result<(), ExecutionError>,
+        Result<(), ExecutionErrorContext>,
     );
 
     fn dev_inspect_transaction(
@@ -108,7 +108,7 @@ pub trait Executor {
         InnerTemporaryStore,
         SuiGasStatus,
         TransactionEffects,
-        Result<Vec<ExecutionResult>, ExecutionError>,
+        Result<Vec<ExecutionResult>, ExecutionErrorContext>,
     );
 
     fn update_genesis_state(

--- a/sui-execution/src/latest.rs
+++ b/sui-execution/src/latest.rs
@@ -14,7 +14,7 @@ use sui_types::{
     committee::EpochId,
     digests::TransactionDigest,
     effects::TransactionEffects,
-    error::{ExecutionError, ExecutionErrorContext, ExecutionErrorTrait, SuiError, SuiResult},
+    error::{ExecutionError, ExecutionErrorTrait, SuiError, SuiResult},
     execution::{ExecutionResult, TypeLayoutStore},
     execution_status::ExecutionFailure,
     gas::SuiGasStatus,
@@ -134,10 +134,10 @@ impl executor::Executor for Executor {
         SuiGasStatus,
         TransactionEffects,
         Vec<ExecutionTiming>,
-        Result<(), ExecutionErrorContext>,
+        Result<(), ExecutionError>,
     ) {
         let (store_out, gas_status_out, effects, timings, result) =
-            execute_transaction_to_effects::<execution_mode::Normal<ExecutionErrorContext>>(
+            execute_transaction_to_effects::<execution_mode::Normal<ExecutionError>>(
                 store,
                 input_objects,
                 gas,

--- a/sui-execution/src/latest.rs
+++ b/sui-execution/src/latest.rs
@@ -25,6 +25,7 @@ use sui_types::{
 };
 
 use move_bytecode_verifier_meter::Meter;
+use mysten_common::debug_fatal;
 use move_vm_runtime_latest::runtime::MoveRuntime;
 use sui_adapter_latest::adapter::{new_move_runtime, run_metered_move_bytecode_verifier};
 use sui_adapter_latest::execution_engine::{
@@ -132,24 +133,29 @@ impl executor::Executor for Executor {
         Vec<ExecutionTiming>,
         Result<(), ExecutionError>,
     ) {
-        execute_transaction_to_effects::<execution_mode::Normal<ExecutionError>>(
-            store,
-            input_objects,
-            gas,
-            gas_status,
-            transaction_kind,
-            rewritten_inputs,
-            transaction_signer,
-            transaction_digest,
-            &self.0,
-            epoch_id,
-            epoch_timestamp_ms,
-            protocol_config,
-            metrics,
-            enable_expensive_checks,
-            execution_params,
-            trace_builder_opt,
-        )
+        let (store_out, gas_status_out, effects, timings, result) =
+            execute_transaction_to_effects::<execution_mode::Normal<ExecutionError>>(
+                store,
+                input_objects,
+                gas,
+                gas_status,
+                transaction_kind,
+                rewritten_inputs,
+                transaction_signer,
+                transaction_digest,
+                &self.0,
+                epoch_id,
+                epoch_timestamp_ms,
+                protocol_config,
+                metrics,
+                enable_expensive_checks,
+                execution_params,
+                trace_builder_opt,
+            );
+        if let Err(error) = &result {
+            log_execution_error(transaction_digest, error);
+        }
+        (store_out, gas_status_out, effects, timings, result)
     }
 
     fn dev_inspect_transaction(
@@ -214,6 +220,9 @@ impl executor::Executor for Executor {
                 &mut None,
             )
         };
+        if let Err(error) = &result {
+            log_execution_error(transaction_digest, error);
+        }
         (inner_temp_store, gas_status, effects, result)
     }
 
@@ -276,5 +285,36 @@ impl verifier::Verifier for Verifier<'_> {
         meter: &mut dyn Meter,
     ) -> SuiResult<()> {
         run_metered_move_bytecode_verifier(modules, &self.config, meter, self.metrics)
+    }
+}
+
+fn log_execution_error(transaction_digest: TransactionDigest, error: &ExecutionError) {
+    use sui_types::execution_status::ExecutionErrorKind as K;
+
+    match error.kind() {
+        K::InvariantViolation | K::VMInvariantViolation => {
+            debug_fatal!(
+                "INVARIANT VIOLATION! Txn Digest: {}, Source: {:?}",
+                transaction_digest,
+                error.source()
+            );
+        }
+        K::SuiMoveVerificationError | K::VMVerificationOrDeserializationError => {
+            tracing::debug!(
+                kind = ?error.kind(),
+                tx_digest = ?transaction_digest,
+                "Verification Error. Source: {:?}",
+                error.source(),
+            );
+        }
+        K::PublishUpgradeMissingDependency | K::PublishUpgradeDependencyDowngrade => {
+            tracing::debug!(
+                kind = ?error.kind(),
+                tx_digest = ?transaction_digest,
+                "Publish/Upgrade Error. Source: {:?}",
+                error.source(),
+            );
+        }
+        _ => (),
     }
 }

--- a/sui-execution/src/latest.rs
+++ b/sui-execution/src/latest.rs
@@ -14,7 +14,7 @@ use sui_types::{
     committee::EpochId,
     digests::TransactionDigest,
     effects::TransactionEffects,
-    error::{ExecutionError, ExecutionErrorTrait, SuiError, SuiResult},
+    error::{ExecutionError, ExecutionErrorContext, ExecutionErrorTrait, SuiError, SuiResult},
     execution::{ExecutionResult, TypeLayoutStore},
     execution_status::ExecutionFailure,
     gas::SuiGasStatus,
@@ -134,10 +134,10 @@ impl executor::Executor for Executor {
         SuiGasStatus,
         TransactionEffects,
         Vec<ExecutionTiming>,
-        Result<(), ExecutionError>,
+        Result<(), ExecutionErrorContext>,
     ) {
         let (store_out, gas_status_out, effects, timings, result) =
-            execute_transaction_to_effects::<execution_mode::Normal<ExecutionError>>(
+            execute_transaction_to_effects::<execution_mode::Normal<ExecutionErrorContext>>(
                 store,
                 input_objects,
                 gas,
@@ -182,10 +182,10 @@ impl executor::Executor for Executor {
         InnerTemporaryStore,
         SuiGasStatus,
         TransactionEffects,
-        Result<Vec<ExecutionResult>, ExecutionError>,
+        Result<Vec<ExecutionResult>, ExecutionErrorContext>,
     ) {
         let (inner_temp_store, gas_status, effects, _timings, result) = if skip_all_checks {
-            execute_transaction_to_effects::<execution_mode::DevInspect<true>>(
+            execute_transaction_to_effects::<execution_mode::DevInspect<true, ExecutionErrorContext>>(
                 store,
                 input_objects,
                 gas,
@@ -204,7 +204,7 @@ impl executor::Executor for Executor {
                 &mut None,
             )
         } else {
-            execute_transaction_to_effects::<execution_mode::DevInspect<false>>(
+            execute_transaction_to_effects::<execution_mode::DevInspect<false, ExecutionErrorContext>>(
                 store,
                 input_objects,
                 gas,

--- a/sui-execution/src/latest.rs
+++ b/sui-execution/src/latest.rs
@@ -14,7 +14,7 @@ use sui_types::{
     committee::EpochId,
     digests::TransactionDigest,
     effects::TransactionEffects,
-    error::{ExecutionError, SuiError, SuiResult},
+    error::{ExecutionError, ExecutionErrorContext, ExecutionErrorTrait, SuiError, SuiResult},
     execution::{ExecutionResult, TypeLayoutStore},
     execution_status::ExecutionFailure,
     gas::SuiGasStatus,
@@ -25,8 +25,8 @@ use sui_types::{
 };
 
 use move_bytecode_verifier_meter::Meter;
-use mysten_common::debug_fatal;
 use move_vm_runtime_latest::runtime::MoveRuntime;
+use mysten_common::debug_fatal;
 use sui_adapter_latest::adapter::{new_move_runtime, run_metered_move_bytecode_verifier};
 use sui_adapter_latest::execution_engine::{
     execute_genesis_state_update, execute_transaction_to_effects,
@@ -106,6 +106,9 @@ impl executor::Executor for Executor {
                 execution_params,
                 trace_builder_opt,
             );
+        if let Err(error) = &result {
+            log_execution_error(transaction_digest, error);
+        }
         (store_out, gas_status_out, effects, timings, result)
     }
 
@@ -131,10 +134,10 @@ impl executor::Executor for Executor {
         SuiGasStatus,
         TransactionEffects,
         Vec<ExecutionTiming>,
-        Result<(), ExecutionError>,
+        Result<(), ExecutionErrorContext>,
     ) {
         let (store_out, gas_status_out, effects, timings, result) =
-            execute_transaction_to_effects::<execution_mode::Normal<ExecutionError>>(
+            execute_transaction_to_effects::<execution_mode::Normal<ExecutionErrorContext>>(
                 store,
                 input_objects,
                 gas,
@@ -288,7 +291,10 @@ impl verifier::Verifier for Verifier<'_> {
     }
 }
 
-fn log_execution_error(transaction_digest: TransactionDigest, error: &ExecutionError) {
+fn log_execution_error<E>(transaction_digest: TransactionDigest, error: &E)
+where
+    E: ExecutionErrorTrait + std::error::Error,
+{
     use sui_types::execution_status::ExecutionErrorKind as K;
 
     match error.kind() {
@@ -296,7 +302,7 @@ fn log_execution_error(transaction_digest: TransactionDigest, error: &ExecutionE
             debug_fatal!(
                 "INVARIANT VIOLATION! Txn Digest: {}, Source: {:?}",
                 transaction_digest,
-                error.source()
+                std::error::Error::source(error)
             );
         }
         K::SuiMoveVerificationError | K::VMVerificationOrDeserializationError => {
@@ -304,7 +310,7 @@ fn log_execution_error(transaction_digest: TransactionDigest, error: &ExecutionE
                 kind = ?error.kind(),
                 tx_digest = ?transaction_digest,
                 "Verification Error. Source: {:?}",
-                error.source(),
+                std::error::Error::source(error),
             );
         }
         K::PublishUpgradeMissingDependency | K::PublishUpgradeDependencyDowngrade => {
@@ -312,7 +318,7 @@ fn log_execution_error(transaction_digest: TransactionDigest, error: &ExecutionE
                 kind = ?error.kind(),
                 tx_digest = ?transaction_digest,
                 "Publish/Upgrade Error. Source: {:?}",
-                error.source(),
+                std::error::Error::source(error),
             );
         }
         _ => (),

--- a/sui-execution/src/v0.rs
+++ b/sui-execution/src/v0.rs
@@ -15,7 +15,7 @@ use sui_types::{
     committee::EpochId,
     digests::TransactionDigest,
     effects::TransactionEffects,
-    error::{ExecutionError, ExecutionErrorContext, SuiError, SuiResult},
+    error::{ExecutionError, SuiError, SuiResult},
     execution::{ExecutionResult, TypeLayoutStore},
     execution_status::ExecutionFailure,
     gas::SuiGasStatus,
@@ -205,7 +205,7 @@ impl executor::Executor for Executor {
         SuiGasStatus,
         TransactionEffects,
         Vec<ExecutionTiming>,
-        Result<(), ExecutionErrorContext>,
+        Result<(), ExecutionError>,
     ) {
         let gas_coins = gas.payment;
         let (inner_temp_store, gas_status, effects, result) =
@@ -228,7 +228,6 @@ impl executor::Executor for Executor {
         if let Err(error) = &result {
             log_execution_error(transaction_digest, error);
         }
-        let result = result.map_err(ExecutionErrorContext::from);
         (inner_temp_store, gas_status, effects, vec![], result)
     }
 

--- a/sui-execution/src/v0.rs
+++ b/sui-execution/src/v0.rs
@@ -15,7 +15,7 @@ use sui_types::{
     committee::EpochId,
     digests::TransactionDigest,
     effects::TransactionEffects,
-    error::{ExecutionError, SuiError, SuiResult},
+    error::{ExecutionError, ExecutionErrorContext, SuiError, SuiResult},
     execution::{ExecutionResult, TypeLayoutStore},
     execution_status::ExecutionFailure,
     gas::SuiGasStatus,
@@ -205,7 +205,7 @@ impl executor::Executor for Executor {
         SuiGasStatus,
         TransactionEffects,
         Vec<ExecutionTiming>,
-        Result<(), ExecutionError>,
+        Result<(), ExecutionErrorContext>,
     ) {
         let gas_coins = gas.payment;
         let (inner_temp_store, gas_status, effects, result) =
@@ -228,6 +228,7 @@ impl executor::Executor for Executor {
         if let Err(error) = &result {
             log_execution_error(transaction_digest, error);
         }
+        let result = result.map_err(ExecutionErrorContext::from);
         (inner_temp_store, gas_status, effects, vec![], result)
     }
 

--- a/sui-execution/src/v0.rs
+++ b/sui-execution/src/v0.rs
@@ -105,6 +105,9 @@ impl executor::Executor for Executor {
                 enable_expensive_checks,
                 execution_params,
             );
+        if let Err(error) = &result {
+            log_execution_error(transaction_digest, error);
+        }
         // note: old versions do not report timings.
         (
             inner_temp_store,
@@ -139,7 +142,7 @@ impl executor::Executor for Executor {
         Result<Vec<ExecutionResult>, ExecutionError>,
     ) {
         let gas_coins = gas.payment;
-        if skip_all_checks {
+        let (inner_temp_store, gas_status, effects, result) = if skip_all_checks {
             execute_transaction_to_effects::<execution_mode::DevInspect<true>>(
                 store,
                 input_objects,
@@ -173,7 +176,11 @@ impl executor::Executor for Executor {
                 enable_expensive_checks,
                 execution_params,
             )
+        };
+        if let Err(error) = &result {
+            log_execution_error(transaction_digest, error);
         }
+        (inner_temp_store, gas_status, effects, result)
     }
 
     fn execute_transaction_to_effects_and_execution_error(
@@ -218,6 +225,9 @@ impl executor::Executor for Executor {
                 enable_expensive_checks,
                 execution_params,
             );
+        if let Err(error) = &result {
+            log_execution_error(transaction_digest, error);
+        }
         (inner_temp_store, gas_status, effects, vec![], result)
     }
 
@@ -286,5 +296,37 @@ impl verifier::Verifier for Verifier<'_> {
             meter,
             self.metrics,
         )
+    }
+}
+
+fn log_execution_error(transaction_digest: TransactionDigest, error: &ExecutionError) {
+    use sui_types::execution_status::ExecutionErrorKind as K;
+
+    match error.kind() {
+        K::InvariantViolation | K::VMInvariantViolation => {
+            tracing::error!(
+                kind = ?error.kind(),
+                tx_digest = ?transaction_digest,
+                "INVARIANT VIOLATION! Source: {:?}",
+                error.source(),
+            );
+        }
+        K::SuiMoveVerificationError | K::VMVerificationOrDeserializationError => {
+            tracing::debug!(
+                kind = ?error.kind(),
+                tx_digest = ?transaction_digest,
+                "Verification Error. Source: {:?}",
+                error.source(),
+            );
+        }
+        K::PublishUpgradeMissingDependency | K::PublishUpgradeDependencyDowngrade => {
+            tracing::debug!(
+                kind = ?error.kind(),
+                tx_digest = ?transaction_digest,
+                "Publish/Upgrade Error. Source: {:?}",
+                error.source(),
+            );
+        }
+        _ => (),
     }
 }

--- a/sui-execution/src/v0.rs
+++ b/sui-execution/src/v0.rs
@@ -15,7 +15,7 @@ use sui_types::{
     committee::EpochId,
     digests::TransactionDigest,
     effects::TransactionEffects,
-    error::{ExecutionError, SuiError, SuiResult},
+    error::{ExecutionError, ExecutionErrorContext, SuiError, SuiResult},
     execution::{ExecutionResult, TypeLayoutStore},
     execution_status::ExecutionFailure,
     gas::SuiGasStatus,
@@ -139,7 +139,7 @@ impl executor::Executor for Executor {
         InnerTemporaryStore,
         SuiGasStatus,
         TransactionEffects,
-        Result<Vec<ExecutionResult>, ExecutionError>,
+        Result<Vec<ExecutionResult>, ExecutionErrorContext>,
     ) {
         let gas_coins = gas.payment;
         let (inner_temp_store, gas_status, effects, result) = if skip_all_checks {
@@ -180,6 +180,7 @@ impl executor::Executor for Executor {
         if let Err(error) = &result {
             log_execution_error(transaction_digest, error);
         }
+        let result = result.map_err(ExecutionErrorContext::from);
         (inner_temp_store, gas_status, effects, result)
     }
 
@@ -205,7 +206,7 @@ impl executor::Executor for Executor {
         SuiGasStatus,
         TransactionEffects,
         Vec<ExecutionTiming>,
-        Result<(), ExecutionError>,
+        Result<(), ExecutionErrorContext>,
     ) {
         let gas_coins = gas.payment;
         let (inner_temp_store, gas_status, effects, result) =
@@ -228,6 +229,7 @@ impl executor::Executor for Executor {
         if let Err(error) = &result {
             log_execution_error(transaction_digest, error);
         }
+        let result = result.map_err(ExecutionErrorContext::from);
         (inner_temp_store, gas_status, effects, vec![], result)
     }
 

--- a/sui-execution/src/v1.rs
+++ b/sui-execution/src/v1.rs
@@ -15,7 +15,7 @@ use sui_types::{
     committee::EpochId,
     digests::TransactionDigest,
     effects::TransactionEffects,
-    error::{ExecutionError, ExecutionErrorContext, SuiError, SuiResult},
+    error::{ExecutionError, SuiError, SuiResult},
     execution::{ExecutionResult, TypeLayoutStore},
     execution_status::ExecutionFailure,
     gas::SuiGasStatus,
@@ -205,7 +205,7 @@ impl executor::Executor for Executor {
         SuiGasStatus,
         TransactionEffects,
         Vec<ExecutionTiming>,
-        Result<(), ExecutionErrorContext>,
+        Result<(), ExecutionError>,
     ) {
         let gas_coins = gas.payment;
         let (inner_temp_store, gas_status, effects, result) =
@@ -228,7 +228,6 @@ impl executor::Executor for Executor {
         if let Err(error) = &result {
             log_execution_error(transaction_digest, error);
         }
-        let result = result.map_err(ExecutionErrorContext::from);
         (inner_temp_store, gas_status, effects, vec![], result)
     }
 

--- a/sui-execution/src/v1.rs
+++ b/sui-execution/src/v1.rs
@@ -105,6 +105,9 @@ impl executor::Executor for Executor {
                 enable_expensive_checks,
                 execution_params,
             );
+        if let Err(error) = &result {
+            log_execution_error(transaction_digest, error);
+        }
         // note: old versions do not report timings.
         (
             inner_temp_store,
@@ -139,7 +142,7 @@ impl executor::Executor for Executor {
         Result<Vec<ExecutionResult>, ExecutionError>,
     ) {
         let gas_coins = gas.payment;
-        if skip_all_checks {
+        let (inner_temp_store, gas_status, effects, result) = if skip_all_checks {
             execute_transaction_to_effects::<execution_mode::DevInspect<true>>(
                 store,
                 input_objects,
@@ -173,7 +176,11 @@ impl executor::Executor for Executor {
                 enable_expensive_checks,
                 execution_params,
             )
+        };
+        if let Err(error) = &result {
+            log_execution_error(transaction_digest, error);
         }
+        (inner_temp_store, gas_status, effects, result)
     }
 
     fn execute_transaction_to_effects_and_execution_error(
@@ -218,6 +225,9 @@ impl executor::Executor for Executor {
                 enable_expensive_checks,
                 execution_params,
             );
+        if let Err(error) = &result {
+            log_execution_error(transaction_digest, error);
+        }
         (inner_temp_store, gas_status, effects, vec![], result)
     }
 
@@ -280,5 +290,37 @@ impl verifier::Verifier for Verifier<'_> {
         meter: &mut dyn Meter,
     ) -> SuiResult<()> {
         run_metered_move_bytecode_verifier(modules, &self.config, meter, self.metrics)
+    }
+}
+
+fn log_execution_error(transaction_digest: TransactionDigest, error: &ExecutionError) {
+    use sui_types::execution_status::ExecutionErrorKind as K;
+
+    match error.kind() {
+        K::InvariantViolation | K::VMInvariantViolation => {
+            tracing::error!(
+                kind = ?error.kind(),
+                tx_digest = ?transaction_digest,
+                "INVARIANT VIOLATION! Source: {:?}",
+                error.source(),
+            );
+        }
+        K::SuiMoveVerificationError | K::VMVerificationOrDeserializationError => {
+            tracing::debug!(
+                kind = ?error.kind(),
+                tx_digest = ?transaction_digest,
+                "Verification Error. Source: {:?}",
+                error.source(),
+            );
+        }
+        K::PublishUpgradeMissingDependency | K::PublishUpgradeDependencyDowngrade => {
+            tracing::debug!(
+                kind = ?error.kind(),
+                tx_digest = ?transaction_digest,
+                "Publish/Upgrade Error. Source: {:?}",
+                error.source(),
+            );
+        }
+        _ => (),
     }
 }

--- a/sui-execution/src/v1.rs
+++ b/sui-execution/src/v1.rs
@@ -15,7 +15,7 @@ use sui_types::{
     committee::EpochId,
     digests::TransactionDigest,
     effects::TransactionEffects,
-    error::{ExecutionError, SuiError, SuiResult},
+    error::{ExecutionError, ExecutionErrorContext, SuiError, SuiResult},
     execution::{ExecutionResult, TypeLayoutStore},
     execution_status::ExecutionFailure,
     gas::SuiGasStatus,
@@ -205,7 +205,7 @@ impl executor::Executor for Executor {
         SuiGasStatus,
         TransactionEffects,
         Vec<ExecutionTiming>,
-        Result<(), ExecutionError>,
+        Result<(), ExecutionErrorContext>,
     ) {
         let gas_coins = gas.payment;
         let (inner_temp_store, gas_status, effects, result) =
@@ -228,6 +228,7 @@ impl executor::Executor for Executor {
         if let Err(error) = &result {
             log_execution_error(transaction_digest, error);
         }
+        let result = result.map_err(ExecutionErrorContext::from);
         (inner_temp_store, gas_status, effects, vec![], result)
     }
 

--- a/sui-execution/src/v1.rs
+++ b/sui-execution/src/v1.rs
@@ -15,7 +15,7 @@ use sui_types::{
     committee::EpochId,
     digests::TransactionDigest,
     effects::TransactionEffects,
-    error::{ExecutionError, SuiError, SuiResult},
+    error::{ExecutionError, ExecutionErrorContext, SuiError, SuiResult},
     execution::{ExecutionResult, TypeLayoutStore},
     execution_status::ExecutionFailure,
     gas::SuiGasStatus,
@@ -139,7 +139,7 @@ impl executor::Executor for Executor {
         InnerTemporaryStore,
         SuiGasStatus,
         TransactionEffects,
-        Result<Vec<ExecutionResult>, ExecutionError>,
+        Result<Vec<ExecutionResult>, ExecutionErrorContext>,
     ) {
         let gas_coins = gas.payment;
         let (inner_temp_store, gas_status, effects, result) = if skip_all_checks {
@@ -180,6 +180,7 @@ impl executor::Executor for Executor {
         if let Err(error) = &result {
             log_execution_error(transaction_digest, error);
         }
+        let result = result.map_err(ExecutionErrorContext::from);
         (inner_temp_store, gas_status, effects, result)
     }
 
@@ -205,7 +206,7 @@ impl executor::Executor for Executor {
         SuiGasStatus,
         TransactionEffects,
         Vec<ExecutionTiming>,
-        Result<(), ExecutionError>,
+        Result<(), ExecutionErrorContext>,
     ) {
         let gas_coins = gas.payment;
         let (inner_temp_store, gas_status, effects, result) =
@@ -228,6 +229,7 @@ impl executor::Executor for Executor {
         if let Err(error) = &result {
             log_execution_error(transaction_digest, error);
         }
+        let result = result.map_err(ExecutionErrorContext::from);
         (inner_temp_store, gas_status, effects, vec![], result)
     }
 

--- a/sui-execution/src/v2.rs
+++ b/sui-execution/src/v2.rs
@@ -15,7 +15,7 @@ use sui_types::{
     committee::EpochId,
     digests::TransactionDigest,
     effects::TransactionEffects,
-    error::{ExecutionError, ExecutionErrorContext, SuiError, SuiResult},
+    error::{ExecutionError, SuiError, SuiResult},
     execution::{ExecutionResult, TypeLayoutStore},
     execution_status::ExecutionFailure,
     gas::SuiGasStatus,
@@ -205,7 +205,7 @@ impl executor::Executor for Executor {
         SuiGasStatus,
         TransactionEffects,
         Vec<ExecutionTiming>,
-        Result<(), ExecutionErrorContext>,
+        Result<(), ExecutionError>,
     ) {
         let gas_coins = gas.payment;
         let (inner_temp_store, gas_status, effects, result) =
@@ -228,7 +228,6 @@ impl executor::Executor for Executor {
         if let Err(error) = &result {
             log_execution_error(transaction_digest, error);
         }
-        let result = result.map_err(ExecutionErrorContext::from);
         (inner_temp_store, gas_status, effects, vec![], result)
     }
 

--- a/sui-execution/src/v2.rs
+++ b/sui-execution/src/v2.rs
@@ -105,6 +105,9 @@ impl executor::Executor for Executor {
                 enable_expensive_checks,
                 execution_params,
             );
+        if let Err(error) = &result {
+            log_execution_error(transaction_digest, error);
+        }
         // note: old versions do not report timings.
         (
             inner_temp_store,
@@ -139,7 +142,7 @@ impl executor::Executor for Executor {
         Result<Vec<ExecutionResult>, ExecutionError>,
     ) {
         let gas_coins = gas.payment;
-        if skip_all_checks {
+        let (inner_temp_store, gas_status, effects, result) = if skip_all_checks {
             execute_transaction_to_effects::<execution_mode::DevInspect<true>>(
                 store,
                 input_objects,
@@ -173,7 +176,11 @@ impl executor::Executor for Executor {
                 enable_expensive_checks,
                 execution_params,
             )
+        };
+        if let Err(error) = &result {
+            log_execution_error(transaction_digest, error);
         }
+        (inner_temp_store, gas_status, effects, result)
     }
 
     fn execute_transaction_to_effects_and_execution_error(
@@ -218,6 +225,9 @@ impl executor::Executor for Executor {
                 enable_expensive_checks,
                 execution_params,
             );
+        if let Err(error) = &result {
+            log_execution_error(transaction_digest, error);
+        }
         (inner_temp_store, gas_status, effects, vec![], result)
     }
 
@@ -280,5 +290,37 @@ impl verifier::Verifier for Verifier<'_> {
         meter: &mut dyn Meter,
     ) -> SuiResult<()> {
         run_metered_move_bytecode_verifier(modules, &self.config, meter, self.metrics)
+    }
+}
+
+fn log_execution_error(transaction_digest: TransactionDigest, error: &ExecutionError) {
+    use sui_types::execution_status::ExecutionErrorKind as K;
+
+    match error.kind() {
+        K::InvariantViolation | K::VMInvariantViolation => {
+            tracing::error!(
+                kind = ?error.kind(),
+                tx_digest = ?transaction_digest,
+                "INVARIANT VIOLATION! Source: {:?}",
+                error.source(),
+            );
+        }
+        K::SuiMoveVerificationError | K::VMVerificationOrDeserializationError => {
+            tracing::debug!(
+                kind = ?error.kind(),
+                tx_digest = ?transaction_digest,
+                "Verification Error. Source: {:?}",
+                error.source(),
+            );
+        }
+        K::PublishUpgradeMissingDependency | K::PublishUpgradeDependencyDowngrade => {
+            tracing::debug!(
+                kind = ?error.kind(),
+                tx_digest = ?transaction_digest,
+                "Publish/Upgrade Error. Source: {:?}",
+                error.source(),
+            );
+        }
+        _ => (),
     }
 }

--- a/sui-execution/src/v2.rs
+++ b/sui-execution/src/v2.rs
@@ -15,7 +15,7 @@ use sui_types::{
     committee::EpochId,
     digests::TransactionDigest,
     effects::TransactionEffects,
-    error::{ExecutionError, SuiError, SuiResult},
+    error::{ExecutionError, ExecutionErrorContext, SuiError, SuiResult},
     execution::{ExecutionResult, TypeLayoutStore},
     execution_status::ExecutionFailure,
     gas::SuiGasStatus,
@@ -205,7 +205,7 @@ impl executor::Executor for Executor {
         SuiGasStatus,
         TransactionEffects,
         Vec<ExecutionTiming>,
-        Result<(), ExecutionError>,
+        Result<(), ExecutionErrorContext>,
     ) {
         let gas_coins = gas.payment;
         let (inner_temp_store, gas_status, effects, result) =
@@ -228,6 +228,7 @@ impl executor::Executor for Executor {
         if let Err(error) = &result {
             log_execution_error(transaction_digest, error);
         }
+        let result = result.map_err(ExecutionErrorContext::from);
         (inner_temp_store, gas_status, effects, vec![], result)
     }
 

--- a/sui-execution/src/v2.rs
+++ b/sui-execution/src/v2.rs
@@ -15,7 +15,7 @@ use sui_types::{
     committee::EpochId,
     digests::TransactionDigest,
     effects::TransactionEffects,
-    error::{ExecutionError, SuiError, SuiResult},
+    error::{ExecutionError, ExecutionErrorContext, SuiError, SuiResult},
     execution::{ExecutionResult, TypeLayoutStore},
     execution_status::ExecutionFailure,
     gas::SuiGasStatus,
@@ -139,7 +139,7 @@ impl executor::Executor for Executor {
         InnerTemporaryStore,
         SuiGasStatus,
         TransactionEffects,
-        Result<Vec<ExecutionResult>, ExecutionError>,
+        Result<Vec<ExecutionResult>, ExecutionErrorContext>,
     ) {
         let gas_coins = gas.payment;
         let (inner_temp_store, gas_status, effects, result) = if skip_all_checks {
@@ -180,6 +180,7 @@ impl executor::Executor for Executor {
         if let Err(error) = &result {
             log_execution_error(transaction_digest, error);
         }
+        let result = result.map_err(ExecutionErrorContext::from);
         (inner_temp_store, gas_status, effects, result)
     }
 
@@ -205,7 +206,7 @@ impl executor::Executor for Executor {
         SuiGasStatus,
         TransactionEffects,
         Vec<ExecutionTiming>,
-        Result<(), ExecutionError>,
+        Result<(), ExecutionErrorContext>,
     ) {
         let gas_coins = gas.payment;
         let (inner_temp_store, gas_status, effects, result) =
@@ -228,6 +229,7 @@ impl executor::Executor for Executor {
         if let Err(error) = &result {
             log_execution_error(transaction_digest, error);
         }
+        let result = result.map_err(ExecutionErrorContext::from);
         (inner_temp_store, gas_status, effects, vec![], result)
     }
 

--- a/sui-execution/src/v3.rs
+++ b/sui-execution/src/v3.rs
@@ -14,7 +14,7 @@ use sui_types::{
     committee::EpochId,
     digests::TransactionDigest,
     effects::TransactionEffects,
-    error::{ExecutionError, ExecutionErrorContext, SuiError, SuiResult},
+    error::{ExecutionError, SuiError, SuiResult},
     execution::{ExecutionResult, TypeLayoutStore},
     gas::SuiGasStatus,
     inner_temporary_store::InnerTemporaryStore,
@@ -139,7 +139,7 @@ impl executor::Executor for Executor {
         SuiGasStatus,
         TransactionEffects,
         Vec<ExecutionTiming>,
-        Result<(), ExecutionErrorContext>,
+        Result<(), ExecutionError>,
     ) {
         let (inner_temp_store, gas_status, effects, timings, result) =
             execute_transaction_to_effects::<execution_mode::Normal>(
@@ -162,7 +162,6 @@ impl executor::Executor for Executor {
         if let Err(error) = &result {
             log_execution_error(protocol_config, transaction_digest, error);
         }
-        let result = result.map_err(ExecutionErrorContext::from);
         (inner_temp_store, gas_status, effects, timings, result)
     }
 

--- a/sui-execution/src/v3.rs
+++ b/sui-execution/src/v3.rs
@@ -14,7 +14,7 @@ use sui_types::{
     committee::EpochId,
     digests::TransactionDigest,
     effects::TransactionEffects,
-    error::{ExecutionError, SuiError, SuiResult},
+    error::{ExecutionError, ExecutionErrorContext, SuiError, SuiResult},
     execution::{ExecutionResult, TypeLayoutStore},
     gas::SuiGasStatus,
     inner_temporary_store::InnerTemporaryStore,
@@ -24,8 +24,8 @@ use sui_types::{
 };
 
 use move_bytecode_verifier_meter::Meter;
-use mysten_common::debug_fatal;
 use move_vm_runtime_v3::move_vm::MoveVM;
+use mysten_common::debug_fatal;
 use sui_adapter_v3::adapter::{new_move_vm, run_metered_move_bytecode_verifier};
 use sui_adapter_v3::execution_engine::{
     execute_genesis_state_update, execute_transaction_to_effects,
@@ -139,7 +139,7 @@ impl executor::Executor for Executor {
         SuiGasStatus,
         TransactionEffects,
         Vec<ExecutionTiming>,
-        Result<(), ExecutionError>,
+        Result<(), ExecutionErrorContext>,
     ) {
         let (inner_temp_store, gas_status, effects, timings, result) =
             execute_transaction_to_effects::<execution_mode::Normal>(
@@ -162,6 +162,7 @@ impl executor::Executor for Executor {
         if let Err(error) = &result {
             log_execution_error(protocol_config, transaction_digest, error);
         }
+        let result = result.map_err(ExecutionErrorContext::from);
         (inner_temp_store, gas_status, effects, timings, result)
     }
 

--- a/sui-execution/src/v3.rs
+++ b/sui-execution/src/v3.rs
@@ -24,6 +24,7 @@ use sui_types::{
 };
 
 use move_bytecode_verifier_meter::Meter;
+use mysten_common::debug_fatal;
 use move_vm_runtime_v3::move_vm::MoveVM;
 use sui_adapter_v3::adapter::{new_move_vm, run_metered_move_bytecode_verifier};
 use sui_adapter_v3::execution_engine::{
@@ -104,6 +105,9 @@ impl executor::Executor for Executor {
                 execution_params,
                 trace_builder_opt,
             );
+        if let Err(error) = &result {
+            log_execution_error(protocol_config, transaction_digest, error);
+        }
         (
             inner_temp_store,
             gas_status,
@@ -137,23 +141,28 @@ impl executor::Executor for Executor {
         Vec<ExecutionTiming>,
         Result<(), ExecutionError>,
     ) {
-        execute_transaction_to_effects::<execution_mode::Normal>(
-            store,
-            input_objects,
-            gas,
-            gas_status,
-            transaction_kind,
-            transaction_signer,
-            transaction_digest,
-            &self.0,
-            epoch_id,
-            epoch_timestamp_ms,
-            protocol_config,
-            metrics,
-            enable_expensive_checks,
-            execution_params,
-            trace_builder_opt,
-        )
+        let (inner_temp_store, gas_status, effects, timings, result) =
+            execute_transaction_to_effects::<execution_mode::Normal>(
+                store,
+                input_objects,
+                gas,
+                gas_status,
+                transaction_kind,
+                transaction_signer,
+                transaction_digest,
+                &self.0,
+                epoch_id,
+                epoch_timestamp_ms,
+                protocol_config,
+                metrics,
+                enable_expensive_checks,
+                execution_params,
+                trace_builder_opt,
+            );
+        if let Err(error) = &result {
+            log_execution_error(protocol_config, transaction_digest, error);
+        }
+        (inner_temp_store, gas_status, effects, timings, result)
     }
 
     fn dev_inspect_transaction(
@@ -216,6 +225,9 @@ impl executor::Executor for Executor {
                 &mut None,
             )
         };
+        if let Err(error) = &result {
+            log_execution_error(protocol_config, transaction_digest, error);
+        }
         (inner_temp_store, gas_status, effects, result)
     }
 
@@ -278,5 +290,49 @@ impl verifier::Verifier for Verifier<'_> {
         meter: &mut dyn Meter,
     ) -> SuiResult<()> {
         run_metered_move_bytecode_verifier(modules, &self.config, meter, self.metrics)
+    }
+}
+
+fn log_execution_error(
+    protocol_config: &ProtocolConfig,
+    transaction_digest: TransactionDigest,
+    error: &ExecutionError,
+) {
+    use sui_types::execution_status::ExecutionErrorKind as K;
+
+    match error.kind() {
+        K::InvariantViolation | K::VMInvariantViolation => {
+            if protocol_config.debug_fatal_on_move_invariant_violation() {
+                debug_fatal!(
+                    "INVARIANT VIOLATION! Txn Digest: {}, Source: {:?}",
+                    transaction_digest,
+                    error.source()
+                );
+            } else {
+                tracing::error!(
+                    kind = ?error.kind(),
+                    tx_digest = ?transaction_digest,
+                    "INVARIANT VIOLATION! Source: {:?}",
+                    error.source(),
+                );
+            }
+        }
+        K::SuiMoveVerificationError | K::VMVerificationOrDeserializationError => {
+            tracing::debug!(
+                kind = ?error.kind(),
+                tx_digest = ?transaction_digest,
+                "Verification Error. Source: {:?}",
+                error.source(),
+            );
+        }
+        K::PublishUpgradeMissingDependency | K::PublishUpgradeDependencyDowngrade => {
+            tracing::debug!(
+                kind = ?error.kind(),
+                tx_digest = ?transaction_digest,
+                "Publish/Upgrade Error. Source: {:?}",
+                error.source(),
+            );
+        }
+        _ => (),
     }
 }

--- a/sui-execution/src/v3.rs
+++ b/sui-execution/src/v3.rs
@@ -14,7 +14,7 @@ use sui_types::{
     committee::EpochId,
     digests::TransactionDigest,
     effects::TransactionEffects,
-    error::{ExecutionError, SuiError, SuiResult},
+    error::{ExecutionError, ExecutionErrorContext, SuiError, SuiResult},
     execution::{ExecutionResult, TypeLayoutStore},
     gas::SuiGasStatus,
     inner_temporary_store::InnerTemporaryStore,
@@ -139,7 +139,7 @@ impl executor::Executor for Executor {
         SuiGasStatus,
         TransactionEffects,
         Vec<ExecutionTiming>,
-        Result<(), ExecutionError>,
+        Result<(), ExecutionErrorContext>,
     ) {
         let (inner_temp_store, gas_status, effects, timings, result) =
             execute_transaction_to_effects::<execution_mode::Normal>(
@@ -162,6 +162,7 @@ impl executor::Executor for Executor {
         if let Err(error) = &result {
             log_execution_error(protocol_config, transaction_digest, error);
         }
+        let result = result.map_err(ExecutionErrorContext::from);
         (inner_temp_store, gas_status, effects, timings, result)
     }
 
@@ -186,7 +187,7 @@ impl executor::Executor for Executor {
         InnerTemporaryStore,
         SuiGasStatus,
         TransactionEffects,
-        Result<Vec<ExecutionResult>, ExecutionError>,
+        Result<Vec<ExecutionResult>, ExecutionErrorContext>,
     ) {
         let (inner_temp_store, gas_status, effects, _timings, result) = if skip_all_checks {
             execute_transaction_to_effects::<execution_mode::DevInspect<true>>(
@@ -228,6 +229,7 @@ impl executor::Executor for Executor {
         if let Err(error) = &result {
             log_execution_error(protocol_config, transaction_digest, error);
         }
+        let result = result.map_err(ExecutionErrorContext::from);
         (inner_temp_store, gas_status, effects, result)
     }
 

--- a/sui-execution/v0/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/v0/sui-adapter/src/execution_engine.rs
@@ -21,7 +21,7 @@ mod checked {
     use sui_types::clock::{CLOCK_MODULE_NAME, CONSENSUS_COMMIT_PROLOGUE_FUNCTION_NAME};
     use sui_types::committee::EpochId;
     use sui_types::effects::TransactionEffects;
-    use sui_types::error::{ExecutionError, ExecutionErrorTrait};
+    use sui_types::error::ExecutionError;
     use sui_types::execution_params::ExecutionOrEarlyError;
     use sui_types::execution_status::{ExecutionErrorKind, ExecutionStatus};
     use sui_types::gas::GasCostSummary;
@@ -109,42 +109,6 @@ mod checked {
         );
 
         let status = if let Err(error) = &execution_result {
-            // Elaborate errors in logs if they are unexpected or their status is terse.
-            use ExecutionErrorKind as K;
-            match error.kind() {
-                K::InvariantViolation | K::VMInvariantViolation => {
-                    #[skip_checked_arithmetic]
-                    tracing::error!(
-                        kind = ?error.kind(),
-                        tx_digest = ?transaction_digest,
-                        "INVARIANT VIOLATION! Source: {:?}",
-                        error.source_ref(),
-                    );
-                }
-
-                K::SuiMoveVerificationError | K::VMVerificationOrDeserializationError => {
-                    #[skip_checked_arithmetic]
-                    tracing::debug!(
-                        kind = ?error.kind(),
-                        tx_digest = ?transaction_digest,
-                        "Verification Error. Source: {:?}",
-                        error.source_ref(),
-                    );
-                }
-
-                K::PublishUpgradeMissingDependency | K::PublishUpgradeDependencyDowngrade => {
-                    #[skip_checked_arithmetic]
-                    tracing::debug!(
-                        kind = ?error.kind(),
-                        tx_digest = ?transaction_digest,
-                        "Publish/Upgrade Error. Source: {:?}",
-                        error.source_ref(),
-                    )
-                }
-
-                _ => (),
-            };
-
             ExecutionStatus::new_failure(error.to_execution_failure())
         } else {
             ExecutionStatus::Success

--- a/sui-execution/v0/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/v0/sui-adapter/src/execution_engine.rs
@@ -21,7 +21,7 @@ mod checked {
     use sui_types::clock::{CLOCK_MODULE_NAME, CONSENSUS_COMMIT_PROLOGUE_FUNCTION_NAME};
     use sui_types::committee::EpochId;
     use sui_types::effects::TransactionEffects;
-    use sui_types::error::ExecutionError;
+    use sui_types::error::{ExecutionError, ExecutionErrorTrait};
     use sui_types::execution_params::ExecutionOrEarlyError;
     use sui_types::execution_status::{ExecutionErrorKind, ExecutionStatus};
     use sui_types::gas::GasCostSummary;

--- a/sui-execution/v1/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/v1/sui-adapter/src/execution_engine.rs
@@ -33,7 +33,7 @@ mod checked {
     use sui_types::clock::{CLOCK_MODULE_NAME, CONSENSUS_COMMIT_PROLOGUE_FUNCTION_NAME};
     use sui_types::committee::EpochId;
     use sui_types::effects::TransactionEffects;
-    use sui_types::error::{ExecutionError, ExecutionErrorTrait};
+    use sui_types::error::ExecutionError;
     use sui_types::execution_status::{ExecutionErrorKind, ExecutionStatus};
     use sui_types::gas::GasCostSummary;
     use sui_types::gas::SuiGasStatus;
@@ -121,42 +121,6 @@ mod checked {
         );
 
         let status = if let Err(error) = &execution_result {
-            // Elaborate errors in logs if they are unexpected or their status is terse.
-            use ExecutionErrorKind as K;
-            match error.kind() {
-                K::InvariantViolation | K::VMInvariantViolation => {
-                    #[skip_checked_arithmetic]
-                    tracing::error!(
-                        kind = ?error.kind(),
-                        tx_digest = ?transaction_digest,
-                        "INVARIANT VIOLATION! Source: {:?}",
-                        error.source_ref(),
-                    );
-                }
-
-                K::SuiMoveVerificationError | K::VMVerificationOrDeserializationError => {
-                    #[skip_checked_arithmetic]
-                    tracing::debug!(
-                        kind = ?error.kind(),
-                        tx_digest = ?transaction_digest,
-                        "Verification Error. Source: {:?}",
-                        error.source_ref(),
-                    );
-                }
-
-                K::PublishUpgradeMissingDependency | K::PublishUpgradeDependencyDowngrade => {
-                    #[skip_checked_arithmetic]
-                    tracing::debug!(
-                        kind = ?error.kind(),
-                        tx_digest = ?transaction_digest,
-                        "Publish/Upgrade Error. Source: {:?}",
-                        error.source_ref(),
-                    )
-                }
-
-                _ => (),
-            };
-
             ExecutionStatus::new_failure(error.to_execution_failure())
         } else {
             ExecutionStatus::Success

--- a/sui-execution/v1/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/v1/sui-adapter/src/execution_engine.rs
@@ -33,7 +33,7 @@ mod checked {
     use sui_types::clock::{CLOCK_MODULE_NAME, CONSENSUS_COMMIT_PROLOGUE_FUNCTION_NAME};
     use sui_types::committee::EpochId;
     use sui_types::effects::TransactionEffects;
-    use sui_types::error::ExecutionError;
+    use sui_types::error::{ExecutionError, ExecutionErrorTrait};
     use sui_types::execution_status::{ExecutionErrorKind, ExecutionStatus};
     use sui_types::gas::GasCostSummary;
     use sui_types::gas::SuiGasStatus;

--- a/sui-execution/v2/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/v2/sui-adapter/src/execution_engine.rs
@@ -39,7 +39,7 @@ mod checked {
     use sui_types::committee::EpochId;
     use sui_types::deny_list_v1::{DENY_LIST_CREATE_FUNC, DENY_LIST_MODULE};
     use sui_types::effects::TransactionEffects;
-    use sui_types::error::ExecutionError;
+    use sui_types::error::{ExecutionError, ExecutionErrorTrait};
     use sui_types::execution_status::{ExecutionErrorKind, ExecutionStatus};
     use sui_types::gas::GasCostSummary;
     use sui_types::gas::SuiGasStatus;

--- a/sui-execution/v2/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/v2/sui-adapter/src/execution_engine.rs
@@ -39,7 +39,7 @@ mod checked {
     use sui_types::committee::EpochId;
     use sui_types::deny_list_v1::{DENY_LIST_CREATE_FUNC, DENY_LIST_MODULE};
     use sui_types::effects::TransactionEffects;
-    use sui_types::error::{ExecutionError, ExecutionErrorTrait};
+    use sui_types::error::ExecutionError;
     use sui_types::execution_status::{ExecutionErrorKind, ExecutionStatus};
     use sui_types::gas::GasCostSummary;
     use sui_types::gas::SuiGasStatus;
@@ -133,42 +133,6 @@ mod checked {
         );
 
         let status = if let Err(error) = &execution_result {
-            // Elaborate errors in logs if they are unexpected or their status is terse.
-            use ExecutionErrorKind as K;
-            match error.kind() {
-                K::InvariantViolation | K::VMInvariantViolation => {
-                    #[skip_checked_arithmetic]
-                    tracing::error!(
-                        kind = ?error.kind(),
-                        tx_digest = ?transaction_digest,
-                        "INVARIANT VIOLATION! Source: {:?}",
-                        error.source_ref(),
-                    );
-                }
-
-                K::SuiMoveVerificationError | K::VMVerificationOrDeserializationError => {
-                    #[skip_checked_arithmetic]
-                    tracing::debug!(
-                        kind = ?error.kind(),
-                        tx_digest = ?transaction_digest,
-                        "Verification Error. Source: {:?}",
-                        error.source_ref(),
-                    );
-                }
-
-                K::PublishUpgradeMissingDependency | K::PublishUpgradeDependencyDowngrade => {
-                    #[skip_checked_arithmetic]
-                    tracing::debug!(
-                        kind = ?error.kind(),
-                        tx_digest = ?transaction_digest,
-                        "Publish/Upgrade Error. Source: {:?}",
-                        error.source_ref(),
-                    )
-                }
-
-                _ => (),
-            };
-
             ExecutionStatus::new_failure(error.to_execution_failure())
         } else {
             ExecutionStatus::Success

--- a/sui-execution/v3/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/v3/sui-adapter/src/execution_engine.rs
@@ -12,7 +12,6 @@ mod checked {
     use move_binary_format::CompiledModule;
     use move_trace_format::format::MoveTraceBuilder;
     use move_vm_runtime::move_vm::MoveVM;
-    use mysten_common::debug_fatal;
     use std::collections::BTreeMap;
     use std::{cell::RefCell, collections::HashSet, rc::Rc, sync::Arc};
     use sui_types::accumulator_root::{ACCUMULATOR_ROOT_CREATE_FUNC, ACCUMULATOR_ROOT_MODULE};
@@ -60,7 +59,7 @@ mod checked {
         ChainIdentifier, get_mainnet_chain_identifier, get_testnet_chain_identifier,
     };
     use sui_types::effects::TransactionEffects;
-    use sui_types::error::{ExecutionError, ExecutionErrorTrait};
+    use sui_types::error::ExecutionError;
     use sui_types::execution::{ExecutionTiming, ResultWithTimings};
     use sui_types::execution_status::{ExecutionErrorKind, ExecutionStatus};
     use sui_types::gas::GasCostSummary;
@@ -185,50 +184,6 @@ mod checked {
         );
 
         let status = if let Err(error) = &execution_result {
-            // Elaborate errors in logs if they are unexpected or their status is terse.
-            use ExecutionErrorKind as K;
-            match error.kind() {
-                K::InvariantViolation | K::VMInvariantViolation => {
-                    if protocol_config.debug_fatal_on_move_invariant_violation() {
-                        debug_fatal!(
-                            "INVARIANT VIOLATION! Txn Digest: {}, Source: {:?}",
-                            transaction_digest,
-                            error.source_ref(),
-                        );
-                    } else {
-                        #[skip_checked_arithmetic]
-                        tracing::error!(
-                            kind = ?error.kind(),
-                            tx_digest = ?transaction_digest,
-                            "INVARIANT VIOLATION! Source: {:?}",
-                            error.source_ref(),
-                        );
-                    }
-                }
-
-                K::SuiMoveVerificationError | K::VMVerificationOrDeserializationError => {
-                    #[skip_checked_arithmetic]
-                    tracing::debug!(
-                        kind = ?error.kind(),
-                        tx_digest = ?transaction_digest,
-                        "Verification Error. Source: {:?}",
-                        error.source_ref(),
-                    );
-                }
-
-                K::PublishUpgradeMissingDependency | K::PublishUpgradeDependencyDowngrade => {
-                    #[skip_checked_arithmetic]
-                    tracing::debug!(
-                        kind = ?error.kind(),
-                        tx_digest = ?transaction_digest,
-                        "Publish/Upgrade Error. Source: {:?}",
-                        error.source_ref(),
-                    )
-                }
-
-                _ => (),
-            };
-
             ExecutionStatus::new_failure(error.to_execution_failure())
         } else {
             ExecutionStatus::Success

--- a/sui-execution/v3/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/v3/sui-adapter/src/execution_engine.rs
@@ -59,7 +59,7 @@ mod checked {
         ChainIdentifier, get_mainnet_chain_identifier, get_testnet_chain_identifier,
     };
     use sui_types::effects::TransactionEffects;
-    use sui_types::error::ExecutionError;
+    use sui_types::error::{ExecutionError, ExecutionErrorTrait};
     use sui_types::execution::{ExecutionTiming, ResultWithTimings};
     use sui_types::execution_status::{ExecutionErrorKind, ExecutionStatus};
     use sui_types::gas::GasCostSummary;


### PR DESCRIPTION
## Description 

Increase vm error visibility with expanded execution error context
- increase the usage of ExecutionErrorTrait in the vm
- create ExecutionErrorContext
- index metadata from ErrorContext into json rpc index
- metadata on JSON RPC


## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
