### PR TITLE
Add sui-fork to release binaries

### DIFF
--- a/binary-build-list.json
+++ b/binary-build-list.json
@@ -6,6 +6,7 @@
         "sui-faucet",
         "sui-bridge",
         "sui-bridge-cli",
+        "sui-fork",
         "sui-test-validator",
         "move-analyzer"
     ],


### PR DESCRIPTION
## Description 

This PR adds `sui-fork` crate to the binary list so that it can be used from `suiup`.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
