### PR TITLE
[forking] Fix how the --data-dir stores the files 18/n

### DIFF
--- a/crates/sui-fork/README.md
+++ b/crates/sui-fork/README.md
@@ -45,9 +45,9 @@ That means that you have full control over the advancement of checkpoints, time,
     `sui-fork start` with no flags forks from mainnet at the latest checkpoint.
     The fork serves Sui gRPC on `127.0.0.1:9000` by default.
 
-    Local resume state is stored under
-    `{data-dir}/{network}/forked_at_{checkpoint}`. When you restart the same
-    fork, reuse the same `--data-dir`, `--network`, and `--checkpoint`.
+    In this example, local resume state is stored directly under
+    `/tmp/sui-fork-demo`. When you restart the same fork, reuse the same fork
+    data directory and omit seed flags.
 
 3. In terminal 2, confirm the fork is reachable:
 
@@ -112,13 +112,15 @@ Owned-object enumeration can be seeded when starting the fork:
 sui-fork start --checkpoint 12345678 --address 0x... --object 0x...
 ```
 
-- `--data-dir` is the exact filesystem root for local fork data. Objects,
-  checkpoints, transactions, indices, and `seed_manifest.json` are written
-  directly under that directory.
+- `--data-dir <path>` is the exact filesystem root for local fork data.
+  Objects, checkpoints, transactions, indices, and `seed_manifest.json` are
+  written directly under that directory.
 - Without `--data-dir`, the default root is
-  `{base_path}/{network}/forked_at_{checkpoint}`, where the base path is the folder based on XDG_DATA_HOME or 
-  HOME on Unix systems, or AppData on Windows, and creates a `sui-fork-data` (or `.sui-fork-data`) directory.
-    `SUI_FORK_DATA` sets `{base_path}` and the rest will be as above.
+  `{base_path}/{network}/forked_at_{checkpoint}`.
+- `SUI_FORK_DATA` sets `{base_path}` directly.
+- On Unix, the default `{base_path}` is `$XDG_DATA_HOME/sui_fork_data` when
+  `XDG_DATA_HOME` is set, otherwise `$HOME/.sui_fork_data`.
+- On Windows, the default `{base_path}` is `%APPDATA%/sui_fork_data`.
 - `--address` is repeatable and seeds metadata for every object owned by that
   address at the fork checkpoint. Address seeding requires a checkpoint in the
   GraphQL object enumeration range.

--- a/crates/sui-fork/README.md
+++ b/crates/sui-fork/README.md
@@ -116,9 +116,9 @@ sui-fork start --checkpoint 12345678 --address 0x... --object 0x...
   checkpoints, transactions, indices, and `seed_manifest.json` are written
   directly under that directory.
 - Without `--data-dir`, the default root is
-  `{base_path}/{network}/forked_at_{checkpoint}`. `FORKING_DATA_STORE` sets
-  `{base_path}` directly; otherwise the base path uses `.sui_fork_data` under
-  the Sui config directory or home directory.
+  `{base_path}/{network}/forked_at_{checkpoint}`, where the base path is the folder based on XDG_DATA_HOME or 
+  HOME on Unix systems, or AppData on Windows, and creates a `sui-fork-data` (or `.sui-fork-data`) directory.
+    `FORK_DATA_STORE` sets `{base_path}` and the rest as above.
 - `--address` is repeatable and seeds metadata for every object owned by that
   address at the fork checkpoint. Address seeding requires a checkpoint in the
   GraphQL object enumeration range.

--- a/crates/sui-fork/README.md
+++ b/crates/sui-fork/README.md
@@ -112,20 +112,29 @@ Owned-object enumeration can be seeded when starting the fork:
 sui-fork start --checkpoint 12345678 --address 0x... --object 0x...
 ```
 
+- `--data-dir` is the exact filesystem root for local fork data. Objects,
+  checkpoints, transactions, indices, and `seed_manifest.json` are written
+  directly under that directory.
+- Without `--data-dir`, the default root is
+  `{base_path}/{network}/forked_at_{checkpoint}`. `FORKING_DATA_STORE` sets
+  `{base_path}` directly; otherwise the base path uses `.sui_fork_data` under
+  the Sui config directory or home directory.
 - `--address` is repeatable and seeds metadata for every object owned by that
   address at the fork checkpoint. Address seeding requires a checkpoint in the
   GraphQL object enumeration range.
 - `--object` is repeatable and fetches that object at the fork checkpoint. If
   the object is address-owned, it is added to the initial owned-object index.
-- Seed metadata is written once to `seed_manifest.json` under the fork
-  directory. The manifest is immutable.
+- Fork metadata is written once to `seed_manifest.json` under the fork
+  directory. The manifest is immutable and records the source network, original
+  fork checkpoint, and any optional seed object metadata. When no seed inputs
+  are provided, it is still written with an empty seed entry list.
 
-When restarting with the same `--data-dir`, `--network`, and `--checkpoint`,
-omit seed flags. If a seed manifest already exists and any seed flags are
-provided, startup fails instead of overwriting or reinterpreting the local
-state. Resume starts from the highest locally persisted checkpoint and keeps
-the durable owned-object index and deleted-object markers authoritative over
-the original seed manifest.
+When restarting with the same fork data directory, omit seed flags. If a seed
+manifest already exists and any seed flags are provided, startup fails instead
+of overwriting or reinterpreting the local state. Resume uses the original fork
+checkpoint from `seed_manifest.json`, starts from the highest locally persisted
+checkpoint, and keeps the durable owned-object index and deleted-object markers
+authoritative over the manifest seed entries.
 
 ## Limitations
 - Sequential execution: Transactions are executed one at a time, no parallelism.

--- a/crates/sui-fork/README.md
+++ b/crates/sui-fork/README.md
@@ -118,7 +118,7 @@ sui-fork start --checkpoint 12345678 --address 0x... --object 0x...
 - Without `--data-dir`, the default root is
   `{base_path}/{network}/forked_at_{checkpoint}`, where the base path is the folder based on XDG_DATA_HOME or 
   HOME on Unix systems, or AppData on Windows, and creates a `sui-fork-data` (or `.sui-fork-data`) directory.
-    `FORK_DATA_STORE` sets `{base_path}` and the rest as above.
+    `SUI_FORK_DATA` sets `{base_path}` and the rest will be as above.
 - `--address` is repeatable and seeds metadata for every object owned by that
   address at the fork checkpoint. Address seeding requires a checkpoint in the
   GraphQL object enumeration range.

--- a/crates/sui-fork/src/cli.rs
+++ b/crates/sui-fork/src/cli.rs
@@ -51,7 +51,8 @@ enum Command {
         #[arg(long)]
         checkpoint: Option<u64>,
 
-        /// Exact directory for on-disk storage
+        /// Optional directory where to store the fork data. If none is provided, a default
+        /// directory is used based on `XDG_DATA_HOME` or `HOME` env variables (APPData on Windows).
         #[arg(long)]
         data_dir: Option<PathBuf>,
 

--- a/crates/sui-fork/src/cli.rs
+++ b/crates/sui-fork/src/cli.rs
@@ -51,8 +51,8 @@ enum Command {
         #[arg(long)]
         checkpoint: Option<u64>,
 
-        /// Base directory for on-disk storage (overrides FORKING_DATA_STORE env var)
-        #[arg(long, env = "FORKING_DATA_STORE")]
+        /// Exact directory for on-disk storage
+        #[arg(long)]
         data_dir: Option<PathBuf>,
 
         /// Address whose owned objects should seed the initial owned-object index
@@ -99,6 +99,10 @@ struct StartOutput {
     network: String,
     checkpoint: u64,
     rpc_addr: String,
+    #[serde(skip)]
+    current_checkpoint: u64,
+    #[serde(skip)]
+    resuming: bool,
 }
 
 #[derive(Serialize)]
@@ -190,7 +194,12 @@ async fn cmd_start(
 ) -> Result<()> {
     let network_name = node.network_name();
 
-    let checkpoint = match checkpoint {
+    let resolved_start = crate::startup::resolve_start_checkpoint_from_local(
+        &node,
+        checkpoint,
+        data_dir.as_deref(),
+    )?;
+    let checkpoint = match resolved_start.checkpoint {
         Some(cp) => cp,
         None => GraphQLClient::new(node.clone(), version)?
             .get_latest_checkpoint_sequence_number()
@@ -200,18 +209,34 @@ async fn cmd_start(
 
     let (context, subscription_handle) =
         crate::startup::initialize(node, checkpoint, version, data_dir, seed_input).await?;
+    let current_checkpoint = {
+        let sim = context.simulacrum().read().await;
+        sim.store()
+            .get_highest_verified_checkpoint()?
+            .map(|checkpoint| checkpoint.data().sequence_number)
+            .unwrap_or(checkpoint)
+    };
 
     let output = StartOutput {
         network: network_name.clone(),
         checkpoint,
         rpc_addr: rpc_addr.to_string(),
+        current_checkpoint,
+        resuming: resolved_start.resuming,
     };
     print_output(&output, json_output);
 
-    info!(
-        "Starting forked network from {} at checkpoint {} (rpc on {})",
-        network_name, checkpoint, rpc_addr,
-    );
+    if resolved_start.resuming {
+        info!(
+            "Resuming forked network from {}; forked at checkpoint {}, current checkpoint {} (rpc on {})",
+            network_name, checkpoint, current_checkpoint, rpc_addr,
+        );
+    } else {
+        info!(
+            "Starting forked network from {} at checkpoint {} (rpc on {})",
+            network_name, checkpoint, rpc_addr,
+        );
+    }
 
     let handle = tokio::spawn(crate::startup::run(
         context,
@@ -304,6 +329,13 @@ fn format_timestamp(ms: u64) -> String {
 
 impl std::fmt::Display for StartOutput {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.resuming {
+            return write!(
+                f,
+                "Resuming forked network from {}; forked at checkpoint {}, current checkpoint {} (rpc on {})",
+                self.network, self.checkpoint, self.current_checkpoint, self.rpc_addr,
+            );
+        }
         write!(
             f,
             "Starting forked network from {} at checkpoint {} (rpc on {})",
@@ -357,6 +389,38 @@ impl std::fmt::Display for StatusOutput {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn start_output_describes_new_start() {
+        let output = StartOutput {
+            network: "mainnet".to_owned(),
+            checkpoint: 11,
+            rpc_addr: "127.0.0.1:9000".to_owned(),
+            current_checkpoint: 11,
+            resuming: false,
+        };
+
+        assert_eq!(
+            output.to_string(),
+            "Starting forked network from mainnet at checkpoint 11 (rpc on 127.0.0.1:9000)",
+        );
+    }
+
+    #[test]
+    fn start_output_describes_resume() {
+        let output = StartOutput {
+            network: "mainnet".to_owned(),
+            checkpoint: 11,
+            rpc_addr: "127.0.0.1:9000".to_owned(),
+            current_checkpoint: 17,
+            resuming: true,
+        };
+
+        assert_eq!(
+            output.to_string(),
+            "Resuming forked network from mainnet; forked at checkpoint 11, current checkpoint 17 (rpc on 127.0.0.1:9000)",
+        );
+    }
 
     #[test]
     fn client_commands_accept_default_rpc_addr() {

--- a/crates/sui-fork/src/filesystem.rs
+++ b/crates/sui-fork/src/filesystem.rs
@@ -2,7 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Folder structure:
+//! With an explicit `--data-dir`, the store is rooted directly at:
+//! {data_dir}/
+//!
+//! Without an explicit `--data-dir`, the store is rooted at:
 //! {base_path}/{network_name}/forked_at_{checkpoint}/
+//!
+//! Under either root:
 //!     - objects/
 //!         - {object_id}/
 //!            - latest                  (text: latest persisted version number)
@@ -22,8 +28,9 @@
 //!             - data                   (BCS-encoded Transaction envelope)
 //!             - effects                (BCS-encoded TransactionEffects)
 //!             - events                 (BCS-encoded TransactionEvents)
-//!     - seed_manifest.json             (JSON seed metadata for initial owned-object index)
+//!     - seed_manifest.json             (JSON fork metadata and optional seed metadata)
 
+use std::env;
 use std::fs;
 use std::io::ErrorKind;
 use std::io::Write as _;
@@ -58,8 +65,8 @@ use sui_types::transaction::VerifiedTransaction;
 use crate::Node;
 use crate::seed::SeedManifest;
 
-/// Directory name appended to the configured filesystem store root.
-const DATA_STORE_DIR: &str = ".forking_data_store";
+/// Directory name appended to config/home fallbacks for the default filesystem store base.
+const DATA_STORE_DIR: &str = ".sui_fork_data";
 /// Per-chain object storage directory.
 const OBJECTS_DIR: &str = "objects";
 /// Per-chain secondary indices directory.
@@ -88,7 +95,7 @@ const CHECKPOINT_CONTENTS_DIR: &str = "contents";
 const CHECKPOINT_DIGEST_INDEX_FILE: &str = "digest_index";
 /// Marker file for the latest checkpoint sequence known to the store.
 const LATEST_FILE: &str = "latest";
-/// JSON file containing immutable pre-fork seed metadata.
+/// JSON file containing immutable fork metadata and optional pre-fork seed metadata.
 const SEED_MANIFEST_FILE: &str = "seed_manifest.json";
 
 /// Current-state removal kind for an object affected by local execution.
@@ -147,41 +154,66 @@ pub(crate) struct FilesystemStore {
 }
 
 impl FilesystemStore {
-    /// Create a new filesystem store rooted at
-    /// `{base_path}/{network_name}/forked_at_{checkpoint}`.
+    /// Create a new filesystem store. Explicit data directories are used as the exact root;
+    /// otherwise the root is `{base_path}/{network_name}/forked_at_{checkpoint}`.
     pub(crate) fn new(
         node: &Node,
         forked_at_checkpoint: CheckpointSequenceNumber,
         data_dir: Option<PathBuf>,
     ) -> Result<Self, Error> {
-        let base = match data_dir {
+        let root = match data_dir {
             Some(dir) => dir,
-            None => Self::base_path()?,
+            None => Self::default_root(node, forked_at_checkpoint)?,
         };
-        let root = base
-            .join(node.network_name())
-            .join(format!("forked_at_{}", forked_at_checkpoint));
         Ok(Self { root })
     }
 
     /// Create a filesystem store with an explicit root directory.
-    #[cfg(test)]
     pub(crate) fn new_with_root(root: PathBuf) -> Self {
         Self { root }
     }
 
     /// Resolve the default base path for on-disk storage.
     pub(crate) fn base_path() -> Result<PathBuf, Error> {
-        let home_dir = std::env::var("FORKING_DATA_STORE")
-            .or_else(|_| std::env::var("SUI_CONFIG_DIR"))
-            .or_else(|_| std::env::var("HOME"))
-            .or_else(|_| std::env::var("USERPROFILE"))
+        Self::base_path_from_env(|key| env::var(key))
+    }
+
+    fn base_path_from_env(
+        mut get_env: impl FnMut(&str) -> Result<String, env::VarError>,
+    ) -> Result<PathBuf, Error> {
+        if let Ok(dir) = get_env("FORKING_DATA_STORE") {
+            return Ok(PathBuf::from(dir));
+        }
+
+        let home_dir = get_env("SUI_CONFIG_DIR")
+            .or_else(|_| get_env("HOME"))
+            .or_else(|_| get_env("USERPROFILE"))
             .map_err(|_| {
                 anyhow!(
                     "Cannot determine home directory. Define a FORKING_DATA_STORE environment variable"
                 )
             })?;
         Ok(PathBuf::from(home_dir).join(DATA_STORE_DIR))
+    }
+
+    fn default_root(
+        node: &Node,
+        forked_at_checkpoint: CheckpointSequenceNumber,
+    ) -> Result<PathBuf, Error> {
+        Ok(Self::root_from_base(
+            Self::base_path()?,
+            node,
+            forked_at_checkpoint,
+        ))
+    }
+
+    fn root_from_base(
+        base: PathBuf,
+        node: &Node,
+        forked_at_checkpoint: CheckpointSequenceNumber,
+    ) -> PathBuf {
+        base.join(node.network_name())
+            .join(format!("forked_at_{}", forked_at_checkpoint))
     }
 
     /// Return the directory path for storing objects data.
@@ -639,6 +671,19 @@ impl FilesystemStore {
         );
 
         self.read_latest_file(&checkpoint_dir)
+    }
+
+    /// Get the highest checkpoint sequence number available on disk, returning `None` when
+    /// checkpoint state has not been initialized yet.
+    pub(crate) fn get_highest_checkpoint_sequence_number_if_exists(
+        &self,
+    ) -> anyhow::Result<Option<CheckpointSequenceNumber>> {
+        let checkpoint_dir = self.checkpoints_dir();
+        if !checkpoint_dir.exists() || !checkpoint_dir.join(LATEST_FILE).exists() {
+            return Ok(None);
+        }
+
+        self.read_latest_file(&checkpoint_dir).map(Some)
     }
 
     /// Path to the per-sequence directory holding `summary`.

--- a/crates/sui-fork/src/filesystem.rs
+++ b/crates/sui-fork/src/filesystem.rs
@@ -66,8 +66,8 @@ use sui_types::transaction::VerifiedTransaction;
 use crate::Node;
 use crate::seed::SeedManifest;
 
-/// Environment variable name for an explicit fork data store.
-const FORK_DATA_STORE: &str = "FORK_DATA_STORE";
+/// Environment variable name for an explicit fork data directory.
+const SUI_FORK_DATA_ENV: &str = "SUI_FORK_DATA";
 /// Directory name appended to XDG_DATA_HOME or $HOME on Unix, or %APPDATA% on Windows, when an
 /// explicit data directory is not provided.
 const DATA_DIR: &str = "sui_fork_data";
@@ -187,13 +187,13 @@ impl FilesystemStore {
     /// values without modifying the actual process environment.
     ///
     /// The resolution logic is as follows:
-    /// 1. If `FORK_DATA_STORE` is set, use its value as the base path.
+    /// 1. If `SUI_FORK_DATA` is set, use its value as the base path.
     /// 2. On Unix, if `XDG_DATA_HOME` is set, append the default data directory name.
     /// 3. Otherwise, fall back to the platform's home data directory.
     fn base_path_from_env(
         mut get_env: impl FnMut(&str) -> Option<OsString>,
     ) -> Result<PathBuf, Error> {
-        if let Some(dir) = get_env(FORK_DATA_STORE) {
+        if let Some(dir) = get_env(SUI_FORK_DATA_ENV) {
             return Ok(PathBuf::from(dir));
         }
 

--- a/crates/sui-fork/src/filesystem.rs
+++ b/crates/sui-fork/src/filesystem.rs
@@ -31,6 +31,7 @@
 //!     - seed_manifest.json             (JSON fork metadata and optional seed metadata)
 
 use std::env;
+use std::ffi::OsString;
 use std::fs;
 use std::io::ErrorKind;
 use std::io::Write as _;
@@ -66,7 +67,7 @@ use crate::Node;
 use crate::seed::SeedManifest;
 
 /// Environment variable name for an explicit fork data store.
-const FORK_DATA_DIR: &str = "FORK_DATA_STORE";
+const FORK_DATA_STORE: &str = "FORK_DATA_STORE";
 /// Directory name appended to XDG_DATA_HOME or $HOME on Unix, or %APPDATA% on Windows, when an
 /// explicit data directory is not provided.
 const DATA_DIR: &str = "sui_fork_data";
@@ -178,7 +179,7 @@ impl FilesystemStore {
 
     /// Resolve the default base path for on-disk storage.
     pub(crate) fn base_path() -> Result<PathBuf, Error> {
-        Self::base_path_from_env(|key| env::var(key))
+        Self::base_path_from_env(|key| env::var_os(key))
     }
 
     /// Resolve the default base path for on-disk storage, using the provided `get_env` function to
@@ -187,30 +188,35 @@ impl FilesystemStore {
     ///
     /// The resolution logic is as follows:
     /// 1. If `FORK_DATA_STORE` is set, use its value as the base path.
-    /// 2. Otherwise, find a default data directory.
+    /// 2. On Unix, if `XDG_DATA_HOME` is set, append the default data directory name.
+    /// 3. Otherwise, fall back to the platform's home data directory.
     fn base_path_from_env(
-        get_env: impl FnOnce(&str) -> Result<String, env::VarError>,
+        mut get_env: impl FnMut(&str) -> Option<OsString>,
     ) -> Result<PathBuf, Error> {
-        if let Ok(dir) = get_env(FORK_DATA_DIR) {
+        if let Some(dir) = get_env(FORK_DATA_STORE) {
             return Ok(PathBuf::from(dir));
         }
 
-        Self::default_data_root()
+        Self::default_data_root_from_env(get_env)
     }
 
     #[cfg(unix)]
-    fn default_data_root() -> anyhow::Result<PathBuf> {
-        if let Some(data_dir) = std::env::var_os("XDG_DATA_HOME") {
+    fn default_data_root_from_env(
+        mut get_env: impl FnMut(&str) -> Option<OsString>,
+    ) -> anyhow::Result<PathBuf> {
+        if let Some(data_dir) = get_env("XDG_DATA_HOME") {
             return Ok(PathBuf::from(data_dir).join(DATA_DIR));
         }
 
-        let home = std::env::var_os("HOME").context("could not find $HOME directory")?;
+        let home = get_env("HOME").context("could not find $HOME directory")?;
         Ok(PathBuf::from(home).join(format!(".{}", DATA_DIR)))
     }
 
     #[cfg(windows)]
-    fn default_data_root() -> anyhow::Result<PathBuf> {
-        let app_data = std::env::var_os("APPDATA").context("could not find %APPDATA% directory")?;
+    fn default_data_root_from_env(
+        mut get_env: impl FnMut(&str) -> Option<OsString>,
+    ) -> anyhow::Result<PathBuf> {
+        let app_data = get_env("APPDATA").context("could not find %APPDATA% directory")?;
         Ok(PathBuf::from(app_data).join(DATA_DIR))
     }
 

--- a/crates/sui-fork/src/filesystem.rs
+++ b/crates/sui-fork/src/filesystem.rs
@@ -65,8 +65,11 @@ use sui_types::transaction::VerifiedTransaction;
 use crate::Node;
 use crate::seed::SeedManifest;
 
-/// Directory name appended to config/home fallbacks for the default filesystem store base.
-const DATA_STORE_DIR: &str = ".sui_fork_data";
+/// Environment variable name for an explicit fork data store.
+const FORK_DATA_DIR: &str = "FORK_DATA_STORE";
+/// Directory name appended to XDG_DATA_HOME or $HOME on Unix, or %APPDATA% on Windows, when an
+/// explicit data directory is not provided.
+const DATA_DIR: &str = "sui_fork_data";
 /// Per-chain object storage directory.
 const OBJECTS_DIR: &str = "objects";
 /// Per-chain secondary indices directory.
@@ -178,24 +181,40 @@ impl FilesystemStore {
         Self::base_path_from_env(|key| env::var(key))
     }
 
+    /// Resolve the default base path for on-disk storage, using the provided `get_env` function to
+    /// access environment variables. This indirection allows tests to inject custom environment
+    /// values without modifying the actual process environment.
+    ///
+    /// The resolution logic is as follows:
+    /// 1. If `FORK_DATA_STORE` is set, use its value as the base path.
+    /// 2. Otherwise, find a default data directory.
     fn base_path_from_env(
-        mut get_env: impl FnMut(&str) -> Result<String, env::VarError>,
+        get_env: impl FnOnce(&str) -> Result<String, env::VarError>,
     ) -> Result<PathBuf, Error> {
-        if let Ok(dir) = get_env("FORKING_DATA_STORE") {
+        if let Ok(dir) = get_env(FORK_DATA_DIR) {
             return Ok(PathBuf::from(dir));
         }
 
-        let home_dir = get_env("SUI_CONFIG_DIR")
-            .or_else(|_| get_env("HOME"))
-            .or_else(|_| get_env("USERPROFILE"))
-            .map_err(|_| {
-                anyhow!(
-                    "Cannot determine home directory. Define a FORKING_DATA_STORE environment variable"
-                )
-            })?;
-        Ok(PathBuf::from(home_dir).join(DATA_STORE_DIR))
+        Self::default_data_root()
     }
 
+    #[cfg(unix)]
+    fn default_data_root() -> anyhow::Result<PathBuf> {
+        if let Some(data_dir) = std::env::var_os("XDG_DATA_HOME") {
+            return Ok(PathBuf::from(data_dir).join(DATA_DIR));
+        }
+
+        let home = std::env::var_os("HOME").context("could not find $HOME directory")?;
+        Ok(PathBuf::from(home).join(format!(".{}", DATA_DIR)))
+    }
+
+    #[cfg(windows)]
+    fn default_data_root() -> anyhow::Result<PathBuf> {
+        let app_data = std::env::var_os("APPDATA").context("could not find %APPDATA% directory")?;
+        Ok(PathBuf::from(app_data).join(DATA_DIR))
+    }
+
+    /// Construct the default root directory for a given node and fork checkpoint.
     fn default_root(
         node: &Node,
         forked_at_checkpoint: CheckpointSequenceNumber,
@@ -207,6 +226,7 @@ impl FilesystemStore {
         ))
     }
 
+    /// Construct the path from base path joined with `{network_name}/forked_at_{checkpoint}`.
     fn root_from_base(
         base: PathBuf,
         node: &Node,

--- a/crates/sui-fork/src/seed.rs
+++ b/crates/sui-fork/src/seed.rs
@@ -1,10 +1,11 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Seed resolution for the initial owned-object index.
+//! Fork manifest and seed resolution for the initial owned-object index.
 //!
-//! Address seeds resolve lightweight object metadata at the fork checkpoint, while
-//! explicit object seeds also cache the full object BCS through the existing object query path.
+//! The manifest is written for every initialized fork directory. Address seeds resolve
+//! lightweight object metadata at the fork checkpoint, while explicit object seeds also cache
+//! the full object BCS through the existing object query path.
 
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
@@ -53,12 +54,22 @@ pub(crate) struct SeedEntry {
     pub(crate) balance: Option<u64>,
 }
 
-/// Durable manifest for pre-fork seed metadata.
+/// Durable manifest for fork metadata and optional pre-fork seed metadata.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub(crate) struct SeedManifest {
     pub(crate) network: String,
     pub(crate) checkpoint: CheckpointSequenceNumber,
     pub(crate) entries: Vec<SeedEntry>,
+}
+
+impl SeedManifest {
+    fn empty(network: String, checkpoint: CheckpointSequenceNumber) -> Self {
+        Self {
+            network,
+            checkpoint,
+            entries: Vec::new(),
+        }
+    }
 }
 
 impl SeedEntry {
@@ -121,6 +132,33 @@ pub(crate) fn ensure_seed_policy(data_store: &DataStore, input: &SeedInput) -> R
     Ok(())
 }
 
+/// Ensure an existing fork manifest matches the requested network and checkpoint.
+pub(crate) fn ensure_seed_manifest_matches(
+    manifest: &SeedManifest,
+    network: &str,
+    checkpoint: Option<CheckpointSequenceNumber>,
+) -> Result<(), Error> {
+    if manifest.network != network {
+        bail!(
+            "Seed manifest network {} does not match requested network {}. Use a different --data-dir.",
+            manifest.network,
+            network,
+        );
+    }
+
+    if let Some(checkpoint) = checkpoint
+        && manifest.checkpoint != checkpoint
+    {
+        bail!(
+            "Seed manifest checkpoint {} does not match requested checkpoint {}. Use a different --data-dir.",
+            manifest.checkpoint,
+            checkpoint,
+        );
+    }
+
+    Ok(())
+}
+
 /// Initialize the durable owned-object index from the seed manifest when it is safe to do so.
 pub(crate) fn initialize_owned_index_from_seed(
     data_store: &DataStore,
@@ -151,7 +189,7 @@ pub(crate) async fn prepare_seed_manifest(
     data_store: &DataStore,
     network: String,
     input: &SeedInput,
-) -> Result<Option<SeedManifest>, Error> {
+) -> Result<SeedManifest, Error> {
     if data_store.local().seed_manifest_exists() {
         if !input.is_empty() {
             bail!(
@@ -159,16 +197,18 @@ pub(crate) async fn prepare_seed_manifest(
                 data_store.local().seed_manifest_path().display(),
             );
         }
-        return data_store.local().read_seed_manifest().map(Some);
+        let manifest = data_store.local().read_seed_manifest()?;
+        ensure_seed_manifest_matches(&manifest, &network, Some(data_store.forked_at_checkpoint()))?;
+        return Ok(manifest);
     }
 
-    if input.is_empty() {
-        return Ok(None);
-    }
-
-    let manifest = resolve_seeds(input, network, data_store).await?;
+    let manifest = if input.is_empty() {
+        SeedManifest::empty(network, data_store.forked_at_checkpoint())
+    } else {
+        resolve_seeds(input, network, data_store).await?
+    };
     data_store.local().write_seed_manifest(&manifest)?;
-    Ok(Some(manifest))
+    Ok(manifest)
 }
 
 fn dedupe_addresses(addresses: &[SuiAddress]) -> Vec<SuiAddress> {
@@ -346,6 +386,30 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn prepare_seed_manifest_writes_empty_manifest_without_seed_input() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let store = DataStore::new_for_testing_with_remote(
+            temp.path().to_path_buf(),
+            "http://localhost:1".to_owned(),
+            11,
+        );
+
+        let manifest = prepare_seed_manifest(&store, "custom".to_owned(), &SeedInput::default())
+            .await
+            .expect("empty seed manifest should be written");
+
+        assert_eq!(
+            manifest,
+            SeedManifest {
+                network: "custom".to_owned(),
+                checkpoint: 11,
+                entries: Vec::new(),
+            }
+        );
+        assert_eq!(store.local().read_seed_manifest().unwrap(), manifest);
+    }
+
+    #[tokio::test]
     async fn prepare_seed_manifest_does_not_write_manifest_when_resolution_fails() {
         let server = MockServer::start().await;
         Mock::given(method("POST"))
@@ -403,8 +467,7 @@ mod tests {
             },
         )
         .await
-        .expect("seed manifest should resolve")
-        .expect("manifest should exist");
+        .expect("seed manifest should resolve");
 
         assert_eq!(manifest.entries.len(), 1);
         assert_eq!(manifest.entries[0].object_id, object.id());

--- a/crates/sui-fork/src/startup.rs
+++ b/crates/sui-fork/src/startup.rs
@@ -97,6 +97,9 @@ pub(crate) fn resolve_start_checkpoint_from_local(
 /// instance from the highest checkpoint already persisted locally. Also builds
 /// the checkpoint subscription broker; the returned handle must be passed to
 /// [`run`] so the gRPC server exposes the streaming RPC.
+///
+/// `data_dir` is the root folder where the fork state is persisted. If `None`, a default path is
+/// used. See the `[FileSystemStore]` docs for details.
 pub async fn initialize(
     node: Node,
     forked_at_checkpoint: CheckpointSequenceNumber,

--- a/crates/sui-fork/src/startup.rs
+++ b/crates/sui-fork/src/startup.rs
@@ -3,6 +3,8 @@
 
 use std::net::SocketAddr;
 use std::num::NonZeroUsize;
+use std::path::Path;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use anyhow::Result;
@@ -27,11 +29,68 @@ use sui_types::sui_system_state::SuiSystemStateTrait;
 
 use crate::Node;
 use crate::context::Context;
+use crate::filesystem::FilesystemStore;
 use crate::proto::forking::forking_service_server::ForkingServiceServer;
 use crate::rpc::executor::ForkedTransactionExecutor;
 use crate::rpc::forking_service::ForkingServiceImpl;
 use crate::seed::SeedInput;
+use crate::seed::ensure_seed_manifest_matches;
 use crate::store::DataStore;
+
+/// Checkpoint selected for startup, plus whether existing local fork state was found.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct ResolvedStartCheckpoint {
+    pub(crate) checkpoint: Option<CheckpointSequenceNumber>,
+    pub(crate) resuming: bool,
+}
+
+/// Resolve the fork checkpoint from local state when possible.
+///
+/// Explicit data directories can be inspected directly before the remote
+/// GraphQL client asks for latest. Default roots cannot be inspected without a
+/// checkpoint because their path contains the checkpoint.
+pub(crate) fn resolve_start_checkpoint_from_local(
+    node: &Node,
+    requested_checkpoint: Option<CheckpointSequenceNumber>,
+    data_dir: Option<&Path>,
+) -> Result<ResolvedStartCheckpoint> {
+    let local = match (data_dir, requested_checkpoint) {
+        (Some(data_dir), _) => Some(FilesystemStore::new_with_root(data_dir.to_path_buf())),
+        (None, Some(checkpoint)) => Some(FilesystemStore::new(node, checkpoint, None)?),
+        (None, None) => None,
+    };
+
+    let Some(local) = local else {
+        return Ok(ResolvedStartCheckpoint {
+            checkpoint: requested_checkpoint,
+            resuming: false,
+        });
+    };
+
+    if local.seed_manifest_exists() {
+        let manifest = local.read_seed_manifest()?;
+        ensure_seed_manifest_matches(&manifest, &node.network_name(), requested_checkpoint)?;
+        return Ok(ResolvedStartCheckpoint {
+            checkpoint: Some(manifest.checkpoint),
+            resuming: true,
+        });
+    }
+
+    if requested_checkpoint.is_some() {
+        return Ok(ResolvedStartCheckpoint {
+            checkpoint: requested_checkpoint,
+            resuming: local
+                .get_highest_checkpoint_sequence_number_if_exists()?
+                .is_some(),
+        });
+    }
+
+    let checkpoint = local.get_highest_checkpoint_sequence_number_if_exists()?;
+    Ok(ResolvedStartCheckpoint {
+        checkpoint,
+        resuming: checkpoint.is_some(),
+    })
+}
 
 /// Initialize a forked network by fetching the fork checkpoint from the remote
 /// endpoint when needed, applying seed metadata, and starting a local Simulacrum
@@ -42,7 +101,7 @@ pub async fn initialize(
     node: Node,
     forked_at_checkpoint: CheckpointSequenceNumber,
     version: &str,
-    data_dir: Option<std::path::PathBuf>,
+    data_dir: Option<PathBuf>,
     seed_input: SeedInput,
 ) -> Result<(Context, SubscriptionServiceHandle)> {
     // 1. Create DataStore — empty local cache, GraphQL wired up.
@@ -55,9 +114,7 @@ pub async fn initialize(
     data_store.download_and_persist_startup_checkpoint()?;
     let manifest =
         crate::seed::prepare_seed_manifest(&data_store, node.network_name(), &seed_input).await?;
-    if let Some(manifest) = &manifest {
-        crate::seed::initialize_owned_index_from_seed(&data_store, manifest)?;
-    }
+    crate::seed::initialize_owned_index_from_seed(&data_store, &manifest)?;
     let checkpoint = data_store
         .get_highest_verified_checkpoint()?
         .ok_or_else(|| anyhow!("checkpoint {} not found", forked_at_checkpoint))?;
@@ -177,5 +234,111 @@ fn override_validators(
         }
         #[cfg(msim)]
         _ => anyhow::bail!("unsupported system state variant"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use sui_types::messages_checkpoint::VerifiedCheckpoint;
+    use sui_types::test_checkpoint_data_builder::TestCheckpointBuilder;
+
+    use crate::seed::SeedManifest;
+
+    use super::*;
+
+    fn write_manifest(root: &Path, network: &str, checkpoint: CheckpointSequenceNumber) {
+        FilesystemStore::new_with_root(root.to_path_buf())
+            .write_seed_manifest(&SeedManifest {
+                network: network.to_owned(),
+                checkpoint,
+                entries: Vec::new(),
+            })
+            .expect("seed manifest should write");
+    }
+
+    fn write_checkpoint(root: &Path, sequence: CheckpointSequenceNumber) {
+        let checkpoint = VerifiedCheckpoint::new_unchecked(
+            TestCheckpointBuilder::new(sequence)
+                .build_checkpoint()
+                .summary,
+        );
+        FilesystemStore::new_with_root(root.to_path_buf())
+            .write_checkpoint_summary(&checkpoint)
+            .expect("checkpoint summary should write");
+    }
+
+    #[test]
+    fn resolve_start_checkpoint_uses_manifest_when_checkpoint_is_omitted() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        write_manifest(temp.path(), "mainnet", 42);
+
+        let resolved = resolve_start_checkpoint_from_local(&Node::Mainnet, None, Some(temp.path()))
+            .expect("checkpoint resolution should not fail");
+
+        assert_eq!(
+            resolved,
+            ResolvedStartCheckpoint {
+                checkpoint: Some(42),
+                resuming: true,
+            }
+        );
+    }
+
+    #[test]
+    fn resolve_start_checkpoint_rejects_requested_checkpoint_mismatch() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        write_manifest(temp.path(), "mainnet", 42);
+
+        let err = resolve_start_checkpoint_from_local(&Node::Mainnet, Some(43), Some(temp.path()))
+            .expect_err("checkpoint mismatch should fail");
+
+        assert!(
+            err.to_string()
+                .contains("does not match requested checkpoint")
+        );
+    }
+
+    #[test]
+    fn resolve_start_checkpoint_rejects_network_mismatch() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        write_manifest(temp.path(), "testnet", 42);
+
+        let err = resolve_start_checkpoint_from_local(&Node::Mainnet, None, Some(temp.path()))
+            .expect_err("network mismatch should fail");
+
+        assert!(err.to_string().contains("does not match requested network"));
+    }
+
+    #[test]
+    fn resolve_start_checkpoint_falls_back_to_legacy_latest_checkpoint() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        write_checkpoint(temp.path(), 17);
+
+        let resolved = resolve_start_checkpoint_from_local(&Node::Mainnet, None, Some(temp.path()))
+            .expect("checkpoint resolution should not fail");
+
+        assert_eq!(
+            resolved,
+            ResolvedStartCheckpoint {
+                checkpoint: Some(17),
+                resuming: true,
+            }
+        );
+    }
+
+    #[test]
+    fn resolve_start_checkpoint_returns_none_for_fresh_start() {
+        let temp = tempfile::tempdir().expect("tempdir");
+
+        let resolved = resolve_start_checkpoint_from_local(&Node::Mainnet, None, Some(temp.path()))
+            .expect("checkpoint resolution should not fail");
+
+        assert_eq!(
+            resolved,
+            ResolvedStartCheckpoint {
+                checkpoint: None,
+                resuming: false,
+            }
+        );
     }
 }

--- a/crates/sui-fork/src/store.rs
+++ b/crates/sui-fork/src/store.rs
@@ -104,9 +104,8 @@ struct RemovedObject {
 impl DataStore {
     /// Create a new `DataStore` for the given network, anchored at `forked_at_checkpoint`.
     ///
-    /// The local filesystem cache is rooted under a per-network, per-checkpoint directory
-    /// (see `FilesystemStore`). The GraphQL client is constructed eagerly but no remote
-    /// requests are made until reads happen.
+    /// The local filesystem cache root is selected by `FilesystemStore`. The GraphQL client is
+    /// constructed eagerly but no remote requests are made until reads happen.
     pub async fn new(
         node: Node,
         forked_at_checkpoint: CheckpointSequenceNumber,

--- a/crates/sui-fork/src/tests/filesystem.rs
+++ b/crates/sui-fork/src/tests/filesystem.rs
@@ -66,9 +66,9 @@ fn env_value(vars: &[(&str, &str)], key: &str) -> Option<OsString> {
 
 #[cfg(unix)]
 #[test]
-fn fork_data_store_env_takes_precedence_over_xdg_and_home() {
+fn sui_fork_data_env_takes_precedence_over_xdg_and_home() {
     let vars = [
-        (FORK_DATA_STORE, "/tmp/custom-fork-base"),
+        (SUI_FORK_DATA_ENV, "/tmp/custom-fork-base"),
         ("XDG_DATA_HOME", "/tmp/xdg-data"),
         ("HOME", "/tmp/home"),
     ];

--- a/crates/sui-fork/src/tests/filesystem.rs
+++ b/crates/sui-fork/src/tests/filesystem.rs
@@ -49,7 +49,7 @@ fn explicit_data_dir_is_used_as_store_root() {
 #[test]
 fn default_root_appends_network_and_checkpoint_to_base_path() {
     let dir = tempfile::tempdir().expect("failed to create tempdir");
-    let base = dir.path().join(DATA_STORE_DIR);
+    let base = dir.path().join(DATA_DIR);
 
     let root = FilesystemStore::root_from_base(base.clone(), &crate::Node::Testnet, 99);
 
@@ -59,27 +59,12 @@ fn default_root_appends_network_and_checkpoint_to_base_path() {
 #[test]
 fn forking_data_store_env_is_used_as_default_base_path_directly() {
     let base = FilesystemStore::base_path_from_env(|key| match key {
-        "FORKING_DATA_STORE" => Ok("/tmp/custom-fork-base".to_owned()),
+        "FORK_DATA_STORE" => Ok("/tmp/custom-fork-base".to_owned()),
         _ => Err(std::env::VarError::NotPresent),
     })
     .unwrap();
 
     assert_eq!(base, std::path::PathBuf::from("/tmp/custom-fork-base"));
-}
-
-#[test]
-fn config_and_home_fallbacks_append_default_store_dir() {
-    let base = FilesystemStore::base_path_from_env(|key| match key {
-        "SUI_CONFIG_DIR" => Ok("/tmp/sui-config".to_owned()),
-        _ => Err(std::env::VarError::NotPresent),
-    })
-    .unwrap();
-
-    assert_eq!(
-        base,
-        std::path::PathBuf::from("/tmp/sui-config").join(".sui_fork_data")
-    );
-    assert_eq!(DATA_STORE_DIR, ".sui_fork_data");
 }
 
 fn make_object(id: ObjectID, version: u64) -> Object {

--- a/crates/sui-fork/src/tests/filesystem.rs
+++ b/crates/sui-fork/src/tests/filesystem.rs
@@ -6,7 +6,9 @@
 //! lives under `src/tests/` but remains a child of the `filesystem` module
 //! and has full `super::*` access to crate-private items.
 
+use std::ffi::OsString;
 use std::fs;
+use std::path::PathBuf;
 
 use sui_types::base_types::ObjectID;
 use sui_types::base_types::SequenceNumber;
@@ -56,15 +58,47 @@ fn default_root_appends_network_and_checkpoint_to_base_path() {
     assert_eq!(root, base.join("testnet").join("forked_at_99"));
 }
 
-#[test]
-fn forking_data_store_env_is_used_as_default_base_path_directly() {
-    let base = FilesystemStore::base_path_from_env(|key| match key {
-        "FORK_DATA_STORE" => Ok("/tmp/custom-fork-base".to_owned()),
-        _ => Err(std::env::VarError::NotPresent),
-    })
-    .unwrap();
+#[cfg(unix)]
+fn env_value(vars: &[(&str, &str)], key: &str) -> Option<OsString> {
+    vars.iter()
+        .find_map(|(name, value)| (*name == key).then(|| OsString::from(*value)))
+}
 
-    assert_eq!(base, std::path::PathBuf::from("/tmp/custom-fork-base"));
+#[cfg(unix)]
+#[test]
+fn fork_data_store_env_takes_precedence_over_xdg_and_home() {
+    let vars = [
+        (FORK_DATA_STORE, "/tmp/custom-fork-base"),
+        ("XDG_DATA_HOME", "/tmp/xdg-data"),
+        ("HOME", "/tmp/home"),
+    ];
+
+    let base = FilesystemStore::base_path_from_env(|key| env_value(&vars, key)).unwrap();
+
+    assert_eq!(base, PathBuf::from("/tmp/custom-fork-base"));
+}
+
+#[cfg(unix)]
+#[test]
+fn xdg_data_home_env_takes_precedence_over_home() {
+    let vars = [("XDG_DATA_HOME", "/tmp/xdg-data"), ("HOME", "/tmp/home")];
+
+    let base = FilesystemStore::base_path_from_env(|key| env_value(&vars, key)).unwrap();
+
+    assert_eq!(base, PathBuf::from("/tmp/xdg-data").join(DATA_DIR));
+}
+
+#[cfg(unix)]
+#[test]
+fn home_env_is_used_when_no_override_or_xdg_data_home() {
+    let vars = [("HOME", "/tmp/home")];
+
+    let base = FilesystemStore::base_path_from_env(|key| env_value(&vars, key)).unwrap();
+
+    assert_eq!(
+        base,
+        PathBuf::from("/tmp/home").join(format!(".{}", DATA_DIR))
+    );
 }
 
 fn make_object(id: ObjectID, version: u64) -> Object {

--- a/crates/sui-fork/src/tests/filesystem.rs
+++ b/crates/sui-fork/src/tests/filesystem.rs
@@ -32,6 +32,56 @@ fn test_store() -> (tempfile::TempDir, FilesystemStore) {
     (dir, store)
 }
 
+#[test]
+fn explicit_data_dir_is_used_as_store_root() {
+    let dir = tempfile::tempdir().expect("failed to create tempdir");
+    let root = dir.path().join("fork-root");
+
+    let store = FilesystemStore::new(&crate::Node::Mainnet, 42, Some(root.clone())).unwrap();
+
+    assert_eq!(store.root, root);
+    assert_eq!(store.objects_dir(), root.join(OBJECTS_DIR));
+    assert_eq!(store.checkpoints_dir(), root.join(CHECKPOINTS_DIR));
+    assert_eq!(store.transactions_dir(), root.join(TRANSACTIONS_DIR));
+    assert_eq!(store.seed_manifest_path(), root.join(SEED_MANIFEST_FILE));
+}
+
+#[test]
+fn default_root_appends_network_and_checkpoint_to_base_path() {
+    let dir = tempfile::tempdir().expect("failed to create tempdir");
+    let base = dir.path().join(DATA_STORE_DIR);
+
+    let root = FilesystemStore::root_from_base(base.clone(), &crate::Node::Testnet, 99);
+
+    assert_eq!(root, base.join("testnet").join("forked_at_99"));
+}
+
+#[test]
+fn forking_data_store_env_is_used_as_default_base_path_directly() {
+    let base = FilesystemStore::base_path_from_env(|key| match key {
+        "FORKING_DATA_STORE" => Ok("/tmp/custom-fork-base".to_owned()),
+        _ => Err(std::env::VarError::NotPresent),
+    })
+    .unwrap();
+
+    assert_eq!(base, std::path::PathBuf::from("/tmp/custom-fork-base"));
+}
+
+#[test]
+fn config_and_home_fallbacks_append_default_store_dir() {
+    let base = FilesystemStore::base_path_from_env(|key| match key {
+        "SUI_CONFIG_DIR" => Ok("/tmp/sui-config".to_owned()),
+        _ => Err(std::env::VarError::NotPresent),
+    })
+    .unwrap();
+
+    assert_eq!(
+        base,
+        std::path::PathBuf::from("/tmp/sui-config").join(".sui_fork_data")
+    );
+    assert_eq!(DATA_STORE_DIR, ".sui_fork_data");
+}
+
 fn make_object(id: ObjectID, version: u64) -> Object {
     make_object_with_owner(id, version, Owner::Immutable)
 }
@@ -281,6 +331,20 @@ fn test_seed_manifest_round_trips_and_is_immutable() {
     assert!(store.seed_manifest_exists());
     assert_eq!(store.read_seed_manifest().unwrap(), manifest);
     assert!(store.write_seed_manifest(&manifest).is_err());
+}
+
+#[test]
+fn test_empty_seed_manifest_round_trips() {
+    let (_dir, store) = test_store();
+    let manifest = SeedManifest {
+        network: "mainnet".to_owned(),
+        checkpoint: 42,
+        entries: Vec::new(),
+    };
+
+    store.write_seed_manifest(&manifest).unwrap();
+
+    assert_eq!(store.read_seed_manifest().unwrap(), manifest);
 }
 
 #[test]


### PR DESCRIPTION
## Description 

This PR removes the extra folder creation when `--data-dir` is passed. With this fix, the `objects | checkpoints | transactions | etc` data will live directly in the directory passed through the flag.

In addition, the `seed_manifest.json` will be written always to disk with some metadata; if address/objects seeding is provided at startup, then it will be persisted too, otherwise those data will be empty. This is needed to ensure easy resume of the fork (knows at which checkpoint was forked, and which is the latest available checkpoint locally).

## Test plan 

Existing CI + new tests.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
