### PR TITLE
ci: pass cache_family to prebuild-sui-images dispatch

### DIFF
--- a/.github/workflows/pre-build-images.yml
+++ b/.github/workflows/pre-build-images.yml
@@ -25,6 +25,7 @@ jobs:
           client-payload: >
             {
               "sui_commit": "${{ github.sha }}",
+              "cache_family": "${{ github.ref_name }}",
               "caller_name": "sui_repo_${{ github.ref_name }}",
               "push_to_dockerhub": "true",
               "build_arm64": "${{ github.ref_name != 'main' && (github.ref_name == 'devnet' || github.ref_name == 'testnet' || github.ref_name == 'mainnet' || (startsWith(github.ref_name, 'releases/sui-') && endsWith(github.ref_name, '-release'))) }}",


### PR DESCRIPTION
## Summary

- Adds \`cache_family: github.ref_name\` to the \`repository_dispatch\` payload sent to MystenLabs/sui-operations on every Sui push.
- Pairs with [MystenLabs/sui-operations#7886](https://github.com/MystenLabs/sui-operations/pull/7886) (action input plumbing) and [MystenLabs/mp3#134](https://github.com/MystenLabs/mp3/pull/134) (rewriter accepts caller-supplied cache_family).
- One line. Zero behaviour change until #7886 + #134 are deployed; the receiver already reads \`client_payload.cache_family\` and the rewriter falls back to \`repo_ref\` when the field is absent.

## Why

mp3's \`/cargo-target\` cache id was previously derived from \`repo_ref\`. When \`repo_ref\` is a SHA (which it is on every push to main), the bucket id changes per commit, and warm incremental builds restart from a cold cache every time.

After all three PRs land, the bucket key becomes the branch — \`main\`, \`releases/sui-vX.Y.Z-release\`, etc. — so all SHAs off the same branch share one cargo-target bucket. Expect materially faster warm incremental builds.

## Branch → bucket mapping

| github.ref_name | mp3 bucket key |
|---|---|
| \`main\` | \`main\` |
| \`releases/sui-v1.71.0-release\` | \`release-releases-sui-v1-71-0-release\` (slugged) |
| \`testnet\` | \`other-testnet\` |
| \`mainnet\` | \`other-mainnet\` |
| \`devnet\` | \`other-devnet\` |

## Test plan

- [ ] Merge order: MystenLabs/sui-operations#7886 → this PR. (Reverse order is safe — \`cache_family\` is silently ignored if the receiver hasn't been updated yet.)
- [ ] After merge, watch a \`prebuild-sui-images\` run triggered by a push to main and confirm:
  - The build request payload includes \`cache_family=\"main\"\`
  - mp3 logs show the cargo-target cache id is keyed off \`main\` rather than the SHA
- [ ] Spot-check a release-branch push → bucket id contains \`release-releases-sui-v...\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)