### PR TITLE
ci: skip arm64 in trigger-builds tag-docker-images dispatch

### DIFF
--- a/.github/workflows/trigger-builds.yml
+++ b/.github/workflows/trigger-builds.yml
@@ -39,4 +39,4 @@ jobs:
           repository: MystenLabs/sui-operations
           token: ${{ secrets.DOCKER_BINARY_BUILDS_DISPATCH }}
           event-type: tag-docker-images
-          client-payload: '{"sui_commit": "${{ github.sha }}", "tag": "${{ github.ref_name }}", "cache_family": "${{ steps.cf.outputs.cache_family }}"}'
+          client-payload: '{"sui_commit": "${{ github.sha }}", "tag": "${{ github.ref_name }}", "cache_family": "${{ steps.cf.outputs.cache_family }}", "build_arm64": "false"}'


### PR DESCRIPTION
## Summary

Pass `"build_arm64": "false"` in the `tag-docker-images` repository_dispatch client-payload that `trigger-builds.yml` sends to sui-operations on every devnet/testnet/mainnet push.

This is **PR 2 of 2**. PR 1 (MystenLabs/sui-operations#7938) added the `build_arm64` input on the receiving side (default `"true"` for back-compat). This PR activates it for the network-branch push path.

## Why

Today, every push to devnet/testnet/mainnet fires arm64 builds via two parallel paths:

1. `pre-build-images.yml` → `prebuild-sui-images` repository_dispatch with `build_arm64=true` (arm64 enabled on these branches after #26653)
2. `trigger-builds.yml` → `tag-docker-images` repository_dispatch → `tag-upload-docker-image.yml` → calls `prebuild-sui-images.yml` with `build_arm64="true"` (hardcoded today, parameterized in sui-operations#7938)

The arm64 rows in path #2 are mostly deduped against path #1 by mp3's atomic-dedup logic, but ~17% slip through the dedup window when both dispatches fire within seconds (measured against `sui-indexer-alt-consistent-store` duplicate rate over an 18-hour window).

With this change, path #2 stops requesting arm64 — pre-build-images.yml is the single source of truth for arm64 image production on network-branch push. The downstream DockerHub tagging (`mysten/sui-node:testnet`, etc.) then re-tags the images that already exist in GAR/DockerHub, no rebuild needed.

## What this does NOT change

- `pre-build-images.yml` (this repo) still passes `build_arm64=true` for devnet/testnet/mainnet pushes (per #26653). Network-branch arm64 production unchanged.
- `release.yml` (this repo) still fires `tag-docker-images` without specifying `build_arm64`, so it falls through to `tag-upload-docker-image.yml`'s default `"true"` at release-tag creation. Release-tag arm64 flow unchanged.
- `release.yml`'s own arm64 binary builds on `ubuntu-arm64` runners (the `Build & Publish Binaries` matrix) — unrelated to mp3, unchanged.

## Test plan

- [x] `git diff` shows a single-line client-payload JSON change
- [x] sui-operations#7938 has landed (or will land before this) and tag-upload-docker-image.yml now reads `client_payload.build_arm64`
- [ ] CI passes
- [ ] Post-merge: confirm next push to devnet/testnet/mainnet — arm64 builds fire from `pre-build-images.yml` only, not from `tag-upload-docker-image.yml` rebuild path. Verify in mp3 by looking for a single `sui-node-arm64` build entry per SHA instead of two near-duplicate dispatches.
- [ ] Post-merge: confirm DockerHub still gets `mysten/sui-node:testnet-arm64` tag updated (the tag-images job re-tags existing GAR/DockerHub artifacts; no rebuild needed).

## Pass-if criteria

Within 24h of merge on the next devnet/testnet/mainnet push, mp3 should show exactly one arm64 build dispatch per (image, SHA) tuple, sourced from `pre-build-images.yml`. The `tag-docker-images` dispatch from this workflow should still apply DockerHub tags but produce zero new arm64 build rows.

Depends on: MystenLabs/sui-operations#7938

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>