### PR TITLE
[chore] fix clippy warnings in tests 

### DIFF
--- a/crates/sui-indexer-alt-graphql/src/api/subscription.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/subscription.rs
@@ -46,7 +46,7 @@ impl Subscription {
                             processed.clone(),
                         );
                         yield Ok(Checkpoint {
-                            sequence_number: processed.sequence_number,
+                            sequence_number: processed.summary.sequence_number,
                             scope,
                             streamed_data: Some(processed),
                         });

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
@@ -363,6 +363,7 @@ impl TransactionContents {
 
         // Streaming fast path: if the scope is backed by a streamed checkpoint containing this
         // transaction, hydrate from the in-memory payload instead of hitting the DB.
+        #[cfg(feature = "staging")]
         if let Some(tx) = self.scope.streamed_transaction_by_digest(digest) {
             return Ok(Self {
                 scope: self.scope.clone(),

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
@@ -560,6 +560,7 @@ impl EffectsContents {
 
         // Streaming fast path: if the scope is backed by a streamed checkpoint containing this
         // transaction, hydrate from the in-memory payload instead of hitting the DB.
+        #[cfg(feature = "staging")]
         if let Some(tx) = self.scope.streamed_transaction_by_digest(digest) {
             return Ok(Self {
                 scope: self.scope.clone(),

--- a/crates/sui-indexer-alt-graphql/src/scope.rs
+++ b/crates/sui-indexer-alt-graphql/src/scope.rs
@@ -24,8 +24,11 @@ use sui_types::object::Object as NativeObject;
 
 use crate::config::Limits;
 use crate::error::RpcError;
+#[cfg(feature = "staging")]
 use crate::task::streaming::ProcessedCheckpoint;
+#[cfg(feature = "staging")]
 use crate::task::streaming::ProcessedTransaction;
+#[cfg(feature = "staging")]
 use crate::task::streaming::StreamingPackageStore;
 use crate::task::watermark::Watermarks;
 
@@ -50,6 +53,7 @@ pub(crate) enum DataSource {
     /// A streamed checkpoint with all per-tx contents and a checkpoint-wide execution-objects
     /// map. If the scope is anchored to a particular transaction in the checkpoint, its digest
     /// is in [`Scope::active_transaction_digest`].
+    #[cfg(feature = "staging")]
     Streamed {
         checkpoint: Arc<ProcessedCheckpoint>,
     },
@@ -132,6 +136,7 @@ impl Scope {
 
     /// Create a scope for streamed checkpoint data. Sets `checkpoint_viewed_at` to `None`
     /// because streamed data is resolved from memory, not bounded by an indexed checkpoint.
+    #[cfg(feature = "staging")]
     pub(crate) fn for_streamed_checkpoint(
         package_store: Arc<StreamingPackageStore>,
         resolver_limits: sui_package_resolver::Limits,
@@ -283,11 +288,13 @@ impl Scope {
     /// Lookup a transaction by digest within the streamed checkpoint backing this scope.
     /// Returns `None` if the scope is not in [`DataSource::Streamed`] mode, or if no
     /// transaction with that digest exists in the checkpoint.
+    #[cfg(feature = "staging")]
     pub(crate) fn streamed_transaction_by_digest(
         &self,
         digest: TransactionDigest,
     ) -> Option<&ProcessedTransaction> {
         match &self.data_source {
+            #[cfg(feature = "staging")]
             DataSource::Streamed { checkpoint } => checkpoint.transaction_by_digest(digest),
             DataSource::Indexed | DataSource::Executed { .. } => None,
         }
@@ -302,6 +309,7 @@ impl Scope {
         match &self.data_source {
             DataSource::Indexed => None,
             DataSource::Executed { execution_objects } => Some(execution_objects),
+            #[cfg(feature = "staging")]
             DataSource::Streamed { checkpoint } => Some(&checkpoint.execution_objects),
         }
     }

--- a/crates/sui-indexer-alt-graphql/src/task/streaming/checkpoint_stream_task.rs
+++ b/crates/sui-indexer-alt-graphql/src/task/streaming/checkpoint_stream_task.rs
@@ -56,6 +56,7 @@
 //! the recovery target, the next live message is itself a gap, and detection
 //! fires again.
 
+#[cfg(feature = "staging")]
 use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::time::Duration;
@@ -74,10 +75,13 @@ use sui_rpc::proto::sui::rpc::v2::Checkpoint as ProtoCheckpoint;
 use sui_rpc::proto::sui::rpc::v2::ExecutedTransaction as ProtoExecutedTransaction;
 use sui_rpc::proto::sui::rpc::v2::SubscribeCheckpointsRequest;
 use sui_rpc::proto::sui::rpc::v2::SubscribeCheckpointsResponse;
+#[cfg(feature = "staging")]
 use sui_rpc::proto::sui::rpc::v2::changed_object::OutputObjectState;
 use sui_rpc::proto::sui::rpc::v2::subscription_service_client::SubscriptionServiceClient;
 use sui_sdk_types::ValidatorAggregatedSignature;
+#[cfg(feature = "staging")]
 use sui_types::base_types::ObjectID;
+#[cfg(feature = "staging")]
 use sui_types::base_types::SequenceNumber;
 use sui_types::crypto::AuthorityStrongQuorumSignInfo;
 use sui_types::crypto::ToFromBytes;
@@ -379,6 +383,10 @@ pub(super) fn process_checkpoint(
         .context("Missing summary.bcs")?
         .deserialize()
         .context("Failed to deserialize checkpoint summary")?;
+    anyhow::ensure!(
+        summary.sequence_number == sequence_number,
+        "Checkpoint sequence_number does not match summary sequence_number"
+    );
 
     let contents: CheckpointContents = checkpoint
         .contents
@@ -399,11 +407,13 @@ pub(super) fn process_checkpoint(
     let timestamp_ms = summary.timestamp_ms;
     let cp_sequence_number = sequence_number;
     let tx_lo = summary.network_total_transactions - checkpoint.transactions.len() as u64;
+    #[cfg(feature = "staging")]
     let checkpoint_objects = deserialize_checkpoint_objects(&checkpoint)?;
 
     // Seed the checkpoint-wide execution-objects map with every existing object version
     // carried by the proto. Tombstones for deleted/wrapped outputs are added below from each
     // transaction's effects because the proto doesn't carry deleted-object payloads.
+    #[cfg(feature = "staging")]
     let mut execution_objects: BTreeMap<(ObjectID, SequenceNumber), Option<NativeObject>> =
         checkpoint_objects
             .iter()
@@ -412,6 +422,7 @@ pub(super) fn process_checkpoint(
 
     let mut transactions = Vec::with_capacity(checkpoint.transactions.len());
     for (i, proto) in checkpoint.transactions.iter().enumerate() {
+        #[cfg(feature = "staging")]
         add_tombstones(&mut execution_objects, proto)?;
         transactions.push(process_transaction(
             proto,
@@ -422,11 +433,11 @@ pub(super) fn process_checkpoint(
     }
 
     Ok(ProcessedCheckpoint::new(
-        sequence_number,
         summary,
         contents,
         signature,
         transactions,
+        #[cfg(feature = "staging")]
         Arc::new(execution_objects),
     ))
 }
@@ -528,6 +539,7 @@ fn extract_packages(checkpoint: &ProtoCheckpoint) -> Vec<Arc<Package>> {
 }
 
 /// Deserialize all objects from the checkpoint-level ObjectSet.
+#[cfg(feature = "staging")]
 fn deserialize_checkpoint_objects(
     checkpoint: &ProtoCheckpoint,
 ) -> anyhow::Result<BTreeMap<(ObjectID, SequenceNumber), NativeObject>> {
@@ -550,6 +562,7 @@ fn deserialize_checkpoint_objects(
 /// carry payloads for deleted/wrapped objects, so tombstones must come from effects; without
 /// them, `execution_output_object_latest` would return the pre-deletion version of an object
 /// that no longer exists at end-of-checkpoint.
+#[cfg(feature = "staging")]
 fn add_tombstones(
     map: &mut BTreeMap<(ObjectID, SequenceNumber), Option<NativeObject>>,
     proto_tx: &ProtoExecutedTransaction,

--- a/crates/sui-indexer-alt-graphql/src/task/streaming/gap_recovery.rs
+++ b/crates/sui-indexer-alt-graphql/src/task/streaming/gap_recovery.rs
@@ -325,7 +325,7 @@ mod tests {
     fn drain_broadcast(receiver: &mut broadcast::Receiver<Arc<ProcessedCheckpoint>>) -> Vec<u64> {
         let mut received = Vec::new();
         while let Ok(cp) = receiver.try_recv() {
-            received.push(cp.sequence_number);
+            received.push(cp.summary.sequence_number);
         }
         received
     }

--- a/crates/sui-indexer-alt-graphql/src/task/streaming/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/task/streaming/mod.rs
@@ -50,6 +50,7 @@ use std::sync::Arc;
 
 use sui_indexer_alt_reader::package_resolver::PackageCache;
 
+#[cfg(feature = "staging")]
 pub(crate) use checkpoint_stream_task::CheckpointBroadcaster;
 pub(crate) use checkpoint_stream_task::CheckpointStreamTask;
 pub(crate) use package_eviction_task::PackageEvictionTask;

--- a/crates/sui-indexer-alt-graphql/src/task/streaming/processed_checkpoint.rs
+++ b/crates/sui-indexer-alt-graphql/src/task/streaming/processed_checkpoint.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+#[cfg(feature = "staging")]
 use std::collections::HashMap;
 
 use sui_indexer_alt_reader::kv_loader::TransactionContents;
@@ -9,11 +10,11 @@ use sui_types::digests::TransactionDigest;
 use sui_types::messages_checkpoint::CheckpointContents;
 use sui_types::messages_checkpoint::CheckpointSummary;
 
+#[cfg(feature = "staging")]
 use crate::scope::ExecutionObjectMap;
 
 /// A checkpoint received from gRPC with pre-deserialized data for subscriber consumption.
 pub(crate) struct ProcessedCheckpoint {
-    pub(crate) sequence_number: u64,
     pub(crate) summary: CheckpointSummary,
     pub(crate) contents: CheckpointContents,
     pub(crate) signature: AuthorityStrongQuorumSignInfo,
@@ -21,9 +22,11 @@ pub(crate) struct ProcessedCheckpoint {
     /// Checkpoint-wide execution objects (inputs and outputs across all transactions in the
     /// checkpoint, including tombstones for deleted/wrapped objects). Object visibility in a
     /// streamed scope is end-of-checkpoint, matching what the indexed Query API exposes.
+    #[cfg(feature = "staging")]
     pub(crate) execution_objects: ExecutionObjectMap,
     /// Index of `transactions` by digest for O(1) lookup that scales across many subscribers.
     /// Built once at construction.
+    #[cfg(feature = "staging")]
     by_digest: HashMap<TransactionDigest, usize>,
 }
 
@@ -37,30 +40,33 @@ pub(crate) struct ProcessedTransaction {
 impl ProcessedCheckpoint {
     /// Construct a checkpoint with the digest index pre-built from `transactions`.
     pub(crate) fn new(
-        sequence_number: u64,
         summary: CheckpointSummary,
         contents: CheckpointContents,
         signature: AuthorityStrongQuorumSignInfo,
         transactions: Vec<ProcessedTransaction>,
-        execution_objects: ExecutionObjectMap,
+        #[cfg(feature = "staging")] execution_objects: ExecutionObjectMap,
     ) -> Self {
+        #[cfg(feature = "staging")]
         let by_digest = transactions
             .iter()
             .enumerate()
             .map(|(i, t)| (t.digest, i))
             .collect();
+
         Self {
-            sequence_number,
             summary,
             contents,
             signature,
             transactions,
+            #[cfg(feature = "staging")]
             execution_objects,
+            #[cfg(feature = "staging")]
             by_digest,
         }
     }
 
     /// Lookup a transaction by digest within this checkpoint.
+    #[cfg(feature = "staging")]
     pub(crate) fn transaction_by_digest(
         &self,
         digest: TransactionDigest,


### PR DESCRIPTION


## Description 

This PR gates a number of fields behind staging feature to avoid clippy warnings during tests. It also removes the sequence number argument as it can be derived from summary.

See such a warning here: https://github.com/MystenLabs/sui/actions/runs/25765937534/job/75678453235?pr=26500#step:5:30

## Test plan 

Existing CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
