### PR TITLE
[RPC] VM error visibility indexing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -660,7 +660,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "alloy-sol-types",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -9852,7 +9852,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11333,7 +11333,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6c3320f9abac597dcbc668774ef006702672474aad53c6d596b62e487b40b1"
 dependencies = [
  "heck 0.4.1",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "once_cell",
@@ -11355,7 +11355,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -11368,7 +11368,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -11566,7 +11566,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.6",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -14583,7 +14583,6 @@ dependencies = [
 [[package]]
 name = "sui-crypto"
 version = "0.3.0"
-source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=f7487a58c6c31f07da08ba1c0cd81ebb8fe90ddd#f7487a58c6c31f07da08ba1c0cd81ebb8fe90ddd"
 dependencies = [
  "ark-bn254",
  "ark-ff 0.4.2",
@@ -16545,7 +16544,6 @@ dependencies = [
 [[package]]
 name = "sui-rpc"
 version = "0.3.1"
-source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=f7487a58c6c31f07da08ba1c0cd81ebb8fe90ddd#f7487a58c6c31f07da08ba1c0cd81ebb8fe90ddd"
 dependencies = [
  "base64 0.22.1",
  "bcs",
@@ -16732,7 +16730,6 @@ dependencies = [
 [[package]]
 name = "sui-sdk-types"
 version = "0.3.1"
-source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=f7487a58c6c31f07da08ba1c0cd81ebb8fe90ddd#f7487a58c6c31f07da08ba1c0cd81ebb8fe90ddd"
 dependencies = [
  "base64ct",
  "bcs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -660,7 +660,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "alloy-sol-types",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -2753,7 +2753,7 @@ checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
 name = "bin-version"
-version = "1.73.0"
+version = "1.74.0"
 dependencies = [
  "const-str",
  "git-version",
@@ -3727,7 +3727,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util 0.7.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "tonic 0.14.5",
+ "tonic 0.14.6",
  "tonic-build",
  "tonic-prost",
  "tonic-rustls",
@@ -6076,7 +6076,7 @@ dependencies = [
  "time",
  "tokio",
  "tokio-stream",
- "tonic 0.14.5",
+ "tonic 0.14.6",
  "tonic-build",
  "tonic-prost",
  "tonic-prost-build",
@@ -8406,7 +8406,7 @@ dependencies = [
 [[package]]
 name = "minibytes"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/tidehunter.git?rev=9a0472f81e71e821e1f4f71e308c2580f16f9e05#9a0472f81e71e821e1f4f71e308c2580f16f9e05"
+source = "git+https://github.com/mystenlabs/tidehunter.git?rev=14b04e9d8130c20fdc03a629c02fe50f628cb789#14b04e9d8130c20fdc03a629c02fe50f628cb789"
 dependencies = [
  "bytes",
  "memmap2 0.7.1",
@@ -9431,7 +9431,7 @@ dependencies = [
 [[package]]
 name = "msim"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/mysten-sim.git?rev=53016c1a9038154b1e47b96f0a314efa7e7d809b#53016c1a9038154b1e47b96f0a314efa7e7d809b"
+source = "git+https://github.com/MystenLabs/mysten-sim.git?rev=2c2ec3ffbc1e559c575dc7de1ff2498d1f6700f6#2c2ec3ffbc1e559c575dc7de1ff2498d1f6700f6"
 dependencies = [
  "ahash 0.7.8",
  "async-task",
@@ -9460,7 +9460,7 @@ dependencies = [
 [[package]]
 name = "msim-macros"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/mysten-sim.git?rev=53016c1a9038154b1e47b96f0a314efa7e7d809b#53016c1a9038154b1e47b96f0a314efa7e7d809b"
+source = "git+https://github.com/MystenLabs/mysten-sim.git?rev=2c2ec3ffbc1e559c575dc7de1ff2498d1f6700f6#2c2ec3ffbc1e559c575dc7de1ff2498d1f6700f6"
 dependencies = [
  "darling 0.14.2",
  "proc-macro2",
@@ -9541,10 +9541,12 @@ dependencies = [
  "mysten-metrics",
  "once_cell",
  "parking_lot 0.12.3",
+ "prost-types 0.14.1",
  "rand 0.8.5",
  "serde_json",
  "sui-macros",
  "tempfile",
+ "thiserror 1.0.69",
  "tokio",
  "tracing",
 ]
@@ -9599,7 +9601,7 @@ dependencies = [
  "sui-tls",
  "tokio",
  "tokio-rustls",
- "tonic 0.14.5",
+ "tonic 0.14.6",
  "tower 0.5.3",
  "tower-http 0.5.2",
  "tracing",
@@ -9852,7 +9854,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11332,8 +11334,8 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6c3320f9abac597dcbc668774ef006702672474aad53c6d596b62e487b40b1"
 dependencies = [
- "heck 0.4.1",
- "itertools 0.10.5",
+ "heck 0.5.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -11355,7 +11357,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -11368,7 +11370,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -11566,7 +11568,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls",
- "socket2 0.5.6",
+ "socket2 0.6.3",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -13805,7 +13807,7 @@ checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 
 [[package]]
 name = "sui"
-version = "1.73.0"
+version = "1.74.0"
 dependencies = [
  "anemo",
  "anyhow",
@@ -14068,7 +14070,7 @@ dependencies = [
 
 [[package]]
 name = "sui-analytics-indexer"
-version = "1.73.0"
+version = "1.74.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -14127,7 +14129,7 @@ dependencies = [
 
 [[package]]
 name = "sui-analytics-indexer-derive"
-version = "1.73.0"
+version = "1.74.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -14200,7 +14202,7 @@ dependencies = [
 
 [[package]]
 name = "sui-bridge"
-version = "1.73.0"
+version = "1.74.0"
 dependencies = [
  "alloy",
  "alloy-multiprovider-strategy",
@@ -14250,7 +14252,7 @@ dependencies = [
  "test-cluster",
  "thiserror 1.0.69",
  "tokio",
- "tonic 0.14.5",
+ "tonic 0.14.6",
  "tower 0.5.3",
  "tracing",
  "typed-store",
@@ -14259,7 +14261,7 @@ dependencies = [
 
 [[package]]
 name = "sui-bridge-cli"
-version = "1.73.0"
+version = "1.74.0"
 dependencies = [
  "alloy",
  "anyhow",
@@ -14355,7 +14357,7 @@ dependencies = [
 
 [[package]]
 name = "sui-checkpoint-blob-indexer"
-version = "1.73.0"
+version = "1.74.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -14386,7 +14388,7 @@ dependencies = [
 
 [[package]]
 name = "sui-cluster-test"
-version = "1.73.0"
+version = "1.74.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -14515,6 +14517,7 @@ dependencies = [
  "reqwest",
  "roaring",
  "rstest",
+ "rustc-hash 2.1.1",
  "scopeguard",
  "serde",
  "serde_json",
@@ -14530,6 +14533,7 @@ dependencies = [
  "sui-execution",
  "sui-framework",
  "sui-genesis-builder",
+ "sui-inverted-index",
  "sui-json-rpc-types",
  "sui-macros",
  "sui-move",
@@ -14583,6 +14587,7 @@ dependencies = [
 [[package]]
 name = "sui-crypto"
 version = "0.3.0"
+source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=5b41bc701525f1b94f1fe63008d4841bc6fb1065#5b41bc701525f1b94f1fe63008d4841bc6fb1065"
 dependencies = [
  "ark-bn254",
  "ark-ff 0.4.2",
@@ -14590,6 +14595,7 @@ dependencies = [
  "ark-snark",
  "ark-std 0.4.0",
  "base64ct",
+ "blst",
  "bnum",
  "ed25519-dalek",
  "itertools 0.14.0",
@@ -14656,7 +14662,7 @@ dependencies = [
 
 [[package]]
 name = "sui-default-config"
-version = "1.73.0"
+version = "1.74.0"
 dependencies = [
  "quote",
  "syn 1.0.107",
@@ -14664,7 +14670,7 @@ dependencies = [
 
 [[package]]
 name = "sui-display"
-version = "1.73.0"
+version = "1.74.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -14688,7 +14694,7 @@ dependencies = [
 
 [[package]]
 name = "sui-e2e-tests"
-version = "1.73.0"
+version = "1.74.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -14706,6 +14712,7 @@ dependencies = [
  "move-core-types",
  "mysten-common",
  "mysten-metrics",
+ "mysten-network",
  "p256",
  "passkey-authenticator",
  "passkey-client",
@@ -14748,7 +14755,7 @@ dependencies = [
  "test-cluster",
  "tokio",
  "tokio-stream",
- "tonic 0.14.5",
+ "tonic 0.14.6",
  "tracing",
  "url",
 ]
@@ -14824,7 +14831,7 @@ dependencies = [
 
 [[package]]
 name = "sui-faucet"
-version = "1.73.0"
+version = "1.74.0"
 dependencies = [
  "anyhow",
  "axum 0.8.3",
@@ -14836,6 +14843,7 @@ dependencies = [
  "serde_json",
  "shared-crypto",
  "sui-config",
+ "sui-futures",
  "sui-keys",
  "sui-rpc-api",
  "sui-sdk",
@@ -14850,14 +14858,14 @@ dependencies = [
 
 [[package]]
 name = "sui-field-count"
-version = "1.73.0"
+version = "1.74.0"
 dependencies = [
  "sui-field-count-derive",
 ]
 
 [[package]]
 name = "sui-field-count-derive"
-version = "1.73.0"
+version = "1.74.0"
 dependencies = [
  "quote",
  "syn 1.0.107",
@@ -14865,7 +14873,7 @@ dependencies = [
 
 [[package]]
 name = "sui-fork"
-version = "1.73.0"
+version = "1.74.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -14892,7 +14900,7 @@ dependencies = [
  "sui-types",
  "tempfile",
  "tokio",
- "tonic 0.14.5",
+ "tonic 0.14.6",
  "tonic-prost",
  "tracing",
  "tracing-subscriber",
@@ -14924,7 +14932,7 @@ dependencies = [
 
 [[package]]
 name = "sui-framework-snapshot"
-version = "1.73.0"
+version = "1.74.0"
 dependencies = [
  "anyhow",
  "bcs",
@@ -14968,7 +14976,7 @@ dependencies = [
 
 [[package]]
 name = "sui-futures"
-version = "1.73.0"
+version = "1.74.0"
 dependencies = [
  "anyhow",
  "futures",
@@ -15028,7 +15036,7 @@ dependencies = [
 
 [[package]]
 name = "sui-indexer-alt"
-version = "1.73.0"
+version = "1.74.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -15061,12 +15069,12 @@ dependencies = [
 
 [[package]]
 name = "sui-indexer-alt-consistent-api"
-version = "1.73.0"
+version = "1.74.0"
 dependencies = [
  "prost 0.14.1",
  "prost-types 0.14.1",
  "protox",
- "tonic 0.14.5",
+ "tonic 0.14.6",
  "tonic-prost",
  "tonic-prost-build",
  "walkdir",
@@ -15074,7 +15082,7 @@ dependencies = [
 
 [[package]]
 name = "sui-indexer-alt-consistent-store"
-version = "1.73.0"
+version = "1.74.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -15115,7 +15123,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "toml 0.7.4",
- "tonic 0.14.5",
+ "tonic 0.14.6",
  "tonic-health",
  "tonic-reflection",
  "tower 0.5.3",
@@ -15187,7 +15195,7 @@ dependencies = [
  "test-cluster",
  "tokio",
  "tokio-stream",
- "tonic 0.14.5",
+ "tonic 0.14.6",
  "tracing",
  "url",
  "zstd 0.12.3+zstd.1.5.2",
@@ -15195,7 +15203,7 @@ dependencies = [
 
 [[package]]
 name = "sui-indexer-alt-framework"
-version = "1.73.0"
+version = "1.74.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -15234,7 +15242,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
- "tonic 0.14.5",
+ "tonic 0.14.6",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -15244,7 +15252,7 @@ dependencies = [
 
 [[package]]
 name = "sui-indexer-alt-framework-store-traits"
-version = "1.73.0"
+version = "1.74.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -15256,7 +15264,7 @@ dependencies = [
 
 [[package]]
 name = "sui-indexer-alt-graphql"
-version = "1.73.0"
+version = "1.74.0"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -15314,7 +15322,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "toml 0.7.4",
- "tonic 0.14.5",
+ "tonic 0.14.6",
  "tower-http 0.5.2",
  "tracing",
  "url",
@@ -15323,7 +15331,7 @@ dependencies = [
 
 [[package]]
 name = "sui-indexer-alt-jsonrpc"
-version = "1.73.0"
+version = "1.74.0"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -15374,7 +15382,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "toml 0.7.4",
- "tonic 0.14.5",
+ "tonic 0.14.6",
  "tower 0.4.13",
  "tower-http 0.5.2",
  "tower-layer",
@@ -15384,7 +15392,7 @@ dependencies = [
 
 [[package]]
 name = "sui-indexer-alt-metrics"
-version = "1.73.0"
+version = "1.74.0"
 dependencies = [
  "anyhow",
  "axum 0.8.3",
@@ -15399,7 +15407,7 @@ dependencies = [
 
 [[package]]
 name = "sui-indexer-alt-object-store"
-version = "1.73.0"
+version = "1.74.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -15413,7 +15421,7 @@ dependencies = [
 
 [[package]]
 name = "sui-indexer-alt-reader"
-version = "1.73.0"
+version = "1.74.0"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -15441,7 +15449,7 @@ dependencies = [
  "sui-types",
  "thiserror 1.0.69",
  "tokio",
- "tonic 0.14.5",
+ "tonic 0.14.6",
  "tower 0.5.3",
  "tracing",
  "url",
@@ -15449,7 +15457,7 @@ dependencies = [
 
 [[package]]
 name = "sui-indexer-alt-schema"
-version = "1.73.0"
+version = "1.74.0"
 dependencies = [
  "anyhow",
  "bcs",
@@ -15465,16 +15473,16 @@ dependencies = [
 
 [[package]]
 name = "sui-inverted-index"
-version = "1.73.0"
+version = "1.74.0"
 dependencies = [
  "anyhow",
  "async-stream",
  "bcs",
  "futures",
- "itertools 0.13.0",
  "move-core-types",
  "roaring",
  "sui-types",
+ "thiserror 1.0.69",
  "tokio",
 ]
 
@@ -15677,7 +15685,7 @@ dependencies = [
 
 [[package]]
 name = "sui-kv-rpc"
-version = "1.73.0"
+version = "1.74.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -15698,7 +15706,10 @@ dependencies = [
  "prost 0.14.1",
  "prost-types 0.14.1",
  "rustls",
+ "schemars 0.8.21",
  "serde",
+ "serde_json",
+ "serde_yaml 0.8.26",
  "sui-futures",
  "sui-inverted-index",
  "sui-kvstore",
@@ -15710,8 +15721,9 @@ dependencies = [
  "sui-storage",
  "sui-types",
  "telemetry-subscribers",
+ "thiserror 1.0.69",
  "tokio",
- "tonic 0.14.5",
+ "tonic 0.14.6",
  "tonic-prost",
  "tonic-reflection",
  "tracing",
@@ -15719,7 +15731,7 @@ dependencies = [
 
 [[package]]
 name = "sui-kvstore"
-version = "1.73.0"
+version = "1.74.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -15763,7 +15775,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "toml 0.7.4",
- "tonic 0.14.5",
+ "tonic 0.14.6",
  "tonic-prost",
  "tracing",
  "url",
@@ -15771,7 +15783,7 @@ dependencies = [
 
 [[package]]
 name = "sui-light-client"
-version = "1.73.0"
+version = "1.74.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -15804,7 +15816,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
- "tonic 0.14.5",
+ "tonic 0.14.6",
  "tracing",
  "url",
 ]
@@ -15821,7 +15833,7 @@ dependencies = [
 
 [[package]]
 name = "sui-metric-checker"
-version = "1.73.0"
+version = "1.74.0"
 dependencies = [
  "anyhow",
  "backoff",
@@ -15858,7 +15870,7 @@ dependencies = [
 
 [[package]]
 name = "sui-move"
-version = "1.73.0"
+version = "1.74.0"
 dependencies = [
  "anyhow",
  "bin-version",
@@ -15905,7 +15917,7 @@ dependencies = [
 
 [[package]]
 name = "sui-move-build"
-version = "1.73.0"
+version = "1.74.0"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -15931,7 +15943,7 @@ dependencies = [
 
 [[package]]
 name = "sui-move-lsp"
-version = "1.73.0"
+version = "1.74.0"
 dependencies = [
  "bin-version",
  "clap",
@@ -16046,7 +16058,7 @@ dependencies = [
 
 [[package]]
 name = "sui-name-service"
-version = "1.73.0"
+version = "1.74.0"
 dependencies = [
  "bcs",
  "move-core-types",
@@ -16100,7 +16112,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-rustls",
- "tonic 0.14.5",
+ "tonic 0.14.6",
  "tonic-build",
  "tonic-health",
  "tonic-prost",
@@ -16113,7 +16125,7 @@ dependencies = [
 
 [[package]]
 name = "sui-node"
-version = "1.73.0"
+version = "1.74.0"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -16168,7 +16180,7 @@ dependencies = [
 
 [[package]]
 name = "sui-open-rpc"
-version = "1.73.0"
+version = "1.74.0"
 dependencies = [
  "anyhow",
  "bcs",
@@ -16202,7 +16214,7 @@ dependencies = [
 
 [[package]]
 name = "sui-oracle"
-version = "1.73.0"
+version = "1.74.0"
 dependencies = [
  "anyhow",
  "bcs",
@@ -16232,7 +16244,7 @@ dependencies = [
 
 [[package]]
 name = "sui-package-alt"
-version = "1.73.0"
+version = "1.74.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -16251,7 +16263,7 @@ dependencies = [
 
 [[package]]
 name = "sui-package-dump"
-version = "1.73.0"
+version = "1.74.0"
 dependencies = [
  "anyhow",
  "bcs",
@@ -16267,7 +16279,7 @@ dependencies = [
 
 [[package]]
 name = "sui-package-management"
-version = "1.73.0"
+version = "1.74.0"
 dependencies = [
  "anyhow",
  "sui-framework-snapshot",
@@ -16300,7 +16312,7 @@ dependencies = [
 
 [[package]]
 name = "sui-pg-db"
-version = "1.73.0"
+version = "1.74.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -16349,6 +16361,7 @@ dependencies = [
  "move-core-types",
  "move-vm-config",
  "mysten-common",
+ "prost-types 0.14.1",
  "rand 0.8.5",
  "schemars 0.8.21",
  "serde",
@@ -16496,7 +16509,7 @@ dependencies = [
 
 [[package]]
 name = "sui-rosetta"
-version = "1.73.0"
+version = "1.74.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -16537,13 +16550,14 @@ dependencies = [
  "test-cluster",
  "thiserror 1.0.69",
  "tokio",
- "tonic 0.14.5",
+ "tonic 0.14.6",
  "tracing",
 ]
 
 [[package]]
 name = "sui-rpc"
 version = "0.3.1"
+source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=5b41bc701525f1b94f1fe63008d4841bc6fb1065#5b41bc701525f1b94f1fe63008d4841bc6fb1065"
 dependencies = [
  "base64 0.22.1",
  "bcs",
@@ -16555,10 +16569,11 @@ dependencies = [
  "prost-types 0.14.1",
  "serde",
  "serde_json",
+ "sui-crypto",
  "sui-sdk-types",
  "tap",
  "tokio",
- "tonic 0.14.5",
+ "tonic 0.14.6",
  "tonic-prost",
  "tower 0.5.3",
 ]
@@ -16586,11 +16601,13 @@ dependencies = [
  "prost-types 0.14.1",
  "protox",
  "rand 0.8.5",
+ "roaring",
  "serde",
  "serde_json",
  "sui-config",
  "sui-crypto",
  "sui-display",
+ "sui-inverted-index",
  "sui-macros",
  "sui-name-service",
  "sui-package-resolver",
@@ -16602,7 +16619,8 @@ dependencies = [
  "sui-types",
  "tap",
  "tokio",
- "tonic 0.14.5",
+ "tokio-util 0.7.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tonic 0.14.6",
  "tonic-health",
  "tonic-prost",
  "tonic-prost-build",
@@ -16615,7 +16633,7 @@ dependencies = [
 
 [[package]]
 name = "sui-rpc-benchmark"
-version = "1.73.0"
+version = "1.74.0"
 dependencies = [
  "anyhow",
  "bb8",
@@ -16640,7 +16658,7 @@ dependencies = [
 
 [[package]]
 name = "sui-rpc-loadgen"
-version = "1.73.0"
+version = "1.74.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -16661,13 +16679,13 @@ dependencies = [
  "sui-types",
  "telemetry-subscribers",
  "tokio",
- "tonic 0.14.5",
+ "tonic 0.14.6",
  "tracing",
 ]
 
 [[package]]
 name = "sui-rpc-resolver"
-version = "1.73.0"
+version = "1.74.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -16686,7 +16704,7 @@ dependencies = [
 
 [[package]]
 name = "sui-sdk"
-version = "1.73.0"
+version = "1.74.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -16730,6 +16748,7 @@ dependencies = [
 [[package]]
 name = "sui-sdk-types"
 version = "0.3.1"
+source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=5b41bc701525f1b94f1fe63008d4841bc6fb1065#5b41bc701525f1b94f1fe63008d4841bc6fb1065"
 dependencies = [
  "base64ct",
  "bcs",
@@ -16749,7 +16768,7 @@ dependencies = [
 
 [[package]]
 name = "sui-security-watchdog"
-version = "1.73.0"
+version = "1.74.0"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -16797,7 +16816,7 @@ dependencies = [
 
 [[package]]
 name = "sui-single-node-benchmark"
-version = "1.73.0"
+version = "1.74.0"
 dependencies = [
  "bcs",
  "clap",
@@ -16856,7 +16875,7 @@ dependencies = [
 
 [[package]]
 name = "sui-source-validation"
-version = "1.73.0"
+version = "1.74.0"
 dependencies = [
  "anyhow",
  "colored",
@@ -16899,7 +16918,7 @@ dependencies = [
 
 [[package]]
 name = "sui-sql-macro"
-version = "1.73.0"
+version = "1.74.0"
 dependencies = [
  "quote",
  "syn 1.0.107",
@@ -16965,7 +16984,7 @@ dependencies = [
 
 [[package]]
 name = "sui-surfer"
-version = "1.73.0"
+version = "1.74.0"
 dependencies = [
  "bcs",
  "clap",
@@ -17087,7 +17106,7 @@ dependencies = [
 
 [[package]]
 name = "sui-test-validator"
-version = "1.73.0"
+version = "1.74.0"
 
 [[package]]
 name = "sui-tls"
@@ -17113,7 +17132,7 @@ dependencies = [
 
 [[package]]
 name = "sui-tool"
-version = "1.73.0"
+version = "1.74.0"
 dependencies = [
  "anemo",
  "anemo-cli",
@@ -17321,7 +17340,7 @@ dependencies = [
  "tap",
  "thiserror 1.0.69",
  "tokio",
- "tonic 0.14.5",
+ "tonic 0.14.6",
  "tracing",
  "typed-store-error",
  "url",
@@ -17803,7 +17822,7 @@ dependencies = [
  "sui-test-transaction-builder",
  "sui-types",
  "tokio",
- "tonic 0.14.5",
+ "tonic 0.14.6",
  "tracing",
 ]
 
@@ -17962,7 +17981,7 @@ dependencies = [
 [[package]]
 name = "tideconsole"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/tidehunter.git?rev=9a0472f81e71e821e1f4f71e308c2580f16f9e05#9a0472f81e71e821e1f4f71e308c2580f16f9e05"
+source = "git+https://github.com/mystenlabs/tidehunter.git?rev=14b04e9d8130c20fdc03a629c02fe50f628cb789#14b04e9d8130c20fdc03a629c02fe50f628cb789"
 dependencies = [
  "anyhow",
  "clap",
@@ -17976,7 +17995,7 @@ dependencies = [
 [[package]]
 name = "tidehunter"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/tidehunter.git?rev=9a0472f81e71e821e1f4f71e308c2580f16f9e05#9a0472f81e71e821e1f4f71e308c2580f16f9e05"
+source = "git+https://github.com/mystenlabs/tidehunter.git?rev=14b04e9d8130c20fdc03a629c02fe50f628cb789#14b04e9d8130c20fdc03a629c02fe50f628cb789"
 dependencies = [
  "arc-swap",
  "bincode 1.3.3",
@@ -17986,6 +18005,7 @@ dependencies = [
  "crc32fast",
  "libc",
  "lru 0.12.5",
+ "lz4_flex",
  "memmap2 0.7.1",
  "minibytes",
  "parking_lot 0.12.3",
@@ -18442,8 +18462,9 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.14.5"
-source = "git+https://github.com/hyperium/tonic.git?rev=d6ce69b0d93e1de21b0769e942ace00b48f52e17#d6ce69b0d93e1de21b0769e942ace00b48f52e17"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
  "async-trait",
  "axum 0.8.3",
@@ -18475,9 +18496,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.14.2"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c40aaccc9f9eccf2cd82ebc111adc13030d23e887244bc9cfa5d1d636049de3"
+checksum = "c68f61875ac5293cf72e6c8cf0158086428c82c37229e98c840878f1706b0322"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -18487,32 +18508,33 @@ dependencies = [
 
 [[package]]
 name = "tonic-health"
-version = "0.14.2"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a82868bf299e0a1d2e8dce0dc33a46c02d6f045b2c1f1d6cc8dc3d0bf1812ef"
+checksum = "fcfab99db777fba2802f0dfa861d1628d1ae916fb199d29819941f139ae85082"
 dependencies = [
  "prost 0.14.1",
  "tokio",
  "tokio-stream",
- "tonic 0.14.5",
+ "tonic 0.14.6",
  "tonic-prost",
 ]
 
 [[package]]
 name = "tonic-prost"
-version = "0.14.5"
-source = "git+https://github.com/hyperium/tonic.git?rev=d6ce69b0d93e1de21b0769e942ace00b48f52e17#d6ce69b0d93e1de21b0769e942ace00b48f52e17"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
 dependencies = [
  "bytes",
  "prost 0.14.1",
- "tonic 0.14.5",
+ "tonic 0.14.6",
 ]
 
 [[package]]
 name = "tonic-prost-build"
-version = "0.14.2"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4a16cba4043dc3ff43fcb3f96b4c5c154c64cbd18ca8dce2ab2c6a451d058a2"
+checksum = "654e5643eff75d7f8c99197ce1440ed19a3474eada74c12bbac488b2cafdae27"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -18526,14 +18548,15 @@ dependencies = [
 
 [[package]]
 name = "tonic-reflection"
-version = "0.14.5"
-source = "git+https://github.com/hyperium/tonic.git?rev=d6ce69b0d93e1de21b0769e942ace00b48f52e17#d6ce69b0d93e1de21b0769e942ace00b48f52e17"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acccd136a4bf19810a1fde9c74edc6129b42a66b44d0c1c8aaa67aeb49a146a7"
 dependencies = [
  "prost 0.14.1",
  "prost-types 0.14.1",
  "tokio",
  "tokio-stream",
- "tonic 0.14.5",
+ "tonic 0.14.6",
  "tonic-prost",
 ]
 
@@ -18557,7 +18580,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-stream",
- "tonic 0.14.5",
+ "tonic 0.14.6",
  "tower 0.5.3",
  "tower-layer",
  "tower-service",
@@ -18566,9 +18589,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-web"
-version = "0.14.2"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75214f6b6bd28c19aa752ac09fdf0eea546095670906c21fe3940e180a4c43f2"
+checksum = "b5e6a1b6319ca4b61a4c0f0c94d439c8f3ed344cca56fe0df40e1fe4be11380b"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -18576,7 +18599,7 @@ dependencies = [
  "http-body 1.0.1",
  "pin-project",
  "tokio-stream",
- "tonic 0.14.5",
+ "tonic 0.14.6",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -18915,7 +18938,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.7.3",
+ "rand 0.8.5",
  "static_assertions",
 ]
 
@@ -20302,7 +20325,7 @@ dependencies = [
 
 [[package]]
 name = "x"
-version = "1.73.0"
+version = "1.74.0"
 dependencies = [
  "anyhow",
  "camino",

--- a/crates/simulacrum/src/epoch_state.rs
+++ b/crates/simulacrum/src/epoch_state.rs
@@ -150,31 +150,26 @@ impl EpochState {
 
         let transaction_data = transaction.data().transaction_data();
         let (kind, signer, gas_data) = transaction_data.execution_parts();
-        let (inner_temp_store, gas_status, effects, _timings, result) = self
-            .executor
-            .execute_transaction_to_effects_and_execution_error(
-                store.backing_store(),
-                &self.protocol_config,
-                self.execution_metrics.clone(),
-                false, // enable_expensive_checks
-                // TODO: Integrate with early execution error
-                ExecutionOrEarlyError::Ok(()),
-                &self.epoch_start_state.epoch(),
-                self.epoch_start_state.epoch_start_timestamp_ms(),
-                checked_input_objects,
-                gas_data,
-                gas_status,
-                kind,
-                None, // compat_args
-                signer,
-                tx_digest,
-                &mut None,
-            );
-        Ok((
-            inner_temp_store,
-            gas_status,
-            effects,
-            result.map_err(sui_types::error::ExecutionError::from),
-        ))
+        let (inner_temp_store, gas_status, effects, _timings, result, _execution_error_metadata) =
+            self.executor
+                .execute_transaction_to_effects_and_execution_error(
+                    store.backing_store(),
+                    &self.protocol_config,
+                    self.execution_metrics.clone(),
+                    false, // enable_expensive_checks
+                    // TODO: Integrate with early execution error
+                    ExecutionOrEarlyError::Ok(()),
+                    &self.epoch_start_state.epoch(),
+                    self.epoch_start_state.epoch_start_timestamp_ms(),
+                    checked_input_objects,
+                    gas_data,
+                    gas_status,
+                    kind,
+                    None, // compat_args
+                    signer,
+                    tx_digest,
+                    &mut None,
+                );
+        Ok((inner_temp_store, gas_status, effects, result))
     }
 }

--- a/crates/simulacrum/src/epoch_state.rs
+++ b/crates/simulacrum/src/epoch_state.rs
@@ -170,6 +170,11 @@ impl EpochState {
                 tx_digest,
                 &mut None,
             );
-        Ok((inner_temp_store, gas_status, effects, result))
+        Ok((
+            inner_temp_store,
+            gas_status,
+            effects,
+            result.map_err(sui_types::error::ExecutionError::from),
+        ))
     }
 }

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -139,7 +139,9 @@ use sui_types::effects::{
     InputConsensusObject, SignedTransactionEffects, TransactionEffects, TransactionEffectsAPI,
     TransactionEvents, VerifiedSignedTransactionEffects,
 };
-use sui_types::error::{ExecutionError, ExecutionErrorContext, SuiErrorKind, UserInputError};
+use sui_types::error::{
+    ExecutionError, ExecutionErrorContext, ExecutionErrorMetadata, SuiErrorKind, UserInputError,
+};
 use sui_types::event::EventID;
 use sui_types::executable_transaction::VerifiedExecutableTransaction;
 use sui_types::execution_status::ExecutionErrorKind;
@@ -1461,7 +1463,7 @@ impl AuthorityState {
         certificate: &VerifiedExecutableTransaction,
         mut execution_env: ExecutionEnv,
         epoch_store: &Arc<AuthorityPerEpochStore>,
-    ) -> ExecutionOutput<(TransactionEffects, Option<ExecutionErrorContext>)> {
+    ) -> ExecutionOutput<(TransactionEffects, Option<ExecutionError>)> {
         let _scope = monitored_scope("Execution::try_execute_immediately");
         let _metrics_guard = self.metrics.internal_execution_latency.start_timer();
 
@@ -1640,10 +1642,7 @@ impl AuthorityState {
         &self,
         certificate: &VerifiedCertificate,
         execution_env: ExecutionEnv,
-    ) -> (
-        VerifiedSignedTransactionEffects,
-        Option<ExecutionErrorContext>,
-    ) {
+    ) -> (VerifiedSignedTransactionEffects, Option<ExecutionError>) {
         let epoch_store = self.epoch_store_for_testing();
         let (effects, execution_error_opt) = self
             .try_execute_immediately(
@@ -1661,10 +1660,7 @@ impl AuthorityState {
         &self,
         executable: &VerifiedExecutableTransaction,
         execution_env: ExecutionEnv,
-    ) -> (
-        VerifiedSignedTransactionEffects,
-        Option<ExecutionErrorContext>,
-    ) {
+    ) -> (VerifiedSignedTransactionEffects, Option<ExecutionError>) {
         let epoch_store = self.epoch_store_for_testing();
         let (effects, execution_error_opt) = self
             .try_execute_immediately(executable, execution_env, &epoch_store)
@@ -1740,7 +1736,7 @@ impl AuthorityState {
     ) -> ExecutionOutput<(
         TransactionOutputs,
         Vec<ExecutionTiming>,
-        Option<ExecutionErrorContext>,
+        Option<ExecutionError>,
     )> {
         let _scope = monitored_scope("Execution::process_certificate");
         let tx_digest = *certificate.digest();
@@ -1917,8 +1913,12 @@ impl AuthorityState {
         SuiGasStatus,
         TransactionEffects,
         Vec<ExecutionTiming>,
-        Result<(), ExecutionErrorContext>,
+        Result<(), ExecutionError>,
+        Option<ExecutionErrorMetadata>,
     ) {
+        // Fullnodes retain source errors and VM metadata as sidecar data for richer user-facing
+        // error reporting. Validators use the lean execution path and intentionally return no
+        // sidecar metadata so effects stay independent of non-consensus data.
         if is_fullnode {
             let (inner_temp_store, gas_status, effects, timings, execution_error) = executor
                 .execute_transaction_to_effects_and_execution_error(
@@ -1939,12 +1939,18 @@ impl AuthorityState {
                     &mut None,
                 );
 
+            let execution_error_metadata = execution_error
+                .as_ref()
+                .err()
+                .and_then(ExecutionErrorContext::metadata_with_source);
+
             (
                 inner_temp_store,
                 gas_status,
                 effects,
                 timings,
-                execution_error,
+                execution_error.map_err(ExecutionError::from),
+                execution_error_metadata,
             )
         } else {
             let (inner_temp_store, gas_status, effects, timings, execution_failure) = executor
@@ -1971,7 +1977,8 @@ impl AuthorityState {
                 gas_status,
                 effects,
                 timings,
-                execution_failure.map_err(ExecutionErrorContext::from),
+                execution_failure.map_err(ExecutionError::from),
+                None,
             )
         }
     }
@@ -1996,7 +2003,7 @@ impl AuthorityState {
     ) -> ExecutionOutput<(
         TransactionOutputs,
         Vec<ExecutionTiming>,
-        Option<ExecutionErrorContext>,
+        Option<ExecutionError>,
     )> {
         let _scope = monitored_scope("Execution::prepare_certificate");
         let _metrics_guard = self.metrics.prepare_certificate_latency.start_timer();
@@ -2060,31 +2067,37 @@ impl AuthorityState {
         let tracking_store = TrackingBackingStore::new(self.get_backing_store().as_ref());
 
         #[allow(unused_mut)]
-        let (inner_temp_store, _, mut effects, timings, execution_error_result) = self
-            .execute_transaction_to_effects(
-                &**epoch_store.executor(),
-                &tracking_store,
-                protocol_config,
-                // TODO: would be nice to pass the whole NodeConfig here, but it creates a
-                // cyclic dependency w/ sui-adapter
-                self.config
-                    .expensive_safety_check_config
-                    .enable_deep_per_tx_sui_conservation_check(),
-                execution_params,
-                &epoch_store.epoch_start_config().epoch_data().epoch_id(),
-                epoch_store
-                    .epoch_start_config()
-                    .epoch_data()
-                    .epoch_start_timestamp(),
-                input_objects,
-                gas_data,
-                gas_status,
-                kind,
-                rewritten_inputs,
-                signer,
-                tx_digest,
-                self.is_fullnode(epoch_store),
-            );
+        let (
+            inner_temp_store,
+            _,
+            mut effects,
+            timings,
+            execution_error_result,
+            execution_error_metadata,
+        ) = self.execute_transaction_to_effects(
+            &**epoch_store.executor(),
+            &tracking_store,
+            protocol_config,
+            // TODO: would be nice to pass the whole NodeConfig here, but it creates a
+            // cyclic dependency w/ sui-adapter
+            self.config
+                .expensive_safety_check_config
+                .enable_deep_per_tx_sui_conservation_check(),
+            execution_params,
+            &epoch_store.epoch_start_config().epoch_data().epoch_id(),
+            epoch_store
+                .epoch_start_config()
+                .epoch_data()
+                .epoch_start_timestamp(),
+            input_objects,
+            gas_data,
+            gas_status,
+            kind,
+            rewritten_inputs,
+            signer,
+            tx_digest,
+            self.is_fullnode(epoch_store),
+        );
 
         let execution_error_opt = execution_error_result.err();
 
@@ -2197,10 +2210,6 @@ impl AuthorityState {
                 &tracking_store.into_read_objects(),
             );
 
-        let execution_error_metadata = execution_error_opt
-            .as_ref()
-            .and_then(ExecutionErrorContext::metadata_with_source);
-
         // index certificate
         let _ = self
             .post_process_one_tx(certificate, &effects, &inner_temp_store, epoch_store)
@@ -2252,10 +2261,7 @@ impl AuthorityState {
                 epoch_store,
             )
             .unwrap();
-        Ok((
-            transaction_outputs,
-            execution_error_opt.map(ExecutionError::from),
-        ))
+        Ok((transaction_outputs, execution_error_opt))
     }
 
     #[instrument(skip_all)]

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -139,9 +139,7 @@ use sui_types::effects::{
     InputConsensusObject, SignedTransactionEffects, TransactionEffects, TransactionEffectsAPI,
     TransactionEvents, VerifiedSignedTransactionEffects,
 };
-use sui_types::error::{
-    ExecutionError, ExecutionErrorContext, ExecutionErrorMetadata, SuiErrorKind, UserInputError,
-};
+use sui_types::error::{ExecutionError, ExecutionErrorMetadata, SuiErrorKind, UserInputError};
 use sui_types::event::EventID;
 use sui_types::executable_transaction::VerifiedExecutableTransaction;
 use sui_types::execution_status::ExecutionErrorKind;
@@ -1920,36 +1918,37 @@ impl AuthorityState {
         // error reporting. Validators use the lean execution path and intentionally return no
         // sidecar metadata so effects stay independent of non-consensus data.
         if is_fullnode {
-            let (inner_temp_store, gas_status, effects, timings, execution_error) = executor
-                .execute_transaction_to_effects_and_execution_error(
-                    store,
-                    protocol_config,
-                    self.metrics.execution_metrics.clone(),
-                    enable_expensive_checks,
-                    execution_params,
-                    epoch_id,
-                    epoch_timestamp_ms,
-                    input_objects,
-                    gas_data,
-                    gas_status,
-                    kind,
-                    rewritten_inputs,
-                    signer,
-                    tx_digest,
-                    &mut None,
-                );
-
-            let execution_error_metadata = execution_error
-                .as_ref()
-                .err()
-                .and_then(ExecutionErrorContext::metadata_with_source);
+            let (
+                inner_temp_store,
+                gas_status,
+                effects,
+                timings,
+                execution_error,
+                execution_error_metadata,
+            ) = executor.execute_transaction_to_effects_and_execution_error(
+                store,
+                protocol_config,
+                self.metrics.execution_metrics.clone(),
+                enable_expensive_checks,
+                execution_params,
+                epoch_id,
+                epoch_timestamp_ms,
+                input_objects,
+                gas_data,
+                gas_status,
+                kind,
+                rewritten_inputs,
+                signer,
+                tx_digest,
+                &mut None,
+            );
 
             (
                 inner_temp_store,
                 gas_status,
                 effects,
                 timings,
-                execution_error.map_err(ExecutionError::from),
+                execution_error,
                 execution_error_metadata,
             )
         } else {

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -139,7 +139,7 @@ use sui_types::effects::{
     InputConsensusObject, SignedTransactionEffects, TransactionEffects, TransactionEffectsAPI,
     TransactionEvents, VerifiedSignedTransactionEffects,
 };
-use sui_types::error::{ExecutionError, SuiErrorKind, UserInputError};
+use sui_types::error::{ExecutionError, ExecutionErrorContext, SuiErrorKind, UserInputError};
 use sui_types::event::EventID;
 use sui_types::executable_transaction::VerifiedExecutableTransaction;
 use sui_types::execution_status::ExecutionErrorKind;
@@ -1461,7 +1461,7 @@ impl AuthorityState {
         certificate: &VerifiedExecutableTransaction,
         mut execution_env: ExecutionEnv,
         epoch_store: &Arc<AuthorityPerEpochStore>,
-    ) -> ExecutionOutput<(TransactionEffects, Option<ExecutionError>)> {
+    ) -> ExecutionOutput<(TransactionEffects, Option<ExecutionErrorContext>)> {
         let _scope = monitored_scope("Execution::try_execute_immediately");
         let _metrics_guard = self.metrics.internal_execution_latency.start_timer();
 
@@ -1640,7 +1640,10 @@ impl AuthorityState {
         &self,
         certificate: &VerifiedCertificate,
         execution_env: ExecutionEnv,
-    ) -> (VerifiedSignedTransactionEffects, Option<ExecutionError>) {
+    ) -> (
+        VerifiedSignedTransactionEffects,
+        Option<ExecutionErrorContext>,
+    ) {
         let epoch_store = self.epoch_store_for_testing();
         let (effects, execution_error_opt) = self
             .try_execute_immediately(
@@ -1658,7 +1661,10 @@ impl AuthorityState {
         &self,
         executable: &VerifiedExecutableTransaction,
         execution_env: ExecutionEnv,
-    ) -> (VerifiedSignedTransactionEffects, Option<ExecutionError>) {
+    ) -> (
+        VerifiedSignedTransactionEffects,
+        Option<ExecutionErrorContext>,
+    ) {
         let epoch_store = self.epoch_store_for_testing();
         let (effects, execution_error_opt) = self
             .try_execute_immediately(executable, execution_env, &epoch_store)
@@ -1734,7 +1740,7 @@ impl AuthorityState {
     ) -> ExecutionOutput<(
         TransactionOutputs,
         Vec<ExecutionTiming>,
-        Option<ExecutionError>,
+        Option<ExecutionErrorContext>,
     )> {
         let _scope = monitored_scope("Execution::process_certificate");
         let tx_digest = *certificate.digest();
@@ -1905,40 +1911,69 @@ impl AuthorityState {
         rewritten_inputs: Option<Vec<bool>>,
         signer: SuiAddress,
         tx_digest: TransactionDigest,
+        is_fullnode: bool,
     ) -> (
         InnerTemporaryStore,
         SuiGasStatus,
         TransactionEffects,
         Vec<ExecutionTiming>,
-        Result<(), ExecutionError>,
+        Result<(), ExecutionErrorContext>,
     ) {
-        let (inner_temp_store, gas_status, effects, timings, execution_error) = executor
-            // TODO only run this function on FullNodes, use `execute_transaction_to_effects` on validators.
-            .execute_transaction_to_effects_and_execution_error(
-                store,
-                protocol_config,
-                self.metrics.execution_metrics.clone(),
-                enable_expensive_checks,
-                execution_params,
-                epoch_id,
-                epoch_timestamp_ms,
-                input_objects,
-                gas_data,
-                gas_status,
-                kind,
-                rewritten_inputs,
-                signer,
-                tx_digest,
-                &mut None,
-            );
+        if is_fullnode {
+            let (inner_temp_store, gas_status, effects, timings, execution_error) = executor
+                .execute_transaction_to_effects_and_execution_error(
+                    store,
+                    protocol_config,
+                    self.metrics.execution_metrics.clone(),
+                    enable_expensive_checks,
+                    execution_params,
+                    epoch_id,
+                    epoch_timestamp_ms,
+                    input_objects,
+                    gas_data,
+                    gas_status,
+                    kind,
+                    rewritten_inputs,
+                    signer,
+                    tx_digest,
+                    &mut None,
+                );
 
-        (
-            inner_temp_store,
-            gas_status,
-            effects,
-            timings,
-            execution_error,
-        )
+            (
+                inner_temp_store,
+                gas_status,
+                effects,
+                timings,
+                execution_error,
+            )
+        } else {
+            let (inner_temp_store, gas_status, effects, timings, execution_failure) = executor
+                .execute_transaction_to_effects(
+                    store,
+                    protocol_config,
+                    self.metrics.execution_metrics.clone(),
+                    enable_expensive_checks,
+                    execution_params,
+                    epoch_id,
+                    epoch_timestamp_ms,
+                    input_objects,
+                    gas_data,
+                    gas_status,
+                    kind,
+                    rewritten_inputs,
+                    signer,
+                    tx_digest,
+                    &mut None,
+                );
+
+            (
+                inner_temp_store,
+                gas_status,
+                effects,
+                timings,
+                execution_failure.map_err(ExecutionErrorContext::from),
+            )
+        }
     }
 
     /// execute_certificate validates the transaction input, and executes the certificate,
@@ -1961,7 +1996,7 @@ impl AuthorityState {
     ) -> ExecutionOutput<(
         TransactionOutputs,
         Vec<ExecutionTiming>,
-        Option<ExecutionError>,
+        Option<ExecutionErrorContext>,
     )> {
         let _scope = monitored_scope("Execution::prepare_certificate");
         let _metrics_guard = self.metrics.prepare_certificate_latency.start_timer();
@@ -2024,8 +2059,7 @@ impl AuthorityState {
 
         let tracking_store = TrackingBackingStore::new(self.get_backing_store().as_ref());
 
-        #[allow(unused_mut)]
-        let (inner_temp_store, _, mut effects, timings, execution_error_opt) = self
+        let (inner_temp_store, _, effects, timings, execution_error_result) = self
             .execute_transaction_to_effects(
                 &**epoch_store.executor(),
                 &tracking_store,
@@ -2048,7 +2082,10 @@ impl AuthorityState {
                 rewritten_inputs,
                 signer,
                 tx_digest,
+                self.is_fullnode(epoch_store),
             );
+
+        let execution_error_opt = execution_error_result.err();
 
         let object_funds_checker = self.object_funds_checker.load();
         if let Some(object_funds_checker) = object_funds_checker.as_ref()
@@ -2127,6 +2164,9 @@ impl AuthorityState {
             );
         }
 
+        #[cfg(msim)]
+        let mut effects = effects;
+
         fail_point_arg!("simulate_fork_during_execution", |(
             forked_validators,
             full_halt,
@@ -2159,6 +2199,10 @@ impl AuthorityState {
                 &tracking_store.into_read_objects(),
             );
 
+        let execution_error_metadata = execution_error_opt
+            .as_ref()
+            .and_then(ExecutionErrorContext::metadata_with_source);
+
         // index certificate
         let _ = self
             .post_process_one_tx(certificate, &effects, &inner_temp_store, epoch_store)
@@ -2174,6 +2218,7 @@ impl AuthorityState {
             effects,
             inner_temp_store,
             unchanged_loaded_runtime_objects,
+            execution_error_metadata,
         );
 
         let elapsed = prepare_certificate_start_time.elapsed().as_micros() as f64;
@@ -2187,7 +2232,7 @@ impl AuthorityState {
             );
         }
 
-        ExecutionOutput::Success((transaction_outputs, timings, execution_error_opt.err()))
+        ExecutionOutput::Success((transaction_outputs, timings, execution_error_opt))
     }
 
     pub fn prepare_certificate_for_benchmark(
@@ -2209,7 +2254,10 @@ impl AuthorityState {
                 epoch_store,
             )
             .unwrap();
-        Ok((transaction_outputs, execution_error_opt))
+        Ok((
+            transaction_outputs,
+            execution_error_opt.map(ExecutionError::from),
+        ))
     }
 
     #[instrument(skip_all)]
@@ -2339,7 +2387,14 @@ impl AuthorityState {
         let execution_error_source = execution_result
             .as_ref()
             .err()
-            .and_then(|e| e.source().as_ref().map(|e| e.to_string()));
+            .and_then(|e| std::error::Error::source(e).map(|e| e.to_string()));
+        if let Some(error) = execution_result.as_ref().err() {
+            debug!(
+                tx_digest = ?tx_digest,
+                execution_error_kind = ?error.kind(),
+                "dry run transaction execution failed"
+            );
+        }
 
         let response = DryRunTransactionBlockResponse {
             suggested_gas_price,

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2059,7 +2059,8 @@ impl AuthorityState {
 
         let tracking_store = TrackingBackingStore::new(self.get_backing_store().as_ref());
 
-        let (inner_temp_store, _, effects, timings, execution_error_result) = self
+        #[allow(unused_mut)]
+        let (inner_temp_store, _, mut effects, timings, execution_error_result) = self
             .execute_transaction_to_effects(
                 &**epoch_store.executor(),
                 &tracking_store,
@@ -2163,9 +2164,6 @@ impl AuthorityState {
                 effects.digest()
             );
         }
-
-        #[cfg(msim)]
-        let mut effects = effects;
 
         fail_point_arg!("simulate_fork_during_execution", |(
             forked_validators,
@@ -2388,13 +2386,6 @@ impl AuthorityState {
             .as_ref()
             .err()
             .and_then(|e| std::error::Error::source(e).map(|e| e.to_string()));
-        if let Some(error) = execution_result.as_ref().err() {
-            debug!(
-                tx_digest = ?tx_digest,
-                execution_error_kind = ?error.kind(),
-                "dry run transaction execution failed"
-            );
-        }
 
         let response = DryRunTransactionBlockResponse {
             suggested_gas_price,

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2390,7 +2390,7 @@ impl AuthorityState {
         let execution_error_source = execution_result
             .as_ref()
             .err()
-            .and_then(|e| std::error::Error::source(e).map(|e| e.to_string()));
+            .and_then(|e| e.source().as_ref().map(|e| e.to_string()));
 
         let response = DryRunTransactionBlockResponse {
             suggested_gas_price,

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2072,7 +2072,7 @@ impl AuthorityState {
             _,
             mut effects,
             timings,
-            execution_error_result,
+            execution_error_opt,
             execution_error_metadata,
         ) = self.execute_transaction_to_effects(
             &**epoch_store.executor(),
@@ -2099,7 +2099,7 @@ impl AuthorityState {
             self.is_fullnode(epoch_store),
         );
 
-        let execution_error_opt = execution_error_result.err();
+        let execution_error_opt = execution_error_opt.err();
 
         let object_funds_checker = self.object_funds_checker.load();
         if let Some(object_funds_checker) = object_funds_checker.as_ref()

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -19,9 +19,11 @@ use fastcrypto::hash::{HashFunction, MultisetHash, Sha3_256};
 use futures::stream::FuturesUnordered;
 use move_core_types::account_address::AccountAddress;
 use move_core_types::resolver::{ModuleResolver, SerializedPackage};
+use prost::Message as _;
 use serde::{Deserialize, Serialize};
 use sui_config::node::AuthorityStorePruningConfig;
 use sui_macros::fail_point_arg;
+use sui_rpc::proto::sui::rpc::v2::ExecutionErrorMetadata as RpcExecutionErrorMetadata;
 use sui_types::error::{ExecutionErrorMetadata, SuiErrorKind, UserInputError};
 use sui_types::execution::TypeLayoutStore;
 use sui_types::global_state_hash::GlobalStateHash;
@@ -348,7 +350,19 @@ impl AuthorityStore {
         &self,
         digest: &TransactionDigest,
     ) -> Result<Option<ExecutionErrorMetadata>, TypedStoreError> {
-        self.perpetual_tables.execution_error_metadata.get(digest)
+        self.perpetual_tables
+            .execution_error_metadata
+            .get(digest)?
+            .map(|bytes| {
+                RpcExecutionErrorMetadata::decode(bytes.as_slice())
+                    .map(|metadata| ExecutionErrorMetadata::from(&metadata))
+            })
+            .transpose()
+            .map_err(|err| {
+                TypedStoreError::SerializationError(format!(
+                    "failed to decode execution error metadata: {err}"
+                ))
+            })
     }
 
     pub fn multi_get_effects<'a>(
@@ -872,11 +886,12 @@ impl AuthorityStore {
         }
 
         if let Some(metadata) = execution_error_metadata
-            && !metadata.attributes.is_empty()
+            && !metadata.is_empty()
         {
+            let metadata: RpcExecutionErrorMetadata = metadata.into();
             write_batch.insert_batch(
                 &self.perpetual_tables.execution_error_metadata,
-                [(transaction_digest, metadata)],
+                [(transaction_digest, metadata.encode_to_vec())],
             )?;
         }
 

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -872,7 +872,7 @@ impl AuthorityStore {
         }
 
         if let Some(metadata) = execution_error_metadata
-            && !metadata.is_empty()
+            && !metadata.attributes.is_empty()
         {
             write_batch.insert_batch(
                 &self.perpetual_tables.execution_error_metadata,

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -22,7 +22,7 @@ use move_core_types::resolver::{ModuleResolver, SerializedPackage};
 use serde::{Deserialize, Serialize};
 use sui_config::node::AuthorityStorePruningConfig;
 use sui_macros::fail_point_arg;
-use sui_types::error::{SuiErrorKind, UserInputError};
+use sui_types::error::{ExecutionErrorMetadata, SuiErrorKind, UserInputError};
 use sui_types::execution::TypeLayoutStore;
 use sui_types::global_state_hash::GlobalStateHash;
 use sui_types::message_envelope::Message;
@@ -342,6 +342,13 @@ impl AuthorityStore {
         self.perpetual_tables
             .unchanged_loaded_runtime_objects
             .get(digest)
+    }
+
+    pub fn get_execution_error_metadata(
+        &self,
+        digest: &TransactionDigest,
+    ) -> Result<Option<ExecutionErrorMetadata>, TypedStoreError> {
+        self.perpetual_tables.execution_error_metadata.get(digest)
     }
 
     pub fn multi_get_effects<'a>(
@@ -791,6 +798,7 @@ impl AuthorityStore {
             written,
             events,
             unchanged_loaded_runtime_objects,
+            execution_error_metadata,
             locks_to_delete,
             new_locks_to_init,
             ..
@@ -860,6 +868,15 @@ impl AuthorityStore {
             write_batch.insert_batch(
                 &self.perpetual_tables.unchanged_loaded_runtime_objects,
                 [(transaction_digest, unchanged_loaded_runtime_objects)],
+            )?;
+        }
+
+        if let Some(metadata) = execution_error_metadata
+            && !metadata.is_empty()
+        {
+            write_batch.insert_batch(
+                &self.perpetual_tables.execution_error_metadata,
+                [(transaction_digest, metadata)],
             )?;
         }
 

--- a/crates/sui-core/src/authority/authority_store_pruner.rs
+++ b/crates/sui-core/src/authority/authority_store_pruner.rs
@@ -300,6 +300,8 @@ impl AuthorityStorePruner {
             &perpetual_db.unchanged_loaded_runtime_objects,
             transactions.iter(),
         )?;
+        perpetual_batch
+            .delete_batch(&perpetual_db.execution_error_metadata, transactions.iter())?;
         perpetual_batch.delete_batch(&perpetual_db.effects, effect_digests)?;
 
         let mut checkpoints_batch = checkpoint_db.tables.certified_checkpoints.batch();

--- a/crates/sui-core/src/authority/authority_store_tables.rs
+++ b/crates/sui-core/src/authority/authority_store_tables.rs
@@ -11,6 +11,7 @@ use std::path::Path;
 use std::sync::atomic::AtomicU64;
 use sui_types::base_types::SequenceNumber;
 use sui_types::effects::{TransactionEffects, TransactionEvents};
+use sui_types::error::ExecutionErrorMetadata;
 use sui_types::global_state_hash::GlobalStateHash;
 use sui_types::storage::MarkerValue;
 use typed_store::metrics::SamplingInterval;
@@ -99,6 +100,9 @@ pub struct AuthorityPerpetualTables {
 
     // Loaded (and unchanged) runtime object references.
     pub(crate) unchanged_loaded_runtime_objects: DBMap<TransactionDigest, Vec<ObjectKey>>,
+
+    // Local execution error metadata, keyed by the digest of the transaction that produced it.
+    pub(crate) execution_error_metadata: DBMap<TransactionDigest, ExecutionErrorMetadata>,
 
     /// DEPRECATED in favor of the table of the same name in authority_per_epoch_store.
     /// Please do not add new accessors/callsites.
@@ -323,6 +327,16 @@ impl AuthorityPerpetualTables {
             ),
             (
                 "unchanged_loaded_runtime_objects".to_string(),
+                ThConfig::new_with_rm_prefix(
+                    32,
+                    mutexes,
+                    uniform_key,
+                    KeySpaceConfig::default().with_relocation_filter(|_, _| Decision::Remove),
+                    digest_prefix.clone(),
+                ),
+            ),
+            (
+                "execution_error_metadata".to_string(),
                 ThConfig::new_with_rm_prefix(
                     32,
                     mutexes,

--- a/crates/sui-core/src/authority/authority_store_tables.rs
+++ b/crates/sui-core/src/authority/authority_store_tables.rs
@@ -101,6 +101,7 @@ pub struct AuthorityPerpetualTables {
     pub(crate) unchanged_loaded_runtime_objects: DBMap<TransactionDigest, Vec<ObjectKey>>,
 
     // Local execution error metadata, keyed by the digest of the transaction that produced it.
+    // Values are encoded `sui_rpc::proto::sui::rpc::v2::ExecutionErrorMetadata` bytes.
     pub(crate) execution_error_metadata: DBMap<TransactionDigest, Vec<u8>>,
 
     /// DEPRECATED in favor of the table of the same name in authority_per_epoch_store.
@@ -944,62 +945,4 @@ fn effects_table_config(db_options: DBOptions) -> DBOptions {
         .optimize_for_point_lookup(
             read_size_from_env(ENV_VAR_EFFECTS_BLOCK_CACHE_SIZE).unwrap_or(1024),
         )
-}
-
-#[cfg(test)]
-mod tests {
-    use prost::Message as _;
-    use sui_rpc::proto::sui::rpc::v2::ExecutionErrorMetadata as RpcExecutionErrorMetadata;
-    use sui_types::digests::TransactionDigest;
-    use sui_types::error::ExecutionErrorMetadata;
-    use typed_store::DBMapUtils;
-    use typed_store::rocks::{DBMap, MetricConf};
-    use typed_store::traits::Map;
-
-    #[derive(Clone, PartialEq, prost::Message)]
-    struct FutureExecutionErrorMetadata {
-        #[prost(string, optional, tag = "1")]
-        message: Option<String>,
-        #[prost(string, optional, tag = "2")]
-        future_field: Option<String>,
-    }
-
-    #[tokio::test]
-    async fn execution_error_metadata_table_accepts_future_proto_schema() {
-        #[derive(DBMapUtils)]
-        struct ExecutionErrorMetadataTables {
-            execution_error_metadata: DBMap<TransactionDigest, Vec<u8>>,
-        }
-
-        let tempdir = tempfile::tempdir().unwrap();
-        let tables = ExecutionErrorMetadataTables::open_tables_read_write(
-            tempdir.path().to_owned(),
-            MetricConf::new("test_execution_error_metadata"),
-            None,
-            None,
-        );
-        let digest = TransactionDigest::random();
-        let future_metadata = FutureExecutionErrorMetadata {
-            message: Some("Object runtime cached objects limit reached".to_string()),
-            future_field: Some("new metadata added by a future schema".to_string()),
-        };
-
-        tables
-            .execution_error_metadata
-            .insert(&digest, &future_metadata.encode_to_vec())
-            .unwrap();
-
-        let stored_metadata = tables
-            .execution_error_metadata
-            .get(&digest)
-            .unwrap()
-            .unwrap();
-        let rpc_metadata = RpcExecutionErrorMetadata::decode(stored_metadata.as_slice()).unwrap();
-        let metadata = ExecutionErrorMetadata::from(&rpc_metadata);
-
-        assert_eq!(
-            metadata.message.as_deref(),
-            Some("Object runtime cached objects limit reached")
-        );
-    }
 }

--- a/crates/sui-core/src/authority/authority_store_tables.rs
+++ b/crates/sui-core/src/authority/authority_store_tables.rs
@@ -11,7 +11,6 @@ use std::path::Path;
 use std::sync::atomic::AtomicU64;
 use sui_types::base_types::SequenceNumber;
 use sui_types::effects::{TransactionEffects, TransactionEvents};
-use sui_types::error::ExecutionErrorMetadata;
 use sui_types::global_state_hash::GlobalStateHash;
 use sui_types::storage::MarkerValue;
 use typed_store::metrics::SamplingInterval;
@@ -102,7 +101,7 @@ pub struct AuthorityPerpetualTables {
     pub(crate) unchanged_loaded_runtime_objects: DBMap<TransactionDigest, Vec<ObjectKey>>,
 
     // Local execution error metadata, keyed by the digest of the transaction that produced it.
-    pub(crate) execution_error_metadata: DBMap<TransactionDigest, ExecutionErrorMetadata>,
+    pub(crate) execution_error_metadata: DBMap<TransactionDigest, Vec<u8>>,
 
     /// DEPRECATED in favor of the table of the same name in authority_per_epoch_store.
     /// Please do not add new accessors/callsites.
@@ -945,4 +944,62 @@ fn effects_table_config(db_options: DBOptions) -> DBOptions {
         .optimize_for_point_lookup(
             read_size_from_env(ENV_VAR_EFFECTS_BLOCK_CACHE_SIZE).unwrap_or(1024),
         )
+}
+
+#[cfg(test)]
+mod tests {
+    use prost::Message as _;
+    use sui_rpc::proto::sui::rpc::v2::ExecutionErrorMetadata as RpcExecutionErrorMetadata;
+    use sui_types::digests::TransactionDigest;
+    use sui_types::error::ExecutionErrorMetadata;
+    use typed_store::DBMapUtils;
+    use typed_store::rocks::{DBMap, MetricConf};
+    use typed_store::traits::Map;
+
+    #[derive(Clone, PartialEq, prost::Message)]
+    struct FutureExecutionErrorMetadata {
+        #[prost(string, optional, tag = "1")]
+        message: Option<String>,
+        #[prost(string, optional, tag = "2")]
+        future_field: Option<String>,
+    }
+
+    #[tokio::test]
+    async fn execution_error_metadata_table_accepts_future_proto_schema() {
+        #[derive(DBMapUtils)]
+        struct ExecutionErrorMetadataTables {
+            execution_error_metadata: DBMap<TransactionDigest, Vec<u8>>,
+        }
+
+        let tempdir = tempfile::tempdir().unwrap();
+        let tables = ExecutionErrorMetadataTables::open_tables_read_write(
+            tempdir.path().to_owned(),
+            MetricConf::new("test_execution_error_metadata"),
+            None,
+            None,
+        );
+        let digest = TransactionDigest::random();
+        let future_metadata = FutureExecutionErrorMetadata {
+            message: Some("Object runtime cached objects limit reached".to_string()),
+            future_field: Some("new metadata added by a future schema".to_string()),
+        };
+
+        tables
+            .execution_error_metadata
+            .insert(&digest, &future_metadata.encode_to_vec())
+            .unwrap();
+
+        let stored_metadata = tables
+            .execution_error_metadata
+            .get(&digest)
+            .unwrap()
+            .unwrap();
+        let rpc_metadata = RpcExecutionErrorMetadata::decode(stored_metadata.as_slice()).unwrap();
+        let metadata = ExecutionErrorMetadata::from(&rpc_metadata);
+
+        assert_eq!(
+            metadata.message.as_deref(),
+            Some("Object runtime cached objects limit reached")
+        );
+    }
 }

--- a/crates/sui-core/src/authority/authority_test_utils.rs
+++ b/crates/sui-core/src/authority/authority_test_utils.rs
@@ -120,7 +120,7 @@ pub async fn execute_from_consensus(
         .try_execute_executable_for_test(&executable, env)
         .await;
     let effects = result.inner().data().clone();
-    (effects, execution_error_opt.map(ExecutionError::from))
+    (effects, execution_error_opt)
 }
 
 /// This is the primary test helper for executing transactions end-to-end.
@@ -221,11 +221,7 @@ pub async fn submit_and_execute_with_error(
         execution_error_opt = fullnode_execution_error_opt;
     }
 
-    Ok((
-        executable,
-        result.into_inner(),
-        execution_error_opt.map(ExecutionError::from),
-    ))
+    Ok((executable, result.into_inner(), execution_error_opt))
 }
 
 /// Enqueues multiple transactions for execution after they've been through consensus.

--- a/crates/sui-core/src/authority/authority_test_utils.rs
+++ b/crates/sui-core/src/authority/authority_test_utils.rs
@@ -120,7 +120,7 @@ pub async fn execute_from_consensus(
         .try_execute_executable_for_test(&executable, env)
         .await;
     let effects = result.inner().data().clone();
-    (effects, execution_error_opt)
+    (effects, execution_error_opt.map(ExecutionError::from))
 }
 
 /// This is the primary test helper for executing transactions end-to-end.
@@ -221,7 +221,11 @@ pub async fn submit_and_execute_with_error(
         execution_error_opt = fullnode_execution_error_opt;
     }
 
-    Ok((executable, result.into_inner(), execution_error_opt))
+    Ok((
+        executable,
+        result.into_inner(),
+        execution_error_opt.map(ExecutionError::from),
+    ))
 }
 
 /// Enqueues multiple transactions for execution after they've been through consensus.

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/data_ingestion_handler.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/data_ingestion_handler.rs
@@ -123,6 +123,8 @@ pub(crate) fn load_checkpoint(
             signatures: tx.tx_signatures().to_vec(),
             effects: fx.clone(),
             events,
+            execution_error_metadata: transaction_cache_reader
+                .get_execution_error_metadata(tx.digest()),
             unchanged_loaded_runtime_objects: transaction_cache_reader
                 .get_unchanged_loaded_runtime_objects(tx.digest())
                 // We don't write empty sets to the DB to save space, so if this load went through

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -4190,6 +4190,13 @@ mod tests {
             unimplemented!()
         }
 
+        fn get_execution_error_metadata(
+            &self,
+            _digest: &TransactionDigest,
+        ) -> Option<sui_types::error::ExecutionErrorMetadata> {
+            unimplemented!()
+        }
+
         fn transaction_executed_in_last_epoch(&self, _: &TransactionDigest, _: EpochId) -> bool {
             unimplemented!()
         }

--- a/crates/sui-core/src/execution_cache.rs
+++ b/crates/sui-core/src/execution_cache.rs
@@ -26,7 +26,7 @@ use sui_protocol_config::ProtocolVersion;
 use sui_types::base_types::{FullObjectID, VerifiedExecutionData};
 use sui_types::digests::{TransactionDigest, TransactionEffectsDigest};
 use sui_types::effects::{TransactionEffects, TransactionEvents};
-use sui_types::error::{SuiError, SuiErrorKind, SuiResult, UserInputError};
+use sui_types::error::{ExecutionErrorMetadata, SuiError, SuiErrorKind, SuiResult, UserInputError};
 use sui_types::executable_transaction::VerifiedExecutableTransaction;
 use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 use sui_types::object::Object;
@@ -533,6 +533,11 @@ pub trait TransactionCacheRead: Send + Sync {
         &self,
         digest: &TransactionDigest,
     ) -> Option<Vec<ObjectKey>>;
+
+    fn get_execution_error_metadata(
+        &self,
+        digest: &TransactionDigest,
+    ) -> Option<ExecutionErrorMetadata>;
 
     fn take_accumulator_events(&self, digest: &TransactionDigest) -> Option<Vec<AccumulatorEvent>>;
 

--- a/crates/sui-core/src/execution_cache/unit_tests/writeback_cache_tests.rs
+++ b/crates/sui-core/src/execution_cache/unit_tests/writeback_cache_tests.rs
@@ -564,6 +564,7 @@ async fn test_execution_error_metadata_round_trip() {
         s.outputs.execution_error_metadata = Some(metadata.clone());
 
         let tx = s.do_tx().await;
+        assert!(s.cache.dirty.execution_error_metadata.contains_key(&tx));
         assert_eq!(
             s.cache.get_execution_error_metadata(&tx),
             Some(metadata.clone())
@@ -581,6 +582,26 @@ async fn test_execution_error_metadata_round_trip() {
             Some(metadata.clone())
         );
         assert_eq!(s.cache.get_execution_error_metadata(&tx), Some(metadata));
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn test_empty_execution_error_metadata_is_ignored() {
+    telemetry_subscribers::init_for_testing();
+    Scenario::iterate(|mut s| async move {
+        s.outputs.execution_error_metadata = Some(BTreeMap::new());
+
+        let tx = s.do_tx().await;
+        assert!(!s.cache.dirty.execution_error_metadata.contains_key(&tx));
+        assert_eq!(s.cache.get_execution_error_metadata(&tx), None);
+
+        s.commit(tx).await.unwrap();
+        assert_eq!(s.cache.get_execution_error_metadata(&tx), None);
+
+        s.reset_cache();
+        assert_eq!(s.store.get_execution_error_metadata(&tx).unwrap(), None);
+        assert_eq!(s.cache.get_execution_error_metadata(&tx), None);
     })
     .await;
 }

--- a/crates/sui-core/src/execution_cache/unit_tests/writeback_cache_tests.rs
+++ b/crates/sui-core/src/execution_cache/unit_tests/writeback_cache_tests.rs
@@ -23,6 +23,7 @@ use sui_types::{
 };
 use sui_types::{
     effects::{TestEffectsBuilder, TransactionEffectsAPI},
+    error::ExecutionErrorMetadata,
     event::Event,
 };
 use tokio::sync::RwLock;
@@ -556,11 +557,12 @@ async fn test_committed() {
 async fn test_execution_error_metadata_round_trip() {
     telemetry_subscribers::init_for_testing();
     Scenario::iterate(|mut s| async move {
-        let mut metadata = BTreeMap::new();
-        metadata.insert(
-            "source".to_string(),
-            "Object runtime cached objects limit reached".to_string(),
-        );
+        let metadata = ExecutionErrorMetadata {
+            attributes: BTreeMap::from([(
+                "source".to_string(),
+                "Object runtime cached objects limit reached".to_string(),
+            )]),
+        };
         s.outputs.execution_error_metadata = Some(metadata.clone());
 
         let tx = s.do_tx().await;
@@ -590,7 +592,7 @@ async fn test_execution_error_metadata_round_trip() {
 async fn test_empty_execution_error_metadata_is_ignored() {
     telemetry_subscribers::init_for_testing();
     Scenario::iterate(|mut s| async move {
-        s.outputs.execution_error_metadata = Some(BTreeMap::new());
+        s.outputs.execution_error_metadata = Some(ExecutionErrorMetadata::default());
 
         let tx = s.do_tx().await;
         assert!(!s.cache.dirty.execution_error_metadata.contains_key(&tx));

--- a/crates/sui-core/src/execution_cache/unit_tests/writeback_cache_tests.rs
+++ b/crates/sui-core/src/execution_cache/unit_tests/writeback_cache_tests.rs
@@ -157,6 +157,7 @@ impl Scenario {
             effects,
             events,
             unchanged_loaded_runtime_objects: Default::default(),
+            execution_error_metadata: None,
             accumulator_events: Default::default(),
             markers: Default::default(),
             wrapped: Default::default(),
@@ -547,6 +548,39 @@ async fn test_committed() {
 
         s.reset_cache();
         s.assert_live(&[1, 2]);
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn test_execution_error_metadata_round_trip() {
+    telemetry_subscribers::init_for_testing();
+    Scenario::iterate(|mut s| async move {
+        let mut metadata = BTreeMap::new();
+        metadata.insert(
+            "source".to_string(),
+            "Object runtime cached objects limit reached".to_string(),
+        );
+        s.outputs.execution_error_metadata = Some(metadata.clone());
+
+        let tx = s.do_tx().await;
+        assert_eq!(
+            s.cache.get_execution_error_metadata(&tx),
+            Some(metadata.clone())
+        );
+
+        s.commit(tx).await.unwrap();
+        assert_eq!(
+            s.cache.get_execution_error_metadata(&tx),
+            Some(metadata.clone())
+        );
+
+        s.reset_cache();
+        assert_eq!(
+            s.store.get_execution_error_metadata(&tx).unwrap(),
+            Some(metadata.clone())
+        );
+        assert_eq!(s.cache.get_execution_error_metadata(&tx), Some(metadata));
     })
     .await;
 }

--- a/crates/sui-core/src/execution_cache/unit_tests/writeback_cache_tests.rs
+++ b/crates/sui-core/src/execution_cache/unit_tests/writeback_cache_tests.rs
@@ -557,12 +557,7 @@ async fn test_committed() {
 async fn test_execution_error_metadata_round_trip() {
     telemetry_subscribers::init_for_testing();
     Scenario::iterate(|mut s| async move {
-        let metadata = ExecutionErrorMetadata {
-            attributes: BTreeMap::from([(
-                "source".to_string(),
-                "Object runtime cached objects limit reached".to_string(),
-            )]),
-        };
+        let metadata = ExecutionErrorMetadata::new("Object runtime cached objects limit reached");
         s.outputs.execution_error_metadata = Some(metadata.clone());
 
         let tx = s.do_tx().await;

--- a/crates/sui-core/src/execution_cache/writeback_cache.rs
+++ b/crates/sui-core/src/execution_cache/writeback_cache.rs
@@ -233,6 +233,8 @@ struct UncommittedData {
 
     unchanged_loaded_runtime_objects: DashMap<TransactionDigest, Vec<ObjectKey>>,
 
+    /// Error metadata originating from `ExecutionErrorContext`, retained with transaction
+    /// data until pruning. Includes source errors and VM-level details when available.
     execution_error_metadata: DashMap<TransactionDigest, ExecutionErrorMetadata>,
 
     executed_effects_digests: DashMap<TransactionDigest, TransactionEffectsDigest>,
@@ -995,7 +997,7 @@ impl WritebackCache {
             .insert(tx_digest, unchanged_loaded_runtime_objects.clone());
 
         if let Some(metadata) = execution_error_metadata
-            && !metadata.is_empty()
+            && !metadata.attributes.is_empty()
         {
             self.metrics.record_cache_write("execution_error_metadata");
             self.dirty

--- a/crates/sui-core/src/execution_cache/writeback_cache.rs
+++ b/crates/sui-core/src/execution_cache/writeback_cache.rs
@@ -76,7 +76,7 @@ use sui_types::base_types::{
 use sui_types::bridge::{Bridge, get_bridge};
 use sui_types::digests::{ObjectDigest, TransactionDigest, TransactionEffectsDigest};
 use sui_types::effects::{TransactionEffects, TransactionEvents};
-use sui_types::error::{SuiError, SuiErrorKind, SuiResult, UserInputError};
+use sui_types::error::{ExecutionErrorMetadata, SuiError, SuiErrorKind, SuiResult, UserInputError};
 use sui_types::executable_transaction::VerifiedExecutableTransaction;
 use sui_types::global_state_hash::GlobalStateHash;
 use sui_types::message_envelope::Message;
@@ -233,6 +233,8 @@ struct UncommittedData {
 
     unchanged_loaded_runtime_objects: DashMap<TransactionDigest, Vec<ObjectKey>>,
 
+    execution_error_metadata: DashMap<TransactionDigest, ExecutionErrorMetadata>,
+
     executed_effects_digests: DashMap<TransactionDigest, TransactionEffectsDigest>,
 
     // Transaction outputs that have not yet been written to the DB. Items are removed from this
@@ -253,6 +255,7 @@ impl UncommittedData {
             pending_transaction_writes: DashMap::with_shard_amount(2048),
             transaction_events: DashMap::with_shard_amount(2048),
             unchanged_loaded_runtime_objects: DashMap::with_shard_amount(2048),
+            execution_error_metadata: DashMap::with_shard_amount(2048),
             total_transaction_inserts: AtomicU64::new(0),
             total_transaction_commits: AtomicU64::new(0),
         }
@@ -266,6 +269,7 @@ impl UncommittedData {
         self.pending_transaction_writes.clear();
         self.transaction_events.clear();
         self.unchanged_loaded_runtime_objects.clear();
+        self.execution_error_metadata.clear();
         self.total_transaction_inserts
             .store(0, std::sync::atomic::Ordering::Relaxed);
         self.total_transaction_commits
@@ -282,6 +286,7 @@ impl UncommittedData {
                     && self.executed_effects_digests.is_empty()
                     && self.transaction_events.is_empty()
                     && self.unchanged_loaded_runtime_objects.is_empty()
+                    && self.execution_error_metadata.is_empty()
                     && self
                         .total_transaction_inserts
                         .load(std::sync::atomic::Ordering::Relaxed)
@@ -913,6 +918,7 @@ impl WritebackCache {
             wrapped,
             events,
             unchanged_loaded_runtime_objects,
+            execution_error_metadata,
             ..
         } = &*tx_outputs;
 
@@ -987,6 +993,15 @@ impl WritebackCache {
         self.dirty
             .unchanged_loaded_runtime_objects
             .insert(tx_digest, unchanged_loaded_runtime_objects.clone());
+
+        if let Some(metadata) = execution_error_metadata
+            && !metadata.is_empty()
+        {
+            self.metrics.record_cache_write("execution_error_metadata");
+            self.dirty
+                .execution_error_metadata
+                .insert(tx_digest, metadata.clone());
+        }
 
         self.metrics.record_cache_write("executed_effects_digests");
         self.dirty
@@ -1189,6 +1204,8 @@ impl WritebackCache {
             .unchanged_loaded_runtime_objects
             .remove(&tx_digest)
             .expect("unchanged_loaded_runtime_objects must exist");
+
+        self.dirty.execution_error_metadata.remove(&tx_digest);
 
         self.dirty
             .executed_effects_digests
@@ -2305,6 +2322,21 @@ impl TransactionCacheRead for WritebackCache {
             .or_else(|| {
                 self.store
                     .get_unchanged_loaded_runtime_objects(digest)
+                    .expect("db error")
+            })
+    }
+
+    fn get_execution_error_metadata(
+        &self,
+        digest: &TransactionDigest,
+    ) -> Option<ExecutionErrorMetadata> {
+        self.dirty
+            .execution_error_metadata
+            .get(digest)
+            .map(|b| b.clone())
+            .or_else(|| {
+                self.store
+                    .get_execution_error_metadata(digest)
                     .expect("db error")
             })
     }

--- a/crates/sui-core/src/execution_cache/writeback_cache.rs
+++ b/crates/sui-core/src/execution_cache/writeback_cache.rs
@@ -997,7 +997,7 @@ impl WritebackCache {
             .insert(tx_digest, unchanged_loaded_runtime_objects.clone());
 
         if let Some(metadata) = execution_error_metadata
-            && !metadata.attributes.is_empty()
+            && !metadata.is_empty()
         {
             self.metrics.record_cache_write("execution_error_metadata");
             self.dirty

--- a/crates/sui-core/src/storage.rs
+++ b/crates/sui-core/src/storage.rs
@@ -19,7 +19,7 @@ use sui_types::base_types::TransactionDigest;
 use sui_types::committee::Committee;
 use sui_types::committee::EpochId;
 use sui_types::effects::{TransactionEffects, TransactionEvents};
-use sui_types::error::{SuiErrorKind, SuiResult};
+use sui_types::error::{ExecutionErrorMetadata, SuiErrorKind, SuiResult};
 use sui_types::full_checkpoint_content::ObjectSet;
 use sui_types::messages_checkpoint::CheckpointContentsDigest;
 use sui_types::messages_checkpoint::CheckpointDigest;
@@ -243,6 +243,15 @@ impl ReadStore for RocksDbStore {
         self.cache_traits
             .transaction_cache_reader
             .get_unchanged_loaded_runtime_objects(digest)
+    }
+
+    fn get_execution_error_metadata(
+        &self,
+        digest: &TransactionDigest,
+    ) -> Option<ExecutionErrorMetadata> {
+        self.cache_traits
+            .transaction_cache_reader
+            .get_execution_error_metadata(digest)
     }
 
     fn get_transaction_checkpoint(
@@ -487,6 +496,13 @@ impl ReadStore for RestReadStore {
         digest: &TransactionDigest,
     ) -> Option<Vec<ObjectKey>> {
         self.rocks.get_unchanged_loaded_runtime_objects(digest)
+    }
+
+    fn get_execution_error_metadata(
+        &self,
+        digest: &TransactionDigest,
+    ) -> Option<ExecutionErrorMetadata> {
+        self.rocks.get_execution_error_metadata(digest)
     }
 
     fn get_transaction_checkpoint(

--- a/crates/sui-core/src/transaction_outputs.rs
+++ b/crates/sui-core/src/transaction_outputs.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 use sui_types::accumulator_event::AccumulatorEvent;
 use sui_types::base_types::{FullObjectID, ObjectRef};
 use sui_types::effects::{TransactionEffects, TransactionEffectsAPI, TransactionEvents};
+use sui_types::error::ExecutionErrorMetadata;
 use sui_types::full_checkpoint_content::ObjectSet;
 use sui_types::inner_temporary_store::{InnerTemporaryStore, WrittenObjects};
 use sui_types::storage::{FullObjectKey, MarkerValue, ObjectKey};
@@ -19,6 +20,7 @@ pub struct TransactionOutputs {
     pub effects: TransactionEffects,
     pub events: TransactionEvents,
     pub unchanged_loaded_runtime_objects: Vec<ObjectKey>,
+    pub execution_error_metadata: Option<ExecutionErrorMetadata>,
     pub accumulator_events: Mutex<Option<Vec<AccumulatorEvent>>>,
 
     pub markers: Vec<(FullObjectKey, MarkerValue)>,
@@ -36,6 +38,7 @@ impl TransactionOutputs {
         effects: TransactionEffects,
         inner_temporary_store: InnerTemporaryStore,
         unchanged_loaded_runtime_objects: Vec<ObjectKey>,
+        execution_error_metadata: Option<ExecutionErrorMetadata>,
     ) -> TransactionOutputs {
         let InnerTemporaryStore {
             input_objects,
@@ -186,6 +189,7 @@ impl TransactionOutputs {
             effects,
             events,
             unchanged_loaded_runtime_objects,
+            execution_error_metadata,
             accumulator_events: Mutex::new(Some(accumulator_events)),
             markers,
             wrapped,
@@ -210,6 +214,7 @@ impl TransactionOutputs {
             effects,
             events: TransactionEvents { data: vec![] },
             unchanged_loaded_runtime_objects: vec![],
+            execution_error_metadata: None,
             accumulator_events: Mutex::new(Some(vec![])),
             markers: vec![],
             wrapped: vec![],

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -5486,8 +5486,8 @@ async fn test_validator_execution_does_not_store_error_metadata() {
         .unwrap();
     assert!(
         fullnode_metadata
-            .attributes
-            .get("source")
+            .message
+            .as_deref()
             .is_some_and(|source| source.contains("bad_function"))
     );
 }

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -34,7 +34,7 @@ use sui_protocol_config::{
     Chain, ExecutionTimeEstimateParams, PerObjectCongestionControlMode, ProtocolConfig,
     ProtocolVersion,
 };
-use sui_types::effects::TransactionEffects;
+use sui_types::effects::{TransactionEffects, TransactionEffectsAPI};
 use sui_types::epoch_data::EpochData;
 use sui_types::error::UserInputError;
 use sui_types::execution::SharedInput;
@@ -5396,6 +5396,101 @@ async fn test_function_not_found() {
     );
 
     assert_eq!(execution_error_source, Some("Could not resolve function 'bad_function' in module '0x0000000000000000000000000000000000000000000000000000000000000001::option'".to_string()),)
+}
+
+#[tokio::test]
+async fn test_validator_execution_does_not_store_error_metadata() {
+    let (sender, sender_key): (_, AccountKeyPair) = get_key_pair();
+    let gas_object_id = ObjectID::random();
+    let (validator, fullnode, _) =
+        init_state_with_ids_and_object_basics_with_fullnode(vec![(sender, gas_object_id)]).await;
+
+    let mut builder = ProgrammableTransactionBuilder::new();
+    builder
+        .move_call(
+            ObjectID::from_single_byte(1),
+            ident_str!("option").to_owned(),
+            ident_str!("bad_function").to_owned(),
+            vec![],
+            vec![],
+        )
+        .unwrap();
+    let kind = TransactionKind::programmable(builder.finish());
+
+    let rgp = validator.reference_gas_price_for_testing().unwrap();
+    let txn_data = TransactionData::new_with_gas_coins(
+        kind,
+        sender,
+        vec![
+            validator
+                .get_object(&gas_object_id)
+                .await
+                .unwrap()
+                .compute_object_reference(),
+        ],
+        TEST_ONLY_GAS_UNIT_FOR_PUBLISH * rgp,
+        rgp,
+    );
+
+    let transaction = to_sender_signed_transaction(txn_data, &sender_key);
+    let executable = create_executable_transaction(&validator, transaction).unwrap();
+    let env = ExecutionEnv::new().with_assigned_versions(AssignedVersions::new(vec![], None));
+
+    let (validator_effects, validator_execution_error) = validator
+        .try_execute_executable_for_test(&executable, env.clone())
+        .await;
+    let (fullnode_effects, fullnode_execution_error) = fullnode
+        .try_execute_executable_for_test(&executable, env)
+        .await;
+
+    let validator_effects = validator_effects.inner().data();
+    let fullnode_effects = fullnode_effects.inner().data();
+    assert_eq!(validator_effects.status(), fullnode_effects.status());
+    assert_eq!(
+        validator_effects.transaction_digest(),
+        fullnode_effects.transaction_digest()
+    );
+    assert_eq!(
+        validator_effects.gas_cost_summary(),
+        fullnode_effects.gas_cost_summary()
+    );
+    assert_eq!(validator_effects.created(), fullnode_effects.created());
+    assert_eq!(validator_effects.mutated(), fullnode_effects.mutated());
+    assert_eq!(validator_effects.deleted(), fullnode_effects.deleted());
+    assert_eq!(validator_effects.wrapped(), fullnode_effects.wrapped());
+    assert!(matches!(
+        validator_effects.status(),
+        ExecutionStatus::Failure(ExecutionFailure {
+            error: ExecutionErrorKind::FunctionNotFound,
+            command: Some(0),
+        })
+    ));
+
+    assert_eq!(
+        validator_execution_error.and_then(|error| error.metadata_with_source()),
+        None
+    );
+    assert_eq!(
+        validator
+            .get_transaction_cache_reader()
+            .get_execution_error_metadata(executable.digest()),
+        None,
+    );
+
+    let fullnode_metadata = fullnode_execution_error
+        .and_then(|error| error.metadata_with_source())
+        .unwrap();
+    assert!(
+        fullnode_metadata
+            .get("source")
+            .is_some_and(|source| source.contains("bad_function"))
+    );
+    assert_eq!(
+        fullnode
+            .get_transaction_cache_reader()
+            .get_execution_error_metadata(executable.digest()),
+        Some(fullnode_metadata),
+    );
 }
 
 #[tokio::test]

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -5466,10 +5466,7 @@ async fn test_validator_execution_does_not_store_error_metadata() {
         })
     ));
 
-    assert_eq!(
-        validator_execution_error.and_then(|error| error.metadata_with_source()),
-        None
-    );
+    assert!(validator_execution_error.is_some());
     assert_eq!(
         validator
             .get_transaction_cache_reader()
@@ -5477,19 +5474,21 @@ async fn test_validator_execution_does_not_store_error_metadata() {
         None,
     );
 
-    let fullnode_metadata = fullnode_execution_error
-        .and_then(|error| error.metadata_with_source())
+    let fullnode_source = fullnode_execution_error
+        .as_ref()
+        .and_then(|error| std::error::Error::source(error))
+        .map(ToString::to_string)
+        .unwrap();
+    assert!(fullnode_source.contains("bad_function"));
+    let fullnode_metadata = fullnode
+        .get_transaction_cache_reader()
+        .get_execution_error_metadata(executable.digest())
         .unwrap();
     assert!(
         fullnode_metadata
+            .attributes
             .get("source")
             .is_some_and(|source| source.contains("bad_function"))
-    );
-    assert_eq!(
-        fullnode
-            .get_transaction_cache_reader()
-            .get_execution_error_metadata(executable.digest()),
-        Some(fullnode_metadata),
     );
 }
 

--- a/crates/sui-genesis-builder/src/lib.rs
+++ b/crates/sui-genesis-builder/src/lib.rs
@@ -919,8 +919,8 @@ fn create_genesis_transaction(
         let (kind, signer, mut gas_data) = transaction_data.execution_parts();
         gas_data.payment = vec![];
         let input_objects = CheckedInputObjects::new_for_genesis(vec![]);
-        let (inner_temp_store, _, effects, _timings, _execution_error) = executor
-            .execute_transaction_to_effects_and_execution_error(
+        let (inner_temp_store, _, effects, _timings, _execution_error, _execution_error_metadata) =
+            executor.execute_transaction_to_effects_and_execution_error(
                 &InMemoryStorage::new(Vec::new()),
                 protocol_config,
                 metrics,

--- a/crates/sui-kv-rpc/src/v2alpha/list_checkpoints.rs
+++ b/crates/sui-kv-rpc/src/v2alpha/list_checkpoints.rs
@@ -499,6 +499,7 @@ fn render_full_checkpoint(
                 signatures: tx.signatures.unwrap_or_default(),
                 effects,
                 events: tx.events,
+                execution_error_metadata: None,
                 unchanged_loaded_runtime_objects: tx.unchanged_loaded_runtime_objects,
             })
         })

--- a/crates/sui-replay-2/src/execution.rs
+++ b/crates/sui-replay-2/src/execution.rs
@@ -129,25 +129,26 @@ pub fn execute_transaction_to_effects(
         Some(error) => ExecutionOrEarlyError::Err(error),
         None => ExecutionOrEarlyError::Ok(()),
     };
-    let (inner_store, gas_status, effects, _execution_timing, result) = executor
-        .executor
-        .execute_transaction_to_effects_and_execution_error(
-            &store,
-            protocol_config,
-            executor.execution_metrics.clone(),
-            false, // expensive checks
-            execution_params,
-            &epoch,
-            epoch_start_timestamp,
-            input_objects,
-            txn_data.gas_data().clone(),
-            gas_status,
-            txn_data.kind().clone(),
-            None, // compat_args
-            txn_data.sender(),
-            digest,
-            trace_builder_opt,
-        );
+    let (inner_store, gas_status, effects, _execution_timing, result, _execution_error_metadata) =
+        executor
+            .executor
+            .execute_transaction_to_effects_and_execution_error(
+                &store,
+                protocol_config,
+                executor.execution_metrics.clone(),
+                false, // expensive checks
+                execution_params,
+                &epoch,
+                epoch_start_timestamp,
+                input_objects,
+                txn_data.gas_data().clone(),
+                gas_status,
+                txn_data.kind().clone(),
+                None, // compat_args
+                txn_data.sender(),
+                digest,
+                trace_builder_opt,
+            );
     let ReplayStore {
         object_cache,
         checkpoint: _,
@@ -175,7 +176,7 @@ pub fn execute_transaction_to_effects(
 
     debug!(op = "execute_tx", phase = "end", "execution");
     Ok((
-        result.map_err(ExecutionError::from),
+        result,
         TxnContextAndEffects {
             txn_data,
             execution_effects: effects,

--- a/crates/sui-replay-2/src/execution.rs
+++ b/crates/sui-replay-2/src/execution.rs
@@ -175,7 +175,7 @@ pub fn execute_transaction_to_effects(
 
     debug!(op = "execute_tx", phase = "end", "execution");
     Ok((
-        result,
+        result.map_err(ExecutionError::from),
         TxnContextAndEffects {
             txn_data,
             execution_effects: effects,

--- a/crates/sui-replay/src/replay.rs
+++ b/crates/sui-replay/src/replay.rs
@@ -792,8 +792,8 @@ impl LocalExec {
             Some(error) => ExecutionOrEarlyError::Err(error),
             None => ExecutionOrEarlyError::Ok(()),
         };
-        let (inner_store, gas_status, effects, _timings, result) = executor
-            .execute_transaction_to_effects_and_execution_error(
+        let (inner_store, gas_status, effects, _timings, result, _execution_error_metadata) =
+            executor.execute_transaction_to_effects_and_execution_error(
                 &self,
                 protocol_config,
                 metrics.clone(),
@@ -834,7 +834,7 @@ impl LocalExec {
             required_objects: all_required_objects,
             local_exec_temporary_store: Some(inner_store),
             local_exec_effects: effects,
-            local_exec_status: Some(result.map_err(ExecutionError::from)),
+            local_exec_status: Some(result),
         })
     }
 
@@ -988,7 +988,7 @@ impl LocalExec {
             Some(error) => ExecutionOrEarlyError::Err(error),
             None => ExecutionOrEarlyError::Ok(()),
         };
-        let (_, _, effects, _timings, exec_res) = executor
+        let (_, _, effects, _timings, exec_res, _execution_error_metadata) = executor
             .execute_transaction_to_effects_and_execution_error(
                 &store,
                 &protocol_config,
@@ -1015,7 +1015,7 @@ impl LocalExec {
             required_objects,
             local_exec_temporary_store: None, // We dont capture it for cert exec run
             local_exec_effects: effects,
-            local_exec_status: Some(exec_res.map_err(ExecutionError::from)),
+            local_exec_status: Some(exec_res),
         })
     }
 

--- a/crates/sui-replay/src/replay.rs
+++ b/crates/sui-replay/src/replay.rs
@@ -834,7 +834,7 @@ impl LocalExec {
             required_objects: all_required_objects,
             local_exec_temporary_store: Some(inner_store),
             local_exec_effects: effects,
-            local_exec_status: Some(result),
+            local_exec_status: Some(result.map_err(ExecutionError::from)),
         })
     }
 
@@ -1015,7 +1015,7 @@ impl LocalExec {
             required_objects,
             local_exec_temporary_store: None, // We dont capture it for cert exec run
             local_exec_effects: effects,
-            local_exec_status: Some(exec_res),
+            local_exec_status: Some(exec_res.map_err(ExecutionError::from)),
         })
     }
 

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -1166,7 +1166,38 @@ impl std::fmt::Debug for SuiError {
 }
 
 pub(crate) type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
-pub type ExecutionErrorMetadata = BTreeMap<String, String>;
+
+#[derive(Clone, Eq, PartialEq, JsonSchema, Serialize, Deserialize, prost::Message)]
+pub struct ExecutionErrorMetadata {
+    #[prost(btree_map = "string, string", tag = "1")]
+    pub attributes: BTreeMap<String, String>,
+}
+
+#[cfg(test)]
+mod execution_error_metadata_tests {
+    use super::ExecutionErrorMetadata;
+    use prost::Message;
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn execution_error_metadata_protobuf_round_trip() {
+        let metadata = ExecutionErrorMetadata {
+            attributes: BTreeMap::from([(
+                "source".to_string(),
+                "Object runtime cached objects limit reached".to_string(),
+            )]),
+        };
+
+        let encoded = metadata.encode_to_vec();
+        let decoded = ExecutionErrorMetadata::decode(encoded.as_slice()).unwrap();
+
+        assert_eq!(decoded, metadata);
+        assert_eq!(
+            decoded.attributes.get("source").map(String::as_str),
+            Some("Object runtime cached objects limit reached")
+        );
+    }
+}
 
 /// A trait for execution errors that provides common methods for accessing error information and creating new errors.
 pub trait ExecutionErrorTrait:
@@ -1311,10 +1342,12 @@ impl ExecutionErrorContext {
     pub fn metadata_with_source(&self) -> Option<ExecutionErrorMetadata> {
         let mut metadata = self.metadata.clone();
         if let Some(source) = self.source.as_ref() {
-            metadata.insert("source".to_string(), source.to_string());
+            metadata
+                .attributes
+                .insert("source".to_string(), source.to_string());
         }
 
-        (!metadata.is_empty()).then_some(metadata)
+        (!metadata.attributes.is_empty()).then_some(metadata)
     }
 
     pub fn to_execution_status(&self) -> (ExecutionErrorKind, Option<CommandIndex>) {
@@ -1387,7 +1420,7 @@ impl From<ExecutionError> for ExecutionErrorContext {
         } = *inner;
         Self {
             kind,
-            metadata: BTreeMap::new(),
+            metadata: ExecutionErrorMetadata::default(),
             source,
             command,
         }

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -1165,7 +1165,7 @@ impl std::fmt::Debug for SuiError {
     }
 }
 
-pub(crate) type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
+pub type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
 
 /// Additional fullnode execution details captured for failed transactions.
 /// This metadata is stored as a non-consensus sidecar and can be different across fullnode versions.
@@ -1278,6 +1278,15 @@ impl ExecutionError {
         &self.inner.source
     }
 
+    pub fn into_parts(self) -> (ExecutionErrorKind, Option<BoxError>, Option<CommandIndex>) {
+        let ExecutionErrorInner {
+            kind,
+            source,
+            command,
+        } = *self.inner;
+        (kind, source, command)
+    }
+
     pub fn to_execution_status(&self) -> (ExecutionErrorKind, Option<CommandIndex>) {
         (self.kind().clone(), self.command())
     }
@@ -1308,126 +1317,6 @@ impl ExecutionErrorTrait for ExecutionError {
 
     fn command(&self) -> Option<CommandIndex> {
         self.command()
-    }
-}
-
-#[derive(Debug)]
-pub struct ExecutionErrorContext {
-    kind: ExecutionErrorKind,
-    metadata: ExecutionErrorMetadata,
-    source: Option<BoxError>,
-    command: Option<CommandIndex>,
-}
-
-impl ExecutionErrorContext {
-    pub fn kind(&self) -> &ExecutionErrorKind {
-        &self.kind
-    }
-
-    pub fn command(&self) -> Option<CommandIndex> {
-        self.command
-    }
-
-    pub fn metadata_with_source(&self) -> Option<ExecutionErrorMetadata> {
-        let mut metadata = self.metadata.clone();
-        if let Some(source) = self.source.as_ref() {
-            metadata.message.get_or_insert_with(|| source.to_string());
-        }
-
-        (!metadata.is_empty()).then_some(metadata)
-    }
-
-    pub fn to_execution_status(&self) -> (ExecutionErrorKind, Option<CommandIndex>) {
-        (self.kind().clone(), self.command())
-    }
-}
-
-impl ExecutionErrorTrait for ExecutionErrorContext {
-    fn new(
-        failure: ExecutionFailure,
-        source: Option<BoxError>,
-        metadata: ExecutionErrorMetadata,
-    ) -> Self {
-        let ExecutionFailure { error, command } = failure;
-        Self {
-            kind: error,
-            metadata,
-            source,
-            command,
-        }
-    }
-
-    fn with_command_index(self, command: CommandIndex) -> Self {
-        Self {
-            command: Some(command),
-            ..self
-        }
-    }
-
-    fn kind(&self) -> &ExecutionErrorKind {
-        self.kind()
-    }
-
-    fn command(&self) -> Option<CommandIndex> {
-        self.command()
-    }
-}
-
-impl std::fmt::Display for ExecutionErrorContext {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "ExecutionErrorContext: {:?}", self)
-    }
-}
-
-impl std::error::Error for ExecutionErrorContext {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        self.source.as_deref().map(|e| e as _)
-    }
-}
-
-impl From<ExecutionErrorKind> for ExecutionErrorContext {
-    fn from(kind: ExecutionErrorKind) -> Self {
-        <Self as ExecutionErrorTrait>::from_kind(kind)
-    }
-}
-
-impl From<ExecutionFailure> for ExecutionErrorContext {
-    fn from(value: ExecutionFailure) -> Self {
-        <Self as ExecutionErrorTrait>::from_execution_failure(value)
-    }
-}
-
-impl From<ExecutionError> for ExecutionErrorContext {
-    fn from(value: ExecutionError) -> Self {
-        let ExecutionError { inner } = value;
-        let ExecutionErrorInner {
-            kind,
-            source,
-            command,
-        } = *inner;
-        Self {
-            kind,
-            metadata: ExecutionErrorMetadata::default(),
-            source,
-            command,
-        }
-    }
-}
-
-impl From<ExecutionErrorContext> for ExecutionError {
-    fn from(value: ExecutionErrorContext) -> Self {
-        let ExecutionErrorContext {
-            kind,
-            metadata: _,
-            source,
-            command,
-        } = value;
-        let err = ExecutionError::new(kind, source);
-        if let Some(command) = command {
-            err.with_command_index(command)
-        } else {
-            err
-        }
     }
 }
 

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -1167,35 +1167,24 @@ impl std::fmt::Debug for SuiError {
 
 pub(crate) type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
 
-#[derive(Clone, Eq, PartialEq, JsonSchema, Serialize, Deserialize, prost::Message)]
+/// Additional fullnode execution details captured for failed transactions.
+/// This metadata is stored as a non-consensus sidecar and can be different across fullnode versions.
+/// Not a part of chain state.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct ExecutionErrorMetadata {
-    #[prost(btree_map = "string, string", tag = "1")]
-    pub attributes: BTreeMap<String, String>,
+    /// Human-readable execution error detail intended for diagnostics and user-facing APIs.
+    pub message: Option<String>,
 }
 
-#[cfg(test)]
-mod execution_error_metadata_tests {
-    use super::ExecutionErrorMetadata;
-    use prost::Message;
-    use std::collections::BTreeMap;
+impl ExecutionErrorMetadata {
+    pub fn new(source: impl Into<String>) -> Self {
+        Self {
+            message: Some(source.into()),
+        }
+    }
 
-    #[test]
-    fn execution_error_metadata_protobuf_round_trip() {
-        let metadata = ExecutionErrorMetadata {
-            attributes: BTreeMap::from([(
-                "source".to_string(),
-                "Object runtime cached objects limit reached".to_string(),
-            )]),
-        };
-
-        let encoded = metadata.encode_to_vec();
-        let decoded = ExecutionErrorMetadata::decode(encoded.as_slice()).unwrap();
-
-        assert_eq!(decoded, metadata);
-        assert_eq!(
-            decoded.attributes.get("source").map(String::as_str),
-            Some("Object runtime cached objects limit reached")
-        );
+    pub fn is_empty(&self) -> bool {
+        self.message.as_deref().is_none_or(str::is_empty)
     }
 }
 
@@ -1342,12 +1331,10 @@ impl ExecutionErrorContext {
     pub fn metadata_with_source(&self) -> Option<ExecutionErrorMetadata> {
         let mut metadata = self.metadata.clone();
         if let Some(source) = self.source.as_ref() {
-            metadata
-                .attributes
-                .insert("source".to_string(), source.to_string());
+            metadata.message.get_or_insert_with(|| source.to_string());
         }
 
-        (!metadata.attributes.is_empty()).then_some(metadata)
+        (!metadata.is_empty()).then_some(metadata)
     }
 
     pub fn to_execution_status(&self) -> (ExecutionErrorKind, Option<CommandIndex>) {

--- a/crates/sui-types/src/execution_status.rs
+++ b/crates/sui-types/src/execution_status.rs
@@ -3,7 +3,9 @@
 
 use crate::ObjectID;
 use crate::base_types::SuiAddress;
-use crate::error::{BoxError, ExecutionError, ExecutionErrorMetadata, ExecutionErrorTrait};
+pub(crate) use crate::error::{
+    BoxError, ExecutionError, ExecutionErrorMetadata, ExecutionErrorTrait,
+};
 use move_binary_format::file_format::{CodeOffset, TypeParameterIndex};
 use move_core_types::language_storage::ModuleId;
 use serde::{Deserialize, Serialize};

--- a/crates/sui-types/src/full_checkpoint_content.rs
+++ b/crates/sui-types/src/full_checkpoint_content.rs
@@ -5,6 +5,7 @@ use std::collections::BTreeMap;
 
 use crate::base_types::{ExecutionData, ObjectID, ObjectRef};
 use crate::effects::{TransactionEffects, TransactionEffectsAPI, TransactionEvents};
+use crate::error::ExecutionErrorMetadata;
 use crate::messages_checkpoint::{CertifiedCheckpointSummary, CheckpointContents};
 use crate::object::Object;
 use crate::signature::GenericSignature;
@@ -217,6 +218,8 @@ pub struct ExecutedTransaction {
     pub effects: TransactionEffects,
     /// The events, if any, emitted by this transactions during execution
     pub events: Option<TransactionEvents>,
+    /// Additional metadata captured when local execution fails.
+    pub execution_error_metadata: Option<ExecutionErrorMetadata>,
     pub unchanged_loaded_runtime_objects: Vec<ObjectKey>,
 }
 
@@ -472,6 +475,7 @@ impl From<CheckpointData> for Checkpoint {
                     events: tx.events,
 
                     // lossy
+                    execution_error_metadata: None,
                     unchanged_loaded_runtime_objects: Vec::new(),
                 }
             })

--- a/crates/sui-types/src/rpc_proto_conversions.rs
+++ b/crates/sui-types/src/rpc_proto_conversions.rs
@@ -1181,35 +1181,10 @@ impl From<crate::execution_status::ExecutionStatus> for ExecutionStatus {
     }
 }
 
+
 //
 // ExecutionError
 //
-
-pub use sui_rpc::proto::sui::rpc::v2::ExecutionErrorMetadata;
-
-impl From<crate::execution_status::ExecutionErrorMetadata> for ExecutionErrorMetadata {
-    fn from(metadata: crate::error::ExecutionErrorMetadata) -> Self {
-        let mut message = Self::default();
-        message.message = metadata.message;
-        message
-    }
-}
-
-impl From<&crate::execution_status::ExecutionErrorMetadata> for ExecutionErrorMetadata {
-    fn from(metadata: &crate::error::ExecutionErrorMetadata) -> Self {
-        let mut message = Self::default();
-        message.message = metadata.message.clone();
-        message
-    }
-}
-
-impl From<&ExecutionErrorMetadata> for crate::execution_status::ExecutionErrorMetadata {
-    fn from(metadata: &ExecutionErrorMetadata) -> Self {
-        Self {
-            message: metadata.message.clone(),
-        }
-    }
-}
 
 fn size_error(size: u64, max_size: u64) -> SizeError {
     let mut message = SizeError::default();
@@ -1421,6 +1396,37 @@ impl From<crate::execution_status::ExecutionErrorKind> for ExecutionError {
         message
     }
 }
+
+//
+// ExecutionErrorMetadata
+//
+
+pub use sui_rpc::proto::sui::rpc::v2::ExecutionErrorMetadata;
+
+impl From<crate::execution_status::ExecutionErrorMetadata> for ExecutionErrorMetadata {
+    fn from(metadata: crate::error::ExecutionErrorMetadata) -> Self {
+        let mut message = Self::default();
+        message.message = metadata.message;
+        message
+    }
+}
+
+impl From<&crate::execution_status::ExecutionErrorMetadata> for ExecutionErrorMetadata {
+    fn from(metadata: &crate::error::ExecutionErrorMetadata) -> Self {
+        let mut message = Self::default();
+        message.message = metadata.message.clone();
+        message
+    }
+}
+
+impl From<&ExecutionErrorMetadata> for crate::execution_status::ExecutionErrorMetadata {
+    fn from(metadata: &ExecutionErrorMetadata) -> Self {
+        Self {
+            message: metadata.message.clone(),
+        }
+    }
+}
+
 
 //
 // CommandArgumentError

--- a/crates/sui-types/src/rpc_proto_conversions.rs
+++ b/crates/sui-types/src/rpc_proto_conversions.rs
@@ -1398,37 +1398,6 @@ impl From<crate::execution_status::ExecutionErrorKind> for ExecutionError {
 }
 
 //
-// ExecutionErrorMetadata
-//
-
-pub use sui_rpc::proto::sui::rpc::v2::ExecutionErrorMetadata;
-
-impl From<crate::execution_status::ExecutionErrorMetadata> for ExecutionErrorMetadata {
-    fn from(metadata: crate::error::ExecutionErrorMetadata) -> Self {
-        let mut message = Self::default();
-        message.message = metadata.message;
-        message
-    }
-}
-
-impl From<&crate::execution_status::ExecutionErrorMetadata> for ExecutionErrorMetadata {
-    fn from(metadata: &crate::error::ExecutionErrorMetadata) -> Self {
-        let mut message = Self::default();
-        message.message = metadata.message.clone();
-        message
-    }
-}
-
-impl From<&ExecutionErrorMetadata> for crate::execution_status::ExecutionErrorMetadata {
-    fn from(metadata: &ExecutionErrorMetadata) -> Self {
-        Self {
-            message: metadata.message.clone(),
-        }
-    }
-}
-
-
-//
 // CommandArgumentError
 //
 
@@ -1564,6 +1533,36 @@ impl From<crate::execution_status::MoveLocation> for MoveLocation {
         message.instruction = Some(value.instruction.into());
         message.function_name = value.function_name.map(|name| name.to_string());
         message
+    }
+}
+
+//
+// ExecutionErrorMetadata
+//
+
+pub use sui_rpc::proto::sui::rpc::v2::ExecutionErrorMetadata;
+
+impl From<crate::execution_status::ExecutionErrorMetadata> for ExecutionErrorMetadata {
+    fn from(metadata: crate::error::ExecutionErrorMetadata) -> Self {
+        let mut message = Self::default();
+        message.message = metadata.message;
+        message
+    }
+}
+
+impl From<&crate::execution_status::ExecutionErrorMetadata> for ExecutionErrorMetadata {
+    fn from(metadata: &crate::error::ExecutionErrorMetadata) -> Self {
+        let mut message = Self::default();
+        message.message = metadata.message.clone();
+        message
+    }
+}
+
+impl From<&ExecutionErrorMetadata> for crate::execution_status::ExecutionErrorMetadata {
+    fn from(metadata: &ExecutionErrorMetadata) -> Self {
+        Self {
+            message: metadata.message.clone(),
+        }
     }
 }
 

--- a/crates/sui-types/src/rpc_proto_conversions.rs
+++ b/crates/sui-types/src/rpc_proto_conversions.rs
@@ -220,6 +220,7 @@ impl TryFrom<&ExecutedTransaction> for crate::full_checkpoint_content::ExecutedT
                 .iter()
                 .map(TryInto::try_into)
                 .collect::<Result<_, _>>()?,
+            execution_error_metadata: None,
         })
     }
 }
@@ -1183,6 +1184,32 @@ impl From<crate::execution_status::ExecutionStatus> for ExecutionStatus {
 //
 // ExecutionError
 //
+
+pub use sui_rpc::proto::sui::rpc::v2::ExecutionErrorMetadata;
+
+impl From<crate::execution_status::ExecutionErrorMetadata> for ExecutionErrorMetadata {
+    fn from(metadata: crate::error::ExecutionErrorMetadata) -> Self {
+        let mut message = Self::default();
+        message.message = metadata.message;
+        message
+    }
+}
+
+impl From<&crate::execution_status::ExecutionErrorMetadata> for ExecutionErrorMetadata {
+    fn from(metadata: &crate::error::ExecutionErrorMetadata) -> Self {
+        let mut message = Self::default();
+        message.message = metadata.message.clone();
+        message
+    }
+}
+
+impl From<&ExecutionErrorMetadata> for crate::execution_status::ExecutionErrorMetadata {
+    fn from(metadata: &ExecutionErrorMetadata) -> Self {
+        Self {
+            message: metadata.message.clone(),
+        }
+    }
+}
 
 fn size_error(size: u64, max_size: u64) -> SizeError {
     let mut message = SizeError::default();

--- a/crates/sui-types/src/storage/read_store.rs
+++ b/crates/sui-types/src/storage/read_store.rs
@@ -11,6 +11,7 @@ use crate::digests::{
 };
 use crate::dynamic_field::DynamicFieldType;
 use crate::effects::{TransactionEffects, TransactionEvents};
+use crate::error::ExecutionErrorMetadata;
 use crate::full_checkpoint_content::{Checkpoint, ExecutedTransaction, ObjectSet};
 use crate::messages_checkpoint::{
     CheckpointContents, CheckpointSequenceNumber, VerifiedCheckpoint,
@@ -146,6 +147,13 @@ pub trait ReadStore: ObjectStore {
         digest: &TransactionDigest,
     ) -> Option<Vec<ObjectKey>>;
 
+    fn get_execution_error_metadata(
+        &self,
+        _digest: &TransactionDigest,
+    ) -> Option<ExecutionErrorMetadata> {
+        None
+    }
+
     fn get_transaction_checkpoint(
         &self,
         digest: &TransactionDigest,
@@ -222,6 +230,7 @@ pub trait ReadStore: ObjectStore {
                 signatures: tx.tx_signatures().to_vec(),
                 effects: fx.clone(),
                 events,
+                execution_error_metadata: self.get_execution_error_metadata(tx.digest()),
                 unchanged_loaded_runtime_objects: self
                     .get_unchanged_loaded_runtime_objects(tx.digest())
                     //TODO Do we throw an error or just stub in an empty vector?
@@ -360,6 +369,13 @@ impl<T: ReadStore + ?Sized> ReadStore for &T {
         (*self).get_unchanged_loaded_runtime_objects(digest)
     }
 
+    fn get_execution_error_metadata(
+        &self,
+        digest: &TransactionDigest,
+    ) -> Option<ExecutionErrorMetadata> {
+        (*self).get_execution_error_metadata(digest)
+    }
+
     fn get_transaction_checkpoint(
         &self,
         digest: &TransactionDigest,
@@ -478,6 +494,13 @@ impl<T: ReadStore + ?Sized> ReadStore for Box<T> {
         (**self).get_unchanged_loaded_runtime_objects(digest)
     }
 
+    fn get_execution_error_metadata(
+        &self,
+        digest: &TransactionDigest,
+    ) -> Option<ExecutionErrorMetadata> {
+        (**self).get_execution_error_metadata(digest)
+    }
+
     fn get_transaction_checkpoint(
         &self,
         digest: &TransactionDigest,
@@ -594,6 +617,13 @@ impl<T: ReadStore + ?Sized> ReadStore for Arc<T> {
         digest: &TransactionDigest,
     ) -> Option<Vec<ObjectKey>> {
         (**self).get_unchanged_loaded_runtime_objects(digest)
+    }
+
+    fn get_execution_error_metadata(
+        &self,
+        digest: &TransactionDigest,
+    ) -> Option<ExecutionErrorMetadata> {
+        (**self).get_execution_error_metadata(digest)
     }
 
     fn get_transaction_checkpoint(

--- a/crates/sui-types/src/test_checkpoint_data_builder.rs
+++ b/crates/sui-types/src/test_checkpoint_data_builder.rs
@@ -648,6 +648,7 @@ impl TestCheckpointBuilder {
                     signatures: sender_signed.tx_signatures,
                     effects: tx.effects,
                     events: tx.events,
+                    execution_error_metadata: None,
                     unchanged_loaded_runtime_objects: Vec::new(),
                 }
             })

--- a/external-crates/move/Cargo.lock
+++ b/external-crates/move/Cargo.lock
@@ -6287,15 +6287,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "sui-crypto"
-version = "0.3.0"
-
-[[patch.unused]]
-name = "sui-rpc"
-version = "0.3.1"
-
-[[patch.unused]]
-name = "sui-sdk-types"
-version = "0.3.1"

--- a/external-crates/move/Cargo.lock
+++ b/external-crates/move/Cargo.lock
@@ -6287,3 +6287,15 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
+
+[[patch.unused]]
+name = "sui-crypto"
+version = "0.3.0"
+
+[[patch.unused]]
+name = "sui-rpc"
+version = "0.3.1"
+
+[[patch.unused]]
+name = "sui-sdk-types"
+version = "0.3.1"

--- a/sui-execution/src/error_context.rs
+++ b/sui-execution/src/error_context.rs
@@ -1,0 +1,120 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use sui_types::error::{BoxError, ExecutionError, ExecutionErrorMetadata, ExecutionErrorTrait};
+use sui_types::execution_status::{CommandIndex, ExecutionErrorKind, ExecutionFailure};
+
+#[derive(Debug)]
+pub struct ExecutionErrorContext {
+    kind: ExecutionErrorKind,
+    metadata: ExecutionErrorMetadata,
+    source: Option<BoxError>,
+    command: Option<CommandIndex>,
+}
+
+impl ExecutionErrorContext {
+    pub fn kind(&self) -> &ExecutionErrorKind {
+        &self.kind
+    }
+
+    pub fn command(&self) -> Option<CommandIndex> {
+        self.command
+    }
+
+    pub fn metadata_with_source(&self) -> Option<ExecutionErrorMetadata> {
+        let mut metadata = self.metadata.clone();
+        if let Some(source) = self.source.as_ref() {
+            metadata.message.get_or_insert_with(|| source.to_string());
+        }
+
+        (!metadata.is_empty()).then_some(metadata)
+    }
+
+    pub fn to_execution_status(&self) -> (ExecutionErrorKind, Option<CommandIndex>) {
+        (self.kind().clone(), self.command())
+    }
+}
+
+impl ExecutionErrorTrait for ExecutionErrorContext {
+    fn new(
+        failure: ExecutionFailure,
+        source: Option<BoxError>,
+        metadata: ExecutionErrorMetadata,
+    ) -> Self {
+        let ExecutionFailure { error, command } = failure;
+        Self {
+            kind: error,
+            metadata,
+            source,
+            command,
+        }
+    }
+
+    fn with_command_index(self, command: CommandIndex) -> Self {
+        Self {
+            command: Some(command),
+            ..self
+        }
+    }
+
+    fn kind(&self) -> &ExecutionErrorKind {
+        self.kind()
+    }
+
+    fn command(&self) -> Option<CommandIndex> {
+        self.command()
+    }
+}
+
+impl std::fmt::Display for ExecutionErrorContext {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "ExecutionErrorContext: {:?}", self)
+    }
+}
+
+impl std::error::Error for ExecutionErrorContext {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.source.as_deref().map(|e| e as _)
+    }
+}
+
+impl From<ExecutionErrorKind> for ExecutionErrorContext {
+    fn from(kind: ExecutionErrorKind) -> Self {
+        <Self as ExecutionErrorTrait>::from_kind(kind)
+    }
+}
+
+impl From<ExecutionFailure> for ExecutionErrorContext {
+    fn from(value: ExecutionFailure) -> Self {
+        <Self as ExecutionErrorTrait>::from_execution_failure(value)
+    }
+}
+
+impl From<ExecutionError> for ExecutionErrorContext {
+    fn from(value: ExecutionError) -> Self {
+        let (kind, source, command) = value.into_parts();
+        Self {
+            kind,
+            metadata: ExecutionErrorMetadata::default(),
+            source,
+            command,
+        }
+    }
+}
+
+impl From<ExecutionErrorContext> for ExecutionError {
+    fn from(value: ExecutionErrorContext) -> Self {
+        let ExecutionErrorContext {
+            kind,
+            metadata: _,
+            source,
+            command,
+        } = value;
+        let err = ExecutionError::new(kind, source);
+        if let Some(command) = command {
+            err.with_command_index(command)
+        } else {
+            err
+        }
+    }
+}

--- a/sui-execution/src/executor.rs
+++ b/sui-execution/src/executor.rs
@@ -13,7 +13,7 @@ use sui_types::{
     committee::EpochId,
     digests::TransactionDigest,
     effects::TransactionEffects,
-    error::ExecutionError,
+    error::{ExecutionError, ExecutionErrorContext},
     execution::{ExecutionResult, TypeLayoutStore},
     execution_status::ExecutionFailure,
     gas::SuiGasStatus,
@@ -79,7 +79,7 @@ pub trait Executor {
         SuiGasStatus,
         TransactionEffects,
         Vec<ExecutionTiming>,
-        Result<(), ExecutionError>,
+        Result<(), ExecutionErrorContext>,
     );
 
     fn dev_inspect_transaction(

--- a/sui-execution/src/executor.rs
+++ b/sui-execution/src/executor.rs
@@ -13,7 +13,7 @@ use sui_types::{
     committee::EpochId,
     digests::TransactionDigest,
     effects::TransactionEffects,
-    error::{ExecutionError, ExecutionErrorContext},
+    error::{ExecutionError, ExecutionErrorMetadata},
     execution::{ExecutionResult, TypeLayoutStore},
     execution_status::ExecutionFailure,
     gas::SuiGasStatus,
@@ -79,7 +79,8 @@ pub trait Executor {
         SuiGasStatus,
         TransactionEffects,
         Vec<ExecutionTiming>,
-        Result<(), ExecutionErrorContext>,
+        Result<(), ExecutionError>,
+        Option<ExecutionErrorMetadata>,
     );
 
     fn dev_inspect_transaction(

--- a/sui-execution/src/latest.rs
+++ b/sui-execution/src/latest.rs
@@ -14,7 +14,10 @@ use sui_types::{
     committee::EpochId,
     digests::TransactionDigest,
     effects::TransactionEffects,
-    error::{ExecutionError, ExecutionErrorContext, ExecutionErrorTrait, SuiError, SuiResult},
+    error::{
+        ExecutionError, ExecutionErrorContext, ExecutionErrorMetadata, ExecutionErrorTrait,
+        SuiError, SuiResult,
+    },
     execution::{ExecutionResult, TypeLayoutStore},
     execution_status::ExecutionFailure,
     gas::SuiGasStatus,
@@ -134,7 +137,8 @@ impl executor::Executor for Executor {
         SuiGasStatus,
         TransactionEffects,
         Vec<ExecutionTiming>,
-        Result<(), ExecutionErrorContext>,
+        Result<(), ExecutionError>,
+        Option<ExecutionErrorMetadata>,
     ) {
         let (store_out, gas_status_out, effects, timings, result) =
             execute_transaction_to_effects::<execution_mode::Normal<ExecutionErrorContext>>(
@@ -158,7 +162,18 @@ impl executor::Executor for Executor {
         if let Err(error) = &result {
             log_execution_error(transaction_digest, error);
         }
-        (store_out, gas_status_out, effects, timings, result)
+        let execution_error_metadata = result
+            .as_ref()
+            .err()
+            .and_then(ExecutionErrorContext::metadata_with_source);
+        (
+            store_out,
+            gas_status_out,
+            effects,
+            timings,
+            result.map_err(ExecutionError::from),
+            execution_error_metadata,
+        )
     }
 
     fn dev_inspect_transaction(

--- a/sui-execution/src/latest.rs
+++ b/sui-execution/src/latest.rs
@@ -15,7 +15,7 @@ use sui_types::{
     digests::TransactionDigest,
     effects::TransactionEffects,
     error::{
-        ExecutionError, ExecutionErrorContext, ExecutionErrorMetadata, ExecutionErrorTrait,
+        ExecutionError, ExecutionErrorMetadata, ExecutionErrorTrait,
         SuiError, SuiResult,
     },
     execution::{ExecutionResult, TypeLayoutStore},
@@ -27,6 +27,7 @@ use sui_types::{
     transaction::{CheckedInputObjects, ProgrammableTransaction, TransactionKind},
 };
 
+use crate::error_context::ExecutionErrorContext;
 use move_bytecode_verifier_meter::Meter;
 use move_vm_runtime_latest::runtime::MoveRuntime;
 use mysten_common::debug_fatal;

--- a/sui-execution/src/latest.rs
+++ b/sui-execution/src/latest.rs
@@ -14,7 +14,7 @@ use sui_types::{
     committee::EpochId,
     digests::TransactionDigest,
     effects::TransactionEffects,
-    error::{ExecutionError, ExecutionErrorTrait, SuiError, SuiResult},
+    error::{ExecutionError, ExecutionErrorContext, ExecutionErrorTrait, SuiError, SuiResult},
     execution::{ExecutionResult, TypeLayoutStore},
     execution_status::ExecutionFailure,
     gas::SuiGasStatus,
@@ -134,10 +134,10 @@ impl executor::Executor for Executor {
         SuiGasStatus,
         TransactionEffects,
         Vec<ExecutionTiming>,
-        Result<(), ExecutionError>,
+        Result<(), ExecutionErrorContext>,
     ) {
         let (store_out, gas_status_out, effects, timings, result) =
-            execute_transaction_to_effects::<execution_mode::Normal<ExecutionError>>(
+            execute_transaction_to_effects::<execution_mode::Normal<ExecutionErrorContext>>(
                 store,
                 input_objects,
                 gas,

--- a/sui-execution/src/lib.rs
+++ b/sui-execution/src/lib.rs
@@ -22,6 +22,7 @@ mod v3;
 
 #[cfg(test)]
 mod tests;
+mod error_context;
 
 pub fn executor(
     protocol_config: &ProtocolConfig,

--- a/sui-execution/src/v0.rs
+++ b/sui-execution/src/v0.rs
@@ -15,7 +15,7 @@ use sui_types::{
     committee::EpochId,
     digests::TransactionDigest,
     effects::TransactionEffects,
-    error::{ExecutionError, SuiError, SuiResult},
+    error::{ExecutionError, ExecutionErrorContext, SuiError, SuiResult},
     execution::{ExecutionResult, TypeLayoutStore},
     execution_status::ExecutionFailure,
     gas::SuiGasStatus,
@@ -205,7 +205,7 @@ impl executor::Executor for Executor {
         SuiGasStatus,
         TransactionEffects,
         Vec<ExecutionTiming>,
-        Result<(), ExecutionError>,
+        Result<(), ExecutionErrorContext>,
     ) {
         let gas_coins = gas.payment;
         let (inner_temp_store, gas_status, effects, result) =
@@ -228,6 +228,7 @@ impl executor::Executor for Executor {
         if let Err(error) = &result {
             log_execution_error(transaction_digest, error);
         }
+        let result = result.map_err(ExecutionErrorContext::from);
         (inner_temp_store, gas_status, effects, vec![], result)
     }
 

--- a/sui-execution/src/v0.rs
+++ b/sui-execution/src/v0.rs
@@ -15,7 +15,7 @@ use sui_types::{
     committee::EpochId,
     digests::TransactionDigest,
     effects::TransactionEffects,
-    error::{ExecutionError, ExecutionErrorContext, SuiError, SuiResult},
+    error::{ExecutionError, ExecutionErrorContext, ExecutionErrorMetadata, SuiError, SuiResult},
     execution::{ExecutionResult, TypeLayoutStore},
     execution_status::ExecutionFailure,
     gas::SuiGasStatus,
@@ -205,7 +205,8 @@ impl executor::Executor for Executor {
         SuiGasStatus,
         TransactionEffects,
         Vec<ExecutionTiming>,
-        Result<(), ExecutionErrorContext>,
+        Result<(), ExecutionError>,
+        Option<ExecutionErrorMetadata>,
     ) {
         let gas_coins = gas.payment;
         let (inner_temp_store, gas_status, effects, result) =
@@ -229,7 +230,18 @@ impl executor::Executor for Executor {
             log_execution_error(transaction_digest, error);
         }
         let result = result.map_err(ExecutionErrorContext::from);
-        (inner_temp_store, gas_status, effects, vec![], result)
+        let execution_error_metadata = result
+            .as_ref()
+            .err()
+            .and_then(ExecutionErrorContext::metadata_with_source);
+        (
+            inner_temp_store,
+            gas_status,
+            effects,
+            vec![],
+            result.map_err(ExecutionError::from),
+            execution_error_metadata,
+        )
     }
 
     fn update_genesis_state(

--- a/sui-execution/src/v0.rs
+++ b/sui-execution/src/v0.rs
@@ -15,7 +15,7 @@ use sui_types::{
     committee::EpochId,
     digests::TransactionDigest,
     effects::TransactionEffects,
-    error::{ExecutionError, ExecutionErrorContext, ExecutionErrorMetadata, SuiError, SuiResult},
+    error::{ExecutionError, ExecutionErrorMetadata, SuiError, SuiResult},
     execution::{ExecutionResult, TypeLayoutStore},
     execution_status::ExecutionFailure,
     gas::SuiGasStatus,
@@ -229,18 +229,13 @@ impl executor::Executor for Executor {
         if let Err(error) = &result {
             log_execution_error(transaction_digest, error);
         }
-        let result = result.map_err(ExecutionErrorContext::from);
-        let execution_error_metadata = result
-            .as_ref()
-            .err()
-            .and_then(ExecutionErrorContext::metadata_with_source);
         (
             inner_temp_store,
             gas_status,
             effects,
             vec![],
-            result.map_err(ExecutionError::from),
-            execution_error_metadata,
+            result,
+            None,
         )
     }
 

--- a/sui-execution/src/v1.rs
+++ b/sui-execution/src/v1.rs
@@ -15,7 +15,7 @@ use sui_types::{
     committee::EpochId,
     digests::TransactionDigest,
     effects::TransactionEffects,
-    error::{ExecutionError, SuiError, SuiResult},
+    error::{ExecutionError, ExecutionErrorContext, SuiError, SuiResult},
     execution::{ExecutionResult, TypeLayoutStore},
     execution_status::ExecutionFailure,
     gas::SuiGasStatus,
@@ -205,7 +205,7 @@ impl executor::Executor for Executor {
         SuiGasStatus,
         TransactionEffects,
         Vec<ExecutionTiming>,
-        Result<(), ExecutionError>,
+        Result<(), ExecutionErrorContext>,
     ) {
         let gas_coins = gas.payment;
         let (inner_temp_store, gas_status, effects, result) =
@@ -228,6 +228,7 @@ impl executor::Executor for Executor {
         if let Err(error) = &result {
             log_execution_error(transaction_digest, error);
         }
+        let result = result.map_err(ExecutionErrorContext::from);
         (inner_temp_store, gas_status, effects, vec![], result)
     }
 

--- a/sui-execution/src/v1.rs
+++ b/sui-execution/src/v1.rs
@@ -15,7 +15,7 @@ use sui_types::{
     committee::EpochId,
     digests::TransactionDigest,
     effects::TransactionEffects,
-    error::{ExecutionError, ExecutionErrorContext, SuiError, SuiResult},
+    error::{ExecutionError, ExecutionErrorContext, ExecutionErrorMetadata, SuiError, SuiResult},
     execution::{ExecutionResult, TypeLayoutStore},
     execution_status::ExecutionFailure,
     gas::SuiGasStatus,
@@ -205,7 +205,8 @@ impl executor::Executor for Executor {
         SuiGasStatus,
         TransactionEffects,
         Vec<ExecutionTiming>,
-        Result<(), ExecutionErrorContext>,
+        Result<(), ExecutionError>,
+        Option<ExecutionErrorMetadata>,
     ) {
         let gas_coins = gas.payment;
         let (inner_temp_store, gas_status, effects, result) =
@@ -229,7 +230,18 @@ impl executor::Executor for Executor {
             log_execution_error(transaction_digest, error);
         }
         let result = result.map_err(ExecutionErrorContext::from);
-        (inner_temp_store, gas_status, effects, vec![], result)
+        let execution_error_metadata = result
+            .as_ref()
+            .err()
+            .and_then(ExecutionErrorContext::metadata_with_source);
+        (
+            inner_temp_store,
+            gas_status,
+            effects,
+            vec![],
+            result.map_err(ExecutionError::from),
+            execution_error_metadata,
+        )
     }
 
     fn update_genesis_state(

--- a/sui-execution/src/v1.rs
+++ b/sui-execution/src/v1.rs
@@ -15,7 +15,7 @@ use sui_types::{
     committee::EpochId,
     digests::TransactionDigest,
     effects::TransactionEffects,
-    error::{ExecutionError, ExecutionErrorContext, ExecutionErrorMetadata, SuiError, SuiResult},
+    error::{ExecutionError, ExecutionErrorMetadata, SuiError, SuiResult},
     execution::{ExecutionResult, TypeLayoutStore},
     execution_status::ExecutionFailure,
     gas::SuiGasStatus,
@@ -229,18 +229,13 @@ impl executor::Executor for Executor {
         if let Err(error) = &result {
             log_execution_error(transaction_digest, error);
         }
-        let result = result.map_err(ExecutionErrorContext::from);
-        let execution_error_metadata = result
-            .as_ref()
-            .err()
-            .and_then(ExecutionErrorContext::metadata_with_source);
         (
             inner_temp_store,
             gas_status,
             effects,
             vec![],
-            result.map_err(ExecutionError::from),
-            execution_error_metadata,
+            result,
+            None,
         )
     }
 

--- a/sui-execution/src/v2.rs
+++ b/sui-execution/src/v2.rs
@@ -15,7 +15,7 @@ use sui_types::{
     committee::EpochId,
     digests::TransactionDigest,
     effects::TransactionEffects,
-    error::{ExecutionError, SuiError, SuiResult},
+    error::{ExecutionError, ExecutionErrorContext, SuiError, SuiResult},
     execution::{ExecutionResult, TypeLayoutStore},
     execution_status::ExecutionFailure,
     gas::SuiGasStatus,
@@ -205,7 +205,7 @@ impl executor::Executor for Executor {
         SuiGasStatus,
         TransactionEffects,
         Vec<ExecutionTiming>,
-        Result<(), ExecutionError>,
+        Result<(), ExecutionErrorContext>,
     ) {
         let gas_coins = gas.payment;
         let (inner_temp_store, gas_status, effects, result) =
@@ -228,6 +228,7 @@ impl executor::Executor for Executor {
         if let Err(error) = &result {
             log_execution_error(transaction_digest, error);
         }
+        let result = result.map_err(ExecutionErrorContext::from);
         (inner_temp_store, gas_status, effects, vec![], result)
     }
 

--- a/sui-execution/src/v2.rs
+++ b/sui-execution/src/v2.rs
@@ -15,7 +15,7 @@ use sui_types::{
     committee::EpochId,
     digests::TransactionDigest,
     effects::TransactionEffects,
-    error::{ExecutionError, ExecutionErrorContext, SuiError, SuiResult},
+    error::{ExecutionError, ExecutionErrorContext, ExecutionErrorMetadata, SuiError, SuiResult},
     execution::{ExecutionResult, TypeLayoutStore},
     execution_status::ExecutionFailure,
     gas::SuiGasStatus,
@@ -205,7 +205,8 @@ impl executor::Executor for Executor {
         SuiGasStatus,
         TransactionEffects,
         Vec<ExecutionTiming>,
-        Result<(), ExecutionErrorContext>,
+        Result<(), ExecutionError>,
+        Option<ExecutionErrorMetadata>,
     ) {
         let gas_coins = gas.payment;
         let (inner_temp_store, gas_status, effects, result) =
@@ -229,7 +230,18 @@ impl executor::Executor for Executor {
             log_execution_error(transaction_digest, error);
         }
         let result = result.map_err(ExecutionErrorContext::from);
-        (inner_temp_store, gas_status, effects, vec![], result)
+        let execution_error_metadata = result
+            .as_ref()
+            .err()
+            .and_then(ExecutionErrorContext::metadata_with_source);
+        (
+            inner_temp_store,
+            gas_status,
+            effects,
+            vec![],
+            result.map_err(ExecutionError::from),
+            execution_error_metadata,
+        )
     }
 
     fn update_genesis_state(

--- a/sui-execution/src/v2.rs
+++ b/sui-execution/src/v2.rs
@@ -15,7 +15,7 @@ use sui_types::{
     committee::EpochId,
     digests::TransactionDigest,
     effects::TransactionEffects,
-    error::{ExecutionError, ExecutionErrorContext, ExecutionErrorMetadata, SuiError, SuiResult},
+    error::{ExecutionError, ExecutionErrorMetadata, SuiError, SuiResult},
     execution::{ExecutionResult, TypeLayoutStore},
     execution_status::ExecutionFailure,
     gas::SuiGasStatus,
@@ -229,18 +229,13 @@ impl executor::Executor for Executor {
         if let Err(error) = &result {
             log_execution_error(transaction_digest, error);
         }
-        let result = result.map_err(ExecutionErrorContext::from);
-        let execution_error_metadata = result
-            .as_ref()
-            .err()
-            .and_then(ExecutionErrorContext::metadata_with_source);
         (
             inner_temp_store,
             gas_status,
             effects,
             vec![],
-            result.map_err(ExecutionError::from),
-            execution_error_metadata,
+            result,
+            None,
         )
     }
 

--- a/sui-execution/src/v3.rs
+++ b/sui-execution/src/v3.rs
@@ -14,7 +14,7 @@ use sui_types::{
     committee::EpochId,
     digests::TransactionDigest,
     effects::TransactionEffects,
-    error::{ExecutionError, ExecutionErrorContext, SuiError, SuiResult},
+    error::{ExecutionError, ExecutionErrorContext, ExecutionErrorMetadata, SuiError, SuiResult},
     execution::{ExecutionResult, TypeLayoutStore},
     gas::SuiGasStatus,
     inner_temporary_store::InnerTemporaryStore,
@@ -139,7 +139,8 @@ impl executor::Executor for Executor {
         SuiGasStatus,
         TransactionEffects,
         Vec<ExecutionTiming>,
-        Result<(), ExecutionErrorContext>,
+        Result<(), ExecutionError>,
+        Option<ExecutionErrorMetadata>,
     ) {
         let (inner_temp_store, gas_status, effects, timings, result) =
             execute_transaction_to_effects::<execution_mode::Normal>(
@@ -163,7 +164,18 @@ impl executor::Executor for Executor {
             log_execution_error(protocol_config, transaction_digest, error);
         }
         let result = result.map_err(ExecutionErrorContext::from);
-        (inner_temp_store, gas_status, effects, timings, result)
+        let execution_error_metadata = result
+            .as_ref()
+            .err()
+            .and_then(ExecutionErrorContext::metadata_with_source);
+        (
+            inner_temp_store,
+            gas_status,
+            effects,
+            timings,
+            result.map_err(ExecutionError::from),
+            execution_error_metadata,
+        )
     }
 
     fn dev_inspect_transaction(

--- a/sui-execution/src/v3.rs
+++ b/sui-execution/src/v3.rs
@@ -14,7 +14,7 @@ use sui_types::{
     committee::EpochId,
     digests::TransactionDigest,
     effects::TransactionEffects,
-    error::{ExecutionError, ExecutionErrorContext, ExecutionErrorMetadata, SuiError, SuiResult},
+    error::{ExecutionError, ExecutionErrorMetadata, SuiError, SuiResult},
     execution::{ExecutionResult, TypeLayoutStore},
     gas::SuiGasStatus,
     inner_temporary_store::InnerTemporaryStore,
@@ -163,18 +163,13 @@ impl executor::Executor for Executor {
         if let Err(error) = &result {
             log_execution_error(protocol_config, transaction_digest, error);
         }
-        let result = result.map_err(ExecutionErrorContext::from);
-        let execution_error_metadata = result
-            .as_ref()
-            .err()
-            .and_then(ExecutionErrorContext::metadata_with_source);
         (
             inner_temp_store,
             gas_status,
             effects,
             timings,
-            result.map_err(ExecutionError::from),
-            execution_error_metadata,
+            result,
+            None,
         )
     }
 

--- a/sui-execution/src/v3.rs
+++ b/sui-execution/src/v3.rs
@@ -14,7 +14,7 @@ use sui_types::{
     committee::EpochId,
     digests::TransactionDigest,
     effects::TransactionEffects,
-    error::{ExecutionError, SuiError, SuiResult},
+    error::{ExecutionError, ExecutionErrorContext, SuiError, SuiResult},
     execution::{ExecutionResult, TypeLayoutStore},
     gas::SuiGasStatus,
     inner_temporary_store::InnerTemporaryStore,
@@ -139,7 +139,7 @@ impl executor::Executor for Executor {
         SuiGasStatus,
         TransactionEffects,
         Vec<ExecutionTiming>,
-        Result<(), ExecutionError>,
+        Result<(), ExecutionErrorContext>,
     ) {
         let (inner_temp_store, gas_status, effects, timings, result) =
             execute_transaction_to_effects::<execution_mode::Normal>(
@@ -162,6 +162,7 @@ impl executor::Executor for Executor {
         if let Err(error) = &result {
             log_execution_error(protocol_config, transaction_digest, error);
         }
+        let result = result.map_err(ExecutionErrorContext::from);
         (inner_temp_store, gas_status, effects, timings, result)
     }
 


### PR DESCRIPTION
## Description 
  Adds JSON-RPC index support for VM execution error visibility.

  This threads richer `ExecutionErrorContext` through fullnode execution, extracts execution error metadata/source for failed txs, and writes it to a new `execution_error_metadata` index by tx digest. Validators continue using the on-chain data `ExecutionFailure` path and drop the extra metadata.

  The new index table is prunable by transaction sequence number and has a round-trip unit test.

requires changes to sui-apis sui-rust-sdk:
https://github.com/MystenLabs/sui-rust-sdk/pull/267
https://github.com/MystenLabs/sui-apis/pull/28

## Test plan 
sui core
- test_execution_error_metadata_round_trip
- test_empty_execution_error_metadata_is_ignored
- test_validator_execution_does_not_store_error_metadata
- execution_error_metadata_table_accepts_future_proto_schema

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
