### PR TITLE
[ci] Do not run CI on edits to markdown files only

### DIFF
--- a/.github/actions/diffs/action.yml
+++ b/.github/actions/diffs/action.yml
@@ -9,10 +9,10 @@ outputs:
     value: "${{ steps.diff.outputs.isOldDoc }}"    
   isRust:
     description: True when changes happened to the Rust code
-    value: "${{ steps.diff.outputs.isRust }}"
+    value: "${{ steps.diff.outputs.isRust == 'true' && steps.markdown_only.outputs.isNonFrameworkMarkdownOnly != 'true' }}"
   isMove:
     description: True when changes happened to the Move code
-    value: "${{ steps.diff.outputs.isMove }}"
+    value: "${{ steps.diff.outputs.isMove == 'true' && steps.markdown_only.outputs.isNonFrameworkMarkdownOnly != 'true' }}"
   isSolidity:
     description: True when changes happened to the Solidity code
     value: "${{ steps.diff.outputs.isSolidity }}"
@@ -90,3 +90,44 @@ runs:
         isReleaseNotesScript:
           - 'scripts/release_notes.py'
           - 'scripts/release_notes_test.py'
+  - name: List Changed Files
+    uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # pin@v3.0.2
+    id: changed_files
+    with:
+      list-files: shell
+      filters: |
+        all:
+          - '**'
+          - '.*'
+          - '.*/**'
+          - '**/.*'
+          - '**/.*/**'
+  - name: Detect Markdown-only Changes
+    id: markdown_only
+    shell: bash
+    run: |
+      set -euo pipefail
+
+      changed_files=(${{ steps.changed_files.outputs.all_files }})
+      is_non_framework_markdown_only=true
+
+      if [ ${#changed_files[@]} -eq 0 ]; then
+        is_non_framework_markdown_only=false
+      fi
+
+      for file in "${changed_files[@]}"; do
+        case "$file" in
+          crates/sui-framework/* | external-crates/move/documentation/* | external-crates/move/crates/move-stdlib/*)
+            is_non_framework_markdown_only=false
+            break
+            ;;
+          *.md)
+            ;;
+          *)
+            is_non_framework_markdown_only=false
+            break
+            ;;
+        esac
+      done
+
+      echo "isNonFrameworkMarkdownOnly=$is_non_framework_markdown_only" >> "$GITHUB_OUTPUT"

--- a/.github/actions/diffs/action.yml
+++ b/.github/actions/diffs/action.yml
@@ -115,6 +115,8 @@ runs:
         is_non_framework_markdown_only=false
       fi
 
+      # These dirs contain .md files consumed by Move package builds /
+      # doc snapshot tests, so markdown changes here must still run CI. 
       for file in "${changed_files[@]}"; do
         case "$file" in
           crates/sui-framework/* | external-crates/move/documentation/* | external-crates/move/crates/move-stdlib/*)


### PR DESCRIPTION
## Description 

I had a few PRs that would fix README.md files in the `/crates` folder. Unfortunately, that triggers all the tests which I think we shouldn't need to do, except for the `sui-framework` crate and for `external-crates/move/documentation` and `external-crates/move/crates/move-stdlib`.

## Test plan 

Existing CI
---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
