### PR TITLE
sui-tool: add --metrics-port flag to download-formal-snapshot

### DIFF
--- a/crates/sui-tool/src/commands.rs
+++ b/crates/sui-tool/src/commands.rs
@@ -343,6 +343,9 @@ pub enum ToolCommand {
         /// Defaults to 3 retries. Set to 0 to disable retries.
         #[clap(long = "max-retries", default_value = "3")]
         max_retries: usize,
+        /// Port for the Prometheus metrics server. Defaults to 9184.
+        #[clap(long = "metrics-port", default_value = "9184")]
+        metrics_port: u16,
     },
 
     #[clap(name = "replay")]
@@ -659,6 +662,7 @@ impl ToolCommand {
                 latest,
                 verbose,
                 max_retries,
+                metrics_port,
             } => {
                 if !verbose {
                     tracing_handle
@@ -788,6 +792,7 @@ impl ToolCommand {
                     network,
                     verify,
                     max_retries,
+                    metrics_port,
                 )
                 .await?;
             }

--- a/crates/sui-tool/src/lib.rs
+++ b/crates/sui-tool/src/lib.rs
@@ -9,6 +9,7 @@ use futures::future::join_all;
 use itertools::Itertools;
 use std::collections::BTreeMap;
 use std::fmt::Write;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -789,6 +790,7 @@ pub async fn download_formal_snapshot(
     network: Chain,
     verify: SnapshotVerifyMode,
     max_retries: usize,
+    metrics_port: u16,
 ) -> Result<(), anyhow::Error> {
     let m = MultiProgress::new();
     let msg = format!(
@@ -804,8 +806,8 @@ pub async fn download_formal_snapshot(
     }
 
     // Start prometheus server so that we can serve metrics during snapshot download
-    let registry_service =
-        mysten_metrics::start_prometheus_server("127.0.0.1:9184".parse().unwrap());
+    let metrics_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), metrics_port);
+    let registry_service = mysten_metrics::start_prometheus_server(metrics_addr);
     let prometheus_registry = registry_service.default_registry();
     DBMetrics::init(registry_service.clone());
     mysten_metrics::init_metrics(&prometheus_registry);


### PR DESCRIPTION
## Summary

`download_formal_snapshot` in `crates/sui-tool/src/lib.rs` currently binds its prometheus metrics server to a hardcoded `127.0.0.1:9184`. This conflicts with:

- Running on a host where a validator is already bound to 9184 (the validator's own prometheus endpoint).
- Running multiple snapshot downloads in parallel on the same host.

This PR adds `--metrics-port <u16>` to `sui-tool download-formal-snapshot`, defaulting to 9184 so existing invocations are unchanged.

## Test plan

- [ ] `cargo check -p sui-tool` passes
- [ ] `sui-tool download-formal-snapshot --help` shows the new flag with default 9184
- [ ] Running the command without the flag continues to bind 9184 as before
- [ ] Running with `--metrics-port 9999` binds 9999 instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)