### PR TITLE
[move][move-compiler] IndexMap for deterministic type constraints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8782,6 +8782,7 @@ dependencies = [
  "codespan-reporting",
  "dunce",
  "hex",
+ "indexmap 2.8.0",
  "insta",
  "lsp-types 0.95.1",
  "move-abstract-interpreter",

--- a/external-crates/move/Cargo.lock
+++ b/external-crates/move/Cargo.lock
@@ -2622,6 +2622,7 @@ dependencies = [
  "datatest-stable",
  "dunce",
  "hex",
+ "indexmap 2.8.0",
  "insta",
  "lsp-types",
  "move-abstract-interpreter",

--- a/external-crates/move/crates/move-compiler/Cargo.toml
+++ b/external-crates/move/crates/move-compiler/Cargo.toml
@@ -12,6 +12,7 @@ anyhow.workspace = true
 codespan-reporting.workspace = true
 dunce.workspace = true
 hex.workspace = true
+indexmap.workspace = true
 regex.workspace = true
 clap.workspace = true
 petgraph.workspace = true

--- a/external-crates/move/crates/move-compiler/src/typing/core.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/core.rs
@@ -34,6 +34,7 @@ use crate::{
     },
     typing::deprecation_warnings::Deprecations,
 };
+use indexmap::IndexMap;
 use known_attributes::AttributePosition;
 use move_ir_types::location::*;
 use move_symbol_pool::Symbol;
@@ -1329,7 +1330,8 @@ impl TVarCounter {
 #[derive(Clone, Debug)]
 pub struct Subst {
     tvars: HashMap<TVar, Type>,
-    tvar_constraints: HashMap<TVar, VarConstraint>,
+    // IndexMap (rather than HashMap) so iteration order matches insertion order.
+    tvar_constraints: IndexMap<TVar, VarConstraint>,
 }
 
 #[derive(Clone, Debug)]
@@ -1344,7 +1346,7 @@ impl Subst {
     pub fn empty() -> Self {
         Self {
             tvars: HashMap::new(),
-            tvar_constraints: HashMap::new(),
+            tvar_constraints: IndexMap::new(),
         }
     }
 
@@ -2389,7 +2391,8 @@ pub fn solve_constraints(context: &mut Context) {
     use BuiltinTypeName_ as BT;
 
     // Resolve divergent type variables first, so that downstream constraints (e.g., base type)
-    // can see Void rather than an unresolved TVar.
+    // can see Void rather than an unresolved TVar. `tvar_constraints` is an IndexMap so iteration
+    // is deterministic using insertion order.
     {
         let var_constraints = context.subst.tvar_constraints.clone();
         let mut subst = std::mem::replace(&mut context.subst, Subst::empty());


### PR DESCRIPTION
## Description 

solve_constraints in typing/core.rs iterated Subst::tvar_constraints (a HashMap<TVar, VarConstraint>) twice:

  1. Resolving divergent type variables to Void before constraint solving.
  2. Defaulting unresolved Num / String literal vars to u64 / vector<u8>.

HashMap iteration order is non-deterministic, so the order in which divergent vars were bound and literal defaults were applied could vary run-to-run. When defaulting choices interact with later unification, this can perturb downstream diagnostics and (in principle) which type a literal lands on.

## Test plan 

Tests all still pass, and deterministically now.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
