### PR TITLE
ci: pass cache_family to ensure-sui-binaries dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -278,10 +278,18 @@ jobs:
     name: Tag sui binaries in s3
     runs-on: ubuntu-latest
     steps:
+      - name: Derive cache_family from release tag
+        id: cf
+        shell: bash
+        run: |
+          sui_tag="${{ env.TAG_NAME }}"
+          sui_version=$(echo "${sui_tag}" | sed -e 's|^refs/tags/||' -e 's/^mainnet-v//' -e 's/^testnet-v//' -e 's/^devnet-v//')
+          echo "cache_family=releases/sui-v${sui_version}-release" >> "$GITHUB_OUTPUT"
+
       - name: Dispatch ensure-sui-binaries in MystenLabs/sui-operations
         uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # pin@v4.0.1
         with:
           repository: MystenLabs/sui-operations
           token: ${{ secrets.DOCKER_BINARY_BUILDS_DISPATCH }}
           event-type: ensure-sui-binaries
-          client-payload: '{"sui_commit": "${{ github.sha }}", "tag_name": "${{ env.TAG_NAME }}"}'
+          client-payload: '{"sui_commit": "${{ github.sha }}", "tag_name": "${{ env.TAG_NAME }}", "cache_family": "${{ steps.cf.outputs.cache_family }}"}'


### PR DESCRIPTION
## Summary

- Adds \`cache_family\` to the \`repository_dispatch\` payload sent from \`release.yml\` to MystenLabs/sui-operations after a release tag is created.
- Derives \`releases/sui-v{X.Y.Z}-release\` from the release tag name (\`{network}-v{X.Y.Z}\`).
- Mirrors [MystenLabs/sui#26584](https://github.com/MystenLabs/sui/pull/26584) (already merged) for the second dispatch entry point in this repo.
- Pairs with [MystenLabs/sui-operations#7886](https://github.com/MystenLabs/sui-operations/pull/7886) and [MystenLabs/mp3#134](https://github.com/MystenLabs/mp3/pull/134).

## Why

\`release.yml\` is the binary-build entry point triggered when a release tag (e.g. \`testnet-v1.72.0\`) is created. The \`tag-release-binaries-in-s3\` job dispatches \`ensure-sui-binaries\` in MystenLabs/sui-operations to copy binaries to the tag-aliased S3 prefix. Until now this dispatch sent only \`sui_commit\` (a SHA), so on a cache-miss the mp3 path used a per-SHA \`/cargo-target\` bucket — defeating warm incremental builds.

After this lands the bucket key is the originating release branch.

## Test plan

- [ ] Merge order: sui-ops#7886 first → this PR. (Reverse order is safe — \`cache_family\` is silently ignored if the receiver hasn't been deployed yet.)
- [ ] On the next release tag creation, confirm the \`tag-release-binaries-in-s3\` job sends \`cache_family=releases/sui-vX.Y.Z-release\` in the dispatch payload (visible in the corresponding sui-operations \`ensure-sui-binaries\` workflow run input).

🤖 Generated with [Claude Code](https://claude.com/claude-code)