### PR TITLE
Avoid intermediate Vec allocation in rejected_transactions_digest

### DIFF
--- a/crates/sui-core/src/consensus_types/consensus_output_api.rs
+++ b/crates/sui-core/src/consensus_types/consensus_output_api.rs
@@ -82,9 +82,8 @@ impl ConsensusCommitAPI for consensus_core::CommittedSubDag {
     }
 
     fn rejected_transactions_digest(&self) -> Digest {
-        let bytes = bcs::to_bytes(&self.rejected_transactions_by_block).unwrap();
         let mut hasher = sui_types::crypto::DefaultHash::new();
-        hasher.update(bytes);
+        bcs::serialize_into(&mut hasher, &self.rejected_transactions_by_block).unwrap();
         hasher.finalize().digest.into()
     }
 


### PR DESCRIPTION
## Summary

`rejected_transactions_digest` builds the BCS bytes into a `Vec<u8>` and then feeds them to the hasher with `update`. Streaming the BCS bytes straight into the hasher with `bcs::serialize_into` skips the intermediate allocation.

```diff
 fn rejected_transactions_digest(&self) -> Digest {
-    let bytes = bcs::to_bytes(&self.rejected_transactions_by_block).unwrap();
     let mut hasher = sui_types::crypto::DefaultHash::new();
-    hasher.update(bytes);
+    bcs::serialize_into(&mut hasher, &self.rejected_transactions_by_block).unwrap();
     hasher.finalize().digest.into()
 }
```

This is the same transformation #26415 applied across other call sites; `consensus_output_api.rs` wasn't in that pass.

The digest output is identical because BCS produces the same byte sequence whether the bytes are buffered first or written incrementally. `DefaultHash` is `Blake2b256`, which already implements `std::io::Write` via fastcrypto's `HashFunctionWrapper`.

The function is called per consensus commit from `ConsensusHandler`, so the saving lands on the hot path.

## Test plan

- `cargo check -p sui-core` and `cargo xclippy` in `crates/sui-core` both clean.
- `cargo test -p sui-core --lib consensus_handler::tests` — 15/15 pass; the existing digest path is exercised through `test_consensus_commit_handler`.

---

## Release notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework: