### PR TITLE
sui-rpc-api: set ValidDuring expiration on gasless simulate path

### DIFF
--- a/crates/sui-e2e-tests/tests/grpc_simulate_gasless_tests.rs
+++ b/crates/sui-e2e-tests/tests/grpc_simulate_gasless_tests.rs
@@ -15,10 +15,11 @@ use sui_rpc::proto::sui::rpc::v2::Transaction;
 use sui_rpc::proto::sui::rpc::v2::transaction_execution_service_client::TransactionExecutionServiceClient;
 use sui_types::SUI_FRAMEWORK_PACKAGE_ID;
 use sui_types::base_types::{ObjectRef, SuiAddress};
+use sui_types::gas_coin::GAS;
 use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
 use sui_types::transaction::{
-    self, GasData, ObjectArg, TransactionData, TransactionDataV1, TransactionExpiration,
-    TransactionKind,
+    self, FundsWithdrawalArg, GasData, ObjectArg, TransactionData, TransactionDataV1,
+    TransactionExpiration, TransactionKind,
 };
 use test_cluster::addr_balance_test_env::{TestEnv, TestEnvBuilder};
 
@@ -86,6 +87,41 @@ fn build_coin_send_funds_tx(
         Identifier::new("send_funds").unwrap(),
         vec![coin_type],
         vec![coin_arg, recipient_arg],
+    );
+    wrap_tx(
+        sender,
+        TransactionKind::ProgrammableTransaction(builder.finish()),
+    )
+}
+
+/// Build a gasless-eligible PTB that withdraws `amount` of `coin_type` from the sender's
+/// address balance and forwards it to `recipient` via `balance::send_funds`. The PTB has *no*
+/// `Coin<T>` object inputs — its only `CallArg`s are a `FundsWithdrawal` and a `Pure` recipient
+/// — so replay protection cannot come from address-owned object inputs and must be supplied by
+/// the transaction's `expiration`.
+fn build_balance_withdrawal_send_funds_tx(
+    sender: SuiAddress,
+    coin_type: TypeTag,
+    amount: u64,
+    recipient: SuiAddress,
+) -> TransactionData {
+    let mut builder = ProgrammableTransactionBuilder::new();
+    let withdraw_arg = FundsWithdrawalArg::balance_from_sender(amount, coin_type.clone());
+    let withdraw_arg = builder.funds_withdrawal(withdraw_arg).unwrap();
+    let balance = builder.programmable_move_call(
+        SUI_FRAMEWORK_PACKAGE_ID,
+        Identifier::new("balance").unwrap(),
+        Identifier::new("redeem_funds").unwrap(),
+        vec![coin_type.clone()],
+        vec![withdraw_arg],
+    );
+    let recipient_arg = builder.pure(recipient).unwrap();
+    builder.programmable_move_call(
+        SUI_FRAMEWORK_PACKAGE_ID,
+        Identifier::new("balance").unwrap(),
+        Identifier::new("send_funds").unwrap(),
+        vec![coin_type],
+        vec![balance, recipient_arg],
     );
     wrap_tx(
         sender,
@@ -257,5 +293,44 @@ async fn simulate_falls_back_to_priced_when_gasless_post_exec_fails() {
         !gas_payment.objects.is_empty(),
         "fallback priced flow must have run gas selection",
     );
+    assert!(returned.effects().status().success());
+}
+
+/// A gasless-eligible PTB whose only `CallArg`s are a `FundsWithdrawal` (withdrawing from the
+/// sender's address balance) and a `Pure` recipient — i.e. it has zero address-owned object
+/// inputs — must still be simulatable. Replay protection in this case can only come from the
+/// transaction's `expiration`, which the caller never sets when going through the unresolved
+/// proto path. The simulate flow therefore needs to fill in a `ValidDuring` expiration before
+/// invoking the executor; otherwise `check_replay_protection` rejects the tx with
+/// "Transactions must either have address-owned inputs, or a ValidDuring expiration".
+#[sim_test]
+async fn simulate_gasless_with_no_address_owned_inputs_succeeds() {
+    let mut test_env = setup_gasless_env().await;
+    let sender = test_env.get_sender(1);
+    let recipient = test_env.get_sender(2);
+
+    let sui_type = GAS::type_tag();
+    transaction::add_gasless_token_for_testing(sui_type.to_canonical_string(true), 0);
+    // Seed sender's SUI address balance. `fund_one_address_balance` updates the gas ref from
+    // the tx effects (rather than the lagging RPC indexer), keeping the env's view in sync.
+    test_env.fund_one_address_balance(sender, 5_000).await;
+
+    let tx = build_balance_withdrawal_send_funds_tx(sender, sui_type, 1_000, recipient);
+
+    let response = connect(&test_env)
+        .await
+        .simulate_transaction(
+            SimulateTransactionRequest::new(to_unresolved_proto(tx, None))
+                .with_do_gas_selection(true),
+        )
+        .await
+        .unwrap()
+        .into_inner();
+
+    let returned = response.transaction();
+    let gas_payment = returned.transaction().gas_payment();
+    assert_eq!(gas_payment.price, Some(0));
+    assert_eq!(gas_payment.budget, Some(0));
+    assert!(gas_payment.objects.is_empty());
     assert!(returned.effects().status().success());
 }

--- a/crates/sui-rpc-api/src/grpc/v2/transaction_execution_service/simulate/mod.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/transaction_execution_service/simulate/mod.rs
@@ -28,6 +28,7 @@ use sui_types::transaction::InputObjectKind;
 use sui_types::transaction::InputObjects;
 use sui_types::transaction::ObjectReadResult;
 use sui_types::transaction::TransactionDataAPI;
+use sui_types::transaction::TransactionExpiration;
 use sui_types::transaction::TransactionKind;
 use sui_types::transaction_executor::SimulateTransactionResult;
 use sui_types::transaction_executor::TransactionChecks;
@@ -113,6 +114,8 @@ pub fn simulate_transaction(
                 let mut gasless_tx = transaction.clone();
                 gasless_tx.gas_data_mut().price = 0;
                 gasless_tx.gas_data_mut().budget = 0;
+                // All gassless txns have to have a correct `ValidDuring` TransactionExpiration.
+                set_valid_during_transaction_expiration(service, &mut gasless_tx)?;
 
                 let simulation_result = executor
                     .simulate_transaction(gasless_tx.clone(), checks, false)
@@ -449,6 +452,31 @@ fn mock_gas_storage_cost(
         .unwrap_or(0)
 }
 
+/// Populate a `ValidDuring` expiration covering the current epoch and the next one.
+fn set_valid_during_transaction_expiration(
+    service: &RpcService,
+    transaction: &mut sui_types::transaction::TransactionData,
+) -> Result<()> {
+    // Early return if the TransactionExpiration is already set to `ValidDuring`
+    if matches!(
+        transaction.expiration(),
+        TransactionExpiration::ValidDuring { .. }
+    ) {
+        return Ok(());
+    }
+
+    let current_epoch = service.reader.inner().get_latest_checkpoint()?.epoch();
+    *transaction.expiration_mut() = TransactionExpiration::ValidDuring {
+        min_epoch: Some(current_epoch),
+        max_epoch: Some(current_epoch.saturating_add(1)),
+        min_timestamp: None,
+        max_timestamp: None,
+        chain: service.chain_id,
+        nonce: rand::random(),
+    };
+    Ok(())
+}
+
 fn select_gas(
     service: &RpcService,
     transaction: &mut sui_types::transaction::TransactionData,
@@ -465,7 +493,6 @@ fn select_gas(
     use sui_types::gas_coin::GasCoin;
     use sui_types::transaction::Command;
     use sui_types::transaction::TransactionDataAPI;
-    use sui_types::transaction::TransactionExpiration;
 
     let reader = &service.reader;
 
@@ -509,17 +536,8 @@ fn select_gas(
         // Address balance
         transaction.gas_data_mut().payment.clear();
 
-        let current_epoch = service.reader.inner().get_latest_checkpoint()?.epoch();
-
         if matches!(transaction.expiration(), TransactionExpiration::None) {
-            *transaction.expiration_mut() = TransactionExpiration::ValidDuring {
-                min_epoch: Some(current_epoch),
-                max_epoch: Some(current_epoch.saturating_add(1)),
-                min_timestamp: None,
-                max_timestamp: None,
-                chain: service.chain_id,
-                nonce: rand::random(),
-            };
+            set_valid_during_transaction_expiration(service, transaction)?;
         }
 
         budget
@@ -592,16 +610,8 @@ fn select_gas(
             selected_gas.insert(0, coin_reservation);
             selected_gas_value += ab_value;
 
-            // Set expiration for address balance usage if not already set
             if matches!(transaction.expiration(), TransactionExpiration::None) {
-                *transaction.expiration_mut() = TransactionExpiration::ValidDuring {
-                    min_epoch: Some(current_epoch),
-                    max_epoch: Some(current_epoch.saturating_add(1)),
-                    min_timestamp: None,
-                    max_timestamp: None,
-                    chain: service.chain_id,
-                    nonce: rand::random(),
-                };
+                set_valid_during_transaction_expiration(service, transaction)?;
             }
         }
 


### PR DESCRIPTION
Previously, when the gRPC `SimulateTransaction` endpoint took the auto-gasless branch, it cleared the gas price/budget and invoked the executor without populating `TransactionExpiration`. For PTBs whose only inputs are a `FundsWithdrawal` and a `Pure` recipient (e.g. the free-tier address-balance redeem-and-send flow), the tx then has no address-owned object inputs, no gas payment, and no expiration, so `check_replay_protection` rejects it with "Transactions must either have address-owned inputs, or a ValidDuring expiration with at most two epochs of validity".

With this commit, the gasless branch fills in a `ValidDuring` expiration covering the current and next epoch before invoking the executor, mirroring what `select_gas` already does for the address-balance-funded paths. The shared logic is extracted into `set_valid_during_transaction_expiration`, and `select_gas`'s two inlined call sites now use the helper as well.

Also add an e2e test (`simulate_gasless_with_no_address_owned_inputs_succeeds`) that builds a `redeem_funds<SUI>` + `send_funds<SUI>` PTB against a seeded address balance and exercises the gasless simulate path through the unresolved proto flow. Without the fix, the test reproduces the exact error verbatim; with the fix, it passes.

## Description 

Describe the changes or additions included in this PR.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
