### PR TITLE
docs: improve search result display and fix garbled titles

### DIFF
--- a/docs/site/src/components/Search/CustomHitsContent.tsx
+++ b/docs/site/src/components/Search/CustomHitsContent.tsx
@@ -4,7 +4,12 @@
 import React from "react";
 import { useHits } from "react-instantsearch";
 import { useHistory } from "@docusaurus/router";
-import { truncateAtWord, getDeepestHierarchyLabel } from "./utils";
+import {
+  truncateAtWord,
+  getDeepestHierarchyLabel,
+  getHierarchyBreadcrumbs,
+  cleanTooltipText,
+} from "./utils";
 
 export default function CustomHitsContent({ name }) {
   const { hits: items } = useHits();
@@ -52,35 +57,44 @@ export default function CustomHitsContent({ name }) {
   return (
     <>
       {Object.entries(grouped).map(([key, group], index) => {
+        const pageCrumbs = getHierarchyBreadcrumbs(group[0].hierarchy);
+        const pageTitle =
+          pageCrumbs.length > 0
+            ? pageCrumbs[Math.min(1, pageCrumbs.length - 1)]
+            : "[no title]";
+
         return (
           <div
-            className="p-6 pb-[40px] mb-6 bg-sui-gray-35 rounded-[20px]"
+            className="p-6 pb-6 mb-6 bg-sui-gray-35 dark:bg-sui-gray-85 rounded-2xl"
             key={index}
           >
-            <div className="text-xl text-sui-gray-3s font-semibold mb-4">
-              {group[0].hierarchy?.lvl1 ||
-                group[0].hierarchy?.lvl0 ||
-                "[no title]"}
+            <div className="text-lg font-semibold mb-1 text-gray-900 dark:text-white">
+              {pageTitle}
             </div>
-            <div className="">
+            {pageCrumbs.length > 0 && (
+              <div className="text-xs text-gray-500 dark:text-sui-gray-50 mb-4">
+                {pageCrumbs.join(" > ")}
+              </div>
+            )}
+            <div className="space-y-3">
               {group.map((hit, i) => {
-                const level = hit.type;
-                let sectionTitle = hit.lvl0;
-                if (level === "content") {
-                  sectionTitle = getDeepestHierarchyLabel(hit.hierarchy);
-                } else {
-                  sectionTitle = hit.hierarchy?.[level] || level;
-                }
+                const hitCrumbs = getHierarchyBreadcrumbs(hit.hierarchy);
+                const sectionTitle =
+                  hitCrumbs.length > 0
+                    ? hitCrumbs[hitCrumbs.length - 1]
+                    : cleanTooltipText(
+                        getDeepestHierarchyLabel(hit.hierarchy),
+                      );
 
                 const hitHost = new URL(hit.url).host;
                 const isInternal = hitHost === currentHost;
 
                 return (
-                  <div key={i} className="mb-2">
+                  <div key={i} className="py-1">
                     {isInternal ? (
                       <button
                         onClick={() => history.push(new URL(hit.url).pathname)}
-                        className="text-base text-blue-600 hover:text-sui-blue underline text-left bg-transparent border-0 pl-0 cursor-pointer font-[Inter]"
+                        className="text-sm text-blue-700 dark:text-sui-blue-light hover:text-sui-blue-dark dark:hover:text-white font-medium underline text-left bg-transparent border-0 pl-0 cursor-pointer"
                       >
                         {sectionTitle}
                       </button>
@@ -89,19 +103,21 @@ export default function CustomHitsContent({ name }) {
                         href={hit.url}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="text-base text-blue-600 underline pb-2"
+                        className="text-sm text-blue-700 dark:text-sui-blue-light hover:text-sui-blue-dark dark:hover:text-white font-medium underline"
                       >
                         {sectionTitle}
                       </a>
                     )}
-                    <p
-                      className="font-normal text-base text-sui-gray-5s"
-                      dangerouslySetInnerHTML={{
-                        __html: hit.content
-                          ? truncateAtWord(hit._highlightResult.content.value)
-                          : "",
-                      }}
-                    />
+                    {hit.content && (
+                      <p
+                        className="font-normal text-sm text-gray-600 dark:text-sui-gray-45 mt-1"
+                        dangerouslySetInnerHTML={{
+                          __html: truncateAtWord(
+                            hit._highlightResult.content.value,
+                          ),
+                        }}
+                      />
+                    )}
                   </div>
                 );
               })}

--- a/docs/site/src/components/Search/SearchModal.tsx
+++ b/docs/site/src/components/Search/SearchModal.tsx
@@ -9,7 +9,12 @@ import {
   useInstantSearch,
   Index,
 } from "react-instantsearch";
-import { truncateAtWord, getDeepestHierarchyLabel } from "./utils";
+import {
+  truncateAtWord,
+  getDeepestHierarchyLabel,
+  getHierarchyBreadcrumbs,
+  cleanTooltipText,
+} from "./utils";
 import ControlledSearchBox from "./ControlledSearchBox";
 import TabbedResults from "./TabbedResults";
 
@@ -46,38 +51,32 @@ const indices = [
 ];
 
 function HitItem({ hit }: { hit: any }) {
-  const level = hit.type;
-  let sectionTitle = hit.lvl0;
-  if (level === "content") {
-    sectionTitle = getDeepestHierarchyLabel(hit.hierarchy);
-  } else {
-    sectionTitle = hit.hierarchy?.[level] || level;
-  }
+  const crumbs = getHierarchyBreadcrumbs(hit.hierarchy);
+  const title = crumbs.length > 0 ? crumbs[crumbs.length - 1] : cleanTooltipText(hit.hierarchy?.lvl0 || "Untitled");
+  const breadcrumb = crumbs.length > 1 ? crumbs.slice(0, -1) : [];
+
   return (
-    <div className="modal-result">
-      <a
-        href={hit.url}
-        className="text-blue-600 dark:text-sui-blue dark:hover:text-sui-blue-light font-medium"
-      >
-        {hit.title}
-      </a>
-      <a
-        href={hit.url}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="text-base text-blue-600 dark:text-sui-blue dark:hover:text-sui-blue-light underline pb-2"
-      >
-        {sectionTitle}
-      </a>
-      <p
-        className="text-sm text-gray-600 dark:text-sui-gray-50"
-        dangerouslySetInnerHTML={{
-          __html: hit.content
-            ? truncateAtWord(hit._highlightResult.content.value, 100)
-            : "",
-        }}
-      ></p>
-    </div>
+    <a
+      href={hit.url}
+      className="modal-result block px-4 py-3 -mx-2 rounded-lg no-underline hover:bg-sui-gray-40 dark:hover:bg-sui-gray-80 transition-colors"
+    >
+      {breadcrumb.length > 0 && (
+        <div className="text-xs text-gray-500 dark:text-sui-gray-55 mb-1 truncate">
+          {breadcrumb.join(" > ")}
+        </div>
+      )}
+      <div className="text-sm font-medium text-gray-900 dark:text-white">
+        {title}
+      </div>
+      {hit.content && (
+        <p
+          className="text-xs text-gray-600 dark:text-sui-gray-45 mt-1 mb-0 line-clamp-2"
+          dangerouslySetInnerHTML={{
+            __html: truncateAtWord(hit._highlightResult.content.value, 120),
+          }}
+        />
+      )}
+    </a>
   );
 }
 
@@ -159,7 +158,6 @@ export default function MultiIndexSearchModal({
   useEffect(() => {
     if (isOpen) {
       document.body.style.overflow = "hidden";
-      // Focus the search input when modal opens
       setTimeout(() => {
         searchBoxRef.current?.focus();
       }, 300);
@@ -170,6 +168,15 @@ export default function MultiIndexSearchModal({
       document.body.style.overflow = "";
     };
   }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, onClose]);
 
   const activeMeta = {
     sui_docs: null,
@@ -184,17 +191,20 @@ export default function MultiIndexSearchModal({
 
   if (!isOpen) return null;
   return (
-    <div className="fixed inset-0 bg-black/50 z-50 flex justify-center p-4">
-      <div className="bg-white dark:bg-sui-gray-90 w-full max-w-3xl px-6 rounded-lg shadow-md max-h-[600px] flex flex-col">
+    <div
+      className="fixed inset-0 bg-black/50 z-50 flex justify-center items-start pt-[10vh]"
+      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+    >
+      <div className="bg-white dark:bg-sui-gray-90 w-full max-w-4xl rounded-xl shadow-2xl max-h-[min(600px,80vh)] flex flex-col overflow-hidden">
         <div ref={scrollContainerRef} className="flex-1 overflow-y-auto">
           <InstantSearch searchClient={searchClient} indexName={activeIndex}>
-            <div className="bg-white dark:bg-sui-gray-90 rounded-t sticky top-0 z-10">
+            <div className="bg-white dark:bg-sui-gray-90 rounded-t sticky top-0 z-10 px-6">
               <div className="bg-white dark:bg-sui-gray-90 h-8 flex justify-end">
                 <button
                   onClick={onClose}
-                  className="bg-transparent border-none outline-none text-sm underline cursor-pointer"
+                  className="bg-transparent border-none outline-none text-xs text-gray-400 dark:text-sui-gray-60 hover:text-gray-600 cursor-pointer"
                 >
-                  Close
+                  ESC
                 </button>
               </div>
               <ControlledSearchBox
@@ -204,8 +214,8 @@ export default function MultiIndexSearchModal({
                 inputRef={searchBoxRef}
               />
               {query.length < 3 && (
-                <p className="text-sm text-sui-gray-5s dark:text-sui-gray-50 pl-4 mb-2 -mt-6">
-                  Three characters initiates search...
+                <p className="text-xs text-gray-400 dark:text-sui-gray-60 pl-1 mb-2 -mt-6">
+                  Type at least 3 characters to search
                 </p>
               )}
               <TabbedResults
@@ -218,39 +228,41 @@ export default function MultiIndexSearchModal({
                 }))}
               />
             </div>
-            {indices.map((index) => (
-              <Index indexName={index.indexName} key={index.indexName}>
-                <ResultsUpdater
-                  indexName={index.indexName}
-                  onUpdate={(indexName, count) =>
-                    setTabCounts((prev) => ({ ...prev, [indexName]: count }))
-                  }
-                />
-                {index.indexName === activeIndex && (
-                  <>
-                    <HitsList scrollContainerRef={scrollContainerRef} />
-                    <EmptyState label={index.label} />
-                  </>
-                )}
-              </Index>
-            ))}
+            <div className="px-6 pb-4">
+              {indices.map((index) => (
+                <Index indexName={index.indexName} key={index.indexName}>
+                  <ResultsUpdater
+                    indexName={index.indexName}
+                    onUpdate={(indexName, count) =>
+                      setTabCounts((prev) => ({ ...prev, [indexName]: count }))
+                    }
+                  />
+                  {index.indexName === activeIndex && (
+                    <>
+                      <HitsList scrollContainerRef={scrollContainerRef} />
+                      <EmptyState label={index.label} />
+                    </>
+                  )}
+                </Index>
+              ))}
+            </div>
           </InstantSearch>
         </div>
-        <div className="h-14 bg-white dark:bg-sui-gray-90 flex items-center justify-between text-sm border-t border-solid border-sui-gray-50 border-b-transparent border-l-transparent border-r-transparent">
+        <div className="h-12 px-6 bg-white dark:bg-sui-gray-90 flex items-center justify-between text-xs border-t border-solid border-sui-gray-50 dark:border-sui-gray-80 border-b-transparent border-l-transparent border-r-transparent shrink-0">
           <a
             href={`/search?q=${encodeURIComponent(query)}`}
-            className="text-blue-600 dark:text-sui-blue dark:hover:text-sui-blue-light underline"
+            className="text-gray-500 dark:text-sui-gray-50 hover:text-sui-blue dark:hover:text-sui-blue-light no-underline"
           >
-            Go to full search page
+            View all results
           </a>
           {activeMeta && (
             <a
               href={activeMeta.url}
               target="_blank"
               rel="noopener noreferrer"
-              className="text-blue-600 dark:text-sui-blue dark:hover:text-sui-blue-light underline"
+              className="text-gray-500 dark:text-sui-gray-50 hover:text-sui-blue dark:hover:text-sui-blue-light no-underline"
             >
-              Visit {activeMeta.label} →
+              {activeMeta.label} &rarr;
             </a>
           )}
         </div>

--- a/docs/site/src/components/Search/utils.tsx
+++ b/docs/site/src/components/Search/utils.tsx
@@ -3,6 +3,25 @@
 
 const { decode } = require("he");
 
+/**
+ * Strip tooltip text injected by the Algolia crawler.
+ *
+ * The docs use inline <Tooltip> components whose hidden definition text
+ * gets concatenated by the crawler, producing strings like:
+ *   "Create, build, and test a MoveMoveAn open source programming language used for all activity on Sui. project​"
+ *
+ * Pattern: a word is immediately followed by itself + a capital-letter
+ * definition ending in a period. We replace the duplicated word + definition
+ * with just the original word.
+ */
+export function cleanTooltipText(text: string): string {
+  // Remove zero-width spaces (&#8203; / \u200B / ​)
+  let cleaned = text.replace(/\u200B/g, "");
+  // Strip duplicated-word tooltip definitions:  Word + Word + UppercaseDefinition...period
+  cleaned = cleaned.replace(/(\b\w{2,})\1[A-Z][^.]*\.\s?/g, "$1 ");
+  return cleaned.trim();
+}
+
 export function truncateAtWord(text, maxChars = 250) {
   if (text.length <= maxChars) return text;
   const decoded = decode(text);
@@ -23,4 +42,24 @@ export function getDeepestHierarchyLabel(hierarchy) {
   }
 
   return lastValue || hierarchy.lvl6 || "";
+}
+
+/**
+ * Build an ordered breadcrumb array from a DocSearch hierarchy object.
+ * Deduplicates adjacent identical levels (e.g. lvl0 === lvl1).
+ * Strips crawler tooltip artefacts from each level.
+ */
+export function getHierarchyBreadcrumbs(hierarchy): string[] {
+  if (!hierarchy) return [];
+  const levels = ["lvl0", "lvl1", "lvl2", "lvl3", "lvl4", "lvl5", "lvl6"];
+  const crumbs: string[] = [];
+  for (const lvl of levels) {
+    const raw = hierarchy[lvl];
+    if (raw == null) break;
+    const value = cleanTooltipText(raw);
+    if (crumbs.length === 0 || crumbs[crumbs.length - 1] !== value) {
+      crumbs.push(value);
+    }
+  }
+  return crumbs;
 }

--- a/docs/site/src/css/custom.css
+++ b/docs/site/src/css/custom.css
@@ -596,7 +596,7 @@ td .theme-code-block {
 }
 
 .modal-result mark {
-  @apply bg-sui-steel-dark;
+  @apply bg-sui-blue-bright/30 text-inherit rounded-sm;
 }
 
 .ais-Pagination-list {


### PR DESCRIPTION
## Summary
- Strip inline tooltip text that the Algolia crawler concatenates into hierarchy values, producing garbled titles like "Create, build, and test a MoveMoveAn open source programming language used for all activity on Sui. project"
- Replace the dual-link modal search result layout with a clean breadcrumb > title > snippet card
- Widen the search modal (`max-w-2xl` to `max-w-4xl`) to prevent tab labels from wrapping
- Improve text contrast across both the search modal and full search page (bumped breadcrumb, snippet, and link colors)
- Add ESC key and click-outside-to-close to the search modal

## Test plan
- [ ] Open search modal, search for "test" — titles should be clean, no tooltip text
- [ ] Verify tab labels ("Sui", "SuiNS", "The Move Book", "SDKs", "Walrus") fit on one line
- [ ] Verify breadcrumbs, titles, and snippets are readable in both light and dark mode
- [ ] Navigate to `/search?q=test` and verify full search page results are also clean
- [ ] Press ESC or click backdrop to close the modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)