### PR TITLE
sui-adapter-transactional-tests: expand address-balance gas-smashing coverage

### DIFF
--- a/crates/sui-adapter-transactional-tests/tests/address_balances/address_balance_storage_oog.move
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/address_balance_storage_oog.move
@@ -1,11 +1,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-// Exercises the storage-OOG reset + re-smash path for pure `[AddressBalance]`
-// gas payment.
-// Workload creates many new objects; with a tight budget storage charging
-// fails, triggering reset + re-smash. Verifies the re-smash invariant doesn't
-// fire and the post-reset accumulator event is emitted cleanly without
+// Storage-OOG reset + re-smash for pure `[AddressBalance]` gas payment. The
+// workload creates many new objects; with a tight budget, storage charging
+// fails, triggering reset + re-smash. Verifies the re-smash invariant holds
+// and the post-reset accumulator event is emitted cleanly without
 // duplication.
 
 //# init --addresses test=0x0 --accounts A B --enable-address-balance-gas-payments --enable-coin-reservations --enable-accumulators

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/address_balance_storage_oog.move
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/address_balance_storage_oog.move
@@ -1,0 +1,40 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Exercises the storage-OOG reset + re-smash path for pure `[AddressBalance]`
+// gas payment.
+// Workload creates many new objects; with a tight budget storage charging
+// fails, triggering reset + re-smash. Verifies the re-smash invariant doesn't
+// fire and the post-reset accumulator event is emitted cleanly without
+// duplication.
+
+//# init --addresses test=0x0 --accounts A B --enable-address-balance-gas-payments --enable-coin-reservations --enable-accumulators
+
+//# publish
+module test::oog;
+public struct W has key, store { id: UID }
+public fun make(n: u64, ctx: &mut TxContext) {
+    let mut i = 0;
+    while (i < n) {
+        sui::transfer::public_transfer(W { id: object::new(ctx) }, ctx.sender());
+        i = i + 1;
+    }
+}
+
+// Seed A's address balance.
+//# programmable --sender A --inputs 100000000000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::into_balance<sui::sui::SUI>(Result(0));
+//> 2: sui::balance::send_funds<sui::sui::SUI>(Result(1), Input(1));
+
+//# create-checkpoint
+
+//# view-funds sui::balance::Balance<sui::sui::SUI> A
+
+// Pure address-balance gas payment; large object count exceeds budget storage.
+//# programmable --sender A --gas-budget 5000000 --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(5000000) --inputs 100
+//> test::oog::make(Input(0))
+
+//# create-checkpoint
+
+//# view-funds sui::balance::Balance<sui::sui::SUI> A

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/address_balance_storage_oog.snap
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/address_balance_storage_oog.snap
@@ -1,0 +1,44 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 8 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 13-24:
+//# publish
+created: object(1,0)
+mutated: object(0,2)
+gas summary: computation_cost: 1000000, storage_cost: 5502400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 25-28:
+//# programmable --sender A --inputs 100000000000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::into_balance<sui::sui::SUI>(Result(0));
+//> 2: sui::balance::send_funds<sui::sui::SUI>(Result(1), Input(1));
+mutated: object(0,0)
+accumulators_written: (object(2,0), A, sui::balance::Balance<sui::sui::SUI>, Merge, 100000000000)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, line 30:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 4, lines 32-34:
+//# view-funds sui::balance::Balance<sui::sui::SUI> A
+100000000000
+
+task 5, lines 35-36:
+//# programmable --sender A --gas-budget 5000000 --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(5000000) --inputs 100
+//> test::oog::make(Input(0))
+Error: Transaction Effects Status: Insufficient Gas.
+Debug of error: InsufficientGas at command None
+
+task 6, line 38:
+//# create-checkpoint
+Checkpoint created: 2
+
+task 7, line 40:
+//# view-funds sui::balance::Balance<sui::sui::SUI> A
+99999000000

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/address_balance_storage_oog.snap
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/address_balance_storage_oog.snap
@@ -6,13 +6,13 @@ processed 8 tasks
 init:
 A: object(0,0), B: object(0,1)
 
-task 1, lines 13-24:
+task 1, lines 12-23:
 //# publish
 created: object(1,0)
 mutated: object(0,2)
 gas summary: computation_cost: 1000000, storage_cost: 5502400,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 2, lines 25-28:
+task 2, lines 24-27:
 //# programmable --sender A --inputs 100000000000 @A
 //> 0: SplitCoins(Gas, [Input(0)]);
 //> 1: sui::coin::into_balance<sui::sui::SUI>(Result(0));
@@ -21,24 +21,24 @@ mutated: object(0,0)
 accumulators_written: (object(2,0), A, sui::balance::Balance<sui::sui::SUI>, Merge, 100000000000)
 gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 3, line 30:
+task 3, line 29:
 //# create-checkpoint
 Checkpoint created: 1
 
-task 4, lines 32-34:
+task 4, lines 31-33:
 //# view-funds sui::balance::Balance<sui::sui::SUI> A
 100000000000
 
-task 5, lines 35-36:
+task 5, lines 34-35:
 //# programmable --sender A --gas-budget 5000000 --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(5000000) --inputs 100
 //> test::oog::make(Input(0))
 Error: Transaction Effects Status: Insufficient Gas.
 Debug of error: InsufficientGas at command None
 
-task 6, line 38:
+task 6, line 37:
 //# create-checkpoint
 Checkpoint created: 2
 
-task 7, line 40:
+task 7, line 39:
 //# view-funds sui::balance::Balance<sui::sui::SUI> A
 99999000000

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/coin_coin_reservation_gas.move
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/coin_coin_reservation_gas.move
@@ -1,9 +1,9 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-// Exercises gas smashing for `[Coin, Coin, AddressBalance]`: a real Coin as
-// the smash target with a second Coin secondary and an address-balance
-// reservation. All three smash side-effects fire together:
+// `[Coin, Coin, AddressBalance]`: real Coin as smash target plus a second
+// Coin secondary plus an address-balance reservation. Three smash
+// side-effects fire together:
 //   - the second coin is consumed (deleted),
 //   - the reservation emits a single Split accumulator event,
 //   - the smash target is mutated with the summed value.

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/coin_coin_reservation_gas.move
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/coin_coin_reservation_gas.move
@@ -1,0 +1,44 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Exercises gas smashing for `[Coin, Coin, AddressBalance]`: a real Coin as
+// the smash target with a second Coin secondary and an address-balance
+// reservation. All three smash side-effects fire together:
+//   - the second coin is consumed (deleted),
+//   - the reservation emits a single Split accumulator event,
+//   - the smash target is mutated with the summed value.
+
+//# init --addresses test=0x0 --accounts A B --enable-address-balance-gas-payments --enable-coin-reservations --enable-accumulators
+
+//# view-object 0,0
+
+// Seed A's address balance.
+//# programmable --sender A --inputs 100000000000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::into_balance<sui::sui::SUI>(Result(0));
+//> 2: sui::balance::send_funds<sui::sui::SUI>(Result(1), Input(1));
+
+// Create a second SUI coin owned by A (will be smashed in as a secondary).
+//# programmable --sender A --inputs 1000000000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+
+//# create-checkpoint
+
+//# view-funds sui::balance::Balance<sui::sui::SUI> A
+
+// Pay gas with `[Coin, Coin, AddressBalance]`. Smash target is the gas coin
+// (object 0,0). The second coin (object 3,0) gets deleted; the withdrawal
+// secondary emits a `Split, 500_000_000` accumulator event.
+//# programmable --sender A --gas-payment object(0,0) --gas-payment object(3,0) --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(500000000) --inputs 100000 @B
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+
+//# create-checkpoint
+
+// A's address balance should have dropped by exactly 500_000_000.
+//# view-funds sui::balance::Balance<sui::sui::SUI> A
+
+// Smash target (object 0,0) holds the leftover (start + secondary coin value
+// + reservation - net gas cost). Object 3,0 should no longer exist.
+//# view-object 0,0

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/coin_coin_reservation_gas.snap
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/coin_coin_reservation_gas.snap
@@ -1,0 +1,81 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 10 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 13-15:
+//# view-object 0,0
+Owner: Account Address ( A )
+Version: 1
+Contents: sui::coin::Coin<sui::sui::SUI> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(0,0),
+        },
+    },
+    balance: sui::balance::Balance<sui::sui::SUI> {
+        value: 300000000000000u64,
+    },
+}
+
+task 2, lines 16-21:
+//# programmable --sender A --inputs 100000000000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::into_balance<sui::sui::SUI>(Result(0));
+//> 2: sui::balance::send_funds<sui::sui::SUI>(Result(1), Input(1));
+// Create a second SUI coin owned by A (will be smashed in as a secondary).
+mutated: object(0,0)
+accumulators_written: (object(2,0), A, sui::balance::Balance<sui::sui::SUI>, Merge, 100000000000)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, lines 22-24:
+//# programmable --sender A --inputs 1000000000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+created: object(3,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 4, line 26:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 5, lines 28-32:
+//# view-funds sui::balance::Balance<sui::sui::SUI> A
+100000000000
+
+task 6, lines 33-35:
+//# programmable --sender A --gas-payment object(0,0) --gas-payment object(3,0) --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(500000000) --inputs 100000 @B
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+created: object(6,0)
+mutated: object(0,0)
+deleted: object(3,0)
+accumulators_written: (object(2,0), A, sui::balance::Balance<sui::sui::SUI>, Split, 500000000)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 1956240, non_refundable_storage_fee: 19760
+
+task 7, lines 37-39:
+//# create-checkpoint
+Checkpoint created: 2
+
+task 8, lines 40-43:
+//# view-funds sui::balance::Balance<sui::sui::SUI> A
+99500000000
+
+task 9, line 44:
+//# view-object 0,0
+Owner: Account Address ( A )
+Version: 4
+Contents: sui::coin::Coin<sui::sui::SUI> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(0,0),
+        },
+    },
+    balance: sui::balance::Balance<sui::sui::SUI> {
+        value: 299900494894360u64,
+    },
+}

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/coin_with_multi_reservation_gas.move
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/coin_with_multi_reservation_gas.move
@@ -1,0 +1,41 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Exercises gas smashing for `[gas_coin, withdraw, withdraw]`: a real Coin as
+// the smash target with multiple address-balance reservations from the same
+// sender. The two reservations share a payment location and are summed before
+// being smashed into the gas coin. Verifies that:
+//   - the smash target stays a real Coin (no ephemeral coin path),
+//   - a single accumulator event is emitted for the merged reservation,
+//   - leftover reservation lands in the gas coin (not refunded to the balance).
+
+//# init --addresses test=0x0 --accounts A B --enable-address-balance-gas-payments --enable-coin-reservations --enable-accumulators
+
+//# view-object 0,0
+
+// Seed A's address balance.
+//# programmable --sender A --inputs 100000000000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::into_balance<sui::sui::SUI>(Result(0));
+//> 2: sui::balance::send_funds<sui::sui::SUI>(Result(1), Input(1));
+
+//# create-checkpoint
+
+//# view-funds sui::balance::Balance<sui::sui::SUI> A
+
+// Pay gas with `[gas_coin, withdraw, withdraw]`. The two withdrawals share
+// the same address-balance location and are summed during smashing; the
+// smash target is the real gas coin (object 0,0).
+//# programmable --sender A --gas-payment object(0,0) --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(500000000) --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(500000000) --inputs 100000 @B
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+
+//# create-checkpoint
+
+// Address balance should have decreased by exactly the net gas usage on the
+// reserved amount (1_000_000_000 reserved minus what survives in the coin).
+//# view-funds sui::balance::Balance<sui::sui::SUI> A
+
+// Inspect the gas coin: leftover reservation stays here, not refunded to A's
+// address balance.
+//# view-object 0,0

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/coin_with_multi_reservation_gas.move
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/coin_with_multi_reservation_gas.move
@@ -1,10 +1,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-// Exercises gas smashing for `[gas_coin, withdraw, withdraw]`: a real Coin as
-// the smash target with multiple address-balance reservations from the same
-// sender. The two reservations share a payment location and are summed before
-// being smashed into the gas coin. Verifies that:
+// `[gas_coin, withdraw, withdraw]`: real Coin as smash target, multiple
+// address-balance reservations from the same sender. The two reservations
+// share a payment location and are summed before being smashed in.
+// Verifies that:
 //   - the smash target stays a real Coin (no ephemeral coin path),
 //   - a single accumulator event is emitted for the merged reservation,
 //   - leftover reservation lands in the gas coin (not refunded to the balance).

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/coin_with_multi_reservation_gas.snap
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/coin_with_multi_reservation_gas.snap
@@ -1,0 +1,71 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 9 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 14-16:
+//# view-object 0,0
+Owner: Account Address ( A )
+Version: 1
+Contents: sui::coin::Coin<sui::sui::SUI> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(0,0),
+        },
+    },
+    balance: sui::balance::Balance<sui::sui::SUI> {
+        value: 300000000000000u64,
+    },
+}
+
+task 2, lines 17-20:
+//# programmable --sender A --inputs 100000000000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::into_balance<sui::sui::SUI>(Result(0));
+//> 2: sui::balance::send_funds<sui::sui::SUI>(Result(1), Input(1));
+mutated: object(0,0)
+accumulators_written: (object(2,0), A, sui::balance::Balance<sui::sui::SUI>, Merge, 100000000000)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, line 22:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 4, lines 24-28:
+//# view-funds sui::balance::Balance<sui::sui::SUI> A
+100000000000
+
+task 5, lines 29-31:
+//# programmable --sender A --gas-payment object(0,0) --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(500000000) --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(500000000) --inputs 100000 @B
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+created: object(5,0)
+mutated: object(0,0)
+accumulators_written: (object(2,0), A, sui::balance::Balance<sui::sui::SUI>, Split, 1000000000)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 6, lines 33-36:
+//# create-checkpoint
+Checkpoint created: 2
+
+task 7, lines 37-40:
+//# view-funds sui::balance::Balance<sui::sui::SUI> A
+99000000000
+
+task 8, line 41:
+//# view-object 0,0
+Owner: Account Address ( A )
+Version: 3
+Contents: sui::coin::Coin<sui::sui::SUI> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(0,0),
+        },
+    },
+    balance: sui::balance::Balance<sui::sui::SUI> {
+        value: 299900995914120u64,
+    },
+}

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/max_withdraws_boundary.move
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/max_withdraws_boundary.move
@@ -1,15 +1,15 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-// Locks in the per-transaction `max_withdraws = 10` cap. The cap counts
-// explicit WithdrawFunds PTB commands plus coin reservations, with `+1` for
-// the implicit gas-budget withdrawal ONLY when gas is paid purely from
-// address balance (i.e. no explicit gas-payment entries). When all gas
-// payments are explicit `--gas-payment withdraw(...)`, the payment list is
-// non-empty, so the implicit +1 is NOT added; the cap applies directly to
-// the count of withdraws.
-// 10 explicit reservations = at boundary, should PASS.
-// 11 explicit reservations = over limit, should REJECT.
+// Per-transaction `max_withdraws = 10` cap. The cap counts explicit
+// WithdrawFunds PTB commands plus coin reservations, with +1 for the
+// implicit gas-budget withdrawal only when gas is paid purely from address
+// balance (i.e. no explicit gas-payment entries). When all gas payments are
+// explicit `--gas-payment withdraw(...)`, the payment list is non-empty, so
+// the implicit +1 is not added; the cap applies directly to the count of
+// withdraws.
+//   - 10 explicit reservations: at boundary, passes.
+//   - 11 explicit reservations: over limit, rejects.
 
 //# init --addresses test=0x0 --accounts A --enable-address-balance-gas-payments --enable-coin-reservations --enable-accumulators
 

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/max_withdraws_boundary.move
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/max_withdraws_boundary.move
@@ -1,0 +1,32 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Locks in the per-transaction `max_withdraws = 10` cap. The cap counts
+// explicit WithdrawFunds PTB commands plus coin reservations, with `+1` for
+// the implicit gas-budget withdrawal ONLY when gas is paid purely from
+// address balance (i.e. no explicit gas-payment entries). When all gas
+// payments are explicit `--gas-payment withdraw(...)`, the payment list is
+// non-empty, so the implicit +1 is NOT added; the cap applies directly to
+// the count of withdraws.
+// 10 explicit reservations = at boundary, should PASS.
+// 11 explicit reservations = over limit, should REJECT.
+
+//# init --addresses test=0x0 --accounts A --enable-address-balance-gas-payments --enable-coin-reservations --enable-accumulators
+
+// Seed A's address balance with plenty.
+//# programmable --sender A --inputs 1000000000000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::into_balance<sui::sui::SUI>(Result(0));
+//> 2: sui::balance::send_funds<sui::sui::SUI>(Result(1), Input(1));
+
+//# create-checkpoint
+
+// 10 withdraw reservations, each 20M. Total available 200M, budget 100M, plenty for workload. Boundary case, should PASS.
+//# programmable --sender A --gas-budget 100000000 --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(20000000) --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(20000000) --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(20000000) --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(20000000) --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(20000000) --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(20000000) --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(20000000) --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(20000000) --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(20000000) --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(20000000) --inputs 100 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+
+// 11 withdraw reservations, each 20M. Total available 220M. Over limit, should REJECT at validation.
+//# programmable --sender A --gas-budget 100000000 --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(20000000) --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(20000000) --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(20000000) --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(20000000) --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(20000000) --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(20000000) --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(20000000) --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(20000000) --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(20000000) --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(20000000) --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(20000000) --inputs 100 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/max_withdraws_boundary.snap
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/max_withdraws_boundary.snap
@@ -1,0 +1,35 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 5 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 17-20:
+//# programmable --sender A --inputs 1000000000000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::into_balance<sui::sui::SUI>(Result(0));
+//> 2: sui::balance::send_funds<sui::sui::SUI>(Result(1), Input(1));
+mutated: object(0,0)
+accumulators_written: (object(1,0), A, sui::balance::Balance<sui::sui::SUI>, Merge, 1000000000000)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 22-24:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 3, lines 25-29:
+//# programmable --sender A --gas-budget 100000000 --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(20000000) --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(20000000) --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(20000000) --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(20000000) --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(20000000) --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(20000000) --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(20000000) --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(20000000) --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(20000000) --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(20000000) --inputs 100 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+// 11 withdraw reservations, each 20M. Total available 220M. Over limit, should REJECT at validation.
+created: object(3,0)
+accumulators_written: (object(1,0), A, sui::balance::Balance<sui::sui::SUI>, Split, 1988100)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 4, lines 30-32:
+//# programmable --sender A --gas-budget 100000000 --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(20000000) --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(20000000) --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(20000000) --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(20000000) --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(20000000) --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(20000000) --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(20000000) --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(20000000) --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(20000000) --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(20000000) --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(20000000) --inputs 100 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+Error: Error checking transaction input objects: Invalid withdraw reservation: Maximum number of balance withdraw reservations is 10

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/mixed_gas_move_abort.move
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/mixed_gas_move_abort.move
@@ -1,0 +1,37 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Exercises the abort-path of gas charging for `[Coin, AddressBalance]`
+// payment: a Move abort triggers a temporary-store reset and a re-smash
+// before storage is charged. Verifies that re-smashing produces consistent
+// results, and that the final accumulator event and gas coin charge reflect
+// the post-abort state, not the pre-abort attempt.
+
+//# init --addresses test=0x0 --accounts A --enable-address-balance-gas-payments --enable-coin-reservations --enable-accumulators
+
+//# publish
+module test::boom;
+public fun boom() { abort 7 }
+
+// Seed A's address balance.
+//# programmable --sender A --inputs 100000000000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::into_balance<sui::sui::SUI>(Result(0));
+//> 2: sui::balance::send_funds<sui::sui::SUI>(Result(1), Input(1));
+
+//# create-checkpoint
+
+//# view-funds sui::balance::Balance<sui::sui::SUI> A
+
+// Mixed payment: coin smash target + address-balance secondary; call aborts.
+//# programmable --sender A --gas-payment object(0,0) --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(500000000)
+//> test::boom::boom()
+
+//# create-checkpoint
+
+// Address balance after abort: charge against the merged reservation should
+// reflect computation cost (no storage cost since writes were dumped on
+// abort).
+//# view-funds sui::balance::Balance<sui::sui::SUI> A
+
+//# view-object 0,0

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/mixed_gas_move_abort.move
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/mixed_gas_move_abort.move
@@ -1,11 +1,11 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-// Exercises the abort-path of gas charging for `[Coin, AddressBalance]`
-// payment: a Move abort triggers a temporary-store reset and a re-smash
-// before storage is charged. Verifies that re-smashing produces consistent
-// results, and that the final accumulator event and gas coin charge reflect
-// the post-abort state, not the pre-abort attempt.
+// Move abort with `[Coin, AddressBalance]` gas payment. The abort triggers a
+// temporary-store reset and a re-smash before storage is charged. Verifies
+// that re-smashing produces consistent results, and that the final
+// accumulator event and gas coin charge reflect the post-abort state, not
+// the pre-abort attempt.
 
 //# init --addresses test=0x0 --accounts A --enable-address-balance-gas-payments --enable-coin-reservations --enable-accumulators
 

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/mixed_gas_move_abort.snap
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/mixed_gas_move_abort.snap
@@ -1,0 +1,59 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 9 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 12-16:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 3465600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 17-20:
+//# programmable --sender A --inputs 100000000000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::into_balance<sui::sui::SUI>(Result(0));
+//> 2: sui::balance::send_funds<sui::sui::SUI>(Result(1), Input(1));
+mutated: object(0,0)
+accumulators_written: (object(2,0), A, sui::balance::Balance<sui::sui::SUI>, Merge, 100000000000)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, line 22:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 4, lines 24-26:
+//# view-funds sui::balance::Balance<sui::sui::SUI> A
+100000000000
+
+task 5, lines 27-28:
+//# programmable --sender A --gas-payment object(0,0) --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(500000000)
+//> test::boom::boom()
+Error: Transaction Effects Status: Move Runtime Abort. Location: test::boom::boom (function index 0) at offset 1, Abort Code: 7
+Debug of error: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("boom") }, function: 0, instruction: 1, function_name: Some("boom") }, 7) at command Some(0)
+
+task 6, lines 30-34:
+//# create-checkpoint
+Checkpoint created: 2
+
+task 7, line 35:
+//# view-funds sui::balance::Balance<sui::sui::SUI> A
+99500000000
+
+task 8, line 37:
+//# view-object 0,0
+Owner: Account Address ( A )
+Version: 3
+Contents: sui::coin::Coin<sui::sui::SUI> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(0,0),
+        },
+    },
+    balance: sui::balance::Balance<sui::sui::SUI> {
+        value: 299900497002120u64,
+    },
+}

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/mixed_gas_storage_oog.move
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/mixed_gas_storage_oog.move
@@ -1,11 +1,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-// Exercises the storage-OOG reset + re-smash path for `[Coin, AddressBalance]`
-// gas payment.
-// Smash target = Coin: reset must un-mutate the gas coin's smashed value and
-// clear the secondary's `Split` withdraw accumulator event; re-smash must
-// re-mutate and re-emit consistently.
+// Storage-OOG reset + re-smash for `[Coin, AddressBalance]` gas payment.
+// Smash target is the Coin: reset must un-mutate the gas coin's smashed
+// value and clear the secondary's Split withdraw accumulator event; re-smash
+// must re-mutate and re-emit consistently.
 
 //# init --addresses test=0x0 --accounts A B --enable-address-balance-gas-payments --enable-coin-reservations --enable-accumulators
 

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/mixed_gas_storage_oog.move
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/mixed_gas_storage_oog.move
@@ -1,0 +1,41 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Exercises the storage-OOG reset + re-smash path for `[Coin, AddressBalance]`
+// gas payment.
+// Smash target = Coin: reset must un-mutate the gas coin's smashed value and
+// clear the secondary's `Split` withdraw accumulator event; re-smash must
+// re-mutate and re-emit consistently.
+
+//# init --addresses test=0x0 --accounts A B --enable-address-balance-gas-payments --enable-coin-reservations --enable-accumulators
+
+//# publish
+module test::oog;
+public struct W has key, store { id: UID }
+public fun make(n: u64, ctx: &mut TxContext) {
+    let mut i = 0;
+    while (i < n) {
+        sui::transfer::public_transfer(W { id: object::new(ctx) }, ctx.sender());
+        i = i + 1;
+    }
+}
+
+// Seed A's address balance.
+//# programmable --sender A --inputs 100000000000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::into_balance<sui::sui::SUI>(Result(0));
+//> 2: sui::balance::send_funds<sui::sui::SUI>(Result(1), Input(1));
+
+//# create-checkpoint
+
+//# view-funds sui::balance::Balance<sui::sui::SUI> A
+
+// Mixed [Coin, AddressBalance] payment with tight budget; workload OOGs storage.
+//# programmable --sender A --gas-budget 5000000 --gas-payment object(0,0) --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(5000000) --inputs 100
+//> test::oog::make(Input(0))
+
+//# create-checkpoint
+
+//# view-funds sui::balance::Balance<sui::sui::SUI> A
+
+//# view-object 0,0

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/mixed_gas_storage_oog.snap
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/mixed_gas_storage_oog.snap
@@ -6,13 +6,13 @@ processed 9 tasks
 init:
 A: object(0,0), B: object(0,1)
 
-task 1, lines 12-23:
+task 1, lines 11-22:
 //# publish
 created: object(1,0)
 mutated: object(0,2)
 gas summary: computation_cost: 1000000, storage_cost: 5502400,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 2, lines 24-27:
+task 2, lines 23-26:
 //# programmable --sender A --inputs 100000000000 @A
 //> 0: SplitCoins(Gas, [Input(0)]);
 //> 1: sui::coin::into_balance<sui::sui::SUI>(Result(0));
@@ -21,29 +21,29 @@ mutated: object(0,0)
 accumulators_written: (object(2,0), A, sui::balance::Balance<sui::sui::SUI>, Merge, 100000000000)
 gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 3, line 29:
+task 3, line 28:
 //# create-checkpoint
 Checkpoint created: 1
 
-task 4, lines 31-33:
+task 4, lines 30-32:
 //# view-funds sui::balance::Balance<sui::sui::SUI> A
 100000000000
 
-task 5, lines 34-35:
+task 5, lines 33-34:
 //# programmable --sender A --gas-budget 5000000 --gas-payment object(0,0) --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(5000000) --inputs 100
 //> test::oog::make(Input(0))
 Error: Transaction Effects Status: Insufficient Gas.
 Debug of error: InsufficientGas at command None
 
-task 6, line 37:
+task 6, line 36:
 //# create-checkpoint
 Checkpoint created: 2
 
-task 7, line 39:
+task 7, line 38:
 //# view-funds sui::balance::Balance<sui::sui::SUI> A
 99995000000
 
-task 8, line 41:
+task 8, line 40:
 //# view-object 0,0
 Owner: Account Address ( A )
 Version: 3

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/mixed_gas_storage_oog.snap
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/mixed_gas_storage_oog.snap
@@ -1,0 +1,59 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 9 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 12-23:
+//# publish
+created: object(1,0)
+mutated: object(0,2)
+gas summary: computation_cost: 1000000, storage_cost: 5502400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 24-27:
+//# programmable --sender A --inputs 100000000000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::into_balance<sui::sui::SUI>(Result(0));
+//> 2: sui::balance::send_funds<sui::sui::SUI>(Result(1), Input(1));
+mutated: object(0,0)
+accumulators_written: (object(2,0), A, sui::balance::Balance<sui::sui::SUI>, Merge, 100000000000)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, line 29:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 4, lines 31-33:
+//# view-funds sui::balance::Balance<sui::sui::SUI> A
+100000000000
+
+task 5, lines 34-35:
+//# programmable --sender A --gas-budget 5000000 --gas-payment object(0,0) --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(5000000) --inputs 100
+//> test::oog::make(Input(0))
+Error: Transaction Effects Status: Insufficient Gas.
+Debug of error: InsufficientGas at command None
+
+task 6, line 37:
+//# create-checkpoint
+Checkpoint created: 2
+
+task 7, line 39:
+//# view-funds sui::balance::Balance<sui::sui::SUI> A
+99995000000
+
+task 8, line 41:
+//# view-object 0,0
+Owner: Account Address ( A )
+Version: 3
+Contents: sui::coin::Coin<sui::sui::SUI> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(0,0),
+        },
+    },
+    balance: sui::balance::Balance<sui::sui::SUI> {
+        value: 299900002002120u64,
+    },
+}

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/override_send_funds_to_self.move
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/override_send_funds_to_self.move
@@ -1,0 +1,48 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Esoteric override edge case: `[AddressBalance(A), Coin]` smash target =
+// AB, secondary Coin gets deleted; then `send_funds(Gas, @A)` transfers the
+// ephemeral gas coin's value back into A's address balance. At gas
+// finalization, the gas-charge location is overridden to the recipient's
+// address balance -- which is the SAME address as the original payer, so
+// the override is logically a no-op. This test pins down that the gas
+// accounting still settles correctly.
+// Compared to the existing pure-address-balance send_funds-to-self test,
+// this adds a secondary Coin to the smash so the secondary-coin deletion
+// and Merge deposit-back paths run too.
+
+//# init --addresses test=0x0 --accounts A --enable-address-balance-gas-payments --enable-coin-reservations --enable-accumulators
+
+// Seed A's address balance.
+//# programmable --sender A --inputs 100000000000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::into_balance<sui::sui::SUI>(Result(0));
+//> 2: sui::balance::send_funds<sui::sui::SUI>(Result(1), Input(1));
+
+// Create a 1B coin owned by A - this will be the secondary in the smash.
+//# programmable --sender A --inputs 1000000000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+
+//# create-checkpoint
+
+//# view-funds sui::balance::Balance<sui::sui::SUI> A
+
+//# view-object 2,0
+
+// Pay with [AB(500M), Coin(1B)]; send_funds(Gas, @A) - recipient is the
+// original AB owner. The override target equals the original gas charge
+// location.
+//# programmable --sender A --gas-budget 500000000 --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(500000000) --gas-payment object(2,0) --inputs @A
+//> sui::coin::send_funds<sui::sui::SUI>(Gas, Input(0))
+
+//# create-checkpoint
+
+// After: A's AB should reflect all accumulator events - deposit-back from
+// smashing the secondary coin (Merge: coin value), the send_funds transfer
+// of the ephemeral coin to A's AB (Merge: full smashed value), the override-
+// driven debit (Split: full smashed value), and the final gas charge.
+//# view-funds sui::balance::Balance<sui::sui::SUI> A
+
+//# view-object 2,0

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/override_send_funds_to_self.snap
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/override_send_funds_to_self.snap
@@ -1,0 +1,67 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 10 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 18-23:
+//# programmable --sender A --inputs 100000000000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::into_balance<sui::sui::SUI>(Result(0));
+//> 2: sui::balance::send_funds<sui::sui::SUI>(Result(1), Input(1));
+// Create a 1B coin owned by A - this will be the secondary in the smash.
+mutated: object(0,0)
+accumulators_written: (object(1,0), A, sui::balance::Balance<sui::sui::SUI>, Merge, 100000000000)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 24-26:
+//# programmable --sender A --inputs 1000000000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 3, line 28:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 4, line 30:
+//# view-funds sui::balance::Balance<sui::sui::SUI> A
+100000000000
+
+task 5, lines 32-36:
+//# view-object 2,0
+Owner: Account Address ( A )
+Version: 3
+Contents: sui::coin::Coin<sui::sui::SUI> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(2,0),
+        },
+    },
+    balance: sui::balance::Balance<sui::sui::SUI> {
+        value: 1000000000u64,
+    },
+}
+
+task 6, lines 37-38:
+//# programmable --sender A --gas-budget 500000000 --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(500000000) --gas-payment object(2,0) --inputs @A
+//> sui::coin::send_funds<sui::sui::SUI>(Gas, Input(0))
+deleted: object(2,0)
+accumulators_written: (object(1,0), A, sui::balance::Balance<sui::sui::SUI>, Merge, 999978120)
+gas summary: computation_cost: 1000000, storage_cost: 0,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 7, lines 40-45:
+//# create-checkpoint
+Checkpoint created: 2
+
+task 8, line 46:
+//# view-funds sui::balance::Balance<sui::sui::SUI> A
+100999978120
+
+task 9, line 48:
+//# view-object 2,0
+No object at id 2,0

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/rebate_exceeds_cost.move
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/rebate_exceeds_cost.move
@@ -1,0 +1,63 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Demonstrates the case where storage rebate exceeds storage cost plus
+// computation -- i.e. net gas usage is negative (a refund). Smash
+// `[AB, Coin, Coin, Coin]` with a trivial workload (one SplitCoins +
+// TransferObjects, creating one new coin):
+//   - 3 secondary coins deleted -> ~3 coins' worth of storage rebate
+//   - 1 new coin created        -> ~1 coin's worth of storage cost
+//   - small computation cost
+// Net gas usage comes out negative. With AB as the smash target, the surplus
+// is credited back to A's address balance via an accumulator event on top
+// of the coin-value deposit-back (the 3 coins' balance values folded into
+// AB, minus the small amount routed to the recipient).
+
+//# init --addresses test=0x0 --accounts A --enable-address-balance-gas-payments --enable-coin-reservations --enable-accumulators
+
+// Seed A's address balance.
+//# programmable --sender A --inputs 100000000000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::into_balance<sui::sui::SUI>(Result(0));
+//> 2: sui::balance::send_funds<sui::sui::SUI>(Result(1), Input(1));
+
+// Create three identical 1_000_000_000 coins for A (will be smashed/deleted).
+//# programmable --sender A --inputs 1000000000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+
+//# programmable --sender A --inputs 1000000000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+
+//# programmable --sender A --inputs 1000000000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+
+//# create-checkpoint
+
+//# view-funds sui::balance::Balance<sui::sui::SUI> A
+
+//# view-object 2,0
+
+//# view-object 3,0
+
+//# view-object 4,0
+
+// Smash [AB(5M), Coin(1B), Coin(1B), Coin(1B)] with trivial workload. AB is
+// the smash target so net gas refund + coin-value deposit both land in AB.
+//# programmable --sender A --gas-budget 5000000 --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(5000000) --gas-payment object(2,0) --gas-payment object(3,0) --gas-payment object(4,0) --inputs 100 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+
+//# create-checkpoint
+
+// After: A's AB should be ~ 100B + 3B (coin values) + |net_gas_refund|.
+// The three coins are gone.
+//# view-funds sui::balance::Balance<sui::sui::SUI> A
+
+//# view-object 2,0
+
+//# view-object 3,0
+
+//# view-object 4,0

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/rebate_exceeds_cost.move
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/rebate_exceeds_cost.move
@@ -1,19 +1,18 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-// Demonstrates the case where storage rebate exceeds storage cost plus
-// computation -- i.e. net gas usage is negative (a refund). Smash
-// `[AB, Coin, Coin, Coin]` with a trivial workload (one SplitCoins +
-// TransferObjects, creating one new coin):
+// Storage rebate exceeds storage cost plus computation, so net gas usage is
+// negative (a refund). Smash `[AB, Coin, Coin, Coin]` with a trivial workload
+// (one SplitCoins + TransferObjects, creating one new coin):
 //   - 3 secondary coins deleted -> ~3 coins' worth of storage rebate
 //   - 1 new coin created        -> ~1 coin's worth of storage cost
 //   - small computation cost
-// Net gas usage comes out negative. With AB as the smash target, the surplus
-// is credited back to A's address balance via an accumulator event on top
-// of the coin-value deposit-back (the 3 coins' balance values folded into
-// AB, minus the small amount routed to the recipient).
+// With AB as the smash target, the surplus is credited back to A's address
+// balance via an accumulator event on top of the coin-value deposit-back
+// (3 coins' balance values folded into AB, minus the 100 MIST routed out to
+// B as a new coin).
 
-//# init --addresses test=0x0 --accounts A --enable-address-balance-gas-payments --enable-coin-reservations --enable-accumulators
+//# init --addresses test=0x0 --accounts A B --enable-address-balance-gas-payments --enable-coin-reservations --enable-accumulators
 
 // Seed A's address balance.
 //# programmable --sender A --inputs 100000000000 @A
@@ -46,7 +45,7 @@
 
 // Smash [AB(5M), Coin(1B), Coin(1B), Coin(1B)] with trivial workload. AB is
 // the smash target so net gas refund + coin-value deposit both land in AB.
-//# programmable --sender A --gas-budget 5000000 --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(5000000) --gas-payment object(2,0) --gas-payment object(3,0) --gas-payment object(4,0) --inputs 100 @A
+//# programmable --sender A --gas-budget 5000000 --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(5000000) --gas-payment object(2,0) --gas-payment object(3,0) --gas-payment object(4,0) --inputs 100 @B
 //> 0: SplitCoins(Gas, [Input(0)]);
 //> TransferObjects([Result(0)], Input(1))
 

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/rebate_exceeds_cost.snap
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/rebate_exceeds_cost.snap
@@ -1,0 +1,123 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 16 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 19-24:
+//# programmable --sender A --inputs 100000000000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::into_balance<sui::sui::SUI>(Result(0));
+//> 2: sui::balance::send_funds<sui::sui::SUI>(Result(1), Input(1));
+// Create three identical 1_000_000_000 coins for A (will be smashed/deleted).
+mutated: object(0,0)
+accumulators_written: (object(1,0), A, sui::balance::Balance<sui::sui::SUI>, Merge, 100000000000)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 25-27:
+//# programmable --sender A --inputs 1000000000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 3, lines 29-31:
+//# programmable --sender A --inputs 1000000000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+created: object(3,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 4, lines 33-35:
+//# programmable --sender A --inputs 1000000000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+created: object(4,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 5, line 37:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 6, line 39:
+//# view-funds sui::balance::Balance<sui::sui::SUI> A
+100000000000
+
+task 7, line 41:
+//# view-object 2,0
+Owner: Account Address ( A )
+Version: 3
+Contents: sui::coin::Coin<sui::sui::SUI> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(2,0),
+        },
+    },
+    balance: sui::balance::Balance<sui::sui::SUI> {
+        value: 1000000000u64,
+    },
+}
+
+task 8, line 43:
+//# view-object 3,0
+Owner: Account Address ( A )
+Version: 4
+Contents: sui::coin::Coin<sui::sui::SUI> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(3,0),
+        },
+    },
+    balance: sui::balance::Balance<sui::sui::SUI> {
+        value: 1000000000u64,
+    },
+}
+
+task 9, lines 45-48:
+//# view-object 4,0
+Owner: Account Address ( A )
+Version: 5
+Contents: sui::coin::Coin<sui::sui::SUI> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(4,0),
+        },
+    },
+    balance: sui::balance::Balance<sui::sui::SUI> {
+        value: 1000000000u64,
+    },
+}
+
+task 10, lines 49-51:
+//# programmable --sender A --gas-budget 5000000 --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(5000000) --gas-payment object(2,0) --gas-payment object(3,0) --gas-payment object(4,0) --inputs 100 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+created: object(10,0)
+deleted: object(2,0), object(3,0), object(4,0)
+accumulators_written: (object(1,0), A, sui::balance::Balance<sui::sui::SUI>, Merge, 3000946260)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 2934360, non_refundable_storage_fee: 29640
+
+task 11, lines 53-56:
+//# create-checkpoint
+Checkpoint created: 2
+
+task 12, line 57:
+//# view-funds sui::balance::Balance<sui::sui::SUI> A
+103000946260
+
+task 13, line 59:
+//# view-object 2,0
+No object at id 2,0
+
+task 14, line 61:
+//# view-object 3,0
+No object at id 3,0
+
+task 15, line 63:
+//# view-object 4,0
+No object at id 4,0

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/rebate_exceeds_cost.snap
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/rebate_exceeds_cost.snap
@@ -4,9 +4,9 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 processed 16 tasks
 
 init:
-A: object(0,0)
+A: object(0,0), B: object(0,1)
 
-task 1, lines 19-24:
+task 1, lines 18-23:
 //# programmable --sender A --inputs 100000000000 @A
 //> 0: SplitCoins(Gas, [Input(0)]);
 //> 1: sui::coin::into_balance<sui::sui::SUI>(Result(0));
@@ -16,7 +16,7 @@ mutated: object(0,0)
 accumulators_written: (object(1,0), A, sui::balance::Balance<sui::sui::SUI>, Merge, 100000000000)
 gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 2, lines 25-27:
+task 2, lines 24-26:
 //# programmable --sender A --inputs 1000000000 @A
 //> 0: SplitCoins(Gas, [Input(0)]);
 //> TransferObjects([Result(0)], Input(1))
@@ -24,7 +24,7 @@ created: object(2,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 3, lines 29-31:
+task 3, lines 28-30:
 //# programmable --sender A --inputs 1000000000 @A
 //> 0: SplitCoins(Gas, [Input(0)]);
 //> TransferObjects([Result(0)], Input(1))
@@ -32,7 +32,7 @@ created: object(3,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 4, lines 33-35:
+task 4, lines 32-34:
 //# programmable --sender A --inputs 1000000000 @A
 //> 0: SplitCoins(Gas, [Input(0)]);
 //> TransferObjects([Result(0)], Input(1))
@@ -40,15 +40,15 @@ created: object(4,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 5, line 37:
+task 5, line 36:
 //# create-checkpoint
 Checkpoint created: 1
 
-task 6, line 39:
+task 6, line 38:
 //# view-funds sui::balance::Balance<sui::sui::SUI> A
 100000000000
 
-task 7, line 41:
+task 7, line 40:
 //# view-object 2,0
 Owner: Account Address ( A )
 Version: 3
@@ -63,7 +63,7 @@ Contents: sui::coin::Coin<sui::sui::SUI> {
     },
 }
 
-task 8, line 43:
+task 8, line 42:
 //# view-object 3,0
 Owner: Account Address ( A )
 Version: 4
@@ -78,7 +78,7 @@ Contents: sui::coin::Coin<sui::sui::SUI> {
     },
 }
 
-task 9, lines 45-48:
+task 9, lines 44-47:
 //# view-object 4,0
 Owner: Account Address ( A )
 Version: 5
@@ -93,8 +93,8 @@ Contents: sui::coin::Coin<sui::sui::SUI> {
     },
 }
 
-task 10, lines 49-51:
-//# programmable --sender A --gas-budget 5000000 --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(5000000) --gas-payment object(2,0) --gas-payment object(3,0) --gas-payment object(4,0) --inputs 100 @A
+task 10, lines 48-50:
+//# programmable --sender A --gas-budget 5000000 --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(5000000) --gas-payment object(2,0) --gas-payment object(3,0) --gas-payment object(4,0) --inputs 100 @B
 //> 0: SplitCoins(Gas, [Input(0)]);
 //> TransferObjects([Result(0)], Input(1))
 created: object(10,0)
@@ -102,22 +102,22 @@ deleted: object(2,0), object(3,0), object(4,0)
 accumulators_written: (object(1,0), A, sui::balance::Balance<sui::sui::SUI>, Merge, 3000946260)
 gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 2934360, non_refundable_storage_fee: 29640
 
-task 11, lines 53-56:
+task 11, lines 52-55:
 //# create-checkpoint
 Checkpoint created: 2
 
-task 12, line 57:
+task 12, line 56:
 //# view-funds sui::balance::Balance<sui::sui::SUI> A
 103000946260
 
-task 13, line 59:
+task 13, line 58:
 //# view-object 2,0
 No object at id 2,0
 
-task 14, line 61:
+task 14, line 60:
 //# view-object 3,0
 No object at id 3,0
 
-task 15, line 63:
+task 15, line 62:
 //# view-object 4,0
 No object at id 4,0

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/reservation_coin_coin_gas.move
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/reservation_coin_coin_gas.move
@@ -1,0 +1,48 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Exercises gas smashing for `[AddressBalance, Coin, Coin]`: an address-balance
+// withdrawal as the smash target with two Coin secondaries. Distinct path from
+// `[Coin, Coin, AddressBalance]`:
+//   - both coins are consumed (deleted),
+//   - the surplus (total smashed minus reservation) is deposited back into
+//     the address balance via a single Merge accumulator event,
+//   - the actual gas charge against the address balance happens at final
+//     charging time via a separate Split event.
+
+//# init --addresses test=0x0 --accounts A B --enable-address-balance-gas-payments --enable-coin-reservations --enable-accumulators
+
+//# view-object 0,0
+
+// Seed A's address balance.
+//# programmable --sender A --inputs 100000000000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::into_balance<sui::sui::SUI>(Result(0));
+//> 2: sui::balance::send_funds<sui::sui::SUI>(Result(1), Input(1));
+
+// Create two extra SUI coins to be smashed into the withdrawal target.
+//# programmable --sender A --inputs 1000000000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+
+//# programmable --sender A --inputs 1000000000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+
+//# create-checkpoint
+
+//# view-funds sui::balance::Balance<sui::sui::SUI> A
+
+// Pay with `[AddressBalance, Coin, Coin]`. Smash target is the reservation;
+// both coins are deleted. total_smashed = 500_000_000 + 1_000_000_000 +
+// 1_000_000_000 = 2_500_000_000; deposit-back = 2_000_000_000.
+//# programmable --sender A --gas-budget 500000000 --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(500000000) --gas-payment object(3,0) --gas-payment object(4,0) --inputs 100000 @B
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+
+//# create-checkpoint
+
+// A's address balance should reflect: starting balance + 2B deposit-back -
+// net gas charge. The deposit-back event and the gas charge event should be
+// visible as separate accumulator entries in the snapshot.
+//# view-funds sui::balance::Balance<sui::sui::SUI> A

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/reservation_coin_coin_gas.move
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/reservation_coin_coin_gas.move
@@ -1,14 +1,13 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-// Exercises gas smashing for `[AddressBalance, Coin, Coin]`: an address-balance
-// withdrawal as the smash target with two Coin secondaries. Distinct path from
-// `[Coin, Coin, AddressBalance]`:
+// `[AddressBalance, Coin, Coin]`: address-balance withdrawal as smash target
+// with two Coin secondaries.
 //   - both coins are consumed (deleted),
-//   - the surplus (total smashed minus reservation) is deposited back into
-//     the address balance via a single Merge accumulator event,
-//   - the actual gas charge against the address balance happens at final
-//     charging time via a separate Split event.
+//   - surplus (total smashed minus reservation) is deposited back into the
+//     address balance via a single Merge accumulator event,
+//   - the gas charge against the address balance happens at final charging
+//     time via a separate Split event.
 
 //# init --addresses test=0x0 --accounts A B --enable-address-balance-gas-payments --enable-coin-reservations --enable-accumulators
 

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/reservation_coin_coin_gas.snap
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/reservation_coin_coin_gas.snap
@@ -1,0 +1,73 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 10 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 15-17:
+//# view-object 0,0
+Owner: Account Address ( A )
+Version: 1
+Contents: sui::coin::Coin<sui::sui::SUI> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(0,0),
+        },
+    },
+    balance: sui::balance::Balance<sui::sui::SUI> {
+        value: 300000000000000u64,
+    },
+}
+
+task 2, lines 18-23:
+//# programmable --sender A --inputs 100000000000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::into_balance<sui::sui::SUI>(Result(0));
+//> 2: sui::balance::send_funds<sui::sui::SUI>(Result(1), Input(1));
+// Create two extra SUI coins to be smashed into the withdrawal target.
+mutated: object(0,0)
+accumulators_written: (object(2,0), A, sui::balance::Balance<sui::sui::SUI>, Merge, 100000000000)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, lines 24-26:
+//# programmable --sender A --inputs 1000000000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+created: object(3,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 4, lines 28-30:
+//# programmable --sender A --inputs 1000000000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+created: object(4,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 5, line 32:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 6, lines 34-38:
+//# view-funds sui::balance::Balance<sui::sui::SUI> A
+100000000000
+
+task 7, lines 39-41:
+//# programmable --sender A --gas-budget 500000000 --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(500000000) --gas-payment object(3,0) --gas-payment object(4,0) --inputs 100000 @B
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+created: object(7,0)
+deleted: object(3,0), object(4,0)
+accumulators_written: (object(2,0), A, sui::balance::Balance<sui::sui::SUI>, Merge, 1999868240)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 1956240, non_refundable_storage_fee: 19760
+
+task 8, lines 43-47:
+//# create-checkpoint
+Checkpoint created: 2
+
+task 9, line 48:
+//# view-funds sui::balance::Balance<sui::sui::SUI> A
+101999868240

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/reservation_coin_coin_gas.snap
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/reservation_coin_coin_gas.snap
@@ -6,7 +6,7 @@ processed 10 tasks
 init:
 A: object(0,0), B: object(0,1)
 
-task 1, lines 15-17:
+task 1, lines 14-16:
 //# view-object 0,0
 Owner: Account Address ( A )
 Version: 1
@@ -21,7 +21,7 @@ Contents: sui::coin::Coin<sui::sui::SUI> {
     },
 }
 
-task 2, lines 18-23:
+task 2, lines 17-22:
 //# programmable --sender A --inputs 100000000000 @A
 //> 0: SplitCoins(Gas, [Input(0)]);
 //> 1: sui::coin::into_balance<sui::sui::SUI>(Result(0));
@@ -31,7 +31,7 @@ mutated: object(0,0)
 accumulators_written: (object(2,0), A, sui::balance::Balance<sui::sui::SUI>, Merge, 100000000000)
 gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 3, lines 24-26:
+task 3, lines 23-25:
 //# programmable --sender A --inputs 1000000000 @A
 //> 0: SplitCoins(Gas, [Input(0)]);
 //> TransferObjects([Result(0)], Input(1))
@@ -39,7 +39,7 @@ created: object(3,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 4, lines 28-30:
+task 4, lines 27-29:
 //# programmable --sender A --inputs 1000000000 @A
 //> 0: SplitCoins(Gas, [Input(0)]);
 //> TransferObjects([Result(0)], Input(1))
@@ -47,15 +47,15 @@ created: object(4,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 5, line 32:
+task 5, line 31:
 //# create-checkpoint
 Checkpoint created: 1
 
-task 6, lines 34-38:
+task 6, lines 33-37:
 //# view-funds sui::balance::Balance<sui::sui::SUI> A
 100000000000
 
-task 7, lines 39-41:
+task 7, lines 38-40:
 //# programmable --sender A --gas-budget 500000000 --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(500000000) --gas-payment object(3,0) --gas-payment object(4,0) --inputs 100000 @B
 //> 0: SplitCoins(Gas, [Input(0)]);
 //> TransferObjects([Result(0)], Input(1))
@@ -64,10 +64,10 @@ deleted: object(3,0), object(4,0)
 accumulators_written: (object(2,0), A, sui::balance::Balance<sui::sui::SUI>, Merge, 1999868240)
 gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 1956240, non_refundable_storage_fee: 19760
 
-task 8, lines 43-47:
+task 8, lines 42-46:
 //# create-checkpoint
 Checkpoint created: 2
 
-task 9, line 48:
+task 9, line 47:
 //# view-funds sui::balance::Balance<sui::sui::SUI> A
 101999868240

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/reservation_coin_storage_oog.move
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/reservation_coin_storage_oog.move
@@ -1,0 +1,51 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Exercises the storage-OOG reset + re-smash path for `[AddressBalance, Coin]`
+// gas payment. This is the only OOG shape where reset must **un-delete** a
+// secondary coin: the coin is deleted during the first smash; reset has to
+// restore it so the re-smash can re-read its value and re-delete it. Also
+// exercises clearing the Merge deposit-back accumulator event before it's
+// re-emitted.
+
+//# init --addresses test=0x0 --accounts A B --enable-address-balance-gas-payments --enable-coin-reservations --enable-accumulators
+
+//# publish
+module test::oog;
+public struct W has key, store { id: UID }
+public fun make(n: u64, ctx: &mut TxContext) {
+    let mut i = 0;
+    while (i < n) {
+        sui::transfer::public_transfer(W { id: object::new(ctx) }, ctx.sender());
+        i = i + 1;
+    }
+}
+
+// Seed A's address balance.
+//# programmable --sender A --inputs 100000000000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::into_balance<sui::sui::SUI>(Result(0));
+//> 2: sui::balance::send_funds<sui::sui::SUI>(Result(1), Input(1));
+
+// Create a coin to be smashed into the withdrawal target.
+//# programmable --sender A --inputs 1000000000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+
+//# create-checkpoint
+
+//# view-funds sui::balance::Balance<sui::sui::SUI> A
+
+// [AddressBalance, Coin] payment with tight budget; workload OOGs storage.
+// On reset, the secondary coin (object 3,0) must be un-deleted so the
+// re-smash can read its value again.
+//# programmable --sender A --gas-budget 5000000 --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(5000000) --gas-payment object(3,0) --inputs 100
+//> test::oog::make(Input(0))
+
+//# create-checkpoint
+
+//# view-funds sui::balance::Balance<sui::sui::SUI> A
+
+// The secondary coin should be gone after the (re-smashed) tx succeeds in
+// re-deleting it.
+//# view-object 3,0

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/reservation_coin_storage_oog.move
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/reservation_coin_storage_oog.move
@@ -1,11 +1,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-// Exercises the storage-OOG reset + re-smash path for `[AddressBalance, Coin]`
-// gas payment. This is the only OOG shape where reset must **un-delete** a
-// secondary coin: the coin is deleted during the first smash; reset has to
-// restore it so the re-smash can re-read its value and re-delete it. Also
-// exercises clearing the Merge deposit-back accumulator event before it's
+// Storage-OOG reset + re-smash for `[AddressBalance, Coin]` gas payment.
+// The secondary coin is deleted during the first smash, so reset has to
+// un-delete it before the re-smash can re-read its value and re-delete it.
+// Also clears the Merge deposit-back accumulator event before it's
 // re-emitted.
 
 //# init --addresses test=0x0 --accounts A B --enable-address-balance-gas-payments --enable-coin-reservations --enable-accumulators

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/reservation_coin_storage_oog.snap
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/reservation_coin_storage_oog.snap
@@ -1,0 +1,57 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 10 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 13-24:
+//# publish
+created: object(1,0)
+mutated: object(0,2)
+gas summary: computation_cost: 1000000, storage_cost: 5502400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 25-30:
+//# programmable --sender A --inputs 100000000000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::into_balance<sui::sui::SUI>(Result(0));
+//> 2: sui::balance::send_funds<sui::sui::SUI>(Result(1), Input(1));
+// Create a coin to be smashed into the withdrawal target.
+mutated: object(0,0)
+accumulators_written: (object(2,0), A, sui::balance::Balance<sui::sui::SUI>, Merge, 100000000000)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, lines 31-33:
+//# programmable --sender A --inputs 1000000000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+created: object(3,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 4, line 35:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 5, lines 37-41:
+//# view-funds sui::balance::Balance<sui::sui::SUI> A
+100000000000
+
+task 6, lines 42-43:
+//# programmable --sender A --gas-budget 5000000 --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(5000000) --gas-payment object(3,0) --inputs 100
+//> test::oog::make(Input(0))
+Error: Transaction Effects Status: Insufficient Gas.
+Debug of error: InsufficientGas at command None
+
+task 7, line 45:
+//# create-checkpoint
+Checkpoint created: 2
+
+task 8, lines 47-50:
+//# view-funds sui::balance::Balance<sui::sui::SUI> A
+100999978120
+
+task 9, line 51:
+//# view-object 3,0
+No object at id 3,0

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/reservation_reservation_coin_gas.move
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/reservation_reservation_coin_gas.move
@@ -1,12 +1,11 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-// Exercises gas smashing for `[AddressBalance, AddressBalance, Coin]` (same
-// address). The two withdrawals share a payment location and are summed
-// into a single entry *before* smashing runs. What smashing then sees is
-// `[AddressBalance(merged), Coin]`, but the snapshot must show only *one*
-// withdrawal-side accumulator event for the merged reservation (not two),
-// confirming that the dedup happens upfront.
+// `[AddressBalance, AddressBalance, Coin]` (same address). The two
+// withdrawals share a payment location and are summed into a single entry
+// before smashing runs. Smashing then sees `[AddressBalance(merged), Coin]`.
+// The snapshot must show only one withdrawal-side accumulator event for the
+// merged reservation (not two), confirming the dedup happens upfront.
 
 //# init --addresses test=0x0 --accounts A B --enable-address-balance-gas-payments --enable-coin-reservations --enable-accumulators
 

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/reservation_reservation_coin_gas.move
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/reservation_reservation_coin_gas.move
@@ -1,0 +1,41 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Exercises gas smashing for `[AddressBalance, AddressBalance, Coin]` (same
+// address). The two withdrawals share a payment location and are summed
+// into a single entry *before* smashing runs. What smashing then sees is
+// `[AddressBalance(merged), Coin]`, but the snapshot must show only *one*
+// withdrawal-side accumulator event for the merged reservation (not two),
+// confirming that the dedup happens upfront.
+
+//# init --addresses test=0x0 --accounts A B --enable-address-balance-gas-payments --enable-coin-reservations --enable-accumulators
+
+//# view-object 0,0
+
+// Seed A's address balance.
+//# programmable --sender A --inputs 100000000000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::into_balance<sui::sui::SUI>(Result(0));
+//> 2: sui::balance::send_funds<sui::sui::SUI>(Result(1), Input(1));
+
+// Create a SUI coin to be smashed into the (deduped) withdrawal target.
+//# programmable --sender A --inputs 1000000000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+
+//# create-checkpoint
+
+//# view-funds sui::balance::Balance<sui::sui::SUI> A
+
+// Pay with `[AddressBalance, AddressBalance, Coin]`. The two 500M reservations
+// dedup into a single 1B entry. Coin (object 3,0) gets deleted.
+// total_smashed = 1_000_000_000 + 1_000_000_000 = 2_000_000_000;
+// deposit-back = 1_000_000_000.
+//# programmable --sender A --gas-budget 1000000000 --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(500000000) --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(500000000) --gas-payment object(3,0) --inputs 100000 @B
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+
+//# create-checkpoint
+
+// Final balance reflects: start + 1B deposit-back - net gas charge.
+//# view-funds sui::balance::Balance<sui::sui::SUI> A

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/reservation_reservation_coin_gas.snap
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/reservation_reservation_coin_gas.snap
@@ -6,7 +6,7 @@ processed 9 tasks
 init:
 A: object(0,0), B: object(0,1)
 
-task 1, lines 13-15:
+task 1, lines 12-14:
 //# view-object 0,0
 Owner: Account Address ( A )
 Version: 1
@@ -21,7 +21,7 @@ Contents: sui::coin::Coin<sui::sui::SUI> {
     },
 }
 
-task 2, lines 16-21:
+task 2, lines 15-20:
 //# programmable --sender A --inputs 100000000000 @A
 //> 0: SplitCoins(Gas, [Input(0)]);
 //> 1: sui::coin::into_balance<sui::sui::SUI>(Result(0));
@@ -31,7 +31,7 @@ mutated: object(0,0)
 accumulators_written: (object(2,0), A, sui::balance::Balance<sui::sui::SUI>, Merge, 100000000000)
 gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 3, lines 22-24:
+task 3, lines 21-23:
 //# programmable --sender A --inputs 1000000000 @A
 //> 0: SplitCoins(Gas, [Input(0)]);
 //> TransferObjects([Result(0)], Input(1))
@@ -39,15 +39,15 @@ created: object(3,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 4, line 26:
+task 4, line 25:
 //# create-checkpoint
 Checkpoint created: 1
 
-task 5, lines 28-33:
+task 5, lines 27-32:
 //# view-funds sui::balance::Balance<sui::sui::SUI> A
 100000000000
 
-task 6, lines 34-36:
+task 6, lines 33-35:
 //# programmable --sender A --gas-budget 1000000000 --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(500000000) --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(500000000) --gas-payment object(3,0) --inputs 100000 @B
 //> 0: SplitCoins(Gas, [Input(0)]);
 //> TransferObjects([Result(0)], Input(1))
@@ -56,10 +56,10 @@ deleted: object(3,0)
 accumulators_written: (object(2,0), A, sui::balance::Balance<sui::sui::SUI>, Merge, 998890120)
 gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 7, lines 38-40:
+task 7, lines 37-39:
 //# create-checkpoint
 Checkpoint created: 2
 
-task 8, line 41:
+task 8, line 40:
 //# view-funds sui::balance::Balance<sui::sui::SUI> A
 100998890120

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/reservation_reservation_coin_gas.snap
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/reservation_reservation_coin_gas.snap
@@ -1,0 +1,65 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 9 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 13-15:
+//# view-object 0,0
+Owner: Account Address ( A )
+Version: 1
+Contents: sui::coin::Coin<sui::sui::SUI> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(0,0),
+        },
+    },
+    balance: sui::balance::Balance<sui::sui::SUI> {
+        value: 300000000000000u64,
+    },
+}
+
+task 2, lines 16-21:
+//# programmable --sender A --inputs 100000000000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::into_balance<sui::sui::SUI>(Result(0));
+//> 2: sui::balance::send_funds<sui::sui::SUI>(Result(1), Input(1));
+// Create a SUI coin to be smashed into the (deduped) withdrawal target.
+mutated: object(0,0)
+accumulators_written: (object(2,0), A, sui::balance::Balance<sui::sui::SUI>, Merge, 100000000000)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, lines 22-24:
+//# programmable --sender A --inputs 1000000000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+created: object(3,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 4, line 26:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 5, lines 28-33:
+//# view-funds sui::balance::Balance<sui::sui::SUI> A
+100000000000
+
+task 6, lines 34-36:
+//# programmable --sender A --gas-budget 1000000000 --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(500000000) --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(500000000) --gas-payment object(3,0) --inputs 100000 @B
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+created: object(6,0)
+deleted: object(3,0)
+accumulators_written: (object(2,0), A, sui::balance::Balance<sui::sui::SUI>, Merge, 998890120)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 7, lines 38-40:
+//# create-checkpoint
+Checkpoint created: 2
+
+task 8, line 41:
+//# view-funds sui::balance::Balance<sui::sui::SUI> A
+100998890120

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/send_funds_gas_to_random.move
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/send_funds_gas_to_random.move
@@ -1,0 +1,51 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Unsponsored tx, sender A pays with `[AB(A), Coin]`, workload sends the
+// ephemeral gas coin's value to a random third party (C). The reservation
+// and the secondary coin's value both flow through the smash to C's AB via
+// `send_funds`; the override then redirects the gas charge to AB(C).
+// Expected:
+//   - A's AB: net change is -reservation. The deposit-back Merge from smash
+//     (+coin_value) is offset by a Split of -total_smashed at gas
+//     finalization, leaving net -reservation.
+//   - C's AB: net change is +total_smashed - net_gas. Receives the ephemeral
+//     via send_funds (Merge total_smashed) and is charged gas via the
+//     override (Split net_gas).
+//   - secondary coin: deleted.
+// Combined: A sends reservation + coin_value to C through smash+send_funds;
+// C nets out paying the gas.
+
+//# init --addresses test=0x0 --accounts A B C --enable-address-balance-gas-payments --enable-coin-reservations --enable-accumulators
+
+// Seed A's address balance.
+//# programmable --sender A --inputs 100000000000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::into_balance<sui::sui::SUI>(Result(0));
+//> 2: sui::balance::send_funds<sui::sui::SUI>(Result(1), Input(1));
+
+// Create a 1B coin owned by A -- secondary in the smash.
+//# programmable --sender A --inputs 1000000000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+
+//# create-checkpoint
+
+//# view-funds sui::balance::Balance<sui::sui::SUI> A
+
+//# view-funds sui::balance::Balance<sui::sui::SUI> C
+
+// Pay with [AB(500M), Coin(1B)]; send_funds(Gas, @C). C is a random third party.
+//# programmable --sender A --gas-budget 500000000 --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(500000000) --gas-payment object(2,0) --inputs @C
+//> sui::coin::send_funds<sui::sui::SUI>(Gas, Input(0))
+
+//# create-checkpoint
+
+// A's AB ends up with just the deposit-back from the deleted secondary coin
+// (no gas charge against A).
+//# view-funds sui::balance::Balance<sui::sui::SUI> A
+
+// C's AB receives the ephemeral value and is debited gas via the override.
+//# view-funds sui::balance::Balance<sui::sui::SUI> C
+
+//# view-object 2,0

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/send_funds_gas_to_random.snap
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/send_funds_gas_to_random.snap
@@ -1,0 +1,60 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 11 tasks
+
+init:
+A: object(0,0), B: object(0,1), C: object(0,2)
+
+task 1, lines 22-27:
+//# programmable --sender A --inputs 100000000000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::into_balance<sui::sui::SUI>(Result(0));
+//> 2: sui::balance::send_funds<sui::sui::SUI>(Result(1), Input(1));
+// Create a 1B coin owned by A -- secondary in the smash.
+mutated: object(0,0)
+accumulators_written: (object(1,0), A, sui::balance::Balance<sui::sui::SUI>, Merge, 100000000000)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 28-30:
+//# programmable --sender A --inputs 1000000000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 3, line 32:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 4, line 34:
+//# view-funds sui::balance::Balance<sui::sui::SUI> A
+100000000000
+
+task 5, lines 36-38:
+//# view-funds sui::balance::Balance<sui::sui::SUI> C
+No funds accumulator object found
+
+task 6, lines 39-40:
+//# programmable --sender A --gas-budget 500000000 --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(500000000) --gas-payment object(2,0) --inputs @C
+//> sui::coin::send_funds<sui::sui::SUI>(Gas, Input(0))
+deleted: object(2,0)
+accumulators_written: (object(1,0), A, sui::balance::Balance<sui::sui::SUI>, Split, 500000000), (object(6,0), C, sui::balance::Balance<sui::sui::SUI>, Merge, 1499978120)
+gas summary: computation_cost: 1000000, storage_cost: 0,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 7, lines 42-45:
+//# create-checkpoint
+Checkpoint created: 2
+
+task 8, lines 46-48:
+//# view-funds sui::balance::Balance<sui::sui::SUI> A
+99500000000
+
+task 9, line 49:
+//# view-funds sui::balance::Balance<sui::sui::SUI> C
+1499978120
+
+task 10, line 51:
+//# view-object 2,0
+No object at id 2,0

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/send_funds_gas_to_random_oog.move
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/send_funds_gas_to_random_oog.move
@@ -1,0 +1,54 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Unsponsored tx, sender A pays with `[AB(A), Coin]`, workload sends Gas to
+// a random third party (C) and also creates a large object that blows
+// storage. On OOG, reset drops execution writes (including the send_funds
+// transfer) and re-smash undoes the override. The gas charge falls back to
+// A's AB (the original smash-target location); C is not charged.
+
+//# init --addresses test=0x0 --accounts A B C --enable-address-balance-gas-payments --enable-coin-reservations --enable-accumulators
+
+//# publish
+module test::big;
+public struct W has key, store { id: UID, data: vector<u8> }
+public fun make(size: u64, ctx: &mut TxContext) {
+    let mut data = vector[];
+    let mut i = 0;
+    while (i < size) { vector::push_back(&mut data, 0u8); i = i + 1 };
+    sui::transfer::public_transfer(W { id: object::new(ctx), data }, ctx.sender());
+}
+
+// Seed A's address balance.
+//# programmable --sender A --inputs 100000000000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::into_balance<sui::sui::SUI>(Result(0));
+//> 2: sui::balance::send_funds<sui::sui::SUI>(Result(1), Input(1));
+
+// Create a 1B secondary coin owned by A.
+//# programmable --sender A --inputs 1000000000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+
+//# create-checkpoint
+
+// Pay with [AB(500M), Coin(1B)]; workload makes a big W then send_funds(Gas, @C).
+//# programmable --sender A --gas-budget 5000000 --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(500000000) --gas-payment object(3,0) --inputs 10000 @C
+//> 0: test::big::make(Input(0));
+//> sui::coin::send_funds<sui::sui::SUI>(Gas, Input(1))
+
+//# create-checkpoint
+
+// A's AB: charged the post-reset net gas (the override was undone, so the
+// original smash-target AB(A) pays). The secondary coin was deleted during
+// smashing -- that side-effect persists across reset, so the coin's value
+// deposit-back is still emitted. Net to A: +deposit_back - net_gas.
+//# view-funds sui::balance::Balance<sui::sui::SUI> A
+
+// C's AB should not exist: send_funds was rolled back and override was
+// undone, so no funds were ever credited to C and no charge fell on C.
+//# view-funds sui::balance::Balance<sui::sui::SUI> C
+
+// Secondary coin should still be deleted (smashing happens before execution
+// and is preserved across reset/re-smash).
+//# view-object 3,0

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/send_funds_gas_to_random_oog.snap
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/send_funds_gas_to_random_oog.snap
@@ -4,25 +4,25 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 processed 10 tasks
 
 init:
-A: object(0,0), B: object(0,1)
+A: object(0,0), B: object(0,1), C: object(0,2)
 
-task 1, lines 12-23:
+task 1, lines 12-22:
 //# publish
 created: object(1,0)
-mutated: object(0,2)
-gas summary: computation_cost: 1000000, storage_cost: 5502400,  storage_rebate: 0, non_refundable_storage_fee: 0
+mutated: object(0,3)
+gas summary: computation_cost: 1000000, storage_cost: 5722800,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 2, lines 24-29:
+task 2, lines 23-28:
 //# programmable --sender A --inputs 100000000000 @A
 //> 0: SplitCoins(Gas, [Input(0)]);
 //> 1: sui::coin::into_balance<sui::sui::SUI>(Result(0));
 //> 2: sui::balance::send_funds<sui::sui::SUI>(Result(1), Input(1));
-// Create a coin to be smashed into the withdrawal target.
+// Create a 1B secondary coin owned by A.
 mutated: object(0,0)
 accumulators_written: (object(2,0), A, sui::balance::Balance<sui::sui::SUI>, Merge, 100000000000)
 gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 3, lines 30-32:
+task 3, lines 29-31:
 //# programmable --sender A --inputs 1000000000 @A
 //> 0: SplitCoins(Gas, [Input(0)]);
 //> TransferObjects([Result(0)], Input(1))
@@ -30,28 +30,29 @@ created: object(3,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 4, line 34:
+task 4, lines 33-35:
 //# create-checkpoint
 Checkpoint created: 1
 
-task 5, lines 36-40:
-//# view-funds sui::balance::Balance<sui::sui::SUI> A
-100000000000
-
-task 6, lines 41-42:
-//# programmable --sender A --gas-budget 5000000 --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(5000000) --gas-payment object(3,0) --inputs 100
-//> test::oog::make(Input(0))
+task 5, lines 36-38:
+//# programmable --sender A --gas-budget 5000000 --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(500000000) --gas-payment object(3,0) --inputs 10000 @C
+//> 0: test::big::make(Input(0));
+//> sui::coin::send_funds<sui::sui::SUI>(Gas, Input(1))
 Error: Transaction Effects Status: Insufficient Gas.
 Debug of error: InsufficientGas at command None
 
-task 7, line 44:
+task 6, lines 40-45:
 //# create-checkpoint
 Checkpoint created: 2
 
-task 8, lines 46-49:
+task 7, lines 46-49:
 //# view-funds sui::balance::Balance<sui::sui::SUI> A
-100999978120
+100998178120
 
-task 9, line 50:
+task 8, lines 50-53:
+//# view-funds sui::balance::Balance<sui::sui::SUI> C
+No funds accumulator object found
+
+task 9, line 54:
 //# view-object 3,0
 No object at id 3,0

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/send_funds_gas_to_sender.move
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/send_funds_gas_to_sender.move
@@ -1,16 +1,11 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-// Esoteric override edge case: `[AddressBalance(A), Coin]` smash target =
-// AB, secondary Coin gets deleted; then `send_funds(Gas, @A)` transfers the
-// ephemeral gas coin's value back into A's address balance. At gas
-// finalization, the gas-charge location is overridden to the recipient's
-// address balance -- which is the SAME address as the original payer, so
-// the override is logically a no-op. This test pins down that the gas
-// accounting still settles correctly.
-// Compared to the existing pure-address-balance send_funds-to-self test,
-// this adds a secondary Coin to the smash so the secondary-coin deletion
-// and Merge deposit-back paths run too.
+// Unsponsored tx, sender A pays with `[AB(A), Coin]`, workload
+// `send_funds(Gas, @A)` sends the ephemeral gas coin's value back into A's
+// own address balance. At gas finalization, the gas-charge location is
+// overridden to the recipient's AB -- the same address as the original
+// payer, so the override is logically a no-op.
 
 //# init --addresses test=0x0 --accounts A --enable-address-balance-gas-payments --enable-coin-reservations --enable-accumulators
 

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/send_funds_gas_to_sender.snap
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/send_funds_gas_to_sender.snap
@@ -6,7 +6,7 @@ processed 10 tasks
 init:
 A: object(0,0)
 
-task 1, lines 18-23:
+task 1, lines 13-18:
 //# programmable --sender A --inputs 100000000000 @A
 //> 0: SplitCoins(Gas, [Input(0)]);
 //> 1: sui::coin::into_balance<sui::sui::SUI>(Result(0));
@@ -16,7 +16,7 @@ mutated: object(0,0)
 accumulators_written: (object(1,0), A, sui::balance::Balance<sui::sui::SUI>, Merge, 100000000000)
 gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 2, lines 24-26:
+task 2, lines 19-21:
 //# programmable --sender A --inputs 1000000000 @A
 //> 0: SplitCoins(Gas, [Input(0)]);
 //> TransferObjects([Result(0)], Input(1))
@@ -24,15 +24,15 @@ created: object(2,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 3, line 28:
+task 3, line 23:
 //# create-checkpoint
 Checkpoint created: 1
 
-task 4, line 30:
+task 4, line 25:
 //# view-funds sui::balance::Balance<sui::sui::SUI> A
 100000000000
 
-task 5, lines 32-36:
+task 5, lines 27-31:
 //# view-object 2,0
 Owner: Account Address ( A )
 Version: 3
@@ -47,21 +47,21 @@ Contents: sui::coin::Coin<sui::sui::SUI> {
     },
 }
 
-task 6, lines 37-38:
+task 6, lines 32-33:
 //# programmable --sender A --gas-budget 500000000 --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(500000000) --gas-payment object(2,0) --inputs @A
 //> sui::coin::send_funds<sui::sui::SUI>(Gas, Input(0))
 deleted: object(2,0)
 accumulators_written: (object(1,0), A, sui::balance::Balance<sui::sui::SUI>, Merge, 999978120)
 gas summary: computation_cost: 1000000, storage_cost: 0,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 7, lines 40-45:
+task 7, lines 35-40:
 //# create-checkpoint
 Checkpoint created: 2
 
-task 8, line 46:
+task 8, line 41:
 //# view-funds sui::balance::Balance<sui::sui::SUI> A
 100999978120
 
-task 9, line 48:
+task 9, line 43:
 //# view-object 2,0
 No object at id 2,0

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/send_funds_gas_to_sponsor.move
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/send_funds_gas_to_sponsor.move
@@ -1,0 +1,27 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Sponsored tx, sponsor's coin pays gas, workload sends the gas coin's
+// value to the sponsor's address balance via `send_funds`. The gas-charge
+// override redirects the final charge from sponsor's Coin to sponsor's AB.
+// Net: B's AB ends with +coin_value - net_gas; A is untouched.
+
+//# init --addresses test=0x0 --accounts A B --enable-address-balance-gas-payments --enable-accumulators
+
+// Sponsored tx: sender = A, sponsor = B. Default gas payment uses B's gas
+// coin (object 0,1). Workload `send_funds(Gas, @B)` transfers the gas coin
+// to B's AB during execution; `finish_gas_coin` then overrides
+// gas-charge-location to AB(B).
+//# programmable --sender A --sponsor B --inputs @B
+//> sui::coin::send_funds<sui::sui::SUI>(Gas, Input(0))
+
+//# create-checkpoint
+
+// Sponsor B's gas coin should be deleted (consumed by send_funds).
+//# view-object 0,1
+
+// B's AB receives a single net Merge = original_coin_value - net_gas.
+// A's AB is unchanged (no accumulator object for A exists).
+//# view-funds sui::balance::Balance<sui::sui::SUI> B
+
+//# view-funds sui::balance::Balance<sui::sui::SUI> A

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/send_funds_gas_to_sponsor.snap
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/send_funds_gas_to_sponsor.snap
@@ -1,0 +1,30 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 6 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 15-16:
+//# programmable --sender A --sponsor B --inputs @B
+//> sui::coin::send_funds<sui::sui::SUI>(Gas, Input(0))
+deleted: object(0,1)
+accumulators_written: (object(1,0), B, sui::balance::Balance<sui::sui::SUI>, Merge, 299999999000000)
+gas summary: computation_cost: 1000000, storage_cost: 0,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 18-20:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 3, lines 21-24:
+//# view-object 0,1
+No object at id 0,1
+
+task 4, line 25:
+//# view-funds sui::balance::Balance<sui::sui::SUI> B
+299999999000000
+
+task 5, line 27:
+//# view-funds sui::balance::Balance<sui::sui::SUI> A
+No funds accumulator object found

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/send_funds_gas_to_sponsor_oog.move
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/send_funds_gas_to_sponsor_oog.move
@@ -1,0 +1,38 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Sponsored tx, sponsor's coin pays gas, workload sends Gas to sponsor's
+// address balance and creates a large object that blows storage. On OOG,
+// reset drops execution writes (including the send_funds transfer) and
+// re-smash undoes the override. The gas charge falls back to the original
+// smash-target location -- sponsor's Coin -- not the recipient's AB.
+
+//# init --addresses test=0x0 --accounts A B --enable-address-balance-gas-payments --enable-accumulators
+
+//# publish
+module test::big;
+public struct W has key, store { id: UID, data: vector<u8> }
+public fun make(size: u64, ctx: &mut TxContext) {
+    let mut data = vector[];
+    let mut i = 0;
+    while (i < size) { vector::push_back(&mut data, 0u8); i = i + 1 };
+    sui::transfer::public_transfer(W { id: object::new(ctx), data }, ctx.sender());
+}
+
+// Sponsored tx with tight budget. Workload makes a big W (storage OOG) then
+// send_funds(Gas, @B). Sponsor B's coin (object 0,1) is the gas payment.
+//# programmable --sender A --sponsor B --gas-budget 5000000 --inputs 10000 @B
+//> 0: test::big::make(Input(0));
+//> sui::coin::send_funds<sui::sui::SUI>(Gas, Input(1))
+
+//# create-checkpoint
+
+// Sponsor B's gas coin should still exist (transfer rolled back), owned by
+// B, with value reduced by the post-reset net gas.
+//# view-object 0,1
+
+// B's AB should not have been created (send_funds and override rolled back).
+//# view-funds sui::balance::Balance<sui::sui::SUI> B
+
+// A's AB should not exist either (A never had one and was never charged).
+//# view-funds sui::balance::Balance<sui::sui::SUI> A

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/send_funds_gas_to_sponsor_oog.snap
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/send_funds_gas_to_sponsor_oog.snap
@@ -1,0 +1,47 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 7 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 12-23:
+//# publish
+created: object(1,0)
+mutated: object(0,2)
+gas summary: computation_cost: 1000000, storage_cost: 5722800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 24-26:
+//# programmable --sender A --sponsor B --gas-budget 5000000 --inputs 10000 @B
+//> 0: test::big::make(Input(0));
+//> sui::coin::send_funds<sui::sui::SUI>(Gas, Input(1))
+Error: Transaction Effects Status: Insufficient Gas.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InsufficientGas, source: None, command: None } }
+
+task 3, lines 28-31:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 4, lines 32-34:
+//# view-object 0,1
+Owner: Account Address ( B )
+Version: 2
+Contents: sui::coin::Coin<sui::sui::SUI> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(0,1),
+        },
+    },
+    balance: sui::balance::Balance<sui::sui::SUI> {
+        value: 299999996212000u64,
+    },
+}
+
+task 5, lines 35-37:
+//# view-funds sui::balance::Balance<sui::sui::SUI> B
+No funds accumulator object found
+
+task 6, line 38:
+//# view-funds sui::balance::Balance<sui::sui::SUI> A
+No funds accumulator object found

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/smash_lamport_timestamp.move
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/smash_lamport_timestamp.move
@@ -1,16 +1,14 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-// Verifies that a `[AddressBalance, Coin]` smash respects the lamport-
-// timestamp rule across the FULL input set, including the secondary Coin
-// (which is deleted during smashing). All mutable inputs end up at
-// max(input versions) + 1, even when that maximum is carried by the
-// to-be-deleted secondary.
+// Lamport-timestamp rule on `[AddressBalance, Coin]` smash: mutable inputs
+// end up at max(input versions) + 1 across the full input set, including
+// the secondary Coin (which is deleted during smashing).
 // Setup:
-//   - Three W mutable inputs created early at low versions (K).
-//   - A Coin X created and then bumped (via being the gas object in
-//     several minimal txs) to a high version C >> K.
-//   - Final tx smashes `[withdraw, X]` and force-mutates W1, W2, W3.
+//   - three W mutable inputs created early at low versions (call them K),
+//   - one Coin X created and then bumped (via being the gas object in
+//     several minimal txs) to a high version C >> K,
+//   - final tx smashes `[withdraw, X]` and force-mutates W1, W2, W3.
 // Expected: post-tx versions of W1, W2, W3 all equal C + 1 (not K + 1),
 // confirming X's pre-tx version is folded into the tx's lamport timestamp
 // even though X itself is deleted.
@@ -30,7 +28,7 @@ public fun make(ctx: &mut TxContext) {
 //> 1: sui::coin::into_balance<sui::sui::SUI>(Result(0));
 //> 2: sui::balance::send_funds<sui::sui::SUI>(Result(1), Input(1));
 
-// Create three small W mutable inputs early so they end up at LOW versions.
+// Create three small W mutable inputs early so they end up at low versions.
 //# run test::obj::make --sender A
 
 //# run test::obj::make --sender A
@@ -57,7 +55,7 @@ public fun make(ctx: &mut TxContext) {
 
 //# create-checkpoint
 
-// Pre-state: W1, W2, W3 are at low versions; X is at a HIGHER version due to
+// Pre-state: W1, W2, W3 are at low versions; X is at a higher version due to
 // the bumping above.
 //# view-object 3,0 --hide-contents
 
@@ -76,7 +74,7 @@ public fun make(ctx: &mut TxContext) {
 
 //# create-checkpoint
 
-// Post-state: W1, W2, W3 should ALL be at the SAME post-tx version, which
+// Post-state: W1, W2, W3 should all be at the same post-tx version, which
 // equals (X's pre-tx version) + 1 -- not (W's pre-tx version + 1).
 //# view-object 3,0 --hide-contents
 

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/smash_lamport_timestamp.move
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/smash_lamport_timestamp.move
@@ -1,0 +1,85 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Verifies that a `[AddressBalance, Coin]` smash respects the lamport-
+// timestamp rule across the FULL input set, including the secondary Coin
+// (which is deleted during smashing). All mutable inputs end up at
+// max(input versions) + 1, even when that maximum is carried by the
+// to-be-deleted secondary.
+// Setup:
+//   - Three W mutable inputs created early at low versions (K).
+//   - A Coin X created and then bumped (via being the gas object in
+//     several minimal txs) to a high version C >> K.
+//   - Final tx smashes `[withdraw, X]` and force-mutates W1, W2, W3.
+// Expected: post-tx versions of W1, W2, W3 all equal C + 1 (not K + 1),
+// confirming X's pre-tx version is folded into the tx's lamport timestamp
+// even though X itself is deleted.
+
+//# init --addresses test=0x0 --accounts A --enable-address-balance-gas-payments --enable-coin-reservations --enable-accumulators
+
+//# publish
+module test::obj;
+public struct W has key, store { id: UID }
+public fun make(ctx: &mut TxContext) {
+    sui::transfer::public_transfer(W { id: object::new(ctx) }, ctx.sender());
+}
+
+// Seed A's AB so we have funds for the final tx.
+//# programmable --sender A --inputs 100000000000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::into_balance<sui::sui::SUI>(Result(0));
+//> 2: sui::balance::send_funds<sui::sui::SUI>(Result(1), Input(1));
+
+// Create three small W mutable inputs early so they end up at LOW versions.
+//# run test::obj::make --sender A
+
+//# run test::obj::make --sender A
+
+//# run test::obj::make --sender A
+
+// Create Coin X (split off from A's default gas coin).
+//# programmable --sender A --inputs 1000000000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+
+// Bump X's version by using it as the gas object in three minimal txs.
+//# programmable --sender A --gas-budget 5000000 --gas-payment object(6,0) --inputs 1 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+
+//# programmable --sender A --gas-budget 5000000 --gas-payment object(6,0) --inputs 1 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+
+//# programmable --sender A --gas-budget 5000000 --gas-payment object(6,0) --inputs 1 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+
+//# create-checkpoint
+
+// Pre-state: W1, W2, W3 are at low versions; X is at a HIGHER version due to
+// the bumping above.
+//# view-object 3,0 --hide-contents
+
+//# view-object 4,0 --hide-contents
+
+//# view-object 5,0 --hide-contents
+
+//# view-object 6,0 --hide-contents
+
+// Final tx: smash `[withdraw, X]` with W1, W2, W3 as mutable inputs.
+// X is the secondary and gets deleted during smashing. Lamport timestamp
+// for this tx = max(W*, X, AB accumulator) + 1 = X.version + 1 (since X is
+// the highest).
+//# programmable --sender A --gas-budget 5000000 --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(5000000) --gas-payment object(6,0) --inputs object(3,0) object(4,0) object(5,0) @A
+//> TransferObjects([Input(0), Input(1), Input(2)], Input(3))
+
+//# create-checkpoint
+
+// Post-state: W1, W2, W3 should ALL be at the SAME post-tx version, which
+// equals (X's pre-tx version) + 1 -- not (W's pre-tx version + 1).
+//# view-object 3,0 --hide-contents
+
+//# view-object 4,0 --hide-contents
+
+//# view-object 5,0 --hide-contents

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/smash_lamport_timestamp.snap
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/smash_lamport_timestamp.snap
@@ -1,0 +1,132 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 20 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 20-27:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 5152800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 28-33:
+//# programmable --sender A --inputs 100000000000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::into_balance<sui::sui::SUI>(Result(0));
+//> 2: sui::balance::send_funds<sui::sui::SUI>(Result(1), Input(1));
+// Create three small W mutable inputs early so they end up at LOW versions.
+mutated: object(0,0)
+accumulators_written: (object(2,0), A, sui::balance::Balance<sui::sui::SUI>, Merge, 100000000000)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, line 34:
+//# run test::obj::make --sender A
+created: object(3,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2211600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 4, line 36:
+//# run test::obj::make --sender A
+created: object(4,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2211600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 5, lines 38-40:
+//# run test::obj::make --sender A
+created: object(5,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2211600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 6, lines 41-45:
+//# programmable --sender A --inputs 1000000000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+// Bump X's version by using it as the gas object in three minimal txs.
+created: object(6,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 7, lines 46-48:
+//# programmable --sender A --gas-budget 5000000 --gas-payment object(6,0) --inputs 1 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+created: object(7,0)
+mutated: object(6,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 8, lines 50-52:
+//# programmable --sender A --gas-budget 5000000 --gas-payment object(6,0) --inputs 1 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+created: object(8,0)
+mutated: object(6,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 9, lines 54-56:
+//# programmable --sender A --gas-budget 5000000 --gas-payment object(6,0) --inputs 1 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+created: object(9,0)
+mutated: object(6,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 10, lines 58-61:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 11, line 62:
+//# view-object 3,0 --hide-contents
+Owner: Account Address ( A )
+Version: 3
+Type: test::obj::W
+
+task 12, line 64:
+//# view-object 4,0 --hide-contents
+Owner: Account Address ( A )
+Version: 4
+Type: test::obj::W
+
+task 13, line 66:
+//# view-object 5,0 --hide-contents
+Owner: Account Address ( A )
+Version: 5
+Type: test::obj::W
+
+task 14, lines 68-73:
+//# view-object 6,0 --hide-contents
+Owner: Account Address ( A )
+Version: 9
+Type: sui::coin::Coin<sui::sui::SUI>
+
+task 15, lines 74-75:
+//# programmable --sender A --gas-budget 5000000 --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(5000000) --gas-payment object(6,0) --inputs object(3,0) object(4,0) object(5,0) @A
+//> TransferObjects([Input(0), Input(1), Input(2)], Input(3))
+mutated: object(3,0), object(4,0), object(5,0)
+deleted: object(6,0)
+accumulators_written: (object(2,0), A, sui::balance::Balance<sui::sui::SUI>, Merge, 993947769)
+gas summary: computation_cost: 1000000, storage_cost: 3670800,  storage_rebate: 4612212, non_refundable_storage_fee: 46588
+
+task 16, lines 77-80:
+//# create-checkpoint
+Checkpoint created: 2
+
+task 17, line 81:
+//# view-object 3,0 --hide-contents
+Owner: Account Address ( A )
+Version: 10
+Type: test::obj::W
+
+task 18, line 83:
+//# view-object 4,0 --hide-contents
+Owner: Account Address ( A )
+Version: 10
+Type: test::obj::W
+
+task 19, line 85:
+//# view-object 5,0 --hide-contents
+Owner: Account Address ( A )
+Version: 10
+Type: test::obj::W

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/smash_lamport_timestamp.snap
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/smash_lamport_timestamp.snap
@@ -6,41 +6,41 @@ processed 20 tasks
 init:
 A: object(0,0)
 
-task 1, lines 20-27:
+task 1, lines 18-25:
 //# publish
 created: object(1,0)
 mutated: object(0,1)
 gas summary: computation_cost: 1000000, storage_cost: 5152800,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 2, lines 28-33:
+task 2, lines 26-31:
 //# programmable --sender A --inputs 100000000000 @A
 //> 0: SplitCoins(Gas, [Input(0)]);
 //> 1: sui::coin::into_balance<sui::sui::SUI>(Result(0));
 //> 2: sui::balance::send_funds<sui::sui::SUI>(Result(1), Input(1));
-// Create three small W mutable inputs early so they end up at LOW versions.
+// Create three small W mutable inputs early so they end up at low versions.
 mutated: object(0,0)
 accumulators_written: (object(2,0), A, sui::balance::Balance<sui::sui::SUI>, Merge, 100000000000)
 gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 3, line 34:
+task 3, line 32:
 //# run test::obj::make --sender A
 created: object(3,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 2211600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 4, line 36:
+task 4, line 34:
 //# run test::obj::make --sender A
 created: object(4,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 2211600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 5, lines 38-40:
+task 5, lines 36-38:
 //# run test::obj::make --sender A
 created: object(5,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 2211600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 6, lines 41-45:
+task 6, lines 39-43:
 //# programmable --sender A --inputs 1000000000 @A
 //> 0: SplitCoins(Gas, [Input(0)]);
 //> TransferObjects([Result(0)], Input(1))
@@ -49,7 +49,7 @@ created: object(6,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 7, lines 46-48:
+task 7, lines 44-46:
 //# programmable --sender A --gas-budget 5000000 --gas-payment object(6,0) --inputs 1 @A
 //> 0: SplitCoins(Gas, [Input(0)]);
 //> TransferObjects([Result(0)], Input(1))
@@ -57,7 +57,7 @@ created: object(7,0)
 mutated: object(6,0)
 gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 8, lines 50-52:
+task 8, lines 48-50:
 //# programmable --sender A --gas-budget 5000000 --gas-payment object(6,0) --inputs 1 @A
 //> 0: SplitCoins(Gas, [Input(0)]);
 //> TransferObjects([Result(0)], Input(1))
@@ -65,7 +65,7 @@ created: object(8,0)
 mutated: object(6,0)
 gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 9, lines 54-56:
+task 9, lines 52-54:
 //# programmable --sender A --gas-budget 5000000 --gas-payment object(6,0) --inputs 1 @A
 //> 0: SplitCoins(Gas, [Input(0)]);
 //> TransferObjects([Result(0)], Input(1))
@@ -73,35 +73,35 @@ created: object(9,0)
 mutated: object(6,0)
 gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 10, lines 58-61:
+task 10, lines 56-59:
 //# create-checkpoint
 Checkpoint created: 1
 
-task 11, line 62:
+task 11, line 60:
 //# view-object 3,0 --hide-contents
 Owner: Account Address ( A )
 Version: 3
 Type: test::obj::W
 
-task 12, line 64:
+task 12, line 62:
 //# view-object 4,0 --hide-contents
 Owner: Account Address ( A )
 Version: 4
 Type: test::obj::W
 
-task 13, line 66:
+task 13, line 64:
 //# view-object 5,0 --hide-contents
 Owner: Account Address ( A )
 Version: 5
 Type: test::obj::W
 
-task 14, lines 68-73:
+task 14, lines 66-71:
 //# view-object 6,0 --hide-contents
 Owner: Account Address ( A )
 Version: 9
 Type: sui::coin::Coin<sui::sui::SUI>
 
-task 15, lines 74-75:
+task 15, lines 72-73:
 //# programmable --sender A --gas-budget 5000000 --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(5000000) --gas-payment object(6,0) --inputs object(3,0) object(4,0) object(5,0) @A
 //> TransferObjects([Input(0), Input(1), Input(2)], Input(3))
 mutated: object(3,0), object(4,0), object(5,0)
@@ -109,23 +109,23 @@ deleted: object(6,0)
 accumulators_written: (object(2,0), A, sui::balance::Balance<sui::sui::SUI>, Merge, 993947769)
 gas summary: computation_cost: 1000000, storage_cost: 3670800,  storage_rebate: 4612212, non_refundable_storage_fee: 46588
 
-task 16, lines 77-80:
+task 16, lines 75-78:
 //# create-checkpoint
 Checkpoint created: 2
 
-task 17, line 81:
+task 17, line 79:
 //# view-object 3,0 --hide-contents
 Owner: Account Address ( A )
 Version: 10
 Type: test::obj::W
 
-task 18, line 83:
+task 18, line 81:
 //# view-object 4,0 --hide-contents
 Owner: Account Address ( A )
 Version: 10
 Type: test::obj::W
 
-task 19, line 85:
+task 19, line 83:
 //# view-object 5,0 --hide-contents
 Owner: Account Address ( A )
 Version: 10

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/smash_order_comparison.move
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/smash_order_comparison.move
@@ -1,27 +1,27 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-// Paired comparison: `[Coin, AddressBalance]` vs `[AddressBalance, Coin]` with
-// identical coin sizes, identical reservations, identical workloads, and
-// identical pre-state. Exposes the smash-order asymmetry that's otherwise
-// obscured by varying setups:
-//   - `[Coin, AB]`: the smash-target coin is MUTATED. Storage cost includes
-//     its re-storage AND any new objects created during execution. Storage
-//     rebate refunds the coin's pre-existing rebate. Net storage gas ~ high.
-//     The reservation lands in the coin's `balance.value`; AB is debited via
-//     a Split accumulator event.
-//   - `[AB, Coin]`: the secondary coin is DELETED. Storage cost only counts
-//     newly created objects. The deleted coin's storage rebate refunds in
-//     full with no offsetting re-storage. Net storage gas ~ low. The coin's
-//     balance VALUE flows back into AB via a Merge accumulator event; the
+// Paired comparison of `[Coin, AddressBalance]` vs `[AddressBalance, Coin]`
+// with identical coin sizes, reservations, workloads, and pre-state.
+// Exposes the smash-order asymmetry:
+//   - `[Coin, AB]`: smash-target coin is mutated. Storage cost includes its
+//     re-storage plus any new objects created during execution; rebate
+//     refunds the coin's pre-existing rebate; net storage gas is high. The
+//     reservation lands in the coin's `balance.value`; AB is debited via a
+//     Split accumulator event.
+//   - `[AB, Coin]`: the secondary coin is deleted. Storage cost only counts
+//     newly created objects; the deleted coin's storage rebate refunds in
+//     full with no offsetting re-storage; net storage gas is low. The coin's
+//     balance value flows back into AB via a Merge accumulator event; the
 //     gas charge against AB happens separately.
-// The two senders (A, B) start with identical funded address balances and
-// identical 1_000_000_000 coins; the workload is the same (split 100 MIST
-// off Gas and TransferObjects to self). Anything that differs between the
-// two `gas summary` / `accumulators_written` lines is attributable to the
-// smash order alone.
+// Senders A and B start with identical funded address balances and identical
+// 1_000_000_000 coins; the workload is the same (split 100 MIST off Gas and
+// TransferObjects to a common third party C). Anything differing between
+// the two
+// `gas summary` / `accumulators_written` lines is attributable to smash
+// order alone.
 
-//# init --addresses test=0x0 --accounts A B --enable-address-balance-gas-payments --enable-coin-reservations --enable-accumulators
+//# init --addresses test=0x0 --accounts A B C --enable-address-balance-gas-payments --enable-coin-reservations --enable-accumulators
 
 // Seed A's and B's address balances identically.
 //# programmable --sender A --inputs 100000000000 @A
@@ -57,14 +57,14 @@
 // ===== Case A: smash [Coin, AB] =====
 // Coin (object 3,0, value 1_000_000_000) is the smash target.
 // Reservation = 500_000_000 from A's address balance.
-//# programmable --sender A --gas-budget 500000000 --gas-payment object(3,0) --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(500000000) --inputs 100 @A
+//# programmable --sender A --gas-budget 500000000 --gas-payment object(3,0) --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(500000000) --inputs 100 @C
 //> 0: SplitCoins(Gas, [Input(0)]);
 //> TransferObjects([Result(0)], Input(1))
 
 // ===== Case B: smash [AB, Coin] =====
 // Reservation = 500_000_000 from B's address balance is the smash target.
-// Coin (object 4,0, value 1_000_000_000) is the secondary; will be DELETED.
-//# programmable --sender B --gas-budget 500000000 --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(500000000) --gas-payment object(4,0) --inputs 100 @B
+// Coin (object 4,0, value 1_000_000_000) is the secondary; will be deleted.
+//# programmable --sender B --gas-budget 500000000 --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(500000000) --gas-payment object(4,0) --inputs 100 @C
 //> 0: SplitCoins(Gas, [Input(0)]);
 //> TransferObjects([Result(0)], Input(1))
 

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/smash_order_comparison.move
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/smash_order_comparison.move
@@ -1,0 +1,84 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Paired comparison: `[Coin, AddressBalance]` vs `[AddressBalance, Coin]` with
+// identical coin sizes, identical reservations, identical workloads, and
+// identical pre-state. Exposes the smash-order asymmetry that's otherwise
+// obscured by varying setups:
+//   - `[Coin, AB]`: the smash-target coin is MUTATED. Storage cost includes
+//     its re-storage AND any new objects created during execution. Storage
+//     rebate refunds the coin's pre-existing rebate. Net storage gas ~ high.
+//     The reservation lands in the coin's `balance.value`; AB is debited via
+//     a Split accumulator event.
+//   - `[AB, Coin]`: the secondary coin is DELETED. Storage cost only counts
+//     newly created objects. The deleted coin's storage rebate refunds in
+//     full with no offsetting re-storage. Net storage gas ~ low. The coin's
+//     balance VALUE flows back into AB via a Merge accumulator event; the
+//     gas charge against AB happens separately.
+// The two senders (A, B) start with identical funded address balances and
+// identical 1_000_000_000 coins; the workload is the same (split 100 MIST
+// off Gas and TransferObjects to self). Anything that differs between the
+// two `gas summary` / `accumulators_written` lines is attributable to the
+// smash order alone.
+
+//# init --addresses test=0x0 --accounts A B --enable-address-balance-gas-payments --enable-coin-reservations --enable-accumulators
+
+// Seed A's and B's address balances identically.
+//# programmable --sender A --inputs 100000000000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::into_balance<sui::sui::SUI>(Result(0));
+//> 2: sui::balance::send_funds<sui::sui::SUI>(Result(1), Input(1));
+
+//# programmable --sender B --inputs 100000000000 @B
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::into_balance<sui::sui::SUI>(Result(0));
+//> 2: sui::balance::send_funds<sui::sui::SUI>(Result(1), Input(1));
+
+// Create identical 1_000_000_000 coins, one per sender.
+//# programmable --sender A --inputs 1000000000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+
+//# programmable --sender B --inputs 1000000000 @B
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+
+//# create-checkpoint
+
+// ===== Before state =====
+//# view-funds sui::balance::Balance<sui::sui::SUI> A
+
+//# view-funds sui::balance::Balance<sui::sui::SUI> B
+
+//# view-object 3,0
+
+//# view-object 4,0
+
+// ===== Case A: smash [Coin, AB] =====
+// Coin (object 3,0, value 1_000_000_000) is the smash target.
+// Reservation = 500_000_000 from A's address balance.
+//# programmable --sender A --gas-budget 500000000 --gas-payment object(3,0) --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(500000000) --inputs 100 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+
+// ===== Case B: smash [AB, Coin] =====
+// Reservation = 500_000_000 from B's address balance is the smash target.
+// Coin (object 4,0, value 1_000_000_000) is the secondary; will be DELETED.
+//# programmable --sender B --gas-budget 500000000 --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(500000000) --gas-payment object(4,0) --inputs 100 @B
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+
+//# create-checkpoint
+
+// ===== After state =====
+// A: AB balance dropped by exactly 500M (the Split withdraw event). Coin 3,0
+// is still alive, mutated to hold (1B + 500M - case_A_gas_cost).
+//# view-funds sui::balance::Balance<sui::sui::SUI> A
+
+//# view-object 3,0
+
+// B: AB balance shows (start - 500M + 1B - case_B_gas_cost) = start + 500M
+// minus case_B_gas. Coin 4,0 no longer exists.
+//# view-funds sui::balance::Balance<sui::sui::SUI> B
+
+//# view-object 4,0

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/smash_order_comparison.snap
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/smash_order_comparison.snap
@@ -4,7 +4,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 processed 17 tasks
 
 init:
-A: object(0,0), B: object(0,1)
+A: object(0,0), B: object(0,1), C: object(0,2)
 
 task 1, lines 27-30:
 //# programmable --sender A --inputs 100000000000 @A
@@ -84,19 +84,19 @@ Contents: sui::coin::Coin<sui::sui::SUI> {
 }
 
 task 10, lines 60-66:
-//# programmable --sender A --gas-budget 500000000 --gas-payment object(3,0) --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(500000000) --inputs 100 @A
+//# programmable --sender A --gas-budget 500000000 --gas-payment object(3,0) --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(500000000) --inputs 100 @C
 //> 0: SplitCoins(Gas, [Input(0)]);
 //> TransferObjects([Result(0)], Input(1))
 // ===== Case B: smash [AB, Coin] =====
 // Reservation = 500_000_000 from B's address balance is the smash target.
-// Coin (object 4,0, value 1_000_000_000) is the secondary; will be DELETED.
+// Coin (object 4,0, value 1_000_000_000) is the secondary; will be deleted.
 created: object(10,0)
 mutated: object(3,0)
 accumulators_written: (object(1,0), A, sui::balance::Balance<sui::sui::SUI>, Split, 500000000)
 gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 11, lines 67-69:
-//# programmable --sender B --gas-budget 500000000 --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(500000000) --gas-payment object(4,0) --inputs 100 @B
+//# programmable --sender B --gas-budget 500000000 --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(500000000) --gas-payment object(4,0) --inputs 100 @C
 //> 0: SplitCoins(Gas, [Input(0)]);
 //> TransferObjects([Result(0)], Input(1))
 created: object(11,0)

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/smash_order_comparison.snap
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/smash_order_comparison.snap
@@ -1,0 +1,136 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 17 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 27-30:
+//# programmable --sender A --inputs 100000000000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::into_balance<sui::sui::SUI>(Result(0));
+//> 2: sui::balance::send_funds<sui::sui::SUI>(Result(1), Input(1));
+mutated: object(0,0)
+accumulators_written: (object(1,0), A, sui::balance::Balance<sui::sui::SUI>, Merge, 100000000000)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 32-37:
+//# programmable --sender B --inputs 100000000000 @B
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::into_balance<sui::sui::SUI>(Result(0));
+//> 2: sui::balance::send_funds<sui::sui::SUI>(Result(1), Input(1));
+// Create identical 1_000_000_000 coins, one per sender.
+mutated: object(0,1)
+accumulators_written: (object(2,0), B, sui::balance::Balance<sui::sui::SUI>, Merge, 100000000000)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, lines 38-40:
+//# programmable --sender A --inputs 1000000000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+created: object(3,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 4, lines 42-44:
+//# programmable --sender B --inputs 1000000000 @B
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+created: object(4,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 5, lines 46-48:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 6, line 49:
+//# view-funds sui::balance::Balance<sui::sui::SUI> A
+100000000000
+
+task 7, line 51:
+//# view-funds sui::balance::Balance<sui::sui::SUI> B
+100000000000
+
+task 8, line 53:
+//# view-object 3,0
+Owner: Account Address ( A )
+Version: 3
+Contents: sui::coin::Coin<sui::sui::SUI> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(3,0),
+        },
+    },
+    balance: sui::balance::Balance<sui::sui::SUI> {
+        value: 1000000000u64,
+    },
+}
+
+task 9, lines 55-59:
+//# view-object 4,0
+Owner: Account Address ( B )
+Version: 3
+Contents: sui::coin::Coin<sui::sui::SUI> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(4,0),
+        },
+    },
+    balance: sui::balance::Balance<sui::sui::SUI> {
+        value: 1000000000u64,
+    },
+}
+
+task 10, lines 60-66:
+//# programmable --sender A --gas-budget 500000000 --gas-payment object(3,0) --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(500000000) --inputs 100 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+// ===== Case B: smash [AB, Coin] =====
+// Reservation = 500_000_000 from B's address balance is the smash target.
+// Coin (object 4,0, value 1_000_000_000) is the secondary; will be DELETED.
+created: object(10,0)
+mutated: object(3,0)
+accumulators_written: (object(1,0), A, sui::balance::Balance<sui::sui::SUI>, Split, 500000000)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 11, lines 67-69:
+//# programmable --sender B --gas-budget 500000000 --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(500000000) --gas-payment object(4,0) --inputs 100 @B
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+created: object(11,0)
+deleted: object(4,0)
+accumulators_written: (object(2,0), B, sui::balance::Balance<sui::sui::SUI>, Merge, 998990020)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 12, lines 71-75:
+//# create-checkpoint
+Checkpoint created: 2
+
+task 13, line 76:
+//# view-funds sui::balance::Balance<sui::sui::SUI> A
+99500000000
+
+task 14, lines 78-81:
+//# view-object 3,0
+Owner: Account Address ( A )
+Version: 4
+Contents: sui::coin::Coin<sui::sui::SUI> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(3,0),
+        },
+    },
+    balance: sui::balance::Balance<sui::sui::SUI> {
+        value: 1498002020u64,
+    },
+}
+
+task 15, line 82:
+//# view-funds sui::balance::Balance<sui::sui::SUI> B
+100998990020
+
+task 16, line 84:
+//# view-object 4,0
+No object at id 4,0

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/sponsor_withdraw_rejected.move
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/sponsor_withdraw_rejected.move
@@ -1,0 +1,22 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// A sponsored transaction cannot pay gas via an address-balance withdrawal.
+
+//# init --addresses test=0x0 --accounts A B --enable-address-balance-gas-payments --enable-coin-reservations --enable-accumulators
+
+// Seed B's address balance so a hypothetical sponsor-side withdrawal would
+// have funds available.
+//# programmable --sender B --inputs 100000000000 @B
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::into_balance<sui::sui::SUI>(Result(0));
+//> 2: sui::balance::send_funds<sui::sui::SUI>(Result(1), Input(1));
+
+//# create-checkpoint
+
+// Sponsored tx with withdraw gas payment -- expected to be rejected by
+// validation. The withdraw amount targets B (the sponsor) at the test-runner
+// level, but validation resolves it against A (sender), producing a mismatch.
+//# programmable --sender A --sponsor B --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(500000000) --inputs 100000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/sponsor_withdraw_rejected.snap
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/sponsor_withdraw_rejected.snap
@@ -1,0 +1,26 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 4 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 10-13:
+//# programmable --sender B --inputs 100000000000 @B
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::into_balance<sui::sui::SUI>(Result(0));
+//> 2: sui::balance::send_funds<sui::sui::SUI>(Result(1), Input(1));
+mutated: object(0,1)
+accumulators_written: (object(1,0), B, sui::balance::Balance<sui::sui::SUI>, Merge, 100000000000)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 15-19:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 3, lines 20-22:
+//# programmable --sender A --sponsor B --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(500000000) --inputs 100000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> TransferObjects([Result(0)], Input(1))
+Error: Error checking transaction input objects: Gas object is not an owned object with owner: AddressOwner(@A)

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/storage_oog_charges_full_budget.move
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/storage_oog_charges_full_budget.move
@@ -1,12 +1,12 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-// Exercises the deepest OOG fallback: when even input-object-only storage
-// charging fails (after the usual reset + retry), the engine gives up on
-// charging storage and instead charges the user the FULL gas budget.
+// Deepest OOG fallback: when even input-object-only storage charging fails
+// (after the usual reset + retry), the engine gives up on charging storage
+// and charges the user the full gas budget instead.
 // Strategy: pre-create several large input objects (W containing a big
-// vector<u8>). On the OOG tx, pass them as inputs and TransferObjects them
-// to self, with a tight budget. Re-mutating each input costs a small
+// vector<u8>); on the OOG tx, pass them as inputs and TransferObjects them
+// to self with a tight budget. Re-mutating each input costs a small
 // non-refundable fee on top of the rebate refund. With big-data objects,
 // that non-refundable slice adds up enough that even input-only storage
 // can't be paid, forcing the fallback. The snapshot shows A's address
@@ -69,7 +69,7 @@ public fun make(size: u64, ctx: &mut TxContext) {
 
 // After the OOG fallback, the engine drops all writes from execution but
 // still forces every mutable input to be re-stored (version bump) for
-// safety. All five W's should land on the SAME post-tx version (the tx's
+// safety. All five W's should land on the same post-tx version (the tx's
 // lamport timestamp), even though the workload's TransferObjects was rolled
 // back.
 //# view-object 3,0 --hide-contents

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/storage_oog_charges_full_budget.move
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/storage_oog_charges_full_budget.move
@@ -1,0 +1,83 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Exercises the deepest OOG fallback: when even input-object-only storage
+// charging fails (after the usual reset + retry), the engine gives up on
+// charging storage and instead charges the user the FULL gas budget.
+// Strategy: pre-create several large input objects (W containing a big
+// vector<u8>). On the OOG tx, pass them as inputs and TransferObjects them
+// to self, with a tight budget. Re-mutating each input costs a small
+// non-refundable fee on top of the rebate refund. With big-data objects,
+// that non-refundable slice adds up enough that even input-only storage
+// can't be paid, forcing the fallback. The snapshot shows A's address
+// balance dropping by exactly the budget.
+
+//# init --addresses test=0x0 --accounts A --enable-address-balance-gas-payments --enable-coin-reservations --enable-accumulators
+
+//# publish
+module test::big;
+public struct W has key, store { id: UID, data: vector<u8> }
+public fun make(size: u64, ctx: &mut TxContext) {
+    let mut data = vector[];
+    let mut i = 0;
+    while (i < size) { vector::push_back(&mut data, 0u8); i = i + 1 };
+    sui::transfer::public_transfer(W { id: object::new(ctx), data }, ctx.sender());
+}
+
+// Seed A's address balance.
+//# programmable --sender A --inputs 100000000000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::into_balance<sui::sui::SUI>(Result(0));
+//> 2: sui::balance::send_funds<sui::sui::SUI>(Result(1), Input(1));
+
+// Create 5 big W objects (each holding 10_000 bytes of data).
+//# run test::big::make --args 10000 --sender A
+
+//# run test::big::make --args 10000 --sender A
+
+//# run test::big::make --args 10000 --sender A
+
+//# run test::big::make --args 10000 --sender A
+
+//# run test::big::make --args 10000 --sender A
+
+//# create-checkpoint
+
+//# view-funds sui::balance::Balance<sui::sui::SUI> A
+
+// Pre-state versions of the W inputs (each should be version 2 from creation).
+//# view-object 3,0 --hide-contents
+
+//# view-object 4,0 --hide-contents
+
+//# view-object 5,0 --hide-contents
+
+//# view-object 6,0 --hide-contents
+
+//# view-object 7,0 --hide-contents
+
+// OOG tx: pay with AB only, tight budget, pass all 5 big W's as inputs
+// and TransferObjects them back to A. Each re-mutation incurs
+// non-refundable cost; with 5 big inputs and a tight budget, even
+// input-only storage charge fails.
+//# programmable --sender A --gas-budget 2500000 --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(10000000) --inputs object(3,0) object(4,0) object(5,0) object(6,0) object(7,0) @A
+//> TransferObjects([Input(0), Input(1), Input(2), Input(3), Input(4)], Input(5))
+
+//# create-checkpoint
+
+//# view-funds sui::balance::Balance<sui::sui::SUI> A
+
+// After the OOG fallback, the engine drops all writes from execution but
+// still forces every mutable input to be re-stored (version bump) for
+// safety. All five W's should land on the SAME post-tx version (the tx's
+// lamport timestamp), even though the workload's TransferObjects was rolled
+// back.
+//# view-object 3,0 --hide-contents
+
+//# view-object 4,0 --hide-contents
+
+//# view-object 5,0 --hide-contents
+
+//# view-object 6,0 --hide-contents
+
+//# view-object 7,0 --hide-contents

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/storage_oog_charges_full_budget.snap
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/storage_oog_charges_full_budget.snap
@@ -1,0 +1,135 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 23 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 17-27:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 5722800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 28-33:
+//# programmable --sender A --inputs 100000000000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::coin::into_balance<sui::sui::SUI>(Result(0));
+//> 2: sui::balance::send_funds<sui::sui::SUI>(Result(1), Input(1));
+// Create 5 big W objects (each holding 10_000 bytes of data).
+mutated: object(0,0)
+accumulators_written: (object(2,0), A, sui::balance::Balance<sui::sui::SUI>, Merge, 100000000000)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, line 34:
+//# run test::big::make --args 10000 --sender A
+created: object(3,0)
+mutated: object(0,0)
+gas summary: computation_cost: 2800000, storage_cost: 78226800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 4, line 36:
+//# run test::big::make --args 10000 --sender A
+created: object(4,0)
+mutated: object(0,0)
+gas summary: computation_cost: 2800000, storage_cost: 78226800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 5, line 38:
+//# run test::big::make --args 10000 --sender A
+created: object(5,0)
+mutated: object(0,0)
+gas summary: computation_cost: 2800000, storage_cost: 78226800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 6, line 40:
+//# run test::big::make --args 10000 --sender A
+created: object(6,0)
+mutated: object(0,0)
+gas summary: computation_cost: 2800000, storage_cost: 78226800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 7, line 42:
+//# run test::big::make --args 10000 --sender A
+created: object(7,0)
+mutated: object(0,0)
+gas summary: computation_cost: 2800000, storage_cost: 78226800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 8, line 44:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 9, lines 46-48:
+//# view-funds sui::balance::Balance<sui::sui::SUI> A
+100000000000
+
+task 10, line 49:
+//# view-object 3,0 --hide-contents
+Owner: Account Address ( A )
+Version: 3
+Type: test::big::W
+
+task 11, line 51:
+//# view-object 4,0 --hide-contents
+Owner: Account Address ( A )
+Version: 4
+Type: test::big::W
+
+task 12, line 53:
+//# view-object 5,0 --hide-contents
+Owner: Account Address ( A )
+Version: 5
+Type: test::big::W
+
+task 13, line 55:
+//# view-object 6,0 --hide-contents
+Owner: Account Address ( A )
+Version: 6
+Type: test::big::W
+
+task 14, lines 57-62:
+//# view-object 7,0 --hide-contents
+Owner: Account Address ( A )
+Version: 7
+Type: test::big::W
+
+task 15, lines 63-64:
+//# programmable --sender A --gas-budget 2500000 --gas-payment withdraw<sui::balance::Balance<sui::sui::SUI>>(10000000) --inputs object(3,0) object(4,0) object(5,0) object(6,0) object(7,0) @A
+//> TransferObjects([Input(0), Input(1), Input(2), Input(3), Input(4)], Input(5))
+Error: Transaction Effects Status: Insufficient Gas.
+Debug of error: InsufficientGas at command None
+
+task 16, line 66:
+//# create-checkpoint
+Checkpoint created: 2
+
+task 17, lines 68-74:
+//# view-funds sui::balance::Balance<sui::sui::SUI> A
+99997500000
+
+task 18, line 75:
+//# view-object 3,0 --hide-contents
+Owner: Account Address ( A )
+Version: 8
+Type: test::big::W
+
+task 19, line 77:
+//# view-object 4,0 --hide-contents
+Owner: Account Address ( A )
+Version: 8
+Type: test::big::W
+
+task 20, line 79:
+//# view-object 5,0 --hide-contents
+Owner: Account Address ( A )
+Version: 8
+Type: test::big::W
+
+task 21, line 81:
+//# view-object 6,0 --hide-contents
+Owner: Account Address ( A )
+Version: 8
+Type: test::big::W
+
+task 22, line 83:
+//# view-object 7,0 --hide-contents
+Owner: Account Address ( A )
+Version: 8
+Type: test::big::W

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/transfer_gas_to_sponsor.move
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/transfer_gas_to_sponsor.move
@@ -1,0 +1,22 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Sponsored tx, sponsor's coin pays gas, workload
+// `TransferObjects([Gas], @B)` transfers the gas coin to the sponsor. The
+// override fires (location -> Coin(gas_id)) but is a no-op since the
+// location was already Coin. Verifies the gas coin ends up still owned by
+// the sponsor (which already owned it) with value reduced by net_gas.
+
+//# init --addresses test=0x0 --accounts A B --enable-address-balance-gas-payments --enable-accumulators
+
+// Sponsored tx: sender = A, sponsor = B. Default gas payment uses B's gas
+// coin (0,1). Workload transfers Gas back to B; final gas charge is debited
+// from the (still-existing) gas coin's value.
+//# programmable --sender A --sponsor B --inputs @B
+//> TransferObjects([Gas], Input(0))
+
+//# create-checkpoint
+
+// Gas coin (0,1) should still exist, owned by B, with value reduced by
+// net_gas. Storage cost is for the mutation (no new objects created).
+//# view-object 0,1

--- a/crates/sui-adapter-transactional-tests/tests/address_balances/transfer_gas_to_sponsor.snap
+++ b/crates/sui-adapter-transactional-tests/tests/address_balances/transfer_gas_to_sponsor.snap
@@ -1,0 +1,32 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 4 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 15-16:
+//# programmable --sender A --sponsor B --inputs @B
+//> TransferObjects([Gas], Input(0))
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 18-21:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 3, line 22:
+//# view-object 0,1
+Owner: Account Address ( B )
+Version: 2
+Contents: sui::coin::Coin<sui::sui::SUI> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(0,1),
+        },
+    },
+    balance: sui::balance::Balance<sui::sui::SUI> {
+        value: 299999998012000u64,
+    },
+}


### PR DESCRIPTION
## Description 

  Adds combination, error-path, comparison, and lamport-timestamp tests around
  mixed `[Coin, AB]` gas-payment shapes.

  Smash combinations:
    - coin_with_multi_reservation_gas      [Coin, AB, AB] dedup
    - coin_coin_reservation_gas            [Coin, Coin, AB]
    - reservation_coin_coin_gas            [AB, Coin, Coin]
    - reservation_reservation_coin_gas     [AB, AB, Coin] dedup + delete
    - smash_order_comparison               paired [Coin, AB] vs [AB, Coin]
    - rebate_exceeds_cost                  net-negative gas (refund)

  Error & reset paths:
    - mixed_gas_move_abort                 abort triggers reset + re-smash
    - address_balance_storage_oog          v2 storage OOG, AB only
    - mixed_gas_storage_oog                v2 storage OOG, [Coin, AB]
    - reservation_coin_storage_oog         v2 storage OOG, un-delete on reset
    - storage_oog_charges_full_budget      deepest OOG fallback (full budget)

  Validation & version edge cases:
    - max_withdraws_boundary               10/11 reservations boundary
    - override_send_funds_to_self          gas-charge override to original payer
    - smash_lamport_timestamp              deleted secondary's version flows
                                           into lamport stamp

🤖  assisted

## Test plan 

It's all tests 🎉 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
