### PR TITLE
sui-tool: add tideconsole subcommand behind feature flag

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -163,6 +163,9 @@ jobs:
       - name: cargo test with tidehunter
         run: |
           RUST_BACKTRACE=1 USE_TIDEHUNTER=1 cargo nextest run --profile ci --cargo-quiet -p sui-core --features typed-store/tidehunter
+      - name: cargo check sui-tool with tidehunter + tideconsole
+        run: |
+          RUST_BACKTRACE=1 USE_TIDEHUNTER=1 cargo check --quiet -p sui-tool --features typed-store/tidehunter,sui-tool/tideconsole
       # Ensure there are no uncommitted changes in the repo after running tests
       - run: scripts/changed-files.sh
         shell: bash

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10205,6 +10205,9 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "oorandom"
@@ -11330,7 +11333,7 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6c3320f9abac597dcbc668774ef006702672474aad53c6d596b62e487b40b1"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -12172,6 +12175,34 @@ checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
  "hmac",
  "subtle",
+]
+
+[[package]]
+name = "rhai"
+version = "1.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f9ef5dabe4c0b43d8f1187dc6beb67b53fe607fff7e30c5eb7f71b814b8c2c1"
+dependencies = [
+ "ahash 0.8.11",
+ "bitflags 2.11.0",
+ "num-traits",
+ "once_cell",
+ "rhai_codegen",
+ "smallvec",
+ "smartstring",
+ "thin-vec",
+ "web-time",
+]
+
+[[package]]
+name = "rhai_codegen"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4322a2a4e8cf30771dd9f27f7f37ca9ac8fe812dddd811096a98483080dabe6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -13363,6 +13394,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "smartstring"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fb72c633efbaa2dd666986505016c32c3044395ceaf881518399d2f4127ee29"
+dependencies = [
+ "autocfg",
+ "static_assertions",
+ "version_check",
 ]
 
 [[package]]
@@ -17075,8 +17117,11 @@ dependencies = [
  "mysten-metrics",
  "num_cpus",
  "object_store 0.13.0",
+ "parking_lot 0.12.3",
  "prometheus",
+ "rhai",
  "ron",
+ "rustyline",
  "serde",
  "serde_json",
  "strum 0.27.1",
@@ -17094,6 +17139,7 @@ dependencies = [
  "sui-types",
  "telemetry-subscribers",
  "tempfile",
+ "tideconsole",
  "tokio",
  "tracing",
  "typed-store",
@@ -17822,6 +17868,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "thin-vec"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0f7e269b48f0a7dd0146680fa24b50cc67fc0373f086a5b2f99bd084639b482"
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -17888,6 +17940,20 @@ dependencies = [
  "byteorder",
  "integer-encoding",
  "ordered-float 2.10.1",
+]
+
+[[package]]
+name = "tideconsole"
+version = "0.1.0"
+source = "git+https://github.com/mystenlabs/tidehunter.git?rev=9a0472f81e71e821e1f4f71e308c2580f16f9e05#9a0472f81e71e821e1f4f71e308c2580f16f9e05"
+dependencies = [
+ "anyhow",
+ "clap",
+ "hex",
+ "parking_lot 0.12.3",
+ "rhai",
+ "rustyline",
+ "tidehunter",
 ]
 
 [[package]]
@@ -18832,7 +18898,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.8.5",
+ "rand 0.7.3",
  "static_assertions",
 ]
 

--- a/crates/sui-tool/Cargo.toml
+++ b/crates/sui-tool/Cargo.toml
@@ -50,3 +50,12 @@ sui-types.workspace = true
 sui-package-dump.workspace = true
 sui-tls.workspace = true
 bin-version.workspace = true
+
+[target.'cfg(not(windows))'.dependencies]
+tideconsole = {git = "https://github.com/mystenlabs/tidehunter.git", rev = "9a0472f81e71e821e1f4f71e308c2580f16f9e05", package = "tideconsole", optional = true}
+rhai = { version = "1", optional = true }
+rustyline = { version = "14", optional = true }
+parking_lot = { workspace = true, optional = true }
+
+[features]
+tideconsole = ["dep:tideconsole", "dep:rhai", "dep:rustyline", "dep:parking_lot"]

--- a/crates/sui-tool/src/commands.rs
+++ b/crates/sui-tool/src/commands.rs
@@ -375,7 +375,7 @@ pub enum ToolCommand {
     },
 
     /// Interactive Rhai shell for inspecting a TideHunter database.
-    #[cfg(feature = "tideconsole")]
+    #[cfg(all(feature = "tideconsole", not(windows)))]
     #[command(name = "tideconsole")]
     TideConsole {
         /// Path to a TideHunter database directory to open on startup (bound to variable 'db').
@@ -978,7 +978,7 @@ impl ToolCommand {
                 execute_replay_command(rpc_url, safety_checks, use_authority, cfg_path, chain, cmd)
                     .await?;
             }
-            #[cfg(feature = "tideconsole")]
+            #[cfg(all(feature = "tideconsole", not(windows)))]
             ToolCommand::TideConsole { db, exec, script } => {
                 tokio::task::spawn_blocking(move || crate::tideconsole_cmd::run(db, exec, script))
                     .await??;

--- a/crates/sui-tool/src/commands.rs
+++ b/crates/sui-tool/src/commands.rs
@@ -980,10 +980,8 @@ impl ToolCommand {
             }
             #[cfg(feature = "tideconsole")]
             ToolCommand::TideConsole { db, exec, script } => {
-                tokio::task::spawn_blocking(move || {
-                    crate::tideconsole_cmd::run(db, exec, script)
-                })
-                .await??;
+                tokio::task::spawn_blocking(move || crate::tideconsole_cmd::run(db, exec, script))
+                    .await??;
             }
         };
         Ok(())

--- a/crates/sui-tool/src/commands.rs
+++ b/crates/sui-tool/src/commands.rs
@@ -373,6 +373,21 @@ pub enum ToolCommand {
         #[command(subcommand)]
         cmd: ReplayToolCommand,
     },
+
+    /// Interactive Rhai shell for inspecting a TideHunter database.
+    #[cfg(feature = "tideconsole")]
+    #[command(name = "tideconsole")]
+    TideConsole {
+        /// Path to a TideHunter database directory to open on startup (bound to variable 'db').
+        #[arg(short, long)]
+        db: Option<PathBuf>,
+        /// Rhai snippet to evaluate non-interactively, then exit.
+        #[arg(short, long)]
+        exec: Option<String>,
+        /// Path to a Rhai script file to evaluate non-interactively, then exit.
+        #[arg(short, long)]
+        script: Option<PathBuf>,
+    },
 }
 
 async fn check_locked_object(
@@ -962,6 +977,13 @@ impl ToolCommand {
             } => {
                 execute_replay_command(rpc_url, safety_checks, use_authority, cfg_path, chain, cmd)
                     .await?;
+            }
+            #[cfg(feature = "tideconsole")]
+            ToolCommand::TideConsole { db, exec, script } => {
+                tokio::task::spawn_blocking(move || {
+                    crate::tideconsole_cmd::run(db, exec, script)
+                })
+                .await??;
             }
         };
         Ok(())

--- a/crates/sui-tool/src/lib.rs
+++ b/crates/sui-tool/src/lib.rs
@@ -71,6 +71,8 @@ use typed_store::DBMetrics;
 pub mod commands;
 pub mod db_tool;
 mod formal_snapshot_util;
+#[cfg(feature = "tideconsole")]
+pub mod tideconsole_cmd;
 
 #[derive(
     Clone, Serialize, Deserialize, Debug, PartialEq, Copy, PartialOrd, Ord, Eq, ValueEnum, Default,

--- a/crates/sui-tool/src/lib.rs
+++ b/crates/sui-tool/src/lib.rs
@@ -71,7 +71,7 @@ use typed_store::DBMetrics;
 pub mod commands;
 pub mod db_tool;
 mod formal_snapshot_util;
-#[cfg(feature = "tideconsole")]
+#[cfg(all(feature = "tideconsole", not(windows)))]
 pub mod tideconsole_cmd;
 
 #[derive(

--- a/crates/sui-tool/src/tideconsole_cmd.rs
+++ b/crates/sui-tool/src/tideconsole_cmd.rs
@@ -1,0 +1,122 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use parking_lot::Mutex;
+use rhai::{Dynamic, Engine, Scope};
+use rustyline::error::ReadlineError;
+use rustyline::{Config, DefaultEditor};
+use std::path::PathBuf;
+use std::sync::Arc;
+use tideconsole::engine::{ConsoleContext, create_engine, init_scope_with_db, is_complete};
+
+pub fn run(db: Option<PathBuf>, exec: Option<String>, script: Option<PathBuf>) -> Result<()> {
+    let ctx = Arc::new(Mutex::new(ConsoleContext::default()));
+    let engine = create_engine(ctx.clone());
+    let mut scope = Scope::new();
+
+    if let Some(path) = db {
+        init_scope_with_db(&engine, &mut scope, &ctx, &path.display().to_string())?;
+    }
+
+    if let Some(code) = exec {
+        let result = engine
+            .eval_with_scope::<Dynamic>(&mut scope, &code)
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        if !result.is_unit() {
+            println!("{result}");
+        }
+        return Ok(());
+    }
+
+    if let Some(path) = script {
+        let code = std::fs::read_to_string(&path)
+            .map_err(|e| anyhow::anyhow!("Failed to read {}: {e}", path.display()))?;
+        let result = engine
+            .eval_with_scope::<Dynamic>(&mut scope, &code)
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        if !result.is_unit() {
+            println!("{result}");
+        }
+        return Ok(());
+    }
+
+    repl(&engine, &mut scope)
+}
+
+fn repl(engine: &Engine, scope: &mut Scope<'_>) -> Result<()> {
+    let rl_config = Config::builder()
+        .history_ignore_space(true)
+        .max_history_size(1000)
+        .unwrap()
+        .build();
+    let mut rl = DefaultEditor::with_config(rl_config)?;
+
+    let history_path = std::env::var("HOME")
+        .ok()
+        .map(|h| PathBuf::from(h).join(".tideconsole_history"));
+
+    if let Some(ref p) = history_path {
+        let _ = rl.load_history(p);
+    }
+
+    println!("TideConsole — TideHunter Interactive Shell");
+    println!("Type help() for available methods, Ctrl+D to exit.");
+    println!("Use `let db = open(\"/path/to/db\")` to open a database.\n");
+
+    let mut buf = String::new();
+
+    loop {
+        let prompt = if buf.is_empty() { ">> " } else { ".. " };
+
+        match rl.readline(prompt) {
+            Ok(line) => {
+                if buf.is_empty() && !line.trim().is_empty() {
+                    let _ = rl.add_history_entry(line.as_str());
+                }
+
+                if !buf.is_empty() {
+                    buf.push('\n');
+                }
+                buf.push_str(&line);
+
+                if !is_complete(&buf) {
+                    continue;
+                }
+
+                let input = buf.trim().to_string();
+                buf.clear();
+
+                if input.is_empty() {
+                    continue;
+                }
+
+                match engine.eval_with_scope::<Dynamic>(scope, &input) {
+                    Ok(v) if !v.is_unit() => println!("{v}"),
+                    Ok(_) => {}
+                    Err(e) => eprintln!("Error: {e}"),
+                }
+            }
+            Err(ReadlineError::Interrupted) => {
+                if !buf.is_empty() {
+                    buf.clear();
+                    println!("(input cleared)");
+                }
+            }
+            Err(ReadlineError::Eof) => {
+                println!("Goodbye!");
+                break;
+            }
+            Err(e) => {
+                eprintln!("Readline error: {e}");
+                break;
+            }
+        }
+    }
+
+    if let Some(ref p) = history_path {
+        let _ = rl.save_history(p);
+    }
+
+    Ok(())
+}

--- a/crates/sui-tool/src/tideconsole_cmd.rs
+++ b/crates/sui-tool/src/tideconsole_cmd.rs
@@ -4,8 +4,8 @@
 use anyhow::Result;
 use parking_lot::Mutex;
 use rhai::{Dynamic, Engine, Scope};
+use rustyline::DefaultEditor;
 use rustyline::error::ReadlineError;
-use rustyline::{Config, DefaultEditor};
 use std::path::PathBuf;
 use std::sync::Arc;
 use tideconsole::engine::{ConsoleContext, create_engine, init_scope_with_db, is_complete};
@@ -45,20 +45,7 @@ pub fn run(db: Option<PathBuf>, exec: Option<String>, script: Option<PathBuf>) -
 }
 
 fn repl(engine: &Engine, scope: &mut Scope<'_>) -> Result<()> {
-    let rl_config = Config::builder()
-        .history_ignore_space(true)
-        .max_history_size(1000)
-        .unwrap()
-        .build();
-    let mut rl = DefaultEditor::with_config(rl_config)?;
-
-    let history_path = std::env::var("HOME")
-        .ok()
-        .map(|h| PathBuf::from(h).join(".tideconsole_history"));
-
-    if let Some(ref p) = history_path {
-        let _ = rl.load_history(p);
-    }
+    let mut rl = DefaultEditor::new()?;
 
     println!("TideConsole — TideHunter Interactive Shell");
     println!("Type help() for available methods, Ctrl+D to exit.");
@@ -71,10 +58,6 @@ fn repl(engine: &Engine, scope: &mut Scope<'_>) -> Result<()> {
 
         match rl.readline(prompt) {
             Ok(line) => {
-                if buf.is_empty() && !line.trim().is_empty() {
-                    let _ = rl.add_history_entry(line.as_str());
-                }
-
                 if !buf.is_empty() {
                     buf.push('\n');
                 }
@@ -112,10 +95,6 @@ fn repl(engine: &Engine, scope: &mut Scope<'_>) -> Result<()> {
                 break;
             }
         }
-    }
-
-    if let Some(ref p) = history_path {
-        let _ = rl.save_history(p);
     }
 
     Ok(())

--- a/docker/sui-node-th/Dockerfile
+++ b/docker/sui-node-th/Dockerfile
@@ -24,7 +24,7 @@ ARG GIT_REVISION
 ENV GIT_REVISION=$GIT_REVISION
 ENV USE_TIDEHUNTER=1
 RUN cargo build --locked --profile ${PROFILE} \
-    --features typed-store/tidehunter \
+    --features typed-store/tidehunter,sui-tool/tideconsole \
     --bin sui-node --bin sui --bin sui-tool --bin stress
 
 # Production Image


### PR DESCRIPTION
## Summary
- New `sui-tool tideconsole` subcommand wraps the upstream [tideconsole](https://github.com/MystenLabs/tidehunter/tree/main/tools/tideconsole) Rhai-based interactive shell for TideHunter databases. The handler in `crates/sui-tool/src/tideconsole_cmd.rs` mirrors tideconsole's own `main.rs` (REPL + `--exec` + `--script` modes).
- Gated by a new `tideconsole` feature on `sui-tool` so default builds are unchanged. The feature pulls in `tideconsole` (git, same rev as the existing `tidehunter` dep in `typed-store`) plus `rhai`, `rustyline`, and `parking_lot`, all as optional deps.
- Tideconsole is **not** re-exported through typed-store — it's a debug tool, not a storage-backend concern, so depending on it directly from sui-tool keeps validator builds slim (no rhai/rustyline pulled into anything that turns on `typed-store/tidehunter`).
- Subcommand is only compiled with `--features tideconsole`; doesn't depend on `cfg(tidehunter)` since tideconsole opens DB directories on its own (no integration with `AuthorityPerpetualTables`).

## Usage
```
cargo run -p sui-tool --features tideconsole -- tideconsole --db /path/to/tidehunter-db
cargo run -p sui-tool --features tideconsole -- tideconsole --db /path --exec 'db.wal_stats()'
cargo run -p sui-tool --features tideconsole -- tideconsole --db /path --script analysis.rhai
```

## Test plan
- [x] `cargo check -p sui-tool` (baseline, no feature) — passes
- [x] `cargo check -p sui-tool --features tideconsole` — passes
- [ ] Smoke-test against a real TideHunter directory locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)