### PR TITLE
[sui cli] Add pass through command `sui move format` for `prettier-move`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11564,7 +11564,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls",
- "socket2 0.5.6",
+ "socket2 0.6.3",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -15830,6 +15830,7 @@ dependencies = [
  "toml 0.7.4",
  "tracing",
  "walkdir",
+ "which",
 ]
 
 [[package]]
@@ -18821,7 +18822,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.7.3",
+ "rand 0.8.5",
  "static_assertions",
 ]
 
@@ -19609,6 +19610,15 @@ dependencies = [
  "lazy_static",
  "serde",
  "wezterm-dynamic",
+]
+
+[[package]]
+name = "which"
+version = "8.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81995fafaaaf6ae47a7d0cc83c67caf92aeb7e5331650ae6ff856f7c0c60c459"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -579,6 +579,7 @@ webpki = { version = "0.103.10", package = "rustls-webpki", features = [
   "std",
   "ring",
 ] }
+which = "8.0.2"
 winnow = "0.7"
 wiremock = "0.5"
 x509-parser = { version = "0.17.0", features = ["verify"] }
@@ -776,4 +777,3 @@ tonic-reflection = { git = "https://github.com/hyperium/tonic.git", rev = "d6ce6
 async-graphql = { git = "https://github.com/amnn/async-graphql", branch = "v7.0.1-react-18-graphiql-4" }
 async-graphql-axum = { git = "https://github.com/amnn/async-graphql", branch = "v7.0.1-react-18-graphiql-4" }
 async-graphql-value = { git = "https://github.com/amnn/async-graphql", branch = "v7.0.1-react-18-graphiql-4" }
-

--- a/crates/sui-move/Cargo.toml
+++ b/crates/sui-move/Cargo.toml
@@ -18,6 +18,7 @@ prometheus.workspace = true
 bin-version.workspace = true
 serde.workspace = true
 toml.workspace = true
+which.workspace = true
 
 move-binary-format.workspace = true
 move-cli.workspace = true

--- a/crates/sui-move/src/format.rs
+++ b/crates/sui-move/src/format.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::{Context, bail};
+use anyhow::{Context, bail, ensure};
 use clap::Parser;
 use std::{
     io::{self, BufRead, IsTerminal, Write},
@@ -11,15 +11,17 @@ use std::{
 /// Format Move source files using `prettier-move`.
 ///
 /// This is a thin alias around the `prettier-move` shim shipped by the
-/// `@mysten/prettier-plugin-move` npm package — every argument is forwarded
-/// verbatim. If `prettier-move` is not found on `PATH`, the command offers
-/// to install it via `npm i -g`.
+/// `@mysten/prettier-plugin-move` npm package — every argument (including
+/// `--help`) is forwarded verbatim. If `prettier-move` is not found on
+/// `PATH`, the command offers to install it via `npm i -g`.
 #[derive(Parser)]
+#[clap(disable_help_flag = true)]
 #[group(id = "sui-move-format")]
 pub struct Format {
     /// Arguments forwarded verbatim to `prettier-move`. Examples:
     ///   sui move format -c sources/foo.move      # check
     ///   sui move format -w .                     # write the package
+    ///   sui move format --help                   # prettier-move help
     #[clap(trailing_var_arg = true, allow_hyphen_values = true)]
     args: Vec<String>,
 }
@@ -28,7 +30,7 @@ const NPM_INSTALL_ARGS: &[&str] = &["i", "-g", "prettier", "@mysten/prettier-plu
 
 impl Format {
     pub async fn execute(self) -> anyhow::Result<()> {
-        if !is_on_path("prettier-move")? {
+        if which::which("prettier-move").is_err() {
             bootstrap_prettier_move()?;
         }
 
@@ -47,41 +49,21 @@ impl Format {
     }
 }
 
-/// Probe `PATH` for `bin` by invoking `bin --version`. Returns `Ok(true)` if
-/// the binary ran (regardless of its exit status — `--version` may be
-/// rejected by some shims), `Ok(false)` if the binary was not found, and
-/// `Err` for other I/O errors.
-fn is_on_path(bin: &str) -> anyhow::Result<bool> {
-    match Command::new(bin)
-        .arg("--version")
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
-    {
-        Ok(_) => Ok(true),
-        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(false),
-        Err(e) => Err(e).with_context(|| format!("failed to probe `{bin}`")),
-    }
-}
-
 fn bootstrap_prettier_move() -> anyhow::Result<()> {
-    if !is_on_path("npm")? {
-        bail!(
-            "`prettier-move` is not installed and `npm` was not found on PATH.\n\
-             Install Node.js 18+ (which provides `npm`) from https://nodejs.org, \
-             then re-run `sui move format`."
-        );
-    }
-
     let install_cmd = format!("npm {}", NPM_INSTALL_ARGS.join(" "));
 
-    if !io::stdin().is_terminal() {
-        bail!(
-            "`prettier-move` is not installed. Re-run from a terminal to install \
-             interactively, or install manually with:\n    {install_cmd}"
-        );
-    }
+    ensure!(
+        which::which("npm").is_ok(),
+        "`prettier-move` is not installed and `npm` was not found on PATH.\n\
+         Install Node.js 18+ (which provides `npm`) from https://nodejs.org, \
+         then install `prettier-move` with:\n    {install_cmd}"
+    );
+
+    ensure!(
+        io::stdin().is_terminal(),
+        "`prettier-move` is not installed. Re-run from a terminal to install \
+         interactively, or install manually with:\n    {install_cmd}"
+    );
 
     print!("`prettier-move` is not installed. Install it now with `{install_cmd}`? [y/N] ");
     io::stdout().flush().ok();
@@ -92,9 +74,10 @@ fn bootstrap_prettier_move() -> anyhow::Result<()> {
         .read_line(&mut answer)
         .context("failed to read response from stdin")?;
 
-    if !matches!(answer.trim(), "y" | "Y" | "yes" | "YES") {
-        bail!("aborted: `prettier-move` is required for `sui move format`");
-    }
+    ensure!(
+        matches!(answer.trim(), "y" | "Y" | "yes" | "YES"),
+        "aborted: `prettier-move` is required for `sui move format`"
+    );
 
     let status = Command::new("npm")
         .args(NPM_INSTALL_ARGS)
@@ -104,16 +87,16 @@ fn bootstrap_prettier_move() -> anyhow::Result<()> {
         .status()
         .context("failed to spawn `npm`")?;
 
-    if !status.success() {
-        bail!("`{install_cmd}` failed with status {status}");
-    }
+    ensure!(
+        status.success(),
+        "`{install_cmd}` failed with status {status}"
+    );
 
-    if !is_on_path("prettier-move")? {
-        bail!(
-            "`npm` reported success but `prettier-move` is still not on PATH. \
-             Ensure your global npm `bin` directory is on PATH (try `npm bin -g`)."
-        );
-    }
+    ensure!(
+        which::which("prettier-move").is_ok(),
+        "`npm` reported success but `prettier-move` is still not on PATH. \
+         Ensure your global npm `bin` directory is on PATH (try `npm bin -g`)."
+    );
 
     eprintln!("\nSuccessfully installed `prettier-move`.\n");
     Ok(())

--- a/crates/sui-move/src/format.rs
+++ b/crates/sui-move/src/format.rs
@@ -1,0 +1,120 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{Context, bail};
+use clap::Parser;
+use std::{
+    io::{self, BufRead, IsTerminal, Write},
+    process::{Command, Stdio},
+};
+
+/// Format Move source files using `prettier-move`.
+///
+/// This is a thin alias around the `prettier-move` shim shipped by the
+/// `@mysten/prettier-plugin-move` npm package — every argument is forwarded
+/// verbatim. If `prettier-move` is not found on `PATH`, the command offers
+/// to install it via `npm i -g`.
+#[derive(Parser)]
+#[group(id = "sui-move-format")]
+pub struct Format {
+    /// Arguments forwarded verbatim to `prettier-move`. Examples:
+    ///   sui move format -c sources/foo.move      # check
+    ///   sui move format -w .                     # write the package
+    #[clap(trailing_var_arg = true, allow_hyphen_values = true)]
+    args: Vec<String>,
+}
+
+const NPM_INSTALL_ARGS: &[&str] = &["i", "-g", "prettier", "@mysten/prettier-plugin-move"];
+
+impl Format {
+    pub async fn execute(self) -> anyhow::Result<()> {
+        if !is_on_path("prettier-move")? {
+            bootstrap_prettier_move()?;
+        }
+
+        let status = Command::new("prettier-move")
+            .args(&self.args)
+            .stdin(Stdio::inherit())
+            .stdout(Stdio::inherit())
+            .stderr(Stdio::inherit())
+            .status()
+            .context("failed to spawn `prettier-move`")?;
+
+        if let Some(code) = status.code() {
+            std::process::exit(code);
+        }
+        bail!("`prettier-move` terminated by signal");
+    }
+}
+
+/// Probe `PATH` for `bin` by invoking `bin --version`. Returns `Ok(true)` if
+/// the binary ran (regardless of its exit status — `--version` may be
+/// rejected by some shims), `Ok(false)` if the binary was not found, and
+/// `Err` for other I/O errors.
+fn is_on_path(bin: &str) -> anyhow::Result<bool> {
+    match Command::new(bin)
+        .arg("--version")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+    {
+        Ok(_) => Ok(true),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(false),
+        Err(e) => Err(e).with_context(|| format!("failed to probe `{bin}`")),
+    }
+}
+
+fn bootstrap_prettier_move() -> anyhow::Result<()> {
+    if !is_on_path("npm")? {
+        bail!(
+            "`prettier-move` is not installed and `npm` was not found on PATH.\n\
+             Install Node.js 18+ (which provides `npm`) from https://nodejs.org, \
+             then re-run `sui move format`."
+        );
+    }
+
+    let install_cmd = format!("npm {}", NPM_INSTALL_ARGS.join(" "));
+
+    if !io::stdin().is_terminal() {
+        bail!(
+            "`prettier-move` is not installed. Re-run from a terminal to install \
+             interactively, or install manually with:\n    {install_cmd}"
+        );
+    }
+
+    print!("`prettier-move` is not installed. Install it now with `{install_cmd}`? [y/N] ");
+    io::stdout().flush().ok();
+
+    let mut answer = String::new();
+    io::stdin()
+        .lock()
+        .read_line(&mut answer)
+        .context("failed to read response from stdin")?;
+
+    if !matches!(answer.trim(), "y" | "Y" | "yes" | "YES") {
+        bail!("aborted: `prettier-move` is required for `sui move format`");
+    }
+
+    let status = Command::new("npm")
+        .args(NPM_INSTALL_ARGS)
+        .stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .status()
+        .context("failed to spawn `npm`")?;
+
+    if !status.success() {
+        bail!("`{install_cmd}` failed with status {status}");
+    }
+
+    if !is_on_path("prettier-move")? {
+        bail!(
+            "`npm` reported success but `prettier-move` is still not on PATH. \
+             Ensure your global npm `bin` directory is on PATH (try `npm bin -g`)."
+        );
+    }
+
+    eprintln!("\nSuccessfully installed `prettier-move`.\n");
+    Ok(())
+}

--- a/crates/sui-move/src/lib.rs
+++ b/crates/sui-move/src/lib.rs
@@ -12,6 +12,7 @@ pub mod build;
 pub mod cache_package;
 pub mod coverage;
 pub mod disassemble;
+pub mod format;
 pub mod migrate;
 pub mod new;
 pub mod summary;
@@ -25,6 +26,7 @@ pub enum Command {
     #[command(hide = true)]
     CachePackage(cache_package::CachePackage),
     Disassemble(disassemble::Disassemble),
+    Format(format::Format),
     Migrate(migrate::Migrate),
     New(new::New),
     Test(unit_test::Test),
@@ -51,6 +53,7 @@ pub async fn execute_move_command(
         Command::CachePackage(c) => c.execute(flavor).await,
         Command::Coverage(c) => c.execute(package_path, build_config, flavor).await,
         Command::Disassemble(c) => c.execute(package_path, build_config, flavor).await,
+        Command::Format(c) => c.execute().await,
         Command::Migrate(c) => c.execute(package_path, build_config, flavor).await,
         Command::New(c) => c.execute(package_path),
         Command::Summary(s) => {

--- a/crates/sui/tests/shell_tests/sui_move_format_tests/check_clean/check_clean.sh
+++ b/crates/sui/tests/shell_tests/sui_move_format_tests/check_clean/check_clean.sh
@@ -1,0 +1,10 @@
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Happy path: stub `prettier-move` exits 0. Asserts the user's args are
+# forwarded verbatim.
+
+chmod +x stubs/prettier-move
+export PATH="$PWD/stubs:$(dirname "$(command -v sui)")"
+
+sui move --client.config $CONFIG format -c example

--- a/crates/sui/tests/shell_tests/sui_move_format_tests/check_clean/check_clean.snap
+++ b/crates/sui/tests/shell_tests/sui_move_format_tests/check_clean/check_clean.snap
@@ -1,0 +1,23 @@
+---
+source: crates/sui/tests/shell_tests.rs
+assertion_line: 112
+---
+----- script -----
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Happy path: stub `prettier-move` exits 0. Asserts the user's args are
+# forwarded verbatim.
+
+chmod +x stubs/prettier-move
+export PATH="$PWD/stubs:$(dirname "$(command -v sui)")"
+
+sui move --client.config $CONFIG format -c example
+
+----- results -----
+success: true
+exit_code: 0
+----- stdout -----
+prettier-move called with: -c example
+
+----- stderr -----

--- a/crates/sui/tests/shell_tests/sui_move_format_tests/check_clean/stubs/prettier-move
+++ b/crates/sui/tests/shell_tests/sui_move_format_tests/check_clean/stubs/prettier-move
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Stub `prettier-move` used by sui_move_format_tests/check_clean.
+# Behaves as a clean check: prints the args and exits 0.
+
+if [ "$1" = "--version" ]; then
+    echo "stub-prettier-move 0.0.0"
+    exit 0
+fi
+
+echo "prettier-move called with: $*"
+exit 0

--- a/crates/sui/tests/shell_tests/sui_move_format_tests/check_dirty/check_dirty.sh
+++ b/crates/sui/tests/shell_tests/sui_move_format_tests/check_dirty/check_dirty.sh
@@ -1,0 +1,11 @@
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Exit-code propagation: stub `prettier-move` exits 1 (as real prettier does
+# in `--check` mode when files would be reformatted). `sui move format` must
+# surface the same exit code.
+
+chmod +x stubs/prettier-move
+export PATH="$PWD/stubs:$(dirname "$(command -v sui)")"
+
+sui move --client.config $CONFIG format -c example

--- a/crates/sui/tests/shell_tests/sui_move_format_tests/check_dirty/check_dirty.snap
+++ b/crates/sui/tests/shell_tests/sui_move_format_tests/check_dirty/check_dirty.snap
@@ -1,0 +1,25 @@
+---
+source: crates/sui/tests/shell_tests.rs
+assertion_line: 112
+---
+----- script -----
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Exit-code propagation: stub `prettier-move` exits 1 (as real prettier does
+# in `--check` mode when files would be reformatted). `sui move format` must
+# surface the same exit code.
+
+chmod +x stubs/prettier-move
+export PATH="$PWD/stubs:$(dirname "$(command -v sui)")"
+
+sui move --client.config $CONFIG format -c example
+
+----- results -----
+success: false
+exit_code: 1
+----- stdout -----
+
+----- stderr -----
+[warn] sources/foo.move
+Code style issues found in 1 file.

--- a/crates/sui/tests/shell_tests/sui_move_format_tests/check_dirty/stubs/prettier-move
+++ b/crates/sui/tests/shell_tests/sui_move_format_tests/check_dirty/stubs/prettier-move
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Stub `prettier-move` used by sui_move_format_tests/check_dirty.
+# Simulates a `--check` finding unformatted files: prints a diff to stderr
+# and exits 1. `sui move format` should propagate the exit code.
+
+if [ "$1" = "--version" ]; then
+    echo "stub-prettier-move 0.0.0"
+    exit 0
+fi
+
+echo "[warn] sources/foo.move" >&2
+echo "Code style issues found in 1 file." >&2
+exit 1

--- a/crates/sui/tests/shell_tests/sui_move_format_tests/help/help.sh
+++ b/crates/sui/tests/shell_tests/sui_move_format_tests/help/help.sh
@@ -1,5 +1,10 @@
 # Copyright (c) Mysten Labs, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-# `sui move format --help` renders the description.
-sui move format --help | sed -n '1,5p'
+# `--help` is forwarded to `prettier-move` (rather than intercepted by clap)
+# so the user sees prettier-move's full help.
+
+chmod +x stubs/prettier-move
+export PATH="$PWD/stubs:$(dirname "$(command -v sui)")"
+
+sui move --client.config $CONFIG format --help

--- a/crates/sui/tests/shell_tests/sui_move_format_tests/help/help.sh
+++ b/crates/sui/tests/shell_tests/sui_move_format_tests/help/help.sh
@@ -1,0 +1,5 @@
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# `sui move format --help` renders the description.
+sui move format --help | sed -n '1,5p'

--- a/crates/sui/tests/shell_tests/sui_move_format_tests/help/help.snap
+++ b/crates/sui/tests/shell_tests/sui_move_format_tests/help/help.snap
@@ -1,22 +1,22 @@
 ---
 source: crates/sui/tests/shell_tests.rs
-assertion_line: 112
 ---
 ----- script -----
 # Copyright (c) Mysten Labs, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-# `sui move format --help` renders the description.
-sui move format --help | sed -n '1,5p'
+# `--help` is forwarded to `prettier-move` (rather than intercepted by clap)
+# so the user sees prettier-move's full help.
+
+chmod +x stubs/prettier-move
+export PATH="$PWD/stubs:$(dirname "$(command -v sui)")"
+
+sui move --client.config $CONFIG format --help
 
 ----- results -----
 success: true
 exit_code: 0
 ----- stdout -----
-Format Move source files using `prettier-move`.
-
-This is a thin alias around the `prettier-move` shim shipped by the `@mysten/prettier-plugin-move`
-npm package — every argument is forwarded verbatim. If `prettier-move` is not found on `PATH`, the
-command offers to install it via `npm i -g`.
+prettier-move called with: --help
 
 ----- stderr -----

--- a/crates/sui/tests/shell_tests/sui_move_format_tests/help/help.snap
+++ b/crates/sui/tests/shell_tests/sui_move_format_tests/help/help.snap
@@ -1,0 +1,22 @@
+---
+source: crates/sui/tests/shell_tests.rs
+assertion_line: 112
+---
+----- script -----
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# `sui move format --help` renders the description.
+sui move format --help | sed -n '1,5p'
+
+----- results -----
+success: true
+exit_code: 0
+----- stdout -----
+Format Move source files using `prettier-move`.
+
+This is a thin alias around the `prettier-move` shim shipped by the `@mysten/prettier-plugin-move`
+npm package — every argument is forwarded verbatim. If `prettier-move` is not found on `PATH`, the
+command offers to install it via `npm i -g`.
+
+----- stderr -----

--- a/crates/sui/tests/shell_tests/sui_move_format_tests/help/stubs/prettier-move
+++ b/crates/sui/tests/shell_tests/sui_move_format_tests/help/stubs/prettier-move
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Stub `prettier-move` used by sui_move_format_tests/help.
+# Echoes args so the snapshot can confirm `--help` is forwarded.
+
+echo "prettier-move called with: $*"
+exit 0

--- a/crates/sui/tests/shell_tests/sui_move_format_tests/missing_tool_no_npm/missing_tool_no_npm.sh
+++ b/crates/sui/tests/shell_tests/sui_move_format_tests/missing_tool_no_npm/missing_tool_no_npm.sh
@@ -1,0 +1,12 @@
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Neither `prettier-move` nor `npm` are on PATH. `sui move format` should
+# bail with the Node.js install hint and a non-zero exit code.
+
+# Strip PATH down to the sui binary's directory so neither `prettier-move`
+# nor `npm` (which the host may have in /usr/local/bin, NVM dirs, ...) can
+# leak through.
+export PATH="$(dirname "$(command -v sui)")"
+
+sui move --client.config $CONFIG format -c

--- a/crates/sui/tests/shell_tests/sui_move_format_tests/missing_tool_no_npm/missing_tool_no_npm.snap
+++ b/crates/sui/tests/shell_tests/sui_move_format_tests/missing_tool_no_npm/missing_tool_no_npm.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/sui/tests/shell_tests.rs
-assertion_line: 112
 ---
 ----- script -----
 # Copyright (c) Mysten Labs, Inc.
@@ -21,6 +20,7 @@ success: false
 exit_code: 1
 ----- stdout -----
 `prettier-move` is not installed and `npm` was not found on PATH.
-Install Node.js 18+ (which provides `npm`) from https://nodejs.org, then re-run `sui move format`.
+Install Node.js 18+ (which provides `npm`) from https://nodejs.org, then install `prettier-move` with:
+    npm i -g prettier @mysten/prettier-plugin-move
 
 ----- stderr -----

--- a/crates/sui/tests/shell_tests/sui_move_format_tests/missing_tool_no_npm/missing_tool_no_npm.snap
+++ b/crates/sui/tests/shell_tests/sui_move_format_tests/missing_tool_no_npm/missing_tool_no_npm.snap
@@ -1,0 +1,26 @@
+---
+source: crates/sui/tests/shell_tests.rs
+assertion_line: 112
+---
+----- script -----
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Neither `prettier-move` nor `npm` are on PATH. `sui move format` should
+# bail with the Node.js install hint and a non-zero exit code.
+
+# Strip PATH down to the sui binary's directory so neither `prettier-move`
+# nor `npm` (which the host may have in /usr/local/bin, NVM dirs, ...) can
+# leak through.
+export PATH="$(dirname "$(command -v sui)")"
+
+sui move --client.config $CONFIG format -c
+
+----- results -----
+success: false
+exit_code: 1
+----- stdout -----
+`prettier-move` is not installed and `npm` was not found on PATH.
+Install Node.js 18+ (which provides `npm`) from https://nodejs.org, then re-run `sui move format`.
+
+----- stderr -----

--- a/crates/sui/tests/shell_tests/sui_move_format_tests/missing_tool_npm_present_no_tty/missing_tool_npm_present_no_tty.sh
+++ b/crates/sui/tests/shell_tests/sui_move_format_tests/missing_tool_npm_present_no_tty/missing_tool_npm_present_no_tty.sh
@@ -1,0 +1,13 @@
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# `prettier-move` missing, `npm` present (stubbed), stdin is not a TTY (the
+# harness pipes stdin from cargo nextest). `sui move format` must skip the
+# interactive prompt and bail with the manual-install hint. The stub `npm`
+# only handles `--version`; if the install path is reached by mistake, the
+# stub fails loudly.
+
+chmod +x stubs/npm
+export PATH="$PWD/stubs:$(dirname "$(command -v sui)")"
+
+sui move --client.config $CONFIG format -c

--- a/crates/sui/tests/shell_tests/sui_move_format_tests/missing_tool_npm_present_no_tty/missing_tool_npm_present_no_tty.snap
+++ b/crates/sui/tests/shell_tests/sui_move_format_tests/missing_tool_npm_present_no_tty/missing_tool_npm_present_no_tty.snap
@@ -1,0 +1,27 @@
+---
+source: crates/sui/tests/shell_tests.rs
+assertion_line: 112
+---
+----- script -----
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# `prettier-move` missing, `npm` present (stubbed), stdin is not a TTY (the
+# harness pipes stdin from cargo nextest). `sui move format` must skip the
+# interactive prompt and bail with the manual-install hint. The stub `npm`
+# only handles `--version`; if the install path is reached by mistake, the
+# stub fails loudly.
+
+chmod +x stubs/npm
+export PATH="$PWD/stubs:$(dirname "$(command -v sui)")"
+
+sui move --client.config $CONFIG format -c
+
+----- results -----
+success: false
+exit_code: 1
+----- stdout -----
+`prettier-move` is not installed. Re-run from a terminal to install interactively, or install manually with:
+    npm i -g prettier @mysten/prettier-plugin-move
+
+----- stderr -----

--- a/crates/sui/tests/shell_tests/sui_move_format_tests/missing_tool_npm_present_no_tty/stubs/npm
+++ b/crates/sui/tests/shell_tests/sui_move_format_tests/missing_tool_npm_present_no_tty/stubs/npm
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Stub `npm` used by sui_move_format_tests/missing_tool_npm_present_no_tty.
+# Only `npm --version` should ever be called (by `sui move format`'s probe);
+# the install path must be aborted because stdin is not a TTY. Any other
+# invocation here would indicate a regression.
+
+if [ "$1" = "--version" ]; then
+    echo "10.0.0"
+    exit 0
+fi
+
+echo "ERROR: stub npm should not have been invoked with: $*" >&2
+exit 99

--- a/crates/sui/tests/shell_tests/sui_move_format_tests/passthrough/passthrough.sh
+++ b/crates/sui/tests/shell_tests/sui_move_format_tests/passthrough/passthrough.sh
@@ -1,0 +1,10 @@
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Multiple args (flag + path) are forwarded verbatim, no `--` separator
+# required.
+
+chmod +x stubs/prettier-move
+export PATH="$PWD/stubs:$(dirname "$(command -v sui)")"
+
+sui move --client.config $CONFIG format -w sources/foo.move

--- a/crates/sui/tests/shell_tests/sui_move_format_tests/passthrough/passthrough.snap
+++ b/crates/sui/tests/shell_tests/sui_move_format_tests/passthrough/passthrough.snap
@@ -1,0 +1,23 @@
+---
+source: crates/sui/tests/shell_tests.rs
+assertion_line: 112
+---
+----- script -----
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Multiple args (flag + path) are forwarded verbatim, no `--` separator
+# required.
+
+chmod +x stubs/prettier-move
+export PATH="$PWD/stubs:$(dirname "$(command -v sui)")"
+
+sui move --client.config $CONFIG format -w sources/foo.move
+
+----- results -----
+success: true
+exit_code: 0
+----- stdout -----
+prettier-move called with: -w sources/foo.move
+
+----- stderr -----

--- a/crates/sui/tests/shell_tests/sui_move_format_tests/passthrough/stubs/prettier-move
+++ b/crates/sui/tests/shell_tests/sui_move_format_tests/passthrough/stubs/prettier-move
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Stub `prettier-move` used by sui_move_format_tests/passthrough.
+
+if [ "$1" = "--version" ]; then
+    echo "stub-prettier-move 0.0.0"
+    exit 0
+fi
+
+echo "prettier-move called with: $*"
+exit 0


### PR DESCRIPTION
## Description 

- 🤖 Heavily vibe coded
- In an effort to increase awareness and usability of `prettier-move` formatter, this adds a passthrough command to `prettier-move`
  - If it is not in the path, it asks to install it (with the default being N)
  - If `npm` is missing, it informs the user and bails. 

## Test plan 

- Added tests
- Called the command locally 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [X] CLI: Adds `sui move format` passthrough command for `prettier-move` auto-formatter.
- [ ] Rust SDK:
- [ ] Indexing Framework:
