### PR TITLE
fix: duplicated words in sui-adapter and move-vm-runtime comments

### DIFF
--- a/external-crates/move/crates/move-vm-runtime/src/runtime/package_resolution.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/runtime/package_resolution.rs
@@ -183,7 +183,7 @@ fn load_packages(
         }
     };
 
-    // Should all be the same length, the the ordering should be preserved.
+    // Should all be the same length, the ordering should be preserved.
     debug_assert_eq!(pkgs.len(), ids.len());
     for (pkg, id) in pkgs.iter().zip(ids.iter()) {
         debug_assert_eq!(pkg.version_id, *id);

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/metering/pre_translation.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/metering/pre_translation.rs
@@ -12,7 +12,7 @@ use sui_types::{
 /// - number of inputs and pure input bytes
 /// - number of commands and their arguments
 /// - for Move calls, count arguments to the function (both value and type arguments) as the
-///   "arguments" to charge for for the command.
+///   "arguments" to charge for the command.
 pub fn meter<E: ExecutionErrorTrait>(
     meter: &mut TranslationMeter,
     transaction: &ProgrammableTransaction,

--- a/sui-execution/v3/sui-adapter/src/static_programmable_transactions/metering/pre_translation.rs
+++ b/sui-execution/v3/sui-adapter/src/static_programmable_transactions/metering/pre_translation.rs
@@ -12,7 +12,7 @@ use sui_types::{
 /// - number of inputs and pure input bytes
 /// - number of commands and their arguments
 /// - for Move calls, count arguments to the function (both value and type arguments) as the
-///   "arguments" to charge for for the command.
+///   "arguments" to charge for the command.
 pub fn meter(
     meter: &mut TranslationMeter,
     transaction: &ProgrammableTransaction,


### PR DESCRIPTION
Three one-line typo fixes for duplicated words in doc-comments:
- `sui-execution/latest/sui-adapter/src/static_programmable_transactions/metering/pre_translation.rs` — "arguments" to charge for for the command. → "...to charge for the command."
- `sui-execution/v3/sui-adapter/src/static_programmable_transactions/metering/pre_translation.rs` — same comment, same fix
- `external-crates/move/crates/move-vm-runtime/src/runtime/package_resolution.rs` — "Should all be the same length, the the ordering should be preserved." → "...the ordering should be preserved."

No code/behavior change.