### PR TITLE
[onchain-deps 1] Implement on-chain package fetching and manifest generation

### DIFF
--- a/crates/sui-package-alt/src/sui_flavor.rs
+++ b/crates/sui-package-alt/src/sui_flavor.rs
@@ -230,6 +230,14 @@ impl MoveFlavor for SuiFlavor {
     fn is_system_address(&self, address: &move_package_alt::schema::OriginalID) -> bool {
         is_system_package(address.0)
     }
+
+    async fn fetch_onchain_package(
+        &self,
+        _address: &move_package_alt::schema::PublishedID,
+    ) -> anyhow::Result<move_package_alt::OnChainPackageData> {
+        // TODO: implement via gRPC get_object → MovePackage
+        anyhow::bail!("on-chain package fetching is not yet implemented for SuiFlavor")
+    }
 }
 
 /// We validate that a modern manifest cannot define the "legacy" system names.

--- a/crates/sui-package-alt/src/sui_flavor.rs
+++ b/crates/sui-package-alt/src/sui_flavor.rs
@@ -8,10 +8,10 @@ use async_trait::async_trait;
 use indexmap::IndexMap;
 use move_compiler::editions::Edition;
 use move_package_alt::{
-    MoveFlavor,
+    MoveFlavor, OnChainPackageData,
     schema::{
         EnvironmentID, EnvironmentName, GitSha, LockfileDependencyInfo, LockfileGitDepInfo,
-        PackageName, ParsedManifest, ReplacementDependency, SystemDepName,
+        OriginalID, PackageName, ParsedManifest, PublishedID, ReplacementDependency, SystemDepName,
     },
 };
 
@@ -231,10 +231,12 @@ impl MoveFlavor for SuiFlavor {
         is_system_package(address.0)
     }
 
+    /// Fetch an on-chain package via gRPC. Returns an error if there is no network connection
+    /// or if the object at `address` is not a package.
     async fn fetch_onchain_package(
         &self,
-        address: &move_package_alt::schema::PublishedID,
-    ) -> anyhow::Result<move_package_alt::OnChainPackageData> {
+        address: &PublishedID,
+    ) -> anyhow::Result<OnChainPackageData> {
         let Some(ref client) = self.client else {
             anyhow::bail!("cannot fetch on-chain package {address}: no network connection")
         };
@@ -244,7 +246,7 @@ impl MoveFlavor for SuiFlavor {
         let package = object
             .data
             .try_as_package()
-            .ok_or_else(|| anyhow::anyhow!("object {address} is not a package"))?;
+            .with_context(|| format!("object {address} is not a package"))?;
 
         let modules = package.serialized_module_map().clone();
         let dependencies = package
@@ -252,16 +254,15 @@ impl MoveFlavor for SuiFlavor {
             .iter()
             .map(|(original_id, upgrade_info)| {
                 (
-                    move_package_alt::schema::OriginalID((*original_id).into()),
-                    move_package_alt::schema::PublishedID(upgrade_info.upgraded_id.into()),
+                    OriginalID((*original_id).into()),
+                    PublishedID(upgrade_info.upgraded_id.into()),
                 )
             })
             .collect();
-        let original_id =
-            move_package_alt::schema::OriginalID(package.original_package_id().into());
+        let original_id = OriginalID(package.original_package_id().into());
         let version: u64 = package.version().into();
 
-        Ok(move_package_alt::OnChainPackageData {
+        Ok(OnChainPackageData {
             modules,
             dependencies,
             original_id,

--- a/crates/sui-package-alt/src/sui_flavor.rs
+++ b/crates/sui-package-alt/src/sui_flavor.rs
@@ -233,10 +233,43 @@ impl MoveFlavor for SuiFlavor {
 
     async fn fetch_onchain_package(
         &self,
-        _address: &move_package_alt::schema::PublishedID,
+        address: &move_package_alt::schema::PublishedID,
     ) -> anyhow::Result<move_package_alt::OnChainPackageData> {
-        // TODO: implement via gRPC get_object → MovePackage
-        anyhow::bail!("on-chain package fetching is not yet implemented for SuiFlavor")
+        let Some(ref client) = self.client else {
+            anyhow::bail!(
+                "cannot fetch on-chain package {address}: no network connection \
+                 (SuiFlavor created in offline mode)"
+            )
+        };
+
+        let object_id = ObjectID::from(address.0);
+        let object = client.clone().get_object(object_id).await?;
+        let package = object
+            .data
+            .try_as_package()
+            .ok_or_else(|| anyhow::anyhow!("object {address} is not a package"))?;
+
+        let modules = package.serialized_module_map().clone();
+        let dependencies = package
+            .linkage_table()
+            .iter()
+            .map(|(original_id, upgrade_info)| {
+                (
+                    move_package_alt::schema::OriginalID((*original_id).into()),
+                    move_package_alt::schema::PublishedID(upgrade_info.upgraded_id.into()),
+                )
+            })
+            .collect();
+        let original_id =
+            move_package_alt::schema::OriginalID(package.original_package_id().into());
+        let version: u64 = package.version().into();
+
+        Ok(move_package_alt::OnChainPackageData {
+            modules,
+            dependencies,
+            original_id,
+            version,
+        })
     }
 }
 

--- a/crates/sui-package-alt/src/sui_flavor.rs
+++ b/crates/sui-package-alt/src/sui_flavor.rs
@@ -236,9 +236,7 @@ impl MoveFlavor for SuiFlavor {
         address: &move_package_alt::schema::PublishedID,
     ) -> anyhow::Result<move_package_alt::OnChainPackageData> {
         let Some(ref client) = self.client else {
-            anyhow::bail!(
-                "cannot fetch on-chain package {address}: no network connection"
-            )
+            anyhow::bail!("cannot fetch on-chain package {address}: no network connection")
         };
 
         let object_id = ObjectID::from(address.0);

--- a/crates/sui-package-alt/src/sui_flavor.rs
+++ b/crates/sui-package-alt/src/sui_flavor.rs
@@ -237,8 +237,7 @@ impl MoveFlavor for SuiFlavor {
     ) -> anyhow::Result<move_package_alt::OnChainPackageData> {
         let Some(ref client) = self.client else {
             anyhow::bail!(
-                "cannot fetch on-chain package {address}: no network connection \
-                 (SuiFlavor created in offline mode)"
+                "cannot fetch on-chain package {address}: no network connection"
             )
         };
 

--- a/external-crates/move/crates/move-package-alt/design/on-chain-fetching.md
+++ b/external-crates/move/crates/move-package-alt/design/on-chain-fetching.md
@@ -20,15 +20,6 @@ The package system fetches the bytecode and linkage table from the network (via 
 cache, and loads the package like any other dependency. Stub Move source files are
 generated from the bytecode so the compiler can type-check against the dependency.
 
-### Implementation status
-
-- Schema and validation: **done** (#26552)
-- Fetching and manifest generation: **done** (#26561)
-- Stub source generation: DVX-2119
-- System package deduplication: DVX-2126
-- Support for `sui move test-publish`: DVX-2120
-- Support for `sui move test`: DVX-2060
-
 ## User-facing manifest format
 
 On-chain dependencies use two forms of the `on-chain` key:
@@ -91,7 +82,7 @@ The generated `Move.toml` for an on-chain package looks like:
 
 ```toml
 [package]
-name = "self"
+name = "_onchain_package"
 implicit-dependencies = false
 
 [environments]
@@ -104,7 +95,7 @@ onchain_0x0003 = { on-chain = "0x0033", override = true }
 
 Key design choices:
 
-- **`name = "self"`** — a fixed name for all generated packages. Users never need to know
+- **`name = "_onchain_package"`** — a fixed name for all generated packages. Users never need to know
   this name because the rename-from check is skipped for on-chain dependencies.
 - **`implicit-dependencies = false`** — prevents the generated manifest from pulling in the
   flavor's implicit dependencies (e.g. `sui`, `std`), which would conflict with the system
@@ -141,7 +132,7 @@ calls `get_object` via gRPC, extracts the `MovePackage` from the object, and map
 
 After fetching, `Package::load` reads the generated manifest and proceeds through the
 normal loading pipeline — combining deps, checking environments, loading publications.
-The rename-from check is skipped for on-chain deps (the `"self"` package name won't match
+The rename-from check is skipped for on-chain deps (the `"_onchain_package"` name won't match
 the user's dependency name).
 
 ## Environment handling

--- a/external-crates/move/crates/move-package-alt/design/on-chain-fetching.md
+++ b/external-crates/move/crates/move-package-alt/design/on-chain-fetching.md
@@ -1,0 +1,191 @@
+# On-Chain Package Fetching
+
+## Overview
+
+On-chain dependencies allow Move packages to depend on other packages by their on-chain
+address, without requiring source code. This is needed because MVR is currently
+source-only, which breaks when source isn't published or doesn't match on-chain bytecode.
+
+A user declares an on-chain dependency in their `Move.toml`:
+```toml
+[dependencies]
+my_dep = { on-chain = true }
+
+[dep-replacements.mainnet]
+my_dep = { on-chain = "0x1234..." }
+```
+
+The package system fetches the bytecode and linkage table from the network (via the
+`MoveFlavor` trait), generates a synthetic `Move.toml` and `Published.toml` in a local
+cache, and loads the package like any other dependency. Stub Move source files are
+generated from the bytecode so the compiler can type-check against the dependency.
+
+### Implementation status
+
+- Schema and validation: **done** (#26552)
+- Fetching and manifest generation: **done** (#26561)
+- Stub source generation: DVX-2119
+- System package deduplication: DVX-2126
+- Support for `sui move test-publish`: DVX-2120
+- Support for `sui move test`: DVX-2060
+
+## User-facing manifest format
+
+On-chain dependencies use two forms of the `on-chain` key:
+
+- **`on-chain = true`** in `[dependencies]` — declares that a dependency is on-chain,
+  without specifying an address. The address must be provided per-environment in
+  `[dep-replacements]`.
+- **`on-chain = "0x..."`** in `[dep-replacements]` — provides the on-chain address for a
+  specific environment.
+
+```toml
+[package]
+name = "my_package"
+
+[dependencies]
+my_dep = { on-chain = true }
+
+[dep-replacements.mainnet]
+my_dep = { on-chain = "0x1234..." }
+
+[dep-replacements.testnet]
+my_dep = { on-chain = "0x5678..." }
+```
+
+Validation rules enforced during combining:
+- `on-chain = "0x..."` in `[dependencies]` is rejected (addresses belong in dep-replacements)
+- `on-chain = true` in `[dep-replacements]` is rejected (replacements must have an address)
+- `on-chain = true` with no dep-replacement is rejected (no address to fetch)
+- `use-environment` on on-chain deps is rejected (on-chain packages use a fixed environment)
+
+## Cache layout
+
+On-chain packages are cached at `~/.move/on-chain/<chain_id>/<address>/`. The cache is
+populated on first fetch and reused on subsequent builds. A filesystem lock
+(`PackageSystemLock::new_for_onchain`) serializes concurrent access.
+
+```
+~/.move/on-chain/<chain_id>/<address>/
+├── Move.toml          # generated manifest
+├── Published.toml     # generated publication metadata
+├── bytecode/           
+│   ├── module_a.mv    # serialized CompiledModule bytecode
+│   └── module_b.mv
+└── sources/            # (future) generated stub Move source
+    ├── module_a.move
+    └── module_b.move
+```
+
+The `bytecode/` directory uses a different path from the compiler's
+`build/<pkg>/bytecode_modules/` to avoid clobbering the original bytecode if the package
+is recompiled.
+
+The cache check uses manifest existence: if `Move.toml` exists, the fetch is skipped
+entirely. The cache is written atomically — bytecode, source stubs, manifest, and
+Published.toml are all written in a single locked section, with the manifest written last.
+
+## Generated manifest
+
+The generated `Move.toml` for an on-chain package looks like:
+
+```toml
+[package]
+name = "self"
+implicit-dependencies = false
+
+[environments]
+_on_chain = "<chain_id>"
+
+[dep-replacements._on_chain]
+onchain_0x0002 = { on-chain = "0x0002", override = true }
+onchain_0x0003 = { on-chain = "0x0033", override = true }
+```
+
+Key design choices:
+
+- **`name = "self"`** — a fixed name for all generated packages. Users never need to know
+  this name because the rename-from check is skipped for on-chain dependencies.
+- **`implicit-dependencies = false`** — prevents the generated manifest from pulling in the
+  flavor's implicit dependencies (e.g. `sui`, `std`), which would conflict with the system
+  deps already in the graph.
+- **`override = true`** — on-chain dep-replacements are overrides so they take precedence
+  when the same dependency appears in the graph.
+- **Dependency names** — linkage table entries are named `onchain_<original_id>`. These
+  names are arbitrary identifiers; the `on-chain` address is what matters.
+- **`Published.toml`** — records the package's `published-at`, `original-id`, `version`,
+  and `chain-id` under the `_on_chain` environment, following the same schema as
+  user-authored Published.toml files.
+
+## Fetching pipeline
+
+When `fetch()` encounters a `Pinned::OnChain { address }`, it delegates to
+`on_chain::fetch::fetch_onchain`, which:
+
+1. Computes the cache directory from `MOVE_HOME`, chain ID, and address
+2. Acquires an exclusive filesystem lock for the cache directory
+3. Checks if the manifest already exists (cache hit → return immediately)
+4. Calls `config.flavor.fetch_onchain_package(address)` to download
+   `OnChainPackageData` from the network (modules, linkage table, original ID, version)
+5. Writes bytecode to `bytecode/<name>.mv`
+6. Generates stub source files (currently a no-op, DVX-2119)
+7. Generates `Move.toml` via `ParsedManifest` + `RenderToml`
+8. Generates `Published.toml` via `ParsedPublishedFile` + `RenderToml`
+9. Returns the cache directory path as a `PackagePath`
+
+The `MoveFlavor::fetch_onchain_package` trait method is the only network-touching
+operation. `Vanilla` looks up from a pre-populated `BTreeMap` (for testing). `SuiFlavor`
+calls `get_object` via gRPC, extracts the `MovePackage` from the object, and maps
+`module_map`, `linkage_table`, `original_package_id()`, and `version` to
+`OnChainPackageData`.
+
+After fetching, `Package::load` reads the generated manifest and proceeds through the
+normal loading pipeline — combining deps, checking environments, loading publications.
+The rename-from check is skipped for on-chain deps (the `"self"` package name won't match
+the user's dependency name).
+
+## Environment handling
+
+Environment names are per-package: different packages in the dependency graph may use
+different names for the same network. For example, one package might call mainnet
+`"mainnet"` while another calls it `"production"`.
+
+On-chain packages are tied to a specific chain (determined by the chain ID at fetch time),
+so they don't need environment flexibility. Generated manifests use a single fixed
+environment name `_on_chain` mapped to the chain ID.
+
+To connect the caller's environment to the generated package's `_on_chain` environment,
+`use_environment` is forced to `_on_chain` during combining for all `OnChainAt`
+dependencies (in `CombinedDependency::from_replacement` and
+`from_default_with_replacement`). This means the graph builder loads on-chain packages
+with the `_on_chain` environment regardless of what the parent package's environment is
+called. Explicit `use-environment` on on-chain deps is rejected with an error.
+
+This design means the cache is written once per chain ID + address pair and never needs to
+be updated for different environment names.
+
+## Known limitations and future work
+
+- **System package deduplication (DVX-2126):** The linkage table entries are all turned
+  into on-chain dep-replacements, including entries for system packages (e.g. `0x1`, `0x2`
+  on Sui). System packages are mutable and should instead be resolved as system deps. More
+  generally, a package may be reachable both as an on-chain dep (from a linkage table) and
+  as a source dep (from the user's manifest or system deps). These need to be
+  deduplicated, likely in a post-processing step after the full graph is built. This blocks
+  practical end-to-end testing since almost all on-chain packages depend on system
+  packages.
+- **Stub source generation (DVX-2119):** `write_source` is currently a no-op. Stub Move
+  source files need to be generated from bytecode so the compiler can type-check against
+  on-chain dependencies. A draft implementation exists in PR #26555
+  (`mdgeorge/onchain-stubs`) and will be integrated into `on_chain/move_source.rs`.
+- **Manifest serialization mismatch (DVX-2125):** `ManifestDependencyInfo`'s derived
+  `Serialize` doesn't match its custom `Deserialize`. The `RenderToml` impl on
+  `ParsedManifest` works around this by rendering dep-replacements manually. The proper fix
+  is to decouple the digest computation from serialization, then fix the serializer.
+- **`move_home` threading (DVX-2127):** The on-chain cache, git cache, and lock files all
+  hardcode `MOVE_HOME`. Threading a configurable `move_home` through `PackageConfig` would
+  enable per-test cache isolation. Currently, tests use unique addresses to avoid
+  collisions.
+- **Test-publish (DVX-2120):** Support for `sui move test-publish` with on-chain
+  dependencies.
+- **Unit tests (DVX-2060):** Support for `sui move test` with on-chain dependencies.

--- a/external-crates/move/crates/move-package-alt/src/dependency/combine.rs
+++ b/external-crates/move/crates/move-package-alt/src/dependency/combine.rs
@@ -302,6 +302,6 @@ mod tests {
             move_command_line_common::env::MOVE_HOME.as_str(),
             "<MOVE_HOME>",
         );
-        assert_snapshot!(err, @"Error while loading dependency <MOVE_HOME>/on-chain/_test_env_id/0x0000000000000000000000000000000000000000000000000000000000000001: failed to fetch on-chain package at 0x0000000000000000000000000000000000000000000000000000000000000001: on-chain package not found: 0x0000000000000000000000000000000000000000000000000000000000000001");
+        assert_snapshot!(err, @"Error while loading dependency <MOVE_HOME>/on-chain/_test_env_id/0x0000000000000000000000000000000000000000000000000000000000000001: on-chain package not found: 0x0000000000000000000000000000000000000000000000000000000000000001");
     }
 }

--- a/external-crates/move/crates/move-package-alt/src/dependency/combine.rs
+++ b/external-crates/move/crates/move-package-alt/src/dependency/combine.rs
@@ -297,9 +297,11 @@ mod tests {
             .build();
 
         let err = scenario.root_package_err("root").await;
-        assert!(
-            err.contains("on-chain package not found"),
-            "expected fetch error, got: {err}"
+        // Redact the MOVE_HOME path which varies per user
+        let err = err.replace(
+            move_command_line_common::env::MOVE_HOME.as_str(),
+            "<MOVE_HOME>",
         );
+        assert_snapshot!(err, @"Error while loading dependency <MOVE_HOME>/on-chain/_test_env_id/0x0000000000000000000000000000000000000000000000000000000000000001: failed to fetch on-chain package at 0x0000000000000000000000000000000000000000000000000000000000000001: on-chain package not found: 0x0000000000000000000000000000000000000000000000000000000000000001");
     }
 }

--- a/external-crates/move/crates/move-package-alt/src/dependency/combine.rs
+++ b/external-crates/move/crates/move-package-alt/src/dependency/combine.rs
@@ -147,10 +147,23 @@ impl CombinedDependency {
             ));
         }
 
+        // On-chain deps use a fixed environment; reject explicit use-environment
+        let use_environment =
+            if matches!(&dep.dependency_info, ManifestDependencyInfo::OnChainAt(_)) {
+                if replacement.use_environment.is_some() {
+                    return Err(ManifestError::with_file(file)(
+                        ManifestErrorKind::OnChainWithUseEnvironment { name },
+                    ));
+                }
+                crate::on_chain::fetch::ON_CHAIN_ENV_NAME.to_string()
+            } else {
+                replacement.use_environment.unwrap_or(source_env_name)
+            };
+
         Ok(Self {
             context: DependencyContext {
                 name,
-                use_environment: replacement.use_environment.unwrap_or(source_env_name),
+                use_environment,
                 is_override: dep.is_override,
                 addresses: replacement.addresses,
                 containing_file: file,
@@ -184,11 +197,24 @@ impl CombinedDependency {
             ));
         }
 
+        // On-chain deps use a fixed environment; reject explicit use-environment
+        let use_environment =
+            if matches!(&dep.dependency_info, ManifestDependencyInfo::OnChainAt(_)) {
+                if replacement.use_environment.is_some() {
+                    return Err(ManifestError::with_file(file)(
+                        ManifestErrorKind::OnChainWithUseEnvironment { name },
+                    ));
+                }
+                crate::on_chain::fetch::ON_CHAIN_ENV_NAME.to_string()
+            } else {
+                replacement.use_environment.unwrap_or(source_env_name)
+            };
+
         // TODO: possibly additional compatibility checks here?
         Ok(Self {
             context: DependencyContext {
                 name,
-                use_environment: replacement.use_environment.unwrap_or(source_env_name),
+                use_environment,
                 is_override: dep.is_override,
                 addresses: replacement.addresses,
                 containing_file: file,

--- a/external-crates/move/crates/move-package-alt/src/dependency/combine.rs
+++ b/external-crates/move/crates/move-package-alt/src/dependency/combine.rs
@@ -148,17 +148,17 @@ impl CombinedDependency {
         }
 
         // On-chain deps use a fixed environment; reject explicit use-environment
-        let use_environment =
-            if matches!(&dep.dependency_info, ManifestDependencyInfo::OnChainAt(_)) {
-                if replacement.use_environment.is_some() {
-                    return Err(ManifestError::with_file(file)(
-                        ManifestErrorKind::OnChainWithUseEnvironment { name },
-                    ));
-                }
-                crate::on_chain::fetch::ON_CHAIN_ENV_NAME.to_string()
-            } else {
-                replacement.use_environment.unwrap_or(source_env_name)
-            };
+        let use_environment = if matches!(&dep.dependency_info, ManifestDependencyInfo::OnChain(_))
+        {
+            if replacement.use_environment.is_some() {
+                return Err(ManifestError::with_file(file)(
+                    ManifestErrorKind::OnChainWithUseEnvironment { name },
+                ));
+            }
+            crate::on_chain::fetch::ON_CHAIN_ENV_NAME.to_string()
+        } else {
+            replacement.use_environment.unwrap_or(source_env_name)
+        };
 
         Ok(Self {
             context: DependencyContext {
@@ -198,17 +198,17 @@ impl CombinedDependency {
         }
 
         // On-chain deps use a fixed environment; reject explicit use-environment
-        let use_environment =
-            if matches!(&dep.dependency_info, ManifestDependencyInfo::OnChainAt(_)) {
-                if replacement.use_environment.is_some() {
-                    return Err(ManifestError::with_file(file)(
-                        ManifestErrorKind::OnChainWithUseEnvironment { name },
-                    ));
-                }
-                crate::on_chain::fetch::ON_CHAIN_ENV_NAME.to_string()
-            } else {
-                replacement.use_environment.unwrap_or(source_env_name)
-            };
+        let use_environment = if matches!(&dep.dependency_info, ManifestDependencyInfo::OnChain(_))
+        {
+            if replacement.use_environment.is_some() {
+                return Err(ManifestError::with_file(file)(
+                    ManifestErrorKind::OnChainWithUseEnvironment { name },
+                ));
+            }
+            crate::on_chain::fetch::ON_CHAIN_ENV_NAME.to_string()
+        } else {
+            replacement.use_environment.unwrap_or(source_env_name)
+        };
 
         // TODO: possibly additional compatibility checks here?
         Ok(Self {

--- a/external-crates/move/crates/move-package-alt/src/dependency/combine.rs
+++ b/external-crates/move/crates/move-package-alt/src/dependency/combine.rs
@@ -287,8 +287,8 @@ mod tests {
         );
     }
 
-    /// on-chain = true + address replacement passes combining and fails during fetch.
-    /// This error should change when on-chain dep fetching is implemented.
+    /// on-chain = true + address replacement passes combining and fails during fetch
+    /// because Vanilla has no on-chain packages registered.
     #[test(tokio::test)]
     async fn on_chain_with_address_replacement_passes_combining() {
         let scenario = TestPackageGraph::new(["root"])
@@ -298,7 +298,7 @@ mod tests {
 
         let err = scenario.root_package_err("root").await;
         assert!(
-            err.contains("On-chain dependencies are not yet supported"),
+            err.contains("on-chain package not found"),
             "expected fetch error, got: {err}"
         );
     }

--- a/external-crates/move/crates/move-package-alt/src/dependency/combine.rs
+++ b/external-crates/move/crates/move-package-alt/src/dependency/combine.rs
@@ -148,13 +148,15 @@ impl CombinedDependency {
         }
 
         // On-chain deps use a fixed environment; reject explicit use-environment
-        let use_environment = if matches!(&dep.dependency_info, ManifestDependencyInfo::OnChain(_))
-        {
-            if replacement.use_environment.is_some() {
-                return Err(ManifestError::with_file(file)(
-                    ManifestErrorKind::OnChainWithUseEnvironment { name },
-                ));
-            }
+        let is_on_chain = matches!(&dep.dependency_info, ManifestDependencyInfo::OnChain(_));
+
+        if is_on_chain && replacement.use_environment.is_some() {
+            return Err(ManifestError::with_file(file)(
+                ManifestErrorKind::OnChainWithUseEnvironment { name },
+            ));
+        }
+
+        let use_environment = if is_on_chain {
             crate::on_chain::fetch::ON_CHAIN_ENV_NAME.to_string()
         } else {
             replacement.use_environment.unwrap_or(source_env_name)
@@ -198,13 +200,15 @@ impl CombinedDependency {
         }
 
         // On-chain deps use a fixed environment; reject explicit use-environment
-        let use_environment = if matches!(&dep.dependency_info, ManifestDependencyInfo::OnChain(_))
-        {
-            if replacement.use_environment.is_some() {
-                return Err(ManifestError::with_file(file)(
-                    ManifestErrorKind::OnChainWithUseEnvironment { name },
-                ));
-            }
+        let is_on_chain = matches!(&dep.dependency_info, ManifestDependencyInfo::OnChain(_));
+
+        if is_on_chain && replacement.use_environment.is_some() {
+            return Err(ManifestError::with_file(file)(
+                ManifestErrorKind::OnChainWithUseEnvironment { name },
+            ));
+        }
+
+        let use_environment = if is_on_chain {
             crate::on_chain::fetch::ON_CHAIN_ENV_NAME.to_string()
         } else {
             replacement.use_environment.unwrap_or(source_env_name)

--- a/external-crates/move/crates/move-package-alt/src/dependency/fetch.rs
+++ b/external-crates/move/crates/move-package-alt/src/dependency/fetch.rs
@@ -43,12 +43,12 @@ pub type FetchResult<T> = Result<T, FetchError>;
 /// transformed into git dependencies.
 pub async fn fetch<F: MoveFlavor>(
     pinned: &Pinned,
-    env: &Environment,
+    _env: &Environment,
     config: &PackageConfig<F>,
 ) -> FetchResult<PackagePath> {
     let path = match &pinned {
         Pinned::OnChain { address } => {
-            crate::on_chain::fetch::fetch_onchain(address, env, config).await?
+            crate::on_chain::fetch::fetch_onchain(address, config).await?
         }
         Pinned::Git(dep) => dep
             .inner

--- a/external-crates/move/crates/move-package-alt/src/dependency/fetch.rs
+++ b/external-crates/move/crates/move-package-alt/src/dependency/fetch.rs
@@ -13,6 +13,7 @@ use thiserror::Error;
 use crate::{
     flavor::MoveFlavor,
     git::GitError,
+    on_chain::OnChainError,
     package::{
         package_loader::PackageConfig,
         paths::{PackagePath, PackagePathError},
@@ -30,8 +31,8 @@ pub enum FetchError {
     #[error("Error while fetching `{1}`: {0}")]
     GitFailure(GitError, String),
 
-    #[error("Error while fetching on-chain package: {0}")]
-    OnChainFailure(#[from] anyhow::Error),
+    #[error(transparent)]
+    OnChainFailure(#[from] OnChainError),
 }
 
 pub type FetchResult<T> = Result<T, FetchError>;

--- a/external-crates/move/crates/move-package-alt/src/dependency/fetch.rs
+++ b/external-crates/move/crates/move-package-alt/src/dependency/fetch.rs
@@ -11,9 +11,13 @@ use path_clean::PathClean;
 use thiserror::Error;
 
 use crate::{
+    flavor::MoveFlavor,
     git::GitError,
-    package::paths::{PackagePath, PackagePathError},
-    schema::{EnvironmentID, LocalDepInfo},
+    package::{
+        package_loader::PackageConfig,
+        paths::{PackagePath, PackagePathError},
+    },
+    schema::{Environment, LocalDepInfo},
 };
 
 use super::Pinned;
@@ -26,8 +30,8 @@ pub enum FetchError {
     #[error("Error while fetching `{1}`: {0}")]
     GitFailure(GitError, String),
 
-    #[error("On-chain dependencies are not yet supported")]
-    OnChainNotSupported,
+    #[error("Error while fetching on-chain package: {0}")]
+    OnChainFailure(#[from] anyhow::Error),
 }
 
 pub type FetchResult<T> = Result<T, FetchError>;
@@ -35,21 +39,22 @@ pub type FetchResult<T> = Result<T, FetchError>;
 /// Ensure that the dependency's files are present on the disk and return a path to them.
 /// Assumes that `pinned` is already normalized - paths of any local dependencies are relative
 /// to the current working directory, and local dependencies of git dependencies have been
-/// transformed into git dependencies. `chain_id` is used to determine the cache location for
-/// on-chain dependencies.
-pub async fn fetch(
+/// transformed into git dependencies.
+pub async fn fetch<F: MoveFlavor>(
     pinned: &Pinned,
-    allow_dirty: bool,
-    chain_id: &EnvironmentID,
+    env: &Environment,
+    config: &PackageConfig<F>,
 ) -> FetchResult<PackagePath> {
     let path = match &pinned {
-        Pinned::OnChain { .. } => return Err(FetchError::OnChainNotSupported),
+        Pinned::OnChain { address } => {
+            crate::on_chain::fetch::fetch_onchain(address, env, config).await?
+        }
         Pinned::Git(dep) => dep
             .inner
-            .checkout_repo(allow_dirty)
+            .checkout_repo(config.allow_dirty)
             .await
             .map_err(FetchError::from_git(pinned))?,
-        _ => pinned.unfetched_path(chain_id),
+        _ => pinned.unfetched_path(&config.chain_id),
     };
 
     PackagePath::new(path).map_err(FetchError::from_package(pinned))

--- a/external-crates/move/crates/move-package-alt/src/dependency/fetch.rs
+++ b/external-crates/move/crates/move-package-alt/src/dependency/fetch.rs
@@ -18,7 +18,7 @@ use crate::{
         package_loader::PackageConfig,
         paths::{PackagePath, PackagePathError},
     },
-    schema::{Environment, LocalDepInfo},
+    schema::LocalDepInfo,
 };
 
 use super::Pinned;
@@ -43,7 +43,6 @@ pub type FetchResult<T> = Result<T, FetchError>;
 /// transformed into git dependencies.
 pub async fn fetch<F: MoveFlavor>(
     pinned: &Pinned,
-    _env: &Environment,
     config: &PackageConfig<F>,
 ) -> FetchResult<PackagePath> {
     let path = match &pinned {

--- a/external-crates/move/crates/move-package-alt/src/dependency/pin.rs
+++ b/external-crates/move/crates/move-package-alt/src/dependency/pin.rs
@@ -213,6 +213,11 @@ impl Pinned {
         matches!(self, Pinned::Root(_))
     }
 
+    /// Is this an on-chain dependency?
+    pub(crate) fn is_on_chain(&self) -> bool {
+        matches!(self, Pinned::OnChain { .. })
+    }
+
     /// Return the absolute path to the directory that this package would be fetched into, without
     /// actually fetching it. `chain_id` is used to determine the cache location for on-chain
     /// dependencies.

--- a/external-crates/move/crates/move-package-alt/src/flavor/mod.rs
+++ b/external-crates/move/crates/move-package-alt/src/flavor/mod.rs
@@ -13,9 +13,23 @@ use serde::{Serialize, de::DeserializeOwned};
 
 use crate::schema::{
     EnvironmentID, EnvironmentName, LockfileDependencyInfo, OriginalID, PackageName,
-    ParsedManifest, ReplacementDependency, SystemDepName,
+    ParsedManifest, PublishedID, ReplacementDependency, SystemDepName,
 };
 use indexmap::IndexMap;
+
+/// Data returned by [`MoveFlavor::fetch_onchain_package`] representing a package fetched from the
+/// network.
+#[derive(Clone, Debug)]
+pub struct OnChainPackageData {
+    /// Module name → compiled bytecode
+    pub modules: BTreeMap<String, Vec<u8>>,
+    /// Original dependency ID → current linked address
+    pub dependencies: BTreeMap<OriginalID, PublishedID>,
+    /// The original (runtime) ID of this package
+    pub original_id: OriginalID,
+    /// The on-chain version of this package
+    pub version: u64,
+}
 
 /// A [MoveFlavor] is used to parameterize the package management system. It defines the types and
 /// methods for package management that are specific to a particular instantiation of the Move
@@ -66,4 +80,11 @@ pub trait MoveFlavor: Debug + Send + Sync {
     /// addresses are not dropped when substituting ephemeral addresses (they can still be
     /// overridden)
     fn is_system_address(&self, address: &OriginalID) -> bool;
+
+    /// Fetch the on-chain package at `address` from the network. Returns the module bytecode,
+    /// linkage table (as original → linked address), original ID, and version.
+    async fn fetch_onchain_package(
+        &self,
+        address: &PublishedID,
+    ) -> anyhow::Result<OnChainPackageData>;
 }

--- a/external-crates/move/crates/move-package-alt/src/flavor/mod.rs
+++ b/external-crates/move/crates/move-package-alt/src/flavor/mod.rs
@@ -81,8 +81,8 @@ pub trait MoveFlavor: Debug + Send + Sync {
     /// overridden)
     fn is_system_address(&self, address: &OriginalID) -> bool;
 
-    /// Fetch the on-chain package at `address` from the network. Returns the module bytecode,
-    /// linkage table (as original → linked address), original ID, and version.
+    /// Fetch the on-chain package at `address` from the network, returning an
+    /// [`OnChainPackageData`].
     async fn fetch_onchain_package(
         &self,
         address: &PublishedID,

--- a/external-crates/move/crates/move-package-alt/src/flavor/mod.rs
+++ b/external-crates/move/crates/move-package-alt/src/flavor/mod.rs
@@ -21,7 +21,7 @@ use indexmap::IndexMap;
 /// network.
 #[derive(Clone, Debug)]
 pub struct OnChainPackageData {
-    /// Module name → compiled bytecode
+    /// Module name → serialized `CompiledModule` bytecode (the `.mv` format)
     pub modules: BTreeMap<String, Vec<u8>>,
     /// Original dependency ID → current linked address
     pub dependencies: BTreeMap<OriginalID, PublishedID>,

--- a/external-crates/move/crates/move-package-alt/src/flavor/vanilla.rs
+++ b/external-crates/move/crates/move-package-alt/src/flavor/vanilla.rs
@@ -9,14 +9,16 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
+use anyhow::anyhow;
+
 use crate::schema::{
     Environment, EnvironmentID, EnvironmentName, LockfileDependencyInfo, OriginalID, PackageName,
-    ParsedManifest, ReplacementDependency,
+    ParsedManifest, PublishedID, ReplacementDependency,
 };
 
 use async_trait::async_trait;
 
-use super::MoveFlavor;
+use super::{MoveFlavor, OnChainPackageData};
 use indexmap::IndexMap;
 
 pub const DEFAULT_ENV_NAME: &str = "_test_env";
@@ -24,9 +26,13 @@ pub const DEFAULT_ENV_ID: &str = "_test_env_id";
 
 /// The [Vanilla] implementation of the [MoveFlavor] trait. This implementation supports no
 /// flavor-specific resolvers and stores no additional metadata in the lockfile.
+///
+/// On-chain packages can be pre-populated via [`Vanilla::with_on_chain_package`] for testing.
 #[derive(Debug, Default)]
 #[non_exhaustive]
-pub struct Vanilla;
+pub struct Vanilla {
+    on_chain_packages: BTreeMap<PublishedID, OnChainPackageData>,
+}
 
 #[derive(Serialize, Deserialize, Clone, Debug, Default)]
 #[serde(rename_all = "kebab-case")]
@@ -78,12 +84,28 @@ impl MoveFlavor for Vanilla {
     fn is_system_address(&self, address: &crate::schema::OriginalID) -> bool {
         address == &OriginalID::from(0xBEEF)
     }
+
+    async fn fetch_onchain_package(
+        &self,
+        address: &PublishedID,
+    ) -> anyhow::Result<OnChainPackageData> {
+        self.on_chain_packages
+            .get(address)
+            .cloned()
+            .ok_or_else(|| anyhow!("on-chain package not found: {address}"))
+    }
 }
 
 impl Vanilla {
-    /// Create a new `Vanilla` flavor.
+    /// Create a new `Vanilla` flavor with no on-chain packages.
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Add an on-chain package for testing. Returns `self` for chaining.
+    pub fn with_on_chain_package(mut self, address: PublishedID, data: OnChainPackageData) -> Self {
+        self.on_chain_packages.insert(address, data);
+        self
     }
 
     pub fn default_environment() -> Environment {

--- a/external-crates/move/crates/move-package-alt/src/flavor/vanilla.rs
+++ b/external-crates/move/crates/move-package-alt/src/flavor/vanilla.rs
@@ -7,9 +7,8 @@
 
 use std::collections::BTreeMap;
 
+use anyhow::Context;
 use serde::{Deserialize, Serialize};
-
-use anyhow::anyhow;
 
 use crate::schema::{
     Environment, EnvironmentID, EnvironmentName, LockfileDependencyInfo, OriginalID, PackageName,
@@ -27,7 +26,7 @@ pub const DEFAULT_ENV_ID: &str = "_test_env_id";
 /// The [Vanilla] implementation of the [MoveFlavor] trait. This implementation supports no
 /// flavor-specific resolvers and stores no additional metadata in the lockfile.
 ///
-/// On-chain packages can be pre-populated via [`Vanilla::with_on_chain_package`] for testing.
+/// On-chain packages can be pre-populated via [`Vanilla::with_on_chain_package`].
 #[derive(Clone, Debug, Default)]
 #[non_exhaustive]
 pub struct Vanilla {
@@ -92,17 +91,17 @@ impl MoveFlavor for Vanilla {
         self.on_chain_packages
             .get(address)
             .cloned()
-            .ok_or_else(|| anyhow!("on-chain package not found: {address}"))
+            .with_context(|| format!("on-chain package not found: {address}"))
     }
 }
 
 impl Vanilla {
-    /// Create a new `Vanilla` flavor with no on-chain packages.
+    /// Create a new `Vanilla` flavor.
     pub fn new() -> Self {
         Self::default()
     }
 
-    /// Add an on-chain package for testing. Returns `self` for chaining.
+    /// Add a pre-populated on-chain package. Returns `self` for chaining.
     pub fn with_on_chain_package(mut self, address: PublishedID, data: OnChainPackageData) -> Self {
         self.on_chain_packages.insert(address, data);
         self

--- a/external-crates/move/crates/move-package-alt/src/flavor/vanilla.rs
+++ b/external-crates/move/crates/move-package-alt/src/flavor/vanilla.rs
@@ -28,7 +28,7 @@ pub const DEFAULT_ENV_ID: &str = "_test_env_id";
 /// flavor-specific resolvers and stores no additional metadata in the lockfile.
 ///
 /// On-chain packages can be pre-populated via [`Vanilla::with_on_chain_package`] for testing.
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 #[non_exhaustive]
 pub struct Vanilla {
     on_chain_packages: BTreeMap<PublishedID, OnChainPackageData>,

--- a/external-crates/move/crates/move-package-alt/src/graph/rename_from.rs
+++ b/external-crates/move/crates/move-package-alt/src/graph/rename_from.rs
@@ -76,6 +76,11 @@ impl<F: MoveFlavor> PackageGraph<F> {
         for edge in self.inner.edges(self.root_index) {
             let dep = &edge.weight();
 
+            // On-chain packages have synthetic names, so skip the rename check
+            if dep.pinned().is_on_chain() {
+                continue;
+            }
+
             let target_pkg = self.inner[edge.target()].clone();
             let local_dep_name = dep.name().to_string();
             let actual_dep_name = target_pkg.name().to_string();

--- a/external-crates/move/crates/move-package-alt/src/lib.rs
+++ b/external-crates/move/crates/move-package-alt/src/lib.rs
@@ -12,6 +12,7 @@ mod errors;
 mod flavor;
 mod graph;
 mod logging;
+mod on_chain;
 mod package;
 
 pub mod git;
@@ -24,7 +25,7 @@ pub use package::paths::read_name_from_manifest;
 // TODO: maybe put SourcePackageLayout, NamedAddress into schema
 
 pub use errors::{PackageError, PackageResult};
-pub use flavor::{MoveFlavor, Vanilla};
+pub use flavor::{MoveFlavor, OnChainPackageData, Vanilla};
 pub use graph::{NamedAddress, PackageInfo};
 pub use package::layout::SourcePackageLayout;
 pub use package::{

--- a/external-crates/move/crates/move-package-alt/src/on_chain/errors.rs
+++ b/external-crates/move/crates/move-package-alt/src/on_chain/errors.rs
@@ -3,8 +3,6 @@
 
 //! Error types for on-chain package fetching.
 
-use std::path::PathBuf;
-
 use thiserror::Error;
 
 use crate::{package::package_lock::LockError, schema::PublishedID};
@@ -17,27 +15,6 @@ pub enum OnChainError {
         address: PublishedID,
         #[source]
         source: anyhow::Error,
-    },
-
-    #[error("failed to write on-chain package cache at {path}: {source}")]
-    CacheWrite {
-        path: PathBuf,
-        #[source]
-        source: std::io::Error,
-    },
-
-    #[error("failed to parse cached manifest at {path}: {source}")]
-    ManifestParse {
-        path: PathBuf,
-        #[source]
-        source: toml_edit::de::Error,
-    },
-
-    #[error("failed to serialize manifest for on-chain package {address}: {source}")]
-    ManifestSerialize {
-        address: PublishedID,
-        #[source]
-        source: toml_edit::ser::Error,
     },
 
     #[error(transparent)]

--- a/external-crates/move/crates/move-package-alt/src/on_chain/errors.rs
+++ b/external-crates/move/crates/move-package-alt/src/on_chain/errors.rs
@@ -12,36 +12,36 @@ use crate::{package::package_lock::LockError, schema::PublishedID};
 /// Errors that can occur while fetching an on-chain package.
 #[derive(Error, Debug)]
 pub enum OnChainError {
-    #[error("failed to fetch on-chain package at {address}: {source}")]
-    FetchFailed {
+    #[error("{source}")]
+    Fetch {
         address: PublishedID,
         #[source]
         source: anyhow::Error,
     },
 
     #[error("failed to write on-chain package cache at {path}: {source}")]
-    CacheWriteFailed {
+    CacheWrite {
         path: PathBuf,
         #[source]
         source: std::io::Error,
     },
 
     #[error("failed to parse cached manifest at {path}: {source}")]
-    ManifestParseFailed {
+    ManifestParse {
         path: PathBuf,
         #[source]
         source: toml_edit::de::Error,
     },
 
     #[error("failed to serialize manifest for on-chain package {address}: {source}")]
-    ManifestSerializeFailed {
+    ManifestSerialize {
         address: PublishedID,
         #[source]
         source: toml_edit::ser::Error,
     },
 
     #[error(transparent)]
-    LockFailed(#[from] LockError),
+    Lock(#[from] LockError),
 }
 
 pub type OnChainResult<T> = Result<T, OnChainError>;

--- a/external-crates/move/crates/move-package-alt/src/on_chain/errors.rs
+++ b/external-crates/move/crates/move-package-alt/src/on_chain/errors.rs
@@ -1,0 +1,47 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Error types for on-chain package fetching.
+
+use std::path::PathBuf;
+
+use thiserror::Error;
+
+use crate::{package::package_lock::LockError, schema::PublishedID};
+
+/// Errors that can occur while fetching an on-chain package.
+#[derive(Error, Debug)]
+pub enum OnChainError {
+    #[error("failed to fetch on-chain package at {address}: {source}")]
+    FetchFailed {
+        address: PublishedID,
+        #[source]
+        source: anyhow::Error,
+    },
+
+    #[error("failed to write on-chain package cache at {path}: {source}")]
+    CacheWriteFailed {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("failed to parse cached manifest at {path}: {source}")]
+    ManifestParseFailed {
+        path: PathBuf,
+        #[source]
+        source: toml_edit::de::Error,
+    },
+
+    #[error("failed to serialize manifest for on-chain package {address}: {source}")]
+    ManifestSerializeFailed {
+        address: PublishedID,
+        #[source]
+        source: toml_edit::ser::Error,
+    },
+
+    #[error(transparent)]
+    LockFailed(#[from] LockError),
+}
+
+pub type OnChainResult<T> = Result<T, OnChainError>;

--- a/external-crates/move/crates/move-package-alt/src/on_chain/fetch.rs
+++ b/external-crates/move/crates/move-package-alt/src/on_chain/fetch.rs
@@ -155,15 +155,19 @@ fn write_manifest(
     // TODO(DVX-2125): once the digest is decoupled from serialization, use RenderToml.
     let mut doc = toml_edit::ser::to_document(&manifest).expect("can serialize generated manifest");
 
-    // Build dep-replacements manually via toml_edit
+    // Build dep-replacements manually via toml_edit, using inline tables for each dep
+    // (e.g. `onchain_0x02 = { on-chain = "0x02", override = true }`)
     if !data.dependencies.is_empty() {
         let mut env_table = toml_edit::Table::new();
         for (original_id, linked_address) in &data.dependencies {
             let dep_name = format!("onchain_{original_id}");
-            let mut dep_table = toml_edit::Table::new();
-            dep_table.insert("on-chain", toml_edit::value(linked_address.to_string()));
-            dep_table.insert("override", toml_edit::value(true));
-            env_table.insert(&dep_name, toml_edit::Item::Table(dep_table));
+            let mut dep = toml_edit::InlineTable::new();
+            dep.insert("on-chain", linked_address.to_string().into());
+            dep.insert("override", true.into());
+            env_table.insert(
+                &dep_name,
+                toml_edit::Item::Value(toml_edit::Value::InlineTable(dep)),
+            );
         }
         let mut replacements = toml_edit::Table::new();
         replacements.insert(ON_CHAIN_ENV_NAME, toml_edit::Item::Table(env_table));
@@ -299,14 +303,8 @@ mod tests {
         [dep-replacements]
 
         [dep-replacements._on_chain]
-
-        [dep-replacements._on_chain.onchain_0x0000000000000000000000000000000000000000000000000000000000000002]
-        on-chain = "0x0000000000000000000000000000000000000000000000000000000000000002"
-        override = true
-
-        [dep-replacements._on_chain.onchain_0x0000000000000000000000000000000000000000000000000000000000000003]
-        on-chain = "0x0000000000000000000000000000000000000000000000000000000000000033"
-        override = true
+        onchain_0x0000000000000000000000000000000000000000000000000000000000000002 = { on-chain = "0x0000000000000000000000000000000000000000000000000000000000000002", override = true }
+        onchain_0x0000000000000000000000000000000000000000000000000000000000000003 = { on-chain = "0x0000000000000000000000000000000000000000000000000000000000000033", override = true }
         "#);
     }
 

--- a/external-crates/move/crates/move-package-alt/src/on_chain/fetch.rs
+++ b/external-crates/move/crates/move-package-alt/src/on_chain/fetch.rs
@@ -8,7 +8,7 @@
 //! - `bytecode/<module_name>.mv` — serialized `CompiledModule` bytecode (the same format
 //!   the compiler writes to `build/<pkg>/bytecode_modules/`; we use a separate directory
 //!   to avoid clobbering the original bytecode if the package is recompiled)
-//! - `Move.toml` — a generated manifest with `name = "self"` and a single fixed
+//! - `Move.toml` — a generated manifest with `name = "_onchain_package"` and a single fixed
 //!   environment (`_on_chain = "<chain_id>"`)
 //! - `Published.toml` — publication metadata for the `_on_chain` environment
 //!
@@ -24,6 +24,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use anyhow::Context;
 use serde_spanned::Spanned;
 
 use crate::{
@@ -41,7 +42,7 @@ use crate::{
 use super::{OnChainError, OnChainResult};
 
 /// The package name used for all generated on-chain package manifests.
-const ON_CHAIN_PACKAGE_NAME: &str = "self";
+const ON_CHAIN_PACKAGE_NAME: &str = "_onchain_package";
 
 /// The fixed environment name used in generated on-chain package manifests. On-chain
 /// packages are tied to a specific chain, so they use a single environment rather than
@@ -54,7 +55,7 @@ pub(crate) const ON_CHAIN_ENV_NAME: &str = "_on_chain";
 /// The generated `Move.toml` looks like:
 /// ```toml
 /// [package]
-/// name = "self"
+/// name = "_onchain_package"
 /// implicit-dependencies = false
 ///
 /// [environments]
@@ -82,12 +83,12 @@ pub(crate) async fn fetch_onchain<F: MoveFlavor>(
     config: &PackageConfig<F>,
 ) -> OnChainResult<PathBuf> {
     let cache_dir = cache_dir_for(&config.chain_id, address);
-    let manifest_path = cache_dir.join(SourcePackageLayout::Manifest.location_str());
+    let published_path = cache_dir.join("Published.toml");
 
     let _lock = PackageSystemLock::new_for_onchain(&config.chain_id, address)?;
 
-    // Skip if the cache is already populated
-    if manifest_path.exists() {
+    // Published.toml is the last file written, so its existence indicates a complete cache.
+    if published_path.exists() {
         return Ok(cache_dir);
     }
 
@@ -100,10 +101,15 @@ pub(crate) async fn fetch_onchain<F: MoveFlavor>(
             source,
         })?;
 
-    write_bytecode(&cache_dir, &data.modules);
-    write_source(&cache_dir);
-    write_manifest(&cache_dir, &manifest_path, &config.chain_id, &data);
-    write_published::<F>(&cache_dir, address, &config.chain_id, &data);
+    // Write cache files, cleaning up on I/O failure to avoid a partially-populated cache.
+    let result = write_cache::<F>(&cache_dir, &config.chain_id, address, &data);
+    if result.is_err() {
+        let _ = fs::remove_dir_all(&cache_dir);
+    }
+    result.map_err(|source| OnChainError::Fetch {
+        address: address.clone(),
+        source,
+    })?;
 
     Ok(cache_dir)
 }
@@ -117,15 +123,33 @@ fn cache_dir_for(chain_id: &str, address: &PublishedID) -> PathBuf {
         .join(address.to_string())
 }
 
+/// Write all cache files for an on-chain package. Published.toml is written last so that
+/// its presence indicates a complete cache.
+fn write_cache<F: MoveFlavor>(
+    cache_dir: &Path,
+    chain_id: &str,
+    address: &PublishedID,
+    data: &OnChainPackageData,
+) -> anyhow::Result<()> {
+    write_bytecode(cache_dir, &data.modules)?;
+    write_source(cache_dir);
+    write_manifest(cache_dir, chain_id, data)?;
+    write_published::<F>(cache_dir, address, chain_id, data)?;
+    Ok(())
+}
+
 /// Write serialized `CompiledModule` bytecode to `<cache_dir>/bytecode/<name>.mv`.
-fn write_bytecode(cache_dir: &Path, modules: &BTreeMap<String, Vec<u8>>) {
+fn write_bytecode(cache_dir: &Path, modules: &BTreeMap<String, Vec<u8>>) -> anyhow::Result<()> {
     let bytecode_dir = cache_dir.join("bytecode");
-    fs::create_dir_all(&bytecode_dir).expect("can create on-chain package cache directory");
+    fs::create_dir_all(&bytecode_dir)
+        .with_context(|| format!("creating cache directory {}", bytecode_dir.display()))?;
 
     for (name, bytes) in modules {
         let path = bytecode_dir.join(format!("{name}.mv"));
-        fs::write(&path, bytes).expect("can write module bytecode to cache");
+        fs::write(&path, bytes)
+            .with_context(|| format!("writing module bytecode to {}", path.display()))?;
     }
+    Ok(())
 }
 
 /// Generate stub Move source files from bytecode. Currently a no-op; will be implemented
@@ -136,11 +160,13 @@ fn write_source(_cache_dir: &Path) {}
 /// Generate the `Move.toml` for an on-chain package.
 fn write_manifest(
     cache_dir: &Path,
-    manifest_path: &Path,
     chain_id: &str,
     data: &OnChainPackageData,
-) {
-    fs::create_dir_all(cache_dir).expect("can create on-chain package cache directory");
+) -> anyhow::Result<()> {
+    fs::create_dir_all(cache_dir)
+        .with_context(|| format!("creating cache directory {}", cache_dir.display()))?;
+
+    let manifest_path = cache_dir.join(SourcePackageLayout::Manifest.location_str());
 
     let mut manifest = new_manifest();
     manifest.environments.insert(
@@ -176,8 +202,9 @@ fn write_manifest(
             .insert(ON_CHAIN_ENV_NAME.to_string(), env_replacements);
     }
 
-    fs::write(manifest_path, manifest.render_as_toml())
-        .expect("can write generated manifest to cache");
+    fs::write(&manifest_path, manifest.render_as_toml())
+        .with_context(|| format!("writing manifest to {}", manifest_path.display()))?;
+    Ok(())
 }
 
 /// Create a new empty `ParsedManifest` for an on-chain package.
@@ -199,13 +226,14 @@ fn new_manifest() -> ParsedManifest {
     }
 }
 
-/// Generate `Published.toml` for an on-chain package.
+/// Generate `Published.toml` for an on-chain package. This is written last so that its
+/// presence indicates a complete cache.
 fn write_published<F: MoveFlavor>(
     cache_dir: &Path,
     address: &PublishedID,
     chain_id: &str,
     data: &OnChainPackageData,
-) {
+) -> anyhow::Result<()> {
     let pub_path = cache_dir.join("Published.toml");
 
     let mut pubfile = ParsedPublishedFile::<F>::default();
@@ -224,7 +252,9 @@ fn write_published<F: MoveFlavor>(
     );
 
     let rendered = pubfile.render_as_toml();
-    fs::write(&pub_path, rendered).expect("can write Published.toml to cache");
+    fs::write(&pub_path, rendered)
+        .with_context(|| format!("writing Published.toml to {}", pub_path.display()))?;
+    Ok(())
 }
 
 #[cfg(test)]
@@ -264,7 +294,7 @@ mod tests {
         let dir = tempdir().unwrap();
         let data = test_data(vec![]);
 
-        write_bytecode(dir.path(), &data.modules);
+        write_bytecode(dir.path(), &data.modules).unwrap();
 
         let my_mod = dir.path().join("bytecode/my_module.mv");
         let other_mod = dir.path().join("bytecode/other_module.mv");
@@ -276,13 +306,13 @@ mod tests {
     #[test]
     fn manifest_no_deps() {
         let dir = tempdir().unwrap();
-        let manifest_path = dir.path().join("Move.toml");
         let data = test_data(vec![]);
 
-        write_manifest(dir.path(), &manifest_path, "test_chain", &data);
+        write_manifest(dir.path(), "test_chain", &data).unwrap();
 
+        let manifest_path = dir.path().join("Move.toml");
         assert_snapshot!(fs::read_to_string(&manifest_path).unwrap(), @r#"
-        package = { name = "self", implicit-dependencies = false }
+        package = { name = "_onchain_package", implicit-dependencies = false }
         environments = { _on_chain = "test_chain" }
         dependencies = {}
         dep-replacements = {}
@@ -293,13 +323,13 @@ mod tests {
     #[test]
     fn manifest_with_deps() {
         let dir = tempdir().unwrap();
-        let manifest_path = dir.path().join("Move.toml");
         let data = test_data(vec![(0x2, 0x2), (0x3, 0x33)]);
 
-        write_manifest(dir.path(), &manifest_path, "test_chain", &data);
+        write_manifest(dir.path(), "test_chain", &data).unwrap();
 
+        let manifest_path = dir.path().join("Move.toml");
         assert_snapshot!(fs::read_to_string(&manifest_path).unwrap(), @r#"
-        package = { name = "self", implicit-dependencies = false }
+        package = { name = "_onchain_package", implicit-dependencies = false }
         environments = { _on_chain = "test_chain" }
         dependencies = {}
 
@@ -315,11 +345,11 @@ mod tests {
     #[test]
     fn manifest_round_trips() {
         let dir = tempdir().unwrap();
-        let manifest_path = dir.path().join("Move.toml");
         let data = test_data(vec![(0x2, 0x2)]);
 
-        write_manifest(dir.path(), &manifest_path, "test_chain", &data);
+        write_manifest(dir.path(), "test_chain", &data).unwrap();
 
+        let manifest_path = dir.path().join("Move.toml");
         let content = fs::read_to_string(&manifest_path).unwrap();
         let parsed: ParsedManifest = toml_edit::de::from_str(&content).unwrap();
 
@@ -340,7 +370,7 @@ mod tests {
         let address = PublishedID::from(0x1234_u16);
         let data = test_data(vec![]);
 
-        write_published::<Vanilla>(dir.path(), &address, "test_chain", &data);
+        write_published::<Vanilla>(dir.path(), &address, "test_chain", &data).unwrap();
 
         assert_snapshot!(fs::read_to_string(dir.path().join("Published.toml")).unwrap(), @r#"
         # Generated by Move

--- a/external-crates/move/crates/move-package-alt/src/on_chain/fetch.rs
+++ b/external-crates/move/crates/move-package-alt/src/on_chain/fetch.rs
@@ -158,7 +158,7 @@ fn write_manifest(
                     PackageName::new(format!("onchain_{original_id}")).expect("valid identifier");
                 let replacement = ReplacementDependency {
                     dependency: Some(DefaultDependency {
-                        dependency_info: ManifestDependencyInfo::OnChainAt(OnChainAddress {
+                        dependency_info: ManifestDependencyInfo::OnChain(OnChainAddress {
                             on_chain: linked_address.clone(),
                         }),
                         is_override: true,

--- a/external-crates/move/crates/move-package-alt/src/on_chain/fetch.rs
+++ b/external-crates/move/crates/move-package-alt/src/on_chain/fetch.rs
@@ -8,9 +8,15 @@
 //! - `bytecode/<module_name>.mv` — serialized `CompiledModule` bytecode (the same format
 //!   the compiler writes to `build/<pkg>/bytecode_modules/`; we use a separate directory
 //!   to avoid clobbering the original bytecode if the package is recompiled)
-//! - `Move.toml` — a generated manifest with `name = "self"`, with environments and
-//!   dep-replacements added incrementally as the package is used in different environments
-//! - `Published.toml` — publication metadata, also updated incrementally per environment
+//! - `Move.toml` — a generated manifest with `name = "self"` and a single fixed
+//!   environment (`_on_chain = "<chain_id>"`)
+//! - `Published.toml` — publication metadata for the `_on_chain` environment
+//!
+//! We use a fixed environment name ([`ON_CHAIN_ENV_NAME`]) because environment names are
+//! per-package: different packages in the graph may use different names for the same
+//! network. On-chain packages don't need environment flexibility since they're tied to a
+//! specific chain. The parent package's `use_environment` is set to this fixed name during
+//! combining (see [`crate::dependency::combine`]).
 
 use std::{
     collections::BTreeMap,
@@ -26,9 +32,9 @@ use crate::{
         layout::SourcePackageLayout, package_loader::PackageConfig, package_lock::PackageSystemLock,
     },
     schema::{
-        DefaultDependency, Environment, ManifestDependencyInfo, OnChainAddress, PackageName,
-        ParsedManifest, ParsedPublishedFile, Publication, PublishAddresses, PublishedID,
-        RenderToml, ReplacementDependency,
+        DefaultDependency, ManifestDependencyInfo, OnChainAddress, PackageName, ParsedManifest,
+        ParsedPublishedFile, Publication, PublishAddresses, PublishedID, RenderToml,
+        ReplacementDependency,
     },
 };
 
@@ -37,27 +43,27 @@ use super::{OnChainError, OnChainResult};
 /// The package name used for all generated on-chain package manifests.
 const ON_CHAIN_PACKAGE_NAME: &str = "self";
 
+/// The fixed environment name used in generated on-chain package manifests. On-chain
+/// packages are tied to a specific chain, so they use a single environment rather than
+/// mirroring the caller's environment name.
+pub(crate) const ON_CHAIN_ENV_NAME: &str = "_on_chain";
+
 /// Fetch an on-chain package, writing bytecode and generating manifest/publication files
-/// in the cache directory. If the bytecode is already cached, skips the network fetch but
-/// still ensures the manifest and Published.toml include the current environment.
+/// in the cache directory. If the cache already exists, returns immediately.
 ///
 /// The generated `Move.toml` looks like:
 /// ```toml
 /// [package]
 /// name = "self"
+/// implicit-dependencies = false
 ///
 /// [environments]
-/// my_env = "some_chain_id"
+/// _on_chain = "<chain_id>"
 ///
-/// [dep-replacements.my_env.onchain_0x0000...0002]
+/// [dep-replacements._on_chain.onchain_0x0000...0002]
 /// on-chain = "0x0000...0002"
 /// override = true
 /// ```
-///
-/// Environments and dep-replacements are added incrementally: fetching the same package
-/// for a second environment adds a new entry without disturbing existing ones. This does
-/// not trigger repinning for other environments because the manifest digest is computed
-/// per-environment from the `CombinedDependency` list.
 ///
 /// # Known limitation: system packages
 ///
@@ -73,33 +79,30 @@ const ON_CHAIN_PACKAGE_NAME: &str = "self";
 // TODO: filter system packages from the linkage table or deduplicate in the graph builder.
 pub(crate) async fn fetch_onchain<F: MoveFlavor>(
     address: &PublishedID,
-    env: &Environment,
     config: &PackageConfig<F>,
 ) -> OnChainResult<PathBuf> {
     let cache_dir = cache_dir_for(&config.chain_id, address);
-    let bytecode_dir = cache_dir.join("bytecode");
+    let manifest_path = cache_dir.join(SourcePackageLayout::Manifest.location_str());
 
     let _lock = PackageSystemLock::new_for_onchain(&config.chain_id, address)?;
 
-    // Skip network fetch if bytecode is already cached
-    let data = if bytecode_dir.exists() && fs::read_dir(&bytecode_dir).is_ok_and(|d| d.count() > 0)
-    {
-        None
-    } else {
-        let data = config
-            .flavor
-            .fetch_onchain_package(address)
-            .await
-            .map_err(|source| OnChainError::Fetch {
-                address: address.clone(),
-                source,
-            })?;
-        write_bytecode(&cache_dir, &data.modules);
-        Some(data)
-    };
+    // Skip if the cache is already populated
+    if manifest_path.exists() {
+        return Ok(cache_dir);
+    }
 
-    update_manifest(&cache_dir, env, &data);
-    update_published::<F>(&cache_dir, address, env, &data);
+    let data = config
+        .flavor
+        .fetch_onchain_package(address)
+        .await
+        .map_err(|source| OnChainError::Fetch {
+            address: address.clone(),
+            source,
+        })?;
+
+    write_bytecode(&cache_dir, &data.modules);
+    write_manifest(&cache_dir, &manifest_path, &config.chain_id, &data);
+    write_published::<F>(&cache_dir, address, &config.chain_id, &data);
 
     Ok(cache_dir)
 }
@@ -123,50 +126,31 @@ fn write_bytecode(cache_dir: &Path, modules: &BTreeMap<String, Vec<u8>>) {
     }
 }
 
-/// Generate or update the `Move.toml` in the cache directory. Adds the current
-/// environment and dep-replacements for on-chain dependencies from the linkage table.
-/// If the manifest already exists and contains this environment, it is not modified.
-fn update_manifest(cache_dir: &Path, env: &Environment, data: &Option<OnChainPackageData>) {
-    let manifest_path = cache_dir.join(SourcePackageLayout::Manifest.location_str());
+/// Generate the `Move.toml` for an on-chain package.
+fn write_manifest(
+    cache_dir: &Path,
+    manifest_path: &Path,
+    chain_id: &str,
+    data: &OnChainPackageData,
+) {
+    fs::create_dir_all(cache_dir).expect("can create on-chain package cache directory");
 
-    let mut manifest = load_or_create_manifest(cache_dir, &manifest_path);
+    let mut manifest = new_manifest();
 
-    // Skip if this environment is already present
-    if manifest
-        .environments
-        .keys()
-        .any(|k| k.as_ref() == env.name())
-    {
-        return;
-    }
-
-    // Add environment
     manifest.environments.insert(
-        Spanned::new(0..1, env.name().to_string()),
-        Spanned::new(0..1, env.id().to_string()),
+        Spanned::new(0..1, ON_CHAIN_ENV_NAME.to_string()),
+        Spanned::new(0..1, chain_id.to_string()),
     );
 
-    // Add dep-replacements from linkage table
-    if let Some(data) = data {
-        let env_replacements = dep_replacements_for(&data.dependencies);
+    let env_replacements = dep_replacements_for(&data.dependencies);
+    if !env_replacements.is_empty() {
         manifest
             .dep_replacements
-            .insert(env.name().to_string(), env_replacements);
+            .insert(ON_CHAIN_ENV_NAME.to_string(), env_replacements);
     }
 
     let doc = toml_edit::ser::to_document(&manifest).expect("can serialize generated manifest");
-    fs::write(&manifest_path, doc.to_string()).expect("can write generated manifest to cache");
-}
-
-/// Load an existing `ParsedManifest` from disk, or create a new one for an on-chain package.
-fn load_or_create_manifest(cache_dir: &Path, manifest_path: &Path) -> ParsedManifest {
-    if manifest_path.exists() {
-        let content = fs::read_to_string(manifest_path).expect("can read cached manifest");
-        toml_edit::de::from_str(&content).expect("can parse cached manifest")
-    } else {
-        fs::create_dir_all(cache_dir).expect("can create on-chain package cache directory");
-        new_manifest()
-    }
+    fs::write(manifest_path, doc.to_string()).expect("can write generated manifest to cache");
 }
 
 /// Build dep-replacement entries from a linkage table.
@@ -221,37 +205,21 @@ fn new_manifest() -> ParsedManifest {
     }
 }
 
-/// Generate or update `Published.toml` in the cache directory. Adds a publication entry
-/// for the current environment if not already present.
-fn update_published<F: MoveFlavor>(
+/// Generate `Published.toml` for an on-chain package.
+fn write_published<F: MoveFlavor>(
     cache_dir: &Path,
     address: &PublishedID,
-    env: &Environment,
-    data: &Option<OnChainPackageData>,
+    chain_id: &str,
+    data: &OnChainPackageData,
 ) {
     let pub_path = cache_dir.join("Published.toml");
 
-    let mut pubfile: ParsedPublishedFile<F> = if pub_path.exists() {
-        let content = fs::read_to_string(&pub_path).expect("can read cached Published.toml");
-        toml_edit::de::from_str(&content).expect("can parse cached Published.toml")
-    } else {
-        ParsedPublishedFile::default()
-    };
-
-    // Skip if this environment is already present
-    if pubfile.published.contains_key(env.name()) {
-        return;
-    }
-
-    // We need the on-chain data to create a publication entry
-    let Some(data) = data else {
-        return;
-    };
+    let mut pubfile = ParsedPublishedFile::<F>::default();
 
     pubfile.published.insert(
-        env.name().to_string(),
+        ON_CHAIN_ENV_NAME.to_string(),
         Publication {
-            chain_id: env.id().to_string(),
+            chain_id: chain_id.to_string(),
             addresses: PublishAddresses {
                 published_at: address.clone(),
                 original_id: data.original_id.clone(),

--- a/external-crates/move/crates/move-package-alt/src/on_chain/fetch.rs
+++ b/external-crates/move/crates/move-package-alt/src/on_chain/fetch.rs
@@ -2,6 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Fetches on-chain packages and generates synthetic manifests and publication files.
+//!
+//! On-chain packages are cached at `~/.move/on-chain/<chain_id>/<address>/`. The cache
+//! contains:
+//! - `bytecode/<module_name>.mv` — serialized `CompiledModule` bytecode (the same format
+//!   the compiler writes to `build/<pkg>/bytecode_modules/`; we use a separate directory
+//!   to avoid clobbering the original bytecode if the package is recompiled)
+//! - `Move.toml` — a generated manifest with `name = "self"`, with environments and
+//!   dep-replacements added incrementally as the package is used from different contexts
+//! - `Published.toml` — publication metadata, also updated incrementally per environment
 
 use std::{
     collections::BTreeMap,
@@ -9,35 +18,74 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use anyhow::{Context, anyhow};
-use toml_edit::{DocumentMut, Item, Table, value};
+use serde_spanned::Spanned;
 
 use crate::{
     flavor::{MoveFlavor, OnChainPackageData},
-    package::{package_loader::PackageConfig, package_lock::PackageSystemLock},
+    package::{
+        layout::SourcePackageLayout, package_loader::PackageConfig, package_lock::PackageSystemLock,
+    },
     schema::{
-        Environment, OriginalID, ParsedPublishedFile, Publication, PublishAddresses, PublishedID,
-        RenderToml,
+        DefaultDependency, Environment, ManifestDependencyInfo, OnChainAddress, PackageName,
+        ParsedManifest, ParsedPublishedFile, Publication, PublishAddresses, PublishedID,
+        RenderToml, ReplacementDependency,
     },
 };
 
-/// Fetch an on-chain package and generate its manifest and publication files. Returns the path
-/// to the generated package directory in the cache.
+use super::{OnChainError, OnChainResult};
+
+/// The package name used for all generated on-chain package manifests.
+const ON_CHAIN_PACKAGE_NAME: &str = "self";
+
+/// Fetch an on-chain package, writing bytecode and generating manifest/publication files
+/// in the cache directory. If the bytecode is already cached, skips the network fetch but
+/// still ensures the manifest and Published.toml include the current environment.
+///
+/// The generated `Move.toml` looks like:
+/// ```toml
+/// [package]
+/// name = "self"
+///
+/// [environments]
+/// mainnet = "35834a8a"
+///
+/// [dep-replacements.mainnet.onchain_0x0000...0002]
+/// on-chain = "0x0000...0002"
+/// ```
+///
+/// Environments and dep-replacements are added incrementally: fetching the same package
+/// for a second environment adds a new entry without disturbing existing ones. This does
+/// not trigger repinning for other environments because the manifest digest is computed
+/// per-environment from the `CombinedDependency` list.
 pub(crate) async fn fetch_onchain<F: MoveFlavor>(
     address: &PublishedID,
     env: &Environment,
     config: &PackageConfig<F>,
-) -> anyhow::Result<PathBuf> {
+) -> OnChainResult<PathBuf> {
     let cache_dir = cache_dir_for(&config.chain_id, address);
+    let bytecode_dir = cache_dir.join("bytecode");
 
-    let _lock = PackageSystemLock::new_for_onchain(&config.chain_id, address)
-        .map_err(|e| anyhow!("failed to acquire lock for on-chain package {address}: {e}"))?;
+    let _lock = PackageSystemLock::new_for_onchain(&config.chain_id, address)?;
 
-    let data = config.flavor.fetch_onchain_package(address).await?;
+    // Skip network fetch if bytecode is already cached
+    let data = if bytecode_dir.exists() && fs::read_dir(&bytecode_dir).is_ok_and(|d| d.count() > 0)
+    {
+        None
+    } else {
+        let data = config
+            .flavor
+            .fetch_onchain_package(address)
+            .await
+            .map_err(|source| OnChainError::FetchFailed {
+                address: address.clone(),
+                source,
+            })?;
+        write_bytecode(&cache_dir, &data.modules)?;
+        Some(data)
+    };
 
-    write_bytecode(&cache_dir, &data.modules)?;
-    update_manifest(&cache_dir, env, &data.dependencies)?;
-    update_published::<F>(&cache_dir, address, env, &data)?;
+    update_manifest(&cache_dir, address, env, data.as_ref())?;
+    update_published::<F>(&cache_dir, address, env, data.as_ref())?;
 
     Ok(cache_dir)
 }
@@ -50,91 +98,164 @@ fn cache_dir_for(chain_id: &str, address: &PublishedID) -> PathBuf {
         .join(address.to_string())
 }
 
-/// Write module bytecode files to `<cache_dir>/bytecode/<name>.mv`.
-fn write_bytecode(cache_dir: &Path, modules: &BTreeMap<String, Vec<u8>>) -> anyhow::Result<()> {
+/// Write serialized `CompiledModule` bytecode to `<cache_dir>/bytecode/<name>.mv`.
+fn write_bytecode(cache_dir: &Path, modules: &BTreeMap<String, Vec<u8>>) -> OnChainResult<()> {
     let bytecode_dir = cache_dir.join("bytecode");
-    fs::create_dir_all(&bytecode_dir)
-        .with_context(|| format!("creating bytecode dir: {}", bytecode_dir.display()))?;
+    fs::create_dir_all(&bytecode_dir).map_err(|source| OnChainError::CacheWriteFailed {
+        path: bytecode_dir.clone(),
+        source,
+    })?;
 
     for (name, bytes) in modules {
         let path = bytecode_dir.join(format!("{name}.mv"));
-        fs::write(&path, bytes)
-            .with_context(|| format!("writing module bytecode: {}", path.display()))?;
+        fs::write(&path, bytes).map_err(|source| OnChainError::CacheWriteFailed {
+            path: path.clone(),
+            source,
+        })?;
     }
 
     Ok(())
 }
 
-/// Generate or update `Move.toml` in the cache directory. Adds the environment and
-/// dep-replacements for on-chain dependencies from the linkage table.
+/// Generate or update the `Move.toml` in the cache directory. Adds the current
+/// environment and dep-replacements for on-chain dependencies from the linkage table.
+/// If the manifest already exists and contains this environment, it is not modified.
 fn update_manifest(
     cache_dir: &Path,
+    address: &PublishedID,
     env: &Environment,
-    dependencies: &BTreeMap<OriginalID, PublishedID>,
-) -> anyhow::Result<()> {
-    let manifest_path = cache_dir.join("Move.toml");
+    data: Option<&OnChainPackageData>,
+) -> OnChainResult<()> {
+    let manifest_path = cache_dir.join(SourcePackageLayout::Manifest.location_str());
 
-    let mut doc = if manifest_path.exists() {
-        let content = fs::read_to_string(&manifest_path)
-            .with_context(|| format!("reading {}", manifest_path.display()))?;
-        content
-            .parse::<DocumentMut>()
-            .with_context(|| format!("parsing {}", manifest_path.display()))?
+    let mut manifest: ParsedManifest = if manifest_path.exists() {
+        let content = fs::read_to_string(&manifest_path).map_err(|source| {
+            OnChainError::CacheWriteFailed {
+                path: manifest_path.clone(),
+                source,
+            }
+        })?;
+        toml_edit::de::from_str(&content).map_err(|source| OnChainError::ManifestParseFailed {
+            path: manifest_path.clone(),
+            source,
+        })?
     } else {
-        fs::create_dir_all(cache_dir)
-            .with_context(|| format!("creating cache dir: {}", cache_dir.display()))?;
-        let mut doc = DocumentMut::new();
-        let mut package = Table::new();
-        package.insert("name", value("self"));
-        doc.insert("package", Item::Table(package));
-        doc
+        fs::create_dir_all(cache_dir).map_err(|source| OnChainError::CacheWriteFailed {
+            path: cache_dir.to_path_buf(),
+            source,
+        })?;
+        new_manifest()
     };
 
-    // Add environment entry
-    if !doc.contains_key("environments") {
-        doc.insert("environments", Item::Table(Table::new()));
-    }
-    doc["environments"][env.name()] = value(env.id());
+    // Check if this environment is already present
+    let env_already_present = manifest
+        .environments
+        .keys()
+        .any(|k| k.as_ref() == env.name());
 
-    // Add dep-replacements for this environment
-    if !dependencies.is_empty() {
-        if !doc.contains_key("dep-replacements") {
-            doc.insert("dep-replacements", Item::Table(Table::new()));
-        }
-        let replacements = &mut doc["dep-replacements"];
-
-        let mut env_table = Table::new();
-        for (original_id, linked_address) in dependencies {
-            let dep_name = format!("onchain_{original_id}");
-            let mut dep_table = Table::new();
-            dep_table.insert("on-chain", value(linked_address.to_string()));
-            env_table.insert(&dep_name, Item::Table(dep_table));
-        }
-        replacements[env.name()] = Item::Table(env_table);
+    if env_already_present {
+        return Ok(());
     }
 
-    fs::write(&manifest_path, doc.to_string())
-        .with_context(|| format!("writing {}", manifest_path.display()))?;
+    // Add environment
+    manifest.environments.insert(
+        Spanned::new(0..1, env.name().to_string()),
+        Spanned::new(0..1, env.id().to_string()),
+    );
+
+    // Add dep-replacements from linkage table
+    if let Some(data) = data {
+        let mut env_replacements = BTreeMap::new();
+        for (original_id, linked_address) in &data.dependencies {
+            let dep_name =
+                PackageName::new(format!("onchain_{original_id}")).expect("valid identifier");
+            let replacement = ReplacementDependency {
+                dependency: Some(DefaultDependency {
+                    dependency_info: ManifestDependencyInfo::OnChainAt(OnChainAddress {
+                        on_chain: linked_address.clone(),
+                    }),
+                    is_override: false,
+                    rename_from: None,
+                    modes: None,
+                }),
+                addresses: None,
+                use_environment: None,
+            };
+            env_replacements.insert(dep_name, Spanned::new(0..1, replacement));
+        }
+        manifest
+            .dep_replacements
+            .insert(env.name().to_string(), env_replacements);
+    }
+
+    // Serialize and write
+    let doc = toml_edit::ser::to_document(&manifest).map_err(|source| {
+        OnChainError::ManifestSerializeFailed {
+            address: address.clone(),
+            source,
+        }
+    })?;
+    fs::write(&manifest_path, doc.to_string()).map_err(|source| {
+        OnChainError::CacheWriteFailed {
+            path: manifest_path,
+            source,
+        }
+    })?;
 
     Ok(())
 }
 
-/// Generate or update `Published.toml` in the cache directory.
+/// Create a new empty `ParsedManifest` for an on-chain package.
+fn new_manifest() -> ParsedManifest {
+    ParsedManifest {
+        package: crate::schema::PackageMetadata {
+            name: Spanned::new(
+                0..1,
+                PackageName::new(ON_CHAIN_PACKAGE_NAME).expect("valid identifier"),
+            ),
+            edition: None,
+            implicit_dependencies: false,
+            unrecognized_fields: BTreeMap::new(),
+        },
+        environments: BTreeMap::new(),
+        dependencies: BTreeMap::new(),
+        dep_replacements: BTreeMap::new(),
+        legacy_data: None,
+    }
+}
+
+/// Generate or update `Published.toml` in the cache directory. Adds a publication entry
+/// for the current environment if not already present.
 fn update_published<F: MoveFlavor>(
     cache_dir: &Path,
     address: &PublishedID,
     env: &Environment,
-    data: &OnChainPackageData,
-) -> anyhow::Result<()> {
+    data: Option<&OnChainPackageData>,
+) -> OnChainResult<()> {
     let pub_path = cache_dir.join("Published.toml");
 
     let mut pubfile: ParsedPublishedFile<F> = if pub_path.exists() {
-        let content = fs::read_to_string(&pub_path)
-            .with_context(|| format!("reading {}", pub_path.display()))?;
-        toml_edit::de::from_str(&content)
-            .with_context(|| format!("parsing {}", pub_path.display()))?
+        let content =
+            fs::read_to_string(&pub_path).map_err(|source| OnChainError::CacheWriteFailed {
+                path: pub_path.clone(),
+                source,
+            })?;
+        toml_edit::de::from_str(&content).map_err(|source| OnChainError::ManifestParseFailed {
+            path: pub_path.clone(),
+            source,
+        })?
     } else {
         ParsedPublishedFile::default()
+    };
+
+    // Skip if this environment is already present
+    if pubfile.published.contains_key(env.name()) {
+        return Ok(());
+    }
+
+    // We need the on-chain data to create a publication entry
+    let Some(data) = data else {
+        return Ok(());
     };
 
     pubfile.published.insert(
@@ -151,7 +272,10 @@ fn update_published<F: MoveFlavor>(
     );
 
     let rendered = pubfile.render_as_toml();
-    fs::write(&pub_path, rendered).with_context(|| format!("writing {}", pub_path.display()))?;
+    fs::write(&pub_path, rendered).map_err(|source| OnChainError::CacheWriteFailed {
+        path: pub_path,
+        source,
+    })?;
 
     Ok(())
 }

--- a/external-crates/move/crates/move-package-alt/src/on_chain/fetch.rs
+++ b/external-crates/move/crates/move-package-alt/src/on_chain/fetch.rs
@@ -223,8 +223,9 @@ mod tests {
 
     use super::*;
     use crate::{
-        flavor::Vanilla,
+        flavor::{Vanilla, vanilla::DEFAULT_ENV_NAME},
         schema::{OriginalID, PublishedID},
+        test_utils::graph_builder::TestPackageGraph,
     };
 
     /// Helper to create test on-chain package data.
@@ -349,9 +350,6 @@ mod tests {
     /// Rename-from check is skipped for on-chain deps.
     #[test(tokio::test)]
     async fn rename_from_skipped_for_on_chain() {
-        use crate::flavor::vanilla::DEFAULT_ENV_NAME;
-        use crate::test_utils::graph_builder::TestPackageGraph;
-
         // "my_dep" won't match the generated package name "self", but the
         // rename-from check should be skipped for on-chain deps.
         let scenario = TestPackageGraph::new(["root"])
@@ -359,7 +357,7 @@ mod tests {
             .add_on_chain_dep(
                 "root",
                 "my_dep",
-                "0x0000000000000000000000000000000000000000000000000000000000000001",
+                &PublishedID::from(1_u16).to_string(),
                 |d| d.in_env(DEFAULT_ENV_NAME),
             )
             .build();
@@ -375,24 +373,20 @@ mod tests {
     /// Both should be fetched and loaded.
     #[test(tokio::test)]
     async fn transitive_on_chain_dep() {
-        use crate::flavor::vanilla::DEFAULT_ENV_NAME;
-        use crate::test_utils::graph_builder::TestPackageGraph;
-
-        let addr_a = PublishedID::from(0xA_u16);
-        let addr_b = PublishedID::from(0xB_u16);
-
         let scenario = TestPackageGraph::new(["root"])
             .add_on_chain_dep("root", "dep_a", "true", |d| d)
-            .add_on_chain_dep("root", "dep_a", &addr_a.to_string(), |d| {
-                d.in_env(DEFAULT_ENV_NAME)
+            .add_on_chain_dep(
+                "root",
+                "dep_a",
+                &PublishedID::from(0xA_u16).to_string(),
+                |d| d.in_env(DEFAULT_ENV_NAME),
+            )
+            .add_on_chain_pkg(PublishedID::from(0xA_u16), |pkg| {
+                pkg.dep(OriginalID::from(0xB_u16), PublishedID::from(0xB_u16))
             })
-            .add_on_chain_pkg(addr_a, |pkg| {
-                pkg.dep(OriginalID::from(0xB_u16), addr_b.clone())
-            })
-            .add_on_chain_pkg(addr_b, |pkg| pkg)
+            .add_on_chain_pkg(PublishedID::from(0xB_u16), |pkg| pkg)
             .build();
 
-        // Should succeed — both packages fetched and loaded
         let root = scenario.root_package("root").await;
         assert!(root.packages().len() >= 3, "expected root + A + B");
     }
@@ -402,29 +396,27 @@ mod tests {
     #[test(tokio::test)]
     #[ignore] // TODO: requires deduplication of on-chain and source deps
     async fn on_chain_overlaps_with_local_dep() {
-        use crate::flavor::vanilla::DEFAULT_ENV_NAME;
-        use crate::test_utils::graph_builder::TestPackageGraph;
-
-        let addr_a = PublishedID::from(0xA_u16);
-        let addr_shared = PublishedID::from(0xCC_u16);
-
-        // local_dep is published at 0xCC — same address as A's linkage entry
         let scenario = TestPackageGraph::new(["root"])
-            .add_published("local_dep", OriginalID::from(0xCC_u16), addr_shared.clone())
+            .add_published(
+                "local_dep",
+                OriginalID::from(0xCC_u16),
+                PublishedID::from(0xCC_u16),
+            )
             .add_deps([("root", "local_dep")])
             .add_on_chain_dep("root", "dep_a", "true", |d| d)
-            .add_on_chain_dep("root", "dep_a", &addr_a.to_string(), |d| {
-                d.in_env(DEFAULT_ENV_NAME)
+            .add_on_chain_dep(
+                "root",
+                "dep_a",
+                &PublishedID::from(0xA_u16).to_string(),
+                |d| d.in_env(DEFAULT_ENV_NAME),
+            )
+            .add_on_chain_pkg(PublishedID::from(0xA_u16), |pkg| {
+                pkg.dep(OriginalID::from(0xCC_u16), PublishedID::from(0xCC_u16))
             })
-            .add_on_chain_pkg(addr_a, |pkg| {
-                pkg.dep(OriginalID::from(0xCC_u16), addr_shared.clone())
-            })
-            .add_on_chain_pkg(addr_shared, |pkg| pkg)
+            .add_on_chain_pkg(PublishedID::from(0xCC_u16), |pkg| pkg)
             .build();
 
         let root = scenario.root_package("root").await;
-        // After deduplication: root + local_dep + on-chain A = 3 packages
-        // (local_dep and on-chain 0xCC should be the same node)
         assert_eq!(
             root.packages().len(),
             3,

--- a/external-crates/move/crates/move-package-alt/src/on_chain/fetch.rs
+++ b/external-crates/move/crates/move-package-alt/src/on_chain/fetch.rs
@@ -80,7 +80,7 @@ pub(crate) async fn fetch_onchain<F: MoveFlavor>(
     address: &PublishedID,
     config: &PackageConfig<F>,
 ) -> OnChainResult<PathBuf> {
-    let cache_dir = cache_dir_for(&config.move_home, &config.chain_id, address);
+    let cache_dir = cache_dir_for(&config.chain_id, address);
     let manifest_path = cache_dir.join(SourcePackageLayout::Manifest.location_str());
 
     let _lock = PackageSystemLock::new_for_onchain(&config.chain_id, address)?;
@@ -108,8 +108,9 @@ pub(crate) async fn fetch_onchain<F: MoveFlavor>(
 }
 
 /// Return the cache directory for an on-chain package.
-fn cache_dir_for(move_home: &Path, chain_id: &str, address: &PublishedID) -> PathBuf {
-    move_home
+// TODO(DVX-2127): use config.move_home instead of hardcoded MOVE_HOME
+fn cache_dir_for(chain_id: &str, address: &PublishedID) -> PathBuf {
+    PathBuf::from(move_command_line_common::env::MOVE_HOME.as_str())
         .join("on-chain")
         .join(chain_id)
         .join(address.to_string())
@@ -353,6 +354,10 @@ mod tests {
         "#);
     }
 
+    // NOTE: each test must use unique on-chain addresses to avoid cache collisions
+    // when tests run in parallel, since the cache is shared at ~/.move/on-chain/.
+    // TODO(DVX-2127): thread move_home through the cache to enable per-test isolation.
+
     /// Rename-from check is skipped for on-chain deps.
     #[test(tokio::test)]
     async fn rename_from_skipped_for_on_chain() {
@@ -363,7 +368,7 @@ mod tests {
             .add_on_chain_dep(
                 "root",
                 "my_dep",
-                &PublishedID::from(1_u16).to_string(),
+                &PublishedID::from(0x1001_u16).to_string(),
                 |d| d.in_env(DEFAULT_ENV_NAME),
             )
             .build();
@@ -384,13 +389,13 @@ mod tests {
             .add_on_chain_dep(
                 "root",
                 "dep_a",
-                &PublishedID::from(0xA_u16).to_string(),
+                &PublishedID::from(0x2001_u16).to_string(),
                 |d| d.in_env(DEFAULT_ENV_NAME),
             )
-            .add_on_chain_pkg(PublishedID::from(0xA_u16), |pkg| {
-                pkg.dep(OriginalID::from(0xB_u16), PublishedID::from(0xB_u16))
+            .add_on_chain_pkg(PublishedID::from(0x2001_u16), |pkg| {
+                pkg.dep(OriginalID::from(0x2002_u16), PublishedID::from(0x2002_u16))
             })
-            .add_on_chain_pkg(PublishedID::from(0xB_u16), |pkg| pkg)
+            .add_on_chain_pkg(PublishedID::from(0x2002_u16), |pkg| pkg)
             .build();
 
         let root = scenario.root_package("root").await;
@@ -405,26 +410,26 @@ mod tests {
         let scenario = TestPackageGraph::new(["root"])
             .add_published(
                 "local_dep",
-                OriginalID::from(0xCC_u16),
-                PublishedID::from(0xCC_u16),
+                OriginalID::from(0x3002_u16),
+                PublishedID::from(0x3002_u16),
             )
             .add_deps([("root", "local_dep")])
             .add_on_chain_dep("root", "dep_a", "true", |d| d)
             .add_on_chain_dep(
                 "root",
                 "dep_a",
-                &PublishedID::from(0xA_u16).to_string(),
+                &PublishedID::from(0x3001_u16).to_string(),
                 |d| d.in_env(DEFAULT_ENV_NAME),
             )
-            .add_on_chain_pkg(PublishedID::from(0xA_u16), |pkg| {
-                pkg.dep(OriginalID::from(0xCC_u16), PublishedID::from(0xCC_u16))
+            .add_on_chain_pkg(PublishedID::from(0x3001_u16), |pkg| {
+                pkg.dep(OriginalID::from(0x3002_u16), PublishedID::from(0x3002_u16))
             })
-            .add_on_chain_pkg(PublishedID::from(0xCC_u16), |pkg| pkg)
+            .add_on_chain_pkg(PublishedID::from(0x3002_u16), |pkg| pkg)
             .build();
 
         let root = scenario.root_package("root").await;
         // After deduplication: root + local_dep + on-chain A = 3 packages
-        // (local_dep and on-chain 0xCC should be the same node)
+        // (local_dep and on-chain 0x3002 should be the same node)
         assert_eq!(
             root.packages().len(),
             3,

--- a/external-crates/move/crates/move-package-alt/src/on_chain/fetch.rs
+++ b/external-crates/move/crates/move-package-alt/src/on_chain/fetch.rs
@@ -32,9 +32,8 @@ use crate::{
         layout::SourcePackageLayout, package_loader::PackageConfig, package_lock::PackageSystemLock,
     },
     schema::{
-        DefaultDependency, ManifestDependencyInfo, OnChainAddress, PackageName, ParsedManifest,
-        ParsedPublishedFile, Publication, PublishAddresses, PublishedID, RenderToml,
-        ReplacementDependency,
+        PackageName, ParsedManifest, ParsedPublishedFile, Publication, PublishAddresses,
+        PublishedID, RenderToml,
     },
 };
 
@@ -81,7 +80,7 @@ pub(crate) async fn fetch_onchain<F: MoveFlavor>(
     address: &PublishedID,
     config: &PackageConfig<F>,
 ) -> OnChainResult<PathBuf> {
-    let cache_dir = cache_dir_for(&config.chain_id, address);
+    let cache_dir = cache_dir_for(&config.move_home, &config.chain_id, address);
     let manifest_path = cache_dir.join(SourcePackageLayout::Manifest.location_str());
 
     let _lock = PackageSystemLock::new_for_onchain(&config.chain_id, address)?;
@@ -108,8 +107,8 @@ pub(crate) async fn fetch_onchain<F: MoveFlavor>(
 }
 
 /// Return the cache directory for an on-chain package.
-fn cache_dir_for(chain_id: &str, address: &PublishedID) -> PathBuf {
-    PathBuf::from(move_command_line_common::env::MOVE_HOME.as_str())
+fn cache_dir_for(move_home: &Path, chain_id: &str, address: &PublishedID) -> PathBuf {
+    move_home
         .join("on-chain")
         .join(chain_id)
         .join(address.to_string())
@@ -136,54 +135,35 @@ fn write_manifest(
     fs::create_dir_all(cache_dir).expect("can create on-chain package cache directory");
 
     let mut manifest = new_manifest();
-
     manifest.environments.insert(
         Spanned::new(0..1, ON_CHAIN_ENV_NAME.to_string()),
         Spanned::new(0..1, chain_id.to_string()),
     );
 
-    let env_replacements = dep_replacements_for(&data.dependencies);
-    if !env_replacements.is_empty() {
-        manifest
-            .dep_replacements
-            .insert(ON_CHAIN_ENV_NAME.to_string(), env_replacements);
+    // Serialize everything except dep-replacements. ManifestDependencyInfo's derived
+    // Serialize doesn't match its custom Deserialize (the serializer produces tagged enum
+    // output like `OnChainAt = { ... }` but the deserializer expects flat keys like
+    // `on-chain = "0x..."`). We can't fix Serialize because the digest computation depends
+    // on the current (incorrect) format. See DVX-2125 for the proper fix.
+    // TODO(DVX-2125): once the digest is decoupled from serialization, use RenderToml.
+    let mut doc = toml_edit::ser::to_document(&manifest).expect("can serialize generated manifest");
+
+    // Build dep-replacements manually via toml_edit
+    if !data.dependencies.is_empty() {
+        let mut env_table = toml_edit::Table::new();
+        for (original_id, linked_address) in &data.dependencies {
+            let dep_name = format!("onchain_{original_id}");
+            let mut dep_table = toml_edit::Table::new();
+            dep_table.insert("on-chain", toml_edit::value(linked_address.to_string()));
+            dep_table.insert("override", toml_edit::value(true));
+            env_table.insert(&dep_name, toml_edit::Item::Table(dep_table));
+        }
+        let mut replacements = toml_edit::Table::new();
+        replacements.insert(ON_CHAIN_ENV_NAME, toml_edit::Item::Table(env_table));
+        doc.insert("dep-replacements", toml_edit::Item::Table(replacements));
     }
 
-    let doc = toml_edit::ser::to_document(&manifest).expect("can serialize generated manifest");
     fs::write(manifest_path, doc.to_string()).expect("can write generated manifest to cache");
-}
-
-/// Build dep-replacement entries from a linkage table.
-fn dep_replacements_for(
-    dependencies: &BTreeMap<crate::schema::OriginalID, PublishedID>,
-) -> BTreeMap<PackageName, Spanned<ReplacementDependency>> {
-    dependencies
-        .iter()
-        .map(|(original_id, linked_address)| {
-            let dep_name =
-                PackageName::new(format!("onchain_{original_id}")).expect("valid identifier");
-            (
-                dep_name,
-                Spanned::new(0..1, on_chain_replacement(linked_address)),
-            )
-        })
-        .collect()
-}
-
-/// Create a `ReplacementDependency` for an on-chain address.
-fn on_chain_replacement(address: &PublishedID) -> ReplacementDependency {
-    ReplacementDependency {
-        dependency: Some(DefaultDependency {
-            dependency_info: ManifestDependencyInfo::OnChainAt(OnChainAddress {
-                on_chain: address.clone(),
-            }),
-            is_override: true,
-            rename_from: None,
-            modes: None,
-        }),
-        addresses: None,
-        use_environment: None,
-    }
 }
 
 /// Create a new empty `ParsedManifest` for an on-chain package.
@@ -231,4 +211,163 @@ fn write_published<F: MoveFlavor>(
 
     let rendered = pubfile.render_as_toml();
     fs::write(&pub_path, rendered).expect("can write Published.toml to cache");
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use insta::assert_snapshot;
+    use tempfile::tempdir;
+    use test_log::test;
+
+    use super::*;
+    use crate::{
+        flavor::Vanilla,
+        schema::{OriginalID, PublishedID},
+    };
+
+    /// Helper to create test on-chain package data.
+    fn test_data(deps: Vec<(u16, u16)>) -> OnChainPackageData {
+        OnChainPackageData {
+            modules: BTreeMap::from([
+                ("my_module".to_string(), vec![0xDE, 0xAD]),
+                ("other_module".to_string(), vec![0xBE, 0xEF]),
+            ]),
+            dependencies: deps
+                .into_iter()
+                .map(|(orig, linked)| (OriginalID::from(orig), PublishedID::from(linked)))
+                .collect(),
+            original_id: OriginalID::from(0xABCD_u16),
+            version: 3,
+        }
+    }
+
+    /// Writing bytecode creates files at `bytecode/<name>.mv`.
+    #[test]
+    fn bytecode_files() {
+        let dir = tempdir().unwrap();
+        let data = test_data(vec![]);
+
+        write_bytecode(dir.path(), &data.modules);
+
+        let my_mod = dir.path().join("bytecode/my_module.mv");
+        let other_mod = dir.path().join("bytecode/other_module.mv");
+        assert_eq!(fs::read(&my_mod).unwrap(), vec![0xDE, 0xAD]);
+        assert_eq!(fs::read(&other_mod).unwrap(), vec![0xBE, 0xEF]);
+    }
+
+    /// Generated Move.toml for a package with no linkage table dependencies.
+    #[test]
+    fn manifest_no_deps() {
+        let dir = tempdir().unwrap();
+        let manifest_path = dir.path().join("Move.toml");
+        let data = test_data(vec![]);
+
+        write_manifest(dir.path(), &manifest_path, "test_chain", &data);
+
+        assert_snapshot!(fs::read_to_string(&manifest_path).unwrap(), @r#"
+        package = { name = "self", implicit-dependencies = false }
+        environments = { _on_chain = "test_chain" }
+        dependencies = {}
+        dep-replacements = {}
+        "#);
+    }
+
+    /// Generated Move.toml includes dep-replacements from the linkage table.
+    #[test]
+    fn manifest_with_deps() {
+        let dir = tempdir().unwrap();
+        let manifest_path = dir.path().join("Move.toml");
+        let data = test_data(vec![(0x2, 0x2), (0x3, 0x33)]);
+
+        write_manifest(dir.path(), &manifest_path, "test_chain", &data);
+
+        assert_snapshot!(fs::read_to_string(&manifest_path).unwrap(), @r#"
+        package = { name = "self", implicit-dependencies = false }
+        environments = { _on_chain = "test_chain" }
+        dependencies = {}
+
+        [dep-replacements]
+
+        [dep-replacements._on_chain]
+
+        [dep-replacements._on_chain.onchain_0x0000000000000000000000000000000000000000000000000000000000000002]
+        on-chain = "0x0000000000000000000000000000000000000000000000000000000000000002"
+        override = true
+
+        [dep-replacements._on_chain.onchain_0x0000000000000000000000000000000000000000000000000000000000000003]
+        on-chain = "0x0000000000000000000000000000000000000000000000000000000000000033"
+        override = true
+        "#);
+    }
+
+    /// Generated Move.toml round-trips through parse.
+    #[test]
+    fn manifest_round_trips() {
+        let dir = tempdir().unwrap();
+        let manifest_path = dir.path().join("Move.toml");
+        let data = test_data(vec![(0x2, 0x2)]);
+
+        write_manifest(dir.path(), &manifest_path, "test_chain", &data);
+
+        let content = fs::read_to_string(&manifest_path).unwrap();
+        let parsed: ParsedManifest = toml_edit::de::from_str(&content).unwrap();
+
+        assert_eq!(parsed.package.name.as_ref().as_str(), ON_CHAIN_PACKAGE_NAME);
+        assert!(!parsed.package.implicit_dependencies);
+        assert!(
+            parsed
+                .environments
+                .keys()
+                .any(|k| k.as_ref() == ON_CHAIN_ENV_NAME)
+        );
+    }
+
+    /// Generated Published.toml has the expected structure.
+    #[test]
+    fn published_toml() {
+        let dir = tempdir().unwrap();
+        let address = PublishedID::from(0x1234_u16);
+        let data = test_data(vec![]);
+
+        write_published::<Vanilla>(dir.path(), &address, "test_chain", &data);
+
+        assert_snapshot!(fs::read_to_string(dir.path().join("Published.toml")).unwrap(), @r#"
+        # Generated by Move
+        # This file contains metadata about published versions of this package in different environments
+        # This file SHOULD be committed to source control
+
+        [published._on_chain]
+        chain-id = "test_chain"
+        published-at = "0x0000000000000000000000000000000000000000000000000000000000001234"
+        original-id = "0x000000000000000000000000000000000000000000000000000000000000abcd"
+        version = 3
+        "#);
+    }
+
+    /// Rename-from check is skipped for on-chain deps.
+    #[test(tokio::test)]
+    async fn rename_from_skipped_for_on_chain() {
+        use crate::flavor::vanilla::DEFAULT_ENV_NAME;
+        use crate::test_utils::graph_builder::TestPackageGraph;
+
+        // "my_dep" won't match the generated package name "self", but the
+        // rename-from check should be skipped for on-chain deps.
+        let scenario = TestPackageGraph::new(["root"])
+            .add_on_chain_dep("root", "my_dep", "true", |d| d)
+            .add_on_chain_dep(
+                "root",
+                "my_dep",
+                "0x0000000000000000000000000000000000000000000000000000000000000001",
+                |d| d.in_env(DEFAULT_ENV_NAME),
+            )
+            .build();
+
+        let err = scenario.root_package_err("root").await;
+        assert!(
+            !err.contains("rename-from"),
+            "should not get rename-from error for on-chain deps, got: {err}"
+        );
+    }
 }

--- a/external-crates/move/crates/move-package-alt/src/on_chain/fetch.rs
+++ b/external-crates/move/crates/move-package-alt/src/on_chain/fetch.rs
@@ -397,10 +397,10 @@ mod tests {
         assert!(root.packages().len() >= 3, "expected root + A + B");
     }
 
-    /// An on-chain dep's linkage table references the same address as a local dep
-    /// that is published at that address. This creates a duplicate in the graph.
-    /// TODO: deduplication should resolve this.
+    /// When an on-chain dep's linkage table references the same address as a local dep,
+    /// they should be deduplicated to a single package in the graph.
     #[test(tokio::test)]
+    #[ignore] // TODO: requires deduplication of on-chain and source deps
     async fn on_chain_overlaps_with_local_dep() {
         use crate::flavor::vanilla::DEFAULT_ENV_NAME;
         use crate::test_utils::graph_builder::TestPackageGraph;
@@ -422,26 +422,14 @@ mod tests {
             .add_on_chain_pkg(addr_shared, |pkg| pkg)
             .build();
 
-        // This currently loads both as separate packages (no deduplication).
-        // TODO: when deduplication is implemented, this should resolve to a
-        // single package and this test should be updated.
-        let result = scenario.try_root_package("root", |cfg| cfg).await;
-        match result {
-            Ok(root) => {
-                // Both the local dep and on-chain fetched copy are in the graph
-                assert!(
-                    root.packages().len() >= 4,
-                    "expected root + local_dep + on-chain A + on-chain CC, got {}",
-                    root.packages().len()
-                );
-            }
-            Err(err) => {
-                let msg = err.to_string();
-                assert!(
-                    !msg.contains("rename-from"),
-                    "unexpected rename-from error: {msg}"
-                );
-            }
-        }
+        let root = scenario.root_package("root").await;
+        // After deduplication: root + local_dep + on-chain A = 3 packages
+        // (local_dep and on-chain 0xCC should be the same node)
+        assert_eq!(
+            root.packages().len(),
+            3,
+            "expected root + local_dep + on-chain A (deduplicated), got {}",
+            root.packages().len()
+        );
     }
 }

--- a/external-crates/move/crates/move-package-alt/src/on_chain/fetch.rs
+++ b/external-crates/move/crates/move-package-alt/src/on_chain/fetch.rs
@@ -1,0 +1,157 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Fetches on-chain packages and generates synthetic manifests and publication files.
+
+use std::{
+    collections::BTreeMap,
+    fs,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{Context, anyhow};
+use toml_edit::{DocumentMut, Item, Table, value};
+
+use crate::{
+    flavor::{MoveFlavor, OnChainPackageData},
+    package::{package_loader::PackageConfig, package_lock::PackageSystemLock},
+    schema::{
+        Environment, OriginalID, ParsedPublishedFile, Publication, PublishAddresses, PublishedID,
+        RenderToml,
+    },
+};
+
+/// Fetch an on-chain package and generate its manifest and publication files. Returns the path
+/// to the generated package directory in the cache.
+pub(crate) async fn fetch_onchain<F: MoveFlavor>(
+    address: &PublishedID,
+    env: &Environment,
+    config: &PackageConfig<F>,
+) -> anyhow::Result<PathBuf> {
+    let cache_dir = cache_dir_for(&config.chain_id, address);
+
+    let _lock = PackageSystemLock::new_for_onchain(&config.chain_id, address)
+        .map_err(|e| anyhow!("failed to acquire lock for on-chain package {address}: {e}"))?;
+
+    let data = config.flavor.fetch_onchain_package(address).await?;
+
+    write_bytecode(&cache_dir, &data.modules)?;
+    update_manifest(&cache_dir, env, &data.dependencies)?;
+    update_published::<F>(&cache_dir, address, env, &data)?;
+
+    Ok(cache_dir)
+}
+
+/// Return the cache directory for an on-chain package.
+fn cache_dir_for(chain_id: &str, address: &PublishedID) -> PathBuf {
+    PathBuf::from(move_command_line_common::env::MOVE_HOME.as_str())
+        .join("on-chain")
+        .join(chain_id)
+        .join(address.to_string())
+}
+
+/// Write module bytecode files to `<cache_dir>/bytecode/<name>.mv`.
+fn write_bytecode(cache_dir: &Path, modules: &BTreeMap<String, Vec<u8>>) -> anyhow::Result<()> {
+    let bytecode_dir = cache_dir.join("bytecode");
+    fs::create_dir_all(&bytecode_dir)
+        .with_context(|| format!("creating bytecode dir: {}", bytecode_dir.display()))?;
+
+    for (name, bytes) in modules {
+        let path = bytecode_dir.join(format!("{name}.mv"));
+        fs::write(&path, bytes)
+            .with_context(|| format!("writing module bytecode: {}", path.display()))?;
+    }
+
+    Ok(())
+}
+
+/// Generate or update `Move.toml` in the cache directory. Adds the environment and
+/// dep-replacements for on-chain dependencies from the linkage table.
+fn update_manifest(
+    cache_dir: &Path,
+    env: &Environment,
+    dependencies: &BTreeMap<OriginalID, PublishedID>,
+) -> anyhow::Result<()> {
+    let manifest_path = cache_dir.join("Move.toml");
+
+    let mut doc = if manifest_path.exists() {
+        let content = fs::read_to_string(&manifest_path)
+            .with_context(|| format!("reading {}", manifest_path.display()))?;
+        content
+            .parse::<DocumentMut>()
+            .with_context(|| format!("parsing {}", manifest_path.display()))?
+    } else {
+        fs::create_dir_all(cache_dir)
+            .with_context(|| format!("creating cache dir: {}", cache_dir.display()))?;
+        let mut doc = DocumentMut::new();
+        let mut package = Table::new();
+        package.insert("name", value("self"));
+        doc.insert("package", Item::Table(package));
+        doc
+    };
+
+    // Add environment entry
+    if !doc.contains_key("environments") {
+        doc.insert("environments", Item::Table(Table::new()));
+    }
+    doc["environments"][env.name()] = value(env.id());
+
+    // Add dep-replacements for this environment
+    if !dependencies.is_empty() {
+        if !doc.contains_key("dep-replacements") {
+            doc.insert("dep-replacements", Item::Table(Table::new()));
+        }
+        let replacements = &mut doc["dep-replacements"];
+
+        let mut env_table = Table::new();
+        for (original_id, linked_address) in dependencies {
+            let dep_name = format!("onchain_{original_id}");
+            let mut dep_table = Table::new();
+            dep_table.insert("on-chain", value(linked_address.to_string()));
+            env_table.insert(&dep_name, Item::Table(dep_table));
+        }
+        replacements[env.name()] = Item::Table(env_table);
+    }
+
+    fs::write(&manifest_path, doc.to_string())
+        .with_context(|| format!("writing {}", manifest_path.display()))?;
+
+    Ok(())
+}
+
+/// Generate or update `Published.toml` in the cache directory.
+fn update_published<F: MoveFlavor>(
+    cache_dir: &Path,
+    address: &PublishedID,
+    env: &Environment,
+    data: &OnChainPackageData,
+) -> anyhow::Result<()> {
+    let pub_path = cache_dir.join("Published.toml");
+
+    let mut pubfile: ParsedPublishedFile<F> = if pub_path.exists() {
+        let content = fs::read_to_string(&pub_path)
+            .with_context(|| format!("reading {}", pub_path.display()))?;
+        toml_edit::de::from_str(&content)
+            .with_context(|| format!("parsing {}", pub_path.display()))?
+    } else {
+        ParsedPublishedFile::default()
+    };
+
+    pubfile.published.insert(
+        env.name().to_string(),
+        Publication {
+            chain_id: env.id().to_string(),
+            addresses: PublishAddresses {
+                published_at: address.clone(),
+                original_id: data.original_id.clone(),
+            },
+            version: data.version,
+            metadata: F::PublishedMetadata::default(),
+        },
+    );
+
+    let rendered = pubfile.render_as_toml();
+    fs::write(&pub_path, rendered).with_context(|| format!("writing {}", pub_path.display()))?;
+
+    Ok(())
+}

--- a/external-crates/move/crates/move-package-alt/src/on_chain/fetch.rs
+++ b/external-crates/move/crates/move-package-alt/src/on_chain/fetch.rs
@@ -100,6 +100,7 @@ pub(crate) async fn fetch_onchain<F: MoveFlavor>(
         })?;
 
     write_bytecode(&cache_dir, &data.modules);
+    write_source(&cache_dir);
     write_manifest(&cache_dir, &manifest_path, &config.chain_id, &data);
     write_published::<F>(&cache_dir, address, &config.chain_id, &data);
 
@@ -124,6 +125,11 @@ fn write_bytecode(cache_dir: &Path, modules: &BTreeMap<String, Vec<u8>>) {
         fs::write(&path, bytes).expect("can write module bytecode to cache");
     }
 }
+
+/// Generate stub Move source files from bytecode. Currently a no-op; will be implemented
+/// when stub generation (PR #26555) is integrated.
+// TODO: implement stub source generation from bytecode
+fn write_source(_cache_dir: &Path) {}
 
 /// Generate the `Move.toml` for an on-chain package.
 fn write_manifest(
@@ -391,10 +397,10 @@ mod tests {
         assert!(root.packages().len() >= 3, "expected root + A + B");
     }
 
-    /// When an on-chain dep's linkage table references the same address as a local dep,
-    /// they should be deduplicated to a single package in the graph.
+    /// An on-chain dep's linkage table references the same address as a local dep.
+    /// Currently both are loaded as separate packages (no deduplication).
+    /// TODO: when deduplication is implemented, update this test to assert 3 packages.
     #[test(tokio::test)]
-    #[ignore] // TODO: requires deduplication of on-chain and source deps
     async fn on_chain_overlaps_with_local_dep() {
         let scenario = TestPackageGraph::new(["root"])
             .add_published(
@@ -416,12 +422,13 @@ mod tests {
             .add_on_chain_pkg(PublishedID::from(0xCC_u16), |pkg| pkg)
             .build();
 
-        let root = scenario.root_package("root").await;
-        assert_eq!(
-            root.packages().len(),
-            3,
-            "expected root + local_dep + on-chain A (deduplicated), got {}",
-            root.packages().len()
+        // Currently this fails to load because of duplicate packages.
+        // TODO: after deduplication is implemented, this should succeed with 3 packages.
+        let result = scenario.try_root_package("root", |cfg| cfg).await;
+        assert!(
+            result.is_err(),
+            "expected error due to duplicate packages, but got {} packages",
+            result.map(|r| r.packages().len()).unwrap_or(0)
         );
     }
 }

--- a/external-crates/move/crates/move-package-alt/src/on_chain/fetch.rs
+++ b/external-crates/move/crates/move-package-alt/src/on_chain/fetch.rs
@@ -370,4 +370,123 @@ mod tests {
             "should not get rename-from error for on-chain deps, got: {err}"
         );
     }
+
+    /// An on-chain package whose linkage table points to another on-chain package.
+    /// Both should be fetched and loaded.
+    #[test(tokio::test)]
+    async fn transitive_on_chain_dep() {
+        use crate::flavor::vanilla::DEFAULT_ENV_NAME;
+        use crate::test_utils::graph_builder::TestPackageGraph;
+
+        let addr_a = PublishedID::from(0xA_u16);
+        let addr_b = PublishedID::from(0xB_u16);
+
+        // Package A depends on package B (via linkage table)
+        let data_a = OnChainPackageData {
+            modules: BTreeMap::from([("mod_a".into(), vec![1])]),
+            dependencies: BTreeMap::from([(OriginalID::from(0xB_u16), addr_b.clone())]),
+            original_id: OriginalID::from(0xA_u16),
+            version: 1,
+        };
+
+        // Package B has no dependencies
+        let data_b = OnChainPackageData {
+            modules: BTreeMap::from([("mod_b".into(), vec![2])]),
+            dependencies: BTreeMap::new(),
+            original_id: OriginalID::from(0xB_u16),
+            version: 1,
+        };
+
+        let scenario = TestPackageGraph::new(["root"])
+            .add_on_chain_dep("root", "dep_a", "true", |d| d)
+            .add_on_chain_dep("root", "dep_a", &addr_a.to_string(), |d| {
+                d.in_env(DEFAULT_ENV_NAME)
+            })
+            .add_on_chain_pkg(
+                addr_a,
+                data_a.modules.clone(),
+                data_a.dependencies.clone(),
+                data_a.original_id.clone(),
+                data_a.version,
+            )
+            .add_on_chain_pkg(
+                addr_b,
+                data_b.modules.clone(),
+                data_b.dependencies.clone(),
+                data_b.original_id.clone(),
+                data_b.version,
+            )
+            .build();
+
+        // Should succeed — both packages fetched and loaded
+        let root = scenario.root_package("root").await;
+        assert!(root.packages().len() >= 3, "expected root + A + B");
+    }
+
+    /// An on-chain dep's linkage table references the same address as a local dep.
+    #[test(tokio::test)]
+    async fn on_chain_overlaps_with_local_dep() {
+        use crate::flavor::vanilla::DEFAULT_ENV_NAME;
+        use crate::test_utils::graph_builder::TestPackageGraph;
+
+        let addr_a = PublishedID::from(0xA_u16);
+        let addr_local = PublishedID::from(0xCC_u16);
+
+        // Package A's linkage table references 0xCC, which is also a local dep
+        let data_a = OnChainPackageData {
+            modules: BTreeMap::from([("mod_a".into(), vec![1])]),
+            dependencies: BTreeMap::from([(OriginalID::from(0xCC_u16), addr_local.clone())]),
+            original_id: OriginalID::from(0xA_u16),
+            version: 1,
+        };
+
+        // 0xCC is available both as on-chain (from A's linkage) and as local dep "local_dep"
+        let data_cc = OnChainPackageData {
+            modules: BTreeMap::from([("mod_cc".into(), vec![3])]),
+            dependencies: BTreeMap::new(),
+            original_id: OriginalID::from(0xCC_u16),
+            version: 1,
+        };
+
+        let scenario = TestPackageGraph::new(["root", "local_dep"])
+            .add_deps([("root", "local_dep")])
+            .add_on_chain_dep("root", "dep_a", "true", |d| d)
+            .add_on_chain_dep("root", "dep_a", &addr_a.to_string(), |d| {
+                d.in_env(DEFAULT_ENV_NAME)
+            })
+            .add_on_chain_pkg(
+                addr_a,
+                data_a.modules.clone(),
+                data_a.dependencies.clone(),
+                data_a.original_id.clone(),
+                data_a.version,
+            )
+            .add_on_chain_pkg(
+                addr_local,
+                data_cc.modules.clone(),
+                data_cc.dependencies.clone(),
+                data_cc.original_id.clone(),
+                data_cc.version,
+            )
+            .build();
+
+        // Currently both will be loaded as separate packages in the graph
+        // (deduplication is a known TODO). Just verify it doesn't crash.
+        let result = scenario.try_root_package("root", |cfg| cfg).await;
+        // Document the current behavior — success or a specific error
+        match result {
+            Ok(root) => {
+                // Both the local dep and on-chain dep are in the graph
+                assert!(root.packages().len() >= 3);
+            }
+            Err(err) => {
+                // If it fails, it shouldn't be a rename-from error
+                let msg = err.to_string();
+                assert!(
+                    !msg.contains("rename-from"),
+                    "unexpected rename-from error: {msg}"
+                );
+            }
+        }
+    }
 }

--- a/external-crates/move/crates/move-package-alt/src/on_chain/fetch.rs
+++ b/external-crates/move/crates/move-package-alt/src/on_chain/fetch.rs
@@ -32,8 +32,9 @@ use crate::{
         layout::SourcePackageLayout, package_loader::PackageConfig, package_lock::PackageSystemLock,
     },
     schema::{
-        PackageName, ParsedManifest, ParsedPublishedFile, Publication, PublishAddresses,
-        PublishedID, RenderToml,
+        DefaultDependency, ManifestDependencyInfo, OnChainAddress, PackageName, ParsedManifest,
+        ParsedPublishedFile, Publication, PublishAddresses, PublishedID, RenderToml,
+        ReplacementDependency,
     },
 };
 
@@ -147,34 +148,36 @@ fn write_manifest(
         Spanned::new(0..1, chain_id.to_string()),
     );
 
-    // Serialize everything except dep-replacements. ManifestDependencyInfo's derived
-    // Serialize doesn't match its custom Deserialize (the serializer produces tagged enum
-    // output like `OnChainAt = { ... }` but the deserializer expects flat keys like
-    // `on-chain = "0x..."`). We can't fix Serialize because the digest computation depends
-    // on the current (incorrect) format. See DVX-2125 for the proper fix.
-    // TODO(DVX-2125): once the digest is decoupled from serialization, use RenderToml.
-    let mut doc = toml_edit::ser::to_document(&manifest).expect("can serialize generated manifest");
-
-    // Build dep-replacements manually via toml_edit, using inline tables for each dep
-    // (e.g. `onchain_0x02 = { on-chain = "0x02", override = true }`)
+    // Add dep-replacements from linkage table
     if !data.dependencies.is_empty() {
-        let mut env_table = toml_edit::Table::new();
-        for (original_id, linked_address) in &data.dependencies {
-            let dep_name = format!("onchain_{original_id}");
-            let mut dep = toml_edit::InlineTable::new();
-            dep.insert("on-chain", linked_address.to_string().into());
-            dep.insert("override", true.into());
-            env_table.insert(
-                &dep_name,
-                toml_edit::Item::Value(toml_edit::Value::InlineTable(dep)),
-            );
-        }
-        let mut replacements = toml_edit::Table::new();
-        replacements.insert(ON_CHAIN_ENV_NAME, toml_edit::Item::Table(env_table));
-        doc.insert("dep-replacements", toml_edit::Item::Table(replacements));
+        let env_replacements = data
+            .dependencies
+            .iter()
+            .map(|(original_id, linked_address)| {
+                let dep_name =
+                    PackageName::new(format!("onchain_{original_id}")).expect("valid identifier");
+                let replacement = ReplacementDependency {
+                    dependency: Some(DefaultDependency {
+                        dependency_info: ManifestDependencyInfo::OnChainAt(OnChainAddress {
+                            on_chain: linked_address.clone(),
+                        }),
+                        is_override: true,
+                        rename_from: None,
+                        modes: None,
+                    }),
+                    addresses: None,
+                    use_environment: None,
+                };
+                (dep_name, Spanned::new(0..1, replacement))
+            })
+            .collect();
+        manifest
+            .dep_replacements
+            .insert(ON_CHAIN_ENV_NAME.to_string(), env_replacements);
     }
 
-    fs::write(manifest_path, doc.to_string()).expect("can write generated manifest to cache");
+    fs::write(manifest_path, manifest.render_as_toml())
+        .expect("can write generated manifest to cache");
 }
 
 /// Create a new empty `ParsedManifest` for an on-chain package.

--- a/external-crates/move/crates/move-package-alt/src/on_chain/fetch.rs
+++ b/external-crates/move/crates/move-package-alt/src/on_chain/fetch.rs
@@ -58,6 +58,19 @@ const ON_CHAIN_PACKAGE_NAME: &str = "self";
 /// for a second environment adds a new entry without disturbing existing ones. This does
 /// not trigger repinning for other environments because the manifest digest is computed
 /// per-environment from the `CombinedDependency` list.
+///
+/// # Known limitation: system packages
+///
+/// The linkage table entries are currently all turned into on-chain dep-replacements. This
+/// includes entries for system packages (e.g. `0x1`, `0x2` on Sui), which are mutable and
+/// should instead be resolved as system deps. Since almost all on-chain packages depend on
+/// system packages, this means the generated manifest will redundantly fetch system packages
+/// on-chain rather than using the source versions already in the graph.
+///
+/// The general problem is that a package may be reachable both as an on-chain dep (from the
+/// linkage table) and as a source dep (from system deps or the user's manifest). These need
+/// to be deduplicated, likely in a post-processing step after the full graph is built.
+// TODO: filter system packages from the linkage table or deduplicate in the graph builder.
 pub(crate) async fn fetch_onchain<F: MoveFlavor>(
     address: &PublishedID,
     env: &Environment,

--- a/external-crates/move/crates/move-package-alt/src/on_chain/fetch.rs
+++ b/external-crates/move/crates/move-package-alt/src/on_chain/fetch.rs
@@ -75,7 +75,7 @@ pub(crate) const ON_CHAIN_ENV_NAME: &str = "_on_chain";
 /// The general problem is that a package may be reachable both as an on-chain dep (from the
 /// linkage table) and as a source dep (from system deps or the user's manifest). These need
 /// to be deduplicated, likely in a post-processing step after the full graph is built.
-// TODO: filter system packages from the linkage table or deduplicate in the graph builder.
+// TODO(DVX-2126): filter system packages from the linkage table or deduplicate in the graph builder.
 pub(crate) async fn fetch_onchain<F: MoveFlavor>(
     address: &PublishedID,
     config: &PackageConfig<F>,
@@ -397,10 +397,10 @@ mod tests {
         assert!(root.packages().len() >= 3, "expected root + A + B");
     }
 
-    /// An on-chain dep's linkage table references the same address as a local dep.
-    /// Currently both are loaded as separate packages (no deduplication).
-    /// TODO: when deduplication is implemented, update this test to assert 3 packages.
+    /// When an on-chain dep's linkage table references the same address as a local dep,
+    /// they should be deduplicated to a single package in the graph.
     #[test(tokio::test)]
+    #[ignore] // TODO(DVX-2126): requires deduplication of on-chain and source deps
     async fn on_chain_overlaps_with_local_dep() {
         let scenario = TestPackageGraph::new(["root"])
             .add_published(
@@ -422,13 +422,14 @@ mod tests {
             .add_on_chain_pkg(PublishedID::from(0xCC_u16), |pkg| pkg)
             .build();
 
-        // Currently this fails to load because of duplicate packages.
-        // TODO: after deduplication is implemented, this should succeed with 3 packages.
-        let result = scenario.try_root_package("root", |cfg| cfg).await;
-        assert!(
-            result.is_err(),
-            "expected error due to duplicate packages, but got {} packages",
-            result.map(|r| r.packages().len()).unwrap_or(0)
+        let root = scenario.root_package("root").await;
+        // After deduplication: root + local_dep + on-chain A = 3 packages
+        // (local_dep and on-chain 0xCC should be the same node)
+        assert_eq!(
+            root.packages().len(),
+            3,
+            "expected root + local_dep + on-chain A (deduplicated), got {}",
+            root.packages().len()
         );
     }
 }

--- a/external-crates/move/crates/move-package-alt/src/on_chain/fetch.rs
+++ b/external-crates/move/crates/move-package-alt/src/on_chain/fetch.rs
@@ -381,41 +381,15 @@ mod tests {
         let addr_a = PublishedID::from(0xA_u16);
         let addr_b = PublishedID::from(0xB_u16);
 
-        // Package A depends on package B (via linkage table)
-        let data_a = OnChainPackageData {
-            modules: BTreeMap::from([("mod_a".into(), vec![1])]),
-            dependencies: BTreeMap::from([(OriginalID::from(0xB_u16), addr_b.clone())]),
-            original_id: OriginalID::from(0xA_u16),
-            version: 1,
-        };
-
-        // Package B has no dependencies
-        let data_b = OnChainPackageData {
-            modules: BTreeMap::from([("mod_b".into(), vec![2])]),
-            dependencies: BTreeMap::new(),
-            original_id: OriginalID::from(0xB_u16),
-            version: 1,
-        };
-
         let scenario = TestPackageGraph::new(["root"])
             .add_on_chain_dep("root", "dep_a", "true", |d| d)
             .add_on_chain_dep("root", "dep_a", &addr_a.to_string(), |d| {
                 d.in_env(DEFAULT_ENV_NAME)
             })
-            .add_on_chain_pkg(
-                addr_a,
-                data_a.modules.clone(),
-                data_a.dependencies.clone(),
-                data_a.original_id.clone(),
-                data_a.version,
-            )
-            .add_on_chain_pkg(
-                addr_b,
-                data_b.modules.clone(),
-                data_b.dependencies.clone(),
-                data_b.original_id.clone(),
-                data_b.version,
-            )
+            .add_on_chain_pkg(addr_a, |pkg| {
+                pkg.dep(OriginalID::from(0xB_u16), addr_b.clone())
+            })
+            .add_on_chain_pkg(addr_b, |pkg| pkg)
             .build();
 
         // Should succeed — both packages fetched and loaded
@@ -423,64 +397,45 @@ mod tests {
         assert!(root.packages().len() >= 3, "expected root + A + B");
     }
 
-    /// An on-chain dep's linkage table references the same address as a local dep.
+    /// An on-chain dep's linkage table references the same address as a local dep
+    /// that is published at that address. This creates a duplicate in the graph.
+    /// TODO: deduplication should resolve this.
     #[test(tokio::test)]
     async fn on_chain_overlaps_with_local_dep() {
         use crate::flavor::vanilla::DEFAULT_ENV_NAME;
         use crate::test_utils::graph_builder::TestPackageGraph;
 
         let addr_a = PublishedID::from(0xA_u16);
-        let addr_local = PublishedID::from(0xCC_u16);
+        let addr_shared = PublishedID::from(0xCC_u16);
 
-        // Package A's linkage table references 0xCC, which is also a local dep
-        let data_a = OnChainPackageData {
-            modules: BTreeMap::from([("mod_a".into(), vec![1])]),
-            dependencies: BTreeMap::from([(OriginalID::from(0xCC_u16), addr_local.clone())]),
-            original_id: OriginalID::from(0xA_u16),
-            version: 1,
-        };
-
-        // 0xCC is available both as on-chain (from A's linkage) and as local dep "local_dep"
-        let data_cc = OnChainPackageData {
-            modules: BTreeMap::from([("mod_cc".into(), vec![3])]),
-            dependencies: BTreeMap::new(),
-            original_id: OriginalID::from(0xCC_u16),
-            version: 1,
-        };
-
-        let scenario = TestPackageGraph::new(["root", "local_dep"])
+        // local_dep is published at 0xCC — same address as A's linkage entry
+        let scenario = TestPackageGraph::new(["root"])
+            .add_published("local_dep", OriginalID::from(0xCC_u16), addr_shared.clone())
             .add_deps([("root", "local_dep")])
             .add_on_chain_dep("root", "dep_a", "true", |d| d)
             .add_on_chain_dep("root", "dep_a", &addr_a.to_string(), |d| {
                 d.in_env(DEFAULT_ENV_NAME)
             })
-            .add_on_chain_pkg(
-                addr_a,
-                data_a.modules.clone(),
-                data_a.dependencies.clone(),
-                data_a.original_id.clone(),
-                data_a.version,
-            )
-            .add_on_chain_pkg(
-                addr_local,
-                data_cc.modules.clone(),
-                data_cc.dependencies.clone(),
-                data_cc.original_id.clone(),
-                data_cc.version,
-            )
+            .add_on_chain_pkg(addr_a, |pkg| {
+                pkg.dep(OriginalID::from(0xCC_u16), addr_shared.clone())
+            })
+            .add_on_chain_pkg(addr_shared, |pkg| pkg)
             .build();
 
-        // Currently both will be loaded as separate packages in the graph
-        // (deduplication is a known TODO). Just verify it doesn't crash.
+        // This currently loads both as separate packages (no deduplication).
+        // TODO: when deduplication is implemented, this should resolve to a
+        // single package and this test should be updated.
         let result = scenario.try_root_package("root", |cfg| cfg).await;
-        // Document the current behavior — success or a specific error
         match result {
             Ok(root) => {
-                // Both the local dep and on-chain dep are in the graph
-                assert!(root.packages().len() >= 3);
+                // Both the local dep and on-chain fetched copy are in the graph
+                assert!(
+                    root.packages().len() >= 4,
+                    "expected root + local_dep + on-chain A + on-chain CC, got {}",
+                    root.packages().len()
+                );
             }
             Err(err) => {
-                // If it fails, it shouldn't be a rename-from error
                 let msg = err.to_string();
                 assert!(
                     !msg.contains("rename-from"),

--- a/external-crates/move/crates/move-package-alt/src/on_chain/fetch.rs
+++ b/external-crates/move/crates/move-package-alt/src/on_chain/fetch.rs
@@ -9,7 +9,7 @@
 //!   the compiler writes to `build/<pkg>/bytecode_modules/`; we use a separate directory
 //!   to avoid clobbering the original bytecode if the package is recompiled)
 //! - `Move.toml` — a generated manifest with `name = "self"`, with environments and
-//!   dep-replacements added incrementally as the package is used from different contexts
+//!   dep-replacements added incrementally as the package is used in different environments
 //! - `Published.toml` — publication metadata, also updated incrementally per environment
 
 use std::{
@@ -47,10 +47,11 @@ const ON_CHAIN_PACKAGE_NAME: &str = "self";
 /// name = "self"
 ///
 /// [environments]
-/// mainnet = "35834a8a"
+/// my_env = "some_chain_id"
 ///
-/// [dep-replacements.mainnet.onchain_0x0000...0002]
+/// [dep-replacements.my_env.onchain_0x0000...0002]
 /// on-chain = "0x0000...0002"
+/// override = true
 /// ```
 ///
 /// Environments and dep-replacements are added incrementally: fetching the same package
@@ -80,12 +81,12 @@ pub(crate) async fn fetch_onchain<F: MoveFlavor>(
                 address: address.clone(),
                 source,
             })?;
-        write_bytecode(&cache_dir, &data.modules)?;
+        write_bytecode(&cache_dir, &data.modules);
         Some(data)
     };
 
-    update_manifest(&cache_dir, address, env, data.as_ref())?;
-    update_published::<F>(&cache_dir, address, env, data.as_ref())?;
+    update_manifest(&cache_dir, env, &data);
+    update_published::<F>(&cache_dir, address, env, &data);
 
     Ok(cache_dir)
 }
@@ -99,61 +100,31 @@ fn cache_dir_for(chain_id: &str, address: &PublishedID) -> PathBuf {
 }
 
 /// Write serialized `CompiledModule` bytecode to `<cache_dir>/bytecode/<name>.mv`.
-fn write_bytecode(cache_dir: &Path, modules: &BTreeMap<String, Vec<u8>>) -> OnChainResult<()> {
+fn write_bytecode(cache_dir: &Path, modules: &BTreeMap<String, Vec<u8>>) {
     let bytecode_dir = cache_dir.join("bytecode");
-    fs::create_dir_all(&bytecode_dir).map_err(|source| OnChainError::CacheWrite {
-        path: bytecode_dir.clone(),
-        source,
-    })?;
+    fs::create_dir_all(&bytecode_dir).expect("can create on-chain package cache directory");
 
     for (name, bytes) in modules {
         let path = bytecode_dir.join(format!("{name}.mv"));
-        fs::write(&path, bytes).map_err(|source| OnChainError::CacheWrite {
-            path: path.clone(),
-            source,
-        })?;
+        fs::write(&path, bytes).expect("can write module bytecode to cache");
     }
-
-    Ok(())
 }
 
 /// Generate or update the `Move.toml` in the cache directory. Adds the current
 /// environment and dep-replacements for on-chain dependencies from the linkage table.
 /// If the manifest already exists and contains this environment, it is not modified.
-fn update_manifest(
-    cache_dir: &Path,
-    address: &PublishedID,
-    env: &Environment,
-    data: Option<&OnChainPackageData>,
-) -> OnChainResult<()> {
+fn update_manifest(cache_dir: &Path, env: &Environment, data: &Option<OnChainPackageData>) {
     let manifest_path = cache_dir.join(SourcePackageLayout::Manifest.location_str());
 
-    let mut manifest: ParsedManifest = if manifest_path.exists() {
-        let content =
-            fs::read_to_string(&manifest_path).map_err(|source| OnChainError::CacheWrite {
-                path: manifest_path.clone(),
-                source,
-            })?;
-        toml_edit::de::from_str(&content).map_err(|source| OnChainError::ManifestParse {
-            path: manifest_path.clone(),
-            source,
-        })?
-    } else {
-        fs::create_dir_all(cache_dir).map_err(|source| OnChainError::CacheWrite {
-            path: cache_dir.to_path_buf(),
-            source,
-        })?;
-        new_manifest()
-    };
+    let mut manifest = load_or_create_manifest(cache_dir, &manifest_path);
 
-    // Check if this environment is already present
-    let env_already_present = manifest
+    // Skip if this environment is already present
+    if manifest
         .environments
         .keys()
-        .any(|k| k.as_ref() == env.name());
-
-    if env_already_present {
-        return Ok(());
+        .any(|k| k.as_ref() == env.name())
+    {
+        return;
     }
 
     // Add environment
@@ -164,42 +135,58 @@ fn update_manifest(
 
     // Add dep-replacements from linkage table
     if let Some(data) = data {
-        let mut env_replacements = BTreeMap::new();
-        for (original_id, linked_address) in &data.dependencies {
-            let dep_name =
-                PackageName::new(format!("onchain_{original_id}")).expect("valid identifier");
-            let replacement = ReplacementDependency {
-                dependency: Some(DefaultDependency {
-                    dependency_info: ManifestDependencyInfo::OnChainAt(OnChainAddress {
-                        on_chain: linked_address.clone(),
-                    }),
-                    is_override: false,
-                    rename_from: None,
-                    modes: None,
-                }),
-                addresses: None,
-                use_environment: None,
-            };
-            env_replacements.insert(dep_name, Spanned::new(0..1, replacement));
-        }
+        let env_replacements = dep_replacements_for(&data.dependencies);
         manifest
             .dep_replacements
             .insert(env.name().to_string(), env_replacements);
     }
 
-    // Serialize and write
-    let doc = toml_edit::ser::to_document(&manifest).map_err(|source| {
-        OnChainError::ManifestSerialize {
-            address: address.clone(),
-            source,
-        }
-    })?;
-    fs::write(&manifest_path, doc.to_string()).map_err(|source| OnChainError::CacheWrite {
-        path: manifest_path,
-        source,
-    })?;
+    let doc = toml_edit::ser::to_document(&manifest).expect("can serialize generated manifest");
+    fs::write(&manifest_path, doc.to_string()).expect("can write generated manifest to cache");
+}
 
-    Ok(())
+/// Load an existing `ParsedManifest` from disk, or create a new one for an on-chain package.
+fn load_or_create_manifest(cache_dir: &Path, manifest_path: &Path) -> ParsedManifest {
+    if manifest_path.exists() {
+        let content = fs::read_to_string(manifest_path).expect("can read cached manifest");
+        toml_edit::de::from_str(&content).expect("can parse cached manifest")
+    } else {
+        fs::create_dir_all(cache_dir).expect("can create on-chain package cache directory");
+        new_manifest()
+    }
+}
+
+/// Build dep-replacement entries from a linkage table.
+fn dep_replacements_for(
+    dependencies: &BTreeMap<crate::schema::OriginalID, PublishedID>,
+) -> BTreeMap<PackageName, Spanned<ReplacementDependency>> {
+    dependencies
+        .iter()
+        .map(|(original_id, linked_address)| {
+            let dep_name =
+                PackageName::new(format!("onchain_{original_id}")).expect("valid identifier");
+            (
+                dep_name,
+                Spanned::new(0..1, on_chain_replacement(linked_address)),
+            )
+        })
+        .collect()
+}
+
+/// Create a `ReplacementDependency` for an on-chain address.
+fn on_chain_replacement(address: &PublishedID) -> ReplacementDependency {
+    ReplacementDependency {
+        dependency: Some(DefaultDependency {
+            dependency_info: ManifestDependencyInfo::OnChainAt(OnChainAddress {
+                on_chain: address.clone(),
+            }),
+            is_override: true,
+            rename_from: None,
+            modes: None,
+        }),
+        addresses: None,
+        use_environment: None,
+    }
 }
 
 /// Create a new empty `ParsedManifest` for an on-chain package.
@@ -227,31 +214,25 @@ fn update_published<F: MoveFlavor>(
     cache_dir: &Path,
     address: &PublishedID,
     env: &Environment,
-    data: Option<&OnChainPackageData>,
-) -> OnChainResult<()> {
+    data: &Option<OnChainPackageData>,
+) {
     let pub_path = cache_dir.join("Published.toml");
 
     let mut pubfile: ParsedPublishedFile<F> = if pub_path.exists() {
-        let content = fs::read_to_string(&pub_path).map_err(|source| OnChainError::CacheWrite {
-            path: pub_path.clone(),
-            source,
-        })?;
-        toml_edit::de::from_str(&content).map_err(|source| OnChainError::ManifestParse {
-            path: pub_path.clone(),
-            source,
-        })?
+        let content = fs::read_to_string(&pub_path).expect("can read cached Published.toml");
+        toml_edit::de::from_str(&content).expect("can parse cached Published.toml")
     } else {
         ParsedPublishedFile::default()
     };
 
     // Skip if this environment is already present
     if pubfile.published.contains_key(env.name()) {
-        return Ok(());
+        return;
     }
 
     // We need the on-chain data to create a publication entry
     let Some(data) = data else {
-        return Ok(());
+        return;
     };
 
     pubfile.published.insert(
@@ -268,10 +249,5 @@ fn update_published<F: MoveFlavor>(
     );
 
     let rendered = pubfile.render_as_toml();
-    fs::write(&pub_path, rendered).map_err(|source| OnChainError::CacheWrite {
-        path: pub_path,
-        source,
-    })?;
-
-    Ok(())
+    fs::write(&pub_path, rendered).expect("can write Published.toml to cache");
 }

--- a/external-crates/move/crates/move-package-alt/src/on_chain/fetch.rs
+++ b/external-crates/move/crates/move-package-alt/src/on_chain/fetch.rs
@@ -76,7 +76,7 @@ pub(crate) async fn fetch_onchain<F: MoveFlavor>(
             .flavor
             .fetch_onchain_package(address)
             .await
-            .map_err(|source| OnChainError::FetchFailed {
+            .map_err(|source| OnChainError::Fetch {
                 address: address.clone(),
                 source,
             })?;
@@ -101,14 +101,14 @@ fn cache_dir_for(chain_id: &str, address: &PublishedID) -> PathBuf {
 /// Write serialized `CompiledModule` bytecode to `<cache_dir>/bytecode/<name>.mv`.
 fn write_bytecode(cache_dir: &Path, modules: &BTreeMap<String, Vec<u8>>) -> OnChainResult<()> {
     let bytecode_dir = cache_dir.join("bytecode");
-    fs::create_dir_all(&bytecode_dir).map_err(|source| OnChainError::CacheWriteFailed {
+    fs::create_dir_all(&bytecode_dir).map_err(|source| OnChainError::CacheWrite {
         path: bytecode_dir.clone(),
         source,
     })?;
 
     for (name, bytes) in modules {
         let path = bytecode_dir.join(format!("{name}.mv"));
-        fs::write(&path, bytes).map_err(|source| OnChainError::CacheWriteFailed {
+        fs::write(&path, bytes).map_err(|source| OnChainError::CacheWrite {
             path: path.clone(),
             source,
         })?;
@@ -129,18 +129,17 @@ fn update_manifest(
     let manifest_path = cache_dir.join(SourcePackageLayout::Manifest.location_str());
 
     let mut manifest: ParsedManifest = if manifest_path.exists() {
-        let content = fs::read_to_string(&manifest_path).map_err(|source| {
-            OnChainError::CacheWriteFailed {
+        let content =
+            fs::read_to_string(&manifest_path).map_err(|source| OnChainError::CacheWrite {
                 path: manifest_path.clone(),
                 source,
-            }
-        })?;
-        toml_edit::de::from_str(&content).map_err(|source| OnChainError::ManifestParseFailed {
+            })?;
+        toml_edit::de::from_str(&content).map_err(|source| OnChainError::ManifestParse {
             path: manifest_path.clone(),
             source,
         })?
     } else {
-        fs::create_dir_all(cache_dir).map_err(|source| OnChainError::CacheWriteFailed {
+        fs::create_dir_all(cache_dir).map_err(|source| OnChainError::CacheWrite {
             path: cache_dir.to_path_buf(),
             source,
         })?;
@@ -190,16 +189,14 @@ fn update_manifest(
 
     // Serialize and write
     let doc = toml_edit::ser::to_document(&manifest).map_err(|source| {
-        OnChainError::ManifestSerializeFailed {
+        OnChainError::ManifestSerialize {
             address: address.clone(),
             source,
         }
     })?;
-    fs::write(&manifest_path, doc.to_string()).map_err(|source| {
-        OnChainError::CacheWriteFailed {
-            path: manifest_path,
-            source,
-        }
+    fs::write(&manifest_path, doc.to_string()).map_err(|source| OnChainError::CacheWrite {
+        path: manifest_path,
+        source,
     })?;
 
     Ok(())
@@ -235,12 +232,11 @@ fn update_published<F: MoveFlavor>(
     let pub_path = cache_dir.join("Published.toml");
 
     let mut pubfile: ParsedPublishedFile<F> = if pub_path.exists() {
-        let content =
-            fs::read_to_string(&pub_path).map_err(|source| OnChainError::CacheWriteFailed {
-                path: pub_path.clone(),
-                source,
-            })?;
-        toml_edit::de::from_str(&content).map_err(|source| OnChainError::ManifestParseFailed {
+        let content = fs::read_to_string(&pub_path).map_err(|source| OnChainError::CacheWrite {
+            path: pub_path.clone(),
+            source,
+        })?;
+        toml_edit::de::from_str(&content).map_err(|source| OnChainError::ManifestParse {
             path: pub_path.clone(),
             source,
         })?
@@ -272,7 +268,7 @@ fn update_published<F: MoveFlavor>(
     );
 
     let rendered = pubfile.render_as_toml();
-    fs::write(&pub_path, rendered).map_err(|source| OnChainError::CacheWriteFailed {
+    fs::write(&pub_path, rendered).map_err(|source| OnChainError::CacheWrite {
         path: pub_path,
         source,
     })?;

--- a/external-crates/move/crates/move-package-alt/src/on_chain/mod.rs
+++ b/external-crates/move/crates/move-package-alt/src/on_chain/mod.rs
@@ -1,0 +1,13 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! On-chain dependency fetching and manifest generation.
+//!
+//! When a package depends on an on-chain package, we need to:
+//! 1. Download the bytecode and linkage table from the network (via [`MoveFlavor`])
+//! 2. Generate a synthetic `Move.toml` and `Published.toml` in the cache directory
+//! 3. Write the bytecode modules to disk
+//!
+//! The cache layout is `~/.move/on-chain/<chain_id>/<address>/`.
+
+pub(crate) mod fetch;

--- a/external-crates/move/crates/move-package-alt/src/on_chain/mod.rs
+++ b/external-crates/move/crates/move-package-alt/src/on_chain/mod.rs
@@ -10,4 +10,7 @@
 //!
 //! The cache layout is `~/.move/on-chain/<chain_id>/<address>/`.
 
+mod errors;
 pub(crate) mod fetch;
+
+pub(crate) use errors::{OnChainError, OnChainResult};

--- a/external-crates/move/crates/move-package-alt/src/package/manifest.rs
+++ b/external-crates/move/crates/move-package-alt/src/package/manifest.rs
@@ -77,6 +77,12 @@ pub enum ManifestErrorKind {
     OnChainReplacementWithoutAddress { name: PackageName },
 
     #[error(
+        "On-chain dependency `{name}` cannot specify `use-environment`. On-chain packages \
+         use a fixed environment."
+    )]
+    OnChainWithUseEnvironment { name: PackageName },
+
+    #[error(
         "On-chain dependency `{name}` requires an address. Add a `[dep-replacements]` entry \
          with `on-chain = \"0x...\"`."
     )]

--- a/external-crates/move/crates/move-package-alt/src/package/package_impl.rs
+++ b/external-crates/move/crates/move-package-alt/src/package/package_impl.rs
@@ -77,7 +77,7 @@ impl<F: MoveFlavor> Package<F> {
     ) -> PackageResult<Self> {
         debug!("loading package {:?}", dep);
         let flavor = &*config.flavor;
-        let path = fetch::fetch(&dep, config.allow_dirty, &config.chain_id).await?;
+        let path = fetch::fetch(&dep, env, config).await?;
 
         // try to load a legacy manifest (with an `[addresses]` section)
         //   - if it fails, load a modern manifest (and return any errors)
@@ -404,7 +404,10 @@ fn check_for_environment<F: MoveFlavor>(
 #[cfg(test)]
 mod tests {
     use crate::{
-        flavor::vanilla::{DEFAULT_ENV_ID, DEFAULT_ENV_NAME, Vanilla},
+        flavor::{
+            OnChainPackageData,
+            vanilla::{DEFAULT_ENV_ID, DEFAULT_ENV_NAME, Vanilla},
+        },
         schema::{
             LocalDepInfo, LockfileDependencyInfo, PublishAddresses, PublishedID,
             ReplacementDependency, SystemDepName,
@@ -490,6 +493,13 @@ mod tests {
 
         fn is_system_address(&self, _: &OriginalID) -> bool {
             false
+        }
+
+        async fn fetch_onchain_package(
+            &self,
+            _address: &PublishedID,
+        ) -> anyhow::Result<OnChainPackageData> {
+            anyhow::bail!("on-chain fetching not supported in TestFlavor")
         }
     }
 

--- a/external-crates/move/crates/move-package-alt/src/package/package_impl.rs
+++ b/external-crates/move/crates/move-package-alt/src/package/package_impl.rs
@@ -77,7 +77,7 @@ impl<F: MoveFlavor> Package<F> {
     ) -> PackageResult<Self> {
         debug!("loading package {:?}", dep);
         let flavor = &*config.flavor;
-        let path = fetch::fetch(&dep, env, config).await?;
+        let path = fetch::fetch(&dep, config).await?;
 
         // try to load a legacy manifest (with an `[addresses]` section)
         //   - if it fails, load a modern manifest (and return any errors)

--- a/external-crates/move/crates/move-package-alt/src/package/package_loader.rs
+++ b/external-crates/move/crates/move-package-alt/src/package/package_loader.rs
@@ -48,10 +48,6 @@ pub struct PackageConfig<F: MoveFlavor> {
 
     /// The flavor instance for flavor-specific operations (system deps, on-chain fetching, etc.)
     pub flavor: Arc<F>,
-
-    /// Root directory for caching fetched dependencies (git checkouts, on-chain packages).
-    /// Defaults to `~/.move` (the value of the `MOVE_HOME` environment variable).
-    pub move_home: PathBuf,
 }
 
 #[derive(Clone, Debug)]
@@ -107,7 +103,6 @@ impl<F: MoveFlavor> PackageLoader<F> {
             ignore_digests: false,
             allow_dirty: false,
             flavor: flavor.into(),
-            move_home: PathBuf::from(move_command_line_common::env::MOVE_HOME.as_str()),
         };
         Self { config }
     }
@@ -164,10 +159,6 @@ impl<F: MoveFlavor> PackageLoader<F> {
     pub(crate) fn config(&self) -> &PackageConfig<F> {
         &self.config
     }
-
-    pub(crate) fn config_mut(&mut self) -> &mut PackageConfig<F> {
-        &mut self.config
-    }
 }
 
 impl<F: MoveFlavor> PackageConfig<F> {
@@ -187,7 +178,6 @@ impl<F: MoveFlavor> PackageConfig<F> {
             ignore_digests: false,
             allow_dirty: false,
             flavor,
-            move_home: PathBuf::from(move_command_line_common::env::MOVE_HOME.as_str()),
         }
     }
 }

--- a/external-crates/move/crates/move-package-alt/src/package/package_loader.rs
+++ b/external-crates/move/crates/move-package-alt/src/package/package_loader.rs
@@ -48,6 +48,10 @@ pub struct PackageConfig<F: MoveFlavor> {
 
     /// The flavor instance for flavor-specific operations (system deps, on-chain fetching, etc.)
     pub flavor: Arc<F>,
+
+    /// Root directory for caching fetched dependencies (git checkouts, on-chain packages).
+    /// Defaults to `~/.move` (the value of the `MOVE_HOME` environment variable).
+    pub move_home: PathBuf,
 }
 
 #[derive(Clone, Debug)]
@@ -103,6 +107,7 @@ impl<F: MoveFlavor> PackageLoader<F> {
             ignore_digests: false,
             allow_dirty: false,
             flavor: flavor.into(),
+            move_home: PathBuf::from(move_command_line_common::env::MOVE_HOME.as_str()),
         };
         Self { config }
     }
@@ -159,6 +164,10 @@ impl<F: MoveFlavor> PackageLoader<F> {
     pub(crate) fn config(&self) -> &PackageConfig<F> {
         &self.config
     }
+
+    pub(crate) fn config_mut(&mut self) -> &mut PackageConfig<F> {
+        &mut self.config
+    }
 }
 
 impl<F: MoveFlavor> PackageConfig<F> {
@@ -178,6 +187,7 @@ impl<F: MoveFlavor> PackageConfig<F> {
             ignore_digests: false,
             allow_dirty: false,
             flavor,
+            move_home: PathBuf::from(move_command_line_common::env::MOVE_HOME.as_str()),
         }
     }
 }

--- a/external-crates/move/crates/move-package-alt/src/package/package_lock.rs
+++ b/external-crates/move/crates/move-package-alt/src/package/package_lock.rs
@@ -7,6 +7,7 @@ use tracing::debug;
 
 use crate::git::get_cache_path;
 use crate::logging::user_error;
+use crate::schema::PublishedID;
 
 #[derive(Debug, Error)]
 pub enum LockError {
@@ -40,6 +41,17 @@ impl PackageSystemLock {
         let path = cache_path_for(repo_id)?;
         Self::new_for_path(&path, true).map_err(|source| LockError::CacheLockError {
             name: repo_id.to_string(),
+            path,
+            source,
+        })
+    }
+
+    /// Acquire a lock for fetching an on-chain package. Keyed by chain ID and address.
+    pub fn new_for_onchain(chain_id: &str, address: &PublishedID) -> LockResult<Self> {
+        let key = format!("onchain_{chain_id}_{address}");
+        let path = cache_path_for(&key)?;
+        Self::new_for_path(&path, true).map_err(|source| LockError::CacheLockError {
+            name: key,
             path,
             source,
         })

--- a/external-crates/move/crates/move-package-alt/src/package/root_package.rs
+++ b/external-crates/move/crates/move-package-alt/src/package/root_package.rs
@@ -617,6 +617,7 @@ pkg_b = { local = "../pkg_b" }"#,
         // WARNING! If you change these digests, make sure you know what you are doing! If the
         // computed digests change, it means that all packages will be repinned! (made this not a
         // snapshot test to avoid accidental updating)
+        // See DVX-2125 for decoupling digest computation from serialization.
         assert_eq!(
             lockfile,
             indoc::indoc!(

--- a/external-crates/move/crates/move-package-alt/src/schema/manifest.rs
+++ b/external-crates/move/crates/move-package-alt/src/schema/manifest.rs
@@ -10,7 +10,7 @@ use crate::compatibility::legacy::LegacyData;
 
 use super::{
     EnvironmentName, LocalDepInfo, OnChainAddress, OnChainPlaceholder, PackageName,
-    PublishAddresses, ResolverName,
+    PublishAddresses, RenderToml, ResolverName,
 };
 
 /// The on-chain identifier for an environment (such as a chain ID); these are bound to environment
@@ -174,6 +174,83 @@ impl ReplacementDependency {
             use_environment: None,
         }
     }
+}
+
+impl RenderToml for ParsedManifest {
+    /// Render as TOML suitable for parsing back. Uses `toml_edit::ser` for most fields,
+    /// but renders dep-replacements manually because `ManifestDependencyInfo`'s derived
+    /// `Serialize` doesn't match its custom `Deserialize` (see DVX-2125).
+    fn render_as_toml(&self) -> String {
+        // Serialize with empty dep-replacements to avoid the broken serializer
+        let without_deps = ParsedManifest {
+            dep_replacements: BTreeMap::new(),
+            ..self.clone()
+        };
+        let mut doc = toml_edit::ser::to_document(&without_deps).expect("can serialize manifest");
+
+        // Render dep-replacements manually with correct format
+        if !self.dep_replacements.is_empty() {
+            let mut all_replacements = toml_edit::Table::new();
+            for (env_name, deps) in &self.dep_replacements {
+                let mut env_table = toml_edit::Table::new();
+                for (dep_name, replacement) in deps {
+                    let inline = render_replacement(replacement.as_ref());
+                    env_table.insert(
+                        dep_name.as_str(),
+                        toml_edit::Item::Value(toml_edit::Value::InlineTable(inline)),
+                    );
+                }
+                all_replacements.insert(env_name, toml_edit::Item::Table(env_table));
+            }
+            doc.insert("dep-replacements", toml_edit::Item::Table(all_replacements));
+        }
+
+        doc.to_string()
+    }
+}
+
+/// Render a single dep-replacement entry as an inline table.
+fn render_replacement(dep: &ReplacementDependency) -> toml_edit::InlineTable {
+    let mut table = toml_edit::InlineTable::new();
+
+    if let Some(ref d) = dep.dependency {
+        match &d.dependency_info {
+            ManifestDependencyInfo::OnChain(addr) => {
+                table.insert("on-chain", addr.on_chain.to_string().into());
+            }
+            ManifestDependencyInfo::OnChainPlaceholder(placeholder) => {
+                let val: bool = placeholder.on_chain.clone().into();
+                table.insert("on-chain", val.into());
+            }
+            ManifestDependencyInfo::Local(loc) => {
+                table.insert("local", loc.local.to_string_lossy().to_string().into());
+            }
+            ManifestDependencyInfo::Git(git) => {
+                table.insert("git", git.repo.clone().into());
+                if let Some(ref rev) = git.rev {
+                    table.insert("rev", rev.clone().into());
+                }
+            }
+            ManifestDependencyInfo::System(sys) => {
+                table.insert("system", sys.system.clone().into());
+            }
+            ManifestDependencyInfo::External(_) => {
+                // External deps have complex serialization; skip for now
+            }
+        }
+        if d.is_override {
+            table.insert("override", true.into());
+        }
+        if let Some(ref rename) = d.rename_from {
+            table.insert("rename-from", rename.as_str().into());
+        }
+    }
+
+    if let Some(ref env) = dep.use_environment {
+        table.insert("use-environment", env.clone().into());
+    }
+
+    table
 }
 
 impl<'de> Deserialize<'de> for ManifestDependencyInfo {

--- a/external-crates/move/crates/move-package-alt/src/schema/manifest.rs
+++ b/external-crates/move/crates/move-package-alt/src/schema/manifest.rs
@@ -25,7 +25,10 @@ pub type SystemDepName = String;
 
 // Note: [Manifest] objects should not be mutated or serialized; they are user-defined files so
 // tools that write them should use [toml_edit] to set / preserve the formatting. However, we do
-// implement [Serialize] and provide [render_as_toml], primarily for generating tests
+// implement [Serialize] and provide [render_as_toml], primarily for generating tests.
+// WARNING: the derived Serialize for ManifestDependencyInfo does not match its custom
+// Deserialize — serialized manifests won't round-trip. The digest computation depends on
+// the current format, so don't change it without also fixing DVX-2125.
 #[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct ParsedManifest {

--- a/external-crates/move/crates/move-package-alt/src/test_utils/graph_builder.rs
+++ b/external-crates/move/crates/move-package-alt/src/test_utils/graph_builder.rs
@@ -181,16 +181,15 @@ impl OnChainPkgSpec {
         Self {
             original_id: OriginalID(address.0),
             address,
-            modules: BTreeMap::from([("module".into(), vec![0xCA, 0xFE])]),
+            modules: BTreeMap::new(),
             dependencies: BTreeMap::new(),
             version: 1,
         }
     }
 
-    /// Set the bytecode modules (name → bytes).
-    pub fn modules(mut self, modules: BTreeMap<String, Vec<u8>>) -> Self {
-        self.modules = modules;
-        self
+    /// Add a module by loading bytecode from a `.mv` file in `tests/data/`.
+    pub fn module(self, _name: &str, _mv_file: &str) -> Self {
+        todo!("load .mv bytecode from tests/data/")
     }
 
     /// Add a linkage table entry: this on-chain package depends on `linked` at `original`.

--- a/external-crates/move/crates/move-package-alt/src/test_utils/graph_builder.rs
+++ b/external-crates/move/crates/move-package-alt/src/test_utils/graph_builder.rs
@@ -222,8 +222,6 @@ pub struct Scenario {
     root_path: PathBuf,
     tempdir: Option<TempDir>,
     vanilla: Vanilla,
-    /// Override for `move_home` in `PackageConfig`, so on-chain caches go to a temp dir.
-    move_home: PathBuf,
 }
 
 impl TestPackageGraph {
@@ -422,14 +420,10 @@ impl TestPackageGraph {
             vanilla = vanilla.with_on_chain_package(address, data);
         }
 
-        let move_home = root_path.join(".move_home");
-        std::fs::create_dir_all(&move_home).unwrap();
-
         Scenario {
             tempdir,
             root_path,
             vanilla,
-            move_home,
         }
     }
 
@@ -922,7 +916,6 @@ impl Scenario {
         )
         .config()
         .clone();
-        config.move_home = self.move_home.clone();
 
         let mtx = path.lock().unwrap();
 
@@ -967,13 +960,13 @@ impl Scenario {
         package: impl AsRef<str>,
         config: impl Fn(PackageLoader<Vanilla>) -> PackageLoader<Vanilla>,
     ) -> PackageResult<RootPackage<Vanilla>> {
-        let mut loader = PackageLoader::new(
+        config(PackageLoader::new(
             self.path_for(package),
             Vanilla::default_environment(),
             self.vanilla.clone(),
-        );
-        loader.config_mut().move_home = self.move_home.clone();
-        config(loader).load().await
+        ))
+        .load()
+        .await
     }
 
     pub fn read_file(&self, file: impl AsRef<Path>) -> String {

--- a/external-crates/move/crates/move-package-alt/src/test_utils/graph_builder.rs
+++ b/external-crates/move/crates/move-package-alt/src/test_utils/graph_builder.rs
@@ -81,6 +81,8 @@ pub struct TestPackageGraph {
     inner: DiGraph<PackageSpec, DepSpec>,
     nodes: BTreeMap<String, NodeIndex>,
     root: Option<PathBuf>,
+    /// On-chain packages to register with Vanilla for testing.
+    on_chain_pkgs: Vec<(PublishedID, crate::flavor::OnChainPackageData)>,
 }
 
 /// Information used to build a node in the package graph
@@ -174,6 +176,9 @@ pub struct PubSpec {
 pub struct Scenario {
     root_path: PathBuf,
     tempdir: Option<TempDir>,
+    vanilla: Vanilla,
+    /// Override for `move_home` in `PackageConfig`, so on-chain caches go to a temp dir.
+    move_home: PathBuf,
 }
 
 impl TestPackageGraph {
@@ -185,6 +190,7 @@ impl TestPackageGraph {
             inner,
             nodes,
             root: None,
+            on_chain_pkgs: Vec::new(),
         };
         result.add_packages(node_names)
     }
@@ -302,6 +308,29 @@ impl TestPackageGraph {
         self
     }
 
+    /// Register an on-chain package with the given `address`, bytecode `modules`, and linkage
+    /// table `dependencies`. The package data will be available via `Vanilla::fetch_onchain_package`
+    /// in tests that use this scenario.
+    pub fn add_on_chain_pkg(
+        mut self,
+        address: PublishedID,
+        modules: BTreeMap<String, Vec<u8>>,
+        dependencies: BTreeMap<OriginalID, PublishedID>,
+        original_id: OriginalID,
+        version: u64,
+    ) -> Self {
+        self.on_chain_pkgs.push((
+            address,
+            crate::flavor::OnChainPackageData {
+                modules,
+                dependencies,
+                original_id,
+                version,
+            },
+        ));
+        self
+    }
+
     pub fn at(mut self, path: impl AsRef<Path>) -> Self {
         self.root = Some(path.as_ref().to_path_buf());
         self
@@ -346,7 +375,20 @@ impl TestPackageGraph {
             }
         }
 
-        Scenario { tempdir, root_path }
+        let mut vanilla = Vanilla::new();
+        for (address, data) in self.on_chain_pkgs {
+            vanilla = vanilla.with_on_chain_package(address, data);
+        }
+
+        let move_home = root_path.join(".move_home");
+        std::fs::create_dir_all(&move_home).unwrap();
+
+        Scenario {
+            tempdir,
+            root_path,
+            vanilla,
+            move_home,
+        }
     }
 
     /// Return the contents of a `Move.toml` file for the package represented by `node`
@@ -831,13 +873,14 @@ impl Scenario {
     ) -> PackageResult<PackageGraph<Vanilla>> {
         let path = PackagePath::new(self.path_for(&package)).unwrap();
 
-        let config = PackageLoader::new(
+        let mut config = PackageLoader::new(
             self.path_for(&package),
             Vanilla::default_environment(),
-            Vanilla::new(),
+            self.vanilla.clone(),
         )
         .config()
         .clone();
+        config.move_home = self.move_home.clone();
 
         let mtx = path.lock().unwrap();
 
@@ -882,13 +925,13 @@ impl Scenario {
         package: impl AsRef<str>,
         config: impl Fn(PackageLoader<Vanilla>) -> PackageLoader<Vanilla>,
     ) -> PackageResult<RootPackage<Vanilla>> {
-        config(PackageLoader::new(
+        let mut loader = PackageLoader::new(
             self.path_for(package),
             Vanilla::default_environment(),
-            Vanilla::new(),
-        ))
-        .load()
-        .await
+            self.vanilla.clone(),
+        );
+        loader.config_mut().move_home = self.move_home.clone();
+        config(loader).load().await
     }
 
     pub fn read_file(&self, file: impl AsRef<Path>) -> String {

--- a/external-crates/move/crates/move-package-alt/src/test_utils/graph_builder.rs
+++ b/external-crates/move/crates/move-package-alt/src/test_utils/graph_builder.rs
@@ -166,6 +166,52 @@ pub struct DepSpec {
     modes: Option<Vec<ModeName>>,
 }
 
+/// Builder for on-chain package test data registered via
+/// [`TestPackageGraph::add_on_chain_pkg`].
+pub struct OnChainPkgSpec {
+    address: PublishedID,
+    modules: BTreeMap<String, Vec<u8>>,
+    dependencies: BTreeMap<OriginalID, PublishedID>,
+    original_id: OriginalID,
+    version: u64,
+}
+
+impl OnChainPkgSpec {
+    fn new(address: PublishedID) -> Self {
+        Self {
+            original_id: OriginalID(address.0),
+            address,
+            modules: BTreeMap::from([("module".into(), vec![0xCA, 0xFE])]),
+            dependencies: BTreeMap::new(),
+            version: 1,
+        }
+    }
+
+    /// Set the bytecode modules (name → bytes).
+    pub fn modules(mut self, modules: BTreeMap<String, Vec<u8>>) -> Self {
+        self.modules = modules;
+        self
+    }
+
+    /// Add a linkage table entry: this on-chain package depends on `linked` at `original`.
+    pub fn dep(mut self, original: OriginalID, linked: PublishedID) -> Self {
+        self.dependencies.insert(original, linked);
+        self
+    }
+
+    /// Set the original (runtime) ID if it differs from the address.
+    pub fn original_id(mut self, id: OriginalID) -> Self {
+        self.original_id = id;
+        self
+    }
+
+    /// Set the on-chain version.
+    pub fn version(mut self, version: u64) -> Self {
+        self.version = version;
+        self
+    }
+}
+
 /// Information about a publication
 pub struct PubSpec {
     chain_id: EnvironmentID,
@@ -308,24 +354,21 @@ impl TestPackageGraph {
         self
     }
 
-    /// Register an on-chain package with the given `address`, bytecode `modules`, and linkage
-    /// table `dependencies`. The package data will be available via `Vanilla::fetch_onchain_package`
-    /// in tests that use this scenario.
+    /// Register an on-chain package at `address`. The `build` closure configures the
+    /// package's bytecode, linkage table, and version via [`OnChainPkgSpec`].
     pub fn add_on_chain_pkg(
         mut self,
         address: PublishedID,
-        modules: BTreeMap<String, Vec<u8>>,
-        dependencies: BTreeMap<OriginalID, PublishedID>,
-        original_id: OriginalID,
-        version: u64,
+        build: impl FnOnce(OnChainPkgSpec) -> OnChainPkgSpec,
     ) -> Self {
+        let spec = build(OnChainPkgSpec::new(address.clone()));
         self.on_chain_pkgs.push((
             address,
             crate::flavor::OnChainPackageData {
-                modules,
-                dependencies,
-                original_id,
-                version,
+                modules: spec.modules,
+                dependencies: spec.dependencies,
+                original_id: spec.original_id,
+                version: spec.version,
             },
         ));
         self


### PR DESCRIPTION
## Summary

Implements on-chain package fetching and manifest generation for move-package-alt,
stacked on #26552 (on-chain pinning v2) and #26562 (Vanilla::new refactor).

- **`OnChainPackageData`** type and **`fetch_onchain_package`** trait method on `MoveFlavor`
  - Vanilla: looks up from pre-populated test data map
  - SuiFlavor: fetches via gRPC `get_object`, extracts `MovePackage` fields
- **`on_chain` module** (parallel to `git`): fetches bytecode, generates `Move.toml` and
  `Published.toml` in `~/.move/on-chain/<chain_id>/<address>/`
- **Fixed `_on_chain` environment**: generated manifests use a single environment name,
  avoiding per-package environment name conflicts. `use_environment` is forced during combining.
- **`OnChainError`** error type, **`PackageSystemLock::new_for_onchain`** for FS locking
- **Skip rename-from** for on-chain deps (synthetic `name = "self"`)
- **`add_on_chain_pkg`** on `TestPackageGraph` with `OnChainPkgSpec` builder
- **`write_source`** stub for future stub generation integration

### Known limitations
- System packages in linkage tables are fetched on-chain instead of using source deps (DVX-2126)
- Manifest serialization uses hybrid approach due to DVX-2125
- On-chain cache uses global `MOVE_HOME`; per-test isolation deferred (DVX-2127)
- Full pipeline requires stub source generation (PR #26555)

## Test plan

- [x] 192 tests pass (8 new + 184 existing), clippy/fmt clean
- [x] Unit tests: bytecode write, manifest generation (with/without deps), Published.toml, round-trip
- [x] Integration: transitive on-chain deps, rename-from skip
- [x] Ignored test documenting expected deduplication behavior (DVX-2126)
- [ ] Shell tests in sui crate (deferred — blocked on system package handling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)