### PR TITLE
release: drop sui-test-validator from release_binaries

### DIFF
--- a/binary-build-list.json
+++ b/binary-build-list.json
@@ -7,7 +7,6 @@
         "sui-bridge",
         "sui-bridge-cli",
         "sui-fork",
-        "sui-test-validator",
         "move-analyzer"
     ],
     "internal_binaries": [


### PR DESCRIPTION
## Summary

- Remove the deprecated \`sui-test-validator\` entry from \`binary-build-list.json\` so \`release.yml\` no longer expects it in S3.
- Closes the \`sui-test-validator\` half of #26412.

## Why

The \`sui-test-validator\` crate was [deprecated in #18515 (July 2024)](https://github.com/MystenLabs/sui/pull/18515). Its entire \`main()\` is a stub that prints "use \`sui start\` instead" — no validator logic remains.

Since #26411 (Apr 28) switched \`release.yml\` to fetch prebuilt Linux binaries from \`s3://sui-releases/<sha>/\`, every entry in \`release_binaries\` must exist in S3. \`sui-test-validator\` is not built by any Dockerfile and not in mp3's \`binary_upload_config\`, so the prebuilt path 404s on every fresh release tag.

Observed failures (no successful devnet release after #26411):

| Release | Result |
|---|---|
| devnet-v1.71.0 (Apr 27) | ❌ missing sui-test-validator, move-analyzer |
| devnet-v1.72.0 (May 11) | ❌ same |

Mainnet/testnet have been skating by because they re-tag a SHA whose tarball was already published, so they short-circuit on \`s3_existing_archive\` and never hit the prebuilt fetch.

## Follow-ups (not in this PR)

- **\`sui-fork\`** — same class of gap (added to \`release_binaries\` in #26570 without a Dockerfile or mp3 wiring). Should be wired through \`docker/sui-tools/Dockerfile\` + mp3 \`binary_upload_config\`, not dropped, since it was added intentionally for \`suiup\`.
- **\`move-analyzer\`** — Dockerfile already added in #26572; mp3 config in [sui-operations#7877](https://github.com/MystenLabs/sui-operations/pull/7877). Both landed today.
- **Stub crate** — leaving \`crates/sui-test-validator/\` and \`scripts/sui-test-validator.sh\` in place per #18515's intent ("keep the binary with a migration message"). Out of scope.

## Test plan

- [ ] Cherry-pick to \`devnet\` to unblock devnet-v1.72.0 re-tag.
- [ ] Confirm next devnet release tag passes the "Download prebuilt binaries from S3" step (will still fail on \`sui-fork\` until that's wired — tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)