### PR TITLE
[indexer-alt] Add cp_digests table and pipeline

### DIFF
--- a/crates/sui-indexer-alt-schema/migrations/2026-05-11-000000_cp_digests/down.sql
+++ b/crates/sui-indexer-alt-schema/migrations/2026-05-11-000000_cp_digests/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS cp_digests;

--- a/crates/sui-indexer-alt-schema/migrations/2026-05-11-000000_cp_digests/up.sql
+++ b/crates/sui-indexer-alt-schema/migrations/2026-05-11-000000_cp_digests/up.sql
@@ -1,0 +1,14 @@
+-- Maps a checkpoint's sequence number to its digest, so checkpoints can be
+-- looked up by digest. The reverse direction is served by the secondary
+-- index on `cp_digest`. Mirrors the `tx_digests` table's shape.
+--
+-- New deployments populate this table from genesis; existing deployments
+-- will only have entries for checkpoints indexed after this migration runs.
+CREATE TABLE IF NOT EXISTS cp_digests
+(
+    cp_sequence_number BIGINT PRIMARY KEY,
+    cp_digest          BYTEA  NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS cp_digests_cp_digest
+    ON cp_digests (cp_digest);

--- a/crates/sui-indexer-alt-schema/src/checkpoints.rs
+++ b/crates/sui-indexer-alt-schema/src/checkpoints.rs
@@ -10,6 +10,7 @@ use sui_protocol_config::ProtocolVersion;
 use sui_types::digests::ChainIdentifier;
 use sui_types::digests::CheckpointDigest;
 
+use crate::schema::cp_digests;
 use crate::schema::kv_checkpoints;
 use crate::schema::kv_genesis;
 
@@ -23,6 +24,13 @@ pub struct StoredCheckpoint {
     pub checkpoint_summary: Vec<u8>,
     /// BCS serialized AuthorityQuorumSignInfo
     pub validator_signatures: Vec<u8>,
+}
+
+#[derive(Insertable, Debug, Clone, FieldCount, Queryable, Selectable)]
+#[diesel(table_name = cp_digests)]
+pub struct StoredCpDigest {
+    pub cp_sequence_number: i64,
+    pub cp_digest: Vec<u8>,
 }
 
 #[derive(Insertable, Selectable, Queryable, Debug, Clone)]

--- a/crates/sui-indexer-alt-schema/src/schema.rs
+++ b/crates/sui-indexer-alt-schema/src/schema.rs
@@ -18,6 +18,13 @@ diesel::table! {
 }
 
 diesel::table! {
+    cp_digests (cp_sequence_number) {
+        cp_sequence_number -> Int8,
+        cp_digest -> Bytea,
+    }
+}
+
+diesel::table! {
     cp_sequence_numbers (cp_sequence_number) {
         cp_sequence_number -> Int8,
         tx_lo -> Int8,
@@ -221,6 +228,7 @@ diesel::table! {
 diesel::allow_tables_to_appear_in_same_query!(
     cp_bloom_blocks,
     cp_blooms,
+    cp_digests,
     cp_sequence_numbers,
     ev_emit_mod,
     ev_struct_inst,

--- a/crates/sui-indexer-alt/src/config.rs
+++ b/crates/sui-indexer-alt/src/config.rs
@@ -129,6 +129,7 @@ pub struct PipelineLayer {
     // All concurrent pipelines
     pub cp_bloom_blocks: Option<ConcurrentLayer>,
     pub cp_blooms: Option<ConcurrentLayer>,
+    pub cp_digests: Option<ConcurrentLayer>,
     pub cp_sequence_numbers: Option<ConcurrentLayer>,
     pub ev_emit_mod: Option<ConcurrentLayer>,
     pub ev_struct_inst: Option<ConcurrentLayer>,
@@ -314,6 +315,7 @@ impl PipelineLayer {
         PipelineLayer {
             cp_blooms: Some(Default::default()),
             cp_bloom_blocks: Some(Default::default()),
+            cp_digests: Some(Default::default()),
             sum_displays: Some(Default::default()),
             cp_sequence_numbers: Some(Default::default()),
             ev_emit_mod: Some(Default::default()),
@@ -445,6 +447,7 @@ impl Merge for PipelineLayer {
         Ok(PipelineLayer {
             cp_blooms: self.cp_blooms.merge(other.cp_blooms)?,
             cp_bloom_blocks: self.cp_bloom_blocks.merge(other.cp_bloom_blocks)?,
+            cp_digests: self.cp_digests.merge(other.cp_digests)?,
             sum_displays: self.sum_displays.merge(other.sum_displays)?,
             cp_sequence_numbers: self.cp_sequence_numbers.merge(other.cp_sequence_numbers)?,
             ev_emit_mod: self.ev_emit_mod.merge(other.ev_emit_mod)?,

--- a/crates/sui-indexer-alt/src/handlers/cp_digests.rs
+++ b/crates/sui-indexer-alt/src/handlers/cp_digests.rs
@@ -1,0 +1,98 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use diesel::ExpressionMethods;
+use diesel::QueryDsl;
+use diesel_async::RunQueryDsl;
+use sui_indexer_alt_framework::pipeline::Processor;
+use sui_indexer_alt_framework::postgres::Connection;
+use sui_indexer_alt_framework::postgres::handler::Handler;
+use sui_indexer_alt_framework::types::full_checkpoint_content::Checkpoint;
+use sui_indexer_alt_schema::checkpoints::StoredCpDigest;
+use sui_indexer_alt_schema::schema::cp_digests;
+
+pub(crate) struct CpDigests;
+
+#[async_trait]
+impl Processor for CpDigests {
+    const NAME: &'static str = "cp_digests";
+
+    type Value = StoredCpDigest;
+
+    async fn process(&self, checkpoint: &Arc<Checkpoint>) -> Result<Vec<Self::Value>> {
+        let cp_sequence_number = checkpoint.summary.sequence_number as i64;
+        let cp_digest = checkpoint.summary.digest().inner().to_vec();
+        Ok(vec![StoredCpDigest {
+            cp_sequence_number,
+            cp_digest,
+        }])
+    }
+}
+
+#[async_trait]
+impl Handler for CpDigests {
+    async fn commit<'a>(values: &[Self::Value], conn: &mut Connection<'a>) -> Result<usize> {
+        Ok(diesel::insert_into(cp_digests::table)
+            .values(values)
+            .on_conflict_do_nothing()
+            .execute(conn)
+            .await?)
+    }
+
+    async fn prune<'a>(
+        &self,
+        from: u64,
+        to_exclusive: u64,
+        conn: &mut Connection<'a>,
+    ) -> Result<usize> {
+        let filter = cp_digests::table
+            .filter(cp_digests::cp_sequence_number.between(from as i64, to_exclusive as i64 - 1));
+
+        Ok(diesel::delete(filter).execute(conn).await?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use diesel_async::RunQueryDsl;
+    use sui_indexer_alt_framework::Indexer;
+    use sui_indexer_alt_framework::types::test_checkpoint_data_builder::TestCheckpointBuilder;
+    use sui_indexer_alt_schema::MIGRATIONS;
+
+    use super::*;
+
+    async fn get_all_cp_digests(conn: &mut Connection<'_>) -> Result<Vec<StoredCpDigest>> {
+        let query = cp_digests::table.load(conn).await?;
+        Ok(query)
+    }
+
+    /// Verify that the processor extracts the (sequence_number, digest) pair for each checkpoint
+    /// and that the pruner removes entries by sequence-number range.
+    #[tokio::test]
+    async fn test_cp_digests_pruning() {
+        let (indexer, _db) = Indexer::new_for_testing(&MIGRATIONS).await;
+        let mut conn = indexer.store().connect().await.unwrap();
+
+        // Build and commit 3 checkpoints so we have three rows with distinct digests.
+        let mut builder = TestCheckpointBuilder::new(0);
+        for _ in 0..3 {
+            builder = builder.start_transaction(0).finish_transaction();
+            let checkpoint = Arc::new(builder.build_checkpoint());
+            let values = CpDigests.process(&checkpoint).await.unwrap();
+            CpDigests::commit(&values, &mut conn).await.unwrap();
+        }
+
+        // Prune checkpoints from `[0, 2)`.
+        let rows_pruned = CpDigests.prune(0, 2, &mut conn).await.unwrap();
+        assert_eq!(rows_pruned, 2);
+
+        // Only the entry for checkpoint 2 should remain.
+        let remaining = get_all_cp_digests(&mut conn).await.unwrap();
+        assert_eq!(remaining.len(), 1);
+        assert_eq!(remaining[0].cp_sequence_number, 2);
+    }
+}

--- a/crates/sui-indexer-alt/src/handlers/mod.rs
+++ b/crates/sui-indexer-alt/src/handlers/mod.rs
@@ -7,6 +7,7 @@ use sui_indexer_alt_framework::types::object::Owner;
 
 pub(crate) mod cp_bloom_blocks;
 pub(crate) mod cp_blooms;
+pub(crate) mod cp_digests;
 pub(crate) mod cp_sequence_numbers;
 pub(crate) mod ev_emit_mod;
 pub(crate) mod ev_struct_inst;

--- a/crates/sui-indexer-alt/src/lib.rs
+++ b/crates/sui-indexer-alt/src/lib.rs
@@ -22,6 +22,7 @@ use crate::config::IndexerConfig;
 use crate::config::PipelineLayer;
 use crate::handlers::cp_bloom_blocks::CpBloomBlocks;
 use crate::handlers::cp_blooms::CpBlooms;
+use crate::handlers::cp_digests::CpDigests;
 use crate::handlers::cp_sequence_numbers::CpSequenceNumbers;
 use crate::handlers::ev_emit_mod::EvEmitMod;
 use crate::handlers::ev_struct_inst::EvStructInst;
@@ -71,6 +72,7 @@ pub async fn setup_indexer(
         sum_displays,
         cp_blooms,
         cp_bloom_blocks,
+        cp_digests,
         cp_sequence_numbers,
         ev_emit_mod,
         ev_struct_inst,
@@ -180,6 +182,7 @@ pub async fn setup_indexer(
 
     add_concurrent!(CpBlooms, cp_blooms);
     add_concurrent!(CpBloomBlocks, cp_bloom_blocks);
+    add_concurrent!(CpDigests, cp_digests);
     add_concurrent!(CpSequenceNumbers, cp_sequence_numbers);
     add_concurrent!(EvEmitMod, ev_emit_mod);
     add_concurrent!(EvStructInst, ev_struct_inst);


### PR DESCRIPTION
## Summary

 - Adds a `kv_checkpoints_by_digest` table on the PG indexer that maps `checkpoint_digest` → `sequence_number`.
- Enables checkpoint lookup by digest: a follow-up GraphQL PR will translate a digest argument on `Query.checkpoint(digest:)` to a sequence number through this table, then fall through to the existing `kv_checkpoints` resolver chain for the full payload. 

## Test plan

- `cargo nextest run -p sui-indexer-alt kv_checkpoints_by_digest` (new pipeline unit test: insert + prune end-to-end against a temp PG).
- Local mainnet ingestion run, verified

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework: