### PR TITLE
typed-store: additional tidehunter memory env knobs

### DIFF
--- a/crates/sui-core/src/authority/authority_store_tables.rs
+++ b/crates/sui-core/src/authority/authority_store_tables.rs
@@ -256,7 +256,9 @@ impl AuthorityPerpetualTables {
                     owned_object_transaction_locks_indexing,
                     mutexes * 16,
                     KeyType::uniform(default_cells_per_mutex()),
-                    bloom_config.clone().with_max_dirty_keys(16 * default_max_dirty_keys()),
+                    bloom_config
+                        .clone()
+                        .with_max_dirty_keys(16 * default_max_dirty_keys()),
                 ),
             ),
             (

--- a/crates/sui-core/src/authority/authority_store_tables.rs
+++ b/crates/sui-core/src/authority/authority_store_tables.rs
@@ -195,7 +195,8 @@ impl AuthorityPerpetualTables {
         tracing::warn!("AuthorityPerpetualTables using tidehunter");
         use typed_store::tidehunter_util::{
             Bytes, Decision, KeyIndexing, KeySpaceConfig, KeyType, ThConfig,
-            default_cells_per_mutex, default_mutex_count, default_value_cache_size,
+            default_cells_per_mutex, default_max_dirty_keys, default_mutex_count,
+            default_value_cache_size,
         };
         let mutexes = default_mutex_count() * 2;
         let transaction_mutexes = mutexes * 4;
@@ -233,7 +234,7 @@ impl AuthorityPerpetualTables {
             KeyIndexing::key_reduction(obj_ref_size, 16..(obj_ref_size - 16));
 
         let mut objects_config = KeySpaceConfig::new()
-            .with_max_dirty_keys(4096)
+            .with_max_dirty_keys(4 * default_max_dirty_keys())
             .with_value_cache_size(value_cache_size);
         if matches!(db_options_override, Some(options) if options.is_validator) {
             objects_config = objects_config.with_compactor(Box::new(objects_compactor));
@@ -255,7 +256,7 @@ impl AuthorityPerpetualTables {
                     owned_object_transaction_locks_indexing,
                     mutexes * 16,
                     KeyType::uniform(default_cells_per_mutex()),
-                    bloom_config.clone().with_max_dirty_keys(16192),
+                    bloom_config.clone().with_max_dirty_keys(16 * default_max_dirty_keys()),
                 ),
             ),
             (

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -226,12 +226,12 @@ impl CheckpointStoreTables {
         use crate::authority::authority_store_pruner::apply_relocation_filter;
         use typed_store::tidehunter_util::{
             Decision, KeySpaceConfig, KeyType, ThConfig, default_cells_per_mutex,
-            default_mutex_count, default_value_cache_size,
+            default_max_dirty_keys, default_mutex_count, default_value_cache_size,
         };
         let mutexes = default_mutex_count();
         let u64_sequence_key = KeyType::from_prefix_bits(6 * 8);
         let override_dirty_keys_config = KeySpaceConfig::new()
-            .with_max_dirty_keys(16_000)
+            .with_max_dirty_keys(16 * default_max_dirty_keys())
             .with_value_cache_size(default_value_cache_size());
         let config_u64 = ThConfig::new_with_config(
             8,

--- a/crates/typed-store/src/tidehunter_util.rs
+++ b/crates/typed-store/src/tidehunter_util.rs
@@ -111,10 +111,10 @@ fn thdb_config() -> Config {
         frag_size,
         // run snapshot every 64 Gb written to wal
         snapshot_written_bytes: parse_env_usize("TH_SNAPSHOT_WRITTEN_BYTES", 1)
-            .unwrap_or(64u64 as usize * 1024 * 1024 * 1024),
+            .unwrap_or(64 * 1024 * 1024 * 1024) as u64,
         // force unloading dirty index entries if behind 60 Gb of wal
         snapshot_unload_threshold: parse_env_usize("TH_SNAPSHOT_UNLOAD_THRESHOLD", 1)
-            .unwrap_or(60u64 as usize * 1024 * 1024 * 1024),
+            .unwrap_or(60 * 1024 * 1024 * 1024) as u64,
         unload_jitter_pct: 30,
         max_dirty_keys: default_max_dirty_keys(),
         max_maps,

--- a/crates/typed-store/src/tidehunter_util.rs
+++ b/crates/typed-store/src/tidehunter_util.rs
@@ -111,10 +111,10 @@ fn thdb_config() -> Config {
         frag_size,
         // run snapshot every 64 Gb written to wal
         snapshot_written_bytes: parse_env_usize("TH_SNAPSHOT_WRITTEN_BYTES", 1)
-            .unwrap_or(64 * 1024 * 1024 * 1024),
+            .unwrap_or(64u64 as usize * 1024 * 1024 * 1024),
         // force unloading dirty index entries if behind 60 Gb of wal
         snapshot_unload_threshold: parse_env_usize("TH_SNAPSHOT_UNLOAD_THRESHOLD", 1)
-            .unwrap_or(60 * 1024 * 1024 * 1024),
+            .unwrap_or(60u64 as usize * 1024 * 1024 * 1024),
         unload_jitter_pct: 30,
         max_dirty_keys: default_max_dirty_keys(),
         max_maps,

--- a/crates/typed-store/src/tidehunter_util.rs
+++ b/crates/typed-store/src/tidehunter_util.rs
@@ -69,7 +69,7 @@ fn parse_env_usize(name: &str, minimum: usize) -> Option<usize> {
     })
 }
 
-fn default_max_dirty_keys() -> usize {
+pub fn default_max_dirty_keys() -> usize {
     parse_env_usize("TH_DEFAULT_MAX_DIRTY_KEYS", 1).unwrap_or(1024)
 }
 
@@ -110,9 +110,11 @@ fn thdb_config() -> Config {
     Config {
         frag_size,
         // run snapshot every 64 Gb written to wal
-        snapshot_written_bytes: 64 * 1024 * 1024 * 1024,
+        snapshot_written_bytes: parse_env_usize("TH_SNAPSHOT_WRITTEN_BYTES", 1)
+            .unwrap_or(64 * 1024 * 1024 * 1024),
         // force unloading dirty index entries if behind 60 Gb of wal
-        snapshot_unload_threshold: 60 * 1024 * 1024 * 1024,
+        snapshot_unload_threshold: parse_env_usize("TH_SNAPSHOT_UNLOAD_THRESHOLD", 1)
+            .unwrap_or(60 * 1024 * 1024 * 1024),
         unload_jitter_pct: 30,
         max_dirty_keys: default_max_dirty_keys(),
         max_maps,
@@ -134,7 +136,7 @@ pub fn default_mutex_count() -> usize {
 }
 
 pub fn default_value_cache_size() -> usize {
-    1000
+    parse_env_usize("TH_DEFAULT_VALUE_CACHE_SIZE", 1).unwrap_or(1000)
 }
 
 pub(crate) fn apply_range_bounds(


### PR DESCRIPTION
- Make default_max_dirty_keys() public so callers can scale relative to it
- Scale all with_max_dirty_keys() call sites as multiples of default_max_dirty_keys() (4x for objects, 16x for owned_object_transaction_locks and checkpoints)
- Add TH_SNAPSHOT_WRITTEN_BYTES env var (default 64 GB)
- Add TH_SNAPSHOT_UNLOAD_THRESHOLD env var (default 60 GB)
- Add TH_DEFAULT_VALUE_CACHE_SIZE env var (default 1000)

This allows further memory tuning on memory-constrained nodes where TH perpetual table initialization OOMs before the node can start serving.

## Description 

Describe the changes or additions included in this PR.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
