### PR TITLE
[graphql] Add TransactionEffects.version field

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transaction_effects/version.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transaction_effects/version.move
@@ -1,0 +1,17 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 108 --accounts A B --simulator
+
+//# programmable --sender A --inputs 100 @B
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+
+//# create-checkpoint
+
+//# run-graphql
+{ # Test version field exposes the effects schema discriminator (V1 -> 1, V2 -> 2)
+  transaction: transactionEffects(digest: "@{digest_1}") {
+    version
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transaction_effects/version.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transaction_effects/version.snap
@@ -1,0 +1,29 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 4 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 6-8:
+//# programmable --sender A --inputs 100 @B
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+created: object(1,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, line 10:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 3, lines 12-17:
+//# run-graphql
+Response: {
+  "data": {
+    "transaction": {
+      "version": 2
+    }
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_execute_transaction_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_execute_transaction_tests.rs
@@ -648,6 +648,7 @@ async fn test_execute_transaction_effects_json() {
                 executeTransaction(transactionDataBcs: $txData, signatures: $sigs) {
                     effects {
                         status
+                        version
                         effectsJson
                         balanceChangesJson
                     }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_simulate_transaction_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_simulate_transaction_tests.rs
@@ -1181,6 +1181,7 @@ async fn test_simulate_transaction_effects_json() {
                 simulateTransaction(transaction: $txData) {
                     effects {
                         status
+                        version
                         effectsJson
                         balanceChangesJson
                     }

--- a/crates/sui-indexer-alt-e2e-tests/tests/snapshots/graphql_execute_transaction_tests__execute_transaction_effects_json.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/snapshots/graphql_execute_transaction_tests__execute_transaction_effects_json.snap
@@ -5,6 +5,7 @@ expression: "result.pointer(\"/data/executeTransaction\")"
 {
   "effects": {
     "status": "SUCCESS",
+    "version": 2,
     "effectsJson": {
       "digest": "[digest]",
       "version": 2,

--- a/crates/sui-indexer-alt-e2e-tests/tests/snapshots/graphql_simulate_transaction_tests__simulate_transaction_effects_json.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/snapshots/graphql_simulate_transaction_tests__simulate_transaction_effects_json.snap
@@ -5,6 +5,7 @@ expression: "result.pointer(\"/data/simulateTransaction\")"
 {
   "effects": {
     "status": "SUCCESS",
+    "version": 2,
     "effectsJson": {
       "digest": "[digest]",
       "version": 2,

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -4234,6 +4234,10 @@ type TransactionEffects {
 	The unchanged consensus-managed objects that were referenced by this transaction.
 	"""
 	unchangedConsensusObjects(first: Int, after: String, last: Int, before: String): UnchangedConsensusObjectConnection
+	"""
+	The schema version of the effects struct.
+	"""
+	version: Int
 }
 
 input TransactionFilter {

--- a/crates/sui-indexer-alt-graphql/src/api/types/snapshots/sui_indexer_alt_graphql__api__types__available_range__field_piplines_tests__registry_collect_pipelines_snapshot.snap
+++ b/crates/sui-indexer-alt-graphql/src/api/types/snapshots/sui_indexer_alt_graphql__api__types__available_range__field_piplines_tests__registry_collect_pipelines_snapshot.snap
@@ -1682,6 +1682,9 @@ TransactionEffects.checkpoint
 TransactionEffects.status
   => {}
 
+TransactionEffects.version
+  => {}
+
 TransactionEffects.lamportVersion
   => {}
 

--- a/crates/sui-indexer-alt-graphql/src/api/types/snapshots/sui_indexer_alt_graphql__api__types__available_range__field_piplines_tests__registry_collect_pipelines_snapshot_staging.snap
+++ b/crates/sui-indexer-alt-graphql/src/api/types/snapshots/sui_indexer_alt_graphql__api__types__available_range__field_piplines_tests__registry_collect_pipelines_snapshot_staging.snap
@@ -1691,6 +1691,9 @@ TransactionEffects.checkpoint
 TransactionEffects.status
   => {}
 
+TransactionEffects.version
+  => {}
+
 TransactionEffects.lamportVersion
   => {}
 

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
@@ -20,6 +20,7 @@ use sui_indexer_alt_schema::transactions::BalanceChange as StoredBalanceChange;
 use sui_rpc::proto::sui::rpc::v2::BalanceChange as GrpcBalanceChange;
 use sui_rpc::proto::sui::rpc::v2::ExecutedTransaction;
 use sui_types::digests::TransactionDigest;
+use sui_types::effects::TransactionEffects as NativeTransactionEffects;
 use sui_types::effects::TransactionEffectsAPI;
 use sui_types::execution_status::ExecutionStatus as NativeExecutionStatus;
 use sui_types::signature::GenericSignature;
@@ -119,6 +120,21 @@ impl EffectsContents {
                 .map(|effects| match effects.status() {
                     NativeExecutionStatus::Success => ExecutionStatus::Success,
                     NativeExecutionStatus::Failure(_) => ExecutionStatus::Failure,
+                })
+                .map_err(RpcError::from),
+        )
+    }
+
+    /// The schema version of the effects struct.
+    async fn version(&self) -> Option<Result<i32, RpcError>> {
+        let content = self.contents.as_ref()?;
+
+        Some(
+            content
+                .effects()
+                .map(|effects| match effects {
+                    NativeTransactionEffects::V1(_) => 1i32,
+                    NativeTransactionEffects::V2(_) => 2,
                 })
                 .map_err(RpcError::from),
         )

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -4238,6 +4238,10 @@ type TransactionEffects {
 	The unchanged consensus-managed objects that were referenced by this transaction.
 	"""
 	unchangedConsensusObjects(first: Int, after: String, last: Int, before: String): UnchangedConsensusObjectConnection
+	"""
+	The schema version of the effects struct.
+	"""
+	version: Int
 }
 
 input TransactionFilter {

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -4267,6 +4267,10 @@ type TransactionEffects {
 	The unchanged consensus-managed objects that were referenced by this transaction.
 	"""
 	unchangedConsensusObjects(first: Int, after: String, last: Int, before: String): UnchangedConsensusObjectConnection
+	"""
+	The schema version of the effects struct.
+	"""
+	version: Int
 }
 
 input TransactionFilter {

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -4263,6 +4263,10 @@ type TransactionEffects {
 	The unchanged consensus-managed objects that were referenced by this transaction.
 	"""
 	unchangedConsensusObjects(first: Int, after: String, last: Int, before: String): UnchangedConsensusObjectConnection
+	"""
+	The schema version of the effects struct.
+	"""
+	version: Int
 }
 
 input TransactionFilter {


### PR DESCRIPTION
## Summary
- Adds typed TransactionEffects.version returning 1 or 2 (the effects schema discriminator).
- Closes a parity gap with the gRPC SimulateTransactionResponse, where this field is exposed but the GraphQL schema only had it nested inside effectsJson.

## Test plan
- unit + e2e tests

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [x] GraphQL: Adding new TransactionEffects.version field for typed TransactionEffects version (v1, v2, etc)
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework: