### PR TITLE
docker/sui-node-th: align with #26478 + unlock mp3 cargo cache

### DIFF
--- a/docker/sui-node-th/Dockerfile
+++ b/docker/sui-node-th/Dockerfile
@@ -1,38 +1,47 @@
 # Build application
 #
-# Copy in all crates, Cargo.toml and Cargo.lock unmodified,
-# and build the application.
+# Single-stage builder + minimal runtime. Layer cache short-circuits when the
+# COPY inputs are byte-identical to a previous build.
+#
 FROM rust:1.92-bullseye AS builder
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends cmake clang \
+ && rm -rf /var/lib/apt/lists/*
 ARG PROFILE=release
-ARG GIT_REVISION
-ENV GIT_REVISION=$GIT_REVISION
-WORKDIR "$WORKDIR/sui"
-RUN apt-get update && apt-get install -y cmake clang
+WORKDIR /sui
 
+# COPYs ordered least- to most-frequently-changing for deeper layer cache hits.
+COPY rust-toolchain.toml ./
+COPY .cargo .cargo
 COPY Cargo.toml Cargo.lock ./
+COPY external-crates external-crates
+COPY sui-execution sui-execution
 COPY consensus consensus
 COPY crates crates
-COPY sui-execution sui-execution
-COPY external-crates external-crates
 
+# GIT_REVISION declared late so SHA changes don't invalidate the COPYs above.
+ARG GIT_REVISION
+ENV GIT_REVISION=$GIT_REVISION
 ENV USE_TIDEHUNTER=1
-RUN cargo build --profile ${PROFILE} --features typed-store/tidehunter \
+RUN cargo build --locked --profile ${PROFILE} \
+    --features typed-store/tidehunter \
     --bin sui-node --bin sui --bin sui-tool --bin stress \
     --target-dir target/tidehunter
 
 # Production Image
 FROM debian:bullseye-slim AS runtime
-# Use jemalloc as memory allocator
-RUN apt-get update && apt-get install -y ca-certificates curl
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates curl \
+ && rm -rf /var/lib/apt/lists/*
+WORKDIR /sui
 ARG PROFILE=release
-WORKDIR "$WORKDIR/sui"
 # Tidehunter-feature binaries ship at suffixed paths only — no canonical
 # aliases, since the storage backend is incompatible with rocksdb and a
 # silent swap at /opt/sui/bin/sui-node could corrupt unrelated databases.
-COPY --from=builder /sui/target/tidehunter/release/sui-node /opt/sui/bin/sui-node-th
-COPY --from=builder /sui/target/tidehunter/release/sui      /opt/sui/bin/sui-th
-COPY --from=builder /sui/target/tidehunter/release/sui-tool /opt/sui/bin/sui-tool-th
-COPY --from=builder /sui/target/tidehunter/release/stress   /opt/sui/bin/stress-th
+COPY --from=builder /sui/target/tidehunter/${PROFILE}/sui-node /opt/sui/bin/sui-node-th
+COPY --from=builder /sui/target/tidehunter/${PROFILE}/sui      /opt/sui/bin/sui-th
+COPY --from=builder /sui/target/tidehunter/${PROFILE}/sui-tool /opt/sui/bin/sui-tool-th
+COPY --from=builder /sui/target/tidehunter/${PROFILE}/stress   /opt/sui/bin/stress-th
 
 ARG BUILD_DATE
 ARG GIT_REVISION

--- a/docker/sui-node-th/Dockerfile
+++ b/docker/sui-node-th/Dockerfile
@@ -25,8 +25,7 @@ ENV GIT_REVISION=$GIT_REVISION
 ENV USE_TIDEHUNTER=1
 RUN cargo build --locked --profile ${PROFILE} \
     --features typed-store/tidehunter \
-    --bin sui-node --bin sui --bin sui-tool --bin stress \
-    --target-dir target/tidehunter
+    --bin sui-node --bin sui --bin sui-tool --bin stress
 
 # Production Image
 FROM debian:bullseye-slim AS runtime
@@ -39,10 +38,10 @@ WORKDIR /sui
 # silent swap at /opt/sui/bin/sui-node could corrupt unrelated databases.
 # Source path is hardcoded to /release/ because the release and bench
 # profiles both emit there (bench inherits release's dir-name).
-COPY --from=builder /sui/target/tidehunter/release/sui-node /opt/sui/bin/sui-node-th
-COPY --from=builder /sui/target/tidehunter/release/sui      /opt/sui/bin/sui-th
-COPY --from=builder /sui/target/tidehunter/release/sui-tool /opt/sui/bin/sui-tool-th
-COPY --from=builder /sui/target/tidehunter/release/stress   /opt/sui/bin/stress-th
+COPY --from=builder /sui/target/release/sui-node /opt/sui/bin/sui-node-th
+COPY --from=builder /sui/target/release/sui      /opt/sui/bin/sui-th
+COPY --from=builder /sui/target/release/sui-tool /opt/sui/bin/sui-tool-th
+COPY --from=builder /sui/target/release/stress   /opt/sui/bin/stress-th
 
 ARG BUILD_DATE
 ARG GIT_REVISION

--- a/docker/sui-node-th/Dockerfile
+++ b/docker/sui-node-th/Dockerfile
@@ -34,14 +34,15 @@ RUN apt-get update \
  && apt-get install -y --no-install-recommends ca-certificates curl \
  && rm -rf /var/lib/apt/lists/*
 WORKDIR /sui
-ARG PROFILE=release
 # Tidehunter-feature binaries ship at suffixed paths only — no canonical
 # aliases, since the storage backend is incompatible with rocksdb and a
 # silent swap at /opt/sui/bin/sui-node could corrupt unrelated databases.
-COPY --from=builder /sui/target/tidehunter/${PROFILE}/sui-node /opt/sui/bin/sui-node-th
-COPY --from=builder /sui/target/tidehunter/${PROFILE}/sui      /opt/sui/bin/sui-th
-COPY --from=builder /sui/target/tidehunter/${PROFILE}/sui-tool /opt/sui/bin/sui-tool-th
-COPY --from=builder /sui/target/tidehunter/${PROFILE}/stress   /opt/sui/bin/stress-th
+# Source path is hardcoded to /release/ because the release and bench
+# profiles both emit there (bench inherits release's dir-name).
+COPY --from=builder /sui/target/tidehunter/release/sui-node /opt/sui/bin/sui-node-th
+COPY --from=builder /sui/target/tidehunter/release/sui      /opt/sui/bin/sui-th
+COPY --from=builder /sui/target/tidehunter/release/sui-tool /opt/sui/bin/sui-tool-th
+COPY --from=builder /sui/target/tidehunter/release/stress   /opt/sui/bin/stress-th
 
 ARG BUILD_DATE
 ARG GIT_REVISION


### PR DESCRIPTION
## Summary

Two related changes to `docker/sui-node-th/Dockerfile`:

1. **Mechanical port of [#26478](https://github.com/MystenLabs/sui/pull/26478)** — same lessons applied to the TideHunter sibling.
2. **Drop `--target-dir target/tidehunter`** — the custom target dir had no Dockerfile-side consumer and was actively gating off mp3's cargo target cache.

## #26478 alignment

- **`WORKDIR "$WORKDIR/sui"` → `WORKDIR /sui`.** The original resolved to `/sui` only because `$WORKDIR` is unset in the rust base image. Confusing antipattern; just write the absolute path.
- **Cache-friendly COPY ordering.** Reorder least- to most-frequently-changing: `rust-toolchain.toml` → `.cargo` → `Cargo.toml`/`Cargo.lock` → `external-crates` → `sui-execution` → `consensus` → `crates`. Source churn in `crates/` no longer cascades to invalidate the layers above it.
- **`GIT_REVISION` declared after the COPYs.** Scope of this benefit (per codex review): preserves the apt-install + COPY layers for SHA-only rebuilds. The `RUN cargo build` layer itself still re-runs in plain Docker, because the `ENV GIT_REVISION=...` state changes the layer hash. The meaningful cargo target reuse comes from cache mounts (mp3#123) — see below.
- **Add `rust-toolchain.toml` and `.cargo` COPYs.** Builder now picks up the pinned toolchain and the project-level cargo config (rustflags, target-specific linker hooks). Required for cache-mount contents to stay valid across builds.
- **`cargo build --locked`** for reproducibility.
- **Lean apt on both stages**: `--no-install-recommends` + `rm -rf /var/lib/apt/lists/*`.
- **Drop the misleading `# Use jemalloc as memory allocator` comment** — jemalloc is not actually installed in this image.

Runtime COPY paths stay hardcoded at `/sui/target/release/...` to match Cargo's actual output: both `--profile release` and `--profile bench` (used by `./build.sh --debug-symbols`) emit into `target/.../release/` because `[profile.bench]` inherits release's `dir-name`. An earlier rev tried `${PROFILE}` here and broke `--debug-symbols` — fixed before merge per codex review.

## Drop `--target-dir target/tidehunter`

The custom target dir was a defensive choice in [#26423](https://github.com/MystenLabs/sui/pull/26423) to avoid hypothetical binary collision with sui-node, but it has no consumer that this Dockerfile feeds:

- mp3's binary extraction (`pulumi/apps/mp3/Pulumi.production.yaml`) reads from `/opt/sui/bin/sui-node-th` (the runtime image path), not the builder's target dir.
- ansible roles use binary names. K8s entrypoints use runtime paths. None care about builder-stage paths.
- `MystenLabs/sui-operations/.github/workflows/sui-release-binaries.yml` (legacy host-side cargo flow, still used for PTN per [sui-operations#7770](https://github.com/MystenLabs/sui-operations/pull/7770)) does reference `target/tidehunter`, but it runs its own `cargo build --target-dir target/tidehunter` on the runner — completely independent of this Dockerfile. Not affected by this change.

The collision concern in mp3 is already eliminated by mp3's design — buildkit cache mount IDs are namespaced per (repo, image, arch, rust-builder-tag), so sui-node and sui-node-th have separate caches structurally:

```
id=mp3-cargo-target-mystenlabs-sui-sui-node-amd64-1-92-bullseye-v7      # sui-node
id=mp3-cargo-target-mystenlabs-sui-sui-node-th-amd64-1-92-bullseye-v7   # sui-node-th
```

**Active downside of keeping it**: mp3's image-builder rewriter (`crates/image-builder/src/utils/dockerfile_rewrite.rs:557`) treats `--target-dir` as a sentinel that **disables cache-mount injection entirely**:

```rust
.any(|t| *t == "cd" || *t == "pushd" || t.starts_with("--target-dir"))
```

So today, sui-node-th gets ~0% benefit from the persistent cargo target cache that sui-node enjoys — just because the Dockerfile redirects cargo away from `/cargo-target`.

Dropping the flag lets cargo write to the default `target/release/`, which matches `/cargo-target` where mp3 mounts the cache. mp3's rewriter then injects:

```dockerfile
RUN --mount=type=cache,target=/cargo-target,id=mp3-cargo-target-...sui-node-th-amd64-1-92-bullseye-v7,sharing=locked \
    --mount=type=cache,target=/usr/local/cargo/registry,... \
    --mount=type=cache,target=/usr/local/cargo/git,... \
    export CARGO_TARGET_DIR=/cargo-target \
    && (find /cargo-target/release -maxdepth 1 -type f -delete 2>/dev/null || true) \
    && cargo build --locked --profile release --features typed-store/tidehunter \
       --bin sui-node --bin sui --bin sui-tool --bin stress \
    && mkdir -p "$(pwd)/target/release" \
    && (cp /cargo-target/release/* "$(pwd)/target/release/" 2>/dev/null || true)
```

Runtime COPY paths follow: `/sui/target/release/sui-node` etc. instead of `/sui/target/tidehunter/release/sui-node`.

### Known mp3 rewriter limitation (not a regression)

For the **`PROFILE=bench`** code path (only invoked by `./build.sh --debug-symbols` locally — never by mp3 today), Cargo writes to `target/release/` (bench inherits release's dir-name) but mp3's rewriter copy-back step uses `cp /cargo-target/${PROFILE}/* …`. If someone ever wires a bench mp3 build, the copy-back would miss because cargo wrote to `release/` while the rewriter looks in `bench/`. That's a pre-existing mp3 issue unrelated to this PR — flagged here so it's on record. Not affected today: mp3 production builds use `PROFILE=release` exclusively.

## Behavior preserved

Still builds 4 binaries (`sui-node`, `sui`, `sui-tool`, `stress`) with `--features typed-store/tidehunter` and `USE_TIDEHUNTER=1`, runtime ships them at `-th`-suffixed paths inside `/opt/sui/bin/`. Image name, label set, base image, ENV/WORKDIR contract all unchanged.

## Why this Dockerfile next

It's the most direct application of #26478's lessons:

- Same structure / same maintainer / same upstream `rust:1.92-bullseye` base.
- TideHunter migration is in active rollout (icn-tnt-val-01, jnb-tnt-val-00, 3/4 scion-testnet validators are `build_with_tidehunter: true`), so every TideHunter cherry-pick rebuilds this image.

## Test plan

- [ ] CI super-linter (hadolint, prettier, etc.) passes.
- [ ] mp3 builds the image successfully on this branch.
- [ ] `./docker/sui-node-th/build.sh` succeeds locally (release profile).
- [ ] `./docker/sui-node-th/build.sh --debug-symbols` succeeds locally (bench profile, hits the `/release/` source path).
- [ ] First post-merge mp3 build of sui-node-th: confirm rewritten Dockerfile shows `--mount=type=cache,target=/cargo-target,id=mp3-cargo-target-...sui-node-th-amd64-...` (cache mount now active).
- [ ] Compare wall time across consecutive sui-node-th builds at different SHAs (should drop materially once the cache is warm — sui-node sees -5% to -15% on cold-cache different-SHA, much more on cache-warm repeats).
- [ ] Verify `sui-node-th --version` reports the expected git revision.
- [ ] Confirm runtime image contains `/opt/sui/bin/sui-node-th`, `sui-th`, `sui-tool-th`, `stress-th`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)