### PR TITLE
[docs] cannot use `ObjectRef`

### DIFF
--- a/docs/content/develop/objects/transfers/transfer-to-object.mdx
+++ b/docs/content/develop/objects/transfers/transfer-to-object.mdx
@@ -258,8 +258,8 @@ tx.moveCall({
   arguments: [tx.object("0xcafe"), tx.object("0xc0ffee")]
 });
 const result = await client.signAndExecuteTransaction({
-      transaction: tx,
-  });
+    transaction: tx,
+});
 ...
 ```
 
@@ -288,7 +288,7 @@ client
 
 </Tabs>
 
-Object arguments can also have an `ObjectRef` constructor where you can provide an explicit object ID, version, and digest. There is also a `ReceivingRef` constructor that takes the same arguments corresponding to a receiving argument.
+Object arguments can also have an `ReceivingRef` constructor where you can provide an explicit object ID, version, and digest.
 
 ## Soul-bound objects {#soul-bound-example}
 


### PR DESCRIPTION
## Description 

Using `ObjectRef` will result in an error:

```
error: Error checking transaction input objects: Transaction was not signed by the correct sender: Object 0xcdecb0e883c80ff66b6ddf3248579f57c080190c2972b35224c1d1e6e2d1ffec is owned by account address 0xd936f0c6983d485b6beac78c8fe0132da3a7ba2b9ef7ffc3e53bf49597af0dc0, but given owner/signer address is 0x9e4092b6a894e6b168aa1c6c009f5c1c1fcb83fb95e5aa39144e1d2be4ee0d67
```