### PR TITLE
[chore] fix cargo-deny issue with `diesel-async`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4785,9 +4785,9 @@ dependencies = [
 
 [[package]]
 name = "diesel"
-version = "2.3.8"
+version = "2.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78df0e4e8c596662edb07fbfbb7f23769cca35049827df5f909084d956b6aeaf"
+checksum = "9940fb8467a0a06312218ed384185cb8536aa10d8ec017d0ce7fad2c1bd882d5"
 dependencies = [
  "bitflags 2.11.0",
  "byteorder",
@@ -4800,16 +4800,15 @@ dependencies = [
 
 [[package]]
 name = "diesel-async"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b95864e58597509106f1fddfe0600de7e589e1fddddd87f54eee0a49fd111bbc"
+checksum = "9c20ddcc6737cecdaef3dfecb2796bdfe3002456521189d30be8e4c5a1bc821d"
 dependencies = [
  "bb8",
  "diesel",
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "scoped-futures",
  "tokio",
  "tokio-postgres",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -360,7 +360,7 @@ derive-syn-parse = "0.1.5"
 derive_more = "1.0.0"
 diesel = "2.3"
 diesel_migrations = "2.3"
-diesel-async = "0.8"
+diesel-async = "0.9"
 dirs = "4.0.0"
 duration-str = "0.5.0"
 ed25519 = { version = "2", features = ["pkcs8", "alloc", "zeroize"] }

--- a/crates/sui-bridge-indexer/src/storage.rs
+++ b/crates/sui-bridge-indexer/src/storage.rs
@@ -9,7 +9,6 @@ use diesel::{ExpressionMethods, QueryDsl, TextExpressionMethods};
 use diesel::{OptionalExtension, SelectableHelper};
 use diesel_async::AsyncConnection;
 use diesel_async::RunQueryDsl;
-use diesel_async::scoped_futures::ScopedFutureExt;
 
 use crate::ProcessedTxnData;
 use crate::indexer_builder::{IndexerProgressStore, Persistent};
@@ -63,104 +62,97 @@ impl Persistent<ProcessedTxnData> for PgBridgePersistent {
         }
         let connection = &mut self.pool.get().await?;
         connection
-            .transaction(|conn| {
-                async move {
-                    for d in data {
-                        match d {
-                            ProcessedTxnData::TokenTransfer(t) => {
-                                diesel::insert_into(token_transfer::table)
-                                    .values(&t.to_db())
+            .transaction(async |conn| {
+                for d in data {
+                    match d {
+                        ProcessedTxnData::TokenTransfer(t) => {
+                            diesel::insert_into(token_transfer::table)
+                                .values(&t.to_db())
+                                .on_conflict((
+                                    token_transfer::dsl::chain_id,
+                                    token_transfer::dsl::nonce,
+                                    token_transfer::dsl::status,
+                                ))
+                                .do_update()
+                                .set((
+                                    token_transfer::chain_id.eq(excluded(token_transfer::chain_id)),
+                                    token_transfer::nonce.eq(excluded(token_transfer::nonce)),
+                                    token_transfer::status.eq(excluded(token_transfer::status)),
+                                    token_transfer::block_height
+                                        .eq(excluded(token_transfer::block_height)),
+                                    token_transfer::timestamp_ms
+                                        .eq(excluded(token_transfer::timestamp_ms)),
+                                    token_transfer::txn_hash.eq(excluded(token_transfer::txn_hash)),
+                                    token_transfer::txn_sender
+                                        .eq(excluded(token_transfer::txn_sender)),
+                                    token_transfer::gas_usage
+                                        .eq(excluded(token_transfer::gas_usage)),
+                                    token_transfer::data_source
+                                        .eq(excluded(token_transfer::data_source)),
+                                    token_transfer::is_finalized
+                                        .eq(excluded(token_transfer::is_finalized)),
+                                ))
+                                .filter(token_transfer::is_finalized.eq(false))
+                                .execute(conn)
+                                .await?;
+
+                            if let Some(d) = t.to_data_maybe() {
+                                diesel::insert_into(token_transfer_data::table)
+                                    .values(&d)
                                     .on_conflict((
-                                        token_transfer::dsl::chain_id,
-                                        token_transfer::dsl::nonce,
-                                        token_transfer::dsl::status,
+                                        token_transfer_data::dsl::chain_id,
+                                        token_transfer_data::dsl::nonce,
                                     ))
                                     .do_update()
                                     .set((
-                                        token_transfer::chain_id
-                                            .eq(excluded(token_transfer::chain_id)),
-                                        token_transfer::nonce.eq(excluded(token_transfer::nonce)),
-                                        token_transfer::status.eq(excluded(token_transfer::status)),
-                                        token_transfer::block_height
-                                            .eq(excluded(token_transfer::block_height)),
-                                        token_transfer::timestamp_ms
-                                            .eq(excluded(token_transfer::timestamp_ms)),
-                                        token_transfer::txn_hash
-                                            .eq(excluded(token_transfer::txn_hash)),
-                                        token_transfer::txn_sender
-                                            .eq(excluded(token_transfer::txn_sender)),
-                                        token_transfer::gas_usage
-                                            .eq(excluded(token_transfer::gas_usage)),
-                                        token_transfer::data_source
-                                            .eq(excluded(token_transfer::data_source)),
-                                        token_transfer::is_finalized
-                                            .eq(excluded(token_transfer::is_finalized)),
+                                        token_transfer_data::chain_id
+                                            .eq(excluded(token_transfer_data::chain_id)),
+                                        token_transfer_data::nonce
+                                            .eq(excluded(token_transfer_data::nonce)),
+                                        token_transfer_data::block_height
+                                            .eq(excluded(token_transfer_data::block_height)),
+                                        token_transfer_data::timestamp_ms
+                                            .eq(excluded(token_transfer_data::timestamp_ms)),
+                                        token_transfer_data::txn_hash
+                                            .eq(excluded(token_transfer_data::txn_hash)),
+                                        token_transfer_data::sender_address
+                                            .eq(excluded(token_transfer_data::sender_address)),
+                                        token_transfer_data::destination_chain
+                                            .eq(excluded(token_transfer_data::destination_chain)),
+                                        token_transfer_data::recipient_address
+                                            .eq(excluded(token_transfer_data::recipient_address)),
+                                        token_transfer_data::token_id
+                                            .eq(excluded(token_transfer_data::token_id)),
+                                        token_transfer_data::amount
+                                            .eq(excluded(token_transfer_data::amount)),
+                                        token_transfer_data::is_finalized
+                                            .eq(excluded(token_transfer_data::is_finalized)),
+                                        token_transfer_data::message_timestamp_ms.eq(excluded(
+                                            token_transfer_data::message_timestamp_ms,
+                                        )),
                                     ))
-                                    .filter(token_transfer::is_finalized.eq(false))
-                                    .execute(conn)
-                                    .await?;
-
-                                if let Some(d) = t.to_data_maybe() {
-                                    diesel::insert_into(token_transfer_data::table)
-                                        .values(&d)
-                                        .on_conflict((
-                                            token_transfer_data::dsl::chain_id,
-                                            token_transfer_data::dsl::nonce,
-                                        ))
-                                        .do_update()
-                                        .set((
-                                            token_transfer_data::chain_id
-                                                .eq(excluded(token_transfer_data::chain_id)),
-                                            token_transfer_data::nonce
-                                                .eq(excluded(token_transfer_data::nonce)),
-                                            token_transfer_data::block_height
-                                                .eq(excluded(token_transfer_data::block_height)),
-                                            token_transfer_data::timestamp_ms
-                                                .eq(excluded(token_transfer_data::timestamp_ms)),
-                                            token_transfer_data::txn_hash
-                                                .eq(excluded(token_transfer_data::txn_hash)),
-                                            token_transfer_data::sender_address
-                                                .eq(excluded(token_transfer_data::sender_address)),
-                                            token_transfer_data::destination_chain.eq(excluded(
-                                                token_transfer_data::destination_chain,
-                                            )),
-                                            token_transfer_data::recipient_address.eq(excluded(
-                                                token_transfer_data::recipient_address,
-                                            )),
-                                            token_transfer_data::token_id
-                                                .eq(excluded(token_transfer_data::token_id)),
-                                            token_transfer_data::amount
-                                                .eq(excluded(token_transfer_data::amount)),
-                                            token_transfer_data::is_finalized
-                                                .eq(excluded(token_transfer_data::is_finalized)),
-                                            token_transfer_data::message_timestamp_ms.eq(excluded(
-                                                token_transfer_data::message_timestamp_ms,
-                                            )),
-                                        ))
-                                        .filter(token_transfer_data::is_finalized.eq(false))
-                                        .execute(conn)
-                                        .await?;
-                                }
-                            }
-                            ProcessedTxnData::GovernanceAction(a) => {
-                                diesel::insert_into(schema::governance_actions::table)
-                                    .values(&a.to_db())
-                                    .on_conflict_do_nothing()
-                                    .execute(conn)
-                                    .await?;
-                            }
-                            ProcessedTxnData::Error(e) => {
-                                diesel::insert_into(sui_error_transactions::table)
-                                    .values(&e.to_db())
-                                    .on_conflict_do_nothing()
+                                    .filter(token_transfer_data::is_finalized.eq(false))
                                     .execute(conn)
                                     .await?;
                             }
                         }
+                        ProcessedTxnData::GovernanceAction(a) => {
+                            diesel::insert_into(schema::governance_actions::table)
+                                .values(&a.to_db())
+                                .on_conflict_do_nothing()
+                                .execute(conn)
+                                .await?;
+                        }
+                        ProcessedTxnData::Error(e) => {
+                            diesel::insert_into(sui_error_transactions::table)
+                                .values(&e.to_db())
+                                .on_conflict_do_nothing()
+                                .execute(conn)
+                                .await?;
+                        }
                     }
-                    Ok(())
                 }
-                .scope_boxed()
+                Ok(())
             })
             .await
     }

--- a/crates/sui-pg-db/src/store.rs
+++ b/crates/sui-pg-db/src/store.rs
@@ -247,7 +247,7 @@ impl store::SequentialStore for Db {
         ) -> ScopedBoxFuture<'a, 'r, anyhow::Result<R>>,
     {
         let mut conn = self.connect().await?;
-        AsyncConnection::transaction(&mut conn, |conn| f(conn)).await
+        AsyncConnection::transaction(&mut conn, async |conn| f(conn).await).await
     }
 }
 


### PR DESCRIPTION
## Description 

This PR fixes the `diesel-async` cargo deny issue by bumping `diesel-async` to 0.9 and fixing the API call in `sui-pg-db` and `sui-bridge-indexer` crates.

## Test plan 

Existing CI.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
