### PR TITLE
indexer/checkpoint: line up header configuration with #26526

### DIFF
--- a/crates/sui-checkpoint-blob-indexer/src/main.rs
+++ b/crates/sui-checkpoint-blob-indexer/src/main.rs
@@ -51,12 +51,6 @@ struct Args {
     #[arg(long, group = "store")]
     gcs: Option<String>,
 
-    /// GCP project ID for requester-pays GCS buckets. When set, the
-    /// `x-goog-user-project` header is included in every request so that
-    /// charges are billed to this project instead of the bucket owner.
-    #[arg(long, requires = "gcs")]
-    gcs_project_id: Option<String>,
-
     /// Write to Azure Blob Storage. Provide the container name.
     /// (env: AZURE_STORAGE_ACCOUNT_NAME, AZURE_STORAGE_ACCESS_KEY)
     #[arg(long, group = "store")]
@@ -69,6 +63,11 @@ struct Args {
     /// Write to local filesystem. Provide the path to the directory.
     #[arg(long, group = "store")]
     path: Option<PathBuf>,
+
+    /// Default header to include in object store requests, as `<name>:<value>`.
+    /// Can be provided multiple times.
+    #[arg(long = "store-header", value_parser = parse_object_store_header)]
+    store_headers: Vec<(HeaderName, HeaderValue)>,
 
     /// Request timeout
     #[arg(long, default_value = "30s", value_parser = humantime::parse_duration)]
@@ -104,7 +103,17 @@ async fn main() -> anyhow::Result<()> {
     info!("Config: {:#?}", config);
 
     let is_bounded_job = args.indexer_args.last_checkpoint.is_some();
-    let client_options = ClientOptions::default().with_timeout(args.request_timeout);
+
+    let mut client_options = ClientOptions::default().with_timeout(args.request_timeout);
+    if !args.store_headers.is_empty() {
+        let mut headers = HeaderMap::new();
+        for (name, value) in &args.store_headers {
+            headers.append(name.clone(), value.clone());
+        }
+
+        client_options = client_options.with_default_headers(headers)
+    }
+
     let retry_config = RetryConfig {
         max_retries: 0,
         ..Default::default()
@@ -121,19 +130,6 @@ async fn main() -> anyhow::Result<()> {
             .build()
             .map(Arc::new)?
     } else if let Some(bucket) = args.gcs {
-        let mut client_options = client_options;
-        if let Some(project_id) = &args.gcs_project_id {
-            let header_value = HeaderValue::from_str(project_id)
-                .expect("invalid project ID for requester-pays header");
-            let headers = HeaderMap::from_iter([
-                (
-                    HeaderName::from_static("x-goog-user-project"),
-                    header_value.clone(),
-                ),
-                (HeaderName::from_static("userproject"), header_value),
-            ]);
-            client_options = client_options.with_default_headers(headers);
-        }
         info!(bucket, "Using GCS storage");
         GoogleCloudStorageBuilder::from_env()
             .with_client_options(client_options)
@@ -225,5 +221,114 @@ async fn main() -> anyhow::Result<()> {
         Err(Error::Task(_)) => {
             std::process::exit(2);
         }
+    }
+}
+
+fn parse_object_store_header(header: &str) -> Result<(HeaderName, HeaderValue), String> {
+    let (name, value) = header
+        .split_once(':')
+        .ok_or_else(|| "object store header must be in `<name>:<value>` format".to_string())?;
+
+    let name = HeaderName::from_bytes(name.as_bytes())
+        .map_err(|err| format!("invalid object store header name `{name}`: {err}"))?;
+    let value = HeaderValue::from_str(value)
+        .map_err(|err| format!("invalid object store header value for `{name}`: {err}"))?;
+
+    Ok((name, value))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::error::ErrorKind;
+
+    #[test]
+    fn test_args_object_store_headers() {
+        let args = Args::try_parse_from([
+            "cmd",
+            "--config",
+            "config.toml",
+            "--gcs",
+            "bucket",
+            "--store-header",
+            "x-goog-user-project:my-project",
+            "--store-header",
+            "authorization:Bearer abc:def",
+            "--local-ingestion-path",
+            "/tmp/checkpoints",
+        ])
+        .unwrap();
+
+        assert_eq!(args.store_headers.len(), 2);
+        assert_eq!(
+            args.store_headers[0].0,
+            HeaderName::from_static("x-goog-user-project")
+        );
+        assert_eq!(
+            args.store_headers[0].1,
+            HeaderValue::from_static("my-project")
+        );
+        assert_eq!(
+            args.store_headers[1].0,
+            HeaderName::from_static("authorization")
+        );
+        assert_eq!(
+            args.store_headers[1].1,
+            HeaderValue::from_static("Bearer abc:def")
+        );
+    }
+
+    #[test]
+    fn test_args_object_store_header_requires_delimiter() {
+        let err = Args::try_parse_from([
+            "cmd",
+            "--config",
+            "config.toml",
+            "--gcs",
+            "bucket",
+            "--store-header",
+            "x-goog-user-project",
+            "--local-ingestion-path",
+            "/tmp/checkpoints",
+        ])
+        .unwrap_err();
+
+        assert_eq!(err.kind(), ErrorKind::ValueValidation);
+    }
+
+    #[test]
+    fn test_args_object_store_header_rejects_invalid_name() {
+        let err = Args::try_parse_from([
+            "cmd",
+            "--config",
+            "config.toml",
+            "--gcs",
+            "bucket",
+            "--store-header",
+            "bad name:value",
+            "--local-ingestion-path",
+            "/tmp/checkpoints",
+        ])
+        .unwrap_err();
+
+        assert_eq!(err.kind(), ErrorKind::ValueValidation);
+    }
+
+    #[test]
+    fn test_args_object_store_header_rejects_invalid_value() {
+        let err = Args::try_parse_from([
+            "cmd",
+            "--config",
+            "config.toml",
+            "--gcs",
+            "bucket",
+            "--store-header",
+            "x-test:bad\nvalue",
+            "--local-ingestion-path",
+            "/tmp/checkpoints",
+        ])
+        .unwrap_err();
+
+        assert_eq!(err.kind(), ErrorKind::ValueValidation);
     }
 }


### PR DESCRIPTION
## Description

Use the same mechanism to pass custom headers to the indexer that writes checkpoints as we do for the indexers that read those checkpoints.

## Test plan

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
