### PR TITLE
docker: cache-friendly Dockerfile rewrites for Tier 1 images

### DIFF
--- a/docker/sui-indexer-alt-consistent-store/Dockerfile
+++ b/docker/sui-indexer-alt-consistent-store/Dockerfile
@@ -5,8 +5,6 @@
 ARG PROFILE=release-unwind
 FROM rust:1.92-bullseye AS builder
 ARG PROFILE
-ARG GIT_REVISION
-ENV GIT_REVISION=$GIT_REVISION
 WORKDIR "$WORKDIR/sui"
 
 # sui-indexer need ca-certificates
@@ -14,13 +12,19 @@ RUN apt update && apt install -y ca-certificates
 
 RUN apt-get update && apt-get install -y cmake clang
 
+# COPYs ordered least- to most-frequently-changing for deeper layer cache hits.
+COPY rust-toolchain.toml ./
+COPY .cargo .cargo
 COPY Cargo.toml Cargo.lock ./
+COPY external-crates external-crates
+COPY sui-execution sui-execution
 COPY consensus consensus
 COPY crates crates
-COPY sui-execution sui-execution
-COPY external-crates external-crates
 
-RUN cargo build --profile ${PROFILE} --bin sui-indexer-alt-consistent-store
+# GIT_REVISION declared late so SHA changes don't invalidate the COPYs above.
+ARG GIT_REVISION
+ENV GIT_REVISION=$GIT_REVISION
+RUN cargo build --locked --profile ${PROFILE} --bin sui-indexer-alt-consistent-store
 
 # Production Image
 FROM debian:bullseye-slim AS runtime

--- a/docker/sui-indexer-alt-graphql/Dockerfile
+++ b/docker/sui-indexer-alt-graphql/Dockerfile
@@ -6,9 +6,7 @@
 ARG PROFILE=release-unwind
 FROM rust:1.92-bullseye AS builder
 ARG PROFILE
-ARG GIT_REVISION
 ARG FEATURES=""
-ENV GIT_REVISION=$GIT_REVISION
 WORKDIR "$WORKDIR/sui"
 
 # sui-indexer need ca-certificates
@@ -16,16 +14,22 @@ RUN apt update && apt install -y ca-certificates postgresql
 
 RUN apt-get update && apt-get install -y cmake clang
 
+# COPYs ordered least- to most-frequently-changing for deeper layer cache hits.
+COPY rust-toolchain.toml ./
+COPY .cargo .cargo
 COPY Cargo.toml Cargo.lock ./
+COPY external-crates external-crates
+COPY sui-execution sui-execution
 COPY consensus consensus
 COPY crates crates
-COPY sui-execution sui-execution
-COPY external-crates external-crates
 
+# GIT_REVISION declared late so SHA changes don't invalidate the COPYs above.
+ARG GIT_REVISION
+ENV GIT_REVISION=$GIT_REVISION
 RUN if [ -n "$FEATURES" ]; then \
-        cargo build --profile ${PROFILE} --bin sui-indexer-alt-graphql --features "$FEATURES"; \
+        cargo build --locked --profile ${PROFILE} --bin sui-indexer-alt-graphql --features "$FEATURES"; \
     else \
-        cargo build --profile ${PROFILE} --bin sui-indexer-alt-graphql; \
+        cargo build --locked --profile ${PROFILE} --bin sui-indexer-alt-graphql; \
     fi
 
 # Production Image

--- a/docker/sui-indexer-alt-jsonrpc/Dockerfile
+++ b/docker/sui-indexer-alt-jsonrpc/Dockerfile
@@ -5,8 +5,6 @@
 ARG PROFILE=release-unwind
 FROM rust:1.92-bullseye AS builder
 ARG PROFILE
-ARG GIT_REVISION
-ENV GIT_REVISION=$GIT_REVISION
 WORKDIR "$WORKDIR/sui"
 
 # sui-indexer need ca-certificates
@@ -14,13 +12,19 @@ RUN apt update && apt install -y ca-certificates postgresql
 
 RUN apt-get update && apt-get install -y cmake clang
 
+# COPYs ordered least- to most-frequently-changing for deeper layer cache hits.
+COPY rust-toolchain.toml ./
+COPY .cargo .cargo
 COPY Cargo.toml Cargo.lock ./
+COPY external-crates external-crates
+COPY sui-execution sui-execution
 COPY consensus consensus
 COPY crates crates
-COPY sui-execution sui-execution
-COPY external-crates external-crates
 
-RUN cargo build --profile ${PROFILE} --bin sui-indexer-alt-jsonrpc
+# GIT_REVISION declared late so SHA changes don't invalidate the COPYs above.
+ARG GIT_REVISION
+ENV GIT_REVISION=$GIT_REVISION
+RUN cargo build --locked --profile ${PROFILE} --bin sui-indexer-alt-jsonrpc
 
 # Production Image
 FROM debian:bullseye-slim AS runtime

--- a/docker/sui-indexer-alt/Dockerfile
+++ b/docker/sui-indexer-alt/Dockerfile
@@ -4,8 +4,6 @@
 # and build the application.
 FROM rust:1.92-bullseye AS builder
 ARG PROFILE=release
-ARG GIT_REVISION
-ENV GIT_REVISION=$GIT_REVISION
 WORKDIR "$WORKDIR/sui"
 
 # sui-indexer need ca-certificates
@@ -13,13 +11,19 @@ RUN apt update && apt install -y ca-certificates postgresql
 
 RUN apt-get update && apt-get install -y cmake clang
 
+# COPYs ordered least- to most-frequently-changing for deeper layer cache hits.
+COPY rust-toolchain.toml ./
+COPY .cargo .cargo
 COPY Cargo.toml Cargo.lock ./
+COPY external-crates external-crates
+COPY sui-execution sui-execution
 COPY consensus consensus
 COPY crates crates
-COPY sui-execution sui-execution
-COPY external-crates external-crates
 
-RUN cargo build --profile ${PROFILE} --bin sui-indexer-alt
+# GIT_REVISION declared late so SHA changes don't invalidate the COPYs above.
+ARG GIT_REVISION
+ENV GIT_REVISION=$GIT_REVISION
+RUN cargo build --locked --profile ${PROFILE} --bin sui-indexer-alt
 
 # Production Image
 FROM debian:bullseye-slim AS runtime

--- a/docker/sui-kv-rpc/Dockerfile
+++ b/docker/sui-kv-rpc/Dockerfile
@@ -1,18 +1,22 @@
-FROM rust:1.92-bullseye as build
+FROM rust:1.92-bullseye AS build
 
 ARG PROFILE=release
 WORKDIR /work
 
 RUN apt-get update && apt-get install -y cmake clang
 
-COPY .git/ .git/
+# COPYs ordered least- to most-frequently-changing for deeper layer cache hits.
+COPY rust-toolchain.toml ./
+COPY .cargo .cargo
 COPY Cargo.toml Cargo.lock ./
+COPY external-crates external-crates
+COPY sui-execution sui-execution
 COPY consensus consensus
 COPY crates crates
-COPY sui-execution sui-execution
-COPY external-crates external-crates
 
-RUN cargo build --profile ${PROFILE} --bin sui-kv-rpc
+# .git/ copied late so per-commit metadata churn doesn't invalidate the COPYs above.
+COPY .git/ .git/
+RUN cargo build --locked --profile ${PROFILE} --bin sui-kv-rpc
 
 FROM gcr.io/distroless/cc-debian12 as deploy
 

--- a/docker/sui-services/Dockerfile
+++ b/docker/sui-services/Dockerfile
@@ -1,18 +1,23 @@
 FROM rust:1.92-bullseye AS chef
 WORKDIR sui
-ARG GIT_REVISION
-ENV GIT_REVISION=$GIT_REVISION
 RUN apt-get update && apt-get install -y cmake clang libpq5 ca-certificates libpq-dev postgresql
 
 # Build application
-FROM chef AS builder 
+FROM chef AS builder
 
+# COPYs ordered least- to most-frequently-changing for deeper layer cache hits.
+COPY rust-toolchain.toml ./
+COPY .cargo .cargo
 COPY Cargo.toml Cargo.lock ./
+COPY external-crates external-crates
+COPY sui-execution sui-execution
 COPY consensus consensus
 COPY crates crates
-COPY sui-execution sui-execution
-COPY external-crates external-crates
-RUN cargo build --release \
+
+# GIT_REVISION declared late so SHA changes don't invalidate the COPYs above.
+ARG GIT_REVISION
+ENV GIT_REVISION=$GIT_REVISION
+RUN cargo build --locked --release \
     --bin sui-oracle \
     --bin sui-metric-checker
 RUN mkdir /sui/bin/


### PR DESCRIPTION
## Summary

Apply the same cache-friendly Dockerfile pattern already used by `sui-node`, `sui-tools`, and `sui-node-th` to the next batch of high-frequency Mysten-built images:

- `sui-indexer-alt`
- `sui-indexer-alt-graphql`
- `sui-indexer-alt-jsonrpc`
- `sui-indexer-alt-consistent-store`
- `sui-kv-rpc`
- `sui-services` (sui-oracle + sui-metric-checker)

### What changes per Dockerfile

- `COPY rust-toolchain.toml ./` + `COPY .cargo .cargo` at the top so the toolchain/config layer is cached separately from sources.
- Workspace COPYs reordered least- → most-frequently-changing: `external-crates → sui-execution → consensus → crates`. Source edits in `crates/` no longer invalidate the heavier `external-crates` and `sui-execution` layers.
- `ARG GIT_REVISION` + `ENV GIT_REVISION=$GIT_REVISION` moved to **after** the COPYs so a fresh SHA on every build no longer busts every source COPY layer.
- `cargo build` now uses `--locked`.

Image-specific:
- `sui-kv-rpc`: `COPY .git/` moved to be the last COPY before `cargo build` (same reason as `GIT_REVISION` — per-commit `.git/` churn was invalidating every source layer above it).
- `sui-services`: `ARG GIT_REVISION` / `ENV GIT_REVISION` removed from the `chef` base stage (where they were busting every downstream layer) and declared late in `builder`.

No changes to runtime stages, produced binaries, or installed packages. Only Docker layer ordering and cache mount points.

### Codegen note (not a regression, worth flagging)

Adding `COPY .cargo .cargo` means these six images now honor the workspace's `.cargo/config.toml`, which carries `[build] rustflags = ["-C", "force-frame-pointers=yes", "-C", "force-unwind-tables=yes", "-A", "unknown_lints", "-A", "mismatched_lifetime_syntaxes"]`.

Before this PR, the six rebuilt images were silently missing these flags — they compiled without frame pointers and without unwind tables. After this PR, they match `sui-node` / `sui-tools` / `sui-node-th`, which have shipped with these flags for ages. User-visible binary behavior is unchanged. The observable effects:

- pprof / perf / flamegraph stack-walking now works for `sui-indexer-alt-*` / `sui-kv-rpc` / `sui-services` (improvement).
- Proper backtraces in panic handlers (improvement).
- ~1-2% runtime cost from frame pointers and a small image-size bump from unwind tables (acceptable; consistent with the rest of the fleet).

Anyone bisecting a future perf change on these images should know this commit aligns codegen, not just layer caching.

### Why

Pairs with the mp3-side cache_family threading and the `mysten-rust-builder` rewriter (sui-ops #7886, mp3 #138). With this preamble in place, the rewriter's injected `--mount=type=cache,target=/sui/target,id=<cache_family>` mount has a stable cache key across SHA-only commits, and the cargo-target PVC bucket can be reused effectively.

## Test plan

- [ ] CI Docker image builds succeed for all 6 images
- [ ] Confirm post-merge mp3 builds for these images use the rewriter and pick a non-empty `cache_family` (visible in `mp3_rewriter_applied_total{cache_family=...}`)
- [ ] Spot-check one build's `sticky_dispatch_total{result=\"hit\"}` increment after a second SHA on the same `cache_family`
- [ ] Sanity-check one of the new binaries still runs (e.g. `sui-indexer-alt --version`) — frame-pointer / unwind-table codegen change shouldn't affect external behavior, but cheap to verify