### PR TITLE
sui-indexer-alt-consistent-store: support restoring from arbitrary epoch directories

### DIFF
--- a/crates/sui-indexer-alt-consistent-store/src/restore/formal_snapshot.rs
+++ b/crates/sui-indexer-alt-consistent-store/src/restore/formal_snapshot.rs
@@ -51,7 +51,7 @@ pub struct FormalSnapshotArgs {
 
     /// Fetch formal snapshot from local filesystem. Provide the path to the snapshot directory.
     #[arg(long, group = "source")]
-    pub path: Option<PathBuf>,
+    pub local: Option<PathBuf>,
 
     /// URL of the remote checkpoint store. Used to fetch the mapping between epochs and
     /// checkpoints.
@@ -59,8 +59,16 @@ pub struct FormalSnapshotArgs {
     pub remote_store_url: Url,
 
     /// The epoch to restore from. Restores from the latest epoch if not specified.
-    #[arg(long)]
+    #[arg(long, conflicts_with = "path")]
     pub epoch: Option<u64>,
+
+    /// Path within the storage source pointing directly at an epoch directory
+    /// (e.g. `archive/epoch_600`). When supplied, the tool skips reading the
+    /// root `MANIFEST` and the per-epoch `_SUCCESS` marker — the operator vouches
+    /// for the snapshot being complete. The epoch number is parsed from the
+    /// trailing `epoch_<N>` path component.
+    #[arg(long, conflicts_with = "epoch")]
+    pub path: Option<String>,
 }
 
 /// Interface over a formal snapshot at a specific epoch.
@@ -69,14 +77,19 @@ pub(super) struct FormalSnapshot {
     /// The source of files related to the formal snapshot.
     source: Arc<dyn Storage + Send + Sync + 'static>,
 
+    epoch_dir: String,
+
     /// The point in time this snapshot is from.
     watermark: Watermark,
 }
 
 impl FormalSnapshot {
-    /// Establish a connection to a formal snapshot source, and validate that it can serve data for
-    /// a formal snapshot at the specified epoch (or the latest available epoch if none is
-    /// specified).
+    /// Establish a connection to a formal snapshot for a specific epoch.
+    ///
+    /// When `--path` is supplied, the operator names the epoch directory directly.
+    /// Otherwise the source's root `MANIFEST` is consulted to validate the epoch
+    /// and a `_SUCCESS` marker is checked; if no epoch is supplied, the latest in
+    /// the manifest is used.
     pub(super) async fn new(
         snapshot_args: FormalSnapshotArgs,
         connection_args: StorageConnectionArgs,
@@ -108,42 +121,56 @@ impl FormalSnapshot {
         } else if let Some(endpoint) = snapshot_args.http {
             info!(endpoint = %endpoint, "HTTP storage");
             HttpStorage::new(endpoint, connection_args).map(Arc::new)?
-        } else if let Some(path) = snapshot_args.path {
+        } else if let Some(path) = snapshot_args.local {
             info!(path = %path.display(), "Directory storage");
             LocalFileSystem::new_with_prefix(path).map(Arc::new)?
         } else {
             bail!("No formal snapshot source provided");
         };
 
-        // Fetch details about all the epochs it has available, and use that to confirm and
-        // validate the epoch to restore from (it is available and complete at the source).
-        let root_manifest = RootManifest::read(
-            store
-                .get("MANIFEST".into())
+        let (epoch, epoch_dir) = if let Some(path) = snapshot_args.path {
+            let basename = path.rsplit('/').next().unwrap_or(&path);
+            let epoch = basename
+                .strip_prefix("epoch_")
+                .and_then(|s| s.parse::<u64>().ok())
+                .with_context(|| {
+                    format!(
+                        "Failed to parse epoch number from --path: {path:?}. \
+                         Expected the trailing component to be `epoch_<N>`."
+                    )
+                })?;
+            (epoch, path)
+        } else {
+            let root_manifest = RootManifest::read(
+                store
+                    .get("MANIFEST".into())
+                    .await
+                    .context("Failed to fetch root manifest")?
+                    .as_ref(),
+            )?;
+
+            let epoch = snapshot_args
+                .epoch
+                .or_else(|| root_manifest.latest())
+                .context("No epochs available in the snapshot store")?;
+
+            ensure!(
+                root_manifest.contains(epoch),
+                "Requested epoch {epoch} is not available in the snapshot store",
+            );
+
+            let epoch_dir = format!("epoch_{epoch}");
+            let is_complete = store
+                .get(format!("{epoch_dir}/_SUCCESS").into())
                 .await
-                .context("Failed to fetch root manifest")?
-                .as_ref(),
-        )?;
+                .is_ok();
 
-        // If an epoch has not been specified, restore from the latest available epoch.
-        let epoch = snapshot_args
-            .epoch
-            .or_else(|| root_manifest.latest())
-            .context("No epochs available in the snapshot store")?;
+            ensure!(is_complete, "Snapshot for epoch {epoch} is not complete");
 
-        ensure!(
-            root_manifest.contains(epoch),
-            "Requested epoch {epoch} is not available in the snapshot store",
-        );
+            (epoch, epoch_dir)
+        };
 
-        let is_complete = store
-            .get(format!("epoch_{epoch}/_SUCCESS").into())
-            .await
-            .is_ok();
-
-        ensure!(is_complete, "Snapshot for epoch {epoch} is not complete");
-
-        info!(epoch, "Connected to valid formal snapshot");
+        info!(epoch, epoch_dir, "Connected to valid formal snapshot");
 
         // Use the remote store to associate the epoch with a watermark pointing to its last
         // transaction. We only use `end_of_epoch_checkpoints` here, so no byte counter is needed.
@@ -188,6 +215,7 @@ impl FormalSnapshot {
 
         Ok(Self {
             source: store,
+            epoch_dir,
             watermark,
         })
     }
@@ -199,7 +227,7 @@ impl FormalSnapshot {
 
     /// Load the manifest for this snapshot, detailing all its files.
     pub(super) async fn manifest(&self) -> anyhow::Result<Bytes> {
-        let path = format!("epoch_{}/MANIFEST", self.watermark.epoch_hi_inclusive);
+        let path = format!("{}/MANIFEST", self.epoch_dir);
 
         self.source
             .get(path.into())
@@ -215,8 +243,8 @@ impl FormalSnapshot {
         };
 
         let path = format!(
-            "epoch_{}/{}_{}.{ext}",
-            self.watermark.epoch_hi_inclusive, metadata.bucket, metadata.partition
+            "{}/{}_{}.{ext}",
+            self.epoch_dir, metadata.bucket, metadata.partition
         );
 
         self.source

--- a/crates/sui-indexer-alt-consistent-store/src/restore/formal_snapshot.rs
+++ b/crates/sui-indexer-alt-consistent-store/src/restore/formal_snapshot.rs
@@ -59,15 +59,17 @@ pub struct FormalSnapshotArgs {
     pub remote_store_url: Url,
 
     /// The epoch to restore from. Restores from the latest epoch if not specified.
-    #[arg(long, conflicts_with = "path")]
+    /// Required when `--path` is set, since the per-prefix layout may not include
+    /// a `MANIFEST` to discover the latest epoch.
+    #[arg(long)]
     pub epoch: Option<u64>,
 
-    /// Path within the storage source pointing directly at an epoch directory
-    /// (e.g. `archive/epoch_600`). When supplied, the tool skips reading the
-    /// root `MANIFEST` and the per-epoch `_SUCCESS` marker — the operator vouches
-    /// for the snapshot being complete. The epoch number is parsed from the
-    /// trailing `epoch_<N>` path component.
-    #[arg(long, conflicts_with = "epoch")]
+    /// Path prefix within the storage source containing per-epoch subdirectories.
+    /// When supplied, the tool looks for `<path>/epoch_<N>/` (with `<N>` from
+    /// `--epoch`) and skips reading the root `MANIFEST` and the per-epoch
+    /// `_SUCCESS` marker — the operator vouches for the snapshot being complete.
+    /// Requires `--epoch`.
+    #[arg(long, requires = "epoch")]
     pub path: Option<String>,
 }
 
@@ -86,10 +88,11 @@ pub(super) struct FormalSnapshot {
 impl FormalSnapshot {
     /// Establish a connection to a formal snapshot for a specific epoch.
     ///
-    /// When `--path` is supplied, the operator names the epoch directory directly.
-    /// Otherwise the source's root `MANIFEST` is consulted to validate the epoch
-    /// and a `_SUCCESS` marker is checked; if no epoch is supplied, the latest in
-    /// the manifest is used.
+    /// When `--path` is supplied, the epoch directory is taken to be
+    /// `<path>/epoch_<epoch>` and the root `MANIFEST` / `_SUCCESS` checks are
+    /// skipped. Otherwise the source's root `MANIFEST` is consulted to validate
+    /// the epoch and a `_SUCCESS` marker is checked; if no epoch is supplied,
+    /// the latest in the manifest is used.
     pub(super) async fn new(
         snapshot_args: FormalSnapshotArgs,
         connection_args: StorageConnectionArgs,
@@ -129,17 +132,10 @@ impl FormalSnapshot {
         };
 
         let (epoch, epoch_dir) = if let Some(path) = snapshot_args.path {
-            let basename = path.rsplit('/').next().unwrap_or(&path);
-            let epoch = basename
-                .strip_prefix("epoch_")
-                .and_then(|s| s.parse::<u64>().ok())
-                .with_context(|| {
-                    format!(
-                        "Failed to parse epoch number from --path: {path:?}. \
-                         Expected the trailing component to be `epoch_<N>`."
-                    )
-                })?;
-            (epoch, path)
+            let epoch = snapshot_args
+                .epoch
+                .expect("clap requires --epoch when --path is set");
+            (epoch, format!("{path}/epoch_{epoch}"))
         } else {
             let root_manifest = RootManifest::read(
                 store


### PR DESCRIPTION
## Summary

Closes #26563.

The `restore formal-snapshot` flow currently assumes a fixed layout at the storage source: a root `MANIFEST` enumerating epochs, an `epoch_<N>/` directory per epoch, and a `_SUCCESS` marker confirming each epoch is complete. That works for the live snapshots at the bucket root of `gs://mysten-mainnet-formal/` but not for the historical archive under `gs://mysten-mainnet-formal/archive/`, which ships none of those markers and isn't at the bucket root. There's no other public source for the historical epochs.

This PR follows the design from #26563 (revised per review feedback):

- Adds a new `--path <prefix>` flag pointing at a path prefix inside the storage source that contains per-epoch subdirectories. The tool then looks for `<path>/epoch_<N>/`, with `<N>` from `--epoch`.
- When `--path` is supplied, the tool skips the root `MANIFEST` and per-epoch `_SUCCESS` lookups — the operator vouches for the snapshot being complete.
- `--path` requires `--epoch` (since the prefix layout may not include a `MANIFEST` to discover the latest epoch).
- When `--path` is not set, behaviour is unchanged.
- The previous `--path` flag (which configured the local filesystem source) is renamed to `--local`.

Example:

```
sui-indexer-alt-consistent-store restore \
  --gcs mysten-mainnet-formal \
  --path archive \
  --epoch 600 \
  --remote-store-url https://checkpoints.mainnet.sui.io \
  --pipeline balances
```

All of the new logic is concentrated in `FormalSnapshot::new`. A new `epoch_dir` field on `FormalSnapshot` carries the resolved directory (`epoch_<N>` or `<path>/epoch_<N>`); `manifest()` and `file()` use it directly instead of reconstructing `epoch_<N>` from the watermark.

## Test plan

- [x] `cargo check -p sui-indexer-alt-consistent-store` passes.
- [x] `cargo build -p sui-indexer-alt-consistent-store --release` succeeds.
- [x] `sui-indexer-alt-consistent-store restore --help` shows `--path` and `--local` with correct descriptions and the `--path` → `--epoch` requirement.
- [x] End-to-end against the live bucket: `restore --gcs mysten-mainnet-formal --path archive --epoch 600 --remote-store-url https://checkpoints.mainnet.sui.io --pipeline balances` — the tool resolves `epoch_dir="archive/epoch_600"`, anchors the watermark, reads the per-epoch `MANIFEST` from `gs://mysten-mainnet-formal/archive/epoch_600/MANIFEST`, broadcasts 726 partitions, and the `balances` pipeline worker starts fetching them. Before this PR no flag combination could reach this layout.
- [x] Canonical flow unchanged: `restore --gcs mysten-mainnet-formal --epoch 1070 --remote-store-url ...` exercises the original MANIFEST + `_SUCCESS` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)