### PR TITLE
[move] Cache-package path + external resolver env_name (DVX-2095, DVX-2097)

### DIFF
--- a/crates/sui/tests/shell_tests/cache_package/cache_package.sh
+++ b/crates/sui/tests/shell_tests/cache_package/cache_package.sh
@@ -1,5 +1,7 @@
 # Copyright (c) Mysten Labs, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-# Run the `cache-package` command
-sui move --client.config $CONFIG cache-package testnet 4c78adac "{ local="\"$(pwd -W 2>/dev/null || pwd)/a\"" }"
+# Run the `cache-package` command. Redact `path` because its value depends on
+# the (platform-specific) temp directory — it's covered by the unit tests.
+sui move --client.config $CONFIG cache-package testnet 4c78adac "{ local="\"$(pwd -W 2>/dev/null || pwd)/a\"" }" \
+| sed 's/"path":"[^"]*"/"path":"<PATH>"/'

--- a/crates/sui/tests/shell_tests/cache_package/cache_package.snap
+++ b/crates/sui/tests/shell_tests/cache_package/cache_package.snap
@@ -12,6 +12,6 @@ sui move --client.config $CONFIG cache-package testnet 4c78adac "{ local="\"$(pw
 success: true
 exit_code: 0
 ----- stdout -----
-{"name":"a","published-at":"0x000000000000000000000000000000000000000000000000000000000000cafe","original-id":"0x00000000000000000000000000000000000000000000000000000000deadbeef","chain_id":"4c78adac"}
+{"name":"a","path":"<SANDBOX_DIR>/a","published-at":"0x000000000000000000000000000000000000000000000000000000000000cafe","original-id":"0x00000000000000000000000000000000000000000000000000000000deadbeef","chain_id":"4c78adac"}
 
 ----- stderr -----

--- a/crates/sui/tests/shell_tests/cache_package/cache_package.snap
+++ b/crates/sui/tests/shell_tests/cache_package/cache_package.snap
@@ -5,13 +5,15 @@ source: crates/sui/tests/shell_tests.rs
 # Copyright (c) Mysten Labs, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-# Run the `cache-package` command
-sui move --client.config $CONFIG cache-package testnet 4c78adac "{ local="\"$(pwd -W 2>/dev/null || pwd)/a\"" }"
+# Run the `cache-package` command. Redact `path` because its value depends on
+# the (platform-specific) temp directory — it's covered by the unit tests.
+sui move --client.config $CONFIG cache-package testnet 4c78adac "{ local="\"$(pwd -W 2>/dev/null || pwd)/a\"" }" \
+| sed 's/"path":"[^"]*"/"path":"<PATH>"/'
 
 ----- results -----
 success: true
 exit_code: 0
 ----- stdout -----
-{"name":"a","path":"<SANDBOX_DIR>/a","published-at":"0x000000000000000000000000000000000000000000000000000000000000cafe","original-id":"0x00000000000000000000000000000000000000000000000000000000deadbeef","chain_id":"4c78adac"}
+{"name":"a","path":"<PATH>","published-at":"0x000000000000000000000000000000000000000000000000000000000000cafe","original-id":"0x00000000000000000000000000000000000000000000000000000000deadbeef","chain_id":"4c78adac"}
 
 ----- stderr -----

--- a/crates/sui/tests/shell_tests/git/git_example.sh
+++ b/crates/sui/tests/shell_tests/git/git_example.sh
@@ -15,4 +15,6 @@ HASH=$(git -C a log --pretty=format:%H)
 
 sui move --client.config "$CONFIG" cache-package testnet 4c78adac \
 "{ git = \"file://$(pwd)/a\", rev = \"${HASH}\", subdir = \".\" }" 2>&1 \
-| sed "s|$(pwd)|<ROOT>|g" | grep -v "output from \`git"
+| sed "s|$(pwd)|<ROOT>|g" \
+| sed 's/"path":"[^"]*"/"path":"<PATH>"/' \
+| grep -v "output from \`git"

--- a/crates/sui/tests/shell_tests/git/git_example.snap
+++ b/crates/sui/tests/shell_tests/git/git_example.snap
@@ -19,7 +19,9 @@ HASH=$(git -C a log --pretty=format:%H)
 
 sui move --client.config "$CONFIG" cache-package testnet 4c78adac \
 "{ git = \"file://$(pwd)/a\", rev = \"${HASH}\", subdir = \".\" }" 2>&1 \
-| sed "s|$(pwd)|<ROOT>|g" | grep -v "output from \`git"
+| sed "s|$(pwd)|<ROOT>|g" \
+| sed 's/"path":"[^"]*"/"path":"<PATH>"/' \
+| grep -v "output from \`git"
 
 ----- results -----
 success: true
@@ -27,6 +29,6 @@ exit_code: 0
 ----- stdout -----
 Downloading from file://<ROOT>/a
   │ warning: filtering not recognized by server, ignoring
-{"name":"a","chain_id":"4c78adac"}
+{"name":"a","path":"<PATH>","chain_id":"4c78adac"}
 
 ----- stderr -----

--- a/external-crates/move/crates/move-package-alt/src/dependency/pin.rs
+++ b/external-crates/move/crates/move-package-alt/src/dependency/pin.rs
@@ -14,7 +14,7 @@ use crate::{
     git::{GitCache, GitError, GitTree},
     package::paths::PackagePath,
     schema::{
-        EnvironmentID, EnvironmentName, EphemeralDependencyInfo, LocalDepInfo,
+        Environment, EnvironmentID, EnvironmentName, EphemeralDependencyInfo, LocalDepInfo,
         LockfileDependencyInfo, LockfileGitDepInfo, ManifestGitDependency, ModeName,
         OnChainDepInfo, PackageName, RenderToml, RootDepInfo,
     },
@@ -73,27 +73,26 @@ pub struct PinnedLocalDependency {
 
 impl PinnedDependency {
     /// Replace all dependencies in `deps` with their pinned versions:
-    ///  - first, all external dependencies are resolved (in environment `environment_id`)
+    ///  - first, all external dependencies are resolved (in environment `env`)
     ///  - next, the revisions for git dependencies are replaced with 40-character shas
     ///  - finally, local dependencies are transformed relative to `parent`
     pub(crate) async fn pin<F: MoveFlavor>(
         parent: &Pinned,
         deps: Vec<CombinedDependency>,
-        environment_id: &EnvironmentID,
+        env: &Environment,
         flavor: &F,
     ) -> PackageResult<Vec<PinnedDependency>> {
         debug!("pinning dependencies");
         // replace all system dependencies using the flavor
-        let (non_system_deps, mut result) =
-            Self::replace_system_deps(deps, environment_id, flavor).await?;
+        let (non_system_deps, mut result) = Self::replace_system_deps(deps, env, flavor).await?;
 
         // resolution - replace all externally resolved dependencies with internal dependencies
-        let deps = ResolvedDependency::resolve(non_system_deps, environment_id).await?;
+        let deps = ResolvedDependency::resolve(non_system_deps, env).await?;
 
         // pinning - fix git shas and normalize local deps
         for dep in deps.into_iter() {
             let transformed = match dep.dep_info {
-                Resolved::Local(ref loc) => loc.clone().pin(parent, environment_id)?,
+                Resolved::Local(ref loc) => loc.clone().pin(parent, env.id())?,
                 Resolved::Git(ref git) => git.pin().await?,
                 Resolved::OnChain(_) => todo!(),
             };
@@ -120,10 +119,10 @@ impl PinnedDependency {
     /// the system dependencies using `flavor`.
     async fn replace_system_deps<F: MoveFlavor>(
         deps: Vec<CombinedDependency>,
-        environment_id: &EnvironmentID,
+        env: &Environment,
         flavor: &F,
     ) -> PackageResult<(Vec<CombinedDependency>, Vec<PinnedDependency>)> {
-        let all_system_deps = flavor.system_deps(environment_id).await;
+        let all_system_deps = flavor.system_deps(env.id()).await;
         let valid_list = move_compiler::format_oxford_list!(
             "and",
             "{}",

--- a/external-crates/move/crates/move-package-alt/src/dependency/resolve.rs
+++ b/external-crates/move/crates/move-package-alt/src/dependency/resolve.rs
@@ -21,10 +21,10 @@ use tracing::debug;
 
 use crate::{
     logging::user_info,
-    package::{EnvironmentID, EnvironmentName},
+    package::EnvironmentName,
     schema::{
-        EXTERNAL_RESOLVE_ARG, PackageName, ResolveRequest, ResolveResponse, ResolverDependencyInfo,
-        ResolverName,
+        EXTERNAL_RESOLVE_ARG, Environment, PackageName, ResolveRequest, ResolveResponse,
+        ResolverDependencyInfo, ResolverName,
     },
 };
 
@@ -89,7 +89,7 @@ impl ResolvedDependency {
     /// Precondition: there are no `System` dependencies (TODO: this needs better design)
     pub async fn resolve(
         deps: Vec<CombinedDependency>,
-        environment_id: &EnvironmentID,
+        env: &Environment,
     ) -> ResolverResult<Vec<ResolvedDependency>> {
         // iterate over [deps] to collect queries for external resolvers
         let mut requests: BTreeMap<ResolverName, BTreeMap<PackageName, ResolveRequest>> =
@@ -100,7 +100,8 @@ impl ResolvedDependency {
                 requests.entry(ext.resolver.clone()).or_default().insert(
                     dep.context.name.clone(),
                     ResolveRequest {
-                        env: environment_id.clone(),
+                        env: env.id().clone(),
+                        env_name: env.name().clone(),
                         data: ext.data.clone(),
                     },
                 );

--- a/external-crates/move/crates/move-package-alt/src/graph/builder.rs
+++ b/external-crates/move/crates/move-package-alt/src/graph/builder.rs
@@ -293,7 +293,7 @@ impl<'a, F: MoveFlavor> PackageGraphBuilder<'a, F> {
         let pinned = PinnedDependency::pin(
             package.dep_for_self(),
             package.direct_deps().clone(),
-            env.id(),
+            env,
             &*self.config.flavor,
         )
         .await

--- a/external-crates/move/crates/move-package-alt/src/mocks/mock-resolver.rs
+++ b/external-crates/move/crates/move-package-alt/src/mocks/mock-resolver.rs
@@ -30,10 +30,12 @@ use tracing::debug;
 use tracing_subscriber::EnvFilter;
 
 type EnvironmentID = String;
+type EnvironmentName = String;
 
 #[derive(Deserialize)]
 struct ResolveRequest {
     env: EnvironmentID,
+    env_name: EnvironmentName,
     data: RequestData,
 }
 
@@ -112,7 +114,10 @@ fn parse_input() -> BTreeMap<RequestID, ResolveRequest> {
 /// Process [request], creating a [Response] with the given [id]
 /// Ends the process if an [Exit] variant is discovered
 fn process_request(id: RequestID, request: ResolveRequest) -> Response<serde_json::Value> {
-    debug!("Resolving request `{id}` for environment {}.", request.env);
+    debug!(
+        "Resolving request `{id}` for environment `{}` (id `{}`).",
+        request.env_name, request.env
+    );
     match request.data {
         RequestData::Stdio(exit) => {
             if let Some(line) = exit.stderr {

--- a/external-crates/move/crates/move-package-alt/src/package/package_impl.rs
+++ b/external-crates/move/crates/move-package-alt/src/package/package_impl.rs
@@ -337,7 +337,7 @@ pub async fn cache_package<F: MoveFlavor>(
     // pin
     let root = Pinned::Root(dummy_path.clone());
     let flavor = Arc::new(flavor);
-    let deps = PinnedDependency::pin(&root, vec![combined], env.id(), &*flavor).await?;
+    let deps = PinnedDependency::pin(&root, vec![combined], env, &*flavor).await?;
 
     // load
     let package = Package::<F>::load(

--- a/external-crates/move/crates/move-package-alt/src/package/package_impl.rs
+++ b/external-crates/move/crates/move-package-alt/src/package/package_impl.rs
@@ -351,6 +351,7 @@ pub async fn cache_package<F: MoveFlavor>(
     // summarize
     Ok(CachedPackageInfo {
         name: package.name().clone(),
+        path: package.path().path().to_path_buf(),
         addresses: package.publication().map(|p| p.addresses.clone()),
         chain_id: env.id.clone(),
     })
@@ -597,14 +598,17 @@ mod tests {
             .add_published("a", OriginalID::from(1), PublishedID::from(2))
             .build();
 
-        let path = scenario.path_for("a");
+        let pkg_path = scenario.path_for("a");
         let env = default_environment();
-        let dep = &ManifestDependencyInfo::Local(LocalDepInfo { local: path });
+        let dep = &ManifestDependencyInfo::Local(LocalDepInfo {
+            local: pkg_path.clone(),
+        });
 
         let info = cache_package::<Vanilla>(&env, dep, Vanilla).await.unwrap();
 
         let CachedPackageInfo {
             name,
+            path,
             addresses,
             chain_id,
         } = info;
@@ -615,6 +619,7 @@ mod tests {
         } = addresses.unwrap();
 
         assert_eq!(name.as_str(), "a");
+        assert_eq!(path, pkg_path);
         assert_eq!(published_at, PublishedID::from(2));
         assert_eq!(original_id, OriginalID::from(1));
         assert_eq!(chain_id, DEFAULT_ENV_ID);

--- a/external-crates/move/crates/move-package-alt/src/schema/cache_result.rs
+++ b/external-crates/move/crates/move-package-alt/src/schema/cache_result.rs
@@ -1,14 +1,18 @@
+use std::path::PathBuf;
+
 use serde::Serialize;
 
 use crate::schema::{EnvironmentID, PackageName, PublishAddresses};
 
 /// The output for the `cache-package` command
 #[derive(Serialize)]
-#[serde(rename = "kebab-case")]
 pub struct CachedPackageInfo {
     pub name: PackageName,
+    pub path: PathBuf,
 
     #[serde(flatten)]
     pub addresses: Option<PublishAddresses>,
+
+    // Serialized as `chain_id` rather than `chain-id`; can't change for backwards compatibility.
     pub chain_id: EnvironmentID,
 }

--- a/external-crates/move/crates/move-package-alt/src/schema/resolver.rs
+++ b/external-crates/move/crates/move-package-alt/src/schema/resolver.rs
@@ -3,7 +3,7 @@ use std::fmt::Display;
 use anyhow::ensure;
 use serde::{Deserialize, Serialize};
 
-use super::{EnvironmentID, LocalDepInfo, ManifestGitDependency, OnChainDepInfo};
+use super::{EnvironmentID, EnvironmentName, LocalDepInfo, ManifestGitDependency, OnChainDepInfo};
 
 pub const EXTERNAL_RESOLVE_ARG: &str = "--resolve-deps";
 pub const EXTERNAL_RESOLVE_METHOD: &str = "resolve";
@@ -25,6 +25,7 @@ pub enum ResolverDependencyInfo {
 #[derive(Serialize, Debug)]
 pub struct ResolveRequest {
     pub env: EnvironmentID,
+    pub env_name: EnvironmentName,
     pub data: toml::Value,
 }
 
@@ -53,5 +54,35 @@ impl From<ResolverName> for String {
 impl Display for ResolverName {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.0.fmt(f)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use indoc::indoc;
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+
+    /// Serializing a [ResolveRequest] produces the expected JSON wire format.
+    #[test]
+    fn serialize_resolve_request() {
+        let req = ResolveRequest {
+            env: "id123".to_string(),
+            env_name: "testnet".to_string(),
+            data: toml::Value::String("foo".into()),
+        };
+        let rendered = serde_json::to_string_pretty(&req).unwrap();
+        assert_eq!(
+            rendered,
+            indoc!(
+                r#"
+                {
+                  "env": "id123",
+                  "env_name": "testnet",
+                  "data": "foo"
+                }"#
+            )
+        );
     }
 }


### PR DESCRIPTION
[CLAUDE]

## Summary

Two related improvements to `move-package-alt`:

- **DVX-2097**: `cache-package` now returns the on-disk path of the fetched package in `CachedPackageInfo.path`, so downstream tooling can locate it.
- **DVX-2095**: External resolvers now receive the environment **name** (in addition to its chain id) via a new `env_name` field on `ResolveRequest`. This is additive and backward-compatible — existing resolvers ignore the new field, and new ones can use it to call back into `cache-package` with the correct env. `&Environment` is threaded through `PinnedDependencyInfo::pin` and `ResolvedDependency::resolve` rather than passing `&EnvironmentID` alone.

Two commits, one per ticket.

## Test plan

- [x] Unit test pinning the JSON wire format of `ResolveRequest` (env, env_name, data)
- [x] Mock-resolver updated to deserialize `env_name`; all 9 existing `external_*` integration tests still pass (so the field is reaching the resolver process)
- [x] `package::tests::test_cache_package` updated to assert the new `path` matches the input local-dep path
- [x] `crates/sui/tests/shell_tests/cache_package/cache_package.snap` re-snapped for the new `path` field
- [x] `cargo move-clippy` + `cargo fmt -- --check` clean in `move-package-alt`
- [ ] CI passes