### PR TITLE
[move][move-compiler] Fix non-deterministic divergent tvar resolution

### DIFF
--- a/external-crates/move/crates/move-compiler/src/typing/core.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/core.rs
@@ -2393,13 +2393,23 @@ pub fn solve_constraints(context: &mut Context) {
     {
         let var_constraints = context.subst.tvar_constraints.clone();
         let mut subst = std::mem::replace(&mut context.subst, Subst::empty());
-        for (var, constraint) in &var_constraints {
-            if let VarConstraint::Divergent(loc) = constraint {
-                let last_tvar = forward_tvar(&subst, *var);
-                if subst.get(last_tvar).is_none() {
-                    join_bind_tvar(&mut subst, *loc, last_tvar, sp(*loc, VOID_TYPE.clone()))
-                        .expect("ICE failed handling unbound divergent type");
+        // Sort by tvar ID so the location chosen for merged divergent vars is deterministic.
+        let mut divergent: Vec<_> = var_constraints
+            .iter()
+            .filter_map(|(var, c)| {
+                if let VarConstraint::Divergent(loc) = c {
+                    Some((*var, *loc))
+                } else {
+                    None
                 }
+            })
+            .collect();
+        divergent.sort_by_key(|(var, _)| *var);
+        for (var, loc) in divergent {
+            let last_tvar = forward_tvar(&subst, var);
+            if subst.get(last_tvar).is_none() {
+                join_bind_tvar(&mut subst, loc, last_tvar, sp(loc, VOID_TYPE.clone()))
+                    .expect("ICE failed handling unbound divergent type");
             }
         }
         context.subst = subst;


### PR DESCRIPTION
## Description

`solve_constraints` iterates over `tvar_constraints: HashMap<TVar, VarConstraint>` to resolve divergent type variables (those arising from `abort` expressions) to `Void`. Because `HashMap` iteration order is non-deterministic across process runs, when two divergent tvars are merged (e.g. from `if (cond) abort 0 else abort 1`), the source location assigned to the merged `Void` type depended on which tvar the hasher happened to visit first. This caused snapshot tests to flip non-deterministically between the two abort locations.

Fix: collect divergent vars into a `Vec`, sort by `TVar` ID (which reflects allocation order), then iterate. The lowest-numbered tvar (first `abort` in source order) consistently wins.

## Test plan

- `void_other_cases` snapshot test now passes stably across repeated runs
- Full `move-compiler` test suite: 2199/2199 pass