### PR TITLE
[Block Streaming] support DKG generation as an Observer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5492,10 +5492,14 @@ dependencies = [
 name = "fastcrypto"
 version = "0.1.9"
 <<<<<<< HEAD
+<<<<<<< HEAD
 source = "git+https://github.com/MystenLabs/fastcrypto?rev=0eea35ee442a798fb1f1e7c2f39dc021bd21dbc3#0eea35ee442a798fb1f1e7c2f39dc021bd21dbc3"
 =======
 source = "git+https://github.com/MystenLabs/fastcrypto?rev=8e9ae9ba438a3219ad849d3f163c61868e1ce3c9#8e9ae9ba438a3219ad849d3f163c61868e1ce3c9"
 >>>>>>> 86a9ea0ec6 ([refactor] support randomness for observer sync nodes)
+=======
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=a2a33f214e67df33e97275b4bc72da84f243f4a4#a2a33f214e67df33e97275b4bc72da84f243f4a4"
+>>>>>>> 8adfeb8a73 ([refactor] use initial Observer version.)
 dependencies = [
  "aes",
  "aes-gcm",
@@ -5555,7 +5559,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto-derive"
 version = "0.1.3"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=8e9ae9ba438a3219ad849d3f163c61868e1ce3c9#8e9ae9ba438a3219ad849d3f163c61868e1ce3c9"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=a2a33f214e67df33e97275b4bc72da84f243f4a4#a2a33f214e67df33e97275b4bc72da84f243f4a4"
 dependencies = [
  "quote",
  "syn 1.0.107",
@@ -5564,7 +5568,9 @@ dependencies = [
 [[package]]
 name = "fastcrypto-tbls"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=8e9ae9ba438a3219ad849d3f163c61868e1ce3c9#8e9ae9ba438a3219ad849d3f163c61868e1ce3c9"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=a2a33f214e67df33e97275b4bc72da84f243f4a4#a2a33f214e67df33e97275b4bc72da84f243f4a4"
+dependencies = [
+ "bcs",
  "digest 0.10.7",
  "hex",
  "itertools 0.10.5",
@@ -5581,7 +5587,7 @@ source = "git+https://github.com/MystenLabs/fastcrypto?rev=8e9ae9ba438a3219ad849
 [[package]]
 name = "fastcrypto-vdf"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=8e9ae9ba438a3219ad849d3f163c61868e1ce3c9#8e9ae9ba438a3219ad849d3f163c61868e1ce3c9"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=a2a33f214e67df33e97275b4bc72da84f243f4a4#a2a33f214e67df33e97275b4bc72da84f243f4a4"
 dependencies = [
  "bcs",
  "fastcrypto",
@@ -5598,7 +5604,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto-zkp"
 version = "0.1.3"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=8e9ae9ba438a3219ad849d3f163c61868e1ce3c9#8e9ae9ba438a3219ad849d3f163c61868e1ce3c9"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=a2a33f214e67df33e97275b4bc72da84f243f4a4#a2a33f214e67df33e97275b4bc72da84f243f4a4"
 dependencies = [
  "ark-bn254",
  "ark-ec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5491,7 +5491,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto"
 version = "0.1.9"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=2ae161a578262a5bbf5c3872054c7f957d744f78#2ae161a578262a5bbf5c3872054c7f957d744f78"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=239eed70b763f89fdb1e6c6866fe389690945c45#239eed70b763f89fdb1e6c6866fe389690945c45"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -5552,7 +5552,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto-derive"
 version = "0.1.3"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=2ae161a578262a5bbf5c3872054c7f957d744f78#2ae161a578262a5bbf5c3872054c7f957d744f78"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=239eed70b763f89fdb1e6c6866fe389690945c45#239eed70b763f89fdb1e6c6866fe389690945c45"
 dependencies = [
  "quote",
  "syn 1.0.107",
@@ -5561,7 +5561,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto-tbls"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=2ae161a578262a5bbf5c3872054c7f957d744f78#2ae161a578262a5bbf5c3872054c7f957d744f78"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=239eed70b763f89fdb1e6c6866fe389690945c45#239eed70b763f89fdb1e6c6866fe389690945c45"
 dependencies = [
  "bcs",
  "digest 0.10.7",
@@ -5581,7 +5581,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto-vdf"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=2ae161a578262a5bbf5c3872054c7f957d744f78#2ae161a578262a5bbf5c3872054c7f957d744f78"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=239eed70b763f89fdb1e6c6866fe389690945c45#239eed70b763f89fdb1e6c6866fe389690945c45"
 dependencies = [
  "bcs",
  "fastcrypto",
@@ -5598,7 +5598,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto-zkp"
 version = "0.1.3"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=2ae161a578262a5bbf5c3872054c7f957d744f78#2ae161a578262a5bbf5c3872054c7f957d744f78"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=239eed70b763f89fdb1e6c6866fe389690945c45#239eed70b763f89fdb1e6c6866fe389690945c45"
 dependencies = [
  "ark-bn254",
  "ark-ec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5491,15 +5491,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto"
 version = "0.1.9"
-<<<<<<< HEAD
-<<<<<<< HEAD
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=0eea35ee442a798fb1f1e7c2f39dc021bd21dbc3#0eea35ee442a798fb1f1e7c2f39dc021bd21dbc3"
-=======
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=8e9ae9ba438a3219ad849d3f163c61868e1ce3c9#8e9ae9ba438a3219ad849d3f163c61868e1ce3c9"
->>>>>>> 86a9ea0ec6 ([refactor] support randomness for observer sync nodes)
-=======
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=a2a33f214e67df33e97275b4bc72da84f243f4a4#a2a33f214e67df33e97275b4bc72da84f243f4a4"
->>>>>>> 8adfeb8a73 ([refactor] use initial Observer version.)
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=2ae161a578262a5bbf5c3872054c7f957d744f78#2ae161a578262a5bbf5c3872054c7f957d744f78"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -5531,6 +5523,7 @@ dependencies = [
  "hex",
  "hex-literal 0.4.1",
  "hkdf",
+ "itertools 0.12.1",
  "lazy_static",
  "merlin",
  "num-bigint 0.4.6",
@@ -5559,7 +5552,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto-derive"
 version = "0.1.3"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=a2a33f214e67df33e97275b4bc72da84f243f4a4#a2a33f214e67df33e97275b4bc72da84f243f4a4"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=2ae161a578262a5bbf5c3872054c7f957d744f78#2ae161a578262a5bbf5c3872054c7f957d744f78"
 dependencies = [
  "quote",
  "syn 1.0.107",
@@ -5568,10 +5561,11 @@ dependencies = [
 [[package]]
 name = "fastcrypto-tbls"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=a2a33f214e67df33e97275b4bc72da84f243f4a4#a2a33f214e67df33e97275b4bc72da84f243f4a4"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=2ae161a578262a5bbf5c3872054c7f957d744f78#2ae161a578262a5bbf5c3872054c7f957d744f78"
 dependencies = [
  "bcs",
  "digest 0.10.7",
+ "fastcrypto",
  "hex",
  "itertools 0.10.5",
  "rand 0.8.5",
@@ -5587,7 +5581,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto-vdf"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=a2a33f214e67df33e97275b4bc72da84f243f4a4#a2a33f214e67df33e97275b4bc72da84f243f4a4"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=2ae161a578262a5bbf5c3872054c7f957d744f78#2ae161a578262a5bbf5c3872054c7f957d744f78"
 dependencies = [
  "bcs",
  "fastcrypto",
@@ -5604,7 +5598,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto-zkp"
 version = "0.1.3"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=a2a33f214e67df33e97275b4bc72da84f243f4a4#a2a33f214e67df33e97275b4bc72da84f243f4a4"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=2ae161a578262a5bbf5c3872054c7f957d744f78#2ae161a578262a5bbf5c3872054c7f957d744f78"
 dependencies = [
  "ark-bn254",
  "ark-ec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5491,7 +5491,11 @@ dependencies = [
 [[package]]
 name = "fastcrypto"
 version = "0.1.9"
+<<<<<<< HEAD
 source = "git+https://github.com/MystenLabs/fastcrypto?rev=0eea35ee442a798fb1f1e7c2f39dc021bd21dbc3#0eea35ee442a798fb1f1e7c2f39dc021bd21dbc3"
+=======
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=8e9ae9ba438a3219ad849d3f163c61868e1ce3c9#8e9ae9ba438a3219ad849d3f163c61868e1ce3c9"
+>>>>>>> 86a9ea0ec6 ([refactor] support randomness for observer sync nodes)
 dependencies = [
  "aes",
  "aes-gcm",
@@ -5523,7 +5527,6 @@ dependencies = [
  "hex",
  "hex-literal 0.4.1",
  "hkdf",
- "itertools 0.12.1",
  "lazy_static",
  "merlin",
  "num-bigint 0.4.6",
@@ -5552,7 +5555,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto-derive"
 version = "0.1.3"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=0eea35ee442a798fb1f1e7c2f39dc021bd21dbc3#0eea35ee442a798fb1f1e7c2f39dc021bd21dbc3"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=8e9ae9ba438a3219ad849d3f163c61868e1ce3c9#8e9ae9ba438a3219ad849d3f163c61868e1ce3c9"
 dependencies = [
  "quote",
  "syn 1.0.107",
@@ -5561,11 +5564,8 @@ dependencies = [
 [[package]]
 name = "fastcrypto-tbls"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=0eea35ee442a798fb1f1e7c2f39dc021bd21dbc3#0eea35ee442a798fb1f1e7c2f39dc021bd21dbc3"
-dependencies = [
- "bcs",
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=8e9ae9ba438a3219ad849d3f163c61868e1ce3c9#8e9ae9ba438a3219ad849d3f163c61868e1ce3c9"
  "digest 0.10.7",
- "fastcrypto",
  "hex",
  "itertools 0.10.5",
  "rand 0.8.5",
@@ -5581,7 +5581,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto-vdf"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=0eea35ee442a798fb1f1e7c2f39dc021bd21dbc3#0eea35ee442a798fb1f1e7c2f39dc021bd21dbc3"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=8e9ae9ba438a3219ad849d3f163c61868e1ce3c9#8e9ae9ba438a3219ad849d3f163c61868e1ce3c9"
 dependencies = [
  "bcs",
  "fastcrypto",
@@ -5598,7 +5598,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto-zkp"
 version = "0.1.3"
-source = "git+https://github.com/MystenLabs/fastcrypto?rev=0eea35ee442a798fb1f1e7c2f39dc021bd21dbc3#0eea35ee442a798fb1f1e7c2f39dc021bd21dbc3"
+source = "git+https://github.com/MystenLabs/fastcrypto?rev=8e9ae9ba438a3219ad849d3f163c61868e1ce3c9#8e9ae9ba438a3219ad849d3f163c61868e1ce3c9"
 dependencies = [
  "ark-bn254",
  "ark-ec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -617,10 +617,10 @@ move-abstract-stack = { path = "external-crates/move/crates/move-abstract-stack"
 move-analyzer = { path = "external-crates/move/crates/move-analyzer" }
 move-trace-format = { path = "external-crates/move/crates/move-trace-format" }
 
-fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "2ae161a578262a5bbf5c3872054c7f957d744f78" }
-fastcrypto-tbls = { git = "https://github.com/MystenLabs/fastcrypto", rev = "2ae161a578262a5bbf5c3872054c7f957d744f78" }
-fastcrypto-zkp = { git = "https://github.com/MystenLabs/fastcrypto", rev = "2ae161a578262a5bbf5c3872054c7f957d744f78", package = "fastcrypto-zkp" }
-fastcrypto-vdf = { git = "https://github.com/MystenLabs/fastcrypto", rev = "2ae161a578262a5bbf5c3872054c7f957d744f78", features = [
+fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "239eed70b763f89fdb1e6c6866fe389690945c45" }
+fastcrypto-tbls = { git = "https://github.com/MystenLabs/fastcrypto", rev = "239eed70b763f89fdb1e6c6866fe389690945c45" }
+fastcrypto-zkp = { git = "https://github.com/MystenLabs/fastcrypto", rev = "239eed70b763f89fdb1e6c6866fe389690945c45", package = "fastcrypto-zkp" }
+fastcrypto-vdf = { git = "https://github.com/MystenLabs/fastcrypto", rev = "239eed70b763f89fdb1e6c6866fe389690945c45", features = [
   "experimental",
 ] }
 passkey-types = { version = "0.4.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -617,10 +617,10 @@ move-abstract-stack = { path = "external-crates/move/crates/move-abstract-stack"
 move-analyzer = { path = "external-crates/move/crates/move-analyzer" }
 move-trace-format = { path = "external-crates/move/crates/move-trace-format" }
 
-fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "0eea35ee442a798fb1f1e7c2f39dc021bd21dbc3" }
-fastcrypto-tbls = { git = "https://github.com/MystenLabs/fastcrypto", rev = "0eea35ee442a798fb1f1e7c2f39dc021bd21dbc3" }
-fastcrypto-zkp = { git = "https://github.com/MystenLabs/fastcrypto", rev = "0eea35ee442a798fb1f1e7c2f39dc021bd21dbc3", package = "fastcrypto-zkp" }
-fastcrypto-vdf = { git = "https://github.com/MystenLabs/fastcrypto", rev = "0eea35ee442a798fb1f1e7c2f39dc021bd21dbc3", features = [
+fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "8e9ae9ba438a3219ad849d3f163c61868e1ce3c9" }
+fastcrypto-tbls = { git = "https://github.com/MystenLabs/fastcrypto", rev = "8e9ae9ba438a3219ad849d3f163c61868e1ce3c9" }
+fastcrypto-zkp = { git = "https://github.com/MystenLabs/fastcrypto", rev = "8e9ae9ba438a3219ad849d3f163c61868e1ce3c9", package = "fastcrypto-zkp" }
+fastcrypto-vdf = { git = "https://github.com/MystenLabs/fastcrypto", rev = "8e9ae9ba438a3219ad849d3f163c61868e1ce3c9", features = [
   "experimental",
 ] }
 passkey-types = { version = "0.4.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -617,10 +617,10 @@ move-abstract-stack = { path = "external-crates/move/crates/move-abstract-stack"
 move-analyzer = { path = "external-crates/move/crates/move-analyzer" }
 move-trace-format = { path = "external-crates/move/crates/move-trace-format" }
 
-fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "8e9ae9ba438a3219ad849d3f163c61868e1ce3c9" }
-fastcrypto-tbls = { git = "https://github.com/MystenLabs/fastcrypto", rev = "8e9ae9ba438a3219ad849d3f163c61868e1ce3c9" }
-fastcrypto-zkp = { git = "https://github.com/MystenLabs/fastcrypto", rev = "8e9ae9ba438a3219ad849d3f163c61868e1ce3c9", package = "fastcrypto-zkp" }
-fastcrypto-vdf = { git = "https://github.com/MystenLabs/fastcrypto", rev = "8e9ae9ba438a3219ad849d3f163c61868e1ce3c9", features = [
+fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "a2a33f214e67df33e97275b4bc72da84f243f4a4" }
+fastcrypto-tbls = { git = "https://github.com/MystenLabs/fastcrypto", rev = "a2a33f214e67df33e97275b4bc72da84f243f4a4" }
+fastcrypto-zkp = { git = "https://github.com/MystenLabs/fastcrypto", rev = "a2a33f214e67df33e97275b4bc72da84f243f4a4", package = "fastcrypto-zkp" }
+fastcrypto-vdf = { git = "https://github.com/MystenLabs/fastcrypto", rev = "a2a33f214e67df33e97275b4bc72da84f243f4a4", features = [
   "experimental",
 ] }
 passkey-types = { version = "0.4.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -617,10 +617,10 @@ move-abstract-stack = { path = "external-crates/move/crates/move-abstract-stack"
 move-analyzer = { path = "external-crates/move/crates/move-analyzer" }
 move-trace-format = { path = "external-crates/move/crates/move-trace-format" }
 
-fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "a2a33f214e67df33e97275b4bc72da84f243f4a4" }
-fastcrypto-tbls = { git = "https://github.com/MystenLabs/fastcrypto", rev = "a2a33f214e67df33e97275b4bc72da84f243f4a4" }
-fastcrypto-zkp = { git = "https://github.com/MystenLabs/fastcrypto", rev = "a2a33f214e67df33e97275b4bc72da84f243f4a4", package = "fastcrypto-zkp" }
-fastcrypto-vdf = { git = "https://github.com/MystenLabs/fastcrypto", rev = "a2a33f214e67df33e97275b4bc72da84f243f4a4", features = [
+fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "2ae161a578262a5bbf5c3872054c7f957d744f78" }
+fastcrypto-tbls = { git = "https://github.com/MystenLabs/fastcrypto", rev = "2ae161a578262a5bbf5c3872054c7f957d744f78" }
+fastcrypto-zkp = { git = "https://github.com/MystenLabs/fastcrypto", rev = "2ae161a578262a5bbf5c3872054c7f957d744f78", package = "fastcrypto-zkp" }
+fastcrypto-vdf = { git = "https://github.com/MystenLabs/fastcrypto", rev = "2ae161a578262a5bbf5c3872054c7f957d744f78", features = [
   "experimental",
 ] }
 passkey-types = { version = "0.4.0" }

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -1340,6 +1340,8 @@ impl AuthorityPerEpochStore {
         mut randomness_manager: RandomnessManager,
     ) -> SuiResult<()> {
         let reporter = randomness_manager.reporter();
+        debug_assert!(reporter.is_some() || self.node_role.is_fullnode());
+
         let result = randomness_manager.start_dkg().await;
         if self
             .randomness_manager

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -1340,9 +1340,6 @@ impl AuthorityPerEpochStore {
         mut randomness_manager: RandomnessManager,
     ) -> SuiResult<()> {
         let reporter = randomness_manager.reporter();
-        if reporter.is_none() && self.node_role.is_validator() {
-            debug_fatal!("expected a RandomnessReporter for a validator");
-        }
 
         let result = randomness_manager.start_dkg().await;
         if self
@@ -1354,12 +1351,19 @@ impl AuthorityPerEpochStore {
                 "BUG: `set_randomness_manager` called more than once; this should never happen"
             );
         }
-        if let Some(reporter) = reporter
-            && self.randomness_reporter.set(reporter).is_err()
-        {
-            debug_fatal!(
-                "BUG: `set_randomness_manager` called more than once; this should never happen"
-            );
+        match reporter {
+            Some(reporter) => {
+                if self.randomness_reporter.set(reporter).is_err() {
+                    debug_fatal!(
+                        "BUG: `set_randomness_manager` called more than once; this should never happen"
+                    );
+                }
+            }
+            None => {
+                if self.node_role.is_validator() {
+                    debug_fatal!("expected a RandomnessReporter for a validator");
+                }
+            }
         }
         result
     }

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -1340,7 +1340,9 @@ impl AuthorityPerEpochStore {
         mut randomness_manager: RandomnessManager,
     ) -> SuiResult<()> {
         let reporter = randomness_manager.reporter();
-        debug_assert!(reporter.is_some() || self.node_role.is_fullnode());
+        if reporter.is_none() && self.node_role.is_validator() {
+            debug_fatal!("expected a RandomnessReporter for a validator");
+        }
 
         let result = randomness_manager.start_dkg().await;
         if self

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -1350,7 +1350,9 @@ impl AuthorityPerEpochStore {
                 "BUG: `set_randomness_manager` called more than once; this should never happen"
             );
         }
-        if self.randomness_reporter.set(reporter).is_err() {
+        if let Some(reporter) = reporter
+            && self.randomness_reporter.set(reporter).is_err()
+        {
             debug_fatal!(
                 "BUG: `set_randomness_manager` called more than once; this should never happen"
             );

--- a/crates/sui-core/src/authority/test_authority_builder.rs
+++ b/crates/sui-core/src/authority/test_authority_builder.rs
@@ -435,7 +435,7 @@ impl<'a> TestAuthorityBuilder<'a> {
                 Arc::downgrade(&epoch_store),
                 consensus_client,
                 randomness::Handle::new_stub(),
-                config.protocol_key_pair(),
+                Some(config.protocol_key_pair()),
             )
             .await;
             if let Some(randomness_manager) = randomness_manager {

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -49,6 +49,7 @@ use sui_types::{
         ConsensusPosition, ConsensusTransaction, ConsensusTransactionKey, ConsensusTransactionKind,
         ExecutionTimeObservation,
     },
+    node_role::NodeRole,
     sui_system_state::epoch_start_sui_system_state::EpochStartSystemStateTrait,
     transaction::{
         InputObjectKind, SenderSignedData, TransactionDataAPI, TransactionKey, VerifiedTransaction,
@@ -3251,11 +3252,11 @@ impl MysticetiConsensusHandler {
         mut consensus_handler: ConsensusHandler<CheckpointService>,
         mut commit_receiver: UnboundedReceiver<consensus_core::CommittedSubDag>,
         commit_consumer_monitor: Arc<CommitConsumerMonitor>,
-        process_consensus_commits: bool,
+        _node_role: NodeRole,
     ) -> Self {
         debug!(
             last_processed_commit_at_startup,
-            process_consensus_commits, "Starting consensus replay"
+            "Starting consensus replay"
         );
         let mut tasks = JoinSet::new();
         tasks.spawn(monitored_future!(async move {

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -3252,7 +3252,7 @@ impl MysticetiConsensusHandler {
         mut consensus_handler: ConsensusHandler<CheckpointService>,
         mut commit_receiver: UnboundedReceiver<consensus_core::CommittedSubDag>,
         commit_consumer_monitor: Arc<CommitConsumerMonitor>,
-        _node_role: NodeRole,
+        node_role: NodeRole,
     ) -> Self {
         debug!(
             last_processed_commit_at_startup,
@@ -3263,7 +3263,7 @@ impl MysticetiConsensusHandler {
             // TODO: pause when execution is overloaded, so consensus can detect the backpressure.
             while let Some(consensus_commit) = commit_receiver.recv().await {
                 let commit_index = consensus_commit.commit_ref.index;
-                if !process_consensus_commits {
+                if !node_role.should_process_consensus_commits() {
                     debug!(
                         commit_index,
                         "Observer skipping consensus commit processing"

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -3263,7 +3263,7 @@ impl MysticetiConsensusHandler {
             // TODO: pause when execution is overloaded, so consensus can detect the backpressure.
             while let Some(consensus_commit) = commit_receiver.recv().await {
                 let commit_index = consensus_commit.commit_ref.index;
-                if !node_role.should_process_consensus_commits() {
+                if !node_role.process_consensus_commits() {
                     debug!(
                         commit_index,
                         "Observer skipping consensus commit processing"

--- a/crates/sui-core/src/consensus_manager/mod.rs
+++ b/crates/sui-core/src/consensus_manager/mod.rs
@@ -273,7 +273,7 @@ impl ConsensusManager {
             consensus_handler,
             commit_receiver,
             monitor.clone(),
-            node_role.should_process_consensus_commits(),
+            node_role,
         );
         let mut consensus_handler = self.consensus_handler.lock().await;
         *consensus_handler = Some(handler);

--- a/crates/sui-core/src/epoch/randomness.rs
+++ b/crates/sui-core/src/epoch/randomness.rs
@@ -322,9 +322,8 @@ pub struct RandomnessManager {
 }
 
 impl RandomnessManager {
+    
     // Returns None in case of invalid input or other failure to initialize DKG.
-    // When `authority_key_pair` is Some, creates an active Party (validator).
-    // When None, creates a read-only Observer (fullnode).
     pub async fn try_new(
         epoch_store_weak: Weak<AuthorityPerEpochStore>,
         consensus_adapter: Box<dyn SubmitToConsensus>,

--- a/crates/sui-core/src/epoch/randomness.rs
+++ b/crates/sui-core/src/epoch/randomness.rs
@@ -792,7 +792,7 @@ impl RandomnessManager {
             let observer = observer.clone();
             self.enqueued_messages.insert(
                 msg.sender(),
-                tokio::task::spawn_blocking(move || {
+                tokio::task::spawn(async move {
                     match VersionedProcessedMessage::process_observer(observer, msg) {
                         Ok(processed) => Some(processed),
                         Err(err) => {

--- a/crates/sui-core/src/epoch/randomness.rs
+++ b/crates/sui-core/src/epoch/randomness.rs
@@ -79,7 +79,7 @@ impl VersionedProcessedMessage {
         }
     }
 
-    pub fn process(
+    pub fn process_party(
         party: Arc<dkg_v1::Party<PkG, EncG>>,
         message: VersionedDkgMessage,
     ) -> FastCryptoResult<VersionedProcessedMessage> {
@@ -88,7 +88,20 @@ impl VersionedProcessedMessage {
         Ok(VersionedProcessedMessage::V1(processed))
     }
 
-    pub fn merge(
+    pub fn process_observer(
+        observer: Arc<dkg_v1::Observer<PkG, EncG>>,
+        message: VersionedDkgMessage,
+    ) -> FastCryptoResult<VersionedProcessedMessage> {
+        let raw_msg = message.unwrap_v1();
+        observer.process_message(raw_msg.clone())?;
+        Ok(VersionedProcessedMessage::V1(dkg_v1::ProcessedMessage {
+            message: raw_msg,
+            shares: vec![],
+            complaint: None,
+        }))
+    }
+
+    pub fn merge_party(
         party: Arc<dkg_v1::Party<PkG, EncG>>,
         messages: Vec<Self>,
     ) -> FastCryptoResult<(VersionedDkgConfirmation, VersionedUsedProcessedMessages)> {
@@ -102,6 +115,28 @@ impl VersionedProcessedMessage {
         Ok((
             VersionedDkgConfirmation::V1(conf),
             VersionedUsedProcessedMessages::V1(msgs),
+        ))
+    }
+
+    pub fn merge_observer(
+        observer: &dkg_v1::Observer<PkG, EncG>,
+        messages: Vec<Self>,
+    ) -> FastCryptoResult<VersionedUsedProcessedMessages> {
+        let raw_messages: Vec<_> = messages
+            .into_iter()
+            .map(|pm| pm.unwrap_v1().message)
+            .collect();
+        let used = observer.merge(raw_messages)?;
+        Ok(VersionedUsedProcessedMessages::V1(
+            dkg_v1::UsedProcessedMessages(
+                used.into_iter()
+                    .map(|m| dkg_v1::ProcessedMessage {
+                        message: m,
+                        shares: vec![],
+                        complaint: None,
+                    })
+                    .collect(),
+            ),
         ))
     }
 }
@@ -121,10 +156,10 @@ impl VersionedUsedProcessedMessages {
         }
     }
 
-    fn complete_dkg<'a, Iter: Iterator<Item = &'a VersionedDkgConfirmation>>(
+    fn complete_dkg_party<'a>(
         &self,
         party: Arc<dkg_v1::Party<PkG, EncG>>,
-        confirmations: Iter,
+        confirmations: impl Iterator<Item = &'a VersionedDkgConfirmation>,
     ) -> FastCryptoResult<Output<PkG, EncG>> {
         // All inputs are verified in add_confirmation, so we can assume they are of the correct version.
         let rng = &mut StdRng::from_rng(OsRng).expect("RNG construction should not fail");
@@ -139,6 +174,21 @@ impl VersionedUsedProcessedMessages {
                 .collect::<Vec<_>>(),
             rng,
         )
+    }
+
+    fn complete_dkg_observer<'a>(
+        &self,
+        observer: &dkg_v1::Observer<PkG, EncG>,
+        confirmations: impl Iterator<Item = &'a VersionedDkgConfirmation>,
+    ) -> FastCryptoResult<Output<PkG, EncG>> {
+        let raw_messages: Vec<_> = self
+            .unwrap_v1_ref()
+            .0
+            .iter()
+            .map(|pm| pm.message.clone())
+            .collect();
+        let confirmations: Vec<_> = confirmations.map(|c| c.unwrap_v1().clone()).collect();
+        observer.complete(&raw_messages, &confirmations)
     }
 }
 
@@ -171,7 +221,7 @@ pub struct RandomnessManager {
     // State for DKG.
     dkg_start_time: OnceCell<Instant>,
     party: Option<Arc<dkg_v1::Party<PkG, EncG>>>,
-    observer: Option<dkg_v1::Observer<PkG, EncG>>,
+    observer: Option<Arc<dkg_v1::Observer<PkG, EncG>>>,
     enqueued_messages: BTreeMap<PartyId, JoinHandle<Option<VersionedProcessedMessage>>>,
     processed_messages: BTreeMap<PartyId, VersionedProcessedMessage>,
     used_messages: OnceCell<VersionedUsedProcessedMessages>,
@@ -315,7 +365,7 @@ impl RandomnessManager {
             info!(
                 "random beacon: Observer initialized with total_weight={total_weight}, t={t}, num_nodes={num_nodes}, oracle initial_prefix={prefix_str:?}",
             );
-            (None, Some(observer))
+            (None, Some(Arc::new(observer)))
         };
 
         // Load existing data from store.
@@ -433,18 +483,22 @@ impl RandomnessManager {
     /// Sends the initial dkg::Message to begin the randomness DKG protocol.
     /// For observers, this is a no-op (observers don't send messages).
     pub async fn start_dkg(&mut self) -> SuiResult {
+        if self.is_observer() {
+            // Observers only observe — they don't create or send DKG messages.
+            info!("random beacon: observer started observing DKG");
+            return Ok(());
+        }
+
         if self.used_messages.initialized() || self.dkg_output.initialized() {
             // DKG already started (or completed or failed).
             return Ok(());
         }
 
         let _ = self.dkg_start_time.set(Instant::now());
-
-        // Observers only observe — they don't create or send DKG messages.
-        let Some(party) = &self.party else {
-            info!("random beacon: observer started observing DKG");
-            return Ok(());
-        };
+        let party = self
+            .party
+            .clone()
+            .expect("At this point we expect to have a Party initialised");
 
         let epoch_store = self.epoch_store()?;
         let dkg_version = epoch_store.protocol_config().dkg_version();
@@ -501,185 +555,9 @@ impl RandomnessManager {
     ) -> SuiResult {
         let epoch_store = self.epoch_store()?;
 
-        // Once we have enough Messages, merge them.
-        if !self.dkg_output.initialized() && !self.used_messages.initialized() {
-            // Process all enqueued messages.
-            let mut handles: FuturesUnordered<_> = std::mem::take(&mut self.enqueued_messages)
-                .into_values()
-                .collect();
-            while let Some(res) = handles.next().await {
-                if let Ok(Some(processed)) = res {
-                    self.processed_messages
-                        .insert(processed.sender(), processed.clone());
-                    consensus_output.insert_dkg_processed_message(processed);
-                }
-            }
-
-            if let Some(observer) = &self.observer {
-                // Observer: merge raw messages, no Confirmation sent.
-                let raw_messages: Vec<_> = self
-                    .processed_messages
-                    .values()
-                    .map(|pm| pm.unwrap_v1_ref().message.clone())
-                    .collect();
-                match observer.merge(raw_messages) {
-                    Ok(used) => {
-                        info!("random beacon: observer merged {} DKG messages", used.len());
-                        let used_msgs =
-                            VersionedUsedProcessedMessages::V1(dkg_v1::UsedProcessedMessages(
-                                used.into_iter()
-                                    .map(|m| dkg_v1::ProcessedMessage {
-                                        message: m,
-                                        shares: vec![],
-                                        complaint: None,
-                                    })
-                                    .collect(),
-                            ));
-                        if self.used_messages.set(used_msgs.clone()).is_err() {
-                            error!("BUG: used_messages should only ever be set once");
-                        }
-                        consensus_output.insert_dkg_used_messages(used_msgs);
-                    }
-                    Err(FastCryptoError::NotEnoughInputs) => (), // wait for more input
-                    Err(e) => debug!("random beacon: observer error merging DKG Messages: {e:?}"),
-                }
-            } else {
-                // Party: merge and produce a Confirmation to send.
-                let party = self.party.clone().expect("party must be set for validator");
-                match VersionedProcessedMessage::merge(
-                    party,
-                    self.processed_messages
-                        .values()
-                        .cloned()
-                        .collect::<Vec<_>>(),
-                ) {
-                    Ok((conf, used_msgs)) => {
-                        info!(
-                            "random beacon: sending DKG Confirmation with {} complaints",
-                            conf.num_of_complaints()
-                        );
-                        if self.used_messages.set(used_msgs.clone()).is_err() {
-                            error!("BUG: used_messages should only ever be set once");
-                        }
-                        consensus_output.insert_dkg_used_messages(used_msgs);
-
-                        let transaction = ConsensusTransaction::new_randomness_dkg_confirmation(
-                            epoch_store.name,
-                            &conf,
-                        );
-
-                        #[allow(unused_mut)]
-                        let mut fail_point_skip_sending = false;
-                        fail_point_if!("rb-dkg", || {
-                            // maybe skip sending in simtests
-                            fail_point_skip_sending = true;
-                        });
-                        if !fail_point_skip_sending {
-                            self.consensus_adapter
-                                .submit_to_consensus(&[transaction], &epoch_store)?;
-                        }
-
-                        let elapsed = self.dkg_start_time.get().map(|t| t.elapsed().as_millis());
-                        if let Some(elapsed) = elapsed {
-                            epoch_store
-                                .metrics
-                                .epoch_random_beacon_dkg_confirmation_time_ms
-                                .set(elapsed as i64);
-                        }
-                    }
-                    Err(FastCryptoError::NotEnoughInputs) => (), // wait for more input
-                    Err(e) => debug!("random beacon: error while merging DKG Messages: {e:?}"),
-                }
-            }
-        }
-
-        // Once we have enough Confirmations, complete DKG.
-        if !self.dkg_output.initialized() && self.used_messages.initialized() {
-            let complete_result = if let Some(observer) = &self.observer {
-                // Observer: extract raw messages and complete without secrets.
-                let used = self
-                    .used_messages
-                    .get()
-                    .expect("checked above that `used_messages` is initialized");
-                let raw_messages: Vec<_> = used
-                    .unwrap_v1_ref()
-                    .0
-                    .iter()
-                    .map(|pm| pm.message.clone())
-                    .collect();
-                let confirmations: Vec<_> = self
-                    .confirmations
-                    .values()
-                    .map(|c| c.unwrap_v1().clone())
-                    .collect();
-                observer
-                    .complete(&raw_messages, &confirmations)
-                    .map(|obs_output| Output {
-                        nodes: obs_output.nodes,
-                        vss_pk: obs_output.vss_pk,
-                        shares: None,
-                    })
-            } else {
-                // Party: complete with decrypted shares.
-                let party = self.party.clone().expect("party must be set for validator");
-                self.used_messages
-                    .get()
-                    .expect("checked above that `used_messages` is initialized")
-                    .complete_dkg(party, self.confirmations.values())
-            };
-
-            let role = if self.is_observer() {
-                "Observer"
-            } else {
-                "Party"
-            };
-            let epoch = epoch_store.committee().epoch();
-            let num_confirmations = self.confirmations.len();
-            let num_messages = self.processed_messages.len();
-
-            match complete_result {
-                Ok(output) => {
-                    let num_shares = output.shares.as_ref().map_or(0, |shares| shares.len());
-                    let epoch_elapsed = epoch_store.epoch_open_time.elapsed().as_millis();
-                    let elapsed = self.dkg_start_time.get().map(|t| t.elapsed().as_millis());
-                    info!(
-                        "random beacon: DKG complete role={role} epoch={epoch} commit_round={round} \
-                         num_messages={num_messages} num_confirmations={num_confirmations} \
-                         num_shares={num_shares} epoch_elapsed_ms={epoch_elapsed} dkg_elapsed_ms={elapsed:?}"
-                    );
-                    epoch_store
-                        .metrics
-                        .epoch_random_beacon_dkg_num_shares
-                        .set(num_shares as i64);
-                    epoch_store
-                        .metrics
-                        .epoch_random_beacon_dkg_epoch_start_completion_time_ms
-                        .set(epoch_elapsed as i64);
-                    epoch_store.metrics.epoch_random_beacon_dkg_failed.set(0);
-                    if let Some(elapsed) = elapsed {
-                        epoch_store
-                            .metrics
-                            .epoch_random_beacon_dkg_completion_time_ms
-                            .set(elapsed as i64);
-                    }
-                    self.dkg_output
-                        .set(Some(output.clone()))
-                        .expect("checked above that `dkg_output` is uninitialized");
-                    if let Some(party) = &self.party {
-                        self.network_handle.update_epoch(
-                            epoch_store.committee().epoch(),
-                            self.authority_info.clone(),
-                            output.clone(),
-                            party.t(),
-                            None,
-                        );
-                    }
-                    consensus_output.set_dkg_output(output);
-                }
-                Err(FastCryptoError::NotEnoughInputs) => (), // wait for more input
-                Err(e) => error!("random beacon: error while processing DKG Confirmations: {e:?}"),
-            }
-        }
+        self.try_merge_messages(consensus_output, &epoch_store)
+            .await?;
+        self.try_complete_dkg(consensus_output, round, &epoch_store)?;
 
         // If we ran out of time, mark DKG as failed.
         if !self.dkg_output.initialized()
@@ -696,6 +574,174 @@ impl RandomnessManager {
             self.dkg_output
                 .set(None)
                 .expect("checked above that `dkg_output` is uninitialized");
+        }
+
+        Ok(())
+    }
+
+    /// Drains enqueued messages and attempts to merge them. For validators, a successful merge
+    /// produces and broadcasts a DKG Confirmation. For observers, it just records the used messages.
+    async fn try_merge_messages(
+        &mut self,
+        consensus_output: &mut ConsensusCommitOutput,
+        epoch_store: &Arc<AuthorityPerEpochStore>,
+    ) -> SuiResult {
+        if self.dkg_output.initialized() || self.used_messages.initialized() {
+            return Ok(());
+        }
+
+        // Process all enqueued messages.
+        let mut handles: FuturesUnordered<_> = std::mem::take(&mut self.enqueued_messages)
+            .into_values()
+            .collect();
+        while let Some(res) = handles.next().await {
+            if let Ok(Some(processed)) = res {
+                self.processed_messages
+                    .insert(processed.sender(), processed.clone());
+                consensus_output.insert_dkg_processed_message(processed);
+            }
+        }
+
+        let messages: Vec<_> = self.processed_messages.values().cloned().collect();
+
+        if let Some(observer) = &self.observer {
+            match VersionedProcessedMessage::merge_observer(observer, messages) {
+                Ok(used_msgs) => {
+                    info!(
+                        "random beacon: observer merged {} DKG messages",
+                        used_msgs.unwrap_v1_ref().0.len()
+                    );
+                    if self.used_messages.set(used_msgs.clone()).is_err() {
+                        error!("BUG: used_messages should only ever be set once");
+                    }
+                    consensus_output.insert_dkg_used_messages(used_msgs);
+                }
+                Err(FastCryptoError::NotEnoughInputs) => (), // wait for more input
+                Err(e) => debug!("random beacon: observer error merging DKG Messages: {e:?}"),
+            }
+        } else {
+            let party = self.party.clone().expect("party must be set for validator");
+            match VersionedProcessedMessage::merge_party(party, messages) {
+                Ok((conf, used_msgs)) => {
+                    info!(
+                        "random beacon: sending DKG Confirmation with {} complaints",
+                        conf.num_of_complaints()
+                    );
+                    if self.used_messages.set(used_msgs.clone()).is_err() {
+                        error!("BUG: used_messages should only ever be set once");
+                    }
+                    consensus_output.insert_dkg_used_messages(used_msgs);
+
+                    let transaction = ConsensusTransaction::new_randomness_dkg_confirmation(
+                        epoch_store.name,
+                        &conf,
+                    );
+
+                    #[allow(unused_mut)]
+                    let mut fail_point_skip_sending = false;
+                    fail_point_if!("rb-dkg", || {
+                        // maybe skip sending in simtests
+                        fail_point_skip_sending = true;
+                    });
+                    if !fail_point_skip_sending {
+                        self.consensus_adapter
+                            .submit_to_consensus(&[transaction], epoch_store)?;
+                    }
+
+                    let elapsed = self.dkg_start_time.get().map(|t| t.elapsed().as_millis());
+                    if let Some(elapsed) = elapsed {
+                        epoch_store
+                            .metrics
+                            .epoch_random_beacon_dkg_confirmation_time_ms
+                            .set(elapsed as i64);
+                    }
+                }
+                Err(FastCryptoError::NotEnoughInputs) => (), // wait for more input
+                Err(e) => debug!("random beacon: error while merging DKG Messages: {e:?}"),
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Attempts to complete DKG once enough Confirmations have been collected. For validators,
+    /// this produces the shared public key and private key shares. For observers, only the
+    /// shared public key is derived.
+    fn try_complete_dkg(
+        &mut self,
+        consensus_output: &mut ConsensusCommitOutput,
+        round: Round,
+        epoch_store: &Arc<AuthorityPerEpochStore>,
+    ) -> SuiResult {
+        if !self.dkg_output.initialized() && self.used_messages.initialized() {
+            let used_messages = self
+                .used_messages
+                .get()
+                .expect("checked above that `used_messages` is initialized");
+            let complete_result = if let Some(observer) = &self.observer {
+                used_messages.complete_dkg_observer(observer, self.confirmations.values())
+            } else {
+                let party = self.party.clone().expect("party must be set for validator");
+                used_messages.complete_dkg_party(party, self.confirmations.values())
+            };
+
+            let epoch = epoch_store.committee().epoch();
+            let num_confirmations = self.confirmations.len();
+            let num_messages = self.processed_messages.len();
+
+            match complete_result {
+                Ok(output) => {
+                    // Set the output now both internally and to consensus output
+                    self.dkg_output
+                        .set(Some(output.clone()))
+                        .expect("checked above that `dkg_output` is uninitialized");
+                    consensus_output.set_dkg_output(output.clone());
+
+                    let epoch_elapsed = epoch_store.epoch_open_time.elapsed().as_millis();
+                    epoch_store
+                        .metrics
+                        .epoch_random_beacon_dkg_epoch_start_completion_time_ms
+                        .set(epoch_elapsed as i64);
+                    epoch_store.metrics.epoch_random_beacon_dkg_failed.set(0);
+
+                    if let Some(party) = &self.party {
+                        let num_shares = output.shares.as_ref().map_or(0, |shares| shares.len());
+                        let elapsed = self.dkg_start_time.get().map(|t| t.elapsed().as_millis());
+                        info!(
+                            "random beacon: DKG complete for Party epoch={epoch} commit_round={round} \
+                             num_messages={num_messages} num_confirmations={num_confirmations} \
+                             num_shares={num_shares} epoch_elapsed_ms={epoch_elapsed} dkg_elapsed_ms={elapsed:?}"
+                        );
+                        epoch_store
+                            .metrics
+                            .epoch_random_beacon_dkg_num_shares
+                            .set(num_shares as i64);
+
+                        if let Some(elapsed) = elapsed {
+                            epoch_store
+                                .metrics
+                                .epoch_random_beacon_dkg_completion_time_ms
+                                .set(elapsed as i64);
+                        }
+
+                        self.network_handle.update_epoch(
+                            epoch_store.committee().epoch(),
+                            self.authority_info.clone(),
+                            output,
+                            party.t(),
+                            None,
+                        );
+                    } else {
+                        info!(
+                            "random beacon: DKG complete for Observer epoch={epoch} commit_round={round} \
+                             num_messages={num_messages} num_confirmations={num_confirmations} \
+                             epoch_elapsed_ms={epoch_elapsed}"
+                        );
+                    }
+                }
+                Err(FastCryptoError::NotEnoughInputs) => (), // wait for more input
+                Err(e) => error!("random beacon: error while processing DKG Confirmations: {e:?}"),
+            }
         }
 
         Ok(())
@@ -739,38 +785,33 @@ impl RandomnessManager {
         }
 
         if let Some(observer) = &self.observer {
-            // Observer: validate synchronously, then stage via enqueued_messages
-            // so advance_dkg persists to consensus_output in the same place as Party.
-            let raw_msg = msg.unwrap_v1();
-            match observer.process_message(raw_msg.clone()) {
-                Ok(()) => {
-                    let processed = VersionedProcessedMessage::V1(dkg_v1::ProcessedMessage {
-                        message: raw_msg,
-                        shares: vec![],
-                        complaint: None,
-                    });
-                    let sender = processed.sender();
-                    self.enqueued_messages
-                        .insert(sender, tokio::task::spawn(async move { Some(processed) }));
-                }
-                Err(err) => {
-                    debug!("random beacon: observer error validating DKG Message: {err:?}");
-                }
-            }
+            let observer = observer.clone();
+            self.enqueued_messages.insert(
+                msg.sender(),
+                tokio::task::spawn_blocking(move || {
+                    match VersionedProcessedMessage::process_observer(observer, msg) {
+                        Ok(processed) => Some(processed),
+                        Err(err) => {
+                            debug!("random beacon: observer error validating DKG Message: {err:?}");
+                            None
+                        }
+                    }
+                }),
+            );
         } else {
             let party = self.party.clone().expect("party must be set for validator");
             // TODO: Could save some CPU by not processing messages if we already have enough to merge.
             self.enqueued_messages.insert(
                 msg.sender(),
-                tokio::task::spawn_blocking(move || {
-                    match VersionedProcessedMessage::process(party, msg) {
+                tokio::task::spawn_blocking(
+                    move || match VersionedProcessedMessage::process_party(party, msg) {
                         Ok(processed) => Some(processed),
                         Err(err) => {
                             debug!("random beacon: error while processing DKG Message: {err:?}");
                             None
                         }
-                    }
-                }),
+                    },
+                ),
             );
         }
         Ok(())

--- a/crates/sui-core/src/epoch/randomness.rs
+++ b/crates/sui-core/src/epoch/randomness.rs
@@ -628,7 +628,7 @@ impl RandomnessManager {
                     .complete_dkg(party, self.confirmations.values())
             };
 
-            let role = if self.observer.is_some() {
+            let role = if self.is_observer() {
                 "Observer"
             } else {
                 "Party"
@@ -851,7 +851,7 @@ impl RandomnessManager {
 
     /// Starts the process of generating the given RandomnessRound (validators only).
     pub fn generate_randomness(&self, epoch: EpochId, randomness_round: RandomnessRound) {
-        if self.observer.is_some() {
+        if self.is_observer() {
             return;
         }
         self.network_handle
@@ -869,7 +869,7 @@ impl RandomnessManager {
     /// Generates a new RandomnessReporter for reporting observed rounds to this RandomnessManager.
     /// Returns None for observers (they don't generate partial signatures).
     pub fn reporter(&self) -> Option<RandomnessReporter> {
-        if self.observer.is_some() {
+        if self.is_observer() {
             return None;
         }
         Some(RandomnessReporter {
@@ -878,6 +878,10 @@ impl RandomnessManager {
             network_handle: self.network_handle.clone(),
             highest_completed_round: self.highest_completed_round.clone(),
         })
+    }
+
+    fn is_observer(&self) -> bool {
+        self.observer.is_some()
     }
 
     fn epoch_store(&self) -> SuiResult<Arc<AuthorityPerEpochStore>> {

--- a/crates/sui-core/src/epoch/randomness.rs
+++ b/crates/sui-core/src/epoch/randomness.rs
@@ -449,7 +449,10 @@ impl RandomnessManager {
             );
         }
 
-        // Resume randomness round tracking from where we left off.
+        // Resume randomness generation from where we left off.
+        // This must be loaded regardless of whether DKG has finished yet, since the
+        // RandomnessEventLoop and commit-handling logic in AuthorityPerEpochStore both depend on
+        // this state.
         rm.next_randomness_round = tables
             .randomness_next_round
             .get(&SINGLETON_KEY)
@@ -620,6 +623,7 @@ impl RandomnessManager {
                 Err(e) => debug!("random beacon: observer error merging DKG Messages: {e:?}"),
             }
         } else {
+            // Once we have enough Messages, send a Confirmation.
             let party = self.party.clone().expect("party must be set for validator");
             match VersionedProcessedMessage::merge_party(party, messages) {
                 Ok((conf, used_msgs)) => {

--- a/crates/sui-core/src/epoch/randomness.rs
+++ b/crates/sui-core/src/epoch/randomness.rs
@@ -71,73 +71,12 @@ impl VersionedProcessedMessage {
         }
     }
 
-    pub fn unwrap_v1_ref(&self) -> &dkg_v1::ProcessedMessage<PkG, EncG> {
+    pub fn as_v1(&self) -> Option<&dkg_v1::ProcessedMessage<PkG, EncG>> {
         if let VersionedProcessedMessage::V1(msg) = self {
-            msg
+            Some(msg)
         } else {
-            panic!("BUG: expected message version is 1")
+            None
         }
-    }
-
-    pub fn process_party(
-        party: Arc<dkg_v1::Party<PkG, EncG>>,
-        message: VersionedDkgMessage,
-    ) -> FastCryptoResult<VersionedProcessedMessage> {
-        // All inputs are verified in add_message, so we can assume they are of the correct version.
-        let processed = party.process_message(message.unwrap_v1(), &mut rand::thread_rng())?;
-        Ok(VersionedProcessedMessage::V1(processed))
-    }
-
-    pub fn process_observer(
-        observer: Arc<dkg_v1::Observer<PkG, EncG>>,
-        message: VersionedDkgMessage,
-    ) -> FastCryptoResult<VersionedProcessedMessage> {
-        let raw_msg = message.unwrap_v1();
-        observer.process_message(raw_msg.clone())?;
-        Ok(VersionedProcessedMessage::V1(dkg_v1::ProcessedMessage {
-            message: raw_msg,
-            shares: vec![],
-            complaint: None,
-        }))
-    }
-
-    pub fn merge_party(
-        party: Arc<dkg_v1::Party<PkG, EncG>>,
-        messages: Vec<Self>,
-    ) -> FastCryptoResult<(VersionedDkgConfirmation, VersionedUsedProcessedMessages)> {
-        // All inputs were created by this validator, so we can assume they are of the correct version.
-        let (conf, msgs) = party.merge(
-            &messages
-                .into_iter()
-                .map(|vm| vm.unwrap_v1())
-                .collect::<Vec<_>>(),
-        )?;
-        Ok((
-            VersionedDkgConfirmation::V1(conf),
-            VersionedUsedProcessedMessages::V1(msgs),
-        ))
-    }
-
-    pub fn merge_observer(
-        observer: &dkg_v1::Observer<PkG, EncG>,
-        messages: Vec<Self>,
-    ) -> FastCryptoResult<VersionedUsedProcessedMessages> {
-        let raw_messages: Vec<_> = messages
-            .into_iter()
-            .map(|pm| pm.unwrap_v1().message)
-            .collect();
-        let used = observer.merge(raw_messages)?;
-        Ok(VersionedUsedProcessedMessages::V1(
-            dkg_v1::UsedProcessedMessages(
-                used.into_iter()
-                    .map(|m| dkg_v1::ProcessedMessage {
-                        message: m,
-                        shares: vec![],
-                        complaint: None,
-                    })
-                    .collect(),
-            ),
-        ))
     }
 }
 
@@ -148,47 +87,197 @@ pub enum VersionedUsedProcessedMessages {
 }
 
 impl VersionedUsedProcessedMessages {
-    pub fn unwrap_v1_ref(&self) -> &dkg_v1::UsedProcessedMessages<PkG, EncG> {
+    pub fn as_v1(&self) -> Option<&dkg_v1::UsedProcessedMessages<PkG, EncG>> {
         if let VersionedUsedProcessedMessages::V1(msg) = self {
-            msg
+            Some(msg)
         } else {
-            panic!("BUG: invalid VersionedUsedProcessedMessages version")
+            None
+        }
+    }
+}
+
+/// Distinguishes between an active DKG participant (validator) and a read-only observer (fullnode).
+enum DkgRole {
+    Party(dkg_v1::Party<PkG, EncG>),
+    Observer(dkg_v1::Observer<PkG, EncG>),
+}
+
+impl DkgRole {
+    /// Creates a new DkgRole. When `authority_key_pair` is Some, creates an active Party
+    /// (validator). When None, creates a read-only Observer (fullnode).
+    ///
+    /// * `authority_key_pair` - The validator's BLS key pair used to derive the DKG private key.
+    ///   When None, an Observer is created that can follow DKG but not produce shares.
+    /// * `nodes` - The reduced set of DKG participants with their public keys and weights.
+    /// * `t` - The threshold number of shares required to reconstruct randomness.
+    /// * `random_oracle` - Epoch-specific oracle used to derive deterministic challenges during DKG.
+    fn try_new(
+        authority_key_pair: Option<&AuthorityKeyPair>,
+        nodes: nodes::Nodes<EncG>,
+        t: u16,
+        random_oracle: fastcrypto_tbls::random_oracle::RandomOracle,
+    ) -> Option<Self> {
+        let total_weight = nodes.total_weight();
+        let num_nodes = nodes.num_nodes();
+
+        if let Some(authority_key_pair) = authority_key_pair {
+            let randomness_private_key = bls12381::Scalar::from_byte_array(
+                authority_key_pair
+                    .copy()
+                    .private()
+                    .as_bytes()
+                    .try_into()
+                    .expect("key length should match"),
+            )
+            .expect("should work to convert BLS key to Scalar");
+            let party = match dkg_v1::Party::<PkG, EncG>::new(
+                fastcrypto_tbls::ecies_v1::PrivateKey::<bls12381::G2Element>::from(
+                    randomness_private_key,
+                ),
+                nodes,
+                t,
+                random_oracle,
+                &mut rand::thread_rng(),
+            ) {
+                Ok(party) => party,
+                Err(err) => {
+                    error!("random beacon: error while initializing Party: {err:?}");
+                    return None;
+                }
+            };
+            let name: AuthorityName = authority_key_pair.public().into();
+            info!(
+                "random beacon: Party initialized with authority={name}, total_weight={total_weight}, t={t}, num_nodes={num_nodes}",
+            );
+            Some(DkgRole::Party(party))
+        } else {
+            let observer = match dkg_v1::Observer::<PkG, EncG>::new(nodes, t, random_oracle) {
+                Ok(observer) => observer,
+                Err(err) => {
+                    error!("random beacon: error while initializing Observer: {err:?}");
+                    return None;
+                }
+            };
+            info!(
+                "random beacon: Observer initialized with total_weight={total_weight}, t={t}, num_nodes={num_nodes}",
+            );
+            Some(DkgRole::Observer(observer))
         }
     }
 
-    fn complete_dkg_party<'a>(
-        &self,
-        party: Arc<dkg_v1::Party<PkG, EncG>>,
-        confirmations: impl Iterator<Item = &'a VersionedDkgConfirmation>,
-    ) -> FastCryptoResult<Output<PkG, EncG>> {
-        // All inputs are verified in add_confirmation, so we can assume they are of the correct version.
-        let rng = &mut StdRng::from_rng(OsRng).expect("RNG construction should not fail");
-        let VersionedUsedProcessedMessages::V1(msg) = self else {
-            panic!("BUG: invalid VersionedUsedProcessedMessages version")
-        };
-        party.complete(
-            msg,
-            &confirmations
-                .map(|vm| vm.unwrap_v1())
-                .cloned()
-                .collect::<Vec<_>>(),
-            rng,
-        )
+    fn is_party(&self) -> bool {
+        matches!(self, DkgRole::Party(_))
     }
 
-    fn complete_dkg_observer<'a>(
+    fn is_observer(&self) -> bool {
+        matches!(self, DkgRole::Observer(_))
+    }
+
+    /// Processes a received DKG message according to the role.
+    fn process_message(
         &self,
-        observer: &dkg_v1::Observer<PkG, EncG>,
+        message: VersionedDkgMessage,
+    ) -> FastCryptoResult<VersionedProcessedMessage> {
+        match self {
+            DkgRole::Party(party) => {
+                let processed =
+                    party.process_message(message.unwrap_v1(), &mut rand::thread_rng())?;
+                Ok(VersionedProcessedMessage::V1(processed))
+            }
+            DkgRole::Observer(observer) => {
+                let raw_msg = message.unwrap_v1();
+                observer.process_message(raw_msg.clone())?;
+                Ok(VersionedProcessedMessage::V1(dkg_v1::ProcessedMessage {
+                    message: raw_msg,
+                    shares: vec![],
+                    complaint: None,
+                }))
+            }
+        }
+    }
+
+    /// Merges processed DKG messages. For Party, produces a confirmation and used messages.
+    /// For Observer, produces only used messages, confirmation is None, as observer nodes do
+    /// not have any voting rights.
+    fn merge_messages(
+        &self,
+        messages: Vec<VersionedProcessedMessage>,
+    ) -> FastCryptoResult<(
+        Option<VersionedDkgConfirmation>,
+        VersionedUsedProcessedMessages,
+    )> {
+        match self {
+            DkgRole::Party(party) => {
+                let (conf, msgs) = party.merge(
+                    &messages
+                        .into_iter()
+                        .map(|vm| vm.unwrap_v1())
+                        .collect::<Vec<_>>(),
+                )?;
+                Ok((
+                    Some(VersionedDkgConfirmation::V1(conf)),
+                    VersionedUsedProcessedMessages::V1(msgs),
+                ))
+            }
+            DkgRole::Observer(observer) => {
+                let raw_messages: Vec<_> = messages
+                    .into_iter()
+                    .map(|pm| pm.unwrap_v1().message)
+                    .collect();
+                let used = observer.merge(raw_messages)?;
+                Ok((
+                    None,
+                    VersionedUsedProcessedMessages::V1(dkg_v1::UsedProcessedMessages(
+                        used.into_iter()
+                            .map(|m| dkg_v1::ProcessedMessage {
+                                message: m,
+                                shares: vec![],
+                                complaint: None,
+                            })
+                            .collect(),
+                    )),
+                ))
+            }
+        }
+    }
+
+    /// Completes DKG from used messages and confirmations. The output contains the shared public key which can be used
+    /// from there after to validate the randomness round signatures. For the observer case the output will contain the public
+    /// key but no shares, as again the node does not participate in the voting process.
+    fn complete_dkg<'a>(
+        &self,
+        used_messages: &VersionedUsedProcessedMessages,
         confirmations: impl Iterator<Item = &'a VersionedDkgConfirmation>,
     ) -> FastCryptoResult<Output<PkG, EncG>> {
-        let raw_messages: Vec<_> = self
-            .unwrap_v1_ref()
-            .0
-            .iter()
-            .map(|pm| pm.message.clone())
-            .collect();
-        let confirmations: Vec<_> = confirmations.map(|c| c.unwrap_v1().clone()).collect();
-        observer.complete(&raw_messages, &confirmations)
+        match self {
+            DkgRole::Party(party) => {
+                let rng = &mut StdRng::from_rng(OsRng).expect("RNG construction should not fail");
+                let msg = used_messages
+                    .as_v1()
+                    .expect("expected V1 used processed messages");
+                party.complete(
+                    msg,
+                    &confirmations
+                        .map(|vm| vm.as_v1().expect("expected V1 confirmation"))
+                        .cloned()
+                        .collect::<Vec<_>>(),
+                    rng,
+                )
+            }
+            DkgRole::Observer(observer) => {
+                let raw_messages: Vec<_> = used_messages
+                    .as_v1()
+                    .expect("expected V1 used processed messages")
+                    .0
+                    .iter()
+                    .map(|pm| pm.message.clone())
+                    .collect();
+                let confirmations: Vec<_> = confirmations
+                    .map(|c| c.as_v1().expect("expected V1 confirmation").clone())
+                    .collect();
+                observer.complete(&raw_messages, &confirmations)
+            }
+        }
     }
 }
 
@@ -220,8 +309,7 @@ pub struct RandomnessManager {
 
     // State for DKG.
     dkg_start_time: OnceCell<Instant>,
-    party: Option<Arc<dkg_v1::Party<PkG, EncG>>>,
-    observer: Option<Arc<dkg_v1::Observer<PkG, EncG>>>,
+    role: Arc<DkgRole>,
     enqueued_messages: BTreeMap<PartyId, JoinHandle<Option<VersionedProcessedMessage>>>,
     processed_messages: BTreeMap<PartyId, VersionedProcessedMessage>,
     used_messages: OnceCell<VersionedUsedProcessedMessages>,
@@ -315,58 +403,18 @@ impl RandomnessManager {
                 return None;
             }
         };
-        let total_weight = nodes.total_weight();
-        let num_nodes = nodes.num_nodes();
-        let prefix_str = format!(
+        let random_oracle = fastcrypto_tbls::random_oracle::RandomOracle::new(&format!(
             "dkg {} {}",
             Hex::encode(epoch_store.get_chain_identifier().as_bytes()),
             committee.epoch()
-        );
-        let random_oracle = fastcrypto_tbls::random_oracle::RandomOracle::new(prefix_str.as_str());
+        ));
 
-        let (party, observer) = if let Some(authority_key_pair) = authority_key_pair {
-            let randomness_private_key = bls12381::Scalar::from_byte_array(
-                authority_key_pair
-                    .copy()
-                    .private()
-                    .as_bytes()
-                    .try_into()
-                    .expect("key length should match"),
-            )
-            .expect("should work to convert BLS key to Scalar");
-            let party = match dkg_v1::Party::<PkG, EncG>::new(
-                fastcrypto_tbls::ecies_v1::PrivateKey::<bls12381::G2Element>::from(
-                    randomness_private_key,
-                ),
-                nodes,
-                t,
-                random_oracle,
-                &mut rand::thread_rng(),
-            ) {
-                Ok(party) => party,
-                Err(err) => {
-                    error!("random beacon: error while initializing Party: {err:?}");
-                    return None;
-                }
-            };
-            let name: AuthorityName = authority_key_pair.public().into();
-            info!(
-                "random beacon: Party initialized with authority={name}, total_weight={total_weight}, t={t}, num_nodes={num_nodes}, oracle initial_prefix={prefix_str:?}",
-            );
-            (Some(Arc::new(party)), None)
-        } else {
-            let observer = match dkg_v1::Observer::<PkG, EncG>::new(nodes, t, random_oracle) {
-                Ok(observer) => observer,
-                Err(err) => {
-                    error!("random beacon: error while initializing Observer: {err:?}");
-                    return None;
-                }
-            };
-            info!(
-                "random beacon: Observer initialized with total_weight={total_weight}, t={t}, num_nodes={num_nodes}, oracle initial_prefix={prefix_str:?}",
-            );
-            (None, Some(Arc::new(observer)))
-        };
+        let role = Arc::new(DkgRole::try_new(
+            authority_key_pair,
+            nodes,
+            t,
+            random_oracle,
+        )?);
 
         // Load existing data from store.
         let highest_completed_round = tables
@@ -380,8 +428,7 @@ impl RandomnessManager {
             network_handle: network_handle.clone(),
             authority_info,
             dkg_start_time: OnceCell::new(),
-            party,
-            observer,
+            role,
             enqueued_messages: BTreeMap::new(),
             processed_messages: BTreeMap::new(),
             used_messages: OnceCell::new(),
@@ -406,7 +453,7 @@ impl RandomnessManager {
             rm.dkg_output
                 .set(Some(dkg_output.clone()))
                 .expect("setting new OnceCell should succeed");
-            if let Some(party) = &rm.party {
+            if let DkgRole::Party(party) = rm.role.as_ref() {
                 network_handle.update_epoch(
                     committee.epoch(),
                     rm.authority_info.clone(),
@@ -464,7 +511,7 @@ impl RandomnessManager {
         );
 
         // Re-send partial signatures for incomplete rounds (validators only).
-        if rm.party.is_some() {
+        if rm.role.is_party() {
             let first_incomplete_round = highest_completed_round
                 .map(|r| r + 1)
                 .unwrap_or(RandomnessRound(0));
@@ -486,11 +533,13 @@ impl RandomnessManager {
     /// Sends the initial dkg::Message to begin the randomness DKG protocol.
     /// For observers, this is a no-op (observers don't send messages).
     pub async fn start_dkg(&mut self) -> SuiResult {
-        if self.is_observer() {
-            // Observers only observe — they don't create or send DKG messages.
-            info!("random beacon: observer started observing DKG");
-            return Ok(());
-        }
+        let party = match self.role.as_ref() {
+            DkgRole::Observer(_) => {
+                info!("random beacon: observer started observing DKG");
+                return Ok(());
+            }
+            DkgRole::Party(party) => party,
+        };
 
         if self.used_messages.initialized() || self.dkg_output.initialized() {
             // DKG already started (or completed or failed).
@@ -498,16 +547,12 @@ impl RandomnessManager {
         }
 
         let _ = self.dkg_start_time.set(Instant::now());
-        let party = self
-            .party
-            .clone()
-            .expect("At this point we expect to have a Party initialised");
 
         let epoch_store = self.epoch_store()?;
         let dkg_version = epoch_store.protocol_config().dkg_version();
         info!("random beacon: starting DKG, version {dkg_version}");
 
-        let msg = match VersionedDkgMessage::create(dkg_version, party.clone()) {
+        let msg = match VersionedDkgMessage::create(dkg_version, party) {
             Ok(msg) => msg,
             Err(FastCryptoError::IgnoredMessage) => {
                 info!(
@@ -607,35 +652,29 @@ impl RandomnessManager {
 
         let messages: Vec<_> = self.processed_messages.values().cloned().collect();
 
-        if let Some(observer) = &self.observer {
-            match VersionedProcessedMessage::merge_observer(observer, messages) {
-                Ok(used_msgs) => {
-                    info!(
-                        "random beacon: observer merged {} DKG messages",
-                        used_msgs.unwrap_v1_ref().0.len()
-                    );
-                    if self.used_messages.set(used_msgs.clone()).is_err() {
-                        error!("BUG: used_messages should only ever be set once");
-                    }
-                    consensus_output.insert_dkg_used_messages(used_msgs);
-                }
-                Err(FastCryptoError::NotEnoughInputs) => (), // wait for more input
-                Err(e) => debug!("random beacon: observer error merging DKG Messages: {e:?}"),
-            }
-        } else {
-            // Once we have enough Messages, send a Confirmation.
-            let party = self.party.clone().expect("party must be set for validator");
-            match VersionedProcessedMessage::merge_party(party, messages) {
-                Ok((conf, used_msgs)) => {
+        match self.role.merge_messages(messages) {
+            Ok((conf, used_msgs)) => {
+                if let Some(conf) = &conf {
                     info!(
                         "random beacon: sending DKG Confirmation with {} complaints",
                         conf.num_of_complaints()
                     );
-                    if self.used_messages.set(used_msgs.clone()).is_err() {
-                        error!("BUG: used_messages should only ever be set once");
-                    }
-                    consensus_output.insert_dkg_used_messages(used_msgs);
+                } else {
+                    info!(
+                        "random beacon: observer merged {} DKG messages",
+                        used_msgs
+                            .as_v1()
+                            .expect("expected V1 used processed messages")
+                            .0
+                            .len()
+                    );
+                }
+                if self.used_messages.set(used_msgs.clone()).is_err() {
+                    error!("BUG: used_messages should only ever be set once");
+                }
+                consensus_output.insert_dkg_used_messages(used_msgs);
 
+                if let Some(conf) = conf {
                     let transaction = ConsensusTransaction::new_randomness_dkg_confirmation(
                         epoch_store.name,
                         &conf,
@@ -660,9 +699,9 @@ impl RandomnessManager {
                             .set(elapsed as i64);
                     }
                 }
-                Err(FastCryptoError::NotEnoughInputs) => (), // wait for more input
-                Err(e) => debug!("random beacon: error while merging DKG Messages: {e:?}"),
             }
+            Err(FastCryptoError::NotEnoughInputs) => (), // wait for more input
+            Err(e) => debug!("random beacon: error while merging DKG Messages: {e:?}"),
         }
 
         Ok(())
@@ -682,12 +721,9 @@ impl RandomnessManager {
                 .used_messages
                 .get()
                 .expect("checked above that `used_messages` is initialized");
-            let complete_result = if let Some(observer) = &self.observer {
-                used_messages.complete_dkg_observer(observer, self.confirmations.values())
-            } else {
-                let party = self.party.clone().expect("party must be set for validator");
-                used_messages.complete_dkg_party(party, self.confirmations.values())
-            };
+            let complete_result = self
+                .role
+                .complete_dkg(used_messages, self.confirmations.values());
 
             let epoch = epoch_store.committee().epoch();
             let num_confirmations = self.confirmations.len();
@@ -708,39 +744,44 @@ impl RandomnessManager {
                         .set(epoch_elapsed as i64);
                     epoch_store.metrics.epoch_random_beacon_dkg_failed.set(0);
 
-                    if let Some(party) = &self.party {
-                        let num_shares = output.shares.as_ref().map_or(0, |shares| shares.len());
-                        let elapsed = self.dkg_start_time.get().map(|t| t.elapsed().as_millis());
-                        info!(
-                            "random beacon: DKG complete for Party epoch={epoch} commit_round={round} \
-                             num_messages={num_messages} num_confirmations={num_confirmations} \
-                             num_shares={num_shares} epoch_elapsed_ms={epoch_elapsed} dkg_elapsed_ms={elapsed:?}"
-                        );
-                        epoch_store
-                            .metrics
-                            .epoch_random_beacon_dkg_num_shares
-                            .set(num_shares as i64);
-
-                        if let Some(elapsed) = elapsed {
+                    match self.role.as_ref() {
+                        DkgRole::Party(party) => {
+                            let num_shares =
+                                output.shares.as_ref().map_or(0, |shares| shares.len());
+                            let elapsed =
+                                self.dkg_start_time.get().map(|t| t.elapsed().as_millis());
+                            info!(
+                                "random beacon: DKG complete for Party epoch={epoch} commit_round={round} \
+                                 num_messages={num_messages} num_confirmations={num_confirmations} \
+                                 num_shares={num_shares} epoch_elapsed_ms={epoch_elapsed} dkg_elapsed_ms={elapsed:?}"
+                            );
                             epoch_store
                                 .metrics
-                                .epoch_random_beacon_dkg_completion_time_ms
-                                .set(elapsed as i64);
-                        }
+                                .epoch_random_beacon_dkg_num_shares
+                                .set(num_shares as i64);
 
-                        self.network_handle.update_epoch(
-                            epoch_store.committee().epoch(),
-                            self.authority_info.clone(),
-                            output,
-                            party.t(),
-                            None,
-                        );
-                    } else {
-                        info!(
-                            "random beacon: DKG complete for Observer epoch={epoch} commit_round={round} \
-                             num_messages={num_messages} num_confirmations={num_confirmations} \
-                             epoch_elapsed_ms={epoch_elapsed}"
-                        );
+                            if let Some(elapsed) = elapsed {
+                                epoch_store
+                                    .metrics
+                                    .epoch_random_beacon_dkg_completion_time_ms
+                                    .set(elapsed as i64);
+                            }
+
+                            self.network_handle.update_epoch(
+                                epoch_store.committee().epoch(),
+                                self.authority_info.clone(),
+                                output,
+                                party.t(),
+                                None,
+                            );
+                        }
+                        DkgRole::Observer(_) => {
+                            info!(
+                                "random beacon: DKG complete for Observer epoch={epoch} commit_round={round} \
+                                 num_messages={num_messages} num_confirmations={num_confirmations} \
+                                 epoch_elapsed_ms={epoch_elapsed}"
+                            );
+                        }
                     }
                 }
                 Err(FastCryptoError::NotEnoughInputs) => (), // wait for more input
@@ -788,36 +829,17 @@ impl RandomnessManager {
             return Ok(());
         }
 
-        if let Some(observer) = &self.observer {
-            let observer = observer.clone();
-            self.enqueued_messages.insert(
-                msg.sender(),
-                tokio::task::spawn(async move {
-                    match VersionedProcessedMessage::process_observer(observer, msg) {
-                        Ok(processed) => Some(processed),
-                        Err(err) => {
-                            debug!("random beacon: observer error validating DKG Message: {err:?}");
-                            None
-                        }
-                    }
-                }),
-            );
-        } else {
-            let party = self.party.clone().expect("party must be set for validator");
-            // TODO: Could save some CPU by not processing messages if we already have enough to merge.
-            self.enqueued_messages.insert(
-                msg.sender(),
-                tokio::task::spawn_blocking(
-                    move || match VersionedProcessedMessage::process_party(party, msg) {
-                        Ok(processed) => Some(processed),
-                        Err(err) => {
-                            debug!("random beacon: error while processing DKG Message: {err:?}");
-                            None
-                        }
-                    },
-                ),
-            );
-        }
+        let sender = msg.sender();
+        let role = self.role.clone();
+        // TODO: Could save some CPU by not processing messages if we already have enough to merge.
+        let handle = tokio::task::spawn_blocking(move || match role.process_message(msg) {
+            Ok(processed) => Some(processed),
+            Err(err) => {
+                debug!("random beacon: error while processing DKG Message: {err:?}");
+                None
+            }
+        });
+        self.enqueued_messages.insert(sender, handle);
         Ok(())
     }
 
@@ -896,11 +918,10 @@ impl RandomnessManager {
 
     /// Starts the process of generating the given RandomnessRound (validators only).
     pub fn generate_randomness(&self, epoch: EpochId, randomness_round: RandomnessRound) {
-        if self.is_observer() {
-            return;
+        if self.role.is_party() {
+            self.network_handle
+                .send_partial_signatures(epoch, randomness_round);
         }
-        self.network_handle
-            .send_partial_signatures(epoch, randomness_round);
     }
 
     pub fn dkg_status(&self) -> DkgStatus {
@@ -914,7 +935,7 @@ impl RandomnessManager {
     /// Generates a new RandomnessReporter for reporting observed rounds to this RandomnessManager.
     /// Returns None for observers (they don't generate partial signatures).
     pub fn reporter(&self) -> Option<RandomnessReporter> {
-        if self.is_observer() {
+        if self.role.is_observer() {
             return None;
         }
         Some(RandomnessReporter {
@@ -923,10 +944,6 @@ impl RandomnessManager {
             network_handle: self.network_handle.clone(),
             highest_completed_round: self.highest_completed_round.clone(),
         })
-    }
-
-    fn is_observer(&self) -> bool {
-        self.observer.is_some()
     }
 
     #[cfg(test)]
@@ -1035,471 +1052,350 @@ mod tests {
     use sui_types::messages_consensus::ConsensusTransactionKind;
     use tokio::sync::mpsc;
 
-    #[tokio::test]
-    async fn test_dkg_v1() {
-        test_dkg(1).await;
+    use arc_swap::Guard;
+
+    /// Test harness that sets up validators (and optionally an observer) with mock consensus,
+    /// ready for DKG message exchange.
+    struct DkgTestSetup {
+        epoch_stores: Vec<Guard<Arc<AuthorityPerEpochStore>>>,
+        randomness_managers: Vec<RandomnessManager>,
+        rx_consensus: mpsc::Receiver<Vec<ConsensusTransaction>>,
+        num_validators: usize,
     }
 
-    async fn test_dkg(version: u64) {
+    impl DkgTestSetup {
+        async fn new(include_observer: bool) -> Self {
+            let network_config =
+                sui_swarm_config::network_config_builder::ConfigBuilder::new_with_temp_dir()
+                    .committee_size(NonZeroUsize::new(4).unwrap())
+                    .with_reference_gas_price(500)
+                    .build();
+
+            let mut protocol_config =
+                ProtocolConfig::get_for_version(ProtocolVersion::max(), Chain::Unknown);
+            protocol_config.set_random_beacon_dkg_version_for_testing(1);
+
+            let num_validators = network_config.validator_configs.len();
+            let mut epoch_stores = Vec::new();
+            let mut randomness_managers = Vec::new();
+            let (tx_consensus, rx_consensus) = mpsc::channel(100);
+
+            for validator in network_config.validator_configs.iter() {
+                let mut mock_consensus_client = MockConsensusClient::new();
+                let tx_consensus = tx_consensus.clone();
+                mock_consensus_client
+                    .expect_submit()
+                    .withf(move |transactions: &[ConsensusTransaction], _epoch_store| {
+                        tx_consensus.try_send(transactions.to_vec()).unwrap();
+                        true
+                    })
+                    .returning(|_, _| {
+                        Ok((
+                            Vec::new(),
+                            with_block_status(BlockStatus::Sequenced(BlockRef::MIN)),
+                        ))
+                    });
+
+                let state = TestAuthorityBuilder::new()
+                    .with_protocol_config(protocol_config.clone())
+                    .with_genesis_and_keypair(
+                        &network_config.genesis,
+                        validator.protocol_key_pair(),
+                    )
+                    .build()
+                    .await;
+                let consensus_adapter = Arc::new(ConsensusAdapter::new(
+                    Arc::new(mock_consensus_client),
+                    CheckpointStore::new_for_tests(),
+                    state.name,
+                    100_000,
+                    100_000,
+                    ConsensusAdapterMetrics::new_test(),
+                    Arc::new(tokio::sync::Notify::new()),
+                ));
+                let epoch_store = state.epoch_store_for_testing();
+                let randomness_manager = RandomnessManager::try_new(
+                    Arc::downgrade(&epoch_store),
+                    Box::new(consensus_adapter.clone()),
+                    sui_network::randomness::Handle::new_stub(),
+                    Some(validator.protocol_key_pair()),
+                )
+                .await
+                .unwrap();
+
+                epoch_stores.push(epoch_store);
+                randomness_managers.push(randomness_manager);
+            }
+
+            if include_observer {
+                let observer_epoch_store = epoch_stores[0].clone();
+                let mut mock_observer_consensus = MockConsensusClient::new();
+                mock_observer_consensus
+                    .expect_submit()
+                    .returning(|_, _| panic!("observer should not submit to consensus"));
+                let observer_adapter = Arc::new(ConsensusAdapter::new(
+                    Arc::new(mock_observer_consensus),
+                    CheckpointStore::new_for_tests(),
+                    observer_epoch_store.name,
+                    100_000,
+                    100_000,
+                    ConsensusAdapterMetrics::new_test(),
+                    Arc::new(tokio::sync::Notify::new()),
+                ));
+                let observer_manager = RandomnessManager::try_new(
+                    Arc::downgrade(&observer_epoch_store),
+                    Box::new(observer_adapter),
+                    sui_network::randomness::Handle::new_stub(),
+                    None,
+                )
+                .await
+                .unwrap();
+
+                epoch_stores.push(observer_epoch_store.into());
+                randomness_managers.push(observer_manager);
+            }
+
+            Self {
+                epoch_stores,
+                randomness_managers,
+                rx_consensus,
+                num_validators,
+            }
+        }
+
+        /// Runs start_dkg on all managers and collects the DKG messages from validators.
+        async fn start_dkg_and_collect_messages(&mut self) -> Vec<VersionedDkgMessage> {
+            let mut dkg_messages = Vec::new();
+            for randomness_manager in self.randomness_managers.iter_mut() {
+                randomness_manager.start_dkg().await.unwrap();
+            }
+            for _ in 0..self.num_validators {
+                let mut dkg_message = self.rx_consensus.recv().await.unwrap();
+                assert!(dkg_message.len() == 1);
+                match dkg_message.remove(0).kind {
+                    ConsensusTransactionKind::RandomnessDkgMessage(_, bytes) => {
+                        let msg: VersionedDkgMessage = bcs::from_bytes(&bytes)
+                            .expect("DKG message deserialization should not fail");
+                        dkg_messages.push(msg);
+                    }
+                    _ => panic!("wrong type of message sent"),
+                }
+            }
+            dkg_messages
+        }
+
+        /// Distributes DKG messages to all managers and advances DKG at the given round.
+        async fn distribute_messages_and_advance(
+            &mut self,
+            dkg_messages: &[VersionedDkgMessage],
+            advance_round: Round,
+        ) {
+            for i in 0..self.randomness_managers.len() {
+                let mut output = ConsensusCommitOutput::new(0);
+                output.record_consensus_commit_stats(ExecutionIndicesWithStatsV2 {
+                    index: ExecutionIndices {
+                        last_committed_round: 0,
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                });
+                for (j, dkg_message) in dkg_messages.iter().cloned().enumerate() {
+                    self.randomness_managers[i]
+                        .add_message(&self.epoch_stores[j].name, dkg_message)
+                        .unwrap();
+                }
+                self.randomness_managers[i]
+                    .advance_dkg(&mut output, advance_round)
+                    .await
+                    .unwrap();
+                let mut batch = self.epoch_stores[i].db_batch_for_test();
+                output
+                    .write_to_batch(&self.epoch_stores[i], &mut batch)
+                    .unwrap();
+                batch.write().unwrap();
+            }
+        }
+
+        /// Collects DKG confirmations from validators and distributes them to all managers.
+        async fn collect_and_distribute_confirmations(&mut self) {
+            let mut dkg_confirmations = Vec::new();
+            for _ in 0..self.num_validators {
+                let mut dkg_confirmation = self.rx_consensus.recv().await.unwrap();
+                assert!(dkg_confirmation.len() == 1);
+                match dkg_confirmation.remove(0).kind {
+                    ConsensusTransactionKind::RandomnessDkgConfirmation(_, bytes) => {
+                        let msg: VersionedDkgConfirmation = bcs::from_bytes(&bytes)
+                            .expect("DKG confirmation deserialization should not fail");
+                        dkg_confirmations.push(msg);
+                    }
+                    _ => panic!("wrong type of message sent"),
+                }
+            }
+            for i in 0..self.randomness_managers.len() {
+                let mut output = ConsensusCommitOutput::new(0);
+                output.record_consensus_commit_stats(ExecutionIndicesWithStatsV2 {
+                    index: ExecutionIndices {
+                        last_committed_round: 1,
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                });
+                for (j, dkg_confirmation) in dkg_confirmations.iter().cloned().enumerate() {
+                    self.randomness_managers[i]
+                        .add_confirmation(&mut output, &self.epoch_stores[j].name, dkg_confirmation)
+                        .unwrap();
+                }
+                self.randomness_managers[i]
+                    .advance_dkg(&mut output, 0)
+                    .await
+                    .unwrap();
+                let mut batch = self.epoch_stores[i].db_batch_for_test();
+                output
+                    .write_to_batch(&self.epoch_stores[i], &mut batch)
+                    .unwrap();
+                batch.write().unwrap();
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_dkg() {
         telemetry_subscribers::init_for_testing();
 
-        let network_config =
-            sui_swarm_config::network_config_builder::ConfigBuilder::new_with_temp_dir()
-                .committee_size(NonZeroUsize::new(4).unwrap())
-                .with_reference_gas_price(500)
-                .build();
+        let mut setup = DkgTestSetup::new(false).await;
+        let dkg_messages = setup.start_dkg_and_collect_messages().await;
+        setup
+            .distribute_messages_and_advance(&dkg_messages, 0)
+            .await;
+        setup.collect_and_distribute_confirmations().await;
 
-        let mut protocol_config =
-            ProtocolConfig::get_for_version(ProtocolVersion::max(), Chain::Unknown);
-        protocol_config.set_random_beacon_dkg_version_for_testing(version);
-
-        let mut epoch_stores = Vec::new();
-        let mut randomness_managers = Vec::new();
-        let (tx_consensus, mut rx_consensus) = mpsc::channel(100);
-
-        for validator in network_config.validator_configs.iter() {
-            // Send consensus messages to channel.
-            let mut mock_consensus_client = MockConsensusClient::new();
-            let tx_consensus = tx_consensus.clone();
-            mock_consensus_client
-                .expect_submit()
-                .withf(move |transactions: &[ConsensusTransaction], _epoch_store| {
-                    tx_consensus.try_send(transactions.to_vec()).unwrap();
-                    true
-                })
-                .returning(|_, _| {
-                    Ok((
-                        Vec::new(),
-                        with_block_status(BlockStatus::Sequenced(BlockRef::MIN)),
-                    ))
-                });
-
-            let state = TestAuthorityBuilder::new()
-                .with_protocol_config(protocol_config.clone())
-                .with_genesis_and_keypair(&network_config.genesis, validator.protocol_key_pair())
-                .build()
-                .await;
-            let consensus_adapter = Arc::new(ConsensusAdapter::new(
-                Arc::new(mock_consensus_client),
-                CheckpointStore::new_for_tests(),
-                state.name,
-                100_000,
-                100_000,
-                ConsensusAdapterMetrics::new_test(),
-                Arc::new(tokio::sync::Notify::new()),
-            ));
-            let epoch_store = state.epoch_store_for_testing();
-            let randomness_manager = RandomnessManager::try_new(
-                Arc::downgrade(&epoch_store),
-                Box::new(consensus_adapter.clone()),
-                sui_network::randomness::Handle::new_stub(),
-                Some(validator.protocol_key_pair()),
-            )
-            .await
-            .unwrap();
-
-            epoch_stores.push(epoch_store);
-            randomness_managers.push(randomness_manager);
-        }
-
-        // Generate and distribute Messages.
-        let mut dkg_messages = Vec::new();
-        for randomness_manager in randomness_managers.iter_mut() {
-            randomness_manager.start_dkg().await.unwrap();
-
-            let mut dkg_message = rx_consensus.recv().await.unwrap();
-            assert!(dkg_message.len() == 1);
-            match dkg_message.remove(0).kind {
-                ConsensusTransactionKind::RandomnessDkgMessage(_, bytes) => {
-                    let msg: VersionedDkgMessage = bcs::from_bytes(&bytes)
-                        .expect("DKG message deserialization should not fail");
-                    dkg_messages.push(msg);
-                }
-                _ => panic!("wrong type of message sent"),
-            }
-        }
-        for i in 0..randomness_managers.len() {
-            let mut output = ConsensusCommitOutput::new(0);
-            output.record_consensus_commit_stats(ExecutionIndicesWithStatsV2 {
-                index: ExecutionIndices {
-                    last_committed_round: 0,
-                    ..Default::default()
-                },
-                ..Default::default()
-            });
-            for (j, dkg_message) in dkg_messages.iter().cloned().enumerate() {
-                randomness_managers[i]
-                    .add_message(&epoch_stores[j].name, dkg_message)
-                    .unwrap();
-            }
-            randomness_managers[i]
-                .advance_dkg(&mut output, 0)
-                .await
-                .unwrap();
-            let mut batch = epoch_stores[i].db_batch_for_test();
-            output.write_to_batch(&epoch_stores[i], &mut batch).unwrap();
-            batch.write().unwrap();
-        }
-
-        // Generate and distribute Confirmations.
-        let mut dkg_confirmations = Vec::new();
-        for _ in 0..randomness_managers.len() {
-            let mut dkg_confirmation = rx_consensus.recv().await.unwrap();
-            assert!(dkg_confirmation.len() == 1);
-            match dkg_confirmation.remove(0).kind {
-                ConsensusTransactionKind::RandomnessDkgConfirmation(_, bytes) => {
-                    let msg: VersionedDkgConfirmation = bcs::from_bytes(&bytes)
-                        .expect("DKG message deserialization should not fail");
-                    dkg_confirmations.push(msg);
-                }
-                _ => panic!("wrong type of message sent"),
-            }
-        }
-        for i in 0..randomness_managers.len() {
-            let mut output = ConsensusCommitOutput::new(0);
-            output.record_consensus_commit_stats(ExecutionIndicesWithStatsV2 {
-                index: ExecutionIndices {
-                    last_committed_round: 1,
-                    ..Default::default()
-                },
-                ..Default::default()
-            });
-            for (j, dkg_confirmation) in dkg_confirmations.iter().cloned().enumerate() {
-                randomness_managers[i]
-                    .add_confirmation(&mut output, &epoch_stores[j].name, dkg_confirmation)
-                    .unwrap();
-            }
-            randomness_managers[i]
-                .advance_dkg(&mut output, 0)
-                .await
-                .unwrap();
-            let mut batch = epoch_stores[i].db_batch_for_test();
-            output.write_to_batch(&epoch_stores[i], &mut batch).unwrap();
-            batch.write().unwrap();
-        }
-
-        // Verify DKG completed.
-        for randomness_manager in &randomness_managers {
-            assert_eq!(DkgStatus::Successful, randomness_manager.dkg_status());
+        for rm in &setup.randomness_managers {
+            assert_eq!(DkgStatus::Successful, rm.dkg_status());
         }
     }
 
     #[tokio::test]
-    async fn test_dkg_expiration_v1() {
-        test_dkg_expiration(1).await;
-    }
-
-    async fn test_dkg_expiration(version: u64) {
+    async fn test_dkg_expiration() {
         telemetry_subscribers::init_for_testing();
 
-        let network_config =
-            sui_swarm_config::network_config_builder::ConfigBuilder::new_with_temp_dir()
-                .committee_size(NonZeroUsize::new(4).unwrap())
-                .with_reference_gas_price(500)
-                .build();
+        let mut setup = DkgTestSetup::new(false).await;
+        let dkg_messages = setup.start_dkg_and_collect_messages().await;
+        // Pass u64::MAX as round to trigger DKG timeout.
+        setup
+            .distribute_messages_and_advance(&dkg_messages, u64::MAX)
+            .await;
 
-        let mut epoch_stores = Vec::new();
-        let mut randomness_managers = Vec::new();
-        let (tx_consensus, mut rx_consensus) = mpsc::channel(100);
-
-        let mut protocol_config =
-            ProtocolConfig::get_for_version(ProtocolVersion::max(), Chain::Unknown);
-        protocol_config.set_random_beacon_dkg_version_for_testing(version);
-
-        for validator in network_config.validator_configs.iter() {
-            // Send consensus messages to channel.
-            let mut mock_consensus_client = MockConsensusClient::new();
-            let tx_consensus = tx_consensus.clone();
-            mock_consensus_client
-                .expect_submit()
-                .withf(move |transactions: &[ConsensusTransaction], _epoch_store| {
-                    tx_consensus.try_send(transactions.to_vec()).unwrap();
-                    true
-                })
-                .returning(|_, _| {
-                    Ok((
-                        Vec::new(),
-                        with_block_status(consensus_core::BlockStatus::Sequenced(BlockRef::MIN)),
-                    ))
-                });
-
-            let state = TestAuthorityBuilder::new()
-                .with_protocol_config(protocol_config.clone())
-                .with_genesis_and_keypair(&network_config.genesis, validator.protocol_key_pair())
-                .build()
-                .await;
-            let consensus_adapter = Arc::new(ConsensusAdapter::new(
-                Arc::new(mock_consensus_client),
-                CheckpointStore::new_for_tests(),
-                state.name,
-                100_000,
-                100_000,
-                ConsensusAdapterMetrics::new_test(),
-                Arc::new(tokio::sync::Notify::new()),
-            ));
-            let epoch_store = state.epoch_store_for_testing();
-            let randomness_manager = RandomnessManager::try_new(
-                Arc::downgrade(&epoch_store),
-                Box::new(consensus_adapter.clone()),
-                sui_network::randomness::Handle::new_stub(),
-                Some(validator.protocol_key_pair()),
-            )
-            .await
-            .unwrap();
-
-            epoch_stores.push(epoch_store);
-            randomness_managers.push(randomness_manager);
+        for rm in &setup.randomness_managers {
+            assert_eq!(DkgStatus::Failed, rm.dkg_status());
         }
-
-        // Generate and distribute Messages.
-        let mut dkg_messages = Vec::new();
-        for randomness_manager in randomness_managers.iter_mut() {
-            randomness_manager.start_dkg().await.unwrap();
-
-            let mut dkg_message = rx_consensus.recv().await.unwrap();
-            assert!(dkg_message.len() == 1);
-            match dkg_message.remove(0).kind {
-                ConsensusTransactionKind::RandomnessDkgMessage(_, bytes) => {
-                    let msg: VersionedDkgMessage = bcs::from_bytes(&bytes)
-                        .expect("DKG message deserialization should not fail");
-                    dkg_messages.push(msg);
-                }
-                _ => panic!("wrong type of message sent"),
-            }
-        }
-        for i in 0..randomness_managers.len() {
-            let mut output = ConsensusCommitOutput::new(0);
-            output.record_consensus_commit_stats(ExecutionIndicesWithStatsV2 {
-                index: ExecutionIndices {
-                    last_committed_round: 0,
-                    ..Default::default()
-                },
-                ..Default::default()
-            });
-            for (j, dkg_message) in dkg_messages.iter().cloned().enumerate() {
-                randomness_managers[i]
-                    .add_message(&epoch_stores[j].name, dkg_message)
-                    .unwrap();
-            }
-            randomness_managers[i]
-                .advance_dkg(&mut output, u64::MAX)
-                .await
-                .unwrap();
-            let mut batch = epoch_stores[i].db_batch_for_test();
-            output.write_to_batch(&epoch_stores[i], &mut batch).unwrap();
-            batch.write().unwrap();
-        }
-
-        // Verify DKG failed.
-        for randomness_manager in &randomness_managers {
-            assert_eq!(DkgStatus::Failed, randomness_manager.dkg_status());
-        }
-    }
-
-    #[tokio::test]
-    async fn test_dkg_observer_v1() {
-        test_dkg_observer(1).await;
     }
 
     /// Verifies that an Observer completes DKG alongside validators and derives the same
     /// shared public key (vss_pk), but without receiving any private key shares.
-    async fn test_dkg_observer(version: u64) {
+    #[tokio::test]
+    async fn test_dkg_observer() {
         telemetry_subscribers::init_for_testing();
 
-        let network_config =
-            sui_swarm_config::network_config_builder::ConfigBuilder::new_with_temp_dir()
-                .committee_size(NonZeroUsize::new(4).unwrap())
-                .with_reference_gas_price(500)
-                .build();
+        let mut setup = DkgTestSetup::new(true).await;
+        let observer_idx = setup.randomness_managers.len() - 1;
 
-        let mut protocol_config =
-            ProtocolConfig::get_for_version(ProtocolVersion::max(), Chain::Unknown);
-        protocol_config.set_random_beacon_dkg_version_for_testing(version);
+        let dkg_messages = setup.start_dkg_and_collect_messages().await;
+        setup
+            .distribute_messages_and_advance(&dkg_messages, 0)
+            .await;
 
-        let num_validators = network_config.validator_configs.len();
-        let mut epoch_stores = Vec::new();
-        let mut randomness_managers = Vec::new();
-        let (tx_consensus, mut rx_consensus) = mpsc::channel(100);
-
-        for validator in network_config.validator_configs.iter() {
-            let mut mock_consensus_client = MockConsensusClient::new();
-            let tx_consensus = tx_consensus.clone();
-            mock_consensus_client
-                .expect_submit()
-                .withf(move |transactions: &[ConsensusTransaction], _epoch_store| {
-                    tx_consensus.try_send(transactions.to_vec()).unwrap();
-                    true
-                })
-                .returning(|_, _| {
-                    Ok((
-                        Vec::new(),
-                        with_block_status(BlockStatus::Sequenced(BlockRef::MIN)),
-                    ))
-                });
-
-            let state = TestAuthorityBuilder::new()
-                .with_protocol_config(protocol_config.clone())
-                .with_genesis_and_keypair(&network_config.genesis, validator.protocol_key_pair())
-                .build()
-                .await;
-            let consensus_adapter = Arc::new(ConsensusAdapter::new(
-                Arc::new(mock_consensus_client),
-                CheckpointStore::new_for_tests(),
-                state.name,
-                100_000,
-                100_000,
-                ConsensusAdapterMetrics::new_test(),
-                Arc::new(tokio::sync::Notify::new()),
-            ));
-            let epoch_store = state.epoch_store_for_testing();
-            let randomness_manager = RandomnessManager::try_new(
-                Arc::downgrade(&epoch_store),
-                Box::new(consensus_adapter.clone()),
-                sui_network::randomness::Handle::new_stub(),
-                Some(validator.protocol_key_pair()),
-            )
-            .await
-            .unwrap();
-
-            epoch_stores.push(epoch_store);
-            randomness_managers.push(randomness_manager);
+        for rm in &setup.randomness_managers {
+            assert_eq!(DkgStatus::Pending, rm.dkg_status());
         }
 
-        // Append an Observer as the last entry, reusing a validator's epoch store (same committee).
-        {
-            let observer_epoch_store = epoch_stores[0].clone();
-            let mut mock_observer_consensus = MockConsensusClient::new();
-            mock_observer_consensus
-                .expect_submit()
-                .returning(|_, _| panic!("observer should not submit to consensus"));
-            let observer_adapter = Arc::new(ConsensusAdapter::new(
-                Arc::new(mock_observer_consensus),
-                CheckpointStore::new_for_tests(),
-                observer_epoch_store.name,
-                100_000,
-                100_000,
-                ConsensusAdapterMetrics::new_test(),
-                Arc::new(tokio::sync::Notify::new()),
-            ));
-            let observer_manager = RandomnessManager::try_new(
-                Arc::downgrade(&observer_epoch_store),
-                Box::new(observer_adapter),
-                sui_network::randomness::Handle::new_stub(),
-                None,
-            )
-            .await
-            .unwrap();
+        setup.collect_and_distribute_confirmations().await;
 
-            epoch_stores.push(observer_epoch_store.into());
-            randomness_managers.push(observer_manager);
-        }
-        let observer_idx = randomness_managers.len() - 1;
-
-        // Generate DKG Messages from validators. The observer's start_dkg is a no-op.
-        let mut dkg_messages = Vec::new();
-        for randomness_manager in randomness_managers.iter_mut() {
-            randomness_manager.start_dkg().await.unwrap();
-        }
-        for _ in 0..num_validators {
-            let mut dkg_message = rx_consensus.recv().await.unwrap();
-            assert!(dkg_message.len() == 1);
-            match dkg_message.remove(0).kind {
-                ConsensusTransactionKind::RandomnessDkgMessage(_, bytes) => {
-                    let msg: VersionedDkgMessage = bcs::from_bytes(&bytes)
-                        .expect("DKG message deserialization should not fail");
-                    dkg_messages.push(msg);
-                }
-                _ => panic!("wrong type of message sent"),
-            }
-        }
-
-        // Distribute messages to all participants (validators + observer).
-        for i in 0..randomness_managers.len() {
-            let mut output = ConsensusCommitOutput::new(0);
-            output.record_consensus_commit_stats(ExecutionIndicesWithStatsV2 {
-                index: ExecutionIndices {
-                    last_committed_round: 0,
-                    ..Default::default()
-                },
-                ..Default::default()
-            });
-            for (j, dkg_message) in dkg_messages.iter().cloned().enumerate() {
-                randomness_managers[i]
-                    .add_message(&epoch_stores[j].name, dkg_message)
-                    .unwrap();
-            }
-            randomness_managers[i]
-                .advance_dkg(&mut output, 0)
-                .await
-                .unwrap();
-            let mut batch = epoch_stores[i].db_batch_for_test();
-            output.write_to_batch(&epoch_stores[i], &mut batch).unwrap();
-            batch.write().unwrap();
-        }
-
-        // Verify DKG is not yet complete for any participant after the message phase.
-        for randomness_manager in &randomness_managers {
-            assert_eq!(DkgStatus::Pending, randomness_manager.dkg_status());
-        }
-
-        // Collect Confirmations (only validators produce these).
-        let mut dkg_confirmations = Vec::new();
-        for _ in 0..num_validators {
-            let mut dkg_confirmation = rx_consensus.recv().await.unwrap();
-            assert!(dkg_confirmation.len() == 1);
-            match dkg_confirmation.remove(0).kind {
-                ConsensusTransactionKind::RandomnessDkgConfirmation(_, bytes) => {
-                    let msg: VersionedDkgConfirmation = bcs::from_bytes(&bytes)
-                        .expect("DKG confirmation deserialization should not fail");
-                    dkg_confirmations.push(msg);
-                }
-                _ => panic!("wrong type of message sent"),
-            }
-        }
-
-        // Distribute confirmations to all participants (validators + observer).
-        for i in 0..randomness_managers.len() {
-            let mut output = ConsensusCommitOutput::new(0);
-            output.record_consensus_commit_stats(ExecutionIndicesWithStatsV2 {
-                index: ExecutionIndices {
-                    last_committed_round: 1,
-                    ..Default::default()
-                },
-                ..Default::default()
-            });
-            for (j, dkg_confirmation) in dkg_confirmations.iter().cloned().enumerate() {
-                randomness_managers[i]
-                    .add_confirmation(&mut output, &epoch_stores[j].name, dkg_confirmation)
-                    .unwrap();
-            }
-            randomness_managers[i]
-                .advance_dkg(&mut output, 0)
-                .await
-                .unwrap();
-            let mut batch = epoch_stores[i].db_batch_for_test();
-            output.write_to_batch(&epoch_stores[i], &mut batch).unwrap();
-            batch.write().unwrap();
-        }
-
-        // Verify all participants completed DKG.
-        for randomness_manager in &randomness_managers {
-            assert_eq!(DkgStatus::Successful, randomness_manager.dkg_status());
+        for rm in &setup.randomness_managers {
+            assert_eq!(DkgStatus::Successful, rm.dkg_status());
         }
 
         // Verify the observer derived the same vss_pk as validators, but without shares.
-        let observer_output = randomness_managers[observer_idx]
+        let observer_output = setup.randomness_managers[observer_idx]
             .dkg_output()
             .expect("observer should have DKG output");
-        let validator_output = randomness_managers[0]
+        let validator_output = setup.randomness_managers[0]
             .dkg_output()
             .expect("validator should have DKG output");
         assert_eq!(observer_output.vss_pk, validator_output.vss_pk);
         assert!(observer_output.shares.is_none());
 
-        // Verify validators have private key shares.
-        for rm in &randomness_managers[..num_validators] {
+        for rm in &setup.randomness_managers[..setup.num_validators] {
             let output = rm.dkg_output().expect("validator should have DKG output");
             assert!(output.shares.is_some());
         }
+    }
+
+    /// Builds a minimal set of DKG Nodes from a network config's validator key pairs.
+    fn build_dkg_nodes(
+        network_config: &sui_swarm_config::network_config::NetworkConfig,
+    ) -> (nodes::Nodes<EncG>, u16) {
+        let dkg_nodes: Vec<_> = network_config
+            .validator_configs
+            .iter()
+            .enumerate()
+            .map(|(i, v)| {
+                let pk = bls12381::G2Element::from_byte_array(
+                    v.protocol_key_pair()
+                        .public()
+                        .as_bytes()
+                        .try_into()
+                        .expect("key length should match"),
+                )
+                .expect("should work to convert BLS key to G2Element");
+                nodes::Node::<EncG> {
+                    id: i as u16,
+                    pk: fastcrypto_tbls::ecies_v1::PublicKey::from(pk),
+                    weight: 1,
+                }
+            })
+            .collect();
+        let num_nodes = dkg_nodes.len();
+        // threshold = ceil(num_nodes / 3) works for a minimal committee
+        let t = num_nodes.div_ceil(3) as u16;
+        nodes::Nodes::new(dkg_nodes).map(|n| (n, t)).unwrap()
+    }
+
+    #[test]
+    fn test_dkg_role_try_new_party() {
+        let network_config =
+            sui_swarm_config::network_config_builder::ConfigBuilder::new_with_temp_dir()
+                .committee_size(NonZeroUsize::new(4).unwrap())
+                .with_reference_gas_price(500)
+                .build();
+
+        let (nodes, t) = build_dkg_nodes(&network_config);
+        let random_oracle =
+            fastcrypto_tbls::random_oracle::RandomOracle::new("test_dkg_role_party");
+
+        let role = DkgRole::try_new(
+            Some(network_config.validator_configs[0].protocol_key_pair()),
+            nodes,
+            t,
+            random_oracle,
+        );
+        assert!(role.is_some());
+        assert!(role.unwrap().is_party());
+    }
+
+    #[test]
+    fn test_dkg_role_try_new_observer() {
+        let network_config =
+            sui_swarm_config::network_config_builder::ConfigBuilder::new_with_temp_dir()
+                .committee_size(NonZeroUsize::new(4).unwrap())
+                .with_reference_gas_price(500)
+                .build();
+
+        let (nodes, t) = build_dkg_nodes(&network_config);
+        let random_oracle =
+            fastcrypto_tbls::random_oracle::RandomOracle::new("test_dkg_role_observer");
+
+        let role = DkgRole::try_new(None, nodes, t, random_oracle);
+        assert!(role.is_some());
+        assert!(role.unwrap().is_observer());
     }
 }

--- a/crates/sui-core/src/epoch/randomness.rs
+++ b/crates/sui-core/src/epoch/randomness.rs
@@ -322,7 +322,6 @@ pub struct RandomnessManager {
 }
 
 impl RandomnessManager {
-    
     // Returns None in case of invalid input or other failure to initialize DKG.
     pub async fn try_new(
         epoch_store_weak: Weak<AuthorityPerEpochStore>,

--- a/crates/sui-core/src/epoch/randomness.rs
+++ b/crates/sui-core/src/epoch/randomness.rs
@@ -399,17 +399,19 @@ impl RandomnessManager {
             );
         }
 
-        // Resume randomness generation from where we left off (validators only).
+        // Resume randomness round tracking from where we left off.
+        rm.next_randomness_round = tables
+            .randomness_next_round
+            .get(&SINGLETON_KEY)
+            .expect("typed_store should not fail")
+            .unwrap_or(RandomnessRound(0));
+        info!(
+            "random beacon: starting from next_randomness_round={}",
+            rm.next_randomness_round.0
+        );
+
+        // Re-send partial signatures for incomplete rounds (validators only).
         if rm.party.is_some() {
-            rm.next_randomness_round = tables
-                .randomness_next_round
-                .get(&SINGLETON_KEY)
-                .expect("typed_store should not fail")
-                .unwrap_or(RandomnessRound(0));
-            info!(
-                "random beacon: starting from next_randomness_round={}",
-                rm.next_randomness_round.0
-            );
             let first_incomplete_round = highest_completed_round
                 .map(|r| r + 1)
                 .unwrap_or(RandomnessRound(0));
@@ -611,7 +613,7 @@ impl RandomnessManager {
                     .map(|c| c.unwrap_v1().clone())
                     .collect();
                 observer
-                    .complete::<rand::rngs::ThreadRng>(&raw_messages, &confirmations)
+                    .complete(&raw_messages, &confirmations)
                     .map(|obs_output| Output {
                         nodes: obs_output.nodes,
                         vss_pk: obs_output.vss_pk,

--- a/crates/sui-core/src/epoch/randomness.rs
+++ b/crates/sui-core/src/epoch/randomness.rs
@@ -501,7 +501,7 @@ impl RandomnessManager {
 
         // Once we have enough Messages, merge them.
         if !self.dkg_output.initialized() && !self.used_messages.initialized() {
-            // Process all enqueued messages (Party path only — observer inserts directly).
+            // Process all enqueued messages.
             let mut handles: FuturesUnordered<_> = std::mem::take(&mut self.enqueued_messages)
                 .into_values()
                 .collect();
@@ -610,7 +610,13 @@ impl RandomnessManager {
                     .values()
                     .map(|c| c.unwrap_v1().clone())
                     .collect();
-                observer.complete(&raw_messages, &confirmations)
+                observer
+                    .complete::<rand::rngs::ThreadRng>(&raw_messages, &confirmations)
+                    .map(|obs_output| Output {
+                        nodes: obs_output.nodes,
+                        vss_pk: obs_output.vss_pk,
+                        shares: None,
+                    })
             } else {
                 // Party: complete with decrypted shares.
                 let party = self.party.clone().expect("party must be set for validator");
@@ -731,19 +737,19 @@ impl RandomnessManager {
         }
 
         if let Some(observer) = &self.observer {
-            // Observer: lightweight validation (no decryption), store directly.
+            // Observer: validate synchronously, then stage via enqueued_messages
+            // so advance_dkg persists to consensus_output in the same place as Party.
             let raw_msg = msg.unwrap_v1();
             match observer.process_message(raw_msg.clone()) {
                 Ok(()) => {
-                    let processed = dkg_v1::ProcessedMessage {
+                    let processed = VersionedProcessedMessage::V1(dkg_v1::ProcessedMessage {
                         message: raw_msg,
                         shares: vec![],
                         complaint: None,
-                    };
-                    self.processed_messages.insert(
-                        processed.message.sender,
-                        VersionedProcessedMessage::V1(processed),
-                    );
+                    });
+                    let sender = processed.sender();
+                    self.enqueued_messages
+                        .insert(sender, tokio::task::spawn(async move { Some(processed) }));
                 }
                 Err(err) => {
                     debug!("random beacon: observer error validating DKG Message: {err:?}");

--- a/crates/sui-core/src/epoch/randomness.rs
+++ b/crates/sui-core/src/epoch/randomness.rs
@@ -925,6 +925,11 @@ impl RandomnessManager {
         self.observer.is_some()
     }
 
+    #[cfg(test)]
+    fn dkg_output(&self) -> Option<&dkg_v1::Output<PkG, EncG>> {
+        self.dkg_output.get().and_then(|o| o.as_ref())
+    }
+
     fn epoch_store(&self) -> SuiResult<Arc<AuthorityPerEpochStore>> {
         self.epoch_store
             .upgrade()
@@ -1284,6 +1289,213 @@ mod tests {
         // Verify DKG failed.
         for randomness_manager in &randomness_managers {
             assert_eq!(DkgStatus::Failed, randomness_manager.dkg_status());
+        }
+    }
+
+    #[tokio::test]
+    async fn test_dkg_observer_v1() {
+        test_dkg_observer(1).await;
+    }
+
+    /// Verifies that an Observer completes DKG alongside validators and derives the same
+    /// shared public key (vss_pk), but without receiving any private key shares.
+    async fn test_dkg_observer(version: u64) {
+        telemetry_subscribers::init_for_testing();
+
+        let network_config =
+            sui_swarm_config::network_config_builder::ConfigBuilder::new_with_temp_dir()
+                .committee_size(NonZeroUsize::new(4).unwrap())
+                .with_reference_gas_price(500)
+                .build();
+
+        let mut protocol_config =
+            ProtocolConfig::get_for_version(ProtocolVersion::max(), Chain::Unknown);
+        protocol_config.set_random_beacon_dkg_version_for_testing(version);
+
+        let num_validators = network_config.validator_configs.len();
+        let mut epoch_stores = Vec::new();
+        let mut randomness_managers = Vec::new();
+        let (tx_consensus, mut rx_consensus) = mpsc::channel(100);
+
+        for validator in network_config.validator_configs.iter() {
+            let mut mock_consensus_client = MockConsensusClient::new();
+            let tx_consensus = tx_consensus.clone();
+            mock_consensus_client
+                .expect_submit()
+                .withf(move |transactions: &[ConsensusTransaction], _epoch_store| {
+                    tx_consensus.try_send(transactions.to_vec()).unwrap();
+                    true
+                })
+                .returning(|_, _| {
+                    Ok((
+                        Vec::new(),
+                        with_block_status(BlockStatus::Sequenced(BlockRef::MIN)),
+                    ))
+                });
+
+            let state = TestAuthorityBuilder::new()
+                .with_protocol_config(protocol_config.clone())
+                .with_genesis_and_keypair(&network_config.genesis, validator.protocol_key_pair())
+                .build()
+                .await;
+            let consensus_adapter = Arc::new(ConsensusAdapter::new(
+                Arc::new(mock_consensus_client),
+                CheckpointStore::new_for_tests(),
+                state.name,
+                100_000,
+                100_000,
+                ConsensusAdapterMetrics::new_test(),
+                Arc::new(tokio::sync::Notify::new()),
+            ));
+            let epoch_store = state.epoch_store_for_testing();
+            let randomness_manager = RandomnessManager::try_new(
+                Arc::downgrade(&epoch_store),
+                Box::new(consensus_adapter.clone()),
+                sui_network::randomness::Handle::new_stub(),
+                Some(validator.protocol_key_pair()),
+            )
+            .await
+            .unwrap();
+
+            epoch_stores.push(epoch_store);
+            randomness_managers.push(randomness_manager);
+        }
+
+        // Append an Observer as the last entry, reusing a validator's epoch store (same committee).
+        {
+            let observer_epoch_store = epoch_stores[0].clone();
+            let mut mock_observer_consensus = MockConsensusClient::new();
+            mock_observer_consensus
+                .expect_submit()
+                .returning(|_, _| panic!("observer should not submit to consensus"));
+            let observer_adapter = Arc::new(ConsensusAdapter::new(
+                Arc::new(mock_observer_consensus),
+                CheckpointStore::new_for_tests(),
+                observer_epoch_store.name,
+                100_000,
+                100_000,
+                ConsensusAdapterMetrics::new_test(),
+                Arc::new(tokio::sync::Notify::new()),
+            ));
+            let observer_manager = RandomnessManager::try_new(
+                Arc::downgrade(&observer_epoch_store),
+                Box::new(observer_adapter),
+                sui_network::randomness::Handle::new_stub(),
+                None,
+            )
+            .await
+            .unwrap();
+
+            epoch_stores.push(observer_epoch_store.into());
+            randomness_managers.push(observer_manager);
+        }
+        let observer_idx = randomness_managers.len() - 1;
+
+        // Generate DKG Messages from validators. The observer's start_dkg is a no-op.
+        let mut dkg_messages = Vec::new();
+        for randomness_manager in randomness_managers.iter_mut() {
+            randomness_manager.start_dkg().await.unwrap();
+        }
+        for _ in 0..num_validators {
+            let mut dkg_message = rx_consensus.recv().await.unwrap();
+            assert!(dkg_message.len() == 1);
+            match dkg_message.remove(0).kind {
+                ConsensusTransactionKind::RandomnessDkgMessage(_, bytes) => {
+                    let msg: VersionedDkgMessage = bcs::from_bytes(&bytes)
+                        .expect("DKG message deserialization should not fail");
+                    dkg_messages.push(msg);
+                }
+                _ => panic!("wrong type of message sent"),
+            }
+        }
+
+        // Distribute messages to all participants (validators + observer).
+        for i in 0..randomness_managers.len() {
+            let mut output = ConsensusCommitOutput::new(0);
+            output.record_consensus_commit_stats(ExecutionIndicesWithStatsV2 {
+                index: ExecutionIndices {
+                    last_committed_round: 0,
+                    ..Default::default()
+                },
+                ..Default::default()
+            });
+            for (j, dkg_message) in dkg_messages.iter().cloned().enumerate() {
+                randomness_managers[i]
+                    .add_message(&epoch_stores[j].name, dkg_message)
+                    .unwrap();
+            }
+            randomness_managers[i]
+                .advance_dkg(&mut output, 0)
+                .await
+                .unwrap();
+            let mut batch = epoch_stores[i].db_batch_for_test();
+            output.write_to_batch(&epoch_stores[i], &mut batch).unwrap();
+            batch.write().unwrap();
+        }
+
+        // Verify DKG is not yet complete for any participant after the message phase.
+        for randomness_manager in &randomness_managers {
+            assert_eq!(DkgStatus::Pending, randomness_manager.dkg_status());
+        }
+
+        // Collect Confirmations (only validators produce these).
+        let mut dkg_confirmations = Vec::new();
+        for _ in 0..num_validators {
+            let mut dkg_confirmation = rx_consensus.recv().await.unwrap();
+            assert!(dkg_confirmation.len() == 1);
+            match dkg_confirmation.remove(0).kind {
+                ConsensusTransactionKind::RandomnessDkgConfirmation(_, bytes) => {
+                    let msg: VersionedDkgConfirmation = bcs::from_bytes(&bytes)
+                        .expect("DKG confirmation deserialization should not fail");
+                    dkg_confirmations.push(msg);
+                }
+                _ => panic!("wrong type of message sent"),
+            }
+        }
+
+        // Distribute confirmations to all participants (validators + observer).
+        for i in 0..randomness_managers.len() {
+            let mut output = ConsensusCommitOutput::new(0);
+            output.record_consensus_commit_stats(ExecutionIndicesWithStatsV2 {
+                index: ExecutionIndices {
+                    last_committed_round: 1,
+                    ..Default::default()
+                },
+                ..Default::default()
+            });
+            for (j, dkg_confirmation) in dkg_confirmations.iter().cloned().enumerate() {
+                randomness_managers[i]
+                    .add_confirmation(&mut output, &epoch_stores[j].name, dkg_confirmation)
+                    .unwrap();
+            }
+            randomness_managers[i]
+                .advance_dkg(&mut output, 0)
+                .await
+                .unwrap();
+            let mut batch = epoch_stores[i].db_batch_for_test();
+            output.write_to_batch(&epoch_stores[i], &mut batch).unwrap();
+            batch.write().unwrap();
+        }
+
+        // Verify all participants completed DKG.
+        for randomness_manager in &randomness_managers {
+            assert_eq!(DkgStatus::Successful, randomness_manager.dkg_status());
+        }
+
+        // Verify the observer derived the same vss_pk as validators, but without shares.
+        let observer_output = randomness_managers[observer_idx]
+            .dkg_output()
+            .expect("observer should have DKG output");
+        let validator_output = randomness_managers[0]
+            .dkg_output()
+            .expect("validator should have DKG output");
+        assert_eq!(observer_output.vss_pk, validator_output.vss_pk);
+        assert!(observer_output.shares.is_none());
+
+        // Verify validators have private key shares.
+        for rm in &randomness_managers[..num_validators] {
+            let output = rm.dkg_output().expect("validator should have DKG output");
+            assert!(output.shares.is_some());
         }
     }
 }

--- a/crates/sui-core/src/epoch/randomness.rs
+++ b/crates/sui-core/src/epoch/randomness.rs
@@ -71,6 +71,14 @@ impl VersionedProcessedMessage {
         }
     }
 
+    pub fn unwrap_v1_ref(&self) -> &dkg_v1::ProcessedMessage<PkG, EncG> {
+        if let VersionedProcessedMessage::V1(msg) = self {
+            msg
+        } else {
+            panic!("BUG: expected message version is 1")
+        }
+    }
+
     pub fn process(
         party: Arc<dkg_v1::Party<PkG, EncG>>,
         message: VersionedDkgMessage,
@@ -105,6 +113,14 @@ pub enum VersionedUsedProcessedMessages {
 }
 
 impl VersionedUsedProcessedMessages {
+    pub fn unwrap_v1_ref(&self) -> &dkg_v1::UsedProcessedMessages<PkG, EncG> {
+        if let VersionedUsedProcessedMessages::V1(msg) = self {
+            msg
+        } else {
+            panic!("BUG: invalid VersionedUsedProcessedMessages version")
+        }
+    }
+
     fn complete_dkg<'a, Iter: Iterator<Item = &'a VersionedDkgConfirmation>>(
         &self,
         party: Arc<dkg_v1::Party<PkG, EncG>>,
@@ -154,7 +170,8 @@ pub struct RandomnessManager {
 
     // State for DKG.
     dkg_start_time: OnceCell<Instant>,
-    party: Arc<dkg_v1::Party<PkG, EncG>>,
+    party: Option<Arc<dkg_v1::Party<PkG, EncG>>>,
+    observer: Option<dkg_v1::Observer<PkG, EncG>>,
     enqueued_messages: BTreeMap<PartyId, JoinHandle<Option<VersionedProcessedMessage>>>,
     processed_messages: BTreeMap<PartyId, VersionedProcessedMessage>,
     used_messages: OnceCell<VersionedUsedProcessedMessages>,
@@ -168,11 +185,13 @@ pub struct RandomnessManager {
 
 impl RandomnessManager {
     // Returns None in case of invalid input or other failure to initialize DKG.
+    // When `authority_key_pair` is Some, creates an active Party (validator).
+    // When None, creates a read-only Observer (fullnode).
     pub async fn try_new(
         epoch_store_weak: Weak<AuthorityPerEpochStore>,
         consensus_adapter: Box<dyn SubmitToConsensus>,
         network_handle: randomness::Handle,
-        authority_key_pair: &AuthorityKeyPair,
+        authority_key_pair: Option<&AuthorityKeyPair>,
     ) -> Option<Self> {
         let epoch_store = match epoch_store_weak.upgrade() {
             Some(epoch_store) => epoch_store,
@@ -194,7 +213,6 @@ impl RandomnessManager {
         };
         let protocol_config = epoch_store.protocol_config();
 
-        let name: AuthorityName = authority_key_pair.public().into();
         let committee = epoch_store.committee();
         let info = RandomnessManager::randomness_dkg_info_from_committee(committee);
         if tracing::enabled!(tracing::Level::DEBUG) {
@@ -254,33 +272,51 @@ impl RandomnessManager {
             Hex::encode(epoch_store.get_chain_identifier().as_bytes()),
             committee.epoch()
         );
-        let randomness_private_key = bls12381::Scalar::from_byte_array(
-            authority_key_pair
-                .copy()
-                .private()
-                .as_bytes()
-                .try_into()
-                .expect("key length should match"),
-        )
-        .expect("should work to convert BLS key to Scalar");
-        let party = match dkg_v1::Party::<PkG, EncG>::new(
-            fastcrypto_tbls::ecies_v1::PrivateKey::<bls12381::G2Element>::from(
-                randomness_private_key,
-            ),
-            nodes,
-            t,
-            fastcrypto_tbls::random_oracle::RandomOracle::new(prefix_str.as_str()),
-            &mut rand::thread_rng(),
-        ) {
-            Ok(party) => party,
-            Err(err) => {
-                error!("random beacon: error while initializing Party: {err:?}");
-                return None;
-            }
+        let random_oracle = fastcrypto_tbls::random_oracle::RandomOracle::new(prefix_str.as_str());
+
+        let (party, observer) = if let Some(authority_key_pair) = authority_key_pair {
+            let randomness_private_key = bls12381::Scalar::from_byte_array(
+                authority_key_pair
+                    .copy()
+                    .private()
+                    .as_bytes()
+                    .try_into()
+                    .expect("key length should match"),
+            )
+            .expect("should work to convert BLS key to Scalar");
+            let party = match dkg_v1::Party::<PkG, EncG>::new(
+                fastcrypto_tbls::ecies_v1::PrivateKey::<bls12381::G2Element>::from(
+                    randomness_private_key,
+                ),
+                nodes,
+                t,
+                random_oracle,
+                &mut rand::thread_rng(),
+            ) {
+                Ok(party) => party,
+                Err(err) => {
+                    error!("random beacon: error while initializing Party: {err:?}");
+                    return None;
+                }
+            };
+            let name: AuthorityName = authority_key_pair.public().into();
+            info!(
+                "random beacon: Party initialized with authority={name}, total_weight={total_weight}, t={t}, num_nodes={num_nodes}, oracle initial_prefix={prefix_str:?}",
+            );
+            (Some(Arc::new(party)), None)
+        } else {
+            let observer = match dkg_v1::Observer::<PkG, EncG>::new(nodes, t, random_oracle) {
+                Ok(observer) => observer,
+                Err(err) => {
+                    error!("random beacon: error while initializing Observer: {err:?}");
+                    return None;
+                }
+            };
+            info!(
+                "random beacon: Observer initialized with total_weight={total_weight}, t={t}, num_nodes={num_nodes}, oracle initial_prefix={prefix_str:?}",
+            );
+            (None, Some(observer))
         };
-        info!(
-            "random beacon: state initialized with authority={name}, total_weight={total_weight}, t={t}, num_nodes={num_nodes}, oracle initial_prefix={prefix_str:?}",
-        );
 
         // Load existing data from store.
         let highest_completed_round = tables
@@ -294,7 +330,8 @@ impl RandomnessManager {
             network_handle: network_handle.clone(),
             authority_info,
             dkg_start_time: OnceCell::new(),
-            party: Arc::new(party),
+            party,
+            observer,
             enqueued_messages: BTreeMap::new(),
             processed_messages: BTreeMap::new(),
             used_messages: OnceCell::new(),
@@ -319,13 +356,15 @@ impl RandomnessManager {
             rm.dkg_output
                 .set(Some(dkg_output.clone()))
                 .expect("setting new OnceCell should succeed");
-            network_handle.update_epoch(
-                committee.epoch(),
-                rm.authority_info.clone(),
-                dkg_output,
-                rm.party.t(),
-                highest_completed_round,
-            );
+            if let Some(party) = &rm.party {
+                network_handle.update_epoch(
+                    committee.epoch(),
+                    rm.authority_info.clone(),
+                    dkg_output,
+                    party.t(),
+                    highest_completed_round,
+                );
+            }
         } else {
             info!(
                 "random beacon: no existing DKG output found for epoch {}",
@@ -360,30 +399,29 @@ impl RandomnessManager {
             );
         }
 
-        // Resume randomness generation from where we left off.
-        // This must be loaded regardless of whether DKG has finished yet, since the
-        // RandomnessEventLoop and commit-handling logic in AuthorityPerEpochStore both depend on
-        // this state.
-        rm.next_randomness_round = tables
-            .randomness_next_round
-            .get(&SINGLETON_KEY)
-            .expect("typed_store should not fail")
-            .unwrap_or(RandomnessRound(0));
-        info!(
-            "random beacon: starting from next_randomness_round={}",
-            rm.next_randomness_round.0
-        );
-        let first_incomplete_round = highest_completed_round
-            .map(|r| r + 1)
-            .unwrap_or(RandomnessRound(0));
-        if first_incomplete_round < rm.next_randomness_round {
+        // Resume randomness generation from where we left off (validators only).
+        if rm.party.is_some() {
+            rm.next_randomness_round = tables
+                .randomness_next_round
+                .get(&SINGLETON_KEY)
+                .expect("typed_store should not fail")
+                .unwrap_or(RandomnessRound(0));
             info!(
-                "random beacon: resuming generation for randomness rounds from {} to {}",
-                first_incomplete_round,
-                rm.next_randomness_round - 1,
+                "random beacon: starting from next_randomness_round={}",
+                rm.next_randomness_round.0
             );
-            for r in first_incomplete_round.0..rm.next_randomness_round.0 {
-                network_handle.send_partial_signatures(committee.epoch(), RandomnessRound(r));
+            let first_incomplete_round = highest_completed_round
+                .map(|r| r + 1)
+                .unwrap_or(RandomnessRound(0));
+            if first_incomplete_round < rm.next_randomness_round {
+                info!(
+                    "random beacon: resuming generation for randomness rounds from {} to {}",
+                    first_incomplete_round,
+                    rm.next_randomness_round - 1,
+                );
+                for r in first_incomplete_round.0..rm.next_randomness_round.0 {
+                    network_handle.send_partial_signatures(committee.epoch(), RandomnessRound(r));
+                }
             }
         }
 
@@ -391,6 +429,7 @@ impl RandomnessManager {
     }
 
     /// Sends the initial dkg::Message to begin the randomness DKG protocol.
+    /// For observers, this is a no-op (observers don't send messages).
     pub async fn start_dkg(&mut self) -> SuiResult {
         if self.used_messages.initialized() || self.dkg_output.initialized() {
             // DKG already started (or completed or failed).
@@ -399,16 +438,22 @@ impl RandomnessManager {
 
         let _ = self.dkg_start_time.set(Instant::now());
 
+        // Observers only observe — they don't create or send DKG messages.
+        let Some(party) = &self.party else {
+            info!("random beacon: observer started observing DKG");
+            return Ok(());
+        };
+
         let epoch_store = self.epoch_store()?;
         let dkg_version = epoch_store.protocol_config().dkg_version();
         info!("random beacon: starting DKG, version {dkg_version}");
 
-        let msg = match VersionedDkgMessage::create(dkg_version, self.party.clone()) {
+        let msg = match VersionedDkgMessage::create(dkg_version, party.clone()) {
             Ok(msg) => msg,
             Err(FastCryptoError::IgnoredMessage) => {
                 info!(
                     "random beacon: no DKG Message for party id={} (zero weight)",
-                    self.party.id
+                    party.id
                 );
                 return Ok(());
             }
@@ -454,9 +499,9 @@ impl RandomnessManager {
     ) -> SuiResult {
         let epoch_store = self.epoch_store()?;
 
-        // Once we have enough Messages, send a Confirmation.
+        // Once we have enough Messages, merge them.
         if !self.dkg_output.initialized() && !self.used_messages.initialized() {
-            // Process all enqueued messages.
+            // Process all enqueued messages (Party path only — observer inserts directly).
             let mut handles: FuturesUnordered<_> = std::mem::take(&mut self.enqueued_messages)
                 .into_values()
                 .collect();
@@ -468,67 +513,131 @@ impl RandomnessManager {
                 }
             }
 
-            // Attempt to generate the Confirmation.
-            match VersionedProcessedMessage::merge(
-                self.party.clone(),
-                self.processed_messages
+            if let Some(observer) = &self.observer {
+                // Observer: merge raw messages, no Confirmation sent.
+                let raw_messages: Vec<_> = self
+                    .processed_messages
                     .values()
-                    .cloned()
-                    .collect::<Vec<_>>(),
-            ) {
-                Ok((conf, used_msgs)) => {
-                    info!(
-                        "random beacon: sending DKG Confirmation with {} complaints",
-                        conf.num_of_complaints()
-                    );
-                    if self.used_messages.set(used_msgs.clone()).is_err() {
-                        error!("BUG: used_messages should only ever be set once");
+                    .map(|pm| pm.unwrap_v1_ref().message.clone())
+                    .collect();
+                match observer.merge(raw_messages) {
+                    Ok(used) => {
+                        info!("random beacon: observer merged {} DKG messages", used.len());
+                        let used_msgs =
+                            VersionedUsedProcessedMessages::V1(dkg_v1::UsedProcessedMessages(
+                                used.into_iter()
+                                    .map(|m| dkg_v1::ProcessedMessage {
+                                        message: m,
+                                        shares: vec![],
+                                        complaint: None,
+                                    })
+                                    .collect(),
+                            ));
+                        if self.used_messages.set(used_msgs.clone()).is_err() {
+                            error!("BUG: used_messages should only ever be set once");
+                        }
+                        consensus_output.insert_dkg_used_messages(used_msgs);
                     }
-                    consensus_output.insert_dkg_used_messages(used_msgs);
-
-                    let transaction = ConsensusTransaction::new_randomness_dkg_confirmation(
-                        epoch_store.name,
-                        &conf,
-                    );
-
-                    #[allow(unused_mut)]
-                    let mut fail_point_skip_sending = false;
-                    fail_point_if!("rb-dkg", || {
-                        // maybe skip sending in simtests
-                        fail_point_skip_sending = true;
-                    });
-                    if !fail_point_skip_sending {
-                        self.consensus_adapter
-                            .submit_to_consensus(&[transaction], &epoch_store)?;
-                    }
-
-                    let elapsed = self.dkg_start_time.get().map(|t| t.elapsed().as_millis());
-                    if let Some(elapsed) = elapsed {
-                        epoch_store
-                            .metrics
-                            .epoch_random_beacon_dkg_confirmation_time_ms
-                            .set(elapsed as i64);
-                    }
+                    Err(FastCryptoError::NotEnoughInputs) => (), // wait for more input
+                    Err(e) => debug!("random beacon: observer error merging DKG Messages: {e:?}"),
                 }
-                Err(FastCryptoError::NotEnoughInputs) => (), // wait for more input
-                Err(e) => debug!("random beacon: error while merging DKG Messages: {e:?}"),
+            } else {
+                // Party: merge and produce a Confirmation to send.
+                let party = self.party.clone().expect("party must be set for validator");
+                match VersionedProcessedMessage::merge(
+                    party,
+                    self.processed_messages
+                        .values()
+                        .cloned()
+                        .collect::<Vec<_>>(),
+                ) {
+                    Ok((conf, used_msgs)) => {
+                        info!(
+                            "random beacon: sending DKG Confirmation with {} complaints",
+                            conf.num_of_complaints()
+                        );
+                        if self.used_messages.set(used_msgs.clone()).is_err() {
+                            error!("BUG: used_messages should only ever be set once");
+                        }
+                        consensus_output.insert_dkg_used_messages(used_msgs);
+
+                        let transaction = ConsensusTransaction::new_randomness_dkg_confirmation(
+                            epoch_store.name,
+                            &conf,
+                        );
+
+                        #[allow(unused_mut)]
+                        let mut fail_point_skip_sending = false;
+                        fail_point_if!("rb-dkg", || {
+                            // maybe skip sending in simtests
+                            fail_point_skip_sending = true;
+                        });
+                        if !fail_point_skip_sending {
+                            self.consensus_adapter
+                                .submit_to_consensus(&[transaction], &epoch_store)?;
+                        }
+
+                        let elapsed = self.dkg_start_time.get().map(|t| t.elapsed().as_millis());
+                        if let Some(elapsed) = elapsed {
+                            epoch_store
+                                .metrics
+                                .epoch_random_beacon_dkg_confirmation_time_ms
+                                .set(elapsed as i64);
+                        }
+                    }
+                    Err(FastCryptoError::NotEnoughInputs) => (), // wait for more input
+                    Err(e) => debug!("random beacon: error while merging DKG Messages: {e:?}"),
+                }
             }
         }
 
-        // Once we have enough Confirmations, process them and update shares.
+        // Once we have enough Confirmations, complete DKG.
         if !self.dkg_output.initialized() && self.used_messages.initialized() {
-            match self
-                .used_messages
-                .get()
-                .expect("checked above that `used_messages` is initialized")
-                .complete_dkg(self.party.clone(), self.confirmations.values())
-            {
+            let complete_result = if let Some(observer) = &self.observer {
+                // Observer: extract raw messages and complete without secrets.
+                let used = self
+                    .used_messages
+                    .get()
+                    .expect("checked above that `used_messages` is initialized");
+                let raw_messages: Vec<_> = used
+                    .unwrap_v1_ref()
+                    .0
+                    .iter()
+                    .map(|pm| pm.message.clone())
+                    .collect();
+                let confirmations: Vec<_> = self
+                    .confirmations
+                    .values()
+                    .map(|c| c.unwrap_v1().clone())
+                    .collect();
+                observer.complete(&raw_messages, &confirmations)
+            } else {
+                // Party: complete with decrypted shares.
+                let party = self.party.clone().expect("party must be set for validator");
+                self.used_messages
+                    .get()
+                    .expect("checked above that `used_messages` is initialized")
+                    .complete_dkg(party, self.confirmations.values())
+            };
+
+            let role = if self.observer.is_some() {
+                "Observer"
+            } else {
+                "Party"
+            };
+            let epoch = epoch_store.committee().epoch();
+            let num_confirmations = self.confirmations.len();
+            let num_messages = self.processed_messages.len();
+
+            match complete_result {
                 Ok(output) => {
                     let num_shares = output.shares.as_ref().map_or(0, |shares| shares.len());
                     let epoch_elapsed = epoch_store.epoch_open_time.elapsed().as_millis();
                     let elapsed = self.dkg_start_time.get().map(|t| t.elapsed().as_millis());
                     info!(
-                        "random beacon: DKG complete in {epoch_elapsed}ms since epoch start, {elapsed:?}ms since DKG start, with {num_shares} shares for this node"
+                        "random beacon: DKG complete role={role} epoch={epoch} commit_round={round} \
+                         num_messages={num_messages} num_confirmations={num_confirmations} \
+                         num_shares={num_shares} epoch_elapsed_ms={epoch_elapsed} dkg_elapsed_ms={elapsed:?}"
                     );
                     epoch_store
                         .metrics
@@ -548,13 +657,15 @@ impl RandomnessManager {
                     self.dkg_output
                         .set(Some(output.clone()))
                         .expect("checked above that `dkg_output` is uninitialized");
-                    self.network_handle.update_epoch(
-                        epoch_store.committee().epoch(),
-                        self.authority_info.clone(),
-                        output.clone(),
-                        self.party.t(),
-                        None,
-                    );
+                    if let Some(party) = &self.party {
+                        self.network_handle.update_epoch(
+                            epoch_store.committee().epoch(),
+                            self.authority_info.clone(),
+                            output.clone(),
+                            party.t(),
+                            None,
+                        );
+                    }
                     consensus_output.set_dkg_output(output);
                 }
                 Err(FastCryptoError::NotEnoughInputs) => (), // wait for more input
@@ -619,20 +730,41 @@ impl RandomnessManager {
             return Ok(());
         }
 
-        let party = self.party.clone();
-        // TODO: Could save some CPU by not processing messages if we already have enough to merge.
-        self.enqueued_messages.insert(
-            msg.sender(),
-            tokio::task::spawn_blocking(move || {
-                match VersionedProcessedMessage::process(party, msg) {
-                    Ok(processed) => Some(processed),
-                    Err(err) => {
-                        debug!("random beacon: error while processing DKG Message: {err:?}");
-                        None
-                    }
+        if let Some(observer) = &self.observer {
+            // Observer: lightweight validation (no decryption), store directly.
+            let raw_msg = msg.unwrap_v1();
+            match observer.process_message(raw_msg.clone()) {
+                Ok(()) => {
+                    let processed = dkg_v1::ProcessedMessage {
+                        message: raw_msg,
+                        shares: vec![],
+                        complaint: None,
+                    };
+                    self.processed_messages.insert(
+                        processed.message.sender,
+                        VersionedProcessedMessage::V1(processed),
+                    );
                 }
-            }),
-        );
+                Err(err) => {
+                    debug!("random beacon: observer error validating DKG Message: {err:?}");
+                }
+            }
+        } else {
+            let party = self.party.clone().expect("party must be set for validator");
+            // TODO: Could save some CPU by not processing messages if we already have enough to merge.
+            self.enqueued_messages.insert(
+                msg.sender(),
+                tokio::task::spawn_blocking(move || {
+                    match VersionedProcessedMessage::process(party, msg) {
+                        Ok(processed) => Some(processed),
+                        Err(err) => {
+                            debug!("random beacon: error while processing DKG Message: {err:?}");
+                            None
+                        }
+                    }
+                }),
+            );
+        }
         Ok(())
     }
 
@@ -709,8 +841,11 @@ impl RandomnessManager {
         Ok(Some(randomness_round))
     }
 
-    /// Starts the process of generating the given RandomnessRound.
+    /// Starts the process of generating the given RandomnessRound (validators only).
     pub fn generate_randomness(&self, epoch: EpochId, randomness_round: RandomnessRound) {
+        if self.observer.is_some() {
+            return;
+        }
         self.network_handle
             .send_partial_signatures(epoch, randomness_round);
     }
@@ -724,13 +859,17 @@ impl RandomnessManager {
     }
 
     /// Generates a new RandomnessReporter for reporting observed rounds to this RandomnessManager.
-    pub fn reporter(&self) -> RandomnessReporter {
-        RandomnessReporter {
+    /// Returns None for observers (they don't generate partial signatures).
+    pub fn reporter(&self) -> Option<RandomnessReporter> {
+        if self.observer.is_some() {
+            return None;
+        }
+        Some(RandomnessReporter {
             epoch_store: self.epoch_store.clone(),
             epoch: self.epoch,
             network_handle: self.network_handle.clone(),
             highest_completed_round: self.highest_completed_round.clone(),
-        }
+        })
     }
 
     fn epoch_store(&self) -> SuiResult<Arc<AuthorityPerEpochStore>> {
@@ -892,7 +1031,7 @@ mod tests {
                 Arc::downgrade(&epoch_store),
                 Box::new(consensus_adapter.clone()),
                 sui_network::randomness::Handle::new_stub(),
-                validator.protocol_key_pair(),
+                Some(validator.protocol_key_pair()),
             )
             .await
             .unwrap();
@@ -1041,7 +1180,7 @@ mod tests {
                 Arc::downgrade(&epoch_store),
                 Box::new(consensus_adapter.clone()),
                 sui_network::randomness::Handle::new_stub(),
-                validator.protocol_key_pair(),
+                Some(validator.protocol_key_pair()),
             )
             .await
             .unwrap();

--- a/crates/sui-core/src/epoch/randomness.rs
+++ b/crates/sui-core/src/epoch/randomness.rs
@@ -141,7 +141,7 @@ impl DkgRole {
             ) {
                 Ok(party) => party,
                 Err(err) => {
-                    error!("random beacon: error while initializing Party: {err:?}");
+                    debug_fatal!("random beacon: error while initializing Party: {err:?}");
                     return None;
                 }
             };
@@ -154,7 +154,7 @@ impl DkgRole {
             let observer = match dkg_v1::Observer::<PkG, EncG>::new(nodes, t, random_oracle) {
                 Ok(observer) => observer,
                 Err(err) => {
-                    error!("random beacon: error while initializing Observer: {err:?}");
+                    debug_fatal!("random beacon: error while initializing Observer: {err:?}");
                     return None;
                 }
             };

--- a/crates/sui-core/src/execution_scheduler/execution_scheduler_impl.rs
+++ b/crates/sui-core/src/execution_scheduler/execution_scheduler_impl.rs
@@ -174,8 +174,8 @@ impl ExecutionScheduler {
         scheduler_type: FundsWithdrawSchedulerType,
         address_funds_scheduler_metrics: &Arc<AddressFundsSchedulerMetrics>,
     ) -> Option<FundsWithdrawScheduler> {
-        let withdraw_scheduler_enabled =
-            epoch_store.is_validator() && epoch_store.accumulators_enabled();
+        let withdraw_scheduler_enabled = epoch_store.node_role().is_withdraw_scheduler_enabled()
+            && epoch_store.accumulators_enabled();
         if !withdraw_scheduler_enabled {
             return None;
         }

--- a/crates/sui-core/src/execution_scheduler/execution_scheduler_impl.rs
+++ b/crates/sui-core/src/execution_scheduler/execution_scheduler_impl.rs
@@ -174,7 +174,7 @@ impl ExecutionScheduler {
         scheduler_type: FundsWithdrawSchedulerType,
         address_funds_scheduler_metrics: &Arc<AddressFundsSchedulerMetrics>,
     ) -> Option<FundsWithdrawScheduler> {
-        let withdraw_scheduler_enabled = epoch_store.node_role().is_withdraw_scheduler_enabled()
+        let withdraw_scheduler_enabled = epoch_store.node_role().process_consensus_commits()
             && epoch_store.accumulators_enabled();
         if !withdraw_scheduler_enabled {
             return None;

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -1406,11 +1406,16 @@ impl SuiNode {
         );
 
         if node_role.runs_consensus() && epoch_store.randomness_state_enabled() {
+            let authority_key_pair = if node_role.is_validator() {
+                Some(config.protocol_key_pair())
+            } else {
+                None
+            };
             let randomness_manager = RandomnessManager::try_new(
                 Arc::downgrade(&epoch_store),
                 Box::new(consensus_adapter.clone()),
                 randomness_handle,
-                config.protocol_key_pair(),
+                authority_key_pair,
             )
             .await;
             if let Some(randomness_manager) = randomness_manager {

--- a/crates/sui-types/src/messages_consensus.rs
+++ b/crates/sui-types/src/messages_consensus.rs
@@ -27,7 +27,6 @@ use serde::{Deserialize, Serialize};
 use std::collections::hash_map::DefaultHasher;
 use std::fmt::{Debug, Formatter};
 use std::hash::{Hash, Hasher};
-use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 /// The index of an authority in the consensus committee.
@@ -521,7 +520,7 @@ impl VersionedDkgMessage {
 
     pub fn create(
         dkg_version: u64,
-        party: Arc<dkg_v1::Party<bls12381::G2Element, bls12381::G2Element>>,
+        party: &dkg_v1::Party<bls12381::G2Element, bls12381::G2Element>,
     ) -> FastCryptoResult<VersionedDkgMessage> {
         assert_eq!(dkg_version, 1, "BUG: invalid DKG version");
         let msg = party.create_message(&mut rand::thread_rng())?;
@@ -559,10 +558,10 @@ impl VersionedDkgConfirmation {
         }
     }
 
-    pub fn unwrap_v1(&self) -> &dkg_v1::Confirmation<bls12381::G2Element> {
+    pub fn as_v1(&self) -> Option<&dkg_v1::Confirmation<bls12381::G2Element>> {
         match self {
-            VersionedDkgConfirmation::V1(msg) => msg,
-            _ => panic!("BUG: expected V1 confirmation"),
+            VersionedDkgConfirmation::V1(msg) => Some(msg),
+            _ => None,
         }
     }
 

--- a/crates/sui-types/src/node_role.rs
+++ b/crates/sui-types/src/node_role.rs
@@ -79,6 +79,10 @@ impl NodeRole {
     pub fn should_run_rpc_servers(&self) -> bool {
         matches!(self, Self::FullNode(_))
     }
+
+    pub fn is_withdraw_scheduler_enabled(&self) -> bool {
+        matches!(self, Self::Validator | Self::FullNode(FullNodeSyncMode::ConsensusObserver))
+    }
 }
 
 impl std::fmt::Display for NodeRole {
@@ -103,7 +107,6 @@ mod tests {
         assert!(role.runs_consensus());
         assert!(!role.should_enable_index_processing());
         assert!(!role.should_run_rpc_servers());
-        assert!(role.should_process_consensus_commits());
     }
 
     #[test]
@@ -112,7 +115,6 @@ mod tests {
         assert!(role.runs_consensus());
         assert!(role.should_enable_index_processing());
         assert!(role.should_run_rpc_servers());
-        assert!(!role.should_process_consensus_commits());
     }
 
     #[test]
@@ -121,6 +123,5 @@ mod tests {
         assert!(!role.runs_consensus());
         assert!(role.should_enable_index_processing());
         assert!(role.should_run_rpc_servers());
-        assert!(!role.should_process_consensus_commits());
     }
 }

--- a/crates/sui-types/src/node_role.rs
+++ b/crates/sui-types/src/node_role.rs
@@ -71,20 +71,13 @@ impl NodeRole {
     /// Whether this node should process consensus commit output (execute
     /// transactions, create checkpoints, etc.). Observers stream blocks but
     /// rely on state-sync for execution, so they skip commit processing.
-    pub fn should_process_consensus_commits(&self) -> bool {
+    pub fn process_consensus_commits(&self) -> bool {
         matches!(self, Self::Validator)
     }
 
     /// Whether this node should expose HTTP/RPC servers (JSON-RPC, REST).
     pub fn should_run_rpc_servers(&self) -> bool {
         matches!(self, Self::FullNode(_))
-    }
-
-    pub fn is_withdraw_scheduler_enabled(&self) -> bool {
-        matches!(
-            self,
-            Self::Validator | Self::FullNode(FullNodeSyncMode::ConsensusObserver)
-        )
     }
 }
 
@@ -110,6 +103,7 @@ mod tests {
         assert!(role.runs_consensus());
         assert!(!role.should_enable_index_processing());
         assert!(!role.should_run_rpc_servers());
+        assert!(role.process_consensus_commits());
     }
 
     #[test]
@@ -118,6 +112,7 @@ mod tests {
         assert!(role.runs_consensus());
         assert!(role.should_enable_index_processing());
         assert!(role.should_run_rpc_servers());
+        assert!(!role.process_consensus_commits());
     }
 
     #[test]
@@ -126,5 +121,6 @@ mod tests {
         assert!(!role.runs_consensus());
         assert!(role.should_enable_index_processing());
         assert!(role.should_run_rpc_servers());
+        assert!(!role.process_consensus_commits());
     }
 }

--- a/crates/sui-types/src/node_role.rs
+++ b/crates/sui-types/src/node_role.rs
@@ -81,7 +81,10 @@ impl NodeRole {
     }
 
     pub fn is_withdraw_scheduler_enabled(&self) -> bool {
-        matches!(self, Self::Validator | Self::FullNode(FullNodeSyncMode::ConsensusObserver))
+        matches!(
+            self,
+            Self::Validator | Self::FullNode(FullNodeSyncMode::ConsensusObserver)
+        )
     }
 }
 


### PR DESCRIPTION
## Description 

This is the first in a series of PRs enabling block-streaming full nodes to process randomness round signatures. This will allow them  to execute transactions from local commits without waiting for randomness state update transactions to arrive via checkpoints - which would negate the latency benefit of block streaming.                                                                                   
                                                                                                                                         
This PR updates the fastcrypto library to introduce the Observer construct for the DKG protocol. An Observer (i.e. a block-streaming full node) can follow the DKG process and derive the shared public key without having any voting rights or private key shares. This is possible because all DKG messages and confirmations are propagated through consensus and are therefore durably available to anyone following the DAG. With the public key in hand, the observer can verify randomness round signatures received from its block-streaming  peer - the signatures themselves are the only piece that travels over a side channel rather than through consensus.  

## Test plan 

CI/PT

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
