### PR TITLE
[move-ide] Generic macro type param processing fix

### DIFF
--- a/external-crates/move/crates/move-analyzer/editors/code/package-lock.json
+++ b/external-crates/move/crates/move-analyzer/editors/code/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "move",
-  "version": "1.0.42",
+  "version": "1.0.43",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "move",
-      "version": "1.0.42",
+      "version": "1.0.43",
       "license": "Apache-2.0",
       "dependencies": {
         "command-exists": "^1.2.9",

--- a/external-crates/move/crates/move-analyzer/editors/code/package.json
+++ b/external-crates/move/crates/move-analyzer/editors/code/package.json
@@ -5,7 +5,7 @@
   "publisher": "mysten",
   "icon": "images/move.png",
   "license": "Apache-2.0",
-  "version": "1.0.42",
+  "version": "1.0.43",
   "preview": true,
   "repository": {
     "url": "https://github.com/MystenLabs/sui.git",

--- a/external-crates/move/crates/move-analyzer/src/analysis/mod.rs
+++ b/external-crates/move/crates/move-analyzer/src/analysis/mod.rs
@@ -97,6 +97,7 @@ pub fn run_typing_analysis(
         compiler_analysis_info,
         type_params: BTreeMap::new(),
         expression_scope: OrdMap::new(),
+        current_macro_call_loc: None,
     };
 
     process_typed_modules(

--- a/external-crates/move/crates/move-analyzer/src/analysis/typing_analysis.rs
+++ b/external-crates/move/crates/move-analyzer/src/analysis/typing_analysis.rs
@@ -63,6 +63,9 @@ pub struct TypingAnalysisContext<'a> {
     pub expression_scope: OrdMap<Symbol, LocalDef>,
     /// IDE Annotation Information from the Compiler
     pub compiler_analysis_info: &'a CompilerAnalysisInfo,
+    /// Tracks the root (outermost) macro call location for the current expansion chain.
+    /// Used to disambiguate MacroCallInfo lookups for nested macro calls.
+    pub current_macro_call_loc: Option<Loc>,
 }
 
 /// Definition of a local (or parameter)
@@ -1199,34 +1202,109 @@ impl TypingVisitorContext for TypingAnalysisContext<'_> {
                     };
                     true
                 }
-                TE::Unit { .. }
-                | TE::Builtin(_, _)
-                | TE::Vector(_, _, _, _)
-                | TE::IfElse(_, _, _)
-                | TE::While(_, _, _)
-                | TE::Loop { .. }
-                | TE::NamedBlock(_, _)
-                | TE::Block(_)
-                | TE::Assign(_, _, _)
-                | TE::Mutate(_, _)
-                | TE::Return(_)
-                | TE::Abort(_)
-                | TE::Give(_, _)
-                | TE::Continue(_)
-                | TE::Dereference(_)
-                | TE::UnaryExp(_, _)
-                | TE::BinopExp(_, _, _, _)
-                | TE::ExpList(_)
-                | TE::Value(_)
-                | TE::TempBorrow(_, _)
-                | TE::Cast(_, _)
-                | TE::Annotate(_, _)
-                | TE::UnresolvedError => false,
+                // All remaining expression types are handled here rather than
+                // delegating to the default visit_exp traversal. This is necessary
+                // because the macro and lambda handlers in visit_exp_custom set state
+                // (traverse_only, current_macro_call_loc) that must persist throughout
+                // the entire expression traversal. If visit_exp_inner returns false,
+                // visit_exp_custom also returns false, and the default visit_exp
+                // traversal runs AFTER the state has been restored — defeating the
+                // macro/lambda state management.
+                TE::Block(seq) | TE::NamedBlock(_, seq) => {
+                    visitor.visit_seq(exp.exp.loc, seq);
+                    true
+                }
+                TE::IfElse(e1, e2, e3_opt) => {
+                    visitor.visit_exp(e1);
+                    visitor.visit_exp(e2);
+                    if let Some(e3) = e3_opt {
+                        visitor.visit_exp(e3);
+                    }
+                    true
+                }
+                TE::While(_, e1, e2) | TE::Mutate(e1, e2) => {
+                    visitor.visit_exp(e1);
+                    visitor.visit_exp(e2);
+                    true
+                }
+                TE::Assign(lvalues, ty_ann, e) => {
+                    visitor.visit_exp(e);
+                    for lvalue in lvalues.value.iter() {
+                        visitor.visit_lvalue(&LValueKind::Assign, lvalue);
+                    }
+                    ty_ann
+                        .iter()
+                        .flatten()
+                        .for_each(|ty| visitor.visit_type(Some(exp_loc), ty));
+                    true
+                }
+                TE::Loop { body, .. } => {
+                    visitor.visit_exp(body);
+                    true
+                }
+                TE::Return(e)
+                | TE::Abort(e)
+                | TE::Give(_, e)
+                | TE::Dereference(e)
+                | TE::UnaryExp(_, e)
+                | TE::TempBorrow(_, e) => {
+                    visitor.visit_exp(e);
+                    true
+                }
+                TE::BinopExp(e1, _, ty, e2) => {
+                    visitor.visit_type(Some(exp_loc), ty);
+                    visitor.visit_exp(e1);
+                    visitor.visit_exp(e2);
+                    true
+                }
+                TE::Builtin(bf, e) => {
+                    visitor.visit_exp(e);
+                    use T::BuiltinFunction_ as BF;
+                    match &bf.value {
+                        BF::Freeze(t) => visitor.visit_type(Some(exp_loc), t),
+                        BF::Assert(_) => (),
+                    }
+                    true
+                }
+                TE::Vector(_, _, ty, e) => {
+                    visitor.visit_type(Some(exp_loc), ty);
+                    visitor.visit_exp(e);
+                    true
+                }
+                TE::ExpList(list) => {
+                    for l in list {
+                        match l {
+                            T::ExpListItem::Single(e, ty) => {
+                                visitor.visit_exp(e);
+                                visitor.visit_type(Some(exp_loc), ty);
+                            }
+                            T::ExpListItem::Splat(_, e, tys) => {
+                                visitor.visit_exp(e);
+                                tys.iter()
+                                    .for_each(|ty| visitor.visit_type(Some(exp_loc), ty));
+                            }
+                        }
+                    }
+                    true
+                }
+                TE::Cast(e, ty) | TE::Annotate(e, ty) => {
+                    visitor.visit_exp(e);
+                    visitor.visit_type(Some(exp_loc), ty);
+                    true
+                }
+                TE::Unit { .. } | TE::Value(_) | TE::Continue(_) | TE::UnresolvedError => true,
             }
         }
 
         let expanded_lambda = self.compiler_analysis_info.is_expanded_lambda(&exp.exp.loc);
-        if let Some(macro_call_info) = self.compiler_analysis_info.get_macro_info(&exp.exp.loc) {
+        // Compute the root_call_loc for MacroCallInfo disambiguation:
+        // if we're already inside a macro expansion, use the existing root;
+        // otherwise this is the outermost call, so use exp.exp.loc as root.
+        let root_call_loc = self.current_macro_call_loc.unwrap_or(exp.exp.loc);
+        if let Some(macro_call_info) = self
+            .compiler_analysis_info
+            .get_macro_info(&exp.exp.loc, root_call_loc)
+        {
             debug_assert!(!expanded_lambda, "Compiler info issue");
             let MacroCallInfo {
                 module,
@@ -1234,14 +1312,19 @@ impl TypingVisitorContext for TypingAnalysisContext<'_> {
                 method_name,
                 type_arguments,
                 by_value_args,
+                root_call_loc: info_root,
             } = macro_call_info.clone();
             self.process_module_call(&module, &name, method_name, &type_arguments, None);
             by_value_args.iter().for_each(|a| self.visit_seq_item(a));
             let old_traverse_mode = self.traverse_only;
+            let old_macro_call_loc = self.current_macro_call_loc;
+            // Set root for nested macro lookups
+            self.current_macro_call_loc = Some(info_root);
             // stop adding new use-defs etc.
             self.traverse_only = true;
             let result = visit_exp_inner(self, exp);
             self.traverse_only = old_traverse_mode;
+            self.current_macro_call_loc = old_macro_call_loc;
             result
         } else if expanded_lambda {
             let old_traverse_mode = self.traverse_only;

--- a/external-crates/move/crates/move-analyzer/src/compiler_info.rs
+++ b/external-crates/move/crates/move-analyzer/src/compiler_info.rs
@@ -11,8 +11,9 @@ use move_ir_types::location::Loc;
 /// This is cached and used during typing analysis.
 #[derive(Default, Debug, Clone)]
 pub struct CompilerAnalysisInfo {
-    /// Macro call information
-    pub macro_info: BTreeMap<Loc, CI::MacroCallInfo>,
+    /// Macro call information keyed by expanded expression location.
+    /// Multiple expansions can share locations from macro definitions.
+    pub macro_info: BTreeMap<Loc, Vec<CI::MacroCallInfo>>,
     /// Expanded lambda expressions
     pub expanded_lambdas: BTreeSet<Loc>,
     /// Ellipsis-generated binders (to filter from IDE)
@@ -36,8 +37,12 @@ impl CompilerAnalysisInfo {
         Self::default()
     }
 
-    pub fn get_macro_info(&self, loc: &Loc) -> Option<&CI::MacroCallInfo> {
-        self.macro_info.get(loc)
+    pub fn get_macro_info(&self, loc: &Loc, root_call_loc: Loc) -> Option<&CI::MacroCallInfo> {
+        let entries = self.macro_info.get(loc)?;
+        // Macro-expanded expressions can share locations because locations
+        // inside an expanded macro body come from the macro definition. Only
+        // use metadata from the expansion tree currently being traversed.
+        entries.iter().find(|e| e.root_call_loc == root_call_loc)
     }
 
     pub fn is_expanded_lambda(&self, loc: &Loc) -> bool {
@@ -84,7 +89,7 @@ pub fn process_ide_annotations(
     for (loc, entry) in annotations {
         match entry {
             CI::IDEAnnotation::MacroCallInfo(info) => {
-                analysis.macro_info.insert(loc, *info);
+                analysis.macro_info.entry(loc).or_default().push(*info);
             }
             CI::IDEAnnotation::ExpandedLambda => {
                 analysis.expanded_lambdas.insert(loc);

--- a/external-crates/move/crates/move-analyzer/src/symbols/compilation.rs
+++ b/external-crates/move/crates/move-analyzer/src/symbols/compilation.rs
@@ -1196,7 +1196,11 @@ fn merge_compiler_analysis_info(
     // as incremental compilation produced these
     // only for modified files
     for (loc, mut entries) in new_info.macro_info {
-        result.macro_info.entry(loc).or_default().append(&mut entries);
+        result
+            .macro_info
+            .entry(loc)
+            .or_default()
+            .append(&mut entries);
     }
     result.expanded_lambdas.extend(new_info.expanded_lambdas);
     result.ellipsis_binders.extend(new_info.ellipsis_binders);

--- a/external-crates/move/crates/move-analyzer/src/symbols/compilation.rs
+++ b/external-crates/move/crates/move-analyzer/src/symbols/compilation.rs
@@ -1195,7 +1195,9 @@ fn merge_compiler_analysis_info(
     // Add new entries - no additional filtering needed
     // as incremental compilation produced these
     // only for modified files
-    result.macro_info.extend(new_info.macro_info);
+    for (loc, mut entries) in new_info.macro_info {
+        result.macro_info.entry(loc).or_default().append(&mut entries);
+    }
     result.expanded_lambdas.extend(new_info.expanded_lambdas);
     result.ellipsis_binders.extend(new_info.ellipsis_binders);
     result.string_values.extend(new_info.string_values);

--- a/external-crates/move/crates/move-analyzer/tests/generic-macro-type-param/Move.toml
+++ b/external-crates/move/crates/move-analyzer/tests/generic-macro-type-param/Move.toml
@@ -1,0 +1,10 @@
+[package]
+name = "GenericMacroTypeParam"
+version = "0.0.1"
+edition = "2024.beta"
+
+[dependencies]
+MoveStdlib = { local = "../../../move-stdlib/", addr_subst = { "std" = "0x1" } }
+
+[addresses]
+GenericMacroTypeParam = "0xCAFE"

--- a/external-crates/move/crates/move-analyzer/tests/generic-macro-type-param/sources/find_index.move
+++ b/external-crates/move/crates/move-analyzer/tests/generic-macro-type-param/sources/find_index.move
@@ -1,0 +1,34 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module GenericMacroTypeParam::a_victim {
+    public fun do_ref_test(): u64 {
+        let v = vector[0u64, 10, 100, 1_000];
+        let mut sum = 0;
+        v.do_ref!(|e| sum = sum + *e);
+        sum
+    }
+}
+
+module GenericMacroTypeParam::z_generic {
+    public fun id_ref<K>(v: &vector<K>): &vector<K> {
+        v
+    }
+
+    // Generic invocations of the same macro. The receiver is intentionally an
+    // inline generic call, so the macro payload's by-value args contain K.
+    // This test is a bit fragile as we cannot fully control evaluation order
+    // of macro expansions in the compiler. Nevertheless, as it is, this test
+    // manages to consistently expose the bug (assertion failure) prior to
+    // the fix being implemented.
+    public fun count<K: copy + drop>(v: &vector<K>): u64 {
+        let mut n = 0;
+        id_ref<K>(v).do_ref!(|_| n = n + 1);
+        id_ref<K>(v).do_ref!(|_| n = n + 1);
+        id_ref<K>(v).do_ref!(|_| n = n + 1);
+        id_ref<K>(v).do_ref!(|_| n = n + 1);
+        id_ref<K>(v).do_ref!(|_| n = n + 1);
+        id_ref<K>(v).do_ref!(|_| n = n + 1);
+        n
+    }
+}

--- a/external-crates/move/crates/move-analyzer/tests/generic_macro_type_param.ide
+++ b/external-crates/move/crates/move-analyzer/tests/generic_macro_type_param.ide
@@ -1,0 +1,22 @@
+// Reproduces a macro metadata collision between generic and non-generic
+// expansions of the same macro.
+//
+// Before the fix, macro metadata was keyed only by the expanded expression's
+// location, which comes from the macro definition. If the compiler expands a
+// non-generic invocation first and then generic invocations of the same macro,
+// generic metadata can overwrite the non-generic metadata.
+//
+// The analyzer can then process the non-generic expanded code using metadata
+// from the generic invocation. That metadata references the generic type
+// but the non-generic function does not have this type in scope.
+{
+  "UseDef": {
+    "project": "tests/generic-macro-type-param",
+    "file_tests": {
+      "find_index.move": [
+        { "use_line": 6, "use_ndx": 0 },
+        { "use_line": 8, "use_ndx": 0 }
+      ]
+    }
+  }
+}

--- a/external-crates/move/crates/move-analyzer/tests/generic_macro_type_param.snap
+++ b/external-crates/move/crates/move-analyzer/tests/generic_macro_type_param.snap
@@ -1,0 +1,19 @@
+---
+source: crates/move-analyzer/tests/ide_testsuite.rs
+---
+== find_index.move ========================================================
+-- test 0 -------------------
+use line: 6, use_ndx: 0
+Use: 'v', start: 12, end: 13
+Def: 'v', line: 5, def char: 12
+TypeDef: no info
+On Hover:
+let v: vector<u64>
+
+-- test 1 -------------------
+use line: 8, use_ndx: 0
+Use: 'v', start: 8, end: 9
+Def: 'v', line: 5, def char: 12
+TypeDef: no info
+On Hover:
+let v: vector<u64>

--- a/external-crates/move/crates/move-compiler/src/shared/ide.rs
+++ b/external-crates/move/crates/move-compiler/src/shared/ide.rs
@@ -65,6 +65,13 @@ pub struct MacroCallInfo {
     pub type_arguments: Vec<N::Type>,
     /// By-value args (at this point there should only be one, representing receiver arg)
     pub by_value_args: Vec<T::SequenceItem>,
+    /// Location of the outermost (root) macro call in the expansion chain.
+    /// For the outermost call itself, this equals call_loc. For nested macro calls
+    /// (e.g., do! inside find_index!), this is the location of the outermost
+    /// find_index! call site. Used to disambiguate MacroCallInfo entries that share
+    /// the same inner call Loc (from the macro body) but belong to different
+    /// expansion contexts.
+    pub root_call_loc: Loc,
 }
 
 #[derive(Debug, Clone, PartialOrd, Ord, PartialEq, Eq)]
@@ -284,6 +291,7 @@ impl From<(Loc, IDEAnnotation)> for Diagnostic {
                     method_name,
                     type_arguments,
                     by_value_args,
+                    root_call_loc: _,
                 } = *info;
                 let mut diag = diag!(IDE::MacroCallInfo, (loc, "macro call info"));
                 diag.add_note(format!("Called {module}::{name}"));

--- a/external-crates/move/crates/move-compiler/src/typing/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/translate.rs
@@ -4840,12 +4840,25 @@ fn expand_macro(
             let use_funs = N::UseFuns::new(context.current_call_color());
             let block = TE::Block((use_funs, seq));
             if context.env().ide_mode() {
+                // The first stack entry is the outermost macro call. Argument
+                // frames can appear inside that call stack, but never as the
+                // root.
+                let root_expansion = context.macro_expansion.first();
+                debug_assert!(
+                    matches!(root_expansion, Some(core::MacroExpansion::Call(_))),
+                    "macro expansion stack root should be a call"
+                );
+                let root_call_loc = match root_expansion {
+                    Some(core::MacroExpansion::Call(c)) => c.invocation,
+                    Some(core::MacroExpansion::Argument { .. }) | None => call_loc,
+                };
                 let macro_call_info = MacroCallInfo {
                     module: m,
                     name: f,
                     method_name,
                     type_arguments: type_args.clone(),
                     by_value_args,
+                    root_call_loc,
                 };
                 let info = IDEAnnotation::MacroCallInfo(Box::new(macro_call_info));
                 context.add_ide_info(call_loc, info);


### PR DESCRIPTION
## Description 

This PR fixes a problem related to analyzing macros expanded multiple times in the user code, sometimes with generic and sometimes with non-generic types.

The gist of the problem was that compiler information gathered in the IDE mode for macro expansion was dropped when translated to a data structure on the `move-analyzer` side. The reason for it was that only one macro expansion information was preserved, as it was keyed on original macro function location.

In the process, another bug was fixed - macro body analysis is guarded by the `traverse_only` flag which was not maintained correctly during IR traversals. 

## Test plan 

Added a new test exposing the macro expansion bug (assertion failure in debug mode)
