### PR TITLE
docs: add visitor_type custom prop to Plausible tracking

### DIFF
--- a/docs/site/src/shared/plugins/plausible/client/index.ts
+++ b/docs/site/src/shared/plugins/plausible/client/index.ts
@@ -13,6 +13,15 @@ declare global {
   }
 }
 
+const BOT_PATTERNS = /bot|crawler|spider|crawling|headless|puppet|phantom|selenium|playwright|archiver|fetcher|slurp|mediapartners/i;
+
+function detectVisitorType(): "agent" | "human" {
+  const ua = navigator.userAgent || "";
+  if (BOT_PATTERNS.test(ua)) return "agent";
+  if ((navigator as any).webdriver) return "agent";
+  return "human";
+}
+
 export async function onRouteDidUpdate({ location }: { location: Location }) {
   if (!ExecutionEnvironment.canUseDOM) return;
 
@@ -72,5 +81,8 @@ export async function onRouteDidUpdate({ location }: { location: Location }) {
   track("pageview", {
     url: location.pathname + location.search + location.hash,
     referrer: document.referrer || undefined,
+    props: {
+      visitor_type: detectVisitorType(),
+    },
   });
 }


### PR DESCRIPTION
Detect agent vs human visitors via User-Agent patterns and navigator.webdriver, and pass visitor_type as a custom property on each pageview event.

## Description 

Describe the changes or additions included in this PR.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
