### PR TITLE
Add testnet DUSDC request link to DeepBook Predict docs

### DIFF
--- a/docs/content/onchain-finance/deepbook-predict/deepbook-predict.mdx
+++ b/docs/content/onchain-finance/deepbook-predict/deepbook-predict.mdx
@@ -25,6 +25,10 @@ DeepBook Predict smart contracts might change before Mainnet deployment. Treat t
 
 :::
 
+## Request testnet DUSDC
+
+Builders can request testnet DUSDC tokens for DeepBook Predict integration and testing by submitting the [DeepBook Predict DUSDC request form](https://tally.so/r/Xx102L).
+
 ## Key features
 
 DeepBook Predict provides the following capabilities:

--- a/docs/content/onchain-finance/deepbook-predict/deepbook-predict.mdx
+++ b/docs/content/onchain-finance/deepbook-predict/deepbook-predict.mdx
@@ -25,9 +25,9 @@ DeepBook Predict smart contracts might change before Mainnet deployment. Treat t
 
 :::
 
-## Request testnet DUSDC
+## Request Testnet tokens
 
-Builders can request testnet DUSDC tokens for DeepBook Predict integration and testing by submitting the [DeepBook Predict DUSDC request form](https://tally.so/r/Xx102L).
+Builders can request Testnet tokens for DeepBook Predict integration and testing, including DUSDC and other assets, by submitting the [DeepBook Predict Testnet token request form](https://tally.so/r/Xx102L).
 
 ## Key features
 


### PR DESCRIPTION
## Summary
- Add a new early section in the DeepBook Predict overview that points builders to the testnet DUSDC request form
- Place the section before Key features so the token request flow is visible near the top of the doc

## Testing
- Not run (not requested)