### PR TITLE
ci: thread cache_family into sui-operations tag-docker-images dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -264,13 +264,21 @@ jobs:
     name: Tag sui docker images in DockerHub
     runs-on: ubuntu-latest
     steps:
+      - name: Derive cache_family from release tag
+        id: cf
+        shell: bash
+        run: |
+          sui_tag="${{ env.TAG_NAME }}"
+          sui_version=$(echo "${sui_tag}" | sed -e 's|^refs/tags/||' -e 's/^mainnet-v//' -e 's/^testnet-v//' -e 's/^devnet-v//')
+          echo "cache_family=releases/sui-v${sui_version}-release" >> "$GITHUB_OUTPUT"
+
       - name: Dispatch Tagging of images in DockerHub, in MystenLabs/sui-operations
         uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # pin@v4.0.1
         with:
           repository: MystenLabs/sui-operations
           token: ${{ secrets.DOCKER_BINARY_BUILDS_DISPATCH }}
           event-type: tag-docker-images
-          client-payload: '{"sui_commit": "${{ github.sha }}", "tag": "${{ env.TAG_NAME }}"}'
+          client-payload: '{"sui_commit": "${{ github.sha }}", "tag": "${{ env.TAG_NAME }}", "cache_family": "${{ steps.cf.outputs.cache_family }}"}'
 
   # Tag sui binaries in S3 under the release alias so node operators that pull
   # by tag name (e.g. `release: testnet-v1.70.2` in ansible) find them.

--- a/.github/workflows/trigger-builds.yml
+++ b/.github/workflows/trigger-builds.yml
@@ -22,10 +22,21 @@ jobs:
     if: github.event_name == 'push' && contains(fromJSON('["devnet", "testnet", "mainnet"]'), github.ref_name)
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
+        with:
+          fetch-depth: 1
+
+      - name: Derive cache_family from Cargo.toml
+        id: cf
+        shell: bash
+        run: |
+          sui_version=$(awk '/^\[workspace\.package\]/{found=1} found && /^version =/{gsub(/[" ]/,"",$3); print $3; exit}' Cargo.toml)
+          echo "cache_family=releases/sui-v${sui_version}-release" >> "$GITHUB_OUTPUT"
+
       - name: Dispatch Tagging of images in DockerHub, in MystenLabs/sui-operations
         uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # pin@v4.0.1
         with:
           repository: MystenLabs/sui-operations
           token: ${{ secrets.DOCKER_BINARY_BUILDS_DISPATCH }}
           event-type: tag-docker-images
-          client-payload: '{"sui_commit": "${{ github.sha }}", "tag": "${{ github.ref_name }}"}'
+          client-payload: '{"sui_commit": "${{ github.sha }}", "tag": "${{ github.ref_name }}", "cache_family": "${{ steps.cf.outputs.cache_family }}"}'


### PR DESCRIPTION
## Summary

`trigger-builds.yml` and `release.yml` both `repository_dispatch` `tag-docker-images` to sui-operations, which calls `tag-upload-docker-image.yml`. That workflow chains into `prebuild-sui-images.yml` on cache miss, where `cache_family` selects the mp3 cargo-target cache bucket and the buildkitd-ss sticky-pod bucket for the build.

Both dispatches were sending an **empty `cache_family`**, which left mp3 with no bucket signal on cache-miss rebuilds — same root cause as [sui-operations#7897](https://github.com/MystenLabs/sui-operations/pull/7897) (which threaded `cache_family` through every `ensure-sui-binaries.yml` caller on the sui-operations side).

## Changes

Mirror the existing pattern in `release.yml`'s `ensure-sui-binaries` dispatch:

- **`release.yml`** — add the same `Derive cache_family from release tag` step to the `tag-docker-hub-images` job; pass `cache_family: releases/sui-vX.Y.Z-release` in the dispatch payload.
- **`trigger-builds.yml`** — fires on `push` to devnet/testnet/mainnet, so derive the release version from `Cargo.toml` at the pushed SHA and pass `cache_family: releases/sui-vX.Y.Z-release`.

## Why this matters

Without `cache_family`, mp3's sticky picker can't bucket the cache-miss rebuild. The rebuild lands on an arbitrary `buildkitd-ss-*` pod with a fresh cargo-target cache, defeating the whole point of the stateful pool for these images. With `cache_family=releases/sui-vX.Y.Z-release`, mp3 buckets the build into the right release-branch family and reuses the warm cache.

This is a low-frequency path (cache misses are rare since release commits are usually pre-built by CI), but when it does fire, the build is on the critical release path and benefits the most from cache reuse.

## Test plan

- [x] `actionlint` on both files — 34 pre-existing warnings, 0 new errors
- [ ] After merge: next push to devnet/testnet/mainnet triggers `trigger-builds.yml` and the resulting `tag-docker-images` dispatch in sui-operations shows `cache_family` populated in the mp3 `image_builds` DB row (only if it cache-misses; otherwise just verifies the payload reaches sui-operations correctly)
- [ ] After merge: next sui release tag triggers `release.yml` and the resulting `tag-docker-images` dispatch shows `cache_family` populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)