### PR TITLE
[address balances] Invariant checks for transaction effects

### DIFF
--- a/crates/sui-open-rpc/tests/snapshots/generate_spec__openrpc.snap.json
+++ b/crates/sui-open-rpc/tests/snapshots/generate_spec__openrpc.snap.json
@@ -1378,6 +1378,7 @@
                 "enable_vdf": false,
                 "enable_verify_bulletproofs_ristretto255": false,
                 "end_of_epoch_transaction_supported": false,
+                "enforce_address_balance_change_invariant": false,
                 "enforce_checkpoint_timestamp_monotonicity": false,
                 "fix_checkpoint_signature_mapping": false,
                 "flexible_tx_context_positions": false,

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -1083,6 +1083,13 @@ struct FeatureFlags {
     // MAX_PUBLIC_INPUTS public inputs.
     #[serde(skip_serializing_if = "is_false")]
     limit_groth16_pvk_inputs: bool,
+
+    // If true, the funds-accumulator address-balance change invariant
+    // (`TemporaryStore::check_address_balance_changes`) is enforced as a consensus check —
+    // violations abort the tx via the conservation-recovery flow. When false, the check still
+    // runs but a violation panics so unexpected violations surface during rollout.
+    #[serde(skip_serializing_if = "is_false")]
+    enforce_address_balance_change_invariant: bool,
 }
 
 fn is_false(b: &bool) -> bool {
@@ -2813,6 +2820,10 @@ impl ProtocolConfig {
 
     pub fn limit_groth16_pvk_inputs(&self) -> bool {
         self.feature_flags.limit_groth16_pvk_inputs
+    }
+
+    pub fn enforce_address_balance_change_invariant(&self) -> bool {
+        self.feature_flags.enforce_address_balance_change_invariant
     }
 }
 

--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -2081,7 +2081,9 @@ impl TransactionKind {
         Ok(input_objects)
     }
 
-    pub fn get_funds_withdrawals<'a>(&'a self) -> impl Iterator<Item = &'a FundsWithdrawalArg> + 'a {
+    pub fn get_funds_withdrawals<'a>(
+        &'a self,
+    ) -> impl Iterator<Item = &'a FundsWithdrawalArg> + 'a {
         let TransactionKind::ProgrammableTransaction(pt) = &self else {
             return Either::Left(iter::empty());
         };

--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -2081,7 +2081,7 @@ impl TransactionKind {
         Ok(input_objects)
     }
 
-    fn get_funds_withdrawals<'a>(&'a self) -> impl Iterator<Item = &'a FundsWithdrawalArg> + 'a {
+    pub fn get_funds_withdrawals<'a>(&'a self) -> impl Iterator<Item = &'a FundsWithdrawalArg> + 'a {
         let TransactionKind::ProgrammableTransaction(pt) = &self else {
             return Either::Left(iter::empty());
         };

--- a/sui-execution/latest/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/latest/sui-adapter/src/execution_engine.rs
@@ -139,9 +139,7 @@ mod checked {
     ) -> BTreeMap<(SuiAddress, TypeTag), u64> {
         use sui_types::balance::Balance;
         use sui_types::gas_coin::GAS;
-        use sui_types::transaction::{
-            Reservation, WithdrawFrom, is_gas_paid_from_address_balance,
-        };
+        use sui_types::transaction::{Reservation, WithdrawFrom, is_gas_paid_from_address_balance};
 
         let mut reservations: BTreeMap<(SuiAddress, TypeTag), u64> = BTreeMap::new();
         let sui_balance_type = Balance::type_tag(GAS::type_tag());
@@ -151,9 +149,7 @@ mod checked {
                 WithdrawFrom::Sender => transaction_signer,
                 WithdrawFrom::Sponsor => gas_data.owner,
             };
-            let reservation = match arg.reservation {
-                Reservation::MaxAmountU64(n) => n,
-            };
+            let Reservation::MaxAmountU64(reservation) = arg.reservation;
             *reservations
                 .entry((owner, arg.type_arg.to_type_tag()))
                 .or_insert(0) += reservation;
@@ -614,7 +610,7 @@ mod checked {
                             let mut layout_resolver = TypeLayoutResolver::new(
                                 move_vm,
                                 store.protocol_config(),
-                                Box::new(&*store),
+                                Box::new(store),
                             );
                             store.check_sui_conserved_expensive(
                                 cost_summary,

--- a/sui-execution/latest/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/latest/sui-adapter/src/execution_engine.rs
@@ -124,6 +124,58 @@ mod checked {
         }
     }
 
+    /// Compute the per-`(address, type)` funds-accumulator reservation budget consumed by
+    /// `TemporaryStore::check_address_balance_changes`. Today every funds accumulator is a
+    /// `Balance<T>`, but the `(address, TypeTag)` keying lets this generalize as more
+    /// accumulator types are added. Sources:
+    /// - PTB `FundsWithdrawalArg`s for any supported accumulator type (sender or sponsor as
+    ///   owner).
+    /// - Gas paid entirely from address balance (credits `(gas_owner, Balance<SUI>)`).
+    /// - Gas-data entries with coin-reservation digests (also credit `(gas_owner, Balance<SUI>)`).
+    fn compute_input_reservations(
+        transaction_kind: &TransactionKind,
+        gas_data: &GasData,
+        transaction_signer: SuiAddress,
+    ) -> BTreeMap<(SuiAddress, TypeTag), u64> {
+        use sui_types::balance::Balance;
+        use sui_types::gas_coin::GAS;
+        use sui_types::transaction::{
+            Reservation, WithdrawFrom, is_gas_paid_from_address_balance,
+        };
+
+        let mut reservations: BTreeMap<(SuiAddress, TypeTag), u64> = BTreeMap::new();
+        let sui_balance_type = Balance::type_tag(GAS::type_tag());
+
+        for arg in transaction_kind.get_funds_withdrawals() {
+            let owner = match arg.withdraw_from {
+                WithdrawFrom::Sender => transaction_signer,
+                WithdrawFrom::Sponsor => gas_data.owner,
+            };
+            let reservation = match arg.reservation {
+                Reservation::MaxAmountU64(n) => n,
+            };
+            *reservations
+                .entry((owner, arg.type_arg.to_type_tag()))
+                .or_insert(0) += reservation;
+        }
+
+        if is_gas_paid_from_address_balance(gas_data, transaction_kind) {
+            *reservations
+                .entry((gas_data.owner, sui_balance_type.clone()))
+                .or_insert(0) += gas_data.budget;
+        }
+
+        for entry in &gas_data.payment {
+            if let Ok(parsed) = ParsedDigest::try_from(entry.2) {
+                *reservations
+                    .entry((gas_data.owner, sui_balance_type.clone()))
+                    .or_insert(0) += parsed.reservation_amount();
+            }
+        }
+
+        reservations
+    }
+
     #[allow(clippy::type_complexity)]
     #[instrument(name = "tx_execute_to_effects", level = "debug", skip_all)]
     pub fn execute_transaction_to_effects<Mode: ExecutionMode>(
@@ -205,6 +257,9 @@ mod checked {
             && is_gasless_transaction(&gas_data, &transaction_kind);
         let is_epoch_change = transaction_kind.is_end_of_epoch_tx();
 
+        let input_reservations =
+            compute_input_reservations(&transaction_kind, &gas_data, transaction_signer);
+
         let (gas_cost_summary, execution_result, timings) = execute_transaction::<Mode>(
             store,
             &mut temporary_store,
@@ -219,6 +274,7 @@ mod checked {
             execution_params,
             trace_builder_opt,
             is_gasless,
+            &input_reservations,
         );
 
         let status = if let Err(error) = &execution_result {
@@ -415,6 +471,7 @@ mod checked {
         execution_params: ExecutionOrEarlyError,
         trace_builder_opt: &mut Option<MoveTraceBuilder>,
         is_gasless: bool,
+        input_reservations: &BTreeMap<(SuiAddress, TypeTag), u64>,
     ) -> (
         GasCostSummary,
         Result<Mode::ExecutionResults, Mode::Error>,
@@ -525,6 +582,7 @@ mod checked {
             &cost_summary,
             is_genesis_tx,
             advance_epoch_gas_summary,
+            input_reservations,
         ) {
             // FIXME: we cannot fail the transaction if this is an epoch change transaction.
             result = Err(e);
@@ -544,22 +602,21 @@ mod checked {
         cost_summary: &GasCostSummary,
         is_genesis_tx: bool,
         advance_epoch_gas_summary: Option<(u64, u64)>,
+        input_reservations: &BTreeMap<(SuiAddress, TypeTag), u64>,
     ) -> Result<(), Mode::Error> {
         let mut result: Result<(), Mode::Error> = Ok(());
         if !is_genesis_tx && !Mode::skip_conservation_checks() {
-            // ensure that this transaction did not create or destroy SUI, try to recover if the check fails
-            let conservation_result = {
-                temporary_store
+            let run_checks = |store: &TemporaryStore<'_>| -> Result<(), ExecutionError> {
+                store
                     .check_sui_conserved(simple_conservation_checks, cost_summary)
                     .and_then(|()| {
                         if enable_expensive_checks {
-                            // ensure that this transaction did not create or destroy SUI, try to recover if the check fails
                             let mut layout_resolver = TypeLayoutResolver::new(
                                 move_vm,
-                                temporary_store.protocol_config(),
-                                Box::new(&*temporary_store),
+                                store.protocol_config(),
+                                Box::new(&*store),
                             );
-                            temporary_store.check_sui_conserved_expensive(
+                            store.check_sui_conserved_expensive(
                                 cost_summary,
                                 advance_epoch_gas_summary,
                                 &mut layout_resolver,
@@ -568,38 +625,20 @@ mod checked {
                             Ok(())
                         }
                     })
+                    .and_then(|()| store.check_address_balance_changes(input_reservations))
             };
-            if let Err(conservation_err) = conservation_result {
-                // conservation violated. try to avoid panic by dumping all writes, charging for gas, re-checking
-                // conservation, and surfacing an aborted transaction with an invariant violation if all of that works
+
+            if let Err(conservation_err) = run_checks(temporary_store) {
+                // conservation violated. try to avoid panic by dumping all writes, charging for gas,
+                // re-checking conservation, and surfacing an aborted transaction with an invariant
+                // violation if all of that works.
                 result = Err(conservation_err.into());
                 gas_charger.reset(temporary_store);
                 gas_charger.charge_gas(temporary_store, &mut result);
-                // check conservation once more
-                if let Err(recovery_err) = {
-                    temporary_store
-                        .check_sui_conserved(simple_conservation_checks, cost_summary)
-                        .and_then(|()| {
-                            if enable_expensive_checks {
-                                // ensure that this transaction did not create or destroy SUI, try to recover if the check fails
-                                let mut layout_resolver = TypeLayoutResolver::new(
-                                    move_vm,
-                                    temporary_store.protocol_config(),
-                                    Box::new(&*temporary_store),
-                                );
-                                temporary_store.check_sui_conserved_expensive(
-                                    cost_summary,
-                                    advance_epoch_gas_summary,
-                                    &mut layout_resolver,
-                                )
-                            } else {
-                                Ok(())
-                            }
-                        })
-                } {
-                    // if we still fail, it's a problem with gas
-                    // charging that happens even in the "aborted" case--no other option but panic.
-                    // we will create or destroy SUI otherwise
+                if let Err(recovery_err) = run_checks(temporary_store) {
+                    // if we still fail, it's a problem with gas charging that happens even in the
+                    // "aborted" case — no other option but panic. We will create or destroy SUI
+                    // otherwise (or admit an unauthorized accumulator Split).
                     panic!(
                         "SUI conservation fail in tx block {}: {}\nGas status is {}\nTx was ",
                         tx_digest,

--- a/sui-execution/latest/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/latest/sui-adapter/src/execution_engine.rs
@@ -625,7 +625,12 @@ mod checked {
                             Ok(())
                         }
                     })
-                    .and_then(|()| store.check_address_balance_changes(input_reservations))
+                    .and_then(|()| {
+                        store.check_address_balance_changes(
+                            store.protocol_config(),
+                            input_reservations,
+                        )
+                    })
             };
 
             if let Err(conservation_err) = run_checks(temporary_store) {

--- a/sui-execution/latest/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/latest/sui-adapter/src/temporary_store.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::gas_charger::{GasCharger, PaymentLocation};
-use mysten_common::ZipDebugEqIteratorExt;
+use mysten_common::{ZipDebugEqIteratorExt, debug_fatal};
 use mysten_metrics::monitored_scope;
 use parking_lot::RwLock;
 use std::collections::{BTreeMap, BTreeSet, HashSet};
@@ -85,6 +85,16 @@ pub struct TemporaryStore<'backing> {
     /// The set of per-epoch config objects that were loaded during execution, and are not in the
     /// input objects. This allows us to commit them to the effects.
     loaded_per_epoch_config_objects: RwLock<BTreeSet<ObjectID>>,
+
+    /// Index ranges into `execution_results.accumulator_events` for events emitted from PTB
+    /// (Move) execution. Each `record_execution_results` call appends a contiguous range
+    /// bracketing the merge. Any index outside these ranges was emitted by the runtime outside
+    /// of PTB execution (currently only `gas_charger`'s `add_accumulator_event`). Consumed by
+    /// `check_sui_address_balance_changes` inside `run_conservation_checks` to gate
+    /// non-PTB-emitted events behind input reservations. Cleared on `drop_writes` since the
+    /// underlying events are also cleared. A `Vec` is sufficient because real transactions run
+    /// the PTB at most a handful of times.
+    ptb_emitted_accumulator_event_ranges: Vec<std::ops::Range<usize>>,
 }
 
 impl<'backing> TemporaryStore<'backing> {
@@ -138,6 +148,7 @@ impl<'backing> TemporaryStore<'backing> {
             generated_runtime_ids: BTreeSet::new(),
             cur_epoch,
             loaded_per_epoch_config_objects: RwLock::new(BTreeSet::new()),
+            ptb_emitted_accumulator_event_ranges: Vec::new(),
         }
     }
 
@@ -481,6 +492,8 @@ impl<'backing> TemporaryStore<'backing> {
 
     pub fn drop_writes(&mut self) {
         self.execution_results.drop_writes();
+        // The PTB-emitted ranges pointed into the now-cleared accumulator_events vec.
+        self.ptb_emitted_accumulator_event_ranges.clear();
     }
 
     pub fn read_object(&self, id: &ObjectID) -> Option<&Object> {
@@ -1130,6 +1143,88 @@ impl TemporaryStore<'_> {
         Ok(())
     }
 
+    /// Defense-in-depth invariant on funds-accumulator events. Per `(address, type)`:
+    /// - If the pair is in `input_reservations`: net withdrawal ≤ budget.
+    /// - Else if PTB-emitted events touched it: runtime contribution must not push the net
+    ///   below Move's deposit (`actual ≥ min(0, ptb_change)`).
+    /// - Else: any event is unauthorized — fatal.
+    ///
+    /// Currently the only funds-accumulator type is `Balance<T>`, so the check is scoped to
+    /// those events. As more accumulator shapes are added the filter and the integer
+    /// arithmetic here will need to grow with them.
+    ///
+    /// PTB-emitted events are identified via `ptb_emitted_accumulator_event_ranges`, populated
+    /// at `record_execution_results` time. They are trusted because Move enforces `&mut UID`
+    /// and the native checks the actual balance.
+    pub fn check_address_balance_changes(
+        &self,
+        input_reservations: &BTreeMap<(SuiAddress, TypeTag), u64>,
+    ) -> Result<(), ExecutionError> {
+        use sui_types::balance::Balance;
+
+        let mut actual_changes: BTreeMap<(SuiAddress, TypeTag), i128> = BTreeMap::new();
+        let mut ptb_changes: BTreeMap<(SuiAddress, TypeTag), i128> = BTreeMap::new();
+        for (idx, event) in self.execution_results.accumulator_events.iter().enumerate() {
+            // Only Balance<T> accumulators are supported today; extend this filter when
+            // additional funds-accumulator types are introduced.
+            if !Balance::is_balance_type(&event.write.address.ty) {
+                continue;
+            }
+            let is_ptb_emitted = self
+                .ptb_emitted_accumulator_event_ranges
+                .iter()
+                .any(|range| range.contains(&idx));
+            let key = (event.write.address.address, event.write.address.ty.clone());
+            let AccumulatorValue::Integer(amount) = event.write.value else {
+                debug_fatal!(
+                    "Unexpected non-integer value in funds-accumulator event: {:?}",
+                    event.write.value
+                );
+                continue;
+            };
+            let amount = amount as i128;
+            let change = match event.write.operation {
+                AccumulatorOperation::Split => -amount,
+                AccumulatorOperation::Merge => amount,
+            };
+            *actual_changes.entry(key.clone()).or_insert(0) += change;
+            if is_ptb_emitted {
+                *ptb_changes.entry(key).or_insert(0) += change;
+            }
+        }
+
+        for (key, actual) in actual_changes {
+            let (address, type_tag) = &key;
+            if let Some(budget) = input_reservations.get(&key).copied() {
+                let net_withdrawn = -actual.min(0) as u128;
+                assert_invariant!(
+                    net_withdrawn <= budget as u128,
+                    "Balance accumulator withdrawal exceeds reservation budget at address \
+                    {address} for type {type_tag}: net Split {net_withdrawn}, budget {budget}"
+                );
+            } else if let Some(ptb_change) = ptb_changes.get(&key).copied() {
+                // Runtime-emitted withdrawals at this (address, type) are bounded by Move's
+                // net deposit at the same key: actual ≥ min(0, ptb_change). When Move
+                // deposited (ptb_change > 0), the runtime may withdraw down to 0; when Move
+                // withdrew (ptb_change < 0), the runtime may not withdraw further.
+                assert_invariant!(
+                    actual >= ptb_change.min(0),
+                    "PTB-emitted Balance accumulator events do not cover runtime withdrawals \
+                    at address {address} for type {type_tag}: PTB change {ptb_change}, net \
+                    change {actual}"
+                );
+            } else {
+                invariant_violation!(
+                    "Unauthorized runtime Balance accumulator event at address {address} for \
+                    type {type_tag}: net change {actual} (no input reservation, no PTB-emitted \
+                    events)"
+                );
+            }
+        }
+
+        Ok(())
+    }
+
     /// Check that this transaction neither creates nor destroys SUI.
     /// This more expensive check will check a third invariant on top of the 2 performed
     /// by `check_sui_conserved` above:
@@ -1326,9 +1421,25 @@ impl Storage for TemporaryStore<'_> {
 
         // It's important to merge instead of override results because it's
         // possible to execute PT more than once during tx execution.
+        // Track the index range of accumulator events brought in here as PTB-emitted; the
+        // address-balance change invariant (run inside `run_conservation_checks`) uses this
+        // set to distinguish trusted PTB-emitted events from runtime-emitted ones.
+        let event_start = self.execution_results.accumulator_events.len();
         self.execution_results.merge_results(
             results, /* consistent_merge */ true, /* invariant_checks */ true,
         )?;
+        let event_end = self.execution_results.accumulator_events.len();
+        debug_assert!(
+            event_start <= event_end,
+            "merge_results should not shrink accumulator_events"
+        );
+        let (event_start, event_end) = (event_start.min(event_end), event_start.max(event_end));
+        let range = event_start..event_end;
+        match self.ptb_emitted_accumulator_event_ranges.last_mut() {
+            // Coalesce with the previous PTB range if no runtime events were added in between.
+            Some(last) if last.end == range.start => last.end = range.end,
+            _ => self.ptb_emitted_accumulator_event_ranges.push(range),
+        }
 
         Ok(())
     }

--- a/sui-execution/latest/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/latest/sui-adapter/src/temporary_store.rs
@@ -1151,12 +1151,34 @@ impl TemporaryStore<'_> {
     ///
     /// Currently the only funds-accumulator type is `Balance<T>`, so the check is scoped to
     /// those events. As more accumulator shapes are added the filter and the integer
-    /// arithmetic here will need to grow with them.
+    /// arithmetic in `check_address_balance_changes_impl` will need to grow with them.
     ///
     /// PTB-emitted events are identified via `ptb_emitted_accumulator_event_ranges`, populated
     /// at `record_execution_results` time. They are trusted because Move enforces `&mut UID`
     /// and the native checks the actual balance.
+    ///
+    /// `protocol_config.enforce_address_balance_change_invariant()` selects the failure mode:
+    /// - On (post-flag): violations are returned as `Err` so the caller's
+    ///   conservation-recovery flow can abort the tx cleanly.
+    /// - Off (pre-flag): the check still runs, but a violation panics so unexpected
+    ///   violations surface loudly during rollout.
     pub fn check_address_balance_changes(
+        &self,
+        protocol_config: &ProtocolConfig,
+        input_reservations: &BTreeMap<(SuiAddress, TypeTag), u64>,
+    ) -> Result<(), ExecutionError> {
+        let result = self.check_address_balance_changes_impl(input_reservations);
+        if protocol_config.enforce_address_balance_change_invariant() {
+            result
+        } else {
+            if let Err(e) = result {
+                panic!("address-balance-change invariant violated pre-flag: {e}");
+            }
+            Ok(())
+        }
+    }
+
+    fn check_address_balance_changes_impl(
         &self,
         input_reservations: &BTreeMap<(SuiAddress, TypeTag), u64>,
     ) -> Result<(), ExecutionError> {

--- a/sui-execution/latest/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/latest/sui-adapter/src/temporary_store.rs
@@ -1188,8 +1188,13 @@ impl TemporaryStore<'_> {
         let mut ptb_changes: BTreeMap<(SuiAddress, TypeTag), i128> = BTreeMap::new();
         for (idx, event) in self.execution_results.accumulator_events.iter().enumerate() {
             // Only Balance<T> accumulators are supported today; extend this filter when
-            // additional funds-accumulator types are introduced.
+            // additional funds-accumulator types are introduced. The debug_fatal flags any
+            // new shape so this check is updated alongside it instead of silently skipping.
             if !Balance::is_balance_type(&event.write.address.ty) {
+                debug_fatal!(
+                    "Unexpected non-Balance accumulator event type: {:?}",
+                    event.write.address.ty
+                );
                 continue;
             }
             let is_ptb_emitted = self

--- a/sui-execution/latest/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/latest/sui-adapter/src/temporary_store.rs
@@ -1187,12 +1187,20 @@ impl TemporaryStore<'_> {
         let mut actual_changes: BTreeMap<(SuiAddress, TypeTag), i128> = BTreeMap::new();
         let mut ptb_changes: BTreeMap<(SuiAddress, TypeTag), i128> = BTreeMap::new();
         for (idx, event) in self.execution_results.accumulator_events.iter().enumerate() {
-            // Only Balance<T> accumulators are supported today; extend this filter when
-            // additional funds-accumulator types are introduced. The debug_fatal flags any
-            // new shape so this check is updated alongside it instead of silently skipping.
+            // Filter on the value shape first: only `Integer` carries the funds-flow we care
+            // about. Other shapes (e.g. `EventDigest` for event-stream heads) belong to
+            // non-Balance accumulators and are out of scope here. If we ever see an `Integer`
+            // value at a non-`Balance<T>` type, the accounting invariants below don't apply
+            // — debug_fatal so that case is surfaced instead of silently accepted.
+            let amount = match event.write.value {
+                AccumulatorValue::Integer(amount) => amount as i128,
+                AccumulatorValue::IntegerTuple(_, _) | AccumulatorValue::EventDigest(_) => {
+                    continue;
+                }
+            };
             if !Balance::is_balance_type(&event.write.address.ty) {
                 debug_fatal!(
-                    "Unexpected non-Balance accumulator event type: {:?}",
+                    "Integer accumulator value at non-Balance type: {:?}",
                     event.write.address.ty
                 );
                 continue;
@@ -1202,14 +1210,6 @@ impl TemporaryStore<'_> {
                 .iter()
                 .any(|range| range.contains(&idx));
             let key = (event.write.address.address, event.write.address.ty.clone());
-            let AccumulatorValue::Integer(amount) = event.write.value else {
-                debug_fatal!(
-                    "Unexpected non-integer value in funds-accumulator event: {:?}",
-                    event.write.value
-                );
-                continue;
-            };
-            let amount = amount as i128;
             let change = match event.write.operation {
                 AccumulatorOperation::Split => -amount,
                 AccumulatorOperation::Merge => amount,


### PR DESCRIPTION
## Description 

- Adds invariant checks that are run after conservation checks
  - All net changes must be permissible under the input reservations (as applicable)
  - For any changes outside of the input reservations, they must come from the PTB runtime
  
## Test plan 

- Ran tests 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
