### PR TITLE
[chore] Update tidehunter to 48f0621

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8407,7 +8407,7 @@ dependencies = [
 [[package]]
 name = "minibytes"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/tidehunter.git?rev=f7e5ab73209035fa1695777defc1a11368425d2d#f7e5ab73209035fa1695777defc1a11368425d2d"
+source = "git+https://github.com/mystenlabs/tidehunter.git?rev=48f0621dc08b3992dbd168631f36b88b003f4a2c#48f0621dc08b3992dbd168631f36b88b003f4a2c"
 dependencies = [
  "bytes",
  "memmap2 0.7.1",
@@ -17893,7 +17893,7 @@ dependencies = [
 [[package]]
 name = "tidehunter"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/tidehunter.git?rev=f7e5ab73209035fa1695777defc1a11368425d2d#f7e5ab73209035fa1695777defc1a11368425d2d"
+source = "git+https://github.com/mystenlabs/tidehunter.git?rev=48f0621dc08b3992dbd168631f36b88b003f4a2c#48f0621dc08b3992dbd168631f36b88b003f4a2c"
 dependencies = [
  "arc-swap",
  "bincode 1.3.3",

--- a/crates/typed-store/Cargo.toml
+++ b/crates/typed-store/Cargo.toml
@@ -34,7 +34,7 @@ sui-macros.workspace = true
 mysten-common.workspace = true
 mysten-metrics.workspace = true
 [target.'cfg(not(windows))'.dependencies]
-tidehunter = {git = "https://github.com/mystenlabs/tidehunter.git", rev = "f7e5ab73209035fa1695777defc1a11368425d2d", version = "0.1.0", optional = true}
+tidehunter = {git = "https://github.com/mystenlabs/tidehunter.git", rev = "48f0621dc08b3992dbd168631f36b88b003f4a2c", version = "0.1.0", optional = true}
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 rocksdb = { version = "0.22.0", default-features = false, features = ["jemalloc"] }


### PR DESCRIPTION
## Summary
- Updates tidehunter git dependency to `48f0621dc08b3992dbd168631f36b88b003f4a2c`

## Test plan
- [ ] Deploy to private-testnet with `build_with_tidehunter=true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)