### PR TITLE
[sui-fork] add back `ConsensusAddressOwner` support for owned objects and seeding

### DIFF
--- a/crates/sui-fork/design/owned_objects_design.md
+++ b/crates/sui-fork/design/owned_objects_design.md
@@ -72,8 +72,7 @@ struct OwnedObjectEntry {
 }
 ```
 
-Only Move objects owned by an address with a `StructTag` are indexed. This
-includes `AddressOwner` and `ConsensusAddressOwner`. Shared, immutable,
+Objets with `AddressOwner` and `ConsensusAddressOwner` types are kept in the index. Shared, immutable,
 object-owned, and package objects are excluded.
 
 ## Write Path

--- a/crates/sui-fork/design/owned_objects_design.md
+++ b/crates/sui-fork/design/owned_objects_design.md
@@ -72,8 +72,9 @@ struct OwnedObjectEntry {
 }
 ```
 
-Only address-owned Move objects with a `StructTag` are indexed. Shared,
-immutable, object-owned, consensus-owned, and package objects are excluded.
+Only Move objects owned by an address with a `StructTag` are indexed. This
+includes `AddressOwner` and `ConsensusAddressOwner`. Shared, immutable,
+object-owned, and package objects are excluded.
 
 ## Write Path
 
@@ -143,8 +144,8 @@ The design should be validated with tests for:
 - removal markers blocking latest/current reads while preserving exact-version
   reads
 - owned index upsert, removal, persistence, and sort order
-- address-owned writes appearing in `owned_objects`
+- address writes appearing in `owned_objects`
 - transfers moving entries between owners
-- non-address-owned transitions removing entries
+- transitions away from address ownership removing entries
 - local deletion removing entries and blocking remote resurrection
 - RPC owned-object iteration type filtering and cursor behavior

--- a/crates/sui-fork/design/seeding_design.md
+++ b/crates/sui-fork/design/seeding_design.md
@@ -79,7 +79,7 @@ Seed resolution:
 
 ## GraphQL queries
 
-### Address-owned objects query
+### Address objects query
 
 `src/gql/queries.rs` owns the checkpoint-scoped address query. The seed module
 calls `GraphQLClient::get_address_owned_objects_at_checkpoint()` and does not
@@ -99,6 +99,7 @@ query($sequenceNumber: UInt53, $address: SuiAddress!, $first: Int, $after: Strin
             digest
             owner {
               ... on AddressOwner { address { address } }
+              ... on ConsensusAddressOwner { address { address } }
             }
             contents {
               type { repr }
@@ -115,9 +116,9 @@ query($sequenceNumber: UInt53, $address: SuiAddress!, $first: Int, $after: Strin
 
 - Page size: 50
 - Paginate with cursor loop (same pattern as `events_query`)
-- Only collect `AddressOwner` entries. Other owner variants are handled by the
-  query fallback and skipped; they are not usable as address-owned gas/input
-  objects for the initial index.
+- Only collect `AddressOwner` and `ConsensusAddressOwner` entries. Other owner
+  variants are handled by the query fallback and skipped; they are not
+  controlled by the seeded address for the initial index.
 
 ### Individual objects (reuse existing)
 
@@ -190,8 +191,8 @@ once the fork has started executing.
   read masks fetch BCS lazily
 
 **When a seeded object is deleted/mutated post-fork**:
-- `update_objects()` removes the old index entry, adds the new address-owned entry, or removes the
-  entry for wrapped/shared/immutable/object-owned transitions
+- `update_objects()` removes the old index entry, adds the new address-owned entry,
+  or removes the entry for wrapped/shared/immutable/object-owned transitions
 - local deleted markers prevent current-object reads from falling back to the remote endpoint
 
 **Key invariant**: Seed manifest is immutable after creation. Post-fork state is tracked entirely

--- a/crates/sui-fork/src/cli.rs
+++ b/crates/sui-fork/src/cli.rs
@@ -60,7 +60,7 @@ enum Command {
         #[arg(long = "address")]
         addresses: Vec<SuiAddress>,
 
-        /// Object ID to fetch and seed if it is address-owned
+        /// Object ID to fetch and seed if it is owned by an address
         #[arg(long = "object")]
         object_ids: Vec<ObjectID>,
 

--- a/crates/sui-fork/src/filesystem.rs
+++ b/crates/sui-fork/src/filesystem.rs
@@ -126,7 +126,7 @@ impl RemovedObjectKind {
     }
 }
 
-/// Index entry for a live address-owned object.
+/// Index entry for a live object owned by an address.
 #[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
 pub(crate) struct OwnedObjectEntry {
     pub(crate) owner: SuiAddress,
@@ -138,11 +138,12 @@ pub(crate) struct OwnedObjectEntry {
 
 impl OwnedObjectEntry {
     fn from_object(object: &Object) -> Option<Self> {
-        let Owner::AddressOwner(owner) = &object.owner else {
-            return None;
+        let owner = match &object.owner {
+            Owner::AddressOwner(owner) | Owner::ConsensusAddressOwner { owner, .. } => *owner,
+            _ => return None,
         };
         Some(Self {
-            owner: *owner,
+            owner,
             object_id: object.id(),
             version: object.version(),
             object_type: object.struct_tag()?,

--- a/crates/sui-fork/src/filesystem.rs
+++ b/crates/sui-fork/src/filesystem.rs
@@ -126,7 +126,7 @@ impl RemovedObjectKind {
     }
 }
 
-/// Index entry for a live object owned by an address.
+/// Index entry for a live address-owned object.
 #[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
 pub(crate) struct OwnedObjectEntry {
     pub(crate) owner: SuiAddress,

--- a/crates/sui-fork/src/gql/client.rs
+++ b/crates/sui-fork/src/gql/client.rs
@@ -129,7 +129,7 @@ impl TransactionRead for GraphQLClient {
 }
 
 impl GraphQLClient {
-    /// Fetch address-owned object metadata at a checkpoint, paginating through
+    /// Fetch metadata for objects owned by an address at a checkpoint, paginating through
     /// the checkpoint-scoped ownership connection.
     pub(crate) async fn get_address_owned_objects_at_checkpoint(
         &self,

--- a/crates/sui-fork/src/gql/queries.rs
+++ b/crates/sui-fork/src/gql/queries.rs
@@ -242,7 +242,7 @@ pub(crate) mod address_owned_objects_query {
 
     const PAGE_SIZE: i32 = 50;
 
-    /// Lightweight metadata for an address-owned object at a checkpoint.
+    /// Lightweight metadata for an object owned by an address at a checkpoint.
     #[derive(Clone, Debug, Eq, PartialEq)]
     pub(crate) struct AddressOwnedObject {
         pub(crate) object_id: ObjectID,
@@ -334,6 +334,7 @@ pub(crate) mod address_owned_objects_query {
     #[cynic(schema_module = "crate::gql::queries::schema")]
     pub(crate) enum Owner {
         AddressOwner(AddressOwner),
+        ConsensusAddressOwner(ConsensusAddressOwner),
         #[cynic(fallback)]
         Other,
     }
@@ -341,6 +342,12 @@ pub(crate) mod address_owned_objects_query {
     #[derive(cynic::QueryFragment)]
     #[cynic(schema_module = "crate::gql::queries::schema")]
     pub(crate) struct AddressOwner {
+        address: Option<OwnerAddress>,
+    }
+
+    #[derive(cynic::QueryFragment)]
+    #[cynic(schema_module = "crate::gql::queries::schema")]
+    pub(crate) struct ConsensusAddressOwner {
         address: Option<OwnerAddress>,
     }
 
@@ -448,13 +455,12 @@ pub(crate) mod address_owned_objects_query {
 
     fn decode_move_object(node: MoveObject) -> Result<Option<AddressOwnedObject>, Error> {
         let owner = match node.owner {
-            Some(Owner::AddressOwner(owner)) => owner
-                .address
-                .ok_or_else(|| anyhow!("address-owned seed entry is missing owner address"))?
-                .address
-                .0
-                .parse::<SuiAddressType>()
-                .with_context(|| format!("invalid seed owner for object {}", node.address.0))?,
+            Some(Owner::AddressOwner(owner)) => {
+                parse_owner_address(owner.address, &node.address.0)?
+            }
+            Some(Owner::ConsensusAddressOwner(owner)) => {
+                parse_owner_address(owner.address, &node.address.0)?
+            }
             _ => return Ok(None),
         };
         let contents = node
@@ -490,6 +496,18 @@ pub(crate) mod address_owned_objects_query {
             object_type,
             balance,
         }))
+    }
+
+    fn parse_owner_address(
+        address: Option<OwnerAddress>,
+        object_id: &str,
+    ) -> Result<SuiAddressType, Error> {
+        address
+            .ok_or_else(|| anyhow!("address seed entry is missing owner address"))?
+            .address
+            .0
+            .parse::<SuiAddressType>()
+            .with_context(|| format!("invalid seed owner for object {object_id}"))
     }
 
     #[cfg(test)]
@@ -590,6 +608,21 @@ pub(crate) mod address_owned_objects_query {
             })
         }
 
+        fn immutable_node(object: &Object) -> serde_json::Value {
+            serde_json::json!({
+                "address": object.id().to_string(),
+                "version": object.version().value(),
+                "digest": object.digest().to_string(),
+                "owner": {
+                    "__typename": "Immutable",
+                },
+                "contents": {
+                    "type": { "repr": object.struct_tag().unwrap().to_canonical_string(true) },
+                    "json": { "balance": "789" },
+                }
+            })
+        }
+
         #[test]
         fn coin_balance_from_json_reads_string_balance() {
             let ty = GasCoin::type_();
@@ -602,7 +635,7 @@ pub(crate) mod address_owned_objects_query {
         }
 
         #[tokio::test]
-        async fn query_paginates_and_skips_non_address_owned_objects() {
+        async fn query_paginates_and_includes_consensus_address_owned_objects() {
             let server = MockServer::start().await;
             let owner = SuiAddressType::random_for_testing_only();
             let first = Object::with_id_owner_version_for_testing(
@@ -617,6 +650,11 @@ pub(crate) mod address_owned_objects_query {
                     start_version: SequenceNumber::from_u64(8),
                     owner,
                 },
+            );
+            let immutable = Object::with_id_owner_version_for_testing(
+                ObjectID::random(),
+                SequenceNumber::from_u64(9),
+                SuiOwner::Immutable,
             );
 
             Mock::given(method("POST"))
@@ -640,7 +678,10 @@ pub(crate) mod address_owned_objects_query {
                 })))
                 .respond_with(
                     ResponseTemplate::new(200).set_body_json(address_objects_response(
-                        vec![consensus_owned_node(&second, owner)],
+                        vec![
+                            consensus_owned_node(&second, owner),
+                            immutable_node(&immutable),
+                        ],
                         false,
                         None,
                     )),
@@ -654,10 +695,13 @@ pub(crate) mod address_owned_objects_query {
                 .await
                 .expect("address seed should resolve");
 
-            assert_eq!(entries.len(), 1);
+            assert_eq!(entries.len(), 2);
             assert_eq!(entries[0].object_id, first.id());
             assert_eq!(entries[0].version, first.version());
             assert_eq!(entries[0].balance, Some(123));
+            assert_eq!(entries[1].object_id, second.id());
+            assert_eq!(entries[1].version, second.version());
+            assert_eq!(entries[1].balance, Some(456));
 
             let requests = server
                 .received_requests()
@@ -672,7 +716,7 @@ pub(crate) mod address_owned_objects_query {
                 .expect("query string should be present");
             assert!(query.contains("address(address: $address)"));
             assert!(query.contains("... on AddressOwner"));
-            assert!(!query.contains("ConsensusAddressOwner"));
+            assert!(query.contains("... on ConsensusAddressOwner"));
         }
 
         #[tokio::test]

--- a/crates/sui-fork/src/gql/queries.rs
+++ b/crates/sui-fork/src/gql/queries.rs
@@ -242,7 +242,7 @@ pub(crate) mod address_owned_objects_query {
 
     const PAGE_SIZE: i32 = 50;
 
-    /// Lightweight metadata for an object owned by an address at a checkpoint.
+    /// Lightweight metadata for an address-owned object at a checkpoint.
     #[derive(Clone, Debug, Eq, PartialEq)]
     pub(crate) struct AddressOwnedObject {
         pub(crate) object_id: ObjectID,
@@ -503,7 +503,7 @@ pub(crate) mod address_owned_objects_query {
         object_id: &str,
     ) -> Result<SuiAddressType, Error> {
         address
-            .ok_or_else(|| anyhow!("address seed entry is missing owner address"))?
+            .context("address seed entry is missing owner address")?
             .address
             .0
             .parse::<SuiAddressType>()

--- a/crates/sui-fork/src/seed.rs
+++ b/crates/sui-fork/src/seed.rs
@@ -512,8 +512,7 @@ mod tests {
             },
         )
         .await
-        .expect("seed manifest should resolve")
-        .expect("manifest should exist");
+        .expect("seed manifest should resolve");
 
         assert_eq!(manifest.entries.len(), 1);
         assert_eq!(manifest.entries[0].object_id, object.id());

--- a/crates/sui-fork/src/seed.rs
+++ b/crates/sui-fork/src/seed.rs
@@ -39,7 +39,7 @@ use crate::gql::GraphQLClient;
 pub struct SeedInput {
     /// Addresses whose owned objects should seed the initial owned-object index.
     pub addresses: Vec<SuiAddress>,
-    /// Object IDs to fetch and seed when they are address-owned.
+    /// Object IDs to fetch and seed when they are owned by an address.
     pub object_ids: Vec<ObjectID>,
 }
 
@@ -74,15 +74,16 @@ impl SeedManifest {
 
 impl SeedEntry {
     fn from_object(object: &Object) -> Option<Self> {
-        let Owner::AddressOwner(owner) = &object.owner else {
-            return None;
+        let owner = match &object.owner {
+            Owner::AddressOwner(owner) | Owner::ConsensusAddressOwner { owner, .. } => *owner,
+            _ => return None,
         };
 
         Some(Self {
             object_id: object.id(),
             version: object.version(),
             digest: object.digest(),
-            owner: *owner,
+            owner,
             object_type: object.struct_tag()?,
             balance: object.as_coin_maybe().map(|coin| coin.value()),
         })
@@ -286,7 +287,7 @@ fn resolve_object_seeds(
             warn!(
                 %object_id,
                 checkpoint,
-                "object seed is not address-owned and will not be added to the owned-object index",
+                "object seed is not owned by an address and will not be added to the owned-object index",
             );
         }
     }
@@ -471,6 +472,52 @@ mod tests {
 
         assert_eq!(manifest.entries.len(), 1);
         assert_eq!(manifest.entries[0].object_id, object.id());
+        assert_eq!(
+            store
+                .local()
+                .get_object_at_version(&object.id(), object.version().value())
+                .expect("local object lookup should not fail")
+                .unwrap(),
+            object,
+        );
+    }
+
+    #[tokio::test]
+    async fn prepare_seed_manifest_fetches_explicit_consensus_address_owner_object() {
+        let server = MockServer::start().await;
+        let owner = SuiAddress::random_for_testing_only();
+        let object = Object::with_id_owner_version_for_testing(
+            ObjectID::random(),
+            SequenceNumber::from_u64(3),
+            Owner::ConsensusAddressOwner {
+                start_version: SequenceNumber::from_u64(3),
+                owner,
+            },
+        );
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(object_response_body(&object)))
+            .mount(&server)
+            .await;
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let store =
+            DataStore::new_for_testing_with_remote(temp.path().to_path_buf(), server.uri(), 11);
+        let manifest = prepare_seed_manifest(
+            &store,
+            "custom".to_owned(),
+            &SeedInput {
+                addresses: vec![],
+                object_ids: vec![object.id()],
+            },
+        )
+        .await
+        .expect("seed manifest should resolve")
+        .expect("manifest should exist");
+
+        assert_eq!(manifest.entries.len(), 1);
+        assert_eq!(manifest.entries[0].object_id, object.id());
+        assert_eq!(manifest.entries[0].owner, owner);
         assert_eq!(
             store
                 .local()

--- a/crates/sui-fork/src/store.rs
+++ b/crates/sui-fork/src/store.rs
@@ -626,16 +626,19 @@ impl DataStore {
             .collect())
     }
 
-    /// Validate that the given `OwnedObjectEntry` corresponds to an actual owned object in the
-    /// local store, and if so convert it to `OwnedObjectInfo`. This guards against stale index
+    /// Validate that the given `OwnedObjectEntry` corresponds to a locally cached object still
+    /// controlled by the indexed address. This guards against stale index
     /// entries that point to objects that have been deleted or wrapped by later transactions.
     fn valid_owned_object_info(&self, entry: OwnedObjectEntry) -> Option<OwnedObjectInfo> {
         if let Some(object) = self.local().get_latest_object(&entry.object_id).ok()? {
             if object.version() != entry.version {
                 return None;
             }
-            if object.owner != sui_types::object::Owner::AddressOwner(entry.owner) {
-                return None;
+            match &object.owner {
+                sui_types::object::Owner::AddressOwner(owner)
+                | sui_types::object::Owner::ConsensusAddressOwner { owner, .. }
+                    if *owner == entry.owner => {}
+                _ => return None,
             }
             let object_type = object.struct_tag()?;
             if object_type != entry.object_type {

--- a/crates/sui-fork/src/tests/store_execution.rs
+++ b/crates/sui-fork/src/tests/store_execution.rs
@@ -254,6 +254,42 @@ fn test_owned_objects_tracks_address_owner_transfers() {
 }
 
 #[test]
+fn test_owned_objects_tracks_consensus_address_owner_writes() {
+    let (_temp, mut store) = test_data_store();
+    let owner = SuiAddress::random_for_testing_only();
+    let object_id = ObjectID::random();
+    let object = make_gas_object(
+        object_id,
+        1,
+        Owner::ConsensusAddressOwner {
+            start_version: SequenceNumber::from_u64(1),
+            owner,
+        },
+    );
+
+    store.update_objects(BTreeMap::from([(object_id, object)]), vec![]);
+
+    let infos: Vec<_> = RpcIndexes::owned_objects_iter(&store, owner, Some(GasCoin::type_()), None)
+        .expect("owned-object iterator should build")
+        .map(|result| result.expect("owned-object entry should decode"))
+        .collect();
+    assert_eq!(infos.len(), 1);
+    assert_eq!(infos[0].owner, owner);
+    assert_eq!(infos[0].object_id, object_id);
+    assert_eq!(infos[0].version, SequenceNumber::from_u64(1));
+    assert_eq!(infos[0].balance, Some(1_000_000));
+
+    let immutable = make_gas_object(object_id, 2, Owner::Immutable);
+    store.update_objects(BTreeMap::from([(object_id, immutable)]), vec![]);
+    assert_eq!(
+        RpcIndexes::owned_objects_iter(&store, owner, Some(GasCoin::type_()), None)
+            .expect("owned-object iterator should build")
+            .count(),
+        0,
+    );
+}
+
+#[test]
 fn test_owned_objects_removes_non_address_owned_transitions() {
     let (_temp, mut store) = test_data_store();
     let owner = SuiAddress::random_for_testing_only();


### PR DESCRIPTION


## Description 

This PR adds back the ConsensusAddressOwner type that we need to support for owned objects and seeding. Initially, I started with it in the design, but in a later PR I removed it. This is needed as we can seed objects that are consensus "owned".

## Test plan 

New tests + existing CI.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
