### PR TITLE
[pruner] disable object pruner by default on tidehunter validators

### DIFF
--- a/crates/sui-core/src/authority/authority_store_pruner.rs
+++ b/crates/sui-core/src/authority/authority_store_pruner.rs
@@ -841,10 +841,11 @@ impl AuthorityStorePruner {
         #[cfg(tidehunter)]
         {
             if let Some(num_epochs_to_retain) = config.num_epochs_to_retain_for_checkpoints() {
+                let prune_objects = config.num_epochs_to_retain != u64::MAX;
                 tokio::task::spawn(async move {
                     loop {
                         tokio::select! {
-                            _ = objects_prune_interval.tick() => {
+                            _ = objects_prune_interval.tick(), if prune_objects => {
                                 if let Err(err) = Self::prune_objects_for_eligible_epochs(&perpetual_db, &checkpoint_store, rpc_index.as_deref(), config.clone(), metrics.clone(), epoch_duration_ms).await {
                                     error!("Failed to prune objects: {:?}", err);
                                 }
@@ -929,6 +930,20 @@ impl AuthorityStorePruner {
         registry: &Registry,
         pruner_watermarks: Arc<PrunerWatermarks>, // used by tidehunter relocation filters
     ) -> Self {
+        // On tidehunter validators the per-keyspace `objects_compactor`
+        // (see `AuthorityPerpetualTables::open`) already retains only the latest
+        // version per ObjectID during compaction, so running the object pruner
+        // would duplicate that work. Force-disable it regardless of the configured
+        // value.
+        #[cfg(tidehunter)]
+        if is_validator && pruning_config.num_epochs_to_retain != u64::MAX {
+            info!(
+                "Tidehunter validator: disabling object pruner (was num_epochs_to_retain={}). The objects compactor performs equivalent compaction.",
+                pruning_config.num_epochs_to_retain
+            );
+            pruning_config.num_epochs_to_retain = u64::MAX;
+        }
+
         if pruning_config.num_epochs_to_retain > 0 && pruning_config.num_epochs_to_retain < u64::MAX
         {
             warn!(


### PR DESCRIPTION
## Summary

On tidehunter validators, the `objects` keyspace is configured with an `objects_compactor` (`AuthorityPerpetualTables::open` in `authority_store_tables.rs`) that, during compaction, walks each object's key range and **retains only the latest version per `ObjectID`**. That is functionally the same outcome the authority store object pruner achieves by issuing explicit delete batches.

Today both run side-by-side on tidehunter validators:
- compactor: keeps latest version per ObjectID during natural compaction passes
- pruner: walks recent checkpoints' effects and issues `delete_batch` for `modified_at_versions` + `all_tombstones`

That's two ways of doing the same job — wasting CPU, doing extra IO, and (on the pruner side) writing additional tombstones the compactor would have collapsed anyway.

This change makes `AuthorityStorePruner::new` force `num_epochs_to_retain = u64::MAX` for `#[cfg(tidehunter)] && is_validator`, regardless of the configured value. It also gates the tidehunter pruning select arm on `num_epochs_to_retain != u64::MAX`, mirroring the existing rocksdb path so the pruner task simply doesn't tick when disabled.

Non-tidehunter behavior is unchanged. Tidehunter fullnodes (`!is_validator`) are also unchanged (no compactor configured for them).

## Test plan

- [ ] CI clippy passes for both default and `--features typed-store/tidehunter` builds
- [ ] Verify on private-testnet: after deploying, `num_epochs_to_retain_for_objects` metric should report `u64::MAX` and `last_pruned_checkpoint` should stop advancing for objects
- [ ] No regression in objects keyspace size growth (compactor still doing its job)

🤖 Generated with [Claude Code](https://claude.com/claude-code)