### PR TITLE
docker(sui-tools): apply Dockerfile cleanup pattern from #26478, #26501

### DIFF
--- a/docker/sui-tools/Dockerfile
+++ b/docker/sui-tools/Dockerfile
@@ -1,21 +1,28 @@
 # Build application
 #
-# Copy in all crates, Cargo.toml and Cargo.lock unmodified,
-# and build the application.
+# Single-stage builder + minimal runtime. Layer cache short-circuits when the
+# COPY inputs are byte-identical to a previous build.
+#
 FROM rust:1.92-bullseye AS builder
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends cmake clang libpq5 libpq-dev \
+ && rm -rf /var/lib/apt/lists/*
 ARG PROFILE=release
-ARG GIT_REVISION
-ENV GIT_REVISION=$GIT_REVISION
-WORKDIR "$WORKDIR/sui"
-RUN apt-get update && apt-get install -y cmake clang libpq5 libpq-dev
+WORKDIR /sui
 
+# COPYs ordered least- to most-frequently-changing for deeper layer cache hits.
+COPY rust-toolchain.toml ./
+COPY .cargo .cargo
 COPY Cargo.toml Cargo.lock ./
+COPY external-crates external-crates
+COPY sui-execution sui-execution
 COPY consensus consensus
 COPY crates crates
-COPY sui-execution sui-execution
-COPY external-crates external-crates
 
-RUN cargo build --profile ${PROFILE} \
+# GIT_REVISION declared late so SHA changes don't invalidate the COPYs above.
+ARG GIT_REVISION
+ENV GIT_REVISION=$GIT_REVISION
+RUN cargo build --locked --profile ${PROFILE} \
     --bin sui-faucet \
     --bin sui-bridge \
     --bin bridge-indexer \
@@ -26,18 +33,20 @@ RUN cargo build --profile ${PROFILE} \
 
 # Production Image
 FROM debian:bullseye-slim AS runtime
-WORKDIR "$WORKDIR/sui"
-
-# sui-tool needs libpq at runtime and uses git when fetching move dependencies during build
-RUN apt-get update && apt-get install -y libpq5 libpq-dev ca-certificates git
-
-COPY --from=builder /sui/target/release/sui-faucet /usr/local/bin
-COPY --from=builder /sui/target/release/sui-bridge /usr/local/bin
-COPY --from=builder /sui/target/release/bridge-indexer /usr/local/bin
-COPY --from=builder /sui/target/release/sui-bridge-cli /usr/local/bin
-COPY --from=builder /sui/target/release/sui /usr/local/bin
-COPY --from=builder /sui/target/release/sui-cluster-test /usr/local/bin
-COPY --from=builder /sui/target/release/sui-tool /usr/local/bin
+# sui-tool needs libpq at runtime and git when fetching Move dependencies.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates git libpq5 libpq-dev \
+ && rm -rf /var/lib/apt/lists/*
+WORKDIR /sui
+# Source path is hardcoded to /release/ because the bench profile inherits
+# release's dir-name.
+COPY --from=builder /sui/target/release/sui-faucet       /usr/local/bin/sui-faucet
+COPY --from=builder /sui/target/release/sui-bridge       /usr/local/bin/sui-bridge
+COPY --from=builder /sui/target/release/bridge-indexer   /usr/local/bin/bridge-indexer
+COPY --from=builder /sui/target/release/sui-bridge-cli   /usr/local/bin/sui-bridge-cli
+COPY --from=builder /sui/target/release/sui              /usr/local/bin/sui
+COPY --from=builder /sui/target/release/sui-cluster-test /usr/local/bin/sui-cluster-test
+COPY --from=builder /sui/target/release/sui-tool         /usr/local/bin/sui-tool
 
 ARG BUILD_DATE
 ARG GIT_REVISION

--- a/docker/sui-tools/Dockerfile
+++ b/docker/sui-tools/Dockerfile
@@ -34,8 +34,10 @@ RUN cargo build --locked --profile ${PROFILE} \
 # Production Image
 FROM debian:bullseye-slim AS runtime
 # sui-tool needs libpq at runtime and git when fetching Move dependencies.
+# openssh-client is explicit — without it `--no-install-recommends` drops the
+# git→ssh-client recommendation, breaking git@/ssh:// Move sources.
 RUN apt-get update \
- && apt-get install -y --no-install-recommends ca-certificates git libpq5 libpq-dev \
+ && apt-get install -y --no-install-recommends ca-certificates git openssh-client libpq5 libpq-dev \
  && rm -rf /var/lib/apt/lists/*
 WORKDIR /sui
 # Source path is hardcoded to /release/ because the bench profile inherits


### PR DESCRIPTION
## Summary

Brings `docker/sui-tools/Dockerfile` in line with the patterns established by:

- #26478 — `docker/sui-node/Dockerfile`
- #26501 — `docker/sui-node-th/Dockerfile`

Mechanical cleanup only — no functional change to the produced binaries, their install paths, or the effective runtime environment.

## Changes

- Hoist \`apt-get install\` to an immutable layer with \`--no-install-recommends\` and \`rm -rf /var/lib/apt/lists/*\`. Builder and runtime stages both.
- Reorder \`COPY\`s least- to most-frequently-changing: \`rust-toolchain.toml\`, \`.cargo\`, \`Cargo.toml/lock\`, \`external-crates\`, \`sui-execution\`, \`consensus\`, \`crates\`.
- Add missing \`COPY rust-toolchain.toml\` and \`COPY .cargo\` (without them a Rust-toolchain or cargo-config change silently miscaches).
- Move \`ARG GIT_REVISION\` / \`ENV\` *after* the COPYs so SHA churn doesn't invalidate source layers.
- Add \`--locked\` to \`cargo build\` to fail loudly if \`Cargo.lock\` drifts during a build.
- Replace \`WORKDIR \"$WORKDIR/sui\"\` (with an unset var) with \`WORKDIR /sui\`.
- Hardcode runtime \`COPY --from=builder\` source paths to \`/sui/target/release/\` (bench profile inherits release's dir-name; using a \`${PROFILE}\` template would silently break a bench build, mirroring the codex P1 fix on #26501).

## Backwards compatibility

No interface changes for downstream consumers:

| Surface | Status |
|---|---|
| Built binaries (\`sui-faucet\`, \`sui-bridge\`, \`bridge-indexer\`, \`sui-bridge-cli\`, \`sui\`, \`sui-cluster-test\`, \`sui-tool\`) | Same set, same install paths in \`/usr/local/bin\` |
| Runtime apt-installed packages (\`libpq5\`, \`libpq-dev\`, \`ca-certificates\`, \`git\`, \`openssh-client\`) | Same effective set. \`openssh-client\` is now explicit — under \`--no-install-recommends\` it would otherwise be dropped, breaking \`git@\` / \`ssh://\` Move sources. The previous recommends-on install pulled it in transitively. |
| Build args (\`PROFILE\`, \`GIT_REVISION\`, \`BUILD_DATE\`) | Identical interface |
| \`docker/sui-tools/build.sh\` | Works unmodified |
| mp3 binary extraction (\`MystenLabs/sui:sui-tools\` and \`:sui-tools-arm64\` in sui-operations \`Pulumi.{staging,production}.yaml\`) | Same \`/usr/local/bin/*\` paths preserved |

## Test plan

- [ ] CI build of sui-tools image succeeds on this PR
- [ ] mp3 staging/prod binary extraction continues to find all 5 expected binaries (\`sui\`, \`sui-bridge\`, \`sui-bridge-cli\`, \`sui-faucet\`, \`sui-tool\`) at the configured paths
- [ ] \`docker/sui-tools/build.sh\` produces a runnable image locally
- [ ] Cluster tests (\`.github/actions/cluster-tests/action.yml\`) still find \`sui-cluster-test\` in the image
- [ ] Sanity-check that \`sui move\` can fetch a Move package via both HTTPS and \`git@\` SSH URLs from the image

## Follow-up

After this lands, add \`sui-tools\` to the mp3 rewriter \`image_allowlist\` (sui-operations \`Pulumi.staging.yaml\`, then production), the same path #26501 took for \`sui-node-th\`. That unlocks mold linking and cache-mounted cargo for sui-tools builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)