### PR TITLE
move-package-alt: sanitize Git env vars in subprocess calls

### DIFF
--- a/external-crates/move/crates/move-package-alt/src/git/cache.rs
+++ b/external-crates/move/crates/move-package-alt/src/git/cache.rs
@@ -343,6 +343,22 @@ pub async fn run_git_cmd_with_args(args: &[&str], cwd: Option<&PathBuf>) -> GitR
         .stderr(Stdio::piped());
     cmd.env("GIT_CONFIG_GLOBAL", "");
 
+    // Sanitize Git environment variables that may leak from the parent process.
+    // When the Move build is invoked from within a Git context (e.g. CI, hooks,
+    // worktrees), these variables can cause child git operations to target the
+    // wrong repository or use the wrong index.
+    for var in [
+        "GIT_DIR",
+        "GIT_WORK_TREE",
+        "GIT_INDEX_FILE",
+        "GIT_OBJECT_DIRECTORY",
+        "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+        "GIT_CEILING_DIRECTORIES",
+        "GIT_COMMON_DIR",
+    ] {
+        cmd.env_remove(var);
+    }
+
     if let Some(cwd) = cwd {
         cmd.current_dir(cwd);
     }


### PR DESCRIPTION
When the Move build system is invoked from within a Git context (CI pipelines, git hooks, worktrees), environment variables like GIT_DIR, GIT_WORK_TREE, and GIT_INDEX_FILE can leak into the child git processes used to fetch dependencies. This causes the dependency fetcher to operate against the wrong repository or index.

Unset the problematic Git environment variables in run_git_cmd_with_args() so that each child git process discovers its own context from the working directory, matching the existing GIT_CONFIG_GLOBAL sanitization.

## Description 

Describe the changes or additions included in this PR.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
