### PR TITLE
ci: scope arm64 prebuild to network branches only

### DIFF
--- a/.github/workflows/pre-build-images.yml
+++ b/.github/workflows/pre-build-images.yml
@@ -28,7 +28,7 @@ jobs:
               "cache_family": "${{ github.ref_name }}",
               "caller_name": "sui_repo_${{ github.ref_name }}",
               "push_to_dockerhub": "true",
-              "build_arm64": "${{ github.ref_name != 'main' && (github.ref_name == 'devnet' || github.ref_name == 'testnet' || github.ref_name == 'mainnet' || (startsWith(github.ref_name, 'releases/sui-') && endsWith(github.ref_name, '-release'))) }}",
+              "build_arm64": "${{ github.ref_name == 'devnet' || github.ref_name == 'testnet' || github.ref_name == 'mainnet' }}",
               "graphql_rpc": "true",
               "indexer_alt": "true",
               "stress": "true",


### PR DESCRIPTION
## Summary

Limit `build_arm64=true` in `pre-build-images.yml` to push events on `devnet` / `testnet` / `mainnet`. Drop the `releases/sui-*-release` clause so cherry-picks to release branches no longer build arm64 layers.

## Why

No internal K8s workload runs on arm64 — the `c4a-*` ARM64 node pools in `gke-go` (`workloads-primary`, `workloads-secondary`) are tainted `dedicated=buildkit-arm-builds` and exist solely to host mp3's BuildKit pods that produce arm64 images. No application Deployment/StatefulSet has a `kubernetes.io/arch: arm64` nodeSelector anywhere in `pulumi/apps/` or `pulumi/services/`. The only readers of `s3://sui-releases/arm64/` are the `workflow_dispatch`-only `build-publish-binaries.yml` and external DockerHub pulls of `mysten/<image>:*-arm64`.

External arm64 consumption is served via DockerHub tags (`mysten/sui-node:testnet`, `mysten/sui-node:testnet-v1.72.1`, plus `-arm64` variants). Those continue to be produced by `tag-upload-docker-image.yml` on network-branch push events and at release-tag creation — both paths already pass `build_arm64=true`.

## Where arm64 fires after this change

| Trigger | arm64 built? |
|---|---|
| push to `main` | no (unchanged) |
| push to `devnet` / `testnet` / `mainnet` | yes |
| push to `releases/sui-*-release` (cherry-picks) | **no** (was yes) |
| release tag creation (`{network}-v*`) | yes — via existing `tag-docker-images` dispatch |
| `sui-operations/tag-upload-docker-image.yml` (workflow_call/dispatch) | yes — independent of this change |
| sui `release.yml` (binaries on `ubuntu-arm64` runners) | yes — independent of mp3 |

Mechanism that keeps the release-tag path correct: at tag time, `tag-docker-images` re-fires the prebuild matrix, and mp3 registry-skip (the `image_build_registry_skipped_total` path) short-circuits when the image already exists in GAR. In the steady state, the arm64 image was produced when the release-branch tip was force-pushed to the network branch in step T1/M1 of `/release {testnet,mainnet}`, so the tag-time rebuild is a no-op.

## Test plan

- [x] `git diff` shows a single-line change to the `build_arm64` expression
- [x] No other workflow inputs touched
- [ ] CI passes (super-linter on the changed YAML)
- [ ] Post-merge: confirm next push to `releases/sui-v*-release` does NOT trigger `MystenLabs/sui:sui-node-arm64` / `sui-tools-arm64` build rows in mp3
- [ ] Post-merge: confirm next push to `devnet`/`testnet`/`mainnet` still triggers arm64 build rows
- [ ] Post-merge: confirm next release tag still produces `mysten/sui-node:{tag}-arm64` on DockerHub via `tag-upload-docker-image.yml`

## Pass-if criteria

After merge, the next `releases/sui-v*-release` push should produce zero `linux/arm64` build entries in mp3 for that SHA. Network-branch and release-tag flows should be unchanged.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>