### PR TITLE
sui-core: add address balances design docs

### DIFF
--- a/crates/sui-core/src/accumulators/design_docs/README.md
+++ b/crates/sui-core/src/accumulators/design_docs/README.md
@@ -14,7 +14,7 @@ If you are touching code under `crates/sui-core/src/accumulators/` or
 | [`data_model.md`](./data_model.md) | On-chain layout: the `0xACC` root, `AccumulatorObjId` derivation, dynamic-field representation, and the version invariant. |
 | [`write_path.md`](./write_path.md) | How a balance changes: `FundsWithdrawalArg`, transaction rewriting, accumulator events (Split/Merge), `AccumulatorSettlementTxBuilder`, and the placeholder→settlement-txns→barrier expansion. Also covers the two paths by which settlement reaches a node (validator vs. checkpoint executor). |
 | [`address_funds_scheduling.md`](./address_funds_scheduling.md) | Pre-execution withdraw scheduling for **address-owned** accumulator accounts (max amounts known up front). Eager scheduler, naive baseline, determinism. |
-| [`object_funds_checking.md`](./object_funds_checking.md) | Post-execution sufficiency checking for **object-owned** accumulator accounts (amounts known only after Move VM runs). |
+| [`object_funds_checking.md`](./object_funds_checking.md) | Post-execution sufficiency checking for **object-owned** accumulator accounts (amounts known only after the transaction is run). |
 | [`coin_reservations.md`](./coin_reservations.md) | Backward-compat layer that lets pre-address-balance SDKs use address balances by encoding withdrawals as fake `ObjectRef`s. Transitional — expected to be removed once SDK migration is done. |
 
 The **read path** (RPC balance queries via `accumulators/balances.rs` and the
@@ -44,7 +44,7 @@ on those modules is the source of truth — no separate doc is provided here.
                            │            │
                            ▼            ▼
                   ┌──────────────────────────────────┐
-                  │           Move VM                │
+                  │     execution engine/adapter     │
                   │  emits AccumulatorEvents per     │
                   │  Split/Merge — see write_path.md │
                   └──────────────┬───────────────────┘
@@ -93,7 +93,7 @@ on those modules is the source of truth — no separate doc is provided here.
   barrier transaction (`Mutable` access).
 - **Barrier transaction** — the final settlement transaction that gates the accumulator version
   bump. Driven by `accumulators::build_accumulator_barrier_tx`.
-- **Split / Merge** — Move VM accumulator events. Split = withdrawal, Merge = deposit.
+- **Split / Merge** — Accumulator events. Split = withdrawal, Merge = deposit.
 - **Running max withdraw** — the peak net withdrawal an account experiences during a single
   transaction's execution. The basis for object-funds sufficiency checking.
 - **Reservation** — in the address-funds scheduler, the *declared maximum* a transaction may

--- a/crates/sui-core/src/accumulators/design_docs/README.md
+++ b/crates/sui-core/src/accumulators/design_docs/README.md
@@ -1,0 +1,111 @@
+# Address Balances: Design Documentation
+
+This directory contains the design documentation for Sui's **address balances** system —
+the accumulator-based mechanism that lets addresses (and objects) hold virtual `Balance<T>`
+amounts directly on a single shared root object, without spawning per-coin objects.
+
+If you are touching code under `crates/sui-core/src/accumulators/` or
+`crates/sui-core/src/execution_scheduler/funds_withdraw_scheduler/`, this is the place to start.
+
+## What's in this directory
+
+| Doc | Topic |
+|-----|-------|
+| [`data_model.md`](./data_model.md) | On-chain layout: the `0xACC` root, `AccumulatorObjId` derivation, dynamic-field representation, and the version invariant. |
+| [`write_path.md`](./write_path.md) | How a balance changes: `FundsWithdrawalArg`, transaction rewriting, accumulator events (Split/Merge), `AccumulatorSettlementTxBuilder`, and the placeholder→settlement-txns→barrier expansion. Also covers the two paths by which settlement reaches a node (validator vs. checkpoint executor). |
+| [`address_funds_scheduling.md`](./address_funds_scheduling.md) | Pre-execution withdraw scheduling for **address-owned** accumulator accounts (max amounts known up front). Eager scheduler, naive baseline, determinism. |
+| [`object_funds_checking.md`](./object_funds_checking.md) | Post-execution sufficiency checking for **object-owned** accumulator accounts (amounts known only after Move VM runs). |
+| [`coin_reservations.md`](./coin_reservations.md) | Backward-compat layer that lets pre-address-balance SDKs use address balances by encoding withdrawals as fake `ObjectRef`s. Transitional — expected to be removed once SDK migration is done. |
+
+The **read path** (RPC balance queries via `accumulators/balances.rs` and the
+`AccountFundsRead` trait in `accumulators/funds_read.rs`) is small enough that the inline rustdoc
+on those modules is the source of truth — no separate doc is provided here.
+
+## High-level architecture
+
+```
+                  ┌──────────────────────────────────┐
+                  │         User Transaction         │
+                  └──────────────┬───────────────────┘
+                                 │
+                                 ▼
+                Has declared address withdraws?
+                                 │
+                          ┌──────┴──────┐
+                         YES            NO
+                          │             │
+                          ▼             │
+              ┌────────────────────────┐│
+              │ FundsWithdrawScheduler ││
+              │ (PRE-execution gate)   ││
+              │ — see address_funds_   ││
+              │   scheduling.md        ││
+              └────────────┬───────────┘│
+                           │            │
+                           ▼            ▼
+                  ┌──────────────────────────────────┐
+                  │           Move VM                │
+                  │  emits AccumulatorEvents per     │
+                  │  Split/Merge — see write_path.md │
+                  └──────────────┬───────────────────┘
+                                 │
+                                 ▼
+                      Has object withdraws?
+                                 │
+                          ┌──────┴──────┐
+                         YES            NO
+                          │             │
+                          ▼             │
+              ┌────────────────────────┐│
+              │  ObjectFundsChecker    ││
+              │  (POST-execution check)││
+              │  — see object_funds_   ││
+              │    checking.md         ││
+              └────────────┬───────────┘│
+                           │            │
+                           ▼            ▼
+                  Effects committed; events
+                  accumulated for settlement
+                                 │
+                                 ▼
+                  ┌──────────────────────────────────┐
+                  │  Settlement: N parallel          │
+                  │  settlement txns + barrier tx    │
+                  │  (bumps accumulator version)     │
+                  │  — see write_path.md §4          │
+                  └──────────────────────────────────┘
+```
+
+## Glossary
+
+- **Accumulator root (`0xACC`)** — the singleton shared object
+  (`SUI_ACCUMULATOR_ROOT_OBJECT_ID`) that owns every virtual balance as a dynamic field.
+- **Accumulator version** — the `SequenceNumber` of the accumulator root. Bumped exactly once
+  per settlement batch, by the *barrier* transaction.
+- **`AccumulatorObjId`** — the `ObjectID` of an individual accumulator account (a dynamic field
+  under `0xACC`). Derived deterministically from `(owner_address, balance_type)`.
+- **Address funds** — virtual balances owned by an address (`SuiAddress`). Withdraw maximums are
+  declared in transaction data; sufficiency can be checked **before** execution.
+- **Object funds** — virtual balances owned by another object (UID). Withdraw amounts are
+  computed by Move code at runtime; sufficiency must be checked **after** execution.
+- **Settlement** — the act of folding a commit's accumulator events into the on-chain root.
+  Implemented as N parallel settlement transactions (`NonExclusiveWrite` access) plus one
+  barrier transaction (`Mutable` access).
+- **Barrier transaction** — the final settlement transaction that gates the accumulator version
+  bump. Driven by `accumulators::build_accumulator_barrier_tx`.
+- **Split / Merge** — Move VM accumulator events. Split = withdrawal, Merge = deposit.
+- **Running max withdraw** — the peak net withdrawal an account experiences during a single
+  transaction's execution. The basis for object-funds sufficiency checking.
+- **Reservation** — in the address-funds scheduler, the *declared maximum* a transaction may
+  withdraw from an account. Held against the in-memory balance until settlement releases it.
+- **Checkpoint-builder path / checkpoint-executor path** — the two ways settlement reaches a validator.
+  Documented in [`write_path.md`](./write_path.md) §5 and consumed everywhere else.
+
+## Conventions used in these docs
+
+- Code references prefer symbol names such as `module::Type` or `Type::method`; line-specific
+  references are used sparingly when the exact site matters. Where a function is named, it's the
+  source of truth — the doc should follow the code, not the other way around.
+- Diagrams are ASCII, kept simple enough to edit in place.
+- "Sections N.M" cross-references are within a single doc; cross-doc references give the file
+  path explicitly.

--- a/crates/sui-core/src/accumulators/design_docs/README.md
+++ b/crates/sui-core/src/accumulators/design_docs/README.md
@@ -87,7 +87,7 @@ on those modules is the source of truth — no separate doc is provided here.
 - **Address funds** — virtual balances owned by an address (`SuiAddress`). Withdraw maximums are
   declared in transaction data; sufficiency can be checked **before** execution.
 - **Object funds** — virtual balances owned by another object (UID). Withdraw amounts are
-  computed by Move code at runtime; sufficiency must be checked **after** execution.
+  determined by Move program logic at runtime; sufficiency must be checked **after** execution.
 - **Settlement** — the act of folding a commit's accumulator events into the on-chain root.
   Implemented as N parallel settlement transactions (`NonExclusiveWrite` access) plus one
   barrier transaction (`Mutable` access).

--- a/crates/sui-core/src/accumulators/design_docs/address_funds_scheduling.md
+++ b/crates/sui-core/src/accumulators/design_docs/address_funds_scheduling.md
@@ -1,0 +1,676 @@
+# Address Funds Withdraw Scheduling
+
+This document covers the **pre-execution** sufficiency check for address-owned virtual balance
+withdrawals — the work done by `FundsWithdrawScheduler` (under
+`crates/sui-core/src/execution_scheduler/funds_withdraw_scheduler/address_funds/`) before a
+withdrawing transaction is allowed to execute.
+
+For the on-chain data layout, see [`data_model.md`](./data_model.md). For how a withdraw is
+declared and how settlement transactions are constructed, see
+[`write_path.md`](./write_path.md). For the post-execution sufficiency check used for
+**object-owned** accumulator accounts, see
+[`object_funds_checking.md`](./object_funds_checking.md).
+
+## 1. Inputs and outputs
+
+### What "address funds" means here
+
+Address-funds withdrawals are withdrawals from address-owned accumulator accounts where the
+*maximum* withdrawal amount is known **before execution**. The transaction data declares an
+upper bound (`Reservation::MaxAmountU64`) on how much each account may withdraw — the actual
+amount withdrawn during execution can be smaller (or even zero), but never larger. This upper
+bound is enough to check sufficiency before the Move VM starts: if the account doesn't have
+enough to cover the declared maximum, the transaction is guaranteed to fail, so we skip
+execution entirely and return an early error.
+
+Object-funds withdrawals (where the amount is known only after the Move VM runs) are out of
+scope here — see [`object_funds_checking.md`](./object_funds_checking.md).
+
+### Core data structures
+
+A `TxFundsWithdraw` captures the maximum withdrawal a single transaction may perform from each
+account:
+
+```rust
+pub struct TxFundsWithdraw {
+    pub tx_digest: TransactionDigest,
+    pub reservations: BTreeMap<AccumulatorObjId, u64>,
+}
+```
+
+Each entry in `reservations` is an upper bound. The map is the same shape as
+`process_funds_withdrawals_for_execution`'s output (see [`write_path.md`](./write_path.md) §1).
+
+A `WithdrawReservations` groups all the withdrawals from a single consensus commit (that share
+the same accumulator version) into one batch:
+
+```rust
+pub struct WithdrawReservations {
+    pub accumulator_version: SequenceNumber,
+    pub withdraws: Vec<TxFundsWithdraw>,
+}
+```
+
+The scheduler returns a `ScheduleResult` for each transaction, which is one of three outcomes:
+
+- **`SufficientFunds`** — the account has enough to cover the declared maximum withdrawal. The
+  transaction can proceed to execution (where it may withdraw up to that amount).
+- **`InsufficientFunds`** — the account cannot cover the declared maximum. The transaction
+  will be executed with an `Insufficient` flag, causing it to fail immediately with an
+  `InsufficientFundsForWithdraw` error without running any Move code.
+- **`SkipSchedule`** — the accumulator version for this transaction has already been settled.
+  This happens either when the scheduler's own in-memory version has advanced past it (the
+  validator path), or — more commonly for a node that is catching up — when the on-chain
+  version of an account object has been moved past the requested version by settlement txns
+  coming from the checkpoint executor (see [`write_path.md`](./write_path.md) §5). Either way,
+  no scheduling action is needed; the transaction can be released.
+
+A result can be **immediate** (known right away) or **pending** (will be resolved later when
+settlement provides more information). Pending results are delivered through oneshot channels.
+
+### Where it fits in the pipeline
+
+When a batch of transactions arrives from consensus, `ExecutionScheduler::enqueue` classifies
+each one:
+
+1. **Ordinary transactions** (no fund withdrawals) go straight to the execution queue.
+2. **Transactions with withdrawals** are routed through the funds withdraw scheduler first.
+   They cannot execute until the scheduler determines whether their withdrawals are valid.
+3. **Settlement and barrier transactions** are handled by `SettlementScheduler` (see
+   [`write_path.md`](./write_path.md) §4 and §5). When their effects materialize,
+   `settle_address_funds` is called to update the scheduler's in-memory state.
+
+```
+  Consensus          Withdraw            Execution
+   Output    ──────> Scheduler  ──────>   Queue
+              gate:                     (ready to
+              "does this tx             execute)
+               have enough
+               funds?"
+
+                         │
+              Settlement │ called after settlement +
+              (validator │ barrier txns execute (early
+                  path)  │ settlement / checkpoint builder)
+                         ▼
+              Scheduler updates its
+              internal balance state
+```
+
+When a checkpoint is being applied via the **checkpoint executor**
+([`write_path.md`](./write_path.md) §5), the settlement and barrier transactions run through
+the normal execution pipeline like any other system transaction, and the on-chain state
+advances. But because the node didn't construct those transactions, `settle_address_funds` is
+**not** invoked. The scheduler is designed to handle this gracefully — see §3 below for the
+specific in-memory checks that keep the scheduler consistent with storage.
+
+### After scheduling
+
+Once the scheduler returns a result for a transaction:
+
+- **SufficientFunds** — the transaction is re-enqueued into the normal execution pipeline. It
+  will execute its Move code normally, and the withdrawal will happen as part of execution.
+- **InsufficientFunds** — the transaction is re-enqueued with
+  `FundsWithdrawStatus::Insufficient` set in its `ExecutionEnv`. When the execution pipeline
+  picks it up, it sees this flag and immediately returns
+  `ExecutionErrorKind::InsufficientFundsForWithdraw` — the Move VM never runs. The transaction
+  still produces effects (a failed execution) so it can be included in checkpoints.
+- **SkipSchedule** — the transaction is dropped from the scheduler's perspective. This
+  typically means a checkpoint executor has already executed the corresponding settlement (and
+  barrier) on this node, so the on-chain state is already past the requested version.
+
+### The channel-based wrapper
+
+The public `FundsWithdrawScheduler` struct wraps the actual scheduling logic behind two
+unbounded channels. One processes withdrawal requests; the other processes settlement
+notifications. Two background tokio tasks drain these channels sequentially.
+
+Why channels? The inner scheduler state (tracked balances, pending reservations) is mutable and
+must be updated in a consistent order. By funneling all mutations through single-consumer
+channels, we guarantee that withdrawals are processed one batch at a time and settlements are
+applied one at a time, without needing complex locking protocols.
+
+## 2. The simplest mental model: wait-then-check
+
+Before explaining the eager scheduler (the production implementation), it helps to understand
+the simplest possible approach. This mental model is implemented as the
+`NaiveFundsWithdrawScheduler` in the codebase, used only for correctness testing — it will
+never run in production. But it captures the essential logic that any withdraw scheduler must
+get right.
+
+The idea is straightforward: **wait until the accumulator version is fully settled, then check
+balances from storage.**
+
+When a batch of withdrawals arrives at version V, the scheduler looks at the current settled
+version:
+
+- If the current version **equals V**, the state is settled and we have exact balances. Read
+  each account's balance from storage, then process transactions one by one in consensus
+  order. For each transaction, check whether every account has enough to cover its withdrawal.
+  Successful withdrawals deduct from a local balance copy (so later transactions in the same
+  batch see the reduced balance). If any account is short, the transaction gets
+  `InsufficientFunds`.
+- If the current version is **ahead of V**, these withdrawals are stale — already settled by
+  another path (e.g., the checkpoint executor advanced storage; see
+  [`write_path.md`](./write_path.md) §5). All transactions get `SkipSchedule`.
+- If the current version is **behind V**, settlement hasn't happened yet. Block until it does,
+  then check as above.
+
+### Example: why order matters
+
+Consider Account A with balance 1000. Three transactions arrive in the same consensus commit,
+all reading version 5:
+
+| Transaction | Max Withdrawal |
+|-------------|----------------|
+| TX1 | up to 400 from A |
+| TX2 | up to 300 from A |
+| TX3 | up to 500 from A |
+
+The scheduler reads A's balance (1000) and processes them in consensus order, deducting each
+transaction's declared maximum:
+
+1. **TX1**: max 400. Balance is 1000 — sufficient. Deduct max to 600. Result: **SufficientFunds**.
+2. **TX2**: max 300. Balance is 600 — sufficient. Deduct max to 300. Result: **SufficientFunds**.
+3. **TX3**: max 500. Balance is 300 — insufficient. Result: **InsufficientFunds**.
+
+The deduction uses the declared maximum, not the actual amount (which isn't known until
+execution). This is conservative: it guarantees that if a transaction is approved, it will
+have enough funds no matter how much it actually withdraws (up to its declared max).
+
+If TX3 had arrived before TX2 in the consensus ordering, TX3 would have succeeded (600 ≥ 500)
+and TX2 would have failed (100 < 300). This is why all validators must process withdrawals in
+the same order — the ordering comes from consensus, and the scheduling result is deterministic.
+
+### Why this isn't good enough
+
+The wait-then-check approach adds unnecessary latency: every withdrawal blocks until its declared
+version is settled on chain, even when the scheduler already has all the information needed to
+decide it.
+
+The key observation is that the scheduler itself sees every withdrawal reservation in the order
+consensus assigned them. By the time a new request arrives, the scheduler already knows what
+every prior reservation against that account declared as its maximum withdrawal — that is enough
+to compute the post-reservation balance without waiting for any of those earlier transactions to
+finish executing. Settlement adjusts the in-memory state to match on-chain reality, but it is
+not required to make a sound sufficient/insufficient decision for the next request. The naive
+scheduler ignores this and blocks anyway.
+
+The eager scheduler exploits this directly.
+
+## 3. The eager scheduler
+
+The eager scheduler is the production implementation. Its key innovation is maintaining
+in-memory balance state so it can often approve withdrawals **immediately, without waiting for
+settlement**.
+
+### 3.1 Skipping already-settled versions (both paths)
+
+Before getting into per-account bookkeeping, it is worth pinning down exactly when the eager
+scheduler can short-circuit a batch. There are two version-based gates in
+`schedule_withdraws`, each catching a different way that storage can have already moved past a
+request:
+
+- **`reservations.accumulator_version < cur_accumulator_version`** — the scheduler's own
+  in-memory version is already past the request. This happens when `settle_address_funds` has
+  already been called on this node for that version (validator path). All withdraws in the
+  batch return `SkipSchedule`.
+- **The initial balance read for an untracked account returns a version > the request's
+  version** — the on-chain account object has been moved past the request even though the
+  scheduler's in-memory `accumulator_version` may not have. This is precisely the
+  checkpoint-executor case from [`write_path.md`](./write_path.md) §5: the settlement and
+  barrier transactions ran out of a downloaded checkpoint, advancing the per-account version,
+  but `settle_address_funds` was never called. The whole batch returns `SkipSchedule`.
+
+Together these two checks guarantee that the eager scheduler never schedules withdraws against
+a version that some component (in-memory or on-disk) has already moved past, regardless of
+which path delivered the settlement.
+
+### 3.1.1 Why a latest-state read is sufficient here
+
+This is a place where the address-funds scheduler is intentionally asking a weaker question than
+the object-funds checker asks later in the pipeline.
+
+For an untracked account, `get_latest_account_amount` returns both the latest visible balance and
+the version that balance came from. The scheduler uses that pair for two purposes only:
+
+1. **Staleness detection.** If storage already says "this account is at version > V", then the
+   scheduler knows the request for version V is stale and returns `SkipSchedule`.
+2. **Conservative reservation against the current lower bound.** If storage is at version `<= V`,
+   the scheduler may reserve against that balance, but only using the declared maximum withdrawal
+   and only inside the scheduler's own per-account reservation discipline.
+
+What the scheduler does **not** need here is an exact historical snapshot for version V. If the
+version has already passed, some other part of the system has already carried the transaction
+family forward: either this node processed settlement in-process and updated the scheduler via
+`settle_address_funds`, or storage was advanced by the checkpoint executor and the scheduler can
+stand down. In either case, the correct action is "do not schedule this batch again", not "replay
+the old balance check at version V".
+
+This is why latest-state plus version monotonicity is enough for address funds, while object
+funds need MVCC-bounded reads.
+
+### 3.2 The core insight
+
+Suppose Account A has a balance of 10,000. A transaction arrives at a not-yet-settled version
+declaring a max withdrawal of 100. The simple approach would wait. But the eager scheduler
+reasons differently: "I know the current balance. I know how much I've already reserved (at
+the declared maximum) for other pending withdrawals. If there's still room for this new max
+withdrawal, I can approve it now — no matter what the settlement brings, the funds are there."
+
+The critical invariant is: **the known balance can only decrease by at most the sum of all
+reserved maximums, plus whatever settlement deltas arrive.** By tracking reserved maximums, the
+eager scheduler can determine that new withdrawals fit within what's left — or that they don't
+and must wait. Because reservations are conservative (based on the declared max, not the
+actual withdrawal), the scheduler may sometimes over-reserve, but this is corrected when
+settlement arrives with the actual (smaller) delta.
+
+The race to keep in mind is that settlement may be applied by a different execution path than the
+one currently looking at the transaction. The eager scheduler is safe because its decisions are
+only:
+
+- approve now based on a conservative reservation, or
+- wait for more settlement information, or
+- detect that some other path already moved past this version and stop scheduling it.
+
+It never needs to reconstruct the exact historical balance after the version has already passed.
+
+### 3.3 Per-account state
+
+The eager scheduler tracks an `AccountState` for every account with pending or reserved
+withdrawals. To approve withdrawals without waiting for settlement, the scheduler must
+repeatedly answer one question: *given everything I have already committed to for this account,
+does the next request still fit?* Each field of `AccountState` exists to make that question
+answerable.
+
+- **`last_updated_balance`** — the anchor that sufficiency checks subtract from. It is the most
+  recent balance the scheduler knows to be correct, read from storage the first time the
+  account is seen and kept current as settlement deltas arrive.
+
+- **`last_updated_version`** — the version that `last_updated_balance` corresponds to. The
+  version is tracked for two reasons:
+  - *Deciding when a balance is final.* Settlement advances one version at a time. If an
+    incoming request's version equals `last_updated_version`, the balance held is final for
+    that version and any insufficiency is a deterministic failure (outcome 2 in §3.4). If the
+    request's version is ahead, a later settlement could still deposit funds, so the request
+    must wait (outcome 3). Without the version, the scheduler cannot tell these two cases
+    apart.
+  - *Idempotency of settlement.* Settlement deltas can be re-delivered (for example after
+    restart). `settle_funds` ignores deltas at versions less than or equal to
+    `last_updated_version`, so each delta applies exactly once.
+
+- **`reserved_funds`** — the running total of withdrawals the scheduler has *already approved*
+  but that have not yet settled on chain. The scheduler approves before execution, so until
+  each approved withdrawal actually deducts itself, that money has been promised and must be
+  held back from the next sufficiency check. Reservations are stored as a deque of
+  `(version, amount)`: when settlement crosses a version, that version's reservation is
+  released and replaced by the *actual* deduction from the settlement delta (which may be
+  smaller than the reserved maximum). The running total keeps sufficiency checks O(1).
+
+- **`pending_reservations`** — a FIFO queue for withdrawals the scheduler cannot decide yet —
+  requests whose version is not yet settled and whose balance is currently insufficient. A
+  future settlement may bring deposits that make them feasible, so they wait here until the
+  next settlement gives the scheduler more information.
+
+The lifecycle of an account in the tracker:
+
+```
+  Account first seen    Reserve withdrawals    Settlement arrives    All resolved
+  with withdrawal   ──> against known      ──> balance updated,  ──> account removed
+  (read balance         balance                reservations          from tracker
+   from storage)                               released, pending
+                                               queue drained
+```
+
+### 3.4 Reserving funds: the three outcomes
+
+When a new withdrawal arrives for an account, the scheduler pushes it onto the account's
+pending queue and then tries to process it. There are three possible outcomes:
+
+**1. Immediate Success (reserve against known balance).**
+If `total_reserved + max_withdrawal ≤ last_updated_balance`, then there are clearly enough
+funds to cover even the worst case. The max withdrawal amount is added to `reserved_funds`,
+and the withdrawal is marked as satisfied for this account. If this was the last account the
+transaction was waiting on, the transaction immediately gets `SufficientFunds`.
+
+This is the fast path. It handles the common case where an account has a large balance
+relative to the declared maximum, and the scheduler doesn't need to wait for anything.
+
+**2. Deterministic Failure (version is settled, balance is insufficient).**
+If the withdrawal's accumulator version equals the last settled version, the scheduler has the
+*final* balance for that version — no future settlement can change it. If the balance minus
+reserved funds is too low, the transaction is doomed. The scheduler immediately notifies
+`InsufficientFunds`.
+
+**3. Uncertain — Must Wait (version is not yet settled, balance is insufficient).**
+If the withdrawal's version is *ahead* of the last settled version, the scheduler doesn't have
+final balance information. A future settlement might deposit funds into this account, making
+the withdrawal feasible. The withdrawal stays in the `pending_reservations` queue and will be
+retried when settlement arrives.
+
+```
+  New withdrawal arrives for Account A
+       │
+       ▼
+  total_reserved + amount ≤ balance?
+       │
+    ┌──┴──┐
+   YES    NO
+    │      │
+    │      ▼
+    │  Is this version already settled?
+    │      │
+    │   ┌──┴──┐
+    │  YES    NO
+    │   │      │
+    │   │      ▼
+    │   │   WAIT: stay in pending queue
+    │   │   (settlement may bring deposits)
+    │   │
+    │   ▼
+    │  FAIL: InsufficientFunds
+    │  (final answer — balance can't grow)
+    │
+    ▼
+  SUCCESS: reserve the amount
+  (add to reserved_funds, notify if all accounts done)
+```
+
+### 3.5 The pending queue and head-of-line ordering
+
+Each account maintains its pending queue as a strict FIFO. If a withdrawal at the front of the
+queue cannot be resolved (it's waiting for settlement), **all subsequent withdrawals for that
+account are blocked too**, even if they individually would fit in the available balance.
+
+Why? Because processing out-of-order could violate determinism. Consider: if TX1 needs 800
+from an account with balance 1000, and TX2 needs 100, we might be tempted to approve TX2
+immediately. But whether TX1 ultimately succeeds or fails depends on settlement. If TX1
+succeeds, the remaining balance is 200 (enough for TX2). If TX1 fails, the remaining balance is
+1000 (still enough). So TX2 is fine either way in this case — but in general, the math doesn't
+always work out, and processing out of order would require complex speculation logic. The FIFO
+approach is simple and guarantees that all validators make identical decisions.
+
+## 4. Settlement in the eager scheduler
+
+When a settlement arrives (version N → N+1) via `settle_address_funds`, the eager scheduler
+does three things:
+
+**Step 1: Identify affected accounts.** Three sets of accounts need updating:
+
+- Accounts with reserved funds at version N (just settled — their reservations can be
+  released).
+- Accounts with pending withdrawals at version N+1 (can now be deterministically decided).
+- Accounts that appear in the settlement's `funds_changes` map (their balance changed).
+
+**Step 2: Update each affected account.**
+For each account, the scheduler:
+
+1. Applies the balance delta from the settlement (e.g., balance += deposit, balance -=
+   withdrawal). Note that this delta reflects the *actual* amount withdrawn during execution,
+   which may be less than the *maximum* that was reserved.
+2. Releases reserved funds for the now-settled version (reducing `total_reserved` by the
+   reserved maximum). The net effect of steps 1 and 2 can actually *increase* the effective
+   available balance — for example, if we reserved 400 but only 300 was actually withdrawn,
+   releasing the reservation adds back 400 while the settlement subtracts only 300, freeing
+   up 100 more than what was previously available.
+3. Drains the pending queue: repeatedly tries to reserve the front withdrawal, since the
+   balance and/or reserved total may have changed enough to make previously-blocked
+   withdrawals feasible.
+
+**Step 3: Garbage-collect empty accounts.**
+If an account has no more reserved funds and no pending withdrawals, it is removed from the
+tracker. This keeps memory usage proportional to the number of in-flight withdrawals.
+
+**Idempotency.** `settle_funds` short-circuits if its `next_accumulator_version` is less than
+or equal to the scheduler's current `accumulator_version`, and `AccountState::settle_funds`
+ignores deltas at versions less than or equal to the account's `last_updated_version`. This is
+what makes the call safe in the face of mixed paths: even if a node briefly tracks an account
+in memory and then the same version is later observed via storage (or vice versa), no
+double-application occurs.
+
+Note that on the **checkpoint-executor path** ([`write_path.md`](./write_path.md) §5),
+`settle_address_funds` is never called — there is simply nothing to do in memory, because
+§3.1's storage-version check already prevents the scheduler from ever building up reservations
+or pending entries against a version that storage has moved past.
+
+## 5. Worked examples
+
+### 5.1 Basic eager scheduling (reservation vs. actual withdrawal)
+
+**Setup**: two accounts, Alice (balance 1000) and Bob (balance 500), both at version 5.
+
+**Consensus Commit 1** arrives with two transactions at version 5:
+
+- TX1 declares a max withdrawal of 400 from Alice and 200 from Bob.
+- TX2 declares a max withdrawal of 300 from Alice.
+
+The scheduler processes TX1 first:
+
+- Alice: total reserved is 0, and 0 + 400 ≤ 1000. Reserve succeeds. Reserved = {v5: 400}.
+- Bob: total reserved is 0, and 0 + 200 ≤ 500. Reserve succeeds. Reserved = {v5: 200}.
+- Both accounts are done → TX1 gets **SufficientFunds** immediately.
+
+Then TX2:
+
+- Alice: total reserved is 400, and 400 + 300 = 700 ≤ 1000. Reserve succeeds. Reserved = {v5: 700}.
+- Only one account → TX2 gets **SufficientFunds** immediately.
+
+Both transactions are released for execution without waiting for any settlement. Note that 700
+is the total *maximum* reserved for Alice — the actual execution may withdraw less.
+
+```
+  After scheduling:
+  ┌──────────────────────────────────────────┐
+  │  Alice:  balance=1000  reserved={v5:700} │
+  │  Bob:    balance=500   reserved={v5:200} │
+  └──────────────────────────────────────────┘
+```
+
+**Consensus Commit 2** arrives with TX3 at version 6 (before version 5 settles):
+
+- TX3 declares a max withdrawal of 400 from Alice.
+- Alice: total reserved is 700, and 700 + 400 = 1100 > 1000. Cannot reserve.
+- Version 6 ≠ last settled version (5), so this is **uncertain**. TX3 goes into Alice's
+  pending queue and the scheduler returns **Pending**.
+
+```
+  After scheduling TX3:
+  ┌────────────────────────────────────────────────────┐
+  │  Alice:  balance=1000  reserved={v5:700}           │
+  │          pending_queue=[TX3: needs 400 at v6]      │
+  │  Bob:    balance=500   reserved={v5:200}           │
+  └────────────────────────────────────────────────────┘
+```
+
+**Settlement v5→v6** arrives with changes: Alice −500, Bob −200.
+
+Notice that Alice's settlement delta is −500, not −700. TX1 and TX2 reserved a combined maximum
+of 700, but during actual execution they only withdrew 500 total (each withdrew less than its
+declared maximum).
+
+The scheduler processes Alice:
+
+1. Apply delta: balance = 1000 + (−500) = 500. Version advances to 6.
+2. Release reserved funds at v5: total reserved goes from 700 to 0.
+   The net effect: the balance went from an *effective available* of 300 (1000 − 700 reserved)
+   to 500 (actual balance after settlement, with no reservations). The gap between the
+   reserved max (700) and the actual withdrawal (500) freed up 200 extra.
+3. Drain pending queue: TX3 needs 400. Is 0 + 400 ≤ 500? Yes! Reserve succeeds.
+   TX3 gets **SufficientFunds**.
+
+The scheduler processes Bob:
+
+1. Apply delta: balance = 500 + (−200) = 300. Version advances to 6.
+2. Release reserved funds at v5: total reserved goes from 200 to 0.
+3. No pending withdrawals.
+
+Both accounts are now empty (no reserved funds, no pending queue) and are removed from the
+tracker.
+
+This example illustrates how the conservative reservation approach (reserving the max) can
+temporarily over-reserve, but settlement corrects this. TX3 was initially blocked because the
+scheduler assumed the worst case (700 withdrawn from Alice). When settlement revealed the
+actual amount was only 500, the freed-up balance was enough for TX3 to proceed.
+
+### 5.2 A deposit unblocks a pending withdrawal
+
+**Setup**: Account A has balance 100 at version 5.
+
+**Consensus Commit** at version 6 (before v5 settles):
+
+- TX1 declares a max withdrawal of 200 from A.
+- A: total reserved is 0, but 0 + 200 = 200 > 100. Cannot reserve.
+- Version 6 ≠ last settled version (5) → **uncertain**. TX1 is queued as Pending.
+
+The withdrawal is stuck. But then...
+
+**Settlement v5→v6** arrives with changes: A +150 (someone deposited 150 into A's accumulator
+during the v5 batch).
+
+The scheduler processes A:
+
+1. Apply delta: balance = 100 + 150 = 250. Version advances to 6.
+2. No reserved funds to release (nothing was reserved at v5).
+3. Drain pending queue: TX1 needs 200. Is 0 + 200 ≤ 250? Yes! Reserve succeeds.
+   TX1 gets **SufficientFunds**.
+
+```
+  Timeline:
+
+  Version 5           Settlement v5→v6         After settlement
+  ─────────           ────────────────         ────────────────
+  A: bal=100          A gets +150 deposit      A: bal=250
+  TX1 wants 200       ───────────────────>     TX1 reserved: 200 ✓
+  Can't reserve yet                            → SufficientFunds!
+  (uncertain)
+```
+
+The key point: the eager scheduler didn't reject TX1 outright when it first saw insufficient
+balance. Because the version hadn't settled yet, it held the withdrawal in the pending queue.
+When settlement brought a deposit, the pending withdrawal was automatically retried and
+approved.
+
+### 5.3 Multi-account withdrawal
+
+A single transaction can withdraw from multiple accounts. The `PendingWithdraw` object is
+shared (via `Arc`) across all the accounts that a transaction touches. It maintains a set of
+accounts that have **not yet** successfully reserved their portion.
+
+**Setup**: Alice has balance 1000, Bob has balance 500, both at version 5.
+
+TX1 declares a max withdrawal of 100 from Alice and 200 from Bob. The scheduler creates a
+single `PendingWithdraw` for TX1, shared between Alice's account state and Bob's account state.
+
+```
+  PendingWithdraw for TX1:
+  ┌─────────────────────────────────────┐
+  │  pending accounts: {Alice, Bob}     │
+  │  oneshot sender: [waiting to send]  │
+  └─────────────────────────────────────┘
+         ▲                    ▲
+         │                    │
+    Alice's account      Bob's account
+    state holds a        state holds a
+    reference (Arc)      reference (Arc)
+```
+
+Processing proceeds account by account:
+
+1. **Alice's account** checks: 0 + 100 ≤ 1000. Success! It calls
+   `pending_withdraw.remove_pending_account(Alice)`. The pending set becomes `{Bob}`. Not
+   empty yet — don't notify.
+
+2. **Bob's account** checks: 0 + 200 ≤ 500. Success! It calls
+   `pending_withdraw.remove_pending_account(Bob)`. The pending set becomes `{}`. Empty —
+   **send SufficientFunds** through the oneshot channel.
+
+If Bob's account had failed (say Bob only had 50), then `notify_insufficient_funds()` would
+fire immediately, sending **InsufficientFunds** — even though Alice's portion was fine. The
+transaction fails as a whole if **any** account is short.
+
+An important subtlety: even when a transaction fails due to one account being insufficient, the
+other accounts that succeeded still have their balance "reserved" (deducted from the available
+pool for subsequent transactions). This is intentional — it ensures that the scheduler's
+accounting stays consistent regardless of which transactions ultimately succeed or fail.
+
+### 5.4 Queued withdrawals across versions
+
+This example shows how the pending queue interacts with multiple versions.
+
+**Setup**: Account A has balance 500 at version 5. Last settled version is 5.
+
+**Step 1**: TX1 at version 5 declares a max withdrawal of 400.
+
+- 0 + 400 ≤ 500 → reserved immediately. Reserved = {v5: 400}. **SufficientFunds**.
+
+**Step 2**: TX2 at version 6 declares a max withdrawal of 200.
+
+- 400 + 200 = 600 > 500 → cannot reserve.
+- Version 6 ≠ settled version 5 → **uncertain** → queued in pending.
+
+**Step 3**: TX3 at version 6 declares a max withdrawal of 50.
+
+- TX2 is already at the front of the pending queue and is unresolved.
+- TX3 is pushed behind TX2. Even though 400 + 50 = 450 ≤ 500, TX3 cannot skip ahead.
+- TX3 is also **Pending**.
+
+```
+  Account A state:
+  ┌─────────────────────────────────────────────────┐
+  │  balance: 500       reserved: {v5: 400}         │
+  │  pending queue: [TX2(200@v6), TX3(50@v6)]       │
+  └─────────────────────────────────────────────────┘
+```
+
+**Step 4**: Settlement v5→v6 arrives, with changes: A −400 (the TX1 withdrawal is settled).
+
+1. Apply delta: balance = 500 + (−400) = 100. Version → 6.
+2. Release reserved at v5: total reserved drops from 400 to 0.
+3. Drain pending queue:
+   - TX2 needs 200. Is 0 + 200 ≤ 100? No. Version 6 == settled version 6 →
+     **InsufficientFunds**. TX2 is removed from the queue.
+   - TX3 needs 50. Is 0 + 50 ≤ 100? Yes! Reserved. **SufficientFunds**.
+
+Even though TX3 could have been approved earlier in isolation, the FIFO ordering ensured it
+waited behind TX2. Once TX2 was resolved (and failed), TX3 was immediately processed and
+approved.
+
+## 6. Determinism
+
+The withdraw scheduler must be **deterministic**: given the same inputs, all validators must
+produce the same scheduling decisions. This is essential because the scheduling outcome
+(sufficient vs. insufficient) determines whether a transaction executes normally or fails with
+an early error, and validators must agree on this.
+
+Determinism is achieved through several mechanisms:
+
+1. **Consensus ordering** — all validators see the same transactions in the same order within
+   each consensus commit, and process commits in the same sequence.
+2. **Sequential processing** — the channel-based wrapper ensures withdrawals and settlements
+   are processed one at a time, in arrival order.
+3. **FIFO per-account queuing** — the pending queue prevents out-of-order decisions that
+   could diverge across validators.
+4. **Version-gated decisions** — a withdrawal is only decided at the "uncertain" vs.
+   "deterministic" boundary based on whether its version has been settled, which all
+   validators agree on.
+
+The eager scheduler's stress tests verify determinism by running the same inputs multiple
+times and asserting identical results.
+
+## 7. Epoch boundaries
+
+At each epoch boundary, the address-funds scheduler is fully replaced:
+
+1. **`close_epoch()`** is called on the current `FundsWithdrawScheduler`, signaling it to stop.
+2. The old scheduler is dropped, and a fresh one is constructed (initialized with the current
+   accumulator version from the new epoch's state).
+3. The old scheduler's channel senders are dropped, which causes its background tasks to
+   gracefully exit when their receivers close.
+
+This clean break means no in-flight in-memory state carries over across epochs. Any pending
+withdrawals from the old epoch are effectively abandoned — they'll be handled by the
+checkpoint executor during epoch transition, and the new epoch starts from the on-chain state
+at the boundary.
+
+The object-funds checker is replaced through the same mechanism — see
+[`object_funds_checking.md`](./object_funds_checking.md) §5.

--- a/crates/sui-core/src/accumulators/design_docs/address_funds_scheduling.md
+++ b/crates/sui-core/src/accumulators/design_docs/address_funds_scheduling.md
@@ -192,10 +192,13 @@ decide it.
 The key observation is that the scheduler itself sees every withdrawal reservation in the order
 consensus assigned them. By the time a new request arrives, the scheduler already knows what
 every prior reservation against that account declared as its maximum withdrawal — that is enough
-to compute the post-reservation balance without waiting for any of those earlier transactions to
-finish executing. Settlement adjusts the in-memory state to match on-chain reality, but it is
-not required to make a sound sufficient/insufficient decision for the next request. The naive
-scheduler ignores this and blocks anyway.
+to establish a lower bound on the balance still available to the new request (the worst case where
+every prior reservation withdraws its full declared maximum), without waiting for any of those
+earlier transactions to finish executing. That lower bound is all the scheduler needs: if it still
+covers the new request's declared maximum, the request is guaranteed to be satisfiable. Settlement
+adjusts the in-memory state to match on-chain reality, but it is not required to make a sound
+sufficient/insufficient decision for the next request. The naive scheduler ignores this and
+blocks anyway.
 
 The eager scheduler exploits this directly.
 

--- a/crates/sui-core/src/accumulators/design_docs/address_funds_scheduling.md
+++ b/crates/sui-core/src/accumulators/design_docs/address_funds_scheduling.md
@@ -19,11 +19,11 @@ Address-funds withdrawals are withdrawals from address-owned accumulator account
 *maximum* withdrawal amount is known **before execution**. The transaction data declares an
 upper bound (`Reservation::MaxAmountU64`) on how much each account may withdraw — the actual
 amount withdrawn during execution can be smaller (or even zero), but never larger. This upper
-bound is enough to check sufficiency before the Move VM starts: if the account doesn't have
+bound is enough to check sufficiency before transaction execution starts: if the account doesn't have
 enough to cover the declared maximum, the transaction is guaranteed to fail, so we skip
 execution entirely and return an early error.
 
-Object-funds withdrawals (where the amount is known only after the Move VM runs) are out of
+Object-funds withdrawals (where the amount is known only after the transaction is executed) are out of
 scope here — see [`object_funds_checking.md`](./object_funds_checking.md).
 
 ### Core data structures
@@ -57,7 +57,7 @@ The scheduler returns a `ScheduleResult` for each transaction, which is one of t
   transaction can proceed to execution (where it may withdraw up to that amount).
 - **`InsufficientFunds`** — the account cannot cover the declared maximum. The transaction
   will be executed with an `Insufficient` flag, causing it to fail immediately with an
-  `InsufficientFundsForWithdraw` error without running any Move code.
+  `InsufficientFundsForWithdraw` error without executing the transaction.
 - **`SkipSchedule`** — the accumulator version for this transaction has already been settled.
   This happens either when the scheduler's own in-memory version has advanced past it (the
   validator path), or — more commonly for a node that is catching up — when the on-chain
@@ -101,19 +101,20 @@ When a checkpoint is being applied via the **checkpoint executor**
 ([`write_path.md`](./write_path.md) §5), the settlement and barrier transactions run through
 the normal execution pipeline like any other system transaction, and the on-chain state
 advances. But because the node didn't construct those transactions, `settle_address_funds` is
-**not** invoked. The scheduler is designed to handle this gracefully — see §3 below for the
-specific in-memory checks that keep the scheduler consistent with storage.
+**not** invoked. The scheduler is designed to handle this gracefully — see
+[§3 below](#3-the-eager-scheduler) for the specific in-memory checks that keep the scheduler
+consistent with storage.
 
 ### After scheduling
 
 Once the scheduler returns a result for a transaction:
 
 - **SufficientFunds** — the transaction is re-enqueued into the normal execution pipeline. It
-  will execute its Move code normally, and the withdrawal will happen as part of execution.
+  will execute the transaction normally, and the withdrawal will happen as part of execution.
 - **InsufficientFunds** — the transaction is re-enqueued with
   `FundsWithdrawStatus::Insufficient` set in its `ExecutionEnv`. When the execution pipeline
   picks it up, it sees this flag and immediately returns
-  `ExecutionErrorKind::InsufficientFundsForWithdraw` — the Move VM never runs. The transaction
+  `ExecutionErrorKind::InsufficientFundsForWithdraw` — the transaction never runs. The transaction
   still produces effects (a failed execution) so it can be included in checkpoints.
 - **SkipSchedule** — the transaction is dropped from the scheduler's perspective. This
   typically means a checkpoint executor has already executed the corresponding settlement (and

--- a/crates/sui-core/src/accumulators/design_docs/coin_reservations.md
+++ b/crates/sui-core/src/accumulators/design_docs/coin_reservations.md
@@ -1,0 +1,243 @@
+# Coin Reservations: Backward Compatibility for Pre-Address-Balance Clients
+
+This document covers the **coin reservation** compatibility layer — the mechanism that lets
+SDKs and wallets that predate address balances continue to send transactions even when the
+sender's wallet contains *only* address balance and no coin objects to use as gas or inputs.
+
+This is a **transitional** subsystem. The goal is to be invisible to old clients: they think
+they're seeing a regular `Coin<T>` object and using it normally, while the validator-side and
+RPC-side code translates back and forth between the fake coin object and the real address
+balance. Once enough of the ecosystem migrates to native address-balance support, this layer is
+expected to be removed.
+
+For the on-chain data layout, see [`data_model.md`](./data_model.md). For where coin
+reservations enter the write path proper, see [`write_path.md`](./write_path.md) §1.
+
+## 1. The problem
+
+A user's wallet may contain only address balances (virtual `Balance<T>` amounts under the
+accumulator root) and no `Coin<T>` objects. An old SDK that doesn't understand address
+balances has only one way to express "spend some funds": construct a `CallArg::Object` /
+`Gas::ImmOrOwnedObject` reference to a coin. With no real coin objects available, the SDK
+would have nothing to point at, and the wallet would appear empty.
+
+The compatibility layer solves this by **synthesizing a fake `ObjectRef` that *encodes* an
+address-balance withdrawal**. From the SDK's perspective it's just a coin. From the
+validator's and RPC's perspective, the magic value in the object's digest identifies it as a
+disguised withdrawal and triggers a translation pipeline.
+
+## 2. The encoding
+
+A coin-reservation `ObjectRef` is laid out exactly like a regular owned-object reference:
+
+```
+(ObjectID, SequenceNumber, ObjectDigest)
+```
+
+with all three components carrying meaning:
+
+### 2.1 `ObjectID` — masked accumulator object ID
+
+The `ObjectID` is the `AccumulatorObjId` of the underlying balance (which is itself derived
+from `(owner, type)` — see [`data_model.md`](./data_model.md) §3), **XOR-masked with the
+network's chain identifier** (the genesis checkpoint digest):
+
+```rust
+pub fn mask_or_unmask_id(object_id: ObjectID, chain_identifier: ChainIdentifier) -> ObjectID {
+    // 32-byte XOR
+}
+```
+
+(`sui-types/src/coin_reservation.rs:183`.) XOR is its own inverse, so the same function masks
+and unmasks. The mask serves two purposes:
+
+1. **Cross-chain replay protection.** Without masking, a signed transaction containing a fake
+   coin ref against accumulator object `V` on chain A could be replayed against the same `V`
+   on chain B — and an attacker could pre-mine an address whose accumulator id matches a
+   target `V` on the foreign chain. With masking, the on-chain object id the validator
+   actually checks is `V ⊕ chain_id`. To replay against another chain, an attacker would have
+   to mine `(addr, type)` such that `dynamic_field_key(addr, type) ⊕ FOREIGN_CHAIN_ID =
+   TARGET_ACCUMULATOR_ID ⊕ TARGET_CHAIN_ID` — a 256-bit collision search per chain, which is
+   not feasible.
+2. **A natural "is this a fake?" detector for read APIs.** An RPC server that's asked to read
+   the masked id will find no such object (the real object lives at the unmasked id). The
+   server can then unmask, retry, and — if the second read hits an accumulator account —
+   conclude that the original id was a coin-reservation reference. See §4 for how that's used.
+
+### 2.2 `SequenceNumber` — version hint
+
+The `SequenceNumber` field is the version of the accumulator root object at the time the
+fake ref was synthesized. The protocol does **not** read it; it exists purely to help old
+clients that key their object-cache entries on `(id, version)`. Treat it as opaque.
+
+### 2.3 `ObjectDigest` — packed payload
+
+The `ObjectDigest` (32 bytes) is repurposed to carry the actual reservation payload, in three
+fixed-offset fields:
+
+| Bytes  | Field                | Notes                                                             |
+|--------|----------------------|-------------------------------------------------------------------|
+| 0..8   | `reservation_amount` | `u64` little-endian. The maximum the tx may withdraw.             |
+| 8..12  | `epoch_id`           | `u32` little-endian. The epoch in which the tx is valid.          |
+| 12..32 | magic constant       | `0xac` × 20. Used to recognize a coin-reservation digest.         |
+
+The magic constant gives `ParsedDigest::is_coin_reservation_digest` a cheap check
+(`sui-types/src/coin_reservation.rs:95`). The 4-byte epoch field is a *very* generous
+budget — at one epoch per day it's more than 12 million years.
+
+The encode/decode roundtrip lives in `sui-types/src/coin_reservation.rs:107-137`
+(`ParsedDigest <-> ObjectDigest`) and `:170-181`
+(`ParsedObjectRefWithdrawal::parse` / `::encode`).
+
+## 3. The pipeline
+
+A coin-reservation `ObjectRef` flows through the system in a fixed sequence:
+
+```
+   Old client / SDK
+        │
+        │ get_all_coins(owner)  ──────►  RPC returns synthesized
+        │ get_object(masked_id)          fake Coin<T> objects
+        │                                (see §4 below)
+        ▼
+   Construct tx using
+   the fake ObjectRef as
+   gas or as an input
+        │
+        ▼
+   ┌──────────────────────────────────────────┐
+   │ Signing-time validation                  │
+   │  - validity_check (transaction.rs:830)   │
+   │  - is_coin_reservation_digest gate       │
+   │  - sender == owner check on accumulator  │
+   │  - gas-only: must be Balance<SUI>,       │
+   │    sponsorship not allowed               │
+   └────────────────┬─────────────────────────┘
+                    │
+                    ▼
+   ┌──────────────────────────────────────────┐
+   │ Execution-time rewriting                 │
+   │  rewrite_transaction_for_coin_           │
+   │    reservations (transaction_rewriting   │
+   │    .rs:19)                               │
+   │  fake ObjectRef ──► CallArg::FundsWith-  │
+   │    drawal(FundsWithdrawalArg{...})       │
+   └────────────────┬─────────────────────────┘
+                    │
+                    ▼
+   Same write path as native address balances
+   (see write_path.md §1)
+```
+
+### 3.1 Read-side: what RPC returns
+
+The synthesized refs are produced by RPC code, not by users. The two main paths are:
+
+- **`AuthorityState::get_address_balance_coin_info(owner, balance_type)`**
+  — looks up the on-chain accumulator object for `(owner, type)`, reads
+  the current balance, and calls `coin_reservation::encode_object_ref` to package it into a
+  fake `ObjectRef`. Returns `(fake_ref, balance, last_tx_digest)`.
+- **`AuthorityState::get_all_address_balance_coin_infos(owner)`** — same idea, but iterates every
+  coin type the owner
+  has a balance in.
+
+These are wired into `getCoins`, `getAllCoins`, `getObject`, etc. from the
+`sui-json-rpc::authority_state` shim layer.
+
+### 3.2 Read-side: handling `getObject(masked_id)`
+
+When a client calls `getObject` with a masked id, the on-chain object doesn't exist (the real
+object lives at the unmasked id). The fallback in
+`sui_json_rpc::authority_state::get_object_read` implements the two-phase trick from §2.1:
+
+1. Try the requested id. If it exists, return it (i.e., the masked id collided with a real
+   object — vanishingly unlikely, but handled).
+2. If not, unmask using the local chain id and try again.
+3. If the second read hits a balance accumulator field, synthesize a fake `Coin<T>` object
+   (an `Object` whose `MoveObject` is a coin with the masked id and the current balance)
+   and return *that*. Otherwise return the original `NotExists`.
+
+Step 3 is what makes the layer transparent to old clients: they ask for the coin they were
+told about, and get back something that walks like a coin and quacks like a coin, even though
+no such on-chain object actually exists.
+
+### 3.3 Signing-time validation
+
+`CallArg::validity_check` gates coin-reservation refs behind the
+`enable_coin_reservation_obj_refs` protocol flag. If the flag is off and a digest matches the
+magic, the transaction is rejected with `Unsupported`.
+
+For gas, the validity check is stricter inside `TransactionData::check_gas`:
+
+- The reservation must be for `Balance<SUI>` specifically (the unmasked id must equal
+  `AccumulatorValue::get_field_id(sender, Balance<SUI>)`).
+- `gas_owner == sender` — sponsorship is **not** supported via coin reservations. (Native
+  `FundsWithdrawalArg::balance_from_sponsor` *does* support sponsorship; the restriction is
+  specific to the legacy path.)
+
+Validity checks that need owner/type information also resolve the unmasked accumulator object
+through `CoinReservationResolver` (`sui-types/src/coin_reservation.rs:210`). The
+`CachingCoinReservationResolver` (`accumulators/coin_reservations.rs:20`) wraps it with a
+moka cache: `(owner, type_tag)` for an accumulator never changes once the object exists, so
+successful lookups and certain permanent errors are cached. **Transient `not_found` is not
+cached** — the accumulator may not exist on this node yet but will appear once the relevant
+settlement transaction executes; caching the miss would poison the cache.
+
+### 3.4 Execution-time rewriting
+
+`accumulators::transaction_rewriting::rewrite_transaction_for_coin_reservations` is invoked just
+before execution. It walks the PTB inputs; for each
+`CallArg::Object(ImmOrOwnedObject(ref))` whose digest parses as a coin-reservation digest, it:
+
+1. Parses the ref into `ParsedObjectRefWithdrawal`.
+2. Calls `coin_reservation_resolver.resolve_funds_withdrawal(sender, parsed,
+   accumulator_version)` to get the canonical `FundsWithdrawalArg`. The
+   `accumulator_version` matters during checkpoint replay: we read the accumulator at the
+   version *before* any settlement transaction in the same checkpoint has modified it.
+3. Replaces the input with `CallArg::FundsWithdrawal(...)`.
+
+After this rewrite the transaction looks identical to one a modern SDK would have built,
+and from `process_funds_withdrawals_for_execution` onwards (see
+[`write_path.md`](./write_path.md) §1) there is no longer any distinction.
+
+Note that the gas path does **not** go through this rewriter today — gas coin reservations
+are detected and accumulated inside `process_funds_withdrawals_for_execution` directly
+(`TransactionData::process_funds_withdrawals_for_execution`). The two paths converge at the
+per-account reservation map.
+
+## 4. Why this design
+
+A few choices in the encoding are worth calling out:
+
+- **Why XOR instead of an HMAC or signature?** XOR is symmetric (one function masks and
+  unmasks), free in CPU, and sufficient: the security argument is collision resistance on
+  256-bit ids, not unforgeability. An attacker can construct any masked id they like; what
+  they cannot do is make it resolve to *someone else's* real accumulator on a target chain.
+- **Why pack the amount into the digest?** A coin reservation needs to carry an amount so the
+  validator knows the cap; the digest is the only field with 32 free bytes. The remaining
+  20 bytes go to the magic constant, which both signals "this is a reservation" and
+  squeezes the chance of a collision with a real object digest into negligible territory.
+- **Why a magic byte pattern instead of a typed enum?** Because the wire format must be a
+  raw `ObjectDigest` — old clients and serialization paths don't have a "or a reservation
+  envelope" branch to look at. The magic is the cheapest in-band tag that fits.
+- **Why no sponsorship for gas reservations?** Sponsorship would mean someone *other than*
+  the sender pays gas. The legacy path's encoding only carries one address (the unmasked
+  accumulator id, which always belongs to the sender), so sponsorship can't be expressed
+  here without a wire-format change. Modern transactions that need sponsored gas should use
+  the native `FundsWithdrawalArg::balance_from_sponsor` path instead.
+
+## 5. Lifecycle
+
+This whole layer is intended to be temporary. Once enough SDKs and wallets natively support
+`FundsWithdrawalArg`, the protocol-config flag (`enable_coin_reservation_obj_refs`) can be
+disabled and the supporting code removed. The natural cleanup order:
+
+1. RPC stops returning fake coin refs (`get_address_balance_coin_info` and friends).
+2. The protocol flag is turned off — signing-time validation rejects any remaining
+   coin-reservation digests.
+3. After a deprecation window, the rewriting code, the `coin_reservation` module, and this
+   doc are deleted.
+
+Until then: treat all of `coin_reservation.rs`, `accumulators/coin_reservations.rs`, and
+`accumulators/transaction_rewriting.rs` as belonging to one cohesive subsystem documented
+here.

--- a/crates/sui-core/src/accumulators/design_docs/data_model.md
+++ b/crates/sui-core/src/accumulators/design_docs/data_model.md
@@ -164,7 +164,7 @@ The same machinery supports balances owned by *another object* rather than an ad
 too, so the same dynamic-field structure works. The differences are operational, not structural:
 
 - An object-owned balance is mutated by Move code that has access to that object. Therefore the
-  withdrawal *amount* is decided at runtime, inside the Move VM.
+  withdrawal *amount* is decided at runtime, inside the PTB.
 - Sufficiency must be checked *after* execution. That is what
   [`object_funds_checking.md`](./object_funds_checking.md) is about.
 

--- a/crates/sui-core/src/accumulators/design_docs/data_model.md
+++ b/crates/sui-core/src/accumulators/design_docs/data_model.md
@@ -1,0 +1,224 @@
+# Address Balances: Data Model
+
+This document covers **how virtual balances are laid out on-chain**: the accumulator root, the
+per-account dynamic field, the value representation, and the version invariant. It is purely
+about data structures — the algorithms that read and modify them live in
+[`write_path.md`](./write_path.md), [`address_funds_scheduling.md`](./address_funds_scheduling.md),
+and [`object_funds_checking.md`](./object_funds_checking.md).
+
+## 1. The accumulator root
+
+There is exactly one accumulator root object per network, at the well-known address
+`SUI_ACCUMULATOR_ROOT_OBJECT_ID` (commonly written `0xACC`). It is a **shared object**, with its
+initial shared version recorded in the epoch start configuration
+(`accumulator_root_obj_initial_shared_version`).
+
+Every virtual balance is a dynamic field hanging off this single root, so all balance reads and
+writes touch the same object identity. From a consensus perspective, the root is therefore a
+heavily-contended shared object — which is precisely why the system goes to such lengths to
+**not** force every withdraw to wait on a strict version chain. See
+[`write_path.md`](./write_path.md) §3 for how shared-object access modes (`NonExclusiveWrite` vs.
+`Mutable`) make parallel settlement work.
+
+The root carries a `SequenceNumber` like any other object. We call this the **accumulator
+version**, and it is bumped exactly once per consensus commit, by the barrier transaction
+(see §4 below and [`write_path.md`](./write_path.md) §3).
+
+## 2. Per-account accumulator objects
+
+Each address-owned virtual balance is a dynamic field under `0xACC`, keyed by
+`accumulator::Key<Balance<T>>` and storing a Move value of type
+`accumulator::U128 { value: u128 }`.
+
+The relevant Rust types live in `sui-types/src/accumulator_root.rs`:
+
+```rust
+pub struct AccumulatorKey { pub owner: SuiAddress }
+
+pub enum AccumulatorValue {
+    U128(U128),
+}
+
+pub struct U128 { pub value: u128 }
+```
+
+A wrapper `AccumulatorObjId` newtypes the underlying `ObjectID` so the rest of the codebase can
+make it impossible to confuse "any object id" with "an accumulator account id":
+
+```rust
+pub struct AccumulatorObjId(ObjectID);
+```
+
+Sui balances are nominally `u64`, but the accumulator stores them as `u128`. The wider storage
+type is forward-looking: it leaves room to extend the system to `u128`-denominated balance
+types in the future without an on-chain migration. Since storage types are effectively
+permanent (changing them requires a migration of every accumulator account), it pays to be
+conservative here.
+
+## 3. ID derivation
+
+`AccumulatorObjId` is derived deterministically from `(owner_address, balance_type)`. The
+derivation goes through Sui's standard dynamic-field ID machinery, with the parent set to
+`SUI_ACCUMULATOR_ROOT_OBJECT_ID` and the field name set to `Key<Balance<T>>`:
+
+```rust
+pub fn get_field_id(owner: SuiAddress, type_: &TypeTag) -> SuiResult<AccumulatorObjId> {
+    if !Balance::is_balance_type(type_) {
+        return Err(...); // only Balance<T> is supported today
+    }
+    let key = AccumulatorKey { owner };
+    Ok(AccumulatorObjId(
+        DynamicFieldKey(
+            SUI_ACCUMULATOR_ROOT_OBJECT_ID,
+            key,
+            AccumulatorKey::get_type_tag(std::slice::from_ref(type_)),
+        )
+        .into_unbounded_id()?
+        .as_object_id(),
+    ))
+}
+```
+
+(implemented by `AccumulatorValue::get_field_id` in `sui-types::accumulator_root`)
+
+The implication is that **any caller can compute the `AccumulatorObjId` for `(addr, T)` without
+reading state**. That is what makes the address-funds scheduler's pre-execution analysis
+possible — given a `FundsWithdrawalArg` and the transaction's sender/sponsor, the scheduler
+knows exactly which account ids the withdraw will touch (see
+[`write_path.md`](./write_path.md) §1 and [`address_funds_scheduling.md`](./address_funds_scheduling.md) §1).
+
+## 4. The accumulator version
+
+The accumulator version (the `SequenceNumber` of `0xACC`) is the linchpin of the whole system.
+Three things to internalize:
+
+1. **It advances by exactly one per settlement batch.** Even though the on-chain settlement is
+   spread across multiple transactions (N parallel settlement txns plus a barrier — see
+   [`write_path.md`](./write_path.md) §4), only the barrier mutates the accumulator root. So
+   the version goes from V to V+1 in a single step, atomically with the barrier transaction's
+   effects. In the common case there is one such batch for the ordinary transactions derived from
+   a consensus commit, but the code can also construct an additional accumulator settlement batch
+   for the randomness lane. The invariant is therefore per settlement batch, not globally "once
+   per consensus commit".
+
+2. **All withdraws and deposits within a single settlement batch read the same accumulator version.**
+   Shared-object version assignment pins every transaction in that batch that touches
+   `0xACC` to one version V, and the barrier that closes the batch bumps the version to V+1.
+   This means transactions within that batch see *identical* balances (in storage), which is
+   what motivates the unsettled-withdraws tracking in
+   [`object_funds_checking.md`](./object_funds_checking.md) §2.
+
+3. **The version is *not* an execution dependency for withdraws.** A transaction at version V+1
+   does **not** have to wait for the V→V+1 settlement to finish executing before it can execute
+   itself. The eager scheduler may approve it immediately based on in-memory balance bookkeeping
+   (see [`address_funds_scheduling.md`](./address_funds_scheduling.md) §3). The version is a
+   logical label that tells the scheduler which "snapshot" to reason about, not a barrier the
+   transaction has to physically clear.
+
+The per-account accumulator object itself is also versioned. Reads can be **version-bounded**:
+
+```rust
+AccumulatorValue::load(child_object_resolver, version_bound, owner, type_) -> Option<Self>
+```
+
+This is how `AccountFundsRead::get_account_amount_at_version` works. Version-bounded reads use
+the dynamic-field MVCC machinery (`BoundedDynamicFieldID`); they let the system read "what was
+the balance at the accumulator version this transaction was assigned" even when storage has
+since moved past.
+
+That does **not** mean arbitrary historical reads are always available. The contract on
+`AccountFundsRead::get_account_amount_at_version` is narrower: callers must only use it when they
+can guarantee the target version has not yet been pruned. In practice, old versions remain
+available only while the system has not finalized enough checkpoint progress to make them
+prune-eligible.
+
+That precision is necessary whenever correctness depends on the answer to the historical
+question "what balance did version V observe?" rather than the latest-state question "has the
+system already advanced past V?" The two scheduler/checker subsystems intentionally ask
+different questions:
+
+- The **address-funds scheduler** mostly needs the latest-state question. It is deciding whether
+  to reserve a transaction *before* execution, and if storage has already advanced past the
+  requested version then the request is stale and can be handed off via `SkipSchedule` to the
+  rest of execution, which will observe the already-applied settlement effects through normal
+  state reads.
+- The **object-funds checker** needs the historical question. It runs *after* execution, once a
+  transaction has already produced accumulator events, and it must decide whether those effects
+  are valid for the transaction's assigned accumulator version. At that point a latest-state read
+  would be unsafe: storage may already include later settlements that this transaction was not
+  allowed to rely on.
+
+That is also why the implementation is careful about *when* it attempts such reads. If checkpoint
+progress advances far enough while a historical read is in flight, the old version can become
+prune-eligible. The code therefore "dances" around the root version and checkpoint progress to
+make sure it is reading inside a window where the target historical version is still guaranteed to
+exist.
+
+The rest of this design directory is largely about keeping those two questions from being
+accidentally conflated.
+
+## 5. Object-owned virtual balances
+
+The same machinery supports balances owned by *another object* rather than an address. The
+`AccumulatorKey { owner }` field is a `SuiAddress`, but a Move object's UID encodes as an address
+too, so the same dynamic-field structure works. The differences are operational, not structural:
+
+- An object-owned balance is mutated by Move code that has access to that object. Therefore the
+  withdrawal *amount* is decided at runtime, inside the Move VM.
+- Sufficiency must be checked *after* execution. That is what
+  [`object_funds_checking.md`](./object_funds_checking.md) is about.
+
+The on-chain layout is unchanged: still a dynamic field under `0xACC`, still a `U128` value,
+still derived deterministically from `(owner, type)`.
+
+## 6. Lifecycle
+
+A given accumulator account object goes through a small number of states during its lifetime:
+
+```
+      not-yet-created
+           │
+           │  first deposit settles
+           ▼
+      ┌─────────────────────┐
+      │  exists, balance>0  │
+      └─────────────────────┘
+           │  ▲
+   each    │  │  each
+   settle  │  │  settle
+           ▼  │
+      ┌─────────────────────┐
+      │  exists, balance=0  │
+      └─────────────────────┘
+           │
+           │  garbage-collected when an
+           │  empty account is left
+           │  empty after settlement
+           ▼
+      destroyed (deleted as part of settlement)
+```
+
+The exact creation/deletion behavior is enforced by the settlement Move logic
+(`accumulator_settlement::settle_u128`). The barrier transaction records counts of accounts
+created and destroyed via `record_accumulator_object_changes` for metrics. From the Rust
+scheduler's point of view, this lifecycle is mostly invisible — it sees deposits and withdrawals
+as `funds_changes: BTreeMap<AccumulatorObjId, i128>` deltas — but it is reflected in the
+storage-version reads:
+
+- For an account that doesn't exist yet, `get_latest_account_amount` returns
+  `(0, current_root_version)`.
+- After deletion, the same call returns `(0, current_root_version)`.
+- Between creation and deletion, it returns `(balance, account_object_version)`.
+
+This shape — "balance plus the version it was read at" — is what lets the scheduler detect when
+storage has advanced past a request even without an in-process settlement notification (see
+[`address_funds_scheduling.md`](./address_funds_scheduling.md) §3).
+
+## 7. Off-topic data: event streams
+
+For completeness: the accumulator infrastructure is also used to host *event streams* (the
+`EventStreamHead` machinery in `accumulator_root.rs`). Those are **not** balances and are not
+covered by the rest of this directory. They share the dynamic-field-under-`0xACC` storage shape
+but live in a different module (`accumulator_settlement::EventStreamHead`) and are settled with a
+different Move entrypoint (`settle_events`). If you are working on event streams, treat the rest
+of these docs as informative context rather than authoritative.

--- a/crates/sui-core/src/accumulators/design_docs/data_model.md
+++ b/crates/sui-core/src/accumulators/design_docs/data_model.md
@@ -163,9 +163,10 @@ The same machinery supports balances owned by *another object* rather than an ad
 `AccumulatorKey { owner }` field is a `SuiAddress`, but a Move object's UID encodes as an address
 too, so the same dynamic-field structure works. The differences are operational, not structural:
 
-- An object-owned balance is mutated by Move code that has access to that object. Therefore the
-  withdrawal *amount* is decided at runtime, inside the PTB.
-- Sufficiency must be checked *after* execution. That is what
+- An object-owned balance can only be withdrawn from by a Move program with access to the owning
+  object, and the withdrawal *amount* is determined by that program's logic at runtime — not
+  declared up front in transaction data.
+- Sufficiency must therefore be checked *after* execution. That is what
   [`object_funds_checking.md`](./object_funds_checking.md) is about.
 
 The on-chain layout is unchanged: still a dynamic field under `0xACC`, still a `U128` value,

--- a/crates/sui-core/src/accumulators/design_docs/object_funds_checking.md
+++ b/crates/sui-core/src/accumulators/design_docs/object_funds_checking.md
@@ -15,9 +15,10 @@ and concepts but are distinct subsystems with different correctness arguments.
 
 Address funds withdrawals have a key advantage: the maximum withdrawal amount is declared in
 the transaction data, so it can be checked before the transaction is run. Object funds withdrawals
-have no such advantage. An object-owned accumulator account is controlled by a Move program,
-and the withdrawal amount is computed at runtime. There is no way to know how much will be
-withdrawn until execution finishes.
+have no such advantage. An object-owned accumulator account can only be withdrawn from by a Move
+program with access to the owning object, and the withdrawal amount is determined by that
+program's logic at runtime. There is no way to know how much will be withdrawn until execution
+finishes.
 
 This means the system must **execute first, then check**. If the check fails, the transaction
 must be re-executed in a way that produces a deterministic failure.

--- a/crates/sui-core/src/accumulators/design_docs/object_funds_checking.md
+++ b/crates/sui-core/src/accumulators/design_docs/object_funds_checking.md
@@ -2,7 +2,7 @@
 
 This document covers the **post-execution** sufficiency check for object-owned virtual balance
 withdrawals — the work done by `ObjectFundsChecker` (in
-`crates/sui-core/src/accumulators/object_funds_checker/`) after the Move VM finishes a
+`crates/sui-core/src/accumulators/object_funds_checker/`) after PTB execution finishes a
 transaction that withdrew from object-owned accumulator accounts.
 
 For the on-chain data layout, see [`data_model.md`](./data_model.md). For how withdrawals are
@@ -14,7 +14,7 @@ and concepts but are distinct subsystems with different correctness arguments.
 ## 1. Why post-execution?
 
 Address funds withdrawals have a key advantage: the maximum withdrawal amount is declared in
-the transaction data, so it can be checked before the Move VM runs. Object funds withdrawals
+the transaction data, so it can be checked before the transaction is run. Object funds withdrawals
 have no such advantage. An object-owned accumulator account is controlled by a Move program,
 and the withdrawal amount is computed at runtime. There is no way to know how much will be
 withdrawn until execution finishes.
@@ -25,7 +25,7 @@ must be re-executed in a way that produces a deterministic failure.
 ```
   ┌───────────────┐     ┌───────────────────┐     ┌────────────────────┐
   │ Execute       │     │ ObjectFundsChecker │     │ Commit Effects     │
-  │ Move VM       │ ──> │ (post-execution    │ ──> │                    │
+  │ adapter       │ ──> │ (post-execution    │ ──> │                    │
   │               │     │  sufficiency check)│     │                    │
   └───────────────┘     └────────┬──────────┘     └────────────────────┘
                                  │
@@ -40,7 +40,7 @@ must be re-executed in a way that produces a deterministic failure.
 
 ### Computing the withdrawal amount: the running max
 
-After the Move VM finishes executing a transaction, the system examines all accumulator events
+After the adapter finishes executing a transaction, the system examines all accumulator events
 produced during execution. These events are either **Split** operations (withdrawals — taking
 funds out of an account) or **Merge** operations (deposits — putting funds into an account).
 See [`write_path.md`](./write_path.md) §3 for the event types.
@@ -145,7 +145,7 @@ settled and the checker can make a definitive decision.
 When the version **is settled** but the balance is insufficient, the checker immediately sends
 an `Insufficient` status. The transaction is re-enqueued with
 `FundsWithdrawStatus::Insufficient` set in its `ExecutionEnv`, so the next execution
-short-circuits with an `InsufficientFundsForWithdraw` error without running the Move VM.
+short-circuits with an `InsufficientFundsForWithdraw` error without executing the transaction.
 
 One subtlety worth noting: a balance read at a historical version is only meaningful if that
 version is still readable. This is guaranteed by the pipeline, not by a separate retention
@@ -277,7 +277,7 @@ approved, allowing 1100 to be withdrawn from an account with only 1000.
 
 **Consensus Commit at version 6** contains TX1, which reads accumulator version 6.
 
-**TX1's first execution**: the Move VM runs and produces a running max withdrawal of 200 from
+**TX1's first execution**: the transaction is executed and produces a running max withdrawal of 200 from
 Y.
 
 - Checker sees accumulator version 6. Last settled version is 5.
@@ -290,7 +290,7 @@ Y.
 `MaybeSufficient` through its oneshot channel. The background task re-enqueues TX1 for
 execution.
 
-**TX1's second execution**: the Move VM runs again (same code, same inputs) and again produces
+**TX1's second execution**: the transaction is executed again (same code, same inputs) and again produces
 a running max withdrawal of 200 from Y.
 
 - Checker sees accumulator version 6. Last settled version is now 6.
@@ -303,7 +303,7 @@ a running max withdrawal of 200 from Y.
 
 If the balance after settlement had been only 100, the checker would have immediately sent
 `Insufficient`. TX1 would be re-enqueued with the insufficient flag, and its third execution
-would produce an `InsufficientFundsForWithdraw` early error without running the Move VM.
+would produce an `InsufficientFundsForWithdraw` early error without executing the transaction.
 
 ## 4. Garbage collection
 
@@ -348,15 +348,15 @@ While both systems validate withdrawals against accumulator balances, they diffe
 fundamental ways:
 
 **When the amount is known.** Address fund withdrawal maximums are declared in the
-transaction data and known before execution. Object fund withdrawal amounts are computed by
-the Move VM during execution.
+transaction data and known before execution. Object fund withdrawal amounts are computed
+during execution.
 
 **When the check happens.** Address funds are checked *before* execution (pre-execution gate).
 Object funds are checked *after* execution (post-execution validation).
 
 **How insufficient funds are handled.** For address funds, the eager scheduler can
-immediately fail the transaction — the Move VM never runs. For object funds, the Move VM has
-already run; the checker must re-enqueue the transaction for a second execution with an
+immediately fail the transaction. For object funds, the PTB has
+already been run; the checker must re-enqueue the transaction for a second execution with an
 `Insufficient` flag that triggers an early error.
 
 **Reservation vs. exact amounts.** The address funds scheduler uses conservative reservations

--- a/crates/sui-core/src/accumulators/design_docs/object_funds_checking.md
+++ b/crates/sui-core/src/accumulators/design_docs/object_funds_checking.md
@@ -1,0 +1,376 @@
+# Object Funds Checking (Post-Execution)
+
+This document covers the **post-execution** sufficiency check for object-owned virtual balance
+withdrawals — the work done by `ObjectFundsChecker` (in
+`crates/sui-core/src/accumulators/object_funds_checker/`) after the Move VM finishes a
+transaction that withdrew from object-owned accumulator accounts.
+
+For the on-chain data layout, see [`data_model.md`](./data_model.md). For how withdrawals are
+declared, executed, and settled, see [`write_path.md`](./write_path.md). For the
+**pre-execution** check used for address-owned accumulator accounts, see
+[`address_funds_scheduling.md`](./address_funds_scheduling.md). The two checks share machinery
+and concepts but are distinct subsystems with different correctness arguments.
+
+## 1. Why post-execution?
+
+Address funds withdrawals have a key advantage: the maximum withdrawal amount is declared in
+the transaction data, so it can be checked before the Move VM runs. Object funds withdrawals
+have no such advantage. An object-owned accumulator account is controlled by a Move program,
+and the withdrawal amount is computed at runtime. There is no way to know how much will be
+withdrawn until execution finishes.
+
+This means the system must **execute first, then check**. If the check fails, the transaction
+must be re-executed in a way that produces a deterministic failure.
+
+```
+  ┌───────────────┐     ┌───────────────────┐     ┌────────────────────┐
+  │ Execute       │     │ ObjectFundsChecker │     │ Commit Effects     │
+  │ Move VM       │ ──> │ (post-execution    │ ──> │                    │
+  │               │     │  sufficiency check)│     │                    │
+  └───────────────┘     └────────┬──────────┘     └────────────────────┘
+                                 │
+                    ┌────────────┼────────────┐
+                    │            │            │
+               Sufficient   Pending       Pending
+               (commit      (version      (version settled,
+                effects)     unsettled,    insufficient →
+                             wait then     re-execute with
+                             re-execute)   Insufficient flag)
+```
+
+### Computing the withdrawal amount: the running max
+
+After the Move VM finishes executing a transaction, the system examines all accumulator events
+produced during execution. These events are either **Split** operations (withdrawals — taking
+funds out of an account) or **Merge** operations (deposits — putting funds into an account).
+See [`write_path.md`](./write_path.md) §3 for the event types.
+
+The system computes a value called `accumulator_running_max_withdraws` (stored on
+`InnerTemporaryStore`), which represents the **peak net withdrawal** for each account at any
+point during the transaction. The idea is to track the high-water mark of how much an account
+is "in the red" at any moment during execution.
+
+The algorithm walks through each event in order and maintains a running signed counter per
+account:
+
+- **Split(amount)** — adds `amount` to the running net withdrawal for that account.
+- **Merge(amount)** — subtracts `amount` from the running net withdrawal for that account.
+
+Whenever the running net withdrawal for an account becomes positive and exceeds the previous
+peak, the peak is updated. The final output is the peak value for each account.
+
+Consider a transaction that produces the following events for Account X:
+
+| Event       | Running Net Withdrawal | Peak |
+|-------------|------------------------|------|
+| Split(100)  | 100                    | 100  |
+| Merge(100)  | 0                      | 100  |
+| Split(100)  | 100                    | 100  |
+
+The running max for Account X is **100**, not 200. Although 200 worth of splits occurred, 100
+was re-deposited in between, so the account was never more than 100 "in the red" at any one
+time. This is the amount the checker needs to validate against the account's balance.
+
+Another example:
+
+| Event       | Running Net Withdrawal | Peak |
+|-------------|------------------------|------|
+| Split(300)  | 300                    | 300  |
+| Split(200)  | 500                    | 500  |
+| Merge(100)  | 400                    | 500  |
+
+Here the running max is **500** — that's the moment when the account was furthest in the red.
+
+### Separating address vs. object withdrawals
+
+A single transaction can have both address and object withdrawals. After execution, the
+checker needs to identify which withdrawals are which. It does this by comparing the
+accumulator events against the transaction's pre-declared address funds reservations (from
+[`address_funds_scheduling.md`](./address_funds_scheduling.md) §1). Any accumulator account
+that appears in the running max withdrawals but was **not** pre-declared as an address
+withdrawal is treated as an object withdrawal that needs post-execution checking.
+
+If there are no object withdrawals, the checker returns immediately and effects are committed.
+
+## 2. The check: settled vs. unsettled
+
+The checker needs to determine whether the account has enough funds to cover the computed
+running max withdrawal. This depends on whether the transaction's accumulator version has
+already been settled. The checker tracks `last_settled_version` via a `tokio::sync::watch`
+channel; that channel is bumped from inside `process_certificate` whenever a **barrier
+transaction** finishes executing (see [`write_path.md`](./write_path.md) §4.3). This is
+convenient given the two settlement paths described in
+[`write_path.md`](./write_path.md) §5: whether the barrier ran via the validator's settlement
+scheduler or via the checkpoint executor, the same hook fires, so the watch channel stays
+accurate without any path-specific code.
+
+```
+  Object withdrawal computed after execution
+       │
+       ▼
+  Is the accumulator version already settled?
+       │
+    ┌──┴──┐
+   YES    NO
+    │      │
+    │      ▼
+    │   WAIT: spawn watcher task
+    │   (blocks until version settles,
+    │    then re-enqueue transaction
+    │    with MaybeSufficient status)
+    │
+    ▼
+  Read balance at version.
+  Subtract unsettled withdrawals (see §2.1).
+  Is the effective balance ≥ running max withdrawal?
+       │
+    ┌──┴──┐
+   YES    NO
+    │      │
+    │      ▼
+    │   FAIL: re-enqueue with Insufficient flag
+    │   (next execution will produce early error)
+    │
+    ▼
+  SUCCESS: record this withdrawal as unsettled,
+  commit effects normally
+```
+
+When the version is **not yet settled**, the checker cannot know the final balance — a
+deposit in the same or earlier commit might change it. So it spawns a background task that
+watches the `watch` channel for the settled version to advance. When settlement arrives, the
+task re-enqueues the transaction for re-execution. On the second pass, the version will be
+settled and the checker can make a definitive decision.
+
+When the version **is settled** but the balance is insufficient, the checker immediately sends
+an `Insufficient` status. The transaction is re-enqueued with
+`FundsWithdrawStatus::Insufficient` set in its `ExecutionEnv`, so the next execution
+short-circuits with an `InsufficientFundsForWithdraw` error without running the Move VM.
+
+One subtlety worth noting: a balance read at a historical version is only meaningful if that
+version is still readable. This is guaranteed by the pipeline, not by a separate retention
+mechanism. Versions ahead of the checkpoint executor are still held in memory; versions at or
+behind the executor are persisted and only become prune-eligible once the executor advances past
+them. A transaction whose `ObjectFundsChecker` is still running has, by definition, not yet been
+executed — so the checkpoint containing it has not been finalized, and the executor sits at or
+before it. Every version the checker can be asked about is therefore either in memory or still on
+disk, and safe to read.
+
+### 2.1 Why object funds cannot just "skip" like address funds
+
+It is tempting to ask whether object funds could use the same shortcut as the address-funds
+scheduler: if storage has already advanced past version V, why not simply declare the request
+stale and move on?
+
+The answer is that object-funds checking runs at a different point in the pipeline and therefore
+has a different responsibility. By the time `ObjectFundsChecker` runs:
+
+- the transaction has already executed once,
+- it has already produced concrete accumulator events and a running-max withdrawal,
+- and there is no separate pre-execution scheduler left to "hand off" the transaction to.
+
+Address funds have that handoff point. When `schedule_withdraws` returns `SkipSchedule`, it is
+deliberately saying "some other execution path already advanced the authoritative state for this
+version, so the dedicated address-funds gate should stop here." The transaction can continue
+through the normal execution pipeline, which is the component that owns the next step.
+
+Object funds do not have an equivalent escape hatch. The checker itself is the component that
+owns the post-execution decision: commit these effects, retry later, or force a deterministic
+insufficient-funds failure. If it merely observed that latest storage had advanced and then
+"skipped", it would lose the only point where the already-executed transaction's object-withdraw
+effects are reconciled against the version they were actually assigned.
+
+This is why the checker waits for settlement visibility and then re-checks against the
+transaction's assigned accumulator version, rather than trying to treat "latest storage is
+newer" as a sufficient answer.
+
+### 2.2 Preventing double-spending: unsettled withdrawals tracking
+
+There is a subtle problem. All transactions in the same consensus commit read the **same**
+accumulator version, and balances in storage are only updated by settlement transactions. So
+if TX1 and TX2 both read version 5 and both withdraw from the same object account, the balance
+they each see in storage is identical. Without additional tracking, the checker would approve
+both withdrawals against the full balance, potentially allowing more to be withdrawn than the
+account holds.
+
+The `ObjectFundsChecker` solves this with a structure called `unsettled_withdraws`:
+
+```rust
+unsettled_withdraws: BTreeMap<AccumulatorObjId, BTreeMap<SequenceNumber, u128>>
+```
+
+This tracks, for each account at each version, how much has been approved but not yet
+settled. When the checker evaluates a new withdrawal, it reads the balance from storage and
+**subtracts** the already-tracked unsettled amount for that account and version:
+
+```
+effective_balance = storage_balance_at_version - unsettled_withdrawals_at_version
+```
+
+If the effective balance is sufficient, the checker approves the withdrawal and adds the new
+amount to the unsettled tracking. This ensures that each subsequent check sees a progressively
+reduced available balance.
+
+A companion structure, `unsettled_accounts`, tracks which accounts have unsettled entries at
+each version. This is used for garbage collection (§4) and is not required for correctness.
+
+### 2.3 Determinism
+
+Object funds checking is deterministic, but through a different mechanism than the address-funds
+scheduler. A transaction can only withdraw from an object by taking that object as a mutable
+input. Sui's execution model already serializes any transactions that share a mutable input, so
+for each object account, all withdrawals from it are linearized in a single consensus-determined
+order — even though unrelated transactions across the system execute in parallel.
+
+The checker leverages this directly: for any given object, it sees withdrawals one at a time, in
+the same order on every validator. Combined with the unsettled-withdrawals tracking, this means
+every validator deducts the same amounts in the same order from each object's balance, and so
+arrives at the same sufficient/insufficient decisions. Determinism is per-object, which is
+exactly the granularity object-funds checking requires.
+
+## 3. Worked examples
+
+### 3.1 Double-spend prevention within a consensus commit
+
+**Setup**: Object account X has balance 1000 at version 5. Version 5 is already settled.
+
+Three transactions in the same consensus commit all read version 5 and withdraw from X:
+
+**TX1 executes**: running max for X is 300.
+
+- Checker reads balance: 1000.
+- Unsettled at (X, v5): 0.
+- Effective balance: 1000 − 0 = 1000 ≥ 300 → **sufficient**.
+- Update unsettled: (X, v5) = 300.
+- Effects committed.
+
+**TX2 executes**: running max for X is 400.
+
+- Checker reads balance: 1000 (unchanged in storage — no settlement yet).
+- Unsettled at (X, v5): 300.
+- Effective balance: 1000 − 300 = 700 ≥ 400 → **sufficient**.
+- Update unsettled: (X, v5) = 700.
+- Effects committed.
+
+**TX3 executes**: running max for X is 400.
+
+- Checker reads balance: 1000.
+- Unsettled at (X, v5): 700.
+- Effective balance: 1000 − 700 = 300 < 400 → **insufficient**.
+- TX3 is re-enqueued with `Insufficient` flag. Its next execution will fail with an early
+  error.
+
+```
+  Storage balance: 1000 (constant — hasn't settled yet)
+
+  TX1: needs 300   effective = 1000 - 0   = 1000 ≥ 300 ✓   unsettled → 300
+  TX2: needs 400   effective = 1000 - 300 =  700 ≥ 400 ✓   unsettled → 700
+  TX3: needs 400   effective = 1000 - 700 =  300 < 400 ✗   → Insufficient
+```
+
+Without the unsettled tracking, all three would see the full 1000 balance and all would be
+approved, allowing 1100 to be withdrawn from an account with only 1000.
+
+### 3.2 Pending check with re-execution
+
+**Setup**: Object account Y has balance 500 at version 5. Last settled version is 5.
+
+**Consensus Commit at version 6** contains TX1, which reads accumulator version 6.
+
+**TX1's first execution**: the Move VM runs and produces a running max withdrawal of 200 from
+Y.
+
+- Checker sees accumulator version 6. Last settled version is 5.
+- Version 6 > settled version 5 → **unsettled**, cannot check yet.
+- Checker spawns a background watcher task and returns `Pending`.
+- `should_commit_object_funds_withdraws()` returns `false`.
+- Execution pipeline returns `RetryLater` — effects are **not** committed.
+
+**Settlement v5→v6** arrives. The watcher task is notified (via the watch channel). It sends
+`MaybeSufficient` through its oneshot channel. The background task re-enqueues TX1 for
+execution.
+
+**TX1's second execution**: the Move VM runs again (same code, same inputs) and again produces
+a running max withdrawal of 200 from Y.
+
+- Checker sees accumulator version 6. Last settled version is now 6.
+- Version 6 ≤ settled version 6 → can check.
+- Storage balance at version 6: let's say 600 (after settlement applied deposits). Unsettled
+  at (Y, v6): 0.
+- Effective balance: 600 − 0 = 600 ≥ 200 → **sufficient**.
+- Update unsettled: (Y, v6) = 200.
+- Effects committed.
+
+If the balance after settlement had been only 100, the checker would have immediately sent
+`Insufficient`. TX1 would be re-enqueued with the insufficient flag, and its third execution
+would produce an `InsufficientFundsForWithdraw` early error without running the Move VM.
+
+## 4. Garbage collection
+
+The unsettled withdrawals tracking must be cleaned up to prevent unbounded memory growth.
+This happens via `ObjectFundsChecker::commit_effects`, called once a batch of effects has
+been committed.
+
+The checker scans the committed effects for transactions whose object changes touch the
+accumulator root (i.e., settlement and barrier transactions). For each such version, it
+removes all unsettled withdrawal entries at that version from both `unsettled_withdraws` and
+`unsettled_accounts`.
+
+This is safe because once effects are committed, storage balances reflect the actual state,
+and no further checking against the old unsettled entries is needed. As with the watch
+channel in §2, this hook is path-agnostic: it works the same whether the settlement was
+produced by this validator or downloaded via the checkpoint executor (see
+[`write_path.md`](./write_path.md) §5).
+
+## 5. Assigned version requirement
+
+`ObjectFundsChecker` validates a post-execution object withdrawal against the transaction's
+assigned accumulator version. That version tells it which historical balance snapshot to read
+and which `unsettled_withdraws` bucket to charge.
+
+This is part of the production invariant for the checker: by the time object-funds checking
+runs, the transaction has a concrete assigned accumulator version. Maintain changes to this
+area with that requirement in mind; without a specific assigned version, the checker would have
+no well-defined historical balance to validate against.
+
+## 6. Epoch boundaries
+
+The `ObjectFundsChecker` is replaced at epoch boundaries the same way the address-funds
+scheduler is — see [`address_funds_scheduling.md`](./address_funds_scheduling.md) §7. The
+`watch` channel sender on the old checker is dropped, ending any in-flight watcher tasks
+(their `within_alive_epoch` guard breaks them out of waiting cleanly). Pending object funds
+checks from the old epoch are effectively abandoned and will be handled by the checkpoint
+executor during epoch transition.
+
+## 7. Key differences from address funds scheduling
+
+While both systems validate withdrawals against accumulator balances, they differ in
+fundamental ways:
+
+**When the amount is known.** Address fund withdrawal maximums are declared in the
+transaction data and known before execution. Object fund withdrawal amounts are computed by
+the Move VM during execution.
+
+**When the check happens.** Address funds are checked *before* execution (pre-execution gate).
+Object funds are checked *after* execution (post-execution validation).
+
+**How insufficient funds are handled.** For address funds, the eager scheduler can
+immediately fail the transaction — the Move VM never runs. For object funds, the Move VM has
+already run; the checker must re-enqueue the transaction for a second execution with an
+`Insufficient` flag that triggers an early error.
+
+**Reservation vs. exact amounts.** The address funds scheduler uses conservative reservations
+based on declared maximums. The object funds checker uses the exact running max computed from
+actual execution events.
+
+**State tracking complexity.** The eager address funds scheduler maintains per-account state
+with balance tracking, reserved funds, and pending queues. The object funds checker maintains
+a simpler structure: just a map of unsettled withdrawal amounts per account per version.
+
+**Settlement interaction.** The address-funds scheduler uses settlement to release
+reservations and drain pending queues — it actively updates in-memory balance state, driven
+by the `settle_address_funds(...)` call (validator path only). The object funds checker uses
+settlement only as a trigger: once the version is settled, it re-executes the transaction and
+checks the actual balance from storage. The trigger is the barrier transaction's execution
+hook in `process_certificate`, which fires regardless of whether settlement reached the node
+via the validator path or the checkpoint executor.

--- a/crates/sui-core/src/accumulators/design_docs/write_path.md
+++ b/crates/sui-core/src/accumulators/design_docs/write_path.md
@@ -1,0 +1,360 @@
+# Address Balances: Write Path
+
+This document covers everything that *changes* an accumulator balance:
+
+1. How a transaction declares an address-funds withdraw (`FundsWithdrawalArg`,
+   `CallArg::FundsWithdrawal`).
+2. How that declaration is rewritten and resolved during signing/execution
+   (`accumulators/transaction_rewriting.rs`, `accumulators/coin_reservations.rs`).
+3. How the Move VM emits accumulator events (`AccumulatorEvent`) for both Split (withdraw) and
+   Merge (deposit) operations.
+4. How those events are aggregated into the on-chain settlement: the placeholder
+   `AccumulatorSettlement` key, the N parallel settlement transactions, and the barrier
+   transaction that bumps the accumulator version.
+5. The two paths by which settlement reaches a node: directly through the validator's own
+   settlement scheduling, or indirectly via the checkpoint executor when catching up from
+   peers. The schedulers handle both. This is referenced from every other doc in this
+   directory.
+
+For the on-chain data layout these operations target, see [`data_model.md`](./data_model.md).
+For pre-execution withdraw scheduling, see
+[`address_funds_scheduling.md`](./address_funds_scheduling.md). For post-execution sufficiency
+checking, see [`object_funds_checking.md`](./object_funds_checking.md).
+
+## 1. Declaring a withdraw in a transaction
+
+Address-funds withdraws are explicit transaction inputs. They appear as one of two surface
+forms:
+
+- **`CallArg::FundsWithdrawal(FundsWithdrawalArg)`** — the canonical form. The transaction
+  data carries an inline `FundsWithdrawalArg` describing what to withdraw and how much.
+- **Coin reservations encoded as masked `ObjectRef`s.** A backward-compat form for old SDKs
+  that only know how to construct object-ref-shaped inputs. These are detected and rewritten
+  into `CallArg::FundsWithdrawal` before execution, after which the rest of the write path is
+  identical. The encoding, validation, and rewriting pipeline are documented separately in
+  [`coin_reservations.md`](./coin_reservations.md).
+
+`FundsWithdrawalArg` is defined in `sui-types::transaction`:
+
+```rust
+pub struct FundsWithdrawalArg {
+    pub reservation: Reservation,           // currently: MaxAmountU64(u64)
+    pub type_arg: WithdrawalTypeArg,        // currently: Balance(TypeTag)
+    pub withdraw_from: WithdrawFrom,        // Sender | Sponsor
+}
+```
+
+A few things worth knowing:
+
+- The `MaxAmountU64` is a **maximum** the transaction may withdraw, not the exact amount.
+  Actual amounts are decided by the Move code at execution time and may be lower (even zero).
+  This is what makes pre-execution scheduling safe but conservative — see
+  [`address_funds_scheduling.md`](./address_funds_scheduling.md) §3.
+- `withdraw_from = Sponsor` is what powers gas-from-balance. The implicit gas withdrawal is
+  conceptually a `FundsWithdrawalArg::balance_from_sponsor(gas_budget, GAS::type_tag())` — see
+  `TransactionData::get_funds_withdrawal_for_gas_payment`. It is added to the
+  withdraw map for execution alongside any explicit user withdraws.
+- Only `Balance<T>` is supported as the type today. The various derivation/lookup helpers in
+  `accumulator_root.rs` enforce this at runtime.
+
+### From declaration to per-account reservation map
+
+At execution time, all of a transaction's address-fund withdraws are aggregated into a per-
+account reservation map by `TransactionData::process_funds_withdrawals_for_execution`:
+
+```rust
+fn process_funds_withdrawals_for_execution(...)
+    -> BTreeMap<AccumulatorObjId, u64>
+```
+
+The function:
+
+1. Walks every `CallArg::FundsWithdrawal` in the PTB inputs.
+2. Adds the implicit gas withdraw if gas is paid from address balance.
+3. For each withdraw, derives the `AccumulatorObjId` from
+   `(owner_for_withdrawal(tx), type_arg.to_type_tag())` (see [`data_model.md`](./data_model.md)
+   §3) and accumulates the declared maximum into the per-account total.
+4. For coin reservations that haven't been rewritten yet (e.g. validating a signed but
+   not-yet-executed cert), it parses the masked object refs and adds them in the same shape.
+   See [`coin_reservations.md`](./coin_reservations.md).
+
+The output is exactly the input shape consumed by `WithdrawReservations` in the address-funds
+scheduler (see [`address_funds_scheduling.md`](./address_funds_scheduling.md) §1).
+
+There are sibling entrypoints used at signing/voting time
+(`process_funds_withdrawals_for_signing`) and for gas estimation
+(`process_funds_withdrawals_for_estimation`); they are non-deterministic helpers (uncoordinated
+reads) and do **not** drive scheduling. Only `..._for_execution` is part of the deterministic
+path. Related read-side validation also lives on `AccountFundsRead`: for gasless withdrawals,
+`check_remaining_amounts_after_withdrawal` enforces that the leftover balance is either zero or
+at least the token's configured minimum transfer amount.
+
+## 2. From transaction inputs to Move VM behavior
+
+Once a `FundsWithdrawalArg` is in a `CallArg`, the Move VM treats it like any other input
+during PTB execution. Withdrawing produces a `Balance<T>` value that downstream Move calls can
+consume; depositing into another address's `Balance<T>` produces the symmetric effect. From the
+VM's point of view there is no special-case flow — the deposit/withdraw show up as ordinary
+Move runtime events.
+
+What's special is what the VM *emits* when `Balance<T>` ends up moving in or out of an
+accumulator account. These show up as **accumulator events** in the inner temporary store and
+ultimately on `TransactionEffects`.
+
+## 3. Accumulator events
+
+`AccumulatorEvent` (`sui-types/src/accumulator_event.rs:21`):
+
+```rust
+pub struct AccumulatorEvent {
+    pub accumulator_obj: AccumulatorObjId,
+    pub write: AccumulatorWriteV1,
+}
+```
+
+`AccumulatorWriteV1` (`sui-types/src/effects/object_change.rs:112`):
+
+```rust
+pub struct AccumulatorWriteV1 {
+    pub address: AccumulatorAddress,        // (SuiAddress, TypeTag)
+    pub operation: AccumulatorOperation,    // Merge | Split
+    pub value: AccumulatorValue,            // Integer(u64) | IntegerTuple(...) | EventDigest(...)
+}
+```
+
+For balances, `value` is always `Integer(u64)`. The only operations that matter for this doc
+are:
+
+- **Merge(amount)** — a deposit of `amount` units into the account.
+- **Split(amount)** — a withdrawal of `amount` units from the account.
+
+`AccumulatorEvent::from_balance_change(addr, balance_type, net_change_i64)` is the canonical
+way to manufacture one given a signed delta (see `accumulator_event.rs:50`).
+
+The full ordered list of events for a transaction lives on
+`InnerTemporaryStore::accumulator_events` and is what feeds settlement. A derived summary,
+`InnerTemporaryStore::accumulator_running_max_withdraws: BTreeMap<AccumulatorObjId, u128>`, is
+also computed during execution; that one is the input to object-funds checking — see
+[`object_funds_checking.md`](./object_funds_checking.md) §1 for what "running max" means.
+
+### Where events surface in effects
+
+After execution, accumulator events end up on `TransactionEffects`. The
+`accumulator_events()` API on `TransactionEffectsAPI` reconstructs them by walking object
+changes; on validators we usually still have the original vector in the writeback cache, so
+`AccumulatorSettlementTxBuilder::new` prefers `cache.take_accumulator_events(tx)` to avoid the
+linear scan (see `accumulators/mod.rs:246`).
+
+## 4. Settlement: from placeholder to real on-chain transactions
+
+The most subtle part of the write path is what happens at the *end* of a consensus commit.
+What looks like "the settlement transaction" from a high level turns out to be a small batch of
+real on-chain transactions, and the way they reach a node depends on whether the node executed
+the source transactions itself or downloaded the checkpoint from a peer.
+
+### 4.1 The placeholder key
+
+What consensus emits at the end of each commit is **not** a complete settlement transaction. It
+is just a placeholder — a `TransactionKey::AccumulatorSettlement(epoch, checkpoint_height)`
+that reserves a slot for "whatever transactions will end up settling this commit." The
+placeholder has no body yet because the body depends on what the regular transactions in the
+commit actually do.
+
+The placeholder is plumbed through the system as a `Schedulable::AccumulatorSettlement(...)`
+in `SettlementScheduler::enqueue` (see
+`crates/sui-core/src/execution_scheduler/settlement_scheduler.rs`). On a validator, the
+settlement scheduler waits for the regular transactions to finish, then constructs and enqueues
+the real settlement transactions itself — this is the "early settlement" path. The checkpoint
+builder also constructs settlement transactions when a checkpoint is built; the two paths
+coordinate via `wait_for_settlement_transactions` / `wait_for_barrier_transaction` on the epoch
+store.
+
+### 4.2 Building the real transactions
+
+`AccumulatorSettlementTxBuilder` (in `accumulators/mod.rs:219`) does the construction. The
+flow is:
+
+1. **Aggregate events.** Walk the effects of every transaction included in the (early)
+   settlement scope. For each `AccumulatorEvent`, accumulate Merge and Split totals per
+   account, plus per-account input/output SUI flows (used for the balanced-flow assertions in
+   the settlement Move code).
+
+2. **Compute `funds_changes`.**
+   `AccumulatorSettlementTxBuilder::collect_funds_changes(&self) -> BTreeMap<AccumulatorObjId, i128>`
+   nets each account's Merge total minus its Split total. This is the same map that the
+   address-funds scheduler eventually receives as `FundsSettlement::funds_changes`.
+
+3. **Chunk and build.** `build_tx` chunks the per-account updates into one or more
+   programmable system transactions, sized by
+   `protocol_config.max_updates_per_settlement_txn`. Each chunk produces one `TransactionKind`:
+
+   - Acquires the accumulator root with `SharedObjectMutability::NonExclusiveWrite`. This is
+     the key trick — it lets multiple settlement txns run concurrently, since none of them
+     conflict with each other on the root, while still blocking ordinary withdraw/deposit
+     transactions that need a determinate version.
+   - Calls `accumulator_settlement::settlement_prologue(root, epoch, checkpoint_height, idx,
+     total_input_sui, total_output_sui)`.
+   - Calls `accumulator_settlement::settle_u128(root, address, merge_amount, split_amount, ...)`
+     for each account in the chunk.
+
+4. **Build the barrier transaction.** `accumulators::build_accumulator_barrier_tx` produces
+   the final transaction in the settlement set. It:
+
+   - Acquires the accumulator root with `SharedObjectMutability::Mutable`. This is what
+     forces it to serialize after all settlement txns in the same commit — every settlement
+     txn took `NonExclusiveWrite`, and `Mutable` is exclusive against `NonExclusiveWrite`.
+   - Calls the same `settlement_prologue` (with `total_input_sui = 0`, `total_output_sui = 0`)
+     so the barrier participates in the same protocol checks.
+   - Calls `accumulator_metadata::record_accumulator_object_changes(root, created, deleted)`,
+     where `created` and `deleted` are computed by scanning the settlement txns' effects
+     (`accumulators::count_accumulator_object_changes`).
+   - **The barrier mutates the root**, which is what bumps the accumulator version from V to
+     V+1.
+
+So while the algorithmic story in the rest of these docs talks about "the settlement at
+version V→V+1" as if it were one event, the on-chain reality is: many parallel settlement
+txns followed by one barrier that gates the version bump.
+
+```
+  ┌────────────────────────────────────────────────────────────────────┐
+  │                       Consensus Commit                             │
+  │                                                                    │
+  │   TX1, TX2, ... (regular transactions, all reading accumulator     │
+  │   version V; some withdraw, some deposit, some both)               │
+  │                                                                    │
+  │   AccumulatorSettlement placeholder key (no body yet)              │
+  └────────────────────────────────────────────────────────────────────┘
+                                  │
+                                  ▼
+            Regular transactions execute (parallel, in any order
+            consistent with consensus / object dependencies)
+                                  │
+                                  ▼
+            Their accumulator events are aggregated, per-account,
+            via AccumulatorSettlementTxBuilder.
+                                  │
+                                  ▼
+       ┌─────────────────────────────────────────────────────┐
+       │  Settlement TX 0 (chunk 0)  │  ... in parallel ...  │
+       │     NonExclusiveWrite       │   NonExclusiveWrite   │
+       │   settlement_prologue       │  settlement_prologue  │
+       │   settle_u128 × M           │  settle_u128 × M      │
+       └────────────────┬─────────────────────┬──────────────┘
+                        ▼                     ▼
+                       (effects)            (effects)
+                              │           │
+                              ▼           ▼
+                  ┌───────────────────────────────────┐
+                  │   Barrier TX  (Mutable on root)   │
+                  │   settlement_prologue             │
+                  │   record_accumulator_object_      │
+                  │     changes(created, deleted)     │
+                  │   ► bumps accumulator V → V+1     │
+                  └────────────────┬──────────────────┘
+                                   │
+                                   ▼
+            Address funds:       Object funds:
+            settle_address_funds last_settled_version
+            with FundsSettlement watch channel bumped
+            { V+1, funds_changes }   to V+1 (when barrier
+                                     executes)
+```
+
+### 4.3 What the schedulers see
+
+After all settlement txns and the barrier finish, the validator-side settlement code calls:
+
+```rust
+ExecutionScheduler::settle_address_funds(FundsSettlement {
+    next_accumulator_version: V+1,
+    funds_changes: <aggregated map from collect_funds_changes>,
+});
+```
+
+(See `settlement_scheduler.rs:399` for the early-settlement path and
+`checkpoints/mod.rs:1729` for the checkpoint-builder path.) The address-funds scheduler
+ingests this via its settlement channel and updates per-account state — see
+[`address_funds_scheduling.md`](./address_funds_scheduling.md) §4.
+
+The object-funds checker uses a different hook: it tracks `last_settled_version` via a
+`tokio::sync::watch` channel that is bumped from inside
+`AuthorityState::process_certificate` whenever a **barrier transaction** finishes executing
+(gated by `TransactionKind::is_accumulator_barrier_settle_tx`). This is a deliberate design
+choice — see §5 below.
+
+## 5. Two paths to settlement
+
+A second subtlety pervades these docs and is worth pinning down here:
+
+> **Settlement transactions can execute on a node independently of the original
+> balance-changing transactions that produced their inputs.**
+
+In particular, a node that is catching up from peers via the **checkpoint executor** may
+execute the settlement txns and the barrier directly out of a downloaded checkpoint, without
+ever having scheduled or executed the withdraw/deposit transactions that fed them. From the
+scheduler's point of view, the on-chain accumulator version simply advances "out of band."
+
+There are therefore two paths by which a settlement reaches a node:
+
+1. **Checkpoint-builder path.** The node executed the regular transactions, so it
+   has the events available. After settlement txns + barrier execute, the system explicitly
+   calls `ExecutionScheduler::settle_address_funds(...)` (from `SettlementScheduler` for early
+   settlement, or from `CheckpointBuilder` later). The address-funds scheduler's in-memory
+   state is updated through this call.
+2. **Checkpoint-executor path.** The node downloaded a checkpoint and executes whatever it
+   contains, including the settlement txns and the barrier. The on-chain version of the
+   accumulator root and individual accumulator account objects advance as a side effect of
+   executing those transactions, but **`settle_address_funds` is never called on this path** —
+   the node never had the source events. The scheduler's in-memory `accumulator_version` may
+   therefore lag behind storage.
+
+Each subsystem keeps the two paths consistent without path-specific code:
+
+- The **address-funds scheduler** uses storage-version checks at scheduling time plus
+  idempotent in-memory settlement (see
+  [`address_funds_scheduling.md`](./address_funds_scheduling.md) §3.1 and §4). On the
+  checkpoint-executor path it never builds up state for an already-settled version in the
+  first place, so there's nothing to reconcile.
+- The **object-funds checker** drives `last_settled_version` from the barrier-tx execution
+  hook in `process_certificate`, which fires regardless of which path produced the barrier.
+  See [`object_funds_checking.md`](./object_funds_checking.md) §3.
+- **Garbage collection** for unsettled withdraws is tied to effects commitment
+  (`ObjectFundsChecker::commit_effects`), which is also path-agnostic.
+
+In short: the validator path uses richer in-process notifications; the checkpoint-executor
+path uses just on-chain effects. The schedulers are designed so that "I observed the on-chain
+state moved" is sufficient — the in-process notifications are an optimization, not a
+correctness requirement.
+
+One subtle consequence is that "observed the on-chain state moved" is sufficient only for the
+subsystem whose job is to gate *pre-execution* work. That is the address-funds scheduler: once
+some other path has advanced storage past version V, the scheduler can safely stop and return
+`SkipSchedule`.
+
+The object-funds checker is different because it runs *post-execution*. At that point there is no
+separate scheduler left to take over, and the checker must still reconcile an already-executed
+transaction's object-withdraw effects against the accumulator version assigned to that
+transaction. That is why it uses a barrier-driven settled-version signal plus MVCC-bounded reads,
+rather than a latest-state skip.
+
+There is a second boundary to keep in mind for those MVCC-bounded reads: checkpoint finalization
+and pruning. Historical object versions are not assumed to live forever. The cache layer's
+historical-read logic is deliberately written to read within a root-version stability window,
+because once checkpoint progress advances enough to make a version prune-eligible, blindly
+reaching back for "whatever version V used to say" is no longer safe. This is another reason the
+code distinguishes carefully between latest-state detection (`SkipSchedule`) and true
+historical-version validation.
+
+## 6. Summary of artifacts and where they live
+
+| Artifact | Type | Defined in | Consumed by |
+|----------|------|-----------|-------------|
+| `FundsWithdrawalArg` | tx input | `sui-types/src/transaction.rs` | signing; execution; scheduler |
+| `process_funds_withdrawals_for_execution` | fn | `sui-types/src/transaction.rs` | scheduler input construction |
+| `rewrite_transaction_for_coin_reservations` | fn | `accumulators/transaction_rewriting.rs` | tx normalization before execution |
+| `AccumulatorEvent` | execution output | `sui-types/src/accumulator_event.rs` | settlement builder; object funds checker |
+| `accumulator_running_max_withdraws` | execution output | `sui-types/src/inner_temporary_store.rs` | object funds checker |
+| `AccumulatorSettlementTxBuilder` | settlement constructor | `accumulators/mod.rs` | early-settlement scheduler; checkpoint builder |
+| `build_accumulator_barrier_tx` | settlement constructor | `accumulators/mod.rs` | early-settlement scheduler; checkpoint builder |
+| `FundsSettlement { next_accumulator_version, funds_changes }` | scheduler input | `funds_withdraw_scheduler/address_funds/mod.rs` | address-funds scheduler |
+| `settle_accumulator_version` | watch-channel update | `accumulators/object_funds_checker/mod.rs` | invoked from `process_certificate` on barrier execution |


### PR DESCRIPTION
## Summary

Adds a new `crates/sui-core/src/accumulators/design_docs/` directory documenting the full
address-balances subsystem. This replaces an earlier scheduling-only design doc that lived
under the address-funds scheduler with a directory-scoped reference covering everything from
on-chain layout to settlement, including the legacy coin-reservation compatibility layer.

The set of docs:

- `README.md` — entry point, top-level architecture, glossary.
- `data_model.md` — on-chain layout: \`0xACC\` root, \`AccumulatorObjId\` derivation, the
  accumulator version invariant.
- `write_path.md` — \`FundsWithdrawalArg\`, accumulator events, the placeholder→N parallel
  settlement txns→barrier expansion, and the two paths by which settlement reaches a node
  (validator-side construction vs. checkpoint executor).
- \`address_funds_scheduling.md\` — pre-execution withdraw scheduling for address-owned
  accumulator accounts: eager scheduler, naive baseline, determinism, examples.
- \`object_funds_checking.md\` — post-execution sufficiency checking for object-owned
  accumulator accounts: running max, unsettled-withdraws tracking, re-execution flow.
- \`coin_reservations.md\` — backward-compat layer for SDKs that predate address balances:
  XOR-masked \`ObjectRef\` encoding, two-phase RPC reads, signing-time validation,
  execution-time rewriting. Transitional, expected to be removed once SDK migration completes.

## Test plan

- [ ] Reviewer skim for correctness of code references (file paths, line numbers, function
      names) and overall accuracy.
- [ ] No code changes; no tests run.