### PR TITLE
[move][move-decompiler] Eliminate more gotos from conditional restructuring

### DIFF
--- a/external-crates/move/crates/move-decompiler/src/structuring/ast.rs
+++ b/external-crates/move/crates/move-decompiler/src/structuring/ast.rs
@@ -30,6 +30,47 @@ pub enum Input {
     Code(Label, Code, Option<Label>),
 }
 
+/// Provenance for a surviving `Jump`/`JumpIf`. Each variant names the structurer path that
+/// created the goto; the tag rides through `insert_breaks` and is printed on stderr when a
+/// Jump is lowered to `Unstructured(Goto)` in `generate_output`, letting the corpus driver
+/// attribute residual gotos by source.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GotoSource {
+    /// Then-arm of a Condition targets the post-dominator.
+    ConseqEqPostDom,
+    /// Else-arm of a Condition targets the post-dominator.
+    AltEqPostDom,
+    /// Condition whose arm targets the condition node itself (back-edge to the loop head).
+    DegenerateJumpIf,
+    /// Arm target sits outside start's dominator subtree (typically a Continue/Break to an
+    /// enclosing loop, rewritten later by that loop's `insert_breaks`).
+    ArmOutsideSubtree,
+    /// JumpIf emitted at a latch node by `structure_latch_node`.
+    LatchTest,
+    /// Jump emitted at a latch node's Code-input by `structure_latch_node`.
+    LatchCode,
+    /// Self-edge Jump emitted by `structure_code_node` for a code block whose `next` is
+    /// itself. Suspected unreachable in practice.
+    SelfLoop,
+    /// Escape Jump synthesized in `insert_breaks` when a JumpIf has one Latch arm.
+    EscapeJumpIf,
+}
+
+impl GotoSource {
+    pub fn as_tag(&self) -> &'static str {
+        match self {
+            GotoSource::ConseqEqPostDom => "CPD",
+            GotoSource::AltEqPostDom => "APD",
+            GotoSource::DegenerateJumpIf => "DJI",
+            GotoSource::ArmOutsideSubtree => "AOS",
+            GotoSource::LatchTest => "LT",
+            GotoSource::LatchCode => "LC",
+            GotoSource::SelfLoop => "SL",
+            GotoSource::EscapeJumpIf => "EJI",
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub enum Structured {
     /// `break 'label;` — targets the labeled enclosing Loop. Structuring always knows which
@@ -49,8 +90,10 @@ pub enum Structured {
         /* enum */ (ModuleId<Symbol>, Symbol),
         /* variant x rhs */ Vec<(Symbol, Structured)>,
     ),
-    Jump(Label),
-    JumpIf(Code, Label, Label),
+    /// Goto. `GotoSource` records which structurer path created it for instrumentation.
+    Jump(GotoSource, Label),
+    /// Two-way goto. Same instrumentation as `Jump`.
+    JumpIf(GotoSource, Code, Label, Label),
 }
 
 // -------------------------------------------------------------------------------------------------
@@ -157,13 +200,19 @@ impl std::fmt::Display for Structured {
                     indent(f, level)?;
                     writeln!(f, "continue 'loop_{};", label.index())
                 }
-                Structured::Jump(node_index) => {
+                Structured::Jump(src, node_index) => {
                     indent(f, level)?;
-                    writeln!(f, "jump {:?};", node_index)
+                    writeln!(f, "jump<{}> {:?};", src.as_tag(), node_index)
                 }
-                Structured::JumpIf(_, node_index, node_index1) => {
+                Structured::JumpIf(src, _, node_index, node_index1) => {
                     indent(f, level)?;
-                    writeln!(f, "jump_if ({:?}, {:?});", node_index, node_index1)
+                    writeln!(
+                        f,
+                        "jump_if<{}> ({:?}, {:?});",
+                        src.as_tag(),
+                        node_index,
+                        node_index1
+                    )
                 }
             }
         }

--- a/external-crates/move/crates/move-decompiler/src/structuring/graph.rs
+++ b/external-crates/move/crates/move-decompiler/src/structuring/graph.rs
@@ -22,6 +22,10 @@ pub struct Graph {
     pub loop_heads: HashSet<NodeIndex>,
     pub back_edges: HashMap<NodeIndex, HashSet<NodeIndex>>,
     pub post_dominators: Dominators<NodeIndex>,
+    /// For each node, the set of enclosing loop heads whose bodies contain it. Empty for
+    /// top-level nodes. Built once in `Graph::new` and read by `structure_acyclic_region`
+    /// to compare the loop scope of `start` against that of `post_dominator`.
+    pub loop_scopes: HashMap<NodeIndex, HashSet<NodeIndex>>,
 }
 
 impl Graph {
@@ -62,14 +66,35 @@ impl Graph {
             print_heading("loop heads");
             println!("{loop_heads:#?}");
         }
-        Self {
+        let mut graph = Self {
             cfg,
             dom_tree,
             loop_heads,
             back_edges,
             post_dominators,
             return_,
+            loop_scopes: HashMap::new(),
+        };
+        // For each loop head, compute its body and record membership. Precomputing here
+        // turns the per-call scope-equality check in `structure_acyclic_region` into O(1).
+        let mut loop_scopes: HashMap<NodeIndex, HashSet<NodeIndex>> = HashMap::new();
+        for &lh in &graph.loop_heads {
+            let (body, _) = graph.find_loop_nodes(lh);
+            for node in body {
+                loop_scopes.entry(node).or_default().insert(lh);
+            }
         }
+        graph.loop_scopes = loop_scopes;
+        graph
+    }
+
+    /// The set of loop heads whose bodies contain `node`. Empty for top-level nodes. Two
+    /// nodes share a loop scope iff this returns equal sets for them.
+    pub fn loop_scope_of(&self, node: NodeIndex) -> &HashSet<NodeIndex> {
+        static EMPTY: std::sync::OnceLock<HashSet<NodeIndex>> = std::sync::OnceLock::new();
+        self.loop_scopes
+            .get(&node)
+            .unwrap_or_else(|| EMPTY.get_or_init(HashSet::new))
     }
 
     pub fn update_latch_nodes(&mut self, node: NodeIndex, latch: NodeIndex) {

--- a/external-crates/move/crates/move-decompiler/src/structuring/mod.rs
+++ b/external-crates/move/crates/move-decompiler/src/structuring/mod.rs
@@ -9,7 +9,10 @@ pub(crate) mod term_reconstruction;
 
 use crate::{
     config::{self, print_heading},
-    structuring::{ast as D, graph::Graph},
+    structuring::{
+        ast::{self as D, GotoSource},
+        graph::Graph,
+    },
 };
 
 use petgraph::{graph::NodeIndex, visit::DfsPostOrder};
@@ -188,7 +191,9 @@ fn insert_breaks(
             LatchKind::Continue => DS::Continue(loop_head),
             LatchKind::Break => DS::Break(loop_head),
             LatchKind::InLoop => DS::Seq(vec![]),
-            LatchKind::Latch => DS::Jump(next),
+            // A JumpIf arm that escapes this loop (and isn't a body fall-through).
+            // Tagged D2 because it originates inside `insert_breaks`'s JumpIf handling.
+            LatchKind::Latch => DS::Jump(GotoSource::EscapeJumpIf, next),
         };
         Box::new(conseq)
     }
@@ -217,22 +222,23 @@ fn insert_breaks(
             Box::new(insert_breaks(loop_nodes, loop_head, succ_node, *conseq)),
             Box::new(alt.map(|alt| insert_breaks(loop_nodes, loop_head, succ_node, alt))),
         ),
-        DS::Jump(next) => match find_latch_kind(loop_nodes, loop_head, succ_node, next) {
+        DS::Jump(src, next) => match find_latch_kind(loop_nodes, loop_head, succ_node, next) {
             LatchKind::Continue => DS::Continue(loop_head),
             LatchKind::Break => DS::Break(loop_head),
             // TODO check if jump target is the next node
             LatchKind::InLoop => D::Structured::Seq(vec![]),
             // Targets neither this loop nor anything dominated by it; leave the raw Jump for
             // an enclosing loop's pass (or for `generate_output` to lower to Unstructured).
-            LatchKind::Latch => node,
+            // Preserve the original creation tag: the same Jump escaping outward.
+            LatchKind::Latch => DS::Jump(src, next),
         },
-        DS::JumpIf(code, next, other) => {
+        DS::JumpIf(src, code, next, other) => {
             let next_latch = find_latch_kind(loop_nodes, loop_head, succ_node, next);
             let other_latch = find_latch_kind(loop_nodes, loop_head, succ_node, other);
             match (next_latch, other_latch) {
                 (LatchKind::Continue, LatchKind::Continue) => DS::Continue(loop_head),
                 (LatchKind::Break, LatchKind::Break) => DS::Break(loop_head),
-                (LatchKind::Latch, LatchKind::Latch) => DS::JumpIf(code, next, other),
+                (LatchKind::Latch, LatchKind::Latch) => DS::JumpIf(src, code, next, other),
                 (LatchKind::InLoop, LatchKind::InLoop) => unreachable!(),
                 (conseq_lk, alt_lk) => {
                     let conseq = lower_conseq(conseq_lk, loop_head, next);
@@ -268,18 +274,12 @@ fn structure_acyclic(
     input: &mut BTreeMap<D::Label, D::Input>,
     inside_loop: bool,
 ) {
-    let dom_node = graph.dom_tree.get(node);
     if graph.back_edges.contains_key(&node) {
         let result = structure_latch_node(config, graph, node, input.remove(&node).unwrap());
         structured_blocks.insert(node, result);
-    } else if dom_node.all_children().count() > 0 {
+    } else {
         let result =
             structure_acyclic_region(config, graph, structured_blocks, input, node, inside_loop);
-        structured_blocks.insert(node, result);
-    } else {
-        assert!(matches!(&input[&node], D::Input::Code(..)));
-        let code_node = input.remove(&node).unwrap();
-        let result = structure_code_node(config, graph, structured_blocks, node, code_node);
         structured_blocks.insert(node, result);
     }
 }
@@ -292,6 +292,12 @@ fn structure_acyclic_region(
     start: NodeIndex,
     inside_loop: bool,
 ) -> D::Structured {
+    // Code has no arms and no post-dominator role; delegate before the dom-tree work.
+    if matches!(&input[&start], D::Input::Code(..)) {
+        let code_node = input.remove(&start).unwrap();
+        return structure_code_node(config, graph, structured_blocks, start, code_node);
+    }
+
     let dom_node = graph.dom_tree.get(start);
     let ichildren = dom_node.immediate_children().collect::<HashSet<_>>();
     let post_dominator = graph.post_dominators.immediate_dominator(start).unwrap();
@@ -310,31 +316,120 @@ fn structure_acyclic_region(
         );
     }
 
-    let structured = match input.remove(&start).unwrap() {
-        D::Input::Condition(_, code, conseq, alt) if conseq == start || alt == start => {
-            return D::Structured::JumpIf(code, conseq, alt);
-        }
-        D::Input::Condition(_lbl, code, conseq, alt) => {
-            assert!(ichildren.contains(&conseq));
+    // True when every predecessor of `post_dominator` lies in start's dominator subtree.
+    // Post-dom is then reachable only through us, so no outer scope will emit it; arm-jumps
+    // targeting it become redundant and can be elided in favor of inline sequencing.
+    let we_own_post_dom = if post_dominator == graph.return_ {
+        false
+    } else {
+        let subtree: HashSet<NodeIndex> = dom_node
+            .all_children()
+            .chain(std::iter::once(start))
+            .collect();
+        graph
+            .cfg
+            .neighbors_directed(post_dominator, petgraph::Direction::Incoming)
+            .all(|pred| subtree.contains(&pred))
+    };
+    // True when start and post_dominator share the same set of enclosing loops. Inlining
+    // post_dom consumes it from `structured_blocks`; if it belongs to an outer scope (e.g.,
+    // a post-loop continuation), the consuming structurer would drag it inside the wrong
+    // region.
+    let same_loop_scope = graph.loop_scope_of(start) == graph.loop_scope_of(post_dominator);
+    let emit_post_dom_in_seq = post_dominator != graph.return_
+        && we_own_post_dom
+        && same_loop_scope
+        && !graph.back_edges.contains_key(&start)
+        && !inside_loop;
 
-            let conseq_arm = if conseq != post_dominator {
-                structured_blocks.remove(&conseq).unwrap()
-            } else {
-                D::Structured::Jump(conseq)
-            };
-            let alt = if ichildren.contains(&alt) && alt != post_dominator {
-                graph.update_latch_branch_nodes(start, vec![conseq, alt]);
-                let alt = structured_blocks.remove(&alt);
-                assert!(alt.is_some());
-                alt
-            } else if alt == post_dominator {
-                graph.update_latch_branch_nodes(start, vec![conseq]);
-                Some(D::Structured::Jump(alt))
-            } else {
-                graph.update_latch_nodes(start, conseq);
+    if config.debug_print.dominators {
+        println!("  we own post-dominator: {we_own_post_dom}");
+        println!("  emit post-dominator in sequence: {emit_post_dom_in_seq}");
+    }
+
+    /// Classify one Condition arm and produce its structured form (or `None` to omit it):
+    ///   - `target == start`: back-edge to a loop head; emit `Jump(DegenerateJumpIf)`.
+    ///   - `target == post_dom`, owned and inline-sequenced: `None` (fall through).
+    ///   - `target == post_dom`, not owned/sequenced: `Jump(pd_src)` for `insert_breaks`
+    ///     to rewrite. `pd_src` distinguishes which arm produced it.
+    ///   - `target` in start's dominator subtree: embed its already-structured form.
+    ///   - Otherwise: `Jump(ArmOutsideSubtree)`. Target is owned by an enclosing structure;
+    ///     the enclosing `insert_breaks` rewrites it.
+    fn arm_for(
+        target: NodeIndex,
+        start: NodeIndex,
+        post_dominator: NodeIndex,
+        ichildren: &HashSet<NodeIndex>,
+        structured_blocks: &mut BTreeMap<NodeIndex, D::Structured>,
+        emit_post_dom_in_seq: bool,
+        pd_src: GotoSource,
+    ) -> Option<D::Structured> {
+        if target == start {
+            Some(D::Structured::Jump(GotoSource::DegenerateJumpIf, target))
+        } else if target == post_dominator {
+            if emit_post_dom_in_seq {
                 None
-            };
-            D::Structured::IfElse(code, Box::new(conseq_arm), Box::new(alt))
+            } else {
+                Some(D::Structured::Jump(pd_src, target))
+            }
+        } else if ichildren.contains(&target) {
+            Some(structured_blocks.remove(&target).unwrap())
+        } else {
+            Some(D::Structured::Jump(GotoSource::ArmOutsideSubtree, target))
+        }
+    }
+
+    let structured = match input.remove(&start).unwrap() {
+        D::Input::Condition(_lbl, code, conseq, alt) => {
+            // No `ichildren.contains(&conseq)` assertion: `arm_for` handles every case
+            // (in-subtree, post-dom, self-edge, or outside-subtree).
+            let conseq_arm = arm_for(
+                conseq,
+                start,
+                post_dominator,
+                &ichildren,
+                structured_blocks,
+                emit_post_dom_in_seq,
+                GotoSource::ConseqEqPostDom,
+            );
+            let alt_arm = arm_for(
+                alt,
+                start,
+                post_dominator,
+                &ichildren,
+                structured_blocks,
+                emit_post_dom_in_seq,
+                GotoSource::AltEqPostDom,
+            );
+
+            // Transfer back-edge ownership for absorbed arms (arms whose structured body we
+            // embedded; only the `ichildren` branch of `arm_for` absorbs). Arms that emit a
+            // Jump marker keep their own bookkeeping.
+            let mut absorbed = vec![];
+            if conseq != start && ichildren.contains(&conseq) && conseq != post_dominator {
+                absorbed.push(conseq);
+            }
+            if alt != start && ichildren.contains(&alt) && alt != post_dominator {
+                absorbed.push(alt);
+            }
+            if !absorbed.is_empty() {
+                graph.update_latch_branch_nodes(start, absorbed);
+            }
+
+            match (conseq_arm, alt_arm) {
+                // Both arms collapsed to the inline post-dom. Conditional reduces to
+                // evaluating `code` for effect; the post-dom block is sequenced below.
+                (None, None) => D::Structured::Block(code),
+                // Empty-then with non-empty else. A later `Exp::IfElse` refinement can
+                // negate the condition and flip into a non-empty `then`.
+                (None, Some(body)) => D::Structured::IfElse(
+                    code,
+                    Box::new(D::Structured::Seq(vec![])),
+                    Box::new(Some(body)),
+                ),
+                (Some(body), None) => D::Structured::IfElse(code, Box::new(body), Box::new(None)),
+                (Some(c), Some(a)) => D::Structured::IfElse(code, Box::new(c), Box::new(Some(a))),
+            }
         }
         D::Input::Variants(_lbl, code, enum_, items) => {
             let latches = items
@@ -372,9 +467,7 @@ fn structure_acyclic_region(
             // more painful -- analysis.
             D::Structured::Switch(code, enum_, arms)
         }
-        code @ D::Input::Code(..) => {
-            return structure_code_node(config, graph, structured_blocks, start, code);
-        }
+        D::Input::Code(..) => unreachable!("Code shortcut at top of structure_acyclic_region"),
     };
     let mut exp = vec![structured];
 
@@ -414,10 +507,12 @@ fn structure_latch_node(
     }
     assert!(graph.back_edges.contains_key(&node_ndx));
     match node {
-        D::Input::Condition(_, code, conseq, alt) => D::Structured::JumpIf(code, conseq, alt),
+        D::Input::Condition(_, code, conseq, alt) => {
+            D::Structured::JumpIf(GotoSource::LatchTest, code, conseq, alt)
+        }
         D::Input::Code(_, code, next) => D::Structured::Seq(vec![
             D::Structured::Block(code),
-            D::Structured::Jump(next.unwrap()),
+            D::Structured::Jump(GotoSource::LatchCode, next.unwrap()),
         ]),
         D::Input::Variants(_, _, _, _) => unreachable!(),
     }
@@ -434,9 +529,10 @@ fn structure_code_node(
         println!("structuring code node: {node:#?}");
     }
     match node {
-        D::Input::Code(_, code, Some(next)) if next == node_ndx => {
-            D::Structured::Seq(vec![D::Structured::Block(code), D::Structured::Jump(next)])
-        }
+        D::Input::Code(_, code, Some(next)) if next == node_ndx => D::Structured::Seq(vec![
+            D::Structured::Block(code),
+            D::Structured::Jump(GotoSource::SelfLoop, next),
+        ]),
         D::Input::Code(_, code, next) => {
             let mut seq = vec![D::Structured::Block(code)];
             if let Some(next) = next
@@ -475,8 +571,8 @@ fn flatten_sequence(seq: D::Structured) -> D::Structured {
             | DS::IfElse(_, _, _)
             | DS::Switch(_, _, _)
             | DS::Continue(_)
-            | DS::Jump(_)
-            | DS::JumpIf(_, _, _) => result.push(entry),
+            | DS::Jump(_, _)
+            | DS::JumpIf(_, _, _, _) => result.push(entry),
         }
     }
 

--- a/external-crates/move/crates/move-decompiler/src/translate.rs
+++ b/external-crates/move/crates/move-decompiler/src/translate.rs
@@ -332,7 +332,15 @@ fn generate_output(mut terms: BTreeMap<D::Label, Out::Exp>, structured: D::Struc
             };
             // When a cond block has list of exp before the jump, we need to pop the conditional statement and
             let (cond, mut exps) = (seq.pop().unwrap(), seq);
-            let alt_exp = alt.map(|a| generate_output(terms.clone(), a));
+            // Drop an alt that collapsed to an empty Seq (typically from `LatchKind::InLoop`
+            // in `insert_breaks`); otherwise the output renders with empty `else { }` braces.
+            let alt_exp = alt.and_then(|a| {
+                let e = generate_output(terms.clone(), a);
+                match &e {
+                    Exp::Seq(items) if items.is_empty() => None,
+                    _ => Some(e),
+                }
+            });
             exps.push(Out::Exp::IfElse(
                 Box::new(cond),
                 Box::new(generate_output(terms.clone(), *conseq)),
@@ -358,11 +366,14 @@ fn generate_output(mut terms: BTreeMap<D::Label, Out::Exp>, structured: D::Struc
             ));
             Out::Exp::Seq(exps)
         }
-        D::Structured::Jump(target) => {
+        D::Structured::Jump(src, target) => {
             let label = target.index() as u64;
+            // Surviving Jump becomes a real goto; tag the line with its creation site so
+            // the corpus driver can break down residue by category.
+            eprintln!("GOTO[{}] -> label_{}", src.as_tag(), label);
             Out::Exp::Unstructured(vec![Out::UnstructuredNode::Goto(label)])
         }
-        D::Structured::JumpIf(code, then_target, else_target) => {
+        D::Structured::JumpIf(src, code, then_target, else_target) => {
             let term = terms.remove(&(code as u32).into()).unwrap();
             let Exp::Seq(mut seq) = term else {
                 panic!("Expected Seq for JumpIf condition")
@@ -371,6 +382,12 @@ fn generate_output(mut terms: BTreeMap<D::Label, Out::Exp>, structured: D::Struc
 
             let then_label = then_target.index() as u64;
             let else_label = else_target.index() as u64;
+            eprintln!(
+                "GOTO[{}] -> label_{}/label_{}",
+                src.as_tag(),
+                then_label,
+                else_label
+            );
 
             seq.push(Out::Exp::IfElse(
                 Box::new(cond),

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/dbke.mv.snap
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/dbke.mv.snap
@@ -82,10 +82,6 @@ public fun elf<T,T,T>(l0: &mut 0x2c8d603bc51326b8c13cef9dd07031a408a48dddb541963
         let l52 = bm::gdtp(l1, l2, l15);
         if (l6) {
             pool::cancel_all_orders(l0, l2, &l52, l3, freeze(l15))
-        } else {
-            unstructured {
-                goto 'label_41;
-            }
         };
         let (reg_31, reg_32, reg_33) = pool::pool_book_params(freeze(l0));
         let l32 = reg_33;
@@ -151,8 +147,6 @@ public fun elf<T,T,T>(l0: &mut 0x2c8d603bc51326b8c13cef9dd07031a408a48dddb541963
                     l22 = reg_134;
                     l19 = l18;
                     l50 = true;
-                } else {
-                    
                 };
                 let l49 = dbke::sp(&l22, &l19, l51, l27, l29);
                 if (l49 == 0u64) {

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/nft_claim.mv.snap
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/nft_claim.mv.snap
@@ -80,8 +80,6 @@ public entry fun mint_batch(l0: &mut 0x5c00961b77fad9e563bbf817c5cf8f49f7db8aa7b
         let l5 = *(&(&l1)[l3]);
         if (!(vec_set::contains(&l0.claimed, &l5))) {
             nft_claim::mint_single(l0, l5, l2)
-        } else {
-            
         };
         l3 = l3 + 1u64;
     }

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/output/0x5c00961b77fad9e563bbf817c5cf8f49f7db8aa7b12bf6799ee00a837816a3d8/nft_claim.move
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/output/0x5c00961b77fad9e563bbf817c5cf8f49f7db8aa7b12bf6799ee00a837816a3d8/nft_claim.move
@@ -77,8 +77,6 @@ public entry fun mint_batch(l0: &mut 0x5c00961b77fad9e563bbf817c5cf8f49f7db8aa7b
         let l5 = *(&(&l1)[l3]);
         if (!(vec_set::contains(&l0.claimed, &l5))) {
             nft_claim::mint_single(l0, l5, l2)
-        } else {
-            
         };
         l3 = l3 + 1u64;
     }

--- a/external-crates/move/crates/move-decompiler/tests/bytecode/output/0xb24efcc5dcf03cf4b1fb0e2155206b4e2c5b008da29ff4025a0db241e4578976/dbke.move
+++ b/external-crates/move/crates/move-decompiler/tests/bytecode/output/0xb24efcc5dcf03cf4b1fb0e2155206b4e2c5b008da29ff4025a0db241e4578976/dbke.move
@@ -79,10 +79,6 @@ public fun elf<T,T,T>(l0: &mut 0x2c8d603bc51326b8c13cef9dd07031a408a48dddb541963
         let l52 = bm::gdtp(l1, l2, l15);
         if (l6) {
             pool::cancel_all_orders(l0, l2, &l52, l3, freeze(l15))
-        } else {
-            unstructured {
-                goto 'label_41;
-            }
         };
         let (reg_31, reg_32, reg_33) = pool::pool_book_params(freeze(l0));
         let l32 = reg_33;
@@ -148,8 +144,6 @@ public fun elf<T,T,T>(l0: &mut 0x2c8d603bc51326b8c13cef9dd07031a408a48dddb541963
                     l22 = reg_134;
                     l19 = l18;
                     l50 = true;
-                } else {
-                    
                 };
                 let l49 = dbke::sp(&l22, &l19, l51, l27, l29);
                 if (l49 == 0u64) {

--- a/external-crates/move/crates/move-decompiler/tests/move/loops/loop_cases.snap
+++ b/external-crates/move/crates/move-decompiler/tests/move/loops/loop_cases.snap
@@ -23,7 +23,6 @@ module loop_cases {
             l0 = l0 + 1u64;
             if (l0 % 2u64 == 1u64) {
                 continue;
-            } else {
             }
             if (l0 == 10u64) {
                 break;
@@ -84,7 +83,6 @@ module loop_cases {
             l1 = l1 * 2u64 + l0;
             if (l1 - l0 % 3u64 == 0u64) {
                 l1 = 100u64;
-            } else {
             }
             if (l0 >= 10u64) {
                 break;

--- a/external-crates/move/crates/move-decompiler/tests/move/loops/loop_cases@full.snap
+++ b/external-crates/move/crates/move-decompiler/tests/move/loops/loop_cases@full.snap
@@ -27,8 +27,6 @@ public fun loop_test_2() {
         l0 = l0 + 1u64;
         if (l0 % 2u64 == 1u64) {
             continue
-        } else {
-            
         };
         if (l0 == 10u64) {
             break
@@ -91,8 +89,6 @@ public fun loop_test_9() {
         l1 = l1 * 2u64 + l0;
         if (l1 - l0 % 3u64 == 0u64) {
             l1 = 100u64;
-        } else {
-            
         };
         if (l0 >= 10u64) {
             break

--- a/external-crates/move/crates/move-decompiler/tests/structuring/cond_with_no_ichildren.snap
+++ b/external-crates/move/crates/move-decompiler/tests/structuring/cond_with_no_ichildren.snap
@@ -1,0 +1,16 @@
+---
+source: crates/move-decompiler/tests/tests.rs
+---
+if (0) {
+    if (1) {
+        jump<AOS> NodeIndex(3);
+    } else {
+        jump<AOS> NodeIndex(4);
+    }
+} else {
+    if (2) {
+        jump<AOS> NodeIndex(3);
+    } else {
+        jump<AOS> NodeIndex(4);
+    }
+}

--- a/external-crates/move/crates/move-decompiler/tests/structuring/cond_with_no_ichildren.stt
+++ b/external-crates/move/crates/move-decompiler/tests/structuring/cond_with_no_ichildren.stt
@@ -1,0 +1,31 @@
+// A Condition node whose arms are both shared with another path -- neither arm is in the
+// Condition's dominator subtree, so `structure_acyclic`'s "no ichildren -> must be Code"
+// assertion fires for node 1 and node 2.
+//
+//        0 (cond) ── true ──> 1 (cond)
+//        │ false               │ true ─> 3
+//        ▼                     │ false ─> 4
+//        2 (cond) ── true ─────┘
+//        │ false
+//        ▼
+//        (same 3/4 from node 2's perspective)
+//
+// CFG:
+//   0 -> 1  (cond conseq)
+//   0 -> 2  (cond alt)
+//   1 -> 3  (cond conseq)
+//   1 -> 4  (cond alt)
+//   2 -> 3  (cond conseq)
+//   2 -> 4  (cond alt)
+//   3 sink
+//   4 sink
+//
+// For node 1: arms are 3 and 4. Each of 3 and 4 has two predecessors (1 and 2), so neither
+// is dominated immediately by 1. ichildren(1) = {}. Node 1 is not a back-edge source. Its
+// input is Condition. The assertion fires.
+
+cond,0,1,2
+cond,1,3,4
+cond,2,3,4
+code,3
+code,4

--- a/external-crates/move/crates/move-decompiler/tests/structuring/inner_alt_shared_with_outer.snap
+++ b/external-crates/move/crates/move-decompiler/tests/structuring/inner_alt_shared_with_outer.snap
@@ -1,0 +1,14 @@
+---
+source: crates/move-decompiler/tests/tests.rs
+---
+{ 0 }
+if (1) {
+    if (2) {
+        { 3 }
+    } else {
+        jump<AOS> NodeIndex(4);
+    }
+} else {
+    { 4 }
+}
+{ 5 }

--- a/external-crates/move/crates/move-decompiler/tests/structuring/inner_alt_shared_with_outer.stt
+++ b/external-crates/move/crates/move-decompiler/tests/structuring/inner_alt_shared_with_outer.stt
@@ -1,0 +1,44 @@
+// Regression test for the A4 case: inner condition's alt arm targets a node that is
+// neither the inner's post-dominator nor immediately dominated by it — instead it's a
+// "shared continuation" reached from both the outer cond's alt AND the inner cond's alt.
+//
+//        0
+//        |
+//        1 (cond) — then=2, else=4
+//       / \
+//      2   4    (node 4 is reachable from BOTH 1's else AND 2's else)
+//     /|   |
+//    3 |   |
+//    | └─→ 4
+//    └───→ 5
+//          ↑
+//          4 ───┘
+//
+// CFG (forward edges only):
+//   0 → 1
+//   1 → 2  (cond conseq)
+//   1 → 4  (cond alt)
+//   2 → 3  (inner cond conseq)
+//   2 → 4  (inner cond alt — the A4 edge: 4 is not ichild of 2 (1 dominates 4 too)
+//          and not the post-dom of 2 (5 is))
+//   3 → 5
+//   4 → 5
+//   5 (sink)
+//
+// For inner cond 2:
+//   - ichildren(2) = {3}   (4 has two predecessors so 1 dominates it, not 2)
+//   - post_dom(2)  = 5     (paths 2→3→5 and 2→4→5 converge at 5)
+//   - So `alt=4` hits neither branch of the current arm logic: it's not the post-dom
+//     and not an ichild → the existing code emits `None` for the alt arm, silently
+//     dropping the 2→4 edge.
+//
+// Currently this snapshot will show the alt arm as missing or jump[A4] absent —
+// after Phase 1 lands, the alt should emit a goto[A4] (or, when Phase 4 lands, the
+// arm becomes a proper enclosing-scope `LatchEdge` and disappears entirely).
+
+code,0,1
+cond,1,2,4
+cond,2,3,4
+code,3,5
+code,4,5
+code,5

--- a/external-crates/move/crates/move-decompiler/tests/structuring/loop_14.snap
+++ b/external-crates/move/crates/move-decompiler/tests/structuring/loop_14.snap
@@ -9,8 +9,6 @@ source: crates/move-decompiler/tests/tests.rs
         { 3 }
         if (4) {
             { 5 }
-        } else {
-            { }
         }
         { 6 }
         continue 'loop_1;

--- a/external-crates/move/crates/move-decompiler/tests/structuring/nested_ifs_1.snap
+++ b/external-crates/move/crates/move-decompiler/tests/structuring/nested_ifs_1.snap
@@ -6,12 +6,10 @@ if (0) {
         if (2) {
             { 3 }
         } else {
-            jump NodeIndex(4);
+            jump<APD> NodeIndex(4);
         }
     } else {
-        jump NodeIndex(4);
+        jump<APD> NodeIndex(4);
     }
-} else {
-    jump NodeIndex(4);
 }
 { 4 }

--- a/external-crates/move/crates/move-decompiler/tests/structuring/tangled_infinite_loops.snap
+++ b/external-crates/move/crates/move-decompiler/tests/structuring/tangled_infinite_loops.snap
@@ -11,7 +11,7 @@ if (0) {
         }
     }
 } else {
-    jump NodeIndex(3);
+    jump<APD> NodeIndex(3);
 }
 'loop_3: loop {
     { 3 }


### PR DESCRIPTION
## Description 

Eliminate the redundant goto-to-post-dom logic that drove most of the residual `goto`s (~77%) in decompiled output. The Condition arm logic now emits None when we own and inline-sequence the post-dom, so the dropped `goto` and the inline post-dom are no longer both emitted. Per-site provenance tags (GotoSource) ride along so we can attribute whatever residue is left.

Also fixes a latent bug where an arm whose target was outside our dominator subtree got silently dropped; it now emits a Jump  marker for the enclosing scope to rewrite. 

Fixes an additional bug with two assertions that overstated invariants; Move's compiler can emit Conditions with no immediate dom-children.

We also not quantify the kind of a Jump that is generated, for easier tracking and fixing the last of them.

## Test plan 

All 52 snapshot tests pass. Two new structuring regressions:
  - inner_alt_shared_with_outer.stt — formerly-dropped continue to outer loop now visible as jump<AOS>.
  - cond_with_no_ichildren.stt — branching node with both arms shared no longer panics in the dispatcher.

Corpus run drops residual-goto packages from ~44k to ~10k. 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
