### PR TITLE
[move][move-decompiler] Disable inline_immediates and normalize degenerate conditions

### DIFF
--- a/external-crates/move/crates/move-decompiler/src/refinement/introduce_while.rs
+++ b/external-crates/move/crates/move-decompiler/src/refinement/introduce_while.rs
@@ -31,7 +31,7 @@ impl Refine for IntroduceWhile0 {
         // Only fire when the Break(label) matches this loop's label (so the break really exits
         // *this* Loop and not a labeled outer one).
         let target = *loop_label;
-        if !is_break_of(conseq, target) && !is_break_of(alt, target) {
+        if !is_break_to(conseq, target) && !is_break_to(alt, target) {
             return false;
         }
 
@@ -43,7 +43,7 @@ impl Refine for IntroduceWhile0 {
                 unreachable!()
             };
             let alt = alt.unwrap();
-            if is_break_of(&conseq, loop_label) {
+            if is_break_to(&conseq, loop_label) {
                 negate(&mut test);
                 Exp::While(loop_label, test, Box::new(alt))
             } else {
@@ -54,7 +54,7 @@ impl Refine for IntroduceWhile0 {
     }
 }
 
-fn is_break_of(exp: &Exp, loop_label: Option<crate::ast::Label>) -> bool {
+fn is_break_to(exp: &Exp, loop_label: Option<crate::ast::Label>) -> bool {
     matches!(exp, Exp::Break(l) if *l == loop_label)
 }
 
@@ -75,7 +75,7 @@ impl Refine for IntroduceWhile1 {
                 let Exp::IfElse(_, conseq, alt) = &seq[0] else {
                     return false;
                 };
-                if !is_break_of(conseq, loop_label) {
+                if !is_break_to(conseq, loop_label) {
                     return false;
                 }
                 let None = alt.as_ref() else {

--- a/external-crates/move/crates/move-decompiler/src/testing.rs
+++ b/external-crates/move/crates/move-decompiler/src/testing.rs
@@ -50,6 +50,11 @@ pub fn structuring_unit_test(file_path: &std::path::Path) -> String {
 
             match parts.as_slice() {
                 ["cond", a, b, c] => match (a.parse::<u32>(), b.parse::<u32>(), c.parse::<u32>()) {
+                    // Match the translate.rs normalization: a `cond` whose two arms target
+                    // the same label is a `code` with a dead condition.
+                    (Ok(a), Ok(b), Ok(c)) if b == c => {
+                        nodes.push(In::Code(a.into(), a.into(), Some(b.into())))
+                    }
                     (Ok(a), Ok(b), Ok(c)) => {
                         nodes.push(In::Condition(a.into(), a.into(), b.into(), c.into()))
                     }

--- a/external-crates/move/crates/move-decompiler/src/translate.rs
+++ b/external-crates/move/crates/move-decompiler/src/translate.rs
@@ -183,12 +183,27 @@ fn extract_input(block: &SB::BasicBlock, next_block_label: Option<SB::Label>) ->
                 condition: _,
                 then_label,
                 else_label,
-            } => DI::Condition(
-                (block.label as u32).into(),
-                (block.label as u32).into(),
-                (*then_label as u32).into(),
-                (*else_label as u32).into(),
-            ),
+            } => {
+                // A degenerate JumpIf whose two arms target the same label is just an
+                // unconditional jump with a dead condition. The compiler can leave these
+                // around when an arm body is empty (`if (c) {}`) and the optimizer forwards
+                // the empty arm to the join. Lower it as `Code` so structuring isn't asked
+                // to handle a Condition whose successors aren't dominated by it.
+                if then_label == else_label {
+                    DI::Code(
+                        (block.label as u32).into(),
+                        (block.label as u32).into(),
+                        Some((*then_label as u32).into()),
+                    )
+                } else {
+                    DI::Condition(
+                        (block.label as u32).into(),
+                        (block.label as u32).into(),
+                        (*then_label as u32).into(),
+                        (*else_label as u32).into(),
+                    )
+                }
+            }
             SI::VariantSwitch {
                 condition: _,
                 enum_,

--- a/external-crates/move/crates/move-decompiler/src/translate.rs
+++ b/external-crates/move/crates/move-decompiler/src/translate.rs
@@ -29,7 +29,9 @@ pub fn model_with_config<S: SourceKind>(
     config: &Config,
     model: Model<S>,
 ) -> anyhow::Result<Out::Decompiled<S>> {
-    let stackless = move_stackless_bytecode_2::from_model(&model, /* optimize */ true)?;
+    // Don't optimize the stackless bytecode: we want to faithfully decompile what the
+    // bytecode actually contains.
+    let stackless = move_stackless_bytecode_2::from_model(&model, /* optimize */ false)?;
     let packages = packages(config, &model, stackless);
     Ok(Out::Decompiled { model, packages })
 }

--- a/external-crates/move/crates/move-decompiler/tests/structuring/degenerate_cond.snap
+++ b/external-crates/move/crates/move-decompiler/tests/structuring/degenerate_cond.snap
@@ -1,7 +1,5 @@
 ---
 source: crates/move-decompiler/tests/tests.rs
 ---
-'loop_0: loop {
-    { 0 }
-    continue 'loop_0;
-}
+{ 0 }
+{ 1 }

--- a/external-crates/move/crates/move-decompiler/tests/structuring/degenerate_cond.stt
+++ b/external-crates/move/crates/move-decompiler/tests/structuring/degenerate_cond.stt
@@ -1,0 +1,12 @@
+// A `cond` whose two arms point at the same label models the bytecode that compilation
+// produces for source-level `if (test_thing) {}` (empty then-body, optimizer forwards the
+// empty arm to the join). The translate.rs and testing.rs construction sites both normalize
+// this to a `Code` with a single fall-through edge, so structuring never sees a
+// dom-tree-leaf Condition with shared successors.
+//
+//   0  (cond, both arms -> 1)
+//   |
+//   1  (sink)
+
+cond,0,1,1
+code,1

--- a/external-crates/move/crates/move-decompiler/tests/structuring/loop_8.stt
+++ b/external-crates/move/crates/move-decompiler/tests/structuring/loop_8.stt
@@ -1,4 +1,6 @@
-// loop { continue }
+// A self-back-edge whose two arms target the same successor (itself). The construction-site
+// normalization turns it into `code,0,0` (self-looping code), so the block body's
+// condition-computation is preserved inside the loop instead of being dropped.
 
 cond,0,0,0
 

--- a/external-crates/move/crates/move-decompiler/tests/tests.rs
+++ b/external-crates/move/crates/move-decompiler/tests/tests.rs
@@ -47,7 +47,7 @@ fn run_move_test(file_path: &Path) -> datatest_stable::Result<()> {
 
     let model = model_builder::build(&mut writer, &root_pkg, &config)?;
 
-    let bytecode = move_stackless_bytecode_2::from_model(&model, /* optimize */ true)?;
+    let bytecode = move_stackless_bytecode_2::from_model(&model, /* optimize */ false)?;
 
     let test_module_names = std::io::BufReader::new(std::fs::File::open(file_path)?)
         .lines()


### PR DESCRIPTION
## Description

Two fixes for cleaner structuring: stop optimizing the stackless bytecode (we want faithful bytecode-to-source mapping), and lower a `JumpIf` whose arms target the same label as a `Code` edge so structuring never sees a degenerate Condition.

## Test plan

Snapshot test updates.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
