### PR TITLE
[move-ir] vector pack/unpack refactor

### DIFF
--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/control_flow/last_jump_unconditional_reference.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/control_flow/last_jump_unconditional_reference.mvir
@@ -5468,7 +5468,7 @@ label start:
     return; return; return; return; return; return; return; return; return; return; return; return;
     return; return; return; return; return; return; return; return; return; return;
 label code:
-    v = vec_pack_1<u64>(0);
+    v = vector<u64; 1>(0);
     vref = &mut v;
     r = vec_mut_borrow<u64>(copy(vref), 0);
     _ = vec_pop_back<u64>(copy(vref));

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/vector_ops_non_droppable_resource_not_destroyed.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/vector_ops_non_droppable_resource_not_destroyed.mvir
@@ -4,7 +4,7 @@ mvir 0x1::M {
     fun f() {
         let v: vector<Self::R>;
     label b0:
-        v = vec_pack_0<Self::R>();
+        v = vector<Self::R; 0>();
         return;
     }
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/expressivity/simple_dangling.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/expressivity/simple_dangling.mvir
@@ -33,7 +33,7 @@ mvir 0x4::vector {
         let r: &mut u64;
     label b0:
         r = vec_mut_borrow<u64>(copy(v), 0);
-        *move(v) = vec_pack_0<u64>();
+        *move(v) = vector<u64; 0>();
         return;
     }
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/vector_ops_double_borrow.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/vector_ops_double_borrow.mvir
@@ -6,7 +6,7 @@ entry fun foo() {
     let e_imm1: &u64;
     let e_mut2: &mut u64;
 label b0:
-    v = vec_pack_0<u64>();
+    v = vector<u64; 0>();
     vec_push_back<u64>(&mut v, 0);
     vec_push_back<u64>(&mut v, 1);
 
@@ -25,7 +25,7 @@ entry fun foo() {
     let e_mut1: &mut u64;
     let e_imm2: &u64;
 label b0:
-    v = vec_pack_0<u64>();
+    v = vector<u64; 0>();
     vec_push_back<u64>(&mut v, 0);
     vec_push_back<u64>(&mut v, 1);
 
@@ -44,7 +44,7 @@ entry fun foo() {
     let e_mut1: &mut u64;
     let e_mut2: &mut u64;
 label b0:
-    v = vec_pack_0<u64>();
+    v = vector<u64; 0>();
     vec_push_back<u64>(&mut v, 0);
     vec_push_back<u64>(&mut v, 1);
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/vector_ops_move_after_borrow.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/vector_ops_move_after_borrow.mvir
@@ -5,7 +5,7 @@ entry fun foo() {
     let v: vector<u64>;
     let e_imm: &u64;
 label b0:
-    v = vec_pack_0<u64>();
+    v = vector<u64; 0>();
     vec_push_back<u64>(&mut v, 0);
     e_imm = vec_imm_borrow<u64>(&v, 0);
 
@@ -21,7 +21,7 @@ entry fun foo() {
     let v: vector<u64>;
     let e_mut: &mut u64;
 label b0:
-    v = vec_pack_0<u64>();
+    v = vector<u64; 0>();
     vec_push_back<u64>(&mut v, 0);
     e_mut = vec_mut_borrow<u64>(&mut v, 0);
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/vector_ops_pop_after_borrow.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/vector_ops_pop_after_borrow.mvir
@@ -5,7 +5,7 @@ entry fun foo() {
     let v: vector<u64>;
     let e_imm: &u64;
 label b0:
-    v = vec_pack_0<u64>();
+    v = vector<u64; 0>();
     vec_push_back<u64>(&mut v, 0);
     e_imm = vec_imm_borrow<u64>(&v, 0);
 
@@ -21,7 +21,7 @@ entry fun foo() {
     let v: vector<u64>;
     let e_mut: &mut u64;
 label b0:
-    v = vec_pack_0<u64>();
+    v = vector<u64; 0>();
     vec_push_back<u64>(&mut v, 0);
     e_mut = vec_mut_borrow<u64>(&mut v, 0);
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/vector_ops_invalid_type_args.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/vector_ops_invalid_type_args.mvir
@@ -3,7 +3,7 @@ mvir 0x42::m {
 
 entry fun foo() {
 label b0:
-    _ = vec_pack_0<u64, bool>();
+    _ = vector<u64, bool; 0>();
     return;
 }
 
@@ -13,7 +13,7 @@ mvir 0x42::m {
 
 entry fun foo() {
 label b0:
-    _ = vec_pack_0<>();
+    _ = vector<; 0>();
     return;
 }
 
@@ -23,7 +23,7 @@ mvir 0x42::m {
 
 entry fun foo() {
 label b0:
-    _ = vec_pack_0<&u64>();
+    _ = vector<&u64; 0>();
     return;
 }
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/vector_ops_invalid_type_args.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/vector_ops_invalid_type_args.snap
@@ -5,25 +5,11 @@ processed 3 tasks
 
 task 0, lines 1-10:
 //# run
-Error: Unable to publish module '0000000000000000000000000000000000000000000000000000000000000042::m'. Got VMError: {
-    major_status: NUMBER_OF_TYPE_ARGUMENTS_MISMATCH,
-    sub_status: None,
-    location: 0x42::m,
-    indices: [(Signature, 0), (FunctionDefinition, 0)],
-    offsets: [],
-    message: "expected 1 type token for vector operations, got 2",
-}
+Error: ParserError: Invalid Token: expected Semicolon, not Comma
 
 task 1, lines 11-20:
 //# run
-Error: Unable to publish module '0000000000000000000000000000000000000000000000000000000000000042::m'. Got VMError: {
-    major_status: NUMBER_OF_TYPE_ARGUMENTS_MISMATCH,
-    sub_status: None,
-    location: 0x42::m,
-    indices: [(Signature, 0), (FunctionDefinition, 0)],
-    offsets: [],
-    message: "expected 1 type token for vector operations, got 0",
-}
+Error: ParserError: Invalid Token: invalid token kind for type Semicolon
 
 task 2, lines 21-30:
 //# run

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/vector_ops_pack_unpack.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/vector_ops_pack_unpack.mvir
@@ -4,7 +4,7 @@ mvir 0x42::m {
 entry fun foo() {
     let v: vector<bool>;
 label b0:
-    v = vec_pack_0<bool>(true);
+    v = vector<bool; 0>(true);
     return;
 }
 
@@ -15,7 +15,7 @@ mvir 0x43::m {
 entry fun foo() {
     let v: vector<bool>;
 label b0:
-    v = vec_pack_1<bool>();
+    v = vector<bool; 1>();
     return;
 }
 
@@ -27,8 +27,8 @@ entry fun foo() {
     let v: vector<bool>;
     let x: bool;
 label b0:
-    v = vec_pack_1<bool>(true);
-    x = vec_unpack_2<bool>(move(v));
+    v = vector<bool; 1>(true);
+    vector<bool; 2>(x, _) = move(v);
     return;
 }
 
@@ -40,8 +40,8 @@ entry fun foo() {
     let v: vector<bool>;
     let x: bool;
 label b0:
-    v = vec_pack_1<bool>(true);
-    x = vec_unpack_0<bool>(move(v));
+    v = vector<bool; 1>(true);
+    vector<bool; 0>(x) = move(v);
     return;
 }
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/vector_ops_pack_unpack.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/vector_ops_pack_unpack.snap
@@ -25,20 +25,14 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
 
 task 2, lines 23-35:
 //# run
-Error: Unable to publish module '0000000000000000000000000000000000000000000000000000000000000044::m'. Got VMError: {
-    major_status: POSITIVE_STACK_SIZE_AT_BLOCK_END,
-    sub_status: None,
+Error: Function execution failed with VMError: {
+    major_status: VECTOR_OPERATION_ERROR,
+    sub_status: Some(3),
     location: 0x44::m,
-    indices: [(FunctionDefinition, 0)],
-    offsets: [(FunctionDefinitionIndex(0), 0)],
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 4)],
 }
 
 task 3, lines 36-48:
 //# run
-Error: Unable to publish module '0000000000000000000000000000000000000000000000000000000000000045::m'. Got VMError: {
-    major_status: NEGATIVE_STACK_SIZE_WITHIN_BLOCK,
-    sub_status: None,
-    location: 0x45::m,
-    indices: [(FunctionDefinition, 0)],
-    offsets: [(FunctionDefinitionIndex(0), 0)],
-}
+Error: ParserError: Invalid Token: vector unpack arity mismatch: expected 0 lvalues, got 1

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/vector_ops_type_mismatch.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/vector_ops_type_mismatch.mvir
@@ -4,7 +4,7 @@ mvir 0x42::m {
 entry fun foo() {
     let v: vector<u8>;
 label b0:
-    v = vec_pack_0<bool>();
+    v = vector<bool; 0>();
     return;
 }
 
@@ -16,7 +16,7 @@ entry fun foo() {
     let v: vector<u8>;
     let v_mut: &mut vector<bool>;
 label b0:
-    v = vec_pack_0<u8>();
+    v = vector<u8; 0>();
     v_mut = &mut v;
 
     return;
@@ -31,7 +31,7 @@ entry fun foo() {
     let v_imm: &vector<u8>;
     let v_len: u8;
 label b0:
-    v = vec_pack_0<u8>();
+    v = vector<u8; 0>();
     v_imm = &v;
     v_len = vec_len<u8>(move(v_imm));
 
@@ -48,7 +48,7 @@ entry fun foo() {
     let e: u64;
 label b0:
     e = 0;
-    v = vec_pack_0<u8>();
+    v = vector<u8; 0>();
     v_mut = &mut v;
     vec_push_back<u8>(move(v_mut), move(e));
 
@@ -64,7 +64,7 @@ entry fun foo() {
     let v_mut: &mut vector<u8>;
     let e: u64;
 label b0:
-    v = vec_pack_0<u8>();
+    v = vector<u8; 0>();
     v_mut = &mut v;
     vec_push_back<u8>(copy(v_mut), 0);
 
@@ -84,7 +84,7 @@ entry fun foo() {
 label b0:
     i1 = 0;
     i2 = 1;
-    v = vec_pack_0<u8>();
+    v = vector<u8; 0>();
     v_mut = &mut v;
     vec_swap<u8>(move(v_mut), move(i1), move(i2));
 
@@ -99,7 +99,7 @@ mvir 0x42::m {
 entry fun foo() {
     let v: vector<bool>;
 label b0:
-    v = vec_pack_1<bool>(28u8);
+    v = vector<bool; 1>(28u8);
     return;
 }
 
@@ -113,8 +113,8 @@ entry fun foo() {
     let x: bool;
     let y: bool;
 label b0:
-    v = vec_pack_2<u8>(1u8, 0u8);
-    x, y = vec_unpack_2<bool>(move(v));
+    v = vector<u8; 2>(1u8, 0u8);
+    vector<bool; 2>(x, y) = move(v);
     return;
 }
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/vector_pack_mismatch.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/vector_pack_mismatch.mvir
@@ -5,7 +5,7 @@ entry fun foo() {
     let v: vector<bool>;
 label b0:
     (1);                // 0
-    vec_pack_1<bool>(); // 1
+    _ = vector<bool; 1>(); // 1
     v = ();             // 2
     return;             // 3
 }
@@ -20,7 +20,7 @@ entry fun foo() {
 label b0:
     (0);                // 0
     (false);            // 1
-    vec_pack_2<bool>(); // 2
+    _ = vector<bool; 2>(); // 2
     v = ();             // 3
     return;             // 4
     return;
@@ -35,7 +35,7 @@ entry fun foo() {
     let v: vector<u8>;
 label b0:
     (1u8, false, 2u8);
-    v = vec_pack_3<u8>();
+    v = vector<u8; 3>();
     return;
 }
 
@@ -48,7 +48,7 @@ entry fun foo() {
     let v: vector<bool>;
 label b0:
     (false, 0, 0, 0);
-    v = vec_pack_3<bool>();
+    v = vector<bool; 3>();
     _ = ();
     return;
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/vector_pack_mismatch.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/vector_pack_mismatch.snap
@@ -6,21 +6,21 @@ processed 4 tasks
 task 0, lines 1-13:
 //# run
 Error: Unable to publish module '0000000000000000000000000000000000000000000000000000000000000042::m'. Got VMError: {
-    major_status: TYPE_MISMATCH,
+    major_status: NEGATIVE_STACK_SIZE_WITHIN_BLOCK,
     sub_status: None,
     location: 0x42::m,
     indices: [(FunctionDefinition, 0)],
-    offsets: [(FunctionDefinitionIndex(0), 1)],
+    offsets: [(FunctionDefinitionIndex(0), 0)],
 }
 
 task 1, lines 15-29:
 //# run
 Error: Unable to publish module '0000000000000000000000000000000000000000000000000000000000000042::m'. Got VMError: {
-    major_status: TYPE_MISMATCH,
+    major_status: NEGATIVE_STACK_SIZE_WITHIN_BLOCK,
     sub_status: None,
     location: 0x42::m,
     indices: [(FunctionDefinition, 0)],
-    offsets: [(FunctionDefinitionIndex(0), 2)],
+    offsets: [(FunctionDefinitionIndex(0), 0)],
 }
 
 task 2, lines 31-42:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/vector_type_param_exploits.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/vector_type_param_exploits.mvir
@@ -33,7 +33,7 @@ mvir 0x42::M3 {
     public fun call(): vector<Self::S<u64>> {
     let x: vector<Self::S<u64>>;
     label b0:
-        x = vec_pack_0<Self::S<u64>>();
+        x = vector<Self::S<u64>; 0>();
         Self::bad_sig(&x);
         return move(x);
     }
@@ -51,7 +51,7 @@ mvir 0x42::M4 {
     public fun call(): vector<Self::S<signer>> {
     let x: vector<Self::S<signer>>;
     label b0:
-        x = vec_pack_0<Self::S<signer>>();
+        x = vector<Self::S<signer>; 0>();
         Self::bad_sig(&x);
         return move(x);
     }

--- a/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/bytecode-generation/expressions/builtins/vector.mvir
+++ b/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/bytecode-generation/expressions/builtins/vector.mvir
@@ -8,7 +8,7 @@ entry fun foo() {
     let e_imm: &u64;
     let e_mut: &mut u64;
 label b0:
-    v = vec_pack_0<u64>();
+    v = vector<u64; 0>();
     v_imm = &v;
     v_len = vec_len<u64>(copy(v_imm));
     _ = move(v_imm);
@@ -27,7 +27,7 @@ label b0:
     _ = vec_pop_back<u64>(copy(v_mut));
     _ = move(v_mut);
 
-    vec_unpack_0<u64>(move(v));
+    vector<u64; 0>() = move(v);
     return;
 }
 }

--- a/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/parsing/vector_pack_missing_arity.mvir
+++ b/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/parsing/vector_pack_missing_arity.mvir
@@ -1,0 +1,10 @@
+//# print-bytecode
+// Vector pack/unpack require an unsigned integer literal arity after `;`.
+mvir 0x42::M {
+    public fun foo() {
+        let v: vector<u64>;
+    label b0:
+        v = vector<u64; >();
+        return;
+    }
+}

--- a/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/parsing/vector_pack_missing_arity.snap
+++ b/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/parsing/vector_pack_missing_arity.snap
@@ -1,0 +1,8 @@
+---
+source: crates/move-transactional-test-runner/src/framework.rs
+---
+processed 1 task
+
+task 0, lines 1-10:
+//# print-bytecode
+Error: ParserError: Invalid Token: expected unsigned integer literal

--- a/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/parsing/vector_unpack_arity_mismatch.mvir
+++ b/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/parsing/vector_unpack_arity_mismatch.mvir
@@ -1,0 +1,13 @@
+//# print-bytecode
+// The bracket count on a vector unpack must match the arity in `#N`.
+// Here we declare arity 2 but provide only 1 LValue, which is a parse error.
+mvir 0x42::M {
+    public fun foo() {
+        let v: vector<u64>;
+        let x: u64;
+    label b0:
+        v = vector<u64; 2>(1, 2);
+        vector<u64; 2>(x) = move(v);
+        return;
+    }
+}

--- a/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/parsing/vector_unpack_arity_mismatch.snap
+++ b/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/parsing/vector_unpack_arity_mismatch.snap
@@ -1,0 +1,8 @@
+---
+source: crates/move-transactional-test-runner/src/framework.rs
+---
+processed 1 task
+
+task 0, lines 1-13:
+//# print-bytecode
+Error: ParserError: Invalid Token: vector unpack arity mismatch: expected 2 lvalues, got 1

--- a/external-crates/move/crates/move-ir-to-bytecode-syntax/src/lexer.rs
+++ b/external-crates/move/crates/move-ir-to-bytecode-syntax/src/lexer.rs
@@ -79,13 +79,11 @@ pub enum Tok {
     Return,
     Struct,
     True,
-    VecPack(u64),
     VecLen,
     VecImmBorrow,
     VecMutBorrow,
     VecPushBack,
     VecPopBack,
-    VecUnpack(u64),
     VecSwap,
     LBrace,
     Pipe,
@@ -248,21 +246,7 @@ impl<'input> Lexer<'input> {
                             "vec_push_back" => (Tok::VecPushBack, len),
                             "vec_pop_back" => (Tok::VecPopBack, len),
                             "vec_swap" => (Tok::VecSwap, len),
-                            _ => {
-                                if let Some(stripped) = name.strip_prefix("vec_pack_") {
-                                    match stripped.parse::<u64>() {
-                                        Ok(num) => (Tok::VecPack(num), len),
-                                        Err(_) => (Tok::NameBeginTyValue, len + 1),
-                                    }
-                                } else if let Some(stripped) = name.strip_prefix("vec_unpack_") {
-                                    match stripped.parse::<u64>() {
-                                        Ok(num) => (Tok::VecUnpack(num), len),
-                                        Err(_) => (Tok::NameBeginTyValue, len + 1),
-                                    }
-                                } else {
-                                    (Tok::NameBeginTyValue, len + 1)
-                                }
-                            }
+                            _ => (Tok::NameBeginTyValue, len + 1),
                         },
                         Some('(') => match name {
                             "assert" => (Tok::Assert, len + 1),

--- a/external-crates/move/crates/move-ir-to-bytecode-syntax/src/syntax.rs
+++ b/external-crates/move/crates/move-ir-to-bytecode-syntax/src/syntax.rs
@@ -450,13 +450,11 @@ fn parse_qualified_function_name(
 ) -> Result<FunctionCall, ParseError<Loc, anyhow::Error>> {
     let start_loc = tokens.start_loc();
     let call = match tokens.peek() {
-        Tok::VecPack(_)
-        | Tok::VecLen
+        Tok::VecLen
         | Tok::VecImmBorrow
         | Tok::VecMutBorrow
         | Tok::VecPushBack
         | Tok::VecPopBack
-        | Tok::VecUnpack(_)
         | Tok::VecSwap
         | Tok::Freeze
         | Tok::ToU8
@@ -598,6 +596,13 @@ fn parse_call(
 // }
 
 fn parse_call_or_term_(tokens: &mut Lexer) -> Result<Exp_, ParseError<Loc, anyhow::Error>> {
+    // `vector<T; N>(args)` — vector pack expression.
+    if is_vector_pack_unpack_prefix(tokens) {
+        let (ty, n) = parse_vector_pack_prefix(tokens)?;
+        let args = parse_call_or_term(tokens)?;
+        return Ok(Exp_::VecPack(ty, n, Box::new(args)));
+    }
+
     let is_module_call = tokens.peek() == Tok::NameValue && tokens.lookahead()? == Tok::ColonColon;
     if is_module_call {
         let f = parse_qualified_function_name(tokens)?;
@@ -620,13 +625,11 @@ fn parse_call_or_term_(tokens: &mut Lexer) -> Result<Exp_, ParseError<Loc, anyho
         };
     }
     match tokens.peek() {
-        Tok::VecPack(_)
-        | Tok::VecLen
+        Tok::VecLen
         | Tok::VecImmBorrow
         | Tok::VecMutBorrow
         | Tok::VecPushBack
         | Tok::VecPopBack
-        | Tok::VecUnpack(_)
         | Tok::VecSwap
         | Tok::Freeze
         | Tok::ToU8
@@ -789,14 +792,66 @@ fn parse_module_name(tokens: &mut Lexer) -> Result<ModuleName, ParseError<Loc, a
 //     "vec_*<" <type_actuals: TypeActuals> ">" =>? { ... },
 //     "freeze" => Builtin::Freeze,
 // }
+//
+// VectorPack (expression):
+//     "vector" "<" <ty: Type> ";" <n: U64> ">" <args: CallOrTerm>
+//         => Exp_::VecPack(ty, n, args)
+//
+// VectorUnpack (statement):
+//     "vector" "<" <ty: Type> ";" <n: U64> ">"
+//         "(" <lvs: Comma<LValue>> ")" "=" <e: Exp> ";"
+//         => Statement_::VecUnpack(ty, n, lvs, e)
+//
+// Pack and unpack share the prefix `vector<T; N>` and disambiguate by
+// position: pack lives in expression position, unpack lives in statement
+// position with `=`. See `parse_vector_pack_prefix`, the dispatch in
+// `parse_call_or_term_`, and `parse_vector_unpack_statement` below.
+
+fn parse_u64_literal(tokens: &mut Lexer) -> Result<u64, ParseError<Loc, anyhow::Error>> {
+    if tokens.peek() != Tok::U64Value {
+        return Err(ParseError::InvalidToken {
+            location: current_token_loc(tokens),
+            message: "expected unsigned integer literal".to_string(),
+        });
+    }
+    let mut s = tokens.content();
+    if s.ends_with("u64") {
+        s = &s[..s.len() - 3];
+    }
+    let n = u64::from_str(s).map_err(|_| ParseError::InvalidToken {
+        location: current_token_loc(tokens),
+        message: format!("invalid u64 literal: {}", s),
+    })?;
+    tokens.advance()?;
+    Ok(n)
+}
+
+// Returns true when the upcoming tokens are the prefix of a vector pack or
+// unpack form: `vector<` (a `NameBeginTyValue` whose content is `"vector<"`).
+// Used to dispatch in expression and statement positions before committing
+// to parsing.
+fn is_vector_pack_unpack_prefix(tokens: &Lexer) -> bool {
+    tokens.peek() == Tok::NameBeginTyValue && tokens.content() == "vector<"
+}
+
+// Parses `vector < <Type> ; <U64> >`, returning (element type, arity).
+// Caller has confirmed via `is_vector_pack_unpack_prefix` that the upcoming
+// tokens are `vector<...`.
+fn parse_vector_pack_prefix(
+    tokens: &mut Lexer,
+) -> Result<(Type, u64), ParseError<Loc, anyhow::Error>> {
+    debug_assert!(is_vector_pack_unpack_prefix(tokens));
+    tokens.advance()?; // consume `vector<` (a single NameBeginTyValue token)
+    let ty = parse_type(tokens)?;
+    consume_token(tokens, Tok::Semicolon)?;
+    let arity = parse_u64_literal(tokens)?;
+    adjust_token(tokens, &[Tok::Greater])?;
+    consume_token(tokens, Tok::Greater)?;
+    Ok((ty, arity))
+}
 
 fn parse_builtin(tokens: &mut Lexer) -> Result<Builtin, ParseError<Loc, anyhow::Error>> {
     match tokens.peek() {
-        Tok::VecPack(num) => {
-            tokens.advance()?;
-            let type_actuals = parse_type_actuals(tokens)?;
-            Ok(Builtin::VecPack(type_actuals, num))
-        }
         Tok::VecLen => {
             tokens.advance()?;
             let type_actuals = parse_type_actuals(tokens)?;
@@ -821,11 +876,6 @@ fn parse_builtin(tokens: &mut Lexer) -> Result<Builtin, ParseError<Loc, anyhow::
             tokens.advance()?;
             let type_actuals = parse_type_actuals(tokens)?;
             Ok(Builtin::VecPopBack(type_actuals))
-        }
-        Tok::VecUnpack(num) => {
-            tokens.advance()?;
-            let type_actuals = parse_type_actuals(tokens)?;
-            Ok(Builtin::VecUnpack(type_actuals, num))
         }
         Tok::VecSwap => {
             tokens.advance()?;
@@ -950,6 +1000,33 @@ fn parse_assign_(tokens: &mut Lexer) -> Result<Statement_, ParseError<Loc, anyho
     Ok(Statement_::Assign(lvalues, e))
 }
 
+// `vector<T; N>(lvalues) = expr;` — vector unpack statement form. Mirrors
+// the shape of struct unpack `Foo<T> { f: var } = expr` (see `parse_unpack_`):
+// same prefix `vector<T; N>` lives in pack/expression position too, but here
+// the parens hold LValues (var / `_` / `*ref`) and the bracket count = arity.
+fn parse_vector_unpack_statement(
+    tokens: &mut Lexer,
+) -> Result<Statement_, ParseError<Loc, anyhow::Error>> {
+    let (ty, n) = parse_vector_pack_prefix(tokens)?;
+    consume_token(tokens, Tok::LParen)?;
+    let lparen_end = tokens.previous_end_loc();
+    let lvalues = parse_comma_list(tokens, &[Tok::RParen], parse_lvalue, true)?;
+    consume_token(tokens, Tok::RParen)?;
+
+    if lvalues.len() as u64 != n {
+        return Err(ParseError::InvalidToken {
+            location: make_loc(tokens.file_hash(), lparen_end, tokens.previous_end_loc()),
+            message: format!(
+                "vector unpack arity mismatch: expected {n} lvalues, got {}",
+                lvalues.len()
+            ),
+        });
+    }
+    consume_token(tokens, Tok::Equal)?;
+    let rhs = parse_exp(tokens)?;
+    Ok(Statement_::VecUnpack(ty, n, lvalues, Box::new(rhs)))
+}
+
 fn parse_unpack_(
     tokens: &mut Lexer,
     name: Symbol,
@@ -1064,7 +1141,8 @@ fn parse_statement_(tokens: &mut Lexer) -> Result<Statement_, ParseError<Loc, an
             // This could be: an LValue for an assignment, a NameAndTypeActuals
             // (with no type_actuals) for an unpack, or a module-qualified
             // function call / variant unpack of the form `M::foo(...)` /
-            // `M::Variant { ... } = e`.
+            // `M::Variant { ... } = e`. Vector unpack `vector<T; N>(lvs) = e`
+            // is dispatched via the `Tok::NameBeginTyValue` arm below.
             match tokens.lookahead()? {
                 Tok::LBrace => {
                     let name = parse_name(tokens)?;
@@ -1113,6 +1191,12 @@ fn parse_statement_(tokens: &mut Lexer) -> Result<Statement_, ParseError<Loc, an
         }
         Tok::Star | Tok::Underscore => parse_assign_(tokens),
         Tok::NameBeginTyValue => {
+            // `vector<T; N>(lvs) = e;` — vector unpack statement form.
+            // Distinguished from struct unpack `Foo<T> { f: x } = e;` by the
+            // `vector<` content of the lex token.
+            if is_vector_pack_unpack_prefix(tokens) {
+                return parse_vector_unpack_statement(tokens);
+            }
             let (name, tys) = parse_name_and_type_actuals(tokens)?;
             parse_unpack_(tokens, name, tys)
         }
@@ -1120,13 +1204,11 @@ fn parse_statement_(tokens: &mut Lexer) -> Result<Statement_, ParseError<Loc, an
             consume_token(tokens, Tok::VariantSwitch)?;
             parse_variant_switch_(tokens)
         }
-        Tok::VecPack(_)
-        | Tok::VecLen
+        Tok::VecLen
         | Tok::VecImmBorrow
         | Tok::VecMutBorrow
         | Tok::VecPushBack
         | Tok::VecPopBack
-        | Tok::VecUnpack(_)
         | Tok::VecSwap
         | Tok::Freeze
         | Tok::ToU8

--- a/external-crates/move/crates/move-ir-to-bytecode/src/compiler.rs
+++ b/external-crates/move/crates/move-ir-to-bytecode/src/compiler.rs
@@ -152,7 +152,7 @@ struct FunctionFrame {
     local_types: Signature,
     // i64 to allow the bytecode verifier to catch errors of
     // - negative stack sizes
-    // - excessivley large stack sizes
+    // - excessively large stack sizes
     // The max stack depth of the file_format is set as u16.
     // Theoretically, we could use a BigInt here, but that is probably overkill for any testing
     max_stack_depth: i64,
@@ -1169,6 +1169,22 @@ fn compile_statement(
                 push_instr!(field_.loc, st_loc);
             }
         }
+        Statement_::VecUnpack(ty, num, lvalues, e) => {
+            // Evaluate the vector expression first (pushes the vector).
+            compile_expression(context, function_frame, code, *e)?;
+
+            let tokens = compile_types(context, function_frame.type_parameters(), &[ty])?;
+            let type_actuals_id = context.signature_index(Signature(tokens))?;
+            push_instr!(statement.loc, Bytecode::VecUnpack(type_actuals_id, num));
+
+            function_frame.pop()?; // pop the vector
+            for _ in 0..num {
+                function_frame.push()?; // each unpacked element
+            }
+
+            // Bind each unpacked value to its LValue (LIFO via compile_lvalues).
+            compile_lvalues(context, function_frame, code, lvalues)?;
+        }
         Statement_::UnpackVariant(name, variant_name, tys, bindings, e, unpack_type) => {
             let tokens = Signature(compile_types(
                 context,
@@ -1394,6 +1410,21 @@ fn compile_expression(
             }
             function_frame.push()?;
         }
+        Exp_::VecPack(ty, num, args) => {
+            // Evaluate the args expression first; the args are expected to
+            // push exactly `num` values onto the stack (typically an
+            // ExprList of `num` expressions).
+            compile_expression(context, function_frame, code, *args)?;
+
+            let tokens = compile_types(context, function_frame.type_parameters(), &[ty])?;
+            let type_actuals_id = context.signature_index(Signature(tokens))?;
+            push_instr!(exp.loc, Bytecode::VecPack(type_actuals_id, num));
+
+            for _ in 0..num {
+                function_frame.pop()?;
+            }
+            function_frame.push()?; // push the resulting vector
+        }
         Exp_::UnaryExp(op, e) => {
             compile_expression(context, function_frame, code, *e)?;
             match op {
@@ -1579,16 +1610,6 @@ fn compile_call(
     match call.value {
         FunctionCall_::Builtin(function) => {
             match function {
-                Builtin::VecPack(tys, num) => {
-                    let tokens = compile_types(context, function_frame.type_parameters(), &tys)?;
-                    let type_actuals_id = context.signature_index(Signature(tokens))?;
-                    push_instr!(call.loc, Bytecode::VecPack(type_actuals_id, num));
-
-                    for _ in 0..num {
-                        function_frame.pop()?;
-                    }
-                    function_frame.push()?; // push the return value
-                }
                 Builtin::VecLen(tys) => {
                     let tokens = compile_types(context, function_frame.type_parameters(), &tys)?;
                     let type_actuals_id = context.signature_index(Signature(tokens))?;
@@ -1630,16 +1651,6 @@ fn compile_call(
 
                     function_frame.pop()?; // pop the vector ref
                     function_frame.push()?; // push the value
-                }
-                Builtin::VecUnpack(tys, num) => {
-                    let tokens = compile_types(context, function_frame.type_parameters(), &tys)?;
-                    let type_actuals_id = context.signature_index(Signature(tokens))?;
-                    push_instr!(call.loc, Bytecode::VecUnpack(type_actuals_id, num));
-
-                    function_frame.pop()?; // pop the vector ref
-                    for _ in 0..num {
-                        function_frame.push()?;
-                    }
                 }
                 Builtin::VecSwap(tys) => {
                     let tokens = compile_types(context, function_frame.type_parameters(), &tys)?;

--- a/external-crates/move/crates/move-ir-types/src/ast.rs
+++ b/external-crates/move/crates/move-ir-types/src/ast.rs
@@ -396,8 +396,6 @@ pub type Function = Spanned<Function_>;
 /// type system and/or have access to some runtime/storage context
 #[derive(Debug, PartialEq, Clone)]
 pub enum Builtin {
-    /// Pack a vector fix a fixed number of elements. Zero elements means an empty vector.
-    VecPack(Vec<Type>, u64),
     /// Get the length of a vector
     VecLen(Vec<Type>),
     /// Acquire an immutable reference to the element at a given index of the vector
@@ -408,8 +406,6 @@ pub enum Builtin {
     VecPushBack(Vec<Type>),
     /// Pop and return an element from the end of the vector
     VecPopBack(Vec<Type>),
-    /// Destroy a vector of a fixed length. Zero length means destroying an empty vector.
-    VecUnpack(Vec<Type>, u64),
     /// Swap the elements at twi indices in the vector
     VecSwap(Vec<Type>),
 
@@ -486,6 +482,10 @@ pub enum Statement_ {
     JumpIfFalse(Box<Exp>, BlockLabel),
     /// `n { f_1: x_1, ... , f_j: x_j  } = e`
     Unpack(DatatypeName, Vec<Type>, Fields<Var>, Box<Exp>),
+    /// Destroy a vector of a fixed length, binding each popped value to the
+    /// corresponding LValue: `vector<T; N>(lv_1, ..., lv_N) = e`. The
+    /// `Box<Exp>` is the input vector expression.
+    VecUnpack(Type, u64, Vec<LValue>, Box<Exp>),
     /// `e::v { f_1: x_1, ... , f_j: x_j  } = e`
     UnpackVariant(
         DatatypeName,
@@ -619,6 +619,10 @@ pub enum Exp_ {
     /// as the current struct class (i.e., the class of the method we're currently executing).
     /// `n { f_1: e_1, ... , f_j: e_j }`
     Pack(DatatypeName, Vec<Type>, ExpFields),
+    /// Pack a vector of a fixed number of elements: `vector<T; N>(<args>)`. The
+    /// `Box<Exp>` is the args expression (typically an `ExprList`) supplying
+    /// the N stack values to pack.
+    VecPack(Type, u64, Box<Exp>),
     /// `&e.f`, `&mut e.f`
     Borrow {
         /// mutable or not
@@ -1455,15 +1459,11 @@ impl fmt::Display for Var_ {
 impl fmt::Display for Builtin {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Builtin::VecPack(tys, num) => write!(f, "vec_pack_{}{}", num, format_type_actuals(tys)),
             Builtin::VecLen(tys) => write!(f, "vec_len{}", format_type_actuals(tys)),
             Builtin::VecImmBorrow(tys) => write!(f, "vec_imm_borrow{}", format_type_actuals(tys)),
             Builtin::VecMutBorrow(tys) => write!(f, "vec_mut_borrow{}", format_type_actuals(tys)),
             Builtin::VecPushBack(tys) => write!(f, "vec_push_back{}", format_type_actuals(tys)),
             Builtin::VecPopBack(tys) => write!(f, "vec_pop_back{}", format_type_actuals(tys)),
-            Builtin::VecUnpack(tys, num) => {
-                write!(f, "vec_unpack_{}{}", num, format_type_actuals(tys))
-            }
             Builtin::VecSwap(tys) => write!(f, "vec_swap{}", format_type_actuals(tys)),
             Builtin::Freeze => write!(f, "freeze"),
             Builtin::ToU8 => write!(f, "to_u8"),
@@ -1545,6 +1545,14 @@ impl fmt::Display for Statement_ {
                         "{} {} : {},",
                         acc, field, var
                     )),
+                e
+            ),
+            Statement_::VecUnpack(ty, n, lvalues, e) => write!(
+                f,
+                "vector<{}; {}>({}) = {};",
+                ty,
+                n,
+                intersperse(lvalues, ", "),
                 e
             ),
             Statement_::UnpackVariant(name, variant_name, tys, bindings, e, unpack_type) => {
@@ -1671,6 +1679,7 @@ impl fmt::Display for Exp_ {
                     acc, field, op,
                 ))
             ),
+            Exp_::VecPack(ty, n, args) => write!(f, "vector<{}; {}>{}", ty, n, args),
             Exp_::Borrow {
                 is_mutable,
                 exp,

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/builtins/vector_ops_all_ok.mvir
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/builtins/vector_ops_all_ok.mvir
@@ -10,7 +10,7 @@ entry fun foo() {
     let e_mut: &mut u64;
     let e_val: u64;
 label b0:
-    v = vec_pack_0<u64>();
+    v = vector<u64; 0>();
     v_imm = &v;
     v_len = vec_len<u64>(copy(v_imm));
     assert(move(v_len) == 0, 1);
@@ -41,7 +41,7 @@ label b0:
     assert(move(v_len) == 0, 6);
     _ = move(v_mut);
 
-    vec_unpack_0<u64>(move(v));
+    vector<u64; 0>() = move(v);
     return;
 }
 

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/builtins/vector_ops_borrow_and_modify_ok.mvir
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/builtins/vector_ops_borrow_and_modify_ok.mvir
@@ -4,7 +4,7 @@ mvir 0x5::M {
     public fun new(): vector<u64> {
         let v: vector<u64>;
     label b0:
-        v = vec_pack_1<u64>(100);
+        v = vector<u64; 1>(100);
         vec_push_back<u64>(&mut v, 200);
         return move(v);
     }

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/builtins/vector_ops_bound_ok.mvir
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/builtins/vector_ops_bound_ok.mvir
@@ -4,7 +4,7 @@ mvir 0x6::m {
 entry fun foo() {
     let v: vector<u64>;
 label b0:
-    v = vec_pack_0<u64>();
+    v = vector<u64; 0>();
     vec_push_back<u64>(&mut v, 0);
     _ = vec_imm_borrow<u64>(&v, 0);
 
@@ -18,7 +18,7 @@ mvir 0x7::m {
 entry fun foo() {
     let v: vector<u64>;
 label b0:
-    v = vec_pack_1<u64>(42);
+    v = vector<u64; 1>(42);
     _ = vec_imm_borrow<u64>(&v, 0);
 
     return;
@@ -31,7 +31,7 @@ mvir 0x8::m {
 entry fun foo() {
     let v: vector<u64>;
 label b0:
-    v = vec_pack_0<u64>();
+    v = vector<u64; 0>();
     vec_push_back<u64>(&mut v, 0);
     _ = vec_mut_borrow<u64>(&mut v, 0);
 
@@ -45,7 +45,7 @@ mvir 0x9::m {
 entry fun foo() {
     let v: vector<u64>;
 label b0:
-    v = vec_pack_1<u64>(42);
+    v = vector<u64; 1>(42);
     _ = vec_mut_borrow<u64>(&mut v, 0);
 
     return;
@@ -58,7 +58,7 @@ mvir 0xa::m {
 entry fun foo() {
     let v: vector<u64>;
 label b0:
-    v = vec_pack_0<u64>();
+    v = vector<u64; 0>();
     vec_push_back<u64>(&mut v, 0);
     vec_swap<u64>(&mut v, 0, 0);
 
@@ -72,7 +72,7 @@ mvir 0xb::m {
 entry fun foo() {
     let v: vector<u64>;
 label b0:
-    v = vec_pack_1<u64>(42);
+    v = vector<u64; 1>(42);
     vec_swap<u64>(&mut v, 0, 0);
 
     return;

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/builtins/vector_ops_len_ok.mvir
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/builtins/vector_ops_len_ok.mvir
@@ -4,7 +4,7 @@ mvir 0x5::m {
 entry fun foo() {
     let v: vector<u64>;
 label b0:
-    v = vec_pack_0<u64>();
+    v = vector<u64; 0>();
     assert(vec_len<u64>(&v) == 0, 0);
 
     return;
@@ -17,7 +17,7 @@ mvir 0x6::m {
 entry fun foo() {
     let v: vector<u64>;
 label b0:
-    v = vec_pack_1<u64>(42);
+    v = vector<u64; 1>(42);
     assert(vec_len<u64>(&v) == 1, 1);
 
     return;
@@ -30,7 +30,7 @@ mvir 0x7::m {
 entry fun foo() {
     let v: vector<u64>;
 label b0:
-    v = vec_pack_2<u64>(42, 43);
+    v = vector<u64; 2>(42, 43);
     assert(vec_len<u64>(&v) == 2, 2);
 
     return;

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/builtins/vector_ops_out_of_bound.mvir
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/builtins/vector_ops_out_of_bound.mvir
@@ -4,7 +4,7 @@ mvir 0x5::m {
 entry fun foo() {
     let v: vector<u64>;
 label b0:
-    v = vec_pack_0<u64>();
+    v = vector<u64; 0>();
     vec_push_back<u64>(&mut v, 0);
     _ = vec_imm_borrow<u64>(&v, 1);
 
@@ -18,7 +18,7 @@ mvir 0x6::m {
 entry fun foo() {
     let v: vector<u64>;
 label b0:
-    v = vec_pack_0<u64>();
+    v = vector<u64; 0>();
     vec_push_back<u64>(&mut v, 0);
     _ = vec_mut_borrow<u64>(&mut v, 1);
 
@@ -32,7 +32,7 @@ mvir 0x7::m {
 entry fun foo() {
     let v: vector<u64>;
 label b0:
-    v = vec_pack_0<u64>();
+    v = vector<u64; 0>();
     vec_swap<u64>(&mut v, 0, 1);
 
     return;

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/builtins/vector_ops_pack_unpack_ok.mvir
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/builtins/vector_ops_pack_unpack_ok.mvir
@@ -6,9 +6,9 @@ entry fun foo() {
     let v2: vector<u64>;
     let e: u64;
 label b0:
-    v1 = vec_pack_1<u64>(42);
-    e = vec_unpack_1<u64>(move(v1));
-    v2 = vec_pack_1<u64>(move(e));
+    v1 = vector<u64; 1>(42);
+    vector<u64; 1>(e) = move(v1);
+    v2 = vector<u64; 1>(move(e));
     assert(*vec_imm_borrow<u64>(&v2, 0) == 42, 42);
 
     return;
@@ -24,9 +24,9 @@ entry fun foo() {
     let e1: u64;
     let e2: u64;
 label b0:
-    v1 = vec_pack_2<u64>(42, 43);
-    e1, e2 = vec_unpack_2<u64>(move(v1));
-    v2 = vec_pack_2<u64>(move(e1), move(e2));
+    v1 = vector<u64; 2>(42, 43);
+    vector<u64; 2>(e1, e2) = move(v1);
+    v2 = vector<u64; 2>(move(e1), move(e2));
     assert(*vec_imm_borrow<u64>(&v2, 0) == 42, 42);
     assert(*vec_imm_borrow<u64>(&v2, 1) == 43, 43);
 

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/builtins/vector_ops_pop_empty.mvir
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/builtins/vector_ops_pop_empty.mvir
@@ -4,7 +4,7 @@ mvir 0x5::m {
 entry fun foo() {
     let v: vector<u64>;
 label b0:
-    v = vec_pack_0<u64>();
+    v = vector<u64; 0>();
     _ = vec_pop_back<u64>(&mut v);
 
     return;
@@ -17,7 +17,7 @@ mvir 0x6::m {
 entry fun foo() {
     let v: vector<u64>;
 label b0:
-    v = vec_pack_1<u64>(42);
+    v = vector<u64; 1>(42);
     _ = vec_pop_back<u64>(&mut v);
     _ = vec_pop_back<u64>(&mut v);
 

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/builtins/vector_ops_pop_ok.mvir
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/builtins/vector_ops_pop_ok.mvir
@@ -4,7 +4,7 @@ mvir 0x5::m {
 entry fun foo() {
     let v: vector<u64>;
 label b0:
-    v = vec_pack_1<u64>(42);
+    v = vector<u64; 1>(42);
     _ = vec_pop_back<u64>(&mut v);
 
     return;
@@ -18,7 +18,7 @@ mvir 0x6::m {
 entry fun foo() {
     let v: vector<u64>;
 label b0:
-    v = vec_pack_2<u64>(42, 43);
+    v = vector<u64; 2>(42, 43);
     _ = vec_pop_back<u64>(&mut v);
     _ = vec_pop_back<u64>(&mut v);
 

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/builtins/vector_ops_unpack_less.mvir
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/builtins/vector_ops_unpack_less.mvir
@@ -4,8 +4,8 @@ mvir 0x5::m {
 entry fun foo() {
     let v: vector<u64>;
 label b0:
-    v = vec_pack_1<u64>(42);
-    vec_unpack_0<u64>(move(v));
+    v = vector<u64; 1>(42);
+    vector<u64; 0>() = move(v);
 
     return;
 }
@@ -17,8 +17,8 @@ mvir 0x6::m {
 entry fun foo() {
     let v: vector<u64>;
 label b0:
-    v = vec_pack_2<u64>(42, 43);
-    _ = vec_unpack_1<u64>(move(v));
+    v = vector<u64; 2>(42, 43);
+    vector<u64; 1>(_) = move(v);
 
     return;
 }
@@ -30,9 +30,9 @@ mvir 0x7::m {
 entry fun foo() {
     let v: vector<u64>;
 label b0:
-    v = vec_pack_1<u64>(42);
+    v = vector<u64; 1>(42);
     vec_push_back<u64>(&mut v, 43);
-    _ = vec_unpack_1<u64>(move(v));
+    vector<u64; 1>(_) = move(v);
 
     return;
 }

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/builtins/vector_ops_unpack_more.mvir
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/builtins/vector_ops_unpack_more.mvir
@@ -4,8 +4,8 @@ mvir 0x5::m {
 entry fun foo() {
     let v: vector<u64>;
 label b0:
-    v = vec_pack_0<u64>();
-    _ = vec_unpack_1<u64>(move(v));
+    v = vector<u64; 0>();
+    vector<u64; 1>(_) = move(v);
 
     return;
 }
@@ -17,8 +17,8 @@ mvir 0x6::m {
 entry fun foo() {
     let v: vector<u64>;
 label b0:
-    v = vec_pack_1<u64>(42);
-    _, _ = vec_unpack_2<u64>(move(v));
+    v = vector<u64; 1>(42);
+    vector<u64; 2>(_, _) = move(v);
 
     return;
 }
@@ -30,9 +30,9 @@ mvir 0x7::m {
 entry fun foo() {
     let v: vector<u64>;
 label b0:
-    v = vec_pack_1<u64>(42);
+    v = vector<u64; 1>(42);
     _ = vec_pop_back<u64>(&mut v);
-    _ = vec_unpack_1<u64>(move(v));
+    vector<u64; 1>(_) = move(v);
 
     return;
 }

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/builtins/vector_ops_unpack_ok.mvir
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/builtins/vector_ops_unpack_ok.mvir
@@ -4,8 +4,8 @@ mvir 0x5::m {
 entry fun foo() {
     let v: vector<u64>;
 label b0:
-    v = vec_pack_1<u64>(42);
-    _ = vec_unpack_1<u64>(move(v));
+    v = vector<u64; 1>(42);
+    vector<u64; 1>(_) = move(v);
 
     return;
 }
@@ -17,8 +17,8 @@ mvir 0x6::m {
 entry fun foo() {
     let v: vector<u64>;
 label b0:
-    v = vec_pack_2<u64>(42, 43);
-    _, _ = vec_unpack_2<u64>(move(v));
+    v = vector<u64; 2>(42, 43);
+    vector<u64; 2>(_, _) = move(v);
 
     return;
 }
@@ -30,9 +30,9 @@ mvir 0x7::m {
 entry fun foo() {
     let v: vector<u64>;
 label b0:
-    v = vec_pack_1<u64>(42);
+    v = vector<u64; 1>(42);
     vec_push_back<u64>(&mut v, 43);
-    _, _ = vec_unpack_2<u64>(move(v));
+    vector<u64; 2>(_, _) = move(v);
 
     return;
 }
@@ -45,9 +45,9 @@ mvir 0x8::m {
 entry fun foo() {
     let v: vector<u64>;
 label b0:
-    v = vec_pack_1<u64>(42);
+    v = vector<u64; 1>(42);
     _ = vec_pop_back<u64>(&mut v);
-    vec_unpack_0<u64>(move(v));
+    vector<u64; 0>() = move(v);
 
     return;
 }

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/builtins/vector_ops_using_generics.mvir
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/builtins/vector_ops_using_generics.mvir
@@ -5,7 +5,7 @@ mvir 0x42::Tests {
     public fun test<T: copy + drop>(x: T) {
         let v: vector<T>;
         label l0:
-        v = vec_pack_0<T>();
+        v = vector<T; 0>();
         assert(vec_len<T>(&v) == 0, 42);
         vec_push_back<T>(&mut v, copy(x));
         vec_push_back<T>(&mut v, copy(x));
@@ -14,7 +14,7 @@ mvir 0x42::Tests {
         _ = vec_mut_borrow<T>(&mut v, 0);
         _ = vec_pop_back<T>(&mut v);
         _ = vec_pop_back<T>(&mut v);
-        vec_unpack_0<T>(move(v));
+        vector<T; 0>() = move(v);
         return;
     }
 }

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/instructions/inaccessible_borrowed_local.mvir
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/instructions/inaccessible_borrowed_local.mvir
@@ -7,10 +7,10 @@ entry fun foo() {
     label start:
         jump_if_false (true) end;
     label if_true:
-        x = vec_pack_0<u64>();
+        x = vector<u64; 0>();
         r = &x;
     label end:
-        x = vec_pack_0<u64>();
+        x = vector<u64; 0>();
         return;
 }
 
@@ -22,7 +22,7 @@ entry fun foo() {
     let x: vector<u64>;
     let r: &vector<u64>;
     label start:
-        x = vec_pack_0<u64>();
+        x = vector<u64; 0>();
         jump_if_false (true) end;
     label if_true:
         r = &x;

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/native_functions/vector_module.mvir
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/native_functions/vector_module.mvir
@@ -49,7 +49,7 @@ mvir 0x42::M {
         Coin::destroy(vec_pop_back<Coin::Coin>(&mut f));
         jump loop;
     label end:
-        vec_unpack_0<Coin::Coin>(move(f));
+        vector<Coin::Coin; 0>() = move(f);
         return;
     }
 

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/references/unpack_vec_with_unreachable_ref.mvir
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/references/unpack_vec_with_unreachable_ref.mvir
@@ -12,12 +12,12 @@ entry fun foo() {
     let unpacked: Self::S;
 label b0:
     s = S { f: 0 };
-    v = vec_pack_1<Self::S>(copy(s));
+    v = vector<Self::S; 1>(copy(s));
     jump_if_false (true) b_join;
 label b_ref:
     er = vec_imm_borrow<Self::S>(&v, 0);
 label b_join:
-    unpacked = vec_unpack_1<Self::S>(move(v));
+    vector<Self::S; 1>(unpacked) = move(v);
     assert(move(unpacked) == copy(s), 1);
     return;
 }

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/references/vec_pop_back_with_unreachable_ref.mvir
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/references/vec_pop_back_with_unreachable_ref.mvir
@@ -13,7 +13,7 @@ entry fun foo() {
     let popped: Self::S;
 label b0:
     s = S { f: 0 };
-    v = vec_pack_1<Self::S>(copy(s));
+    v = vector<Self::S; 1>(copy(s));
     jump_if_false (true) b_join;
 label b_ref:
     er = vec_imm_borrow<Self::S>(&v, 0);


### PR DESCRIPTION
## Description 

- Changes vector pack/unpack from a builtin function with "infinite" identifiers, to a syntax of `vector<type; size>` for both pack and unpack

## Test plan 

- Updated tests 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
