### PR TITLE
sui-core: drop fastpath guard in object_funds_checker

### DIFF
--- a/crates/sui-core/src/accumulators/object_funds_checker/integration_tests.rs
+++ b/crates/sui-core/src/accumulators/object_funds_checker/integration_tests.rs
@@ -168,29 +168,6 @@ async fn test_object_withdraw_basic_flow() {
 }
 
 #[tokio::test]
-async fn test_object_withdraw_fast_path_abort() {
-    let env = TestEnv::new().await;
-
-    env.fund_address(env.vault_obj.into(), 1000).await;
-
-    let gas = env.oref(&env.gas_obj).await;
-    let tx = TestTransactionBuilder::new(env.sender, gas, env.rgp())
-        .transfer_sui_to_address_balance(
-            FundSource::object_fund_owned(env.package_id, env.oref(&env.vault_obj).await),
-            vec![(1000, env.sender)],
-        )
-        .build();
-    let cert = VerifiedExecutableTransaction::new_for_testing(tx, &env.keypair);
-
-    let output = env
-        .authority
-        // Fastpath execution
-        .try_execute_immediately(&cert, ExecutionEnv::new(), &env.epoch_store)
-        .await;
-    assert!(matches!(output, ExecutionOutput::RetryLater));
-}
-
-#[tokio::test]
 async fn test_object_withdraw_multiple_withdraws() {
     let env = TestEnv::new().await;
 

--- a/crates/sui-core/src/accumulators/object_funds_checker/mod.rs
+++ b/crates/sui-core/src/accumulators/object_funds_checker/mod.rs
@@ -6,7 +6,7 @@ use std::{
     sync::Arc,
 };
 
-use mysten_common::assert_reachable;
+use mysten_common::{assert_reachable, debug_fatal};
 use parking_lot::RwLock;
 use sui_types::{
     SUI_ACCUMULATOR_ROOT_OBJECT_ID,
@@ -124,10 +124,10 @@ impl ObjectFundsChecker {
         // for the epoch, and every production path that produces such a tx also
         // assigns an accumulator version. The `None` paths (accumulator-disabled
         // epoch, end-of-epoch tx) never produce withdraws and so never reach here.
-        let accumulator_version = execution_env
-            .assigned_versions
-            .accumulator_version
-            .expect("accumulator_version must be set for a tx with object withdraws");
+        let Some(accumulator_version) = execution_env.assigned_versions.accumulator_version else {
+            debug_fatal!("accumulator_version must be set for a tx with object withdraws");
+            return false;
+        };
         match self.check_object_funds(object_withdraws, accumulator_version, funds_read.as_ref()) {
             // Sufficient funds, we can go ahead and commit the execution results as it is.
             ObjectFundsWithdrawStatus::SufficientFunds => {

--- a/crates/sui-core/src/accumulators/object_funds_checker/mod.rs
+++ b/crates/sui-core/src/accumulators/object_funds_checker/mod.rs
@@ -120,15 +120,14 @@ impl ObjectFundsChecker {
             debug!("No object withdraws, committing effects");
             return true;
         }
-        let Some(accumulator_version) = execution_env.assigned_versions.accumulator_version else {
-            // Without an assigned accumulator version we cannot determine the
-            // deterministic balance state for the withdraws, so refuse to commit
-            // the effects. Callers that don't (or can't) assign a version up front
-            // (e.g. checkpoint executor paths that pass `None`, tests calling
-            // `try_execute_immediately` with a bare `ExecutionEnv`) fall into this
-            // branch.
-            return false;
-        };
+        // A tx with object withdraws can only exist when accumulators are enabled
+        // for the epoch, and every production path that produces such a tx also
+        // assigns an accumulator version. The `None` paths (accumulator-disabled
+        // epoch, end-of-epoch tx) never produce withdraws and so never reach here.
+        let accumulator_version = execution_env
+            .assigned_versions
+            .accumulator_version
+            .expect("accumulator_version must be set for a tx with object withdraws");
         match self.check_object_funds(object_withdraws, accumulator_version, funds_read.as_ref()) {
             // Sufficient funds, we can go ahead and commit the execution results as it is.
             ObjectFundsWithdrawStatus::SufficientFunds => {

--- a/crates/sui-core/src/accumulators/object_funds_checker/mod.rs
+++ b/crates/sui-core/src/accumulators/object_funds_checker/mod.rs
@@ -121,13 +121,12 @@ impl ObjectFundsChecker {
             return true;
         }
         let Some(accumulator_version) = execution_env.assigned_versions.accumulator_version else {
-            // Fastpath transactions that perform object funds withdraws
-            // must wait for consensus to assign the accumulator version.
-            // We cannot optimize the scheduling by processing fastpath object withdraws
-            // sooner because these may get reverted, and we don't want them
-            // pollute the scheduler tracking state.
-            // TODO: We could however optimize execution by caching
-            // the execution state to avoid re-execution.
+            // Without an assigned accumulator version we cannot determine the
+            // deterministic balance state for the withdraws, so refuse to commit
+            // the effects. Callers that don't (or can't) assign a version up front
+            // (e.g. checkpoint executor paths that pass `None`, tests calling
+            // `try_execute_immediately` with a bare `ExecutionEnv`) fall into this
+            // branch.
             return false;
         };
         match self.check_object_funds(object_withdraws, accumulator_version, funds_read.as_ref()) {

--- a/crates/sui-core/src/accumulators/object_funds_checker/unit_tests.rs
+++ b/crates/sui-core/src/accumulators/object_funds_checker/unit_tests.rs
@@ -367,16 +367,6 @@ async fn test_should_commit_early_exits() {
         state.execution_scheduler(),
         &epoch_store,
     ));
-    // Fastpath path transactions that have object funds withdraws must wait.
-    assert!(!checker.should_commit_object_funds_withdraws(
-        &tx,
-        &ExecutionStatus::Success,
-        &withdraws,
-        &ExecutionEnv::new().with_assigned_versions(AssignedVersions::new(vec![], None)),
-        state.get_account_funds_read(),
-        state.execution_scheduler(),
-        &epoch_store,
-    ));
 
     // Failed execution should always commit.
     assert!(checker.should_commit_object_funds_withdraws(

--- a/crates/sui-core/src/authority/shared_object_version_manager.rs
+++ b/crates/sui-core/src/authority/shared_object_version_manager.rs
@@ -39,8 +39,14 @@ pub struct AssignedVersions {
     /// Accumulator version number at the beginning of the consensus commit
     /// that this transaction belongs to. It is used to determine the deterministic
     /// balance state of the accounts involved in funds withdrawals.
-    /// None only if accumulator is not enabled at protocol level.
-    /// TODO: Make it required once accumulator is enabled.
+    ///
+    /// `None` when no accumulator version applies to this transaction, e.g.:
+    /// - accumulators are not enabled at the protocol level for this epoch
+    ///   (`assign_versions_for_certificate` returns `None`);
+    /// - the transaction is an end-of-epoch / change-epoch tx, which does not
+    ///   read or write the accumulator root;
+    /// - the checkpoint being replayed by the checkpoint executor has no
+    ///   accumulator versions in its effects (whole checkpoint is `None`).
     pub accumulator_version: Option<SequenceNumber>,
 }
 

--- a/crates/sui-core/src/authority/shared_object_version_manager.rs
+++ b/crates/sui-core/src/authority/shared_object_version_manager.rs
@@ -40,13 +40,10 @@ pub struct AssignedVersions {
     /// that this transaction belongs to. It is used to determine the deterministic
     /// balance state of the accounts involved in funds withdrawals.
     ///
-    /// `None` when no accumulator version applies to this transaction, e.g.:
-    /// - accumulators are not enabled at the protocol level for this epoch
-    ///   (`assign_versions_for_certificate` returns `None`);
+    /// `None` when no accumulator version applies to this transaction:
+    /// - accumulators are not enabled at the protocol level for this epoch, or
     /// - the transaction is an end-of-epoch / change-epoch tx, which does not
-    ///   read or write the accumulator root;
-    /// - the checkpoint being replayed by the checkpoint executor has no
-    ///   accumulator versions in its effects (whole checkpoint is `None`).
+    ///   read or write the accumulator root.
     pub accumulator_version: Option<SequenceNumber>,
 }
 


### PR DESCRIPTION
## Summary

With fastpath execution removed, the `let Some(accumulator_version) = ... else { return false }` guard in `ObjectFundsChecker::should_commit_object_funds_withdraws` was only reachable from a single test that explicitly bypassed scheduling. A tx with object withdraws can only exist when accumulators are enabled for the epoch, and every production path that produces such a tx also assigns an accumulator version, so the guard is no longer load-bearing.

- Replace the guard with `.expect(...)` on `assigned_versions.accumulator_version`
- Remove the now-obsolete `test_object_withdraw_fast_path_abort` integration test
- Clarify the doc on `AssignedVersions::accumulator_version` to enumerate the legitimate `None` cases (accumulator-disabled epoch, end-of-epoch tx) instead of the stale "TODO: make required" note

## Test plan

- [ ] `cargo nextest run -p sui-core` passes
- [ ] `cargo xclippy -p sui-core` clean