### PR TITLE
[typed-store] Fix schedule_delete_all leaving the largest key behind

### DIFF
--- a/crates/typed-store/src/rocks/mod.rs
+++ b/crates/typed-store/src/rocks/mod.rs
@@ -1783,7 +1783,10 @@ where
             .map(|(k, _v)| k);
         if let Some((first_key, last_key)) = first_key.zip(last_key) {
             let mut batch = self.batch();
+            // `schedule_delete_range` excludes its upper bound, so the largest key
+            // would survive; delete it explicitly to actually clear the map.
             batch.schedule_delete_range(self, &first_key, &last_key)?;
+            batch.delete_batch(self, [last_key])?;
             batch.write()?;
         }
         Ok(())

--- a/crates/typed-store/src/rocks/mod.rs
+++ b/crates/typed-store/src/rocks/mod.rs
@@ -1520,18 +1520,30 @@ impl DBBatch {
         from: &K,
         to: &K,
     ) -> Result<(), TypedStoreError> {
+        self.schedule_delete_range_raw(db, be_fix_int_ser(from), be_fix_int_ser(to))
+    }
+
+    /// Like [`Self::schedule_delete_range`], but takes pre-encoded byte ranges
+    /// directly. Useful when the desired bounds do not correspond to any
+    /// serializable key — for example, when the caller needs an exclusive
+    /// upper bound that is the lexicographic successor of a real key in order
+    /// to express a closed range as a half-open one (see
+    /// `schedule_delete_all`).
+    pub fn schedule_delete_range_raw<K, V>(
+        &mut self,
+        db: &DBMap<K, V>,
+        from: impl AsRef<[u8]>,
+        to: impl AsRef<[u8]>,
+    ) -> Result<(), TypedStoreError> {
         if !Arc::ptr_eq(&db.db, &self.database) {
             return Err(TypedStoreError::CrossDBBatch);
         }
 
-        let from_buf = be_fix_int_ser(from);
-        let to_buf = be_fix_int_ser(to);
-
         if let StorageWriteBatch::Rocks(b) = &mut self.batch {
             b.delete_range_cf(
                 &rocks_cf_from_db(&self.database, db.cf_name())?,
-                from_buf,
-                to_buf,
+                from.as_ref(),
+                to.as_ref(),
             );
         }
         Ok(())
@@ -1782,11 +1794,19 @@ where
             .transpose()?
             .map(|(k, _v)| k);
         if let Some((first_key, last_key)) = first_key.zip(last_key) {
+            let from_buf = be_fix_int_ser(&first_key);
+            // The underlying RocksDB range tombstone treats its upper bound as
+            // exclusive, so naively passing `last_key` would leave the largest
+            // entry behind. Appending a 0x00 byte yields the lexicographic
+            // successor of the encoded `last_key`, making the half-open range
+            // `[first_buf, last_buf ++ 0x00)` equivalent to the closed range
+            // `[first_key, last_key]`. Keeping the whole clear as a single
+            // range tombstone preserves the visibility semantics governed by
+            // `ignore_range_deletions`.
+            let mut to_buf = be_fix_int_ser(&last_key);
+            to_buf.push(0u8);
             let mut batch = self.batch();
-            // `schedule_delete_range` excludes its upper bound, so the largest key
-            // would survive; delete it explicitly to actually clear the map.
-            batch.schedule_delete_range(self, &first_key, &last_key)?;
-            batch.delete_batch(self, [last_key])?;
+            batch.schedule_delete_range_raw(self, &from_buf, &to_buf)?;
             batch.write()?;
         }
         Ok(())

--- a/crates/typed-store/src/rocks/mod.rs
+++ b/crates/typed-store/src/rocks/mod.rs
@@ -1524,10 +1524,11 @@ impl DBBatch {
     }
 
     /// Like [`Self::schedule_delete_range`], but takes pre-encoded byte ranges
-    /// directly. Useful when the desired bounds do not correspond to any
-    /// serializable key — for example, when the caller needs an exclusive
-    /// upper bound that is the lexicographic successor of a real key in order
-    /// to express a closed range as a half-open one (see
+    /// directly: `from` is inclusive and `to` is exclusive, matching the
+    /// underlying RocksDB range tombstone. Useful when the desired bounds do
+    /// not correspond to any serializable key — for example, when the caller
+    /// needs an exclusive upper bound that is the lexicographic successor of a
+    /// real key in order to express a closed range as a half-open one (see
     /// `schedule_delete_all`).
     pub fn schedule_delete_range_raw<K, V>(
         &mut self,

--- a/crates/typed-store/src/rocks/tests.rs
+++ b/crates/typed-store/src/rocks/tests.rs
@@ -411,6 +411,54 @@ async fn test_delete_range() {
 }
 
 #[tokio::test]
+async fn test_schedule_delete_all_includes_last_key() {
+    let options = ReadWriteOptions::default().set_ignore_range_deletions(false);
+    let db: DBMap<i32, String> = DBMap::reopen(
+        &open_rocksdb(temp_dir(), &[rocksdb::DEFAULT_COLUMN_FAMILY_NAME]),
+        None,
+        &options,
+        false,
+    )
+    .unwrap();
+
+    let mut batch = db.batch();
+    batch
+        .insert_batch(&db, (0..101).map(|i| (i, i.to_string())))
+        .expect("Failed to batch insert");
+    batch.write().expect("Failed to execute batch");
+
+    db.schedule_delete_all().expect("Failed to delete all");
+
+    let remaining: Vec<_> = db.safe_iter().map(|item| item.unwrap()).collect();
+    assert_eq!(
+        Vec::<(i32, String)>::new(),
+        remaining,
+        "schedule_delete_all must remove every entry, including the largest key",
+    );
+}
+
+#[tokio::test]
+async fn test_schedule_delete_all_single_entry() {
+    let options = ReadWriteOptions::default().set_ignore_range_deletions(false);
+    let db: DBMap<i32, String> = DBMap::reopen(
+        &open_rocksdb(temp_dir(), &[rocksdb::DEFAULT_COLUMN_FAMILY_NAME]),
+        None,
+        &options,
+        false,
+    )
+    .unwrap();
+
+    db.insert(&42, &"only".to_string()).unwrap();
+
+    db.schedule_delete_all().expect("Failed to delete all");
+
+    assert!(
+        db.is_empty(),
+        "schedule_delete_all on a single-entry map must empty it",
+    );
+}
+
+#[tokio::test]
 async fn test_iter_with_bounds() {
     let db = open_map(temp_dir(), None);
 

--- a/crates/typed-store/src/rocks/tests.rs
+++ b/crates/typed-store/src/rocks/tests.rs
@@ -458,6 +458,43 @@ async fn test_schedule_delete_all_single_entry() {
     );
 }
 
+// With the default `ignore_range_deletions = true`, a range tombstone is only
+// observable to readers after compaction. This test pins down the contract:
+// every entry must follow the same path (visible before compaction, gone after
+// it), with no asymmetry between the largest key and the rest -- a stray point
+// delete on `last_key` would surface here as the largest key vanishing before
+// compaction while everything else is still readable.
+#[tokio::test]
+async fn test_schedule_delete_all_default_read_options() {
+    let db: DBMap<i32, String> = open_map(temp_dir(), None);
+
+    let mut batch = db.batch();
+    batch
+        .insert_batch(&db, (0..101).map(|i| (i, i.to_string())))
+        .expect("Failed to batch insert");
+    batch.write().expect("Failed to execute batch");
+
+    db.schedule_delete_all()
+        .expect("Failed to schedule delete all");
+
+    for k in 0..=100 {
+        assert!(
+            db.contains_key(&k).expect("Failed to query key"),
+            "key {k} disappeared before compaction under default ReadWriteOptions",
+        );
+    }
+
+    db.flush().expect("Failed to flush");
+    db.compact_range(&0_i32, &101_i32)
+        .expect("Failed to compact range");
+
+    let remaining: Vec<_> = db.safe_iter().map(|item| item.unwrap()).collect();
+    assert!(
+        remaining.is_empty(),
+        "schedule_delete_all under default ReadWriteOptions must clear the map after compaction; remaining = {remaining:?}",
+    );
+}
+
 #[tokio::test]
 async fn test_iter_with_bounds() {
     let db = open_map(temp_dir(), None);


### PR DESCRIPTION
## Summary
`schedule_delete_all` cleared the table with `schedule_delete_range(first, last)`, which is documented `[from, to)` exclusive-upper (see its docstring and `test_delete_range` at `tests.rs:410`). The largest key therefore always survived; on a single-key map the function deleted nothing.

The sole caller — `AuthorityStore::clear_object_per_epoch_marker_table` — runs at every epoch boundary on every node. Per-epoch markers are keyed with `EpochId` as the leading component, so the residual row is inert at read time (subsequent-epoch reads filter by exact `EpochId` and never observe it), but the function still violates its own contract as a general-purpose `Map` trait method.

## Fix
Clear the table with a single range tombstone whose exclusive upper bound is the lexicographic successor of the encoded largest key: `be_fix_int_ser(&last_key)` with a trailing `0x00` byte appended. Appending `0x00` is the unique lexicographic successor of any byte sequence, so the half-open range `[first_buf, last_buf ++ 0x00)` is exactly the closed range `[first_key, last_key]`. (This mirrors the existing `key_buf.push(0)` pattern in `iterator_bounds_with_range` at `crates/typed-store/src/util.rs`.)

Keeping the whole clear as one range tombstone — rather than a range delete plus a point delete on the largest key — preserves consistent visibility: every entry follows the same path governed by `ignore_range_deletions`, instead of the largest key vanishing immediately via a point delete while the rest of the table stays readable until compaction.

A new `DBBatch::schedule_delete_range_raw` takes pre-encoded byte ranges (`from` inclusive, `to` exclusive) for callers that need bounds not corresponding to any serializable key; `schedule_delete_range` now delegates to it.

## Reproduction (actual test output)
Three regression tests are added. `test_schedule_delete_all_default_read_options` uses the default `ReadWriteOptions` (`ignore_range_deletions = true`): it asserts every key is still visible immediately after `schedule_delete_all` (no leaked point delete), then asserts the table is empty after `flush() + compact_range()`. The two `*_includes_last_key` / `*_single_entry` tests use `ignore_range_deletions = false` to assert immediate emptiness.

**Before the fix** — the default-options test against the previous (range + point delete) implementation reproduces the visibility skew exactly:

```
thread 'rocks::tests::test_schedule_delete_all_default_read_options' panicked at crates/typed-store/src/rocks/tests.rs:481:9:
key 100 disappeared before compaction under default ReadWriteOptions
```

And against the original unpatched `schedule_delete_all`, the `ignore_range_deletions = false` tests fail because the largest key (and, for a single-key map, the whole map) survives:

```
assertion `left == right` failed: schedule_delete_all must remove every entry, including the largest key
  left: []
 right: [(100, "100")]
```

**After the fix** — full typed-store suite (`cargo nextest run -p typed-store`):

```
PASS  rocks::tests::test_schedule_delete_all_single_entry
PASS  rocks::tests::test_schedule_delete_all_includes_last_key
PASS  rocks::tests::test_schedule_delete_all_default_read_options
Summary  38 tests run: 38 passed, 0 skipped
```

`cargo xclippy` on the crate finishes clean.

## Test plan
- [x] 3 regression tests (two with `ignore_range_deletions = false`, one with the default options) fail before the fix, pass with it (output above).
- [x] Full typed-store nextest suite: 38/38.
- [x] `cargo xclippy` clean; `cargo fmt --all -- --check` clean.
