### PR TITLE
[snapshot_restore] wait_for_tidehunter_background_threads before rename

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8407,7 +8407,7 @@ dependencies = [
 [[package]]
 name = "minibytes"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/tidehunter.git?rev=5a5a23b79a7410cb9e1894d2f71d3ac01bf732ed#5a5a23b79a7410cb9e1894d2f71d3ac01bf732ed"
+source = "git+https://github.com/mystenlabs/tidehunter.git?rev=f7e5ab73209035fa1695777defc1a11368425d2d#f7e5ab73209035fa1695777defc1a11368425d2d"
 dependencies = [
  "bytes",
  "memmap2 0.7.1",
@@ -17882,7 +17882,7 @@ dependencies = [
 [[package]]
 name = "tidehunter"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/tidehunter.git?rev=5a5a23b79a7410cb9e1894d2f71d3ac01bf732ed#5a5a23b79a7410cb9e1894d2f71d3ac01bf732ed"
+source = "git+https://github.com/mystenlabs/tidehunter.git?rev=f7e5ab73209035fa1695777defc1a11368425d2d#f7e5ab73209035fa1695777defc1a11368425d2d"
 dependencies = [
  "arc-swap",
  "bincode 1.3.3",

--- a/crates/sui-core/src/authority/authority_store_tables.rs
+++ b/crates/sui-core/src/authority/authority_store_tables.rs
@@ -438,6 +438,24 @@ impl AuthorityPerpetualTables {
         self.objects.db.force_rebuild_control_region()
     }
 
+    /// Wait for tidehunter background threads to finish before allowing the caller
+    /// to e.g. rename the database directory. Consumes `Arc<Self>` so all internal
+    /// `Arc<Database>` clones held by the column family `DBMap`s are released as
+    /// part of the drop, leaving only the `Arc<Database>` extracted here.
+    #[cfg(tidehunter)]
+    pub fn wait_for_tidehunter_background_threads(self: Arc<Self>) {
+        let strong = Arc::strong_count(&self);
+        if strong != 1 {
+            println!(
+                "WARNING: wait_for_tidehunter_background_threads called with Arc<AuthorityPerpetualTables> strong_count={} (expected 1); other clones will keep DBMap.db Arc<Database> alive past drop(self) and the inner Database wait will warn/timeout",
+                strong,
+            );
+        }
+        let db = self.objects.db.clone();
+        drop(self);
+        db.wait_for_tidehunter_background_threads();
+    }
+
     // This is used by indexer to find the correct version of dynamic field child object.
     // We do not store the version of the child object, but because of lamport timestamp,
     // we know the child must have version number less then or eq to the parent.

--- a/crates/sui-tool/src/lib.rs
+++ b/crates/sui-tool/src/lib.rs
@@ -1024,9 +1024,20 @@ pub async fn download_formal_snapshot(
     // After a large backfill, rebuild the tidehunter control region to reclaim disk space
     // and reduce startup time. No-op when compiled without tidehunter.
     #[cfg(tidehunter)]
-    perpetual_db
-        .force_rebuild_control_region()
-        .expect("Failed to rebuild tidehunter control region after snapshot restore");
+    {
+        perpetual_db
+            .force_rebuild_control_region()
+            .expect("Failed to rebuild tidehunter control region after snapshot restore");
+        // The tidehunter Db spawns background threads (periodic snapshot, relocator,
+        // flusher pool, etc.) that own file handles inside the staging directory.
+        // Wait for them to exit before renaming staging -> live, otherwise a
+        // periodic timer could try to open a new file under the (now missing) path.
+        println!(
+            "Waiting for tidehunter background threads to finish before renaming staging to live"
+        );
+        perpetual_db.wait_for_tidehunter_background_threads();
+        println!("Tidehunter background threads finished, proceeding with rename");
+    }
 
     let new_path = path.parent().unwrap().join("live");
     if new_path.exists() {

--- a/crates/typed-store/Cargo.toml
+++ b/crates/typed-store/Cargo.toml
@@ -34,7 +34,7 @@ sui-macros.workspace = true
 mysten-common.workspace = true
 mysten-metrics.workspace = true
 [target.'cfg(not(windows))'.dependencies]
-tidehunter = {git = "https://github.com/mystenlabs/tidehunter.git", rev = "5a5a23b79a7410cb9e1894d2f71d3ac01bf732ed", version = "0.1.0", optional = true}
+tidehunter = {git = "https://github.com/mystenlabs/tidehunter.git", rev = "f7e5ab73209035fa1695777defc1a11368425d2d", version = "0.1.0", optional = true}
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 rocksdb = { version = "0.22.0", default-features = false, features = ["jemalloc"] }

--- a/crates/typed-store/src/rocks/mod.rs
+++ b/crates/typed-store/src/rocks/mod.rs
@@ -423,6 +423,29 @@ impl Database {
         Ok(())
     }
 
+    /// Wait for tidehunter background threads to finish.
+    ///
+    /// Consumes the `Arc<Database>`. Caller must ensure no other clones of this
+    /// `Arc<Database>` (e.g. via `DBMap::db`) are alive — otherwise the inner
+    /// `Arc<TideHunterDb>` strong count will not reach zero and the wait will
+    /// poll until it panics.
+    #[cfg(tidehunter)]
+    pub fn wait_for_tidehunter_background_threads(self: Arc<Self>) {
+        let strong = Arc::strong_count(&self);
+        if strong != 1 {
+            println!(
+                "WARNING: wait_for_tidehunter_background_threads called with Arc<Database> strong_count={} (expected 1); other clones will keep the inner tidehunter Db alive and the wait may panic on timeout",
+                strong,
+            );
+        }
+        let Storage::TideHunter(th_arc) = &self.storage else {
+            return;
+        };
+        let th_arc = th_arc.clone();
+        drop(self);
+        th_arc.wait_for_background_threads_to_finish();
+    }
+
     #[cfg(tidehunter)]
     pub fn drop_cells_in_range(
         &self,


### PR DESCRIPTION
## Summary
Waits for tidehunter background threads before rename during snapshot restore. Also updates tidehunter to `f7e5ab73209035fa1695777defc1a11368425d2d`.

## Test plan
- [ ] Deploy to private-testnet with `build_with_tidehunter=true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)